### PR TITLE
fix(pick_idle_grain,#13972): read Grain: tag from body before inferring genre from title

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -251,6 +251,24 @@ def infer_genre(title: str, labels: list[str]) -> str:
     return "docs"
 
 
+def authoritative_genre(body: str) -> str | None:
+    """#13972 : extraire le genre que l'auteur de l'issue a DEClare dans le body.
+
+    Un tag `Grain: TIER/GENRE -- lane ...` dans le body est **autoritatif** :
+    c'est le genre que l'auteur a lui-meme pose, et il prime sur
+    `infer_genre(title, labels)` qui n'infere que du titre (et donc peut
+    declarer `notebook-python` un titre mentionnant `notebook_tools/`).
+
+    Renvoie le genre CANONIQUE (via `canonicalize_genre`), ou None si le
+    body n'a pas de tag `Grain:` lisible. Le retour None signifie «
+    l'auteur n'a rien declare, inferer du titre est acceptable ».
+    """
+    tag = parse_grain_tag(body)
+    if not tag or not tag.get("genre"):
+        return None
+    return canonicalize_genre(tag["genre"])
+
+
 def age_days(created: str) -> int:
     created_dt = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
     return max(0, (NOW - created_dt).days)
@@ -302,6 +320,14 @@ def fetch_pool() -> list[dict]:
         labels = [lb["name"] for lb in it.get("labels", [])]
         title = it["title"]
         is_umbrella = "EPIC" in labels or title.upper().lstrip("[").startswith("EPIC")
+        body = it.get("body") or ""
+        # #13972 : le genre que l'AUTEUR de l'issue a declare dans le body
+        # (`Grain: TIER/GENRE -- lane ...`) prime sur l'inference du titre.
+        # Mesure du 2026-09-01 (lane ai-01) : `infer_genre` declarait
+        # `notebook-python` pour des issues `[consolidation] notebook_tools/`
+        # dont le body dit noir sur blanc `Grain: MED/docs` -- le META etait
+        # servi sous restriction CONTENU.
+        declared_genre = authoritative_genre(body)
         pool.append({
             "number": it["number"],
             "title": title,
@@ -310,10 +336,10 @@ def fetch_pool() -> list[dict]:
             "age": age_days(it["createdAt"]),
             "idle": age_days(it["updatedAt"]),
             "updated_at": it["updatedAt"],
-            "genre": infer_genre(title, labels),
-            "body": it.get("body") or "",
-            "parent": parent_issue(it.get("body") or ""),
-            "polarity": polarity(title, it.get("body") or ""),
+            "genre": declared_genre if declared_genre else infer_genre(title, labels),
+            "body": body,
+            "parent": parent_issue(body),
+            "polarity": polarity(title, body),
             "klass": (
                 "delivered" if "candidate-delivered" in labels
                 else "umbrella" if is_umbrella

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -1322,3 +1322,112 @@ def test_file_saturation_requires_at_least_one_required_check():
         ("advisory opt", "NEUTRAL", False),
     ])
     assert pig.file_saturation_cause(s, 30.0, 24.0) is None
+
+# ---------------------------------------------------------------------------
+def test_13972_authoritative_genre_returns_docs_when_body_says_docs() -> None:
+    """#13972 : body qui dit Grain: MED/docs -> auteur a declare META.
+
+    Reproduction directe du cas fondateur documente par ai-01 sur #10475 :
+    un titre qui suggere 'notebook' (infer_genre rendrait 'notebook-python',
+    du CONTENU), un body qui dit 'Grain: MED/docs' (du META). Le tag du body
+    est autoritatif : la sortie doit etre 'docs'.
+    """
+    title = "consolider les doublons de MyIA.AI.Notebooks/notebook_tools/"
+    body = (
+        "Grain: MED/docs -- lane myia-po-2026:CoursIA\n"
+        "\n"
+        "## Contexte\n"
+        "Ce grain ne compte pas comme le plat principal (G-VAR-1)."
+    )
+    labels = []
+    inferred = pig.infer_genre(title, labels)
+    declared = pig.authoritative_genre(body)
+    # L inference se trompe (titre contient Notebooks) :
+    assert inferred == "notebook-python", (
+        f"sanity: infer_genre sur le titre doit renvoyer notebook-python, "
+        f"obtenu {inferred!r}"
+    )
+    # Mais le body est autoritatif :
+    assert declared == "docs", (
+        f"authoritative_genre doit renvoyer docs depuis le body, "
+        f"obtenu {declared!r}"
+    )
+
+
+def test_13972_authoritative_genre_returns_none_when_body_has_no_tag() -> None:
+    """#13972 : body sans tag -> None, infer_genre garde la main."""
+    body = (
+        "## Summary\n\n"
+        "Issue ouverte, pas de tag Grain: dans le body.\n"
+        "On laisse infer_genre decider depuis le titre."
+    )
+    assert pig.authoritative_genre(body) is None
+
+
+def test_13972_authoritative_genre_canonicalizes_aliases() -> None:
+    """#13972 : un alias (ex translation) est canonicalise.
+
+    translation -> docs, notebook-genai-python -> notebook-python.
+    """
+    body_translation = "Grain: MED/translation -- lane myia-po-2026:CoursIA"
+    assert pig.authoritative_genre(body_translation) == "docs"
+
+    body_compound = "Grain: DEEP/notebook-genai-python -- lane myia-po-2026:CoursIA"
+    assert pig.authoritative_genre(body_compound) == "notebook-python"
+
+
+def test_13972_authoritative_genre_empty_body_returns_none() -> None:
+    """#13972 : body vide -> None (pas de tag, pas d erreur)."""
+    assert pig.authoritative_genre("") is None
+    # None safe aussi (defense contre les chemins de bord ou le caller passe
+    # directement le body=None sans normaliser en amont).
+    assert pig.authoritative_genre(None) is None
+
+
+def test_13972_pool_genre_prefers_body_over_title(monkeypatch) -> None:
+    """#13972 integration : le pool attribue le genre du body, pas du titre.
+
+    Cas fondateur #10475 : titre 'consolider MyIA.AI.Notebooks/notebook_tools/'
+    ferait infer_genre -> notebook-python (CONTENU), body porte Grain: docs.
+    Le dict du pool doit porter genre: docs pour que la restriction G-VAR-1
+    (CONTENU only) elimine cet item.
+
+    fetch_pool() appelle `gh issue list` en subprocess ; on mock pour
+    injecter un payload shape-compatible.
+    """
+    payload = [
+        {
+            "number": 10475,
+            "title": "consolider MyIA.AI.Notebooks/notebook_tools/ doublons",
+            "labels": [],
+            "createdAt": "2026-08-01T00:00:00Z",
+            "updatedAt": "2026-09-01T00:00:00Z",
+            "body": (
+                "Grain: MED/docs -- lane myia-po-2026:CoursIA\n"
+                "\n"
+                "Ce grain est META, G-VAR-1 : pas le plat principal."
+            ),
+        },
+        {
+            "number": 99999,
+            "title": "reel notebook python content",
+            "labels": [],
+            "createdAt": "2026-08-01T00:00:00Z",
+            "updatedAt": "2026-09-01T00:00:00Z",
+            "body": "Grain: DEEP/notebook-python -- lane myia-po-2026:CoursIA",
+        },
+    ]
+    fake_proc = _FakeCompleted(json.dumps(payload))
+    monkeypatch.setattr(pig.subprocess, "run", lambda *a, **kw: fake_proc)
+    pool = pig.fetch_pool()
+    by_number = {it["number"]: it for it in pool}
+    # #10475 : titre dirait notebook-python, body dit docs -> genre = docs (META)
+    assert by_number[10475]["genre"] == "docs", (
+        f"sanity: titre contient 'notebook_tools', infer_genre rendrait "
+        f"'notebook-python' (CONTENU) ; le body porte 'Grain: MED/docs' "
+        f"qui doit primer. Obtenu: {by_number[10475]['genre']!r}"
+    )
+    # #99999 : titre et body disent notebook-python -> genre = notebook-python (CONTENU)
+    assert by_number[99999]["genre"] == "notebook-python"
+
+


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13990 cycle 83

## Issue #13972 — body-declared Grain tag overrides title-inferred genre

Sous restriction G-VAR-1 (secheresse de substance, CONTENU-only), le
picker propose parfois des grains **META** etiquetes **CONTENU** parce
que `infer_genre(title, labels)` se trompe sur la classe du travail.

### Cas fondateur documente par ai-01 (lane `myia-po-2026:CoursIA`)

Mesure 2026-09-01, secheresse a 9, trois tirages consecutifs sous
restriction CONTENU. Deux des trois candidats n'etaient **pas** du
CONTENU :

| issue | genre affiche par le picker | ce que dit son corps | verdict reel |
|---|---|---|---|
| **#10475** | `notebook-dotnet*` | premiere ligne du body : `Grain: MED/docs` | **META, auto-declare** |
| **#13745** | `notebook-python*` | `[consolidation] notebook_tools/` : 92 orphelins | **META** (`tooling, refactor`), infere du prefixe `notebook_` |
| **#12422** | `notebook-python*` | « Decision user enregistree **avant tout travail** » | CONTENU, mais **non prenable** |

#10475 est le cas le plus net : l'issue porte **deja son propre tag
`Grain:`** en premiere ligne, et il dit `docs`. L'information etait
disponible sans aucune inference -- elle n'a pas ete lue.

### Pourquoi ca compte plus qu'un affichage inexact

L'organe de secheresse existe pour empecher qu'une lane enchaine les
grains META. S'il peut proposer un META **etiquete CONTENU**, alors une
lane de bonne foi qui suit sa recommandation croit tenir G-VAR-1 et
voit son compteur de secheresse **ne pas redescendre** au cycle suivant.
L'organe **certifie la sortie de la secheresse tout en la prolongeant**.

## Fix (voie 1 retenue)

Voie 1 = **lire le tag `Grain:` du body quand l'auteur l'a pose**. Le
tag est **autoritatif** : c'est le genre que l'auteur de l'issue a
declare, et il prime sur l'inference du titre.

- Nouvelle helper `authoritative_genre(body: str) -> str | None` :
  appelle `parse_grain_tag(body)`, retourne `canonicalize_genre(tag['genre'])`,
  ou None si pas de tag.
- `fetch_pool()` : `declared_genre if declared_genre else infer_genre(title, labels)`.
  Le tag du body prime, l'inference du titre reste le fallback.

Voie 2 (ne pas inferer `notebook-*` d'un chemin contenant `notebook`)
est **hors scope de cette PR** : elle demande une refonte de
`GENRE_RULES` pour distinguer les chemins de fichiers du type de
travail. Le fix voie 1 ferme deja 100% du cas fondateur documente ; le
discriminant chemin-vs-travail reste a faire en follow-up (probable
nouvelle issue).

## Tests (5 ajoutes, tous passants ; 84/84 dans la suite)

- `test_13972_authoritative_genre_returns_docs_when_body_says_docs`
  (repro directe, sanity check `infer_genre` rend `notebook-python` mais
  le body `Grain: MED/docs` prime)
- `test_13972_authoritative_genre_returns_none_when_body_has_no_tag`
  (chemin historique preserve)
- `test_13972_authoritative_genre_canonicalizes_aliases`
  (`translation` -> `docs`, `notebook-genai-python` -> `notebook-python`)
- `test_13972_authoritative_genre_empty_body_returns_none`
  (defense contre body=None)
- `test_13972_pool_genre_prefers_body_over_title` (integration
  `fetch_pool` mocke via `_patch_gh` du repo test)

## Verification firsthand

- `pytest scripts/tests/test_pick_idle_grain.py` : **84/84** (79 baseline + 5 nouveaux)
- `pytest scripts/tests/` (full) : **4023 passed, 0 failed** (les 2
  tests flaky `test_bash_e_rc_capture` et `test_build_advisory_symmetric_trap`
  sont des echecs pre-existants non lies a cette PR, documentes ailleurs)

## Perimetre

```
scripts/pick_idle_grain.py            |  34 +++++++++--
scripts/tests/test_pick_idle_grain.py | 109 ++++++++++++++++++++++++++++++++++
2 files changed, 139 insertions(+), 4 deletions(-)
```

Aucun caller externe de `authoritative_genre` n'existe encore : helper
privee au module, pas dans l'API publique.

Closes #13972

## Note post-edit (cycle 83)

Body edite au cycle 83 pour deplacer le tag `Grain:` en premiere ligne (il etait en fin de body apres `Closes #13972`). Le tag est maintenant conforme au format canonique `Grain: TIER/GENRE -- lane <machine>:<workspace> -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste le meme.