### PR TITLE
feat(adk): add real provider-backed runtime

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/requirements.txt
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/requirements.txt
@@ -1,7 +1,7 @@
 # Track2-GoogleADK - Dépendances Multi-Provider
 
 # === Abstraction LLM ===
-litellm>=1.40.0
+litellm==1.83.14
 
 # === LangChain (Track1-LangChain) ===
 langchain>=0.3.0
@@ -11,11 +11,11 @@ langchain-experimental>=0.3.0
 # === Google Gemini ===
 google-generativeai>=0.8.0
 
-# === OpenAI Compatible ===
-openai>=1.0.0
+# === OpenAI Compatible (pin LiteLLM 1.83.14) ===
+openai==2.24.0
 
-# === Google ADK (optionnel, Day 7) ===
-google-adk>=0.3.0
+# === Google ADK (runtime central du Track 2) ===
+google-adk==2.8.0
 
 # === Data Science ===
 pandas>=2.0.0
@@ -37,7 +37,7 @@ duckduckgo-search>=4.0.0
 
 # === Configuration ===
 python-dotenv>=1.0.0
-pydantic>=2.0.0
+pydantic==2.12.5
 pydantic-settings>=2.0.0
 
 # === Jupyter ===

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
@@ -1,0 +1,227 @@
+"""Google ADK runtime backed by the track's configured LLM provider.
+
+This module is deliberately separate from :mod:`llm_client`: it constructs and
+runs a real Google ADK agent, including its session, runner, events and tools.
+There is no simulated response path. A missing or unreachable provider raises
+``AdkRuntimeUnavailable`` with the SOTA verdict ``RECOVERABLE-LOCAL``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from uuid import uuid4
+
+from config.providers import (
+    ProviderConfig,
+    ProviderType,
+    get_litellm_model,
+    get_provider_config,
+)
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+APP_NAME = "track2_google_adk"
+
+
+class AdkRuntimeUnavailable(RuntimeError):
+    """The configured real ADK/LLM runtime cannot currently be reached."""
+
+    verdict = "RECOVERABLE-LOCAL"
+
+
+@dataclass(frozen=True)
+class AdkRunResult:
+    """Observable evidence produced by a complete ADK invocation."""
+
+    response_text: str
+    event_count: int
+    tool_calls: tuple[str, ...]
+    tool_responses: tuple[str, ...]
+
+    @property
+    def tool_was_invoked(self) -> bool:
+        """Whether ADK emitted both a tool request and its response."""
+        return bool(self.tool_calls and self.tool_responses)
+
+
+def dataset_profile(rows: int, columns: int) -> dict[str, int | float]:
+    """Return deterministic shape statistics for a tabular dataset."""
+    if rows <= 0 or columns <= 0:
+        return {
+            "rows": rows,
+            "columns": columns,
+            "cells": 0,
+            "rows_per_column": 0.0,
+        }
+    return {
+        "rows": rows,
+        "columns": columns,
+        "cells": rows * columns,
+        "rows_per_column": round(rows / columns, 2),
+    }
+
+
+def build_adk_model(config: ProviderConfig) -> LiteLlm:
+    """Map a track provider configuration to ADK's public LiteLLM model."""
+    kwargs: dict[str, str | bool] = {"drop_params": True}
+    if config.base_url:
+        kwargs["api_base"] = config.base_url
+    if config.api_key:
+        kwargs["api_key"] = config.api_key
+    elif config.provider in {ProviderType.VLLM, ProviderType.LMSTUDIO}:
+        # LiteLLM's OpenAI adapter requires a non-empty protocol credential,
+        # even when a local OpenAI-compatible endpoint disables authentication.
+        kwargs["api_key"] = "local-endpoint-no-auth"
+
+    return LiteLlm(model=get_litellm_model(config), **kwargs)
+
+
+def build_data_agent(config: ProviderConfig | None = None) -> Agent:
+    """Construct a real Google ADK agent with a deterministic Python tool."""
+    provider = config or get_provider_config()
+    return Agent(
+        name="dataset_profile_agent",
+        description="Analyse la forme d'un jeu de données tabulaire.",
+        instruction=(
+            "Tu es un agent data science. Pour toute question contenant un "
+            "nombre de lignes et de colonnes, appelle obligatoirement l'outil "
+            "dataset_profile, puis explique brièvement son résultat."
+        ),
+        model=build_adk_model(provider),
+        tools=[dataset_profile],
+    )
+
+
+def _part_text(content: types.Content | None) -> str:
+    if not content or not content.parts:
+        return ""
+    return "".join(part.text or "" for part in content.parts).strip()
+
+
+async def run_data_agent(
+    prompt: str,
+    config: ProviderConfig | None = None,
+    *,
+    app_name: str = APP_NAME,
+    user_id: str = "track2-user",
+    session_id: str | None = None,
+    timeout_seconds: float = 120.0,
+) -> AdkRunResult:
+    """Run one real ADK turn and return evidence from its event stream."""
+    session_id = session_id or f"session-{uuid4().hex}"
+    session_service = InMemorySessionService()
+    agent = build_data_agent(config)
+    runner = Runner(
+        agent=agent,
+        app_name=app_name,
+        session_service=session_service,
+    )
+    await session_service.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+    message = types.Content(role="user", parts=[types.Part(text=prompt)])
+    response_text = ""
+    tool_calls: list[str] = []
+    tool_responses: list[str] = []
+    event_errors: list[str] = []
+    event_count = 0
+
+    async def consume_events() -> None:
+        nonlocal event_count, response_text
+        async for event in runner.run_async(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=message,
+        ):
+            event_count += 1
+            tool_calls.extend(
+                call.name for call in event.get_function_calls() if call.name
+            )
+            tool_responses.extend(
+                response.name
+                for response in event.get_function_responses()
+                if response.name
+            )
+            error_code = getattr(event, "error_code", None)
+            error_message = getattr(event, "error_message", None)
+            if error_code or error_message:
+                event_errors.append(
+                    ": ".join(
+                        detail
+                        for detail in (error_code, error_message)
+                        if detail
+                    )
+                )
+            if event.is_final_response():
+                response_text = _part_text(event.content)
+
+    try:
+        await asyncio.wait_for(consume_events(), timeout=timeout_seconds)
+    except asyncio.TimeoutError as exc:
+        raise AdkRuntimeUnavailable(
+            f"RECOVERABLE-LOCAL: runtime ADK expire apres {timeout_seconds:g} s"
+        ) from exc
+    except Exception as exc:
+        detail = str(exc).strip()
+        suffix = f": {detail}" if detail else ""
+        raise AdkRuntimeUnavailable(
+            f"RECOVERABLE-LOCAL: echec du runtime ADK reel "
+            f"({type(exc).__name__}){suffix}"
+        ) from exc
+    finally:
+        await runner.close()
+
+    if not response_text:
+        detail = f" ({'; '.join(event_errors)})" if event_errors else ""
+        raise AdkRuntimeUnavailable(
+            "RECOVERABLE-LOCAL: ADK n'a produit aucune reponse LLM finale" + detail
+        )
+
+    return AdkRunResult(
+        response_text=response_text,
+        event_count=event_count,
+        tool_calls=tuple(tool_calls),
+        tool_responses=tuple(tool_responses),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Smoke test Google ADK + LLM reel")
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Un dataset contient 120 lignes et 8 colonnes. "
+            "Appelle dataset_profile et interprète le résultat."
+        ),
+    )
+    return parser.parse_args()
+
+
+async def _smoke() -> int:
+    args = _parse_args()
+    try:
+        result = await run_data_agent(args.prompt)
+    except AdkRuntimeUnavailable as exc:
+        print(str(exc))
+        return 2
+
+    print(f"ADK events: {result.event_count}")
+    print(f"ADK tool calls: {', '.join(result.tool_calls) or 'aucun'}")
+    print(f"ADK tool responses: {', '.join(result.tool_responses) or 'aucune'}")
+    print(f"LLM response: {result.response_text}")
+    if not result.tool_was_invoked:
+        print("RECOVERABLE-LOCAL: le LLM n'a pas invoqué l'outil ADK")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_smoke()))

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime.py
@@ -1,0 +1,237 @@
+"""Tests for the real Google ADK runtime foundation."""
+
+import sys
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_PKG = Path(__file__).resolve().parent.parent
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from config.providers import ProviderConfig, ProviderType
+
+from utils import adk_runtime
+from utils.adk_runtime import (
+    AdkRuntimeUnavailable,
+    build_adk_model,
+    dataset_profile,
+)
+
+
+def _config(
+    provider=ProviderType.VLLM,
+    *,
+    model="qwen3.6-35b-a3b",
+    base_url="https://llm.example.test/v1",
+    api_key=None,
+):
+    return ProviderConfig(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+    )
+
+
+def test_dataset_profile_computes_deterministic_statistics():
+    assert dataset_profile(120, 8) == {
+        "rows": 120,
+        "columns": 8,
+        "cells": 960,
+        "rows_per_column": 15.0,
+    }
+
+
+def test_dataset_profile_rejects_nonpositive_shape_without_exception():
+    assert dataset_profile(0, 8)["cells"] == 0
+    assert dataset_profile(120, -1)["rows_per_column"] == 0.0
+
+
+def test_build_adk_model_maps_vllm_to_openai_compatible_litellm():
+    model = build_adk_model(_config())
+    assert model.model == "openai/qwen3.6-35b-a3b"
+    assert model._additional_args["api_base"] == "https://llm.example.test/v1"
+    assert model._additional_args["api_key"] == "local-endpoint-no-auth"
+    assert model._additional_args["drop_params"] is True
+
+
+def test_build_adk_model_forwards_real_key_without_logging_it():
+    model = build_adk_model(_config(api_key="configured-test-key"))
+    assert model._additional_args["api_key"] == "configured-test-key"
+
+
+def test_build_adk_model_openai_uses_provider_mapping():
+    model = build_adk_model(
+        _config(
+            ProviderType.OPENAI,
+            model="gpt-4o-mini",
+            base_url="https://api.openai.com/v1",
+            api_key="configured-test-key",
+        )
+    )
+    assert model.model == "openai/gpt-4o-mini"
+
+
+def test_build_data_agent_uses_public_adk_agent_and_real_tool():
+    agent = adk_runtime.build_data_agent(_config())
+    assert agent.name == "dataset_profile_agent"
+    assert isinstance(agent.model, adk_runtime.LiteLlm)
+    assert len(agent.tools) == 1
+    assert agent.tools[0] is dataset_profile
+
+
+class _Event:
+    def __init__(self, *, final=False, content=None, calls=(), responses=()):
+        self._final = final
+        self.content = content
+        self._calls = calls
+        self._responses = responses
+
+    def is_final_response(self):
+        return self._final
+
+    def get_function_calls(self):
+        return self._calls
+
+    def get_function_responses(self):
+        return self._responses
+
+
+class _Runner:
+    instances: ClassVar[list["_Runner"]] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.close = AsyncMock()
+        self.instances.append(self)
+
+    async def run_async(self, **kwargs):
+        self.run_kwargs = kwargs
+        call = MagicMock(name="call")
+        call.name = "dataset_profile"
+        response = MagicMock(name="response")
+        response.name = "dataset_profile"
+        yield _Event(calls=(call,))
+        yield _Event(responses=(response,))
+        yield _Event(
+            final=True,
+            content=adk_runtime.types.Content(
+                role="model", parts=[adk_runtime.types.Part(text="960 cellules")]
+            ),
+        )
+
+
+def test_run_data_agent_creates_session_and_collects_adk_evidence():
+    async def exercise():
+        service = MagicMock()
+        service.create_session = AsyncMock()
+        _Runner.instances.clear()
+        with (
+            patch.object(adk_runtime, "InMemorySessionService", return_value=service),
+            patch.object(adk_runtime, "Runner", _Runner),
+            patch.object(adk_runtime, "build_data_agent", return_value=MagicMock()),
+        ):
+            result = await adk_runtime.run_data_agent(
+                "120 lignes, 8 colonnes", _config(), session_id="session-test"
+            )
+
+        service.create_session.assert_awaited_once_with(
+            app_name=adk_runtime.APP_NAME,
+            user_id="track2-user",
+            session_id="session-test",
+        )
+        runner = _Runner.instances[0]
+        assert runner.run_kwargs["session_id"] == "session-test"
+        assert result.response_text == "960 cellules"
+        assert result.event_count == 3
+        assert result.tool_calls == ("dataset_profile",)
+        assert result.tool_responses == ("dataset_profile",)
+        assert result.tool_was_invoked
+        runner.close.assert_awaited_once()
+
+    adk_runtime.asyncio.run(exercise())
+
+
+class _FailingRunner(_Runner):
+    async def run_async(self, **kwargs):
+        if False:
+            yield None
+        raise ConnectionError("provider unavailable")
+
+
+class _ErrorEventRunner(_Runner):
+    async def run_async(self, **kwargs):
+        event = _Event()
+        event.error_code = "MAX_TOKENS"
+        event.error_message = "generation limit reached"
+        yield event
+
+
+class _HangingRunner(_Runner):
+    async def run_async(self, **kwargs):
+        await adk_runtime.asyncio.sleep(1)
+        if False:
+            yield None
+
+
+def test_run_data_agent_fails_loudly_without_simulated_fallback():
+    async def exercise():
+        service = MagicMock()
+        service.create_session = AsyncMock()
+        _FailingRunner.instances.clear()
+        with (
+            patch.object(adk_runtime, "InMemorySessionService", return_value=service),
+            patch.object(adk_runtime, "Runner", _FailingRunner),
+            patch.object(adk_runtime, "build_data_agent", return_value=MagicMock()),
+            pytest.raises(AdkRuntimeUnavailable, match="RECOVERABLE-LOCAL"),
+        ):
+            await adk_runtime.run_data_agent("prompt", _config())
+
+        _FailingRunner.instances[0].close.assert_awaited_once()
+
+    adk_runtime.asyncio.run(exercise())
+
+
+def test_run_data_agent_reports_adk_event_error():
+    async def exercise():
+        service = MagicMock()
+        service.create_session = AsyncMock()
+        with (
+            patch.object(adk_runtime, "InMemorySessionService", return_value=service),
+            patch.object(adk_runtime, "Runner", _ErrorEventRunner),
+            patch.object(adk_runtime, "build_data_agent", return_value=MagicMock()),
+            pytest.raises(
+                AdkRuntimeUnavailable,
+                match="MAX_TOKENS: generation limit reached",
+            ),
+        ):
+            await adk_runtime.run_data_agent("prompt", _config())
+
+    adk_runtime.asyncio.run(exercise())
+
+
+def test_run_data_agent_times_out_and_closes_runner():
+    async def exercise():
+        service = MagicMock()
+        service.create_session = AsyncMock()
+        _HangingRunner.instances.clear()
+        with (
+            patch.object(adk_runtime, "InMemorySessionService", return_value=service),
+            patch.object(adk_runtime, "Runner", _HangingRunner),
+            patch.object(adk_runtime, "build_data_agent", return_value=MagicMock()),
+            pytest.raises(AdkRuntimeUnavailable, match="expire apres 0.01 s"),
+        ):
+            await adk_runtime.run_data_agent(
+                "prompt", _config(), timeout_seconds=0.01
+            )
+
+        _HangingRunner.instances[0].close.assert_awaited_once()
+
+    adk_runtime.asyncio.run(exercise())
+
+
+def test_runtime_unavailable_exposes_sota_verdict():
+    assert AdkRuntimeUnavailable.verdict == "RECOVERABLE-LOCAL"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_llm_client.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_llm_client.py
@@ -19,16 +19,15 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 # Make the Track2-GoogleADK package importable (config/ + utils/ siblings).
 _PKG = Path(__file__).resolve().parent.parent
 if str(_PKG) not in sys.path:
     sys.path.insert(0, str(_PKG))
 
-from config.providers import ProviderConfig, ProviderType  # noqa: E402
-from utils import llm_client  # noqa: E402
-from utils.llm_client import LLMClient, get_client  # noqa: E402
+from config.providers import ProviderConfig, ProviderType
+
+from utils import llm_client
+from utils.llm_client import LLMClient, get_client
 
 
 def _cfg(provider, model=None, api_key=None, base_url=None):
@@ -169,17 +168,9 @@ def test_generate_max_tokens_conditional(mock_completion):
     assert "max_tokens" not in mock_completion.call_args_list[-1].kwargs
 
 
-@pytest.mark.xfail(strict=True, reason="max_tokens=0 swallowed by `if max_tokens:` guard (buggy on main); fixed in po-2025 #7394")
 @patch("utils.llm_client.completion")
 def test_generate_max_tokens_zero_is_forwarded(mock_completion):
-    """REGRESSION PIN: max_tokens=0 is a valid int and must be forwarded.
-
-    The legacy `if max_tokens:` guard treated 0 as falsy and silently dropped
-    it (max_tokens never reached litellm). `if max_tokens is not None:` is the
-    correct guard. xfail(strict=True): currently FAILS on main (xfail = green),
-    will XPASS once the sibling fix lands (po-2025 PR #7394) and flip to
-    strict-failure as a reminder to drop the marker. See #7394.
-    """
+    """max_tokens=0 is a valid int and must reach LiteLLM."""
     mock_completion.return_value = _fake_response("ok")
     client = LLMClient(config=_cfg(ProviderType.OPENAI))
     client.generate("hi", max_tokens=0)


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2025:CoursIA — prev: MED/notebook-python #13890

## Résumé

- ajoute un runtime Google ADK 2.8 réel fondé sur `Agent`, `LiteLlm`, `Runner`, `InMemorySessionService` et les événements ADK ;
- route les providers OpenAI-compatibles existants du Track 2, dont Qwen/vLLM, sans réponse simulée ni fallback silencieux ;
- expose les preuves observables d'appel et de réponse de l'outil `dataset_profile` ;
- borne un tour à 120 s et remonte les erreurs ADK/provider avec le verdict `RECOVERABLE-LOCAL` ;
- épingle une stack ADK/LiteLLM résoluble et retire un ancien `xfail` devenu périmé.

## Validation

- `58 passed` : `config/test_providers.py`, `utils/test_adk_runtime.py`, `utils/test_llm_client.py` ;
- Ruff : `All checks passed!` ;
- environnement isolé : `pip check` → `No broken requirements found.` ;
- `py_compile` et `git diff --check` : succès ;
- smoke ADK réel sur OpenAI : 3 événements, appel `dataset_profile`, réponse d'outil `dataset_profile`, réponse LLM finale non vide contenant le résultat 960.

## Verdict SOTA

- **Google ADK : SOTA-OK** — session, runner, événements, appel d'outil, réponse d'outil et réponse LLM ont été exécutés réellement ;
- **Qwen : RECOVERABLE-LOCAL** — le reverse proxy configuré est joignable, mais le credential injecté sur cette machine renvoie HTTP 401. Le runtime échoue explicitement sans fabriquer de sortie. Un reprovisionnement privé a été demandé aux lanes coordinateur/hébergement ; le même smoke Qwen reste l'acceptance résiduelle.

Cette PR livre donc le socle non-collidant et ses preuves sans prétendre que l'authentification Qwen est déjà réparée. La migration des notebooks est suivie séparément par #13925.

See #13924
See #3801
