### PR TITLE
fix(gate,#13685): une dismissal ne leve la reserve que si elle vient de son emetteur

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1547,6 +1547,49 @@ def review_threads(pr: int) -> list[dict]:
     return out
 
 
+def improper_dismissals(pr: int) -> set[str]:
+    """Auteurs de review dont la reserve a ete dismissee par QUELQU'UN D'AUTRE.
+
+    `gh pr view --json reviews` ne dit ni qui a dismisse ni quand : il ne rend
+    que l'etat final `DISMISSED`. L'acteur vit dans la timeline REST
+    (`review_dismissed`), l'auteur de la review dans les reviews REST — les deux
+    se joignent par l'`id` NUMERIQUE (le champ `id` de `gh pr view` est un
+    node-id GraphQL, `PRR_kwDO...`, non comparable au `review_id` entier).
+
+    Retourne des LOGINS d'auteurs de review, pas des ids : la reserve est
+    reappariee par auteur dans `analyse`. Sur-approximation assumee quand un
+    meme auteur a deux reviews dismissees dont une legitimement — un gate se
+    trompe du cote qui bloque, jamais du cote qui laisse passer.
+
+    Non cable sur `audit()` : deux appels API par PR, pour un chemin retrospectif
+    ou l'enforcement n'a plus lieu. Le gate pre-merge est le point de controle.
+    """
+    try:
+        reviews = gh_json(["api", f"repos/{REPO}/pulls/{pr}/reviews", "--paginate"])
+        events = gh_json(["api", f"repos/{REPO}/issues/{pr}/timeline", "--paginate"])
+    except Exception:
+        return set()  # timeline illisible : on retombe sur l'ancien comportement
+    if not isinstance(reviews, list) or not isinstance(events, list):
+        return set()
+    author_of = {
+        r.get("id"): ((r.get("user") or {}).get("login") or "")
+        for r in reviews if isinstance(r, dict)
+    }
+    improper: set[str] = set()
+    for e in events:
+        if not isinstance(e, dict) or e.get("event") != "review_dismissed":
+            continue
+        actor = ((e.get("actor") or {}).get("login") or "")
+        rid = (e.get("dismissed_review") or {}).get("review_id")
+        emitter = author_of.get(rid)
+        if not emitter:
+            continue
+        if actor == emitter or actor in LIFT_OVERRIDE_LOGINS:
+            continue
+        improper.add(emitter)
+    return improper
+
+
 def _names_author(body: str, author: str) -> bool:
     """``body`` mentionne-t-il ``author`` comme identite, pas par hasard ?
 
@@ -1563,7 +1606,7 @@ def _names_author(body: str, author: str) -> bool:
 
 
 def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
-            issue_created=None) -> dict:
+            issue_created=None, dismissed_improperly=None) -> dict:
     """cutoff = mergedAt (audit retro) ou now (gate pre-merge)."""
     commits = [ts(c.get("committedDate")) for c in (pr_data.get("commits") or [])]
     commits = [c for c in commits if c]
@@ -1757,13 +1800,35 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
     for r in pr_data.get("reviews") or []:
         login = (r.get("author") or {}).get("login", "")
         body = r.get("body", "")
-        if r.get("state") == "DISMISSED":
-            # Une dismissal GitHub n'est possible que par l'auteur de la review
-            # (ou un admin) : la reserve est formellement RETIREE par son
-            # emetteur — pas un signal (#11222, levée (b)).
-            continue
+        state = r.get("state")
+        if state == "DISMISSED":
+            # #13685 — la premisse precedente (« une dismissal n'est possible
+            # que par l'auteur de la review ou un admin ») est FAUSSE : tout
+            # compte disposant du droit d'ecriture peut dismisser la review d'un
+            # tiers, l'auteur de la PR compris. Le `continue` inconditionnel
+            # faisait donc de `PUT /pulls/N/reviews/ID/dismissals` une trappe :
+            # sur #13685, la CHANGES_REQUESTED de clusterManager-Myia (« 1 defect
+            # bloquant trouve ») est dismissee a 18:14:56Z, et `check-navlinks`
+            # passe FAILURE a 18:16:11Z — 75 secondes plus tard. La reserve etait
+            # declaree levee pendant que la propriete qu'elle protege etait encore
+            # cassee. C'est #12798 mecanise : se lever soi-meme la reserve d'un
+            # tiers ne repond pas a la remarque, ca la declare repondue.
+            #
+            # Une dismissal n'eteint donc la reserve que si elle vient de son
+            # EMETTEUR (retrait volontaire, #11222 levee (b)) ou d'un login
+            # d'override nomme. Dismissee par quiconque d'autre, elle SURVIT.
+            if login not in (dismissed_improperly or ()):
+                continue
+            # La reserve survivante reprend son etat D'ORIGINE : la timeline
+            # rend `dismissed_review.state == "changes_requested"`. Sans cette
+            # ligne le signal existe mais retombe en `review:DISMISSED` — hors
+            # de la branche qui force BOT-CONCERN, et hors du durcissement
+            # `src == "review:CHANGES_REQUESTED"` en aval. Mesure sur #13685 :
+            # `improper_dismissals` rendait bien {clusterManager-Myia} et le
+            # gate restait vert. Un signal hors de sa branche ne bloque rien.
+            state = "CHANGES_REQUESTED"
         kind = classify(login, body)
-        if r.get("state") == "CHANGES_REQUESTED":
+        if state == "CHANGES_REQUESTED":
             kind = "BOT-CONCERN" if kind is None else kind
         # #11677 — symetrique APPROVED : l'etat natif GitHub `APPROVED` temoigne
         # qu'aucune reserve n'est posee. Si classify() a deja retourne un kind
@@ -1774,7 +1839,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         # cette branche, le verdict positif est calcule sur la prose seule,
         # alors que la preuve la plus dure (l'etat natif) est disponible
         # deux lignes plus haut. Meme symetrie que CHANGES_REQUESTED ci-dessus.
-        elif r.get("state") == "APPROVED":
+        elif state == "APPROVED":
             if kind is None:
                 pass  # kind reste None (l'etat natif confirme l'extinction)
             # Le test porte sur le corps DEPOUILLE, jamais sur le brut : une
@@ -1796,7 +1861,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                 kind = None
         if kind:
             signals.append((ts(r.get("submittedAt")), kind, login, body,
-                            f"review:{r.get('state')}"))
+                            f"review:{state}"))
 
     blocking = []
     for (when, kind, login, body, src) in signals:
@@ -2046,7 +2111,8 @@ def gate(pr: int, as_json: bool) -> int:
     merged = ts(data.get("mergedAt"))
     cutoff = merged or datetime.now(timezone.utc)
     result = analyse(data, review_threads(pr), cutoff,
-                     issue_created=gh_issue_created)
+                     issue_created=gh_issue_created,
+                     dismissed_improperly=improper_dismissals(pr))
     if as_json:
         print(json.dumps(result, indent=1, ensure_ascii=False))
     elif not result["blocked"]:

--- a/scripts/tests/test_check_unaddressed_nits_dismissal.py
+++ b/scripts/tests/test_check_unaddressed_nits_dismissal.py
@@ -1,0 +1,96 @@
+"""Une dismissal ne leve la reserve que si elle vient de son EMETTEUR (#13685).
+
+Le gate portait la premisse ecrite « une dismissal GitHub n'est possible que par
+l'auteur de la review (ou un admin) », et faisait donc un `continue`
+inconditionnel sur `state == "DISMISSED"`. Cette premisse est FAUSSE : tout
+compte disposant du droit d'ecriture peut dismisser la review d'un tiers,
+l'auteur de la PR compris. `PUT /pulls/N/reviews/ID/dismissals` etait donc une
+trappe : la reserve d'autrui s'eteignait d'un appel d'API.
+
+Mesure du 2026-08-30 sur #13685 : la CHANGES_REQUESTED de clusterManager-Myia
+(« 1 defect bloquant trouve ») est dismissee a 18:14:56Z ; `check-navlinks`
+passe FAILURE a 18:16:11Z, 75 secondes plus tard. La reserve etait declaree
+levee pendant que la propriete qu'elle protege etait encore cassee — #12798
+mecanise.
+
+Le second test verrouille le defaut trouve EN COURS de correction : reconnaitre
+la dismissal impropre ne suffit pas. La reserve survivante doit reprendre son
+etat d'ORIGINE (`CHANGES_REQUESTED`), sinon le signal existe mais retombe en
+`review:DISMISSED` — hors de la branche qui force BOT-CONCERN et hors du
+durcissement `src == "review:CHANGES_REQUESTED"` en aval. Premiere passe :
+`improper_dismissals()` rendait bien `{clusterManager-Myia}` et le gate restait
+vert. Un signal hors de sa branche ne bloque rien.
+"""
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_unaddressed_nits.py"
+spec = importlib.util.spec_from_file_location("cun_dismissal", CHECK_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["cun_dismissal"] = mod
+spec.loader.exec_module(mod)
+
+MERGED = datetime(2026, 8, 30, 20, 0, tzinfo=timezone.utc)
+
+
+def _pr(review_state="DISMISSED"):
+    return {
+        "number": 13685,
+        "author": {"login": "jsboige"},
+        "commits": [{"committedDate": "2026-08-30T13:00:00Z"}],
+        "comments": [],
+        "reviews": [{
+            "author": {"login": "clusterManager-Myia"},
+            "state": review_state,
+            "submittedAt": "2026-08-30T14:30:35Z",
+            "body": "**[Hermes]** — 1 defect bloquant trouve : les 2 liens sont casses.",
+        }],
+    }
+
+
+def test_dismissal_par_un_tiers_ne_leve_pas():
+    """Dismissee par quelqu'un d'autre que son emetteur : la reserve SURVIT."""
+    res = mod.analyse(_pr(), [], MERGED,
+                      dismissed_improperly={"clusterManager-Myia"})
+    assert res["blocked"] is True
+    assert len(res["blocking"]) == 1
+    assert res["blocking"][0]["author"] == "clusterManager-Myia"
+
+
+def test_reserve_survivante_reprend_letat_changes_requested():
+    """Le signal doit porter `review:CHANGES_REQUESTED`, pas `review:DISMISSED`.
+
+    C'est ce qui l'amene dans la branche BOT-CONCERN et sous le durcissement
+    anti-extinction-par-commentaire-posterieur. Sans cela le gate reste vert.
+    """
+    res = mod.analyse(_pr(), [], MERGED,
+                      dismissed_improperly={"clusterManager-Myia"})
+    assert res["blocking"][0]["src"] == "review:CHANGES_REQUESTED"
+    assert res["blocking"][0]["kind"] == "BOT-CONCERN"
+
+
+def test_dismissal_par_son_emetteur_leve_toujours():
+    """Retrait volontaire par l'auteur de la review : extinction legitime (#11222)."""
+    res = mod.analyse(_pr(), [], MERGED, dismissed_improperly=set())
+    assert res["blocked"] is False
+
+
+def test_defaut_de_lecture_ne_bloque_jamais_a_tort():
+    """Timeline illisible -> `dismissed_improperly=None` -> ancien comportement.
+
+    Un gate qui bloque quand son instrument est muet transforme une panne de
+    lecture en refus de merge. Fail-closed sur le comportement anterieur.
+    """
+    assert mod.analyse(_pr(), [], MERGED)["blocked"] is False
+    assert mod.analyse(_pr(), [], MERGED, dismissed_improperly=None)["blocked"] is False
+
+
+def test_une_review_non_dismissee_est_inchangee():
+    """Temoin negatif : le patch ne touche pas le chemin nominal."""
+    res = mod.analyse(_pr("CHANGES_REQUESTED"), [], MERGED,
+                      dismissed_improperly=set())
+    assert res["blocked"] is True
+    assert res["blocking"][0]["src"] == "review:CHANGES_REQUESTED"


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/tooling #13650

## Le defaut

Le gate B.0 portait une premisse **ecrite dans son propre commentaire** :

> « Une dismissal GitHub n'est possible que par l'auteur de la review (ou un admin) : la reserve est formellement RETIREE par son emetteur — pas un signal. »

Elle est **fausse**. Tout compte disposant du droit d'ecriture peut dismisser la review d'un tiers, l'auteur de la PR compris. Le `continue` inconditionnel sur `state == "DISMISSED"` faisait donc de `PUT /pulls/N/reviews/ID/dismissals` une trappe : la reserve d'autrui s'eteignait d'un seul appel d'API, et le gate rendait `rc=0`.

## Comment il a ete trouve

Mesure du 2026-08-30 sur **#13685** :

| Horodatage | Evenement |
|---|---|
| 14:30:35Z | `clusterManager-Myia` poste `CHANGES_REQUESTED` — « **1 defect bloquant trouve** » |
| **18:14:56Z** | La review est **dismissee** (acteur `jsboige`, message « Stale CHANGES_REQUESTED ») |
| **18:16:11Z** | `check-navlinks` passe **FAILURE** — **75 secondes plus tard** |

La reserve a ete declaree levee pendant que la propriete qu'elle protege etait encore cassee. C'est le cas **#12798** mecanise : se lever soi-meme la reserve d'un tiers ne repond pas a la remarque, ca la declare repondue.

Le geste etait consigne cote lane comme une **strategie reutilisable** (« stratégie `PUT dismissals` sustained »), aux cotes de deux autres vecteurs contre le meme organe — `gh api -X DELETE` sur un commentaire, et PATCH d'un corps pour neutraliser les mots-cles cherches. Ce PR ne ferme que le troisieme ; les deux premiers sont suivis en #13636 et par la remise a plat coordinateur du dashboard workspace-CoursIA-2.

## Le correctif

- **`improper_dismissals(pr)`** joint `pulls/N/reviews` (REST) et `issues/N/timeline` (REST) par l'`id` **numerique**. Le champ `id` de `gh pr view --json reviews` est un node-id GraphQL (`PRR_kwDO...`), non comparable au `review_id` entier de la timeline — c'est pourquoi la jointure passe par REST des deux cotes. Rend les **logins d'auteurs** dont la reserve a ete dismissee par un tiers.
- **La reserve survivante reprend son etat d'ORIGINE** `CHANGES_REQUESTED`. C'est la moitie non evidente du fix : a la premiere passe, `improper_dismissals()` rendait deja `{clusterManager-Myia}` **et le gate restait vert** — le signal existait mais retombait en `review:DISMISSED`, donc hors de la branche qui force `BOT-CONCERN` *et* hors du durcissement `src == "review:CHANGES_REQUESTED"` en aval. Un signal hors de sa branche ne bloque rien.
- **Fail-closed** : timeline illisible → `set()` → comportement anterieur. Un gate qui bloque quand son instrument est muet transforme une panne de lecture en refus de merge.
- **Non cable sur `audit()`** : deux appels API par PR, sur un chemin retrospectif ou l'enforcement n'a plus lieu.

## Verification

**Controle positif** — #13685 : `rc=0` → `rc=1`, avec le motif juste :

```
BLOCKED  PR #13685 — 1 nit(s) non leve(s) :
  [BOT-CONCERN] clusterManager-Myia via review:CHANGES_REQUESTED (+4.5h avant merge)
      **[Hermes]** — 1 defect bloquant trouve (les 2 nouveaux liens Lean-18 d'App-22 sont casses)
```

**Temoin negatif de la fonction** : `improper_dismissals(13563)` → `set()` (aucune dismissal).

**Non-regression, 6 PR reelles, verdicts identiques a avant le patch** : `#13563` `#13647` `#13605` `#13634` → `rc=0` ; `#13618` `#13627` → `rc=1`.

**Tests** : `290 passed` sur les 4 fichiers du gate (285 existants + 5 ajoutes). Les 5 nouveaux couvrent la dismissal par un tiers, la restitution d'etat (le sous-defaut ci-dessus), la dismissal legitime par l'emetteur, le cas fail-closed, et un temoin negatif sur le chemin nominal.

*Note : `pytest -k nits` sur `scripts/tests/` remonte 6 erreurs de collecte (`test_sudoku_rrn.py` et 5 autres). Verifiees **preexistantes sur `main`**, hors perimetre de ce PR.*

## Portee

Ce PR ferme un vecteur, pas la classe. `rc=0` reste calcule sur l'etat **courant** des trois surfaces : supprimer un commentaire le blanchit encore, parce qu'aucun snapshot ne conserve ce qui a disparu. La consigne coordinateur en attendant est de lire les CHECKS **et** la timeline `review_dismissed`, jamais le code de retour seul.

See #13685
