### PR TITLE
fix(search): retargeter les renvois App-12 -> App-14b dans Search-17

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb
@@ -3185,7 +3185,7 @@
     "\n",
     "La tranche 1 a comparé six paradigmes sur un problème de **satisfaction de contraintes**. Le projet étudiant distillé (cf. §9) en couvre deux autres ; cette tranche applique le même protocole au **Puissance 4** — un **jeu adversarial à somme nulle, information parfaite**.\n",
     "\n",
-    "Les algorithmes eux-mêmes (minimax, élagage alpha-beta, MCTS) sont enseignés en détail dans [`App-12-ConnectFour`](../Applications/Search/App-12-ConnectFour.ipynb) (moteur de jeu, baseline aléatoire, alpha-beta) et [`App-14-ConnectFour-Adversarial`](../Applications/Search/App-14-ConnectFour-Adversarial.ipynb) (minimax, alpha-beta, MCTS, benchmark mono-position). **Ce notebook ne les ré-enseigne pas** : il pose la question de la **sélection** — même harnais, même timeout, mêmes métriques, mais un terrain dont la nature change ce que « bien résoudre » veut dire.\n"
+    "Les algorithmes eux-mêmes (minimax, élagage alpha-beta, MCTS) sont enseignés en détail dans [`App-14b-ConnectFour`](../Applications/Search/App-14b-ConnectFour.ipynb) (moteur de jeu, baseline aléatoire, alpha-beta) et [`App-14-ConnectFour-Adversarial`](../Applications/Search/App-14-ConnectFour-Adversarial.ipynb) (minimax, alpha-beta, MCTS, benchmark mono-position). **Ce notebook ne les ré-enseigne pas** : il pose la question de la **sélection** — même harnais, même timeout, mêmes métriques, mais un terrain dont la nature change ce que « bien résoudre » veut dire.\n"
    ]
   },
   {
@@ -4453,7 +4453,7 @@
    "source": [
     "### 8.7 Renvois\n",
     "\n",
-    "- [`App-12-ConnectFour`](../Applications/Search/App-12-ConnectFour.ipynb) — moteur, baseline aléatoire, alpha-beta (cours détaillé).\n",
+    "- [`App-14b-ConnectFour`](../Applications/Search/App-14b-ConnectFour.ipynb) — moteur, baseline aléatoire, alpha-beta (cours détaillé).\n",
     "- [`App-14-ConnectFour-Adversarial`](../Applications/Search/App-14-ConnectFour-Adversarial.ipynb) — minimax, alpha-beta, MCTS et benchmark mono-position par profondeur.\n",
     "- Tranche 3/3 (Wordle — élimination bayésienne / entropie / CSP) : à venir, même protocole.\n"
    ]


### PR DESCRIPTION
## Summary

Le commit `07bf76093` (« reclass(search): App-12 ConnectFour devient App-14b/14c, companions de App-14 ») a renommé le notebook **App-12-ConnectFour** sur `main` **sans corriger les deux renvois** qui y pointaient depuis `Search-17-Empirical-Algorithm-Selection.ipynb` (cellules « ## 8. Deuxième terrain » et « ## 8.7 Renvois »). Il en résulte **2 navlinks cassées**, qui font échouer le garde `check-navlinks` sur **toute** PR dont l'arbre de merge les traverse — y compris le PR de sweep newline **#13606** (ma lane), bloqué par cette régression main-side alors que mon diff ne touche pas `Search-17`.

Ce PR retargete les deux liens vers `App-14b-ConnectFour.ipynb` (le notebook Python remplaçant, dans le même répertoire `Search/Applications/Search/`). Modif **markdown-only** : aucune cellule code ni output modifiée.

## Validation

- `python scripts/notebook_tools/check_notebook_navlinks.py --check` → `OK: 0 NEW broken navlink vs baseline` (exit 0).
- `python scripts/notebook_tools/validate_pr_notebooks.py origin/main MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb` → `1/1 passed (27 code cells)`.
- Pré-commit : tous hooks passés, dont H.3 (execution_count non null — notebook entièrement exécuté).

## Impact

Débloque **#13606** (que je répare par ailleurs) : sa dernière red restante était ce `check-navlinks` main-side. Après merge de ce fix, l'arbre de merge de #13606 porte les liens retargetés.

Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #13606
