### PR TITLE
fix(dl,#12992): retirer la stale ref _quarto.yml:689 du doublon 3.1-Retropropagation-From-Scratch

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -686,7 +686,6 @@ project:
     - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8d-Lean-Novikoff-Convergence.ipynb"
     - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb"
     - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.0-Theorie-Information.ipynb"
-    - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.1-Retropropagation-From-Scratch.ipynb"
     - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.1-Retropropagation.ipynb"
     - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.2-Optimisateurs.ipynb"
     - "MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.3-Regularisation.ipynb"


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #13723

fix(dl,#12992): retirer la stale ref `_quarto.yml:689` du doublon 3.1-Retropropagation-From-Scratch

## Acceptance #12992 — clôturée (deuxième moitié)

L'acceptance #12992 ("Cleanup: retirer le doublon orphelin 3.1-Retropropagation-From-Scratch.ipynb (superséde #12736)") a été traitée en deux temps :

1. **`git rm` du fichier orphelin** : commit `e9752f00e` (2026-08-25, MERGED, par `jsboige`). Le narratif annonçait "0 référence entrante (grep md/ipynb/json/yml + scripts/.github/docs)" — vérification **a posteriori** (c.799) montre que le grep a manqué `_quarto.yml`. **La sidebar du site Quarto publié (`_site`) référence encore le fichier absent.** Quarto génère une entrée vide ou un warning.

2. **Suppression de la nav stale `_quarto.yml:689`** : **cette PR**. Diff : 1 fichier, 1 ligne, -107 octets.

## Vérification firsthand c.799

- `git ls-files MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.1-Retropropagation-From-Scratch.ipynb` → vide (le `git rm` e9752f00e est complet côté disque).
- `git grep -n "3.1-Retropropagation-From-Scratch"` → 4 matches, classés :

| Fichier:ligne | Nature | Action |
|---|---|---|
| `_quarto.yml:689` | sidebar nav stale | **Retiré** par cette PR |
| `scripts/notebook_tools/check_duplicate_notebook_index.py:6` | commentaire narratif incident fondateur #12753 | Conservé (histoire) |
| `scripts/notebook_tools/check_duplicate_notebook_index.py:165` | test case anti-réintroduction | Conservé (garde-fou) |
| `scripts/notebook_tools/check_duplicate_notebook_index.py:182` | scenario self-test | Conservé (garde-fou) |

Les 3 références du detector sont des **garde-fous anti-réintroduction** (incident fondateur #12753 documenté). Pas des refs orphelines. **Laissées intactes.**

## Conformité règles

- Tell c.793-L1 ★ MAJEUR sustained : **JAMAIS nbformat roundtrip**, JAMAIS `Write`/lecture via notebook — j'ai utilisé `io.open(..., 'rb')` + `replace` + `io.open(..., 'wb')` pour préserver LF (Tell c.704-L1).
- Tell c.704-L1 ★ sustained : diff préservé LF (`CRLF count: 0, LF-only: 1043` après edit).
- Tell c.711-L1 sustained : force-push re-trigger PR gate non requis (première push).
- Tell c.898 ★★★ collision guard : `git worktree list` + `gh pr list --state all --search "12992"` + `git grep` vérifiés avant `git push` (PRs #12468/#13026/#12996/#12760 toutes visibles).

## G-VAR-3 adjacency strict — HELD attendu sans [G-VAR-3 OVERRIDE]

Le grain précédent narrow-po-2026 mergé est **#13723** (cycle c.782 MED/notebook-python CONTENU). G-VAR-3 strict adjacency : **LIGHT consecutive après MED dans le même genre** = bloqué sans `[G-VAR-3 OVERRIDE]` du coordinateur.

Cette PR **sera HELD** par le merge-gate. **C'est attendu** : le user m'a explicitement autorisé à livrer quand même (AskUserQuestion answer : "Indique au coordinateur ton blocage et livre stp") — l'utilisateur préfère un HELD propre avec GM signal qu'un narrow-honest WAIT supplémentaire.

## État MCP / narrow monotonie

- **MCP roo-state-manager DOWN** sustained c.797 → c.799 (3ᵉ cycle). Fallback gh-only (cette PR utilise uniquement `git` local + `gh` CLI).
- **Tell c.640 R5 narrow monotonie** : 23ᵉ cycle sustained avant cette PR.
- **Tell c.696-L1 narrow-attente consolidée** : 23ᵉ cycle sustained (#13685/#13723/#13813 0 FAILURE substance narrow-po-2026-owned).

## Backlink

`Closes #12992` (acceptance complète maintenant que la stale ref est retirée).
`See #12753` (incident fondateur qui a inspiré le detector, qui garde ses références comme anti-réintroduction).

## Coordonnées

- Branch: `feature/12992-quarto-staleref`
- Commit: `4b7cdee56`
- Worktree: `C:/dev/CoursIA-12992-staleref`
- Diff: 1 file, 1 deletion(-)
- Lane: `myia-po-2026:CoursIA-2`