### PR TITLE
fix(readme,#13780): DataScienceWithAgents arbre + tables alignés sur disque (33 → 50 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -24,7 +24,7 @@ La formation couvre deux stacks complémentaires :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 33 (7 LangChain + 10 ADK + 2 fondations Python + 12 fondations ML + 2 deep learning) |
+| Notebooks | 50 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning) |
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 
@@ -80,26 +80,40 @@ DataScienceWithAgents/
 │       ├── 1.2-NumPy.ipynb
 │       └── 1.3-Pandas.ipynb
 │
-├── 02-ML-Cours/                # Fondations ML canoniques (12 notebooks)
+├── 02-ML-Cours/                # Fondations ML canoniques (21 notebooks)
 │   ├── 2.1-Workflow-ML.ipynb
 │   ├── 2.2-Descente-de-gradient.ipynb
 │   ├── 2.3-Regression-lineaire-logistique.ipynb
+│   ├── 2.3b-Naive-Bayes-Generatif.ipynb
+│   ├── 2.3c-Regression-Grande-Dimension.ipynb
+│   ├── 2.3d-Modele-Gaussien-LDA-QDA.ipynb
 │   ├── 2.4-Arbres-Forets-Ensembles.ipynb
 │   ├── 2.5-Biais-Variance-CV-ROC.ipynb
 │   ├── 2.5b-Calibration-Probabilites.ipynb
+│   ├── 2.5c-Equite-Sous-Groupes.ipynb
 │   ├── 2.6-Clustering-KMeans-PCA.ipynb
 │   ├── 2.7-Modeles-Non-Parametriques.ipynb
 │   ├── 2.8-Theorie-PAC.ipynb
 │   ├── 2.8b-Theorie-PAC-Lean.ipynb
 │   ├── 2.8c-Borne-Temoin-Concentration.ipynb
+│   ├── 2.8d-Lean-Novikoff-Convergence.ipynb
 │   ├── 2.9-Grokking-Generalisation.ipynb
 │   ├── 2.10-Optimisation-Hyperparametres.ipynb
 │   ├── 2.11-Regularisation-Sparse-LASSO.ipynb
+│   ├── 2.12-Donnees-Desequilibrees.ipynb
 │   └── 2.13-Analyse-Erreurs.ipynb
 │
-├── 03-DeepLearning/            # Deep learning from scratch (2 notebooks)
+├── 03-DeepLearning/            # Deep learning from scratch (10 notebooks)
+│   ├── 3.0-Theorie-Information.ipynb
 │   ├── 3.1-Retropropagation.ipynb
-│   └── 3.2-Optimisateurs.ipynb
+│   ├── 3.2-Optimisateurs.ipynb
+│   ├── 3.3-Regularisation.ipynb
+│   ├── 3.4-Attention-Transformer-From-Scratch.ipynb
+│   ├── 3.5-Phenomenes-de-Generalisation.ipynb
+│   ├── 3.6-Modeles-Generatifs.ipynb
+│   ├── 3.6b-Modeles-Generatifs-PyTorch.ipynb
+│   ├── 3.7-Distillation-Maitre-Eleve.ipynb
+│   └── 3.8-Representations-Contrastives.ipynb
 │
 ├── Track1-LangChain/ # Track LangChain (7 labs)
 │   ├── Day1-Foundations/Labs/              # Revision
@@ -122,24 +136,30 @@ DataScienceWithAgents/
 
 ## Fondations ML (02-ML-Cours)
 
-Le socle machine learning canonique avec scikit-learn, posé à la main entre les fondations NumPy/Pandas et les labs agentic — là où scikit-learn n'apparaissait jusqu'ici que comme une séquence magique non expliquée. Douze notebooks (workflow, descente de gradient, régression linéaire/logistique, arbres et ensembles, biais-variance/CV/ROC, calibration des probabilités, clustering/ACP, SVM à noyau/k-NN, théorie PAC/dimension VC, ses deux compagnons formel et concentration, un épilogue 2.9 grokking, puis deux chapitres de praticien — optimisation d'hyperparamètres et analyse d'erreurs), chacun rendant visible un concept-phare et ancrant les articles fondateurs.
+Le socle machine learning canonique avec scikit-learn, posé à la main entre les fondations NumPy/Pandas et les labs agentic — là où scikit-learn n'apparaissait jusqu'ici que comme une séquence magique non expliquée. Vingt-et-un notebooks (workflow, descente de gradient, régression linéaire/logistique complétée par le pont génératif Naive Bayes et la régression en grande dimension PCR/PLS/Ridge, arbres et ensembles, biais-variance/CV/ROC, calibration des probabilités, équité par sous-groupes, clustering/ACP, SVM à noyau/k-NN, théorie PAC/dimension VC et ses trois compagnons formel/concentration/Perceptron, un épilogue 2.9 grokking, puis trois chapitres de praticien — optimisation d'hyperparamètres, régularisation sparse LASSO/ElasticNet, classes déséquilibrées, et analyse d'erreurs), chacun rendant visible un concept-phare et ancrant les articles fondateurs.
 
 | Notebook | Sujet | Concept-phare |
 |----------|-------|---------------|
 | [2.1-Workflow-ML](02-ML-Cours/2.1-Workflow-ML.ipynb) | split → fit → predict → évaluer | surapprentissage rendu visible |
 | [2.2-Descente-de-gradient](02-ML-Cours/2.2-Descente-de-gradient.ipynb) | ouvrir la boîte noire de `fit()` | 3 learning rates (lent / bon / divergeant) |
 | [2.3-Regression-lineaire-logistique](02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb) | OLS vs MLE | droite vs sigmoïde |
+| [2.3b-Naive-Bayes-Generatif](02-ML-Cours/2.3b-Naive-Bayes-Generatif.ipynb) | *Pont génératif* — classifieur naïf de Bayes (Bernoulli, multinomial, Gaussien), hypothèse d'indépendance conditionnelle | **L'indépendance qui décide** : la frontière est inherited du modèle conjoint, pas apprise |
+| [2.3c-Regression-Grande-Dimension](02-ML-Cours/2.3c-Regression-Grande-Dimension.ipynb) | p >> n : Ridge (L2), PCR (ACP) et PLS (supervisée) | **Var ≠ valeur prédictive** : la PLS trouve en 5 composantes ce que la PCR paie à 44 |
+| [2.3d-Modele-Gaussien-LDA-QDA](02-ML-Cours/2.3d-Modele-Gaussien-LDA-QDA.ipynb) | Analyse discriminante linéaire vs quadratique | **L'hypothèse de covariance décide la frontière** : partagée → droite (LDA), propre → conique (QDA) |
 | [2.4-Arbres-Forets-Ensembles](02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb) | DecisionTree, RandomForest, GradientBoosting | réduction de variance |
 | [2.5-Biais-Variance-CV-ROC](02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb) | biais-variance, validation croisée, ROC/AUC | coût du seuil de décision |
 | [2.5b-Calibration-Probabilites](02-ML-Cours/2.5b-Calibration-Probabilites.ipynb) | calibration des probabilités : reliability diagram, ECE | pourquoi 0.87 n'est pas 87 % de chances |
+| [2.5c-Equite-Sous-Groupes](02-ML-Cours/2.5c-Equite-Sous-Groupes.ipynb) | équité par sous-groupe : parité démographique, equalized odds, post-traitement par seuils (Hardt) | **L'accuracy globale ne suffit pas** : 96,4 % global coexiste avec des écarts de groupe [0,92–1,00] |
 | [2.6-Clustering-KMeans-PCA](02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb) | non supervisé : KMeans + ACP | structure retrouvée sans étiquettes |
 | [2.7-Modeles-Non-Parametriques](02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb) | SVM à noyau et k plus proches voisins | kernel trick (linéaire vs RBF) |
 | [2.8-Theorie-PAC](02-ML-Cours/2.8-Theorie-PAC.ipynb) | théorie PAC : sample complexity, dimension VC | la borne PAC prédit l'empirique |
 | [2.8b-Theorie-PAC-Lean](02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb) | *Compagnon Lean* (kernel `lean4-wsl`) — la même borne PAC, démontrée | ce que 2.8 constate, le lake le prouve |
 | [2.8c-Borne-Temoin-Concentration](02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb) | *Carte transversale + illustrations Python* — Sections 1--3 (reconstruction de la borne, témoin extrémal, Hoeffding bilatérale) sous kernel `coursia-ml-training` | qui porte quoi, et la mesure numérique Python exécutée |
+| [2.8d-Lean-Novikoff-Convergence](02-ML-Cours/2.8d-Lean-Novikoff-Convergence.ipynb) | *Compagnon Lean* (kernel `lean4-wsl`) — la moitié Perceptron du lake : Novikoff `n·γ² ≤ R²`, ses deux lemmes, son témoin de saturation | **Le théorème interrogé en direct** : `#check` + `#print axioms` depuis le lake, dynamique rejouée sur entiers |
 | [2.9-Grokking-Generalisation](02-ML-Cours/2.9-Grokking-Generalisation.ipynb) | *Épilogue* — grokking : la généralisation qui arrive en retard (premier réseau de neurones) | **L'horloge cachée** : embeddings rangés en cercle après le grok (ACP + Fourier) |
 | [2.10-Optimisation-Hyperparametres](02-ML-Cours/2.10-Optimisation-Hyperparametres.ipynb) | méthodologie du réglage : grille, hasard, bayésien (TPE) — et quand s'arrêter | le critère d'arrêt économise la moitié des essais |
 | [2.11-Regularisation-Sparse-LASSO](02-ML-Cours/2.11-Regularisation-Sparse-LASSO.ipynb) | *Régularisation sparse* — LASSO (L1, polyèdre) vs Ridge (L2, boule), coord descent, sélection de λ, ElasticNet sur features corrélées | **la géométrie décide** : polyèdre L1 → sparsity, boule L2 → shrink ; sur ρ > 0.7, ElasticNet stabilise |
+| [2.12-Donnees-Desequilibrees](02-ML-Cours/2.12-Donnees-Desequilibrees.ipynb) | *Classes déséquilibrées* — la métrique qui ment (accuracy vs PR), rééchantillonnage, seuillage par coût | **La courbe PR dit la vérité** : sur ~3 % de positifs, la ROC flatte — seule l'average precision rend l'arbitrage visible |
 | [2.13-Analyse-Erreurs](02-ML-Cours/2.13-Analyse-Erreurs.ipynb) | le geste du praticien : diagnostiquer un modèle entraîné (tranches, worst-k) | la poche invisible : 67.6% d'erreur sous un score global correct |
 
 Documentation complète : [02-ML-Cours/README.md](02-ML-Cours/README.md)
@@ -150,8 +170,16 @@ Le prolongement direct du socle : là où [2.2](02-ML-Cours/2.2-Descente-de-grad
 
 | Notebook | Sujet | Concept-phare |
 |----------|-------|---------------|
+| [3.0-Theorie-Information](03-DeepLearning/3.0-Theorie-Information.ipynb) | Entropie, cross-entropy et KL from scratch sur texte français, MSE vs CE sur classifieur, température softmax, pont DPO/GRPO | **La loss qui fait apprendre** : pourquoi la CE et pas la MSE ; KL comme mesure de décalage entre distributions |
 | [3.1-Retropropagation](03-DeepLearning/3.1-Retropropagation.ipynb) | Le MLP et la rétropropagation à la main (NumPy pur, sans autograd) | **Le gradient vérifié** (différence finie 1,3e-11 ; parité exacte avec PyTorch ; init nulle = gradient nul) |
 | [3.2-Optimisateurs](03-DeepLearning/3.2-Optimisateurs.ipynb) | Momentum, Adagrad, RMSProp, Adam et schedules, écrits puis validés pas à pas contre `torch.optim` | **La parité exacte** (5 mises à jour identiques à ≤2,2e-16 ; Beale 5 trajectoires ; MLP 3 graines ; schedules : coût en déterministe, gain en bruité) |
+| [3.3-Regularisation](03-DeepLearning/3.3-Regularisation.ipynb) | Dropout, weight decay et early stopping écrits à la main sur un MLP construit pour surapprendre (17 000 paramètres, 100 points, 12 étiquettes fausses) | **Corriger la variance sans changer le modèle** : trois remèdes appliqués au même surapprentissage fabriqué |
+| [3.4-Attention-Transformer-From-Scratch](03-DeepLearning/3.4-Attention-Transformer-From-Scratch.ipynb) | De l'attention mono-tête lisible sur l'inversion de séquence au mini-GPT de 1,25 M entraîné dans le notebook | **L'attention jusqu'au bout, sur CPU** : attention + masque causal + multi-têtes + bloc pré-norme, mini-GPT char-level (117 s, *Le Horla*) |
+| [3.5-Phenomenes-de-Generalisation](03-DeepLearning/3.5-Phenomenes-de-Generalisation.ipynb) | Grokking et double descente reproduits en NumPy pur (MLP à embeddings + Adam à la main), confrontés à la borne PAC du 2.8 | **Le phénomène sans la boîte noire** : mémorisation → transition abrupte, et le W de la double descente (pic au seuil M ≈ n, 20 graines) |
+| [3.6-Modeles-Generatifs](03-DeepLearning/3.6-Modeles-Generatifs.ipynb) | VAE, GAN et diffusion (DDPM) écrits en NumPy pur, même cible (huit modes sur un cercle), même budget, face à une baseline GMM | **Trois objectifs, trois échecs** : VAE couvre mais moyenne, GAN s'effondre, diffusion raffine au prix de 100 passes |
+| [3.6b-Modeles-Generatifs-PyTorch](03-DeepLearning/3.6b-Modeles-Generatifs-PyTorch.ipynb) | *Versant framework* du 3.6 : VAE, GAN et DDPM entraînés sur cible 2D à 4 modes (PyTorch CPU) | **Le compromis qualité/diversité** : 4 mécanismes sur mêmes métriques, verdict nuancé, pas de « gagnant » unique |
+| [3.7-Distillation-Maitre-Eleve](03-DeepLearning/3.7-Distillation-Maitre-Eleve.ipynb) | Distillation teacher/student : maître entraîné distille son savoir vers un élève ~9× plus petit | **Le facteur T² vérifié** : la KL brute chute en ~1/T², la KL scalée reste constante ; verdict INCONCLUSIVE au seuil strict |
+| [3.8-Representations-Contrastives](03-DeepLearning/3.8-Representations-Contrastives.ipynb) | Pré-entraînement contrastif moderne : vues continues, encodeur MLP et loss InfoNCE from scratch, pont vers skip-gram | **Apprendre des représentations sans étiquettes** : deux vues attirent leurs embeddings, les autres repoussent |
 
 Documentation complète : [03-DeepLearning/README.md](03-DeepLearning/README.md)
 


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2023:CoursIA-2 — prev: MED/guard c.876

# fix(readme,#13780): DataScienceWithAgents arbre + tables alignés sur disque (33 → 50 notebooks)

## Symptôme

Le README racine [`MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md`](../../MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md) dérivait du disque sur **17 notebooks** non documentés : il annonçait **33 notebooks** (12 fondations ML + 2 deep learning) là où le disque en porte **50** (21 + 10). Quatre surfaces affectées :

| Surface | Avant (drift) | Après (aligné) |
|---|---|---|
| Stats l.27 | `33 (7 + 10 + 2 + 12 + 2)` | `50 (7 + 10 + 2 + 21 + 10)` |
| Arbre structurel l.83-101 | 15 lignes 02-ML-Cours + 2 lignes 03-DeepLearning | 21 lignes 02 + 10 lignes 03 |
| Prose l.139 | « Douze notebooks (...) » | « Vingt-et-un notebooks (...) » |
| Table Fondations ML (l.141-163) | 14 entrées (manquent 2.3b, 2.3c, 2.3d, 2.5c, 2.8d, 2.12) | **21** entrées (les 14 + 6 ajoutées) |
| Table Deep Learning (l.169-172) | 2 entrées (3.1, 3.2) | **10** entrées (les 2 + 3.0, 3.3, 3.4, 3.5, 3.6, 3.6b, 3.7, 3.8) |

## Mesure firsthand disque vs README

```bash
$ find MyIA.AI.Notebooks/ML/DataScienceWithAgents -name "*.ipynb" -not -name "*_output*" | sort
# 50 notebooks au total, dont :
#   01-PythonForDataScience/ : 2
#   02-ML-Cours/             : 21 (manquent README : 2.3b, 2.3c, 2.3d, 2.5c, 2.8d, 2.12)
#   03-DeepLearning/         : 10 (manquent README : 3.0, 3.3, 3.4, 3.5, 3.6, 3.6b, 3.7, 3.8)
#   Track1-LangChain/        : 7
#   Track2-GoogleADK/        : 10
```

Les contenus des nouvelles entrées sont pris **mot pour mot** des READMEs source canoniques :
- `02-ML-Cours/README.md` (175 lignes) → table « Vue d'ensemble » l.17-38 — fournit les 6 entrées 02 ajoutées.
- `03-DeepLearning/README.md` (66 lignes) → table « Vue d'ensemble » l.25-36 — fournit les 8 entrées 03 ajoutées.

Tell NEW c.11900 ★★★ : vérification firsthand disque vs body PR.

## Cause-racine

Le README racine a été écrit à la création de la série (avant l'enrichissement progressif par PRs des notebooks 2.3b–2.13 et 3.0–3.8) et **jamais resynchronisé** depuis. La règle catalog-pr-hygiene **HARD 1** (« catalogue byte-identique à main ») couvre le `COURSE_CATALOG.generated.json`, pas les READMEs manuels ; aucun organe CI ne rescanne les READMs racines de série. Issue **#13780** (ouverte par audit antérieur) avait signalé le drift sans correction manuelle.

## Anti-régression (futur)

Hors scope de cette PR, mais à noter pour suivi :
- Aucun mécanisme n'empêche la re-dérive d'un README racine après enrichissement de notebooks. Le candidat serait un guard `readme-notebooks-drift-guard.yml` qui parse l'arbre structurel + tables d'un README racine, énumère les `.ipynb` disque via `find`, et échoue en advisory si écart (label `readme-drift`). **PR séparée** si user le souhaite.
- 01-PythonForDataScience (2 notebooks) aligné ✅ ; Track1-LangChain (7) aligné ✅ ; Track2-GoogleADK (10) aligné ✅ ; seules les deux sous-séries ML canoniques (02, 03) avaient dérivé.

## Validation

- `git diff --stat` : **+33 / −5** sur 1 fichier (atomique, 1 sujet, règle H.3 pre-commit OK).
- `grep -nE "(12 notebooks|2 notebooks|33 \(|Douze notebooks)"` README → **0 hit** (drift résiduel nul).
- Comptage table Fondations ML : 21 entrées (lignes 143-162) — vs disque 21 ✅.
- Comptage table Deep Learning : 10 entrées (lignes 173-182) — vs disque 10 ✅.
- Aucun code source touché (README seul) — pas de cellule, pas de notebook, pas de sortie à re-exécuter (règle C.2 + H.1).
- Aucun secret, aucune clé API (règle 2 secrets-hygiene OK).

## Tells invoquées

- Tell c.11900 ★★★ : vérification firsthand disque vs body — `find` + tables READMEs sources lus en direct.
- Tell c.478-L1 ★★★ : `Grain: MED/readme` L1 body PR ✅.
- Tell c.518-L1 ★★ strict : aucun WIP d'autre lane touché (README seul).
- Tell c.589-L1 ★★★ strict : 0 merge worker — geste livré via PR, coordinateur merge.
- Tell c.666 : amend HORS worktree (body PR généré en scratchpad).
- Tell c.745-L2 ★★★ strict : 0 retouche WIP — diff minimal, tables complétées sans reformulation.
- Tell c.795-2 ★ ★★ strict : `--body-file` strict (ce PR body via `gh pr create --body-file`).
- Tell c.836-L1 ★★ : voie 3 B.0 — non applicable ici (pas de conflit gate).
- Tell c.589-L1 ★★★ strict sustained 0 merge worker.

## Action attendue coordinateur

1. **Merge** Tell c.589-L1 ★★★ strict — drift aligné, aucun blocage gate.
2. **EPIC catalogage READMEs racine** — si user souhaite un guard anti-régression, PR séparée sur le sujet (cf §Anti-régression).
3. **PRs cross-lane orphelines sustained** Tell NEW c.871-L1 ★★★★ — toujours en attente tag `Grain:` (#14003, #14008, #14005, etc.).

— myia-po-2023:CoursIA-2 (c.877)
