### PR TITLE
fix(ci): le stale-sweep replie par (workflow_id, name) — 30% du pool gelé par un fold aveugle aux runs jumeaux

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -160,12 +160,21 @@ jobs:
             [ -z "${NUM:-}" ] && continue
             # details_url (.../actions/runs/{run_id}/job/{job_id}) is collected
             # on purpose: it is the only field carrying the run id, which the
-            # selector needs to fold check-runs per (run_id, name) instead of
-            # per name -- three workflows emit a job named "Ratchet (base vs
-            # PR)" and a name-only fold merges their verdicts (#11808).
+            # selector resolves through the map below to fold check-runs per
+            # (workflow_id, name) instead of per name -- three workflows emit a
+            # job named "Ratchet (base vs PR)" and a name-only fold merges their
+            # verdicts (#11808).
             BODY=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
                      --jq '[.check_runs[] | {name, status, conclusion, started_at, details_url}]' 2>/dev/null) || continue
-            printf '{"number":%s,"sha":"%s","fork":%s,"checks":%s}\n' "$NUM" "$SHA" "${FORK:-false}" "$BODY" >> /tmp/runs.jsonl
+            # Carte run_id -> workflow_id. UN seul appel de plus par PR (pas par
+            # run) : la liste des runs du SHA porte deja `workflow_id`. C'est ce
+            # qui permet de replier les runs JUMEAUX d'un MEME workflow sans
+            # jamais fusionner deux workflows homonymes (#11808). Si l'appel
+            # echoue, la carte est vide et la cle retombe sur run_id : le
+            # comportement anterieur, jamais plus permissif.
+            WFMAP=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=100" --jq '[.workflow_runs[] | {key:(.id|tostring), value:.workflow_id}] | from_entries' 2>/dev/null)
+            if [ -z "${WFMAP:-}" ]; then WFMAP='{}'; fi
+            printf '{"number":%s,"sha":"%s","fork":%s,"checks":%s,"workflows":%s}\n' "$NUM" "$SHA" "${FORK:-false}" "$BODY" "$WFMAP" >> /tmp/runs.jsonl
           done < /tmp/openprs.txt
           echo "[stale-sweep] open PRs inspected: $(wc -l < /tmp/runs.jsonl | tr -d ' ')"
 
@@ -192,21 +201,46 @@ jobs:
           # scripts/tests/test_pr_gate_sweep_select.py, which points this at a
           # fixture. Default is the sweep's own collection file.
           #
-          # Fold key is (run_id, name), NEVER the name alone (#11808). Three
-          # workflows emit a job displaying the same name "Ratchet (base vs
-          # PR)"; folding by name lets the most recent of the three erase the
-          # verdicts of the other two -- measured 2026-08-19 on #11804: an
-          # Output-Failure SUCCESS at 16:21 covered a live Papermill FAILURE
-          # from 16:19, and this sweep re-ran a gate on a PR that was NOT
-          # healthy. The run id is not in the REST payload; details_url
-          # (.../actions/runs/{run_id}/job/{job_id}) carries it at no extra
-          # API call. `gh run rerun` rewrites a run's check-run IN PLACE, so
-          # same (run_id, name) keeps latest-wins -- the fold's original
-          # purpose, a superseded attempt of the SAME workflow -- and only the
-          # cross-workflow merge disappears.
-          def _fold_key(c):
+          # Fold key is (workflow_id, name) -- NEVER the name alone (#11808), and
+          # no longer (run_id, name) either (defect measured 2026-09-01).
+          #
+          # Not the name alone: three distinct workflows emit a job displaying
+          # the same name "Ratchet (base vs PR)". Folding by name lets the most
+          # recent of the three erase the verdicts of the other two -- measured
+          # 2026-08-19 on #11804, where an Output-Failure SUCCESS at 16:21
+          # covered a live Papermill FAILURE from 16:19 and this sweep re-ran a
+          # gate on a PR that was NOT healthy.
+          #
+          # Not the run id either: that key assumed the only way ONE workflow
+          # yields two check-runs on one SHA is a rerun -- which rewrites its
+          # check-run IN PLACE and so keeps the same run id. That is false for a
+          # workflow triggered by SEVERAL events. `Always-on guards` carries no
+          # `paths:` filter and fires on both `pull_request` and
+          # `pull_request_review`: two runs, two run ids, one workflow, one SHA.
+          # Keying on the run id kept the SUPERSEDED failure alive, so this
+          # sweep excluded the PR at every pass ("red gate, kept out") while
+          # `pr_gate.py` -- which folds by NAME, latest-wins -- saw green.
+          # Measured on #13869 (SHA d207b5e15): run 33432764140 (`pull_request`)
+          # failure 20:05:20Z, run 33435266510 (`pull_request_review`) success
+          # 20:20:51Z. 23 of the 77 open PRs (30 %) were frozen this way, three
+          # of them the coordinator's own -- which is itself the evidence that
+          # this was a mechanism, not lane indiscipline.
+          #
+          # (workflow_id, name) answers both at once: twin runs of ONE workflow
+          # fold under latest-wins (the fold's original purpose), and two
+          # DIFFERENT workflows never merge. The governing principle is that a
+          # REPAIR selector must never be STRICTER than the gate it repairs.
+          #
+          # The map is collected above at one extra API call per PR. When it is
+          # absent -- collection failure, or a fixture predating this change --
+          # the key falls back to the run id: the previous behaviour, never
+          # anything more permissive.
+          def _fold_key(c, wfmap):
               m = re.search(r"/runs/(\d+)/", c.get("details_url") or "")
-              return (m.group(1) if m else "unattributed", c.get("name") or "?")
+              if not m:
+                  return ("unattributed", c.get("name") or "?")
+              run_id = m.group(1)
+              return (str(wfmap.get(run_id, run_id)), c.get("name") or "?")
 
           def _diag(p, why, blockers):
               print(f'[stale-sweep] #{p["number"]}: red gate, kept out -- {why}: '
@@ -219,8 +253,9 @@ jobs:
                   continue
               p = json.loads(line)
               latest = {}
+              wfmap = {str(k): v for k, v in (p.get("workflows") or {}).items()}
               for c in (p.get("checks") or []):
-                  key = _fold_key(c)
+                  key = _fold_key(c, wfmap)
                   started = c.get("started_at") or ""
                   if key not in latest or started >= latest[key][0]:
                       latest[key] = (started, c)

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -81,7 +81,7 @@ def _run_selector_both(tmp_path, rows):
     return out
 
 
-def _pr(number, checks, sha="deadbeef", fork=False):
+def _pr(number, checks, sha="deadbeef", fork=False, workflows=None):
     """checks = tuples (name, status, conclusion, started_at[, run_id]).
 
     Sans 5e element, la fixture ne porte pas de details_url : le selecteur
@@ -99,7 +99,10 @@ def _pr(number, checks, sha="deadbeef", fork=False):
                 f"{ch[4]}/job/96158568958"
             )
         rows.append(row)
-    return {"number": number, "sha": sha, "fork": fork, "checks": rows}
+    row_out = {"number": number, "sha": sha, "fork": fork, "checks": rows}
+    if workflows:
+        row_out["workflows"] = {str(k): v for k, v in workflows.items()}
+    return row_out
 
 
 GATE_OK = ("PR gate", "completed", "success", "2026-01-01T10:00:00Z")
@@ -302,3 +305,47 @@ def test_excluded_incomplete_pr_names_its_blocking_check(tmp_path):
     assert proc.stdout.strip() == ""
     assert "#112" in proc.stderr
     assert "unfinished" in proc.stderr
+
+
+def test_same_workflow_twin_runs_green_supersedes_red(tmp_path):
+    """Defaut mesure le 2026-09-01 : un MEME workflow produit DEUX runs sur un
+    MEME SHA parce qu'il tire sur deux evenements (`pull_request` et
+    `pull_request_review`) -- deux run_id, pas un rerun. Le repli par
+    (run_id, name) les garde separes, la failure superseded survit, et le
+    sweep exclut la PR a chaque passage (`red gate, kept out`).
+
+    Cas reel : #13869, SHA d207b5e15 -- run 33432764140 (`pull_request`)
+    failure 20:05:20Z, run 33435266510 (`pull_request_review`) success
+    20:20:51Z. `pr_gate.py` replie par NOM (latest-wins) et voit du vert ;
+    le sweep voyait du rouge. 23 des 77 PRs ouvertes (30 %) etaient gelees.
+
+    Falsification : ce test echoue sur le repli par (run_id, name).
+    """
+    guard_old = ("Always-on guards", "completed", "failure",
+                 "2026-01-01T09:00:00Z", 33432764140)
+    guard_new = ("Always-on guards", "completed", "success",
+                 "2026-01-01T09:15:00Z", 33435266510)
+    out = _run_selector(tmp_path, [_pr(
+        113, [GATE_FAIL, guard_old, guard_new],
+        workflows={33432764140: 555, 33435266510: 555},
+    )])
+    assert out.strip() == "113 deadbeef false"
+
+
+def test_distinct_workflows_same_name_still_separate(tmp_path):
+    """Controle positif de non-regression #11808 : deux workflows DIFFERENTS
+    (workflow_id 555 et 777) portant le meme nom de job ne fusionnent pas --
+    le vert du second n'efface pas le rouge du premier, la PR reste dehors.
+
+    C'est ce que la clef (workflow_id, name) preserve et qu'un repli par nom
+    seul perdrait.
+    """
+    ratchet_red = ("Ratchet (base vs PR)", "completed", "failure",
+                   "2026-01-01T09:00:00Z", 900)
+    ratchet_green = ("Ratchet (base vs PR)", "completed", "success",
+                     "2026-01-01T09:15:00Z", 901)
+    out = _run_selector(tmp_path, [_pr(
+        114, [GATE_FAIL, ratchet_red, ratchet_green],
+        workflows={900: 555, 901: 777},
+    )])
+    assert out.strip() == ""


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/notebook-python #13986

**See #13978** (jambe disjointe : advisories `cancelled`). Ici c'est un `failure` **réel**, que la table de #13978 classait à juste titre comme une exclusion correcte.

## Le défaut

Le sweep de réparation **gelait** les PRs qu'il devait dégeler. Sa clé de repliement des check-runs, `(run_id, name)`, reposait sur une prémisse fausse — inscrite **verbatim dans son propre commentaire** :

> `gh run rerun` rewrites a run's check-run IN PLACE, so same (run_id, name) keeps latest-wins

Vrai d'un **rerun**. Faux d'un workflow déclenché par **plusieurs événements**. `Always-on guards` n'a pas de filtre `paths:` et se déclenche sur `pull_request` **et** `pull_request_review` : deux runs, deux `run_id`, **un seul workflow**, un seul SHA.

Conséquence : la clé par `run_id` maintenait en vie l'échec **supersédé**, donc le sweep excluait la PR à chaque passe (« red gate, kept out ») pendant que `pr_gate.py` — qui replie par **nom**, latest-wins — la voyait verte. Les deux organes lisaient le même SHA et n'étaient pas d'accord.

**Mesure**, #13869 (SHA `d207b5e15`) :

| run | événement | conclusion | heure |
|---|---|---|---|
| 33432764140 | `pull_request` | failure | 20:05:20Z |
| 33435266510 | `pull_request_review` | **success** | 20:20:51Z |

**23 des 77 PRs ouvertes (30 %)** étaient gelées ainsi, dont **trois à moi** — ce qui est en soi la preuve qu'il s'agissait d'un mécanisme, pas d'une indiscipline de lane.

## Le fix

`(workflow_id, name)` répond aux **deux** exigences à la fois :

- les runs **jumeaux d'un même** workflow se replient sous latest-wins — l'objet même du fold ;
- deux workflows **différents** ne fusionnent jamais, donc la protection de **#11808** (trois workflows émettant un job nommé `Ratchet (base vs PR)`) survit **intacte**.

Coût : **un** appel d'API de plus **par PR** (pas par run) — la liste des runs du SHA porte déjà `workflow_id`. Carte absente (échec de collecte, fixture antérieure) → repli sur `run_id`, soit le comportement antérieur, **jamais plus permissif**.

## Preuves

**Tests — 18/18.** Les deux gardes #11808 pré-existants passent **inchangés** (c'est le point : le fix ne les affaiblit pas). Deux tests neufs encadrent le correctif :

- `test_same_workflow_twin_runs_green_supersedes_red` — **a échoué avant le patch, passe après**. C'est la falsification, écrite avant le fix.
- `test_distinct_workflows_same_name_still_separate` — deux workflows homonymes restent séparés.

Les tests exécutent le sélecteur **livré verbatim** via la couture `SWEEP_RUNS_FILE` (`_extract_selector()` extrait le heredoc du YAML parsé) : ils ne testent pas une copie.

**Contrôle positif dans l'organe réel**, pas seulement dans la fixture — la requête effectivement écrite dans le workflow, rendue sur le SHA de #13869 :

```
run 33432764140 -> workflow 344731609
run 33435266510 -> workflow 344731609
MEME workflow : True
workflows a runs multiples sur ce SHA : {344731609: 2}
```

Le fold ne fusionne **exactement** que la paire qui était le défaut — aucun autre workflow n'a de runs multiples sur ce SHA.

## Sur le tag, en toute transparence

`tooling` et non `guard` : le discriminant de [variation-protocol.md](.claude/rules/variation-protocol.md) est « est-ce que ça peut rougir ». Le stale-sweep **ne poste aucun verdict** sur une PR — c'est un organe de réparation qui relance des gates. Précédent sur le **même fichier** : #13979, mergée sous `MED/tooling`.

Conséquence à noter puisqu'elle m'avantage : `tooling` n'est dans **aucun** des deux axes du cap G-VAR-2 (ni tier, ni genre). Je l'écris pour que ce soit contestable plutôt que discret — le raisonnement précède la conséquence, et il tient indépendamment d'elle.

Genre **META** : cette PR ne lève donc **pas** le plancher G-VAR-1 de ma lane, et ne prétend pas le faire.

## Portée — ce que ce fix ne fait pas

Le dégel des 19 PRs de ce cycle a été obtenu **à la main** (rerun). Ce correctif est ce qui empêche le **regel** : sans lui, la prochaine PR touchée par un `pull_request_review` regèle. Il ne répare pas les 4 rouges résiduels, qui sont de vraies défaillances d'organe appartenant à leurs lanes (#14012, #14002, #13932, et **#13912 qui est à moi**).
