### PR TITLE
fix(search,#13576): navlinks Search-17 vers App-14b-ConnectFour (App-12 renommé)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb
@@ -3185,7 +3185,7 @@
     "\n",
     "La tranche 1 a comparé six paradigmes sur un problème de **satisfaction de contraintes**. Le projet étudiant distillé (cf. §9) en couvre deux autres ; cette tranche applique le même protocole au **Puissance 4** — un **jeu adversarial à somme nulle, information parfaite**.\n",
     "\n",
-    "Les algorithmes eux-mêmes (minimax, élagage alpha-beta, MCTS) sont enseignés en détail dans [`App-12-ConnectFour`](../Applications/Search/App-12-ConnectFour.ipynb) (moteur de jeu, baseline aléatoire, alpha-beta) et [`App-14-ConnectFour-Adversarial`](../Applications/Search/App-14-ConnectFour-Adversarial.ipynb) (minimax, alpha-beta, MCTS, benchmark mono-position). **Ce notebook ne les ré-enseigne pas** : il pose la question de la **sélection** — même harnais, même timeout, mêmes métriques, mais un terrain dont la nature change ce que « bien résoudre » veut dire.\n"
+    "Les algorithmes eux-mêmes (minimax, élagage alpha-beta, MCTS) sont enseignés en détail dans [`App-14b-ConnectFour`](../Applications/Search/App-14b-ConnectFour.ipynb) (moteur de jeu, baseline aléatoire, alpha-beta) et [`App-14-ConnectFour-Adversarial`](../Applications/Search/App-14-ConnectFour-Adversarial.ipynb) (minimax, alpha-beta, MCTS, benchmark mono-position). **Ce notebook ne les ré-enseigne pas** : il pose la question de la **sélection** — même harnais, même timeout, mêmes métriques, mais un terrain dont la nature change ce que « bien résoudre » veut dire.\n"
    ]
   },
   {
@@ -4453,7 +4453,7 @@
    "source": [
     "### 8.7 Renvois\n",
     "\n",
-    "- [`App-12-ConnectFour`](../Applications/Search/App-12-ConnectFour.ipynb) — moteur, baseline aléatoire, alpha-beta (cours détaillé).\n",
+    "- [`App-14b-ConnectFour`](../Applications/Search/App-14b-ConnectFour.ipynb) — moteur, baseline aléatoire, alpha-beta (cours détaillé).\n",
     "- [`App-14-ConnectFour-Adversarial`](../Applications/Search/App-14-ConnectFour-Adversarial.ipynb) — minimax, alpha-beta, MCTS et benchmark mono-position par profondeur.\n",
     "- Tranche 3/3 (Wordle — élimination bayésienne / entropie / CSP) : à venir, même protocole.\n"
    ]


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #13804

## Résumé

Réparation de la **seule référence morte restante sur `main`**. Le reclass `App-12-ConnectFour` → `App-14b-ConnectFour` (cahiers `Applications/Search`) a balayé toutes les références **sauf** celles de `Search-17-Empirical-Algorithm-Selection`, qui pointaient encore vers `App-12-ConnectFour.ipynb` — désormais **absent de `main`**.

Deux cellules markdown corrigées (index 52 §8 intro, index 70 §8.7 Renvois) : lien texte + href → `App-14b-ConnectFour.ipynb` (successeur confirmé, présent sur `main`, cf. balayage des 7 autres notebooks référents).

## Pourquoi c'était bloquant

Cette référence morte cassait **`check-navlinks`** (baseline `scripts/tests/baseline_nb_navlinks.json` = 0 connue → « NEW broken ») pour **tout PR `.ipynb`**, dont #13804 (tranche 1/6 #13755, reclass Cloud-01 → Cloud-03b). Le défaut était **pré-existant sur `main`** (introduit par l'interaction #13576 + reclass App-12→App-14b), **pas** causé par #13804. Le réparer libère la gate et débloque #13804 une fois mergé.

## Preuves

- `git grep -c "App-12-ConnectFour"` (arbre `origin/main`) — ne renvoie que `Search-17` (2 lignes) ; **0 fichier `App-12-ConnectFour.ipynb`** sur `origin/main`.
- Successeur vérifié : `App-14b-ConnectFour.ipynb` présent sur `main` (titre « App-14b : Puissance 4 — Comparaison d'algorithmes IA (Bonus) »).
- **Markdown-only** : aucune cellule code, `execution_count` ni `outputs` modifiés (diff = 2 insertions / 2 suppressions, hunks aux lignes 3188 & 4456 ; 27 cellules code conservent `execution_count`).
- `python scripts/notebook_tools/check_notebook_navlinks.py --check` → `OK: 0 NEW broken navlink vs baseline (0 connus, 1191 notebooks scannés)`.
- Pas de paire twin (`twin_pairs.d` n'a pas de `search-17`) ; pas de re-exécution requise (markdown seul, cf. C.2 exception).

## Attribution

La référence était introduite par #13576 (Search-17 tranche 2, terrain Puissance 4) — la correction est le rattrapage de son interaction avec le reclass App-12→App-14b.

See #13576
