### PR TITLE
fix(guard,#13097): advisory de collision en schedule -- 176 cancelled pour 50 success, 428 min sans verdict

### DIFF
--- a/.github/workflows/pr-path-collision-advisory.yml
+++ b/.github/workflows/pr-path-collision-advisory.yml
@@ -19,16 +19,33 @@ name: PR path-collision advisory
 # a common cited issue, weak = file only) plus the overlapping paths. Strong
 # pairs additionally get the `pr-overlap` label.
 #
-# The fixed concurrency group + cancel-in-progress keeps the runner famine
-# (#13097) fed: a burst of synchronize events collapses into one scan (the
-# detector is whole-pool and idempotent, the last run covers everything).
+# Trigger changed to `schedule` (#13097 remedy A, measured 2026-08-31). The
+# pull_request trigger + a FIXED concurrency group + cancel-in-progress
+# extinguished the organ exactly when it was most needed: over 228 runs
+# (08-30 12:09Z -> 08-31 19:21Z) it produced 176 `cancelled` for 50 `success`,
+# and during the fleet peak (09Z-16Z on 08-31) 102 runs yielded 2 verdicts --
+# 83 consecutive runs across six hours yielded ZERO. Largest gap between two
+# verdicts: 428 min. A completed scan takes ~2.9 min median while the 10Z hour
+# fired one run every ~2 min: arrivals outran service, so every run died before
+# finishing, and a cancelled run posts no check-run (#13097's own mechanism).
+#
+# The detector needs NO PR context -- it reads open PRs through `gh pr list`
+# (whole-pool, idempotent; its only env dependency is GITHUB_REPOSITORY). So a
+# schedule serves it fully, removes ~228 runs/31h of PR fan-out from the
+# famished hosted pool, and lets each scan run to completion. The concurrency
+# group stays FIXED (one scan at a time is the intent) but no longer cancels
+# what is in flight: with cancel-in-progress false, the running scan finishes
+# and a burst collapses into at most one pending run, which is the behaviour
+# the group was always meant to provide.
 #
 # The organ NEVER blocks: the script always exits 0 and this job has no
 # merge/status gate.
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  # Off-round minutes: the top of the hour is when every cron in the account
+  # fires at once, which is the queue this organ must stop competing with.
+  schedule:
+    - cron: '7,27,47 * * * *'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -44,7 +61,7 @@ on:
 
 concurrency:
   group: pr-path-collision-advisory
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA -- prev: MED/guard #13781

See #13097 · See #12704 · See #13615

## Le défaut, mesuré

`pr-path-collision-advisory.yml` s'éteignait exactement quand il servait le plus. Sur **228 runs** (30/08 12:09Z → 31/08 19:21Z) :

| | runs | succès |
|---|---|---|
| heures creuses 21Z→08Z | 81 | 34 |
| **pic de flotte 09Z→16Z (31/08)** | **102** | **2** |
| dont 10Z–15Z, six heures consécutives | 83 | **0** |

**176 `cancelled` pour 50 `success`. Plus grand trou entre deux verdicts : 428 min (7 h 08).**

Mécanisme : un scan qui aboutit dure **2,9 min** (médiane) alors que l'heure 10Z déclenchait un run toutes les **~2 min**. Les arrivées dépassent le service, donc le groupe de concurrence **fixe** + `cancel-in-progress: true` tuait chaque run avant sa fin — et un run annulé ne poste aucun check-run. C'est exactement le mécanisme chiffré en #13097, toujours vivant après sa clôture du 31/08 07:27Z. Trace côté PR, sur #13724 :

```
[pr-gate] advisory (not blocking): List open-PR path collisions (cancelled)
```

L'intention écrite dans l'en-tête (« une rafale se réduit à un seul scan, le dernier couvre tout ») était juste ; c'est le moyen qui la contredisait sous charge.

## Le correctif

Le détecteur est **whole-pool et idempotent** : il lit les PRs ouvertes via `gh pr list` et n'a besoin d'**aucun contexte de PR** — sa seule dépendance d'environnement est `GITHUB_REPOSITORY` (`scripts/check_pr_path_collisions.py:507`). Un `schedule` le sert donc intégralement.

- `pull_request: [opened, synchronize]` → `schedule: '7,27,47 * * * *'` (minutes hors rondes : le haut de l'heure est la file que cet organe doit cesser de concurrencer). Retire ~228 runs/31 h de fan-out du pool hébergé affamé — remède A de #13097.
- `cancel-in-progress: true` → **`false`**. Le groupe reste **fixe** (un scan à la fois *est* l'intention) mais n'annule plus ce qui est en vol : le run courant va au bout et une rafale se réduit à un seul run *pending*. C'est le comportement documenté par GitHub — *« any existing pending job or workflow in the same concurrency group will be canceled and the new queued job will take its place »* — donc l'économie de runner est conservée, la complétion est garantie.

**`runs-on` inchangé (`ubuntu-latest`).** La policy d'isolation self-hosted (#12704) interdit à raison qu'un job déclenché par une PR tourne sur un runner du cluster (dépôt public, payload de fork = code non fiable à côté des credentials). Cette PR n'y touche pas.

## Validation

```
python scripts/check_pr_path_collisions.py --self-test   → rc=0, 6/6 contrôles
    OK   historical #12737/#13385 flagged strong with #13313
    OK   stacked pair produces no collision
    OK   artifact-only overlap produces no collision
    OK   disjoint-issue overlap is weak tier
    OK   body-only common issue tiers strong
python scripts/ci/check_self_hosted_runner_policy.py     → rc=0 (inchangé)
yaml.safe_load                                            → triggers=[schedule, workflow_dispatch]
                                                            cancel-in-progress=False
```

Le `--self-test` porte des contrôles **positifs** (une collision historique connue doit être signalée), pas seulement des négatifs : un détecteur débranché échouerait dessus.

## Ce que cette PR ne fait pas — déclaré

Elle n'est **pas** le plancher de ma lane. Genre `guard` = **META** (G-VAR-1 exige DEEP/MED **et** un genre de CONTENU), et c'est mon **troisième `guard` consécutif** (`prev` #13781, lui-même après #13726) — `guard` étant dans la liste LIGHT de G-VAR-3, c'est une adjacence que le protocole interdit. Je la livre parce que le travail est écrit, mesuré et validé (« on ne jette pas du travail écrit »), et je le déclare plutôt que de le maquiller en plancher tenu.

Le défaut de fond est un **défaut de provisionnement de ma propre lane**, mesuré ce cycle : 8 PRs ouvertes, **0 de contenu**. Le grain de contenu qui portera le cycle suivant est nommé dans le rapport de cycle, pas différé.
