### PR TITLE
fix(grain_tag,#13830): widen _LANE_RE workspace class to admit Latin-1 letters

### DIFF
--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -174,7 +174,19 @@ _GRAIN_FULL_RE = re.compile(
 # every legitimate one (a workspace word never starts `NNNN-NN-NN`).
 _LANE_RE = re.compile(
     r"lane\s*:?\s+"
-    r"([A-Za-z0-9._-]+:[A-Za-z0-9._-]+"
+    # #13830 -- the workspace class widens from `[A-Za-z0-9._-]+` to
+    # `[A-Za-zÀ-ÖØ-öø-ÿ0-9._-]+` (Latin-1 letter range U+00C0-U+00FF
+    # added) so a workspace with Latin-1 letters (e.g. `LivresAgités`)
+    # stops truncating at the first non-ASCII byte. Digits, underscore,
+    # hyphen, period are all preserved so `CoursIA-2` and similar survive.
+    # The machine slug keeps its ASCII-only class (`myia-<slug>` -- no
+    # legitimate machine ID carries Latin-1 letters), so the fix is scoped
+    # to the workspace token (after the colon). The upper-case-initial
+    # constraint on continuation words (`(?-i:[A-Z0-9])`) keeps prose from
+    # being swallowed, and the bare-date + colon/URL guards below are
+    # unchanged. The twin `_LANE_FALLBACK_RE` MUST move with the primary
+    # or the founder's class of bug (#12145) re-opens on the fallback only.
+    r"([A-Za-z0-9._-]+:[A-Za-zÀ-ÖØ-öø-ÿ0-9._-]+"
     r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9])[A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})",
     re.IGNORECASE,
 )
@@ -205,7 +217,15 @@ _LANE_RE = re.compile(
 # THIS regex that swallowed `2026-08-23` into the lane token. The sibling
 # moves with the fix.
 _LANE_FALLBACK_RE = re.compile(
-    r"\b(myia-[A-Za-z0-9._-]+:[A-Za-z][A-Za-z0-9._-]*"
+    # #13830 -- twin of `_LANE_RE`: the workspace class widens from
+    # `[A-Za-z][A-Za-z0-9._-]*` to `[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9._-]*`
+    # (Latin-1 letter range U+00C0-U+00FF added) so a workspace with Latin-1
+    # letters (e.g. `LivresAgités`) stops truncating at the first non-ASCII
+    # byte. Casse-sensible here (`re.IGNORECASE` absent on this branch), so
+    # `[A-Z]` keeps meaning upper case ASCII only; the additional range is
+    # closed in U+00FF. The twin MUST move with the primary or the founder's
+    # class of bug (#12145) re-opens on the fallback only.
+    r"\b(myia-[A-Za-z0-9._-]+:[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9._-]*"
     r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})[A-Z0-9][A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})"
 )
 

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -740,3 +740,87 @@ def test_lane_marker_residues_report_malformed_forms():
     # A clean marker carries no residue.
     clean = "[CLAIMED] lane myia-po-2023:CoursIA -- paths: foo.py"
     assert gt.lane_marker_residues(clean) == []
+
+
+# --- #13830: workspace with Latin-1 letters used to truncate ---------------
+#
+# Founder case: a lane whose workspace carries Latin-1 letters (e.g.
+# `myia-ai-01:LivresAgites`) was truncated to `myia-ai-01:LivresAgit` -- the
+# first non-ASCII byte was eaten by the `[A-Za-z0-9._-]+` class. The cap
+# G-VAR-2 then counted zero grains on the lane that wrote its name correctly.
+# The fix widens the workspace class to `[A-Za-zA...-O...-o...-y0-9._-]+` in
+# BOTH `_LANE_RE` and `_LANE_FALLBACK_RE` (the twin MUST move or the bug
+# re-opens on the fallback only -- the documented founder shape #12145).
+
+
+def test_lane_latin1_workspace_not_truncated_primary():
+    """Primary regex: `lane <machine>:<workspace>` body form.
+
+    Pre-fix returned `myia-ai-01:LivresAgit` (lost `es` after the `e`).
+    Post-fix must return the full token with the accented letter intact.
+    """
+    body = "[CLAIMED] #13286 — lane myia-ai-01:LivresAgités 2026-08-23"
+    assert gt.extract_lane(body) == "myia-ai-01:LivresAgités"
+
+
+def test_lane_latin1_workspace_not_truncated_fallback():
+    """Fallback regex: marker-line form, no literal `lane` keyword (#10395).
+
+    The twin regex MUST accept the same shape, otherwise the founder bug
+    (#12145) re-opens on the fallback only -- a class of bug the file
+    explicitly calls out at the `_LANE_FALLBACK_RE` definition site.
+    """
+    line = "[CLAIMED] myia-ai-01:LivresAgités 2026-08-23T00:52Z"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgités"
+
+
+def test_lane_latin1_multiple_accented_letters():
+    """Multiple Latin-1 letters in the same workspace word."""
+    line = "[CLAIMED] myia-ai-01:LivresAgitésÉlégants 2026-08-23T00:52Z"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgitésÉlégants"
+
+
+def test_lane_ascii_workspace_still_truncates_correctly():
+    """Non-regression: an ASCII workspace still returns the same token.
+
+    Mandatory control -- without it, a too-permissive class could swallow
+    the next prose word and the test would still pass.
+    """
+    line = "[CLAIMED] myia-ai-01:LivresAgit 2026-08-23T00:52Z"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgit"
+
+
+def test_lane_latin1_does_not_swallow_prose():
+    """The Latin-1 widening must not extend the token into the next prose word.
+
+    Pre-fix: the class stopped at the first non-ASCII byte (and dropped
+    the rest). Post-fix: the class extends through accented letters but
+    still halts at whitespace and punctuation -- prose after the workspace
+    stays out of the lane token.
+    """
+    body = "[CLAIMED] lane myia-ai-01:LivresAgités a livre trois PRs."
+    assert gt.extract_lane(body) == "myia-ai-01:LivresAgités"
+
+
+def test_lane_latin1_hyphenated_workspace_still_works():
+    """Non-regression #13830 must NOT re-introduce the `CoursIA-2` bug.
+
+    The original `[A-Za-z0-9._-]+` class let `CoursIA-2` through; the
+    fix must keep that path open.
+    """
+    body = "Grain: MED/guard - lane myia-po-2024:CoursIA-2 - prev: tooling #13862"
+    assert gt.extract_lane(body) == "myia-po-2024:CoursIA-2"
+
+
+def test_lane_latin1_bare_date_still_rejected():
+    """Non-regression #12719: a bare date immediately after the workspace
+    must NOT be swallowed by the continuation clause. The widening does
+    not touch the `(?!\d{4}-\d{2}-\d{2})` negative lookahead, but the
+    test pins that down explicitly.
+    """
+    line = "[CLAIMED] myia-ai-01:LivresAgités 2026-08-23 — Medical-Chatbot : amorcage batch"
+    # The lane token is the workspace only; the bare date is reported as a
+    # residue but the lane extraction still works.
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgités"
+    residues = gt.lane_marker_residues(line)
+    assert any(r.startswith("bare-date:") for r in residues), residues


### PR DESCRIPTION
## Summary

Issue #13830 releve que la classe de caracteres du **workspace** dans
`_LANE_RE` et `_LANE_FALLBACK_RE` (`scripts/grain_tag.py`) est
`[A-Za-z0-9._-]+` -- ASCII seul. Une lane dont le workspace porte une
lettre Latin-1 (ex. `myia-ai-01:LivresAgites`) est tronquee au
premier octet non-ASCII, devient differente d'elle-meme, et son cap
G-VAR-2 tombe a zero grain. La lane reste invisible a `pick_idle_grain`,
et `variation_light_cap` la declare en arret a tort.

Cette PR elargit la classe du workspace (apres le `:`) a
`[A-Za-zA...-O...-o...-y0-9._-]+` dans **les deux** regex soeurs. La
classe de la machine (avant le `:`) reste ASCII -- `myia-<slug>` ne
porte pas de Latin-1 en pratique.

## Le defaut (mesure firsthand)

```text
$ python -c "import sys; sys.path.insert(0, 'scripts'); from grain_tag import extract_lane;
             print(repr(extract_lane('no lane keyword here', marker_line='[CLAIMED] myia-ai-01:LivresAgites 2026-08-23T00:52Z')))"
PRE-FIX: 'myia-ai-01:LivresAgit'    # tronque apres le 'e' (U+00E9)
POST-FIX: 'myia-ai-01:LivresAgites' # token complet
```

Trois PRs mergees sur cette lane (scan des 300 dernieres) :
`#13286`, `#13415`, `#13575`. Cap G-VAR-2 les a toutes comptees a
zero grain alors qu'elles etaient legitimes. L'organe d'adjacence a
mors ; le cap, lui, ne voyait rien a compter.

## Le fix

```python
# AVANT
_LANE_RE = re.compile(
    r"lane\s*:?\s+"
    r"([A-Za-z0-9._-]+:[A-Za-z0-9._-]+"          # workspace ASCII seul
    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9])[A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})",
    re.IGNORECASE,
)

# APRES
_LANE_RE = re.compile(
    r"lane\s*:?\s+"
    r"([A-Za-z0-9._-]+:[A-Za-zÀ-ÖØ-öø-ÿ0-9._-]+" # workspace + Latin-1 U+00C0-U+00FF
    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9])[A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})",
    re.IGNORECASE,
)

_LANE_FALLBACK_RE = re.compile(
    r"\b(myia-[A-Za-z0-9._-]+:[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9._-]*"  # jumeau
    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})[A-Z0-9][A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})"
)
```

**Contraintes preservees** (toutes documentees dans le code) :
- casse-sensible continuation (`(?-i:[A-Z0-9])` sur `_LANE_RE`,
  `[A-Z0-9]` sur `_LANE_FALLBACK_RE`)
- garde anti-date `(?!\d{4}-\d{2}-\d{2})` (cf #12719)
- rejet timestamps / URLs `(?![:@])`
- casse stricte sur la branche fallback (qui n'a pas `re.IGNORECASE`)

**Pourquoi deux regex soeurs** : le fichier lui-meme appelle cela dans
le commentaire `_LANE_FALLBACK_RE` ("Fixing one half of a duplicated
mechanism and not grepping for the other is the recurring shape of this
class of bug #12145."). Les deux sont editees en parallele.

## Verification

```text
$ python -m pytest scripts/tests/test_grain_tag.py -v
============================= 71 passed in 0.14s ==============================
```

64 anciens tests intacts (zero vert -> rouge) + 7 nouveaux :

| Test | Role |
|------|------|
| `test_lane_latin1_workspace_not_truncated_primary` | Fondateur : primary regex + `LivresAgités` retourne le token complet |
| `test_lane_latin1_workspace_not_truncated_fallback` | Fondateur : fallback regex + `LivresAgités` retourne le token complet (le jumeau DOIT suivre, sinon le bug #12145 re-ouvre sur le fallback) |
| `test_lane_latin1_multiple_accented_letters` | Variante : `LivresAgitésÉlégants` (plusieurs accents) |
| `test_lane_ascii_workspace_still_truncates_correctly` | Non-regression ASCII obligatoire -- un motif trop large repasserait vert sans qu'on le voie |
| `test_lane_latin1_does_not_swallow_prose` | L'elargissement ne doit pas etendre le token dans la prose suivante |
| `test_lane_latin1_hyphenated_workspace_still_works` | Non-regression `CoursIA-2` -- le `-` reste dans la classe |
| `test_lane_latin1_bare_date_still_rejected` | Non-regression #12719 -- la bare date reste signalee comme residue |

```text
$ python -m pytest scripts/tests/test_check_lane_claim.py \
    scripts/tests/test_lane_claim_required.py \
    scripts/tests/test_variation_adjacency_guard.py \
    scripts/tests/test_variation_prev_guard.py \
    scripts/tests/test_variation_tag_required.py \
    scripts/tests/test_pick_idle_grain.py -q
======================= 470 passed, 1 skipped in 15.19s =======================
```

Tous les tests des consommateurs downstream (lane_claim,
variation_*, pick_idle_grain) passent inchanges. Le seul `skipped`
est un test non lie (verifie par grep avant push).

## Pre-commit (10/10 hooks PASSED)

```text
Secret scanner (gitleaks)..........................................Passed
Refuse NEW text=True without encoding= (subprocess, cp1252 crash)...Passed
+ 8 autres hooks "no files to check" (pas de notebook, pas de YAML)
```

## Acceptance issue #13830

- [x] **Lane a workspace accentue matche** dans la primary regex
      (`extract_lane` body avec keyword `lane`) et dans la fallback
      (marker line, sans keyword). Controle positif firsthand sur
      `myia-ai-01:LivresAgités`.
- [x] **Les jumeaux `_LANE_RE` et `_LANE_FALLBACK_RE` bougent en
      parallele** -- le commentaire `_LANE_FALLBACK_RE` lui-meme
      rappelle que c'est la forme du fondateur #12145.
- [x] **Non-regression** : ASCII, `CoursIA-2`, prose swallowing, bare
      date, casse-sensible. 64 anciens tests + 470 tests
      downstream verts.
- [x] **Pas de machine slug en Latin-1** -- la classe machine reste
      ASCII (`myia-<slug>` n'en porte pas en pratique), le fix est
      scope au workspace.

## Lien avec cycles / missions precedents

- **#13830** (cette PR) : elargissement classe workspace Latin-1.
- **#12719** : fondateur bare-date ; le garde `(?!\d{4}-\d{2}-\d{2})`
  est preserve par cette PR.
- **#12145** : fondateur space tolerance ; le test
  `test_lane_workspace_with_spaces` reste vert.
- **#13842** : AGENTGUARD005b, autre guard -- non lie au fix mais
  dans le meme perimetre tooling de garde.
- **#13874** (cycle 34 precedent) : autre garde CI (fork guard
  trigger-agnostic) ; meme pattern (regex de garde + tests de
  non-regression).

Grain: MED/guard - lane myia-po-2026:CoursIA - prev: LIGHT/guard #13874 cycle 34.
paths: scripts/grain_tag.py, scripts/tests/test_grain_tag.py

Closes #13830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
