### PR TITLE
reclass(z3,#13765): demotion Z3-Python-07 en side Z3-Python-01b

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -259,13 +259,13 @@ La série joue un rôle charnière dans la famille SymbolicAI : elle **consomme*
 |---|----------|--------|---------|-----------|
 | **Fondations Z3-API (Python + jumeaux C#)** |   |   |   |   |
 | 01 | [Z3-Python-01-Introduction](SMT/Z3-API/Z3-Python-01-Introduction.ipynb) · [C#](SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb) | Python / .NET | Premier solve() : booléens, entiers, solveur, modèle | 3 |
+| 01b | [Z3-Python-01b-Style-Declaratif-Linq](SMT/Z3-API/Z3-Python-01b-Style-Declaratif-Linq.ipynb) | Python | Comparaison style impératif vs LINQ-like avec Z3 Python | 2 |
 | 02 | [Z3-Python-02-Sudoku](SMT/Z3-API/Z3-Python-02-Sudoku.ipynb) · [C#](SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb) | Python / .NET | Sudoku 9×9 par contraintes, propagation, unicité | 3 |
 | 03 | [Z3-Python-03-Tactics](SMT/Z3-API/Z3-Python-03-Tactics.ipynb) · [C#](SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb) | Python / .NET | Tactiques (simplify, solve-eq, bit-blast), combinaison de solveurs | 3 |
 | 04 | [Z3-Python-04-Strings-Regex](SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb) · [C#](SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb) | Python / .NET | Théorie des chaînes, regex, exemples Sphinx | 3 |
 | 05 | [Z3-Python-05-Quantifiers-Proofs](SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb) · [C#](SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb) | Python / .NET | Quantificateurs ∀/∃, preuve par instantiation, incomplétude | 3 |
 | 06 | [Z3-Python-06-Advanced-Optimization](SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb) · [C#](SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb) | Python / .NET | Optimisation MaxSAT, Optimize(), Pareto | 3 |
 | **Z3-API patterns impératifs (Python)** |   |   |   |   |
-| 07 | [Z3-Python-07-Style-Declaratif-Linq](SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb) | Python | Comparaison style impératif vs LINQ-like avec Z3 Python | 2 |
 | 08 | [Z3-Python-08-Ordonnancement](SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb) | Python | Ordonnancement de tâches, précédences, disjonctions | 3 |
 | 09 | [Z3-Python-09-Enigme-Einstein](SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb) | Python | Énigme d'Einstein, 5 maisons, 5 attributs × 5 valeurs | 3 |
 | 10 | [Z3-Python-10-Cryptarithmetic](SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb) | Python | Cryptarithmes SEND+MORE=MONEY, alphamétique | 3 |

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/README.md
@@ -49,6 +49,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3-Linq2Z3/](../Z3-Linq2Z3/README.md
 |---|----------|-------|------|--------|
 | 01 | [Introduction](Z3-Python-01-Introduction.ipynb) | `Solver`, `Int`/`Bool`/`Real`, sat/unsat, `Optimize` | ~30 min | PRODUCTION |
 | 01ᶜˢ | [Introduction (twin C# .NET)](Z3-Python-01-Introduction-Csharp.ipynb) | Parité .NET : même moteur Z3 via `Microsoft.Z3` (NuGet) | ~30 min | PRODUCTION |
+| 01b | [Du style déclaratif LINQ au solveur Z3](Z3-Python-01b-Style-Declaratif-Linq.ipynb) | Pont C# Z3.Linq ↔ pyz3 : `assert_and_track`, `unsat_core`, coloration de graphe (Australie) | ~30 min | PRODUCTION |
 | 02 | [Sudoku](Z3-Python-02-Sudoku.ipynb) | Sudoku comme CSP, `Distinct`, visualisation matplotlib | ~25 min | PRODUCTION |
 | 02ᶜˢ | [Sudoku (twin C# .NET)](Z3-Python-02-Sudoku-Csharp.ipynb) | Parité .NET : même moteur Z3, visualisation ASCII | ~25 min | PRODUCTION |
 | 03 | [Tactiques et théories](Z3-Python-03-Tactics.ipynb) | `Tactic`, `BitVec`, `Array` | ~35 min | PRODUCTION |
@@ -59,7 +60,6 @@ Une série sœur existe en C# : [SymbolicAI/Z3-Linq2Z3/](../Z3-Linq2Z3/README.md
 | 05ᶜˢ | [Quantificateurs et preuves (twin C# .NET)](Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb) | Parité .NET : `MkForall`, `MkExists`, réfutation, `ReasonUnknown` via `Microsoft.Z3` (NuGet) | ~35 min | PRODUCTION |
 | 06 | [Optimisation avancée](Z3-Python-06-Advanced-Optimization.ipynb) | Pareto, objectifs multiples, `Optimize` hiérarchique, MaxSAT | ~40 min | PRODUCTION |
 | 06ᶜˢ | [Optimisation avancée (twin C# .NET)](Z3-Python-06-Advanced-Optimization-Csharp.ipynb) | Parité .NET : `MkOptimize`, `MkMaximize`/`MkMinimize`, front de Pareto, `AssertSoft` (MaxSAT) via `Microsoft.Z3` (NuGet) | ~40 min | PRODUCTION |
-| 07 | [Du style déclaratif LINQ au solveur Z3](Z3-Python-07-Style-Declaratif-Linq.ipynb) | Pont C# Z3.Linq ↔ pyz3 : `assert_and_track`, `unsat_core`, coloration de graphe (Australie) | ~30 min | PRODUCTION |
 | 08 | [Ordonnancement (Job-Shop Scheduling)](Z3-Python-08-Ordonnancement.ipynb) | `Optimize.minimize`, contrainte disjonctive `Or(...)`, makespan minimal, diagramme de Gantt | ~35 min | PRODUCTION |
 | 09 | [L'énigme d'Einstein (Zebra puzzle)](Z3-Python-09-Enigme-Einstein.ipynb) | Encodage par position, `Distinct`, adjacences, satisfiabilité vs optimisation, unicité prouvée | ~30 min | PRODUCTION |
 | 10 | [Cryptarithmes (SEND + MORE = MONEY)](Z3-Python-10-Cryptarithmetic.ipynb) | `Int`, `Distinct`, équation positionnelle, propagation vs brute force, retenues déduites | ~25 min | PRODUCTION |

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01b-Style-Declaratif-Linq.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01b-Style-Declaratif-Linq.ipynb
@@ -5,9 +5,11 @@
    "id": "c01",
    "metadata": {},
    "source": [
-    "# Z3-Python 07 — Du style declaratif LINQ au solveur Z3 en Python\n",
+    "# Z3-Python-01b — Du style declaratif LINQ au solveur Z3 en Python\n",
     "\n",
-    "**Navigation** : [Z3-Python-06 >>](Z3-Python-06-Advanced-Optimization.ipynb) | [Index](README.md) | [Z3 C# (Z3.Linq) ->](../Z3-Linq2Z3/README.md)\n",
+    "**Navigation** : [Z3-Python-01 — Introduction <<](Z3-Python-01-Introduction.ipynb) | [Index](README.md) | [Z3 C# (Z3.Linq) ->](../Z3-Linq2Z3/README.md)\n",
+    "\n",
+    "*Compagnon de style déclaratif du module [Z3-Python-01 — Introduction](Z3-Python-01-Introduction.ipynb) : approfondissement optionnel de la lane Python, extension unilatérale documentée (aucun twin C#).*\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "\n",
     "\n",
-    "[← Serie Z3-Python](README.md) | [Z3-Python-07 (style declaratif LINQ) →](Z3-Python-07-Style-Declaratif-Linq.ipynb)\n",
+    "[← Serie Z3-Python](README.md) | [Z3-Python-06 (optimisation avancée) →](Z3-Python-06-Advanced-Optimization.ipynb)\n",
     "\n",
     "\n",
     "\n",

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -951,7 +951,7 @@ project:
     - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb"
     - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb"
     - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb"
-    - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb"
+    - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01b-Style-Declaratif-Linq.ipynb"
     - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb"
     - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb"
     - "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb"

--- a/scripts/notebook_tools/pedagogy_density_baseline.json
+++ b/scripts/notebook_tools/pedagogy_density_baseline.json
@@ -684,7 +684,7 @@
     "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb": 1646.846,
     "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb": 2437.364,
     "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb": 2267.0,
-    "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb": 1484.143,
+    "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01b-Style-Declaratif-Linq.ipynb": 1484.143,
     "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb": 735.667,
     "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb": 1115.429,
     "MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb": 879.0,


### PR DESCRIPTION
## Summary

Demotion de Z3-Python-07-Style-Declaratif-Linq en side **Z3-Python-01b** (fille Z3 de #5081, application #12375/#12933). Le style declaratif LINQ est une variante de style rattachee aux fondations API (niveau Solver/add/check du 01, verifie sur le contenu), pas un domaine SMT essentiel distinct.

## Changements (6 fichiers, +9/-7)

- `git mv` Z3-Python-07 -> Z3-Python-01b (outputs et code inchanges)
- cell0 : titre `Z3-Python 07` -> `Z3-Python-01b`, navlink prev 06 -> 01, ligne compagnon (convention 16b) documentant lextension unilaterale sans twin C#
- Z3-Python-08 : navlink prev re-ancre sur 06 (la lane principale devient 06 -> 08)
- READMEs Z3-API + SymbolicAI : ligne deplacee 07 -> 01b juste apres le 01
- `_quarto.yml` : chemin renomme (position inchangee : la lane Python 01-06 est absente du listing quarto, entree entre les twins C# et les notebooks Python-only)
- `pedagogy_density_baseline.json` : cle renommee, float preserve (anti-orphelin #13815, forward-compat avec #13826)

## Verification (criteres de l issue, 7/7)

1. Lane des numeros simples intacte — survol complet partage avec C#
2. Style LINQ accessible comme approfondissement optionnel ; **aucun twin C# cree** (aucun yaml twin_pairs.d pour 07 : z3-python-01..06 ont leurs twins, pas 07 — verifie)
3. Identifiant 01b conforme #12933 (precedent 16b/16c/16d/16e), extension unilaterale documentee (ligne compagnon)
4. Sweep 7 refs entrantes : 5 maj, `docs/archive/ledgers-reviews/2026-07-11-h4-sota-6112.md` (ledger historique, intouchable) + catalogue (regenere par catalog-drift CI, non modifie manuellement). README Z3-API audite fichier-entier : 28 notebooks disque / 28 lignes numerotees, 0 lien manquant, 0 disque-hors-README. README Linq2Z3 : 3 refs Z3-Python (04, prose serie soeur), aucune vers 07
5. `twin_pairs.d` : non applicable (pas de paire 07) ; `check_twin_parity.py` EXIT=0, 157 paires, unique DRIFT = ML-5 TimeSeries **preexistant sur main** (0 fichier ML dans ce diff)
6. Catalogue byte-identique a main
7. Markdown-only prouve : diff ipynb = cell0 uniquement (3 lignes source markdown), `execution_count`/outputs intacts, JSON valide, compteur exercices (2) preserve dans la ligne deplacee

check_notebook_navlinks : 4/4 OK (01b, 08, 01, 06). Pre-commit : tous hooks Passed (gitleaks, H.3, etc.).

Closes #13765
