### PR TITLE
fix(sln,#13747): reconcilier MyIA.AI.Shared GUID entre les 2 .sln canonique (C3C93A0C) + rattacher MyIA.AI.Shared.Tests a MyIA.CoursIA.sln

### DIFF
--- a/MyIA.CoursIA.sln
+++ b/MyIA.CoursIA.sln
@@ -3,8 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyIA.AI.Shared", "MyIA.AI.Shared\MyIA.AI.Shared.csproj", "{7A348024-9D4A-4E70-B7AE-6757C0BBF994}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyIA.AI.Shared", "MyIA.AI.Shared\MyIA.AI.Shared.csproj", "{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.AI.Shared.Tests", "MyIA.AI.Shared.Tests\MyIA.AI.Shared.Tests.csproj", "{852EA4BC-F566-451E-84D4-659ECDC79A88}"
+EndProject
+
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.AI.Notebooks", "MyIA.AI.Notebooks\MyIA.AI.Notebooks.csproj", "{2DCA709C-28FB-4369-B93C-A256CFE27F99}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.Trading.Converter", "MyIA.Trading.Converter\MyIA.Trading.Converter.csproj", "{F3B5C8D1-2E47-4A89-9B6E-3C8F2A1D7E45}"
@@ -19,10 +22,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7A348024-9D4A-4E70-B7AE-6757C0BBF994}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7A348024-9D4A-4E70-B7AE-6757C0BBF994}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7A348024-9D4A-4E70-B7AE-6757C0BBF994}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7A348024-9D4A-4E70-B7AE-6757C0BBF994}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2DCA709C-28FB-4369-B93C-A256CFE27F99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2DCA709C-28FB-4369-B93C-A256CFE27F99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2DCA709C-28FB-4369-B93C-A256CFE27F99}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## fix(sln,#13747): reconcilier MyIA.AI.Shared GUID entre les 2 .sln canonique (C3C93A0C) + rattacher MyIA.AI.Shared.Tests a MyIA.CoursIA.sln

Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA-2 — prev: LIGHT/narrow-cycle #13047 (REPAIR signalisation)

Refs #13747 (V3 consolidation .NET racine, tranche 1/N)
Refs #13737 (EPIC consolidation navigation transversale)

## Contexte

Issue #13747 (consolidation Projets .NET racine) liste 6 sous-points. Cette PR adresse la **tranche 1/N** : les 2 premiers points (GUID divergents + Tests orphelin d'une solution), confirmés first-hand.

**Vérification first-hand (2026-09-01, main HEAD 6ece451c8)** :

| Fichier | GUID de MyIA.AI.Shared | Présent ? |
|---|---|---|
| `MyIA.AI.Shared.sln` | `C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04` | ✅ |
| `MyIA.CoursIA.sln` | `7A348024-9D4A-4E70-B7AE-6757C0BBF994` | ✅ (DIFFÉRENT) |
| `MyIA.AI.Shared.Tests` dans `MyIA.CoursIA.sln` | — | ❌ ABSENT |
| `MyIA.AI.Shared.Tests` dans `MyIA.AI.Shared.sln` | `852EA4BC-F566-451E-84D4-659ECDC79A88` | ✅ |

## Modifications

### 1. GUID canonique de MyIA.AI.Shared

Choix : **`C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04`** (celui de `MyIA.AI.Shared.sln`, le .sln dédié du projet). Justification : c'est le .sln historique du projet (donc canonique), le GUID dans `MyIA.CoursIA.sln` a probablement été regénéré par Visual Studio lors d'une réimportation.

**Modifications** :
- `MyIA.CoursIA.sln` ligne `Project(...)` : GUID `7A348024-...` → `C3C93A0C-...`
- `MyIA.CoursIA.sln` section `ProjectConfigurationPlatforms` : 4 références mises à jour (Debug/Release × ActiveCfg/Build.0)

### 2. Rattachement de MyIA.AI.Shared.Tests à MyIA.CoursIA.sln

**Ajouts** :
- `MyIA.CoursIA.sln` ligne `Project("...MyIA.AI.Shared.Tests...", "{852EA4BC-...}")` insérée après le project MyIA.AI.Shared
- `MyIA.CoursIA.sln` section `ProjectConfigurationPlatforms` : 4 lignes ajoutées (Debug/Release × ActiveCfg/Build.0)

## Acceptance vérifiée

| Critère | État |
|---|---|
| Un seul GUID canonique pour MyIA.AI.Shared | ✅ `C3C93A0C` |
| MyIA.AI.Shared.Tests ajouté à MyIA.CoursIA.sln | ✅ |
| `dotnet build MyIA.AI.Shared.csproj` | ✅ 0 erreurs, 0 avertissements |
| `dotnet build MyIA.AI.Shared.Tests.csproj` | ✅ 0 erreurs, 0 avertissements (la dépendance à MyIA.AI.Shared résout correctement) |
| Catalogue byte-identique | ✅ (pas de catalogue touché) |

**Note sur le build complet** : `dotnet build MyIA.CoursIA.sln` a échoué dans cet environnement à cause d'un téléchargement NuGet (`Microsoft.ML.DnnImageFeaturizer.AlexNet.0.24.0-preview.26160.2`) qui n'aboutit pas (réseau/CI). **Ce problème est externe à cette PR** (projet MyIA.AI.Notebooks, non touché par mes modifs). Les 2 projets que je modifie compilent OK en isolation.

## Anti-régression

- **Pas de modification de MyIA.AI.Shared.sln** (le .sln canonique reste intact).
- **Pas de modification de MyIA.AI.Shared.csproj / MyIA.AI.Shared.Tests.csproj** (uniquement le .sln qui les référence).
- **Notebooks .NET Interactive inchangés** : `MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb` référence `MyIA.AI.Shared` par chemin DLL (`#r "..."`), pas par GUID → runtime préservé.

## Hors scope c.301 (tranches ultérieures de #13737 / #13747)

- `OutputType=Exe` dans `MyIA.AI.Notebooks.csproj` (sortir le générateur `AutoInvokeSKAgentsNotebookUpdater` dans un projet dédié `MyIA.WorkbookGen/`) — V3 tranche 2, demande création de projet
- `ML/ML.Net/Infer.NETCacheHelper.cs` orphelin — V3 tranche 3
- `LearningTheory.en.md` (ML.NET) — V3 tranche 4 / relocalisation Epic #1650
- 0 référence entrante sur `MyIA.AI.Shared` (à vérifier plus précisément après cette PR)

Refs #13737 (V3 racine ≤ 12 entrées)

## Suite

- PR mergeable substance-OK (build des 2 projets affectés validés)
- Tranches 2-4 de #13747 restent à traiter en cycles ultérieurs