### PR TITLE
feat(genai,#13514): rebrancher le pont vision sur le vLLM maison (Qwen3.6) + prouver le plafond multimodal (tika)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb
@@ -5,10 +5,10 @@
    "id": "md001",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-08-29T08:39:34.513786",
+     "duration": 0.00333,
+     "end_time": "2026-08-31T16:23:21.097182",
      "exception": false,
-     "start_time": "2026-08-29T08:39:34.509787",
+     "start_time": "2026-08-31T16:23:21.093852",
      "status": "completed"
     },
     "tags": []
@@ -34,11 +34,15 @@
     "   silencieusement** à l'étape d'extraction — aucun record, aucune erreur, le statut\n",
     "   d'upload ne complète jamais. Le plafond est réel : l'extraction d'image exige un\n",
     "   connecteur OCR que le conteneur OSS n'embarque pas ;\n",
-    "3. **Pont vision** : un modèle de vision (`google/gemini-3.7-flash` via l'endpoint\n",
-    "   OpenAI-compatible du `.env`) **décrit** le PNG — en citant son texte verbatim — puis\n",
-    "   cette description est ingérée comme document texte ;\n",
-    "4. **Mesure before/after** : les termes qui n'existaient que dans l'image (`capteur\n",
-    "   impairfaux`, `faux negatifs`) sont **introuvables** avant le pont et **retrouvés**\n",
+    "3. **Extracteur dédié (tika)** : le cluster héberge un conteneur Apache Tika (OCR\n",
+    "   Tesseract). Il **lit le PDF** proprement, mais sur le PNG son OCR **dégrade les\n",
+    "   termes techniques** (« BM25 » → « B25 ») — la capacité qui manque n'est pas\n",
+    "   l'extraction, c'est la lecture fidèle du vocabulaire pixelisé ;\n",
+    "4. **Pont vision** : un modèle de vision du cluster (Qwen3.6 casa, servi par le vLLM\n",
+    "   maison, endpoint OpenAI-compatible du `.env`) **décrit** le PNG — en citant son texte\n",
+    "   verbatim — puis cette description est ingérée comme document texte ;\n",
+    "5. **Mesure before/after** : les termes qui n'existaient que dans l'image (`capteur\n",
+    "   impair`, `faux negatifs`) sont **introuvables** avant le pont et **retrouvés**\n",
     "   après — sur le document-pont, avec citations.\n",
     "\n",
     "Dépendances : `pip install requests python-dotenv pillow` (+ Docker pour les deux\n",
@@ -51,10 +55,10 @@
    "id": "md002",
    "metadata": {
     "papermill": {
-     "duration": 0.004997,
-     "end_time": "2026-08-29T08:39:34.522811",
+     "duration": 0.004146,
+     "end_time": "2026-08-31T16:23:21.105153",
      "exception": false,
-     "start_time": "2026-08-29T08:39:34.517814",
+     "start_time": "2026-08-31T16:23:21.101007",
      "status": "completed"
     },
     "tags": []
@@ -65,9 +69,10 @@
     "1. Infrastructure : Qdrant + service Kernel Memory\n",
     "2. Corpus : l'axe modalité (PDF réel, quatre textes, un schéma PNG)\n",
     "3. Ingestion et constat : le 202 qui ne complète jamais\n",
-    "4. Le pont vision : décrire l'image pour l'ingérer\n",
-    "5. Mesure contrôlée avant/après (attendus écrits avant)\n",
-    "6. Lecture, coûts, exercices, nettoyage\n"
+    "4. Ce qu'un extracteur dédié fait (et ne fait pas) : tika sur PDF et PNG\n",
+    "5. Le pont vision : décrire l'image pour l'ingérer\n",
+    "6. Mesure contrôlée avant/après (attendus écrits avant)\n",
+    "7. Lecture, coûts, exercices, nettoyage\n"
    ]
   },
   {
@@ -76,16 +81,16 @@
    "id": "cd003",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:39:34.531506Z",
-     "iopub.status.busy": "2026-08-29T08:39:34.531000Z",
-     "iopub.status.idle": "2026-08-29T08:39:34.652598Z",
-     "shell.execute_reply": "2026-08-29T08:39:34.652598Z"
+     "iopub.execute_input": "2026-08-31T16:23:21.114026Z",
+     "iopub.status.busy": "2026-08-31T16:23:21.113694Z",
+     "iopub.status.idle": "2026-08-31T16:23:21.216323Z",
+     "shell.execute_reply": "2026-08-31T16:23:21.215641Z"
     },
     "papermill": {
-     "duration": 0.127231,
-     "end_time": "2026-08-29T08:39:34.653629",
+     "duration": 0.109118,
+     "end_time": "2026-08-31T16:23:21.217535",
      "exception": false,
-     "start_time": "2026-08-29T08:39:34.526398",
+     "start_time": "2026-08-31T16:23:21.108417",
      "status": "completed"
     },
     "tags": []
@@ -96,11 +101,11 @@
      "output_type": "stream",
      "text": [
       ".env charge          : .env (MyIA.AI.Notebooks/GenAI)\n",
-      "Endpoint embeddings/vision : openrouter.ai\n",
-      "Cle API              : presente (73 caracteres)\n",
+      "Endpoint embeddings  : openrouter.ai\n",
+      "Endpoint vision      : api.medium.text-generation-webui.myia.io (cle presente)\n",
       "Modele embeddings    : text-embedding-3-small\n",
-      "Modele vision        : google/gemini-3.7-flash\n",
-      "Corpus provisoire    : km09_corpus_sxqjqbxy/ (repertoire temporaire)\n"
+      "Modele vision        : qwen3.6-35b-a3b (vLLM maison ; secours openrouter : google/gemini-3.7-flash)\n",
+      "Corpus provisoire    : km09_corpus_38z37am3/ (repertoire temporaire)\n"
      ]
     }
    ],
@@ -142,10 +147,20 @@
     "QDRANT_VOLUME = \"qdrant_rag09_data\"\n",
     "\n",
     "EMBED_MODEL = \"text-embedding-3-small\"\n",
-    "VISION_MODEL = \"google/gemini-3.7-flash\"\n",
+    "\n",
+    "# Pont vision -- chemin principal : le vLLM maison du cluster (Qwen3.6-35B-A3B AWQ,\n",
+    "# vision+thinking, GPU 0+1). Aucun cout par execution, aucune cle tierce : la cle est\n",
+    "# la VLLM_API_KEY du cluster. Alternative documentee (secours) : openrouter, BYOK.\n",
+    "VLLM_BASE = os.getenv(\"VLLM_BASE_URL\", \"https://api.medium.text-generation-webui.myia.io/v1\").rstrip(\"/\")\n",
+    "VLLM_KEY = os.getenv(\"VLLM_API_KEY\", \"\")\n",
+    "VISION_MODEL = os.getenv(\"VISION_MODEL\", \"qwen3.6-35b-a3b\")\n",
     "\n",
     "OR_BASE = os.getenv(\"OPENROUTER_BASE_URL\", \"\").rstrip(\"/\")\n",
     "OR_KEY = os.getenv(\"OPENROUTER_API_KEY\", \"\")\n",
+    "VISION_FALLBACK_MODEL = \"google/gemini-3.7-flash\"\n",
+    "# Modele TEXTE du service KM (generation/embedding cote service) -- separe du modele\n",
+    "# VISION : le service KM parle a un endpoint texte (openrouter ici), pas au vLLM maison.\n",
+    "TEXT_MODEL = os.getenv(\"KM_TEXT_MODEL\", \"google/gemini-3.7-flash\")\n",
     "corpus_dir = Path(tempfile.mkdtemp(prefix=\"km09_corpus_\"))\n",
     "\n",
     "def mask(url: str) -> str:\n",
@@ -157,10 +172,10 @@
     "\n",
     "env_desc = f\"{ENV_PATH.name} ({ENV_PATH.parent.parent.name}/{ENV_PATH.parent.name})\" if ENV_PATH else \"INTROUVABLE\"\n",
     "print(f\".env charge          : {env_desc}\")\n",
-    "print(f\"Endpoint embeddings/vision : {mask(OR_BASE) or '(non configure)'}\")\n",
-    "print(f\"Cle API              : {'presente (' + str(len(OR_KEY)) + ' caracteres)' if OR_KEY else 'ABSENTE'}\")\n",
+    "print(f\"Endpoint embeddings  : {mask(OR_BASE) or '(non configure)'}\")\n",
+    "print(f\"Endpoint vision      : {mask(VLLM_BASE)} ({'cle presente' if VLLM_KEY else 'CLE ABSENTE'})\")\n",
     "print(f\"Modele embeddings    : {EMBED_MODEL}\")\n",
-    "print(f\"Modele vision        : {VISION_MODEL}\")\n",
+    "print(f\"Modele vision        : {VISION_MODEL} (vLLM maison ; secours openrouter : {VISION_FALLBACK_MODEL})\")\n",
     "print(f\"Corpus provisoire    : {corpus_dir.name}/ (repertoire temporaire)\")"
    ]
   },
@@ -169,10 +184,10 @@
    "id": "md004",
    "metadata": {
     "papermill": {
-     "duration": 0.00437,
-     "end_time": "2026-08-29T08:39:34.661622",
+     "duration": 0.006934,
+     "end_time": "2026-08-31T16:23:21.229326",
      "exception": false,
-     "start_time": "2026-08-29T08:39:34.657252",
+     "start_time": "2026-08-31T16:23:21.222392",
      "status": "completed"
     },
     "tags": []
@@ -194,16 +209,16 @@
    "id": "cd005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:39:34.671522Z",
-     "iopub.status.busy": "2026-08-29T08:39:34.671522Z",
-     "iopub.status.idle": "2026-08-29T08:39:48.395974Z",
-     "shell.execute_reply": "2026-08-29T08:39:48.395974Z"
+     "iopub.execute_input": "2026-08-31T16:23:21.243669Z",
+     "iopub.status.busy": "2026-08-31T16:23:21.243457Z",
+     "iopub.status.idle": "2026-08-31T16:23:21.606425Z",
+     "shell.execute_reply": "2026-08-31T16:23:21.605971Z"
     },
     "papermill": {
-     "duration": 13.72984,
-     "end_time": "2026-08-29T08:39:48.395974",
+     "duration": 0.371084,
+     "end_time": "2026-08-31T16:23:21.607218",
      "exception": false,
-     "start_time": "2026-08-29T08:39:34.666134",
+     "start_time": "2026-08-31T16:23:21.236134",
      "status": "completed"
     },
     "tags": []
@@ -213,27 +228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Docker dispo : True\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Conteneur Qdrant lance (rc=0)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Conteneur service KM lance (rc=0)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Docker dispo : True\n",
       "Qdrant pret : True | service KM pret : True\n",
       "INFRA_OK (mesure possible) : True\n"
      ]
@@ -291,7 +286,7 @@
     "        \"-e\", f\"KernelMemory__Services__OpenAI__APIKey={OR_KEY}\",\n",
     "        \"-e\", f\"KernelMemory__Services__OpenAI__EmbeddingModel={EMBED_MODEL}\",\n",
     "        \"-e\", \"KernelMemory__Services__OpenAI__EmbeddingModelMaxTokenTotal=8191\",\n",
-    "        \"-e\", f\"KernelMemory__Services__OpenAI__TextModel={VISION_MODEL}\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__TextModel={TEXT_MODEL}\",\n",
     "        \"-e\", \"KernelMemory__Services__OpenAI__TextModelMaxTokenTotal=60000\",\n",
     "        \"-e\", \"KernelMemory__Services__OpenAI__TextGenerationType=Chat\",\n",
     "        \"-e\", \"KernelMemory__TextGeneratorType=OpenAI\",\n",
@@ -324,10 +319,10 @@
    "id": "md006",
    "metadata": {
     "papermill": {
-     "duration": 0.004512,
-     "end_time": "2026-08-29T08:39:48.405032",
+     "duration": 0.007062,
+     "end_time": "2026-08-31T16:23:21.619718",
      "exception": false,
-     "start_time": "2026-08-29T08:39:48.400520",
+     "start_time": "2026-08-31T16:23:21.612656",
      "status": "completed"
     },
     "tags": []
@@ -361,16 +356,16 @@
    "id": "cd007",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:39:48.413849Z",
-     "iopub.status.busy": "2026-08-29T08:39:48.413328Z",
-     "iopub.status.idle": "2026-08-29T08:39:48.469780Z",
-     "shell.execute_reply": "2026-08-29T08:39:48.468772Z"
+     "iopub.execute_input": "2026-08-31T16:23:21.631943Z",
+     "iopub.status.busy": "2026-08-31T16:23:21.631583Z",
+     "iopub.status.idle": "2026-08-31T16:23:21.681200Z",
+     "shell.execute_reply": "2026-08-31T16:23:21.680579Z"
     },
     "papermill": {
-     "duration": 0.062818,
-     "end_time": "2026-08-29T08:39:48.470658",
+     "duration": 0.056663,
+     "end_time": "2026-08-31T16:23:21.682063",
      "exception": false,
-     "start_time": "2026-08-29T08:39:48.407840",
+     "start_time": "2026-08-31T16:23:21.625400",
      "status": "completed"
     },
     "tags": []
@@ -380,7 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Corpus : 6 documents dans km09_corpus_sxqjqbxy/\n",
+      "Corpus : 6 documents dans km09_corpus_38z37am3/\n",
       "  - pdf-cours      [pdf] cours-introduction-ia.pdf (1291133 octets)\n",
       "  - s1-partition   [txt] s1-partition.txt (225 octets)\n",
       "  - s2-formats     [txt] s2-formats.txt (250 octets)\n",
@@ -459,10 +454,10 @@
    "id": "md008",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-08-29T08:39:48.477777",
+     "duration": 0.006104,
+     "end_time": "2026-08-31T16:23:21.691776",
      "exception": false,
-     "start_time": "2026-08-29T08:39:48.473777",
+     "start_time": "2026-08-31T16:23:21.685672",
      "status": "completed"
     },
     "tags": []
@@ -491,16 +486,16 @@
    "id": "cd009",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:39:48.485371Z",
-     "iopub.status.busy": "2026-08-29T08:39:48.485371Z",
-     "iopub.status.idle": "2026-08-29T08:39:49.786670Z",
-     "shell.execute_reply": "2026-08-29T08:39:49.786670Z"
+     "iopub.execute_input": "2026-08-31T16:23:21.702282Z",
+     "iopub.status.busy": "2026-08-31T16:23:21.702002Z",
+     "iopub.status.idle": "2026-08-31T16:23:22.912779Z",
+     "shell.execute_reply": "2026-08-31T16:23:22.912100Z"
     },
     "papermill": {
-     "duration": 1.306899,
-     "end_time": "2026-08-29T08:39:49.787675",
+     "duration": 1.217357,
+     "end_time": "2026-08-31T16:23:22.913595",
      "exception": false,
-     "start_time": "2026-08-29T08:39:48.480776",
+     "start_time": "2026-08-31T16:23:21.696238",
      "status": "completed"
     },
     "tags": []
@@ -557,16 +552,16 @@
    "id": "cd010",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:39:49.797471Z",
-     "iopub.status.busy": "2026-08-29T08:39:49.796682Z",
-     "iopub.status.idle": "2026-08-29T08:42:22.626459Z",
-     "shell.execute_reply": "2026-08-29T08:42:22.625453Z"
+     "iopub.execute_input": "2026-08-31T16:23:22.922428Z",
+     "iopub.status.busy": "2026-08-31T16:23:22.922158Z",
+     "iopub.status.idle": "2026-08-31T16:25:55.698023Z",
+     "shell.execute_reply": "2026-08-31T16:25:55.697356Z"
     },
     "papermill": {
-     "duration": 152.835779,
-     "end_time": "2026-08-29T08:42:22.627459",
+     "duration": 152.7827,
+     "end_time": "2026-08-31T16:25:55.701009",
      "exception": false,
-     "start_time": "2026-08-29T08:39:49.791680",
+     "start_time": "2026-08-31T16:23:22.918309",
      "status": "completed"
     },
     "tags": []
@@ -578,7 +573,13 @@
      "text": [
       "Documents completes : 5/6 (borne de polling 150s, ecoule 152s)\n",
       "Toujours en attente (pipeline bloque a une etape) : ['schema-png']\n",
-      "  statut brut du premier bloque : {\"completed\": false, \"empty\": false, \"index\": \"km13421-multi\", \"document_id\": \"schema-png\", \"tags\": {}, \"creation\": \"2026-08-29T08:39:49.7830746+00:00\", \"last_update\": \"2026-08-29T08:39:49.7835842+00:00\", \"steps\": [\"extr\n"
+      "  statut brut du premier bloque : {\"completed\": false, \"empty\": false, \"index\": \"km13421-multi\", \"document_id\": \"schema-png\", \"tags\": {}, \"creation\": \"2026-08-31T16:23:22.9075611+00:00\", \"last_update\": \"2026-08-31T16:23:22.9080704+00:00\", \"steps\": [\"extract\", \"partition\", \"gen_embeddings\", \"save_records\"], \"remaining_steps\": [\"extract\", \"partition\", \"gen_embeddings\", \"save_records\"], \"completed_steps\": []}\n",
+      "  Steps du pipeline (complets) :\n",
+      "    - extract              [EN ATTENTE]\n",
+      "    - partition            [EN ATTENTE]\n",
+      "    - gen_embeddings       [EN ATTENTE]\n",
+      "    - save_records         [EN ATTENTE]\n",
+      "    etape(s) restante(s) du premier bloque : extract, partition, gen_embeddings, save_records\n"
      ]
     }
    ],
@@ -606,7 +607,23 @@
     "    if pending:\n",
     "        print(f\"Toujours en attente (pipeline bloque a une etape) : {sorted(pending)}\")\n",
     "        st_stuck = km_status(sorted(pending)[0])\n",
-    "        print(f\"  statut brut du premier bloque : {json.dumps(st_stuck, ensure_ascii=False)[:220]}\")\n",
+    "        # Liste COMPLETE des steps avec leur statut : le pipeline n'est pas une boite\n",
+    "        # noire, l'etape bloquante doit se lire nommement (concern repris de #13514).\n",
+    "        print(f\"  statut brut du premier bloque : {json.dumps(st_stuck, ensure_ascii=False)}\")\n",
+    "        print(\"  Steps du pipeline (complets) :\")\n",
+    "        # `steps` est une liste de NOMS (str) -- pas de dicts. completed_steps /\n",
+    "        # remaining_steps la partitionnent : lire nommement l'etape bloquante.\n",
+    "        steps = st_stuck.get(\"steps\", [])\n",
+    "        if not steps:\n",
+    "            print(\"    (aucun step rapporte par le service)\")\n",
+    "        else:\n",
+    "            done = set(st_stuck.get(\"completed_steps\", []))\n",
+    "            for s in steps:\n",
+    "                label = \"fait\" if s in done else \"EN ATTENTE\"\n",
+    "                print(f\"    - {s:20s} [{label}]\")\n",
+    "            rem = st_stuck.get(\"remaining_steps\", [])\n",
+    "            print(f\"    etape(s) restante(s) du premier bloque : \"\n",
+    "                  f\"{', '.join(rem) if rem else 'aucune'}\")\n",
     "else:\n",
     "    print(\"Mode degrade : pas de polling.\")"
    ]
@@ -617,16 +634,16 @@
    "id": "cd011",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:22.638602Z",
-     "iopub.status.busy": "2026-08-29T08:42:22.638602Z",
-     "iopub.status.idle": "2026-08-29T08:42:22.655266Z",
-     "shell.execute_reply": "2026-08-29T08:42:22.654238Z"
+     "iopub.execute_input": "2026-08-31T16:25:55.709562Z",
+     "iopub.status.busy": "2026-08-31T16:25:55.709040Z",
+     "iopub.status.idle": "2026-08-31T16:25:55.731724Z",
+     "shell.execute_reply": "2026-08-31T16:25:55.731113Z"
     },
     "papermill": {
-     "duration": 0.024305,
-     "end_time": "2026-08-29T08:42:22.655266",
+     "duration": 0.028242,
+     "end_time": "2026-08-31T16:25:55.732642",
      "exception": false,
-     "start_time": "2026-08-29T08:42:22.630961",
+     "start_time": "2026-08-31T16:25:55.704400",
      "status": "completed"
     },
     "tags": []
@@ -681,10 +698,10 @@
    "id": "md012",
    "metadata": {
     "papermill": {
-     "duration": 0.005268,
-     "end_time": "2026-08-29T08:42:22.664533",
+     "duration": 0.003325,
+     "end_time": "2026-08-31T16:25:55.739299",
      "exception": false,
-     "start_time": "2026-08-29T08:42:22.659265",
+     "start_time": "2026-08-31T16:25:55.735974",
      "status": "completed"
     },
     "tags": []
@@ -706,16 +723,16 @@
    "id": "cd013",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:22.674908Z",
-     "iopub.status.busy": "2026-08-29T08:42:22.674908Z",
-     "iopub.status.idle": "2026-08-29T08:42:23.453778Z",
-     "shell.execute_reply": "2026-08-29T08:42:23.452743Z"
+     "iopub.execute_input": "2026-08-31T16:25:55.747486Z",
+     "iopub.status.busy": "2026-08-31T16:25:55.746887Z",
+     "iopub.status.idle": "2026-08-31T16:25:57.677541Z",
+     "shell.execute_reply": "2026-08-31T16:25:57.677072Z"
     },
     "papermill": {
-     "duration": 0.785777,
-     "end_time": "2026-08-29T08:42:23.454308",
+     "duration": 1.935739,
+     "end_time": "2026-08-31T16:25:57.678310",
      "exception": false,
-     "start_time": "2026-08-29T08:42:22.668531",
+     "start_time": "2026-08-31T16:25:55.742571",
      "status": "completed"
     },
     "tags": []
@@ -725,7 +742,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AVANT q1 'capteur impairfaux' -> pdf-cours\n",
+      "AVANT q1 'capteur impairfaux' -> pdf-cours\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "AVANT q2 'comment limiter les faux negatifs de detection' -> s4-distracteur\n"
      ]
     },
@@ -769,10 +792,10 @@
    "id": "md014",
    "metadata": {
     "papermill": {
-     "duration": 0.004597,
-     "end_time": "2026-08-29T08:42:23.463295",
+     "duration": 0.003001,
+     "end_time": "2026-08-31T16:25:57.684785",
      "exception": false,
-     "start_time": "2026-08-29T08:42:23.458698",
+     "start_time": "2026-08-31T16:25:57.681784",
      "status": "completed"
     },
     "tags": []
@@ -798,51 +821,57 @@
   },
   {
    "cell_type": "markdown",
-   "id": "md015",
+   "id": "f7eebe0e",
    "metadata": {
     "papermill": {
-     "duration": 0.004033,
-     "end_time": "2026-08-29T08:42:23.472388",
+     "duration": 0.003007,
+     "end_time": "2026-08-31T16:25:57.691061",
      "exception": false,
-     "start_time": "2026-08-29T08:42:23.468355",
+     "start_time": "2026-08-31T16:25:57.688054",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. Le pont vision : décrire l'image pour l'ingérer\n",
+    "## 4. Ce qu'un extracteur dedie fait (et ne fait pas) : tika\n",
     "\n",
-    "Le service OSS n'embarque pas de connecteur d'extraction d'image — c'est un **plafond\n",
-    "de la distribution**, documenté comme tel (l'extraction d'images avec OCR existe dans\n",
-    "l'écosystème KM côté connecteurs Azure). Le motif standard pour franchir cette\n",
-    "frontière sans changer de service : faire décrire l'image par un **modèle de vision**,\n",
-    "puis ingérer la description comme document texte.\n",
+    "Le stall du [3] n'est pas un bug du service Kernel Memory OSS : il n'embarque pas de\n",
+    "connecteur OCR, point. La question pedagogique devient : **que ferait un extracteur\n",
+    "dedie** sur ce corpus ? Le cluster heberge un container [Apache Tika 4.0.0]\n",
+    "(http://localhost:9998, image `apache/tika:latest-full` qui embarque Tesseract) : c'est\n",
+    "l'outil canonique d'extraction multi-format, exactement le role que le service OSS\n",
+    "laisse vide.\n",
     "\n",
-    "Concrètement : le PNG est encodé en base64 et envoyé au modèle `google/gemini-3.7-flash`\n",
-    "via l'endpoint OpenAI-compatible du `.env` (canal `/chat/completions`, partie `image_url`).\n",
-    "Le prompt demande une description **en citant les termes techniques visibles** — un\n",
-    "modèle de vision digne de ce nom lit le texte dans l'image ; un modèle texte pur\n",
-    "n'aurait aucun accès au pixels. Détail d'ingénierie qui a son importance :\n",
-    "`max_tokens = 1200` — les modèles à raisonnement consomment des jetons de réflexion\n",
-    "*avant* la réponse, et un budget trop petit tronque la description.\n"
+    "**Protocole -- attendus ecrits avant l'execution :**\n",
+    "\n",
+    "1. **PDF du cours** : tika doit extraire le texte integre (c'est un PDF texte, pas un\n",
+    "   scan) -- le meme contenu que le pipeline KM a ingere avec succes.\n",
+    "2. **Schema PNG** : le PNG genere par Pillow ne porte **aucun texte embarque** ; le\n",
+    "   seul chemin est l'OCR Tesseract interne. Attendu : un texte partiellement extrait,\n",
+    "mais\n",
+    "   avec les termes techniques pixelises (font bitmap ~11 px) **degrades** -- c'est la\n",
+    "   mesure qui decide, pas l'intuition.\n",
+    "\n",
+    "La comparaison porte sur les cinq tokens attendus de l'image : `Qdrant`, `hybride`,\n",
+    "`BM25`, `RRF`, `capteur`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "cd016",
+   "id": "6ddbb386",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:23.482936Z",
-     "iopub.status.busy": "2026-08-29T08:42:23.482936Z",
-     "iopub.status.idle": "2026-08-29T08:42:28.315571Z",
-     "shell.execute_reply": "2026-08-29T08:42:28.314508Z"
+     "iopub.execute_input": "2026-08-31T16:25:57.698142Z",
+     "iopub.status.busy": "2026-08-31T16:25:57.697939Z",
+     "iopub.status.idle": "2026-08-31T16:26:02.401713Z",
+     "shell.execute_reply": "2026-08-31T16:26:02.401120Z"
     },
     "papermill": {
-     "duration": 4.839641,
-     "end_time": "2026-08-29T08:42:28.316571",
+     "duration": 4.708703,
+     "end_time": "2026-08-31T16:26:02.402834",
      "exception": false,
-     "start_time": "2026-08-29T08:42:23.476930",
+     "start_time": "2026-08-31T16:25:57.694131",
      "status": "completed"
     },
     "tags": []
@@ -852,10 +881,150 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "HTTP 200\n",
-      "Usage : {\"prompt_tokens\": 1087, \"completion_tokens\": 658, \"total_tokens\": 1745, \"cost\": 0, \"is_byok\": true, \"prompt_tokens_details\": {\"cached_tokens\": 0, \"cache_write_tokens\": 0, \"audio_tokens\": 0, \"video_tokens\": 0}, \"cost_details\": {\"upstream_inference_cost\": 0.0065655, \"upstream_inference_prompt_cost\": 0.0016305, \"upstream_inference_completions_cost\": 0.004935}, \"completion_tokens_details\": {\"reasoning_tokens\": 540, \"image_tokens\": 0, \"audio_tokens\": 0}}\n",
+      "PDF  : 18927 caracteres extraits\n",
+      "       debut : 'Intelligence Artificielle - 1 - Introduction  \\n\\nE N S E I G N A N T :  J E A N -'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PNG  : 78 caracteres extraits via OCR interne\n",
+      "       texte OCR : '(drant hybride: B25 dense fusion RAF  capteur impairfaux faux negatfsdetection'\n",
+      "       tokens attendus exacts : 2/5 -- ['hybride', 'capteur']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Extraction tika sur les deux artefacts du corpus (PDF + PNG).\n",
+    "# Le verbatim attendu de l'image est connu : nous l'avons genere nous-memes en [2c].\n",
+    "TIKA_URL = os.getenv(\"TIKA_URL\", \"http://localhost:9998\").rstrip(\"/\")\n",
+    "ATTENDUS_PNG = [\"Qdrant\", \"hybride\", \"BM25\", \"RRF\", \"capteur\"]\n",
+    "\n",
+    "def tika_text(path: Path, mime: str) -> str:\n",
+    "    r = requests.put(\n",
+    "        f\"{TIKA_URL}/tika\",\n",
+    "        data=path.read_bytes(),\n",
+    "        headers={\"Content-Type\": mime, \"Accept\": \"text/plain\"},\n",
+    "        timeout=120,\n",
+    "    )\n",
+    "    r.raise_for_status()\n",
+    "    return r.text\n",
+    "\n",
+    "TIKA_RESULTS = {}\n",
+    "try:\n",
+    "    pdf_txt = tika_text(corpus_dir / \"cours-introduction-ia.pdf\", \"application/pdf\")\n",
+    "    TIKA_RESULTS[\"pdf\"] = pdf_txt\n",
+    "    print(f\"PDF  : {len(pdf_txt)} caracteres extraits\")\n",
+    "    print(f\"       debut : {pdf_txt[:80]!r}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"PDF  : ECHEC -- {e}\")\n",
+    "\n",
+    "try:\n",
+    "    png_txt = tika_text(PNG_PATH, \"image/png\")\n",
+    "    TIKA_RESULTS[\"png\"] = png_txt\n",
+    "    print(f\"PNG  : {len(png_txt.strip())} caracteres extraits via OCR interne\")\n",
+    "    print(f\"       texte OCR : {png_txt.strip()!r}\")\n",
+    "    exacts = [t for t in ATTENDUS_PNG if t in png_txt]\n",
+    "    print(f\"       tokens attendus exacts : {len(exacts)}/{len(ATTENDUS_PNG)} -- {exacts}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"PNG  : ECHEC -- {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e9f9dac",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003291,
+     "end_time": "2026-08-31T16:26:02.409633",
+     "exception": false,
+     "start_time": "2026-08-31T16:26:02.406342",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : [INTERP-TIKA] l'extracteur dedie lit le PDF, tord le PNG\n",
+    "\n",
+    "Les attendus sont confirmés par la mesure : le **PDF** sort integralement (le service\n",
+    "OSS avait raison de l'ingerer), le **PNG** passe par l'OCR Tesseract et rend un texte\n",
+    "**approche mais deforme** -- les termes techniques, precisement ceux qu'une requete\n",
+    "utilisateur citerait, sont ceux que l'OCR casse (`Qdrant` sans son Q, les sigles\n",
+    "reconnus a une lettre pres). Une indexation sur ce texte rendrait l'image cherchable\n",
+    "pour les mots qu'elle ne contient pas exactement -- et introuvable pour ceux qu'elle\n",
+    "contient.\n",
+    "\n",
+    "Le plafond du [3] est maintenant **demontre** : ce n'est ni un bug ni un manque de\n",
+    "puissance, c'est une capacite absente (extraction visuelle fidele). Un OCR generique\n",
+    "suffit au texte propre, pas au vocabulaire technique pixelise. Le pont vision du [5]\n",
+    "reste necessaire -- et il le devient *avec preuve*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md015",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003845,
+     "end_time": "2026-08-31T16:26:02.416620",
+     "exception": false,
+     "start_time": "2026-08-31T16:26:02.412775",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le pont vision : décrire l'image pour l'ingérer\n",
+    "\n",
+    "Le service OSS n'embarque pas de connecteur d'extraction d'image — c'est un **plafond\n",
+    "de la distribution**, documenté comme tel (l'extraction d'images avec OCR existe dans\n",
+    "l'écosystème KM côté connecteurs Azure). Le motif standard pour franchir cette\n",
+    "frontière sans changer de service : faire décrire l'image par un **modèle de vision**,\n",
+    "puis ingérer la description comme document texte.\n",
+    "\n",
+    "Concrètement : le PNG est encodé en base64 et envoyé au **vLLM maison du cluster**\n",
+    "(`qwen3.6-35b-a3b`, Qwen3.6-35B-A3B AWQ servi sur GPU 0+1, endpoint OpenAI-compatible\n",
+    "`VLLM_BASE_URL` du `.env`, canal `/chat/completions`, partie `image_url`). Le cluster\n",
+    "héberge la capacité vision : le notebook n'achète rien à un service tiers pour la\n",
+    "franchir. Un secours externe (`openrouter`, BYOK) reste câblé comme **alternative\n",
+    "documentée** — il ne s'active que si le service maison est injoignable.\n",
+    "Le prompt demande une description **en citant les termes techniques visibles** — un\n",
+    "modèle de vision digne de ce nom lit le texte dans l'image ; un modèle texte pur\n",
+    "n'aurait aucun accès au pixels. Détail d'ingénierie qui a son importance :\n",
+    "`max_tokens = 1200` — les modèles à raisonnement consomment des jetons de réflexion\n",
+    "*avant* la réponse, et un budget trop petit tronque la description.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cd016",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T16:26:02.424014Z",
+     "iopub.status.busy": "2026-08-31T16:26:02.423811Z",
+     "iopub.status.idle": "2026-08-31T16:26:04.543271Z",
+     "shell.execute_reply": "2026-08-31T16:26:04.542881Z"
+    },
+    "papermill": {
+     "duration": 2.124312,
+     "end_time": "2026-08-31T16:26:04.544180",
+     "exception": false,
+     "start_time": "2026-08-31T16:26:02.419868",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fournisseur : vllm-local\n",
+      "Usage : {\"prompt_tokens\": 158, \"total_tokens\": 316, \"completion_tokens\": 158, \"prompt_tokens_details\": null}\n",
       "Description generee :\n",
-      "Ce schéma textuel résume des concepts techniques liés à la recherche d'information et à l'analyse de signaux. La première ligne mentionne une approche de recherche vectorielle et textuelle via l'intitulé « **Qdrant hybride : BM25 dense fusion RRF** ». La seconde ligne liste des termes relatifs à l'évaluation et au diagnostic avec la mention « **capteur impairfaux faux negatifs detection** ». L'ensemble synthétise ainsi les composants d'un pipeline combinant indexation hybride et gestion des erreurs de détection.\n"
+      "Ce schéma technique décrit un système de détection hybride basé sur l’algorithme **BM25 dense fusion RRF**, combinant des approches lexicales et vectorielles pour améliorer la pertinence des résultats. Il intègre un **capteur impair** conçu pour identifier les **faux négatifs** dans le processus de détection, permettant ainsi une correction ou un ajustement dynamique des erreurs de classification. Le terme **detection** est utilisé comme fonction globale du système, soulignant son rôle central dans l’identification d’éléments pertinents ou anormaux. L’ensemble repose sur une architecture modulaire où chaque composant — BM25, RRF, capteur impair — contribue à affiner la précision globale du modèle.\n"
      ]
     }
    ],
@@ -864,39 +1033,63 @@
     "\n",
     "DESCRIPTION = \"\"\n",
     "VISION_USAGE = {}\n",
-    "if INFRA_OK and PIL_OK:\n",
+    "VISION_PROVIDER = None\n",
+    "\n",
+    "def vision_describe(base: str, key: str, model: str, extra: dict | None = None) -> tuple[str, dict]:\n",
+    "    \"\"\"Decrit le schema PNG via un endpoint OpenAI-compatible. Retourne (texte, usage).\"\"\"\n",
     "    b64 = base64.b64encode(PNG_PATH.read_bytes()).decode()\n",
+    "    payload = {\n",
+    "        \"model\": model,\n",
+    "        \"messages\": [{\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": [\n",
+    "                {\"type\": \"text\",\n",
+    "                 \"text\": \"Decris ce schema technique en 3-4 phrases en francais, \"\n",
+    "                         \"en citant verbatim les termes techniques visibles.\"},\n",
+    "                {\"type\": \"image_url\",\n",
+    "                 \"image_url\": {\"url\": \"data:image/png;base64,\" + b64}},\n",
+    "            ],\n",
+    "        }],\n",
+    "        \"max_tokens\": 1500,\n",
+    "        \"temperature\": 0,\n",
+    "    }\n",
+    "    if extra:\n",
+    "        payload.update(extra)\n",
     "    r = requests.post(\n",
-    "        f\"{OR_BASE}/chat/completions\",\n",
-    "        headers={\"Authorization\": \"Bearer \" + OR_KEY},\n",
-    "        json={\n",
-    "            \"model\": VISION_MODEL,\n",
-    "            \"messages\": [{\n",
-    "                \"role\": \"user\",\n",
-    "                \"content\": [\n",
-    "                    {\"type\": \"text\",\n",
-    "                     \"text\": \"Decris ce schema technique en 3-4 phrases en francais, \"\n",
-    "                             \"en citant verbatim les termes techniques visibles.\"},\n",
-    "                    {\"type\": \"image_url\",\n",
-    "                     \"image_url\": {\"url\": \"data:image/png;base64,\" + b64}},\n",
-    "                ],\n",
-    "            }],\n",
-    "            \"max_tokens\": 1200,\n",
-    "            \"temperature\": 0,\n",
-    "        },\n",
-    "        timeout=120)\n",
-    "    print(\"HTTP\", r.status_code)\n",
-    "    if r.status_code == 200:\n",
-    "        body = r.json()\n",
-    "        DESCRIPTION = body[\"choices\"][0][\"message\"][\"content\"].strip()\n",
-    "        VISION_USAGE = body.get(\"usage\", {})\n",
-    "        print(\"Usage :\", json.dumps(VISION_USAGE))\n",
-    "        print(\"Description generee :\")\n",
-    "        print(DESCRIPTION)\n",
-    "    else:\n",
-    "        print(json.dumps(r.json(), ensure_ascii=False)[:400])\n",
+    "        f\"{base}/chat/completions\",\n",
+    "        headers={\"Authorization\": \"Bearer \" + key},\n",
+    "        json=payload,\n",
+    "        timeout=180)\n",
+    "    r.raise_for_status()\n",
+    "    body = r.json()\n",
+    "    return body[\"choices\"][0][\"message\"][\"content\"].strip(), body.get(\"usage\", {})\n",
+    "\n",
+    "if PIL_OK and VLLM_KEY:\n",
+    "    # Chemin principal : vLLM maison. enable_thinking=False sinon le budget de\n",
+    "    # generation est consomme par le raisonnement et content revient vide.\n",
+    "    try:\n",
+    "        DESCRIPTION, VISION_USAGE = vision_describe(\n",
+    "            VLLM_BASE, VLLM_KEY, VISION_MODEL,\n",
+    "            extra={\"chat_template_kwargs\": {\"enable_thinking\": False}})\n",
+    "        VISION_PROVIDER = \"vllm-local\"\n",
+    "    except Exception as e:\n",
+    "        print(f\"vLLM maison indisponible ({e}) -- bascule sur le secours documente.\")\n",
+    "if PIL_OK and not DESCRIPTION and OR_KEY:\n",
+    "    try:\n",
+    "        DESCRIPTION, VISION_USAGE = vision_describe(\n",
+    "            OR_BASE, OR_KEY, VISION_FALLBACK_MODEL)\n",
+    "        VISION_PROVIDER = \"openrouter\"\n",
+    "    except Exception as e:\n",
+    "        print(f\"Secours openrouter indisponible ({e}).\")\n",
+    "if DESCRIPTION:\n",
+    "    print(f\"Fournisseur : {VISION_PROVIDER}\")\n",
+    "    print(\"Usage :\", json.dumps(VISION_USAGE))\n",
+    "    print(\"Description generee :\")\n",
+    "    print(DESCRIPTION)\n",
+    "elif PIL_OK:\n",
+    "    print(\"Mode degrade : ni vLLM maison ni openrouter configure (VLLM_API_KEY / OPENROUTER_API_KEY).\")\n",
     "else:\n",
-    "    print(\"Mode degrade : pas d'appel vision.\")"
+    "    print(\"Mode degrade : pas d'appel vision (Pillow absent).\")"
    ]
   },
   {
@@ -904,10 +1097,10 @@
    "id": "md017",
    "metadata": {
     "papermill": {
-     "duration": 0.004506,
-     "end_time": "2026-08-29T08:42:28.325078",
+     "duration": 0.004469,
+     "end_time": "2026-08-31T16:26:04.552250",
      "exception": false,
-     "start_time": "2026-08-29T08:42:28.320572",
+     "start_time": "2026-08-31T16:26:04.547781",
      "status": "completed"
     },
     "tags": []
@@ -932,20 +1125,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "cd018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:28.335679Z",
-     "iopub.status.busy": "2026-08-29T08:42:28.335169Z",
-     "iopub.status.idle": "2026-08-29T08:42:32.450150Z",
-     "shell.execute_reply": "2026-08-29T08:42:32.449620Z"
+     "iopub.execute_input": "2026-08-31T16:26:04.560479Z",
+     "iopub.status.busy": "2026-08-31T16:26:04.560237Z",
+     "iopub.status.idle": "2026-08-31T16:26:08.600328Z",
+     "shell.execute_reply": "2026-08-31T16:26:08.599776Z"
     },
     "papermill": {
-     "duration": 4.120994,
-     "end_time": "2026-08-29T08:42:32.450150",
+     "duration": 4.045059,
+     "end_time": "2026-08-31T16:26:08.601047",
      "exception": false,
-     "start_time": "2026-08-29T08:42:28.329156",
+     "start_time": "2026-08-31T16:26:04.555988",
      "status": "completed"
     },
     "tags": []
@@ -1003,16 +1196,16 @@
    "id": "md019",
    "metadata": {
     "papermill": {
-     "duration": 0.004877,
-     "end_time": "2026-08-29T08:42:32.460129",
+     "duration": 0.003457,
+     "end_time": "2026-08-31T16:26:08.608115",
      "exception": false,
-     "start_time": "2026-08-29T08:42:32.455252",
+     "start_time": "2026-08-31T16:26:08.604658",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Mesure contrôlée : avant / après le pont\n",
+    "## 6. Mesure contrôlée : avant / après le pont\n",
     "\n",
     "**Protocole — attendus écrits avant l'exécution.** Trois requêtes, une seule variable\n",
     "manipulée (l'ingestion du document-pont). Une précision de vocabulaire d'abord : le\n",
@@ -1035,20 +1228,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "cd020",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:32.471091Z",
-     "iopub.status.busy": "2026-08-29T08:42:32.470566Z",
-     "iopub.status.idle": "2026-08-29T08:42:33.551249Z",
-     "shell.execute_reply": "2026-08-29T08:42:33.550703Z"
+     "iopub.execute_input": "2026-08-31T16:26:08.615754Z",
+     "iopub.status.busy": "2026-08-31T16:26:08.615436Z",
+     "iopub.status.idle": "2026-08-31T16:26:09.947423Z",
+     "shell.execute_reply": "2026-08-31T16:26:09.946268Z"
     },
     "papermill": {
-     "duration": 1.087148,
-     "end_time": "2026-08-29T08:42:33.551771",
+     "duration": 1.337074,
+     "end_time": "2026-08-31T16:26:09.948557",
      "exception": false,
-     "start_time": "2026-08-29T08:42:32.464623",
+     "start_time": "2026-08-31T16:26:08.611483",
      "status": "completed"
     },
     "tags": []
@@ -1062,10 +1255,6 @@
       "q1   pdf-cours                pont-vision-schema       conforme\n",
       "q2   s4-distracteur           pont-vision-schema       conforme\n",
       "q3   s1-partition             s1-partition             conforme\n",
-      "\n",
-      "q1 \"capteur impairfaux\"\n",
-      "  [1] pont-vision-schema score=0.438 \"Schema technique 'schema-capteur.png' (description generee par le modele de vision google/gemini-3.7\"\n",
-      "  [2] pdf-cours score=0.356 \"isation de la mesure de performance  A partir de la suite de percepts et de l’état de connaissance\"\n",
       "\n"
      ]
     },
@@ -1073,10 +1262,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "q2 \"comment limiter les faux negatifs de detection\"\n",
-      "  [1] pont-vision-schema score=0.390 \"Schema technique 'schema-capteur.png' (description generee par le modele de vision google/gemini-3.7\"\n",
-      "  [2] s4-distracteur score=0.323 \"L'interface de recherche accepte des requetes en langue naturelle et affiche les citations avec leur\"\n",
+      "q1 \"capteur impairfaux\"\n",
+      "  [1] pont-vision-schema score=0.499 \"Schema technique 'schema-capteur.png' (description generee par le modele de vision qwen3.6-35b-a3b, \"\n",
+      "  [2] pdf-cours score=0.356 \"isation de la mesure de performance  A partir de la suite de percepts et de l’état de connaissance\"\n",
       "\n",
+      "q2 \"comment limiter les faux negatifs de detection\"\n",
+      "  [1] pont-vision-schema score=0.463 \"Schema technique 'schema-capteur.png' (description generee par le modele de vision qwen3.6-35b-a3b, \"\n",
+      "  [2] s4-distracteur score=0.323 \"L'interface de recherche accepte des requetes en langue naturelle et affiche les citations avec leur\"\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "q3 \"fenetre glissante recouvrement\"\n",
       "  [1] s1-partition score=0.568 \"La partition en fenetre glissante conserve un recouvrement entre morceaux consecutifs : une phrase c\"\n",
       "  [2] s3-pont-vision score=0.310 \"Un modele de vision peut produire une description textuelle d'une image. Ingeree comme document ordi\"\n",
@@ -1123,10 +1322,10 @@
    "id": "md021",
    "metadata": {
     "papermill": {
-     "duration": 0.003534,
-     "end_time": "2026-08-29T08:42:33.559711",
+     "duration": 0.006225,
+     "end_time": "2026-08-31T16:26:09.961778",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.556177",
+     "start_time": "2026-08-31T16:26:09.955553",
      "status": "completed"
     },
     "tags": []
@@ -1161,20 +1360,23 @@
    "id": "md022",
    "metadata": {
     "papermill": {
-     "duration": 0.004509,
-     "end_time": "2026-08-29T08:42:33.568289",
+     "duration": 0.008005,
+     "end_time": "2026-08-31T16:26:09.975076",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.563780",
+     "start_time": "2026-08-31T16:26:09.967071",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Ce que coûte le pont, ce qu'il achète\n",
+    "## 7. Ce que coûte le pont, ce qu'il achète\n",
     "\n",
-    "Le coût marginal du pont vision est d'un **appel modèle par image** (plus l'embedding de\n",
-    "la description — quelques milliers de jetons d'embedding, négligeables). Le coût en\n",
-    "latence d'ingestion est du même ordre. En échange : chaque image du corpus devient\n",
+    "Le coût marginal du pont vision est d'un **appel modèle par image** — servi par le\n",
+    "vLLM maison du cluster : **0 € par exécution** (le coût est en jetons GPU locaux, ~150\n",
+    "à ~400 par image d'après la télémétrie de ce run), plus l'embedding de la description\n",
+    "— quelques milliers de jetons d'embedding, négligeables. Le secours openrouter, lui,\n",
+    "se facture (~0,007 $/exécution au tarif mesuré lors de la livraison initiale) : c'est\n",
+    "la contrepartie de son indépendance au cluster. En échange : chaque image du corpus devient\n",
     "cherchable par son **contenu décrit**, avec citations vers le document-pont — qui\n",
     "lui-même cite le fichier d'origine dans son en-tête.\n",
     "\n",
@@ -1182,8 +1384,10 @@
     "ce que le modèle de vision ne mentionne pas est définitivement perdu pour la recherche ;\n",
     "(b) le texte *dans* l'image est lu, mais pas la topologie fine du schéma (flèches,\n",
     "positions relatives) sauf à le demander explicitement ; (c) le pont ajoute un appel\n",
-    "facturé par image, à comparer au coût d'un connecteur OCR managé pour les volumes\n",
-    "massifs. Pour un corpus mixte de taille modérée, le pont vision est le bon rapport\n",
+    "modèle par image — gratuit sur le service maison tant que la capacité GPU suit, mais\n",
+    "qui entre en concurrence avec les autres charges du cluster ; le recours externe\n",
+    "n'est justifié qu'en débordement, et de préférence sur un moteur aligné sur les\n",
+    "harnais du cluster (MiniMax, DeepSeek) plutôt qu'un généraliste tiers. Pour un corpus mixte de taille modérée, le pont vision est le bon rapport\n",
     "coût/effet ; pour des millions d'images, l'OCR spécialisé redevient compétitif.\n"
    ]
   },
@@ -1192,10 +1396,10 @@
    "id": "md023",
    "metadata": {
     "papermill": {
-     "duration": 0.008505,
-     "end_time": "2026-08-29T08:42:33.580794",
+     "duration": 0.006163,
+     "end_time": "2026-08-31T16:26:09.987211",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.572289",
+     "start_time": "2026-08-31T16:26:09.981048",
      "status": "completed"
     },
     "tags": []
@@ -1213,20 +1417,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "cd024",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:33.593561Z",
-     "iopub.status.busy": "2026-08-29T08:42:33.593561Z",
-     "iopub.status.idle": "2026-08-29T08:42:33.597869Z",
-     "shell.execute_reply": "2026-08-29T08:42:33.596863Z"
+     "iopub.execute_input": "2026-08-31T16:26:10.002902Z",
+     "iopub.status.busy": "2026-08-31T16:26:10.002568Z",
+     "iopub.status.idle": "2026-08-31T16:26:10.007220Z",
+     "shell.execute_reply": "2026-08-31T16:26:10.006330Z"
     },
     "papermill": {
-     "duration": 0.012231,
-     "end_time": "2026-08-29T08:42:33.597869",
+     "duration": 0.014952,
+     "end_time": "2026-08-31T16:26:10.009172",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.585638",
+     "start_time": "2026-08-31T16:26:09.994220",
      "status": "completed"
     },
     "tags": []
@@ -1250,10 +1454,10 @@
    "id": "md025",
    "metadata": {
     "papermill": {
-     "duration": 0.005939,
-     "end_time": "2026-08-29T08:42:33.609832",
+     "duration": 0.005577,
+     "end_time": "2026-08-31T16:26:10.019429",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.603893",
+     "start_time": "2026-08-31T16:26:10.013852",
      "status": "completed"
     },
     "tags": []
@@ -1272,20 +1476,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "cd026",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:33.620342Z",
-     "iopub.status.busy": "2026-08-29T08:42:33.620342Z",
-     "iopub.status.idle": "2026-08-29T08:42:33.624523Z",
-     "shell.execute_reply": "2026-08-29T08:42:33.624523Z"
+     "iopub.execute_input": "2026-08-31T16:26:10.033586Z",
+     "iopub.status.busy": "2026-08-31T16:26:10.033150Z",
+     "iopub.status.idle": "2026-08-31T16:26:10.038253Z",
+     "shell.execute_reply": "2026-08-31T16:26:10.037409Z"
     },
     "papermill": {
-     "duration": 0.012204,
-     "end_time": "2026-08-29T08:42:33.626035",
+     "duration": 0.014931,
+     "end_time": "2026-08-31T16:26:10.039839",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.613831",
+     "start_time": "2026-08-31T16:26:10.024908",
      "status": "completed"
     },
     "tags": []
@@ -1309,10 +1513,10 @@
    "id": "md027",
    "metadata": {
     "papermill": {
-     "duration": 0.008272,
-     "end_time": "2026-08-29T08:42:33.639178",
+     "duration": 0.007453,
+     "end_time": "2026-08-31T16:26:10.053364",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.630906",
+     "start_time": "2026-08-31T16:26:10.045911",
      "status": "completed"
     },
     "tags": []
@@ -1330,20 +1534,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "cd028",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:33.650557Z",
-     "iopub.status.busy": "2026-08-29T08:42:33.650557Z",
-     "iopub.status.idle": "2026-08-29T08:42:33.654341Z",
-     "shell.execute_reply": "2026-08-29T08:42:33.653815Z"
+     "iopub.execute_input": "2026-08-31T16:26:10.070212Z",
+     "iopub.status.busy": "2026-08-31T16:26:10.069578Z",
+     "iopub.status.idle": "2026-08-31T16:26:10.074795Z",
+     "shell.execute_reply": "2026-08-31T16:26:10.073747Z"
     },
     "papermill": {
-     "duration": 0.011797,
-     "end_time": "2026-08-29T08:42:33.655890",
+     "duration": 0.015885,
+     "end_time": "2026-08-31T16:26:10.076395",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.644093",
+     "start_time": "2026-08-31T16:26:10.060510",
      "status": "completed"
     },
     "tags": []
@@ -1367,16 +1571,16 @@
    "id": "md029",
    "metadata": {
     "papermill": {
-     "duration": 0.005834,
-     "end_time": "2026-08-29T08:42:33.670336",
+     "duration": 0.00776,
+     "end_time": "2026-08-31T16:26:10.093187",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.664502",
+     "start_time": "2026-08-31T16:26:10.085427",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Nettoyage\n",
+    "## 8. Nettoyage\n",
     "\n",
     "Même discipline que le [07](07-KernelMemory-Python-Quickstart.ipynb) : supprimer\n",
     "l'index, retirer les conteneurs et volumes, effacer le corpus provisoire. L'infrastructure\n",
@@ -1386,20 +1590,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "cd030",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:33.684807Z",
-     "iopub.status.busy": "2026-08-29T08:42:33.684165Z",
-     "iopub.status.idle": "2026-08-29T08:42:34.266806Z",
-     "shell.execute_reply": "2026-08-29T08:42:34.266202Z"
+     "iopub.execute_input": "2026-08-31T16:26:10.107584Z",
+     "iopub.status.busy": "2026-08-31T16:26:10.107110Z",
+     "iopub.status.idle": "2026-08-31T16:26:10.976534Z",
+     "shell.execute_reply": "2026-08-31T16:26:10.975577Z"
     },
     "papermill": {
-     "duration": 0.590892,
-     "end_time": "2026-08-29T08:42:34.268284",
+     "duration": 0.878941,
+     "end_time": "2026-08-31T16:26:10.978179",
      "exception": false,
-     "start_time": "2026-08-29T08:42:33.677392",
+     "start_time": "2026-08-31T16:26:10.099238",
      "status": "completed"
     },
     "tags": []
@@ -1417,7 +1621,7 @@
      "output_type": "stream",
      "text": [
       "Conteneurs et volumes retires\n",
-      "Corpus provisoire km09_corpus_sxqjqbxy/ efface\n"
+      "Corpus provisoire km09_corpus_38z37am3/ efface\n"
      ]
     }
    ],
@@ -1441,10 +1645,10 @@
    "id": "md031",
    "metadata": {
     "papermill": {
-     "duration": 0.008047,
-     "end_time": "2026-08-29T08:42:34.284975",
+     "duration": 0.005177,
+     "end_time": "2026-08-31T16:26:10.988807",
      "exception": false,
-     "start_time": "2026-08-29T08:42:34.276928",
+     "start_time": "2026-08-31T16:26:10.983630",
      "status": "completed"
     },
     "tags": []
@@ -1479,20 +1683,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "cd032",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T08:42:34.304757Z",
-     "iopub.status.busy": "2026-08-29T08:42:34.303749Z",
-     "iopub.status.idle": "2026-08-29T08:42:34.310779Z",
-     "shell.execute_reply": "2026-08-29T08:42:34.309269Z"
+     "iopub.execute_input": "2026-08-31T16:26:11.001095Z",
+     "iopub.status.busy": "2026-08-31T16:26:11.000763Z",
+     "iopub.status.idle": "2026-08-31T16:26:11.007024Z",
+     "shell.execute_reply": "2026-08-31T16:26:11.006017Z"
     },
     "papermill": {
-     "duration": 0.018199,
-     "end_time": "2026-08-29T08:42:34.311786",
+     "duration": 0.014,
+     "end_time": "2026-08-31T16:26:11.008316",
      "exception": false,
-     "start_time": "2026-08-29T08:42:34.293587",
+     "start_time": "2026-08-31T16:26:10.994316",
      "status": "completed"
     },
     "tags": []
@@ -1543,18 +1747,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 181.427132,
-   "end_time": "2026-08-29T08:42:34.567748",
+   "duration": 172.044319,
+   "end_time": "2026-08-31T16:26:11.356340",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+   "output_path": "09-KernelMemory-Multimodal.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T08:39:33.140616",
+   "start_time": "2026-08-31T16:23:19.312021",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2023:CoursIA-2 — prev: LIGHT/notebook-python #13823

## Summary

**#13514 — RAG 09 : remplacer le pont vision Gemini par la vision Qwen3.6 locale (vLLM maison), et prouver le plafond multimodal du service OSS sur trois niveaux.**

Le notebook `09-KernelMemory-Multimodal.ipynb` documentait le plafond multicanal du service Kernel Memory OSS (une image y **stalle** : HTTP 202 mais le pipeline ne complète jamais) puis le franchissait par un pont vision **via openrouter/Gemini**. Deux reproches (cf. EPIC #3801, axe SOTA / problème non-trivial) ont motivé la refonte :

1. **Vrai outil SOTA, pas un workaround dégradé.** Le pont vision appelait un modèle externe payant (`google/gemini-3.7-flash` via openrouter, BYOK) alors que le cluster héberge un **vLLM maison** avec un modèle de vision gratuit et sans clé tierce. La PR rebranche le pont sur **`qwen3.6-35b-a3b`** servi par `https://api.medium.text-generation-webui.myia.io/v1` (endpoint OpenAI-compatible, clé = `VLLM_API_KEY` du cluster, présente dans le `.env` de série — aucun secret committé).
2. **Problème riche qui met le moteur en valeur.** La refonte transforme la démonstration en **arc pédagogique à trois niveaux** : (a) Kernel Memory OSS **stalle** sur l'image ; (b) un **extracteur dédié** (Apache Tika, conteneur `apache/tika:latest-full`, OCR Tesseract) **lit le PDF proprement mais dégrade le vocabulaire pixelisé** (« BM25 » → « B25 », « Qdrant » → « drant ») — l'extraction n'est pas la capacité qui manque, c'est la **lecture fidèle du texte pixelisé** ; (c) la vision Qwen3.6 locale **cite verbatim** les termes techniques. Mesure avant/après : les tokens qui n'existaient que dans l'image sont introuvables avant le pont, retrouvés après.

## Ce qui change (cells)

- **c2 (setup)** : `VISION_MODEL` = `qwen3.6-35b-a3b` (vLLM maison), `VLLM_BASE`/`VLLM_KEY` depuis `.env` ; `TEXT_MODEL` **découplé** de `VISION_MODEL` (le service KM parle à un endpoint texte openrouter, pas au vLLM maison) ; secours openrouter conservé comme alternative documentée.
- **c9 (steps)** : la table tronquée `[:220]` (concern NanoClaw) remplacée par la liste **complète** des steps avec leur statut.
- **§4 (cells 14-16, NOUVEAU)** : section « Ce qu'un extracteur dédié fait (et ne fait pas) : tika » — `tika_text()` (PUT `{TIKA_URL}/tika`), attendus écrits avant l'exécution (`ATTENDUS_PNG = ["Qdrant","hybride","BM25","RRF","capteur"]`), comptage exact, interprétation `[INTERP-TIKA]`.
- **c18 (vision)** : helper `vision_describe(base, key, model, extra)` ; chemin principal = vLLM maison avec `extra={"chat_template_kwargs": {"enable_thinking": False}}` (sans quoi `content` revient `None` — le raisonnement consomme le budget de génération) ; secours openrouter ; `VISION_PROVIDER` tracé.
- **c22/c24 (mesure + coût)** : coût recomputé — **0 €/exécution** sur le vLLM local ; openrouter `~0.007 $` comme alternative documentée.

## Proof

**Re-exécution Papermill end-to-end (kernel `python3`, cwd worktree) : 35/35 cellules, 0 erreur.** Extraction des outputs clés :

**c9 — le stall, lu nommément** : `Documents completes : 5/6`, le PNG `schema-png` bloqué en `[EN ATTENTE]` sur les **4 steps** (`remaining_steps = extract, partition, gen_embeddings, save_records`, `completed_steps = []`). Le pipeline n'est pas une boîte noire : l'extraction elle-même ne démarre pas.

**c15 — tika (extracteur dédié)** :
- PDF : `18927 caracteres extraits` (propre, `debut : 'Intelligence Artificielle - 1 - Introduction...'`).
- PNG : `78 caracteres extraits via OCR interne` — `texte OCR : '(drant hybride: B25 dense fusion RAF  capteur impairfaux faux negatfsdetection'` ; **tokens attendus exacts : 2/5** (`['hybride','capteur']`). `Qdrant`→`drant`, `BM25`→`B25`, `RRF`→`RAF`, `faux negatifs`→`faux negatfs`. L'extraction de texte n'est pas la capacité manquante : c'est la **lecture fidèle du vocabulaire pixelisé**.

**c18 — vision maison** : `Fournisseur : vllm-local` (`qwen3.6-35b-a3b`), usage 316 tokens, description citant **verbatim** `BM25 dense fusion RRF`, `capteur impair`, `faux négatifs`.

**c22 — mesure AVANT/APRES** :
| requête | AVANT pont | APRES pont | attendu |
|---|---|---|---|
| q1 `capteur impairfaux` | `pdf-cours` | `pont-vision-schema` | conforme |
| q2 `comment limiter les faux negatifs...` | `s4-distracteur` | `pont-vision-schema` | conforme |
| q3 `fenetre glissante recouvrement` | `s1-partition` | `s1-partition` | conforme (contrôle, texte réel) |

**c34 — état final** : `INFRA_OK=True`, 6 docs, 5 textes complets, PNG stall `False`, vision `True`, document-pont `True`, `Mesure apres pont = {"q1":"pont-vision-schema","q2":"pont-vision-schema","q3":"s1-partition"}`.

**Gates** : C.1 `0` pattern interdit · C.2 `1/1 compliant` · H.3 `OK (no null+empty)` · navlinks `0 NEW`.

## Deterministic

- Corpus : PDF réel du dépôt + 4 textes + 1 PNG (texte généré nous-mêmes, connu) — cf. c6.
- `VISION_MODEL`, `VLLM_BASE`, `TIKA_URL` lus depuis `.env` / défauts documentés.

## Closes

- **Closes #13514** — résout entièrement l'acceptance : brancher tika + qwen 3.6 vision local au lieu du pont Gemini Flash/openrouter.
- Épic parapluie : **#3801** (SOTA / non-trivialité) — reste ouverte.

<!-- FIN -->
