### PR TITLE
fix(notebook,#13625): réconcilier la règle de décision §5.7 avec la règle exécutée (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-25-InoculationRL.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-25-InoculationRL.ipynb
@@ -2365,8 +2365,9 @@
     "|---|---|\n",
     "| early < 2% **et** late ≥ 2% **et** ≥3/4 graines croissantes | **ONSET DYNAMIQUE (régime papier)** |\n",
     "| late ≥ 2× early **et** ≥3/4 graines croissantes | **ONSET DYNAMIQUE (signature montée)** |\n",
-    "| late > 2% sans montée majoritaire | ONSET STATIQUE MAINTENU |\n",
-    "| sinon | ABSENT / NON MONOTONE |"
+    "| late > 2% **et** ≥3/4 graines croissantes (hors régimes dynamiques ci-dessus : ni régime papier `early < 2% → late ≥ 2%`, ni signature montée `late ≥ 2× early`) | ONSET STATIQUE MAINTENU (plateau sous-seuil dynamique) |\n",
+    "| sinon | ABSENT / NON MONOTONE |\n",
+    "\n> **Nomenclature — « plateau » = sous-seuil dynamique.** Le verdict **ONSET STATIQUE MAINTENU** est celui de la règle **exécutée** (cell[32]) : `late > 2%` **et** ≥3/4 graines croissantes, **sans** signature d'onset dynamique (ni « régime papier », ni « montée ≥ 2× early », capturées par les deux lignes précédentes). « Plateau persistant » ne signifie donc pas une fréquence strictement plate : c'est l'**absence de signature dynamique** qui qualifie le verdict — le hack émis reste bas (sub-2×, ~7-12 % ici) malgré un gradient qui le fait légèrement bouger. Cette table aligne la prose sur la condition réellement implémentée ; l'issue #13625 a relevé que la formulation pré-enregistrée « sans montée majoritaire » ne correspondait pas au `inc ≥ 3` du code.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #13764

See #13625 (divergence prose/code §5.7 — résolution côté prose, markdown-only)

## Diagnostic

La table « Règle de décision » de la §5.7 (cell[31], écrite avant le run) posait le verdict
**ONSET STATIQUE MAINTENU** sur la condition « `late > 2%` **sans montée majoritaire** ». Or la règle
**exécutée** (cell[32]) exige l'inverse — `elif med_l > 0.02 and inc >= 3` : la montée majoritaire
(`inc >= 3`) est **requise**, pas absente. Les deux formulations étaient contradictoires, et la prose
contredisait aussi la table d'observations (cell[33]) où W (4/4 graines croissantes) et S (3/4) sont
tous deux classés ONSET STATIQUE MAINTENU.

## Résolution (markdown-only, C.2-exempt)

Aligner la prose de la §5.7 sur la règle réellement implémentée et observée :

- **Ligne ONSET STATIQUE MAINTENU** : `late > 2% et ≥3/4 graines croissantes, hors régimes dynamiques
  (ni régime papier `early < 2% → late ≥ 2%`, ni signature montée `late ≥ 2× early`)` — les deux
  signatures dynamiques étant capturées par les deux lignes précédentes.
- **Verbatim renommé** « plateau **sous-seuil dynamique** » + note de bas de tableau : « plateau »
  ne signifie pas une fréquence strictement plate (ce qui est le point soulevé par #13625 : un verdict
  nommé « plateau persistant » ne devrait pas requérir une montée) ; c'est l'**absence de signature
  dynamique** (sub-2×) qui qualifie le verdict — le hack émis reste bas (~7-12 % ici) malgré un gradient
  qui le fait légèrement bouger.

Le notebook redevient **interne cohérent** : prose == règle exécutée == observations (W/S → STATIQUE).

## Preuves de validation

- **Markdown-only** : `git diff` = 1 fichier, 3+/2-, **0 ligne** `outputs`/`execution_count`/`"cell_type": "code"` — les cellules code sont byte-identiques (exception C.2 : aucune modification de cellule code → aucune ré-exécution requise).
- **JSON + nbformat** : valide (44 cellules), `nbformat.validate` OK.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0`.
- **Navlinks** : `check_notebook_navlinks.py --family IIT --tracked-only` → 0 lien cassé (69 notebooks).
- **Pré-commit H.3** : PASS (aucun `execution_count` null sur les cellules code).
- **Catalogue** : byte-identique à main (inchangé).
- **Twin** : ICT-25 n'est pas un notebook twin → pas de gate #8057 / rebaseline requise.

## Hors périmètre (signalé)

La règle **exécutée** garde sa condition `inc >= 3`. Si l'arbitrage retient que la définition « plateau »
doit être **sans** condition de montée (`elif med_l > 0.02:` sans `inc >= 3`), c'est une modification de
**cellule code** (cell[32]) qui exige une **ré-exécution GPU 15h** — hors d'un cycle worker, à dispatcher.
Cette PR résout la divergence du côté prose (la seule modification markdown-only possible) et documente
la sémantique ; le choix code-vs-prose reste ouvert à ai-01.
