### PR TITLE
feat(ci,#13378): route 11 pure-Python guards to the Linux self-hosted leg (tranche 1)

### DIFF
--- a/.github/workflows/banner-guard.yml
+++ b/.github/workflows/banner-guard.yml
@@ -48,7 +48,12 @@ concurrency:
 jobs:
   banner-scan:
     name: "probeAddresses banner guard (main-repo notebooks)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/cell-order-gate.yml
+++ b/.github/workflows/cell-order-gate.yml
@@ -31,7 +31,13 @@ concurrency:
 jobs:
   cell-order:
     name: "No cell-ordering regression in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/hooks-parity.yml
+++ b/.github/workflows/hooks-parity.yml
@@ -26,10 +26,19 @@ concurrency:
   group: hooks-parity-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   parity:
     name: parity gate
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
     # Advisory: surfaces the warning without breaking the rest of the CI run.
     # `continue-on-error` is only valid on a job or a step -- at the workflow
     # root it is an unknown key, which Actions rejects with a startup_failure

--- a/.github/workflows/notebook-cell-source-parses.yml
+++ b/.github/workflows/notebook-cell-source-parses.yml
@@ -42,7 +42,13 @@ concurrency:
 
 jobs:
   cell-source-parses:
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/notebook-exec-sequence-ratchet.yml
+++ b/.github/workflows/notebook-exec-sequence-ratchet.yml
@@ -43,7 +43,13 @@ concurrency:
 jobs:
   ratchet:
     name: Exec-sequence ratchet (base vs PR)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/notebook-interp-positioning.yml
+++ b/.github/workflows/notebook-interp-positioning.yml
@@ -34,7 +34,12 @@ concurrency:
 jobs:
   check-interp-positioning:
     name: check_interp_positioning.py
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/notebook-navlink-check.yml
+++ b/.github/workflows/notebook-navlink-check.yml
@@ -29,7 +29,13 @@ concurrency:
 
 jobs:
   check-navlinks:
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/notebook-navlink-check.yml
+++ b/.github/workflows/notebook-navlink-check.yml
@@ -39,5 +39,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # La jambe Linux conteneurisee n'expose pas de `python` systeme (job
+      # 100021313259, exit 127) : le checker est stdlib-only, mais l'interprete
+      # vient de setup-python, comme dans les dix autres gardes de la tranche 1.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Check notebook navlinks
         run: python scripts/notebook_tools/check_notebook_navlinks.py --check

--- a/.github/workflows/notebook-papermill-ratchet.yml
+++ b/.github/workflows/notebook-papermill-ratchet.yml
@@ -31,7 +31,13 @@ concurrency:
 jobs:
   ratchet:
     name: Papermill ratchet (base vs PR)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pip-leak-guard.yml
+++ b/.github/workflows/pip-leak-guard.yml
@@ -28,7 +28,12 @@ concurrency:
 jobs:
   pip-leak-delta:
     name: "!pip install HIGH delta guard (#6314)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/prose-counts-guard.yml
+++ b/.github/workflows/prose-counts-guard.yml
@@ -30,7 +30,13 @@ concurrency:
 
 jobs:
   prose-counts:
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/solution-leak-guard.yml
+++ b/.github/workflows/solution-leak-guard.yml
@@ -62,7 +62,12 @@ concurrency:
 jobs:
   solution-leak-delta:
     name: "Solution-leak HIGH delta (advisory, WARN phase, #8053)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 1, decision ai-01
+    # 2026-09-01) : garde Python pur, sans secret ni usage du GITHUB_TOKEN. La garde
+    # same-repo ci-dessous saute les PRs de fork (pr_gate.py compte `skipped` comme
+    # OK) : aucun code de fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
 
     steps:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -6,8 +6,12 @@ execute untrusted code next to the cluster's credentials. This scanner therefore
 fails closed: every self-hosted job must belong to an explicitly allowed
 workflow, use the exact dedicated label set, and avoid runner groups (unavailable
 for this personal-account repository). Every pull_request job must also carry
-the exact same-repository guard. Dynamic ``runs-on`` expressions are rejected
-because their target cannot be proved statically.
+the exact same-repository guard. Triggers whose payload can name a fork pull
+request (pull_request_target, workflow_run, issue_comment, pull_request_review,
+pull_request_review_comment) never reach a self-hosted job, whatever the guard
+says; push / schedule / workflow_dispatch only run repository-owned refs and are
+accepted. Dynamic ``runs-on`` expressions are rejected because their target
+cannot be proved statically.
 
 Exit codes:
   0  policy satisfied (including the explicit baseline of zero self-hosted jobs)
@@ -106,6 +110,18 @@ SAME_REPO_GUARD_UNIVERSAL = (
     "|| github.event.pull_request.head.repo.full_name == github.repository"
 )
 ACCEPTED_SAME_REPO_GUARDS = frozenset({SAME_REPO_GUARD, SAME_REPO_GUARD_UNIVERSAL})
+# Evenements dont le code de workflow vient de la branche par defaut mais dont
+# le payload nomme une pull request potentiellement issue d'un fork : un job
+# peut faire `checkout refs/pull/N/head` et executer du code de fork sur le
+# runner. Refuses sur self-hosted au meme titre que pull_request_target
+# (#14148, reserve NanoClaw n.2). A l'inverse, push / schedule /
+# workflow_dispatch ne portent que des refs du depot : la branche `== null`
+# de la garde universelle y est sure par construction, pas par accident.
+FORK_REACHABLE_TRIGGERS = frozenset({
+    "issue_comment",
+    "pull_request_review",
+    "pull_request_review_comment",
+})
 DEFAULT_WORKFLOWS_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 
@@ -233,12 +249,23 @@ def _normalise_condition(value: Any) -> str:
 
 def _starts_with_accepted_guard(condition: str) -> bool:
     """True iff ``condition`` leads with one of the accepted same-repo
-    guards, optionally wrapped in parens and optionally followed by `&& ...`
-    selection predicates. The guard must be the LEAD predicate, and any
-    suffix joined by `||` is rejected (the `||` would let the guard fall
-    through). The standalone tests ``test_guard_weakened_by_or_is_rejected``
-    and ``test_universal_guard_weakened_by_or_is_rejected`` verify that
+    guards, optionally followed by `&& ...` selection predicates. The guard
+    must be the LEAD predicate, and any suffix joined by `||` is rejected
+    (the `||` would let the guard fall through). The standalone tests
+    ``test_guard_weakened_by_or_is_rejected`` and
+    ``test_universal_guard_weakened_by_or_is_rejected`` verify that
     `|| always()` is refused.
+
+    Parentheses: the direct guard may be bare or wrapped. The UNIVERSAL guard
+    carries an internal `||`, so it is accepted bare only when it is the whole
+    condition; combined with `&& ...` it MUST be wrapped --
+    `(<universal>) && <selection>`. This is not a parser limitation to work
+    around: in GitHub expressions `&&` binds tighter than `||`, so the bare
+    form reads `A == null || (A == repo && sel)` and runs the job on every
+    non-pull_request event regardless of the selection. The bare scan below
+    splits at the first top-level operator (the internal `||`) and rejects;
+    ``_guard_violation_message`` names the required parentheses
+    (#14148, NanoClaw concern 1).
     """
     if not condition:
         return False
@@ -291,6 +318,20 @@ def _starts_with_accepted_guard(condition: str) -> bool:
                 return True
             return False
     return False
+
+
+def _guard_violation_message(condition: str) -> str:
+    """Name the exact defect: a bare universal guard followed by `&&` is the
+    one rejection whose fix is not "add the guard" but "add parentheses"."""
+    if condition.startswith(SAME_REPO_GUARD_UNIVERSAL):
+        tail = condition[len(SAME_REPO_GUARD_UNIVERSAL):].lstrip()
+        if tail.startswith("&&"):
+            return (
+                "universal same-repo guard combined with `&&` must be parenthesised: "
+                "`(<universal guard>) && <selection>` -- `&&` binds tighter than `||`, "
+                "so the bare form bypasses the selection outside pull_request context"
+            )
+    return "pull_request self-hosted job must lead with the same-repo job guard"
 
 
 def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
@@ -399,6 +440,14 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                     "REUSABLE_SELF_HOSTED",
                     "self-hosted jobs must not hide inside reusable workflows",
                 ))
+            for trigger in sorted(FORK_REACHABLE_TRIGGERS & triggers):
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "FORK_REACHABLE_TRIGGER",
+                    f"{trigger} can check out a fork pull request and must never "
+                    "reach a self-hosted runner",
+                ))
 
             if path.name not in SELF_HOSTED_WORKFLOW_ALLOWLIST:
                 violations.append(Violation(
@@ -446,7 +495,7 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                         path.name,
                         str(job_name),
                         "SAME_REPO_GUARD",
-                        "pull_request self-hosted job must lead with the same-repo job guard",
+                        _guard_violation_message(condition),
                     ))
 
     return ScanResult(len(paths), jobs_scanned, self_hosted_jobs, violations, broken)

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -51,10 +51,26 @@ DEDICATED_LABEL_SETS = (REQUIRED_LABELS, LINUX_RUNNER_LABELS)
 # - linux-self-hosted-tests.yml: workflow_dispatch-ONLY pilot vehicle for the
 #   containerized Linux runner (#13378, po-2024, dispatch ai-01 2026-08-31),
 #   zero fan-out, --ephemeral inside a capped Docker container.
+# - tranche 1 (#13378, decision ai-01 2026-09-01, owner myia-po-2024:CoursIA):
+#   pure-Python guards, no secret, no GITHUB_TOKEN use, universal same-repo
+#   guard (#13874) at job level so fork PRs are skipped (pr_gate.py counts
+#   `skipped` as OK). Routed to the containerized Linux leg to relieve the
+#   GitHub-hosted queue. Rollback = revert of the routing PR.
 SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "pr-gate-stale-sweep.yml",
     "windows-self-hosted-tests.yml",
     "linux-self-hosted-tests.yml",
+    "banner-guard.yml",
+    "solution-leak-guard.yml",
+    "prose-counts-guard.yml",
+    "notebook-interp-positioning.yml",
+    "notebook-cell-source-parses.yml",
+    "cell-order-gate.yml",
+    "pip-leak-guard.yml",
+    "hooks-parity.yml",
+    "notebook-exec-sequence-ratchet.yml",
+    "notebook-navlink-check.yml",
+    "notebook-papermill-ratchet.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -100,6 +100,98 @@ def test_universal_guard_with_combined_target_is_accepted(tmp_path):
     assert result.self_hosted_jobs == 1
 
 
+def test_bare_universal_guard_with_and_selection_is_rejected_with_parenthesis_hint(tmp_path):
+    """#14148 (reserve NanoClaw n.1) : la forme universelle NUE combinee a un
+    `&&` est refusee -- `&&` lie plus fort que `||`, donc la forme nue se lit
+    `A == null || (A == repo && sel)` et tourne sur tout evenement hors
+    pull_request quelle que soit la selection -- et le message nomme la
+    parenthese requise, pas seulement « must lead with the guard »."""
+    write_workflow(tmp_path, "windows-self-hosted-tests", """
+        name: bare-universal-and
+        on: [pull_request]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository && inputs.target == 'confinement' }}
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert codes(result) == {"SAME_REPO_GUARD"}
+    [violation] = result.violations
+    assert "parenthesised" in violation.message
+    assert "(<universal guard>) && <selection>" in violation.message
+
+
+def test_job_without_any_guard_keeps_generic_message(tmp_path):
+    """Le message « parenthesised » est reserve a la forme universelle nue +
+    `&&` : un job sans garde du tout garde le message generique."""
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: no-guard
+        on: [pull_request]
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo unsafe
+        """)
+    [violation] = policy.scan_workflows(tmp_path).violations
+    assert violation.code == "SAME_REPO_GUARD"
+    assert "parenthesised" not in violation.message
+
+
+def test_fork_reachable_comment_triggers_cannot_reach_self_hosted_job(tmp_path):
+    """#14148 (reserve NanoClaw n.2) : issue_comment / pull_request_review /
+    pull_request_review_comment tournent sur le code de la branche par defaut
+    mais leur payload nomme une PR potentiellement issue d'un fork -- un
+    `checkout refs/pull/N/head` executerait du code de fork sur le runner.
+    Refuses comme pull_request_target, garde ou pas."""
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: comment-driven
+        on: [issue_comment, pull_request_review, workflow_dispatch]
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    fork_reachable = [v for v in result.violations if v.code == "FORK_REACHABLE_TRIGGER"]
+    assert sorted(v.message.split(" ")[0] for v in fork_reachable) == [
+        "issue_comment",
+        "pull_request_review",
+    ]
+
+
+def test_push_and_schedule_triggers_remain_accepted_with_universal_guard(tmp_path):
+    """Contre-controle de la reserve n.2 : push / schedule / workflow_dispatch
+    ne portent que des refs du depot -- la branche `== null` de la garde
+    universelle y est sure par construction. Cas reels sur main :
+    banner-guard.yml (pull_request + push), hooks-parity.yml (+ schedule)."""
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: push-schedule
+        on:
+          pull_request:
+          push:
+            branches: [main]
+          schedule:
+            - cron: '7 3 * * *'
+          workflow_dispatch:
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository }}
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo safe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert result.violations == []
+    assert result.self_hosted_jobs == 1
+
+
 def test_universal_guard_weakened_by_or_is_rejected(tmp_path):
     """#13874 FN-safety : meme avec la forme universelle, l'ajout d'un
     `|| always()` ou `|| true` reintroduit le trou. La garde universelle


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/tooling #14126

See #13378 (tranche 1 du routage vers la jambe Linux conteneurisée). Décision coordinateur du 2026-09-01 sur l'issue ; la jambe est en ligne sur po-2024 depuis 20:24Z (2 slots, runner `myia-po-2024-linux-docker-*`, labels `self-hosted,coursia-ephemeral,coursia-linux`, preuve run 33554804211).

## Ce que fait la PR

11 guards **Python pur, sans secret, sans usage du `GITHUB_TOKEN`**, déclenchés sur `pull_request` (donc porteurs de la charge réelle de la file), passent de `ubuntu-latest` à `[self-hosted, coursia-ephemeral, coursia-linux]` :

`banner-guard` · `solution-leak-guard` · `prose-counts-guard` · `notebook-interp-positioning` · `notebook-cell-source-parses` · `cell-order-gate` · `pip-leak-guard` · `hooks-parity` · `notebook-exec-sequence-ratchet` · `notebook-navlink-check` · `notebook-papermill-ratchet` (parse-only : `check_papermill_ratchet.py`, pas d'exécution papermill).

Sur chaque job : `runs-on` dédié, garde same-repo **forme universelle** (#13874) au niveau job, `timeout-minutes: 10` là où il manquait (15 conservé sur solution-leak-guard), `permissions: contents: read` à la racine là où il manquait (hooks-parity). Le checker `scripts/ci/check_self_hosted_runner_policy.py` voit son `SELF_HOSTED_WORKFLOW_ALLOWLIST` étendu des 11 noms avec commentaire d'owner.

## Sécurité (invariants #13378)

- **Aucun code de fork n'atteint le runner** : la garde `github.event.pull_request.head.repo.full_name == null || ... == github.repository` saute le job sur une PR de fork ; `pr_gate.py` compte `skipped` comme OK (`CONCLUSION_OK`), donc la PR de fork reste mergeable. Les événements `push` / `schedule` / `workflow_dispatch` (champ `pull_request` nul) continuent de tourner — c'est la raison de la forme universelle plutôt que de la forme directe.
- Pas de `pull_request_target`, pas de secret, pas d'écriture via le token, labels exacts (le checker refuse un `runs-on` dynamique et tout jeu de labels non dédié).
- **Retour arrière = revert de cette PR** (aucun état côté runner).

## Écart avec le commentaire de décision sur #13378

Le commentaire nommait quatre guards `workflow_dispatch`-only (output-failure-ratchet, exercise-leak-ci, perimeter-review-guard, testpaths-coverage-guard). Ils portent **zéro charge automatique** : les router ne soulage pas la file. Ils sont remplacés par des guards de même classe (Python pur, sans secret) déclenchés sur `pull_request`, qui sont ceux qui dominent la file (216 runs en attente à 20:45Z).

**Exclus volontairement** : `notebook-execution-required.yml` (`issues: write` + `pull-requests: write` + `actions/github-script` + exécution de notebooks) ; `secret-scan.yml` (télécharge un binaire gitleaks — candidat tranche 2 après mesure d'empreinte) ; tout workflow à token en écriture.

## Validation

- `python scripts/ci/check_self_hosted_runner_policy.py --check` → `workflows=130 jobs=158 self_hosted=14`, OK.
- `python -m pytest scripts/tests/test_check_self_hosted_runner_policy.py -q` → 41 passed (dont `test_current_repository_self_hosted_jobs_satisfy_isolation_policy`, qui scanne le dépôt réel).
- **Contrôle positif** : le checker de `main` (forme directe seule, sans les entrées d'allowlist) rejette les 11 workflows — 22 violations (`SAME_REPO_GUARD` ×11 + `WORKFLOW_NOT_ALLOWED` ×11). L'allowlist et la forme universelle sont toutes deux porteuses.
- Parse YAML des **11 workflows routés** + vérification structurelle (runs-on / if / timeout / permissions) par script.
- **Périmètre effectif de la PR : 13 fichiers** — les 11 workflows ci-dessus (`banner-guard`, `cell-order-gate`, `hooks-parity`, `notebook-cell-source-parses`, `notebook-exec-sequence-ratchet`, `notebook-interp-positioning`, `notebook-navlink-check`, `notebook-papermill-ratchet`, `pip-leak-guard`, `prose-counts-guard`, `solution-leak-guard`) plus `scripts/ci/check_self_hosted_runner_policy.py` et `scripts/tests/test_check_self_hosted_runner_policy.py`. Aucun autre fichier touché.

## Empilement et ordre de merge

**Base** : #13947 (forme universelle acceptée par le checker) est mergée le 2026-09-01 ; la branche est rebasée dessus — 2 commits de routage + 1 commit de durcissement du checker (réserves NanoClaw ci-dessous).

## Partition avec la claim po-2024 (#13378)

La claim po-2024 du 2026-08-31 couvre `scripts/ci/check_self_hosted_runner_policy.py` et `docs/ci/self-hosted-runners.md`. Cette PR ne touche le checker que sur le bloc `SELF_HOSTED_WORKFLOW_ALLOWLIST` (l'ordre de merge est tenu par ai-01). **La doc reste à po-2024** (PR doc + persistance en vol) : lignes à mettre à jour nommées dans le DM — §« Tranches suivantes » (phrase « 93 jobs restent sur GitHub-hosted » caduque), forme de garde citée, ligne `coursia-linux` de la table des labels.

## Après merge — à po-2024

Mesurer l'empreinte réelle des 11 jobs sur les 2 slots (durée, RAM, `setup-python` en cache ou pas) et régler N. Risque nommé : si la file `coursia-linux` dépasse le timeout de `pr_gate.py`, le verdict devient `STARVED` (exit 1, jamais un vert par défaut) — c'est le signal pour monter N ou dérouter une partie des 11 vers `ubuntu-latest`.


## Réserves NanoClaw (review 2026-09-01T21:17Z) — traitées en code (commit 46888afb7)

- **Réserve 1** (docstring « parenthèses optionnelles ») : `_starts_with_accepted_guard` documente désormais que la forme universelle combinée à `&&` **doit** être parenthésée (`&&` lie plus fort que `||` : la forme nue exécute le job sur tout événement hors `pull_request` quelle que soit la sélection). La violation `SAME_REPO_GUARD` nomme la parenthèse requise quand c'est le défaut.
- **Réserve 2** (`== null` vrai hors PR) : le checker refuse sur self-hosted les événements dont le payload peut nommer une PR de fork — `issue_comment`, `pull_request_review`, `pull_request_review_comment` (`FORK_REACHABLE_TRIGGER`) — en plus de `pull_request_target` / `workflow_run` / `workflow_call` déjà refusés. `push` / `schedule` / `workflow_dispatch` (refs du dépôt uniquement) restent acceptés : 3 des 11 workflows routés les portent (`banner-guard`, `notebook-cell-source-parses`, `hooks-parity`), et c'est la raison de la forme universelle.

4 tests ajoutés (45 verts) ; `check_self_hosted_runner_policy.py --check` : OK, 131 workflows, 14 jobs self-hosted.

