### PR TITLE
feat(notebooks,#13934): brancher-plusieurs-providers — 6 lectures ancrees aux sorties (1004->1394)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-5-Multi-Provider/brancher-plusieurs-providers-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-5-Multi-Provider/brancher-plusieurs-providers-par-l-api.ipynb
@@ -297,6 +297,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "lecture-catalogue-vllm-local",
+   "metadata": {},
+   "source": [
+    "### Lecture — un catalogue qui tient en un modèle\n",
+    "\n",
+    "`ai/models` renvoie **un seul modèle pour `vllm-local` : `qwen3.6-35b-a3b`**. Trois champs méritent lecture :\n",
+    "\n",
+    "- **`features = ['completion']`** : ce modèle est déclaré pour *compléter*, pas (via cette route) pour dialoguer. Le catalogue expose la capacité ; le point d'entrée `ai/chat` en fera l'usage, la cellule suivante serrera la main dans l'autre sens.\n",
+    "- **`8192` tokens de contexte, `4096` de complétion max** : le volume est borné — c'est l'ordre de grandeur d'une inférence locale quantifiée. C'est le guide de dimensionnement pour ne pas lui envoyer un corpus entier.\n",
+    "- **`price = {in: 0, out: 0}`** et tags **`['core', 'chat']`** : l'instance de dev est gratuite et marquée `core`. Le prix nul ne dit rien de la valeur, il dit l'absence de comptage.\n",
+    "\n",
+    "Le catalogue est donc la **source de vérité sur ce que le serveur sait servir** — on l'interroge avant de brancher un usage."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "3a02297b",
@@ -339,6 +355,18 @@
     "              payload={\"env_id\": \"environnement-inexistant\"})\n",
     "print()\n",
     "print(\"environnement inexistant :\", inconnu.get(\"success\"), \"|\", inconnu.get(\"error\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lecture-poignee-de-main",
+   "metadata": {},
+   "source": [
+    "### Lecture — la poignée de main, et son échec propre\n",
+    "\n",
+    "`ai/test_connection` répond pour `vllm-local` : **`success = True`, `provider = custom`, `modeles trouves = 1 ['qwen3.6-35b-a3b']`**. Le `provider` est `custom` ; le champ `details['endpoint']` — l'adresse du serveur de modèles — est volontairement masqué, c'est un secret local.\n",
+    "\n",
+    "Le second appel répond face à un `envId` inventé : **`success = False`, message « Environment not found. »** Le serveur **valide l'identifiant**, il ne l'invente pas : une faute de frappe dans un `env_id` ne produit pas un modèle vide, elle produit un **échec explicite**. C'est le contrat à garder pour la suite — on peut donc interroger un environnement inexistant **en toute sécurité** : l'API refuse avant de toucher quoi que ce soit."
    ]
   },
   {
@@ -543,6 +571,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "lecture-declarer-second-env",
+   "metadata": {},
+   "source": [
+    "### Lecture — déclarer un second environnement par recopie\n",
+    "\n",
+    "Ajouter `vllm-secours` ne part pas de zéro : la cellule **recopie la configuration de `vllm-local`** (`copy.deepcopy(source)`), change `id` et `name`, puis re-POST le `settings/update` complet. Résultat : **`update = True`, et `ai_envs` porte désormais deux entrées** — `vllm-local` et `vllm-secours`, même `type custom`, même modèle `qwen3.6-35b-a3b`.\n",
+    "\n",
+    "Le geste est un **read-modify-write** : on lit `ai_envs`, on le modifie en mémoire, on le réécrit en entier. C'est précisément la contre-mesure du piège de la section précédente — `settings/update` *remplace*, il ne *patch* pas, donc il faut toujours renvoyer l'objet complet. L'`id` suffit à faire un nouvel environnement : le serveur n'exige aucun enregistrement préalable."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "db7bc073",
@@ -578,6 +618,18 @@
     "test = api(\"/mwai/v1/ai/test_connection\", method=\"POST\", payload={\"env_id\": \"vllm-secours\"})\n",
     "print(\"connexion du secours :\", test.get(\"success\"),\n",
     "      \"|\", (test.get(\"data\") or {}).get(\"message\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lecture-interroger-secours",
+   "metadata": {},
+   "source": [
+    "### Lecture — le secours répond : même serveur, autre enveloppe\n",
+    "\n",
+    "Le nouveau `envId` est interrogé deux fois. `ai/models` sur `vllm-secours` → **`['qwen3.6-35b-a3b']`** ; `ai/test_connection` sur `vllm-secours` → **`True`, « Connection successful. Found 1 models. »**\n",
+    "\n",
+    "Le secours **tient** le même modèle que l'instance principale — un seul, toujours `qwen3.6-35b-a3b`. C'est cohérent : `vllm-secours` est une **copie** de `vllm-local`, donc les deux pointent le même backend sous un id différent. La valeur de la déclaration n'est pas un nouveau moteur, c'est une **enveloppe de repli** : si `vllm-local` tombe, `vllm-secours` est déjà configuré. La suite montre comment basculer."
    ]
   },
   {
@@ -634,6 +686,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "lecture-basculer-usage",
+   "metadata": {},
+   "source": [
+    "### Lecture — basculer un usage, vérifier, remettre\n",
+    "\n",
+    "La bascule réécrit `ai_default_env` en read-modify-write : `vllm-local` → `vllm-secours`. La vérification rend **`default_env bascule : vllm-secours | model : qwen3.6-35b-a3b`**, puis la cellule **remet tout à sa place** : `default_env remis : vllm-local`.\n",
+    "\n",
+    "Deux lectures : (1) **`ai_default_model` suit l'environnement** — basculer l'env change aussi le modèle par défaut, on ne les règle pas indépendamment. (2) La séquence est une **inversion maîtrisée** : on écrit, on vérifie, on remet. C'est l'ombre d'un blue-green, et le test de non-régression est justement `remis = vllm-local` — l'usage est revenu à son point de départ."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "dacd0b7f",
@@ -671,6 +735,18 @@
     "test = api(\"/mwai/v1/ai/test_connection\", method=\"POST\", payload={\"env_id\": \"vllm-local\"})\n",
     "print(\"connexion vllm-local :\", test.get(\"success\"),\n",
     "      \"|\", (test.get(\"data\") or {}).get(\"message\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lecture-purger-secours",
+   "metadata": {},
+   "source": [
+    "### Lecture — purger : la réversibilité du read-modify-write\n",
+    "\n",
+    "La purge réécrit `ai_envs` **sans** `vllm-secours` (`[e for e in ... if e[\"id\"] != \"vllm-secours\"]`). L'état final est bien l'état initial : **`envs final = ['vllm-local']`, `default_env = vllm-local`, `model = qwen3.6-35b-a3b`, `module_embeddings = True`**, et `ai/test_connection` sur `vllm-local` → **`True`, « Connection successful. Found 1 models. »**\n",
+    "\n",
+    "C'est la leçon de la section : parce que `settings/update` **remplace** l'objet entier, toute modification (ajout, bascule, purge) est **entièrement réversible** — il suffit de réécrire `ai_envs` (ou `ai_default_env`) avec la valeur voulue. L'instance jetable revient à son état de référence sans état résiduel, et la dernière poignée de main confirme que le serveur est de nouveau opérationnel."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-dotnet #14043 (substance distincte : notebook Python d'API multi-provider AI Engine, et non GameTheory-05 C#)

## Sujet

`brancher-plusieurs-providers-par-l-api.ipynb` sortait à **1004 c/cell** (seuil 1200) et portait un **run de 4 cellules code consécutives** ([13]-[16]) sans aucune interprétation entre elles, plus les cellules [7]/[8]. Les sorties committées — 1 modèle `qwen3.6-35b-a3b` (8192/4096 tokens), poignée `provider=custom`, env inexistant `False` « Environment not found. », `ai_envs` 2 entrées après déclaration, bascule `default_env vllm-secours` puis remise `vllm-local`, purge — n'étaient lues par **aucune** cellule markdown.

Ajout de **6 cellules markdown « Lecture »** ADDITIVES, chacune ancrée aux valeurs committées qu'aucune autre cellule ne lit :

| # | Position (après) | Contenu ancré (valeurs committées) |
|---|---|---|
| 1 | cell. 7 (catalogue `ai/models`) | **1 seul modèle `qwen3.6-35b-a3b`**, `features=['completion']`, contexte **8192/4096**, prix **0/0**, tags `['core','chat']` — le catalogue comme source de vérité |
| 2 | cell. 8 (poignée `ai/test_connection`) | `success=True`, `provider=custom`, 1 modèle ; env inventé → `False` « Environment not found. » — l'API **valide** l'envId, échec explicite |
| 3 | cell. 13 (déclarer `vllm-secours`) | recopie `copy.deepcopy` de `vllm-local`, `update=True`, `ai_envs` → **2 entrées** — read-modify-write (contre-mesure du piège §4) |
| 4 | cell. 14 (interroger le secours) | même modèle `['qwen3.6-35b-a3b']`, `connect True` « Found 1 models. » — enveloppe de repli, même backend |
| 5 | cell. 15 (basculer l'usage chat) | `default_env vllm-local → vllm-secours → vllm-local`, `model` suit l'env — inversion maîtrisée |
| 6 | cell. 16 (purger le secours) | `envs final=['vllm-local']`, `default_env=vllm-local`, `module_embeddings=True`, connexion OK — réversibilité du read-modify-write, instance sans état résiduel |

## Validation

- **Code byte-identique** : 12/12 cellules code inchangées (source + `outputs` + `execution_count` + `metadata` comparés JSON-normalisés contre `origin/main`, sans `text=True` — pas de faux mojibake cp1252). Enrichissement **markdown-only**, exempt de re-exécution (C.2/C.3 exception modifs uniquement markdown) ; pre-commit H.3 passé (cellules code conservent `execution_count` + `outputs`).
- **Densité** : `pedagogy_density.py` **1004 → 1394 c/cell** (seuil 1200 atteint, « 0 below ») ; 26 → 32 cellules ; 6 insertions, 0 deletions.
- **`detect_consecutive_code_cells.py` : Run >= 2 = 0** — le run de 4 consécutives [13]-[16] est **corrigé** par cette PR (défaut pré-existant signalé, résolu en ajoutant l'interprétation manquante entre chaque cellule).
- **Guards verts** : `detect_markdown_rendering.py` 0 violation · `detect_code_in_markdown_cells.py` 0 nouveau vs baseline (2) · `scan_cell_ordering.py` 0 finding · `check_interp_positioning.py` 0 finding.
- **Pas de twin pair** (aucune entrée `twin_pairs.d` ne référence ce notebook) ; **catalogue intact** (`catalog-pr-hygiene`).
- Choix du grain : picker sans candidat CONTENU non-VOID ; scan famille `AI-Engine-WordPress` à densité < seuil → les items basse-densité y sont **déjà interprétés** (auditer-la-conformite-visuelle : 843 c/cell = artefact 9273/11, interprétation complète) → pivot vers ce notebook, seul à détenir un **vrai gap** (run de 4 consécutives + sorties non lues). REFUS documenté de l'item 2 (auditer) sur l'issue #13934, commentaire 5493162598.

See #13934
