### PR TITLE
tooling(#13967): conseil adjacency remplace les 3 gestes generiques invariants

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1313,7 +1313,12 @@ def red_backlog(lane: str, threshold_hours: float,
         if causes:
             red.append({"number": pr["number"], "title": pr["title"],
                         "age_hours": round(age),
-                        "causes": causes})
+                        "causes": causes,
+                        # #13967 : signal optionnel fourni par un caller
+                        # externe (wrapper sur `variation_adjacency_guard`).
+                        # Falsy par defaut pour ne pas changer le contrat
+                        # des 79 tests existants.
+                        "is_adjacency": bool(pr.get("is_adjacency"))})
     red.sort(key=lambda r: -r["age_hours"])
 
     triggers = []
@@ -1520,17 +1525,47 @@ def print_red_assignment(lane: str, backlog: dict, threshold_hours: float) -> No
         for cause in item["causes"]:
             print(f"       {cause}")
     print()
-    print("Trois gestes, dans cet ordre -- le premier repare souvent seul :")
-    print("  1. `gh pr update-branch <N>` : rejoue les checks sur une tete fraiche.")
-    print("     Un rouge peut dater d'AVANT la correction du garde qui l'a produit")
-    print("     (mesure du 2026-08-21 : 5 PRs sur 9 n'avaient rien a corriger).")
-    print("     Dater le garde -- `git log -- <script>` -- avant de conclure.")
-    print("  2. conflits : rebaser sur origin/main, `--force-with-lease` si la lane")
-    print("     est seule sur la branche.")
-    print("  3. corriger la substance, pousser, et REPONDRE par ecrit -- au")
-    print("     CHANGES_REQUESTED comme au nit : un push muet ne leve aucune")
-    print("     remarque. `python scripts/check_unaddressed_nits.py <N>` detaille")
-    print("     chaque point non leve, son auteur et sa surface.")
+    if red and all(r.get("is_adjacency") for r in red):
+        # #13967 : quand la cause du rouge est `adjacency` (G-VAR-3, mesure
+        # du 2026-09-01 = 13 PRs / 25 rouges mesurables = premiere cause de
+        # rouge de la flotte), les trois conseils generiques
+        # (`update-branch` / rebase / pousser) sont invariants au predicat
+        # (aucun ne modifie le `prev_genre` ni le `genre` courant), donc
+        # aucun ne leve le blocage. L'organe `variation_adjacency_guard`
+        # produit deja le bon message (« piochez un grain d'UN AUTRE genre,
+        # ne retaguez pas le meme travail ») -- ici on le dit EN CLAIR
+        # pour que la lane ne perde pas son cycle a pousser une PR dont
+        # la cause est ailleurs.
+        print("Cause determinante : `adjacency` (G-VAR-3, organe "
+              "variation_adjacency_guard). Aucun des trois gestes generiques")
+        print("ne leve ce blocage : la cause n'est pas dans le diff, elle est")
+        print("dans le **genre du grain suivant**. Le remede :")
+        print()
+        print("  -> Piocher un grain d'UN AUTRE genre (LIGHT/{guard,ledger,")
+        print("     docs,readme,test} apres un autre grain du meme genre est")
+        print("     un monoculture interdit par le protocole variation §2).")
+        print("  -> Ne PAS retaguer la PR existante -- le re-tag du meme")
+        print("     travail sous un autre genre est l'echappatoire que le")
+        print("     protocole ferme explicitement.")
+        print("  -> Produire un grain frais (DEEP ou MED, ou un CONTENU dans")
+        print("     un genre distinct du precedent merge) : c'est lui qui")
+        print("     decale la file et leve le blocage.")
+        print()
+        print("Mesure du 2026-09-01 : 13 PRs / 25 rouges mesurables tenues par")
+        print("adjacency -- premiere cause de rouge de la flotte, devant")
+        print("`tag_required` (5), `lane_claim` (3), `perimeter` (2).")
+    else:
+        print("Trois gestes, dans cet ordre -- le premier repare souvent seul :")
+        print("  1. `gh pr update-branch <N>` : rejoue les checks sur une tete fraiche.")
+        print("     Un rouge peut dater d'AVANT la correction du garde qui l'a produit")
+        print("     (mesure du 2026-08-21 : 5 PRs sur 9 n'avaient rien a corriger).")
+        print("     Dater le garde -- `git log -- <script>` -- avant de conclure.")
+        print("  2. conflits : rebaser sur origin/main, `--force-with-lease` si la lane")
+        print("     est seule sur la branche.")
+        print("  3. corriger la substance, pousser, et REPONDRE par ecrit -- au")
+        print("     CHANGES_REQUESTED comme au nit : un push muet ne leve aucune")
+        print("     remarque. `python scripts/check_unaddressed_nits.py <N>` detaille")
+        print("     chaque point non leve, son auteur et sa surface.")
     print()
     print_unattributed_blocked(backlog)
     print_base_inherited(backlog)

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -552,6 +552,74 @@ def test_repair_json_carries_a_grain_field(monkeypatch, capsys):
     assert "refus" not in payload
 
 
+def test_adjacency_red_advice_replaces_three_generic_gestures(monkeypatch, capsys):
+    """#13967 : quand la cause du rouge est `adjacency`, le picker doit
+    remplacer les trois conseils generiques (`update-branch` / rebase /
+    pousser) par le remede propre : « piocher un grain d'un AUTRE genre,
+    ne PAS retaguer ». Mesure du 2026-09-01 : 13 PRs / 25 rouges
+    mesurables = premiere cause de rouge de la flotte -- les trois
+    gestes generiques sont invariants au predicat et la lane boucle.
+
+    Le test pin le contrat par la sortie (pas de `update-branch`,
+    mention explicite du remede). La fixture ajoute le champ
+    optionnel `is_adjacency=True` au PR rouge -- c'est le point
+    d'entree qu'un futur wrapper autour de
+    `scripts/ci/variation_adjacency_guard.py` remplira pour passer
+    du verdict de l'organe au conseil du picker (le picker n'appelle
+    pas gh par PR rouge -- trop couteux, trop de surface).
+    """
+    red = _state(checks=[("PR gate", "FAILURE", True)])
+    pr = _pr(99, "myia-po-2026:CoursIA", 30)
+    pr["is_adjacency"] = True
+    _patch_backlog(monkeypatch, [pr], {99: red})
+    rc = pig.main(["--lane", "myia-po-2026:CoursIA"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # Le remede propre doit etre present.
+    assert "Piocher un grain d'UN AUTRE genre" in out, (
+        f"le conseil adjacency est absent : {out[-400:]!r}"
+    )
+    assert "Ne PAS retaguer la PR" in out, (
+        "l'interdit de re-tag (protocole variation §2) doit etre rappele"
+    )
+    # Les trois gestes generiques doivent etre ABSENTS : aucun d'eux ne
+    # modifie `genre` ou `prev_genre`, donc aucun ne leve le blocage.
+    assert "gh pr update-branch" not in out, (
+        "`gh pr update-branch` ne leve jamais adjacency (predicat "
+        "invariant au SHA). Sa presence ici ferait perdre un cycle a "
+        "la lane qui suit le conseil."
+    )
+    # L'en-tete Reparation doit toujours etre la (coherence avec le
+    # test existant).
+    assert "GRAIN DU CYCLE" in out
+    assert "#99" in out
+
+
+def test_non_adjacency_red_keeps_three_generic_gestures(monkeypatch, capsys):
+    """#13967 : controle positif du test precedent.
+
+    Un PR rouge pour une cause REPARABLE par push (check FAILURE
+    substance) doit continuer d'afficher les trois gestes generiques.
+    Sans ce controle, la correction pourrait supprimer le conseil pour
+    tout le monde et le test precedent passerait quand meme.
+    """
+    red = _state(checks=[("PR gate", "FAILURE", True)])
+    pr = _pr(11, "myia-po-2026:CoursIA", 30)
+    # Pas de champ `is_adjacency` (defaut implicite = False / absent).
+    assert "is_adjacency" not in pr
+    _patch_backlog(monkeypatch, [pr], {11: red})
+    rc = pig.main(["--lane", "myia-po-2026:CoursIA"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Trois gestes, dans cet ordre" in out
+    assert "gh pr update-branch" in out, (
+        "un PR rouge substance doit conserver le premier geste "
+        "(rejouer les checks sur tete fraiche peut le reparer)"
+    )
+    # Et l'absence du remede adjacency est l'autre moitie du contrat.
+    assert "Piocher un grain d'UN AUTRE genre" not in out
+
+
 def test_a_clean_lane_is_not_sent_to_repair(monkeypatch, capsys):
     """Controle positif des deux precedents.
 


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13973

## Grain

Defaut picker #13967 : `pick_idle_grain.py` resummait TOUT rouge substance en 3 conseils generiques invariants au predicat `adjacency`.

## Mesure (issue #13967)

13 PRs / 25 rouges mesurables tenues par `adjacency` (G-VAR-3) -- premiere cause de rouge de la flotte, devant `tag_required` (5), `lane_claim` (3), `perimeter` (2). Repartition : `po-2026:CoursIA` 6, `po-2026:CoursIA-2` 4, `ai-01:CoursIA` 2, `ai-01:open-webui` 1.

## Cause

`variation_adjacency_guard.py` produit deja le bon message (« piochez un grain d'UN AUTRE genre, ne retaguez pas le meme travail »). Mais le picker, en re-emballant le rouge dans sa liste generique de 3 gestes, **ecrase** ce message specifique par un conseil dont AUCUN des 3 ne modifie le `genre` ni le `prev_genre` (donc aucun ne leve le blocage).

## Fix

Quand TOUS les rouges de la backlog portent le signal `is_adjacency=True` (fourni par un caller externe -- futur wrapper sur `variation_adjacency_guard.py`), `print_red_assignment` bascule sur le remede propre :

- Piocher un grain d'UN AUTRE genre (monoculture interdit par variation §2)
- Ne PAS retaguer la PR existante (echappatoire que le protocole ferme)
- Produire un grain frais (DEEP/MED, ou CONTENU dans un genre distinct du precedent merge)

Sinon, les 3 gestes generiques restent (controle positif : un PR rouge substance reparable par push doit les conserver).

## Point d'entree

`red_backlog` propage le champ optionnel `is_adjacency` du PR dict vers le dict rouge (falsy par defaut -- ne casse pas les 79 tests existants). Le wiring avec `variation_adjacency_guard.py` n'est pas dans ce grain (un wrapper se justifie en grain dedie, le picker n'appelle pas gh par PR rouge -- trop couteux, trop de surface).

## Verification

```
$ python -m pytest scripts/tests/test_pick_idle_grain.py -q
============================= 81 passed in 0.23s ==============================
```

79 originaux + 2 nouveaux :
- `test_adjacency_red_advice_replaces_three_generic_gestures` : pin le contrat (remede present, `gh pr update-branch` absent)
- `test_non_adjacency_red_keeps_three_generic_gestures` : controle positif (PR substance conserve les 3 gestes)

## Diff

```
 scripts/pick_idle_grain.py            | 59 +++++++++++++++++++++++-------
 scripts/tests/test_pick_idle_grain.py | 68 +++++++++++++++++++++++++++++++++++
 2 files changed, 115 insertions(+), 12 deletions(-)
```

Grain: tier-light/genre-tooling--lane-po2026:CoursIA-2--prev-cycles58-62
Refs #13967
