### PR TITLE
Add: interpretation cells for Search-4 LocalSearch-Csharp (N-Queens benchmark, exos)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch-Csharp.ipynb
@@ -860,6 +860,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-nqueens-encoding",
+   "metadata": {},
+   "source": [
+    "### Lecture - l'encodage par permutation reduit le probleme a un seul type de conflit\n",
+    "\n",
+    "La sortie de demo rend un echiquier 8x8 **aleatoire** avec `reines[i] = colonne de la reine de la ligne i`. Ce choix d'encodage n'est pas anodin : **une reine par ligne et par colonne par construction** (c'est une permutation), donc il ne peut y avoir **aucun** conflit ligne ni colonne -- seuls les conflits **diagonaux** restent a eliminer (ici **6** sur le placement initial rendu).\n",
+    "\n",
+    "- **La fonction objectif se reduit a un compteur de conflits diagonaux** `Conflits(reines)` : 0 = solution. Le paysage a une hauteur bien definie et l'optimum est facile a reconnaitre (cout nul) -- c'est ce qui rend le probleme utilisable comme banc d'essai.\n",
+    "- **Permutation = bijection** : l'espace de recherche est exactement `n!` (pas `n^n`), ce qui rend la recherche locale bien plus efficace qu'un encodage par cases ou deux reines peuvent partager une ligne.\n",
+    "- Le but de toutes les metaheuristiques des cellules suivantes est de faire descendre `Conflits` de sa valeur initiale (**6** sur la demo) a **0**, malgre les minima locaux du paysage diagonal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3bdf7b93",
    "metadata": {
     "papermill": {
@@ -1468,6 +1482,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-benchmark",
+   "metadata": {},
+   "source": [
+    "### Lecture - le benchmark tranche : HC se coince, SA et Tabu sortent toujours\n",
+    "\n",
+    "Les tableaux rendus par `Benchmark` sont la lecon centrale du notebook. Sur **8-Reines (15 essais)**, Hill Climbing ne reussit que **7/15 (47 %)** quand Simulated Annealing et Tabu Search reussissent **15/15 (100 %)**. Sur **20-Reines (10 essais)**, la tendance s'accentue : **4/10 (40 %)** pour HC contre **10/10 (100 %)** pour les deux autres.\n",
+    "\n",
+    "- **HC est glouton** : il ne monte jamais un voisin de cout strictement superieur, donc il reste bloque dans le premier minimum local rencontre -- et les paysages de conflits diagonaux des N-Reines en sont pleins. La chute de 47 % a 40 % quand N passe de 8 a 20 montre que **plus le probleme est grand, plus HC se coince** (les minima locaux se multiplient).\n",
+    "- **SA echappe aux optima locaux** via la temperature (elle accepte des degradations transitoires) ; **Tabu** via sa **memoire** (elle interdit de rejouer les recents coups defavorables). Les deux atteignent 100 % dans les deux tailles.\n",
+    "- **Warning `CS0219`** : `itHC/itSA/itTS` sont comptees mais jamais utilisees -- un reliquat de code (compteur d'iterations dont l'affichage a ete retire). Sans consequence sur les resultats, et le code n'est pas modifie ici (enrichissement markdown-only)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "634b9173",
    "metadata": {
     "papermill": {
@@ -1544,6 +1572,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-exo1",
+   "metadata": {},
+   "source": [
+    "### Lecture - Exercice 1 : Random-Restart adaptatif\n",
+    "\n",
+    "L'exercice demande d'arreter les relances des qu'un **seuil de qualite** est atteint, plutot que de toujours bruler un nombre fixe de tentatives. La structure attendue garde la boucle de Random-Restart Hill Climbing mais ajoute un `break` quand le cout retourne tombe sous le `seuil` -- la vraie question de calibration est le compromis **qualite visee vs budget de relances**. Le stub rend `pass`, donc l'exercice est a completer : ajouter la condition d'arret puis relire la sortie -- le taux de reussite doit montrer que le seuil **economise** des relances sans perdre de solutions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e157039c",
    "metadata": {
     "papermill": {
@@ -1612,6 +1650,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-exo2",
+   "metadata": {},
+   "source": [
+    "### Lecture - Exercice 2 : memoire a long terme\n",
+    "\n",
+    "La recherche tabou de la section 5 utilise une liste tabou a **taille fixe**. L'exercice etend la memoire (diversification : interdire aussi des attributs ou des mouvements \"oublies\" depuis longtemps, pas seulement les tout derniers). L'idee est une **aspiration** qui pousse la recherche dans des regions inexplorees. Sur le banc N-Reines, une memoire longue sert surtout quand la liste courte recompute un optimum local deja vu : comparez le taux de reussite a celui de la section 5 pour le mesurer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fb212085",
    "metadata": {
     "papermill": {
@@ -1669,6 +1717,16 @@
     "}\n",
     "\n",
     "ComparerRefroidissementsNReines(n: 20, essais: 10);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-exo3",
+   "metadata": {},
+   "source": [
+    "### Lecture - Exercice 3 : trois programmes de refroidissement\n",
+    "\n",
+    "La section 3 comparait les programmes de refroidissement sur la fonction 1D (et le paradoxe du logarithmique). L'exercice vous demande de **refaire cette comparaison sur les N-Reines** : le meilleur programme sur une fonction 1D n'est pas forcement le meilleur sur un paysage de permutations. Mesurez le taux de reussite et le nombre d'iterations a 0 conflit pour chaque programme, puis confrontez au verdict de la section 3 -- c'est le \"No Free Lunch\" des schemas de temperature."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml
@@ -28,6 +28,12 @@
       csharp_sha: 2feb723adf68258ced22949f71e9eb70070c87b9
       content_python_sha: dddab5b007203cb73db9a7a6bb64eb31deb4d4da2a3a33ef87fc9ecf19aafe8b
       content_csharp_sha: bf240ace38f5d9f054a979ed694bb77ff34e84ac79f9353683168205fc830b07
+    - date: "2026-09-01"
+      by: myia-po-2027:CoursIA
+      python_sha: 6211d4343dc10fb0a22e5b6811dfe7c25a1bb768
+      csharp_sha: 17dc92abed5f6b4b1ddfd9960e8d1d51dafb3d78
+      content_python_sha: dddab5b007203cb73db9a7a6bb64eb31deb4d4da2a3a33ef87fc9ecf19aafe8b
+      content_csharp_sha: 74f9300152cb6aebe49afe5ce2e718ab215aa8b31c57f0eac5375811ffebcc8a
   known_differences:
     - '2026-08-31 : ATTESTATION UNILATERALE (PR #13659, lane myia-ai-01:CoursIA) -- reparation d''echappements JSON manges dans le markdown du cote C#. CAUSE : dans le .ipynb, la sequence dollar-\bot-dollar ecrite avec UN SEUL antislash est lue par le parseur JSON comme l''echappement \b (backspace, U+0008) ; la source chargee porte un caractere de controle et le notebook rend un dollar-ot-dollar prive de sa commande LaTeX. FIX : doubler l''antislash (\\bot). Le DRIFT est UNILATERAL parce que le DEFAUT l''est : la contrepartie Search-4-LocalSearch.ipynb (Python), 39 cellules markdown, a ete scannee sous controle positif (le litteral defectueux passe a json.loads doit rendre U+0008 -- assertion verifiee avant le scan) et ne porte AUCUN caractere de controle U+0008/U+000B/U+000C. Il n''y a donc rien a reparer de ce cote : l''attestation ne consacre aucune asymetrie de contenu. PORTEE DU DIFF cote repare (comparaison des JSON parses origin/main -> HEAD) : markdown uniquement, 0 cellule code touchee, 0 sortie modifiee, 0 execution_count deplace, 0 cellule ajoutee ou retiree.'
     - "Socle pedagogique commun : metaheuristiques de recherche locale — Hill Climbing (variations steepest/first-improvement + diagnosis plateau/ridge), Simulated Annealing (schema de refroidissement, critere de Metropolis), Tabu Search (liste tabou, memoire a court terme). Comparaison empirique sur N-Reines. Les deux twins implementent les 3 algorithmes from-scratch (parite algorithmique, pas seulement narratif)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/notebook-python #14009 (substance distincte : autre famille, C# et non Python, lectures à dominante méthodologie-du-voisinage, pas méthodologie-de-mesure)

## Sujet

`Search-4-LocalSearch-Csharp.ipynb` sortait à **947 c/cell** (seuil 1200). Ajout de **5 cellules markdown d'interprétation**, chacune ancrée aux outputs committés ou à la structure du code explicitement citée. Le notebook porte déjà des interprétations aux cellules [3],[5],[7],[9],[11],[14],[16],[18],[20] ; les insertions couvrent les zones de code sans interprétation adjacente :

| # | Position | Contenu ancré |
|---|---|---|
| 1 | après l'encodage N-Reines | `reines[i] = colonne de la reine de la ligne i` = **permutation** → une reine par ligne/colonne par construction, donc seuls les **conflits diagonaux** restent (la démo rend **6** conflits initiaux) ; objectif `Conflits` = compteur de diagonales, 0 = solution ; espace `n!` (pas `n^n`) |
| 2 | après `Benchmark` | **8-Reines (15 essais) : HC 7/15 (47 %), SA 15/15 (100 %), Tabu 15/15 (100 %)** · **20-Reines (10 essais) : HC 4/10 (40 %), SA 10/10 (100 %), Tabu 10/10 (100 %)** : HC glouton se coince dans les minima locaux, et la chute 47→40 % quand N monte montre que **plus le problème est grand, plus HC se coince** ; SA (température accepte les dégradations) et Tabu (mémoire interdit de rejouer les coups récents) atteignent 100 % ; warning `CS0219` (itérateurs `itHC/itSA/itTS` comptés jamais utilisés) = reliquat, code non modifié |
| 3 | après l'Exercice 1 | Random-Restart **adaptatif** : `break` dès que le coût passe sous le `seuil` ; la vraie calibration est qualité visée vs budget de relances ; stub `pass` → à compléter |
| 4 | après l'Exercice 2 | liste tabou → **mémoire à long terme** (diversification, interdire des attributs/mouvements anciens) ; sur N-Reines, sert quand la liste courte recompute un optimum local déjà vu |
| 5 | après l'Exercice 3 | re-comparer les **trois programmes de refroidissement** sur les N-Reines (en plus de la fonction 1D de la section 3) : le meilleur 1D n'est pas forcément le meilleur sur un paysage de permutations — No Free Lunch des schémas de température |

## Validation

- **2 fichiers au total** : `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch-Csharp.ipynb` (enrichissement markdown) + `scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml` (rebaseline twin-parity, commit dédié).
- **Code byte-identique** : 13/13 cellules code inchangées (source + outputs + `execution_count` + `metadata` comparés JSON par index contre `origin/main`) — enrichissement markdown-only, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown).
- **Densité** : `pedagogy_density.py` 947 → **1266 c/cell** (seuil 1200 atteint) ; 29 → 34 cellules ; 5 insertions, 0 deletions.
- **Guards verts** : `detect_consecutive_code_cells.py` 0 run · `detect_markdown_rendering.py` 0 violation · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2).
- **`scan_cell_ordering.py` 1 finding PRÉEXISTANT** : `SECTION_GAP` — `## 6. Exercices` saute de 3 à 6 sous le parent `<root>`. Vérifié sur une copie témoin de `origin/main` (`/tmp/s4_base.ipynb`, cellule #22) : **le défaut existait avant cette PR et n'est pas causé par elle**. Relevé, non traité (hors scope — règle 3 : signaler, pas toucher).
- **Twin parity** : paire `Search/Part1-Foundations` (`search-4-localsearch.yaml`), `parity_level: semantic` — enrichissement markdown-only d'un seul côté + rebaseline (attestation lue sur HEAD blobs, post-commit), workflow documenté comme légitime dans les audits de la paire.
- Choix du grain : picker s.c. sans candidat CONTENU non-VOID (tout couvert par PRs ouvertes ou META ; #8182 fortement disputé) — enrichissement densité-driven d'un notebook C# (`notebook-dotnet`), chemin disjoint de #14009 (Applications/CSP), #13980 (Applications/Hybrid) et #13959 (Part4-Metaheuristics).

