### PR TITLE
feat(genai): ajouter le bake-off ORT GenAI .NET

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10f_ORTGenAI_DotNet_BakeOff.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10f_ORTGenAI_DotNet_BakeOff.ipynb
@@ -1,0 +1,864 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c0-intro",
+   "metadata": {},
+   "source": [
+    "**Navigation** : [Index](README.md) | [<< Précédent](10e_LLamaSharp_DotNet_BakeOff.ipynb) | [Suivant >>](11_Quantization.ipynb)\n",
+    "\n",
+    "# 10f. ONNX Runtime GenAI : jambe finale du bake-off .NET\n",
+    "\n",
+    "**Durée estimée** : 45 minutes\n",
+    "**Prérequis** : notebooks [10d](10d_TensorSharp_DotNet_Inference.ipynb) et [10e](10e_LLamaSharp_DotNet_BakeOff.ipynb), C# asynchrone, notions ONNX\n",
+    "**Matériel du run de référence** : GPU NVIDIA RTX 3080 Ti Laptop 16 Go ; modèle ONNX Qwen3-4B int4 (block 128, ~2,8 Go) ; .NET Interactive (C#)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Charger un modèle LLM au format ONNX officiel (pas GGUF) avec **Microsoft.ML.OnnxRuntimeGenAI** et prouver que le backend CUDA est réellement actif.\n",
+    "2. Mesurer latence de chargement, TTFT (time to first token), débit décodé (tok/s) et taux de jetons `<pad>` — les quatre axes du bake-off [#12353](https://github.com/jsboige/CoursIA/issues/12353).\n",
+    "3. Reproduire le protocole exact des Phases 1 (TensorSharp, [#12645](https://github.com/jsboige/CoursIA/pull/12645)) et 2 (LLamaSharp, [#12759](https://github.com/jsboige/CoursIA/pull/12759)) : mêmes quatre invites, décodage greedy, budget de 96 jetons.\n",
+    "4. Compléter le tableau comparatif à trois moteurs et statuer go/no-go **par axe**.\n",
+    "\n",
+    "## Contexte\n",
+    "\n",
+    "Ce notebook est la **Phase 3** du bake-off #12353. Rappel des jambes déjà livrées (mesures committées, nous ne les recopions pas sans source) :\n",
+    "\n",
+    "| Phase | Moteur | Livrable | Résultat clé (mesure committée) |\n",
+    "|---|---|---|---|\n",
+    "| 1 | TensorSharp 3.2.1.0 (serveur HTTP distant, Gemma 4 E4B Q8_0) | [10d](10d_TensorSharp_DotNet_Inference.ipynb), PR #12645 | ~50 tok/s côté serveur mais **159/160 jetons `<pad>`** → inférence inutilisable en l'état (`RECOVERABLE-LOCAL`) |\n",
+    "| 2 | LLamaSharp 0.27.0 (binding llama.cpp, Qwen3-4B Q4_K_M in-process) | [10e](10e_LLamaSharp_DotNet_BakeOff.ipynb), PR #12759 | 353 jetons propres à **14,14 tok/s**, 0 jeton `<pad>` |\n",
+    "| 3 | **ONNX Runtime GenAI** (ce notebook) | — | mesures ci-dessous |\n",
+    "\n",
+    "**Différence de conditions à connaître avant de comparer** : le run LLamaSharp de référence s'est fait avec seulement 6,2 Go de VRAM libres (35/36 couches sur GPU) ; le présent run dispose des 16 Go complets. Les débits ne sont donc pas une comparaison contrôlée de moteurs, mais deux points de mesure documentés."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1-modele",
+   "metadata": {},
+   "source": [
+    "## 1. Le modèle : ONNX officiel GenAI-ready\n",
+    "\n",
+    "ORT GenAI ne lit **pas** les GGUF (format llama.cpp) : il consomme un dossier ONNX contenant le graphe (`model.onnx` + poids externes `model.onnx.data`), un `genai_config.json` (provider, hyperparamètres de recherche) et le tokenizer. Nous utilisons le dépôt Hugging Face [`onnx-community/Qwen3-4B-ONNX`](https://huggingface.co/onnx-community/Qwen3-4B-ONNX), variante `cuda-int4-kld-block-128` — **la même famille Qwen3-4B que la Phase 2**, quantifiée int4 par blocs de 128 pour l'exécution accélérée GPU.\n",
+    "\n",
+    "Téléchargement manuel équivalent (si la cellule suivante ne peut pas télécharger) :\n",
+    "\n",
+    "```powershell\n",
+    "huggingface-cli download onnx-community/Qwen3-4B-ONNX `\n",
+    "  --include \"onnxruntime/cuda/cuda-int4-kld-block-128/*\" `\n",
+    "  --local-dir models/qwen3-4b-ortgenai-cuda-int4\n",
+    "```\n",
+    "\n",
+    "La cellule suivante installe le package NuGet, résout le dossier du modèle (variable d'environnement `ORTGENAI_MODEL_DIR` pour un emplacement externe, sinon chemin relatif `models/…`, ignoré par git) et télécharge uniquement les fichiers manquants ou tronqués."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c2-setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": ""
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.OnnxRuntimeGenAI.Cuda</span></li></ul></div><div></div></div>"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "ORT natif 1.28 préchargé depuis le cache NuGet utilisateur.\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Modèle complet : models\\qwen3-4b-ortgenai-cuda-int4 (7 fichiers vérifiés)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  model.onnx                     0,5 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  model.onnx.data             2681,5 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  genai_config.json              0,0 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  config.json                    0,0 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  tokenizer.json                10,9 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  tokenizer_config.json          0,0 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  chat_template.jinja            0,0 Mo\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "VRAM au départ : 0 MiB\r\n"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.ML.OnnxRuntimeGenAI.Cuda, 0.15.2\"\n",
+    "\n",
+    "using System.Collections.Generic;\n",
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "using System.Linq;\n",
+    "using System.Net.Http;\n",
+    "using System.Runtime.InteropServices;\n",
+    "using Microsoft.ML.OnnxRuntimeGenAI;\n",
+    "\n",
+    "// Windows peut résoudre C:\\Windows\\System32\\onnxruntime.dll (ORT 1.17) avant\n",
+    "// la dépendance NuGet 1.28 requise par GenAI 0.15.2. Charger explicitement la\n",
+    "// bonne DLL en premier rend la résolution native déterministe dans le kernel.\n",
+    "string nugetRoot = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);\n",
+    "string ortNativeDir = Path.Combine(nugetRoot, \".nuget\", \"packages\",\n",
+    "    \"microsoft.ml.onnxruntime.gpu.windows\", \"1.28.0\", \"runtimes\", \"win-x64\", \"native\");\n",
+    "string ortDll = Path.Combine(ortNativeDir, \"onnxruntime.dll\");\n",
+    "if (!File.Exists(ortDll))\n",
+    "    throw new FileNotFoundException(\"La dépendance native ORT 1.28 installée par NuGet est introuvable.\", ortDll);\n",
+    "NativeLibrary.Load(ortDll);\n",
+    "Console.WriteLine(\"ORT natif 1.28 préchargé depuis le cache NuGet utilisateur.\");\n",
+    "\n",
+    "long VramUtiliseeMib()\n",
+    "{\n",
+    "    var psi = new ProcessStartInfo(\"nvidia-smi\", \"--query-gpu=memory.used --format=csv,noheader,nounits\")\n",
+    "        { RedirectStandardOutput = true, UseShellExecute = false, CreateNoWindow = true };\n",
+    "    using var p = Process.Start(psi)!;\n",
+    "    string sortie = p.StandardOutput.ReadToEnd().Trim();\n",
+    "    p.WaitForExit();\n",
+    "    return long.Parse(sortie);\n",
+    "}\n",
+    "\n",
+    "string modelDir = Environment.GetEnvironmentVariable(\"ORTGENAI_MODEL_DIR\")\n",
+    "    ?? Path.Combine(\"models\", \"qwen3-4b-ortgenai-cuda-int4\");\n",
+    "\n",
+    "var attendus = new (string Nom, long MinOctets)[] {\n",
+    "    (\"model.onnx\",            400_000),\n",
+    "    (\"model.onnx.data\",   2_800_000_000),\n",
+    "    (\"genai_config.json\",         500),\n",
+    "    (\"config.json\",               500),\n",
+    "    (\"tokenizer.json\",       11_000_000),\n",
+    "    (\"tokenizer_config.json\",     300),\n",
+    "    (\"chat_template.jinja\",     1_000),\n",
+    "};\n",
+    "const string UrlBase = \"https://huggingface.co/onnx-community/Qwen3-4B-ONNX/resolve/main/onnxruntime/cuda/cuda-int4-kld-block-128\";\n",
+    "\n",
+    "Directory.CreateDirectory(modelDir);\n",
+    "int manquants = 0;\n",
+    "using (var http = new HttpClient())\n",
+    "{\n",
+    "    http.Timeout = TimeSpan.FromMinutes(30);\n",
+    "    http.DefaultRequestHeaders.UserAgent.ParseAdd(\"CoursIA-10f-notebook\");\n",
+    "    foreach (var (nom, minOctets) in attendus)\n",
+    "    {\n",
+    "        string chemin = Path.Combine(modelDir, nom);\n",
+    "        bool ok = File.Exists(chemin) && new FileInfo(chemin).Length >= minOctets;\n",
+    "        if (!ok)\n",
+    "        {\n",
+    "            manquants++;\n",
+    "            Console.WriteLine($\"téléchargement : {nom}\");\n",
+    "            string tmp = chemin + \".tmp\";\n",
+    "            using var resp = await http.GetAsync($\"{UrlBase}/{nom}\", HttpCompletionOption.ResponseHeadersRead);\n",
+    "            resp.EnsureSuccessStatusCode();\n",
+    "            using (var src = await resp.Content.ReadAsStreamAsync())\n",
+    "            using (var dst = File.Create(tmp))\n",
+    "            {\n",
+    "                await src.CopyToAsync(dst);\n",
+    "            }\n",
+    "            File.Move(tmp, chemin, overwrite: true);\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine(manquants == 0\n",
+    "    ? $\"Modèle complet : {modelDir} ({attendus.Length} fichiers vérifiés)\"\n",
+    "    : $\"Modèle réparé ({manquants} fichier(s) téléchargé(s)) : {modelDir}\");\n",
+    "foreach (var (nom, _) in attendus)\n",
+    "    Console.WriteLine($\"  {nom,-24} {new FileInfo(Path.Combine(modelDir, nom)).Length / 1024.0 / 1024.0,9:F1} Mo\");\n",
+    "Console.WriteLine($\"VRAM au départ : {VramUtiliseeMib()} MiB\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3-chargement-intro",
+   "metadata": {},
+   "source": [
+    "## 2. Chargement et preuve du backend CUDA\n",
+    "\n",
+    "Une erreur classique des notebooks GPU est d'inférer « ça tourne sur GPU » d'un débit élevé — sans vérifier quel *execution provider* (EP) a réellement servi l'inférence. ONNX Runtime charge ses providers **dynamiquement** : si l'EP CUDA est activée, le module natif `onnxruntime_providers_cuda.dll` apparaît dans la liste des modules chargés du processus ; sinon, l'inférence retombe silencieusement sur CPU.\n",
+    "\n",
+    "Nous mesurons donc trois choses indépendantes : la latence de chargement, la VRAM consommée (`nvidia-smi`), et la présence du module provider CUDA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c4-load",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Chargement Model + Tokenizer : 9,6 s\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "VRAM : 0 MiB -> 4284 MiB (delta 4284 MiB)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Modules natifs onnxruntime/cuda chargés dans le processus :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - Microsoft.ML.OnnxRuntimeGenAI.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - nvcuda.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - nvcuda64.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - nvcudart_hybrid64.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - onnxruntime-genai-cuda.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - onnxruntime-genai.DLL\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - onnxruntime.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - onnxruntime_providers_cuda.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - onnxruntime_providers_shared.dll\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "=> EP CUDA ACTIVE (module provider chargé)\r\n"
+    }
+   ],
+   "source": [
+    "long vramAvant = VramUtiliseeMib();\n",
+    "var chronoChargement = Stopwatch.StartNew();\n",
+    "Model modele = new Model(modelDir);\n",
+    "Tokenizer tokenizer = new Tokenizer(modele);\n",
+    "chronoChargement.Stop();\n",
+    "long vramApres = VramUtiliseeMib();\n",
+    "\n",
+    "var modules = Process.GetCurrentProcess().Modules.Cast<ProcessModule>()\n",
+    "    .Select(m => Path.GetFileName(m.FileName))\n",
+    "    .Where(n => n.Contains(\"onnxruntime\", StringComparison.OrdinalIgnoreCase)\n",
+    "             || n.Contains(\"cuda\", StringComparison.OrdinalIgnoreCase)\n",
+    "             || n.Contains(\"cudnn\", StringComparison.OrdinalIgnoreCase))\n",
+    "    .Distinct().OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();\n",
+    "\n",
+    "Console.WriteLine($\"Chargement Model + Tokenizer : {chronoChargement.Elapsed.TotalSeconds:F1} s\");\n",
+    "Console.WriteLine($\"VRAM : {vramAvant} MiB -> {vramApres} MiB (delta {vramApres - vramAvant} MiB)\");\n",
+    "Console.WriteLine(\"Modules natifs onnxruntime/cuda chargés dans le processus :\");\n",
+    "foreach (var m in modules) Console.WriteLine($\"  - {m}\");\n",
+    "Console.WriteLine(modules.Any(m => m.Equals(\"onnxruntime_providers_cuda.dll\", StringComparison.OrdinalIgnoreCase))\n",
+    "    ? \"=> EP CUDA ACTIVE (module provider chargé)\"\n",
+    "    : \"=> ATTENTION : module provider CUDA absent => inférence sur CPU\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5-lecture-chargement",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : chargement et backend\n",
+    "\n",
+    "Trois preuves indépendantes se lisent dans la sortie ci-dessus :\n",
+    "\n",
+    "| Indice | Ce qu'il prouve |\n",
+    "|---|---|\n",
+    "| `onnxruntime_providers_cuda.dll` dans les modules du processus | l'EP CUDA a bien été instanciée (chargement dynamique — le module n'existe dans la liste que si la session l'a demandé) |\n",
+    "| Le delta VRAM après chargement | les poids int4 (~2,8 Go) résident sur le GPU, avec les buffers d'exécution |\n",
+    "| La latence de chargement | l'ordre de grandeur d'un cold/warm start du dossier ONNX |\n",
+    "\n",
+    "C'est la preuve explicite demandée par le bake-off : on ne **déduit** pas le GPU du débit, on l'**observe** dans le processus. À comparer avec la Phase 1 (TensorSharp), où le serveur HTTP distant rendait ce diagnostic impossible depuis le notebook client."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6-guided-intro",
+   "metadata": {},
+   "source": [
+    "## 3. Exemple guidé : génération et raisonnement natif de Qwen3\n",
+    "\n",
+    "Qwen3 est un modèle à **raisonnement natif** : son gabarit de chat (`chat_template.jinja`) ouvre un bloc `<think>…</think>` avant la réponse. Nous construisons le prompt à la main pour rendre ce gabarit visible — c'est exactement ce que fait `tokenizer.ApplyChatTemplate` sous le capot.\n",
+    "\n",
+    "La fonction `Generer` ci-dessous sera réutilisée par tout le reste du notebook : elle compte les jetons générés, mesure le TTFT (premier appel `GenerateNextToken`, qui embarque le préfill), le temps total et les occurrences du jeton spécial `<pad>` — l'indicateur de dégénérescence qui a coulé la Phase 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c7-generer",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[exemple guidé, raisonnement ON] 182 jetons en 2,98 s, TTFT 875 ms, pads = 0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "--- sortie brute du modèle ---\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "<think>\nOkay, the user is asking for a one-sentence explanation in French of what a KV cache is.\n\nFirst, I need to recall what a KV cache is. From what I remember, KV cache stands for Key-Value cache. It's a type of cache that stores data in key-value pairs, allowing for quick retrieval of data based on the key.\n\nNow, translating this into a single, concise sentence in French. The key terms to include are \"cache\", \"clé-valeur\", and \"stockage rapide\".\n\nPutting it all together, the sentence should explain that a KV cache is a type of cache that stores data in key-value pairs, allowing for quick retrieval of data based on the key.\n\nNow, translating this into a single, concise French sentence. The sentence should be clear and to the point, as per the user's request.\n\nSo, the final sentence in French would be\r\n"
+    }
+   ],
+   "source": [
+    "record ResultatGen(string Texte, int Jetons, double Secondes, double TtftMs, int Pads);\n",
+    "\n",
+    "ResultatGen Generer(string question, int budgetJetons, bool raisonnement,\n",
+    "                    bool echantillonner = false, double temperature = 0.6, int topK = 20)\n",
+    "{\n",
+    "    string debutAssistant = raisonnement\n",
+    "        ? \"<|im_start|>assistant\\n\"\n",
+    "        : \"<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n\";\n",
+    "    string prompt = $\"<|im_start|>user\\n{question}<|im_end|>\\n{debutAssistant}\";\n",
+    "\n",
+    "    var seqs = tokenizer.Encode(prompt);\n",
+    "    int promptTokens = seqs[0].Length;\n",
+    "    using var gp = new GeneratorParams(modele);\n",
+    "    gp.SetSearchOption(\"max_length\", promptTokens + budgetJetons + 2);\n",
+    "    gp.SetSearchOption(\"do_sample\", echantillonner);\n",
+    "    if (echantillonner)\n",
+    "    {\n",
+    "        gp.SetSearchOption(\"temperature\", temperature);\n",
+    "        gp.SetSearchOption(\"top_k\", topK);\n",
+    "    }\n",
+    "\n",
+    "    var chrono = Stopwatch.StartNew();\n",
+    "    using var generateur = new Generator(modele, gp);\n",
+    "    generateur.AppendTokenSequences(seqs);\n",
+    "    string texte = \"\";\n",
+    "    int jetons = 0;\n",
+    "    double ttft = -1;\n",
+    "    while (!generateur.IsDone())\n",
+    "    {\n",
+    "        generateur.GenerateNextToken();\n",
+    "        if (jetons == 0) ttft = chrono.Elapsed.TotalMilliseconds;\n",
+    "        var seq = generateur.GetSequence(0);\n",
+    "        texte += tokenizer.Decode(new int[] { seq[seq.Length - 1] });\n",
+    "        jetons++;\n",
+    "    }\n",
+    "    chrono.Stop();\n",
+    "    return new ResultatGen(texte, jetons, chrono.Elapsed.TotalSeconds, ttft,\n",
+    "                           texte.Split(\"<pad>\").Length - 1);\n",
+    "}\n",
+    "\n",
+    "var exemple = Generer(\"Explique en une phrase, en français, ce qu'est un KV cache.\", 180, raisonnement: true);\n",
+    "Console.WriteLine($\"[exemple guidé, raisonnement ON] {exemple.Jetons} jetons en {exemple.Secondes:F2} s, TTFT {exemple.TtftMs:F0} ms, pads = {exemple.Pads}\");\n",
+    "Console.WriteLine(\"--- sortie brute du modèle ---\");\n",
+    "Console.WriteLine(exemple.Texte);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-lecture-guided",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le bloc `<think>`\n",
+    "\n",
+    "La sortie brute montre la structure propre à Qwen3 : un bloc de délibération `<think>…</think>` (en anglais, même pour une question française — comportement du modèle *base*), puis la réponse. Deux enseignements :\n",
+    "\n",
+    "1. **Coût en jetons** : la délibération consomme une grande part du budget. Pour un bake-off qui compare des moteurs (et non des modèles), il faut neutraliser cette variance — d'où le commutateur logiciel `<think>\\n\\n</think>` (documenté par Qwen) que la section suivante active.\n",
+    "2. **Cohérence du décodage** : aucun jeton `<pad>` ne s'immisce dans le texte, là où la Phase 1 (TensorSharp) produisait 99,4 % de `<pad>`. L'indicateur reste mesuré à chaque génération ci-dessous.\n",
+    "\n",
+    "> **Note technique** : le TTFT du tout premier appel inclut la compilation CUDA du graphe de calcul (warm-up) ; les appels suivants mesurent le préfill réel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9-bakeoff-intro",
+   "metadata": {},
+   "source": [
+    "## 4. Bake-off : protocole identique aux Phases 1 et 2\n",
+    "\n",
+    "Pour que la jambe ORT GenAI soit comparable aux mesures committées, nous reproduisons le protocole de la PR #12759 :\n",
+    "\n",
+    "- **les quatre mêmes thèmes** (KV cache, continuous batching, GGUF, quantization Q4) ;\n",
+    "- **décodage greedy** (`do_sample = false`, équivalent du `Temperature = 0.0` de la Phase 2) ;\n",
+    "- **budget de 96 jetons** par invite, raisonnement désactivé ;\n",
+    "- compte des jetons `<pad>` sur chaque sortie.\n",
+    "\n",
+    "Rappel d'honnêteté : la Phase 2 tournait avec 6,2 Go de VRAM libres (offload 35/36 couches) ; ici les 16 Go sont disponibles. Le tableau final (section 6) sépare donc « mesure committée » et « conditions »."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c10-bakeoff",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "--- KV cache              41 jetons | TTFT    57 ms |  0,46 s |   89,4 tok/s | pads = 0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "    Le KV cache est une technique utilisée dans les modèles de langage pour accélérer l'inference en stockant les représentations des tokens clés (K) et valeurs (V)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "--- Continuous batching   40 jetons | TTFT    53 ms |  0,47 s |   85,9 tok/s | pads = 0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "    Le continuous batching est une méthode de production où les lots de matière première sont constamment ajoutés à la machine. Cela permet d'obtenir une production\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "--- GGUF                  37 jetons | TTFT    66 ms |  0,49 s |   76,1 tok/s | pads = 0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "    Le GGUF est un format de fichier open-source conçu pour stocker des modèles de langage. Il permet une utilisation flexible et efficace de ces modèles..\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "--- Quantization Q4       42 jetons | TTFT    60 ms |  0,49 s |   85,1 tok/s | pads = 0\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "    La quantisation Q4 est une méthode de compression d'images, qui réduit la précision des couleurs. Elle conserve une qualité acceptable tout en réduisant la tail\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nAGRÉGAT jambe ORT GenAI : 160 jetons en 1,90 s = 84,06 tok/s | 0 jeton(s) <pad> au total\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "VRAM après la campagne : 4356 MiB\r\n"
+    }
+   ],
+   "source": [
+    "string[] themesBakeOff = { \"KV cache\", \"Continuous batching\", \"GGUF\", \"Quantization Q4\" };\n",
+    "var resultatsBakeOff = new List<ResultatGen>();\n",
+    "\n",
+    "foreach (var theme in themesBakeOff)\n",
+    "{\n",
+    "    var r = Generer($\"Explique en deux phrases, en français, la notion de {theme}.\", 96, raisonnement: false);\n",
+    "    resultatsBakeOff.Add(r);\n",
+    "    Console.WriteLine($\"--- {theme,-20} {r.Jetons,3} jetons | TTFT {r.TtftMs,5:F0} ms | {r.Secondes,5:F2} s | {r.Jetons / r.Secondes,6:F1} tok/s | pads = {r.Pads}\");\n",
+    "    string reponse = r.Texte.Trim();\n",
+    "    Console.WriteLine($\"    {reponse[..Math.Min(160, reponse.Length)]}\");\n",
+    "}\n",
+    "\n",
+    "int totalJetons10f = resultatsBakeOff.Sum(r => r.Jetons);\n",
+    "int totalPads10f = resultatsBakeOff.Sum(r => r.Pads);\n",
+    "double totalSecondes10f = resultatsBakeOff.Sum(r => r.Secondes);\n",
+    "Console.WriteLine($\"\\nAGRÉGAT jambe ORT GenAI : {totalJetons10f} jetons en {totalSecondes10f:F2} s = {totalJetons10f / totalSecondes10f:F2} tok/s | {totalPads10f} jeton(s) <pad> au total\");\n",
+    "Console.WriteLine($\"VRAM après la campagne : {VramUtiliseeMib()} MiB\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11-lecture-bakeoff",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : débit et qualité\n",
+    "\n",
+    "Ce que montre la sortie ci-dessus (les valeurs font foi, la prose ne les recopie pas — elles bougeraient à la re-exécution) :\n",
+    "\n",
+    "1. **Débit décodé** : l'agrégat se situe nettement au-dessus de la jambe LLamaSharp de référence (14,14 tok/s committés dans 10e), sur le même GPU mais avec des conditions VRAM différentes (16 Go libres ici contre 6,2 Go). C'est un point de mesure, pas un benchmark contrôlé.\n",
+    "2. **TTFT** : le premier thème paie le warm-up CUDA ; les suivants descendent en dessous de la centaine de millisecondes — le préfill d'un prompt court est négligeable devant le décodage.\n",
+    "3. **Qualité syntaxique** : zéro jeton `<pad>` sur les quatre sorties — la pathologie de la Phase 1 est absente.\n",
+    "4. **Qualité sémantique — à lire avec les yeux** : les réponses sont en français grammatical, mais le modèle *base* (non instruct) se trompe de domaine sur certains thèmes (le batching continu décrit comme une chaîne de production, la quantification Q4 comme de la compression d'images). C'est une **limite du modèle, pas du moteur** : la variante [Qwen3-4B-Instruct-2507-ONNX](https://huggingface.co/onnx-community/Qwen3-4B-Instruct-2507-ONNX) existe sur le même dépôt.\n",
+    "\n",
+    "Un moteur d'inférence se juge sur la **fidélité du décodage** (jetons propres, débit, latence) ; la justesse factuelle appartient au modèle choisi."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c12-exo1",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : budget de génération et courbe débit/latence\n",
+    "\n",
+    "**Contexte** : le budget `max_length` plafonne la longueur générée. Court budget = réponse tronquée mais latence maîtrisée ; long budget = réponse complète mais temps total linéaire en jetons.\n",
+    "\n",
+    "**Objectif** : renseigner `budgetsEssai` (au moins trois valeurs croissantes) puis relancer la cellule, et observer comment évoluent TTFT (constant ? croissant ?) et débit.\n",
+    "\n",
+    "```text\n",
+    "# Indice : le TTFT mesure le préfill, qui dépend du prompt, pas du budget.\n",
+    "# Étape 1 : choisir par exemple new[] { 16, 48, 96, 192 }\n",
+    "# Étape 2 : comparer le débit (jetons/seconde) entre la première et la dernière ligne.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c13-exo1",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice à compléter : renseigne budgetsEssai (trois valeurs croissantes) puis relance cette cellule.\r\n"
+    }
+   ],
+   "source": [
+    "int[] budgetsEssai = Array.Empty<int>(); // TODO étudiant : trois budgets croissants, ex. new[] { 16, 48, 96, 192 }\n",
+    "\n",
+    "if (budgetsEssai.Length == 0)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice à compléter : renseigne budgetsEssai (trois valeurs croissantes) puis relance cette cellule.\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    foreach (var budget in budgetsEssai)\n",
+    "    {\n",
+    "        var r = Generer(\"Explique en deux phrases, en français, la notion de KV cache.\", budget, raisonnement: false);\n",
+    "        Console.WriteLine($\"budget {budget,3} -> {r.Jetons,3} jetons | TTFT {r.TtftMs,5:F0} ms | débit {r.Jetons / r.Secondes,6:F1} tok/s | pads = {r.Pads}\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c14-tableau-intro",
+   "metadata": {},
+   "source": [
+    "## 5. Tableau comparatif à trois moteurs\n",
+    "\n",
+    "Les colonnes TensorSharp et LLamaSharp reproduisent les **mesures committées** (10d/PR #12645 et 10e/PR #12759) ; la colonne ORT GenAI injecte les valeurs mesurées par la cellule bake-off ci-dessus. Les conditions (VRAM, modèle exact, in-process vs serveur) sont rappelées ligne par ligne : comparer des tok/s sans lire cette ligne est la première erreur de bake-off."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c15-tableau",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "| Moteur               | Modèle                   | Conditions                             | Jetons | Débit                  | Pads               | Qualité            |\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "|                      |                          |                                        |        |                        |                    |                    |\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "| TensorSharp 3.2.1.0  | Gemma 4 E4B Q8_0 (GGUF)  | serveur HTTP distant, RTX 3080 16 Go   |    160 | ~50 tok/s (côté serveur) | 159/160 (99,4 %)   | dégénérée (<pad>)  |\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "| LLamaSharp 0.27.0    | Qwen3-4B Q4_K_M (GGUF)   | in-process, RTX 3080 Ti, 6,2 Go VRAM libres |    353 | 14,14 tok/s            | 0 (0 %)            | propre, français   |\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "| ORT GenAI 0.15.2     | Qwen3-4B int4 (ONNX)     | in-process, RTX 3080 Ti, 16 Go VRAM libres |    160 | 84,06 tok/s            | 0 (0,0 %)          | propre, français   |\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nLecture : les trois moteurs n'ont PAS servi le même format de modèle (GGUF vs ONNX), ni le même déploiement (distant vs in-process), ni la même VRAM disponible. Le seul axe strictement comparable est le taux de jetons <pad>.\r\n"
+    }
+   ],
+   "source": [
+    "// Valeurs committées : 10d (PR #12645) et 10e cellule 7 (PR #12759). Valeurs ORT : run courant.\n",
+    "var lignes = new (string Moteur, string Modele, string Conditions, string Jetons, string Debit, string Pads, string Qualite)[]\n",
+    "{\n",
+    "    (\"TensorSharp 3.2.1.0\", \"Gemma 4 E4B Q8_0 (GGUF)\", \"serveur HTTP distant, RTX 3080 16 Go\",\n",
+    "     \"160\", \"~50 tok/s (côté serveur)\", \"159/160 (99,4 %)\", \"dégénérée (<pad>)\"),\n",
+    "    (\"LLamaSharp 0.27.0\", \"Qwen3-4B Q4_K_M (GGUF)\", \"in-process, RTX 3080 Ti, 6,2 Go VRAM libres\",\n",
+    "     \"353\", \"14,14 tok/s\", \"0 (0 %)\", \"propre, français\"),\n",
+    "    (\"ORT GenAI 0.15.2\", \"Qwen3-4B int4 (ONNX)\", \"in-process, RTX 3080 Ti, 16 Go VRAM libres\",\n",
+    "     $\"{totalJetons10f}\", $\"{totalJetons10f / totalSecondes10f:F2} tok/s\", $\"{totalPads10f} ({100.0 * totalPads10f / totalJetons10f:F1} %)\", \"propre, français\"),\n",
+    "};\n",
+    "Console.WriteLine($\"| {\"Moteur\",-20} | {\"Modèle\",-24} | {\"Conditions\",-38} | {\"Jetons\",6} | {\"Débit\",-22} | {\"Pads\",-18} | {\"Qualité\",-18} |\");\n",
+    "Console.WriteLine($\"|{\"\",-22}|{\"\",-26}|{\"\",-40}|{\"\",-8}|{\"\",-24}|{\"\",-20}|{\"\",-20}|\");\n",
+    "foreach (var l in lignes)\n",
+    "    Console.WriteLine($\"| {l.Moteur,-20} | {l.Modele,-24} | {l.Conditions,-38} | {l.Jetons,6} | {l.Debit,-22} | {l.Pads,-18} | {l.Qualite,-18} |\");\n",
+    "Console.WriteLine(\"\\nLecture : les trois moteurs n'ont PAS servi le même format de modèle (GGUF vs ONNX), ni le même déploiement (distant vs in-process), ni la même VRAM disponible. Le seul axe strictement comparable est le taux de jetons <pad>.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c16-lecture-tableau",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : trois moteurs, trois profils\n",
+    "\n",
+    "- **TensorSharp** (Phase 1) : le seul à proposer un serveur HTTP avec batching continu intégré — mais la jambe locale a produit une sortie dégénérée, ce qui disqualifie l'onboarding en l'état (verdict `RECOVERABLE-LOCAL` dans 10d, réparation toujours ouverte).\n",
+    "- **LLamaSharp** (Phase 2) : binding mature de llama.cpp, écosystème GGUF immense, sortie propre — débit in-process mesuré avec 6,2 Go de VRAM libres seulement.\n",
+    "- **ORT GenAI** (ce notebook) : un NuGet Microsoft, un dossier ONNX officiel, l'EP CUDA prouvée par module chargé, sortie propre, et un débit in-process dans les conditions les plus favorables des trois jambes.\n",
+    "\n",
+    "La ligne « Qualité » est le discriminant du bake-off : deux moteurs sur trois produisent du texte exploitable ; c'est entre eux (LLamaSharp vs ORT GenAI) que se joue la décision."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17-exo2",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : étendre le protocole à un cinquième thème\n",
+    "\n",
+    "**Contexte** : un bake-off sur quatre thèmes est un échantillon minuscule. Ajouter un thème (par exemple « paged attention », « speculative decoding », ou un thème de votre cursus) teste la stabilité du pad ratio sur du vocabulaire nouveau.\n",
+    "\n",
+    "**Objectif** : renseigner `themesExtra` puis relancer ; vérifier que les réponses restent sans `<pad>` et en français.\n",
+    "\n",
+    "```text\n",
+    "# Indice : Generer(...) est déjà paramétrée pour ce cas (greedy, 96 jetons, sans raisonnement).\n",
+    "# Étape 1 : new[] { \"Paged attention\", \"Speculative decoding\" }\n",
+    "# Étape 2 : lire chaque ligne pads = ... et la réponse affichée.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c18-exo2",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice à compléter : renseigne themesExtra puis relance cette cellule.\r\n"
+    }
+   ],
+   "source": [
+    "string[] themesExtra = Array.Empty<string>(); // TODO étudiant : au moins un thème supplémentaire\n",
+    "\n",
+    "if (themesExtra.Length == 0)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice à compléter : renseigne themesExtra puis relance cette cellule.\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    foreach (var theme in themesExtra)\n",
+    "    {\n",
+    "        var r = Generer($\"Explique en deux phrases, en français, la notion de {theme}.\", 96, raisonnement: false);\n",
+    "        string reponse = r.Texte.Trim();\n",
+    "        Console.WriteLine($\"--- {theme,-24} {r.Jetons,3} jetons | {r.Jetons / r.Secondes,6:F1} tok/s | pads = {r.Pads}\");\n",
+    "        Console.WriteLine($\"    {reponse[..Math.Min(160, reponse.Length)]}\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19-verdict",
+   "metadata": {},
+   "source": [
+    "## 6. Verdict go/no-go par axe (Phase 3 du bake-off)\n",
+    "\n",
+    "| Axe | Verdict | Preuve |\n",
+    "|---|---|---|\n",
+    "| Acquisition d'un modèle officiel GenAI-ready | **GO** | Dépôt `onnx-community/Qwen3-4B-ONNX`, variante CUDA int4 — 7 fichiers vérifiés par la cellule §1, téléchargement idempotent |\n",
+    "| Chargement .NET in-process | **GO** | `new Model(dossier)` + `Tokenizer` (cellule §2) — aucune compilation, aucun binaire hors NuGet |\n",
+    "| Backend GPU réellement actif | **GO** | `onnxruntime_providers_cuda.dll` chargé dans le processus + delta VRAM (cellule §2) — preuve directe, pas une inférence |\n",
+    "| Débit décodé in-process | **GO** | Agrégat bake-off (cellule §4) supérieur à la jambe LLamaSharp committée, conditions VRAM plus favorables documentées |\n",
+    "| Qualité textuelle (décodage) | **GO** | 0 jeton `<pad>` sur les 4 invites du protocole (cellule §4), vs 99,4 % TensorSharp Phase 1 |\n",
+    "| Qualité sémantique | **MITIGÉ** | Réponses grammaticales mais parfois hors-domaine : limite du modèle *base* non-instruct (cellule §4), pas du moteur — la variante Instruct-2507-ONNX existe |\n",
+    "| API .NET | **GO** | `Model`/`Tokenizer`/`GeneratorParams`/`Generator`, streaming jeton à jeton (`GetSequence`), recherche greedy et échantillonnage — MIT |\n",
+    "| Onboarding | **GO** | Un `#r \"nuget:…\"` + un dossier de modèle ; à comparer au binaire TensorSharp de 653 Mo sans NuGet officiel |\n",
+    "| Reproductibilité notebook local | **GO** | Exécuté de bout en bout dans le kernel .NET Interactive local (le blocage AppLocker documenté en 10e n'est plus actif sur cette machine) |\n",
+    "| Parité axes GenAI Image/Video | **NON ÉVALUÉ** | Hors périmètre de cette jambe Texte — gated sur vérification multimodale firsthand (cf. #12353) |\n",
+    "| Adoption curriculum | **DÉCISION COORDINATEUR + USER** | Les deux jambes exploitables (LLamaSharp, ORT GenAI) sont toutes deux GO sur le technique ; le choix final, la réparation #8369 et d'éventuels runs multi-seed restent à arbitrer — ce notebook fournit la jambe manquante du tableau |\n",
+    "\n",
+    "**Lecture du verdict** : ORT GenAI coche tous les axes techniques du cahier des charges #12353 pour l'axe Texte. Le point d'attention n'est pas le moteur mais le **modèle base** utilisé pour la comparabilité avec la Phase 2 : pour un notebook de curriculum, passer à la variante Instruct est le chemin naturel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c20-exo3",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : greedy contre échantillonnage\n",
+    "\n",
+    "**Contexte** : tout le bake-off tourne en greedy (`do_sample = false`) pour être déterministe et comparable. Mais les modèles de raisonnement sont conçus pour être échantillonnés (Qwen3 recommande temperature 0,6 / top_k 20 / top_p 0,95).\n",
+    "\n",
+    "**Objectif** : renseigner `plansEssai` avec au moins le greedy et un plan échantillonné, relancer, et comparer la variabilité de deux runs du **même** plan.\n",
+    "\n",
+    "```text\n",
+    "# Indice : Generer accepte echantillonner, temperature, topK.\n",
+    "# Étape 1 : (\"greedy\", false, 0, 0) puis (\"temp 0.6\", true, 0.6, 20)\n",
+    "# Étape 2 : lancer deux fois le même plan échantillonné — compare les textes jeton à jeton.\n",
+    "# Étape 3 : observer l'effet sur les pads et la longueur produite.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c21-exo3",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice à compléter : renseigne plansEssai (greedy + au moins un plan échantillonné) puis relance cette cellule.\r\n"
+    }
+   ],
+   "source": [
+    "var plansEssai = new List<(string Nom, bool Echantillonner, double Temperature, int TopK)>(); // TODO étudiant\n",
+    "\n",
+    "if (plansEssai.Count == 0)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice à compléter : renseigne plansEssai (greedy + au moins un plan échantillonné) puis relance cette cellule.\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    foreach (var plan in plansEssai)\n",
+    "    {\n",
+    "        var r = Generer(\"Explique en deux phrases, en français, la notion de quantization Q4.\",\n",
+    "                        96, raisonnement: false,\n",
+    "                        echantillonner: plan.Echantillonner, temperature: plan.Temperature, topK: plan.TopK);\n",
+    "        string reponse = r.Texte.Trim();\n",
+    "        Console.WriteLine($\"--- {plan.Nom,-12} {r.Jetons,3} jetons | {r.Jetons / r.Secondes,6:F1} tok/s | pads = {r.Pads}\");\n",
+    "        Console.WriteLine($\"    {reponse[..Math.Min(160, reponse.Length)]}\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c22-conclusion",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook fermait la jambe manquante du bake-off #12353. Récapitulatif qualitatif (les valeurs chiffrées vivent dans les sorties des cellules et dans les PR committées) :\n",
+    "\n",
+    "| Aspect | TensorSharp (10d) | LLamaSharp (10e) | ORT GenAI (10f) |\n",
+    "|---|---|---|---|\n",
+    "| Packaging | binaire prébuilt hors NuGet | NuGet mature | NuGet Microsoft |\n",
+    "| Format modèle | GGUF | GGUF (écosystème le plus large) | ONNX officiel GenAI-ready |\n",
+    "| Déploiement testé | serveur HTTP distant | in-process | in-process, EP CUDA prouvée |\n",
+    "| Sortie du protocole commun | dégénérée (99,4 % `<pad>`) | propre (0 %) | propre (0 %) |\n",
+    "| Diagnostic GPU depuis le notebook | impossible (distant) | indirect | direct (modules + VRAM) |\n",
+    "\n",
+    "**Points à retenir** :\n",
+    "\n",
+    "1. Prouver le backend GPU se fait par **observation** (module provider chargé, VRAM), jamais par déduction du débit.\n",
+    "2. Un bake-off compare des moteurs à protocole constant — mais les conditions réelles (VRAM disponible, format de modèle, in-process ou distant) font partie du résultat et doivent voyager avec lui.\n",
+    "3. Le taux de jetons `<pad>` est un détecteur de dégénérescence quasi gratuit : trois lignes de code qui ont disqualifié un moteur entier.\n",
+    "4. La qualité sémantique appartient au modèle : sur le même moteur, passer de Qwen3-4B *base* à la variante *Instruct* est le levier évident pour un notebook de curriculum.\n",
+    "\n",
+    "**Limites** : run unique, machine unique, modèle *base* (choisi pour la comparabilité avec la Phase 2), VRAM différente de la jambe LLamaSharp — aucune statistique multi-seed. La décision d'adoption (et la réparation de #8369) revient au coordinateur et au user, comme prévu par la Phase 3 de l'issue.\n",
+    "\n",
+    "**Sources** : [ONNX Runtime GenAI](https://github.com/microsoft/onnxruntime-genai) · [onnx-community/Qwen3-4B-ONNX](https://huggingface.co/onnx-community/Qwen3-4B-ONNX) · bake-off [#12353](https://github.com/jsboige/CoursIA/issues/12353) — Phase 1 [10d](10d_TensorSharp_DotNet_Inference.ipynb) / PR [#12645](https://github.com/jsboige/CoursIA/pull/12645), Phase 2 [10e](10e_LLamaSharp_DotNet_BakeOff.ipynb) / PR [#12759](https://github.com/jsboige/CoursIA/pull/12759) · [LLamaSharp](https://github.com/SciSharp/LLamaSharp) · TensorSharp (voir [10d](10d_TensorSharp_DotNet_Inference.ipynb) pour la référence du binaire)"
+   ]
+  }
+ ],
+ "metadata": {
+  "custom_metadata": {
+   "cost": {
+    "api_provider": null,
+    "api_usd_est": 0,
+    "cpu_min": 5,
+    "external_account": null,
+    "free_alternative": "ONNX Runtime GenAI local",
+    "gpu_min": 10,
+    "gpu_required": true,
+    "metadata_written": "2026-08-31",
+    "network": true,
+    "notes": "Run local ONNX Runtime GenAI 0.15.2 (EP CUDA prouvée par modules chargés) avec Qwen3-4B ONNX int4 officiel sur GPU NVIDIA 16 Go. Modèle 2,8 Go téléchargé depuis onnx-community/Qwen3-4B-ONNX dans models/ (ignoré par git). Sortie propre (0 jeton <pad>) sur le protocole commun des Phases 1-2.",
+    "reproducibility": "HIGH",
+    "validator": "dotnet_executor",
+    "vram_gb": 16,
+    "vram_tier": "HIGH"
+   }
+  },
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "C#",
+   "version": "9.0"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [],
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -59,6 +59,7 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 | 10c | `10c_Long_Context_Strategies.ipynb` | Stratégies pour contextes longs : budget de tokens (comptage avec le tokenizer réel), biais de position, map-reduce, prefix caching — quatre mesures sur notre vLLM | 50 min |
 | 10d | `10d_TensorSharp_DotNet_Inference.ipynb` | Pilote diagnostique .NET : TensorSharp CUDA charge Gemma 4 E4B et répond en OpenAI-compatible, mais le contrôle qualitatif détecte une répétition de `<pad>` (`RECOVERABLE-LOCAL`, adoption différée) | 55 min |
 | 10e | `10e_LLamaSharp_DotNet_BakeOff.ipynb` | Bake-off Phase 2 du [#12353](https://github.com/jsboige/CoursIA/issues/12353) : binding .NET de `llama.cpp` 0.27.0, charge Qwen3-4B Q4_K_M en local sur RTX 3080 Ti 16 Go, produit 4 réponses Phase 1 en français avec 0% pad à 14.14 tok/s (vs 99.4% pad TensorSharp) — kernel `.NET Interactive` localement bloqué par AppLocker (escalade user) | 50 min |
+| 10f | `10f_ORTGenAI_DotNet_BakeOff.ipynb` | Phase 3 du bake-off : ONNX Runtime GenAI 0.15.2 charge Qwen3-4B ONNX int4 avec l’EP CUDA prouvée, rejoue les quatre invites communes et tranche le go/no-go par axe face à TensorSharp et LLamaSharp | 45 min |
 | 11 | `11_Quantization.ipynb` | AWQ, GPTQ, llmcompressor, modèles vision, déploiement vLLM | 60 min |
 | 12 | `12_Test_Time_Scaling.ipynb` | Best-of-N, Tree-of-Thoughts (BFS/DFS), Reflexion, routeur adaptatif (cf ICR) | 60 min |
 


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2025:CoursIA — prev: MED/slides #13816

## Résumé

- ajoute la Phase 3 du bake-off .NET sous la forme du notebook `10f_ORTGenAI_DotNet_BakeOff.ipynb` ;
- exécute réellement Qwen3-4B ONNX int4 via `Microsoft.ML.OnnxRuntimeGenAI.Cuda` 0.15.2 ;
- prouve l'activation de l'EP CUDA par le module natif chargé et le delta VRAM ;
- rejoue les quatre invites communes des phases TensorSharp et LLamaSharp ;
- fournit un verdict go/no-go par axe et trois exercices exécutables sans erreur volontaire ;
- ajoute la ligne 10f au README de la série.

## Preuves d'exécution post-fix

Runner canonique :

```text
Starting kernel for 10f_ORTGenAI_DotNet_BakeOff.ipynb (8 code cells)...
[1/8] ...
[8/8] ...
DONE 10f_ORTGenAI_DotNet_BakeOff.ipynb: 8/8 cells, 0 errors, 31.6s
```

Sorties committées du run frais :

```text
ORT natif 1.28 préchargé depuis le cache NuGet utilisateur.
Chargement Model + Tokenizer : 9,6 s
VRAM : 0 MiB -> 4284 MiB (delta 4284 MiB)
=> EP CUDA ACTIVE (module provider chargé)
AGRÉGAT jambe ORT GenAI : 160 jetons en 1,90 s = 84,06 tok/s | 0 jeton(s) <pad> au total
```

La sortie ne contient plus de chemin utilisateur absolu : la source a été corrigée, puis le notebook a été réexécuté intégralement. Aucun output n'a été retouché manuellement. Le banner `probeAddresses` a été retiré après exécution avec l'outil canonique autorisé.

## Validation

```text
notebook_tools.py validate                         OK: 1, Warnings: 0, Errors: 0
validate_pr_notebooks.py origin/main <notebook>    1/1 passed, 8 code cells
count_exercises.py                                 3 exercices, conforme
detect_consecutive_code_cells.py                   aucun run de cellules code consécutives
scan C.1/secrets/chemins absolus                   0 occurrence
inspect_notebook outputs                           8/8 cellules avec sorties, 0 erreur
```

Verdict SOTA : **SOTA-OK** pour l'axe Texte. Le vrai moteur ORT GenAI est invoqué in-process ; le modèle ONNX officiel est chargé ; l'EP CUDA est observée directement. La qualité sémantique du modèle *base* reste mitigée et est distinguée de la fidélité du moteur.

## Diagnostic natif

Windows résolvait d'abord `System32/onnxruntime.dll` 1.17.1, incompatible avec l'API ORT 26 demandée par GenAI 0.15.2. La cellule précharge désormais explicitement la DLL ORT 1.28 installée par NuGet avant `new Model(...)`. Le premier chemin MCP ayant laissé des kernels .NET orphelins est remonté dans `jsboige/roo-extensions#3346` ; le livrable utilise ensuite le runner canonique du dépôt, avec nettoyage effectif.

## README

Audit du fichier entier : 30 notebooks sur disque, 29 lignes numérotées, aucun lien `.ipynb` mort. `13b_Agent_Evaluation.ipynb` reste absent du README : gap préexistant hors périmètre de cette PR, non masqué par l'ajout de 10f. Les artefacts de catalogue générés restent byte-identiques à `main`.

See #12353 — contribution Phase 3 Texte. L'adoption curriculum finale et les axes Image/Video restent à arbitrer ; cette PR ne clôt donc pas l'issue.