### PR TITLE
fix(prover,#1453): calibration sorry_replacement morte-née — stub lanceur + restauration byte-exacte

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -152,6 +152,68 @@ def count_real_sorries(content: str) -> int:
     return len(_SORRY_TOKEN_RE.findall(strip_lean_comments(content)))
 
 
+_TOP_LEVEL_DECL_RE = re.compile(
+    r"^(theorem|lemma|def|abbrev|instance|structure|inductive|class|"
+    r"private|protected|partial|noncomputable|namespace|end|section|open|"
+    r"attribute|@\[|#eval|#check|#print|/--|/-|--|set_option)\b"
+)
+
+
+def stub_theorem_proof(source: str, theorem_name: str) -> str:
+    """Replace the proof of ``theorem_name`` with ``:= by sorry`` (calibration, #1453).
+
+    Calibration targets are committed WITH their approved proof — that proof is
+    the ground truth the prover must reproduce, not a state to preserve at
+    runtime. This stubs the declaration body from its ``:=`` up to the next
+    top-level construct, leaving the statement (signature) intact so the
+    prover attacks exactly the declaration the DEMO config names.
+
+    End-of-proof rule: the first non-blank line at column 0 after the ``:=``
+    line (Lean convention: proof bodies are indented under ``:= by``). This
+    also catches the ``/--`` docstring of the next declaration, so the stub
+    never swallows a sibling's documentation.
+
+    Raises ValueError when the declaration, its ``:=`` or its terminator is
+    not found — a calibration run must fail loud rather than stub the wrong
+    region and report a fake target.
+    """
+    source = _require_str("source", source, allow_empty=False)
+    theorem_name = _require_str("theorem_name", theorem_name, allow_empty=False)
+    lines = source.splitlines(keepends=True)
+
+    decl_re = re.compile(
+        r"^\s*(theorem|lemma|def|abbrev)\s+" + re.escape(theorem_name) + r"\b"
+    )
+    decl_idx = next(
+        (i for i, ln in enumerate(lines) if decl_re.match(ln)), None
+    )
+    if decl_idx is None:
+        raise ValueError(f"declaration {theorem_name!r} not found")
+
+    arrow_idx = None
+    arrow_col = None
+    for j in range(decl_idx, len(lines)):
+        if j > decl_idx and _TOP_LEVEL_DECL_RE.match(lines[j]):
+            raise ValueError(
+                f"no ':=' found in {theorem_name!r} before next declaration"
+            )
+        col = lines[j].find(":=")
+        if col != -1:
+            arrow_idx, arrow_col = j, col
+            break
+    if arrow_idx is None:
+        raise ValueError(f"no ':=' found in {theorem_name!r}")
+
+    end_idx = len(lines)
+    for k in range(arrow_idx + 1, len(lines)):
+        if re.match(r"\S", lines[k]):
+            end_idx = k
+            break
+
+    stub_line = lines[arrow_idx][:arrow_col].rstrip() + " := by sorry\n"
+    return "".join(lines[:arrow_idx] + [stub_line] + lines[end_idx:])
+
+
 # Implicit-sorry detection (Epic #1500, c.1301+209):
 #
 # Tactic strategies like ``apply?`` / ``exact?`` / ``solve_by_elim`` fall back

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -15,6 +15,11 @@ Output format (parseable by harvest scripts):
     [BG] TRACE_PATH=<absolute path>
     [BG] TREE_LOCK <path>          (advisory lock taken, See #6790)
     [BG] LOCKED <reason>           (another prover holds the tree -> exit 3)
+    [BG] CALIBRATION_STUB theorem=<name> line=<n>   (#1453 sorry_replacement
+                                   target: approved proof stubbed in place,
+                                   original restored on exit — paired with
+                                   CALIBRATION_RESTORE)
+    [BG] CALIBRATION_RESTORE approved proof restored
     [BG] DO_NOT_TARGET_REDIRECT requested_line=N -> M   (--line hit a DO NOT TARGET region; auto-redirected to CURRENT TARGET)
     [BG] DO_NOT_TARGET_REFUSED requested_line=N ...      (no safe CURRENT TARGET -> exit 4, workflow never launched)
     [BG] EXIT code=<rc>            (always printed, even on exception path)
@@ -66,7 +71,10 @@ from target_guard import (  # noqa: E402
 from prover.config import DEMOS  # noqa: E402
 from prover.provers import MultiAgentSorryProver  # noqa: E402
 from prover.trace import TraceLogger  # noqa: E402
-from prover.lean_utils import count_real_sorries  # noqa: E402  (#9402: real-token counter)
+from prover.lean_utils import (  # noqa: E402  (#9402: real-token counter)
+    count_real_sorries,
+    stub_theorem_proof,
+)
 from prover.tree_lock import (  # noqa: E402
     acquire_tree_lock,
     find_lean_project_root,
@@ -135,6 +143,8 @@ async def main(args: argparse.Namespace) -> int:
     _bg(
         f"PROVIDER reasoning={args.provider} fast={args.local_provider} "
         f"tactic={getattr(args, 'tactic_provider', None) or 'openrouter'} "
+        f"search={getattr(args, 'search_provider', None) or 'p6_routing'} "
+        f"critic={getattr(args, 'critic_provider', None) or 'p6_routing'} "
         f"director={args.director_provider or 'none'} "
         f"max_iter={args.max_iter} workflow_timeout={args.workflow_timeout}s"
     )
@@ -161,6 +171,51 @@ async def main(args: argparse.Namespace) -> int:
 async def _run_locked(
     args: argparse.Namespace, demo: dict, file_target: str
 ) -> int:
+    """Run body under the tree lock, with #1453 calibration preparation.
+
+    A DEMO declaring ``sorry_type: sorry_replacement`` targets scaffolding
+    committed WITH its approved proof — that proof is the ground truth the
+    prover must reproduce, not a state to keep. Without this step the prover's
+    pre-flight counts 0 real sorry, exits ``already_solved`` in 0.1 s and the
+    run reports ``success=True`` with 0 iterations: the whole Conway
+    calibration gradient (DEMOS 39-52) was dead-on-arrival this way (measured
+    firsthand 2026-09-01 on demo 39, #1453).
+
+    The stub is written in place (the tree lock already serialises in-place
+    mutation, #6790) and the original bytes are restored in ``finally`` —
+    bytes I/O, no newline translation.
+    """
+    calibration_target = None
+    if (
+        demo.get("sorry_type") == "sorry_replacement"
+        and demo.get("file")
+        and demo.get("theorem_name")
+        and _peek_sorry_count(demo["file"]) == 0
+    ):
+        target_path = Path(demo["file"])
+        original = target_path.read_bytes()
+        stubbed = stub_theorem_proof(
+            original.decode("utf-8"), demo["theorem_name"]
+        )
+        target_path.write_bytes(stubbed.encode("utf-8"))
+        calibration_target = (target_path, original)
+        _bg(
+            f"CALIBRATION_STUB theorem={demo['theorem_name']} "
+            f"line={demo.get('line')} - approved proof stubbed to sorry, "
+            f"original restored on exit"
+        )
+
+    try:
+        return await _run_calibration_ready(args, demo, file_target)
+    finally:
+        if calibration_target is not None:
+            calibration_target[0].write_bytes(calibration_target[1])
+            _bg("CALIBRATION_RESTORE approved proof restored")
+
+
+async def _run_calibration_ready(
+    args: argparse.Namespace, demo: dict, file_target: str
+) -> int:
     """The original run body, executed while holding the tree lock."""
     pre_sorry = _peek_sorry_count(file_target) if demo.get("file") else None
     if pre_sorry is not None:
@@ -177,6 +232,8 @@ async def _run_locked(
         director_provider=args.director_provider,
         coordinator_provider=getattr(args, "coordinator_provider", None),
         tactic_provider=getattr(args, "tactic_provider", None),
+        search_provider=getattr(args, "search_provider", None),
+        critic_provider=getattr(args, "critic_provider", None),
     )
 
     t0 = time.time()
@@ -202,6 +259,10 @@ async def _run_locked(
 
     _bg(f"RESULT_KEYS {sorted(result.keys())}")
     _bg(f"RESULT_SUCCESS {result.get('success')}")
+    # #1453: success=True with already_solved=True and 0 iterations is a NO-OP
+    # exit, not a proof — make the distinction parseable for harvest scripts
+    # instead of letting every already-solved exit read as a proven target.
+    _bg(f"RESULT_ALREADY_SOLVED {bool(result.get('already_solved'))}")
     _bg(f"RESULT_BEST_SORRY {result.get('best_sorry')}")
     _bg(f"RESULT_ITERATIONS {result.get('iterations')}")
     _bg(f"RESULT_ATTEMPTS {result.get('attempts')}")
@@ -244,6 +305,17 @@ def parse_args() -> argparse.Namespace:
                    help="Provider for TacticAgent (default: openrouter). "
                         "#1289: GLM-5.1 (zai) times out at 1680s on tactic generation; "
                         "GPT-5.5 via openrouter expected ~60-120s.")
+    p.add_argument("--search-provider", default=None,
+                   help="Provider for SearchAgent. #7477 P6 routing sends "
+                        "fast-class agents (Search/Critic) via the p6_routing "
+                        "map, typically to 'local' — --local-provider does not "
+                        "reach them, and on a lane whose local vLLM is "
+                        "unreachable (isolated /24, #9976) every run dies at "
+                        "SearchAgent creation with Missing credentials. This "
+                        "exposes the override the prover class already accepts "
+                        "(measured firsthand on demo 39, #1453).")
+    p.add_argument("--critic-provider", default=None,
+                   help="Provider for CriticAgent (see --search-provider).")
     p.add_argument("--force-lock", action="store_true",
                    help="Break an existing .prover.lock even if its holder "
                         "looks alive or is on a foreign host (WSL<->Windows). "

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_calibration_stub.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_calibration_stub.py
@@ -1,0 +1,114 @@
+"""Tests for the #1453 calibration sorry_replacement semantics.
+
+Forensic (measured firsthand 2026-09-01): a calibration DEMO whose target is
+committed WITH its approved proof exits ``already_solved`` in 0.1 s with
+``success=True`` and 0 iterations — the launcher-level stub
+(``run_prover_bg._run_locked``) plus ``lean_utils.stub_theorem_proof`` fix the
+dead-on-arrival Conway gradient (DEMOS 39-52). These tests lock the pure
+transformation; the launcher pairing (stub -> run -> restore) is exercised
+end-to-end by the [BG] CALIBRATION_STUB/CALIBRATION_RESTORE lines.
+
+The fixture is EMBEDDED, not read from ``conway_lean/Conway/Nim.lean``: a live
+prover run stubs that file in place, and a test reading it races the run
+(measured: full-suite run alongside a live demo-39 attack read the stubbed
+state and failed on a sorry count of 2 vs 1).
+"""
+
+import pytest
+
+from prover.lean_utils import count_real_sorries, stub_theorem_proof
+
+# Shape copied from conway_lean/Conway/Nim.lean (worktree 3e6d8eab578):
+# module docstring, namespace, defs, #evals, anchored rfl theorem, then the
+# calibration decide-level target and its successor with a docstring.
+NIM_FIXTURE = """\
+/-
+  `Conway.Nim` — Jeu de Nim et theoreme de Bouton (1901)
+-/
+import Mathlib.Data.List.Basic
+
+namespace Conway
+/-- Le nim-sum d'une position : XOR-fold des tailles de tas. -/
+def nimSum (heaps : List Nat) : Nat :=
+  heaps.foldl (· ^^^ ·) 0
+
+/-- Une position de Nim est gagnante pour le premier joueur ssi son nim-sum est non nul. -/
+def isWinningNim (heaps : List Nat) : Bool :=
+  nimSum heaps != 0
+
+#eval nimSum [3, 4, 5]      -- 2
+#eval isWinningNim [3, 4, 5] -- true
+
+/-- Ancre prouvee : la position vide a un nim-sum nul. -/
+theorem nimSum_nil : nimSum [] = 0 := rfl
+
+/-- CALIBRATION (decide) : la position [3,4,5] est gagnante pour le premier joueur. -/
+theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by
+  decide
+
+/-- CALIBRATION (unfold + zero_xor) : un tas unique a un nim-sum egal a sa taille. -/
+theorem nimSum_single (n : Nat) : nimSum [n] = n := by
+  simp [nimSum, Nat.xor_zero]
+
+theorem nimSum_357 : ∃ s,
+    nimSum [3, 5, 7] = s ∧
+    s = 1 ∧
+    nimSum [3 ^^^ s, 5, 7] = 0 := by
+  decide
+
+end Conway
+"""
+
+
+def test_stub_adds_exactly_one_real_sorry():
+    stubbed = stub_theorem_proof(NIM_FIXTURE, "isWinningNim_345")
+    assert count_real_sorries(stubbed) == count_real_sorries(NIM_FIXTURE) + 1
+
+
+def test_stub_preserves_statement_and_neighbour_theorems():
+    stubbed = stub_theorem_proof(NIM_FIXTURE, "isWinningNim_345")
+    assert (
+        "theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by sorry"
+        in stubbed
+    )
+    # the approved proof body is gone
+    after = stubbed.split("isWinningNim_345", 1)[1]
+    assert "decide" not in after.split("theorem", 1)[0]
+    # neighbours untouched (ground truth to re-prove later, not collateral)
+    assert "theorem nimSum_nil : nimSum [] = 0 := rfl" in stubbed
+    assert "theorem nimSum_single (n : Nat) : nimSum [n] = n := by" in stubbed
+    assert "theorem nimSum_357" in stubbed
+
+
+def test_stub_does_not_swallow_next_docstring():
+    stubbed = stub_theorem_proof(NIM_FIXTURE, "isWinningNim_345")
+    # the next declaration's docstring must survive verbatim (col-0 /-- ends
+    # the proof region)
+    after = stubbed.split(":= by sorry", 1)[1]
+    assert "/--" in after
+
+
+def test_stub_single_line_rfl_proof():
+    stubbed = stub_theorem_proof(NIM_FIXTURE, "nimSum_nil")
+    assert "theorem nimSum_nil : nimSum [] = 0 := by sorry" in stubbed
+    assert ":= rfl" not in stubbed
+
+
+def test_stub_multiline_statement_keeps_signature():
+    # statement spanning several lines before ':=' must stay byte-intact,
+    # proof body replaced, stub on the ':=' line
+    stubbed = stub_theorem_proof(NIM_FIXTURE, "nimSum_357")
+    assert "theorem nimSum_357 : ∃ s,\n    nimSum [3, 5, 7] = s ∧\n    s = 1 ∧" in stubbed
+    assert "nimSum [3 ^^^ s, 5, 7] = 0 := by sorry" in stubbed
+    assert "end Conway" in stubbed
+
+
+def test_stub_unknown_theorem_raises():
+    with pytest.raises(ValueError, match="not found"):
+        stub_theorem_proof(NIM_FIXTURE, "no_such_theorem_here")
+
+
+def test_stub_statement_without_assign_raises():
+    source = "theorem broken : Nat\n\ntheorem next : True := trivial\n"
+    with pytest.raises(ValueError, match="no ':='"):
+        stub_theorem_proof(source, "broken")


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2027:CoursIA — prev: MED/notebook-dotnet #13895

## Forensic #1453 — le gradient calibration Conway était mort-né, et le harnais le rapportait comme un succès

Deux findings, mesurés firsthand ce cycle (reproductions locales, venv projet) :

1. **Toutes les cibles calibration `sorry_replacement` sortent en 0,1 s `already_solved` avec `success=True` et 0 itération.** Reproduit sur la demo 39 (`CALIBRATION_CONWAY_NIM_WINNING_345`) : le pré-vol du prover compte les sorry réels du fichier cible — 0, car le scaffolding est committé AVEC sa preuve approuvée (c'est le design du sous-track CALIBRATION, validé user 2026-05-23 : la preuve approuvée est le ground truth à reproduire) — et déclare la cible prouvée **sans jamais exécuter l'étape de remplacement que l'entrée DEMOS déclare** (`sorry_type: "sorry_replacement"`, config.py). Le gradient entier (DEMOS 39-52) est mort-né depuis sa création : les 7 traces locales du 2026-08-24 (`multi/autonomous Conway`, provider openrouter) sont des listes VIDES — artefacts de 2 octets, zéro span.
2. **`RESULT_SUCCESS True` sur un run qui n'a rien fait.** Un exit `already_solved` se lit comme un succès dans le protocole [BG] des harvest scripts — indistinguable d'une cible prouvée.

## Fix — au niveau lanceur (le pré-vol `already_solved` vit dans `provers.py`, claim actif po-2026)

- `prover/lean_utils.py` — `stub_theorem_proof(source, theorem_name)` : transformation pure qui remplace le corps de la déclaration, de son `:=` à la prochaine ligne non-blanche en colonne 0, par `:= by sorry`. Signature byte-intacte (le prover attaque exactement la déclaration nommée par la config), docstring du voisin préservée, et échec **loud** (`ValueError`) si déclaration / `:=` / terminator manquant — un run calibration doit échouer bruyamment plutôt que stubber la mauvaise région.
- `run_prover_bg.py` — étape de préparation calibration dans `_run_locked` : si `sorry_type == "sorry_replacement"` et 0 sorry réel sur disque, stub in-place (I/O **bytes**, zéro traduction newline), run, puis **restauration des octets originaux en `finally`** — le tree lock (#6790) sérialise déjà la mutation in-place, le stub étend ce contrat à la préparation de cible. Deux nouvelles lignes [BG] documentées dans le protocole : `CALIBRATION_STUB` / `CALIBRATION_RESTORE`, plus `RESULT_ALREADY_SOLVED` pour qu'un exit no-op ne se lise plus comme une preuve.
- `run_prover_bg.py` — expose `--search-provider` / `--critic-provider` (passthrough vers les overrides que `MultiAgentSorryProver` accepte déjà) : le routage P6 (#7477) envoie les agents fast-class via `p6_routing`, typiquement vers `local` — `--local-provider` ne les atteint pas, et sur une lane au /24 isolé (#9976) chaque run meurt à la création du SearchAgent (`Missing credentials`). Mesuré firsthand sur la demo 39 ce cycle : le run e2e post-fix stub correctement, puis crash `openai.OpenAIError` dans `create_search_agent` — sans ce passthrough, le fix calibration était invérifiable au-delà du stub.

## Validation

- **731/731 tests harnais verts** (venv projet, pytest 9.1.1) — dont 7 nouveaux `tests/test_calibration_stub.py` à fixture **embarquée** : un test lisant `Nim.lean` sur disque race un run vivant qui le stubbe (mesuré firsthand : la suite complète lancée pendant l'attaque demo-39 a lu l'état stubbé).
- **End-to-end demo 39** (providers openrouter y compris search/critic, `--max-iter 2 --workflow-timeout 600`, worktree isolé, venv projet) :
  - avant le fix = exit 0,1 s `already_solved` `success=True` **0 itération** (faux succès) ;
  - après le fix = `CALIBRATION_STUB theorem=isWinningNim_345`, `PRE_FILE_SORRY_COUNT 1`, `RESULT_ALREADY_SOLVED False`, **2 itérations réelles** (Coordinator → set_attack_plan, SearchAgent → lookup_proven_pattern + search_mathlib_lemmas, TacticAgent) en 112,8 s, `FINAL ok=False` — verdict honnête sous le cap de validation volontaire (la config annonce 1-3 itérations attendues) ;
  - `CALIBRATION_RESTORE approved proof restored` et `Nim.lean` **byte-identique** après le run : sha256 `670099baa0fb8536…` identique avant/après, y compris sur le chemin d'exception (le premier run e2e est mort dans `create_search_agent` et le `finally` a déjà restauré — mesuré).
  - Le run a aussi fait remonter deux résiduels hors-scope de cette PR : les probes GoalExtract échouent tous sur `unexpected identifier; expected 'lemma'` (parsing du fichier probe, préexistant) et la ligne config 42 est périmée (AutoFix redirige vers 57, le vrai emplacement). Détail complet du run dans le commentaire #1453.

See #1453 (finding forensic + PR harnais — acceptance du cycle satisfaite sur les deux jambes)
