### PR TITLE
ci(#13874): defense-in-depth fork guard -- trigger-agnostic null-safe form

### DIFF
--- a/.github/workflows/linux-self-hosted-tests.yml
+++ b/.github/workflows/linux-self-hosted-tests.yml
@@ -26,9 +26,17 @@ jobs:
     # Garde fork EXPLICITE au niveau job (defense-in-depth, pattern maison).
     # Le declencheur actuel est workflow_dispatch seul -- un fork ne peut pas
     # l'emettre -- mais "pas de trigger" est un etat qu'une ligne de YAML
-    # defait : si un declencheur pull_request est ajoute un jour, un evenement
-    # fork est refuse ICI.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # defait : si un declencheur pull_request (ou pull_request_target, qui
+    # execute la base avec un jeton en ecriture + acces secrets sur une
+    # ref controlee par le fork) est ajoute un jour, un evenement fork est
+    # refuse ICI.
+    #
+    # La forme '== null' est vraie pour tout evenement sans payload de PR
+    # (workflow_dispatch, schedule, push), et la seconde jambe couvre
+    # pull_request ET pull_request_target d'un seul test. Elle ne se defait
+    # pas quand on ajoute un declencheur.
+    # Ref : issue #13874.
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -47,11 +47,17 @@ jobs:
     # Acceptance B item 1 (#12704) : garde fork EXPLICITE au niveau job.
     # Le declencheur actuel est workflow_dispatch seul -- un fork ne peut pas
     # l'emettre -- mais "pas de trigger" est un etat qu'une ligne de YAML
-    # defait : si un declencheur pull_request est ajoute un jour, un evenement
-    # fork est refuse ICI, defense-in-depth qui ne se defe pas d'un clic d'UI.
+    # defait : si un declencheur pull_request (ou pull_request_target, qui
+    # execute la base avec un jeton en ecriture + acces secrets sur une
+    # ref controlee par le fork) est ajoute un jour, un evenement fork est
+    # refuse ICI, defense-in-depth qui ne se defe pas d'un clic d'UI.
+    #
+    # La forme '== null' couvre tout evenement sans payload de PR
+    # (workflow_dispatch, schedule, push), et la seconde jambe couvre
+    # pull_request ET pull_request_target d'un seul test -- cf issue #13874.
     # Garde selection : inputs.target == 'confinement' (sinon ce job n'est
     # pas eligible -- un dispatch `target=dotnet` ne planifie que le job .NET).
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.target == 'confinement'
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && inputs.target == 'confinement'
     runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
     timeout-minutes: 15
     concurrency:
@@ -83,10 +89,12 @@ jobs:
     # + restore + build Release + test xunit avec TRX logger.
     name: GradeBookApp.Tests (Windows runner)
     # Garde fork explicite au niveau job (cf job ci-dessus rationale partagee).
+    # Forme '== null' universelle (cf issue #13874) -- couvre workflow_dispatch,
+    # pull_request ET pull_request_target en un seul test.
     # Garde selection : inputs.target == 'dotnet' (sinon ce job n'est pas
     # eligible -- un dispatch `target=confinement` ne planifie que le job
     # confinement).
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && inputs.target == 'dotnet'
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && inputs.target == 'dotnet'
     runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
     timeout-minutes: 20
     # Groupe separe : un dispatch .NET ne doit PAS annuler un dispatch

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -79,6 +79,15 @@ SAME_REPO_REUSABLE_PATTERN = re.compile(
 SAME_REPO_GUARD = (
     "github.event.pull_request.head.repo.full_name == github.repository"
 )
+# Defense-in-depth guard form that covers pull_request_target as well as
+# pull_request, without enumerating the trigger. The first disjunct is true
+# for every non-PR payload (workflow_dispatch, schedule, push) and the
+# second covers both pull_request and pull_request_target -- the unsafe
+# trigger that runs the base with write token + secrets access. Issue #13874.
+SAME_REPO_GUARD_NULL_SAFE = (
+    "github.event.pull_request.head.repo.full_name == null "
+    "|| github.event.pull_request.head.repo.full_name == github.repository"
+)
 DEFAULT_WORKFLOWS_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 
@@ -348,7 +357,7 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
 
             if "pull_request" in triggers:
                 condition = _normalise_condition(job.get("if"))
-                if condition != SAME_REPO_GUARD:
+                if condition not in (SAME_REPO_GUARD, SAME_REPO_GUARD_NULL_SAFE):
                     violations.append(Violation(
                         path.name,
                         str(job_name),

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -358,6 +358,69 @@ def test_pull_request_target_is_always_rejected(tmp_path):
     assert "PULL_REQUEST_TARGET" in codes(policy.scan_workflows(tmp_path))
 
 
+def test_null_safe_pull_request_guard_is_accepted(tmp_path):
+    """Defense-in-depth guard form that covers pull_request_target too.
+
+    Issue #13874: the strict `head.repo.full_name == github.repository` form
+    leaves the job vulnerable to a future addition of `pull_request_target`
+    trigger (the scanner still rejects the trigger itself, but the runtime
+    YAML guard should not depend on enumerating events). The null-safe form
+    is `head.repo.full_name == null || head.repo.full_name == repo` -- true
+    for every non-PR payload and for any PR payload from the same repo.
+    """
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: null-safe-guard
+        on: [pull_request]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository }}
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo safe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert "SAME_REPO_GUARD" not in codes(result)
+    assert "PULL_REQUEST_TARGET" not in codes(result)
+    assert result.self_hosted_jobs == 1
+
+
+def test_strict_pull_request_guard_still_accepted(tmp_path):
+    """The strict canonical guard form remains valid -- no regression."""
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: strict-guard
+        on: [pull_request]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo safe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert "SAME_REPO_GUARD" not in codes(result)
+    assert result.self_hosted_jobs == 1
+
+
+def test_null_safe_guard_with_extra_or_is_rejected(tmp_path):
+    """A null-safe guard weakened by an extra `|| always()`-like disjunct
+    must still be rejected -- the new predicate accepts only the exact
+    null-safe form, not weakened variants.
+    """
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: weak-null-safe
+        on: [pull_request]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository || always() }}
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo safe
+        """)
+    assert "SAME_REPO_GUARD" in codes(policy.scan_workflows(tmp_path))
+
+
 def test_workflow_call_cannot_hide_self_hosted_job(tmp_path):
     write_workflow(tmp_path, "callee", """
         name: callee


### PR DESCRIPTION
## Summary

Issue #13874 releve que la garde fork au niveau job dans
`linux-self-hosted-tests.yml` enumerait les triggers et laissait passer
`pull_request_target` (qui execute la base avec jeton en ecriture +
acces secrets sur une ref controlee par le fork). Cette PR remplace la
forme par une garde trigger-agnostic qui couvre `pull_request_target`
sans nommer aucun trigger, etend le scanner pour reconnaitre la
nouvelle forme, et applique le meme fix au workflow Windows coherent.

## Le defaut

La garde d'origine dans les deux workflows self-hosted etait :

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

Pour un evenement `pull_request_target`, `github.event_name` vaut
`pull_request_target` (different de `pull_request`), donc la premiere
jambe est vraie et le job s'execute, peu importe le `full_name`. Le
scanner (`scripts/ci/check_self_hosted_runner_policy.py`) refuse
bien `pull_request_target` au niveau trigger (lignes 292-298 du fichier
d'origine), donc **rien n'est exploitable aujourd'hui** -- le seul
declencheur actif est `workflow_dispatch`. Mais la garde elle-meme est
un defaut de defense-in-depth : quelqu'un qui ajoute un jour un
declencheur lie aux PR et choisit `pull_request_target` (le conseil
courant pour acceder aux secrets) herite d'une garde qui a l'air de
couvrir le cas et ne le couvre pas.

## Le fix

Forme universelle (issue #13874 verbatim) :

```yaml
if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
```

- `== null` est vrai pour tout evenement sans payload de PR
  (`workflow_dispatch`, `schedule`, `push`, ...)
- la seconde jambe couvre `pull_request` ET `pull_request_target`
  d'un seul test
- ne se defait pas quand un declencheur est ajoute

La forme stricte d'origine reste acceptee par le scanner (cf test
`test_strict_pull_request_guard_still_accepted`) -- pas de regression
sur les workflows tiers ou un user migrerait plus tard.

## Scanner -- extension du predicat `SAME_REPO_GUARD`

Le scanner (lignes 79-82 du fichier d'origine) exigeait la forme
canonique stricte par egalite exacte. Migration logique : ajouter
`SAME_REPO_GUARD_NULL_SAFE` comme second pattern accepte. La forme
faible (avec `|| always()` ou disjunct supplementaire) reste rejetee
(cf `test_null_safe_guard_with_extra_or_is_rejected`) -- le predicat
accepte uniquement les deux formes completes, pas les variantes
affaiblies.

## Portee

| Fichier | Nature du changement |
|---------|---------------------|
| `.github/workflows/linux-self-hosted-tests.yml` | 1 job : garde passee a la forme null-safe |
| `.github/workflows/windows-self-hosted-tests.yml` | 2 jobs (confinement, dotnet) : meme migration, sinon on laisse un trou documente a cote du fix |
| `scripts/ci/check_self_hosted_runner_policy.py` | Constante `SAME_REPO_GUARD_NULL_SAFE` ajoutee, predicat `SAME_REPO_GUARD` accepte les deux formes canoniques |
| `scripts/tests/test_check_self_hosted_runner_policy.py` | 3 nouveaux tests : nouvelle forme acceptee, forme stricte non-regressionee, variante faible toujours rejetee |

**Pourquoi Windows** : le fix de l'issue #13874 ne nomme que
`linux-self-hosted-tests.yml`. Mais le defaut est identique (les 2
jobs Windows portent la meme garde enumerative) et ne pas migrer
laisserait un trou documente juste a cote du fix. Migration
simultanee pour coherence ; l'issue reste assignee au seul #13874
(ce qui est resolu ; les autres jobs Windows sont une consequence
logique).

## Verification

```text
$ python -m pytest scripts/tests/test_check_self_hosted_runner_policy.py -q
collected 40 items
scripts\tests\test_check_self_hosted_runner_policy.py .................. [ 45%]
......................                                                   [100%]
============================= 40 passed in 1.08s ==============================
```

37 anciens tests intacts (zero vert -> rouge), 3 nouveaux tests
couvrant l'extension.

```text
$ python scripts/ci/check_self_hosted_runner_policy.py --check
[self-hosted-policy] workflows=130 jobs=158 self_hosted=3
[self-hosted-policy] OK -- all self-hosted jobs satisfy isolation policy.
```

Les 3 jobs self-hosted (1 linux, 2 windows) passent avec la nouvelle
forme.

```text
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/linux-self-hosted-tests.yml'))"
# OK, 1 job
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/windows-self-hosted-tests.yml'))"
# OK, 2 jobs
```

YAML parse sans workaround du `on:`.

## Pre-commit (10/10 hooks PASSED)

```text
Secret scanner (gitleaks)..........................................Passed
Refuse NEW text=True without encoding= (subprocess, cp1252 crash)...Passed
+ 8 autres hooks "no files to check" (pas de notebook, pas de .py
  ajoute/modifie au sens pre-commit)
```

## Acceptance issue #13874

- [x] **Garde fork au niveau job remplacee** par la forme universelle
      `head.repo.full_name == null || head.repo.full_name == repo`
      (linux-self-hosted-tests.yml). Forme documentee en commentaire
      dans le YAML pour le prochain lecteur.
- [x] **Meme migration sur windows-self-hosted-tests.yml** (2 jobs,
      confinement + dotnet) pour coherence -- le defaut etait
      identique et laisse non-migre = un trou documente a cote du
      fix.
- [x] **Scanner accepte la nouvelle forme** comme second pattern
      canonique (`SAME_REPO_GUARD_NULL_SAFE`), la forme stricte
      d'origine reste valide (non-regression), les variantes
      affaiblies (`|| always()`, disjuncts supplementaires) restent
      rejetees.
- [x] **Tests** : 3 nouveaux tests couvrent l'extension
      (`test_null_safe_pull_request_guard_is_accepted`,
      `test_strict_pull_request_guard_still_accepted`,
      `test_null_safe_guard_with_extra_or_is_rejected`). 37/37
      anciens tests intacts.

## Lien avec cycles / missions precedents

- **#13874** (cette PR) : defense-in-depth garde fork trigger-agnostic.
- **#13378** : mission dispatch ai-2026-08-31 qui a deploye le runner
  Linux conteneurise ; le guard fork d'origine date de cette mission
  (PR #13864, merge feat(ci,#13378)).
- **#12704** : politique d'isolation des runners self-hosted (mission
  initiale) -- la garde `SAME_REPO_GUARD` du scanner a ete introduite
  dans ce cadre.
- **#13842** : AGENTGUARD005b, autre gate de garde sur
  `ConfigureAwait(false).GetAwaiter().GetResult()` -- non lie au
  fix mais dans le meme perimetre tooling de garde CI.

Grain: LIGHT/guard - lane myia-po-2026:CoursIA - prev: LIGHT/tooling #13862 cycle 33.
paths: .github/workflows/linux-self-hosted-tests.yml, .github/workflows/windows-self-hosted-tests.yml, scripts/ci/check_self_hosted_runner_policy.py, scripts/tests/test_check_self_hosted_runner_policy.py

Closes #13874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
