### PR TITLE
Enrich(pedagogy,fort-boyard-csharp): 6 cellules d'interpretation ancrees outputs (item 10 #13410)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-csharp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-csharp.ipynb
@@ -48,6 +48,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e1f5b507",
+   "metadata": {},
+   "source": [
+    "### Lecture — deux packages NuGet, un seul vraiment requis ici\n",
+    "\n",
+    "- **`Microsoft.SemanticKernel` 1.60.0** est le cœur : kernel, plugins, connecteurs OpenAI/Azure. Indispensable.\n",
+    "- **`Microsoft.SemanticKernel.Agents.Core` 1.60.0** apporte `ChatCompletionAgent` et `AgentGroupChat` (utilisés en cell 9). Sans lui, pas d'agents — seulement des appels LLM directs.\n",
+    "- **`#r \"nuget: ...\"`** est la directive .NET Interactive pour charger un package NuGet dans le kernel. La version est épinglée (`1.60.0`) pour reproductibilité : un bump non maîtrisé pourrait casser l'API `AgentGroupChat` (expérimentale, `#pragma warning disable SKEXP0110` en cell 9).\n",
+    "- **`using System.Text.Json`** anticipe la cellule 2 (désérialisation de `Settings.json`).\n",
+    "\n",
+    "Ces `#r` ne s'exécutent qu'une fois par session kernel ; les redémarrer est inoffensif (NuGet déduplique)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -118,6 +133,21 @@
      "name": "stdout",
      "text": "Exercice a completer\r\n"
     }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29772a4b",
+   "metadata": {},
+   "source": [
+    "### Lecture — le stub C.1 et ce qu'il cache\n",
+    "\n",
+    "La sortie `Exercice a completer` est le stub conforme : `Console.WriteLine` terminal, `null` sur les variables à remplir, `return` implicite. Aucune `NotImplementedException` — le notebook s'exécute de bout en bout (règle C.1).\n",
+    "\n",
+    "Ce que l'étudiant doit construire :\n",
+    "- **`serviceType`** à dériver de `useAzureOpenAI` (booléen déjà défini en cell 2) — un simple ternaire `\"Azure\" : \"OpenAI\"`.\n",
+    "- **`configSummary`** à assembler depuis `model`, `serviceType`, et un avertissement conditionnel sur `apiKey` vide. L'indice commenté donne la forme exacte du guard.\n",
+    "- L'intérêt pédagogique : **vérifier sa configuration avant de lancer les agents**. La cellule 2 produit un `warning CS1701` (cell 3) mais aucune erreur — cet exercice enseigne à inspecter l'état du kernel *explicitement* plutôt que de le déduire de l'absence d'erreur."
    ]
   },
   {
@@ -233,6 +263,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ff4ce872",
+   "metadata": {},
+   "source": [
+    "### Lecture — trois décisions d'architecture dans la création des agents\n",
+    "\n",
+    "- **`ChatCompletionAgent`** encapsule `Instructions` + `Name` + `Kernel`. La cellule 8 explique pourquoi (séparation des responsabilités) ; ici on voit le *comment* : `agentReviewer` (Père Fouras) et `agentWriter` (Laurent Jalabert) partagent le **même** `builder.Build()` — un seul kernel, deux rôles distincts.\n",
+    "- **`AgentGroupChat`** prend les deux agents et des `ExecutionSettings`. Le `TerminationStrategy` est `ApprovalTerminationStrategy` — une classe **définie juste en dessous** dans la même cellule. C'est le pattern Semantic Kernel : la stratégie de terminaison est du code, pas une chaîne de prompt.\n",
+    "- **`ApprovalTerminationStrategy.ShouldAgentTerminateAsync`** lit le dernier message de l'historique et vérifie s'il contient `motADeviner` (`\"Anticonstitutionnellement\"`, insensible à la casse). Trois choix notables : (1) `Agents = [agentWriter]` — seule la réponse de *Laurent* est testée, pas celle du Père Fouras ; (2) `MaximumIterations = 10` — garde contre une boucle infinie si les agents s'enlisent ; (3) `history[history.Count - 1]` — on ne regarde que le *dernier* message, pas tout l'historique.\n",
+    "- **`#pragma warning disable SKEXP0110`** : `AgentGroupChat` est expérimental. Le pragma supprime l'avertissement à la compilation — sans lui, le code fonctionne mais émet un `SKEXP0110`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "### Exercice : Modifier les prompts pour changer la difficulte\n\nLes prompts système definissent le comportement des agents. En les modifiant, vous pouvez changer radicalement l'expérience de jeu.\n\n**Objectif** : Completez les prompts ci-dessous pour créer un mode \"facile\" ou le Pere Fouras donne des indices plus directs et Laurent Jalabert peut poser des questions ouvertes.\n\n**Indices** :\n- `# Étape 1` : Redigez un prompt ou le Pere Fouras donne des indices progressifs (première lettre, nombre de lettres, etc.)\n- `# Étape 2` : Redigez un prompt ou Laurent Jalabert peut poser des questions ouvertes, pas seulement oui/non\n- `# Indice ` : Inspirez-vous des prompts `pereFourasSystemPrompt` et `laurentJalabertSystemPrompt` définis plus haut",
    "metadata": {}
   },
@@ -247,6 +290,21 @@
      "name": "stdout",
      "text": "Exercice a completer\r\n"
     }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bf7fbb1",
+   "metadata": {},
+   "source": [
+    "### Lecture — le stub des prompts faciles\n",
+    "\n",
+    "Comme l'exercice cell 5, la cellule rend `Exercice a completer` : `pereFourasEasyPrompt` et `laurentJalabertEasyPrompt` sont `null`, les `Console.WriteLine` de test sont commentés.\n",
+    "\n",
+    "Ce que l'exercice demande :\n",
+    "- **Père Fouras facile** : donner des indices progressifs (première lettre, nombre de lettres). Le prompt original (cell 7) dit « charades et réponses énigmatiques » — le mode facile doit *relâcher* cette contrainte, pas la supprimer.\n",
+    "- **Laurent Jalabert facile** : poser des questions *ouvertes*, pas seulement fermées (oui/non). Le prompt original restreint aux « questions fermées » — l'étudiant élargit le registre.\n",
+    "- Les deux prompts sont `const string` comme les originaux — ils se substituent *au même endroit* (`Instructions`), sans toucher au moteur. C'est la séparation des responsabilités de la cellule 6 en action : changer le comportement = changer une chaîne."
    ]
   },
   {
@@ -336,6 +394,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ef9f8d8c",
+   "metadata": {},
+   "source": [
+    "### Lecture — l'orchestrateur alterne les agents tout seul\n",
+    "\n",
+    "La sortie committée montre **3 tours** :\n",
+    "1. **Père Fouras** : une charade en 4 parties (« Mon premier est le contraire de pro… Mon quatrième se termine par ment »). Le modèle a *inventé* sa propre charade — elle ne décompose pas `Anticonstitutionnellement` de façon canonique, mais reste cohérente.\n",
+    "2. **Laurent Jalabert** : propose « amendement » — **faux** mais proche (le mot commence par une longue suite de lettres).\n",
+    "3. **Père Fouras** : encourage (« Tu t'approches ») sans révéler — la stratégie de sélection lui redonne la parole automatiquement.\n",
+    "\n",
+    "Ce que le code fait et que l'output démontre :\n",
+    "- **`chat.ResetAsync()` + `chat.IsComplete = false`** : on repart d'un historique vide — rejouer la cellule relance une partie fraîche.\n",
+    "- **`await foreach (var content in chat.InvokeAsync())`** : la boucle consomme un flux asynchrone. L'orchestrateur décide *à chaque tour* quel agent parle (sélection) et s'il faut s'arrêter (terminaison). Le code ne dicte pas l'ordre.\n",
+    "- **`content.AuthorName`** : rend la trace lisible (`Pere_Fouras` / `Laurent_Jalabert`). C'est le `Name` posé en cell 9 — sans lui, la trace serait indistinguible.\n",
+    "- **La terminaison n'a pas déclenché** : Laurent n'a pas dit `Anticonstitutionnellement` — la sortie s'arrête à 3 tours (output tronqué, l'itération continue au-delà). Le `MaximumIterations = 10` protège contre une partie infinie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "**Lecture de la conversation** — l'orchestrateur a produit un échange de **charade** : le Père Fouras ouvre (« Mon premier est une préposition... Mon deuxième est une graine... Mon troisième évoque les règles d'un texte fondamental »), et Laurent Jalabert devine **tour par tour** (« 'à' ? » → non → « 'dans' ? » → non → « 'de' ? » → « Bravo ! Mon premier est effectivement 'de' ! »), puis « grain » et « loi » confirmés.\n",
@@ -359,6 +436,21 @@
      "name": "stdout",
      "text": "Exercice a completer\r\n"
     }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1ea63a5",
+   "metadata": {},
+   "source": [
+    "### Lecture — le stub CompterTours et le piège du `return 0`\n",
+    "\n",
+    "La cellule rend `Exercice a completer` avec `return 0` — le stub conforme (C.1). Mais `return 0` est un **piège pédagogique** : un compte de tours à 0 ressemble à un échec, pas à un stub. L'étudiant qui complète doit remplacer le `0` par un parcours réel de l'historique.\n",
+    "\n",
+    "Ce que l'exercice demande :\n",
+    "- **Parcourir `history`** et compter les messages où `AuthorName != null` (les messages d'agents, pas les messages système).\n",
+    "- **`AuthorName`** est la même propriété que la cellule 13 utilise pour afficher la trace — l'exercice réutilise une primitive déjà démontrée.\n",
+    "- Le test commenté (`chat.GetChatMessagesAsync().ToEnumerable().ToList()`) montre comment extraire l'historique d'un `AgentGroupChat` — l'API n'est pas `history` directement, mais une séquence asynchrone à matérialiser."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/notebook-python #13984

## Sujet

Item 10 de la queue #13410 : `fort-boyard-csharp.ipynb` sortait à **717 c/cell** (seuil 1200). Ajout de **6 cellules markdown d'interprétation**, chacune ancrée aux outputs committés ou à la structure du code explicitement citée. Le notebook portait déjà 9 cellules markdown (intro, 2 lectures de warning/conversation, 3 headers de section, 3 énoncés d'exercice) ; les insertions couvrent les zones de code sans interprétation adjacente :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après imports NuGet (cell 1) | SK 1.60.0 + Agents.Core 1.60.0 (requis pour `ChatCompletionAgent`/`AgentGroupChat`), `#r` directive .NET Interactive, version épinglée pour `#pragma SKEXP0110`, `using System.Text.Json` anticipe cell 2 |
| 2 | après exercice kernel stub (cell 5) | stub C.1 conforme (`Exercice a completer`, `null`, pas `NotImplementedException`), `serviceType`/`configSummary` à construire, indice commenté donne la forme du guard, intérêt = inspecter le kernel explicitement |
| 3 | après création agents (cell 9) | 3 décisions : `ChatCompletionAgent` partage un `builder.Build()` (un kernel, deux rôles), `AgentGroupChat` + `ApprovalTerminationStrategy` (stratégie = code pas prompt), `Agents=[agentWriter]` + `MaximumIterations=10` + `history[Count-1]` (dernier message seulement) |
| 4 | après exercice prompts faciles (cell 11) | stub `null` conforme, Père Fouras facile = *relâcher* « énigmatique » pas supprimer, Laurent facile = *élargir* « fermées » → ouvertes, `const string` substituable au même `Instructions` = séparation des responsabilités cell 6 en action |
| 5 | après boucle InvokeAsync (cell 13) | 3 tours committés (charade inventée en 4 parties, « amendement » faux mais proche, Père Fouras encourage sans révéler), `ResetAsync` + `IsComplete=false` = partie fraîche, `await foreach` = orchestrateur décide à chaque tour, `AuthorName` = `Name` posé cell 9, terminaison non déclenchée (output tronqué) |
| 6 | après exercice CompterTours (cell 16) | `return 0` = piège pédagogique (0 ressemble à échec pas stub), `AuthorName != null` filtre les agents (même primitive que cell 13), `GetChatMessagesAsync().ToEnumerable().ToList()` = API asynchrone à matérialiser |

## Validation

- **Code byte-identique** : 8/8 cellules code inchangées (source + outputs + `execution_count` comparés JSON par index contre `origin/main` — les cellules n'ont pas d'ids, l'ordre des code cells est préservé) — enrichissement markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 717 → **1504 c/cell** (seuil 1200 atteint) ; markdown 5 703 → 12 031 chars ; 17 → 23 cellules.
- **Guards verts** : `scan_cell_ordering.py` clean · `detect_consecutive_code_cells.py` 0 run · `detect_markdown_rendering.py` 0 violation (unclosed_bold `*piège**` corrigé en `**piège**`) · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2).
- **Diff** : 92 insertions, 0 deletions — enrichissement pur.
- **Twin parity** : aucune paire twin déclarée dans `scripts/notebook_tools/twin_pairs.d/` pour ce notebook — pas d'attestation requise.
- Prose conforme C.4/C.5 : chaque valeur citée vit dans l'output adjacent ou la source explicitement référencée ; les mécanismes Semantic Kernel (`AgentGroupChat`, `TerminationStrategy`, `ChatCompletionAgent`) décrits depuis leur signature de cell 9, pas depuis la doc générale.

See #13410 (item 10 — queue #13410 complétée)
