### PR TITLE
fix(guard,#10097): detect math pipes in notebook tables

### DIFF
--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -2,10 +2,11 @@ name: Markdown table syntax advisory
 
 # Source-level lint for GFM markdown table syntax defects (#10097, sub-issue of
 # #3966). The scanner (scripts/notebook_tools/scan_md_table_syntax.py) detects
-# five pathologies that break table rendering: COL_MISMATCH (bare unescaped |
-# in a cell), CODE_SPAN_PIPE (bare | inside an inline code span -- the notebook
-# renderer does not protect code spans), NO_SEP (missing |---| separator),
-# NO_BLANK_BEFORE/AFTER (paragraph glued to the table). This workflow makes
+# seven pathologies that break table rendering: COL_MISMATCH (bare unescaped |
+# in a cell), CODE_SPAN_PIPE and notebook-only MATH_SPAN_PIPE (the notebook
+# renderer does not protect either span), NO_SEP (missing |---| separator),
+# NO_BLANK_BEFORE/AFTER (paragraph glued to the table), and ORPHAN_TABLE_ROW.
+# This workflow makes
 # defects in *.ipynb markdown cells and *.md / README* files VISIBLE on the PR.
 #
 # ADVISORY, never blocking (mirrors exercises-advisory.yml, #8814 acceptance 5):
@@ -120,7 +121,7 @@ jobs:
             unset_label() { true; }
           fi
 
-          ensure_label "$LABEL_DEFECT" "PR introduces a markdown table syntax defect (COL_MISMATCH / CODE_SPAN_PIPE / NO_SEP / NO_BLANK_BEFORE/AFTER). Advisory, non-blocking. See #10097." "d93f0b"
+          ensure_label "$LABEL_DEFECT" "PR introduces a markdown table syntax defect (COL_MISMATCH / CODE_SPAN_PIPE / MATH_SPAN_PIPE / NO_SEP / NO_BLANK_BEFORE/AFTER / ORPHAN_TABLE_ROW). Advisory, non-blocking. See #10097." "d93f0b"
 
           if [ "$COUNT" -eq 0 ]; then
             echo "No in-scope files to scan."

--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Source-level lint for GFM markdown table syntax defects.
 
-Detects five pathologies that break table rendering in the GitHub preview
+Detects seven pathologies that break table rendering in the GitHub preview
 (source-level, render-agnostic -- it flags the *convention violation* that
 breaks rendering on at least one common renderer, not a post-render check):
 
@@ -24,6 +24,12 @@ breaks rendering on at least one common renderer, not a post-render check):
     literal pipes + ``\n``). Confirmed on 2.8c-Borne-Temoin-Concentration cell[12]
     (#12220). Escaping the pipe as ``\\|`` inside the code span is safe on every
     renderer -- this is the actionable fix.
+
+  - **MATH_SPAN_PIPE** (notebooks only): a raw ``|`` inside ``$...$`` within a
+    recognized table row. GitHub's notebook renderer splits cells before math
+    rendering, so ``$|F_B| / |A|$`` creates phantom columns. Regular ``.md``
+    rendering remains out of scope because it handles this notation correctly.
+    The portable notebook fix is pipe-free LaTeX such as ``\\lvert``/``\\rvert``.
 
   - **NO_SEP**: a run of 3+ consecutive ``|``-shaped lines with NO
     ``:?-+:?`` separator row among them. GFM does not recognize the block as a
@@ -335,6 +341,30 @@ def _has_bare_pipe_in_code_span(line):
     return False
 
 
+def _has_bare_pipe_in_math_span(line):
+    """True if a real inline-math span holds a raw ``|``.
+
+    ``MATH_SPAN_RE`` can conservatively bridge two currency markers across a cell
+    delimiter (``Input ($/1M) | Output ($/1M)``). A whitespace-padded pipe inside
+    such a match is the table delimiter, not math content, so it remains excluded.
+    Already escaped ``\\|`` forms are safe and excluded too.
+    """
+    for match in MATH_SPAN_RE.finditer(line):
+        span = ESCAPED_PIPE_RE.sub('', match.group(0))
+        for index, char in enumerate(span):
+            if char != '|':
+                continue
+            is_padded_delimiter = (
+                index > 0
+                and index + 1 < len(span)
+                and span[index - 1].isspace()
+                and span[index + 1].isspace()
+            )
+            if not is_padded_delimiter:
+                return True
+    return False
+
+
 def _is_blank(line):
     # A bare blockquote marker ``>`` (optionally followed by whitespace) renders
     # as a blank separator within a blockquote -- it provides the same visual
@@ -349,8 +379,13 @@ def _is_blank(line):
 # Pathology detection on a cell/file's lines
 # ---------------------------------------------------------------------------
 
-def detect_md_table_syntax(lines, source_label="line"):
-    """Detect the 4 pathologies in a list of source lines.
+def detect_md_table_syntax(
+        lines, source_label="line", detect_math_span_pipes=False):
+    """Detect table pathologies in a list of source lines.
+
+    ``detect_math_span_pipes`` is notebook-specific: the notebook renderer splits
+    table cells before rendering inline math, while regular GitHub Markdown renders
+    raw absolute-value bars inside math spans correctly.
 
     Returns a list of findings: dict(pathology, line, detail, snippet).
     `line` is 1-indexed within `lines`. `source_label` is used only for the
@@ -428,6 +463,18 @@ def detect_md_table_syntax(lines, source_label="line"):
                             "pipe brute dans un code span (``...``) d'une cellule "
                             "de table -> le renderer notebook decoupe la cellule "
                             "et casse la table ; echapper en '\\|'"
+                        ),
+                        "snippet": c_line.strip()[:80],
+                    })
+                if (detect_math_span_pipes
+                        and _has_bare_pipe_in_math_span(c_line)):
+                    findings.append({
+                        "pathology": "MATH_SPAN_PIPE",
+                        "line": c_lnum,
+                        "detail": (
+                            "pipe brute dans un span mathematique ($...$) d'une "
+                            "cellule de table -> le renderer notebook decoupe la "
+                            "cellule et casse la table ; utiliser \\lvert/\\rvert"
                         ),
                         "snippet": c_line.strip()[:80],
                     })
@@ -552,7 +599,7 @@ def scan_notebook(path):
             continue
         src = cell.get("source", [])
         lines = "".join(src).split("\n") if isinstance(src, list) else src.split("\n")
-        for f in detect_md_table_syntax(lines):
+        for f in detect_md_table_syntax(lines, detect_math_span_pipes=True):
             findings.append({"cell_index": ci, **f})
     return {"path": str(path), "error": None, "findings": findings}
 

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -2,11 +2,12 @@
 syntax defect detector (#10097, sub-issue of #3966).
 
 Tests cover:
-  - the core ``detect_md_table_syntax`` line-list API (the 4 pathologies:
-    COL_MISMATCH, NO_SEP, NO_BLANK_BEFORE, NO_BLANK_AFTER, each positive + clean);
+  - the core ``detect_md_table_syntax`` line-list API and its table pathologies;
   - the GFM-correct column counter (``_column_count``): backtick code spans,
     escaped ``\\|``, inline math ``$...$``, and borderless rows are NOT false
     positives;
+  - notebook-only ``MATH_SPAN_PIPE`` detection with controls for pipe-free LaTeX,
+    escaped conditionals, currency columns, and regular Markdown scope;
   - the fence-aware block grouping (pipes inside ``` blocks are ignored);
   - the notebook / markdown walkers (``scan_notebook`` / ``scan_markdown``);
   - the CLI (``--json`` shape, ``--check`` exit codes, empty-scan exit 2).
@@ -312,6 +313,120 @@ class TestDetectCodeSpanPipe:
         f = detect_md_table_syntax(lines)
         assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
         assert [x for x in f if x["pathology"] == "CODE_SPAN_PIPE"] != []
+
+
+class TestDetectMathSpanPipe:
+    """MATH_SPAN_PIPE: raw absolute-value bars break notebook table rendering."""
+
+    def test_raw_pipe_in_math_span_flagged_for_notebooks(self):
+        lines = [
+            "| Objet | Definition | Mesure |",
+            "|---|---|---|",
+            "| $r$ | rapport $|F_B| / |A|$ | ratio |",
+        ]
+        findings = detect_md_table_syntax(
+            lines, detect_math_span_pipes=True)
+        math_findings = [
+            item for item in findings
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ]
+        assert len(math_findings) == 1
+        assert math_findings[0]["line"] == 3
+        assert [
+            item for item in findings
+            if item["pathology"] == "COL_MISMATCH"
+        ] == []
+
+    def test_pipe_free_latex_not_flagged(self):
+        lines = [
+            "| Objet | Definition | Mesure |",
+            "|---|---|---|",
+            "| $r$ | rapport $\\lvert F_B\\rvert / \\lvert A\\rvert$ | ratio |",
+        ]
+        findings = detect_md_table_syntax(
+            lines, detect_math_span_pipes=True)
+        assert [
+            item for item in findings
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ] == []
+
+    def test_currency_columns_not_flagged(self):
+        lines = [
+            "| Modele | Cout | Estimation |",
+            "|---|---|---|",
+            "| OpenAI tts-1 | $15.00 | ~$0.75 |",
+        ]
+        findings = detect_md_table_syntax(
+            lines, detect_math_span_pipes=True)
+        assert [
+            item for item in findings
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ] == []
+
+    def test_currency_header_not_flagged(self):
+        lines = [
+            "| Modele | Input ($/1M tokens) | Output ($/1M tokens) |",
+            "|---|---|---|",
+            "| local | 0 | 0 |",
+        ]
+        findings = detect_md_table_syntax(
+            lines, detect_math_span_pipes=True)
+        assert [
+            item for item in findings
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ] == []
+
+    def test_escaped_math_pipe_not_flagged(self):
+        lines = [
+            "| Objet | Definition |",
+            "|---|---|",
+            "| politique | $\\pi(a\\|s)$ |",
+        ]
+        findings = detect_md_table_syntax(
+            lines, detect_math_span_pipes=True)
+        assert [
+            item for item in findings
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ] == []
+
+    def test_regular_markdown_scope_stays_clean(self, tmp_path):
+        path = tmp_path / "table.md"
+        path.write_text(
+            "| Objet | Definition | Mesure |\n"
+            "|---|---|---|\n"
+            "| $r$ | rapport $|F_B| / |A|$ | ratio |\n",
+            encoding="utf-8",
+        )
+        result = scan_markdown(path)
+        assert [
+            item for item in result["findings"]
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ] == []
+
+    def test_notebook_scope_reports_math_pipe(self, tmp_path):
+        path = tmp_path / "table.ipynb"
+        path.write_text(json.dumps({
+            "cells": [{
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [
+                    "| Objet | Definition | Mesure |\n",
+                    "|---|---|---|\n",
+                    "| $r$ | rapport $|F_B| / |A|$ | ratio |\n",
+                ],
+            }],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }), encoding="utf-8")
+        result = scan_notebook(path)
+        findings = [
+            item for item in result["findings"]
+            if item["pathology"] == "MATH_SPAN_PIPE"
+        ]
+        assert len(findings) == 1
+        assert findings[0]["cell_index"] == 0
+        assert findings[0]["line"] == 3
 
 
 class TestDetectNoSep:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: MED/notebook-python #13890

## Résumé

- ajoute la pathologie notebook-only `MATH_SPAN_PIPE` au scanner canonique des tables Markdown ;
- détecte les pipes brutes dans les spans mathématiques des lignes de table reconnues, que le renderer notebook découpe en colonnes fantômes ;
- conserve le silence sur les fichiers `.md`, dont le renderer traite correctement cette notation ;
- exclut les pipes déjà échappées et les faux spans formés entre deux marqueurs monétaires ;
- documente la nouvelle pathologie dans le workflow advisory existant.

Le notebook signalé `ICT-Greffe2-EspaceAtteignable.ipynb` est détecté en cellule 1, ligne 7. Sa correction de contenu est coordonnée avec la PR #13813, qui modifie déjà ce fichier, afin d’éviter deux branches concurrentes sur le même notebook.

## Validation

```text
pytest test_scan_md_table_syntax.py + test_md_table_sweep_comment.py : 78 passed
py_compile scan_md_table_syntax.py : PASS
git diff --check : PASS
```

Contrôle reproductible sur le notebook signalé :

```text
avant  : 1 MATH_SPAN_PIPE — cell 1, line 7, $|F_B| / |A|$
après  : 0 finding — $\lvert F_B\rvert / \lvert A\rvert$
```

Mesure corpus après contrôles de précision :

```text
MATH_SPAN_PIPE : 3 occurrences réelles / 3 notebooks
- Planners-12-LOOP : $\pi(a|s)$
- Search-1-StateSpace : $|S|$
- ICT-Greffe2-EspaceAtteignable : $|F_B| / |A|$
```

Contrôles négatifs couverts : LaTeX sans pipe (`\lvert`/`\rvert`), pipe math déjà échappée, colonnes/en-têtes monétaires, fichiers Markdown ordinaires, et maintien de l’absence de `COL_MISMATCH` logique.

See #10097
