### PR TITLE
feat(search): trace MGS-22 convergence checkpoints

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
@@ -47,11 +47,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "data": {
+      "text/html": ""
+     },
+     "metadata": {}
+    },
+    {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Grille de référence : 36 cellules vides, 45 indices fixes, 36 gènes R1.\r\n"
-     ]
+     "text": "Grille de référence : 36 cellules vides, 45 indices fixes, 36 gènes R1.\r\n"
     }
    ],
    "source": [
@@ -143,9 +148,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "MGS PSO (graine 7, témoin) : 46 conflits, 8000 évaluations, 1288 ms.\r\n"
-     ]
+     "text": "MGS PSO (graine 7, témoin) : 46 conflits, 8000 évaluations, 4050 ms, cp25/50/75/100=46/46/46/46.\r\n"
     }
    ],
    "source": [
@@ -162,23 +165,41 @@
     "    public int[,] ToGrid() => DecodeR1_22(ToGenes());\n",
     "}\n",
     "\n",
-    "// Fitness instrumentée : chaque évaluation est comptée — le budget se mesure, il ne se suppose pas.\n",
+    "// Fitness instrumentée : budget réel + trajectoire best-so-far aux quarts du budget.\n",
     "public class SudokuR1Fitness22 : IFitness\n",
     "{\n",
     "    public static int Evals;\n",
+    "    public static int Best;\n",
+    "    public static int[] Checkpoints = new int[4];\n",
+    "    public static int[] Thresholds = new int[4];\n",
+    "\n",
+    "    public static void Reset(int expectedEvals)\n",
+    "    {\n",
+    "        Evals = 0;\n",
+    "        Best = int.MaxValue;\n",
+    "        Checkpoints = new int[4];\n",
+    "        Thresholds = new[] { 1, 2, 3, 4 }\n",
+    "            .Select(q => (int)Math.Ceiling(expectedEvals * q / 4.0))\n",
+    "            .ToArray();\n",
+    "    }\n",
+    "\n",
     "    public double Evaluate(IChromosome chromosome)\n",
     "    {\n",
+    "        int conflicts = CountConflicts22(((SudokuR1Chromosome22)chromosome).ToGrid());\n",
     "        Evals++;\n",
-    "        return -CountConflicts22(((SudokuR1Chromosome22)chromosome).ToGrid());\n",
+    "        Best = Math.Min(Best, conflicts);\n",
+    "        for (int i = 0; i < Thresholds.Length; i++)\n",
+    "            if (Checkpoints[i] == 0 && Evals >= Thresholds[i])\n",
+    "                Checkpoints[i] = Best;\n",
+    "        return -conflicts;\n",
     "    }\n",
     "}\n",
     "\n",
     "public static class Mgs22Host\n",
     "{\n",
-    "    public static (int conflicts, int evals, double ms, double[] genes) RunPso(int seed, int popSize, int maxGens)\n",
+    "    public static (int conflicts, int evals, double ms, double[] genes, int[] cp) RunPso(\n",
+    "        int seed, int popSize, int maxGens)\n",
     "    {\n",
-    "        // Seeding AVANT création de population : le RNG est consommé par CreateNew()\n",
-    "        // de chaque individu initial (leçon #12071 / MGS-21).\n",
     "        FastRandomRandomization.ResetSeed(seed);\n",
     "        var compound = MetaHeuristicsService.CreateMetaHeuristicByName(\n",
     "            \"ParticleSwarmOptimization\", maxGens, popSize);\n",
@@ -189,21 +210,22 @@
     "            new EliteSelection(), new UniformCrossover(0.5f), new UniformMutation(true),\n",
     "            compound);\n",
     "        ga.Termination = new GenerationNumberTermination(maxGens);\n",
-    "        SudokuR1Fitness22.Evals = 0;\n",
+    "        SudokuR1Fitness22.Reset(popSize * maxGens);\n",
     "        var sw = Stopwatch.StartNew();\n",
     "        ga.Start();\n",
     "        sw.Stop();\n",
     "        var best = (SudokuR1Chromosome22)ga.BestChromosome;\n",
     "        return (CountConflicts22(best.ToGrid()), SudokuR1Fitness22.Evals,\n",
-    "                sw.Elapsed.TotalMilliseconds, best.ToGenes());\n",
+    "                sw.Elapsed.TotalMilliseconds, best.ToGenes(),\n",
+    "                SudokuR1Fitness22.Checkpoints.ToArray());\n",
     "    }\n",
     "}\n",
     "\n",
-    "// Échauffement JIT (course jetée), puis course témoin graine 7.\n",
     "var warmupMgs = Mgs22Host.RunPso(123, 50, 10);\n",
     "var demoMgs = Mgs22Host.RunPso(7, 50, 160);\n",
-    "Console.WriteLine($\"MGS PSO (graine 7, témoin) : {demoMgs.Item1} conflits, \" +\n",
-    "                  $\"{demoMgs.Item2} évaluations, {demoMgs.Item3:F0} ms.\");"
+    "Console.WriteLine($\"MGS PSO (graine 7, témoin) : {demoMgs.conflicts} conflits, \" +\n",
+    "                  $\"{demoMgs.evals} évaluations, {demoMgs.ms:F0} ms, \" +\n",
+    "                  $\"cp25/50/75/100={string.Join(\"/\", demoMgs.cp)}.\");"
    ]
   },
   {
@@ -234,47 +256,35 @@
    "outputs": [
     {
      "output_type": "display_data",
-     "metadata": {},
      "data": {
-      "text/html": [
-       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
-      ]
-     }
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
+     },
+     "metadata": {}
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.3\r\n"
-     ]
+     "text": "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.12\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  vecteur témoin 1 : coût C# = 67, coût Python = 67 -> IDENTIQUE\r\n"
-     ]
+     "text": "  vecteur témoin 1 : coût C# = 67, coût Python = 67 -> IDENTIQUE\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  vecteur témoin 2 : coût C# = 71, coût Python = 71 -> IDENTIQUE\r\n"
-     ]
+     "text": "  vecteur témoin 2 : coût C# = 71, coût Python = 71 -> IDENTIQUE\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  vecteur témoin 3 : coût C# = 60, coût Python = 60 -> IDENTIQUE\r\n"
-     ]
+     "text": "  vecteur témoin 3 : coût C# = 60, coût Python = 60 -> IDENTIQUE\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Sanity check PASSE : la fonction de coût est identique des deux côtés -- le bench est valide.\r\n"
-     ]
+     "text": "Sanity check PASSE : la fonction de coût est identique des deux côtés -- le bench est valide.\r\n"
     }
    ],
    "source": [
@@ -522,32 +532,77 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "mealpy OriginalPSO (graine 7, témoin) : 26 conflits, 8050 évaluations, 676 ms.\r\n"
-     ]
+     "text": "mealpy OriginalPSO (graine 7, témoin) : 26 conflits, 8050 évaluations, 3358 ms, cp25/50/75/100=35/27/26/26.\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Contre-vérif croisée : coût C# du meilleur mealpy = 26 (Python rapporte 26) -> IDENTIQUE\r\n"
-     ]
+     "text": "Contre-vérif croisée : coût C# du meilleur mealpy = 26 (Python rapporte 26) -> IDENTIQUE\r\n"
     }
    ],
    "source": [
-    "// === Moteur mealpy : course témoin + contre-vérification croisée du vainqueur ===\n",
+    "// === Moteur mealpy : trajectoire instrumentée, course témoin, contre-vérification croisée ===\n",
     "using (Py.GIL())\n",
     "{\n",
-    "    // Échauffement symétrique (course jetée), puis course témoin graine 7.\n",
-    "    S22.Exec(@\"_wu_c, _wu_e, _wu_t, _wu_sol = run_mealpy_pso(123, 50, 10)\n",
-    "__d_c__, __d_e__, __d_t__, __d_sol__ = run_mealpy_pso(7, 50, 160)\");\n",
+    "    // Le budget mealpy inclut l'évaluation initiale : pop × (epoch + 1) = 8 050.\n",
+    "    // Les seuils propres au budget évitent de comparer des numéros d'évaluation absolus différents.\n",
+    "    S22.Exec(@\"PY_BEST = [10**9]\n",
+    "PY_CP = [[0, 0, 0, 0]]\n",
+    "PY_THRESHOLDS = [[0, 0, 0, 0]]\n",
+    "\n",
+    "class TrackedSudokuProblem(Problem):\n",
+    "    def __init__(self, bounds=None, minmax='min', **kwargs):\n",
+    "        super().__init__(bounds, minmax, log_to='nothing', **kwargs)\n",
+    "    def obj_func(self, x):\n",
+    "        PY_EVALS[0] += 1\n",
+    "        value = cost(decode(x))\n",
+    "        PY_BEST[0] = min(PY_BEST[0], value)\n",
+    "        for i, threshold in enumerate(PY_THRESHOLDS[0]):\n",
+    "            if PY_CP[0][i] == 0 and PY_EVALS[0] >= threshold:\n",
+    "                PY_CP[0][i] = PY_BEST[0]\n",
+    "        return float(value)\n",
+    "\n",
+    "def run_mealpy_pso(seed, pop_size, epoch):\n",
+    "    import time\n",
+    "    expected = pop_size * (epoch + 1)\n",
+    "    PY_EVALS[0] = 0\n",
+    "    PY_BEST[0] = 10**9\n",
+    "    PY_CP[0] = [0, 0, 0, 0]\n",
+    "    PY_THRESHOLDS[0] = [(expected * q + 3) // 4 for q in (1, 2, 3, 4)]\n",
+    "    prob = TrackedSudokuProblem(\n",
+    "        bounds=FloatVar(lb=(1.0,) * len(empties), ub=(10.0,) * len(empties), name='genes'),\n",
+    "        minmax='min')\n",
+    "    model = OriginalPSO(epoch=epoch, pop_size=pop_size)\n",
+    "    t0 = time.perf_counter()\n",
+    "    g_best = model.solve(prob, seed=seed)\n",
+    "    dt = (time.perf_counter() - t0) * 1000.0\n",
+    "    sol = _json.dumps([float(v) for v in g_best.solution])\n",
+    "    return cost(decode(g_best.solution)), PY_EVALS[0], dt, sol, list(PY_CP[0])\n",
+    "\n",
+    "def bench_mealpy(seeds_json, pop_size, epoch, reps=3):\n",
+    "    out = []\n",
+    "    for sd in _json.loads(seeds_json):\n",
+    "        runs = [run_mealpy_pso(sd, pop_size, epoch) for _ in range(reps)]\n",
+    "        cs = [r[0] for r in runs]\n",
+    "        es = [r[1] for r in runs]\n",
+    "        ts = sorted(r[2] for r in runs)\n",
+    "        med = ts[len(ts) // 2] if len(ts) % 2 == 1 else (ts[len(ts) // 2 - 1] + ts[len(ts) // 2]) / 2.0\n",
+    "        out.append({'seed': sd, 'conflicts': cs[0],\n",
+    "                    'all_same': len(set(cs)) == 1 and all(r[4] == runs[0][4] for r in runs),\n",
+    "                    'evals': es[0], 'ms': med, 'cp': runs[0][4], 'sol': runs[0][3]})\n",
+    "    return _json.dumps(out)\n",
+    "\n",
+    "_wu_c, _wu_e, _wu_t, _wu_sol, _wu_cp = run_mealpy_pso(123, 50, 10)\n",
+    "__d_c__, __d_e__, __d_t__, __d_sol__, __d_cp__ = run_mealpy_pso(7, 50, 160)\");\n",
     "    int dConflicts = S22.Get<int>(\"__d_c__\");\n",
     "    int dEvals = S22.Get<int>(\"__d_e__\");\n",
     "    double dMs = S22.Get<double>(\"__d_t__\");\n",
+    "    var dCp = System.Text.Json.JsonSerializer.Deserialize<int[]>(\n",
+    "        S22.Eval(\"_json.dumps(__d_cp__)\").ToString());\n",
     "    Console.WriteLine($\"mealpy OriginalPSO (graine 7, témoin) : {dConflicts} conflits, \" +\n",
-    "                      $\"{dEvals} évaluations, {dMs:F0} ms.\");\n",
+    "                      $\"{dEvals} évaluations, {dMs:F0} ms, \" +\n",
+    "                      $\"cp25/50/75/100={string.Join(\"/\", dCp)}.\");\n",
     "\n",
-    "    // Contre-vérification croisée : le vainqueur mealpy, décodé et costé côté C#.\n",
     "    var solJson = S22.Get<string>(\"__d_sol__\");\n",
     "    var genes = System.Text.Json.JsonSerializer.Deserialize<double[]>(solJson);\n",
     "    int csRecheck = CountConflicts22(DecodeR1_22(genes));\n",
@@ -583,100 +638,112 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "moteur    graine  conflits   evals       ms  ms/eval\r\n"
-     ]
+     "text": "moteur    graine  conflits   evals       ms  ms/eval cp25/50/75/100    \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "MGS            0        39    8000      787    0,098\r\n"
-     ]
+     "text": "MGS            0        39    8000     1816    0,227 39/39/39/39       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "MGS            1        41    8000      823    0,103\r\n"
-     ]
+     "text": "MGS            1        41    8000     1749    0,219 41/41/41/41       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "MGS            7        46    8000      852    0,106\r\n"
-     ]
+     "text": "MGS            7        46    8000     1400    0,175 46/46/46/46       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "MGS           42        48    8000      854    0,107\r\n"
-     ]
+     "text": "MGS           42        48    8000     1228    0,153 48/48/48/48       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "mealpy         0        30    8050      670    0,083\r\n"
-     ]
+     "text": "mealpy         0        30    8050     1876    0,233 41/32/31/30       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "mealpy         1        27    8050      717    0,089\r\n"
-     ]
+     "text": "mealpy         1        27    8050     1600    0,199 43/35/29/27       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "mealpy         7        26    8050      691    0,086\r\n"
-     ]
+     "text": "mealpy         7        26    8050     1577    0,196 35/27/26/26       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "mealpy        42        31    8050      640    0,080\r\n"
-     ]
+     "text": "mealpy        42        31    8050     1771    0,220 43/36/33/31       \r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "\r\n"
-     ]
+     "text": "\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "MGS    : médiane conflits 43,5 (min 39, max 48), ms/éval moyen 0,104\r\n"
-     ]
+     "text": "MGS    : médiane conflits 43,5 (min 39, max 48), ms/éval moyen 0,194\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "mealpy : médiane conflits 28,5 (min 26, max 31), ms/éval moyen 0,084\r\n"
-     ]
+     "text": "mealpy : médiane conflits 28,5 (min 26, max 31), ms/éval moyen 0,212\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Rapport ms/éval mealpy/MGS : 0,81x\r\n"
-     ]
+     "text": "Rapport ms/éval mealpy/MGS : 1,09x\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Déterminisme : conflits identiques sur les 3 répétitions pour 8/8 paires graine-moteur.\r\n"
-     ]
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Trajectoires best-so-far agrégées (médiane [min-max]) :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 25% : MGS 43,5 [39-48] | mealpy 42,0 [35-43] | delta MGS-mealpy +1,5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 50% : MGS 43,5 [39-48] | mealpy 33,5 [27-36] | delta MGS-mealpy +10,0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 75% : MGS 43,5 [39-48] | mealpy 30,0 [26-33] | delta MGS-mealpy +13,5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp100% : MGS 43,5 [39-48] | mealpy 28,5 [26-31] | delta MGS-mealpy +15,0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Forme de l'écart qualité : stagnation tardive MGS.\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Axe coût par step : MGS devant (0,91x le coût mealpy)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Déterminisme : conflits ET checkpoints identiques sur les 3 répétitions pour 8/8 paires graine-moteur.\r\n"
     }
    ],
    "source": [
@@ -688,27 +755,27 @@
     "    public bool all_same { get; set; }\n",
     "    public int evals { get; set; }\n",
     "    public double ms { get; set; }\n",
+    "    public List<int> cp { get; set; }\n",
     "    public string sol { get; set; }\n",
     "}\n",
     "\n",
     "int[] Seeds22 = { 0, 1, 7, 42 };\n",
     "\n",
-    "// --- Côté MGS (C#) : 3 répétitions par graine, ms = médiane (amendement §2) ---\n",
-    "var mgsRows = new List<(int seed, int conflicts, int evals, double ms, bool allSame)>();\n",
+    "var mgsRows = new List<(int seed, int conflicts, int evals, double ms, bool allSame, int[] cp)>();\n",
     "foreach (var sd in Seeds22)\n",
     "{\n",
-    "    var runs3 = new List<(int c, int e, double t)>();\n",
+    "    var runs3 = new List<(int c, int e, double t, int[] q)>();\n",
     "    for (int rep = 0; rep < 3; rep++)\n",
     "    {\n",
     "        var r = Mgs22Host.RunPso(sd, 50, 160);\n",
-    "        runs3.Add((r.Item1, r.Item2, r.Item3));\n",
+    "        runs3.Add((r.conflicts, r.evals, r.ms, r.cp));\n",
     "    }\n",
     "    var times = runs3.Select(x => x.t).OrderBy(t => t).ToList();\n",
-    "    double med = times[1];\n",
-    "    mgsRows.Add((sd, runs3[0].c, runs3[0].e, med, runs3.All(x => x.c == runs3[0].c)));\n",
+    "    mgsRows.Add((sd, runs3[0].c, runs3[0].e, times[1],\n",
+    "                 runs3.All(x => x.c == runs3[0].c && x.q.SequenceEqual(runs3[0].q)),\n",
+    "                 runs3[0].q));\n",
     "}\n",
     "\n",
-    "// --- Côté mealpy (Python, boucle unique dans le scope) ---\n",
     "string mealpyJson;\n",
     "using (Py.GIL())\n",
     "{\n",
@@ -718,18 +785,38 @@
     "}\n",
     "var mealpyRows = System.Text.Json.JsonSerializer.Deserialize<List<BenchRow22>>(mealpyJson);\n",
     "\n",
-    "// --- Table ---\n",
-    "static double Median22(List<int> xs)\n",
+    "static double Median22(IEnumerable<int> xs)\n",
     "{\n",
     "    var s = xs.OrderBy(x => x).ToList();\n",
     "    return (s.Count % 2 == 1) ? s[s.Count / 2] : (s[s.Count / 2 - 1] + s[s.Count / 2]) / 2.0;\n",
     "}\n",
     "\n",
-    "Console.WriteLine($\"{\"moteur\",-9} {\"graine\",6} {\"conflits\",9} {\"evals\",7} {\"ms\",8} {\"ms/eval\",8}\");\n",
+    "static string Shape22(double[] mgs, double[] mealpy)\n",
+    "{\n",
+    "    var delta = Enumerable.Range(0, 4).Select(i => mgs[i] - mealpy[i]).ToArray();\n",
+    "    var signs = delta.Where(x => x != 0).Select(Math.Sign).Distinct().ToList();\n",
+    "    if (signs.Count > 1) return \"croisement\";\n",
+    "\n",
+    "    var labels = new List<string>();\n",
+    "    double finalGap = Math.Abs(delta[3]);\n",
+    "    if (finalGap > 0 && Math.Abs(delta[0]) >= 0.75 * finalGap)\n",
+    "        labels.Add(\"précipitation précoce\");\n",
+    "\n",
+    "    double lateMgs = mgs[1] - mgs[3];\n",
+    "    double lateMealpy = mealpy[1] - mealpy[3];\n",
+    "    if (lateMealpy - lateMgs >= 2.0)\n",
+    "        labels.Add(\"stagnation tardive MGS\");\n",
+    "    else if (lateMgs - lateMealpy >= 2.0)\n",
+    "        labels.Add(\"stagnation tardive mealpy\");\n",
+    "\n",
+    "    return labels.Count > 0 ? string.Join(\" + \", labels) : \"écart progressif/mixte\";\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"{\"moteur\",-9} {\"graine\",6} {\"conflits\",9} {\"evals\",7} {\"ms\",8} {\"ms/eval\",8} {\"cp25/50/75/100\",-18}\");\n",
     "foreach (var r in mgsRows)\n",
-    "    Console.WriteLine($\"{\"MGS\",-9} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms,8:F0} {r.ms / r.evals,8:F3}\");\n",
+    "    Console.WriteLine($\"{\"MGS\",-9} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms,8:F0} {r.ms / r.evals,8:F3} {string.Join(\"/\", r.cp),-18}\");\n",
     "foreach (var r in mealpyRows)\n",
-    "    Console.WriteLine($\"{\"mealpy\",-9} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms,8:F0} {r.ms / r.evals,8:F3}\");\n",
+    "    Console.WriteLine($\"{\"mealpy\",-9} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms,8:F0} {r.ms / r.evals,8:F3} {string.Join(\"/\", r.cp),-18}\");\n",
     "\n",
     "var mgsC = mgsRows.Select(r => r.conflicts).ToList();\n",
     "var mpC = mealpyRows.Select(r => r.conflicts).ToList();\n",
@@ -739,15 +826,46 @@
     "Console.WriteLine($\"MGS    : médiane conflits {Median22(mgsC):F1} (min {mgsC.Min()}, max {mgsC.Max()}), ms/éval moyen {mgsMsEval:F3}\");\n",
     "Console.WriteLine($\"mealpy : médiane conflits {Median22(mpC):F1} (min {mpC.Min()}, max {mpC.Max()}), ms/éval moyen {mpMsEval:F3}\");\n",
     "Console.WriteLine($\"Rapport ms/éval mealpy/MGS : {mpMsEval / mgsMsEval:F2}x\");\n",
-    "int detMgs = mgsRows.Count(r => r.allSame) + mealpyRows.Count(r => r.all_same);\n",
-    "Console.WriteLine($\"Déterminisme : conflits identiques sur les 3 répétitions pour {detMgs}/8 paires graine-moteur.\");"
+    "\n",
+    "var mgsCpMedian = Enumerable.Range(0, 4).Select(k => Median22(mgsRows.Select(r => r.cp[k]))).ToArray();\n",
+    "var mpCpMedian = Enumerable.Range(0, 4).Select(k => Median22(mealpyRows.Select(r => r.cp[k]))).ToArray();\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Trajectoires best-so-far agrégées (médiane [min-max]) :\");\n",
+    "for (int k = 0; k < 4; k++)\n",
+    "{\n",
+    "    var m = mgsRows.Select(r => r.cp[k]).ToList();\n",
+    "    var p = mealpyRows.Select(r => r.cp[k]).ToList();\n",
+    "    Console.WriteLine($\"  cp{25 * (k + 1),3}% : MGS {mgsCpMedian[k]:F1} [{m.Min()}-{m.Max()}] | \" +\n",
+    "                      $\"mealpy {mpCpMedian[k]:F1} [{p.Min()}-{p.Max()}] | \" +\n",
+    "                      $\"delta MGS-mealpy {mgsCpMedian[k] - mpCpMedian[k]:+0.0;-0.0;0.0}\");\n",
+    "}\n",
+    "Console.WriteLine($\"Forme de l'écart qualité : {Shape22(mgsCpMedian, mpCpMedian)}.\");\n",
+    "Console.WriteLine(\"Axe coût par step : \" +\n",
+    "                  (mpMsEval < mgsMsEval\n",
+    "                      ? $\"mealpy devant ({mpMsEval / mgsMsEval:F2}x le coût MGS)\"\n",
+    "                      : $\"MGS devant ({mgsMsEval / mpMsEval:F2}x le coût mealpy)\"));\n",
+    "\n",
+    "int deterministic = mgsRows.Count(r => r.allSame) + mealpyRows.Count(r => r.all_same);\n",
+    "Console.WriteLine($\"Déterminisme : conflits ET checkpoints identiques sur les 3 répétitions pour {deterministic}/8 paires graine-moteur.\");"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "m22c11",
    "metadata": {},
-   "source": "### Lecture du croisement : vitesse au coude-à-coude (sensible au matériel), mealpy domine en qualité\n\nLes critères pré-enregistrés, appliqués aux médianes de 3 répétitions :\n\n- **Qualité** : mealpy médiane 28,5 contre 43,5 pour MGS — et **séparation totale des gammes** : le pire mealpy (31 conflits, graine 42) fait mieux que le meilleur MGS (39 conflits, graine 0). Le critère « médiane strictement inférieure ET max sous min » est satisfait dans les deux clauses : domination complète, sans chevauchement de distributions. Ce verdict est **déterministe et reproductible à l'identique** (re-exécution #13407 : mêmes conflits 4/4 graines, mêmes médianes).\n- **Vitesse** : rapport ms/éval de **0,81×** sur cette exécution — mealpy ~19 % moins cher par évaluation. Les médianes par graine : mealpy 640-717 ms pour ~8 050 évaluations, MGS 787-854 ms pour 8 000. Le run original (outputs remplacés par la re-exécution #13407) donnait **0,99×** après amendement anti-pic GC (1,31× en moyenne brute) : la vitesse relative est **sensible au matériel** — l'écart observé traverse 1,0× d'une machine à l'autre. Le verdict robuste est la **parité d'ordre de grandeur** (0,8×-1,3× observé), pas le signe de l'écart. L'amendement de protocole reste décisif : le run pilote en timing single-run concluant « 0,8×, mealpy 20 % plus vite » était un **artefact** — un pic de garbage collection .NET (1 132 ms mesurés pour une course qui en prend ~660 à chaud) avait gonflé la moyenne MGS. Tout timing de cette série se lit en médiane de répétitions.\n- **Déterminisme** : 8/8 paires graine-moteur avec conflits identiques sur les 3 répétitions — le seeding est prouvé *en direct*, et corollaire important : la différence de qualité entre moteurs (39-48 contre 26-31) **n'est pas du bruit**, chaque course seedée reproduit exactement son résultat.\n\nL'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se lit donc en deux moitiés : **réfutée sur l'axe vitesse** (MGS tient l'ordre de grandeur de mealpy à budget égal, l'écart restant dans la sensibilité matérielle), et **vérifiée en sens inverse sur l'axe qualité** (mealpy devant, nettement, de façon déterministe). La nuance honnête sur l'axe qualité : les deux « PSO canoniques » ne partagent pas leurs paramètres par défaut (coefficients d'inertie et d'attraction réglés différemment par chaque bibliothèque) — l'axe mesure *la bibliothèque telle qu'on la lance*, ce que mesure un utilisateur réel, pas une course de formules identiques. La section suivante explique pourquoi l'équilibre vitesse est, malgré tout, le résultat le plus instructif du notebook."
+   "source": [
+    "### Lecture du croisement : l'écart se construit après le premier quart\n",
+    "\n",
+    "Les critères pré-enregistrés et les trajectoires best-so-far donnent une lecture plus précise que les seuls résultats finaux :\n",
+    "\n",
+    "- **Qualité finale** : mealpy atteint une médiane de 28,5 conflits contre 43,5 pour MGS, avec séparation totale des gammes : 26-31 contre 39-48.\n",
+    "- **Trajectoire médiane** : MGS est déjà à 43,5 au checkpoint 25 % et ne progresse plus ensuite ; mealpy passe de 42,0 à 33,5, puis 30,0 et 28,5. L'écart médian MGS − mealpy se creuse donc de +1,5 à +15,0 conflits.\n",
+    "- **Forme de l'écart** : le classifieur dérivé des quatre checkpoints conclut `stagnation tardive MGS`. L'avantage mealpy n'est pas acquis brutalement à l'initialisation : il apparaît surtout parce que mealpy continue d'améliorer son best-so-far de la seconde moitié jusqu'à la fin, là où MGS a déjà gelé.\n",
+    "- **Déterminisme** : conflits finaux **et** quatre checkpoints sont identiques sur les trois répétitions pour les huit couples graine-moteur. La forme observée n'est donc pas un artefact d'une seule trajectoire.\n",
+    "- **Coût par étape** : la cellule calcule dynamiquement le rapport ms/éval du run courant. Les temps absolus ne sont pas recopiés ici, car ils dépendent du matériel ; le verdict robuste reste la parité d'ordre de grandeur.\n",
+    "\n",
+    "L'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se sépare ainsi en deux axes : MGS tient l'ordre de grandeur sur le coût par étape, mais mealpy domine nettement la qualité à budget égal. Les deux PSO ne partagent pas tous leurs paramètres par défaut : ce banc mesure donc les bibliothèques telles qu'un utilisateur les lance, tandis que les checkpoints localisent **quand** leur comportement diverge."
+   ]
   },
   {
    "cell_type": "code",
@@ -762,30 +880,22 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Fitness seule, 500 vecteurs identiques (médiane de 5 répétitions par côté) :\r\n"
-     ]
+     "text": "Fitness seule, 500 vecteurs identiques (médiane de 5 répétitions par côté) :\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  C#     : 3,5 ms total -> 0,007 ms/éval\r\n"
-     ]
+     "text": "  C#     : 6,9 ms total -> 0,014 ms/éval\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  Python : 17,8 ms total -> 0,036 ms/éval\r\n"
-     ]
+     "text": "  Python : 38,2 ms total -> 0,076 ms/éval\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  rapport Python/C# : 5,13x\r\n"
-     ]
+     "text": "  rapport Python/C# : 5,56x\r\n"
     }
    ],
    "source": [
@@ -825,7 +935,19 @@
    "cell_type": "markdown",
    "id": "m22c13",
    "metadata": {},
-   "source": "### Lecture du coût par évaluation : fitness C# ~5× plus rapide — et un bench au coude-à-coule quand même\n\nC'est la cellule qui explique le paradoxe apparent du croisement. Mesurée seule, hors moteur, sur les 500 mêmes vecteurs (médiane de 5 répétitions) :\n\n- **fitness C# : 0,007 ms/éval** (3,5 ms pour 500) — **fitness Python : 0,036 ms/éval** (17,8 ms) : rapport **5,13×** en faveur du C# (run original : 5,72× — l'écart JIT .NET contre Python interprété est bien là, massif, de l'ordre de 5-6× d'une machine à l'autre).\n\nPourtant le bench complet donne 0,104 ms/éval pour MGS contre 0,084 pour mealpy — un écart de seulement ~20 %, là où la fitness seule en promettait 5×. La décomposition arithmétique est la leçon du notebook :\n\n| | fitness (mesurée) | moteur (bench − fitness) | total |\n|---|---|---|---|\n| **MGS** | 0,007 ms/éval | **0,097 ms/éval** | 0,104 |\n| **mealpy** | 0,036 ms/éval | **0,048 ms/éval** | 0,084 |\n\nDeux effets opposés se compensent : la fitness C# est ~5× plus rapide, mais la **mécanique de génération** de MetaGeneticSharp (sélection, croisement, mutation, structures de population) dépense ~0,097 ms par évaluation, soit **~2,0×** celle de mealpy (~0,048 ms ; run original : 1,8×) — et la fitness ne pèse que ~7 % du coût total côté MGS. Trois moralités mesurées : *le coût par évaluation d'un moteur n'est pas le coût de sa fitness* ; *un avantage fitness spectaculaire (~5×) peut être presque invisible dans le temps total* ; et *un timing single-run aurait conclu n'importe quoi* — le pilot a lu 0,8× sur un run, le run amendé 0,99×, cette exécution 0,81×, pour le même code (les deux derniers chiffres sur des machines différentes : le signe de l'écart vitesse n'est pas une propriété du code)."
+   "source": [
+    "### Lecture du coût par évaluation : isoler la fitness du moteur\n",
+    "\n",
+    "La cellule mesure `decode + cost` sur les 500 mêmes vecteurs, cinq fois par langage, puis affiche la médiane. Le rapport Python/C# reste très supérieur à un : la fitness C# est nettement moins coûteuse isolément.\n",
+    "\n",
+    "Ce résultat ne se transpose pas directement au bench complet. Le temps par évaluation y inclut aussi la mise à jour des particules, la gestion de la population et les structures propres à chaque bibliothèque. La comparaison utile est donc la décomposition calculée depuis les deux cellules de mesure :\n",
+    "\n",
+    "- **fitness isolée** : avantage C# net ;\n",
+    "- **moteur complet** : coût par étape du même ordre de grandeur ;\n",
+    "- **conséquence** : accélérer encore la fitness C# ne suffit pas à expliquer ni à corriger la stagnation tardive observée aux checkpoints.\n",
+    "\n",
+    "Les temps absolus restent dans l'output frais et ne sont pas recopiés ici : ils changent avec la machine. Les rapports mesurés dans une même cellule conservent, eux, la comparaison pédagogique."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -852,9 +974,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer : bench croise GA mealpy vs GA MGS (4 graines, budget egal).\r\n"
-     ]
+     "text": "Exercice a completer : bench croise GA mealpy vs GA MGS (4 graines, budget egal).\r\n"
     }
    ],
    "source": [
@@ -892,9 +1012,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer : budget x4 des deux cotes, comparaison des medianes et du rapport ms/eval.\r\n"
-     ]
+     "text": "Exercice a completer : budget x4 des deux cotes, comparaison des medianes et du rapport ms/eval.\r\n"
     }
    ],
    "source": [
@@ -930,9 +1048,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer : profil decode/cost par cote, repartition fitness vs moteur.\r\n"
-     ]
+     "text": "Exercice a completer : profil decode/cost par cote, repartition fitness vs moteur.\r\n"
     }
    ],
    "source": [
@@ -950,7 +1066,17 @@
    "cell_type": "markdown",
    "id": "m22c20",
    "metadata": {},
-   "source": "## Résumé et perspectives\n\n**Réponse à l'hypothèse de départ.** Sur ce plan (PSO canonique contre OriginalPSO, grille Easy[0], coût prouvé identique, ~8 000 évaluations, graines {0, 1, 7, 42}, médianes de répétitions) : **vitesse au coude-à-coule** (0,81× le coût par éval sur cette exécution ; 0,99× sur le run original — l'écart traverse 1,0× selon la machine, le verdict robuste est la parité d'ordre de grandeur), **mealpy domine en qualité** (médiane 28,5 contre 43,5 conflits, séparation totale des gammes 26-31 contre 39-48 — reproductible à l'identique, la re-exécution #13407 retrouve chaque conflit par graine). L'hypothèse « les perfs ne suivront pas mealpy » est réfutée sur l'axe vitesse — MetaGeneticSharp tient l'ordre de grandeur — et l'écart réel entre bibliothèques se joue sur les **défauts du solveur** (qualité à budget égal), pas sur la vitesse d'exécution.\n\n**Le mécanisme, mesuré.** La fitness C# est 5,13× plus rapide (0,007 contre 0,036 ms/éval), mais la mécanique MGS coûte ~2,0× plus par évaluation (0,097 contre 0,048 ms) — les deux effets se compensent largement (0,104 contre 0,084 ms/éval au total). C'est la démonstration la plus utile du notebook pour la suite de la série : optimiser la fitness C# (déjà marginale à ~7 % du total) ne rapprochera MGS de personne ; la cible est la mécanique de génération.\n\n**La méthode, réutilisable.** Sanity check sur vecteurs témoins LCG avant tout bench cross-langage ; seed explicite en `solve()` côté mealpy (le constructeur l'ignore silencieusement — piège documenté ici pour la série) ; `ResetSeed` avant création de population côté MGS ; **tout timing en médiane de répétitions** — l'amendement de ce notebook (un pic GC .NET peut fausser un single-run de ±60 %) vaut pour tous les bancs à venir ; et, leçon de la re-exécution #13407 : les **grandeurs seedées (conflits, médianes) sont reproductibles à l'identique**, les **rapports de timing sont sensibles au matériel** — un verdict vitesse ne se lit jamais sur le seul signe d'un ratio observé une fois.\n\n**Perspectives.** (1) Les exercices testent la robustesse du verdict : GA contre GA (Exercice 1 — mealpy a aussi `BaseGA`, MGS son composé `Default`), budget ×4 (Exercice 2). (2) Le point d'entrée pour dépasser mealpy en qualité n'est pas la vitesse brute mais les **composés spécialisés** de la série (seeding MGS-4/MGS-7, îles) : le composé PSO canonique, pris isolément, perd contre les défauts bien réglés de mealpy sur ce cas. (3) Le profiling de l'Exercice 3 dira où va la milliseconde moteur — les 0,097 ms/éval de mécanique MGS étant la cible évidente."
+   "source": [
+    "## Résumé et perspectives\n",
+    "\n",
+    "**Réponse à l'hypothèse de départ.** Sur ce plan apparié — PSO canonique contre `OriginalPSO`, même grille et même coût, budgets mesurés, graines {0, 1, 7, 42} — mealpy domine la qualité finale : médiane 28,5 contre 43,5 conflits, avec séparation des gammes 26-31 contre 39-48. Le coût par étape reste du même ordre de grandeur ; son signe varie avec le matériel et se lit dans l'output, pas dans une valeur figée en prose.\n",
+    "\n",
+    "**Le mécanisme, désormais localisé.** Les checkpoints montrent que l'écart n'est pas principalement une précipitation initiale : MGS atteint sa médiane finale dès 25 % du budget et stagne, tandis que mealpy améliore encore son best-so-far jusqu'à 100 %. Le classifieur dérivé des outputs conclut donc **stagnation tardive MGS**. La fitness C# isolée reste nettement moins coûteuse, mais cet avantage ne produit ni meilleure convergence ni domination nette du coût moteur complet.\n",
+    "\n",
+    "**La méthode, réutilisable.** Sanity check cross-langage sur vecteurs témoins LCG ; graines passées explicitement à `solve()` et `ResetSeed()` ; budgets comptés dans les fitness ; trajectoires best-so-far aux quarts du budget propre à chaque moteur ; médiane et min-max sur quatre graines ; temps mesurés en médiane de répétitions. Le notebook vérifie maintenant le déterminisme des conflits **et** des checkpoints pour les huit couples graine-moteur.\n",
+    "\n",
+    "**Perspectives.** (1) L'Exercice 1 teste si la forme d'écart se reproduit GA contre GA. (2) L'Exercice 2 prolonge le budget pour distinguer gel durable et retard rattrapable. (3) L'Exercice 3 sépare décodage et compte de conflits afin de localiser le coût de la fitness sans le confondre avec la dynamique du solveur."
+   ]
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
@@ -858,13 +858,13 @@
     "\n",
     "Les critères pré-enregistrés et les trajectoires best-so-far donnent une lecture plus précise que les seuls résultats finaux :\n",
     "\n",
-    "- **Qualité finale** : mealpy atteint une médiane de 28,5 conflits contre 43,5 pour MGS, avec séparation totale des gammes : 26-31 contre 39-48.\n",
+    "- **Qualité finale** : mealpy atteint une médiane de 28,5 conflits contre 43,5 pour MGS, avec séparation totale des gammes : 26-31 contre 39-48. Le pire résultat mealpy reste ainsi meilleur que le meilleur résultat MGS ; la domination ne dépend pas d'un chevauchement interprété favorablement.\n",
     "- **Trajectoire médiane** : MGS est déjà à 43,5 au checkpoint 25 % et ne progresse plus ensuite ; mealpy passe de 42,0 à 33,5, puis 30,0 et 28,5. L'écart médian MGS − mealpy se creuse donc de +1,5 à +15,0 conflits.\n",
     "- **Forme de l'écart** : le classifieur dérivé des quatre checkpoints conclut `stagnation tardive MGS`. L'avantage mealpy n'est pas acquis brutalement à l'initialisation : il apparaît surtout parce que mealpy continue d'améliorer son best-so-far de la seconde moitié jusqu'à la fin, là où MGS a déjà gelé.\n",
-    "- **Déterminisme** : conflits finaux **et** quatre checkpoints sont identiques sur les trois répétitions pour les huit couples graine-moteur. La forme observée n'est donc pas un artefact d'une seule trajectoire.\n",
-    "- **Coût par étape** : la cellule calcule dynamiquement le rapport ms/éval du run courant. Les temps absolus ne sont pas recopiés ici, car ils dépendent du matériel ; le verdict robuste reste la parité d'ordre de grandeur.\n",
+    "- **Déterminisme** : conflits finaux **et** quatre checkpoints sont identiques sur les trois répétitions pour les huit couples graine-moteur. La forme observée n'est donc pas un artefact d'une seule trajectoire, et la séparation finale n'est pas du bruit entre répétitions.\n",
+    "- **Coût par étape** : la cellule calcule dynamiquement le rapport ms/éval du run courant. Les temps absolus ne sont pas recopiés ici, car ils dépendent du matériel ; le verdict robuste reste la parité d'ordre de grandeur. Les répétitions médianes évitent notamment qu'un pic ponctuel du runtime .NET dicte le verdict.\n",
     "\n",
-    "L'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se sépare ainsi en deux axes : MGS tient l'ordre de grandeur sur le coût par étape, mais mealpy domine nettement la qualité à budget égal. Les deux PSO ne partagent pas tous leurs paramètres par défaut : ce banc mesure donc les bibliothèques telles qu'un utilisateur les lance, tandis que les checkpoints localisent **quand** leur comportement diverge."
+    "L'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se sépare ainsi en deux axes : MGS tient l'ordre de grandeur sur le coût par étape, mais mealpy domine nettement la qualité à budget égal. Les deux PSO ne partagent pas tous leurs paramètres par défaut : ce banc mesure donc les bibliothèques telles qu'un utilisateur les lance, tandis que les checkpoints localisent **quand** leur comportement diverge. Cette distinction est décisive pour la suite : elle interdit d'attribuer immédiatement l'écart au noyau MGS, mais elle désigne la stagnation après le premier quart comme phénomène à instrumenter."
    ]
   },
   {
@@ -938,15 +938,18 @@
    "source": [
     "### Lecture du coût par évaluation : isoler la fitness du moteur\n",
     "\n",
-    "La cellule mesure `decode + cost` sur les 500 mêmes vecteurs, cinq fois par langage, puis affiche la médiane. Le rapport Python/C# reste très supérieur à un : la fitness C# est nettement moins coûteuse isolément.\n",
+    "La cellule mesure `decode + cost` sur les 500 mêmes vecteurs, cinq fois par langage, puis affiche la médiane. Le rapport Python/C# reste très supérieur à un : la fitness C# est nettement moins coûteuse isolément. Ce résultat préserve l'observation antérieure d'un écart d'environ 5-6× selon la machine, sans figer en prose un temps absolu qui dériverait au prochain passage kernel.\n",
     "\n",
     "Ce résultat ne se transpose pas directement au bench complet. Le temps par évaluation y inclut aussi la mise à jour des particules, la gestion de la population et les structures propres à chaque bibliothèque. La comparaison utile est donc la décomposition calculée depuis les deux cellules de mesure :\n",
     "\n",
     "- **fitness isolée** : avantage C# net ;\n",
     "- **moteur complet** : coût par étape du même ordre de grandeur ;\n",
+    "- **mécanique résiduelle** : la différence `temps total par évaluation − fitness isolée` absorbe l'essentiel du coût côté MGS ;\n",
     "- **conséquence** : accélérer encore la fitness C# ne suffit pas à expliquer ni à corriger la stagnation tardive observée aux checkpoints.\n",
     "\n",
-    "Les temps absolus restent dans l'output frais et ne sont pas recopiés ici : ils changent avec la machine. Les rapports mesurés dans une même cellule conservent, eux, la comparaison pédagogique."
+    "Les anciennes mesures illustraient déjà ce paradoxe : un avantage massif de la fitness C# devenait presque invisible dans le temps total, parce que sélection, structures de population et mises à jour du moteur dominaient le budget par étape. Le présent run confirme la structure du diagnostic sans transformer des chiffres machine-dépendants en constantes pédagogiques.\n",
+    "\n",
+    "Trois moralités en découlent : *le coût par évaluation d'un moteur n'est pas le coût de sa fitness* ; *un avantage fitness spectaculaire peut être absorbé par la mécanique de génération* ; et *un timing single-run peut inverser le signe du classement*. Les temps absolus restent donc dans l'output frais. Les rapports mesurés dans une même cellule et la décomposition fitness/moteur conservent, eux, la comparaison pédagogique."
    ]
   },
   {
@@ -1069,13 +1072,15 @@
    "source": [
     "## Résumé et perspectives\n",
     "\n",
-    "**Réponse à l'hypothèse de départ.** Sur ce plan apparié — PSO canonique contre `OriginalPSO`, même grille et même coût, budgets mesurés, graines {0, 1, 7, 42} — mealpy domine la qualité finale : médiane 28,5 contre 43,5 conflits, avec séparation des gammes 26-31 contre 39-48. Le coût par étape reste du même ordre de grandeur ; son signe varie avec le matériel et se lit dans l'output, pas dans une valeur figée en prose.\n",
+    "**Réponse à l'hypothèse de départ.** Sur ce plan apparié — PSO canonique contre `OriginalPSO`, même grille et même coût, budgets mesurés, graines {0, 1, 7, 42} — mealpy domine la qualité finale : médiane 28,5 contre 43,5 conflits, avec séparation des gammes 26-31 contre 39-48. Le coût par étape reste du même ordre de grandeur ; son signe varie avec le matériel et se lit dans l'output, pas dans une valeur figée en prose. L'hypothèse « les perfs ne suivront pas mealpy » est donc réfutée sur l'axe vitesse brute, mais confirmée sur l'axe qualité à budget égal.\n",
     "\n",
-    "**Le mécanisme, désormais localisé.** Les checkpoints montrent que l'écart n'est pas principalement une précipitation initiale : MGS atteint sa médiane finale dès 25 % du budget et stagne, tandis que mealpy améliore encore son best-so-far jusqu'à 100 %. Le classifieur dérivé des outputs conclut donc **stagnation tardive MGS**. La fitness C# isolée reste nettement moins coûteuse, mais cet avantage ne produit ni meilleure convergence ni domination nette du coût moteur complet.\n",
+    "**Le mécanisme, désormais localisé.** Les checkpoints montrent que l'écart n'est pas principalement une précipitation initiale : MGS atteint sa médiane finale dès 25 % du budget et stagne, tandis que mealpy améliore encore son best-so-far jusqu'à 100 %. Le classifieur dérivé des outputs conclut donc **stagnation tardive MGS**. La fitness C# isolée reste nettement moins coûteuse, mais cet avantage ne produit ni meilleure convergence ni domination nette du coût moteur complet. La cible d'analyse n'est donc plus « accélérer la fitness » : elle devient la dynamique de population après le premier quart — diversité, amélioration de pbest/gbest, réinsertion ou perturbation.\n",
     "\n",
-    "**La méthode, réutilisable.** Sanity check cross-langage sur vecteurs témoins LCG ; graines passées explicitement à `solve()` et `ResetSeed()` ; budgets comptés dans les fitness ; trajectoires best-so-far aux quarts du budget propre à chaque moteur ; médiane et min-max sur quatre graines ; temps mesurés en médiane de répétitions. Le notebook vérifie maintenant le déterminisme des conflits **et** des checkpoints pour les huit couples graine-moteur.\n",
+    "**La méthode, réutilisable.** Sanity check cross-langage sur vecteurs témoins LCG ; graines passées explicitement à `solve()` et `ResetSeed()` ; budgets comptés dans les fitness ; trajectoires best-so-far aux quarts du budget propre à chaque moteur ; médiane et min-max sur quatre graines ; temps mesurés en médiane de répétitions. Le notebook vérifie maintenant le déterminisme des conflits **et** des checkpoints pour les huit couples graine-moteur. Cette séparation protège deux leçons des runs précédents : les grandeurs seedées sont reproductibles, tandis que les rapports de timing restent sensibles au matériel.\n",
     "\n",
-    "**Perspectives.** (1) L'Exercice 1 teste si la forme d'écart se reproduit GA contre GA. (2) L'Exercice 2 prolonge le budget pour distinguer gel durable et retard rattrapable. (3) L'Exercice 3 sépare décodage et compte de conflits afin de localiser le coût de la fitness sans le confondre avec la dynamique du solveur."
+    "**Ce que le benchmark ne prouve pas encore.** Les paramètres par défaut des deux PSO diffèrent. La trajectoire identifie donc un phénomène, pas encore sa cause unique : défaut du noyau MGS, régime de paramètres ou interaction avec la représentation R1 restent à départager. Toute amélioration doit conserver fonction de coût, graines, budgets et checkpoints, puis comparer avant/après sur le même plan.\n",
+    "\n",
+    "**Perspectives.** (1) L'Exercice 1 teste si la forme d'écart se reproduit GA contre GA, afin de distinguer effet bibliothèque et effet algorithme. (2) L'Exercice 2 prolonge le budget pour distinguer gel durable et retard rattrapable. (3) L'Exercice 3 sépare décodage et compte de conflits afin de localiser le coût de la fitness sans le confondre avec la dynamique du solveur. La suite corrective doit surtout instrumenter diversité et taux d'amélioration, tester un changement MGS atomique, puis rejouer exactement ce benchmark pour conclure `IMPROVES`, `NO IMPROVEMENT`, `TRADE-OFF` ou `INCONCLUSIVE`."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #13731

## Résumé

- instrumente les trajectoires best-so-far de MGS et mealpy aux checkpoints 25/50/75/100 % de leur budget propre ;
- agrège les quatre graines partagées `{0, 1, 7, 42}` par médiane et min-max ;
- vérifie sur trois répétitions que conflits finaux et checkpoints sont identiques pour les huit couples graine-moteur ;
- sépare le coût par évaluation du temps total et dérive dynamiquement la forme de l'écart.

See #12607
See #1203

## Résultats mesurés

| Checkpoint | MGS médiane [min-max] | mealpy médiane [min-max] | Delta MGS-mealpy |
|---|---:|---:|---:|
| 25 % | 43,5 [39-48] | 42,0 [35-43] | +1,5 |
| 50 % | 43,5 [39-48] | 33,5 [27-36] | +10,0 |
| 75 % | 43,5 [39-48] | 30,0 [26-33] | +13,5 |
| 100 % | 43,5 [39-48] | 28,5 [26-31] | +15,0 |

Classification dérivée : **stagnation tardive MGS**. MGS atteint sa médiane finale dès le premier quart, tandis que mealpy continue de progresser jusqu'au budget complet.

Déterminisme : conflits **et** quatre checkpoints identiques sur trois répétitions pour **8/8** couples graine-moteur.

## Exécution réelle

- kernel : `.net-csharp` ;
- environnement PythonNet : Python 3.13.12, mealpy 3.0.2 ;
- budget MGS : 8 000 évaluations par course ;
- budget mealpy : 8 050 évaluations par course, population initiale incluse ;
- exécution finale : **9/9 cellules, 0 erreur, 71,9 s** ;
- `execution_count` : 1 à 9, outputs committés ;
- contre-vérification C#/Python du coût mealpy : `IDENTIQUE`.

## Verdict SOTA

**SOTA-OK** : le notebook exécute les vrais moteurs MetaGeneticSharp et mealpy `OriginalPSO` via PythonNet, sans substitution ni sortie fabriquée. Les DLL MetaGeneticSharp ont été reconstruites depuis les gitlinks canoniques avant exécution (`MetaGeneticSharp.sln` : 0 erreur ; 39 warnings préexistants).

## Validation

- `validate_pr_notebooks.py` : `EXEC_PROVED`, 9 cellules code, passed ;
- `check_cell_source_parses.py` : 0 finding ;
- `count_exercises.py` : 3 exercices, conforme ;
- ordering / interprétations / navlinks : 0 finding ;
- cellules code consécutives : 0 run ;
- bannière `probeAddresses` : retirée par l'outil canonique, rescan à 0 ;
- C.1 : aucune erreur volontaire ;
- pre-commit ciblé : tous les hooks passent, dont gitleaks et H.3 ;
- scope : un seul notebook, aucun artefact catalogue modifié.

## Limites

Les deux PSO utilisent les paramètres par défaut de leurs bibliothèques respectives : le banc compare l'expérience utilisateur réelle à budget égal, pas deux formules paramétriques strictement identiques. Les temps absolus restent machine-dépendants ; la prose ne fige donc pas leur valeur.