### PR TITLE
feat(agentguard,#10473): AGENTGUARD005 — sync-over-async via GetAwaiter().GetResult()

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/AnalyzerReleases.Shipped.md
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 1.3.0
+
+- AGENTGUARD005 : `GetAwaiter().GetResult()` sur une expression de type `Task` ou `Task<T>` (analyse semantique du receiver ; exemption : la tache n'est pas `System.Threading.Tasks.Task`, donc les awaiters personnalises sont exempts)
+
 ## 1.2.0
 
 - AGENTGUARD004 : `CancellationToken` disponible mais omis lors d'un appel dont la signature cible expose explicitement ce type (analyse semantique ; exemptions : token deja passe, aucune cible annulable, aucun token disponible, homonyme)

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/SyncOverAsyncAnalyzer.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Analyzers/SyncOverAsyncAnalyzer.cs
@@ -1,0 +1,104 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace AgentGuard.Analyzers;
+
+/// <summary>
+/// AGENTGUARD005 : blocage synchrone d'une Task via GetAwaiter().GetResult().
+///
+/// Quatrieme pattern typique du code genere par agent : appeler une tache
+/// asynchrone depuis du code synchrone en la bloquant par `.GetAwaiter()
+/// .GetResult()` au lieu de l'attendre (`await`). Meme consequence qu'
+/// AGENTGUARD001 (.Result / .Wait()) : deadlock potentiel en code d'agent --
+/// mais un pattern plus discret, parce que l'agent "voit" un appel de
+/// methode ordinaire et ne se doute pas qu'il traverse l'etat-majeur
+/// d'une tache.
+///
+/// La forme legitime est `await` ; la resolution de la valeur doit passer
+/// par le mecanisme d'attente, pas par la decompilation explicite de la
+/// machine a etats de la tache.
+///
+/// Formes LEGITIMES (a ne PAS signaler) :
+///   - `await tache`                  -- composition normale
+///   - `tache.GetAwaiter().GetResult()` -- UNIQUEMENT si la tache n'est PAS
+///                                         issue de `Task` ou `Task<T>` (un
+///                                         awaiter personnalise qui implemente
+///                                         `INotifyCompletion` n'a pas le
+///                                         pattern deadlock du TaskAwaiter)
+///   - `monAwaiterPerso.GetResult()`  -- un awaiter custom peut avoir une
+///                                         semantique differente (par exemple
+///                                         synchrone-par-construction)
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SyncOverAsyncAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "AGENTGUARD005";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Blocage synchrone via GetAwaiter().GetResult()",
+        "GetAwaiter().GetResult() bloque une Task/{0} de maniere synchrone : remplacer par await",
+        "Agentisme",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Le code genere par agent qui synchronise une tache via .GetAwaiter().GetResult() expose au deadlock. Preferer await.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        // On s'abonne aux INVOCATIONS : le noeud syntaxique pertinent est
+        // l'appel a GetResult(). Le filtre syntaxique est "le membre est
+        // appele par un appel a GetAwaiter() sur une expression de type
+        // Task ou Task<T>" -- le type est verifie SEMANTIQUEMENT (pas de
+        // recherche par nom), ce qui evince les awaiters personnalises
+        // et les methodes homonymes.
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)
+    {
+        var inv = (InvocationExpressionSyntax)ctx.Node;
+
+        // 1. Filtre syntaxique bon marche : le membre invoque s'appelle
+        //    GetResult. Un awaiter custom peut s'appeler autrement, mais
+        //    la cible de ce diagnostic est precisement le pattern
+        //    canonique `.GetAwaiter().GetResult()` -- on accepte donc
+        //    de laisser passer les autres noms (ils relevent d'un autre
+        //    analyseur, ou ils sont exempts par construction).
+        if (inv.Expression is not MemberAccessExpressionSyntax member) return;
+        if (member.Name.Identifier.ValueText is not "GetResult") return;
+
+        // 2. Filtre syntaxique : le receiver du GetResult() est lui-meme
+        //    un appel a GetAwaiter() (forme canonique de la machine a etats
+        //    d'une tache). `monAwaiter.GetResult()` directement (sans
+        //    passer par GetAwaiter) echoue a ce filtre -- ce qui est
+        //    coherent : ce code appelle une methode sur une variable
+        //    deja awaiter, pas sur une tache.
+        if (member.Expression is not InvocationExpressionSyntax awaiterCall) return;
+        if (awaiterCall.Expression is not MemberAccessExpressionSyntax awaiterMember) return;
+        if (awaiterMember.Name.Identifier.ValueText is not "GetAwaiter") return;
+
+        // 3. Filtre semantique : le type de l'expression sur laquelle
+        //    GetAwaiter() est appele est-il Task ou Task<T> ? On utilise
+        //    le modele semantique -- un `customAwaitable.GetAwaiter()`
+        //    ou `ValueTask<int>.GetAwaiter()` ne correspond PAS, le code
+        //    est alors legitime. C'est la cle anti-faux-positif.
+        var tacheExpr = awaiterMember.Expression;
+        var typeInfo = ctx.SemanticModel.GetTypeInfo(tacheExpr);
+        if (typeInfo.Type is not INamedTypeSymbol ct) return;
+        if (ct.MetadataName is not ("Task" or "Task`1")) return;
+        // Defence supplementaire : le namespace doit etre System.Threading.Tasks
+        // (evince un `Task` local qui porterait le meme nom simple).
+        if (ct.ContainingNamespace?.ToDisplayString() != "System.Threading.Tasks") return;
+
+        ctx.ReportDiagnostic(Diagnostic.Create(
+            Rule, inv.GetLocation(), ct.MetadataName));
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Demo/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Demo/Program.cs
@@ -93,3 +93,27 @@ public static class AgentCancellation
         System.Threading.CancellationToken cancellationToken = default)
         => Task.FromResult($"[LLM] {prompt}");
 }
+
+// Cinquieme terrain fautif (AGENTGUARD005) : variante syntaxique d'
+// AGENTGUARD001, meme defaut semantique. Au lieu de `.Result`, l'agent
+// decompile explicitement la machine a etats de la tache :
+// `tache.GetAwaiter().GetResult()`. Meme consequence en production
+// (deadlock sur un SynchronizationContext), mais un chemin syntaxique
+// distinct qui justifie un analyseur dedie -- AGENTGUARD001 ne regarde
+// que `.Result` / `.Wait()`. Diagnostic attendu sur la derniere ligne.
+public static class AgentSyncOverAsync
+{
+    // Genere par agent "pour eviter un await" : la tache est "synchronisee"
+    // en traversant manuellement la machine a etats. C'est exactement le
+    // defaut que AGENTGUARD005 attrape.
+    public static string ReponseSynchrone(string prompt)
+    {
+        return CallLlmAsync(prompt).GetAwaiter().GetResult();   // AGENTGUARD005
+    }
+
+    private static async Task<string> CallLlmAsync(string prompt)
+    {
+        await Task.Delay(50);
+        return $"[LLM] {prompt}";
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/Program.cs
@@ -60,6 +60,7 @@ foreach (var path in args)
             new AsyncVoidAnalyzer(),
             new TaskRunFireAnalyzer(),
             new CancellationTokenPropagationAnalyzer(),
+            new SyncOverAsyncAnalyzer(),
         ]);
 
     // Les erreurs de compilation empechent le modele semantique de resoudre
@@ -73,6 +74,7 @@ foreach (var path in args)
         AsyncVoidAnalyzer.DiagnosticId,         // AGENTGUARD002
         TaskRunFireAnalyzer.DiagnosticId,       // AGENTGUARD003
         CancellationTokenPropagationAnalyzer.DiagnosticId, // AGENTGUARD004
+        SyncOverAsyncAnalyzer.DiagnosticId,     // AGENTGUARD005
     };
     var diagnostics = (await withAnalyzers.GetAllDiagnosticsAsync())
         .Where(d => ids.Contains(d.Id))

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncAwaiterPersonnalise.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncAwaiterPersonnalise.cs
@@ -1,0 +1,43 @@
+// Faux positif pour AGENTGUARD005 : un awaiter personnalise peut exposer
+// une methode `GetResult()` qui n'a rien a voir avec la machine a etats
+// d'une Task. L'analyseur doit ignorer ce cas (le filtre semantique
+// verifie que le receiver du `GetAwaiter()` est bien de type
+// `System.Threading.Tasks.Task` ou `Task<T>` ; ici il est de type
+// `MonAwaitable`, donc on laisse passer).
+//
+// Verdict attendu : PROPRE (aucun diagnostic AGENTGUARD005).
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace AwaiterCustom;
+
+public readonly struct MonAwaitable
+{
+    private readonly int _valeur;
+    public MonAwaitable(int valeur) => _valeur = valeur;
+
+    public MonAwaiter GetAwaiter() => new MonAwaiter(_valeur);
+}
+
+public readonly struct MonAwaiter : INotifyCompletion
+{
+    private readonly int _valeur;
+    public MonAwaiter(int valeur) => _valeur = valeur;
+
+    public bool IsCompleted => true;
+    public int GetResult() => _valeur;
+    public void OnCompleted(Action continuation) => continuation();
+}
+
+public static class AgentAwaiterPersonnalise
+{
+    // Le code appelle `.GetAwaiter().GetResult()` mais sur un type qui
+    // n'est PAS `System.Threading.Tasks.Task`. L'analyseur ne doit PAS
+    // signaler -- un awaiter custom peut etre synchrone-par-construction.
+    public static int LireValeur()
+    {
+        MonAwaitable a = new MonAwaitable(7);
+        return a.GetAwaiter().GetResult();
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncCorrige.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncCorrige.cs
@@ -1,0 +1,22 @@
+// Version corrigee du terrain SyncOverAsyncFautif.cs : la methode est
+// declaree `async` et la tache est composee via `await`. Plus de
+// `.GetAwaiter().GetResult()` nulle part -- c'est la forme canonique
+// que l'analyseur laisse passer.
+//
+// Verdict attendu : PROPRE (aucun diagnostic AGENTGUARD005 ; AGENTGUARD001
+// ne s'applique pas non plus -- pas de .Result ni .Wait).
+
+using System;
+using System.Threading.Tasks;
+
+public static class AgentSyncOverAsyncCorrige
+{
+    // Le fix : methode async + await explicite. La tache est composee,
+    // ses exceptions sont observees par l'appelant, pas de blocage
+    // synchrone.
+    public static async Task<int> MesurerLatenceAsync()
+    {
+        await Task.Delay(100);
+        return 42;
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncFautif.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncFautif.cs
@@ -1,0 +1,24 @@
+// Terrain fautif pour AGENTGUARD005 : un agent genere du code "pour
+// simplifier" en remplacant un `await tache` par
+// `tache.GetAwaiter().GetResult()`. Le resultat est un blocage synchrone
+// d'une `Task` non-generique -- exactement le meme defaut qu'AGENTGUARD001
+// attrape via .Result, mais emprunte par un chemin syntaxique distinct
+// (GetAwaiter() est appele explicitement).
+//
+// Verdict attendu : 1 diagnostic AGENTGUARD005 sur la ligne
+// `Task.Delay(...).GetAwaiter().GetResult()`.
+
+using System;
+using System.Threading.Tasks;
+
+public static class AgentSyncOverAsyncFautif
+{
+    public static int MesurerLatence()
+    {
+        // Genere par agent "pour simplifier" : au lieu d'etre async, la
+        // methode "synchronise" la tache. C'est le defaut qu'AGENTGUARD005
+        // doit attraper au build.
+        Task.Delay(100).GetAwaiter().GetResult();   // AGENTGUARD005
+        return 42;
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncGenericFautif.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncGenericFautif.cs
@@ -1,0 +1,29 @@
+// Terrain fautif pour AGENTGUARD005 (variante Task<T>) : un agent
+// genere du code en "synchronisant" une tache qui rend une valeur. Le
+// pattern est identique a `SyncOverAsyncFautif.cs`, mais le type est
+// `Task<int>` au lieu de `Task` non-generique. L'analyseur doit
+// reconnaitre les deux formes via le filtre semantique
+// `Task` ou `Task<T>` (MetadataName `"Task"` ou `"Task\`1"`).
+//
+// Verdict attendu : 1 diagnostic AGENTGUARD005 sur la ligne
+// `CallLlmAsync(...).GetAwaiter().GetResult()`.
+
+using System;
+using System.Threading.Tasks;
+
+public static class AgentSyncOverAsyncGenericFautif
+{
+    public static string ReponseSynchrone(string prompt)
+    {
+        // Genere par agent "pour eviter un await" : la valeur est extraite
+        // en decompilant la machine a etats de la tache. C'est le defaut
+        // classique du code d'agent qui essaye de rester synchrone.
+        return AppelerLlmAsync(prompt).GetAwaiter().GetResult();   // AGENTGUARD005
+    }
+
+    private static async Task<string> AppelerLlmAsync(string prompt)
+    {
+        await Task.Delay(50);
+        return $"[LLM] {prompt}";
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncSansGetResult.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/AgentGuard.Verifier/samples/SyncOverAsyncSansGetResult.cs
@@ -1,0 +1,21 @@
+// Faux positif pour AGENTGUARD005 : un awaiter custom expose
+// `IsCompleted` mais pas `GetResult()` -- l'agent appelle `IsCompleted`
+// directement. La forme n'est pas `.GetAwaiter().GetResult()`, donc
+// l'analyseur laisse passer (le filtre syntaxique requiert GetResult).
+//
+// Verdict attendu : PROPRE (aucun diagnostic AGENTGUARD005).
+
+using System;
+using System.Threading.Tasks;
+
+public static class AgentSansGetResult
+{
+    // Pas de GetResult() dans la chaine -- l'agent n'a meme pas compile
+    // ce code en realite, mais la question est : si on ecrit
+    // `tache.GetAwaiter().IsCompleted`, est-ce que AGENTGUARD005 crie ?
+    // Non : le membre accede est IsCompleted, pas GetResult.
+    public static bool VerifierAchevement(Task<int> tache)
+    {
+        return tache.GetAwaiter().IsCompleted;
+    }
+}


### PR DESCRIPTION
# feat(agentguard,#10473): AGENTGUARD005 — sync-over-async via `.GetAwaiter().GetResult()`

Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/refactor #13797

## Résumé

Cinquième règle du garde-fou Roslyn AgentGuard (série *The Unexpected AI Stack: C#/.NET*, EPIC #10473 axe Roslyn). AGENTGUARD005 attrape le pattern `tache.GetAwaiter().GetResult()` lorsque la tache est de type `System.Threading.Tasks.Task` ou `Task<T>` — variante syntaxique d'AGENTGUARD001 (qui ne couvre que `.Result` / `.Wait()`), même défaut sémantique (deadlock sur SynchronizationContext, exceptions mal-observées).

## Détection

L'analyseur s'abonne aux `InvocationExpression` et applique trois filtres successifs :

1. **Syntaxique** : le membre invoqué s'appelle `GetResult` ET son receiver est lui-même une `InvocationExpression` dont le membre s'appelle `GetAwaiter`. La forme canonique `.GetAwaiter().GetResult()` est ainsi isolée des appels à un `GetResult()` sur une variable déjà awaiter.
2. **Sémantique** : le type de l'expression sur laquelle `GetAwaiter()` est appelé est résolu via `SemanticModel.GetTypeInfo`. Le diagnostic n'est posé que si le type est `INamedTypeSymbol` avec `MetadataName` `"Task"` ou `"Task\`1"` ET `ContainingNamespace.ToDisplayString() == "System.Threading.Tasks"`. Les awaiters personnalisés (custom `GetAwaiter()` qui retourne un type implémentant `INotifyCompletion` mais n'étant pas `Task`) sont exempts.
3. **Aucune heuristique de nom** : le diagnostic n'inspecte pas le nom de la méthode ou du receiver — tout repose sur la résolution sémantique de la chaîne `task.GetAwaiter().GetResult()`.

## Exemptions vérifiées

| Forme | Verdict | Pourquoi |
|---|---|---|
| `await tache` | PROPRE | l'instrument ne s'abonne pas à `AwaitExpression` |
| `tache.GetAwaiter().IsCompleted` | PROPRE | filtre syntaxique : le membre n'est pas `GetResult` |
| `monAwaitableCustom.GetAwaiter().GetResult()` | PROPRE | filtre sémantique : `monAwaitableCustom` n'est pas `Task`/`Task<T>` |
| `Task.Delay(100).GetAwaiter().GetResult()` | **AGENTGUARD005** | cas fautif canonique, `Task` non-générique |
| `CallLlmAsync(prompt).GetAwaiter().GetResult()` | **AGENTGUARD005** | variante `Task<T>`, `MetadataName == "Task\`1"` |

## Sortie dotnet

### Canal build (Demo)

```text
warning AGENTGUARD005: GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await [Program.cs(111,16)]
```

### Canal API Roslyn (Verifier) — diagnostic attendu/observé

| Sample | Attendu | Observé | Verdict |
|---|---|---|---|
| `SyncOverAsyncFautif.cs` (Task) | 1× AGENTGUARD005 | 1× AGENTGUARD005 @ 21:9 | ✓ |
| `SyncOverAsyncGenericFautif.cs` (Task<T>) | 1× AGENTGUARD005 | 1× AGENTGUARD005 @ 21:16 | ✓ |
| `SyncOverAsyncCorrige.cs` (await) | PROPRE | PROPRE | ✓ |
| `SyncOverAsyncAwaiterPersonnalise.cs` (custom awaiter) | PROPRE | PROPRE | ✓ |
| `SyncOverAsyncSansGetResult.cs` (no GetResult) | PROPRE | PROPRE | ✓ |

**Aucun faux positif sur les 4 autres analyseurs (AGENTGUARD001/002/003/004)** : leurs cas fautifs/corrigés/homonymes rendent les verdicts attendus.

## Outillage touché

| Fichier | Changement |
|---|---|
| `AgentGuard.Analyzers/SyncOverAsyncAnalyzer.cs` | **nouveau** — analyseur Roslyn 1.3.0 |
| `AgentGuard.Analyzers/AnalyzerReleases.Shipped.md` | section 1.3.0 ajoutée |
| `AgentGuard.Demo/Program.cs` | nouveau terrain fautif `AgentSyncOverAsync` ligne 111 |
| `AgentGuard.Verifier/Program.cs` | AGENTGUARD005 ajouté à `WithAnalyzers` + `ids[]` |
| `AgentGuard.Verifier/samples/SyncOverAsyncFautif.cs` | **nouveau** — Task fautif |
| `AgentGuard.Verifier/samples/SyncOverAsyncGenericFautif.cs` | **nouveau** — Task<T> fautif |
| `AgentGuard.Verifier/samples/SyncOverAsyncCorrige.cs` | **nouveau** — corrigé await |
| `AgentGuard.Verifier/samples/SyncOverAsyncAwaiterPersonnalise.cs` | **nouveau** — faux-positif awaiter custom |
| `AgentGuard.Verifier/samples/SyncOverAsyncSansGetResult.cs` | **nouveau** — faux-positif appel sans `GetResult` |

## Séquençage collision #13606

**Notebook 06 NON touché** dans cette PR. Critère #5 du claim : « modifier/ré-exécuter le notebook seulement depuis un `origin/main` intégrant #13606, afin de préserver son sweep LF transversal ». Vérification firsthand : `git log origin/main --grep=13606` = 0 résultat au moment de la livraison — #13606 n'est PAS encore sur main. Le notebook 06 sera enrichi dans une PR dédiée, post-merge #13606.

## Catalogue / traductions

Byte-identique à `main`. Aucun fichier `*.generated.{json,md}` touché, aucun `README.<lang>.md` modifié, aucun marqueur `CATALOG-STATUS` affecté.

## Sortie dotnet (build complet)

```text
$ dotnet build AgentGuard.Analyzers.csproj
La génération a réussi.
    0 Avertissement(s)
    0 Erreur(s)

$ dotnet build AgentGuard.Demo.csproj
... 6 Avertissement(s) -- 001 x2, 002, 003, 004, 005
    0 Erreur(s)

$ dotnet build AgentGuard.Verifier.csproj
La génération a réussi.
    0 Avertissement(s)
    0 Erreur(s)
```

`See #10473` (sous-grain E3 / AGENTGUARD005 de l'EPIC Aspire).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
