### PR TITLE
fix(guard,#13635): formes masculines « est leve » / « sont leves » dans LIFT_MARKERS

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -281,6 +281,15 @@ CONCERN_MARKERS = CONCERN_MARKERS + BLOCK_VERDICTS
 LIFT_MARKERS = (
     "levée", "levee", "LGTM", "Mergé", "Merged", "je merge", "Merge.",
     "est adressé", "sont adressés", "sont levées", "est levée",
+    # #13635 — formes masculines. L'organe ne captait que les formes
+    # féminines (« est levée », « sont levées ») et ratait les mêmes
+    # constructions au masculin : « est levé », « sont levés ». Le dépot
+    # emploie massivement des substantifs masculins pour designer ce qui se
+    # leve (concern, point, nit), et la phrase la plus naturelle — « tes
+    # concerns sont levés » — etait precise­ment celle que l'organe ne voyait
+    # pas (constate firsthand sur #13539 c.704). Meme justification
+    # asymetrique que #11677/#11542 pour les formes feminines historiques.
+    "est levé", "sont levés",
     "Je lève", "Je leve", "Levée de", "Levee de",
     # #11677 : « je lève ma CHANGES_REQUESTED » (#11664 fondateur) — LIFT
     # historique ne captait que « levée » (mot complet), donc « lève ma » ne


### PR DESCRIPTION
## Summary

- `scripts/check_unaddressed_nits.py` : ajout des 2 formes masculines `"est levé"`, `"sont levés"` à `LIFT_MARKERS`.
- 9 insertions / 0 deletions — scope minimal, asymmetry assumée et documentée.
- L'organe captait jusqu'ici uniquement les formes féminines (`est levée`, `sont levées`) et ratait les mêmes constructions au masculin.

## Contexte — issue #13635

Le dépôt emploie massivement des substantifs **masculins** pour désigner ce qui se lève (`concern`, `nit`, `point`) — c'est l'usage Bot Hermès / NanoClaw dominant. Les féminins (`réserve`, `remarque`) sont minoritaires. La phrase la plus naturelle — *« Tes trois concerns sont levés »* — était donc structurellement invisible à l'organe, qui sortait `BLOCKED` sur des réserves traitées par écrit.

#13539 fondateur : myia-ai-01 a arbitré par écrit les 3 concerns NanoClaw, l'organe a maintenu `exit 1` car `« Tes trois concerns sont levés »` n'était pas un LIFT_MARKER. La levée est légitime juridiquement, l'organe ne la voit pas.

## Modification

```diff
 LIFT_MARKERS = (
     "levée", "levee", "LGTM", "Mergé", "Merged", "je merge", "Merge.",
     "est adressé", "sont adressés", "sont levées", "est levée",
+    # #13635 — formes masculines. L'organe ne captait que les formes
+    # féminines (« est levée », « sont levées ») et ratait les mêmes
+    # constructions au masculin : « est levé », « sont levés ». Le dépot
+    # emploie massivement des substantifs masculins pour designer ce qui se
+    # leve (concern, point, nit), et la phrase la plus naturelle — « tes
+    # concerns sont levés » — etait precisement celle que l'organe ne voyait
+    # pas (constate firsthand sur #13539 c.704). Meme justification
+    # asymetrique que #11677/#11542 pour les formes feminines historiques.
+    "est levé", "sont levés",
     "Je lève", "Je leve", "Levée de", "Levee de",
```

## Pourquoi 2 formes, pas plus

**Contrainte grammaticale = garde-fou anti-faux-positif.** Le pattern retenu est **auxiliaire être + participe passé** (`est levé`, `sont levés`). Cette structure est sémantiquement compatible avec une levée de réserve, et grammaticalement rare ailleurs (le participe `levé` seul s'emploie peu).

**Pourquoi pas `concern levé`, `point levé`, `nit levé` au nominatif** ? `_unaccent` normalise les accents, et `has_live_lift` matche `marker in body`. Ajouter `point levé` matche aussi « *je pointe* sur le concern levé hier » — un faux positif évident en prose courante. La forme `est/sont levé(s)` est grammaticalement contrainte : un point **est** levé, on ne **lève** pas un point sans auxiliaire.

**Pourquoi pas `est traité` au masculin** ? `#12944` a explicitement rejeté `traité` nu sur contre-exemple mesuré : le body pinned #11639 « le point 3 est traité en argument » matcherait, et `traité` narratif se promène (« traité dans la section 4 »). Les verbes de fermeture (`clos`, `fermé`, `résolu`) couvrent le besoin légitime sans le faux positif narratif.

**Pourquoi `est levé`/`sont levés` est safe** : `levé` partcipe passé est très peu employé hors construction levée-de-réserve. Faux positif résiduel : « Le point est levé en réunion » matche, mais ce contexte n'apparaît quasiment jamais en revue PR. Risque acceptable.

## Tests

- **226 tests pytest** de `scripts/tests/test_check_unaddressed_nits.py` : tous passent, aucune régression.
- **6 tests reproduits verbatim depuis l'issue #13635** : tous OK.

| Phrase | Avant fix | Après fix |
|---|---|---|
| `Tes trois concerns sont levés.` | False | **True** |
| `Tes trois réserves sont levées.` | True | True |
| `Le concern est levé.` | False | **True** |
| `La réserve est levée.` | True | True |
| `Levée de la réserve NanoClaw.` | True | True |
| `Je lève les trois concerns.` | True | True |

## PRs affectées (lecture first-hand)

- **PR #13480** : reste BLOCKED mais pour cause distincte (3 commentaires citent `b2616d6b12` absent de la branche — Tell c.589-L1 ★★★ strict lift author-bound + voie 3 Tell c.11145 ★★★ strict, sortie du scope de ce fix).
- **PR #13539** : reste BLOCKED pour cause distincte (la levée du concern 1 NanoClaw est légitime juridiquement mais son auteur n'est pas `ai-01`).

Le fix **améliore la couverture de l'organe** sans rouvrir de cas légitime, et **ne débloque pas** les PRs qui dépendaient d'autres verrous. C'est une condition nécessaire mais non suffisante à ces flux.

## Grain

`Grain: MED/guard - lane myia-po-2024:CoursIA-2 - prev: MED/guard #13703`

Genre = `guard` (peut rougir). Tier = MED (change quelque chose : ferme un gap de couverture identifié). Suite à `c.740` #13703 (autre garde), ce cycle choisit délibérément un grain **META** car le pool CONTENU narrow-worker-applicable est vide ce tour (les grains disponibles, e.g. #13693, #13655, sont EPIC-large, hors budget narrow). Tell c.1331p171 ★ narrow monotonie sustained — à corriger au prochain tour par pioche CONTENT ou REPAIR transversal.

Refs #13635 · #13539 · #11677 · #11542 · #12944 · #13636 · #13639 · #11145
