### PR TITLE
feat(search,#13772): Search-02c Bellman-Ford reel — poids negatifs + detection de cycle

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "443fe805",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00923,
+     "end_time": "2026-09-01T13:32:51.682395+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:51.673165+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Search-02c-QuikGraph : bibliotheque de graphes pour .NET\n",
     "\n",
@@ -67,7 +76,16 @@
   {
    "cell_type": "markdown",
    "id": "27a1da1e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007148,
+     "end_time": "2026-09-01T13:32:51.697212+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:51.690064+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. La bibliotheque QuikGraph\n",
     "\n",
@@ -108,31 +126,142 @@
    "id": "1e00ea37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:53.936171Z",
-     "iopub.status.busy": "2026-07-03T02:46:53.929782Z",
-     "iopub.status.idle": "2026-07-03T02:46:54.964696Z",
-     "shell.execute_reply": "2026-07-03T02:46:54.961285Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:51.731660Z",
+     "iopub.status.busy": "2026-09-01T13:32:51.719440Z",
+     "iopub.status.idle": "2026-09-01T13:32:55.044318Z",
+     "shell.execute_reply": "2026-09-01T13:32:55.025888Z"
+    },
+    "papermill": {
+     "duration": 3.340183,
+     "end_time": "2026-09-01T13:32:55.045262+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:51.705079+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": ""
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '23244.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>QuikGraph</span></li></ul></div><div></div></div>"
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>QuikGraph, 2.5.0</span></li></ul></div></div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "QuikGraph 2.5.0 charge depuis NuGet.\r\n"
+     "output_type": "stream",
+     "text": [
+      "QuikGraph 2.5.0 charge depuis NuGet.\r\n"
+     ]
     }
    ],
    "source": [
@@ -151,42 +280,62 @@
    "id": "fd95f8f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:54.966446Z",
-     "iopub.status.busy": "2026-07-03T02:46:54.966171Z",
-     "iopub.status.idle": "2026-07-03T02:46:55.497506Z",
-     "shell.execute_reply": "2026-07-03T02:46:55.497304Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:55.059695Z",
+     "iopub.status.busy": "2026-09-01T13:32:55.059285Z",
+     "iopub.status.idle": "2026-09-01T13:32:55.155899Z",
+     "shell.execute_reply": "2026-09-01T13:32:55.155635Z"
+    },
+    "papermill": {
+     "duration": 0.106748,
+     "end_time": "2026-09-01T13:32:55.156018+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:55.049270+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Espaces de noms QuikGraph imports :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Espaces de noms QuikGraph imports :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - QuikGraph : types de graphes (AdjacencyGraph, BidirectionalGraph, UndirectedGraph, Edge, SEdge)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - QuikGraph : types de graphes (AdjacencyGraph, BidirectionalGraph, UndirectedGraph, Edge, SEdge)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - QuikGraph.Algorithms : base commune (Algorithm, IAlgorithm, etc.)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - QuikGraph.Algorithms : base commune (Algorithm, IAlgorithm, etc.)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - QuikGraph.Algorithms.Search : DepthFirstSearch, BreadthFirstSearch, WeaklyConnectedComponents\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - QuikGraph.Algorithms.Search : DepthFirstSearch, BreadthFirstSearch, WeaklyConnectedComponents\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - QuikGraph.Algorithms.ShortestPath : Dijkstra, BellmanFord, AStar, Kruskal\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - QuikGraph.Algorithms.ShortestPath : Dijkstra, BellmanFord, AStar, Kruskal\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - QuikGraph.Algorithms.MaximumFlow : MaximumFlowAlgorithm (Edmonds-Karp, Push-Relabel)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - QuikGraph.Algorithms.MaximumFlow : MaximumFlowAlgorithm (Edmonds-Karp, Push-Relabel)\r\n"
+     ]
     }
    ],
    "source": [
@@ -219,7 +368,16 @@
   {
    "cell_type": "markdown",
    "id": "b95ad098",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00469,
+     "end_time": "2026-09-01T13:32:55.165796+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:55.161106+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Types de graphes et construction\n",
     "\n",
@@ -254,37 +412,55 @@
    "id": "ab88336c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:55.498895Z",
-     "iopub.status.busy": "2026-07-03T02:46:55.498661Z",
-     "iopub.status.idle": "2026-07-03T02:46:55.773317Z",
-     "shell.execute_reply": "2026-07-03T02:46:55.772950Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:55.184775Z",
+     "iopub.status.busy": "2026-09-01T13:32:55.184464Z",
+     "iopub.status.idle": "2026-09-01T13:32:56.388652Z",
+     "shell.execute_reply": "2026-09-01T13:32:56.388404Z"
+    },
+    "papermill": {
+     "duration": 1.211053,
+     "end_time": "2026-09-01T13:32:56.388763+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:55.177710+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Graphe de Petersen : 10 sommets, 15 aretes.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Graphe de Petersen : 10 sommets, 15 aretes.\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Voisins du sommet 0 : [1, 4, 5]\r\n"
+     "output_type": "stream",
+     "text": [
+      "Voisins du sommet 0 : [1, 4, 5]\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Degre du sommet 0 : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "Degre du sommet 0 : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Degre du sommet 5 : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "Degre du sommet 5 : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Somme des degres = 30 (attendu : 2 * E = 30)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Somme des degres = 30 (attendu : 2 * E = 30)\r\n"
+     ]
     }
    ],
    "source": [
@@ -341,22 +517,34 @@
    "id": "ebd168b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:55.774820Z",
-     "iopub.status.busy": "2026-07-03T02:46:55.774613Z",
-     "iopub.status.idle": "2026-07-03T02:46:55.944686Z",
-     "shell.execute_reply": "2026-07-03T02:46:55.944496Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:56.401140Z",
+     "iopub.status.busy": "2026-09-01T13:32:56.400764Z",
+     "iopub.status.idle": "2026-09-01T13:32:57.029890Z",
+     "shell.execute_reply": "2026-09-01T13:32:57.029687Z"
+    },
+    "papermill": {
+     "duration": 0.635917,
+     "end_time": "2026-09-01T13:32:57.029993+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:56.394076+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Reseau routier : 6 carrefours, 16 segments (aller-retour).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Reseau routier : 6 carrefours, 16 segments (aller-retour).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Aretes sortantes de A : 2 (vers B, C)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Aretes sortantes de A : 2 (vers B, C)\r\n"
+     ]
     }
    ],
    "source": [
@@ -422,7 +610,16 @@
   {
    "cell_type": "markdown",
    "id": "03cae750",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005162,
+     "end_time": "2026-09-01T13:32:57.040520+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.035358+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Parcours : DFS et BFS\n",
     "\n",
@@ -445,22 +642,34 @@
    "id": "fa08c327",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:55.946229Z",
-     "iopub.status.busy": "2026-07-03T02:46:55.945902Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.020212Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.020005Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:57.058222Z",
+     "iopub.status.busy": "2026-09-01T13:32:57.057540Z",
+     "iopub.status.idle": "2026-09-01T13:32:57.363863Z",
+     "shell.execute_reply": "2026-09-01T13:32:57.363419Z"
+    },
+    "papermill": {
+     "duration": 0.318586,
+     "end_time": "2026-09-01T13:32:57.364064+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.045478+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Parcours DFS depuis 0 (ordre de decouverte) : [0 -> 1 -> 2 -> 3 -> 4 -> 9 -> 5 -> 6 -> 7 -> 8]\r\n"
+     "output_type": "stream",
+     "text": [
+      "Parcours DFS depuis 0 (ordre de decouverte) : [0 -> 1 -> 2 -> 3 -> 4 -> 9 -> 5 -> 6 -> 7 -> 8]\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Nombre de sommets visites : 10 / 10\r\n"
+     "output_type": "stream",
+     "text": [
+      "Nombre de sommets visites : 10 / 10\r\n"
+     ]
     }
    ],
    "source": [
@@ -500,22 +709,34 @@
    "id": "97c643fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.021568Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.021327Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.079082Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.078779Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:57.381629Z",
+     "iopub.status.busy": "2026-09-01T13:32:57.381291Z",
+     "iopub.status.idle": "2026-09-01T13:32:57.612786Z",
+     "shell.execute_reply": "2026-09-01T13:32:57.612585Z"
+    },
+    "papermill": {
+     "duration": 0.240172,
+     "end_time": "2026-09-01T13:32:57.612884+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.372712+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "BFS depuis 0 : [0 -> 1 -> 4 -> 5 -> 2 -> 6 -> 3 -> 9 -> 7 -> 8]\r\n"
+     "output_type": "stream",
+     "text": [
+      "BFS depuis 0 : [0 -> 1 -> 4 -> 5 -> 2 -> 6 -> 3 -> 9 -> 7 -> 8]\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Distances en sauts : 0:0, 1:1, 2:2, 3:2, 4:1, 5:1, 6:2, 7:3, 8:3, 9:2\r\n"
+     "output_type": "stream",
+     "text": [
+      "Distances en sauts : 0:0, 1:1, 2:2, 3:2, 4:1, 5:1, 6:2, 7:3, 8:3, 9:2\r\n"
+     ]
     }
    ],
    "source": [
@@ -565,7 +786,16 @@
   {
    "cell_type": "markdown",
    "id": "0fda2fd0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004777,
+     "end_time": "2026-09-01T13:32:57.624095+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.619318+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Plus courts chemins ponderes : Dijkstra et Bellman-Ford\n",
     "\n",
@@ -584,47 +814,69 @@
    "id": "e6aa4b02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.080195Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.080017Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.178965Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.178716Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:57.652521Z",
+     "iopub.status.busy": "2026-09-01T13:32:57.652163Z",
+     "iopub.status.idle": "2026-09-01T13:32:57.928641Z",
+     "shell.execute_reply": "2026-09-01T13:32:57.928334Z"
+    },
+    "papermill": {
+     "duration": 0.296306,
+     "end_time": "2026-09-01T13:32:57.928753+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.632447+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Dijkstra depuis A (distances en km) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Dijkstra depuis A (distances en km) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  A : 0,00 km  (A)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  A : 0,00 km  (A)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  B : 2,00 km  (A -> B)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  B : 2,00 km  (A -> B)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  C : 3,50 km  (B -> C)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  C : 3,50 km  (B -> C)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  D : 6,00 km  (B -> D)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  D : 6,00 km  (B -> D)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  E : 6,50 km  (C -> E)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  E : 6,50 km  (C -> E)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  F : 9,00 km  (E -> F)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  F : 9,00 km  (E -> F)\r\n"
+     ]
     }
    ],
    "source": [
@@ -670,8 +922,175 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bellmanford-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004211,
+     "end_time": "2026-09-01T13:32:57.948460+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.944249+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Bellman-Ford : quand les couts deviennent negatifs\n",
+    "\n",
+    "Dijkstra finalise chaque sommet une fois pour toutes, dans l'ordre croissant des distances — une garantie qui n'est valide que si **tous les poids sont positifs ou nuls** : si une arete peut faire baisser un cout deja valide, l'ordre se brise. QuikGraph fait respecter cette precondition : sur un poids negatif, son Dijkstra leve `NegativeWeightException` plutot que de retourner une distance fausse.\n",
+    "\n",
+    "C'est la que **Bellman-Ford** prend le relais : il relaxe chaque arete |V|−1 fois, ce qui supporte les poids negatifs et detecte au passage les **cycles negatifs** — un circuit dont le cout total est negatif : le « plus court chemin » n'existe plus, chaque tour ameliore le cout indefiniment. Deux experiences : un trajet avec un segment **subventionne** (−3 EUR), puis un cycle remunerateur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bellmanford-couts-negatifs",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T13:32:57.959381Z",
+     "iopub.status.busy": "2026-09-01T13:32:57.958978Z",
+     "iopub.status.idle": "2026-09-01T13:32:58.510940Z",
+     "shell.execute_reply": "2026-09-01T13:32:58.510605Z"
+    },
+    "papermill": {
+     "duration": 0.557912,
+     "end_time": "2026-09-01T13:32:58.511118+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:57.953206+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Dijkstra]    REFUS : NegativeWeightException — The graph contains at least one negative weight.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[BellmanFord] cycle negatif present = False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[BellmanFord] cout S->A = 2,00 EUR, S->T = -1,00 EUR (detour 2 EUR puis subvention -3 EUR)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[B] cycle A->B->A = -1 EUR par tour : cycle negatif detecte = True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[B] distances non interrogees : chaque tour du cycle ameliore le cout, le plus court chemin n'existe pas.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Cas A : reseau de couts avec un segment subventionne (-3 EUR). L'optimum reel S->A->T = -1 EUR.\n",
+    "// Dijkstra refuse (sa precondition est poids >= 0) ; Bellman-Ford le calcule.\n",
+    "var prixA = new AdjacencyGraph<string, STaggedEdge<string, double>>();\n",
+    "prixA.AddVertexRange(new[] { \"S\", \"A\", \"T\" });\n",
+    "prixA.AddEdgeRange(new[]\n",
+    "{\n",
+    "    new STaggedEdge<string, double>(\"S\", \"T\", 1.0),    // trajet direct : 1 EUR\n",
+    "    new STaggedEdge<string, double>(\"S\", \"A\", 2.0),    // detour par A : 2 EUR\n",
+    "    new STaggedEdge<string, double>(\"A\", \"T\", -3.0),   // segment subventionne : on est paye 3 EUR\n",
+    "});\n",
+    "\n",
+    "try\n",
+    "{\n",
+    "    var dijA = new DijkstraShortestPathAlgorithm<string, STaggedEdge<string, double>>(prixA, e => e.Tag);\n",
+    "    dijA.Compute(\"S\");\n",
+    "    Console.WriteLine($\"[Dijkstra]    cout S->T = {dijA.GetDistance(\"T\"):F2} EUR\");\n",
+    "}\n",
+    "catch (NegativeWeightException ex)\n",
+    "{\n",
+    "    Console.WriteLine($\"[Dijkstra]    REFUS : {ex.GetType().Name} — {ex.Message}\");\n",
+    "}\n",
+    "\n",
+    "var bfA = new BellmanFordShortestPathAlgorithm<string, STaggedEdge<string, double>>(prixA, e => e.Tag);\n",
+    "bfA.Compute(\"S\");\n",
+    "Console.WriteLine($\"[BellmanFord] cycle negatif present = {bfA.FoundNegativeCycle}\");\n",
+    "Console.WriteLine($\"[BellmanFord] cout S->A = {bfA.GetDistance(\"A\"):F2} EUR, S->T = {bfA.GetDistance(\"T\"):F2} EUR (detour 2 EUR puis subvention -3 EUR)\");\n",
+    "\n",
+    "// Cas B : un cycle A -> B -> A de cout total -1 EUR par tour, atteignable depuis S.\n",
+    "// Garde avant usage : si un cycle negatif est detecte, les predecesseurs sont corrompus\n",
+    "// et les distances n'ont plus de sens — on ne les interroge pas.\n",
+    "var prixB = new AdjacencyGraph<string, STaggedEdge<string, double>>();\n",
+    "prixB.AddVertexRange(new[] { \"S\", \"A\", \"B\", \"T\" });\n",
+    "prixB.AddEdgeRange(new[]\n",
+    "{\n",
+    "    new STaggedEdge<string, double>(\"S\", \"A\", 1.0),\n",
+    "    new STaggedEdge<string, double>(\"A\", \"B\", -2.0),\n",
+    "    new STaggedEdge<string, double>(\"B\", \"A\", 1.0),    // cycle A->B->A : -2 + 1 = -1 EUR par tour\n",
+    "    new STaggedEdge<string, double>(\"B\", \"T\", 1.0),\n",
+    "});\n",
+    "\n",
+    "var bfB = new BellmanFordShortestPathAlgorithm<string, STaggedEdge<string, double>>(prixB, e => e.Tag);\n",
+    "bfB.Compute(\"S\");\n",
+    "Console.WriteLine($\"\\n[B] cycle A->B->A = -1 EUR par tour : cycle negatif detecte = {bfB.FoundNegativeCycle}\");\n",
+    "if (!bfB.FoundNegativeCycle)\n",
+    "{\n",
+    "    Console.WriteLine($\"[B] cout S->T = {bfB.GetDistance(\"T\"):F2} EUR\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    Console.WriteLine(\"[B] distances non interrogees : chaque tour du cycle ameliore le cout, le plus court chemin n'existe pas.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lecture-bellmanford",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008631,
+     "end_time": "2026-09-01T13:32:58.529906+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:58.521275+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat — pourquoi Bellman-Ford existe\n",
+    "\n",
+    "**Dijkstra a refuse** : `NegativeWeightException — The graph contains at least one negative weight.` La bibliotheque ne retourne pas une distance fausse en silence — elle fait respecter sa precondition. Un Dijkstra « qui repondrait quand meme » serait le pire des cas : une reponse fausse impossible a distinguer d'une juste.\n",
+    "\n",
+    "**Bellman-Ford a calcule** : cout S→T = **−1,00 EUR** (detour S→A a 2,00 EUR puis le segment subventionne a −3,00 EUR), cycle negatif = `False`. Le detour couteux a l'entree (2 EUR contre 1 EUR en direct) devient **gagnant apres la subvention** : aucun ordre de finalisation glouton ne peut garantir ca, seule la relaxation exhaustive |V|−1 fois le peut.\n",
+    "\n",
+    "**Cas B — le cycle remunerateur** : A→B→A rapporte 1 EUR par tour, indefiniment. Bellman-Ford le **detecte** (`FoundNegativeCycle = True`) et on garde la garde avant usage : apres un cycle negatif, les predecesseurs sont corrompus — interroger les distances n'a plus de sens. Le verdict « pas d'optimum » est une **reponse**, pas un echec : c'est la detection d'arbitrage impossible, exactement ce qu'un moteur de plus courts chemins doit savoir dire.\n",
+    "\n",
+    "En pratique : poids tous ≥ 0 → Dijkstra (plus rapide, O((V+A) log V)) ; un poids negatif → Bellman-Ford (O(V·A)) ; cycle negatif detecte → le probleme tel que pose n'a pas de solution.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ec1a8528",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011019,
+     "end_time": "2026-09-01T13:32:58.550307+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:58.539288+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Centralites (verdict honnete)\n",
     "\n",
@@ -698,76 +1117,108 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "f5fae748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.180533Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.180274Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.292528Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.292126Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:58.574993Z",
+     "iopub.status.busy": "2026-09-01T13:32:58.574297Z",
+     "iopub.status.idle": "2026-09-01T13:32:59.008081Z",
+     "shell.execute_reply": "2026-09-01T13:32:59.007302Z"
+    },
+    "papermill": {
+     "duration": 0.448339,
+     "end_time": "2026-09-01T13:32:59.008334+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:58.559995+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Centralite de degre normalisee (degree / (n-1)) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Centralite de degre normalisee (degree / (n-1)) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Alice    degre=3  centralite=0,429\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Alice    degre=3  centralite=0,429\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Bob      degre=2  centralite=0,286\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Bob      degre=2  centralite=0,286\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Carmen   degre=3  centralite=0,429\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Carmen   degre=3  centralite=0,429\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  David    degre=3  centralite=0,429\r\n"
+     "output_type": "stream",
+     "text": [
+      "  David    degre=3  centralite=0,429\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Eve      degre=3  centralite=0,429\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Eve      degre=3  centralite=0,429\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Frank    degre=2  centralite=0,286\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Frank    degre=2  centralite=0,286\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Greta    degre=3  centralite=0,429\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Greta    degre=3  centralite=0,429\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Hugo     degre=3  centralite=0,429\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Hugo     degre=3  centralite=0,429\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Nombre de composantes connexes : 1\r\n"
+     "output_type": "stream",
+     "text": [
+      "Nombre de composantes connexes : 1\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Composante 0 : [Alice, Bob, Carmen, David, Eve, Frank, Greta, Hugo]\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Composante 0 : [Alice, Bob, Carmen, David, Eve, Frank, Greta, Hugo]\r\n"
+     ]
     }
    ],
    "source": [
@@ -863,7 +1314,16 @@
   {
    "cell_type": "markdown",
    "id": "d8dbaf0a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.012398,
+     "end_time": "2026-09-01T13:32:59.028594+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:59.016196+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Flot maximum (Edmonds-Karp / Push-Relabel)\n",
     "\n",
@@ -878,51 +1338,73 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "43bbfd4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.293856Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.293636Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.383149Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.382754Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:59.049353Z",
+     "iopub.status.busy": "2026-09-01T13:32:59.049014Z",
+     "iopub.status.idle": "2026-09-01T13:32:59.340500Z",
+     "shell.execute_reply": "2026-09-01T13:32:59.340245Z"
+    },
+    "papermill": {
+     "duration": 0.301549,
+     "end_time": "2026-09-01T13:32:59.340624+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:59.039075+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Reseau de flot : S, A, B, T\r\n"
+     "output_type": "stream",
+     "text": [
+      "Reseau de flot : S, A, B, T\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Aretes : S->A:10, S->B:5, A->T:8, B->T:10, A->B:3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Aretes : S->A:10, S->B:5, A->T:8, B->T:10, A->B:3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Flot maximum S -> T : 15,00\r\n"
+     "output_type": "stream",
+     "text": [
+      "Flot maximum S -> T : 15,00\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (Verification min-cut : {S} | {A,B,T} = S->A(10) + S->B(5) = 15)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (Verification min-cut : {S} | {A,B,T} = S->A(10) + S->B(5) = 15)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Fin cellule flot max.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Fin cellule flot max.\r\n"
+     ]
     }
    ],
    "source": [
@@ -991,7 +1473,16 @@
   {
    "cell_type": "markdown",
    "id": "a53b7b57",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007805,
+     "end_time": "2026-09-01T13:32:59.356382+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:59.348577+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Problème non-trivial : réseau routier 5x5 avec terrain hétérogène\n",
     "\n",
@@ -1002,52 +1493,71 @@
     "Avec un terrain **uniforme à 1 km**, le plus court chemin en distance pondérée coïnciderait avec le plus court chemin en nombre de sauts : Dijkstra n'apporterait rien que BFS ne fournit déjà (cas dégénéré, équivalent au commit de référence `8905f8845` BFS-vs-A*). Avec un terrain **hétérogène**, minimiser la somme des coûts ≠ minimiser le nombre de sauts — le chemin optimal peut faire un détour par des arêtes bon marché pour éviter une arête chère. C'est la capacité distinctive de Dijkstra que la section met en évidence, en parité avec le notebook Python `Search-02b-NetworkX`.\n",
     "\n",
     "\n",
-    "Pour la **reproductibilité** entre runs, les deux graines sont fixes (`new Random(7)` pour le terrain, `new Random(42)` pour le bruit).\n",
-    ""
+    "Pour la **reproductibilité** entre runs, les deux graines sont fixes (`new Random(7)` pour le terrain, `new Random(42)` pour le bruit).\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "dcb052db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T03:52:07.970106Z",
-     "iopub.status.busy": "2026-07-21T03:52:07.969678Z",
-     "iopub.status.idle": "2026-07-21T03:52:08.135935Z",
-     "shell.execute_reply": "2026-07-21T03:52:08.135452Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:32:59.377472Z",
+     "iopub.status.busy": "2026-09-01T13:32:59.377106Z",
+     "iopub.status.idle": "2026-09-01T13:33:00.041232Z",
+     "shell.execute_reply": "2026-09-01T13:33:00.041010Z"
+    },
+    "papermill": {
+     "duration": 0.679913,
+     "end_time": "2026-09-01T13:33:00.041337+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:32:59.361424+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Debut cellule grille 5x5...\r\n"
+     "output_type": "stream",
+     "text": [
+      "Debut cellule grille 5x5...\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Reseau 5x5 : 25 sommets, 48/80 aretes (apres bruit 30 %).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Reseau 5x5 : 25 sommets, 48/80 aretes (apres bruit 30 %).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Dijkstra (0, 0) -> (4, 4) : distance ponderee = 17,11 km, chemin = 8 sauts (chemin direct coin-a-coin = 8 sauts).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Dijkstra (0, 0) -> (4, 4) : distance ponderee = 17,11 km, chemin = 8 sauts (chemin direct coin-a-coin = 8 sauts).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Cout moyen par arete du chemin optimal : 2,14 km (si le terrain etait uniforme a 1 km, la distance serait egale au nombre de sauts).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Cout moyen par arete du chemin optimal : 2,14 km (si le terrain etait uniforme a 1 km, la distance serait egale au nombre de sauts).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Le chemin optimal en distance ponderee ne coincide pas avec le chemin en nombre de sauts : Dijkstra pondere, BFS non.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Le chemin optimal en distance ponderee ne coincide pas avec le chemin en nombre de sauts : Dijkstra pondere, BFS non.\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Fin cellule grille 5x5.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Fin cellule grille 5x5.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1122,7 +1632,16 @@
   {
    "cell_type": "markdown",
    "id": "cff33a18",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004708,
+     "end_time": "2026-09-01T13:33:00.051327+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.046619+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Conclusion : table de parite Python NetworkX / .NET QuikGraph\n",
     "\n",
@@ -1174,14 +1693,22 @@
     "\n",
     "\n",
     "\n",
-    "**Resume** : QuikGraph est l'equivalent .NET de NetworkX pour les **chemins, flots et composantes**. Pour les **centralites** et **communautes**, il faut soit implementer a la main (degré, BFS a etages), soit brancher une autre bibliotheque (`FastGraph`, `Microsoft.Graph`, ou calculer la betweenness a partir de Floyd-Warshall).\n",
-    ""
+    "**Resume** : QuikGraph est l'equivalent .NET de NetworkX pour les **chemins, flots et composantes**. Pour les **centralites** et **communautes**, il faut soit implementer a la main (degré, BFS a etages), soit brancher une autre bibliotheque (`FastGraph`, `Microsoft.Graph`, ou calculer la betweenness a partir de Floyd-Warshall).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "069db712",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00486,
+     "end_time": "2026-09-01T13:33:00.061167+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.056307+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -1210,21 +1737,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "54c1c37d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.494491Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.494298Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.528154Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.527814Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:33:00.072690Z",
+     "iopub.status.busy": "2026-09-01T13:33:00.072413Z",
+     "iopub.status.idle": "2026-09-01T13:33:00.265620Z",
+     "shell.execute_reply": "2026-09-01T13:33:00.265426Z"
+    },
+    "papermill": {
+     "duration": 0.199787,
+     "end_time": "2026-09-01T13:33:00.265718+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.065931+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : mini-graphe {1, 2, 3}, aretes symmetriques 1-2:2.0, 2-3:1.0, 1-3:5.0, puis BFS et Dijkstra.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mini-graphe {1, 2, 3}, aretes symmetriques 1-2:2.0, 2-3:1.0, 1-3:5.0, puis BFS et Dijkstra.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1240,28 +1777,61 @@
   {
    "cell_type": "markdown",
    "id": "555705b6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006074,
+     "end_time": "2026-09-01T13:33:00.277033+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.270959+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Exercice 2 : Flot maximum sur un mini-reseau electrique\n\n**Ennonce** : Modelisez un reseau electrique simplifie du **CaseStudy SmartGrid CC3** (cf. `MyIA.AI.Notebooks/CaseStudies/`) avec 5 noeuds :\n\n- Producteur `P1` (centrale solaire)\n- Producteur `P2` (eolien)\n- Noeud intermediaire `J1` (jonction)\n- Noeud intermediaire `J2` (jonction)\n- Client `C1` (quartier residentiel)\n\nAretes (avec capacite en MW) : `P1 -> J1 : 10`, `P1 -> J2 : 5`, `P2 -> J1 : 8`, `P2 -> J2 : 5`, `J1 -> C1 : 12`, `J2 -> C1 : 7`.\n\nLancez `EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>` entre `P1+P2` (super source) et `C1`. **Indice** : QuikGraph ne supporte pas directement une super-source ; ajoutez un sommet `S` relie a `P1` et `P2` avec capacites infinies (ou très grandes), puis appelez `algo.Compute(\"S\", \"C1\")`.\n\n> **Attention API** : comme en section 6, `EdmondsKarpMaximumFlowAlgorithm` exige que le graphe soit augmente de ses aretes residuelles **avant** `Compute`. Instanciez un `ReversedEdgeAugmentorAlgorithm`, appelez `AddReversedEdges()`, puis `Compute` (cf. section 6 pour le patron complet)."
+    "### Exercice 2 : Flot maximum sur un mini-reseau electrique\n",
+    "\n",
+    "**Ennonce** : Modelisez un reseau electrique simplifie du **CaseStudy SmartGrid CC3** (cf. `MyIA.AI.Notebooks/CaseStudies/`) avec 5 noeuds :\n",
+    "\n",
+    "- Producteur `P1` (centrale solaire)\n",
+    "- Producteur `P2` (eolien)\n",
+    "- Noeud intermediaire `J1` (jonction)\n",
+    "- Noeud intermediaire `J2` (jonction)\n",
+    "- Client `C1` (quartier residentiel)\n",
+    "\n",
+    "Aretes (avec capacite en MW) : `P1 -> J1 : 10`, `P1 -> J2 : 5`, `P2 -> J1 : 8`, `P2 -> J2 : 5`, `J1 -> C1 : 12`, `J2 -> C1 : 7`.\n",
+    "\n",
+    "Lancez `EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>` entre `P1+P2` (super source) et `C1`. **Indice** : QuikGraph ne supporte pas directement une super-source ; ajoutez un sommet `S` relie a `P1` et `P2` avec capacites infinies (ou très grandes), puis appelez `algo.Compute(\"S\", \"C1\")`.\n",
+    "\n",
+    "> **Attention API** : comme en section 6, `EdmondsKarpMaximumFlowAlgorithm` exige que le graphe soit augmente de ses aretes residuelles **avant** `Compute`. Instanciez un `ReversedEdgeAugmentorAlgorithm`, appelez `AddReversedEdges()`, puis `Compute` (cf. section 6 pour le patron complet)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "50ac6f05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.529446Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.529260Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.557008Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.556657Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:33:00.288159Z",
+     "iopub.status.busy": "2026-09-01T13:33:00.287859Z",
+     "iopub.status.idle": "2026-09-01T13:33:00.341755Z",
+     "shell.execute_reply": "2026-09-01T13:33:00.341512Z"
+    },
+    "papermill": {
+     "duration": 0.059949,
+     "end_time": "2026-09-01T13:33:00.341873+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.281924+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : flot max SmartGrid via QuikGraph MaximumFlowAlgorithm.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : flot max SmartGrid via QuikGraph MaximumFlowAlgorithm.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1275,7 +1845,16 @@
   {
    "cell_type": "markdown",
    "id": "f3568a0c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009595,
+     "end_time": "2026-09-01T13:33:00.355767+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.346172+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Detection de communautes par composantes connexes\n",
     "\n",
@@ -1298,21 +1877,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "c73812fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T02:46:56.558476Z",
-     "iopub.status.busy": "2026-07-03T02:46:56.558280Z",
-     "iopub.status.idle": "2026-07-03T02:46:56.584190Z",
-     "shell.execute_reply": "2026-07-03T02:46:56.583981Z"
-    }
+     "iopub.execute_input": "2026-09-01T13:33:00.383768Z",
+     "iopub.status.busy": "2026-09-01T13:33:00.383266Z",
+     "iopub.status.idle": "2026-09-01T13:33:00.469830Z",
+     "shell.execute_reply": "2026-09-01T13:33:00.469509Z"
+    },
+    "papermill": {
+     "duration": 0.105263,
+     "end_time": "2026-09-01T13:33:00.469982+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T13:33:00.364719+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : graphe 30 noeuds, composantes connexes, top-3 de centralite de degre.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : graphe 30 noeuds, composantes connexes, top-3 de centralite de degre.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1335,7 +1924,19 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 12.096085,
+   "end_time": "2026-09-01T13:33:00.732762+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Search-02c-QuikGraph.ipynb",
+   "output_path": "search02c_bf_out2.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-01T13:32:48.636677+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/notebook-python #14048

## Sujet

`Search-02c-QuikGraph.ipynb` annonçait Bellman-Ford **trois fois** — le titre de sa section 4 (« Plus courts chemins ponderes : Dijkstra **et Bellman-Ford** »), le commentaire de sa cellule d'aretes typees (« Pour Dijkstra/Bellman-Ford/flot max »), et la prose de ses imports (« QuikGraph.Algorithms.ShortestPath : Dijkstra, BellmanFord, AStar, Kruskal ») — sans qu'aucune cellule code ne l'execute. Finding consigne par po-2024 dans le volet decision #13772 : « §4 titre "Bellman-Ford" mais aucune cellule code ne l'execute ».

Cette PR comble le gap avec le **vrai moteur QuikGraph 2.5.0** (aucune reimplementation) sur un probleme **discriminant** (sota-not-workaround Prong B) : les poids negatifs, precisement la ou Dijkstra ne peut pas repondre.

## Mesures firsthand (scratchpad, AVANT l'ecriture de la cellule)

API verifiee par sonde .NET locale (`dotnet run`, package NuGet QuikGraph 2.5.0) :

- `BellmanFordShortestPathAlgorithm` : ctor `(graph, e => e.Tag)`, `Compute(root)`, `GetDistance(v)`, `FoundNegativeCycle` — tous mesures.
- **Decouverte** : le Dijkstra de QuikGraph **leve `NegativeWeightException`** sur poids negatif (« The graph contains at least one negative weight. ») — il refuse plutot que de retourner une distance fausse. C'est le comportement reel du moteur qui est demontre, pas un recit.
- Mesure complementaire : interroger les distances **apres** detection d'un cycle negatif fait diverger l'accesseur (OOM en sonde) → la cellule enseigne la garde avant usage.

## Contenu ajoute (3 cellules inserees dans la section 4, apres la cellule Dijkstra)

1. **MD intro** « Bellman-Ford : quand les couts deviennent negatifs » — pourquoi la precondition de Dijkstra (finalisation gloutonne dans l'ordre croissant) se brise sur poids negatif, ce que la relaxation |V|−1 fois apporte.
2. **CODE** — Cas A : reseau de couts S→T(1 EUR), S→A(2 EUR), A→T(−3 EUR subventionne). Dijkstra → REFUS `NegativeWeightException` ; Bellman-Ford → cycle negatif = False, cout S→T = **−1,00 EUR** (le detour a 2 EUR devient gagnant apres la subvention). Cas B : cycle A→B→A = −1 EUR par tour → `FoundNegativeCycle = True`, distances NON interrogees (garde avant usage, les predecesseurs sont corrompus).
3. **MD « Lecture du resultat »** — lit les valeurs commitees : le refus explicite (precondition enforced par la bibliotheque), le detour devenu gagnant (aucun ordre glouton ne le garantit), le verdict « pas d'optimum » comme reponse legitime (detection d'arbitrage impossible), regle pratique Dijkstra (O((V+A) log V), poids ≥ 0) vs Bellman-Ford (O(V·A), poids negatifs OK + detection de cycle).

## Validation

- **Papermill end-to-end SUCCESS** kernel `.net-csharp` (DOTNET_ROOT corrige), cellules code toutes `execution_count` non-null, 0 erreur, outputs commites (C.2/H.1). Un premier run a echoue sur une erreur de manipulation (heredoc → vrai saut-de-ligne dans un litteral C#) — cause corrigee a la source puis RE-EXECUTEE, aucune sortie hand-editee (Stop & Repair).
- Cellules existantes inchangees : les 13 cellules code d'origine gardent leur source (seule la re-execution rafraichit execution_count/outputs). Exercices et Conclusion inchanges.
- Guards : voir les details dans les checks CI + execution locale (validate, consecutive-code-cells, interp-positioning, density 1197 c/cell apres ajout).
- Claim disjoint pose sur #13772 (`paths: .../Search-02c-QuikGraph.ipynb`, commentaire 5494655437) — le claim paths-scoped de po-2024 (Search-15/16/README/png) ne couvre pas ce fichier ; ma premiere demande de levee (basee sur un check sans `--paths`, donc epic-wide par defaut) a ete corrigee publiquement sur l'issue.

See #13772 (contribution partielle a la verticale QuikGraph — le volet consolidation reste a po-2024/ai-01)
