### PR TITLE
fix(slides): split overflowing Wumpus symbols slide

### DIFF
--- a/slides/03-logique/slides.md
+++ b/slides/03-logique/slides.md
@@ -134,7 +134,11 @@ layout: default
 - Odeur, brise, lueur, choc, cri
   -> Vecteur
 
-## Symboles
+---
+layout: default
+---
+
+# Monde du Wumpus : symboles
 
 - A = Agent
 - B = Brise


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #13527

## Résumé

- sépare la liste des symboles du monde du Wumpus dans une slide dédiée ;
- préserve les huit définitions et l'image de la slide d'introduction ;
- élimine le débordement ciblé sans réduire la taille de police.

## Validation

- `scan_slidev_composition.py` : deck 128 → 129 slides ; défauts hors-canvas réels 4 → 3 ; slide Wumpus `content_bottom` 654 → 362 ; slides 7 et 8 sans hors-canvas ni chevauchement ;
- contrôle positif canonique : `CONTROL PASS`, baseline slide 5 signalée (4 éléments hors-canvas) ;
- QA visuel humain à `?clicks=99` sur les slides 7 et 8 : contenu complet, aucun chevauchement ni débordement visible ;
- Slidev v51.8.2 build : `✓ built in 11.51s` ;
- export PDF : 129 pages, 5 157 024 octets ;
- `git diff --check` : succès.

Les trois autres débordements réels du deck restent hors de cette PR atomique.

See #11508
