### PR TITLE
docs(harness): gh auth switch autorisé pour les workers — la ligne rouge est le merge/close, pas le switch (rectification user)

### DIFF
--- a/.claude/commands/continue.md
+++ b/.claude/commands/continue.md
@@ -1,6 +1,6 @@
 # Continue - Cycle worker
 
-Reprendre le travail sur cette lane : lire les directives coordinateur, choisir la prochaine tache, livrer une PR, reporter. C'est le prompt du cron worker (30 min staggered). **Un worker ne lance JAMAIS `/coordinate`** (lecon #1502) : pas de merge, pas de `gh auth switch`, pas de close d'issue d'autrui.
+Reprendre le travail sur cette lane : lire les directives coordinateur, choisir la prochaine tache, livrer une PR, reporter. C'est le prompt du cron worker (30 min staggered). **Un worker ne lance JAMAIS `/coordinate`** (lecon #1502) : pas de merge, pas de close d'issue d'autrui. **`gh auth switch` est autorise et necessaire** (trousseau gh partage entre workspaces — mandat user 2026-08-31) : la ligne rouge est le merge/close d'autrui, pas le switch lui-meme.
 
 ## Workflow
 

--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -5,7 +5,7 @@ description: Cycle de coordination ai-01 (coordinateur UNIQUEMENT — jamais sur
 
 # Skill: Coordinate - Cycle coordinateur ai-01
 
-Cycle de coordination du cluster CoursIA. **Reserve au coordinateur ai-01** : un worker ne lance JAMAIS `/coordinate` (lecon #1502 phantom-merger — le cron worker execute `/continue`). Un worker ne merge pas et ne fait pas de `gh auth switch`.
+Cycle de coordination du cluster CoursIA. **Reserve au coordinateur ai-01** : un worker ne lance JAMAIS `/coordinate` (lecon #1502 phantom-merger — le cron worker execute `/continue`). Un worker ne merge pas et ne close pas l'issue d'autrui ; `gh auth switch` est autorise et necessaire (trousseau gh partage entre workspaces — mandat user 2026-08-31) : le switch n'est pas la ligne rouge, le merge/close l'est.
 
 **Target**: `$ARGUMENTS`
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/notebook-python #13702

## Summary

Rectification user 2026-08-31 (verbatim : « Quelle est cette règle fantasque que tu cites? Vous partagez un trousseau gh à plusieurs workspaces, les switchs ne sont pas qu'autorisés, ils sont nécessaires ») : la clause « pas de `gh auth switch` » attachée à la leçon #1502 dans le prompt du cron worker était une **généralisation néfaste** — elle a bloqué un push légitime ce jour (credential wincred roté vers `jsboigeEpita` après une session de notation ; le worker s'est interdit le switch qui débloquait, coût : un blocage signalé + intervention user).

La leçon #1502 (phantom-merger) vise le **merge** par un worker, pas la gestion du trousseau. Sur cette machine, plusieurs workspaces partagent le trousseau gh (`jsboige`, `jsboigeEpita`, comptes myia) — les switchs d'account sont une opération normale et nécessaire.

- [continue.md](.claude/commands/continue.md) : « pas de merge, pas de `gh auth switch`, pas de close d'issue d'autrui » → « pas de merge, pas de close d'issue d'autrui. `gh auth switch` est autorise et necessaire (trousseau gh partage entre workspaces — mandat user 2026-08-31) : la ligne rouge est le merge/close d'autrui, pas le switch lui-meme ».
- [coordinate/SKILL.md](.claude/skills/coordinate/SKILL.md) : « Un worker ne merge pas et ne fait pas de `gh auth switch` » → « Un worker ne merge pas et ne close pas l'issue d'autrui ; `gh auth switch` est autorise et necessaire ».

Les autres occurrences de `gh auth switch` dans le harnais (coordinator-discipline.md règle 1 = flux de merge ai-01 ; model-delegation.md n°6 = fenêtre sous-agent anti-race) décrivent des contextes distincts et restent inchangées.

## Validation

- Diff : 2 fichiers harnais, 1 ligne chacun (+2/−2), aucun autre changement.
- Les lignes rouges worker (jamais `/coordinate`, pas de merge, pas de close d'issue d'autrui) sont préservées mot pour mot.
- Catalogue : non touché.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
