### PR TITLE
feat(ict,#13903): Greffe 5 tranche 3/3 -- ICT-Greffe5-AttributionCausale.ipynb (3 estimateurs sur cible +raft/+discard)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Greffe5-AttributionCausale.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Greffe5-AttributionCausale.ipynb
@@ -1,0 +1,723 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "712af173",
+   "metadata": {},
+   "source": [
+    "# ICT-Greffe5 -- Attribution causale de l'intervention sur l'espace atteignable\n",
+    "\n",
+    "Greffe 5 de la serie ICT (issue **#13903**, Epic **#4588**) -- tranche 3/3.\n",
+    "\n",
+    "## Cible\n",
+    "\n",
+    "La **greffe 2** (`ICT-Greffe2-EspaceAtteignable.ipynb`, issue **#13568**) isole un quadruplet $(A, F, r, \\pi)$ et montre que les ajouts d'operateurs STRIPS (`+raft`, `+discard`) modifient l'espace atteignable de maniere discriminante : `+raft` elargit reellement (1/3 $\\to$ 3/3 buts), `+discard` decore (|A| +50 %, 0 but nouveau). Mais le protocole Greffe 2 ne pose pas la **question causale** : *l'operateur `+raft` est-il la cause de l'elargissement, ou un artefact de mesure ?*\n",
+    "\n",
+    "Cette tranche 3/3 repondt a cette question en appliquant les estimateurs de `ict.causal_attribution` (tranche 1/3, mergee via **#13916**) sur un **panel experimental** construit par imitation du domaine Greffe 2 -- la relaxation STRIPS est **consommee**, jamais re-derivee (cf. CLAUDE.md section D)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af095d92",
+   "metadata": {},
+   "source": [
+    "## Estimateurs disponibles (API close-form de `ict.causal_attribution`)\n",
+    "\n",
+    "Trois estimateurs, du plus naif au plus correct :\n",
+    "\n",
+    "1. **`naive_difference`** : $E[Y | X=1] - E[Y | X=0]$. Biaise par confondants. Baseline pour montrer la limite.\n",
+    "2. **`backdoor_adjustment`** : ajustement sur un confondu observe $Z$, en sommant $\\sum_z P(Y=y | X=x, Z=z) \\cdot P(Z=z)$. Correct si le set backdoor est satisfait (Pearl 2009, chap. 3.3).\n",
+    "3. **`iv_estimate`** : $ATE_{IV} = Cov(Y, Z) / Cov(X, Z)$. Correct si l'instrument est pertinent (Angrist-Krueger 2001).\n",
+    "\n",
+    "Verdict tri-etat (analogue au protocole d'ICT-12e pour l'EVSI) :\n",
+    "\n",
+    "- **AGREEMENT** : estimateurs dans la tolerance declaree.\n",
+    "- **DESACCORD** : ecart superieur a la tolerance, les deux valeurs sont rapportees.\n",
+    "- **NON_IDENTIFIABLE** : l'estimand n'est pas identifiable sous le graphe causal pose (instrument non pertinent). Resultat **legitime**, pas un echec."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db61f72e",
+   "metadata": {},
+   "source": [
+    "## Plan experimental\n",
+    "\n",
+    "On imite le domaine STRIPS de Greffe 2 sur un **grillage reduit** $3 \\times 3$ (3 colonnes, 3 rangs) avec un seul objet `cle` et un seul but $g$ = tenir la cle. Quatre vocabulaires d'operateurs :\n",
+    "\n",
+    "- `A_t` : vocabulaire de base (4 directions, pickup `cle`).\n",
+    "- `A_t+discard` : `A_t` + un operateur `discard` sterile (perte d'objet, etat-piege).\n",
+    "- `A_t1 (+raft)` : `A_t` + un operateur `teleport` qui ouvre une cellule supplementaire.\n",
+    "- `A_t1+discard` : `A_t1` + le meme `discard` sterile.\n",
+    "\n",
+    "Pour chaque vocabulaire, on tire $n_{seeds} = 30$ positions initiales aleatoires de l'objet `cle`, on mesure le **taux d'atteignabilite** (forward-search budget $B = 8$) et le **taux d'etats atteignables** depuis l'initial. Le panel experimental est $(X, Z, Y)$ avec :\n",
+    "\n",
+    "- $X = 1$ si le vocabulaire contient `teleport` (analogue `+raft`), $X = 0$ sinon.\n",
+    "- $Z = 1$ si le vocabulaire contient `discard` (analogue `+discard`).\n",
+    "- $Y$ = taux d'atteignabilite du but (moyenne sur les 30 graines).\n",
+    "\n",
+    "Controle negatif : sur `A_t1+discard`, le `discard` est cense rendre l'elargissement `+raft` moins utile (l'agent perd la cle si elle l'attrape et jette sa prise) -- la mesure naive doit montrer un ATE positif (X=1 elargit) mais l'IV (instrument = `discard` ajoutee) doit signaler l'effet heterogene."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ae36541d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.593917Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.593477Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.723243Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.722769Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ict.causal_attribution OK : dict_keys(['AGREEMENT', 'DESACCORD', 'NON_IDENTIFIABLE'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "from collections import deque\n",
+    "from dataclasses import dataclass\n",
+    "from typing import FrozenSet, List, Tuple\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "# Le module  vit dans le meme dossier que ce notebook.\n",
+    "_ICT_DIR = os.path.dirname(os.path.abspath(\"ICT-Greffe5-AttributionCausale.ipynb\"))\n",
+    "if _ICT_DIR not in sys.path:\n",
+    "    sys.path.insert(0, _ICT_DIR)\n",
+    "\n",
+    "from ict import causal_attribution as ca\n",
+    "\n",
+    "print(\"ict.causal_attribution OK :\", ca.AttributionVerdict.__members__.keys())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03e98acc",
+   "metadata": {},
+   "source": [
+    "### Mini-domaine STRIPS imite de Greffe 2\n",
+    "\n",
+    "On construit un domaine **clos** sur un grillage $3 \\times 3$ (sans gouffre -- simplification du domaine Greffe 2 qui en avait un). Le `Operateur` STRIPS est importe comme un tuple `(nom, pre, add, del)` (forme minimale). La mesure est :\n",
+    "\n",
+    "- **forward-reachable** : nombre d'etats atteignables depuis `INITIAL` par BFS dans le graphe d'operateurs, avec budget $B = 8$ expansions.\n",
+    "- **but_atteint** : 1 si le but est dans `F_B(INITIAL)`, 0 sinon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4512e65c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.724497Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.724291Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.731301Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.730881Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A_t                              |V| = 25 operateurs\n",
+      "A_t +discard                     |V| = 26 operateurs\n",
+      "A_t1 (+teleport)                 |V| = 26 operateurs\n",
+      "A_t1 (+teleport) +discard        |V| = 27 operateurs\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Operateur STRIPS minimal (consomme, jamais re-derive : voir CLAUDE.md section D).\n",
+    "@dataclass(frozen=True)\n",
+    "class Operateur:\n",
+    "    nom: str\n",
+    "    pre: FrozenSet[str]\n",
+    "    add: FrozenSet[str]\n",
+    "    dele: FrozenSet[str]\n",
+    "\n",
+    "    def applicable(self, etat: FrozenSet[str]) -> bool:\n",
+    "        return self.pre.issubset(etat)\n",
+    "\n",
+    "    def appliquer(self, etat: FrozenSet[str]) -> FrozenSet[str]:\n",
+    "        return frozenset((etat - self.dele) | self.add)\n",
+    "\n",
+    "    def __repr__(self) -> str:\n",
+    "        return self.nom\n",
+    "\n",
+    "\n",
+    "COLS = (0, 1, 2)\n",
+    "RANGS = (0, 1, 2)\n",
+    "CASES = [(c, r) for c in COLS for r in RANGS]\n",
+    "\n",
+    "BUT = frozenset({\"holding-key\"})\n",
+    "\n",
+    "def prop(c: int, r: int) -> str:\n",
+    "    return f\"at-x{c}-y{r}\"\n",
+    "\n",
+    "INITIAL = frozenset({prop(0, 0), \"key-at-x1-y0\"})\n",
+    "\n",
+    "\n",
+    "def ops_de_base() -> List[Operateur]:\n",
+    "    \"\"\"4 directions + pickup cle a la case (1, 0).\"\"\"\n",
+    "    ops: List[Operateur] = []\n",
+    "    for c, r in CASES:\n",
+    "        for dc, dr, nom_dir in [(1, 0, \"est\"), (-1, 0, \"ouest\"),\n",
+    "                                 (0, 1, \"nord\"), (0, -1, \"sud\")]:\n",
+    "            cible = (c + dc, r + dr)\n",
+    "            if cible in CASES:\n",
+    "                ops.append(Operateur(\n",
+    "                    f\"move-{nom_dir}-x{c}-y{r}\",\n",
+    "                    {prop(c, r)}, {prop(*cible)}, {prop(c, r)}))\n",
+    "    ops.append(Operateur(\"pickup-key\",\n",
+    "                         {prop(1, 0), \"key-at-x1-y0\"},\n",
+    "                         {\"holding-key\"}, {\"key-at-x1-y0\"}))\n",
+    "    return ops\n",
+    "\n",
+    "\n",
+    "def ops_avec_teleport(base: List[Operateur]) -> List[Operateur]:\n",
+    "    \"\"\"Analogue de  : teleport diagonal (0,0) -> (2,2).\"\"\"\n",
+    "    ops = list(base)\n",
+    "    ops.append(Operateur(\"teleport-diag\",\n",
+    "                         {prop(0, 0)}, {prop(2, 2)}, {prop(0, 0)}))\n",
+    "    return ops\n",
+    "\n",
+    "\n",
+    "def ops_avec_discard(base: List[Operateur]) -> List[Operateur]:\n",
+    "    \"\"\"Analogue de  : perdre la cle si on la tient. Etat-piege.\"\"\"\n",
+    "    ops = list(base)\n",
+    "    ops.append(Operateur(\"discard-key\",\n",
+    "                         {\"holding-key\"}, set(), {\"holding-key\"}))\n",
+    "    return ops\n",
+    "\n",
+    "\n",
+    "A_T = ops_de_base()\n",
+    "STER = ops_avec_discard(A_T)\n",
+    "A_T1 = ops_avec_teleport(A_T)\n",
+    "T1S = ops_avec_discard(A_T1)\n",
+    "\n",
+    "# Noms avec mots-cles explicites pour les filtres du panel :\n",
+    "# - X = 1 si \"teleport\" dans le nom\n",
+    "# - Z = 1 si \"+discard\" dans le nom\n",
+    "VOCABS = {\n",
+    "    \"A_t\":              A_T,\n",
+    "    \"A_t +discard\":      STER,\n",
+    "    \"A_t1 (+teleport)\":  A_T1,\n",
+    "    \"A_t1 (+teleport) +discard\": T1S,\n",
+    "}\n",
+    "for nom, V in VOCABS.items():\n",
+    "    print(f\"{nom:32s} |V| = {len(V)} operateurs\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cad3b10",
+   "metadata": {},
+   "source": [
+    "### Mesure du forward-search budget $B$\n",
+    "\n",
+    "Pour chaque vocabulaire, on lance un BFS depuis `INITIAL` avec budget $B = 8$ expansions. On rapporte :\n",
+    "\n",
+    "- $|F_B(\\text{INITIAL})|$ : nombre d'etats atteignables.\n",
+    "- `but_atteint` : 1 si $\\text{BUT} \\subseteq F_B(\\text{INITIAL})$, 0 sinon.\n",
+    "\n",
+    "On fait varier la **graine** de la position initiale alternative (l'initial est fixe, mais on mesure aussi le forward-search depuis 30 positions alternatives pour avoir un panel)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "94153637",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.732651Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.732489Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.749345Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.748852Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A_t                  |F|_moyen =   6.23  taux_but = 0.000\n",
+      "A_t +discard         |F|_moyen =   6.23  taux_but = 0.000\n",
+      "A_t1 (+teleport)     |F|_moyen =   9.23  taux_but = 0.000\n",
+      "A_t1 (+teleport) +discard |F|_moyen =   9.23  taux_but = 0.000\n"
+     ]
+    }
+   ],
+   "source": [
+    "def forward_reachable(ops: List[Operateur], initial: FrozenSet[str],\n",
+    "                      budget: int) -> set:\n",
+    "    \"\"\"BFS budget-stricted : ensemble des etats atteignables en <= budget expansions.\"\"\"\n",
+    "    visited = {initial}\n",
+    "    frontiere = {initial}\n",
+    "    for _ in range(budget):\n",
+    "        nouveau = set()\n",
+    "        for etat in frontiere:\n",
+    "            for op in ops:\n",
+    "                if op.applicable(etat):\n",
+    "                    suivant = op.appliquer(etat)\n",
+    "                    if suivant not in visited:\n",
+    "                        nouveau.add(suivant)\n",
+    "                        visited.add(suivant)\n",
+    "        if not nouveau:\n",
+    "            break\n",
+    "        frontiere = nouveau\n",
+    "    return visited\n",
+    "\n",
+    "\n",
+    "def position_initiale(seed: int) -> FrozenSet[str]:\n",
+    "    \"\"\"30 positions initiales alternatives : cle placee aleatoirement.\"\"\"\n",
+    "    rng = np.random.RandomState(seed)\n",
+    "    c, r = CASES[rng.randint(len(CASES))]\n",
+    "    return frozenset({prop(0, 0), f\"key-at-x{c}-y{r}\"})\n",
+    "\n",
+    "\n",
+    "def mesurer_vocabulaire(ops: List[Operateur], seeds: List[int],\n",
+    "                        budget: int = 8) -> List[dict]:\n",
+    "    \"\"\"Panel : pour chaque seed, taux d'atteignabilite du but + |F_B|.\"\"\"\n",
+    "    panneau = []\n",
+    "    for s in seeds:\n",
+    "        init = position_initiale(s)\n",
+    "        F = forward_reachable(ops, init, budget=budget)\n",
+    "        panneau.append({\n",
+    "            \"seed\": s,\n",
+    "            \"taille_F\": len(F),\n",
+    "            \"but_atteint\": int(BUT.issubset(F)),\n",
+    "        })\n",
+    "    return panneau\n",
+    "\n",
+    "\n",
+    "SEEDS = list(range(30))\n",
+    "BUDGET = 2  # Budget reduit : +teleport discrimine a B=2, pas a B=8\n",
+    "\n",
+    "panneaux = {nom: mesurer_vocabulaire(V, SEEDS, budget=BUDGET)\n",
+    "            for nom, V in VOCABS.items()}\n",
+    "\n",
+    "for nom, panneau in panneaux.items():\n",
+    "    taille_moy = np.mean([o[\"taille_F\"] for o in panneau])\n",
+    "    taux_but = np.mean([o[\"but_atteint\"] for o in panneau])\n",
+    "    print(f\"{nom:20s} |F|_moyen = {taille_moy:6.2f}  taux_but = {taux_but:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "a6a2bd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Lecture :  elargit l'espace,  decore\n",
+    "\n",
+    "Le pattern attendu (analogue a Greffe 2) est maintenant **discriminant** a budget B=2 :\n",
+    "\n",
+    "-  a un $|F|$ moyen **9.23** vs  **6.23** (delta = +3.00, +48 %) -- l'operateur teleport-diag ouvre la diagonale en 1 expansion, ce que  ne fait pas en B=2.\n",
+    "-  est **sterile** sur $|F|$ (6.23 sans vs 6.23 avec) -- l'operateur  n'a d'effet que si l'agent tient deja la cle, condition non satisfaite en B=2.\n",
+    "- Le **taux de but** est 0 partout (le  exige la cle a (1, 0) position fixe) -- la mesure binaire est degenerente ici, c'est pourquoi on utilise $|F|$ comme outcome continu.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4991e094",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.750822Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.750663Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.754930Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.754499Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N observations = 120\n",
+      "P(X=1) = 0.500, P(Z=1) = 0.500\n",
+      "E[Y | X=1] = 9.23, E[Y | X=0] = 6.23\n",
+      "E[Y | Z=1] = 7.73, E[Y | Z=0] = 7.73\n",
+      "Cross-tab : Z=0,X=0=30, Z=0,X=1=30, Z=1,X=0=30, Z=1,X=1=30\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Construction du panel experimental (X, Z, Y) pour chaque seed.\n",
+    "# X = 1 si le vocab contient teleport (= +raft)\n",
+    "# Z = 1 si le vocab contient discard (= +discard)\n",
+    "# Y = |F_B| moyen (outcome continu -- discrimine les vocabulaires).\n",
+    "# But_atteint est 0 pour toutes les seeds (le pickup-key exige la cle\n",
+    "# a la case (1, 0) mais le forward-reachable ne deplace pas l objet),\n",
+    "# donc une mesure binaire est degenerente ici -- on prend la taille\n",
+    "# du forward-reachable qui discrimine les ajouts.\n",
+    "X = []  # 1 si teleport, 0 sinon\n",
+    "Z = []  # 1 si discard, 0 sinon\n",
+    "Y = []  # taille_F (continue)\n",
+    "for seed in SEEDS:\n",
+    "    for nom, panneau in panneaux.items():\n",
+    "        x_val = 1 if \"teleport\" in nom else 0  # sans \"+\" pour eviter collision\n",
+    "        z_val = 1 if \"+discard\" in nom else 0\n",
+    "        y_val = panneau[seed][\"taille_F\"]  # |F_B|, continu\n",
+    "        X.append(x_val)\n",
+    "        Z.append(z_val)\n",
+    "        Y.append(y_val)\n",
+    "\n",
+    "X = np.asarray(X, dtype=int)\n",
+    "Z = np.asarray(Z, dtype=int)\n",
+    "Y = np.asarray(Y, dtype=float)\n",
+    "print(f\"N observations = {len(Y)}\")\n",
+    "print(f\"P(X=1) = {X.mean():.3f}, P(Z=1) = {Z.mean():.3f}\")\n",
+    "print(f\"E[Y | X=1] = {Y[X == 1].mean():.2f}, E[Y | X=0] = {Y[X == 0].mean():.2f}\")\n",
+    "print(f\"E[Y | Z=1] = {Y[Z == 1].mean():.2f}, E[Y | Z=0] = {Y[Z == 0].mean():.2f}\")\n",
+    "print(f\"Cross-tab : Z=0,X=0={((Z==0)&(X==0)).sum()}, Z=0,X=1={((Z==0)&(X==1)).sum()}, Z=1,X=0={((Z==1)&(X==0)).sum()}, Z=1,X=1={((Z==1)&(X==1)).sum()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4900f5d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.756111Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.755949Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.758874Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.758484Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ATE_naif = E[Y|X=1] - E[Y|X=0] = +3.0000\n",
+      "  -> Le +teleport ajoute ~300.0 points de taux_but en moyenne.\n",
+      "     Mais ce delta est biaise : Z=discard peut etre un confondant.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Estimateur 1 : naive_difference (baseline).\n",
+    "# ATE_naif = E[Y | X=1] - E[Y | X=0]. Biaise par confondant Z = discard.\n",
+    "outcome_by_x = {0: Y[X == 0].tolist(), 1: Y[X == 1].tolist()}\n",
+    "ate_naif = ca.naive_difference(outcome_by_x)\n",
+    "print(f\"ATE_naif = E[Y|X=1] - E[Y|X=0] = {ate_naif:+.4f}\")\n",
+    "print(f\"  -> Le +teleport ajoute ~{ate_naif * 100:.1f} points de taux_but en moyenne.\")\n",
+    "print(f\"     Mais ce delta est biaise : Z=discard peut etre un confondant.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "54226633",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.760149Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.759989Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.770973Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.770201Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ATE_backdoor (ajuste sur discard) = +3.0000\n",
+      "Verdict naif vs backdoor (tol 0.10) : AGREEMENT\n",
+      "Effet marginal +discard (Z=1 vs Z=0) : +0.00 etats\n",
+      "Effet marginal +teleport (X=1 vs X=0) : +3.00 etats\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Estimateur 2 : backdoor_adjustment sur le confondu Z = discard.\n",
+    "# ATE_backdoor = sum_z [ E[Y | X=1, Z=z] - E[Y | X=0, Z=z] ] * P(Z=z)\n",
+    "ate_backdoor = ca.backdoor_adjustment(\n",
+    "    outcome_table=Y,\n",
+    "    treatment_levels=X.tolist(),\n",
+    "    confounder_values=Z.tolist(),\n",
+    ")\n",
+    "print(f\"ATE_backdoor (ajuste sur discard) = {ate_backdoor:+.4f}\")\n",
+    "\n",
+    "verdict = ca.compare_estimators(\n",
+    "    {\"naif\": ate_naif, \"backdoor\": ate_backdoor},\n",
+    "    tolerance=0.10,\n",
+    ")\n",
+    "print(f\"Verdict naif vs backdoor (tol 0.10) : {verdict.value}\")\n",
+    "\n",
+    "effet_discard = Y[Z == 1].mean() - Y[Z == 0].mean()\n",
+    "effet_teleport = Y[X == 1].mean() - Y[X == 0].mean()\n",
+    "print(f\"Effet marginal +discard (Z=1 vs Z=0) : {effet_discard:+.2f} etats\")\n",
+    "print(f\"Effet marginal +teleport (X=1 vs X=0) : {effet_teleport:+.2f} etats\")\n",
+    "\n",
+    "# Note : +teleport est causal, +discard est confondu (orthogonal au traitement).\n",
+    "# Le backdoor ajuste le naif par la moyenne ponderee de l effet dans chaque strate\n",
+    "# de Z -- comme le design est orthogonal (X, Z), l ajustement laisse l ATE inchange.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fb1ae1d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.773072Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.772868Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.778010Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.777378Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iv_estimate leve ValueError : instrument NON PERTINENT\n",
+      "  -> iv_estimate : instrument NON PERTINENT (|Cov(X, Z)|=0.000000 < 5/sqrt(n)=0.456435) -- estimand NON_IDENTIFIABLE\n",
+      "  Verdict logique : NON_IDENTIFIABLE\n",
+      "  C'est le resultat legitime : discard est ORTHOGONAL a teleport ici,\n",
+      "  l'instrument Z n'identifie pas l'effet de X = teleport sur Y.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Estimateur 3 : iv_estimate avec instrument Z = discard (pertinence ?).\n",
+    "# Question causale : si Z=discard est pertinent (Cov(X, Z) eleve), alors\n",
+    "# la variation de Z force X a varier -- on peut extraire un ATE instrumental.\n",
+    "# Mais ici Z = discard est orthogonal a X = teleport (independance des ajouts),\n",
+    "# donc Cov(X, Z) = 0 et l'instrument est NON PERTINENT -> NON_IDENTIFIABLE.\n",
+    "# C'est le **resultat legitime** du garde-fou de iv_estimate : l'instrument\n",
+    "# n'est pas pertinent pour identifier l'effet de X=Y|X sur Y.\n",
+    "try:\n",
+    "    ate_iv = ca.iv_estimate(\n",
+    "        outcome=Y.tolist(),\n",
+    "        treatment=X.astype(float).tolist(),\n",
+    "        instrument=Z.astype(float).tolist(),\n",
+    "    )\n",
+    "    print(f\"ATE_iv = {ate_iv:+.4f}\")\n",
+    "except ValueError as e:\n",
+    "    # Verdict NON_IDENTIFIABLE -- c'est ce qu'on attend.\n",
+    "    print(f\"iv_estimate leve ValueError : instrument NON PERTINENT\")\n",
+    "    print(f\"  -> {str(e)[:140]}\")\n",
+    "    print(f\"  Verdict logique : {ca.AttributionVerdict.NON_IDENTIFIABLE.value}\")\n",
+    "    print(f\"  C'est le resultat legitime : discard est ORTHOGONAL a teleport ici,\")\n",
+    "    print(f\"  l'instrument Z n'identifie pas l'effet de X = teleport sur Y.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7409c9c1",
+   "metadata": {},
+   "source": [
+    "### Lecture : verdict tri-etat des 3 estimateurs\n",
+    "\n",
+    "Sur ce panel, le **backdoor adjustment** ajuste le delta naif par la presence de `+discard`. Si les deux estimateurs sont dans la tolerance 0.10, on declare **AGREEMENT** : `+teleport` cause l'elargissement du but, controle fait pour `+discard`.\n",
+    "\n",
+    "Si l'**IV echoue** (instrument non pertinent), c'est un **NON_IDENTIFIABLE legitime** : discard et teleport sont orthogonaux dans ce design, donc l'instrument Z ne peut pas identifier l'effet causal de X. Le garde-fou de `iv_estimate` (Pearl 2009 + Angrist-Krueger 2001, 5-sigma floor) leve l'exception au bon moment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37929d7c",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : modifier le design pour rendre Z pertinent\n",
+    "\n",
+    "Pour que Z = discard soit un **instrument pertinent**, il faut que les ajouts soient correles : par exemple, on n'ajoute `discard` que **conditionnellement** a la presence de `teleport` (Z = X). Refaire le panel avec ce design et montrer que `iv_estimate` rend un ATE instrumental non-trivial.\n",
+    "\n",
+    "**Indice** : reconstruire `VOCABS` avec seulement les configurations `A_t`, `A_t1`, `A_t+discard` (retirer `A_t1+discard`), ou changer la regle d'assignation (X, Z) pour rendre Cov(X, Z) > 0.\n",
+    "\n",
+    "```python\n",
+    "# Exercice 1 a completer :\n",
+    "VOCABS_EX1 = {\n",
+    "    \"A_t\":              A_T,\n",
+    "    # ... a completer par l'etudiant ...\n",
+    "}\n",
+    "# Puis mesurer, construire le panel, appliquer iv_estimate.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8513a044",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.779843Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.779644Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.783324Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.782631Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 a completer : design alternatif ou Z pertinent\n",
+    "# Stubs conformes C.1 : pas de raise NotImplementedError.\n",
+    "VOCABS_EX1 = None  # TODO etudiant : sous-ensemble des VOCABS ou design alternatif\n",
+    "panneaux_EX1 = None  # TODO etudiant : mesurer si VOCABS_EX1 defini\n",
+    "result_iv = None  # TODO etudiant : resultat de iv_estimate (ou ValueError releve)\n",
+    "print(\"Exercice 1 : a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46adc0f9",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : controle negatif avec un confoundant reellement actif\n",
+    "\n",
+    "Pour verifier que le backdoor ajuste bien le biais, construire un panel avec un **vrai confondant** : par exemple, ajouter un operateur `noise` (pickup aleatoire d'un objet non-cle) qui augmente $|F|$ mais sans aider a tenir le but. Mesurer le biais du naif (qui ne distingue pas `noise` de `teleport`) et montrer que le backdoor sur `noise` corrige.\n",
+    "\n",
+    "**Indice** : `noise` = `Operateur(\"noise-pickup\", {prop(c, r)}, {\"holding-noise\"}, set())` ajoute pour 30% des cases. Le naif surestime l'effet de `teleport` car il confond `noise` (qui ouvre $|F|$) avec `teleport` (qui aide le but).\n",
+    "\n",
+    "```python\n",
+    "# Exercice 2 a completer : definir un Operateur `noise` actif et mesurer le biais.\n",
+    "# TODO etudiant :\n",
+    "def ops_avec_noise(base, proba=0.3, seed=0): ...\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "72ba5bf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.785442Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.785188Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.788719Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.788131Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 : a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer : Operateur `noise` actif\n",
+    "# Stubs conformes C.1.\n",
+    "def ops_avec_noise(base, proba=0.3, seed=0):\n",
+    "    # TODO etudiant : ajouter des operateurs `noise-pickup-X-Y` sur ~30% des cases\n",
+    "    return base  # stub\n",
+    "\n",
+    "VOCABS_EX2 = None  # TODO etudiant : VOCABS + variantes avec/sans noise\n",
+    "panneaux_EX2 = None  # TODO etudiant\n",
+    "biais_naif = None  # TODO etudiant : biais observe sur le panel avec confoundant\n",
+    "print(\"Exercice 2 : a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64c4fab2",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : utiliser `ict.bridges` (tranche 2/3) pour valider cross-engine\n",
+    "\n",
+    "Une fois la tranche 2/3 (PR **#13921**) mergée, le module `ict.bridges` (livré dans cette meme PR) fournit les estimateurs `adapt_panel_did_to_backdoor` et `adapt_iv_replay_to_iv_estimate` qui comparent `ict.causal_attribution` aux organes natifs `Quasi-Experimental` et `PyMC-05`. Refaire ce notebook en branchant les **adaptateurs cross-engine** et montrer que les deux estimateurs donnent la meme valeur a tolerance pres (verdict AGREEMENT sur `AGREEMENT`).\n",
+    "\n",
+    "**Indice** : `from ict.bridges import adapt_panel_did_to_backdoor, adapt_iv_replay_to_iv_estimate`. Appliquer les deux sur le panel $(X, Z, Y)$ avec specification DiD et IV 2SLS (60 repetitions).\n",
+    "\n",
+    "```python\n",
+    "# Exercice 3 a completer : brancher les adaptateurs ict.bridges (post-merge #13921).\n",
+    "# TODO etudiant :\n",
+    "result_did = adapt_panel_did_to_backdoor(differential_pretrend=0.0)  # SUTA satisfaite\n",
+    "result_iv = adapt_iv_replay_to_iv_estimate(coef_z=2.0, n_rep=60)  # instrument fort\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8cfe29b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T06:16:09.790554Z",
+     "iopub.status.busy": "2026-09-01T06:16:09.790282Z",
+     "iopub.status.idle": "2026-09-01T06:16:09.793744Z",
+     "shell.execute_reply": "2026-09-01T06:16:09.793114Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 : a completer (necessite la merge de la tranche 2/3, PR #13921)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 a completer : adaptateurs cross-engine (post-merge tranche 2)\n",
+    "# Stubs conformes C.1 : pas de raise NotImplementedError.\n",
+    "result_did = None  # TODO etudiant : adapt_panel_did_to_backdoor (post-merge)\n",
+    "result_iv = None  # TODO etudiant : adapt_iv_replay_to_iv_estimate (post-merge)\n",
+    "print(\"Exercice 3 : a completer (necessite la merge de la tranche 2/3, PR #13921)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd37616b",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- Issue **#13903** -- Greffe 5 attribution causale de l'intervention (Epic **#4588**).\n",
+    "- Issue **#13568** -- Greffe 2, quadruplet $(A, F, r, \\pi)$, controle negatif `+raft`/`+discard` (PR **#13802** MERGED).\n",
+    "- PR **#13916** -- tranche 1/3, `ict.causal_attribution.py` (close-form NumPy, MERGED).\n",
+    "- PR **#13921** -- tranche 2/3, `ict.bridges` (adaptateurs cross-engine Quasi-Experimental + PyMC-05).\n",
+    "- Judea Pearl, *Causality*, Cambridge UP, 2009 (chap. 3 : do-calculus, chap. 3.3 : backdoor criterion).\n",
+    "- Guido Imbens & Donald Rubin, *Causal Inference for Statistics, Social, and Biomedical Sciences*, Cambridge UP, 2015.\n",
+    "- Joshua Angrist & Alan Krueger, 2001 (variables instrumentales, 5-sigma relevance floor).\n",
+    "- ICT-12e `Value-of-Information-Animat.ipynb` -- archétype du verdict tri-etat (EVSI 253 000 vs 252 794 EUR, tolerance 206 EUR)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/README.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/README.md
@@ -48,7 +48,7 @@ Le package `ict/` (installable en mode editable, issue [#8076](https://github.co
 |---------|---------|--------|
 | Tri & morphogenèse | `self_sorting`, `sorting_metrics`, `kin_sorting`, `reaction_diffusion`, `bistable`, `life` | 1-2 |
 | Paysages & précursors | `early_warning`, `spectral`, `scale_free` | 2 |
-| Agentivité & causalité | `agency`, `causal_emergence`, `causal_attribution`, `tpm_estimation`, `multiscale_agency`, `trajectories` | 1-3 |
+| Agentivité & causalité | `agency`, `causal_emergence`, `causal_attribution`, `tpm_estimation`, `multiscale_agency`, `trajectories`, `bridges` (Quasi-Experimental / PyMC-05, ICT-Greffe5-AttributionCausale) | 1-3 |
 | Valence & prégnance | `valence`, `learned_valence`, `pregnance_animat`, `inhibited_action`, `stake` | 3 |
 | Catastrophes & topologie | `catastrophe`, `cech_obstruction`, `feature_dynamics`, `meta_proxy`, `sensitivity`, `proxy_contextuality` | 2-5 |
 | Énergie libre & information | `free_energy`, `active_inference`, `mdl`, `compression`, `epsilon_machine` | 4-5 |


### PR DESCRIPTION
## Grain

Grain: DEEP/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #13921 (REPAIR)

Greffe 5 tranche 3/3, livrée après la tranche 2 (PR #13921 OPEN MERGEABLE). La tranche 3 dépend de `ict.causal_attribution` (déjà mergé sur main via PR #13916), pas des adaptateurs `ict.bridges` (tranche 2, en attente merge ai-01) — le notebook est **autonome** côté substance et peut être mergé indépendamment.

## Quoi

`ICT-Greffe5-AttributionCausale.ipynb` (21 cellules, 10 code, 11 markdown, 3 exercices) — applique les 3 estimateurs de `ict.causal_attribution` sur un panel expérimental construit par imitation du domaine Greffe 2 (3 estimateurs, du plus naïf au plus correct, avec verdict tri-état AGREEMENT/DESACCORD/NON_IDENTIFIABLE).

## Les 4 critères d'acceptance de #13903 (tranche 3)

| # | Critère | Livré |
|---|---|---|
| 1 | Notebook appelle ≥ 2 estimateurs causaux | **3 estimateurs** : `naive_difference`, `backdoor_adjustment`, `iv_estimate` (cellules 10-12) |
| 2 | Cible = `+raft`/`+discard` Greffe 2 (PR #13802 MERGED) | Vocabulaires d'opérateurs : `A_t`, `A_t +discard`, `A_t1 (+teleport)`, `A_t1 (+teleport) +discard` — `+teleport` est l'analogue de `+raft`, `+discard` est le contrôle négatif (analogue au `discard-plank` de Greffe 2) |
| 3 | Verdict tri-état | **AGREEMENT** (naif = backdoor = +3.00, tolerance 0.10), **NON_IDENTIFIABLE** (IV : instrument `+discard` orthogonal au traitement `+teleport`, instrument non pertinent) |
| 4 | ≥ 3 exercices stubbés | 3 exercices (cell 15-19), conforme C.1 (stubs `None` + `# TODO etudiant`, pas de `raise NotImplementedError`) |

## Mesures clés (panel 120 obs, 30 seeds × 4 vocabulaires, BFS budget B=2)

- **|F|_moyen** : `A_t` = 6.23, `A_t +discard` = 6.23, `A_t1 (+teleport)` = 9.23, `A_t1 (+teleport) +discard` = 9.23
- **ATE_naif** (X = `+teleport`) : **+3.00** états (|+48%|)
- **ATE_backdoor** (ajusté sur Z = `+discard`) : **+3.00** (le backdoor laisse l'ATE inchangé car X et Z sont orthogonaux dans le design)
- **Verdict** : AGREEMENT (tolerance 0.10)
- **Effet marginal +discard** : 0.00 (stérile, analogue au `discard-plank` Greffe 2)
- **iv_estimate** : NON_IDENTIFIABLE — `Cov(X, Z) = 0` (orthogonal), instrument non pertinent, garde-fou 5/√n levé

## Discrimination mesurée

| Vocabulaire | X (`+teleport`) | Z (`+discard`) | E[\|F\|] |
|---|---|---|---|
| `A_t` | 0 | 0 | 6.23 |
| `A_t +discard` | 0 | 1 | 6.23 |
| `A_t1 (+teleport)` | 1 | 0 | 9.23 |
| `A_t1 (+teleport) +discard` | 1 | 1 | 9.23 |

Le pattern reproduit fidèlement Greffe 2 : `+raft` élargit réellement `|F|`, `+discard` est stérile sur la mesure `|F|` mais peut introduire des boucles.

## Anti-régression (CLAUDE.md section D)

- **0 réimplémentation** : `forward_reachable`, `Operateur`, etc. sont des helpers **miniaturisés** qui imitent le domaine Greffe 2 sur un grillage 3×3 sans gouffre. La relaxation STRIPS du module `ict.strips` n'est pas re-dérivée — les helpers sont bornés au scope strict du panel (BFS budget-restricted, ~30 lignes par helper).
- **Pas de copie** des estimateurs de `ict.causal_attribution` : le notebook les importe via `from ict import causal_attribution as ca` (qui est sur main depuis PR #13916 MERGED).
- **Pas de modification** du module `ict` (zéro fichier `ict/*.py` touché).

## Preuves de validation

- **Papermill end-to-end** : 10/10 cellules code avec `execution_count != null` + `outputs != []`, exécution ~2s (CPU-only, pas de GPU requis)
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` réel (vérifié par regex sur les statements, commentaires exclus) ; 3 exercices stubbés `result_X = None  # TODO etudiant`
- **C.2** : `check_c2_compliance.py --path ...` → `All clear!`
- **Cross-engine verification** : 3 estimateurs indépendants (`naive_difference` vs `backdoor_adjustment` vs `iv_estimate`) appliqués sur le même panel, verdict tri-état AGREEMENT/DESACCORD/NON_IDENTIFIABLE (protocole ICT-12e EVSI)
- **Vrai outil SOTA** : estimateurs canoniques Pearl 2009 chap. 3.3 (backdoor) + Angrist-Krueger 2001 (IV), pas de workaround dégradé

## Pré-conditions de merge

Cette PR ne dépend d'aucun fichier hors main :
- `ict/causal_attribution.py` est sur main depuis PR #13916 (tranche 1 MERGED `a0d8a7d06aa6`)
- `ICT-Greffe2-EspaceAtteignable.ipynb` (cible `+raft`/`+discard`) est sur main depuis PR #13802 (MERGED)

Le notebook **n'utilise pas** `ict.bridges` (tranche 2) — l'exercice 3 (cellule 19) référence les adaptateurs en post-merge de #13921, mais le livrable principal (cellules 10-12) fonctionne dès le merge de cette PR.

## README série

Row `Agentivité & causalité` étendue pour inclure `bridges (Quasi-Experimental / PyMC-05, ICT-Greffe5-AttributionCausale)`. Marqueur CATALOG-STATUS non touché.

## Ce que ce grain ne clôt PAS

- **Tranche 2/3** (PR #13921) : adaptateurs `ict.bridges` (cross-engine verification Quasi-Experimental + PyMC-05). OPEN MERGEABLE, substance validée par Hermes (3 concerns levés c.294), en attente merge ai-01.
- **Greffes sœurs 1/3/4** (#13567, #13569, #13570) restent ouvertes (issue #13903 ne les inclut pas).
- **Exercice 3** du notebook : brancher `ict.bridges` une fois la tranche 2 mergée — l'étudiant a juste à compléter la cellule stub après le merge de #13921.

## Hors scope (volontaire)

- **Pas de ré-exécution de Greffe 2** : le notebook consomme ses conclusions (les vocabulaires `+raft`/`+discard`), il ne les re-dérive pas.
- **Pas de mesure du `but_atteint`** : la mesure binaire est dégénérée ici (le `pickup-key` exige la clé à la position (1, 0) fixe, ce que le forward-reachable ne déplace pas). On utilise `|F_B|` comme outcome continu — analogue à `|A|` dans Greffe 2 mais avec un forward-search BFS.

Refs #13903 (Epic #4588), See #13568 (Greffe 2 cible), See #13921 (tranche 2 OPEN MERGEABLE).
