### PR TITLE
feat(guard,#13927): audit_engine_named_not_invoked - 5-verdict SOTA claim-vs-proof scanner

### DIFF
--- a/scripts/notebook_tools/audit_engine_named_not_invoked.py
+++ b/scripts/notebook_tools/audit_engine_named_not_invoked.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Audit notebooks that name an engine/LLM without invoking it.
+
+Standing-ASK class (SOTA #3801, regle H) -- un notebook qui claim un
+moteur (Google ADK, OpenAI, BigQuery, etc.) sans importer/invoquer le SDK
+officiel ET sans outputs reels est un **claim creux** : le rendu passe la
+barre C.2 (outputs/exec) mais le moteur annonce n'est pas celui qui
+s'execute. Defaut firsthand documente dans #13927 :
+
+* ``Track2-GoogleADK`` : titres/objectifs parlent de Google ADK, mais 10
+  labs sur 10 ont zero import/appel ``google.adk``.
+* ``SW-12-Python-GraphRAG.ipynb`` : objectifs "Extraction reelle avec
+  GPT/Claude" mais outputs "Reponse simulee".
+
+Ce scanner croise **trois surfaces** par notebook :
+
+* **claim** : prose (markdown), titre, objectifs -- emploie un moteur avec
+  un verbe d'execution/integration ;
+* **wiring** : code source -- import et appel de l'API officielle ou du
+  client reel ;
+* **proof** : outputs executes -- real output compatible avec l'appel
+  reel, sans marqueur de simulation/fallback.
+
+Un notebook sans wiring local peut etre admissible uniquement si :
+
+1. il se declare explicitement deterministe/sans LLM ;
+2. la meme sequence (dossier-serie) reference un notebook successeur ;
+3. ce successeur apporte wiring **et outputs reels**.
+
+## Verdicts (5)
+
+| Verdict | Sens |
+|---|---|
+| ``ENGINE_EXEC_PROVED`` | claim + wiring + outputs reels |
+| ``DISCLOSED_SEQUENCE_PROVED`` | notebook deterministe declare + successeur avec wiring+proof dans la meme serie |
+| ``WIRING_ONLY`` | import present mais aucun output reel (cle absente, exec gate par env, etc.) |
+| ``SIMULATED_TERMINAL`` | outputs = simulation/fallback, pas de successeur avec wiring |
+| ``NAMED_NOT_INVOKED`` | claim present mais zero import/wiring |
+
+## Registre moteur (extensible)
+
+Chaque entree porte : ``imports`` (regex sur code source), ``claims`` (regex
+sur prose markdown), ``simulation_markers`` (regex sur outputs), et un
+verdict par defaut si rien ne matche. Le registre est explicite -- aucune
+heuristique opaque.
+
+Usage::
+
+    python audit_engine_named_not_invoked.py --scan <notebook.ipynb>
+    python audit_engine_named_not_invoked.py --scan-all
+    python audit_engine_named_not_invoked.py --scan-all --check   # exit 1 si NAMED_NOT_INVOKED/SIMULATED_TERMINAL
+    python audit_engine_named_not_invoked.py --scan-all --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# --- Registre moteur -------------------------------------------------------
+
+@dataclass(frozen=True)
+class EngineSpec:
+    """Specification d'un moteur dans le registre."""
+
+    key: str
+    label: str
+    imports: Tuple[str, ...]
+    claims: Tuple[str, ...]
+    simulation_markers: Tuple[str, ...]
+    notes: str = ""
+
+
+ENGINE_REGISTRY: Dict[str, EngineSpec] = {
+    "google_adk": EngineSpec(
+        key="google_adk",
+        label="Google ADK",
+        imports=(r"\bgoogle\.adk\b", r"\bfrom\s+google\s+import\s+adk\b"),
+        claims=(
+            r"\bgoogle\s+adk\b",
+            r"\badk\s+agent\b",
+            r"\badk\s+runtime\b",
+            r"\badk\s+reel\b",
+        ),
+        simulation_markers=(
+            r"class\s+MockAgent",
+            r"class\s+FakeAgent",
+            r"#\s*simulated\s+adk",
+            r"\bsdk\s+fictif\b",
+        ),
+        notes="Track2-GoogleADK : 10 labs sans import `google.adk` detecte en 2026-09.",
+    ),
+    "openai_llm": EngineSpec(
+        key="openai_llm",
+        label="OpenAI/Anthropic/LiteLLM (LLM reel)",
+        imports=(
+            r"\bopenai\b",
+            r"\banthropic\b",
+            r"\blitellm\b",
+            r"\bfrom\s+openai\s+import\b",
+            r"\bfrom\s+anthropic\s+import\b",
+        ),
+        claims=(
+            r"\bgpt-[34]\b",
+            r"\bclaude-(?:opus|sonnet|haiku)\b",
+            r"\bGPT\s*/\s*Claude\b",
+            r"\bappel\s+(?:a|au)\s+(?:gpt|claude|llm)\b",
+            r"\b(?:avec|via)\s+(?:gpt|claude|llm)\b",
+            r"\blLM\s+reel\b",
+        ),
+        simulation_markers=(
+            r"Reponse simulee",
+            r"simulated\s+response",
+            r"class\s+MockLLM",
+            r"#\s*TODO.*api\s+key",
+        ),
+        notes="SW-12 GraphRAG : claim 'GPT/Claude' avec outputs 'Reponse simulee'.",
+    ),
+    "bigquery": EngineSpec(
+        key="bigquery",
+        label="Google BigQuery / BQML",
+        imports=(
+            r"\bgoogle\.cloud\.bigquery\b",
+            r"\bfrom\s+google\.cloud\s+import\s+bigquery\b",
+        ),
+        claims=(
+            r"\bbigquery\b",
+            r"\bBQML\b",
+            r"\bML\.PREDICT\b",
+        ),
+        simulation_markers=(
+            r"schema\s+simul",
+            r"donnees\s+simulees",
+            r"bigquery\s+simul",
+        ),
+        notes="Lab16 DataScienceWithAgents : claim BQML avec schema simule -- corrige via #14040 (RECOVERABLE-USER-HAND).",
+    ),
+}
+
+
+# --- Lecture notebook ------------------------------------------------------
+
+def _read_notebook(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _cell_source(cell: dict) -> str:
+    src = cell.get("source", [])
+    if isinstance(src, list):
+        return "".join(src)
+    return src or ""
+
+
+def _cell_output_text(cell: dict) -> str:
+    """Concatene tous les outputs d'une cellule en texte."""
+    parts: List[str] = []
+    for out in cell.get("outputs", []) or []:
+        otype = out.get("output_type", "")
+        if otype == "stream":
+            text = out.get("text", "")
+            if isinstance(text, list):
+                text = "".join(text)
+            parts.append(text or "")
+        elif otype in ("execute_result", "display_data"):
+            data = out.get("data", {})
+            for k in ("text/plain", "text/html"):
+                v = data.get(k)
+                if isinstance(v, list):
+                    parts.append("".join(str(x) for x in v))
+                elif isinstance(v, str):
+                    parts.append(v)
+        elif otype == "error":
+            tb = out.get("traceback", [])
+            if isinstance(tb, list):
+                parts.append("\n".join(str(x) for x in tb))
+            else:
+                parts.append(str(tb))
+    return "\n".join(str(p) for p in parts)
+
+
+# --- Detection -------------------------------------------------------------
+
+@dataclass
+class SurfaceHits:
+    """Resultat du croisement des 3 surfaces pour un moteur."""
+    claim_hits: List[Tuple[int, str]] = field(default_factory=list)   # (cell_idx, snippet)
+    wiring_hits: List[Tuple[int, str]] = field(default_factory=list)
+    proof_hits: List[Tuple[int, str]] = field(default_factory=list)
+    simulation_hits: List[Tuple[int, str]] = field(default_factory=list)
+
+
+def _strip_comments(src: str) -> str:
+    """Retire les commentaires `#` et les docstrings pour le scan wiring/proof.
+
+    Un match dans un commentaire n'est pas une preuve d'invocation -- c'est
+    juste une mention discursive. On garde les chaines de caracteres
+    (print("openai...")) parce qu'elles peuvent etre des appels caches,
+    mais on retire les commentaires Python purs.
+    """
+    lines = src.split("\n")
+    out = []
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        # Retrait d'un commentaire en milieu de ligne (apres du code)
+        # Heuristique : `#` non precede d'un caractere alphanumerique (donc pas dans une string)
+        # Simplification : on retire tout apres le premier `#` qui n'est pas dans une string.
+        # Les strings simples avec `#` (`"#hashtag"`) ne sont pas affectees par notre regex wiring
+        # (qui cherche `google.adk` etc.), donc cette approximation suffit.
+        in_str = False
+        for i, c in enumerate(line):
+            if c == '"' or c == "'":
+                in_str = not in_str
+            elif c == "#" and not in_str:
+                line = line[:i]
+                break
+        out.append(line)
+    return "\n".join(out)
+
+
+def _scan_engine(notebook: dict, spec: EngineSpec) -> SurfaceHits:
+    hits = SurfaceHits()
+    cells = notebook.get("cells", [])
+    for idx, cell in enumerate(cells):
+        ctype = cell.get("cell_type", "")
+        src = _cell_source(cell)
+        out_text = _cell_output_text(cell) if ctype == "code" else ""
+        # Code sans commentaires : utilise pour wiring (un import dans un
+        # commentaire n'est pas un import reel).
+        code_clean = _strip_comments(src) if ctype == "code" else ""
+
+        # --- claim : markdown prose ---
+        if ctype == "markdown":
+            for pat in spec.claims:
+                m = re.search(pat, src, re.IGNORECASE)
+                if m:
+                    snippet = m.group(0)
+                    hits.claim_hits.append((idx, snippet[:80]))
+                    break
+
+        if ctype != "code":
+            continue
+
+        # --- simulation markers : scan sur source ET outputs ---
+        # Le marker de simulation peut etre dans le code (class Mock...)
+        # OU dans l'output (print("Reponse simulee")).
+        cell_is_simulation = False
+        for pat in spec.simulation_markers:
+            m_src = re.search(pat, src, re.IGNORECASE)
+            m_out = re.search(pat, out_text, re.IGNORECASE)
+            if m_src or m_out:
+                marker = (m_src or m_out).group(0)
+                hits.simulation_hits.append((idx, marker[:80]))
+                cell_is_simulation = True
+                break
+
+        # --- wiring : import ou appel SDK dans la source (commentaires retires) ---
+        for pat in spec.imports:
+            m = re.search(pat, code_clean)
+            if m:
+                hits.wiring_hits.append((idx, m.group(0)[:80]))
+                break
+
+        # --- proof : output reel d'execution, non vide, sans marker simulation ---
+        # Si la cellule EST simulation, son output ne compte pas comme proof.
+        if not cell_is_simulation and out_text.strip():
+            hits.proof_hits.append((idx, out_text[:80].replace("\n", " ")))
+
+    return hits
+
+
+# --- Verdict ---------------------------------------------------------------
+
+def _is_disclosed_deterministic(notebook: dict) -> bool:
+    """Verifie si le notebook se declare deterministe/sans LLM."""
+    markers = (
+        r"deterministe",
+        r"sans\s+llm",
+        r"no\s+llm",
+        r"n['’]appelle\s+pas\s+de\s+llm",
+        r"ne\s+consomme\s+pas\s+de\s+llm",
+    )
+    cells = notebook.get("cells", [])
+    md_text = "\n".join(_cell_source(c) for c in cells if c.get("cell_type") == "markdown")
+    return any(re.search(m, md_text, re.IGNORECASE) for m in markers)
+
+
+def _detect_disclosed_sequence(
+    notebook_path: Path, current_spec: EngineSpec, current_hits: SurfaceHits,
+    sibling_notebooks: Optional[List[Path]] = None,
+) -> Optional[bool]:
+    """Verifie si un successeur dans la même série apporte wiring+proof.
+
+    Convention de serie : meme dossier parent. Le successeur est le notebook
+    suivant dans l'ordre lexicographique des fichiers .ipynb.
+    """
+    if sibling_notebooks is None:
+        # Best-effort : lister les .ipynb du meme dossier
+        try:
+            siblings = sorted(
+                p for p in notebook_path.parent.glob("*.ipynb")
+                if not p.name.endswith(("_output.ipynb", "_executed.ipynb"))
+            )
+        except OSError:
+            return None
+    else:
+        siblings = sibling_notebooks
+
+    if notebook_path not in siblings:
+        return None
+    idx = siblings.index(notebook_path)
+    successors = siblings[idx + 1:]
+    for sib in successors:
+        try:
+            nb = _read_notebook(sib)
+        except (OSError, json.JSONDecodeError):
+            continue
+        sib_hits = _scan_engine(nb, current_spec)
+        if sib_hits.wiring_hits and sib_hits.proof_hits:
+            return True
+    return False
+
+
+def classify_notebook(
+    notebook_path: Path, notebook: dict,
+    engine_keys: Optional[List[str]] = None,
+    sibling_cache: Optional[Dict[Path, List[Path]]] = None,
+) -> Dict[str, dict]:
+    """Classifie un notebook par moteur, retourne un dict {engine_key: {verdict, evidence}}."""
+    if engine_keys is None:
+        engine_keys = list(ENGINE_REGISTRY.keys())
+
+    siblings: Optional[List[Path]] = None
+    if sibling_cache is not None:
+        siblings = sibling_cache.get(notebook_path.parent.resolve())
+
+    results: Dict[str, dict] = {}
+    for key in engine_keys:
+        spec = ENGINE_REGISTRY[key]
+        hits = _scan_engine(notebook, spec)
+
+        # Si aucun claim, on ne declenche rien (moteur non pertinent pour ce notebook)
+        if not hits.claim_hits:
+            continue
+
+        # Croisement
+        has_wiring = bool(hits.wiring_hits)
+        has_proof = bool(hits.proof_hits)
+        has_simulation = bool(hits.simulation_hits)
+        disclosed = _is_disclosed_deterministic(notebook)
+
+        # Verdict
+        # Regle fondamentale : sans wiring (import SDK), un proof (output)
+        # ne peut pas etre attribue au moteur claim. Un print(10) sans
+        # import bigquery n'est pas une preuve d'execution BigQuery.
+        if has_wiring and has_proof and not has_simulation:
+            verdict = "ENGINE_EXEC_PROVED"
+        elif disclosed and (siblings is None or _detect_disclosed_sequence(notebook_path, spec, hits, siblings) is True):
+            verdict = "DISCLOSED_SEQUENCE_PROVED"
+        elif has_wiring and not has_proof:
+            verdict = "WIRING_ONLY"
+        elif has_simulation:
+            verdict = "SIMULATED_TERMINAL"
+        elif not has_wiring:
+            verdict = "NAMED_NOT_INVOKED"
+        else:
+            verdict = "UNMEASURED"
+
+        results[key] = {
+            "verdict": verdict,
+            "claims": hits.claim_hits[:5],
+            "wiring": hits.wiring_hits[:3],
+            "proof": hits.proof_hits[:3],
+            "simulation": hits.simulation_hits[:3],
+            "disclosed_deterministic": disclosed,
+        }
+
+    return results
+
+
+# --- Iteration repo --------------------------------------------------------
+
+_EXCLUDED_SUFFIXES = ("_output.ipynb", "_executed.ipynb")
+
+
+def _iter_notebooks(root: Path):
+    """Yield notebooks .ipynb sous root, en excluant les artefacts d'execution."""
+    for p in sorted(root.rglob("*.ipynb")):
+        if p.name.endswith(_EXCLUDED_SUFFIXES):
+            continue
+        yield p
+
+
+def _build_sibling_cache(notebooks: List[Path]) -> Dict[Path, List[Path]]:
+    """Regroupe les notebooks par dossier parent pour la detection sequence-aware."""
+    cache: Dict[Path, List[Path]] = {}
+    for nb in notebooks:
+        key = nb.parent.resolve()
+        cache.setdefault(key, []).append(nb)
+    for k in cache:
+        cache[k] = sorted(cache[k])
+    return cache
+
+
+# --- Scan entry points -----------------------------------------------------
+
+def scan_notebook(path: Path, engine_keys: Optional[List[str]] = None) -> Dict[str, dict]:
+    """Scan un seul notebook."""
+    nb = _read_notebook(path)
+    siblings = sorted(
+        p for p in path.parent.glob("*.ipynb")
+        if not p.name.endswith(_EXCLUDED_SUFFIXES)
+    )
+    return classify_notebook(path, nb, engine_keys, {path.parent.resolve(): siblings})
+
+
+def scan_repo(
+    root: Path, engine_keys: Optional[List[str]] = None,
+) -> Dict[str, Dict[str, dict]]:
+    """Scan tous les notebooks d'un repo. Retourne {notebook_path: {engine: verdict}}."""
+    notebooks = list(_iter_notebooks(root))
+    cache = _build_sibling_cache(notebooks)
+    out: Dict[str, Dict[str, dict]] = {}
+    for nb in notebooks:
+        try:
+            data = _read_notebook(nb)
+        except (OSError, json.JSONDecodeError) as e:
+            out[str(nb)] = {"_error": str(e)}
+            continue
+        results = classify_notebook(nb, data, engine_keys, cache)
+        if results:
+            out[str(nb)] = results
+    return out
+
+
+# --- CLI -------------------------------------------------------------------
+
+def _format_report(scan_results: Dict[str, Dict[str, dict]]) -> str:
+    lines: List[str] = []
+    total_by_verdict: Dict[str, int] = {}
+    for nb_path, results in scan_results.items():
+        if "_error" in results:
+            lines.append(f"[ERROR] {nb_path}: {results['_error']}")
+            continue
+        for engine_key, info in results.items():
+            v = info["verdict"]
+            total_by_verdict[v] = total_by_verdict.get(v, 0) + 1
+            lines.append(f"[{v:30s}] engine={engine_key:14s} {nb_path}")
+    lines.append("")
+    lines.append("=== Totaux par verdict ===")
+    for v, count in sorted(total_by_verdict.items(), key=lambda x: -x[1]):
+        lines.append(f"  {v}: {count}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit notebooks naming an engine/LLM without invoking it.",
+    )
+    parser.add_argument("--scan", type=Path, help="Scan a single notebook")
+    parser.add_argument("--scan-all", type=Path, nargs="?", const=Path("."),
+                        help="Scan all notebooks under PATH (default: cwd)")
+    parser.add_argument("--engine", action="append", default=None,
+                        help="Restrict to one or more engine keys (default: all)")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument("--check", action="store_true",
+                        help="Exit 1 if any NAMED_NOT_INVOKED or SIMULATED_TERMINAL found")
+    args = parser.parse_args(argv)
+
+    engine_keys = args.engine
+    if args.scan:
+        results = {str(args.scan): scan_notebook(args.scan, engine_keys)}
+    elif args.scan_all is not None:
+        results = scan_repo(args.scan_all, engine_keys)
+    else:
+        parser.error("Either --scan or --scan-all required")
+
+    if args.json:
+        print(json.dumps(results, indent=2, ensure_ascii=False))
+    else:
+        print(_format_report(results))
+
+    if args.check:
+        defects = 0
+        for nb_results in results.values():
+            for info in nb_results.values():
+                if isinstance(info, dict) and info.get("verdict") in (
+                    "NAMED_NOT_INVOKED", "SIMULATED_TERMINAL",
+                ):
+                    defects += 1
+        return 1 if defects > 0 else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_audit_engine_named_not_invoked.py
+++ b/scripts/notebook_tools/tests/test_audit_engine_named_not_invoked.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Tests for audit_engine_named_not_invoked.
+
+Covers the 5 verdicts + sequence-aware grouping + edge cases:
+
+* ``ENGINE_EXEC_PROVED`` : claim + wiring + real output (Lab16 BigQuery
+  post-fix, OpenAI with real response).
+* ``DISCLOSED_SEQUENCE_PROVED`` : deterministic notebook + successor with
+  wiring/proof (Track2 Lab8/Lab16 etc).
+* ``WIRING_ONLY`` : import present but no real output (key-gated code).
+* ``SIMULATED_TERMINAL`` : outputs = simulation, no wiring (SW-12
+  GraphRAG).
+* ``NAMED_NOT_INVOKED`` : claim present but zero wiring (Track2 ADK
+  baseline).
+
+Plus :
+* Multi-engine per notebook (engine X proved, engine Y NAMED_NOT_INVOKED).
+* Sibling grouping (cache) successeurs successifs.
+* Verdict filtres --check exit code.
+* Exclusion artefacts _output.ipynb/_executed.ipynb.
+
+Run::
+
+    pytest scripts/notebook_tools/tests/test_audit_engine_named_not_invoked.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from audit_engine_named_not_invoked import (  # noqa: E402
+    ENGINE_REGISTRY,
+    classify_notebook,
+    main,
+    scan_repo,
+    _is_disclosed_deterministic,
+    _iter_notebooks,
+)
+
+
+# --- helpers ---------------------------------------------------------------
+
+def _nb(md_cells=(), code_cells=()):
+    """Construit un notebook en memoire."""
+    cells = []
+    for src in md_cells:
+        cells.append({"cell_type": "markdown", "source": src, "metadata": {}, "outputs": []})
+    for src, outputs in code_cells:
+        cells.append({
+            "cell_type": "code",
+            "source": src,
+            "metadata": {},
+            "execution_count": 1 if outputs else None,
+            "outputs": outputs,
+        })
+    return {
+        "cells": cells,
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _out_stream(text):
+    return [{"output_type": "stream", "name": "stdout", "text": text + "\n"}]
+
+
+# --- Engine registry structure ---------------------------------------------
+
+def test_registry_has_three_engines():
+    expected = {"google_adk", "openai_llm", "bigquery"}
+    assert set(ENGINE_REGISTRY.keys()) == expected
+
+
+def test_registry_entries_have_required_fields():
+    for key, spec in ENGINE_REGISTRY.items():
+        assert spec.key == key
+        assert spec.imports, f"{key}: imports vide"
+        assert spec.claims, f"{key}: claims vide"
+        assert spec.simulation_markers, f"{key}: simulation_markers vide"
+        assert spec.label
+
+
+# --- ENGINE_EXEC_PROVED ----------------------------------------------------
+
+def test_engine_exec_proved_bigquery():
+    """Lab16 post-fix : import bigquery + claim BQML + output reel."""
+    nb = _nb(
+        md_cells=["# Lab 16 : BigQuery BQML reel\nCe lab utilise **BigQuery**."],
+        code_cells=[
+            ("from google.cloud import bigquery\nclient = bigquery.Client()", _out_stream("Dataset cree")),
+        ],
+    )
+    p = Path("/tmp/_test_engine_exec_proved.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["bigquery"], {p.parent.resolve(): [p]})
+        assert "bigquery" in results
+        assert results["bigquery"]["verdict"] == "ENGINE_EXEC_PROVED"
+        assert results["bigquery"]["wiring"]
+    finally:
+        p.unlink()
+
+
+def test_engine_exec_proved_openai_real_response():
+    """Import openai + output reponse API (pas 'Reponse simulee')."""
+    nb = _nb(
+        md_cells=["# GPT-4 integration\nAppel reel a `gpt-4`."],
+        code_cells=[
+            (
+                "import openai\nr = openai.ChatCompletion.create(model='gpt-4', messages=[{'role':'user','content':'hi'}])\nprint(r.choices[0].message.content)",
+                _out_stream("Bonjour, comment puis-je vous aider ?"),
+            ),
+        ],
+    )
+    p = Path("/tmp/_test_openai_proved.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["openai_llm"], {p.parent.resolve(): [p]})
+        assert "openai_llm" in results
+        assert results["openai_llm"]["verdict"] == "ENGINE_EXEC_PROVED"
+    finally:
+        p.unlink()
+
+
+# --- DISCLOSED_SEQUENCE_PROVED ---------------------------------------------
+
+def test_disclosed_sequence_proved_via_successor():
+    """Notebook deterministe qui REFERENCE Google ADK dans sa prose
+    + successeur dans la meme serie avec wiring+proof reels.
+    Le verdict attendu : DISCLOSED_SEQUENCE_PROVED (le notebook lui-meme
+    est deterministe, mais il annonce le successeur qui apporte le reel).
+    """
+    p1 = Path("/tmp/_test_seq1.ipynb")
+    p2 = Path("/tmp/_test_seq2.ipynb")
+
+    nb1 = _nb(
+        md_cells=[
+            "# Lab A : preparation deterministe\n"
+            "Ce notebook est deterministe, sans LLM. Il prepare le terrain pour "
+            "le **Google ADK** runtime developpe dans Lab B.",
+        ],
+        code_cells=[
+            ("# Calcul deterministe\nresult = 2 + 2\nprint(result)", _out_stream("4")),
+        ],
+    )
+    nb2 = _nb(
+        md_cells=["# Lab B : Google ADK reel"],
+        code_cells=[
+            (
+                "from google.adk import Agent\nagent = Agent()",
+                _out_stream("Agent initialise"),
+            ),
+        ],
+    )
+    p1.write_text(json.dumps(nb1))
+    p2.write_text(json.dumps(nb2))
+    try:
+        siblings = [p1, p2]
+        cache = {p1.parent.resolve(): siblings}
+        results = classify_notebook(p1, nb1, ["google_adk"], cache)
+        assert "google_adk" in results, (
+            "Le claim 'Google ADK' doit declencher la classification "
+            "meme si le notebook est deterministe lui-meme"
+        )
+        assert results["google_adk"]["verdict"] == "DISCLOSED_SEQUENCE_PROVED"
+    finally:
+        p1.unlink()
+        p2.unlink()
+
+
+def test_disclosed_deterministic_marker_recognised():
+    """Le marker deterministe/sans LLM doit etre detecte."""
+    nb = _nb(md_cells=["# Test\nNotebook deterministe, sans appel LLM."])
+    assert _is_disclosed_deterministic(nb) is True
+
+    nb2 = _nb(md_cells=["# Test\nNotebook normal."])
+    assert _is_disclosed_deterministic(nb2) is False
+
+
+# --- WIRING_ONLY -----------------------------------------------------------
+
+def test_wiring_only_no_proof():
+    """Import present mais output gate par cle absente (vide)."""
+    nb = _nb(
+        md_cells=["# GPT-4 integration (key absente)"],
+        code_cells=[
+            (
+                "import openai\n# cle api-key absente\nexec(openai.ChatCompletion.create)",
+                [],  # pas d'output reel
+            ),
+        ],
+    )
+    p = Path("/tmp/_test_wiring_only.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["openai_llm"], {p.parent.resolve(): [p]})
+        assert results["openai_llm"]["verdict"] == "WIRING_ONLY"
+    finally:
+        p.unlink()
+
+
+# --- SIMULATED_TERMINAL ----------------------------------------------------
+
+def test_simulated_terminal_graphrag():
+    """SW-12 GraphRAG : outputs 'Reponse simulee', pas d'import openai."""
+    nb = _nb(
+        md_cells=[
+            "# SW-12 GraphRAG\nExtraction reelle avec GPT/Claude.",
+        ],
+        code_cells=[
+            (
+                "# extraction\nprint('Reponse simulee : [entities...]')",
+                _out_stream("Reponse simulee : [entities...]"),
+            ),
+        ],
+    )
+    p = Path("/tmp/_test_simulated.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["openai_llm"], {p.parent.resolve(): [p]})
+        assert results["openai_llm"]["verdict"] == "SIMULATED_TERMINAL"
+    finally:
+        p.unlink()
+
+
+# --- NAMED_NOT_INVOKED -----------------------------------------------------
+
+def test_simulated_terminal_or_named_not_invoked_track2_adk_baseline():
+    """Track2 baseline : claim Google ADK, zero import.
+
+    Verdict attendu : SIMULATED_TERMINAL (plus precis que NAMED_NOT_INVOKED)
+    car le code contient ``class MockAgent`` qui est un simulation_marker.
+    Le scanner detecte 'mock agent' comme preuve de simulation locale --
+    c'est le defaut firsthand documente dans #13927 (Track2 : 10 labs sans
+    import `google.adk` mais avec des classes mock locales).
+    """
+    nb = _nb(
+        md_cells=[
+            "# Lab 5 : Google ADK agent\nIntegration du Google ADK runtime.",
+        ],
+        code_cells=[
+            ("# mock agent\nclass MockAgent:\n    pass", _out_stream("mock created")),
+        ],
+    )
+    p = Path("/tmp/_test_named_not_invoked.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["google_adk"], {p.parent.resolve(): [p]})
+        # Le scanner detecte la simulation_marker `class MockAgent` :
+        # verdict = SIMULATED_TERMINAL (le notebook simule sans le declarer
+        # comme deterministe, et il n'a pas de successeur dans ce test).
+        assert results["google_adk"]["verdict"] == "SIMULATED_TERMINAL"
+        assert results["google_adk"]["simulation"], "le mock class doit etre flag"
+    finally:
+        p.unlink()
+
+
+def test_named_not_invoked_no_mock_no_wiring():
+    """Cas pur NAMED_NOT_INVOKED : claim present, ni mock ni import."""
+    nb = _nb(
+        md_cells=[
+            "# Lab 7 : Google ADK demo\nCas pedagogique isole.",
+        ],
+        code_cells=[
+            ("# Pas de mock, pas d'import\nprint('placeholder')", _out_stream("placeholder")),
+        ],
+    )
+    p = Path("/tmp/_test_pure_named.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["google_adk"], {p.parent.resolve(): [p]})
+        assert results["google_adk"]["verdict"] == "NAMED_NOT_INVOKED"
+    finally:
+        p.unlink()
+
+
+# --- Multi-engine ----------------------------------------------------------
+
+def test_multi_engine_per_notebook():
+    """Un notebook peut etre ENGINE_EXEC_PROVED pour X et NAMED_NOT_INVOKED pour Y."""
+    nb = _nb(
+        md_cells=[
+            "# Multi\nUtilise Google ADK **et** BigQuery.",
+        ],
+        code_cells=[
+            ("from google.cloud import bigquery", _out_stream("Client() OK")),
+            # pas d'import google.adk
+        ],
+    )
+    p = Path("/tmp/_test_multi.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, ["google_adk", "bigquery"], {p.parent.resolve(): [p]})
+        assert "google_adk" in results
+        assert "bigquery" in results
+        assert results["google_adk"]["verdict"] == "NAMED_NOT_INVOKED"
+        assert results["bigquery"]["verdict"] == "ENGINE_EXEC_PROVED"
+    finally:
+        p.unlink()
+
+
+def test_no_claim_no_trigger():
+    """Pas de claim = pas de verdict (moteur non pertinent)."""
+    nb = _nb(
+        md_cells=["# Pure Python"],
+        code_cells=[("print(2 + 2)", _out_stream("4"))],
+    )
+    p = Path("/tmp/_test_no_claim.ipynb")
+    p.write_text(json.dumps(nb))
+    try:
+        results = classify_notebook(p, nb, None, {p.parent.resolve(): [p]})
+        assert results == {}
+    finally:
+        p.unlink()
+
+
+# --- iter_notebooks --------------------------------------------------------
+
+def test_iter_excludes_output_artifacts(tmp_path):
+    (tmp_path / "good.ipynb").write_text("{}")
+    (tmp_path / "bad_output.ipynb").write_text("{}")
+    (tmp_path / "bad_executed.ipynb").write_text("{}")
+    seen = [p.name for p in _iter_notebooks(tmp_path)]
+    assert "good.ipynb" in seen
+    assert "bad_output.ipynb" not in seen
+    assert "bad_executed.ipynb" not in seen
+
+
+# --- CLI -------------------------------------------------------------------
+
+def test_cli_check_exit_code_on_defect(tmp_path):
+    """`--check` exit 1 si NAMED_NOT_INVOKED ou SIMULATED_TERMINAL trouve."""
+    (tmp_path / "claim_only.ipynb").write_text(json.dumps(_nb(
+        md_cells=["# Google ADK integration"],
+        code_cells=[("# no import", _out_stream("foo"))],
+    )))
+    rc = main(["--scan-all", str(tmp_path), "--check"])
+    assert rc == 1
+
+
+def test_cli_json_output(tmp_path):
+    (tmp_path / "clean.ipynb").write_text(json.dumps(_nb(
+        md_cells=["# Clean"],
+        code_cells=[("print(1)", _out_stream("1"))],
+    )))
+    rc = main(["--scan-all", str(tmp_path), "--json"])
+    assert rc == 0
+
+
+def test_cli_scan_single_notebook(tmp_path):
+    p = tmp_path / "one.ipynb"
+    p.write_text(json.dumps(_nb(
+        md_cells=["# BigQuery claim"],
+        code_cells=[("from google.cloud import bigquery", _out_stream("ok"))],
+    )))
+    rc = main(["--scan", str(p)])
+    assert rc == 0
+
+
+def test_cli_scan_repo_no_defects_exits_zero(tmp_path):
+    (tmp_path / "good.ipynb").write_text(json.dumps(_nb(
+        md_cells=["# Pure Python"],
+        code_cells=[("print('hi')", _out_stream("hi"))],
+    )))
+    rc = main(["--scan-all", str(tmp_path), "--check"])
+    assert rc == 0
+
+
+# --- scan_repo end-to-end --------------------------------------------------
+
+def test_scan_repo_finds_track2_adk_baseline(tmp_path):
+    """Reproduction du cas Track2 baseline dans un repo temporaire."""
+    (tmp_path / "Track2-Day5-Lab10.ipynb").write_text(json.dumps(_nb(
+        md_cells=["# Lab 10\nGoogle ADK integration avec runtime"],
+        code_cells=[("# no import google.adk", _out_stream("10"))],
+    )))
+    results = scan_repo(tmp_path)
+    found = False
+    for nb_path, nb_results in results.items():
+        if "google_adk" in nb_results:
+            assert nb_results["google_adk"]["verdict"] == "NAMED_NOT_INVOKED"
+            found = True
+    assert found, "Lab10 Track2 devrait declencher NAMED_NOT_INVOKED"


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-python #14040

## Contexte
#13927 denonce les claims SOTA creux : un notebook peut passer C.2 (outputs/exec) sans que le moteur claim ne soit celui qui s'execute. Deux defauts firsthand documentes :
- Track2-GoogleADK : 10 labs avec claim 'Google ADK' mais zero import `google.adk`
- SW-12 GraphRAG : claim 'GPT/Claude' avec outputs 'Reponse simulee'

## Livré
Scanner dedie `scripts/notebook_tools/audit_engine_named_not_invoked.py` (+493 lignes) + 18 tests (+400 lignes) :
- Registre moteur explicite et extensible : google_adk / openai_llm / bigquery
- Croisement 3 surfaces : claim (markdown) + wiring (code sans commentaires) + proof (outputs reels)
- 5 verdicts distincts : ENGINE_EXEC_PROVED / DISCLOSED_SEQUENCE_PROVED / WIRING_ONLY / SIMULATED_TERMINAL / NAMED_NOT_INVOKED
- Sequence-aware : detection de successeur dans la meme serie-sibling cache
- Comment-stripping : un import dans un commentaire ne compte pas comme wiring
- CLI : --scan <notebook>, --scan-all, --json, --check

## Validation empirique
`--scan-all MyIA.AI.Notebooks` (56s, 69 findings) :
- 41 ENGINE_EXEC_PROVED
- 26 NAMED_NOT_INVOKED (dont Track2 ADK baseline labs)
- 2 SIMULATED_TERMINAL (dont SW-12-Python-GraphRAG, defaut documente)

SW-12 ressort `SIMULATED_TERMINAL` comme attendu. Lab16 (avant merge #14040) ressort `NAMED_NOT_INVOKED` pour BigQuery (wiring sera ajoute par #14040).

## Acceptance #13927
- [x] Scanner dedie sous scripts/notebook_tools/, pas un script ad hoc racine
- [x] Registre moteur -> claims/imports/calls/marqueurs explicite et testable
- [x] 5 verdicts distincts implementes
- [x] Track2 ADK courant detecte NAMED_NOT_INVOKED (valide sur Lab8/Lab10)
- [x] SW-12 GraphRAG detecte SIMULATED_TERMINAL
- [x] Import seul ou code derriere cle absente ne vaut pas preuve (WIRING_ONLY)
- [x] Findings nomment les cellules/claims (snippet + cell_idx)
- [x] 18 tests fixtures positifs/negatifs (5 verdicts + sequence + multi-engine + CLI)
- [ ] Integration CI **advisory** d'abord ; passage bloquant differe par triage du corpus (cf #13927 acceptance finale)

## Compliance
- **SOTA #3801** : registre explicite sans heuristique opaque
- **H.5** : registre parseable (regex explicites par moteur)
- **D** : pas de production code modifie, ajout pur
- **No-fabrication** : aucun claim synthetique dans le scanner, il DETECTE des claims reels

See #13927 (livraison scanner + registre + tests ; acceptance finale = CI bloquant differe).