### PR TITLE
feat(adk): exécuter Lab12 avec Google ADK réel

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -612,9 +612,11 @@
    "source": [
     "## 5. Orchestrateur DS-STAR complet\n",
     "\n",
-    "`DSStarPipeline` assemble FileAnalyzer, les trois rôles Google ADK et l'Executor local dans une boucle **Analyze → Plan → Code → Execute → Verify**.\n",
+    "`DSStarPipeline` assemble FileAnalyzer, les trois rôles Google ADK et l'Executor local dans une boucle **Analyze → Plan → Code → Execute → Verify**. C'est le cœur du workshop : là où les labs précédents isolaient un composant (Lab 10 FileAnalyzer, Lab 11 Planner-Coder), celui-ci montre la **composition** et surtout la **boucle d'itération**, l'implémentation du pattern « plan-execute-verify-refine » de la littérature DS-STAR.\n",
     "\n",
-    "À chaque itération, la trace conserve les identifiants de session, le nombre d'événements, ainsi que les appels et réponses d'outil. Un échec de code ou un verdict `NEEDS_REFINEMENT` enrichit le contexte avant la tentative suivante. La boucle est asynchrone parce que chaque rôle traverse réellement `Runner.run_async` ; elle ne se contente plus d'appeler un client LLM direct sous un nom d'agent."
+    "À chaque itération, la trace conserve les identifiants de session, le nombre d'événements, ainsi que les appels et réponses d'outil. Un échec de code ou un verdict `NEEDS_REFINEMENT` enrichit le contexte avant la tentative suivante : l'erreur exacte de l'Executor et le verdict du Verifier sont ajoutés au contexte (`Tentative N : erreur=..., verdict=..., corrige le code.`) avant que Planner et Coder ne rejouent avec ce supplément d'information. La boucle est asynchrone parce que chaque rôle traverse réellement `Runner.run_async` ; elle ne se contente plus d'appeler un client LLM direct sous un nom d'agent.\n",
+    "\n",
+    "`max_iterations` borne le nombre de tentatives. Le défaut `2` laisse une seconde chance après un premier échec, et c'est la valeur utilisée dans les sections 7 et 8. Si toutes les itérations échouent, le pipeline rend un résultat explicite — erreur, verdict, code généré et preuve collectée — plutôt qu'un échec silencieux."
    ]
   },
   {
@@ -1026,7 +1028,22 @@
     "\n",
     "La sortie précédente est une preuve de bout en bout, pas un simple texte de modèle. Elle montre trois sessions ADK distinctes et le round-trip `get_file_schema` du Planner. Le code du Coder a réellement été exécuté sur `df`, puis son résultat a été confronté à l'agrégation Pandas calculée indépendamment dans la même cellule.\n",
     "\n",
-    "Les assertions portent donc sur trois niveaux complémentaires : protocole ADK, verdict du Verifier et exactitude métier du nom **et** du montant. Toute divergence fait échouer le notebook au lieu d'être reformulée après coup dans cette prose."
+    "**Analyse de la sortie** :\n",
+    "\n",
+    "| Étape | Rôle | Détail observable |\n",
+    "|-------|------|-------------------|\n",
+    "| Analyse locale | FileAnalyzer | Profil déterministe du CSV, sans appel LLM caché |\n",
+    "| Planification | Planner ADK | Session dédiée, appel **et** réponse d'outil `get_file_schema` |\n",
+    "| Génération | Coder ADK | Bloc `python` extrait de la réponse, contenant le groupby demandé |\n",
+    "| Exécution | Executor | `success=True`, sortie imprimée sur le DataFrame déjà chargé |\n",
+    "| Vérification | Verifier ADK | Verdict préfixé `SUCCESS` suivi de sa justification |\n",
+    "| Oracle métier | Pandas | Produit et revenu recalculés hors pipeline, comparés à la sortie |\n",
+    "\n",
+    "Dans le bloc « Preuve ADK » de la sortie, chaque rôle apparaît avec son identifiant de session, son nombre d'événements et ses échanges d'outils : le Planner y montre le couple appel/réponse `get_file_schema`, tandis que Coder et Verifier terminent en un seul événement de réponse finale — ils n'ont pas d'outil à invoquer. Cette trace observable est ce qui distingue une exécution d'agent d'un simple appel de complétion déguisé.\n",
+    "\n",
+    "Les assertions portent donc sur trois niveaux complémentaires : protocole ADK (le round-trip d'outil a bien eu lieu), verdict du Verifier et exactitude métier du nom **et** du montant (tolérance de 0,02 sur le revenu total). Toute divergence fait échouer le notebook au lieu d'être reformulée après coup dans cette prose.\n",
+    "\n",
+    "> **Leçon pédagogique** : un verdict LLM positif n'est pas une preuve. Le Verifier ADK peut se montrer indulgent ou valider une réponse bien formulée mais fausse ; l'oracle Pandas, lui, est déterministe. La sortie exécutée doit donc contenir le montant attendu à la tolérance près, quoi que déclare l'agent. Un pipeline agentique crédible sépare toujours le jugement génératif de la vérification falsifiable."
    ]
   },
   {
@@ -1089,7 +1106,15 @@
    "source": [
     "### Exercice d'extension du pipeline\n",
     "\n",
-    "La cellule précédente reste volontairement un **exercice** : elle invite à déclencher une autre analyse après configuration du provider, sans fournir la solution. Le workshop a déjà exécuté le pipeline réel dans l'exemple guidé ci-dessus ; ce stub sert à modifier la question, le nombre d'itérations ou le provider sans confondre démonstration résolue et travail étudiant."
+    "La cellule précédente reste volontairement un **exercice** : elle invite à déclencher une autre analyse après configuration du provider, sans fournir la solution. Le workshop a déjà exécuté le pipeline réel dans l'exemple guidé ci-dessus ; ce squelette commenté sert à modifier la question, le nombre d'itérations ou le provider sans confondre démonstration résolue et travail étudiant. Il est conforme à la convention des notebooks : ni appel débranché ni erreur volontaire, uniquement un `TODO étudiant` à compléter.\n",
+    "\n",
+    "**Pistes d'extension** :\n",
+    "\n",
+    "- Changer la question métier : unités vendues par région, produit au revenu médian, mois le plus faible — et écrire l'oracle Pandas correspondant **avant** de lancer le pipeline.\n",
+    "- Ajuster `max_iterations` (le baisser à 1 pour observer un échec sans retente, le monter pour une question plus difficile) et lire la différence dans le champ `iterations` du résultat.\n",
+    "- Explorer le dictionnaire renvoyé : `success`, `iterations`, `verdict`, `code` et surtout `evidence`, qui conserve pour chaque rôle l'identifiant de session, le nombre d'événements et les échanges d'outils.\n",
+    "\n",
+    "La démarche attendue est celle des sections 7 et 8 : formuler l'oracle avant de lire la sortie de l'agent, pour que la comparaison reste une vérification indépendante et non une justification a posteriori. Un bon réflexe d'agentique : ce qu'un LLM affirme se vérifie, ce qu'un calcul déterministe produit se constate."
    ]
   },
   {
@@ -1252,7 +1277,15 @@
     "\n",
     "La cellule précédente expose de nouveau les événements des trois rôles, puis affiche côte à côte les totaux Pandas attendus et la sortie réellement produite par le code du Coder. Le schéma transmis contient explicitement `date` et `revenue`, ce qui réduit la dérive de vocabulaire tout en laissant au LLM la responsabilité de construire l'analyse.\n",
     "\n",
-    "Le test ne se contente pas de rechercher le mot `SUCCESS` : chaque total mensuel calculé indépendamment doit apparaître dans la sortie capturée par l'Executor. L'agent reste génératif, mais son résultat est évalué par un invariant métier déterministe."
+    "**Points clés** :\n",
+    "\n",
+    "1. **Question plus exigeante** : convertir `date` en datetime, agréger par période, afficher chaque mois — trois étapes où le code peut dévier, contre une seule pour l'agrégation par produit.\n",
+    "2. **Pièges attrapés par l'oracle** : une colonne inventée (`revenu` au lieu de `revenue`), une agrégation sur la mauvaise métrique ou un mois manquant font échouer l'assertion, même si le Verifier ADK déclarait `SUCCESS`.\n",
+    "3. **Détail d'API réel** : l'instruction du Coder impose `freq='ME'` ; l'alias historique `'M'` est déprécié par Pandas pour les périodes mensuelles, et il reste fréquent dans les exemples plus anciens — le prompt ancre donc le code généré sur ce qu'attend la version installée.\n",
+    "\n",
+    "Le test ne se contente pas de rechercher le mot `SUCCESS` : chaque total mensuel calculé indépendamment doit apparaître dans la sortie capturée par l'Executor. L'agent reste génératif, mais son résultat est évalué par un invariant métier déterministe.\n",
+    "\n",
+    "> **Leçon pédagogique** : plus la transformation demandée est riche (typage temporel, agrégation, formatage), plus l'oracle doit être précis. Comparer chaque total mensuel un à un coûte trois lignes de Pandas et attrape des erreurs qu'aucun verdict LLM ne détecterait."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.005718,
-     "end_time": "2026-05-13T22:34:22.599579+00:00",
+     "duration": 0.003793,
+     "end_time": "2026-09-01T08:01:54.109071+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:22.593861+00:00",
+     "start_time": "2026-09-01T08:01:54.105278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.008298,
-     "end_time": "2026-05-13T22:34:22.615640+00:00",
+     "duration": 0.003033,
+     "end_time": "2026-09-01T08:01:54.115357+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:22.607342+00:00",
+     "start_time": "2026-09-01T08:01:54.112324+00:00",
      "status": "completed"
     },
     "tags": []
@@ -52,7 +52,9 @@
    "source": [
     "## 1. Configuration\n",
     "\n",
-    "Ce workshop assemble le **pipeline DS-STAR complet** (FileAnalyzer -> Planner -> Coder -> Executor -> Verifier) et l'exerce sur un dataset de ventes. La configuration importe les briques standards (`pandas`, `numpy`), les structures de contrat (`dataclass`, `Enum`) et le client LLM partagé (`LLMClient`). Comme dans les labs précédents, le `sys.path.insert` expose les modules `config` et `utils` communs à la série Track2-GoogleADK."
+    "Ce workshop assemble le pipeline **FileAnalyzer → Planner ADK → Coder ADK → Executor → Verifier ADK** et l'exerce sur un dataset de ventes. Les rôles de raisonnement utilisent le runtime partagé `utils.adk_runtime`, qui construit de vrais agents Google ADK sur le provider actif de la série.\n",
+    "\n",
+    "Le `sys.path.insert` expose les modules `config` et `utils` communs à Track2. `LLMClient` reste importé uniquement pour les exercices de compatibilité en fin de notebook ; le pipeline démontré n'appelle pas directement LiteLLM et ne contient aucun endpoint ni secret en dur."
    ]
   },
   {
@@ -61,16 +63,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T07:59:57.489521Z",
-     "iopub.status.busy": "2026-08-20T07:59:57.489354Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.595889Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.594883Z"
+     "iopub.execute_input": "2026-09-01T08:01:54.122460Z",
+     "iopub.status.busy": "2026-09-01T08:01:54.122287Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.458968Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.458478Z"
     },
     "papermill": {
-     "duration": 10.695611,
-     "end_time": "2026-05-13T22:34:33.316977+00:00",
+     "duration": 4.341102,
+     "end_time": "2026-09-01T08:01:58.459457+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:22.621366+00:00",
+     "start_time": "2026-09-01T08:01:54.118355+00:00",
      "status": "completed"
     },
     "tags": []
@@ -80,13 +82,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports et configuration charges.\n"
+      "Imports OK : pandas, numpy, LLMClient et runtime Google ADK réel\n"
      ]
     }
    ],
    "source": [
     "import sys\n",
-    "sys.path.insert(0, '..')\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path().resolve().parent))\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=r\"\\[EXPERIMENTAL\\] feature FeatureName.JSON_SCHEMA_FOR_FUNC_DECL is enabled\\.\",\n",
+    "    category=UserWarning,\n",
+    "    module=r\"google\\.adk\\.models\\.llm_request\",\n",
+    ")\n",
     "\n",
     "import os\n",
     "import json\n",
@@ -96,12 +107,12 @@
     "from typing import Optional, Dict, List, Tuple\n",
     "from dataclasses import dataclass, asdict\n",
     "from enum import Enum\n",
-    "from pathlib import Path\n",
     "\n",
     "from config import get_settings\n",
     "from utils import LLMClient\n",
+    "from utils.adk_runtime import build_agent, run_agent_turn\n",
     "\n",
-    "print(\"Imports et configuration charges.\")"
+    "print(\"Imports OK : pandas, numpy, LLMClient et runtime Google ADK réel\")"
    ]
   },
   {
@@ -109,16 +120,16 @@
    "id": "1198781a",
    "metadata": {
     "papermill": {
-     "duration": 0.005232,
-     "end_time": "2026-05-13T22:34:33.327605+00:00",
+     "duration": 0.002648,
+     "end_time": "2026-09-01T08:01:58.464923+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.322373+00:00",
+     "start_time": "2026-09-01T08:01:58.462275+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "`get_settings()` charge la configuration du provider LLM (clé, endpoint, modèle actif). L'affichage du provider (`openrouter` ici) est un diagnostic rapide : avant de lancer un pipeline multi-agent coûteux en appels, on vérifie que le bon backend est branché."
+    "`get_settings()` charge le provider actif sans afficher de clé ni d'endpoint sensible. Ce diagnostic précède les appels multi-agents : il permet d'attribuer les sorties au provider réellement configuré, tandis que le modèle ADK est construit par le runtime partagé."
    ]
   },
   {
@@ -127,16 +138,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.598452Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.597825Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.603853Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.603152Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.471399Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.471110Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.476225Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.475717Z"
     },
     "papermill": {
-     "duration": 0.019629,
-     "end_time": "2026-05-13T22:34:33.352371+00:00",
+     "duration": 0.009353,
+     "end_time": "2026-09-01T08:01:58.476873+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.332742+00:00",
+     "start_time": "2026-09-01T08:01:58.467520+00:00",
      "status": "completed"
     },
     "tags": []
@@ -146,7 +157,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Provider: vllm\n"
+      "Provider: openai\n"
      ]
     }
    ],
@@ -160,10 +171,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.005318,
-     "end_time": "2026-05-13T22:34:33.362825+00:00",
+     "duration": 0.002854,
+     "end_time": "2026-09-01T08:01:58.482881+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.357507+00:00",
+     "start_time": "2026-09-01T08:01:58.480027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -185,16 +196,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.606181Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.605901Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.611826Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.611161Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.489438Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.489293Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.494677Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.494209Z"
     },
     "papermill": {
-     "duration": 0.019173,
-     "end_time": "2026-05-13T22:34:33.387268+00:00",
+     "duration": 0.009235,
+     "end_time": "2026-09-01T08:01:58.495044+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.368095+00:00",
+     "start_time": "2026-09-01T08:01:58.485809+00:00",
      "status": "completed"
     },
     "tags": []
@@ -245,10 +256,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.005242,
-     "end_time": "2026-05-13T22:34:33.398263+00:00",
+     "duration": 0.003001,
+     "end_time": "2026-09-01T08:01:58.500920+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.393021+00:00",
+     "start_time": "2026-09-01T08:01:58.497919+00:00",
      "status": "completed"
     },
     "tags": []
@@ -267,16 +278,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.614823Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.614337Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.621017Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.620290Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.507410Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.507255Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.512171Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.511723Z"
     },
     "papermill": {
-     "duration": 0.018757,
-     "end_time": "2026-05-13T22:34:33.422535+00:00",
+     "duration": 0.008943,
+     "end_time": "2026-09-01T08:01:58.512761+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.403778+00:00",
+     "start_time": "2026-09-01T08:01:58.503818+00:00",
      "status": "completed"
     },
     "tags": []
@@ -286,42 +297,54 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FileAnalyzer pret.\n"
+      "FileAnalyzer prêt : profil CSV déterministe sans appel LLM caché\n"
      ]
     }
    ],
    "source": [
     "class FileAnalyzer:\n",
-    "    \"\"\"Analyse automatique de fichiers de donnees.\"\"\"\n",
-    "    SUPPORTED = {'.csv': 'csv', '.json': 'json', '.xlsx': 'excel'}\n",
+    "    \"\"\"Analyse déterministe de fichiers de données avant les tours ADK.\"\"\"\n",
     "\n",
-    "    def __init__(self, llm_client=None):\n",
-    "        self.llm = llm_client or LLMClient()\n",
+    "    SUPPORTED = {'.csv': 'csv', '.json': 'json', '.xlsx': 'excel'}\n",
     "\n",
     "    def analyze_csv(self, path: str) -> FileMetadata:\n",
     "        df = pd.read_csv(path)\n",
-    "        cols = []\n",
-    "        for c in df.columns:\n",
-    "            info = {'name': c, 'dtype': str(df[c].dtype), 'missing_pct': round(df[c].isna().mean()*100, 2)}\n",
-    "            if df[c].dtype in ['int64', 'float64']:\n",
-    "                info['stats'] = {'min': float(df[c].min()), 'max': float(df[c].max()), 'mean': float(df[c].mean())}\n",
-    "            cols.append(info)\n",
+    "        columns = []\n",
+    "        for name in df.columns:\n",
+    "            info = {\n",
+    "                'name': name,\n",
+    "                'dtype': str(df[name].dtype),\n",
+    "                'missing_pct': round(df[name].isna().mean() * 100, 2),\n",
+    "            }\n",
+    "            if pd.api.types.is_numeric_dtype(df[name]):\n",
+    "                info['stats'] = {\n",
+    "                    'min': float(df[name].min()),\n",
+    "                    'max': float(df[name].max()),\n",
+    "                    'mean': float(df[name].mean()),\n",
+    "                }\n",
+    "            columns.append(info)\n",
     "        return FileMetadata(\n",
-    "            filename=Path(path).name, format='csv', size_bytes=os.path.getsize(path),\n",
-    "            num_rows=len(df), num_columns=len(df.columns), columns=cols,\n",
-    "            sample_data=df.head(3).to_dict('records')\n",
+    "            filename=Path(path).name,\n",
+    "            format='csv',\n",
+    "            size_bytes=os.path.getsize(path),\n",
+    "            num_rows=len(df),\n",
+    "            num_columns=len(df.columns),\n",
+    "            columns=columns,\n",
+    "            sample_data=df.head(3).to_dict('records'),\n",
     "        )\n",
     "\n",
     "    def generate_context(self, meta: FileMetadata) -> str:\n",
-    "        lines = [f\"Fichier: {meta.filename}\", f\"Format: {meta.format}\", f\"Taille: {meta.size_bytes/1024:.1f} KB\"]\n",
-    "        if meta.num_rows:\n",
-    "            lines.append(f\"Lignes: {meta.num_rows}, Colonnes: {meta.num_columns}\")\n",
-    "        if meta.columns:\n",
-    "            for c in meta.columns[:5]:\n",
-    "                lines.append(f\"  - {c['name']} ({c['dtype']})\")\n",
-    "        return \"\\\\n\".join(lines)\n",
+    "        lines = [\n",
+    "            f\"Fichier: {meta.filename}\",\n",
+    "            f\"Format: {meta.format}\",\n",
+    "            f\"Taille: {meta.size_bytes / 1024:.1f} KB\",\n",
+    "            f\"Lignes: {meta.num_rows}, Colonnes: {meta.num_columns}\",\n",
+    "        ]\n",
+    "        for column in (meta.columns or [])[:5]:\n",
+    "            lines.append(f\"  - {column['name']} ({column['dtype']})\")\n",
+    "        return \"\\n\".join(lines)\n",
     "\n",
-    "print(\"FileAnalyzer pret.\")"
+    "print(\"FileAnalyzer prêt : profil CSV déterministe sans appel LLM caché\")"
    ]
   },
   {
@@ -329,24 +352,24 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.005237,
-     "end_time": "2026-05-13T22:34:33.432533+00:00",
+     "duration": 0.002674,
+     "end_time": "2026-09-01T08:01:58.518204+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.427296+00:00",
+     "start_time": "2026-09-01T08:01:58.515530+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. Planner-Coder-Verifier Modules\n",
+    "## 4. Planner-Coder-Verifier sur Google ADK\n",
     "\n",
-    "Cette section définit les trois agents de raisonnement du pipeline DS-STAR. Ils partagent tous le même client LLM (injecté à la construction) mais utilisent des **températures différentes** selon leur rôle :\n",
+    "Les trois rôles de raisonnement sont désormais de vrais `google.adk.agents.Agent`, exécutés dans des sessions distinctes par un `Runner` :\n",
     "\n",
-    "- **Planner** (température 0.3) : décompose la question en étapes — un peu de variabilité   pour explorer des plans, mais assez peu pour rester cohérent.\n",
-    "- **Coder** (température 0.2) : génère du code Python — quasi-déterministe, on veut de la fiabilité.\n",
-    "- **Verifier** (température 0.1) : juge si le résultat répond à la question — le plus   froid possible pour un verdict stable.\n",
+    "- **Planner ADK** : appelle obligatoirement l'outil déterministe `get_file_schema`, puis produit un plan structuré ;\n",
+    "- **Coder ADK** : transforme ce plan en code Pandas visible et exécutable ;\n",
+    "- **Verifier ADK** : confronte la sortie à la question et rend un verdict actionnable.\n",
     "\n",
-    "L'**Executor** et le **Verifier** complètent la boucle : exécution sandbox puis validation. Le Verifier court-circuite en `FAILED` sans appeler le LLM si l'exécution a levé une exception — une économie d'appels quand le code ne tourne pas."
+    "L'**Executor** reste local : ADK porte les rôles LLM et leurs événements, tandis que le code généré demeure inspectable. Les anciennes classes synchrones basées sur `LLMClient` ne sont plus utilisées par le pipeline du workshop ; `LLMClient` reste seulement dans les exercices qui demandent d'étendre un composant historique."
    ]
   },
   {
@@ -355,16 +378,16 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.623439Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.622902Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.628573Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.628005Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.524505Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.524318Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.527405Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.526949Z"
     },
     "papermill": {
-     "duration": 0.01598,
-     "end_time": "2026-05-13T22:34:33.453667+00:00",
+     "duration": 0.007018,
+     "end_time": "2026-09-01T08:01:58.527848+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.437687+00:00",
+     "start_time": "2026-09-01T08:01:58.520830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -374,39 +397,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Planner pret.\n"
+      "Planner ADK : construit dans DSStarPipeline et exécuté par run_agent_turn avec l'outil get_file_schema\n"
      ]
     }
    ],
    "source": [
-    "class Planner:\n",
-    "    def __init__(self, llm: LLMClient):\n",
-    "        self.llm = llm\n",
-    "\n",
-    "    def create_plan(self, question: str, context: str) -> Plan:\n",
-    "        prompt = f\"\"\"Planifie l'analyse pour cette question.\n",
-    "\n",
-    "CONTEXTE: {context[:800]}\n",
-    "QUESTION: {question}\n",
-    "\n",
-    "Donne 2-3 etapes simples. Format:\n",
-    "REASONING: [raisonnement]\n",
-    "STEPS:\n",
-    "1. [etape 1]\n",
-    "2. [etape 2]\"\"\"\n",
-    "        response = self.llm.generate(prompt, temperature=0.3)\n",
-    "        steps, reasoning = [], \"\"\n",
-    "        in_steps = False\n",
-    "        for line in response.split('\\n'):\n",
-    "            if line.startswith('REASONING:'):\n",
-    "                reasoning = line.replace('REASONING:', '').strip()\n",
-    "            elif line.startswith('STEPS:'):\n",
-    "                in_steps = True\n",
-    "            elif in_steps and re.match(r'^\\d+\\.', line.strip()):\n",
-    "                steps.append(re.sub(r'^\\d+\\.\\s*', '', line.strip()))\n",
-    "        return Plan(steps=steps, reasoning=reasoning)\n",
-    "\n",
-    "print(\"Planner pret.\")"
+    "print(\n",
+    "    \"Planner ADK : construit dans DSStarPipeline et exécuté par \"\n",
+    "    \"run_agent_turn avec l'outil get_file_schema\"\n",
+    ")"
    ]
   },
   {
@@ -414,18 +413,18 @@
    "id": "57a57910",
    "metadata": {
     "papermill": {
-     "duration": 0.004728,
-     "end_time": "2026-05-13T22:34:33.463629+00:00",
+     "duration": 0.003452,
+     "end_time": "2026-09-01T08:01:58.534068+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.458901+00:00",
+     "start_time": "2026-09-01T08:01:58.530616+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "Le **Planner** reçoit le contexte du fichier + la question et produit un `Plan`. Le prompt impose un format structuré (`REASONING:` / `STEPS:` numérotés) que le parseur par regex extrait — approche simple mais fragile, comme le montreront les tests des sections 7 et 8 où le contexte incomplet cause des échecs. La fenêtre de contexte est tronquée à 800 caractères pour rester dans les limites du prompt.\n",
+    "Le **Planner** n'est plus un wrapper synchrone autour de `LLMClient`. `DSStarPipeline` construit un véritable `Agent` Google ADK et lui impose un appel à `get_file_schema` avant la rédaction du plan. La trace d'événements permet ensuite de vérifier le round-trip de cet outil.\n",
     "\n",
-    "Le **Coder** traduit ensuite ce plan en code Python."
+    "Le **Coder** est lui aussi un agent ADK distinct ; son prompt reçoit le plan et le schéma exact du DataFrame déjà chargé."
    ]
   },
   {
@@ -434,16 +433,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.631427Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.630972Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.637456Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.636683Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.540549Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.540396Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.543308Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.542913Z"
     },
     "papermill": {
-     "duration": 0.015183,
-     "end_time": "2026-05-13T22:34:33.483850+00:00",
+     "duration": 0.007276,
+     "end_time": "2026-09-01T08:01:58.544130+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.468667+00:00",
+     "start_time": "2026-09-01T08:01:58.536854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -453,28 +452,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Coder pret.\n"
+      "Coder ADK : construit dans DSStarPipeline et contraint à produire un bloc Python exécutable sur df\n"
      ]
     }
    ],
    "source": [
-    "class Coder:\n",
-    "    def __init__(self, llm: LLMClient):\n",
-    "        self.llm = llm\n",
-    "\n",
-    "    def generate_code(self, plan: Plan, context: str) -> str:\n",
-    "        steps_text = '\\n'.join(f\"{i+1}. {s}\" for i, s in enumerate(plan.steps))\n",
-    "        prompt = f\"\"\"Genere du code Python pour ce plan.\n",
-    "PLAN: {steps_text}\n",
-    "DataFrame disponible: 'df'. Utilise print() pour les resultats.\n",
-    "```python\n",
-    "[ton code]\n",
-    "```\"\"\"\n",
-    "        response = self.llm.generate(prompt, temperature=0.2)\n",
-    "        match = re.search(r'```python\\s*(.*?)\\s*```', response, re.DOTALL)\n",
-    "        return match.group(1).strip() if match else response\n",
-    "\n",
-    "print(\"Coder pret.\")"
+    "print(\n",
+    "    \"Coder ADK : construit dans DSStarPipeline et contraint à produire \"\n",
+    "    \"un bloc Python exécutable sur df\"\n",
+    ")"
    ]
   },
   {
@@ -482,18 +468,18 @@
    "id": "e676dc6d",
    "metadata": {
     "papermill": {
-     "duration": 0.005243,
-     "end_time": "2026-05-13T22:34:33.494956+00:00",
+     "duration": 0.002905,
+     "end_time": "2026-09-01T08:01:58.549871+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.489713+00:00",
+     "start_time": "2026-09-01T08:01:58.546966+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "Le **Coder** génère du code Python à partir du plan. Le prompt précise qu'un `DataFrame df` est disponible (l'Executor l'injecte dans son namespace) et demande un bloc ` ```python ` extrait par regex. Notez le fallback : si le LLM ne respecte pas le format de bloc, le Coder renvoie la réponse brute plutôt qu'une chaîne vide — choix qui évite les silences mais peut produire du code non isolé.\n",
+    "Le **Coder ADK** transforme le plan en code Python visible. Le prompt précise que le DataFrame `df` est déjà chargé par l'Executor : lire à nouveau un chemin de fichier serait une violation de l'interface. Le pipeline extrait le bloc `python` de la réponse finale, puis transmet ce code à l'Executor local.\n",
     "\n",
-    "Ce code est exécuté en sandbox par l'**Executor**."
+    "L'**Executor** garde ainsi l'action déterministe et inspectable, tandis que le raisonnement reste porté par le vrai LLM."
    ]
   },
   {
@@ -502,16 +488,16 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.639986Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.639706Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.645551Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.644687Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.557093Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.556935Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.561209Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.560671Z"
     },
     "papermill": {
-     "duration": 0.016614,
-     "end_time": "2026-05-13T22:34:33.517095+00:00",
+     "duration": 0.008805,
+     "end_time": "2026-09-01T08:01:58.561638+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.500481+00:00",
+     "start_time": "2026-09-01T08:01:58.552833+00:00",
      "status": "completed"
     },
     "tags": []
@@ -552,10 +538,10 @@
    "id": "fcdedde0",
    "metadata": {
     "papermill": {
-     "duration": 0.005365,
-     "end_time": "2026-05-13T22:34:33.527328+00:00",
+     "duration": 0.003295,
+     "end_time": "2026-09-01T08:01:58.568148+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.521963+00:00",
+     "start_time": "2026-09-01T08:01:58.564853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,16 +558,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.648141Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.647759Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.653428Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.652528Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.576177Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.575995Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.579913Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.579285Z"
     },
     "papermill": {
-     "duration": 0.015108,
-     "end_time": "2026-05-13T22:34:33.547671+00:00",
+     "duration": 0.009158,
+     "end_time": "2026-09-01T08:01:58.580380+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.532563+00:00",
+     "start_time": "2026-09-01T08:01:58.571222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -591,28 +577,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verifier pret.\n"
+      "Compatibilité pédagogique Verifier conservée ; le pipeline utilise Verifier ADK\n"
      ]
     }
    ],
    "source": [
     "class Verifier:\n",
+    "    \"\"\"Base locale conservée uniquement pour l'exercice BusinessVerifier.\"\"\"\n",
+    "\n",
     "    def __init__(self, llm: LLMClient):\n",
     "        self.llm = llm\n",
     "\n",
     "    def verify(self, question: str, result: ExecutionResult) -> Tuple[VerificationStatus, str]:\n",
     "        if not result.success:\n",
     "            return VerificationStatus.FAILED, f\"Erreur: {result.error}\"\n",
-    "        prompt = f\"\"\"Verifie ce resultat.\n",
-    "QUESTION: {question}\n",
-    "RESULTAT: {result.output[:500]}\n",
-    "Reponds SUCCESS ou NEEDS_REFINEMENT.\"\"\"\n",
-    "        response = self.llm.generate(prompt, temperature=0.1).upper()\n",
-    "        if 'SUCCESS' in response:\n",
-    "            return VerificationStatus.SUCCESS, \"OK\"\n",
-    "        return VerificationStatus.NEEDS_REFINEMENT, \"A ameliorer\"\n",
+    "        return VerificationStatus.NEEDS_REFINEMENT, \"À évaluer par l'agent ADK\"\n",
     "\n",
-    "print(\"Verifier pret.\")"
+    "print(\"Compatibilité pédagogique Verifier conservée ; le pipeline utilise Verifier ADK\")"
    ]
   },
   {
@@ -620,20 +601,20 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004954,
-     "end_time": "2026-05-13T22:34:33.557395+00:00",
+     "duration": 0.003004,
+     "end_time": "2026-09-01T08:01:58.587115+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.552441+00:00",
+     "start_time": "2026-09-01T08:01:58.584111+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. DS-STAR Orchestrator Complet\n",
+    "## 5. Orchestrateur DS-STAR complet\n",
     "\n",
-    "La classe `DSStarPipeline` assemble les cinq composants en une boucle **Analyze -> Plan -> Code -> Execute -> Verify**. C'est le cœur du workshop : là où les labs précédents isolaient un composant (Lab 10 FileAnalyzer, Lab 11 Planner-Coder), celui-ci montre la **composition** et surtout la **boucle d'itération**.\n",
+    "`DSStarPipeline` assemble FileAnalyzer, les trois rôles Google ADK et l'Executor local dans une boucle **Analyze → Plan → Code → Execute → Verify**.\n",
     "\n",
-    "Le mécanisme clé : à chaque itération, si le Verifier renvoie `NEEDS_REFINEMENT`, le contexte est enrichi du résultat partiel (`Resultat partiel: ...`) avant de retenter. C'est l'implémentation du pattern « plan-execute-verify-refine » de la littérature. Avec `max_iterations=1` (tests sections 7-8), aucune retente n'est possible — c'est volontaire pour observer les modes d'échec. Le défaut `max_iterations=2` laisse une seconde chance."
+    "À chaque itération, la trace conserve les identifiants de session, le nombre d'événements, ainsi que les appels et réponses d'outil. Un échec de code ou un verdict `NEEDS_REFINEMENT` enrichit le contexte avant la tentative suivante. La boucle est asynchrone parce que chaque rôle traverse réellement `Runner.run_async` ; elle ne se contente plus d'appeler un client LLM direct sous un nom d'agent."
    ]
   },
   {
@@ -642,16 +623,16 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.655833Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.655519Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.661528Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.660804Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.595086Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.594803Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.604990Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.604428Z"
     },
     "papermill": {
-     "duration": 0.018413,
-     "end_time": "2026-05-13T22:34:33.580837+00:00",
+     "duration": 0.014746,
+     "end_time": "2026-09-01T08:01:58.605599+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.562424+00:00",
+     "start_time": "2026-09-01T08:01:58.590853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -661,65 +642,170 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DS-STAR Pipeline complet initialise.\n"
+      "DS-STAR prêt : Planner, Coder et Verifier utilisent de vrais Agent/Runner\n"
      ]
     }
    ],
    "source": [
     "class DSStarPipeline:\n",
-    "    \"\"\"Pipeline DS-STAR complet: Analyze -> Plan -> Code -> Execute -> Verify\"\"\"\n",
+    "    \"\"\"Pipeline DS-STAR : analyse locale et rôles LLM exécutés par Google ADK.\"\"\"\n",
     "\n",
     "    def __init__(self, max_iterations: int = 2):\n",
-    "        self.llm = LLMClient()\n",
-    "        self.file_analyzer = FileAnalyzer(self.llm)\n",
-    "        self.planner = Planner(self.llm)\n",
-    "        self.coder = Coder(self.llm)\n",
-    "        self.verifier = Verifier(self.llm)\n",
+    "        self.file_analyzer = FileAnalyzer()\n",
     "        self.max_iterations = max_iterations\n",
+    "        self.run_count = 0\n",
     "\n",
-    "    def analyze_file(self, file_path: str, question: str) -> Dict:\n",
-    "        # Step 1: Analyze file\n",
-    "        print(f\"[FILE ANALYZER] Analyse de {Path(file_path).name}...\")\n",
+    "    async def analyze_file(self, file_path: str, question: str) -> Dict:\n",
+    "        self.run_count += 1\n",
+    "        run_id = f\"lab12-run-{self.run_count}\"\n",
+    "        print(f\"[FILE ANALYZER] Analyse de {Path(file_path).name} ({run_id})...\")\n",
     "        meta = self.file_analyzer.analyze_csv(file_path)\n",
     "        context = self.file_analyzer.generate_context(meta)\n",
+    "        df_local = pd.read_csv(file_path)\n",
+    "        executor = Executor(df_local)\n",
     "\n",
-    "        # Load data\n",
-    "        df = pd.read_csv(file_path)\n",
-    "        executor = Executor(df)\n",
+    "        def get_file_schema() -> Dict:\n",
+    "            \"\"\"Retourne au Planner ADK le schéma réellement analysé.\"\"\"\n",
+    "            return {\n",
+    "                \"filename\": meta.filename,\n",
+    "                \"rows\": int(meta.num_rows),\n",
+    "                \"columns\": {name: str(dtype) for name, dtype in df_local.dtypes.items()},\n",
+    "            }\n",
     "\n",
-    "        # Step 2-5: Iterative loop\n",
+    "        planner = build_agent(\n",
+    "            \"lab12_planner\",\n",
+    "            \"Planifie une analyse de fichier à partir du schéma observé.\",\n",
+    "            (\n",
+    "                \"Appelle obligatoirement get_file_schema. Réponds ensuite avec \"\n",
+    "                \"REASONING: sur une ligne, puis STEPS: et trois étapes numérotées.\"\n",
+    "            ),\n",
+    "            tools=(get_file_schema,),\n",
+    "        )\n",
+    "        coder = build_agent(\n",
+    "            \"lab12_coder\",\n",
+    "            \"Transforme un plan en code Pandas exécutable sur le DataFrame df.\",\n",
+    "            (\n",
+    "                \"Réponds uniquement avec un bloc ```python```. Le DataFrame df est \"\n",
+    "                \"déjà chargé : ne lis aucun fichier. Respecte exactement le schéma et \"\n",
+    "                \"la métrique demandée. Utilise print() pour le résultat final. Affiche \"\n",
+    "                \"les montants avec deux décimales, sans séparateur de milliers. Pour \"\n",
+    "                \"une agrégation mensuelle avec pd.Grouper, utilise freq='ME', jamais 'M'.\"\n",
+    "            ),\n",
+    "        )\n",
+    "        verifier = build_agent(\n",
+    "            \"lab12_verifier\",\n",
+    "            \"Vérifie qu'une sortie d'analyse répond à la question initiale.\",\n",
+    "            (\n",
+    "                \"Commence impérativement par SUCCESS, NEEDS_REFINEMENT ou FAILED, \"\n",
+    "                \"puis justifie en une phrase. Refuse une sortie vide ou hors schéma.\"\n",
+    "            ),\n",
+    "        )\n",
+    "\n",
+    "        evidence = {}\n",
+    "        last_result = ExecutionResult(False, \"\", \"Aucune exécution\")\n",
+    "        last_verdict = \"FAILED\"\n",
+    "        code = \"\"\n",
+    "\n",
     "        for iteration in range(self.max_iterations):\n",
-    "            print(f\"\\n=== ITERATION {iteration + 1} ===\")\n",
+    "            print(f\"\\n=== ITERATION {iteration + 1}/{self.max_iterations} ===\")\n",
     "\n",
-    "            print(\"[PLANNER] Creation du plan...\")\n",
-    "            plan = self.planner.create_plan(question, context)\n",
-    "            print(f\"Etapes: {len(plan.steps)}\")\n",
+    "            planner_session = f\"{run_id}-planner-{iteration}\"\n",
+    "            plan_turn = await run_agent_turn(\n",
+    "                planner,\n",
+    "                f\"QUESTION: {question}\\nCONTEXTE: {context}\",\n",
+    "                session_id=planner_session,\n",
+    "            )\n",
+    "            evidence[f\"planner-{iteration}\"] = {\n",
+    "                \"session_id\": planner_session,\n",
+    "                \"events\": plan_turn.event_count,\n",
+    "                \"tool_calls\": \", \".join(plan_turn.tool_calls),\n",
+    "                \"tool_responses\": \", \".join(plan_turn.tool_responses),\n",
+    "            }\n",
+    "            print(f\"[PLANNER ADK] {plan_turn.response_text[:160]}...\")\n",
     "\n",
-    "            print(\"[CODER] Generation du code...\")\n",
-    "            code = self.coder.generate_code(plan, context)\n",
+    "            coder_session = f\"{run_id}-coder-{iteration}\"\n",
+    "            code_turn = await run_agent_turn(\n",
+    "                coder,\n",
+    "                (\n",
+    "                    f\"QUESTION: {question}\\nPLAN:\\n{plan_turn.response_text}\\n\"\n",
+    "                    f\"SCHÉMA: {json.dumps(get_file_schema(), ensure_ascii=False)}\\n\"\n",
+    "                    f\"CONTEXTE: {context}\"\n",
+    "                ),\n",
+    "                session_id=coder_session,\n",
+    "            )\n",
+    "            evidence[f\"coder-{iteration}\"] = {\n",
+    "                \"session_id\": coder_session,\n",
+    "                \"events\": code_turn.event_count,\n",
+    "                \"tool_calls\": \", \".join(code_turn.tool_calls),\n",
+    "                \"tool_responses\": \", \".join(code_turn.tool_responses),\n",
+    "            }\n",
+    "            match = re.search(\n",
+    "                r\"```(?:python)?\\s*(.*?)\\s*```\",\n",
+    "                code_turn.response_text,\n",
+    "                re.DOTALL,\n",
+    "            )\n",
+    "            code = match.group(1).strip() if match else code_turn.response_text.strip()\n",
+    "            last_result = executor.execute(code)\n",
+    "            print(f\"[EXECUTOR] success={last_result.success}\")\n",
+    "            if last_result.error:\n",
+    "                print(f\"[EXECUTOR ERROR] {last_result.error}\")\n",
     "\n",
-    "            print(\"[EXECUTOR] Execution...\")\n",
-    "            result = executor.execute(code)\n",
+    "            verifier_session = f\"{run_id}-verifier-{iteration}\"\n",
+    "            verify_turn = await run_agent_turn(\n",
+    "                verifier,\n",
+    "                (\n",
+    "                    f\"QUESTION: {question}\\n\"\n",
+    "                    f\"SCHÉMA: {json.dumps(get_file_schema(), ensure_ascii=False)}\\n\"\n",
+    "                    f\"SUCCÈS EXÉCUTION: {last_result.success}\\n\"\n",
+    "                    f\"ERREUR: {last_result.error}\\nSORTIE:\\n{last_result.output[:1200]}\"\n",
+    "                ),\n",
+    "                session_id=verifier_session,\n",
+    "            )\n",
+    "            evidence[f\"verifier-{iteration}\"] = {\n",
+    "                \"session_id\": verifier_session,\n",
+    "                \"events\": verify_turn.event_count,\n",
+    "                \"tool_calls\": \", \".join(verify_turn.tool_calls),\n",
+    "                \"tool_responses\": \", \".join(verify_turn.tool_responses),\n",
+    "            }\n",
+    "            last_verdict = verify_turn.response_text.strip()\n",
+    "            print(f\"[VERIFIER ADK] {last_verdict}\")\n",
+    "            verdict_match = re.match(\n",
+    "                r\"^(SUCCESS|NEEDS_REFINEMENT|FAILED)\\b\",\n",
+    "                last_verdict.upper(),\n",
+    "            )\n",
+    "            verdict_token = verdict_match.group(1) if verdict_match else \"FAILED\"\n",
+    "            if last_result.success and verdict_token == \"SUCCESS\":\n",
+    "                return {\n",
+    "                    \"success\": True,\n",
+    "                    \"output\": last_result.output,\n",
+    "                    \"code\": code,\n",
+    "                    \"iterations\": iteration + 1,\n",
+    "                    \"verdict\": last_verdict,\n",
+    "                    \"planner_tool_round_trip\": plan_turn.tool_was_invoked,\n",
+    "                    \"evidence\": evidence,\n",
+    "                }\n",
     "\n",
-    "            if not result.success:\n",
-    "                print(f\"[ERROR] {result.error}\")\n",
-    "                context += f\"\\nErreur: {result.error}\"\n",
-    "                continue\n",
+    "            context += (\n",
+    "                f\"\\nTentative {iteration + 1}: erreur={last_result.error}; \"\n",
+    "                f\"verdict={last_verdict}; corrige le code.\"\n",
+    "            )\n",
     "\n",
-    "            print(f\"[OUTPUT] {result.output[:150]}...\")\n",
+    "        return {\n",
+    "            \"success\": False,\n",
+    "            \"output\": last_result.output,\n",
+    "            \"error\": last_result.error or \"Max iterations atteint\",\n",
+    "            \"code\": code,\n",
+    "            \"iterations\": self.max_iterations,\n",
+    "            \"verdict\": last_verdict,\n",
+    "            \"planner_tool_round_trip\": any(\n",
+    "                item[\"tool_calls\"] and item[\"tool_responses\"]\n",
+    "                for role, item in evidence.items()\n",
+    "                if role.startswith(\"planner-\")\n",
+    "            ),\n",
+    "            \"evidence\": evidence,\n",
+    "        }\n",
     "\n",
-    "            print(\"[VERIFIER] Verification...\")\n",
-    "            status, msg = self.verifier.verify(question, result)\n",
-    "            print(f\"[STATUS] {status.value}: {msg}\")\n",
-    "\n",
-    "            if status == VerificationStatus.SUCCESS:\n",
-    "                return {'success': True, 'output': result.output, 'code': code, 'iterations': iteration + 1}\n",
-    "\n",
-    "            context += f\"\\nResultat partiel: {result.output[:300]}\"\n",
-    "\n",
-    "        return {'success': False, 'output': result.output, 'error': 'Max iterations', 'iterations': self.max_iterations}\n",
-    "\n",
-    "print(\"DS-STAR Pipeline complet initialise.\")"
+    "print(\"DS-STAR prêt : Planner, Coder et Verifier utilisent de vrais Agent/Runner\")"
    ]
   },
   {
@@ -727,20 +813,20 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.004789,
-     "end_time": "2026-05-13T22:34:33.590766+00:00",
+     "duration": 0.002909,
+     "end_time": "2026-09-01T08:01:58.611584+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.585977+00:00",
+     "start_time": "2026-09-01T08:01:58.608675+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Creation d'un Dataset de Test\n",
+    "## 6. Création d'un dataset de test\n",
     "\n",
-    "Dataset synthétique de ventes (150 lignes, produits Widget A/B/Gadget X, régions Nord/Sud/Est/Ouest, revenus et unités aléatoires). Le `np.random.seed(42)` garantit la **reproductibilité** : chaque exécution du workshop produit le même fichier, donc les modes d'échec commentés dans les interprétations des sections 7 et 8 restent stables d'une exécution à l'autre.\n",
+    "Le dataset synthétique contient 150 ventes réparties entre trois produits et quatre régions. `np.random.seed(42)` rend les valeurs reproductibles : les oracles Pandas des deux sections suivantes calculent donc des résultats stables.\n",
     "\n",
-    "Ce dataset est volontairement simple pour que les questions d'analyse (produit le plus rentable, évolution mensuelle) soient claires — la difficulté du workshop vient de l'agent, pas des données."
+    "Le problème reste lisible, mais il exerce plusieurs capacités distinctes du pipeline : inspection de schéma par outil, agrégation catégorielle, conversion temporelle, génération de code et vérification métier indépendante."
    ]
   },
   {
@@ -749,16 +835,16 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.663841Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.663614Z",
-     "iopub.status.idle": "2026-08-20T08:00:00.676254Z",
-     "shell.execute_reply": "2026-08-20T08:00:00.675730Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.618676Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.618483Z",
+     "iopub.status.idle": "2026-09-01T08:01:58.628684Z",
+     "shell.execute_reply": "2026-09-01T08:01:58.627988Z"
     },
     "papermill": {
-     "duration": 0.034836,
-     "end_time": "2026-05-13T22:34:33.630794+00:00",
+     "duration": 0.014616,
+     "end_time": "2026-09-01T08:01:58.629199+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.595958+00:00",
+     "start_time": "2026-09-01T08:01:58.614583+00:00",
      "status": "completed"
     },
     "tags": []
@@ -768,7 +854,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dataset cree: tmp941_j6i9\\sales.csv\n",
+      "Dataset cree: tmpyulx5vy9\\sales.csv\n",
       "150 lignes, colonnes: ['date', 'product', 'region', 'revenue', 'units']\n"
      ]
     }
@@ -798,18 +884,20 @@
    "id": "cell-17",
    "metadata": {
     "papermill": {
-     "duration": 0.005265,
-     "end_time": "2026-05-13T22:34:33.641492+00:00",
+     "duration": 0.003198,
+     "end_time": "2026-09-01T08:01:58.635630+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.636227+00:00",
+     "start_time": "2026-09-01T08:01:58.632432+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Test du Pipeline DS-STAR\n",
+    "## 7. Première analyse réelle : revenu total par produit\n",
     "\n",
-    "Premier test : question d'agrégation simple (« Quel produit génère le plus de revenu total ? ») avec `max_iterations=1`. L'interprétation suivante détaille un **mode d'échec révélateur** : le code généré tente d'ouvrir `sales.csv` par nom relatif alors que le fichier vit dans un répertoire temporaire — le contexte transmis au Coder ne contient pas le chemin absolu. C'est le genre de bug d'interface entre agents qu'une boucle d'itération avec contexte enrichi pourrait corriger, mais `max_iterations=1` l'interdit."
+    "Le premier scénario traverse toute la chaîne **FileAnalyzer → Planner ADK → Coder ADK → Executor → Verifier ADK**. Le Planner doit consulter le schéma par outil ; le Coder opère ensuite sur le DataFrame `df` déjà injecté.\n",
+    "\n",
+    "La cellule calcule aussi, directement avec Pandas, le produit et le revenu attendus. Ces valeurs indépendantes servent d'oracle métier : un verdict LLM positif ne suffit pas si la sortie exécutée ne contient pas le bon résultat."
    ]
   },
   {
@@ -818,16 +906,16 @@
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:00.678376Z",
-     "iopub.status.busy": "2026-08-20T08:00:00.678215Z",
-     "iopub.status.idle": "2026-08-20T08:00:09.374943Z",
-     "shell.execute_reply": "2026-08-20T08:00:09.374573Z"
+     "iopub.execute_input": "2026-09-01T08:01:58.643137Z",
+     "iopub.status.busy": "2026-09-01T08:01:58.642928Z",
+     "iopub.status.idle": "2026-09-01T08:02:04.400214Z",
+     "shell.execute_reply": "2026-09-01T08:02:04.399159Z"
     },
     "papermill": {
-     "duration": 6.583544,
-     "end_time": "2026-05-13T22:34:40.230095+00:00",
+     "duration": 5.76196,
+     "end_time": "2026-09-01T08:02:04.401027+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:33.646551+00:00",
+     "start_time": "2026-09-01T08:01:58.639067+00:00",
      "status": "completed"
     },
     "tags": []
@@ -837,99 +925,108 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "finish_reason: stop\n",
-      "content: '\\n\\n```python\\nimport pandas as pd\\n\\n# Charger le fichier CSV\\ndf = pd.read_csv(\\'sales.csv\\')\\n\\n# Calculer le revenu total par produit\\nrevenu_par_produit = df.groupby(\\'product\\')[\\'revenue\\'].su\n",
-      "prompt_tokens: 66\n",
-      "completion_tokens: 866\n",
+      "[FILE ANALYZER] Analyse de sales.csv (lab12-run-1)...\n",
       "\n",
-      ">>> SUCCES : le modele a rendu 463 caracteres.\n",
+      "=== ITERATION 1/2 ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PLANNER ADK] REASONING: Pour déterminer quel produit génère le plus de revenu total, nous allons analyser les données du fichier sales.csv en faisant une somme des revenus p...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[EXECUTOR] success=True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[VERIFIER ADK] SUCCESS, la sortie répond correctement à la question initiale en indiquant le produit qui génère le plus de revenu total avec son nom et le montant correspondant.\n",
+      "Produit attendu (Pandas): Gadget X\n",
+      "Revenu attendu (Pandas): 59242.44\n",
+      "Succès pipeline: True\n",
+      "Itérations: 1\n",
+      "Planner tool round-trip: True\n",
+      "Verdict ADK: SUCCESS, la sortie répond correctement à la question initiale en indiquant le produit qui génère le plus de revenu total avec son nom et le montant correspondant.\n",
+      "Sortie Executor:\n",
+      "Gadget X: 59242.44\n",
       "\n",
-      "\n",
-      "```python\n",
-      "import pandas as pd\n",
-      "\n",
-      "# Charger le fichier CSV\n",
-      "df = pd.read_csv('sales.csv')\n",
-      "\n",
-      "# Calculer le revenu total par produit\n",
-      "revenu_par_produit = df.groupby('product')['revenue'].sum()\n",
-      "\n",
-      "# Identifier le produit avec le revenu total le plus élevé\n",
-      "produit_top = revenu_par_produit.idxmax()\n",
-      "revenu_max = revenu_par_produit.max()\n",
-      "\n",
-      "# Afficher le résultat\n",
-      "print(f\"Le produit qui génère le plus de revenu total est : {produit_top} avec un revenu de {revenu_max}.\")\n",
-      "```\n"
+      "Preuve ADK:\n",
+      "- planner-0: session=lab12-run-1-planner-0, events=3, tool_calls=get_file_schema, tool_responses=get_file_schema\n",
+      "- coder-0: session=lab12-run-1-coder-0, events=1, tool_calls=aucun, tool_responses=aucune\n",
+      "- verifier-0: session=lab12-run-1-verifier-0, events=1, tool_calls=aucun, tool_responses=aucune\n"
      ]
     }
    ],
    "source": [
-    "# Test avec une question simple -- exec reelle via LLMClient (RECOVERABLE-MACHINE, LAN vLLM).\n",
-    "# Le pipeline DS-STAR est execute avec l'endpoint LLM reel (192.168.0.47:5002) pour capturer\n",
-    "# le succes observable du modele (max_tokens=1500 couvre la phase de raisonnement).\n",
-    "# cwd est fixe vers test_dir AVANT l'appel pour eviter le FileNotFoundError 'sales.csv'\n",
-    "# (defaut Prong A resolu dans la branche parente feature/11696-output-failure-repair PR #11722).\n",
+    "question_product = (\n",
+    "    \"Quel produit génère le plus de revenu total ? \"\n",
+    "    \"Affiche son nom et le revenu total correspondant.\"\n",
+    ")\n",
+    "pipeline = DSStarPipeline(max_iterations=2)\n",
+    "product_result = await pipeline.analyze_file(csv_path, question_product)\n",
     "\n",
-    "import os\n",
-    "os.chdir(test_dir)\n",
+    "product_totals = df.groupby('product')['revenue'].sum()\n",
+    "expected_product = product_totals.idxmax()\n",
+    "expected_revenue = float(product_totals.max())\n",
+    "observed_numbers = [\n",
+    "    float(value.replace(',', '.'))\n",
+    "    for value in re.findall(r\"\\d+(?:[.,]\\d+)?\", product_result['output'])\n",
+    "]\n",
     "\n",
-    "# Capture brute de l'appel -- l'endpoint LAN vLLM (RECOVERABLE-MACHINE) avec un budget\n",
-    "# tokens qui couvre la phase de raisonnement du modele (RECOVERABLE-LOCAL : max_tokens).\n",
-    "# Le notebook montre le succes (content = le script pandas demande), pas l'echec.\n",
-    "import litellm\n",
-    "from litellm import completion\n",
-    "\n",
-    "response = completion(\n",
-    "    model=\"openai/qwen3.6-35b-a3b\",\n",
-    "    messages=[\n",
-    "        {\"role\": \"user\", \"content\": (\n",
-    "            \"Genere un script pandas qui ouvre 'sales.csv' (colonnes: date, product, \"\n",
-    "            \"region, revenue, units; 150 lignes) et affiche le produit qui genere \"\n",
-    "            \"le plus de revenu total. Renvoie le code dans un bloc ```python```.\"\n",
-    "        )},\n",
-    "    ],\n",
-    "    api_base=\"http://192.168.0.47:5002/v1\",\n",
-    "    api_key=os.environ[\"VLLM_API_KEY\"],\n",
-    "    temperature=0.2,\n",
-    "    max_tokens=1500,\n",
+    "assert product_result['planner_tool_round_trip'], (\n",
+    "    \"Le Planner ADK n'a pas effectué le round-trip get_file_schema\"\n",
+    ")\n",
+    "assert product_result['success'], product_result.get('error', product_result['verdict'])\n",
+    "assert expected_product in product_result['output'], (\n",
+    "    \"La sortie exécutée ne nomme pas le produit calculé indépendamment\"\n",
+    ")\n",
+    "assert any(abs(value - expected_revenue) < 0.02 for value in observed_numbers), (\n",
+    "    \"La sortie exécutée ne contient pas le revenu total attendu\"\n",
     ")\n",
     "\n",
-    "choice = response.choices[0]\n",
-    "print(f'finish_reason: {choice.finish_reason}')\n",
-    "print(f'content: {repr(choice.message.content)[:200]}')\n",
-    "if choice.message.content is None and getattr(choice.message, 'reasoning_content', None):\n",
-    "    print(f'reasoning[:160]: {choice.message.reasoning_content[:160]!r}')\n",
-    "print(f'prompt_tokens: {response.usage.prompt_tokens}')\n",
-    "print(f'completion_tokens: {response.usage.completion_tokens}')\n",
-    "\n",
-    "if choice.message.content is None:\n",
-    "    print('(!) content is None -- max_tokens trop bas ?')\n",
-    "else:\n",
-    "    print()\n",
-    "    print('>>> SUCCES : le modele a rendu', len(choice.message.content), 'caracteres.')\n",
-    "    print(choice.message.content)\n"
+    "print(f\"Produit attendu (Pandas): {expected_product}\")\n",
+    "print(f\"Revenu attendu (Pandas): {expected_revenue:.2f}\")\n",
+    "print(f\"Succès pipeline: {product_result['success']}\")\n",
+    "print(f\"Itérations: {product_result['iterations']}\")\n",
+    "print(f\"Planner tool round-trip: {product_result['planner_tool_round_trip']}\")\n",
+    "print(f\"Verdict ADK: {product_result['verdict']}\")\n",
+    "print(f\"Sortie Executor:\\n{product_result['output'].strip()}\")\n",
+    "print(\"\\nPreuve ADK:\")\n",
+    "for role, item in product_result['evidence'].items():\n",
+    "    print(\n",
+    "        f\"- {role}: session={item['session_id']}, events={item['events']}, \"\n",
+    "        f\"tool_calls={item['tool_calls'] or 'aucun'}, \"\n",
+    "        f\"tool_responses={item['tool_responses'] or 'aucune'}\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "68fc3a6e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003558,
+     "end_time": "2026-09-01T08:02:04.408620+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:04.405062+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Lecture du resultat precedent\n",
+    "### Lecture du résultat : agrégation par produit\n",
     "\n",
-    "La cellule 22 **execute reellement** l'appel LLM via `litellm.completion()` sur l'endpoint LAN vLLM (`http://192.168.0.47:5002/v1`, cle `VLLM_API_KEY` chargee depuis `.env`). Le cwd est fixe vers `test_dir` AVANT l'appel pour eviter le `FileNotFoundError` `sales.csv` (defaut Prong A resolu dans la branche parente `feature/11696-output-failure-repair` PR #11722).\n",
+    "La sortie précédente est une preuve de bout en bout, pas un simple texte de modèle. Elle montre trois sessions ADK distinctes et le round-trip `get_file_schema` du Planner. Le code du Coder a réellement été exécuté sur `df`, puis son résultat a été confronté à l'agrégation Pandas calculée indépendamment dans la même cellule.\n",
     "\n",
-    "L'appel reEL capture le **succes du modele** `qwen3.6-35b-a3b` : avec un budget `max_tokens=1500` qui couvre la phase de raisonnement interne du modele, la sortie `content` porte le script pandas demande (`stop` reason, completion_tokens ~1376). Piege classique des modeles a raisonnement explicite : un plafond trop bas tronque apres le raisonnement et avant la reponse, donnant l'impression d'un defaut alors que le modele repond.\n",
-    "\n",
-    "**Verdict Prong A final** :\n",
-    "- **cwd fix (RECOVERABLE-LOCAL)** : RESOLU (PR #11722). `os.chdir(test_dir)` precede `litellm.completion()` dans la cellule.\n",
-    "- **LLM endpoint (RECOVERABLE-MACHINE)** : RESOLU par defaut sur ce runner -- l'endpoint LAN vLLM `192.168.0.47:5002` est joignable (HTTP 401 sans cle = serveur VIVANT, modele servi). la cle `VLLM_API_KEY` est dans `Track2-GoogleADK/.env` (gitignored, cf cellule 2 du .env.example).\n",
-    "- **Budget tokens (RECOVERABLE-LOCAL)** : RESOLU ici par `max_tokens=1500`. Un modele a raisonnement explicite consomme ~1200 tokens de `reasoning_content` avant le premier token de `content`. Adapter le plafond au-del`a de cette borne (1500-2048) garantit une sortie complete.\n",
-    "\n",
-    "Le notebook enseigne ce piege (cf. cell25) : la cellule 22 documente **le resultat reel** d'un appel LLM avec budget adapte, pas un stub abstrait. La cellule 24 reste un exercice pedagogique (stub C.1 conforme) pour les etudiants desirant tester un autre modele ou un autre budget sur leur machine authentifiee.\n",
-    "\n",
-    "> **Lecon pedagogique** : un modele de raisonnement a besoin d'un budget qui couvre sa reflexion AVANT sa reponse. Un plafond dimensionne pour un non-reasoning rend un `content` vide qu'on prend pour une panne. Piege que les etudiants rencontreront pour de vrai sur les modeles `qwen3.6+`, `o1*`, `deepseek-r1*`, etc.\n"
+    "Les assertions portent donc sur trois niveaux complémentaires : protocole ADK, verdict du Verifier et exactitude métier du nom **et** du montant. Toute divergence fait échouer le notebook au lieu d'être reformulée après coup dans cette prose."
    ]
   },
   {
@@ -938,69 +1035,61 @@
    "id": "1e99f4d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:09.376411Z",
-     "iopub.status.busy": "2026-08-20T08:00:09.376144Z",
-     "iopub.status.idle": "2026-08-20T08:00:09.380123Z",
-     "shell.execute_reply": "2026-08-20T08:00:09.379331Z"
-    }
+     "iopub.execute_input": "2026-09-01T08:02:04.451095Z",
+     "iopub.status.busy": "2026-09-01T08:02:04.450643Z",
+     "iopub.status.idle": "2026-09-01T08:02:04.456796Z",
+     "shell.execute_reply": "2026-09-01T08:02:04.455795Z"
+    },
+    "papermill": {
+     "duration": 0.045139,
+     "end_time": "2026-09-01T08:02:04.457648+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:04.412509+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : decommenter le bloc ci-dessus apres avoir configure un modele fonctionnel.\n"
+      "Exercice à compléter : formuler et vérifier une nouvelle analyse ADK\n"
      ]
     }
    ],
    "source": [
-    "# Variante : appel direct au pipeline DSStarPipeline (pour etudiant sur machine authentifiee).\n",
-    "# Les cellules 22 et 27 ci-dessus capturent deja le mode d'echec reel du modele upstream.\n",
-    "# Cette cellule reste un EXERCICE PEDAGOGIQUE : si l'etudiant dispose d'un endpoint LLM\n",
-    "# fonctionnel (Gemini, OpenRouter, OpenAI, ou vLLM local avec un modele instruct),\n",
-    "# il peut decommenter le code ci-dessous pour executer le pipeline complet.\n",
+    "# Exercice : posez une nouvelle question au pipeline Google ADK.\n",
+    "# L'exemple guidé précédent a déjà prouvé l'exécution réelle du runtime.\n",
     "\n",
-    "import os\n",
+    "# TODO étudiant : décommentez puis adaptez la question ou max_iterations.\n",
+    "# extension_pipeline = DSStarPipeline(max_iterations=2)\n",
+    "# extension_question = \"Quelle région a vendu le plus d'unités ?\"\n",
+    "# extension_result = await extension_pipeline.analyze_file(csv_path, extension_question)\n",
+    "# print(f\"Succès: {extension_result['success']}\")\n",
+    "# print(f\"Itérations: {extension_result['iterations']}\")\n",
+    "# print(f\"Sortie: {extension_result['output'][:300]}\")\n",
     "\n",
-    "# cwd est deja sur test_dir depuis cell22 ; reaffirmons par securite.\n",
-    "os.chdir(test_dir)\n",
-    "\n",
-    "# TODO etudiant : decommenter le bloc ci-dessous apres avoir verifie que la config\n",
-    "# (.env ou variables d'environnement) pointe vers un modele fonctionnel (non-reasoning-only).\n",
-    "# Le modele qwen3.6-35b-a3b par defaut produit du content=None (cf. cell22) -- pour\n",
-    "# obtenir un code fonctionnel, switcher vers un modele instruct ou un autre provider.\n",
-    "\n",
-    "# pipeline = DSStarPipeline(max_iterations=2)\n",
-    "# question = \"Quel produit genere le plus de revenu total?\"\n",
-    "# result = pipeline.analyze_file(csv_path, question)\n",
-    "# print(f\"Success: {result['success']}\")\n",
-    "# print(f\"Iterations: {result['iterations']}\")\n",
-    "# print(f\"Output: {result['output'][:300]}\")\n",
-    "\n",
-    "print(\"Exercice a completer : decommenter le bloc ci-dessus apres avoir configure un modele fonctionnel.\")"
+    "print(\"Exercice à compléter : formuler et vérifier une nouvelle analyse ADK\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "fe5f6ba1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005484,
+     "end_time": "2026-09-01T08:02:04.469203+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:04.463719+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Interpretation : Premier test du pipeline\n",
+    "### Exercice d'extension du pipeline\n",
     "\n",
-    "**Resultat obtenu** : La cellule 22 execute l'appel LLM sur l'endpoint LAN vLLM avec `max_tokens=1500`. Le modele reussit : `finish_reason=stop`, `content` porte le script pandas demande (groupby + tri), `completion_tokens` ~1376.\n",
-    "\n",
-    "**Analyse de la sortie** :\n",
-    "\n",
-    "| Etape | Statut | Detail |\n",
-    "|-------|--------|--------|\n",
-    "| FileAnalyzer | OK | Fichier detecte via `os.chdir(test_dir)` (cwd Prong A resolu PR #11722) |\n",
-    "| litellm.completion() | OK | Appel reussi, 200 OK, prompt_tokens + completion_tokens mesures |\n",
-    "| Modele upstream | OK | `finish_reason=stop`, `content` porte le script pandas |\n",
-    "| Code genere | OK | Script pandas avec `pd.read_csv`, groupby par `product`, tri par `revenue` total |\n",
-    "\n",
-    "**Note sur la lecon pedagogique** : a `max_tokens=200` (valeur initiale du notebook, cf. PR #11864), l'appel retourne `content=None` + `finish_reason=length` -- le modele a raisonne en interne (~1200 tokens de `reasoning_content`) puis a ete coupe avant le premier token de `content`. Symptome identique a un modele defectueux, mais en realite c'est un parametre mal calibre. La regle generale : `max_tokens` >= 1500 pour les modeles a raisonnement explicite, sinon la sortie observable (`content`) est vide par construction.\n",
-    "\n",
-    "**Pour les etudiants** : la cellule 24 reste un exercice pedagogique (stub C.1 conforme) qui debranche volontairement l'appel LLM. Ils peuvent tester d'autres modeles / providers via la config multi-provider documentee en cellule 2.\n"
+    "La cellule précédente reste volontairement un **exercice** : elle invite à déclencher une autre analyse après configuration du provider, sans fournir la solution. Le workshop a déjà exécuté le pipeline réel dans l'exemple guidé ci-dessus ; ce stub sert à modifier la question, le nombre d'itérations ou le provider sans confondre démonstration résolue et travail étudiant."
    ]
   },
   {
@@ -1008,18 +1097,20 @@
    "id": "cell-19",
    "metadata": {
     "papermill": {
-     "duration": 0.005897,
-     "end_time": "2026-05-13T22:34:40.241344+00:00",
+     "duration": 0.004045,
+     "end_time": "2026-09-01T08:02:04.477195+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:40.235447+00:00",
+     "start_time": "2026-09-01T08:02:04.473150+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 8. Test avec Question Complexe\n",
+    "## 8. Deuxième analyse réelle : évolution mensuelle\n",
     "\n",
-    "Second test : question d'analyse temporelle (« Montre l'évolution des revenus par mois »). L'interprétation suivante documente un autre mode d'échec typique des agents LLM : une **confusion de nom de colonne** (`revenu` vs `revenue`) dans le code généré. Ce type d'erreur de schéma est fréquent quand le LLM oscille entre conventions FR/EN ou singulier/pluriel — la boucle d'itération est précisément conçue pour le rattraper, à condition que `max_iterations` le permette."
+    "Le second scénario exige une transformation temporelle : convertir `date`, agréger `revenue` par mois, puis imprimer chaque période et son total. Il réutilise la même architecture ADK, mais avec de nouvelles sessions et un nouveau code généré.\n",
+    "\n",
+    "Un oracle Pandas indépendant vérifie que chaque total mensuel attendu apparaît dans la sortie. Cette comparaison attrape notamment une colonne inventée (`revenu` au lieu de `revenue`) ou une agrégation sur la mauvaise métrique, même si un LLM tentait de déclarer `SUCCESS`."
    ]
   },
   {
@@ -1028,16 +1119,16 @@
    "id": "cell-20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:09.381825Z",
-     "iopub.status.busy": "2026-08-20T08:00:09.381570Z",
-     "iopub.status.idle": "2026-08-20T08:00:21.085565Z",
-     "shell.execute_reply": "2026-08-20T08:00:21.084971Z"
+     "iopub.execute_input": "2026-09-01T08:02:04.491264Z",
+     "iopub.status.busy": "2026-09-01T08:02:04.491095Z",
+     "iopub.status.idle": "2026-09-01T08:02:08.720605Z",
+     "shell.execute_reply": "2026-09-01T08:02:08.719619Z"
     },
     "papermill": {
-     "duration": 6.385802,
-     "end_time": "2026-05-13T22:34:46.633125+00:00",
+     "duration": 4.238016,
+     "end_time": "2026-09-01T08:02:08.721565+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:40.247323+00:00",
+     "start_time": "2026-09-01T08:02:04.483549+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1047,103 +1138,121 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "finish_reason: stop\n",
-      "content: '\\n\\n```python\\nimport pandas as pd\\nimport matplotlib.pyplot as plt\\n\\n# 1. Charger le fichier CSV\\ndf = pd.read_csv(\\'sales.csv\\')\\n\\n# 2. Convertir la colonne \\'date\\' en type datetime\\ndf[\\'date\\'\n",
-      "prompt_tokens: 59\n",
-      "completion_tokens: 1252\n",
+      "[FILE ANALYZER] Analyse de sales.csv (lab12-run-2)...\n",
       "\n",
-      ">>> SUCCES : le modele a rendu 850 caracteres.\n",
+      "=== ITERATION 1/2 ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PLANNER ADK] REASONING: Le fichier contient des données de ventes avec des colonnes pertinentes pour l'analyse des revenus par mois.\n",
       "\n",
+      "STEPS:\n",
+      "1. Convertir la colonne `date` e...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[EXECUTOR] success=True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[VERIFIER ADK] SUCCESS, la sortie d'analyse montre correctement l'évolution du revenu total par mois en agrégant les revenus par période mensuelle et en affichant chaque mois avec son total.\n",
+      "Totaux mensuels attendus (Pandas):\n",
+      "- 2024-01: 33626.92\n",
+      "- 2024-02: 30399.24\n",
+      "- 2024-03: 38575.22\n",
+      "- 2024-04: 32180.79\n",
+      "- 2024-05: 30531.25\n",
+      "Succès pipeline: True\n",
+      "Itérations: 1\n",
+      "Planner tool round-trip: True\n",
+      "Verdict ADK: SUCCESS, la sortie d'analyse montre correctement l'évolution du revenu total par mois en agrégant les revenus par période mensuelle et en affichant chaque mois avec son total.\n",
+      "Sortie Executor:\n",
+      "date\n",
+      "2024-01-31    33626.92\n",
+      "2024-02-29    30399.24\n",
+      "2024-03-31    38575.22\n",
+      "2024-04-30    32180.79\n",
+      "2024-05-31    30531.25\n",
+      "Freq: ME, Name: revenue, dtype: object\n",
       "\n",
-      "```python\n",
-      "import pandas as pd\n",
-      "import matplotlib.pyplot as plt\n",
-      "\n",
-      "# 1. Charger le fichier CSV\n",
-      "df = pd.read_csv('sales.csv')\n",
-      "\n",
-      "# 2. Convertir la colonne 'date' en type datetime\n",
-      "df['date'] = pd.to_datetime(df['date'])\n",
-      "\n",
-      "# 3. Extraire l'année et le mois pour faciliter le regroupement\n",
-      "df['year_month'] = df['date'].dt.to_period('M')\n",
-      "\n",
-      "# 4. Calculer la somme des revenus par mois\n",
-      "revenue_by_month = df.groupby('year_month')['revenue'].sum()\n",
-      "\n",
-      "# 5. Afficher le résultat dans la console\n",
-      "print(\"Évolution des revenus par mois :\")\n",
-      "print(revenue_by_month)\n",
-      "\n",
-      "# 6. Visualiser l'évolution (graphique en ligne)\n",
-      "revenue_by_month.plot(kind='line', marker='o', figsize=(10, 5), \n",
-      "                      title='Évolution des revenus par mois', \n",
-      "                      xlabel='Mois', ylabel='Revenus')\n",
-      "plt.grid(True, linestyle='--', alpha=0.6)\n",
-      "plt.tight_layout()\n",
-      "plt.show()\n",
-      "```\n"
+      "Preuve ADK:\n",
+      "- planner-0: session=lab12-run-2-planner-0, events=3, tool_calls=get_file_schema, tool_responses=get_file_schema\n",
+      "- coder-0: session=lab12-run-2-coder-0, events=1, tool_calls=aucun, tool_responses=aucune\n",
+      "- verifier-0: session=lab12-run-2-verifier-0, events=1, tool_calls=aucun, tool_responses=aucune\n"
      ]
     }
    ],
    "source": [
-    "# Question d'analyse temporelle -- exec reelle via LLMClient (cf. cellule 22).\n",
-    "# Meme endpoint LAN vLLM, budget tokens adapte pour ce modele de raisonnement.\n",
-    "\n",
-    "import os\n",
-    "\n",
-    "# cwd doit deja pointer sur test_dir depuis cell22 ; reaffirmons par securite.\n",
-    "os.chdir(test_dir)\n",
-    "\n",
-    "from litellm import completion\n",
-    "\n",
-    "response = completion(\n",
-    "    model=\"openai/qwen3.6-35b-a3b\",\n",
-    "    messages=[\n",
-    "        {\"role\": \"user\", \"content\": (\n",
-    "            \"Genere un script pandas qui ouvre 'sales.csv' (colonnes: date, product, \"\n",
-    "            \"region, revenue, units) et affiche l'evolution des revenus par mois. \"\n",
-    "            \"Renvoie le code dans un bloc ```python```.\"\n",
-    "        )},\n",
-    "    ],\n",
-    "    api_base=\"http://192.168.0.47:5002/v1\",\n",
-    "    api_key=os.environ[\"VLLM_API_KEY\"],\n",
-    "    temperature=0.2,\n",
-    "    max_tokens=1500,\n",
+    "question_month = (\n",
+    "    \"Montre l'évolution du revenu total par mois. Convertis date en datetime, \"\n",
+    "    \"agrège revenue par période mensuelle et affiche chaque mois avec son total.\"\n",
     ")\n",
+    "monthly_result = await pipeline.analyze_file(csv_path, question_month)\n",
     "\n",
-    "choice = response.choices[0]\n",
-    "print(f'finish_reason: {choice.finish_reason}')\n",
-    "print(f'content: {repr(choice.message.content)[:200]}')\n",
-    "if choice.message.content is None and getattr(choice.message, 'reasoning_content', None):\n",
-    "    print(f'reasoning[:160]: {choice.message.reasoning_content[:160]!r}')\n",
-    "print(f'prompt_tokens: {response.usage.prompt_tokens}')\n",
-    "print(f'completion_tokens: {response.usage.completion_tokens}')\n",
+    "expected_monthly = (\n",
+    "    df.assign(date=pd.to_datetime(df['date']))\n",
+    "    .groupby(pd.Grouper(key='date', freq='ME'))['revenue']\n",
+    "    .sum()\n",
+    ")\n",
+    "observed_monthly_numbers = [\n",
+    "    float(value.replace(',', '.'))\n",
+    "    for value in re.findall(r\"\\d+(?:[.,]\\d+)?\", monthly_result['output'])\n",
+    "]\n",
     "\n",
-    "if choice.message.content is None:\n",
-    "    print('(!) content is None -- max_tokens trop bas ?')\n",
-    "else:\n",
-    "    print()\n",
-    "    print('>>> SUCCES : le modele a rendu', len(choice.message.content), 'caracteres.')\n",
-    "    print(choice.message.content)\n"
+    "assert monthly_result['planner_tool_round_trip'], (\n",
+    "    \"Le second Planner ADK n'a pas appelé get_file_schema\"\n",
+    ")\n",
+    "assert monthly_result['success'], monthly_result.get('error', monthly_result['verdict'])\n",
+    "for total in expected_monthly:\n",
+    "    assert any(abs(value - float(total)) < 0.02 for value in observed_monthly_numbers), (\n",
+    "        f\"Total mensuel attendu absent de la sortie: {total:.2f}\"\n",
+    "    )\n",
+    "\n",
+    "print(\"Totaux mensuels attendus (Pandas):\")\n",
+    "for month, total in expected_monthly.items():\n",
+    "    print(f\"- {month:%Y-%m}: {total:.2f}\")\n",
+    "print(f\"Succès pipeline: {monthly_result['success']}\")\n",
+    "print(f\"Itérations: {monthly_result['iterations']}\")\n",
+    "print(f\"Planner tool round-trip: {monthly_result['planner_tool_round_trip']}\")\n",
+    "print(f\"Verdict ADK: {monthly_result['verdict']}\")\n",
+    "print(f\"Sortie Executor:\\n{monthly_result['output'].strip()}\")\n",
+    "print(\"\\nPreuve ADK:\")\n",
+    "for role, item in monthly_result['evidence'].items():\n",
+    "    print(\n",
+    "        f\"- {role}: session={item['session_id']}, events={item['events']}, \"\n",
+    "        f\"tool_calls={item['tool_calls'] or 'aucun'}, \"\n",
+    "        f\"tool_responses={item['tool_responses'] or 'aucune'}\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "da57074f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003402,
+     "end_time": "2026-09-01T08:02:08.730305+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:08.726903+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Interpretation : Analyse temporelle\n",
+    "### Lecture du résultat : agrégation temporelle\n",
     "\n",
-    "**Resultat obtenu** : La cellule 27 **execute reellement** l'appel LLM (cf. cellule 22), capture brute du meme endpoint LAN vLLM. Avec `max_tokens=1500`, le modele rend un script pandas pour l'evolution des revenus par mois : `finish_reason=stop`, `content` porte le code, `completion_tokens` mesure.\n",
+    "La cellule précédente expose de nouveau les événements des trois rôles, puis affiche côte à côte les totaux Pandas attendus et la sortie réellement produite par le code du Coder. Le schéma transmis contient explicitement `date` et `revenue`, ce qui réduit la dérive de vocabulaire tout en laissant au LLM la responsabilité de construire l'analyse.\n",
     "\n",
-    "**Points cles** :\n",
-    "\n",
-    "1. **cwd fix (RECOVERABLE-LOCAL)** : RESOLU (PR parente #11722). `os.chdir(test_dir)` precede `litellm.completion()` dans la cellule.\n",
-    "2. **endpoint LLM (RECOVERABLE-MACHINE)** : RESOLU -- l'endpoint LAN vLLM `192.168.0.47:5002` est joignable + cle `VLLM_API_KEY` chargee depuis `.env` (gitignored).\n",
-    "3. **Budget tokens (RECOVERABLE-LOCAL)** : RESOLU -- `max_tokens=1500` couvre la phase de raisonnement (~1200 tokens) avant la sortie `content`. La cellule 22 et la cellule 27 utilisent la meme valeur, garantissant un succes reproducible.\n",
-    "\n",
-    "**Piege des modeles a raisonnement explicite** : sur un modele `qwen3.6+`, `o1*`, `deepseek-r1*` (et analogues), un plafond `max_tokens` trop bas tronque apres le `reasoning_content` et avant le `content`. Le `finish_reason=length` est l'API qui dit « j'ai atteint TON plafond » -- jamais « je n'ai rien a dire ». Si la sortie est vide, doubler le budget et relancer est le premier reflexe, pas le changement de modele.\n"
+    "Le test ne se contente pas de rechercher le mot `SUCCESS` : chaque total mensuel calculé indépendamment doit apparaître dans la sortie capturée par l'Executor. L'agent reste génératif, mais son résultat est évalué par un invariant métier déterministe."
    ]
   },
   {
@@ -1151,10 +1260,10 @@
    "id": "cell-21",
    "metadata": {
     "papermill": {
-     "duration": 0.006142,
-     "end_time": "2026-05-13T22:34:46.646124+00:00",
+     "duration": 0.005876,
+     "end_time": "2026-09-01T08:02:08.740138+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:46.639982+00:00",
+     "start_time": "2026-09-01T08:02:08.734262+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1171,16 +1280,16 @@
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:21.088185Z",
-     "iopub.status.busy": "2026-08-20T08:00:21.087836Z",
-     "iopub.status.idle": "2026-08-20T08:00:21.091893Z",
-     "shell.execute_reply": "2026-08-20T08:00:21.091431Z"
+     "iopub.execute_input": "2026-09-01T08:02:08.758433Z",
+     "iopub.status.busy": "2026-09-01T08:02:08.758123Z",
+     "iopub.status.idle": "2026-09-01T08:02:08.763969Z",
+     "shell.execute_reply": "2026-09-01T08:02:08.763124Z"
     },
     "papermill": {
-     "duration": 0.01734,
-     "end_time": "2026-05-13T22:34:46.669702+00:00",
+     "duration": 0.016015,
+     "end_time": "2026-09-01T08:02:08.764942+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:46.652362+00:00",
+     "start_time": "2026-09-01T08:02:08.748927+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1190,17 +1299,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cleanup done\n"
+      "Répertoire temporaire supprimé: tmpyulx5vy9\n"
      ]
     }
    ],
    "source": [
     "import shutil\n",
-    "# Revenir au cwd d'origine avant de supprimer test_dir (cwd est resté sur test_dir depuis cells 22+27)\n",
-    "NB_DIR_ORIG = os.path.dirname(os.path.abspath(\"__file__\")) if \"__file__\" in dir() else os.getcwd()\n",
-    "os.chdir(os.path.dirname(NB_DIR_ORIG) or os.path.expanduser(\"~\"))\n",
+    "\n",
     "shutil.rmtree(test_dir)\n",
-    "print('Cleanup done')"
+    "print(f\"Répertoire temporaire supprimé: {Path(test_dir).name}\")"
    ]
   },
   {
@@ -1208,45 +1315,43 @@
    "id": "cell-23",
    "metadata": {
     "papermill": {
-     "duration": 0.006278,
-     "end_time": "2026-05-13T22:34:46.682132+00:00",
+     "duration": 0.003691,
+     "end_time": "2026-09-01T08:02:08.773091+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:46.675854+00:00",
+     "start_time": "2026-09-01T08:02:08.769400+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 10. Resume du Workshop\n",
-    "### Architecture DS-STAR Complete\n",
+    "## 10. Résumé du workshop\n",
     "\n",
-    "Ce diagramme synthétise l'agent DS-STAR complet : un harnais déterministe orchestrant un module d'ingestion (FileAnalyzer) puis une boucle de raisonnement-action-vérification (Planner-Coder-Verifier). Cette architecture illustre le modèle canonique d'**agent LLM modulaire** (Xi et al. 2025) et le système DS-STAR (Guo et al. 2025) qui atteint l'état de l'art sur le benchmark DABStep.\n",
+    "### Architecture exécutée\n",
+    "\n",
+    "Le pipeline sépare le raisonnement LLM, porté par trois vrais agents Google ADK, de l'action Pandas locale et inspectable. Le Planner consulte le schéma par outil avant que le Coder produise du code ; le Verifier rend ensuite un verdict sur la sortie de l'Executor.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    F[Fichier CSV] --> A[FileAnalyzer déterministe]\n",
+    "    A --> P[Planner Agent + get_file_schema]\n",
+    "    P --> C[Coder Agent]\n",
+    "    C --> E[Executor Pandas local]\n",
+    "    E --> V[Verifier Agent]\n",
+    "    V -->|SUCCESS| R[Résultat vérifié]\n",
+    "    V -->|NEEDS_REFINEMENT ou FAILED| P\n",
     "```\n",
-    "[Fichier] --> [FileAnalyzer] --> Contexte\n",
-    "                                     |\n",
-    "                                     v\n",
-    "                               [Planner] --> Plan\n",
-    "                                     |\n",
-    "                                     v\n",
-    "                               [Coder] --> Code\n",
-    "                                     |\n",
-    "                                     v\n",
-    "                             [Executor] --> Résultat\n",
-    "                                     |\n",
-    "                                     v\n",
-    "                             [Verifier] --> SUCCESS/RETRY\n",
-    "```\n",
-    "### Points cles\n",
-    "1. **FileAnalyzer**: Extrait le contexte structure des fichiers\n",
-    "2. **Boucle iterative**: Permet de corriger et raffiner automatiquement\n",
-    "3. **Verifier**: Assure la qualite des résultats avant de retourner\n",
-    "### Ameliorations possibles\n",
-    "- Support de plus de formats (JSON, Excel, Parquet)\n",
-    "- Caching des metadonnees\n",
-    "- Parallelisation pour multi-fichiers\n",
-    "- Rapport final structure (Markdown/HTML)\n",
+    "\n",
+    "### Points clés\n",
+    "\n",
+    "1. **Runtime réel** : chaque rôle LLM traverse une session et un `Runner` Google ADK.\n",
+    "2. **Preuve observable** : événements, appels d'outil et réponses d'outil sont conservés.\n",
+    "3. **Code inspectable** : le Coder génère le code, mais seul l'Executor local l'exécute sur `df`.\n",
+    "4. **Validation falsifiable** : les exemples comparent la sortie à des calculs Pandas indépendants.\n",
+    "5. **Extensions** : les exercices proposent le multi-fichiers, des critères métier et un rapport Markdown sans livrer leur solution.\n",
+    "\n",
     "### Prochaine étape\n",
-    "- **Lab 13**: MLE-STAR - Recherche web pour modèles SOTA"
+    "\n",
+    "Le **Lab 13** étend cette architecture vers la recherche de modèles SOTA."
    ]
   },
   {
@@ -1254,10 +1359,10 @@
    "id": "12b61a38",
    "metadata": {
     "papermill": {
-     "duration": 0.005892,
-     "end_time": "2026-05-13T22:34:46.693546+00:00",
+     "duration": 0.003271,
+     "end_time": "2026-09-01T08:02:08.779830+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:46.687654+00:00",
+     "start_time": "2026-09-01T08:02:08.776559+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1282,16 +1387,16 @@
    "id": "5c5e922b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:21.093479Z",
-     "iopub.status.busy": "2026-08-20T08:00:21.093182Z",
-     "iopub.status.idle": "2026-08-20T08:00:21.098619Z",
-     "shell.execute_reply": "2026-08-20T08:00:21.098130Z"
+     "iopub.execute_input": "2026-09-01T08:02:08.786860Z",
+     "iopub.status.busy": "2026-09-01T08:02:08.786704Z",
+     "iopub.status.idle": "2026-09-01T08:02:08.795715Z",
+     "shell.execute_reply": "2026-09-01T08:02:08.795182Z"
     },
     "papermill": {
-     "duration": 0.021256,
-     "end_time": "2026-05-13T22:34:46.721011+00:00",
+     "duration": 0.013075,
+     "end_time": "2026-09-01T08:02:08.796143+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:46.699755+00:00",
+     "start_time": "2026-09-01T08:02:08.783068+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1346,7 +1451,16 @@
   {
    "cell_type": "markdown",
    "id": "4c070bc1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003119,
+     "end_time": "2026-09-01T08:02:08.802268+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:08.799149+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Amelioration du Verifier avec Critères Metier\n",
     "\n",
@@ -1369,11 +1483,19 @@
    "id": "111586fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:21.100157Z",
-     "iopub.status.busy": "2026-08-20T08:00:21.099913Z",
-     "iopub.status.idle": "2026-08-20T08:00:21.105720Z",
-     "shell.execute_reply": "2026-08-20T08:00:21.105332Z"
-    }
+     "iopub.execute_input": "2026-09-01T08:02:08.809946Z",
+     "iopub.status.busy": "2026-09-01T08:02:08.809805Z",
+     "iopub.status.idle": "2026-09-01T08:02:08.814829Z",
+     "shell.execute_reply": "2026-09-01T08:02:08.814455Z"
+    },
+    "papermill": {
+     "duration": 0.009658,
+     "end_time": "2026-09-01T08:02:08.815490+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:08.805832+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1452,7 +1574,16 @@
   {
    "cell_type": "markdown",
    "id": "2ef15b04",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003164,
+     "end_time": "2026-09-01T08:02:08.822080+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:08.818916+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Generation de Rapport Automatique\n",
     "\n",
@@ -1475,11 +1606,19 @@
    "id": "14059b48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:00:21.107158Z",
-     "iopub.status.busy": "2026-08-20T08:00:21.107016Z",
-     "iopub.status.idle": "2026-08-20T08:00:21.110611Z",
-     "shell.execute_reply": "2026-08-20T08:00:21.110154Z"
-    }
+     "iopub.execute_input": "2026-09-01T08:02:08.829437Z",
+     "iopub.status.busy": "2026-09-01T08:02:08.829290Z",
+     "iopub.status.idle": "2026-09-01T08:02:08.833163Z",
+     "shell.execute_reply": "2026-09-01T08:02:08.832723Z"
+    },
+    "papermill": {
+     "duration": 0.008378,
+     "end_time": "2026-09-01T08:02:08.833623+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:08.825245+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1549,10 +1688,10 @@
    "id": "40a947e2",
    "metadata": {
     "papermill": {
-     "duration": 0.005857,
-     "end_time": "2026-05-13T22:34:46.732799+00:00",
+     "duration": 0.003114,
+     "end_time": "2026-09-01T08:02:08.840086+00:00",
      "exception": false,
-     "start_time": "2026-05-13T22:34:46.726942+00:00",
+     "start_time": "2026-09-01T08:02:08.836972+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1567,7 +1706,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-44c8ee92",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003166,
+     "end_time": "2026-09-01T08:02:08.846308+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T08:02:08.843142+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",
@@ -1611,7 +1759,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 17.367198,
+   "end_time": "2026-09-01T08:02:09.751251+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lab12-DS-Star-Workshop.ipynb",
+   "output_path": "Lab12-DS-Star-Workshop.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-01T08:01:52.384053+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -616,7 +616,7 @@
     "\n",
     "À chaque itération, la trace conserve les identifiants de session, le nombre d'événements, ainsi que les appels et réponses d'outil. Un échec de code ou un verdict `NEEDS_REFINEMENT` enrichit le contexte avant la tentative suivante : l'erreur exacte de l'Executor et le verdict du Verifier sont ajoutés au contexte (`Tentative N : erreur=..., verdict=..., corrige le code.`) avant que Planner et Coder ne rejouent avec ce supplément d'information. La boucle est asynchrone parce que chaque rôle traverse réellement `Runner.run_async` ; elle ne se contente plus d'appeler un client LLM direct sous un nom d'agent.\n",
     "\n",
-    "`max_iterations` borne le nombre de tentatives. Le défaut `2` laisse une seconde chance après un premier échec, et c'est la valeur utilisée dans les sections 7 et 8. Si toutes les itérations échouent, le pipeline rend un résultat explicite — erreur, verdict, code généré et preuve collectée — plutôt qu'un échec silencieux."
+    "`max_iterations` borne le nombre de tentatives — donc le coût — et empêche une correction sans fin. Le défaut `2` laisse une seconde chance après un premier échec, et c'est la valeur utilisée dans les sections 7 et 8. Si toutes les itérations échouent, le pipeline rend un résultat explicite — erreur, verdict, code généré et preuve collectée — plutôt qu'un échec silencieux : l'appelant peut distinguer un succès métier d'une simple réponse textuelle plausible."
    ]
   },
   {
@@ -1030,18 +1030,20 @@
     "\n",
     "**Analyse de la sortie** :\n",
     "\n",
-    "| Étape | Rôle | Détail observable |\n",
-    "|-------|------|-------------------|\n",
-    "| Analyse locale | FileAnalyzer | Profil déterministe du CSV, sans appel LLM caché |\n",
-    "| Planification | Planner ADK | Session dédiée, appel **et** réponse d'outil `get_file_schema` |\n",
-    "| Génération | Coder ADK | Bloc `python` extrait de la réponse, contenant le groupby demandé |\n",
-    "| Exécution | Executor | `success=True`, sortie imprimée sur le DataFrame déjà chargé |\n",
+    "| Étape | Rôle | Preuve observable dans la sortie |\n",
+    "|-------|------|----------------------------------|\n",
+    "| Analyse locale | FileAnalyzer | Profil déterministe du CSV (`sales.csv`, 150 lignes, schéma réel), sans appel LLM caché |\n",
+    "| Planification | Planner ADK | Session dédiée, 3 événements, appel **et** réponse d'outil `get_file_schema` — le plan se fonde sur les colonnes réellement disponibles |\n",
+    "| Génération | Coder ADK | Session distincte, bloc `python` extrait de la réponse, contenant le groupby demandé |\n",
+    "| Exécution | Executor | `success=True`, sortie `Gadget X: 59242.44` imprimée sur le DataFrame déjà chargé |\n",
     "| Vérification | Verifier ADK | Verdict préfixé `SUCCESS` suivi de sa justification |\n",
-    "| Oracle métier | Pandas | Produit et revenu recalculés hors pipeline, comparés à la sortie |\n",
+    "| Oracle métier | Pandas | Produit et revenu recalculés hors pipeline, comparés à la sortie à 0,02 près |\n",
     "\n",
     "Dans le bloc « Preuve ADK » de la sortie, chaque rôle apparaît avec son identifiant de session, son nombre d'événements et ses échanges d'outils : le Planner y montre le couple appel/réponse `get_file_schema`, tandis que Coder et Verifier terminent en un seul événement de réponse finale — ils n'ont pas d'outil à invoquer. Cette trace observable est ce qui distingue une exécution d'agent d'un simple appel de complétion déguisé.\n",
     "\n",
     "Les assertions portent donc sur trois niveaux complémentaires : protocole ADK (le round-trip d'outil a bien eu lieu), verdict du Verifier et exactitude métier du nom **et** du montant (tolérance de 0,02 sur le revenu total). Toute divergence fait échouer le notebook au lieu d'être reformulée après coup dans cette prose.\n",
+    "\n",
+    "Le runtime multi-provider reste configurable : changer de modèle peut modifier le plan ou la forme du code, mais pas l'oracle attendu. C'est ce qui rend l'expérience reproductible et falsifiable d'un provider à l'autre.\n",
     "\n",
     "> **Leçon pédagogique** : un verdict LLM positif n'est pas une preuve. Le Verifier ADK peut se montrer indulgent ou valider une réponse bien formulée mais fausse ; l'oracle Pandas, lui, est déterministe. La sortie exécutée doit donc contenir le montant attendu à la tolérance près, quoi que déclare l'agent. Un pipeline agentique crédible sépare toujours le jugement génératif de la vérification falsifiable."
    ]
@@ -1110,9 +1112,15 @@
     "\n",
     "**Pistes d'extension** :\n",
     "\n",
-    "- Changer la question métier : unités vendues par région, produit au revenu médian, mois le plus faible — et écrire l'oracle Pandas correspondant **avant** de lancer le pipeline.\n",
-    "- Ajuster `max_iterations` (le baisser à 1 pour observer un échec sans retente, le monter pour une question plus difficile) et lire la différence dans le champ `iterations` du résultat.\n",
+    "- Changer la question métier — par exemple la région qui totalise le plus d'unités vendues, le produit au revenu médian ou le mois le plus faible — et écrire l'oracle Pandas correspondant **avant** de lancer le pipeline : colonne de groupement, mesure, opération et format de sortie attendus.\n",
+    "- Ajuster `max_iterations` : le baisser à 1 pour observer un échec sans retente, le monter pour une question plus difficile, et lire la différence dans le champ `iterations` du résultat comme dans le coût en tours. L'objectif n'est pas d'obtenir toujours un succès, mais de savoir attribuer un échec à l'interface, au code généré ou au critère métier.\n",
     "- Explorer le dictionnaire renvoyé : `success`, `iterations`, `verdict`, `code` et surtout `evidence`, qui conserve pour chaque rôle l'identifiant de session, le nombre d'événements et les échanges d'outils.\n",
+    "\n",
+    "Observez ensuite les trois niveaux de diagnostic :\n",
+    "\n",
+    "1. le Planner a-t-il appelé `get_file_schema` et utilisé les bons noms de colonnes ?\n",
+    "2. le code du Coder travaille-t-il sur `df` sans dépendre d'un chemin local ?\n",
+    "3. le Verifier distingue-t-il une sortie exacte d'une réponse plausible mais incomplète ?\n",
     "\n",
     "La démarche attendue est celle des sections 7 et 8 : formuler l'oracle avant de lire la sortie de l'agent, pour que la comparaison reste une vérification indépendante et non une justification a posteriori. Un bon réflexe d'agentique : ce qu'un LLM affirme se vérifie, ce qu'un calcul déterministe produit se constate."
    ]
@@ -1279,11 +1287,15 @@
     "\n",
     "**Points clés** :\n",
     "\n",
-    "1. **Question plus exigeante** : convertir `date` en datetime, agréger par période, afficher chaque mois — trois étapes où le code peut dévier, contre une seule pour l'agrégation par produit.\n",
+    "1. **Question plus exigeante** : convertir `date` en datetime, agréger par période, afficher chaque mois — trois étapes où le code peut dévier, contre une seule pour l'agrégation par produit. Le code généré reste libre dans sa forme, mais il doit préserver les cinq périodes et leurs montants.\n",
     "2. **Pièges attrapés par l'oracle** : une colonne inventée (`revenu` au lieu de `revenue`), une agrégation sur la mauvaise métrique ou un mois manquant font échouer l'assertion, même si le Verifier ADK déclarait `SUCCESS`.\n",
     "3. **Détail d'API réel** : l'instruction du Coder impose `freq='ME'` ; l'alias historique `'M'` est déprécié par Pandas pour les périodes mensuelles, et il reste fréquent dans les exemples plus anciens — le prompt ancre donc le code généré sur ce qu'attend la version installée.\n",
     "\n",
     "Le test ne se contente pas de rechercher le mot `SUCCESS` : chaque total mensuel calculé indépendamment doit apparaître dans la sortie capturée par l'Executor. L'agent reste génératif, mais son résultat est évalué par un invariant métier déterministe.\n",
+    "\n",
+    "Les identifiants `lab12-run-2-{planner,coder,verifier}-0` prouvent aussi que le deuxième scénario ne réutilise pas silencieusement les sessions du premier : le Planner effectue un nouveau round-trip de schéma et le Coder produit un nouveau programme ; seule la configuration partagée du pipeline est réutilisée.\n",
+    "\n",
+    "Si une tentative échoue, lisez les preuves dans l'ordre : erreur de l'Executor, premier token du verdict, puis trace d'outil du Planner. Cette séquence permet de distinguer un code invalide, une sortie métier incomplète et un plan fondé sur un schéma erroné, sans attribuer automatiquement le défaut au modèle.\n",
     "\n",
     "> **Leçon pédagogique** : plus la transformation demandée est riche (typage temporel, agrégation, formatage), plus l'oracle doit être précis. Comparer chaque total mensuel un à un coûte trois lignes de Pandas et attrape des erreurs qu'aucun verdict LLM ne détecterait."
    ]


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #13954

## Résumé

- migre le workshop Lab12 du faux pipeline `LLMClient`/LiteLLM direct vers trois vrais `google.adk.agents.Agent` : Planner, Coder et Verifier ;
- exécute chaque rôle dans une session distincte par le `Runner` partagé de #13954 ;
- impose au Planner un round-trip réel avec l'outil déterministe `get_file_schema` ;
- garde FileAnalyzer et Executor locaux afin que le schéma, le code généré et sa sortie restent inspectables ;
- remplace les deux endpoints LAN et appels LiteLLM en dur par deux exécutions complètes du pipeline configuré ;
- ajoute deux oracles Pandas indépendants : produit/revenu total, puis cinq totaux mensuels ;
- conserve les exercices comme stubs et remplace le diagramme ASCII par Mermaid.

## Dépendance résolue

#13954 est désormais mergée. La PR cible `main` et son périmètre effectif est réduit au seul notebook Lab12 ; le diff accumulateur signalé par la review antérieure n'est plus présent.

## Exécution réelle

Provider : OpenAI, modèle configuré `gpt-4o-mini` via le `.env` gitignored de Track2.

Aucun mock, fallback simulé, endpoint en dur ni output fabriqué n'est utilisé.

```text
Papermill SUCCESS
Success: 1
Failed: 0
Total time: 18.5s
```

Preuve committée, analyse produit :

```text
Produit attendu (Pandas): Gadget X
Revenu attendu (Pandas): 59242.44
Succès pipeline: True
Itérations: 1
Planner tool round-trip: True
Sortie Executor: Gadget X: 59242.44
planner: events=3, tool_calls=get_file_schema, tool_responses=get_file_schema
coder: events=1
verifier: events=1
```

Preuve committée, analyse mensuelle :

```text
2024-01: 33626.92
2024-02: 30399.24
2024-03: 38575.22
2024-04: 32180.79
2024-05: 30531.25
Succès pipeline: True
Planner tool round-trip: True
sessions: lab12-run-2-{planner,coder,verifier}-0
```

## Validation post-fix

- `validate_pr_notebooks.py`: `1/1 passed`, 17 cellules code vérifiées ;
- inspection notebook : 17/17 cellules code exécutées, 17/17 avec outputs, 0 erreur ;
- `notebook_tools.py validate --quick`: 1 OK, 0 warning, 0 erreur ;
- `scan_cell_ordering.py --fail-on HIGH`: clean, 0 finding ;
- `detect_consecutive_code_cells.py`: aucun run de cellules code consécutives ;
- `count_exercises.py`: 5 exercices, seuil respecté ;
- tests provider/runtime hermétiques : `39 passed` ;
- scan sorties : 0 path leak ; métadonnées Papermill normalisées au basename ;
- aucun endpoint, token, clé ou chemin machine en source/output ;
- `git diff --check`: succès.
- réparation exact-head `87a0c373a` du garde `detect_md_content_loss.py` : 23 cellules markdown avant/après, volume normalisé `14639 → 14903`, `findings=0` ; seules quatre sources markdown ont changé, les 17 cellules code et leurs outputs sont byte-identiques au head exécuté précédent.

## Diagnostic dérive

**Causes :** le notebook nommait Planner/Coder/Verifier mais les implémentait comme wrappers `LLMClient`, tandis que ses deux exemples contournaient entièrement le pipeline avec `litellm.completion`, un endpoint LAN et une clé spécifiques. La prose décrivait en plus des budgets de tokens et erreurs historiques plutôt que le runtime réellement démontré.

**Verdict : `CAUSE_FIXED`.** Le workshop traverse maintenant le vrai runtime Google ADK, expose ses événements et round-trips d'outil, exécute le code produit et compare le résultat à deux oracles métier indépendants.

## SOTA

**Google ADK : `SOTA-OK`.** Le package réel exécute trois agents, sessions et runners ; appels et réponses de `get_file_schema` sont visibles dans l'output committé.

**LLM : `SOTA-OK`.** Les six tours Planner/Coder/Verifier des deux analyses appellent un vrai modèle OpenAI ; aucune réponse déterministe ne remplace le LLM.

**Qwen : `RECOVERABLE-LOCAL`.** Le runtime partagé le supporte, mais cette lane n'a pas encore reçu un smoke Qwen positif ; le notebook utilise donc un autre LLM réel plutôt qu'un mock.

Livraison partielle de #13925 : tranche atomique Lab12 uniquement.

See #13925
Depends on #13954
