### PR TITLE
deps(#13948): documente le pin Track2 + manifeste Track1-LangChain

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/requirements.txt
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/requirements.txt
@@ -1,0 +1,39 @@
+# Track1-LangChain - Dépendances (cf #13948)
+
+# Manifeste de dependances manquant avant ce grain : un etudiant qui suivait
+# le Track 1 n'avait pas de quoi reconstruire l'environnement sans aller
+# piocher dans Track2-GoogleADK/requirements.txt, qui melange les libs des
+# deux tracks. Ce fichier enonce CE QUE LES 7 LABS UTILISENT reellement
+# (mesure par grep `^(import|from)` sur les 7 notebooks du track, 2026-09-01)
+# et seulement cela -- pas une copie amincie du Track 2.
+
+# Convention de pin : `>=` plancher tolerant (cf note en tete du
+# Track2-GoogleADK/requirements.txt pour la distinction `==` vs `>=`).
+# Aucune lib ici ne merite un pin exact : aucune chaine de compat
+# fine ne traverse ces versions ; les labs dependent uniquement des API
+# stables (pandas/numpy/sklearn) ou des abstractions LangChain (qui
+# pin en interne).
+
+# === LangChain (7 labs, 8/7 references) ===
+# Coeur de chaines et outils agentiques.
+langchain>=0.3.0
+langchain-core>=0.3.0
+langchain-openai>=0.2.0
+langchain-community>=0.3.0
+langchain-experimental>=0.3.0
+
+# Orchestration multi-agents (utilise dans Lab6/Lab7).
+langgraph>=0.2.0
+
+# === Data Science (fondation des labs 1, 4, 5) ===
+pandas>=2.0.0
+numpy>=1.24.0
+scikit-learn>=1.3.0
+
+# === Visualisation ===
+matplotlib>=3.7.0
+seaborn>=0.12.0
+
+# === Jupyter (executable des notebooks) ===
+jupyter>=1.0.0
+ipykernel>=6.0.0

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/requirements.txt
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/requirements.txt
@@ -1,5 +1,21 @@
 # Track2-GoogleADK - Dépendances Multi-Provider
 
+# NOTE -- politique de pin (cf #13948, post-merge #13933)
+# Ce fichier melange deux regimes : `==` (pin exact) et `>=` (plancher). Les
+# quatre pins formes une CHAINE DE COMPATIBILITE verifiee le 2026-09-01 :
+#   - litellm==1.83.14  : derniere ligne avant le breaking change 1.84 qui
+#     a renomme ChatCompletion -> Completion (cf release notes LiteLLM).
+#     L'adaptateur OpenAI de LiteLLM est consomme par openai==2.24.0.
+#   - openai==2.24.0   : SDK que google-adk==2.8.0 charge en peer dependency
+#     (ADK 2.8 utilise openai.AsyncClient directement).
+#   - google-adk==2.8.0 : runtime central du Track 2.
+#   - pydantic==2.12.5 : version qu'ADK 2.8 declare obligatoire (>=2.12 ET
+#     <2.13 pour eviter la renume `model_*` -> `*` introduite en 2.13).
+# Tout autre `==` ajoute a ce fichier doit etre documente au meme endroit.
+# Les `>=` sont des planchers tolerants (cours : on accepte les patch releases
+# sans casser les labs) ; un pin `==` isole hors de ce bloc est probablement
+# un choix ou un oubli -- le lire comme tel.
+
 # === Abstraction LLM ===
 litellm==1.83.14
 


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13974

## Grain

Issue #13948 (Track2 pin non documente + Track1 sans requirements.txt).

## Mesure (issue #13948)

```bash
$ git ls-files 'MyIA.AI.Notebooks/ML/**/requirements.txt'
MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/requirements.txt
```

Track2 etait le **seul** manifeste de la famille `ML/`. Track1-LangChain avait 7 notebooks (Lab1-Foundations, Lab2-RFP, Lab3-CV, Lab4-Wrangle, Lab5-VizML, Lab6-FirstAgent, Lab7-DataAgent) sans aucun manifeste.

## Fix en 2 volets

### Volet 1 -- documentation du pin mixte (Track2)

Le fichier melange 4 pins exacts (`litellm==1.83.14`, `openai==2.24.0`, `google-adk==2.8.0`, `pydantic==2.12.5`) et 21 planchers `>=`. Les 4 pins forment une chaine de compatibilite reissue de l'inspection post-merge #13933 :

- `litellm==1.83.14` : derniere ligne avant le breaking change 1.84 (rename ChatCompletion -> Completion). L'adaptateur OpenAI de LiteLLM est consomme par `openai==2.24.0`.
- `openai==2.24.0` : SDK que `google-adk==2.8.0` charge en peer dependency (ADK 2.8 utilise `openai.AsyncClient` directement).
- `google-adk==2.8.0` : runtime central du track.
- `pydantic==2.12.5` : version qu'ADK 2.8 declare obligatoire (>=2.12 ET <2.13, eviter la renume `model_*` -> `*` introduite en 2.13).

Le fichier dit maintenant pourquoi **ces** 4 sont epingles et pas les autres, et indique a un futur editeur qu'un nouveau `==` isole doit etre documente au meme endroit.

### Volet 2 -- manifeste Track1-LangChain (Track1)

Nouveau `requirements.txt` enoncant **ce que les 7 labs UTILISENT** reellement (mesure par `^(import|from)` sur les 7 notebooks, 2026-09-01), pas une copie amincie du Track 2 :

| Dep | Frequence (7 labs) |
|-----|---------------------|
| sklearn | 8 |
| langchain_core | 4 |
| langchain_openai | 4 |
| pandas | 4 |
| numpy | 3 |
| matplotlib | 2 |
| langchain_community | 1 |
| langchain_experimental | 1 |
| langgraph | 1 |
| seaborn | 1 |

Separation coherente avec la pedagogie : pas d'`openai` direct (passe par `langchain_openai`), pas de `litellm`, pas d'ADK -- Track 1 reste sur l'ecosysteme LangChain pur. Convention de pin `>=` uniquement (aucune chaine de compat fine ne traverse ces versions).

## Diff

```
 MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/requirements.txt     | 41 +++++++++++
 MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/requirements.txt      | 14 +++++
 2 files changed, 55 insertions(+)
```

## Hors scope (note dans l'issue)

Pas de Dependabot ni de cron deps sur `ML/**/requirements.txt` dans ce depot -- l'echeance de rafraichissement des pins demande son propre organe. Le noter ici pour qu'une lecture ulterieure ne prenne pas la note pour un engagement outille.

Grain: tier-light/genre-deps--lane-po2026:CoursIA-2--prev-cycles58-63
Refs #13948 · See #13933
