### PR TITLE
fix(guard,#13636-repair): self-override ai-01 sur sa propre PR — parser Grain:

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1562,6 +1562,70 @@ def _names_author(body: str, author: str) -> bool:
                      body) is not None
 
 
+# #13636 — pattern `Grain: ... lane <machine:workspace>` du dernier commit
+# FONCTIONNEL (non-merge). Le tag `Grain:` est la voie de verite de la lane
+# qui a livre le commit (cf variation-protocol.md §1), distincte du login
+# PR affiche qui peut etre `jsboige` pour cause d'identite de poussee
+# partagee (#13316). On extrait la lane `<machine:workspace>` au tag, sans
+# considerer le login commit author (qui peut etre jsboige meme quand
+# l'operateur fonctionnel est myia-ai-01). Une lane `myia-ai-01:*` signale
+# un override de meme operateur (self-override) ; toute autre lane signale
+# un override tiers legitime.
+_GRAIN_LANE_RE = re.compile(
+    r"(?im)^\s*\[?\s*Grain\s*:\s*[^\n]*?\blane\s+([A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+)"
+)
+
+
+def _pr_operator_lane(pr_data: dict) -> str:
+    """Lane fonctionnelle de la PR, lue du dernier commit FONCTIONNEL.
+
+    #13636 (REPAIR #13703) — le tag `Grain: ... lane X` du commit
+    fonctionnel est la seule source de verite de la lane operatrice quand
+    l'identite de poussee partagee `jsboige` masque l'operateur reel. On
+    parcourt les commits par date decroissante, on SAUTE les merges
+    (commit message commence par `Merge `), et on prend le premier commit
+    FONCTIONNEL. Renvoie la lane (`machine:workspace`) ou `""` si aucune
+    n'est trouvee (= on ne peut pas conclure self-override).
+    """
+    raw_commits = pr_data.get("commits") or []
+    by_date = sorted(
+        [c for c in raw_commits if c.get("committedDate")],
+        key=lambda c: c.get("committedDate") or "",
+        reverse=True,
+    )
+    for c in by_date:
+        msg = c.get("messageBody") or ""
+        headline = c.get("messageHeadline") or ""
+        full = (headline + "\n" + msg).strip()
+        if full.lower().startswith("merge "):
+            continue
+        m = _GRAIN_LANE_RE.search(full)
+        if m:
+            return m.group(1)
+    return ""
+
+
+def _is_self_override(lift_author: str, lift_body: str, pr_data: dict) -> bool:
+    """L'override pose par `lift_author` est-il un self-override par la lane ?
+
+    #13636 (REPAIR #13703) — un override `[OVERRIDE] lane X` pose par un
+    lifter dans LIFT_OVERRIDE_LOGINS (= `myia-ai-01`) sur une PR dont le
+    dernier commit FONCTIONNEL porte `Grain: ... lane myia-ai-01:...` est
+    un self-override par construction (l'arbitre tiers ne peut pas etre
+    l'operateur de la PR). Renvoie True si la lane du Grain matche la lane
+    du lifter (i.e. toutes deux cote ai-01). Renvoie False par defaut si la
+    lane fonctionnelle est introuvable (on ne peut pas conclure, on laisse
+    passer — fail-OPEN pour les PRs sans tag Grain).
+    """
+    if lift_author not in LIFT_OVERRIDE_LOGINS:
+        return False
+    pr_lane = _pr_operator_lane(pr_data)
+    if not pr_lane:
+        return False  # pas de signal Grain : on ne peut pas conclure
+    # Si la lane fonctionnelle est cote ai-01, l'override est self-override.
+    return pr_lane.startswith("myia-ai-01:")
+
+
 def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
             issue_created=None) -> dict:
     """cutoff = mergedAt (audit retro) ou now (gate pre-merge)."""
@@ -1569,6 +1633,11 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
     commits = [c for c in commits if c]
     last_commit = max(commits) if commits else None
     pr_author = (pr_data.get("author") or {}).get("login", "")
+    # #13636 (REPAIR #13703) — lane fonctionnelle lue du tag `Grain:` du
+    # dernier commit FONCTIONNEL. Sert dans `_is_self_override` pour
+    # detecter l'override de meme operateur pose par ai-01 sur PR
+    # jsboige-pushed (login commit = jsboige, mais l'operateur reel = ai-01).
+    pr_operator_lane = _pr_operator_lane(pr_data)
 
     # #11145 — borne d'auteur, durcie par #12836 : seule une levee de l'auteur
     # de la reserve compte. #12798 a montre pourquoi PR_AUTHOR n'est pas une
@@ -1653,8 +1722,16 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         # lanes (self-review cap #12319), un override jsboige est
         # indiscernable d'une auto-levee de lane (replay #12737).
         m = OVERRIDE_LANE.search(lift_body or "")
-        return (lift_author in LIFT_OVERRIDE_LOGINS
-                and m is not None)
+        if not (lift_author in LIFT_OVERRIDE_LOGINS and m is not None):
+            return False
+        # #13636 (REPAIR #13703) — un override par l'arbitre tiers n'est
+        # recevable que si l'arbitre n'est PAS l'operateur fonctionnel de
+        # la PR. Le tag `Grain:` du dernier commit FONCTIONNEL identifie
+        # cette lane. Si elle est cote `myia-ai-01:`, l'override est un
+        # self-override (REJETE). Si le Grain manque (PR sans tag), on ne
+        # peut pas conclure et on laisse passer (fail-OPEN) — un override
+        # bien forme par un tiers reste valide par ailleurs.
+        return not _is_self_override(lift_author, lift_body or "", pr_data)
 
     # Fenetre 2026-08-16 (#11222) : les temps plats ne suffisent pas pour un
     # CHANGES_REQUESTED. Une PHRASE explicite de levee (LIFT_MARKER non

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3222,3 +3222,116 @@ def test_13635_conditionnel_je_leve_masculin_reste_bloquant():
         "myia-ai-01",
         "Une seule chose a changer — corrige la ligne 19 et je leve le concern."
     ) == "BOT-CONCERN"
+
+
+# #13636 (REPAIR #13703) — 4 controles d'integration : le tag `Grain: lane X`
+# du dernier commit FONCTIONNEL identifie l'operateur fonctionnel, et un
+# override `[OVERRIDE] lane X` pose par un lifter dans LIFT_OVERRIDE_LOGINS
+# (= `myia-ai-01`) sur une PR dont la lane est aussi cote ai-01 constitue
+# un self-override par construction (REJETE). Avant ce fix, le garde ne
+# pouvait rien conclure (le login commit = `jsboige`, l'operateur reel =
+# `myia-ai-01` -- l'identite de poussee partagee #13316 masquait le vrai
+# operateur). Le fix lit la lane du tag `Grain:` du dernier commit
+# fonctionnel (non-merge).
+
+
+def lift_myia_override(body="[OVERRIDE] lane myia-ai-01:CoursIA"):
+    """Override pose par myia-ai-01 (arbitre tiers)."""
+    return {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+            "body": body + "\n\nTes trois concerns sont leves, levee acquise."}
+
+
+def lift_ai01_comment(body=None):
+    """Commentaire leveur par myia-ai-01, sans override ni LIFT_MARKER."""
+    return {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+            "body": body or "Acknowledge."}
+
+
+def commit_with_grain(grain_lane="myia-ai-01:CoursIA"):
+    """Commit fonctionnel portant le tag Grain: lane X."""
+    return {"oid": NIT_OID, "committedDate": at(19),
+            "messageHeadline": "fix(guard,#13636): test",
+            "messageBody": f"Grain: MED/guard - lane {grain_lane} - prev: MED/guard #13698\n\nTest commit."}
+
+
+def merge_commit():
+    """Commit merge (a sauter dans le parsing)."""
+    return {"oid": "a" * 40, "committedDate": at(20),
+            "messageHeadline": "Merge branch 'main' into fix/13636",
+            "messageBody": ""}
+
+
+def test_13636_self_override_ai01_on_ai01_pr_bloque():
+    """#13636 / REPAIR #13703 — controle 1 : override par myia-ai-01 sur PR
+    dont le Grain lane est `myia-ai-01:` (self-override) doit BLOQUER le
+    merge (le lifter ne peut pas s'auto-arbiter). Avant ce fix, le gate
+    passait vert (le `or` annulait le garde, et l'operateur reel etait
+    masque par l'identite de poussee partagee `jsboige`). Avec le fix, le
+    tag Grain identifie l'operateur fonctionnel et le self-override est
+    detecte puis rejete.
+    """
+    bot_nit = {"author": {"login": "clusterManager-Myia"},
+               "createdAt": at(9),
+               "body": "**[NanoClaw]** CHANGES_REQUESTED - 2 concerns structurels."}
+    res = run([bot_nit, lift_myia_override()],
+              commits=[merge_commit(), commit_with_grain("myia-ai-01:CoursIA")],
+              pr_author="jsboige")
+    assert res["blocked"] is True, "self-override par ai-01 sur PR ai-01 doit BLOQUER"
+
+
+def test_13636_override_ai01_on_po2024_pr_passe():
+    """#13636 / REPAIR #13703 — controle 2 : override par myia-ai-01 sur PR
+    dont le Grain lane est `myia-po-2024:` (autre lane) doit PASSER le
+    merge (l'arbitre tiers est distinct de l'operateur fonctionnel).
+    """
+    bot_nit = {"author": {"login": "clusterManager-Myia"},
+               "createdAt": at(9),
+               "body": "**[NanoClaw]** CHANGES_REQUESTED - 2 concerns structurels."}
+    res = run([bot_nit, lift_myia_override()],
+              commits=[commit_with_grain("myia-po-2024:CoursIA-2")],
+              pr_author="jsboige")
+    assert res["blocked"] is False, "override tiers par ai-01 sur PR po-2024 doit PASSER"
+
+
+def test_13636_pr_sans_grain_fail_open():
+    """#13636 / REPAIR #13703 — controle 3 : PR sans tag Grain sur le dernier
+    commit fonctionnel. On ne peut pas conclure (pas de signal), on laisse
+    passer (fail-OPEN) — un override bien forme par un tiers reste valide.
+    """
+    bot_nit = {"author": {"login": "clusterManager-Myia"},
+               "createdAt": at(9),
+               "body": "**[NanoClaw]** CHANGES_REQUESTED - 2 concerns structurels."}
+    no_grain_commit = {"oid": NIT_OID, "committedDate": at(19),
+                       "messageHeadline": "fix: typo",
+                       "messageBody": "No grain tag here"}
+    res = run([bot_nit, lift_myia_override()],
+              commits=[merge_commit(), no_grain_commit],
+              pr_author="jsboige")
+    assert res["blocked"] is False, "PR sans Grain : fail-OPEN sur override"
+
+
+def test_13636_payload_reel_pr_13703_bloque():
+    """#13636 / REPAIR #13703 — controle 4 : payload REEL de PR #13703 avant
+    merge (`authors` liste, login affiche `jsboige`, tag Grain
+    `myia-ai-01:CoursIA`). Avant ce fix, le gate passait vert (parser
+    defect : `authors` rend liste, mon code lisait `author` objet et rendait
+    `last_committer_login=""`, donc `pr_operator=pr_author="jsboige"` ; le
+    `or` annulait le garde et `lifter != pr_operator` (VRAI) ouvrait la
+    porte sans consulter `_has_named_override`). Avec ce fix, le tag Grain
+    identifie `myia-ai-01:CoursIA`, l'override est reconnu comme self-override,
+    le gate BLOQUE.
+    """
+    bot_nit = {"author": {"login": "clusterManager-Myia"},
+               "createdAt": at(9),
+               "body": "**[NanoClaw]** CHANGES_REQUESTED - 2 concerns structurels."}
+    pr_13703_payload = {
+        "oid": "6c59372c02ac908bb95f54e56428e78fc49e2092",
+        "committedDate": "2026-08-30T18:20:34Z",
+        "authors": [{"login": "jsboige"}, {"login": "claude"}],
+        "messageHeadline": "fix(guard,#13636): trappe d'override ai-01 sur sa propre PR",
+        "messageBody": "Grain: MED/guard - lane myia-ai-01:CoursIA - prev: MED/guard #13698\n\n#13636 signale qu'un commentaire [OVERRIDE] lane myia-ai-01:CoursIA pose par myia-ai-01 sur sa PROPRE PR levait la branche BLOCK...",
+    }
+    res = run([bot_nit, lift_myia_override()],
+              commits=[pr_13703_payload],
+              pr_author="jsboige")
+    assert res["blocked"] is True, "PR #13703 payload REEL : self-override doit BLOQUER"


### PR DESCRIPTION
## Summary

REPAIR de #13703 (c.740) qui fermait incomplètement #13636. Le fix c.740
utilisait `gh pr view --json commits` puis lisait `author` (objet singulier)
— l'API rend en réalité `authors` (liste). Conséquence : `last_committer_login`
toujours vide, `pr_operator` retombait sur `pr_author="jsboige"`, le `or`
annulait le garde `_has_named_override`, et la trappe d'override restait
grande ouverte sur les PRs dont l'opérateur fonctionnel est `myia-ai-01`
mais poussé sous l'identité partagée `jsboige`.

## Détection

DM HIGH po-2025 à 20:29:20Z (msg-20260830T182920-n55103), preflight
COMMENTED sur PR #13703 + lecture first-hand du payload API réel. Tell
c.717-L1 ★ NEW critique `p1-dispatch-claim-verification-self` :
validation self-échec G.1 — j'avais testé le helper `_has_named_override`
isolé mais PAS contre le payload API réel. Invalidation publique postée
en commentaire #13703 (comment 5470512492).

## Fix

Remplacement de la résolution `pr_operator` (auteur du dernier commit)
par le parsing du **tag `Grain: lane X`** du dernier commit FONCTIONNEL
(non-merge). Le tag `Grain:` est la source de vérité de la lane
fonctionnelle d'une PR (#13316), et il survit à l'identité de poussée
partagée `jsboige`. Le tag est posé en première ligne de chaque commit
par les agents de la flotte (variation-protocol.md §1).

`_is_self_override(lift_author, lift_body, pr_data)` détecte :
- lifter PAS dans `LIFT_OVERRIDE_LOGINS` (`{"myia-ai-01"}`) → False
- lane opérateur `myia-ai-01:` (préf. match) ET lifter = `myia-ai-01` → True (REJETÉ)
- lane opérateur tierce → False (override recevable)
- PR sans tag `Grain:` → False (fail-OPEN, override tiers reste valide)

`_lift_eligible` retourne `not _is_self_override(...)` quand lifter ∈
LIFT_OVERRIDE_LOGINS ET override lane nommée détectée.

## Tests (230 passed total, 0 régression)

4 tests d'intégration dans `scripts/tests/test_check_unaddressed_nits.py` :

1. `test_13636_self_override_ai01_on_ai01_pr_bloque` — payload PR avec
   Grain `myia-ai-01:CoursIA`, override par `myia-ai-01` → BLOQUÉ
2. `test_13636_override_ai01_on_po2024_pr_passe` — override tiers valide
   (Grain `myia-po-2024:CoursIA-2`) → PAS BLOQUÉ
3. `test_13636_pr_sans_grain_fail_open` — PR sans tag Grain → PAS BLOQUÉ
   (fail-OPEN)
4. `test_13636_payload_reel_pr_13703_bloque` — payload API réel de
   PR #13703 (`authors` liste, login `jsboige`, Grain `myia-ai-01:CoursIA`)
   → BLOQUÉ (le défaut c.740 reproduit littéralement)

226 tests existants passent (anti-régression).

## Liens

- #13636 (issue source) — `Closes` (fix ferme la trappe)
- #13703 (PR c.740 LIVRÉE-INVALIDE) — REPAIR
- #12798, #13316 (identité poussée partagée jsboige)
- #11145, #12319, #13083 (bornes strictes lift author-bound)
- Tell c.717-L1 ★ NEW critique `p1-dispatch-claim-verification-self`
- Tell c.741-L13 ★ NEW CRITIQUE `pr-13703-fix-13636-parser-bug`
- Comment PR #13703 (comment 5470512492) — invalidation publique c.741

Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/guard #13705
