### PR TITLE
fix(gate,#13779): l'echappatoire A RELIRE masquait le commentaire qui motivait le HOLD -- union + compte total

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -2087,10 +2087,28 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
             "body": body,
         })
     # Ce qui suit le dernier commit est le plus a risque (rien ne peut
-    # pretendre l'avoir traite) ; a defaut, la queue -- exactement les
+    # pretendre l'avoir traite) ; s'y ajoute la queue -- exactement les
     # `comments[-3:]` que la regle demande de relire avant `gh pr merge`.
+    #
+    # #13779 -- le repli etait EXCLUSIF (`after_lc or queue`) : des qu'UN
+    # commentaire suivait le dernier commit, toute la queue anterieure
+    # sortait de l'affichage, et l'en-tete imprimait le compte du
+    # SOUS-ENSEMBLE en le presentant comme le total. Mesure sur #13712 :
+    # 5 non evalues, 3 affiches -- et parmi les 2 masques, le
+    # `[ADJOINT PREFLIGHT]` de 19:30:49Z dont le point non traite motivait
+    # le HOLD du coordinateur sur cette PR meme. Masque parce qu'un commit
+    # etait passe apres lui, alors que « un commit pousse apres la remarque
+    # ne la leve PAS a lui seul » (B.0) : sur la seule PR ou l'echappatoire
+    # a servi, elle a cache le commentaire qui justifiait le blocage.
+    #
+    # Les deux mecanismes COMPOSENT au lieu de s'exclure : tout le
+    # post-dernier-commit, PLUS la queue des anterieurs -- que l'existence
+    # du premier n'annule plus. Strict sur-ensemble de l'ancien affichage :
+    # cette borne ne peut que montrer davantage, jamais moins, et ne touche
+    # aucun verdict (`unevaluated` ne participe pas a `blocked`).
     after_lc = [u for u in unevaluated if u["after_last_commit"]]
-    to_read = after_lc or unevaluated[-3:]
+    before_lc = [u for u in unevaluated if not u["after_last_commit"]]
+    to_read = sorted(after_lc + before_lc[-3:], key=lambda u: u["at"] or "")
 
     return {
         "pr": pr_data.get("number"),
@@ -2125,10 +2143,16 @@ def _print_unevaluated(result: dict) -> None:
     rows = result.get("unevaluated") or []
     if not rows:
         return
+    # #13779 : le compte imprime est celui du TOTAL non evalue, pas celui des
+    # lignes affichees -- un organe dont tout le propos est de ne pas certifier
+    # son propre silence ne peut pas sous-declarer ce qu'il n'a pas lu.
+    total = result.get("unevaluated_total") or len(rows)
+    omitted = total - len(rows)
     after = sum(1 for r in rows if r["after_last_commit"])
     tail = f", dont {after} posterieur(s) au dernier commit" if after else ""
+    cut = f" — {len(rows)} affiche(s), {omitted} plus ancien(s) omis" if omitted > 0 else ""
     print()
-    print(f"  --- A RELIRE : {len(rows)} commentaire(s) NON EVALUE(S) par cet organe{tail} ---")
+    print(f"  --- A RELIRE : {total} commentaire(s) NON EVALUE(S) par cet organe{tail}{cut} ---")
     print("  Le verdict ci-dessus ne porte QUE sur les phrases de levee. Ces")
     print("  commentaires n'ont pas ete classes : les lire avant `gh pr merge`.")
     for r in rows:

--- a/scripts/tests/test_check_unaddressed_nits_unevaluated.py
+++ b/scripts/tests/test_check_unaddressed_nits_unevaluated.py
@@ -1,0 +1,140 @@
+"""Tests #13779 — l'echappatoire « A RELIRE » ne masque plus, et ne sous-declare plus.
+
+`_print_unevaluated` existe pour que l'organe CESSE DE CERTIFIER SON SILENCE
+(#13512) : ce qu'il n'a pas su classer, il l'imprime. Deux defauts vidaient la
+promesse de sa substance, tous deux dans la selection `to_read` :
+
+  - **repli EXCLUSIF** : `after_lc or unevaluated[-3:]` — des qu'UN commentaire
+    suivait le dernier commit, toute la queue anterieure sortait de
+    l'affichage. Le critere presuppose qu'un commit traite ce qui le precede,
+    quand B.0 dit l'inverse en toutes lettres (« un commit pousse apres la
+    remarque ne la leve PAS a lui seul »).
+  - **compte du sous-ensemble presente comme total** : l'en-tete imprimait
+    `len(rows)`, pas `unevaluated_total`.
+
+Mesure fondatrice, PR #13712 (2026-08-30) : 5 non evalues, 3 affiches — et
+parmi les 2 masques, le `[ADJOINT PREFLIGHT]` de 19:30:49Z dont le point non
+traite motivait le HOLD du coordinateur sur cette PR meme. Sur la seule PR ou
+l'echappatoire a servi, elle a cache le commentaire qui justifiait le blocage,
+et l'a cache parce qu'un commit etait passe apres lui.
+
+Les tests sont ecrits par leurs FAUX NEGATIFS : chacun echoue sur le code
+d'avant. Aucun appel reseau — `analyse()` est pur.
+"""
+import contextlib
+import importlib.util
+import io
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_unaddressed_nits.py"
+
+spec = importlib.util.spec_from_file_location(
+    "check_unaddressed_nits_unevaluated", CHECK_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_unaddressed_nits_unevaluated"] = mod
+spec.loader.exec_module(mod)
+
+COMMIT_AT = "2026-08-30T10:00:00Z"
+CUTOFF = datetime(2026, 8, 30, 13, 0, tzinfo=timezone.utc)
+
+# Prose sans aucun CONCERN_MARKERS : l'organe ne la classe pas — c'est admis,
+# et c'est exactement la population que « A RELIRE » existe pour rendre visible.
+PREFLIGHT = ("[ADJOINT PREFLIGHT] Relecture complete : le point 3 sur la "
+             "provenance reste ouvert, la cellule 12 ne porte pas la sortie "
+             "qu'annonce la prose.")
+LATER = "[REPONSE PREFLIGHT] Les points 1 et 2 sont traites au nouveau head."
+
+
+def _c(at, body, login="jsboige"):
+    return {"author": {"login": login}, "createdAt": at, "body": body}
+
+
+def _pr(comments, commit_at=COMMIT_AT):
+    return {"number": 13712, "title": "t", "author": {"login": "jsboige"},
+            "commits": [{"committedDate": commit_at}],
+            "reviews": [], "comments": comments}
+
+
+def _run(comments):
+    return mod.analyse(_pr(comments), [], CUTOFF)
+
+
+def test_13779_precondition_bodies_are_genuinely_unclassified():
+    """Sans ca les tests suivants passeraient pour la mauvaise raison."""
+    assert mod.classify("jsboige", PREFLIGHT) is None
+    assert mod.classify("jsboige", LATER) is None
+
+
+def test_13779_pre_last_commit_comment_survives_a_later_one():
+    """LE faux negatif fondateur : un commit posterieur ne doit rien masquer."""
+    res = _run([_c("2026-08-30T09:30:00Z", PREFLIGHT),
+                _c("2026-08-30T11:00:00Z", LATER)])
+    bodies = [u["body"] for u in res["unevaluated"]]
+    assert PREFLIGHT in bodies, (
+        "le commentaire anterieur au dernier commit a ete masque par "
+        "l'existence d'un commentaire posterieur — defaut #13779")
+    assert LATER in bodies
+    assert res["unevaluated_total"] == 2
+
+
+def test_13779_displayed_count_matches_total_when_nothing_is_omitted():
+    """Le cas de la mesure #13712 : 5 non evalues, 5 affiches."""
+    res = _run([_c("2026-08-30T09:%02d:00Z" % m, PREFLIGHT + str(m))
+                for m in (10, 30)]
+               + [_c("2026-08-30T11:%02d:00Z" % m, LATER + str(m))
+                  for m in (0, 30, 45)])
+    assert res["unevaluated_total"] == 5
+    assert len(res["unevaluated"]) == 5
+
+
+def test_13779_header_prints_the_total_not_the_displayed_count():
+    """L'en-tete sous-declarait ce que l'organe n'avait pas lu."""
+    res = _run([_c("2026-08-30T09:%02d:00Z" % m, PREFLIGHT + str(m))
+                for m in (10, 20, 30, 40, 50)]
+               + [_c("2026-08-30T11:00:00Z", LATER)])
+    assert res["unevaluated_total"] == 6
+    assert len(res["unevaluated"]) == 4, "1 posterieur + queue de 3 anterieurs"
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        mod._print_unevaluated(res)
+    head = buf.getvalue()
+    assert "A RELIRE : 6 commentaire(s)" in head, (
+        "le compte imprime doit etre le TOTAL non evalue, pas les lignes "
+        "affichees — sinon l'organe sous-declare son propre silence")
+    assert "2 plus ancien(s) omis" in head, "l'omission doit etre NOMMEE"
+
+
+def test_13779_tail_of_pre_last_commit_stays_bounded():
+    """Composer les deux mecanismes ne doit pas rendre la sortie illisible."""
+    res = _run([_c("2026-08-30T09:%02d:00Z" % m, PREFLIGHT + str(m))
+                for m in range(0, 50, 10)]
+               + [_c("2026-08-30T11:00:00Z", LATER)])
+    before = [u for u in res["unevaluated"] if not u["after_last_commit"]]
+    assert len(before) == 3, "la queue anterieure reste plafonnee a 3"
+    assert res["unevaluated_total"] == 6
+
+
+def test_13779_display_is_chronological():
+    """L'anterieur se lit avant le posterieur, comme le fil de la PR."""
+    res = _run([_c("2026-08-30T09:30:00Z", PREFLIGHT),
+                _c("2026-08-30T11:00:00Z", LATER)])
+    ats = [u["at"] for u in res["unevaluated"]]
+    assert ats == sorted(ats)
+
+
+def test_13779_no_posterior_comment_keeps_the_tail_behaviour():
+    """Controle de non-regression : sans posterieur, l'ancien comportement."""
+    res = _run([_c("2026-08-30T09:%02d:00Z" % m, PREFLIGHT + str(m))
+                for m in range(0, 50, 10)])
+    assert res["unevaluated_total"] == 5
+    assert len(res["unevaluated"]) == 3
+
+
+def test_13779_surfacing_never_blocks():
+    """Rendre visible n'est pas bloquer : `unevaluated` ne touche aucun verdict."""
+    res = _run([_c("2026-08-30T09:30:00Z", PREFLIGHT),
+                _c("2026-08-30T11:00:00Z", LATER)])
+    assert res["blocked"] is False


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA -- prev: MED/guard #13726

Facette **C** de #13779, livree en premier a la demande du coordinateur : c'est le seul filet sur lequel il se rabat quand l'organe rend `rc=0`, et il sous-declarait.

## Le defaut

`analyse` selectionnait les non-evalues par un repli **exclusif** :

```python
after_lc = [u for u in unevaluated if u["after_last_commit"]]
to_read  = after_lc or unevaluated[-3:]
```

Des qu'**un** commentaire suivait le dernier commit, toute la queue anterieure sortait de l'affichage. Et `_print_unevaluated` imprimait `len(rows)` -- le compte du **sous-ensemble** -- en le presentant comme le total.

Le critere presuppose qu'un commit traite ce qui le precede. B.0 dit l'inverse en toutes lettres : « **un commit pousse apres la remarque ne la leve PAS a lui seul** [...] ce qui leve une remarque est **une phrase**, pas un SHA ». L'organe existe pour cesser de certifier son silence (#13512) ; il certifiait le sien.

## La fixture

PR #13712, mesuree le 2026-08-30 : **5 non evalues, 3 affiches**. Parmi les 2 masques, le `[ADJOINT PREFLIGHT]` de 19:30:49Z -- **dont le point non traite motivait le HOLD du coordinateur sur cette PR meme**.

Sur la seule PR ou l'echappatoire a servi, elle a cache le commentaire qui justifiait le blocage, et l'a cache parce qu'un commit etait passe apres lui. Il n'existe pas de meilleur cas de test ; il est repris tel quel comme fixture.

## Les deux correctifs

- **Selection** : les deux mecanismes **composent** au lieu de s'exclure -- tout le post-dernier-commit, **plus** la queue des anterieurs, que l'existence du premier n'annule plus. Queue toujours plafonnee a 3 (la sortie reste lisible). La borne est un **strict sur-ensemble** de l'ancien affichage : elle ne peut que montrer davantage.
- **En-tete** : le compte imprime est `unevaluated_total`, et l'omission residuelle est **nommee** (« N plus ancien(s) omis ») au lieu d'etre muette.

## Tests -- ecrits par leurs faux negatifs

8 tests. **4 echouent sur le code d'avant** (verifie en re-checkoutant `origin/main` sous la meme suite) : masquage du commentaire anterieur, compte de l'en-tete, plafond de la queue, cas complet. **4 sont des controles** qui passent des deux cotes : precondition (les corps sont genuinement non classes), chronologie, absence de posterieur (non-regression de l'ancien comportement), et « surfacer n'est pas bloquer ».

```
304 passed
```

## Mesure d'impact -- 29 PRs ouvertes

**Zero verdict change** : `unevaluated` ne participe pas a `blocked`, et la mesure le confirme plutot que de l'argumenter (ancien et nouveau module charges cote a cote sur les memes payloads).

| PR | avant aff/tot | apres aff/tot | en-tete |
|---|---|---|---|
| #13712 | 3/5 | **5/5** | complet |
| #13606 | 3/4 | **4/4** | complet |
| #13539 | 1/2 | **2/2** | complet |
| #13156 | 6/7 | **7/7** | complet |
| #13685 | 3/4 | 3/4 | **omission nommee** (1) |

5 PRs dont l'en-tete sous-declarait ; 4 passent a l'affichage complet, la 5e nomme desormais ce qu'elle omet.

## Portee -- ce que cette PR ne fait pas

Les facettes **A** (le preflight de 3322 car. que `classify` rend `None`) et **B** (le HOLD coordinateur invisible a `_block_emitted`, qui ne connait que `BLOCAGE`/`BLOCK` alors que `variation-protocol.md` §3 dit **HOLD**) restent **ouvertes sur #13779**. Elles touchent des predicats de classement, pas l'affichage : les melanger ici aurait mele un correctif a verdict nul a deux correctifs qui en changent.

## Note de variation -- a arbitrer par le coordinateur

3e `MED/guard` consecutif de la lane (#13714 -> #13726 -> celle-ci). Substance genuinement distincte a chaque fois (adjacence G-VAR-3, tolerance DEEP/MED du domaine-coeur) : #13726 portait `collect_followup_lifts` + `gh_issue_created`, celle-ci porte la selection `unevaluated` + son affichage. L'attribution vient d'une decision de collision du coordinateur (une seule main sur ce fichier, L898), pas d'un tirage.

See #13779
See #13512
