### PR TITLE
docs(lean,#13957): correct prose around native_decide -> decide

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -17,7 +17,7 @@ Ce fichier est le module **FONDATIONS** de l'hommage Phase 2 (Epic #1647) :
 - Predicats `IsStillLife`, `IsOscillator`, `IsSpaceship`
 - Temoins pour les patterns canoniques petits
   (block, beehive, blinker, toad, beacon, glider)
-- Micro-preuves verifiables par `native_decide` sur egalite de liste
+- Micro-preuvres verifiees par `decide` (reduit par le noyau sur `Bool`)
 
 La representation par liste evite le goulot d'etranglement `Quot.lift` /
 `Eq.rec` qui survient quand le noyau Lean essaie de decider l'egalite de
@@ -61,8 +61,9 @@ def lexLt (a b : Int × Int) : Bool :=
 
 /-- Une grille du Jeu de la Vie de Conway : liste triee et dedupliquee de
     cellules vivantes. Nous utilisons `List` plutot que `Finset` car
-    l'egalite de liste est decidee par comparaison structurelle (pas de
-    `Quot.lift`), ce que `native_decide` sait traiter. -/
+    l'egalite de liste est decidee par le noyau par comparaison
+    structurelle (pas de `Quot.lift`), ce que `decide` traite sans
+    synthese de `Decidable` utilisateur. -/
 abbrev Grid := List (Int × Int)
 
 /-! ## Voisinage
@@ -164,9 +165,9 @@ def evolve (n : Nat) (g : Grid) : Grid :=
 /-! ## Predicats de patterns
 
 Nous definissons des predicats a valeur booleenne (renvoyant `Bool`) pour
-que `native_decide` puisse les evaluer en compilant vers le code natif et
-en comparant l'egalite de `Bool`. Pas de synthese de `Decidable` ni de
-`Quot.lift` necessaire — juste une reduction de `Bool`.
+que `decide` puisse reduire l'enonce `b = true` par simple evaluation de
+`Bool`, sans synthese de `Decidable` ni de `Quot.lift` utilisateur — le
+reducteur du noyau elabore directement la verite du `Bool` retourne.
 -/
 
 /-- Une vie immobile : une grille inchangee par une etape d'evolution. -/
@@ -191,8 +192,8 @@ decouverts au debut des annees 1970 par le groupe de Conway a Cambridge et
 par les joueurs de la communaute M.I.T. PDP-6/PDP-10.
 
 Chaque pattern est donne dans l'ordre lexicographique trie de sorte que
-`step` produise une liste dans le meme ordre, ce qui permet a
-`native_decide` de verifier l'egalite par comparaison structurelle.
+`step` produise une liste dans le meme ordre, ce qui permet a `decide`
+de verifier l'egalite par simple reduction structurelle du `Bool`.
 -/
 
 /-- Le **Block** : un carre 2x2. La plus petite vie immobile. -/
@@ -221,10 +222,10 @@ def glider : Grid := [(0, 0), (1, 0), (1, 2), (2, 0), (2, 1)]
 /-! ## Micro-preuves
 
 Voici les premiers resultats formels de la Phase 1 : verifications simples
-de patterns classiques par `native_decide`. Les predicats renvoient `Bool`,
-donc `native_decide` compile la fonction d'etape en code natif, evalue
-l'expression booleenne et verifie qu'elle egale `true`. Pas de synthese de
-`Decidable` ni de `Quot.lift` implique.
+de patterns classiques par `decide`. Les predicats renvoient `Bool`,
+donc le reducteur du noyau elabore la fonction d'etape, evalue
+l'expression booleenne et verifie qu'elle egale `true`. Pas de synthese
+de `Decidable` ni de `Quot.lift` implique.
 -/
 
 /-- Le Block est une vie immobile : `isStillLife block = true`. -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean
@@ -17,7 +17,7 @@ This file is the FOUNDATIONS module of the Phase 2 tribute (Epic #1647):
 - Predicates `IsStillLife`, `IsOscillator`, `IsSpaceship`
 - Witnesses for the canonical small patterns
   (block, beehive, blinker, toad, beacon, glider)
-- Microproofs verifiable by `native_decide` on list equality
+- Microproofs discharged by `decide` (kernel reduction on `Bool`)
 
 The list representation avoids the `Quot.lift` / `Eq.rec` bottleneck
 that arises when Lean's kernel tries to decide `Finset` equality
@@ -60,7 +60,8 @@ def lexLt (a b : Int × Int) : Bool :=
 
 /-- A grid of Conway's Game of Life: sorted, deduplicated list of live cells.
     We use `List` rather than `Finset` because list equality is decided by
-    structural comparison (no `Quot.lift`), which `native_decide` handles. -/
+    the kernel through structural comparison (no `Quot.lift`), which
+    `decide` discharges without user-supplied `Decidable` synthesis. -/
 abbrev Grid := List (Int × Int)
 
 /-! ## Neighborhood
@@ -156,9 +157,10 @@ def evolve (n : Nat) (g : Grid) : Grid :=
 
 /-! ## Pattern predicates
 
-We define Boolean-valued predicates (returning `Bool`) so that `native_decide`
-can evaluate them by compiling to native code and comparing `Bool` equality.
-No `Decidable` synthesis or `Quot.lift` needed — just `Bool` reduction.
+We define Boolean-valued predicates (returning `Bool`) so that `decide`
+can reduce the statement `b = true` by plain `Bool` evaluation, without
+user-supplied `Decidable` synthesis or `Quot.lift` — the kernel reducer
+elaborates the truth of the returned `Bool` directly.
 -/
 
 /-- A still life: a grid unchanged by one step of evolution. -/
@@ -183,8 +185,8 @@ discovered in the early 1970s by Conway's group at Cambridge and by
 players of the M.I.T. PDP-6/PDP-10 community.
 
 Each pattern is given in sorted lexicographic order so that `step`
-produces a list in the same order, enabling `native_decide` to verify
-equality by structural comparison.
+produces a list in the same order, enabling `decide` to verify
+equality by plain structural `Bool` reduction.
 -/
 
 /-- The **Block**: a 2x2 square. The smallest still life. -/
@@ -213,10 +215,10 @@ def glider : Grid := [(0, 0), (1, 0), (1, 2), (2, 0), (2, 1)]
 /-! ## Microproofs
 
 These are the first formal results of Phase 1: simple verifications of
-classic patterns by `native_decide`. The predicates return `Bool`, so
-`native_decide` compiles the step function to native code, evaluates the
-Boolean expression, and checks it equals `true`. No `Decidable` synthesis
-or `Quot.lift` involved.
+classic patterns by `decide`. The predicates return `Bool`, so the kernel
+reducer elaborates the step function, evaluates the Boolean expression,
+and checks it equals `true`. No `Decidable` synthesis or `Quot.lift`
+involved.
 -/
 
 /-- The Block is a still life: `isStillLife block = true`. -/


### PR DESCRIPTION
Grain: MED/docs -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13981

## Summary

Issue #13957 — `conway_lean/Conway/Life.lean` and its sibling `Life_en.lean` carried 6 prose mentions of `native_decide` whose code had moved on. All 7 small-pattern lemmas are now proved `by decide` (kernel Bool reduction), but the docstrings still described the older `native_decide` story. This closes the drift between prose and code.

Sibling-pair treatment (convention i18n #4980) : both files updated in lockstep — same line numbers in each (FR L20/65/167/195/224-225 ↔ EN L20/63/160/188/218-219).

## Acceptance checklist (verbatim from #13957)

- [x] **6 mentions de `native_decide` en prose corrigées ou requalifiées** — chaque mention alignée sur l'état actuel (`decide` / "le reducteur du noyau elabore")
- [x] **Le sibling anglais `Life_en.lean` reçoit le même traitement** — convention i18n #4980
- [x] **`lake build` SUCCESS après modification** — 3005 jobs total, last two `Built Conway.Life_en (80s)` + `Built Conway.Life (80s)` (exit code 0)
- [x] **Aucun changement de tactique, de signature ou d'énoncé** — diff strictement prose (verified via `by decide` count = 7 unchanged, function signatures byte-identical)

## Diff signature

```
 MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean    | 25 +++++++++++-----------
 MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean | 24 +++++++++++----------
 2 files changed, 26 insertions(+), 23 deletions(-)
```

Per-side table:

| Line | File | Before | After |
|---|---|---|---|
| 20 | FR | "Micro-preuves verifiables par `native_decide` sur egalite de liste" | "Micro-preuves verifiees par `decide` (reduit par le noyau sur `Bool`)" |
| 20 | EN | "Microproofs verifiable by `native_decide` on list equality" | "Microproofs discharged by `decide` (kernel reduction on `Bool`)" |
| 65 / 63 | FR/EN | "ce que `native_decide` sait traiter" | "ce que `decide` traite sans synthese de `Decidable` utilisateur" / "which `decide` discharges without user-supplied `Decidable` synthesis" |
| 167 / 160 | FR/EN | "pour que `native_decide` puisse les evaluer en compilant vers le code natif" | "pour que `decide` puisse reduire l'enonce `b = true` par simple evaluation de `Bool`" |
| 195 / 188 | FR/EN | "ce qui permet a `native_decide` de verifier l'egalite" | "ce qui permet a `decide` de verifier par simple reduction structurelle du `Bool`" |
| 224-225 / 218-219 | FR/EN | "de patterns classiques par `native_decide`. ... `native_decide` compile la fonction d'etape en code natif" | "de patterns classiques par `decide`. ... le reducteur du noyau elabore la fonction d'etape" |

## Why this matters beyond housekeeping

`native_decide` is on the **forbidden** axioms list (PR review discipline §B — kernel bypass without proof). The prose was actively **mis-selling** the module's epistemic status: it advertised "micro-preuves compilées en code natif" when the actual proofs are kernel-decided `Bool` reductions. From a reader's perspective, this is a strictly worse claim than reality — `decide` is a stronger guarantee (kernel-verified) than `native_decide` would have been (axiom-accepted).

The docstring on `sortDedup` (L124-136) already narrates the inverse story correctly: `insertionSort` was chosen so `decide` could evaluate, while `mergeSort` blocks `decide` (probe po-2026 c.786). The 6 prose mentions were a residue from before that swap.

## Lake build validation (RÈGLE §B PR review discipline)

```
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
$ lake build Conway.Life Conway.Life_en
...
✔ [3004/3005] Built Conway.Life_en    (80s)
✔ [3005/3005] Built Conway.Life       (80s)
Build completed successfully (3005 jobs).
```

Full Mathlib build takes ~12-15 minutes on this machine (no cache). Both target modules rebuilt cleanly with my prose-only diff. Zero proof regression possible (no `by decide` line moved, no signature touched).

## Compliance

- **Scope** : 2 fichiers, +26/-23, 1 sujet unique (largement sous les seuils 3000/15/4).
- **Pre-commit** : gitleaks Passed.
- **Anti-régression** : aucune modification de tactique (`grep -c "by decide"` = 7 avant/après), aucune modification de signature (`abbrev Grid`, `def step`, `def evolve`, `def isStillLife`, etc. byte-identiques), aucune modification d'énoncé (`block_still_life` etc. byte-identiques).
- **i18n #4980** : sibling pair traité en lockstep.
- **catalog-pr-hygiene** : aucun marqueur CATALOG-STATUS touché.
- **Worker discipline** : pas de merge, pas de `gh auth switch`, pas de close d'autrui.

Closes #13957
