### PR TITLE
feat(search,#1203): rendre les exercices MGS-7c exécutables

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7c-RosenbrockGriewank.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7c-RosenbrockGriewank.ipynb
@@ -178,6 +178,11 @@
      "output_type": "stream",
      "name": "stdout",
      "text": "Rosenbrock d2/d5/d30 distincts : d2=AE88ECD5F7D2, d5=B7BBEA88982D, d30=764196A80A50\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Infrastructure' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -270,6 +275,11 @@
      "output_type": "stream",
      "name": "stdout",
      "text": "Griewank d2/d5/d30 distincts : d2=E63E5AB748AA, d5=08E8023BDB79, d30=1A21D4092B12\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Infrastructure' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -353,53 +363,60 @@
    "cell_type": "markdown",
    "id": "ea0ae223",
    "metadata": {},
-   "source": [
-    "## Exercices\n",
-    "\n",
-    "### Exercice 1 : quantifier la *disparition* de la vallée Rosenbrock\n",
-    "\n",
-    "Mesurer la **variance spatiale** du canal rouge entre la heatmap Rosenbrock-d2 et\n",
-    "Rosenbrock-d30. Si la vallée disparaît, la variance du canal rouge devrait chuter nettement — mais le rendu déterministe le **refute sur Rosenbrock** : var(R) MONTE ×1,9 (2737→5163), elle ne chute que ×1,5 sur Griewank (7712→5085). L'intuition « structure invisible sous MAX » ne survit pas à la mesure (cf tableau ci-dessus, rendu déterministe par pixel).\n",
-    "Squelette :\n",
-    "\n",
-    "```csharp\n",
-    "var stats = new List<(int dim, double varianceRouge)>();\n",
-    "foreach (int dim in new[] { 2, 5, 30 }) {\n",
-    "    using var h = KnownFunctionLandscape.RenderHeatmap(\n",
-    "        new RosenbrockFitness(), dimension: dim, nbSamples: 50,\n",
-    "        rng: new Random(42 + dim), width: 120, height: 120);\n",
-    "    // TODO: collecter les valeurs R des 14400 pixels, calculer variance.\n",
-    "}\n",
-    "// Afficher le ratio variance(d2) / variance(d30).\n",
-    "```\n",
-    "\n",
-    "### Exercice 2 : produit-cosinus vs somme-cosinus (Griewank vs Ackley)\n",
-    "\n",
-    "Charger Ackley-d2 et Griewank-d2, comparer le **spectre de fréquences spatiales**\n",
-    "(transformée de Fourier 2-D du canal rouge). Le produit de Griewank doit montrer un\n",
-    "spectre **plus épars** (fréquences dictées par $\\sqrt{i}$) que la somme d'Ackley\n",
-    "(spectre **continu**).\n",
-    "### Exercice 3 : rudesse du paysage et comptage des minima locaux\n",
-    "\n",
-    "Un pixel de la heatmap est un **minimum local** s'il est strictement inférieur\n",
-    "à ses 4 voisins (haut, bas, gauche, droite) sur le canal rouge. Compter le\n",
-    "nombre de minima locaux pour Rosenbrock-d2 et Griewank-d2. Attendu :\n",
-    "Rosenbrock $\\approx 1$ minimum (paysage *lisse*, fond de vallée unique) ;\n",
-    "Griewank $\\gg 1$ (paysage *rugueux*, le produit de cosinus crée de nombreux\n",
-    "puits). Le ratio quantifie la **rudesse**, la propriété qui rend les\n",
-    "métaheuristiques nécessaires là où un gradient seul reste piégé. Squelette :\n",
-    "\n",
-    "```csharp\n",
-    "using var hR = KnownFunctionLandscape.RenderHeatmap(\n",
-    "    new RosenbrockFitness(), dimension: 2, nbSamples: 50,\n",
-    "    rng: new Random(42), width: 120, height: 120);\n",
-    "using var hG = KnownFunctionLandscape.RenderHeatmap(\n",
-    "    new GriewankFitness(), dimension: 2, nbSamples: 50,\n",
-    "    rng: new Random(42), width: 120, height: 120);\n",
-    "// TODO: pour chaque heatmap, parcourir les pixels interieurs (1..118),\n",
-    "// comparer R[pixel] a ses 4 voisins (haut/bas/gauche/droite), compter\n",
-    "// les minima locaux stricts et afficher le ratio Rosenbrock / Griewank.\n",
-    "```"
+   "source": "## Exercices\n\n### Exercice 1 : quantifier la *disparition* de la vallée Rosenbrock\n\nMesurez la **variance spatiale** du canal rouge entre les heatmaps Rosenbrock en dimensions 2, 5 et 30. Si la vallée disparaît, cette variance devrait chuter nettement — mais le rendu déterministe ci-dessus suggère au contraire une hausse en dimension 30. Calculez les trois variances puis le ratio `variance(d2) / variance(d30)` pour confronter l'intuition à la mesure.\n\n**Indice :** collectez la composante `R` des 14 400 pixels de chaque bitmap, puis utilisez la moyenne des carrés des écarts à la moyenne."
+  },
+  {
+   "cell_type": "code",
+   "id": "a11203cb",
+   "source": "// EXERCICE 1 : variance du canal rouge selon la dimension.\n// TODO etudiant : calculer la variance de R pour chaque heatmap.\nvar variancesRouges = new List<(int dimension, double variance)>();\nforeach (int dim in new[] { 2, 5, 30 })\n{\n    using var heatmap = KnownFunctionLandscape.RenderHeatmap(\n        new RosenbrockFitness(), dimension: dim, nbSamples: 50,\n        rng: new Random(42 + dim), width: 120, height: 120);\n\n    // Etape 1 : collecter heatmap.Bitmap.GetPixel(x, y).R pour tous les pixels.\n    // Etape 2 : calculer moyenne puis moyenne des ecarts au carre.\n    // Etape 3 : ajouter (dim, variance) a variancesRouges.\n}\n\nConsole.WriteLine(\"Exercice 1 a completer : mesurer variance(R) en d2, d5 et d30.\");",
+   "metadata": {},
+   "execution_count": 4,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 1 a completer : mesurer variance(R) en d2, d5 et d30.\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21930e48",
+   "source": "### Exercice 2 : comparer les signatures fréquentielles de Griewank et Ackley\n\nComparez en dimension 2 la structure répétitive de **Griewank** à celle d'**Ackley**. À partir du canal rouge de chaque heatmap, construisez un profil horizontal moyen, puis comparez la fréquence dominante des deux profils. L'objectif est de vérifier quantitativement la différence entre produit de cosinus et somme de cosinus.\n\n**Indice :** moyennez le canal rouge colonne par colonne avant d'appliquer une transformée discrète de Fourier ; ignorez la composante continue lors de la recherche du maximum spectral.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "3104d45a",
+   "source": "// EXERCICE 2 : profils spectraux Griewank et Ackley en dimension 2.\n// TODO etudiant : extraire les profils horizontaux moyens puis leur frequence dominante.\nvar heatmapGriewank = KnownFunctionLandscape.RenderHeatmap(\n    new GriewankFitness(), dimension: 2, nbSamples: 50,\n    rng: new Random(7), width: 120, height: 120);\nvar heatmapAckley = KnownFunctionLandscape.RenderHeatmap(\n    new AckleyFitness(), dimension: 2, nbSamples: 50,\n    rng: new Random(99), width: 120, height: 120);\n\n// Etape 1 : moyenner le canal R de chaque colonne pour chaque heatmap.\n// Etape 2 : calculer la transformee discrete de Fourier des deux profils.\n// Etape 3 : ignorer la composante continue et comparer les pics dominants.\nConsole.WriteLine(\"Exercice 2 a completer : comparer les frequences dominantes Griewank/Ackley.\");\nheatmapGriewank.Dispose();\nheatmapAckley.Dispose();",
+   "metadata": {},
+   "execution_count": 5,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 2 a completer : comparer les frequences dominantes Griewank/Ackley.\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe1c58f2",
+   "source": "### Exercice 3 : compter les minima locaux en 2-D\n\nEstimez la multimodalité visible en comptant les **minima locaux stricts** dans les heatmaps Rosenbrock et Griewank en dimension 2. Un pixel intérieur est un minimum local si son canal rouge est strictement inférieur à ceux de ses quatre voisins directs. Comparez les deux comptes et affichez leur ratio.\n\n**Indice :** parcourez seulement les pixels intérieurs (`1..118`) afin que chaque pixel possède quatre voisins ; traitez séparément un éventuel dénominateur nul.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "0860771c",
+   "source": "// EXERCICE 3 : minima locaux stricts en dimension 2.\n// TODO etudiant : compter les minima locaux de Rosenbrock et Griewank.\nvar heatmapRosenbrock2D = KnownFunctionLandscape.RenderHeatmap(\n    new RosenbrockFitness(), dimension: 2, nbSamples: 50,\n    rng: new Random(42), width: 120, height: 120);\nvar heatmapGriewank2D = KnownFunctionLandscape.RenderHeatmap(\n    new GriewankFitness(), dimension: 2, nbSamples: 50,\n    rng: new Random(42), width: 120, height: 120);\n\n// Etape 1 : parcourir x et y de 1 a 118.\n// Etape 2 : comparer R(x,y) aux quatre voisins directs.\n// Etape 3 : afficher les deux comptes et leur ratio.\nConsole.WriteLine(\"Exercice 3 a completer : compter les minima locaux Rosenbrock/Griewank.\");\nheatmapRosenbrock2D.Dispose();\nheatmapGriewank2D.Dispose();",
+   "metadata": {},
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 3 a completer : compter les minima locaux Rosenbrock/Griewank.\r\n"
+    }
    ]
   },
   {
@@ -422,7 +439,7 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": "none",
    "qcc_tokens_est": 0,
    "cpu_min": 1,


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/research-code MetaGeneticSharp#51

## Résumé

- transforme les trois exercices MGS-7c, auparavant enfermés dans une cellule Markdown, en trois couples consigne Markdown + stub C# exécutable ;
- conserve les `TODO`, indices et étapes sans livrer les solutions étudiantes ;
- ajoute un squelette borné pour la comparaison spectrale Griewank/Ackley, qui n'en avait aucun ;
- conserve le moteur réel `KnownFunctionLandscape.RenderHeatmap` et ses DLL MetaGeneticSharp.

## Validation réelle

Exécution complète avec le kernel `.net-csharp` après rebuild Debug du submodule MetaGeneticSharp :

```text
Starting kernel for MGS-7c-RosenbrockGriewank.ipynb (6 code cells)...
DONE MGS-7c-RosenbrockGriewank.ipynb: 6/6 cells, 0 errors, 9.5s
```

Contrôles post-exécution :

```text
validate_pr_notebooks.py: 1/1 passed, 6 code cells
count_exercises.py: 3 exercices, 1 notebook conforme, 0 sous le seuil
scan_cell_ordering.py: 1 clean, 0 finding
inspect_notebook: 6/6 cellules avec outputs, 0 erreur
C.1 scan: aucun NotImplementedException / NotImplementedError / assert False / 1/0
git diff --check: OK
```

Le bandeau réseau `.NET Interactive` a été retiré uniquement après la ré-exécution avec l'outil autorisé `strip_probe_banner.py --apply` (1 ligne). Aucun asset généré ni catalogue n'est modifié.

## Verdict

- **SOTA-OK** : les stubs invoquent le vrai moteur MetaGeneticSharp, sans sortie de substitution.
- Avant : `0/3` exercice détecté par l'organe canonique.
- Après : `3/3` exercices exécutables, avec outputs informatifs et sans solution exposée.

See #1203
See #2161
