### PR TITLE
fix(tests,#13960): remove 4 byte-identical duplicate test definitions

### DIFF
--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -506,55 +506,6 @@ def test_same_repository_reusable_workflow_rejects_path_traversal(tmp_path):
     assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
 
 
-def test_missing_trigger_breaks_instrument(tmp_path):
-    write_workflow(tmp_path, "broken-trigger", """
-        name: broken-trigger
-        jobs:
-          test:
-            runs-on: ubuntu-latest
-            steps:
-              - run: echo no-trigger
-        """)
-    result = policy.scan_workflows(tmp_path)
-    assert result.broken == ["broken-trigger.yml: missing on trigger"]
-
-
-def test_empty_runs_on_list_breaks_instrument(tmp_path):
-    write_workflow(tmp_path, "broken-runner", """
-        name: broken-runner
-        on: workflow_dispatch
-        jobs:
-          test:
-            runs-on: []
-            steps:
-              - run: echo no-runner
-        """)
-    result = policy.scan_workflows(tmp_path)
-    assert result.broken == [
-        "broken-runner.yml:test: runs-on list must contain labels"
-    ]
-
-
-def test_missing_jobs_breaks_instrument(tmp_path):
-    write_workflow(tmp_path, "broken-jobs", """
-        name: broken-jobs
-        on: workflow_dispatch
-        """)
-    result = policy.scan_workflows(tmp_path)
-    assert result.broken == ["broken-jobs.yml: missing jobs"]
-
-
-def test_same_repository_reusable_workflow_rejects_path_traversal(tmp_path):
-    write_workflow(tmp_path, "caller", """
-        name: caller
-        on: [pull_request]
-        jobs:
-          test:
-            uses: jsboige/CoursIA/.github/workflows/../evil.yml@main
-        """)
-    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
-
-
 def test_invalid_yaml_breaks_the_instrument(tmp_path):
     write_workflow(tmp_path, "broken", "on: [pull_request\njobs: [")
     result = policy.scan_workflows(tmp_path)


### PR DESCRIPTION
Grain: LIGHT/test -- lane myia-po-2026:CoursIA -- prev: LIGHT/test #13961 cycle 80

## Constat

Issue #13960 releve que `scripts/tests/test_check_self_hosted_runner_policy.py`
porte **4 paires de fonctions de test byte-identiques** (sha256 verifies
ligne-a-ligne) : la 2e def eclipse la 1re en Python, le 2e etant jamais
execute.

Paires dedupes (2e copies supprimees, choix indifferent car corps
identiques) :

| Fonction | def 1 | def 2 | sha256 |
|---|---|---|---|
| `test_missing_trigger_breaks_instrument` | l.460-470 | l.509-519 | b4df2c636a6f |
| `test_empty_runs_on_list_breaks_instrument` | l.473-486 | l.522-535 | 5729c27bf5ce |
| `test_missing_jobs_breaks_instrument` | l.489-495 | l.538-544 | 9977b325e75a |
| `test_same_repository_reusable_workflow_rejects_path_traversal` | l.498-506 | l.547-555 | 3271a663c4f7 |

## Pourquoi c'etait un defaut

- **Sans effet aujourd'hui** : les 2 corps etant identiques, l'eclipse est
  neutre en couverture. Les 2e defs etaient deja shadowed et non
  collectees separement par pytest (37 items collects avant ET apres).
- **Code mort + test fantome demain** : si une seule des 2 copies evoluait
  lors d'un futur refactoring, la semantique du fichier changerait
  silencieusement -- la version visible dans un edur n'est pas celle
  executee.
- Signe de confusion possible lors de tout futur `git blame`/review sur
  ce bloc.

## Fix

One-liner de dedup : supprimer la 2e copie de chaque paire (l.509-555
apres la 1re copie complete l.460-506). Aucune modification de
comportement, aucun changement de nom, aucun changement de signature.

## Verification

- **AST scan apres patch** : 0 doublon parmi les `defs test_*` du fichier.
- **SHA256 par def** : 37 uniques, 0 collision (les 4 doublons sont retires).
- **pytest scripts/tests/test_check_self_hosted_runner_policy.py** :
  37/37 PASS avant ET apres patch.
- Aucun appelant externe : le fichier est un module de tests isole, pas
  reference ailleurs que par pytest.

## Perimetre

```
scripts/tests/test_check_self_hosted_runner_policy.py | 49 ----------------------
1 file changed, 49 deletions(-)
```

Pure soustraction. Pas de modification de comportement, pas de touch
d'aucun module de production.

Closes #13960

## Note post-edit (cycle 83)

Body edite au cycle 83 pour deplacer le tag `Grain:` en premiere ligne du body (il etait en fin de body). Le tag etait conforme dans son contenu mais le parseur canonique cherche `Grain:` en premiere ligne du body (word-start), pas en fin. Reecriture en `Grain: LIGHT/test -- lane myia-po-2026:CoursIA -- prev: ...` en premiere ligne, tag de fin supprime. Pas de modification de code ; le diff reste -49.