### PR TITLE
fix(tests,#13988): import pytest in 5 tests calling pytest.main without import

### DIFF
--- a/scripts/tests/test_base_not_main_no_paths_filter.py
+++ b/scripts/tests/test_base_not_main_no_paths_filter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/scripts/tests/test_candidate_delivered.py
+++ b/scripts/tests/test_candidate_delivered.py
@@ -15,6 +15,8 @@ the verdicts measured firsthand on the #10466 sample:
 import sys
 import os
 
+import pytest
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from candidate_delivered import classify, is_epic, _parse_cross_ref_events  # noqa: E402

--- a/scripts/tests/test_pr_close_keyword_guard.py
+++ b/scripts/tests/test_pr_close_keyword_guard.py
@@ -17,6 +17,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 # Make ``scripts/ci`` importable (sibling of ``scripts/tests``).
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
 

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 

--- a/scripts/tests/test_variation_genre_recensement.py
+++ b/scripts/tests/test_variation_genre_recensement.py
@@ -11,6 +11,8 @@ reader on every form the CI guard accepts.
 import os
 import sys
 
+import pytest
+
 # Make scripts/ importable (sibling of tests/), same pattern as test_grain_tag.py
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13997 cycle 83

## Contexte (#13988)

Issue #13988 nommee par Hermes en review de #13917 (LGTM avec note mineure, non bloquant). Le bloc __main__ de `scripts/tests/test_workflow_dispatch_revalidate.py` appelle `pytest.main` SANS `import pytest` — **code mort trompeur** : `python <file>` direct conclut a un test casse alors que la suite pytest est verte (2 passed 0.94s).

L'audit `grep -rn 'pytest.main' scripts/tests/` montre que le motif est **REPANDU** : 14 tests appellent pytest.main, dont 7 SANS import pytest. Le ticket dit explicitement : « si le motif est repandu, l'aligner plutot que de le retirer isolement ».

## Cohorte identifiee (sur origin/main)

5 fichiers BUG fixes ici :
- test_base_not_main_no_paths_filter.py
- test_candidate_delivered.py
- test_pr_close_keyword_guard.py
- test_series_saturation.py
- test_variation_genre_recensement.py

Le 6e cas (#13917) sera corrige par son merge. Le 7e cas initialement cru (test_setup_hooks_selftest) etait un faux positif : il a bien un import pytest (le grep "^import pytest" ne matchait pas a cause de la position, mais `pytest` est bien dans le namespace).

## Fix

Ajout de la ligne `import pytest` au bloc d'imports stdlib de chaque fichier BUG, alignement avec les 7 fichiers OK deja conformes. Aucune autre modification.

```diff
 from __future__ import annotations

 import sys
 from pathlib import Path

+import pytest
+
 import yaml
```

## Verification

| Item | Avant | Apres |
|------|-------|-------|
| `pytest <each file>` (canonique) | 98/98 PASS | 98/98 PASS |
| `python test_base_not_main_no_paths_filter.py` | NameError pytest | 3 passed 0.05s |
| `python test_series_saturation.py` | NameError pytest | 2 passed |
| `python test_variation_genre_recensement.py` | NameError pytest | 79 passed |

## Hors scope

- Aucun toucher au code source, harnais, CI workflows, catalogue, ou autres tests.
- Le 6e cas (PR #13917) sera corrige par son merge.

## Grain tag (contexte)

`LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13997 cycle 83`

Scope : 1 commit (73bdb91e8), 5 fichiers, +9/-0.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

## Note post-edit (cycle 83)

Body edite au cycle 83 pour deplacer le tag `Grain:` en premiere ligne (il etait sous `## Grain tag` en fin de body, non detectable par le parser canonique). Le tag est maintenant conforme au format `Grain: TIER/GENRE -- lane <machine>:<workspace> -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste +9/-0.