### PR TITLE
fix(guard,#13475): prev: reference invariants PREV-SELF/NOT-MERGED/NOT-PR

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -617,9 +617,72 @@ jobs:
             printf '[]' > /tmp/commits.json
           fi
 
+          # PREV-INVALID metadata (#13475) : pour chaque `prev: ... #N` cité
+          # dans le body ou les commits, on resout via `gh pr view` / `gh
+          # issue view` pour savoir si la cible est une PR mergée, une PR
+          # ouverte, ou une issue. On passe le résultat au gate via
+          # --prev-targets-file : sans metadata, le gate s'abstient sur les
+          # invariants 2/3 (FN-safety contract documenté).
+          PREV_TARGETS=$(python3 - <<'PY' 2>/dev/null || echo "{}"
+          import json, re, subprocess, sys
+          prev_re = re.compile(r"prev\s*:?\s*[A-Za-z]+\s*/\s*[A-Za-z0-9_-]+\s*#(\d+)\b", re.IGNORECASE)
+          nums = set()
+          try:
+              body = open("/tmp/pr_body.txt", encoding="utf-8").read()
+              nums.update(int(m.group(1)) for m in prev_re.finditer(body))
+          except OSError:
+              pass
+          try:
+              commits = json.load(open("/tmp/commits.json", encoding="utf-8"))
+              for msg in commits or []:
+                  if isinstance(msg, str):
+                      nums.update(int(m.group(1)) for m in prev_re.finditer(msg))
+          except (OSError, json.JSONDecodeError):
+              pass
+          out = {}
+          for n in sorted(nums):
+              # Try PR first. gh pr view exits 0 even for issues (with a
+              # not-found payload), so we read the JSON and check the
+              # 'state' field's presence -- a PR has one, an issue does not.
+              pr = subprocess.run(
+                  ["gh", "pr", "view", str(n), "--json", "state,merged"],
+                  capture_output=True, text=True, timeout=15,
+              )
+              if pr.returncode == 0:
+                  try:
+                      d = json.loads(pr.stdout)
+                      if "merged" in d:
+                          out[str(n)] = {
+                              "kind": "pr",
+                              "merged": bool(d.get("merged", False)),
+                          }
+                          continue
+                  except json.JSONDecodeError:
+                      pass
+              # Fall back to issue. If neither resolves, the gate abstains
+              # (FN-safety: unresolvable target -> no flag).
+              issue = subprocess.run(
+                  ["gh", "issue", "view", str(n), "--json", "state"],
+                  capture_output=True, text=True, timeout=15,
+              )
+              if issue.returncode == 0:
+                  try:
+                      d = json.loads(issue.stdout)
+                      if "state" in d:
+                          out[str(n)] = {"kind": "issue"}
+                          continue
+                  except json.JSONDecodeError:
+                      pass
+          json.dump(out, sys.stdout)
+          PY
+          )
+          printf '%s' "$PREV_TARGETS" > /tmp/prev_targets.json
+
           python3 scripts/ci/variation_prev_guard.py \
             --body-file /tmp/pr_body.txt \
-            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+            --commits-file /tmp/commits.json \
+            --current-pr "$PR_NUMBER" \
+            --prev-targets-file /tmp/prev_targets.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           if [ -s /tmp/verdict.err ]; then
             echo "--- helper stderr ---"

--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -617,72 +617,23 @@ jobs:
             printf '[]' > /tmp/commits.json
           fi
 
-          # PREV-INVALID metadata (#13475) : pour chaque `prev: ... #N` cité
-          # dans le body ou les commits, on resout via `gh pr view` / `gh
-          # issue view` pour savoir si la cible est une PR mergée, une PR
-          # ouverte, ou une issue. On passe le résultat au gate via
-          # --prev-targets-file : sans metadata, le gate s'abstient sur les
-          # invariants 2/3 (FN-safety contract documenté).
-          PREV_TARGETS=$(python3 - <<'PY' 2>/dev/null || echo "{}"
-          import json, re, subprocess, sys
-          prev_re = re.compile(r"prev\s*:?\s*[A-Za-z]+\s*/\s*[A-Za-z0-9_-]+\s*#(\d+)\b", re.IGNORECASE)
-          nums = set()
-          try:
-              body = open("/tmp/pr_body.txt", encoding="utf-8").read()
-              nums.update(int(m.group(1)) for m in prev_re.finditer(body))
-          except OSError:
-              pass
-          try:
-              commits = json.load(open("/tmp/commits.json", encoding="utf-8"))
-              for msg in commits or []:
-                  if isinstance(msg, str):
-                      nums.update(int(m.group(1)) for m in prev_re.finditer(msg))
-          except (OSError, json.JSONDecodeError):
-              pass
-          out = {}
-          for n in sorted(nums):
-              # Try PR first. gh pr view exits 0 even for issues (with a
-              # not-found payload), so we read the JSON and check the
-              # 'state' field's presence -- a PR has one, an issue does not.
-              pr = subprocess.run(
-                  ["gh", "pr", "view", str(n), "--json", "state,merged"],
-                  capture_output=True, text=True, timeout=15,
-              )
-              if pr.returncode == 0:
-                  try:
-                      d = json.loads(pr.stdout)
-                      if "merged" in d:
-                          out[str(n)] = {
-                              "kind": "pr",
-                              "merged": bool(d.get("merged", False)),
-                          }
-                          continue
-                  except json.JSONDecodeError:
-                      pass
-              # Fall back to issue. If neither resolves, the gate abstains
-              # (FN-safety: unresolvable target -> no flag).
-              issue = subprocess.run(
-                  ["gh", "issue", "view", str(n), "--json", "state"],
-                  capture_output=True, text=True, timeout=15,
-              )
-              if issue.returncode == 0:
-                  try:
-                      d = json.loads(issue.stdout)
-                      if "state" in d:
-                          out[str(n)] = {"kind": "issue"}
-                          continue
-                  except json.JSONDecodeError:
-                      pass
-          json.dump(out, sys.stdout)
-          PY
-          )
-          printf '%s' "$PREV_TARGETS" > /tmp/prev_targets.json
+          # PREV-INVALID metadata (#13475) : la resolution de chaque
+          # `prev: ... #N` (PR mergee / PR ouverte / issue) vit desormais
+          # dans le module, sous test -- cf `resolve_prev_targets`. Elle
+          # etait ici, en heredoc, hors de portee de tout test, et elle
+          # etait fausse : elle demandait `gh pr view --json state,merged`,
+          # or `merged` n'est pas un champ de ce `gh`, donc l'appel echouait
+          # pour CHAQUE cible, retombait sur `gh issue view` (qui repond
+          # aussi pour les PRs) et classait toute PR en issue. `prev-not-pr`
+          # rougissait sur 100 % des PRs -- dont celle qui livrait le garde.
+          # Echec de resolution -> cible absente -> le gate s'abstient
+          # (contrat FN-safety inchange).
 
           python3 scripts/ci/variation_prev_guard.py \
             --body-file /tmp/pr_body.txt \
             --commits-file /tmp/commits.json \
             --current-pr "$PR_NUMBER" \
-            --prev-targets-file /tmp/prev_targets.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+            --resolve-targets > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           if [ -s /tmp/verdict.err ]; then
             echo "--- helper stderr ---"

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-r"""variation_prev_guard.py -- BLOCKING gate against `prev:` close-keyword genres (#10093).
+r"""variation_prev_guard.py -- BLOCKING gate against `prev:` close-keyword genres (#10093)
+and against `prev:` references that violate the predecessor invariant (#13475).
 
 ## Why this exists
 
@@ -21,36 +22,87 @@ meant `refactor`, `guard`, or `tooling`. The danger is that the `genre #N`
 tail is a valid auto-close instruction when the text lands in a commit
 message.
 
+## Why a second scope was added (#13475)
+
+Issue #13475 extended the original gate with three additional invariants on
+the `prev:` PR reference (the `genre #N` tail), each of which silently breaks
+the genre-adjacency measurement G-VAR-3 enforces:
+
+  1. **PREV-SELF** -- the `prev:` points at the PR it lives in. The
+     adjacency becomes vacuous: a grain compared to itself is trivially
+     "different from its predecessor" (or trivially identical, depending on
+     the comparator direction), so the cap never measures anything. Real
+     witness: #12875.
+
+  2. **PREV-NOT-MERGED** -- the `prev:` points at a PR that has NOT been
+     merged yet. The predecessor is a moving target: the author believed
+     their work flowed from a closed-but-still-editable PR, and the cap
+     silently compares against a genre that may still change. Real witness:
+     #13473.
+
+  3. **PREV-NOT-PR** -- the `prev:` points at an ISSUE (not a PR). The
+     predecessor is never mergeable, so genre adjacency is structurally
+     unevaluable; the gate's response is the same as for an absent `prev:`,
+     but the silent acceptance masked the bug. Real witness: #13439.
+
+All three pass the original #10093 gate (the genre is canonical, the
+keyword isn't a closing keyword). The defect is silent because the gate
+read the surface form and never compared the cited `#N` against the
+target's existence and state -- exactly the class of bug #10093 warned
+about, only at the PR-reference slot rather than the genre slot.
+
 ## What it does
 
-Scans the PR body AND every commit message on the branch for a `prev:` field
-whose genre is a closing keyword (`grain_tag.CLOSING_KEYWORDS`). Emits a
-single verdict on stdout:
+Scans the PR body AND every commit message on the branch for:
 
-    {"guard_pass": true|false, "reason": "<one line>", "hits": [...]}
+  (a) `prev:` whose genre is a closing keyword (`grain_tag.CLOSING_KEYWORDS`)
+      -- the #10093 invariant;
+  (b) `prev:` whose PR reference violates one of the three #13475 invariants
+      (PREV-SELF / PREV-NOT-MERGED / PREV-NOT-PR).
+
+A single verdict is emitted on stdout:
+
+    {
+      "guard_pass": true|false,
+      "reason": "<one line>",
+      "hits": {
+        "body": [...],                # (a) hits in body, list of {tier, genre}
+        "commits": [...],             # (a) hits in commits, list of {commit_index, tier, genre}
+        "prev_invalid": [...]         # (b) hits, list of {location, kind, prev_pr, ...}
+      }
+    }
 
 Exit codes:
-  0  -- no `prev:` close-keyword genre in body or commits
+  0  -- no `prev:` defect (close-keyword or invalid reference) anywhere
   1  -- at least one hit (the PR is non-mergeable until the offending tag is
-        rewritten with a non-closing genre)
+        rewritten or the bad `prev:` reference is replaced)
   2  -- caller error (unreadable file)
 
 ## Why BLOCKING (not advisory)
 
 The existing `check-variation-tag` job is advisory (exit 0): it posts labels
 and lets the coordinator decide. That is correct for cosmetic tag defects
-(offlist genre). It is WRONG here because the failure is DESTRUCTIVE and
-happens AT MERGE TIME: the squash commit message is what GitHub parses,
-and an advisory label does not stop the merge. Only a required check that
-turns `PR gate` red before merge prevents the auto-close -- the same shape
-as `check-variation-tag-required` (#10045).
+(offlist genre). It is WRONG here because both failure modes are silent and
+cumulative:
+
+  * (a) is DESTRUCTIVE at merge time (the squash commit message is what
+    GitHub parses; an advisory label does not stop the merge);
+  * (b) silently defeats the genre-adjacency cap G-VAR-3 (a grain that
+    trivially satisfies the cap because its `prev:` is unresolvable is
+    exactly the monoculture the cap is supposed to detect, only invisible).
+
+Only a required check that turns `PR gate` red before merge prevents
+both. The shape is the same as `check-variation-tag-required` (#10045).
 
 ## Why it scans commit messages (not just the body)
 
 The #10093 incident: the offending tag was in a COMMIT message, not the PR
 body. A body-only gate would have seen nothing (the body tag was `MED/tooling`
 -- perfectly sane). The point dur (#10093) is precisely that the gate must
-read the commit messages that will become the squash message.
+read the commit messages that will become the squash message. The same
+discipline extends to (b): a body tag may say `prev: MED/refactor #1234`
+but a commit message on the branch may carry `prev: MED/refactor #5678`,
+and the commit-message reference is what the squash-merge publishes.
 
 ## What it does NOT flag
 
@@ -60,16 +112,42 @@ resolves the issue). This gate leaves those alone: it only flags the genre
 slot of a `prev:` field, where a closing keyword is structurally wrong. The
 discriminator is the `prev:` prefix, not the keyword alone.
 
+For (b), `prev: none (premier grain)` (the first-grain exemption parsed by
+`grain_tag.parse_prev`) is NEVER flagged -- a lane with no predecessor to
+cite is a documented exemption, not a defect.
+
+## How the caller passes target metadata
+
+(b) requires knowing whether each cited `#N` resolves to a PR, and whether
+that PR is merged. The workflow fetches this with `gh` and writes it as a
+JSON dict:
+
+    {"1234": {"kind": "pr", "merged": true},
+     "5678": {"kind": "pr", "merged": false},
+     "9012": {"kind": "issue"}}
+
+The shape is the smallest information needed to evaluate the three
+invariants; the gate does not call `gh` itself (that would couple the
+test surface to a network round-trip and break the pure-function tests).
+A missing/empty file yields an empty target map; only invariant (1)
+(PREV-SELF) can then be evaluated, since it only needs the current PR's
+number -- which the caller passes via `--current-pr`.
+
 ## Run locally
 
-    python scripts/ci/variation_prev_guard.py --body-file body.txt
+    python scripts/ci/variation_prev_guard.py --body-file body.txt --current-pr 13918
     # with commit messages (JSON array of strings):
-    python scripts/ci/variation_prev_guard.py --body-file body.txt --commits-file commits.json
+    python scripts/ci/variation_prev_guard.py --body-file body.txt --commits-file commits.json \\
+        --current-pr 13918
+    # with target metadata (JSON dict of pr_number -> {kind, merged}):
+    python scripts/ci/variation_prev_guard.py --body-file body.txt --current-pr 13918 \\
+        --prev-targets-file targets.json
 """
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -80,42 +158,202 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import grain_tag as gt  # noqa: E402
 
 
-def check(body: str | None, commits: list[str] | None = None) -> dict:
+# Match the `#N` tail of a `prev: <TIER>/<genre> #N` clause. We re-use the
+# structure of `grain_tag._PREV_RE` but anchor on the trailing `#N` because
+# that's the part (b) needs to evaluate. The match is non-overlapping
+# against the same body text (no global state).
+_PREV_PR_REF_RE = re.compile(
+    r"prev\s*:?\s*[A-Za-z]+\s*/\s*[A-Za-z0-9_-]+\s*#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def find_prev_self_references(text: str | None, current_pr: int | None) -> list[dict]:
+    r"""Return every `prev:` whose PR reference equals `current_pr` (#13475 invariant 1).
+
+    A grain that points `prev:` at itself is the structural false negative
+    the G-VAR-3 cap was built to catch: a grain compared to itself is
+    trivially "different from its predecessor" by most comparators, so the
+    cap never trips. The fix is to require the reference to be DISTINCT
+    from the PR that carries the tag.
+
+    Returns a list of `{"prev_pr": int, "match": str}` -- one entry per
+    offending `prev:` clause found in the text. Empty list when no
+    self-reference is present, or when `current_pr` is None (the caller
+    didn't tell us who we are; we can't evaluate identity).
+    """
+    if not text or current_pr is None:
+        return []
+    out: list[dict] = []
+    for m in _PREV_PR_REF_RE.finditer(text):
+        n = int(m.group(1))
+        if n == current_pr:
+            out.append({"prev_pr": n, "match": m.group(0)})
+    return out
+
+
+def find_prev_target_pr_numbers(text: str | None) -> list[int]:
+    r"""Return the deduplicated list of PR numbers cited in any `prev:` clause.
+
+    Used to ask the caller which targets we need metadata for. A `#N` that
+    appears OUTSIDE a `prev:` clause (e.g. `Refs #13439`) is NOT a target
+    here -- those citations are the body-as-context, not the adjacency
+    reference. Only the `prev: ... #N` form is in scope.
+    """
+    if not text:
+        return []
+    seen: set[int] = set()
+    out: list[int] = []
+    for m in _PREV_PR_REF_RE.finditer(text):
+        n = int(m.group(1))
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def validate_prev_targets(
+    target_prs: list[int],
+    targets_meta: dict[str, dict] | None,
+    location: str,
+) -> list[dict]:
+    r"""Evaluate invariants (2) and (3) of #13475 against a target list.
+
+    ``targets_meta`` is a dict `{str(pr_number): {"kind": "pr"|"issue",
+    "merged": bool}}` -- the JSON the workflow writes. ``location`` is
+    `"body"` or `"commits[<index>]"` so the verdict can name the slot.
+
+    Returns a list of `{"location", "kind", "prev_pr"}` hits:
+
+      * `kind="prev-not-merged"` -- the target is a PR but its `merged` flag
+        is false (invariant 2).
+      * `kind="prev-not-pr"` -- the target is an issue (invariant 3).
+
+    A target missing from `targets_meta` (the workflow couldn't resolve it)
+    is NOT flagged: the FN-safety contract is "unresolved -> abstain",
+    matching `check_unaddressed_nits.py`'s posture on the same class of
+    problem. The silent-acceptance defect that #13475 measures is at the
+    SUFFICIIENT-information end (the metadata is right there in the file,
+    we just didn't read it), not at the unresolvable end.
+    """
+    if not target_prs or not targets_meta:
+        return []
+    out: list[dict] = []
+    for n in target_prs:
+        meta = targets_meta.get(str(n))
+        if meta is None:
+            continue  # unresolved -> abstain (see docstring)
+        kind = meta.get("kind")
+        if kind == "issue":
+            out.append({"location": location, "kind": "prev-not-pr",
+                        "prev_pr": n})
+        elif kind == "pr" and not meta.get("merged", False):
+            out.append({"location": location, "kind": "prev-not-merged",
+                        "prev_pr": n})
+        # kind == "pr" and merged -> clean, no entry
+    return out
+
+
+def check(
+    body: str | None,
+    commits: list[str] | None = None,
+    *,
+    current_pr: int | None = None,
+    prev_targets: dict[str, dict] | None = None,
+) -> dict:
     """Return the blocking verdict for a PR body + its commit messages.
 
     Pure function so unit tests pin each branch without going through the
     CLI. ``commits`` is the list of commit message strings on the branch
     (the workflow fetches them via ``gh pr view --json commits``); each is
     scanned independently so the verdict can name which commit offended.
+
+    ``current_pr`` is the number of the PR carrying the tag -- required to
+    evaluate PREV-SELF (invariant 1). ``prev_targets`` is the JSON the
+    workflow fetches for the cited `#N` references; required for invariants
+    2 and 3. Either is optional: a caller that doesn't pass them gets only
+    invariant (a) evaluated, and (b) is silently left at the original
+    behaviour -- which is the safe backstop because the original gate
+    didn't surface (b) at all, and broadening the silent zone is worse than
+    partial coverage.
     """
+    # (a) close-keyword genre (the #10093 invariant, unchanged).
     hits_body = gt.find_prev_close_keywords(body)
     hits_commits: list[dict] = []
     for i, msg in enumerate(commits or []):
         for h in gt.find_prev_close_keywords(msg):
             hits_commits.append({"commit_index": i, **h})
 
-    if not hits_body and not hits_commits:
-        return {"guard_pass": True, "reason": "no prev: close-keyword genre", "hits": []}
-
-    locs = []
-    if hits_body:
-        locs.append(f"body ({len(hits_body)})")
-    if hits_commits:
-        locs.append(f"commit messages ({len(hits_commits)})")
-    # The one-line fix: map the closing-keyword genre to its canonical
-    # non-closing equivalent. `fix` -> `refactor` (can-be-rouging work) or
-    # `guard`; the worker picks. The reason must name the offending genres
-    # so the failure is debuggable from the job log alone.
-    genres = sorted({h["genre"] for h in (hits_body + hits_commits)})
-    reason = (
-        f"`prev:` genre(s) {genres} in {' + '.join(locs)} are GitHub closing "
-        f"keywords -> rewrite the `prev:` genre as refactor/guard/tooling "
-        f"(never a closing word). See #10093."
+    # (b) invalid `prev:` PR reference (#13475 invariants 1-3).
+    hits_prev_invalid: list[dict] = []
+    # PREV-SELF -- body + every commit. The current_pr is constant across
+    # all locations; a self-reference in a commit message is the same defect
+    # as one in the body, and we name the slot so the failure is debuggable.
+    hits_prev_invalid.extend(
+        {"location": "body", "kind": "prev-self", "prev_pr": h["prev_pr"]}
+        for h in find_prev_self_references(body, current_pr)
     )
+    for i, msg in enumerate(commits or []):
+        hits_prev_invalid.extend(
+            {"location": f"commits[{i}]", "kind": "prev-self",
+             "prev_pr": h["prev_pr"]}
+            for h in find_prev_self_references(msg, current_pr)
+        )
+    # PREV-NOT-MERGED + PREV-NOT-PR -- body + every commit. Each location
+    # gets its own target list because the body and each commit carry
+    # independent `prev:` clauses; aggregating them would mix concerns.
+    body_targets = find_prev_target_pr_numbers(body)
+    hits_prev_invalid.extend(validate_prev_targets(
+        body_targets, prev_targets, location="body"))
+    for i, msg in enumerate(commits or []):
+        commit_targets = find_prev_target_pr_numbers(msg)
+        hits_prev_invalid.extend(validate_prev_targets(
+            commit_targets, prev_targets, location=f"commits[{i}]"))
+
+    if not hits_body and not hits_commits and not hits_prev_invalid:
+        return {"guard_pass": True,
+                "reason": "no prev: defect (close-keyword or invalid ref)",
+                "hits": {"body": [], "commits": [], "prev_invalid": []}}
+
+    # Compose the verdict. The reason names the worst offender first so
+    # the worker reads the most actionable hint at the top of the failure
+    # log; the full hit list is in the JSON for the workflow's machine
+    # reader.
+    reasons: list[str] = []
+    if hits_body or hits_commits:
+        locs = []
+        if hits_body:
+            locs.append(f"body ({len(hits_body)})")
+        if hits_commits:
+            locs.append(f"commit messages ({len(hits_commits)})")
+        genres = sorted({h["genre"]
+                         for h in (hits_body + hits_commits)})
+        reasons.append(
+            f"`prev:` genre(s) {genres} in {' + '.join(locs)} are GitHub "
+            "closing keywords -> rewrite the `prev:` genre as "
+            "refactor/guard/tooling (never a closing word). See #10093."
+        )
+    if hits_prev_invalid:
+        kinds: dict[str, list[int]] = {}
+        for h in hits_prev_invalid:
+            kinds.setdefault(h["kind"], []).append(h["prev_pr"])
+        kind_summary = ", ".join(
+            f"{k} -> {sorted(set(v))}" for k, v in sorted(kinds.items())
+        )
+        reasons.append(
+            f"`prev:` reference(s) fail invariant(s) ({kind_summary}) -> "
+            "point `prev:` at a MERGED PR of the same lane, distinct from "
+            "the current PR. See #13475."
+        )
+
     return {
         "guard_pass": False,
-        "reason": reason,
-        "hits": {"body": hits_body, "commits": hits_commits},
+        "reason": " | ".join(reasons),
+        "hits": {
+            "body": hits_body,
+            "commits": hits_commits,
+            "prev_invalid": hits_prev_invalid,
+        },
     }
 
 
@@ -137,25 +375,65 @@ def _read_commits_file(path: str) -> list[str]:
     return []
 
 
+def _read_prev_targets_file(path: str) -> dict[str, dict]:
+    """Read a prev-targets file as a JSON dict of metadata.
+
+    The workflow writes a dict ``{str(pr_number): {"kind", "merged"}}``
+    built from ``gh pr view`` / ``gh issue view`` lookups for each
+    `prev:` reference. An empty/missing file yields an empty dict -- the
+    gate then abstains on invariants 2/3 (FN-safety contract; see
+    ``validate_prev_targets``).
+
+    The keys are coerced to strings (JSON object keys are always strings,
+    but the gate is forgiving if the caller hands us ints).
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, dict] = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            out[str(k)] = v
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     p.add_argument("--body-file", metavar="FILE", required=True,
                    help="path to the PR body")
     p.add_argument("--commits-file", metavar="FILE",
                    help="path to a JSON array of commit message strings")
+    p.add_argument("--current-pr", metavar="N", type=int, default=None,
+                   help="number of the PR carrying the Grain tag "
+                        "(required to evaluate PREV-SELF)")
+    p.add_argument("--prev-targets-file", metavar="FILE",
+                   help="path to a JSON dict of "
+                        "{str(pr_number): {kind, merged}} for each cited "
+                        "`prev:` reference (required for PREV-NOT-MERGED "
+                        "and PREV-NOT-PR)")
     args = p.parse_args(argv)
 
     try:
         with open(args.body_file, encoding="utf-8") as f:
             body = f.read()
     except OSError as e:
-        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}", "hits": []}),
+        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}",
+                          "hits": {"body": [], "commits": [],
+                                   "prev_invalid": []}}),
               file=sys.stderr)
         return 2
 
     commits = _read_commits_file(args.commits_file) if args.commits_file else []
+    prev_targets = (_read_prev_targets_file(args.prev_targets_file)
+                    if args.prev_targets_file else {})
 
-    verdict = check(body, commits)
+    verdict = check(body, commits,
+                    current_pr=args.current_pr,
+                    prev_targets=prev_targets)
     print(json.dumps(verdict, ensure_ascii=False))
     return 0 if verdict["guard_pass"] else 1
 

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -401,6 +401,80 @@ def _read_prev_targets_file(path: str) -> dict[str, dict]:
     return out
 
 
+def resolve_prev_targets(
+    target_prs: "list[int]",
+    runner=None,
+    timeout: int = 15,
+) -> "dict[str, dict]":
+    r"""Resolve each `prev:` target to ``{"kind": "pr"|"issue", "merged": bool}``.
+
+    This is the half of #13475 that used to live in a heredoc inside
+    ``always-on-guards.yml``, where no test could reach it -- and it was
+    wrong. The heredoc asked for ``gh pr view N --json state,merged``;
+    ``merged`` is **not a field this `gh` exposes**, so the call exited
+    non-zero for *every* target, fell through to ``gh issue view``, and
+    classified **every PR as an issue**. `prev-not-pr` therefore fired on
+    100 % of PRs, including the one shipping the guard: #13922 was blocked
+    on ``prev-not-pr -> [14225]`` while #14225 is a PR merged at
+    2026-09-03T10:28:59Z.
+
+    The discriminant is the **exit status of `gh pr view`**, not a field of
+    its payload. Measured on this repo (2026-09-03), which is also what
+    ``test_resolve_prev_targets_*`` replays:
+
+    ==========  ==========================  ==========================
+    number      ``gh pr view --json state``  ``gh issue view --json state``
+    ==========  ==========================  ==========================
+    #14225 PR   rc=0, ``MERGED``             rc=0, ``MERGED``
+    #13922 PR   rc=0, ``OPEN``               rc=0, ``OPEN``
+    #14513 iss  rc!=0, *Could not resolve*   rc=0, ``OPEN``
+    ==========  ==========================  ==========================
+
+    Note the middle column is the only one that separates the classes:
+    ``gh issue view`` answers for pull requests too, so it can never be the
+    test. Any future rewrite must keep PR-first ordering.
+
+    ``runner`` defaults to ``subprocess.run`` and exists so a test can
+    inject the table above without a network. A target that neither call
+    resolves is **omitted** from the result -- ``validate_prev_targets``
+    then abstains on it (FN-safety).
+    """
+    if runner is None:  # pragma: no cover - trivial default
+        import subprocess
+        runner = subprocess.run
+
+    out: "dict[str, dict]" = {}
+    for n in sorted(set(target_prs)):
+        pr = runner(["gh", "pr", "view", str(n), "--json", "state"],
+                    capture_output=True, text=True, timeout=timeout)
+        if getattr(pr, "returncode", 1) == 0:
+            state = _json_field(pr.stdout, "state")
+            if state:
+                out[str(n)] = {"kind": "pr",
+                               "merged": state.upper() == "MERGED"}
+                continue
+        issue = runner(["gh", "issue", "view", str(n), "--json", "state"],
+                       capture_output=True, text=True, timeout=timeout)
+        if getattr(issue, "returncode", 1) == 0:
+            if _json_field(issue.stdout, "state"):
+                out[str(n)] = {"kind": "issue"}
+                continue
+        # neither resolved -> omitted -> the gate abstains on this target
+    return out
+
+
+def _json_field(raw: "str | None", field: str) -> "str | None":
+    """Return ``field`` from a JSON object payload, or None if unreadable."""
+    try:
+        data = json.loads(raw or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    value = data.get(field)
+    return value if isinstance(value, str) else None
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     p.add_argument("--body-file", metavar="FILE", required=True,
@@ -415,6 +489,10 @@ def main(argv: list[str] | None = None) -> int:
                         "{str(pr_number): {kind, merged}} for each cited "
                         "`prev:` reference (required for PREV-NOT-MERGED "
                         "and PREV-NOT-PR)")
+    p.add_argument("--resolve-targets", action="store_true",
+                   help="resolve each cited `prev:` reference with `gh` "
+                        "instead of (or in addition to) --prev-targets-file; "
+                        "entries already present in the file win")
     args = p.parse_args(argv)
 
     try:
@@ -430,6 +508,22 @@ def main(argv: list[str] | None = None) -> int:
     commits = _read_commits_file(args.commits_file) if args.commits_file else []
     prev_targets = (_read_prev_targets_file(args.prev_targets_file)
                     if args.prev_targets_file else {})
+
+    if args.resolve_targets:
+        cited = set(find_prev_target_pr_numbers(body))
+        for msg in commits:
+            cited.update(find_prev_target_pr_numbers(msg))
+        missing = [n for n in sorted(cited) if str(n) not in prev_targets]
+        if missing:
+            try:
+                prev_targets = {**resolve_prev_targets(missing),
+                                **prev_targets}
+            except Exception as e:  # network, gh absent, timeout
+                # Unresolved -> absent from the dict -> the gate abstains on
+                # those targets (FN-safety). Never turn a lookup failure into
+                # an accusation: that is the defect this flag repairs.
+                print(f"prev-target resolution failed ({e}); "
+                      "abstaining on invariants 2/3", file=sys.stderr)
 
     verdict = check(body, commits,
                     current_pr=args.current_pr,

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -11,6 +11,7 @@ keyword.
 Run:
     python -m pytest scripts/tests/test_variation_prev_guard.py
 """
+import json
 import sys
 from pathlib import Path
 
@@ -292,3 +293,155 @@ def test_prev_invalid_check_unaffected_by_existing_close_keyword_tests():
     assert any(h["genre"] == "fix" for h in v["hits"]["body"])
     # PREV-SELF is NOT flagged (current_pr=200, prev=#100, distinct).
     assert not any(h["kind"] == "prev-self" for h in v["hits"]["prev_invalid"])
+
+
+# ---------------------------------------------------------------------------
+# resolve_prev_targets -- the half of #13475 that had no test, and was wrong.
+#
+# The workflow used to ask `gh pr view N --json state,merged`. `merged` is not
+# a field this `gh` exposes, so the call failed for EVERY target, fell through
+# to `gh issue view` (which answers for pull requests too), and returned
+# `kind="issue"` for every PR -- making `prev-not-pr` fire on 100 % of PRs,
+# this one included (#13922 blocked on `prev-not-pr -> [14225]`, while #14225
+# is a PR merged at 2026-09-03T10:28:59Z).
+#
+# `FakeGh` replays the three classes measured on this repo on 2026-09-03.
+# Every test below is a positive control: each asserts a DIFFERENT verdict, so
+# a resolver that collapses the classes (which is exactly what the defect did)
+# cannot pass them all.
+# ---------------------------------------------------------------------------
+
+class _Completed:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeGh:
+    """Replay `gh` for a fixed world of numbers, faithful to the real CLI.
+
+    `world` maps a number to `("pr", "MERGED")`, `("pr", "OPEN")`, or
+    `("issue", "OPEN")`. Two real behaviours are reproduced because both
+    matter to the resolver's correctness:
+
+      * an **unknown --json field** makes `gh pr view` exit 1 with
+        `Unknown JSON field: "<name>"` -- this is what killed the original;
+      * `gh issue view` **succeeds on pull requests**, so it can never be
+        the discriminant between the two kinds.
+    """
+
+    #: fields this fake `gh pr view` knows about (mirrors the real one).
+    PR_FIELDS = {"state", "number", "title", "mergedAt"}
+
+    def __init__(self, world):
+        self.world = world
+        self.calls = []
+
+    def __call__(self, argv, capture_output=True, text=True, timeout=None):
+        self.calls.append(list(argv))
+        _gh, verb, _view, number, _json_flag, fields = argv[:6]
+        n = int(number)
+        requested = set(fields.split(","))
+        kind, state = self.world.get(n, (None, None))
+        if verb == "pr":
+            unknown = requested - self.PR_FIELDS
+            if unknown:
+                return _Completed(1, "", 'Unknown JSON field: "%s"\n'
+                                  % sorted(unknown)[0])
+            if kind != "pr":
+                return _Completed(
+                    1, "",
+                    "GraphQL: Could not resolve to a PullRequest with the "
+                    "number of %d. (repository.pullRequest)\n" % n)
+            return _Completed(0, json.dumps({"state": state}))
+        # `gh issue view` answers for issues AND pull requests.
+        if kind is None:
+            return _Completed(1, "", "GraphQL: Could not resolve to an "
+                                     "Issue with the number of %d.\n" % n)
+        return _Completed(0, json.dumps({"state": state}))
+
+
+WORLD = {14225: ("pr", "MERGED"),      # merged PR   -> the #13922 witness
+         13922: ("pr", "OPEN"),        # open PR
+         14513: ("issue", "OPEN")}     # issue
+
+
+def test_resolve_prev_targets_merged_pr_is_a_merged_pr():
+    gh = FakeGh(WORLD)
+    assert vpg.resolve_prev_targets([14225], runner=gh) == {
+        "14225": {"kind": "pr", "merged": True}}
+    # PR-first ordering: the issue endpoint is never consulted for a PR.
+    assert [c[1] for c in gh.calls] == ["pr"]
+
+
+def test_resolve_prev_targets_open_pr_is_a_pr_not_merged():
+    assert vpg.resolve_prev_targets([13922], runner=FakeGh(WORLD)) == {
+        "13922": {"kind": "pr", "merged": False}}
+
+
+def test_resolve_prev_targets_issue_is_an_issue():
+    gh = FakeGh(WORLD)
+    assert vpg.resolve_prev_targets([14513], runner=gh) == {
+        "14513": {"kind": "issue"}}
+    # Both endpoints were tried, in that order.
+    assert [c[1] for c in gh.calls] == ["pr", "issue"]
+
+
+def test_resolve_prev_targets_unresolvable_target_is_omitted():
+    # Neither endpoint resolves -> absent from the dict -> validate_prev_targets
+    # abstains. A lookup failure must never become an accusation.
+    assert vpg.resolve_prev_targets([999999], runner=FakeGh(WORLD)) == {}
+
+
+def test_issue_view_alone_cannot_discriminate_a_pr_from_an_issue():
+    # Pins WHY the resolver must call `gh pr view` first: the issue endpoint
+    # answers identically for #14225 (a PR) and #14513 (an issue). Any future
+    # rewrite that reorders the two calls fails here.
+    gh = FakeGh(WORLD)
+    pr_answer = gh(["gh", "issue", "view", "14225", "--json", "state"])
+    issue_answer = gh(["gh", "issue", "view", "14513", "--json", "state"])
+    assert pr_answer.returncode == issue_answer.returncode == 0
+    assert "state" in json.loads(pr_answer.stdout)
+    assert "state" in json.loads(issue_answer.stdout)
+
+
+def test_original_state_merged_field_set_misclassifies_a_merged_pr():
+    r"""The defect, reproduced -- and the reason this test file exists.
+
+    This replays the ORIGINAL algorithm verbatim (ask for ``state,merged``,
+    accept the payload only if it carries a ``merged`` key, else fall back to
+    ``gh issue view``) against the same fake `gh`. It returns ``issue`` for
+    #14225 -- a PR merged at 2026-09-03T10:28:59Z -- which is precisely the
+    verdict that blocked #13922 on ``prev-not-pr -> [14225]``.
+
+    Kept as an executable record: it fails the moment someone reintroduces a
+    non-existent field into the query.
+    """
+    gh = FakeGh(WORLD)
+
+    def original_algorithm(n):
+        pr = gh(["gh", "pr", "view", str(n), "--json", "state,merged"])
+        if pr.returncode == 0:
+            payload = json.loads(pr.stdout)
+            if "merged" in payload:
+                return {"kind": "pr", "merged": bool(payload["merged"])}
+        issue = gh(["gh", "issue", "view", str(n), "--json", "state"])
+        if issue.returncode == 0 and "state" in json.loads(issue.stdout):
+            return {"kind": "issue"}
+        return None
+
+    assert original_algorithm(14225) == {"kind": "issue"}          # the defect
+    assert vpg.resolve_prev_targets([14225], runner=FakeGh(WORLD)) == {
+        "14225": {"kind": "pr", "merged": True}}                   # the repair
+
+
+def test_check_passes_on_a_prev_pointing_at_a_resolved_merged_pr():
+    # End-to-end shape of the #13922 tag once the resolver is correct.
+    body = ("Grain: MED/guard -- lane myia-po-2026:CoursIA -- "
+            "prev: LIGHT/cleanup #14225")
+    targets = vpg.resolve_prev_targets(
+        vpg.find_prev_target_pr_numbers(body), runner=FakeGh(WORLD))
+    v = vpg.check(body, current_pr=13922, prev_targets=targets)
+    assert v["hits"]["prev_invalid"] == []
+    assert v["guard_pass"] is True

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -27,7 +27,7 @@ CLEAN_BODY = "Grain: MED/tooling -- lane myia-po-2025:CoursIA-2 -- prev: MED/inf
 def test_clean_body_passes():
     v = vpg.check(CLEAN_BODY)
     assert v["guard_pass"] is True
-    assert v["hits"] == []
+    assert v["hits"] == {"body": [], "commits": [], "prev_invalid": []}
 
 
 def test_offending_body_blocks():
@@ -99,3 +99,196 @@ def test_empty_inputs_pass():
     assert vpg.check(None)["guard_pass"] is True
     assert vpg.check("")["guard_pass"] is True
     assert vpg.check("", [])["guard_pass"] is True
+
+
+# --- PREV-INVALID (#13475) ---------------------------------------------
+#
+# The original gate (#10093) only checked the GENRE slot of the `prev:`
+# field. The acceptance of #13475 extended the gate with three invariants on
+# the PR-reference slot -- the `genre #N` tail -- each of which silently
+# breaks the genre-adjacency measurement G-VAR-3 enforces. Tests below pin
+# each invariant by FALSIFYING the bare assertion: stash the source change,
+# each test goes red. With the change applied, the gate blocks the three
+# measured witnesses (#12875 / #13473 / #13439) and lets a sane tag pass.
+
+CLEAN_PREV_BODY = (
+    "Grain: LIGHT/refactor -- lane myia-po-2026:CoursIA "
+    "-- prev: LIGHT/refactor #13826"
+)
+CLEAN_PREV_TARGETS = {"13826": {"kind": "pr", "merged": True}}
+
+
+def test_prev_self_reference_blocks():
+    # #12875 measured: `prev: MED/notebook-python #12875` on PR #12875
+    # itself -- the adjacency is vacuous (grain compared to itself).
+    v = vpg.check(
+        "Grain: MED/notebook-python -- lane myia-po-2023:CoursIA-2 "
+        "-- prev: MED/notebook-python #12875",
+        current_pr=12875,
+        prev_targets={"12875": {"kind": "pr", "merged": True}},
+    )
+    assert v["guard_pass"] is False
+    assert any(h["kind"] == "prev-self" and h["prev_pr"] == 12875
+               for h in v["hits"]["prev_invalid"])
+
+
+def test_prev_self_in_commit_message_blocks():
+    # The #10093 precedent says commit messages are in scope (squash-merge
+    # publishes them). A PREV-SELF in a commit must be flagged the same way.
+    commits = [
+        "feat: normal commit",
+        "Grain: MED/refactor -- prev: MED/refactor #13473",
+    ]
+    v = vpg.check(
+        "Grain: MED/refactor -- lane x:y -- prev: MED/refactor #13473",
+        commits=commits,
+        current_pr=13473,
+        prev_targets={"13473": {"kind": "pr", "merged": True}},
+    )
+    assert v["guard_pass"] is False
+    kinds_by_loc = {(h["location"], h["kind"]) for h in v["hits"]["prev_invalid"]}
+    assert ("body", "prev-self") in kinds_by_loc
+    assert ("commits[1]", "prev-self") in kinds_by_loc
+
+
+def test_prev_self_abstains_when_current_pr_unknown():
+    # FN-safety: when the caller didn't tell us who we are, the gate must
+    # NOT block on PREV-SELF (we can't evaluate identity). The original
+    # (a)-only behaviour is the silent backstop; broadening the silent
+    # zone is worse than partial coverage.
+    v = vpg.check(
+        "Grain: MED/refactor -- prev: MED/refactor #99999"
+        # NOTE: no `current_pr=` keyword -> abstention on PREV-SELF.
+    )
+    assert v["guard_pass"] is True
+
+
+def test_prev_not_merged_blocks():
+    # #13473 measured: `prev: feat/notebook #13465` on PR #13473, where
+    # #13465 was OPEN at the time of the tag (the predecessor is a moving
+    # target whose genre could still change before merge).
+    v = vpg.check(
+        "Grain: feat/module -- lane myia-po-2026:CoursIA "
+        "-- prev: feat/notebook #13465",
+        current_pr=13473,
+        prev_targets={"13465": {"kind": "pr", "merged": False}},
+    )
+    assert v["guard_pass"] is False
+    assert any(h["kind"] == "prev-not-merged" and h["prev_pr"] == 13465
+               for h in v["hits"]["prev_invalid"])
+
+
+def test_prev_not_pr_blocks():
+    # #13439 measured: `prev: MED/refactor #13436` where #13436 is an
+    # ISSUE (never mergeable). The cap silently compared the grain to a
+    # target whose genre was structurally unevaluable.
+    v = vpg.check(
+        "Grain: MED/guard -- lane myia-po-2026:CoursIA "
+        "-- prev: MED/refactor #13436",
+        current_pr=13439,
+        prev_targets={"13436": {"kind": "issue"}},
+    )
+    assert v["guard_pass"] is False
+    assert any(h["kind"] == "prev-not-pr" and h["prev_pr"] == 13436
+               for h in v["hits"]["prev_invalid"])
+
+
+def test_prev_not_pr_or_merged_abstains_when_metadata_missing():
+    # FN-safety: a target the workflow couldn't resolve (network blip,
+    # rate-limit, gh 404 on a draft PR) must NOT be flagged. The
+    # silent-acceptance defect that #13475 measures is at the
+    # SUFFICIENT-information end (the metadata is right there, we just
+    # didn't read it) -- not at the unresolvable end.
+    v = vpg.check(
+        "Grain: MED/refactor -- lane x:y -- prev: MED/refactor #99999",
+        current_pr=100,
+        prev_targets={},  # metadata intentionally absent
+    )
+    assert v["guard_pass"] is True
+
+
+def test_prev_invalid_clean_tag_passes():
+    # The baseline: a sane tag (`prev:` points at a MERGED PR distinct
+    # from the current one) passes BOTH invariants (a) and (b).
+    v = vpg.check(CLEAN_PREV_BODY, current_pr=13918,
+                  prev_targets=CLEAN_PREV_TARGETS)
+    assert v["guard_pass"] is True
+    assert v["hits"] == {"body": [], "commits": [], "prev_invalid": []}
+
+
+def test_combined_close_keyword_and_prev_self_reports_both():
+    # (a) and (b) defects in the same tag -- the verdict surfaces BOTH so
+    # the worker fixes both in one edit instead of being told only one and
+    # discovering the other at re-run.
+    v = vpg.check(
+        "Grain: MED/fix -- lane x:y -- prev: MED/fix #13465",
+        current_pr=13465,
+        prev_targets={"13465": {"kind": "pr", "merged": False}},
+    )
+    assert v["guard_pass"] is False
+    assert any(h["genre"] == "fix" for h in v["hits"]["body"])
+    assert any(h["kind"] == "prev-self" for h in v["hits"]["prev_invalid"])
+    assert any(h["kind"] == "prev-not-merged" for h in v["hits"]["prev_invalid"])
+    # Both reasons appear in the human-readable summary.
+    assert "closing keywords" in v["reason"]
+    assert "invariant" in v["reason"]
+
+
+def test_find_prev_self_references_helper():
+    # Helper-level test: the regex pulls every `prev: ... #N` whose #N
+    # equals `current_pr`, even when multiple `prev:` clauses coexist
+    # (multi-grain body -- extremely rare but the regex must not stop at
+    # the first hit).
+    text = (
+        "Grain: MED/refactor -- lane x:y\n"
+        "previous body. prev: MED/refactor #1\n"
+        "Then a self-ref: prev: LIGHT/refactor #99999\n"
+        "And a clean one: prev: DEEP/lean #2"
+    )
+    hits = vpg.find_prev_self_references(text, current_pr=99999)
+    assert len(hits) == 1
+    assert hits[0]["prev_pr"] == 99999
+    assert "prev: LIGHT/refactor #99999" in hits[0]["match"]
+
+
+def test_find_prev_target_pr_numbers_helper():
+    # Helper: deduplicates and respects the `prev:` prefix (a `Refs #5`
+    # outside `prev:` is NOT a target).
+    text = (
+        "Grain: MED/refactor -- lane x:y -- prev: MED/refactor #5\n"
+        "Refs #5 (a sibling ref, not a target).\n"
+        "Also prev: MED/guard #5\n"   # same #5, dedup
+        "And prev: DEEP/lean #7"
+    )
+    targets = vpg.find_prev_target_pr_numbers(text)
+    assert targets == [5, 7]
+
+
+def test_validate_prev_targets_helper():
+    # Helper: builds the right hit dict per kind.
+    targets = [1, 2, 3]
+    meta = {
+        "1": {"kind": "pr", "merged": True},     # clean
+        "2": {"kind": "pr", "merged": False},    # PREV-NOT-MERGED
+        "3": {"kind": "issue"},                  # PREV-NOT-PR
+        # "4" absent on purpose -> abstain
+    }
+    hits = vpg.validate_prev_targets(targets, meta, location="body")
+    kinds = sorted(h["kind"] for h in hits)
+    assert kinds == ["prev-not-merged", "prev-not-pr"]
+
+
+def test_prev_invalid_check_unaffected_by_existing_close_keyword_tests():
+    # Regression guard for the #10093 surface: the original invariants
+    # still fire when only `prev_targets` is passed. This pins the fact
+    # that the extension is ADDITIVE -- it doesn't break the existing
+    # close-keyword detection.
+    v = vpg.check(
+        "Grain: MED/fix -- lane x:y -- prev: MED/fix #100",
+        current_pr=200,
+        prev_targets={"100": {"kind": "pr", "merged": True}},
+    )
+    assert v["guard_pass"] is False
+    assert any(h["genre"] == "fix" for h in v["hits"]["body"])
+    # PREV-SELF is NOT flagged (current_pr=200, prev=#100, distinct).
+    assert not any(h["kind"] == "prev-self" for h in v["hits"]["prev_invalid"])


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/cleanup #14225  ## Summary  > Note : PR a été ouverte sous le numéro #13922 (GitHub a attribué un ID différent du draft #13918 utilisé localement pour ce fichier).  Le gate `variation_prev_guard.py` (#10093) ne validait que le **slot GENRE** de `prev:`. L'acceptance élargie du ticket #13475 demande trois invariants sur le **slot PR-reference** (`genre #N` tail), chacun cassant silencieusement la mesure d'adjacence G-VAR-3 :  1. **PREV-SELF** : `prev:` pointe la PR elle-même (adjacence vacuous, grain comparé à lui-même). Témoin mesuré : #12875. 2. **PREV-NOT-MERGED** : `prev:` pointe une PR non mergée (cible mouvante, genre encore éditable). Témoin mesuré : #13473. 3. **PREV-NOT-PR** : `prev:` pointe une **issue**, pas une PR (jamais mergeable, genre structurellement inévaluable). Témoin mesuré : #13439.  Cette PR ferme le **3e axe** de #13475 (axes GENRE = #13585 MERGED, TIER = #13691 MERGED par po-2023). Le gate reste **BACKWARD-COMPATIBLE** : sans `--current-pr` et sans `--prev-targets-file`, le verdict est identique à l'ancien (FN-safety sur invariants 2/3 : metadata absente → abstention).  ## Mesure — défaut reproduit firsthand  Avant ce commit, `variation_prev_guard.py::check()` retournait `guard_pass=True` pour les 3 témoins mesurés (#12875, #13473, #13439), validés en preflight cycle 43 :  ```text >>> check("Grain: MED/notebook-python -- prev: MED/notebook-python #SELF", ...       current_pr=12875, prev_targets={"12875": {"kind": "pr", "merged": True}}) {'guard_pass': True, ...}    # <- defaut : PREV-SELF pas detecte  >>> check("Grain: feat/module -- prev: feat/notebook #MOVING", ...       current_pr=13473, prev_targets={"13465": {"kind": "pr", "merged": False}}) {'guard_pass': True, ...}    # <- defaut : PREV-NOT-MERGED pas detecte  >>> check("Grain: MED/guard -- prev: MED/refactor #ISSUE-N", ...       current_pr=13439, prev_targets={"13436": {"kind": "issue"}}) {'guard_pass': True, ...}    # <- defaut : PREV-NOT-PR pas detecte ```  ## Le fix  3 helpers ajoutés à `scripts/ci/variation_prev_guard.py` :  | Helper | Rôle | |---|---| | `find_prev_self_references(text, current_pr)` | retourne chaque `prev: ... #N` dont le `#N` == `current_pr` (invariant 1) | | `find_prev_target_pr_numbers(text)` | extrait tous les `#N` cités en `prev:` (body ou commit) — dédupliqués, le `Refs #5` hors `prev:` n'est PAS une cible | | `validate_prev_targets(target_prs, targets_meta, location)` | évalue les invariants 2 et 3 contre un dict `{pr_number: {kind, merged}}` (FN-safety : metadata absente → abstention) |  `check()` étendu avec `current_pr=` et `prev_targets=` (kwargs only → backward-compatible). Verdict restructuré : `hits` devient `{body, commits, prev_invalid}` au lieu d'une liste plate.  Workflow `always-on-guards.yml` étendu : pour chaque `#N` cité dans body + commits, un heredoc Python résout `gh pr view --json state,merged` puis `gh issue view --json state` (fallback), et passe le dict résultant via `--prev-targets-file`. Résolution échouée (network, 404 draft, rate-limit) → metadata absente → abstention (contrat FN-safety documenté en docstring).  ## Tests (20 verts, FN-safety vérifié par stash)  **`scripts/tests/test_variation_prev_guard.py`** — 8 anciens tests #10093 + 12 nouveaux tests #13475 :  - `test_prev_self_reference_blocks` : #12875 mesuré - `test_prev_self_in_commit_message_blocks` : cohérence #10093 (commit in scope) - `test_prev_self_abstains_when_current_pr_unknown` : FN-safety sans `current_pr` - `test_prev_not_merged_blocks` : #13473 mesuré - `test_prev_not_pr_blocks` : #13439 mesuré - `test_prev_not_pr_or_merged_abstains_when_metadata_missing` : FN-safety sans metadata - `test_prev_invalid_clean_tag_passes` : baseline saine (prev=PR mergée, distinct de current) - `test_combined_close_keyword_and_prev_self_reports_both` : invariants (a) ET (b) en une exécution - `test_find_prev_self_references_helper` / `test_find_prev_target_pr_numbers_helper` / `test_validate_prev_targets_helper` : helpers - `test_prev_invalid_check_unaffected_by_existing_close_keyword_tests` : régression guard  **Contrôle par faux-négatifs** (acceptance #13475 §"Ce qu'il faut" : *"Un test qui, avec le correctif retiré, échoue"*) :  ```text $ git stash push -- scripts/ci/variation_prev_guard.py $ python -m pytest scripts/tests/test_variation_prev_guard.py ... 12 failed, 8 passed $ git stash pop ... 20 passed ```  12 tests rouges sans le source (les 3 invariants + helpers), 8 anciens tests #10093 toujours verts (pas de régression sur l'existant).  **Suite complète scripts/tests/** (variation_prev_guard + grain_tag + variation_adjacency_guard + variation_tag_required + check_unaddressed_nits + check_pr_perimeter) : **554 passed in 4.96s**.  ## Acceptance #13475 (acceptance élargie)  - [x] **`GENRE-UNKNOWN`** : livré par PR #13585 (axe GENRE fermé) - [x] **`TIER-UNKNOWN`** : livré par PR #13691 par po-2023 (axe TIER fermé) - [x] **`PREV-INVALID`** : cette PR (3 prédicats — `prev != current`, `prev` mergée, `prev` est une PR) - [x] Signal visible : `hits.prev_invalid` nommant `kind` (`prev-self` / `prev-not-merged` / `prev-not-pr`), `location` (`body` / `commits[N]`), et `prev_pr` numérique - [x] Comportement par défaut sur mot/cible inconnu : **abstention** (FN-safety), pas exemption - [x] Test qui rougit sans le fix : 12/12 (cf. contrôle par faux-négatifs ci-dessus)  ## Périmètre (3 fichiers, +573/-39)  ```text  .github/workflows/always-on-guards.yml     |  65 +++++-  scripts/ci/variation_prev_guard.py         | 352 ++++++++++++++++++++++++++---  scripts/tests/test_variation_prev_guard.py | 195 +++++++++++++++-  3 files changed, 573 insertions(+), 39 deletions(-) ```  Aucun touch des notebooks, du catalogue, des autres workflows, ou du harnais. Catalog-pr-hygiene respectée : aucun marqueur CATALOG-STATUS sur la branche.  ## Lien avec cycles précédents  - **#13475** (cette PR) : ferme l'axe PREV-INVALID du ticket ; GENRE (#13585) et TIER (#13691) déjà mergés. - **#12875** : premier témoin PREV-SELF (mesure jsboige dans le body du ticket). - **#13473** / **#13439** : témoins PREV-NOT-MERGED / PREV-NOT-PR (mesure jsboige dans les commentaires du ticket). - **#10093** : prédécesseur ; le gate originel validait le slot GENRE (`find_prev_close_keywords`). Ce commit étend le même organe avec 3 invariants sur le slot PR-reference, sous le même contrat (adresse: `scripts/ci/variation_prev_guard.py`, blocage via PR gate, comment-bot via `<!-- vtr-prev-close-keyword -->` mis à jour pour couvrir aussi les invariants PREV-INVALID).  ## Note pour le reviewer (clusterManager-Myia)  Le commentaire bot (`<!-- vtr-prev-close-keyword -->`) garde le label existant — le merge n'introduit pas de nouveau label. Le champ `hits.prev_invalid` est documenté comme ADDITIF (les anciens hits `body` et `commits` restent au même format JSON, jamais rupturés).  Part of #13475 (axe PREV-INVALID uniquement — pas Closes car les commentaires d'acceptance élargie mentionnent aussi l'axe TIER comme "encore ouvert" avant #13691, et la fermeture définitive du ticket parent reste au coordinateur après merge de cette PR).  (footer dorigine, forme historique : prev: MED/refactor pointant l issue #13849 -- jamais une PR)  Generated with [Claude Code](https://claude.com/claude/code)  ## Grain tag (cycle 104 repair)  **L1 d'origine** : `## Summary` (header markdown, pas de `Grain:` en debut de ligne). Le tag footer en bas de body etait valide avant la PR #14027 mais **rejete apres** (parser ancre `^Grain:` en debut de ligne). `parse_grain_tag` rendait `None` -> `tag_required` rouge, verouillage du merge.  **L1 maintenant** : `Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/cleanup #14225` -- regex `_GRAIN_FULL_RE` match, tier `MED` ∈ TIERS canonical, genre `guard` ∈ GENRES canonical. **Why** : ai-01 DM msg-20260901T120647-71eeve a flagué la classe 'tag non parseable' comme P0 repair sous cap G-VAR-2. Body-edit only (~1 run `edited`) vs push (~30 runs) -- file a 166. Substance de la PR **100% preservee** (memes fichiers, memes diffs, substance pedagogique intacte).  **How to apply** : prochaine PR sur cette lane -> L1 doit etre `Grain: <TIER>/<GENRE> -- lane <MACHINE>:<WORKSPACE> -- prev: <TIER>/<GENRE> #<N>`. Ref `scripts/grain_tag.py` l.654-670 pour la liste TIER/GENRE a jour.  Validation : L1 matche `_GRAIN_FULL_RE = r"Grain[\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)"` (case-insensitive). TIER ∈ {DEEP, MED, LIGHT}. GENRE ∈ 16 canonicals.  