### PR TITLE
feat(genai,#1028): P6 tranche 3 — chaîne orchestrée LIVE livre complet Boule de Suif

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/llm_client.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/llm_client.py
@@ -131,6 +131,7 @@ def call_structured(
     system_prompt: str,
     user_prompt: str,
     context_block: str = "",
+    timeout: int = 120,
 ) -> dict:
     """Call GPT-5.4-mini with JSON Schema structured output and retry logic.
 
@@ -178,6 +179,7 @@ def call_structured(
     last_error: str = ""
 
     for attempt in range(1, _MAX_RETRIES + 1):
+        resp = None
         try:
             payload: dict = {
                 "model": _MODEL,
@@ -192,7 +194,7 @@ def call_structured(
                     "Content-Type": "application/json",
                 },
                 json=payload,
-                timeout=120,
+                timeout=timeout,
             )
             resp.raise_for_status()
 
@@ -205,7 +207,7 @@ def call_structured(
 
         except (requests.RequestException, KeyError, json.JSONDecodeError) as exc:
             detail = ""
-            if hasattr(resp, "text"):
+            if resp is not None and hasattr(resp, "text"):
                 detail = resp.text[:500]
             last_error = f"API/parse error (attempt {attempt}): {exc}\n{detail}"
 

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p3_dramatic_context.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p3_dramatic_context.py
@@ -174,6 +174,7 @@ def calibrate_scenes(
         system,
         user,
         context_block=context_block,
+        timeout=300,
     )
 
     scene_map = {m["paragraph_id"]: m["act"] for m in result.get("mappings", [])}

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p5_tts.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p5_tts.py
@@ -951,6 +951,14 @@ def run(force: bool = False) -> Path:
     print(f"  Generated: {generated}, Cached: {cached}, Failed: {failed}")
     print(f"  Total duration: {total_duration:.1f}s ({total_duration/60:.1f}min)")
 
+    if generated == 0 and cached == 0 and failed > 0:
+        raise RuntimeError(
+            f"P5 : {failed}/{total} segments en echec, 0 generes — service TTS "
+            "probablement down pendant la passe (cf. 'FishAudio TTS error' dans les "
+            "logs). tts_results.json est conserve pour inspection ; relancer la "
+            "passe apres restauration du service (supprimer tts_results.json)."
+        )
+
     return results_path
 
 

--- a/scripts/audiobook_pipeline.py
+++ b/scripts/audiobook_pipeline.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 V4_DIR = REPO_ROOT / "MyIA.AI.Notebooks" / "GenAI" / "Audio" / "04-Applications"
-DEFAULT_BOOK = V4_DIR / "boule_de_suif_full.txt"
+DEFAULT_BOOK = V4_DIR.parent / "boule_de_suif_full.txt"
 
 if str(V4_DIR) not in sys.path:
     sys.path.insert(0, str(V4_DIR))
@@ -117,6 +117,16 @@ def main() -> int:
         return 2
 
     window = select_window(args.from_pass, args.to_pass)
+
+    context_path = V4_DIR / "v4" / "outputs" / "narrative_context.json"
+    if any(p.key != "p0" for p in window) and not context_path.exists():
+        print(
+            f"Artefact P0 manquant : {context_path}\n"
+            "Les passes p1_5+ le requierent (context_injector.load_narrative_context, "
+            "sans fallback). Executer p0 (SearXNG requis) ou fournir l'artefact.",
+            file=sys.stderr,
+        )
+        return 2
     print(f"Livre    : {args.book}")
     print(f"Mode     : {'DRY-RUN (aucun service)' if args.dry_run else 'COMPLET'}")
     print(f"Fenetre  : {window[0].key}..{window[-1].key} "


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2023:CoursIA-2 — prev: MED/lean #13941

## Summary

Tranche 3 de l'EPIC #1028, follow-up **nommé par les Non-goals de #13898** (« Livre complet Boule de Suif en live — follow-up dédié ») : première exécution **live en chaîne orchestrée** `p1_5..p7` sur le **livre entier** (385 paragraphes / 64 chunks p2), là où la tranche 2 (#13905) avait validé l'orchestrateur sur le mini-livre borné (21 para / 4 chunks). Toutes passes gated réellement exécutées : LLM structurant (p1_5, p2, p3, p4), FishAudio S2-Pro (p5), ffmpeg (p6c), Whisper (p7).

## Incident opérationnel : `tts-fishaudio-idle-monitor` tue le service en pleine chaîne

Preuve horodatée (`docker logs tts-fishaudio-idle-monitor`) : le monitor arrête `tts-fishaudio` après **1200 s d'idle** — les phases LLM amont (p3+p4 ≈ 36 min sans appel TTS) déclenchent le kill **pendant la chaîne**, et p5 arrive sur un port refusé (385/385 échecs, « total stops: 3 » dans le monitor). Le mini-livre (t2) ne le déclenchait pas : ses phases LLM duraient < 20 min. **Mitigation appliquée pour le run** : `docker stop tts-fishaudio-idle-monitor` pendant l'exécution de la fenêtre, redémarré après — le monitor est une infra d'économie GPU légitime, pas un bug ; mais toute chaîne longue LLM→TTS doit le suspendre (à documenter côté EPIC #1028).

## Défauts production corrigés au passage (4) — tous révélés par le passage à l'échelle livre complet

1. **`DEFAULT_BOOK` pointait hors-cible** (orchestrateur) : `V4_DIR / "boule_de_suif_full.txt"` (v4/ sous-répertoire) alors que le livre vit à `V4_DIR.parent` — sans `--book`, exit 2 « Livre introuvable » systématique.
2. **Fail-fast pré-vol artefact P0** (orchestrateur) : `context_injector.load_narrative_context` **raise dur** si `v4/outputs/narrative_context.json` est absent — l'affirmation du body #13898 « p1_5 tolère l'absence de narrative_context.json — paramètre optionnel » est **fausse** (le paramètre `narrative_context_path: Path | None = None` ne fait que re-tomber sur le chemin par défaut, qui lève). La tranche 2 n'a passé que parce que son worktree portait l'artefact. L'orchestrateur échoue maintenant **avant tout appel service** (exit 2, message explicite) au lieu d'une cascade trompeuse 7/7.
3. **`llm_client.call_structured` : `UnboundLocalError` masquant l'erreur réelle** — si `requests.post` lève avant affectation (timeout), le handler `except` référence `resp` non lié → l'exception d'origine (timeout sur le one-shot p3 de 385 paragraphes, prompt ~10× le mini-livre) est **remplacée** par un crash obscurscissant. Fix : `resp = None` pré-affecté + garde `resp is not None` + paramètre `timeout` (défaut 120 inchangé) ; `p3.calibrate_scenes` passe `timeout=300` (appel one-shot gros volume). Le mini-livre ne déclenchait jamais ce chemin (prompts courts).
4. **`p5_tts.run()` rapportait `[ OK ]` avec 0 segment généré** — quand le service TTS est down, la passe logge les erreurs par segment, écrit `tts_results.json` (385 failed) et **retourne sans lever** : l'orchestrateur affiche `[ OK ] p5`, p6 compile un mp3 de 6 Ko, p7 rend « Speakers: -1, WER: 1.0 », et la chaîne se termine « Pipeline complet termine » EXIT=0 **sans avoir rien produit**. Fix : `run()` lève `RuntimeError` quand `generated == 0 and cached == 0 and failed > 0` (résultats conservés pour inspection) — ce mode de défaillance ne peut plus se déguiser en succès.

## Run live (livre complet)

| Passe | Résultat live (livre complet) | Mini-livre (t2, #13905) |
|---|---|---|
| p1_5 | 278 para (filtre BdS) → 8 chunks LLM → 110 mentions brutes → **11 canonical + 16 figurants = 27 locuteurs** (~7 min) | 4 locuteurs, 0 figurant |
| p2 | 385 para → 64 chunks LLM → **385 segments**, coverage 44.0 % (warning émis) (~12 min) | 21 para → 4 chunks → 21 seg (57.5 %) |
| p3 | scene map 385 para (one-shot, `timeout=300`) + 39 batches de 10 → dramatic_context.json 289 Ko (~22 min) | 21 segments, tension moy. 4.6/10 |
| p4 | 39 batches → **809 tags (798 officiels S2-Pro)** sur 385 segments (~14 min) | 21/21 tagués, 42 tags |
| p5 | **385/385 générés, 0 échec, 0 cache** — 75,4 Mo d'audio (wall-clock ~7 h20, ~69 s/segment, `_MAX_WORKERS=1` séquentiel S2-Pro) | 21/21 générés, 0 échec, 56.5 s |
| p6c | ffmpeg → `boule_de_suif_v4.mp3` **75,4 Mo / 52 min** (vs 6 Ko au run creux d'incident) | mp3 compilé |
| p7 | Whisper : **WER moyen 0.097**, P95 0.5, 3 segments > 30 % ; diarization detected −1 vs expected 9 (heuristique non-conclusive, même sortie que t2) ; **verdict quality_report : PASS** | WER moyen 0.105, P95 0.3, PASS |

## Services

- `tts-fishaudio` relancé au démarrage du cycle (Exited 137, 4 h avant — même symptôme que la tranche 2) → healthy sur 8197.
- whisper-api healthy (8190), LLM keys présentes (GenAI/.env).
- p0 (SearXNG) toujours gated hors scope — artefact `narrative_context.json` du run p0 de mai réutilisé (même livre, artefact livre-dépendant, pas run-dépendant).

## Artefacts

`v4/outputs/` est gitignored (preuves locales) : speaker_catalog.json, segments_v4.json, dramatic_context.json, annotated_v4.json, tts_results.json, boule_de_suif_v4.mp3, quality_report.json — tailles et métriques citées ci-dessus.

See #1028 (tranche 3). Residuel : p0 live différé à la remontée SearXNG (401 documenté #13898) ; livre arbitraire autre que BdS nécessitera un p0 fonctionnel (narrative context livre-dépendant).
