### PR TITLE
fix(perimeter,#13471): NFD-normalisation accents + lecture 2-mots-OR dans _count_has_incidental_qualifier

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -83,6 +83,7 @@ import shutil
 import subprocess
 import sys
 import time
+import unicodedata
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -550,6 +551,13 @@ STRONG_SCOPE_WORDS = (
 # this PR changes". Closed list measured on the 120-PR corpus; unknown
 # qualifiers stay authorial (a false negative does not signal itself, so the
 # default must fail loud).
+#
+# #13471 : les chaines accentuees sont NFD-strippees avant match (voir
+# `_count_has_incidental_qualifier`). Les entrees canoniques sont stockees
+# telles quelles pour la lisibilite de la liste (un mainteneur voit 'vérifié'
+# et comprend), mais le predicat compare les deux cotes apres strip --
+# donc 'verifié' (hybride 1er e nu / dernier accentué), 'vérifié', 'verifie',
+# 'verifies' collapsent sur la meme cle 'verifie'.
 INCIDENTAL_QUALIFIERS = frozenset({
     "mp3", "wav", "mathlib", "machine-path", "fr", "en", "scratch",
     "restants", "restant", "reste", "restants,", "nouveau", "nouveaux",
@@ -799,28 +807,79 @@ def _has_strong_scope(low: str) -> bool:
     return False
 
 
+def _strip_accents(s: str) -> str:
+    """#13471: NFD decompose + drop combining marks. Both sides of the
+    incidental-qualifier match are run through this so accent variants
+    ('verifié' hybride, 'vérifié', 'verifie') collapse to the same key.
+    Couvre les variantes futures sans nouvelle tranche de liste -- c'est
+    precisement la serie de tranches que ce depot cherche a eviter."""
+    return "".join(
+        ch for ch in unicodedata.normalize("NFD", s)
+        if unicodedata.category(ch) != "Mn"
+    )
+
+
+# #13471: pre-normalized lookup set for incidental qualifier match. We normalize
+# INCIDENTAL_QUALIFIERS once at module load (frozen set of NFD-stripped lower
+# tokens) rather than normalizing per-call -- the set is small (~80 entries)
+# and the predicate runs O(matches_per_line).
+_INCIDENTAL_QUALIFIERS_NFD = frozenset(_strip_accents(w).lower() for w in INCIDENTAL_QUALIFIERS)
+_INCIDENTAL_QUALIFIER_PAIRS_NFD = frozenset(
+    _strip_accents(p).lower() for p in INCIDENTAL_QUALIFIER_PAIRS
+)
+
+
 def _count_has_incidental_qualifier(line: str, m: re.Match) -> bool:
     """#12718: true when the COUNT match `m` is immediately followed by an
     `INCIDENTAL_QUALIFIERS` word (or a qualified two-word pair). A count so
     qualified is a sub-claim ("N fichiers neufs : ... (330 lignes)"), not the
     whole-PR perimeter -- and, unlike an antecedent exemption, it overrides a
     diffstat neighbor on the same line. Extracted from _count_is_exempt so the
-    two callers (per-count exemption, incidental override) share one predicate."""
+    two callers (per-count exemption, incidental override) share one predicate.
+
+    #13471 (2 residus) :
+      - Accent variants : les deux cotes du match passent par NFD-strip, donc
+        'verifié' (hybride, premier e nu / dernier accentue) est reconnu au
+        meme titre que 'vérifié' / 'verifie' / 'verifies' (formes deja
+        listees). Une nouvelle variante accidentee future sera couverte sans
+        nouvelle tranche.
+      - 2 mots en OR : le predicat matche si le PREMIER OU le SECOND des deux
+        premiers mots est dans `INCIDENTAL_QUALIFIERS`. La condition pre-
+        existante (1er mot OU paire exacte `INCIDENTAL_QUALIFIER_PAIRS`)
+        attrapait 'audio generes' mais pas 'puis conformes' -- le 2eme mot
+        'conformes' est dans `INCIDENTAL_QUALIFIERS` mais le 1er ('puis')
+        ne l'est pas, donc le predicat rendait False. Apres le fix, le
+        second mot incident est lu comme un standalone."""
     # #13440: le pluriel parenthetique "(s)" est neutralise avant lecture du
     # qualificatif ("fichier(s) verifies" doit lire "verifies").
     after = PLURAL_PAREN.sub(" ", line[m.end():], count=1)
-    mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
-    if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
-        return True
-    mw2 = re.match(
+    # Le pattern lit **au plus** les 2 premiers mots ; au-dela, les
+    # separateurs (parentheses ouvrantes, backticks, slash) ferment le
+    # token. C'est le pattern d'origine (conservé) -- le predicat ne doit
+    # **pas** traverser les delimiteurs vers des mots eloignes
+    # (anti-regression : '- 1 fichier modifie (`scripts/.../foo.py`, +1/-1)'
+    # matchait 'modifie' puis voyait 'scripts' comme 2eme mot, mais 'scripts'
+    # EST dans la liste ; il faut rester aveugle derriere la parenthese).
+    _WORD_RE = re.compile(
         r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
-        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
-        after,
+        r"(?:\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+))?"
     )
-    if mw2:
-        pair = f"{mw2.group(1)} {mw2.group(2)}".lower()
-        if (mw2.group(1).lower() in INCIDENTAL_QUALIFIERS
-                or pair in INCIDENTAL_QUALIFIER_PAIRS):
+    mw = _WORD_RE.match(after)
+    if not mw:
+        return False
+    first_nfd = _strip_accents(mw.group(1)).lower()
+    if first_nfd in _INCIDENTAL_QUALIFIERS_NFD:
+        return True
+    if mw.group(2):
+        # Paire exacte (close-list, formes specifiques type 'audio generes').
+        pair_nfd = f"{first_nfd} {_strip_accents(mw.group(2)).lower()}"
+        if pair_nfd in _INCIDENTAL_QUALIFIER_PAIRS_NFD:
+            return True
+        # #13471 Résidu 2 : 2 mots en OR. Le 2eme mot seul est incident
+        # ('puis conformes' -- 'conformes' est dans la liste single-word mais
+        # 'puis' ne l'est pas).
+        second_nfd = _strip_accents(mw.group(2)).lower()
+        if second_nfd in _INCIDENTAL_QUALIFIERS_NFD:
             return True
     return False
 

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -2477,6 +2477,132 @@ def test_13440_founder_negated_diff_still_exempt():
             f"le compte fondateur doit rester exempt : {m.group(0)!r}"
         )
 
+
+# ---------------------------------------------------------------------------
+# #13471 — 2 residus de la fenetre de qualificatif `_count_has_incidental_qualifier`
+# nommes au merge de #13463, laisses ouverts. Les 2 residus partagent la
+# meme fenetre ; le fix unifie dans le predicat (normalisation NFD + lecture
+# 2 mots en OR).
+#
+# Residu 1 -- les formes hybrides accentuees (premier e nu, dernier accentue)
+# ne sont pas normalisees avant match. Issue : « verifié » / « verifiés » ne
+# sont pas reconnus alors que « vérifié » / « vérifiés » / « verifie » /
+# « verifies » le sont (toutes 4 collapent sur la meme cle NFD-stripped).
+#
+# Residu 2 -- la fenetre ne lit que le 1er mot apres le compte. Un compte
+# dont le 2eme mot est incident (mais pas le 1er) reste aveuglant. Issue :
+# « 9 fichiers verifies puis modifies » -- 'puis' n'est pas incident,
+# 'modifies' est un verbe de modif (donc strong scope, hors scope du
+# Residu 2) ; le VRAI trou est « N fichiers puis conformes » / « N fichiers
+# independamment analyses ».
+#
+# Methodologie : les 2 controles positifs sont ecrits en **assertions directes**
+# sur `_count_is_incidental` (verdict blocant). Les FN deliberes et le bare
+# authorial sont des controles non-regression (verdict ne change pas).
+# ---------------------------------------------------------------------------
+def test_13471_residu1_hybrid_accent_recognized():
+    """Le Résidu 1 : « verifié » (premier e nu, dernier accentué) doit etre
+    reconnu au meme titre que « vérifié » / « verifie » / « verifies ». La
+    normalisation NFD fait collapser toutes les variantes sur la meme cle,
+    et la liste close n'a PAS besoin d'etre etendue -- c'est precisement
+    la serie de tranches que l'issue prescrit d'eviter."""
+    # Hybride : premier e nu, dernier accentue (le cas fondateur de l'issue).
+    assert _count_is_incidental("- 9 fichiers verifié puis corriges") is True, (
+        "le Résidu 1 fondateur (verifié hybride) doit etre incident"
+    )
+    # Hybride + participe +2 (verifies hybride).
+    assert _count_is_incidental("- 13 fichiers verifiés avec Papermill") is True, (
+        "le Résidu 1 pluriel (verifiés hybride) doit etre incident"
+    )
+    # Forme deja listee (control non-regression) : ne change pas.
+    assert _count_is_incidental("- 18 fichiers vérifiés sans BOM") is True, (
+        "la forme canonique listee ne change pas de verdict"
+    )
+    # Forme deja listee (control non-regression) : ne change pas.
+    assert _count_is_incidental("- 18 fichiers verifie") is True, (
+        "la forme nue sans accent ne change pas de verdict"
+    )
+
+
+def test_13471_residu2_second_word_incidental_recognized():
+    """Le Résidu 2 : un compte dont le 2eme mot apres le nombre est incident
+    (mais pas le 1er) doit etre reconnu comme incidental. La fenetre pre-
+    existante ne lisait que le 1er mot, ce qui rendait aveuglant « N
+    fichiers <mot-non-incidental> puis conformes » (le 1er mot n'est pas
+    dans INCIDENTAL_QUALIFIERS, le 2eme 'conformes' l'est)."""
+    # Le trou reel fondateur du Résidu 2 : 'puis' n'est pas incident,
+    # 'conformes' l'est -- le 1er-mot-seul rendait False avant le fix.
+    assert _count_is_incidental("- 9 fichiers puis conformes") is True, (
+        "le Résidu 2 fondateur ('puis conformes') doit etre incident"
+    )
+    # Variante : 1er mot adverbial, 2eme participe incident.
+    assert _count_is_incidental(
+        "- 9 fichiers independamment analyses"
+    ) is True, (
+        "le Résidu 2 variante ('independamment analyses') doit etre incident"
+    )
+    # Forme deja couverte avant le fix (control non-regression).
+    assert _count_is_incidental(
+        "- 9 fichiers verifies puis modifies"
+    ) is True, (
+        "la forme 2-mots-incidents ne change pas de verdict"
+    )
+
+
+def test_13471_fn_deliberes_stay_blocking():
+    """Les FN délibérés du fondateur #13440 restent bloquants après le
+    fix : « restaurés » / « re-exécutés » / « touchés » sont des périmètres
+    authentiques dans ce dépôt (campagne accents #2876, tranches MGS,
+    verbes de modification) et HORS de INCIDENTAL_QUALIFIERS. La
+    normalisation NFD ne les ajoute pas par effet de bord."""
+    # restaures (campagne accents #2876) -- perimetre authentique.
+    assert _count_is_incidental(
+        "- 18 fichiers avec accents restaurés"
+    ) is False, (
+        "« restaurés » reste bloquant (campagne accents)"
+    )
+    # re-executés (tranches MGS) -- perimetre authentique.
+    assert _count_is_incidental(
+        "- 13 fichiers re-executés"
+    ) is False, (
+        "« re-executés » reste bloquant (tranches MGS)"
+    )
+    # touchés -- verbe de modification, _has_strong_scope bloque la ligne.
+    assert _count_is_incidental(
+        "- 13 fichiers touchés uniquement"
+    ) is False, (
+        "« touchés » reste bloquant (verbe de modification)"
+    )
+
+
+def test_13471_bare_authorial_preserved():
+    """Le « 25 fichier(s) » sans qualificatif reste auteur (fail-loud
+    préservé) : le 2eme token est la parenthese vide, qui ne contient pas
+    de mot, donc le predicat rend False (pas d'incidental). Le résidu du
+    2-mots-OR ne fait pas fuiter un verdict blanc sur un auteur reel."""
+    assert _count_is_incidental("- 25 fichier(s)") is False, (
+        "le bare authorial reste bloquant (predicate ne doit pas "
+        "lire du vide comme un mot)"
+    )
+    assert _count_is_incidental("- 13 fichiers") is False, (
+        "le compte nu reste bloquant"
+    )
+
+
+def test_13471_founder_negated_diff_still_exempt():
+    """Non-régression fondateur #11775 : « 91 fichiers inchanges sur 2
+    touches » -- la ligne porte « scope » (strong scope word) et est
+    exemptée par negated-diff (91) + locative (2). La normalisation NFD
+    des 2 premiers mots ne doit pas alterer ces exemptions par-compte."""
+    line = "- 91 fichiers inchanges sur 2 touches -- scope delta confirme"
+    matches = list(COUNT_CLAIM.finditer(line))
+    assert matches, "le fondateur doit porter des comptes"
+    for m in matches:
+        assert _count_is_exempt(line, m) is True, (
+            f"le compte fondateur doit rester exempt : {m.group(0)!r}"
+        )
+
+
 def test_12718_hyphenated_scope_does_not_block():
     """#12718: 'in-scope' (hyphenated, descriptive) is NOT a strong-scope
     perimeter label -- `_has_strong_scope` excludes the hyphenated compound,


### PR DESCRIPTION
## Summary

Deux residus NOMMES et MESURES au merge de #13463, laisses ouverts dans la fenetre de qualificatif de `_count_has_incidental_qualifier` (predicate partagee par `_count_is_incidental` et `_count_is_exempt`). Les deux residus partagent la meme fenetre ; le fix les unifie dans le predicat -- **un seul passage**, pas une tranche de liste par variante accidentee (c'est precisement la serie de tranches que ce depot cherche a eviter).

## Residu 1 — pas de normalisation accents

Le predicat comparait `mw.group(1).lower() in INCIDENTAL_QUALIFIERS` sans aucune normalisation. Les chaines hybrides accidentees (`verifié` / `verifiés`, premier `e` nu dernier accentué) sont en NFD distincts des chaines listees (`vérifié` / `vérifiés` / `verifie` / `verifies`) -- le predicat les ratait.

**Mesure issue #13471 (verbatim)** : « les chaines `verifié` / `verifies` avec accentuation partielle figurent dans la liste de #13441 et pas dans celle de #13463 ».

**Forme du fix** : helper `_strip_accents()` (NFD-decompose + drop `Mn` combining marks via `unicodedata`), applique aux DEUX cotes du match via deux sets pre-normalises au module load :

```python
_INCIDENTAL_QUALIFIERS_NFD = frozenset(
    _strip_accents(w).lower() for w in INCIDENTAL_QUALIFIERS
)
_INCIDENTAL_QUALIFIER_PAIRS_NFD = frozenset(
    _strip_accents(p).lower() for p in INCIDENTAL_QUALIFIER_PAIRS
)
```

Les entrees canoniques de la liste sont stockees telles quelles (lisibilite mainteneur), mais le predicat compare apres strip -- toutes les formes collapsent sur la meme cle. **Une nouvelle variante accidentee future est couverte sans nouvelle tranche de liste.**

## Residu 2 — fenetre 1er mot OU paire exacte (pas 2-mots-OR)

Le predicat matche si le 1er mot est dans `INCIDENTAL_QUALIFIERS` OU si la paire exacte (1er + 2eme) est dans `INCIDENTAL_QUALIFIER_PAIRS`. Il ne lit PAS le 2eme mot en standalone -- consequence : `N fichiers puis conformes` (1er mot 'puis' hors liste, 2eme 'conformes' dans liste) etait aveuglant, alors que `conformes` EST dans `INCIDENTAL_QUALIFIERS`.

**Mesure Hermes (review sur head `f73e513d`, verbatim)** : « `9 fichiers analyses et corriges` devient incidental (le verbe de modification en seconde position n'est pas lu) ». Le cas fondateur reel est `N fichiers <adverbe> puis <participe-incident>` -- le 1er mot adverbial precede le 2eme incident, et le predicat pre-existant rendait False.

**Forme du fix** : ajouter une branche « 2eme mot dans `INCIDENTAL_QUALIFIERS` » a cote de la branche paire exacte. La fenetre d'analyse reste bornee aux 2 premiers mots via `re.match` -- le predicat ne traverse PAS les separateurs (parentheses, backticks, slash) vers des mots eloignes. **Anti-regression preservee** : sur `- 1 fichier modifie (\`scripts/.../check_concurrency_conj.py\`, +1/-1)` le predicat matche 'modifie' puis voit la parenthese ouvrante -- la fenetre se ferme la.

## Verification firsthand (pre-fix vs post-fix)

```text
$ python -c '... _count_is_incidental(line)'
                                       pre-fix   post-fix
- 9 fichiers verifié puis corriges       False     True   <- Residu 1 fondateur
- 13 fichiers verifiés avec Papermill    False     True   <- Residu 1 pluriel hybride
- 9 fichiers puis conformes              False     True   <- Residu 2 fondateur
- 9 fichiers independamment analyses     False     True   <- Residu 2 variante
- 18 fichiers avec accents restaurés     False     False  <- FN délibéré #13440 (perimetre authentique)
- 13 fichiers re-executés                False     False  <- FN délibéré #13440
- 13 fichiers touchés uniquement        False     False  <- verbe de modif (hors scope Residu 2)
- 25 fichier(s) (bare authorial)         False     False  <- auteur nu préservé
```

## Tests (170/170 PASSED, dont 5 nouveaux `test_13471_*`)

```text
$ python -m pytest scripts/tests/test_check_pr_perimeter.py
collected 170 items
... (165 anciens intacts, zero vert→rouge)
test_13471_residu1_hybrid_accent_recognized             PASSED
test_13471_residu2_second_word_incidental_recognized    PASSED
test_13471_fn_deliberes_stay_blocking                   PASSED
test_13471_bare_authorial_preserved                    PASSED
test_13471_founder_negated_diff_still_exempt           PASSED
============================= 170 passed in 3.90s =============================
```

| Test | Role |
|------|------|
| `test_13471_residu1_hybrid_accent_recognized` | Controle positif Residu 1 (2 variantes hybrides `verifié`/`verifiés`) + 2 non-regression (`vérifiés`, `verifie`) |
| `test_13471_residu2_second_word_incidental_recognized` | Controle positif Residu 2 (`puis conformes`, `independamment analyses`) + 1 non-regression (`verifies puis modifies`) |
| `test_13471_fn_deliberes_stay_blocking` | `restaurés` / `re-exécutés` / `touchés` restent bloquants (FN délibérés #13440 et fondateur #11775) |
| `test_13471_bare_authorial_preserved` | `25 fichier(s)` seul reste auteur (fail-loud préservé, le 2eme token vide ne fait pas fuiter le verdict) |
| `test_13471_founder_negated_diff_still_exempt` | Non-régression fondateur #11775 (`91 fichiers inchanges sur 2 touches -- scope delta confirme`), la normalisation NFD ne touche pas les exemptions par-compte |

## Acceptance issue #13471

- [x] Controle positif par residu en fichier (pas en heredoc), montrant le
      garde ROUGE sur la forme fautive AVANT le fix.
- [x] Tests de non-régression du fondateur #11775 restent verts (test
      explicite `test_13471_founder_negated_diff_still_exempt` + 165
      anciens tests intacts, zero vert→rouge).
- [x] FN délibérés `13 fichiers re-exécutés` / `18 fichiers restaurés`
      restent bloquants (test `test_13471_fn_deliberes_stay_blocking`).
- [x] `25 fichier(s)` seul, sans qualificatif, reste auteur (fail-loud
      préservé, test `test_13471_bare_authorial_preserved`).

## Trou adjacent NON couvert (hors scope, signale pour traçabilité)

`verifiée` / `vérifiées` (participe passé féminin) ne sont PAS dans `INCIDENTAL_QUALIFIERS` (la liste close ne contient que `verifie` / `verifies`, masculin). Ce n'est PAS le trou de l'issue #13471 (qui parle explicitement de « premier `e` nu, dernier accentué » = masculin) -- c'est une omission pré-existante dans la liste close. **Signale pour reference** mais hors scope de cette PR (l'ajouter serait une extension non demandée par l'issue ; la liste close ne se complete que sur mesure du corpus).

## Perimetre (2 fichiers, 196 insertions / 11 suppressions)

```text
scripts/check_pr_perimeter.py            |  81 +++++++++++++++++---
scripts/tests/test_check_pr_perimeter.py | 126 +++++++++++++++++++++++++++++++
```

## Lien avec cycles precedents

- **#13471** (cette PR) : 2 residus de la fenetre de qualificatif.
- **#13463** : PR qui a rendu les 2 residus visibles (mesure pre-PR).
- **#13440** : fondateur du predicat et des FN délibérés (`restaurés` / `re-exécutés` / `touchés` restent hors liste par design).
- **#11775** : fondateur perimetre assertion (`91 fichiers inchanges sur 2 touches -- scope delta confirme`).
- **#11985** : forme 4 (corpus count `--` perimetre) et inventoriant la sémantique des « other-object counts ».

Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: tooling #13842 cycle 30.
paths: scripts/check_pr_perimeter.py, scripts/tests/test_check_pr_perimeter.py

Closes #13471
See #13463, #13440, #11775, #11985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
