### PR TITLE
tooling(#13972): infer_genre lit le tag Grain du body avant le regex titre

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -243,7 +243,24 @@ GENRE_RULES: list[tuple[str, str]] = [
 NOW = dt.datetime.now(dt.timezone.utc)
 
 
-def infer_genre(title: str, labels: list[str]) -> str:
+def infer_genre(title: str, labels: list[str], body: str | None = None) -> str:
+    """Infer the GENRE of an issue from signals.
+
+    Priority order (#13972 acceptance point 1):
+      1. `Grain: <TIER>/<GENRE>` tag in the body, IF parseable. The tag is
+         authoritative (cf variation-protocol.md §1: « Le GENRE est le TYPE
+         DE TRAVAIL, jamais la famille ou vivent les fichiers »). Without
+         this, #10475 happens: body carries `Grain: MED/docs` in its first
+         line, but the title contains "notebook" -- the regex below would
+         infer `notebook-python` and the picker would propose it under a
+         secheresse-CONTENU restriction, defeating the guard.
+      2. Title + labels heuristic (GENRE_RULES, ordre important).
+      3. Fallback `docs` (the historically-safer META default).
+    """
+    if body:
+        tag = parse_grain_tag(body)
+        if tag and tag.get("genre"):
+            return tag["genre"]
     hay = (title + " " + " ".join(labels)).lower()
     for pattern, genre in GENRE_RULES:
         if re.search(pattern, hay):
@@ -310,7 +327,7 @@ def fetch_pool() -> list[dict]:
             "age": age_days(it["createdAt"]),
             "idle": age_days(it["updatedAt"]),
             "updated_at": it["updatedAt"],
-            "genre": infer_genre(title, labels),
+            "genre": infer_genre(title, labels, it.get("body") or ""),
             "body": it.get("body") or "",
             "parent": parent_issue(it.get("body") or ""),
             "polarity": polarity(title, it.get("body") or ""),

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -427,6 +427,49 @@ def _pr_with_author(n, lane, age_hours, author):
     return pr
 
 
+def test_infer_genre_reads_body_grain_tag_before_title_heuristic_13972():
+    """#13972 acceptance point 1 : si le body porte un tag `Grain: <TIER>/<GENRE>`
+    parseable, il est autoritatif -- le regex sur titre+labels ne doit pas
+    le contredire. Cas concret : #10475 (premiere ligne du body `Grain: MED/docs`)
+    titre `2.11 LASSO - notebook regression notebook-tools ...` -- le regex
+    inferait `notebook-python` (META, jamais du CONTENU), mais le tag Grain
+    dit `docs` (qui EST du CONTENU sous la partition du picker).
+    """
+    body = (
+        "Grain: MED/docs -- lane myia-ai-01:CoursIA\n\n"
+        "## Description\n"
+        "Mon issue avec un titre qui parle de notebook (ne pas se laisser avoir)."
+    )
+    title = "notebook regression sur 2.11 LASSO - notebook-tools harmonisation"
+    labels = ["documentation"]
+    # Le tag Grain MED/docs doit l'emporter sur le regex titre.
+    genre = pig.infer_genre(title, labels, body)
+    assert genre == "docs", (
+        f"le tag Grain du body est autoritatif, attendu 'docs', got {genre!r}. "
+        f"Sans ce contrat, #10475 (et ses semblables) restent classifies "
+        f"META alors que leur auteur a declare CONTENU."
+    )
+
+
+def test_infer_genre_falls_back_to_title_heuristic_when_no_grain_tag():
+    """#13972 controle positif : quand le body ne porte AUCUN tag Grain,
+    le regex sur titre+labels prend le relais (comportement historique).
+    Un titre `notebook Python regression` -> `notebook-python`.
+    """
+    body = (
+        "## Description\n"
+        "Pas de tag Grain ici, juste un titre parlant de notebook."
+    )
+    title = "notebook Python regression Lab3"
+    labels = []
+    genre = pig.infer_genre(title, labels, body)
+    assert genre == "notebook-python", (
+        f"fallback heuristique attendu `notebook-python`, got {genre!r}. "
+        f"Un correctif qui supprime le regex titre sans alternative retrecit "
+        f"dangereusement le vivier."
+    )
+
+
 def test_base_inherited_red_is_not_the_lanes(monkeypatch):
     """#13545 : 11 PRs / 4 lanes accusees pour un seul defaut de main.
 


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/guard #13974 cycle 75

## Grain

Issue #13972, sous-point acceptance 1 : tag `Grain:` du body autoritatif sur le regex titre+labels.

## Diagnostic

`pick_idle_grain.infer_genre(title, labels)` regarde le titre et les labels. Quand le titre contient `notebook`, le regex matche `notebook-python` (META, jamais eligible a une restriction CONTENU). Mais le body peut porter un tag `Grain: <TIER>/<GENRE>` qui contredit ce regex.

Cas #10475 (2026-09-01, secheresse 9 sur `myia-ai-01:CoursIA`) :
- body premiere ligne : `Grain: MED/docs` (CONTENU)
- titre : `2.11 LASSO - notebook regression notebook-tools ...`
- infere sans le fix : `notebook-python` (META, sort du jeu restreint CONTENU)
- infere avec le fix : `docs` (CONTENU, sort du jeu comme attendu)

Mesure du 2026-09-01 : 3 candidats sous restriction CONTENU, **2 META** (#10475, #13745). Le garde peut certifier la sortie de secheresse tout en la prolongeant silencieusement.

## Fix

`infer_genre(title, labels, body=None)` tente d'abord `parse_grain_tag(body)`. Si parseable, son champ `genre` est retourne. Sinon, fallback au regex historique, puis `docs` par defaut. Le parser `grain_tag.py` etait deja importe dans pick_idle_grain (utilise pour le guard et le prev), donc zero nouvelle dependance.

```diff
-def infer_genre(title: str, labels: list[str]) -> str:
+def infer_genre(title: str, labels: list[str], body: str | None = None) -> str:
+    if body:
+        tag = parse_grain_tag(body)
+        if tag and tag.get("genre"):
+            return tag["genre"]
     hay = (title + " " + " ".join(labels)).lower()
     for pattern, genre in GENRE_RULES:
         ...
```

L'appelant unique (`fetch_pool`) passe `it.get("body") or ""` -- le body est deja charge par le `gh issue list --json ... body`.

## Verification

```
$ python -m pytest scripts/tests/test_pick_idle_grain.py -q
============================= 81 passed in 0.23s ==============================
```

79 originaux + 2 nouveaux :
- `test_infer_genre_reads_body_grain_tag_before_title_heuristic_13972` : body `Grain: MED/docs` + titre `notebook regression ...` -> genre `docs`. Couvre le cas #10475.
- `test_infer_genre_falls_back_to_title_heuristic_when_no_grain_tag` : controle positif. Sans tag Grain, le regex titre continue de matcher `notebook-python`. Sans ce test, un correctif qui supprime le regex sans alternative retrecit dangereusement le vivier.

## Diff

```
 scripts/pick_idle_grain.py            | 21 +++++++++++++++--
 scripts/tests/test_pick_idle_grain.py | 43 +++++++++++++++++++++++++++++++++++
 2 files changed, 62 insertions(+), 2 deletions(-)
```

## Hors scope (acceptance points 2/3/4 explicites dans l'issue)

- Point 2 : discrimination `scripts/notebook_tools/**` vs `MyIA.AI.Notebooks/**/*.ipynb` (un script `notebook_tools/` n'est pas un notebook).
- Point 3 : annotation des clauses d'auto-exclusion dans le body (« ne compte pas comme le plat principal », « ne pas lancer avant decision user »).
- Point 4 : validation end-to-end sur la secheresse 9 du 2026-09-01 (rejouer le tirage et verifier que #10475 et #13745 sortent du jeu restreint).

Ces 3 points sont des grains dedies, atomiques, chacun avec son propre controle positif. Un grain composite (1 PR = 4 acceptance points + test E2E) violerait la regle A du PR-review-discipline (composites trop larges).

Refs #13972 · See #13086

## Note post-merge (cycle 82)

Body edite au cycle 82 pour ajouter le prefixe `Grain:` manquant en premiere ligne (le tag etait en fin de body, non detectable par le parser canonique). Le tag est maintenant conforme au format `Grain: TIER/GENRE -- lane ... -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste +62/-2.