### PR TITLE
feat(genai,#13898): P6 tranche 2 — première chaîne orchestrée LIVE p1_5..p7 (passes gated)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p2_segmentation.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p2_segmentation.py
@@ -91,18 +91,23 @@ Assure-toi que :
 # ── Pre-processing ──
 
 
-def load_source_text(path: Path = SOURCE_TEXT) -> str:
+def load_source_text(path: Path | None = None) -> str:
     """Load the full source text file.
+
+    Reads the module-level ``SOURCE_TEXT`` at call time (an orchestrator may
+    override it after import; a default-argument binding would freeze the
+    original path).
 
     Raises:
         FileNotFoundError: If the source text file does not exist.
     """
-    if not path.exists():
+    resolved = SOURCE_TEXT if path is None else path
+    if not resolved.exists():
         raise FileNotFoundError(
-            f"Source text not found: {path}\n"
+            f"Source text not found: {resolved}\n"
             "Place boule_de_suif_full.txt in the 04-Applications directory."
         )
-    return path.read_text(encoding="utf-8")
+    return resolved.read_text(encoding="utf-8")
 
 
 def split_into_paragraphs(text: str) -> list[dict]:

--- a/scripts/audiobook_pipeline.py
+++ b/scripts/audiobook_pipeline.py
@@ -5,7 +5,8 @@ Chainage des passes v4 (p0..p7) de `MyIA.AI.Notebooks/GenAI/Audio/04-Application
 sur un livre arbitraire. Chaque passe est un module v4 existant avec son
 point d'entree `run()` ; cet orchestrateur les execute dans l'ordre, avec :
 
-- `--book PATH`      : texte source arbitraire (defaut : boule_de_suif_full.txt)
+- `--book PATH`      : texte source arbitraire (defaut : boule_de_suif_full.txt),
+                       plombe dans toute passe lisant SOURCE_TEXT (p0, p1_5, p2)
 - `--dry-run`        : n'appelle AUCUN service externe -- les passes gatees
                        (LLM, TTS, SearXNG) sont planifiees avec leur gate
                        documentee, la segmentation deterministe (p2) s'execute
@@ -137,7 +138,7 @@ def main() -> int:
             continue
         try:
             mod = __import__(p.module, fromlist=["run"])
-            if p.key == "p2":
+            if hasattr(mod, "SOURCE_TEXT"):
                 mod.SOURCE_TEXT = args.book
             out = mod.run()
             print(f"[ OK  ] {p.key:5s} {p.label} -> {getattr(out, 'name', out)}")


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA-2 — prev: MED/qc #13894

## Summary

**P6 tranche 2 (issue #13898, EPIC #1028)** — première exécution **LIVE chaînée** de `scripts/audiobook_pipeline.py` (le mode COMPLET existait depuis la tranche 1 #12355 mais n'avait jamais tourné en chaîne ; les artefacts existants venaient de runs passe-par-passe).

Corpus borné : mini-livre synthétique `datasets/synthetic/persona_test_book.txt` (21 paragraphes, 4 locuteurs canoniques, validé P7-t1 #12362), fenêtre `p1_5..p7`, fenêtre p0 exclue (gate SearXNG down, mesuré).

## Découvertes + fixes (le cœur du grain)

Deux bugs réels de live-mode trouvés par la première exécution, corrigés :

| Bug | Symptôme | Fix |
|---|---|---|
| `--book` plombé seulement dans p2 | p0/p1_5 lisaient toujours `boule_de_suif_full.txt` codé dur | orchestrateur : `hasattr(mod, "SOURCE_TEXT")` → plombe toute passe qui expose `SOURCE_TEXT` (p0, p1_5, p2) |
| default-arg figé dans p2 | `def load_source_text(path=SOURCE_TEXT)` lie le path **à la définition** — l'injection orchestrateur était inopérante pour p2 (385 paragraphes de BdS chargés au lieu des 21 du mini-livre) | `path: Path \| None = None` + résolution du global **à l'appel** |

Preuve du fix p2 : run 2 « 21 paragraphs / 4 chunks » (vs 385/64 avant), cohérent avec le dry-run P7-t1 (21 para / 4 chunks).

## Matrice de gates (mesurée ce cycle)

| Passe | Gate | Statut |
|---|---|---|
| p0 recherche narrative | SearXNG `search.myia.io` | **DOWN** (HTTP 401, mesuré 2026-09-01) — fenêtre démarrée à p1_5 ; narrative_context du mini-livre converti depuis `persona_catalog.json` (P7-t1), provenance dans l'artefact |
| p1_5 catalogue | LLM structurant (GenAI/.env) | LIVE |
| p2 segmentation | LLM | LIVE |
| p3 contexte dramatique | LLM | LIVE |
| p4 annotation prosodique | LLM | LIVE |
| p5 TTS | FishAudio S2-Pro :8197 | LIVE (conteneur relancé exit-137 → healthy) |
| p6c compilation | ffmpeg | LIVE |
| p7 vérification | Whisper-api | LIVE |

## Résultat du run live

**`Pipeline complet termine. — exit 0, 7/7 passes OK, zéro FAIL`** (run chaîné via l'orchestrateur, mini-livre 21 paragraphes, ~8 min wall) :

| Passe | Sortie | Métriques live |
|---|---|---|
| p1_5 | `speaker_catalog.json` | 4 locuteurs canoniques identifiés (= les 4 personas du catalogue), 0 figurant |
| p2 | `segments_v4.json` | 21 paragraphes → 4 chunks LLM → 51 segments bruts → 21 dédupliqués ; **coverage 57.5 %** (warning émis par la passe — métrique honnête, segments plus courts que la source) |
| p3 | `dramatic_context.json` + `p3_scene_map.json` | 21 segments mappés, tension moyenne 4.6/10 |
| p4 | `annotated_v4.json` | 21/21 segmentés tagués, 42 tags S2-Pro officiels, 9 tags uniques, 0 narrateur non-tagué, 0 même-départ consécutif |
| p5 | `tts_results.json` | **21/21 générés, 0 échec**, 56.5 s (FishAudio S2-Pro live) |
| p6c | mp3 compilé | 21 segments, 122.7 s, 2.8 MB (ffmpeg live, frontières d'actes aux segments 10/20) |
| p7 | `quality_report.json` | **WER moyen 0.105**, P95 0.3, verdict **PASS** |

**Findings live-mode supplémentaires (documentés, non corrigés — hors scope minimal)** :
1. **p3 code en dur des actes BdS** (`ACT_TENSION_DEFAULTS` + descriptions diligence/auberge/pressing) : la calibration de scènes d'un livre arbitraire est orientée par la structure de Boule de Suif (notre run a mappé le conte synthétique sur 3 actes BdS). Follow-up : dériver les actes de `narrative_context.acts`.
2. **p7 diarization down-tolerated** : service `localhost:7860` (Gradio) refusé → la passe continue (Speakers: −1) sans échec. Gate à documenter dans le registre des services requis.
3. **p6c/p7 codent dur** `boule_de_suif_v4.mp3` (déjà noté) — sur livre arbitraire, l'audiobook porte le nom du livre par défaut.

**Finding supplémentaire (non corrigé, hors scope minimal)** : `p6_compile.run()` et `p7_verify.run()` codent dur le nom de sortie `boule_de_suif_v4.mp3` — voir findings ci-dessous.

## Preuves

- Log d'exécution complet cité ci-dessus (exit code, passes OK/FAIL).
- Artefacts dans `v4/outputs/` (gitignored, non committés — outputs de run local).
- Diff commité : 2 fichiers (`scripts/audiobook_pipeline.py`, `v4/p2_segmentation.py`), aucun output committé.

## État de l'issue

`See #13898` — P6 tranche 2 honorée sur corpus borné ; p0 live (re-run SearXNG à sa remontée) et livre complet Boule de Suif en live restent des follow-ups nommés (non-goals documentés dans l'issue).

## Test plan

- [x] Fix orchestrateur plombé pour p0/p1_5/p2 (preuve : p2 charge 21 para, 4 chunks)
- [x] Fix default-arg p2 (114 tests v4 verts post-fix)
- [x] Run live p1_5..p7 exit 0, zéro FAIL (log complet cité)
- [x] Artefacts produits (speaker_catalog, segments_v4, dramatic_context, annotated_v4, tts_results, mp3, quality_report)
- [x] Matrice gates + métriques

See #13898 (P6 tranche 2 — chaîne orchestrée live sur corpus borné)
See #1028 (EPIC GenAI Audiobook)
