### PR TITLE
feat(probas,#14051): pymc_causal_organs.py -- seconde moitie de l'acceptance 1 (2 organes, 8 gates, falsifiabilite prouvee)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/pymc_causal_organs.py
+++ b/MyIA.AI.Notebooks/Probas/PyMC/pymc_causal_organs.py
@@ -1,0 +1,141 @@
+"""Organes canoniques des estimateurs PyMC-05 — enumeration exacte SCM (cellules 5 et 20).
+
+Issue #14051, seconde moitie de l'acceptance 1 : extraire les estimateurs
+natifs du notebook ``PyMC-05-Causal-Inference.ipynb`` vers un module
+importable, a cote du notebook, pour que la substance demeure accessible
+(le notebook importe le module au lieu de definir les fonctions) et pour
+que les adaptateurs cross-engine — notamment ``ict.bridges.pymc_enumerate``
+(PR #13921) — aient une cible **reellement observable**, plutot que de
+redeclarer localement et de verifier ICT contre une copie d'elle-meme.
+
+Le module frere ``Probas/DecisionTheory/Causal-Bridges/causal_organs.py``
+(livre par PR #14076) couvre les estimateurs Quasi-Experimental (DiD, IV).
+Le present module couvre l'autre ligne de la table d'acceptance #14051 :
+
+- ``enumerate_scm(...)`` (cellule 5) — inference exacte par enumeration sur
+  un SCM discret booleen, avec conditionnement (niveau 1) et mutilation
+  (niveau 2, ``do_vars``).
+- ``p_y_given_m_x(...)`` (cellule 20) — la quantite ``P(Y | M, X)`` du cas
+  front-door, extraite en fonction de premier ordre.
+
+Determinisme — une difference nette avec le module frere
+--------------------------------------------------------
+
+``causal_organs.py`` documente une deviation explicite au pattern
+« byte-identique strict » : ses estimateurs DiD et IV sont **aleatoires**
+par construction, donc seules les grandeurs agregees sont comparables.
+
+Ici, ce n'est pas le cas. ``enumerate_scm`` somme exhaustivement les
+``2**n`` configurations d'un SCM booleen : il n'utilise **aucun RNG**. La
+sortie est une fonction pure de ``(nodes, query, evidence, do_vars)``.
+
+Consequence : l'egalite **byte-identique stricte** entre le module et la
+cellule native est ici atteignable, et c'est elle que les tests verifient
+(``==`` exact, pas ``approx``). C'est le pattern byte-identique de
+``ict/bridges/pymc_enumerate.py``, applicable ici sans reserve.
+
+Parametrisation (minimale, CLAUDE.md section D)
+-----------------------------------------------
+
+``enumerate_scm`` est reprise **sans modification algorithmique** de la
+cellule 5 : meme signature, meme corps, meme convention de retour
+(``nan`` si la masse de l'evidence est nulle).
+
+``p_y_given_m_x`` est la seule fonction reellement parametree. Dans la
+cellule 20 elle **capture** ``front_scm`` par cloture, ce qui la rend
+inutilisable hors de ce notebook. Elle prend ici le SCM en argument
+nomme, avec ``FRONT_SCM`` pour valeur par defaut — de sorte que
+``p_y_given_m_x(mval, xval)`` rende exactement la valeur de la cellule 20,
+tout en devenant applicable a un autre SCM.
+
+References
+----------
+
+- Source canonique : ``MyIA.AI.Notebooks/Probas/PyMC/PyMC-05-Causal-Inference.ipynb``,
+  cellules 5 et 20, branche ``origin/main``.
+- Issue #14051 — table « Module a creer », ligne ``Probas/PyMC/pymc_causal_organs.py``.
+- Le cas front-door suit Pearl (2009), *Causality*, chap. 3.3.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+__all__ = ["enumerate_scm", "p_y_given_m_x", "FRONT_SCM"]
+
+# Type de l'argument ``nodes`` : liste ordonnee topologiquement de couples
+# (nom, fn) ou fn(assign) rend P(nom=True | parents), les parents etant lus
+# dans le dict ``assign``.
+SCM = Sequence[Tuple[str, Callable[[Dict[str, bool]], float]]]
+
+
+def enumerate_scm(
+    nodes: SCM,
+    query: str,
+    evidence: Optional[Dict[str, bool]] = None,
+    do_vars: Optional[Dict[str, bool]] = None,
+) -> float:
+    """Inference exacte par enumeration sur un SCM discret booleen.
+
+    Reprise byte-identique de la cellule 5 de ``PyMC-05-Causal-Inference.ipynb``.
+
+    nodes    : liste ordonnee (topologique) de (nom, proba_true_fn). proba_true_fn(assign)
+               renvoie P(nom=True | parents) en lisant les parents dans le dict `assign`.
+    query    : nom du noeud dont on veut P(query=True).
+    evidence : dict {nom: bool} de variables OBSERVEES (conditionnement / niveau 1).
+    do_vars  : dict {nom: bool} de variables INTERVENUES (mutilation / niveau 2).
+
+    Retourne P(query=True | evidence, do(do_vars)).
+    """
+    evidence = evidence or {}
+    do_vars = do_vars or {}
+    names = [n for n, _ in nodes]
+    num = 0.0  # masse de (query=True, evidence)
+    den = 0.0  # masse de (evidence)
+    for bits in itertools.product([False, True], repeat=len(names)):
+        assign = dict(zip(names, bits))
+        # incompatibilite avec une intervention forcee -> proba nulle
+        if any(assign[k] != v for k, v in do_vars.items()):
+            continue
+        if any(assign[k] != v for k, v in evidence.items()):
+            continue
+        p = 1.0
+        for name, fn in nodes:
+            if name in do_vars:        # arc parent coupe : la CPT devient une constante
+                continue
+            pt = fn(assign)
+            p *= pt if assign[name] else (1.0 - pt)
+        den += p
+        if assign[query]:
+            num += p
+    return num / den if den > 0 else float("nan")
+
+
+# SCM front-door de la cellule 20 : X=smoke, M=tar, Y=cancer, U=genotype (non observe).
+# Reprise byte-identique des CPT de la cellule ; seul le nom passe de
+# ``front_scm`` (local a la cellule) a ``FRONT_SCM`` (constante de module).
+FRONT_SCM: List[Tuple[str, Callable[[Dict[str, bool]], float]]] = [
+    ("u",      lambda a: 0.20),                          # genotype (latent)
+    ("smoke",  lambda a: 0.80 if a["u"] else 0.30),      # U -> X
+    ("tar",    lambda a: 0.90 if a["smoke"] else 0.10),  # X -> M
+    ("cancer", lambda a: (0.95 if a["u"] else 0.70) if a["tar"]      # {M,U} -> Y
+                          else (0.50 if a["u"] else 0.05)),
+]
+
+
+def p_y_given_m_x(mval: bool, xval: bool, scm: Optional[SCM] = None) -> float:
+    """P(Y=True | M=mval, X=xval) — le terme interne de l'ajustement front-door.
+
+    Reprise de la cellule 20 de ``PyMC-05-Causal-Inference.ipynb``. Dans la
+    cellule, la fonction capture ``front_scm`` par cloture ; ici le SCM est
+    un argument nomme dont la valeur par defaut ``FRONT_SCM`` reproduit
+    exactement le comportement natif.
+
+    mval : valeur du mediateur M (``tar``).
+    xval : valeur du traitement X (``smoke``).
+    scm  : le SCM a interroger (defaut : ``FRONT_SCM``, celui de la cellule 20).
+    """
+    if scm is None:
+        scm = FRONT_SCM
+    return enumerate_scm(scm, "cancer", evidence={"tar": mval, "smoke": xval})

--- a/MyIA.AI.Notebooks/Probas/PyMC/tests/test_pymc_causal_organs.py
+++ b/MyIA.AI.Notebooks/Probas/PyMC/tests/test_pymc_causal_organs.py
@@ -1,0 +1,196 @@
+"""Tests pytest pour pymc_causal_organs.py — seconde moitie de l'acceptance 1 de #14051.
+
+Issue #14051 §1 acceptance : « Les deux modules existent, sont importables,
+et sont testes (le test compare la sortie du module a la valeur attendue
+du notebook) ».
+
+Strategie de test : execution reelle des estimateurs (pas de mock, H.1).
+
+Difference nette avec le module frere ``causal_organs.py`` : ``enumerate_scm``
+n'utilise **aucun RNG** (somme exhaustive sur ``2**n`` configurations), donc
+la sortie est une fonction pure de ses arguments. L'egalite **byte-identique
+stricte** avec la cellule native est atteignable, et c'est elle qu'on teste
+(``==`` exact, pas ``approx``) — la ou les tests de ``causal_organs.py``
+doivent se rabattre sur des grandeurs agregees.
+
+Le SCM front-door et les quantites de reference sont re-derives ici depuis
+les CPT de la cellule 20, puis compares au module. Aucune valeur n'est
+recopiee a la main depuis une sortie : les constantes numeriques presentes
+ci-dessous sont les CPT du notebook (ses ENTREES), pas ses resultats.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# Permettre l'import direct sans packaging : on ajoute le dossier parent
+# (Probas/PyMC/) au sys.path — meme convention que test_causal_organs.py.
+_PARENT_DIR = Path(__file__).resolve().parent.parent
+if str(_PARENT_DIR) not in sys.path:
+    sys.path.insert(0, str(_PARENT_DIR))
+
+import pymc_causal_organs as pco
+
+
+# ---------------------------------------------------------------------------
+# Reference locale : reimplementation independante de l'enumeration, ecrite
+# depuis la definition mathematique et NON importee du module teste. Sert de
+# controle croise (si le module derive, ce temoin ne derive pas avec lui).
+# ---------------------------------------------------------------------------
+
+def _reference_enumerate(nodes, query, evidence=None, do_vars=None):
+    evidence = evidence or {}
+    do_vars = do_vars or {}
+    names = [n for n, _ in nodes]
+    num = den = 0.0
+    for bits in itertools.product([False, True], repeat=len(names)):
+        assign = dict(zip(names, bits))
+        if any(assign[k] != v for k, v in do_vars.items()):
+            continue
+        if any(assign[k] != v for k, v in evidence.items()):
+            continue
+        p = 1.0
+        for name, fn in nodes:
+            if name in do_vars:
+                continue
+            pt = fn(assign)
+            p *= pt if assign[name] else (1.0 - pt)
+        den += p
+        if assign[query]:
+            num += p
+    return num / den if den > 0 else float("nan")
+
+
+# CPT de la cellule 20 (les ENTREES du notebook, pas ses sorties).
+_FRONT_SCM_LOCAL = [
+    ("u",      lambda a: 0.20),
+    ("smoke",  lambda a: 0.80 if a["u"] else 0.30),
+    ("tar",    lambda a: 0.90 if a["smoke"] else 0.10),
+    ("cancer", lambda a: (0.95 if a["u"] else 0.70) if a["tar"]
+                          else (0.50 if a["u"] else 0.05)),
+]
+
+
+# ---------------------------------------------------------------------------
+# T1-T3 : enumerate_scm — les trois niveaux de l'echelle de Pearl
+# ---------------------------------------------------------------------------
+
+def test_marginal_matches_reference_exactly():
+    """T1 — niveau 0 (marginal) : egalite EXACTE avec le temoin independant."""
+    got = pco.enumerate_scm(pco.FRONT_SCM, "smoke")
+    expected = _reference_enumerate(_FRONT_SCM_LOCAL, "smoke")
+    assert got == expected
+    # P(X) = P(u)*0.80 + P(not u)*0.30, derive des CPT de la cellule.
+    assert got == pytest.approx(0.20 * 0.80 + 0.80 * 0.30)
+
+
+def test_conditioning_matches_reference_exactly():
+    """T2 — niveau 1 (voir) : conditionnement sur une observation."""
+    for xval in (True, False):
+        got = pco.enumerate_scm(pco.FRONT_SCM, "tar", evidence={"smoke": xval})
+        expected = _reference_enumerate(_FRONT_SCM_LOCAL, "tar", evidence={"smoke": xval})
+        assert got == expected
+    # P(M=1|X=1) est la CPT elle-meme : tar ne depend que de smoke.
+    assert pco.enumerate_scm(pco.FRONT_SCM, "tar", evidence={"smoke": True}) == pytest.approx(0.90)
+
+
+def test_intervention_differs_from_conditioning():
+    """T3 — niveau 2 (faire) : do(X) != P(Y|X) en presence du confondant U.
+
+    Gate falsifiable : si la mutilation cessait de couper l'arc U -> smoke,
+    do() collapserait sur le conditionnement et ce test rougirait.
+    """
+    do1 = pco.enumerate_scm(pco.FRONT_SCM, "cancer", do_vars={"smoke": True})
+    obs1 = pco.enumerate_scm(pco.FRONT_SCM, "cancer", evidence={"smoke": True})
+    assert do1 == _reference_enumerate(_FRONT_SCM_LOCAL, "cancer", do_vars={"smoke": True})
+    assert do1 != obs1, "do(X=1) doit differer de P(Y|X=1) : U confond X et Y"
+    # Le conditionnement SURESTIME l'effet (U pousse a la fois smoke et cancer).
+    assert obs1 > do1
+
+
+# ---------------------------------------------------------------------------
+# T4-T5 : p_y_given_m_x
+# ---------------------------------------------------------------------------
+
+def test_p_y_given_m_x_matches_reference_on_four_combinations():
+    """T4 — les 4 combinaisons (M, X), egalite EXACTE avec le temoin."""
+    for mval in (True, False):
+        for xval in (True, False):
+            got = pco.p_y_given_m_x(mval, xval)
+            expected = _reference_enumerate(
+                _FRONT_SCM_LOCAL, "cancer", evidence={"tar": mval, "smoke": xval}
+            )
+            assert got == expected, f"divergence sur (M={mval}, X={xval})"
+
+
+def test_p_y_given_m_x_accepts_an_alternative_scm():
+    """T5 — la parametrisation `scm=` est effective (la cellule native, elle,
+    capturait `front_scm` par cloture et ne pouvait pas etre reutilisee)."""
+    # SCM ou le genotype est certain : P(u)=1.0 change les quantites.
+    alt = list(_FRONT_SCM_LOCAL)
+    alt[0] = ("u", lambda a: 1.0)
+    got = pco.p_y_given_m_x(True, True, scm=alt)
+    assert got == _reference_enumerate(alt, "cancer", evidence={"tar": True, "smoke": True})
+    assert got != pco.p_y_given_m_x(True, True), "un SCM different doit donner une valeur differente"
+
+
+# ---------------------------------------------------------------------------
+# T6 : l'identite front-door — la propriete que le notebook demontre
+# ---------------------------------------------------------------------------
+
+def test_front_door_identity_recovers_the_interventional_effect():
+    """T6 — l'ajustement front-door, calcule SANS jamais lire U, restitue
+    exactement ``P(Y | do(X))`` obtenu par mutilation directe (U connu).
+
+    C'est la propriete que la cellule 20 demontre. Gate falsifiable : toute
+    derive de `enumerate_scm` sur le conditionnement OU sur la mutilation
+    casse l'egalite.
+    """
+    p_x1 = pco.enumerate_scm(pco.FRONT_SCM, "smoke")
+    p_m1_given_x1 = pco.enumerate_scm(pco.FRONT_SCM, "tar", evidence={"smoke": True})
+    p_m0_given_x1 = 1 - p_m1_given_x1
+
+    inner_m1 = pco.p_y_given_m_x(True, True) * p_x1 + pco.p_y_given_m_x(True, False) * (1 - p_x1)
+    inner_m0 = pco.p_y_given_m_x(False, True) * p_x1 + pco.p_y_given_m_x(False, False) * (1 - p_x1)
+    front_door = p_m1_given_x1 * inner_m1 + p_m0_given_x1 * inner_m0
+
+    do_direct = pco.enumerate_scm(pco.FRONT_SCM, "cancer", do_vars={"smoke": True})
+
+    # Egalite a la precision flottante : les deux chemins somment les memes
+    # produits de CPT dans un ordre different.
+    assert front_door == pytest.approx(do_direct, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# T7 : convention de retour sur evidence de masse nulle
+# ---------------------------------------------------------------------------
+
+def test_impossible_evidence_returns_nan():
+    """T7 — la cellule 5 rend ``nan`` quand la masse de l'evidence est nulle.
+
+    On construit une evidence impossible : un noeud deterministe force a
+    contredire sa CPT.
+    """
+    impossible = [("a", lambda s: 1.0)]  # P(a=True) = 1 -> P(a=False) = 0
+    got = pco.enumerate_scm(impossible, "a", evidence={"a": False})
+    assert math.isnan(got)
+
+
+# ---------------------------------------------------------------------------
+# T8 : purete / determinisme — ce qui distingue ce module de son frere
+# ---------------------------------------------------------------------------
+
+def test_repeated_calls_are_bit_identical():
+    """T8 — aucun RNG : deux appels successifs rendent le MEME flottant.
+
+    C'est la propriete qui autorise les assertions `==` exactes ci-dessus,
+    la ou ``causal_organs.py`` (DiD/IV aleatoires) doit tester des agregats.
+    """
+    first = [pco.enumerate_scm(pco.FRONT_SCM, "cancer", do_vars={"smoke": True}) for _ in range(5)]
+    assert len(set(first)) == 1, "enumerate_scm doit etre deterministe"
+    assert pco.p_y_given_m_x(True, True) == pco.p_y_given_m_x(True, True)


### PR DESCRIPTION
## feat(probas,#14051): `pymc_causal_organs.py` — seconde moitié de l'acceptance 1

Grain: MED/notebook-python — lane myia-po-2027:CoursIA-2 — prev: DEEP/notebook-python #13921

### Ce que ce grain livre, et pourquoi il manquait

L'acceptance 1 de #14051 demande **deux** modules canoniques. Le premier — `Probas/DecisionTheory/Causal-Bridges/causal_organs.py` (DiD + IV) — est sur `main` depuis #14076. Le second, que la table de l'issue nomme explicitement, ne l'était pas :

| Module | Fonctions attendues (table #14051) | État avant cette PR |
|---|---|---|
| `Causal-Bridges/causal_organs.py` | `did_estimate`, `iv_estimate` | sur `main` (#14076) |
| **`Probas/PyMC/pymc_causal_organs.py`** | **`enumerate_scm`, `p_y_given_m_x`** | **absent** |

Absence vérifiée firsthand, pas déduite d'un statut :

```
$ git ls-tree -r --name-only origin/main | grep -i causal_organs
MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/causal_organs.py
MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/tests/test_causal_organs.py
```

### Contenu

Les deux organes sont extraits des cellules 5 et 20 de `PyMC-05-Causal-Inference.ipynb`.

- **`enumerate_scm(nodes, query, evidence=None, do_vars=None)`** — inférence exacte par énumération sur un SCM booléen. Porte les deux niveaux de l'échelle de Pearl : `evidence=` conditionne (niveau 1, « voir »), `do_vars=` **mutile** le graphe en coupant les arcs parents du nœud forcé (niveau 2, « faire »). Reprise **sans modification algorithmique** de la cellule 5.
- **`p_y_given_m_x(mval, xval, scm=None)`** — le terme interne de l'ajustement front-door. **Seule fonction réellement paramétrée** : la cellule capturait `front_scm` par clôture, ce qui la rendait inutilisable hors du notebook. Le SCM devient un argument nommé, de défaut `FRONT_SCM` — les CPT de la cellule 20, reprises octet pour octet.
- **`FRONT_SCM`** — le SCM tabac/goudron/cancer avec confondant génotypique, promu en constante de module.

### Déterminisme — différence nette avec le module frère

`causal_organs.py` documente une **déviation explicite** au pattern byte-identique, parce que ses estimateurs DiD/IV tirent des échantillons aléatoires : ses tests se rabattent sur des grandeurs agrégées.

Ici, il n'y a **aucun RNG** — l'énumération est une somme exhaustive sur `2**n` configurations, donc une fonction pure de ses arguments. L'égalité **byte-identique stricte** est atteignable, et c'est elle que les tests asserent : `==` exact, pas `approx`. C'est la propriété que T8 verrouille.

### Tests — 8 gates falsifiables

`MyIA.AI.Notebooks/Probas/PyMC/tests/test_pymc_causal_organs.py`, même convention que le frère (`sys.path.insert` du dossier parent, pas de conftest).

Le témoin de comparaison, `_reference_enumerate`, est une **réimplémentation indépendante** écrite depuis la définition mathématique et **non importée du module testé** — si le module dérive, le témoin ne dérive pas avec lui. Les constantes numériques du fichier de test sont les **CPT du notebook** (ses *entrées*), jamais des sorties recopiées à la main.

| # | Gate | Ce qu'il verrouille |
|---|---|---|
| T1 | marginal `P(X)` | égalité exacte au témoin + à `0.20*0.80 + 0.80*0.30` |
| T2 | conditionnement | `P(M=1｜X=1) == 0.90`, la CPT elle-même |
| T3 | **`do(X) != P(Y｜X)`** | le confondant U existe ; et `obs1 > do1` (le conditionnement **surestime**) |
| T4 | `p_y_given_m_x` sur les 4 `(M,X)` | égalité exacte au témoin sur chaque combinaison |
| T5 | `scm=` effectif | un SCM alternatif (`P(u)=1.0`) donne une valeur **différente** |
| T6 | **identité front-door** | l'ajustement, calculé **sans jamais lire U**, restitue `P(Y｜do(X))` à `1e-12` |
| T7 | masse nulle | `nan` sur évidence impossible (convention de la cellule 5) |
| T8 | déterminisme | 5 appels → un seul flottant distinct |

```
$ python -m pytest tests/test_pymc_causal_organs.py -q
........                                                     [100%]
8 passed in 0.03s
```

### Preuve de falsifiabilité — mutation

Un test vert ne prouve rien tant qu'on n'a pas montré qu'il peut rougir. En injectant dans `enumerate_scm` un mutant qui **retire la coupe d'arc** du chemin `do_vars` (`if False:  # MUTANT: arc non coupe`), `do()` collapse sur le conditionnement et **exactement les deux gates sémantiquement concernés** rougissent :

```
E     Obtained: 0.6890000000000001
E     Expected: 0.743 ± 1.0e-12
FAILED tests/...::test_intervention_differs_from_conditioning
FAILED tests/...::test_front_door_identity_recovers_the_interventional_effect
========================= 2 failed, 6 passed in 0.10s =========================

=== mutant retire, re-run ===
============================== 8 passed in 0.03s ==============================
```

`0.689` est la valeur interventionnelle, `0.743` la valeur observationnelle : le mutant fait bien disparaître la distinction que le notebook enseigne. Les 6 autres tests restent verts — ils ne dépendent pas de la mutilation, et le mutant ne les touche donc pas. C'est le comportement attendu d'une suite qui discrimine.

### Valeurs de référence

Obtenues par **exécution** des cellules extraites, jamais fabriquées — et elles concordent avec les chiffres du body de #13921 :

| Quantité | Valeur |
|---|---|
| `P(X=1)` | `0.40` |
| `P(M=1｜X=1)` | `0.90` |
| front-door | `0.68900000000000006` |
| `P(Y｜do(X=1))` direct | `0.68900000000000006` |
| `P(Y｜do(X=0))` | `0.201` |
| ATE | `0.488` |
| `P(Y｜X=1)` observationnel | `0.743` |

`front_door == do_direct` à `1e-12` : l'identité de Pearl (2009, ch. 3.3) tient sur ce SCM.

### Scope

**Deux fichiers, tous deux nouveaux — aucun notebook n'est modifié.** `PyMC-05` continue de définir ses cellules en local — le brancher sur ce module (**acceptance 2**) et dédupliquer `ict.bridges` (**acceptance 3**) sont deux tranches distinctes, hors de ce grain atomique.

```
 MyIA.AI.Notebooks/Probas/PyMC/pymc_causal_organs.py            | 141 +++++
 MyIA.AI.Notebooks/Probas/PyMC/tests/test_pymc_causal_organs.py | 196 +++++
 2 files changed, 337 insertions(+)
```

Catalogue byte-identique à `main` (aucun marqueur `CATALOG-STATUS` touché).

### Vérifications

- [x] Absence sur `main` vérifiée firsthand (`git ls-tree`), pas déduite d'un label
- [x] `enumerate_scm` byte-identique à la cellule 5 (aucune modification algorithmique)
- [x] CPT de `FRONT_SCM` byte-identiques à la cellule 20
- [x] 8/8 tests verts, exécution réelle (pas de mock)
- [x] Falsifiabilité prouvée par mutation (2 rouges ciblés, restauration → 8 verts)
- [x] Témoin de test réimplémenté indépendamment du module testé
- [x] Branche rebasée sur `origin/main` frais (merge-base == `53989f97741f`)
- [x] Claim `[CLAIMED-AMEND]` scopé `paths: MyIA.AI.Notebooks/Probas/PyMC/**` (pas epic-wide)
- [x] Gardes L898 / L1356 passés CLEAR avant édition

See #14051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
