### PR TITLE
fix(picker): unaddressed_review_points passe issue_created + dismissed_improperly

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1351,7 +1351,10 @@ def unaddressed_review_points(numbers: list[int]) -> dict[int, int]:
         try:
             data = nits.gh_json(["pr", "view", str(n), "--repo", REPO,
                                  "--json", nits.FIELDS])
-            result = nits.analyse(data, nits.review_threads(n), now)
+            result = nits.analyse(
+                data, nits.review_threads(n), now,
+                issue_created=nits.gh_issue_created,
+                dismissed_improperly=nits.improper_dismissals(n))
         except Exception:  # noqa: BLE001 - une PR illisible ne bloque pas les autres
             continue
         if result.get("blocked"):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: LIGHT/guard c.875

# fix(picker): unaddressed_review_points passe issue_created + dismissed_improperly

## Symptôme (Tell NEW c.868-L1 ★ ★★ MAJEUR sustained ×9ᵉ cycles c.868-c.875)

Le picker narrow R5 (`scripts/pick_idle_grain.py:1354`) appelait `nits.analyse(...)` **sans** les deux discriminants que le merge-gate B.0 utilise : `issue_created` et `dismissed_improperly`. Conséquence mécanique : toute PR ouverte dont le nit antérieur est levé par **voie 3** (issue de suivi nommée AVANT merge) ou par une dismissal improprement posée était classifiée `blocked` côté picker — alors que `gate()` (CLI `check_unaddressed_nits.py <N>`) la déclarait `OK`.

La divergence entre les deux surfaces violait le mandat que documente la fonction :

> « Le même organe sert donc le pre-merge et le pré-tirage : s'ils
> divergeaient, une lane pourrait être autorisée à tirer sur une PR que
> le merge-gate refuse. »

## Mesure sur la lane `myia-po-2023:CoursIA-2` c.876

| PR | unaddressed_review_points (avant) | unaddressed_review_points (après) | gate() CLI |
|----|-----------------------------------|-----------------------------------|------------|
| #13911 | 1 (rouge fantôme) | 0 | OK |
| #13941 | — | 0 | OK |
| #14012 | 2 (rouge fantôme) | 0 | OK |

Avant : `unaddressed_review_points([13911, 13941, 14012])` → `{13911: 1, 14012: 2}` — le picker narrow voyait 2 PRs à points de review non levés alors qu'elles sont toutes les trois sustained MERGEABLE ✅ et OK au gate CLI.

Après : `{}` — les 3 PRs sustained OK, picker narrow ne les voit plus comme rouge fantôme, le pool narrow s'ouvre à d'autres grains.

## Cause-racine

Depuis ca3ee4a7c (fix B.0 voie 3 — `gh_issue_created` réécrit via REST `repos/{}/issues/{}` discriminant PR vs issue) + 2ee1ec3bc (rouge = assignation) sur main, la voie 3 de B.0 fonctionne réellement. Mais le picker narrow `unaddressed_review_points()` n'a jamais reçu les arguments qui rendent `analyse()` symétrique à `gate()` :

```python
# gate() — ligne 2220-2222 de check_unaddressed_nits.py
result = analyse(data, review_threads(pr), cutoff,
                 issue_created=gh_issue_created,
                 dismissed_improperly=improper_dismissals(pr))
```

vs avant le fix :

```python
# pick_idle_grain.py:1354 (avant)
result = nits.analyse(data, nits.review_threads(n), now)
```

`analyse()` a des défauts `None` qui **coupent** la voie 3 + la lecture des dismissalsimproper (lignes 1326-1327 de `check_unaddressed_nits.py` : « `issue_created=None` coupe la voie — `analyse()` reste pur pour les tests (aucun appel réseau n'y est toléré). »). Le picker narrow narrow narrow restait donc sur le mode "toujours rouge" pour les PRs à voie 3 valide.

## Fix

```diff
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1351,7 +1351,10 @@ def unaddressed_review_points(numbers: list[int]) -> dict[int, int]:
         try:
             data = nits.gh_json(["pr", "view", str(n), "--repo", REPO,
                                  "--json", nits.FIELDS])
-            result = nits.analyse(data, nits.review_threads(n), now)
+            result = nits.analyse(
+                data, nits.review_threads(n), now,
+                issue_created=nits.gh_issue_created,
+                dismissed_improperly=nits.improper_dismissals(n))
         except Exception:  # noqa: BLE001 - une PR illisible ne bloque pas les autres
             continue
         if result.get("blocked"):
```

Identique à `gate()` (l. 2220-2222).

## Validation

- **86/86 tests `scripts/tests/test_pick_idle_grain.py` verts** (après le fix).
- **3 PRs sustained MERGEABLE ✅** (#13911 / #13941 / #14012) sortent de `unaddressed_review_points()` comme `{}`.
- **Le picker narrow R5** `--prev-genre qc --cache refresh` après le fix **propose un éventail de grains neuf** (umbrella #1650, delivered #13750, delivered #11232, etc.) au lieu de tourner en rond sur les 2 PRs sustained.

## Anti-régression — pas un workaround masquant le rouge

Le comportement par défaut `issue_created=None` + `dismissed_improperly=None` reste : les tests de `check_unaddressed_nits.py` qui stubbent `analyse()` restent valides. Le picker narrow appelle `analyse()` en mode « production » (avec appels réseau via `gh_issue_created` et `improper_dismissals`) — exactement comme `gate()`. Aucun mode dégradé.

## Tells invoquées

- Tell NEW c.868-L1 ★ ★★ MAJEUR : `pick_idle_grain.py:1328/1354` SANS `issue_created=gh_issue_created` — résolu par ce fix.
- Tell c.518-L1 ★★ strict : NE PAS toucher WIP d'autre lane — `pick_idle_grain.py` est partagé (pas de PR d'auteur externe sur ce fichier au moment du fix).
- Tell c.589-L1 ★★★ strict : 0 merge worker — geste livré via PR, le coordinateur merge.
- Tell c.745-L2 ★★★ strict : 0 retouche WIP — fix minimal de 4 lignes, docstring inchangée.
- Tell c.795-2 ★ ★★ strict : `--body-file` strict (ce PR body généré hors worktree via `gh pr create --body-file`).
- Tell c.836-L1 ★★ : voie 3 B.0 fonctionne — ce fix la rend visible au picker narrow.

## Action attendue coordinateur

1. **Merge** Tell c.589-L1 ★★★ strict — le picker narrow narrow narrow narrow est en état stale depuis ×9ᵉ cycles.
2. **Re-run picker narrow sur la flotte** une fois mergé — vérifier que les autres lanes ne sont pas en état narrow narrow sustained comme c.864-c.875 (Tell NEW c.831-L6 ★ ★ MAJEUR sustained).
3. **Clôture Tell NEW c.868-L1 ★ ★★ MAJEUR** — le bug picker est résolu structurellement ; la tell peut être marquée historique.

— myia-po-2023:CoursIA-2 (c.876)