### PR TITLE
docs(casestudies): aligner le tableau de maturite sur le marqueur CATALOG-STATUS

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -247,12 +247,12 @@ Le template étudiant (`student/`) contient le squelette du projet : classes ave
 
 ## Statistiques catalogue à jour
 
-| Sous-projet | Notebooks | Statut | Paradigmes mobilisés |
-|-------------|-----------|--------|----------------------|
-| [Diagnostic-Medical](Diagnostic-Medical/) | 2 (student + solution) | PRODUCTION | A* + génétique + Z3 (CSP) |
-| [Oncology-Planning](Oncology-Planning/) | 2 (student + solution) | PRODUCTION | Ontologie + CSP/OR-Tools + Pyro (Pyro probabiliste) + bonus smart contract (`OncoContract`) |
-| [SmartGrid-Energy](SmartGrid-Energy/) | 2 (student + solution) | BETA | CP-SAT + bayésien (risque défaillance) + multi-objectif (coût/CO2) |
-| **Total** | **6 notebooks** | **PRODUCTION=4, BETA=2** | 4 paradigmes : symbolique (CSP/ontologie) + statistique (probabiliste/évolutionnaire) + recherche (A*) + optimisation (CP-SAT) |
+| Sous-projet | Notebooks | Maturité (marqueur `CATALOG-STATUS`) | Paradigmes mobilisés |
+|-------------|-----------|--------------------------------------|----------------------|
+| [Diagnostic-Medical](Diagnostic-Medical/) | 2 (student + solution) | BETA + BETA | A* + génétique + Z3 (CSP) |
+| [Oncology-Planning](Oncology-Planning/) | 2 (student + solution) | BETA (solution) + DRAFT (student) | Ontologie + CSP/OR-Tools + Pyro (Pyro probabiliste) + bonus smart contract (`OncoContract`) |
+| [SmartGrid-Energy](SmartGrid-Energy/) | 2 (student + solution) | BETA + BETA | CP-SAT + bayésien (risque défaillance) + multi-objectif (coût/CO2) |
+| **Total** | **6 notebooks** | **BETA=5, DRAFT=1** | 4 paradigmes : symbolique (CSP/ontologie) + statistique (probabiliste/évolutionnaire) + recherche (A*) + optimisation (CP-SAT) |
 
 Chaque notebook solution fait l'objet d'une **validation par assertions** (cellule terminale `tests_automatises()` ou prints discriminants) dans son sous-dossier `solution/` ; le template `student/` porte les stubs conformes (règle C.1 : `pass` / `return None` / `print("Exercice à compléter")` / jamais `raise NotImplementedError`) et reste exécutable end-to-end. La cohérence est garantie par `requirements.txt` au racine (`numpy`, `pandas`, `matplotlib`, `seaborn`, `z3-solver`, `rdflib`, `pyro-ppl`, `torch`, `ortools` — 9 dépendances communes aux 3 cas).
 


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-ai-01:CoursIA — prev: MED/notebook-python #13986

## Le défaut

`MyIA.AI.Notebooks/CaseStudies/README.md` se contredit **lui-même**, à 248 lignes d'écart :

| Endroit | Ce qui est écrit |
|---|---|
| ligne 7 — marqueur `CATALOG-STATUS` (généré par `catalog-cron.yml`) | `maturity: BETA=5, DRAFT=1` |
| ligne 255 — tableau de prose « Statistiques catalogue à jour » | `**PRODUCTION=4, BETA=2**` |

Le catalogue généré tranche : sur les **1064** entrées du dépôt, `maturity=PRODUCTION` est accordé **0 fois** (BETA 961, ALPHA 56, DRAFT 43, TEMPLATE 4). `PRODUCTION` est une valeur *légale* de l'échelle (`scripts/notebook_tools/batch_reexecute.py:163`) mais **jamais attribuée**. Les 6 notebooks CaseStudies sont, dans le catalogue :

```
Diagnostic-Medical/{solution,student}   BETA  / BETA
Oncology-Planning/solution              BETA
Oncology-Planning/student               DRAFT
SmartGrid-Energy/{solution,student}     BETA  / BETA
```

## Le correctif

La prose est alignée sur le marqueur, **qui fait autorité** — le README le déclare lui-même dans sa note éditoriale (« Le marqueur `CATALOG-STATUS` ci-dessus est autoritatif pour le compte agrégé »), et `Search/README.md:618` porte la même clause pour la répartition de maturité.

La colonne est renommée **`Statut` → `Maturité`** : elle contenait des valeurs de l'échelle `maturity` (PRODUCTION/BETA/ALPHA/DRAFT) sous l'intitulé de l'échelle `status` (READY/DEMO/BROKEN). Les deux coexistent dans le catalogue, et leur confusion est la cause de la dérive — la corriger sans renommer la colonne laisserait le piège en place.

## Périmètre : mesuré, pas supposé

Avant de corriger, j'ai balayé les **13 READMEs de série** en comparant le marqueur généré à toute mention de maturité dans la prose :

- **1 divergence réelle** — celle-ci.
- 1 faux positif — `Search/README.md:632` (« **ALPHA=0** : pas d'ALPHA sur cette série ») est une remarque comparative, pas un compte concurrent ; son marqueur ne porte pas de ligne `maturity`.
- 11 READMEs sans divergence.

La dérive est **isolée**, pas systématique : ce n'est donc pas une tranche de rollout, et il n'y a pas de suite à provisionner.

## Gardes

- Marqueur `CATALOG-STATUS` **byte-identique** à `origin/main` (vérifié par `diff` sur les lignes 3-8) — catalog-pr-hygiene R1.
- `COURSE_CATALOG.generated.{json,md}` **non touchés** ; le diff est d'un seul fichier, 6 insertions / 6 suppressions, toutes dans le tableau.
- Aucun BOM introduit.
- L898 : aucune PR ouverte sur ce chemin hors le véhicule catalogue permanent #13839, qui ne touche que le marqueur.

## Précédent

Même classe de défaut, même remède : **#9966** (`docs(semanticweb,#3975): reconcile SemanticWeb §E audit prose maturity drift (PRODUCTION=23 -> BETA=25)`), MERGED.

See #3975.

## Note de cap — cette PR ne doit pas être mergée aujourd'hui

`variation_light_cap.py --genre-signals --lane myia-ai-01:CoursIA` sur les 62 PRs mergées du 2026-09-01 rend, pour ma lane : `lane_grains: 6`, `light_genre: 4`, `cap: 2` → **`CAP-EXCEEDED-BY-GENRE: true`**. Un `LIGHT/readme` de plus creuse le dépassement.

Je suis à la fois l'auteur et le détenteur de l'override : m'auto-accorder la levée serait exactement le geste que le protocole interdit. La PR est ouverte (le travail est écrit, on ne le jette pas) et **attend la réinitialisation du budget** — ou un mainteneur tiers. Elle n'est pas bloquée techniquement.
