### PR TITLE
fix(guard,word-form): exempt measurement results with definite articles

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -495,6 +495,8 @@ def check_assertion(files: list[dict], assertion: str, block: str = "") -> list[
             pass
         elif _word_form_is_measurement_object(scan_target):
             pass
+        elif _word_form_is_measurement_result(scan_target, block):
+            pass
         else:
             problems.append(
                 f"l'assertion pretend {word_count} fichier(s), la liste effective en compte {len(files)} : "
@@ -941,6 +943,34 @@ def _word_form_is_measurement_object(text: str) -> bool:
     if m is None:
         return False
     return bool(_DISCRIMINATION_VERB.search(text[max(0, m.start() - 80):m.start()]))
+
+
+_MEASUREMENT_RESULT = re.compile(
+    r"\b(?:\d+|aucun(?:e)?)\s+(?:occurrences?|hits?|r[ée]sultats?|matches?)\b",
+    re.IGNORECASE,
+)
+_DEFINITE_WORD_FORM = re.compile(
+    r"\b(?:sur|dans)\s+(?:les|ces)\s+[*_]*"
+    r"(?:deux|trois|quatre|cinq|six|sept|huit|neuf|dix)\s+fichiers?\b",
+    re.IGNORECASE,
+)
+
+
+def _word_form_is_measurement_result(text: str, block: str = "") -> bool:
+    """True when a definite word-form count is the corpus of a measured result.
+
+    The result may sit on the same line or immediately above it in the same
+    paragraph block (soft-wrap invariant). A strong scope word keeps genuine
+    perimeter assertions blocking even when they also mention zero results.
+    """
+    surface = block or text
+    if _has_strong_scope(surface.lower()):
+        return False
+    count = _DEFINITE_WORD_FORM.search(surface)
+    if count is None:
+        return False
+    result = list(_MEASUREMENT_RESULT.finditer(surface, 0, count.start()))
+    return bool(result)
 
 
 def _additive_line_sum(line: str) -> int:

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -2970,6 +2970,38 @@ def test_13791_word_form_plain_indefinite_still_blocks():
     assert check_assertion(files, "un fichier modifié (`a.py`)") != []
 
 
+def test_13791_word_form_measurement_result_exempts():
+    """Un résultat de mesure sur les deux fichiers n'est pas le périmètre."""
+    files = [{"path": f"file-{i}.py"} for i in range(6)]
+    line = (
+        "les anciennes formes `Z3-Python 07`, `Z3-Python-06 >>` et la clé "
+        "baseline `Z3_PYTHON_CLAVIER`: **0 occurrence** sur les **deux fichiers** corrigés"
+    )
+    assert check_assertion(files, line) == []
+
+
+def test_13791_word_form_measurement_result_soft_wrap_exempts():
+    """Le résultat de mesure reste exempté après un retour à la ligne doux."""
+    files = [{"path": f"file-{i}.py"} for i in range(6)]
+    body = "les anciennes formes : **0 occurrence**\nsur les **deux fichiers** corrigés"
+    line, _context, block = extract_perimeter_assertions_with_block(body)[0]
+    assert check_assertion(files, line, block=block) == []
+
+
+def test_13791_digit_scope_with_zero_result_still_blocks():
+    """Contrôle FN : le périmètre chiffré reste rouge malgré zéro résultat."""
+    files = [{"path": "a.py"}, {"path": "b.py"}, {"path": "c.py"}]
+    line = "Périmètre : 2 fichiers twins uniquement, aucune autre modification."
+    assert check_assertion(files, line) != []
+
+
+def test_13791_word_form_scope_with_zero_result_still_blocks():
+    """Contrôle FN : le périmètre en lettres reste rouge malgré zéro résultat."""
+    files = [{"path": "a.py"}, {"path": "b.py"}, {"path": "c.py"}]
+    line = "Périmètre : deux fichiers uniquement, aucune autre modification."
+    assert check_assertion(files, line) != []
+
+
 def test_13791_paragraph_block_boundaries():
     """Le bloc paragraphe s'arrête aux lignes vides et aux fences, dans les
     deux directions."""


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: MED/slides #13867

## Résumé

- distingue les résultats de mesure du type « 0 occurrence sur les deux fichiers » des déclarations de périmètre ;
- conserve cette exemption quand la phrase est coupée sur deux lignes du même paragraphe ;
- maintient les assertions portant un marqueur fort de périmètre en échec.

## Validation

- `python -m pytest scripts/tests/test_check_pr_perimeter.py -q` : 169 tests réussis ;
- reproduction PR #13796 : `check_assertion` passe sur une fixture synthétique comportant six entrées ;
- contrôles faux négatifs chiffré et word-form : restent rouges ;
- `git -c core.whitespace=cr-at-eol diff --check origin/main..HEAD` : succès.

Dispatch direct du coordinateur, sans issue dédiée.

