### PR TITLE
refactor(qc-py-cloud): resolve Cloud-04 collision (MeanReversion vs RL-DQN-Trading)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -105,7 +105,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : NLP et Sentiment dans le Trading Algorithmique\n",
     "\n",
@@ -235,7 +235,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Architecture du Modèle FinBERT\n",
     "\n",
@@ -382,7 +382,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : Code Source de l'Algorithme QuantConnect\n",
     "\n",
@@ -793,7 +793,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Deploiement sur QuantConnect Cloud via MCP\n",
     "\n",
@@ -847,7 +847,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Résultats du Backtest\n",
     "\n",
@@ -1059,7 +1059,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",
@@ -1078,7 +1078,7 @@
     "|----------|-------|------|\n",
     "| Cloud-02 | Classification ML (Random Forest) | [QC-Py-Cloud-02-ML-Classification.ipynb](QC-Py-Cloud-02-ML-Classification.ipynb) |\n",
     "| Cloud-03 | Risk Parity | [QC-Py-Cloud-03-Risk-Parity.ipynb](QC-Py-Cloud-03-Risk-Parity.ipynb) |\n",
-    "| Cloud-04 | RL DQN Trading | [QC-Py-Cloud-04-RL-DQN-Trading.ipynb](QC-Py-Cloud-04-RL-DQN-Trading.ipynb) |\n",
+    "| Cloud-10 | RL DQN Trading | [QC-Py-Cloud-10-RL-DQN-Trading.ipynb](QC-Py-Cloud-10-RL-DQN-Trading.ipynb) |\n",
     "| Cloud-05 | Regime Switching | [QC-Py-Cloud-05-RegimeSwitching.ipynb](QC-Py-Cloud-05-RegimeSwitching.ipynb) |\n"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "# QC-Py-Cloud-03 : Parite de Risque (Risk Parity)\n",
     "\n",
-    "[< Classification de Texte](./QC-Py-Cloud-02-ML-Classification.ipynb) | [Suivant : RL DQN >](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb)\n",
+    "[< Classification de Texte](./QC-Py-Cloud-02-ML-Classification.ipynb) | [Suivant : RL DQN >](./QC-Py-Cloud-10-RL-DQN-Trading.ipynb)\n",
     "\n",
     "**Niveau** : Intermediaire | **Duree estimee** : 25 min | **Kernel** : Python 3\n",
     "\n",
@@ -954,7 +954,7 @@
     "| Derive | `_check_drift()` | Rebalancement intra-mensuel |\n",
     "| Exécution | `SetHoldings()` | Rebalancement vers cibles |\n",
     "\n",
-    "[< Classification de Texte](./QC-Py-Cloud-02-ML-Classification.ipynb) | [Suivant : RL DQN >](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb)"
+    "[< Classification de Texte](./QC-Py-Cloud-02-ML-Classification.ipynb) | [Suivant : RL DQN >](./QC-Py-Cloud-10-RL-DQN-Trading.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[<< Sommaire QC](../README.md) | [Précédent : QC-Py-Cloud-03-Risk-Parity <<](./QC-Py-Cloud-03-Risk-Parity.ipynb) | [Suivant : QC-Py-Cloud-04-RL-DQN-Trading >>](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb)\n",
+    "[<< Sommaire QC](../README.md) | [Précédent : QC-Py-Cloud-03-Risk-Parity <<](./QC-Py-Cloud-03-Risk-Parity.ipynb) | [Suivant : QC-Py-Cloud-05-MLP-Forecasting >>](./QC-Py-Cloud-05-MLP-Forecasting.ipynb)\n",
     "\n",
     "# QC-Py-Cloud-04 — Mean Reversion on Sector ETFs\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# QC-Py-Cloud-05 : Prevision par Reseau de Neurones (MLP)\n",
     "\n",
-    "[< RL DQN](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | [Retour au sommaire](../README.md)\n",
+    "[< RL DQN](./QC-Py-Cloud-10-RL-DQN-Trading.ipynb) | [Retour au sommaire](../README.md)\n",
     "\n",
     "**Niveau** : Avance | **Duree estimee** : 30 min | **Kernel** : Python 3\n",
     "\n",
@@ -785,7 +785,7 @@
     "| Re-entrainement | `Schedule.month_start` | Mensuel sur fenêtre 252j |\n",
     "| Sélection | Seuil P>0.52 | Top-N avec min positions |\n",
     "\n",
-    "[RL DQN <](./QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | [Retour au sommaire](../README.md)"
+    "[RL DQN <](./QC-Py-Cloud-10-RL-DQN-Trading.ipynb) | [Retour au sommaire](../README.md)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb
@@ -14,11 +14,11 @@
     "tags": []
    },
    "source": [
-    "[<< Sommaire QC](../README.md) | [Précédent : QC-Py-Cloud-04-MeanReversion <<](./QC-Py-Cloud-04-MeanReversion.ipynb) | [Suivant : QC-Py-Cloud-05-MLP-Forecasting >>](./QC-Py-Cloud-05-MLP-Forecasting.ipynb)\n",
+    "[<< Sommaire QC](../README.md) | [Précédent : QC-Py-Cloud-09-OptionWheel <<](./QC-Py-Cloud-09-OptionWheel.ipynb)\n",
     "\n",
-    "# QC-Py-Cloud-04 : Reinforcement Learning - DQN Trading\n",
+    "# QC-Py-Cloud-10 : Reinforcement Learning - DQN Trading\n",
     "\n",
-    "[< Risk Parity](./QC-Py-Cloud-03-Risk-Parity.ipynb) | [Suivant : MLP Forecasting >](./QC-Py-Cloud-05-MLP-Forecasting.ipynb)\n",
+    "[< Option Wheel](./QC-Py-Cloud-09-OptionWheel.ipynb) | [Retour au sommaire >](../README.md)\n",
     "\n",
     "**Niveau** : Avance | **Duree estimee** : 35 min | **Kernel** : Python 3\n",
     "\n",
@@ -44,7 +44,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Apprentissage par Renforcement pour le Trading\n",
     "\n",
@@ -738,7 +738,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",
@@ -838,8 +838,8 @@
    "end_time": "2026-04-28T16:10:55.534683",
    "environment_variables": {},
    "exception": null,
-   "input_path": "QC-Py-Cloud-04-RL-DQN-Trading.ipynb",
-   "output_path": "QC-Py-Cloud-04-RL-DQN-Trading.ipynb",
+   "input_path": "QC-Py-Cloud-10-RL-DQN-Trading.ipynb",
+   "output_path": "QC-Py-Cloud-10-RL-DQN-Trading.ipynb",
    "parameters": {},
    "start_time": "2026-04-28T16:10:54.126976",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -82,7 +82,6 @@ Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Auc
 | QC-Py-Cloud-03-Risk-Parity | EXÉCUTÉ | |
 | QC-Py-Cloud-03b-RiskParity-Composite | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-04-MeanReversion | doc cloud | markdown-only — backtest sur QC Cloud |
-| QC-Py-Cloud-04-RL-DQN-Trading | EXÉCUTÉ | |
 | QC-Py-Cloud-05-MLP-Forecasting | EXÉCUTÉ | |
 | QC-Py-Cloud-05-RegimeSwitching | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-06-VolTargeting | doc cloud | markdown-only — backtest sur QC Cloud |
@@ -90,6 +89,7 @@ Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Auc
 | QC-Py-Cloud-07-TemporalCNN | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-08-ValueFactor-ZScore | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-09-OptionWheel | doc cloud | markdown-only — backtest sur QC Cloud |
+| QC-Py-Cloud-10-RL-DQN-Trading | EXÉCUTÉ | |
 | QC-Py-33-RL-PPO-Trading | EXÉCUTÉ | |
 | QC-Py-34-RL-SAC-A2C-Trading | EXÉCUTÉ | |
 | QC-Py-35-RL-Portfolio-Construction | EXÉCUTÉ | |
@@ -227,7 +227,6 @@ Notebooks de recherche et stratégies exécutées sur QuantConnect Cloud.
 | [QC-Py-Cloud-03-Risk-Parity](QC-Py-Cloud-03-Risk-Parity.ipynb) | Risk Parité |
 | [QC-Py-Cloud-03b-RiskParity-Composite](QC-Py-Cloud-03b-RiskParity-Composite.ipynb) | Risk Parité composite |
 | [QC-Py-Cloud-04-MeanReversion](QC-Py-Cloud-04-MeanReversion.ipynb) | Mean Reversion |
-| [QC-Py-Cloud-04-RL-DQN-Trading](QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | RL DQN |
 | [QC-Py-Cloud-05-MLP-Forecasting](QC-Py-Cloud-05-MLP-Forecasting.ipynb) | MLP Forecasting |
 | [QC-Py-Cloud-05-RegimeSwitching](QC-Py-Cloud-05-RegimeSwitching.ipynb) | Régime Switching |
 | [QC-Py-Cloud-06-VolTargeting](QC-Py-Cloud-06-VolTargeting.ipynb) | Volatility Targeting |
@@ -235,6 +234,7 @@ Notebooks de recherche et stratégies exécutées sur QuantConnect Cloud.
 | [QC-Py-Cloud-07-TemporalCNN](QC-Py-Cloud-07-TemporalCNN.ipynb) | Temporal CNN |
 | [QC-Py-Cloud-08-ValueFactor-ZScore](QC-Py-Cloud-08-ValueFactor-ZScore.ipynb) | Value Factor Z-Score |
 | [QC-Py-Cloud-09-OptionWheel](QC-Py-Cloud-09-OptionWheel.ipynb) | Option Wheel (risk education) |
+| [QC-Py-Cloud-10-RL-DQN-Trading](QC-Py-Cloud-10-RL-DQN-Trading.ipynb) | RL DQN (advanced) |
 
 ## Utilitaires
 

--- a/STABLE_SNAPSHOT.md
+++ b/STABLE_SNAPSHOT.md
@@ -81,7 +81,7 @@
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb` | QuantConnect | 9/12 | 2026-07-14 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb` | QuantConnect | 6/9 | 2026-07-02 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb` | QuantConnect | 3/6 | 2026-07-02 |
-| `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb` | QuantConnect | 2/5 | 2026-06-27 |
+| `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb` | QuantConnect | 2/5 | 2026-06-27 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb` | QuantConnect | 2/5 | 2026-07-02 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb` | QuantConnect | 11/14 | 2026-07-15 |
 | `MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb` | QuantConnect | 3/11 | 2026-07-02 |

--- a/docs/notebook-metadata/production-scope.md
+++ b/docs/notebook-metadata/production-scope.md
@@ -99,7 +99,7 @@ Le détail par notebook suit en strate A ci-dessous : consultation, plus décisi
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb`
-- [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb`
+- [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-RegimeSwitching.ipynb`

--- a/scripts/notebook_tools/pedagogy_density_baseline.json
+++ b/scripts/notebook_tools/pedagogy_density_baseline.json
@@ -418,7 +418,7 @@
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-DualMomentum.ipynb": 3204.333,
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb": 1103.5,
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb": 3719.667,
-    "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb": 1231.2,
+    "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb": 1231.2,
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-MLP-Forecasting.ipynb": 1298.2,
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-RegimeSwitching.ipynb": 3574.667,
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-PCA-StatArb.ipynb": 4315.0,

--- a/scripts/relabel_qc_exercises.py
+++ b/scripts/relabel_qc_exercises.py
@@ -34,7 +34,7 @@ RELABEL_MAP = {
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb": [
         (6, 2, 1), (8, 1, 2),
     ],
-    "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb": [
+    "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb": [
         (10, 3, 2), (12, 2, 3),
     ],
     "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-07-TemporalCNN.ipynb": [


### PR DESCRIPTION
Grain: MED/refactor -- lane myia-po-2026:CoursIA -- prev: MED/refactor #14080 (cycle 106)

## Contexte (#13755)

Issue #13755 documente 6 collisions dans la sous-serie `Cloud-XX` du dossier `MyIA.AI.Notebooks/QuantConnect/Python/`. Deux sujets distincts partagent le meme numero de slot, ce qui rend l'identifiant numerique ambigu.

Cette PR traite la collision **Cloud-04** :
- Slot 04 = MeanReversion (stats-based, doc cloud) -> **conserve**
- Slot 04 = RL-DQN-Trading (reinforcement learning) -> **deplace en Cloud-10**

Le precedent #13804 a etabli la convention `Cloud-03b-RiskParity-Composite` pour les branches pedagogiques. Pour RL-DQN-Trading, la relation pedagogique est trop faible (sujet avance distinct) ; un slot numerique libre est preferable.

## Decisions

- **MeanReversion reste en Cloud-04** : c'est le sujet "canonique" doc cloud pour ce slot, deja precede par Cloud-03-Risk-Parity.
- **RL-DQN-Trading -> Cloud-10** : slot libre suivant Cloud-09-OptionWheel, aligne avec la numerotation `QC-Py-33-RL-PPO-Trading` / `QC-Py-34-RL-SAC-A2C-Trading` (les autres notebooks RL avancent dans la serie 3x).
- **Pas de relation `b`-slot** : Cloud-04b n'est pas cree car RL-DQN n'est pas un approfondissement de MeanReversion.

## Sweep (10 fichiers)

| Fichier | Nature |
|---------|--------|
| `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb` -> `QC-Py-Cloud-10-RL-DQN-Trading.ipynb` | git mv (98% similarite) |
| `QC-Py-Cloud-04-MeanReversion.ipynb` | cell[0] navlink Suivant -> Cloud-05-MLP-Forecasting |
| `QC-Py-Cloud-03-Risk-Parity.ipynb` | cell[0] L4 + cell[16] L20 navlink Suivant -> Cloud-10-RL-DQN-Trading |
| `QC-Py-Cloud-05-MLP-Forecasting.ipynb` | cell[0] L2 + cell[11] L29 navlink Precedent -> Cloud-10-RL-DQN-Trading |
| `QC-Py-Cloud-01-FinBERT-Sentiment.ipynb` | cell[22] L19 table sommaire inline (Cloud-10 row) |
| `README.md` (series QC Python) | 2 tables : rename entries + append Cloud-10 apres Cloud-09 |
| `STABLE_SNAPSHOT.md` | L84 checklist reference |
| `docs/notebook-metadata/production-scope.md` | L102 checklist reference |
| `scripts/notebook_tools/pedagogy_density_baseline.json` | L421 key rename |
| `scripts/relabel_qc_exercises.py` | L37 RELABEL_MAP key rename |

## Verification

- `git diff --stat` : 22 insertions / 22 deletions (avant hook auto-fix). Apres hooks decoratifs : 28/28.
- Aucun fichier non-renomme touche en dehors du sweep prevu.
- Catalogue `COURSE_CATALOG.generated.json` laisse byte-identique (catalog-pr-hygiene HARD 1 — cron-owned).
- Aucun changement de code/strategie/quantbook : **rename + navlinks uniquement**.

## Hors scope

- Les 3 collisions restantes (#13755 slot 02 / 05 / 06) -> PR separees par collision (cf issue).
- Modification des strategies ou metriques.
- Regeneration du catalogue (HARD 1).

## Refs

Refs #13755
