### PR TITLE
test(ci,#13960): dedup 4 byte-identical pairs in test_check_self_hosted_runner_policy

### DIFF
--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -506,55 +506,6 @@ def test_same_repository_reusable_workflow_rejects_path_traversal(tmp_path):
     assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
 
 
-def test_missing_trigger_breaks_instrument(tmp_path):
-    write_workflow(tmp_path, "broken-trigger", """
-        name: broken-trigger
-        jobs:
-          test:
-            runs-on: ubuntu-latest
-            steps:
-              - run: echo no-trigger
-        """)
-    result = policy.scan_workflows(tmp_path)
-    assert result.broken == ["broken-trigger.yml: missing on trigger"]
-
-
-def test_empty_runs_on_list_breaks_instrument(tmp_path):
-    write_workflow(tmp_path, "broken-runner", """
-        name: broken-runner
-        on: workflow_dispatch
-        jobs:
-          test:
-            runs-on: []
-            steps:
-              - run: echo no-runner
-        """)
-    result = policy.scan_workflows(tmp_path)
-    assert result.broken == [
-        "broken-runner.yml:test: runs-on list must contain labels"
-    ]
-
-
-def test_missing_jobs_breaks_instrument(tmp_path):
-    write_workflow(tmp_path, "broken-jobs", """
-        name: broken-jobs
-        on: workflow_dispatch
-        """)
-    result = policy.scan_workflows(tmp_path)
-    assert result.broken == ["broken-jobs.yml: missing jobs"]
-
-
-def test_same_repository_reusable_workflow_rejects_path_traversal(tmp_path):
-    write_workflow(tmp_path, "caller", """
-        name: caller
-        on: [pull_request]
-        jobs:
-          test:
-            uses: jsboige/CoursIA/.github/workflows/../evil.yml@main
-        """)
-    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
-
-
 def test_invalid_yaml_breaks_the_instrument(tmp_path):
     write_workflow(tmp_path, "broken", "on: [pull_request\njobs: [")
     result = policy.scan_workflows(tmp_path)


### PR DESCRIPTION
Grain: LIGHT/test -- lane myia-po-2026:CoursIA -- prev: DEEP/guard #13940

## Summary

Issue #13960 — `scripts/tests/test_check_self_hosted_runner_policy.py` carried 4 byte-identical test function pairs (8 copies total = 2 of each). Drop the second copy of each; keep the first occurrence at its original position. 49 lines removed, 0 inserted, no semantic change.

## Dedup scope (sha256 byte-identity per pair)

| Function | 1st occurrence | 2nd occurrence | sha256 |
|----------|----------------|----------------|--------|
| `test_missing_trigger_breaks_instrument` | line 460 | line 509 | `7b784ee3…` |
| `test_empty_runs_on_list_breaks_instrument` | line 473 | line 522 | `c8feb098…` |
| `test_missing_jobs_breaks_instrument` | line 489 | line 538 | `03bf0a26…` |
| `test_same_repository_reusable_workflow_rejects_path_traversal` | line 498 | line 547 | `26bb279d…` |

Byte-identity confirmed for each pair (sha256 of the function body including its trailing blank lines).

## Validation post-fix

```
python -m pytest scripts/tests/test_check_self_hosted_runner_policy.py -q
============================= 37 passed in 1.48s ==============================
```

Collected tests still 37 (was 37), passing 37/37 (was 37/37). No test added, no test removed — only duplicated copies collapsed.

## Diff signature

```
 scripts/tests/test_check_self_hosted_runner_policy.py | 49 ----------------------
 1 file changed, 49 deletions(-)
```

`git diff --check` clean (no whitespace warnings). Pre-commit hooks green (gitleaks + others Passed).

## Pourquoi c'est un LIGHT/dedup, pas un refactor

- 0 lignes ajoutees
- 0 logique modifiee
- 0 nouveau test
- Le scope est **strictement** les 4 paires byte-identiques ; pas de reformatage, pas de renaming, pas de reorganisation d'imports. Les autres fonctions restent à leur position d'origine.

Closes #13960
