### PR TITLE
tools(lane-claim,#13595): mode --open-prs-on — PRs ouvertes sur un chemin, sans filtre de lane

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -3110,6 +3110,86 @@ def _run_check_paths(
     return 0
 
 
+def _run_open_prs_on(
+    paths: list[str],
+    prs: list[dict] | None = None,
+) -> int:
+    """List OPEN PRs touching `paths` across ALL lanes (no lane filter).
+
+    #13595: the `--paths` guard filters its result by *lane* -- an OPEN PR of
+    the caller's OWN lane reads as "your own PR is fine" and is dropped from
+    the verdict. That is exactly the blind spot of case A (one machine, same
+    lane, two worktrees, 74 s apart): there is only one lane, so the guard
+    finds no *other*-lane collision and concludes CLEAR while two branches of
+    the same lane are racing on the same files.
+
+    This mode drops the lane filter entirely: it lists EVERY OPEN PR whose
+    files intersect `paths`, whatever the lane -- INCLUDING the caller's own.
+    It is NON-BLOCKING (returns 0 always): the signal is broad enough to
+    produce legitimate false positives (two PRs on a large notebook), so the
+    lane decides, it is never summarily refused (#13595 point 3).
+
+    Returns:
+        0 always (list mode). A `RuntimeError` from `gh` is surfaced by the
+          caller as exit 1; this mode itself carries no collision verdict.
+    """
+    if not paths:
+        print("error: --open-prs-on requires at least one path/glob",
+              file=sys.stderr)
+        return 1
+    if prs is None:
+        try:
+            prs = _gh_open_prs_with_files()
+        except RuntimeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+    hits: list[dict] = []
+    for pr in prs:
+        pr_files = pr.get("files") or []
+        intersecting = [
+            f.get("path", "") for f in pr_files
+            if f.get("path") and _path_matches(f["path"], paths)
+        ]
+        if not intersecting:
+            continue
+        lane = extract_lane(pr.get("body") or "")
+        hits.append({
+            "number": pr.get("number"),
+            "headRefName": pr.get("headRefName"),
+            "lane": lane,
+            "lane_readable": lane is not None,
+            "files": intersecting,
+            "title": pr.get("title"),
+        })
+
+    if hits:
+        print(
+            f"OPEN PRs on paths {paths!r} "
+            f"(mode open-prs-on -- NO lane filter, non-blocking):"
+        )
+        for h in hits:
+            lane = h["lane"] if h["lane_readable"] else "UNREADABLE"
+            print(
+                f"  #{h['number']} lane={lane} head={h['headRefName']} "
+                f"files=[{', '.join(h['files'])}] -- {h['title']}"
+            )
+        print(
+            "\nNote: your OWN lane appearing here is the case-A signal "
+            "(same lane, two worktrees). Re-check before opening a branch, "
+            "or confirm the other PR is resolved/separate before pushing.\n"
+            "Re-query equivalent (the geste from #13595):"
+        )
+        print(
+            "  gh pr list --state open --json number,headRefName,files "
+            "--jq '.[] | select(.files[].path | test(\"<chemin>\")) "
+            "| \"#\\(.number) \\(.headRefName)\"'"
+        )
+    else:
+        print(f"NO open PR intersects paths {paths!r}. Path is free.")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(
         description=(
@@ -3162,6 +3242,17 @@ def main(argv: list[str] | None = None) -> int:
                         "treated as if it did not exist for the blocker "
                         "decision. Without `--paths`, override scope is "
                         "ignored (legacy epic-wide behaviour, preserved).")
+    p.add_argument("--open-prs-on", metavar="PATH", nargs="+", action="extend",
+                   default=None,
+                   help="list-mode (#13595): one or more file paths/globs. "
+                        "List EVERY OPEN PR whose files[] intersect, "
+                        "REGARDLESS of lane -- including the caller's own "
+                        "(case A: same lane, two worktrees). NON-BLOCKING: "
+                        "returns 0 always; the lane decides, it is never "
+                        "refused. Use when a PATH may be raced by another "
+                        "worktree of your own machine/lane, where the "
+                        "lane-filtered `--paths` guard is structurally blind. "
+                        "Mutually exclusive with `--paths`.")
     act = p.add_mutually_exclusive_group()
     act.add_argument("--claim", metavar="INTENTION",
                      help="post a [CLAIMED] comment for your lane. Runs the "
@@ -3197,6 +3288,24 @@ def main(argv: list[str] | None = None) -> int:
                 f"(positional FIRST).",
                 file=sys.stderr,
             )
+    if args.open_prs_on is not None:
+        for entry in _warn_bare_integer_paths(args.open_prs_on):
+            print(
+                f"WARN: --open-prs-on entry {entry!r} is a bare integer -- an "
+                f"issue number swallowed by nargs='+' (#10881). Correct form: "
+                f"`check_lane_claim.py {entry} --lane <lane> --open-prs-on ...` "
+                f"(positional FIRST).",
+                file=sys.stderr,
+            )
+
+    # #13595 -- `--open-prs-on` (list-mode) and `--paths` (guard-mode) are
+    # mutually exclusive. The guard fires BEFORE either branch, else `--paths`
+    # returns first and the caller never learns their `--open-prs-on` was
+    # silently ignored.
+    if args.open_prs_on is not None and args.paths is not None:
+        print("error: --open-prs-on and --paths are mutually exclusive; "
+              "run them separately", file=sys.stderr)
+        return 1
 
     # Path-only mode (#9959) does NOT require an issue number -- it is the
     # missing leg of L898 dispatched pre-claim to detect cross-lane PR
@@ -3206,6 +3315,11 @@ def main(argv: list[str] | None = None) -> int:
     # `[OVERRIDE]` markers, #10342).
     if args.paths is not None and args.issue is None:
         return _run_check_paths(args.paths, args.lane)
+
+    # #13595 -- list-mode: no lane filter, non-blocking. `--open-prs-on` is
+    # its own mode and does not require an issue number.
+    if args.open_prs_on is not None:
+        return _run_open_prs_on(args.open_prs_on)
 
     # Posting modes: short-circuit before any read. Both require an issue.
     if args.issue is None:

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -1366,6 +1366,93 @@ def test_paths_multiple_prs_mixed(capsys):
     assert "BLOCKED" in captured.err
 
 
+# --- --open-prs-on mode (#13595) --------------------------------------------
+#
+# The `--paths` guard filters by lane: an OPEN PR of the caller's OWN lane
+# reads as "your own PR is fine" and is dropped from the verdict. That is the
+# blind spot of case A (one machine, SAME lane, two worktrees, 74 s apart):
+# there is only one lane, so the guard finds no *other*-lane collision and
+# reports CLEAR while two branches of the same lane race on the same files.
+# `--open-prs-on` drops the lane filter entirely and lists EVERY intersecting
+# OPEN PR -- including the caller's own -- as a NON-BLOCKING signal.
+
+def test_open_prs_on_same_lane_both_surface(capsys):
+    """THE positive control (#13595 point 2): two OPEN PRs of the SAME lane
+    on the same file must BOTH surface. A detector that renders nothing on
+    this case is indistinguishable from a disconnected detector -- and this
+    is exactly the shape `--paths` misses (self_overlap == 'your own PR is
+    fine', exit 0, no verdict)."""
+    body = (
+        "Grain: MED/tooling -- lane myia-po-2024:CoursIA -- prev: ...\n"
+    )
+    prs = [
+        _pr(13586, ["scripts/check_lane_claim.py"], body=body),
+        _pr(13558, ["scripts/check_lane_claim.py"], body=body),
+    ]
+    rc = clc._run_open_prs_on(["scripts/check_lane_claim.py"], prs=prs)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "#13586" in out
+    assert "#13558" in out
+    assert "lane=myia-po-2024:CoursIA" in out
+    # The same-lane caveat is stated so the lane cannot mistake the list for
+    # a clearance.
+    assert "NO lane filter" in out
+
+
+def test_open_prs_on_cross_lane_both_surface(capsys):
+    # Two lanes both surface -- the mode is lane-agnostic, so the other-lane
+    # collision is listed too (it would BLOCK under `--paths` but here it is
+    # a list only).
+    self_body = "Grain: MED/tooling -- lane myia-po-2024:CoursIA -- prev: ...\n"
+    other_body = "Grain: MED/lean -- lane myia-po-2026:CoursIA-2 -- prev: ...\n"
+    prs = [
+        _pr(9001, ["scripts/check_lane_claim.py"], body=self_body),
+        _pr(9002, ["scripts/check_lane_claim.py"], body=other_body),
+    ]
+    rc = clc._run_open_prs_on(["scripts/check_lane_claim.py"], prs=prs)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "#9001" in out
+    assert "#9002" in out
+    assert "myia-po-2024:CoursIA" in out
+    assert "myia-po-2026:CoursIA-2" in out
+
+
+def test_open_prs_on_no_intersection_free(capsys):
+    # No OPEN PR intersects the paths -> "Path is free", exit 0.
+    prs = [_pr(9003, ["docs/other.md", "scripts/unrelated.py"])]
+    rc = clc._run_open_prs_on(["scripts/check_lane_claim.py"], prs=prs)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Path is free" in out
+
+
+def test_open_prs_on_empty_paths_usage_error(capsys):
+    rc = clc._run_open_prs_on([], prs=[])
+    assert rc == 1
+    assert "--open-prs-on requires" in capsys.readouterr().err
+
+
+def test_open_prs_on_untagged_lane_surfaces(capsys):
+    # PR with no readable Grain lane tag still surfaces, labeled UNREADABLE --
+    # same treatment as `--paths` (the tag is the only attribution signal).
+    prs = [_pr(9004, ["scripts/check_lane_claim.py"], body="no grain tag here")]
+    rc = clc._run_open_prs_on(["scripts/check_lane_claim.py"], prs=prs)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "#9004" in out
+    assert "UNREADABLE" in out
+
+
+def test_open_prs_on_non_blocking_even_with_hits(capsys):
+    # Hits present, yet exit 0 -- the mode refuses nothing (#13595 point 3).
+    body = "Grain: MED/tooling -- lane myia-po-2024:CoursIA -- prev: ...\n"
+    prs = [_pr(9005, ["scripts/check_lane_claim.py"], body=body)]
+    rc = clc._run_open_prs_on(["scripts/check_lane_claim.py"], prs=prs)
+    assert rc == 0
+
+
 # --- [OVERRIDE] (#10223) -- coordinator adjudication -------------------------
 #
 # `[OVERRIDE] lane <X>` grants the claim to lane X and closes every other


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #13803

Closes #13595 — extension `check_lane_claim.py` d'un mode **chemin sans filtre de lane** (`--open-prs-on <glob>`).

## Quoi

Le garde `--paths` existant filtre son verdict par **lane** : une PR OUVERTE de **sa propre** lane se lit « your own PR is fine » et sort du verdict. C'est précisément l'angle mort du **cas A** de #13595 — une machine, **même** lane, deux worktrees, 74 s d'écart (#13586 / #13558) : il n'y a qu'une lane, le garde ne trouve donc **aucun** *autre-lane* à détecter et répond CLEAR pendant que deux branches de la même lane courent sur les mêmes fichiers.

Le nouveau mode `--open-prs-on` **supprime le filtre de lane** : il liste **chaque** PR ouverte dont `files[]` intersecte le chemin, **y compris la sienne**.

## Les 3 critères de #13595

| # | Critère | Livré |
|---|---|---|
| 1 | Mode `--open-prs-on <glob>`, sans filtre de lane, y compris sa propre lane | `_run_open_prs_on()` + branche CLI : liste `#<num> lane=<lane\|UNREADABLE> head=<head> files=[...]` pour chaque PR ouverte intersectante |
| 2 | **Contrôle positif obligatoire** en test | `test_open_prs_on_same_lane_both_surface` — les deux PR de #13586/#13558 (même lane, même fichier) ressortent **toutes deux** + 5 autres cas (cross-lane, sans-intersection, empty→exit 1, UNREADABLE, non-bloquant) |
| 3 | **Non-bloquant mais nommé** | retourne `0` **toujours** (le signal est assez large pour des vrais faux positifs — deux PRs sur un gros notebook — ; la lane décide, elle n'est jamais refusée) ; ré-requête `gh pr list ... --jq` fournie en aide |

## Prévention des régressions

- **Mutual exclusion** : `--open-prs-on` + `--paths` → `exit 1` (« run them separately »). Le garde fire **avant** la branche `--paths`, sinon `--paths` retournerait le premier et le `--open-prs-on` serait silencieusement ignoré.
- **Warning #10881** : le piège « bare integer avalé par nargs='+' » est étendu au nouveau mode.
- **Rien dupliqué** : `_gh_open_prs_with_files()` + `_path_matches()` (déjà testés) réutilisés, aucune nouvelle logique `gh`, aucun appel REST direct.

## Preuves de validation

- `tests/test_check_lane_claim.py` : **287 passed, 1 skipped** (dont 6 nouveaux `open_prs_on`) — non-régression sur tout le fichier.
- `test_fast_lane.py` / `test_lane_claim_required.py` / `test_pick_claim_filter.py` / `test_check_workflow_label_paths.py` : **123 passed**.
- CLI end-to-end : `--open-prs-on scripts/check_lane_claim.py --lane myia-po-2024:CoursIA` → « Path is free » (exit 0) ; `--open-prs-on` + `--paths` → exit 1.

## Genre — META (ne tient pas G-VAR-1)

Grain `guard` (étend un organe qui peut rougir) = classe **META**. Le plancher G-VAR-1 de ce cycle **n'est pas tenu par cette PR** : la track principale du cycle (QC #13117) a échoué sur l'infra (le chemin compile du MCP `qc-mcp-lite` retourne un compileId synthétique jamais enregistré — `create_backtest` → « Compile id not found »), et les grains CONTENU libres du pool étaient couverts (#13567 → PR #13712 ouverte d'une autre lane ; #13569 livrée cycle 19 ; #11112 substantiellement livré) ou gated (#13570 → bac à sable #13798). Les PRs CONTENU de cette lane en attente merge coord (**#13803**, #13802, #13798, #13775) portent le plancher des cycles précédents.
