### PR TITLE
fix(genai,#13750): tranche orphelins racine -- disposition e2e + visibilite tutorials/shared

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -302,6 +302,12 @@ Les **prochaines étapes** recommandées après ce parcours : explorer les **ép
 
 ## Annexes
 
+### Guides, outillage et validation
+
+- [`tutorials/`](tutorials/README.md) — guides pratiques approfondis (DALL-E 3, GPT-5 image, écosystème OpenRouter, workflows éducatifs) : la vue d'ensemble réutilisable là où les notebooks démontrent pas à pas.
+- [`shared/helpers/`](shared/helpers/README.md) — bibliothèque partagée Python de la série (clients services GenAI, helpers audio/vidéo, tests).
+- [`_research/e2e_quant_validation.ipynb`](_research/e2e_quant_validation.ipynb) — validation bout-en-bout des services quantifiés post-migration (Z-Image vLLM GGUF Q4_KM, Qwen Image Edit Nunchaku INT4, Wan 2.1 T2V) : health check, latence de génération, VRAM GPU. Artefact de référence de la stack, complémentaire à `python scripts/genai-stack/genai.py validate --full`.
+
 ### Démarrage rapide
 
 #### 1. Configuration

--- a/MyIA.AI.Notebooks/GenAI/_research/e2e_quant_validation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/_research/e2e_quant_validation.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GenAI E2E Quant Validation\n",
     "\n",
-    "**Navigation** : [Index](README.md)\n",
+    "**Navigation** : [Index](../README.md)\n",
     "\n",
     "\n",
     "**Purpose:** Reproducible end-to-end validation of quantized GenAI services post-migration.\n",
@@ -26,7 +26,7 @@
     "- ComfyUI Video (Wan 2.1 T2V) — port 8189\n",
     "\n",
     "**Metrics captured:** Output preview, generation latency, GPU VRAM usage.\n",
-    "**Date:** 2026-05-12 | **Branch:** feat/cycle25-genai-e2e-quant-po2023"
+    "**Date:** 2026-05-12 | **Branch:** feat/cycle25-genai-e2e-quant-po2023\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/README.md
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/README.md
@@ -1,0 +1,10 @@
+# shared/helpers — bibliothèque partagée GenAI
+
+Helpers Python transverses de la série GenAI, importés par les notebooks via `sys.path` ou directement.
+
+- `genai_helpers.py`, `genai_service.py` — appels services GenAI (réseau, retries, formats).
+- `comfyui_client.py` — client ComfyUI (workflows, polling, récupération d'assets).
+- `audio_helpers.py`, helpers vidéo — encode/décodage et montage des sorties Audio/Video.
+- `test_genai_helpers.py`, `test_video_helpers.py` — tests unitaires (`pytest shared/helpers/`).
+
+Règles : pas de secret en dur (`.env` + `os.getenv`), pas d'emoji, type hints Python 3.10+.


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA-2 — prev: LIGHT/notebook-python #13931

## Summary

Tranche « orphelins racine GenAI » de #13750 (items 1-4 de la section « Orphelins / mal parentés ») : l'e2e invisibilité racine est résolue, tutorials/ et shared/helpers/ deviennent découvrables depuis le README de la série.

**Correction de classification au passage (premierhand)** : le body classe `_e2e_quant_validation.ipynb` comme « sujet QuantConnect ». Contenu réel vérifié : « Reproducible end-to-end validation of **quantized GenAI services** post-migration » (Z-Image vLLM GGUF Q4_KM :8001, Qwen Image Edit ComfyUI Nunchaku INT4 :8188, Wan 2.1 T2V :8189 — latence + VRAM). « quant » = quantization, pas QuantConnect. La prescription « déplacer sous QuantConnect/research/ » est donc vide ; la disposition retenue suit l'alternative du body (« vérifier consommateurs d'abord » : 0 consommateur, `git grep` vide).

## Changements

1. **`_e2e_quant_validation.ipynb` → `_research/e2e_quant_validation.ipynb`** (`git mv`, similarité 99 % — seule la cellule nav `[Index](README.md)` → `[Index](../README.md)` change). Exécution préservée : 13 cellules / 7 code / 0 `execution_count` null / 0 output vide (vérifié post-round-trip). L'artefact rejoint le répertoire des non-série ; underscore racine retiré.
2. **README GenAI** : nouvelle sous-section « Guides, outillage et validation » (Annexes) — liens vers `tutorials/` (item 2 : plus jamais non-référencé), `shared/helpers/` et le notebook e2e déplacé. Marqueur `CATALOG-STATUS` inchangé (byte-identique, HARD 1 catalog-pr-hygiene).
3. **`shared/helpers/README.md`** créé (item 3) : rôle de la bibliothèque (clients services, ComfyUI, audio/vidéo, tests), importée par 00-Environment/Audio/Video (vérifié `git grep`).
4. **`debate.txt`** (item 4) : déjà absent du disque — rien à faire, consigné ici.

## Hors périmètre (grains séparés, restent ouverts sur #13750)

- Série Texte plate (29 ipynb) : structuration en niveaux — demande arbitrage renum vs README par regroupement.
- `Audio/v4/` pipeline 25 .py : move vers scripts/ avec vérification imports.
- `_research/qwen_sae_inventory.md` mal parenté (renvoyé à l'issue docs/ par le body).

## Hygiène locale (hors git)

Le jumeau `_e2e_quant_validation_output.ipynb` (896 Ko, 12 mai) était **untracked** (jamais commité, résidu papermill local) — supprimé du disque, aucune incidence sur le dépôt.

## Note CI

`regen_quarto_render.py --check` échoue sur cette branche pour le drift **préexistant sur main** (identique +25/−8, 0 ligne e2e/_research dans le diff — vérifié) : fix déjà porté par PR #13931 en attente de merge. Si le garde render-drift rougit ici, il rougit pour main, pas pour ce diff.

See #13750 (contribution partielle : 4 items de la section orphelins sur les 3 axes du body).
