### PR TITLE
fix(gametheory,#10382): GT-2 twin C# — Stop & Repair de la sortie nashpy masquee a la main

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm-Csharp.ipynb
@@ -5,10 +5,10 @@
    "id": "gt2c01",
    "metadata": {
     "papermill": {
-     "duration": 0.000539,
-     "end_time": "2026-08-15T13:19:30.673882",
+     "duration": 0.008741,
+     "end_time": "2026-08-31T21:47:33.583386+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:30.673343",
+     "start_time": "2026-08-31T21:47:33.574645+00:00",
      "status": "completed"
     },
     "tags": []
@@ -53,16 +53,16 @@
    "id": "gt2c02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:30.689038Z",
-     "iopub.status.busy": "2026-08-15T13:19:30.688026Z",
-     "iopub.status.idle": "2026-08-15T13:19:32.158288Z",
-     "shell.execute_reply": "2026-08-15T13:19:32.153698Z"
+     "iopub.execute_input": "2026-08-31T21:47:33.663829Z",
+     "iopub.status.busy": "2026-08-31T21:47:33.623189Z",
+     "iopub.status.idle": "2026-08-31T21:47:38.038739Z",
+     "shell.execute_reply": "2026-08-31T21:47:38.030025Z"
     },
     "papermill": {
-     "duration": 1.484406,
-     "end_time": "2026-08-15T13:19:32.158288",
+     "duration": 4.433555,
+     "end_time": "2026-08-31T21:47:38.039843+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:30.673882",
+     "start_time": "2026-08-31T21:47:33.606288+00:00",
      "status": "completed"
     },
     "tags": []
@@ -116,7 +116,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '42688.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '12508.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -203,10 +203,10 @@
    "id": "gt2c03",
    "metadata": {
     "papermill": {
-     "duration": 0.003142,
-     "end_time": "2026-08-15T13:19:32.165710",
+     "duration": 0.0044,
+     "end_time": "2026-08-31T21:47:38.048034+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.162568",
+     "start_time": "2026-08-31T21:47:38.043634+00:00",
      "status": "completed"
     },
     "tags": []
@@ -232,16 +232,16 @@
    "id": "gt2c04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:32.175068Z",
-     "iopub.status.busy": "2026-08-15T13:19:32.174538Z",
-     "iopub.status.idle": "2026-08-15T13:19:32.607184Z",
-     "shell.execute_reply": "2026-08-15T13:19:32.607184Z"
+     "iopub.execute_input": "2026-08-31T21:47:38.059048Z",
+     "iopub.status.busy": "2026-08-31T21:47:38.058750Z",
+     "iopub.status.idle": "2026-08-31T21:47:39.279041Z",
+     "shell.execute_reply": "2026-08-31T21:47:39.278607Z"
     },
     "papermill": {
-     "duration": 0.438365,
-     "end_time": "2026-08-15T13:19:32.607184",
+     "duration": 1.225729,
+     "end_time": "2026-08-31T21:47:39.279157+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.168819",
+     "start_time": "2026-08-31T21:47:38.053428+00:00",
      "status": "completed"
     },
     "tags": []
@@ -301,10 +301,10 @@
    "id": "gt2c05",
    "metadata": {
     "papermill": {
-     "duration": 0.004239,
-     "end_time": "2026-08-15T13:19:32.615687",
+     "duration": 0.016927,
+     "end_time": "2026-08-31T21:47:39.306443+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.611448",
+     "start_time": "2026-08-31T21:47:39.289516+00:00",
      "status": "completed"
     },
     "tags": []
@@ -325,16 +325,16 @@
    "id": "gt2c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:32.621493Z",
-     "iopub.status.busy": "2026-08-15T13:19:32.621493Z",
-     "iopub.status.idle": "2026-08-15T13:19:32.705956Z",
-     "shell.execute_reply": "2026-08-15T13:19:32.705956Z"
+     "iopub.execute_input": "2026-08-31T21:47:39.327578Z",
+     "iopub.status.busy": "2026-08-31T21:47:39.326859Z",
+     "iopub.status.idle": "2026-08-31T21:47:39.654482Z",
+     "shell.execute_reply": "2026-08-31T21:47:39.650895Z"
     },
     "papermill": {
-     "duration": 0.088736,
-     "end_time": "2026-08-15T13:19:32.705956",
+     "duration": 0.337089,
+     "end_time": "2026-08-31T21:47:39.654611+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.617220",
+     "start_time": "2026-08-31T21:47:39.317522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -404,10 +404,10 @@
    "id": "gt2c07",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-08-15T13:19:32.711102",
+     "duration": 0.004387,
+     "end_time": "2026-08-31T21:47:39.675663+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.711102",
+     "start_time": "2026-08-31T21:47:39.671276+00:00",
      "status": "completed"
     },
     "tags": []
@@ -430,16 +430,16 @@
    "id": "gt2c08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:32.721193Z",
-     "iopub.status.busy": "2026-08-15T13:19:32.721193Z",
-     "iopub.status.idle": "2026-08-15T13:19:32.908957Z",
-     "shell.execute_reply": "2026-08-15T13:19:32.908957Z"
+     "iopub.execute_input": "2026-08-31T21:47:39.684639Z",
+     "iopub.status.busy": "2026-08-31T21:47:39.684361Z",
+     "iopub.status.idle": "2026-08-31T21:47:40.285934Z",
+     "shell.execute_reply": "2026-08-31T21:47:40.285530Z"
     },
     "papermill": {
-     "duration": 0.191594,
-     "end_time": "2026-08-15T13:19:32.908957",
+     "duration": 0.606217,
+     "end_time": "2026-08-31T21:47:40.286118+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.717363",
+     "start_time": "2026-08-31T21:47:39.679901+00:00",
      "status": "completed"
     },
     "tags": []
@@ -515,10 +515,10 @@
    "id": "gt2c09",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-08-15T13:19:32.908957",
+     "duration": 0.003897,
+     "end_time": "2026-08-31T21:47:40.295505+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.908957",
+     "start_time": "2026-08-31T21:47:40.291608+00:00",
      "status": "completed"
     },
     "tags": []
@@ -537,10 +537,10 @@
    "id": "gt2c10",
    "metadata": {
     "papermill": {
-     "duration": 0.006134,
-     "end_time": "2026-08-15T13:19:32.923532",
+     "duration": 0.005043,
+     "end_time": "2026-08-31T21:47:40.304148+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.917398",
+     "start_time": "2026-08-31T21:47:40.299105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -561,16 +561,16 @@
    "id": "gt2c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:32.932622Z",
-     "iopub.status.busy": "2026-08-15T13:19:32.932622Z",
-     "iopub.status.idle": "2026-08-15T13:19:33.023831Z",
-     "shell.execute_reply": "2026-08-15T13:19:33.023831Z"
+     "iopub.execute_input": "2026-08-31T21:47:40.313338Z",
+     "iopub.status.busy": "2026-08-31T21:47:40.313041Z",
+     "iopub.status.idle": "2026-08-31T21:47:40.648818Z",
+     "shell.execute_reply": "2026-08-31T21:47:40.648511Z"
     },
     "papermill": {
-     "duration": 0.095744,
-     "end_time": "2026-08-15T13:19:33.023831",
+     "duration": 0.340568,
+     "end_time": "2026-08-31T21:47:40.648919+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:32.928087",
+     "start_time": "2026-08-31T21:47:40.308351+00:00",
      "status": "completed"
     },
     "tags": []
@@ -667,10 +667,10 @@
    "id": "gt2c12",
    "metadata": {
     "papermill": {
-     "duration": 0.002152,
-     "end_time": "2026-08-15T13:19:33.040939",
+     "duration": 0.003203,
+     "end_time": "2026-08-31T21:47:40.655929+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.038787",
+     "start_time": "2026-08-31T21:47:40.652726+00:00",
      "status": "completed"
     },
     "tags": []
@@ -693,16 +693,16 @@
    "id": "gt2c13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:33.051389Z",
-     "iopub.status.busy": "2026-08-15T13:19:33.051027Z",
-     "iopub.status.idle": "2026-08-15T13:19:33.153685Z",
-     "shell.execute_reply": "2026-08-15T13:19:33.153685Z"
+     "iopub.execute_input": "2026-08-31T21:47:40.664273Z",
+     "iopub.status.busy": "2026-08-31T21:47:40.663937Z",
+     "iopub.status.idle": "2026-08-31T21:47:41.039491Z",
+     "shell.execute_reply": "2026-08-31T21:47:41.038391Z"
     },
     "papermill": {
-     "duration": 0.107541,
-     "end_time": "2026-08-15T13:19:33.153685",
+     "duration": 0.380475,
+     "end_time": "2026-08-31T21:47:41.039714+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.046144",
+     "start_time": "2026-08-31T21:47:40.659239+00:00",
      "status": "completed"
     },
     "tags": []
@@ -763,10 +763,10 @@
    "id": "gt2c14",
    "metadata": {
     "papermill": {
-     "duration": 0.003703,
-     "end_time": "2026-08-15T13:19:33.163507",
+     "duration": 0.008505,
+     "end_time": "2026-08-31T21:47:41.058322+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.159804",
+     "start_time": "2026-08-31T21:47:41.049817+00:00",
      "status": "completed"
     },
     "tags": []
@@ -784,10 +784,10 @@
    "id": "gt2c15",
    "metadata": {
     "papermill": {
-     "duration": 0.003635,
-     "end_time": "2026-08-15T13:19:33.170886",
+     "duration": 0.007295,
+     "end_time": "2026-08-31T21:47:41.076595+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.167251",
+     "start_time": "2026-08-31T21:47:41.069300+00:00",
      "status": "completed"
     },
     "tags": []
@@ -806,16 +806,16 @@
    "id": "gt2c16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:33.177705Z",
-     "iopub.status.busy": "2026-08-15T13:19:33.177705Z",
-     "iopub.status.idle": "2026-08-15T13:19:33.226954Z",
-     "shell.execute_reply": "2026-08-15T13:19:33.226954Z"
+     "iopub.execute_input": "2026-08-31T21:47:41.096553Z",
+     "iopub.status.busy": "2026-08-31T21:47:41.096068Z",
+     "iopub.status.idle": "2026-08-31T21:47:41.268823Z",
+     "shell.execute_reply": "2026-08-31T21:47:41.268447Z"
     },
     "papermill": {
-     "duration": 0.052263,
-     "end_time": "2026-08-15T13:19:33.226954",
+     "duration": 0.183699,
+     "end_time": "2026-08-31T21:47:41.268923+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.174691",
+     "start_time": "2026-08-31T21:47:41.085224+00:00",
      "status": "completed"
     },
     "tags": []
@@ -865,10 +865,10 @@
    "id": "gt2c17",
    "metadata": {
     "papermill": {
-     "duration": 0.004265,
-     "end_time": "2026-08-15T13:19:33.238505",
+     "duration": 0.004665,
+     "end_time": "2026-08-31T21:47:41.278286+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.234240",
+     "start_time": "2026-08-31T21:47:41.273621+00:00",
      "status": "completed"
     },
     "tags": []
@@ -885,16 +885,16 @@
    "id": "gt2c18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:33.245936Z",
-     "iopub.status.busy": "2026-08-15T13:19:33.245936Z",
-     "iopub.status.idle": "2026-08-15T13:19:33.319971Z",
-     "shell.execute_reply": "2026-08-15T13:19:33.319971Z"
+     "iopub.execute_input": "2026-08-31T21:47:41.287050Z",
+     "iopub.status.busy": "2026-08-31T21:47:41.286779Z",
+     "iopub.status.idle": "2026-08-31T21:47:41.521302Z",
+     "shell.execute_reply": "2026-08-31T21:47:41.520969Z"
     },
     "papermill": {
-     "duration": 0.079219,
-     "end_time": "2026-08-15T13:19:33.319971",
+     "duration": 0.239419,
+     "end_time": "2026-08-31T21:47:41.521458+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.240752",
+     "start_time": "2026-08-31T21:47:41.282039+00:00",
      "status": "completed"
     },
     "tags": []
@@ -944,10 +944,10 @@
    "id": "gt2c26",
    "metadata": {
     "papermill": {
-     "duration": 0.00404,
-     "end_time": "2026-08-15T13:19:33.332776",
+     "duration": 0.004412,
+     "end_time": "2026-08-31T21:47:41.531806+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.328736",
+     "start_time": "2026-08-31T21:47:41.527394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -979,16 +979,16 @@
    "id": "gt2c27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:33.335911Z",
-     "iopub.status.busy": "2026-08-15T13:19:33.335911Z",
-     "iopub.status.idle": "2026-08-15T13:19:35.637106Z",
-     "shell.execute_reply": "2026-08-15T13:19:35.637106Z"
+     "iopub.execute_input": "2026-08-31T21:47:41.544720Z",
+     "iopub.status.busy": "2026-08-31T21:47:41.544139Z",
+     "iopub.status.idle": "2026-08-31T21:47:45.138226Z",
+     "shell.execute_reply": "2026-08-31T21:47:45.137986Z"
     },
     "papermill": {
-     "duration": 2.301195,
-     "end_time": "2026-08-15T13:19:35.637106",
+     "duration": 3.602143,
+     "end_time": "2026-08-31T21:47:45.138330+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:33.335911",
+     "start_time": "2026-08-31T21:47:41.536187+00:00",
      "status": "completed"
     },
     "tags": []
@@ -997,7 +997,7 @@
     {
      "data": {
       "text/plain": [
-       "=== Pont nashpy : from-scratch (BCL .NET) vs nashpy (<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python311\\python.exe) ===\r\n",
+       "=== Pont nashpy : from-scratch (BCL .NET) vs nashpy (python.exe) ===\r\n",
        "Les deux moteurs calculent TOUS les equilibres de Nash (purs et mixtes) par enumeration de supports.\r\n",
        "\r\n",
        "--- PD (2x2) : nashpy=1 equilibre(s) ---\r\n",
@@ -1154,7 +1154,7 @@
     "}\n",
     "\n",
     "var sb = new StringBuilder();\n",
-    "sb.AppendLine($\"=== Pont nashpy : from-scratch (BCL .NET) vs nashpy ({pythonExe}) ===\");\n",
+    "sb.AppendLine($\"=== Pont nashpy : from-scratch (BCL .NET) vs nashpy ({Path.GetFileName(pythonExe)}) ===\");\n",
     "sb.AppendLine(\"Les deux moteurs calculent TOUS les equilibres de Nash (purs et mixtes) par enumeration de supports.\");\n",
     "sb.AppendLine();\n",
     "int okTotal = 0;\n",
@@ -1216,10 +1216,10 @@
    "id": "gt2c19",
    "metadata": {
     "papermill": {
-     "duration": 0.002817,
-     "end_time": "2026-08-15T13:19:35.646445",
+     "duration": 0.003956,
+     "end_time": "2026-08-31T21:47:45.147707+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.643628",
+     "start_time": "2026-08-31T21:47:45.143751+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1243,16 +1243,16 @@
    "id": "gt2c20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:35.646445Z",
-     "iopub.status.busy": "2026-08-15T13:19:35.646445Z",
-     "iopub.status.idle": "2026-08-15T13:19:35.745088Z",
-     "shell.execute_reply": "2026-08-15T13:19:35.745088Z"
+     "iopub.execute_input": "2026-08-31T21:47:45.156356Z",
+     "iopub.status.busy": "2026-08-31T21:47:45.156071Z",
+     "iopub.status.idle": "2026-08-31T21:47:45.455091Z",
+     "shell.execute_reply": "2026-08-31T21:47:45.454594Z"
     },
     "papermill": {
-     "duration": 0.098643,
-     "end_time": "2026-08-15T13:19:35.745088",
+     "duration": 0.304113,
+     "end_time": "2026-08-31T21:47:45.455303+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.646445",
+     "start_time": "2026-08-31T21:47:45.151190+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1283,10 +1283,10 @@
    "id": "gt2c21",
    "metadata": {
     "papermill": {
-     "duration": 0.003704,
-     "end_time": "2026-08-15T13:19:35.752958",
+     "duration": 0.009015,
+     "end_time": "2026-08-31T21:47:45.472441+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.749254",
+     "start_time": "2026-08-31T21:47:45.463426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1303,16 +1303,16 @@
    "id": "gt2c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:35.760852Z",
-     "iopub.status.busy": "2026-08-15T13:19:35.760852Z",
-     "iopub.status.idle": "2026-08-15T13:19:35.796929Z",
-     "shell.execute_reply": "2026-08-15T13:19:35.796929Z"
+     "iopub.execute_input": "2026-08-31T21:47:45.485695Z",
+     "iopub.status.busy": "2026-08-31T21:47:45.485351Z",
+     "iopub.status.idle": "2026-08-31T21:47:45.614683Z",
+     "shell.execute_reply": "2026-08-31T21:47:45.614390Z"
     },
     "papermill": {
-     "duration": 0.041333,
-     "end_time": "2026-08-15T13:19:35.796929",
+     "duration": 0.135948,
+     "end_time": "2026-08-31T21:47:45.614780+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.755596",
+     "start_time": "2026-08-31T21:47:45.478832+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1341,10 +1341,10 @@
    "id": "gt2c23",
    "metadata": {
     "papermill": {
-     "duration": 0.003638,
-     "end_time": "2026-08-15T13:19:35.805743",
+     "duration": 0.003832,
+     "end_time": "2026-08-31T21:47:45.623169+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.802105",
+     "start_time": "2026-08-31T21:47:45.619337+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1368,16 +1368,16 @@
    "id": "gt2c24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T13:19:35.815595Z",
-     "iopub.status.busy": "2026-08-15T13:19:35.815595Z",
-     "iopub.status.idle": "2026-08-15T13:19:35.850079Z",
-     "shell.execute_reply": "2026-08-15T13:19:35.850079Z"
+     "iopub.execute_input": "2026-08-31T21:47:45.632601Z",
+     "iopub.status.busy": "2026-08-31T21:47:45.632321Z",
+     "iopub.status.idle": "2026-08-31T21:47:45.746526Z",
+     "shell.execute_reply": "2026-08-31T21:47:45.746306Z"
     },
     "papermill": {
-     "duration": 0.042717,
-     "end_time": "2026-08-15T13:19:35.850079",
+     "duration": 0.119163,
+     "end_time": "2026-08-31T21:47:45.746629+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.807362",
+     "start_time": "2026-08-31T21:47:45.627466+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1406,10 +1406,10 @@
    "id": "gt2c25",
    "metadata": {
     "papermill": {
-     "duration": 0.004018,
-     "end_time": "2026-08-15T13:19:35.860563",
+     "duration": 0.003741,
+     "end_time": "2026-08-31T21:47:45.754410+00:00",
      "exception": false,
-     "start_time": "2026-08-15T13:19:35.856545",
+     "start_time": "2026-08-31T21:47:45.750669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1448,7 +1448,7 @@
     "- von Neumann, J. (1928). *Zur Théorie der Gesellschaftsspiele* (minimax, zero-sum).\n",
     "- Twin Python : [GameTheory-02-NormalForm](GameTheory-02-NormalForm.ipynb) (nashpy).\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "*Tranche 1 du twin .NET⇄Python (#4956 marathon). Théorie des jeux stratégique = 1er concept. from-scratch = la valeur pedagogique de ce twin, complementaire au solveur nashpy.*"
    ]
@@ -1487,14 +1487,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.183516,
-   "end_time": "2026-08-15T13:19:35.988427",
+   "duration": 18.511675,
+   "end_time": "2026-08-31T21:47:46.015135+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-2-NormalForm-Csharp.ipynb",
-   "output_path": "gt2_exec.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm-Csharp.ipynb",
+   "output_path": "GameTheory-02-NormalForm-Csharp.ipynb",
    "parameters": {},
-   "start_time": "2026-08-15T13:19:28.804911",
+   "start_time": "2026-08-31T21:47:27.503460+00:00",
    "version": "2.6.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
@@ -69,6 +69,12 @@
       csharp_sha: 2b3068bac4f613d4e59367b008e16508ccc11eb7
       content_python_sha: 558e48a9e9cc3a4b1888ea4b53e77206b8ac644190ad7eb862391777f9f97249
       content_csharp_sha: e35af013248ef23ca44a90a4af732e49edbf4f6d5b5b292482a92c37b3c6dfdd
+    - date: "2026-09-01"
+      by: myia-po-2027:CoursIA
+      python_sha: 41545c9563539d1bf1a24f4feec56d06b2d2336c
+      csharp_sha: 67622028940ff423bac6a3b7dbb865e7815c60ee
+      content_python_sha: 558e48a9e9cc3a4b1888ea4b53e77206b8ac644190ad7eb862391777f9f97249
+      content_csharp_sha: caaa44829b2e5c44adf37045c20e3a99d8e15bef6e2198d116e6d5b24d0daafb
   known_differences:
     - "Socle pedagogique commun : jeux sous forme normale (matrices de gains 2 joueurs), strategies pures, dominance, equilibres de Nash purs sur 5 jeux canoniques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies)."
     - "Idiomes framework : Python = `numpy` + `nashpy` (lib mature, Game(A,B), support_enumeration). C# = pur `System.*` (Linq, Collections), classes from-scratch (matrices A/B/Payoffs, pas de lib tiers)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: LIGHT/tooling #13889

## Summary — Stop & Repair : la sortie nashpy de GT-2 twin C# n'était pas une sortie

La cellule 8 du twin C# (`GameTheory-02-NormalForm-Csharp.ipynb`, pont nashpy CLI, mandat #10382) imprimait le chemin **absolu** de l'interpréteur Python (`{pythonExe}`), et la sortie committée sur `main` portait un **`<USER_PATH>` littéral** à la place — c'est-à-dire une sortie **masquée à la main**, pas une sortie exécutée. C'est la classe de défaut que Stop & Repair interdit (secrets-hygiene règle 6, sota-not-workaround Prong A) : la sortie d'une cellule est le compte-rendu de ce que le code a réellement produit ; la maquiller revient à falsifier la preuve d'exécution, et le matériau ressort à la prochaine exécution.

## Correctif (triage C — corriger la source, puis re-exécuter)

- **Source** : `sb.AppendLine($"=== Pont nashpy : ... ({pythonExe}) ===")` → `({Path.GetFileName(pythonExe)})` — basename au lieu du chemin absolu (`using System.IO` déjà présent). 1 ligne, 1 occurrence.
- **Re-exécution complète** (papermill, kernel `.net-csharp`, `DOTNET_ROOT="C:\Program Files\dotnet"`) : **12/12 cellules code, `execution_count` 1..12, 0 erreur**.
- **nashpy installé** au préalable (règle F : réparer, pas contourner) : `python -m pip install nashpy` → 0.0.43 sur le premier `python` du PATH — celui que la cellule découvre via `where python`.
- **Sortie fraîche** : `=== Pont nashpy : from-scratch (BCL .NET) vs nashpy (python.exe) ===` — plus de `<USER_PATH>`, plus de chemin absolu. Le vrai nashpy résout les 4 jeux (PD 1 éq., BoS 3 éq., MP, RPS), exploitabilités mesurées, 4/4 `CORRESPOND`.
- **Strip outillé post-exec** : `strip_probe_banner.py --apply` — 9 lignes probeAddresses normalisées (canon L532).
- **Attestation registre** : `check_twin_parity.py --update --pair "GameTheory-2 NormalForm" --by myia-po-2027:CoursIA` — rebaseline des SHAs en dernier, après strips (#8957).

## Ce que cette PR ne fait PAS (et pourquoi)

- **`parity_level` reste `semantic`** — non par omission : la sémantique de `native-both` est un design-gate ouvert (**#11200**, cf. le maintien identique de `search-1` malgré ses deux moteurs SOTA bridgés), et le `bridge_verdict: SOTA-OK` à 6 axes motivés est déjà en place dans le yaml. Le flip n'est pas à cette lane de le faire.
- Aucun changement pédagogique : le from-scratch BCL (sections 1-7) et le pont oracle (section 8) sont inchangés — seule la forme d'impression du chemin change.

## Validation (4 preuves H.1)

1. `execution_count` 1..12 ≠ null sur les 12 cellules code
2. 0 `error` output
3. Papermill end-to-end **exit 0** (PM_EXIT=0, sortie scratchpad `gt2_exec.ipynb` recopiée)
4. `grep` : plus aucun `USER_PATH` ni chemin `C:\` dans les sorties committées

See #10382 (hygiène de la tranche 2 déjà livrée ; le burndown `native-both` reste gated par #11200).
