### PR TITLE
fix(notebook,#13944): rendre l'ecart EN-LASSO c15 dérive — 0.007 littéral → max(ecarts_b0)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.11-Regularisation-Sparse-LASSO.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.11-Regularisation-Sparse-LASSO.ipynb
@@ -48,7 +48,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numpy=2.4.6\n"
+      "numpy=2.2.6\n"
      ]
     }
    ],
@@ -548,7 +548,7 @@
      "output_type": "stream",
      "text": [
       "LassoCV : alpha* = 0.16105, n_nonzeros = 19, support recovery = 1.00\n",
-      "        Temps execution : 0.05s\n",
+      "        Temps execution : 0.02s\n",
       "        MSE train moyen : 9.340\n",
       "\n",
       "Lambda min = 3.23590 / lambda max = 0.00324\n",
@@ -686,7 +686,7 @@
       "=> Lasso reproduit ici une selection stable de la feature 0 dans les 5 tirages (jamais 0),\n",
       "   et b_1 reste non-nul (0.018, -0.076, 0.113, -0.080, 0.123) --\n",
       "   le design (rho=0.7, p=10, alpha_eq=0.4) ne reproduit PAS l'arbitraire strict du LASSO sur paires.\n",
-      "=> ElasticNet suit LASSO a +-0.007 pres sur la feature 0 des paires (EN ~= LASSO ici),\n",
+      "=> ElasticNet suit LASSO a +-0.002 pres sur la feature 0 des paires (EN ~= LASSO ici),\n",
       "   donc aucune redistribution visible -- la difference L1/L2 est ailleurs (shrinkage L2 global),\n",
       "   pas dans la selection au sein de la paire.\n"
      ]
@@ -727,6 +727,7 @@
     "print()\n",
     "print(f'Vraies features actives : [0, 2, 4, 6, 8]')\n",
     "print()\n",
+    "ecarts_b0 = []\n",
     "for i, res in enumerate(results_colin):\n",
     "    b_lasso_nz = sorted(np.where(np.abs(res['b_lasso']) > 1e-8)[0].tolist())\n",
     "    b_en_nz = sorted(np.where(np.abs(res['b_en']) > 1e-8)[0].tolist())\n",
@@ -734,12 +735,13 @@
     "    pair_en = (res['b_en'][0], res['b_en'][1])\n",
     "    print(f'Tirage {i}: LASSO nz = {b_lasso_nz}, EN nz = {b_en_nz}')\n",
     "    print(f'           Paire (0,1) LASSO = ({pair_lasso[0]:.3f}, {pair_lasso[1]:.3f}) | EN = ({pair_en[0]:.3f}, {pair_en[1]:.3f})')\n",
+    "    ecarts_b0.append(abs(pair_en[0] - pair_lasso[0]))\n",
     "\n",
     "print()\n",
     "print('=> Lasso reproduit ici une selection stable de la feature 0 dans les 5 tirages (jamais 0),')\n",
     "print('   et b_1 reste non-nul (0.018, -0.076, 0.113, -0.080, 0.123) --')\n",
     "print('   le design (rho=0.7, p=10, alpha_eq=0.4) ne reproduit PAS l\\'arbitraire strict du LASSO sur paires.')\n",
-    "print('=> ElasticNet suit LASSO a +-0.007 pres sur la feature 0 des paires (EN ~= LASSO ici),')\n",
+    "print(f'=> ElasticNet suit LASSO a +-{max(ecarts_b0):.3f} pres sur la feature 0 des paires (EN ~= LASSO ici),')\n",
     "print('   donc aucune redistribution visible -- la difference L1/L2 est ailleurs (shrinkage L2 global),')\n",
     "print('   pas dans la selection au sein de la paire.')\n",
     ""


### PR DESCRIPTION
fix(notebook,#13944): rendre l'écart EN-LASSO c15 dérivé — `0.007` littéral → `max(ecarts_b0)`

Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/guard #13951

## Résumé

Issue #13944 : la cellule code 15 du notebook `2.11-Regularisation-Sparse-LASSO.ipynb` imprime un **littéral `+-0.007`** codé en dur dans la source du `print`. La cellule markdown 16, réparée par #13724, annonce désormais **`±0.002`** (écarts EN−LASSO : `−0.002, +0.002, +0.002, +0.001, 0.000`, max abs = 0.002). Constat : « sera régénéré à la prochaine exec kernel » invoqué par c.774 est **faux** — `0.007` est un littéral dans la *source* du `print`, pas une valeur calculée. Re-exécution kernel = impression identique, indéfiniment.

## Le défaut (mesure)

Sur la sortie commit actuelle (tête `b17f24ac90` de #13724 avant merge) :

- Code c15 : `print('=> ElasticNet suit LASSO a +-0.007 pres sur la feature 0 ...')` ← littéral.
- Markdown c16 : `ecarts EN-LASSO : -0.002, +0.002, +0.002, +0.001, 0.000, max abs = 0.002` ← mesure réelle.

Comptage sur la tête : `0.002` apparaît 7 fois dans le markdown, `0.007` 1 fois — précisément la chaîne imprimée par le code. L'étudiant qui lit la sortie puis le paragraphe voit deux chiffres pour une même grandeur.

## Fix appliqué : valeur **dérivée** de `max(ecarts_b0)`

### 1) Collecte des écarts EN−LASSO sur feature 0

Dans la boucle `for i, res in enumerate(results_colin):`, après l'impression de chaque paire :

```python
ecarts_b0.append(abs(pair_en[0] - pair_lasso[0]))
```

`ecarts_b0` est initialisée **avant** la boucle (ligne `ecarts_b0 = []` insérée juste avant `for i, res in enumerate(...)`).

### 2) `print` final — `f-string` dynamique

Remplacé :

```python
print('=> ElasticNet suit LASSO a +-0.007 pres sur la feature 0 des paires (EN ~= LASSO ici),')
```

par :

```python
print(f'=> ElasticNet suit LASSO a +-{max(ecarts_b0):.3f} pres sur la feature 0 des paires (EN ~= LASSO ici),')
```

Le format `:.3f` reproduit la précision du markdown c16 (`0.002`, 3 décimales).

### 3) Re-exécution Papermill

Papermill SUCCESS, 29/29 cellules, 0 erreur, kernel `python3`. `execution_count` 1-10 continu, outputs réels regenérés. Le `+-0.002` imprimé **coïncide exactement** avec le `±0.002` du markdown c16.

## Vérifications

```
python -m papermill 2.11-Regularisation-Sparse-LASSO.ipynb -k python3
Executing: 100%|██████████| 29/29 [00:13<00:00,  2.12cell/s]
returncode: 0

c15 outputs (last 3) :
  '   le design (rho=0.7, p=10, alpha_eq=0.4) ne reproduit PAS l'arbitraire strict du LASSO sur paires.\n'
  '=> ElasticNet suit LASSO a +-0.002 pres sur la feature 0 des paires (EN ~= LASSO ici),\n'
  '   donc aucune redistribution visible -- la difference L1/L2 est ailleurs (shrinkage L2 global),\n'

c15 execution_count: 6 (regénéré)
0 erreur dans les 29 cellules
10/10 code cells avec execution_count (1-10 continu)
```

Pre-commit (H.3 — refuse un-executed notebooks + #13326 — refuse un-compilable cell source) : **Passed**.

## Scope

| Fichier | Statut | Diff |
|---|---|---|
| `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.11-Regularisation-Sparse-LASSO.ipynb` | modified | +6/-4 (3 lignes de code c15 : init `ecarts_b0 = []`, `ecarts_b0.append(...)` dans la boucle, `print(f'...max(ecarts_b0):.3f}...')`) |

**Total : 1 fichier, +6/-4, 1 sujet unique (largement sous les seuils 3000/15).**

- Pas de modification du markdown c14/c16/c17/c27 (cohérence vérifiée : le `0.002` du markdown c16 reste exact ; `0.007` littéral restant en c27 fait partie de la conclusion et sort du scope de l'acceptance #13944).
- Pas de modification du runner, des workflows, de la config CI.
- Pas d'élargissement du kernel — Python 3.11.15 local suffit.
- Pas de modification du catalogue, harnais, ou autres scripts.

## Compliance

- **Tell c.692-L1 strict** : 1 fichier, +6/-4, 1 sujet unique.
- **Tell c.591-L1 strict** : livraison CPU-only (Python pur, pas de GPU ni de service externe).
- **Tell c.805 LEÇON DURABLE** : grain MED/notebook-python CONTENU (R6 variété : après 4 grains MED/guard consécutifs #13943 #13947 #13949 #13951, retour à notebook-python).
- **Worker identity c.598** : pas de merge, pas de `gh auth switch`, pas de close d'autrui.
- **catalog-pr-hygiene HARD 1** : aucun marqueur `CATALOG-STATUS` touché.
- **C.1** : pas de `raise NotImplementedError` / `assert False` / `1/0` ajouté.
- **C.2** : notebook committé AVEC outputs (29/29 cellules, `execution_count` 1-10 continu, 0 erreur, output c15 = `+-0.002` dérivé).
- **C.3** : scope strict = ce seul notebook, 1 cellule code touchée (c15), 0 ajout/suppression de cellule.
- **H.3** : pre-commit check `execution_count is None and not outputs` PASSED.
- **Anti-régression** : 0 stub fonctionnel, 0 `sorry` sur code de production. Le `print` ne supprime pas de cellule illustrative — il reste 4 prints avant le print dérivé (introduction rho, features actives, format paire LASSO/EN par tirage, sélection stable LASSO sur 5 tirages).
- **`[CLAIMED]` posé avant travail** (Tell c.598 + dashboard append pré-début).
- **Acceptance #13944** : 4/4 critères vérifiés à l'instant (dérivé, re-exécuté, `0.002` = c16, 0 cellule ajoutée/supprimée).

Refs #13944 (acceptance satisfaite : le `+-0.007` littéral est éliminé ; le print affiche désormais `max(ecarts_b0)` calculé sur les 5 tirages ; la valeur `+-0.002` coincide avec le markdown c16 ; notebook re-exécuté via papermill avec 0 erreur et `execution_count` 1-10 continu).
