### PR TITLE
fix(guard,#13730): retirer jsboige de COORDINATOR_LOGINS -- mirroir de #13316

### DIFF
--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -111,7 +111,14 @@ from variation_light_cap import (  # noqa: E402
 #   * it NAMES the replacement genre the lane takes next, and that genre
 #     DIFFERS from the blocked one -- otherwise the override would waive the
 #     rule while promising to break it again.
-COORDINATOR_LOGINS = frozenset({"myia-ai-01", "jsboige"})
+#
+# #13730 mirror of #13316: `jsboige` is the shared push identity of every
+# lane, not a coordinator. Keeping it here turns the G-VAR-3 ban into a
+# permission the lane can grant itself -- the exact opposite of the
+# non-vacuity clause above. The other organ (`check_unaddressed_nits`,
+# LIFT_OVERRIDE_LOGINS) was hardened by #13316 for the same reason; the
+# adjacency guard was missed. Coordinator identity = `myia-ai-01` only.
+COORDINATOR_LOGINS = frozenset({"myia-ai-01"})
 
 _OVERRIDE_RE = re.compile(
     r"\[\s*G-?VAR-?3\s+OVERRIDE\s*\]"          # the marker

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -222,7 +222,7 @@ def test_override_genre_outside_the_enum_passes_through():
 def test_last_coordinator_marker_wins():
     ov = vag.parse_override([
         {"author": "myia-po-2026", "body": "[G-VAR-3 OVERRIDE] next: lean"},
-        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] next: qc"},
+        {"author": "myia-ai-01", "body": "[G-VAR-3 OVERRIDE] next: qc"},
     ])
     assert ov is not None and ov["next_genre"] == "qc"
     assert vag.check(_BLOCKED, override=ov)["guard_pass"] is True
@@ -338,21 +338,37 @@ def test_well_formed_override_still_lifts_after_12096():
     # so the malformed cases above are provably not passing by accident of
     # a disconnected helper.
     v = vag.check(_BLOCKED, override=_ov(
-        "jsboige", "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: qc"))
+        "myia-ai-01", "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: qc"))
     assert v["guard_pass"] is True
     assert v["overridden"] is True
     assert v["override_next"] == "qc"
+
+
+def test_13730_jsboige_is_NOT_a_coordinator_login():
+    # #13730 mirror of #13316: `jsboige` is the shared push identity of
+    # every lane, not a coordinator. A well-formed override authored by
+    # `jsboige` is therefore INVISIBLE to parse_override (worker cannot
+    # self-exempt by section 1 + choice C of #12096), and the gate stays
+    # down. This pins the post-#13316 hardening at the adjacency organ.
+    ov = vag.parse_override([
+        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: qc"},
+    ])
+    assert ov is None  # invisible: shared-identity author is not a coordinator
+    v = vag.check(_BLOCKED, override=ov)
+    assert v["guard_pass"] is False
+    assert v["blocking"] is True
+    assert v["overridden"] is False
 
 
 def test_parse_override_malformed_reasons_distinct():
     # The three malformed clauses produce three DISTINCT reasons -- a single
     # generic "malformed" message would put the diagnosis burden back on the
     # coordinator (#12096: "avec la raison et la forme attendue").
-    r_missing = vag.parse_override([{"author": "jsboige",
+    r_missing = vag.parse_override([{"author": "myia-ai-01",
                                      "body": "[G-VAR-3 OVERRIDE] lane x:y"}])
-    r_offline = vag.parse_override([{"author": "jsboige",
+    r_offline = vag.parse_override([{"author": "myia-ai-01",
                                      "body": "[G-VAR-3 OVERRIDE] lane x:y\nnext: lean"}])
-    r_shape = vag.parse_override([{"author": "jsboige",
+    r_shape = vag.parse_override([{"author": "myia-ai-01",
                                    "body": "[G-VAR-3 OVERRIDE] next: 7days"}])
     assert "manquant" in r_missing["malformed"]
     assert "meme ligne" in r_offline["malformed"]
@@ -449,8 +465,8 @@ def test_13261_malformed_fallback_is_the_MOST_RECENT_rejection():
     # newest-first semantics: the MOST RECENT coordinator rejection is the
     # announced one (its reason is the actionable one).
     ov = vag.parse_override([
-        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] lane x:y"},
-        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] next: 7days"},
+        {"author": "myia-ai-01", "body": "[G-VAR-3 OVERRIDE] lane x:y"},
+        {"author": "myia-ai-01", "body": "[G-VAR-3 OVERRIDE] next: 7days"},
     ])
     assert ov is not None and "malformed" in ov
     assert "n'est pas un genre" in ov["malformed"]  # the newer, not "manquant"


### PR DESCRIPTION
## Summary

`scripts/ci/variation_adjacency_guard.py:114` portait :

```python
COORDINATOR_LOGINS = frozenset({"myia-ai-01", "jsboige"})
```

`jsboige` est l'**identité de poussée partagée de toutes les lanes** (po-2023/2024/2025/2026 + ai-01 + CoursIA-2), pas un identifiant coordinateur. Le garde d'adjacence n'avait jamais reçu le correctif fermé pour l'organe miroir (`check_unaddressed_nits.py:134`, `LIFT_OVERRIDE_LOGINS = {"myia-ai-01"}`) par PR #13316 — **vérification mécanique** :

```
$ git log --oneline --all --grep="13316" -- scripts/ci/variation_adjacency_guard.py
(vide)
```

La clause de **non-vacuité** du protocole de variation (commentaire l.104-110) dit textuellement :

> it is authored by a coordinator login (**a worker cannot self-exempt**)

Cette garantie est **fausse en l'état**. Toute lane qui poste sous l'identité partagée satisfait `login in COORDINATOR_LOGINS` et lève son propre G-VAR-3. Le ban absolu du protocole devient une dispense générale à la discrétion de la lane sanctionnée.

## Le fix

Une ligne : retrait de `"jsboige"` du frozenset, avec commentaire de bloc citant #13316 et #13730 comme trace. C’est le miroir exact du fix `check_unaddressed_nits.py` ferme par #13316. Le commentaire de conception au-dessus renseigne aussi le pourquoi (identité partagée ≠ identité coordinateur).

## Mesure préalable — 0 PR ouverte ne dépend d'un override jsboige

| PR | Auteur | Override [G-VAR-3 OVERRIDE] jsboige actif ? | Survivra au fix ? |
|---|---|---|---|
| #13835 (narrow-po-2026, CoursIA-2) | jsboige | **NON** (juste LGTM/INFO dans le thread) | OUI (HELD attendu par design, ne lève pas) |
| #13912 (myia-ai-01) | jsboige | **NON** (juste LGTM review) | OUI (nécessite aucun override, bloquée par `variation-light-cap-reached` advisory) |
| #13784 (myia-ai-01) | myia-ai-01 | N/A (auteur déjà coordinator) | OUI (utilise `myia-ai-01` qui demeure coordinator valide) |

**Conclusion : 0 PR ouverte ne devient rouge par ce fix.** Aucun override `jsboige` actif à reporter ailleurs, aucun blocage hérité à assumer. La mesure honore la leçon [[dead-resolver-masks-a-permissive-predicate]] : on ne livre pas un durcissement sans avoir compté ses effets de bord.

## Tests — 52 verts (52 anciens + 1 nouveau), FN-safety vérifiée par stash

**`scripts/tests/test_variation_adjacency_guard.py`** :

- `test_last_coordinator_marker_wins` : auteur `jsboige` → `myia-ai-01` (le test pin la logique « dernier override valide gagne parmi les coordinateurs », pas l’auteur jsboige spécifique)
- `test_well_formed_override_still_lifts_after_12096` : idem auteur → `myia-ai-01`
- `test_parse_override_malformed_reasons_distinct` (3 sous-cas) : idem auteur → `myia-ai-01`
- `test_13261_malformed_fallback_is_the_MOST_RECENT_rejection` : idem auteur → `myia-ai-01`
- **`test_13730_jsboige_is_NOT_a_coordinator_login` (NOUVEAU)** : pin explicite du comportement post-fix. `[G-VAR-3 OVERRIDE]` bien formé porté par `jsboige` → `parse_override` rend `None` (worker cannot self-exempt, choix C de #12096) ; le gate reste `blocking=True`, `overridden=False`. C’est le témoin positif du hardening.

**Contrôle par faux-négatifs** (acceptance #13730 § « Ce qu'il faut » : *« Un test qui, avec le correctif retiré, échoue »*) :

```text
$ git stash push -- scripts/ci/variation_adjacency_guard.py
Saved working directory and index state WIP on feature/cycle-44-pioche
$ python -m pytest scripts/tests/test_variation_adjacency_guard.py -q
... F......................                     [100%]
FAILED test_13730_jsboige_is_NOT_a_coordinator_login
1 failed, 51 passed in 0.14s
$ git stash pop
... 52 passed in 0.14s
```

**1 test rouge sans le source, 51 verts = régression nulle sur l’existant.** Le nouveau test rougit sans le fix ; les 4 tests adaptés passent avec ou sans le fix (ils testent la logique « override par coordinateur », pas l’auteur spécifique) — pattern acceptable : aucun test adapté ne devient silencieusement inopérant.

Suite étendue (gardes variation) : **`142 passed in 0.60s`** sur `test_variation_adjacency_guard` + `test_variation_prev_guard` + `test_variation_tag_required` + `test_grain_tag`. Aucun régression croisée.

## Périmètre (2 fichiers, +31/-8)

```text
 scripts/ci/variation_adjacency_guard.py         |  9 +++++++-
 scripts/tests/test_variation_adjacency_guard.py | 30 +++++++++++++++++++------
 2 files changed, 31 insertions(+), 8 deletions(-)
```

Aucun toucher : catalogue, autres organes (notamment `check_unaddressed_nits` déjà durci par #13316), notebooks, workflows, harnais.

## Acceptance #13730

- [x] **Mesure préalable** : 0 PR ouverte dépend d'un override `jsboige` actif (cf. tableau ci-dessus).
- [x] **Source corrigé** : `COORDINATOR_LOGINS = frozenset({"myia-ai-01"})`, miroir de #13316.
- [x] **Commentaire de bloc** au-dessus de la constante : cite #13316 + #13730 + raison (« identité partagée ≠ coordinateur »), preuve de preservation de la décision.
- [x] **Témoin positif du hardening** : `test_13730_jsboige_is_NOT_a_coordinator_login` rougit sans le fix (stash prouvé).
- [x] **Aucun régression** sur l'existant (51 tests adapts, 142 tests verts étendus).
- [x] **Hardening réversible** : un test qui marchait avant (`test_well_formed_override_still_lifts_after_12096` avec jsboige) est adapté — diff documente le pourquoi (le test pin la logique « override par coordinateur », pas l’auteur spécifique).

## Lien avec cycles précédents

- **#13730** (cette PR) : ferme le pendant oublié de #13316 sur le second organe.
- **#13316** : durcissement de `check_unaddressed_nits.LIFT_OVERRIDE_LOGINS` — le précédent à calquer.
- **#12096** : trois états de `parse_override` (None / malformed / well-formed). Le nouveau test vérifie qu'un `jsboige` auteur tombe bien dans le **premier** état (None), pas le second (malformed) — le worker n'a pas d'arbitrage à rejeter.
- **#10223** : `[OVERRIDE]` des lane-claims, mîcme garantie de non-vacuité (un lane ne s'auto-attribue pas un statut qu'il n'a pas).

Closes #13730

Part of #11170 (G-VAR-3 ensemble cohérent : deux organes portes par le mîcme contrat de non-vacuité, un seul survivant manquait au hardening).

Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: MED/guard #13849

Generated with [Claude Code](https://claude.com/claude/code)
