### PR TITLE
feat(gametheory,#12207): GT-03e le mur traverse — critere de cloture 3/4 vers 4/4

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03e-Meta-Actions-Tarifees.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03e-Meta-Actions-Tarifees.ipynb
@@ -5,10 +5,10 @@
    "id": "c01",
    "metadata": {
     "papermill": {
-     "duration": 0.002974,
-     "end_time": "2026-08-22T11:41:58.805538+00:00",
+     "duration": 0.004894,
+     "end_time": "2026-09-01T14:19:53.221214+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.802564+00:00",
+     "start_time": "2026-09-01T14:19:53.216320+00:00",
      "status": "completed"
     },
     "tags": []
@@ -36,10 +36,10 @@
    "id": "c02",
    "metadata": {
     "papermill": {
-     "duration": 0.002076,
-     "end_time": "2026-08-22T11:41:58.810292+00:00",
+     "duration": 0.003736,
+     "end_time": "2026-09-01T14:19:53.230908+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.808216+00:00",
+     "start_time": "2026-09-01T14:19:53.227172+00:00",
      "status": "completed"
     },
     "tags": []
@@ -56,16 +56,16 @@
    "id": "c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.815565Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.815382Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.821210Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.820289Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.240945Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.240569Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.255335Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.254324Z"
     },
     "papermill": {
-     "duration": 0.009416,
-     "end_time": "2026-08-22T11:41:58.821762+00:00",
+     "duration": 0.021342,
+     "end_time": "2026-09-01T14:19:53.256202+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.812346+00:00",
+     "start_time": "2026-09-01T14:19:53.234860+00:00",
      "status": "completed"
     },
     "tags": []
@@ -106,10 +106,10 @@
    "id": "c04",
    "metadata": {
     "papermill": {
-     "duration": 0.002229,
-     "end_time": "2026-08-22T11:41:58.826573+00:00",
+     "duration": 0.003111,
+     "end_time": "2026-09-01T14:19:53.262671+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.824344+00:00",
+     "start_time": "2026-09-01T14:19:53.259560+00:00",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +131,16 @@
    "id": "c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.831971Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.831821Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.839212Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.838422Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.267783Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.267636Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.274407Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.273953Z"
     },
     "papermill": {
-     "duration": 0.010951,
-     "end_time": "2026-08-22T11:41:58.839702+00:00",
+     "duration": 0.010073,
+     "end_time": "2026-09-01T14:19:53.275124+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.828751+00:00",
+     "start_time": "2026-09-01T14:19:53.265051+00:00",
      "status": "completed"
     },
     "tags": []
@@ -195,10 +195,10 @@
    "id": "c07",
    "metadata": {
     "papermill": {
-     "duration": 0.00216,
-     "end_time": "2026-08-22T11:41:58.844024+00:00",
+     "duration": 0.001623,
+     "end_time": "2026-09-01T14:19:53.278666+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.841864+00:00",
+     "start_time": "2026-09-01T14:19:53.277043+00:00",
      "status": "completed"
     },
     "tags": []
@@ -217,16 +217,16 @@
    "id": "c08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.849179Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.849043Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.853713Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.852963Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.282728Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.282580Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.286682Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.286227Z"
     },
     "papermill": {
-     "duration": 0.008082,
-     "end_time": "2026-08-22T11:41:58.854239+00:00",
+     "duration": 0.00689,
+     "end_time": "2026-09-01T14:19:53.287224+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.846157+00:00",
+     "start_time": "2026-09-01T14:19:53.280334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -274,10 +274,10 @@
    "id": "c09",
    "metadata": {
     "papermill": {
-     "duration": 0.002883,
-     "end_time": "2026-08-22T11:41:58.859781+00:00",
+     "duration": 0.001588,
+     "end_time": "2026-09-01T14:19:53.290440+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.856898+00:00",
+     "start_time": "2026-09-01T14:19:53.288852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -296,16 +296,16 @@
    "id": "c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.865743Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.865509Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.903940Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.902634Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.294331Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.294201Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.321859Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.321429Z"
     },
     "papermill": {
-     "duration": 0.042588,
-     "end_time": "2026-08-22T11:41:58.904790+00:00",
+     "duration": 0.030573,
+     "end_time": "2026-09-01T14:19:53.322583+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.862202+00:00",
+     "start_time": "2026-09-01T14:19:53.292010+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "c12",
    "metadata": {
     "papermill": {
-     "duration": 0.002487,
-     "end_time": "2026-08-22T11:41:58.910205+00:00",
+     "duration": 0.001747,
+     "end_time": "2026-09-01T14:19:53.326215+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.907718+00:00",
+     "start_time": "2026-09-01T14:19:53.324468+00:00",
      "status": "completed"
     },
     "tags": []
@@ -387,16 +387,16 @@
    "id": "c13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.916874Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.916637Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.921568Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.920334Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.330641Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.330481Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.333765Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.333378Z"
     },
     "papermill": {
-     "duration": 0.009457,
-     "end_time": "2026-08-22T11:41:58.922451+00:00",
+     "duration": 0.006164,
+     "end_time": "2026-09-01T14:19:53.334290+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.912994+00:00",
+     "start_time": "2026-09-01T14:19:53.328126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -442,10 +442,10 @@
    "id": "c14",
    "metadata": {
     "papermill": {
-     "duration": 0.002672,
-     "end_time": "2026-08-22T11:41:58.928185+00:00",
+     "duration": 0.001698,
+     "end_time": "2026-09-01T14:19:53.337647+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.925513+00:00",
+     "start_time": "2026-09-01T14:19:53.335949+00:00",
      "status": "completed"
     },
     "tags": []
@@ -462,16 +462,16 @@
    "id": "c15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.934914Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.934696Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.942700Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.941747Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.341777Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.341650Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.347188Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.346715Z"
     },
     "papermill": {
-     "duration": 0.012724,
-     "end_time": "2026-08-22T11:41:58.943672+00:00",
+     "duration": 0.008306,
+     "end_time": "2026-09-01T14:19:53.347643+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.930948+00:00",
+     "start_time": "2026-09-01T14:19:53.339337+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "c16",
    "metadata": {
     "papermill": {
-     "duration": 0.002612,
-     "end_time": "2026-08-22T11:41:58.949115+00:00",
+     "duration": 0.00182,
+     "end_time": "2026-09-01T14:19:53.351275+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.946503+00:00",
+     "start_time": "2026-09-01T14:19:53.349455+00:00",
      "status": "completed"
     },
     "tags": []
@@ -535,13 +535,130 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mur-traverse-titre",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001657,
+     "end_time": "2026-09-01T14:19:53.354569+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T14:19:53.352912+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le mur traversé — ce que le migrant coupe (critère de clôture #12207)\n",
+    "\n",
+    "Le chantier #12207 se clôt quand un lecteur peut, dans un notebook exécuté : partir d'un jeu nommé, atteindre un autre jeu nommé par un chemin qu'il n'a pas écrit lui-même, **voir le mur qu'il traverse**, et lire le coût de la méta-action qui l'y a mené. Les marches 1-2 ont nommé les jeux, calculé les chemins optimaux et balayé les coûts — mais aucune sortie ne **montrait** le mur. Entre deux chambres strictes adjacentes, l'égalité des deux cases permutées est un mur de codimension 1 : la lecture Bruns-Kimmich de GT-3b, rendue visible ici dans le flot de migration payée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "mur-traverse-lambda",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T14:19:53.359292Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.359100Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.364061Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.363592Z"
+    },
+    "papermill": {
+     "duration": 0.008287,
+     "end_time": "2026-09-01T14:19:53.364502+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T14:19:53.356215+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu depart (Ligne) : (1, 4, 2, 3)  ->  cible : (2, 4, 1, 3)  (1 meta-action, rang 2 -> 4)\n",
+      "Cases permutees : TG (rang 1) <-> BG (rang 2)\n",
+      "\n",
+      "lambda |   u_TG    u_TD    u_BG    u_BD  | table ordinale induite\n",
+      "------------------------------------------------------------------\n",
+      "  0.00 |  1.00   4.00   2.00   3.00 | chambre de depart\n",
+      "  0.25 |  1.25   4.00   1.75   3.00 | chambre de depart\n",
+      "  0.50 |  1.50   4.00   1.50   3.00 | MUR : u_TG = u_BG -- codimension 1\n",
+      "  0.75 |  1.75   4.00   1.25   3.00 | chambre cible\n",
+      "  1.00 |  2.00   4.00   1.00   3.00 | chambre cible\n",
+      "\n",
+      "Le migrant coupe UN mur (l'egalite TG/BG des rangs 1 et 2)\n",
+      "a lambda = 0.50, et l'a paye c = 1 : rang 2 -> rang 4, gain net +1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le mur traverse : la meta-action echange les rangs k et k+1 de deux cases. Dans l'espace\n",
+    "# des utilites (representant lineaire u = valeur du rang), la deformation\n",
+    "# u(lambda) = (1-lambda)*u_depart + lambda*u_cible coupe l'hyperplan d'egalite des deux\n",
+    "# cases permutees. De part et d'autre, la table ordinale est CONSTANTE : c'est la chambre.\n",
+    "positions = [i for i in range(4) if r_t[i] != t_cible[i]]\n",
+    "assert len(positions) == 2, \"une meta-action = un swap de deux cases\"\n",
+    "iA, iB = positions\n",
+    "noms = [\"TG\", \"TD\", \"BG\", \"BD\"]\n",
+    "\n",
+    "def table_depuis_u(u):\n",
+    "    \"\"\"La table ordinale (rangs 1..4) induite par un profile d'utilites.\"\"\"\n",
+    "    ordre = sorted(range(4), key=lambda j: u[j])\n",
+    "    t = [0] * 4\n",
+    "    for rang, j in enumerate(ordre, start=1):\n",
+    "        t[j] = rang\n",
+    "    return tuple(t)\n",
+    "\n",
+    "print(f\"Jeu depart (Ligne) : {r_t}  ->  cible : {t_cible}  ({bd} meta-action, rang {p0} -> {p1})\")\n",
+    "print(f\"Cases permutees : {noms[iA]} (rang {r_t[iA]}) <-> {noms[iB]} (rang {r_t[iB]})\")\n",
+    "print()\n",
+    "print(\"lambda |   u_TG    u_TD    u_BG    u_BD  | table ordinale induite\")\n",
+    "print(\"-\" * 66)\n",
+    "for lam in (0.0, 0.25, 0.5, 0.75, 1.0):\n",
+    "    u = tuple((1 - lam) * r_t[j] + lam * t_cible[j] for j in range(4))\n",
+    "    if abs(u[iA] - u[iB]) < 1e-12:\n",
+    "        classe = f\"MUR : u_{noms[iA]} = u_{noms[iB]} -- codimension 1\"\n",
+    "    else:\n",
+    "        t = table_depuis_u(u)\n",
+    "        classe = \"chambre de depart\" if t == r_t else (\"chambre cible\" if t == t_cible else str(t))\n",
+    "    print(f\"  {lam:.2f} | \" + \"  \".join(f\"{x:5.2f}\" for x in u) + f\" | {classe}\")\n",
+    "print()\n",
+    "print(f\"Le migrant coupe UN mur (l'egalite {noms[iA]}/{noms[iB]} des rangs {min(r_t[iA], r_t[iB])} et {min(r_t[iA], r_t[iB]) + 1})\")\n",
+    "print(f\"a lambda = 0.50, et l'a paye c = {bd} : rang {p0} -> rang {p1}, gain net {p1 - p0 - bd:+d}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mur-traverse-lecture",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001706,
+     "end_time": "2026-09-01T14:19:53.367960+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T14:19:53.366254+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : les quatre maillons enchaînés\n",
+    "\n",
+    "La sortie ci-dessus est le critère de clôture de #12207 réalisé en un seul flot exécuté : un **jeu nommé** (le premier migrant opportuniste, tables affichées), rejoint par un **chemin qu'il n'a pas écrit** (le BFS optimal de la marche 2), en **traversant un mur visible** — la table ordinale reste celle de la chambre de départ pour tout λ < 0.5, celle de la chambre cible pour tout λ > 0.5, et l'égalité des deux cases permutées à λ = 0.50 exactement est le mur de codimension 1 — et le **coût lu** : c = 1 pour cette traversée, gain net +1 en rang.\n",
+    "\n",
+    "Le passage payé se lit désormais `chambre -> mur -> chambre voisine` : la méta-action tarifée achète exactement une traversée de mur, et rien d'autre — un échange de rangs qui ne modifie l'ordre d'aucune autre case ne peut couper plus d'un mur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c17",
    "metadata": {
     "papermill": {
-     "duration": 0.002726,
-     "end_time": "2026-08-22T11:41:58.954799+00:00",
+     "duration": 0.001684,
+     "end_time": "2026-09-01T14:19:53.371406+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.952073+00:00",
+     "start_time": "2026-09-01T14:19:53.369722+00:00",
      "status": "completed"
     },
     "tags": []
@@ -556,20 +673,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:58.961465Z",
-     "iopub.status.busy": "2026-08-22T11:41:58.961241Z",
-     "iopub.status.idle": "2026-08-22T11:41:58.990820Z",
-     "shell.execute_reply": "2026-08-22T11:41:58.989534Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.375668Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.375494Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.399619Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.399179Z"
     },
     "papermill": {
-     "duration": 0.034014,
-     "end_time": "2026-08-22T11:41:58.991507+00:00",
+     "duration": 0.027084,
+     "end_time": "2026-09-01T14:19:53.400196+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.957493+00:00",
+     "start_time": "2026-09-01T14:19:53.373112+00:00",
      "status": "completed"
     },
     "tags": []
@@ -630,10 +747,10 @@
    "id": "c19",
    "metadata": {
     "papermill": {
-     "duration": 0.002612,
-     "end_time": "2026-08-22T11:41:58.997390+00:00",
+     "duration": 0.001985,
+     "end_time": "2026-09-01T14:19:53.404191+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:58.994778+00:00",
+     "start_time": "2026-09-01T14:19:53.402206+00:00",
      "status": "completed"
     },
     "tags": []
@@ -652,20 +769,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:59.003781Z",
-     "iopub.status.busy": "2026-08-22T11:41:59.003554Z",
-     "iopub.status.idle": "2026-08-22T11:41:59.008281Z",
-     "shell.execute_reply": "2026-08-22T11:41:59.007178Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.408543Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.408284Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.411724Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.411273Z"
     },
     "papermill": {
-     "duration": 0.008906,
-     "end_time": "2026-08-22T11:41:59.008922+00:00",
+     "duration": 0.006258,
+     "end_time": "2026-09-01T14:19:53.412206+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.000016+00:00",
+     "start_time": "2026-09-01T14:19:53.405948+00:00",
      "status": "completed"
     },
     "tags": []
@@ -709,10 +826,10 @@
    "id": "c21",
    "metadata": {
     "papermill": {
-     "duration": 0.00248,
-     "end_time": "2026-08-22T11:41:59.014303+00:00",
+     "duration": 0.001961,
+     "end_time": "2026-09-01T14:19:53.415976+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.011823+00:00",
+     "start_time": "2026-09-01T14:19:53.414015+00:00",
      "status": "completed"
     },
     "tags": []
@@ -731,20 +848,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:59.021429Z",
-     "iopub.status.busy": "2026-08-22T11:41:59.021214Z",
-     "iopub.status.idle": "2026-08-22T11:41:59.051785Z",
-     "shell.execute_reply": "2026-08-22T11:41:59.050665Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.420507Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.420322Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.444445Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.444077Z"
     },
     "papermill": {
-     "duration": 0.034929,
-     "end_time": "2026-08-22T11:41:59.052379+00:00",
+     "duration": 0.027266,
+     "end_time": "2026-09-01T14:19:53.445174+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.017450+00:00",
+     "start_time": "2026-09-01T14:19:53.417908+00:00",
      "status": "completed"
     },
     "tags": []
@@ -791,10 +908,10 @@
    "id": "c23",
    "metadata": {
     "papermill": {
-     "duration": 0.003206,
-     "end_time": "2026-08-22T11:41:59.058489+00:00",
+     "duration": 0.001848,
+     "end_time": "2026-09-01T14:19:53.449155+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.055283+00:00",
+     "start_time": "2026-09-01T14:19:53.447307+00:00",
      "status": "completed"
     },
     "tags": []
@@ -812,10 +929,10 @@
    "id": "c24",
    "metadata": {
     "papermill": {
-     "duration": 0.002858,
-     "end_time": "2026-08-22T11:41:59.064641+00:00",
+     "duration": 0.001794,
+     "end_time": "2026-09-01T14:19:53.452726+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.061783+00:00",
+     "start_time": "2026-09-01T14:19:53.450932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -835,10 +952,10 @@
    "id": "c25",
    "metadata": {
     "papermill": {
-     "duration": 0.002816,
-     "end_time": "2026-08-22T11:41:59.070361+00:00",
+     "duration": 0.001941,
+     "end_time": "2026-09-01T14:19:53.456438+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.067545+00:00",
+     "start_time": "2026-09-01T14:19:53.454497+00:00",
      "status": "completed"
     },
     "tags": []
@@ -851,20 +968,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:59.077474Z",
-     "iopub.status.busy": "2026-08-22T11:41:59.077174Z",
-     "iopub.status.idle": "2026-08-22T11:41:59.081936Z",
-     "shell.execute_reply": "2026-08-22T11:41:59.080535Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.460996Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.460840Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.463868Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.463374Z"
     },
     "papermill": {
-     "duration": 0.009908,
-     "end_time": "2026-08-22T11:41:59.083126+00:00",
+     "duration": 0.006076,
+     "end_time": "2026-09-01T14:19:53.464366+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.073218+00:00",
+     "start_time": "2026-09-01T14:19:53.458290+00:00",
      "status": "completed"
     },
     "tags": []
@@ -891,10 +1008,10 @@
    "id": "c27",
    "metadata": {
     "papermill": {
-     "duration": 0.003041,
-     "end_time": "2026-08-22T11:41:59.089390+00:00",
+     "duration": 0.001806,
+     "end_time": "2026-09-01T14:19:53.468295+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.086349+00:00",
+     "start_time": "2026-09-01T14:19:53.466489+00:00",
      "status": "completed"
     },
     "tags": []
@@ -907,20 +1024,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:59.096691Z",
-     "iopub.status.busy": "2026-08-22T11:41:59.096505Z",
-     "iopub.status.idle": "2026-08-22T11:41:59.099612Z",
-     "shell.execute_reply": "2026-08-22T11:41:59.098831Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.472938Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.472779Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.475099Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.474716Z"
     },
     "papermill": {
-     "duration": 0.007683,
-     "end_time": "2026-08-22T11:41:59.100433+00:00",
+     "duration": 0.005636,
+     "end_time": "2026-09-01T14:19:53.475693+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.092750+00:00",
+     "start_time": "2026-09-01T14:19:53.470057+00:00",
      "status": "completed"
     },
     "tags": []
@@ -947,10 +1064,10 @@
    "id": "c29",
    "metadata": {
     "papermill": {
-     "duration": 0.002519,
-     "end_time": "2026-08-22T11:41:59.105551+00:00",
+     "duration": 0.00181,
+     "end_time": "2026-09-01T14:19:53.479404+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.103032+00:00",
+     "start_time": "2026-09-01T14:19:53.477594+00:00",
      "status": "completed"
     },
     "tags": []
@@ -963,20 +1080,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:41:59.112198Z",
-     "iopub.status.busy": "2026-08-22T11:41:59.112044Z",
-     "iopub.status.idle": "2026-08-22T11:41:59.115526Z",
-     "shell.execute_reply": "2026-08-22T11:41:59.114618Z"
+     "iopub.execute_input": "2026-09-01T14:19:53.483750Z",
+     "iopub.status.busy": "2026-09-01T14:19:53.483568Z",
+     "iopub.status.idle": "2026-09-01T14:19:53.485888Z",
+     "shell.execute_reply": "2026-09-01T14:19:53.485403Z"
     },
     "papermill": {
-     "duration": 0.007739,
-     "end_time": "2026-08-22T11:41:59.116069+00:00",
+     "duration": 0.005175,
+     "end_time": "2026-09-01T14:19:53.486341+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.108330+00:00",
+     "start_time": "2026-09-01T14:19:53.481166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1003,10 +1120,10 @@
    "id": "c31",
    "metadata": {
     "papermill": {
-     "duration": 0.002719,
-     "end_time": "2026-08-22T11:41:59.121689+00:00",
+     "duration": 0.001872,
+     "end_time": "2026-09-01T14:19:53.490077+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.118970+00:00",
+     "start_time": "2026-09-01T14:19:53.488205+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1032,10 +1149,10 @@
    "id": "c32",
    "metadata": {
     "papermill": {
-     "duration": 0.002636,
-     "end_time": "2026-08-22T11:41:59.127222+00:00",
+     "duration": 0.001811,
+     "end_time": "2026-09-01T14:19:53.493687+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:41:59.124586+00:00",
+     "start_time": "2026-09-01T14:19:53.491876+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1065,18 +1182,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.15"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.450664,
-   "end_time": "2026-08-22T11:41:59.245325+00:00",
+   "duration": 3.134525,
+   "end_time": "2026-09-01T14:19:53.618371+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-03e-Meta-Actions-Tarifees.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03e-Meta-Actions-Tarifees.ipynb",
    "output_path": "GameTheory-03e-Meta-Actions-Tarifees.ipynb",
    "parameters": {},
-   "start_time": "2026-08-22T11:41:57.794661+00:00",
+   "start_time": "2026-09-01T14:19:50.483846+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: notebook-dotnet #14067

## Sujet

Le **critère de clôture §5 de #12207** demande : « un lecteur peut, dans un notebook exécuté : partir d'un jeu nommé, atteindre un autre jeu nommé par un chemin qu'il n'a pas écrit lui-même, **voir le mur qu'il traverse**, et lire le coût de la méta-action qui l'y a mené. »

Confrontation D1-D5 faite ce cycle (commentaire sur l'issue) : D1 (grammaire, 03a), D2 (chambres/murs, 03b), D3 (chemin minimal certifié, 03a), D4 (les trois marches, 03e) sont livrés — mais le critère de clôture n'était tenu qu'à **3/4** : dans 03e, « mur » n'apparaissait que dans les nav-links et un nom de variable ; aucune sortie exécutée ne **montrait** le mur traversé pendant une migration payée.

## Contenu ajouté (3 cellules insérées dans 03e, marche 2, après « Lecture : deux raisons de partir »)

1. **MD titre** — « Le mur traversé — ce que le migrant coupe (critère de clôture #12207) ».
2. **CODE** — reprend le migrant opportuniste déjà calculé par la marche 2 (variables `r_t`, `t_cible`, `bd`, `p0`, `p1` de la cellule 12 — aucune recomputation parallèle) et paramètre la déformation linéaire `u(λ) = (1-λ)·u_départ + λ·u_cible`. Pour chaque λ : table ordinale induite (tri des utilités). Résultat committé : la table reste celle de la **chambre de départ** pour tout λ < 0.5, celle de la **chambre cible** pour tout λ > 0.5, et à **λ = 0.50 exactement** `u_TG = u_BG` — le mur, codimension 1. Le coût est lu dans la même sortie : `c = 1`, rang 2 → 4, gain net +1.
3. **MD lecture** — les quatre maillons enchaînés en un flot exécuté : jeu nommé → chemin BFS non écrit par le lecteur → mur visible (constance ordinale de part et d'autre) → coût lu. Lecture BK : la méta-action tarifée achète exactement **une traversée de mur** — un swap de rangs k/k+1 ne peut couper plus d'un mur.

## Validation

- **Papermill end-to-end SUCCESS** kernel `python3` (33/33 cellules, 3 s) ; ma cellule ec=7, 0 erreur, 13/13 cellules code avec `execution_count` + outputs (C.2/H.1).
- **Cellules existantes inchangées** : les 30 cellules d'origine gardent leur source (vérifié par alignement d'ids + comparaison source ; seuls ec/outputs sont rafraîchis par la re-exécution).
- **Guards locaux verts** : validate_pr_notebooks 1/1 PASS · interp-positioning 0 · markdown-rendering 0 · code-in-markdown 0 (0 new vs baseline) · cell-ordering clean · consecutive-code-cells **0 runs** (les 3 cellules ajoutées séparent code par du markdown).
- Sortie **déterministe** : le substrat 03e est pur stdlib sans RNG ; le migrant opportuniste est `jeux` trié → reproductible bit à bit.
- Claim paths-scoped sur #12207 (commentaire 5495351238) — disjoint du scope `GameTheory-3f-*.ipynb` de po-2025.

See #12207 (clôture du critère §5 — la fermeture de l'umbrella reste à ai-01 après lecture de la confrontation D1-D5)
