### PR TITLE
feat(vibe,#14114): picker calibré et relais humain

### DIFF
--- a/.vibe/AGENTS.md
+++ b/.vibe/AGENTS.md
@@ -3,7 +3,8 @@
 
 **Workspace:** CoursIA  
 **Machine:** myia-po-2025  
-**Role:** Worker agent (30min cycles, aligned sur scheduler myia-ai-01)  
+**Lane canonique:** myia-po-2025:Microsoft VS Code
+**Role:** Worker autonome a cadence 4 h, livrables en relais humain (jamais de push/PR autonome)
 **Commande:** `.vibe/commands/continue.md`  
 **Config locale:** `.vibe/config.toml` (override global si besoin)  
 
@@ -36,28 +37,38 @@ D:\dev\CoursIA\.vibe\
 
 ## Commande Worker : `.vibe/commands/continue.md`
 
-### Workflow (30 min max)
+### Cadence : feeder 4 h, probe `--wake` 1 h
+
+- Le **feeder externe**, arme toutes les 4 h, envoie le payload de travail.
+- La **schtask horaire** reste un probe `--wake` : no-op tant qu'aucun payload n'est en attente.
+- Ce prompt ne s'exécute que lorsque le feeder/wake fournit un payload — aucun arbitrage de cadence in-prompt.
+
+### Workflow d'un payload
 
 **Phase 1 : Contexte**
 1. roosync_messages(action:"inbox", status:"unread")
 2. roosync_dashboard(action:"read", type:"workspace", section:"all")
-3. Filtrer par machine:myia-po-2025
-4. git checkout main && git pull --ff-only
+3. Filtrer par lane : myia-po-2025:Microsoft VS Code
+4. git fetch origin main ; travail en worktree isole `feature/<sujet>` depuis origin/main
 
-**Phase 2 : Priorisation**
-- P0 : Missions coordinateur HIGH/URGENT
-- P1 : Taches [CLAIMED] par myia-po-2025
-- P2 : Pool global -> Poser [CLAIMED] <#N> -- <machine:myia-po-2025> <ts>
+**Phase 2 : Selection — le picker d'abord (P0 inclus)**
+- **Premier geste de selection : le picker calibre**, apres lecture inbox/dashboard — jamais de scan manuel du pool avant lui :
+  `python scripts/pick_idle_grain.py --lane "myia-po-2025:Microsoft VS Code" --prev-genre <genre> --json`
+  (verification des claims active ; `--no-check-claims` interdit)
+- Sortie `"mode": "repair"` : **P0** — le picker retourne le backlog rouge/review de la lane ; la reparation de la PR nommee EST le grain du cycle, preparee en relais humain comme tout livrable Vibe.
+- Sinon : filtrer les candidats selon le **profil Vibe** : mono-sujet, CPU/local, verifiable textuellement. Exclus : GPU/vision, QuantConnect, Lean froid, notebooks a re-executer, travail relationnel/multi-fichiers, catalogue (enumeration des PRs de la lane via le tag `Grain:` du body, jamais `--author @me` : faux 0 silencieux sur cette machine multi-comptes).
+- Avant d'editer : `check_lane_claim.py --lane "myia-po-2025:Microsoft VS Code" <N>`, puis `[CLAIMED]` en commentaire d'issue (tag `Grain:` et clause `paths:` sur deux lignes distinctes).
 
 **Phase 3 : Execution**
-- 1 sujet = 1 PR, catalogue byte-identique
-- Notebooks : C.1/C.2/H.3
-- Toujours SOTA, jamais workaround (regle F)
+- 1 sujet = 1 livrable, catalogue byte-identique a main
+- Outils SOTA, jamais workaround (regle F) ; env casse : diagnostiquer et relayer
+- Commit LOCAL uniquement (branche `feature/<sujet>`, message conventionnel) — JAMAIS de push
 
-**Phase 4 : Rapport**
-1. Commit + PR AVANT [DONE]
-2. [DONE] <machine:myia-po-2025> <resume> -- PR#<N> -- grade: <A/B/C>
-3. [ASK USER] separe si bloqueur
+**Phase 4 : Rapport + relais humain**
+1. Commit local AVANT tout rapport
+2. `[REVIEW-NEEDED]` sur le dashboard : branche, commit, fichiers, resume du diff, preuves, tests, tag `Grain:` propose — l'humain relit puis pousse / ouvre la PR
+3. `[DONE] myia-po-2025:Microsoft VS Code <resume> -- branche <nom> -- grade: <A/B/C>`
+4. `[ASK USER]` separe si bloqueur
 
 ---
 
@@ -72,17 +83,18 @@ G:/Mon Drive/Synchronisation/RooSync/.shared-state/dashboards/workspace-roo-exte
 
 ### Commande git/gh
 ```bash
-gh issue list --state open --json number,title,labels
-gh pr list --state open --author @me
+gh issue list --state open --limit 100 --json number,title,labels
+# PRs ouvertes de la lane, via le tag Grain: du body (jamais --author @me)
+gh pr list --state open --limit 100 --json number,title,body --jq '.[] | select(.body != null and (.body | contains("myia-po-2025:Microsoft VS Code"))) | "#\(.number) \(.title)"'
 ```
 
 ---
 
 ## Scheduler
 
-- Frequence : 30 min (staggered)
-- Alignment : scheduler myia-ai-01 (schtasks)
-- Commande : `vibe --prompt .vibe/commands/continue.md --timeout 1800 --agent auto-approve`
+- **Feeder externe** : arme toutes les 4 h, il envoie le payload de travail.
+- **Schtask horaire** : probe `--wake`, no-op tant qu'aucun payload n'est en attente.
+- Le prompt `.vibe/commands/continue.md` ne s'exécute que sur payload fourni par le feeder/wake — aucun arbitrage de cadence in-prompt.
 
 ---
 
@@ -91,8 +103,9 @@ gh pr list --state open --author @me
 1. Pas de session persistante -> etablir contexte depuis dashboard
 2. CLI non-interactif -> checkpoints frequents dans dashboard
 3. mistral-medium-3.5 -> utiliser bash pour execution code
-4. Timeout a 27 min : commit [WIP] + [DONE-PARTIAL]
+4. Echeance a ~25 min : cloturer (commit local + [REVIEW-NEEDED] + [DONE]), jamais de travail non commite a l'echeance
 5. MCP stdio fonctionne -> utiliser noms complets: roo-state-manager_*
+6. Push et ouverture de PR ne sont JAMAIS autonomes : relais humain [REVIEW-NEEDED]
 
 ---
 
@@ -102,8 +115,12 @@ gh pr list --state open --author @me
 # Lire dashboard
 roosync_dashboard(action: "read", type: "workspace", section: "all")
 
-# Poster message
-roosync_dashboard(action: "append", type: "workspace", tags: ["DONE"], content: "[DONE] myia-po-2025: PR #12345 -- grade: A")
+# Poster un livrable en relais humain
+roosync_dashboard(action: "append", type: "workspace", tags: ["ASK"],
+  content: "[REVIEW-NEEDED] myia-po-2025:Microsoft VS Code -- issue #N : branche feature/<sujet>, commit <SHA>, diff/preuves/tests ci-dessous")
+
+# Poster la fin de payload
+roosync_dashboard(action: "append", type: "workspace", tags: ["DONE"], content: "[DONE] myia-po-2025:Microsoft VS Code : <resume> -- branche feature/<sujet> -- grade: A")
 
 # Chercher
 roosync_search(query: "fix main red", limit: 10)
@@ -127,6 +144,7 @@ roosync_search(query: "fix main red", limit: 10)
 |------|--------|-----|
 | 2026-08-20 | Creation + correction MCP | jsboige + Mistral Vibe |
 | 2026-08-20 | Annonce dans 3 dashboards | Mistral Vibe |
+| 2026-09-01 | Alignement #14114 : picker calibre en premier geste de selection (P0 rouge/review via mode repair), relais humain [REVIEW-NEEDED] (plus de push/PR autonome), cadence feeder 4 h / probe `--wake` 1 h, retrait de `--author @me` | jsboige + Claude Code |
 
 ---
 

--- a/.vibe/commands/continue.md
+++ b/.vibe/commands/continue.md
@@ -55,7 +55,7 @@ python scripts/pick_idle_grain.py --lane "myia-po-2025:Microsoft VS Code" --prev
   ```bash
   gh pr list --state merged --limit 50 --json body,mergedAt --jq '[.[] | select(.body != null and (.body | contains("myia-po-2025:Microsoft VS Code"))) | {m: .mergedAt, g: (.body | capture("(?m)^Grain:[ \t]*[A-Z]+/(?<g>[a-z-]+)").g // "?")}] | sort_by(.m) | last | if . == null then "(aucun)" else .g end'
   ```
-  Reponse `(aucun)` -> omettre le drapeau.
+  Réponse `(aucun)` ou `?` -> omettre le drapeau : `?` signifie que la lane a été trouvée, mais que son tag `Grain:` n'a pas fourni de genre capturable.
 
 **Interpretation de la sortie JSON :**
 

--- a/.vibe/commands/continue.md
+++ b/.vibe/commands/continue.md
@@ -1,14 +1,25 @@
 # Continue - Cycle worker Mistral Vibe (mistral-medium-3.5)
 
-**Lane:** myia-po-2025 (detectee via hostname)  
+**Lane:** myia-po-2025:Microsoft VS Code (canonique, machine:workspace)
 **Workspace:** D:\dev\CoursIA  
 **Modele:** mistral-medium-3.5  
-**Frequence:** 30 min (staggered, aligne sur scheduler myia-ai-01)  
+**Cadence:** feeder externe armé toutes les 4 h envoie le payload ; schtask horaire = probe `--wake` no-op sans payload. Ce prompt ne s'exécute que sur payload.
 **Config MCP:** `~/.vibe/config.toml` (TOML, Vibe 3.5+) + `.vibe/config.toml` (local override)
 
 ---
 
-## Protocole OBLIGATOIRE (identique a Claude Code)
+## Interdits absolus (HARD, avant tout le reste)
+
+| Interdit | Pourquoi | Remplacement |
+|-----------|----------|--------------|
+| `git push`, `gh pr create`, `gh pr merge`, `gh pr close` | Aucun push ni PR autonome : relais humain explicite | Post [REVIEW-NEEDED] sur le dashboard (Phase 4) |
+| `gh ... --author @me` | `@me` suit le compte keyring actif (4 comptes sur cette machine) : faux 0 silencieux qui fait croire la file vide | Enumeration des PRs de la lane par tag `Grain:` (Raccourcis) |
+| `gh pr review`, arbitrages sur d'autres lanes | Decisions relationnelles = humain / coordinateur, jamais Vibe | Signaler sur le dashboard |
+| Regenerer le catalogue, push direct sur main, force push | Regles depot (catalog-pr-hygiene, git-workflow) | Laisser le cron / la CI |
+
+---
+
+## Protocole OBLIGATOIRE (aligne sur les regles cluster : CLAUDE.md + .claude/rules/)
 
 ### Phase 1 : Contexte (30s)
 
@@ -18,49 +29,91 @@
 
 2. **Dashboard workspace** :
    `roo-state-manager_roosync_dashboard(action:"read", type:"workspace", section:"all")`
-   -> Chercher `[DISPATCH->inbox]` et `steers` pour `machine:myia-po-2025`.
+   -> Chercher `[DISPATCH->inbox]` et `steers` pour `myia-po-2025:Microsoft VS Code`.
 
-3. **Filtre lane** : Ne traiter que messages adresses a cette lane/machine.
+3. **Filtre lane** : ne traiter que les messages adresses a cette lane / machine.
 
 4. **Git** :
    ```bash
-   git checkout main && git pull --ff-only
+   git fetch origin main
    git status
    ```
-   -> Si arbre sale (WIP autrui) : worktree isole
-   `git worktree add ../CoursIA-<sujet> -b feature/<sujet> origin/main`
+   -> Travail TOUJOURS en worktree isole depuis une base fraiche :
+   `git worktree add ../CoursIA-vibe-<sujet> -b feature/<sujet> origin/main`
+   (jamais de travail sur un arbre partage ; la branche reste LOCALE, voir Interdits).
 
----
+### Phase 2 : Selection — le picker d'abord (P0 inclus)
 
-### Phase 2 : Priorisation
+**Premier geste de selection : le picker calibre** — apres la lecture inbox/dashboard (Phase 1), jamais de scan manuel du pool avant lui :
 
-**P0** : Missions coordinateur HIGH/URGENT (DM ou dashboard)  
-**P1** : Taches `[CLAIMED]` par `myia-po-2025` non terminees  
-**P2** : Pool global (`gh issue list --state open` cross-lane)  
-   -> Poser `[CLAIMED] <#N> -- <machine:myia-po-2025> <ts>` AVANT de commencer
+```bash
+python scripts/pick_idle_grain.py --lane "myia-po-2025:Microsoft VS Code" --prev-genre <genre precedent> --json
+```
 
-> **Regle** : >=1 PR/wakeup = PLANCHER. "Rien a faire" avec >0 issues = echec.
+- La verification des claims est active sur ce tirage ; `--no-check-claims` est interdit.
+- `--prev-genre` = genre du grain precedent de la lane, lu sur le tag `Grain:` de sa derniere PR mergee :
+  ```bash
+  gh pr list --state merged --limit 50 --json body,mergedAt --jq '[.[] | select(.body != null and (.body | contains("myia-po-2025:Microsoft VS Code"))) | {m: .mergedAt, g: (.body | capture("(?m)^Grain:[ \t]*[A-Z]+/(?<g>[a-z-]+)").g // "?")}] | sort_by(.m) | last | if . == null then "(aucun)" else .g end'
+  ```
+  Reponse `(aucun)` -> omettre le drapeau.
 
----
+**Interpretation de la sortie JSON :**
 
-### Phase 3 : Execution
+- `"mode": "repair"` + `"assignment": "reparer-son-rouge"` -> **P0** : le picker retourne le backlog rouge/review de la lane. Le grain du cycle EST la reparation de la PR nommee dans `grain` (points de review d'abord : `python scripts/check_unaddressed_nits.py <N>`). La reparation se prepare comme tout livrable Vibe : branche locale + commit + [REVIEW-NEEDED] (jamais de push direct sur la branche de la PR). Tant qu'il reste une PR a reprendre, pas de nouveau grain.
+- Sinon -> tirage de candidats. Filtrer selon le **profil Vibe** (Phase 3). Aucun candidat compatible -> `--reroll 1` ; toujours aucun -> post [ASK] sur le dashboard en demandant un steering compatible profil Vibe. Ne JAMAIS claimer un grain hors profil.
 
-- **PR** : 1 sujet = 1 PR. Catalogue byte-identique a main.
-  `Closes #N` si issue resolue, sinon `See #N`.
-- **Notebooks** : C.1 (pas d'erreur), C.2 (commit AVEC outputs), H.3 (pre-commit).
-- **Outils** : Toujours SOTA, jamais workaround degrade (regle F).
-- **Env casse** : Reparer, pas contourner.
-- **Skills** : Uniquement si delegation explicite.
+**P1** : steering coordinateur nomme (DM / dashboard) — prime sur le tirage quand il existe ET est compatible profil.
+**P2** : candidat retenu du tirage.
 
----
+**Avant d'EDITER (verrou anti-collision)** :
 
-### Phase 4 : Rapport OBLIGATOIRE (avant timeout)
+```bash
+python scripts/check_lane_claim.py --lane "myia-po-2025:Microsoft VS Code" <N>
+```
 
-1. **Commit + PR AVANT le rapport** -- jamais de [DONE] sur travail non commite.
-2. **Dashboard** :
-   `[DONE] <machine:myia-po-2025> <resume> -- PR#<N> -- grade: <A/B/C>`
-3. **Bloqueurs** : Tag `[ASK USER]` **separe** du [DONE]. Repeter a CHAQUE fin.
-4. **DM coordinateur** : Repondre si mission traitee.
+Puis poser le claim sur l'issue en commentaire DEUX LIGNES (le tag `Grain:` sur SA ligne, la clause `paths:` sur la sienne) :
+
+```
+[CLAIMED] lane myia-po-2025:Microsoft VS Code -- paths: <globs>
+Grain: <TIER>/<GENRE> -- lane myia-po-2025:Microsoft VS Code -- prev: <TIER>/<GENRE> #<PR precedente ou none>
+```
+
+Pas de timestamp redige dans le corps : le `createdAt` serveur fait foi. Un `[CLAIMED]` d'une autre lane actif sur ces paths -> piocher ailleurs.
+
+### Phase 3 : Execution — profil Vibe borne
+
+**Profil ADMIS** : grain mono-sujet, borne, CPU/local, verifiable par commandes textuelles (un seul domaine, un livrable).
+
+**Profil EXCLU** (ne pas claimer, meme si tire) :
+- GPU, generation, forward pass, QA visuel (vision)
+- QuantConnect (backtests, QC Cloud)
+- Lean froid (lake non chaud, build WSL lourd)
+- Notebooks a re-executer (la regle C.2 exige la re-execution apres edition : hors profil Vibe)
+- Travail relationnel ou multi-fichiers : refactor cross-fichier, coordination multi-agents, reviews, merges, regeneration du catalogue
+
+**Regles d'execution** :
+- 1 sujet = 1 livrable. Catalogue byte-identique a main : `COURSE_CATALOG.generated.*` et les marqueurs `CATALOG-STATUS` appartiennent a l'automatisation, ne jamais les regenerer.
+- Commit LOCAL uniquement : branche `feature/<sujet>`, message conventionnel `type(scope): description`, trailer `Co-Authored-By: Claude Code <noreply@anthropic.com>` si assiste.
+- Outils SOTA, jamais workaround degrade (regle F). Env casse : preparer le diagnostic et le relayer, ne pas contourner.
+- Echeance a ~25 min : cloturer le grain courant — commit local + [REVIEW-NEEDED] + [DONE] — jamais de travail non commite a l'echeance.
+
+### Phase 4 : Rapport + relais humain OBLIGATOIRE
+
+1. **Commit local AVANT tout rapport** — jamais de [DONE] sur travail non commite.
+2. **[REVIEW-NEEDED] sur le dashboard** (workspace CoursIA) — relais humain explicite et verifiable :
+   ```
+   [REVIEW-NEEDED] myia-po-2025:Microsoft VS Code -- issue #<N>
+   - Branche : feature/<sujet> (worktree <chemin>, base <SHA court de origin/main>)
+   - Commit : <SHA>
+   - Fichiers : <liste>
+   - Diff : <resume : quoi, pourquoi>
+   - Preuves : <commandes lancees + sorties clees>
+   - Tests/checks : <resultats>
+   - Grain propose : Grain: <TIER>/<GENRE> -- lane myia-po-2025:Microsoft VS Code -- prev: <...>
+   ```
+   L'humain relit, pousse la branche et ouvre la PR. Le tag `Grain:` doit se retrouver dans le body de la PR : c'est lui qui rattache la PR a la lane (comptage cap, garde rouge du picker).
+3. **[DONE]** : `[DONE] myia-po-2025:Microsoft VS Code <resume> -- branche feature/<sujet> -- grade: <A/B/C>`
+4. **Bloqueurs** : tag `[ASK USER]` SEPARE du [DONE]. Repeter a CHAQUE fin de payload tant que non leve.
 5. **MEMORY.md** : MAJ si lecon durable.
 
 ---
@@ -98,7 +151,7 @@ roo-state-manager_conversation_browser
    ```
    G:/Mon Drive/Synchronisation/RooSync/.shared-state/dashboards/
    ```
-4. **Ou git/gh** : `gh issue list --state open`
+4. **Ou git/gh** : `gh issue list --state open --limit 100`
 
 ---
 
@@ -106,9 +159,11 @@ roo-state-manager_conversation_browser
 
 | Commande | Action |
 |----------|--------|
-| `gh issue list --state open --json number,title,labels` | Liste issues |
+| `python scripts/pick_idle_grain.py --lane "myia-po-2025:Microsoft VS Code" --prev-genre <genre> --json` | Premier geste de selection (verification des claims active) |
+| `gh pr list --state open --limit 100 --json number,title,body --jq '.[] \| select(.body != null and (.body \| contains("myia-po-2025:Microsoft VS Code"))) \| "#\(.number) \(.title)"'` | PRs ouvertes de la lane (via tag `Grain:`, jamais `--author @me`) |
+| `python scripts/check_unaddressed_nits.py <N>` | Points de review non leves sur une PR |
+| `python scripts/check_lane_claim.py --lane "myia-po-2025:Microsoft VS Code" <N>` | Verrou de claim avant edition |
 | `git worktree list` | Voir worktrees |
-| `gh pr list --state open --author @me` | Mes PRs |
 
 ---
 
@@ -127,7 +182,7 @@ roo-state-manager_conversation_browser
 | MCP non charge | Verifier config.toml, redemarrer session |
 | HTTP 502/429 | Attendre reset (5h), fallback GDrive |
 | Tool call silent fail | Utiliser noms complets: roo-state-manager_* |
-| Worktree conflict | git worktree prune + rebase frais |
+| Worktree conflict | git worktree prune + repartir d'une base fraiche origin/main |
 
 ---
 
@@ -137,6 +192,7 @@ roo-state-manager_conversation_browser
 |------|--------|-----|
 | 2026-08-20 | Creation initiale | jsboige + Mistral Vibe |
 | 2026-08-20 | Correction noms outils MCP | Mistral Vibe |
+| 2026-09-01 | Alignement #14114 : picker calibre en premier geste de selection (P0 rouge/review via mode repair), relais humain [REVIEW-NEEDED] (plus de push/PR autonome), cadence feeder 4 h / probe `--wake` 1 h, retrait de `--author @me` | jsboige + Claude Code |
 
 ---
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: DEEP/training #14090

## Résumé

Aligne le harnais CoursIA de Mistral Vibe sur le contrat worker actuel avant la reprise autonome :

- lane canonique `myia-po-2025:Microsoft VS Code` ;
- feeder de travail toutes les 4 h, avec schtask horaire conservée comme probe/no-op sans payload ;
- sélection par `pick_idle_grain.py` avec `--prev-genre` et `--json`, claims vérifiés par défaut (`--no-check-claims` interdit) ;
- reprise des propres PRs bloquées avant tout nouveau grain ;
- grains bornés mono-sujet, CPU/local, sans GPU/QC/vision/Lean froid/notebook à ré-exécuter ni travail relationnel multi-fichiers ;
- branche et commit locaux seulement, puis relais humain `[REVIEW-NEEDED]` avant push et ouverture de PR ;
- suppression de `gh ... --author @me`, qui peut produire un faux zéro sur une machine multi-comptes.

## Validation

- Invocation réelle sur `origin/main` du picker avec la lane canonique, `--prev-genre tooling --json` : exit 0, JSON valide, claims renseignés, `red_backlog` présent ; `--no-check-claims` n'est pas utilisé.
- Vérifications textuelles ciblées sur les deux fichiers : lane/cadence/relais présents ; aucun scan manuel comme voie normale ; aucune commande `--author @me`, `git push` ou `gh pr create` autorisée.
- Aucun test ou workflow existant ne cible `.vibe/` ; changement de harnais Markdown uniquement.

## Portée

Deux fichiers seulement : `.vibe/AGENTS.md` et `.vibe/commands/continue.md`. Catalogue inchangé. Aucun notebook modifié.

Closes #14114
