### PR TITLE
fix(sweep,#13676): set -euo pipefail strict mode

### DIFF
--- a/.github/workflows/epic-neglect-sweep.yml
+++ b/.github/workflows/epic-neglect-sweep.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           # exit 2 by design on a failed control: the sweep must not run
           # (nor post) on logic whose positive control just failed (#13653, review NanoClaw obs.1)
           python scripts/epic_neglect_sweep.py --self-test || exit 2


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #13702

## Fix

`scripts/.../epic-neglect-sweep.yml` ligne 59 : `set -uo pipefail` → `set -euo pipefail` (-e ajouté).

**Pourquoi** : `pipefail` seul ne propage un code non-zéro qu'à travers un *pipeline* (commande1 | commande2). Sur les appels `python ...` directs du step, il n'a aucun effet — seul `-e` fait échouer le step sur un retour non-zéro. Le `|| exit 2` ligne 62 capture déjà l'erreur `--self-test`, donc le step **fonctionne** aujourd'hui — mais l'absence de `-e` est un piège en puissance pour le prochain éditeur qui pensera « pipefail suffit » et retirera le `|| exit 2` en se fiant à la bash-strictness apparente.

**Crédit** : observation ai-01 (DM `msg-20260830T214027-jxu7uf` 23:40).

## Validation

- 8/8 self-test controls verts (commande locale : `bash -c "set -euo pipefail; python scripts/epic_neglect_sweep.py --self-test"`).
- Aucune régression sur le step `--apply-comment` (le sweep retourne 0 par design sur listing-failure, cf ligne 416 + 432 — `-e` ne casse rien ici).
- Diff minimal : +1/-1 caractère.

## Périmètre

Branche `fix/13676-pipefail-self-test` à merger dans `feature/13653-epic-neglect-sweep` pour clore #13676 (point ai-01 sur la série guard).

See #13676 — complément守卫.
