### PR TITLE
docs(proactive-coord,#13870): L721 stale-tracker guard -- query by tag, not --author

### DIFF
--- a/.claude/rules/proactive-coordination.md
+++ b/.claude/rules/proactive-coordination.md
@@ -56,7 +56,19 @@ Une requête à `--limit 300` (troncature défaite par construction), un tirage 
 
 ## Leçons ancrées (checks pré-`[DONE]`)
 
-- **L721 ★ — stale-tracker guard.** Avant **tout** claim de « 0 PR / saturated / idle » : `gh pr list --author <self> --state open --json number -q 'length'`. L'omettre produit des états terminaux **faux négatifs** (une session parallèle a peut-être déjà livré).
+- **L721 ★ — stale-tracker guard.** Avant **tout** claim de « 0 PR / saturated / idle » : la requête DOIT interroger le **tag de lane** (la même clé que `pick_idle_grain.py` lit), **PAS** `--author <self>`. Forme canonique (variable shell, robuste Git Bash / PowerShell / CMD) :
+
+  ```bash
+  LANE="<machine:workspace>"  # ex. myia-po-2026:CoursIA
+  gh pr list --state open --limit 100 --json number,title,body \
+    --jq ".[]|select(.body|test(\"lane $LANE\"))|\"#\(.number) \(.title)\""
+  ```
+
+  **Pourquoi pas `--author <self>`** (#13870) : les workers poussent sous le compte `jsboige` partagé, pas sous leur nom de lane -- `--author myia-po-2026` rend **0** alors que la lane porte 25 PRs ouvertes (mesure 2026-09-01, 59 PRs pool). Quatre lanes sur cinq voient `0` de leur propre travail avec la requête prescrite, et une lane a escaladé `[URGENT] HIGH` (`msg-20260831T181622-9fucbh`) en croyant n'avoir rien livré alors qu'elle portait 12 PRs -- exactement l'état terminal faux-négatif que ce garde devait prévenir.
+
+  **Contrôle positif obligatoire** : la requête corrigée se valide par ses **faux négatifs** symétriques -- une lane connue pour avoir N PRs doit en rendre N, pas par le fait qu'elle rende un nombre. Mesure de référence du 2026-09-01 : `myia-po-2026:CoursIA` → 25, `myia-po-2024:CoursIA` → 11, `myia-ai-01:CoursIA` → 9, `myia-po-2027:CoursIA` → 5, `myia-po-2023:CoursIA` → 3 -- toutes non-nulles (la mesure 2026-08-31 de l'issue #13870 incluait `myia-po-2025` à 1 PR qui a depuis été mergée).
+
+  **Repli** : si une PR ne porte **pas** le tag `Grain:` lisible, elle reste invisible aux deux requêtes (tag + author) ; c'est l'angle mort partagé avec `GRAIN-ORPHANS-SWEEP` (#13086). Traiter par le sweep dédié, **pas** en relâchant la requête ici.
 - **L740 ★ — CronList 7-day verify.** Les crons `CronCreate` sont **session-only, auto-expirent à 7 j**. Avant `[DONE]`, vérifier qu'ils vivent encore et **re-armer** — un cron expiré = wakeup mort = lane-idle silencieuse.
 - **L898 ★★★ — collision guard : avant d'ÉCRIRE, pas avant de pousser.** Avant de poser un `[CLAIMED]`, rédiger un steer/verdict, éditer un fichier **ou** `git push` : `git worktree list` + `gh pr list --search head:<branch>` + `gh pr list --search "<mot-clé>"` + `gh pr list --state open --json files` sur le **chemin** visé. Relire l'artefact sur `main` **ne remplace pas** ce check : `main` ne montre pas ce qui est *ouvert*. Coût ~10 s ; coût de l'omission = travail dupliqué et rétractation publique.
 - **L1356 ★★★ — preflight de claim : `--state all`, jamais `--state open` seul (incidents #13562/#13608, corroboré po-2025 sur #12794).** L898 vérifie ce qui est **ouvert** ; une PR **MERGÉE** qui a livré l'issue en rider (référence à un autre numéro, pas de `Closes #N`) est invisible à ce filtre, et l'issue reste OPEN sans PR liée — **« OPEN + zéro PR liée » n'est PAS une preuve de fraîcheur**. Avant tout `[CLAIMED]` : (1) `gh search prs "<N>"` (ou `gh pr list --state all --search "<N>"`) — une PR merged sur le sujet = grain livré ; (2) `ls -d <repo-worktrees>/*<motif>*` — un **worktree orphelin** nommé pour l'issue signale une session antérieure : la compaction efface le souvenir du travail, pas le disque ; inspecter sa branche (`git log -1`) avant de créer quoi que ce soit. Si livré : poster un commentaire `[INFO] candidate-delivered` avec preuve (commit + tests) pour fermeture par le coordinateur — **ne pas réimplémenter, ne pas closer soi-même**.


### PR DESCRIPTION
## Summary

Issue #13870 releve que `.claude/rules/proactive-coordination.md` L721
prescrit `gh pr list --author <self>` comme garde anti-faux-negatif,
alors que **cette requete produit le faux negatif qu'elle devait
prevenir**. Les workers poussent sous le compte partage `jsboige`,
pas leur nom de lane, donc `--author myia-po-2026` rend `0` alors que
la lane porte 25 PRs ouvertes. Quatre lanes sur cinq voient `0` de
leur propre travail avec la requete prescrite.

Cette PR remplace la requete par une variante basee sur le **tag de
lane** -- la meme cle machine-readable que `pick_idle_grain.py`
utilise deja (le picker, lui, trouve correctement les PRs d'une lane :
c'est la requete manuelle prescrite par la regle qui diverge de
l'organe).

## Le defaut (mesure firsthand, 2026-09-01, 59 PR pool)

| Lane | `--author myia-X` | `Grain: lane myia-X` | Ecart |
|------|---------------------|-----------------------|-------|
| `myia-po-2026:CoursIA` | **0** | **25** | -25 |
| `myia-po-2024:CoursIA` | **0** | **11** | -11 |
| `myia-ai-01:CoursIA`   | 5   | 9  | -4 (coordinateur sous son propre nom) |
| `myia-po-2027:CoursIA` | **0** | **5** | -5 |
| `myia-po-2023:CoursIA` | **0** | **3** | -3 |

**Quatre lanes sur cinq voient zero** avec la requete prescrite.

## L'incident fondateur

`myia-po-2024:CoursIA-2` a applique L721 a la lettre, obtenu `0`, et
conclu « la lane n'a aucune PR ouverte » puis « plancher G-VAR-1 non
tenu, 132ᵉ cycle, defaut de provisionnement ai-01 » -- escalade DM
`[URGENT] HIGH` (`msg-20260831T181622-9fucbh`).

La lane portait a cet instant **12 PRs ouvertes**, dont 2 DEEP/notebook,
1 MED/lean, et 6 autres grains notebook -- c'est-a-dire massivement du
CONTENU, exactement ce dont elle se declarait privee. Le cycle a ete
depense en escalade au lieu de reparer #13724 et #13734.

Le garde n'a pas seulement rate son but : il l'a **fabrique**.

## Le fix

Forme canonique (variable shell, robuste Git Bash / PowerShell / CMD --
les formes `--arg` jq ou single-quoted ont des comportements de shell
qui varient selon l'env) :

```bash
LANE="<machine:workspace>"  # ex. myia-po-2026:CoursIA
gh pr list --state open --limit 100 --json number,title,body \
  --jq ".[]|select(.body|test(\"lane \$LANE\"))|\"#\(.number) \(.title)\""
```

Le matcher est la meme cle que `pick_idle_grain.py` lit (`scripts/pick_idle_grain.py:169`
« #9485 -- Lecteur PARTAGE du tag `Grain:`. C'est la SEULE ancre qui
rattache une PR a une lane »).

**Pourquoi pas `--author <self>`** :
- Workers poussent sous le compte partage `jsboige`, pas leur nom de lane.
- Le coordinateur `myia-ai-01` pousse sous son propre nom, ce qui rend
  `--author myia-ai-01` non-nul mais **par accident** (5 PRs) -- pas un
  garde, un artefact.

**Pourquoi pas assouplir la cle de matching (relax `lane` prefix)** :
Le matching strict `test("lane \$LANE")` est ce qui distingue le tag
de lane d'une mention fortuite du nom de lane en prose. Le relacher
ouvrirait la porte aux faux positifs (un PR qui mentionne `myia-po-2026`
dans un commentaire anodin se retrouverait compte).

## Verification firsthand

```text
$ LANE="myia-po-2026:CoursIA" gh pr list --state open --limit 100 \
    --json number,title,body \
    --jq '.[]|select(.body|test("lane myia-po-2026:CoursIA"))|"#\(.number)"'
25 PRs rendues (coherent avec le comptage tag dans le tableau ci-dessus)

$ gh pr list --author myia-po-2026 --state open --json number -q 'length'
0  # le bug que L721 perpetuait

$ gh pr list --author @me --state open --json number -q 'length'
30 # nombre global qui melange TOUTES les lanes -- inutilisable comme garde par lane
```

## Acceptance issue #13870

- [x] **L721 ne prescrit plus `--author <self>`** : remplace par la
      requete tag-based (meme cle que `pick_idle_grain.py`).
- [x] **Controle positif obligatoire documente** : la requete corrigee
      se valide par ses **faux negatifs symetriques** -- une lane
      connue pour avoir N PRs doit en rendre N. Mesure de reference
      2026-09-01 in-line dans le commentaire de la regle.
- [x] **Repli pour PR sans tag lisible** : la regle precise que c'est
      l'angle mort partage avec `GRAIN-ORPHANS-SWEEP` #13086, a
      traiter par le sweep dedie -- **pas** en relachant la requete ici.
- [x] **Verification qu'aucune autre regle du harnais ne prescrit
      `--author <self>`** : `grep -rnE "gh pr list.*--author"
      .claude/rules/ docs/` retourne **uniquement** la L721 modifiee.
      Aucun autre site a corriger.

## Perimetre (1 fichier, +13/-1)

```text
.claude/rules/proactive-coordination.md | 14 +++++++++++++-
```

Aucun code Python, aucun test (la regle est une prescription de
commande shell). La validation est la mesure de comptage PRs
ci-dessus ; les autres PRs existantes servent de reference.

## Lien avec cycles / missions precedents

- **#13870** (cette PR) : correction de la prescription L721.
- **#9485** : Lecteur partage du tag `Grain:` (mentionne dans le code
  `pick_idle_grain.py:169` comme SEULE ancre lane). C'est ce que la
  nouvelle requete de L721 utilise comme cle.
- **#13086** : `GRAIN-ORPHANS-SWEEP` -- l'angle mort des PRs sans tag
  lisible, designe explicitement comme le point de traitement dedie
  (pas de relachement de la requete ici).
- **#12719** : fondateur bare-date `_LANE_RE` (classe ASCII) -- autre
  bug dans la lecture du tag lane, traite en cycle 35 par PR #13899.
- **#12145** : fondateur space tolerance `_LANE_RE` -- autre bug
  historique lie.

Grain: LIGHT/tooling (META — correction d'une regle de coordination) — lane myia-po-2026:CoursIA — prev: MED/guard #13830 cycle 35.
paths: .claude/rules/proactive-coordination.md

Closes #13870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
