### PR TITLE
fix(guard,#13946): check_pr_perimeter -- co-presence d'assertion concurrente

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -396,6 +396,112 @@ def _count_is_range_enum(line: str, m: re.Match) -> bool:
     return bool(_RANGE_ENUM_TAIL.match(tail if nl < 0 else tail[:nl]))
 
 
+# #13946 : nombre « nu » apres verbe de perimetre -- l'ellipse du nom est
+# legittime en francais (« qui en touche 2 ») et en anglais shorthand
+# (« touches 2 », « adds 2 »). Sans cette variante, le perimetre reel
+# (« touche 2 ») n'est pas visible pour le predicat de co-presence.
+_BARE_COUNT_VERBS = (
+    "touche", "touchent", "livré", "livrée", "livres", "livre",
+    "modifie", "modifiés", "modifiée", "modifiees",
+    "ajoute", "ajouté", "ajoutés", "ajoutée",
+    "englobe", "englobent", "concerne", "concernent",
+)
+_BARE_COUNT_AFTER_VERB_RE = re.compile(
+    r"\b(?:" + "|".join(_BARE_COUNT_VERBS) + r")\s+(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+# #13946 : un compte N fichiers est cite POUR ETRE REFUTE quand, sur la meme
+# ligne ou dans le meme bloc de paragraphe, une AUTRE assertion de perimetre
+# explicite (verbe d'action + compte qui matche len(files)) declare le vrai
+# perimetre. Le garde punissait la precaution qu'il devrait recompenser :
+# l'auteur desambigue (cite les comptes hors-scope, declare le perimetre
+# reel), et plus il ecrit d'occurrences du nombre, plus il a de chances de
+# rougir. Le predicat ci-dessous distingue *affirmer* un compte de le *citer
+# pour le nier* en co-presence d'une assertion concurrente du meme paragraphe.
+#
+# Verbe d'action = un mot-cle qui designe ce que la PR livre / modifie /
+# touche, distinct d'un verbe de mention / citation / description.
+_PERIMETER_VERBS = (
+    "touche", "touchent", "livré", "livrée", "livres", "livre",
+    "modifie", "modifiés", "modifiée", "modifiees",
+    "ajoute", "ajouté", "ajoutés", "ajoutée",
+    "perimetre", "périmètre", "perimeter",
+    "scope", "englobe", "englobent", "concerne", "concernent",
+    "edition", "édition",
+)
+_PERIMETER_VERB_RE = re.compile(
+    r"\b(?:" + "|".join(_PERIMETER_VERBS) + r")\b", re.IGNORECASE
+)
+
+
+def _count_concurrent_with_perimeter_claim(
+    line: str, m: re.Match, block: str, file_count: int
+) -> bool:
+    """True when the count `m` is CO-PRESENT on its line (or in the enclosing
+    paragraph block) with a competing perimeter assertion whose numeric value
+    matches `file_count`. Founder #13946 : PR #13856 wrote « 28 fichiers tranche
+    3 » (compte prévisionnel hors-scope) AND « qui en touche 2 » (perimetre
+    reel) on the same line -- the body explicitly named both numbers, the
+    author meant the second, the guard read the first.
+
+    Two sub-cases detected:
+    (a) SAME LINE : a perimeter verb followed (anywhere on the rest of the
+        line) by a count whose value matches `file_count`. The count form
+        can be EITHER « N fichiers » (COUNT_CLAIM) OR « verbe N » (ellipse
+        du nom -- « qui en touche 2 », « touches 2 »). The match `m` is the
+        other count, on the same surface.
+    (b) SAME BLOCK : the enclosing paragraph block contains a perimeter verb
+        followed by a count matching `file_count`. The match `m` is one of
+        multiple counts on a multi-line scope statement.
+
+    Safe by construction : exemption fires only when ANOTHER count on the same
+    line or block matches len(files). A single count whose value already
+    matches len(files) never reaches this branch (claimed == len(files)
+    short-circuits earlier in check_assertion). The only way the exemption
+    triggers is a perimeter assertion that competes with `m` -- exactly the
+    co-presence the issue names.
+    """
+    claimed = int(m.group(1))
+    if claimed == file_count:
+        return False  # m itself already matches; no exemption needed
+    if not _PERIMETER_VERB_RE.search(line):
+        return False  # no perimeter verb on m's line -> nothing competes
+
+    def _has_matching_count_on(surface: str, start_excl: int = -1) -> bool:
+        # (1) « N fichiers » shape -- COUNT_CLAIM matches the named form
+        for other in COUNT_CLAIM.finditer(surface):
+            if other.start() == start_excl:
+                continue
+            if int(other.group(1)) == file_count:
+                return True
+        # (2) bare « verbe N » shape -- _BARE_COUNT_AFTER_VERB_RE matches
+        # the ellipse. The verb is captured IN the regex, so any hit has
+        # the verb present.
+        for other in _BARE_COUNT_AFTER_VERB_RE.finditer(surface):
+            if int(other.group(1)) == file_count:
+                return True
+        return False
+
+    # (a) same line : any other count (named or bare) matches file_count
+    if _has_matching_count_on(line, start_excl=m.start()):
+        return True
+    # (b) same paragraph block : a perimeter verb + matching count on
+    #     ANOTHER line of the block. m's own line is excluded (already
+    #     covered by (a) -- the verb may sit on m's line, with the
+    #     matching count following it).
+    if block:
+        m_line_idx = block.count("\n", 0, block.find(line)) if line in block else -1
+        block_lines = block.splitlines()
+        for idx, bl_line in enumerate(block_lines):
+            if idx == m_line_idx:
+                continue
+            if _PERIMETER_VERB_RE.search(bl_line) and _has_matching_count_on(bl_line):
+                return True
+    return False
+
+
 def check_assertion(files: list[dict], assertion: str, block: str = "") -> list[str]:
     """Confront a perimeter assertion with the effective file list.
 
@@ -446,6 +552,16 @@ def check_assertion(files: list[dict], assertion: str, block: str = "") -> list[
                 if int(mm.group(1)) != 0
                 and not _count_in_citation(scan_target, mm)
                 and not _count_is_range_enum(scan_target, mm)
+                # #13946 : a count cited to be refuted is CO-PRESENT with a
+                # competing perimeter assertion that names len(files). The
+                # filter is content-based, not label-based: the author who
+                # disambiguates by writing "X fichiers (hors scope) qui en
+                # touche Y" deserves the green, not the red. block is the
+                # same enclosing paragraph as the candidate (passed by the
+                # caller's extract_perimeter_assertions_with_block).
+                and not _count_concurrent_with_perimeter_claim(
+                    scan_target, mm, block, len(files)
+                )
             ),
             None,
         )

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -31,6 +31,7 @@ from check_pr_perimeter import (  # noqa: E402
     select_candidates,
     _additive_line_sum,
     _check_unterminated_fence,
+    _count_concurrent_with_perimeter_claim,
     _count_is_exempt,
     _count_is_incidental,
     _fence_line_indices,
@@ -3148,3 +3149,122 @@ def test_13791_paragraph_block_boundaries():
     fenced = "- 1 fichier a\n```python\nx = 1\n```\n"
     idx_f = fenced.splitlines().index("- 1 fichier a")
     assert "x = 1" not in _paragraph_block(fenced, idx_f)
+
+
+# #13946 : un compte N fichiers est cité POUR ÊTRE RÉFUTÉ quand, sur la même
+# ligne ou dans le même bloc de paragraphe, une AUTRE assertion de périmètre
+# explicite (verbe d'action + compte qui matche len(files)) déclare le vrai
+# périmètre. Tests couvrent (a) le scenario fondateur verbatim, (b) la
+# co-presence sur la même ligne sous une autre forme (« perimetre livre N »),
+# (c) la co-presence entre lignes d'un même bloc, (d) le contrôle FN : sans
+# assertion concurrente le compte est confronté normalement.
+
+
+def _first_count_match(line: str, value: str):
+    """Pick the COUNT_CLAIM match whose value equals `value`."""
+    import re as _re
+    pat = _re.compile(r"\b(\d+)\s*(?:fichiers?|files?)\b", _re.IGNORECASE)
+    return next(m for m in pat.finditer(line) if m.group(1) == value)
+
+
+def test_13946_founder_line_exempts_cited_count():
+    """#13856 founder : « 28 fichiers tranche 3 » co-present avec
+    « qui en touche 2 » sur la meme ligne. Le 28 est cite pour etre refute,
+    le 2 est le perimetre reel. Exemption."""
+    line = (
+        "compte « 28 fichiers tranche 3 » sont des constats empiriques "
+        "previsionnels pour les tranches ulterieures (HORS scope PR), "
+        "pas le perimetre livre par cette PR qui en touche 2 (CLAUDE.md "
+        "+ _archive-convention.md)."
+    )
+    m = _first_count_match(line, "28")
+    files = [{"path": "CLAUDE.md"}, {"path": "docs/reference/_archive-convention.md"}]
+    assert _count_concurrent_with_perimeter_claim(line, m, line, len(files)) is True
+
+
+def test_13946_same_line_named_form_exempts():
+    """Co-presence meme ligne sous la forme « perimetre livre N fichiers ». Le 28
+    est hors-scope, le 2 (apres « livre ») est le perimetre reel."""
+    line = "« 28 fichiers » previsionnels, le perimetre livre 2 fichiers"
+    m = _first_count_match(line, "28")
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    assert _count_concurrent_with_perimeter_claim(line, m, line, len(files)) is True
+
+
+def test_13946_multiline_block_exempts():
+    """Co-presence entre lignes du meme paragraphe : le 28 sur la premiere ligne
+    (avec verbe de perimetre) declare le perimetre reel, le compte 99 sur la
+    deuxieme ligne est le hors-scope."""
+    block = (
+        "Le perimetre livre 28 fichiers dans cette tranche.\n"
+        "Hors scope : 99 fichiers seront touches ulterieurement.\n"
+    )
+    m = _first_count_match(block, "99")
+    files = [{"path": f"f{i}.py"} for i in range(28)]
+    assert _count_concurrent_with_perimeter_claim(block, m, block, len(files)) is True
+
+
+def test_13946_no_concurrent_claim_does_not_exempt():
+    """Controle FN : « 28 fichiers » seul, sans assertion concurrente qui matche
+    len(files), n'est pas exempté. Le predicat laisse passer le compte vers
+    la confrontation (qui rougit)."""
+    line = "Jai modifie 28 fichiers dans cette PR."
+    m = _first_count_match(line, "28")
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    assert _count_concurrent_with_perimeter_claim(line, m, line, len(files)) is False
+
+
+def test_13946_no_perimeter_verb_does_not_exempt():
+    """Controle FN : pas de verbe de perimetre sur la ligne -> pas d'exemption,
+    meme si plusieurs nombres sont co-presents."""
+    line = "Inventaire : 28 fichiers totaux, 2 dossiers, 11 emplacements."
+    m = _first_count_match(line, "28")
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    assert _count_concurrent_with_perimeter_claim(line, m, line, len(files)) is False
+
+
+def test_13946_no_other_count_does_not_exempt():
+    """Controle FN : verbe de perimetre present mais AUCUN autre count qui
+    matche len(files) -> pas d'exemption."""
+    line = "Le perimetre livre 5 fichiers (cette PR en touche 7 ailleurs)."
+    # line n'a pas de COUNT_CLAIM (« 5 fichiers » est un count, mais le verbe
+    # est sur la meme ligne ; le predicat regarde si un AUTRE count matche).
+    # On prend le 7 (word-form, pas COUNT_CLAIM). Simulons : seul un compte
+    # « 5 fichiers » matche COUNT_CLAIM, et il matche lui-meme le verbe.
+    # En construisant m=5, on demande si un autre count matche len(files)=5.
+    # Aucun autre -> pas d'exemption.
+    m = _first_count_match(line, "5")
+    files = [{"path": f"f{i}.py"} for i in range(5)]
+    assert _count_concurrent_with_perimeter_claim(line, m, line, len(files)) is False
+
+
+def test_13946_founder_pr_13856_scan_passes():
+    """Integration : `check_pr_perimeter 13856 --scan-thread` rend rc=0
+    apres le fix. Le corps de #13856 a le 28 dans un span «» ET en co-
+    presence avec « qui en touche 2 » -- le fix couvre la classe, le span
+    couvre deja l'instance."""
+    import subprocess
+    proc = subprocess.run(
+        ["python", "scripts/check_pr_perimeter.py", "13856", "--scan-thread"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=".",
+    )
+    assert proc.returncode == 0, (
+        f"PR #13856 doit passer apres le fix, a rendu rc={proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_13946_tp_pr_13860_still_red():
+    """Non-regression : #13860 (vrai positif : body pretend 2 fichiers,
+    liste effective 0) reste rouge. Le predicat ne s'active que quand UNE
+    AUTRE assertion de perimetre matche len(files), pas quand le body est
+    simplement faux."""
+    import subprocess
+    proc = subprocess.run(
+        ["python", "scripts/check_pr_perimeter.py", "13860", "--scan-thread"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=".",
+    )
+    assert proc.returncode == 1, (
+        f"PR #13860 doit rester rouge (vrai positif), a rendu rc={proc.returncode}\n"
+        f"stdout:\n{proc.stdout}"
+    )


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13990 cycle 84

## Issue #13946 — co-presence d'assertion concurrente (piste 3)

Le predicat `check_pr_perimeter` matchait un nombre suivi de « fichiers » sans
regarder le contexte enonciatif. Quand un auteur desambigue (cite des comptes
hors-scope ET declare le perimetre reel sur la meme ligne ou dans le meme
paragraphe), le garde **punissait la precaution qu'il devrait recompenser** :
plus il ecrivait d'occurrences du nombre, plus il avait de chances de rougir.

### Scenario fondateur (issue #13946, PR #13856)

Body verbatim :

> Les comptes « 28 fichiers », « 3 sous-dossiers », « 11 emplacements » listes
> ci-dessus et dans la doc sont des **constats empiriques previsionnels** pour
> les tranches ulterieures (HORS scope PR), **pas** le perimetre livre par
> cette PR qui en touche 2 (CLAUDE.md + `_archive-convention.md`).

L'auteur a : (a) marque le compte `(hors scope PR)`, (b) mis le nombre entre
guillemets francais, (c) enonce le vrai perimetre -- « qui en touche 2 » -- a
six mots de distance. Les trois signaux disponibles sont presents.

### Etat avant le fix (mesure firsthand)

```
$ python scripts/check_pr_perimeter.py 13856 --scan-thread
...
~~ [review (COMMENTED) / jsboige] l'assertion pretend 28 fichier(s),
   la liste effective en compte 2 : CLAUDE.md, docs/reference/_archive-convention.md
VERDICT: OK   (avec SIGNAL non-bloquant)
```

Le span `« ... »` couvrait deja le 28 sur origin/main (post #13888). Mais la
**classe de bug** reste : un auteur qui omet les guillemets francais, OU qui
declare le perimetre par ellipse (« qui en touche 2 » sans le mot « fichiers »),
rougit toujours. C'est exactement la classe que l'issue #13946 nomme en
acceptant la piste 3.

## Fix

Predicat `_count_concurrent_with_perimeter_claim(line, m, block, file_count)`
qui distingue *affirmer* un compte de le *citer pour le nier* en co-presence
d'une assertion concurrente du meme paragraphe.

**Deux sources de compte** :

| Source | Pattern | Exemple |
|---|---|---|
| `COUNT_CLAIM` (existant) | `\b(\d+)\s*(?:fichiers?|files?)\b` | « 28 fichiers tranche 3 » |
| `_BARE_COUNT_AFTER_VERB_RE` (nouveau) | `\b(?:touche\|touche...)\s+(\d+)\b` | « qui en touche 2 » (ellipse) |

**Deux surfaces de detection** :

- (a) **meme ligne** : verbe de perimetre + autre count qui matche `len(files)`
- (b) **meme bloc de paragraphe, autre ligne** : verbe de perimetre + count
      qui matche `len(files)` sur une autre ligne du bloc

**Safe par construction** : exemption tiree SEULEMENT quand une AUTRE assertion
de perimetre matche `len(files)`. Un compte unique dont la valeur ne matche
pas continue de rougir normalement.

**Verbe de perimetre** (closed list, false-negative default) :

```
touche, touchent, livre, livré, livrée, livres,
modifie, modifiés, modifiée, modifiees,
ajoute, ajouté, ajoutés, ajoutée,
englobe, englobent, concerne, concernent,
perimetre, périmètre, perimeter, scope, edition
```

## Verification

| Item | Resultat |
|---|---|
| `pytest scripts/tests/test_check_pr_perimeter.py` | **182/182 PASS** (174 anciens + 8 nouveaux) |
| `pytest scripts/tests/` (full) | **4069/4069 PASS** (skip 2 tests flaky pre-existants) |
| `check_pr_perimeter 13856 --scan-thread` (FP fondateur) | **rc=0** OK |
| `check_pr_perimeter 13860 --scan-thread` (TP, body pretend 2 / liste 0) | **rc=1** FAIL (conserve) |
| `check_pr_perimeter 13884 --scan-thread` (TP, body pretend 3 / liste 1) | **rc=1** FAIL (conserve) |
| `check_pr_perimeter 13921 --scan-thread` (TP selon issue) | OK SIGNAL (etait OK avant le fix, comportement identique) |

## Tests ajoutes (8)

- `test_13946_founder_line_exempts_cited_count` : scenario fondateur verbatim
- `test_13946_same_line_named_form_exempts` : co-presence meme ligne sous forme nommee « perimetre livre N fichiers »
- `test_13946_multiline_block_exempts` : co-presence entre lignes d'un meme bloc
- `test_13946_no_concurrent_claim_does_not_exempt` : controle FN (verbe mais pas d'autre count)
- `test_13946_no_perimeter_verb_does_not_exempt` : controle FN (counts sans verbe)
- `test_13946_no_other_count_does_not_exempt` : controle FN (verbe + count, mais compte matche lui-meme)
- `test_13946_founder_pr_13856_scan_passes` : integration scan PR #13856 -> rc=0
- `test_13946_tp_pr_13860_still_red` : non-regression scan PR #13860 -> rc=1

## Perimetre

```
scripts/check_pr_perimeter.py            | 116 ++++++++++++++++++++++++++++++
scripts/tests/test_check_pr_perimeter.py | 120 +++++++++++++++++++++++++++++++
2 files changed, 236 insertions(+)
```

Pure addition. Aucune ligne de code existante modifiee -- l'ajout du predicat
est strictement borne au filter `count_claim` (1 ligne de condition ajoutee).

Closes #13946

## Note sur la duplication

Le script sur origin/main couvre deja partiellement le cas fondateur via
`_GUILLEMET_SPAN` (le 28 est dans `« 28 fichiers tranche 3 »` sur la ligne 29
du body de #13856). Le fix ici etend la couverture a la CLASSE de patterns
(meme sans guillemets, ou avec ellipse du nom), pas seulement a l'instance.
C'est la portee que l'issue #13946 nomme en acceptation : un detecteur qui
matche des phrases doit ignorer les occurrences en position de citation OU
de refutation, sinon il rend impossible d'ecrire sur le defaut qu'il detecte.