### PR TITLE
Enrichissement markdown-only separer-les-environnements-de-vecteurs (559 -> 1210 c/cell) — tranche 1 #13934

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/separer-les-environnements-de-vecteurs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/separer-les-environnements-de-vecteurs.ipynb
@@ -22,6 +22,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "505238d3",
+   "metadata": {},
+   "source": "### Comment lire ce notebook\n\nLe notebook a deux parties, chacune démontée en quatre temps : la mise en\nscène (une fixture synthétique), le geste (l'appel de fonction), la\nsortie (committée, donc vérifiable), la **lecture** (une section qui\nrelit la sortie ligne à ligne — jamais l'intention). La première partie\nmontre une **fuite de lecture** : un visiteur public reçoit du contenu\nréservé. La deuxième montre une **destruction d'écriture** : une\nréindexation mal ciblée écrase un corpus voisin. Les deux défaillances\nsont les deux faces d'une même cause — la partition par environnement\nest un contrôle d'accès que rien ne protège par défaut.\n\nDeux conventions de lecture, à connaître avant d'aller plus loin.\nD'abord, **chaque chiffre cité dans les interprétations figure dans une\nsortie committée** au-dessus : rien n'est affirmé qui ne soit imprimé\npar une cellule, et la graine fixe garantit qu'une ré-exécution\nreproduit ces sorties à l'identique. Ensuite, les sections « Lecture »\npratiquent la relecture **adverse** : elles cherchent ce que la sortie\nne dit pas, ou ce qu'un lecteur pressé y lirait de travers (un 20 %\nfavorable, un 0 % qui n'est pas une amélioration, une victime choisie\npar accident). La méthode du notebook est exactement son sujet : une\naffirmation sur un système ne vaut que si elle est ancrée dans une\nsortie que quiconque peut reproduire.\nPour une lecture pressée, trois arrêts suffisent : les deux sections\n**Lecture** (après chaque défaillance mesurée) puis **La leçon, mesurée**\nen fin de parcours. Le reste — la mise en scène, les protocoles, les\nfrontières — approfondit chaque arrêt. Et si une seule phrase devait\nrester : les deux défaillances de ce notebook n'ont été visibles nulle\npart sur l'installation réelle qui les a inspirées, parce que **aucune\nsonde ne les mesurait** — tout le reste n'est que la mise en œuvre de\ncette constatation."
+  },
+  {
+   "cell_type": "markdown",
    "id": "c2ea73c9",
    "metadata": {},
    "source": [
@@ -46,6 +52,12 @@
     "rendra la fuite possible, et qui montre pourquoi le contrôle d'accès ne\n",
     "peut pas se déduire de la seule distance vectorielle."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cdb7286",
+   "metadata": {},
+   "source": "### Lire la table des six régimes comme une carte de risques, pas une liste\n\nSix environnements, quatre régimes d'accès seulement (`ouvert`, `réservé`,\n`confidentiel`, `interne`) : la table ci-dessus n'est pas une nomenclature\nde rangement, c'est une **carte de risques**. Le risque de fuite d'un\nenvironnement ne dépend pas de son régime seul, mais du produit\n**proximité sémantique × distance de régime** avec chacun de ses voisins.\n`vitrine` et `logistique` sont `ouvert` et `interne`, mais ils parlent de\nchoses sans aucun rapport (œuvres mises en avant d'un côté, fiches\nfournisseurs de l'autre) : leur proximité sémantique est faible, donc un\nretrieval non filtré a peu de chances de ramener l'un quand on cherche\nl'autre. À l'inverse, `catalogue_public` et `comite_lecture` partagent le\nrégime le plus défavorable qui soit — deux publics dont l'un a le droit de\nvoir et l'autre pas (`ouvert` contre `réservé`) — **autour des mêmes\nœuvres** : proximité sémantique maximale, distance de régime maximale.\nC'est exactement là que la fuite se concentrera, et ce n'est pas un hasard\nde fixture : dans une vraie maison d'édition, les fichiers de rélecture\ncommentent les mêmes textes que le catalogue public.\n\nCette lecture a une conséquence pratique pour l'audit d'un vrai store :\n**on n'audite pas six environnements, on audite les paires**. Enumérer les\nenvironnements et leurs régimes ne suffit pas ; il faut la matrice des\nproximités (quels environnements parlent des mêmes sujets ?) croisée avec\nla matrice des régimes (quels couples ont des droits différents ?). Les\ncases à haut risque de cette matrice sont les candidats au test de fuite\nci-dessous — les autres peuvent attendre. Un audit qui traite les\nenvironnements indépendamment les uns des autres rate la structure même du\nrisque, qui vit **entre** eux.\n\nReste une différence avec un audit réel : ici, la matrice est connue\nd'avance — la cellule de construction ci-dessous *déclare* le couplage\n`catalogue_public / comite_lecture` (le décalage `scale=0.6`). Sur un vrai\nstore, personne ne déclare rien : les proximités doivent être **découvertes**\npar la mesure — par exemple en comparant les centroïdes d'environnements\n( moyenne des vecteurs de chaque environnement, similarité cosinus entre\ncentroïdes), puis en classant les paires par proximité avant de tester\ncelles qui cumulent proximité sémantique et régimes distincts. La carte\ndes risques d'un store réel est un résultat d'analyse, pas une donnée de\nconfiguration — et c'est précisément pour cela qu'elle n'est dressée\nnulle part : personne ne la demande tant que rien n'a fui.\nUne dernière précision, sur le **sens** de la fuite : le risque n'est pas\nsymétrique. Du public vers le réservé, il n'y a pas de fuite d'accès — un\nmembre du comité qui reçoit du contenu public a le droit de le voir ; la\nseule dégradation est qualitative (du bruit dans ses résultats). C'est le\nsens inverse qui compte — `comite_lecture` vers `catalogue_public` —\nparce que c'est le seul qui livre du contenu protégé à qui n'y a pas\ndroit. Un test de fuite qui tournerait « dans tous les sens » diluerait\nson verdict dans du faux positif ; le protocole doit cibler les requêtes\némises **depuis les régimes les moins privilégiés**. La carte des risques\ngagne donc une flèche : chaque paire à risque porte un sens, du régime\nsupérieur vers le régime inférieur."
   },
   {
    "cell_type": "code",
@@ -75,6 +87,12 @@
     "    \"vitrine\",\n",
     "]"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77578c67",
+   "metadata": {},
+   "source": "### Le contrat de dépendances — et une défaillance conçue pour être falsifiable\n\nTrois lignes de configuration ouvrent le notebook : une graine\n(`default_rng(7)`), une dimension (`DIM = 16`), une liste\n(`ENVIRONNEMENTS`). Autour d'elles, le contrat de dépendances tient en un\ncommentaire : **numpy uniquement, aucun réseau, aucune clé, aucun\nmodèle**. Ce n'est pas une économie de moyens, c'est une décision\npédagogique doublée d'une garantie épistémologique. Pédagogique : tout\nlecteur peut exécuter l'intégralité de la démonstration sans compte, sans\nGPU, sans facture — la barrière d'entrée du contrôle est nulle, alors\nqu'elle est énorme sur une vraie plateforme (une installation, des clés,\nun corpus). Épistémologique : sans appel réseau, le résultat ne dépend\nd'aucun service externe qui aurait changé entre l'écriture et la\nrelecture — les chiffres committés ne périment pas.\n\n`DIM = 16` mérite un mot : seize dimensions suffisent à donner aux six\nnuages une structure stable et lisible (des directions bien séparables),\ntout en restant petit assez pour que les distances se raisonnent à la\nmain. Une vraie plateforme embarbe sur des milliers de dimensions et une\nsimilarité cosinus ; la géométrie diffère en degré, pas en nature — ce\nqui compte ici est le mécanisme, pas l'échelle.\n\nLe plus important : **la défaillance de ce notebook est falsifiable par\nconstruction**. La cause de la fuite — le couplage des deux nuages — est\nune ligne de fixture, pas une propriété profonde de la plateforme. Un\nlecteur sceptique peut ouvrir la cellule suivante, remplacer le décalage\ndu couplage (`scale=0.6`) par un décalage de l'ordre des centroïdes\n(`scale=3.0`), ré-exécuter : les nuages se séparent, la fuite disparaît.\nLa démonstration ne dit pas « la fuite est inévitable » ; elle dit « la\nfuite apparaît quand des environnements sémantiquement voisins ont des\nrégimes distincts, et disparaît quand on éloigne les contenus ». Une\naffirmation dont on peut supprimer la cause pour la tester est la seule\nqui vaille d'être committée."
   },
   {
    "cell_type": "markdown",
@@ -140,6 +158,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "32f4fd3d",
+   "metadata": {},
+   "source": "### Ce que la sortie affirme — et comment la fixture est construite pour exhiber la défaillance\n\nLa sortie committée annonce `6 environnements, 240 chunks au total,\ndimension 16`, avec exactement `40 vecteurs` par environnement. Deux\nlectures s'imposent, une sur le nombre, une sur la construction.\n\n**Sur le nombre** : un vrai store n'est pas équilibré — un catalogue\npublic compte des centaines de chunks quand une archive de direction en\ncompte dix. L'équilibre ici n'est pas du réalisme, c'est un choix de\nmesure : à effectif égal, le top-5 d'une recherche non filtrée donne à\nchaque environnement la même chance *statistique* d'apparaître. La fuite\nqu'on mesurera plus bas ne pourra donc pas être imputée à un effet de\nvolume (« l'environnement envahissant n'était que plus gros ») ; elle ne\npourra venir que de la **géométrie** — les vecteurs eux-mêmes. C'est la\nvariable qu'on veut isoler, et l'équilibrage est l'instrument qui\nl'isole. À l'inverse, un lecteur qui voudrait étudier l'effet de volume\nn'aurait qu'à casser l'équilibre (`N_PAR_ENV` distinct par environnement)\net observer une seconde cause de fuite : un environnement majoritaire\nenvahit mécaniquement les top-k globaux sans aucune proximité\nsémantique — deux mécanismes de fuite indépendants, un seul visible dans\nun store donné selon sa distribution.\n\n**Sur la construction** : les trois échelles numériques du code se lisent\ncomme un programme. Centroïdes tirés à `scale=3.0` : six directions bien\ndistinctes dans l'espace. Bruit des chunks à `scale=1.5` : des nuages\nassez compacts pour rester reconnaissables. Couplage\n`comite_lecture = catalogue_public + bruit(scale=0.6)` : un décalage\n**cinq fois plus petit** que l'écart typique entre environnements — les\ndeux nuages se chevauchent partiellement. La fixture n'essaie pas de\nsimuler une distribution réaliste de contenus : elle **fabrique les\nconditions exactes de la défaillance à démontrer**, et l'assume. Un\nlecteur qui reproduirait l'expérience avec des centroïdes tous éloignés\nverrait une fuite nulle et conclurait à tort que le filtre est superflu —\nla réponse serait dans sa fixture, pas dans la plateforme.\n\n**Sur la reproductibilité** : la graine `RNG = default_rng(7)` rend le\nstore déterministe — chaque exécution re-dérive exactement les 240 mêmes\nvecteurs. Chaque affirmation chiffrée de ce notebook (le taux de fuite,\nle compte après accident) peut donc être re-vérifiée par quiconque\nrelance les cellules : rien ne repose sur un tirage qui aurait bien\ntourné une fois. La graine a aussi un second rôle, moins visible : elle\nrend l'**accident de réindexation** de la deuxième partie reproductible\nlui aussi — la victime, les comptes avant/après, tout se rejoue à\nl'identique, ce qui est la condition pour qu'un rapport d'incident\ndémonstratif vaille preuve."
+  },
+  {
+   "cell_type": "markdown",
    "id": "be8ab602",
    "metadata": {},
    "source": [
@@ -192,6 +216,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e9c94b5d",
+   "metadata": {},
+   "source": "### Le contrat de `retrieve` : la sécurité logée dans un paramètre par défaut\n\nAvant de regarder les résultats, arrêtons-nous sur la signature :\n`retrieve(query, store, k=5, filtre=None)`. Lire une API du point de vue\nde la sécurité, c'est d'abord regarder ses **défauts** — ce qui se passe\nquand l'appelant fait l'effort minimal. Ici, le chemin sans effort est\n`filtre=None`, et le code est explicite : ce chemin balaie **tous** les\nenvironnements. Autrement dit, le comportement dangereux n'est pas une\nerreur de manipulation à contourner : c'est la **valeur par défaut**,\ncelle que prend l'appel quand on ne réfléchit pas. Un design sûr par\ndéfaut exigerait l'inverse — `filtre` obligatoire, sans valeur par\ndéfaut, l'appelant devant nommer l'environnement qu'il revendique. La\ndocumentation (`# dangereux`) est ici la seule barrière, et une docstring\nne filtre rien : elle informe celui qui la lit, elle ne contraint personne.\n\nDeuxième lecture, structurelle : le filtre s'applique **avant** le\nclassement. La fonction construit `vecs` uniquement à partir des\nenvironnements cherchés, puis fait le top-k sur cet espace réduit. Une\nimplémentation naïve ferait l'inverse — chercher les k plus proches\nglobaux puis retirer ceux du mauvais régime — et cette variante aurait\ndeux défauts : elle rendrait moins de k résultats (les intrus retirés ne\nsont pas remplacés), et surtout elle aurait **classé** les chunks par\nproximité globale avant de trier, laissant la distance décider de ce qui\nreste. Restreindre avant de classer, c'est ce qui fait du filtre un\ncontrôle d'accès et pas un cosmétique de présentation.\n\nTroisième lecture, instrumentale : la liste `labels`, remplie en parallèle\nde `vecs`, est ce qui rendra la fuite **mesurable**. Sans elle, on\nrecevrait cinq vecteurs sans provenance, et la question « d'où viennent\nces résultats ? » resterait sans instrument. L'instrumentation de la\ndéfaillance est ici co-localisée avec la fonction qui peut la causer —\nun choix de conception à imiter quand on audite une vraie API : la\nprovenance des résultats fait partie du contrat, ou rien ne peut être\nprouvé. Et une quatrième lecture, transversale : les **autres paramètres\nportent aussi du risque**. `k` est un paramètre d'exposition (la section\nsuivante montre l'intrus entrer au rang exact de k). Et l'argument\n`store` lui-même : rien n'empêche de passer un autre store que le sien —\nla fuite cross-environnement et la fuite cross-store sont **le même bug\nun étage plus haut**. Une API de retrieval fait confiance à chacun de\nses arguments ; la sécurité ne réside dans aucun d'eux, mais dans ce qui\nles choisit."
+  },
+  {
+   "cell_type": "markdown",
    "id": "ef855592",
    "metadata": {},
    "source": [
@@ -201,6 +231,12 @@
     "cherche les 5 chunks les plus proches. Si l'environnement cible n'est pas\n",
     "précisé, le retrieve balaie tout le store."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87db8392",
+   "metadata": {},
+   "source": "### Le protocole du test, avant son résultat\n\nLa cellule qui suit exécute le test le plus simple qui expose la fuite.\nUn test bien lu vaut mieux qu'un résultat bien interprété : son protocole\ntient en quatre choix, et chacun mérite d'être vu.\n\n**Le choix de la requête.** C'est un chunk de `catalogue_public` — un\npoint *à l'intérieur* du nuage public, donc un cas **favorable** : la\nrequête est entourée de ses pairs, qui occupent naturellement les\npremiers rangs. On teste le mécanisme dans les conditions les plus\ndouces ; un cas défavorable (une requête dans la zone de chevauchement,\nprès de la frontière des deux nuages) fuirait davantage. Où est la\nfrontière ? Dans cette fixture, elle est *connaissable* : à mi-chemin\ndes centroïdes des deux environnements. Les requêtes les plus\nrévélatrices d'un vrai test seraient tirées précisément là — non pas au\ncœur d'un nuage, mais à l'endroit où les régimes s'entremêlent. C'est la\ndifference entre tester ce qu'on sait voir et tester là où ça casse.\n\n**Le choix de k.** Cinq résultats : assez pour qu'un intrus ait sa\nchance, assez peu pour que la fuite reste lisible à l'œil dans la liste.\nk est un paramètre du test autant que du système : un k trop petit peut\ncacher la fuite (l'intrus entre au rang k, on l'a vu), un k trop grand\nla rend massive mais statistiquement banale. Le protocole honnête\nbalaye k — encore l'exercice 1.\n\n**Le choix de l'attendu.** `environnement_attendu = \"catalogue_public\"`\nest la norme du test : tout ce qui n'est pas lui est un intrus, par\ndéfinition. Ce choix est trivial ici ; il ne l'est pas dans un vrai\nsystème multi-environnements, où certaines recherches sont *légitimement*\nmulti-régimes (un membre du comité cherche dans catalogue **et** comité).\nLe test de fuite d'une vraie installation commence par décider quelles\nrequêtes ont droit à quels régimes — c'est une politique, pas un\nparamètre.\n\n**Le choix de la grandeur.** Le taux (fraction du top-k hors régime\nattendu) plutôt qu'un booléen : un test binaire « fuite oui/non » perd\ntout le gradient — 20 % sur k=5, c'est un chunk réservé livré au\npublic ; à 60 %, c'est la majorité de la réponse. Le gradient est ce\nqui permet de suivre une dérive, pas seulement de constater un état.\n**Le choix de l'état du store.** Le test s'exécute sur le store tel que\nconstruit — intact, équilibré. C'est le bon état pour un premier test,\nmais pas le seul qui compte : les bugs d'accès peuvent être\n**état-dépendants** (un store muté, réindexé partiellement, ou déséquilibré\nse comporte autrement). Détail d'hygiène visible dans ce notebook : la\ndeuxième partie **mute** le store (l'accident détruit `catalogue_public`),\net les tests de fuite tournent avant — l'ordre des parties n'est pas\nnarratif, il est expérimental. Toute suite de tests qui mutent leur sujet\ndoit soit restaurer l'état, soit s'exécuter du moins destructeur au plus\ndestructeur ; sinon, un résultat dépend de cellules qui tournent avant,\net la ré-exécution d'une cellule isolée ne reproduit plus rien."
   },
   {
    "cell_type": "code",
@@ -239,6 +275,12 @@
     "    intrus = [r for r in top5_sans_filtre if r != \"catalogue_public\"]\n",
     "    print(f\"  -> un visiteur public reçoit du contenu de : {intrus}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffed3d95",
+   "metadata": {},
+   "source": "### Lire le top-5 : l'intrus entre exactement au rang k\n\nLa sortie committée mérite une lecture lente, ligne par ligne :\n\n```\nTop-5 sans filtre : ['catalogue_public', 'catalogue_public',\n                     'catalogue_public', 'catalogue_public', 'comite_lecture']\nTaux de fuite : 20%\n```\n\nQuatre chunks publics, puis — **au cinquième rang, le dernier demandé** —\nun chunk du comité de lecture. L'intrus ne se glisse pas au milieu du\nclassement : il entre **à la frontière de k**. C'est structurel : la\nrequête est elle-même un chunk de `catalogue_public`, donc ses plus\nproches voisins sont d'abord ses pairs du même nuage ; ce n'est qu'une\nfois les voisins immédiats épuisés que la zone de chevauchement avec le\nnuage du comité commence à livrer ses chunks. La conséquence pratique est\ndirecte : **augmenter k, c'est ouvrir la porte**. À k=3, cette requête ne\nfuirait pas ; à k=10, elle fuirait davantage ; à k=240, elle renverrait\ntout le store. Le paramètre k, présenté comme un réglage de confort de\nrecherche, est un paramètre d'exposition — et c'est précisément ce que\nl'exercice 1 demande de mesurer sur une batterie de requêtes.\n\nIl faut aussi lire la nature de la requête, car la fixture prend ici une\nliberté avec la production : `requete = store[\"catalogue_public\"][0]` —\nla requête **est un chunk du store**, donc un point **à l'intérieur** du\nnuage public, entouré de ses pairs. Dans un système réel, la requête est\nle vecteur d'une *question* posée par un visiteur : elle est proche de\nses réponses, mais pas au cœur d'un nuage préexistant — elle se situe\nquelque part entre les nuages. Une requête réelle a donc toutes les\nchances de fuir **davantage** que ce 20 %, car elle est moins protégée\npar la densité de pairs autour d'elle. Le chiffre committé est une borne\nfavorable, pas un plafond : la fixture minimise la fuite en choisissant\nle cas le plus facile à raisonner.\n\nLe chiffre de 20 % doit enfin être lu pour ce qu'il est : **une requête,\nun tirage**. Cette requête-ci tombe dans une zone du nuage public encore\nproche de son centre ; d'autres requêtes, tirées plus profondément dans\nla zone de chevauchement, ont des voisins comité plus proches que leurs\nvoisins publics — leur fuite sera plus forte. Une métrique de production\nne retient ni un best case ni un tirage isolé : elle résume une\ndistribution (moyenne **et pire cas**). Le singleton de cette cellule\ndémontre le **mécanisme** ; la batterie de l'exercice mesure\nl'**ampleur**."
   },
   {
    "cell_type": "markdown",
@@ -294,6 +336,12 @@
     "print(f\"  sans filtre : {fuite:.0%} de fuite (contenu réservé livré au public)\")\n",
     "print(f\"  avec filtre : {fuite_f:.0%} de fuite (recherche scopée au régime attendu)\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "080fe639",
+   "metadata": {},
+   "source": "### 0 % n'est pas une amélioration du retrieve — c'est un autre retrieve\n\nLa comparaison finale condense tout en deux lignes : `sans filtre : 20%\nde fuite`, `avec filtre : 0%`. La tentation est de lire « le filtre\naméliore la recherche ». La lecture exacte est plus forte et plus\ndérangeante : **ce ne sont pas deux qualités d'une même recherche, ce\nsont deux recherches différentes**. Même requête, mais deux espaces :\n240 chunks d'un côté, 40 de l'autre. Le top-5 filtré n'est pas le top-5\nnon filtré débarrassé de son intrus — les cinq chunks retenus sont les\nmeilleurs **parmi le régime seul**, un classement qui n'existait pas dans\nla recherche globale. Le filtre ne corrige pas un défaut du retrieve ; il\nchange la question posée (« les chunks les plus proches **que ce\nvisiteur a le droit de voir** »).\n\nCela fixe ce que le filtre **ne fait pas**, et c'est le point le plus\nimportant de cette section : `filtre` est un argument comme un autre.\nN'importe quel appelant peut écrire `retrieve(requete, store, k=5,\nfiltre=\"comite_lecture\")` — la fonction fait confiance à l'appelant sur\nla légitimité du régime demandé. Le contrôle d'accès réel vit donc\n**en amont** : dans ce qui décide de la valeur de `filtre` pour un\nvisiteur donné (la configuration du chatbot, la session, les droits de\nl'utilisateur authentifié). C'est la distinction entre le persona et\nl'autorité : un prompt système peut *prier* le chatbot de rester public,\nune partition correctement câblée l'y *contraint* — et réciproquement,\nune partition correcte câblée sur le mauvais filtre contraint le\nchatbot... à fuir dans l'autre sens. La bonne question d'audit n'est pas\n« y a-t-il un filtre ? » mais **« qui choisit la valeur du filtre, et au\nnom de quoi »**.\n\nCette question a un test opérationnel, et il se joue côté serveur :\nvérifier que la valeur de `filtre` vient d'une **configuration liée à\nl'identité authentifiée** (le chatbot public est câblé sur\n`catalogue_public`, point final), et non d'un paramètre que la requête\ncliente peut porter — car un paramètre que le client choisit n'est pas\nun contrôle d'accès, c'est une suggestion. Le test négatif est\ndécisif : appeler l'API **en tant que visiteur public** en demandant\n`filtre=\"comite_lecture\"` ; si l'API obéit, le filtre n'est pas une\nfrontière — il est un bouton dans la main de celui qu'il devait arrêter.\nUn contrôle d'accès qui ne refuse jamais n'est pas silencieux : il est\nabsent."
   },
   {
    "cell_type": "markdown",
@@ -380,6 +428,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a510cf24",
+   "metadata": {},
+   "source": "### Pourquoi la victime est `catalogue_public` : un accident d'ordre d'insertion\n\nRegardons la sortie comme un rapport d'incident :\n\n```\nAVANT :  catalogue_public : 40 vecteurs   |  comite_lecture : 40 vecteurs\nreindexer(..., environnement=None) a écrit dans : catalogue_public\nAPRÈS :  catalogue_public : 12 vecteurs   |  comite_lecture : 40 vecteurs\n```\n\nL'intention était de réindexer **la vitrine** ; la vitrine est intacte.\nLa victime est `catalogue_public` — un tiers qui n'était ni la cible ni\nl'auteur du geste. Pourquoi lui ? Parce que `reindexer` écrit dans\n`next(iter(store))` : le **premier environnement du dictionnaire**, au\nsens de l'ordre d'insertion Python. Et le premier inséré était\n`catalogue_public`... parce qu'il était premier dans la liste\n`ENVIRONNEMENTS` de la cellule de setup. La « destination par défaut »\nn'est pas un choix — c'est un **artefact d'ordre de déclaration**. Dans\nune autre installation, le même oubli aurait détruit un autre\nenvironnement : la victime est déterminée par un détail de code sans\nrapport avec l'intention de l'opérateur.\n\nLe mécanisme de destruction lui-même tient en une ligne : `store[cible] =\nnouveau_corpus` — une affectation qui **remplace la référence** à l'ancien\ntableau. Pas de fusion, pas de version, pas de corbeille : les 40 chunks\nd'origine cessent d'être atteignables à l'instant de l'affectation, et 28\nd'entre eux (40 - 12) n'existent plus nulle part. Aucune erreur, aucun\navertissement — la fonction a fait exactement ce qu'on lui a demandé.\nC'est la définition même de l'accident silencieux : **le système ne peut\npas signaler ce qu'il ne considère pas comme une faute**, et une\naffectation n'est jamais une faute pour Python. Le signalement doit donc\nvenir d'ailleurs — du comptage avant/après, seul instrument de la\ncellule suivante.\n\nCe schéma — une API d'écriture dont un argument absent déclenche une\ndestruction sans diagnostic — est une **classe**, pas un cas isolé. Le\nvrai `reindexer` d'une plateforme vectorielle en donne d'autres\ninstances : une réindexation sans environnement cible écrit « quelque\npart » (première collection, collection par défaut, celle du contexte) ;\nune suppression sans condition vide le namespace entier. La signature\ncommune : l'argument par défaut choisit **une cible destructrice** plutôt\nque de refuser. Le remède de conception est toujours le même — faire de\nl'absence d'argument un **refus** — et c'est exactement la variante que\nl'exercice 2 demande d'écrire."
+  },
+  {
+   "cell_type": "markdown",
    "id": "6d55778b",
    "metadata": {},
    "source": [
@@ -395,6 +449,12 @@
     "sans préciser l'environnement cible écrase un corpus voisin ». Le comptage\n",
     "avant/après est le seul instrument qui révèle l'accident."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0efecfe",
+   "metadata": {},
+   "source": "### Ce que la graine répare — et ce que rien ne répare\n\nIl faut être honnête sur une commodité dont dispose ce notebook et dont\naucun store de production ne dispose : **ici, l'accident est réversible**.\nLes 40 chunks détruits de `catalogue_public` peuvent être re-dérivés à\nl'identique en relançant les cellules de construction — la graine fixe\n(`default_rng(7)`) garantit que le RNG re-produit exactement les mêmes\nvecteurs. Le notebook peut se permettre de détruire des données parce\nque sa fixture est déterministe : c'est une propriété de l'environnement\nd'expérience, pas de la défaillance étudiée.\n\nDans un vrai store, il n'y a pas de graine. Les vecteurs détruits\nprovenaient d'un modèle d'embeddings appliqué à des documents réels.\nRé-indexer ces mêmes documents reconstruit des vecteurs *équivalents* —\nmais « équivalent » n'est pas « identique » : si le modèle d'embeddings a\nchangé de version entre l'indexation initiale et la restauration, les\nnouveaux vecteurs ne sont pas ceux d'avant. Les voisins se déplacent\nlégèrement, les classements top-k varient aux marges, et la qualité de\nretrieval dérive d'une quantité que personne n'a mesurée parce que\npersonne n'a pensé à la mesurer. La restauration complète exige donc\ntrois choses : les **documents sources** (le store ne les contient pas —\nun vector store ne stocke que des vecteurs et des métadonnées), la\n**version exacte du modèle d'embeddings**, et un **comptage de contrôle**\naprès reconstruction. Le taux de fuite et le comptage de la leçon\nci-dessus ne font que **détecter** ; la récupération est une chaîne de\nprovenance, et elle s'est envolée avec les 28 chunks.\n\nLe corollaire opérationnel se range en trois lignes de procédure, à\nécrire avant l'accident et pas après : (1) sauvegarder les **documents\nsources** avec leur découpage (le chunking fait partie de la provenance —\nre-découper autrement change les vecteurs même à modèle constant) ;\n(2) consigner la **version du modèle d'embeddings** à côté du store,\ncomme on versionne un schéma de base de données ; (3) vérifier après\ntoute restauration que le comptage par environnement **et** un\néchantillon de requêtes de contrôle rendent les mêmes résultats\nqu'avant. Un store qui n'a pas ces trois lignes n'est pas recoverable :\nil est seulement re-créable — et ce n'est pas la même propriété."
   },
   {
    "cell_type": "markdown",
@@ -423,6 +483,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e586743d",
+   "metadata": {},
+   "source": "### Les frontières de la mesure\n\nLes deux métriques de la leçon — taux de fuite et comptage avant/après —\nsont les bons instruments pour ce notebook, à condition de savoir ce\nqu'elles ne mesurent **pas**. Quatre frontières, dans l'ordre d'importance\npratique :\n\n1. **Une requête n'est pas une distribution.** Le 20 % ci-dessus est un\n   tirage unique, favorable. La métrique déployable est une batterie de\n   requêtes résumée par sa moyenne **et son pire cas** — un seul chiffre\n   moyen peut masquer une requête qui fuit à 80 %. C'est l'objet de\n   l'exercice 1, qui fait passer la mesure du mécanisme à l'ampleur.\n\n2. **La détection n'est pas la prévention.** Un taux de fuite mesuré l'a\n   été *après* que le contenu a fui : la métrique constate, elle\n   n'empêche pas. La prévention, c'est le filtre correctement câblé —\n   c'est-à-dire la question « qui choisit la valeur de `filtre` » de la\n   section précédente. Les deux se complètent : le câblage prévient, la\n   métrique vérifie que le câblage tient dans le temps (une\n   reconfiguration peut l'avoir défait silencieusement — le câblage\n   d'origine n'est pas une garantie éternelle, c'est un état à\n   re-vérifier).\n\n3. **La géométrie de démonstration n'est pas la géométrie de\n   production.** Des nuages gaussiens en distance L2 sur 16 dimensions\n   ne se comportent pas comme des embeddings réels en similarité\n   cosinus sur des milliers de dimensions. Ce qui se transfère n'est pas\n   le chiffre, c'est la **structure** : la distance ignore le régime\n   d'accès, donc la fuite se concentre sur les paires\n   sémantiquement proches à régimes distincts. Le même raisonnement vaut\n   pour la requête-chunk du point précédent : une vraie question, hors\n   des nuages, fuit plus que le point intérieur choisi ici.\n\n4. **Aucun modèle d'utilisateur ici.** Le notebook fait confiance à\n   l'appelant pour la valeur du filtre ; une installation réelle lie le\n   filtre à l'identité authentifiée de l'appelant. Le jour où la mesure\n   de fuite d'un store réel est verte alors qu'un test manuel montre le\n   contraire, la première hypothèse à vérifier est celle-ci : la\n   batterie mesure-t-elle avec les **mêmes droits que les visiteurs\n   réels**, ou avec un compte privilégié qui contourne ce que la\n   production applique ? Une sonde verte sous un compte admin ne dit\n   rien du parcours visiteur.\n\nUne sonde par classe de défaillance, et aucune sonde ne certifie à la\nplace des autres : la fuite et l'écrasement avaient chacun besoin du\nleur."
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ed4f465",
    "metadata": {},
    "source": [
@@ -432,6 +498,12 @@
     "Aucun n'est corrigé — à toi de compléter le geste à partir des fonctions\n",
     "déjà définies (`retrieve`, `taux_de_fuite`, `reindexer`)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df80de4d",
+   "metadata": {},
+   "source": "### Mesurer, protéger, surveiller : pourquoi cet ordre\n\nLes trois exercices qui suivent ne sont pas trois variations sur un\nthème : chacun incarne une **posture** différente devant les deux\ndéfaillances, et leur ordre est le programme.\n\nL'exercice 1 (**mesurer**) fait passer la fuite du cas unique à la\ndistribution : moyennes sur une batterie de requêtes pour plusieurs\nvaleurs de k. C'est la posture qui quantifie l'exposition — sans elle,\non ne sait pas si le 20 % committé est un accident doux ou le bas d'une\néchelle qui monte à 80 %. Elle vient première pour une raison simple :\nprotéger avant d'avoir mesuré, c'est corriger sans savoir de combien.\n\nL'exercice 2 (**protéger**) attaque la cause : supprimer le défaut\ndangereux de `reindexer` en refusant l'ambiguïté plutôt qu'en choisissant\nsilencieusement une victime. C'est la posture de conception — le remède\nne s'applique pas au store mais à l'API qui l'expose. Remarquer le\nmouvement : la donnée du problème était un environnement écrasé ; la\nsolution est une signature de fonction. Les accidents silencieux se\nréparent en amont de l'accident.\n\nL'exercice 3 (**surveiller**) installe la détection : une assertion qui\ncompare les comptes avant/après. C'est la posture opérationnelle — elle\nsuppose les deux premières faites et protège contre leur déclin, car un\ncâblage correct aujourd'hui peut être défait demain par une\nreconfiguration. Mesurer, protéger, surveiller : chacun des trois couvre\nla fenêtre temporelle que les deux autres laissent ouverte.\nCes trois postures ne dépendent ni du langage ni du moteur : le store de\nce notebook est un dictionnaire numpy, mais une collection vectorielle\nhébergée (Pinecone, Qdrant, pgvector, ou l'environnement d'embeddings\nd'une plateforme de publication) expose les mêmes classes de défaillance\n— un namespace oublié dans une requête, une réindexation dont la cible\npar défaut n'est pas celle qu'on croit. Les exercices se transposent\ntel quels : la batterie de mesure devient un script d'évaluation, le\n`reindexer` qui refuse devient une garde dans le code d'ingestion, le\ncomptage devient une sonde en continu. Ce qui change d'un moteur à\nl'autre est le nom des paramètres ; ce qui ne change pas est l'ordre des\npostures."
   },
   {
    "cell_type": "markdown",
@@ -553,26 +625,7 @@
    "cell_type": "markdown",
    "id": "c83988f9",
    "metadata": {},
-   "source": [
-    "## Provenance et pour aller plus loin\n",
-    "\n",
-    "Ce notebook matérialise le **Parcours 2** de `livresagites-parcours.md`\n",
-    "(RAG sur corpus et piège du multi-environnement). Il est le compagnon\n",
-    "exécutable de l'assertion « la séparation par environnement est un\n",
-    "contrôle d'accès ».\n",
-    "\n",
-    "- **Parcours 3** (audit d'un serveur MCP) a son propre compagnon :\n",
-    "  `auditer-un-serveur-mcp.ipynb`.\n",
-    "- La fixture est **synthétique à 100 %** (numpy, seed=7) : aucun appel\n",
-    "  réseau, aucune clé, aucune donnée client. Les noms d'environnements\n",
-    "  (`catalogue_public`, `comite_lecture`…) sont des rôles d'accès\n",
-    "  génériques, pas des noms réels ; les chunks sont des vecteurs, pas de\n",
-    "  la prose.\n",
-    "- Le scénario de chevauchement (`catalogue_public` ↔ `comite_lecture`)\n",
-    "  est volontaire : il modélise le cas réaliste où deux environnements\n",
-    "  traitent du contenu sémantiquement proche — précisément celui où un\n",
-    "  filtre d'environnement devient indispensable."
-   ]
+   "source": "## Provenance et pour aller plus loin\n\nCe notebook matérialise le **Parcours 2** de `livresagites-parcours.md`\n(RAG sur corpus et piège du multi-environnement). Il est le compagnon\nexécutable de l'assertion « la séparation par environnement est un\ncontrôle d'accès ».\n\n- **Parcours 3** (audit d'un serveur MCP) a son propre compagnon :\n  `auditer-un-serveur-mcp.ipynb`.\n- La fixture est **synthétique à 100 %** (numpy, seed=7) : aucun appel\n  réseau, aucune clé, aucune donnée client. Les noms d'environnements\n  (`catalogue_public`, `comite_lecture`…) sont des rôles d'accès\n  génériques, pas des noms réels ; les chunks sont des vecteurs, pas de\n  la prose.\n- Le scénario de chevauchement (`catalogue_public` / `comite_lecture`)\n  est volontaire : il modélise le cas réaliste où deux environnements\n  traitent du contenu sémantiquement proche — précisément celui où un\n  filtre d'environnement devient indispensable."
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/separer-les-environnements-de-vecteurs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/separer-les-environnements-de-vecteurs.ipynb
@@ -625,7 +625,26 @@
    "cell_type": "markdown",
    "id": "c83988f9",
    "metadata": {},
-   "source": "## Provenance et pour aller plus loin\n\nCe notebook matérialise le **Parcours 2** de `livresagites-parcours.md`\n(RAG sur corpus et piège du multi-environnement). Il est le compagnon\nexécutable de l'assertion « la séparation par environnement est un\ncontrôle d'accès ».\n\n- **Parcours 3** (audit d'un serveur MCP) a son propre compagnon :\n  `auditer-un-serveur-mcp.ipynb`.\n- La fixture est **synthétique à 100 %** (numpy, seed=7) : aucun appel\n  réseau, aucune clé, aucune donnée client. Les noms d'environnements\n  (`catalogue_public`, `comite_lecture`…) sont des rôles d'accès\n  génériques, pas des noms réels ; les chunks sont des vecteurs, pas de\n  la prose.\n- Le scénario de chevauchement (`catalogue_public` / `comite_lecture`)\n  est volontaire : il modélise le cas réaliste où deux environnements\n  traitent du contenu sémantiquement proche — précisément celui où un\n  filtre d'environnement devient indispensable."
+   "source": [
+    "## Provenance et pour aller plus loin\n",
+    "\n",
+    "Ce notebook matérialise le **Parcours 2** de `livresagites-parcours.md`\n",
+    "(RAG sur corpus et piège du multi-environnement). Il est le compagnon\n",
+    "exécutable de l'assertion « la séparation par environnement est un\n",
+    "contrôle d'accès ».\n",
+    "\n",
+    "- **Parcours 3** (audit d'un serveur MCP) a son propre compagnon :\n",
+    "  `auditer-un-serveur-mcp.ipynb`.\n",
+    "- La fixture est **synthétique à 100 %** (numpy, seed=7) : aucun appel\n",
+    "  réseau, aucune clé, aucune donnée client. Les noms d'environnements\n",
+    "  (`catalogue_public`, `comite_lecture`…) sont des rôles d'accès\n",
+    "  génériques, pas des noms réels ; les chunks sont des vecteurs, pas de\n",
+    "  la prose.\n",
+    "- Le scénario de chevauchement (`catalogue_public` ↔ `comite_lecture`)\n",
+    "  est volontaire : il modélise le cas réaliste où deux environnements\n",
+    "  traitent du contenu sémantiquement proche — précisément celui où un\n",
+    "  filtre d'environnement devient indispensable."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/docs #13575

Quoi:
Tranche 1 de l'issue #13934 : enrichissement markdown-only du notebook `separer-les-environnements-de-vecteurs.ipynb` (03-3-RAG-et-Embeddings), de 559 à 1210 c/cell (43 542 chars / 36 cellules). 12 cellules d'interprétation ajoutées (9 d'analyse + 3 d'ancrage plan de lecture/protocole/programme) + 4 extensions de cellules ajoutées. Pattern #13410 : interprétations ancrées aux sorties committées (fuite 20 % sur top-5, filtre 0 %, accident de réindexation 40 -> 12 vecteurs), code byte-identique, zéro ré-exécution.

Preuve (HEAD e096acd1b, testé firsthand) :
- `validate_pr_notebooks.py main <file>` : PASS (9 cellules code)
- `check_notebook_navlinks.py` : 0 lien cassé
- `detect_md_content_loss.py --base origin/main --check` : findings=0
- Cellules code byte-identiques vs main (assert dans scripts d'enrichissement + validateur)
- Cellules markdown originales byte-identiques (vérifié par comparaison id+source vs origin/main) ; diff net = 72 insertions, 0 délétion
- Densité : 43 542 chars source / 36 cellules = 1209,5 c/cell >= 1200
- Scan sécurité lignes ajoutées : 0 emoji, 0 homoglyphe, 0 secret, 0 terme client, 0 CRLF

Périmètre:
1 fichier : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/separer-les-environnements-de-vecteurs.ipynb`. Aucun autre chemin touché. Tranches 2-19 (#13934) hors périmètre.