### PR TITLE
feat(ci): refresh-stale-adjacency re-trigger G-VAR-3 stale verdict via body marker

### DIFF
--- a/scripts/ci/refresh_stale_adjacency.py
+++ b/scripts/ci/refresh_stale_adjacency.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Refresh a PR's stale G-VAR-3 adjacency verdict by re-triggering the check.
+
+## Why this exists
+
+The G-VAR-3 adjacency guard resolves a lane's REAL predecessor from the MERGED
+sequence of the lane in a 21-day window (`fetch_merged_prs_since.py --days
+21`). The guard re-runs only on `pull_request: synchronize, edited, reopened`
+(`always-on-guards.yml` l.57) -- a push to the branch OR a body edit. When the
+merged sequence changes (a sibling PR merges and bumps the predecessor), the
+guard verdicts go stale: the previously failing `prev_genre` is now resolved
+to a different grain, but nothing in the workflow says "recompute", and the
+PR stays MERGEABLE=FALSE in the PR gate while it would be MERGEABLE=TRUE if
+re-checked.
+
+The founder case (2026-09-01) was the myia-po-2026:CoursIA lane:
+`MERGEABLE=FALSE` on 7 PRs whose GRAIN tag (MED/guard, LIGHT/guard, ...) was
+in genuine adjacency with #13585 (MED/guard, merged 2026-08-31T18:47:59Z) at
+PR-open time. After #13888 (MED/tooling) merged at 2026-09-01T07:13:59Z, the
+guard's predecessor resolution moved to tooling -- so the same PRs would now
+PASS if re-checked. The `pull_request: synchronize` trigger fires on push, not
+on sequence changes, so no automatic refresh happens.
+
+This script automates the manual workaround: simulate the guard locally with
+the CURRENT merged sequence, and if the simulated verdict PASSES while the
+PR is currently failing on `Always-on guards`, append an idempotent
+`<!-- refresh-adj: ISO8601 -->` marker to the body and `gh pr edit
+--body-file`. That re-fires the `pull_request: edited` event and the guard
+recomputes with the current sequence -- which is now PASS.
+
+## What it does NOT do
+
+- It does NOT bypass the G-VAR-3 rule. If the simulated verdict FAILS, the
+  script exits non-zero with the reason and does NOT modify the body. The
+  rule stays authoritative; the marker is only a refresh, never an override.
+- It does NOT modify the body for any reason other than the refresh marker.
+  The marker is invisible on GitHub's rendered view and idempotent on
+  re-runs: a second invocation finds the marker, replaces the timestamp,
+  does not duplicate the line.
+- It does NOT touch the underlying code or the substance of the PR. The
+  diff stays zero on the source files; only the body SHA changes by the
+  one-line append.
+
+## Usage
+
+    python scripts/ci/refresh_stale_adjacency.py --pr 13812 --pr 13869 --pr 13917
+    python scripts/ci/refresh_stale_adjacency.py --pr 13812 --dry-run
+
+## Exit codes
+
+  0  -- every PR either passes the simulated guard, or was successfully
+       refreshed (marker appended, edit posted).
+  1  -- at least one PR fails the simulated guard with a real reason
+       (genuine G-VAR-3 adjacency); nothing was modified on those PRs.
+  2  -- caller error (gh failure, missing argument).
+
+The marker is exactly one line:
+
+    <!-- refresh-adj: 2026-09-01T09:42:00Z -->
+
+appended at the end of the body, followed by a newline if missing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make the shared extractor + adjacency guard importable from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import grain_tag as gt  # noqa: E402
+from variation_adjacency_guard import (  # noqa: E402
+    check,
+    parse_override,
+    resolve_merged_prev_genre,
+)
+
+MARKER_RE = re.compile(r"<!--\s*refresh-adj:\s*[^>]+\s*-->")
+MARKER_PREFIX = "<!-- refresh-adj:"
+MARKER_TZ = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def now_marker() -> str:
+    """Return the current UTC timestamp in the marker format."""
+    return f"{MARKER_PREFIX} {datetime.now(timezone.utc).strftime(MARKER_TZ)} -->"
+
+
+def run_gh(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    """Run a `gh` CLI invocation, return CompletedProcess (stdout=str)."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=check,
+    )
+
+
+def fetch_merged_window(days: int = 21) -> list[dict]:
+    """Fetch the merged-window used by the G-VAR-3 guard (21d default)."""
+    proc = subprocess.run(
+        ["python", "scripts/ci/fetch_merged_prs_since.py", "--days", str(days)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"fetch_merged_prs_since failed: {proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def get_pr_body(pr_number: int) -> str:
+    """Return the current body of `pr_number` as a string."""
+    proc = run_gh("pr", "view", str(pr_number), "--json", "body")
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh pr view #{pr_number} failed: {proc.stderr}")
+    data = json.loads(proc.stdout)
+    return data.get("body") or ""
+
+
+def get_pr_comments(pr_number: int) -> list[dict]:
+    """Return the {author.login, body} list for `pr_number` (override scan)."""
+    proc = run_gh("pr", "view", str(pr_number), "--json", "comments",
+                  "--jq", '[.comments[] | {author: .author.login, body: .body}]')
+    if proc.returncode != 0:
+        return []
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def get_pr_checks(pr_number: int) -> dict:
+    """Return the current check state of `pr_number` (name -> conclusion)."""
+    proc = run_gh("pr", "checks", str(pr_number))
+    checks: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        # Format: NAME<tab>CONCLUSION<tab>DURATION<tab>URL
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        checks[parts[0]] = parts[1]
+    return checks
+
+
+def is_always_on_guards_failing(pr_number: int) -> bool:
+    """True if `Always-on guards -- 12 organes, 1 checkout` is currently FAIL."""
+    checks = get_pr_checks(pr_number)
+    name = "Always-on guards -- 12 organes, 1 checkout"
+    return checks.get(name) == "fail"
+
+
+def append_marker(body: str, marker: str) -> str:
+    """Append `marker` to `body`, idempotent (replaces existing marker)."""
+    body = body.rstrip("\n")
+    # Strip any previous refresh-adj marker (with the line that carries it)
+    body = MARKER_RE.sub("", body).rstrip("\n")
+    if not body:
+        return f"{marker}\n"
+    return f"{body}\n{marker}\n"
+
+
+def simulate_adjacency(pr_number: int, body: str, merged_window: list[dict]) -> dict:
+    """Run the G-VAR-3 guard on `body` against the current `merged_window`.
+
+    Returns the guard verdict dict. This is the SAME computation the CI runs
+    (`scripts/ci/variation_adjacency_guard.py --body-file ... --merged-prs-file
+    ...`), so a `guard_pass: True` here means the CI will turn green on the
+    next re-trigger.
+    """
+    g = gt.parse_grain_tag(body)
+    if g is None:
+        # Body has no Grain tag -- a different guard (tag-required) is the
+        # cause. Don't refresh.
+        return {
+            "guard_pass": False,
+            "blocking": False,
+            "adjacent": False,
+            "reason": "no Grain tag in body -- tag-required is the cause, not adjacency",
+        }
+
+    override = parse_override(get_pr_comments(pr_number))
+    merged_prev = resolve_merged_prev_genre(merged_window, g["lane"])
+    return check(body, override=override, merged_prev=merged_prev)
+
+
+def refresh_one(pr_number: int, dry_run: bool, merged_window: list[dict]) -> dict:
+    """Run the full refresh cycle for `pr_number`. Returns a status dict."""
+    body = get_pr_body(pr_number)
+    verdict = simulate_adjacency(pr_number, body, merged_window)
+    always_on_failing = is_always_on_guards_failing(pr_number)
+    new_body = append_marker(body, now_marker())
+    would_refresh = (
+        always_on_failing
+        and verdict["guard_pass"]
+        and verdict.get("blocking") is not True
+    )
+    refreshed = False
+    if would_refresh and not dry_run:
+        proc = run_gh("pr", "edit", str(pr_number), "--body-file", "-",
+                      check=False)
+        # Need to pipe stdin -- the `--body-file -` reads from stdin in some
+        # gh versions; if not supported, fall back to a temp file.
+        if "unknown flag" in proc.stderr or "flag" in proc.stderr.lower():
+            tmp = Path(f"/tmp/refresh_body_{pr_number}.md")
+            tmp.write_text(new_body, encoding="utf-8")
+            proc2 = run_gh("pr", "edit", str(pr_number), "--body-file", str(tmp))
+            tmp.unlink(missing_ok=True)
+            refreshed = proc2.returncode == 0
+        else:
+            proc2 = subprocess.run(
+                ["gh", "pr", "edit", str(pr_number), "--body-file", "-"],
+                input=new_body,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            refreshed = proc2.returncode == 0
+    elif would_refresh and dry_run:
+        refreshed = True  # virtual: would have been done
+
+    return {
+        "pr": pr_number,
+        "always_on_failing": always_on_failing,
+        "guard_pass": verdict["guard_pass"],
+        "adjacent": verdict.get("adjacent"),
+        "prev_genre": verdict.get("prev_genre"),
+        "prev_pr": verdict.get("prev_pr"),
+        "reason": verdict.get("reason", ""),
+        "would_refresh": would_refresh,
+        "refreshed": refreshed,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--pr", type=int, action="append", required=True,
+                   help="PR number to consider (repeatable)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report what would be done without modifying any PR")
+    args = p.parse_args(argv)
+
+    try:
+        merged_window = fetch_merged_window()
+    except RuntimeError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 2
+
+    results = [refresh_one(pr, args.dry_run, merged_window) for pr in args.pr]
+    print(json.dumps({"results": results}, indent=2, ensure_ascii=False))
+
+    # Exit 1 if any PR failed the simulated guard with a real reason (the
+    # refresh only covers stale-failing verdicts; a fresh failing verdict is
+    # not ours to override).
+    any_real_fail = any(
+        not r["guard_pass"] and not r["always_on_failing"]
+        for r in results
+    )
+    return 1 if any_real_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_refresh_stale_adjacency.py
+++ b/scripts/tests/test_refresh_stale_adjacency.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Unit tests for refresh_stale_adjacency (the G-VAR-3 stale-verdict re-trigger).
+
+Covers the pure helpers: `append_marker` (idempotent), `now_marker` (format),
+and the verdict-routing logic of `refresh_one` simulated via fake `gh` output.
+
+The end-to-end `refresh_one` calls real `gh` CLI -- so the live-call branch is
+tested by hand against a small set of PRs and NOT in pytest. The unit tests
+focus on:
+
+  * `append_marker` idempotency -- running the function N times on the same
+    body produces exactly ONE marker, with the latest timestamp.
+  * The marker format -- exactly one line, ISO-8601 UTC, prefixed.
+  * `now_marker` returns a string that round-trips through `append_marker`.
+  * The verdict-routing matrix of `refresh_one` -- given a fake
+    `(always_on_failing, guard_pass)` pair, decide correctly whether to
+    refresh.
+
+We mock the subprocess calls so the unit tests do not need network. The
+fixture `FakeRun` emulates `subprocess.run` output for `gh pr view --json
+body` and `gh pr checks`. A monkeypatch fixture swaps
+`subprocess.run` for a controller.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import refresh_stale_adjacency as rsa  # noqa: E402
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+class FakeRun:
+    """Emulates `subprocess.run` return for `gh` calls.
+
+    `specs` is a dict mapping `argv` tuple -> (returncode, stdout, stderr).
+    The first matching spec wins; the default is (0, "", "") so unrelated
+    calls return cleanly.
+    """
+
+    def __init__(self, specs: dict | None = None) -> None:
+        self.specs: dict = specs or {}
+        self.calls: list[tuple] = []
+
+    def __call__(self, argv, capture_output=True, text=True, check=False,
+                 input=None, **kwargs):  # noqa: ANN001 -- mirror subprocess.run
+        self.calls.append(tuple(argv))
+        # Find a matching spec (subsequence match: argv must contain all of
+        # `argv_prefix` tokens in order).
+        for key, val in self.specs.items():
+            if self._argv_matches(list(argv), key):
+                rc, stdout, stderr = val
+                cp = subprocess.CompletedProcess(
+                    args=argv, returncode=rc, stdout=stdout, stderr=stderr,
+                )
+                return cp
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="", stderr="",
+        )
+
+    @staticmethod
+    def _argv_matches(argv, key) -> bool:
+        # If key is a tuple of strings, all must appear in argv in order.
+        if isinstance(key, tuple):
+            i = 0
+            for tok in argv:
+                if tok == key[i]:
+                    i += 1
+                    if i == len(key):
+                        return True
+            return False
+        return False
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Replace `subprocess.run` with a FakeRun controller.
+
+    Returns the FakeRun instance; the caller sets `.specs` to declare
+    expected `gh` invocations.
+    """
+    fr = FakeRun()
+    monkeypatch.setattr(rsa.subprocess, "run", fr)
+    return fr
+
+
+# --- pure helper tests ------------------------------------------------------
+
+
+def test_append_marker_adds_one_line():
+    body = "## Quoi\n\nClose #1.\n\nGrain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/guard #0\n"
+    out = rsa.append_marker(body, "<!-- refresh-adj: 2026-09-01T09:42:00Z -->")
+    assert out.count("<!-- refresh-adj:") == 1
+    assert out.endswith("<!-- refresh-adj: 2026-09-01T09:42:00Z -->\n")
+    assert "Grain: MED/guard" in out  # substance preserved
+
+
+def test_append_marker_idempotent():
+    body = "## Section\n\nBody.\n"
+    out1 = rsa.append_marker(body, "<!-- refresh-adj: 2026-09-01T09:00:00Z -->")
+    out2 = rsa.append_marker(out1, "<!-- refresh-adj: 2026-09-01T09:30:00Z -->")
+    out3 = rsa.append_marker(out2, "<!-- refresh-adj: 2026-09-01T10:00:00Z -->")
+    assert out3.count("<!-- refresh-adj:") == 1, f"expected 1, got {out3.count('<!-- refresh-adj:')}"
+    assert "2026-09-01T10:00:00Z" in out3
+    assert "2026-09-01T09:00:00Z" not in out3
+    assert "2026-09-01T09:30:00Z" not in out3
+
+
+def test_append_marker_handles_empty_body():
+    out = rsa.append_marker("", "<!-- refresh-adj: 2026-09-01T00:00:00Z -->")
+    assert out == "<!-- refresh-adj: 2026-09-01T00:00:00Z -->\n"
+
+
+def test_append_marker_handles_none_body():
+    # Defensive: a None body (unusual, but seen in fork PRs) becomes "".
+    out = rsa.append_marker("", "<!-- refresh-adj: X -->")
+    assert "<!-- refresh-adj: X -->" in out
+
+
+def test_now_marker_format():
+    m = rsa.now_marker()
+    # Exactly one line, no trailing newline, exact prefix.
+    assert m.startswith("<!-- refresh-adj: ")
+    assert m.endswith(" -->")
+    # The timestamp between is ISO-8601 UTC (YYYY-MM-DDTHH:MM:SSZ).
+    iso = re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", m)
+    assert iso is not None
+
+
+def test_now_marker_round_trips_through_append_marker():
+    body = "Some body\n"
+    out = rsa.append_marker(body, rsa.now_marker())
+    assert out.count("<!-- refresh-adj:") == 1
+
+
+# --- verdict-routing tests (refresh_one logic, mocked subprocess) ------------
+
+
+PR_BODY_OK = (
+    "## Quoi\n\n"
+    "Fixes #1. Grain tag.\n\n"
+    "Grain: MED/docs -- lane myia-po-2026:CoursIA -- prev: MED/tooling #999\n"
+)
+
+
+def _setup_fake_for_pr(fake_run: FakeRun, pr: int, body: str,
+                        always_on_failing: bool) -> None:
+    """Configure FakeRun for one PR: body, checks, comments."""
+    fake_run.specs[("pr", "view", str(pr), "--json", "body")] = (
+        0, json.dumps({"body": body}), "")
+    fake_run.specs[("pr", "view", str(pr), "--json", "comments",
+                    "--jq")] = (
+        0, "[]", "")
+    checks = [
+        ["Always-on guards -- 12 organes, 1 checkout",
+         "fail" if always_on_failing else "success", "0s", "https://x"],
+    ]
+    checks_text = "\n".join("\t".join(row) for row in checks) + "\n"
+    fake_run.specs[("pr", "checks", str(pr))] = (0, checks_text, "")
+    # `gh pr edit ... --body-file -` (the edit call): accept any input.
+    fake_run.specs[("pr", "edit", str(pr), "--body-file", "-")] = (
+        0, "", "")
+
+
+def test_refresh_one_skips_when_already_passing(fake_run):
+    """If `Always-on guards` is NOT failing, do NOT refresh.
+
+    The script must NEVER touch a PR whose check is already green: the
+    guard could fail on the next run for an unrelated reason and we would
+    have polluted its body for nothing.
+    """
+    _setup_fake_for_pr(fake_run, 13812, PR_BODY_OK, always_on_failing=False)
+    merged_window = [
+        {"number": 999, "body": "Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #998\n",
+         "mergedAt": "2026-09-01T07:00:00Z"},
+    ]
+    result = rsa.refresh_one(13812, dry_run=True, merged_window=merged_window)
+    assert result["would_refresh"] is False
+    assert result["refreshed"] is False
+    assert result["always_on_failing"] is False
+
+
+def test_refresh_one_refreshes_when_stale_failing(fake_run):
+    """If Always-on guards is failing AND guard_pass=True, refresh.
+
+    The founder case: G-VAR-3 stale verdict (the merged sequence has moved
+    past the PR's predecessor).
+    """
+    _setup_fake_for_pr(fake_run, 13812, PR_BODY_OK, always_on_failing=True)
+    merged_window = [
+        {"number": 999, "body": "Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #998\n",
+         "mergedAt": "2026-09-01T07:00:00Z"},
+    ]
+    # MED/docs after MED/tooling -> guard_pass=True.
+    result = rsa.refresh_one(13812, dry_run=True, merged_window=merged_window)
+    assert result["guard_pass"] is True
+    assert result["always_on_failing"] is True
+    assert result["would_refresh"] is True
+    assert result["refreshed"] is True  # dry-run, virtual
+
+
+def test_refresh_one_refuses_when_real_failing(fake_run):
+    """If Always-on guards is failing AND guard_pass=False, do NOT refresh.
+
+    A genuine G-VAR-3 adjacency (the rule is doing its job) is NOT a stale
+    verdict: the script must surface this, not pretend a marker will help.
+    """
+    body_guard = (
+        "## Quoi\n\nFixes.\n\n"
+        "Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/guard #0\n"
+    )
+    _setup_fake_for_pr(fake_run, 13869, body_guard, always_on_failing=True)
+    # Two consecutive LIGHT/guard in the merged window -> G-VAR-3 fires.
+    merged_window = [
+        {"number": 998, "body": "Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #997\n",
+         "mergedAt": "2026-09-01T05:00:00Z"},
+        {"number": 997, "body": "Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #996\n",
+         "mergedAt": "2026-09-01T04:00:00Z"},
+    ]
+    result = rsa.refresh_one(13869, dry_run=True, merged_window=merged_window)
+    assert result["guard_pass"] is False
+    assert result["always_on_failing"] is True
+    assert result["would_refresh"] is False
+    assert result["refreshed"] is False
+
+
+def test_refresh_one_handles_no_grain_tag(fake_run):
+    """If the PR body has no Grain tag, the script refuses to touch it.
+
+    A missing Grain tag is the tag-required guard's territory (#10045).
+    Refresh-adjacency would not help; the marker is misleading noise.
+    """
+    body_no_tag = "## Quoi\n\nThis PR has no Grain tag.\n"
+    _setup_fake_for_pr(fake_run, 13999, body_no_tag, always_on_failing=True)
+    result = rsa.refresh_one(13999, dry_run=True, merged_window=[])
+    assert result["guard_pass"] is False
+    assert result["would_refresh"] is False
+    assert "no Grain tag" in result["reason"]
+
+
+# --- batch behaviour (main) -------------------------------------------------
+
+
+def test_main_mixed_outcomes(fake_run, capsys, monkeypatch):
+    """Run `main` with a mix of stale-failing, real-failing, and already-passing.
+
+    Exit code: 0 (no real failures). Output: a results list, one entry per
+    PR, in the order given. Mocks `fetch_merged_prs_since.py` (no network).
+    """
+    # PR 1: stale-failing -> would_refresh.
+    _setup_fake_for_pr(fake_run, 1, PR_BODY_OK, always_on_failing=True)
+    # PR 2: already-passing -> would NOT refresh.
+    body_pass = "Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #1\n"
+    _setup_fake_for_pr(fake_run, 2, body_pass, always_on_failing=False)
+    merged_window = [
+        {"number": 1, "body": "Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/docs #0\n",
+         "mergedAt": "2026-09-01T05:00:00Z"},
+    ]
+    # fetch_merged_window must also be mocked -- it shells out to a Python
+    # script that reads `gh` and the network.
+    monkeypatch.setattr(rsa, "fetch_merged_window", lambda days=21: merged_window)
+    rc = rsa.main(["--pr", "1", "--pr", "2", "--dry-run"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert len(payload["results"]) == 2
+    assert payload["results"][0]["pr"] == 1
+    assert payload["results"][0]["would_refresh"] is True
+    assert payload["results"][1]["pr"] == 2
+    assert payload["results"][1]["would_refresh"] is False
+
+
+def test_main_exit_1_on_real_failing(fake_run, capsys, monkeypatch):
+    """A real-failing PR (always_on_failing=False, guard_pass=False) -> exit 1.
+
+    This is the diagnostic case: the guard is failing for a reason the
+    refresh cannot fix (e.g., tag-required, off-list genre). The operator
+    needs to know.
+    """
+    body_no_tag = "## Section\n\nNo grain tag here.\n"
+    _setup_fake_for_pr(fake_run, 999, body_no_tag, always_on_failing=False)
+    # No `Always-on guards` failing (it's "success" in the spec above), but
+    # `guard_pass=False` because no Grain tag -- so the route is "real fail".
+    monkeypatch.setattr(rsa, "fetch_merged_window", lambda days=21: [])
+    rc = rsa.main(["--pr", "999", "--dry-run"])
+    assert rc == 1


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #13994 cycle 83

## Founder case (2026-09-01)

myia-po-2026:CoursIA a eu 7 PRs en MERGEABLE=FALSE sur le check `Always-on-guards` alors que le verdict G-VAR-3 sous-jacent etait devenu PASS apres un merge sibling (#13888 (MED/tooling)). Le guard resout le predecesseur reel depuis la fenetre mergee 21j (`fetch_merged_prs_since.py --days 21`), mais le workflow `always-on-guards.yml` ne re-fire que sur `pull_request: synchronize, edited, reopened` -- pas sur les mouvements de la sequence mergee.

## Ce que fait le script

`scripts/ci/refresh_stale_adjacency.py` automatise le contournement :

1. **Simule** le guard `variation_adjacency_guard` localement avec la fenetre mergee COURANTE (meme code, meme fetch window).
2. **Route** selon la paire `(always-on-failing, guard-pass)` :
   - `always-on-failing=True AND guard-pass=True` -> **REFRESH** : marker HTML idempotent + `gh pr edit --body-file -` pour re-trigger `pull_request: edited`.
   - `always-on-failing=True AND guard-pass=False` -> **REFUSE** : vraie adjacence, hors scope du fix (le guard fait son travail).
   - `always-on-failing=False` -> **SKIP** : deja vert, ne pas polluer le body.
3. **Marker** : `<!-- refresh-adj: 2026-09-01T09:42:00Z -->`, idempotent (re-run = 1 ligne, timestamp mis a jour).

## Sortie / codes de retour

- **0** : toutes PRs PASS au simule, OU ont ete refresh avec succes.
- **1** : au moins une PR a un vrai fail (guard_pass=False, always_on_failing=False). Diagnostic, pas de modification.
- **2** : erreur caller (gh failure, argument manquant).

JSON structure sur stdout :
```json
{
  "results": [
    {"pr": 13812, "always_on_failing": true, "guard_pass": true,
     "would_refresh": true, "refreshed": true, ...}
  ]
}
```

## Verification

| Item | Statut |
|------|--------|
| 12 tests pytest | **12/12 PASS** (`scripts/tests/test_refresh_stale_adjacency.py`) |
| Live run #13812 | **refresh OK**, marker append, always-on-guards re-fire `pending` |
| Live run #13882 | **refresh OK**, marker append, always-on-guards re-fire `pending` |
| 7 autres PRs du DM | **SKIP** (deja `always-on-guards=success`) |
| Toujours-on-guards.yml | **INTACT** (pas touche) |
| Guard code | **INTACT** (imports `variation_adjacency_guard` seulement) |
| Catalogue | **INTACT** (regeneration interdite sur branche feature) |

## Hors scope (intentionnel)

- Ne touche PAS le code source, le guard, ou le workflow.
- Ne contourne PAS une vraie adjacence G-VAR-3 (le script simule et sort en exit 1 si la guard dit FAIL).
- Ne modifie PAS le catalogue (toujours byte-identique a `main`).

## Pre-commit

Hooks verts : `check-subprocess-encoding` (encoding='utf-8' ajoute sur les 3 `subprocess.run`), `gitleaks`, etc.

## Grain tag

`LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #13994 cycle 83`

Scope : 1 commit (bc8707b2a), +568/-0 sur 2 fichiers (script + tests).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

## Note post-edit (cycle 83)

Body edite au cycle 83 pour deplacer le tag `Grain:` en premiere ligne (il etait sous `## Grain tag` en fin de body, non detectable par le parser canonique). Le tag est maintenant conforme au format `Grain: TIER/GENRE -- lane <machine>:<workspace> -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste +568/-0.