### PR TITLE
feat(adk): execute Lab11 multi-agent loop

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.008405,
-     "end_time": "2026-08-18T01:21:28.183773",
+     "duration": 0.01556,
+     "end_time": "2026-09-01T03:38:04.148554+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:28.175368",
+     "start_time": "2026-09-01T03:38:04.132994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.007783,
-     "end_time": "2026-08-18T01:21:28.203836",
+     "duration": 0.013459,
+     "end_time": "2026-09-01T03:38:04.175500+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:28.196053",
+     "start_time": "2026-09-01T03:38:04.162041+00:00",
      "status": "completed"
     },
     "tags": []
@@ -70,10 +70,10 @@
    "id": "d11a0b01",
    "metadata": {
     "papermill": {
-     "duration": 0.009101,
-     "end_time": "2026-08-18T01:21:28.220932",
+     "duration": 0.008084,
+     "end_time": "2026-09-01T03:38:04.194483+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:28.211831",
+     "start_time": "2026-09-01T03:38:04.186399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -98,10 +98,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.008896,
-     "end_time": "2026-08-18T01:21:28.239446",
+     "duration": 0.007015,
+     "end_time": "2026-09-01T03:38:04.208371+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:28.230550",
+     "start_time": "2026-09-01T03:38:04.201356+00:00",
      "status": "completed"
     },
     "tags": []
@@ -118,16 +118,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:28.258148Z",
-     "iopub.status.busy": "2026-08-18T01:21:28.258148Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.111184Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.110048Z"
+     "iopub.execute_input": "2026-09-01T03:38:04.222025Z",
+     "iopub.status.busy": "2026-09-01T03:38:04.221756Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.059719Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.058012Z"
     },
     "papermill": {
-     "duration": 10.863838,
-     "end_time": "2026-08-18T01:21:39.112749",
+     "duration": 6.847893,
+     "end_time": "2026-09-01T03:38:11.062599+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:28.248911",
+     "start_time": "2026-09-01T03:38:04.214706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -137,13 +137,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports OK : json, re, pandas, numpy, dataclasses, Enum, config, utils\n"
+      "Imports OK : pandas, numpy, LLMClient et runtime Google ADK réel\n"
      ]
     }
    ],
    "source": [
     "import sys\n",
-    "sys.path.insert(0, '..')\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path().resolve().parent))\n",
     "\n",
     "import json\n",
     "import re\n",
@@ -155,8 +158,9 @@
     "\n",
     "from config import get_settings\n",
     "from utils import LLMClient\n",
+    "from utils.adk_runtime import build_agent, run_agent_turn\n",
     "\n",
-    "print(\"Imports OK : json, re, pandas, numpy, dataclasses, Enum, config, utils\")"
+    "print(\"Imports OK : pandas, numpy, LLMClient et runtime Google ADK réel\")"
    ]
   },
   {
@@ -165,16 +169,16 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.129339Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.129339Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.139206Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.138159Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.081157Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.079998Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.090482Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.089256Z"
     },
     "papermill": {
-     "duration": 0.019915,
-     "end_time": "2026-08-18T01:21:39.140905",
+     "duration": 0.020435,
+     "end_time": "2026-09-01T03:38:11.091453+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.120990",
+     "start_time": "2026-09-01T03:38:11.071018+00:00",
      "status": "completed"
     },
     "tags": []
@@ -198,16 +202,16 @@
    "id": "19c64070",
    "metadata": {
     "papermill": {
-     "duration": 0.007292,
-     "end_time": "2026-08-18T01:21:39.157426",
+     "duration": 0.00742,
+     "end_time": "2026-09-01T03:38:11.104728+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.150134",
+     "start_time": "2026-09-01T03:38:11.097308+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "**Lecture.** Le provider actif est `openrouter` : toutes les étapes LLM de la boucle (plan, génération de code, vérification) passeront par lui. Le fait qu'un seul provider serve les quatre rôles est un choix de simplicité pédagogique — en production, on pourrait vouloir un modèle peu coûteux pour le Planner, un modèle de code spécialisé pour le Coder, etc. L'architecture le permet sans rien changer aux classes."
+    "**Lecture.** L'output précédent donne le provider réellement actif pour cette exécution. Les étapes LLM historiques de la première boucle passent par `LLMClient`; la section Google ADK plus bas réutilise la même configuration pour construire de vrais `Agent`, sessions et `Runner`. Un provider unique simplifie le laboratoire, même si une architecture de production pourrait affecter un modèle différent à chaque rôle."
    ]
   },
   {
@@ -215,10 +219,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.008131,
-     "end_time": "2026-08-18T01:21:39.173183",
+     "duration": 0.005251,
+     "end_time": "2026-09-01T03:38:11.115661+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.165052",
+     "start_time": "2026-09-01T03:38:11.110410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -235,16 +239,16 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.191897Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.191897Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.201351Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.199681Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.128674Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.128309Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.136299Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.135294Z"
     },
     "papermill": {
-     "duration": 0.020891,
-     "end_time": "2026-08-18T01:21:39.202460",
+     "duration": 0.015525,
+     "end_time": "2026-09-01T03:38:11.137150+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.181569",
+     "start_time": "2026-09-01T03:38:11.121625+00:00",
      "status": "completed"
     },
     "tags": []
@@ -284,10 +288,10 @@
    "id": "399bb4a1",
    "metadata": {
     "papermill": {
-     "duration": 0.007928,
-     "end_time": "2026-08-18T01:21:39.218667",
+     "duration": 0.005453,
+     "end_time": "2026-09-01T03:38:11.148158+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.210739",
+     "start_time": "2026-09-01T03:38:11.142705+00:00",
      "status": "completed"
     },
     "tags": []
@@ -301,10 +305,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.00789,
-     "end_time": "2026-08-18T01:21:39.236529",
+     "duration": 0.0061,
+     "end_time": "2026-09-01T03:38:11.161356+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.228639",
+     "start_time": "2026-09-01T03:38:11.155256+00:00",
      "status": "completed"
     },
     "tags": []
@@ -321,16 +325,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.256971Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.255974Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.267072Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.265531Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.174135Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.173788Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.181815Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.180723Z"
     },
     "papermill": {
-     "duration": 0.022486,
-     "end_time": "2026-08-18T01:21:39.268394",
+     "duration": 0.015685,
+     "end_time": "2026-09-01T03:38:11.182589+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.245908",
+     "start_time": "2026-09-01T03:38:11.166904+00:00",
      "status": "completed"
     },
     "tags": []
@@ -397,10 +401,10 @@
    "id": "db065e42",
    "metadata": {
     "papermill": {
-     "duration": 0.007767,
-     "end_time": "2026-08-18T01:21:39.283857",
+     "duration": 0.005853,
+     "end_time": "2026-09-01T03:38:11.194559+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.276090",
+     "start_time": "2026-09-01T03:38:11.188706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -414,10 +418,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.007432,
-     "end_time": "2026-08-18T01:21:39.298801",
+     "duration": 0.005241,
+     "end_time": "2026-09-01T03:38:11.205059+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.291369",
+     "start_time": "2026-09-01T03:38:11.199818+00:00",
      "status": "completed"
     },
     "tags": []
@@ -434,16 +438,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.313429Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.313429Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.322504Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.321355Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.217193Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.216745Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.224163Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.223126Z"
     },
     "papermill": {
-     "duration": 0.01871,
-     "end_time": "2026-08-18T01:21:39.324100",
+     "duration": 0.014854,
+     "end_time": "2026-09-01T03:38:11.225007+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.305390",
+     "start_time": "2026-09-01T03:38:11.210153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -495,10 +499,10 @@
    "id": "88c4fe44",
    "metadata": {
     "papermill": {
-     "duration": 0.00856,
-     "end_time": "2026-08-18T01:21:39.342291",
+     "duration": 0.005271,
+     "end_time": "2026-09-01T03:38:11.235807+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.333731",
+     "start_time": "2026-09-01T03:38:11.230536+00:00",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +516,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.011673,
-     "end_time": "2026-08-18T01:21:39.368049",
+     "duration": 0.005367,
+     "end_time": "2026-09-01T03:38:11.248713+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.356376",
+     "start_time": "2026-09-01T03:38:11.243346+00:00",
      "status": "completed"
     },
     "tags": []
@@ -532,16 +536,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.398436Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.398436Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.409943Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.408361Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.260974Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.260621Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.268083Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.267110Z"
     },
     "papermill": {
-     "duration": 0.030731,
-     "end_time": "2026-08-18T01:21:39.411958",
+     "duration": 0.014742,
+     "end_time": "2026-09-01T03:38:11.268827+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.381227",
+     "start_time": "2026-09-01T03:38:11.254085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -586,10 +590,10 @@
    "id": "8c6cd29a",
    "metadata": {
     "papermill": {
-     "duration": 0.009339,
-     "end_time": "2026-08-18T01:21:39.430789",
+     "duration": 0.006383,
+     "end_time": "2026-09-01T03:38:11.280719+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.421450",
+     "start_time": "2026-09-01T03:38:11.274336+00:00",
      "status": "completed"
     },
     "tags": []
@@ -603,10 +607,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.015082,
-     "end_time": "2026-08-18T01:21:39.454431",
+     "duration": 0.005433,
+     "end_time": "2026-09-01T03:38:11.291613+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.439349",
+     "start_time": "2026-09-01T03:38:11.286180+00:00",
      "status": "completed"
     },
     "tags": []
@@ -623,16 +627,16 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.504836Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.504836Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.521724Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.520096Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.305400Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.305043Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.313469Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.311715Z"
     },
     "papermill": {
-     "duration": 0.040861,
-     "end_time": "2026-08-18T01:21:39.523722",
+     "duration": 0.017393,
+     "end_time": "2026-09-01T03:38:11.315181+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.482861",
+     "start_time": "2026-09-01T03:38:11.297788+00:00",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +689,10 @@
    "id": "13ac199c",
    "metadata": {
     "papermill": {
-     "duration": 0.01129,
-     "end_time": "2026-08-18T01:21:39.551180",
+     "duration": 0.007589,
+     "end_time": "2026-09-01T03:38:11.329190+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.539890",
+     "start_time": "2026-09-01T03:38:11.321601+00:00",
      "status": "completed"
     },
     "tags": []
@@ -702,10 +706,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.00881,
-     "end_time": "2026-08-18T01:21:39.567541",
+     "duration": 0.006729,
+     "end_time": "2026-09-01T03:38:11.343220+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.558731",
+     "start_time": "2026-09-01T03:38:11.336491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -722,16 +726,16 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.587244Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.586740Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.600860Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.599314Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.358763Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.358535Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.373087Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.371973Z"
     },
     "papermill": {
-     "duration": 0.025558,
-     "end_time": "2026-08-18T01:21:39.602309",
+     "duration": 0.02435,
+     "end_time": "2026-09-01T03:38:11.373994+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.576751",
+     "start_time": "2026-09-01T03:38:11.349644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -812,10 +816,10 @@
    "id": "1060e324",
    "metadata": {
     "papermill": {
-     "duration": 0.007623,
-     "end_time": "2026-08-18T01:21:39.617777",
+     "duration": 0.006902,
+     "end_time": "2026-09-01T03:38:11.389519+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.610154",
+     "start_time": "2026-09-01T03:38:11.382617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -829,10 +833,10 @@
    "id": "cell-17",
    "metadata": {
     "papermill": {
-     "duration": 0.007658,
-     "end_time": "2026-08-18T01:21:39.634482",
+     "duration": 0.006253,
+     "end_time": "2026-09-01T03:38:11.404913+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.626824",
+     "start_time": "2026-09-01T03:38:11.398660+00:00",
      "status": "completed"
     },
     "tags": []
@@ -849,16 +853,16 @@
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.651907Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.650903Z",
-     "iopub.status.idle": "2026-08-18T01:21:39.818061Z",
-     "shell.execute_reply": "2026-08-18T01:21:39.817051Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.424172Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.423620Z",
+     "iopub.status.idle": "2026-09-01T03:38:11.455928Z",
+     "shell.execute_reply": "2026-09-01T03:38:11.454585Z"
     },
     "papermill": {
-     "duration": 0.176528,
-     "end_time": "2026-08-18T01:21:39.819524",
+     "duration": 0.043495,
+     "end_time": "2026-09-01T03:38:11.456902+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.642996",
+     "start_time": "2026-09-01T03:38:11.413407+00:00",
      "status": "completed"
     },
     "tags": []
@@ -868,7 +872,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dataset: 200 lignes\n"
+      "Dataset reproductible : 200 lignes, 5 colonnes\n"
      ]
     },
     {
@@ -904,41 +908,41 @@
        "      <th>0</th>\n",
        "      <td>2024-01-01</td>\n",
        "      <td>A</td>\n",
-       "      <td>Est</td>\n",
-       "      <td>678.72</td>\n",
-       "      <td>19</td>\n",
+       "      <td>Sud</td>\n",
+       "      <td>3909.28</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>2024-01-02</td>\n",
-       "      <td>A</td>\n",
+       "      <td>D</td>\n",
        "      <td>Ouest</td>\n",
-       "      <td>2335.31</td>\n",
-       "      <td>34</td>\n",
+       "      <td>4861.95</td>\n",
+       "      <td>30</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2024-01-03</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Nord</td>\n",
-       "      <td>3707.85</td>\n",
-       "      <td>67</td>\n",
+       "      <td>C</td>\n",
+       "      <td>Sud</td>\n",
+       "      <td>2553.63</td>\n",
+       "      <td>52</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>2024-01-04</td>\n",
        "      <td>B</td>\n",
-       "      <td>Sud</td>\n",
-       "      <td>615.84</td>\n",
-       "      <td>73</td>\n",
+       "      <td>Est</td>\n",
+       "      <td>805.10</td>\n",
+       "      <td>91</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>2024-01-05</td>\n",
        "      <td>B</td>\n",
        "      <td>Sud</td>\n",
-       "      <td>926.13</td>\n",
-       "      <td>80</td>\n",
+       "      <td>168.29</td>\n",
+       "      <td>74</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -946,11 +950,11 @@
       ],
       "text/plain": [
        "        date product region  revenue  units\n",
-       "0 2024-01-01       A    Est   678.72     19\n",
-       "1 2024-01-02       A  Ouest  2335.31     34\n",
-       "2 2024-01-03       A   Nord  3707.85     67\n",
-       "3 2024-01-04       B    Sud   615.84     73\n",
-       "4 2024-01-05       B    Sud   926.13     80"
+       "0 2024-01-01       A    Sud  3909.28      2\n",
+       "1 2024-01-02       D  Ouest  4861.95     30\n",
+       "2 2024-01-03       C    Sud  2553.63     52\n",
+       "3 2024-01-04       B    Est   805.10     91\n",
+       "4 2024-01-05       B    Sud   168.29     74"
       ]
      },
      "execution_count": 9,
@@ -959,18 +963,17 @@
     }
    ],
    "source": [
-    "# Dataset de test\n",
-    "import tempfile\n",
-    "import os\n",
+    "# Dataset de test reproductible\n",
+    "rng = np.random.default_rng(42)\n",
     "\n",
     "df = pd.DataFrame({\n",
     "    'date': pd.date_range('2024-01-01', periods=200, freq='D'),\n",
-    "    'product': np.random.choice(['A', 'B', 'C', 'D'], 200),\n",
-    "    'region': np.random.choice(['Nord', 'Sud', 'Est', 'Ouest'], 200),\n",
-    "    'revenue': np.random.uniform(100, 5000, 200).round(2),\n",
-    "    'units': np.random.randint(1, 100, 200)\n",
+    "    'product': rng.choice(['A', 'B', 'C', 'D'], 200),\n",
+    "    'region': rng.choice(['Nord', 'Sud', 'Est', 'Ouest'], 200),\n",
+    "    'revenue': rng.uniform(100, 5000, 200).round(2),\n",
+    "    'units': rng.integers(1, 100, 200)\n",
     "})\n",
-    "print(f'Dataset: {len(df)} lignes')\n",
+    "print(f'Dataset reproductible : {len(df)} lignes, {len(df.columns)} colonnes')\n",
     "df.head()"
    ]
   },
@@ -979,16 +982,16 @@
    "id": "98d61c5a",
    "metadata": {
     "papermill": {
-     "duration": 0.007385,
-     "end_time": "2026-08-18T01:21:39.835039",
+     "duration": 0.00986,
+     "end_time": "2026-09-01T03:38:11.474494+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.827654",
+     "start_time": "2026-09-01T03:38:11.464634+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "**Lecture du test.** L'agent tourne avec `max_iterations=1` pour la rapidité. Observez la trace : le Planner produit 3 étapes, le Coder génère du code, l'Executor l'exécute — mais le code référence `['revenu']` alors que la colonne s'appelle `revenue` : **KeyError**. C'est l'échec canonique d'un Coder LLM (mauvais nom de colonne inféré). Avec une seule itération, la boucle ne peut pas corriger : l'agent rend « Max iterations atteint ». Avec `max_iterations=3`, le Verifier renverrait `NEEDS_REFINEMENT` et le Coder recevrait l'erreur `['revenu']` en contexte — il corrigerait en `revenue` à la tentative suivante. **C'est précisément la valeur de la boucle itérative** : transformer un échec de génération en succès par raffinement."
+    "La cellule suivante exécute la boucle historique `LLMClient` avec une seule itération. Sa trace permet d'observer le plan produit, le code exécuté et le verdict réellement obtenu, sans présupposer un échec particulier du modèle."
    ]
   },
   {
@@ -997,16 +1000,16 @@
    "id": "cell-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:39.851569Z",
-     "iopub.status.busy": "2026-08-18T01:21:39.851569Z",
-     "iopub.status.idle": "2026-08-18T01:21:51.360750Z",
-     "shell.execute_reply": "2026-08-18T01:21:51.359726Z"
+     "iopub.execute_input": "2026-09-01T03:38:11.493660Z",
+     "iopub.status.busy": "2026-09-01T03:38:11.493233Z",
+     "iopub.status.idle": "2026-09-01T03:38:20.792349Z",
+     "shell.execute_reply": "2026-09-01T03:38:20.791130Z"
     },
     "papermill": {
-     "duration": 11.51988,
-     "end_time": "2026-08-18T01:21:51.362639",
+     "duration": 9.309168,
+     "end_time": "2026-09-01T03:38:20.793299+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:39.842759",
+     "start_time": "2026-09-01T03:38:11.484131+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1025,7 +1028,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Etapes: 4\n",
+      "Etapes: 5\n",
       "[CODER] Generation du code...\n"
      ]
     },
@@ -1033,40 +1036,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[EXECUTOR] Execution...\n",
-      "[OUTPUT] Revenu moyen par région:\n",
-      "region\n",
-      "Est      2558.928077\n",
-      "Nord     2766.246667\n",
-      "Ouest    2240.093636\n",
-      "Sud      2247.413214\n",
-      "Name: revenue, dtype: float64\n",
-      "\n",
-      "Région avec le revenu moyen le plus élevé:\n",
-      "Région: No...\n",
-      "[VERIFIER] Verification...\n"
+      "[EXECUTOR] Execution...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[STATUS] success: Resultat valide\n",
+      "[ERROR] ['revenu']\n",
       "\n",
       "==================================================\n",
       "RESULTAT FINAL:\n",
       "==================================================\n",
-      "Revenu moyen par région:\n",
-      "region\n",
-      "Est      2558.928077\n",
-      "Nord     2766.246667\n",
-      "Ouest    2240.093636\n",
-      "Sud      2247.413214\n",
-      "Name: revenue, dtype: float64\n",
-      "\n",
-      "Région avec le revenu moyen le plus élevé:\n",
-      "Région: Nord, Revenu moyen: 2766.2466666666664\n",
-      "\n"
+      "Erreur: Max iterations atteint\n"
      ]
     }
    ],
@@ -1088,37 +1070,411 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-20",
+   "id": "c1c4cc05",
    "metadata": {
     "papermill": {
-     "duration": 0.011609,
-     "end_time": "2026-08-18T01:21:51.383415",
+     "duration": 0.006901,
+     "end_time": "2026-09-01T03:38:20.807048+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:51.371806",
+     "start_time": "2026-09-01T03:38:20.800147+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 10. Résumé du Lab\n",
+    "**Lecture du résultat historique.** La trace précédente montre le comportement réellement obtenu par `LLMClient` sur ce dataset seedé : elle indique le nombre d'étapes, l'output de l'Executor et le verdict du Verifier. Cette observation sert de point de comparaison à la jambe ADK, sans généraliser un succès ou un échec stochastique à toutes les exécutions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62040692",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006474,
+     "end_time": "2026-09-01T03:38:20.820100+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:20.813626+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. La même boucle sur le vrai runtime Google ADK\n",
+    "\n",
+    "La première implémentation rend les contrats Planner-Coder-Executor-Verifier explicites, mais ses rôles LLM sont des wrappers maison autour de `LLMClient`. Cette seconde jambe conserve exactement la boucle pédagogique tout en remplaçant chaque rôle LLM par un vrai `google.adk.agents.Agent` exécuté dans une session par un `Runner`.\n",
+    "\n",
+    "L'Executor reste volontairement local et déterministe : ADK orchestre le raisonnement et les événements, tandis que le code Pandas généré reste visible, exécutable et inspectable. Le Planner reçoit un outil Python réel pour lire le schéma au lieu de l'inventer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1cdbb1c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T03:38:20.838778Z",
+     "iopub.status.busy": "2026-09-01T03:38:20.838231Z",
+     "iopub.status.idle": "2026-09-01T03:38:20.845292Z",
+     "shell.execute_reply": "2026-09-01T03:38:20.844064Z"
+    },
+    "papermill": {
+     "duration": 0.015672,
+     "end_time": "2026-09-01T03:38:20.846194+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:20.830522+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outil ADK prêt : get_dataset_schema expose 200 lignes et 5 colonnes\n"
+     ]
+    }
+   ],
+   "source": [
+    "def get_dataset_schema() -> Dict:\n",
+    "    \"\"\"Retourne au Planner ADK le schéma réellement disponible.\"\"\"\n",
+    "    return {\n",
+    "        \"rows\": int(len(df)),\n",
+    "        \"columns\": {name: str(dtype) for name, dtype in df.dtypes.items()},\n",
+    "    }\n",
+    "\n",
+    "print(\n",
+    "    \"Outil ADK prêt : get_dataset_schema expose \"\n",
+    "    f\"{len(df)} lignes et {len(df.columns)} colonnes\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5bab19c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014988,
+     "end_time": "2026-09-01T03:38:20.871723+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:20.856735+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le schéma est désormais obtenu par un outil déterministe. La cellule suivante construit les trois rôles ADK et garde explicitement la boucle d'orchestration dans le notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7f241f0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T03:38:20.895463Z",
+     "iopub.status.busy": "2026-09-01T03:38:20.895134Z",
+     "iopub.status.idle": "2026-09-01T03:38:20.911435Z",
+     "shell.execute_reply": "2026-09-01T03:38:20.910164Z"
+    },
+    "papermill": {
+     "duration": 0.028508,
+     "end_time": "2026-09-01T03:38:20.912426+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:20.883918+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Boucle ADK définie : Planner, Coder et Verifier utilisent de vrais Agent/Runner\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def adk_analyze(question: str, max_iterations: int = 2) -> Dict:\n",
+    "    \"\"\"Exécute la boucle visible Planner → Coder → Executor → Verifier.\"\"\"\n",
+    "    schema = get_dataset_schema()\n",
+    "    context = (\n",
+    "        \"DataFrame df disponible. Schéma exact: \"\n",
+    "        f\"{json.dumps(schema, ensure_ascii=False)}. \"\n",
+    "        \"Le Planner doit appeler get_dataset_schema.\"\n",
+    "    )\n",
+    "    executor = Executor(df)\n",
+    "    evidence = {}\n",
+    "    last_result = ExecutionResult(False, \"\", \"Aucune exécution\")\n",
+    "    last_verdict = \"FAILED\"\n",
+    "\n",
+    "    planner = build_agent(\n",
+    "        \"lab11_planner\",\n",
+    "        \"Planifie une analyse de données à partir du schéma réel.\",\n",
+    "        (\n",
+    "            \"Appelle obligatoirement get_dataset_schema. Réponds ensuite avec \"\n",
+    "            \"REASONING: sur une ligne, puis STEPS: et 3 étapes numérotées.\"\n",
+    "        ),\n",
+    "        tools=(get_dataset_schema,),\n",
+    "    )\n",
+    "    coder = build_agent(\n",
+    "        \"lab11_coder\",\n",
+    "        \"Transforme un plan d'analyse en code Pandas exécutable.\",\n",
+    "        (\n",
+    "            \"Réponds uniquement avec un bloc ```python```. Le DataFrame s'appelle \"\n",
+    "            \"df. Respecte exactement le schéma fourni et la métrique demandée: \"\n",
+    "            \"revenue désigne le revenu, units le nombre d'unités. Utilise print().\"\n",
+    "        ),\n",
+    "    )\n",
+    "    verifier = build_agent(\n",
+    "        \"lab11_verifier\",\n",
+    "        \"Vérifie qu'une sortie répond à la question initiale.\",\n",
+    "        (\n",
+    "            \"Commence impérativement par SUCCESS, NEEDS_REFINEMENT ou FAILED, \"\n",
+    "            \"puis justifie en une phrase. Vérifie le nom exact de la métrique.\"\n",
+    "        ),\n",
+    "    )\n",
+    "\n",
+    "    for iteration in range(max_iterations):\n",
+    "        planner_session = f\"lab11-planner-{iteration}\"\n",
+    "        plan_turn = await run_agent_turn(\n",
+    "            planner,\n",
+    "            f\"QUESTION: {question}\\nCONTEXTE: {context}\",\n",
+    "            session_id=planner_session,\n",
+    "        )\n",
+    "        evidence[f\"planner-{iteration}\"] = {\n",
+    "            \"session_id\": planner_session,\n",
+    "            \"events\": plan_turn.event_count,\n",
+    "            \"tool_calls\": \", \".join(plan_turn.tool_calls),\n",
+    "            \"tool_responses\": \", \".join(plan_turn.tool_responses),\n",
+    "        }\n",
+    "\n",
+    "        coder_session = f\"lab11-coder-{iteration}\"\n",
+    "        code_turn = await run_agent_turn(\n",
+    "            coder,\n",
+    "            f\"QUESTION: {question}\\nPLAN:\\n{plan_turn.response_text}\\nCONTEXTE: {context}\",\n",
+    "            session_id=coder_session,\n",
+    "        )\n",
+    "        evidence[f\"coder-{iteration}\"] = {\n",
+    "            \"session_id\": coder_session,\n",
+    "            \"events\": code_turn.event_count,\n",
+    "            \"tool_calls\": \", \".join(code_turn.tool_calls),\n",
+    "            \"tool_responses\": \", \".join(code_turn.tool_responses),\n",
+    "        }\n",
+    "        match = re.search(\n",
+    "            r\"```(?:python)?\\s*(.*?)\\s*```\",\n",
+    "            code_turn.response_text,\n",
+    "            re.DOTALL,\n",
+    "        )\n",
+    "        code = match.group(1).strip() if match else code_turn.response_text.strip()\n",
+    "        last_result = executor.execute(code)\n",
+    "\n",
+    "        verifier_session = f\"lab11-verifier-{iteration}\"\n",
+    "        verify_turn = await run_agent_turn(\n",
+    "            verifier,\n",
+    "            (\n",
+    "                f\"QUESTION: {question}\\nSCHÉMA: {json.dumps(schema, ensure_ascii=False)}\\n\"\n",
+    "                f\"SUCCÈS EXÉCUTION: {last_result.success}\\n\"\n",
+    "                f\"ERREUR: {last_result.error}\\nSORTIE:\\n{last_result.output[:1200]}\"\n",
+    "            ),\n",
+    "            session_id=verifier_session,\n",
+    "        )\n",
+    "        evidence[f\"verifier-{iteration}\"] = {\n",
+    "            \"session_id\": verifier_session,\n",
+    "            \"events\": verify_turn.event_count,\n",
+    "            \"tool_calls\": \", \".join(verify_turn.tool_calls),\n",
+    "            \"tool_responses\": \", \".join(verify_turn.tool_responses),\n",
+    "        }\n",
+    "        last_verdict = verify_turn.response_text.strip()\n",
+    "        verdict_match = re.match(\n",
+    "            r\"^(SUCCESS|NEEDS_REFINEMENT|FAILED)\\b\",\n",
+    "            last_verdict.upper(),\n",
+    "        )\n",
+    "        verdict_token = verdict_match.group(1) if verdict_match else \"FAILED\"\n",
+    "        if last_result.success and verdict_token == \"SUCCESS\":\n",
+    "            return {\n",
+    "                \"success\": True,\n",
+    "                \"output\": last_result.output,\n",
+    "                \"code\": code,\n",
+    "                \"iterations\": iteration + 1,\n",
+    "                \"verdict\": last_verdict,\n",
+    "                \"planner_tool_round_trip\": plan_turn.tool_was_invoked,\n",
+    "                \"evidence\": evidence,\n",
+    "            }\n",
+    "\n",
+    "        context += (\n",
+    "            f\"\\nTentative {iteration + 1}: erreur={last_result.error}; \"\n",
+    "            f\"verdict={last_verdict}; corrige le code.\"\n",
+    "        )\n",
+    "\n",
+    "    return {\n",
+    "        \"success\": False,\n",
+    "        \"output\": last_result.output,\n",
+    "        \"error\": last_result.error or \"Max iterations atteint\",\n",
+    "        \"iterations\": max_iterations,\n",
+    "        \"verdict\": last_verdict,\n",
+    "        \"planner_tool_round_trip\": any(\n",
+    "            item[\"tool_calls\"] and item[\"tool_responses\"]\n",
+    "            for role, item in evidence.items()\n",
+    "            if role.startswith(\"planner-\")\n",
+    "        ),\n",
+    "        \"evidence\": evidence,\n",
+    "    }\n",
+    "\n",
+    "print(\"Boucle ADK définie : Planner, Coder et Verifier utilisent de vrais Agent/Runner\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0bc8702",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006966,
+     "end_time": "2026-09-01T03:38:20.926615+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:20.919649+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "La fonction est définie sans encore appeler le provider. L'exécution suivante lance réellement les trois rôles et imprime les preuves issues de leurs flux d'événements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0aa32687",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T03:38:20.942125Z",
+     "iopub.status.busy": "2026-09-01T03:38:20.941730Z",
+     "iopub.status.idle": "2026-09-01T03:38:28.747026Z",
+     "shell.execute_reply": "2026-09-01T03:38:28.744070Z"
+    },
+    "papermill": {
+     "duration": 7.815635,
+     "end_time": "2026-09-01T03:38:28.749233+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:20.933598+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "==================================================\n",
+      "PREUVE GOOGLE ADK RÉELLE\n",
+      "==================================================\n",
+      "planner-0: session=lab11-planner-0, events=3, tool_calls=get_dataset_schema, tool_responses=get_dataset_schema\n",
+      "coder-0: session=lab11-coder-0, events=1, tool_calls=aucun, tool_responses=aucune\n",
+      "verifier-0: session=lab11-verifier-0, events=1, tool_calls=aucun, tool_responses=aucune\n",
+      "Planner tool round-trip: True\n",
+      "Succès: True\n",
+      "Itérations: 1\n",
+      "Région attendue (calcul déterministe): Ouest\n",
+      "Verdict LLM: SUCCESS, la sortie répond correctement à la question initiale en identifiant la région avec le plus grand revenu moyen.\n",
+      "Sortie Executor:\n",
+      "La région avec le plus grand revenu moyen est Ouest avec un revenu moyen de 2800.6191304347826.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exécution réelle : trois Agent ADK, trois sessions, trois Runner et un outil\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.filterwarnings(\n",
+    "        \"ignore\",\n",
+    "        message=(\n",
+    "            r\"\\[EXPERIMENTAL\\] feature \"\n",
+    "            r\"FeatureName\\.JSON_SCHEMA_FOR_FUNC_DECL is enabled\\.\"\n",
+    "        ),\n",
+    "        category=UserWarning,\n",
+    "        module=r\"google\\.adk\\.models\\.llm_request\",\n",
+    "    )\n",
+    "    adk_result = await adk_analyze(question)\n",
+    "\n",
+    "expected_region = df.groupby(\"region\")[\"revenue\"].mean().idxmax()\n",
+    "assert adk_result[\"planner_tool_round_trip\"], \"Le Planner ADK n'a pas appelé l'outil\"\n",
+    "assert adk_result[\"success\"], f\"La boucle ADK a échoué: {adk_result['verdict']}\"\n",
+    "assert expected_region in adk_result[\"output\"], (\n",
+    "    \"La sortie LLM/Executor ne nomme pas la région calculée avec revenue\"\n",
+    ")\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 50)\n",
+    "print(\"PREUVE GOOGLE ADK RÉELLE\")\n",
+    "print(\"=\" * 50)\n",
+    "for role, evidence in adk_result[\"evidence\"].items():\n",
+    "    print(\n",
+    "        f\"{role}: session={evidence['session_id']}, \"\n",
+    "        f\"events={evidence['events']}, \"\n",
+    "        f\"tool_calls={evidence['tool_calls'] or 'aucun'}, \"\n",
+    "        f\"tool_responses={evidence['tool_responses'] or 'aucune'}\"\n",
+    "    )\n",
+    "print(f\"Planner tool round-trip: {adk_result['planner_tool_round_trip']}\")\n",
+    "print(f\"Succès: {adk_result['success']}\")\n",
+    "print(f\"Itérations: {adk_result['iterations']}\")\n",
+    "print(f\"Région attendue (calcul déterministe): {expected_region}\")\n",
+    "print(f\"Verdict LLM: {adk_result['verdict']}\")\n",
+    "print(f\"Sortie Executor:\\n{adk_result['output']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc9d6d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008117,
+     "end_time": "2026-09-01T03:38:28.770733+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:28.762616+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat ADK.** La trace précédente est la preuve d'exécution : chaque rôle LLM possède une session nommée et émet des événements via un `Runner`. Le Planner réalise en plus un aller-retour d'outil (`get_dataset_schema`) avant que le Coder ne produise le code, que l'Executor local ne l'exécute et que le Verifier ne rende son verdict. Cette jambe n'est donc ni une classe maison appelée « ADK », ni une réponse simulée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005876,
+     "end_time": "2026-09-01T03:38:28.782506+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T03:38:28.776630+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 11. Résumé du Lab\n",
     "\n",
     "### Ce que nous avons implémenté\n",
     "\n",
     "1. **Planner** : décompose la question en étapes d'analyse, avec raisonnement.\n",
     "2. **Coder** : génère le code Python qui exécute le plan, à partir du contexte.\n",
-    "3. **Executor** : exécute le code en sandbox et capture stdout + erreurs.\n",
+    "3. **Executor** : exécute le code dans un namespace contrôlé et capture stdout + erreurs.\n",
     "4. **Verifier** : valide le résultat (`SUCCESS`), demande un raffinement (`NEEDS_REFINEMENT`) ou déclare l'échec (`FAILED`).\n",
+    "5. **Google ADK réel** : instancie les rôles LLM comme de vrais `Agent`, crée une session et un `Runner` par rôle, puis observe les événements et le round-trip d'outil du Planner.\n",
     "\n",
     "### Points clés\n",
     "\n",
-    "- **La boucle itérative est la valeur ajoutée de DS-STAR** : un pipeline linéaire aurait échoué sur le `['revenu']` du test ; la boucle rattrape l'erreur en réinjectant le contexte de l'échec au Coder.\n",
-    "- **Le Verifier est le point de décision** : `NEEDS_REFINEMENT` (retry) vs `FAILED` (arrêt) pilote toute l'orchestration. Sans ce verdict à trois valeurs, pas de correction automatique.\n",
-    "- **`max_iterations` est un compromis coût/qualité** : trop bas (1), aucun retry possible ; trop haut, coût LLM non borné.\n",
-    "- **Le contexte s'enrichit à chaque itération** : le Coder de la tentative N+1 voit le code et l'erreur de la tentative N — c'est ce qui rend la correction possible.\n",
+    "- **La boucle itérative est la valeur ajoutée de DS-STAR** : une erreur observée peut être réinjectée dans le contexte de l'itération suivante au lieu de devenir un échec silencieux.\n",
+    "- **Le Verifier est le point de décision** : son verdict pilote le succès, le raffinement ou l'arrêt.\n",
+    "- **`max_iterations` est un compromis coût/qualité** : il borne explicitement le nombre d'appels LLM.\n",
+    "- **ADK orchestre, l'Executor reste déterministe** : le runtime agentique porte les rôles LLM et leurs événements; l'exécution Pandas reste visible et contrôlée dans le notebook.\n",
     "\n",
     "### Prochaine étape\n",
     "\n",
-    "- **Lab 12** : workshop DS-STAR complet sur fichiers réels, où la boucle tourne avec assez d'itérations pour rattraper les échecs de génération."
+    "- **Lab 12** : workshop DS-STAR complet sur fichiers réels, avec davantage d'itérations et de cas d'échec à raffiner."
    ]
   },
   {
@@ -1126,10 +1482,10 @@
    "id": "6df71151",
    "metadata": {
     "papermill": {
-     "duration": 0.007864,
-     "end_time": "2026-08-18T01:21:51.399775",
+     "duration": 0.006169,
+     "end_time": "2026-09-01T03:38:28.796748+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:51.391911",
+     "start_time": "2026-09-01T03:38:28.790579+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1148,20 +1504,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "f634ec8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:21:51.415914Z",
-     "iopub.status.busy": "2026-08-18T01:21:51.415914Z",
-     "iopub.status.idle": "2026-08-18T01:22:24.032876Z",
-     "shell.execute_reply": "2026-08-18T01:22:24.031758Z"
+     "iopub.execute_input": "2026-09-01T03:38:28.902799Z",
+     "iopub.status.busy": "2026-09-01T03:38:28.901728Z",
+     "iopub.status.idle": "2026-09-01T03:38:50.278861Z",
+     "shell.execute_reply": "2026-09-01T03:38:50.275515Z"
     },
     "papermill": {
-     "duration": 32.627099,
-     "end_time": "2026-08-18T01:22:24.033974",
+     "duration": 21.464735,
+     "end_time": "2026-09-01T03:38:50.280854+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:21:51.406875",
+     "start_time": "2026-09-01T03:38:28.816119+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1172,7 +1528,14 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "=== ITERATION 1/2 ===\n",
+      "=== ITERATION 1/2 ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "[PLANNER] Creation du plan...\n"
      ]
     },
@@ -1216,14 +1579,11 @@
       "[EXECUTOR] Execution...\n",
       "[OUTPUT] Le DataFrame est vide.\n",
       "\n",
-      "Informations sur le DataFrame:\n",
-      "<class 'pandas.DataFrame'>\n",
-      "RangeIndex: 0 entries\n",
+      "Aperçu du DataFrame après nettoyage :\n",
       "Empty DataFrame\n",
-      "None\n",
-      "\n",
-      "Statistiques descriptives du DataFrame:\n",
-      "Aucune colonne numérique pour géné...\n",
+      "Columns: []\n",
+      "Index: []\n",
+      "...\n",
       "[VERIFIER] Verification...\n"
      ]
     },
@@ -1261,10 +1621,10 @@
    "id": "634904e2",
    "metadata": {
     "papermill": {
-     "duration": 0.007132,
-     "end_time": "2026-08-18T01:22:24.050578",
+     "duration": 0.012195,
+     "end_time": "2026-09-01T03:38:50.306940+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:22:24.043446",
+     "start_time": "2026-09-01T03:38:50.294745+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1287,20 +1647,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "4ae50f65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:22:24.066718Z",
-     "iopub.status.busy": "2026-08-18T01:22:24.066718Z",
-     "iopub.status.idle": "2026-08-18T01:22:24.075671Z",
-     "shell.execute_reply": "2026-08-18T01:22:24.074662Z"
+     "iopub.execute_input": "2026-09-01T03:38:50.322821Z",
+     "iopub.status.busy": "2026-09-01T03:38:50.322366Z",
+     "iopub.status.idle": "2026-09-01T03:38:50.331958Z",
+     "shell.execute_reply": "2026-09-01T03:38:50.330632Z"
     },
     "papermill": {
-     "duration": 0.018951,
-     "end_time": "2026-08-18T01:22:24.077327",
+     "duration": 0.018538,
+     "end_time": "2026-09-01T03:38:50.332993+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:22:24.058376",
+     "start_time": "2026-09-01T03:38:50.314455+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1377,10 +1737,10 @@
    "id": "7828bf97",
    "metadata": {
     "papermill": {
-     "duration": 0.008486,
-     "end_time": "2026-08-18T01:22:24.094622",
+     "duration": 0.007033,
+     "end_time": "2026-09-01T03:38:50.347351+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:22:24.086136",
+     "start_time": "2026-09-01T03:38:50.340318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1403,20 +1763,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "ffe721d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:22:24.111775Z",
-     "iopub.status.busy": "2026-08-18T01:22:24.110744Z",
-     "iopub.status.idle": "2026-08-18T01:22:24.121622Z",
-     "shell.execute_reply": "2026-08-18T01:22:24.120511Z"
+     "iopub.execute_input": "2026-09-01T03:38:50.390539Z",
+     "iopub.status.busy": "2026-09-01T03:38:50.388548Z",
+     "iopub.status.idle": "2026-09-01T03:38:50.404986Z",
+     "shell.execute_reply": "2026-09-01T03:38:50.403599Z"
     },
     "papermill": {
-     "duration": 0.020535,
-     "end_time": "2026-08-18T01:22:24.122914",
+     "duration": 0.050717,
+     "end_time": "2026-09-01T03:38:50.408491+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:22:24.102379",
+     "start_time": "2026-09-01T03:38:50.357774+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1505,10 +1865,10 @@
    "id": "b3a3c2de",
    "metadata": {
     "papermill": {
-     "duration": 0.007729,
-     "end_time": "2026-08-18T01:22:24.139191",
+     "duration": 0.016358,
+     "end_time": "2026-09-01T03:38:50.435423+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:22:24.131462",
+     "start_time": "2026-09-01T03:38:50.419065+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1525,10 +1885,10 @@
    "id": "cell-7ada47b8",
    "metadata": {
     "papermill": {
-     "duration": 0.007733,
-     "end_time": "2026-08-18T01:22:24.155185",
+     "duration": 0.009297,
+     "end_time": "2026-09-01T03:38:50.462319+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:22:24.147452",
+     "start_time": "2026-09-01T03:38:50.453022+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1576,18 +1936,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.14"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 61.251999,
-   "end_time": "2026-08-18T01:22:26.449556",
+   "duration": 49.785094,
+   "end_time": "2026-09-01T03:38:52.209555+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Lab11-Planner-Coder-Loop.ipynb",
    "output_path": "Lab11-Planner-Coder-Loop.ipynb",
    "parameters": {},
-   "start_time": "2026-08-18T01:21:25.197557",
+   "start_time": "2026-09-01T03:38:02.424461+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
@@ -81,10 +81,28 @@ def build_adk_model(config: ProviderConfig) -> LiteLlm:
     return LiteLlm(model=get_litellm_model(config), **kwargs)
 
 
-def build_data_agent(config: ProviderConfig | None = None) -> Agent:
-    """Construct a real Google ADK agent with a deterministic Python tool."""
+def build_agent(
+    name: str,
+    description: str,
+    instruction: str,
+    *,
+    tools: tuple = (),
+    config: ProviderConfig | None = None,
+) -> Agent:
+    """Construct a real Google ADK agent for one pedagogical role."""
     provider = config or get_provider_config()
     return Agent(
+        name=name,
+        description=description,
+        instruction=instruction,
+        model=build_adk_model(provider),
+        tools=list(tools),
+    )
+
+
+def build_data_agent(config: ProviderConfig | None = None) -> Agent:
+    """Construct a real Google ADK agent with a deterministic Python tool."""
+    return build_agent(
         name="dataset_profile_agent",
         description="Analyse la forme d'un jeu de données tabulaire.",
         instruction=(
@@ -92,8 +110,8 @@ def build_data_agent(config: ProviderConfig | None = None) -> Agent:
             "nombre de lignes et de colonnes, appelle obligatoirement l'outil "
             "dataset_profile, puis explique brièvement son résultat."
         ),
-        model=build_adk_model(provider),
-        tools=[dataset_profile],
+        tools=(dataset_profile,),
+        config=config,
     )
 
 
@@ -103,19 +121,18 @@ def _part_text(content: types.Content | None) -> str:
     return "".join(part.text or "" for part in content.parts).strip()
 
 
-async def run_data_agent(
+async def run_agent_turn(
+    agent: Agent,
     prompt: str,
-    config: ProviderConfig | None = None,
     *,
     app_name: str = APP_NAME,
     user_id: str = "track2-user",
     session_id: str | None = None,
     timeout_seconds: float = 120.0,
 ) -> AdkRunResult:
-    """Run one real ADK turn and return evidence from its event stream."""
+    """Run one real ADK agent turn and return its observable evidence."""
     session_id = session_id or f"session-{uuid4().hex}"
     session_service = InMemorySessionService()
-    agent = build_data_agent(config)
     runner = Runner(
         agent=agent,
         app_name=app_name,
@@ -190,6 +207,26 @@ async def run_data_agent(
         event_count=event_count,
         tool_calls=tuple(tool_calls),
         tool_responses=tuple(tool_responses),
+    )
+
+
+async def run_data_agent(
+    prompt: str,
+    config: ProviderConfig | None = None,
+    *,
+    app_name: str = APP_NAME,
+    user_id: str = "track2-user",
+    session_id: str | None = None,
+    timeout_seconds: float = 120.0,
+) -> AdkRunResult:
+    """Run the track's dataset agent through the generic ADK turn."""
+    return await run_agent_turn(
+        build_data_agent(config),
+        prompt,
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        timeout_seconds=timeout_seconds,
     )
 
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime.py
@@ -83,6 +83,20 @@ def test_build_data_agent_uses_public_adk_agent_and_real_tool():
     assert agent.tools[0] is dataset_profile
 
 
+def test_build_agent_supports_distinct_pedagogical_roles():
+    agent = adk_runtime.build_agent(
+        name="planner_agent",
+        description="Planifie une analyse.",
+        instruction="Produis un plan court.",
+        tools=(dataset_profile,),
+        config=_config(),
+    )
+    assert agent.name == "planner_agent"
+    assert agent.description == "Planifie une analyse."
+    assert agent.instruction == "Produis un plan court."
+    assert agent.tools[0] is dataset_profile
+
+
 class _Event:
     def __init__(self, *, final=False, content=None, calls=(), responses=()):
         self._final = final
@@ -150,6 +164,31 @@ def test_run_data_agent_creates_session_and_collects_adk_evidence():
         assert result.tool_calls == ("dataset_profile",)
         assert result.tool_responses == ("dataset_profile",)
         assert result.tool_was_invoked
+        runner.close.assert_awaited_once()
+
+    adk_runtime.asyncio.run(exercise())
+
+
+def test_run_agent_turn_uses_the_supplied_adk_agent():
+    async def exercise():
+        service = MagicMock()
+        service.create_session = AsyncMock()
+        agent = MagicMock(name="planner_agent")
+        _Runner.instances.clear()
+        with (
+            patch.object(adk_runtime, "InMemorySessionService", return_value=service),
+            patch.object(adk_runtime, "Runner", _Runner),
+        ):
+            result = await adk_runtime.run_agent_turn(
+                agent,
+                "Planifie cette analyse",
+                session_id="planner-session",
+            )
+
+        runner = _Runner.instances[0]
+        assert runner.kwargs["agent"] is agent
+        assert runner.run_kwargs["session_id"] == "planner-session"
+        assert result.response_text == "960 cellules"
         runner.close.assert_awaited_once()
 
     adk_runtime.asyncio.run(exercise())


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #13945

## Résumé

- migre la boucle Planner-Coder-Executor-Verifier de Lab11 vers une seconde jambe exécutée par le vrai runtime Google ADK ;
- construit trois vrais `google.adk.agents.Agent` (Planner, Coder, Verifier), chacun exécuté dans une session par un `Runner` ;
- conserve l'Executor Pandas local et visible afin que le code généré, son output et les erreurs restent inspectables ;
- impose au Planner un round-trip réel avec l'outil `get_dataset_schema` ;
- étend le runtime partagé avec `build_agent` et `run_agent_turn`, tout en préservant l'API `run_data_agent` utilisée par Lab10 ;
- ajoute un garde métier falsifiable : la cellule échoue si le tool round-trip manque, si ADK ne conclut pas au succès ou si la sortie ne nomme pas la région calculée indépendamment sur `revenue` ;
- rend le dataset reproductible avec `numpy.random.default_rng(42)` et retire les affirmations manuelles périmées sur le provider et une KeyError supposée.

## Retargetage terminé

#13945 est mergée. La branche a été reconstruite sur `origin/main` courant puis le commit Lab11 seul a été réappliqué. Le diff porte désormais uniquement Lab11 et les extensions/tests du runtime partagé nécessaires à sa boucle multi-agent ; Lab10 n'est plus dans le périmètre de la PR.

## Exécution réelle

Provider d'exécution : OpenAI, modèle `gpt-4o-mini`.

Le provider Qwen local n'était pas provisionné sur cette lane. Aucun mock, fallback simulé ou output fabriqué n'est utilisé : la série a été provisionnée localement depuis `.secrets/master.env` dans son `.env` gitignored, puis le notebook a été exécuté intégralement.

Preuve committée :

```text
planner-0: session=lab11-planner-0, events=3,
           tool_calls=get_dataset_schema,
           tool_responses=get_dataset_schema
coder-0: session=lab11-coder-0, events=1
verifier-0: session=lab11-verifier-0, events=1
Planner tool round-trip: True
Succès: True
Itérations: 1
Région attendue (calcul déterministe): Ouest
Verdict LLM: SUCCESS, ...
Sortie Executor: La région avec le plus grand revenu moyen est Ouest ...
```

Papermill post-fix :

```text
Success: 1
Failed: 0
Total time: 51.1s
```

## Validation post-retarget

- `validate_pr_notebooks.py`: `1/1 passed`, 16 cellules code vérifiées ;
- inspection notebook : 16/16 cellules code avec `execution_count`, 16/16 avec outputs, 0 erreur ;
- `notebook_tools.py validate --quick`: 1 OK, 0 warning, 0 erreur ;
- `scan_cell_ordering.py --fail-on HIGH`: 1 notebook clean, 0 finding ;
- `count_exercises.py`: 3 exercices, seuil respecté ; sources des trois stubs inchangées ;
- tests runtime/provider hermétiques : `60 passed` avec `ACTIVE_PROVIDER=vllm` pour isoler le test de défaut de la valeur `active_provider=openai` présente dans le `.env` gitignored local ;
- `py_compile`: succès ;
- C.1 : aucun `raise NotImplementedError`, `assert False` ou `1/0` ;
- secrets et chemins machine : aucun finding ; métadonnées Papermill normalisées au basename ;
- `git diff --check`: succès.

## Diagnostic dérive

**Causes :** (1) stochasticité non seedée du dataset ; (2) prose manuelle affirmant un provider et une KeyError qui ne correspondaient plus à l'output adjacent ; (3) rôles dits ADK mais implémentés uniquement comme wrappers `LLMClient` ; (4) première migration ADK où le schéma n'était pas assez contraignant et où le parseur refusait `SUCCESS,` avec ponctuation.

**Verdict : `CAUSE_FIXED`.** Le dataset est seedé, la prose s'en tient aux outputs observés, les rôles sont de vrais agents ADK, le schéma exact est transmis au Coder/Verifier, le verdict accepte sa ponctuation et la cellule de preuve compare le résultat à un calcul Pandas indépendant avant de réussir.

## SOTA

**Google ADK : `SOTA-OK`.** Le vrai package `google-adk==2.8.0` exécute trois agents, sessions et runners ; le round-trip d'outil et les événements sont visibles dans l'output committé.

**LLM : `SOTA-OK`.** Les trois rôles appellent un vrai modèle OpenAI ; aucune réponse déterministe ou simulée ne remplace le LLM.

**Qwen : `RECOVERABLE-LOCAL`.** Le runtime partagé le supporte, mais son endpoint n'est pas provisionné sur cette lane ; un autre LLM réel a donc été utilisé au lieu d'un mock.

Livraison partielle de #13925 : tranche atomique Lab11 uniquement.

See #13925
Delivered after #13945
