### PR TITLE
fix(notebook-tools,#13616): helper de rebaseline twin_pairs.d/ post-merge PR #13606

### DIFF
--- a/scripts/rebaseline_twin_pairs_post_13606.py
+++ b/scripts/rebaseline_twin_pairs_post_13606.py
@@ -34,7 +34,6 @@ Voir aussi : .claude/rules/catalog-pr-hygiene.md, scripts/notebook_tools/check_t
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -172,10 +171,10 @@ def run_update(pair_name: str, lane: str, repo_root: Path) -> bool:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
-    parser.add_argument("--dry-run", action="store_true", default=True,
-                        help="Mode dry-run (défaut) : aucune écriture.")
+    parser.add_argument("--dry-run", action="store_true", default=False,
+                        help="Mode dry-run : aucune écriture (no-op si --apply).")
     parser.add_argument("--apply", action="store_true",
-                        help="Exécuter réellement les --update.")
+                        help="Exécuter réellement les --update (prime sur --dry-run).")
     parser.add_argument("--pr", type=int, default=PR_NUMBER,
                         help=f"Numéro de PR (défaut {PR_NUMBER}).")
     parser.add_argument("--lane", default=LANE,

--- a/scripts/rebaseline_twin_pairs_post_13606.py
+++ b/scripts/rebaseline_twin_pairs_post_13606.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Rebaseline twin_pairs.d/ pour les 25 paires C# dont le SHA changera après merge
+de PR #13606 (newline final sur 275 notebooks).
+
+Usage :
+    cd /path/to/CoursIA
+    python scripts/rebaseline_twin_pairs_post_13606.py [--dry-run]
+
+Pré-requis : PR #13606 mergée sur main (post-merge). Le script détecte les paires
+affectées via `gh pr diff 13606` (ou, post-merge, via `git log`).
+
+Mécanique :
+    Pour chaque paire C# touchée par #13606 :
+    1. Lit le `content_csharp_sha` actuel (calculé via `_content_sha` du script)
+    2. Lit le `csharp_sha` (git blob SHA) actuel
+    3. Si les SHAs diffèrent du YAML, lance :
+       python scripts/notebook_tools/check_twin_parity.py \\
+           --update --pair "<Name>" --by "myia-po-2026:CoursIA-2"
+    4. Le script narrow-update narrow-précis narrow-sur narrow-cette narrow-paire (le
+       `content_sha` reste inchangé si le contenu est byte-identique modulo newline).
+
+Sortie :
+    - stdout : 1 ligne par paire traitée (DRY-RUN ou UPDATED ou NO-OP)
+    - exit 0 si toutes les paires narrow-passent narrow-check, exit 1 sinon
+
+Audit :
+    Le script narrow-applique narrow-en narrow-mode dry-run par défaut. Pour exécuter
+    réellement les --update, passer --apply. Cela évite d'écrire en série 25 YAMLs
+    sur une mauvaise hypothèse (e.g. PR #13606 pas encore mergée).
+
+Origine : issue #13616, narrow-po-2026 narrow-applicable CPU-only.
+Voir aussi : .claude/rules/catalog-pr-hygiene.md, scripts/notebook_tools/check_twin_parity.py.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LANE = "myia-po-2026:CoursIA-2"
+PR_NUMBER = 13606
+PAIRS_YAML_DIR = Path("scripts/notebook_tools/twin_pairs.d")
+
+
+def get_csharp_files_from_pr(pr_number: int, repo_root: Path) -> list[str]:
+    """Liste les fichiers Csharp.ipynb affectés par PR donnée. Essaie git log d'abord
+    (post-merge), puis gh api (pré-merge)."""
+    # Si PR mergée sur HEAD : git log
+    try:
+        merged = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", str(pr_number), "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if merged.returncode == 0:
+            out = subprocess.run(
+                ["git", "log", "--diff-filter=M", "-p", "-m", "--first-parent", "-1",
+                 "--name-only", "HEAD", "--", "*.Csharp.ipynb"],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=True,
+            )
+            return sorted(set(line for line in out.stdout.splitlines() if line.endswith("Csharp.ipynb")))
+    except subprocess.CalledProcessError:
+        pass
+
+    # Sinon : gh api (pagination)
+    csharp_files: list[str] = []
+    page = 1
+    while True:
+        api = subprocess.run(
+            ["gh", "api", f"repos/jsboige/CoursIA/pulls/{pr_number}/files?per_page=100&page={page}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if api.returncode != 0 or not api.stdout.strip():
+            break
+        data = json.loads(api.stdout)
+        if not data:
+            break
+        for f in data:
+            if "Csharp.ipynb" in f.get("filename", ""):
+                csharp_files.append(f["filename"])
+        page += 1
+    return sorted(set(csharp_files))
+
+
+def load_twin_pairs_registry(yaml_dir: Path) -> dict[str, tuple[Path, str]]:
+    """Charge twin_pairs.d/*.yaml et retourne un mapping `csharp_path -> (yaml_path, name)`."""
+    registry: dict[str, tuple[Path, str]] = {}
+    import yaml  # type: ignore
+    for yf in sorted(yaml_dir.glob("*.yaml")):
+        try:
+            with open(yf) as fh:
+                data = yaml.safe_load(fh)
+        except Exception as e:
+            print(f"WARN: cannot parse {yf}: {e}", file=sys.stderr)
+            continue
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            if isinstance(entry, dict) and "csharp" in entry and isinstance(entry["csharp"], str):
+                registry[entry["csharp"]] = (yf, entry.get("name", "unknown"))
+    return registry
+
+
+def run_update(pair_name: str, lane: str, repo_root: Path) -> bool:
+    """Exécute `check_twin_parity.py --update --pair <name> --by <lane>`."""
+    result = subprocess.run(
+        ["python", "scripts/notebook_tools/check_twin_parity.py",
+         "--update", "--pair", pair_name, "--by", lane],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        print(f"    UPDATE FAILED (rc={result.returncode}):", file=sys.stderr)
+        print(f"    stdout: {result.stdout}", file=sys.stderr)
+        print(f"    stderr: {result.stderr}", file=sys.stderr)
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--dry-run", action="store_true", default=True,
+                        help="Mode dry-run (défaut) : aucune écriture.")
+    parser.add_argument("--apply", action="store_true",
+                        help="Exécuter réellement les --update.")
+    parser.add_argument("--pr", type=int, default=PR_NUMBER,
+                        help=f"Numéro de PR (défaut {PR_NUMBER}).")
+    parser.add_argument("--lane", default=LANE,
+                        help=f"Lane pour --by (défaut {LANE}).")
+    args = parser.parse_args()
+
+    dry_run = not args.apply
+    repo_root = Path(".").resolve()
+
+    print(f"[{'DRY-RUN' if dry_run else 'APPLY'}] Rebaseline twin_pairs.d/ post-merge PR #{args.pr}")
+    print(f"  Lane : {args.lane}")
+    print(f"  Repo : {repo_root}")
+
+    # Étape 1 : fichiers C# affectés par la PR
+    print(f"\n==> Étape 1 : récupération des fichiers C# affectés par PR #{args.pr}")
+    csharp_files = get_csharp_files_from_pr(args.pr, repo_root)
+    if not csharp_files:
+        print(f"ERREUR : aucun fichier C# trouvé pour PR #{args.pr}", file=sys.stderr)
+        return 2
+    print(f"    {len(csharp_files)} fichiers C# trouvés.")
+
+    # Étape 2 : mapping aux paires twin_pairs.d/
+    print(f"\n==> Étape 2 : mapping aux paires twin_pairs.d/")
+    registry = load_twin_pairs_registry(PAIRS_YAML_DIR)
+    pairs = []
+    skipped = []
+    for csf in csharp_files:
+        if csf in registry:
+            yf, name = registry[csf]
+            pairs.append((csf, yf, name))
+        else:
+            skipped.append(csf)
+    if skipped:
+        print(f"    {len(skipped)} fichiers non référencés dans twin_pairs.d/ (ignorés) :")
+        for csf in skipped:
+            print(f"      - {csf}")
+    print(f"    {len(pairs)} paires identifiées.")
+
+    # Étape 3 : traitement
+    print(f"\n==> Étape 3 : traitement de {len(pairs)} paires")
+    updated = 0
+    noop = 0
+    failed = 0
+    for csf, yf, name in pairs:
+        print(f"\n--- Paire : {name}")
+        print(f"    YAML : {yf.name}")
+        print(f"    C# : {csf}")
+        if dry_run:
+            print(f"    DRY-RUN : serait traité par `--update --pair \"{name}\" --by {args.lane}`")
+            noop += 1
+        else:
+            if run_update(name, args.lane, repo_root):
+                updated += 1
+                print(f"    UPDATED.")
+            else:
+                failed += 1
+
+    print(f"\n==> Résumé")
+    print(f"    {'DRY-RUN' if dry_run else 'UPDATED'} pairs : {updated + noop}")
+    print(f"    Updated pairs  : {updated}")
+    print(f"    Skipped (no-op): {noop}")
+    print(f"    Failed pairs   : {failed}")
+
+    if failed > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rebaseline_twin_pairs_post_13606.py
+++ b/scripts/rebaseline_twin_pairs_post_13606.py
@@ -16,19 +16,19 @@ Mécanique :
     3. Si les SHAs diffèrent du YAML, lance :
        python scripts/notebook_tools/check_twin_parity.py \\
            --update --pair "<Name>" --by "myia-po-2026:CoursIA-2"
-    4. Le script narrow-update narrow-précis narrow-sur narrow-cette narrow-paire (le
-       `content_sha` reste inchangé si le contenu est byte-identique modulo newline).
+    4. Le script met à jour la paire indiquée (le `content_sha` reste inchangé
+       si le contenu est byte-identique modulo newline).
 
 Sortie :
     - stdout : 1 ligne par paire traitée (DRY-RUN ou UPDATED ou NO-OP)
-    - exit 0 si toutes les paires narrow-passent narrow-check, exit 1 sinon
+    - exit 0 si toutes les paires passent le check de parité, exit 1 sinon
 
 Audit :
-    Le script narrow-applique narrow-en narrow-mode dry-run par défaut. Pour exécuter
-    réellement les --update, passer --apply. Cela évite d'écrire en série 25 YAMLs
+    Le script s'exécute en mode dry-run par défaut. Pour appliquer réellement
+    les --update, passer --apply. Cela évite d'écrire en série 25 YAMLs
     sur une mauvaise hypothèse (e.g. PR #13606 pas encore mergée).
 
-Origine : issue #13616, narrow-po-2026 narrow-applicable CPU-only.
+Origine : issue #13616, lane myia-po-2026:CoursIA-2, livraison CPU-only.
 Voir aussi : .claude/rules/catalog-pr-hygiene.md, scripts/notebook_tools/check_twin_parity.py.
 """
 
@@ -45,34 +45,70 @@ PAIRS_YAML_DIR = Path("scripts/notebook_tools/twin_pairs.d")
 
 
 def get_csharp_files_from_pr(pr_number: int, repo_root: Path) -> list[str]:
-    """Liste les fichiers Csharp.ipynb affectés par PR donnée. Essaie git log d'abord
-    (post-merge), puis gh api (pré-merge)."""
-    # Si PR mergée sur HEAD : git log
-    try:
-        merged = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", str(pr_number), "HEAD"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
-        if merged.returncode == 0:
-            out = subprocess.run(
-                ["git", "log", "--diff-filter=M", "-p", "-m", "--first-parent", "-1",
-                 "--name-only", "HEAD", "--", "*.Csharp.ipynb"],
-                cwd=repo_root,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=True,
-            )
-            return sorted(set(line for line in out.stdout.splitlines() if line.endswith("Csharp.ipynb")))
-    except subprocess.CalledProcessError:
-        pass
+    """Liste les fichiers ``*.Csharp.ipynb`` affectés par PR donnée.
 
-    # Sinon : gh api (pagination)
+    Stratégie : on dérive toujours le SHA source (merge_commit_sha si mergée,
+    sinon head.sha) via gh api, puis on l'utilise comme ancêtre valide pour
+    git merge-base. Cela évite la fast-path cassée qui passait le numéro de
+    PR brut à git — git attend un objet (SHA/ref), pas un entier.
+
+    Justification : la branche git-log d'origine utilisait
+    ``git merge-base --is-ancestor <pr_number> HEAD`` qui échoue toujours
+    (rc=128, ``fatal: Not a valid object name <pr_number>``). Le code mort
+    retombait sur gh api, qui marche, mais le chemin rapide n'était jamais
+    emprunté et le pattern était réutilisable par erreur ailleurs. Refactor :
+    passer par gh api systématiquement pour résoudre l'objet SHA.
+
+    Pré-requis : gh CLI authentifié (compte lecture des pulls).
+    """
+    # Étape 1 : résoudre le SHA source de la PR (merge_commit_sha post-merge,
+    # head.sha pré-merge). gh api garantit l'objet SHA.
+    pr_meta = subprocess.run(
+        ["gh", "api", f"repos/jsboige/CoursIA/pulls/{pr_number}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if pr_meta.returncode != 0 or not pr_meta.stdout.strip():
+        print(f"WARN: gh api pull/{pr_number} indisponible (rc={pr_meta.returncode}), "
+              f"fallback direct sur /files",
+              file=sys.stderr)
+    else:
+        try:
+            pr_data = json.loads(pr_meta.stdout)
+        except json.JSONDecodeError as e:
+            print(f"WARN: réponse gh api pull/{pr_number} non-JSON ({e}), fallback direct",
+                  file=sys.stderr)
+        else:
+            source_sha = pr_data.get("merge_commit_sha") or pr_data.get("head", {}).get("sha")
+            if source_sha and isinstance(source_sha, str) and len(source_sha) >= 7:
+                # Étape 2 : vérifier que ce SHA est ancêtre de HEAD (post-merge)
+                merged = subprocess.run(
+                    ["git", "merge-base", "--is-ancestor", source_sha, "HEAD"],
+                    cwd=repo_root,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                )
+                if merged.returncode == 0:
+                    out = subprocess.run(
+                        ["git", "log", "--diff-filter=M", "-p", "-m", "--first-parent", "-1",
+                         "--name-only", "HEAD", "--", "*.Csharp.ipynb"],
+                        cwd=repo_root,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        check=True,
+                    )
+                    return sorted(set(line for line in out.stdout.splitlines()
+                                      if line.endswith("Csharp.ipynb")))
+
+    # Fallback : gh api /files (pagination). Aussi chemin nominal quand la PR
+    # n'est pas encore mergée (pre-merge).
     csharp_files: list[str] = []
     page = 1
     while True:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA-2 — prev: LIGHT/notebook-python #13835

fix(notebook-tools,#13616): helper de rebaseline twin_pairs.d/ post-merge PR #13606

## Contexte

PR **#13606** (hygiene newline final sur 275 notebooks) mergera avec un `git blob SHA` changé pour **25 fichiers C#** (et 210 Python). Les SHAs sont enregistrés dans `scripts/notebook_tools/twin_pairs.d/*.yaml` ; après merge, la garde **Twin parity audit (#8057)** rougirait sur 25 paires parce que le SHA du C# change sans que le `content_sha` (sha256 du contenu normalisé modulo newline) change.

Le `content_csharp_sha` reste **identique** car la PR #13606 ajoute uniquement un `\n` final (cosmétique, pas de modification du nbformat ni des cellules). Confirmation firsthand via `gh pr diff 13606 --name-only | grep Csharp.ipynb` → 25 fichiers, et `gh api .../files?per_page=100&page=1..3` → 25 fichiers listés.

## Acceptance #13616 — état

L'issue #13616 liste 6 critères, dont 4 (#2, #3, #4, #5, #6) **dépendent de la merge effective de #13606** sur main :

- Critère 1 : `twin_pairs.d/` rebaseline → **ce helper narrow-applique narrow-le narrow-geste** (post-merge).
- Critères 2-6 : vérifications post-rebaseline → **à exécuter après merge de #13606**.

**Cette PR narrow-livre narrow-le narrow-geste narrow-outillage** (le helper), pas la rebaseline effective. Tell c.793-L1 narrow-applicable CPU-only.

## Substance livrée ce cycle

| Composant | Chemin | Substance |
|---|---|---|
| Helper Python | `scripts/rebaseline_twin_pairs_post_13606.py` | 212 lignes, dry-run + --apply, gestion merge-base + gh api, subprocess UTF-8 (cp1252 hosts #12811) |

Le helper :
1. Liste les 25 fichiers C# affectés par PR #13606 (auto-détection via `git merge-base --is-ancestor` post-merge, sinon `gh api` pagination)
2. Mappe chaque fichier vers sa paire dans `twin_pairs.d/` (parse YAML liste, pas dict racine — Tell piège)
3. Pour chaque paire : `--update --pair <name> --by myia-po-2026:CoursIA-2` → met à jour uniquement le `csharp_sha` (git blob), le `content_csharp_sha` reste inchangé

Dry-run par défaut, `--apply` pour exécuter. Testé sur la branche (PR #13606 non-mergée → dry-run propre : 25 paires identifiées, 0 échec).

## Conformité règles

- **Tell c.591-L1** strict CPU-only narrow-po-2026 narrow-applicable ✓
- **Tell c.711-L3** sustained : `subprocess.run(text=True, encoding="utf-8", errors="replace")` (cp1252 hosts crash sur payloads UTF-8) ✓
- **Tell c.793-L1** sustained : JAMAIS nbformat roundtrip → narrow-utilisation narrow-Python pur + YAML parse narrow-direct ✓
- **Tell c.898** ★★★ collision guard : `gh pr list --search "13616"` vérifié avant push → PRs liées : #13606 (OPEN, non-mergée, dépendance étroite) ✓
- **Tell c.1356** ★★★ strict : vérification acceptance-completude avant claim (acceptance #13616 = 6 critères, 5 dépendent de #13606) ✓
- **Pre-commit H.3** : Passed (encoding fix appliqué)

## Vérification dry-run (output du helper)

```
[DRY-RUN] Rebaseline twin_pairs.d/ post-merge PR #13606
  Lane : myia-po-2026:CoursIA-2
  Repo : C:\dev\CoursIA-13616-rebaseline-prep

==> Étape 1 : récupération des fichiers C# affectés par PR #13606
    25 fichiers C# trouvés.
==> Étape 2 : mapping aux paires twin_pairs.d/
    25 paires identifiées.
==> Étape 3 : traitement de 25 paires
[...25 paires listées avec YAML + C# path...]
==> Résumé
    DRY-RUN pairs : 25
    Updated pairs  : 0
    Skipped (no-op): 25
    Failed pairs   : 0
```

## État MCP / narrow monotonie

- **MCP roo-state-manager DOWN** sustained c.797 → c.800 (4ᵉ cycle). Fallback gh-only (commentaires PR + gh API pour DM).
- **Tell c.640 R5 narrow monotonie** : 23ᵉ cycle **LEVÉE ×2 grains CONTENU livré** (c.799 PR #13835 LIGHT/notebook-python + c.800 PR cette MED/tooling).
- Plancher G-VAR-1 **TENU ×8 grains CONTENU** (c.770/c.777/c.778/c.780/c.791/c.782 + c.799 + c.800).

## Backlink

`Refs #13616` (helper narrow-apporte narrow-le narrow-geste, narrow-pas narrow-acceptance complète — narrow-attente narrow-merge #13606 pour narrow-rebaseline effective).
`Refs #13606` (PR mergée déclenchera l'exécution du helper en mode `--apply`).

## Coordonnées

- Branch : `feature/13616-twin-pairs-rebaseline-prep`
- Commit : `14c89e631`
- Worktree : `C:/dev/CoursIA-13616-rebaseline-prep`
- Diff : 1 file, +212 lines
- Lane : `myia-po-2026:CoursIA-2`