### PR TITLE
fix(gametheory): make Axelrod bridge portable

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust-Csharp.ipynb
@@ -86,146 +86,47 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-28524.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '28524.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": []
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Matrice : T=5, R=3, P=1, S=0"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Condition T > R > P > S : True"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Condition 2R > T + S    : True (6 > 5)"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Si les deux conditions tiennent, la cooperation mutuelle (R,R) est Pareto-optimale et stable a l'itere."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -287,13 +188,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "7 strategies IPD definies : AlwaysCooperate, AlwaysDefect, TitForTat, SuspiciousTFT, Grudger, Pavlov, Random."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -372,31 +273,31 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "TitForTat vs AlwaysDefect (200 tours) : TFT=199, AllD=204"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Gain moyen/tour : TFT=0,99, AllD=1,02"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "-> AllD gagne le match (score plus haut), mais TFT limite les degats grace a la retaliation."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -451,15 +352,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Trace TitForTat vs SuspiciousTFT (20 tours) :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Tour | TitForTat        | SuspiciousTFT    | Gain cumule (TitForTat/SuspiciousTFT)\r\n",
@@ -488,17 +390,16 @@
        " TOTAL TitForTat=50 (moy 2,50/tour)  |  SuspiciousTFT=50 (moy 2,50/tour)\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "-> SuspiciousTFT commence par D, TFT repond D au tour 2, et les deux s'enferment en defection mutuelle (P,P)."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -548,6 +449,7 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "=== Tournoi sans bruit (200 tours/match) ===\r\n",
@@ -562,17 +464,16 @@
        "   7  | SuspiciousTFT        |      366,9\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Note : au IPD le score le plus HAUT gagne (convention Axelrod). TitForTat gagne en atteignant souvent la cooperation mutuelle (R=3,R=3), meme si AlwaysDefect la bat sur le match individuel (T=5 > S=0)."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -646,6 +547,7 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "=== Tournoi avec bruit (5% erreurs, moyenne sur 5 repetitions) ===\r\n",
@@ -660,19 +562,19 @@
        "   7  | AlwaysCooperate      |      363,0\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Comparaison sans bruit vs bruite :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Strategie            | sans bruit | avec bruit | variation\r\n",
@@ -686,17 +588,16 @@
        " Random               |      393,1 |      399,5 |       6,4\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "-> Les ecarts (variation) confirment : TitForTat (-97,5) et AlwaysCooperate (-110,6) chutent fort sous le bruit (cascades de punition), alors qu'AlwaysDefect (+13,1) beneficie du chaos. Motive GenerousTitForTat (exercice 2)."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -738,15 +639,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Matrice de gains M[i,j] (gain moyen/tour de i contre j) :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "                AlwaysC  AlwaysD  TitForT  Suspici  Grudger   Pavlov   Random \r\n",
@@ -759,8 +661,7 @@
        "Random             3,94     0,47     2,33     2,31     0,49     2,16     2,06 \r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -821,15 +722,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Evolution des frequences (population initiale equipartie 1/7) :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Etape |  Always  Always  TitFor  Suspic  Grudge  Pavlov  Random \r\n",
@@ -841,17 +743,16 @@
        "  400  |    0,19    0,00    0,31    0,00    0,27    0,23    0,00 \r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "-> Strategie dominante a l'equilibre : TitForTat (frequence 0,31)"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -934,15 +835,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Verdict ESS (Maynard Smith) sur la matrice M de la cellule 7 :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Strategie           | ESS ? | detail du test\r\n",
@@ -956,8 +858,7 @@
        " Random              |  NON | envahi par : AlwaysDefect, TitForTat, SuspiciousTFT, Grudger, Pavlov\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1031,15 +932,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Deux etats finaux, meme dynamique (part de depart Grudger 0.091 -> 0.364) :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Survivantes (face neutre) | x0 equipartie 1/7 | x0 Grudger x4 (4/11)\r\n",
@@ -1050,8 +952,7 @@
        " Pavlov                    |              0,23 |           0,14\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1101,15 +1002,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Controle positif Faucon-Colombe (critere et dynamique doivent s'accorder) :"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Regime V=50, C=25 (guerre peu couteuse)\r\n",
@@ -1124,8 +1026,7 @@
        "\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1196,6 +1097,7 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        " Adversaire          | score TFT | score AllD | qui extrait le plus ?\r\n",
@@ -1208,26 +1110,25 @@
        " Random               |       2,31 |       3,12 | AllD (exploite)\r\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Score total (moyen/tour, 6 adversaires) : TFT=14,80  |  AllD=14,14"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "-> TitForTat a un score total plus HAUT (=meilleur, convention Axelrod) qu'AlwaysDefect : sur l'ensemble du pool, la cooperation robuste bat l'exploitation brute. C'est le resultat historique d'Axelrod (1980)."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1292,13 +1193,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Exercice 1 (exploitabilite) : stub a completer."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1340,13 +1241,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Exercice 2 (GenerousTitForTat) : stub a completer."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1389,13 +1290,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Exercice 3 (invasion evolutive) : stub a completer."
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -1458,9 +1359,9 @@
     "\n",
     "Le verdict **INTRINSIC** initial (PR #10406) concluait « pont Python->.NET pas viable » car axelrod est une lib Python pure utilisée exclusivement via `import`. C'était le **même angle mort taxonomique** que celui corrigé pour GT-13/GT-17/Search-7 (#10459) : l'axe **PythonNet** (.NET → `Python.Runtime` → CPython → lib Python) n'avait pas été envisagé. Or axelrod, exactement comme pyspiel/nashpy/ortools, est une lib Python invoquée par `import` — précisément le cas que PythonNet résout.\n",
     "\n",
-    "Cette annexe démontre le pont .NET → CPython 3.11 → **axelrod** (Knight, Glynatsi et al., 200+ stratégies IPD, `Tournament`, `MoranProcess`) et le reclasse donc **INTRINSIC → RECOVERABLE-LOCAL**. Le pont est **EN PLUS, jamais À LA PLACE** (mandat #10382) : l'implémentation from-scratch des sections 3-9 reste la contrepartie pédagogique principale ; le pont prouve seulement que le moteur SOTA de référence est atteignable depuis .NET.\n",
+    "Cette annexe démontre le pont .NET → CPython 3.10+ → **axelrod** (Knight, Glynatsi et al., 200+ stratégies IPD, `Tournament`, `MoranProcess`) et le reclasse donc **INTRINSIC → RECOVERABLE-LOCAL**. Le pont est **EN PLUS, jamais À LA PLACE** (mandat #10382) : l'implémentation from-scratch des sections 3-9 reste la contrepartie pédagogique principale ; le pont prouve seulement que le moteur SOTA de référence est atteignable depuis .NET.\n",
     "\n",
-    "**Prérequis** : `pip install axelrod` (Python pure, léger) + `pythonnet` 3.0.5 (NuGet) + CPython 3.11.9 (`python311.dll`). Variable d'env optionnelle `PYTHONNET_PYDLL` pour pointer vers une DLL CPython alternative."
+    "**Prérequis** : `pip install axelrod` (Python pure, léger) + `pythonnet` 3.1.0 (NuGet) + CPython 3.10+. Le notebook résout automatiquement la bibliothèque CPython (`python3xx.dll` sous Windows, `libpython3.x.so` sous Linux, `libpython3.x.dylib` sous macOS) et ajoute les dépendances natives d'un environnement Conda Windows ; `PYTHONNET_PYDLL` reste disponible pour une installation non standard."
    ]
   },
   {
@@ -1472,52 +1373,124 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>pythonnet, 3.0.5</span></li></ul></div></div>"
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Runtime Python : 3.13.15 (tags/v3.13.15:4061bc4, Aug  5 2026, 13:05:39) [MSC v.1944 64 bit (AMD64)]\r\n"
+      "Runtime Python : 3.13.12 | packaged by Anaconda, Inc. | (main, Feb 24 2026, 16:05:56) [MSC v.1942 64 bit (AMD64)]\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "axelrod 4.14.0 : Tournament(Cooperator, Defector, TitForTat, Grudger), 20 tours x 3 reps\n",
-      "Classement IPD (Defector gagne en finitude -- théorie Axelrod 1980) :\n",
-      "  Defector         scores=[120, 120, 120]\n",
-      "  Tit For Tat      scores=[148, 148, 148]\n",
-      "  Grudger          scores=[139, 139, 139]\n",
-      "  Cooperator       scores=[139, 139, 139]\n",
+      "Classement IPD de cette expérience finie :\n",
+      "  1. Defector         scores=[148, 148, 148]\n",
+      "  2. Tit For Tat      scores=[139, 139, 139]\n",
+      "  3. Grudger          scores=[139, 139, 139]\n",
+      "  4. Cooperator       scores=[120, 120, 120]\n",
       "Match Cooperator vs Defector (10 tours) score/tour : Coop=0.0, Def=5.0\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "PONT .NET -> axelrod : OK -- TitForTat/Grudger (stratégies nice) dominent le round-robin, résultat Axelrod 1980 (TFT champion)\r\n"
+      "PONT .NET -> axelrod : OK -- sur ce petit tournoi fini, Defector gagne ; le tournoi historique plus large d'Axelrod couronne Tit-for-Tat.\r\n"
      ]
     }
    ],
    "source": [
-    "#r \"nuget: pythonnet,3.0.5\"\n",
+    "#r \"nuget: pythonnet,3.1.0\"\n",
     "using System;\n",
     "using Python.Runtime;\n",
     "\n",
-    "// Pont .NET -> CPython 3.11 -> axelrod (annexe évolution IPD, reclassification #10459).\n",
+    "// Pont .NET -> CPython 3.10+ -> axelrod (annexe évolution IPD, reclassification #10459).\n",
     "// axelrod (Knight, Glynatsi et al.) = lib Python pure, 200+ stratégies IPD, Tournament, MoranProcess.\n",
-    "// Pont via pythonnet (NuGet, Python.Runtime) -> CPython 3.11.9 ou axelrod 4.14.0 est installé (pip).\n",
     "// Même axe de pontage que GT-13/GT-17 (pyspiel CFR/rollout) et Search-7 (pyspiel MCTS).\n",
-    "Runtime.PythonDLL = Environment.GetEnvironmentVariable(\"PYTHONNET_PYDLL\") ?? @\"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python311\\python311.dll\";\n",
+    "static string PreparePythonDll(string candidate)\n",
+    "{\n",
+    "    if (!OperatingSystem.IsWindows()) return candidate;\n",
+    "\n",
+    "    var pythonRoot = System.IO.Path.GetDirectoryName(candidate)!;\n",
+    "    var dependencyDirectories = new[] {\n",
+    "        pythonRoot,\n",
+    "        System.IO.Path.Combine(pythonRoot, \"Library\", \"bin\"),\n",
+    "        System.IO.Path.Combine(pythonRoot, \"DLLs\")\n",
+    "    }.Where(System.IO.Directory.Exists);\n",
+    "    var currentPath = Environment.GetEnvironmentVariable(\"PATH\") ?? \"\";\n",
+    "    Environment.SetEnvironmentVariable(\n",
+    "        \"PATH\",\n",
+    "        string.Join(System.IO.Path.PathSeparator, dependencyDirectories.Append(currentPath)));\n",
+    "    return candidate;\n",
+    "}\n",
+    "\n",
+    "static string ResolvePythonDll()\n",
+    "{\n",
+    "    var configured = Environment.GetEnvironmentVariable(\"PYTHONNET_PYDLL\");\n",
+    "    if (!string.IsNullOrWhiteSpace(configured) && System.IO.File.Exists(configured))\n",
+    "        return PreparePythonDll(configured);\n",
+    "\n",
+    "    if (OperatingSystem.IsWindows())\n",
+    "    {\n",
+    "        var candidates = new List<string>();\n",
+    "        var localAppData = Environment.GetEnvironmentVariable(\"LOCALAPPDATA\");\n",
+    "        if (!string.IsNullOrWhiteSpace(localAppData))\n",
+    "        {\n",
+    "            var pythonRoot = System.IO.Path.Combine(localAppData, \"Programs\", \"Python\");\n",
+    "            if (System.IO.Directory.Exists(pythonRoot))\n",
+    "                candidates.AddRange(\n",
+    "                    System.IO.Directory.GetDirectories(pythonRoot, \"Python3*\")\n",
+    "                        .OrderByDescending(path => path)\n",
+    "                        .SelectMany(path => System.IO.Directory.GetFiles(path, \"python3*.dll\")));\n",
+    "        }\n",
+    "\n",
+    "        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);\n",
+    "        foreach (var root in new[] {\n",
+    "                     System.IO.Path.Combine(home, \"miniconda3\"),\n",
+    "                     System.IO.Path.Combine(home, \"anaconda3\"),\n",
+    "                     @\"C:\\ProgramData\\miniconda3\",\n",
+    "                     @\"C:\\ProgramData\\anaconda3\" })\n",
+    "        {\n",
+    "            if (!System.IO.Directory.Exists(root)) continue;\n",
+    "            var versioned = System.IO.Directory.GetFiles(root, \"python3??.dll\");\n",
+    "            candidates.AddRange(versioned.OrderByDescending(path => path));\n",
+    "        }\n",
+    "\n",
+    "        foreach (var candidate in candidates)\n",
+    "            if (System.IO.File.Exists(candidate)) return PreparePythonDll(candidate);\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        foreach (var root in new[] {\n",
+    "                     \"/usr/lib/x86_64-linux-gnu\",\n",
+    "                     \"/usr/lib/aarch64-linux-gnu\",\n",
+    "                     \"/usr/lib\",\n",
+    "                     \"/usr/local/lib\",\n",
+    "                     \"/opt/homebrew/lib\" })\n",
+    "        {\n",
+    "            if (!System.IO.Directory.Exists(root)) continue;\n",
+    "            var candidates = System.IO.Directory.GetFiles(root, \"libpython3.*\")\n",
+    "                .Where(path => path.EndsWith(\".so\") || path.EndsWith(\".dylib\"))\n",
+    "                .OrderByDescending(path => path);\n",
+    "            foreach (var candidate in candidates) return candidate;\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    throw new System.IO.FileNotFoundException(\n",
+    "        \"Bibliothèque CPython introuvable : définir PYTHONNET_PYDLL ou installer CPython 3.10+ avec axelrod.\");\n",
+    "}\n",
+    "\n",
+    "Runtime.PythonDLL = ResolvePythonDll();\n",
     "PythonEngine.Initialize();\n",
     "Console.WriteLine($\"Runtime Python : {PythonEngine.Version}\");\n",
     "\n",
@@ -1530,12 +1503,12 @@
     "tour = axl.Tournament(players, turns=20, repetitions=3, seed=42)\n",
     "with contextlib.redirect_stderr(io.StringIO()):\n",
     "    results = tour.play()\n",
-    "ranked = list(results.ranked_names)\n",
-    "scores = [list(s) for s in results.scores]\n",
     "lines = [f'axelrod {axl.__version__} : Tournament(Cooperator, Defector, TitForTat, Grudger), 20 tours x 3 reps']\n",
-    "lines.append('Classement IPD (Defector gagne en finitude -- théorie Axelrod 1980) :')\n",
-    "for name, sc in zip(ranked, scores):\n",
-    "    lines.append(f'  {name:16s} scores={sc}')\n",
+    "lines.append('Classement IPD de cette expérience finie :')\n",
+    "for rank, player_index in enumerate(results.ranking, start=1):\n",
+    "    name = players[player_index].name\n",
+    "    scores = list(results.scores[player_index])\n",
+    "    lines.append(f'  {rank}. {name:16s} scores={scores}')\n",
     "m = axl.Match((axl.Cooperator(), axl.Defector()), turns=10)\n",
     "m.play()\n",
     "ms = list(m.final_score_per_turn())\n",
@@ -1544,14 +1517,14 @@
     "\");\n",
     "    Console.WriteLine((string)scope.report);\n",
     "}\n",
-    "Console.WriteLine(\"PONT .NET -> axelrod : OK -- TitForTat/Grudger (stratégies nice) dominent le round-robin, résultat Axelrod 1980 (TFT champion)\");"
+    "Console.WriteLine(\"PONT .NET -> axelrod : OK -- sur ce petit tournoi fini, Defector gagne ; le tournoi historique plus large d'Axelrod couronne Tit-for-Tat.\");"
    ]
   }
  ],
  "metadata": {
   "cost": {
    "api_provider": "none",
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "cpu_min": 3,
    "external_account": "none",
    "free_alternative": "self",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust-Csharp.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "**Twin C# (.NET Interactive)** de [GameTheory-06-EvolutionTrust](GameTheory-06-EvolutionTrust.ipynb) — marathon **#4956** (parité .NET ⇄ Python), volet **GameTheory théorie évolutive**, axe-2 SOTA **#3801** Prong B.\n",
     "\n",
-    "Le notebook Python invoque la librairie **`axelrod`** (boîte noire regroupant 200+ stratégies de Dilemme du Prisonnier Itéré) et **numpy/matplotlib** pour les tournois et la dynamique du réplicateur. Ce twin **déroule tout from-scratch** (BCL .NET 9, **0 NuGet**) : le moteur IPD, les stratégies classiques, le tournoi round-robin d'Axelrod, la matrice de gains et la **dynamique du réplicateur** (intégrale d'Euler).\n",
+    "Le notebook Python invoque la librairie **`axelrod`** (boîte noire regroupant 200+ stratégies de Dilemme du Prisonnier Itéré) et **numpy/matplotlib** pour les tournois et la dynamique du réplicateur. Le cœur pédagogique de ce twin **déroule tout from-scratch** (BCL .NET 9, sans NuGet) : moteur IPD, stratégies classiques, tournoi round-robin d'Axelrod, matrice de gains et **dynamique du réplicateur** (intégrale d'Euler). L'annexe invoque ensuite le vrai moteur `axelrod` via PythonNet pour vérifier que la référence SOTA reste atteignable depuis .NET.\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -19,7 +19,7 @@
     "2. Implémenter des **stratégies** classiques (Tit-for-Tat, Grudger, Pavlov, AlwaysC/D, Random).\n",
     "3. Organiser un **tournoi round-robin** (toutes paires, score moyen par match) — l'expérience d'Axelrod (1980).\n",
     "4. Étudier la **dynamique du réplicateur** : comment les fréquences de stratégies évoluent sous sélection (fitness = gain moyen contre la population).\n",
-    "5. Comprendre pourquoi **Tit-for-Tat** (gagnant d'Axelrod) est robuste : ni exploitable, ni exploiteur.\n"
+    "5. Comprendre pourquoi **Tit-for-Tat** (gagnant d'Axelrod) est robuste : ni exploitable, ni exploiteur."
    ]
   },
   {
@@ -62,7 +62,7 @@
     "| Tournoi | `axelrod.Tournament` | **round-robin manuel** |\n",
     "| Replicator | `axelrod`/numpy | **Euler ODE from-scratch** |\n",
     "| Visualisation | `matplotlib` + animation | **tables console + ASCII** |\n",
-    "| Dépendances | axelrod, numpy, matplotlib | **BCL seule, 0 NuGet** |\n"
+    "| Dépendances | axelrod, numpy, matplotlib | **cœur BCL sans NuGet ; annexe PythonNet** |"
    ]
   },
   {
@@ -1322,7 +1322,7 @@
    "source": [
     "## 10. Résumé\n",
     "\n",
-    "Ce twin C# a reconstruit from-scratch (BCL .NET 9, 0 NuGet) toute la mécanique de la théorie des jeux évolutive :\n",
+    "Ce twin C# a reconstruit from-scratch (BCL .NET 9) toute la mécanique de la théorie des jeux évolutive :\n",
     "\n",
     "1. **Moteur IPD** : matrice T>R>P>S, fonction `Payoff`, conditions du dilemme (2R > T+S).\n",
     "2. **7 stratégies** : AlwaysC, AlwaysD, TitForTat, SuspiciousTFT, Grudger, Pavlov (Win-Stay-Lose-Shift), Random.\n",
@@ -1341,11 +1341,11 @@
     "\n",
     "### Référence SOTA\n",
     "\n",
-    "Le twin Python [GameTheory-06-EvolutionTrust](GameTheory-06-EvolutionTrust.ipynb) utilise la librairie **`axelrod`** (200+ stratégies, tournoi, analyse) + **numpy/matplotlib** (animation de la dynamique). Cette lib est l'outil SOTA de recherche en IPD. **Verdict INTRINSIC (bucket-3, #10382)** : `axelrod` est une librairie **Python pure** (Knight, Glynatsi et al.) — aucun binding .NET n'existe (pas de NuGet « Axelrod.NET »), ce n'est **pas un binaire CLI** invocable par `Process.Start` (à la différence de clingo ou Fast Downward qui le sont ; on ne l'utilise que via `import axelrod as axl` / `axl.Tournament` / `axl.Match`), et ce n'est **pas du Java** (IKVM ponte Java, pas Python — à la différence de Tweety qui est bridgeable via IKVM). Le pont Python → .NET n'est donc pas viable. Le from-scratch C# EST la contrepartie légitime et **définitive** : là où Python délègue à `axelrod` (200+ stratégies, tournoi round-robin, analyse), le C# rend visibles les briques qu'elle orchestre (moteur IPD, stratégies, tournoi, ODE du réplicateur), au niveau de parité `semantic`. En production : axelrod. En pédagogie : comprendre chaque brique, from-scratch.\n",
+    "Le twin Python [GameTheory-06-EvolutionTrust](GameTheory-06-EvolutionTrust.ipynb) utilise la librairie **`axelrod`** (200+ stratégies, tournoi, analyse) + **numpy/matplotlib** (animation de la dynamique). Cette lib est l'outil SOTA de recherche en IPD. **Verdict SOTA-OK (#10459)** : l'annexe ci-dessous invoque réellement `axelrod` depuis .NET via PythonNet (`Python.Runtime` → CPython → `axelrod`), tandis que les sections principales conservent l'implémentation from-scratch comme contrepartie pédagogique. Le pont est en plus, jamais à la place : en production, utiliser `axelrod` ; en pédagogie, comprendre chaque brique.\n",
     "\n",
     "***\n",
     "\n",
-    "**Marathon #4956** — twin C# .NET ⇄ Python. Suite de [GameTheory-03-Topology2x2-Csharp](GameTheory-03-Topology2x2-Csharp.ipynb). Voir #4956, #3801. Revue souhaitée : ai-01, po-2024 (GameTheory/.NET owner), po-2025.\n"
+    "**Marathon #4956** — twin C# .NET ⇄ Python. Suite de [GameTheory-03-Topology2x2-Csharp](GameTheory-03-Topology2x2-Csharp.ipynb). Voir #4956, #3801. Revue souhaitée : ai-01, po-2024 (GameTheory/.NET owner), po-2025."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
@@ -4,7 +4,7 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust-Csharp.ipynb
   parity_level: semantic
   bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Bascule verdict (registre #10382, 2026-08-16, lane myia-po-2024:CoursIA-2) : le pont axelrod PythonNet (cell[29], execution_count=13, `#r nuget pythonnet 3.0.5`, axe 5 #10459) est installe et execute dans le notebook commite -- le reason precedent concluait deja SOTA-OK pour ce role sous un label reste RECOVERABLE-LOCAL : label aligne sur la conclusion. parity_level semantic preserve (gel #11200)."
+  bridge_verdict_reason: "Bascule verdict (registre #10382, axe 5 #10459) : l'annexe axelrod PythonNet (cellule code 36, execution_count=16, `#r nuget pythonnet 3.1.0`) est installée et exécutée dans le notebook commité. Résolution CPython Windows/Linux/macOS et dépendances natives Conda Windows validées ; parity_level semantic préservé (gel #11200)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -70,9 +70,15 @@
       csharp_sha: d465d4c9c186893032969564dc6cdbe675d1a050
       content_python_sha: d26598e7ba8e8c4dbe7f20cf02cd7060f621393a62312d4a1912e5aa6dd7af92
       content_csharp_sha: 01e5645cc9f961328cdd8b4f145378847b26dfac812d2d99323a8ced083d67be
+    - date: "2026-08-30"
+      by: myia-po-2025:CoursIA
+      python_sha: 15b83671f07996eccb6e99843648dbd0c21f265b
+      csharp_sha: b9dbff101c26a9135562845f8a36be8bc36e066e
+      content_python_sha: d26598e7ba8e8c4dbe7f20cf02cd7060f621393a62312d4a1912e5aa6dd7af92
+      content_csharp_sha: 16a44dc520955b52abc12a61c95ec60da50a32d7db26035f35c982cfe133e777
   known_differences:
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
-    - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."
+    - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = cœur `System.*` + moteur IPD from-scratch (T=5/R=3/P=1/S=0), complété par une annexe `pythonnet` 3.1.0 qui invoque le vrai moteur axelrod."
     - "Asymetrie pedagogique : Python utilise matplotlib.animation pour la viz dynamique (gif-like) du tournoi + process de Moran ; le C# travaille en pur System.* sans viz dynamique (asci-art + tableaux). Meme socle theorique (Axelrod + Moran), leviers de demonstration differents (viz riche cote Python, code from-scratch minimaliste cote C#)."
     - "2026-08-24 c.1331p451 LANE : ESS test complet (is_ess + verdicts + x0 + Faucon-Colombe control) sur Python notebook + re-exec complet contre axelrod 4.14 SOTA. python_sha f330b4d -> ffa47a2 (is_ess + verdicts). csharp_sha inchangé (f58d57, jumeau C# toujours sans IsEss ; PR #12755 po-2027 livre la substance C# mais non encore mergee sur main). drift_introduced ATTESTE par cette ligne."
-    - "Verdict RECOVERABLE-LOCAL bucket-3 (#10382, reclassification #10459 2026-08-12) : la librairie `axelrod` (Knight, Glynatsi et al.) est Python pure MAIS pontable via PythonNet (.NET -> Python.Runtime -> CPython -> axelrod), meme axe que GT-13/GT-17/Search-7. Le verdict INTRINSIC initial (#10406, 2026-08-11) concluait 'pont pas viable' car axelrod est 'usage exclusif via import' -- c'etait l angle mort taxonomique #10459 (axe PythonNet omis de la bucket-3). Pont demontre en annexe C# (cellule 30 : axl.Tournament invoque depuis C#, sortie commitee). Le from-scratch C# reste la contrepartie pedagogique principale (niveau semantic) ; le pont est EN PLUS jamais A LA PLACE (mandat #10382)."
+    - "Verdict SOTA-OK (#10382, reclassification #10459) : la librairie `axelrod` (Knight, Glynatsi et al.) est Python pure mais pontable via PythonNet (.NET -> Python.Runtime -> CPython -> axelrod), même axe que GT-13/GT-17/Search-7. Pont démontré dans la dernière cellule C# : `axl.Tournament` exécuté via pythonnet 3.1.0 avec sorties commitées. Le cœur from-scratch C# reste la contrepartie pédagogique principale (niveau semantic) ; le pont est EN PLUS, jamais À LA PLACE."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #13699

## Résumé

- remplace le fallback PythonNet lié à un profil Windows par une résolution CPython portable Windows/Linux/macOS ;
- prépare les répertoires de dépendances natives Conda (`Library/bin`, `DLLs`) avant l'initialisation sous Windows ;
- aligne l'annexe sur `pythonnet` 3.1.0 et CPython 3.10+ ;
- corrige l'affichage du classement Axelrod afin d'associer chaque score au bon joueur et distingue le petit tournoi fini du résultat historique plus large.

See #10643

## Diagnostic

La première ré-exécution a sélectionné `python313.dll` dans Miniconda, puis échoué avec `Win32Exception (126)` dans `Python.Runtime.Delegates` : la DLL CPython existait, mais ses dépendances natives Conda n'étaient pas visibles. Le correctif ajoute le répertoire racine Python, `Library/bin` et `DLLs` au `PATH` du processus avant `PythonEngine.Initialize()`.

## Exécution réelle

- `dotnet_executor.py ... --timeout 300 --verbose` : **16/16 cellules, 0 erreur** ;
- runtime observé : CPython 3.13.12 (Conda) ;
- moteur observé : axelrod 4.14.0 ;
- tournoi réel : Defector 1er, Tit For Tat 2e, Grudger 3e, Cooperator 4e ;
- `strip_probe_banner.py --apply`, puis `--scan` : **0 banner résiduel**.

## Validation

- `validate_pr_notebooks.py origin/main ... --json` : PASS, 16 cellules code, verdict `EXEC_PROVED` ;
- `check_c2_compliance.py --path ... --json` : 0 violation ;
- inspection nbformat complète : 37 cellules, 16 code, 16 avec outputs, 0 erreur, 0 warning ;
- `check_notebook_navlinks.py` : 0 lien cassé ;
- `detect_md_content_loss.py --base origin/main --check` : 0 finding ;
- `scan_cell_ordering.py --severity HIGH` : 0 finding ;
- `count_exercises.py` : 3 exercices, seuil respecté ;
- `check_source_output_ratchet.py origin/main` : 0 régression ;
- `check_papermill_ratchet.py origin/main` : 0 régression ;
- `check_output_failure_text.py origin/main --json` : 0 régression ;
- scan chemins machine / erreurs volontaires : 0 finding ;
- metadata notebook identiques à `origin/main` ; cinq cellules source modifiées : trois cellules markdown de cohérence SOTA, puis l'annexe markdown et son code PythonNet ;
- contrôle du suivi markdown-only post-exécution : les 16 cellules code, leurs outputs et leurs `execution_count` sont inchangés après l'exécution verte ;
- `check_twin_parity.py --pair "GameTheory-6 EvolutionTrust" --verify-recorded-sha --check` et `--per-pair --base origin/main --check` : sortie 0 ;
- registre twin ré-attesté après toute normalisation, verdict et prose curatoriale alignés sur PythonNet 3.1.0 ;
- validation indépendante `notebook-validator` : PASS (structure, exécution, portabilité, absence de fuite et correspondance output/conclusion) ;
- `git diff --check` : propre.

## Verdict SOTA

**SOTA-OK** : l'output committé provient du vrai moteur `axelrod` 4.14.0 invoqué depuis .NET via PythonNet, et non d'un fallback ou d'une sortie fabriquée.
