### PR TITLE
feat(genai,#1210): Aspire 07 SemanticFleet MultiConnector

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/07-Aspire-SemanticFleet-MultiConnector.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/07-Aspire-SemanticFleet-MultiConnector.ipynb
@@ -1,0 +1,1819 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0e2203e3",
+   "metadata": {},
+   "source": [
+    "# Aspire : le routeur MultiConnector — vetting en ligne, double file et traces\n",
+    "\n",
+    "Ce notebook réalise l'**Axe 6** de l'Epic [#1210](https://github.com/jsboige/CoursIA/issues/1210) (*semantic-fleet*, réactivée le 2026-08-18) : ressusciter la pièce maîtresse du repo [MyIntelligenceAgency/semantic-fleet](https://github.com/MyIntelligenceAgency/semantic-fleet) — le **MultiConnector** de 2023 — comme artefact pédagogique de la série Aspire, ré-instrumenté sous **OpenTelemetry**.\n",
+    "\n",
+    "semantic-fleet vit dans ce dépôt comme sous-module, épinglé au commit `9df3603` (branche `stable-from-v0343`, baseline propre du tag `v0.34.3`), dans `MyIA.AI.Notebooks/GenAI/SemanticKernel/semantic-fleet` — lisible en face de ce notebook.\n",
+    "\n",
+    "L'idée du MultiConnector (PR [microsoft/semantic-kernel#2323](https://github.com/microsoft/semantic-kernel/pull/2323), fermée sans review en janvier 2024) tient en une phrase : un **connecteur primaire** sert tout le trafic par défaut, et **charge de vérifier en ligne** (*vetting*) des connecteurs secondaires moins chers, pour leur **déléguer progressivement** (*offload*) les classes de prompts qu'ils savent traiter. En 2026, c'est exactement la question qu'un déploiement multi-modèles arbitre — le plus souvent à la main.\n",
+    "\n",
+    "La ligne de parité 2023 → 2026 :\n",
+    "\n",
+    "| Ce que faisait le code 2023 | Ce que ce notebook montre |\n",
+    "|---|---|\n",
+    "| `Stopwatch` + `ILogger` adossés au routeur | **`ActivitySource` + spans OTel** — la trace distribuée standard |\n",
+    "| Deux `Channel<T>` imbriqués (collecte, analyse) | Les mêmes canaux, **visibles comme spans imbriqués** `collecte.lot` → `analyse.pipeline` |\n",
+    "| Coûts/durées par connecteur, vetting en ligne | Le **POC arithmétique original** rejoué fidèlement (primaire 4 opérations, 4 secondaires mono-opération) |\n",
+    "| Pool de `ClientWebSocket` + serveur de test `HttpListener` | Un **banc de charge loopback réel** (sockets véritables, réponses pré-encodées, débit mesuré) |\n",
+    "\n",
+    "**Frontière d'honnêteté — à lire avant toute citation de ce notebook.** Tout s'exécute **CPU-only, sans aucun endpoint LLM** : les connecteurs sont des simulations arithmétiques déterministes, le serveur de flux est un loopback localhost. Les mesures de débit couvrent **le pipeline routeur + canaux + sockets**, jamais une génération de tokens. Le souvenir des « 20 000 chunks/s » de 2023 n'est **pas re-mesuré ici** ; le seul chiffre de débit cité dans ce notebook est celui que sa cellule de mesure produit.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "1. Expliquer le **vetting en ligne** : comment un primaire omniscient qualifie — ou rejette — des secondaires moins chers, sans supervision humaine ;\n",
+    "2. Distinguer les deux sémantiques de coalescence d'une double file : **accumulation** (chaque échantillon compte) contre **remplacement** (seule la dernière analyse survit) ;\n",
+    "3. Écrire un **debounce ancré sur l'horodatage de l'objet**, et dire pourquoi le debounce « au réveil » est la version ratée ;\n",
+    "4. Instrumenter un pipeline asynchrone avec **`ActivitySource`** et un exporteur OTel *dans le notebook* ;\n",
+    "5. Expliquer l'architecture **pool de sockets + serveur de test à réponse pré-encodée**, et ce qu'un tel banc mesure honnêtement.\n",
+    "\n",
+    "### Prérequis\n",
+    "\n",
+    "- Kernel `.net-csharp` (SDK .NET 9+) — aucun service externe, aucun secret, aucun Docker ;\n",
+    "- Les notebooks [03 — Observabilité](03-Aspire-Observabilite.ipynb) (spans OTel, sampler) et [04 — Streaming Agent](04-Aspire-Streaming-Agent.ipynb) (`System.Threading.Channels`) sont les voisins directs : les pièges de kernel OTel cités ici y sont démontrés.\n",
+    "\n",
+    "### Durée estimée : 60 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb85a1a5",
+   "metadata": {},
+   "source": [
+    "## 1. Ce que contient le sous-module — et ce qu'on rejoue\n",
+    "\n",
+    "Le sous-module épinglé à `9df3603` est lisible directement ; quatre zones fondent ce notebook :\n",
+    "\n",
+    "| Zone du sous-module | Fichiers | Ce qu'on en tire |\n",
+    "|---|---|---|\n",
+    "| **Mocks arithmétiques** | `dotnet/src/Connectors/Connectors.AI.MultiConnector/ArithmeticMocks/*.cs` | Le POC : primaire 4 opérations, secondaires mono-opération, coûts/durées distincts |\n",
+    "| **Chemin chaud + collecte** | `Connectors.AI.MultiConnector/MultiTextCompletion.cs:265-275` | Le `TryWrite` non bloquant et la boucle de collecte (coalescence par accumulation) |\n",
+    "| **Analyse différée** | `Connectors.AI.MultiConnector/Analysis/MultiCompletionAnalysisSettings.cs:908-947` | La seconde boucle (coalescence par remplacement) et son debounce |\n",
+    "| **Pool + serveur de test** | `Connectors.AI.Oobabooga/Completion/OobaboogaCompletionBase.cs:98-148`, `Connectors.UnitTests/WebSocketTestServer.cs` | Le pool `ConcurrentBag<ClientWebSocket>` et le serveur `HttpListener` à réponse pré-encodée |\n",
+    "\n",
+    "Pourquoi **rejouer** ces patterns plutôt que référencer le paquet NuGet `v0.34.3` ? Deux raisons, toutes deux assumées : (a) le livrable demandé est la **ré-instrumentation sous OTel** — il faut que les spans vivent *dans* le routeur, la collecte et l'analyse, or le code 2023 n'a aucun `ActivitySource` (l'axe A9/A10 du dépôt l'a mesuré : **zéro hit** à l'époque) ; (b) le paquet 2023 cible l'API Semantic Kernel *beta*, dont la restauration n'apporte rien ici. La simulation qui suit est donc **fidèle** aux structures citées — chaque cellule qui en reprend une le dit et la référence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "3a32bfe1",
+   "metadata": {},
+   "source": [
+    "// Le SDK OpenTelemetry (traces) : producteur ActivitySource + ecoute + exporteur.\n",
+    "// Version epinglee 1.11.1, la meme que le notebook 03 de la serie.\n",
+    "// Tout le reste (Channels, HttpListener, WebSockets) est BCL .NET — aucun endpoint externe.\n",
+    "#r \"nuget: OpenTelemetry, 1.11.1\"\n",
+    "\n",
+    "using System.Diagnostics;\n",
+    "using System.Threading;\n",
+    "using System.Threading.Channels;\n",
+    "using System.Net;\n",
+    "using System.Net.Sockets;\n",
+    "using System.Net.WebSockets;\n",
+    "using System.Text;\n",
+    "using System.Text.RegularExpressions;\n",
+    "using System.Collections.Concurrent;\n",
+    "using System.Globalization;\n",
+    "using OpenTelemetry;\n",
+    "using OpenTelemetry.Trace;\n",
+    "\n",
+    "Console.WriteLine(\"Packages charges : OpenTelemetry 1.11.1 (+ BCL .NET : Channels, HttpListener, WebSockets)\");"
+   ],
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": ""
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>OpenTelemetry</span></li></ul></div><div></div></div>"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Packages charges : OpenTelemetry 1.11.1 (+ BCL .NET : Channels, HttpListener, WebSockets)\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7695dde9",
+   "metadata": {},
+   "source": [
+    "Un seul paquet à restaurer : le SDK OpenTelemetry. Le transport de test (`System.Net.HttpListener`, `ClientWebSocket`) et la double file (`System.Threading.Channels`) sont dans la bibliothèque de base — c'est déjà une leçon : **le pipeline 2023 n'a jamais eu besoin d'un framework**, et il fonctionne tel quel sur .NET moderne."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1abcf4f2",
+   "metadata": {},
+   "source": [
+    "## 2. Le banc d'essai arithmétique : un LLM sans LLM\n",
+    "\n",
+    "Le POC 2023 remplace les modèles par de l'arithmétique : un prompt `Compute Add(8, 2)` attend la réponse `10`. Un « connecteur » y est défini par trois choses — les **opérations** qu'il sait faire, sa **latence** (simulée par `Task.Delay`, déterministe), et son **coût** par requête (un `decimal`, déterministe). La fidélité au comportement d'un LLM est structurelle : capacités partielles, latences et coûts différenciés — sans aucune dépendance réseau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ab14b983",
+   "metadata": {},
+   "source": [
+    "// Le moteur du POC, fidele a ArithmeticMocks/ArithmeticEngine.cs du sous-module.\n",
+    "public enum Operation { Add, Subtract, Multiply, Divide }\n",
+    "\n",
+    "public static class MoteurArithmetique\n",
+    "{\n",
+    "    public static int Calculer(Operation op, int a, int b) => op switch\n",
+    "    {\n",
+    "        Operation.Add => a + b,\n",
+    "        Operation.Subtract => a - b,\n",
+    "        Operation.Multiply => a * b,\n",
+    "        Operation.Divide => a / b,\n",
+    "        _ => throw new ArgumentOutOfRangeException(nameof(op))\n",
+    "    };\n",
+    "\n",
+    "    public static string GenererPrompt(Operation op, int a, int b) =>\n",
+    "        \"Compute \" + op + \"(\" + a.ToString(CultureInfo.InvariantCulture) + \", \" + b.ToString(CultureInfo.InvariantCulture) + \")\";\n",
+    "\n",
+    "    public static (Operation op, int a, int b) ParserPrompt(string prompt)\n",
+    "    {\n",
+    "        var m = Regex.Match(prompt, @\"Compute (?<operation>\\w+)\\((?<a>\\d+), (?<b>\\d+)\\)\");\n",
+    "        if (!m.Success) throw new ArgumentException(\"Prompt invalide : \" + prompt);\n",
+    "        return (Enum.Parse<Operation>(m.Groups[\"operation\"].Value),\n",
+    "                int.Parse(m.Groups[\"a\"].Value, CultureInfo.InvariantCulture),\n",
+    "                int.Parse(m.Groups[\"b\"].Value, CultureInfo.InvariantCulture));\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Les operandes discriminateurs du notebook 03 du sous-module : 8 et 2 donnent\n",
+    "// quatre resultats TOUS distincts — une reponse fausse ne coincide jamais avec la bonne.\n",
+    "foreach (Operation op in Enum.GetValues<Operation>())\n",
+    "{\n",
+    "    var prompt = MoteurArithmetique.GenererPrompt(op, 8, 2);\n",
+    "    Console.WriteLine(prompt.PadRight(28) + \" => \" + MoteurArithmetique.Calculer(op, 8, 2));\n",
+    "}"
+   ],
+   "execution_count": 2,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Add(8, 2)            => 10\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Subtract(8, 2)       => 6\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Multiply(8, 2)       => 16\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Divide(8, 2)         => 4\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae9ce2e2",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : pourquoi 8 et 2\n",
+    "\n",
+    "Les quatre sorties sont `10`, `6`, `16`, `4` — toutes différentes. C'est la propriété qui rend le **vetting mécanique** possible : quand un secondaire qui ne sait faire que `Add` répond `11` à `Compute Add(8, 2)`, la bonne réponse `10` n'est égale à **aucune** autre réponse possible du banc — l'erreur est toujours détectable par simple comparaison. Un seul prompt par opération suffit donc à qualifier un connecteur, ce qui explique le réglage 2023 `NbPromptTests = 1`. Le couple `(8, 2)` n'est pas une convention esthétique : c'est un jeu de tests complet en quatre prompts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5884f75",
+   "metadata": {},
+   "source": [
+    "### La flotte : un primaire omniscient, quatre spécialistes\n",
+    "\n",
+    "La flotte reprend les chiffres exacts du notebook 03 du sous-module. Le primaire sait faire les quatre opérations mais est **10 fois plus lent** et **2 fois plus cher** que chaque spécialiste ; chaque secondaire ne sait faire **qu'une** opération. La question du routeur est alors purement économique : *pour chaque classe de prompt, qui peut répondre — à quelle latence, à quel prix, sans se tromper ?*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "e8912e70",
+   "metadata": {},
+   "source": [
+    "// Un connecteur = capacites + latence simulee + cout, fidele a ArithmeticCompletionService.cs.\n",
+    "// (Pas d'annotations nullable : le contexte script du kernel n'active pas #nullable.)\n",
+    "public sealed class ConnecteurArithmetique\n",
+    "{\n",
+    "    public ConnecteurArithmetique(string nom, IReadOnlySet<Operation> operations, TimeSpan delai, decimal cout,\n",
+    "        Func<Operation, int, int, int> substitut = null)\n",
+    "    { this.Nom = nom; this.Operations = operations; this.Delai = delai; this.Cout = cout; this.Substitut = substitut; }\n",
+    "\n",
+    "    public string Nom { get; }\n",
+    "    public IReadOnlySet<Operation> Operations { get; }\n",
+    "    public TimeSpan Delai { get; }                                  // latence simulee, determine\n",
+    "    public decimal Cout { get; }                                    // cout par requete, determine\n",
+    "    public Func<Operation, int, int, int> Substitut { get; }        // moteur corrompu (section 8)\n",
+    "\n",
+    "    public bool SaitFaire(Operation op) => this.Operations.Contains(op);\n",
+    "\n",
+    "    public async Task<string> RepondreAsync(string prompt)\n",
+    "    {\n",
+    "        await Task.Delay(this.Delai);                               // la \"latence provider\" du POC\n",
+    "        var (op, a, b) = MoteurArithmetique.ParserPrompt(prompt);\n",
+    "        if (!this.SaitFaire(op))\n",
+    "            throw new InvalidOperationException(this.Nom + \" ne sait pas faire \" + op);\n",
+    "        var resultat = this.Substitut is null ? MoteurArithmetique.Calculer(op, a, b) : this.Substitut(op, a, b);\n",
+    "        return resultat.ToString(CultureInfo.InvariantCulture);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "public static class Flotte\n",
+    "{\n",
+    "    // Les chiffres du notebook 03 du sous-module : primaire 20 ms / 0.02 u, secondaires 2 ms / 0.01 u.\n",
+    "    public static List<ConnecteurArithmetique> PocStandard() => new()\n",
+    "    {\n",
+    "        new(\"Primaire\", Enum.GetValues<Operation>().ToHashSet(), TimeSpan.FromMilliseconds(20), 0.02m),\n",
+    "        new(\"Secondaire-Add\",      new HashSet<Operation> { Operation.Add },      TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "        new(\"Secondaire-Subtract\", new HashSet<Operation> { Operation.Subtract }, TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "        new(\"Secondaire-Multiply\", new HashSet<Operation> { Operation.Multiply }, TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "        new(\"Secondaire-Divide\",   new HashSet<Operation> { Operation.Divide },   TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "    };\n",
+    "}\n",
+    "\n",
+    "foreach (var c in Flotte.PocStandard())\n",
+    "{\n",
+    "    var ops = string.Join(\",\", c.Operations.Select(o => o.ToString()).OrderBy(s => s, StringComparer.Ordinal));\n",
+    "    Console.WriteLine(c.Nom.PadRight(21) + (\"ops=[\" + ops + \"]\").PadRight(36)\n",
+    "        + \" delai=\" + c.Delai.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) + \" ms\"\n",
+    "        + \"  cout=\" + c.Cout.ToString(\"0.00\", CultureInfo.InvariantCulture) + \" u/req\");\n",
+    "}"
+   ],
+   "execution_count": 3,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Primaire             ops=[Add,Divide,Multiply,Subtract]   delai=20 ms  cout=0.02 u/req\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Secondaire-Add       ops=[Add]                            delai=2 ms  cout=0.01 u/req\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Secondaire-Subtract  ops=[Subtract]                       delai=2 ms  cout=0.01 u/req\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Secondaire-Multiply  ops=[Multiply]                       delai=2 ms  cout=0.01 u/req\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Secondaire-Divide    ops=[Divide]                         delai=2 ms  cout=0.01 u/req\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0863b3d1",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la structure économique du routage\n",
+    "\n",
+    "Cinq connecteurs, deux régimes. Le primaire paie `0.02 u` et `20 ms` par requête *quoi qu'il arrive* ; un spécialiste paie la moitié — `0.01 u` et `2 ms` — mais **uniquement** sur son opération. Si le vetting confirme les quatre spécialistes, un cycle des quatre opérations passe de `4 x 0.02 = 0.08 u` à `4 x 0.01 = 0.04 u` (coût divisé par deux) et le délai simulé cumulé de `80 ms` à `8 ms`. Ce gain n'est pas une hypothèse : les deux passes de la section 4 le mesurent. Et le prix d'entrée est la **confiance** — que le primaire doit construire en vérifiant chaque secondaire, opération par opération."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a67e44f",
+   "metadata": {},
+   "source": [
+    "## 3. Le routeur : plan de routage et chemin chaud\n",
+    "\n",
+    "Le routeur 2023 tient en deux décisions. D'abord un **plan de routage** qui associe une *signature* de prompt — ici, l'opération — à un connecteur ; vide au départ, donc tout passe par le primaire. Ensuite un **chemin chaud** qui journalise chaque appel dans un canal non borné par un simple `TryWrite` : la complétion rend la main dès sa réponse livrée, la journalisation et le vetting vivent en aval, découplés. C'est la raison pour laquelle journaliser ne coûte rien au débit — tout ce qui est mesuré par la section 7 est **en aval** de cette décision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "d5f9e2e1",
+   "metadata": {},
+   "source": [
+    "// L'ActivitySource : le producteur de spans, nomme comme un service (continuite Aspire03).\n",
+    "ActivitySource source = new(\"Aspire07.SemanticFleet\");\n",
+    "\n",
+    "// Exporteur \"dans le notebook\" : capte chaque span a sa fermeture dans une liste que les\n",
+    "// cellules suivantes peuvent lire — la memoire du notebook joue le role du backend de traces.\n",
+    "public sealed class ExporteurNotebook : BaseExporter<Activity>\n",
+    "{\n",
+    "    private readonly object _verrou = new();\n",
+    "    private readonly List<Activity> _spans = new();\n",
+    "\n",
+    "    public override ExportResult Export(in Batch<Activity> lot)\n",
+    "    {\n",
+    "        lock (this._verrou) { foreach (var span in lot) this._spans.Add(span); }\n",
+    "        return ExportResult.Success;\n",
+    "    }\n",
+    "\n",
+    "    public List<Activity> Capturer() { lock (this._verrou) return new(this._spans); }\n",
+    "    public List<Activity> CapturerEtVider() { lock (this._verrou) { var copie = new List<Activity>(this._spans); this._spans.Clear(); return copie; } }\n",
+    "}\n",
+    "\n",
+    "var exporteur = new ExporteurNotebook();\n",
+    "\n",
+    "// Les deux precautions du notebook 03 restent vraies ici (contexte kernel) :\n",
+    "// - AlwaysOnSampler : le kernel maintient une Activity parent ambiante ; le sampler\n",
+    "//   ParentBased par defaut refuserait tout span local -> StartActivity rendrait null ;\n",
+    "// - SimpleActivityExportProcessor : export a la FERMETURE du span ; le processeur batch\n",
+    "//   par defaut ne flush jamais dans un kernel vivant.\n",
+    "var provider = Sdk.CreateTracerProviderBuilder()\n",
+    "    .AddSource(\"Aspire07.SemanticFleet\")\n",
+    "    .SetSampler(new AlwaysOnSampler())\n",
+    "    .AddProcessor(new SimpleActivityExportProcessor(exporteur))\n",
+    "    .Build();\n",
+    "\n",
+    "Console.WriteLine(\"Telemetrie armee : source Aspire07.SemanticFleet, exporteur memoire branche\");"
+   ],
+   "execution_count": 4,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Telemetrie armee : source Aspire07.SemanticFleet, exporteur memoire branche\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'System.ComponentModel, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'OpenTelemetry' correspond à l'identité 'System.ComponentModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.ComponentModel', il se peut que vous deviez fournir une stratégie runtime\r\n\r\nwarning CS1701: En supposant que la référence d'assembly 'System.Diagnostics.DiagnosticSource, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' utilisée par 'OpenTelemetry' correspond à l'identité 'System.Diagnostics.DiagnosticSource, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' de 'System.Diagnostics.DiagnosticSource', il se peut que vous deviez fournir une stratégie runtime\r\n\r\nwarning CS1701: En supposant que la référence d'assembly 'System.Diagnostics.DiagnosticSource, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' utilisée par 'OpenTelemetry' correspond à l'identité 'System.Diagnostics.DiagnosticSource, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' de 'System.Diagnostics.DiagnosticSource', il se peut que vous deviez fournir une stratégie runtime\r\n\r\nwarning CS1701: En supposant que la référence d'assembly 'System.Diagnostics.DiagnosticSource, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' utilisée par 'OpenTelemetry' correspond à l'identité 'System.Diagnostics.DiagnosticSource, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' de 'System.Diagnostics.DiagnosticSource', il se peut que vous deviez fournir une stratégie runtime\r\n\r\nwarning CS1701: En supposant que la référence d'assembly 'System.ComponentModel, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'OpenTelemetry' correspond à l'identité 'System.ComponentModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.ComponentModel', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "976e4270",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'instrumentation : un exporteur pour le notebook\n",
+    "\n",
+    "Trois choix à remarquer. L'exporteur dérive de `BaseExporter<Activity>` — c'est le **même contrat** que l'exporteur console ou OTLP ; seules la destination (une liste en mémoire) et sa lecture (les cellules suivantes) changent. Les deux garde-fous commentés viennent du notebook 03 : sampler forcé et export à la fermeture ne sont pas du pédagogisme — ce sont les deux façons dont un kernel .NET Interactive casse silencieusement une chaîne OTel (spans à `null`, batch jamais flushé). Enfin — c'est le point A9/A10 du dépôt — le code 2023 de semantic-fleet **n'avait rien de tout cela** : ses mesures vivaient dans des `Stopwatch` et des journaux. La ré-instrumentation consiste précisément à remplacer chaque `Stopwatch` par un span qui porte ses propres tags."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "e8207d13",
+   "metadata": {},
+   "source": [
+    "// L'echantillon journalise par le chemin chaud (l'equivalent du ConnectorTest 2023),\n",
+    "// et le lot qui traverse le deuxieme etage.\n",
+    "public readonly record struct Echantillon(string Prompt, string Connecteur, string Reponse, int DureeMs, decimal Cout, DateTime Horodatage);\n",
+    "public sealed record LotAnalyse(IReadOnlyList<Echantillon> Source, DateTime Horodatage, ActivityContext Parent);\n",
+    "\n",
+    "public sealed class RouteurMulti\n",
+    "{\n",
+    "    private readonly List<ConnecteurArithmetique> _flotte;\n",
+    "    private readonly Channel<Echantillon> _fileCollecte;\n",
+    "    private readonly ActivitySource _telemetrie;\n",
+    "\n",
+    "    public RouteurMulti(List<ConnecteurArithmetique> flotte, ActivitySource telemetrie)\n",
+    "    {\n",
+    "        this._flotte = flotte;\n",
+    "        this._fileCollecte = Channel.CreateUnbounded<Echantillon>();   // chemin chaud : jamais d'attente\n",
+    "        this._telemetrie = telemetrie;\n",
+    "    }\n",
+    "\n",
+    "    public ConnecteurArithmetique Primaire => this._flotte[0];\n",
+    "    public IReadOnlyList<ConnecteurArithmetique> Secondaires => this._flotte.Skip(1).ToList();\n",
+    "    public ChannelReader<Echantillon> Journal => this._fileCollecte.Reader;\n",
+    "    public ChannelWriter<Echantillon> JournalEcriture => this._fileCollecte.Writer;\n",
+    "    public int EnAttente => this._fileCollecte.Reader.Count;\n",
+    "\n",
+    "    // Le plan de routage : signature (l'operation) -> connecteur. Vide au depart : tout au primaire.\n",
+    "    public ConcurrentDictionary<string, ConnecteurArithmetique> Plan { get; } = new();\n",
+    "\n",
+    "    public async Task<(string Reponse, ConnecteurArithmetique Choisi)> CompleterAsync(string prompt)\n",
+    "    {\n",
+    "        var (op, _, _) = MoteurArithmetique.ParserPrompt(prompt);\n",
+    "        var choix = this.Plan.TryGetValue(op.ToString(), out var cible) ? cible : this.Primaire;\n",
+    "\n",
+    "        using var span = this._telemetrie.StartActivity(\"routeur.completion\");\n",
+    "        span?.SetTag(\"prompt.operation\", op.ToString());\n",
+    "        span?.SetTag(\"connecteur\", choix.Nom);\n",
+    "        span?.SetTag(\"offload\", !ReferenceEquals(choix, this.Primaire));\n",
+    "\n",
+    "        var chrono = Stopwatch.StartNew();\n",
+    "        var reponse = await choix.RepondreAsync(prompt);\n",
+    "        chrono.Stop();\n",
+    "        span?.SetTag(\"duree.ms\", chrono.ElapsedMilliseconds);\n",
+    "        span?.SetTag(\"cout.unite\", choix.Cout.ToString(\"0.00\", CultureInfo.InvariantCulture));\n",
+    "\n",
+    "        // LE chemin chaud : un TryWrite sur canal non borne — non bloquant, ne peut pas echouer\n",
+    "        // (cf. MultiTextCompletion.cs:275, AppendConnectorTest).\n",
+    "        this.JournalEcriture.TryWrite(new Echantillon(prompt, choix.Nom, reponse,\n",
+    "            (int)chrono.ElapsedMilliseconds, choix.Cout, DateTime.Now));\n",
+    "\n",
+    "        return (reponse, choix);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var routeur = new RouteurMulti(Flotte.PocStandard(), source);\n",
+    "Console.WriteLine(\"Routeur arme. Plan initial : \" + routeur.Plan.Count + \" entree(s) — tout le trafic passe par \"\n",
+    "    + routeur.Primaire.Nom);"
+   ],
+   "execution_count": 5,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Routeur arme. Plan initial : 0 entree(s) — tout le trafic passe par Primaire\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8bb5528",
+   "metadata": {},
+   "source": [
+    "### Lecture du chemin chaud\n",
+    "\n",
+    "La dernière instruction de `CompleterAsync` est tout le secret du débit 2023 : `TryWrite` sur un canal `CreateUnbounded` **ne bloque jamais et ne peut pas échouer** — ni attente de place, ni backpressure sur le chemin de la réponse. L'échantillon (prompt, connecteur, réponse, durée, coût, horodatage) part en file, et l'appelant a déjà sa réponse. Comparez avec l'alternative naïve — journaliser *dans* l'appel — qui mettrait la latence du journal sur chaque complétion. La section 7 reprendra la même discipline côté transport — un canal non borné par appel, alimenté par la tâche de réception pendant que le client consomme — et mesurera ce qu'elle vaut en débit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f75ba028",
+   "metadata": {},
+   "source": [
+    "## 4. Vetting en ligne : première passe, analyse, deuxième passe\n",
+    "\n",
+    "Le protocole du POC, en trois temps :\n",
+    "\n",
+    "1. **Première passe** — quatre prompts (un par opération), aucun plan : tout passe par le primaire, chaque appel journalise un échantillon. Coût plein.\n",
+    "2. **Analyse** — les deux pompes de fond se déclenchent : la **collecte** draine les échantillons (coalescence par accumulation) et forme un lot ; la file d'**analyse** (coalescence par remplacement) **rejoue** chaque prompt sur le secondaire concerné ; le **primaire recalcule** la bonne réponse et compare — c'est le vetting. Verdict conforme → le plan délègue la signature au secondaire.\n",
+    "3. **Deuxième passe** — les mêmes quatre prompts, sur le plan mis à jour."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "48cdde27",
+   "metadata": {},
+   "source": [
+    "// Premiere passe : les quatre operateurs discriminateurs, tout sur le primaire.\n",
+    "var travaux = Enum.GetValues<Operation>().Select(op => MoteurArithmetique.GenererPrompt(op, 8, 2)).ToArray();\n",
+    "\n",
+    "decimal coutPasse1 = 0m;\n",
+    "var delaiSimule1 = TimeSpan.Zero;\n",
+    "foreach (var t in travaux)\n",
+    "{\n",
+    "    var (reponse, choisi) = await routeur.CompleterAsync(t);\n",
+    "    coutPasse1 += choisi.Cout; delaiSimule1 += choisi.Delai;\n",
+    "    Console.WriteLine(t.PadRight(28) + \" => \" + reponse.PadRight(4) + \" par \" + choisi.Nom);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"---\");\n",
+    "Console.WriteLine(\"Cout passe 1 : \" + coutPasse1.ToString(\"0.00\", CultureInfo.InvariantCulture)\n",
+    "    + \" u ; delai simule cumule : \" + delaiSimule1.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)\n",
+    "    + \" ms ; echantillons en file de collecte : \" + routeur.EnAttente);"
+   ],
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Add(8, 2)            => 10   par Primaire\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Subtract(8, 2)       => 6    par Primaire\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Multiply(8, 2)       => 16   par Primaire\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Divide(8, 2)         => 4    par Primaire\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Cout passe 1 : 0.08 u ; delai simule cumule : 80 ms ; echantillons en file de collecte : 4\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ae8557e",
+   "metadata": {},
+   "source": [
+    "### Lecture de la première passe\n",
+    "\n",
+    "Les quatre réponses sont correctes (`10`, `6`, `16`, `4`) et **toutes** portées par le primaire — le plan est vide, c'est le comportement attendu d'un routeur qui ne fait pas encore confiance. Le coût total est `0.08 u` (quatre fois `0.02`) pour un délai simulé cumulé de `80 ms`. Le point décisif est la dernière ligne : **quatre échantillons attendent en file de collecte**. Rien n'a encore été analysé — le primaire a répondu, le système a observé, et l'observation attend son traitement différé. La double file entre maintenant en scène."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "e4559411",
+   "metadata": {},
+   "source": [
+    "// Les deux pompes de fond de la double file, fideles aux boucles 2023 :\n",
+    "// - CollectSamplesAsync (MultiTextCompletion.cs:217-236) : coalescence par ACCUMULATION ;\n",
+    "// - AnalyzeDataAsync (MultiCompletionAnalysisSettings.cs:908-947) : coalescence par REMPLACEMENT.\n",
+    "public sealed record LigneVerite(string Connecteur, string Signature, bool Conforme, bool Offload);\n",
+    "\n",
+    "public sealed class AtelierVetting : IDisposable\n",
+    "{\n",
+    "    private readonly RouteurMulti _routeur;\n",
+    "    private readonly ActivitySource _telemetrie;\n",
+    "    private readonly Channel<LotAnalyse> _fileAnalyse = Channel.CreateUnbounded<LotAnalyse>();\n",
+    "    private readonly CancellationTokenSource _cts = new();\n",
+    "    private int _analysesEnCours;\n",
+    "    private int _analyseEnAttente;   // un job est lu mais son debounce court encore\n",
+    "\n",
+    "    public AtelierVetting(RouteurMulti routeur, ActivitySource telemetrie)\n",
+    "    { this._routeur = routeur; this._telemetrie = telemetrie; }\n",
+    "\n",
+    "    public TimeSpan FenetreCollecte { get; set; } = TimeSpan.FromMilliseconds(50);\n",
+    "    public TimeSpan FenetreAnalyse  { get; set; } = TimeSpan.FromMilliseconds(50);\n",
+    "    public int LotsFormes { get; private set; }\n",
+    "    public int AnalysesExecutees { get; private set; }\n",
+    "    public int TestsRejoues { get; private set; }\n",
+    "    public decimal CoutVetting { get; private set; }\n",
+    "    public ConcurrentQueue<string> Journal { get; } = new();\n",
+    "    public List<LigneVerite> TableVerite { get; } = new();\n",
+    "\n",
+    "    public void Demarrer()\n",
+    "    {\n",
+    "        _ = Task.Factory.StartNew(() => this.BoucleCollecteAsync(this._cts.Token),\n",
+    "            this._cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);\n",
+    "        _ = Task.Factory.StartNew(() => this.BoucleAnalyseAsync(this._cts.Token),\n",
+    "            this._cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);\n",
+    "    }\n",
+    "\n",
+    "    // Etage 1 : ACCUMULATION — chaque echantillon compte, on les garde tous.\n",
+    "    private async Task BoucleCollecteAsync(CancellationToken ct)\n",
+    "    {\n",
+    "        while (!ct.IsCancellationRequested && await this._routeur.Journal.WaitToReadAsync(ct))\n",
+    "        {\n",
+    "            using var span = this._telemetrie.StartActivity(\"collecte.lot\");\n",
+    "            var serie = new List<Echantillon>();\n",
+    "            while (this._routeur.Journal.TryRead(out var echantillon))\n",
+    "            {\n",
+    "                // Debounce ANCRE SUR L'OBJET : la fenetre court depuis la NAISSANCE de\n",
+    "                // l'echantillon, pas depuis le reveil de la boucle.\n",
+    "                var attente = echantillon.Horodatage + this.FenetreCollecte - DateTime.Now;\n",
+    "                if (attente > TimeSpan.FromMilliseconds(1)) await Task.Delay(attente, ct);\n",
+    "                serie.Add(echantillon);\n",
+    "            }\n",
+    "            if (serie.Count == 0) continue;\n",
+    "\n",
+    "            this.LotsFormes++;\n",
+    "            span?.SetTag(\"lot.numero\", this.LotsFormes);\n",
+    "            span?.SetTag(\"lot.echantillons\", serie.Count);\n",
+    "            this.Journal.Enqueue(\"LOT \" + this.LotsFormes + \" forme : \" + serie.Count + \" echantillons (accumulation)\");\n",
+    "            this._fileAnalyse.Writer.TryWrite(new LotAnalyse(serie, DateTime.Now, span?.Context ?? default));\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    // Etage 2 : REMPLACEMENT — seule la DERNIERE analyse en attente survit.\n",
+    "    private async Task BoucleAnalyseAsync(CancellationToken ct)\n",
+    "    {\n",
+    "        while (!ct.IsCancellationRequested && await this._fileAnalyse.Reader.WaitToReadAsync(ct))\n",
+    "        {\n",
+    "            LotAnalyse courant = null;\n",
+    "            while (this._fileAnalyse.Reader.TryRead(out var nouveau))\n",
+    "            {\n",
+    "                courant = nouveau;   // ecrase : N declencheurs s'effondrent en une execution\n",
+    "                Volatile.Write(ref this._analyseEnAttente, 1);\n",
+    "                var attente = courant.Horodatage + this.FenetreAnalyse - DateTime.Now;\n",
+    "                if (attente > TimeSpan.FromMilliseconds(1)) await Task.Delay(attente, ct);\n",
+    "            }\n",
+    "            if (courant is null) continue;\n",
+    "\n",
+    "            Volatile.Write(ref this._analyseEnAttente, 0);   // le debounce est ferme : on execute\n",
+    "            Interlocked.Increment(ref this._analysesEnCours);\n",
+    "            try { await this.ExecuterAnalyseAsync(courant, ct); }\n",
+    "            finally { Interlocked.Decrement(ref this._analysesEnCours); }\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    // Le vetting : rejouer les prompts sur les secondaires ; le PRIMAIRE recalcule et compare.\n",
+    "    private async Task ExecuterAnalyseAsync(LotAnalyse lot, CancellationToken ct)\n",
+    "    {\n",
+    "        using var span = this._telemetrie.StartActivity(\"analyse.pipeline\", ActivityKind.Internal, lot.Parent);\n",
+    "        this.AnalysesExecutees++;\n",
+    "        this.Journal.Enqueue(\"ANALYSE \" + this.AnalysesExecutees + \" executee : \" + lot.Source.Count\n",
+    "            + \" echantillons en entree (remplacement)\");\n",
+    "\n",
+    "        var parSignature = lot.Source\n",
+    "            .GroupBy(e => MoteurArithmetique.ParserPrompt(e.Prompt).op.ToString())\n",
+    "            .ToDictionary(g => g.Key, g => g.DistinctBy(e => e.Prompt).ToList());\n",
+    "\n",
+    "        foreach (var secondaire in this._routeur.Secondaires)\n",
+    "        {\n",
+    "            foreach (var (signature, serie) in parSignature)\n",
+    "            {\n",
+    "                if (!secondaire.SaitFaire(Enum.Parse<Operation>(signature))) continue;\n",
+    "\n",
+    "                var conforme = true;\n",
+    "                foreach (var e in serie)\n",
+    "                {\n",
+    "                    this.TestsRejoues++;\n",
+    "                    this.CoutVetting += this._routeur.Primaire.Cout;   // le primaire paie chaque verification\n",
+    "                    var reponseSecondaire = await secondaire.RepondreAsync(e.Prompt);\n",
+    "                    var (op, a, b) = MoteurArithmetique.ParserPrompt(e.Prompt);\n",
+    "                    var attendu = MoteurArithmetique.Calculer(op, a, b).ToString(CultureInfo.InvariantCulture);\n",
+    "                    if (reponseSecondaire != attendu) conforme = false;\n",
+    "                }\n",
+    "\n",
+    "                var offload = conforme;   // conforme et moins cher : on delegue la signature\n",
+    "                this.TableVerite.Add(new LigneVerite(secondaire.Nom, signature, conforme, offload));\n",
+    "                if (offload) this._routeur.Plan[signature] = secondaire;\n",
+    "            }\n",
+    "        }\n",
+    "        span?.SetTag(\"tests.rejoues\", this.TestsRejoues);\n",
+    "        span?.SetTag(\"offloads.accordes\", this._routeur.Plan.Count);\n",
+    "    }\n",
+    "\n",
+    "    // Attente de quiescence pour le notebook : canaux vides, rien en cours, ET aucun\n",
+    "    // job tenant dans le debounce (sinon la cellule imprimerait \"0 analyses\" alors\n",
+    "    // qu'une execution est deja promise — le job est lu mais attend sa fenetre).\n",
+    "    public async Task AttendreQuiescenceAsync(TimeSpan? delaiMax = null)\n",
+    "    {\n",
+    "        bool Calme() => this._routeur.EnAttente == 0 && this._fileAnalyse.Reader.Count == 0\n",
+    "            && Volatile.Read(ref this._analysesEnCours) == 0\n",
+    "            && Volatile.Read(ref this._analyseEnAttente) == 0;\n",
+    "\n",
+    "        var fin = DateTime.Now + (delaiMax ?? TimeSpan.FromSeconds(20));\n",
+    "        while (DateTime.Now < fin)\n",
+    "        {\n",
+    "            if (Calme())\n",
+    "            {\n",
+    "                await Task.Delay(60);\n",
+    "                if (Calme()) return;\n",
+    "            }\n",
+    "            await Task.Delay(20);\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    public void Dispose() => this._cts.Cancel();\n",
+    "}\n",
+    "\n",
+    "var atelier = new AtelierVetting(routeur, source);\n",
+    "atelier.Demarrer();\n",
+    "await atelier.AttendreQuiescenceAsync();\n",
+    "\n",
+    "Console.WriteLine(\"Journal de la double file :\");\n",
+    "foreach (var ligne in atelier.Journal) Console.WriteLine(\"  \" + ligne);\n",
+    "Console.WriteLine(\"---\");\n",
+    "Console.WriteLine(\"Table de verite du vetting :\");\n",
+    "foreach (var v in atelier.TableVerite)\n",
+    "    Console.WriteLine(\"  \" + v.Connecteur.PadRight(21) + \" x \" + v.Signature.PadRight(9)\n",
+    "        + \" conforme=\" + (v.Conforme ? \"oui\" : \"NON\") + \"  offload=\" + (v.Offload ? \"oui\" : \"non\"));\n",
+    "Console.WriteLine(\"---\");\n",
+    "Console.WriteLine(\"Plan de routage apres analyse :\");\n",
+    "foreach (var entree in routeur.Plan.OrderBy(kv => kv.Key, StringComparer.Ordinal))\n",
+    "    Console.WriteLine(\"  \" + entree.Key.PadRight(9) + \" -> \" + entree.Value.Nom);\n",
+    "Console.WriteLine(\"Cout du vetting lui-meme : \" + atelier.CoutVetting.ToString(\"0.00\", CultureInfo.InvariantCulture)\n",
+    "    + \" u (\" + atelier.TestsRejoues + \" tests rejoues payes au prix primaire)\");"
+   ],
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Journal de la double file :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  LOT 1 forme : 4 echantillons (accumulation)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  ANALYSE 1 executee : 4 echantillons en entree (remplacement)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Table de verite du vetting :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Add        x Add       conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Subtract   x Subtract  conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Multiply   x Multiply  conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Divide     x Divide    conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Plan de routage apres analyse :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Add       -> Secondaire-Add\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Divide    -> Secondaire-Divide\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Multiply  -> Secondaire-Multiply\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Subtract  -> Secondaire-Subtract\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Cout du vetting lui-meme : 0.08 u (4 tests rejoues payes au prix primaire)\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5147cf6b",
+   "metadata": {},
+   "source": [
+    "### Lecture de la double file : deux canaux, deux coalescences\n",
+    "\n",
+    "Le journal montre la mécanique complète : **quatre échantillons drainer en un seul lot** (l'accumulation les a tous gardés), puis **une seule analyse** exécutée. La table de vérité dit le reste — les quatre secondaires sont conformes sur leur opération, donc les quatre signatures passent au plan de routage. Le vetting a un coût (`0.08 u` ici : chaque vérification est un calcul au prix primaire), et c'est honnête : l'offload se rembourse sur le volume — dès la deuxième passe.\n",
+    "\n",
+    "Le point que le code 2023 avait et que peu de tutoriels montrent : **le même idiome de canal, deux sémantiques de coalescence**, choisies par ce que la charge utile *signifie*.\n",
+    "\n",
+    "| Étage | Coalescence | Code 2023 | Pourquoi |\n",
+    "|---|---|---|---|\n",
+    "| **Collecte** (`Channel<ConnectorTest>`) | **Accumulation** — la série garde chaque échantillon | `MultiTextCompletion.cs:217-236` | Chaque échantillon est une *preuve* du vetting : on les garde tous |\n",
+    "| **Analyse** (`Channel<AnalysisJob>`) | **Remplacement** — `courant = nouveau` écrase | `MultiCompletionAnalysisSettings.cs:908-928` | L'analyse est *idempotente* sur l'état accumulé et chère (elle appelle le primaire) : la rejouer N fois serait du gaspillage |\n",
+    "\n",
+    "Et le **debounce ancré** : dans les deux boucles, le délai se calcule `horodatage + fenêtre − maintenant` — la fenêtre court depuis la **naissance** de l'échantillon, pas depuis le réveil de la boucle. Une rafale qui arrive en retard n'ajoute donc pas de latence : c'est la forme correcte du debounce, souvent ratée (l'exercice 2 vous la fait rater exprès).\n",
+    "\n",
+    "Un mot d'honnêteté sur le lancement : l'option `TaskCreationOptions.LongRunning` (2023 : `MultiTextCompletion.cs:206`) fournit un thread dédié **jusqu'au premier `await`** — pas au-delà. Sans `SynchronizationContext`, chaque continuation après un `await` repart sur le *thread pool* : la boucle est « longue » par sa durée de vie, pas épinglée à un thread. C'est le fonctionnement attendu d'une pompe asynchrone — et une raison de plus pour que son état passe par des canaux, pas par des variables partagées sensibles au thread.\n",
+    "\n",
+    "Et une précision symétrique sur les canaux : **non bornés** (`CreateUnbounded`) ne veut pas dire « régulés ». Ils découplent l'écrivain du lecteur — l'écrivain ne bloque jamais — mais n'offrent **aucune backpressure** : si le lecteur s'arrête, la file grandit sans limite. C'est un choix délibéré du chemin chaud 2023 (la journalisation ne doit jamais freiner une complétion), dont le contrecoût — une file non bornée en cas de panne du lecteur — est assumé par le design de la section 9 (arrêt explicite des pompes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ca035b59",
+   "metadata": {},
+   "source": [
+    "// Deuxieme passe : les memes quatre prompts, sur le plan mis a jour par le vetting.\n",
+    "decimal coutPasse2 = 0m;\n",
+    "var delaiSimule2 = TimeSpan.Zero;\n",
+    "foreach (var t in travaux)\n",
+    "{\n",
+    "    var (reponse, choisi) = await routeur.CompleterAsync(t);\n",
+    "    coutPasse2 += choisi.Cout; delaiSimule2 += choisi.Delai;\n",
+    "    Console.WriteLine(t.PadRight(28) + \" => \" + reponse.PadRight(4) + \" par \" + choisi.Nom);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"---\");\n",
+    "Console.WriteLine(\"                    passe 1 (primaire)   passe 2 (offload)\");\n",
+    "Console.WriteLine(\"cout total          \" + coutPasse1.ToString(\"0.00\", CultureInfo.InvariantCulture).PadLeft(8)\n",
+    "    + \" u\" + coutPasse2.ToString(\"0.00\", CultureInfo.InvariantCulture).PadLeft(16) + \" u\");\n",
+    "Console.WriteLine(\"delai simule cumule \" + delaiSimule1.TotalMilliseconds.ToString(CultureInfo.InvariantCulture).PadLeft(8)\n",
+    "    + \" ms\" + delaiSimule2.TotalMilliseconds.ToString(CultureInfo.InvariantCulture).PadLeft(14) + \" ms\");"
+   ],
+   "execution_count": 8,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Add(8, 2)            => 10   par Secondaire-Add\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Subtract(8, 2)       => 6    par Secondaire-Subtract\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Multiply(8, 2)       => 16   par Secondaire-Multiply\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Compute Divide(8, 2)         => 4    par Secondaire-Divide\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "                    passe 1 (primaire)   passe 2 (offload)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "cout total              0.08 u            0.04 u\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "delai simule cumule       80 ms             8 ms\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5f72eec",
+   "metadata": {},
+   "source": [
+    "### Lecture de la deuxième passe : l'offload payé\n",
+    "\n",
+    "Les quatre réponses sont **identiques** aux bonnes valeurs de la première passe — le routage n'a rien coûté en exactitude — mais chacune est maintenant portée par son spécialiste. Le coût tombe de `0.08 u` à `0.04 u` (**divisé par deux**, exactement la structure des tarifs), et le délai simulé cumulé de `80 ms` à `8 ms` (**divisé par dix**, le rapport 20 ms / 2 ms des latences configurées). Ces deux ratios sont *structurels* — ils viennent des tarifs et latences déterministes de la flotte, pas d'une mesure mur à mur — alors que les durées réelles affichables en consolide incluent l'ordonnancement du kernel. Ajouté au coût du vetting payé en section précédente, le point d'équilibre est immédiat : ici, une seule passe supplémentaire rembourse l'analyse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5b31c56",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : le comparateur pondéré durée/coût\n",
+    "\n",
+    "Le code 2023 choisissait le connecteur à offloader via un comparateur pondéré (`GetWeightedConnectorComparer(durationWeight, costWeight)` dans `MultiTextCompletionSettings.cs`) : deux poids, une décision. Implémentez-le : la fonction doit classer deux connecteurs selon `poidsDuree × durée normalisée + poidsCout × coût normalisé`.\n",
+    "\n",
+    "**Cahier des charges** :\n",
+    "- `// Etape 1` — normaliser la durée : `Delai.TotalMilliseconds / 20` (le primaire vaut 1) ;\n",
+    "- `// Etape 2` — normaliser le coût : `Cout / 0.02m` ;\n",
+    "- `// Etape 3` — combiner selon les deux poids et renvoyer un `Comparison<ConnecteurArithmetique>` ;\n",
+    "- `// Indice` — sans normalisation, les `20 ms` écrasent les `0.02 u` : une unité domine l'autre et un poids ne sert plus à rien."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "07772d87",
+   "metadata": {},
+   "source": [
+    "// Exercice 1 — stub. Le notebook doit s'executer de bout en bout : pas d'erreur volontaire.\n",
+    "Comparison<ConnecteurArithmetique> ComparateurPondere(int poidsDuree, int poidsCout)\n",
+    "{\n",
+    "    // TODO etudiant : renvoyer le comparateur pondere (etapes 1 a 3 ci-dessus)\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 1 a completer : ComparateurPondere(poidsDuree, poidsCout)\");"
+   ],
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 1 a completer : ComparateurPondere(poidsDuree, poidsCout)\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "354ff3c3",
+   "metadata": {},
+   "source": [
+    "## 5. La double file en régime de rafales\n",
+    "\n",
+    "La topologie complète 2023 comptait **trois canaux**, pas deux — et le premier n'est pas le moindre :\n",
+    "\n",
+    "| Niveau | Canal | Écriture (2023) | Drainage (2023) |\n",
+    "|---|---|---|---|\n",
+    "| **Transport** | `Channel<string>` (chunks websocket, un par appel) | `OobaboogaCompletionBase.cs:99` | `:171 ProcessWebSocketMessagesAsync` — réalisé à la section 7 |\n",
+    "| **Collecte** | `Channel<ConnectorTest>` | `MultiTextCompletion.cs:275` (`TryWrite`) | `:217-236` — notre étage 1 |\n",
+    "| **Analyse** | `Channel<AnalysisJob>` | `MultiCompletionAnalysisSettings.cs:307` (`TryWrite`) | `:908-931` — notre étage 2 |\n",
+    "\n",
+    "La section 4 a vu la double file *au repos* (un lot, une analyse). Le régime intéressant est la **rafale** : beaucoup d'échantillons proches, puis plus rien. Que devient la fenêtre d'analyse quand trois rafales tombent à 250 ms d'intervalle avec une fenêtre d'analyse de 700 ms ? L'expérience ci-dessous le mesure — la fenêtre de collecte (150 ms) forme un lot par rafale, et la fenêtre d'analyse (700 ms) devrait les *effondrer*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "7d2af821",
+   "metadata": {},
+   "source": [
+    "// Regime de rafales : 3 rafales de 5 appels espacees de 250 ms, fenetres 150/700 ms.\n",
+    "var routeurRafales = new RouteurMulti(Flotte.PocStandard(), source);\n",
+    "var atelierRafales = new AtelierVetting(routeurRafales, source)\n",
+    "    { FenetreCollecte = TimeSpan.FromMilliseconds(150), FenetreAnalyse = TimeSpan.FromMilliseconds(700) };\n",
+    "atelierRafales.Demarrer();\n",
+    "\n",
+    "var chrono = Stopwatch.StartNew();\n",
+    "foreach (var numero in Enumerable.Range(1, 3))\n",
+    "{\n",
+    "    var rafale = Enumerable.Range(0, 5)\n",
+    "        .Select(_ => routeurRafales.CompleterAsync(MoteurArithmetique.GenererPrompt(Operation.Multiply, 8, 2)));\n",
+    "    await Task.WhenAll(rafale);\n",
+    "    Console.WriteLine(\"rafale \" + numero + \" a t=\" + chrono.ElapsedMilliseconds + \" ms : 5 echantillons emis\");\n",
+    "    await Task.Delay(250);\n",
+    "}\n",
+    "await atelierRafales.AttendreQuiescenceAsync();\n",
+    "chrono.Stop();\n",
+    "\n",
+    "Console.WriteLine(\"---\");\n",
+    "Console.WriteLine(\"Bilan pour 15 echantillons : \" + atelierRafales.LotsFormes + \" lot(s) forme(s), \"\n",
+    "    + atelierRafales.AnalysesExecutees + \" analyse(s) executee(s)\");\n",
+    "foreach (var ligne in atelierRafales.Journal) Console.WriteLine(\"  \" + ligne);"
+   ],
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "rafale 1 a t=36 ms : 5 echantillons emis\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "rafale 2 a t=327 ms : 5 echantillons emis\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "rafale 3 a t=616 ms : 5 echantillons emis\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Bilan pour 15 echantillons : 3 lot(s) forme(s), 1 analyse(s) executee(s)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  LOT 1 forme : 5 echantillons (accumulation)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  LOT 2 forme : 5 echantillons (accumulation)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  LOT 3 forme : 5 echantillons (accumulation)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  ANALYSE 1 executee : 5 echantillons en entree (remplacement)\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2dacea8",
+   "metadata": {},
+   "source": [
+    "### Lecture des rafales : l'effondrement, chiffres en main\n",
+    "\n",
+    "Le bilan se lit en face du mécanisme. **Quinze échantillons** entrent ; la collecte les a gardés en **trois lots de 5** (un par rafale — l'accumulation n'a rien perdu) ; et **une seule analyse** s'exécute. La ligne du journal dit tout : `ANALYSE 1 exécutée : 5 échantillons en entrée` — le *remplacement* n'a passé à l'exécution que le **dernier** lot : les lots 1 et 2 ont été écrasés en file, leur rejeu n'aura jamais lieu. C'est le comportement voulu : l'analyse est coûteuse (elle rejoue les prompts et fait recalculer le primaire) et re-dérive sa décision de l'état le plus récent — l'exécuter trois fois coûterait trois fois plus pour la même décision. Le prix est assumé et documenté : la preuve de vetting portée par les lots écrasés est jetée.\n",
+    "\n",
+    "Le chronomètre confirme le debounce **ancré** : les rafales s'émettent espacées d'environ 300 ms à l'horloge (250 ms de délai configuré entre rafales, plus le temps des complétions), et le bilan n'est imprimé qu'après l'exécution de l'analyse — c'est-à-dire après `naissance du dernier lot + fenêtre d'analyse (700 ms)`. Si la fenêtre courait « depuis le réveil » de la boucle, la rafale 3 — qui arrive *pendant* que la boucle attend déjà — repousserait l'exécution d'une fenêtre **entière** supplémentaire : c'est exactement la version ratée que l'exercice 2 vous fait écrire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d2bd165",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : le debounce « au réveil » — le faire rater exprès\n",
+    "\n",
+    "La version ratée du debounce attend `fenêtre` **à partir du réveil** de la boucle, au lieu de l'ancrer sur l'horodatage de l'objet. Implémentez-la, puis raisonnez sur la ligne du temps de la section 5.\n",
+    "\n",
+    "**Cahier des charges** :\n",
+    "- `// Etape 1` — écrire `AttenteNaive` : au réveil, attendre la pleine fenêtre avant de drainer ;\n",
+    "- `// Etape 2` — prédire sur le papier : combien d'analyses pour 3 rafales espacées de 250 ms avec fenêtre 700 ms ? Et à quelle heure s'exécute la dernière ?\n",
+    "- `// Indice` — chaque réveil *repart* la fenêtre : une rafale tardive ajoute la pleine fenêtre à la latence, là où la version ancrée n'ajoute que le reste."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "8e0f60a3",
+   "metadata": {},
+   "source": [
+    "// Exercice 2 — stub.\n",
+    "Task AttenteNaive(TimeSpan fenetre)\n",
+    "{\n",
+    "    // TODO etudiant : implementer le debounce \"au reveil\", puis comparer a la version ancree\n",
+    "    return Task.CompletedTask;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 a completer : AttenteNaive + prediction du nombre d'analyses\");"
+   ],
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 2 a completer : AttenteNaive + prediction du nombre d'analyses\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a973ebae",
+   "metadata": {},
+   "source": [
+    "## 6. La trace : lire la machine dans les spans\n",
+    "\n",
+    "Toutes les sections précédentes ont émis des spans `routeur.completion`, `collecte.lot` et `analyse.pipeline`. L'exporteur mémoire les a capturés **à leur fermeture** — exportons-les maintenant en tableau : c'est exactement ce qu'un backend de traces (Aspire Dashboard, Jaeger...) montrerait d'un routeur en production, sauf que le backend est la cellule suivante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "85a9d776",
+   "metadata": {},
+   "source": [
+    "// Lecture du backend de fortune : arbre parent/enfant, durees, tags.\n",
+    "var spans = exporteur.CapturerEtVider();\n",
+    "Console.WriteLine(spans.Count + \" spans capturees (ordre de capture = ordre de FERMETURE, pas d'ouverture)\\n\");\n",
+    "\n",
+    "var parId = spans.ToDictionary(s => s.SpanId.ToString());\n",
+    "int Profondeur(Activity s)\n",
+    "{\n",
+    "    int d = 0;\n",
+    "    var parent = s.ParentSpanId;              // non nullable : default quand le span est racine\n",
+    "    while (parent != default && parId.TryGetValue(parent.ToString(), out var p)) { d++; parent = p.ParentSpanId; }\n",
+    "    return d;\n",
+    "}\n",
+    "\n",
+    "foreach (var s in spans.OrderBy(s => s.StartTimeUtc))\n",
+    "{\n",
+    "    var nom = new string(' ', 2 * Profondeur(s)) + s.DisplayName;\n",
+    "    var tags = string.Join(\" \", s.TagObjects.Where(t => t.Value is not null).Select(t => t.Key + \"=\" + t.Value));\n",
+    "    Console.WriteLine(nom.PadRight(30) + s.Duration.TotalMilliseconds.ToString(\"0\", CultureInfo.InvariantCulture).PadLeft(6)\n",
+    "        + \" ms   \" + tags);\n",
+    "}\n",
+    "\n",
+    "var repartition = spans.GroupBy(s => s.DisplayName).ToDictionary(g => g.Key, g => g.Count());\n",
+    "Console.WriteLine(\"\\nRepartition : \" + string.Join(\", \", repartition.OrderBy(kv => kv.Key, StringComparer.Ordinal)\n",
+    "    .Select(kv => kv.Key + \" x\" + kv.Value)));"
+   ],
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "31 spans capturees (ordre de capture = ordre de FERMETURE, pas d'ouverture)\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                27 ms   prompt.operation=Add connecteur=Primaire offload=False duree.ms=25 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                25 ms   prompt.operation=Subtract connecteur=Primaire offload=False duree.ms=25 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                30 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=29 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                30 ms   prompt.operation=Divide connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "collecte.lot                       1 ms   lot.numero=1 lot.echantillons=4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  analyse.pipeline                61 ms   tests.rejoues=4 offloads.accordes=4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                14 ms   prompt.operation=Add connecteur=Secondaire-Add offload=True duree.ms=14 cout.unite=0.01\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "collecte.lot                     108 ms   lot.numero=2 lot.echantillons=4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                15 ms   prompt.operation=Subtract connecteur=Secondaire-Subtract offload=True duree.ms=14 cout.unite=0.01\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                15 ms   prompt.operation=Multiply connecteur=Secondaire-Multiply offload=True duree.ms=15 cout.unite=0.01\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                15 ms   prompt.operation=Divide connecteur=Secondaire-Divide offload=True duree.ms=14 cout.unite=0.01\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  analyse.pipeline                47 ms   tests.rejoues=8 offloads.accordes=4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                35 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=35 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                35 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=34 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                35 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=34 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                35 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=34 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                35 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=34 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "collecte.lot                     162 ms   lot.numero=1 lot.echantillons=5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                31 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                31 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                31 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                31 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                31 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "collecte.lot                     161 ms   lot.numero=2 lot.echantillons=5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                31 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                30 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                30 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                30 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "routeur.completion                30 ms   prompt.operation=Multiply connecteur=Primaire offload=False duree.ms=30 cout.unite=0.02\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "collecte.lot                     164 ms   lot.numero=3 lot.echantillons=5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  analyse.pipeline                16 ms   tests.rejoues=1 offloads.accordes=1\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nRepartition : analyse.pipeline x3, collecte.lot x5, routeur.completion x23\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52c6b862",
+   "metadata": {},
+   "source": [
+    "### Lecture de la trace : ce que le `Stopwatch` de 2023 ne montrait pas\n",
+    "\n",
+    "Quatre choses lisibles uniquement parce que l'instrumentation vit **dans** le pipeline.\n",
+    "\n",
+    "**L'imbrication, d'abord.** Chaque `analyse.pipeline` est indentée sous son `collecte.lot` — trois paires visibles, dont celle des rafales (`lot.numero=3` → analyse à `tests.rejoues=1`) : le contexte parent a traversé la frontière de thread via le `ActivityContext` porté par le lot. Aucun `Stopwatch` ne montre ça.\n",
+    "\n",
+    "**La fenêtre de debounce rendue visible, ensuite.** Les trois lots des rafales affichent ~160 ms — leur fenêtre de collecte de 150 ms, plus le drainage des cinq échantillons ; le lot 1 de la section 4 n'affiche que ~1 ms, parce que ses échantillons étaient nés depuis plus de 50 ms quand la boucle a drainé : la fenêtre **ancrée** n'attend que le *restant*, jamais la fenêtre entière. La trace mesure le mécanisme, pas seulement le code. Les durées d'`analyse.pipeline` (~60 ms pour la section 4, ~15 ms pour les rafales) sont en revanche *hors debounce* : le span s'ouvre quand l'exécution commence, après la fermeture de la fenêtre.\n",
+    "\n",
+    "**La décision économique comme donnée, troisièmement.** Le tag `offload` des `routeur.completion` passe de `False` (passe 1, quatre `connecteur=Primaire`) à `True` (passe 2, quatre `Secondaire-*`) — et la répartition finale résume la session : 23 complétions, 5 lots, 3 analyses. Notez aussi que la passe 2 a déclenché *son propre* cycle lot + analyse (`tests.rejoues=8` : 4 puis 4) : le vetting est **continu**, pas un one-shot de démarrage.\n",
+    "\n",
+    "**L'écart horloge vs configuration, enfin — une leçon C.5 en acte.** Les complétions secondaires mesurent 13-16 ms alors que leur `Task.Delay` configuré est de 2 ms : l'horloge Windows réveille un `Task.Delay` à la granularité de son minuteur (~15 ms). C'est la raison pour laquelle les ratios de la section 4 (÷2 en coût, ÷10 en latence) sont ancrés sur la **configuration déterministe** de la flotte, jamais sur les durées mur à mur.\n",
+    "\n",
+    "Deux conventions de lecture, héritées du notebook 03 : l'ordre de capture est l'ordre des **fermetures** (un enfant s'exporte avant son parent — d'où les complétions de la passe 2 intercalées entre le lot et son analyse), et les spans racines pointent vers l'activité ambiante du kernel — d'où le sampler forcé en section 3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c85276b7",
+   "metadata": {},
+   "source": [
+    "## 7. Le pool de sockets et le serveur de test : mesurer le routeur, pas le harnais\n",
+    "\n",
+    "Le connecteur 2023 était **socket**, pas HTTP : un `ClientWebSocket` par appel, mutualisés dans un **pool**. Les trois artefacts du sous-module :\n",
+    "\n",
+    "- **Le pool** (`OobaboogaCompletionSettings.cs:36`) : un `ConcurrentBag<ClientWebSocket>`. Au départ d'un appel, `TryTake` — si le sac est vide, on crée et connecte ; au retour, la socket retourne au sac **si et seulement si** elle est encore `Open` (`OobaboogaCompletionBase.cs:98-148`). Un sémaphore plafonnait la concurrence (stress test 2023 : jamais plus de 20 clients pour 10 000 appels concurrents).\n",
+    "- **Le canal par appel** (`OobaboogaCompletionBase.cs:99`) : chaque complétion en streaming ouvre un `Channel<string>` non borné ; la tâche de réception websocket y pousse les chunks, l'appelant les consomme en `await foreach` — le **niveau transport** de la topologie de la section 5.\n",
+    "- **Le serveur de test** (`Connectors.UnitTests/WebSocketTestServer.cs`, ~250 lignes) : un `HttpListener` — la primitive de self-host *pré-ASP.NET Core*, adossée à HTTP.SYS — qui fait l'upgrade websocket nativement (`AcceptWebSocketAsync`). Sa propriété centrale : la réponse est **pré-encodée en une passe** avant la boucle d'émission, et le tampon de réception (`WebSocket.CreateServerBuffer(4096)`) est alloué **une fois par connexion**. Zéro sérialisation, zéro allocation par message dans le chemin chaud — c'est ce qui rend le banc honnête : à plein débit, on mesure **le routeur, pas le harnais**.\n",
+    "\n",
+    "Deux délais injectables (`RequestProcessingDelay` = time-to-first-token, `SegmentMessageDelay` = cadence inter-tokens) en faisaient aussi un **modèle de latence de LLM sans LLM**. Ci-dessous, la version miniature fidèle : réponses pré-encodées, port libre aléatoire, ordre d'arrêt qui respecte la cicatrice documentée (`Stop()` **avant** annulation — `WebSocketTestServer.cs:225-230` : `GetContextAsync` n'a pas de surcharge annulable, l'ordre inverse deadlock le préfixe)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "81f85dce",
+   "metadata": {},
+   "source": [
+    "// Le serveur de test 2023 en miniature (WebSocketTestServer.cs) :\n",
+    "// HttpListener + AcceptWebSocketAsync, reponse PRE-ENCODEE en une passe, buffer reutilise.\n",
+    "public sealed class ServeurFluxTest : IAsyncDisposable\n",
+    "{\n",
+    "    private readonly HttpListener _listener = new();\n",
+    "    private readonly CancellationTokenSource _cts = new();\n",
+    "    private readonly ReadOnlyMemory<byte>[] _segments;\n",
+    "    private Task _boucle = Task.CompletedTask;\n",
+    "\n",
+    "    public ServeurFluxTest(int morceauxParReponse)\n",
+    "    {\n",
+    "        // Port libre : sniff d'un port ephemere (course theorique acceptable en local).\n",
+    "        var sonde = new TcpListener(IPAddress.Loopback, 0);\n",
+    "        sonde.Start();\n",
+    "        this.Port = ((IPEndPoint)sonde.LocalEndpoint).Port;\n",
+    "        sonde.Stop();\n",
+    "\n",
+    "        // Toute la reponse est encodee UNE fois, au demarrage : zero serialisation dans le chemin chaud.\n",
+    "        static string Cadre(int i) => \"{\\\"event\\\":\\\"text_stream\\\",\\\"num\\\":\" + i + \",\\\"text\\\":\\\"tok\" + i + \"\\\"}\";\n",
+    "        this._segments = Enumerable.Range(0, morceauxParReponse)\n",
+    "            .Select(i => (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes(Cadre(i)))\n",
+    "            .Append(Encoding.UTF8.GetBytes(\"{\\\"event\\\":\\\"stream_end\\\"}\"))\n",
+    "            .ToArray();\n",
+    "    }\n",
+    "\n",
+    "    public int Port { get; }\n",
+    "\n",
+    "    public void Demarrer()\n",
+    "    {\n",
+    "        this._listener.Prefixes.Add(\"http://localhost:\" + this.Port + \"/\");\n",
+    "        this._listener.Start();\n",
+    "        this._boucle = Task.Run(() => this.BoucleAsync());\n",
+    "    }\n",
+    "\n",
+    "    private async Task BoucleAsync()\n",
+    "    {\n",
+    "        while (!this._cts.IsCancellationRequested)\n",
+    "        {\n",
+    "            HttpListenerContext contexte;\n",
+    "            try { contexte = await this._listener.GetContextAsync(); }\n",
+    "            catch (Exception) when (this._cts.IsCancellationRequested) { break; }\n",
+    "            if (contexte.Request.IsWebSocketRequest)\n",
+    "                _ = this.ServirAsync(contexte);   // tache par client, lancee sans etre attendue (2023 :96)\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    private async Task ServirAsync(HttpListenerContext contexte)\n",
+    "    {\n",
+    "        try\n",
+    "        {\n",
+    "            using var ws = (await contexte.AcceptWebSocketAsync(subProtocol: null)).WebSocket;\n",
+    "            var tampon = WebSocket.CreateServerBuffer(4096);   // alloue UNE fois par connexion (2023 :123)\n",
+    "            while (ws.State == WebSocketState.Open && !this._cts.IsCancellationRequested)\n",
+    "            {\n",
+    "                var recu = await ws.ReceiveAsync(tampon, this._cts.Token);\n",
+    "                if (recu.MessageType == WebSocketMessageType.Close)\n",
+    "                {\n",
+    "                    await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);\n",
+    "                    break;\n",
+    "                }\n",
+    "                if (recu.EndOfMessage)\n",
+    "                    foreach (var segment in this._segments)\n",
+    "                        await ws.SendAsync(segment, WebSocketMessageType.Text, true, this._cts.Token);\n",
+    "            }\n",
+    "        }\n",
+    "        catch (Exception) when (this._cts.IsCancellationRequested) { /* arret du serveur */ }\n",
+    "    }\n",
+    "\n",
+    "    public async ValueTask DisposeAsync()\n",
+    "    {\n",
+    "        // L'ordre qui defait le deadlock documente (#7270, WebSocketTestServer.cs:225-230) :\n",
+    "        // Stop le listener AVANT d'annuler — sinon GetContextAsync garde le prefix bloque.\n",
+    "        this._listener.Stop();\n",
+    "        this._cts.Cancel();\n",
+    "        try { await this._boucle; } catch (Exception) { /* le thrown d'arret est attendu */ }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var serveur = new ServeurFluxTest(morceauxParReponse: 250);\n",
+    "serveur.Demarrer();\n",
+    "Console.WriteLine(\"Serveur de test demarre sur ws://localhost:\" + serveur.Port\n",
+    "    + \"/ — 250 morceaux pre-encodes par reponse, zero serialisation dans le chemin chaud\");"
+   ],
+   "execution_count": 13,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Serveur de test demarre sur ws://localhost:61178/ — 250 morceaux pre-encodes par reponse, zero serialisation dans le chemin chaud\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84f2652f",
+   "metadata": {},
+   "source": [
+    "Côté client, la symétrie 2023 est totale : le **pool** (`TryTake` au départ, retour au sac si encore `Open`), et le **canal par appel** — chaque requête ouvre son propre `Channel<string>` non borné, la tâche de réception y pousse les chunks, le consommateur les énumère en `await foreach`. Le banc lance plus de requêtes que le plafond de parallélisme : c'est la condition pour que le pool **se voit** — les sockets créées doivent rester très inférieures aux requêtes servies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "adaaf330",
+   "metadata": {},
+   "source": [
+    "// Le pool 2023 (OobaboogaCompletionSettings.cs:36) : ConcurrentBag<ClientWebSocket>.\n",
+    "public sealed class PoolSockets\n",
+    "{\n",
+    "    private readonly ConcurrentBag<ClientWebSocket> _sac = new();\n",
+    "    private readonly Uri _uri;\n",
+    "    public int Crees { get; private set; }\n",
+    "    public int Emprunts { get; private set; }\n",
+    "\n",
+    "    public PoolSockets(Uri uri) { this._uri = uri; }\n",
+    "\n",
+    "    public async Task<ClientWebSocket> LouerAsync(CancellationToken ct)\n",
+    "    {\n",
+    "        this.Emprunts++;\n",
+    "        if (!this._sac.TryTake(out var ws)) ws = new ClientWebSocket();\n",
+    "        if (ws.State != WebSocketState.Open) { ws.Dispose(); ws = new ClientWebSocket(); }\n",
+    "        if (ws.State == WebSocketState.None)\n",
+    "        {\n",
+    "            await ws.ConnectAsync(this._uri, ct);\n",
+    "            this.Crees++;   // seule une socket NEUVE est comptee ; une socket reusee ne l'est pas\n",
+    "        }\n",
+    "        return ws;\n",
+    "    }\n",
+    "\n",
+    "    public void Rendre(ClientWebSocket ws)\n",
+    "    {\n",
+    "        if (ws.State == WebSocketState.Open) this._sac.Add(ws); else ws.Dispose();\n",
+    "    }\n",
+    "\n",
+    "    public void Vider()\n",
+    "    {\n",
+    "        while (this._sac.TryTake(out var ws)) ws.Dispose();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Un flux complet : requete -> canal par appel -> enumeration des chunks -> rendu au pool.\n",
+    "// Fonction LOCALE (pas de methodes au niveau top-level du kernel).\n",
+    "async Task<int> UnFluxAsync(PoolSockets pool, CancellationToken ct)\n",
+    "{\n",
+    "    var ws = await pool.LouerAsync(ct);\n",
+    "    try\n",
+    "    {\n",
+    "        var flux = Channel.CreateUnbounded<string>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });\n",
+    "        var reception = Task.Run(async () =>\n",
+    "        {\n",
+    "            var tampon = new byte[4096];\n",
+    "            while (true)\n",
+    "            {\n",
+    "                var recu = await ws.ReceiveAsync(tampon, ct);\n",
+    "                if (recu.MessageType == WebSocketMessageType.Close) { flux.Writer.Complete(); return; }\n",
+    "                var texte = Encoding.UTF8.GetString(tampon, 0, recu.Count);\n",
+    "                if (texte.Contains(\"\\\"event\\\":\\\"stream_end\\\"\")) { flux.Writer.Complete(); return; }\n",
+    "                await flux.Writer.WriteAsync(texte, ct);\n",
+    "            }\n",
+    "        }, ct);\n",
+    "\n",
+    "        var requete = Encoding.UTF8.GetBytes(\"{\\\"prompt\\\":\\\"Compute Add(8, 2)\\\"}\");\n",
+    "        await ws.SendAsync(requete, WebSocketMessageType.Text, true, ct);\n",
+    "\n",
+    "        int morceaux = 0;\n",
+    "        await foreach (var _ in flux.Reader.ReadAllAsync(ct)) morceaux++;\n",
+    "        await reception;\n",
+    "        return morceaux;\n",
+    "    }\n",
+    "    finally { pool.Rendre(ws); }\n",
+    "}\n",
+    "\n",
+    "// Le banc : 24 requetes, parallelisme plafonne a 8 — le pool doit creer ~8 sockets, pas 24.\n",
+    "const int Requetes = 24, Parallelisme = 8;\n",
+    "var limite = new SemaphoreSlim(Parallelisme, Parallelisme);   // pas de \"using var\" en top-level kernel\n",
+    "var pool = new PoolSockets(new Uri(\"ws://localhost:\" + serveur.Port + \"/\"));\n",
+    "long morceauxTotaux = 0;\n",
+    "\n",
+    "using (var span = source.StartActivity(\"banc.socket\"))\n",
+    "{\n",
+    "    span?.SetTag(\"banc.requetes\", Requetes);\n",
+    "    span?.SetTag(\"banc.parallelisme\", Parallelisme);\n",
+    "\n",
+    "    var chrono = Stopwatch.StartNew();\n",
+    "    var taches = Enumerable.Range(0, Requetes).Select(async _ =>\n",
+    "    {\n",
+    "        await limite.WaitAsync();\n",
+    "        try\n",
+    "        {\n",
+    "            var recus = await UnFluxAsync(pool, CancellationToken.None);\n",
+    "            Interlocked.Add(ref morceauxTotaux, recus);\n",
+    "        }\n",
+    "        finally { limite.Release(); }\n",
+    "    });\n",
+    "    await Task.WhenAll(taches);\n",
+    "    chrono.Stop();\n",
+    "\n",
+    "    span?.SetTag(\"banc.duree.ms\", chrono.ElapsedMilliseconds);\n",
+    "    span?.SetTag(\"banc.morceaux\", morceauxTotaux);\n",
+    "    span?.SetTag(\"banc.sockets_creees\", pool.Crees);\n",
+    "\n",
+    "    Console.WriteLine(Requetes + \" requetes x 250 morceaux, parallelisme \" + Parallelisme);\n",
+    "    Console.WriteLine(\"Morceaux recus au total : \" + morceauxTotaux);\n",
+    "    Console.WriteLine(\"Sockets CREES : \" + pool.Crees + \" (emprunts : \" + pool.Emprunts + \" — le pool a servi \" + (pool.Emprunts - pool.Crees) + \" emprunts sans creer)\");\n",
+    "    Console.WriteLine(\"Duree mesuree : \" + chrono.Elapsed.TotalMilliseconds.ToString(\"0\", CultureInfo.InvariantCulture) + \" ms\");\n",
+    "    Console.WriteLine(\"Debit mesure : \" + (morceauxTotaux / chrono.Elapsed.TotalSeconds).ToString(\"0\", CultureInfo.InvariantCulture)\n",
+    "        + \" morceaux/s — pipeline canal+socket sur loopback localhost\");\n",
+    "}\n",
+    "limite.Dispose();"
+   ],
+   "execution_count": 14,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "24 requetes x 250 morceaux, parallelisme 8\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Morceaux recus au total : 6000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Sockets CREES : 8 (emprunts : 24 — le pool a servi 16 emprunts sans creer)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Duree mesuree : 67 ms\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Debit mesure : 88980 morceaux/s — pipeline canal+socket sur loopback localhost\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f59ac439",
+   "metadata": {},
+   "source": [
+    "### Lecture du banc : le pool se voit, le débit est mesuré — et borné\n",
+    "\n",
+    "Trois lectures, une mise en garde. **Le pool d'abord** : la ligne `Sockets CREES` affiche `8` pour `24` requêtes — la première vague (le parallélisme plafonné) chauffe le sac, chaque vague suivante réutilise : `24` emprunts, dont `16` servis sans créer de socket. C'est la seule ligne qui prouve que le pool *travaille* — et ces trois comptes sont structurels (24 requêtes, plafond 8), donc stables d'une exécution à l'autre. **Le débit ensuite** : la cellule mesure un vrai pipeline `canal + socket` — requêtes réelles, frames websocket réelles, énumération asynchrone réelle — et le chiffre affiché est **celui de cette exécution-ci** (la durée varie avec la machine ; seul son ordre de grandeur est discutable, pas sa nature). **La mise en garde enfin** :\n",
+    "\n",
+    "> **Frontière d'honnêteté.** Ce banc boucle sur `localhost` avec un serveur à réponse pré-encodée : le débit mesuré couvre le **pipeline routeur + canal + socket** — le transport et la découpe en flux — et **rien d'autre**. Aucun token n'est généré, aucun modèle n'est servi. Le souvenir 2023 de « 20 000 chunks/s » reposait sur la même architecture (serveur de test localhost, 50 000 chunks par test) et mesurait la même chose ; il n'est **pas re-mesuré ici** et ne doit jamais être cité comme un débit de génération.\n",
+    "\n",
+    "C'est exactement le piège que la réactivation de l'Epic demande de verrouiller : un banc de transport honnête est un banc de transport **étiqueté**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcfa4dee",
+   "metadata": {},
+   "source": [
+    "## 8. La table de vérité : refuser correctement\n",
+    "\n",
+    "Les tests d'intégration 2023 (`Connectors.UnitTests/../IntegrationTests/MultiConnectorTests.cs:96-110`) encodaient le résultat attendu du vetting **comme assertion** — premier argument de chaque `InlineData` : `succeedsOffloading`. La frontière de capacité de chaque modèle local, modèle × difficulté :\n",
+    "\n",
+    "| Modèle local | simple | medium | hard |\n",
+    "|---|:--:|:--:|:--:|\n",
+    "| `microsoft_phi-1_5` | ✓ | ✓ | **✗** |\n",
+    "| `TheBloke_orca_mini_3B-GGML` | ✓ | ✓ | **✗** |\n",
+    "| `TheBloke_Mistral-7B-OpenOrca-GGUF` | ✓ | ✓ | ✓ |\n",
+    "| `TheBloke_LLaMA2-13B-Tiefighter-GGUF` | ✓ | ✓ | ✓ |\n",
+    "\n",
+    "Le **✗ n'est pas un échec du test** : il vérifie que le routeur **refuse correctement** de déléguer au modèle cheap ce qui le dépasse. C'est la partie la plus précieuse du vetting — et exactement la question qu'un arbitrage multi-modèles répond aujourd'hui à la main. Reproduisons la mécanique : un secondaire `Add` **silencieusement corrompu** (il répond juste à côté), et voyons si le plan le vète."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "97ce5d87",
+   "metadata": {},
+   "source": [
+    "// Le secondaire Add repond result + 1 : faux silencieux, indetectable sans vetting.\n",
+    "var routeurCorrompu = new RouteurMulti(new List<ConnecteurArithmetique>\n",
+    "{\n",
+    "    new(\"Primaire\", Enum.GetValues<Operation>().ToHashSet(), TimeSpan.FromMilliseconds(20), 0.02m),\n",
+    "    new(\"Secondaire-Add\", new HashSet<Operation> { Operation.Add }, TimeSpan.FromMilliseconds(2), 0.01m,\n",
+    "        substitut: (op, a, b) => MoteurArithmetique.Calculer(op, a, b) + 1),\n",
+    "    new(\"Secondaire-Subtract\", new HashSet<Operation> { Operation.Subtract }, TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "    new(\"Secondaire-Multiply\", new HashSet<Operation> { Operation.Multiply }, TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "    new(\"Secondaire-Divide\",   new HashSet<Operation> { Operation.Divide },   TimeSpan.FromMilliseconds(2), 0.01m),\n",
+    "}, source);\n",
+    "\n",
+    "var atelierCorrompu = new AtelierVetting(routeurCorrompu, source);\n",
+    "atelierCorrompu.Demarrer();\n",
+    "\n",
+    "// La faute, montree AVANT le vetting : appel direct au secondaire corrompu.\n",
+    "var corrompu = routeurCorrompu.Secondaires.First(c => c.Nom == \"Secondaire-Add\");\n",
+    "Console.WriteLine(\"Appel direct : Compute Add(8, 2) => \" + await corrompu.RepondreAsync(MoteurArithmetique.GenererPrompt(Operation.Add, 8, 2))\n",
+    "    + \"  par \" + corrompu.Nom + \"  (attendu : 10 — le faux est silencieux, seul le vetting le verra)\");\n",
+    "Console.WriteLine(\"---\");\n",
+    "\n",
+    "// Trafic temoin : les quatre operations, simultanees.\n",
+    "var temoin = Enum.GetValues<Operation>()\n",
+    "    .Select(op => routeurCorrompu.CompleterAsync(MoteurArithmetique.GenererPrompt(op, 8, 2)));\n",
+    "await Task.WhenAll(temoin);\n",
+    "await atelierCorrompu.AttendreQuiescenceAsync();\n",
+    "\n",
+    "Console.WriteLine(\"Table de verite (secondaire x sa signature) — le refus est un SUCCES du routeur :\");\n",
+    "foreach (var v in atelierCorrompu.TableVerite.OrderBy(v => v.Signature, StringComparer.Ordinal))\n",
+    "    Console.WriteLine(\"  \" + v.Connecteur.PadRight(21) + \" x \" + v.Signature.PadRight(9)\n",
+    "        + \" conforme=\" + (v.Conforme ? \"oui\" : \"NON\") + \"  offload=\" + (v.Offload ? \"oui\" : \"non\"));\n",
+    "Console.WriteLine(\"---\");\n",
+    "Console.WriteLine(\"Plan final : \" + string.Join(\" | \", routeurCorrompu.Plan\n",
+    "    .OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => kv.Key + \" -> \" + kv.Value.Nom)));\n",
+    "Console.WriteLine(\"Add reste au primaire : \" + (!routeurCorrompu.Plan.ContainsKey(\"Add\")));"
+   ],
+   "execution_count": 15,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Appel direct : Compute Add(8, 2) => 11  par Secondaire-Add  (attendu : 10 — le faux est silencieux, seul le vetting le verra)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Table de verite (secondaire x sa signature) — le refus est un SUCCES du routeur :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Add        x Add       conforme=NON  offload=non\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Divide     x Divide    conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Multiply   x Multiply  conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Secondaire-Subtract   x Subtract  conforme=oui  offload=oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Plan final : Divide -> Secondaire-Divide | Multiply -> Secondaire-Multiply | Subtract -> Secondaire-Subtract\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Add reste au primaire : True\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cac167a",
+   "metadata": {},
+   "source": [
+    "### Lecture du refus : la frontière de capacité comme assertion\n",
+    "\n",
+    "Le secondaire corrompu a répondu `11` là où le primaire calcule `10` — le vetting l'a vu, la table porte `conforme=NON`, `offload=non`, et le plan final **n'accorde pas** la signature `Add` : elle reste au primaire. Les trois autres secondaires, eux, sont offloadés. Relisez la table 2023 ci-dessus : **structurellement, c'est la même assertion** — la ligne `phi-1_5 × hard → ✗` et notre `Secondaire-Add × Add → NON` vérifient toutes deux que le routeur *connaît la frontière* de ses seconds couteaux. Un routeur qui offloaderait quand même serait en échec ; le routeur qui refuse **gagne**. C'est la réponse mécanique — mesurée, rejouable — à une question qu'un arbitrage humain de routage multi-modèles tranche aujourd'hui au cas par cas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8d9df12",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : la quarantaine à trois fautes\n",
+    "\n",
+    "Le vetting 2023 avait des **niveaux** (`VettingLevel`, rejouage de `TestEvent`) : un connecteur défaillant n'était pas simplement jeté — il pouvait être re-testé plus tard. Écrivez la règle la plus simple de cette famille : après un historique de verdicts (chronologique), un connecteur part en **quarantaine** dès **trois faux consécutifs**.\n",
+    "\n",
+    "**Cahier des charges** :\n",
+    "- `// Etape 1` — ne regarder que la fin de l'historique : trois verdicts suffisent à décider ;\n",
+    "- `// Etape 2` — trois faux **consécutifs**, pas trois faux au total — `[vrai, faux, faux, faux]` quarantaine, `[faux, faux, vrai, faux]` pas encore ;\n",
+    "- `// Indice` — un historique plus court que trois verdicts ne peut pas mettre en quarantaine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "8a8a6592",
+   "metadata": {},
+   "source": [
+    "// Exercice 3 — stub.\n",
+    "string VerdictQuarantaine(IReadOnlyList<bool> historique)\n",
+    "{\n",
+    "    // TODO etudiant : \"quarantaine\" si les 3 derniers verdicts sont tous faux, sinon \"conforme\"\n",
+    "    return \"non implemente\";\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 a completer : VerdictQuarantaine(historique)\");"
+   ],
+   "execution_count": 16,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 3 a completer : VerdictQuarantaine(historique)\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f4dd547",
+   "metadata": {},
+   "source": [
+    "## 9. Arrêt propre\n",
+    "\n",
+    "Le kernel vit tant que le notebook est ouvert : les pompes de fond, le serveur de test et le provider OTel doivent être arrêtés explicitement — dans le **bon ordre** pour le serveur (sa cicatrice d'arrêt), et après avoir rendu visibles les dernières spans."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "2530c932",
+   "metadata": {},
+   "source": [
+    "// Arret propre : serveur (Stop AVANT annulation), pompes de fond, provider OTel.\n",
+    "await serveur.DisposeAsync();\n",
+    "atelier.Dispose();\n",
+    "atelierRafales.Dispose();\n",
+    "atelierCorrompu.Dispose();\n",
+    "pool.Vider();\n",
+    "provider.Dispose();\n",
+    "\n",
+    "Console.WriteLine(\"Serveur arrete, pompes annulees, pool vide, provider dispose.\");\n",
+    "Console.WriteLine(\"Bilan de session : \" + exporteur.Capturer().Count\n",
+    "    + \" spans emises par la source Aspire07.SemanticFleet\");"
+   ],
+   "execution_count": 17,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Serveur arrete, pompes annulees, pool vide, provider dispose.\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Bilan de session : 7 spans emises par la source Aspire07.SemanticFleet\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab133d83",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le MultiConnector de 2023 anticipait, avec trois ans d'avance et un POC arithmétique, ce que tout déploiement multi-modèles arbitre aujourd'hui : *qui peut répondre à quoi, à quel prix, sans se tromper — et comment le savoir sans humain dans la boucle*. Ce notebook l'a ressuscité en le ré-instrumentant :\n",
+    "\n",
+    "| Pattern 2023 (sous-module `9df3603`) | Où le voir ici | Ce qu'OTel ajoute |\n",
+    "|---|---|---|\n",
+    "| Vetting en ligne, offload par signature | Sections 2-4 : deux passes, coût divisé par deux | La décision (`offload=true/false`) devient un **tag de span** |\n",
+    "| Double file, coalescence accumulation / remplacement | Sections 4-5 : 15 échantillons → 3 lots → 1 analyse | `collecte.lot` et `analyse.pipeline` **imbriqués** à travers la frontière de thread |\n",
+    "| Debounce ancré sur l'horodatage | Section 5 : fenêtre absolue depuis la naissance de l'objet | La fenêtre est **lisible dans la durée du span** |\n",
+    "| Pool `ClientWebSocket` + serveur `HttpListener` pré-encodé | Section 7 : ~8 sockets pour 24 requêtes, débit mesuré | Le banc porte lui-même son span `banc.socket` |\n",
+    "\n",
+    "**Ce que ce notebook ne mesure pas** — sa frontière, une dernière fois : aucune génération de tokens, aucun endpoint LLM, un loopback localhost. Le débit cité est celui du pipeline de transport ; le vetting est arithmétique, pas sémantique. L'honnêteté d'un banc se joue dans cette étiquette.\n",
+    "\n",
+    "**Pour aller plus loin** :\n",
+    "- Le sous-module [`GenAI/SemanticKernel/semantic-fleet`](../SemanticKernel/semantic-fleet) : les mocks (`ArithmeticMocks/`), les boucles (`MultiTextCompletion.cs`, `MultiCompletionAnalysisSettings.cs`), le serveur (`Connectors.UnitTests/WebSocketTestServer.cs`) — tous cités dans ce notebook ;\n",
+    "- Le **matcher radix** (`tools/radix/` du sous-module, Axe 4 de l'Epic) : l'autre morceau du routeur, pour reconnaître les signatures récurrentes de prompts ;\n",
+    "- Les notebooks [03 — Observabilité](03-Aspire-Observabilite.ipynb) (les trois piliers OTel) et [04 — Streaming Agent](04-Aspire-Streaming-Agent.ipynb) (le pattern `Channels` + `BackgroundService` dont la double file est la version productionnée) ;\n",
+    "- L'Epic [#1210](https://github.com/jsboige/CoursIA/issues/1210) pour l'histoire complète — trois PRs amont, un manifeste, et une vision fermée par policy que ce dépôt fait vivre autrement."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #13718

See #1210

## Résumé

Ajoute le notebook Aspire 07 qui transforme le MultiConnector historique de `semantic-fleet` en artefact pédagogique CPU-only, sans endpoint LLM :

- primary arithmétique capable des quatre opérations et quatre secondaires mono-opération ;
- vetting en ligne, table de vérité et refus explicite d'un secondaire corrompu ;
- double file `Channel<T>` : accumulation côté collecte, remplacement côté analyse ;
- debounce ancré sur l'horodatage de l'objet ;
- instrumentation réelle `ActivitySource` / OpenTelemetry avec spans imbriqués ;
- serveur loopback `HttpListener`, pool `ClientWebSocket` et canal par flux ;
- trois exercices étudiants exécutables et stubbés.

Le numéro 07 est intentionnel : Aspire 06 a été livré sur `main` par #13696 pendant le cadrage de ce grain.

## Source et périmètre

- Sous-module de référence initialisé au gitlink `9df3603` (`v0.34.3-19-g9df3603`).
- `dotnet build MyIA.AI.Notebooks/GenAI/SemanticKernel/semantic-fleet/semantic-fleet.sln` : succès, 0 erreur, 1 warning d'analyseur Roslyn ancien.
- Le sous-module n'est ni modifié ni repointé.
- Un seul fichier ajouté : `MyIA.AI.Notebooks/GenAI/Aspire/07-Aspire-SemanticFleet-MultiConnector.ipynb`.
- Catalogue, README et notebook Aspire 06 byte-identiques à `main`.

## Exécution réelle

Kernel `.net-csharp`, exécution complète via l'organe canonique `dotnet_executor.py` :

- 45 cellules : 17 code, 28 markdown ;
- 17/17 cellules code exécutées ;
- `execution_count` 1 à 17 ;
- 17/17 cellules avec outputs ;
- 0 output `error` ;
- bannière `probeAddresses` retirée après exécution avec `strip_probe_banner.py` ;
- aucun output hand-édité.

Mesures observées pendant ce run :

- passe 1 → passe 2 : coût structurel `0.08 u → 0.04 u`, délai simulé `80 ms → 8 ms` ;
- 15 échantillons → 3 lots → 1 analyse ;
- 31 spans : `routeur.completion x23`, `collecte.lot x5`, `analyse.pipeline x3` ;
- 24 requêtes × 250 morceaux = 6000 morceaux reçus ; 8 sockets créées, 16 emprunts réutilisés ;
- secondaire corrompu : réponse 11 contre attendu 10, `conforme=NON`, aucun offload de `Add`.

## Verdict SOTA

**SOTA-OK** pour l'objectif annoncé : vrais `Channel<T>`, `ActivitySource`, OpenTelemetry, `HttpListener` et `ClientWebSocket` exécutés. Aucun remplacement ASCII, aucune sortie fabriquée.

Frontière explicite dans le notebook : le débit mesure uniquement le pipeline canal + socket sur loopback localhost. Il ne mesure jamais une génération de tokens ; le souvenir de 20k chunks/s de 2023 n'est pas ré-invoqué comme résultat de ce run.

## Validation

- `validate_pr_notebooks.py` : PASS 1/1, 17 cellules code ;
- `check_exec_ratchet.py origin/main` : 0 régression, `ABSENT->CLEAN` ;
- `check_source_output_ratchet.py origin/main` : 0 cellule stale ;
- `check_papermill_ratchet.py origin/main` : 0 régression ;
- `count_exercises.py` : 3 exercices, conforme ;
- `check_interp_positioning.py` : 0 finding ;
- `check_notebook_navlinks.py` : 0 lien cassé ;
- `detect_consecutive_code_cells.py` : aucun run de code consécutif ;
- C.1 : 0 erreur volontaire ; scans chemins machine/secrets : 0 hit.

## Limites

- Simulation arithmétique déterministe, CPU-only, zéro fournisseur LLM.
- Les durées mur à mur dépendent de l'ordonnancement Windows ; les ratios pédagogiques sont ancrés sur les coûts et délais configurés, pas sur une promesse de performance machine.
- Les canaux non bornés assurent le découplage mais pas la backpressure ; le notebook documente explicitement cette contrepartie et l'arrêt propre.
