### PR TITLE
fix(prover,#1453): probes GoalExtract détruisaient la déclaration sur sorry inline

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 
 # Patterns marking an intentionally-honest sorry (theoretical impossibility,
@@ -416,6 +416,44 @@ _PROBE_UNSOLVED_TOL = 25
 # FX-5c: a lake/lean `error:` line with no `NN:NN:` file position anywhere
 # in it is an infrastructure failure, not an elaboration verdict.
 _UNPOSITIONED_ERROR_LINE_RE = re.compile(r"^\s*error:")
+
+
+def _probe_replaced_lines(
+    lines: List[str], sorry_line: int, probe: str
+) -> List[str]:
+    """Copy of ``lines`` with the sorry at ``sorry_line`` replaced by ``probe``.
+
+    Whole-line replacement (the historical form) is only correct when the
+    sorry sits ALONE on its line (``  sorry``). An INLINE sorry — the
+    single-line idiom ``theorem f : P := by sorry`` (also what the #1453
+    calibration stub writes) — carries the whole declaration on that line:
+    replacing it deletes the theorem and leaves a floating tactic, so every
+    probe in the sequence dies with the same parse error
+    (``unexpected identifier; expected 'lemma'``, measured firsthand on
+    conway_lean Nim.lean demo 39: all 5 probes failed identically and goal
+    extraction silently degraded to the heuristic). Token replacement keeps
+    the declaration and re-seats the probe in its tactic position:
+
+    - ``  sorry``            -> ``  <probe>``            (historical form)
+    - ``theorem f : P := by sorry`` -> ``theorem f : P := by <probe>``
+    - ``theorem f : P := sorry``    -> ``theorem f : P := by <probe>``
+      (a bare ``:= <tactic>`` is a parse error; ``by`` is inserted)
+    - ``· sorry``            -> ``· <probe>``            (bullet position)
+    """
+    raw = lines[sorry_line - 1]
+    code = raw.split("--", 1)[0]
+    m = _SORRY_TOKEN_RE.search(code)
+    if m is None:
+        return list(lines)
+    start, end = m.span()
+    prefix = raw[:start]
+    if prefix.strip() == "":
+        repl = " " * (len(raw) - len(raw.lstrip())) + probe
+    elif prefix.rstrip().endswith(":="):
+        repl = f"{prefix}by {probe}{raw[end:]}"
+    else:
+        repl = f"{prefix}{probe}{raw[end:]}"
+    return lines[:sorry_line - 1] + [repl] + lines[sorry_line:]
 _FILE_POSITION_RE = re.compile(r"\d+:\d+:")
 
 
@@ -501,8 +539,7 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
     relative_path = probe_relative_path(filepath, project_dir, "_GoalExtract.lean")
     tmp_path = Path(filepath).parent / "_GoalExtract.lean"
 
-    indent_str = " " * indent
-    new_lines = lines[:sorry_line - 1] + [indent_str + _TRUE_PROBE] + lines[sorry_line:]
+    new_lines = _probe_replaced_lines(lines, sorry_line, _TRUE_PROBE)
     tmp_path.write_text("\n".join(new_lines), encoding="utf-8")
     try:
         probe_result = verifier.verify_project_file(relative_path)
@@ -684,7 +721,6 @@ def get_goal_state(filepath: str, sorry_line: int) -> Optional[str]:
 
     sorry_text = lines[sorry_line - 1]
     indent = len(sorry_text) - len(sorry_text.lstrip())
-    indent_str = " " * indent
 
     # Skip probing for deeply nested sorries — cascade errors make it unreliable
     if indent >= 8:
@@ -712,7 +748,7 @@ def get_goal_state(filepath: str, sorry_line: int) -> Optional[str]:
     ]
 
     for probe in probes:
-        new_lines = lines[:sorry_line - 1] + [indent_str + probe] + lines[sorry_line:]
+        new_lines = _probe_replaced_lines(lines, sorry_line, probe)
         new_content = "\n".join(new_lines)
         tmp_path.write_text(new_content, encoding="utf-8")
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_probe_inline_sorry.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_probe_inline_sorry.py
@@ -1,0 +1,53 @@
+"""Tests for the inline-sorry probe replacement (#1453).
+
+Forensic (measured firsthand on conway_lean Nim.lean, demo 39 e2e
+2026-09-01): ``get_goal_state`` and ``is_true_placeholder_goal`` replaced the
+WHOLE line carrying the sorry with the probe text. For a sorry sitting alone
+on its line that is fine — but the single-line idiom
+``theorem f : P := by sorry`` (standard Lean, and the exact shape the #1453
+calibration stub writes) carries the whole declaration on that line: the
+replacement deleted the theorem, every probe in the sequence died with the
+same parse error (``unexpected identifier; expected 'lemma'`` at the probe
+file), and goal extraction silently degraded to the heuristic.
+"""
+
+from prover.lean_utils import _probe_replaced_lines
+
+
+def test_pure_sorry_line_keeps_historical_form():
+    out = _probe_replaced_lines(["  sorry"], 1, "exact ()")
+    assert out == ["  exact ()"]
+
+
+def test_inline_by_sorry_preserves_declaration():
+    src = "theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by sorry"
+    out = _probe_replaced_lines([src], 1, "exact rfl")
+    assert out == [
+        "theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by exact rfl"
+    ]
+
+
+def test_bare_assign_sorry_gets_by_inserted():
+    # ':= <tactic>' without 'by' is a parse error; the helper re-seats the
+    # probe in a tactic block
+    out = _probe_replaced_lines(["theorem f : P := sorry"], 1, "exact rfl")
+    assert out == ["theorem f : P := by exact rfl"]
+
+
+def test_bullet_sorry_replaced_in_place():
+    out = _probe_replaced_lines(["  · sorry"], 1, "exact ()")
+    assert out == ["  · exact ()"]
+
+
+def test_no_sorry_token_returns_unchanged():
+    src = ["theorem f : P := rfl", "end"]
+    out = _probe_replaced_lines(list(src), 1, "exact ()")
+    assert out == src
+
+
+def test_replacement_not_insertion_keeps_line_count():
+    src = ["/-- doc -/", "theorem f : P := by sorry", "theorem g : Q := rfl"]
+    out = _probe_replaced_lines(src, 2, "exact rfl")
+    assert len(out) == len(src)
+    assert out[0] == "/-- doc -/"
+    assert out[2] == "theorem g : Q := rfl"


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2027:CoursIA — prev: DEEP/research-code #13907

## Forensic — les probes GoalExtract détruisent la déclaration quand le sorry est inline

Mesuré firsthand sur l'e2e demo 39 de #13907 (worktree isolé, conway_lean) : les cinq probes de `get_goal_state` (`exact ()`, `exact rfl`, `exact (0 : Nat)`, `exact True.intro`, `exact 42`) échouaient TOUS avec la même erreur de parse (`Conway/_GoalExtract.lean: unexpected identifier; expected 'lemma'`), et l'extraction de but retombait silencieusement sur l'heuristique — le but réel n'était jamais transmis au workflow.

Cause : les deux sites de probe (`get_goal_state` et `is_true_placeholder_goal` FX-5) remplaçaient la **ligne entière** portant le sorry par `indent + probe`. C'est correct quand le sorry est seul sur sa ligne — mais l'idiome monoligne `theorem f : P := by sorry` (standard Lean ; c'est aussi la forme qu'écrit le stub calibration de #13907) porte **toute la déclaration** sur cette ligne : le remplacement supprime le théorème et laisse une tactique flottante sous la docstring. Défaut préexistant, pas induit par le stub : tout fichier au sorry inline déclenchait la même dégradation.

## Fix

`prover/lean_utils.py` — helper `_probe_replaced_lines` : remplacement du **token** sorry (préfixe préservé), avec ré-ancrage du probe dans sa position tactique :

| Forme source | Probe file |
|---|---|
| `  sorry` (seul sur sa ligne) | `  <probe>` (forme historique inchangée) |
| `theorem f : P := by sorry` | `theorem f : P := by <probe>` |
| `theorem f : P := sorry` | `theorem f : P := by <probe>` (insertion du `by` : un `:= <tactique>` nu est une erreur de parse) |
| `· sorry` | `· <probe>` |

Les deux sites d'appel l'utilisent ; les `indent_str` devenus morts sont retirés.

## Validation

- **730/730 tests harnais** (venv projet, pytest) dont les nouveaux `tests/test_probe_inline_sorry.py` : forme historique inchangée, déclaration préservée sur `:= by sorry`, insertion du `by` sur `:= sorry`, bullet remplacé in place, compte de lignes préservé (remplacement, pas insertion), ligne sans token sorry inchangée.
- **Compilation réelle contre conway_lean** (lake avec cache Mathlib, code de cette branche) : Nim.lean stubbé inline ligne 57 → le PREMIER probe (`exact ()`) rend le type mismatch porteur du but, et `get_goal_state` extrait `isWinningNim [3, 4, 5] = true` — avant : cinq parse errors identiques, zéro but extrait. Nim.lean restauré byte-identique après le test (sha256 vérifié).

See #1453 (jambe forensic harnais — reprend le résiduel « probes GoalExtract » documenté en issuecomment-5485894220)
