### PR TITLE
feat(notebooks,#13410): Lab9-First-ADK-Agent — 7 lectures ancrées outputs (613→1431 c/cell)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
@@ -318,6 +318,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f5299878",
+   "source": "### Lecture du dataset\n\n**Structure.** 100 lignes, une par vente : une date quotidienne (série `date_range` démarrant au 2024-01-01), un produit parmi 4 (`Widget A`, `Widget B`, `Gadget X`, `Gadget Y`), une région parmi 4 (`Nord`, `Sud`, `Est`, `Ouest`), une quantité (1 à 50) et un prix (10 à 100). La colonne `revenue` est **dérivée** : `quantity × price` — vérifiez sur la première ligne du `head` ci-dessus : 32 × 11,49 = 367,68.\n\n**Reproductibilité.** `np.random.seed(42)` en tête de cellule : rejouer la cellule redonne *exactement* le même dataset — et donc les mêmes résultats dans tout le reste du laboratoire. C'est la condition pour que les valeurs citées dans les interprétations qui suivent (revenus par région, podiums mensuels) restent vraies à la ré-exécution.\n\n**Pourquoi `to_csv`.** L'agent ne reçoit pas le DataFrame en mémoire : il le découvre à travers le résumé injecté dans son prompt système (section 3). Sauvegarder `sales_data.csv` matérialise les données sur disque — utile pour recharger ou partager le même jeu de test sans dépendre de l'état du kernel.\n\n**Une limite à garder en tête.** 100 jours à partir du 1er janvier : la couverture temporelle s'arrête début avril. Ce détail deviendra central à la question 2.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-6",
    "metadata": {
     "papermill": {
@@ -573,6 +579,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ef2df85e",
+   "source": "### Lecture de l'implémentation : trois briques, une passe unique\n\nLa classe ci-dessus tient en trois méthodes privées plus une méthode publique, et chacune porte une décision de conception :\n\n- **`_get_system_prompt`** — le contexte passé au LLM n'est pas seulement la question : il embarque les **colonnes**, les **dtypes**, la **shape**, les 3 premières lignes (`head(3).to_string()`) et les **statistiques descriptives complètes** (`describe()`). Le LLM « voit » le dataset sans jamais le manipuler : il sait avant d'écrire une ligne si `revenue` est numérique et dans quelle fourchette se situent les valeurs. Suit un bloc d'instructions (répondre uniquement par du code Python, balises `` ```python ``, `print()` pour afficher) et un **exemple few-shot** qui fixe le format de réponse attendu.\n\n- **`_extract_code`** — la réponse du LLM est du texte mêlé ; le code est récupéré par une expression régulière sur les balises `` ```python ... ``` ``, avec un repli sur n'importe quel bloc `` ``` `` si la balise de langue manque. C'est la version minimale d'un *parser* de sortie.\n\n- **`_execute_code`** — le cœur potentiellement dangereux : `exec` dans un **namespace limité** à `{df, pd, np, print}`, avec `stdout` redirigé vers un `StringIO` pour capturer la sortie, et toute exception attrapée puis rendue comme chaîne `Erreur: ...` (on verra cette chaîne en action à la section 6). La docstring le dit explicitement : ceci est un garde-fou pédagogique, **pas un sandbox** — en production, l'exécution se conteneurise (Docker, gVisor, RestrictedPython ; voir la section 7).\n\n- **`analyze`** — enchaîne le tout : génération (`temperature=0.1`), extraction, exécution, et retour du triplet `{response, code, output}`. Une seule passe, pas de boucle : la révision CodeAct du graphe de la section 3 n'est pas implémentée ici — on le constatera concrètement sur l'échec de la section 6.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-8",
    "metadata": {
     "papermill": {
@@ -704,6 +716,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b323c9d3",
+   "source": "### Lecture du résultat\n\n**Les chiffres.** Les quatre régions totalisent des revenus du même ordre de grandeur : Est 44 451,45 en tête, puis Sud 40 079,60, Nord 33 944,31 et Ouest 32 673,99 — un écart d'environ 1,4× entre la première et la dernière. Avec 100 ventes réparties aléatoirement sur 4 régions (seed 42), on *attend* des totaux proches : c'est exactement ce qu'on observe, aucune région ne se détache du bruit d'échantillonnage.\n\n**Le triplet de sortie.** La cellule affiche trois sections — `CODE GÉNÉRÉ`, `RÉSULTAT`, `RÉPONSE COMPLETE` — qui correspondent aux trois artefacts du paradigme CodeAct : le code que le LLM a écrit, ce que son exécution a produit, et l'explication qui accompagne le tout (exigée par l'instruction 5 du prompt système). Sur une question simple, le code tient en une ligne idiomatique — `df.groupby('region')['revenue'].sum()` — exactement ce qu'un analyste écrirait à la main : le cadrage du prompt système (colonnes, types, exemple few-shot) suffit à obtenir une génération propre.\n\n**Notez la température.** `analyze()` appelle le LLM avec `temperature=0.1` : pour du code, on veut de la reproductibilité, pas de la créativité — une variation de formulation dans le code généré est un bug potentiel, pas une feature.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-12",
    "metadata": {
     "papermill": {
@@ -791,6 +809,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2830a2af",
+   "source": "### Lecture : le piège d'avril\n\nLe code généré est nettement plus élaboré qu'à la question 1 — conversion `datetime`, extraction du mois par `dt.to_period('M')`, agrégation à deux niveaux `['year_month', 'product']`, tri décroissant, puis `groupby('year_month').head(3)` pour ne garder que le podium de chaque mois. C'est l'exemple type d'une question qu'un simple grouper-sommer ne suffit pas à couvrir : la richesse de la requête se retrouve dans la richesse du code.\n\n**Le podium.** Gadget Y domine nettement janvier (236), février (275) et mars (234) ; Widget A et Gadget X se disputent les places suivantes ; en mars, Widget B (212) remonte au deuxième rang.\n\n**Le piège.** Avril affiche des quantités minuscules — Widget B 113, Widget A 36, Gadget Y 19. Lecture naïve : « effondrement des ventes en avril ». Vérification de couverture temporelle : le dataset de la section 2 est `pd.date_range('2024-01-01', periods=100, freq='D')` — 100 jours, soit du 1er janvier au **9 avril 2024**. Avril ne porte que ~9 jours de ventes contre 29 à 31 pour les mois pleins : la chute d'avril est un **artefact de troncature**, pas un signal métier. Avant d'interpréter une saisonnalité, on vérifie que les périodes comparées couvrent des durées comparables — c'est aussi pourquoi la question ambiguë « Compare avec l'année précédente » de l'exercice de robustesse est impossible : le dataset ne contient qu'une seule année.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-14",
    "metadata": {
     "papermill": {
@@ -872,6 +896,12 @@
     "print(\"\\n=== RÉSULTAT ===\")\n",
     "print(result['output'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fe49e29",
+   "source": "### Lecture : la figure est là, mais la sortie capturée est vide\n\nTrois choses à lire dans cette sortie :\n\n1. **Le code généré** fait le travail complet en style pandas idiomatique : agrégation `groupby('product')['revenue'].sum()`, puis rendu via l'API `.plot(kind='bar')` avec les habillages (`title`, `xlabel`, `ylabel`, `rotation=45`, `tight_layout`). La question imposait « Utilise matplotlib » : le LLM a importé `matplotlib.pyplot` lui-même — logique, l'agent simple n'injecte pas encore `plt` dans son namespace (ce sera le rôle de l'agent étendu, section 6).\n\n2. **La section `=== RÉSULTAT ===` est vide**, alors que la figure s'affiche bien dans la cellule. Ce n'est pas un bug : `_execute_code` capture `stdout` via un `StringIO`, mais `plt.show()` ne passe pas par `stdout` — le rendu part vers le backend d'affichage du kernel, qui l'émet comme image. Le mécanisme de capture de l'agent est **aveugle aux figures** : c'est une limite structurelle de ce design, et elle motive la valeur de retour textuelle des tools `plot_*` de la section 6.\n\n3. **Croisez la figure avec la question 2.** Le graphique classe les produits par *revenu* cumulé, la question 2 les classait par *quantité*. Quand le prix unitaire varie de 10 à 100 (bornes posées à la construction du dataset, section 2), vendre beaucoup d'unités et générer beaucoup de revenu sont deux podiums différents — comparez les deux classements avant de conclure « meilleur produit ». C'est exactement l'ambiguïté que l'exercice « Robustesse » de la section 8 vous demandera de documenter.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -1058,6 +1088,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e3ed85be",
+   "source": "### Le pattern « tool » : deux moitiés qui doivent rester synchrones\n\nL'ajout d'un tool à cet agent ne se joue pas à un seul endroit, mais à **deux**, dans deux méthodes différentes :\n\n1. **Déclarer** le tool dans `_get_system_prompt` (bloc `TOOLS DISPONIBLES`, items 1 à 6) : sans cette ligne, le LLM ne sait pas que la fonction existe et ne l'appellera jamais ;\n2. **L'injecter** dans le `namespace` de `_execute_code` : sans cette entrée, le tool est annoncé mais absent, et le premier appel lèvera un `NameError`.\n\nLes deux moitiés se désynchronisent silencieusement : un tool présent dans le namespace mais non annoncé est du code mort ; un tool annoncé mais non injecté est un piège. L'exercice « Tool Personnalisé » de la section 8 vous fera exécuter ce geste en entier pour `detect_outliers` — les deux moitiés, pas une seule.\n\nNotez aussi deux différences vis-à-vis de l'agent simple :\n\n- `plt` (matplotlib) est désormais **injecté** dans le namespace : l'agent simple laissait le LLM importer lui-même `matplotlib.pyplot`, comme il l'a fait à la question 3 ;\n- les fonctions `plot_*` **retournent une chaîne** (`\"Graphique créé: {title}\"`) : une figure rendue par `plt.show()` ne passe pas par `stdout` (constaté à la question 3), donc sans valeur de retour textuelle le LLM n'aurait aucun feedback d'exécution à lire.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "a980e7cf",
    "metadata": {
     "papermill": {
@@ -1127,6 +1163,12 @@
     "print(\"\\n=== RÉSULTAT ===\")\n",
     "print(result['output'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb2f3619",
+   "source": "### Lecture de l'échec : un tool mal documenté est un tool mal appelé\n\nLa sortie ci-dessus porte une **erreur réelle**, committée telle quel — et c'est précisément elle qui fait la valeur pédagogique de cette section. Décortiquons-la.\n\n**Ce que le LLM a généré.** Le code agrège d'abord le revenu par région (une Series de 4 valeurs), puis la passe telle quelle au tool : `plot_pie(values=revenue_by_region, labels=revenue_by_region.index, ...)`. Le LLM a interprété `values` et `labels` comme des **données**.\n\n**Ce que la signature attend.** Relisez `plot_pie` dans la cellule précédente : elle fait `self.df.groupby(labels)[values].sum()` — ses paramètres sont des **noms de colonnes**, pas des données. Avec un `labels` de 4 éléments face à un DataFrame de 100 lignes, le `groupby` échoue : `Grouper and axis must be same length`. La figure `800x800 with 0 Axes` est le sous-produit du `plt.figure(figsize=(8, 8))` exécuté juste avant l'échec.\n\n**Où est le défaut ?** Pas dans le LLM, mais dans la **documentation du tool**. Le prompt système annonce `plot_pie(values, labels, title) - Crée un graphique circulaire` sans dire si les arguments sont des noms de colonnes ou des données : le LLM a dû **deviner** la convention d'appel — et il a deviné faux. Un tool dont la sémantique n'est pas écrite dans le prompt est un tool qui sera appelé au hasard.\n\n**Pourquoi l'agent ne s'est pas corrigé.** Rappelez-vous le graphe CodeAct de la section 3 : l'arête tiretée « révision » suppose que l'erreur est *ré-injectée* au LLM. La méthode `analyze()` ne le fait pas — elle exécute **une fois** et retourne le triplet (code, output, réponse). Cette implémentation pédagogique est un CodeAct *sans boucle* ; la capacité d'auto-correction du paradigme complet est décrite dans la référence 1. C'est aussi le terrain de l'exercice « Robustesse » de la section 8, dont la catégorie `impossible_a_executer` couvre exactement ce type d'échec.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/research-code #13910

## Sujet

Item 5 de la queue #13410 : `Lab9-First-ADK-Agent.ipynb` sortait à **613 c/cell** (seuil 1200). Ajout de **7 cellules markdown d'interprétation**, chacune ancrée aux valeurs portées par les outputs committés de la cellule de code qu'elle suit immédiatement :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après le dataset (§2) | structure 100 lignes, `revenue = quantity × price` vérifiée sur la ligne 0 du `head` (32 × 11,49 = 367,68), rôle du seed 42, rôle du `to_csv` |
| 2 | après `SimpleDataAgent` (§3) | lecture des 3 briques (prompt système embarquant `describe()`, regex d'extraction, `exec` en namespace limité + docstring « pas un sandbox »), passe unique sans boucle de révision |
| 3 | après Question 1 (§4) | les 4 revenus régionaux cités (Est 44 451,45 en tête, écart ~1,4× max/min), le triplet CodeAct de la sortie, `temperature=0.1` |
| 4 | après Question 2 (§4) | podium mensuel cité (Gadget Y 236/275/234) + **le piège d'avril** : `date_range(periods=100)` ⇒ couverture jusqu'au 9 avril ⇒ la chute d'avril est un artefact de troncature, pas un signal métier |
| 5 | après Question 3 (§4) | `=== RÉSULTAT ===` vide car `plt.show()` ne passe pas par stdout — capture StringIO aveugle aux figures (motivation des retours textuels des tools §6) |
| 6 | après `EnhancedDataAgent` (§6) | le pattern tool en deux moitiés (déclarer au prompt + injecter au namespace), `plt` injecté, retours `"Graphique créé: ..."` |
| 7 | après le test étendu (§6) | **lecture de l'erreur committée** `Grouper and axis must be same length` : le LLM a passé des Series là où la signature attend des noms de colonnes — défaut de documentation du tool, pas du LLM ; figure `800x800 with 0 Axes` = sous-produit du `plt.figure()` antérieur |

## Validation

- **Code byte-identique** : 13/13 cellules code inchangées (source + outputs + `execution_count` vérifiés par comparaison JSON contre `origin/main`) — enrichment markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 613 → **1431 c/cell** (seuil 1200 atteint) ; markdown 7 980 → 18 603 chars.
- **Guards verts** : `scan_cell_ordering.py` clean · `detect_consecutive_code_cells.py` 0 run · `detect_markdown_rendering.py` 0 violation (backticks inline des balises de code délimités en double-backticks) · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline.
- **Diff** : 42 insertions, 0 deletions — enrichissement pur.
- Prose conforme C.4 : chaque valeur citée est présente dans l'output adjacent ou dans la source de la cellule explicitement référencée ; pas de valeur machine-dépendante (C.5).

See #13410 (item 5 — les items 6-10 restent ouverts)
