### PR TITLE
feat(ml,#11962): convertir le pipeline DS-STAR en Mermaid

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb
@@ -759,70 +759,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 6. Architecture des Frameworks DS-STAR et MLE-STAR\n",
-    "\n",
-    "DS-STAR et MLE-STAR sont deux agents de référence (State-of-the-Art) conçus par Google Research pour la data science et l'ingénierie ML — ils incarnent le paradigme d'agent LLM *planner-coder* (décomposition de tâche → génération de code → exécution → raffinement) décrit par Xi et al. (2025) et appliqué à la compétition Kaggle et au cycle d'expérimentation ML.\n",
-    "\n",
-    "Ce track Track2-GoogleADK intègre les frameworks de recherche Google :\n",
-    "\n",
-    "### DS-STAR (Data Science Agent)\n",
-    "\n",
-    "Architecture Planner-Coder-Verifier pour la data science autonome :\n",
-    "\n",
-    "```\n",
-    "┌─────────────┐    ┌─────────────┐    ┌─────────────┐\n",
-    "│  File       │───>│  Planner    │───>│  Coder      │\n",
-    "│  Analyzer   │    │             │    │             │\n",
-    "└─────────────┘    └─────────────┘    └─────────────┘\n",
-    "                          │                   │\n",
-    "                          v                   v\n",
-    "                   ┌─────────────┐    ┌─────────────┐\n",
-    "                   │  Verifier   │<───│  Executor   │\n",
-    "                   │             │    │             │\n",
-    "                   └─────────────┘    └─────────────┘\n",
-    "```\n",
-    "\n",
-    "**Performance** : 45.2% accuracy sur DABStep benchmark\n",
-    "\n",
-    "### MLE-STAR (ML Engineering Agent)\n",
-    "\n",
-    "Extension avec recherche web et optimisation automatique :\n",
-    "\n",
-    "- Web Search pour modèles SOTA\n",
-    "- Ablation studies ciblées\n",
-    "- Ensemble stratégies automatisées\n",
-    "\n",
-    "**Performance** : 63.6% médailles sur MLE-Bench-Lite"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c8a08b01",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003271,
-     "end_time": "2026-08-17T21:59:35.751293+00:00",
-     "exception": false,
-     "start_time": "2026-08-17T21:59:35.748022+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Schema : le pipeline MLE-STAR\n",
-    "\n",
-    "Les agents s'enchainent comme dans le schema ASCII ci-dessus : le Verifier recoit a la fois le plan (du Planner) et le résultat d'exécution (de l'Executor).\n",
-    "\n",
-    "```mermaid\n",
-    "flowchart TD\n",
-    "    FA[\"File Analyzer\"] --> P[\"Planner\"]\n",
-    "    P --> C[\"Coder\"]\n",
-    "    P --> V[\"Verifier\"]\n",
-    "    C --> E[\"Executor\"]\n",
-    "    E --> V\n",
-    "```"
-   ]
+   "source": "## 6. Architecture des Frameworks DS-STAR et MLE-STAR\n\nDS-STAR et MLE-STAR sont deux agents de référence (State-of-the-Art) conçus par Google Research pour la data science et l'ingénierie ML — ils incarnent le paradigme d'agent LLM *planner-coder* (décomposition de tâche → génération de code → exécution → raffinement) décrit par Xi et al. (2025) et appliqué à la compétition Kaggle et au cycle d'expérimentation ML.\n\nCe track Track2-GoogleADK intègre les frameworks de recherche Google :\n\n### DS-STAR (Data Science Agent)\n\nArchitecture Planner-Coder-Verifier pour la data science autonome :\n\n```mermaid\nflowchart TD\n    FA[\"File Analyzer\"] --> P[\"Planner\"]\n    P --> C[\"Coder\"]\n    P --> V[\"Verifier\"]\n    C --> E[\"Executor\"]\n    E --> V\n```\n\nLe planificateur distribue le travail entre génération et vérification, tandis que l'exécuteur renvoie les résultats au vérificateur pour fermer la boucle de raffinement.\n\n**Performance** : 45.2% accuracy sur DABStep benchmark\n\n### MLE-STAR (ML Engineering Agent)\n\nExtension avec recherche web et optimisation automatique :\n\n- Web Search pour modèles SOTA\n- Ablation studies ciblées\n- Ensemble stratégies automatisées\n\n**Performance** : 63.6% médailles sur MLE-Bench-Lite"
   },
   {
    "cell_type": "markdown",

--- a/arxiv_attributions_registry.yaml
+++ b/arxiv_attributions_registry.yaml
@@ -45,7 +45,7 @@ attributions:
 
   - arxiv_id: "2309.07864"
     notebook: "MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb"
-    cell_index: 31
+    cell_index: 30
     expected_citation: "1. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2023."
     source_pr: "#12824"
     correction: "Survey Xi citation: 2025 -> 2023 (cellule Références, 1re entrée)"


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #13886

## Résumé

- remplace le diagramme ASCII Planner-Coder-Verifier de Lab8 par le bloc Mermaid déjà présent juste après lui ;
- consolide les deux cellules Markdown redondantes en une représentation canonique unique ;
- ajoute une lecture explicite de la boucle Planner → Coder/Verifier → Executor → Verifier ;
- conserve byte-identiques les 12 cellules code, leurs outputs et leurs compteurs d'exécution.

## Validation

```text
detect_ascii_flowchart.py : 1 finding -> 0
validate_pr_notebooks.py : 1/1 PASS, 12 cellules code
scan_cell_ordering.py : 1 clean, 0 finding
detect_markdown_rendering.py --check : aucune nouvelle violation ERROR
```

Comparaison sémantique avant/après :

```text
cellules code : 12 -> 12
sources code identiques : True
outputs code identiques : True
execution_count identiques : True
cellules code avec outputs : 12/12
erreurs committées : 0
blocs Mermaid : 1
séquences de box-drawing ASCII : 0
```

La modification est strictement Markdown : aucune ré-exécution n'est due au titre de C.2. Le diff JSON `+2/-65` vient de la fusion de deux cellules Markdown en une ; il ne retire ni contenu pédagogique distinct ni résultat d'exécution.

## Verdict SOTA

**SOTA-OK** : Mermaid est le moteur canonique du dépôt pour les architectures pipeline ; aucune substitution dégradée n'est introduite.

See #11962
