### PR TITLE
fix(ci,#13673): reanimer md-content-loss-gate -- une ellipse dans un commentaire de run: tuait le workflow

### DIFF
--- a/.github/workflows/md-content-loss-gate.yml
+++ b/.github/workflows/md-content-loss-gate.yml
@@ -70,6 +70,13 @@ jobs:
           python-version: '3.11'
 
       - name: Gate changed notebooks
+        env:
+          # Forme sure : le body arrive comme variable d'environnement et
+          # n'est jamais interpole dans le shell (identique a
+          # always-on-guards.yml l.934). Sur workflow_dispatch,
+          # github.event.pull_request est nul -> chaine vide -> inerte,
+          # conforme a l'Acceptance #13491 (malforme = inert).
+          MD_CONTENT_LOSS_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -uo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -93,13 +100,12 @@ jobs:
           # marker pour un finding donne, le comportement nominal (rc=1) est
           # preserve. Le body est passe via l'env var in-memory
           # MD_CONTENT_LOSS_PR_BODY (canal recommande, evite le pattern CodeQL
-          # `actions/code-injection` declenche par `printf '%s' "${{ ...body }}"`
+          # `actions/code-injection` declenche par `printf` du body dans le shell
           # qui taint le body vers le shell). Le detecteur la resout en
           # priorite sur --pr-body-file / MD_CONTENT_LOSS_PR_BODY_FILE (canal
           # historique, conserve pour les tests unitaires et les out-of-band
           # invocations). Les PRs sans body (string vide) ne matchent rien,
           # comportement actuel preserve (cf Acceptance #13491 : malforme = inert).
-          export MD_CONTENT_LOSS_PR_BODY='${{ github.event.pull_request.body }}'
 
           echo "## Markdown content-loss gate" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #13710

## Le defaut

`md-content-loss-gate.yml` est **mort au demarrage** sur `main`. Le tell canonique est present :

```
conclusion=failure   total_count=0 jobs   name=.github/workflows/md-content-loss-gate.yml
```

Un run dont le `name` **est le chemin** est un run dont GitHub n'a pas pu lire la cle `name:` — le fichier a ete rejete avant qu'aucun job n'existe.

**Cause, une ellipse.** Le commentaire ajoute par c.715 (#13673) explique comment le canal in-memory evite le pattern CodeQL `actions/code-injection`. Il est place **dans le bloc `run:`** — c'est donc un commentaire *shell*, pas un commentaire YAML. GitHub interpole `${{ ... }}` dans le scalaire **avant que le shell existe** :

```yaml
# `actions/code-injection` declenche par `printf '%s' "${{ ...body }}"`
                                                          ^^^^^^^^
```

`...body` n'est pas une expression valide → fichier invalide → startup failure. Le commentaire qui documente l'evitement d'une injection est ce qui tue le workflow.

## Portee — mesuree, et plus etroite que ce que le tell suggere

| Mesure | Valeur |
|---|---|
| Runs morts | **68** (contre 3649 vivants sur l'historique du workflow) |
| Premier mort | `6f39c4ae7` — 2026-08-30T12:00:19Z (branche de #13673) |
| Arrivee sur `main` | squash `6a26a5e86` — 16:50:51Z |

**Ce qui a casse** : le workflow autonome — donc son chemin de **re-run manuel `workflow_dispatch` sur `main` apres une panne CI** (raison d'etre du fichier depuis #9858) — et un **rouge permanent sur chaque push vers `main`**.

**Ce qui n'a PAS casse — verifie, pas suppose** : la couverture cote PR. Depuis #12396 tranche 4 ce garde est **absorbe par la voie rapide** (`fast_lane_registry.py` l.642 `source="md-content-loss-gate.yml"`), rendue par `fast-lane-shadow.yml` sous le meme nom de check-run. Controle positif : sur #13673 lui-meme (tete `27f17217e`), le check-run `No markdown content loss in changed notebooks` est **`success`**. Aucune PR n'a merge sans ce garde.

Je corrige ici une premiere redaction de ce body qui affirmait « le garde n'a protege aucune PR ». C'etait faux, et c'etait une sur-accusation : le tell « organe eteint » est reel au niveau du *fichier*, pas au niveau de la *couverture*.

## Le fix

1. **l.96** — l'ellipse quitte le commentaire. La prose dit la meme chose sans `${{`.
2. **l.102** — `export MD_CONTENT_LOSS_PR_BODY='${{ github.event.pull_request.body }}'` dans `run:` → bloc **`env:` du step**. C'est la forme sure, celle qu'`always-on-guards.yml` l.934 emploie deja : le body arrive comme variable d'environnement, **jamais interpole dans le shell** (la forme `export VAR='...'` sort des quotes simples des que le body porte une apostrophe). Sur `workflow_dispatch` — seul declencheur de ce fichier — `github.event.pull_request` est nul → chaine vide → inerte, conforme a l'Acceptance #13491.

## Verifications

- **`always-on-guards.yml` est correct — non touche.** Sa l.934 est deja la forme `env:` ; sa l.928 est un **vrai commentaire YAML**, supprime par le parser avant toute evaluation. Ouvert et lu, plutot que deduit du message de commit. Pas d'injection la.
- **Preuve d'execution** : `workflow_dispatch` sur cette branche → `name=Markdown content-loss gate` (GitHub relit la cle `name:`) et **1 job cree**, contre `total_count=0` avant. C'est la recette canonique d'un organe : un run qui a cree un job, pas « la PR est verte ».
- **Controle positif** : le validateur d'expressions signale `l.96 '...body'` sur le texte d'origine et rend vide sur le texte corrige. Un detecteur muet sur le defaut connu ne prouve rien.
- **Aucun nouveau workflow.** La surcouche CI est deja signalee comme trop lourde ; la classe « expression invalide dans un `run:` » serait attrapee par `actionlint`, non installe ici — je le note sans l'ajouter.

## Adjacence de genre — declaree, pas contournee

`prev: MED/guard #13710` : **deux `guard` consecutifs**, ce que G-VAR-3 interdit sur les genres LIGHT. Je le declare au lieu de re-etiqueter le grain. La raison est que `main` portait un rouge permanent et un fichier invalide, et R5 de proactive-coordination fait passer la reparation du rouge avant le tirage. **Mon plancher CONTENU reste du** au cycle suivant — cette PR ne le tient pas.

See #13673
