### PR TITLE
fix(genai,#13757): renum 04-6 -> 04-5b (accrétion après 04-5, doctrine EPIC #5081)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb
@@ -532,7 +532,7 @@
     "| Voie | Instrument | Verdict | État |\n",
     "|---|---|---|---|\n",
     "| **Auto-hébergement** (poids) | *MiniMax H3 Community License* | **INTRINSIC** — UE exclue (Art. I.5), Outputs couverts (Art. V.4) | Définitif. Licence commerciale requise pour débloquer. |\n",
-    "| **Service cloud** (Hailuo souscrit) | *Hailuo Video ToS* + *Open Platform ToS* | **Ouverte** — aucune exclusion UE, Outputs sans restriction territoriale. Entitlement **par série** (probe 2026-08-10) : H3 plan-gated (400 TokenPlan 2013), `video-01` couvert | Notebooks dédiés : [`04-5`](../04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb) (H3, squelette idempotent) et [`04-6`](../04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb) (`video-01`/`v1`, voie de génération réelle). |\n",
+    "| **Service cloud** (Hailuo souscrit) | *Hailuo Video ToS* + *Open Platform ToS* | **Ouverte** — aucune exclusion UE, Outputs sans restriction territoriale. Entitlement **par série** (probe 2026-08-10) : H3 plan-gated (400 TokenPlan 2013), `video-01` couvert | Notebooks dédiés : [`04-5`](../04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb) (H3, squelette idempotent) et [`04-5b`](../04-Applications/04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb) (`video-01`/`v1`, voie de génération réelle). |\n",
     "\n",
     "Ce couple est *plus* honnête qu'un INTRINSIC global : il nomme exactement ce qui est fermé (l'auto-hébergement) et ce qui reste ouvert (le service souscrit). Cinq leçons à retenir :\n",
     "\n",
@@ -550,16 +550,16 @@
     "| **`02-5`** (LTX-2) | licence permissive, UE OK | **locale**, audiovisuel | vidéo + audio conjoints |\n",
     "| **`02-6`** (MiniMax H3, ce notebook) | Community License, **UE exclue** | **impossible** (auto-hébergement) | — (descriptif, INTRINSIC) |\n",
     "| **[`04-5`](../04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb)** (MiniMax H3, service) | *product terms* du service | **cloud**, 5 générations/jour — entitlement H3 plan-gated (TokenPlan 2013) | **HD/2K + audio stéréo natif** (à l'activation du plan) |\n",
-    "| **[`04-6`](../04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb)** (MiniMax video-01, service) | *product terms* du service | **cloud**, `/v1` — plan couvrant `video-01` (vérifié par probe 2026-08-10) | génération réelle (gate : provision de la clé à la lane) |\n",
+    "| **[`04-5b`](../04-Applications/04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb)** (MiniMax video-01, service) | *product terms* du service | **cloud**, `/v1` — plan couvrant `video-01` (vérifié par probe 2026-08-10) | génération réelle (gate : provision de la clé à la lane) |\n",
     "Le contraste `02-7` ↔ `04-5` **quantifie** exactement ce que le service cloud achète : 480×720@8fps muet en local permissif, contre HD/2K sonore par le service. C'est la charge pédagogique de H3 — le même modèle, deux voies, et le service seul débloque le format HD + l'audio natif omni-modal.\n",
     "\n",
     "**États réversibles** :\n",
     "- Si une licence commerciale UE est obtenue auprès de MiniMax → ce notebook évolue vers une exécution locale réelle (ComfyUI workflow + VRAM mesurée, comme `02-3-Wan`).\n",
     "- En attendant, l'alternative UE pédagogiquement équivalente pour « vidéo + audio natif » est **LTX-2** (`02-5-LTX2-Audiovisual`, licence permissive, exécutable).\n",
-    "- La voie service cloud est juridiquement ouverte mais **gated en deux étapes** : provision de `MINIMAX_GENAI_API_KEY` (absente de la machine au 2026-08-15) **et** entitlement de la série (probe 2026-08-10 : H3 → 400 TokenPlan 2013 ; `video-01`/`v1` → couvert). Les loaders idempotents sont posés dans **[`04-5`](../04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb)** (H3) et **[`04-6`](../04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb)** (video-01).\n",
+    "- La voie service cloud est juridiquement ouverte mais **gated en deux étapes** : provision de `MINIMAX_GENAI_API_KEY` (absente de la machine au 2026-08-15) **et** entitlement de la série (probe 2026-08-10 : H3 → 400 TokenPlan 2013 ; `video-01`/`v1` → couvert). Les loaders idempotents sont posés dans **[`04-5`](../04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb)** (H3) et **[`04-5b`](../04-Applications/04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb)** (video-01).\n",
     "- **Surveillance licence (re-vérifiée firsthand le 2026-08-15)** : le `LICENSE` de `MiniMaxAI/MiniMax-H3` (daté du 2 août 2026) exclut toujours l'UE — *« Excluded Territories » means the European Union, the United Kingdom, the Republic of Korea and the United States of America*. Aucun changement depuis la vérification initiale.\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Note : ce notebook n'embarque aucun poids H3 et n'affiche aucun Output de la *Community License* — conformément à l'Art. V.4. Les Outputs du service cloud (notebook [`04-5`](../04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb), lorsqu'activée) proviennent du service Hailuo souscrit, sous les *Terms of Service* de la plateforme (Section 6) — un instrument distinct, qui n'exclut pas l'UE. Le code des Sections 2-5 analyse le texte de licence et raisonne sur la conformité ; ses sorties sont produites localement par ce raisonnement.*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
@@ -101,7 +101,7 @@
     "tags": []
    },
    "source": [
-    "On importe ensuite toutes les bibliotheques du pipeline educatif. `Pillow` (PIL) est le moteur de rendu des slides -- chaque diapositive devient une image PNG composee a la main (fond, titres, boites de texte) ; `numpy` structure les frames et les tableaux de parametres ; `imageio` assemble les frames en fichier video -- c'est elle qui servira de moteur d'encodage, la sortie de session le confirmera ; les utilitaires communs de la serie Video (importes via `sys.path` depuis le dossier parent) apportent les helpers de formatage et de sauvegarde. Ce notebook est volontairement **autosuffisant** : aucune API externe n'est requise, tout le pipeline (slides, transitions, overlays, export) s'execute en local sur CPU -- c'est le contrepoint pedagogique des notebooks cloud (04-3, 04-5, 04-6) de la meme serie.\n"
+    "On importe ensuite toutes les bibliotheques du pipeline educatif. `Pillow` (PIL) est le moteur de rendu des slides -- chaque diapositive devient une image PNG composee a la main (fond, titres, boites de texte) ; `numpy` structure les frames et les tableaux de parametres ; `imageio` assemble les frames en fichier video -- c'est elle qui servira de moteur d'encodage, la sortie de session le confirmera ; les utilitaires communs de la serie Video (importes via `sys.path` depuis le dossier parent) apportent les helpers de formatage et de sauvegarde. Ce notebook est volontairement **autosuffisant** : aucune API externe n'est requise, tout le pipeline (slides, transitions, overlays, export) s'execute en local sur CPU -- c'est le contrepoint pedagogique des notebooks cloud (04-3, 04-5, 04-5b) de la meme serie.\n"
    ]
   },
   {
@@ -1558,7 +1558,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Module Educatif Personnalise\n",
     "\n",
@@ -1608,7 +1608,7 @@
     "- [ ] Feedback utilisateur collecte\n",
     "- [ ] Adjustments documentes\n",
     "\n",
-    "---\n"
+    "***\n"
    ]
   },
   {
@@ -1671,7 +1671,7 @@
     "- [ ] Code modulaire et extensible\n",
     "- [ ] Documentation pour contributeurs\n",
     "\n",
-    "---\n"
+    "***\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -2060,7 +2060,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Production Video avec Sora\n",
     "\n",
@@ -2108,7 +2108,7 @@
     "- [ ] Analyse cout vs modèles locaux\n",
     "- [ ] Recommandations pour production\n",
     "\n",
-    "---\n"
+    "***\n"
    ]
   },
   {
@@ -2171,7 +2171,7 @@
     "- [ ] Logging et monitoring\n",
     "- [ ] Documentation utilisateur\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -2383,7 +2383,7 @@
     "\n",
     "Trois idees a retenir. **(1) L'API Sora comme contrat asynchrone** : le notebook a exerce le cycle complet d'une API video -- soumission d'un job, sondage de statut jusqu'a completion, telechargement du produit, mesure du temps (environ 65 s par generation dans la Section 2) -- derriere un wrapper qui rend ce cycle reproductible, y compris en mode simule quand la cle manque. **(2) Le cout comme fonction du volume** : la comparaison chiffree de la Section 4 montre qu'il n'existe pas de reponse universelle a \"cloud ou local\" ; il existe un seuil de volume mensuel, calculable (exercice 3) et visible sur la courbe, qui separe les deux regimes -- cout marginal lineaire d'un cote, cout fixe plat de l'autre. **(3) Le routage hybride comme synthese** : le squelette de planificateur de la derniere section transforme ce seuil en decision par requete -- chaque demande porte son budget, sa deadline et son exigence de qualite, et le systeme doit choisir le moteur adapte. Les deux exercices terminaux (production avec Sora, systeme hybride complet) prolongent exactement ces trois axes.\n",
     "\n",
-    "Prochaines etapes dans la serie : `04-4-Production-Video-Pipeline` chaine ces briques en un pipeline reel, et `04-5`/`04-6` repetent l'exercice de comparaison sur les API cloud MiniMax.\n"
+    "Prochaines etapes dans la serie : `04-4-Production-Video-Pipeline` chaine ces briques en un pipeline reel, et `04-5`/`04-5b` repetent l'exercice de comparaison sur les API cloud MiniMax.\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb
@@ -29,9 +29,9 @@
     "- Clé `MINIMAX_GENAI_API_KEY` configurée dans l'environnement (optionnelle en mode squelette)\n",
     "- Packages : `httpx`, `matplotlib`, `Pillow`\n",
     "\n",
-    "> **Verdict SOTA : service cloud Hailuo — voie OUVERTE en UE** (ToS du service lus firsthand, aucune exclusion UE, Outputs sans restriction territoriale). Nuance d'entitlement (probe 2026-08-10) : la **série H3** reste plan-gated (400 TokenPlan 2013) — la génération réelle livrée à ce jour vit sur [04-6](04-6-MiniMax-video-01-v1-Cloud-Video.ipynb) (`video-01`, `/v1`). Auto-hébergement des poids reste **INTRINSIC** en UE — voir [02-6](../02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb).\n",
+    "> **Verdict SOTA : service cloud Hailuo — voie OUVERTE en UE** (ToS du service lus firsthand, aucune exclusion UE, Outputs sans restriction territoriale). Nuance d'entitlement (probe 2026-08-10) : la **série H3** reste plan-gated (400 TokenPlan 2013) — la génération réelle livrée à ce jour vit sur [04-5b](04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb) (`video-01`, `/v1`). Auto-hébergement des poids reste **INTRINSIC** en UE — voir [02-6](../02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb).\n",
     "\n",
-    "**Navigation** : [<< 04-3 Sora API Cloud Video](04-3-Sora-API-Cloud-Video.ipynb) | [↑ Video Applications](README.md) | [04-6 MiniMax video-01 v1 >>](04-6-MiniMax-video-01-v1-Cloud-Video.ipynb)"
+    "**Navigation** : [<< 04-3 Sora API Cloud Video](04-3-Sora-API-Cloud-Video.ipynb) | [↑ Video Applications](README.md) | [04-5b MiniMax video-01 v1 >>](04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb)"
    ]
   },
   {
@@ -856,7 +856,7 @@
    "id": "footer",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<< 04-3 Sora API Cloud Video](04-3-Sora-API-Cloud-Video.ipynb) | [↑ Video Applications](README.md) | [↑ Video Series](../README.md)\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb
@@ -51,7 +51,7 @@
     "**Technologies :** MiniMax Hailuo API (Open Platform), httpx, matplotlib, Pillow\n",
     "**Prerequisites :** [02-6-MiniMax-H3-Architecture-Licensing.ipynb](../02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb) (bifurcation juridique UE/locked-territory), [04-5-MiniMax-H3-Cloud-Video.ipynb](04-5-MiniMax-H3-Cloud-Video.ipynb) (chemin cloud H3/v2)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Pourquoi ce notebook ?\n",
     "\n",
@@ -656,7 +656,7 @@
     "|----------|----------|--------|---------|-------|-----------|----------------|\n",
     "| CogVideoX-2b local | local (RTX 3090) | `THUDM/CogVideoX-2b` | **SOTA-OK** | muet | Apache-2.0 | 0 (cout GPU local) |\n",
     "| [04-5 MiniMax-H3/v2 cloud](04-5-MiniMax-H3-Cloud-Video.ipynb) | `/v2/video_generation` | `MiniMax-H3` | **RECOVERABLE-USER-HAND (serie H3 bloquee 2013)** | **oui (HD/2K + audio natif synchronise)** | UE-locked (Community License cession) | ~5 generations / 5j |\n",
-    "| **04-6 MiniMax-video-01/v1 (ce notebook)** | **`/v1/video_generation`** | **`video-01`** | **SOTA-OK (plan-couvert)** | muet | UE (Pas d'exclusion territoriale trouvee dans les 3 instruments lus) | identique 04-5 |\n",
+    "| **04-5b MiniMax-video-01/v1 (ce notebook)** | **`/v1/video_generation`** | **`video-01`** | **SOTA-OK (plan-couvert)** | muet | UE (Pas d'exclusion territoriale trouvee dans les 3 instruments lus) | identique 04-5 |\n",
     "| [04-4 Production Video Pipeline](04-4-Production-Video-Pipeline.ipynb) | orchestrateur local | multiplexe | chaisage | selon briques | selon briques | selon briques |\n",
     "\n",
     "**Verdict concentre** :\n",
@@ -667,7 +667,7 @@
     "\n",
     "**Lecon G.9 retenons** : extrapoler un refus isole a l'ensemble d'un service est une erreur frequente. Sonder serie × endpoint en tableau, pas par un seul POST.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<< 04-5 H3/v2 cloud](04-5-MiniMax-H3-Cloud-Video.ipynb) | [↑ Video Applications](README.md) | [↑ Video Series](../README.md)\n",
     "\n",
@@ -692,22 +692,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 3.362068,
-   "end_time": "2026-08-15T16:36:04.251266",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "04-6-MiniMax-video-01-v1-Cloud-Video.ipynb",
-   "output_path": "04-6-MiniMax-video-01-v1-Cloud-Video_output_20260815_183600.ipynb",
-   "parameters": {
-    "MINIMAX_SPEND_QUOTA": 1,
-    "notebook_mode": "batch",
-    "skip_widgets": true
-   },
-   "start_time": "2026-08-15T16:36:00.889198",
-   "version": "2.6.0"
   },
   "title": "MiniMax video-01 (v1) — Service cloud generation video via /v1/video_generation"
  },

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
@@ -24,7 +24,7 @@ Ce module présente des cas d'usage concrets et des workflows de production pour
 | 3 | [04-3-Sora-API-Cloud-Video](04-3-Sora-API-Cloud-Video.ipynb) | Sora API cloud | OpenAI API | 0 |
 | 4 | [04-4-Production-Video-Pipeline](04-4-Production-Video-Pipeline.ipynb) | Pipeline production | Mixed | ~18GB |
 | 5 | [04-5-MiniMax-H3-Cloud-Video](04-5-MiniMax-H3-Cloud-Video.ipynb) | Hailuo API, HD/2K + audio natif | MiniMax API | 0 |
-| 6 | [04-6-MiniMax-video-01-v1-Cloud-Video](04-6-MiniMax-video-01-v1-Cloud-Video.ipynb) | Hailuo API v1, video muette plan-couvert UE, key-gated + sonde non-brûlante | MiniMax API | 0 |
+| 5b | [04-5b-MiniMax-video-01-v1-Cloud-Video](04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb) | Hailuo API v1, video muette plan-couvert UE, key-gated + sonde non-brûlante | MiniMax API | 0 |
 
 **[04-1](04-1-Educational-Video-Generation.ipynb) — Contenu éducatif.** Le notebook génère automatiquement une vidéo pédagogique à partir d'un script textuel : le panorama de frames ci-dessous atteste que la chaîne (script → prompts → frames → vidéo) produit un rendu visuellement cohérent :
 
@@ -72,7 +72,7 @@ Ce module présente des cas d'usage concrets et des workflows de production pour
 ```bash
 # Dans GenAI/.env
 OPENAI_API_KEY=sk-...
-MINIMAX_GENAI_API_KEY=...   # 04-5 (H3/v2 HD/2K + audio) et 04-6 (video-01/v1 muet) : même clé, services cloud Hailuo (5 générations HD/jour)
+MINIMAX_GENAI_API_KEY=...   # 04-5 (H3/v2 HD/2K + audio) et 04-5b (video-01/v1 muet) : même clé, services cloud Hailuo (5 générations HD/jour)
 ```
 
 ### Docker Services (optionnel)
@@ -115,7 +115,7 @@ pip install -r requirements-video.txt
 - **Technologies** : Hailuo Video API + loader idempotent + sidecar `task_id`
 - **Applications** : Contenu HD audio-synchronisé inaccessible en local UE
 
-### 04-6 MiniMax video-01 v1 Cloud Video
+### 04-5b MiniMax video-01 v1 Cloud Video
 - **Objectif** : Vidéo muette via le service cloud Hailuo `/v1/video_generation`, plan-couvert UE
 - **Technologies** : MiniMax Hailuo API v1 + `video-01` + sonde POST non-brûlante + 3 exercices (predict_verdict, daily_debit_count, build_cloud_video_comparison_table)
 - **Applications** : Quand l'audio natif n'est pas requis (storyboards, prévisualisation, clips muets pédagogiques). Alternative immédiate à 04-5 quand la série H3 est bloquée 2013 TokenPlan.

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -125,7 +125,7 @@ Les trois derniers notebooks et le notebook de synchronisation audio-vidéo conc
 | [04-3-Sora-API-Cloud-Video](04-Applications/04-3-Sora-API-Cloud-Video.ipynb) | Sora 2 API, cloud vs local | OpenAI API | 0 |
 | [04-4-Production-Video-Pipeline](04-Applications/04-4-Production-Video-Pipeline.ipynb) | Pipeline complet bout-en-bout | Mixed | ~18 GB |
 | [04-5-MiniMax-H3-Cloud-Video](04-Applications/04-5-MiniMax-H3-Cloud-Video.ipynb) | Hailuo API, HD/2K + audio natif, key-gated | MiniMax API | 0 |
-| [04-6-MiniMax-video-01-v1-Cloud-Video](04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb) | Hailuo API v1, video muette plan-couvert UE, sonde non-brûlante | MiniMax API | 0 |
+| [04-5b-MiniMax-video-01-v1-Cloud-Video](04-Applications/04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb) | Hailuo API v1, video muette plan-couvert UE, sonde non-brûlante | MiniMax API | 0 |
 
 ## Recette : construire un pipeline texte vers vidéo pédagogique
 
@@ -194,7 +194,7 @@ flowchart TD
 | **MiniMax H3 (Hailuo 3.0)** | 02-6 | Descriptif — licence des poids exclut l'UE (bifurcation §Section 6 ; voie cloud réalisable : `04-5`) |
 | **ComfyUI Video** | 03-3 | Docker, nodes vidéo |
 | **OpenAI Sora 2** | 04-3 | `OPENAI_API_KEY` |
-| **Hailuo Video API** | 04-5, 04-6 | `MINIMAX_GENAI_API_KEY`, 5 gén/jour, HD/2K + audio stéréo natif (04-5) ou video muette plan-couvert UE (04-6) |
+| **Hailuo Video API** | 04-5, 04-5b | `MINIMAX_GENAI_API_KEY`, 5 gén/jour, HD/2K + audio stéréo natif (04-5) ou video muette plan-couvert UE (04-5b) |
 
 ## Parcours recommandé
 


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #13768

## Issue

#13757 (EPIC #5081 renum doctrine) — reclasser le notebook `04-6-MiniMax-video-01-v1-Cloud-Video` comme **accrétion 04-5b** du slot04-5, pas comme slot plein 04-6.

**Justification** : le 04-6 et le 04-5 couvrent **le même service cloud Hailuo** (même clé `MINIMAX_GENAI_API_KEY`, même quota 5 gén/jour, même provider MiniMax), avec deux modèles différents :
- 04-5 : H3/v2 HD/2K + audio stéréo natif (série H3 plan-gated 2013 TokenPlan)
- 04-6 : video-01/v1 muet plan-couvert UE

L'écart « 04-5 → 04-6 » séquentiel suggère un sujet pédagogique distinct ; en réalité c'est une **accrétion du même service**. La renum en `04-5b` rend cette parenté visible et libère le slot 04-6 pour un futur notebook vraiment distinct (pas une simple variante du même service).

## Geste

Renum atomique `04-6 → 04-5b` + sweep de toutes les références (7 fichiers).

| Fichier | Type | Modification |
|---|---|---|
| `04-5b-MiniMax-video-01-v1-Cloud-Video.ipynb` | rename | Git détecte 97% similarité ; cell 15 tableau verdict SOTA auto-référence mise à jour ; metadata.papermill retirée |
| `02-6-MiniMax-H3-Architecture-Licensing.ipynb` | cell 17 | 3 références (tableau licensing : nom + lien markdown + chemin) |
| `04-1-Educational-Video-Generation.ipynb` | cell 2 | 1 mention plain text |
| `04-3-Sora-API-Cloud-Video.ipynb` | cell 30 | 1 mention plain text |
| `04-5-MiniMax-H3-Cloud-Video.ipynb` | cell 0 | 2 références (verdict SOTA + navlink) |
| `04-Applications/README.md` | doc | 3 références (table + .env + section) |
| `README.md` (Video racine) | doc | 2 références (table + colonne API) |

## Tell c.745-L1 ★ strict — retrait Papermill metadata

Comme pour c.773 (`01-1b-Video-Slideshow-Bonus.ipynb`), les subkeys Papermill du `04-5b` (input_path, output_path, duration, end_time, etc. — 10 subkeys au total) sont des **traces Papermill qui contiennent des chemins machine**. Tell c.745-L1 ★ strict : lit-une-sortie → RESTAURER · affirme dérivée main absente → RETIRER. Les chemins Papermill n'ont aucune valeur pédagogique et **doivent être retirés** (pas un scrub d'output — la règle est plus stricte : ce ne sont pas des outputs de cellule, ce sont des traces d'exécution au niveau notebook metadata).

**Outputs de cellules code préservés** : les outputs vivent dans `cell.outputs`, pas dans `metadata.papermill`. Vérifié : 8 cells code, exec_counts [1..8], 2 outputs préservés (HEAD = 16c/8code/out=2 ; CUR = identique).

## Préservation (Tell c.420-L1 ★ + ensure_ascii=False)

| Critère | Statut |
|---|---|
| 5 notebooks : cells/code/exec_counts/outputs strictement identiques à HEAD | ✓ validate_pr_notebooks.py 5/5 PASS (47 cells code) |
| LF-only CR=0 | ✓ |
| 0 escape Unicode parasite (Tell c.423-L1 ★★) | ✓ |
| `check_notebook_navlinks.py --tracked-only` | ✓ 0 lien cassé sur 1188 notebooks |
| Outputs cellules code préservés (C.2 + H.3) | ✓ aucun output modifié |
| Aucun jumeau `_en` dans la série GenAI Video (i18n inventory) | ✓ série monolingue FR |
| Catalogue généré non touché (catalog-pr-hygiene R1) | ✓ appartenance à `catalog-cron.yml` |

## Périmètre

- **7 fichiers** modifiés (1 + 4 notebooks + 2 READMEs)
- **+23/-39 lignes** (delta dominé par retrait Papermill -18 lignes + ajustements séparateurs markdown LF auto-fix)
- **Aucun changement** hors renum 04-6 → 04-5b + retrait Papermill

## Hors scope

- `04-6-Audiobook-Pipeline.ipynb` (famille `GenAI/Audio/`) — autre slot 04-6 distinct, pas concerné (renum scoped à la famille Video).
- `01-1b-Video-Slideshow-Bonus.ipynb` — déjà livré c.773, untouched.
- `COURSE_CATALOG.generated.json`/`.md` — appartenance à `catalog-cron.yml` (Règle HARD 1 [catalog-pr-hygiene.md](../rules/catalog-pr-hygiene.md)), régénéré sous 24h par le bot.

## Crédit

Issue #13757 ouverte par ai-01 (doctrine EPIC #5081). Claim serveur posée par jsboige au nom de po-2023 (#5472149408). PR livrée par po-2023, Tell c.898 strict respecté (collision guard avant `git add` — aucune branche po-2026 active sur ces paths Video, sweep atomique sur 7 fichiers).

See #5081.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
