### PR TITLE
fix(tooling,#13623): post_comment/edit_comment inspectent returncode — WARN + confirmed/attempted + controle positif

### DIFF
--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -551,16 +551,19 @@ def scan_markers(
     return state, failed
 
 
-def post_comment(repo: str, number: int, body: str, dry_run: bool) -> None:
+def post_comment(repo: str, number: int, body: str, dry_run: bool) -> bool:
+    """POST the marker comment on PR ``number``. Returns True iff the write
+    succeeded. A non-zero rc is WARNed, never silently swallowed (#13623).
+    """
     if dry_run:
-        return
+        return True
     with tempfile.NamedTemporaryFile(
         "w", suffix=".md", encoding="utf-8", delete=False
     ) as tf:
         tf.write(body)
         tmp_path = tf.name
     try:
-        subprocess.run(
+        proc = subprocess.run(
             ["gh", "pr", "comment", str(number), "--repo", repo,
              "--body-file", tmp_path],
             capture_output=True, text=True, check=False, encoding="utf-8",
@@ -568,24 +571,34 @@ def post_comment(repo: str, number: int, body: str, dry_run: bool) -> None:
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
+    if proc.returncode != 0:
+        print(
+            f"WARN: write failed for #{number} — rc={proc.returncode}, "
+            f"{(proc.stderr or proc.stdout).strip()[:200]}",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
-def edit_comment(repo: str, comment_id: str, body: str, dry_run: bool) -> None:
+def edit_comment(repo: str, number: int, comment_id: str, body: str,
+                 dry_run: bool) -> bool:
     """PATCH the existing marker comment in place (update or retract swap).
 
     ``gh pr comment --edit-last`` is not enough: the marker is not guaranteed
     to be the PR's last comment. The REST id from ``find_marker_entry``
-    addresses the comment directly.
+    addresses the comment directly. Returns True iff the write succeeded; a
+    non-zero rc is WARNed, never silently swallowed (#13623).
     """
     if dry_run:
-        return
+        return True
     with tempfile.NamedTemporaryFile(
         "w", suffix=".json", encoding="utf-8", delete=False
     ) as tf:
         json.dump({"body": body}, tf, ensure_ascii=False)
         tmp_path = tf.name
     try:
-        subprocess.run(
+        proc = subprocess.run(
             ["gh", "api", "--method", "PATCH",
              f"repos/{repo}/issues/comments/{comment_id}",
              "--input", tmp_path],
@@ -594,6 +607,14 @@ def edit_comment(repo: str, comment_id: str, body: str, dry_run: bool) -> None:
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
+    if proc.returncode != 0:
+        print(
+            f"WARN: write failed for #{number} — rc={proc.returncode}, "
+            f"{(proc.stderr or proc.stdout).strip()[:200]}",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 def label_strong_pairs(
@@ -826,18 +847,40 @@ def _cli(argv: list[str] | None = None) -> int:
         ),
         file=sys.stderr,
     )
+    confirmed: dict[str, int] = {}
     for a in plan:
         if a.verb == "none":
             continue
         print(f"  {prefix}{a.verb} #{a.number}", file=sys.stderr)
         if a.verb == "post":
-            post_comment(repo, a.number, a.body, args.dry_run)
+            ok = post_comment(repo, a.number, a.body, args.dry_run)
         else:  # update | retract: both are an in-place PATCH by comment id
-            edit_comment(repo, a.comment_id, a.body, args.dry_run)
+            ok = edit_comment(repo, a.number, a.comment_id, a.body, args.dry_run)
+        if ok:
+            confirmed[a.verb] = confirmed.get(a.verb, 0) + 1
 
     # Label both sides of every strong pair (#13615). In --same-issue-only
     # mode every posted collision is strong; otherwise re-derive the tier.
     label_strong_pairs(repo, result.strong_collisions, args.dry_run)
+
+    if not args.dry_run:
+        print(
+            "writes confirmed: "
+            + " ".join(
+                f"{v}={confirmed.get(v, 0)}" for v in ("post", "update", "retract")
+            ),
+            file=sys.stderr,
+        )
+        attempted = sum(counts.get(v, 0) for v in ("post", "update", "retract"))
+        ok_count = sum(confirmed.get(v, 0) for v in ("post", "update", "retract"))
+        failures = attempted - ok_count
+        if failures:
+            print(
+                "advisory: "
+                f"{failures} write(s) failed -- planned {attempted}, "
+                f"confirmed {ok_count}",
+                file=sys.stderr,
+            )
 
     return 0  # advisory: always green
 

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -15,10 +15,14 @@ nothing (#13615).
 """
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import subprocess as _subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "check_pr_path_collisions.py"
 _spec = importlib.util.spec_from_file_location("check_pr_path_collisions", _SCRIPT)
@@ -442,6 +446,76 @@ class TestGhRowExtraction(unittest.TestCase):
         self.assertEqual(row.base_ref, "main")
         self.assertEqual(row.head_ref, "feature/x")
         self.assertEqual(row.cited_issues(), {9})
+
+
+class TestWriteFailureReporting(unittest.TestCase):
+    """#13623 acceptance 4: a forced write failure is WARNed and not confirmed.
+
+    Positive control: the defect itself is that a non-zero rc is swallowed. A
+    test must force a non-zero rc and prove BOTH that the WARN appears AND that
+    the write reports failure (so the caller's ``confirmed`` count excludes it)
+    -- otherwise "no write fails" is indistinguishable from "failures are not
+    looked at".
+    """
+
+    @staticmethod
+    def _proc(rc: int, stderr: str, stdout: str = "") -> _subprocess.CompletedProcess:
+        return _subprocess.CompletedProcess(
+            args=[], returncode=rc, stdout=stdout, stderr=stderr
+        )
+
+    def _run(self, fn, *args, rc: int, stderr: str) -> tuple[bool, str]:
+        stderr_buf = io.StringIO()
+        with mock.patch.object(
+            _mod.subprocess, "run", return_value=self._proc(rc, stderr)
+        ):
+            with contextlib.redirect_stderr(stderr_buf):
+                ok = fn(*args, dry_run=False)
+        return ok, stderr_buf.getvalue()
+
+    def test_post_comment_warns_and_reports_failure(self):
+        ok, err = self._run(
+            _mod.post_comment, "repo", 123, "body", rc=1, stderr="gh: permission denied"
+        )
+        self.assertFalse(ok)
+        self.assertIn("WARN: write failed for #123", err)
+        self.assertIn("permission denied", err)
+
+    def test_edit_comment_warns_and_reports_failure(self):
+        stderr_buf = io.StringIO()
+        with mock.patch.object(
+            _mod.subprocess, "run", return_value=self._proc(1, "gh: rate limit")
+        ):
+            with contextlib.redirect_stderr(stderr_buf):
+                ok = _mod.edit_comment("repo", 123, "id456", "body", dry_run=False)
+        self.assertFalse(ok)
+        self.assertIn("WARN: write failed for #123", stderr_buf.getvalue())
+        self.assertIn("rate limit", stderr_buf.getvalue())
+
+    def test_post_comment_success_silent(self):
+        ok, err = self._run(
+            _mod.post_comment, "repo", 123, "body", rc=0, stderr=""
+        )
+        self.assertTrue(ok)
+        self.assertNotIn("WARN", err)
+
+    def test_edit_comment_success_silent(self):
+        stderr_buf = io.StringIO()
+        with mock.patch.object(
+            _mod.subprocess, "run", return_value=self._proc(0, "")
+        ):
+            with contextlib.redirect_stderr(stderr_buf):
+                ok = _mod.edit_comment("repo", 123, "id456", "body", dry_run=False)
+        self.assertTrue(ok)
+        self.assertNotIn("WARN", stderr_buf.getvalue())
+
+    def test_dry_run_never_calls_gh(self):
+        with mock.patch.object(
+            _mod.subprocess, "run", side_effect=AssertionError("gh must not run in dry-run")
+        ) as mocked:
+            ok = _mod.post_comment("repo", 123, "body", dry_run=True)
+            self.assertTrue(ok)
+            mocked.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/guard #13806

## Summary

`post_comment` / `edit_comment` de `scripts/check_pr_path_collisions.py` appelaient `subprocess.run(..., check=False)` **sans inspecter `returncode`**. Un POST/PATCH qui échoue — permission, commentaire supprimé à la main, rate limit, réseau — était **silencieux**, et le résumé comptait des actions **planifiées** comme des actions **réussies**. Un organe qui rend un compte-rendu de ce qu'il *voulait* faire se lit exactement comme un organe qui rend un compte-rendu de ce qu'il *a* fait.

Le fond de #13498 (le `update`/`retract` implémenté) est correct et a été mergé ; ce suivi porte le défaut signalé par NanoClaw et non traité là.

## Diagnostic dérive/C.4

N/A — script d'outillage, pas un notebook. Aucune sortie de cellule re-alignée.

## Acceptance #13623 (4/4)

1. **returncode inspecté + WARN** : `post_comment`/`edit_comment` émettent `WARN: write failed for #{number} — rc={rc}, {stderr tronqué à 200 car.}` sur rc non nul, et retournent `False`. (`scripts/check_pr_path_collisions.py:574,607`)
2. **Confirmé vs tenté** : le résumé (`_cli`) imprime désormais `writes confirmed: post=N update=N retract=N` **en plus** de la ligne `actions:` (tenté) — les deux comptes ne se mélangent plus. (`check_pr_path_collisions.py:878`
3. **Code de sortie** : reste 0 (organe advisory par contrat — un échec d'écriture ne doit pas rougir le run), et l'échec est écrit **explicitement au résumé** : `advisory: N write(s) failed -- planned X, confirmed Y`. C'est la branche de l'acceptance 3 qui autorise explicitement la voie *« si l'on préfère le garder advisory, l'écrit explicitement dans le résumé »*.
4. **Contrôle positif** : 5 tests dans `test_check_pr_path_collisions.py::TestWriteFailureReporting` — un `subprocess.run` mocké à rc **non nul** vérifie que le WARN apparaît **ET** que l'écriture rapporte l'échec (donc exclue du compte confirmé). Un rc 0 vérifie l'absence de faux WARN. `dry_run=True` vérifie que `gh` n'est jamais appelé. Sans ce contrôle, « aucune écriture n'échoue » serait indistinguable de « les échecs ne sont pas regardés » — le défaut lui-même, reproduit d'un cran.

## Validation

- `python -m unittest scripts.tests.test_check_pr_path_collisions` → **41 tests OK** (36 existants + 5 nouveaux)
- `python scripts/check_pr_path_collisions.py --self-test` → **SELF-TEST OK** (exit 0)
- `python scripts/check_pr_path_collisions.py --dry-run --limit 40` → **exit 0**, `actions: post=0 update=9 retract=3 none=6`, lignes `would-` présentes, aucune `writes confirmed` (correctement masquée en dry-run)
- `python -m py_compile` → OK
- 2 fichiers, 126+/9-.

## Scope

Un sujet, un fichier + ses tests. `label_strong_pairs` (qui émet déjà un WARN sur label échoué depuis #13615) n'est pas touché — le scope de l'issue est `post_comment`/`edit_comment`. Catalogue inchangé.

See #13623
