### PR TITLE
feat(agentguard): détecter la perte de CancellationToken

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/06-Aspire-GardeFous-Roslyn.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/06-Aspire-GardeFous-Roslyn.ipynb
@@ -78,126 +78,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '44280.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Repertoire de travail : Aspire\r\n"
-     ]
+     "name": "stdout",
+     "text": "Repertoire de travail : Aspire\r\n"
     }
    ],
    "source": [
@@ -278,88 +168,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "// Terrain fautif : copie de demo du motif StreamingAgent.App (notebook 04).\n",
-      "// Un worker d'agent consomme une Channel -- motif canonique de la serie --\n",
-      "// mais ici le code genere \"dans le style synchrone\" BLOQUE la tache d'appel\n",
-      "// au LLM avec .Result au lieu de l'attendre. C'est le defaut que l'analyseur\n",
-      "// AGENTGUARD001 doit attraper au `dotnet build` (ce fichier ne leve PAS\n",
-      "// d'exception : le blocage ne deadlock ici qu'un contexte reduit -- le\n",
-      "// notebook explique pourquoi le pattern reste mortel en production).\n",
-      "\n",
-      "using System;\n",
-      "using System.Threading.Channels;\n",
-      "using System.Threading.Tasks;\n",
-      "\n",
-      "var channel = Channel.CreateUnbounded<string>();\n",
-      "_ = Producer.ProduceAsync(channel.Writer, \"traduis cette phrase en anglais\");\n",
-      "\n",
-      "Console.WriteLine(AgentWorker.TranslateSync(channel.Reader));\n",
-      "\n",
-      "public static class AgentWorker\n",
-      "{\n",
-      "    // Genere par agent \"pour simplifier\" : la tache async est bloquee.\n",
-      "    // Deux blocages .Result -- deux diagnostics attendus au build.\n",
-      "    public static string TranslateSync(ChannelReader<string> inbound)\n",
-      "    {\n",
-      "        var prompt = inbound.ReadAsync().AsTask().Result;   // AGENTGUARD001\n",
-      "        return CallLlmAsync(prompt).Result;                 // AGENTGUARD001\n",
-      "    }\n",
-      "\n",
-      "    private static async Task<string> CallLlmAsync(string prompt)\n",
-      "    {\n",
-      "        await Task.Delay(50);            // simule la latence de l'appel LLM\n",
-      "        return $\"[LLM] {prompt}\";\n",
-      "    }\n",
-      "}\n",
-      "\n",
-      "public static class Producer\n",
-      "{\n",
-      "    public static async Task ProduceAsync(ChannelWriter<string> writer, string prompt)\n",
-      "        => await writer.WriteAsync(prompt);\n",
-      "}\n",
-      "\n",
-      "// Second terrain fautif (AGENTGUARD002) : le meme agent, une autre vitesse.\n",
-      "// \"Lancer et oublier\" un traitement en ecrivant async void -- la signature\n",
-      "// ressemble a une async Task, mais la methode n'est pas attendable et ses\n",
-      "// exceptions ne sont observees par personne. Un diagnostic AGENTGUARD002\n",
-      "// attendu au build (et aucun ici n'est un handler d'evenement : pas de\n",
-      "// signature (object, EventArgs)).\n",
-      "public static class AgentFireAndForget\n",
-      "{\n",
-      "    public static void Demarrer()\n",
-      "    {\n",
-      "        SurveillerCanalAsync();            // \"rendu la main\" -- silencieusement\n",
-      "    }\n",
-      "\n",
-      "    // Genere par agent \"pour simplifier\" : async void hors handler.\n",
-      "    public static async void SurveillerCanalAsync()\n",
-      "    {\n",
-      "        await Task.Delay(200);             // simule une boucle de surveillance\n",
-      "        // Si l'appel LLM leve ici, personne ne l'observe : process mort.\n",
-      "    }\n",
-      "}\n",
-      "\n",
-      "// Troisieme terrain fautif (AGENTGUARD003) : le meme agent, troisieme\n",
-      "// vitesse. `Task.Run(() => ...)` est appele comme enonce autonome -- la\n",
-      "// signature est honnete (Task, pas void), mais le retour est jete a la\n",
-      "// corbeille : pas de await, pas d'affectation, pas de `_ =`, pas de\n",
-      "// return. La tache s'execute en arriere-plan, ses exceptions ne sont\n",
-      "// observees par personne. Un diagnostic AGENTGUARD003 attendu au build\n",
-      "// (et c'est la seule forme signalee : `await Task.Run(...)`, `var t =\n",
-      "// Task.Run(...)`, `_ = Task.Run(...)` et `return Task.Run(...)` sont\n",
-      "// exemptes).\n",
-      "public static class AgentTaskRunFire\n",
-      "{\n",
-      "    public static void Demarrer()\n",
-      "    {\n",
-      "        Task.Run(() => Console.WriteLine(\"ping\"));   // AGENTGUARD003\n",
-      "    }\n",
-      "}\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "// Terrain fautif : copie de demo du motif StreamingAgent.App (notebook 04).\n// Un worker d'agent consomme une Channel -- motif canonique de la serie --\n// mais ici le code genere \"dans le style synchrone\" BLOQUE la tache d'appel\n// au LLM avec .Result au lieu de l'attendre. C'est le defaut que l'analyseur\n// AGENTGUARD001 doit attraper au `dotnet build` (ce fichier ne leve PAS\n// d'exception : le blocage ne deadlock ici qu'un contexte reduit -- le\n// notebook explique pourquoi le pattern reste mortel en production).\n\nusing System;\nusing System.Threading.Channels;\nusing System.Threading.Tasks;\n\nvar channel = Channel.CreateUnbounded<string>();\n_ = Producer.ProduceAsync(channel.Writer, \"traduis cette phrase en anglais\");\n\nConsole.WriteLine(AgentWorker.TranslateSync(channel.Reader));\n\npublic static class AgentWorker\n{\n    // Genere par agent \"pour simplifier\" : la tache async est bloquee.\n    // Deux blocages .Result -- deux diagnostics attendus au build.\n    public static string TranslateSync(ChannelReader<string> inbound)\n    {\n        var prompt = inbound.ReadAsync().AsTask().Result;   // AGENTGUARD001\n        return CallLlmAsync(prompt).Result;                 // AGENTGUARD001\n    }\n\n    private static async Task<string> CallLlmAsync(string prompt)\n    {\n        await Task.Delay(50);            // simule la latence de l'appel LLM\n        return $\"[LLM] {prompt}\";\n    }\n}\n\npublic static class Producer\n{\n    public static async Task ProduceAsync(ChannelWriter<string> writer, string prompt)\n        => await writer.WriteAsync(prompt);\n}\n\n// Second terrain fautif (AGENTGUARD002) : le meme agent, une autre vitesse.\n// \"Lancer et oublier\" un traitement en ecrivant async void -- la signature\n// ressemble a une async Task, mais la methode n'est pas attendable et ses\n// exceptions ne sont observees par personne. Un diagnostic AGENTGUARD002\n// attendu au build (et aucun ici n'est un handler d'evenement : pas de\n// signature (object, EventArgs)).\npublic static class AgentFireAndForget\n{\n    public static void Demarrer()\n    {\n        SurveillerCanalAsync();            // \"rendu la main\" -- silencieusement\n    }\n\n    // Genere par agent \"pour simplifier\" : async void hors handler.\n    public static async void SurveillerCanalAsync()\n    {\n        await Task.Delay(200);             // simule une boucle de surveillance\n        // Si l'appel LLM leve ici, personne ne l'observe : process mort.\n    }\n}\n\n// Troisieme terrain fautif (AGENTGUARD003) : le meme agent, troisieme\n// vitesse. `Task.Run(() => ...)` est appele comme enonce autonome -- la\n// signature est honnete (Task, pas void), mais le retour est jete a la\n// corbeille : pas de await, pas d'affectation, pas de `_ =`, pas de\n// return. La tache s'execute en arriere-plan, ses exceptions ne sont\n// observees par personne. Un diagnostic AGENTGUARD003 attendu au build\n// (et c'est la seule forme signalee : `await Task.Run(...)`, `var t =\n// Task.Run(...)`, `_ = Task.Run(...)` et `return Task.Run(...)` sont\n// exemptes).\npublic static class AgentTaskRunFire\n{\n    public static void Demarrer()\n    {\n        Task.Run(() => Console.WriteLine(\"ping\"));   // AGENTGUARD003\n    }\n}\n\n// Quatrieme terrain fautif (AGENTGUARD004) : la requete fournit un\n// CancellationToken, et la cible sait le recevoir, mais le code genere omet\n// l'argument optionnel. L'annulation est perdue au milieu de la chaine.\npublic static class AgentCancellation\n{\n    public static async Task RepondreAsync(\n        string prompt,\n        System.Threading.CancellationToken cancellationToken)\n    {\n        await CallLlmAsync(prompt);                    // AGENTGUARD004\n    }\n\n    private static Task<string> CallLlmAsync(\n        string prompt,\n        System.Threading.CancellationToken cancellationToken = default)\n        => Task.FromResult($\"[LLM] {prompt}\");\n}\n\r\n"
     }
    ],
    "source": [
@@ -434,71 +245,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "using System.Collections.Immutable;\n",
-      "using Microsoft.CodeAnalysis;\n",
-      "using Microsoft.CodeAnalysis.CSharp;\n",
-      "using Microsoft.CodeAnalysis.Diagnostics;\n",
-      "\n",
-      "namespace AgentGuard.Analyzers;\n",
-      "\n",
-      "/// <summary>\n",
-      "/// AGENTGUARD001 : blocage synchrone d'une Task (.Result / .Wait()).\n",
-      "///\n",
-      "/// Pattern typique du code d'agent genere : appeler une tache asynchrone\n",
-      "/// (appel LLM, streaming, canal) depuis du code synchrone en la bloquant.\n",
-      "/// Le garde-fou vit DANS la compilation -- `dotnet build` rend le diagnostic\n",
-      "/// sans aucun outil supplementaire (la these du notebook 06 de la serie Aspire,\n",
-      "/// Epic #10473 axe Roslyn).\n",
-      "/// </summary>\n",
-      "[DiagnosticAnalyzer(LanguageNames.CSharp)]\n",
-      "public sealed class TaskResultBlockAnalyzer : DiagnosticAnalyzer\n",
-      "{\n",
-      "    public const string DiagnosticId = \"AGENTGUARD001\";\n",
-      "\n",
-      "    private static readonly DiagnosticDescriptor Rule = new(\n",
-      "        DiagnosticId,\n",
-      "        \"Blocage synchrone d'une Task\",\n",
-      "        \"Task bloquee de maniere synchrone ({0}) : deadlock potentiel en code d'agent\",\n",
-      "        \"Agentisme\",\n",
-      "        DiagnosticSeverity.Warning,\n",
-      "        isEnabledByDefault: true,\n",
-      "        description: \"Le code genere par agent qui bloque une Task via .Result/.Wait() expose au deadlock.\");\n",
-      "\n",
-      "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n",
-      "        => ImmutableArray.Create(Rule);\n",
-      "\n",
-      "    public override void Initialize(AnalysisContext context)\n",
-      "    {\n",
-      "        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n",
-      "        context.EnableConcurrentExecution();\n",
-      "        // Le membre accede (.Result, .Wait) est un MemberAccessExpression --\n",
-      "        // on s'abonne a CE noeud syntaxique, pas a toute l'arborescence.\n",
-      "        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);\n",
-      "    }\n",
-      "\n",
-      "    private static void AnalyzeNode(SyntaxNodeAnalysisContext ctx)\n",
-      "    {\n",
-      "        var node = (Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax)ctx.Node;\n",
-      "\n",
-      "        // 1. Filtre syntaxique bon marche : le membre s'appelle Result ou Wait.\n",
-      "        if (node.Name is not { Identifier.ValueText: \"Result\" or \"Wait\" }) return;\n",
-      "\n",
-      "        // 2. Filtre semantique : le membre appartient bien a Task / Task<T>.\n",
-      "        //    (Evince les faux positifs : un Result<T> monadique, un .Wait()\n",
-      "        //    de type custom.) C'est le modele semantique qui tranchera.\n",
-      "        if (ctx.SemanticModel.GetSymbolInfo(node).Symbol is not { } member) return;\n",
-      "        if (member.ContainingType is not INamedTypeSymbol ct\n",
-      "            || ct.MetadataName is not (\"Task\" or \"Task`1\")) return;\n",
-      "\n",
-      "        ctx.ReportDiagnostic(Diagnostic.Create(\n",
-      "            Rule, node.GetLocation(), \".\" + node.Name.Identifier.ValueText));\n",
-      "    }\n",
-      "}\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "using System.Collections.Immutable;\nusing Microsoft.CodeAnalysis;\nusing Microsoft.CodeAnalysis.CSharp;\nusing Microsoft.CodeAnalysis.Diagnostics;\n\nnamespace AgentGuard.Analyzers;\n\n/// <summary>\n/// AGENTGUARD001 : blocage synchrone d'une Task (.Result / .Wait()).\n///\n/// Pattern typique du code d'agent genere : appeler une tache asynchrone\n/// (appel LLM, streaming, canal) depuis du code synchrone en la bloquant.\n/// Le garde-fou vit DANS la compilation -- `dotnet build` rend le diagnostic\n/// sans aucun outil supplementaire (la these du notebook 06 de la serie Aspire,\n/// Epic #10473 axe Roslyn).\n/// </summary>\n[DiagnosticAnalyzer(LanguageNames.CSharp)]\npublic sealed class TaskResultBlockAnalyzer : DiagnosticAnalyzer\n{\n    public const string DiagnosticId = \"AGENTGUARD001\";\n\n    private static readonly DiagnosticDescriptor Rule = new(\n        DiagnosticId,\n        \"Blocage synchrone d'une Task\",\n        \"Task bloquee de maniere synchrone ({0}) : deadlock potentiel en code d'agent\",\n        \"Agentisme\",\n        DiagnosticSeverity.Warning,\n        isEnabledByDefault: true,\n        description: \"Le code genere par agent qui bloque une Task via .Result/.Wait() expose au deadlock.\");\n\n    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n        => ImmutableArray.Create(Rule);\n\n    public override void Initialize(AnalysisContext context)\n    {\n        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n        context.EnableConcurrentExecution();\n        // Le membre accede (.Result, .Wait) est un MemberAccessExpression --\n        // on s'abonne a CE noeud syntaxique, pas a toute l'arborescence.\n        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);\n    }\n\n    private static void AnalyzeNode(SyntaxNodeAnalysisContext ctx)\n    {\n        var node = (Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax)ctx.Node;\n\n        // 1. Filtre syntaxique bon marche : le membre s'appelle Result ou Wait.\n        if (node.Name is not { Identifier.ValueText: \"Result\" or \"Wait\" }) return;\n\n        // 2. Filtre semantique : le membre appartient bien a Task / Task<T>.\n        //    (Evince les faux positifs : un Result<T> monadique, un .Wait()\n        //    de type custom.) C'est le modele semantique qui tranchera.\n        if (ctx.SemanticModel.GetSymbolInfo(node).Symbol is not { } member) return;\n        if (member.ContainingType is not INamedTypeSymbol ct\n            || ct.MetadataName is not (\"Task\" or \"Task`1\")) return;\n\n        ctx.ReportDiagnostic(Diagnostic.Create(\n            Rule, node.GetLocation(), \".\" + node.Name.Identifier.ValueText));\n    }\n}\n\r\n"
     }
    ],
    "source": [
@@ -581,11 +330,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : etendre l'analyseur a GetAwaiter().GetResult()\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : etendre l'analyseur a GetAwaiter().GetResult()\r\n"
     }
    ],
    "source": [
@@ -656,26 +403,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "AgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
-      "AgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
-      "AgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\n",
-      "AgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n",
-      "\r\n",
-      "La génération a réussi.\r\n",
-      "\r\n",
-      "AgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
-      "AgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
-      "AgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\n",
-      "AgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n",
-      "    4 Avertissement(s)\r\n",
-      "    0 Erreur(s)\r\n",
-      "\r\n",
-      "Temps écoulé 00:00:06.97\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "AgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(88,15): warning AGENTGUARD004: L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n\r\nLa génération a réussi.\r\n\r\nAgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(88,15): warning AGENTGUARD004: L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n    5 Avertissement(s)\r\n    0 Erreur(s)\r\n\r\nTemps écoulé 00:00:02.01\r\n\r\n"
     }
    ],
    "source": [
@@ -712,20 +442,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du verdict\n",
-    "\n",
-    "La sortie du build porte **deux avertissements `AGENTGUARD001`**, un par blocage :\n",
-    "\n",
-    "- `Program.cs(24,22)` — le `.Result` sur la lecture du canal ;\n",
-    "- `Program.cs(25,16)` — le `.Result` sur l'appel LLM ;\n",
-    "\n",
-    "et **un avertissement `AGENTGUARD002`** — `Program.cs(55,30)`, la méthode `async void SurveillerCanalAsync` du second terrain (section D2). Les deux analyseurs de la série tirent dans le même build, sans configuration supplémentaire : chaque garde-fou ajouté au projet `AgentGuard.Analyzers` est automatiquement actif.\n",
-    "\n",
-    "Chacun nomme le fichier, la ligne, la colonne, et le message complet (« Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent »). Et la dernière ligne — `0 Erreur(s)` — rappelle le choix de sévérité : le build réussit, le diagnostic est un garde-fou, pas un marteau.\n",
-    "\n",
-    "**Le point décisif** : cette sortie est produite par `dotnet build`, la commande la plus ordinaire du monde .NET. Aucune mention d'outil externe, aucune étape de lint. Le diagnostic est arrivé **avec la compilation elle-même** — c'est ce que Python ne peut pas offrir par construction, et que la section C détaille.\n"
-   ]
+   "source": "### Lecture du verdict\n\nLa sortie du build porte désormais **cinq avertissements**, un par défaut démontré :\n\n- `AGENTGUARD001 x2` — les deux `.Result` qui bloquent la lecture du canal puis l'appel LLM ;\n- `AGENTGUARD002 x1` — la méthode `async void SurveillerCanalAsync` hors gestionnaire d'événement ;\n- `AGENTGUARD003 x1` — le `Task.Run(...)` lancé comme énoncé autonome ;\n- `AGENTGUARD004 x1` — l'appel LLM omet le `CancellationToken` pourtant disponible et accepté par la signature cible.\n\nLes quatre analyseurs tirent dans le même build, sans configuration supplémentaire : chaque garde-fou ajouté au projet `AgentGuard.Analyzers` est automatiquement actif. Chacun nomme le fichier, la ligne, la colonne et le message complet. La dernière ligne — `0 Erreur(s)` — rappelle le choix de sévérité : le build réussit, le diagnostic est un garde-fou, pas un marteau.\n\n**Le point décisif** : cette sortie est produite par `dotnet build`, la commande la plus ordinaire du monde .NET. Aucune mention d'outil externe, aucune étape de lint. Le diagnostic est arrivé **avec la compilation elle-même** — c'est ce que Python ne peut pas offrir par construction, et que la section C détaille."
   },
   {
    "cell_type": "markdown",
@@ -770,17 +487,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[Program.cs] VERDICT : 4 diagnostic(s) -- AGENTGUARD001 x2, AGENTGUARD002 x1, AGENTGUARD003 x1\r\n",
-      "    AGENTGUARD001 @ 24:22  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n",
-      "    AGENTGUARD001 @ 25:16  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n",
-      "    AGENTGUARD002 @ 55:30  La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort\r\n",
-      "    AGENTGUARD003 @ 75:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n",
-      "[AgentWorkerCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "[Program.cs] VERDICT : 5 diagnostic(s) -- AGENTGUARD001 x2, AGENTGUARD002 x1, AGENTGUARD003 x1, AGENTGUARD004 x1\r\n    AGENTGUARD001 @ 24:22  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n    AGENTGUARD001 @ 25:16  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n    AGENTGUARD002 @ 55:30  La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort\r\n    AGENTGUARD003 @ 75:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n    AGENTGUARD004 @ 88:15  L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante\r\n[AgentWorkerCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
     }
    ],
    "source": [
@@ -802,16 +511,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture des verdicts\n",
-    "\n",
-    "Deux lignes de verdict, chacune adossée à son fichier :\n",
-    "\n",
-    "- `Program.cs` (le terrain fautif) : **3 diagnostics — AGENTGUARD001 x2** (24:22, 25:16, les mêmes que le canal build) **et AGENTGUARD002 x1** (55:30, le `async void` du second terrain) ;\n",
-    "- `AgentWorkerCorrige.cs` (la version corrigée) : **PROPRE**, aucun garde-fou déclenché.\n",
-    "\n",
-    "**Deux canaux, un seul moteur** : l'analyseur est le même code de ~40 lignes ; ce qui change, c'est qui l'héberge — MSBuild pour le canal build, l'API pour le canal tests/IDE. Un test d'intégration continue peut faire exactement ce que fait ce Verifier : compiler les sources générés par l'agent et exiger zéro AGENTGUARD001. Le garde-fou devient alors **exécutable en CI sur du code qui n'existe même pas sous forme de projet** — du code généré à la volée, collé dans un `CSharpCompilation`, verdict immédiat.\n"
-   ]
+   "source": "### Lecture des verdicts\n\nDeux lignes de verdict, chacune adossée à son fichier :\n\n- `Program.cs` (le terrain fautif) : **5 diagnostics** — `AGENTGUARD001 x2`, puis un diagnostic pour chacun des garde-fous `002`, `003` et `004` ;\n- `AgentWorkerCorrige.cs` (la version corrigée) : **PROPRE**, aucun garde-fou déclenché — son `CancellationToken` voyage déjà de bout en bout.\n\n**Deux canaux, un seul moteur** : les analyseurs sont identiques ; ce qui change, c'est qui les héberge — MSBuild pour le canal build, l'API pour le canal tests/IDE. Un test d'intégration continue peut faire exactement ce que fait ce Verifier : compiler les sources générés par l'agent et exiger zéro diagnostic AgentGuard. Le garde-fou devient alors **exécutable en CI sur du code qui n'existe même pas sous forme de projet** — génération, compilation en mémoire, verdict, puis conservation ou régénération."
   },
   {
    "cell_type": "code",
@@ -835,38 +535,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "// Version corrigee du terrain fautif (AgentGuard.Demo/Program.cs) :\n",
-      "// le worker attend la tache au lieu de la bloquer. C'est la version\n",
-      "// attendue \"propre\" au verdict du Verifier.\n",
-      "\n",
-      "using System;\n",
-      "using System.Threading;\n",
-      "using System.Threading.Channels;\n",
-      "using System.Threading.Tasks;\n",
-      "\n",
-      "public static class AgentWorkerCorrige\n",
-      "{\n",
-      "    // Le fix : async/await de bout en bout. Le thread rend la main pendant\n",
-      "    // l'attente au lieu de se bloquer -- plus de deadlock possible, et le\n",
-      "    // pipeline reste fluide sous charge.\n",
-      "    public static async Task<string> TranslateAsync(\n",
-      "        ChannelReader<string> inbound, CancellationToken ct = default)\n",
-      "    {\n",
-      "        var prompt = await inbound.ReadAsync(ct);\n",
-      "        return await CallLlmAsync(prompt, ct);\n",
-      "    }\n",
-      "\n",
-      "    private static async Task<string> CallLlmAsync(string prompt, CancellationToken ct)\n",
-      "    {\n",
-      "        await Task.Delay(50, ct);       // simule la latence de l'appel LLM\n",
-      "        return $\"[LLM] {prompt}\";\n",
-      "    }\n",
-      "}\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "// Version corrigee du terrain fautif (AgentGuard.Demo/Program.cs) :\n// le worker attend la tache au lieu de la bloquer. C'est la version\n// attendue \"propre\" au verdict du Verifier.\n\nusing System;\nusing System.Threading;\nusing System.Threading.Channels;\nusing System.Threading.Tasks;\n\npublic static class AgentWorkerCorrige\n{\n    // Le fix : async/await de bout en bout. Le thread rend la main pendant\n    // l'attente au lieu de se bloquer -- plus de deadlock possible, et le\n    // pipeline reste fluide sous charge.\n    public static async Task<string> TranslateAsync(\n        ChannelReader<string> inbound, CancellationToken ct = default)\n    {\n        var prompt = await inbound.ReadAsync(ct);\n        return await CallLlmAsync(prompt, ct);\n    }\n\n    private static async Task<string> CallLlmAsync(string prompt, CancellationToken ct)\n    {\n        await Task.Delay(50, ct);       // simule la latence de l'appel LLM\n        return $\"[LLM] {prompt}\";\n    }\n}\n\r\n"
     }
    ],
    "source": [
@@ -950,18 +621,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Outcome<string>.Result = aucun blocage ici\r\n"
-     ]
+     "name": "stdout",
+     "text": "Outcome<string>.Result = aucun blocage ici\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : passer ce type au Verifier et nommer la ligne de l'exemption\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : passer ce type au Verifier et nommer la ligne de l'exemption\r\n"
     }
    ],
    "source": [
@@ -1019,19 +686,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Information : impossible de trouver des fichiers pour le(s) modèle(s) spécifié(s).\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Information : impossible de trouver des fichiers pour le(s) modèle(s) spécifié(s).\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-> ruff ABSENT : en Python le garde-fou est un outil a installer soi-meme\r\n"
-     ]
+     "name": "stdout",
+     "text": "-> ruff ABSENT : en Python le garde-fou est un outil a installer soi-meme\r\n"
     }
    ],
    "source": [
@@ -1144,49 +806,24 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "// --- l'exemption, extraite de AsyncVoidAnalyzer.cs ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "// --- l'exemption, extraite de AsyncVoidAnalyzer.cs ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "private static bool EstHandlerEvenement(MethodDeclarationSyntax method, SyntaxNodeAnalysisContext ctx)\n",
-      "    {\n",
-      "        var parameters = method.ParameterList.Parameters;\n",
-      "        if (parameters.Count < 2) return false;\n",
-      "\n",
-      "        // Premier parametre exactement object (le \"sender\").\n",
-      "        var senderType = ctx.SemanticModel.GetTypeInfo(parameters[0].Type).Type;\n",
-      "        if (senderType?.SpecialType != SpecialType.System_Object) return false;\n",
-      "\n",
-      "        // Second parametre derive de System.EventArgs (ou l'est lui-meme).\n",
-      "        var argsType = ctx.SemanticModel.GetTypeInfo(parameters[1].Type).Type;\n",
-      "        if (argsType is null || argsType.TypeKind == TypeKind.Error) return false;\n",
-      "        return EstEventArgsOuDerive(argsType, ctx.Compilation);\n",
-      "    }\r\n"
-     ]
+     "name": "stdout",
+     "text": "private static bool EstHandlerEvenement(MethodDeclarationSyntax method, SyntaxNodeAnalysisContext ctx)\n    {\n        var parameters = method.ParameterList.Parameters;\n        if (parameters.Count < 2) return false;\n\n        // Premier parametre exactement object (le \"sender\").\n        var senderType = ctx.SemanticModel.GetTypeInfo(parameters[0].Type).Type;\n        if (senderType?.SpecialType != SpecialType.System_Object) return false;\n\n        // Second parametre derive de System.EventArgs (ou l'est lui-meme).\n        var argsType = ctx.SemanticModel.GetTypeInfo(parameters[1].Type).Type;\n        if (argsType is null || argsType.TypeKind == TypeKind.Error) return false;\n        return EstEventArgsOuDerive(argsType, ctx.Compilation);\n    }\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[AsyncVoidFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD002 x1\r\n",
-      "    AGENTGUARD002 @ 13:30  La methode async void 'TraiterCommande' echappe a toute attente -- exceptions non observees, process mort\r\n",
-      "[AsyncVoidCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "[AsyncVoidHandlerExempt.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "[AsyncVoidFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD002 x1\r\n    AGENTGUARD002 @ 13:30  La methode async void 'TraiterCommande' echappe a toute attente -- exceptions non observees, process mort\r\n[AsyncVoidCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[AsyncVoidHandlerExempt.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
     }
    ],
    "source": [
@@ -1282,100 +919,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "using System.Collections.Immutable;\n",
-      "using Microsoft.CodeAnalysis;\n",
-      "using Microsoft.CodeAnalysis.CSharp;\n",
-      "using Microsoft.CodeAnalysis.CSharp.Syntax;\n",
-      "using Microsoft.CodeAnalysis.Diagnostics;\n",
-      "\n",
-      "namespace AgentGuard.Analyzers;\n",
-      "\n",
-      "/// <summary>\n",
-      "/// AGENTGUARD003 : invocation nue de Task.Run, tache non observee.\n",
-      "///\n",
-      "/// Troisieme pattern typique du code genere par agent : ecrire\n",
-      "/// `Task.Run(() => Travail())` comme enonce autonome. La signature est\n",
-      "/// honnete (la methode rend une Task, pas void), MAIS la tache resultante\n",
-      "/// n'est ni attendue (await), ni affectee a une variable, ni retournee,\n",
-      "/// ni explicitement ignoree via discard (`_ =`). Elle s'execute en arriere-\n",
-      "/// plan ; ses exceptions ne sont observees par personne. A la finalisation\n",
-      "/// d'une telle tache fautive, le runtime declenche\n",
-      "/// `TaskScheduler.UnobservedTaskException`, un evenement qui porte une\n",
-      "/// `AggregateException` collectant les exceptions internes -- le defaut\n",
-      "/// (.NET 4.5+) est d'absorber l'evenement et de laisser le process vivre,\n",
-      "/// mais ce comportement est configurable et n'est pas garanti.\n",
-      "///\n",
-      "/// Formes LEGITIMES (a ne PAS signaler) :\n",
-      "///   - `await Task.Run(...)`            -- tache observee\n",
-      "///   - `var t = Task.Run(...)`          -- tache recuperee (composee ou attendue plus tard)\n",
-      "///   - `_ = Task.Run(...)`              -- discard explicite (assume, volontaire)\n",
-      "///   - `return Task.Run(...)`           -- tache retournee a l'appelant\n",
-      "///   - homonyme custom (autre type, autre signature) -- filtre semantique\n",
-      "/// </summary>\n",
-      "[DiagnosticAnalyzer(LanguageNames.CSharp)]\n",
-      "public sealed class TaskRunFireAnalyzer : DiagnosticAnalyzer\n",
-      "{\n",
-      "    public const string DiagnosticId = \"AGENTGUARD003\";\n",
-      "\n",
-      "    private static readonly DiagnosticDescriptor Rule = new(\n",
-      "        DiagnosticId,\n",
-      "        \"Task.Run feu, tache non observee\",\n",
-      "        \"Task.Run '{0}' lance une tache non observee -- exceptions perdues, comportement indefini\",\n",
-      "        \"Agentisme\",\n",
-      "        DiagnosticSeverity.Warning,\n",
-      "        isEnabledByDefault: true,\n",
-      "        description: \"Une invocation nue de Task.Run execute la tache en arriere-plan ; ses exceptions ne sont observees par personne. Utiliser await, affecter a une variable, retourner ou discarder explicitement (_ =).\");\n",
-      "\n",
-      "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n",
-      "        => ImmutableArray.Create(Rule);\n",
-      "\n",
-      "    public override void Initialize(AnalysisContext context)\n",
-      "    {\n",
-      "        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n",
-      "        context.EnableConcurrentExecution();\n",
-      "        // On s'abonne aux INVOCATIONS (le noeud Task.Run(...)). Le diagnostic\n",
-      "        // porte sur l'invocation, pas sur un membre -- le membre ici est un\n",
-      "        // IdentifierName (Run), pas un MemberAccessExpression, donc on ne peut\n",
-      "        // pas reutiliser la strategie d'AGENTGUARD001.\n",
-      "        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);\n",
-      "    }\n",
-      "\n",
-      "    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)\n",
-      "    {\n",
-      "        var inv = (InvocationExpressionSyntax)ctx.Node;\n",
-      "\n",
-      "        // 1. Filtre semantique : la methode invoquee est bien Task.Run.\n",
-      "        //    Reutilise le pattern d'AGENTGUARD001 : resoudre le symbole et\n",
-      "        //    verifier que la ContainingType est Task (non-generique).\n",
-      "        //    Evince les methodes homonymes : un type custom `MonService.Run`\n",
-      "        //    ne doit PAS declencher AGENTGUARD003.\n",
-      "        if (ctx.SemanticModel.GetSymbolInfo(inv).Symbol is not IMethodSymbol method) return;\n",
-      "        if (method.ContainingType is not INamedTypeSymbol ct\n",
-      "            || ct.MetadataName is not \"Task\"\n",
-      "            || ct.ContainingNamespace?.ToDisplayString() != \"System.Threading.Tasks\") return;\n",
-      "        if (method.MetadataName is not \"Run\") return;\n",
-      "\n",
-      "        // 2. Filtre syntaxique : la seule forme signalee est l'ExpressionStatement\n",
-      "        //    nu (l'invocation est l'integralite de l'enonce). Les autres formes\n",
-      "        //    -- await, affectation, discard, return, argument d'une autre\n",
-      "        //    invocation -- ne sont JAMAIS signalees.\n",
-      "        //\n",
-      "        //    Cas particulier `_ = Task.Run(...)` : Roslyn represente le discard\n",
-      "        //    comme un AssignmentExpression avec Left = IdentifierName(\"_\"),\n",
-      "        //    donc le parent n'est PAS un ExpressionStatement nu -- il est\n",
-      "        //    rattrape par le filtre \"n'est pas ExpressionStatement\" et tombe\n",
-      "        //    naturellement dans la branche exempt. Le test terrain le verifie.\n",
-      "        if (inv.Parent is not ExpressionStatementSyntax) return;\n",
-      "\n",
-      "        ctx.ReportDiagnostic(Diagnostic.Create(\n",
-      "            Rule, inv.GetLocation(), inv.ToString()));\n",
-      "    }\n",
-      "}\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "using System.Collections.Immutable;\nusing Microsoft.CodeAnalysis;\nusing Microsoft.CodeAnalysis.CSharp;\nusing Microsoft.CodeAnalysis.CSharp.Syntax;\nusing Microsoft.CodeAnalysis.Diagnostics;\n\nnamespace AgentGuard.Analyzers;\n\n/// <summary>\n/// AGENTGUARD003 : invocation nue de Task.Run, tache non observee.\n///\n/// Troisieme pattern typique du code genere par agent : ecrire\n/// `Task.Run(() => Travail())` comme enonce autonome. La signature est\n/// honnete (la methode rend une Task, pas void), MAIS la tache resultante\n/// n'est ni attendue (await), ni affectee a une variable, ni retournee,\n/// ni explicitement ignoree via discard (`_ =`). Elle s'execute en arriere-\n/// plan ; ses exceptions ne sont observees par personne. A la finalisation\n/// d'une telle tache fautive, le runtime declenche\n/// `TaskScheduler.UnobservedTaskException`, un evenement qui porte une\n/// `AggregateException` collectant les exceptions internes -- le defaut\n/// (.NET 4.5+) est d'absorber l'evenement et de laisser le process vivre,\n/// mais ce comportement est configurable et n'est pas garanti.\n///\n/// Formes LEGITIMES (a ne PAS signaler) :\n///   - `await Task.Run(...)`            -- tache observee\n///   - `var t = Task.Run(...)`          -- tache recuperee (composee ou attendue plus tard)\n///   - `_ = Task.Run(...)`              -- discard explicite (assume, volontaire)\n///   - `return Task.Run(...)`           -- tache retournee a l'appelant\n///   - homonyme custom (autre type, autre signature) -- filtre semantique\n/// </summary>\n[DiagnosticAnalyzer(LanguageNames.CSharp)]\npublic sealed class TaskRunFireAnalyzer : DiagnosticAnalyzer\n{\n    public const string DiagnosticId = \"AGENTGUARD003\";\n\n    private static readonly DiagnosticDescriptor Rule = new(\n        DiagnosticId,\n        \"Task.Run feu, tache non observee\",\n        \"Task.Run '{0}' lance une tache non observee -- exceptions perdues, comportement indefini\",\n        \"Agentisme\",\n        DiagnosticSeverity.Warning,\n        isEnabledByDefault: true,\n        description: \"Une invocation nue de Task.Run execute la tache en arriere-plan ; ses exceptions ne sont observees par personne. Utiliser await, affecter a une variable, retourner ou discarder explicitement (_ =).\");\n\n    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n        => ImmutableArray.Create(Rule);\n\n    public override void Initialize(AnalysisContext context)\n    {\n        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n        context.EnableConcurrentExecution();\n        // On s'abonne aux INVOCATIONS (le noeud Task.Run(...)). Le diagnostic\n        // porte sur l'invocation, pas sur un membre -- le membre ici est un\n        // IdentifierName (Run), pas un MemberAccessExpression, donc on ne peut\n        // pas reutiliser la strategie d'AGENTGUARD001.\n        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);\n    }\n\n    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)\n    {\n        var inv = (InvocationExpressionSyntax)ctx.Node;\n\n        // 1. Filtre semantique : la methode invoquee est bien Task.Run.\n        //    Reutilise le pattern d'AGENTGUARD001 : resoudre le symbole et\n        //    verifier que la ContainingType est Task (non-generique).\n        //    Evince les methodes homonymes : un type custom `MonService.Run`\n        //    ne doit PAS declencher AGENTGUARD003.\n        if (ctx.SemanticModel.GetSymbolInfo(inv).Symbol is not IMethodSymbol method) return;\n        if (method.ContainingType is not INamedTypeSymbol ct\n            || ct.MetadataName is not \"Task\"\n            || ct.ContainingNamespace?.ToDisplayString() != \"System.Threading.Tasks\") return;\n        if (method.MetadataName is not \"Run\") return;\n\n        // 2. Filtre syntaxique : la seule forme signalee est l'ExpressionStatement\n        //    nu (l'invocation est l'integralite de l'enonce). Les autres formes\n        //    -- await, affectation, discard, return, argument d'une autre\n        //    invocation -- ne sont JAMAIS signalees.\n        //\n        //    Cas particulier `_ = Task.Run(...)` : Roslyn represente le discard\n        //    comme un AssignmentExpression avec Left = IdentifierName(\"_\"),\n        //    donc le parent n'est PAS un ExpressionStatement nu -- il est\n        //    rattrape par le filtre \"n'est pas ExpressionStatement\" et tombe\n        //    naturellement dans la branche exempt. Le test terrain le verifie.\n        if (inv.Parent is not ExpressionStatementSyntax) return;\n\n        ctx.ReportDiagnostic(Diagnostic.Create(\n            Rule, inv.GetLocation(), inv.ToString()));\n    }\n}\n\r\n"
     }
    ],
    "source": [
@@ -1401,24 +947,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "Ce notebook a démontré, exécution à l'appui :\n",
-    "\n",
-    "- un **analyseur Roslyn réel** de ~40 lignes (`TaskResultBlockAnalyzer`) attrape le pattern de deadlock le plus récurrent du code d'agent généré ;\n",
-    "- sur le **canal build**, `dotnet build` rend des avertissements `AGENTGUARD001/002/003` sans aucun outil supplémentaire — la thèse DANS-la-compilation, étendue aux trois analyseurs ;\n",
-    "- sur le **canal API**, le `Verifier` compile faulty/corrigé et rend ses verdicts (cinq terrains AGENTGUARD003) — le même moteur que l'IDE et que vos tests CI ;\n",
-    "- le **fix** est minimal : `async`/`await` de bout en bout, et l'analyseur reconnaît la correction ;\n",
-    "- la **deuxième itération E2** de la série est livrée : `AGENTGUARD003` (`Task.Run` feu, `TaskRunFireAnalyzer`) tire dans le même build, avec **cinq terrains** démontrant la precision du filtre sémantique (fautif rouge, await propre, affectation observee, discard explicite, homonyme custom) ;\n",
-    "- le **contraste Python** est un déplacement de moment : là où ruff exige une adoption et une activation par règle, l'analyseur .NET est constitutif de la chaîne de build.\n",
-    "\n",
-    "Trois exercices restent ouverts — la variante furtive `GetAwaiter().GetResult()` (exercice 1), l'exemption `Result<T>` (exercice 2), et l'extension `Task.Factory.StartNew` (exercice 4) — chacun étendant le même squelette à deux étages (syntaxique puis sémantique).\n",
-    "\n",
-    "**Pour aller plus loin** : la série Aspire (notebooks 01-05) fournit le terrain d'agent ; l'Epic #10473 tient la parité Python/C# des garde-fous ; et la documentation Roslyn `DiagnosticAnalyzer` couvre les code fixers et les tests (`Microsoft.CodeAnalysis.Analyzer.Testing`).\n",
-    "\n",
-    "See #10473"
-   ]
+   "source": "## Conclusion\n\nCe notebook a démontré, exécution à l'appui :\n\n- quatre **analyseurs Roslyn réels** attrapent des défauts distincts du code d'agent généré : blocage synchrone, `async void`, `Task.Run` non observé et perte de propagation d'un `CancellationToken` ;\n- sur le **canal build**, `dotnet build` rend `AGENTGUARD001/002/003/004` sans outil supplémentaire — la thèse DANS-la-compilation ;\n- sur le **canal API**, le `Verifier` compile les terrains fautifs, corrigés et homonymes, puis rend les mêmes diagnostics que l'IDE et MSBuild ;\n- chaque analyseur combine un périmètre précis avec des exemptions exécutées, plutôt qu'une heuristique sur le nom d'une méthode ou d'un paramètre ;\n- le contraste Python reste un déplacement de moment : là où ruff exige adoption et activation par règle, l'analyseur .NET est constitutif de la chaîne de build.\n\nLes exercices restent non résolus et étendent les mêmes filtres sémantiques : `GetAwaiter().GetResult()`, l'exemption `Result<T>`, `Task.Factory.StartNew` et, désormais, la portée d'un token dans une fonction locale.\n\n**Pour aller plus loin** : la série Aspire fournit le terrain d'agent ; l'Epic #10473 tient la parité Python/C# des garde-fous ; et la documentation Roslyn `DiagnosticAnalyzer` couvre les code fixers et les tests (`Microsoft.CodeAnalysis.Analyzer.Testing`).\n\nSee #10473"
   },
   {
    "cell_type": "markdown",
@@ -1459,17 +988,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[TaskRunFireFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD003 x1\r\n",
-      "    AGENTGUARD003 @ 14:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n",
-      "[TaskRunFireCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "[TaskRunFireAssignation.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "[TaskRunFireDiscard.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "[TaskRunFireHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "[TaskRunFireFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD003 x1\r\n    AGENTGUARD003 @ 14:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n[TaskRunFireCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[TaskRunFireAssignation.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[TaskRunFireDiscard.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[TaskRunFireHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
     }
    ],
    "source": [
@@ -1564,11 +1085,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : etendre AGENTGUARD003 a Task.Factory.StartNew nu\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : etendre AGENTGUARD003 a Task.Factory.StartNew nu\r\n"
     }
    ],
    "source": [
@@ -1578,6 +1097,72 @@
     "// statique Task.Factory est elle-membre de Task -- d'ou le double saut.\n",
     "// TODO etudiant : ajouter la detection et tester sur un nouveau sample.\n",
     "Console.WriteLine(\"Exercice a completer : etendre AGENTGUARD003 a Task.Factory.StartNew nu\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1699700",
+   "source": "## D3 — `AGENTGUARD004` : l'annulation doit traverser toute la chaîne\n\nUn agent reçoit souvent un `CancellationToken` depuis une requête HTTP ou un `BackgroundService`. Le token n'est utile que s'il voyage jusqu'à chaque opération annulable. Le défaut est discret : la méthode englobante possède bien le token, la cible l'accepte, mais l'appel omet l'argument optionnel. Le code compile et continue à travailler après l'annulation demandée.\n\n`AGENTGUARD004` vise exactement cette rupture. Il ne cherche ni un nom comme `Async`, ni un paramètre nommé `ct` : il demande au modèle sémantique si le symbole englobant possède un vrai `System.Threading.CancellationToken`, puis si la signature cible expose ce même type et si l'argument a été fourni explicitement.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "24a493a4",
+   "source": "// Exemple guide resolu -- lire l'analyseur semantique livre.\nvar analyzer004 = File.ReadAllText(Path.Combine(\n    here, \"AgentGuard.Analyzers\", \"CancellationTokenPropagationAnalyzer.cs\"));\nConsole.WriteLine(analyzer004);",
+   "metadata": {},
+   "execution_count": 14,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "using System.Collections.Immutable;\nusing System.Linq;\nusing Microsoft.CodeAnalysis;\nusing Microsoft.CodeAnalysis.Diagnostics;\nusing Microsoft.CodeAnalysis.Operations;\n\nnamespace AgentGuard.Analyzers;\n\n/// <summary>\n/// AGENTGUARD004 : perte d'un CancellationToken disponible.\n///\n/// Une méthode d'agent reçoit souvent un token depuis la requête HTTP ou le\n/// BackgroundService. Si elle appelle une opération dont la signature expose\n/// explicitement CancellationToken mais omet cet argument optionnel, l'arrêt\n/// demandé ne traverse plus la chaîne. L'analyse est entièrement sémantique :\n/// le type doit être System.Threading.CancellationToken, sans heuristique sur\n/// le nom de la méthode ni du paramètre.\n/// </summary>\n[DiagnosticAnalyzer(LanguageNames.CSharp)]\npublic sealed class CancellationTokenPropagationAnalyzer : DiagnosticAnalyzer\n{\n    public const string DiagnosticId = \"AGENTGUARD004\";\n\n    private static readonly DiagnosticDescriptor Rule = new(\n        DiagnosticId,\n        \"CancellationToken disponible mais non propage\",\n        \"L'appel à '{0}' omet CancellationToken alors que '{1}' est disponible dans la méthode englobante\",\n        \"Agentisme\",\n        DiagnosticSeverity.Warning,\n        isEnabledByDefault: true,\n        description: \"Propager le CancellationToken disponible aux opérations annulables afin que l'arrêt traverse toute la chaîne d'agent.\");\n\n    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n        => ImmutableArray.Create(Rule);\n\n    public override void Initialize(AnalysisContext context)\n    {\n        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n        context.EnableConcurrentExecution();\n        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);\n    }\n\n    private static void AnalyzeInvocation(OperationAnalysisContext ctx)\n    {\n        var invocation = (IInvocationOperation)ctx.Operation;\n        var cancellationToken = ctx.Compilation.GetTypeByMetadataName(\n            \"System.Threading.CancellationToken\");\n        if (cancellationToken is null) return;\n\n        var tokenParameter = invocation.TargetMethod.Parameters.FirstOrDefault(\n            parameter => SymbolEqualityComparer.Default.Equals(\n                parameter.Type, cancellationToken));\n        if (tokenParameter is null) return;\n\n        // Roslyn matérialise un argument optionnel omis avec ArgumentKind.DefaultValue.\n        // Seul un argument Explicit prouve que l'appelant a propagé un token.\n        var tokenIsExplicit = invocation.Arguments.Any(argument =>\n            SymbolEqualityComparer.Default.Equals(argument.Parameter, tokenParameter)\n            && argument.ArgumentKind == ArgumentKind.Explicit);\n        if (tokenIsExplicit) return;\n\n        var availableToken = FindAvailableToken(ctx.ContainingSymbol, cancellationToken);\n        if (availableToken is null) return;\n\n        ctx.ReportDiagnostic(Diagnostic.Create(\n            Rule,\n            invocation.Syntax.GetLocation(),\n            invocation.TargetMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),\n            availableToken.Name));\n    }\n\n    private static IParameterSymbol FindAvailableToken(\n        ISymbol symbol,\n        INamedTypeSymbol cancellationToken)\n    {\n        // Une lambda ou une fonction locale peut capturer le token de sa méthode\n        // englobante : on remonte donc la chaîne de symboles, sans sortir du type.\n        for (var current = symbol; current is not null && current is not INamedTypeSymbol;\n             current = current.ContainingSymbol)\n        {\n            if (current is not IMethodSymbol method) continue;\n\n            var token = method.Parameters.FirstOrDefault(parameter =>\n                SymbolEqualityComparer.Default.Equals(\n                    parameter.Type, cancellationToken));\n            if (token is not null) return token;\n        }\n\n        return null;\n    }\n}\n\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d9de673",
+   "source": "### Mesure — un fautif, quatre contrôles négatifs\n\nLe Verifier soumet cinq sources au même analyseur :\n\n1. token disponible + cible annulable + argument omis : **rouge** ;\n2. token transmis : propre ;\n3. aucun token disponible : propre ;\n4. surcharge réellement choisie sans paramètre token : propre ;\n5. type homonyme `AgentCustom.CancellationToken` : propre.\n\nCe dernier contrôle est décisif : le filtre compare les symboles au type BCL `System.Threading.CancellationToken`, pas leur simple orthographe.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "87b32afa",
+   "source": "var verdicts004 = Shell.Run(here, \"dotnet\",\n    \"run --project AgentGuard.Verifier -- \" +\n    \"AgentGuard.Verifier/samples/CancellationTokenFautif.cs \" +\n    \"AgentGuard.Verifier/samples/CancellationTokenCorrige.cs \" +\n    \"AgentGuard.Verifier/samples/CancellationTokenSansTokenDisponible.cs \" +\n    \"AgentGuard.Verifier/samples/CancellationTokenSurchargeSansToken.cs \" +\n    \"AgentGuard.Verifier/samples/CancellationTokenHomonyme.cs\");\nConsole.WriteLine(verdicts004);",
+   "metadata": {},
+   "execution_count": 15,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[CancellationTokenFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD004 x1\r\n    AGENTGUARD004 @ 10:15  L'appel à 'Task AgentCancellationFautif.EnvoyerAuModeleAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante\r\n[CancellationTokenCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[CancellationTokenSansTokenDisponible.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[CancellationTokenSurchargeSansToken.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[CancellationTokenHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e4272a6",
+   "source": "### Lecture du résultat\n\nLe terrain fautif rend exactement **`AGENTGUARD004 x1`** sur l'appel qui perd l'annulation. Les quatre autres terrains rendent **PROPRE** : le diagnostic disparaît dès que le vrai token est transmis, et il n'apparaît pas quand le contrat ou la portée ne permettent aucune propagation.\n\nLa distinction « surcharge sans token » évite une recommandation impossible : si la méthode réellement résolue par Roslyn n'expose pas `CancellationToken`, l'analyseur ne prétend pas qu'un argument pourrait lui être ajouté. La distinction « homonyme » évite le faux positif lexical. Ces résultats mesurés bornent précisément ce que garantit la règle : **propager un token déjà disponible vers une cible qui l'accepte explicitement**.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef312734",
+   "source": "### Exercice 5 — Borner la portée dans une fonction locale\n\nL'analyseur remonte les symboles englobants : une fonction locale ou une lambda peut capturer le token de sa méthode parente. Cette propriété évite de perdre l'annulation dans un callback interne, mais elle doit rester précise.\n\n**Objectif** : écrire un terrain qui prouve la capture, puis un contre-exemple où un token local est déjà transmis.\n\n- `# Etape 1` : dans une méthode `TraiterAsync(CancellationToken ct)`, déclarer une fonction locale `EtapeAsync()` qui appelle une cible annulable sans `ct` ; verdict attendu : `AGENTGUARD004`.\n- `# Etape 2` : transmettre `ct` depuis la fonction locale ; verdict attendu : PROPRE.\n- `# Indice` : ne modifiez pas les noms des méthodes pour aider l'analyseur — il ne les utilise pas.\n- `# TODO etudiant` : ajouter les deux sources aux samples du Verifier et expliquer quel `ContainingSymbol` rend la capture visible.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "905bc07f",
+   "source": "// Exercice 5 a completer -- terrain minimal de fonction locale.\n// TODO etudiant : transformer ce commentaire en deux samples du Verifier.\n//\n// static async Task TraiterAsync(CancellationToken ct)\n// {\n//     async Task EtapeAsync()\n//     {\n//         await OperationAnnulableAsync();      // attendu : AGENTGUARD004\n//         // puis corriger avec OperationAnnulableAsync(ct)\n//     }\n//     await EtapeAsync();\n// }\nConsole.WriteLine(\"Exercice a completer : verifier la propagation dans une fonction locale\");",
+   "metadata": {},
+   "execution_count": 16,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : verifier la propagation dans une fonction locale\r\n"
+    }
    ]
   }
  ],
@@ -1593,18 +1178,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 28.816773,
-   "end_time": "2026-08-28T21:33:25.574487",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "06-Aspire-GardeFous-Roslyn.ipynb",
-   "output_path": "06-Aspire-GardeFous-Roslyn.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-28T21:32:56.757714",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/AnalyzerReleases.Shipped.md
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 1.2.0
+
+- AGENTGUARD004 : `CancellationToken` disponible mais omis lors d'un appel dont la signature cible expose explicitement ce type (analyse semantique ; exemptions : token deja passe, aucune cible annulable, aucun token disponible, homonyme)
+
 ## 1.1.0
 
 - AGENTGUARD002 : methode async void hors gestionnaire d'evenement (avec exemption semantique handler)

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/CancellationTokenPropagationAnalyzer.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/CancellationTokenPropagationAnalyzer.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace AgentGuard.Analyzers;
+
+/// <summary>
+/// AGENTGUARD004 : perte d'un CancellationToken disponible.
+///
+/// Une méthode d'agent reçoit souvent un token depuis la requête HTTP ou le
+/// BackgroundService. Si elle appelle une opération dont la signature expose
+/// explicitement CancellationToken mais omet cet argument optionnel, l'arrêt
+/// demandé ne traverse plus la chaîne. L'analyse est entièrement sémantique :
+/// le type doit être System.Threading.CancellationToken, sans heuristique sur
+/// le nom de la méthode ni du paramètre.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CancellationTokenPropagationAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "AGENTGUARD004";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "CancellationToken disponible mais non propage",
+        "L'appel à '{0}' omet CancellationToken alors que '{1}' est disponible dans la méthode englobante",
+        "Agentisme",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Propager le CancellationToken disponible aux opérations annulables afin que l'arrêt traverse toute la chaîne d'agent.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext ctx)
+    {
+        var invocation = (IInvocationOperation)ctx.Operation;
+        var cancellationToken = ctx.Compilation.GetTypeByMetadataName(
+            "System.Threading.CancellationToken");
+        if (cancellationToken is null) return;
+
+        var tokenParameter = invocation.TargetMethod.Parameters.FirstOrDefault(
+            parameter => SymbolEqualityComparer.Default.Equals(
+                parameter.Type, cancellationToken));
+        if (tokenParameter is null) return;
+
+        // Roslyn matérialise un argument optionnel omis avec ArgumentKind.DefaultValue.
+        // Seul un argument Explicit prouve que l'appelant a propagé un token.
+        var tokenIsExplicit = invocation.Arguments.Any(argument =>
+            SymbolEqualityComparer.Default.Equals(argument.Parameter, tokenParameter)
+            && argument.ArgumentKind == ArgumentKind.Explicit);
+        if (tokenIsExplicit) return;
+
+        var availableToken = FindAvailableToken(ctx.ContainingSymbol, cancellationToken);
+        if (availableToken is null) return;
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.Syntax.GetLocation(),
+            invocation.TargetMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+            availableToken.Name));
+    }
+
+    private static IParameterSymbol FindAvailableToken(
+        ISymbol symbol,
+        INamedTypeSymbol cancellationToken)
+    {
+        // Une lambda ou une fonction locale peut capturer le token de sa méthode
+        // englobante : on remonte donc la chaîne de symboles, sans sortir du type.
+        for (var current = symbol; current is not null && current is not INamedTypeSymbol;
+             current = current.ContainingSymbol)
+        {
+            if (current is not IMethodSymbol method) continue;
+
+            var token = method.Parameters.FirstOrDefault(parameter =>
+                SymbolEqualityComparer.Default.Equals(
+                    parameter.Type, cancellationToken));
+            if (token is not null) return token;
+        }
+
+        return null;
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Demo/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Demo/Program.cs
@@ -75,3 +75,21 @@ public static class AgentTaskRunFire
         Task.Run(() => Console.WriteLine("ping"));   // AGENTGUARD003
     }
 }
+
+// Quatrieme terrain fautif (AGENTGUARD004) : la requete fournit un
+// CancellationToken, et la cible sait le recevoir, mais le code genere omet
+// l'argument optionnel. L'annulation est perdue au milieu de la chaine.
+public static class AgentCancellation
+{
+    public static async Task RepondreAsync(
+        string prompt,
+        System.Threading.CancellationToken cancellationToken)
+    {
+        await CallLlmAsync(prompt);                    // AGENTGUARD004
+    }
+
+    private static Task<string> CallLlmAsync(
+        string prompt,
+        System.Threading.CancellationToken cancellationToken = default)
+        => Task.FromResult($"[LLM] {prompt}");
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/Program.cs
@@ -55,7 +55,12 @@ foreach (var path in args)
             hasTopLevel ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary));
 
     var withAnalyzers = compilation.WithAnalyzers(
-        [new TaskResultBlockAnalyzer(), new AsyncVoidAnalyzer(), new TaskRunFireAnalyzer()]);
+        [
+            new TaskResultBlockAnalyzer(),
+            new AsyncVoidAnalyzer(),
+            new TaskRunFireAnalyzer(),
+            new CancellationTokenPropagationAnalyzer(),
+        ]);
 
     // Les erreurs de compilation empechent le modele semantique de resoudre
     // les symboles (donc l'analyseur de trancher) : on les rend visibles.
@@ -67,6 +72,7 @@ foreach (var path in args)
         TaskResultBlockAnalyzer.DiagnosticId,   // AGENTGUARD001
         AsyncVoidAnalyzer.DiagnosticId,         // AGENTGUARD002
         TaskRunFireAnalyzer.DiagnosticId,       // AGENTGUARD003
+        CancellationTokenPropagationAnalyzer.DiagnosticId, // AGENTGUARD004
     };
     var diagnostics = (await withAnalyzers.GetAllDiagnosticsAsync())
         .Where(d => ids.Contains(d.Id))

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenCorrige.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenCorrige.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AgentCancellationCorrige
+{
+    public static async Task RepondreAsync(
+        string prompt,
+        CancellationToken cancellationToken)
+    {
+        await EnvoyerAuModeleAsync(prompt, cancellationToken);
+    }
+
+    private static Task EnvoyerAuModeleAsync(
+        string prompt,
+        CancellationToken cancellationToken = default)
+        => Task.Delay(10, cancellationToken);
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenFautif.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenFautif.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AgentCancellationFautif
+{
+    public static async Task RepondreAsync(
+        string prompt,
+        CancellationToken cancellationToken)
+    {
+        await EnvoyerAuModeleAsync(prompt); // AGENTGUARD004
+    }
+
+    private static Task EnvoyerAuModeleAsync(
+        string prompt,
+        CancellationToken cancellationToken = default)
+        => Task.Delay(10, cancellationToken);
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenHomonyme.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenHomonyme.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace AgentCustom;
+
+public readonly record struct CancellationToken(bool PeutAnnuler);
+
+public static class AgentTokenHomonyme
+{
+    public static async Task RepondreAsync(
+        string prompt,
+        CancellationToken cancellationToken)
+    {
+        await EnvoyerAuModeleAsync(prompt);
+    }
+
+    private static Task EnvoyerAuModeleAsync(
+        string prompt,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenSansTokenDisponible.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenSansTokenDisponible.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AgentSansTokenDisponible
+{
+    public static async Task RepondreAsync(string prompt)
+    {
+        await EnvoyerAuModeleAsync(prompt);
+    }
+
+    private static Task EnvoyerAuModeleAsync(
+        string prompt,
+        CancellationToken cancellationToken = default)
+        => Task.Delay(10, cancellationToken);
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenSurchargeSansToken.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/CancellationTokenSurchargeSansToken.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AgentSurchargeSansToken
+{
+    public static async Task RepondreAsync(
+        string prompt,
+        CancellationToken cancellationToken)
+    {
+        await EnvoyerAuModeleAsync(prompt);
+    }
+
+    private static Task EnvoyerAuModeleAsync(string prompt)
+        => Task.Delay(10);
+
+    private static Task EnvoyerAuModeleAsync(
+        string prompt,
+        int priorite,
+        CancellationToken cancellationToken = default)
+        => Task.Delay(priorite, cancellationToken);
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/research-code #13665

## Résumé

- ajoute `AGENTGUARD004`, un analyseur Roslyn sémantique qui signale l'omission d'un vrai `System.Threading.CancellationToken` lorsque la méthode englobante en expose un et que la cible résolue accepte ce type ;
- branche l'analyseur dans le canal build et dans le Verifier Roslyn ;
- ajoute un terrain fautif, un terrain corrigé et trois contrôles de faux positifs : aucun token disponible, surcharge sélectionnée sans token, homonyme personnalisé ;
- étend le notebook Aspire par une section exécutée, une mesure attendue/observée et un nouvel exercice étudiant sans erreur volontaire.

See #10473

## Validation

### Analyseur et démo

```text
dotnet build AgentGuard.Analyzers -t:Rebuild
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet build AgentGuard.Demo -t:Rebuild
Build succeeded. 5 Warning(s), 0 Error(s)
AGENTGUARD001 x2, AGENTGUARD002 x1, AGENTGUARD003 x1, AGENTGUARD004 x1
```

Le diagnostic `AGENTGUARD004` est émis à `Program.cs(88,15)` par le canal analyseur MSBuild.

### Verifier Roslyn — attendu / observé

```text
CancellationTokenFautif.cs                  attendu AGENTGUARD004 x1 — observé AGENTGUARD004 x1
CancellationTokenCorrige.cs                 attendu PROPRE            — observé PROPRE
CancellationTokenSansTokenDisponible.cs     attendu PROPRE            — observé PROPRE
CancellationTokenSurchargeSansToken.cs      attendu PROPRE            — observé PROPRE
CancellationTokenHomonyme.cs                attendu PROPRE            — observé PROPRE
```

La détection s'appuie sur `IInvocationOperation.TargetMethod`, `ArgumentKind.Explicit` et `SymbolEqualityComparer.Default`, sans heuristique sur le nom des méthodes.

### Notebook .NET

```text
06-Aspire-GardeFous-Roslyn.ipynb
16/16 cellules code exécutées, 0 erreur, 23,6 s
execution_count : 1..16
16/16 cellules code avec output
```

- `validate_pr_notebooks.py` : PASS, 1/1 notebook ;
- `notebook_tools.py validate` : 1 OK, 0 avertissement, 0 erreur ;
- `scan_cell_ordering.py --severity HIGH` : 1 clean, 0 finding ;
- contrôle des ancres d'interprétation : 1 clean, 0 finding ;
- `detect_md_content_loss.py --base origin/main --check` : 0 finding, volume markdown 20 957 → 23 168 caractères normalisés ;
- `check_render_volume_delta.py --base origin/main --check` : 0 finding, rendu texte 15 881 → 22 204 octets ;
- `count_exercises.py` : 4 exercices, seuil pédagogique satisfait ;
- `detect_consecutive_code_cells.py` : aucun run de cellules code consécutives ;
- `strip_probe_banner.py --apply` exécuté après l'exécution réelle : une ligne de bannière réseau retirée conformément à l'exception documentée.

Le diff notebook est append-only au niveau des cellules : 0 cellule retirée, 7 ajoutées (4 markdown, 3 code). Le churn JSON restant provient de la ré-exécution et de la normalisation des outputs.

### Configuration GenAI

`python scripts/genai-stack/genai.py validate --full` a été lancé avant l'exécution et a signalé uniquement ComfyUI indisponible sur `localhost:8188`. Ce notebook Roslyn n'appelle ni ComfyUI ni un service GenAI externe ; aucune sortie de substitution ou fabriquée n'a été utilisée. Verdict du chemin exécuté : **SOTA-OK** pour Roslyn et le kernel .NET local.

## Portée

10 fichiers, exclusivement l'analyseur AgentGuard, ses terrains Demo/Verifier et le notebook pédagogique associé. Aucun catalogue généré n'est modifié.
