### PR TITLE
fix(ci,#13978): le stale-sweep cesse d'exclure 38% du pool bloque sur un cancelled d'advisory

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -256,8 +256,39 @@ jobs:
                   _diag(p, "unfinished", [
                       f"{k[1]}[run {k[0]}]" for k in unfinished])
                   continue
+              # #13978 -- `cancelled` rentrait ici par le COMPLEMENT de GREEN,
+              # c'est-a-dire du cote meme que le commentaire de RED exempte
+              # explicitement ("It belongs here, on the GATE side only").
+              # L'asymetrie etait declaree, testee, et non implementee de ce
+              # cote. Sous `cancel-in-progress: true` sur les advisory, un
+              # `cancelled` frais n'est plus la "vraie interruption" rare que
+              # supposait l'acceptance 5 : c'est l'etat STATIONNAIRE de toute
+              # PR ayant recu deux pushes.
+              #
+              # Mesure du sweep 33459621864 (2026-09-01T01:40, 71 PRs
+              # inspectees) : sur 42 exclusions nommees, 26 tenaient a un
+              # `failure` reel et 16 -- 38 % -- a des `cancelled` SEULS, dont
+              # 13 au seul advisory `List open-PR path collisions`. Or ce meme
+              # advisory annule coexiste avec un `PR gate: SUCCESS` sur des PRs
+              # MERGEES (#13916, #13860) : le filtre etait strictement plus
+              # strict que le gate dont il existe pour re-rendre le verdict.
+              #
+              # L'intention d'acceptance 5 -- ne pas blanchir une vraie
+              # interruption -- tient toujours, parce que le sweep ne merge
+              # rien : il RELANCE le gate, qui re-lit l'etat live et conclura
+              # FAIL si un constituant est reellement rouge. Le verdict reste
+              # rendu par le gate, jamais par le sweep. Cout d'un faux positif
+              # d'eligibilite : une minute de runner. Cout du faux negatif
+              # actuel : une PR BLOCKED pour toujours, puisque le gate
+              # `cancelled` ne peut pas devenir SUCCESS tout seul.
+              #
+              # Exemption d'une SEULE conclusion, jamais une liste blanche de
+              # bloquants : `startup_failure`, `stale` et toute conclusion
+              # future inconnue continuent d'exclure.
+              OTHERS_NOT_BLOCKING = GREEN | {"cancelled"}
               red_others = [(k, c) for k, c in others
-                            if (c.get("conclusion") or "") not in GREEN]
+                            if (c.get("conclusion") or "")
+                            not in OTHERS_NOT_BLOCKING]
               if red_others:
                   _diag(p, "red", [
                       f"{k[1]}[run {k[0]}]={c.get('conclusion')}"

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -162,11 +162,55 @@ def test_two_gate_legs_and_not_latest_wins(tmp_path):
     assert out.strip() == "107 deadbeef false"
 
 
-def test_other_latest_cancelled_never_greenwashed(tmp_path):
-    """Asymetrie : un cancelled TOUT RECENT sur un autre check n'est pas vert ->
-    abstention (une interruption reelle ne se maquille pas)."""
+def test_other_latest_cancelled_is_candidate(tmp_path):
+    """#13978 -- INVERSION d'acceptance, datee 2026-09-01.
+
+    L'acceptance 5 d'origine (#11862) abstenait sur un `cancelled` frais porte
+    par un AUTRE check, au motif qu'une "interruption reelle ne se maquille
+    pas". Sa premisse -- un cancelled frais est une interruption RARE -- est
+    tombee : sous `cancel-in-progress: true` sur les workflows advisory, c'est
+    l'etat STATIONNAIRE de toute PR ayant recu deux pushes.
+
+    Mesure du sweep 33459621864 (2026-09-01T01:40, 71 PRs ouvertes) : sur 42
+    exclusions nommees, 16 -- 38 % -- tenaient a des `cancelled` SEULS, dont 13
+    au seul advisory `List open-PR path collisions`. Ce meme advisory annule
+    coexiste avec un `PR gate: SUCCESS` sur des PRs MERGEES (#13916, #13860) :
+    le filtre etait strictement plus strict que le gate dont il existe pour
+    re-rendre le verdict.
+
+    L'intention d'origine tient toujours, et c'est pourquoi l'inversion est
+    sure : le sweep ne merge rien -- il RELANCE le gate, qui re-lit l'etat live
+    et conclura FAIL si un constituant est reellement rouge. Le verdict reste
+    rendu par le gate.
+    """
     cancelled_new = ("Hermes review", "completed", "cancelled", "2026-01-01T11:00:00Z")
     out = _run_selector(tmp_path, [_pr(108, [GATE_FAIL, cancelled_new])])
+    assert out.strip() == "108 deadbeef false"
+
+
+def test_other_cancelled_plus_failure_still_abstains(tmp_path):
+    """CONTROLE POSITIF de l'inversion ci-dessus (#13978).
+
+    Sans lui, le correctif serait indiscernable d'un filtre debranche : il faut
+    montrer qu'un `failure` frais exclut TOUJOURS, y compris quand un
+    `cancelled` l'accompagne. Si ce test passe au vert en meme temps que
+    l'inversion, c'est que `red_others` ne filtre plus rien du tout.
+    """
+    cancelled_new = ("Hermes review", "completed", "cancelled", "2026-01-01T11:00:00Z")
+    failure_new = ("Papermill ratchet", "completed", "failure", "2026-01-01T11:00:00Z")
+    out = _run_selector(tmp_path, [_pr(109, [GATE_FAIL, cancelled_new, failure_new])])
+    assert out.strip() == ""
+
+
+def test_other_startup_failure_still_abstains(tmp_path):
+    """#13978 -- l'exemption porte sur UNE conclusion, pas sur le principe.
+
+    `startup_failure` (et toute conclusion future inconnue) doit continuer
+    d'exclure : le correctif ajoute `cancelled` a un ensemble non-bloquant, il
+    ne remplace pas le filtre par une liste blanche de bloquants.
+    """
+    startup = ("Hermes review", "completed", "startup_failure", "2026-01-01T11:00:00Z")
+    out = _run_selector(tmp_path, [_pr(110, [GATE_FAIL, startup])])
     assert out.strip() == ""
 
 
@@ -178,6 +222,11 @@ def test_selector_has_cancelled_in_red_not_green(tmp_path):
     assert m and "cancelled" in m.group(0)
     m = re.search(r'GREEN = \{[^}]*\}', SELECTOR)
     assert m and "cancelled" not in m.group(0)
+    # #13978 : le cote "autres checks" doit exempter `cancelled` EXPLICITEMENT.
+    # Un retour au complement nu de GREEN (`not in GREEN`) re-excluerait 38 %
+    # du pool bloque sans qu'aucun test d'acceptance ne rougisse.
+    assert 'OTHERS_NOT_BLOCKING = GREEN | {"cancelled"}' in SELECTOR
+    assert "not in OTHERS_NOT_BLOCKING" in SELECTOR
 
 
 # --- #11808 : le repli des check-runs par NOM fusionne des workflows homonymes ---


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #13866

**See #13978.**

## Le defaut

`pr-gate-stale-sweep.yml` est le **seul** organe qui re-rend un `PR gate` annule depuis que #12547 a retire le chemin evenementiel. Son filtre d'eligibilite s'abstient sur une condition **que le gate lui-meme pardonne**.

Le fichier declare l'asymetrie, mot pour mot :

> `cancelled` ... **It belongs here, on the GATE side only**: for other checks a cancelled run is either superseded ... or a real interruption that must not be greenwashed. **Asymmetric on purpose (#11862).**

Mais le cote « autres checks » n'utilisait pas `RED` — il utilisait le **complement de `GREEN`** (`not in GREEN`), par lequel `cancelled` re-rentrait, du cote que le commentaire exempte.

## La preuve

| PR | `PR gate` | check `CANCELLED` | etat |
|---|---|---|---|
| #13916 | **SUCCESS** | `List open-PR path collisions` | **MERGED** |
| #13860 | **SUCCESS** | `List open-PR path collisions` | **MERGED** |
| #13931 / #13956 / #13945 | SUCCESS | *(colonne vide)* | MERGED |

Les trois dernieres lignes sont le **controle positif** : le nom n'est pas un artefact constant de la requete, il apparait quand il y a annulation et disparait sinon.

## Le rayon d'action — sweep 33459621864 (2026-09-01T01:40, 71 PRs)

| Motif | Nombre | Verdict |
|---|---|---|
| >= 1 `failure` reel | 26 | exclusion correcte |
| **uniquement `cancelled`** | **16** | **exclusion fausse (38 %)** |

Treize sur le seul advisory `List open-PR path collisions` : #13913 #13912 #13857 #13848 #13846 #13828 #13827 #13820 #13798 #13782 #13775 #13685 #13672.

L'ensemble **requis** verifie sur #13912 / #13857 / #13672 ne contient qu'**un** check : `PR gate`. Controle positif du meme instrument sur #13945 : `pass` — il n'est pas coince sur « fail ».

Ces PRs restaient `BLOCKED` **indefiniment** : un gate `cancelled` ne devient jamais `SUCCESS` tout seul, et le seul organe qui pouvait le re-rendre refusait de les regarder.

## Le correctif

```python
OTHERS_NOT_BLOCKING = GREEN | {"cancelled"}
red_others = [(k, c) for k, c in others
              if (c.get("conclusion") or "")
              not in OTHERS_NOT_BLOCKING]
```

Exemption d'**une seule** conclusion, jamais une liste blanche de bloquants : `startup_failure`, `stale` et toute conclusion future inconnue continuent d'exclure.

## Ce qui merite le plus d'attention en review

**Ce correctif inverse une acceptance ratifiee et testee** (`test_other_latest_cancelled_never_greenwashed`, #11862). Ce n'est pas un oubli d'implementation que je corrige : c'est une decision de conception dont la **premisse est tombee**. L'acceptance supposait qu'un `cancelled` frais sur un autre check est une interruption *rare* ; sous `cancel-in-progress: true` sur les advisory, c'est l'etat **stationnaire** de toute PR ayant recu deux pushes.

L'intention d'origine — ne pas blanchir une vraie interruption — **tient toujours**, et c'est ce qui rend l'inversion sure : le sweep ne merge rien. Il **relance le gate**, qui re-lit l'etat live et conclura `FAIL` si un constituant est reellement rouge. Le verdict reste rendu par le gate, jamais par le sweep. Cout d'un faux positif d'eligibilite : **une minute de runner**. Cout du faux negatif actuel : **une PR bloquee pour toujours**.

## Validation — falsification, pas seulement du vert

Un suite 100 % verte est aussi ce que rend un filtre debranche. Les deux etats ont donc ete mesures :

```
$ git stash push .github/workflows/pr-gate-stale-sweep.yml
$ python -m pytest scripts/tests/test_pr_gate_sweep_select.py -q
FAILED test_other_latest_cancelled_is_candidate
FAILED test_selector_has_cancelled_in_red_not_green
2 failed, 14 passed

$ git stash pop
$ python -m pytest scripts/tests/test_pr_gate_sweep_select.py -q
16 passed
```

Trois tests ajoutes, dont **deux controles positifs qui passent dans LES DEUX etats** — c'est precisement ce qu'on attend d'un controle, et ce qui distingue le correctif d'un filtre debranche :

| Test | Role |
|---|---|
| `test_other_latest_cancelled_is_candidate` | l'inversion, datee et justifiee en docstring |
| `test_other_cancelled_plus_failure_still_abstains` | **controle** : un `failure` frais exclut toujours, meme accompagne d'un `cancelled` |
| `test_other_startup_failure_still_abstains` | **controle** : l'exemption porte sur une conclusion, pas sur le principe |
| `test_selector_has_cancelled_in_red_not_green` (durci) | un retour au complement nu de `GREEN` re-excluerait 38 % du pool **sans qu'aucune acceptance ne rougisse** |

## Genre declare, et pourquoi

`tooling`, pas `guard`. Le discriminant du protocole est « est-ce que ca peut rougir » : le sweep ne poste **aucun** verdict sur une PR — il est l'organe qui *repare* un verdict, pas celui qui juge. Je le declare explicitement pour qu'un reviewer puisse le contester plutot que de le laisser passer.

Et pour etre net sur le plancher : **c'est un grain META de plus** — le 10e consecutif pour cette lane. Il ne rompt pas ma secheresse G-VAR-1, et je ne le presente pas comme s'il la rompait.

## Suite

Voisin **distinct** : #12588 (le sweep peut *cesser de battre* — probleme d'**execution**). Mesure du jour a verser la-bas : dernier succes `2026-09-01T01:40`, soit **253 min** pour un cron horaire — 4 declenchements manques. Les deux defauts se cumulent : cette semaine le sweep n'a ni battu regulierement, ni repare ce qu'il voyait.
