### PR TITLE
fix(gh_queue_health,#13966): name floor count, fix docstring conj, preserve INCOMPLETE on replay

### DIFF
--- a/scripts/ci/gh_queue_health.py
+++ b/scripts/ci/gh_queue_health.py
@@ -34,6 +34,7 @@ EXIT_BROKEN = 2
 
 PER_PAGE = 100
 INCIDENT_FLOOR_DATE = "2026-08-19"  # origin of the corruption window
+INCIDENT_FLOOR_COUNT = 18  # ghost runs stranded by the 2026-08-19 corruption
 
 
 class InstrumentError(RuntimeError):
@@ -126,37 +127,60 @@ def verdict(ghosts: int, live: int, parse_failures: int) -> str:
     `GHOST_RUNS_DETECTED` is the expected verdict on CoursIA itself (the 18
     ghosts of 2026-08-19). `CLEAN` is expected on repos without historical
     incidents. `STALE_FLOOR` is reserved for the precise case where the ghost
-    count equals the known incident floor (18) -- useful for surfacing the
+    count equals `INCIDENT_FLOOR_COUNT` (18) AND the live bucket is empty --
+    the conjunction matters: 18 ghosts WITH new live runs is
+    `GHOST_RUNS_DETECTED` (the floor is being augmented by fresh activity,
+    not just the historical signature). Useful for surfacing the bare
     signature on CoursIA without false-positive alarms on other repos.
     """
     if parse_failures > 0:
         return "INCOMPLETE"
     if ghosts == 0:
         return "CLEAN"
-    if ghosts == 18 and live == 0:
+    if ghosts == INCIDENT_FLOOR_COUNT and live == 0:
         return "STALE_FLOOR"
     return "GHOST_RUNS_DETECTED"
 
 
-def load_snapshot(path: Path) -> list[dict]:
+def load_snapshot(path: Path) -> tuple[list[dict], list[dict]]:
+    """Read a snapshot and return (runs, preserved_parse_failures).
+
+    A snapshot is one of:
+    - a list of raw `workflow_run` dicts (the live API shape),
+    - a dict `{workflow_runs: [...]}`,
+    - a dict `{snapshot: {workflow_runs: [...]}}` envelope,
+    - a prior analysis output `{cutoff, verdict, counts, snapshot_size,
+      ghosts, live, parse_failures}`.
+
+    For raw shapes (the first three), `classify_runs` will re-derive parse
+    failures from the runs themselves -- preserved_parse_failures is empty.
+
+    For a prior analysis output, the `parse_failures` bucket is preserved
+    as-is (it cannot be re-derived from the synthesized runs). Without this
+    propagation, an `INCOMPLETE` snapshot would replay as `CLEAN` or
+    `GHOST_RUNS_DETECTED` -- a verdict class change at replay, which
+    defeats the purpose of replaying a snapshot.
+    """
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise InstrumentError(f"cannot read snapshot {path}: {exc}") from exc
     if isinstance(value, dict) and "snapshot" in value and isinstance(value["snapshot"], dict):
         if "workflow_runs" in value["snapshot"]:
-            return value["snapshot"]["workflow_runs"]
-        return value["snapshot"].get("runs", [])
+            return value["snapshot"]["workflow_runs"], []
+        return value["snapshot"].get("runs", []), []
     if isinstance(value, list):
-        return value
+        return value, []
     if isinstance(value, dict) and "workflow_runs" in value:
-        return value["workflow_runs"]
+        return value["workflow_runs"], []
     # A prior analysis output looks like {cutoff, verdict, counts, snapshot_size,
     # ghosts, live, parse_failures}. It is already classified, so replaying it
     # through classify_runs is pointless -- but the caller still needs the raw
     # timeline to recompute. We synthesize a synthetic list whose created_at is
     # not used: the ghosts and live buckets carry the real IDs and timestamps,
     # and classify_runs will reproduce the same partition if cutoff matches.
+    # The `parse_failures` bucket is preserved verbatim because it cannot be
+    # re-derived from the synthesized runs.
     if isinstance(value, dict) and "ghosts" in value and "live" in value:
         synthetic: list[dict] = []
         for entry in value.get("ghosts", []) or []:
@@ -165,8 +189,9 @@ def load_snapshot(path: Path) -> list[dict]:
         for entry in value.get("live", []) or []:
             if isinstance(entry, dict) and "created_at" in entry:
                 synthetic.append(entry)
-        if synthetic:
-            return synthetic
+        preserved = list(value.get("parse_failures", []) or [])
+        if synthetic or preserved:
+            return synthetic, preserved
     raise InstrumentError("snapshot must be a list of runs, a dict with workflow_runs, "
                           "a {snapshot: {...}} envelope, or a prior analysis output")
 
@@ -184,10 +209,20 @@ def main(argv: list[str] | None = None) -> int:
     try:
         cutoff = parse_date(args.cutoff)
         if args.input:
-            raw_runs = load_snapshot(args.input)
+            raw_runs, preserved_pf = load_snapshot(args.input)
         else:
             raw_runs = fetch_queued_runs(args.repo)
+            preserved_pf = []
         classification = classify_runs(raw_runs, cutoff)
+        # When the input was a prior analysis output, `classify_runs` cannot
+        # re-derive the parse_failures from the synthesized runs -- they were
+        # never serialized into the synthesized list. Merge the preserved
+        # bucket in so the verdict survives replay unchanged (#13966).
+        if preserved_pf:
+            seen_ids = {pf.get("id") for pf in classification["parse_failures"]}
+            for pf in preserved_pf:
+                if pf.get("id") not in seen_ids:
+                    classification["parse_failures"].append(pf)
         gh_count, lv_count, pf_count = (
             len(classification["ghosts"]),
             len(classification["live"]),

--- a/scripts/tests/test_gh_queue_health.py
+++ b/scripts/tests/test_gh_queue_health.py
@@ -205,3 +205,156 @@ def test_cli_repo_without_input_rejects(tmp_path: Path) -> None:
     proc = _run()
     assert proc.returncode != 0
     assert "one of the arguments" in proc.stderr or "required" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# #13966 follow-ups: INCIDENT_FLOOR_COUNT naming, STALE_FLOOR docstring
+# conjonction, INCOMPLETE preservation across replay
+# ---------------------------------------------------------------------------
+
+
+def test_13966_incident_floor_count_constant_is_18() -> None:
+    """#13966 follow-up 1 -- INCIDENT_FLOOR_COUNT = 18, used at the verdict site.
+
+    The bare number `18` next to `INCIDENT_FLOOR_DATE` was an asymmetry that
+    degraded the signature silently. The constant named makes the change loud.
+    """
+    sys.path.insert(0, str(SCRIPT.parent))
+    import gh_queue_health as mod  # noqa: WPS433
+
+    assert mod.INCIDENT_FLOOR_COUNT == 18
+    assert mod.INCIDENT_FLOOR_DATE == "2026-08-19"
+    # Both used together: 18 ghosts AND no live -> STALE_FLOOR
+    assert mod.verdict(18, 0, 0) == "STALE_FLOOR"
+    # 18 ghosts WITH live runs -> GHOST_RUNS_DETECTED (signature augmented)
+    assert mod.verdict(18, 1, 0) == "GHOST_RUNS_DETECTED"
+    # Different ghost count -> GHOST_RUNS_DETECTED (no false STALE_FLOOR on
+    # other repos with a different number of historical ghosts)
+    assert mod.verdict(5, 0, 0) == "GHOST_RUNS_DETECTED"
+
+
+def test_13966_load_snapshot_returns_tuple_with_parse_failures_preserved() -> None:
+    """#13966 follow-up 3 -- load_snapshot returns (runs, preserved_pf).
+
+    A prior analysis output (the shape written by --output) carries a
+    `parse_failures` bucket that cannot be re-derived from the synthesized
+    runs. The new signature preserves it so replay reproduces the verdict.
+    """
+    sys.path.insert(0, str(SCRIPT.parent))
+    import gh_queue_health as mod  # noqa: WPS433
+
+    analysis = {
+        "cutoff": "2026-08-20",
+        "verdict": "INCOMPLETE",
+        "counts": {"total": 3, "ghosts": 0, "live": 1, "parse_failures": 2},
+        "snapshot_size": 3,
+        "ghosts": [],
+        "live": [
+            {"id": 200, "name": "live", "created_at": "2026-08-25T12:00:00Z",
+             "html_url": "https://gh/live/200"},
+        ],
+        "parse_failures": [
+            {"id": 201, "reason": "missing created_at"},
+            {"id": 202, "reason": "bad created_at 'not-a-timestamp'"},
+        ],
+    }
+    tmp = SCRIPT.parent / "_tmp_13966_analysis.json"
+    try:
+        tmp.write_text(json.dumps(analysis), encoding="utf-8")
+        runs, preserved_pf = mod.load_snapshot(tmp)
+        # The 1 live run is synthesized into the runs list
+        assert len(runs) == 1
+        assert runs[0]["id"] == 200
+        # The 2 parse_failures are preserved verbatim
+        assert len(preserved_pf) == 2
+        assert preserved_pf[0]["id"] == 201
+        assert preserved_pf[1]["id"] == 202
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def test_13966_replay_of_incomplete_snapshot_keeps_incomplete_verdict(tmp_path: Path) -> None:
+    """#13966 follow-up 3 -- replaying an INCOMPLETE snapshot must stay INCOMPLETE.
+
+    Before this fix, `load_snapshot` synthesized only ghosts + live, dropping
+    parse_failures. The replayed verdict then computed as `CLEAN` or
+    `GHOST_RUNS_DETECTED` -- the verdict CLASS changed across replay, which
+    defeats the purpose of replaying a snapshot. The fix preserves the
+    parse_failures bucket, so the replayed verdict matches the original.
+    """
+    analysis = {
+        "cutoff": "2026-08-20",
+        "verdict": "INCOMPLETE",
+        "counts": {"total": 3, "ghosts": 0, "live": 1, "parse_failures": 2},
+        "snapshot_size": 3,
+        "ghosts": [],
+        "live": [
+            {"id": 200, "name": "live", "created_at": "2026-08-25T12:00:00Z",
+             "html_url": "https://gh/live/200"},
+        ],
+        "parse_failures": [
+            {"id": 201, "reason": "missing created_at"},
+            {"id": 202, "reason": "bad created_at 'not-a-timestamp'"},
+        ],
+    }
+    snapshot = tmp_path / "incomplete.json"
+    snapshot.write_text(json.dumps(analysis), encoding="utf-8")
+    proc = _run("--input", str(snapshot))
+    # INCOMPLETE -> EXIT_BROKEN = 2 (per main() / verdict() mapping)
+    assert proc.returncode == 2, (
+        f"expected EXIT_BROKEN=2 (INCOMPLETE), got {proc.returncode}; "
+        f"stderr={proc.stderr}"
+    )
+    body = json.loads(proc.stdout)
+    assert body["verdict"] == "INCOMPLETE"
+    assert body["counts"]["parse_failures"] == 2
+
+
+def test_13966_replay_of_stale_floor_snapshot_keeps_stale_floor(tmp_path: Path) -> None:
+    """#13966 follow-up 3 (control positive) -- replay of STALE_FLOOR still works.
+
+    Sanity check: the prior behavior on a clean STALE_FLOOR snapshot
+    (no parse_failures) is preserved by the fix.
+    """
+    analysis = {
+        "cutoff": "2026-08-20",
+        "verdict": "STALE_FLOOR",
+        "counts": {"total": 18, "ghosts": 18, "live": 0, "parse_failures": 0},
+        "snapshot_size": 18,
+        "ghosts": [
+            {"id": i, "name": f"ghost-{i}",
+             "created_at": f"2026-08-19T03:{i:02d}:00Z",
+             "html_url": f"https://gh/ghost/{i}"}
+            for i in range(18)
+        ],
+        "live": [],
+        "parse_failures": [],
+    }
+    snapshot = tmp_path / "stale.json"
+    snapshot.write_text(json.dumps(analysis), encoding="utf-8")
+    proc = _run("--input", str(snapshot))
+    assert proc.returncode == 1, f"expected EXIT_GHOST=1, got {proc.returncode}"
+    body = json.loads(proc.stdout)
+    assert body["verdict"] == "STALE_FLOOR"
+    assert body["counts"]["ghosts"] == 18
+
+
+def test_13966_load_snapshot_raw_shape_returns_empty_preserved(tmp_path: Path) -> None:
+    """#13966 follow-up 3 (control) -- raw snapshot shape returns [] preserved.
+
+    A raw snapshot (list of runs, {workflow_runs: [...]}, or envelope) does
+    not have a pre-classified `parse_failures` bucket; `classify_runs`
+    derives them from the runs. `load_snapshot` must return an empty
+    preserved list so the caller does not double-count.
+    """
+    sys.path.insert(0, str(SCRIPT.parent))
+    import gh_queue_health as mod  # noqa: WPS433
+
+    raw_list = [{"id": 1, "name": "r1", "created_at": "2026-08-25T00:00:00Z",
+                 "html_url": "https://gh/r/1"}]
+    snapshot = tmp_path / "raw.json"
+    snapshot.write_text(json.dumps(raw_list), encoding="utf-8")
+    runs, preserved = mod.load_snapshot(snapshot)
+    assert len(runs) == 1
+    assert preserved == []


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/test #13987 cycle 83

## Suivi de review NanoClaw sur PR #13909 (cf issue #13966)

Issue #13966 releve 3 constats de la review NanoClaw sur `scripts/ci/gh_queue_health.py`,
portes en suivi **avant** le merge conformement a §B.0 voie 3. Ils sont
mineurs et non bloquants : la review conclut « logique de partition saine »,
« couverture de tests reelle (11 tests lus) », « securite OK ». Rien ici ne
conteste le livrable ; ce sont trois angles qui se degraderaient
silencieusement.

## 1 — Le plancher `18` etait un nombre magique

`verdict()` (l.136) codait `18` en dur, alors que `INCIDENT_FLOOR_DATE`
existait en constante nommee juste a cote. L'asymetrie etait le probleme
: si un futur incident ajoute des fantomes, la signature `STALE_FLOOR` se
degrade **silencieusement** en `GHOST_RUNS_DETECTED` sans que rien ne le
dise.

**Fix :** ajout de `INCIDENT_FLOOR_COUNT = 18` au site de
`INCIDENT_FLOOR_DATE`, utilisation dans `verdict()`.

## 2 — Docstring `STALE_FLOOR` omettait la conjonction

La docstring annonçait « ghost count equals the known incident floor (18) ».
Le code exige **aussi** `live == 0` — conjonction reelle, testee en
`18/0/0`. Un lecteur attendrait donc `STALE_FLOOR` avec 18 fantomes **et**
du live, et ne l'obtiendrait pas.

**Fix :** docstring corrigee pour nommer la conjonction : « ghost count
equals `INCIDENT_FLOOR_COUNT` (18) **AND** the live bucket is empty — the
conjunction matters: 18 ghosts WITH new live runs is
`GHOST_RUNS_DETECTED` (the floor is being augmented by fresh activity,
not just the historical signature). »

## 3 — Le replay d'un snapshot `INCOMPLETE` changeait la classe du verdict

`load_snapshot` ne resynthetisait que ghosts + live. Un snapshot
`INCOMPLETE` rejoue ressortait donc `CLEAN` ou `GHOST_RUNS_DETECTED` : le
verdict **changeait de classe** au replay. Un chemin de convenance qui
rend un verdict different de celui qu'il rejoue n'est pas un replay.

**Fix :** `load_snapshot` change de signature `list[dict]` -> `tuple[list[dict], list[dict]]`
retournant `(runs, preserved_parse_failures)`. Pour les 3 formes « raw »
(list, dict avec workflow_runs, enveloppe) `preserved_parse_failures` est
vide (classify_runs les re-derive). Pour la 4e forme (prior analysis
output) les `parse_failures` du snapshot sont preservees verbatim. Le
caller `main()` les merge dans la classification finale avant verdict.

## Tests (5 ajoutes, 16/16 dans la suite, 4023/0 dans scripts/tests/)

- `test_13966_incident_floor_count_constant_is_18` (pin constant + verdict semantics)
- `test_13966_load_snapshot_returns_tuple_with_parse_failures_preserved`
- `test_13966_replay_of_incomplete_snapshot_keeps_incomplete_verdict` (repro direct du defaut)
- `test_13966_replay_of_stale_floor_snapshot_keeps_stale_floor` (control positif)
- `test_13966_load_snapshot_raw_shape_returns_empty_preserved` (control raw)

## Verification firsthand

- `pytest scripts/tests/test_gh_queue_health.py` : 16/16 PASS (11 baseline + 5 nouveaux)
- `pytest scripts/tests/` (full) : 4023 passed, 29 skipped, 5 xfailed, **0 failed**
  (les 2 tests flaky `test_bash_e_rc_capture` et `test_build_advisory_symmetric_trap`
  sont des echecs pre-existants non lies a cette PR, documentes dans l'issue)

## Hors scope de cette PR (rappel pour ne pas perdre la note)

La review souleve un 4e point : `EXIT_GHOST=1` est l'etat **attendu** en
regime courant sur CoursIA, donc cabler l'instrument dans un step sans
`continue-on-error` ferait echouer la CI en permanence. Ce n'est pas un
defaut du script — c'est une consigne de deploiement, qui appartient a
l'issue de cablage, pas ici.

Closes #13966

## Note post-edit (cycle 83)

Body edite au cycle 83 pour deplacer le tag `Grain:` en premiere ligne (il etait en fin de body apres `Closes #13966`). Le tag est maintenant conforme au format canonique `Grain: TIER/GENRE -- lane <machine>:<workspace> -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste le meme.