### PR TITLE
feat(notebooks,#13410): App-19-WFC 10 lectures ancrees outputs - densite 705->1373 c/cell, code byte-identique

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
@@ -205,6 +205,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-tileset",
+   "metadata": {},
+   "source": [
+    "### Lecture — la structure du tileset porte toute la difficulté\n",
+    "\n",
+    "La sortie texte résume l'essentiel : **5 tuiles, 20 paires autorisées sur 25**. Autrement dit, seules 5 paires de tuiles sont interdites — mais ce sont elles qui font exister le problème : si les 25 paires étaient autorisées, n'importe quel remplissage aléatoire produirait un niveau valide, et ni WFC ni CP-SAT n'auraient de raison d'être. La difficulté de génération est entièrement portée par la densité de ces interdictions.\n",
+    "\n",
+    "Deux repères de lecture de la figure :\n",
+    "\n",
+    "- La matrice se lit **ligne = tuile courante, colonne = voisin** (cf. les labels d'axes posés par la cellule). Une case verte en `(i, j)` dit « la tuile *i* accepte la tuile *j* comme voisine ».\n",
+    "- Le dictionnaire `tileset['weights']`, visible dans la palette mais pas dans la matrice, servira dès la cellule suivante : le tirage WFC est **pondéré**, toutes les tuiles n'ont pas la même probabilité d'être choisies à l'effondrement.\n",
+    "\n",
+    "C'est aussi ici que se joue la généricité annoncée en §7 : le tileset donjon (5 tuiles) et le tileset cave (4 tuiles) alimentent exactement le même code — seules les données JSON changent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "37ee439f",
    "metadata": {
     "papermill": {
@@ -305,6 +322,20 @@
     "recorder = WFCRecorder(ROWS, COLS, tileset, SEED)\n",
     "final_wfc = recorder.solve()\n",
     "print(f\"WFC terminé — {len(recorder.snapshots)} étapes, {recorder.backtracks} retours arrière\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-wfc-steps",
+   "metadata": {},
+   "source": [
+    "### Lecture — anatomie des 102 étapes\n",
+    "\n",
+    "Le décompte se vérifie sur la source de `WFCRecorder` : **102 = 1 instantané initial + 100 effondrements + 1 instantané final**. Le `__init__` enregistre l'état « tous les domaines pleins » ; la grille 10×10 compte 100 cellules, chacune effondrée exactement une fois (un `_record` par effondrement) ; la sortie de `solve()` ajoute l'instantané terminal.\n",
+    "\n",
+    "Le second nombre est le plus instructif : **0 retours arrière**. À chaque effondrement, la propagation AC-3 (`_propagate`) a suffi à maintenir la cohérence des domaines voisins — la pile `stack` du backtracking n'a jamais été consultée. Ce n'est **pas** une propriété générale du WFC : c'est un fait de ce couple instance/graine (20/25 paires autorisées, seed 42). Sur un tileset plus contraint ou une autre graine, le même code peut dérouler des dizaines de retours arrière.\n",
+    "\n",
+    "Enfin, l'effondrement n'est pas uniforme : `rng.choices(d, weights=w)` tire la tuile selon `tileset['weights']` — le seed 42 rend la séquence reproductible, mais la distribution des tuiles du niveau final reflète ces poids."
    ]
   },
   {
@@ -445,6 +476,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-entropy",
+   "metadata": {},
+   "source": [
+    "### Lecture — l'entropie de Shannon comme guide de l'effondrement\n",
+    "\n",
+    "Le module `wfc_cpsat` révèle la politique cachée derrière l'animation : `_pick_cell` balaie toutes les cellules non effondrées et choisit celle d'**entropie minimale**. On effondre donc d'abord là où l'incertitude résiduelle est la plus faible — les cellules déjà très contraintes par leurs voisines — et on laisse la propagation faire le reste. C'est l'heuristique classique « most constrained variable » du CSP, réexprimée en vocabulaire quantique.\n",
+    "\n",
+    "L'entropie affichée à droite vaut `−Σ (wi/s)·log(wi/s)` sur le domaine restant (mêmes poids `weights` que le tirage). Son maximum, atteint pour un domaine plein de 5 tuiles équiprobables, est `log(5) ≈ 1,61` — c'est le `vmax` fixé par la cellule, ce qui garantit une échelle comparable d'une étape à l'autre.\n",
+    "\n",
+    "À l'étape 0 (celle rendue par l'exécution committée) : aucune cellule effondrée, la grille de gauche est intégralement bleue avec un « 5 » par case, la carte d'entropie est uniforme au maximum. Faites glisser le slider vers les dernières étapes : les taches sombres gagnent, l'encadré rouge suit la dernière cellule effondrée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "98536e6e",
    "metadata": {
     "papermill": {
@@ -524,6 +569,21 @@
     "if cpsat_result.stats:\n",
     "    s = cpsat_result.stats\n",
     "    print(f\"Sol: {s['floor_cells']} cases  |  Ennemis: {s['enemy_count']}  |  Clés: {s['key_count']}  |  Coffres: {s['chest_count']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-cpsat-solve",
+   "metadata": {},
+   "source": [
+    "### Lecture — chaque contrainte globale se lit dans la solution\n",
+    "\n",
+    "La sortie porte les quatre nombres qui font la valeur de CP-SAT sur ce problème :\n",
+    "\n",
+    "- **43 cases de sol sur 144** (≈ 30 %) : la solution s'est collée à la borne `min_floor_ratio = 0.30`. Le solveur n'a aucune incitation à maximiser le sol — il satisfait la fenêtre demandée et consacre le reste de son effort à l'objectif déclaré.\n",
+    "- **3 ennemis pour 43 cases** = 7,0 % du sol, dans la fenêtre `[0.05, 0.20]` — et pas à une borne : une inégalité est *satisfaite*, pas nécessairement *saturée*.\n",
+    "- **Clés = 1, coffres = 1** : les contraintes d'égalité (`Add(sum == k)`) sont tenues exactement — c'est précisément ce qu'un processus local comme WFC ne sait pas exprimer (« exactement N occurrences d'un type de tuile »).\n",
+    "- Le statut **`OPTIMAL`** : le solveur ne rend pas seulement une solution, il atteste qu'aucune meilleure n'existe pour l'objectif. WFC, lui, ne produit jamais une telle preuve — il n'a même pas de notion d'optimalité."
    ]
   },
   {
@@ -694,6 +754,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-validate",
+   "metadata": {},
+   "source": [
+    "### Lecture — le contrat de validation de l'exercice\n",
+    "\n",
+    "La cellule committée est le stub attendu : `violations: -1`, `valid: False`, les 4 étapes en commentaires `# Etape N`. Le stub ne lève aucune erreur (le notebook s'exécute de bout en bout, exercices non complétés compris) — c'est la convention de la série.\n",
+    "\n",
+    "Deux observations pour orienter la complétion :\n",
+    "\n",
+    "- Le seuil de validité demandé est **ambitieux** : `connectivity >= 0.5` alors que, dans la comparaison de la section 4, aucune des trois méthodes ne dépasse 7 %. Un `validate_level` correctement complété **rejettera** donc les trois grilles committées de ce notebook — c'est un test de non-régression utile : tout générateur amélioré qui passe ce seuil a réellement progressé.\n",
+    "- Tout le nécessaire est déjà importé en §0 : `adjacency_violations` et `bfs_reachable_floor` sont chargées dans la cellule d'imports. L'exercice est un assemblage de briques existantes, pas une réécriture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "402d486d",
    "metadata": {
     "papermill": {
@@ -768,6 +843,22 @@
     "    var  = tile_variety(g, n_tiles_cmp)\n",
     "    bt   = res['backtracks']\n",
     "    print(f\"  {name:8s}: {res['time']:.2f}s  viol={viol}  conn={conn:.0%}  var={var}/{n_tiles_cmp}  bt={bt}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-trio",
+   "metadata": {},
+   "source": [
+    "### Lecture — ce que chaque ligne du trio révèle\n",
+    "\n",
+    "Les trois lignes de la sortie se lisent comme un argument en trois temps :\n",
+    "\n",
+    "- **Aléatoire** : 20 violations d'adjacence, connectivité 2 %. C'est l'aveu d'une méthode sans modèle — elle remplit la grille et constate.\n",
+    "- **WFC pur** : 0 violations, mais connectivité **inchangée à 2 %**. C'est le point pédagogique central : la propagation locale élimine parfaitement les conflits de voisinage, et pourtant le niveau n'est pas plus traversable. Une contrainte *globale* (« le joueur peut aller partout ») n'est pas la somme des contraintes *locales*.\n",
+    "- **CP-SAT** : 0 violations et connectivité portée à 7 % par la relaxation flow — un triplement, obtenu sans garantie (condition nécessaire, pas suffisante ; la synthèse y revient).\n",
+    "\n",
+    "Deux détails de lecture : `bt=None` pour CP-SAT n'est pas un zéro — la colonne n'a pas de sens pour un solveur SAT, qui ne fait pas de backtracking au sens WFC ; et la variété 5/5 pour les trois méthodes montre que cette métrique ne discrimine rien sur ce tileset."
    ]
   },
   {
@@ -958,6 +1049,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-metrics",
+   "metadata": {},
+   "source": [
+    "### Lecture — le trade-off expressivité/performance, chiffré\n",
+    "\n",
+    "Le tableau texte complète la figure en portant les six métriques collectées (la figure n'en trace que quatre) :\n",
+    "\n",
+    "- **Temps** : 0,4 ms → 46 ms → 1 505 ms sur cette exécution — trois ordres de grandeur entre aléatoire et CP-SAT, un facteur ~30 entre WFC et CP-SAT. L'ordre de grandeur qualitatif est structurel ; les valeurs exactes sont *machine-dep* (la note de la section 6 pose la convention, valable ici aussi).\n",
+    "- **Sol %** : 35 / 40 / 30. CP-SAT se colle à sa borne inférieure (30 %), quand WFC produit la grille la plus ouverte (40 %) sans qu'aucune contrainte ne le lui demande — deux philosophies : satisfaire un cahier des charges vs suivre des poids de tirage.\n",
+    "- **Backtracks** : 0 partout sur cette graine. La comparaison WFC vs CP-SAT se joue donc ici sur l'*expressivité*, pas sur la difficulté de recherche — l'écart de temps achète des contraintes que WFC ne sait pas énoncer, pas une victoire sur un problème commun plus dur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1f768b07",
    "metadata": {
     "papermill": {
@@ -1121,6 +1226,20 @@
     "        print(f\"{name:12s}: {r.status}  {r.solve_time:.2f}s  ennemis={s['enemy_count']}  sol={s['floor_cells']}\")\n",
     "    else:\n",
     "        print(f\"{name:12s}: FAILED ({r.status})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-difficulty",
+   "metadata": {},
+   "source": [
+    "### Lecture — l'inversion contre-intuitive du coût de résolution\n",
+    "\n",
+    "Le résultat le plus surprenant de la section : c'est **Facile**, le preset aux ratios les plus permissifs, qui coûte le plus — statut `FEASIBLE` au terme du timeout de 20 s, optimalité non prouvée — quand **Moyen** et **Difficile**, aux contraintes plus serrées, prouvent leur optimalité en environ une seconde.\n",
+    "\n",
+    "La lecture est structurelle : élargir les fenêtres de ratios élargit l'espace des solutions candidates. Le solveur trouve vite *une* solution, mais doit explorer bien davantage pour prouver qu'aucune meilleure n'existe dans un espace aussi ouvert. Serrer les contraintes élague l'arbre de recherche — la difficulté perçue du niveau généré est l'inverse de la difficulté de le générer *prouvablement bien*. (La sémantique exacte des statuts est détaillée dans la note de la cellule suivante ; seuls les statuts et comptes sont structurels, les temps sont *machine-dep*.)\n",
+    "\n",
+    "Les fenêtres demandées sont tenues sur les trois presets : Facile porte 2 ennemis pour 64 cases de sol (3,1 %, fenêtre `[0.02, 0.08]`), Moyen 4 ennemis pour 43 cases (9,3 %, fenêtre `[0.08, 0.18]`), Difficile 8 ennemis pour 39 cases (20,5 %, fenêtre `[0.18, 0.35]`)."
    ]
   },
   {
@@ -1378,6 +1497,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-cave",
+   "metadata": {},
+   "source": [
+    "### Lecture — la généricité du modèle mise à l'épreuve\n",
+    "\n",
+    "Le changement de tileset est un changement de *données*, pas de *code* : les trois méthodes sont appelées avec la même API (`generate_random`, `PureWFC`, `solve_cpsat`), et la sortie confirme le chargement des 4 tuiles cave (`rock`, `cave`, `lake`, `stairs`) contre 5 au donjon. Toute l'adaptation vit dans les deux JSON — c'est la propriété qui rend l'approche réutilisable au-delà du cas d'école.\n",
+    "\n",
+    "Deux repères de lecture :\n",
+    "\n",
+    "- Le rôle de « sol » est une **convention de nommage** : c'est `floor_cave_id = ... name == 'cave'` qui désigne la tuile jouable ici. Les ratios de la section sont recalibrés pour la morphologie cave (sol 25–65 %, ennemis 3–15 %) — à comparer aux fenêtres du donjon en section 3.\n",
+    "- Le seed est **7** ici (et non 42) : les trois méthodes restent comparées à graine égale *entre elles* — la comparaison reste appariée — mais l'instance diffère de celle du donjon, donc on ne compare pas les niveaux inter-tilesets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "15d35983",
    "metadata": {
     "papermill": {
@@ -1473,6 +1607,18 @@
     "    widgets.HBox([w_seed, w_size, w_ts, w_conn]),\n",
     "    w_floor, w_enemy, w_btn, w_out\n",
     "]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-interactive",
+   "metadata": {},
+   "source": [
+    "### Lecture — le notebook replié en un seul rappel\n",
+    "\n",
+    "Chaque clic sur « Générer » rejoue l'intégralité du pipeline des sections 3 à 5 : `run_all` relance aléatoire + WFC + CP-SAT avec les paramètres du panneau — seed, taille 6–18, tileset donjon ou cave, connectivité on/off — et les trois grilles sont rendues avec leurs métriques recalculées. Le panneau suit le même patron que le slider d'étape de la section 2 : un widget `Output` vidé à chaque interaction (`clear_output(wait=True)`) pour ne retenir que le dernier rendu.\n",
+    "\n",
+    "Une observation honnête sur la version committée : les curseurs **« Sol [min,max] »** et **« Ennemis »** sont affichés dans le panneau, mais le rappel `generate` ne les lit pas — la signature de `run_all` (rows, cols, seed, tileset_path, cpsat_connectivity) n'expose pas de ratios, et le CP-SAT appelé en dessous garde donc ses valeurs par défaut. Les brancher est le prolongement naturel de cette section : étendre `run_all` avec deux paramètres optionnels, ou appeler `solve_cpsat` directement dans `generate` avec les bornes extraites des deux curseurs."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc.yaml
@@ -28,6 +28,12 @@
       csharp_sha: 26fd3dad52bc96f2cb9ae00568f2cee9cfe64be7
       content_python_sha: 5eeb0ebe92fc1fe92e8161cf6a7526462e4f66401fd38191124dff03dee5916b
       content_csharp_sha: 67b23f4caed6f84f57bfd5b87ceae17cf829c8b7167ce08f08d5c9d366117e95
+    - date: "2026-09-01"
+      by: myia-po-2027:CoursIA
+      python_sha: 080c42747ab3d0904965070b39ea7db869767349
+      csharp_sha: 26fd3dad52bc96f2cb9ae00568f2cee9cfe64be7
+      content_python_sha: 859105f0a9c8bb3ae9085ab1f32430ef3b211249882a8465451129f99aa2c935
+      content_csharp_sha: 67b23f4caed6f84f57bfd5b87ceae17cf829c8b7167ce08f08d5c9d366117e95
   known_differences:
     - "Socle pedagogique commun : Generation procedurale WFC / Wave Function Collapse (CSP + ipywidgets interactif) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = WFC + ipywidgets interactif + matplotlib GridSpec ; C# = BCL pure (System.Text) pour le from-scratch (sections 1-8) + Google.OrTools CP-SAT (Tranche 2)."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-dotnet #13919

## Sujet

Item 7 de la queue #13410 : `App-19-ProceduralGeneration-WFC.ipynb` sortait à **705 c/cell** (seuil 1200). Ajout de **10 cellules markdown d'interprétation**, chacune ancrée aux valeurs des outputs committés ou à la source explicitement citée :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après l'inspection du tileset | 5 tuiles, **20/25 paires autorisées** — les 5 interdictions font exister le problème ; lecture ligne=tuile/colonne=voisin ; rôle des `weights` pour la suite |
| 2 | après le solve WFC | décomposition des **102 étapes** (1 initial + 100 effondrements + 1 final, vérifiée sur la source de `WFCRecorder`) ; 0 retours arrière = fait de ce couple instance/graine, pas propriété générale |
| 3 | après le rendu pas-à-pas | `_pick_cell` = **entropie minimale** (« most constrained variable ») ; formule `−Σ(wi/s)log(wi/s)`, max `log(5)≈1,61` = le `vmax` du code |
| 4 | après le 1er solve CP-SAT | 43/144 ≈ 30 % collé à `min_floor_ratio` ; 3 ennemis = 7,0 % du sol dans `[0.05,0.20]` sans saturer ; clés/coffres exacts ; sens du statut `OPTIMAL` (preuve que WFC ne peut pas fournir) |
| 5 | après l'exercice `validate_level` | le stub C.1 ; le seuil `connectivity >= 0.5` rejettera les 3 grilles committées (max 7 % en §4) — test de non-régression ; imports déjà présents |
| 6 | après le trio §4 | l'argument en 3 temps : random 20 viol → WFC 0 viol mais conn **inchangée 2 %** (le point pédagogique central : global ≠ somme des locaux) → CP-SAT 7 % sans garantie ; `bt=None` sans objet pour SAT |
| 7 | après les métriques §5 | hiérarchie 0,4 ms → 46 ms → 1 505 ms (qualitatif structurel, valeurs *machine-dep* par convention §6) ; Sol % 35/40/30 ; l'écart de temps achète de l'expressivité, pas une victoire sur un problème commun |
| 8 | après les presets de difficulté | **l'inversion contre-intuitive** : Facile (ratios permissifs) = FEASIBLE à timeout 20 s, Difficile = OPTIMAL ~1 s — fenêtre large = espace à prouver plus grand ; ratios vérifiés (2/64=3,1 %, 4/43=9,3 %, 8/39=20,5 % dans leurs fenêtres) |
| 9 | après le tileset cave | généricité = changement de données, pas de code ; « sol » = convention de nommage (`name == 'cave'`) ; seed 7 = comparaison appariée inter-méthodes mais pas inter-tilesets |
| 10 | après le générateur interactif | chaque clic rejoue `run_all` ; **observation honnête sourcée** : les curseurs Sol/Ennemis sont affichés mais `generate` ne les lit pas — la signature de `run_all` (lue dans `wfc_cpsat.py`) n'expose pas de ratios ; brancher = prolongement proposé à l'étudiant |

## Validation

- **Code byte-identique** : 16/16 cellules code inchangées (source + outputs + `execution_count` comparés JSON contre `origin/main`) — enrichissement markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 705 → **1373 c/cell** (seuil 1200 atteint) ; markdown 11 280 → 21 970 chars ; 34 → 44 cellules.
- **Guards verts** : `scan_cell_ordering.py` clean · `detect_consecutive_code_cells.py` 0 run · `detect_markdown_rendering.py` 0 violation · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2).
- **Diff** : 146 insertions, 0 deletions — enrichissement pur.
- **Attestation twin** : `check_twin_parity.py --update --pair "App-19 ProceduralGeneration WFC"` passée APRÈS le commit du notebook (rebaseline `content_python_sha`), commit yaml séparé. Édits markdown-only unilatéraux côté Python : précédent #13919 (GT-11 côté C#).
- Prose conforme C.4/C.5 : chaque valeur citée vit dans l'output adjacent ou la source explicitement référencée ; les timings cités portent la convention *machine-dep* déjà posée par le notebook (§6/synthèse).

## Signal pour suivi

Les curseurs « Sol » et « Ennemis » du générateur interactif (§8) sont inertes dans le callback committé (`generate` ne les lit pas ; `run_all` n'expose pas de ratios) — constat sourcé dans la cellule 10, transformé en prolongement pédagogique. Un fix côté code (étendre `run_all` ou appeler `solve_cpsat` directement) serait un grain séparé — il exigerait une re-exécution complète du notebook (C.2).

See #13410 (item 7 — les items 8-10 restent ouverts)
