### PR TITLE
feat(notebooks,#13410): Planners-3-Csharp 9 lectures ancrees outputs - densite 707->1417 c/cell, code byte-identique

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -230,6 +230,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-modele",
+   "metadata": {},
+   "source": [
+    "### Lecture — deux décisions de modélisation qui portent tout le notebook\n",
+    "\n",
+    "Le modèle tient en trois lignes, mais deux choix s'y lisent déjà :\n",
+    "\n",
+    "- **`record GridState(int X, int Y)`** : l'égalité *structurelle* des records (deux `(3, 4)` sont égaux) est ce qui autorise `HashSet<GridState>` et `Dictionary<GridState, ...>` dans tous les algorithmes qui suivent — sans elle, chaque collection comparerait des références et le closed set ne reconnaîtrait jamais une revisite.\n",
+    "- **`CoutCase` = coût d'ENTRÉE dans une case** (le coût du pas est lu sur la case d'arrivée, pas de départ). Cette convention paraît anodine ici ; elle deviendra l'objet du correctif `Skip(1)` de la section 7, où sommer les cases du chemin *avec* le départ ajoute exactement +1 au coût réel.\n",
+    "\n",
+    "Le commentaire de la dernière ligne pose aussi le cadre Prong B : avec `coutMarais = 1`, le terrain redevient uniforme et **BFS = A*** — le cas dégénéré que la section 6 vérifiera, et l'exacte raison pour laquelle la section 7 introduit un vrai poids."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3c860517",
    "metadata": {
     "papermill": {
@@ -332,6 +347,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-bfs",
+   "metadata": {},
+   "source": [
+    "### Lecture — trois détails d'implémentation qui distinguent ce BFS d'un pseudo-code de cours\n",
+    "\n",
+    "- **`cameFrom` fait double emploi** : le dictionnaire sert à la fois de *closed set* (le test `!cameFrom.ContainsKey(n)` refuse les revisites) et de *mémoire de chemin* (la reconstruction remonte les parents). Une seule structure, deux rôles — c'est l'idiome canonique.\n",
+    "- **`stepsCost: 0`** en retour : BFS **ignore littéralement les coûts** — `getSuccessors` lui fournit `(voisin, cost)` et le `cost` n'est jamais lu. C'est la traduction en code de « optimal en nombre de pas, aveugle au coût ».\n",
+    "- **Les avertissements CS8632** de la sortie sont bénins : le contexte script de .NET Interactive n'active pas `#nullable`, les annotations `GridState?` du code restent donc signalées sans être fautives. Ils n'affectent ni l'exécution ni les résultats.\n",
+    "\n",
+    "La reconstruction (`Reconstruct`) remonte du but vers l'initial via les parents puis inverse la liste — le chemin rendu **inclut** le départ, d'où le `path.Count - 1` utilisé partout pour compter les pas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2ffde62f",
    "metadata": {
     "papermill": {
@@ -414,6 +443,20 @@
     "}\n",
     "\n",
     "Console.WriteLine(\"DFS : pile LIFO. Ni optimal ni complet, contraste pedagogique avec BFS.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-dfs",
+   "metadata": {},
+   "source": [
+    "### Lecture — même closed set, seul le conteneur change\n",
+    "\n",
+    "Comparé au BFS deux cellules plus haut, ce DFS ne change **que** le conteneur : `Queue` → `Stack`. Structure du parcours, closed set via `cameFrom`, reconstruction : tout est identique. C'est la démonstration la plus économe que BFS et DFS sont *le même algorithme* à l'ordre d'exploration près.\n",
+    "\n",
+    "La garde `maxDepth = 1000` mérite un mot : elle rend la recherche complète sur cette grille finie de 11×11 (aucun chemin utile ne dépasse 121 cases), mais c'est une rustine — sur un espace d'états infini ou cyclique non détecté, DFS sans limite peut ne jamais terminer. D'où le « ni optimal ni complet sans limite » de l'en-tête de section : le *sans limite* est à prendre au pied de la lettre.\n",
+    "\n",
+    "Enfin, le chemin que DFS rend est arbitraire : il dépend de l'ordre d'énumération d'`ACTIONS` (N, S, E, O) — le premier chemin trouvé par plongée, pas un chemin de qualité quelconque."
    ]
   },
   {
@@ -502,6 +545,20 @@
     "}\n",
     "\n",
     "Console.WriteLine(\"Manhattan = |dx|+|dy| (admissible sur grille). Greedy : priorite = h(n) seul (non optimal).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-greedy",
+   "metadata": {},
+   "source": [
+    "### Lecture — `PriorityQueue` .NET 9 et la fabrique du piège\n",
+    "\n",
+    "La classe `PriorityQueue<GridState, int>` est la brique .NET 9 qui rend les trois algorithmes guidés (Greedy ici, A* ensuite) quasi identiques au pseudo-code : l'élément de moindre priorité sort en premier, sans structure manuelle à maintenir.\n",
+    "\n",
+    "La différence entre Greedy et A* tient **à une seule expression** : Greedy met `heuristic(n, goal)` en priorité, A* mettra `tentative + heuristic(n, goal)`. En ignorant `g`, Greedy oublie ce qui a déjà été payé — c'est la fabrique du piège de la section 7 : attiré par la ligne droite vers le but, il traversera le marais aussi aveuglément que BFS, mais pour la moitié de l'effort d'exploration.\n",
+    "\n",
+    "Noter aussi que `Manhattan` définie ici aura une longue vie : c'est la même fonction qu'utiliseront A*, le test de consistance de la section 8, et le `AStarShortestPathAlgorithm` de QuikGraph en tranche 2."
    ]
   },
   {
@@ -596,6 +653,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-astar",
+   "metadata": {},
+   "source": [
+    "### Lecture — une seule ligne difficle : la relance paresseuse\n",
+    "\n",
+    "Le cœur d'A* tient dans le test `tentative < gScore.GetValueOrDefault(n, int.MaxValue)` : un voisin déjà vu n'est ré-enregistré (parent, `gScore`, enfile avec `f = g + h`) que si on a trouvé un chemin **meilleur** vers lui. C'est le mécanisme qui corrige les promesses hâtives : un nœud enfilé avec un `g` optimiste peut être ré-enfilé plus tard avec un `g` plus juste.\n",
+    "\n",
+    "Détail d'implémentation notable : `PriorityQueue` .NET n'offre pas de *decrease-key*, le code applique donc la **suppression paresseuse** — le nœud ré-enfilé apparaît deux fois dans la file, et l'ancienne entrée, de priorité dépassée, sortira après la nouvelle sans effet (le test de `cameFrom`/`gScore` la rend inoffensive). C'est l'idiome standard quand la file ne sait pas rétrograder une priorité.\n",
+    "\n",
+    "Le contraste avec BFS est net dans la signature : là où BFS rendait `stepsCost: 0`, A* rend `gScore[goal]` — **le coût cumulé réel**, seule quantité qu'il promet de minimiser (sous hypothèse d'admissibilité, vérifiée en section 8)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "827d081f",
    "metadata": {
     "papermill": {
@@ -685,6 +756,20 @@
     "Console.WriteLine($\"  BFS : {bfsPath.Count - 1} pas, {bfsNodes} nœuds explores.\");\n",
     "Console.WriteLine($\"  A*  : {astarPath.Count - 1} pas, cout {astarCost}, {astarNodes} nœuds explores.\");\n",
     "Console.WriteLine(\"  (sans poids, pas de discrimination entre BFS et A* — c'est normal)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-sanity",
+   "metadata": {},
+   "source": [
+    "### Lecture — même chemin, mais l'écart d'efficacité est déjà là\n",
+    "\n",
+    "Les deux algorithmes rendent le même chemin (10 pas, coût 10) : sur terrain uniforme, minimiser les pas et minimiser le coût coïncident — c'est le cas dégénéré, et la sortie le dit honnêtement.\n",
+    "\n",
+    "La colonne qui discrimine déjà est **Nœuds** : 91 pour BFS contre **11** pour A*. BFS explore par anneaux : tout ce qui est à moins de 10 pas du départ (environ la moitié gauche de la grille) passe en file avant le but. A* avance en pointe : la priorité `g + h` maintient chaque nœud exploré sur le corridor `(0,5) → (10,5)`, d'où 11 nœuds — exactement les cases du chemin. Le gain de l'heuristique, invisible dans le coût final, est **dans le travail évité** — un facteur ~8 sur cette instance.\n",
+    "\n",
+    "À retenir pour la suite : c'est *l'efficacité* qu'A* montre ici, pas encore sa *supériorité en coût*. Il faut le terrain pondéré de la section 7 pour voir les deux chemins diverger."
    ]
   },
   {
@@ -855,6 +940,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-prongb",
+   "metadata": {},
+   "source": [
+    "### Lecture — la table chiffre le point cle du notebook\n",
+    "\n",
+    "Trois lectures de la table committée :\n",
+    "\n",
+    "- **BFS et Greedy rendent le même chemin** (10 pas, 5 cases de marais, coût 55) — pour des raisons différentes (BFS minimise les pas ; Greedy suit l'heuristique en ligne droite) mais avec la même aveuglement au coût. Le contraste est dans Nœuds : 91 contre 11 — Greedy paie le même chemin 8× moins cher en exploration.\n",
+    "- **Le coût 55 se décompose exactement** : 5 pas hors marais à coût 1 + 5 pas dans le marais à coût 10 = 5 + 50. Symétriquement, le contournement d'A* coûte 16 pour 16 pas — **tous à coût 1** : quand A* évite le marais, coût et pas coïncident. Ces deux identités arithmétiques sont structurelles (elles dérivent de la définition du terrain, pas de la graine).\n",
+    "- **Le commentaire `Skip(1)` documente un vrai correctif** (le +1 historique) : `CoutChemin` somme les coûts d'entrée, départ exclu — la même convention qui réconcilie les compteurs des tranches 1 et 2.\n",
+    "\n",
+    "Pour l'Exercice 3 : la comparaison utile est `5 + 5c` (chemin droit : 5 pas normaux + 5 pas de marais à coût `c`) contre **16** (contournement) — la valeur committée 55 à `c = 10` confirme la formule. Le seuil de bascule s'en déduit par une inéquation, que l'étudiant résoudra en re-exécutant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f350db4b",
    "metadata": {
     "papermill": {
@@ -925,6 +1026,20 @@
     "}\n",
     "Console.WriteLine($\"Manhattan est consistante sur la grille ponderee : {consistant}\");\n",
     "Console.WriteLine(\"(h(n) <= cout(n->n') + h(n') pour tout arc ; garantit qu'A* ne rouvre pas un nœud ferme)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-consistance",
+   "metadata": {},
+   "source": [
+    "### Lecture — ce que le `True` vérifie, et pourquoi il importe\n",
+    "\n",
+    "La vérification n'est pas symbolique mais **exhaustive sur l'instance** : chaque arc de la grille pondérée (4 directions × 121 cases dans les limites) a subi le test `h(s) <= cost + h(n)`. Le `True` committé dit donc : sur *ce* terrain, Manhattan ne baisse jamais de plus que le coût du pas qui la fait baisser (au plus 1 par pas de coût ≥ 1 — y compris les arcs de coût 10, où la marge est écrasante).\n",
+    "\n",
+    "Pourquoi s'en soucier : la consistance est la condition qui garantit qu'A* **ne rouvre jamais un nœud déjà fermé** — la première fermeture est définitive. Sans elle (heuristique admissible mais inconsistante), l'implémentation « suppression paresseuse » de ce notebook verrait des ré-enfilages de nœud déjà traités, corrects mais coûteux. Avec elle, le closed set implicite est vraiment clos.\n",
+    "\n",
+    "La hiérarchie à retenir : **consistance ⇒ admissibilité** (mais pas l'inverse). Le test ci-dessus est donc le plus fort des deux — et il est passé."
    ]
   },
   {
@@ -1037,6 +1152,20 @@
     "    (int)Math.Round(Math.Sqrt((a.X - b.X) * (a.X - b.X) + (a.Y - b.Y) * (a.Y - b.Y)));  // TODO etudiant : verifier admissibilite\n",
     "Console.WriteLine($\"Euclidienne (0,0)->(3,4) = {Euclidean(new GridState(0,0), new GridState(3,4))} ; Manhattan = {Manhattan(new GridState(0,0), new GridState(3,4))}\");\n",
     "Console.WriteLine(\"Exercice a completer : euclidienne est-elle admissible sur grille 4-connexe ?\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-euclid",
+   "metadata": {},
+   "source": [
+    "### Lecture — l'ancrage chiffré de l'exercice\n",
+    "\n",
+    "La sortie committée donne le point de départ : euclidienne `(0,0)→(3,4)` = **5**, Manhattan = **7**. La distance « à vol d'oiseau » (5 — le triangle 3-4-5) minore strictement le chemin en escaliers (7 pas) : c'est l'inégalité géométrique que l'indice de l'exercice énonce.\n",
+    "\n",
+    "La question de l'exercice n'est pas cette inégalité mais celle de l'**arrondi** : l'implémentation renvoie `(int)Math.Round(...)` — un entier. La subtilité à trancher est donc : l'arrondi peut-il faire *dépasser* à l'heuristique euclidienne le vrai coût restant (des pas de coût 1 sur grille 4-connexe) sur certaines paires ? Le test à écrire est une vérification par énumération analogue à celle de la section 8 — et la réponse dépend des petites distances, là où l'arrondi a le plus d'effet relatif.\n",
+    "\n",
+    "Piste de raisonnement offerte par la sortie : sur `(0,0)→(3,4)`, l'écart (7 − 5 = 2) est généreux ; le doute vit sur les paires **courtes**, où l'arrondi au plus proche peut ajouter une demi-unité."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
@@ -28,6 +28,12 @@
       csharp_sha: 45e5c20ebfcbebfb6d9fbb3900dad550dd73b03b
       content_python_sha: 6d3b47331c520f4dad3ff444d24c19b0c5ccf486e2a744c69e004b5e6d1afe93
       content_csharp_sha: bbc68b3eb99939418bebbe93c76ae9587cdbec5e0507ea5c388ac8f6c7c957b6
+    - date: "2026-09-01"
+      by: myia-po-2027:CoursIA
+      python_sha: f5cf372f6fa80dacca90f67731954c61dae37366
+      csharp_sha: 8181eb9789f9fbdee9b47d8741836cd1d964ae06
+      content_python_sha: 6d3b47331c520f4dad3ff444d24c19b0c5ccf486e2a744c69e004b5e6d1afe93
+      content_csharp_sha: 5ff2eb25edfb2ba274d59f4118feb5844740667353aea20ea0b8f4a81d25d0c5
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables) + recherche de plan PDDL (8-puzzle)."
     - "Tranche 1 (from-scratch) : Python BFS/DFS/Greedy/A* via networkx + matplotlib heatmap terrain ; C# from-scratch BCL .NET 9 + PriorityQueue (meme algorithme, implementation idiomatic)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/notebook-python #13980

## Sujet

Item 8 de la queue #13410 : `Planners-3-State-Space-Csharp.ipynb` sortait à **707 c/cell** (seuil 1200). Ajout de **9 cellules markdown d'interprétation**, chacune ancrée aux outputs committés ou à la source explicitement citée. Les tranches 1-2 étant déjà interprétées (cells 21/24 portent l'en-tête et la Lecture tranche 2), les insertions couvrent le socle from-scratch (cells 2-19) :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après le modèle (§1) | les 2 décisions qui portent tout : égalité structurelle du `record` (prérequis des HashSet/Dict de tous les algos) ; `CoutCase` = coût d'ENTRÉE — la convention qui deviendra le fix `Skip(1)` de §7 |
| 2 | après BFS (§2) | `cameFrom` double emploi (closed set + mémoire de chemin) ; `stepsCost: 0` = BFS ignore littéralement les coûts ; les CS8632 committés sont bénins (pas de contexte `#nullable` en script) |
| 3 | après DFS (§3) | même closed set, seul `Queue`→`Stack` change — BFS/DFS = même algorithme à l'ordre près ; `maxDepth` = rustine sur grille finie ; chemin rendu = artefact de l'ordre d'`ACTIONS` |
| 4 | après Greedy (§4) | `PriorityQueue` .NET 9 ; Greedy vs A* = **une seule expression** de différence ; `Manhattan` définie ici servira A*, le test §8 ET QuikGraph tranche 2 |
| 5 | après A* (§5) | la ligne difficile `tentative < gScore.GetValueOrDefault(...)` = relance paresseuse (pas de decrease-key dans `PriorityQueue` .NET — double entrée inoffensive) ; A* rend `gScore[goal]` là où BFS rendait 0 |
| 6 | après le sanity (§6) | même chemin (10 pas, coût 10) mais **91 vs 11 nœuds** — l'heuristique montre déjà son efficacité (facteur ~8), pas encore sa supériorité en coût |
| 7 | après Prong B (§7) | décomposition exacte du coût 55 = 5 pas × 1 + 5 pas × 10 ; contournement 16 = 16 pas × 1 (identités structurelles) ; pour l'Exercice 3 : la comparaison est **5 + 5c** vs 16 (55 à c=10 le confirme), pas 10×c |
| 8 | après le test de consistance (§8) | le `True` = vérification exhaustive sur chaque arc de l'instance ; consistance ⇒ pas de réouverture de nœud fermé (rend la suppression paresseuse de §5 vraiment close) ; hiérarchie consistance ⇒ admissibilité |
| 9 | après l'exercice euclidienne (§9) | ancrage de la sortie committée (euclidienne 5 vs Manhattan 7 sur (0,0)→(3,4)) ; la vraie question de l'exercice = l'**arrondi** `Math.Round` sur les petites distances — sans spoiler la réponse |

Bonifie au passage le signal `consecutive-code-cells` : le run de 3 cellules code (exercices 1-2-3) est réduit à 2 (insertion entre exercice 2 et 3).

## Validation

- **Code byte-identique** : 13/13 cellules code inchangées (source + outputs + `execution_count` comparés JSON contre `origin/main`) — enrichissement markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 707 → **1417 c/cell** (seuil 1200 atteint) ; markdown 9 201 → 18 420 chars ; 26 → 35 cellules.
- **Guards verts** : `scan_cell_ordering.py` clean · `detect_consecutive_code_cells.py` run max 3→2, 0 violation · `detect_markdown_rendering.py` 0 violation · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2).
- **Diff** : 129 insertions, 0 deletions — enrichissement pur.
- **Attestation twin** : `check_twin_parity.py --update --pair "Planners-3 State-Space"` passée APRÈS le commit du notebook (rebaseline `content_csharp_sha`), commit yaml séparé. Édits markdown-only unilatéraux côté C# : précédent #13919 (GT-11).
- Prose conforme C.4/C.5 : chaque valeur citée vit dans l'output adjacent ou la source explicitement référencée ; identités arithmétiques (55 = 5+5×10, 16 = 16×1) dérivées et déclarées structurelles ; aucun timing cité.

## Note

L'indice de l'Exercice 3 écrit « cout(chemin droit) = 10*coutMarais », forme inexacte (le chemin droit compte 5 pas hors marais : 5 + 5c, vérifié par la sortie committée 55 à c=10). La cellule 7 pose la forme précise sans écrire le seuil — le code de l'indice (hors scope markdown-only) pourrait être rectifié dans un grain séparé si souhaité.

See #13410 (item 8 — les items 9-10 restent ouverts)
