### PR TITLE
feat(prover,#1453): error-signature loop guard in _build_check_or_revert

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -838,6 +838,22 @@ class TacticTools:
         # whether the existing stagnation guards cover the new invariant surface.
         self._consecutive_compile_fail: int = 0
         self._fail_streak_threshold: int = 12
+        # #1453 forensic (cycle-99, c.5496938996 findings P2/P3): error-signature
+        # stagnation. The verbatim loop detector keys (tool, args-hash) — different
+        # edit arguments produce different hashes, so it NEVER fires while the
+        # underlying compile error is constant (Voting L338: 6 different edits,
+        # same "1 errors. Reverted." result). The P4 fail-streak compensates on
+        # the pure treadmill but resets on ANY successful build — alternating
+        # [fail x N -> one delta0 compile success] never reaches cap 12 (zai
+        # trace: 14 fails reset by a single delta0 success). Keying on the
+        # normalized error SIGNATURE closes both gaps at once: >= threshold
+        # consecutive fails carrying the SAME (line, message-prefix) signature
+        # is a loop regardless of which edit produced it or what compiled in
+        # between — the streak resets ONLY on signature change, never on build
+        # success.
+        self._last_error_signature: Optional[tuple] = None
+        self._same_error_signature_streak: int = 0
+        self._error_signature_threshold: int = 3
         self._original_file_size: int = 0
         self._original_content: Optional[str] = None
         # Decomposition budget: how many new sorries the agents may introduce
@@ -1323,6 +1339,62 @@ class TacticTools:
         if self._state is not None:
             self._state.consecutive_compile_fail = self._consecutive_compile_fail
 
+    @staticmethod
+    def _error_signature(errors: list) -> Optional[tuple]:
+        """Normalized identity of a build failure: (line, message-prefix) per error.
+
+        Capped at the first 4 errors and the first 60 chars of each message so
+        cosmetic noise (hint positions, timings) cannot mask a repeat. Returns
+        None for an empty list — no errors, no signature.
+        """
+        if not errors:
+            return None
+        return tuple(
+            (e.get("line"), str(e.get("message", ""))[:60]) for e in errors[:4]
+        )
+
+    def _bump_error_signature_streak(self, errors: list) -> int:
+        """Track consecutive build fails carrying the same normalized signature.
+
+        Resets to 1 ONLY when the signature changes — deliberately NOT on build
+        success: the P2 evasion ([fail x N -> delta0 success] alternating) must
+        keep the streak alive, because the same error coming back after an
+        interleaved success is still the same loop (forensic c.5496938996).
+        """
+        sig = self._error_signature(errors)
+        if sig is None:
+            return self._same_error_signature_streak
+        if sig == self._last_error_signature:
+            self._same_error_signature_streak += 1
+        else:
+            self._last_error_signature = sig
+            self._same_error_signature_streak = 1
+        return self._same_error_signature_streak
+
+    def _error_signature_loop_error(self, errors: list) -> Optional[Dict]:
+        """LOOP_DETECTED error dict once the same signature repeats >= threshold.
+
+        Mirrors the BUILD_FAIL_STORM wording: a hard error directing the agent
+        to stop editing this target and change strategy, since distinct edits
+        keep hitting the same compile error.
+        """
+        if not errors or self._same_error_signature_streak < self._error_signature_threshold:
+            return None
+        first = errors[0]
+        return {
+            "error": (
+                f"LOOP_DETECTED: {self._same_error_signature_streak} consecutive "
+                f"build failures with the SAME compile error signature "
+                f"(line {first.get('line')}: {str(first.get('message', ''))[:60]}). "
+                f"Different edits keep hitting this same error — editing further "
+                f"is the same pathology. CHANGE STRATEGY: decompose elsewhere, "
+                f"use an alternative lemma, or submit your best tactic and yield."
+            ),
+            "reverted": True,
+            "errors": errors[:8],
+            "loop_detected": True,
+        }
+
     def _build_fail_storm_guard(self, tool_name: str) -> Optional[str]:
         """Intra-turn entry-guard: stop editing once the fail streak hits the cap.
 
@@ -1494,6 +1566,24 @@ class TacticTools:
         # that fired 14x invisibly on Voting L338. Bump the streak so the
         # workflow / intra-turn guards can finally see a build_check fail storm.
         self._bump_compile_fail()
+        # #1453 forensic (cycle-99, c.5496938996): same normalized error signature
+        # >= 3x is a loop the args-keyed detector cannot see (P3) and that the
+        # P4 streak loses to the delta0-success reset (P2). Fire BEFORE the agent
+        # burns another edit+build+chat cycle on the same error. The revert above
+        # already restored the file, so returning here keeps the same contract as
+        # the generic BUILD FAILED below.
+        self._bump_error_signature_streak(errors)
+        loop_sig_err = self._error_signature_loop_error(errors)
+        if loop_sig_err is not None:
+            if self._trace:
+                self._trace.log(
+                    agent="TacticTools", role="error_signature_loop",
+                    content=(f"LOOP_DETECTED: same compile error signature "
+                             f"{self._same_error_signature_streak}x after {operation}."),
+                    duration_s=0.01,
+                    tool_result=raw_output[:300],
+                )
+            return loop_sig_err
 
         if self._trace:
             self._trace.log(

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_error_signature_loop.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_error_signature_loop.py
@@ -1,0 +1,138 @@
+"""Unit tests for the error-signature loop guard on TacticTools (#1453, cycle-99).
+
+Background: forensic c.5496938996 (cycle-99, EPIC #1453) established two gaps
+the existing guards cannot close on the dominant ``_build_check_or_revert``
+hard-revert path:
+
+  * P3 — the verbatim loop detector ``_check_tool_loop`` keys ``(tool,
+    args_hash)``: six different edits with different arguments all produced
+    the same ``1 errors. Reverted.`` result (Voting L338, run 1778459482),
+    and the hash never repeated, so it never fired.
+  * P2 — the P4 fail-streak resets on ANY successful build: the zai trace
+    shows 14 fails reset by a single delta0 compile success, so the streak
+    never reached cap 12.
+
+The guard added here keys the NORMALIZED error signature (line + 60-char
+message prefix per error, first 4 errors) and fires LOOP_DETECTED at >= 3
+consecutive fails carrying the SAME signature. The streak resets ONLY on
+signature change — never on build success — by design (P2 evasion).
+
+These tests exercise the counter and firing semantics directly on the
+internal methods — no lake build, no verifier, fully offline.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Mirror the conftest path used by the other prover test modules.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover.state import ProofState, SorryContext  # noqa: E402
+from prover.tools import TacticTools  # noqa: E402
+
+
+def _make_tactic_tools(tmp_path):
+    """Build a TacticTools against a fake .lean file (no real Lean needed)."""
+    fake = tmp_path / "Fake.lean"
+    body = (
+        "import Mathlib.Tactic\n"
+        "namespace TestSpace\n"
+        + "\n".join(f"-- comment line {i}" for i in range(30))
+        + "\ntheorem t : True := by\n  sorry\n"
+        + "\n".join(f"-- trailing line {i}" for i in range(30))
+        + "\nend TestSpace\n"
+    )
+    fake.write_text(body, encoding="utf-8")
+    sorry_line = next(i + 1 for i, l in enumerate(body.split("\n")) if "sorry" in l)
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=sorry_line, indentation=2,
+        indent_str="  ", full_file=body,
+    )
+    return TacticTools(state, str(fake), sctx)
+
+
+_ERR_A_BASE = "unknown identifier 'foo' in the declaration body at line start here"
+ERR_A = [{"line": 12, "message": _ERR_A_BASE}]
+ERR_A_NOISY = [{"line": 12, "message": _ERR_A_BASE + ", extra suffix noise past the 60-char truncation point"}]
+assert len(_ERR_A_BASE) >= 60  # the differing noise must live past the prefix
+ERR_B = [{"line": 34, "message": "type mismatch: expected Nat, got String"}]
+
+
+def test_signature_none_on_empty_errors(tmp_path):
+    tt = _make_tactic_tools(tmp_path)
+    assert tt._error_signature([]) is None
+
+
+def test_streak_increments_on_identical_signature(tmp_path):
+    tt = _make_tactic_tools(tmp_path)
+    assert tt._bump_error_signature_streak(ERR_A) == 1
+    assert tt._bump_error_signature_streak(ERR_A) == 2
+    assert tt._bump_error_signature_streak(ERR_A) == 3
+
+
+def test_streak_resets_to_one_on_different_signature(tmp_path):
+    tt = _make_tactic_tools(tmp_path)
+    tt._bump_error_signature_streak(ERR_A)
+    tt._bump_error_signature_streak(ERR_A)
+    assert tt._bump_error_signature_streak(ERR_B) == 1
+
+
+def test_streak_persists_across_build_success(tmp_path):
+    """P2 evasion: a successful build between two same-signature fails must
+    NOT reset the streak — only a signature change resets it."""
+    tt = _make_tactic_tools(tmp_path)
+    tt._bump_error_signature_streak(ERR_A)
+    tt._bump_error_signature_streak(ERR_A)
+    # Simulate a successful build: the success path never calls the bump.
+    # (On the real path, _consecutive_compile_fail resets here — the signature
+    # streak deliberately does not.)
+    tt._consecutive_compile_fail = 0
+    assert tt._bump_error_signature_streak(ERR_A) == 3
+
+
+def test_loop_error_fires_at_threshold(tmp_path):
+    tt = _make_tactic_tools(tmp_path)
+    for _ in range(3):
+        tt._bump_error_signature_streak(ERR_A)
+    out = tt._error_signature_loop_error(ERR_A)
+    assert out is not None
+    assert "LOOP_DETECTED" in out["error"]
+    assert out["loop_detected"] is True
+    assert out["reverted"] is True
+
+
+def test_loop_error_silent_below_threshold(tmp_path):
+    tt = _make_tactic_tools(tmp_path)
+    tt._bump_error_signature_streak(ERR_A)
+    tt._bump_error_signature_streak(ERR_A)
+    assert tt._error_signature_loop_error(ERR_A) is None
+
+
+def test_loop_error_silent_when_signatures_alternate(tmp_path):
+    """Green path: genuinely different errors (agent progressing) never fire."""
+    tt = _make_tactic_tools(tmp_path)
+    tt._bump_error_signature_streak(ERR_A)
+    tt._bump_error_signature_streak(ERR_B)
+    tt._bump_error_signature_streak(ERR_A)
+    assert tt._same_error_signature_streak == 1
+    assert tt._error_signature_loop_error(ERR_A) is None
+
+
+def test_signature_truncates_message_noise(tmp_path):
+    """Messages differing only past the 60-char prefix share one signature."""
+    tt = _make_tactic_tools(tmp_path)
+    assert tt._error_signature(ERR_A) == tt._error_signature(ERR_A_NOISY)
+    tt._bump_error_signature_streak(ERR_A)
+    assert tt._bump_error_signature_streak(ERR_A_NOISY) == 2
+
+
+def test_loop_error_requires_nonempty_errors(tmp_path):
+    tt = _make_tactic_tools(tmp_path)
+    for _ in range(3):
+        tt._bump_error_signature_streak(ERR_A)
+    assert tt._error_signature_loop_error([]) is None


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2027:CoursIA — prev: MED/notebook-python #14072

## Sujet

Forensic cycle-99 de l'EPIC #1453 (commentaire c.5496938996) : deux gaps que les gardes existantes ne ferment pas sur le chemin dominant `_build_check_or_revert` (hard-revert — celui qui a brûlé 14 fails invisibles / 1352 s sur Voting L338, cycle-98) :

- **P3** — le détecteur verbatim `_check_tool_loop` clé `(tool, args_hash)` : six édits à arguments différents produisant tous la même erreur `1 errors. Reverted.` ne font jamais répéter le hash → jamais déclenché (run `1778459482`, 6× identique, ~170 s de treadmill, streak final 9 < cap 12).
- **P2** — le fail-streak P4 se reset sur **tout** build réussi : la trace `zai` montre 14 fails annulés par un seul succès-compile Δ0 → l'alternance [fail×N → Δ0-succès] n'atteint jamais le cap 12.

## La garde (diff +218 lignes, 2 fichiers)

Fichiers touchés : `agent_tests/prover/tools.py` (+55) et `agent_tests/tests/test_prover_error_signature_loop.py` (+163).

Signature normalisée d'un échec de build = tuples `(line, préfixe-60-du-message)` des 4 premières erreurs. À **≥ 3 fails consécutifs portant la MÊME signature** → erreur dure `LOOP_DETECTED` (miroir du wording BUILD_FAIL_STORM) ordonnant le changement de stratégie. Point de tir : la fin hard-revert de `_build_check_or_revert`, juste après `_bump_compile_fail()` — le fichier est déjà réverté, le contrat de retour est inchangé. Le streak se reset **uniquement sur changement de signature — jamais sur succès de build** (ferme l'évasion P2 par construction).

## Validation

- **9 tests offline** (`tests/test_prover_error_signature_loop.py`, venv projet) : incrément sur signature identique · reset à 1 sur signature différente · **persistance à travers un succès de build** (le cas P2) · tir à ≥3 avec `loop_detected: true` · silence sous le seuil · silence en alternance (chemin vert : erreurs réellement différentes) · troncature du bruit passé 60 chars · signature None sur liste vide.
- **Suite prover complète : 746/746 passés** (7.7 s) — zéro régression sur les gardes existantes (storm, freeze, empty-response, pathology3).
- Diff : `tools.py` (+55) + test file (+163 +9 fixt) — aucune dépendance nouvelle, zéro build Lean supplémentaire, aucune exécution LLM.

## Acceptance EPIC (cycle en cours)

≥1 finding forensic (**c.5496938996** : corpus, 4 pathologies evidence-cited, 2 déjà-corrigées vérifiées) + ≥1 PR harnais (celle-ci). Replay BG frais de Voting L338 = mesure d'efficacité différée au prochain run BG (métrique : wall-clock + compte d'édits avant tir — sur la timeline observée, tir au 3ᵉ erreur identique ~t≈1683 au lieu de jamais : ≥3 cycles edit+build+chat économisés ≈ 60-90 s/tentative).

Scope respecté : claim paths-scopé c.5496939404 (`tools.py` + `tests/*`) ; le LOST_PROGRESS veto (progression réelle) et le crash-verifier restent hors périmètre — non couverts volontairement (diff borné).

See #1453


