### PR TITLE
fix(gametheory,#13743): .gitignore racine pour caches lakes Lean

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/.gitignore
+++ b/MyIA.AI.Notebooks/GameTheory/.gitignore
@@ -1,0 +1,6 @@
+# Lean lake caches & build artefacts — couvre tous les lakes de la série GameTheory (EPIC #4365)
+.lake/
+.mathlib-cache/
+*.olean
+*.ilean
+*.trace


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2027:CoursIA — prev: DEEP/notebook-lean #13879

## Summary

Ajout d'un `.gitignore` **racine** pour les caches Lake/Mathlib de la série GameTheory (`MyIA.AI.Notebooks/GameTheory/.gitignore`) : `.lake/`, `.mathlib-cache/`, `*.olean`, `*.ilean`, `*.trace`.

**Pourquoi racine plutôt qu'un `.gitignore` par lake :** un pattern `*` à la racine s'applique à tout le sous-arbre par sémantique git — un seul fichier couvre les ~20 lakes, exactement comme le précédent `SymbolicAI/Lean/.gitignore` pour la série Lean. À ~20 lakes, un fichier par lake dépasserait le seuil de 15 changedFiles (split G.4), pour un bénéfice git identique. Atomique.

## Ce que ça règle (vérifié de première main)

Les deux « lakes morts » de #13743 — `repeated_games_lean` (1 Go) et `social_choice_lean` (665 Mo) — sont des **tombstones d'archive**, pas des lakes en contenu :

- `git ls-tree origin/main` : ils ne trackent **aucun `.lean`** — seulement README / STATUS / NOTICE / LEAN_PREREQUISITES / lake-manifest.json / lakefile.lean / lean-toolchain.
- Leur `lakefile.lean` + `STATUS.md` déclarent explicitement « ⚑ Archive — le build Lake actif a déménagé » : `RepeatedGames` et `SocialChoice` (+ siblings `_en`, i18n #4980) ont été absorbés byte-identique dans `game_theory_lean/` (EPIC #4365, c.357/c.371).
- Les 1,67 Go sont donc des **caches `.lake/` non trackés** — jamais commutables, mais jusqu'ici **non gitignorés** dans ces deux répertoires (aucun `.gitignore` local, root inexistant). Le présent PR les rend non-commitables.

## Validation

- `git ls-files MyIA.AI.Notebooks/GameTheory | grep -E '\.lake/|\.mathlib-cache/|\.olean$|\.ilean$|\.trace$'` → **0** (aucun fichier tracké ne serait masqué par le nouveau pattern).
- `git check-ignore` sur `.lake/mathlib` des 8 lakes (repeated_games, social_choice, social_choice_lean_peters, game_theory_lean, asymmetric_information, minimax_lean, assignment_lean, conway_cgt_lean) → **8/8 IGNORE**.
- Pre-commit local : tous les hooks verts (gitleaks, H.3 n/a — pas de notebook).

## Scope / limites

- **Aucun fichier tracké supprimé ni déplacé** — les tombstones d'archive (README/STATUS/lakefile) restent en place, comme décidé au moment de l'absorption (#4365). La purge *disque* des `.lake/` résiduels est **machine-locale** (elle se fait sur le poste qui détient le checkout, pas dans un PR).
- **Pas** de modification de `social_choice_lean/README.md` (PR #13863 en cours sur ce fichier — collision évitée) ni de `GameTheory/README.md` (marqueur CATALOG-STATUS, gardé par cron).
- L'adjudication `social_choice_lean` vs `social_choice_lean_peters` (canonicalité) est portée par #13863 et l'EPIC #4365 — hors de ce grain.

## Notes

- Tier/genre honnête : `LIGHT/tooling` (un `.gitignore` est du cache-gouvernance, scan-générable) — **ne tient pas** le plancher G-VAR-1. Le plancher CONTENU de la lane est #13879 (`notebook-lean`, Search-09d / `discrepancy_lean`), réparé ce cycle, merge en attente ai-01. Voir #13743 (partial : tranche cache-gouvernance seule).

