### PR TITLE
fix(slides,#13224): tranche 4 — slide dédiée pour le Venn NLP/NLU + img_122 en pied de colonne gauche

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -1785,6 +1785,7 @@ layout: section
   - + traitement requêtes
   - + score  résultats
 
+<img src="./images/img_122.png" class="w-full max-w-[400px] mx-auto max-h-[76px] object-contain mt-4" alt="Formule de probabilité jointe d'une séquence par chaîne de Markov : produit des P(ci | ci-2:i-1)" />
 
 </div>
 <div>
@@ -1797,16 +1798,29 @@ layout: section
   - Extraction d'ontologie
   - Machine reading
 
-<div class="img-grid">
-<img src="./images/img_122.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Formule de probabilité jointe d'une séquence par chaîne de Markov : produit des P(ci | ci-2:i-1)" />
-<img src="./images/img_123.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Trois pictogrammes de sentiment : positif (pouce levé vert), neutre (main jaune), négatif (pouce rouge)" />
-<img src="./images/img_124.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Diagramme de Venn des tâches NLP et NLU avec listes de problèmes couverts" />
-
-</div>
+<img src="./images/img_123.png" class="w-full max-w-[240px] mx-auto max-h-[96px] object-contain mt-6" alt="Trois pictogrammes de sentiment : positif (pouce levé vert), neutre (main jaune), négatif (pouce rouge)" />
 
 
 </div>
 </div>
+---
+
+
+
+# NLP et NLU : la carte des tâches
+
+
+
+<img src="./images/img_124.png" class="w-full max-h-[372px] object-contain mt-2" alt="Diagramme de Venn des tâches du TAL : l'ensemble NLP contient catégorisation de texte, analyse syntaxique, étiquetage morpho-syntaxique (POS), reconnaissance d'entités nommées (NER), résolution de coréférences et traduction automatique ; le sous-ensemble NLU contient extraction de relations, résumé, analyse sémantique, paraphrase et inférence en langue naturelle, question-réponse, analyse de sentiments et agents de dialogue" />
+
+<div class="text-center text-sm opacity-75 mt-4">
+
+Le <strong>NLU</strong> est un sous-ensemble du <strong>NLP</strong> : les tâches de la zone verte supposent une représentation du <em>sens</em>, celles de la zone bleue seule s'en passent.
+
+</div>
+
+
+
 ---
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet #14145

See #13224 (tranche 4 — la slide « Modèles du langage », que le scanner de la tranche 3 avait manquée).

> **Cette PR a été entièrement refaite** (force-with-lease, `52bd0ee958` → `035f9bc4a7`). La première version supprimait `img_124` et mesurait le rendu avec **Marp CLI** — or ce deck est un deck **Slidev** (`theme: ../theme-ia101`, `mdc: true`, canvas 980×552). Elle mesurait donc un rendu qui n'est pas celui qui ship. Le détail de ce qui change est en fin de body.

## Le défaut

La slide empilait trois images dans un `<div class="img-grid">` à `w-[180px]`, sous une colonne gauche dont la moitié basse était vide :

| Slide 64, avant | Mesure |
|---|---|
| `gap_left_pct` | **51** |
| `gap_right_pct` | 4.9 |
| `center_offset_pct` | 23.1 |
| `severity` | `med` |

Le diagramme de Venn NLP/NLU (`img_124`, **1111×814** natif) y était rendu à ~180 px, soit **~16 % de son échelle** : aucun de ses 14 intitulés de tâches n'était lisible. C'est exactement le constat du body de #13224 — « une image qu'on ne peut pas lire ne documente rien ».

## L'arbitrage retenu

#13224 pose l'alternative textuellement : « **soit il occupe une slide a lui seul, soit il degage** ». La **première** branche est retenue.

- **`img_124` → sa propre slide**, rendue à ~508×372 (**2,8×**), avec une légende qui dit ce que le schéma montre : le NLU est un sous-ensemble du NLP, les tâches de la zone verte supposent une représentation du *sens*.
- **`img_122`** (formule de Markov, 395×68 natif) **descend en pied de colonne gauche**. Ce n'est pas un remplissage : elle *formalise les n-grammes*, qui sont le sujet de cette colonne — et elle comble précisément le vide qui produisait le gap de 51 %. Rendue à ~400 px, soit sa taille native (**2,2×**).
- **`img_123`** (pictogrammes de sentiment, 230×92 natif) reste en colonne droite, centrée, à sa taille native (**1,28×**).

Aucune image n'est retirée, aucune n'est réduite, aucune puce pédagogique n'est touchée.

## Mesures — Slidev, canvas 980×552, `?clicks=99`

`scan_slidev_composition.py` puis `scan_slidev_gap_report.py`, deck servi par `slidev` sur `:3037`. **Mesuré le 2026-09-01** (baseline 23:06 UTC+2, après 23:15 — la baseline est antérieure à l'édition de 23:09, donc non contaminée par le hot-reload).

**Slide 64 :**

| | Avant | Après |
|---|---|---|
| `n_images` | 3 | 2 |
| `gap_left_pct` | 51 | **6.5** |
| `gap_right_pct` | 4.9 | 14.7 |
| `gap_max` | 51 | **14.7** |
| `center_offset_pct` | 23.1 | −4.1 |
| `severity` | `med` | **`none`** |

**Nouvelle slide 65 (le Venn) :** `gap_max 4.9`, `center_offset_pct 0`, `severity none`, `flagged_by_scanner false`.

**Deck entier :**

| | Avant | Après |
|---|---|---|
| Slides | 99 | 100 |
| `gap_max >= 40` | 27 | **26** |
| `severity` | `high 2 / med 25 / low 13 / none 8` | `high 2 / med 24 / low 13 / **none 10**` |
| `n_hors_canvas` | 1 | 1 |
| `n_chevauchements` | 0 | 0 |
| `n_occupation_flagged` | 4 | 4 |

**Contrôle d'attribution** : en réalignant les index sur le décalage d'une slide, **aucune autre slide du deck** ne change de `gap_max` ni de `severity`. Le delta est intégralement imputable aux deux slides touchées.

L'unique `hors_canvas` est la slide **58** « Extensions 2020+ », identique avant et après — **préexistante, hors périmètre**.

## QA vision

Captures 980×552 à `deviceScaleFactor: 2`, navigation `?clicks=99`, avec contrôle « name-what-measured » (le `innerText` de chaque slide est imprimé à côté de sa capture) :

- `slide 64 → head="Modèles du langage N-grams Modèles de Markov Traitements lis"`
- `slide 65 → head="NLP et NLU : la carte des tâches  Le NLU est un sous-ensembl"`
- `slide 66 → head="Grammaires  Caractéristiques  Communication Echange d’inform"`

Lecture des rendus : sur la 64, la moitié basse gauche n'est plus vide et la formule y est lisible ; les pictogrammes de sentiment sont nettement plus grands qu'avant. Sur la 65, **les 14 intitulés du Venn se lisent tous**.

**Contrôle positif du scanner : `controle_positif_ok: null`, avant comme après.** Il est cassé en amont — c'est l'objet de **#13223**, cité par le body de #13224 lui-même. Je le rapporte plutôt que de l'omettre : les trois signaux du scanner ne sont donc pas armés par un contrôle positif, et c'est la QA vision ci-dessus qui porte la preuve du rendu.

## Build

`slidev build slides/S3-acculturation/slides.md` → `exit=0`, `✓ built in 17.26s`.

## Périmètre

- **1 fichier**, `+19 / −5`. `style.css` intact, catalogue byte-identique à `main`.
- La slide « **Grammaires** » (66 après décalage) porte **le même défaut** — `gap_max 51`, `severity med`, `img-grid` identique — et reste **délibérément intacte** : elle est hors du périmètre de la claim de tranche 4, et je la laisse à la lane qui la prendra.
- `See #13224` et non `Closes` : le chantier composition du deck garde 26 slides à `gap_max >= 40`.

## Ce qui change par rapport à la première version de cette PR

| | `52bd0ee958` | `035f9bc4a7` |
|---|---|---|
| Sort de `img_124` | **supprimée** du deck | **slide dédiée**, 2,8× |
| Moteur de mesure | Marp CLI, « slide DOM #40 » | **Slidev**, le moteur du deck |
| `img_122` / `img_123` | grille 2-cols à `max-h-[150px]` | taille native, en colonne |
| Résidu déclaré | « colonne droite reste hors-canvas », non résolu | `severity none`, résolu |
| `max-height: 480px` sur le grid | ajouté en amortissement | inutile, retiré |

La première version décrivait honnêtement un résidu structurel qu'elle ne résolvait pas. Ce résidu était un artefact de mesure : il n'existe pas dans le rendu Slidev.
