### PR TITLE
feat(notebooks): Search-17 7 lectures ancrees outputs - densite 1082->1335 c/cell, code byte-identique

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-Empirical-Algorithm-Selection.ipynb
@@ -485,6 +485,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-grid",
+   "metadata": {},
+   "source": [
+    "### Lecture — la representation choisit deja une famille d'algorithmes\n",
+    "\n",
+    "`SudokuGrid` stocke 81 entiers (`0` = vide), `from_string` normalise `.` et espaces vers `0`, et le constructeur par copie (`row[:]`) isole chaque instance des mutations du solveur — trois petits choix qui conditionnent tout le reste : les solveurs exacts (backtracking, DLX, CP-SAT, Z3) liront la grille comme des CONTRAINTES, les metaheuristiques (GA, recuit) comme un GENOME a optimiser via `_fitness`. Le compte reel rendu par la classe — **51 cases vides** sur la grille easy de demo — fixe l'ordre de grandeur : ~10^51 affectations brutes pour une enumeration nave, ce qui explique d'avance pourquoi le budget de 2 000 000 noeuds ne suffira pas toujours."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "81dffb46",
    "metadata": {
     "papermill": {
@@ -596,6 +606,19 @@
     "# Caracteristiques des instances\n",
     "empties = [g.count_empty() for _, _, g in instances]\n",
     "print(f\"\\nCases vides : min={min(empties)}, max={max(empties)}, moyenne={np.mean(empties):.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-bench-data",
+   "metadata": {},
+   "source": [
+    "### Lecture — 30 instances figees : la reproductibilite avant la performance\n",
+    "\n",
+    "La sortie confirme **30 instances : 10 easy, 10 medium_hard, 10 diabolical**, avec 45 a 64 cases vides (moyenne 56,2). Deux points de methode :\n",
+    "\n",
+    "- **Le corpus est fixe et versionne dans le depot** (serie `Sudoku/Puzzles`). Le commentaire source documente la correction du chemin : l'original pointait vers un clone local machine-dependant, non re-executable ailleurs — le fallback racine-depot rend le benchmark rejouable sur n'importe quelle machine, condition premiere d'une comparaison honnete.\n",
+    "- **La difficulte n'est pas le nombre de cases vides** (la moyenne couvre l'ensemble) : une grille diabolical a 45 trous peut etre plus dure qu'une easy a 60, selon la structure des contraintes. C'est exactement pourquoi le verdict final se coupe PAR difficulte (section 6.6) et non en moyenne globale — une moyenne aurait noye le No Free Lunch que la section 7 met en evidence."
    ]
   },
   {
@@ -947,6 +970,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-dlx-contrast",
+   "metadata": {},
+   "source": [
+    "### Lecture — 37 652 noeuds contre 81 : l'ordre de grandeur du choix d'algorithme\n",
+    "\n",
+    "Sur la meme grille easy de demo, le backtracking nave explore **37 652 noeuds** (cellule precedente) et Dancing Links **81 noeuds en 3,50 ms**. Le rapport n'est pas une micro-optimisation, c'est un facteur ~450 :\n",
+    "\n",
+    "- **81 = exactement le nombre de cases a remplir** : chaque coup de DLX selectionne une colonne et la propagation couvre le reste — sur une grille facile, la solution est quasi determinee par les couvrements successifs, l'arbre de recherche reste lineaire.\n",
+    "- **`__slots__` sur les noeuds** n'est pas decoratif : DLX vit ou meurt par la localite memoire de ses listes doublement chainees — reduire chaque noeud a six pointeurs compacts est ce qui rend le parcours cache-friendly.\n",
+    "- La lecon de selection : entre ecrire un solveur plus rapide et choisir un meilleur modele de probleme (exact cover vs affectation case par case), le second gagne de deux ordres de grandeur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "aec4866e",
    "metadata": {
     "papermill": {
@@ -1128,6 +1165,20 @@
     "out = solve_smt(g.clone(), counter)\n",
     "dt = time.perf_counter() - t0\n",
     "print(f\"SMT (Z3) : success={out['success']}, decisions={counter['n']}, temps={dt*1000:.2f}ms\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-cpsat-z3-counters",
+   "metadata": {},
+   "source": [
+    "### Lecture — branches=0 contre decisions=192 : comparer des compteurs qui ne mesurent pas la meme chose\n",
+    "\n",
+    "CP-SAT rend `branches=0` en 21,02 ms ; Z3 rend `decisions=192` en 42,28 ms — et ce contraste NE DIT PAS que CP-SAT « explore 192 fois moins ». C'est precisement le role du tableau de la section 2 (definition de « noeud explore » par paradigme) :\n",
+    "\n",
+    "- **CP-SAT compte les branches apres propagation/simplification** : sur cette grille, la phase de pre-processing resout la grille sans qu'aucune branche comptee ne soit ouverte. Le temps (21 ms, non nul) montre que le travail a bien eu lieu — hors compteur.\n",
+    "- **Z3 compte ses decisions de recherche apres propagation theorique** : 192 decoupages d'arbre pour converger.\n",
+    "- Les temps restent comparables (21 vs 42 ms) alors que les compteurs different d'un facteur infini : **comparer des noeuds entre paradigmes est une erreur de categorie** — seul le protocole commun (timeout, budget, meme corpus, colonnes de `Metrics`) rend la table finale honnete."
    ]
   },
   {
@@ -1426,6 +1477,20 @@
     "out = solve_simulated_annealing(g.clone(), counter)\n",
     "dt = time.perf_counter() - t0\n",
     "print(f\"Recuit simule : success={out['success']}, fitness={out['quality']}, swaps={counter['n']}, temps={dt*1000:.2f}ms\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-ga-sa",
+   "metadata": {},
+   "source": [
+    "### Lecture — GA echoue, le recuit reussit : le voisinage decide, pas le hasard\n",
+    "\n",
+    "Les deux metaheuristiques partagent `_fitness` (nombre de conflits) et un tirage aleatoire initiale, pourtant la demo rend **GA : success=False, fitness=9.0, 400 200 evaluations, 18,9 s** contre **recuit : success=True, fitness=0.0, 51 754 swaps, 674 ms** :\n",
+    "\n",
+    "- **GA** croise et mute des individus ou chaque bloc 3x3 est une permutation : le croisement de deux solutions partielles casse la structure de blocs et la population stagne sur des plateaux (9 conflits residuels) jusqu'a epuisement du budget.\n",
+    "- **Le recuit** applique un voisinage LOCAL (swap de deux cases dans un bloc) avec un schema de temperature qui ACCEPTE des degradations transitoires (`T=2.0 -> 0.99997^k`) : il traverse les plateaux que le GA ne traverse pas, pour un cout 28 fois moindre.\n",
+    "- Morale de selection : entre deux algorithmes stochastiques, le choix du VOISINAGE domine le reglage des hyperparametres — et tous deux restent, sur ce probleme a contraintes dures, en dessous des solveurs exacts."
    ]
   },
   {
@@ -2543,6 +2608,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-bench-run",
+   "metadata": {},
+   "source": [
+    "### Lecture — 210 mesures en 752,9 s : ce que le log brut revele avant toute agregation\n",
+    "\n",
+    "210 = **7 solveurs x 30 instances** (les 6 paradigmes de la section 4 comptent le backtracking deux fois : naive et MRV). Trois signaux sautent du log AVANT meme la section 6 :\n",
+    "\n",
+    "- **Les echecs du naif sont des coupes budget** : sur medium_hard, cinq lignes rendent `nodes=2000001` — le plafond de la section 2, pas un temps arbitraire. L'echec est donc defini par le protocole, pas par un crash.\n",
+    "- **GA echoue 30/30** en brulant exactement `400200` evaluations chaque fois (200 individus x 2001 generations) — l'echec est systematique, pas un coup de malchance.\n",
+    "- **Le recuit ne reussit que 6/10 en easy et 0/20 au-dela** (300001 = MAX_ITERATIONS atteint) : la demo de la section 4.6 (une seule grille) enjambait la variance inter-instances — c'est le benchmark complet, pas la demo, qui fonde le verdict.\n",
+    "- Noter enfin la dispersion du naif : 445 a 703 681 noeuds SUR easy seul — la difficulte observable varie plus ENTRE instances d'une classe qu'entre classes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bfcc5c8a",
    "metadata": {
     "papermill": {
@@ -3072,6 +3152,20 @@
     "print(\"3. Sur 'diabolical' : backtracking_naif atteint souvent le budget 2M noeuds ;\")\n",
     "print(\"   DLX tient encore grace a la propagation exacte-cover ; CP-SAT et Z3\")\n",
     "print(\"   dependent de la structure ; GA et SA peinent a converger en 5s.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-verdict",
+   "metadata": {},
+   "source": [
+    "### Lecture — easy : Dancing Links gagne, et le naif bat MRV\n",
+    "\n",
+    "Le podium easy (temps median parmi les reussites) : **dancing_links 4,16 ms < backtracking_naive 12,29 ms < backtracking_mrv 18,18 ms < cp_sat 25,97 ms** (10/10 reussites pour les quatre).\n",
+    "\n",
+    "- **DLX confirme a l'echelle** le facteur ~450 vu en demo — le median etend la lecon au-dela d'une grille chanceuse.\n",
+    "- **Le naif DEVANT MRV** est le resultat le plus instructif : choisir la case la plus contrainte reduit les noeuds (visible dans le log : 254 contre 2 576 sur easy_0) mais paie un cout par noeud (re-scan des contraintes) qui n'est pas amorti sur des grilles faciles. Sur medium_hard, le log montre l'inverse — MRV resout 7/10 quand le naif n'en resout que 4/10 (six coupes budget). Le classement S'INVERSE avec la difficulte : c'est le No Free Lunch en acte, pas en theorie.\n",
+    "- **cp_sat a 25,97 ms malgre branches=0** : le cout fixe de modelisation (construire les 81 variables et les 27 AllDifferent) plafonne son plancher temporel — imbattable en robustesse, jamais le plus rapide sur easy."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-python #14009 (substance distincte : autre notebook, autre famille, lectures à dominante méthodologie-de-mesure)

## Sujet

`Search-17-Empirical-Algorithm-Selection.ipynb` sortait à **1082 c/cell** (seuil 1200). Ajout de **7 cellules markdown d'interprétation**, chacune ancrée aux outputs committés (le log de benchmark 210 mesures est particulièrement riche) ou à la structure du code explicitement citée. Les insertions couvrent les zones sans interprétation adjacente :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après `SudokuGrid` | 81 entiers (`0` = vide), `from_string` normalise, copie isolante ; **51 cases vides** comptées sur la grille demo ; la représentation choisit déjà la famille (contraintes vs génome) |
| 2 | après le chargement des données | **30 instances : 10/10/10** (easy/medium_hard/diabolical), 45-64 vides (moy. 56,2) ; commentaire source documente la correction du chemin machine-dépendant → re-exécutable ; difficulté ≠ nombre de vides → verdict PAR difficulté |
| 3 | après DLX | naïf **37 652 nœuds** vs DLX **81 nœuds en 3,50 ms** (~450×) ; 81 = exactement les cases à remplir (propagation quasi déterministe) ; `__slots__` = localité mémoire, pas décoratif |
| 4 | après Z3 | CP-SAT `branches=0` en 21,02 ms vs Z3 `decisions=192` en 42,28 ms — **comparer des nœuds entre paradigmes est une erreur de catégorie** (le compteur CP-SAT exclut la phase de propagation qui fait le travail) ; rôle du protocole commun de la section 2 |
| 5 | après le recuit | GA **success=False, fitness=9.0, 400 200 évals, 18,9 s** vs recuit **success=True, fitness=0.0, 51 754 swaps, 674 ms** : même `_fitness`, même initialisation aléatoire — le VOISINAGE décide (swap local + température qui accepte les dégradations vs croisement qui casse les blocs) |
| 6 | après le benchmark complet | **210 = 7 solveurs × 30** (backtracking compté 2× : naïf + MRV) ; échecs naïf = coupes budget `2000001` ; GA 0/30 en brulant exactement `400200` évals ; recuit 6/10 easy, 0/20 au-delà (`300001` = MAX_ITERATIONS) — la demo 4.6 enjambait la variance inter-instances ; dispersion naïf 445→703 681 nœuds sur easy seul |
| 7 | après le verdict par difficulté | podium easy : **DLX 4,16 ms < naïf 12,29 < MRV 18,18 < CP-SAT 25,97** (10/10 partout) ; le résultat le plus instructif : **naïf DEVANT MRV** sur easy (coût par nœud non amorti) alors que sur medium_hard le log montre l'inverse (MRV 7/10, naïf 4/10) — le classement s'inverse avec la difficulté = No Free Lunch en acte ; plancher fixe CP-SAT (modélisation 81 variables + 27 AllDifferent) |

## Validation

- **Code byte-identique** : 27/27 cellules code inchangées (source + outputs + `execution_count` comparés JSON par index contre `origin/main`) — enrichissement markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 1082 → **1335 c/cell** (seuil 1200 atteint) ; 84 → 91 cellules ; 94 insertions, 0 deletions.
- **Guards verts** : `detect_consecutive_code_cells.py` 0 run · `detect_markdown_rendering.py` 0 violation · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2).
- **`scan_cell_ordering.py` 1 finding PRÉEXISTANT** : `DANGLING_INTRO` sur la « Note distillation : le code ci-dessous… » (cellule #16 sur `origin/main`, #18 après mes 2 insertions avant elle) — vérifié sur la version origin/main rendue dans un fichier témoin : **le défaut existait avant cette PR et n'est pas causé par elle**. Relevé, non traité (hors scope — règle 3 : signaler, pas toucher).
- **Twin parity** : aucune paire twin dans `scripts/notebook_tools/twin_pairs.d/` pour ce notebook.
- Chiffres re-vérifiés contre le log committé : échecs naïf medium_hard recomptés à la main (6 coupes → 4/10) avant écriture, recuit recompté (6/10 easy, 0/20 au-delà).
- Choix du grain : picker c.21 sans candidat CONTENU non-VOID (tout couvert par PRs ouvertes ou META ; #4362 = Lean lourd, Apply gelé user) — enrichissement Search/Part1-Foundations, chemin disjoint de #13959 (Part4) et #13980 (Applications/Hybrid), #14009 (Applications/CSP).
