### PR TITLE
fix(guard,#13965): variation_light_cap -- ledger canonique + consumed_by placeholder

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -278,7 +278,7 @@ jobs:
           if [ "$CAP" = "True" ]; then
             gh pr edit "$PR_NUMBER" --add-label variation-light-cap-reached 2>/dev/null || true
             LANE=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('lane','?'))" 2>/dev/null || echo "?")
-            CB=$(python3 -c "import json; c=(json.load(open('/tmp/status.json')).get('consumed_by') or {}); print(f\"#{c.get('number','?')} (merge a {c.get('mergedAt','?')})\")" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
+            CB=$(python3 -c "import json; d=json.load(open('/tmp/status.json')); c=d.get('consumed_by'); print(f'#{c[\"number\"]} (merge a {c[\"mergedAt\"]})') if isinstance(c, dict) and c.get('number') and c.get('mergedAt') else print('une LIGHT anterieure de cette lane')" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
             # Commentaire idempotent (marqueur HTML invisible anti-spam).
             MARK="<!-- gvar2-light-cap -->"
             if ! gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$MARK"; then

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -361,7 +361,7 @@ jobs:
           if [ "$CAP" = "True" ]; then
             gh pr edit "$PR_NUMBER" --add-label variation-light-cap-reached 2>/dev/null || true
             LANE=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('lane','?'))" 2>/dev/null || echo "?")
-            CB=$(python3 -c "import json; c=(json.load(open('/tmp/status.json')).get('consumed_by') or {}); print(f\"#{c.get('number','?')} (merge a {c.get('mergedAt','?')})\")" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
+            CB=$(python3 -c "import json; d=json.load(open('/tmp/status.json')); c=d.get('consumed_by'); print(f'#{c[\"number\"]} (merge a {c[\"mergedAt\"]})') if isinstance(c, dict) and c.get('number') and c.get('mergedAt') else print('une LIGHT anterieure de cette lane')" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
             # Commentaire idempotent : un marqueur HTML invisible evite le spam
             # a chaque synchronize. On ne poste que si aucun commentaire ne le
             # porte deja.

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -1996,3 +1996,87 @@ def test_light_guard_on_spent_tier_budget_still_caps_13632():
     )
     assert out["tier_cap_reached"] is True
     assert out["cap_reached"] is True
+
+
+# #13965 defaut 1 : un diff md-only sous `docs/ledgers/` (la forme canonique
+# d'une tranche de ledger) inferait `docs` face a une declaration honnete
+# `Grain: MED/ledger` -> GENRE-MISMATCH par construction. Le predicat doit
+# rendre `ledger` pour ce sous-dossier specialise, AVANT le test `docs/`
+# generaliste.
+
+
+def test_13965_genre_from_paths_ledger_canonical():
+    """`docs/ledgers/<file>.md` -> `ledger` (sous-dossier specialise gagne
+    sur son parent `docs/`)."""
+    from variation_light_cap import _genre_from_paths
+    files = ["docs/ledgers/12204-ict-chantier-1-a2.md"]
+    assert _genre_from_paths(files) == "ledger"
+
+
+def test_13965_genre_from_paths_ledger_archive():
+    """`docs/archive/ledgers-reviews/<file>.md` -> `ledger` (archive)."""
+    from variation_light_cap import _genre_from_paths
+    files = ["docs/archive/ledgers-reviews/2026-08-15.md"]
+    assert _genre_from_paths(files) == "ledger"
+
+
+def test_13965_genre_from_paths_docs_other_unchanged():
+    """Controle FN : les autres sous-dossiers `docs/` NON-`ledgers/`
+    continuent de rendre `docs`. La nouvelle branche ne mange pas la
+    portee de `docs/`."""
+    from variation_light_cap import _genre_from_paths
+    assert _genre_from_paths(["docs/reference/claude-code-config.md"]) == "docs"
+    assert _genre_from_paths(["docs/lean/i18n-inventory-cycle-38.md"]) == "docs"
+    assert _genre_from_paths(["docs/README.md".lower().replace("readme.md", "REFERENCE.md")]) in (
+        "docs",
+        None,
+    )
+
+
+def test_13965_genre_mismatch_no_longer_fires_on_canonical_ledger(tmp_path, capsys):
+    """Integration : un PR declare `Grain: MED/ledger` avec un diff md-only
+    sous `docs/ledgers/` ne leve plus GENRE-MISMATCH. Issue #13956 etait
+    le premier cas fondateur ; le fix ferme la classe.
+
+    Le test verifie qu'un PR de ledger md-only declare honnetement ne
+    produit PAS le signal, et qu'un PR md-only declare `guard` SUR le
+    meme sous-dossier le produit ENCORE (controle FN de portee)."""
+    merged_obj = [
+        {"number": 1, "body": "Grain: MED/ledger -- lane myia-po-2023:CoursIA",
+         "mergedAt": "2026-08-08T01:00:00Z"},
+    ]
+    mpath = tmp_path / "merged.json"
+    mpath.write_text(json.dumps(merged_obj), encoding="utf-8")
+    bpath = tmp_path / "body.txt"
+    bpath.write_text(
+        "Grain: MED/ledger -- lane myia-po-2023:CoursIA", encoding="utf-8"
+    )
+    rc = vlc.main([
+        "--replay", str(mpath), "--genre-signals",
+        "--lane", "myia-po-2023:CoursIA",
+        "--body-file", str(bpath),
+        "--files", "docs/ledgers/12204-ict-chantier-1-a2.md",
+    ])
+    out = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert rc == 0
+    # Inferred = declared = `ledger` -> MISMATCH is False.
+    assert out["signals"]["GENRE-MISMATCH"] is False
+    assert out["inferred_genre_from_paths"] == "ledger"
+    assert out["candidate_genre_canonical"] == "ledger"
+
+    # Controle FN : declare `guard` sur le meme sous-doyer -> mismatch
+    # (le fix ne mange pas les vrais positifs de l'axe docs/).
+    bpath.write_text(
+        "Grain: MED/guard -- lane myia-po-2023:CoursIA", encoding="utf-8"
+    )
+    capsys.readouterr()  # clear
+    vlc.main([
+        "--replay", str(mpath), "--genre-signals",
+        "--lane", "myia-po-2023:CoursIA",
+        "--body-file", str(bpath),
+        "--files", "docs/ledgers/12204-ict-chantier-1-a2.md",
+    ])
+    out = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert out["signals"]["GENRE-MISMATCH"] is True
+    assert out["inferred_genre_from_paths"] == "ledger"
+    assert out["candidate_genre_canonical"] == "guard"

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -894,6 +894,17 @@ def _genre_from_paths(files: list[str] | None) -> str | None:
         # MISMATCH 12 of 14 honest code declarations (#10102).
         return None
     # md-only diff: classify the prose work.
+    # #13965 : ledgers canoniques vivent sous `docs/ledgers/` (7 mesures,
+    # plus l'archive `docs/archive/ledgers-reviews/`). Sans branche dediee,
+    # un diff md-only sous `docs/ledgers/` rendait `inferred = "docs"` face
+    # a declaration honnete `Grain: MED/ledger` -- mismatch par construction,
+    # le meme defaut que #10102 pour l'axe code. Le predicat teste `ledger`
+    # AVANT `docs` : un sous-dossier specialise gagne sur son parent, et le
+    # seul ledger declare honnetement ne peut plus mismatcher pour cette
+    # raison. Abstention alternative (None) preservee sur les autres formes
+    # md-only que l'heuristique ne classe pas.
+    if any(f.startswith("docs/ledgers/") or f.startswith("docs/archive/ledgers-reviews/") for f in norm):
+        return "ledger"
     if any(f.startswith("docs/") or f.startswith(".claude/") for f in norm):
         return "docs"
     if all(f.rsplit("/", 1)[-1].upper().startswith("README") for f in norm):


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: MED/guard #14020 cycle 84

## Issue #13965 — 2 defauts advisory sur l'organe consultatif de variation

Issue #13965 releve **2 defauts independants** de l'organe consultatif de variation (`scripts/variation_light_cap.py` + 2 workflows). Les 2 sont **advisory, non bloquants** : ce qu'ils coutent n'est pas un blocage, c'est la **credibilite du signal** -- qui est tout ce qu'un organe consultatif possede.

---

## Defaut 1 — `_genre_from_paths` n'a pas de branche `ledger`

**Predicat** (`scripts/variation_light_cap.py:861`) rendait exactement 3 valeurs : `None`, `"docs"`, `"readme"`. Or `ledger` est dans `LIGHT_GENRES` (L585) et **tous** les ledgers du depot vivent sous `docs/` (`git ls-files 'docs/ledgers/*'` en compte 7, plus l'archive `docs/archive/ledgers-reviews/`).

**Consequence** : un diff **100 % `*.md` sous `docs/ledgers/`** (forme canonique d'une tranche de ledger) voyait `inferred = "docs"` face a une declaration honnete `Grain: MED/ledger` -> le predicat L983 levait `GENRE-MISMATCH` **par construction**. **Aucune facon** de declarer `ledger` honnetement sans declencher le signal.

Meme classe de defaut que #10102 documentee en docstring : forcer `tooling` sur un diff de code faisait mismatcher 12 declarations honnetes sur 14. Meme remede n'avait jamais ete porte sur l'axe `ledger` parce que personne n'avait remarque que `ledger` habite `docs/` lui aussi.

### Fix

Branche dediee dans `_genre_from_paths` :

```python
if any(f.startswith("docs/ledgers/") or f.startswith("docs/archive/ledgers-reviews/") for f in norm):
    return "ledger"
if any(f.startswith("docs/") or f.startswith(".claude/") for f in norm):
    return "docs"
```

Testee AVANT la branche `docs/` generaliste : un sous-dossier specialise gagne sur son parent. L'abstention alternative (None) n'a pas ete retenue -- l'inference `ledger` est confiante quand le chemin pin le sous-dossier.

---

## Defaut 2 — placeholder `#? (merge a ?)` quand `consumed_by` est absent

**Lignes responsables**, identiques dans 2 workflows :
- `.github/workflows/always-on-guards.yml:281`
- `.github/workflows/variation-tag-guard.yml:364`

```sh
CB=$(python3 -c "import json; c=(json.load(open('/tmp/status.json')).get('consumed_by') or {}); print(f\"#{c.get('number','?')} (merge a {c.get('mergedAt','?')})\")" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
```

Le `|| echo` ne se declenchait que si python **plantait**. Quand `consumed_by` etait simplement absent ou vide, l'expression python reussissait et rendait les `'?'` par defaut : le lecteur recevait `#? (merge a ?)`, une reference a une PR qui n'existe pas. **Le repli en clair ne s'affichait jamais dans le seul cas ou il servirait.**

### Fix

Test du contenu `consumed_by` avant le print, sinon print le fallback humain directement en Python (le `|| echo` reste en safety net si python plante) :

```sh
CB=$(python3 -c "import json; d=json.load(open('/tmp/status.json')); c=d.get('consumed_by'); print(f'#{c[\"number\"]} (merge a {c[\"mergedAt\"]})') if isinstance(c, dict) and c.get('number') and c.get('mergedAt') else print('une LIGHT anterieure de cette lane')" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
```

Comportement identique (non-regression) lorsque `consumed_by` est normal (`{"number": 12345, "mergedAt": "2026-09-01T..."}`).

---

## Verification

| Item | Avant | Apres |
|---|---|---|
| `pytest test_variation_light_cap.py` | 111/111 | **115/115** (4 nouveaux tests) |
| `pytest scripts/tests/` (full) | n/a | **4065/4065 PASS** (skip 2 flaky pre-existants) |
| `_genre_from_paths(docs/ledgers/X.md)` | `docs` | **`ledger`** |
| `_genre_from_paths(docs/archive/ledgers-reviews/X.md)` | `docs` | **`ledger`** |
| `_genre_from_paths(docs/reference/X.md)` | `docs` | `docs` (non-regression portee) |
| `_genre_from_paths(README.md)` | `readme` | `readme` (non-regression) |
| `consumed_by` absent -> placeholder | `#? (merge a ?)` | **`une LIGHT anterieure...`** |
| `consumed_by` normal -> placeholder | `#12345 (merge a ...)` | `#12345 (merge a ...)` (non-regression) |

## Tests ajoutes (4)

- `test_13965_genre_from_paths_ledger_canonical` : `docs/ledgers/X.md` -> `ledger`
- `test_13965_genre_from_paths_ledger_archive` : `docs/archive/ledgers-reviews/X.md` -> `ledger`
- `test_13965_genre_from_paths_docs_other_unchanged` : controle FN portee (autres `docs/` non-`ledgers/`)
- `test_13965_genre_mismatch_no_longer_fires_on_canonical_ledger` : integration scan PR declare `MED/ledger` -> GENRE-MISMATCH = False ; controle FN scan PR declare `MED/guard` sur meme sous-dossier -> GENRE-MISMATCH = True.

## Perimetre

```
.github/workflows/always-on-guards.yml    |  2 +-
.github/workflows/variation-tag-guard.yml |  2 +-
scripts/tests/test_variation_light_cap.py | 84 ++++++++++++++++++++++++++++++
scripts/variation_light_cap.py            | 11 ++++
4 files changed, 97 insertions(+), 2 deletions(-)
```

Modifications minimales et symetriques : meme ligne remplacee dans les 2 workflows, branche ajoutee dans 1 predicat, 4 tests d'integration pour verrouiller.

## Acceptance (issue #13965)

1. Un ledger canonique (md-only sous `docs/ledgers/`) ne leve plus GENRE-MISMATCH — demontre par test_13965_genre_mismatch_no_longer_fires_on_canonical_ledger (declare `MED/ledger` -> False ; declare `MED/guard` sur meme sous-dossier -> True, controle FN portee).
2. `consumed_by` absent rend une phrase lisible dans les 2 workflows — la nouvelle logique Python teste `isinstance(c, dict) and c.get('number') and c.get('mergedAt')` avant le print.
3. Aucun elargissement du perimetre du signal — `_genre_from_paths(docs/reference/X.md)` continue de rendre `docs` (controle FN dans test_13965_genre_from_paths_docs_other_unchanged).

Closes #13965

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com)