### PR TITLE
fix(translation,#13546): purger 110 lignes CSV orphelines genai + render_notebook --fail-on-stale

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -394,10 +394,11 @@ jobs:
                   r = subprocess.run(
                     ["python", "scripts/translation/render_notebook.py",
                      "--csv", str(csv_path), "--notebook", nb,
-                     "--lang", lang, "--out", str(out)],
+                     "--lang", lang, "--out", str(out),
+                     "--fail-on-stale"],
                     capture_output=True, text=True)
                   if r.returncode != 0:
-                    print(f"T4 render {nb} -> {lang}: non-zero (may have 0 translated cells). {r.stderr[:160]}")
+                    print(f"T4 render {nb} -> {lang}: non-zero (0 translated cells, or stale/orphan CSV rows). {r.stderr[:160]}")
           print("T4 render pass complete.")
           PY
 

--- a/scripts/translation/render_notebook.py
+++ b/scripts/translation/render_notebook.py
@@ -135,6 +135,7 @@ def render(
     dry_run: bool = False,
     verbose: bool = False,
     require_translated: bool = False,
+    fail_on_stale: bool = False,
 ) -> RenderResult:
     """Render the notebook at ``nb_path`` to ``out_path`` in language ``lang``.
 
@@ -236,6 +237,18 @@ def render(
             f"Refus d'ecrire un clone FR verbatim."
         )
 
+    # Guardrail (#13546) : refuse a render whose CSV carried orphan cell_ids.
+    # Default off preserves the WARN + .stale sidecar contract ; opt-in pour le
+    # moteur de livraison (translation-sync) afin qu'une ligne CSV pointant une
+    # cellule supprimee bloque le pipeline au lieu de passer inapercue.
+    if fail_on_stale and orphan_keys:
+        raise ValueError(
+            f"--fail-on-stale : {len(orphan_keys)} ligne(s) CSV orpheline(s) "
+            f"(cell_id absent du notebook source, lang={lang}, {csv_path.name}) : "
+            f"{', '.join(orphan_keys[:8])}"
+            f"{'...' if len(orphan_keys) > 8 else ''}. Purger le CSV ou re-extraire."
+        )
+
     if not dry_run and out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic write : write to a sibling .tmp then rename. This prevents
@@ -310,6 +323,12 @@ def main(argv: Optional[List[str]] = None) -> int:
              "(guardrail against FR-clone files, #10349). Default off: preserves "
              "the FR-placeholder re-render contract (#10039 criterion 3).",
     )
+    p.add_argument(
+        "--fail-on-stale", action="store_true",
+        help="Refuse a render whose CSV carried orphan cell_ids (rows pointing "
+             "at cells absent from the source notebook, #13546). Default off: "
+             "WARN + .stale sidecar.",
+    )
     args = p.parse_args(argv)
 
     dry_run = args.dry_run or args.out is None
@@ -325,6 +344,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             dry_run=dry_run,
             verbose=args.verbose,
             require_translated=args.require_translated,
+            fail_on_stale=args.fail_on_stale,
         )
     except (FileNotFoundError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/translation/tests/test_render_notebook.py
+++ b/scripts/translation/tests/test_render_notebook.py
@@ -489,6 +489,61 @@ def test_render_csv_without_lang_col_raises(tmp_path):
         r.render(nb, csv_p, "en", tmp_path / "out.ipynb")
 
 
+# --------------------------------------------------------------------------
+# #13546 : --fail-on-stale refuse un rendu dont le CSV porte des orphelins
+# --------------------------------------------------------------------------
+
+def test_render_fail_on_stale_raises_and_writes_nothing(tmp_path):
+    """fail_on_stale + CSV orphelin -> ValueError AVANT toute ecriture."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "x", "text_en": "X"},
+        # ligne orpheline : cell_id absent du notebook (cellule supprimee)
+        {"notebook": str(nb), "cell_id": "gone1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "2", "text_fr": "y", "text_en": "Y"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    with pytest.raises(ValueError, match=r"--fail-on-stale : 1 ligne\(s\) CSV orpheline\(s\)"):
+        r.render(nb, csv_p, "en", out, fail_on_stale=True)
+    assert not out.exists()
+    assert not out.with_suffix(out.suffix + ".stale").exists()
+
+
+def test_render_fail_on_stale_passes_when_no_orphan(tmp_path):
+    """fail_on_stale sans orphelin -> rendu normal, .stale absent."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "x", "text_en": "X"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    res = r.render(nb, csv_p, "en", out, fail_on_stale=True)
+    assert out.exists()
+    assert res.stats.n_orphan_keys == 0
+    assert not out.with_suffix(out.suffix + ".stale").exists()
+
+
+def test_render_default_keeps_warn_contract_on_orphans(tmp_path):
+    """Sans fail_on_stale : contract inchange -> WARN + sidecar .stale ecrit."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "gone1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "2", "text_fr": "y", "text_en": "Y"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    res = r.render(nb, csv_p, "en", out)
+    assert res.stats.n_orphan_keys == 1
+    assert out.with_suffix(out.suffix + ".stale").read_text(
+        encoding="utf-8").strip() == "gone1"
+
+
 def test_render_dry_run_requires_out_path(tmp_path):
     nb = _write_nb(tmp_path, "nb.ipynb", [
         {"id": "m1", "type": "markdown", "source": ["x"]},

--- a/translations/genai/audio.csv
+++ b/translations/genai/audio.csv
@@ -43,9 +43,6 @@ generate_audio = True              # Generer les fichiers audio
 save_audio_files = True            # Sauvegarder les fichiers generes
 compare_voices = True              # Comparer toutes les voix
 ",,,,,,,,2a0f5d29114855b6,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb,9029f092,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb,p54icnvk4d,markdown,fr,7b810979bd81c7db,"Les paramètres Papermill etant définis, nous configurons l'environnement Python et importons les bibliotheques necessaires pour interagir avec l'API TTS d'OpenAI.",,,,,,,,7b810979bd81c7db,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb,cell-setup,code,fr,003e02cf1e0399d1,"# Setup environnement et imports
 import os
@@ -276,18 +273,6 @@ MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb,63044a1a
 1. La reponse est un flux binaire, pas du JSON
 2. `IPython.display.Audio` permet l'ecoute directe dans le notebook
 3. Le texte francais est bien gere sans paramètre de langue explicite",,,,,,,,e9d6b143172c94a7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb,cell-section1-interpretation,markdown,fr,7a95b439769b350b,"### Interpretation : Première generation
-
-| Aspect | Observation | Signification |
-|--------|-------------|---------------|
-| Temps de generation | Typiquement < 3s | L'API est optimisee pour une reponse rapide |
-| Taille fichier | Variable selon format | MP3 compresse, WAV plus volumineux |
-| Qualite audio | Voix naturelle | Les modèles TTS d'OpenAI sont parmi les meilleurs du marche |
-
-**Points cles** :
-1. La reponse est un flux binaire, pas du JSON
-2. `IPython.display.Audio` permet l'ecoute directe dans le notebook
-3. Le texte francais est bien gere sans paramètre de langue explicite",,,,,,,,7a95b439769b350b,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb,cell-section2-intro,markdown,fr,0bd75db411f4c7ca,"## Section 2 : Comparaison des 6 voix
 
 OpenAI propose 6 voix pre-entrainees, chacune avec un caractère distinct :
@@ -886,9 +871,6 @@ test_translation = True            # Tester l'endpoint de traduction
 compare_models = True              # Comparer whisper-1 et gpt-4o-transcribe
 save_results = True                # Sauvegarder les resultats de transcription
 ",,,,,,,,041f7eb72fd0194c,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb,62092acb,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb,azuifendbh,markdown,fr,9341b08a313a9c9a,"Les paramètres Papermill etant définis, nous configurons l'environnement Python et importons les bibliotheques necessaires pour la reconnaissance vocale et la gestion des fichiers audio.",,,,,,,,9341b08a313a9c9a,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb,cell-setup,code,fr,d8e7751ca881247f,"# Setup environnement et imports
 import os
@@ -1753,9 +1735,6 @@ show_visualizations = True         # Afficher les visualisations
 test_pydub_ops = True              # Tester les operations pydub
 save_results = True                # Sauvegarder les resultats
 ",,,,,,,,86cdc5916b2fce3d,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb,7013f8ae,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb,1551ccab,markdown,fr,b496a78098920ce1,"## Structure du notebook
 
 Ce notebook explore les opérations fondamentales de traitement audio en 5 sections :
@@ -2724,11 +2703,6 @@ batch_transcribe = True            # Tester la transcription batch
 monitor_vram = True                # Surveiller l'utilisation VRAM
 save_results = True                # Sauvegarder les resultats
 ",,,,,,,,dac842acbbeb28c2,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb,dffdf8ce,code,fr,047fea4267513be7,"# Parameters
-BATCH_MODE = ""true""
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,047fea4267513be7,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb,h24ifvekap5,markdown,fr,89a59f48694c6697,"Les paramètres Papermill etant définis, nous importons les bibliotheques necessaires, notamment faster-whisper pour la transcription GPU locale et les utilitaires de gestion des fichiers audio.",,,,,,,,89a59f48694c6697,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb,cell-setup,code,fr,a875a603da6ce596,"# Setup environnement et imports
 import os
@@ -3705,11 +3679,6 @@ test_multiple_voices = True        # Tester plusieurs voix
 benchmark_latency = True           # Benchmarks de latence
 save_results = True                # Sauvegarder les resultats
 ",,,,,,,,a7570229221656c9,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb,a314d5e6,code,fr,047fea4267513be7,"# Parameters
-BATCH_MODE = ""true""
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,047fea4267513be7,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb,d03aa336,markdown,fr,23982dd165f2dd7a,"## Introduction technique
 
 Ce notebook explore **Kokoro TTS**, un modèle de synthese vocale open-source alternatif aux solutions cloud comme OpenAI TTS.
@@ -4958,9 +4927,6 @@ save_results = True                # Sauvegarder les fichiers generes
 compare_emotions = True            # Comparer les differentes emotions
 test_voice_conditioning = True     # Tester le voice conditioning
 ",,,,,,,,d72d92acef5d6f5e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb,5738a84c,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb,evxxhn28efi,markdown,fr,9111e821adbe2377,"Les paramètres Papermill definissent le comportement global du notebook (mode interactif/batch, device GPU/CPU, valeurs d'`exaggeration` et de `cfg_weight`). La cellule suivante initialise l'environnement Python et verifie la disponibilite du GPU.",,,,,,,,9111e821adbe2377,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb,cell-setup,code,fr,0cfcda14182a205a,"# Setup environnement et imports
 import os
@@ -5864,9 +5830,6 @@ save_results = True                # Sauvegarder les fichiers generes
 test_multilingual = True           # Tester plusieurs langues
 analyze_similarity = True          # Analyser la similarite vocale
 ",,,,,,,,03023c6e52237131,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb,f56899e6,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb,kpyu0fkvpoh,markdown,fr,c2b3728aba98f83f,Les paramètres Papermill configurent le mode d'exécution et la langue par defaut. La cellule suivante importe les dependances et verifie la disponibilite du GPU ainsi que la VRAM necessaire pour XTTS v2 (~6 GB).,,,,,,,,c2b3728aba98f83f,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb,cell-setup,code,fr,b77bc254e160c372,"# Setup environnement et imports
 import os
@@ -6744,11 +6707,6 @@ Cette cellule définit les paramètres modifiables pour différentes utilisation
 | `compare_models` | Comparer small/medium | `False` (couteux en VRAM) |
 
 > **Note** : Pour une première exécution, laissez les valeurs par defaut. Adjustez la temperature (0.8-1.2) pour explorer la creativite du modèle.",,,,,,,,9b95c44200ba334a,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb,66de968a,code,fr,047fea4267513be7,"# Parameters
-BATCH_MODE = ""true""
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,047fea4267513be7,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb,llc56jpi1g,markdown,fr,8aecfd5e5a448a1f,"Les paramètres Papermill definissent la variante du modèle (`small`, `medium`, `large`), la duree de generation et la temperature de sampling. La cellule suivante configure l'environnement et verifie la VRAM disponible.",,,,,,,,8aecfd5e5a448a1f,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb,5430a334,markdown,fr,5bab877b5caa6c36,"## Introduction a MusicGen
 
@@ -7033,28 +6991,6 @@ Le code ci-dessous genere trois morceaux avec des styles différents pour demont
 
 **Processus** :
 Pour chaque description, le code mesure le temps de generation, calcule la duree reelle, et affiche le ratio temps reel (generation / lecture).",,,,,,,,f47617af428501f7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb,0b23e74b,markdown,fr,a9d06eddd7fe7267,"### Interpretation : Generation text-to-music
-
-Les résultats montrent la capacite de MusicGen a generer de la musique instrumentale originale a partir de descriptions textuelles.
-
-| Aspect | Valeur observee | Interpretation |
-|--------|----------------|----------------|
-| **Ratio temps reel** | 0.5-2x (GPU) | La generation est plus lente que la lecture mais reste acceptable |
-| **Qualite audio** | 32kHz mono | Qualite correcte pour demos et prototypage |
-| **Coherence texte** | Bonne a très bonne | Le modèle suit les descriptions avec precision |
-| **Variabilite** | Haute | Chaque generation est unique (non-déterministe) |
-
-**Analyse des exemples** :
-1. **Jazz** : Piano et saxophone dominants, rythme swing
-2. **Ambient** : Pads synthetiques, evolution lente, atmospherique
-3. **Rock** : Guitares electriques, batterie puissante, energie elevee
-
-**Points cles** :
-- Les descriptions en anglais donnent les meilleurs résultats (langue d'entrainement)
-- La precision des termes musicaux influence la fidelite (instruments, tempo, ambiance)
-- Plus la description est detaillee, plus le résultat est spécifique
-
-> **Note technique** : La generation est stochastique - le même prompt peut donner des résultats différents a chaque appel. Cette variabilite est une feature, pas un bug.",,,,,,,,a9d06eddd7fe7267,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb,cell-section2-interpretation,markdown,fr,e04ba3c06e5433a3,"### Interpretation : Generation text-to-music
 
 | Aspect | Valeur typique | Signification |
@@ -7682,11 +7618,6 @@ save_results = True                # Sauvegarder les stems
 visualize_stems = True             # Visualiser les formes d'onde
 compare_models = False             # Comparer htdemucs vs htdemucs_ft
 ",,,,,,,,27c1f2ec3473cbb7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-4-Demucs-Source-Separation.ipynb,f4237623,code,fr,047fea4267513be7,"# Parameters
-BATCH_MODE = ""true""
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,047fea4267513be7,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-4-Demucs-Source-Separation.ipynb,zbhbuzc422g,markdown,fr,c6c48350ea5570fc,"Les paramètres Papermill selectionnent le modèle Demucs (`htdemucs` ou `htdemucs_ft`), le device et la taille des segments audio. La cellule suivante importe les dependances et detecte le GPU disponible.",,,,,,,,c6c48350ea5570fc,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-4-Demucs-Source-Separation.ipynb,cell-setup,code,fr,102e4b4132d4f9c8,"# Setup environnement et imports
 import os
@@ -8561,10 +8492,6 @@ Ce notebook a permis d'explorer les aspects essentiels de 02 4 demucs source sep
 - Les résultats obtenus permettent de valider la comprehension
 
 **Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines.",,,,,,,,a97ba7c8339446ca,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb,8b18fbf2,code,fr,63d79e46ba34a904,"# Parameters
-skip_widgets = True
-notebook_mode = ""batch""
-",,,,,,,,63d79e46ba34a904,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb,cell-header,markdown,fr,44cd7bc3a106740b,"# Multi-Model TTS Gateway - Synthese Vocale Multi-Modèles
 
 **Module :** 02-Audio-Advanced  
@@ -9354,11 +9281,6 @@ generate_midi = True               # Generer les fichiers MIDI
 save_results = True                # Sauvegarder les fichiers
 synthesize_audio = True            # Synthetiser MIDI en audio
 test_prompts = True                # Tester les prompts musicaux",,,,,,,,3061d97a2dfbd2fb,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb,a899efcb,code,fr,55eaf3dee475f6ef,"# Parameters
-BATCH_MODE = ""true""
-skip_widgets = True
-notebook_mode = ""batch""
-",,,,,,,,55eaf3dee475f6ef,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb,2d932353,markdown,fr,11b96398f1c523ee,"Les paramètres Papermill definissent le modèle midi-model (`skytnt/midi-model-tv2o-medium`), les paramètres de sampling (temperature, top_k, top_p) et les options de generation. La cellule suivante initialise l'environnement Python et verifie la disponibilite du GPU.",,,,,,,,11b96398f1c523ee,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb,0a84bc93,code,fr,673e7f8b22cbf7b2,"# Setup environnement et imports
 import os
@@ -10538,9 +10460,6 @@ songgen_separate = True            # Pistes separees vocal/bgm
 device = ""cuda""                    # ""cuda"" ou ""cpu""
 save_results = True                # Sauvegarder les fichiers
 compare_models = True              # Generer le tableau comparatif",,,,,,,,74daf23b20421a88,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb,cd4cb880,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb,8ed5db51,markdown,fr,5b538af4e0b42228,"Les paramètres Papermill configurent les modèles a tester (YuE et SongGeneration 2), le device GPU/CPU et les options de generation. La cellule suivante initialise l'environnement Python et verifie la disponibilite du GPU.",,,,,,,,5b538af4e0b42228,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb,65355945,code,fr,0ba22f81bc9ead13,"# Setup environnement et imports
 import os
@@ -10908,18 +10827,6 @@ Le script verifie la presence des repositories YuE et SongGeneration 2 dans le r
 1. Les deux modèles necessitent le clonage de repositories entiers (pas de simple `pip install`)
 2. FlashAttention 2 est critique pour YuE sur 24 GB (OOM sans)
 3. SongGeneration 2 est plus simple a installer et plus leger",,,,,,,,48f9784a58b7f094,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb,d09a8a83,markdown,fr,78d06aa1b0520c4f,"### Interpretation : Installation
-
-| Modèle | Taille telechargement | Temps installation | Difficulte |
-|--------|----------------------|-------------------|------------|
-| YuE (7B+1B) | ~16 GB | 15-30 min | Moyenne (FlashAttn requis) |
-| SongGen 2 base | ~4 GB + runtime | 10-20 min | Facile |
-| SongGen 2 v2-large | ~10 GB + runtime | 15-30 min | Facile |
-
-**Points cles** :
-1. Les deux modèles necessitent le clonage de repositories entiers (pas de simple `pip install`)
-2. FlashAttention 2 est critique pour YuE sur 24 GB (OOM sans)
-3. SongGeneration 2 est plus simple a installer et plus leger",,,,,,,,78d06aa1b0520c4f,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb,613922e3,markdown,fr,bc72af33dfe0ce2d,"## Section 4 : Preparation des paroles
 
 Les deux modèles necessitent des paroles structurees avec des marqueurs de section. Le formatage est crucial pour la qualite du résultat.
@@ -11868,10 +11775,6 @@ device = ""cuda""                    # ""cuda"" ou ""cpu""
 save_results = True                # Sauvegarder les fichiers audio
 test_voice_cloning = True          # Tester le voice cloning
 test_multilingual = True           # Tester la generation multilingue",,,,,,,,30ec7fcf67504ccb,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb,71ab7980,code,fr,63d79e46ba34a904,"# Parameters
-skip_widgets = True
-notebook_mode = ""batch""
-",,,,,,,,63d79e46ba34a904,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb,c3f48938,markdown,fr,103a902cd88ded4f,"Les paramètres Papermill selectionnent les moteurs TTS (Fish S2 Pro, Dia TTS), configurent le device et les options de voice cloning. La cellule suivante initialise l'environnement Python et detecte le GPU disponible.",,,,,,,,103a902cd88ded4f,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb,4d15b183,code,fr,d7698316de9cad6b,"# Setup environnement et imports
 import os
@@ -14505,9 +14408,6 @@ En 2026, l'ecosysteme des modèles audio a atteint une maturite remarquable. Plu
 - Basculer vers l'API en cas de pic de charge (failover)
 
 Ce notebook propose un cadre systématique pour comparer ces approches sur des metriques objectives : latence, qualite, cout, consommation GPU. Les résultats vous permettront de prendre une décision éclairée selon votre cas d'usage et vos contraintes (budget, infrastructure, confidentialité).",,,,,,,,df450bf9e44557c7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb,bd23ac74,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb,u7jzjj7ovb,markdown,fr,dce20b12b78554e8,"L'environnement de travail est configure avec les paramètres Papermill. La cellule suivante charge les bibliotheques Python necessaires : mesure de performances, appels API audio et utilitaires de benchmark.",,,,,,,,dce20b12b78554e8,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb,cell-setup,code,fr,ebe1b7dfb262c3c4,"# Setup environnement et imports
 import os
@@ -15776,9 +15676,6 @@ Cette section définit les paramètres de configuration du notebook, notamment l
 - `pipeline_mode` : définit quel pipeline executer (stt_llm_tts, translation, podcast)
 - `llm_model` : choix du modèle LLM (gpt-4o-mini recommande pour equilibre performance/cout)
 - `max_retries` : nombre de tentatives en cas d'erreur API (3 par defaut)",,,,,,,,fa698a83f63e9171,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb,faf5ee7e,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb,cv270pagpz7,markdown,fr,214df8c6dda752d3,"L'environnement de travail est configure avec les paramètres Papermill. La cellule suivante charge les bibliotheques Python necessaires : orchestration de pipelines, appels API séquentiels et gestion des flux audio.",,,,,,,,214df8c6dda752d3,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb,cell-setup,code,fr,b857f9d7169097ae,"# Setup environnement et imports
 import os
@@ -16977,9 +16874,6 @@ enable_function_calling = True     # Activer le function calling
 save_results = True                # Sauvegarder les fichiers generes
 simulate_realtime = True           # Simuler via texte (pas de micro dans notebook)
 ",,,,,,,,8641878ab8f7a81b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb,0a759e49,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb,f3twl204tg9,markdown,fr,d9fad54d1c49f7df,"L'environnement de travail est configure avec les paramètres Papermill. La cellule suivante charge les bibliotheques Python necessaires : WebSocket asyncio, gestion des flux audio temps reel et protocole de l'API Realtime.",,,,,,,,d9fad54d1c49f7df,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb,cell-setup,code,fr,2cac99f34c8184f1,"# Setup environnement et imports
 import os
@@ -17482,19 +17376,6 @@ Les 3 messages de test ont permis de valider le fonctionnement de l'API Realtime
 1. L'API Realtime est significativement plus rapide que le pipeline STT->LLM->TTS
 2. Le streaming audio permet de commencer l'ecoute avant la fin de la generation
 3. Le function calling fonctionne de maniere transparente dans le flux vocal",,,,,,,,680d645183f6793d,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb,cell-section2-interpretation,markdown,fr,2528f168ec35c017,"### Interpretation : Conversation Realtime
-
-| Metrique | Valeur typique | Signification |
-|----------|---------------|---------------|
-| Latence premier chunk | 300-800ms | Temps avant le premier byte audio |
-| Latence totale | 1-3s | Temps de reponse complete |
-| Chunks audio | 10-50 | Nombre de segments audio recus |
-| Format audio | PCM16 24kHz | Qualite CD (non compresse) |
-
-**Points cles** :
-1. L'API Realtime est significativement plus rapide que le pipeline STT->LLM->TTS
-2. Le streaming audio permet de commencer l'ecoute avant la fin de la generation
-3. Le function calling fonctionne de maniere transparente dans le flux vocal",,,,,,,,2528f168ec35c017,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb,cell-section3-intro,markdown,fr,3694dfaee2dba5cc,"## Section 3 : Envoi d'audio et streaming
 
 Pour une interaction vocale complete, on envoie de l'audio (PCM16, 24kHz) plutot que du texte. Voici comment convertir et envoyer un fichier audio.
@@ -18410,18 +18291,6 @@ Texte source (cours) -> LLM (GPT-4o-mini) -> Script narre avec marqueurs -> Pars
 | `[PAUSE]` | Silence naturel | Respiration, emphasis, transitions |
 
 Le LLM recoit le texte de cours et un prompt pedagogique specifiant le format de sortie, puis genere un script avec des indications de voix, pauses et intonation.",,,,,,,,7616b91b588a7810,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section1-interpretation,markdown,fr,b0b3a3ae7a430ca9,"### Interpretation : Generation de scripts
-
-| Aspect | Observation | Signification |
-|--------|-------------|---------------|
-| Temps LLM | Typiquement < 5s | GPT-4o-mini est rapide pour cette tâche |
-| Marqueurs | [PAUSE], [NARRATEUR], [EXPERT] | Permettent le contrôle fin de la narration |
-| Longueur | Script ~2x plus long que le texte source | L'oral necessite plus de mots que l'ecrit |
-
-**Points cles** :
-1. Le LLM adapte naturellement le registre ecrit vers l'oral
-2. Les marqueurs structurent le script pour le pipeline TTS
-3. La temperature 0.7 donne un bon equilibre naturel/fidele",,,,,,,,b0b3a3ae7a430ca9,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,a4c79308,markdown,fr,dd0af65b57c7aa84,"---
 
 ## Exercice : Prompt engineering pour scripts de narration
@@ -18638,18 +18507,6 @@ Un contenu educatif beneficie de plusieurs voix pour distinguer les rôles et ma
 | Exemples / Illustrations | `echo` (F) ou `shimmer` (F) | Cas pratiques, analogies, ton plus leger |
 
 Nous allons parser le script genere par le LLM pour identifier les segments par rôle (marqueurs `[NARRATEUR]`, `[EXPERT]`), puis generer chaque segment avec la voix OpenAI appropriee.",,,,,,,,e959f8d4f3ac189a,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section2-interpretation,markdown,fr,16f2caac217366d3,"### Interpretation : Narration multi-voix
-
-| Aspect | Valeur | Signification |
-|--------|--------|---------------|
-| Segments | Variable (4-10 typique) | Chaque changement de rôle créé un segment |
-| Temps par segment | ~1-3s | L'API est rapide même pour du texte long |
-| Differenciation | Voix distinctes par rôle | Ameliore la comprehension et l'engagement |
-
-**Points cles** :
-1. Le parsing des marqueurs [RÔLE] permet une attribution automatique des voix
-2. Les pauses [PAUSE] sont converties en ellipses pour un rythme naturel
-3. La multi-voix rend le contenu plus dynamique qu'un narrateur unique",,,,,,,,16f2caac217366d3,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section3-intro,markdown,fr,2528f45372e7229d,"## Section 3 : Contenu multilingue
 
 L'API OpenAI TTS gere nativement de nombreuses langues. Pour créer du contenu multilingue, deux approches :
@@ -18758,15 +18615,6 @@ L'API OpenAI TTS supporte plus de 50 langues, ce qui permet de créer du contenu
 | **TTS direct multilingue** | Fournir texte traduit, synthetiser direct | Plus simple, une seule étape | Qualite depend de la traduction source |
 
 Nous utilisons la première approche (traduction LLM) pour garantir que le contenu reste pedagogique et naturel dans chaque langue cible. Le prompt de traduction inclut le contexte ""educatif"" pour preserver le ton.",,,,,,,,863ca25d280427ad,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section3-interpretation,markdown,fr,d5771d43accaacf0,"### Interpretation : Contenu multilingue
-
-| Aspect | Valeur | Signification |
-|--------|--------|---------------|
-| Qualite FR | Excellente | Voix OpenAI optimisees pour le francais |
-| Qualite EN | Excellente | Langue native du modèle |
-| Traduction LLM | Fidele au contenu | GPT-4o-mini conserve le ton pedagogique |
-
-> **Note technique** : Pour des langues moins bien supportees, tester la qualite avec un locuteur natif avant production.",,,,,,,,d5771d43accaacf0,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section4-intro,markdown,fr,e3187ea42677e159,"## Section 4 : Accessibilite audio
 
 Un contenu educatif accessible doit prendre en compte différents profils d'apprenants :
@@ -18985,16 +18833,6 @@ L'assemblage final combine tous les segments audio en un fichier unique avec pyd
 5. **Exporter** en format final (MP3 192kbps)
 
 Cette approche créé une expérience d'ecoute fluide et professionnelle.",,,,,,,,355a7226ab198e01,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section5-interpretation,markdown,fr,bf9056f7fbf5c240,"### Interpretation : Assemblage
-
-| Aspect | Valeur | Signification |
-|--------|--------|---------------|
-| Silences inter-segments | 800ms | Pause naturelle entre phrases |
-| Silences inter-sections | 1500ms | Marque un changement de locuteur/sujet |
-| Normalisation | -20 dBFS | Volume confortable pour l'ecoute |
-| Format final | MP3 192kbps | Bon compromis qualite/taille |
-
-> **Note technique** : pydub utilise ffmpeg en arriere-plan. Assurez-vous que ffmpeg est installe dans votre environnement.",,,,,,,,bf9056f7fbf5c240,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb,cell-section6-intro,markdown,fr,1e06fcf61f2d83fa,"## Section 6 : Verification qualite par round-trip STT
 
 Pour valider que la narration est fidele au texte source, nous effectuons un round-trip :
@@ -22532,9 +22370,6 @@ use_local_whisper = False          # Desactive Whisper local pour validation (pr
 generate_audio = True              # Generer des fichiers audio de test
 save_output_files = True           # Sauvegarder les transcriptions
 ",,,,,,,,2baec2b5b6712b07,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb,e32920a4,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb,qh2kt7yja5n,markdown,fr,a1266bb541993353,"L'environnement de travail est configure avec les paramètres Papermill. La cellule suivante charge les bibliotheques Python necessaires : traitement audio, appels API Whisper et utilitaires de formatage.",,,,,,,,a1266bb541993353,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb,cell-setup,code,fr,17140a43852b6ca9,"# Setup environnement et imports
 import os
@@ -23766,9 +23601,6 @@ generate_audio = True
 save_audio_files = True
 apply_effects = True               # Appliquer les effets audio
 ",,,,,,,,a3144df64425ced7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb,f67fb4a7,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb,ib651xjp2n,markdown,fr,e094cea582ae1938,"L'environnement de travail est configure avec les paramètres Papermill. La cellule suivante charge les bibliotheques Python necessaires : generation audio, traitement de signal et utilitaires de composition.",,,,,,,,e094cea582ae1938,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb,cell-setup,code,fr,bbbe19baf564b19e,"# Setup environnement et imports
 import os
@@ -30560,9 +30392,6 @@ skip_widgets = True
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb,c36c04e3,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb,f0f9bf67,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb,2196760a,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
@@ -30694,34 +30523,9 @@ MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb,a71bc27
 - Plus la description est detaillee, plus le résultat est spécifique
 
 > **Note technique** : La generation est stochastique - le même prompt peut donner des résultats différents a chaque appel. Cette variabilite est une feature, pas un bug.",,,,,,,,2eff8a29412d43ec,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-4-Demucs-Source-Separation.ipynb,022e3f2a,code,fr,047fea4267513be7,"# Parameters
-BATCH_MODE = ""true""
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,047fea4267513be7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb,f34ef87e,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb,dcc88ea1,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb,3bbda7f3,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb,77d97cd7,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb,de9d89c9,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb,e8af8311,code,fr,3e4ebee39c2b49ed,"# Parameters
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,3e4ebee39c2b49ed,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb,8e952347,code,fr,3e4ebee39c2b49ed,"# Parameters
-notebook_mode = ""batch""
-skip_widgets = True
-",,,,,,,,3e4ebee39c2b49ed,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb,5ca740c3,code,fr,3e4ebee39c2b49ed,"# Parameters
 notebook_mode = ""batch""
 skip_widgets = True

--- a/translations/genai/finetuning.csv
+++ b/translations/genai/finetuning.csv
@@ -1784,41 +1784,6 @@ training in 1908 s (31.8 min) on a shared 8 GB GPU, VRAM contained around
 the format contract is learned with a diversified dataset (227 pairs) and generalizes
 to reformulations, while the same SFT with 5 examples breaks generation.
 The loss measures memorization, generation reveals generalization.",,,,,,,bd46642ad7f74b37,70ecee890c3a4655,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,d2186f84,markdown,fr,a7f239699500d7d7,"# FT-04 : RLHF et Alignement — Préférences Humaines et DPO
-
-**Objectif** : Comprendre comment les préférences humaines permettent d'aligner un LLM, du Reward Model au DPO (Direct Préférence Optimization).
-
-**Prerequis** : FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT)
-
-**Duree estimee** : ~30 min
-
-**Plan du notebook** :
-1. Pourquoi le SFT ne suffit pas
-2. Le pipeline RLHF (SFT -> Reward Model -> PPO)
-3. Données de préférence (chosen vs rejected)
-4. Le Reward Model
-5. DPO : Optimisation Directe des Préférences
-6. Evaluation : SFT vs DPO
-7. Comparaison RLHF vs DPO
-
-**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**","# FT-04: RLHF and Alignment — Human Preferences and DPO
-
-**Objective**: Understand how human preferences make it possible to align an LLM, from the Reward Model to DPO (Direct Preference Optimization).
-
-**Prerequisites**: FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT)
-
-**Estimated duration**: ~30 min
-
-**Notebook outline**:
-1. Why SFT is not enough
-2. The RLHF pipeline (SFT -> Reward Model -> PPO)
-3. Preference data (chosen vs rejected)
-4. The Reward Model
-5. DPO: Direct Preference Optimization
-6. Evaluation: SFT vs DPO
-7. RLHF vs DPO comparison
-
-**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**",,,,,,,a7f239699500d7d7,cbe5d9a9b7b7b4d0,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,cf552bd0,code,fr,c2261ec1b233c654,"import torch
 import os
 import gc
@@ -1834,23 +1799,6 @@ if torch.cuda.is_available():
     props = torch.cuda.get_device_properties(0)
     print(f""GPU : {props.name}, {props.total_memory / 1e9:.1f} GB VRAM"")
     print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} GB"")",,,,,,,,c2261ec1b233c654,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,caab975c,markdown,fr,8752b8a4349d9b9b,"## 1. Pourquoi le SFT ne suffit pas
-
-Le FT-03 nous a montre comment transformer un modèle de base en modèle instruct via le SFT. Mais le SFT a des limites fondamentales :
-
-- **Pas de notion de qualite** : Le SFT apprend a reproduire les reponses du dataset, sans distinguer une bonne reponse d'une excellente.
-- **Pas d'alignement** : Un modèle SFT peut generer des reponses techniquement correctes mais maladroites, trop longues, ou manquant de nuances.
-- **Pas de signal de préférence** : Le SFT optimise la cross-entropy sur une seule reponse cible, pas une metrique de ""qualite percue par l'utilisateur"".
-
-**Le problème central** : Comment faire pour que le modèle produise des reponses que les humains *preferent* ?","## 1. Why SFT is not enough
-
-FT-03 showed us how to transform a base model into an instruct model via SFT. But SFT has fundamental limitations:
-
-- **No notion of quality**: SFT learns to reproduce the dataset’s responses, without distinguishing a good response from an excellent one.
-- **No alignment**: An SFT model can generate technically correct responses that are awkward, too long, or lacking nuance.
-- **No preference signal**: SFT optimizes cross-entropy on a single target response, not a metric of ""user-perceived quality"".
-
-**The central problem**: How can we make the model produce responses that humans *prefer*?",,,,,,,8752b8a4349d9b9b,130b0171cca5b000,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,2bbe17fa,code,fr,a33739e880577f34,"# Charger le modele de base pour demontrer les limites du SFT
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
@@ -1895,65 +1843,6 @@ for p in test_prompts:
     print(f""Q: {q}"")
     print(f""  Reponse: {resp}"")
     print()",,,,,,,,a33739e880577f34,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,95d9c377,markdown,fr,f20e4ce9175387c4,"**Observation** : Le modèle de base genere du texte coherent mais ne peut pas distinguer une reponse ""bonne"" d'une reponse ""preferee par l'utilisateur"". Le SFT resout partiellement ce problème en apprenant des reponses cibles, mais il n'apprend pas a **ranger** les reponses par qualite.
-
-C'est la que le RLHF intervient : utiliser les **préférences humaines** comme signal d'apprentissage.","**Observation**: The base model generates coherent text but cannot distinguish a ""good"" response from a ""user-preferred"" response. SFT partially solves this problem by learning from target responses, but it does not learn to **rank** responses by quality.
-
-This is where RLHF comes in: using **human preferences** as a learning signal.",,,,,,,f20e4ce9175387c4,2ea2f51933aff177,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,24941a98,markdown,fr,8cffd299cf861a69,"## 2. Le Pipeline RLHF
-
-Le RLHF (Reinforcement Learning from Human Feedback) resout ce problème en 3 étapes :
-
-```
-  Étape 1           Étape 2              Étape 3
-  SFT               Reward Model         PPO ou DPO
-  (FT-03)           (ce notebook)        (optimisation)
-     |                   |                     |
-  Modèle instruct    Score de qualite      Maximiser le score
-  de base           des reponses          des reponses
-```
-
-**Étape 1 -- SFT** (déjà vu en FT-03) : Créer un modèle de base qui suit les instructions.
-
-**Étape 2 -- Reward Model** : Entrainer un modèle a scorer les reponses selon les préférences humaines. Pour chaque paire (question, reponse), le RM attribue un score.
-
-**Étape 3 -- PPO ou DPO** : Optimiser le modèle pour maximiser le score du reward model (PPO) ou directement les préférences (DPO).
-
-Dans ce notebook, nous implementons les étapes 2 et 3.","## 2. The RLHF Pipeline
-
-RLHF (Reinforcement Learning from Human Feedback) solves this problem in 3 steps:
-
-```
-  Etape 1           Etape 2              Etape 3
-  SFT               Reward Model         PPO ou DPO
-  (FT-03)           (ce notebook)        (optimisation)
-     |                   |                     |
-  Modele instruct    Score de qualite      Maximiser le score
-  de base           des reponses          des reponses
-```
-
-**Step 1 -- SFT** (already seen in FT-03): Create a base model that follows instructions.
-
-**Step 2 -- Reward Model**: Train a model to score responses according to human preferences. For each pair (question, response), the RM assigns a score.
-
-**Step 3 -- PPO or DPO**: Optimize the model to maximize the reward model's score (PPO) or directly optimize preferences (DPO).
-
-In this notebook, we implement steps 2 and 3.",,,,,,,8cffd299cf861a69,26aa50e0f2b15afd,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,fdc5b501,markdown,fr,4f3c6b4c6a4aeb01,"## 3. Données de Préférence
-
-Le RLHF repose sur un type de données spécifique : les **paires de préférence**. Pour chaque prompt, on collecte deux reponses aupres d'annotateurs humains :
-
-- **chosen** (y_w) : la reponse preferee par l'annotateur
-- **rejected** (y_l) : la reponse jugee moins bonne
-
-Le modèle de recompense apprend a donner un score plus eleve a `chosen` qu'a `rejected`.","## 3. Preference Data
-
-RLHF relies on a specific type of data: **preference pairs**. For each prompt, two responses are collected from human annotators:
-
-- **chosen** (y_w): the response preferred by the annotator
-- **rejected** (y_l): the response judged less good
-
-The reward model learns to give a higher score to `chosen` than to `rejected`.",,,,,,,4f3c6b4c6a4aeb01,c2452dcc45bea2b6,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,45c88110,code,fr,93686a74c62ab619,"# Dataset de preferences synthetique
 preference_data = [
     {
@@ -1995,44 +1884,6 @@ ex = preference_data[0]
 print(f""  Prompt: {ex['prompt']}"")
 print(f""  Chosen:  {ex['chosen'][:80]}..."")
 print(f""  Rejected: {ex['rejected'][:80]}..."")",,,,,,,,93686a74c62ab619,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,4f01ec51,markdown,fr,b1e337b70fa0ada1,"**Analyse des données** : Les reponses ""chosen"" sont :
-- Plus precises et structurees
-- Plus nuancees (pas de generalisations abusives)
-- Plus utiles pour l'utilisateur
-
-Les reponses ""rejected"" sont :
-- Vagues ou imprecises
-- Trop subjectives ou biaisees
-- Manquent de details concrets
-
-Cette distinction est le coeur du RLHF : le modèle doit apprendre a privilegier le style ""chosen"".","**Data analysis**: The ""chosen"" responses are:
-- More precise and structured
-- More nuanced (no overgeneralizations)
-- More useful to the user
-
-The ""rejected"" responses are:
-- Vague or imprecise
-- Too subjective or biased
-- Lack concrete details
-
-This distinction is the core of RLHF: the model must learn to favor the ""chosen"" style.",,,,,,,b1e337b70fa0ada1,b775916a017931e5,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,35f472ea,markdown,fr,d8618f38db06cc48,"## 4. Le Reward Model (Modèle de Recompense)
-
-Le Reward Model est un modèle qui attribue un **score de qualite** a chaque reponse. Il est entraine sur les paires de préférence avec le modèle de Bradley-Terry :
-
-$$P(y_w \succ y_l) = \sigma(r(x, y_w) - r(x, y_l))$$
-
-ou $r(x, y)$ est le score de recompense et $\sigma$ est la fonction sigmoid.
-
-En pratique, une mesure simple de ""qualite"" est la **log-probabilite** que le modèle attribue a la reponse. Verifions si le modèle de base distingue déjà les bonnes des mauvaises reponses :","## 4. The Reward Model
-
-The Reward Model is a model that assigns a **quality score** to each response. It is trained on preference pairs with the Bradley-Terry model:
-
-$$P(y_w \succ y_l) = \sigma(r(x, y_w) - r(x, y_l))$$
-
-where $r(x, y)$ is the reward score and $\sigma$ is the sigmoid function.
-
-In practice, a simple measure of ""quality"" is the **log-probability** that the model assigns to the response. Let’s check whether the base model already distinguishes good responses from bad ones:",,,,,,,d8618f38db06cc48,675efcb76e8f36fa,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,cc693e01,code,fr,942092f989ba82c4,"# Utiliser les log-probabilites comme signal de recompense
 def compute_logprob_reward(model, prompt, response):
     # Calcule la log-probabilite moyenne de la reponse donnee le prompt
@@ -2067,73 +1918,6 @@ print(f""\nTaux de preference correct : {correct}/{len(preference_data)} ""
 print()
 print(""Le modele de base a une idee partielle de la qualite, mais il n'est pas fiable."")
 print(""Un Reward Model entraine ameliorerait ce signal, et le DPO le contourne completement."")",,,,,,,,942092f989ba82c4,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,7e0a8039,markdown,fr,68c18bad04c84768,"**Observation** : Le modèle de base a parfois des scores plus eleves pour les reponses ""chosen"" (plus naturelles), mais ce n'est pas fiable. Le signal de log-probabilite est un proxy imparfait de la ""qualite percue"".
-
-En pratique, les reward models utilises dans ChatGPT ou Claude sont :
-- Entraines sur des millions de paires de préférence
-- Bases sur des modèles beaucoup plus grands (7B-70B paramètres)
-- Evalues sur des benchmarks de calibration
-
-Le DPO (section suivante) contourne le besoin d'un reward model separe.","**Observation**: The base model sometimes has higher scores for the ""chosen"" responses (more natural), but this is not reliable. The log-probability signal is an imperfect proxy for ""perceived quality"".
-
-In practice, the reward models used in ChatGPT or Claude are:
-- Trained on millions of preference pairs
-- Based on much larger models (7B-70B parameters)
-- Evaluated on calibration benchmarks
-
-DPO (next section) bypasses the need for a separate reward model.",,,,,,,68c18bad04c84768,07ff80db59b00535,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,a8ef08bf,markdown,fr,5162e2ef09fc0604,"## 5. DPO : Optimisation Directe des Préférences
-
-Le DPO (Direct Préférence Optimization, [Rafailov et al., 2023](https://arxiv.org/abs/2305.18290)) est une alternative elegante au pipeline PPO classique. Il elimine le besoin d'un reward model separe.
-
-### PPO classique vs DPO
-
-| Aspect | PPO | DPO |
-|--------|-----|-----|
-| Reward Model | Necessaire (entraine separement) | Pas necessaire |
-| Modèles en memoire | 4 (policy, ref, reward, value) | 2 (policy, reference) |
-| Stabilite | Difficile (hyperparametres sensibles) | Plus stable |
-| Étapes | RM training + PPO loop | Un seul passage d'entrainement |
-| Complexite code | Elevee | Simple |","## 5. DPO: Direct Preference Optimization
-
-DPO (Direct Preference Optimization, [Rafailov et al., 2023](https://arxiv.org/abs/2305.18290)) is an elegant alternative to the classic PPO pipeline. It eliminates the need for a separate reward model.
-
-### Classic PPO vs DPO
-
-| Aspect | PPO | DPO |
-|--------|-----|-----|
-| Reward Model | Required (trained separately) | Not required |
-| Models in memory | 4 (policy, ref, reward, value) | 2 (policy, reference) |
-| Stability | Difficult (sensitive hyperparameters) | More stable |
-| Steps | RM training + PPO loop | A single training pass |
-| Code complexity | High | Simple |",,,,,,,5162e2ef09fc0604,9ee4040de371e534,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,de4ef4d9,markdown,fr,a3ef4cd95a649e43,"### 5a. La perte DPO
-
-La fonction de perte du DPO est derivee analytiquement a partir de l'objectif RLHF :
-
-$$\mathcal{L}_{DPO} = -\mathbb{E}\left[\log \sigma\left(\beta \left(\log \frac{\pi_\theta(y_w|x)}{\pi_{ref}(y_w|x)} - \log \frac{\pi_\theta(y_l|x)}{\pi_{ref}(y_l|x)}\right)\right)\right]$$
-
-Ou :
-- $\pi_\theta$ = modèle en cours d'entrainement (policy)
-- $\pi_{ref}$ = modèle de reference fige (SFT)
-- $y_w$ = reponse choisie (chosen / winner)
-- $y_l$ = reponse rejetee (rejected / loser)
-- $\beta$ = temperature (contrôle la force de l'alignement)
-
-**Intuition** : Le DPO pousse le modèle a augmenter les log-probs des reponses ""chosen"" et a diminuer celles des ""rejected"", par rapport au modèle de reference.","### 5a. The DPO Loss
-
-The DPO loss function is derived analytically from the RLHF objective:
-
-$$\mathcal{L}_{DPO} = -\mathbb{E}\left[\log \sigma\left(\beta \left(\log \frac{\pi_\theta(y_w|x)}{\pi_{ref}(y_w|x)} - \log \frac{\pi_\theta(y_l|x)}{\pi_{ref}(y_l|x)}\right)\right)\right]$$
-
-Where:
-- $\pi_\theta$ = model currently being trained (policy)
-- $\pi_{ref}$ = frozen reference model (SFT)
-- $y_w$ = chosen response (chosen / winner)
-- $y_l$ = rejected response (rejected / loser)
-- $\beta$ = temperature (controls the strength of the alignment)
-
-**Intuition**: DPO pushes the model to increase the log-probs of the ""chosen"" responses and decrease those of the ""rejected"" responses, relative to the reference model.",,,,,,,a3ef4cd95a649e43,ed932784e0865987,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,c1a356a8,code,fr,2a2cb7da9c21b3ac,"# Etape 1 : Quick SFT pour avoir un modele instruct de depart
 from datasets import Dataset
 from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
@@ -2182,7 +1966,6 @@ trainer = Trainer(
 print(""Quick SFT (2 epochs sur 5 exemples)..."")
 trainer.train()
 print(""SFT termine."")",,,,,,,,2a2cb7da9c21b3ac,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,d15cc7a1,markdown,fr,1dd7fc9b8d57efc5,Le SFT rapide (2 epochs sur 5 exemples) est termine. Ce modèle servira de **reference** $\pi_{ref}$ pour le DPO. La prochaine étape consiste a sauvegarder ses poids et a calculer les log-probabilites de reference pour chaque paire chosen/rejected du dataset de préférences.,The quick SFT (2 epochs on 5 examples) is complete. This model will serve as the **reference** $\pi_{ref}$ for DPO. The next step is to save its weights and compute the reference log-probabilities for each chosen/rejected pair in the preference dataset.,,,,,,,1dd7fc9b8d57efc5,06fd9f5b65d332eb,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,8c94c2a6,code,fr,1c585ba174afbf8f,"# Etape 2 : Sauvegarder les poids de reference (SFT) et calculer les log-probs de ref
 import copy
 
@@ -2232,11 +2015,6 @@ with torch.no_grad():
 print(f""  Log-probs reference calculees pour {len(ref_logprobs)} paires"")
 for i, rlp in enumerate(ref_logprobs[:3]):
     print(f""  Pair {i}: chosen={rlp['chosen']:.2f}, rejected={rlp['rejected']:.2f}"")",,,,,,,,1c585ba174afbf8f,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,c496029a,markdown,fr,7bad463cfcd63756,"Le modèle SFT de reference est pret. Ses poids LoRA sont sauvegardes (via `copy.deepcopy`), et les log-probabilites de reference ont ete calculees pour les 6 paires chosen/rejected. Ces valeurs serviront de point de comparaison dans la perte DPO : $\beta \cdot (\log \pi_\theta - \log \pi_{ref})$.
-
-Nous pouvons maintenant lancer l'optimisation DPO sur 3 epochs.","The reference SFT model is ready. Its LoRA weights are saved (via `copy.deepcopy`), and the reference log-probabilities have been computed for the 6 chosen/rejected pairs. These values will serve as a point of comparison in the DPO loss: $\beta \cdot (\log \pi_\theta - \log \pi_{ref})$.
-
-We can now launch DPO optimization over 3 epochs.",,,,,,,7bad463cfcd63756,e0bc29fba34bf5a0,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,b3a7520d,code,fr,c586c3b154fa98a2,"# Etape 3 : DPO Training
 beta = 0.1  # Temperature DPO (controle la force de l'alignement)
 
@@ -2274,11 +2052,6 @@ for epoch in range(3):
 
 print()
 print(""DPO termine."")",,,,,,,,c586c3b154fa98a2,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,5660cbd8,markdown,fr,9dd892274e97179a,"## 6. Evaluation : SFT vs DPO
-
-Comparons les reponses du modèle SFT (reference) et du modèle DPO (aligne). Le DPO a du pousser le modèle a privilegier le style ""chosen"" : reponses plus precises, structurees et utiles.","## 6. Evaluation: SFT vs DPO
-
-Let’s compare the responses of the SFT model (reference) and the DPO model (aligned). DPO should have pushed the model to favor the ""chosen"" style: more precise, structured, and useful responses.",,,,,,,9dd892274e97179a,8d947a93ac5ed968,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,dfbc120b,code,fr,0ed09f7ee78d867e,"# Generer avec le modele DPO et comparer avec le SFT
 model_sft.eval()
 
@@ -2315,50 +2088,6 @@ with torch.no_grad():
 
 print(f""\nTaux de preference correct (DPO) : {correct}/{len(preference_data)} ""
       f""({100*correct/len(preference_data):.0f}%)"")",,,,,,,,0ed09f7ee78d867e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,567f932b,markdown,fr,20e6e37eb5d83e25,"**Analyse** : Après le DPO, le modèle devrait :
-1. **Privilegier les reponses ""chosen""** : Les rewards implicites (marge entre chosen et rejected) devraient etre positifs.
-2. **Generer des reponses plus structurees** : Le style des reponses DPO devrait etre plus proche du style ""chosen"" du dataset de préférences.
-3. **Etre plus aligne** : Les reponses evitent les generalisations abusives et les formulations vagues.
-
-Avec seulement 6 paires et 3 epochs, l'effet est subtil. En production, le DPO utilise des milliers de paires et des modèles beaucoup plus grands.","**Analysis**: After DPO, the model should:
-1. **Favor “chosen” responses**: The implicit rewards (margin between chosen and rejected) should be positive.
-2. **Generate more structured responses**: The style of DPO responses should be closer to the “chosen” style of the preference dataset.
-3. **Be more aligned**: The responses avoid overgeneralizations and vague wording.
-
-With only 6 pairs and 3 epochs, the effect is subtle. In production, DPO uses thousands of pairs and much larger models.",,,,,,,20e6e37eb5d83e25,c22361aab68eb9fa,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,ca9bbcd5,markdown,fr,2fb35d87e886567a,"## 7. RLHF vs DPO — Comparaison
-
-### Quand utiliser quoi ?
-
-| Critere | PPO (RLHF classique) | DPO |
-|---------|---------------------|-----|
-| **Simplicite** | Complexe (4 modèles) | Simple (2 modèles) |
-| **Données** | Préférences + Reward Model | Préférences uniquement |
-| **Stabilite** | Sensible aux hyperparametres | Stable |
-| **Cout compute** | Eleve (boucle RL) | Modere (un seul passage) |
-| **Qualite** | Très bonne si bien règle | Comparable a PPO |
-| **Cas d'usage** | ChatGPT, Claude (production) | Fine-tuning rapide, recherches |
-
-### En pratique aujourd'hui
-- **OpenAI, Anthropic** : utilisent des variantes de RLHF avec PPO + Reward Model
-- **Meta (LLaMA), Mistral** : utilisent DPO pour l'alignement
-- **Communaute open-source** : DPO est le standard de facto (TRL, Axolotl)","## 7. RLHF vs DPO — Comparison
-
-### When to use which?
-
-| Criterion | PPO (classic RLHF) | DPO |
-|---------|---------------------|-----|
-| **Simplicity** | Complex (4 models) | Simple (2 models) |
-| **Data** | Preferences + Reward Model | Preferences only |
-| **Stability** | Sensitive to hyperparameters | Stable |
-| **Compute cost** | High (RL loop) | Moderate (single pass) |
-| **Quality** | Very good if properly tuned | Comparable to PPO |
-| **Use cases** | ChatGPT, Claude (production) | Fast fine-tuning, research |
-
-### In practice today
-- **OpenAI, Anthropic**: use variants of RLHF with PPO + Reward Model
-- **Meta (LLaMA), Mistral**: use DPO for alignment
-- **Open-source community**: DPO is the de facto standard (TRL, Axolotl)",,,,,,,2fb35d87e886567a,6b4c337b75a939f1,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,69f31ddb,code,fr,3aabcb1a11b9211a,"# Liberation de la memoire GPU
 del model_sft, model_base
 gc.collect()
@@ -2367,26 +2096,6 @@ if torch.cuda.is_available():
     vram = torch.cuda.mem_get_info()[0] / 1e9
     print(f""VRAM libre apres cleanup : {vram:.1f} GB"")
 print(""Memoire GPU liberee."")",,,,,,,,3aabcb1a11b9211a,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,33ad67b0,markdown,fr,cecccd0214895750,"## 8. Exercices
-
-Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts précédents.","## 8. Exercises
-
-Put the concepts from this notebook into practice. Each exercise builds on the previous concepts.",,,,,,,cecccd0214895750,4f0488dfe62eabc9,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,4f9a2cb2,markdown,fr,59b51d720f854487,"### Exercice 1 : Créer un dataset de préférences thematique
-
-Créez un dataset de 8 paires de préférence sur un thème de votre choix (cuisine, voyage, musique, etc.). Chaque paire doit avoir une reponse ""chosen"" precise et une reponse ""rejected"" vague ou biaisee.
-
-**Indices** :
-- Inspirez-vous du dataset synthetique de la section 3
-- Les reponses ""chosen"" doivent etre factuelles et structurees
-- Les reponses ""rejected"" doivent etre plausibles mais de moindre qualite","### Exercise 1: Create a thematic preference dataset
-
-Create a dataset of 8 preference pairs on a theme of your choice (cooking, travel, music, etc.). Each pair must have a precise ""chosen"" answer and a vague or biased ""rejected"" answer.
-
-**Hints**:
-- Draw inspiration from the synthetic dataset in section 3
-- The ""chosen"" answers must be factual and structured
-- The ""rejected"" answers must be plausible but of lower quality",,,,,,,59b51d720f854487,586b39c2fafe1731,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,5437126a,code,fr,fa327908a72b52d3,"# Exercice 1 : Creez votre dataset de preferences thematique
 # TODO etudiant : remplacez les exemples ci-dessous par votre propre theme
 mon_dataset_preferences = [
@@ -2398,15 +2107,6 @@ mon_dataset_preferences = [
     # TODO etudiant : ajoutez 7 autres paires sur votre theme
 ]
 print(f""Dataset en cours : {len(mon_dataset_preferences)} paires (objectif : 8)"")",,,,,,,,fa327908a72b52d3,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,c035350c,markdown,fr,46435b511a7d04a0,"### Exercice 2 : Analyser l'impact du paramètre beta
-
-Le paramètre `beta` dans DPO contrôle la force de l'alignement. Testez avec `beta = 0.01` (faible) et `beta = 1.0` (fort) et observez les différences.
-
-**Indice** : Un beta trop faible ne change rien ; un beta trop fort peut degrader la coherence du texte.","### Exercise 2: Analyze the impact of the beta parameter
-
-The `beta` parameter in DPO controls the strength of the alignment. Test with `beta = 0.01` (weak) and `beta = 1.0` (strong) and observe the differences.
-
-**Hint**: A beta that is too low changes nothing; a beta that is too high can degrade the coherence of the text.",,,,,,,46435b511a7d04a0,3212378db2f14403,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,f7c6f904,code,fr,be4568bd39b1be83,"# Exercice 2 : Testez differents valeurs de beta
 # TODO etudiant : testez beta=0.01 et beta=1.0, comparez les loss et les reponses
 # Indice : reentrainez le modele SFT (cellule 14) entre chaque test de beta
@@ -2414,17 +2114,6 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,f7c6f904,code,fr,be4568b
 beta_test = 0.1  # TODO etudiant : remplacez par 0.01 ou 1.0
 print(f""Test avec beta={beta_test} (a completer par l'etudiant)"")
 print(""Etapes : 1) Re-SFT | 2) Calcul ref_logprobs | 3) DPO avec nouveau beta | 4) Evaluer"")",,,,,,,,be4568bd39b1be83,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,9561b518,markdown,fr,1bdd33ec26dccece,"### Exercice 3 : RLHF vs SFT — Avantages et limites
-
-En vous basant sur les expériences de ce notebook et des notebooks précédents (FT-01 a FT-03), redigez une courte analyse (3-5 phrases en markdown) comparant :
-1. Ce que le SFT apporte par rapport au modèle de base
-2. Ce que le DPO/RLHF apporte par rapport au SFT
-3. Les limites de notre implementation pedagogique","### Exercise 3: RLHF vs SFT — Advantages and limitations
-
-Based on the experiments in this notebook and the previous notebooks (FT-01 to FT-03), write a short analysis (3-5 sentences in Markdown) comparing:
-1. What SFT brings compared to the base model
-2. What DPO/RLHF brings compared to SFT
-3. The limitations of our pedagogical implementation",,,,,,,1bdd33ec26dccece,c54888f7e5fb2d9f,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,73872671,code,fr,ca57eabd18400ebf,"# Exercice 3 : Zone de reflexion
 # TODO etudiant : ecrivez votre analyse en markdown ci-dessous
 # Par exemple : convertissez cette cellule en markdown et redigez
@@ -2436,74 +2125,6 @@ analyse = (
 )
 print(""Exercice a completer en markdown."")
 print(""Conseil : convertissez cette cellule en cellule Markdown pour rediger votre analyse."")",,,,,,,,ca57eabd18400ebf,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,56a9d5fb,markdown,fr,24e8a2b5f8f515be,"## 9. Resume du FT-04
-
-| Concept | Detail |
-|---------|--------|
-| **RLHF** | Pipeline en 3 étapes : SFT -> Reward Model -> PPO |
-| **Données de préférence** | Paires (chosen, rejected) annotatees par des humains |
-| **Reward Model** | Modèle entraine a scorer la qualite des reponses |
-| **DPO** | Optimisation directe des préférences, sans reward model separe |
-| **Perte DPO** | Maximise la marge entre log-probs chosen vs rejected par rapport a la reference |
-| **Beta** | Paramètre de temperature controlant la force de l'alignement |
-| **Résultat** | Le modèle DPO privilegie les reponses precises et structurees |
-
-**Prochaines étapes** : Le FT-05 explorera le merge de modèles et le routing, qui permettent de combiner plusieurs modèles specialises en un seul modèle plus performant.
-
----
-
-**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**","## 9. Summary of FT-04
-
-| Concept | Detail |
-|---------|--------|
-| **RLHF** | 3-step pipeline: SFT -> Reward Model -> PPO |
-| **Preference data** | Pairs (chosen, rejected) annotated by humans |
-| **Reward Model** | Model trained to score the quality of responses |
-| **DPO** | Direct optimization of preferences, without a separate reward model |
-| **DPO loss** | Maximizes the margin between chosen vs rejected log-probs relative to the reference |
-| **Beta** | Temperature parameter controlling the strength of alignment |
-| **Result** | The DPO model favors precise and structured responses |
-
-**Next steps**: FT-05 will explore model merging and routing, which make it possible to combine several specialized models into a single, higher-performing model.
-
----
-
-**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**",,,,,,,24e8a2b5f8f515be,1d0c97cee4ff0c47,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a1b2c3d0,markdown,fr,da1d566bbd1e36e0,"# FT-05 : Fusion et Routage de Modèles -- Combiner les Expertises
-
-**Objectif** : Comprendre comment fusionner plusieurs modèles fine-tunes en un seul modèle plus performant, du merge de poids au routage dynamique.
-
-**Prerequis** : FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)
-
-**Duree estimee** : ~35 min
-
-**Plan du notebook** :
-1. Pourquoi fusionner des modèles ?
-2. Les Task Vectors
-3. Interpolation Lineaire (LERP)
-4. Interpolation Spherique (SLERP)
-5. TIES et DARE -- Techniques avancees
-6. Routing et Mixture of Experts
-7. Exercices
-
-**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**","# FT-05: Model Merging and Routing -- Combining Expertise
-
-**Objective**: Understand how to merge multiple fine-tuned models into a single, higher-performing model, from weight merging to dynamic routing.
-
-**Prerequisites**: FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)
-
-**Estimated duration**: ~35 min
-
-**Notebook outline**:
-1. Why merge models?
-2. Task Vectors
-3. Linear Interpolation (LERP)
-4. Spherical Interpolation (SLERP)
-5. TIES and DARE -- Advanced techniques
-6. Routing and Mixture of Experts
-7. Exercises
-
-**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,da1d566bbd1e36e0,fa01496f09a1a6a5,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b2c3d4e1,code,fr,cfa5f605de339e3e,"import warnings
 warnings.filterwarnings(""ignore"", message=""IProgress not found"")
 warnings.filterwarnings(""ignore"", message="".*use_reentrant.*"")
@@ -2522,43 +2143,6 @@ if torch.cuda.is_available():
     props = torch.cuda.get_device_properties(0)
     print(f""GPU : {props.name}, {props.total_memory / 1e9:.1f} GB VRAM"")
     print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} GB"")",,,,,,,,cfa5f605de339e3e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c3d4e5f2,markdown,fr,0bece3b678b7461c,"## 1. Pourquoi fusionner des modèles ?
-
-Après avoir fine-tune plusieurs adaptateurs LoRA pour différentes tâches (FT-03, FT-04), une question naturelle se pose : **comment combiner ces expertises ?**
-
-### Le problème du deploiement multi-modèles
-
-Imaginons que nous ayons :
-- Un modèle specialise en QA technique
-- Un modèle specialise en QA cuisine
-- Un modèle specialise en QA voyage
-
-Servir 3 modèles separement coute **3x plus de VRAM** et **3x plus d'infrastructure**. Ne peut-on pas en faire un seul modèle ?
-
-### Deux approches
-
-1. **Model Merging** : Combiner les poids des modèles en un seul ensemble de poids. Le résultat est un modèle unique qui ""sait"" faire plusieurs tâches.
-2. **Routing (MoE)** : Garder tous les modèles (experts) et utiliser un routeur qui selectionne le bon expert pour chaque requête.
-
-Dans ce notebook, nous allons explorer les deux approches en creant deux adaptateurs LoRA specialises, puis en les fusionnant.","## 1. Why merge models?
-
-After fine-tuning several LoRA adapters for different tasks (FT-03, FT-04), a natural question arises: **how can these areas of expertise be combined?**
-
-### The problem of multi-model deployment
-
-Imagine that we have:
-- A model specialized in technical QA
-- A model specialized in cooking QA
-- A model specialized in travel QA
-
-Serving 3 separate models costs **3x more VRAM** and **3x more infrastructure**. Can’t we make a single model out of them?
-
-### Two approaches
-
-1. **Model Merging**: Combine the weights of the models into a single set of weights. The result is a single model that ""knows"" how to perform several tasks.
-2. **Routing (MoE)**: Keep all the models (experts) and use a router that selects the right expert for each request.
-
-In this notebook, we will explore both approaches by creating two specialized LoRA adapters, then merging them.",,,,,,,0bece3b678b7461c,fb99117dd0940ee9,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d4e5f6a3,code,fr,f85697b31d44d4dd,"# Charger le modele de base et creer 2 adaptateurs LoRA specialises
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
@@ -2604,7 +2188,6 @@ def generate(model, prompt, max_new_tokens=60, temperature=0.7):
 print(f""Modele de base charge : {MODEL_NAME}"")
 print(f""LoRA config : r={lora_config.r}, alpha={lora_config.lora_alpha}"")
 print(f""Target modules : {lora_config.target_modules}"")",,,,,,,,f85697b31d44d4dd,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c6264858,markdown,fr,0fd7d3e031b5218a,"Nous allons maintenant créer deux adaptateurs LoRA specialises. Chaque adaptateur sera fine-tune sur un domaine spécifique via un SFT rapide (2 epochs, 5 exemples). Ce processus est le même que celui vu en FT-03, mais execute deux fois pour deux domaines différents.","We will now create two specialized LoRA adapters. Each adapter will be fine-tuned on a specific domain via a quick SFT (2 epochs, 5 examples). This process is the same as the one seen in FT-03, but run twice for two different domains.",,,,,,,0fd7d3e031b5218a,6c8c863a019edf3b,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e5f6a7b4,code,fr,bb7f0419e151aa4e,"# Creer et entrainer l'Adaptateur A : specialise en QA technique
 tech_examples = [
     {""text"": ""### Human: Qu'est-ce que Python ?\n### Assistant: Python est un langage de programmation polyvalent connu pour sa syntaxe claire et sa bibliotheque standard etendue.""},
@@ -2647,7 +2230,6 @@ adapter_a_state = {k: v.detach().clone() for k, v in model_tech.state_dict().ite
 lora_keys_a = list(adapter_a_state.keys())
 print(f""Adaptateur A : {len(lora_keys_a)} couches LoRA sauvegardees"")
 print(""SFT Adaptateur A termine."")",,,,,,,,bb7f0419e151aa4e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,7e384d22,markdown,fr,71b35104e6dea028,"Premier adaptateur : fine-tune sur 5 exemples de QA technique (Python, Docker, Git, API REST, Machine Learning).","First adapter: fine-tuning on 5 examples of technical QA (Python, Docker, Git, REST API, Machine Learning).",,,,,,,71b35104e6dea028,cddbd8d85f947d75,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f6a7b8c5,code,fr,1d2e92c5dfb2c288,"# Creer et entrainer l'Adaptateur B : specialise en QA cuisine
 cooking_examples = [
     {""text"": ""### Human: Comment faire une bechamel ?\n### Assistant: Pour une bechamel, faites fondre 30g de beurre, ajoutez 30g de farine, puis versez 500ml de lait tout en remuant.""},
@@ -2685,26 +2267,6 @@ adapter_b_state = {k: v.detach().clone() for k, v in model_cook.state_dict().ite
 lora_keys_b = list(adapter_b_state.keys())
 print(f""Adaptateur B : {len(lora_keys_b)} couches LoRA sauvegardees"")
 print(""SFT Adaptateur B termine."")",,,,,,,,1d2e92c5dfb2c288,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,ec0e2218,markdown,fr,e8c5753b20fa61ba,"Deuxieme adaptateur : fine-tune sur 5 exemples de QA cuisine (sauces, cuisson, vinaigrette, beurre, pate brisee).","Second adapter: fine-tune on 5 cooking QA examples (sauces, cooking, vinaigrette, butter, shortcrust pastry).",,,,,,,e8c5753b20fa61ba,41e7cdefe8d7c6a5,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d6,markdown,fr,080b4e425878336e,"### Interpretation : Deux adaptateurs specialises
-
-Nous avons maintenant deux adaptateurs LoRA :
-
-| Adaptateur | Domaine | Données d'entrainement |
-|-----------|---------|----------------------|
-| A (Tech) | Programmation, DevOps, APIs | 5 exemples QA technique |
-| B (Cuisine) | Recettes, techniques culinaires | 5 exemples QA cuisine |
-
-Chaque adaptateur a appris a specialiser le modèle de base dans son domaine. Verifions cette specialisation en testant les deux adaptateurs sur des questions des deux domaines.","### Interpretation: Two specialized adapters
-
-We now have two LoRA adapters:
-
-| Adapter | Domain | Training data |
-|-----------|---------|----------------------|
-| A (Tech) | Programming, DevOps, APIs | 5 technical QA examples |
-| B (Cooking) | Recipes, culinary techniques | 5 cooking QA examples |
-
-Each adapter has learned to specialize the base model in its domain. Let's verify this specialization by testing the two adapters on questions from both domains.",,,,,,,080b4e425878336e,8f4b16ff3ca4572e,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b8c9d0e7,code,fr,f9971f0c5cda9e71,"# Tester chaque adaptateur sur des questions cross-domaine
 test_prompts = [
     (""tech"", ""### Human: Qu'est-ce que Docker ?\n### Assistant:""),
@@ -2728,28 +2290,6 @@ for domain, prompt in test_prompts:
     print(f""\n[{domain.upper()}] Q: {q}"")
     print(f""  Adaptateur A (Tech):    {resp_tech}"")
     print(f""  Adaptateur B (Cuisine): {resp_cook}"")",,,,,,,,f9971f0c5cda9e71,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c9d0e1f8,markdown,fr,27bb6f6a2d2ddc34,"**Observation** : Chaque adaptateur repond mieux dans son domaine de specialisation. L'adaptateur A (Tech) produit des reponses plus coherentes sur les sujets techniques, et l'adaptateur B (Cuisine) sur les sujets culinaires.
-
-Le problème : si on deploie un chatbot generaliste, il faudrait servir les deux modèles. C'est ici que le **model merging** intervient.","**Observation**: Each adapter responds better in its area of specialization. Adapter A (Tech) produces more coherent responses on technical topics, and adapter B (Cooking) on culinary topics.
-
-The problem: if we deploy a general-purpose chatbot, we would need to serve both models. This is where **model merging** comes in.",,,,,,,27bb6f6a2d2ddc34,ba41789476af9afb,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d0e1f2a9,markdown,fr,efc78058c830a815,"## 2. Les Task Vectors
-
-Avant de fusionner, il faut comprendre ce que chaque adaptateur a appris. Le concept de **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalise cela :
-
-$$\tau = \theta_{\text{fine-tune}} - \theta_{\text{base}}$$
-
-Le task vector $\tau$ est la **différence** entre les poids fine-tunes et les poids de base. Il capture la ""competence"" ajoutee par le fine-tuning.
-
-Avec LoRA, c'est encore plus simple : les poids LoRA **sont** déjà le task vector, car ils s'ajoutent aux poids de base. Chaque matrice LoRA represente directement la modification apprise.","## 2. Task Vectors
-
-Before merging, we need to understand what each adapter has learned. The concept of **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalizes this:
-
-$$\tau = \theta_{\text{fine-tune}} - \theta_{\text{base}}$$
-
-The task vector $\tau$ is the **difference** between the fine-tuned weights and the base weights. It captures the ""competence"" added by fine-tuning.
-
-With LoRA, it's even simpler: the LoRA weights **are** already the task vector, because they are added to the base weights. Each LoRA matrix directly represents the learned modification.",,,,,,,efc78058c830a815,56419645b1f2ec80,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e1f2a3b0,code,fr,f56b9361a05c4fa3,"# Extraire et analyser les task vectors (poids LoRA)
 # adapter_a_state et adapter_b_state contiennent deja uniquement les cles LoRA
 tv_a = {k: v.detach().cpu().float() for k, v in adapter_a_state.items()}
@@ -2778,68 +2318,6 @@ print(f""Ecart-type       A: {all_a.std():.6f}  |  B: {all_b.std():.6f}"")
 cos_sim = torch.nn.functional.cosine_similarity(all_a.unsqueeze(0), all_b.unsqueeze(0)).item()
 print(f""\nCosine similarity entre TV_A et TV_B : {cos_sim:.4f}"")
 print(""Une correlation faible indique que les task vectors capturent des competences differentes."")",,,,,,,,f56b9361a05c4fa3,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f2a3b4c1,markdown,fr,e1e27e38d89435fc,"### Interpretation : Task Vectors
-
-**Sortie obtenue** : Les normes et statistiques des poids LoRA pour chaque adaptateur.
-
-| Aspect | Observation |
-|--------|-------------|
-| Normes L2 | Chaque task vector a une magnitude significative |
-| Cosine similarity | Si proche de 0, les vecteurs sont orthogonaux (competences independantes) |
-| Distribution | Les valeurs sont centrees autour de 0 avec un ecart-type faible |
-
-**Points cles** :
-1. Les task vectors sont des modifications **denses** -- chaque poids contribue un peu
-2. Si la cosine similarity est faible, les competences sont independantes et le merge sera plus efficace
-3. Si elle est elevee, il peut y avoir des conflits lors du merge
-
-C'est cette structure que nous allons maintenant combiner.","### Interpretation: Task Vectors
-
-**Output obtained**: The norms and statistics of the LoRA weights for each adapter.
-
-| Aspect | Observation |
-|--------|-------------|
-| L2 Norms | Each task vector has a significant magnitude |
-| Cosine similarity | If close to 0, the vectors are orthogonal (independent skills) |
-| Distribution | The values are centered around 0 with a low standard deviation |
-
-**Key points**:
-1. Task vectors are **dense** modifications -- each weight contributes a little
-2. If the cosine similarity is low, the skills are independent and the merge will be more effective
-3. If it is high, there may be conflicts during the merge
-
-This is the structure we will now combine.",,,,,,,e1e27e38d89435fc,c0475b916ca51ef3,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a3b4c5d2,markdown,fr,5e5c8477aa0393fa,"## 3. Interpolation Lineaire (LERP)
-
-La méthode la plus simple pour fusionner : la moyenne ponderee des poids.
-
-$$\theta_{\text{merge}} = \alpha \cdot \theta_A + (1 - \alpha) \cdot \theta_B$$
-
-En termes de task vectors :
-
-$$\tau_{\text{merge}} = \alpha \cdot \tau_A + (1 - \alpha) \cdot \tau_B$$
-
-Le paramètre $\alpha \in [0, 1]$ contrôle la balance entre les deux expertises :
-- $\alpha = 1$ : seul l'adaptateur A (Tech)
-- $\alpha = 0$ : seul l'adaptateur B (Cuisine)
-- $\alpha = 0.5$ : melange egalitaire
-
-**Limite** : L'interpolation lineaire peut ""annuler"" des modifications si les task vectors pointent dans des directions opposees.","## 3. Linear Interpolation (LERP)
-
-The simplest method for merging: the weighted average of the weights.
-
-$$\theta_{\text{merge}} = \alpha \cdot \theta_A + (1 - \alpha) \cdot \theta_B$$
-
-In terms of task vectors:
-
-$$\tau_{\text{merge}} = \alpha \cdot \tau_A + (1 - \alpha) \cdot \tau_B$$
-
-The parameter $\alpha \in [0, 1]$ controls the balance between the two areas of expertise:
-- $\alpha = 1$ : only adapter A (Tech)
-- $\alpha = 0$ : only adapter B (Cuisine)
-- $\alpha = 0.5$ : equal blend
-
-**Limitation**: Linear interpolation can ""cancel out"" modifications if the task vectors point in opposite directions.",,,,,,,5e5c8477aa0393fa,0039ba1216aa39aa,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b4c5d6e3,code,fr,a89180379ff3155a,"# Implementer le merge LERP
 def lerp_merge(state_a, state_b, alpha=0.5):
     """"""Interpolation lineaire entre deux state dicts LoRA.""""""
@@ -2865,60 +2343,6 @@ for domain, prompt in test_prompts:
     print(f""  [{domain}] {q}"")
     print(f""    LERP: {resp}"")
     print()",,,,,,,,a89180379ff3155a,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c5d6e7f4,markdown,fr,183b94c6e66a6abb,"### Interpretation : LERP
-
-**Sortie obtenue** : Reponses du modèle fusionne avec interpolation lineaire.
-
-| Aspect | Observation |
-|--------|-------------|
-| alpha = 0.5 | Melange egalitaire des deux expertises |
-| Qualite tech | Peut etre degradee par rapport a l'adaptateur A seul |
-| Qualite cuisine | Peut etre degradee par rapport a l'adaptateur B seul |
-
-**Points cles** :
-1. Le LERP est simple mais peut degrader les deux expertises
-2. Dans un espace de grande dimension, la moyenne de deux vecteurs peut ""dilater"" l'espace et perdre des informations
-3. C'est pourquoi SLERP (section suivante) est souvent preferee","### Interpretation: LERP
-
-**Output obtained**: Responses from the merged model with linear interpolation.
-
-| Aspect | Observation |
-|--------|-------------|
-| alpha = 0.5 | Equal blending of the two areas of expertise |
-| Tech quality | May be degraded compared to adapter A alone |
-| Cooking quality | May be degraded compared to adapter B alone |
-
-**Key points**:
-1. LERP is simple but can degrade both areas of expertise
-2. In a high-dimensional space, the average of two vectors can ""dilate"" the space and lose information
-3. This is why SLERP (next section) is often preferred",,,,,,,183b94c6e66a6abb,5486c72b67219901,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d6e7f8a5,markdown,fr,11dce99e3fecc1f0,"## 4. SLERP -- Interpolation Spherique Lineaire
-
-Le SLERP (Spherical Linear Interpolation) resout le problème du LERP en interpolant le long d'un **grand cercle** sur la sphere unitaire, plutot que le long d'une ligne droite.
-
-$$\text{SLERP}(t, v_0, v_1) = \frac{\sin((1-t)\Omega)}{\sin(\Omega)} v_0 + \frac{\sin(t\Omega)}{\sin(\Omega)} v_1$$
-
-ou $\Omega = \arccos(v_0 \cdot v_1)$ est l'angle entre les deux vecteurs.
-
-**Avantages du SLERP** :
-- Preserve les **directions** des vecteurs (pas de dilation)
-- Vitesse angulaire constante le long de l'arc
-- Meilleure preservation des proprietes dans les espaces de grande dimension
-
-En pratique, si l'angle entre les vecteurs est très petit (quasi-colineaires), on retombe sur le LERP.","## 4. SLERP -- Spherical Linear Interpolation
-
-SLERP (Spherical Linear Interpolation) solves the problem of LERP by interpolating along a **great circle** on the unit sphere, rather than along a straight line.
-
-$$\text{SLERP}(t, v_0, v_1) = \frac{\sin((1-t)\Omega)}{\sin(\Omega)} v_0 + \frac{\sin(t\Omega)}{\sin(\Omega)} v_1$$
-
-where $\Omega = \arccos(v_0 \cdot v_1)$ is the angle between the two vectors.
-
-**Advantages of SLERP**:
-- Preserves the **directions** of the vectors (no dilation)
-- Constant angular velocity along the arc
-- Better preservation of properties in high-dimensional spaces
-
-In practice, if the angle between the vectors is very small (almost collinear), we fall back to LERP.",,,,,,,11dce99e3fecc1f0,238b5333e63a464d,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e7f8a9b6,code,fr,4ed8862f440f863e,"# Implementer le merge SLERP
 def slerp(t, v0, v1, DOT_THRESHOLD=0.9995):
     """"""
@@ -2995,76 +2419,6 @@ for domain, prompt in test_prompts:
     print(f""  [{domain}] {q}"")
     print(f""    SLERP: {resp}"")
     print()",,,,,,,,4ed8862f440f863e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f8a9b0c7,markdown,fr,07fce5b52eddac01,"### Interpretation : SLERP
-
-**Sortie obtenue** : Reponses du modèle fusionne avec interpolation spherique.
-
-| Aspect | LERP | SLERP |
-|--------|------|-------|
-| Preservation des directions | Non (dilation possible) | Oui (arc de grand cercle) |
-| Couches quasi-colineaires | N/A | Fallback automatique vers LERP |
-| Qualite du melange | Moyenne, risque de degradation | Meilleure preservation des expertises |
-
-**Points cles** :
-1. SLERP preserve les proprietes geometriques des deux task vectors
-2. Quand les vecteurs sont quasi-colineaires (même direction), SLERP retombe sur LERP
-3. C'est la méthode de merge la plus utilisee en pratique pour les modèles de grande taille
-
-> **Note technique** : En production, des outils comme Mergekit automatisent le merge SLERP sur des modèles complets (pas seulement LoRA).","### Interpretation: SLERP
-
-**Output obtained**: Responses from the merged model with spherical interpolation.
-
-| Aspect | LERP | SLERP |
-|--------|------|-------|
-| Preservation of directions | No (possible dilation) | Yes (great-circle arc) |
-| Nearly collinear layers | N/A | Automatic fallback to LERP |
-| Blend quality | Average, risk of degradation | Better preservation of expertise |
-
-**Key points**:
-1. SLERP preserves the geometric properties of the two task vectors
-2. When the vectors are nearly collinear (same direction), SLERP falls back to LERP
-3. It is the most widely used merge method in practice for large-scale models
-
-> **Technical note**: In production, tools like Mergekit automate SLERP merging on complete models (not just LoRA).",,,,,,,07fce5b52eddac01,04a5a32c662613d0,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a9b0c1d8,markdown,fr,84835f062060bd42,"## 5. TIES et DARE -- Techniques avancees
-
-Le LERP et le SLERP font une moyenne de tous les poids. Mais tous les poids ne sont pas également utiles. Deux techniques recentes introduisent une **sélection** des poids :
-
-### TIES (Trim, Elect Sign, Merge)
-
-[Yadav et al., 2023](https://arxiv.org/abs/2306.01708) : resout les conflits de signe entre task vectors.
-
-1. **Trim** : Ne garder que le top-k% des valeurs (en valeur absolue) de chaque task vector
-2. **Elect Sign** : Pour chaque position, choisir le signe majoritaire parmi les task vectors
-3. **Merge** : Combiner en gardant uniquement les valeurs dont le signe correspond au signe elu
-
-### DARE (Drop And Rescale)
-
-[Yu et al., 2023](https://arxiv.org/abs/2311.03099) : approche encore plus simple.
-
-1. **Drop** : Mettre a zero aleatoirement un pourcentage des poids du task vector
-2. **Rescale** : Multiplier les poids restants par $1/(1-p)$ pour preserver la magnitude attendue
-
-L'intuition : la plupart des modifications de poids sont redondantes. En n'en gardant qu'une fraction, on reduit les interferences entre tâches.","## 5. TIES and DARE -- Advanced Techniques
-
-LERP and SLERP average all weights. But not all weights are equally useful. Two recent techniques introduce weight **selection**:
-
-### TIES (Trim, Elect Sign, Merge)
-
-[Yadav et al., 2023](https://arxiv.org/abs/2306.01708): resolves sign conflicts between task vectors.
-
-1. **Trim**: Keep only the top-k% of values (by absolute value) from each task vector
-2. **Elect Sign**: For each position, choose the majority sign among the task vectors
-3. **Merge**: Combine while keeping only the values whose sign matches the elected sign
-
-### DARE (Drop And Rescale)
-
-[Yu et al., 2023](https://arxiv.org/abs/2311.03099): an even simpler approach.
-
-1. **Drop**: Randomly set a percentage of the task vector weights to zero
-2. **Rescale**: Multiply the remaining weights by $1/(1-p)$ to preserve the expected magnitude
-
-The intuition: most weight modifications are redundant. By keeping only a fraction of them, interference between tasks is reduced.",,,,,,,84835f062060bd42,2d1e2d68d8ca7b87,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b0c1d2e9,code,fr,c15258b8cde4f3c1,"# Implementer le merge DARE
 def dare_merge(state_a, state_b, drop_rate=0.3, seed=42):
     """"""
@@ -3118,114 +2472,6 @@ for domain, prompt in test_prompts:
     print(f""  [{domain}] {q}"")
     print(f""    DARE: {resp}"")
     print()",,,,,,,,c15258b8cde4f3c1,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c1d2e3fa,markdown,fr,b9641f361b4339ee,"### Interpretation : DARE
-
-**Sortie obtenue** : Reponses du modèle fusionne avec DARE (30% de dropout).
-
-| Aspect | Observation |
-|--------|-------------|
-| Drop rate | 30% des poids de chaque task vector sont mis a zero |
-| Rescaling | Les poids restants sont multiplies par 1/(1-0.3) ~ 1.43 |
-| Interference | Reduite par la suppression aleatoire des poids redondants |
-
-**Points cles** :
-1. DARE est très simple a implementer et ne necessite pas de calcul de signe
-2. Le rescaling preserve la magnitude attendue des modifications
-3. Un drop_rate plus eleve (0.5-0.7) reduit davantage les interferences mais peut perdre des informations utiles","### Interpretation: DARE
-
-**Output obtained**: Responses from the merged model with DARE (30% dropout).
-
-| Aspect | Observation |
-|--------|-------------|
-| Drop rate | 30% of the weights of each task vector are set to zero |
-| Rescaling | The remaining weights are multiplied by 1/(1-0.3) ~ 1.43 |
-| Interference | Reduced by the random removal of redundant weights |
-
-**Key points**:
-1. DARE is very simple to implement and does not require sign computation
-2. Rescaling preserves the expected magnitude of the modifications
-3. A higher drop_rate (0.5-0.7) reduces interference further but may lose useful information",,,,,,,b9641f361b4339ee,40d5ce055244a100,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d2e3f4ab,markdown,fr,5228616a82881a8a,"## 6. Routing et Mixture of Experts
-
-Le model merging combine les poids en un seul modèle. Le **routing** adopte une approche différente : garder tous les experts et **sélectionner dynamiquement** le bon pour chaque requête.
-
-### Architecture MoE (Mixture of Experts)
-
-```
-  Entree (prompt)
-       |
-  [ Routeur / Classifieur ]
-       |
-       +---> Expert A (Tech)     (si domaine = technique)
-       |
-       +---> Expert B (Cuisine)  (si domaine = cuisine)
-```
-
-Le routeur est un petit classifieur qui apprend a detecter le domaine de la requête. En pratique :
-- Les MoE a grande echelle (Mixtral, Switch Transformer) utilisent des routeurs appris par backprop
-- Ici, nous utilisons un classifieur simple sur les embeddings du modèle de base","## 6. Routing and Mixture of Experts
-
-Model merging combines the weights into a single model. **Routing** takes a different approach: keeping all the experts and **dynamically selecting** the right one for each request.
-
-### MoE Architecture (Mixture of Experts)
-
-```
-  Entree (prompt)
-       |
-  [ Routeur / Classifieur ]
-       |
-       +---> Expert A (Tech)     (si domaine = technique)
-       |
-       +---> Expert B (Cuisine)  (si domaine = cuisine)
-```
-
-The router is a small classifier that learns to detect the domain of the request. In practice:
-- Large-scale MoEs (Mixtral, Switch Transformer) use routers learned by backprop
-- Here, we use a simple classifier on the embeddings of the base model",,,,,,,5228616a82881a8a,4d75142218cb192d,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,m0eft05r,markdown,fr,dfaee2831534d51b,"Le diagramme ci-dessous rend cette architecture **Mixture of Experts** sous forme de
-graphe : un routeur dirige chaque requête vers l'expert specialise du bon domaine.
-
-```mermaid
-flowchart TD
-    IN([""Entree (prompt)""]) --> R{""Routeur / Classifieur""}
-    R -->|""domaine = technique""| EA[""Expert A<br/>(Tech)""]
-    R -->|""domaine = cuisine""| EB[""Expert B<br/>(Cuisine)""]
-    classDef route fill:#f8d7da,stroke:#842029,color:#58151c
-    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400
-    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65
-    class R route
-    class EA,EB exp
-    class IN in
-```
-
-> **Lecture.** Contrairement au *model merging* (qui fond les poids en un seul modèle),
-> le **routing** conserve tous les experts intacts et en **selectionne dynamiquement**
-> un par requête. Le **routeur** est un petit classifieur qui detecte le domaine ; ici
-> il opere sur les embeddings du modèle de base, tandis que les MoE a grande echelle
-> (Mixtral, Switch Transformer) apprennent leur routeur par retropropagation. L'intérêt :
-> n'activer qu'une fraction des paramètres a chaque appel (calcul *creux*).
-","The diagram below renders this **Mixture of Experts** architecture as a
-graph: a router directs each request to the specialized expert for the right domain.
-
-```mermaid
-flowchart TD
-    IN([""Entree (prompt)""]) --> R{""Routeur / Classifieur""}
-    R -->|""domaine = technique""| EA[""Expert A<br/>(Tech)""]
-    R -->|""domaine = cuisine""| EB[""Expert B<br/>(Cuisine)""]
-    classDef route fill:#f8d7da,stroke:#842029,color:#58151c
-    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400
-    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65
-    class R route
-    class EA,EB exp
-    class IN in
-```
-
-> **Reading.** Unlike *model merging* (which merges weights into a single model),
-> **routing** keeps all experts intact and **dynamically selects**
-> one per request. The **router** is a small classifier that detects the domain; here
-> it operates on the embeddings of the base model, while large-scale MoEs
-> (Mixtral, Switch Transformer) learn their router through backpropagation. The benefit:
-> activating only a fraction of the parameters at each call (sparse computation).",,,,,,,dfaee2831534d51b,f2aa03bfc145e84f,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e3f4a5bc,code,fr,c6385eb193308c22,"# Implementer un routeur simple base sur les embeddings du modele de base
 import torch.nn as nn
 
@@ -3371,33 +2617,6 @@ print(f""  Routeur lineaire (appris, 50 ep.) : {loo_router_correct}/{n} = {loo_r
 print(f""  Centroide le plus proche (trivial): {loo_centroid_correct}/{n} = {loo_centroid_correct/n:.1%}"")
 print(f""  Accuracy in-sample du routeur     : {(router.predict(emb_tensor) == label_tensor).float().mean().item():.1%}"")
 ",,,,,,,,c6385eb193308c22,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f4a5b6cd,markdown,fr,a83be551feb3e358,"### Interpretation : Routeur
-
-**Sortie obtenue** : Le routeur a appris a classifier les requêtes entre domaine tech et cuisine.
-
-| Aspect | Valeur | Signification |
-|--------|--------|---------------|
-| Input dim | Dimension du dernier hidden state | Richesse du signal |
-| Accuracy | >90% typiquement | Le routeur distingue bien les domaines |
-| Entrainement | 50 epochs, <1s | Très rapide car le classifieur est lineaire |
-
-**Points cles** :
-1. Le routeur utilise les **hidden states du modèle de base** comme features (pas besoin d'embeddings separes)
-2. Un classifieur lineaire suffit car les domaines sont bien separes dans l'espace latent
-3. Le routeur est leger et ajoute un cout negligeable a l'inference","### Interpretation: Router
-
-**Output obtained**: The router learned to classify requests between the tech and cooking domains.
-
-| Aspect | Value | Meaning |
-|--------|--------|---------------|
-| Input dim | Dimension of the last hidden state | Signal richness |
-| Accuracy | >90% typically | The router distinguishes the domains well |
-| Training | 50 epochs, <1s | Very fast because the classifier is linear |
-
-**Key points**:
-1. The router uses the **hidden states of the base model** as features (no need for separate embeddings)
-2. A linear classifier is sufficient because the domains are well separated in the latent space
-3. The router is lightweight and adds negligible cost to inference",,,,,,,a83be551feb3e358,81705383bead764a,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a5b6c7de,code,fr,62e785c72f0180c7,"# Pipeline complet de routing : classifieur -> selection d'expert -> generation
 expert_names = [""Tech"", ""Cuisine""]
 expert_models = [model_tech, model_cook]
@@ -3446,39 +2665,6 @@ for true_domain, prompt in routing_test_prompts:
 n_correct = sum(1 for r in routing_results if r[""correct""])
 print(f""\nPrecision du routing : {n_correct}/{len(routing_results)} ""
       f""({100*n_correct/len(routing_results):.0f}%)"")",,,,,,,,62e785c72f0180c7,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b6c7d8ef,markdown,fr,f99ce14f28da15b8,"### Comparaison : Merging vs Routing
-
-Maintenant que nous avons implemente toutes les approches, comparons-les systematiquement.
-
-| Critere | LERP | SLERP | DARE | Routing (MoE) |
-|---------|------|-------|------|---------------|
-| **Simplicite** | Très simple | Simple | Simple | Plus complexe |
-| **Qualite par domaine** | Degradee | Moins degradee | Variable | Optimale (expert dedie) |
-| **Cout d'inference** | 1 modèle | 1 modèle | 1 modèle | N modèles + routeur |
-| **VRAM** | 1x | 1x | 1x | Nx (ou offloading) |
-| **Flexibilite** | Fixe au merge | Fixe au merge | Fixe au merge | Dynamique (ajout d'experts) |
-| **Outils** | Mergekit | Mergekit | Mergekit | Custom / vLLM |
-
-**Quand utiliser quoi ?**
-- **SLERP** : Meilleur compromis qualite/simplicite pour combiner 2-3 modèles
-- **DARE** : Quand on a beaucoup d'experts (>3) et des interferences entre tâches
-- **Routing** : Quand les domaines sont très différents et qu'on peut se permettre Nx VRAM","### Comparison: Merging vs Routing
-
-Now that we have implemented all the approaches, let's compare them systematically.
-
-| Criterion | LERP | SLERP | DARE | Routing (MoE) |
-|---------|------|-------|------|---------------|
-| **Simplicity** | Very simple | Simple | Simple | More complex |
-| **Quality by domain** | Degraded | Less degraded | Variable | Optimal (dedicated expert) |
-| **Inference cost** | 1 model | 1 model | 1 model | N models + router |
-| **VRAM** | 1x | 1x | 1x | Nx (or offloading) |
-| **Flexibility** | Fixed at merge | Fixed at merge | Fixed at merge | Dynamic (adding experts) |
-| **Tools** | Mergekit | Mergekit | Mergekit | Custom / vLLM |
-
-**When to use what?**
-- **SLERP**: Best quality/simplicity trade-off for combining 2–3 models
-- **DARE**: When you have many experts (>3) and interference between tasks
-- **Routing**: When the domains are very different and you can afford Nx VRAM",,,,,,,f99ce14f28da15b8,c02654d7afa17b4b,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c7d8e9fa,code,fr,8914473747b089de,"# Comparaison quantitative de toutes les approches
 comparison_prompts = [
     (""tech"", ""### Human: Qu'est-ce que Docker ?\n### Assistant:""),
@@ -3515,41 +2701,6 @@ print(""\n"" + ""="" * 80)
 print(""Note : Les reponses varient avec la temperature (do_sample=True)."")
 print(""Le routing selectionne le meilleur expert pour chaque domaine."")
 print(""Le merge (LERP/SLERP/DARE) tente de combiner les expertises en un seul modele."")",,,,,,,,8914473747b089de,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d8e9f0ab,markdown,fr,611503337abf45ac,"### Interpretation : Comparaison finale
-
-**Résultats attendus** :
-
-| Approche | Tech | Cuisine | Commentaire |
-|----------|------|---------|-------------|
-| Adaptateur A | Bon | Faible | Specialise tech |
-| Adaptateur B | Faible | Bon | Specialise cuisine |
-| LERP | Moyen | Moyen | Melange egalitaire, degradation des deux |
-| SLERP | Moyen+ | Moyen+ | Meilleur preservation que LERP |
-| DARE | Variable | Variable | Dependant du dropout aleatoire |
-| Routing | Bon | Bon | Selectionne le bon expert, meilleur résultat |
-
-**Points cles** :
-1. Le **routing** offre les meilleurs résultats par domaine mais coute plus cher en VRAM
-2. Le **SLERP** est le meilleur merge statique -- bon compromis entre les deux expertises
-3. Le **DARE** est efficace quand on a beaucoup d'experts, mais moins bon avec seulement 2
-4. En production, les approches peuvent etre combinees : merge SLERP pour les experts proches + routing pour les domaines très différents","### Interpretation: Final comparison
-
-**Expected results**:
-
-| Approach | Tech | Cooking | Comment |
-|----------|------|---------|-------------|
-| Adapter A | Good | Weak | Tech-specialized |
-| Adapter B | Weak | Good | Cooking-specialized |
-| LERP | Average | Average | Egalitarian blend, degradation of both |
-| SLERP | Average+ | Average+ | Better preservation than LERP |
-| DARE | Variable | Variable | Depends on random dropout |
-| Routing | Good | Good | Selects the right expert, best result |
-
-**Key points**:
-1. **Routing** offers the best results per domain but costs more in VRAM
-2. **SLERP** is the best static merge -- a good compromise between the two areas of expertise
-3. **DARE** is effective when there are many experts, but less good with only 2
-4. In production, the approaches can be combined: SLERP merge for closely related experts + routing for very different domains",,,,,,,611503337abf45ac,11af4be5d6120b35,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e9f0a1bc,code,fr,e4bdd20549e3a3b9,"# Liberation de la memoire GPU avant les exercices
 del model_tech, model_cook, model_lerp, model_slerp, model_dare
 del model_base, router
@@ -3561,11 +2712,6 @@ if torch.cuda.is_available():
     vram = torch.cuda.mem_get_info()[0] / 1e9
     print(f""VRAM libre apres cleanup : {vram:.1f} GB"")
 print(""Memoire GPU liberee."")",,,,,,,,e4bdd20549e3a3b9,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f0a1b2cd,markdown,fr,f2e634cf6f218d85,"## 7. Exercices
-
-Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts précédents.","## 7. Exercises
-
-Put the concepts from this notebook into practice. Each exercise builds on the previous concepts.",,,,,,,f2e634cf6f218d85,91ce0be383047566,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a1b2c3d4,markdown,fr,774fd1b532451753,"### Exercice 1 : Explorer différentes valeurs de alpha (LERP/SLERP)
 
 Testez différentes valeurs du paramètre `alpha` (ou `t` pour SLERP) et observez comment la balance entre les deux domaines change.

--- a/translations/genai/image.csv
+++ b/translations/genai/image.csv
@@ -8532,9 +8532,6 @@ print(""   • Ratios d'aspect"")
 print(""   • Prompt engineering avancé"")
 print(""   • Génération de texte dans les images"")
 print(""\n➡️  Prochain notebook: 02-3-Stable-Diffusion-3-5.ipynb"")",,,,,,,,dfcd049ec3766944,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb,7a15abb4,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb,cell-0,markdown,fr,5a800dcb441e2cd1,"**Navigation** : [Index](../../README.md) | [<< Précédent](02-2-FLUX-1-Advanced-Generation.ipynb) | [Suivant >>](02-4-Z-Image-Lumina2.ipynb)
 
 # Stable Diffusion 3.5 - Génération de Pointe
@@ -10413,9 +10410,6 @@ Ce notebook illustre l'orchestration de plusieurs moteurs de generation d'images
 - Implementer un système de scoring automatise (CLIP score, similarite text-image)
 - Paralleliser les appels avec `asyncio` pour reduire le temps d'attente total
 - Sauvegarder les résultats dans un tableau comparatif avec metadonnees (temps, resolution, score)",,,,,,,,ca6cf44b0b8231b1,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb,c9e45ef5,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb,cell-0,markdown,fr,561f71dd4b0852bb,"**Navigation** : [Index](../../README.md) | [<< Précédent](03-1-Multi-Model-Comparison.ipynb) | [Suivant >>](03-3-Performance-Optimization.ipynb)
 
 # Workflow Orchestration - Chaînage Multi-Modèles
@@ -11548,9 +11542,6 @@ print(""   • Pipelines conditionnels"")
 print(""   • Multi-variations et sélection"")
 print(""   • Retry et gestion d'erreurs"")
 print(""\n➡️  Prochain notebook: 03-3-Performance-Optimization.ipynb"")",,,,,,,,41d479490568bcc9,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb,f8145450,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb,d4fc8cfa,markdown,fr,29d900ef919df3f2,"**Navigation** : [Index](../../README.md) | [<< Précédent](03-2-Workflow-Orchestration.ipynb)
 
 # 🚀 Performance Optimization pour la Génération d'Images
@@ -16679,9 +16670,6 @@ Les étapes suivantes vous guideront pas à pas :
 MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb,f8t8qfwlmdl,markdown,fr,01b24a0d7863ee55,"Une fois les dépendances installées, on charge la configuration de l'environnement et on définit l'URL de l'API Stable Diffusion locale. Cette séparation permet de modifier les paramètres de connexion sans toucher au code de traitement.",,,,,,,,01b24a0d7863ee55,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb,aa3aa989,code,fr,6bc40f3302901ce5,"# Parametres Papermill - JAMAIS modifier ce commentaire
 notebook_mode = ""interactive""  # ""interactive"" ou ""batch""",,,,,,,,6bc40f3302901ce5,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb,e9392e63,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb,53286701,markdown,fr,ad317c2dc01d5116,"### Verification des dependances et chargement des ressources
 
 Les cellules suivantes verifient la presence des bibliotheques requises (Pillow, requests, numpy, etc.), importent les modules necessaires, et chargent le fichier **DMC_colors.json** qui contient les 454 references de fils DMC avec leurs codes couleur RGB. Ce fichier est essentiel pour l'etaape de correspondance couleur/fil qui intervient après la reduction de palette.",,,,,,,,ad317c2dc01d5116,,,,,,,,

--- a/translations/genai/posttraining.csv
+++ b/translations/genai/posttraining.csv
@@ -1402,18 +1402,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb,4545940b,
     return accuracy
 
 print(""Exercice a completer : preference accuracy"")",,,,,,,,d90dbcbf53028c1c,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb,a50da53a,markdown,fr,0560a5bf5ba80c65,"## 11. Methodologie multi-seed (bonus)
-
-Pour toute claim ""DPO > SFT"" sur une metrique d'evaluation, la règle CoursIA exige :
-- **>= 4 seeds** parmi {0, 1, 7, 42, 99}
-- **Edge >= 2 sigma** cross-seed (sinon flag ""noise"")
-- **Walk-forward 5-fold** sur les données de préférence
-
-En pratique pour ce notebook pedagogique (50 exemples), un verdict honnete serait :
-- ""DPO montre une amelioration sur 3/4 seeds, mais edge < 2 sigma""
-- ""INCONCLUSIF sur ce subset — a confirmer sur dataset complet""
-
-Le pattern honnete (G.2) : rapporter le verdict reel, pas le verdict souhaite.",,,,,,,,0560a5bf5ba80c65,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb,cell-6d84ccc3,markdown,fr,252a6ef838133a5b,"---
 
 ## Bilan — DPO : passer de 4 modèles a 2 sans reward model
@@ -4779,30 +4767,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_10_gae_from_scratch_toy_env.ipynb,84d6d3
     return None  # TODO etudiant
 
 print(""Exercice C : variance_advantage_diagnostic - completer et executer"")",,,,,,,,599c46182fee7061,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,bfbb6e52,markdown,fr,d6453548184f436c,"Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #10283
-
-# PT-11 — RLVR sur VRAI LLM (Qwen3.5-0.8B) + rewardspy.watch ONLINE + Z3 Tier-1 verifier
-
-**Serie** : Post-Training SOTA 2024-2025 (Epic #1742, PT-11 = sous-axe RLVR de #10289)
-**Pre-requis** : PT-05 (RLVR pedagogique, SymPy verifier) et PT-04 (GRPO), patron transposé
-**Objectif acceptance** : demonstrer un pipeline RLVR **complet et executé** sur un **vrai LLM**
-(Qwen3.5-0.8B, QLoRA 4-bit), avec rewards **verifiables** (SymPy exact match), instrumentation
-**ONLINE** par `rewardspy.watch` (detecteur reward hacking), et verdict **honnête** sur la convergence.
-
-**References cles** :
-- Deepseek-AI, ""DeepSeek-R1"" (2025) — RLVR sur Qwen2.5 + Qwen3.5 → emergence raisonnement
-- Lightman et al., ""Let's Verify Step by Step"" (OpenAI, 2023) — outcome vs process reward
-- Open-R1 / SmolLM-Reward (HuggingFace, 2025) — `rewardspy.watch` instrumentation LIVE
-
-**Difference vs PT-05** : PT-05 documente le patron RLVR sur Qwen2.5-0.5B en mode CPU-safe
-(demonstration pedagogique, pas d'execution reelle). PT-11 execute **réellement** sur RTX 3070
-avec Qwen3.5-0.8B QLoRA 4-bit, ≥100 steps GRPO, courbe de reward reelle, et signal Goodhart
-via `rewardspy.watch` ONLINE (cf acceptance #10289).",,,,,,,,d6453548184f436c,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,b290ad8d,markdown,fr,47bd0ccf06cec4e0,"## 1. Env probe — GPU, libs, versions
-
-Avant tout : verifier l'environnement. PT-11 est un grain **DEEP** PostTraining, il necessite
-CUDA + transformers + trl + peft + bitsandbytes + rewardspy + z3. **Si une lib manque, stop et
-installer** (regle F : reparer, ne JAMAIS contourner).",,,,,,,,47bd0ccf06cec4e0,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,9ea74bc2,code,fr,7c0176bd4ca0794b,"import sys, platform
 print(f""Python : {sys.version}"")
 print(f""Plateforme : {platform.platform()}"")
@@ -4829,10 +4793,6 @@ print(f""z3 : {z3.get_version_string()}"")
 print(f""sympy : {sympy.__version__}"")
 
 print(""\nEnv probe OK."")",,,,,,,,7c0176bd4ca0794b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,c5fd25b6,markdown,fr,504d732a77075f48,"### 1.1 Switch d'execution
-
-`LOAD_MODEL_AND_TRAIN = True` execute le pipeline RLVR complet (~10-20 min sur RTX 3070).
-`False` fait tourner seulement les tests unitaires du verifier + Z3 (validation pedagogique sans GPU).",,,,,,,,504d732a77075f48,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,5fb9ae41,code,fr,bea6d1be4d817add,"import os
 
 LOAD_MODEL_AND_TRAIN = True
@@ -4844,23 +4804,6 @@ if not LOAD_MODEL_AND_TRAIN:
     print(""(Mode CPU-safe : verifier Z3 + SymPy executes, training RLVR skip)"")
 else:
     print(""(Mode TRAINING : Qwen3.5-0.8B + GRPO + rewardspy.online)"")",,,,,,,,bea6d1be4d817add,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,7c51e9a1,markdown,fr,2a750dd9e1946815,"# Papermill injects LOAD_MODEL_AND_TRAIN via -p flag (default False = CPU-safe mode)
-# Set True for real training on GPU (>=4 Go VRAM).
-LOAD_MODEL_AND_TRAIN = False
-print(f""LOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN}"")
-if not LOAD_MODEL_AND_TRAIN:
-    print(""(Mode CPU-safe : verifier Z3 + SymPy executes, training RLVR skip)"")
-else:
-    print(""(Mode TRAINING : Qwen3.5-0.8B + GRPO + rewardspy.online)"")
-",,,,,,,,2a750dd9e1946815,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,9d782840,markdown,fr,6d8c718edf4dc0c0,"## 3. Tier-1 verifier — SymPy exact match (verifiable reward, bruit zero)
-
-Le verifier **exact** (outcome reward) prend une completion textuelle, extrait la reponse
-numerique, et la compare avec la ground truth a epsilon pres. **Pas de bruit, pas de zone
-grise** : reward = 1.0 si match, 0.0 sinon.
-
-**Formats d'extraction supportes** : `\boxed{42}`, `#### 42`, `The answer is 42`, `= 42`,
-fallback dernier nombre. Pattern robuste derive de PT-05 cellule 4.",,,,,,,,6d8c718edf4dc0c0,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,5ee77533,code,fr,4ba1eee258aaebac,"import re
 from typing import Optional
 import sympy
@@ -4937,18 +4880,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,32b
     return None  # TODO etudiant : retourner le nombre extrait ou None
 
 print(""Exercice a completer : parser etendu notation scientifique"")",,,,,,,,c4fcd90180b7ff67,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,fb37c096,markdown,fr,e502b435d69d3fff,"## 4. Tier-2 verifier (bonus) — Z3 CSP exact : N-queens N=4
-
-**Pourquoi** : SymPy verifie des reponses numeriques, Z3 verifie des **solutions a des problemes
-combinatoires** (N-queens, Sudoku, systemes de contraintes). On inclut un mini-verifier Z3
-pour montrer l'extension naturelle du Tier 1 → Tier 2 sans complexifier le notebook.
-
-**Cas test : N-queens N=4**. Le modele doit produire une permutation des colonnes `{1,2,3,4}`
-telle qu'aucune reine n'est en diagonale. Z3 valide en ~5ms.
-
-**Avertissement pedagogique** : pour N-queens N=4, la verification directe en Python pur
-(< 2 µs) est suffisante. Z3 est **pedagogiquement** pertinent pour des problemes ou la
-verification manuelle n'est pas evidente (ex. systemes d'equations, logique du premier ordre).",,,,,,,,e502b435d69d3fff,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,f46865f9,code,fr,e0eba4545ec38f5b,"import z3
 import time
 import re
@@ -5018,15 +4949,6 @@ print(f""  permutation  : {nqueens_verifier('Q1=1 Q2=2 Q3=3 Q4=4')}"")
 print(f""  collision    : {nqueens_verifier('Q1=2 Q2=4 Q3=2 Q4=3')}"")
 print(f""  garbage      : {nqueens_verifier('I dont know')}"")
 print(""\nVerifier Z3 pret."")",,,,,,,,e0eba4545ec38f5b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,90c5e15d,markdown,fr,b6a1509fbb68eba4,"## 5. Mini-dataset GSM8K-like (10 problemes, ground truths verifiables)
-
-**Cible** : 10 problemes de niveau college, structure variée (arithmetique, geometrie, monnaie).
-**Inspiration** : PT-05 cellule 5 (GSM8K sample). **Variante PT-11** : on inclut un probleme
-plus complexe (3 etapes) pour tester l'amelioration reelle sur les cas non-triviaux.
-
-**Honnetete** : 10 problemes = insuffisant pour multi-seed >= 4 et edge >= 2σ (cf G.2). Ce
-dataset est un **proof-of-concept** du pipeline RLVR, PAS une evaluation rigoureuse (cf verdict
-final, cellule 14).",,,,,,,,b6a1509fbb68eba4,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,21936bba,code,fr,dbc924c68ce9082e,"from datasets import Dataset
 
 GSM8K_SAMPLE_PT11 = [
@@ -5052,18 +4974,6 @@ dataset_rlvr = format_for_grpo(GSM8K_SAMPLE_PT11)
 print(f""Dataset RLVR PT-11 : {len(dataset_rlvr)} problemes avec ground truths verifiables"")
 for i in range(3):
     print(f""  Q{i+1}: {dataset_rlvr[i]['prompt'][0]['content'][:60]}... -> {dataset_rlvr[i]['answer']}"")",,,,,,,,dbc924c68ce9082e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,7869072c,markdown,fr,d34fb5b840106685,"### Exercice 2 : ajouter 5 problemes de geometrie
-
-Le dataset actuel est 100% arithmetique. Ajouter 5 problemes de **geometrie** (aire, perimetre,
-volume) pour augmenter la variete du training et tester la generalisation du verifier.
-
-**Objectif** : `creer_dataset_geometrie()` retourne une liste de 5 problemes formates comme
-`GSM8K_SAMPLE_PT11`.
-
-**Indices** :
-- # Etape 1 : aire triangle (base × hauteur / 2), perimetre cercle (2πr), volume sphere (4/3 πr³)
-- # Etape 2 : utiliser π = 3.14159 ou `math.pi` pour les ground truths
-- # Indice : convertir les floats en arrondi 2 decimales pour eviter les problemes de tolerance",,,,,,,,d34fb5b840106685,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,ec3dfc70,code,fr,ea98e7f017aa676d,"def creer_dataset_geometrie() -> list:
     """"""TODO etudiant : creer 5 problemes de geometrie avec ground truths verifiables.""""""
     problemes = []
@@ -5072,19 +4982,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,ec3
     return problemes
 
 print(""Exercice a completer : dataset geometrie"")",,,,,,,,ea98e7f017aa676d,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,f17b4f6e,markdown,fr,0d12551d0416263a,"## 6. Wrap rewardspy.watch ONLINE — detecteur reward hacking LIVE
-
-`rewardspy.watch` instrumente **en ligne** chaque appel de la reward function. Le detecteur
-analyse la **distribution** des rewards sur la fenetre glissante (window_size=20 par defaut)
-et leve une **alerte** si :
-- **ceiling** : > 85% des rollouts au plafond (suspicion memorisation)
-- **variance_collapse** : variance de reward effondree (mode collapse)
-- **stagnation** : pas de progression sur la fenetre
-
-**C'est exactement le detecteur Goodhart mandate par le user** dans #10289 (« *on a meme
-integre un detecteur de reward hacking dont on se sert dans ICT* »). La traçabilité est
-**ONLINE** : chaque rollout est enregistré avec timestamp, et la decision du detecteur est
-posée dans la même session GRPO.",,,,,,,,0d12551d0416263a,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,46b6baf0,code,fr,5188a368177f2f66,"import rewardspy
 from rewardspy.integrations import watch_trl
 from pathlib import Path
@@ -5166,10 +5063,6 @@ print(f""  - sensitivity = 'medium'"")
 print(f""  - max_reward = 1.0 (plafond outcome reward)"")
 print(f""  - detect = True (reward hacking detector LIVE, export JSONL -> {_REWARD_LOG})"")
 print(f""  - journal groupes informatifs par step (#10603) -> {_INFORMATIVE_LOG}"")",,,,,,,,5188a368177f2f66,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,c8c96e51,markdown,fr,58a98e825a7393ed,"### 6.1 Sanity check : rewardspy detecte-t-il bien les patterns reward hacking ?
-
-Test rapide en CPU-safe : simuler 3 scenarios de reward (stable, collapse, spike) et verifier
-que le detecteur leve les bonnes alertes. Cela valide l'instrumentation avant le training reel.",,,,,,,,58a98e825a7393ed,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,29cf38c3,code,fr,a734d875d5fe584d,"import numpy as np
 
 if not LOAD_MODEL_AND_TRAIN:
@@ -5199,27 +5092,6 @@ if not LOAD_MODEL_AND_TRAIN:
     print(""Sanity check rewardspy OK."")
 else:
     print(""(Skip sanity check en mode TRAINING)"")",,,,,,,,a734d875d5fe584d,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,ab92adb7,markdown,fr,f01a86c73fb973b1,"## 7. Configuration GRPO pour RLVR sur Qwen3.5-0.8B
-
-**Parametres cles** (calibres sur RTX 3070, 8.59 Go VRAM, correction #10603) :
-- **num_generations = 8** : group size G=8 = la valeur par defaut TRL. A G=2, ~30 %
-  des groupes sont homogenes (std reward == 0) => avantage GRPO nul => gradient
-  nul (~30 steps sur 100 seulement portaient du signal, mesure p=0.1819). A G=8,
-  la fraction de groupes informatifs est estimee a ~80 % (mesure dans ce notebook,
-  journalisee par step via `_log_informative_groups`).
-- **per_device_train_batch_size = 8** : DOIT etre divisible par num_generations
-  (contrainte GRPOConfig : batch effectif = num_processes x per_device_batch x
-  grad_accum, divisible par G). 8 % 8 == 0.
-- **gradient_accumulation_steps = 1** : batch effectif 8 == G (pas de compromis
-  signal/wallclock comme en G=2 ou 2x2=4)
-- **max_completion_length = 96** : courtes completions (math concis), meme valeur
-  que le run G=2 (comparaison de la densite de signal a longueur egale)
-- **learning_rate = 5e-6** : valeur PT-05 (signal verifiable plus precis donc
-  moins de risque d'overshoot)
-- **beta = 0.0** : DAPO (beta>0 = crash peft#3340 sur trl1.9.2/tf5.x ; beta=0
-  supprime le KL et rend la loss ~0 par construction — le gradient, lui, est non nul)
-- **max_steps = 100** : acceptance #10289 exige >= 100 steps
-- **bf16 = True** : pas de fp32 (gain memoire x2 sans perte de qualite verifiable)",,,,,,,,f01a86c73fb973b1,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,7a694acc,code,fr,2347444952be3df3,"GRPO_CONFIG_DICT = {
     ""num_generations"": 8,              # #10603 : G=8 = defaut TRL, ~80% groupes informatifs vs ~30% a G=2
     ""beta"": 0.0,                       # DAPO (beta>0 = crash peft#3340 sur trl1.9.2/tf5.x ; beta=0 supprime KL)
@@ -5241,11 +5113,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,7a6
 print(""Configuration GRPO RLVR (compatible trl 1.9.2, G=8 #10603) :"")
 for k, v in GRPO_CONFIG_DICT.items():
     print(f""  {k} = {v}"")",,,,,,,,2347444952be3df3,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,75fe3220,markdown,fr,aa739f9f825fdc7b,"## 8. Chargement modele Qwen3.5-0.8B + QLoRA 4-bit
-
-**Chargement en 4-bit** (NF4 + double quant + bf16 compute) : ~1.5 Go VRAM resident base.
-**LoRA r=8, alpha=16** sur q/k/v/o/gate/up/down_proj (couverture complete MLP+attention).
-**Trainable params** : ~1.5M (sur 0.8B total) ≈ 0.19% — typique d'un RL post-training.",,,,,,,,aa739f9f825fdc7b,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,21c7d28d,code,fr,fa43166230cafaee,"import os
 MODEL_NAME = os.path.expanduser(""~/models/qwen35-0.8b"")  # Local (evite WinError 1314 symlink HF cache)
 
@@ -5253,13 +5120,6 @@ print(f""Chargement modele {MODEL_NAME} + QLoRA 4-bit..."")
 print(f""  Architecture : Qwen3.5-0.8B (classe Qwen3_5ForCausalLM, chemin texte via AutoModelForCausalLM)"")
 print(f""  License : Apache 2.0"")
 print(f""  VRAM mesuree (4-bit NF4) : ~0.8 Go"")",,,,,,,,fa43166230cafaee,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,52480a27,markdown,fr,a3ecec0b2cb8d98d,"## 9. Training RLVR reel (≥100 steps)
-
-**C'est le coeur du notebook** : GRPOTrainer avec reward verifiable wrap par rewardspy.watch.
-**Trace post-training** : loss, reward moyenne, KL divergence par step, temps par step.
-
-**Chronometre** : on capture wallclock pour le verdict final (acceptance #10289 : nommer
-machine + cout GPU reels).",,,,,,,,a3ecec0b2cb8d98d,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,dc301f63,code,fr,98358fd7fec31d08,"if LOAD_MODEL_AND_TRAIN and CUDA_AVAILABLE:
     from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
     from trl import GRPOTrainer, GRPOConfig
@@ -5349,14 +5209,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,dc3
 else:
     print(""Skip training : LOAD_MODEL_AND_TRAIN=False ou pas de CUDA"")
     print(""Pour executer : passer LOAD_MODEL_AND_TRAIN=True et GPU avec >= 4 Go VRAM."")",,,,,,,,98358fd7fec31d08,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,e083fab0,markdown,fr,a16517b6d9caa925,"## 10. Courbe de reward reelle
-
-Trace matplotlib de la reward moyenne par groupe au fil des steps. **Veritable reception** :
-- Reward qui monte = emergence d'un comportement (chain-of-thought ou memorisation)
-- Reward plate = le modele n'apprend pas (verdict INCONCLUSIVE)
-- Reward qui s'effondre = mode collapse (alerte rewardspy `variance_collapse` attendue)
-
-**Sauvegarde portable** : PNG tracke sous `MyIA.AI.Notebooks/GenAI/PostTraining/pt11_grpo_reward_curve.png`",,,,,,,,a16517b6d9caa925,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,b97098c9,code,fr,fc7c9933c32779eb,"import matplotlib.pyplot as plt
 from pathlib import Path
 
@@ -5425,11 +5277,6 @@ else:
     plt.savefig(png_path, dpi=100, bbox_inches='tight')
     print(f""Figure synthetique sauvegardee : {png_path}"")
 plt.show()",,,,,,,,fc7c9933c32779eb,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,a4307b38,markdown,fr,94757cd3b7288a60,"## 11. Evaluation pre/post training — accuracy sur le dataset
-
-On sample le dataset avec le modele **avant** et **apres** training, et on compare les
-accuracies. **Verdict final** : `accuracy_post - accuracy_pre` doit etre ≥ random variation
-sinon le training n'a rien appris (et c'est Honnete de le dire).",,,,,,,,94757cd3b7288a60,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,22e8677f,code,fr,73461f768656bd9f,"if LOAD_MODEL_AND_TRAIN and CUDA_AVAILABLE:
     @torch.no_grad()
     def eval_accuracy(model, tokenizer, dataset, n=10):
@@ -5456,16 +5303,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,22e
     print(f""Accuracy post-training : {acc_post:.2%}"")
 else:
     print(""Skip eval : LOAD_MODEL_AND_TRAIN=False ou pas de CUDA"")",,,,,,,,73461f768656bd9f,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,53ae50a3,markdown,fr,9fcfe6e422abb939,"## 12. Verdict honnete — bilan measurable + signal Goodhart
-
-**Acceptance #10289** : verdict **honnête** sur la convergence (standard: PT-03 « DPO n'a pas
-convergé »). Pas de claim embryonnaire. Les 4 critères verifies :
-
-1. **Modèle SOTA** : Qwen3.5-0.8B chargeable, pas de MLP jouet. ✓ (PT-03 patron).
-2. **Outputs C.2** : courbe de reward reelle ≥ 100 steps, `execution_count != null`. ✓ (issu trainer).
-3. **Rewardspy ONLINE** : au moins 1 signal Goodhart OU documentation honnete du seuil. ✓ (test sanity OK).
-4. **Verdict honnete** : publie l'accuracy atteinte, sans embellir. ✓ (presente ci-dessous).
-5. **Machine + GPU nommes** : RTX 3070, 8.59 Go, mem peak observe. ✓ (voir tableau).",,,,,,,,9fcfe6e422abb939,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,f0772a87,code,fr,0333ab7b822f1abf,"print(""=""*70)
 print("" VERDICT PT-11 — RLVR sur Qwen3.5-0.8B (G=8, #10603) "")
 print(""=""*70)
@@ -5525,20 +5362,6 @@ else:
 print(""=""*70)
 print(""FIN VERDICT"")
 print(""=""*70)",,,,,,,,0333ab7b822f1abf,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,49bbea9e,markdown,fr,192dd5ba59391fd3,"### Exercice 3 : comparer GRPO heuristique vs RLVR sur un meme probleme
-
-Le notebook PT-04 utilise un reward **heuristique** (longueur + mots-cles). Le notebook
-PT-11 utilise un reward **verifiable** (SymPy exact). Comparer les deux : entrainer le meme
-modele (Qwen3.5-0.8B) avec chacun et mesurer la difference d'accuracy finale.
-
-**Objectif** : Implementer `heuristic_reward(completion, ground_truth)` qui retourne
-0.0-1.0 selon la presence de mots-cles (therefore, answer) et la longueur, et comparer
-visuellement les courbes de reward.
-
-**Indices** :
-- # Etape 1 : score = 0.5 si 'therefore' ou 'answer' présent, +0.3 si longueur > 50 chars, +0.2 si match
-- # Etape 2 : comparer en lancant 2 trainings de 50 steps et en plotant les 2 courbes
-- # Indice : le reward heuristique est BROUILLARD, le reward verifier est EXACT — la difference est pedagogique",,,,,,,,192dd5ba59391fd3,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,19255fbf,code,fr,58e32593bcae24b5,"def heuristic_reward(completion: str, ground_truth: float) -> float:
     """"""TODO etudiant : reward heuristique (PT-04 style) pour comparaison.""""""
     score = 0.0
@@ -5554,38 +5377,6 @@ MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,192
     return min(score, 1.0)
 
 print(""Exercice a completer : comparer heuristique vs verifier sur training reel"")",,,,,,,,58e32593bcae24b5,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,9f339399,markdown,fr,ae00d30e98016d7b,"---
-
-## Bilan — RLVR sur vrai LLM : de la promesse theorique au pipeline executable
-
-PT-11 transpose le **patron PT-05** (RLVR pedagogique) sur un **vrai LLM SOTA** (Qwen3.5-0.8B)
-execute **réellement** sur RTX 3070, avec :
-
-1. **Verifier Tier 1 (SymPy)** — outcome reward exact, zero bruit
-2. **Verifier Tier 2 (Z3)** — extension logique/combinatoire (N-queens)
-3. **rewardspy.watch ONLINE** — detecteur reward hacking (ceiling, variance_collapse)
-4. **GRPOTrainer production** — pas de mock, vrai training avec bf16 + QLoRA
-5. **Verdict honnete** — accuracy mesuree pre/post, alertes observees, machine specifiee
-
-**Position dans le track GenAI/PostTraining** : PT-11 est le **chainon manquant** entre
-PT-08/09/10 (toy env from-scratch, pedagogique) et PT-12 (futur, 2B + SAE — lane ai-01 GPU 2).
-Il valide que le pipeline RLVR reel tient sur hardware 8 Go et produit un signal detectable.
-
-**Limites assumées** :
-- 10 problemes GSM8K = insuffisant pour multi-seed >= 4 (cf G.2, regle hard ML)
-- 100 steps = limite basse du plancher acceptance ; multi-epoch viable mais necessite SFT warmup
-- Verdict ponctuel (single seed) — pas de BEATS/NO BEATS ferme, INCONCLUSIVE honnete
-
-**Pour aller plus loin** :
-- **PT-12** (futur) : 2B post-entraine + SAE lecture bf16, lane ai-01 GPU 2 (24 Go libres)
-- **Entrainement multi-seed** : 4 seeds × 100 steps pour BEATS/NO BEATS ferme (cf regle C)
-- **Curriculum** : warmup SFT sur 50 exemples avant RL pour eviter reward sparsity (Pitfall 2)",,,,,,,,ae00d30e98016d7b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb,6b19959a,markdown,fr,e4f20bbe2d390d56,"## 13. Transition vers PT-12 — Sparse Autoencoder + 2B post-entraine
-
-PT-12 (futur, lane ai-01 GPU 2) transpose le pipeline PT-11 sur un modele 2B post-entraine
-avec un **Sparse Autoencoder (SAE)** pour l'interpretabilite des features emergents. Lecture
-SAE = **bf16** obligatoire (cf regle F + future PR PT-12). Le present PT-11 pose les
-fondations : patron GRPO + verifier + rewardspy, complet et reproductible.",,,,,,,,e4f20bbe2d390d56,,,,,,,,
 MyIA.AI.Notebooks/GenAI/PostTraining/PT_11b_multiseed_qwen35_4x100.ipynb,d3623b0a,code,fr,6068f994663d93ed,"# 9.bis Load JSONL multi-seed depuis disk (post-training)
 # Permet la re-execution des cellules d'analyse (26/28/30) sans relancer
 # le training (charge ~32 min/seed x 4 seeds). Le JSONL est append-only pendant

--- a/translations/genai/texte.csv
+++ b/translations/genai/texte.csv
@@ -14106,26 +14106,6 @@ Le dataset a été créé avec succès. Analysons sa structure :
 - **Seed fixe** (`np.random.seed(42)`) : Assure la reproductibilité des résultats
 
 Ce dataset servira de base pour démontrer les capacités d'analyse du Code Interpreter dans les cellules suivantes.",,,,,,,,ebc485c29ba31170,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb,91822051,markdown,fr,f693fd781d846ebe,"### Interprétation des résultats d'analyse
-
-L'assistant a automatiquement :
-
-1. **Chargé le CSV** : Reconnaissance automatique du format et des colonnes
-2. **Calculé les statistiques** : Moyenne, médiane, écart-type sans code manuel
-3. **Agrégé par dimensions** : Totaux par région et par produit avec pandas
-4. **Analysé la tendance** : Comparaison temporelle première/dernière semaine
-
-**Avantages clés** :
-- ✅ **Zéro code manuel** : Simple prompt en langage naturel
-- ✅ **Formatage intelligent** : Résultats structurés et lisibles
-- ✅ **Adaptabilité** : Fonctionne avec n'importe quel CSV similaire
-- ✅ **Explications incluses** : L'assistant interprète les chiffres
-
-**Note importante** : avec un véritable Code Interpreter OpenAI, le code généré par
-le modèle s'exécute dans un sandbox sécurisé et l'utilisateur ne voit que les résultats.
-Dans l'exécution committée ici (mode local fallback), le code pandas/numpy est visible
-dans la cellule source — le comportement observé est donc l'alternative locale, qui
-reproduit fidèlement les résultats qu'aurait produits le Code Interpreter.",,,,,,,,f693fd781d846ebe,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb,ac37b8a0,markdown,fr,75a36fadeb70dea9,"### Téléchargement et visualisation des images
 
 Le Code Interpreter génère les graphiques comme fichiers PNG dans le sandbox. Ces images sont :
@@ -14280,49 +14260,6 @@ Pour une exécution réelle dans le sandbox OpenAI (Code Interpreter), il faut u
 l'API OpenAI directe plutôt que le routage OpenRouter.
 
 **Note importante (sandbox)** : avec un véritable Code Interpreter OpenAI, le code généré par le modèle s'exécute dans un sandbox sécurisé et l'utilisateur ne voit que les résultats. Dans l'exécution committée ici (mode local fallback), le code pandas/numpy est visible dans la cellule source — le comportement observé est donc l'alternative locale, qui reproduit fidèlement les résultats qu'aurait produits le Code Interpreter.",,,,,,,,9812413d64d82c23,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb,7ceae636,markdown,fr,5b8cd786799dc27a,"### Interprétation de la solution
-
-Le système d'équations linéaires a été résolu avec **numpy.linalg.solve()**.
-
-**Processus mathématique** :
-1. Représentation matricielle : `Ax = b`
-   - Matrice A (coefficients) : 3x3
-   - Vecteur b (résultats) : 3x1
-2. Résolution : `x = A⁻¹ × b` (inversion matricielle)
-3. Validation : Vérifier que `Ax = b`
-
-**Applications pratiques** :
-- Économie : Équilibres de marché
-- Physique : Lois de conservation
-- Ingénierie : Circuits électriques, structures
-- Optimisation : Points critiques
-
-**Alternative** : Pour des systèmes plus complexes (non-linéaires), on utilise `scipy.optimize` ou des méthodes itératives.",,,,,,,,5b8cd786799dc27a,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb,41ac62ff,markdown,fr,be79634125d90c11,"### Interprétation des tests statistiques
-
-Les résultats de l'analyse statistique permettent de répondre à plusieurs questions clés :
-
-**1. Test de Shapiro-Wilk (normalité)** :
-- **H0** : Les ventes suivent une distribution normale
-- **Interprétation** : Si p > 0.05 → distribution normale, sinon non-normale
-- **Impact** : Détermine quels tests statistiques sont appropriés
-
-**2. ANOVA (comparaison régions)** :
-- **H0** : Les moyennes de ventes sont identiques entre régions
-- **Interprétation** : Si p < 0.05 → différences significatives entre régions
-- **Usage** : Identifier les régions performantes/sous-performantes
-
-**3. Test du Chi-2 (indépendance)** :
-- **H0** : Région et produit sont indépendants
-- **Interprétation** : Si p < 0.05 → certaines régions préfèrent certains produits
-- **Usage** : Ciblage marketing, gestion des stocks
-
-**4. Corrélation temporelle** :
-- **Coefficient r** : Force et direction de la relation linéaire
-- **Interprétation** : |r| proche de 1 → forte corrélation, proche de 0 → faible
-- **Usage** : Détection de tendances (croissance/déclin)
-
-**Note méthodologique** : Le seuil α = 0.05 (95% de confiance) est standard en sciences sociales. Pour des décisions critiques, utilisez α = 0.01 (99%).",,,,,,,,be79634125d90c11,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb,ceb24535,markdown,fr,f6b8a8344130014e,"## Génération de visualisations
 
 Le Code Interpreter peut créer des graphiques avec matplotlib, seaborn ou plotly. Les images générées sont accessibles via l'API.",,,,,,,,f6b8a8344130014e,,,,,,,,

--- a/translations/genai/video.csv
+++ b/translations/genai/video.csv
@@ -2990,9 +2990,6 @@ run_upscaling = True               # Executer l'upscaling
 compute_metrics = True             # Calculer PSNR/SSIM
 save_results = True
 ",,,,,,,,d88d957676dc4105,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb,5cabb31a,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb,b4cau229bbs,markdown,fr,cea5b03871acef7d,"Les paramètres sont définis. La cellule suivante configure l'environnement Python : imports, detection du chemin GenAI, chargement du `.env` et verification de la disponibilite de Real-ESRGAN.",,,,,,,,cea5b03871acef7d,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb,cell-2,code,fr,ca481eddd4dde0b3,"# Import guards - verification des dependances
 try:
@@ -4984,9 +4981,6 @@ run_generation = True              # Executer la generation
 save_as_mp4 = True                 # Sauvegarder en MP4
 save_results = True
 ",,,,,,,,4c6fba4aefc30bba,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb,1c2315b2,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb,lo8o3p2kbq,markdown,fr,a1e903c4b838f1ce,"Les paramètres Papermill configures, on importe maintenant le client ComfyUI qui permettra de communiquer avec le serveur HunyuanVideo. Un fallback est prevu si le helper n'est pas disponible dans l'environnement courant.",,,,,,,,a1e903c4b838f1ce,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb,cell-2,code,fr,880831e6938322ad,"# Import helpers GenAI (setup du path shared/helpers)
 # Miroir du pattern canonique de 02-3-Wan-Video-Generation.ipynb
@@ -6129,9 +6123,6 @@ run_img2vid = True                 # Tester image-to-video
 save_as_mp4 = True                 # Sauvegarder en MP4
 save_results = True
 ",,,,,,,,aa62658284702950,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb,627f8e41,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb,ca225672,markdown,fr,6bd621e955973242,"## Setup de l'environnement
 
 Installation des dependances, chargement de la configuration depuis , et verification de la disponibilite GPU.",,,,,,,,6bd621e955973242,,,,,,,,
@@ -7247,9 +7238,6 @@ fps_output = 16                    # FPS de la video de sortie
 run_generation = True              # Executer la generation
 save_results = True
 ",,,,,,,,74f737469f92738c,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb,51876294,code,fr,d7a1ea74a47bcb51,"# Parameters
-BATCH_MODE = True
-",,,,,,,,d7a1ea74a47bcb51,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb,n5z05qy88ao,markdown,fr,8dfc8aa3f7a42e02,"Les paramètres Papermill initialises, la cellule suivante installe les dependances requises et importe les bibliotheques necessaires : diffusers pour le pipeline Wan, torch pour l'acceleration GPU, et les utilitaires de gestion des fichiers video.",,,,,,,,8dfc8aa3f7a42e02,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb,8f09a5ea,code,fr,8f4d58f9acc3ca2a,"# Setup environnement et imports
 import os
@@ -9226,9 +9214,6 @@ simple reste statique. C'est ce que l'**Exercice 1** (`compare_image_categories`
 explore : comparer l'amplitude de mouvement générée sur des catégories d'images de
 textures croissantes.
 ",,,,,,,,d468f08ee1d9c2a8,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb,2ad9398f,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb,ltx2-00,markdown,fr,33e0c98ad4ba9c0a,"# LTX-2 - Generation Audiovisuelle Conjointe (Video + Audio)
 
 **Module :** 02-Video-Advanced
@@ -10219,9 +10204,6 @@ guidance_scale = 6.0               # Valeur par defaut informative (CFG classiqu
 run_benchmark = True               # Executer le benchmark
 save_as_mp4 = True                 # Conserver les MP4 telecharges cote notebook
 save_results = True",,,,,,,,94ab717dcd847deb,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb,950456c5,code,fr,d8cfd07b7b0f3965,"# Parameters
-BATCH_MODE = ""true""
-",,,,,,,,d8cfd07b7b0f3965,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb,v9rfo38sg48,markdown,fr,693f9e47189797b9,"On importe ensuite toutes les bibliotheques necessaires : diffusers pour les modèles de generation, numpy et PIL pour la manipulation des frames, et les outils de mesure de performance.",,,,,,,,693f9e47189797b9,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb,cell-setup,code,fr,d6980a441e783f22,"# Setup environnement et imports
 import os
@@ -15360,110 +15342,6 @@ MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipyn
 La creation d'un clip musical synchronise implique de detecter le rythme (BPM)
 et de placer des coupes, effets et transitions sur les temps forts.
 Ici, nous simulons un signal audio rythmique et synchronisons les effets video.",,,,,,,,f141e5ff9182a065,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb,cell-7,code,fr,77d4ef087f453376,"# Creation de clip musical avec synchronisation
-if enable_music_video:
-    print(""\n--- CREATION CLIP MUSICAL ---"")
-    print(""="" * 40)
-    
-    # Simuler la detection de beats (BPM = 120)
-    bpm = 120
-    beat_interval = 60.0 / bpm  # Secondes entre chaque beat
-    total_seconds = video_duration
-    
-    # Generer les positions des beats
-    beat_times = np.arange(0, total_seconds, beat_interval)
-    beat_frames = (beat_times * video_fps).astype(int)
-    beat_frames = beat_frames[beat_frames < len(source_frames)]
-    
-    print(f""BPM simule : {bpm}"")
-    print(f""Intervalle entre beats : {beat_interval:.3f}s"")
-    print(f""Nombre de beats : {len(beat_frames)}"")
-    print(f""Positions (frames) : {beat_frames.tolist()}"")
-    
-    # Effets synchronises sur les beats
-    def apply_beat_flash(frame: np.ndarray, intensity: float = 0.5) -> np.ndarray:
-        """"""Flash lumineux sur un beat.""""""
-        flash = np.full_like(frame, 255)
-        return np.clip(frame * (1 - intensity) + flash * intensity, 0, 255).astype(np.uint8)
-    
-    def apply_beat_zoom(frame: np.ndarray, zoom_factor: float = 1.15) -> np.ndarray:
-        """"""Effet zoom leger sur un beat.""""""
-        h, w = frame.shape[:2]
-        img = Image.fromarray(frame)
-        
-        # Zoom au centre
-        new_w = int(w * zoom_factor)
-        new_h = int(h * zoom_factor)
-        img_zoomed = img.resize((new_w, new_h), Image.LANCZOS)
-        
-        # Recadrer au centre
-        left = (new_w - w) // 2
-        top = (new_h - h) // 2
-        img_cropped = img_zoomed.crop((left, top, left + w, top + h))
-        
-        return np.array(img_cropped)
-    
-    # Appliquer les effets avec decroissance
-    music_frames = [f.copy() for f in source_frames]
-    beat_decay_frames = 3  # Nombre de frames pour l'attenuation de l'effet
-    
-    for beat_frame in beat_frames:
-        for offset in range(beat_decay_frames):
-            idx = beat_frame + offset
-            if idx >= len(music_frames):
-                break
-            decay = 1.0 - (offset / beat_decay_frames)
-            # Alterner flash et zoom
-            if (np.where(beat_frames == beat_frame)[0][0]) % 2 == 0:
-                music_frames[idx] = apply_beat_flash(music_frames[idx], 0.4 * decay)
-            else:
-                zoom = 1.0 + 0.1 * decay
-                music_frames[idx] = apply_beat_zoom(music_frames[idx], zoom)
-    
-    print(f""Effets appliques sur {len(beat_frames)} beats"")
-    
-    # Visualiser quelques beats
-    if len(beat_frames) >= 3:
-        fig, axes = plt.subplots(2, 3, figsize=(14, 6))
-        for col in range(3):
-            b_idx = beat_frames[col]
-            axes[0, col].imshow(source_frames[b_idx])
-            axes[0, col].set_title(f""Original (beat {col+1}, frame {b_idx})"", fontsize=9)
-            axes[0, col].axis('off')
-            axes[1, col].imshow(music_frames[b_idx])
-            axes[1, col].set_title(f""Avec effet"", fontsize=9)
-            axes[1, col].axis('off')
-        plt.suptitle(f""Effets synchronises sur les beats ({bpm} BPM)"", fontsize=13, fontweight='bold')
-        plt.tight_layout()
-        plt.show()
-    
-    if dependencies.get('imageio', False) and save_results:
-        music_path = OUTPUT_DIR / ""creative_music_video.mp4""
-        writer = imageio.get_writer(str(music_path), fps=video_fps, codec='libx264')
-        for f in music_frames:
-            writer.append_data(f)
-        writer.close()
-        print(f""Video sauvegardee : {music_path.name} ({music_path.stat().st_size / 1024:.0f} KB)"")
-else:
-    print(""Creation clip musical desactivee"")",,,,,,,,77d4ef087f453376,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb,cell-8,markdown,fr,e9ca6f03a81247cf,"### Interpretation : Clip musical
-
-| Aspect | Valeur | Signification |
-|--------|--------|---------------|
-| BPM | 120 | Rythme moyen (pop/dance) |
-| Intervalle beats | 0.5s | Un beat toutes les 12 frames a 24fps |
-| Effets | Flash + Zoom | Alternance pour varier le rythme visuel |
-| Decay | 3 frames | Attenuation progressive de l'effet |
-
-**Points cles** :
-1. En production, le BPM serait detecte par analyse audio (librosa.beat)
-2. L'attenuation progressive donne un rendu plus naturel que des effets instantanes
-3. La synchronisation audio-video est critique : 1 frame de decalage est perceptible
-
-## Section 3 : Effet stop-motion et color grading
-
-L'effet stop-motion simule une animation image par image en reduisant le taux de frames
-et en ajoutant des imperfections. Le color grading transforme l'ambiance de la video.",,,,,,,,e9ca6f03a81247cf,,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb,cell-9,code,fr,4f01313494597b6f,"# Effet stop-motion
 if enable_stop_motion:
     print(""\n--- EFFET STOP-MOTION ---"")


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #13700

## Defect mesure (firsthand, main `2920decf99`)

Le constat de #13546 etait toujours vivant a la verification de ce cycle :
- `translations/genai/finetuning.csv` portait **41 lignes orphelines** (FT-04 : 20, FT-05 : 21 — dont `a1b2c3d0`, `c3d4e5f2`, `7e384d22` exactement ceux nommes dans l'issue)
- `render_notebook.py:253` ne faisait que `WARN ... -> .stale` (aucun exit non nul possible)
- `check_translation_sync.py --check` rapporte `ORPHAN_ROW` mais est **exit 0 par design** (CI non-bloquant)

Le label `candidate-delivered` (pose par co-occurrence avec #13542, sujet distinct T2/T3/T4) a ete retire avec preuve ce cycle.

## Livrable

**1. Purge des lignes orphelines — tout `translations/genai/` (perimetre du titre de l'issue)** :

| CSV | lignes | purgees |
|---|---|---|
| finetuning.csv | 196 -> 155 | 41 |
| audio.csv | 1183 -> 1149 | 34 |
| posttraining.csv | 318 -> 298 | 20 |
| video.csv | 584 -> 576 | 8 |
| image.csv | 558 -> 554 | 4 |
| texte.csv | 766 -> 763 | 3 |
| casestudies.csv | 133 | 0 (deja propre) |
| **total** | | **110** |

Perte nulle par construction : les CSV courants sont des extractions (`text_fr` + `src_hash`, pas de colonne `text_en` a perdre) ; une ligne orpheline reference une cellule **supprimee** du notebook source.

**2. Gate `--fail-on-stale` dans `render_notebook.py`** (miroir du pattern `--require-translated` #10349) : orphelins presents -> `ValueError` **avant l'ecriture atomique** (aucun fichier partiel, aucun sidecar ecrit). Default off : le contract WARN + sidecar est preserve (#10039 critere 3).

**3. Cablage** : l'invocation T4 de `translation-sync.yml` passe `--fail-on-stale` — le moteur de livraison (dispatch-gate, hold user #10038) bloque desormais sur orphelins au lieu de les traverser en silence.

**4. Tests** (falsification, style du fichier) : `fail_on_stale` + orphelin -> raise + rien ecrit ; sans orphelin -> rendu normal ; default -> contract WARN + `.stale` inchange.

## Validation (post-dernier-commit)

- `python -m pytest scripts/translation/tests/ -q` : **362 passed, 2 skipped** (25 + 3 nouveaux sur render_notebook)
- `python scripts/translation/check_translation_sync.py translations/genai --check` : **0 ORPHAN_ROW residuel** (69 avant)
- Smoke test end-to-end : `render_notebook.py --csv finetuning.csv --notebook FT-04 --lang en --dry-run --fail-on-stale` -> `orphans: 0`, exit 0
- `translation-sync.yml` : parse YAML OK
- Diff CSV = **deletions pures** (0 insertion) : les lignes conservees sont byte-identiques

## Decouverte preexistante signalee (non traitee ici, one-subject)

Le meme balayage sur `translations/` **complet** compte encore **~2200 ORPHAN_ROW** dans les AUTRES familles (gametheory, iit, ml-datascience, mlnet, planners, probas-*, quantconnect...) — hors perimetre GenAI de cette issue. La classe de defeut est identique (extractions stale apres suppression de cellules) ; a traiter par famille en grains separes.

## Note C.2

Aucun notebook touche (CSV de traduction + scripts + workflow uniquement) — pas de re-execution requise.

Closes #13546
