### PR TITLE
fix(GameTheory,#11168): passe 2 citations arXiv — verif identites + retrait suffixe fabrique GT-13

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03a-Chemins-de-Swaps.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03a-Chemins-de-Swaps.ipynb
@@ -1221,7 +1221,7 @@
     "1. **Le quotient 576 → 144** (classes de jeux à renommage des stratégies près) et la structure $S_4 \\times S_4$ comme tore — Robinson et Goforth rapportent cette lecture ; tout ce notebook travaille sur l'espace complet des 576 jeux et n'affirme rien du quotient.\n",
     "2. **La preuve conceptuelle de la décomposition** (indépendance des côtés, graphe de Cayley, produit cartésien de graphes) — nous en livrons l'énumération exhaustive, pas la démonstration générale ; le vocabulaire Coxeter/Mahler est utilisé au strict minimum calculé.\n",
     "3. **Le tore à 37 trous** et la topologie du quotient — hors scope, rapportée.\n",
-    "4. **Les références arXiv** (2309.15981, 2102.00053, 1704.02230) — citées de seconde main via le réservoir de chantiers (#12211-#12240), non consultées en première main pour ce grain.\n",
+    "4. **Les références arXiv** (2309.15981, 2102.00053, 1704.02230) — identités vérifiées en première main (API arXiv, passe #11168 du 2026-08-31) : Tohmé & Viglizzo, *A categorical representation of games* · Czechowski & Piliouras, *Poincaré-Bendixson Limit Sets in Multi-Agent Learning* · Hedges, *Coherence for lenses and open games* ; la lecture intégrale des trois reste à faire.\n",
     "5. **La théorie des mots réduits** (16 mots pour le retournement de $S_4$) — mesurée par énumération ; la théorie générale des groupes de Coxeter qui l'explique est rapportée.\n",
     "\n",
     "**Module compagnon** : `game_theory_lean/Swaps/Basic.lean` (ce grain) — pur core Lean, sans Mathlib, sans `sorry` ; `lake build Swaps` sans dépendance.\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03b-Chambres-et-Murs.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03b-Chambres-et-Murs.ipynb
@@ -1320,7 +1320,7 @@
     "\n",
     "- **Bruns & Kimmich** — la description géométrique (chambres/murs/strates, make/break tie, archétypes) est **rapportée** de leur formalisation des jeux 2×2, non dérivée de la source primaire ici (dette n°4). Tout ce que le notebook affirme chiffré (75, 5625, 1728, 3, 2, 6, 12) est **calculé localement** et reproductible en ré-exécutant.\n",
     "- **Robinson & Goforth** — le tableau périodique des jeux 2×2 ; ancêtre Rapoport & Guyer. (L'attribution « Gale et Morris » qui circule dans certains transcripts est une hallucination corrigée.)\n",
-    "- **Dettes ouvertes (HARD)** : (1) quotient 576→144 à re-dériver ; (2) groupe $S_4 \\times S_4$ et son action ; (3) tore à 37 trous ; (4) arXiv 2309.15981, 2102.00053, 1704.02230 non ouverts firsthand.\n",
+    "- **Dettes ouvertes (HARD)** : (1) quotient 576→144 à re-dériver ; (2) groupe $S_4 \\times S_4$ et son action ; (3) tore à 37 trous ; (4) arXiv 2309.15981, 2102.00053, 1704.02230 — identités vérifiées firsthand (passe #11168 du 2026-08-31 : Tohmé & Viglizzo 2023 · Czechowski & Piliouras 2021 · Hedges 2017) ; lecture intégrale ouverte.\n",
     "- **Vocabulaire** : volontairement minimal — chambres, murs, strates, codimension, facettes. Aucun vocabulaire faisceautique au-delà de ce que le notebook calcule.\n",
     "\n",
     "*Chantier des jeux 2×2 — voir aussi* : [GT-3 Topology2x2](GameTheory-03-Topology2x2.ipynb) (l'espace et la grammaire) · [GT-3h Deux-Espèces-de-Flèches](GameTheory-03h-Deux-Especes-de-Fleches.ipynb) (quand un swap est un morphisme) · GT-3c « chemin minimal de swaps » ([issue #12222](https://github.com/jsboige/CoursIA/issues/12222), à venir)."

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -7838,7 +7838,7 @@
     "\n",
     "La section 4 a construit `CFRSolver`, un solveur recursif : la fonction `cfr(...)` parcourt l'arbre de jeu et met a jour `regret_sum[info_set]` et `strategy_sum[info_set]` a chaque noeud de decision. Ce point de vue masque une structure plus profonde : **CFR est un circuit**. Chaque information set est un **minimiseur de regret independant** (un `RegretMatcher`), et les bords du circuit transportent les **valeurs contrefactuelles** entre ces minimiseurs.\n",
     "\n",
-    "Cette section reconstruit CFR sous ce jour. Nous suivons la theorie de Farina, Kroer et Sandholm (*Regret Circuits: Composability of Regret Minimizers for Game-Theoretic Equilibrium Computation*, arXiv:1811.02540). Les briques sont :\n",
+    "Cette section reconstruit CFR sous ce jour. Nous suivons la theorie de Farina, Kroer et Sandholm (*Regret Circuits: Composability of Regret Minimizers*, arXiv:1811.02540, ICML 2019). Les briques sont :\n",
     "\n",
     "- le **sequence form** et le **treeplex** : la representation compacte des infosets et des sequences d'actions ;\n",
     "- le **realization plan** : la probabilite de realiser chaque sequence sous une strategie ;\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml
@@ -70,6 +70,12 @@
       csharp_sha: 62d089558097085b4221f5f53cddb12b0d110d12
       content_python_sha: 81d06da3de1eb4633d42ca9e450ecb765121fea236bda17836965eb3b2e1ac6e
       content_csharp_sha: d8a93c30da3c647ad3bd8f3567d5394523c73e1a5cf7b4b0f7adfc6ed10961ed
+    - date: "2026-09-01"
+      by: myia-po-2023:CoursIA-2
+      python_sha: cb188e1e95591931a5f0402fd450fae4627a63fe
+      csharp_sha: 62d089558097085b4221f5f53cddb12b0d110d12
+      content_python_sha: b84434ef10b81566b123c8beff207634d97cd1fd080dda1ca49ba7214e665f42
+      content_csharp_sha: d8a93c30da3c647ad3bd8f3567d5394523c73e1a5cf7b4b0f7adfc6ed10961ed
   known_differences:
     - "Rebaseline 2026-08-05 : cote Python deplace par de-pin des utilites de derniere iteration CFR (-0.033) et MCCFR (-0.055) depuis la prose (decision B #9434 : stochastic unseeded, la variabilite est la lecon -- pas de seed, reframe honnete type md#12/md#15 'Variable' + convergence de la moyenne vers Nash -1/18). Edition markdown-only, parite semantique inchangee (aucune cellule code / sortie / exec_count touchee) ; cote C# non modifie."
     - "Socle pedagogique commun : jeux a information imparfaite, Kuhn Poker (Kuhn 1950/1953) comme jeu de reference, regret matching (Hannan), CFR vanilla (Zinkevich et al. 2007) avec recursion contrefactuelle, variante CFR+ (Tammelin 2014), convergence de la strategie moyenne vers la valeur du jeu / equilibre de Nash."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: LIGHT/refactor #13863

## Summary

Passe 2 de l'EPIC **#11168** (citations arXiv) pour la famille **GameTheory** — balayage des IDs arXiv cités, vérification firsthand via API arXiv, correction des métadonnées fausses et mise à jour des dettes ouvertes.

Trois notebooks touchés (markdown uniquement) :

| Notebook | Cellule | Correction |
|---|---|---|
| `GameTheory-13-ImperfectInfo-CFR.ipynb` | 32 | **Suffixe de titre fabriqué** retiré : « Regret Circuits: Composability of Regret Minimizers *for Game-Theoretic Equilibrium Computation* » → « Regret Circuits: Composability of Regret Minimizers », + venue `ICML 2019` révélée. Vérifié en première main (page auteur : le titre réel n'a pas le suffixe). |
| `GameTheory-03a-Chemins-de-Swaps.ipynb` | 32 | Dette « références citées de seconde main, non consultées » → identités vérifiées (Tohmé & Viglizzo 2309.15981 · Czechowski & Piliouras 2102.00053 · Hedges 1704.02230) ; lecture intégrale reste ouverte. |
| `GameTheory-03b-Chambres-et-Murs.ipynb` | 37 | Idem : dettes « non ouverts firsthand » → identités vérifiées (mêmes 3 IDs) ; lecture intégrale ouverte. |

## Balayage — 6 IDs distincts, tous vérifiés firsthand (API arXiv, 2026-08-31)

| ID | Titre vérifié | Statut dans le corpus |
|---|---|---|
| 2309.15981v3 | Tohmé & Viglizzo — *A categorical representation of games* | correct — dettes 03a/03b documentées |
| 2102.00053v2 | Czechowski & Piliouras — *Poincaré-Bendixson Limit Sets in Multi-Agent Learning* | correct — dettes 03a/03b documentées |
| 1704.02230v3 | Hedges — *Coherence for lenses and open games* | correct — dettes 03a/03b documentées |
| 1811.02540 | Farina, Kroer & Sandholm — *Regret Circuits: Composability of Regret Minimizers* (ICML 2019) | **DÉFAUT : suffixe fabriqué retiré (GT-13 cell 32)** |
| 1705.02955v3 | Brown & Sandholm — *Safe and Nested Subgame Solving for Imperfect-Information Games* | correct |
| 1907.03712v2 | Mazumdar, Ratliff, Jordan & Sastry — *Policy-Gradient Algorithms Have No Guarantees of Convergence in Linear Quadratic Games* | correct |

## Preuves (markdown-only)

- **Zéro cellule code modifiée** : `git diff` = **+3/−3**, code, outputs et `execution_count` intacts (13/13, 13/13, 26/26).
- **4ᵉ fichier** (`ab7afbd51`) : attestation de rebaseline `twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml` — l'édition markdown-only du notebook GT-13 déplace son blob SHA (gate #8057), l'entrée d'audit atteste la parité (python_sha `cb188e1e`, côté C# inchangé, parité sémantique vérifiée firsthand : c'est la correction de citation elle-même, aucune cellule code). `--check --base origin/main` post-rebaseline : `drift_introduced=0`.
- **Vérification firsthand des 6 IDs** : `totalResults=6` cumulé sur les 2 requêtes API (chaque requête vérifie `totalResults > 0` avant tout usage des résultats).
- `check_notebook_navlinks.py --check` : **OK 0 NEW** (1194 notebooks).
- Catalogue **byte-identique** (0 diff sur `COURSE_CATALOG.*`).
- H.3 pre-commit : **Passed** (exec_count non-null sur toutes les cellules code).

## État de l'issue

`See #11168` — passe 2 GameTheory (après passe 1 = PR #12838). 1 défaut réel corrigé (GT-13), 2 dettes documentées (03a/03b). Restant famille : lot des autres familles, à partitionner en passes distinctes.

## Test plan

- [x] Vérifier diff : aucune cellule code touchée
- [x] Navlinks verts (0 NEW)
- [x] Catalogue byte-identique
- [x] H.3 pre-commit Passed
- [ ] CI PR gate

See #11168 (passe 2/∞ familles GameTheory — défaut GT-13 corrigé, dettes 03a/03b documentées)
