### PR TITLE
Enrich(pedagogy,GT-28b): 8 cellules d'interpretation ancrees outputs (item 9 #13410)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-28b-Humour-Banc-Dur.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-28b-Humour-Banc-Dur.ipynb
@@ -128,6 +128,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-setup",
+   "metadata": {},
+   "source": [
+    "### Lecture — trois choix de configuration qui cadrent toute l'expérience\n",
+    "\n",
+    "- **`CATEGORIES` en 5 cellules** réplique la taxonomie du toy model GT-28 (`humour_reussi`, `rire_sans_recadrage`, `recadrage_sans_rire`, `offensif_compris_non_partage`, `rien`). La 5ᵉ cellule `rien` est celle qui rend le banc discriminant : un détecteur qui répond toujours `humour_reussi` ne peut plus tricher.\n",
+    "- **`OPENAI_COMPAT_URL` pointe sur `192.168.0.47:5002/v1`** — un endpoint vLLM local, pas un service cloud. C'est ce qui rend le verdict SOTA `RECOVERABLE-LOCAL` (cell[0]) : l'outil est invoqué, pas simulé.\n",
+    "- **`OPENAI_API_KEY` est une clef locale vLLM, pas un secret production** — le commentaire le dit explicitement, et la valeur n'a pas vocation à être rotée comme une clef OpenAI. C'est la convention pour un service maison sans authentification réelle.\n",
+    "\n",
+    "La cellule committe aussi un `ARGUMENTUM_CACHE` : le CSV sera téléchargé une fois (cell[3]) puis relu depuis le cache pour la reproductibilité — un redémarrage du kernel ne re-déclenchera pas le fetch."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "79340466",
    "metadata": {
     "papermill": {
@@ -230,6 +244,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "interp-fetch",
+   "metadata": {},
+   "source": [
+    "### Lecture — un fetch authentique, traçable par SHA\n",
+    "\n",
+    "Deux sorties committées, deux garanties :\n",
+    "\n",
+    "- **`downloaded 555116 bytes`** : le CSV est réellement descendu (555 KB), pas un stub ni un fichier vide. Le cache local est créé à cette occasion.\n",
+    "- **`upstream master @0af0511c58`** : le SHA du dernier commit upstream est lu via l'API GitHub au moment de l'exécution. C'est la traçabilité du « corpus réel » de l'acceptance #12756 : n'importe qui peut reproduire le fetch sur ce SHA et comparer.\n",
+    "\n",
+    "Pourquoi cette voie plutôt que le submodule ? La cellule markdown précédente le documente : `git submodule update --init` timeout 2 min sur cet env (mesure c.539). Le fetch HTTP direct contourne le submodule **sans en perdre le bénéfice de traçabilité** — c'est un contournement de l'environnement (règle F : réparer), pas un contournement du corpus."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "7390cfad",
@@ -287,6 +316,22 @@
     "print(f\"[parse] {len(argumentum)} instances retenues (champs FR)\")\n",
     "print(f\"[parse] exemple : id={argumentum[0]['path']} titre='{argumentum[0]['titre']}'\")\n",
     "print(f\"         baratineur='{argumentum[0]['baratineur']}' -> piocheur='{argumentum[0]['piocheur']}'\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-parse",
+   "metadata": {},
+   "source": [
+    "### Lecture — 167 scénarios, 7 catégories, 21 sous-catégories\n",
+    "\n",
+    "La sortie détaille la structure du corpus Argumentum :\n",
+    "\n",
+    "- **167 scénarios** au total, répartis sur **7 catégories** (`histoire` 17, `mythologie` 27, `relation intime` 36, `vie professionnelle` 30, `vie personnelle` 25, `pop culture` 18, `politique` 14). `relation intime` est la plus nombreuse — c'est la catégorie la plus propice au matériel humoristique.\n",
+    "- **21 sous-catégories** affinent (ex. `antiquité`, `religions`, `drague et séduction`, `cinéma & télévision`). Ce grain fin servira à l'annotation heuristique de la cellule suivante.\n",
+    "- **Champs retenus** : `path`, `catégorie`, `sous-catégorie`, `titre`, `baratineur`, `piocheur`, `contexte`, `enjeu`, `suggestion`. Le `path` (ex. `7.3.2`) est l'identifiant de scénario utilisé pour le contrôle de disjonction de la section circularité (cell[18]).\n",
+    "\n",
+    "L'exemple imprimé (`baratineur` → `piocheur`) montre la structure d'un scénario Argumentum : un `baratineur` avance une interprétation, un `piocheur` doit la recadrer. C'est précisément la mécanique « recadrage partagé » que la cellule `humour_reussi` modélise."
    ]
   },
   {
@@ -579,6 +624,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-corpus",
+   "metadata": {},
+   "source": [
+    "### Lecture — 120 instances, 4 sources, distribution par cellule\n",
+    "\n",
+    "La sortie confirme l'acceptance `≥ 100 instances` :\n",
+    "\n",
+    "- **Total : 120 instances** (60 Argumentum + 30 blagues positives manuelles + 20 déclarations factuelles + 10 edge cases), l'`assert` passe.\n",
+    "- **Distribution par label** : `humour_reussi` 48, `rien` 38, `recadrage_sans_rire` 13, `rire_sans_recadrage` 14, `offensif_compris_non_partage` 7. Aucune cellule n'est vide, toutes dépassent le seuil de 5 instances — le banc est statistiquement exploitable.\n",
+    "- **Distribution par source** : Argumentum 60, blague-manuelle 30, declaration-factuelle 20, edge-case-curated 10. Quatre sources, deux gratuites (Argumentum + manuel) et deux négatives (factuelle + edge) — la diversité protège contre le biais de source unique.\n",
+    "\n",
+    "Deux lectures structurelles pour la suite :\n",
+    "\n",
+    "- **`humour_reussi` est surreprésentée (48/120 = 40 %)** parce qu'elle agrège l'Argumentum annoté `humour_reussi` (pop culture + relation intime par défaut) ET les 30 blagues positives manuelles. C'est attendu : la classe positive d'intérêt est enrichie pour avoir assez d'exemples.\n",
+    "- **`offensif_compris_non_partage` est la plus rare (7)** : seuls les 10 edge cases l'alimentent (moins les 3 attribués ailleurs). C'est la cellule qui testera le plus la discrimination fine du LLM en section 14."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4cc974f5",
    "metadata": {
     "papermill": {
@@ -676,6 +740,22 @@
     "# Test rapide sur 5 instances\n",
     "for inst in CORPUS_DUR[:5]:\n",
     "    print(f\"  {inst['id']:<10} truth={inst['label']:<25} naive={naive_detector(inst):<25} reframe={reframe_detector(inst)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-llm-test",
+   "metadata": {},
+   "source": [
+    "### Lecture — un appel test réussit, le label est inexact\n",
+    "\n",
+    "Le test sur `CORPUS_DUR[0]` (`arg-7.3.2`, vérité `rire_sans_recadrage`) rend :\n",
+    "\n",
+    "- **`pred='rien'`** — le LLM classe ce scénario Argumentum en `rien`, alors que la vérité terrain (annotation heuristique cell[5]) est `rire_sans_recadrage`. Première erreur, et elle est révélatrice : le LLM ne voit pas le rire dans un scénario de « relation intime / vie de couple », là où l'heuristique le pose par défaut.\n",
+    "- **`latency=163 ms`** — l'endpoint répond vite (une requête). Le batch de 30 (cell[12]) sera donc de l'ordre de 5 s, pas de risque de timeout cumulé.\n",
+    "- **`raw='rien'`** — le LLM a respecté la consigne « UNIQUEMENT le label », pas de texte autour. Le prompt structuré fonctionne ; l'erreur est de classification, pas de format.\n",
+    "\n",
+    "Ce test unique est la preuve `RECOVERABLE-LOCAL` de cell[0] : l'endpoint vit, répond, et produit un label exploitable — même quand le label est faux, ce qui est précisément ce que le banc cherche à mesurer."
    ]
   },
   {
@@ -1110,6 +1190,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "interp-prf1",
+   "metadata": {},
+   "source": [
+    "### Lecture — trois détecteurs, trois régimes de performance\n",
+    "\n",
+    "Le tableau `Precision / Recall / F1` sur la classe positive `humour_reussi` (sous-ensemble 30 instances) :\n",
+    "\n",
+    "- **Naïf** : P=0,500, R=1,000, F1=0,667 — il attrape tous les vrais positifs (R=1) mais au prix de 6 faux positifs (toute cellule `rire_sans_recadrage` est classée `humour_reussi` parce que `laugh=True`). La moitié de ses prédictions `humour_reussi` est fausse.\n",
+    "- **Partage** : P=1,000, R=1,000, F1=1,000 — parfait sur le sous-ensemble. La section circularité (cell[18-20]) montrera **pourquoi ce chiffre n'est pas un résultat** : les features sont dérivées du label, l'identité est constructive.\n",
+    "- **LLM `qwen3.6-35b-a3b`** : P=0,400, R=0,333, F1=0,364 — bien plus faible que les deux détecteurs à règles. Sur 6 vrais `humour_reussi`, il n'en attrape que 2 (R=0,333) et 3 de ses prédictions positives sont fausses (P=0,400).\n",
+    "\n",
+    "La lecture honnête : le LLM **n'est pas évalué sur le même terrain** que les détecteurs à règles. Ces derniers lisent des features booléennes dérivées du label ; le LLM ne voit que le texte. Le F1=0,364 du LLM n'est donc pas « moins bon que 1,000 » — il est **incomparable** au 1,000, qui mesure une identité algébrique, pas une capacité de classification. La section circularité (cell[18-20]) formalise exactement cette réserve."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "7edaced2",
@@ -1292,6 +1388,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "interp-disjonction",
+   "metadata": {},
+   "source": [
+    "### Lecture — 60 consommés, 107 tenus à l'écart, disjonction prouvée\n",
+    "\n",
+    "Le contrôle de circularité #13306 repose sur un prédicat reproductible : tout scénario dont le `path` figure dans `arg_sample` (60 scénarios tirés avec `random.seed(42)` en cell[7]) est « consommé » ; les autres sont « tenus à l'écart ».\n",
+    "\n",
+    "- **60 consommés, 107 tenus à l'écart** (167 total) — l'arithmétique corrigée de l'issue #13306 (`167 - 60`, pas `167 - 120` qui concaténait corpus de travail et consommation Argumentum).\n",
+    "- **Disjonction prouvée par trois contrôles** : intersection des paths = 0, union = 167 (total), intersection des ids `arg-*` du `CORPUS_DUR` avec le tenu-à-l'écart = 0. L'`assert` passe — les ensembles sont mathématiquement disjoints, pas seulement « différents ».\n",
+    "- **Distribution du tenu-à-l'écart** : `humour_reussi` 37, `rien` 28, `recadrage_sans_rire` 17, `rire_sans_recadrage` 14, `offensif_compris_non_partage` 11 — proche de la distribution du consommé, donc le F1 sur le tenu-à-l'écart n'est pas trivialisé par une cellule vide.\n",
+    "\n",
+    "Le point critique pour la cellule suivante : les features des instances tenues à l'écart sont **construites par la même fonction** (`features_from_label`) que celles du corpus. C'est ce qui rend le F1=1,000 sur le tenu-à-l'écart **non informatif** — la circularité écartée est la plus grossière (surapprentissage des instances spécifiques), pas la structurelle (features dérivées du label)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "id": "92f330cc",
@@ -1367,6 +1479,22 @@
     "for lab in CATEGORIES:\n",
     "    inst = {\"features\": features_from_label(lab)}\n",
     "    print(f\"  {lab:<30} -> détecteur : {reframe_detector(inst)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-bootstrap",
+   "metadata": {},
+   "source": [
+    "### Lecture — F1=1,000 partout, IC dégénéré, et c'est précisément le problème\n",
+    "\n",
+    "Les trois lignes rendent le même verdict `P=1,000 R=1,000 F1=1,000` avec un **intervalle de confiance bootstrap `[1,000, 1,000]`** — c'est-à-dire dégénéré (largeur nulle).\n",
+    "\n",
+    "- **Sur le tenu-à-l'écart (107)** : le F1 tient, donc la circularité grossière (surapprentissage des instances spécifiques du corpus) est écartée — c'est la conclusion de #13306.\n",
+    "- **Mais l'IC dégénéré est la signature d'un pipeline déterministe**, pas d'une mesure confiante : un bootstrap non paramétrique sur un classifieur qui est une fonction déterministe des labels rend toujours la même valeur, donc un intervalle de largeur nulle. Ce n'est pas une forte confiance, c'est l'absence de stochasticité.\n",
+    "- **La trace algébrique** l'explique : `label → features_from_label → reframe_detector` est une **involution** (sauf pour `recadrage_sans_rire` qui tombe en `rien` — un cas où le détecteur est strictement plus conservateur que l'annotation). Le détecteur inverse la construction des features, donc il ne peut pas se tromper sur un Argumentum, fût-il tenu à l'écart.\n",
+    "\n",
+    "La réserve structurelle est posée en cell[20] : le F1=1,000 **ne mesure pas la théorie du partage sur le corpus Argumentum**, il mesure l'identité de construction features ↔ label. L'écart avec Qwen (F1 ≈ 0,364) n'est pas un résultat : c'est l'écart entre un détecteur évalué sur son terrain de construction et un modèle évalué hors du sien. La voie de validation réelle est #12756 (features annotées depuis le texte, indépendamment du label)."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-dotnet #13982

## Sujet

Item 9 de la queue #13410 : `GameTheory-28b-Humour-Banc-Dur.ipynb` sortait à **826 c/cell** (seuil 1200). Ajout de **8 cellules markdown d'interprétation**, chacune ancrée aux outputs committés ou à la structure du code explicitement citée. Le notebook portait déjà 9 cellules markdown denses (intro, acceptance, section headers, verdict SOTA, circularité, conclusion) ; les insertions couvrent les zones de code sans interprétation adjacente :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après le setup (cell 1) | 5 catégories répliquant la taxonomie GT-28 ; `rien` = la cellule qui empêche le tricheur ; endpoint vLLM local `192.168.0.47:5002` = verdict `RECOVERABLE-LOCAL` ; `OPENAI_API_KEY` = clef locale non-production ; `ARGUMENTUM_CACHE` = reproductibilité au redémarrage |
| 2 | après le fetch (cell 3) | `downloaded 555116 bytes` = corpus réel descendu ; `upstream master @0af0511c58` = traçabilité du corpus #12756 ; le fetch HTTP contourne le submodule timeout (c.539) sans perdre la traçabilité |
| 3 | après le parse (cell 4) | 167 scénarios, 7 catégories (`relation intime` 36 = la plus nombreuse), 21 sous-catégories ; `path` = id de scénario réutilisé au contrôle de disjonction (cell 18) ; structure `baratineur` → `piocheur` = mécanique du recadrage partagé |
| 4 | après le corpus dur (cell 7) | 120 instances, 4 sources, distribution par cellule (`humour_reussi` 48/40%, `offensif` 7 = la plus rare) ; `assert ≥100` passe ; `humour_reussi` surreprésentée par construction (Argumentum + 30 manuelles) |
| 5 | après le test LLM (cell 10) | `pred='rien'` inexact sur vérité `rire_sans_recadrage` (1ʳᵉ erreur révélatrice) ; `latency=163 ms` (batch 30 ≈ 5 s) ; `raw='rien'` = prompt respecté, erreur de classification pas de format ; preuve `RECOVERABLE-LOCAL` |
| 6 | après P/R/F1 (cell 15) | Naïf P=0.500/R=1.000 (6 FP), Partage 1.000/1.000/1.000 (constructif, cf cell 18-20), LLM 0.400/0.333/0.364 (incomparable au 1.000 — terrains d'évaluation différents) |
| 7 | après la disjonction (cell 18) | 60 consommés / 107 tenus à l'écart (arithmétique corrigée `167-60`), 3 contrôles de disjonction prouvés (paths inter=0, union=167, ids inter=0) ; `features_from_label` identique à cell 7 = ce qui rend le F1 tenu-à-l'écart non informatif |
| 8 | après le bootstrap IC (cell 19) | F1=1.000 partout avec IC `[1.000, 1.000]` dégénéré = signature d'un pipeline déterministe, pas d'une mesure confiante ; trace algébrique `label → features → détecteur` = involution (sauf `recadrage_sans_rire`→`rien`, détecteur plus conservateur) ; réserve structurelle posée cell 20 = l'écart LLM n'est pas un résultat |

## Validation

- **Code byte-identique** : 13/13 cellules code inchangées (source + outputs + `execution_count` comparés JSON par id contre `origin/main`) — enrichissement markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 826 → **1569 c/cell** (seuil 1200 atteint) ; markdown 11 851 → 20 403 chars ; 22 → 30 cellules.
- **Guards verts** : `scan_cell_ordering.py` clean · `detect_consecutive_code_cells.py` run max 2, 0 violation · `detect_markdown_rendering.py` 0 violation · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2).
- **Diff** : 128 insertions, 0 deletions — enrichissement pur.
- **Twin parity** : aucune paire twin déclarée dans `scripts/notebook_tools/twin_pairs.d/` pour ce notebook — pas d'attestation requise.
- Prose conforme C.4/C.5 : chaque valeur citée vit dans l'output adjacent ou la source explicitement référencée ; les verdicts (`RECOVERABLE-LOCAL`, `CIRCULARITE_GROSSIERE_ECARTEE`) sont ceux déjà posés par le notebook (cell 0, cell 20), repris sans les réinventer ; aucun timing cité hormis la latence LLM (163 ms, machine-dep conventionnel).

## Note

Le notebook documente déjà honnêtement (cell 20) que le F1=1.000 du détecteur maison est une identité de construction, pas une performance — les 8 cellules d'interprétation ne réinventent pas ce verdict, elles le rendent lisible au fil de la lecture en l'ancrant sur chaque output qui le fonde.

See #13410 (item 9 — l'item 10 reste ouvert)
