### PR TITLE
feat(qc,#14081): revalidate PatchTST against debiased HAR

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -12,6 +12,7 @@ Updated: 2026-08-24 — M4 DLinear-vol §C extension ETF (Epic #1454): **NO BEAT
 Updated: 2026-08-23 — backlog à déposer : M15 h=32 NO BEATS (#11468) et barreau ETF direction 9/9 NO BEATS (#11427) absents du header — cf sections respectives
 Updated: 2026-08-24 — Re-validation hors-biais des keepers BTC (issues #11041/#11034/#11036) : M15 `refuted-de-biased` 3/3 (l'edge publié = biais² de HAR, var_ratio > 1 partout) ; M4 confirmé h=1/h=5, INCONCLUSIVE h=10 (p_median 0,0598, var_ratio < 1)
 Updated: 2026-08-24 — M15 LSTM-vol patch persistance biais + slice 2/2 dé-biaisé symétrique (issue #12734): patch livré, run complet dispatché au prochain cycle
+Updated: 2026-09-01 — PatchTST BTC log-RV revalidé contre HAR débiaisé train-only (#14081) : h=1 INCONCLUSIVE, h=5/h=10 NO BEATS ; var_ratio > 1 aux trois horizons
 
 Total checkpoints: 70 (20 legacy ARCHIVED + 50 panier baselines)
 
@@ -279,8 +280,9 @@ sur les séries persistées).
 (ce run) et **ETF SPY/TLT/GLD** (#12695 : 9/9 cellules négatives hors biais), les deux terrains
 log-RV du pipeline ; il est général à la famille M15 (LSTM h=64, window 22) sur la cible log-RV.
 En revanche cette entrée **ne couvre pas** : (1) les autres architectures deep-seq (transformer,
-mamba, PatchTST, iTransformer, MoE régimes, GNN — non re-validées hors biais ; leurs éventuels
-edges restent à décomposer par le même instrument) ; (2) la cible direction/rendement (ladder
+mamba, iTransformer, MoE régimes, GNN — non re-validées hors biais ; leurs éventuels edges
+restent à décomposer par le même instrument). PatchTST est désormais couvert séparément par
+#14081 ci-dessous ; (2) la cible direction/rendement (ladder
 #1409 L4 Decision Transformer, validation XRP DT — cible différente, verdict non touché) ;
 (3) M4 DLinear lui-même, qui **survit** sur BTC (`confirmed` h=1/h=5) mais échoue sur ETF
 (#12695) — l'edge M4 est spécifique au terrain crypto (RV BTC agrège 24 h de bars horaires vs
@@ -294,6 +296,40 @@ uniquement, aucune stratégie dérivée, borne crypto 10 bps non imputée.
   biais uniquement ; décomposition `mse = biais² + var` vérifiée au 1e-12 par seed). Artefacts
   hors repo (`results/` gitignoré) — instrument de persistance : PR #12745.
 - **Verdict §C recentré** : **0/3 BEATS, 0/3 INCONCLUSIVE, 3/3 NO BEATS** — `refuted-de-biased`.
+
+## PatchTST-vol BTC — revalidation hors biais (2026-09-01) — issue #14081
+
+Première revalidation deep-seq hors M15 contre la baseline corrigée issue de #12684/#12734.
+Le harnais `scripts/btc_patchtst.py` réutilise le modèle PatchTST (Nie et al., ICLR 2023), mais
+porte sa propre cible log-RV et son vrai walk-forward expanding : le CLI directionnel historique
+n'appliquait pas réellement son drapeau `--walk-forward`. Le défaut `--device` déclaré deux fois,
+qui faisait échouer ce CLI avant tout entraînement, est corrigé et couvert par un test subprocess.
+
+**Protocole réel** : BTC Bitstamp hourly 2014→2024, 2 278 jours de RV (2018-05-15→2024-08-08),
+SHA-256 `38a4e973955cf9f8527c3096931aa958bfae09580737c909450504b21502c573` ; 5 folds expanding,
+seeds {0,1,7,42}, horizons {1,5,10}, cible = moyenne du log-RV futur. PatchTST borné CPU :
+`seq_len=64`, patch 16, stride 8, `d_model=32`, 4 heads, 1 couche, 10 epochs — 14 145 / 15 045 /
+16 170 paramètres selon l'horizon. Un modèle est ajusté par fold et seed, normalisation et sélection
+du meilleur epoch sur le train uniquement. HAR estime son biais signé sur une queue de calibration
+antérieure au test (`calibrate_bias=True`) : aucun target du bloc test ne calibre sa propre baseline.
+DM porte sur les erreurs recentrées avec `loss_fn="mse"` ; toutes les séries alignées par timestamp
+sont persistées hors dépôt pour recalcul post-hoc.
+
+| Horizon | edge PatchTST vs HAR débiaisé | σ cross-seed | dm_p_median recentré | var_ratio PatchTST/HAR | seeds BEATEN | Verdict |
+|---|---:|---:|---:|---:|---:|---|
+| h=1  | −4,23 %  | 1,32 pt | 0,313  | 1,041 | 0/4 | **INCONCLUSIVE** |
+| h=5  | −16,35 % | 2,38 pt | 0,0366 | 1,159 | 3/4 | **NO BEATS** |
+| h=10 | −22,86 % | 2,76 pt | 0,0253 | 1,220 | 4/4 | **NO BEATS** |
+
+**Biais signés moyens PatchTST / HAR débiaisé** : h=1 −0,00475 / −0,00388 ; h=5 −0,04321 /
+−0,00155 ; h=10 −0,05502 / −0,00242. HAR est effectivement recalé ; l'écart restant vient de la
+variance. PatchTST porte une variance supérieure aux trois horizons (`var_ratio > 1`) et la
+dégradation croît avec l'horizon. Le résultat h=1 ne sépare pas les modèles (4/4 DM inconclusifs) ;
+h=5 et h=10 réfutent l'edge deep-seq, respectivement 3/4 et 4/4 seeds significativement battues.
+
+- **Run** : `python scripts/btc_patchtst.py --device cpu --horizons 1 5 10 --seeds 0 1 7 42 --n-splits 5 --seq-len 64 --patch-len 16 --stride 8 --d-model 32 --n-heads 4 --n-layers 1 --epochs 10 --batch-size 32 --out-json results/btc_patchtst_har_debiased_cpu_20260901.json` — 115,9 s CPU, 12/12 combinaisons, 5 folds chacune.
+- **Vérification** : 12 lignes JSON, 1 890 / 1 870 / 1 845 prédictions alignées par seed selon h ; longueurs erreurs/prédictions/timestamps identiques ; `MSE = biais² + variance` recalculé à tolérance numérique sur chaque ligne.
+- **Verdict §C** : **0/3 BEATS, 1/3 INCONCLUSIVE, 2/3 NO BEATS**. Mesure de prévision uniquement : aucune stratégie de trading ni claim après coûts.
 
 ## M4 DLinear-vol — extension §C ETF (2026-08-23) — Epic #1454
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/btc_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/btc_patchtst.py
@@ -2,10 +2,9 @@
 
 Wrapper that reuses existing pipeline modules without modifying them:
 - ``PatchTSTModel`` from ``train_patchtst.py`` (Nie et al., ICLR 2023) -- the
-  CLASS only. The ``train_patchtst`` CLI is deliberately NOT invoked: it
-  carries a duplicate ``--device`` argparse argument and a ``--walk-forward``
-  flag that is accepted but never applied. This module owns its own
-  walk-forward loop instead.
+  CLASS only. The generic CLI targets returns/direction and its
+  ``--walk-forward`` flag does not replace the simple split, so this log-RV
+  revalidation owns an explicit expanding walk-forward loop instead.
 - BTC intraday loader / log-RV primitives: ``intraday_loader``
   (``load_bitstamp_btc``, ``hourly_log_returns``) and ``realized_variance``
   (``daily_realized_variance``, ``realized_variance_to_log``).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/btc_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/btc_patchtst.py
@@ -1,0 +1,819 @@
+"""PatchTST vs train-only-debiased HAR on BTC daily log-RV (issue #14081).
+
+Wrapper that reuses existing pipeline modules without modifying them:
+- ``PatchTSTModel`` from ``train_patchtst.py`` (Nie et al., ICLR 2023) -- the
+  CLASS only. The ``train_patchtst`` CLI is deliberately NOT invoked: it
+  carries a duplicate ``--device`` argparse argument and a ``--walk-forward``
+  flag that is accepted but never applied. This module owns its own
+  walk-forward loop instead.
+- BTC intraday loader / log-RV primitives: ``intraday_loader``
+  (``load_bitstamp_btc``, ``hourly_log_returns``) and ``realized_variance``
+  (``daily_realized_variance``, ``realized_variance_to_log``).
+- The HAR walk-forward baseline: ``har_model.walk_forward_har`` with
+  ``calibrate_bias=True`` (see the debiasing paragraph below).
+- ``dlinear_vol.create_sequences`` for the (input, target) windowing --
+  same convention as the DLinear-vol keeper.
+- ``btc_vol._mse_decomposition`` / ``btc_vol._dm_centered_mse`` for the
+  MSE = bias^2 + variance decomposition and the DM test on mean-centered
+  errors (loss_fn="mse" -> variance differential, the precision leg of
+  pr-review section C).
+
+Protocol (per horizon h in {1, 5, 10} by default, per seed in {0, 1, 7, 42}):
+- Expanding walk-forward, 5 folds (``har_model._make_split_indices``): fold k
+  trains on [0, k * fold_size) and tests on [k * fold_size, (k+1) * fold_size),
+  fold_size = n // (n_splits + 1).
+- ONE PatchTST per (fold, seed). Normalisation stats (mean, std of log-RV)
+  come from the training fold ONLY. Validation is the TAIL of the training
+  sequences ONLY; the best-validation epoch state is restored before test
+  inference. The test fold never enters fitting, normalisation, or model
+  selection.
+- Target = mean future log-RV over the next h days. PatchTST predicts the
+  h-step vector (pred_len = horizon) which is averaged at inference; HAR
+  averages its h iterated one-step forecasts. Both use the identical target
+  convention, and predictions are aligned BY TIMESTAMP on the shared test
+  dates before any comparison metric is computed (guarded by an explicit
+  target-consistency check on the aligned support).
+
+HAR debiasing -- genuinely out-of-sample:
+``walk_forward_har(..., calibrate_bias=True)`` estimates the signed HAR
+offset on a TRAIN-TAIL holdout: the calibration HAR is fit on
+``rv_train[:fit_end]`` and its errors are measured on ``rv_train[fit_end:]``
+-- strictly BEFORE the test window of that fold. That estimated offset is
+subtracted from the test forecasts. Mutating the test region leaves the
+calibration constant unchanged (regression-tested for ``walk_forward_har`` in
+``test_dlinear_debiased_edge.py`` and re-checked on this wrapper in
+``test_btc_patchtst.py``). By contrast, subtracting the mean error measured
+ON THE TEST SUPPORT itself (the ``har_bias_oos`` shortcut used by the earlier
+``btc_vol.py``) would let the test targets calibrate their own baseline --
+that is leakage, and it is explicitly NOT done here. The residual signed bias
+of the debiased HAR on the test support is still REPORTED, but only as a
+diagnostic; it never feeds back into any forecast.
+
+Reported per combo (seed x horizon): signed biases of both models,
+MSE = bias^2 + variance for both, centered-error DM (mse loss), var_ratio
+(patchtst_variance / har_debiased_variance), and edge vs the debiased HAR.
+Per-combo arrays (model_errors, har_errors, predictions, targets, timestamps)
+are persisted in the output JSON for downstream re-analysis.
+
+Aggregation per horizon (pr-review section C): NO BEATS if any seed is BEATEN
+by the debiased baseline; BEATS only if mean edge >= 2 * cross-seed std AND
+median DM p < 0.05; otherwise INCONCLUSIVE.
+
+Usage:
+    python btc_patchtst.py --dry-run                      # synthetic log-RV, CPU
+    python btc_patchtst.py                                # real BTC sweep
+    python btc_patchtst.py --horizons 1 5 --seeds 0 1 7 42 --device cpu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+# Local imports: scripts/ first, then QuantConnect/shared for gpu_training.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+_SHARED = _HERE.parent.parent / "shared"
+if str(_SHARED) not in sys.path:
+    sys.path.append(str(_SHARED))
+
+from gpu_training import batch_thermal_check, setup_amp  # noqa: E402
+from train_patchtst import PatchTSTModel  # noqa: E402  (model class reuse only)
+from har_model import _make_split_indices as make_expanding_splits  # noqa: E402
+from har_model import walk_forward_har  # noqa: E402
+from dlinear_vol import create_sequences  # noqa: E402
+from btc_vol import _dm_centered_mse, _mse_decomposition  # noqa: E402
+from intraday_loader import hourly_log_returns, load_bitstamp_btc  # noqa: E402
+from realized_variance import (  # noqa: E402
+    daily_realized_variance,
+    realized_variance_to_log,
+)
+
+DEFAULT_OUT_JSON = str(_HERE.parent / "results" / "btc_patchtst_har_debiased.json")
+
+# Dry-run overrides (requirement #14081): deterministic synthetic log-RV,
+# 2 folds, 1 seed, 1 horizon, tiny model/epochs, CPU, no download.
+DRY_RUN_OVERRIDES = {
+    "horizons": [1],
+    "seeds": [0],
+    "n_splits": 2,
+    "seq_len": 16,
+    "patch_len": 4,
+    "stride": 2,
+    "d_model": 8,
+    "n_heads": 2,
+    "n_layers": 1,
+    "epochs": 2,
+    "batch_size": 16,
+    "device": "cpu",
+}
+
+
+def load_btc_rv() -> pd.Series:
+    """Daily realized variance of BTC from the Bitstamp hourly CSV."""
+    btc = load_bitstamp_btc()
+    rets = hourly_log_returns(btc)
+    rv = daily_realized_variance(rets)
+    print(f"[btc_patchtst] BTC: {len(rv)} RV days")
+    return rv
+
+
+def synthetic_rv(n: int = 360, seed: int = 0) -> pd.Series:
+    """Deterministic synthetic daily RV (exponential of an AR(1) log-RV).
+
+    Scale is that of a typical daily log-RV (around -12, i.e. RV ~ 6e-6) so
+    the pipeline runs through the exact same numerical ranges as real data.
+    """
+    rng = np.random.default_rng(seed)
+    mu, phi, sigma = -12.0, 0.90, 0.25
+    eps = rng.normal(0.0, sigma, n)
+    log_rv = np.empty(n)
+    log_rv[0] = mu
+    for t in range(1, n):
+        log_rv[t] = mu + phi * (log_rv[t - 1] - mu) + eps[t]
+    index = pd.date_range("2021-01-01", periods=n, freq="D")
+    return pd.Series(np.exp(log_rv), index=index, name="synthetic_RV")
+
+
+def train_normalization_stats(
+    log_rv: np.ndarray, train_end: int
+) -> tuple[float, float]:
+    """Mean/std of log-RV on [0, train_end) ONLY (no test leakage)."""
+    train = np.asarray(log_rv[:train_end], dtype=float)
+    return float(np.mean(train)), max(float(np.std(train)), 1e-6)
+
+
+def train_patchtst_fold(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    *,
+    seq_len: int,
+    horizon: int,
+    patch_len: int,
+    stride: int,
+    d_model: int,
+    n_heads: int,
+    n_layers: int,
+    dropout: float,
+    fc_dropout: float,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    seed: int,
+    device: str = "cpu",
+    val_ratio: float = 0.15,
+) -> tuple[PatchTSTModel, dict]:
+    """Train one PatchTST on a single fold's TRAINING sequences.
+
+    Early stopping / model selection uses a validation split taken from the
+    TAIL of the training sequences only -- the test fold of the walk-forward
+    never enters this function. The best-validation epoch state is restored
+    before returning.
+    """
+    if d_model % n_heads != 0:
+        raise ValueError(f"d_model={d_model} must be divisible by n_heads={n_heads}")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    val_cutoff = int(len(x_train) * (1 - val_ratio))
+    val_cutoff = max(min(val_cutoff, len(x_train) - 1), 1)
+    x_tr, x_val = x_train[:val_cutoff], x_train[val_cutoff:]
+    y_tr, y_val = y_train[:val_cutoff], y_train[val_cutoff:]
+
+    model = PatchTSTModel(
+        n_vars=1,
+        seq_len=seq_len,
+        pred_len=horizon,
+        patch_len=patch_len,
+        stride=stride,
+        d_model=d_model,
+        n_heads=n_heads,
+        n_layers=n_layers,
+        dropout=dropout,
+        fc_dropout=fc_dropout,
+    ).to(device)
+
+    dataset = torch.utils.data.TensorDataset(
+        torch.tensor(np.asarray(x_tr), dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(np.asarray(y_tr), dtype=torch.float32),
+    )
+    val_dataset = torch.utils.data.TensorDataset(
+        torch.tensor(np.asarray(x_val), dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(np.asarray(y_val), dtype=torch.float32),
+    )
+    loader = torch.utils.data.DataLoader(
+        dataset, batch_size=batch_size, shuffle=True,
+        generator=torch.Generator().manual_seed(seed),
+    )
+    val_loader = torch.utils.data.DataLoader(val_dataset, batch_size=batch_size)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    criterion = torch.nn.MSELoss()
+    use_amp, grad_scaler = setup_amp(device)
+
+    best_val_loss = float("inf")
+    best_state: dict | None = None
+
+    for _epoch in range(epochs):
+        model.train()
+        for batch_idx, (xb, yb) in enumerate(loader):
+            # Thermal watchdog: no-op on CPU (torch.cuda check inside).
+            batch_thermal_check(batch_idx, check_every=5, max_temp=80, cool_sleep=30)
+            xb, yb = xb.to(device), yb.to(device)
+            optimizer.zero_grad()
+            with torch.amp.autocast("cuda", enabled=use_amp):
+                loss = criterion(model(xb), yb)
+            if use_amp:
+                grad_scaler.scale(loss).backward()
+                grad_scaler.unscale_(optimizer)
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+                grad_scaler.step(optimizer)
+                grad_scaler.update()
+            else:
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+                optimizer.step()
+
+        model.eval()
+        val_loss, val_batches = 0.0, 0
+        with torch.no_grad():
+            for xb, yb in val_loader:
+                xb, yb = xb.to(device), yb.to(device)
+                with torch.amp.autocast("cuda", enabled=use_amp):
+                    val_loss += criterion(model(xb), yb).item()
+                val_batches += 1
+        avg_val = val_loss / max(val_batches, 1)
+        if avg_val < best_val_loss:
+            best_val_loss = avg_val
+            best_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+    model.eval()
+    return model, {
+        "best_val_loss": round(best_val_loss, 6),
+        "n_train_sequences": int(len(x_tr)),
+        "n_val_sequences": int(len(x_val)),
+        "epochs": int(epochs),
+    }
+
+
+def walk_forward_patchtst(
+    log_rv: np.ndarray,
+    rv_index: pd.DatetimeIndex,
+    *,
+    seq_len: int = 64,
+    horizon: int = 1,
+    n_splits: int = 5,
+    patch_len: int = 16,
+    stride: int = 8,
+    d_model: int = 64,
+    n_heads: int = 4,
+    n_layers: int = 2,
+    dropout: float = 0.2,
+    fc_dropout: float = 0.2,
+    epochs: int = 30,
+    batch_size: int = 32,
+    lr: float = 5e-4,
+    seed: int = 0,
+    device: str = "cpu",
+    val_ratio: float = 0.15,
+    min_train_sequences: int = 20,
+) -> dict:
+    """Expanding walk-forward evaluation of PatchTST on daily log-RV.
+
+    Per fold: normalization on the training fold only, one model per
+    (fold, seed) trained with train-tail validation, forecasts produced with
+    a single forward pass over the fold's test inputs. Target of a forecast
+    dated t is mean(log_rv[t : t + horizon]) -- the HAR target convention.
+    """
+    log_rv = np.asarray(log_rv, dtype=float)
+    n = len(log_rv)
+    if n < seq_len + horizon + 100:
+        raise ValueError(
+            f"need >= {seq_len + horizon + 100} obs for walk-forward, got {n}"
+        )
+
+    splits = make_expanding_splits(n, n_splits)
+
+    preds: list[float] = []
+    truths: list[float] = []
+    dates: list[pd.Timestamp] = []
+    fold_info: list[dict] = []
+
+    for fold_idx, (train_end, test_start, test_end) in enumerate(splits):
+        n_train_seq = train_end - seq_len - horizon + 1
+        if n_train_seq < min_train_sequences:
+            fold_info.append({
+                "fold": fold_idx, "train_end": int(train_end),
+                "test_start": int(test_start), "test_end": int(test_end),
+                "skipped": f"train_sequences<{min_train_sequences}",
+            })
+            continue
+
+        train_mean, train_std = train_normalization_stats(log_rv, train_end)
+        normed = (log_rv - train_mean) / train_std
+        x_all, y_all = create_sequences(normed, seq_len, horizon)
+
+        model, info = train_patchtst_fold(
+            x_all[:n_train_seq], y_all[:n_train_seq],
+            seq_len=seq_len, horizon=horizon,
+            patch_len=patch_len, stride=stride, d_model=d_model,
+            n_heads=n_heads, n_layers=n_layers, dropout=dropout,
+            fc_dropout=fc_dropout, epochs=epochs, batch_size=batch_size,
+            lr=lr, seed=seed, device=device, val_ratio=val_ratio,
+        )
+
+        test_indices = [
+            i for i in range(test_start, test_end - horizon) if i - seq_len >= 0
+        ]
+        if not test_indices:
+            fold_info.append({
+                "fold": fold_idx, "train_end": int(train_end),
+                "test_start": int(test_start), "test_end": int(test_end),
+                "skipped": "empty_test_window",
+                **info,
+            })
+            continue
+
+        x_test = np.asarray(
+            [normed[i - seq_len: i] for i in test_indices], dtype=np.float32
+        )[:, :, None]
+        with torch.no_grad():
+            tensor = torch.tensor(x_test, dtype=torch.float32, device=device)
+            pred_matrix = model(tensor).cpu().numpy()  # [n_test, horizon]
+        fold_preds = pred_matrix.mean(axis=1) * train_std + train_mean
+
+        for i, pred_raw in zip(test_indices, fold_preds):
+            preds.append(float(pred_raw))
+            truths.append(float(np.mean(log_rv[i: i + horizon])))
+            dates.append(rv_index[i])
+
+        fold_info.append({
+            "fold": fold_idx,
+            "train_end": int(train_end),
+            "test_start": int(test_start),
+            "test_end": int(test_end),
+            "train_mean": float(train_mean),
+            "train_std": float(train_std),
+            "n_test": len(test_indices),
+            **info,
+        })
+
+    preds_arr = np.asarray(preds)
+    truths_arr = np.asarray(truths)
+    aggregate_mse = (
+        float(np.mean((preds_arr - truths_arr) ** 2)) if len(preds_arr) else float("nan")
+    )
+    forecasts = pd.Series(
+        preds_arr, index=pd.DatetimeIndex(dates), name="patchtst_logrv_pred"
+    )
+    targets = pd.Series(
+        truths_arr, index=pd.DatetimeIndex(dates), name="logrv_target"
+    )
+    return {
+        "horizon": horizon,
+        "seed": seed,
+        "seq_len": seq_len,
+        "n_splits": n_splits,
+        "n_total_preds": len(preds_arr),
+        "aggregate_mse_logrv": aggregate_mse,
+        "fold_info": fold_info,
+        "forecasts": forecasts,
+        "targets": targets,
+    }
+
+
+def run_debiased_har(
+    rv: pd.Series,
+    horizon: int,
+    n_splits: int,
+    refit_every: int = 22,
+    calibration_size: int = 60,
+) -> dict:
+    """Walk-forward HAR with TRAIN-ONLY bias calibration (genuinely OOS).
+
+    ``calibrate_bias=True`` fits the calibration HAR on ``rv_train[:fit_end]``
+    and measures its signed error on the train tail ``rv_train[fit_end:]``,
+    strictly before the fold's test window; that offset is subtracted from the
+    test forecasts. The test support never calibrates its own baseline (see
+    module docstring). Returns the ``walk_forward_har`` payload.
+    """
+    return walk_forward_har(
+        rv,
+        horizon=horizon,
+        n_splits=n_splits,
+        refit_every=refit_every,
+        calibrate_bias=True,
+        calibration_size=calibration_size,
+    )
+
+
+def align_by_timestamps(
+    model_forecasts: pd.Series,
+    model_targets: pd.Series,
+    har_forecasts: pd.Series,
+    har_targets: pd.Series,
+) -> dict:
+    """Inner-join both models' forecasts on their shared test dates.
+
+    Both walk-forwards use the same target convention (forecast dated t has
+    target mean(log_rv[t:t+h])); the aligned targets must therefore be
+    identical on the shared dates -- enforced, so a convention drift between
+    the two models cannot silently corrupt the comparison.
+    """
+    df = pd.concat(
+        {
+            "model_pred": model_forecasts,
+            "model_target": model_targets,
+            "har_pred": har_forecasts,
+            "har_target": har_targets,
+        },
+        axis=1,
+    ).dropna()
+    if len(df) == 0:
+        return {
+            "timestamps": [],
+            "model_pred": np.asarray([]),
+            "model_target": np.asarray([]),
+            "har_pred": np.asarray([]),
+            "har_target": np.asarray([]),
+        }
+    if not np.allclose(
+        df["model_target"].to_numpy(), df["har_target"].to_numpy(), atol=1e-8
+    ):
+        raise ValueError(
+            "target mismatch on aligned dates: PatchTST and HAR target "
+            "conventions diverged -- refusing to compare"
+        )
+    return {
+        "timestamps": list(df.index),
+        "model_pred": df["model_pred"].to_numpy(dtype=float),
+        "model_target": df["model_target"].to_numpy(dtype=float),
+        "har_pred": df["har_pred"].to_numpy(dtype=float),
+        "har_target": df["har_target"].to_numpy(dtype=float),
+    }
+
+
+def evaluate_combo(aligned: dict, horizon: int) -> dict:
+    """Metrics of one (seed, horizon) combo on the timestamp-aligned support.
+
+    - ``_mse_decomposition`` reports MSE = bias^2 + variance for each model
+      (signed bias is reported, never corrected on the test support).
+    - ``_dm_centered_mse`` runs the DM test on mean-centered errors with
+      loss_fn="mse": biases annihilated, d_mean measures the variance
+      differential (precision leg of pr-review section C).
+    - ``var_ratio`` < 1 means PatchTST is more precise than the debiased HAR.
+    - ``edge_vs_debiased_har_pct`` > 0 means PatchTST has lower total MSE
+      than the debiased HAR on this support.
+    """
+    model_errors = aligned["model_pred"] - aligned["model_target"]
+    har_errors = aligned["har_pred"] - aligned["har_target"]
+    if len(model_errors) < 10:
+        return {
+            "n_aligned": int(len(model_errors)),
+            "dm_centered_stat": float("nan"),
+            "dm_centered_pvalue": float("nan"),
+            "dm_centered_verdict": "INSUFFICIENT_DATA",
+            "edge_vs_debiased_har_pct": float("nan"),
+            "var_ratio_patchtst_over_har_debiased": float("nan"),
+        }
+
+    patchtst_decomp = _mse_decomposition(model_errors)
+    har_decomp = _mse_decomposition(har_errors)
+    dm = _dm_centered_mse(model_errors, har_errors, horizon=horizon)
+
+    har_mse = har_decomp["mse"]
+    model_mse = patchtst_decomp["mse"]
+    edge_pct = (
+        float((har_mse - model_mse) / har_mse * 100.0)
+        if np.isfinite(har_mse) and har_mse > 0
+        else float("nan")
+    )
+    var_ratio = (
+        float(patchtst_decomp["variance"] / har_decomp["variance"])
+        if np.isfinite(har_decomp["variance"]) and har_decomp["variance"] > 0
+        else float("nan")
+    )
+
+    return {
+        "n_aligned": int(len(model_errors)),
+        "patchtst_mse_logrv": float(patchtst_decomp["mse"]),
+        "patchtst_bias": float(np.mean(model_errors)),
+        "patchtst_bias_sq": float(patchtst_decomp["bias_sq"]),
+        "patchtst_variance": float(patchtst_decomp["variance"]),
+        "har_debiased_mse_logrv": float(har_mse),
+        "har_debiased_bias": float(np.mean(har_errors)),
+        "har_debiased_bias_sq": float(har_decomp["bias_sq"]),
+        "har_debiased_variance": float(har_decomp["variance"]),
+        "var_ratio_patchtst_over_har_debiased": var_ratio,
+        "edge_vs_debiased_har_pct": edge_pct,
+        "dm_centered_stat": float(dm["dm_stat"]),
+        "dm_centered_pvalue": float(dm["dm_pvalue"]),
+        "dm_centered_verdict": str(dm["dm_verdict"]),
+        "dm_centered_mean_loss_diff": float(dm.get("mean_loss_diff", float("nan"))),
+    }
+
+
+def aggregate_by_horizon(rows: list[dict]) -> list[dict]:
+    """Aggregate per-horizon verdicts across seeds (pr-review section C).
+
+    NO BEATS as soon as one seed is BEATEN by the debiased baseline;
+    BEATS requires edge >= 2 * cross-seed std AND median DM p < 0.05;
+    everything else is INCONCLUSIVE.
+    """
+    from collections import defaultdict
+
+    grouped: dict[int, list[dict]] = defaultdict(list)
+    for r in rows:
+        if "skipped" in r or "edge_vs_debiased_har_pct" not in r:
+            continue
+        grouped[r["horizon"]].append(r)
+
+    results: list[dict] = []
+    for h, sub in sorted(grouped.items()):
+        edges = np.asarray([r["edge_vs_debiased_har_pct"] for r in sub], dtype=float)
+        pvals = np.asarray([r["dm_centered_pvalue"] for r in sub], dtype=float)
+        verdicts = [r["dm_centered_verdict"] for r in sub]
+        var_ratios = np.asarray(
+            [r["var_ratio_patchtst_over_har_debiased"] for r in sub], dtype=float
+        )
+
+        mean_edge = float(np.nanmean(edges))
+        std_edge = float(np.nanstd(edges)) if len(edges) > 1 else 0.0
+        dm_p_median = float(np.nanmedian(pvals))
+        n_beaten = sum(1 for v in verdicts if "BEATEN" in v)
+        n_beats = sum(1 for v in verdicts if v == "BEATS baseline")
+        n_inconclusive = sum(1 for v in verdicts if v == "INCONCLUSIVE")
+
+        if n_beaten > 0:
+            verdict = "NO BEATS"
+        elif mean_edge >= 2.0 * std_edge and dm_p_median < 0.05:
+            verdict = "BEATS"
+        else:
+            verdict = "INCONCLUSIVE"
+
+        results.append({
+            "horizon": h,
+            "n_seeds": len(sub),
+            "mean_edge_vs_debiased_har_pct": mean_edge,
+            "edge_std_pct": std_edge,
+            "dm_centered_p_median": dm_p_median,
+            "n_beaten": n_beaten,
+            "n_beats": n_beats,
+            "n_inconclusive": n_inconclusive,
+            "mean_var_ratio_patchtst_over_har_debiased": float(np.nanmean(var_ratios)),
+            "mean_patchtst_mse": float(np.nanmean([r["patchtst_mse_logrv"] for r in sub])),
+            "mean_har_debiased_mse": float(
+                np.nanmean([r["har_debiased_mse_logrv"] for r in sub])
+            ),
+            "mean_patchtst_bias": float(np.nanmean([r["patchtst_bias"] for r in sub])),
+            "mean_har_debiased_bias": float(
+                np.nanmean([r["har_debiased_bias"] for r in sub])
+            ),
+            "verdict": verdict,
+        })
+    return results
+
+
+def run_pipeline(
+    rv: pd.Series,
+    *,
+    horizons: list[int],
+    seeds: list[int],
+    seq_len: int = 64,
+    n_splits: int = 5,
+    refit_every: int = 22,
+    calibration_size: int = 60,
+    patch_len: int = 16,
+    stride: int = 8,
+    d_model: int = 64,
+    n_heads: int = 4,
+    n_layers: int = 2,
+    dropout: float = 0.2,
+    fc_dropout: float = 0.2,
+    epochs: int = 30,
+    batch_size: int = 32,
+    lr: float = 5e-4,
+    device: str = "cpu",
+    val_ratio: float = 0.15,
+    out_json: str | Path = DEFAULT_OUT_JSON,
+    coin: str = "BTC-USD",
+    dry_run: bool = False,
+) -> dict:
+    """Full pipeline: HAR (train-only debias) vs walk-forward PatchTST.
+
+    Writes the complete payload (rows with persisted per-combo arrays,
+    per-horizon aggregation, config) to ``out_json`` and returns it.
+    """
+    t0 = time.time()
+    if device == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("ERROR: --device cuda requested but CUDA is not available")
+
+    log_rv = realized_variance_to_log(rv)
+    log_rv_arr = log_rv.values.astype(float)
+    rv_idx = rv.index
+    print(
+        f"[btc_patchtst] {coin}: {len(rv)} RV days, log_rv var={log_rv.var():.4f} "
+        f"(dry_run={dry_run})"
+    )
+
+    rows: list[dict] = []
+    for h in horizons:
+        har_out = run_debiased_har(
+            rv, horizon=h, n_splits=n_splits,
+            refit_every=refit_every, calibration_size=calibration_size,
+        )
+        har_mse = har_out["aggregate_mse_logrv"]
+        print(
+            f"  h={h} debiased HAR MSE={har_mse:.5f} "
+            f"({har_out['n_total_preds']} preds, calibrate_bias=True)"
+        )
+
+        for seed in seeds:
+            ptst_out = walk_forward_patchtst(
+                log_rv_arr, rv_idx,
+                seq_len=seq_len, horizon=h, n_splits=n_splits,
+                patch_len=patch_len, stride=stride, d_model=d_model,
+                n_heads=n_heads, n_layers=n_layers, dropout=dropout,
+                fc_dropout=fc_dropout, epochs=epochs, batch_size=batch_size,
+                lr=lr, seed=seed, device=device, val_ratio=val_ratio,
+            )
+            aligned = align_by_timestamps(
+                ptst_out["forecasts"], ptst_out["targets"],
+                har_out["forecasts"], har_out["targets"],
+            )
+            metrics = evaluate_combo(aligned, horizon=h)
+            if "patchtst_mse_logrv" not in metrics:
+                rows.append({
+                    "coin": coin, "horizon": h, "seed": seed,
+                    "skipped": "insufficient_aligned_obs",
+                })
+                print(f"  h={h} seed={seed} SKIPPED (aligned obs < 10)")
+                continue
+
+            row = {
+                "coin": coin,
+                "horizon": h,
+                "seed": seed,
+                "seq_len": seq_len,
+                "n_splits": n_splits,
+                "epochs": epochs,
+                "device": device,
+                "dry_run": dry_run,
+                "n_rv_days": int(len(rv)),
+                "n_predictions": int(ptst_out["n_total_preds"]),
+                "n_aligned": int(metrics["n_aligned"]),
+                "har_calibrate_bias": True,
+                "har_calibration_size": calibration_size,
+                **metrics,
+                "fold_info": ptst_out["fold_info"],
+                "timestamps": [d.strftime("%Y-%m-%d") for d in aligned["timestamps"]],
+                "predictions": [float(x) for x in aligned["model_pred"]],
+                "targets": [float(x) for x in aligned["model_target"]],
+                "model_errors": [
+                    float(p - t)
+                    for p, t in zip(aligned["model_pred"], aligned["model_target"])
+                ],
+                "har_errors": [
+                    float(p - t)
+                    for p, t in zip(aligned["har_pred"], aligned["har_target"])
+                ],
+                "har_predictions": [float(x) for x in aligned["har_pred"]],
+            }
+            rows.append(row)
+            print(
+                f"  h={h} seed={seed} PatchTST MSE={metrics['patchtst_mse_logrv']:.5f} "
+                f"bias={metrics['patchtst_bias']:+.5f} "
+                f"edge={metrics['edge_vs_debiased_har_pct']:+.2f}% "
+                f"var_ratio={metrics['var_ratio_patchtst_over_har_debiased']:.3f} "
+                f"DM_centered p={metrics['dm_centered_pvalue']:.4f} "
+                f"-> {metrics['dm_centered_verdict']}"
+            )
+
+    aggregated = aggregate_by_horizon(rows)
+    payload = {
+        "rows": rows,
+        "aggregated": aggregated,
+        "elapsed_s": time.time() - t0,
+        "dry_run": dry_run,
+        "config": {
+            "coin": coin,
+            "horizons": horizons,
+            "seeds": seeds,
+            "seq_len": seq_len,
+            "n_splits": n_splits,
+            "refit_every": refit_every,
+            "calibration_size": calibration_size,
+            "patch_len": patch_len,
+            "stride": stride,
+            "d_model": d_model,
+            "n_heads": n_heads,
+            "n_layers": n_layers,
+            "dropout": dropout,
+            "fc_dropout": fc_dropout,
+            "epochs": epochs,
+            "batch_size": batch_size,
+            "lr": lr,
+            "device": device,
+            "val_ratio": val_ratio,
+            "har_debias": "train_tail_calibration (calibrate_bias=True, OOS)",
+            "dm": "centered errors, loss_fn=mse (variance differential)",
+        },
+    }
+
+    out_path = Path(out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, default=str))
+    print(f"\n[done] wrote {out_path}")
+
+    if aggregated:
+        print("\n=== PatchTST vs debiased HAR (BTC) ===")
+        print(pd.DataFrame(aggregated).to_string(index=False))
+        n_beats = sum(1 for r in aggregated if r["verdict"] == "BEATS")
+        n_no = sum(1 for r in aggregated if r["verdict"] == "NO BEATS")
+        n_inc = sum(1 for r in aggregated if r["verdict"] == "INCONCLUSIVE")
+        print(f"\nSummary: {n_beats} BEATS / {n_no} NO BEATS / {n_inc} INCONCLUSIVE")
+
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="PatchTST vs train-only-debiased HAR on BTC daily log-RV "
+                    "(issue #14081)"
+    )
+    parser.add_argument("--horizons", type=int, nargs="+", default=[1, 5, 10])
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 7, 42])
+    parser.add_argument("--seq-len", type=int, default=64)
+    parser.add_argument("--n-splits", type=int, default=5)
+    parser.add_argument("--refit-every", type=int, default=22,
+                        help="HAR mid-fold refit cadence (days)")
+    parser.add_argument("--calibration-size", type=int, default=60,
+                        help="HAR train-tail holdout size for bias calibration")
+    parser.add_argument("--patch-len", type=int, default=16)
+    parser.add_argument("--stride", type=int, default=8)
+    parser.add_argument("--d-model", type=int, default=64)
+    parser.add_argument("--n-heads", type=int, default=4)
+    parser.add_argument("--n-layers", type=int, default=2)
+    parser.add_argument("--dropout", type=float, default=0.2)
+    parser.add_argument("--fc-dropout", type=float, default=0.2)
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr", type=float, default=5e-4)
+    parser.add_argument("--val-ratio", type=float, default=0.15)
+    parser.add_argument("--device", default="cpu", choices=["cpu", "cuda"],
+                        help="CPU by default; cuda must be forced explicitly")
+    parser.add_argument("--out-json", type=str, default=DEFAULT_OUT_JSON)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Deterministic synthetic log-RV, 2 folds, 1 seed, "
+                             "1 horizon, tiny model/epochs, CPU, no download")
+    args = parser.parse_args()
+
+    params = dict(
+        horizons=args.horizons, seeds=args.seeds, seq_len=args.seq_len,
+        n_splits=args.n_splits, refit_every=args.refit_every,
+        calibration_size=args.calibration_size, patch_len=args.patch_len,
+        stride=args.stride, d_model=args.d_model, n_heads=args.n_heads,
+        n_layers=args.n_layers, dropout=args.dropout,
+        fc_dropout=args.fc_dropout, epochs=args.epochs,
+        batch_size=args.batch_size, lr=args.lr, device=args.device,
+        val_ratio=args.val_ratio, out_json=args.out_json,
+    )
+
+    if args.dry_run:
+        print("DRY-RUN: deterministic synthetic log-RV, CPU, tiny model/epochs")
+        for key, value in DRY_RUN_OVERRIDES.items():
+            params[key] = value
+        # Never clobber the real sweep results with a dry-run output.
+        if params["out_json"] == DEFAULT_OUT_JSON:
+            params["out_json"] = str(
+                Path(DEFAULT_OUT_JSON).with_name(
+                    "btc_patchtst_har_debiased_dry_run.json"
+                )
+            )
+        rv = synthetic_rv(n=360, seed=0)
+        params["dry_run"] = True
+    else:
+        rv = load_btc_rv()
+        if len(rv) < 300:
+            raise SystemExit(f"ERROR: only {len(rv)} RV days (need >= 300)")
+        params["dry_run"] = False
+
+    run_pipeline(rv, **params)
+
+    if args.dry_run:
+        print("DRY-RUN complete. Pipeline validated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_btc_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_btc_patchtst.py
@@ -1,0 +1,381 @@
+"""Tests for btc_patchtst.py (issue #14081) -- pure CPU, fast.
+
+Covers:
+- MSE = bias^2 + variance decomposition identity through ``evaluate_combo``.
+- Timestamp alignment (intersection + target-consistency guard).
+- Walk-forward boundaries / expansion and train-only normalisation
+  (no test leakage), including a mutate-the-test-region probe.
+- Genuinely-OOS HAR debias (train-tail calibration untouched by the test
+  region) on the ``run_debiased_har`` wrapper.
+- Aggregation verdicts: BEATS / NO BEATS (dominance) / INCONCLUSIVE.
+- Dry-run end-to-end: full pipeline on synthetic log-RV writes valid JSON.
+
+The real BTC sweep (Bitstamp CSV, 5 folds x 4 seeds x 3 horizons) is NOT
+exercised here -- it is run out-of-band by the coordinator (issue #14081).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from btc_patchtst import (  # noqa: E402
+    aggregate_by_horizon,
+    align_by_timestamps,
+    evaluate_combo,
+    make_expanding_splits,
+    run_debiased_har,
+    run_pipeline,
+    synthetic_rv,
+    train_normalization_stats,
+    walk_forward_patchtst,
+)
+from dlinear_vol import create_sequences  # noqa: E402
+from realized_variance import realized_variance_to_log  # noqa: E402
+
+# Tiny CPU architecture used by every test that trains a model.
+TINY = dict(
+    seq_len=16, patch_len=4, stride=2, d_model=8, n_heads=2, n_layers=1,
+    epochs=2, batch_size=16, lr=5e-4,
+)
+
+
+def _aligned_from_errors(model_errors: np.ndarray, har_errors: np.ndarray) -> dict:
+    """Build an `aligned` payload from crafted error series."""
+    target = np.zeros(len(model_errors))
+    dates = pd.date_range("2020-01-01", periods=len(target), freq="D")
+    return align_by_timestamps(
+        pd.Series(target + model_errors, index=dates),
+        pd.Series(target, index=dates),
+        pd.Series(target + har_errors, index=dates),
+        pd.Series(target, index=dates),
+    )
+
+
+class TestEvaluateComboDecomposition:
+    def test_mse_equals_bias_sq_plus_variance(self):
+        # PatchTST errors: constant +0.5 (pure bias, zero variance).
+        # HAR errors: alternating +/-1 (zero bias, unit variance).
+        model_err = np.full(50, 0.5)
+        har_err = np.tile([-1.0, 1.0], 25)
+
+        out = evaluate_combo(_aligned_from_errors(model_err, har_err), horizon=1)
+
+        assert out["n_aligned"] == 50
+        # Decomposition identity: MSE == bias^2 + variance (exact in float64).
+        assert out["patchtst_mse_logrv"] == pytest.approx(0.25)
+        assert out["patchtst_bias_sq"] + out["patchtst_variance"] == pytest.approx(
+            out["patchtst_mse_logrv"]
+        )
+        assert out["har_debiased_mse_logrv"] == pytest.approx(1.0)
+        assert out["har_debiased_bias_sq"] + out["har_debiased_variance"] == pytest.approx(
+            out["har_debiased_mse_logrv"]
+        )
+        # Signed biases are reported with their sign.
+        assert out["patchtst_bias"] == pytest.approx(0.5)
+        assert out["har_debiased_bias"] == pytest.approx(0.0)
+        assert out["patchtst_variance"] == pytest.approx(0.0)
+        assert out["har_debiased_variance"] == pytest.approx(1.0)
+        # Edge vs debiased HAR: (1.0 - 0.25) / 1.0 = 75%.
+        assert out["edge_vs_debiased_har_pct"] == pytest.approx(75.0)
+        assert out["var_ratio_patchtst_over_har_debiased"] == pytest.approx(0.0)
+
+    def test_insufficient_data_short_circuit(self):
+        out = evaluate_combo(_aligned_from_errors(np.zeros(5), np.zeros(5)), horizon=1)
+        assert out["dm_centered_verdict"] == "INSUFFICIENT_DATA"
+        assert np.isnan(out["edge_vs_debiased_har_pct"])
+
+
+class TestAlignByTimestamps:
+    def test_intersection_on_shared_dates(self):
+        dates = pd.date_range("2020-01-01", periods=12, freq="D")
+        target = pd.Series(np.arange(12.0), index=dates)
+        model_fc = pd.Series(np.arange(10.0) + 0.1, index=dates[:10])
+        har_fc = pd.Series(np.arange(10.0) - 0.2, index=dates[2:])
+
+        out = align_by_timestamps(model_fc, target[:10], har_fc, target[2:])
+
+        assert len(out["timestamps"]) == 8
+        assert out["timestamps"][0] == dates[2]
+        assert out["timestamps"][-1] == dates[9]
+        assert len(out["model_pred"]) == len(out["har_pred"]) == 8
+        np.testing.assert_allclose(out["model_target"], np.arange(2.0, 10.0))
+
+    def test_target_convention_mismatch_raises(self):
+        dates = pd.date_range("2020-01-01", periods=12, freq="D")
+        model_fc = pd.Series(np.zeros(10), index=dates[:10])
+        model_tg = pd.Series(np.zeros(10), index=dates[:10])
+        har_fc = pd.Series(np.zeros(10), index=dates[2:])
+        har_tg = pd.Series(np.ones(10), index=dates[2:])  # diverged convention
+
+        with pytest.raises(ValueError, match="target mismatch"):
+            align_by_timestamps(model_fc, model_tg, har_fc, har_tg)
+
+
+class TestExpandingSplits:
+    def test_boundaries_expanding_and_contiguous(self):
+        splits = make_expanding_splits(300, 5)
+        assert len(splits) == 5
+        train_ends = [s[0] for s in splits]
+        assert train_ends == sorted(train_ends)          # expanding...
+        assert len(set(train_ends)) == 5                 # ...strictly
+        assert train_ends[0] == 300 // 6                 # fold_size = n//(k+1)
+        for train_end, test_start, test_end in splits:
+            assert test_start == train_end               # test starts where train ends
+            assert test_end > test_start                 # non-empty test
+            assert test_end <= 300                       # within the sample
+        assert splits[-1][2] == 300
+
+    def test_dry_run_geometry(self):
+        # Dry-run uses n=360, 2 splits -> folds [120,240) and [240,360).
+        assert make_expanding_splits(360, 2) == [(120, 120, 240), (240, 240, 360)]
+
+
+class TestTrainOnlyNormalization:
+    def test_stats_use_train_slice_only(self):
+        log_rv = np.concatenate([np.ones(100), np.full(100, 10.0)])
+        mean, std = train_normalization_stats(log_rv, 100)
+        assert mean == pytest.approx(1.0)
+        assert std == pytest.approx(1e-6)  # zero std clamped, no NaN
+
+        # Mutating the post-train region cannot move the train stats.
+        log_rv[100:] = -999.0
+        mean2, std2 = train_normalization_stats(log_rv, 100)
+        assert (mean2, std2) == (mean, std)
+
+        # Full-array stats DO see the tail (sanity of the probe above).
+        mean_full, _ = train_normalization_stats(log_rv, 200)
+        assert mean_full == pytest.approx((100 * 1.0 + 100 * -999.0) / 200)
+
+
+class TestSequenceWindowsNoLeakage:
+    def test_training_targets_end_within_train_region(self):
+        arr = np.arange(50.0)
+        seq_len, horizon, train_end = 5, 3, 20
+        x_all, y_all = create_sequences(arr, seq_len, horizon)
+        n_train = train_end - seq_len - horizon + 1
+        x_train, y_train = x_all[:n_train], y_all[:n_train]
+
+        # Window definition: x[j] = arr[j:j+seq_len], y[j] = arr[j+seq_len:j+seq_len+h).
+        np.testing.assert_array_equal(x_train[0], arr[0:5])
+        np.testing.assert_array_equal(y_train[0], arr[5:8])
+        # Last training target ends at index train_end - 1 (strictly inside train).
+        np.testing.assert_array_equal(y_train[-1], arr[17:20])
+        assert (n_train - 1) + seq_len + horizon == train_end
+        # No training sample ever touches arr[train_end:].
+        assert x_train.shape == (n_train, seq_len)
+        assert y_train.shape == (n_train, horizon)
+
+
+class TestWalkForwardPatchtst:
+    def _run(self, log_rv: np.ndarray, seed: int = 0):
+        return walk_forward_patchtst(
+            log_rv,
+            pd.date_range("2021-01-01", periods=len(log_rv), freq="D"),
+            horizon=1, n_splits=2, seed=seed, device="cpu", **TINY,
+        )
+
+    def test_fold_boundaries_and_prediction_count(self):
+        rv = synthetic_rv(n=360, seed=0)
+        log_rv = realized_variance_to_log(rv).values.astype(float)
+        out = self._run(log_rv)
+
+        active = [f for f in out["fold_info"] if "skipped" not in f]
+        assert len(active) == 2
+        assert [(f["train_end"], f["test_start"], f["test_end"]) for f in active] == [
+            (120, 120, 240), (240, 240, 360),
+        ]
+        # One prediction per test day minus the horizon tail, per fold.
+        assert out["n_total_preds"] == (240 - 120 - 1) + (360 - 240 - 1)
+
+    def test_normalization_recorded_from_train_slice_only(self):
+        rv = synthetic_rv(n=360, seed=0)
+        log_rv = realized_variance_to_log(rv).values.astype(float)
+        out = self._run(log_rv)
+
+        for f in out["fold_info"]:
+            if "skipped" in f:
+                continue
+            expected = train_normalization_stats(log_rv, f["train_end"])
+            assert f["train_mean"] == pytest.approx(expected[0])
+            assert f["train_std"] == pytest.approx(expected[1])
+
+    def test_mutating_test_region_leaves_fold0_training_untouched(self):
+        """Direct leakage probe: fold 0 trains on [0,120) only."""
+        rv = synthetic_rv(n=360, seed=0)
+        log_rv = realized_variance_to_log(rv).values.astype(float)
+        base = self._run(log_rv)
+
+        mutated = log_rv.copy()
+        mutated[120:] += 5.0  # distort everything after fold-0's train window
+        changed = self._run(mutated)
+
+        base_f0 = next(f for f in base["fold_info"] if f.get("fold") == 0)
+        changed_f0 = next(f for f in changed["fold_info"] if f.get("fold") == 0)
+        # Fold-0 train stats (and val-selected training) see only [0,120).
+        assert changed_f0["train_mean"] == pytest.approx(base_f0["train_mean"])
+        assert changed_f0["train_std"] == pytest.approx(base_f0["train_std"])
+        assert changed_f0["best_val_loss"] == pytest.approx(base_f0["best_val_loss"])
+        # Fold-1 train window includes the mutated region -> stats must move.
+        base_f1 = next(f for f in base["fold_info"] if f.get("fold") == 1)
+        changed_f1 = next(f for f in changed["fold_info"] if f.get("fold") == 1)
+        assert changed_f1["train_mean"] != pytest.approx(base_f1["train_mean"])
+
+    def test_targets_follow_forecast_dates(self):
+        rv = synthetic_rv(n=360, seed=0)
+        log_rv = realized_variance_to_log(rv).values.astype(float)
+        idx = pd.date_range("2021-01-01", periods=360, freq="D")
+        out = walk_forward_patchtst(
+            log_rv, idx, horizon=1, n_splits=2, seed=0, device="cpu", **TINY,
+        )
+        positions = idx.get_indexer(out["targets"].index)
+        # horizon=1: target of a forecast dated t is exactly log_rv[t].
+        np.testing.assert_allclose(out["targets"].values, log_rv[positions])
+
+
+class TestDebiasedHarIsOos:
+    def test_calibration_ignores_test_region(self):
+        rv = synthetic_rv(n=420, seed=7)
+        base = run_debiased_har(rv, horizon=1, n_splits=4, refit_every=22,
+                                calibration_size=45)
+
+        mutated = rv.copy()
+        first_test_start = 420 // 5
+        mutated.iloc[first_test_start:] *= np.exp(2.0)
+        changed = run_debiased_har(mutated, horizon=1, n_splits=4, refit_every=22,
+                                   calibration_size=45)
+
+        assert base["calibrate_bias"] is True
+        base_biases = base["initial_calibration_bias_by_fold"]
+        changed_biases = changed["initial_calibration_bias_by_fold"]
+        assert len(base_biases) == 4
+        # The debias constant of fold 0 is estimated on train history only:
+        # rescaling the test region cannot move it.
+        assert base_biases[0] == pytest.approx(changed_biases[0])
+        # ...while the test-support MSE obviously changes (probe sanity).
+        assert base["aggregate_mse_logrv"] != pytest.approx(
+            changed["aggregate_mse_logrv"]
+        )
+
+
+def _combo_rows(verdicts: list[str], edges: list[float], p: float = 0.01,
+                horizon: int = 1) -> list[dict]:
+    return [
+        {
+            "horizon": horizon,
+            "seed": seed,
+            "edge_vs_debiased_har_pct": edge,
+            "dm_centered_pvalue": p,
+            "dm_centered_verdict": verdict,
+            "var_ratio_patchtst_over_har_debiased": 0.9,
+            "patchtst_mse_logrv": 1.0,
+            "har_debiased_mse_logrv": 1.1,
+            "patchtst_bias": 0.0,
+            "har_debiased_bias": 0.0,
+        }
+        for seed, verdict, edge in zip((0, 1, 7, 42), verdicts, edges)
+    ]
+
+
+class TestAggregateVerdicts:
+    def test_beats_requires_edge_and_significance(self):
+        rows = _combo_rows(["BEATS baseline"] * 4, [10.0] * 4)
+        agg = aggregate_by_horizon(rows)[0]
+        assert agg["mean_edge_vs_debiased_har_pct"] == pytest.approx(10.0)
+        assert agg["edge_std_pct"] == pytest.approx(0.0)
+        assert agg["dm_centered_p_median"] < 0.05
+        assert agg["n_beats"] == 4
+        assert agg["verdict"] == "BEATS"
+
+    def test_any_beaten_seed_dominates_to_no_beats(self):
+        rows = _combo_rows(
+            ["BEATS baseline", "BEATS baseline", "BEATS baseline",
+             "BEATEN BY baseline"],
+            [10.0, 10.0, 10.0, 10.0],
+        )
+        agg = aggregate_by_horizon(rows)[0]
+        assert agg["n_beaten"] == 1
+        assert agg["n_beats"] == 3
+        # Dominance: one BEATEN seed vetoes BEATS even with a strong mean edge.
+        assert agg["verdict"] == "NO BEATS"
+
+    def test_all_beaten_is_no_beats(self):
+        rows = _combo_rows(["BEATEN BY baseline"] * 4, [-10.0] * 4)
+        agg = aggregate_by_horizon(rows)[0]
+        assert agg["verdict"] == "NO BEATS"
+
+    def test_edge_below_two_sigma_is_inconclusive(self):
+        # mean=10, std=20 -> 10 < 2*20 despite p=0.01.
+        rows = _combo_rows(["BEATS baseline"] * 4, [30.0, -10.0, 30.0, -10.0])
+        agg = aggregate_by_horizon(rows)[0]
+        assert agg["edge_std_pct"] == pytest.approx(20.0)
+        assert agg["verdict"] == "INCONCLUSIVE"
+
+    def test_high_dm_p_is_inconclusive(self):
+        rows = _combo_rows(["BEATS baseline"] * 4, [10.0] * 4, p=0.5)
+        agg = aggregate_by_horizon(rows)[0]
+        assert agg["dm_centered_p_median"] == pytest.approx(0.5)
+        assert agg["verdict"] == "INCONCLUSIVE"
+
+    def test_grouped_by_horizon(self):
+        rows = (
+            _combo_rows(["BEATS baseline"] * 4, [10.0] * 4, horizon=1)
+            + _combo_rows(["BEATEN BY baseline"] * 4, [10.0] * 4, horizon=5)
+        )
+        aggs = aggregate_by_horizon(rows)
+        assert [a["horizon"] for a in aggs] == [1, 5]
+        assert aggs[0]["verdict"] == "BEATS"
+        assert aggs[1]["verdict"] == "NO BEATS"
+
+
+class TestDryRunEndToEnd:
+    def test_full_pipeline_writes_json(self, tmp_path):
+        out_json = tmp_path / "dry_run.json"
+        payload = run_pipeline(
+            synthetic_rv(n=360, seed=0),
+            horizons=[1],
+            seeds=[0],
+            n_splits=2,
+            refit_every=22,
+            calibration_size=60,
+            device="cpu",
+            out_json=out_json,
+            dry_run=True,
+            **TINY,
+        )
+
+        assert out_json.exists()
+        on_disk = json.loads(out_json.read_text())
+        assert on_disk["dry_run"] is True
+        assert payload["dry_run"] is True
+
+        rows = on_disk["rows"]
+        assert len(rows) == 1  # 1 horizon x 1 seed
+        row = rows[0]
+        # Requirement #14081: per-combo arrays persisted and consistent.
+        for key in ("model_errors", "har_errors", "predictions", "targets",
+                    "timestamps"):
+            assert key in row
+            assert len(row[key]) == row["n_aligned"] >= 10
+        for pred, target, err in zip(
+            row["predictions"], row["targets"], row["model_errors"]
+        ):
+            assert err == pytest.approx(pred - target)
+        assert row["har_calibrate_bias"] is True
+        # Decomposition identity holds on the persisted errors.
+        errors = np.asarray(row["model_errors"])
+        bias_sq = float(np.mean(errors)) ** 2
+        variance = float(np.var(errors))
+        assert bias_sq + variance == pytest.approx(row["patchtst_mse_logrv"])
+
+        aggregated = on_disk["aggregated"]
+        assert len(aggregated) == 1
+        assert aggregated[0]["horizon"] == 1
+        assert aggregated[0]["verdict"] in ("BEATS", "NO BEATS", "INCONCLUSIVE")
+        assert on_disk["config"]["har_debias"].startswith("train_tail_calibration")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_patchtst.py
@@ -1,5 +1,6 @@
 """Tests for train_patchtst.py — CPU-only smoke tests."""
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -15,6 +16,19 @@ from train_patchtst import (
     build_sequences,
     normalize_sequences,
 )
+
+
+def test_cli_help_has_no_argument_conflicts():
+    """The PatchTST CLI must construct its parser before any training starts."""
+    script = Path(__file__).resolve().parent.parent / "train_patchtst.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--device" in result.stdout
 
 
 class TestPatchTSTModel:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -416,7 +416,6 @@ def main():
         "--indicators", nargs="+", default=None,
         help="Specific indicators to use (overrides --advanced)",
     )
-    parser.add_argument("--device", default=None, help="Force device (cpu/cuda)")
     args = parser.parse_args()
 
     # Seeds


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2025:CoursIA — prev: DEEP/qc #14068

## Summary

- add a dedicated BTC log-RV PatchTST walk-forward harness against a genuinely train-only-debiased HAR baseline;
- persist timestamp-aligned predictions/errors and report centered-MSE DM plus bias/variance decomposition;
- repair the existing PatchTST CLI startup (`--device` was registered twice) and guard it with a subprocess test;
- record the complete CPU measurement in `REGISTRY.md` with an honest verdict.

## Protocol

- Data: Bitstamp BTC/USD hourly CSV, SHA-256 `38a4e973955cf9f8527c3096931aa958bfae09580737c909450504b21502c573`, 2,278 daily realized-variance observations (2018-05-15 → 2024-08-08).
- Target: mean future log-RV at horizons 1/5/10.
- Walk-forward: 5 expanding folds; seeds 0/1/7/42; one PatchTST per fold/seed.
- PatchTST: seq_len 64, patch 16, stride 8, d_model 32, 4 heads, 1 layer, 10 epochs, CPU.
- Baseline: HAR with signed bias calibrated only on a pre-test training-tail holdout (`calibrate_bias=True`), never from the current test support.
- Decision leg: centered-error DM with `loss_fn="mse"`, plus `MSE = bias² + variance` and `var_ratio_patchtst_over_har_debiased`.
- Verdict: any seed `BEATEN` → NO BEATS; otherwise BEATS only when edge ≥ 2σ and median DM p < 0.05.

## Real CPU result

The complete matrix finished in 115.9 seconds on CPU: 12/12 horizon×seed combinations, each with five expanding folds.

| Horizon | Mean edge vs debiased HAR | Cross-seed σ | Centered-DM median p | Mean variance ratio | Seeds BEATEN | Verdict |
|---|---:|---:|---:|---:|---:|---|
| h=1 | −4.23% | 1.32 pt | 0.3128 | 1.041 | 0/4 | **INCONCLUSIVE** |
| h=5 | −16.35% | 2.38 pt | 0.0366 | 1.159 | 3/4 | **NO BEATS** |
| h=10 | −22.86% | 2.76 pt | 0.0253 | 1.220 | 4/4 | **NO BEATS** |

PatchTST does not beat the train-only-debiased HAR. h=1 is not statistically separated (4/4 seed-level DM verdicts inconclusive); h=5 and h=10 are less precise, with variance ratios above one and significant baseline wins. This is a forecast-only verdict: no trading strategy or after-cost performance claim is made.

Post-hoc verification recalculated MSE and `bias² + variance` from every persisted error series; all 12 rows matched. Per-seed aligned supports contain 1,890 / 1,870 / 1,845 observations for h=1/5/10.

## Validation

- `python MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_training_package.py --verbose`
  - PASS: all package checks and four canonical CPU dry-runs.
- `python -m pytest MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests -q`
  - baseline before new tests: 1,053 passed, 1 skipped.
- targeted integrated tests: 32 passed.
- existing `train_patchtst.py --dry-run --device cpu`: PASS after Stop & Repair; 635,032 parameters, 2 epochs, real CLI/output path.
- new `btc_patchtst.py --dry-run`: PASS; full pipeline and JSON persistence exercised on deterministic synthetic log-RV; smoke verdict NO BEATS (not a performance claim).

## Scope

Four source/test files plus the measured registry entry. No notebook, catalogue, generated result, checkpoint, or dataset committed.

Closes #14081
See #1454



---

**Note de provenance (ai-01).** Cette PR est la forme *same-repo* de #14085, au **SHA identique** `f2fe9ece`. po-2025 avait dû passer par le fork `jsboigeEpita` parce que `gh pr create` refusait sous leur compte (`must be a collaborator`) — sans jamais faire de `gh auth switch`, conformément à leur règle. La branche était déjà poussée sur ce dépôt, donc la PR same-repo est strictement préférable : la suite de checks tourne **nativement**, sans les 7 suites `action_required` quune