### PR TITLE
fix(guards,#13791): perimeter over-accusation -- additive block sum, grep antecedent, measurement-object word-form

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -395,7 +395,7 @@ def _count_is_range_enum(line: str, m: re.Match) -> bool:
     return bool(_RANGE_ENUM_TAIL.match(tail if nl < 0 else tail[:nl]))
 
 
-def check_assertion(files: list[dict], assertion: str) -> list[str]:
+def check_assertion(files: list[dict], assertion: str, block: str = "") -> list[str]:
     """Confront a perimeter assertion with the effective file list.
 
     Fence blocks (transcribed commands, L898 proof) are masked out of the
@@ -411,6 +411,15 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
     body of a PR that modifies the guard itself is diagnostic corpus
     (bootstrap): its counts describe other PRs and the forms being fixed,
     so the equality confrontation is skipped entirely there.
+
+    #13791: `block` is the assertion's enclosing paragraph BLOCK (prefix +
+    line + contiguous lines below, see _paragraph_block). The additive
+    enumeration (#12103) confronts the sum over the BLOCK when the
+    single-line sum mismatches -- an enumeration spanning two bullets
+    ("- 1 fichier modifie (...)" / "- 1 fichier de test modifie (...)",
+    founder #13736) declares 1 + 1 = 2, and the verdict must not depend on
+    where the author pressed Enter. Safe by the same #12103 construction: a
+    FAIL becomes a PASS only when the block sum is exactly len(files).
     """
     problems: list[str] = []
     guard_self = any(f["path"] in GUARD_SELF_PATHS for f in files)
@@ -448,7 +457,20 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
             # that survive the per-count filters instead. Safe by
             # construction: a FAIL becomes a PASS only when the sum is
             # exactly len(files) -- never a new failure.
+            # #13791: the sum spans the enclosing paragraph BLOCK when one
+            # is given -- an additive enumeration lists downward as often as
+            # sideways ("_additive_line_sum est line-scope, la somme additive
+            # meurt au retour a la ligne", founder #13736). Per-count filters
+            # stay per-LINE (each line is classified on its own surface).
             additive = _additive_line_sum(scan_target)
+            if additive != len(files) and block:
+                # the block already contains the candidate line -- replace,
+                # never add (no double count).
+                additive = sum(
+                    _additive_line_sum(ln)
+                    for ln in _fence_mask(block).splitlines()
+                    if ln.strip()
+                )
             if additive != len(files):
                 problems.append(
                     f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
@@ -466,7 +488,12 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
         # file (routing target, dependency, candidate not chosen) -- not the
         # PR's perimeter. Skip the red; the digit branch never produces this
         # shape so the guard sits here only.
+        # #13791: an indefinite word-form opened by a discrimination verb
+        # ("distinguer un fichier corrompu d'un fichier offensif") names the
+        # objects of a comparison, not the perimeter (founder #13736 l.26).
         if _word_form_is_indef_non_pr_subject(scan_target, files):
+            pass
+        elif _word_form_is_measurement_object(scan_target):
             pass
         else:
             problems.append(
@@ -672,6 +699,15 @@ HIT_ANTECEDENT = re.compile(r"\b\d+\s*hits?\b", re.IGNORECASE)
 # _count_is_incidental (no scope word, no diffstat neighborhood). The
 # founder case is the asphalt.
 #
+# #13791: grep / git grep / rg added to the closed list -- grep is THE most
+# common measurement verb in this repo's PR bodies ("2.9 est le seul
+# notebook torch de 02-ML-Cours (grep : 1 fichier)", founder #13782), and
+# without it the guard read a corpus count as a perimeter declaration.
+# FN-control measured on the six verdict PRs of #13791: #11956/#12065/
+# #13557/#13685 carry no grep-antecedent line that flips (their blocking
+# counts sit on diffstat/scope-word lines, which stay blocking before this
+# exemption is even consulted).
+#
 # The pattern matches the antecedent ALONE (no count baked in); the count
 # exemption is per-match and uses line[:m.end()] to allow the antecedent to
 # sit anywhere in the run-up to the count (the per-match exemption already
@@ -682,6 +718,8 @@ MEASUREMENT_ANTECEDENT = re.compile(
     r"count_code_sorry(?:\.py)?|"
     r"scan(?:\s+(?:sur|of|on))?|"
     r"mesures?(?:\s+(?:sur|of|on))?|"
+    r"(?:git\s+)?grep(?:\s+(?:sur|of|on|:|--?rn?))?|"
+    r"rg(?:\s+(?:sur|of|on|:))?|"
     r"registry|registre(?:\s+(?:de|of))?|"
     r"check_(?:unaddressed_nits|pr_perimeter|perimeter))\b",
     re.IGNORECASE,
@@ -871,6 +909,38 @@ def _word_form_is_indef_non_pr_subject(text: str, files: list[dict]) -> bool:
         n not in paths_in_files and n not in paths_in_files_basenames
         for n in named_flat
     )
+
+
+# #13791 -- indefinite word-form count opened by a DISCRIMINATION verb. The
+# founder line (#13736 l.26): "le script echoue sur un faux positif
+# (l'instrument ne peut pas distinguer un fichier corrompu d'un fichier
+# offensif)" -- the word-form trigger read "un fichier" as a 1-file perimeter
+# claim against a 2-file list, while the phrase names the OBJECTS OF A
+# COMPARISON the body is making about the instrument. Same family as
+# #11985 forme 4b (bad surface, not bad count) and #13610 (indefinite
+# article + governing verb). Closed verb list; FN-safety mirrors
+# _word_form_is_indef_non_pr_subject: same 80-char window before the article,
+# and a genuine word-form perimeter claim ("un fichier modifie : X.py")
+# never follows a discrimination verb -- the residual risk ("on distingue un
+# fichier modifie") is the deliberate closed-list trade, measured against
+# the #13791 control PRs (none of #11956/#12065/#13557/#13685 carries a
+# discrimination verb before a word-form count).
+_DISCRIMINATION_VERB = re.compile(
+    r"\b(?:distinguer|diff[ée]rencier|discriminer|contraster|opposer|"
+    r"s[ée]parer|comparer)\b",
+    re.IGNORECASE,
+)
+
+
+def _word_form_is_measurement_object(text: str) -> bool:
+    """#13791: True when a word-form count's indefinite article ("un fichier")
+    sits within 80 chars AFTER a discrimination verb -- the phrase names the
+    objects of a comparison (diagnostic prose about what an instrument
+    distinguishes), not the PR's perimeter."""
+    m = _INDEF_ARTICLE.search(text.lower())
+    if m is None:
+        return False
+    return bool(_DISCRIMINATION_VERB.search(text[max(0, m.start() - 80):m.start()]))
 
 
 def _additive_line_sum(line: str) -> int:
@@ -1188,6 +1258,32 @@ def _paragraph_prefix(text: str, idx: int) -> str:
     return "\n".join(reversed(out))
 
 
+def _paragraph_block(text: str, idx: int) -> str:
+    """#13791: the markdown paragraph CONTAINING line `idx` -- the prefix of
+    `_paragraph_prefix` PLUS the line PLUS the contiguous non-empty lines
+    below it. Same boundaries (blank line, fence delimiter): a block is the
+    maximal run of prose lines an author would read as one unit, which is the
+    unit an additive enumeration spans ("- 1 fichier modifie (...)" /
+    "- 1 fichier de test modifie (...)" on two bullets, founder #13736). The
+    #13335 prefix alone could not see the lines BELOW the candidate -- and an
+    additive enumeration lists downward."""
+    lines = text.splitlines()
+    if not 0 <= idx < len(lines):
+        return ""
+    low, hi = idx, idx
+    while low - 1 >= 0:
+        s = lines[low - 1].strip()
+        if not s or s.startswith("`" * 3) or s.startswith("~" * 3):
+            break
+        low -= 1
+    while hi + 1 < len(lines):
+        s = lines[hi + 1].strip()
+        if not s or s.startswith("`" * 3) or s.startswith("~" * 3):
+            break
+        hi += 1
+    return "\n".join(l.strip() for l in lines[low:hi + 1])
+
+
 def _extract_line_candidates(text: str) -> list[tuple[int, str]]:
     """Index-carrying core of extract_perimeter_assertions: returns
     (line_index, stripped_line) pairs so callers can re-attach body context
@@ -1246,6 +1342,18 @@ def extract_perimeter_assertions_with_context(text: str) -> list[tuple[str, str]
     extract_perimeter_assertions -- only the context differs."""
     return [
         (line, _paragraph_prefix(text, idx))
+        for idx, line in _extract_line_candidates(text)
+    ]
+
+
+def extract_perimeter_assertions_with_block(text: str) -> list[tuple[str, str, str]]:
+    """#13791: candidates paired with (paragraph prefix, enclosing paragraph
+    BLOCK). The block extends the #13335 prefix to the lines BELOW the
+    candidate -- the unit an additive enumeration ("- 1 fichier modifie" /
+    "- 1 fichier de test modifie" on two bullets, founder #13736) spans.
+    Same candidate set; only the carried context differs."""
+    return [
+        (line, _paragraph_prefix(text, idx), _paragraph_block(text, idx))
         for idx, line in _extract_line_candidates(text)
     ]
 
@@ -1680,6 +1788,11 @@ class Candidate:
     # select_candidates from the full body text. Feeds only the
     # MEASUREMENT_ANTECEDENT exemption -- wrap-invariance of the verdict.
     context: str = ""
+    # #13791: enclosing paragraph BLOCK (see _paragraph_block) -- prefix +
+    # line + the contiguous lines below. Feeds only the additive-enumeration
+    # confrontation in check_assertion: an enumeration spanning two bullets
+    # sums across the block, not the single line.
+    block: str = ""
 
     @property
     def blocking(self) -> bool:
@@ -1748,8 +1861,8 @@ def select_candidates(
             if opener is not None:
                 orphan_opener = opener
         body_candidates = [
-            Candidate(text, item["kind"], item["author"], "body", context=ctx)
-            for text, ctx in extract_perimeter_assertions_with_context(body)
+            Candidate(text, item["kind"], item["author"], "body", context=ctx, block=blk)
+            for text, ctx, blk in extract_perimeter_assertions_with_block(body)
         ]
         if n_files is not None and any(
             not _is_incidental_assertion(c.text, c.context)
@@ -1836,7 +1949,7 @@ def main() -> int:
         if body_orphan is not None:
             orphan_opener = body_orphan
         for cand in candidates:
-            for p in check_assertion(report.files, cand.text):
+            for p in check_assertion(report.files, cand.text, block=cand.block):
                 line = f"[{cand.kind} / {cand.author}] {p}"
                 # Every catch stays visible either way -- the detector is not
                 # disarmed, only its consequence is placed where it can be

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -23,6 +23,7 @@ from check_pr_perimeter import (  # noqa: E402
     check_assertion,
     extract_baseline_moves,
     extract_perimeter_assertions,
+    extract_perimeter_assertions_with_block,
     extract_perimeter_assertions_with_context,
     format_report,
     is_downgradable_mismatch,
@@ -36,6 +37,7 @@ from check_pr_perimeter import (  # noqa: E402
     _has_strong_scope,
     _is_incidental_assertion,
     _normalize_rest_files,
+    _paragraph_block,
     _paragraph_prefix,
     _word_form_count,
     _word_form_is_indef_non_pr_subject,
@@ -2871,3 +2873,120 @@ def test_13637_partition_exposes_correct_count_for_assertion():
     )
     # A body that states the true (propre) count passes.
     assert check_assertion(propres, "Périmètre : 2 fichiers.") == []
+
+
+# ---------------------------------------------------------------------------
+# #13791 — somme additive au bloc paragraphe + vocabulaire grep + word-form
+# objet de mesure. Fondateurs mesurés : #13736 (deux puces "1 fichier" + une
+# ligne diagnostique word-form) et #13782 ("(grep : 1 fichier)").
+# ---------------------------------------------------------------------------
+
+FOUNDER_13736_BODY = (
+    "## Périmètre\n"
+    "\n"
+    "- 1 fichier modifié (`scripts/ci/check_concurrency_conj.py`, +1/-1)\n"
+    "- 1 fichier de test modifié (`scripts/tests/test_check_concurrency_conj.py`, +37/-0)\n"
+    "- Aucune collision chemin : les PRs parentes ne touchent plus ce fichier.\n"
+)
+FOUNDER_13736_FILES = [
+    {"path": "scripts/ci/check_concurrency_conj.py"},
+    {"path": "scripts/tests/test_check_concurrency_conj.py"},
+]
+# Ligne diagnostique fondatrice (#13736 l.26) : le word-form « un fichier »
+# y désigne les objets d'une comparaison, pas le périmètre.
+FOUNDER_13736_DIAG = (
+    "Tout workflow malformé fait planter l'instrument, et le script échoue "
+    "sur un faux positif (l'instrument ne peut pas distinguer un fichier "
+    "corrompu d'un fichier offensif)."
+)
+# Ligne fondatrice #13782 : « (grep : 1 fichier) » est une mesure du corpus.
+FOUNDER_13782_LINE = (
+    "2.9 est le **seul notebook torch de 02-ML-Cours** (grep : 1 fichier) : "
+    "c'est assumé par le README."
+)
+
+
+def test_13791_additive_block_sum_spans_bullets():
+    """L'énumération additive sur deux puces (1 + 1 = 2) passe quand la
+    confrontation reçoit le bloc paragraphe -- chaque ligne candidate voit
+    la somme du bloc, pas seulement sa ligne."""
+    triple = extract_perimeter_assertions_with_block(FOUNDER_13736_BODY)
+    digit_candidates = [(l, b) for l, _ctx, b in triple if COUNT_CLAIM.search(l)]
+    assert len(digit_candidates) == 2, digit_candidates
+    for line, block in digit_candidates:
+        assert "1 fichier" in line
+        # chaque puce du bloc porte exactement un compte survivant
+        assert sum(_additive_line_sum(ln) for ln in block.splitlines()) == 2
+        assert check_assertion(FOUNDER_13736_FILES, line, block=block) == [], line
+
+
+def test_13791_additive_line_scope_still_fails_without_block():
+    """Sans bloc (mode --assert, candidates de thread), la somme line-scope
+    mismatche 1 vs 2 -- comportement inchangé, c'est le résidu #13791."""
+    assert check_assertion(
+        FOUNDER_13736_FILES, "- 1 fichier modifié (`scripts/ci/check_concurrency_conj.py`, +1/-1)"
+    ) != []
+
+
+def test_13791_block_sum_never_validates_wrong_total():
+    """Contrôle FN local : une somme de bloc ≠ len(files) reste rouge -- le
+    bloc dessert l'énumération exacte, pas n'importe quelle somme."""
+    body = "- 1 fichier a\n- 1 fichier b\n- 1 fichier c\n"
+    files = [{"path": "a"}, {"path": "b"}]
+    triple = extract_perimeter_assertions_with_block(body)
+    for line, _ctx, block in triple:
+        assert check_assertion(files, line, block=block) != [], line
+
+
+def test_13791_grep_antecedent_exempts_corpus_count():
+    """« (grep : 1 fichier) » est une mesure du corpus (#13782) : le compte
+    est incidental, la candidate ne bloque pas (l'architecture #11712 : la
+    détection reste, seule la conséquence bouge -- check_assertion rend le
+    mismatch, `blocking` le rétrograde en signal)."""
+    assert _is_incidental_assertion(FOUNDER_13782_LINE, "") is True
+    cand = Candidate(FOUNDER_13782_LINE, "PR body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_13791_grep_absence_keeps_the_red():
+    """Contrôle FN : sans antécédent de mesure, « 1 fichier modifié » devant
+    une liste de 2 reste rouge -- grep n'a rien desserré d'autre."""
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    assert check_assertion(files, "1 fichier modifié (`a.py`)") != []
+
+
+def test_13791_word_form_discrimination_verb_exempts():
+    """« distinguer un fichier corrompu d'un fichier offensif » (#13736) :
+    le word-form désigne les objets d'une comparaison, pas le périmètre."""
+    files = [{"path": "scripts/ci/check_concurrency_conj.py"},
+             {"path": "scripts/tests/test_check_concurrency_conj.py"}]
+    assert check_assertion(files, FOUNDER_13736_DIAG) == []
+
+
+def test_13791_word_form_plain_indefinite_still_blocks():
+    """Contrôle FN : « un fichier modifié » sans verbe de discrimination
+    reste confronté (1 vs 2 -> rouge)."""
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    assert check_assertion(files, "un fichier modifié (`a.py`)") != []
+
+
+def test_13791_paragraph_block_boundaries():
+    """Le bloc paragraphe s'arrête aux lignes vides et aux fences, dans les
+    deux directions."""
+    text = (
+        "avant le vide\n"
+        "\n"
+        "- 1 fichier a\n"
+        "- 1 fichier b\n"
+        "\n"
+        "après le vide\n"
+    )
+    lines = text.splitlines()
+    idx = lines.index("- 1 fichier a")
+    block = _paragraph_block(text, idx)
+    assert "- 1 fichier a" in block and "- 1 fichier b" in block
+    assert "avant le vide" not in block and "après le vide" not in block
+    # fence delimiter en borne inférieure
+    fenced = "- 1 fichier a\n```python\nx = 1\n```\n"
+    idx_f = fenced.splitlines().index("- 1 fichier a")
+    assert "x = 1" not in _paragraph_block(fenced, idx_f)


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #13790

Closes #13791. Répare les 2 résidus mesurés par ai-01 (DM 2026-08-31T01:43Z) **+ un 3e résidu découvert à la mesure** (obligatoire pour l'acceptance : sans lui, #13736 ne repasse pas vert).

## Les 3 fixes

1. **Somme additive au bloc paragraphe** (résidu 1, bloque #13736). `_paragraph_block(text, idx)` : le bloc de lignes non vides contiguës CONTENANT la candidate (même bornes que `_paragraph_prefix` #13335 : ligne vide, fence delimiter — pas une fenêtre arbitraire). `Candidate.block` est rempli par `select_candidates` via `extract_perimeter_assertions_with_block` (nouvelle, la 2-tuple publique #13335 est inchangée) ; `check_assertion(files, assertion, block="")` confronte la somme additive du **bloc** quand la somme de ligne mismatche. Les filtres par compte restent **par ligne**. Sûr par construction #12103 : un FAIL ne devient PASS que si la somme du bloc est exactement `len(files)` — le bloc **remplace** la somme de ligne (la candidate y figure déjà), jamais ne s'y additionne.
2. **`grep` / `git grep` / `rg` dans `MEASUREMENT_ANTECEDENT`** (résidu 2, bloque #13782). Liste close étendue ; l'antécédent reste intentionnellement faible (fenêtre avant le compte, FN-safety guards de `_count_is_incidental` inchangés).
3. **Word-form objet de mesure** (découvert en mesurant #13736 ligne par ligne — ai-01 avait mesuré 2 résidus ; la 3e ligne rouge de #13736 n'est pas l'additive mais un word-form). Ligne fondatrice #13736 l.26 : « l'instrument ne peut pas distinguer un fichier corrompu d'un fichier offensif » — le trigger word-form lisait « un fichier » comme un périmètre de 1 face à une liste de 2. `_word_form_is_measurement_object` : article indéfini ouvert par un **verbe de discrimination** (liste close : distinguer/différencier/discriminer/contraster/opposer/séparer/comparer, fenêtre 80 chars — même géométrie que `_word_form_is_indef_non_pr_subject` #13610). Sans le fix 3, #13736 reste FAIL : les 3 rouges de sa baseline sont 2 digits (les puces, fixées par 1) + 1 word-form (cette ligne).

## Contrôle de faux négatif — les 6 verdicts re-mesurés (le tableau exigé par #13791)

| PR | baseline (avant fix) | après fix | Problems identiques ? |
|---|---|---|---|
| #11956 (cas fondateur) | FAIL exit=1, 1 problem | **FAIL** exit=1, 1 problem | oui, byte-identique |
| #12065 (cas fondateur) | FAIL exit=1, 4 problems | **FAIL** exit=1, 4 problems | oui, byte-identiques |
| #13557 (vrai positif du soir) | FAIL exit=1, 3 problems | **FAIL** exit=1, 3 problems | oui, byte-identiques |
| #13685 (vrai positif du soir) | FAIL exit=1, 2 problems | **FAIL** exit=1, 2 problems | oui, byte-identiques |
| #13736 (cible) | FAIL exit=1, 3 problems | **OK exit=0, 0** | — |
| #13782 (cible) | FAIL exit=1, 1 problem | **OK exit=0, 0** | — |

Bonus contrôle : #13601 (3e perimeter légitime cité par #13791, déjà OK en local avant fix) → **OK exit=0 après fix** (0 problems), non dégradé.

Aucun des 4 FAIL ne porte de ligne grep-antecedent ni de word-form à verbe de discrimination : leurs comptes bloquants vivent sur des lignes diffstat/scope-word qui restent bloquantes **avant** même que ces exemptions ne soient consultées (vérifié par énumération des sommes additives possibles : aucune somme de sous-bloc ne peut égaler un `len(files)` des 4 contrôles — {5→0} ; {7,7,7,5,7,7,16}→2 ; {2,2}+word→3 ; {1,3}→9).

## Tests

`scripts/tests/test_check_pr_perimeter.py` : **164 passed, 1 skipped** (156 préexistants verts + 8 nouveaux #13791 : somme-bloc sur 2 puces, line-scope sans bloc échoue toujours, somme de bloc ≠ len reste rouge, grep-antecedent → `blocking=False` (l'architecture #11712 : check_assertion détecte, la classification incidental place la conséquence), grep absent garde le rouge, word-form + verbe de discrimination exempté, word-form simple reste rouge, bornes de `_paragraph_block`).

## Hors périmètre (respecté)

Aucun relâchement de la branche de comptage en général ; `extract_perimeter_assertions_with_context` (signature publique #13335) inchangée ; mode `--assert` CLI inchangé (pas de bloc) ; vocabulaire `MEASUREMENT_ANTECEDENT` reste une liste close documentée avec sa règle d'extension (#11985).
