### PR TITLE
feat(tooling): detect stale epic bodies

### DIFF
--- a/scripts/epic_body_staleness.py
+++ b/scripts/epic_body_staleness.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Report open EPIC bodies that no longer reflect merged delivery.
+
+The analyzer is deliberately read-only. It turns two observable discrepancies
+into a triage list:
+
+* merged pull requests cite an EPIC, but their PR numbers are absent from its
+  body (``unrecorded_merged``);
+* the EPIC still declares a dormant stance despite merged delivery
+  (``stance_contradicted``).
+
+A citation is only a signal: a PR may mention an EPIC incidentally. The output
+therefore names every PR for human review and never edits an issue body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime, timedelta
+
+EPIC_TITLE_RE = re.compile(r"\bepic\b", re.IGNORECASE)
+ISSUE_REF_RE = re.compile(r"(?<![\w])#(\d+)\b")
+OPEN_ISSUE_LIMIT = 500
+SEARCH_RESULT_CAP = 1000
+MERGED_SLICE_DAYS = 3
+MAX_LOOKBACK_DAYS = 3650
+
+# A dormant stance must be a declaration, not merely contain a word such as
+# "background" or "plus tard" in ordinary prose. Strong phrases stand alone;
+# broad status words require a title, heading, or explicit status/priority line.
+STRONG_DORMANT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("pas pour maintenant", re.compile(r"\bpas\s+pour\s+maintenant\b", re.IGNORECASE)),
+    (
+        "pas à traiter maintenant",
+        re.compile(
+            r"\bpas\s+(?:forc[ée]ment\s+)?[àa]\s+traiter\s+maintenant\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "ne pas démarrer",
+        re.compile(r"\bn['’]est\s+pas\s+[àa]\s+d[ée]marrer\b", re.IGNORECASE),
+    ),
+    (
+        "à ouvrir quand on aura le temps",
+        re.compile(r"\b[àa]\s+ouvrir\s+quand\s+on\s+aura\s+le\s+temps\b", re.IGNORECASE),
+    ),
+    (
+        "backlog indexé",
+        re.compile(r"\bbacklog\s+index[ée]e?s?\b", re.IGNORECASE),
+    ),
+)
+CONTEXTUAL_DORMANT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "priority-low",
+        re.compile(
+            r"\b(?:priority\s*[-_: ]\s*low|low\s+priority)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    ("background", re.compile(r"\bbackground\b", re.IGNORECASE)),
+    ("plus tard", re.compile(r"\bplus\s+tard\b", re.IGNORECASE)),
+    ("en veille", re.compile(r"\ben\s+veille\b", re.IGNORECASE)),
+)
+STATUS_CONTEXT_RE = re.compile(
+    r"(?:^|\b)(?:statut|status|priorit[ée]|priority)\b",
+    re.IGNORECASE,
+)
+ACTIVE_OVERRIDE_RE = re.compile(r"\bstatut\s+corrig[ée]\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Epic:
+    """One open issue identified as an EPIC by title or label."""
+
+    number: int
+    title: str
+    body: str
+
+    @classmethod
+    def from_gh_dict(cls, row: dict) -> Epic:
+        return cls(
+            number=int(row["number"]),
+            title=(row.get("title") or "").strip(),
+            body=row.get("body") or "",
+        )
+
+
+@dataclass(frozen=True)
+class MergedPullRequest:
+    """One merged pull request in the measured corpus."""
+
+    number: int
+    title: str
+    body: str
+    merged_at: str
+
+    @classmethod
+    def from_gh_dict(cls, row: dict) -> MergedPullRequest:
+        return cls(
+            number=int(row["number"]),
+            title=row.get("title") or "",
+            body=row.get("body") or "",
+            merged_at=row.get("mergedAt") or "",
+        )
+
+    def cited_issues(self) -> set[int]:
+        return {
+            int(number)
+            for number in ISSUE_REF_RE.findall(f"{self.title}\n{self.body}")
+        }
+
+
+@dataclass(frozen=True)
+class EpicStaleness:
+    """Triage signals for one EPIC."""
+
+    number: int
+    title: str
+    unrecorded_merged: tuple[int, ...]
+    stance_contradicted: bool
+    stance_pattern: str | None
+
+
+def is_epic(row: dict) -> bool:
+    """Recognize both the title convention and labels containing EPIC as a word."""
+    labels = (
+        label.get("name") or ""
+        for label in (row.get("labels") or [])
+    )
+    return bool(EPIC_TITLE_RE.search(row.get("title") or "")) or any(
+        EPIC_TITLE_RE.search(label) for label in labels
+    )
+
+
+def prose_lines_for_stance(title: str, body: str) -> list[str]:
+    """Return non-quoted, non-code lines that may declare a live stance.
+
+    Historical prose is often retained in block quotes when an EPIC is updated.
+    Treating such a quotation as current recreates the exact false positive that
+    motivated issue #13906. Fenced, indented, and inline code are excluded for
+    the same reason: examples are not declarations.
+    """
+    kept = [re.sub(r"`[^`\n]*`", "", title)]
+    in_fence = False
+    in_quote = False
+    for line in body.splitlines():
+        if re.match(r"^\s*(```|~~~)", line):
+            in_fence = not in_fence
+            continue
+        if in_fence or re.match(r"^(?: {4}|\t)", line):
+            continue
+        if re.match(r"^\s*>", line):
+            in_quote = True
+            continue
+        if in_quote:
+            if not line.strip():
+                in_quote = False
+            else:
+                continue
+        kept.append(re.sub(r"`[^`\n]*`", "", line))
+    return kept
+
+
+def dormant_stance(title: str, body: str) -> str | None:
+    """Return the first live dormant-stance pattern, if any."""
+    if ACTIVE_OVERRIDE_RE.search(body):
+        return None
+    lines = prose_lines_for_stance(title, body)
+    prose = "\n".join(lines)
+    for name, pattern in STRONG_DORMANT_PATTERNS:
+        if pattern.search(prose):
+            return name
+    for index, line in enumerate(lines):
+        if index > 0 and not STATUS_CONTEXT_RE.search(line):
+            continue
+        for name, pattern in CONTEXTUAL_DORMANT_PATTERNS:
+            if pattern.search(line):
+                return name
+    return None
+
+
+def analyze_epics(
+    epics: Iterable[Epic],
+    merged_prs: Iterable[MergedPullRequest],
+) -> list[EpicStaleness]:
+    """Compute staleness signals without network access or side effects."""
+    epics = list(epics)
+    merged_prs = list(merged_prs)
+    cited_by_epic: dict[int, list[MergedPullRequest]] = {
+        epic.number: [] for epic in epics
+    }
+    for pr in merged_prs:
+        for issue_number in pr.cited_issues() & cited_by_epic.keys():
+            cited_by_epic[issue_number].append(pr)
+
+    findings: list[EpicStaleness] = []
+    for epic in epics:
+        citing = cited_by_epic[epic.number]
+        recorded = {
+            int(number) for number in ISSUE_REF_RE.findall(epic.body)
+        }
+        unrecorded = tuple(
+            sorted(
+                (pr.number for pr in citing if pr.number not in recorded),
+                reverse=True,
+            )
+        )
+        stance = dormant_stance(epic.title, epic.body) if citing else None
+        if unrecorded or stance:
+            findings.append(
+                EpicStaleness(
+                    number=epic.number,
+                    title=epic.title,
+                    unrecorded_merged=unrecorded,
+                    stance_contradicted=stance is not None,
+                    stance_pattern=stance,
+                )
+            )
+
+    findings.sort(
+        key=lambda finding: (
+            -len(finding.unrecorded_merged),
+            not finding.stance_contradicted,
+            finding.number,
+        )
+    )
+    return findings
+
+
+def build_payload(
+    epics: list[Epic],
+    merged_prs: list[MergedPullRequest],
+) -> dict:
+    """Build an auditable payload whose zero includes the corpus actually read."""
+    findings = analyze_epics(epics, merged_prs)
+    merged_dates = sorted(pr.merged_at for pr in merged_prs if pr.merged_at)
+    return {
+        "corpus": {
+            "open_epics_examined": len(epics),
+            "merged_prs_examined": len(merged_prs),
+            "merged_window_start": merged_dates[0] if merged_dates else None,
+            "merged_window_end": merged_dates[-1] if merged_dates else None,
+        },
+        "finding_count": len(findings),
+        "findings": [asdict(finding) for finding in findings],
+        "limitations": [
+            "A PR citation is a triage signal, not proof that the PR delivers the EPIC.",
+            "Dormant stances are heuristic signals limited to declarative status wording.",
+            "Only the fetched merged-PR corpus is measured; the corpus counts and window are authoritative.",
+            "The analyzer is read-only and never rewrites issue bodies.",
+        ],
+    }
+
+
+def _gh_json(args: list[str]) -> object:
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"cannot execute gh: {exc}") from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh failed ({result.returncode}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return json.loads(result.stdout or "null")
+
+
+def _default_repo() -> str:
+    if repo := os.environ.get("GITHUB_REPOSITORY"):
+        return repo
+    result = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return result.stdout.strip() or "jsboige/CoursIA"
+
+
+def list_open_epics(repo: str) -> list[Epic]:
+    rows = _gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(OPEN_ISSUE_LIMIT),
+            "--json",
+            "number,title,body,labels",
+        ]
+    ) or []
+    if len(rows) >= OPEN_ISSUE_LIMIT:
+        raise RuntimeError(
+            f"open-issue corpus reached its {OPEN_ISSUE_LIMIT}-issue fetch limit"
+        )
+    return [Epic.from_gh_dict(row) for row in rows if is_epic(row)]
+
+
+def _merged_pr_slice(repo: str, since: date, until: date) -> list[dict]:
+    """Fetch one ``[since, until)`` merge-time slice without silent truncation."""
+    rows = _gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "merged",
+            "--search",
+            f"merged:>={since.isoformat()} merged:<{until.isoformat()}",
+            "--limit",
+            str(SEARCH_RESULT_CAP),
+            "--json",
+            "number,title,body,mergedAt",
+        ]
+    ) or []
+    if len(rows) >= SEARCH_RESULT_CAP:
+        if until - since <= timedelta(days=1):
+            raise RuntimeError(
+                f"merge-time slice {since.isoformat()} returned "
+                f"{len(rows)} PRs at GitHub's {SEARCH_RESULT_CAP}-result cap"
+            )
+        middle = since + (until - since) // 2
+        return _merged_pr_slice(repo, since, middle) + _merged_pr_slice(
+            repo, middle, until
+        )
+    return rows
+
+
+def list_merged_prs(repo: str, limit: int) -> list[MergedPullRequest]:
+    """Return the most recently merged PRs, ordered by ``mergedAt``.
+
+    ``gh pr list --state merged --limit N`` is ordered by creation time, not
+    merge time. Walk backwards through bounded merge-time slices until enough
+    unique rows are available, then sort and trim locally.
+    """
+    end = datetime.now(UTC).date() + timedelta(days=1)
+    seen: dict[int, MergedPullRequest] = {}
+    days_looked_back = 0
+    while len(seen) < limit and days_looked_back < MAX_LOOKBACK_DAYS:
+        start = end - timedelta(days=MERGED_SLICE_DAYS)
+        for row in _merged_pr_slice(repo, start, end):
+            pr = MergedPullRequest.from_gh_dict(row)
+            seen[pr.number] = pr
+        end = start
+        days_looked_back += MERGED_SLICE_DAYS
+
+    return sorted(
+        seen.values(),
+        key=lambda pr: (pr.merged_at, pr.number),
+        reverse=True,
+    )[:limit]
+
+
+def _cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=None)
+    parser.add_argument(
+        "--pr-limit",
+        type=int,
+        default=800,
+        help="number of recent merged PRs to examine (default: 800)",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="indent JSON output for human inspection",
+    )
+    args = parser.parse_args(argv)
+    if args.pr_limit <= 0:
+        parser.error("--pr-limit must be positive")
+
+    repo = args.repo or _default_repo()
+    try:
+        epics = list_open_epics(repo)
+        merged_prs = list_merged_prs(repo, args.pr_limit)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        print(f"epic_body_staleness: {exc}", file=sys.stderr)
+        return 1
+
+    json.dump(
+        build_payload(epics, merged_prs),
+        sys.stdout,
+        ensure_ascii=False,
+        indent=2 if args.pretty else None,
+    )
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/scripts/tests/test_epic_body_staleness.py
+++ b/scripts/tests/test_epic_body_staleness.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Regression tests for the read-only EPIC body staleness analyzer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "epic_body_staleness.py"
+_SPEC = importlib.util.spec_from_file_location("epic_body_staleness", _SCRIPT)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+Epic = _MODULE.Epic
+MergedPullRequest = _MODULE.MergedPullRequest
+analyze_epics = _MODULE.analyze_epics
+build_payload = _MODULE.build_payload
+
+
+def _pr(number: int, body: str, *, title: str = "delivery") -> MergedPullRequest:
+    return MergedPullRequest(
+        number=number,
+        title=title,
+        body=body,
+        merged_at=f"2026-08-{number % 28 + 1:02d}T12:00:00Z",
+    )
+
+
+def test_1210_before_correction_triggers_both_signals():
+    """Positive control from #13906: stale stance plus unrecorded delivery."""
+    epic = Epic(
+        1210,
+        "[Epic / priority-low / background] Semantic fleet",
+        "Pas pour maintenant.\n\n## Objectif\nConstruire la flotte.",
+    )
+    finding = analyze_epics(
+        [epic],
+        [_pr(6542, "See #1210"), _pr(5672, "Part of #1210")],
+    )[0]
+
+    assert finding.number == 1210
+    assert finding.unrecorded_merged == (6542, 5672)
+    assert finding.stance_contradicted is True
+    assert finding.stance_pattern == "pas pour maintenant"
+
+
+def test_up_to_date_epic_has_no_signal():
+    epic = Epic(
+        42,
+        "[EPIC] Runtime",
+        "## Livré\n- #101 — runtime initial\n- #102 — tests",
+    )
+
+    assert analyze_epics(
+        [epic],
+        [_pr(101, "See #42"), _pr(102, "See #42")],
+    ) == []
+
+
+def test_quoted_dormant_stance_is_not_live():
+    epic = Epic(
+        1210,
+        "[EPIC] Semantic fleet",
+        (
+            "> Pas pour maintenant.\n\n"
+            "Cette ancienne posture est désormais dépassée.\n"
+            "Livré : #6542."
+        ),
+    )
+
+    assert analyze_epics([epic], [_pr(6542, "See #1210")]) == []
+
+
+@pytest.mark.parametrize(
+    "correction",
+    [
+        "Statut corrigé : ce fut un oubli, pas une position.",
+        "Statut corrigé. Ce n'était pas une position, juste un oubli.",
+    ],
+)
+def test_explicit_corrected_status_overrides_preserved_historical_prose(correction):
+    epic = Epic(
+        1210,
+        "[EPIC] Semantic fleet",
+        (
+            f"**{correction}**\n\n"
+            "**Pas pour maintenant.** Texte historique conservé.\n"
+            "Livré : #6542."
+        ),
+    )
+
+    assert analyze_epics([epic], [_pr(6542, "See #1210")]) == []
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("## Statut : BACKLOG INDEXÉ", "backlog indexé"),
+        ("Cette issue n'est pas à démarrer.", "ne pas démarrer"),
+        ("Une issue à ouvrir, pas forcément à traiter maintenant.", "pas à traiter maintenant"),
+    ],
+)
+def test_strong_dormant_statuses_are_detected(body, expected):
+    epic = Epic(7265, "[EPIC] Heritage", body)
+
+    finding = analyze_epics([epic], [_pr(13466, "See #7265")])[0]
+
+    assert finding.stance_contradicted is True
+    assert finding.stance_pattern == expected
+
+
+def test_quoted_and_code_passages_do_not_recreate_dormant_stance():
+    epic = Epic(
+        7,
+        "[EPIC] Active",
+        (
+            "La chaîne `priority-low` documente l'ancien label.\n"
+            "> Contexte historique :\n"
+            "en veille depuis 2025, sans action.\n\n"
+            "~~~text\nplus tard\n~~~\n"
+            "    pas pour maintenant\n"
+            "Livré : #70."
+        ),
+    )
+
+    assert analyze_epics([epic], [_pr(70, "See #7")]) == []
+
+
+def test_broad_words_require_declarative_status_context():
+    epic = Epic(
+        8,
+        "[EPIC] Active",
+        (
+            "Le worker tourne en background pendant le build.\n"
+            "Les métriques détaillées arrivent plus tard dans ce document.\n"
+            "Livré : #80."
+        ),
+    )
+
+    assert analyze_epics([epic], [_pr(80, "See #8")]) == []
+
+
+def test_contextual_status_and_pattern_variants_are_detected():
+    epics = [
+        Epic(8, "[EPIC / priority: low] Active", ""),
+        Epic(9, "[EPIC] Indexed", "## Statut : backlog indexées"),
+    ]
+    prs = [_pr(80, "See #8"), _pr(90, "See #9")]
+
+    findings = analyze_epics(epics, prs)
+
+    assert findings[0].stance_pattern == "priority-low"
+    assert findings[1].stance_pattern == "backlog indexé"
+
+
+def test_unrecorded_pr_list_is_sorted_and_finding_order_is_triageable():
+    epics = [
+        Epic(1, "[EPIC] One", ""),
+        Epic(2, "[EPIC / plus tard] Two", ""),
+        Epic(3, "[EPIC] Three", ""),
+    ]
+    prs = [
+        _pr(15, "See #1 and #2"),
+        _pr(12, "See #1"),
+        _pr(20, "See #1"),
+        _pr(11, "See #3"),
+    ]
+
+    findings = analyze_epics(epics, prs)
+
+    assert [finding.number for finding in findings] == [1, 2, 3]
+    assert findings[0].unrecorded_merged == (20, 15, 12)
+    assert findings[1].stance_contradicted is True
+
+
+def test_incidental_citation_remains_visible_as_signal_not_verdict():
+    epic = Epic(42, "[EPIC] Target", "")
+    finding = analyze_epics(
+        [epic],
+        [_pr(900, "Unrelated delivery; compare the process in #42")],
+    )[0]
+
+    assert finding.unrecorded_merged == (900,)
+
+
+def test_payload_reports_corpus_even_when_findings_are_empty():
+    epic = Epic(42, "[EPIC] Current", "Delivered by #101")
+    pr = _pr(101, "See #42")
+
+    payload = build_payload([epic], [pr])
+
+    assert payload["finding_count"] == 0
+    assert payload["findings"] == []
+    assert payload["corpus"] == {
+        "open_epics_examined": 1,
+        "merged_prs_examined": 1,
+        "merged_window_start": pr.merged_at,
+        "merged_window_end": pr.merged_at,
+    }
+    assert "read-only" in payload["limitations"][3]
+
+
+def test_is_epic_accepts_title_or_label_and_rejects_plain_issue():
+    assert _MODULE.is_epic({"title": "[EPIC] X", "labels": []})
+    assert _MODULE.is_epic({"title": "EPIC: X", "labels": []})
+    assert _MODULE.is_epic({"title": "Tracker", "labels": [{"name": "EPIC"}]})
+    assert _MODULE.is_epic({"title": "Tracker", "labels": [{"name": "epic-ict"}]})
+    assert not _MODULE.is_epic({"title": "Epictetus notes", "labels": []})
+    assert not _MODULE.is_epic({"title": "Regular issue", "labels": []})
+
+
+def test_list_merged_prs_sorts_by_merge_time_before_trimming(monkeypatch):
+    rows = [
+        {
+            "number": 1,
+            "title": "old creation, latest merge",
+            "body": "",
+            "mergedAt": "2026-09-01T12:00:00Z",
+        },
+        {
+            "number": 2,
+            "title": "new creation, earlier merge",
+            "body": "",
+            "mergedAt": "2026-08-31T12:00:00Z",
+        },
+        {
+            "number": 3,
+            "title": "oldest merge",
+            "body": "",
+            "mergedAt": "2026-08-30T12:00:00Z",
+        },
+    ]
+    monkeypatch.setattr(_MODULE, "_merged_pr_slice", lambda repo, since, until: rows)
+
+    prs = _MODULE.list_merged_prs("example/repo", 2)
+
+    assert [pr.number for pr in prs] == [1, 2]
+
+
+def test_merged_slice_halves_a_capped_window(monkeypatch):
+    calls = []
+
+    def fake_gh(args):
+        search = args[args.index("--search") + 1]
+        calls.append(search)
+        if "merged:>=2026-08-28 merged:<2026-09-01" in search:
+            return [{"number": n} for n in range(_MODULE.SEARCH_RESULT_CAP)]
+        return []
+
+    monkeypatch.setattr(_MODULE, "_gh_json", fake_gh)
+
+    rows = _MODULE._merged_pr_slice(
+        "example/repo",
+        _MODULE.date(2026, 8, 28),
+        _MODULE.date(2026, 9, 1),
+    )
+
+    assert rows == []
+    assert len(calls) == 3
+
+
+def test_cli_prints_json_and_never_writes(monkeypatch, capsys):
+    epic = Epic(42, "[EPIC] Current", "Delivered by #101")
+    pr = _pr(101, "See #42")
+    monkeypatch.setattr(_MODULE, "list_open_epics", lambda repo: [epic])
+    monkeypatch.setattr(_MODULE, "list_merged_prs", lambda repo, limit: [pr])
+
+    assert _MODULE._cli(["--repo", "example/repo", "--pretty"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["corpus"]["open_epics_examined"] == 1
+
+
+def test_cli_reports_read_failure(monkeypatch, capsys):
+    def fail(_repo):
+        raise RuntimeError("GitHub unavailable")
+
+    monkeypatch.setattr(_MODULE, "list_open_epics", fail)
+
+    assert _MODULE._cli(["--repo", "example/repo"]) == 1
+    assert "GitHub unavailable" in capsys.readouterr().err
+
+
+def test_cli_rejects_nonpositive_limit(capsys):
+    with pytest.raises(SystemExit) as exc:
+        _MODULE._cli(["--pr-limit", "0"])
+
+    assert exc.value.code == 2
+    assert "--pr-limit must be positive" in capsys.readouterr().err


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/refactor #13813

## Résumé

- ajoute un organe **read-only** qui analyse les bodies des EPICs ouvertes sans les réécrire ;
- rend `unrecorded_merged` quand une PR mergée cite l’EPIC mais que son numéro n’apparaît pas dans le body ;
- rend `stance_contradicted` pour les postures dormantes déclaratives encore présentes malgré des livraisons mergées ;
- exclut de cette détection les blockquotes, continuations de citation, blocs de code fenced/indentés et code inline ;
- récupère les PRs par tranches de **date de merge**, puis trie et tronque localement — contrairement à `gh pr list --state merged --limit N`, ordonné par date de création ;
- échoue explicitement si le corpus d’issues ou une tranche GitHub atteint son plafond, au lieu de présenter une mesure tronquée comme complète.

## Validation

- `43 passed` :
  - `scripts/tests/test_epic_body_staleness.py`
  - `scripts/tests/test_epic_neglect_sweep.py`
  - `scripts/tests/test_fetch_merged_prs_since.py`
- Ruff : `All checks passed!`
- `py_compile` : succès
- `git diff --check` : succès
- revue indépendante read-only : corpus `EPIC:` élargi, faux positifs de posture et troncature merge-time corrigés avant commit.

## Mesure live

Commande :

```text
python scripts/epic_body_staleness.py --repo jsboige/CoursIA --pr-limit 800 --pretty
```

Corpus réellement lu :

- **61 EPICs ouvertes** ;
- **800 PRs les plus récemment mergées** ;
- fenêtre : `2026-08-23T06:46:49Z` → `2026-08-31T23:55:03Z` ;
- **52 EPICs** portent au moins un signal de triage.

Contrôles live :

- #1203 et #4588 : les mots ordinaires « background » / « plus tard » ne recréent plus un faux statut dormant ;
- #1210 : `Statut corrigé` neutralise la posture historique conservée ;
- #7265 : `BACKLOG INDEXÉ` reste détecté ;
- #1206, #1650 et #11690 : leurs déclarations explicites `Priority: background`, `low priority`, et `n'est pas à démarrer` restent détectées.

Une citation de PR reste volontairement un **signal à trier**, jamais la preuve automatique que la PR livre l’EPIC. Cette PR couvre les acceptances 1–3 de l’issue ; la réécriture humaine des bodies reste séparée.

See #13906
