### PR TITLE
fix(genai): audio-roll — 02-8 Fish S2 Pro est SOTA-OK, pas RECOVERABLE-USER-HAND

### DIFF
--- a/docs/genai/audio-embed-pattern.md
+++ b/docs/genai/audio-embed-pattern.md
@@ -64,12 +64,12 @@ Script réutilisable (`scratchpad`-style, adapter le path) :
 5. 0 path-leak (scan `C:\Users` / `D:\Dev` / `/home/` / `.conda` dans `outputs[].text`).
 6. 0 C.1 (`raise NotImplementedError` / `assert False` / `1/0` dans le source).
 
-## État de l'audio-roll (2026-06-28)
+## État de l'audio-roll (2026-06-28, révisé 2026-08-30)
 
-5/5 défauts **local-résolvables** livrés. Résiduels = tous non-local :
+5/5 défauts **local-résolvables** livrés. Il restait alors 4 résiduels non-local ; **02-8 en est sorti** le 2026-08-30 :
 - **02-7 YuE** → RECOVERABLE-MACHINE (flash-attn = no Windows wheels → Linux).
 - **02-9 AceStep** → RECOVERABLE-USER-HAND (HF `ACE-Step/ACE-Step` RepositoryNotFound même avec token valide).
-- **02-8 Fish S2 Pro** → RECOVERABLE-USER-HAND (`FISH_AUDIO_API_KEY` gitignored).
+- **02-8 Fish S2 Pro** → **SOTA-OK** depuis le 2026-08-30 (#13114). L'étiquette `RECOVERABLE-USER-HAND` portée ici était **mal établie** : elle cherchait une clé API cloud (`FISH_AUDIO_API_KEY`) alors qu'un **service HTTP self-hosted quantisé était déjà déployé** (`docker-configurations/services/tts-fishaudio/`, BnB NF4 4-bit, port 8197). **Aucune clé n'est requise** — le modèle tourne dans le conteneur.
 - **02-2 XTTS** → DEFERRED (Coqui archived, py ≤ 3.11 + GPU).
 
 Quand un résiduel devient local-débloqué (clé provisionnée, repo HF restauré, machine Linux dispo), ré-appliquer ce pattern.


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/guard #13826

## Summary

`docs/genai/audio-embed-pattern.md` portait, pour **02-8 Fish S2 Pro**, le verdict `RECOVERABLE-USER-HAND (FISH_AUDIO_API_KEY gitignored)` — daté du **2026-06-28** et jamais rafraîchi quand le notebook a été requalifié le **2026-08-30** (#13114).

Le notebook dit l'inverse, explicitement :

| Emplacement | Ce qui y est écrit |
|---|---|
| `02-8-Expressive-TTS.ipynb` cell 8 | `FISH_AUDIO_API_KEY` \| **Non requise** \| Le modèle tourne dans le conteneur (aucune clé API cloud) |
| cell 51 | « Verdict SOTA : Fish S2 Pro = **SOTA-OK** … L'étiquette `RECOVERABLE-USER-HAND` posée au run précédent était **mal établie** : elle cherchait une clé API cloud et un moteur Python Linux-only, alors qu'un **service HTTP self-hosted quantisé était déjà déployé sur cette lane** » |
| cell 1 | `fish_http_url = "http://localhost:8197"` — service Docker `tts-fishaudio`, BnB NF4 4-bit, GPU1 |

Le service existe dans l'arbre (`docker-configurations/services/tts-fishaudio/` : Dockerfile, docker-compose.yml, README.md). Vérifié.

## Pourquoi cette ligne méritait un correctif à elle seule

Elle ne dormait pas : **elle produisait activement une fausse escalade**. Le coordinateur re-signalait `FISH_AUDIO_API_KEY` comme bloqueur user à chaque fin de session — alors qu'aucune action user n'était requise, et que les trois issues citées comme bloquées ne l'étaient pas :

| Issue citée | État réel |
|---|---|
| #13114 | **CLOSED**, label `candidate-delivered` |
| #13593 | c'est une **PR**, **MERGED** |
| #9434 | **OPEN** mais sans rapport (mandat « quantitatif tenu par le CI » — aucun lien avec le TTS) |

C'est le mécanisme `stale-body-is-the-mechanism-of-neglect` dans sa forme la plus coûteuse : une ligne de doc périmée qui régénère à l'identique, chaque cycle, une demande adressée à l'utilisateur.

Rectification user 2026-08-31, verbatim : « c'est toi le gardien des clés, et pour les modèles locaux de GenAI, c'est po-2023:CoursIA qui les crée et les met en œuvre ». Les deux moitiés se vérifient ici — inventaire de clés relu (aucune entrée fish/tts/audio, et aucune n'est nécessaire), et le modèle est **local**, servi par le conteneur de po-2023.

## Diff

3 lignes, un seul fichier :

1. Verdict 02-8 : `RECOVERABLE-USER-HAND` → **SOTA-OK**, avec la cause de l'erreur d'étiquetage et le pointeur vers le service.
2. Cadrage du décompte : « Résiduels = tous non-local » → « Il restait alors 4 résiduels non-local ; **02-8 en est sorti** le 2026-08-30 » (la phrase d'origine devenait fausse en laissant 02-8 dans la liste).
3. Titre de section horodaté : `(2026-06-28)` → `(2026-06-28, révisé 2026-08-30)`.

Les trois autres résiduels (02-7 YuE, 02-9 AceStep, 02-2 XTTS) sont **inchangés** : leurs verdicts n'ont pas été re-mesurés ici et je ne les requalifie pas au passage.

## Déclaration de cap — pas de contournement

Ma lane a le budget LIGHT épuisé et enchaîne les grains META. Ce grain est `LIGHT/docs` et **ne prétend pas** tenir le plancher G-VAR-1 : il corrige un défaut que j'ai moi-même propagé et qui coûtait une sollicitation utilisateur par cycle. Je le déclare tel quel plutôt que de le sur-coter, et la dette de contenu de ma lane reste due.

See #13114
