### PR TITLE
guard(#13968): echapper les backticks autour de `Read` dans la ligne FIX

### DIFF
--- a/.github/workflows/manifest-description-visuelle-gate.yml
+++ b/.github/workflows/manifest-description-visuelle-gate.yml
@@ -113,7 +113,7 @@ jobs:
 
           if [ "$fail" -ne 0 ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "FIX: add a \`**Description visuelle** :\` line per figure entry in the MANIFEST, observing the PNG (`Read` on the .png) and describing its visual content (chart type / axes / colors / disposition), distinct from the notebook's pedagogical subject. See scripts/notebook_tools/extract_readme_figures.py for the canonical schema." >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: add a \`**Description visuelle** :\` line per figure entry in the MANIFEST, observing the PNG (\`Read\` on the .png) and describing its visual content (chart type / axes / colors / disposition), distinct from the notebook's pedagogical subject. See scripts/notebook_tools/extract_readme_figures.py for the canonical schema." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
           echo "::notice title=Manifest description_visuelle gate::Checked $checked changed MANIFEST.md file(s); all declare description_visuelle per figure."


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/guard #13974 cycle 75

## Grain

Bug YAML/bash dans `.github/workflows/manifest-description-visuelle-gate.yml:116` -- backticks non échappés causent une substitution de commande et mutile la consigne de réparation.

## Diagnostic

La ligne FIX est composée dans une chaîne bash double-quotée. Sur 2 paires de backticks présentes :

| Paire | | État |
|-------|---|------|
| `` `**Description visuelle**` `` | | Échappée (`\`**Description visuelle**\``) -- pas de substitution |
| `` `Read` `` | | **Non échappée** -- bash exécute `Read`, qui n'existe pas |

Run de référence : [#33471147995](https://github.com/jsboige/CoursIA/actions/runs/33471147995/job/99740996056) (job *Gate changed MANIFESTs*, PR #13656).

Deux conséquences, la seconde étant la vraie :
1. Ligne d'erreur parasite dans le log : `Read: command not found`
2. **La consigne de réparation arrive mutilée** dans le step summary -- le lecteur voit `observing the PNG ( on the .png)`, la moitié utile ("ouvère le PNG") a été mangée par la substitution

Un garde dont le message de réparation est cassé fait payer deux fois : la PR est rouge, et l'opérateur ne lit pas ce qu'il faut faire.

## Fix

Échapper la 2e paire comme la 1re, symétrique :

```diff
-... observing the PNG (`Read` on the .png) and ...
+... observing the PNG (\`Read\` on the .png) and ...
```

## Vérification

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/manifest-description-visuelle-gate.yml', encoding='utf-8'))"
YAML OK

# Backticks dans la ligne FIX :
#   total: 4
#   escaped (\`): 4
#   unescaped: 0
# Verdict: PASS -- aucune substitution de commande possible
```

YAML reste parsable, chaîne double-quotée bien formée.

## Diff

```
 .github/workflows/manifest-description-visuelle-gate.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Le correctif est strictement borné à 1 ligne. Grain LIGHT/guard.

## Contrôle de non-régression

Comme indiqué dans l'issue : déclencher le workflow sur une PR dont le MANIFEST omet le champ, vérifier que le summary contient la phrase entière et que le log ne contient plus `Read: command not found`. Cas réel reproductible depuis `cc46b4d24` (avant `bd53fdd7d` sur #13656).

Refs #13968

## Note post-edit (cycle 83)

Body edite au cycle 83 pour ajouter le prefixe `Grain:` en premiere ligne (le tag etait en fin de body, format `tier-light/genre-guard--lane-...` non detectable par le parser canonique). Le tag est maintenant conforme au format `Grain: TIER/GENRE -- lane ... -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste +1/-1.