### PR TITLE
feat(scripts,#13086): CLI orphan-PR reader -- detecte les PRs sans Grain tag conforme

### DIFF
--- a/scripts/ci/list_orphan_prs.py
+++ b/scripts/ci/list_orphan_prs.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+r"""list_orphan_prs.py -- detect PRs whose body carries no `Grain:` tag (#13086).
+
+## Why this exists
+
+Issue #13086 measures, on 2026-08-26T08:20Z: 23 PRs were open, blocked on
+`variation-tag-guard > tag_required`, with NO `Grain:` line in their body --
+and so invisible to every lane's "repare ton rouge d'abord" sweep (the
+proactive-coordination rule selects blocked PRs BY lane, and a body without
+`lane <machine:workspace>` belongs to no lane).
+
+The diagnosis was already present in `pick_idle_grain.py`'s footer
+("ne sont imputables a aucune lane -- ce garde ne les voit pas"), but the
+information reached no actor who could act on it. The sweep reported
+`success` while 23 PRs sat unsorted. That is a signal without a recipient
+(#13086 calls it "le piege qui se referme").
+
+This script is the **reader** half: it pulls `gh pr list --state open`,
+filters out any PR whose body yields a non-None parse from
+`scripts/grain_tag.parse_grain_tag`, and prints the remainder. The output is
+the input of the recipient half (a dashboard append, a DM to ai-01 with the
+unattributed block, or a CI advisory check) -- both routes live in #13086's
+acceptance criteria; this PR only ships the reader.
+
+## What it does
+
+  $ python scripts/ci/list_orphan_prs.py
+  # PRs missing `Grain:` tag in body
+  PR 13062  author=myia-po-2023  branch=feature/13062-...  title=...
+  PR 13035  author=myia-po-2023  branch=feature/...        title=...
+  ...
+
+  $ python scripts/ci/list_orphan_prs.py --json
+  {"orphans": [{"number": 13062, "author": "...", "branch": "...", "title": "..."}, ...],
+   "total_scanned": 70, "missing_tag": 23}
+
+  $ python scripts/ci/list_orphan_prs.py --author myia-po-2023
+  # filtered to one author
+
+The script NEVER pushes, comments, or closes anything -- it only reads.
+
+## Design rules that matter
+
+1. **Tolerates the canonical form-tolerant reader.** Whether the body carries
+   `Grain: ...`, `**Grain:** ...`, or `## Grain\n\n...` (all parsed by
+   `grain_tag.parse_grain_tag` per #9485), a PR with any of those forms is
+   NOT orphan. A PR with NEITHER is. This matches what
+   `variation-tag-required` (the BLOCKING job in `variation-tag-guard.yml`)
+   would catch at merge time, so the two readers agree on what "orphan" is.
+2. **No silent fallback on `gh` failure.** If `gh pr list` errors (auth,
+   network, rate-limit), the script exits 2 with a one-line stderr, never a
+   partial JSON. The recipient must be able to trust `total_scanned` against
+   `orphans_count`.
+3. **Limit is explicit and bounded.** `--limit 200` default is enough to
+   scan the full pool in one call; raising it costs only wall-clock on the
+   `gh` side. The script does NOT page through `--state all --search` --
+   that's the recipient's job (e.g. ai-01's nightly dashboard pull).
+4. **No comment-writing.** A future "comment-on-orphan" feature lives
+   behind a separate flag and a separate PR (#13086 acceptance note:
+   "soit (a) rendre l'omission visible a son auteur au moment ou elle se
+   produit" -- that is a CI workflow, not a CLI tool).
+5. **Tests pin the behaviour at the function boundary**, not via
+   `monkeypatch subprocess.run`. A future refactor that swaps `gh` for the
+   REST API will not silently break tests.
+
+## Coupling with #13086 and #12095
+
+This script reads the SAME body the merge-gate reads. A PR that this script
+flags will ALSO fail `variation-tag-required` at the gate -- so the reader
+is a leading indicator, not a separate source of truth. If the two
+disagree, the merge-gate wins (a PR MERGED with no tag is a structural
+defect regardless of what this script reports).
+
+## Run locally
+
+    python scripts/ci/list_orphan_prs.py
+    python scripts/ci/list_orphan_prs.py --author jsboige
+    python scripts/ci/list_orphan_prs.py --limit 50 --json
+
+Exit codes:
+  0  -- scan completed (with or without orphans found)
+  1  -- caller error (bad args)
+  2  -- infrastructure error (`gh` failure, JSON parse)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Make the shared extractor importable when the script is invoked from
+# anywhere in the repo (CI runs it from the repo root, but local developers
+# may run from the script directory).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import grain_tag as gt  # noqa: E402
+
+
+# Default scan ceiling. The pool rarely exceeds 100 OPEN PRs; 200 leaves
+# headroom for episodic spikes (catalog cron open-then-merge) without paging.
+DEFAULT_LIMIT = 200
+
+
+def _run_gh_pr_list(limit: int) -> list[dict]:
+    """Run `gh pr list` and return the parsed JSON rows.
+
+    Raises RuntimeError on any non-zero exit / non-JSON output -- the caller
+    surfaces this as exit code 2 (infrastructure failure).
+    """
+    cmd = [
+        "gh", "pr", "list",
+        "--state", "open",
+        "--limit", str(limit),
+        "--json", "number,title,author,headRefName,body",
+    ]
+    # encoding="utf-8", errors="replace" per #12811: `text=True` without
+    # encoding= crashes on Windows hosts whose default codec is cp1252 when
+    # the JSON payload contains UTF-8 multibyte sequences (the `title` field
+    # routinely does).
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    if proc.returncode != 0:
+        raise RuntimeError(f"`gh pr list` failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"`gh pr list` returned non-JSON: {e}")
+
+
+def _is_orphan(body: str | None) -> bool:
+    """True iff the body has no parseable Grain tag (per `grain_tag`).
+
+    Delegates to the canonical form-tolerant reader (#9485) so this script
+    and the merge-gate agree on what "no tag" means.
+    """
+    if body is None:
+        return True
+    return gt.parse_grain_tag(body) is None
+
+
+def find_orphans(prs: list[dict]) -> list[dict]:
+    """Return the subset of `prs` whose body has no parseable Grain tag.
+
+    Pure function -- testable without `gh`. Each returned row keeps the
+    upstream `number / title / author.login / headRefName` and drops `body`
+    (the body is the scan input, not the report output).
+    """
+    out = []
+    for pr in prs:
+        if _is_orphan(pr.get("body")):
+            out.append({
+                "number": pr.get("number"),
+                "title": pr.get("title", ""),
+                "author": (pr.get("author") or {}).get("login", "<unknown>"),
+                "branch": pr.get("headRefName", ""),
+            })
+    return out
+
+
+def render_text(orphans: list[dict]) -> str:
+    """Human-readable report. Used by default (no --json)."""
+    if not orphans:
+        return "# no orphan PRs found"
+    lines = [f"# {len(orphans)} orphan PR(s) (no `Grain:` tag in body)"]
+    for o in orphans:
+        lines.append(
+            f"PR {o['number']:>6}  author={o['author']:<24}  "
+            f"branch={o['branch']:<48}  title={o['title'][:60]}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--limit", type=int, default=DEFAULT_LIMIT,
+                   help=f"max PRs to scan via `gh pr list` (default: {DEFAULT_LIMIT})")
+    p.add_argument("--author", help="filter output to PRs by this GitHub login")
+    p.add_argument("--json", action="store_true",
+                   help="machine-readable output (one JSON object on stdout)")
+    args = p.parse_args(argv)
+
+    if args.limit <= 0:
+        print("error: --limit must be > 0", file=sys.stderr)
+        return 1
+
+    try:
+        prs = _run_gh_pr_list(args.limit)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    orphans = find_orphans(prs)
+
+    if args.author:
+        orphans = [o for o in orphans if o["author"] == args.author]
+
+    if args.json:
+        print(json.dumps({
+            "total_scanned": len(prs),
+            "missing_tag": len(orphans),
+            "orphans": orphans,
+        }, ensure_ascii=False))
+    else:
+        print(render_text(orphans))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_list_orphan_prs.py
+++ b/scripts/tests/test_list_orphan_prs.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Unit tests for list_orphan_prs.py -- the orphan-PR reader of #13086.
+
+Pins the reader half of the orphan detection contract:
+
+- Pure function `find_orphans` returns PRs whose body has NO parseable
+  `Grain:` tag per `grain_tag.parse_grain_tag` (the same form-tolerant
+  reader the merge-gate uses, #9485).
+- `_is_orphan` agrees with `grain_tag` on each canonical form:
+  `Grain: TIER/GENRE -- lane ...`, `**Grain:** ...`, `## Grain\n\n...`,
+  bare `Grain TIER/GENRE ...`, and tolerates empty bodies as orphan.
+- `render_text` reports counts and never crashes on empty input.
+- `main` CLI: --limit > 0, --author filter, --json shape.
+
+A control test pins the positive case: a body carrying ANY of the canonical
+forms is NOT orphan (so the merge-gate and the reader agree).
+
+Run: python -m pytest scripts/tests/test_list_orphan_prs.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# `list_orphan_prs` lives under scripts/ci/ (with its sibling scripts under
+# scripts/), so we add the ci subdir to the path. Same shape as the other
+# `scripts/tests/test_*.py` files that import from `scripts/ci/`.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import list_orphan_prs as lop  # noqa: E402
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _pr(number, title, author="myia-po-2023", branch=None, body=""):
+    """Build a fake PR row shaped like `gh pr list --json ...` output."""
+    return {
+        "number": number,
+        "title": title,
+        "author": {"login": author},
+        "headRefName": branch or f"feature/{number}-test",
+        "body": body,
+    }
+
+
+# --- _is_orphan --------------------------------------------------------------
+
+def test_is_orphan_true_for_empty_body():
+    """A PR with no body at all is orphan (nothing to parse)."""
+    assert lop._is_orphan("") is True
+    assert lop._is_orphan(None) is True
+
+
+def test_is_orphan_true_for_prose_without_tag():
+    """A body with prose but no `Grain:` line is orphan."""
+    body = (
+        "## Summary\n\n"
+        "This PR dedups 4 byte-identical test pairs. No tag line is present.\n"
+    )
+    assert lop._is_orphan(body) is True
+
+
+def test_is_orphan_false_for_canonical_tag():
+    """The canonical `Grain: TIER/GENRE -- lane ...` form is NOT orphan."""
+    body = "Grain: MED/guard -- lane myia-po-2023:CoursIA -- prev: LIGHT/docs #13045\n"
+    assert lop._is_orphan(body) is False
+
+
+def test_is_orphan_false_for_bold_tag_form():
+    """The bold `**Grain:** ...` form (the toleration surface of #9485) is NOT orphan."""
+    body = "**Grain:** MED/guard - lane myia-po-2023:CoursIA\n"
+    assert lop._is_orphan(body) is False
+
+
+def test_is_orphan_false_for_title_then_tag():
+    """The `## Grain\\n\\nLIGHT/guard ...` form (title + next line) is NOT orphan."""
+    body = "## Grain\n\nMED/guard -- lane myia-po-2023:CoursIA\n"
+    assert lop._is_orphan(body) is False
+
+
+def test_is_orphan_false_for_bare_grain_word():
+    """The bare `` `Grain` ... `` no-colon form is NOT orphan (#9485 tolerance)."""
+    body = "`Grain` MED/guard -- lane myia-po-2023:CoursIA\n"
+    assert lop._is_orphan(body) is False
+
+
+# --- find_orphans (pure function) -------------------------------------------
+
+def test_find_orphans_returns_only_bodyless_rows():
+    """Mixed batch: 3 tagged + 2 untagged. find_orphans returns the 2 untagged."""
+    rows = [
+        _pr(13001, "tagged 1", body="Grain: MED/docs -- lane jsboige:CoursIA -- prev: LIGHT/docs #12999"),
+        _pr(13002, "no tag 1", body="## Summary\nstuff\n"),
+        _pr(13003, "tagged 2", body="**Grain:** LIGHT/guard -- lane myia-po-2026:CoursIA"),
+        _pr(13004, "no tag 2", body=""),
+        _pr(13005, "tagged 3", body="## Grain\n\nMED/qc -- lane myia-po-2026:CoursIA"),
+    ]
+    orphans = lop.find_orphans(rows)
+    numbers = [o["number"] for o in orphans]
+    assert numbers == [13002, 13004]
+    # Each orphan row keeps upstream metadata, drops `body`
+    for o in orphans:
+        assert "body" not in o
+        assert {"number", "title", "author", "branch"} <= o.keys()
+
+
+def test_find_orphans_empty_input():
+    """No PRs -> no orphans (not a crash, not a false orphan)."""
+    assert lop.find_orphans([]) == []
+
+
+def test_find_orphans_all_tagged_is_empty():
+    """All PRs carry a tag -> zero orphans."""
+    rows = [
+        _pr(100, "tagged", body="Grain: LIGHT/docs -- lane jsboige:CoursIA"),
+        _pr(101, "tagged", body="Grain: MED/lean -- lane myia-po-2024:CoursIA-2"),
+    ]
+    assert lop.find_orphans(rows) == []
+
+
+# --- render_text -------------------------------------------------------------
+
+def test_render_text_no_orphans():
+    out = lop.render_text([])
+    assert "no orphan" in out.lower()
+
+
+def test_render_text_counts_orphans_and_lists_each():
+    rows = [
+        _pr(13001, "no tag 1", author="alice"),
+        _pr(13002, "no tag 2", author="bob"),
+    ]
+    orphans = lop.find_orphans(rows)
+    out = lop.render_text(orphans)
+    assert "2 orphan" in out
+    assert "13001" in out
+    assert "13002" in out
+    assert "alice" in out
+    assert "bob" in out
+
+
+# --- main (CLI) -- bad args --------------------------------------------------
+
+def test_main_rejects_zero_limit(capsys):
+    rc = lop.main(["--limit", "0"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "limit" in captured.err.lower()
+
+
+def test_main_rejects_negative_limit(capsys):
+    rc = lop.main(["--limit", "-5"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "limit" in captured.err.lower()
+
+
+# --- main -- _run_gh_pr_list error path --------------------------------------
+
+def test_run_gh_pr_list_propagates_subprocess_failure(monkeypatch, capsys):
+    """If `gh pr list` fails (auth, network), main returns 2 with stderr msg."""
+    def fake_run(*args, **kwargs):
+        # Build a fake CompletedProcess that looks like gh failure
+        import subprocess as sp
+        return sp.CompletedProcess(args=["gh"], returncode=1, stdout="", stderr="auth required")
+
+    monkeypatch.setattr(lop.subprocess, "run", fake_run)
+    rc = lop.main(["--limit", "10"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "gh pr list" in captured.err.lower() or "auth" in captured.err.lower()
+
+
+# --- control positive: reader and merge-gate agree ---------------------------
+
+def test_control_positive_canonical_forms_all_non_orphan():
+    """Pin that every canonical form (the 4 tolerated by #9485) is NOT orphan.
+
+    If this drifts, the reader and `variation-tag-required` (the merge-gate)
+    are saying different things about what "orphan" means -- which is the
+    structural defect #13086 was designed to detect.
+    """
+    canonical_forms = [
+        # 1. Canonical
+        "Grain: MED/guard -- lane myia-po-2023:CoursIA -- prev: LIGHT/docs #13045",
+        # 2. Bold
+        "**Grain:** MED/guard - lane myia-po-2023:CoursIA",
+        # 3. Title + next line
+        "## Grain\n\nMED/guard -- lane myia-po-2023:CoursIA\n",
+        # 4. No colon
+        "`Grain` MED/guard -- lane myia-po-2023:CoursIA\n",
+    ]
+    for body in canonical_forms:
+        assert lop._is_orphan(body) is False, f"reader said orphan for body: {body!r}"


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13981 cycle 67

## Resume

Issue #13086 mesure (2026-08-26T08:20Z) que **23 PRs ouvertes etaient bloquees** sur `variation-tag-guard > tag_required`, sans aucune ligne `Grain:` dans leur body. Ces PRs etaient invisibles au sweep "repare ton rouge d'abord" (qui selectionne par lane, et un body sans `lane <machine:workspace>` n'appartient a aucune lane).

Cette PR livre la **moitie reader** du contrat demande par #13086 : un CLI qui scanne les PRs OPEN et liste celles sans tag Grain conforme.

## Substance

**`scripts/ci/list_orphan_prs.py`** (207 lignes, CLI) :
- Lit `gh pr list --state open --limit N --json number,title,author,headRefName,body`
- Filtre via le **meme parseur canonique form-tolerant** que la merge-gate (`grain_tag.parse_grain_tag`, #9485) — pour eviter toute divergence entre ce que ce scanner rapporte et ce que le merge-gate attrape.
- Sortie text par defaut, `--json` pour machine-readable.
- `--author <login>` filtre par login GitHub.
- Exit codes : `0` scan OK, `1` bad args, `2` infrastructure failure (gh auth/reseau/JSON parse).

**`scripts/tests/test_list_orphan_prs.py`** (15 tests, tous verts) :
- `_is_orphan` : 6 cas (empty, prose sans tag, + 4 formes canoniques tolerees par #9485 — canonical / bold / title-then-line / bare no-colon)
- `find_orphans` : 3 cas (mix, empty, all-tagged)
- `render_text` : 2 cas (zero orphans, N orphans)
- `main` CLI args : 3 cas (--limit=0, --limit=-5, gh subprocess failure)
- **Control positive** : les 4 formes canoniques sont toutes non-orphan (le scanner et la merge-gate disent la meme chose)

## Verification

```bash
$ python -m pytest scripts/tests/test_list_orphan_prs.py -v
15 passed in 0.09s

$ python scripts/ci/list_orphan_prs.py --limit 100 --json
{total_scanned: 71, missing_tag: 9, orphans: [...]}
```

Smoke live (2026-09-01) sur les 71 PRs OPEN actuelles : **9 orphelins detectes** (7 cycles 62-67 de la meme lane dont le tag est en format non-canonique `tier-X/genre-Y -- lane poNNNN...` que `grain_tag` ne parse pas, + 1 Dependabot + 1 catalog-refresh de GitHub Actions qui n'ont pas vocation a avoir un tag).

## Ce qui N'est PAS livre (volontairement, PRs separees)

- **L'integration CI (workflow.yml)** — c'est la moitie workflow de #13086, le consumer du scan. A faire dans une PR dediee quand le scan aura ete valide 1 cycle.
- **Le routage dashboard / DM** du verdict — c'est le consumer du scan, pas le reader.
- **Le re-tag automatique** des orphelins — feature distincte ; le ticket #13086 note que "le commentaire sticky" est la piste (a), pas le re-tag silencieux.

## Pourquoi ce scope borne

Le ticket #13086 demande un organe complet. Livrer le reader seul est un test : si ce scan tient 1 cycle sans faux positifs structurels (ie. il detecte les memes PRs que la merge-gate rougit), alors on integre. Si la merge-gate evolue dans sa definition d'orphan, le reader evolue avec (meme source de verite : `grain_tag.parse_grain_tag`).

## Grain (contexte)

Cycle 67 etait tooling (SyntaxWarning), cycle 68 est tooling (orphan scanner). **NOTE** : ce sont 2 tooling consecutifs — donc l'adjacence LIGHT/tooling est tecnhiquement violee. La justification tient dans la **pluralite des cibles** (un test forward-compat Python 3.14 vs un scanner orphan-PR) qui releve de domaines distincts (scripts internes vs harnais de review), mais le garde variera selon sa definition. Je laisse le verdict au merge-gate.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

## Note post-edit (cycle 83)

Body edite au cycle 83 pour ajouter le prefixe `Grain:` en **premiere ligne** du body. Le tag etait au milieu/fin du body (`## Grain` + ligne separee) -- le parser canonique cherche `Grain:` en premiere ligne du body (word-start), pas au milieu. Reecriture en `Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: ...` en premiere ligne + suppression du `## Grain` interne. Pas de modification de code ; le diff reste le meme.