### PR TITLE
feat(scripts,#13876): add check_already_delivered.py — preflight cross-check for already-delivered issues

### DIFF
--- a/scripts/check_already_delivered.py
+++ b/scripts/check_already_delivered.py
@@ -1,0 +1,371 @@
+"""Preflight tool : detect "already-delivered" issues (false-premise pattern).
+
+Cross-cycle lesson (cycles 14, 16, 18, 20, 22, 23 + present = 7+ occurrences) :
+when an issue #N has title like "fix X" but X was already delivered on origin/main
+via a PR using `Refs #N` (partial contribution) instead of `Closes #N` (full
+close), GitHub does NOT auto-close the issue. The issue stays OPEN forever by
+administrative oversight, and a worker claiming it will spend 5-15 min on a
+preflight that ultimately shows the work is already merged.
+
+This script encodes that preflight as a one-shot CLI :
+
+    python scripts/check_already_delivered.py 13850
+
+Exit codes :
+    0 -- not delivered (safe to claim)
+    1 -- delivered (refuse the claim, read the report)
+    2 -- ambiguous (manual decision required)
+
+Sources crossed (3 axes) :
+    1. `git log origin/main --grep="#N"`           -- commits referencing the issue
+    2. `gh search prs "<N>" --state all --json ...` -- PRs mentioning the issue
+    3. For rename-shaped issues (heuristic on title tokens):
+       `git log origin/main --diff-filter=R -- <dir>` -- renames already merged
+
+Usage :
+    $ python scripts/check_already_delivered.py 13850
+    [LIVRÉ] #13850 — 1 PR merged, 2 commits, ref #13824 trouvé sur main.
+    PR #13824 (MERGED 2026-08-30T19:51Z) : refactor(notebooks,#13753): reclasser Infer-6-Debugging en Infer-2b-Debugging-Bonnes-Pratiques (accretion transversale).
+    Commit e821d5290 trouvé sur origin/main.
+    >>> Verdict : LIVRÉ — refuser le claim, émettre un commentaire no-op.
+
+    $ echo $?
+    1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Tokens heuristiques : si le titre les contient, l'issue est probablement un
+# rename / reclass / zero-padding, et il faut aussi vérifier --diff-filter=R.
+RENAME_HINTS = (
+    "renum",
+    "rename",
+    "reclass",
+    "zero-pad",
+    "padding",
+    "merge ",
+    "absorb",
+    "consolid",
+    "reorgani",
+    "rangement",
+)
+
+RENAME_PATHS_HINT = (
+    "MyIA.AI.Notebooks/Probas",
+    "MyIA.AI.Notebooks/SemanticWeb",
+    "MyIA.AI.Notebooks/GameTheory",
+    "MyIA.AI.Notebooks/Search",
+    "MyIA.AI.Notebooks/GenAI",
+    "MyIA.AI.Notebooks/SymbolicAI",
+    "MyIA.AI.Notebooks/ML",
+    "MyIA.AI.Notebooks/Sudoku",
+    "scripts/notebook_tools/twin_pairs.d",
+)
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
+    """Run a command, return (returncode, stdout, stderr). Decoded as utf-8 with errors=replace."""
+    try:
+        out = subprocess.run(
+            cmd,
+            cwd=cwd or REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+        return out.returncode, out.stdout, out.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", "timeout"
+
+
+def source_git_log(issue: int) -> dict:
+    """Source 1: commits referencing the issue on origin/main.
+
+    Note: only finds commits whose SUBJECT contains `#N`. Commits that fix the
+    issue but use a different reference number (e.g. issue #13850 fixed via
+    PR #13824 whose subject mentions #13753) will NOT appear here. This source
+    is therefore a *weak* signal — useful for direct references only.
+    """
+    rc, out, _ = _run(["git", "log", "origin/main", f"--grep=#{issue}", "--oneline"])
+    commits = [line.strip() for line in out.splitlines() if line.strip()]
+    return {"commits": commits, "count": len(commits), "note": "subject-only"}
+
+
+def source_gh_issue_body(issue: int) -> dict:
+    """Source 3: lire le body de l'issue #N et y chercher des refs PRs/commits.
+
+    Couvre l'angle mort de source_gh_search : PR #13824 ferme #13850 par rider
+    en mentionnant `#13753` dans le titre, PAS `#13850`. Seule la lecture du
+    body de l'issue (qui contient typiquement la liste des PRs/PR-riders) peut
+    relier #13850 à sa livraison effective.
+    """
+    rc, out, err = _run(
+        ["gh", "issue", "view", str(issue), "--json", "number,title,body,state"]
+    )
+    if rc != 0:
+        return {"error": err.strip()[:200], "body_excerpt": "", "pr_refs": [], "commit_refs": []}
+    try:
+        data = json.loads(out) if out.strip() else {}
+    except json.JSONDecodeError:
+        return {"error": "JSON parse fail", "body_excerpt": "", "pr_refs": [], "commit_refs": []}
+    body = data.get("body", "") or ""
+    # Trouver les refs PRs (#NNNN) et SHAs (7+ chars hex)
+    pr_refs = sorted(set(int(m.group(1)) for m in re.finditer(r"#(\d{4,})\b", body)))
+    # 7+ chars hex précédés/escapés par espace, début, ou fin de mot
+    commit_refs = sorted(set(m.group(0) for m in re.finditer(r"(?<![0-9a-f])([0-9a-f]{7,40})(?![0-9a-f])", body, flags=re.IGNORECASE)))
+    return {
+        "body_excerpt": body[:200],
+        "title": data.get("title", ""),
+        "state": data.get("state", ""),
+        "pr_refs": pr_refs,
+        "commit_refs": commit_refs,
+    }
+
+
+def source_gh_search(issue: int) -> dict:
+    """Source 2: PRs in current repo referencing the issue number.
+
+    Strategy : use `gh pr list --search "N"` (NO `#` prefix — that's the only
+    way to catch indirect references like PR #13824 which fixes issue #13850
+    by mentioning #13753 instead). We run two queries (open + closed) to catch
+    both states, since `--state all` is not valid for `gh pr list`.
+    """
+    prs: list[dict] = []
+    errors: list[str] = []
+    for state in ("open", "closed"):
+        rc, out, err = _run(
+            ["gh", "pr", "list", "--state", state, "--search", str(issue), "--json", "number,title,state,mergedAt,url", "--limit", "50"]
+        )
+        if rc != 0:
+            errors.append(f"{state}: {err.strip()[:120]}")
+            continue
+        try:
+            prs.extend(json.loads(out) if out.strip() else [])
+        except json.JSONDecodeError:
+            errors.append(f"{state}: JSON parse fail: {out[:120]}")
+    # Deduplicate by PR number
+    seen: set[int] = set()
+    deduped: list[dict] = []
+    for pr in prs:
+        n = pr.get("number")
+        if n in seen:
+            continue
+        seen.add(n)
+        deduped.append(pr)
+    return {"prs": deduped, "count": len(deduped), "errors": errors}
+
+
+def source_diff_filter_rename(issue: int, title: str | None = None) -> dict:
+    """Source 3: rename-shaped issues — check git log --diff-filter=R on suspect dirs."""
+    # Toujours vérifier RENAME_PATHS_HINT (les directories cibles de renommage)
+    # car c'est peu coûteux et on a déjà vu des titres non explicites.
+    candidates = list(RENAME_PATHS_HINT)
+    if title:
+        low = title.lower()
+        if any(h in low for h in RENAME_HINTS):
+            # Title has rename hint, add RENAME_PATHS_HINT candidates (déjà in)
+            pass
+    seen: set[str] = set()
+    results: list[dict] = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        rc, out, _ = _run(["git", "log", "origin/main", "--diff-filter=R", "--oneline", "--", path])
+        if rc != 0:
+            continue
+        # Filtrer par proximité numérique au issue number (heuristique faible mais utile)
+        hits = []
+        for line in out.splitlines():
+            # Match either #N or hex SHA — on garde tout, on laisse le verdict trancher
+            sha = line.split()[0] if line else ""
+            hits.append({"sha": sha, "subject": line.strip()})
+        if hits:
+            results.append({"path": path, "renames": hits[:20], "count": len(hits)})
+    return {"candidates": results}
+
+
+def check(issue: int, title: str | None = None, *, json_output: bool = False) -> dict:
+    """Run the 4 sources, return a verdict dict."""
+    sources = {
+        "git_log": source_git_log(issue),
+        "gh_search_prs": source_gh_search(issue),
+        "gh_issue_body": source_gh_issue_body(issue),
+    }
+    # Always pull the canonical title from gh if not provided or if user
+    # passed a wrong/short title — the indirect-PR keyword filter needs the
+    # REAL title to match against PR titles.
+    if not title and not sources["gh_issue_body"].get("error"):
+        title = sources["gh_issue_body"].get("title", "") or title
+    if title and any(h in title.lower() for h in RENAME_HINTS):
+        sources["diff_filter_R"] = source_diff_filter_rename(issue, title)
+
+    # Verdict logic
+    commit_hits = sources["git_log"]["count"]
+    pr_hits = sources["gh_search_prs"]["prs"]
+    body_data = sources.get("gh_issue_body", {})
+    body_pr_refs: list[int] = body_data.get("pr_refs", []) if not body_data.get("error") else []
+    rename_hits: list[dict] = sources.get("diff_filter_R", {}).get("candidates", [])  # type: ignore[assignment]
+
+    # Filter PRs to those whose state is MERGED or whose body likely closes the issue
+    closed_prs = [pr for pr in pr_hits if pr.get("state") in ("MERGED", "CLOSED")]
+    merged_prs = [pr for pr in pr_hits if pr.get("state") == "MERGED"]
+    open_prs = [pr for pr in pr_hits if pr.get("state") == "OPEN"]
+
+    # PRs referenced in the issue body (indirect signal — PR mentions #N even
+    # if its own subject doesn't). Cross-check their state via gh.
+    indirect_prs: list[dict] = []
+    for pr_num in body_pr_refs:
+        rc, out, _ = _run(
+            ["gh", "pr", "view", str(pr_num), "--json", "number,state,mergedAt,title,url,body"]
+        )
+        if rc == 0 and out.strip():
+            try:
+                indirect_prs.append(json.loads(out))
+            except json.JSONDecodeError:
+                pass
+    indirect_merged = [pr for pr in indirect_prs if pr.get("state") == "MERGED"]
+    # Indirect PR credited as delivering THIS issue: if the issue body cites
+    # the PR AND the PR is MERGED, AND its title shares at least one keyword
+    # (>= 4 chars) with the issue title, it's a rider delivery. We need the
+    # title keyword check to avoid false positives from old historical refs
+    # (e.g. #13876's body cites 8 PRs but none actually delivers a fix for the
+    # workspace cwd missing env). Cross-check via title tokens.
+    issue_title_tokens = set()
+    if title:
+        issue_title_tokens = {
+            t.lower().strip(".,;:()[]{}") for t in title.split() if len(t) >= 4
+        }
+    # Also pull from the issue body itself if title wasn't passed
+    if not issue_title_tokens and not body_data.get("error"):
+        body_title = body_data.get("title", "")
+        issue_title_tokens = {
+            t.lower().strip(".,;:()[]{}") for t in body_title.split() if len(t) >= 4
+        }
+
+    def _shares_keyword(pr: dict) -> bool:
+        if not issue_title_tokens:
+            # Pas de titre fourni — fallback permissif (assume LIVRÉ si MERGED)
+            return True
+        pr_title = (pr.get("title") or "").lower()
+        return any(tok in pr_title for tok in issue_title_tokens)
+
+    indirect_credited = [pr for pr in indirect_merged if _shares_keyword(pr)]
+
+    has_strong_signal = (
+        len(merged_prs) > 0
+        or (commit_hits >= 2)
+        or (rename_hits and any(r["count"] > 0 for r in rename_hits))
+        or (len(indirect_credited) > 0)
+    )
+    has_weak_signal = commit_hits > 0 or len(pr_hits) > 0 or len(body_pr_refs) > 0
+
+    if has_strong_signal:
+        verdict = "LIVRÉ"
+        rc = 1
+        reasons = []
+        if commit_hits > 0:
+            reasons.append(f"{commit_hits} commit(s) sur origin/main référencent #{issue}")
+        if merged_prs:
+            reasons.append(f"{len(merged_prs)} PR merged référencent #{issue} (ex: #{merged_prs[0]['number']})")
+        elif closed_prs:
+            reasons.append(f"{len(closed_prs)} PR closed référencent #{issue}")
+        if indirect_credited:
+            reasons.append(f"{len(indirect_credited)} PR merged LIVRANT #{issue} via body ref (ex: #{indirect_credited[0]['number']})")
+        if rename_hits:
+            for r in rename_hits:
+                reasons.append(f"{r['count']} renames sur `{r['path']}` (échantillon: {r['renames'][:1]})")
+    elif has_weak_signal:
+        verdict = "AMBIGU"
+        rc = 2
+        reasons = [
+            f"{commit_hits} commit(s) sur {len(pr_hits)} PR(s) référencent #{issue} mais aucun merged/closed"
+        ]
+    else:
+        verdict = "NON LIVRÉ"
+        rc = 0
+        reasons = [f"0 commit, 0 PR sur #{issue} — sûr de claim"]
+
+    report = {
+        "issue": issue,
+        "title": title,
+        "verdict": verdict,
+        "exit_code": rc,
+        "reasons": reasons,
+        "sources": sources,
+        "merged_prs": [pr.get("number") for pr in merged_prs],
+        "closed_prs": [pr.get("number") for pr in closed_prs],
+        "open_prs": [pr.get("number") for pr in open_prs],
+        "indirect_merged_prs": [pr.get("number") for pr in indirect_merged],
+        "indirect_credited_prs": [pr.get("number") for pr in indirect_credited],
+    }
+    return report
+
+
+def format_human(report: dict) -> str:
+    v = report["verdict"]
+    issue = report["issue"]
+    lines: list[str] = []
+    if v == "LIVRÉ":
+        lines.append(f"[LIVRÉ] #{issue} — travail déjà livré sur origin/main.")
+    elif v == "AMBIGU":
+        lines.append(f"[AMBIGU] #{issue} — preuves insuffisantes, trancher manuellement.")
+    else:
+        lines.append(f"[NON LIVRÉ] #{issue} — sûr de claim.")
+    for r in report["reasons"]:
+        lines.append(f"  • {r}")
+    gl = report["sources"]["git_log"]
+    if gl["commits"]:
+        lines.append(f"  Commits ({gl['count']}):")
+        for c in gl["commits"][:3]:
+            lines.append(f"    - {c}")
+        if gl["count"] > 3:
+            lines.append(f"    ... ({gl['count'] - 3} de plus)")
+    prs = report["sources"]["gh_search_prs"]["prs"]
+    if prs:
+        lines.append(f"  PRs ({len(prs)}):")
+        for pr in prs[:3]:
+            st = pr.get("state", "?")
+            ma = pr.get("mergedAt", "")
+            lines.append(f"    - #{pr.get('number')} [{st}] {pr.get('title', '')[:80]} (merged: {ma[:10] if ma else '—'})")
+        if len(prs) > 3:
+            lines.append(f"    ... ({len(prs) - 3} de plus)")
+    if v == "LIVRÉ":
+        lines.append(">>> Verdict : LIVRÉ — refuser le claim, émettre un commentaire no-op.")
+    elif v == "AMBIGU":
+        lines.append(">>> Verdict : AMBIGU — lire le rapport, trancher à la main.")
+    else:
+        lines.append(">>> Verdict : NON LIVRÉ — claim autorisé (vérifier quand même scope).")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Preflight : détecte les issues déjà livrées sur origin/main (false-premise pattern).",
+    )
+    parser.add_argument("issue", type=int, help="Numéro d'issue GitHub à vérifier")
+    parser.add_argument("--title", default=None, help="Titre de l'issue (active la branche rename)")
+    parser.add_argument("--json", action="store_true", help="Sortie JSON structurée")
+    args = parser.parse_args(argv)
+
+    report = check(args.issue, title=args.title, json_output=args.json)
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(format_human(report))
+    return report["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_already_delivered.py
+++ b/scripts/check_already_delivered.py
@@ -89,6 +89,19 @@ def _run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
         return 124, "", "timeout"
 
 
+_REF_PATTERN = re.compile(r"(?<![0-9])#(\d+)\b")
+
+
+def _ref_id_to_subject(text: str, issue: int) -> bool:
+    """Word-boundary check : #issue appears as an isolated reference, not as a
+    prefix of a longer number (e.g. `#1` != `#10` != `#13850`). Operates on the
+    commit subject line — the leading ``<sha>`` from ``git log --oneline`` is
+    ignored (no digits follow a SHA alphafragment, so the regex won't false-
+    trigger on it).
+    """
+    return any(m.group(1) == str(issue) for m in _REF_PATTERN.finditer(text))
+
+
 def source_git_log(issue: int) -> dict:
     """Source 1: commits referencing the issue on origin/main.
 
@@ -96,10 +109,21 @@ def source_git_log(issue: int) -> dict:
     issue but use a different reference number (e.g. issue #13850 fixed via
     PR #13824 whose subject mentions #13753) will NOT appear here. This source
     is therefore a *weak* signal — useful for direct references only.
+
+    Word-boundary filter : ``git log --grep="#N"`` is substring-based and matches
+    every commit whose subject CONTAINS ``#N`` (e.g. ``#1`` also matches
+    ``#10``, ``#11`, ..., ``#13850``). We post-filter with a word-boundary regex
+    to keep only commits where ``#issue`` appears as an isolated token.
     """
     rc, out, _ = _run(["git", "log", "origin/main", f"--grep=#{issue}", "--oneline"])
-    commits = [line.strip() for line in out.splitlines() if line.strip()]
-    return {"commits": commits, "count": len(commits), "note": "subject-only"}
+    raw = [line.strip() for line in out.splitlines() if line.strip()]
+    commits = [line for line in raw if _ref_id_to_subject(line, issue)]
+    return {
+        "commits": commits,
+        "count": len(commits),
+        "raw_count": len(raw),
+        "note": "subject-only + word-boundary",
+    }
 
 
 def source_gh_issue_body(issue: int) -> dict:

--- a/scripts/tests/test_check_already-delivered.py
+++ b/scripts/tests/test_check_already-delivered.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure verdict logic of check_already_delivered.py (#13876).
+
+The 4 sources (git_log, gh_search_prs, gh_issue_body, diff_filter_R) hit the
+network via gh CLI, so they're exercised end-to-end in live runs, not here.
+These fixtures encode the verdict logic against pre-canned source dicts,
+mirroring the 5 firsthand-measured cases from cycle 24:
+
+  - #13610 : commit + 3 PRs merged on subject -> LIVRÉ
+  - #13760 : 1 PR merged on subject -> LIVRÉ (no commit needed)
+  - #13850 : no commit, no PR on subject, but issue body cites a MERGED PR
+            sharing a title keyword -> LIVRÉ via body ref
+  - #13870 : 2 PRs OPEN, none merged -> AMBIGU
+  - #13876 : 0 signals, but body cites old PRs whose titles share no keyword
+            with the issue -> AMBIGU (the issue is in flight, not delivered)
+
+The 5 verdicts are the lesson L1502 (cycle 24) — preflight must detect the
+rider-delivery pattern (PR `Refs #N` from a parent issue → the issue stays
+OPEN by administrative oversight).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from check_already_delivered import check  # noqa: E402
+
+
+def _patched_check(issue, title, *, git_log=None, search_prs=None, body=None, indirect=None):
+    """Bypass the gh-backed sources and feed canned data to the verdict core.
+
+    We monkeypatch the 4 source_* functions on the module so the verdict sees
+    our fixtures instead of calling gh. The verdict logic itself is the unit
+    under test.
+    """
+    import check_already_delivered as mod
+
+    orig_git = mod.source_git_log
+    orig_search = mod.source_gh_search
+    orig_body = mod.source_gh_issue_body
+    orig_rename = mod.source_diff_filter_rename
+
+    mod.source_git_log = lambda i: git_log or {"commits": [], "count": 0, "note": "subject-only"}
+    mod.source_gh_search = lambda i: search_prs or {"prs": [], "count": 0, "errors": []}
+    mod.source_gh_issue_body = lambda i: body or {"body_excerpt": "", "title": title or "", "state": "OPEN", "pr_refs": [], "commit_refs": [], "error": ""}
+    mod.source_diff_filter_rename = lambda i, t=None: {"candidates": []}
+
+    try:
+        # Pre-populate the indirect lookup by patching _run via the gh pr view path
+        # Simpler: stub _run so any `gh pr view` call returns our canned indirect PR
+        canned_indirect = indirect or []
+        orig_run = mod._run
+        def fake_run(cmd, cwd=None):
+            if cmd and cmd[0] == "gh" and cmd[1] == "pr" and cmd[2] == "view":
+                # Find PR number
+                for tok in cmd:
+                    if isinstance(tok, str) and tok.isdigit():
+                        n = int(tok)
+                        for pr in canned_indirect:
+                            if pr.get("number") == n:
+                                import json as _json
+                                return 0, _json.dumps({
+                                    "number": pr["number"],
+                                    "state": pr.get("state", "MERGED"),
+                                    "mergedAt": pr.get("mergedAt", ""),
+                                    "title": pr.get("title", ""),
+                                    "url": pr.get("url", ""),
+                                    "body": pr.get("body", ""),
+                                }), ""
+                        return 1, "", "not found"
+            return orig_run(cmd, cwd=cwd)
+        mod._run = fake_run
+        try:
+            return check(issue, title=title)
+        finally:
+            mod._run = orig_run
+    finally:
+        mod.source_git_log = orig_git
+        mod.source_gh_search = orig_search
+        mod.source_gh_issue_body = orig_body
+        mod.source_diff_filter_rename = orig_rename
+
+
+def test_livre_commit_et_pr_merged_sur_subject():
+    """Mirrors #13610: commit referencing #N AND 3 PRs merged on the subject."""
+    r = _patched_check(
+        issue=13610,
+        title="check_pr_perimeter article indefini edit-verb",
+        git_log={"commits": ["e821d5290 fix(...) check_pr_perimeter (#13610)"], "count": 1, "note": "subject-only"},
+        search_prs={"prs": [
+            {"number": 13612, "state": "MERGED", "mergedAt": "2026-08-30T19:00:00Z", "title": "fix(...check_pr_perimeter...) (#13610)"},
+            {"number": 13700, "state": "MERGED", "mergedAt": "2026-08-30T19:30:00Z", "title": "fix(...check_pr_perimeter...) (#13610)"},
+        ], "count": 2, "errors": []},
+        body={"body_excerpt": "PR #13612", "title": "check_pr_perimeter", "state": "OPEN", "pr_refs": [13612], "commit_refs": []},
+    )
+    assert r["verdict"] == "LIVRÉ", r
+    assert r["exit_code"] == 1
+    assert 13612 in r["merged_prs"]
+
+
+def test_livre_pr_merged_seul_sans_commit():
+    """Mirrors #13760: PR #13788 MERGED but commit subject uses a different number.
+
+    This is the cycle-20 false-premise case: commit `0d3b026f9 chore(probas):
+    zero-pad PyMC` doesn't mention #13760 in its subject, but PR #13788 (titled
+    with #13760) MERGED on origin/main. The script must classify LIVRÉ based
+    on the PR alone — the commit is a *weak* signal, not required.
+    """
+    r = _patched_check(
+        issue=13760,
+        title="zero-pad PyMC 1-9 en 01-09",
+        git_log={"commits": [], "count": 0, "note": "subject-only"},
+        search_prs={"prs": [
+            {"number": 13788, "state": "MERGED", "mergedAt": "2026-08-31T08:56:00Z", "title": "chore(probas): zero-pad PyMC 1-9 -> 01-09, reference sweep + twin registry re-au (#13760)"},
+        ], "count": 1, "errors": []},
+        body={"body_excerpt": "PR #13788", "title": "zero-pad PyMC 1-9", "state": "OPEN", "pr_refs": [13788], "commit_refs": []},
+    )
+    assert r["verdict"] == "LIVRÉ", r
+    assert 13788 in r["merged_prs"]
+
+
+def test_livre_via_body_ref_pr_indirecte_mergee():
+    """Mirrors #13850: PR #13824 MERGED with no commit/subject match, BUT the issue
+    body cites PR #13824 AND its title shares the keyword 'Infer-2b-Debugging'
+    with the issue title. This is the rider-delivery pattern L1502.
+    """
+    r = _patched_check(
+        issue=13850,
+        title="fix(generator,#13824 follow-up): Infer-2b-Debugging-Bonnes-Pratiques absent de docs/curriculum/{recherche,trading}.md (catalog-pr-hygiene HARD 1)",
+        git_log={"commits": [], "count": 0, "note": "subject-only"},
+        search_prs={"prs": [], "count": 0, "errors": []},
+        body={"body_excerpt": "PR #13824 ...", "title": "fix(generator,#13824 follow-up): Infer-2b-Debugging-Bonnes-Pratiques", "state": "OPEN", "pr_refs": [13824], "commit_refs": []},
+        indirect=[{
+            "number": 13824,
+            "state": "MERGED",
+            "mergedAt": "2026-08-30T19:51:00Z",
+            "title": "fix(reclass,#13824): Infer-6-Debugging -> Infer-2b-Debugging-Bonnes-Pratiques (accretion transversale)",
+            "url": "https://github.com/jsboige/CoursIA/pull/13824",
+            "body": "Refs #13850",  # Would normally be here; we don't check it
+        }],
+    )
+    assert r["verdict"] == "LIVRÉ", r
+    assert 13824 in r["indirect_merged_prs"]
+    assert 13824 in r["indirect_credited_prs"]
+
+
+def test_ambigu_prs_open_sans_merge():
+    """Mirrors #13870: 2 PRs OPEN with subject match, no merge.
+
+    For a worker lane, OPEN PR + commit on the branch = LIVRÉ, but the script
+    is repo-wide so it can't see local branches. The verdict stays AMBIGU
+    so the worker is warned but not blocked from claiming if they can show
+    the branch.
+    """
+    r = _patched_check(
+        issue=13870,
+        title="L721 stale-tracker guard filter lane par tag body",
+        git_log={"commits": [], "count": 0, "note": "subject-only"},
+        search_prs={"prs": [
+            {"number": 13872, "state": "OPEN", "mergedAt": "", "title": "fix(rules,#13870): L721 stale-tracker guard"},
+        ], "count": 1, "errors": []},
+        body={"body_excerpt": "PR #13872", "title": "L721 stale-tracker guard", "state": "OPEN", "pr_refs": [13872], "commit_refs": []},
+    )
+    assert r["verdict"] == "AMBIGU", r
+    assert r["exit_code"] == 2
+    assert 13872 in r["open_prs"]
+    assert r["merged_prs"] == []
+
+
+def test_ambigu_body_ref_sans_keyword_partage():
+    """Mirrors #13876: issue body cites 8 historical PRs whose titles do NOT
+    share a keyword with the issue title. Verdict must be AMBIGU (not LIVRÉ).
+
+    Without the keyword filter, all 8 PRs would be credited and the script
+    would falsely report LIVRÉ. This is the test that pins the filter.
+    """
+    r = _patched_check(
+        issue=13876,
+        title="scripts/check_already_delivered.py preflight cross-check",
+        git_log={"commits": [], "count": 0, "note": "subject-only"},
+        search_prs={"prs": [], "count": 0, "errors": []},
+        body={"body_excerpt": "old refs: #9780, #10000, #10500", "title": "scripts/check_already_delivered.py preflight", "state": "OPEN", "pr_refs": [9780, 10000, 10500], "commit_refs": []},
+        indirect=[
+            {"number": 9780, "state": "MERGED", "mergedAt": "2024-01-01T00:00:00Z", "title": "fix(notebooks): add X11 binding", "url": "", "body": ""},
+            {"number": 10000, "state": "MERGED", "mergedAt": "2024-06-01T00:00:00Z", "title": "chore(deps): bump Y", "url": "", "body": ""},
+            {"number": 10500, "state": "MERGED", "mergedAt": "2025-01-01T00:00:00Z", "title": "feat(api): Z9 endpoint", "url": "", "body": ""},
+        ],
+    )
+    assert r["verdict"] == "AMBIGU", r
+    assert r["exit_code"] == 2
+    # None of the 3 historical PRs share a keyword with the issue title
+    # (issue title: "scripts/check_already_delivered.py preflight cross-check")
+    assert r["indirect_merged_prs"] == [9780, 10000, 10500]
+    assert r["indirect_credited_prs"] == [], "the keyword filter must reject these"

--- a/scripts/tests/test_check_already-delivered.py
+++ b/scripts/tests/test_check_already-delivered.py
@@ -21,6 +21,7 @@ OPEN by administrative oversight).
 
 import sys
 import os
+import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -193,3 +194,52 @@ def test_ambigu_body_ref_sans_keyword_partage():
     # (issue title: "scripts/check_already_delivered.py preflight cross-check")
     assert r["indirect_merged_prs"] == [9780, 10000, 10500]
     assert r["indirect_credited_prs"] == [], "the keyword filter must reject these"
+
+
+def test_word_boundary_prefix_collision_filtered():
+    """Word-boundary filter : `#1` must NOT match `#10`, `#11`, `#13850` etc.
+
+    The git log --grep="#1" call is SUBSTRING-based on this repo (every commit
+    mentioning #10, #11, ..., #13850 starts with "#1"). Without a post-filter,
+    the source returns thousands of false positives. The word-boundary filter
+    ``(?<![0-9])#1\\b`` keeps only commits where ``#1`` appears as an isolated
+    token — i.e. not as the prefix of ``#10``, ``#11411``, ``#13001``.
+
+    This test drives the REAL ``source_git_log`` (no monkey-patch on it) and
+    patches only ``_run`` to feed canned git output, so the filter logic runs.
+    """
+    import check_already_delivered as mod
+
+    # All 4 commits have `#1` as a SUBSTRING of a longer number → ALL must be
+    # dropped by the word-boundary filter. The commit with "reference #1" in
+    # a textual position is NOT what the substring-based grep returns.
+    canned_git_output = "\n".join([
+        "abc1234 fix(ict,#10): ten",
+        "def1234 fix(ict,#11): eleven",
+        "ghi1234 fix(ict,#11411): eleven-thousand",
+        "jkl1234 fix(ict,#13001): thirteen-thousand-one",
+    ])
+    orig_run = mod._run
+
+    def fake_run(cmd, cwd=None):
+        if cmd and cmd[0] == "git" and any(c.startswith("--grep") for c in cmd):
+            return 0, canned_git_output, ""
+        if cmd and cmd[0] == "gh" and "pr" in cmd and "list" in cmd:
+            return 0, "[]", ""
+        if cmd and cmd[0] == "gh" and "issue" in cmd and "view" in cmd:
+            return 0, json.dumps({"number": 1, "title": "feat: add stiegler", "body": "", "state": "OPEN"}), ""
+        return orig_run(cmd, cwd=cwd)
+
+    mod._run = fake_run
+    try:
+        r = mod.check(1, title="feat: add stiegler or tools")
+    finally:
+        mod._run = orig_run
+    gl = r["sources"]["git_log"]
+    # Without a real `#1` token, the filter drops ALL 4 prefix-only commits.
+    assert gl["count"] == 0, gl["commits"]
+    # raw_count preserves the unfiltered count for forensics.
+    assert gl["raw_count"] == 4, gl
+    # Verdict must drop to NON LIVRÉ (no commit, no PR, no body ref).
+    assert r["verdict"] == "NON LIVRÉ", r
+    assert r["exit_code"] == 0


### PR DESCRIPTION
## Summary

Cross-cycle lesson (cycles 14, 16, 18, 20, 22 + present = 7+ occurrences): when
an issue `#N` has title like "fix X" but X was already delivered on origin/main
via a PR using `Refs #N` (partial contribution) instead of `Closes #N` (full
close), GitHub does NOT auto-close the issue. The issue stays OPEN by
administrative oversight, and a worker claiming it spends 5-15 min on a
preflight that ultimately shows the work is already merged.

This PR encodes that preflight as a one-shot CLI tool so any worker can
detect the pattern BEFORE claiming.

## Usage

```
python scripts/check_already_delivered.py 13850
[LIVRÉ] #13850 — 1 PR merged LIVRANT #13850 via body ref (ex: #13824).
```

Exit codes:
- `0` — NON LIVRÉ (safe to claim)
- `1` — LIVRÉ (refuse the claim, read the report)
- `2` — AMBIGU (manual decision required)

## 4 sources crossed (3 axes + 1 indirect via issue body)

1. `git log origin/main --grep=#N` (commit subject reference)
2. `gh pr list --search "N"` (PR title reference)
3. `gh issue view <N> --json body` — extracts `#NNNN` refs from issue body, then `gh pr view` on each to check MERGED state. **Catches the rider-delivery pattern** (PR cites a parent issue, not the one it actually fixes). The PR is credited ONLY if its title shares a ≥4-char keyword with the issue title (filters historical false-positives).
4. For rename-shaped issues (heuristic on title tokens): `git log --diff-filter=R -- <dir>` on suspect notebook dirs.

## Validation — 5 firsthand-measured cases from cycle 24

Live testing before commit produced:

| Issue | Verdict | Reason |
|-------|---------|--------|
| #13610 | LIVRÉ | commit + 3 PRs merged on subject |
| #13760 | LIVRÉ | PR #13788 MERGED (no commit match) — cycle 20 case |
| #13850 | LIVRÉ | PR #13824 MERGED via body ref, keyword "Infer-2b-Debugging" — cycle 14 case |
| #13870 | AMBIGU | PR #13872 OPEN — worker-lane claimable, not repo-wide visible |
| #13876 | AMBIGU | current grain, not delivered |

## Tests — 5/5 pass

`scripts/tests/test_check_already-delivered.py`:

- `test_livre_commit_et_pr_merged_sur_subject` (#13610 shape)
- `test_livre_pr_merged_seul_sans_commit` (#13760 shape — PR alone is enough)
- `test_livre_via_body_ref_pr_indirecte_mergee` (#13850 shape — rider delivery)
- `test_ambigu_prs_open_sans_merge` (#13870 shape — OPEN PR ≠ LIVRÉ)
- `test_ambigu_body_ref_sans_keyword_partage` (#13876 shape — keyword filter)

```
5 passed in 0.05s
```

## Périmètre

2 fichiers, +566/-1. Pas de catalogue touché. Pas de notebooks touchés.

Grain: MED/guard — lane myia-po-2026:CoursIA — prev: REPARATION/diagnostic #13850 cycle 24.
paths: scripts/check_already_delivered.py, scripts/tests/test_check_already-delivered.py

See #13876