### PR TITLE
fix(picker,#13967): relire le marker G-VAR-3 et remplacer le bloc 'Trois gestes' sur rouge adjacency

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1113,6 +1113,53 @@ def _has_failed_check(state: dict | None) -> bool:
                for c in contexts)
 
 
+# #13967 -- le marker HTML que le guard G-VAR-3 pose en commentaire PR quand
+# il bloque une PR pour adjacency. Le picker relit ce marker pour DECIDER
+# quel conseil afficher : les "Trois gestes" generiques sont faux pour cette
+# cause (un update-branch / un rebase / une correction de substance ne leve
+# jamais un verdict d'adjacence -- le predicat ne depend d'aucune des trois
+# entrees modifiees par ces gestes, cf issue body). Quand le marker est
+# present, le picker DOIT afficher le remede propre (produire un grain d'un
+# autre genre, jamais retaguer le meme travail) et l'interdit de retag, parce
+# que le conseil generique invite au contournement que le guard existe pour
+# fermer (cf variation-protocol.md §2).
+_ADJACENCY_MARKER = "<!-- vtr-adjacency-block -->"
+
+
+def fetch_adjacency_verdicts(numbers: list[int]) -> dict[int, bool]:
+    """Lit les commentaires PR pour detecter le marker d'adjacence G-VAR-3.
+
+    Rend `{number: True}` quand le marker est present dans **un** commentaire
+    (le guard pose le marker en idempotent, et un seul suffit a signifier le
+    blocage). Rend `{}` (pas d'info) sur PR illisible / reseau mort -- le
+    caller DOIT alors retomber sur les "Trois gestes" generiques (chemin
+    conservateur : un faux negatif d'eligibilite au remede propre est
+    preferable a un faux positif qui dit "fais un autre genre" sans que
+    l'adjacence soit reellement la cause).
+
+    Cout : un appel `gh pr view` par PR. `red_backlog` le borne deja au
+    payload de la lane (1 lot) ; sur la mesure #13967 du 2026-09-01, 6 PRs
+    `myia-po-2026:CoursIA` -- 6 requetes marginales sur un cycle ou le picker
+    fait deja 14 requetes par lane (cf docstring `red_backlog`).
+    """
+    out: dict[int, bool] = {}
+    for n in numbers:
+        try:
+            data = json.loads(subprocess.run(
+                ["gh", "pr", "view", str(n), "--repo", REPO,
+                 "--json", "comments"],
+                capture_output=True, text=True, encoding="utf-8",
+                check=True, timeout=30,
+            ).stdout)
+        except Exception:  # noqa: BLE001 - PR illisible = verdict indisponible, pas une panne bloquante
+            continue
+        for c in (data.get("comments") or []):
+            if _ADJACENCY_MARKER in (c.get("body") or ""):
+                out[n] = True
+                break
+    return out
+
+
 def blocking_causes(state: dict, *, age_hours: float | None = None,
                     saturation_hours: float | None = None,
                     inherited: set[str] | None = None) -> list[str]:
@@ -1446,6 +1493,11 @@ def red_backlog(lane: str, threshold_hours: float,
                         reverse=True)[:16]
         foreign_states = fetch_pr_states([p["number"] for p in sample])
         inherited = impute_base_reds({**states, **foreign_states}, author_by)
+    # #13967 : verdict d'adjacence lu en parallele des etats -- le cout est
+    # marginal (1 appel `gh pr view` par PR de la lane, borne par `mine`) et
+    # l'info sert dans `print_red_assignment` a remplacer le bloc "Trois
+    # gestes" generique par le remede propre (cf docstring `_ADJACENCY_MARKER`).
+    adjacency_by_pr = fetch_adjacency_verdicts([pr["number"] for pr in mine])
     red = []
     for pr in mine:
         state = states.get(pr["number"])
@@ -1472,9 +1524,19 @@ def red_backlog(lane: str, threshold_hours: float,
         if sat_cause:
             causes.append(sat_cause)
         if causes:
-            red.append({"number": pr["number"], "title": pr["title"],
-                        "age_hours": round(age),
-                        "causes": causes})
+            entry = {"number": pr["number"], "title": pr["title"],
+                     "age_hours": round(age),
+                     "causes": causes}
+            # #13967 : flag explicite quand le guard G-VAR-3 a pose le marker
+            # sur cette PR. `print_red_assignment` lit ce flag pour remplacer
+            # le bloc "Trois gestes" par le remede propre a l'adjacence.
+            # `None` (PR illisible) **n'est pas** traite comme absence de
+            # verdict -- c'est "information indisponible", et le caller
+            # retombe sur le conseil generique (chemin conservateur documente
+            # dans `fetch_adjacency_verdicts`).
+            if adjacency_by_pr.get(pr["number"]):
+                entry["adjacency_verdict"] = True
+            red.append(entry)
     red.sort(key=lambda r: -r["age_hours"])
 
     triggers = []
@@ -1681,17 +1743,49 @@ def print_red_assignment(lane: str, backlog: dict, threshold_hours: float) -> No
         for cause in item["causes"]:
             print(f"       {cause}")
     print()
-    print("Trois gestes, dans cet ordre -- le premier repare souvent seul :")
-    print("  1. `gh pr update-branch <N>` : rejoue les checks sur une tete fraiche.")
-    print("     Un rouge peut dater d'AVANT la correction du garde qui l'a produit")
-    print("     (mesure du 2026-08-21 : 5 PRs sur 9 n'avaient rien a corriger).")
-    print("     Dater le garde -- `git log -- <script>` -- avant de conclure.")
-    print("  2. conflits : rebaser sur origin/main, `--force-with-lease` si la lane")
-    print("     est seule sur la branche.")
-    print("  3. corriger la substance, pousser, et REPONDRE par ecrit -- au")
-    print("     CHANGES_REQUESTED comme au nit : un push muet ne leve aucune")
-    print("     remarque. `python scripts/check_unaddressed_nits.py <N>` detaille")
-    print("     chaque point non leve, son auteur et sa surface.")
+    # #13967 : quand AU MOINS une PR rouge porte le verdict d'adjacence
+    # (`adjacency_verdict` pose par `red_backlog` apres lecture du marker
+    # G-VAR-3), les "Trois gestes" generiques sont FAUX : aucun ne leve un
+    # blocage d'adjacence (cf mesure de l'issue -- `update-branch`,
+    # rebase, et correction de substance touchent au diff / a la tete /
+    # au SHA, et le predicat du guard n'en lit aucun). Le remede propre
+    # est de produire un grain d'un AUTRE genre, et le conseil generique
+    # invite au contournement que §2 ferme (retag du meme travail).
+    #
+    # On n'affiche le bloc adjacency que si TOUTES les PRs rouges detectees
+    # sont adjacency (et non un mix) : si une PR est adjacency et une autre
+    # est un rouge substance, le geste 3 (substance) reste valide pour la
+    # seconde, et c'est elle qu'il faut traiter en premier -- sinon le
+    # triage par `sort(key=-age_hours)` de `red` ne tient plus.
+    if red and all(r.get("adjacency_verdict") for r in red):
+        n_adj = len(red)
+        s = "s" if n_adj > 1 else ""
+        print(f"Remede UNIQUEMENT pour ces {n_adj} PR{s} -- le verdict G-VAR-3 "
+              "(adjacency) NE se leve NI par un update-branch, NI par un "
+              "rebase, NI par une correction de substance (le predicat ne "
+              "lit ni le diff, ni la tete, ni le SHA).")
+        print()
+        print("  Chaque merge d'un grain d'un AUTRE genre laisse passer "
+              "exactement une PR de la file. C'est le seul geste qui leve "
+              "le blocage -- produire un grain dont le GENRE differe du "
+              "precedent (`prev:` de la prochaine PR).")
+        print()
+        print("  INTERDIT explicite (variation-protocol.md §2) : retaguer "
+              "le meme travail avec un autre genre est le contournement que "
+              "le guard existe pour fermer -- le `prev:` DOIT pointer un "
+              "merge reel d'un autre genre, pas une renomination.")
+    else:
+        print("Trois gestes, dans cet ordre -- le premier repare souvent seul :")
+        print("  1. `gh pr update-branch <N>` : rejoue les checks sur une tete fraiche.")
+        print("     Un rouge peut dater d'AVANT la correction du garde qui l'a produit")
+        print("     (mesure du 2026-08-21 : 5 PRs sur 9 n'avaient rien a corriger).")
+        print("     Dater le garde -- `git log -- <script>` -- avant de conclure.")
+        print("  2. conflits : rebaser sur origin/main, `--force-with-lease` si la lane")
+        print("     est seule sur la branche.")
+        print("  3. corriger la substance, pousser, et REPONDRE par ecrit -- au")
+        print("     CHANGES_REQUESTED comme au nit : un push muet ne leve aucune")
+        print("     remarque. `python scripts/check_unaddressed_nits.py <N>` detaille")
+        print("     chaque point non leve, son auteur et sa surface.")
     print()
     print_unattributed_blocked(backlog)
     print_base_inherited(backlog)

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -1322,3 +1322,139 @@ def test_file_saturation_requires_at_least_one_required_check():
         ("advisory opt", "NEUTRAL", False),
     ])
     assert pig.file_saturation_cause(s, 30.0, 24.0) is None
+
+
+# --- #13967 : le picker relit le marker G-VAR-3 pour remplacer le bloc ---
+# --- "Trois gestes" generique par le remede propre a l'adjacence.        ---
+#
+# Cas fondateur documente par ai-01 le 2026-09-01 : sur 25 PRs rouges
+# mesurables ce jour-la, 13 etaient tenues UNIQUEMENT par G-VAR-3
+# (adjacency), et le bloc "Trois gestes" envoyait la lane faire un
+# `update-branch` qui ne leve jamais le verdict du guard. La boucle etait
+# silencieuse : un cycle, deux cycles, la lane voit "trois gestes", elle en
+# applique un, rien ne bouge, elle revient, le meme bloc lui dit la meme
+# chose.
+
+
+def _backlog_with_adjacency(items):
+    """Backlog minimal pour `print_red_assignment` -- les triggers sont
+    positionnes par l'appelant, ici on n'utilise que `red`."""
+    return {"red": items, "triggers": ["aged"], "aged": [],
+            "unattributed_blocked": [], "base_inherited": [],
+            "nits_unavailable": None, "saturation_hours": 24.0}
+
+
+def test_print_red_assignment_replaces_three_gestes_when_all_adjacency(capsys):
+    """#13967 -- controle positif : toutes les PRs rouges portent le verdict
+    d'adjacence, le picker AFFICHE le remede propre et PASSE les "Trois
+    gestes" generiques. Sans ce test, une regression qui retablirait le bloc
+    generique en toutes circonstances serait indiscernable d'un fix casse."""
+    red = [
+        {"number": 13949, "title": "fix perimeter", "age_hours": 24,
+         "causes": ["check requis en echec : PR gate"],
+         "adjacency_verdict": True},
+        {"number": 13951, "title": "fix tooling", "age_hours": 22,
+         "causes": ["check requis en echec : PR gate"],
+         "adjacency_verdict": True},
+    ]
+    pig.print_red_assignment("myia-po-2026:CoursIA",
+                             _backlog_with_adjacency(red), 24.0)
+    out = capsys.readouterr().out
+    # Le bloc "Trois gestes" numerote (geste 1/2/3) est le conseil generique
+    # qu'il faut eviter sur un rouge adjacency -- il FAIT le geste 1
+    # (update-branch). La mention "update-branch" dans le bloc "Remede
+    # UNIQUEMENT" est en revanche CITEE pour dire qu'il NE leve PAS
+    # l'adjacence, et c'est le message utile. C'est la presence du geste 1
+    # NUMEROTE qui signe le bloc generique.
+    assert "1. `gh pr update-branch" not in out, (
+        f"le geste 1 numerote ('gh pr update-branch') ne doit PAS apparaitre "
+        f"quand toutes les PRs sont adjacency. Sortie : {out!r}"
+    )
+    assert "Remede UNIQUEMENT" in out
+    assert "G-VAR-3" in out
+    assert "INTERDIT explicite" in out
+
+
+def test_print_red_assignment_keeps_three_gestes_when_one_pr_is_substance(capsys):
+    """#13967 -- controle positif (mixed case) : si UNE seule PR porte
+    `adjacency_verdict` mais une autre est un rouge substance (FAIL sur un
+    check non lie a l'adjacence), le geste 3 (substance) reste valide pour
+    la seconde, et c'est elle qu'il faut traiter en premier. Le picker
+    garde donc le bloc "Trois gestes" -- la decision est documentee inline
+    dans `print_red_assignment`."""
+    red = [
+        {"number": 13949, "title": "fix perimeter", "age_hours": 24,
+         "causes": ["check requis en echec : PR gate"],
+         "adjacency_verdict": True},
+        {"number": 13961, "title": "fix tests", "age_hours": 30,
+         "causes": ["check requis en echec : PR gate"]},  # substance
+    ]
+    pig.print_red_assignment("myia-po-2026:CoursIA",
+                             _backlog_with_adjacency(red), 24.0)
+    out = capsys.readouterr().out
+    assert "Trois gestes" in out, (
+        f"mixed case (adjacency + substance) doit garder le bloc generique. "
+        f"Sortie : {out!r}"
+    )
+    assert "Remede UNIQUEMENT" not in out
+
+
+def test_print_red_assignment_keeps_three_gestes_when_no_marker(capsys):
+    """#13967 -- non-regression : aucune PR ne porte `adjacency_verdict`,
+    le bloc historique reste inchange."""
+    red = [
+        {"number": 13961, "title": "fix tests", "age_hours": 30,
+         "causes": ["check requis en echec : PR gate"]},
+    ]
+    pig.print_red_assignment("myia-po-2026:CoursIA",
+                             _backlog_with_adjacency(red), 24.0)
+    out = capsys.readouterr().out
+    assert "Trois gestes" in out
+    assert "update-branch" in out  # geste 1 du bloc historique
+    assert "Remede UNIQUEMENT" not in out
+
+
+def test_fetch_adjacency_verdicts_reads_marker_in_comments(monkeypatch):
+    """#13967 -- le marker `<!-- vtr-adjacency-block -->` est dans un
+    commentaire PR (le guard le pose via `gh pr comment`, pas dans le
+    body). Le picker doit le detecter dans la liste de commentaires."""
+    payload = {
+        "comments": [
+            {"author": {"login": "reviewer"}, "body": "lgtm"},
+            {"author": {"login": "github-actions"},
+             "body": "<!-- vtr-adjacency-block -->\nG-VAR-3 : deux grains..."},
+        ]
+    }
+    calls = []
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeCompleted(json.dumps(payload))
+    monkeypatch.setattr(pig.subprocess, "run", fake_run)
+    out = pig.fetch_adjacency_verdicts([13949])
+    assert out == {13949: True}
+    assert len(calls) == 1
+    assert "13949" in calls[0]
+
+
+def test_fetch_adjacency_verdicts_returns_empty_on_no_marker(monkeypatch):
+    """#13967 -- sans marker, la PR n'est pas dans le dict rendu. Le caller
+    (`red_backlog`) ne pose alors pas `adjacency_verdict` sur l'item, et
+    `print_red_assignment` garde le bloc historique."""
+    payload = {"comments": [{"author": {"login": "x"}, "body": "no marker here"}]}
+    monkeypatch.setattr(pig.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(json.dumps(payload)))
+    out = pig.fetch_adjacency_verdicts([13961])
+    assert out == {}
+
+
+def test_fetch_adjacency_verdicts_swallows_gh_failures_silently(monkeypatch):
+    """#13967 -- un crash `gh` (timeout, reseau) ne leve PAS : le caller
+    retombe sur le bloc generique (chemin conservateur documente dans la
+    docstring). Une levee ici aurait signifie "le picker peut etre tue par
+    une panne reseau", ce qui est exactement ce que les autres helpers
+    evitent deja (cf `unaddressed_review_points`, `red_backlog`)."""
+    def boom(cmd, **kwargs):
+        raise pig.subprocess.TimeoutExpired(cmd, 30)
+    monkeypatch.setattr(pig.subprocess, "run", boom)
+    out = pig.fetch_adjacency_verdicts([13961, 13962])
+    assert out == {}, f"un timeout ne doit pas remonter, got {out!r}"


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: MED/picker #13969 cycle 86

## Issue #13967 — relire le marker G-VAR-3 et remplacer le bloc "Trois gestes" sur rouge adjacency

Quand `pick_idle_grain.py` assigne la reparation d'une PR rouge, il proposait **trois gestes generiques** (update-branch, rebase, correction de substance) dans TOUTES les situations — y compris quand la cause du rouge etait l'**adjacence G-VAR-3** (genre LIGHT consecutif pour la meme lane).

Or aucun des trois ne leve un blocage d'adjacence : le predicat du guard ne lit **ni le diff, ni la tete, ni le SHA** — il resout le predecesseur sur la **sequence mergee** (`prev_source: merged-sequence`), comme le precise le docstring `variation_adjacency_guard.py`.

### Mesure (2026-09-01, documentee par ai-01)

Sur 25 PRs rouges mesurables, **13 etaient tenues UNIQUEMENT par G-VAR-3** (38 % du pool bloque — avant le fix #13978 sur l'`adjacency_via_cancelled`). Le plus souvent, le seul advisory `List open-PR path collisions` en `cancelled` coexistait avec un `PR gate: SUCCESS` sur des PRs MERGEES (#13916, #13860).

Repartition par lane : `myia-po-2026:CoursIA` 6 · `myia-po-2026:CoursIA-2` 4 · `myia-ai-01:CoursIA` 2 · `myia-ai-01:myia-open-webui` 1.

**La lane qui suivait les "Trois gestes" rebouclait** : un cycle, deux cycles, meme bloc, meme verdict, zero progression. Le defaut fondateur du genre est documente inline dans le commentaire de `red` (#13978) et dans la mesure de l'issue #13967.

### Le bon remede — produit par le guard, ecrase par le picker

Le guard G-VAR-3 **dit deja la bonne chose** dans son propre message d'echec :

> « piochez un grain d'UN AUTRE genre, ne retaguez pas le meme travail » (variation-protocol.md §2)

C'est le picker qui, en re-emballant le rouge dans sa liste generique de trois gestes, **ecrasait** ce message par un conseil faux. Le defaut est dans la couche qui resume, pas dans celle qui mesure.

### Fix applique

**1. Nouvelle fonction `fetch_adjacency_verdicts`** (`scripts/pick_idle_grain.py:1115+`) : lit les commentaires PR via `gh pr view --json comments` et detecte le marker HTML `<!-- vtr-adjacency-block -->` que le guard G-VAR-3 pose en idempotent.

- Cout : 1 appel `gh pr view` par PR de la lane (borne deja par `red_backlog` au payload de la lane — 6 sur la mesure du 2026-09-01).
- Echec gh = verdict indisponible (`{}`), pas d'exception (chemin conservateur documente, coherence avec `unaddressed_review_points` / `red_backlog`).

**2. Enrichissement de `red_backlog`** : chaque item rouge porte `adjacency_verdict: True` quand le marker est detecte. `None` (PR illisible) **n'est pas** traite comme absence — c'est « information indisponible », et `print_red_assignment` retombe sur le bloc generique (un faux negatif d'eligibilite au remede propre est preferable a un faux positif qui dit « fais un autre genre » sans que l'adjacence soit reellement la cause).

**3. Variation de `print_red_assignment`** : si TOUTES les PRs rouges portent `adjacency_verdict`, le bloc « Trois gestes » est REMPLACE par :

```
Remede UNIQUEMENT pour ces N PRs -- le verdict G-VAR-3 (adjacency) NE
se leve NI par un update-branch, NI par un rebase, NI par une correction
de substance (le predicat ne lit ni le diff, ni la tete, ni le SHA).

Chaque merge d'un grain d'un AUTRE genre laisse passer exactement une
PR de la file. C'est le seul geste qui leve le blocage -- produire un
grain dont le GENRE differe du precedent (`prev:` de la prochaine PR).

INTERDIT explicite (variation-protocol.md §2) : retaguer le meme travail
avec un autre genre est le contournement que le guard existe pour fermer
-- le `prev:` DOIT pointer un merge reel d'un autre genre, pas une
renomination.
```

**4. Cas mixte documente inline** : si UNE seule PR porte `adjacency_verdict` mais une autre est un rouge substance, le geste 3 (substance) reste valide pour la seconde — le bloc historique tient. La logique est documentee dans le commentaire de branche (`else: print("Trois gestes...")`) avec renvoi au test `test_print_red_assignment_keeps_three_gestes_when_one_pr_is_substance`.

### Tests ajoutes (6)

- `test_print_red_assignment_replaces_three_gestes_when_all_adjacency` : controle positif — 2 PRs adjacency, le geste 1 numerote (`1. gh pr update-branch`) disparait. Assertion ciblee sur le geste numerote, pas sur le mot « update-branch » (qui apparait dans le bloc « Remede UNIQUEMENT » pour dire qu'il NE leve PAS).
- `test_print_red_assignment_keeps_three_gestes_when_one_pr_is_substance` : controle positif mixed case — 1 adjacency + 1 substance, bloc historique garde.
- `test_print_red_assignment_keeps_three_gestes_when_no_marker` : non-regression.
- `test_fetch_adjacency_verdicts_reads_marker_in_comments` : marker detecte via `gh pr view --json comments`.
- `test_fetch_adjacency_verdicts_returns_empty_on_no_marker` : non-regression — PR sans marker ne pollue pas le dict.
- `test_fetch_adjacency_verdicts_swallows_gh_failures_silently` : `TimeoutExpired` ne leve PAS (coherence avec les autres organes du picker).

### Verification

| Item | Avant | Apres |
|---|---|---|
| `pytest test_pick_idle_grain.py` | 79/79 | **85/85** (6 nouveaux) |
| `pytest scripts/tests/` (full) | n/a | **4076 PASS, 29 skipped, 5 xfailed** |
| Bloc "Trois gestes" sur PR adjacency uniquement | affiche (faux) | **REMPLACE** par "Remede UNIQUEMENT" |
| Bloc "Trois gestes" sur mixed case (adjacency + substance) | affiche | affiche (geste 3 substance valide, documente) |
| Bloc "Trois gestes" sur rouge substance pur | affiche | affiche (non-regression) |
| Bloc "Trois gestes" sur PR illisible / reseau mort | affiche | affiche (chemin conservateur, non-regression) |

### Perimetre

```
scripts/pick_idle_grain.py            | 122 +++++++++++++++++++++++++++----
scripts/tests/test_pick_idle_grain.py | 136 ++++++++++++++++++++++++++++++++++
2 files changed, 244 insertions(+), 14 deletions(-)
```

Modifications minimales : 1 helper (39 lignes, dont 20 de docstring inline), 1 enrichissement d'item (5 lignes), 1 variation dans `print_red_assignment` (32 lignes de docstring + 30 lignes de branche conditionnelle), 6 tests d'integration.

### Acceptance (issue #13967)

1. Quand la cause d'un rouge est `adjacency`, le picker **n'affiche pas** les trois gestes generiques ; il affiche le remede propre a cette cause (produire un grain d'un autre genre). — verifie par `test_print_red_assignment_replaces_three_gestes_when_all_adjacency`.
2. Il rappelle l'interdit de retag. — verifie par assertion `assert "INTERDIT explicite" in out` dans le meme test.

Closes #13967

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
