### PR TITLE
feat(parcours,#10921): refonte visuelle parcours.qmd + styles.css

### DIFF
--- a/parcours.qmd
+++ b/parcours.qmd
@@ -4,11 +4,14 @@ subtitle: "Trois parcours certifiés selon votre niveau"
 description: "Parcours d'apprentissage CoursIA : local sobre (Python uniquement), ML.NET + Symbolic (avec .NET Interactive + Lean 4), GenAI complet (Docker + GPU)."
 ---
 
-# Parcours d'apprentissage
-
 Trois parcours certifiés selon votre niveau, vos prérequis, et votre matériel. Tous convergent vers le catalogue unifié — vous pouvez passer de l'un à l'autre au fil de votre progression.
 
-## 1. Local sobre — Python + Jupyter uniquement
+::: {.grid}
+
+::: {.g-col-12 .g-col-md-4 .parcours-card .parcours-card--local}
+### 1. Local sobre
+
+**Python + Jupyter uniquement**
 
 **Prérequis** : Python 3.10+, 8 GB RAM. Aucun GPU, aucun Docker.
 
@@ -16,7 +19,7 @@ Trois parcours certifiés selon votre niveau, vos prérequis, et votre matériel
 
 **Séries accessibles** :
 
-- [Search/Part1-Foundations](MyIA.AI.Notebooks/Search/Part1-Foundations/README.md) — BFS, DFS, Dijkstra, A*
+- [Search/Part1-Foundations](MyIA.AI.Notebooks/Search/Part1-Foundations/README.md) — BFS, DFS, Dijkstra, A\*
 - [Sudoku/Sudoku-Python](MyIA.AI.Notebooks/Sudoku/index.qmd) — solveur Python pur
 - [GameTheory](MyIA.AI.Notebooks/GameTheory/index.qmd) — jeux combinatoires en Python
 - [Probas/InferGlossary](MyIA.AI.Notebooks/Probas/index.qmd) — probabilités discrètes de base
@@ -34,7 +37,13 @@ pip install jupyter papermill
 jupyter notebook MyIA.AI.Notebooks/
 ```
 
-## 2. ML.NET + Symbolic — .NET Interactive + Lean 4
+[Commencer le parcours 1 →](README.md){.btn .btn-primary .parcours-cta}
+:::
+
+::: {.g-col-12 .g-col-md-4 .parcours-card .parcours-card--dotnet}
+### 2. ML.NET + Symbolic
+
+**.NET Interactive + Lean 4**
 
 **Prérequis** : Python (parcours 1) + .NET 9 SDK + (optionnel) WSL pour Lean 4.
 
@@ -48,7 +57,13 @@ jupyter notebook MyIA.AI.Notebooks/
 - [SymbolicAI/Tweety](MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md) — argumentation computationnelle (port IKVM)
 - [SymbolicAI/Planners](MyIA.AI.Notebooks/SymbolicAI/Planners/README.md) — planification automatique (OR-tools)
 
-## 3. GenAI complet — Docker + GPU + services cloud
+[Commencer le parcours 2 →](README.md){.btn .btn-primary .parcours-cta}
+:::
+
+::: {.g-col-12 .g-col-md-4 .parcours-card .parcours-card--genai}
+### 3. GenAI complet
+
+**Docker + GPU + services cloud**
 
 **Prérequis** : parcours 2 + Docker Desktop + GPU NVIDIA (RTX 3090 recommandée, 24 GB VRAM).
 
@@ -60,6 +75,11 @@ jupyter notebook MyIA.AI.Notebooks/
 - [GenAI/Audio/02-Advanced](MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/README.md) — TTS, Whisper, music generation
 - [GenAI/Vibe-Coding](MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md) — assistants IA en local (Claude Code, Roo)
 - [QuantConnect/](MyIA.AI.Notebooks/QuantConnect/README.md) — 50+ stratégies de trading algorithmique (Lean engine)
+
+[Commencer le parcours 3 →](README.md){.btn .btn-primary .parcours-cta}
+:::
+
+:::
 
 ## Passerelles entre parcours
 

--- a/parcours.qmd
+++ b/parcours.qmd
@@ -37,7 +37,7 @@ pip install jupyter papermill
 jupyter notebook MyIA.AI.Notebooks/
 ```
 
-[Commencer le parcours 1 →](README.md){.btn .btn-primary .parcours-cta}
+[Commencer le parcours 1 →](MyIA.AI.Notebooks/Search/Part1-Foundations/README.md){.btn .btn-primary .parcours-cta}
 :::
 
 ::: {.g-col-12 .g-col-md-4 .parcours-card .parcours-card--dotnet}
@@ -57,7 +57,7 @@ jupyter notebook MyIA.AI.Notebooks/
 - [SymbolicAI/Tweety](MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md) — argumentation computationnelle (port IKVM)
 - [SymbolicAI/Planners](MyIA.AI.Notebooks/SymbolicAI/Planners/README.md) — planification automatique (OR-tools)
 
-[Commencer le parcours 2 →](README.md){.btn .btn-primary .parcours-cta}
+[Commencer le parcours 2 →](MyIA.AI.Notebooks/ML/README.md){.btn .btn-primary .parcours-cta}
 :::
 
 ::: {.g-col-12 .g-col-md-4 .parcours-card .parcours-card--genai}
@@ -76,7 +76,7 @@ jupyter notebook MyIA.AI.Notebooks/
 - [GenAI/Vibe-Coding](MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md) — assistants IA en local (Claude Code, Roo)
 - [QuantConnect/](MyIA.AI.Notebooks/QuantConnect/README.md) — 50+ stratégies de trading algorithmique (Lean engine)
 
-[Commencer le parcours 3 →](README.md){.btn .btn-primary .parcours-cta}
+[Commencer le parcours 3 →](MyIA.AI.Notebooks/GenAI/Image/README.md){.btn .btn-primary .parcours-cta}
 :::
 
 :::

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,11 @@
 /* CoursIA custom styles */
 
+/* Navbar */
 .navbar-brand {
   font-weight: 600;
 }
 
+/* Quarto title banner */
 .quarto-title-banner {
   background: linear-gradient(135deg, #1e3a8a 0%, #3b82f6 100%);
   color: white;
@@ -22,6 +24,7 @@
   font-size: 1.25rem;
 }
 
+/* Legacy .series-card retained for compatibility with other pages */
 .series-card {
   border-left: 4px solid #3b82f6;
   padding: 1rem;
@@ -42,4 +45,99 @@
   border-radius: 0.25rem;
   font-size: 0.85rem;
   margin-right: 0.5rem;
+}
+
+/* Parcours cards — #10921
+   3 colonnes égales en desktop (>=768px), empilées en mobile.
+   Bordure colorée à gauche par parcours pour identification visuelle.
+   Theme-aware via prefers-color-scheme + [data-bs-theme=dark].
+*/
+.parcours-card {
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-left-width: 4px;
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  background: var(--bs-card-bg, #ffffff);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.parcours-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+  font-size: 1.35rem;
+}
+
+.parcours-card > p > strong:first-child {
+  display: block;
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.parcours-card ul {
+  padding-left: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.parcours-card ul li {
+  margin-bottom: 0.35rem;
+}
+
+.parcours-card pre {
+  font-size: 0.8rem;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  background: var(--bs-tertiary-bg, #f8f9fa);
+  border: 1px solid var(--bs-border-color, #dee2e6);
+}
+
+.parcours-card .parcours-cta {
+  margin-top: auto;
+  align-self: flex-start;
+}
+
+/* Bordures gauches distinctives par parcours */
+.parcours-card--local  { border-left-color: #198754; }
+.parcours-card--dotnet { border-left-color: #6f42c1; }
+.parcours-card--genai  { border-left-color: #fd7e14; }
+
+/* Theme-aware : prefers-color-scheme dark */
+@media (prefers-color-scheme: dark) {
+  .parcours-card {
+    background: var(--bs-card-bg, #212529);
+    border-color: var(--bs-border-color, #495057);
+  }
+  .parcours-card pre {
+    background: var(--bs-tertiary-bg, #343a40);
+  }
+}
+
+/* Theme-aware : Quarto toggle [data-bs-theme=dark] */
+[data-bs-theme="dark"] .parcours-card {
+  background: var(--bs-card-bg, #212529);
+  border-color: var(--bs-border-color, #495057);
+}
+
+[data-bs-theme="dark"] .parcours-card pre {
+  background: var(--bs-tertiary-bg, #343a40);
+}
+
+/* Mobile : empiler les cards, padding réduit, CTA pleine largeur */
+@media (max-width: 767.98px) {
+  .parcours-card {
+    padding: 1rem;
+  }
+  .parcours-card h3 {
+    font-size: 1.2rem;
+  }
+  .parcours-cta {
+    width: 100%;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2027:CoursIA-2 — prev: MED/guard #13657

## feat(parcours): refonte visuelle de `parcours.qmd` — 1 seul H1, 3 cards responsives avec CTA (#10921)

### Constat avant

Mesure firsthand par Playwright sur `https://jsboige.github.io/CoursIA/parcours.html` :

- **Double H1** : `Parcours d'apprentissage` rendu **deux fois** (une fois via frontmatter `title:`, une fois via `# Parcours d'apprentissage` body ligne 7) → défaut structurel SEO/a11y.
- **3 parcours non-comparables** : liste plate mono-colonne numérotée 1/2/3, aucun visuel distinctif.
- **Aucun CTA** : pas de bouton "Démarrer" / "Choisir mon parcours" → friction d'entrée.
- **Mobile dégradé** : scroll total ~3154px (3.5× desktop), TOC sidebar masquée sans fallback.

### Périmètre atomicité (G.4)

| Fichier | Action |
|---|---|
| `parcours.qmd` | Suppression body H1 ligne 7, restructuration en 3 cards (::: grid + g-col-12 g-col-md-4 :::), ajout 3 CTA `.btn-primary` "Commencer le parcours N →", 1 seul H1 (frontmatter). |
| `styles.css` | Ajout classes `.parcours-card`, `.parcours-card--local/--dotnet/--genai`, bordures gauches distinctives (vert #198754 / violet #6f42c1 / orange #fd7e14), theme-aware `prefers-color-scheme: dark` + `[data-bs-theme="dark"]`, responsive mobile (CTA pleine largeur, padding réduit). |

**2 fichiers, +126/-8 lignes.** Aucun composite. Aucun notebook modifié. Catalogue byte-identique.

### Validation visuelle (Playwright, lane CoursIA-2 a vision)

Mesures firsthand via `quarto render` local + Playwright MCP :

- **Desktop 1280×800** : `h1_count=1`, `card_count=3`, `cta_count=3`. Layout grille 3 colonnes égales, bordures colorées distinctives, TOC réduit à `Passerelles entre parcours`. (Voir capture jointe en revue, jamais dans le repo.)
- **Mobile 375×667** : cards empilées pleine largeur, CTA full-width center, scroll ~4076px (structurellement bien plus lisible que le 3154px pré-fix malgré une hauteur légèrement supérieure due à l'aération).
- **DOM vérifié** : `Array.from(document.querySelectorAll('h1')).length === 1`, `document.querySelectorAll('.parcours-card').length === 3`, `Array.from(document.querySelectorAll('.parcours-cta')).length === 3` avec textes `["Commencer le parcours 1 →", "Commencer le parcours 2 →", "Commencer le parcours 3 →"]`.

### Outillage installé (règle F REPAIR)

Quarto 1.10.18 installé via `winget install Posit.Quarto --accept-package-agreements` sur `myia-po-2027`. Vérifié : `"C:/Program Files/Quarto/bin/quarto.exe" --version` → `1.10.18`.

### Hors scope

- **Renommage des fichiers de série référencés** (liens `MyIA.AI.Notebooks/Search/Part1-Foundations/README.md` etc.) : les chemins sont conservés tels quels car ils fonctionnent sur le site déployé. Toute re-organisation des paths d'URL est hors scope de cette PR atomique.
- **Catalogue généré** : byte-identique à main (règle `catalog-pr-hygiene.md` HARD 1).
- **Autres pages `.qmd`** : styles legacy `.series-card` conservés pour compatibilité.

### Liens

- #10921 — epic parcours visuel (DISPATCH P0 po-2025, msg `msg-20260830T102331-v33r9y`)
- #13581 — précédent FallacyDetection tranche 1 (pattern `git mv` + navlinks + scripts sans ré-exec)

See #10921 (livraison partielle : scope borné à la refonte visuelle de la page d'accueil parcours, pas l'épic entière).

### Anti-patterns évités

- Pas de secret en clair (R6)
- Pas de hand-edit sur cellule committee (H.4) — pas concerné (slides)
- Pas de modification catalogue (catalog-pr-hygiene)
- Pas de modification `.gitignore` (cosmetic dirty EOL préservé)
- eol:lf cosmetic dirty TTS jamais touchés (Tell c.1331p221 ★★★)
