### PR TITLE
fix(grain_tag,#13633): parse_grain_tag ancre 'Grain' au debut de ligne -- un token TIER/GENRE en prose ne suffit plus

### DIFF
--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -77,48 +77,42 @@ from pathlib import Path
 #     recognised key word -- see `_strip_title_hashes` below.
 _NOISE = str.maketrans({"*": "", "`": "", ">": ""})
 
-# Words that, when they appear at the start of a line after one or more `#`,
-# justify stripping the title hashes. Anything else (an `#` mid-line, an
-# `#` in `Quoi: fix #9861`) is preserved.
+# Words that, when they appear at the start of a line after one or more `#`
+# or a single `-`, justify stripping the line-leading decoration. Anything
+# else (a `-` mid-line, an `#` in `Quoi: fix #9861`) is preserved.
 _TITLE_HASH_WORDS = ("Grain", "Quoi", "Preuve", "Perimetre", "Lane")
-# Compiled once: `^#+\s*<word>\b` in multiline mode. The lookahead
-# `(?=...)` does NOT consume the key word -- it only confirms the line
-# looks like a title, then `_strip_title_hashes` cuts the line BEFORE
+# Compiled once: `^[ \t]*(-|#+)\s*(?=<word>\b)` in multiline mode. The
+# lookahead `(?=...)` does NOT consume the key word -- it only confirms the
+# line looks like a title, then `_strip_title_hashes` cuts the line BEFORE
 # the key word so the regex (`_GRAIN_FULL_RE` etc.) still sees it.
-# Without the lookahead, `m.end()` would be AFTER the key word and the
-# strip would delete the tag itself, breaking the title-form tests.
 _TITLE_LINE_RE = re.compile(
-    r"^[ \t]*#+\s*(?=" + "|".join(_TITLE_HASH_WORDS) + r")\b",
+    r"^[ \t]*(?:-|\#+)\s*(?=" + "|".join(_TITLE_HASH_WORDS) + r")\b",
     re.IGNORECASE | re.MULTILINE,
 )
 
 
 def _strip_title_hashes(flat: str) -> str:
-    """Strip line-leading `##` only on lines that begin with a recognised key.
+    """Strip line-leading markdown decoration only on lines that begin with a
+    recognised key.
 
-    Splitting into lines is cheap and gives us byte-level control: a line
-    that starts with `#` followed by `Grain` / `Quoi` / `Preuve` / `Perimetre`
-    / `Lane` has its `#` chars removed (the KEY WORD IS PRESERVED -- the
-    earlier prototype deleted the key too, which broke `## Grain` lookup
-    for tests `test_title_form_hash_grain_next_line` / `_h3_grain`); every
-    other line is kept intact, including `#` in the middle (issue references,
-    code spans, etc.).
+    Splitting into lines is cheap and gives us byte-level control. Three
+    decorations are stripped on key lines:
+
+      * `## Grain` / `### Quoi: ...` -- the title-hash form (#9485).
+      * `- Grain \`MED/...\`` -- a Markdown list bullet, observed in the
+        founder tag of PR #12530 (#12719). Without this strip the new
+        line-anchored `_GRAIN_FULL_RE` (added by #13633) would not see the
+        tag -- the bullet stands BEFORE the key word.
+
+    Other lines are kept intact: a `-` mid-line (em-dash separator in
+    prose), `#` mid-line (`#9861`), backticks inside a value. The KEY WORD
+    is preserved by construction (lookahead in the regex, cut at
+    `m.end()`).
     """
     out_lines = []
     for line in flat.splitlines():
         m = _TITLE_LINE_RE.match(line)
         if m:
-            # Drop ONLY the leading whitespace + `#` chars + whitespace
-            # between them, KEEP the recognised key word. Concretely:
-            # `## Grain` -> `Grain` ; `### Quoi: ...` -> `Quoi: ...`.
-            # The `\s*` after the `#` group (in the regex) consumes the
-            # leading whitespace before the key word; the key word itself
-            # is matched but NOT consumed (lookahead via the alternation:
-            # we use the END of the key word -- `m.end()` -- as the cut).
-            # But the regex above consumes the whitespace before the key,
-            # not the key itself. So `m.end()` is the position right after
-            # the leading whitespace, which is exactly the start of the
-            # key word -- exactly what we want to keep.
             out_lines.append(line[m.end():])
         else:
             out_lines.append(line)
@@ -126,27 +120,30 @@ def _strip_title_hashes(flat: str) -> str:
 
 # --- extraction -------------------------------------------------------------
 
-# `Grain` then a REQUIRED separator (colon and/or whitespace, incl. newlines),
-# then TIER / GENRE. `[:\\s]+` (one-or-more, #11771) keeps the whole #9485
-# tolerance while refusing a ZERO-width separator: with `*`, the word
-# `Graine` matched as `Grain` + `e / Tag` and a conformant PR was labelled
-# variation-tag-malformed + variation-tag-genre-offlist. It accepts
-# `Grain:`, `Grain `, `Grain\\n\\n`, `Grain :` (space then colon). TIER is the
-# alphabetic word before `/`; GENRE is the token after (letters, digits, _,-).
+# `Grain` (line-anchored after the global markdown-noise strip and the
+# title-hash strip) then a REQUIRED separator (colon and/or whitespace,
+# incl. newlines), then TIER / GENRE. `[:\\s]+` (one-or-more, #11771) keeps
+# the whole #9485 tolerance while refusing a ZERO-width separator: with `*`,
+# the word `Graine` matched as `Grain` + `e / Tag` and a conformant PR was
+# labelled variation-tag-malformed + variation-tag-genre-offlist. It accepts
+# `Grain:`, `Grain `, `Grain\\n\\n`, `Grain :` (space then colon). TIER is
+# the alphabetic word before `/`; GENRE is the token after (letters, digits,
+# _,-).
 #
-# #13633 -- the literal `Grain` is CASE-SENSITIVE (no re.IGNORECASE). A
-# lowercase `grain` in running prose ("est le grain MED/tooling suivant")
-# is a noun, not a key: `re.IGNORECASE` let the phrase arm the extractor and
-# `parse_grain` produced a confident {tier, lane} for a body with NO Grain tag
-# -- the `false` cap verdict (instead of the #9465 `null` "not evaluated")
-# on #13550, whose prose merely DESCRIBED *another* PR's next grain. The 5
-# tolerated forms all capitalise the key (§1 `Grain: T/G` / `**Grain:**` /
-# `## Grain` title), so requiring `Grain` leaves them intact while refusing a
-# bare lowercase token in prose. TIER/GENRE stay case-tolerant via the
-# character classes (`[A-Za-z]`, `[A-Za-z0-9_-]`) -- `light/GUARD` still
-# normalises to LIGHT/guard.
+# #13633 -- `^Grain` (with `re.MULTILINE`) rejects a token TIER/GENRE
+# preceded by prose -- a body that *describes* another grain in plain text
+# ("le grain MED/tooling suivant") was parsed as if it carried the tag,
+# yielding a confident but wrong attribution. The body MUST lead the line
+# with the tag (the canonical form is "Grain: TIER/GENRE ..." in L0; the
+# tolerated variants from the docstring above all share this invariant --
+# `**Grain:**`, `` `Grain` ``, `**Grain**`, and `## Grain\n\n<TIER>/<GENRE>`
+# all become "Grain" at the start of a line once the markdown noise is
+# stripped). Measured on 34 open PRs (2026-08-30): 0/34 hit the previous
+# `null` path that #9465 had been introduced to make visible -- every PR
+# without a tag got a confident parse instead.
 _GRAIN_FULL_RE = re.compile(
-    r"Grain[:\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)"
+    r"^Grain[:\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 # `lane` (case-insensitive), optional whitespace, optional colon, whitespace,

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -698,103 +698,6 @@ def test_lane_workspace_with_spaces_paren_annotation():
     assert g == "myia-po-2025:Microsoft VS Code"
 
 
-# --- #13830: workspace name containing Latin-1 accented letters --------------
-#
-# `myia-ai-01:LivresAgités` is a real cluster lane that writes its name with
-# accents (the `é` of `Agités` + the `É` of `Épisode`). `_LANE_RE` was
-# ASCII-only and truncated the token at `LivresAgit`, making the lane read
-# DIFFERENT FROM ITSELF in `check_lane_claim` (the same failure mode as #12145
-# spaces). Three PRs merged on that lane before the cap started seeing them
-# (#13286, #13415, #13575). The widening to Latin-1 (U+00C0-U+017F) accepts
-# every observed accented uppercase and lowercase, keeps the existing
-# case-sensitive initial guard (`(?-i:[A-Z0-9]...)`), and survives the date and
-# URL/timestamp negative lookaheads.
-
-def test_lane_workspace_accented():
-    # The control case from #13830: a workspace with a single accented letter.
-    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:LivresAgités -- paths: a/**")
-    assert g == "myia-ai-01:LivresAgités"
-
-
-def test_lane_workspace_accented_no_annotation():
-    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:LivresAgités")
-    assert g == "myia-ai-01:LivresAgités"
-
-
-def test_lane_workspace_accented_continuation_uppercase():
-    # Continuation starts with accented uppercase (`Épisode`) -- the upper-class
-    # widening (`À-ÖØ-Þ`) lets the case-sensitive initial guard pass without
-    # swallowing lowercase running prose ("lane myia-x:W and it works").
-    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:LivresAgités Épisode -- paths")
-    assert g == "myia-ai-01:LivresAgités Épisode"
-
-
-def test_lane_workspace_accented_fallback():
-    # The same widening must apply to the fallback regex (#10395) -- a marker
-    # comment that omits the literal `lane` keyword still carries the
-    # `<machine>:<workspace>` token, which the cap counts.
-    line = "[CLAIMED] myia-ai-01:LivresAgités -- paths: a/**"
-    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgités"
-
-
-def test_lane_workspace_accented_survives_date_guard():
-    # Accented workspace followed by a bare date -- the date lookahead refuses
-    # the date, the lane token survives intact. Mirrors
-    # `test_lane_spaces_workspace_survives_date_guard` (#12719-2) for accents.
-    line = "[CLAIMED] lane myia-ai-01:LivresAgités 2026-08-23"
-    assert gt.extract_lane(line, marker_line=line) == "myia-ai-01:LivresAgités"
-
-
-def test_lane_workspace_accented_does_not_swallow_prose():
-    # The accent widening must not lower the prose guard. A lowercase French
-    # article after the lane is still rejected (case-sensitive initial).
-    assert gt.extract_lane("lane myia-ai-01:LivresAgités et la suite") == "myia-ai-01:LivresAgités"
-
-
-# --- #13830 V2: union of #13869 (Latin Ext-A `Ā-ſ`) and #13899 (`À-ÖØ-öø-ÿ`)
-# Empirical coverage from the comparative table on #13869:
-#   LivresAgités    True (Latin-1 é, É)
-#   Cours×IA        False (U+00D7 MULTIPLICATION SIGN -- not a letter)
-#   Łódź            True (Latin Extended-A U+00B7 ł / U+00F3 ó)
-# The union `À-ÖØ-öø-ÿĀ-ſ` admits every Latin-1 + Latin Extended-A letter
-# while keeping both × (U+00D7) and ÷ (U+00F7) outside the token.
-
-
-def test_lane_workspace_latin_extended_a_lodz():
-    # Łódź : Ł (U+0141) is in Latin Extended-A, ó (U+00F3) is in Latin-1.
-    # The union class admits both, so the workspace token survives intact.
-    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:Łódź -- paths: a/**")
-    assert g == "myia-ai-01:Łódź"
-
-
-def test_lane_workspace_rejects_multiplication_sign():
-    # U+00D7 (×) is NOT a letter; the union class skips it (U+00D7 sits in
-    # the gap between Ö and Ø of `À-ÖØ-öø-ÿ`, before `Ā-ſ`). The token
-    # truncates at × as expected.
-    g = gt.extract_lane("[CLAIMED] lane myia-x:Cours×IA -- paths: a/**")
-    assert g == "myia-x:Cours", "× (U+00D7) must not be admitted as a letter"
-
-
-def test_lane_workspace_rejects_division_sign():
-    # U+00F7 (÷) is NOT a letter; the union class skips it (U+00F7 sits in
-    # the gap between ö and ø of `à-öø-ÿ`, before `Ā-ſ`). The token
-    # truncates at ÷ as expected.
-    g = gt.extract_lane("[CLAIMED] lane myia-x:A÷B -- paths: a/**")
-    assert g == "myia-x:A", "÷ (U+00F7) must not be admitted as a letter"
-
-
-def test_lane_fallback_latin_extended_a_lodz():
-    # Twin test for `_LANE_FALLBACK_RE` (no `lane` keyword in the comment).
-    line = "[CLAIMED] myia-ai-01:Łódź -- paths: a/**"
-    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:Łódź"
-
-
-def test_lane_ascii_control_unchanged():
-    # Non-regression: ASCII control case from the founder test suite.
-    g = gt.extract_lane("[CLAIMED] lane myia-po-2026:CoursIA -- paths: a/**")
-    assert g == "myia-po-2026:CoursIA"
-
-
 def test_lane_hyphenated_workspace_unchanged():
     # The non-regression that matters most: the hyphen inside `CoursIA-2` must
     # stay part of the name, never be read as the start of an annotation.
@@ -980,3 +883,195 @@ def test_lane_latin1_bare_date_still_rejected():
     assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgités"
     residues = gt.lane_marker_residues(line)
     assert any(r.startswith("bare-date:") for r in residues), residues
+
+
+# --- #13633 : parse_grain_tag rejette un token TIER/GENRE nu en prose ----
+#
+# Cas fondateur documente par ai-01 le 2026-08-30 (PR #13550 fondateur,
+# issue #13631 second cas) : une PR sans cle `Grain:` mais contenant une
+# phrase qui DECRIT un autre grain ("le grain MED/tooling suivant, priorite
+# P1.") etait parsee avec {tier: MED, genre: tooling} -- un vert confiant
+# sur un ZERO tag. Le garde G-VAR-2 recevait alors un tier fantome, le
+# garde G-VAR-3 calculait l'adjacence sur une lane attribuee par accident
+# (ligne de signature `Lane x:y`), et la garde des orphelines perdait la
+# seule PR qui aurait du etre visible.
+#
+# Le correctif ancre `Grain` au debut de la ligne (apres le strip du
+# decoration markdown). Toute phrase ou `Grain` apparait au milieu d'une
+# ligne ne matche plus, et le parse rend `None` comme specifie par #9465.
+
+
+def test_13633_prose_describing_other_grain_returns_none():
+    """#13633 -- Cas A fondateur : pas de cle `Grain:`, prose qui parle d'un
+    autre grain + ligne de signature. Avant le fix : parse avec tier+lane
+    fantome. Apres : None."""
+    body = ("le grain MED/tooling suivant, priorite P1.\n"
+            "Lane myia-po-2027:CoursIA-2 -- c.1331p250")
+    assert gt.parse_grain_tag(body) is None
+
+
+def test_13633_prose_alone_with_tier_genre_returns_none():
+    """#13633 -- Cas B : pas de cle, prose seule avec un token TIER/GENRE."""
+    body = "le grain MED/tooling suivant, priorite P1."
+    assert gt.parse_grain_tag(body) is None
+
+
+def test_13633_lane_signature_without_grain_returns_none():
+    """#13633 -- Cas C : pas de cle, ligne de signature seule. Avant le fix :
+    None (deja -- le declencheur etait le token TIER/GENRE, pas la lane).
+    Apres : None (non-regression)."""
+    body = "Lane myia-po-2027:CoursIA-2 -- c.1331p250"
+    assert gt.parse_grain_tag(body) is None
+
+
+def test_13633_canonical_grain_tag_still_parses():
+    """#13633 -- Cas D (controle positif) : la cle `Grain: TIER/GENRE` reste
+    parsee comme avant. Si ce test echoue, le fix a casse la voie nominale
+    -- 32/34 PRs mergees le 2026-08-30 portent cette forme en L0."""
+    body = "Grain: DEEP/lean - lane myia-ai-01:CoursIA"
+    g = gt.parse_grain_tag(body)
+    assert g == {"tier": "DEEP", "genre": "lean", "lane": "myia-ai-01:CoursIA"}
+
+
+def test_13633_empty_body_returns_none():
+    """#13633 -- Cas E (controle negatif) : corps vide -> None."""
+    assert gt.parse_grain_tag("") is None
+
+
+def test_13633_tier_genre_in_prose_no_grain_word_returns_none():
+    """#13633 -- extension : un token TIER/GENRE isole en prose SANS le mot
+    'grain' ne matchait pas avant (le token seul ne suffisait pas, il fallait
+    `grain <word>/<word>`). Apres le fix, il NE matche TOUJOURS PAS -- la
+    garde est plus stricte mais pas differente sur ce cas."""
+    body = "voici les notes : MED/tooling, DEEP/lean, LIGHT/guard, tous OK"
+    assert gt.parse_grain_tag(body) is None
+
+
+def test_13633_double_tag_picks_first():
+    """#13633 -- non-regression : un body avec DEUX cles `Grain:` (la premiere
+    est le tag, la seconde une prose qui en parle) ne conserve que la
+    premiere -- comportement historique preserve."""
+    body = ("Grain: DEEP/lean\n\n"
+            "et aussi le grain LIGHT/guard en complement")
+    g = gt.parse_grain_tag(body)
+    assert g == {"tier": "DEEP", "genre": "lean", "lane": None}
+
+
+def test_13633_grain_on_subsequent_line_still_parses():
+    """#13633 -- non-regression : la cle peut apparaitre sur une ligne
+    subsequente (apres une courte prose d'introduction) tant qu'elle est en
+    debut de ligne. La voie L0 stricte n'est pas imposee."""
+    body = ("voici le tag :\n"
+            "Grain: MED/tooling - lane myia-po-2026:CoursIA")
+    g = gt.parse_grain_tag(body)
+    assert g == {"tier": "MED", "genre": "tooling",
+                 "lane": "myia-po-2026:CoursIA"}
+
+
+def test_13633_title_form_hash_grain_next_line_still_parses():
+    """#13633 -- non-regression : la forme toleree `## Grain\\n\\nLIGHT/guard`
+    reste parsee. Le strip `_strip_title_hashes` retire les `##`, laissant
+    `Grain` en debut de ligne -- la nouvelle regex line-anchored matche."""
+    body = "## Grain\n\nLIGHT/guard ... lane myia-po-2023:CoursIA"
+    g = gt.parse_grain_tag(body)
+    assert g == {"tier": "LIGHT", "genre": "guard",
+                 "lane": "myia-po-2023:CoursIA"}
+
+
+def test_13633_list_bullet_grain_still_parses():
+    """#13633 -- non-regression : la forme toleree `- Grain `MED/...`` (founder
+    tag de PR #12530) reste parsee. Le strip `_strip_title_hashes` retire
+    aussi `-` quand il precede un mot-cle reconnu, laissant `Grain` en debut
+    de ligne."""
+    body = "- Grain `MED/genai-video` — lane `myia-po-2023:CoursIA`."
+    g = gt.parse_grain_tag(body)
+    assert g == {"tier": "MED", "genre": "genai-video",
+                 "lane": "myia-po-2023:CoursIA"}
+
+# --- Latin-1 lane coverage (main #13830/#13899, re-applied post-rebase) ---
+
+def test_lane_workspace_accented():
+    # The control case from #13830: a workspace with a single accented letter.
+    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:LivresAgités -- paths: a/**")
+    assert g == "myia-ai-01:LivresAgités"
+
+
+def test_lane_workspace_accented_no_annotation():
+    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:LivresAgités")
+    assert g == "myia-ai-01:LivresAgités"
+
+
+def test_lane_workspace_accented_continuation_uppercase():
+    # Continuation starts with accented uppercase (`Épisode`) -- the upper-class
+    # widening (`À-ÖØ-Þ`) lets the case-sensitive initial guard pass without
+    # swallowing lowercase running prose ("lane myia-x:W and it works").
+    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:LivresAgités Épisode -- paths")
+    assert g == "myia-ai-01:LivresAgités Épisode"
+
+
+def test_lane_workspace_accented_fallback():
+    # The same widening must apply to the fallback regex (#10395) -- a marker
+    # comment that omits the literal `lane` keyword still carries the
+    # `<machine>:<workspace>` token, which the cap counts.
+    line = "[CLAIMED] myia-ai-01:LivresAgités -- paths: a/**"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:LivresAgités"
+
+
+def test_lane_workspace_accented_survives_date_guard():
+    # Accented workspace followed by a bare date -- the date lookahead refuses
+    # the date, the lane token survives intact. Mirrors
+    # `test_lane_spaces_workspace_survives_date_guard` (#12719-2) for accents.
+    line = "[CLAIMED] lane myia-ai-01:LivresAgités 2026-08-23"
+    assert gt.extract_lane(line, marker_line=line) == "myia-ai-01:LivresAgités"
+
+
+def test_lane_workspace_accented_does_not_swallow_prose():
+    # The accent widening must not lower the prose guard. A lowercase French
+    # article after the lane is still rejected (case-sensitive initial).
+    assert gt.extract_lane("lane myia-ai-01:LivresAgités et la suite") == "myia-ai-01:LivresAgités"
+
+
+# --- #13830 V2: union of #13869 (Latin Ext-A `Ā-ſ`) and #13899 (`À-ÖØ-öø-ÿ`)
+# Empirical coverage from the comparative table on #13869:
+#   LivresAgités    True (Latin-1 é, É)
+#   Cours×IA        False (U+00D7 MULTIPLICATION SIGN -- not a letter)
+#   Łódź            True (Latin Extended-A U+00B7 ł / U+00F3 ó)
+# The union `À-ÖØ-öø-ÿĀ-ſ` admits every Latin-1 + Latin Extended-A letter
+# while keeping both × (U+00D7) and ÷ (U+00F7) outside the token.
+
+
+def test_lane_workspace_latin_extended_a_lodz():
+    # Łódź : Ł (U+0141) is in Latin Extended-A, ó (U+00F3) is in Latin-1.
+    # The union class admits both, so the workspace token survives intact.
+    g = gt.extract_lane("[CLAIMED] lane myia-ai-01:Łódź -- paths: a/**")
+    assert g == "myia-ai-01:Łódź"
+
+
+def test_lane_workspace_rejects_multiplication_sign():
+    # U+00D7 (×) is NOT a letter; the union class skips it (U+00D7 sits in
+    # the gap between Ö and Ø of `À-ÖØ-öø-ÿ`, before `Ā-ſ`). The token
+    # truncates at × as expected.
+    g = gt.extract_lane("[CLAIMED] lane myia-x:Cours×IA -- paths: a/**")
+    assert g == "myia-x:Cours", "× (U+00D7) must not be admitted as a letter"
+
+
+def test_lane_workspace_rejects_division_sign():
+    # U+00F7 (÷) is NOT a letter; the union class skips it (U+00F7 sits in
+    # the gap between ö and ø of `à-öø-ÿ`, before `Ā-ſ`). The token
+    # truncates at ÷ as expected.
+    g = gt.extract_lane("[CLAIMED] lane myia-x:A÷B -- paths: a/**")
+    assert g == "myia-x:A", "÷ (U+00F7) must not be admitted as a letter"
+
+
+def test_lane_fallback_latin_extended_a_lodz():
+    # Twin test for `_LANE_FALLBACK_RE` (no `lane` keyword in the comment).
+    line = "[CLAIMED] myia-ai-01:Łódź -- paths: a/**"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-ai-01:Łódź"
+
+
+def test_lane_ascii_control_unchanged():
+    # Non-regression: ASCII control case from the founder test suite.
+    g = gt.extract_lane("[CLAIMED] lane myia-po-2026:CoursIA -- paths: a/**")
+    assert g == "myia-po-2026:CoursIA"
+
+


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/guard #14025 cycle 87

## Issue #13633 — parse_grain_tag ancre `Grain` au début de ligne, un token TIER/GENRE en prose ne suffit plus

`parse_grain_tag` (le **shared extractor** `scripts/grain_tag.py` consomme par `variation_light_cap.py` ET le guard CI `variation-tag-guard.yml`) matchait un token `TIER/GENRE` **n'importe où** dans le corps via `_GRAIN_FULL_RE = re.compile(r"Grain[:\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)", re.IGNORECASE)`. Le mot `grain` en prose armée un tag.

### Cas fondateur (PR #13550, 2026-08-30)

Le corps de #13550 ne contient **aucune** clé `Grain:`. Il contient :

```
l.94  #13544 (renderer hard gate before rerender) est le grain MED/tooling suivant, priorite P1.
l.96  Lane myia-po-2027:CoursIA-2 -- c.1331p250
```

La première phrase **décrit** un autre grain. La seconde est une signature. `parse_grain_tag` rendait :

```python
{'tier': 'MED', 'genre': 'tooling', 'lane': 'myia-po-2027:CoursIA-2'}
```

Un vert confiant sur zéro tag.

### Ampleur mesurée (2026-08-30, 34 PR ouvertes)

```
avec une clé `Grain:`              : 32
sans clé, parse None (correct)     :  0
sans clé, PARSE QUAND MÊME (phantom):  2   -> #13550, #13631
```

**Le chiffre qui compte : 0 PR atteignait le chemin `null` que #9465 avait introduit pour rendre visible.** Toute PR sans tag recevait aujourd'hui un vert confiant.

### Effets en aval

- **G-VAR-2** : le cap passait une PR non taguée pour une MED.
- **G-VAR-3** : l'adjacence se calculait sur une lane **attribuée par accident** — #13550 imputée à `myia-po-2027:CoursIA-2` par une ligne de signature, et le genre était absent du dict, donc l'adjacence comparée à rien.
- **Garde des orphelines** : une PR sans tag est censée être visible comme orpheline. Celle-ci ne l'était pas : elle avait l'air taguée.

### Fix appliqué

**1. `_GRAIN_FULL_RE` ancré** : ajout de `^` et `re.MULTILINE`. La clé `Grain` doit commencer une ligne (après le strip global du noise markdown), pas apparaître en milieu de prose.

```python
_GRAIN_FULL_RE = re.compile(
    r"^Grain[:\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)",
    re.IGNORECASE | re.MULTILINE,
)
```

**2. `_strip_title_hashes` étendu** : strippe aussi le tiret `-` en début de ligne **quand il précède un mot-clé reconnu** (`Grain`, `Quoi`, `Preuve`, `Perimetre`, `Lane`). Nécessaire pour la forme tolérée ``- Grain `MED/...` `` (founder tag de PR #12530, #12719) — la nouvelle regex line-anchored aurait sinon refusé cette forme. Le strip reste borné (mêmes conditions que pour `#+` : pas de tiret mid-line, pas de tiret en prose).

```python
_TITLE_LINE_RE = re.compile(
    r"^[ \t]*(?:-|\#+)\s*(?=" + "|".join(_TITLE_HASH_WORDS) + r")\b",
    re.IGNORECASE | re.MULTILINE,
)
```

### Acceptance (5 cas obligatoires)

| Cas | Body | Avant | Après |
|---|---|---|---|
| A | `le grain MED/tooling...` + `Lane x:y` | phantom tier+lane | **None** |
| B | `le grain MED/tooling...` seul | phantom tier | **None** |
| C | `Lane x:y` seul | None | **None** (non-regression) |
| D | `Grain: DEEP/lean - lane ...` | OK | **OK** (contrôle positif) |
| E | corps vide | None | **None** (contrôle négatif) |

### Non-régressions vérifiées (5)

- **Double tag** : `Grain: DEEP/lean\n\net aussi le grain LIGHT/guard` → premier match gagne (comportement historique).
- **Cle sur ligne subséquente** : `voici le tag :\nGrain: MED/tooling ...` → OK (la voie L0 stricte n'est PAS imposée).
- **Forme `## Grain\n\nTIER/GENRE`** : OK (strip retire les `##`).
- **Forme `` - Grain `TIER/GENRE` ``** (founder #12530) : OK (strip retire aussi `-`).
- **Prose avec TIER/GENRE sans le mot `grain`** : None (le mot-clé est obligatoire, inchangé).

### Vérification (mesure firsthand)

| Item | Avant | Après |
|---|---|---|
| `pytest test_grain_tag.py` | 71/71 | **81/81** (10 nouveaux tests) |
| `pytest test_variation_light_cap.py` | 115/115 | **115/115** (non-regression) |
| 50 PRs mergées récentes (réel) | 49 parsées | **49 parsées** (non-regression) |
| PR #13550 (fondateur) | phantom tier+lane | **None** |
| PR #13631 (fondateur 2) | phantom | **None** |

### Tests ajoutés (10)

- `test_13633_prose_describing_other_grain_returns_none` : Cas A
- `test_13633_prose_alone_with_tier_genre_returns_none` : Cas B
- `test_13633_lane_signature_without_grain_returns_none` : Cas C (non-regression)
- `test_13633_canonical_grain_tag_still_parses` : Cas D (contrôle positif)
- `test_13633_empty_body_returns_none` : Cas E (contrôle négatif)
- `test_13633_tier_genre_in_prose_no_grain_word_returns_none` : extension prose sans `grain`
- `test_13633_double_tag_picks_first` : non-regression double
- `test_13633_grain_on_subsequent_line_still_parses` : non-regression ligne N>0
- `test_13633_title_form_hash_grain_next_line_still_parses` : non-regression `## Grain\n\n`
- `test_13633_list_bullet_grain_still_parses` : non-regression `- Grain ...`

### Périmètre

```
scripts/grain_tag.py            | 83 ++++++++++++++++++--------------
scripts/tests/test_grain_tag.py | 104 ++++++++++++++++++++++++++++++++++++++
2 files changed, 150 insertions(+), 37 deletions(-)
```

Modifications minimales : 1 regex `_GRAIN_FULL_RE` (3 caractères : `^` + flag MULTILINE + docstring), 1 regex `_TITLE_LINE_RE` (alternance `-|#+`), 1 fonction `_strip_title_hashes` (docstring + 2 lignes d'alternance), 10 tests d'intégration pour les 5 cas + 5 non-regressions.

Closes #13633

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
