### PR TITLE
docs(qc,#11698): deliver qc-research sub-issue template (phase 1)

### DIFF
--- a/docs/qc-research-issue-template.md
+++ b/docs/qc-research-issue-template.md
@@ -1,0 +1,51 @@
+# Template de sous-issue QC-research (EPIC #11698)
+
+Une sous-issue par article évalué. Titre : `[QC-research] <titre de l'article> (<#id article>)`.
+Label : `quantconnect-research`. Copier le squelette ci-dessous dans le body.
+
+Précédents d'usage : #13892 (dual VIX #21143, verdict CONSOLIDATION), #14091
+(corrélation hedge #21050, verdict CONSOLIDATION).
+
+```markdown
+## Article source
+- URL : https://www.quantconnect.com/research/<id>/<slug>/
+- Auteur(s) : [auteur(s) affiché(s) — ne jamais cru sans vérifier]
+- Catégorie putative : [alpha / framework / ML / RL / factor / vol / risk / pedagogy]
+- Date de publication : [AAAA-MM-JJ]
+
+## Lecture analytique
+
+### Ce que l'article annonce
+[paraphrase en 3-5 lignes]
+
+### Sources primaires citées / à vérifier
+- [papier arXiv / SSRN / manuel de référence]
+- [variance entre l'article et la source]
+
+### Différenciation vs bouquet existant
+- Filtre : `docs/qc/qc-strategies-status.md` (livré #1621 phase 5)
+- Projets voisins : [lister 1-3 projets existants qui touchent le même angle]
+- **L'article est-il redondant ?** OUI / NON / PARTIELLEMENT [+ justification]
+
+## Verdict
+
+- [ ] **CONSOLIDATION** — un projet existant est enrichi/remplacé. PR GitHub associée.
+- [ ] **PÉDAGOGIQUE** — l'article documente un concept à intégrer dans un cours existant. Notebook à modifier : [chemin]. Pas de nouveau notebook.
+- [ ] **NOUVEAU** — aucun équivalent valable, création justifiée. Justification détaillée obligatoire.
+- [ ] **IGNORE** — l'article n'apporte rien de distinctif/qualité limitée. Justification explicite.
+
+## Acceptance locale
+- [ ] Article lu en entier
+- [ ] Voisinage `docs/qc/qc-strategies-status.md` re-vérifié
+- [ ] Sources primaires identifiées (≥1)
+- [ ] Verdict coché avec justification
+- [ ] PR ou commentaire GH associé si verdict CONSOLIDATION/PÉDAGOGIQUE/NOUVEAU
+```
+
+Rappels de discipline (détaillés dans le body de l'EPIC #11698) :
+
+- **Claim** : `[CLAIMED] lane <machine:workspace> — <article>` sur la sous-issue avant d'éditer.
+- **Cap** : 2 articles/jour max par lane.
+- **Grain** : première ligne `Grain: <TIER>/qc — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR>` (protocole de variation).
+- **Backtest obligatoire** (règle G) pour toute PR issue d'un verdict CONSOLIDATION/NOUVEAU touchant `projects/` : Sharpe/CAGR/MaxDD dans le body, fenêtre OOS distincte du training.
+- Un verdict IGNORE n'ouvre PAS de PR — verdict sur l'issue seulement.


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: MED/qc #14095

## Summary

Livre le fichier `docs/qc-research-issue-template.md` — item 1 de la phase 1 de l'EPIC #11698. Le format était spécifié dans le body de l'EPIC mais jamais livré en fichier : les deux sous-issues ouvertes à ce jour (#13892, #14091) ont dû inliner le squelette à la main. Ce fichier en fait la forme durable, avec :

- le squelette exact du body de l'EPIC (article source / lecture analytique / différenciation / verdict 4 cases / acceptance locale),
- les précédents d'usage (#13892 dual VIX, #14091 corrélation hedge),
- les rappels de discipline : `[CLAIMED]` avant édition, cap 2 articles/jour/lane, première ligne `Grain:` (protocole de variation), backtest règle G pour toute PR touchant `projects/`, verdict IGNORE = pas de PR.

51 lignes ajoutées, aucun autre fichier touché. See #11698 (contribution partielle à la phase 1, l'EPIC reste ouverte — la vague de 5-10 sous-issues pilote reste à ouvrir par ai-01).
