### PR TITLE
docs(ml,#13993): note de reference TSAD benchmark flaws + Matrix Profile

### DIFF
--- a/docs/ml/tsad-benchmark-flaws.md
+++ b/docs/ml/tsad-benchmark-flaws.md
@@ -1,0 +1,141 @@
+# Flaws des benchmarks TSAD et place du Matrix Profile
+
+Note de référence compagnon pour les notebooks **ML-10** (critique
+méthodologique des benchmarks de détection d'anomalies temporelles) et
+**ML-11** (Matrix Profile multidimensionnel, méthode non-apprentissage
+qui résiste à la critique). Cette note consolide le cadre méthodologique
+pour que le lectorat situe la série **ML-9 → ML-10 → ML-11** et
+comprenne *pourquoi* elle progresse dans cet ordre.
+
+## La triade de sources
+
+Trois textes éclairent la détection d'anomalies temporelles (TSAD) sous
+des angles complémentaires.
+
+### Wu & Keogh 2020 — le diagnostic fondateur
+
+**Wu, R. & Keogh, E. (2020).** *Current Time Series Anomaly Detection
+Benchmarks are Flawed and are Creating the Illusion of Progress.*
+arXiv:2009.13807, IEEE TKDE 2021.
+[arxiv.org/abs/2009.13807](https://arxiv.org/abs/2009.13807)
+
+Le papier identifie **quatre flaws** dans les benchmarks classiques
+(Yahoo, Numenta, NASA, OMNI) :
+
+1. **Trivialité** — un problème est trivial si une seule ligne de code
+   (primitives vectorisées : `mean`, `max`, `std`, `diff`) le résout.
+   Une fraction significative des benchmarks y cède.
+2. **Densité d'anomalies irréaliste** — plus de la moitié de la série
+   marquée anormale, ou 21 anomalies dans un court segment, ou
+   anomalies collées.
+3. **Ground truth mal étiqueté** — faux positifs et faux négatifs
+   avérés (ex : Yahoo).
+4. **Run-to-failure bias** — les séries proviennent presque toutes de
+   scénarios où la machine a déjà cassé, et l'anomalie est triviale à
+   détecter *a posteriori*.
+
+L'**UCR Archive** (367 séries, Eamonn Keogh) sert de contre-épreuve :
+sur ce corpus, les SOTA publiés s'effondrent à des niveaux proches de
+l'aléatoire.
+
+### Keogh 2025 — la baseline SPC bat le SOTA
+
+**Keogh, E. (2025).** Post Reddit sur TSB-AD-M (NeurIPS 2024) :
+l'application directe de la **règle SPC** (*Statistical Process
+Control*, Shewhart 1924) — `M + 3*S` — surpasse la majorité des
+méthodes SOTA publiées, sans apprentissage, sans ajustement.
+
+L'introspection communautaire n'est pas terminée. Le baseline trivial
+bat le SOTA sur le benchmark de référence.
+
+### Yeh et al. 2024 — Matrix Profile multidimensionnel
+
+**Yeh, C.-C. M. et al. (2024).** *Matrix Profile for Anomaly Detection
+on Multidimensional Time Series.* arXiv:2409.09298.
+[arxiv.org/abs/2409.09298](https://arxiv.org/abs/2409.09298)
+
+Le **Matrix Profile (MP)** d'une série univariée à n sous-séquences
+est le vecteur des distances au plus proche voisin non-trivial de
+chaque sous-séquence — un profil de similarité locale. C'est une
+méthode **non-apprentissage** : pas de paramètre à apprendre, pas de
+risque de surapprendre un benchmark trivial.
+
+L'extension multidimensionnelle (Matrix Profile sur n dimensions)
+préserve la propriété discriminante sur **119 datasets × 3 setups**
+(non-supervisé, supervisé, semi-supervisé), seule méthode constante
+sur tous les benchmarks.
+
+### Fu et al. ICLR 2025 — hybridation MP + autoencodeur
+
+**Fu, Y. et al. (ICLR 2025, soumission).** *FMP-AE: A Hybrid Approach
+to Time Series Anomaly Detection.* OpenReview fErm1seIom.
+[openreview.net/forum?id=fErm1seIom](https://openreview.net/forum?id=fErm1seIom)
+
+L'autoencodeur apprend la représentation ; le **Matrix Profile sert
+de loss structurée hybride** — la reconstruction n'est pas la seule
+contrainte, la cohérence avec les plus proches voisins l'est aussi.
+Le MP reste pertinent à l'ère du deep learning, comme **régulateur
+structurel**.
+
+Code public : [github.com/FyingE/FMP-AE](https://github.com/FyingE/FMP-AE).
+
+## Fil pedagogique : ML-9 → ML-10 → ML-11
+
+La série ML construit le regard critique *avant* l'outil SOTA, sinon
+on enseigne un algorithme sans le cadre qui le rend légitime.
+
+- **ML-9** — Détection d'anomalies par **ACP** sur jeu synthétique
+  capteurs. Pédagogiquement sain pour introduire l'algorithme, mais
+  sans regard critique sur *comment on évalue* un détecteur.
+- **ML-10** — La critique des benchmarks (Wu-Keogh + SPC) : avant
+  d'enseigner un SOTA, montrer qu'un baseline trivial peut le battre,
+  que les benchmarks ont des flaws structurels, que l'illusion de
+  progression est un piège.
+- **ML-11** — Le Matrix Profile, méthode non-apprentissage qui
+  *résiste* à la critique : pas de surapprentissage possible (pas
+  d'apprentissage), constant sur 119 datasets, étendable en
+  multidimensionnel.
+
+Sans ML-10, ML-11 enseignerait un algorithme sans le regard critique
+qui le met en valeur. Sans ML-9, ML-10 manquerait de substrat
+pédagogique pour introduire la notion de détecteur.
+
+## Pointeurs
+
+### Notebooks
+
+- [ML-9-Anomaly-Detection-Python.ipynb](../../MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb) — détection par ACP, Python.
+- [ML-9-Anomaly-Detection.ipynb](../../MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb) — jumeau .NET Interactive.
+
+### Depots de code
+
+- [stumpy](https://github.com/stumpy-dev/stumpy) — implémentation de
+  référence du Matrix Profile en Python.
+- [mmpad_tsb](https://github.com/TheDatumOrg/mmpad_tsb) — Matrix
+  Profile multidimensionnel (paquet officiel des auteurs Yeh et al.).
+- [FMP-AE](https://github.com/FyingE/FMP-AE) — hybridation MP +
+  autoencodeur (Fu et al. ICLR 2025).
+
+### Donnees
+
+- [UCR Archive](https://www.cs.ucr.edu/~eamonn/time_series_data_2018/) —
+  367 séries temporelles labellisées, contre-épreuve des benchmarks
+  trivialement résolus.
+- [TSB-AD](https://github.com/TheDatumOrg/TSB-AD) — TSB-AD-M (NeurIPS
+  2024), benchmark moderne où SPC bat le SOTA publié.
+
+## References
+
+- Wu, R. & Keogh, E. (2020). *Current Time Series Anomaly Detection
+  Benchmarks are Flawed and are Creating the Illusion of Progress.*
+  arXiv:2009.13807.
+- Keogh, E. (2025). Post communautaire sur TSB-AD-M. Reddit r/MachineLearning.
+- Yeh, C.-C. M. et al. (2024). *Matrix Profile for Anomaly Detection
+  on Multidimensional Time Series.* arXiv:2409.09298.
+- Fu, Y. et al. (ICLR 2025, soumission). *FMP-AE: A Hybrid Approach to
+  Time Series Anomaly Detection.* OpenReview fErm1seIom.
+
+## Voir aussi
+
+- Issue #13991 — Notebook ML-10 (critique méthodologique).
+- Issue #13992 — Notebook ML-11 (Matrix Profile multidimensionnel).


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2026:CoursIA -- prev: LIGHT/test #14002 cycle 77

## Contexte (#13993)

Issue #13993 demandait une note de référence FR consolidant la triade **Wu-Keogh 2020 / Keogh 2025 / Yeh 2024 / Fu ICLR 2025** sur la détection d'anomalies temporelles (TSAD), pour accompagner les notebooks compagnons **ML-10** (critique méthodologique des benchmarks) et **ML-11** (Matrix Profile multidimensionnel). La note doit expliquer pourquoi la série progresse **ML-9 → ML-10 → ML-11** dans cet ordre, et servir de référence canonique pour les étudiants qui cherchent à comprendre *pourquoi* on enseigne la critique avant l'outil SOTA.

## Livrable

`docs/ml/tsad-benchmark-flaws.md` (nouveau, 141 lignes) — note de référence en français (règle `readme-french-first`), sectionnée en 5 parties.

### Sections

| Section | Contenu |
|---------|---------|
| **Triade de sources** | 4 paragraphes détaillés : Wu-Keogh (4 flaws structurels + UCR Archive contre-épreuve), Keogh 2025 (SPC bat SOTA sur TSB-AD-M), Yeh 2024 (Matrix Profile non-apprentissage, constant sur 119 datasets × 3 setups), Fu ICLR 2025 (FMP-AE : MP comme loss structurée hybride) |
| **Fil pédagogique** | ML-9 (ACP) → ML-10 (critique) → ML-11 (MP) : pourquoi cet ordre, ce qui manque si on saute une étape |
| **Pointeurs** | Notebooks ML-9 (Python + .NET), 3 dépôts de code (stumpy, mmpad_tsb, FMP-AE), UCR Archive, TSB-AD |
| **Références** | 4 sources primaires avec URLs canoniques (arXiv, OpenReview) |
| **Voir aussi** | Liens vers issues compagnon #13991 (ML-10) et #13992 (ML-11) |

## Acceptance (cf spec ticket)

- [x] Fichier créé en français (règle `readme-french-first`)
- [x] Pas de duplication du contenu des notebooks (référence, pas retranscription)
- [x] Liens vers les 4 sources primaires + 3 dépôts de code + stumpy + UCR Archive
- [x] Section "Voir aussi" référence les issues compagnon #13991/#13992
- [x] 1 PR atomique, genre docs

## Hors scope

- Aucun notebook modifié ni créé (les notebooks ML-10/ML-11 restent à livrer dans des PRs séparées)
- Aucun READMA, MAPPING, AUDIT, RAPPORT ni fichier annexe (le doc lui-même *est* la livraison)
- Catalogue byte-identique à main (pas de toucher à `COURSE_CATALOG.generated.*`)
- Aucun toucher aux notebooks existants (ML-9 reste intact)

## Grain tag

`LIGHT/docs -- lane myia-po-2026:CoursIA -- prev: LIGHT/test #14002 cycle 77`

Scope : 1 commit, 1 fichier, +141/-0.

Variété R6 : docs vs test (cycles 76-77), data (cycle 75), tooling (cycles 73-74). OK.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

---
_Tag `Grain:` remonte en premiere ligne par le coordinateur (ai-01) : il etait declare sous `## Grain tag`, forme que `variation_tag_required.py` ne reconnait pas -- la PR etait donc invisible aux gardes de lane ET a son propre cap. Aucune autre modification ; valeur du tag inchangee, reprise verbatim du corps._