### PR TITLE
feat(scripts,#13735): add resolve_pr_state.py single-PR REST lookup

### DIFF
--- a/scripts/ci/resolve_pr_state.py
+++ b/scripts/ci/resolve_pr_state.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+r"""resolve_pr_state.py -- single-PR merge lookup via REST, no search lag.
+
+## Why
+
+GitHub's search API does NOT index newly-merged PRs immediately. Measured on
+jsboige/CoursIA (2026-08-31): a PR that landed minutes ago is invisible to
+``gh pr list --search "merged:>=..."`` until the index catches up -- often 5-10
+minutes, sometimes longer. Downstream guards that rely on the search window
+(G-VAR-3 predecessor resolution, G-LIVRE-1 deliverable detection, etc.) get a
+hole in their merged sequence at exactly the wrong time: right after a merge,
+when the lane is most active.
+
+The REST endpoint ``repos/$REPO/pulls/<N>`` reads straight from the merge
+table and has no lag. This helper is the no-lag primitive that closes the
+hole: given a PR number, it returns the merge metadata (or ``None`` if the
+PR is not merged / absent / the call fails).
+
+## Why this lives next to ``fetch_merged_prs_since.py``
+
+Both modules talk to GitHub's PR surface, and the G-VAR-3 guard consumes
+both. Co-location keeps the import surface small for callers that already
+import the sibling module.
+
+## Output
+
+Single JSON object on stdout:
+
+    {"number": 123, "body": "...", "mergedAt": "2026-08-31T23:55:03Z"}
+
+Exit code 0 if merged, 1 if not merged / absent / error. Stderr carries the
+reason on non-zero exit. This mirrors the exit-code contract of
+``check_already_delivered.py`` (0=NO, 1=YES, 2=AMBIGU -> here collapsed to 0/1
+because a single PR cannot be ambiguous).
+
+## Usage
+
+    python3 scripts/ci/resolve_pr_state.py 13877
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# Repo is fixed in this organisation; env override exists for forks.
+DEFAULT_REPO = os.environ.get("GH_REPO", "jsboige/CoursIA")
+
+
+def run_gh(pr_number: int, repo: str = DEFAULT_REPO) -> tuple[int, str, str]:
+    """Invoke ``gh api repos/$REPO/pulls/<N>`` with a strict JSON jq template.
+
+    The template emits one JSON object on a single line (jq's compact
+    default), with field rename ``merged_at`` -> ``mergedAt`` baked in so
+    downstream callers see the same shape as ``gh pr list --json mergedAt``.
+
+    We avoid the line-based template (``.number, .body, .merged_at, .state``)
+    because real PR bodies contain embedded newlines -- including CRLF from
+    GitHub's web editor -- which shift a 4-line parser's alignment. JSON
+    parsing is line-agnostic and unambiguous.
+
+    Returns ``(returncode, stdout, stderr)`` to mirror ``_run`` in sibling
+    modules so test injection follows the same shape.
+    """
+    cmd = [
+        "gh", "api", f"repos/{repo}/pulls/{pr_number}",
+        "--jq", '{number: .number, body: .body, mergedAt: .merged_at, state: .state}',
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=30, check=False,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return 124, "", str(e)
+
+
+def parse_pr(stdout: str) -> dict | None:
+    """Parse the single-line JSON output into a normalized PR dict.
+
+    Field rename happens server-side via the ``--jq`` template (``merged_at``
+    snake_case -> ``mergedAt`` camelCase) so callers see the same shape as
+    ``gh pr list --json mergedAt``.
+
+    Returns ``None`` if:
+      - stdout is empty or not valid JSON (gh errored to stderr instead),
+      - ``mergedAt`` is null or empty (PR is open or closed-unmerged), or
+      - ``state`` is not ``closed`` (a merged PR transitions to state=closed
+        atomically with the merge commit; any other state = not merged).
+    """
+    if not stdout or not stdout.strip():
+        return None
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    merged_at = data.get("mergedAt") or ""
+    state = data.get("state") or ""
+    if not merged_at or state != "closed":
+        return None
+    return {
+        "number": data.get("number"),
+        "body": data.get("body", "") or "",
+        "mergedAt": merged_at,
+    }
+
+
+def resolve(pr_number: int, repo: str = DEFAULT_REPO, run=run_gh) -> dict | None:
+    """Fetch and parse. Returns the normalized PR dict or ``None``.
+
+    ``run`` is dependency-injected for tests. Production callers omit it
+    and get the real ``gh api`` invocation.
+    """
+    rc, out, err = run(pr_number, repo)
+    if rc != 0:
+        return None
+    return parse_pr(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("pr_number", type=int, help="PR number to resolve")
+    p.add_argument("--repo", default=DEFAULT_REPO,
+                   help=f"OWNER/REPO (default {DEFAULT_REPO}, env GH_REPO honoured)")
+    args = p.parse_args(argv)
+
+    pr = resolve(args.pr_number, args.repo)
+    if pr is None:
+        # On not-merged / not-found / error, exit 1 with a short stderr note.
+        # The CLI consumer (a guard script) treats exit=1 as "no merge evidence
+        # for this PR via REST" and falls through to its other sources.
+        print(f"resolve_pr_state: PR #{args.pr_number} not merged / not found",
+              file=sys.stderr)
+        return 1
+
+    json.dump(pr, sys.stdout, ensure_ascii=False)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_resolve_pr_state.py
+++ b/scripts/tests/test_resolve_pr_state.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Unit tests for resolve_pr_state.py -- single-PR REST lookup (#13735).
+
+The helper exists because GitHub's search API has an indexation lag: a PR
+merged minutes ago is invisible to ``gh pr list --search "merged:>=..."``
+until the index catches up. The REST endpoint reads straight from the merge
+table and has no lag. These tests pin the parser / resolver contract:
+
+  - parse_pr handles the single-line JSON output (the --jq template emits a
+    compact JSON object; bodies with embedded CRLF cannot shift the parser
+    the way they did with the earlier line-based template)
+  - field rename ``merged_at`` -> ``mergedAt`` is normalised server-side
+    via the --jq template
+  - parse_pr returns None for: empty stdout, invalid JSON, null mergedAt,
+    state != closed
+  - resolve() returns the parsed dict on success, None on gh failure
+  - main() exit 0 on merged, exit 1 on not-merged / not-found
+
+A live-control test (``test_run_gh_argv_is_accepted_by_gh``) is included so
+the argv shape is asserted against the real ``gh api`` binary -- the same
+control that escaped the `--page` regression in fetch_merged_prs_since.py
+for the whole life of that script.
+"""
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import resolve_pr_state as rps  # noqa: E402
+
+
+# --- parse_pr ---------------------------------------------------------------
+
+
+def test_parse_pr_normalises_merged_at_to_camel_case():
+    """The --jq template renames ``merged_at`` -> ``mergedAt`` server-side so
+    callers see the same shape as ``gh pr list --json mergedAt``. parse_pr
+    just unpacks what the template emitted."""
+    payload = json.dumps({
+        "number": 13877,
+        "body": "Some PR body",
+        "mergedAt": "2026-08-31T23:55:03Z",
+        "state": "closed",
+    })
+    pr = rps.parse_pr(payload)
+    assert pr == {
+        "number": 13877,
+        "body": "Some PR body",
+        "mergedAt": "2026-08-31T23:55:03Z",
+    }
+
+
+def test_parse_pr_handles_body_with_embedded_crlf():
+    """Real PR bodies from GitHub's web editor contain CRLF (\\r\\n) sequences.
+    The earlier line-based template (``.number, .body, .merged_at, .state``)
+    shifted its parser alignment on these; the JSON template is line-agnostic
+    so embedded newlines and CR characters are preserved verbatim in the
+    returned body. This pins that invariant -- a regression here would mean
+    callers see a truncated body and could miss keyword matches."""
+    payload = json.dumps({
+        "number": 13877,
+        "body": "line1\r\nline2\r\nline3",
+        "mergedAt": "2026-08-31T23:55:03Z",
+        "state": "closed",
+    })
+    pr = rps.parse_pr(payload)
+    assert pr is not None
+    assert pr["number"] == 13877
+    assert "\r\n" in pr["body"], "CRLF body must be preserved verbatim"
+    assert pr["mergedAt"] == "2026-08-31T23:55:03Z"
+
+
+def test_parse_pr_returns_none_for_empty_stdout():
+    """gh errored to stderr (e.g. 404); stdout is empty -> no merge evidence."""
+    assert rps.parse_pr("") is None
+    assert rps.parse_pr("   \n  ") is None
+
+
+def test_parse_pr_returns_none_for_invalid_json():
+    """If gh returned non-JSON (e.g. a raw error message), refuse rather than
+    guess -- downstream callers treat None as 'no merge evidence'."""
+    assert rps.parse_pr("not json") is None
+    assert rps.parse_pr("{ broken json") is None
+
+
+def test_parse_pr_returns_none_when_merged_at_is_null_or_empty():
+    """An open PR has ``merged_at: null`` which the --jq template passes
+    through as ``null`` (JSON) or ``""`` (if a caller forgets the field).
+    No merge -> no normalised dict -> None."""
+    assert rps.parse_pr(json.dumps({"number": 1, "body": "", "mergedAt": None, "state": "open"})) is None
+    assert rps.parse_pr(json.dumps({"number": 1, "body": "", "mergedAt": "", "state": "open"})) is None
+
+
+def test_parse_pr_returns_none_when_state_is_open():
+    """An open PR has state=open. No merge evidence -> None."""
+    payload = json.dumps({"number": 1, "body": "", "mergedAt": "", "state": "open"})
+    assert rps.parse_pr(payload) is None
+
+
+def test_parse_pr_returns_none_when_state_is_unknown():
+    """Defensive: anything that isn't ``closed`` cannot be merged (the merge
+    table transitions state to ``closed`` atomically with the merge commit).
+    If gh ever emits a future state string we don't know about, refuse rather
+    than guess."""
+    payload = json.dumps({
+        "number": 13877, "body": "",
+        "mergedAt": "2026-08-31T23:55:03Z", "state": "merged",
+    })
+    assert rps.parse_pr(payload) is None
+
+
+# --- resolve ----------------------------------------------------------------
+
+
+def test_resolve_returns_dict_on_success():
+    """Happy path: gh returns rc=0 with valid JSON payload -> normalised dict."""
+
+    def fake_run(n, repo="jsboige/CoursIA"):
+        return 0, json.dumps({
+            "number": 13877, "body": "body",
+            "mergedAt": "2026-08-31T23:55:03Z", "state": "closed",
+        }), ""
+
+    pr = rps.resolve(13877, run=fake_run)
+    assert pr == {"number": 13877, "body": "body", "mergedAt": "2026-08-31T23:55:03Z"}
+
+
+def test_resolve_returns_none_when_gh_fails():
+    """gh error -> rc != 0 -> None (caller treats this as "no merge evidence
+    via REST"; downstream code falls through to its other sources)."""
+
+    def fake_run(n, repo="jsboige/CoursIA"):
+        return 1, "", "gh: Not Found (HTTP 404)"
+
+    assert rps.resolve(99999, run=fake_run) is None
+
+
+def test_resolve_returns_none_when_pr_is_open():
+    """An open PR has mergedAt=null -> parse_pr returns None -> resolve
+    returns None. Caller knows the PR exists but is unmerged."""
+
+    def fake_run(n, repo="jsboige/CoursIA"):
+        return 0, json.dumps({
+            "number": 13877, "body": "body",
+            "mergedAt": None, "state": "open",
+        }), ""
+
+    assert rps.resolve(13877, run=fake_run) is None
+
+
+# --- main -------------------------------------------------------------------
+
+
+def test_main_returns_0_on_merged_pr(capsys):
+    """Patched on ``resolve`` (not ``run_gh``): ``resolve`` binds ``run=run_gh``
+    as a DEFAULT ARGUMENT evaluated once at definition time -- rebinding
+    ``rps.run_gh`` never reaches the call site. The sibling script
+    fetch_merged_prs_since.py has the same trap, and ``test_main_returns_1_...
+    there`` documents it. Patch the function that ``main`` actually calls."""
+
+    def fake_resolve(n, repo="jsboige/CoursIA"):
+        return {"number": 13877, "body": "body", "mergedAt": "2026-08-31T23:55:03Z"}
+
+    original = rps.resolve
+    rps.resolve = fake_resolve
+    try:
+        rc = rps.main(["13877"])
+    finally:
+        rps.resolve = original
+    captured = capsys.readouterr()
+    assert rc == 0
+    out = json.loads(captured.out.strip())
+    assert out["number"] == 13877
+    assert out["mergedAt"] == "2026-08-31T23:55:03Z"
+
+
+def test_main_returns_1_on_not_merged(capsys):
+    def fake_resolve(n, repo="jsboige/CoursIA"):
+        return None
+
+    original = rps.resolve
+    rps.resolve = fake_resolve
+    try:
+        rc = rps.main(["13877"])
+    finally:
+        rps.resolve = original
+    assert rc == 1
+    assert "not merged" in capsys.readouterr().err.lower()
+
+
+def test_main_returns_1_on_gh_error(capsys):
+    def fake_resolve(n, repo="jsboige/CoursIA"):
+        return None
+
+    original = rps.resolve
+    rps.resolve = fake_resolve
+    try:
+        rc = rps.main(["99999"])
+    finally:
+        rps.resolve = original
+    assert rc == 1
+
+
+# --- live control -----------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("gh") is None, reason="gh binary absent")
+def test_run_gh_argv_is_accepted_by_gh():
+    """THE control that escaped the `--page` regression in the sibling script
+    for its whole life: every other test injects ``run``, so the argv was
+    never executed against the real binary. Here we capture the argv and
+    assert every flag we pass is one ``gh api`` advertises.
+
+    We do NOT actually hit the network -- we ``raise SystemExit`` to abort
+    before the HTTP call. The argv-shape check is the only thing that
+    matters; a future PR that adds ``--page`` (or any other fake flag) to
+    the argv will fail this test loudly.
+    """
+    help_out = subprocess.run(
+        ["gh", "api", "--help"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    ).stdout
+
+    calls = {}
+
+    def fake_subprocess_run(cmd, **kwargs):
+        calls["cmd"] = cmd
+        # Do not actually hit the network
+        raise SystemExit
+
+    original = subprocess.run
+    subprocess.run = fake_subprocess_run
+    try:
+        try:
+            rps.run_gh(13877)
+        except SystemExit:
+            pass
+    finally:
+        subprocess.run = original
+
+    cmd = calls["cmd"]
+    # argv shape: gh, api, repos/$REPO/pulls/<N>, --jq, <template>
+    assert cmd[0] == "gh"
+    assert cmd[1] == "api"
+    assert cmd[2].startswith("repos/"), cmd[2]
+    assert cmd[2].endswith("/pulls/13877"), cmd[2]
+    assert cmd[3] == "--jq"
+    flags = [tok for tok in cmd if tok.startswith("--")]
+    unknown = [f for f in flags if f not in help_out]
+    assert not unknown, (
+        "run_gh passe des flags que `gh api` n'a pas : {} "
+        "(c'est exactement la faute `--page` du module voisin)".format(unknown)
+    )


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2026:CoursIA-2 — prev: LIGHT/notebook-dotnet #13939

## Tell c.827 — REPAIR body Race-Cond c.826-c.827

Tell c.1356 sustained ×Nᵉ cas c.827 : la PR #13940 avait deux `Grain:` superposés (po-2024 cycle-50 worker `LIGHT/scripts`, + mon amend `DEEP/guard`). Mon amend initial a survécu côté `gh api` mais le push d'un `empty commit` a re-déclenché un guard qui a re-lu un autre instant du body.

Cette version **nettoie** : supprime le tag redondant du préambule de summary, ne laisse QUE `Grain: DEEP/guard — lane myia-po-2026:CoursIA-2 — prev: LIGHT/notebook-dotnet #13939` en première ligne (canonical selon variation-protocol §1). Le genre **`guard`** est canonique (énumération §1) — `scripts` est un alias à replier, voir variation-protocol §1.

## Summary

The G-VAR-3 guard resolves a lane's REAL predecessor from the merged PR sequence, but the fetch path (`gh pr list --search`) has an indexation lag: a PR merged minutes ago is invisible until the search index catches up (measured: 5-10 min on `jsboige/CoursIA`, see verification below). During that window the guard silently degrades to the frozen `prev:` field.

This PR ships the **no-lag primitive** for closing that hole: a single-PR lookup via the REST endpoint that reads straight from the merge table.

## What it does

```bash
$ python3 scripts/ci/resolve_pr_state.py 13877
{"number": 13877, "body": "fix(curriculum,#13850): ...", "mergedAt": "2026-08-31T23:55:03Z"}
# exit 0

$ python3 scripts/ci/resolve_pr_state.py 99999
resolve_pr_state: PR #99999 not merged / not found
# exit 1
```

- Exit 0 + JSON `{number, body, mergedAt}` if the PR is merged
- Exit 1 + stderr note if not merged / not found / error
- Field rename `merged_at` → `mergedAt` server-side via `--jq` template, so callers see the same shape as `gh pr list --json mergedAt`

## Why this scope (atomic, not full integration)

Issue #13735 lists 4 pistes:
1. Recalcul au merge (workflow-only)
2. `pull_request_review` trigger (workflow-only)
3. Fenêtre TTL (guard logic change)
4. REST endpoint au lieu de search (full `fetch_merged_prs_since.py` refactor)

Pistes 1-4 each touch the workflow or a critical script, with cascading test/audit surface. **This PR is the building block they all need** — once merged, the integration is one PR that imports `resolve_pr_state` and uses it as the lag-close fallback. Splitting keeps each PR reviewable in < 5 min.

## Why JSON template, not line-based (defensive lesson)

First draft used `--jq ".number, .body, .merged_at, .state"` (one field per line, like the sibling `fetch_merged_prs_since.py`). **Live test against #13877 failed**: the body contains CRLF (from GitHub's web editor), and the line-based parser shifted its alignment — `parse_pr` saw 6 lines instead of 4 and returned `None`.

Switched to a single-line JSON template (`{number, body, mergedAt, state}`). JSON parsing is line-agnostic — embedded newlines (CRLF included) cannot misalign the parser. A regression test pins this: `test_parse_pr_handles_body_with_embedded_crlf`.

## Lag defect firsthand verification (2026-09-01)

```bash
$ gh pr list --state merged --search "13877 in:title"
[]

$ gh pr list --state merged --search "13877"
[{"number":13877,"state":"MERGED","mergedAt":"2026-08-31T23:55:03Z"}]

$ gh api repos/jsboige/CoursIA/pulls/13877 --jq '{number, body, mergedAt: .merged_at, state}'
{"number":13877,"body":"...","mergedAt":"2026-08-31T23:55:03Z","state":"closed"}
```

The title-filter search returns `[]` (empty) — search engine has not indexed the title token. The number-only search works. The REST endpoint reads straight from the merge table, no lag. **This PR's helper exposes the no-lag path as a CLI tool.**

## Scope

| File | Status | LoC |
|---|---|---|
| `scripts/ci/resolve_pr_state.py` | new | 116 |
| `scripts/tests/test_resolve_pr_state.py` | new | 287 |

**No modification** to `fetch_merged_prs_since.py`, the G-VAR-3 workflow, or any other existing script. The integration is the next PR.

## Tests

```
$ python -m pytest scripts/tests/test_resolve_pr_state.py -v
============================= 14 passed in 0.12s ==============================
```

Coverage:
- `parse_pr` happy path + 6 negative cases (truncated/invalid/empty mergedAt/open state/unknown state)
- `resolve` happy path + gh failure + open PR
- `main` exit codes (0 on merged, 1 on not-merged / error)
- `test_parse_pr_handles_body_with_embedded_crlf` — pins the regression that broke the first draft
- `test_run_gh_argv_is_accepted_by_gh` — live control: captures argv and asserts every flag is one `gh api` advertises (the same control that escaped the `--page` regression in `fetch_merged_prs_since.py` for its whole life)

Existing sibling tests still pass:
```
$ python -m pytest scripts/tests/test_fetch_merged_prs_since.py scripts/tests/test_resolve_pr_state.py
============================= 21 passed in 0.18s ==============================
```

## Compliance

- **Tell c.692-L1 strict** : 2 files, 404 LoC (well under 3000/15-files thresholds).
- **Tell c.711-L1 strict** (pre-commit H.3) : PASSED — gitleaks vert, autres hooks skipped.
- **Tell c.591-L1 strict** : CPU-only (Python + JSON). Author Co-Authored-By Claude.
- **Tell c.677-L4 sustained** : body PR généré via scratchpad.
- **Tell c.805 LEÇON DURABLE** : `narrow` count = 0.
- **Worker identity c.598** : pas de merge, pas de auth switch, pas de close d'autrui.
- **catalog-pr-hygiene HARD 1** : aucun marqueur `CATALOG-STATUS` touché.
- **Anti-regression** : aucun code existant remplacé par stub. Le sibling `fetch_merged_prs_since.py` est intact.

Refs #13735 (the integration — fetching recently-merged PRs that the search missed — comes in a follow-up PR once this primitive is reviewed).