### PR TITLE
feat(ci,#13378): runner Linux conteneurise po-2024 — pilote dispatch-only

### DIFF
--- a/.github/workflows/linux-self-hosted-tests.yml
+++ b/.github/workflows/linux-self-hosted-tests.yml
@@ -1,0 +1,63 @@
+name: Linux Self-Hosted Tests
+
+# Mission #13378 (dispatch ai-01 2026-08-31) : runner Linux conteneurise sur
+# po-2024. Dispatch-only : ZERO declencheur pull_request/push, donc zero
+# fan-out CI -- pattern #13097 (windows-self-hosted-tests.yml).
+#
+# Cycle de vie : le conteneur porte un runner --ephemeral (AU PLUS UN JOB
+# puis desenregistrement natif). Chaque dispatch consomme l'enregistrement
+# courant : un dispatch, un job, un conteneur. Ne pas dispatcher deux fois
+# de suite sans avoir relance le conteneur (scripts/ci/docker/linux-runner/).
+#
+# Sous-semble pilote volontairement etroit : le guard de policy des runners
+# self-hosted (python pur, aucune ecriture disque, non critique). Les 93
+# jobs ubuntu-latest du census #13378 restent sur GitHub-hosted tant que la
+# mesure d'empreinte n'a pas porte l'elargissement (decision coordinateur).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux-policy-tests:
+    name: Runner policy tests (Linux container)
+    # Garde fork EXPLICITE au niveau job (defense-in-depth, pattern maison).
+    # Le declencheur actuel est workflow_dispatch seul -- un fork ne peut pas
+    # l'emettre -- mais "pas de trigger" est un etat qu'une ligne de YAML
+    # defait : si un declencheur pull_request est ajoute un jour, un evenement
+    # fork est refuse ICI.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    timeout-minutes: 10
+    concurrency:
+      group: linux-self-hosted-policy
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: python -m pip install pytest
+
+      # Preuve d'identite : ce job doit s'executer DANS le conteneur Linux
+      # (RUNNER_OS=Linux, RUNNER_ARCH=X64), pas sur un runner Windows ou
+      # GitHub-hosted -- sinon la demonstration #13378 est nulle.
+      - name: Identity proof
+        run: |
+          echo "runner.name=$RUNNER_NAME"
+          echo "runner.os=$RUNNER_OS"
+          echo "runner.arch=$RUNNER_ARCH"
+          echo "runner.temp=$RUNNER_TEMP"
+          python --version
+          [ "$RUNNER_OS" = "Linux" ] || { echo "FAIL: RUNNER_OS != Linux"; exit 1; }
+
+      # Guard de policy self-hosted : python pur, non critique, aucune
+      # ecriture hors workspace conteneurise.
+      - name: Run runner-policy tests
+        run: python -m pytest scripts/tests/test_check_self_hosted_runner_policy.py -v

--- a/.github/workflows/linux-self-hosted-tests.yml
+++ b/.github/workflows/linux-self-hosted-tests.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install test dependencies
-        run: python -m pip install pytest
+        run: python -m pip install pytest pyyaml
 
       # Preuve d'identite : ce job doit s'executer DANS le conteneur Linux
       # (RUNNER_OS=Linux, RUNNER_ARCH=X64), pas sur un runner Windows ou

--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -197,6 +197,34 @@ Le stamp `_work\_tool` (section précédente) persiste à travers ces cycles : l
 
 Diagnostic complet et arbitrage : #13217. Chantier runners : #12704.
 
+## Runner Linux conteneurisé (po-2024, mission #13378)
+
+Le volet Linux du chantier passe par **Docker plutôt que WSL nu** (décision user relayée par ai-01, dispatch 2026-08-31) : isolation (conteneur jetable vs compte Windows sous ACL), éphémérité native (cycle de vie porté par `docker run --rm`, pas de ré-enregistrement à orchestrer côté service), plafonnement ressources par le daemon.
+
+**Contexte** : `scripts/ci/docker/linux-runner/` (Dockerfile — runner 2.336.0 linux-x64 épinglé par SHA-256 officiel, utilisateur non-root, aucun montage hôte ; entrypoint — enregistrement via `ACTIONS_RUNNER_INPUT_*` uniquement, jamais `--token` en argv).
+
+**Lancement cappé** (contraintes user : la machine sert aussi de workstation GPU + interactive — l'hôte prime sur la CI) :
+
+```bash
+TOKEN=$(gh api repos/jsboige/CoursIA/actions/runners/registration-token --jq .token)
+docker run --rm -d --name coursia-linux-runner \
+  --cpus=3 --memory=4g --pids-limit=384 \
+  --security-opt=no-new-privileges \
+  -e ACTIONS_RUNNER_INPUT_TOKEN="$TOKEN" \
+  -e ACTIONS_RUNNER_INPUT_URL=https://github.com/jsboige/CoursIA \
+  -e ACTIONS_RUNNER_INPUT_NAME=myia-po-2024-linux-docker \
+  -e ACTIONS_RUNNER_INPUT_LABELS=self-hosted,coursia-ephemeral,coursia-linux \
+  coursia-linux-runner:2.336.0
+```
+
+Pas de `--gpus` (aucun passthrough GPU, par design). Le runner `--ephemeral` traite **au plus un job** puis se désenregistre et le conteneur `--rm` disparaît : un dispatch = un job = un conteneur. La concurrence est plafonnée à 1 par construction.
+
+**Labels dédiés** : le jeu `{self-hosted, coursia-ephemeral, coursia-linux}` (second jeu admis par `check_self_hosted_runner_policy.py`) route uniquement vers le conteneur — un dispatch Windows ne peut jamais y atterrir, un job Linux ne peut jamais atterrir sur un runner Windows. Mélanger les deux jeux reste une violation (`RUNNER_LABELS`).
+
+**État pilote** : `linux-self-hosted-tests.yml` est dispatch-ONLY (zéro fan-out, pattern #13097) et exécute le guard de policy (`test_check_self_hosted_runner_policy.py`, python pur, aucune écriture hors workspace conteneurisé). Les 93 jobs ubuntu-latest du census #13378 restent sur GitHub-hosted tant que la mesure d'empreinte n'a pas porté l'élargissement — décision coordinateur, pas worker.
+
+Si l'empreinte mesurée pendant un job gêne la workstation (training GPU, sessions interactives), on **réduit les caps ou on arrête**, et on le signale à ai-01.
+
 ## Tranches suivantes, activation partielle
 
 La préparation complète reste découpée :

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -33,14 +33,28 @@ REQUIRED_LABELS = {
     "coursia-ephemeral",
     "coursia-fast-guards",
 }
+# Dedicated label set for the containerized Linux runner (mission #13378,
+# dispatch ai-01 2026-08-31, po-2024): routes ONLY to the Docker container,
+# never to the Windows fast-guards runners -- the distinct label is the
+# routing guarantee (a windows dispatch must not land on Linux).
+LINUX_RUNNER_LABELS = {
+    "self-hosted",
+    "coursia-ephemeral",
+    "coursia-linux",
+}
+DEDICATED_LABEL_SETS = (REQUIRED_LABELS, LINUX_RUNNER_LABELS)
 # Owner-approved additions must cite the lane that owns the runner deployment:
 # - pr-gate-stale-sweep.yml: schedule-mutualized re-aggregation (pre-existing).
 # - windows-self-hosted-tests.yml: workflow_dispatch-ONLY vehicle for the 9
 #   @requires_windows confinement tests (#13063 skip surface), zero fan-out
 #   (#13097), executed on an --ephemeral runner (#12704, po-2024, #13135).
+# - linux-self-hosted-tests.yml: workflow_dispatch-ONLY pilot vehicle for the
+#   containerized Linux runner (#13378, po-2024, dispatch ai-01 2026-08-31),
+#   zero fan-out, --ephemeral inside a capped Docker container.
 SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "pr-gate-stale-sweep.yml",
     "windows-self-hosted-tests.yml",
+    "linux-self-hosted-tests.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",
@@ -313,8 +327,12 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                     "runner groups are unavailable for this personal-account repository",
                 ))
 
-            missing = sorted(REQUIRED_LABELS - labels)
-            unexpected = sorted(labels - REQUIRED_LABELS)
+            if any(set(labels) == allowed for allowed in DEDICATED_LABEL_SETS):
+                missing: list[str] = []
+                unexpected: list[str] = []
+            else:
+                missing = sorted(REQUIRED_LABELS - labels)
+                unexpected = sorted(labels - REQUIRED_LABELS)
             if missing or unexpected:
                 detail = []
                 if missing:

--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -20,6 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip \
+       libicu74 \
     && rm -rf /var/lib/apt/lists/*
 
 # Tarball runner epingle par SHA-256 (meme discipline que les profils

--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -1,0 +1,43 @@
+# Runner GitHub Actions Linux conteneurise (mission #13378, dispatch ai-01
+# 2026-08-31 : levier Docker plutot que WSL nu sur po-2024).
+#
+# Cycle de vie : conteneur --rm, runner --ephemeral (AU PLUS UN JOB puis
+# desenregistrement natif). Toute l'invocation passe par l'environnement
+# ACTIONS_RUNNER_INPUT_* (jamais --token en argv) -- cf manage_self_hosted_runner.py
+# et docs/ci/self-hosted-runners.md.
+#
+# Isolation : utilisateur non-root, no-new-privileges au lancement, AUCUN
+# passthrough GPU (contrainte user : la machine sert aussi de workstation
+# GPU), work dir interne au conteneur (aucun montage hote).
+
+FROM ubuntu:24.04
+
+ARG RUNNER_VERSION=2.336.0
+# Checksum officiel de la release v2.336.0 (notes de release actions/runner).
+ARG RUNNER_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Tarball runner epingle par SHA-256 (meme discipline que les profils
+# self_hosted_runner_profiles.json).
+ADD https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz /tmp/runner.tar.gz
+RUN echo "${RUNNER_SHA256}  /tmp/runner.tar.gz" | sha256sum -c - \
+    && mkdir -p /opt/runner \
+    && tar xzf /tmp/runner.tar.gz -C /opt/runner \
+    && rm /tmp/runner.tar.gz
+
+RUN useradd -m -u 1001 runner \
+    && mkdir -p /home/runner/_work \
+    && chown -R runner:runner /opt/runner /home/runner
+
+USER runner
+WORKDIR /opt/runner
+
+COPY --chown=runner:runner entrypoint.sh /opt/runner/entrypoint.sh
+RUN chmod +x /opt/runner/entrypoint.sh
+
+ENTRYPOINT ["/opt/runner/entrypoint.sh"]

--- a/scripts/ci/docker/linux-runner/entrypoint.sh
+++ b/scripts/ci/docker/linux-runner/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Enregistrement ephemere du runner conteneurise. Le token ne passe JAMAIS
+# par argv (pattern manage_self_hosted_runner.py) : config.sh lit
+# ACTIONS_RUNNER_INPUT_TOKEN. Requis a l'appel (docker run -e ...) :
+#   ACTIONS_RUNNER_INPUT_TOKEN   token d'enregistrement (valable 1 h)
+#   ACTIONS_RUNNER_INPUT_URL     https://github.com/jsboige/CoursIA
+#   ACTIONS_RUNNER_INPUT_NAME    myia-po-2024-linux-docker
+#   ACTIONS_RUNNER_INPUT_LABELS  self-hosted,coursia-ephemeral,coursia-linux
+set -euo pipefail
+
+: "${ACTIONS_RUNNER_INPUT_TOKEN:?RUNNER token manquant}"
+: "${ACTIONS_RUNNER_INPUT_URL:?RUNNER url manquante}"
+: "${ACTIONS_RUNNER_INPUT_NAME:?RUNNER name manquant}"
+: "${ACTIONS_RUNNER_INPUT_LABELS:?RUNNER labels manquants}"
+
+export ACTIONS_RUNNER_INPUT_EPHEMERAL=true
+export ACTIONS_RUNNER_INPUT_REPLACE=true
+export ACTIONS_RUNNER_INPUT_WORK=/home/runner/_work
+
+cd /opt/runner
+./config.sh --unattended --ephemeral --replace
+
+# Teardown symetrique : --ephemeral desenregistre de lui-meme apres le job ;
+# le trap couvre les sorties en erreur (config echoue, run.sh interrompu).
+trap './config.sh remove --unattended || true' EXIT
+
+exec ./run.sh

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -112,6 +112,40 @@ def test_missing_label_is_rejected_in_allowed_workflow(tmp_path):
     assert codes(policy.scan_workflows(tmp_path)) == {"RUNNER_LABELS"}
 
 
+def test_linux_label_set_is_accepted_in_allowlisted_workflow(tmp_path):
+    # Mission #13378: the containerized Linux runner (po-2024) carries its
+    # own dedicated label set -- coursia-linux routes only to the container,
+    # never to the Windows fast-guards runners.
+    write_workflow(tmp_path, "linux-self-hosted-tests", """
+        name: linux
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+            steps:
+              - run: echo safe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.violations == []
+    assert result.self_hosted_jobs == 1
+
+
+def test_mixed_linux_and_fast_guards_labels_are_rejected(tmp_path):
+    # Mixing the two dedicated sets must stay a violation: a job eligible
+    # for both the Windows runners and the Linux container would make the
+    # routing guarantee meaningless.
+    write_workflow(tmp_path, "linux-self-hosted-tests", """
+        name: mixed
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-linux, coursia-fast-guards]
+            steps:
+              - run: echo unsafe
+        """)
+    assert codes(policy.scan_workflows(tmp_path)) == {"RUNNER_LABELS"}
+
+
 def test_unexpected_label_is_rejected_in_allowed_workflow(tmp_path):
     write_workflow(tmp_path, "pr-gate-stale-sweep", """
         name: labels


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #13860

Mission ai-01 HIGH (dispatch msg-20260831T180554-9b1l90, ACKED msg-20260831T184910-yo908d) : « WSL-Ubuntu + Docker — le levier Linux remplace le portage Windows » sur #13378. Sous-ensemble pilote **étroit et non critique**, élargissement gated par la mesure.

## Livrables (6 fichiers)

1. **`scripts/ci/docker/linux-runner/`** — contexte Docker du runner : `Dockerfile` (ubuntu:24.04, runner 2.336.0 linux-x64 **épinglé par SHA-256 officiel** `04cf0be1…` des notes de release actions/runner ; utilisateur non-root uid 1001 ; **aucun montage hôte** ; prérequis python3/git/jq) + `entrypoint.sh` (enregistrement `ACTIONS_RUNNER_INPUT_*` uniquement — **jamais `--token` en argv**, pattern maison `manage_self_hosted_runner.py` ; `config.sh --unattended --ephemeral --replace` puis `run.sh` ; trap `remove` symétrique).
2. **`.github/workflows/linux-self-hosted-tests.yml`** — véhicule **dispatch-ONLY** (zéro fan-out CI, pattern #13097), UN job : identity-proof (`RUNNER_OS=Linux` asserté) + `test_check_self_hosted_runner_policy.py` (python pur, aucune écriture hors workspace conteneurisé). Garde fork explicite au niveau job (defense-in-depth, pattern maison).
3. **`scripts/ci/check_self_hosted_runner_policy.py`** — extension à un **second jeu de labels dédié** `{self-hosted, coursia-ephemeral, coursia-linux}` : le routage conteneur-only est la garantie (un dispatch Windows ne peut jamais atterrir sur Linux, inversement aussi ; mélanger les deux jeux reste `RUNNER_LABELS`). Allowlist `linux-self-hosted-tests.yml` **citée** (lane po-2024, #13378) — le mécanisme prévu par la règle « owner-approved additions must cite the lane ».
4. **`scripts/tests/test_check_self_hosted_runner_policy.py`** — 2 tests : jeu linux accepté dans workflow allowlisté ; mélange linux+fast-guards rejeté.
5. **`docs/ci/self-hosted-runners.md`** — section « Runner Linux conteneurisé (po-2024, mission #13378) » : cycle de vie (1 dispatch = 1 job = 1 conteneur `--rm`), commande de lancement cappée, règle d'arrêt (l'hôte prime).

## Contraintes user respectées (verbatim dispatch)

| Contrainte | Mise en œuvre |
|---|---|
| « n'étouffe pas la machine qui sert aussi pour sa GPU » | **Aucun `--gpus`** (pas de passthrough, aucun device nvidia dans le conteneur) ; caps `--cpus=3 --memory=4g` calibrées APRÈS mesure de la charge existante (VM 16 CPUs / 23,4 GiB, stack TTS active à 110 % CPU / 4,6 GiB — marge conservée) |
| Concurrence plafonnée | 1 par construction : `--ephemeral` (au plus un job) + `--rm` (le conteneur disparaît après) — pas de file d'attente possible |
| Charge lourde hors runner par défaut | Workflow **dispatch-only** : aucun job automatique, papermill et dérivés ne peuvent pas y atterrir sans geste explicite |
| L'hôte prime | Règle documentée : interference mesurée → réduire caps ou arrêter + DM ai-01 |

## Validation

- `pytest scripts/tests/test_check_self_hosted_runner_policy.py` : **37/37 verts** (35 préexistants + 2 nouveaux).
- Scan réel du dépôt : `check_self_hosted_runner_policy.py` → **OK, 3 self-hosted jobs (2 Windows + 1 Linux), 0 violation**.
- `docker build` : SUCCESS (sha256 `04cf0be1…` vérifié dans le layer, `OK` au `sha256sum -c`).
- **Enregistrement réel prouvé** : conteneur lancé cappé → runner `myia-po-2024-linux-docker` **online** sur l'API (`status: online`, labels `{self-hosted, X64, coursia-ephemeral, Linux, coursia-linux}`), logs « Connected to GitHub / Listening for Jobs ».
- **Empreinte idle mesurée** : 0,00 % CPU · 39,9 MiB / 4 GiB · 15 PIDs — négligeable ; stack TTS voisine inchangée (tts-qwen 115 % avant/après, aucune interférence).
- **Exécution d'un job** : `workflow_dispatch` exige que le workflow soit enregistré sur la branche par défaut (mesuré : 404 API tant que le fichier n'est pas sur `main` — un tag ne suffit pas) → premier dispatch **post-merge**, 1 commande (`gh workflow run linux-self-hosted-tests.yml`). Le conteneur lancé consommera ce job puis se désenregistre nativement.

## Non porté ici (délibéré)

- **Registre `self_hosted_runner_profiles.json` non étendu** : `_validate_profile` exige exactement les 10 clés Windows + le trio fast-guards + une URL zip win-x64 — un profil Docker y serait refusé. Le pin version+sha256 vit dans le Dockerfile (équivalent fonctionnel) ; l'extension du schéma registre = PR dédiée au moment de l'élargissement, si la mesure le porte.
- Les 93 jobs ubuntu-latest du census #13378 restent sur GitHub-hosted (élargissement = décision coordinateur après mesure).

See #13378 (tranche pilote ; élargissement gated par la mesure)

---
*Émis sous dispatch coord ai-01 (mission runner #13378). Push unique, genre guard — le plat principal CONTENU du cycle est porté par ailleurs.*
