### PR TITLE
feat(knot,#2874): relier changeCrossing a mirrorCrossing + deriver changeCrossing_wf_preserves

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -2217,15 +2217,41 @@ def changeCrossing (c : PDCrossing) : PDCrossing where
   e3 := c.e3
   e4 := c.e2
 
+/-- `changeCrossing` est definitionnellement egal a `mirrorCrossing` : les deux
+permutent `e2 ↔ e4`. — Epic #2874, Phase 4. -/
+theorem changeCrossing_eq_mirrorCrossing (c : PDCrossing) :
+    changeCrossing c = mirrorCrossing c := rfl
+
+/-- Appliquer `changeCrossing` a tous les croisements d'un nœud. Comme
+`changeCrossing ≡ mirrorCrossing` (voir `changeCrossing_eq_mirrorCrossing`), cette
+operation coincide definitionnellement avec `Knot.mirror`. — Epic #2874, Phase 4. -/
+def Knot.changeCrossingAll (k : Knot) : Knot where
+  diagram := {
+    crossings := k.diagram.crossings.map changeCrossing
+    numEdges := k.diagram.numEdges
+  }
+
+/-- `Knot.changeCrossingAll` coincide definitionnellement avec `Knot.mirror`.
+— Epic #2874, Phase 4. -/
+theorem changeCrossingAll_eq_mirror (k : Knot) :
+    k.changeCrossingAll = k.mirror := rfl
+
+/-- `changeCrossing` preserve `KnotDiagram.wf`, derive de `mirror_wf_preserves` via la
+defeq `changeCrossing ≡ mirrorCrossing`. — Epic #2874, Phase 4. -/
+theorem changeCrossing_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
+    k.changeCrossingAll.diagram.wf = true := by
+  rw [changeCrossingAll_eq_mirror]
+  exact mirror_wf_preserves k h
+
 /-- Unknotting number: minimum crossing changes to reach the unknot. -/
 def Knot.unknottingNumber (k : Knot) : Nat := by
   exact sorry
-  -- BLOCKED: requires substantial infrastructure not yet in the project:
-  --   1. Crossing change operation on KnotDiagram (changeCrossing exists but no
-  --      well-formedness proof that the result is a valid diagram)
-  --   2. Minimization over equivalence classes (Knot.crossingNumber has same issue)
-  --   3. Reachability in a graph of diagrams
-  -- Phase 4+ target — out of scope for Phase 2
+  -- BLOQUE: requiert une infrastructure substantielle absente du projet :
+  --   1. Minimisation sur les classes d'equivalence (Knot.crossingNumber a le meme probleme)
+  --   2. Accessibilite dans un graphe de diagrammes
+  --   (L'operation de changement de croisement elle-meme est desormais justifiee par
+  --    `changeCrossing_wf_preserves`, derivee de `mirror_wf_preserves` — voir Epic #2874.)
+  -- Cible Phase 4+ — hors scope Phase 2
 
 /-! ## 8. Transfer arriere (scaffolding de recherche — Epic #2874, Phase 5 PR3)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -2147,14 +2147,39 @@ def changeCrossing (c : PDCrossing) : PDCrossing where
   e3 := c.e3
   e4 := c.e2
 
+/-- `changeCrossing` is definitionally equal to `mirrorCrossing` (both swap `e2 ↔ e4`).
+— Epic #2874, Phase 4. -/
+theorem changeCrossing_eq_mirrorCrossing (c : PDCrossing) :
+    changeCrossing c = mirrorCrossing c := rfl
+
+/-- Apply `changeCrossing` to all crossings of a knot. Since `changeCrossing ≡ mirrorCrossing`
+(see `changeCrossing_eq_mirrorCrossing`), this operation coincides definitionally with
+`Knot.mirror`. — Epic #2874, Phase 4. -/
+def Knot.changeCrossingAll (k : Knot) : Knot where
+  diagram := {
+    crossings := k.diagram.crossings.map changeCrossing
+    numEdges := k.diagram.numEdges
+  }
+
+/-- `Knot.changeCrossingAll` coincides definitionally with `Knot.mirror`. — Epic #2874, Phase 4. -/
+theorem changeCrossingAll_eq_mirror (k : Knot) :
+    k.changeCrossingAll = k.mirror := rfl
+
+/-- `changeCrossing` preserves `KnotDiagram.wf`, derived from `mirror_wf_preserves` via the
+definitionally-equal `changeCrossing ≡ mirrorCrossing`. — Epic #2874, Phase 4. -/
+theorem changeCrossing_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
+    k.changeCrossingAll.diagram.wf = true := by
+  rw [changeCrossingAll_eq_mirror]
+  exact mirror_wf_preserves k h
+
 /-- Unknotting number: minimum crossing changes to reach the unknot. -/
 def Knot.unknottingNumber (k : Knot) : Nat := by
   exact sorry
   -- BLOCKED: requires substantial infrastructure not yet in the project:
-  --   1. Crossing change operation on KnotDiagram (changeCrossing exists but no
-  --      well-formedness proof that the result is a valid diagram)
-  --   2. Minimization over equivalence classes (Knot.crossingNumber has same issue)
-  --   3. Reachability in a graph of diagrams
+  --   1. Minimization over equivalence classes (Knot.crossingNumber has same issue)
+  --   2. Reachability in a graph of diagrams
+  --   (The crossing-change operation itself is now justified by `changeCrossing_wf_preserves`,
+  --    derived from `mirror_wf_preserves` — see Epic #2874.)
   -- Phase 4+ target — out of scope for Phase 2
 
 /-! ## 8. Backward transfer (research scaffolding — Epic #2874, Phase 5 PR3)


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: MED/notebook-python #13820

See #2874 (EPIC knot_lean) — tranche changeCrossing/mirror (Phase 4, problème de fond adressé).

## Constat mesuré — le commentaire bloquant de `unknottingNumber` était partiellement faux

Le commentaire (Invariant.lean, item 1) affirmait : « Crossing change operation on KnotDiagram
(changeCrossing exists but **no well-formedness proof** that the result is a valid diagram) ».

Mesure firsthand (avant toute édition) :

| Assertion du commentaire | Effet mesuré |
|---|---|
| `changeCrossing` n'a pas de preuve de well-formedness | **FAUX** — `mirror_wf_preserves` (Basic.lean:549, cloture #8644) prouve `k.mirror.diagram.wf = true`, et `changeCrossing ≡ mirrorCrossing` (Basic.lean:181) **definitionnellement** (les deux permutent `e2 ↔ e4`) |
| `Knot.crossingNumber` a le même souci (item 2) | **VRAI** — minimisation sur classes d'équivalence absente (hors scope Phase 2) |
| Accessibilité dans un graphe de diagrammes (item 3) | **VRAI** — recherche de chemin non implémentée (hors scope Phase 2) |

Le steer coordinateur (changeCrossing = mirrorCrossing defeq, mirror_wf_preserves existe) est **confirmé**,
pas réfuté.

## Changements (FR/EN siblings, convention #4980)

Les **énoncés/preuves sont byte-identiques** entre `Invariant.lean` et `Invariant_en.lean` ; seules les
docstrings et le commentaire inline diffèrent (FR / EN).

1. **`changeCrossing_eq_mirrorCrossing`** — `changeCrossing c = mirrorCrossing c := rfl` : relie les deux
   (définitionnel).
2. **`Knot.changeCrossingAll`** — l'« opération de changement de croisement sur KnotDiagram » que l'item 1
   du commentaire croyait manquante.
3. **`changeCrossingAll_eq_mirror`** — `k.changeCrossingAll = k.mirror := rfl` (défeq, car
   `changeCrossing ≡ mirrorCrossing`).
4. **`changeCrossing_wf_preserves`** — dérivée de `mirror_wf_preserves` via `changeCrossingAll_eq_mirror` :
   `rw [changeCrossingAll_eq_mirror]; exact mirror_wf_preserves k h`.
5. **Commentaire `unknottingNumber` corrigé** — l'item 1 tombe (l'opération est désormais justifiée par
   `changeCrossing_wf_preserves`), les items 2/3 (minimisation, accessibilité) **restent**.

Aucune modification de `Basic.lean`/`Basic_en.lean` (le `mirror_wf_preserves` existant est réutilisé).
Aucun `sorry` ajouté ni déchargé.

## §B.1 — Compte de `sorry` réel (instrument canonique)

```bash
python scripts/lean/count_code_sorry.py --repo . --lake MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean --json
```

| | avant | après |
|---|---|---|
| `distinct_code_sorry` | **11** | **11** |
| `code_sorry` | 22 | 22 |
| `files` | 15 | 15 |

**Aucun `sorry` déchargé** (conforme au mandat : « Ne promettez pas un `sorry` déchargé »).
`distinct_code_sorry` reste **11**, sans crash du counter. (Ne pas utiliser `grep -c sorry` : il compte la
prose — `naive_sorry: 60` pour 11 réels sur ce lake.)

## §B.2 — `lake build SUCCESS` local (règle lean-merge-discipline)

`lake build` (knot_lean, toolchain v4.32.1, Mathlib prébuild central réutilisé — 8264 oleans) →
**« Build completed successfully (3010 jobs) »** (après ré-édition des 2 fichiers, incrémental, seuls les
modules changés + dépendants recompilés : `Knots.Invariant` / `Knots.Invariant_en` + agrégateurs).
Log local capturé ; commit `a6f71e4894`.

## §B.3 — Proof-integrity : **N/A** (écrit explicitement)

Le job `proof-integrity` (câblé par `lean-axiom.yml`) **n'atteint pas** knot_lean : l'entrée du lake y est
**commentée** (`lean-axiom.yml:21-22` : `# project-path: .../knot_lean`). Le gate CI du lake est porté par
`lean-knot.yml` (reusable `lean-build.yml`), `on: push` vers `main`. Aucun nouvel axiome interdit
(`native_decide.*`, `sorryAx`, `Classical.choice`) introduit — les nouveaux théorèmes sont prouvés par
`rfl`/`rw`/`exact` ; le seul `sorryAx` du module (dans `unknottingNumber`) est pré-existant et comptabilisé
par §B.1.

## Critères d'acceptation (dispatch)

- [x] Relier les deux : `changeCrossing = mirrorCrossing` (defeq, `rfl`) — `changeCrossing_eq_mirrorCrossing` + `changeCrossingAll_eq_mirror`
- [x] Dériver `changeCrossing_wf_preserves` de `mirror_wf_preserves`
- [x] Corriger le commentaire bloquant (item 1 tombe, items 2/3 restent)
- [x] FR/EN siblings (#4980) — énoncés/preuves byte-identiques, docstrings FR/EN
- [x] `count_code_sorry.py --json` avant/après dans le body (§B.1)
- [x] `lake build SUCCESS` + lien/log (§B.2)
- [x] Aucun `sorry` déchargé — `distinct_code_sorry` reste 11 (§B.1)

## Hors périmètre (respecté)

- Ne décharge pas `unknottingNumber` (minimisation + accessibilité = Phase 4+).
- Ne touche pas `Knot.crossingNumber` (même problème d'infrastructure).
- Ne modifie pas `LEAN_INVENTORY.md` / `README.md` (le compte de `sorry` reste 11, synchronisé).
- Pas de refonte de `Basic.lean`.

---

Sélection : mission coordinateur HIGH (dispatch inbox, DEEP/lean #2874) — priorité P1 sur le tirage.
