### PR TITLE
fix(search,#13178): MGS-11 IslandSynergy re-exec x2 sur moteur deterministe 607cf7a -- verdict reproduit

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb
@@ -5,10 +5,10 @@
    "id": "dc6c5569",
    "metadata": {
     "papermill": {
-     "duration": 0.002942,
-     "end_time": "2026-06-23T16:29:46.957441+00:00",
+     "duration": 0.002637,
+     "end_time": "2026-08-31T00:57:09.417306+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:46.954499+00:00",
+     "start_time": "2026-08-31T00:57:09.414669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -30,10 +30,10 @@
    "id": "cb043b35",
    "metadata": {
     "papermill": {
-     "duration": 0.002169,
-     "end_time": "2026-06-23T16:29:46.964245+00:00",
+     "duration": 0.002144,
+     "end_time": "2026-08-31T00:57:09.422144+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:46.962076+00:00",
+     "start_time": "2026-08-31T00:57:09.420000+00:00",
      "status": "completed"
     },
     "tags": []
@@ -52,16 +52,16 @@
    "id": "5e7ef7c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:46.979973Z",
-     "iopub.status.busy": "2026-06-23T16:29:46.973302Z",
-     "iopub.status.idle": "2026-06-23T16:29:49.150618Z",
-     "shell.execute_reply": "2026-06-23T16:29:49.145064Z"
+     "iopub.execute_input": "2026-08-31T00:57:09.435517Z",
+     "iopub.status.busy": "2026-08-31T00:57:09.430571Z",
+     "iopub.status.idle": "2026-08-31T00:57:10.860222Z",
+     "shell.execute_reply": "2026-08-31T00:57:10.856330Z"
     },
     "papermill": {
-     "duration": 2.184926,
-     "end_time": "2026-06-23T16:29:49.151288+00:00",
+     "duration": 1.43624,
+     "end_time": "2026-08-31T00:57:10.860390+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:46.966362+00:00",
+     "start_time": "2026-08-31T00:57:09.424150+00:00",
      "status": "completed"
     },
     "tags": []
@@ -69,7 +69,115 @@
    "outputs": [
     {
      "data": {
-      "text/html": []
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-1108816.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1108816.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -107,8 +215,7 @@
     "           : \"win-x64\";\n",
     "NativeLibrary.Load($@\"..\\MetaGeneticSharp\\src\\MetaGeneticSharp.Extensions\\bin\\Debug\\net9.0\\runtimes\\{rid}\\native\\libSkiaSharp.dll\");\n",
     "\n",
-    "Console.WriteLine(\"Wiring OK : MetaGeneticSharp + GeneticSharp + Extensions (composes DE/BBPSO + IslandCompound + ShiftedFitness + SkiaLandscapeRenderer + GIF).\");\n",
-    ""
+    "Console.WriteLine(\"Wiring OK : MetaGeneticSharp + GeneticSharp + Extensions (composes DE/BBPSO + IslandCompound + ShiftedFitness + SkiaLandscapeRenderer + GIF).\");\n"
    ]
   },
   {
@@ -117,16 +224,16 @@
    "id": "9b42c7aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:49.157877Z",
-     "iopub.status.busy": "2026-06-23T16:29:49.157660Z",
-     "iopub.status.idle": "2026-06-23T16:29:49.624578Z",
-     "shell.execute_reply": "2026-06-23T16:29:49.624411Z"
+     "iopub.execute_input": "2026-08-31T00:57:10.869534Z",
+     "iopub.status.busy": "2026-08-31T00:57:10.869155Z",
+     "iopub.status.idle": "2026-08-31T00:57:11.243469Z",
+     "shell.execute_reply": "2026-08-31T00:57:11.243242Z"
     },
     "papermill": {
-     "duration": 0.470598,
-     "end_time": "2026-06-23T16:29:49.624658+00:00",
+     "duration": 0.379301,
+     "end_time": "2026-08-31T00:57:11.243589+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:49.154060+00:00",
+     "start_time": "2026-08-31T00:57:10.864288+00:00",
      "status": "completed"
     },
     "tags": []
@@ -210,10 +317,10 @@
    "id": "30331256",
    "metadata": {
     "papermill": {
-     "duration": 0.002009,
-     "end_time": "2026-06-23T16:29:49.629079+00:00",
+     "duration": 0.004452,
+     "end_time": "2026-08-31T00:57:11.251676+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:49.627070+00:00",
+     "start_time": "2026-08-31T00:57:11.247224+00:00",
      "status": "completed"
     },
     "tags": []
@@ -242,16 +349,16 @@
    "id": "118e478a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:49.633695Z",
-     "iopub.status.busy": "2026-06-23T16:29:49.633521Z",
-     "iopub.status.idle": "2026-06-23T16:29:50.154879Z",
-     "shell.execute_reply": "2026-06-23T16:29:50.154526Z"
+     "iopub.execute_input": "2026-08-31T00:57:11.260918Z",
+     "iopub.status.busy": "2026-08-31T00:57:11.260539Z",
+     "iopub.status.idle": "2026-08-31T00:57:11.745078Z",
+     "shell.execute_reply": "2026-08-31T00:57:11.744922Z"
     },
     "papermill": {
-     "duration": 0.5241,
-     "end_time": "2026-06-23T16:29:50.155028+00:00",
+     "duration": 0.489119,
+     "end_time": "2026-08-31T00:57:11.745180+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:49.630928+00:00",
+     "start_time": "2026-08-31T00:57:11.256061+00:00",
      "status": "completed"
     },
     "tags": []
@@ -400,10 +507,10 @@
    "id": "cea164d4",
    "metadata": {
     "papermill": {
-     "duration": 0.004048,
-     "end_time": "2026-06-23T16:29:50.164918+00:00",
+     "duration": 0.003078,
+     "end_time": "2026-08-31T00:57:11.751821+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:50.160870+00:00",
+     "start_time": "2026-08-31T00:57:11.748743+00:00",
      "status": "completed"
     },
     "tags": []
@@ -435,16 +542,16 @@
    "id": "d0d650f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:50.174236Z",
-     "iopub.status.busy": "2026-06-23T16:29:50.173993Z",
-     "iopub.status.idle": "2026-06-23T16:29:52.934520Z",
-     "shell.execute_reply": "2026-06-23T16:29:52.934294Z"
+     "iopub.execute_input": "2026-08-31T00:57:11.759360Z",
+     "iopub.status.busy": "2026-08-31T00:57:11.759135Z",
+     "iopub.status.idle": "2026-08-31T00:57:14.210306Z",
+     "shell.execute_reply": "2026-08-31T00:57:14.210139Z"
     },
     "papermill": {
-     "duration": 2.76575,
-     "end_time": "2026-06-23T16:29:52.934607+00:00",
+     "duration": 2.455614,
+     "end_time": "2026-08-31T00:57:14.210381+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:50.168857+00:00",
+     "start_time": "2026-08-31T00:57:11.754767+00:00",
      "status": "completed"
     },
     "tags": []
@@ -535,10 +642,10 @@
    "id": "c2b496e9",
    "metadata": {
     "papermill": {
-     "duration": 0.004842,
-     "end_time": "2026-06-23T16:29:52.945177+00:00",
+     "duration": 0.004629,
+     "end_time": "2026-08-31T00:57:14.220117+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:52.940335+00:00",
+     "start_time": "2026-08-31T00:57:14.215488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -571,10 +678,10 @@
    "id": "808d86ba",
    "metadata": {
     "papermill": {
-     "duration": 0.004677,
-     "end_time": "2026-06-23T16:29:52.954583+00:00",
+     "duration": 0.004084,
+     "end_time": "2026-08-31T00:57:14.230012+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:52.949906+00:00",
+     "start_time": "2026-08-31T00:57:14.225928+00:00",
      "status": "completed"
     },
     "tags": []
@@ -590,10 +697,10 @@
    "id": "10485ae5",
    "metadata": {
     "papermill": {
-     "duration": 0.004605,
-     "end_time": "2026-06-23T16:29:52.963871+00:00",
+     "duration": 0.003866,
+     "end_time": "2026-08-31T00:57:14.237864+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:52.959266+00:00",
+     "start_time": "2026-08-31T00:57:14.233998+00:00",
      "status": "completed"
     },
     "tags": []
@@ -610,16 +717,16 @@
    "id": "d99116c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:52.975888Z",
-     "iopub.status.busy": "2026-06-23T16:29:52.975603Z",
-     "iopub.status.idle": "2026-06-23T16:29:53.060030Z",
-     "shell.execute_reply": "2026-06-23T16:29:53.059854Z"
+     "iopub.execute_input": "2026-08-31T00:57:14.247069Z",
+     "iopub.status.busy": "2026-08-31T00:57:14.246878Z",
+     "iopub.status.idle": "2026-08-31T00:57:14.297261Z",
+     "shell.execute_reply": "2026-08-31T00:57:14.297125Z"
     },
     "papermill": {
-     "duration": 0.0908,
-     "end_time": "2026-06-23T16:29:53.060116+00:00",
+     "duration": 0.055574,
+     "end_time": "2026-08-31T00:57:14.297330+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:52.969316+00:00",
+     "start_time": "2026-08-31T00:57:14.241756+00:00",
      "status": "completed"
     },
     "tags": []
@@ -649,10 +756,10 @@
    "id": "ca0a7533",
    "metadata": {
     "papermill": {
-     "duration": 0.005383,
-     "end_time": "2026-06-23T16:29:53.071123+00:00",
+     "duration": 0.004225,
+     "end_time": "2026-08-31T00:57:14.306272+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:53.065740+00:00",
+     "start_time": "2026-08-31T00:57:14.302047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -669,16 +776,16 @@
    "id": "8c5ba3da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:53.084673Z",
-     "iopub.status.busy": "2026-06-23T16:29:53.084403Z",
-     "iopub.status.idle": "2026-06-23T16:29:53.129392Z",
-     "shell.execute_reply": "2026-06-23T16:29:53.129216Z"
+     "iopub.execute_input": "2026-08-31T00:57:14.315377Z",
+     "iopub.status.busy": "2026-08-31T00:57:14.315195Z",
+     "iopub.status.idle": "2026-08-31T00:57:14.354368Z",
+     "shell.execute_reply": "2026-08-31T00:57:14.354196Z"
     },
     "papermill": {
-     "duration": 0.052431,
-     "end_time": "2026-06-23T16:29:53.129480+00:00",
+     "duration": 0.04421,
+     "end_time": "2026-08-31T00:57:14.354461+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:53.077049+00:00",
+     "start_time": "2026-08-31T00:57:14.310251+00:00",
      "status": "completed"
     },
     "tags": []
@@ -706,10 +813,10 @@
    "id": "105efa21",
    "metadata": {
     "papermill": {
-     "duration": 0.005536,
-     "end_time": "2026-06-23T16:29:53.140808+00:00",
+     "duration": 0.005137,
+     "end_time": "2026-08-31T00:57:14.365416+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:53.135272+00:00",
+     "start_time": "2026-08-31T00:57:14.360279+00:00",
      "status": "completed"
     },
     "tags": []
@@ -726,16 +833,16 @@
    "id": "cafe5d69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T16:29:53.154090Z",
-     "iopub.status.busy": "2026-06-23T16:29:53.153807Z",
-     "iopub.status.idle": "2026-06-23T16:29:53.193304Z",
-     "shell.execute_reply": "2026-06-23T16:29:53.193161Z"
+     "iopub.execute_input": "2026-08-31T00:57:14.376144Z",
+     "iopub.status.busy": "2026-08-31T00:57:14.375930Z",
+     "iopub.status.idle": "2026-08-31T00:57:14.411222Z",
+     "shell.execute_reply": "2026-08-31T00:57:14.411062Z"
     },
     "papermill": {
-     "duration": 0.046988,
-     "end_time": "2026-06-23T16:29:53.193376+00:00",
+     "duration": 0.041143,
+     "end_time": "2026-08-31T00:57:14.411339+00:00",
      "exception": false,
-     "start_time": "2026-06-23T16:29:53.146388+00:00",
+     "start_time": "2026-08-31T00:57:14.370196+00:00",
      "status": "completed"
     },
     "tags": []
@@ -775,6 +882,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 7.159446,
+   "end_time": "2026-08-31T00:57:14.660564+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MGS-11-IslandSynergy.ipynb",
+   "output_path": "MGS-11-IslandSynergy.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-31T00:57:07.501118+00:00",
+   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-python #13786

Closes #13178 (tranche MGS-11 de l'umbrella #1203, lane des tranches 7b/7c/7d/8/9). Claim actif repris (aucun re-claim nécessaire). Le genre déclaré est `notebook-dotnet` (re-execution .NET avec verdict quantitatif à reproduire), pas `docs` comme l'annotate le picker — le genre est le type de travail.

## Livrable #13178, point par point

1. **Re-exec A puis B** (papermill mode qui écrit, kernel `.net-csharp`, cwd = dossier du notebook) : A en 12,7 s, B en 10,9 s ; `metadata.papermill.end_time` **2026-08-31T00:56/00:57** dans le fichier committé.
2. **Verdict reproduit, pas réaligné** — tous les nombres au 4ᵉ décimal, identiques au committé :

| | DE | BBPSO | DE+BBPSO | lecture |
|---|---|---|---|---|
| Rastrigin shifté (dim 5) | -1,8562 | -19,8004 | -3,9393 | PAS de synergie |
| Ackley shifté (dim 5) | -1,6819 | -0,6319 | -2,2376 | PAS de synergie |
| **Bilan** | | | | **0/2 synergies** |

3. **Note de provenance** : déjà présente (md cellule 1 cite le gitlink `607cf7a` + « rendu déterministe par pixel — PR MetaGeneticSharp #49 ») — vérifiée, rien à ajouter.
4. **Gitlink** : déjà `607cf7a` sur main — no-op, comme anticipé par le body.
5. **C.1** : 0 violation (validate_pr_notebooks **1/1 PASS**, 7 cellules code) ; `execution_count` 1..7 monotone ; `check_exec_sequence` CLEAN.

## Le point qui rend cette re-exec non triviale : les DLLs stale

Les sorties committées dataient du 21/08, mais le gitlink `607cf7a` date du **26/08** — et les binaires `bin/Debug/net9.0/*.dll` du sous-module dataient eux aussi du **21/08 22:33**, **antérieurs au commit épinglé**. Une re-exec sans rebuild aurait « passé » en exécutant le VIEUX moteur. Cette PR rebuild `dotnet build src/MetaGeneticSharp.Extensions -c Debug` depuis `607cf7a` (SUCCESS, 0 erreur) AVANT les deux runs.

Fait intéressant consigné : les nombres committés (ère pré-fix affichée par le body) sont **déjà exactement** ceux du moteur 607cf7a — le fix #49 (RNG per-pixel pour heatmaps `Parallel.For`) ne touche pas le flux séquentiel des archipels. La re-exec transforme la provenance **présumée** en provenance **prouvée**.

## Déterminisme run1 == run2 (la promesse de la cellule protocole)

Comparaison des streams des 2 runs : **byte-identiques sur toutes les cellules** (y compris le GIF archipel 8 frames 238,9 KB, taille rapportée dans les streams égaux). `FastRandomRandomization.ResetSeed(42)` fixé avant tout accès au générateur.

## Preuves structurelles

- Sources **inchangées** (16/16 cellules byte-identiques vs `git show HEAD:`) — le diff (198+/79-) porte uniquement `execution_count` + outputs + `metadata.papermill`.
- Catalogue non touché ; sous-module non re-pointé (gitlink identique).

## Hors périmètre

Pas de face-à-face MGS↔mealpy (gel user respecté) ; pas de correctif moteur (#13778 P1 est à po-2025, MetaGeneticSharp #50 stackée — hors gitlink de cette tranche).
