### PR TITLE
docs(ml-tp,#13740): document results convention + flag 4 orphan flat JSONs

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -548,6 +548,31 @@ Résultats : `scripts/results/{l1_tsmom,l2_dual_momentum,l3_trend_long_horizon,l
 - **Historique entraînement** : Courbes de perte par epoch
 - **Seeds** : Données synthétiques utilisent seed=42 ; pour production, configurer `PYTHONHASHSEED` et `torch.manual_seed()`
 
+### Convention de stockage des résultats (#13740)
+
+Trois familles d'artefacts, trois emplacements distincts, **un seul verdict canonique par expérience** :
+
+| Type | Emplacement canonique | Contenu | Exemple |
+|---|---|---|---|
+| **Verdict canonique** | `scripts/results/<exp>/results.json` (+ `seed_significance.json` si multi-seed) | Métriques finales (Sharpe, edge, BEATS/NO BEATS) + per-seed | `scripts/results/m11c_dm_test/results.json`, `scripts/results/baselines_zeroshot/seed_significance.json` |
+| **Poids du modèle** | `checkpoints/<famille>/<timestamp>/` | `model.pt` + `metadata.json` (args, hash, courbe de perte) | `checkpoints/lstm/20260501_123516/metadata.json` |
+| **Logs de run** | `outputs/<run_id>/` (auto-créé) | stdout/stderr, gradients, telemetry GPU | (générés par `shared/gpu_training.py`) |
+
+**Règle d'or** : un répertoire `<exp>/` = une expérience = un verdict. Pas de JSON plats au racine de `scripts/results/`.
+
+#### Dérogations historiques connues (4 fichiers plats à migrer)
+
+Ces 4 fichiers violent la convention (JSON plat à la racine de `scripts/results/` au lieu d'un sous-répertoire `<exp>/`). Ils sont **référencés en dur** par `m4_dlinear_vol_sc_validation.ipynb` (chemins `Path(...)` dans 4 cellules), `scripts/btc_vol.py` (default argparse) et `REGISTRY.md` (commandes `--out-json`). La migration est **non triviale** : déplacer les JSON casserait les consommateurs. Décision : **garder en l'état, flagger ici**, et traiter dans une PR dédiée quand les chemins seront refactorés en `Path(__file__).parent / "<exp>"`.
+
+| Fichier plat | Réf. canonique cible | Statut |
+|---|---|---|
+| `scripts/results/m4_dlinear_vol_btc_sc.json` | `scripts/results/m4_dlinear_vol_btc_sc/results.json` | À migrer (4 consumers) |
+| `scripts/results/m4_dlinear_vol_btc_sc_debiased.json` | idem sous-répertoire `--debias` | À migrer |
+| `scripts/results/m4_dlinear_vol_btc_sc_debiased_recentered.json` | idem `--debias --recentered` | À migrer |
+| `scripts/results/m4_dlinear_vol_btc_sc_mse.json` | `scripts/results/m4_dlinear_vol_btc_sc_mse/results.json` | À migrer (3 consumers) |
+
+Pour les **nouvelles expériences** : appliquer la convention dès la première écriture. Le pipeline de validation (`scripts/validate_training_package.py`) devrait idéalement rejeter les JSON plats au racine — non implémenté à ce jour.
+
 ---
 
 ## Conclusion / Prochaines étapes


### PR DESCRIPTION
## Summary

Issue #13740 signale 3 endroits pour les resultats ML-Training-Pipeline
(`scripts/results/` 33 Mo, `results/` 2.3 Mo, `checkpoints/results/` RAPPORTE).
La convention cible est definie mais jamais documentee dans le README du pipeline.
4 fichiers plats violent deja la convention (verifier empirique : `ls scripts/results/*.json`).

Cette PR ajoute une **section documentation** dans la sous-section
`## Reproductibilite` du README, sans toucher aux fichiers :

- Tableau recapitulatif (verdict canonique / poids / logs)
- Regle d'or : "un repertoire `<exp>/` = une experience = un verdict"
- Liste explicite des 4 derogations historiques avec cible de migration
- Note explicite : la migration est reportee (chemins hardcodes dans
  `m4_dlinear_vol_sc_validation.ipynb` c.106/591/901/1070, `scripts/btc_vol.py:279`,
  `REGISTRY.md` c.55/81/108/149)

## Verification empirique (2026-09-01)

```text
$ ls MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/*.json | head
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc_debiased.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc_debiased_recentered.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc_mse.json

$ git ls-files MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc*.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc_debiased.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc_debiased_recentered.json
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m4_dlinear_vol_btc_sc_mse.json

$ git grep -l "m4_dlinear_vol_btc_sc" -- '*.py' '*.ipynb' '*.md'
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m4_dlinear_vol_sc_validation.ipynb
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/btc_vol.py
```

3 consommateurs identifies, 11 chemins hardcodes au total. Migration = PR dediee
refactor des consommateurs en `Path(__file__).parent / "<exp>"` puis `git mv`.

## Perimetre (1 fichier, +25/-0)

```text
 MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md | 25 ++++++++++++++++++++++
 1 file changed, 25 insertions(+)
```

Aucun toucher : code Python, notebooks, scripts CI, workflows, harnais, catalogue.

## CATALOG-STATUS byte-identique

Le bloc `<!-- CATALOG-STATUS ... -->` (l.1-7) est inchange (cf
[catalog-pr-hygiene.md](../blob/main/.claude/rules/catalog-pr-hygiene.md)).
Diff git confirme : seul le bloc `## Reproductibilite > Convention de stockage`
est ajoute.

## Acceptance #13740

- [x] **Convention documentee** dans le README, section Reproductibilite.
- [x] **Derogations flagees** : 4 fichiers plats identifies avec cible de migration.
- [x] **Pas de regression** : scope strict (1 fichier, +25/-0), aucun code touche.
- [x] **Migration differee explicitement** avec rationale (chemins hardcodes).

Refs #13740 (volet documentation ; le volet byte-identical CSV est couvert
par PR #13918 qui ferme la moitie "V1" du ticket). Cette PR documente la
convention pour prevenir les futures violations.

Grain: LIGHT/docs -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-python #13928
