### PR TITLE
fix(data,#13989): refresh DATASET_REGISTRY drift on 2 Argument_Analysis CSVs

### DIFF
--- a/docs/notebook-metadata/DATASET_REGISTRY.md
+++ b/docs/notebook-metadata/DATASET_REGISTRY.md
@@ -116,8 +116,8 @@ Chaque ligne du registre respecte le schéma :
 
 | Chemin | Taille (B) | SHA256 (16 hex) | Licence | Catégorie | Usage | Card |
 |--------|----------:|-----------------|---------|-----------|-------|------|
-| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_fallacies_taxonomy.csv` | 4 069 575 | `3ff86bb20f78bf8…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie sophismes Argumentum | — |
-| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_virtues_taxonomy.csv` | 997 855 | `c5af3145e392339…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie vertus Argumentum | — |
+| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_fallacies_taxonomy.csv` | 4 139 986 | `457ca19a40d5587…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie sophismes Argumentum | — |
+| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_virtues_taxonomy.csv` | 921 641 | `fb3b0bbc5b1e3f2…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie vertus Argumentum | — |
 
 ### SymbolicAI / SemanticWeb (1)
 


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13998

## Contexte (#13989)

Issue #13989 ouverte par NanoClaw en review de #13918 : la ligne de `DATASET_REGISTRY` pour `argumentum_fallacies_taxonomy.csv` est perimee. Le ticket prevenait explicitement : « **une seule ligne perimee est rarement seule** ».

## Audit prealable

`python scripts/audit/check_dataset_registry.py` AVANT le fix :

```
global_status: DRIFT
total_entries: 31
drift_count: 2
  - argumentum_fallacies_taxonomy.csv : 4 069 575 -> 4 139 986
                                        sha 3ff86bb2... -> 457ca19a40d5587b
  - argumentum_virtues_taxonomy.csv   :   997 855 ->   921 641
                                        sha c5af3145... -> fb3b0bbc5b1e3f20
```

Les 2 fichiers du dossier `Argument_Analysis/data/` ont dérivé. Source presumée : PR #13554 « resync taxonomies Argumentum verbatim + garde d'integrite » (commit 5df176913) a remis a jour les blobs sur disque sans rafraichir la ligne correspondante dans le DATASET_REGISTRY.

## Fix

Refresh des 2 lignes (taille + SHA truncated 16 hex avec suffixe `…`) avec les valeurs actuelles.

```diff
-| argumentum_fallacies_taxonomy.csv | 4 069 575 | 3ff86bb20f78bf8… | ODbL-1.0 | ... |
-| argumentum_virtues_taxonomy.csv   |   997 855 | c5af3145e392339… | ODbL-1.0 | ... |
+| argumentum_fallacies_taxonomy.csv | 4 139 986 | 457ca19a40d5587… | ODbL-1.0 | ... |
+| argumentum_virtues_taxonomy.csv   |   921 641 | fb3b0bbc5b1e3f2… | ODbL-1.0 | ... |
```

## Verification

Re-run du validateur APRES le fix :

```
global_status: OK
total_entries: 31
ok_truncated_count: 31
drift_count: 0
missing_count: 0
card_required_count: 0
```

Plus aucune derive. Le garde d'integrite fonctionnait — c'est sa mission, il detectait correctement. Le defaut etait que personne n'avait reactualise le registre apres la derniere resync (#13554).

## Hors scope

- `check_dataset_registry.py` : intact (le validateur detectait deja correctement)
- Autres 29 entrees : deja OK_TRUNCATED, pas touchees
- Catalogue : byte-identique a main (la regeneration automatique par le cron quotidien ; pas de touche manuelle sur branche feature)
- Code des notebooks : pas touche

## Grain tag (contexte)

`LIGHT/data -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13998 cycle 83`

Scope : 1 commit (b15e30906), 1 fichier, +2/-2 (2 lignes, 4 cellules de tableau).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

## Note post-edit (cycle 84)

Body edite au cycle 84 pour deplacer le tag `Grain:` en premiere ligne (il etait sous `## Grain tag` en fin de body, non detectable par le parser canonique). Le tag est maintenant conforme au format `Grain: TIER/GENRE -- lane <machine>:<workspace> -- prev: TIER/GENRE #N`. Pas de modification de code ; le diff reste +2/-2.

## Grain tag (cycle 100 repair)

Genre original `data` n'est pas dans le canonical enum (`scripts/grain_tag.py:654-670`). Plus proche = `tooling` : c'est un fix de cohérence registre (DATASET_REGISTRY refresh SHA + taille), pas une création/modification de dataset. Tier conservé en LIGHT.

**Why**: ai-01 DM msg-20260901T120647-71eeve a flagué la classe "tag non parseable" comme P0 repair sous cap G-VAR-2. Body-edit only (~1 run `edited`) vs push (~30 runs) — file à 166.

**How to apply**: prochaine PR de drift/refresh/sync sur registre → L1 doit utiliser un genre canonical. Ref `scripts/grain_tag.py` l.654-670 pour la liste à jour.

Validation : L1 matche `_GRAIN_FULL_RE = r"Grain[\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)"` (case-insensitive). TIER ∈ {DEEP, MED, LIGHT}. GENRE ∈ 16 canonicals.
