### PR TITLE
fix(ict): ICT-15g exercice 3 — remplacer une table fabriquee par un vrai appel a ict.cech_obstruction

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15g-EmpiricalHuangExploitation.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15g-EmpiricalHuangExploitation.ipynb
@@ -5,10 +5,10 @@
    "id": "ict-15b-empirical-cadrage",
    "metadata": {
     "papermill": {
-     "duration": 0.00382,
-     "end_time": "2026-08-06T23:54:37.257069+00:00",
+     "duration": 0.001791,
+     "end_time": "2026-09-01T06:42:01.493086+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:37.253249+00:00",
+     "start_time": "2026-09-01T06:42:01.491295+00:00",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
    "id": "ict-15b-empirical-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:37.269757Z",
-     "iopub.status.busy": "2026-08-06T23:54:37.269398Z",
-     "iopub.status.idle": "2026-08-06T23:54:37.692245Z",
-     "shell.execute_reply": "2026-08-06T23:54:37.691765Z"
+     "iopub.execute_input": "2026-09-01T06:42:01.496073Z",
+     "iopub.status.busy": "2026-09-01T06:42:01.496073Z",
+     "iopub.status.idle": "2026-09-01T06:42:01.942336Z",
+     "shell.execute_reply": "2026-09-01T06:42:01.940711Z"
     },
     "papermill": {
-     "duration": 0.433377,
-     "end_time": "2026-08-06T23:54:37.694300+00:00",
+     "duration": 0.448746,
+     "end_time": "2026-09-01T06:42:01.943285+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:37.260923+00:00",
+     "start_time": "2026-09-01T06:42:01.494539+00:00",
      "status": "completed"
     },
     "tags": []
@@ -119,16 +119,16 @@
    "id": "ict-15b-empirical-sanity",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:37.705549Z",
-     "iopub.status.busy": "2026-08-06T23:54:37.705323Z",
-     "iopub.status.idle": "2026-08-06T23:54:37.710168Z",
-     "shell.execute_reply": "2026-08-06T23:54:37.709635Z"
+     "iopub.execute_input": "2026-09-01T06:42:01.950896Z",
+     "iopub.status.busy": "2026-09-01T06:42:01.949889Z",
+     "iopub.status.idle": "2026-09-01T06:42:01.956710Z",
+     "shell.execute_reply": "2026-09-01T06:42:01.955565Z"
     },
     "papermill": {
-     "duration": 0.012042,
-     "end_time": "2026-08-06T23:54:37.711384+00:00",
+     "duration": 0.011361,
+     "end_time": "2026-09-01T06:42:01.957602+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:37.699342+00:00",
+     "start_time": "2026-09-01T06:42:01.946241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -184,10 +184,10 @@
    "id": "ict-15b-empirical-methode",
    "metadata": {
     "papermill": {
-     "duration": 0.003156,
-     "end_time": "2026-08-06T23:54:37.718593+00:00",
+     "duration": 0.002473,
+     "end_time": "2026-09-01T06:42:01.963056+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:37.715437+00:00",
+     "start_time": "2026-09-01T06:42:01.960583+00:00",
      "status": "completed"
     },
     "tags": []
@@ -220,16 +220,16 @@
    "id": "ict-15b-empirical-gray-scott",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:37.727177Z",
-     "iopub.status.busy": "2026-08-06T23:54:37.726950Z",
-     "iopub.status.idle": "2026-08-06T23:54:37.825572Z",
-     "shell.execute_reply": "2026-08-06T23:54:37.824679Z"
+     "iopub.execute_input": "2026-09-01T06:42:01.969661Z",
+     "iopub.status.busy": "2026-09-01T06:42:01.969156Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.051825Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.050244Z"
     },
     "papermill": {
-     "duration": 0.105094,
-     "end_time": "2026-08-06T23:54:37.827507+00:00",
+     "duration": 0.087294,
+     "end_time": "2026-09-01T06:42:02.052646+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:37.722413+00:00",
+     "start_time": "2026-09-01T06:42:01.965352+00:00",
      "status": "completed"
     },
     "tags": []
@@ -277,16 +277,16 @@
    "id": "ict-15b-empirical-axelrod",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:37.837818Z",
-     "iopub.status.busy": "2026-08-06T23:54:37.837612Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.245634Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.244882Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.058337Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.058337Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.236338Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.235748Z"
     },
     "papermill": {
-     "duration": 0.414765,
-     "end_time": "2026-08-06T23:54:38.247212+00:00",
+     "duration": 0.182635,
+     "end_time": "2026-09-01T06:42:02.238250+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:37.832447+00:00",
+     "start_time": "2026-09-01T06:42:02.055615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -337,16 +337,16 @@
    "id": "ict-15b-empirical-grokking",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:38.257979Z",
-     "iopub.status.busy": "2026-08-06T23:54:38.257700Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.264730Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.264102Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.243368Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.243368Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.252040Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.251448Z"
     },
     "papermill": {
-     "duration": 0.014281,
-     "end_time": "2026-08-06T23:54:38.265903+00:00",
+     "duration": 0.012387,
+     "end_time": "2026-09-01T06:42:02.253476+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.251622+00:00",
+     "start_time": "2026-09-01T06:42:02.241089+00:00",
      "status": "completed"
     },
     "tags": []
@@ -400,16 +400,16 @@
    "id": "ict-15b-empirical-may",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:38.276922Z",
-     "iopub.status.busy": "2026-08-06T23:54:38.276581Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.297706Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.297047Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.261063Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.260057Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.283278Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.282274Z"
     },
     "papermill": {
-     "duration": 0.027846,
-     "end_time": "2026-08-06T23:54:38.299134+00:00",
+     "duration": 0.027555,
+     "end_time": "2026-09-01T06:42:02.284315+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.271288+00:00",
+     "start_time": "2026-09-01T06:42:02.256760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -458,16 +458,16 @@
    "id": "ict-15b-empirical-cross-substrat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:38.309370Z",
-     "iopub.status.busy": "2026-08-06T23:54:38.309091Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.328471Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.327298Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.291824Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.290304Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.314155Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.313571Z"
     },
     "papermill": {
-     "duration": 0.025691,
-     "end_time": "2026-08-06T23:54:38.329506+00:00",
+     "duration": 0.02795,
+     "end_time": "2026-09-01T06:42:02.315459+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.303815+00:00",
+     "start_time": "2026-09-01T06:42:02.287509+00:00",
      "status": "completed"
     },
     "tags": []
@@ -540,10 +540,10 @@
    "id": "ict-15b-empirical-interp-cross",
    "metadata": {
     "papermill": {
-     "duration": 0.003754,
-     "end_time": "2026-08-06T23:54:38.336897+00:00",
+     "duration": 0.002744,
+     "end_time": "2026-09-01T06:42:02.321334+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.333143+00:00",
+     "start_time": "2026-09-01T06:42:02.318590+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,10 +573,10 @@
    "id": "ict-15b-empirical-exo1-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003947,
-     "end_time": "2026-08-06T23:54:38.345645+00:00",
+     "duration": 0.002496,
+     "end_time": "2026-09-01T06:42:02.326574+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.341698+00:00",
+     "start_time": "2026-09-01T06:42:02.324078+00:00",
      "status": "completed"
     },
     "tags": []
@@ -597,16 +597,16 @@
    "id": "ict-15b-empirical-exo1-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:38.353449Z",
-     "iopub.status.busy": "2026-08-06T23:54:38.353274Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.359653Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.358453Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.332983Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.331984Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.345595Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.345092Z"
     },
     "papermill": {
-     "duration": 0.011791,
-     "end_time": "2026-08-06T23:54:38.360630+00:00",
+     "duration": 0.018198,
+     "end_time": "2026-09-01T06:42:02.347367+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.348839+00:00",
+     "start_time": "2026-09-01T06:42:02.329169+00:00",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +657,10 @@
    "id": "ict-15b-empirical-exo2-md",
    "metadata": {
     "papermill": {
-     "duration": 0.002876,
-     "end_time": "2026-08-06T23:54:38.367031+00:00",
+     "duration": 0.002735,
+     "end_time": "2026-09-01T06:42:02.353282+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.364155+00:00",
+     "start_time": "2026-09-01T06:42:02.350547+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,16 +687,16 @@
    "id": "ict-15b-empirical-exo2-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:38.377887Z",
-     "iopub.status.busy": "2026-08-06T23:54:38.377375Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.396593Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.392850Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.359646Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.359646Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.377207Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.376698Z"
     },
     "papermill": {
-     "duration": 0.027424,
-     "end_time": "2026-08-06T23:54:38.398103+00:00",
+     "duration": 0.022647,
+     "end_time": "2026-09-01T06:42:02.378618+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.370679+00:00",
+     "start_time": "2026-09-01T06:42:02.355971+00:00",
      "status": "completed"
     },
     "tags": []
@@ -747,24 +747,68 @@
    "id": "ict-15b-empirical-exo3-md",
    "metadata": {
     "papermill": {
-     "duration": 0.005414,
-     "end_time": "2026-08-06T23:54:38.407206+00:00",
+     "duration": 0.002742,
+     "end_time": "2026-09-01T06:42:02.384918+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.401792+00:00",
+     "start_time": "2026-09-01T06:42:02.382176+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 -- Comparaison ICT-15b vs ICT-15d (Cech verdict)\n",
+    "### Exercice 3 -- Comparaison ICT-15b vs ICT-15d (verdict de Cech)\n",
     "\n",
-    "ICT-15d (#7744, PR #9334) a livre un verdict `NOISE` pour le proxy Cech sur les memes 4 substrats : les sections de Cech sont **quasi-colineaires par construction** (3 proxys derives de la meme trajectoire collapsent en SVD rang 1). ICT-15b teste une conjecture **binaire** distincte.\n",
+    "ICT-15d (#7744, PR #9334) applique la **cochaine de Cech ponderee** aux memes quatre\n",
+    "substrats : chaque proxy devient une section locale sur des fenetres contigues, et\n",
+    "`cech_obstruction_verdict` rend `NON_TRIVIAL`, `TRIVIAL` ou `INCONCLUSIVE` selon que les\n",
+    "sections se recollent ou non en une mesure globale unique.\n",
     "\n",
-    "**Question** : sur les substrats ou ICT-15b donne `consistent` ET ICT-15d donne `NOISE`, que conclure ?\n",
+    "> **Correction d'attribution.** Une version anterieure de cet enonce pretait a ICT-15d un\n",
+    "> verdict `NOISE` et un « collapse SVD rang 1 » qui aurait touche les quatre substrats.\n",
+    "> Les deux affirmations sont a rejeter, mais pas pour la meme raison.\n",
+    ">\n",
+    "> `NOISE` n'appartient pas au vocabulaire de `cech_obstruction_verdict` : c'est un verdict\n",
+    "> d'ICT-15**c** (`ict.meta_proxy`). L'attribution etait donc simplement fausse.\n",
+    ">\n",
+    "> Le « rang 1 », lui, n'est pas une invention : il est **faux la ou il etait attribue, et\n",
+    "> vrai ailleurs**. Les rangs effectifs publies par ICT-15d valent 2 ou 3 -- jamais 1. Mais\n",
+    "> la cellule ci-dessous, sur les trajectoires *de ce notebook*, mesure bel et bien un\n",
+    "> effondrement en rang 1 sur `axelrod`. L'ancien enonce generalisait donc a quatre substrats\n",
+    "> et au mauvais notebook un phenomene reel mais **local**. C'est la forme d'erreur la plus\n",
+    "> couteuse a detecter, parce qu'un lecteur qui verifie un seul cas peut tomber sur celui qui\n",
+    "> confirme.\n",
     "\n",
-    "**Hypothese** : ICT-15b discrimine parce que sa conjecture est **structurellement plus simple** (un seul scalaire `s_max` vs une decomposition Cech multi-dimensionnelle). Si ICT-15b donne `consistent` sur les substrats ou Cech collapse, c'est un signal que **le scalaire local simple survit la ou l'instrument multi-dim echoue** -- un argument pour la **canonicite** de la sensibilite (ICT-15b motive cela).\n",
+    "**Pourquoi la cellule recalcule au lieu de citer.** Les substrats d'ICT-15d sont regeneres\n",
+    "dans *son* notebook ; recopier ses verdicts ici comparerait deux instruments sur deux jeux\n",
+    "de trajectoires differents, et la colonne MATCH/DIVERGE ne voudrait rien dire. La cellule\n",
+    "ci-dessous applique donc le meme module (`ict.cech_obstruction`) aux trajectoires **de ce\n",
+    "notebook** -- celles-la memes sur lesquelles ICT-15b vient de se prononcer. Les deux\n",
+    "instruments voient alors strictement la meme chose, ce qui est la seule condition sous\n",
+    "laquelle un desaccord est informatif.\n",
     "\n",
-    "Si ICT-15b donne `inconsistent` sur les memes substrats, c'est un signal que **les deux proxys collapsent ensemble** : la structure Markovienne sous-jacente est trop pauvre pour supporter **aucun** des deux instruments. C'est un **verdict d'intrinseque** sur ces substrats.\n"
+    "**Question** : les deux instruments s'accordent-ils substrat par substrat, et lorsqu'ils\n",
+    "divergent, lequel des deux est le plus credible sur ce substrat-la ?\n",
+    "\n",
+    "Deux lectures a departager par la mesure, pas par preference :\n",
+    "\n",
+    "- **ICT-15b discrimine ou Cech renonce** -- le scalaire local simple (`s_max`) survit la ou\n",
+    "  la decomposition multi-dimensionnelle manque de matiere. Argument pour la canonicite de la\n",
+    "  sensibilite.\n",
+    "- **Les deux renoncent ensemble** -- la structure Markovienne sous-jacente est trop pauvre\n",
+    "  pour porter l'un ou l'autre. C'est alors un verdict sur le **substrat**, pas sur les\n",
+    "  instruments.\n",
+    "\n",
+    "Un substrat degenere (peu d'etats visites, trajectoire quasi-constante) doit etre traite a\n",
+    "part : un accord entre deux instruments qui n'ont rien a mesurer n'atteste rien.\n",
+    "\n",
+    "**Piege a ne pas manquer dans la sortie ci-dessous.** Le ratio `s2/s1` n'est pas un\n",
+    "indicateur monotone du verdict : `TRIVIAL` y est atteint par **deux routes opposees**. Un\n",
+    "ratio proche de 1 signale des valeurs singulieres equilibrees (aucune direction ne domine) ;\n",
+    "un ratio proche de 0 signale au contraire un effondrement sur une seule direction. Les deux\n",
+    "donnent `TRIVIAL`, parce que le verdict est porte par l'obstruction `cob`, pas par le ratio.\n",
+    "Lire `s2/s1` comme un score de « qualite » conduit donc a ranger ensemble deux situations\n",
+    "qui n'ont rien de commun -- et c'est exactement l'erreur que la correction d'attribution\n",
+    "ci-dessus documente.\n"
    ]
   },
   {
@@ -773,16 +817,16 @@
    "id": "ict-15b-empirical-exo3-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T23:54:38.416741Z",
-     "iopub.status.busy": "2026-08-06T23:54:38.416473Z",
-     "iopub.status.idle": "2026-08-06T23:54:38.424774Z",
-     "shell.execute_reply": "2026-08-06T23:54:38.424107Z"
+     "iopub.execute_input": "2026-09-01T06:42:02.392020Z",
+     "iopub.status.busy": "2026-09-01T06:42:02.392020Z",
+     "iopub.status.idle": "2026-09-01T06:42:02.438661Z",
+     "shell.execute_reply": "2026-09-01T06:42:02.438070Z"
     },
     "papermill": {
-     "duration": 0.014923,
-     "end_time": "2026-08-06T23:54:38.426298+00:00",
+     "duration": 0.051933,
+     "end_time": "2026-09-01T06:42:02.439958+00:00",
      "exception": false,
-     "start_time": "2026-08-06T23:54:38.411375+00:00",
+     "start_time": "2026-09-01T06:42:02.388025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -792,52 +836,75 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ict.cech_obstruction non disponible -- PR #7578 non mergee sur cette branche.\n",
+      "=== Verdict de Cech recalcule sur les trajectoires de CE notebook ===\n",
+      "  gray_scott :       TRIVIAL | s2/s1=1.0000 | rank=3 | cob=0.0000 | n_windows=30\n",
+      "     axelrod :       TRIVIAL | s2/s1=0.0572 | rank=1 | cob=0.0806 | n_windows=30\n",
+      "    grokking :   NON_TRIVIAL | s2/s1=0.6627 | rank=3 | cob=0.7767 | n_windows=30\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         may :   NON_TRIVIAL | s2/s1=0.4081 | rank=3 | cob=0.5992 | n_windows=30"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "=== Table de comparaison (stub) ===\n",
-      "  gray_scott : ICT-15b= inconclusive | ICT-15d=NOISE        | DIVERGE\n",
-      "     axelrod : ICT-15b=   consistent | ICT-15d=NOISE        | DIVERGE\n",
-      "    grokking : ICT-15b=   consistent | ICT-15d=NOISE        | DIVERGE\n",
-      "         may : ICT-15b=   consistent | ICT-15d=NOISE        | DIVERGE\n"
+      "\n",
+      "Exercice a completer : table de comparaison + conclusion.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 -- Comparaison ICT-15b vs ICT-15d (Cech verdict).\n",
-    "# Le verdict Cech est documente dans ICT-15d-CechObstruction.ipynb (PR #9334).\n",
-    "# Pour cet exercice, on importe le verdict Cech depuis le module\n",
-    "# `ict.cech_obstruction` (PR #7578 fusionnee) et on compare.\n",
-    "# TODO etudiant : implementer la table de comparaison et conclure.\n",
+    "# Exercice 3 -- Comparaison ICT-15b (Huang) vs ICT-15d (Cech) sur LES MEMES trajectoires.\n",
+    "#\n",
+    "# Echafaudage fourni : on calcule le verdict de Cech avec le module reel\n",
+    "# `ict.cech_obstruction` (meme recette qu'ICT-15d : sections -> classe -> verdict).\n",
+    "# TODO etudiant : construire la table de comparaison et conclure (cf enonce ci-dessus).\n",
     "\n",
-    "# Stub : on importe le verdict Cech depuis le module ICT-15d.\n",
-    "try:\n",
-    "    from ict.cech_obstruction import cech_verdict_summary\n",
-    "    cech_verdict = cech_verdict_summary({\n",
-    "        \"gray_scott\": gray_scott_states,\n",
-    "        \"axelrod\": axelrod_states,\n",
-    "        \"grokking\": grokking_states,\n",
-    "        \"may\": may_states,\n",
-    "    })\n",
-    "    print(\"=== Verdict Cech (depuis ict.cech_obstruction) ===\")\n",
-    "    print(f\"  Verdict global : {cech_verdict['verdict']}\")\n",
-    "    for substrat, v in cech_verdict['per_substrat'].items():\n",
-    "        print(f\"  {substrat:>10} : cob={v['cob']}, s2/s1={v['s2_over_s1']:.3f}\")\n",
-    "except ImportError:\n",
-    "    print(\"ict.cech_obstruction non disponible -- PR #7578 non mergee sur cette branche.\")\n",
-    "    cech_verdict = None\n",
+    "from ict import cech_obstruction as CO\n",
     "\n",
-    "# Table de comparaison ICT-15b vs ICT-15d.\n",
-    "if cech_verdict is not None:\n",
-    "    print(\"\\n=== Comparaison ICT-15b (Huang conjecture) vs ICT-15d (Cech verdict) ===\")\n",
-    "    for nom in [\"gray_scott\", \"axelrod\", \"grokking\", \"may\"]:\n",
-    "        v_huang = verdicts[nom]['verdict']\n",
-    "        v_cech = cech_verdict['per_substrat'][nom]['verdict']\n",
-    "        match = \"MATCH\" if v_huang == v_cech else \"DIVERGE\"\n",
-    "        print(f\"  {nom:>10} : ICT-15b={v_huang:>13} | ICT-15d={v_cech:>13} | {match}\")\n",
-    "else:\n",
-    "    print(\"\\n=== Table de comparaison (stub) ===\")\n",
-    "    for nom in [\"gray_scott\", \"axelrod\", \"grokking\", \"may\"]:\n",
-    "        print(f\"  {nom:>10} : ICT-15b={verdicts[nom]['verdict']:>13} | ICT-15d=NOISE        | DIVERGE\")\n"
+    "# Les trois proxys d'ICT-15d, reconstruits ici sur les modules deja importes (SP, SE).\n",
+    "def _spec_gap(states, n_symbols):\n",
+    "    return float(SP.spectral_summary(states, n_symbols)['spectral_gap'])\n",
+    "\n",
+    "def _sens_mean(states, n_symbols):\n",
+    "    return float(SE.sensitivity_distribution(states, n_symbols, lambda x: x)['mean'])\n",
+    "\n",
+    "def _sens_max(states, n_symbols):\n",
+    "    return float(SE.sensitivity_distribution(states, n_symbols, lambda x: x)['max'])\n",
+    "\n",
+    "PROXIES_CECH = {\"spectral_gap\": _spec_gap, \"sens_mean\": _sens_mean, \"sens_max\": _sens_max}\n",
+    "N_SYMBOLS = {\"gray_scott\": n_symbols_gs, \"axelrod\": n_symbols_ax,\n",
+    "             \"grokking\": n_symbols_gk, \"may\": n_symbols_may}\n",
+    "\n",
+    "cech_par_substrat = {}\n",
+    "print(\"=== Verdict de Cech recalcule sur les trajectoires de CE notebook ===\")\n",
+    "for nom, states in all_states.items():\n",
+    "    n_total = len(states)\n",
+    "    window_size = max(2, n_total // 30)          # ~30 fenetres, comme ICT-15d\n",
+    "    sections = CO.proxy_sections(states, N_SYMBOLS[nom], window_size, PROXIES_CECH)\n",
+    "    rep = CO.cech_obstruction_class(sections)\n",
+    "    verdict = CO.cech_obstruction_verdict(rep)\n",
+    "    cech_par_substrat[nom] = {\"verdict\": verdict, \"report\": rep}\n",
+    "    print(f\"  {nom:>10} : {verdict:>13} | s2/s1={rep['s2_over_s1']:.4f} \"\n",
+    "          f\"| rank={rep['effective_rank']} | cob={rep['mean_coboundary']:.4f} \"\n",
+    "          f\"| n_windows={rep['n_windows']}\")\n",
+    "\n",
+    "# TODO etudiant : table de comparaison ICT-15b vs ICT-15d.\n",
+    "#   Pour chaque substrat, mettre en regard verdicts[nom]['verdict'] (Huang, vocabulaire\n",
+    "#   consistent/inconsistent/inconclusive) et cech_par_substrat[nom]['verdict'] (Cech,\n",
+    "#   vocabulaire NON_TRIVIAL/TRIVIAL/INCONCLUSIVE). Les deux vocabulaires ne sont PAS\n",
+    "#   comparables terme a terme : c'est a vous de definir ce que « s'accorder » veut dire\n",
+    "#   ici, et de le justifier -- une comparaison de chaines brutes n'aurait aucun sens.\n",
+    "# TODO etudiant : conclure selon les deux lectures de l'enonce, en isolant les substrats\n",
+    "#   degeneres (regarder n_visited dans `verdicts[nom]` avant de conclure quoi que ce soit).\n",
+    "print(\"\")\n",
+    "print(\"Exercice a completer : table de comparaison + conclusion.\")\n"
    ]
   }
  ],
@@ -857,18 +924,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.892522,
-   "end_time": "2026-08-06T23:54:38.771893+00:00",
+   "duration": 2.89415,
+   "end_time": "2026-09-01T06:42:02.685174+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "ICT-15g-EmpiricalHuangExploitation.ipynb",
    "output_path": "ICT-15g-EmpiricalHuangExploitation.ipynb",
    "parameters": {},
-   "start_time": "2026-08-06T23:54:35.879371+00:00",
+   "start_time": "2026-09-01T06:41:59.791024+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:CoursIA — prev: MED/tooling #13979

## Ce que la PR corrige

L'exercice 3 d'`ICT-15g` demandait a l'etudiant de comparer les verdicts d'ICT-15b et
d'ICT-15d. La cellule qui produisait la matiere de cette comparaison **n'a jamais mesure
quoi que ce soit** :

```python
from ict.cech_obstruction import cech_verdict_summary   # n'existe pas
...
except ImportError:
    print("ict.cech_obstruction non disponible -- PR #7578 non mergee sur cette branche.")
```

Trois defauts distincts, verifies firsthand :

1. **`cech_verdict_summary` n'existe nulle part** dans `ict/cech_obstruction.py`. L'`ImportError`
   etait donc systematique — la branche `except` etait *toujours* le chemin execute, et c'est
   sa sortie qui est committee dans le notebook.
2. **Le message d'excuse est faux.** « PR #7578 non mergee sur cette branche » : le module est
   la, 21 693 octets. Un lecteur qui fait confiance au message conclut a une dependance
   manquante et ne cherche pas plus loin.
3. **La table de repli est fabriquee.** `ICT-15d=NOISE` et `DIVERGE` sont des **litteraux tapes
   dans le `print`**, pas des mesures — et ils sont faux : `NOISE` appartient au vocabulaire
   d'ICT-15**c** (`ict.meta_proxy`), pas a `cech_obstruction_verdict`, dont l'enumeration est
   `NON_TRIVIAL` / `TRIVIAL` / `INCONCLUSIVE`.

Le meme fait faux etait repris en prose dans la cellule markdown d'enonce, de sorte que
l'exercice demandait de **raisonner a partir d'une premisse jamais mesuree**.

### Historique verifie de ICT-15d (pour clore l'hypothese de derive)

J'avais suppose que le `NOISE` etait un vestige d'un etat ancien de 15d. C'est faux, et je le
consigne parce que la mesure contredit l'hypothese la plus commode :

| ref | date | verdict rendu |
|---|---|---|
| `80a289f94` (creation) | 2026-08-04 | `TRIVIAL` 4/4 |
| `4cf9df047` | 2026-08-07 | `NON_TRIVIAL` 4/4 |
| `580e74fc4` → HEAD | 2026-08-28 | `NON_TRIVIAL` 3/4 |

ICT-15d n'a **jamais** rendu `NOISE`, a aucun commit. Ce n'etait pas une derive : c'etait faux
des l'ecriture.

## Ce que la PR livre

**Cellule 15** — import du vrai module, calcul par substrat via `proxy_sections` →
`cech_obstruction_class` → `cech_obstruction_verdict`, sur les trajectoires **de ce notebook**.

Le choix de *recalculer plutot que citer* est motive dans l'enonce : les substrats d'ICT-15d
sont regeneres dans son propre notebook, donc recopier ses verdicts comparerait deux
instruments sur deux jeux de trajectoires differents — la colonne MATCH/DIVERGE ne voudrait
alors rien dire. La table de comparaison et la conclusion restent le **TODO etudiant** (C.1 :
`pass` / prose, aucune erreur volontaire).

Sortie mesuree (re-execution complete, RC=0, 0 erreur) :

| substrat | verdict | s2/s1 | rank | cob |
|---|---|---|---|---|
| gray_scott | `TRIVIAL` | 1.0000 | 3 | 0.0000 |
| axelrod | `TRIVIAL` | 0.0572 | 1 | 0.0806 |
| grokking | `NON_TRIVIAL` | 0.6627 | 3 | 0.7767 |
| may | `NON_TRIVIAL` | 0.4081 | 3 | 0.5992 |

`may` est **bit-identique** a la sortie de ICT-15d (`0.4081 / rank 3 / cob 0.5992`) : le
portage est valide de maniere croisee sur au moins un substrat.

**Cellule 14** — correction d'attribution explicite, et la nuance que la mesure impose : le
« collapse SVD rang 1 » est **faux sur ICT-15d** (rangs publies 2 ou 3, jamais 1) mais **vrai
localement sur `axelrod` ici**. L'ancien enonce generalisait donc un phenomene reel a quatre
substrats et au mauvais notebook — la forme d'erreur la plus couteuse, parce qu'un lecteur qui
verifie un seul cas peut tomber sur celui qui confirme.

Ajout d'un piege pedagogique que la sortie rend desormais visible : `TRIVIAL` est atteint par
**deux routes opposees** — ratio ~1 (isotropie, aucune direction ne domine) et ratio ~0
(effondrement rang 1). Le verdict est porte par `cob`, pas par `s2/s1` ; lire ce ratio comme un
score de qualite range ensemble deux situations sans rapport.

## Verdict SOTA (regle H)

**SOTA-OK** — le notebook execute desormais le vrai `ict.cech_obstruction`, et la sortie
committee est sa vraie sortie. L'etat precedent relevait de la classe « sortie de workaround
degrade alors que l'outil reel etait invocable » : le module etait installe et importable, seul
le nom de l'API etait faux.

## Validation (H.1 / C.2 / C.3)

- Re-execution `papermill --cwd .` → **RC=0**, 10 cellules code, `execution_count` = `[1..10]`, **0 erreur**.
- `--cwd .` est necessaire et suffisant : les notebooks ICT font `ICT_ROOT = Path('.').resolve()`.
- Chemins machine scrubbes — grep valide par **controle positif** sur un fichier temoin (rend 1 ; le notebook rend 0).
- **C.3** : un seul notebook committe, celui dont j'ai modifie la source.
- `COURSE_CATALOG.generated.*` **byte-identiques a `main`** (verifie par `git diff --name-only main`).
- La retouche de la cellule 14 est **markdown-only** → pas de re-execution requise (exception C.2).

## Defaut signale, non corrige ici (principe 3)

`scripts/notebook_tools/batch_reexecute.py:130` passe `cwd=str(REPO_ROOT)` a l'execution. Tout
notebook ICT echoue donc en `ModuleNotFoundError` sous cet outil, alors qu'il s'execute
parfaitement sous `papermill --cwd .`. Ce n'est pas le sujet de cette PR (et le corriger la
ferait basculer un grain CONTENU en META) : **issue de suivi a ouvrir**.

See #12206
