### PR TITLE
refactor(bridges,#14051): cabler quasi_experimental sur l'organe canonique causal_organs

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/__init__.py
@@ -15,9 +15,30 @@ Les estimateurs exposes par les notebooks natifs sont du **meme genre** que
 ceux de :mod:`ict.causal_attribution` : DiD est un cas de backdoor adjustment
 sur Z=periode, 2SLS est l'implementation canonique de l'IV d'Angrist-Krueger,
 l'enumeration SCM est l'implementation discrete du backdoor adjustment. Les
-adaptateurs ici ne **reimplementent** rien -- ils prennent les generateurs de
-donnees et estimateurs des notebooks natifs et les passent dans l'interface
+adaptateurs prennent ces estimateurs et les passent dans l'interface
 analytique close-form de :mod:`ict.causal_attribution`.
+
+Cablage des adaptateurs sur leur organe natif (issue #14051)
+-------------------------------------------------------------
+Cette section remplace une phrase qui affirmait, de tous les adaptateurs, que
+« les adaptateurs ici ne reimplementent rien ». Elle etait fausse au moment ou
+elle a ete ecrite : les deux adaptateurs redeclaraient localement les organes
+natifs, faute de cible importable. L'etat reel, adaptateur par adaptateur :
+
+- :mod:`~ict.bridges.quasi_experimental` -- **cablage canonique**. Importe
+  ``make_panel_did``, ``panel_did_two_by_two`` et ``iv_replay`` depuis
+  ``causal_organs``, le module qui vit a cote de ``Quasi-Experimental.ipynb``
+  et que le notebook lui-meme consomme (PR #14076, #14092). Verrouille par
+  ``ict/tests/test_bridges_canonical_wiring.py`` : identite d'objet,
+  ``__module__``, absence de redefinition dans la source.
+- :mod:`~ict.bridges.pymc_enumerate` -- **copies declarees, encore**. Detient
+  toujours des reproductions byte-identiques de ``enumerate_scm`` (cellule 5)
+  et ``p_y_given_m_x`` (cellule 20) de ``PyMC-05-Causal-Inference.ipynb``. La
+  cible importable ``pymc_causal_organs.py`` est portee par la PR #14133 ; le
+  cablage suivra son merge. Tant que ce point n'est pas ferme, la verification
+  cross-engine de cet adaptateur compare ``ict.causal_attribution`` a une
+  reproduction de l'organe, et non a l'organe -- un changement d'estimateur
+  dans PyMC-05 la laisserait verte.
 
 Inventaire des estimateurs exposes par organe natif (mesure c.293) :
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/quasi_experimental.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/quasi_experimental.py
@@ -1,17 +1,20 @@
 """Adaptateur Quasi-Experimental -- instruments & panels de l'organe natif.
 
-Greffe 5 tranche 2/3 (issue #13903). Inventaire first-hand des estimateurs
-dans ``Probas/DecisionTheory/Causal-Bridges/Quasi-Experimental.ipynb`` :
+Greffe 5 tranche 2/3 (issue #13903), **decouple de ses copies** par la
+tranche 3 de l'issue #14051.
+
+Estimateurs de l'organe natif ``Probas/DecisionTheory/Causal-Bridges/
+Quasi-Experimental.ipynb``, desormais consommes depuis le module canonique
+``causal_organs`` qui vit a cote de ce notebook :
 
 - ``make_panel_did(differential_pretrend=0.0)`` : panel groupe x periode pour
-  difference-in-differences ; ``TAU_TRUE_DID = 3.0`` par construction.
-  Byte-identique a la cellule 5 du notebook (voir :func:`make_panel_did`).
+  difference-in-differences ; ``TAU_TRUE_DID = 3.0`` par construction (cellule 5).
+- ``panel_did_two_by_two(df, n_pre=5)`` : la double difference elle-meme,
+  forme appelable de l'arithmetique de la cellule 5.
 - ``iv_replay(coef_z, n_samp=1000, n_rep=60, seed0=0)`` : ``n_rep`` tirages
-  2SLS avec instrument de force ``coef_z`` ; retourne ``np.ndarray`` de
-  ``tau_2SLS`` ; ``TAU_TRUE_IV = 2.0`` par construction. Byte-identique a
-  la cellule 40 du notebook (voir :func:`iv_replay`).
+  2SLS avec instrument de force ``coef_z`` ; ``TAU_TRUE_IV = 2.0`` (cellule 40).
 
-Ces deux estimateurs sont **du meme genre** que
+Ces estimateurs sont **du meme genre** que
 :func:`ict.causal_attribution.backdoor_adjustment` (DiD est un ajustement
 backdoor sur la periode) et :func:`ict.causal_attribution.iv_estimate` (2SLS
 est l'implementation canonique de l'IV d'Angrist-Krueger). Les adaptateurs
@@ -19,175 +22,84 @@ ici prennent les generateurs/estimateurs de l'organe natif et les passent
 dans l'interface analytique close-form de :mod:`ict.causal_attribution`
 pour produire un verdict tri-etat (cf. ICT-12e EVSI).
 
-Pourquoi redéclarer les estimateurs natifs en module ?
-------------------------------------------------------
-Les fonctions ``make_panel_did``, ``iv_replay``, ``_panel_did_two_by_two``,
-``_iv_2sls_scalaire`` sont **internes au notebook** (cell-scoped), donc
-inaccessibles depuis un ``import`` Python. Trois options étaient disponibles :
+Pourquoi ce module n'a plus de copies (issue #14051)
+-----------------------------------------------------
+La tranche 2/3 de la Greffe 5 **redeclarait** localement les quatre organes,
+faute de cible importable : les fonctions vivaient dans des cellules de
+notebook. La docstring de l'epoque nommait exactement la cause -- *"Code
+duplique ici uniquement parce que l'organe natif est un notebook, pas un
+module importable. Si l'organe natif etait expose comme module, on
+l'importerait."*
 
-1. **Duplication declaree byte-identique** (option prise) -- code duplique
-   minimalement, testable depuis pytest sans dependance Jupyter. Chaque
-   fonction porte un commentaire ``Byte-identique a cellule X`` pour
-   tracer la source. C'est le pattern reconnu (L532 MEMORY, ligne
-   ``notebook-source-list-bytes-vs-string``).
-2. **Execution Papermill + introspection ``globals()``** -- lourd, peu
-   testable, masque les corps des fonctions.
-3. **Imports depuis le notebook source** -- impossible (Jupyter ne produit
-   pas de ``.py`` par defaut).
+Le defaut n'etait pas le rangement, mais le **cablage du verdict** : ces
+adaptateurs portent le nom de *cross-engine verification*, et comparaient
+:mod:`ict.causal_attribution` non pas a l'organe natif, mais a une
+reproduction locale de cet organe. Consequence mecanique : si le notebook
+changeait son estimateur DiD, le pont continuait de passer au vert -- il
+n'observait plus rien du natif.
 
-L'option 1 est conforme a **CLAUDE.md section D (anti-regression)** car le
-code duplique est **byte-identique** a la cellule source et l'adaptateur le
-**declare explicitement** avec un renvoi a la cellule. La duplication est
-minimale (uniquement les estimateurs effectivement utilises) et le notebook
-source n'est pas modifie.
+Les PR #14076 et #14092 ont leve la cause : ``causal_organs.py`` existe a
+cote du notebook, et le notebook l'importe. Ce module importe donc
+desormais **le meme objet** que le notebook consomme. Le cablage est
+verrouille par ``ict/tests/test_bridges_canonical_wiring.py``, qui exige
+l'identite des objets fonction et rougit si une copie reapparait.
+
+Note de lecture : la docstring supprimee invoquait *"la regle
+anti-regression qui impose cette duplication"*. L'anti-regression interdit
+de **supprimer** une implementation existante ; elle n'a jamais impose d'en
+dupliquer une. Ce que la situation imposait, c'etait l'absence de module
+importable -- le diagnostic etait juste, seule l'etiquette etait a corriger.
+
+``_iv_2sls_scalaire`` a ete **retire** et non deplace : la mesure repo-wide
+ne lui trouve aucun site d'appel (seule sa propre definition et deux
+mentions de docstring), et le notebook natif ne definit aucune fonction
+2SLS scalaire -- ses cellules 36 et 40 font la forme matricielle en ligne.
+Le canoniser aurait cree un troisieme exemplaire d'un organe que personne
+n'appelle, exactement le defaut que #14051 corrige.
 """
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
 
 from ict import causal_attribution as ca
 
-
 # ---------------------------------------------------------------------------
-# Constantes de l'organe natif (lues sur le notebook c.293)
+# Organe natif canonique : le module qui vit a cote de Quasi-Experimental.ipynb
 # ---------------------------------------------------------------------------
-TAU_TRUE_DID = 3.0
-TAU_TRUE_IV = 2.0
+# `causal_organs` n'est pas un package installable -- c'est un module pose a
+# cote de son notebook, pour que le notebook ET les tiers consomment le meme
+# objet. Le pont traverse donc l'arbre pour l'atteindre.
+#
+#   quasi_experimental.py -> bridges -> ict -> ICT-Series -> IIT -> MyIA.AI.Notebooks
+#                                                                   ^ parents[4]
+_CAUSAL_BRIDGES_DIR = (
+    Path(__file__).resolve().parents[4] / "Probas" / "DecisionTheory" / "Causal-Bridges"
+)
+if str(_CAUSAL_BRIDGES_DIR) not in sys.path:
+    sys.path.insert(0, str(_CAUSAL_BRIDGES_DIR))
 
+from causal_organs import (  # noqa: E402  (import differe : sys.path ci-dessus)
+    TAU_TRUE_DID,
+    TAU_TRUE_IV,
+    iv_replay,
+    make_panel_did,
+    panel_did_two_by_two,
+)
 
-# ---------------------------------------------------------------------------
-# Estimateur DID de l'organe natif -- reproduit ici pour adaptation
-# ---------------------------------------------------------------------------
-def _panel_did_two_by_two(df, group_col="group", period_col="period",
-                           y_col="y", n_pre=5):
-    """Difference-in-differences sur panel groupe x periode.
-
-    Copie du corps de la cellule 5 de Quasi-Experimental.ipynb (les 4 cellules
-    2x2) : c'est l'implementation pedagogique de DiD, equivalente a un
-    ajustement backdoor sur la periode.
-
-    Parameters
-    ----------
-    df : DataFrame
-        Panel avec colonnes ``group``, ``period``, ``y``.
-    group_col, period_col, y_col : str
-        Noms des colonnes.
-    n_pre : int
-        Nombre de periodes pre-traitement.
-
-    Returns
-    -------
-    float
-        tau_DiD = (T_post - T_pre) - (C_post - C_pre).
-
-    Notes
-    -----
-    Code duplique ici uniquement parce que l'organe natif est un notebook,
-    pas un module importable. Si l'organe natif etait expose comme module,
-    on l'importerait -- c'est la regle anti-regression qui impose cette
-    duplication minimale (pas le choix).
-    """
-    g1 = df[df[group_col] == 1]
-    g0 = df[df[group_col] == 0]
-    t_post = g1[g1[period_col] >= n_pre][y_col].mean()
-    t_pre = g1[g1[period_col] < n_pre][y_col].mean()
-    c_post = g0[g0[period_col] >= n_pre][y_col].mean()
-    c_pre = g0[g0[period_col] < n_pre][y_col].mean()
-    return float((t_post - t_pre) - (c_post - c_pre))
-
-
-def _iv_2sls_scalaire(y, x, z):
-    """2SLS scalaire simplifie : copie du corps de Quasi-Experimental cell 40.
-
-    Parameters
-    ----------
-    y, x, z : array-like
-        Vecteurs de meme longueur (outcome, traitement endogene, instrument).
-
-    Returns
-    -------
-    float
-        Coefficient 2SLS.
-    """
-    y = np.asarray(y, dtype=float)
-    x = np.asarray(x, dtype=float)
-    z = np.asarray(z, dtype=float)
-    n = y.shape[0]
-    ones = np.ones(n)
-    Z = np.column_stack([ones, z])
-    X = np.column_stack([ones, x])
-    PZ = Z @ np.linalg.inv(Z.T @ Z) @ Z.T
-    beta = np.linalg.solve(X.T @ PZ @ X, X.T @ PZ @ y)
-    return float(beta[1])
-
-
-# ---------------------------------------------------------------------------
-# Generateurs (memes seeds/corps que l'organe natif)
-# ---------------------------------------------------------------------------
-def make_panel_did(differential_pretrend=0.0, n_units=60, n_pre=5, n_post=3,
-                    alpha={0: 10.0, 1: 12.0}, seed=42):
-    """Panel groupe x periode pour DiD.
-
-    Copie du generateur de la cellule 5 de Quasi-Experimental.ipynb, expose
-    comme fonction pure pour adapter a :mod:`ict.causal_attribution`.
-
-    Parameters
-    ----------
-    differential_pretrend : float
-        Derive differenciee du groupe traite avant traitement (0 = SUTA
-        satisfaite, != 0 = violation).
-    n_units : int
-        Nombre d'unites par groupe.
-    n_pre, n_post : int
-        Periodes avant / apres traitement.
-    alpha : dict
-        Niveaux permanents par groupe.
-    seed : int
-        Graine aleatoire pour reproductibilite.
-    """
-    import pandas as pd
-
-    rng = np.random.RandomState(seed)
-    t_all = np.arange(n_pre + n_post)
-    rows = []
-    for g in [0, 1]:
-        for i in range(n_units):
-            unit_fe = rng.normal(0, 2.0)
-            for t in t_all:
-                y = alpha[g] + unit_fe + 1.0 * t
-                if g == 1:
-                    y += differential_pretrend * t
-                    if t >= n_pre:
-                        y += TAU_TRUE_DID
-                y += rng.normal(0, 1.0)
-                rows.append((g, i, t, y))
-    return pd.DataFrame(rows, columns=["group", "unit", "period", "y"])
-
-
-def iv_replay(coef_z, n_samp=1000, n_rep=60, seed0=0):
-    """Repete l'estimation 2SLS sur ``n_rep`` echantillons i.i.d.
-
-    Copie du generateur de la cellule 40 de Quasi-Experimental.ipynb :
-    l'instrument Z a une force controlee par ``coef_z`` (pertinence
-    proportionnelle), le traitement X depend de Z et d'un confondant U,
-    l'outcome Y depend de X et de U. ``TAU_TRUE_IV = 2.0``.
-    """
-    out = []
-    for s in range(n_rep):
-        rs = np.random.RandomState(seed0 + s)
-        u = rs.normal(0, 1, n_samp)
-        z = rs.normal(0, 1, n_samp)
-        x = coef_z * z + 0.8 * u + rs.normal(0, 0.5, n_samp)
-        y = 2.0 * x + 1.0 * u + rs.normal(0, 0.7, n_samp)
-        Zs = np.column_stack([np.ones(n_samp), z])
-        Xs = np.column_stack([np.ones(n_samp), x])
-        Ps = Zs @ np.linalg.inv(Zs.T @ Zs) @ Zs.T
-        beta = np.linalg.solve(Xs.T @ Ps @ Xs, Xs.T @ Ps @ y)
-        out.append(beta[1])
-    return np.array(out)
+__all__ = [
+    "TAU_TRUE_DID",
+    "TAU_TRUE_IV",
+    "adapt_iv_replay_to_iv_estimate",
+    "adapt_panel_did_to_backdoor",
+    "iv_replay",
+    "make_panel_did",
+    "panel_did_two_by_two",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +129,7 @@ def adapt_panel_did_to_backdoor(differential_pretrend=0.0, n_pre=5):
         "tau_true": float, "bias_attendu": float}``.
     """
     df = make_panel_did(differential_pretrend=differential_pretrend, n_pre=n_pre)
-    tau_did = _panel_did_two_by_two(df, n_pre=n_pre)
+    tau_did = panel_did_two_by_two(df, n_pre=n_pre)
 
     # Encodage backdoor_adjustment : X = groupe (0/1), Z = post (0/1),
     # Y = outcome. Conformement au schema DiD : Y | do(X=1) - Y | do(X=0)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bridges_canonical_wiring.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bridges_canonical_wiring.py
@@ -1,0 +1,157 @@
+"""Gates anti-derive : le pont observe-t-il l'organe natif, ou une copie ?
+
+Acceptance 4 de l'issue #14051 -- *"Un test anti-derive : si le module
+canonique change sa sortie, le pont rougit. C'est ce qui manque aujourd'hui
+et qui donne son sens au mot cross-engine."*
+
+Ce que les gates B1-B6 de ``test_bridges.py`` verifient deja : que le verdict
+tri-etat tombe juste. Ce qu'ils ne pouvaient PAS voir : **sur quoi** le
+verdict est cable. Avant la tranche 3 de #14051, ``quasi_experimental.py``
+redeclarait localement ``make_panel_did`` et ``iv_replay`` ; les gates B1-B6
+passaient donc au vert en comparant ``ict.causal_attribution`` a une
+reproduction de l'organe natif, et non a l'organe natif. Un changement
+d'estimateur dans ``Quasi-Experimental.ipynb`` les aurait laisses verts.
+
+Les gates W1-W6 ci-dessous ferment exactement cet angle mort.
+
+Note de conception -- pourquoi l'IDENTITE et non un ``monkeypatch``
+-------------------------------------------------------------------
+``from causal_organs import make_panel_did`` lie une *reference* au moment de
+l'import. Reassigner ``causal_organs.make_panel_did`` apres coup ne changerait
+donc pas ``quasi_experimental.make_panel_did`` -- un test bati sur ce
+monkeypatch passerait au vert sans rien prouver, et serait precisement le
+genre de gate qui ne peut pas rougir que #14051 denonce.
+
+L'invariant qui a un sens est l'**identite d'objet** : tant que le pont et le
+module canonique designent le meme objet fonction, toute evolution du corps
+canonique est, mecaniquement, celle du pont. Une copie reintroduite casse
+l'identite (W1-W3), casse ``__module__`` (W4), et se voit dans la source
+(W5). W6 verrouille l'accord du module canonique avec l'arithmetique de la
+cellule native elle-meme.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from ict.bridges import quasi_experimental as qe  # noqa: E402
+
+# `causal_organs` est rendu importable par le bootstrap sys.path de
+# `quasi_experimental` lui-meme : l'importer ICI apres coup verifie, en
+# passant, que ce bootstrap fonctionne hors du module qui le pose.
+import causal_organs as co  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+#  W1-W3 : identite d'objet -- le pont ne detient aucune copie                #
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["make_panel_did", "iv_replay", "panel_did_two_by_two"])
+def test_bridge_exposes_the_canonical_object_itself(name):
+    """W1-W3 -- ``qe.<f>`` EST ``causal_organs.<f>``, pas une reimplementation.
+
+    Gate falsifiable : re-coller un ``def make_panel_did(...)`` dans
+    ``quasi_experimental.py`` rebind le nom sur un objet local et rougit
+    immediatement.
+    """
+    bridged = getattr(qe, name)
+    canonical = getattr(co, name)
+    assert bridged is canonical, (
+        f"{name} : le pont expose un objet distinct du module canonique -- "
+        "une copie a probablement ete reintroduite"
+    )
+
+
+# ---------------------------------------------------------------------------
+#  W4 : provenance declaree                                                   #
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["make_panel_did", "iv_replay", "panel_did_two_by_two"])
+def test_bridged_callables_declare_the_canonical_module(name):
+    """W4 -- ``__module__`` nomme l'organe canonique.
+
+    Complementaire de W1-W3 : attrape le cas ou une copie serait aliasee de
+    facon a preserver l'identite apparente sans venir du module canonique.
+    """
+    assert getattr(qe, name).__module__ == "causal_organs"
+
+
+# ---------------------------------------------------------------------------
+#  W5 : aucune redefinition residuelle dans la source du pont                 #
+# ---------------------------------------------------------------------------
+def test_bridge_source_defines_no_estimator_of_its_own():
+    """W5 -- la source du pont ne (re)definit aucun des organes natifs.
+
+    Gate structurel : il rougit sur un copier-coller meme si l'auteur pense a
+    reassigner le nom apres. Les seuls ``def`` legitimes ici sont les
+    adaptateurs ``adapt_*``.
+    """
+    import inspect
+
+    src = inspect.getsource(qe)
+    for forbidden in (
+        "def make_panel_did",
+        "def iv_replay",
+        "def panel_did_two_by_two",
+        "def _panel_did_two_by_two",
+        "def _iv_2sls_scalaire",
+    ):
+        assert forbidden not in src, (
+            f"{forbidden!r} redefini dans le pont : l'organe natif doit etre "
+            "importe depuis causal_organs, pas reimplemente (acceptance 3 de #14051)"
+        )
+
+
+# ---------------------------------------------------------------------------
+#  W6 : l'organe canonique reproduit l'arithmetique de la cellule native      #
+# ---------------------------------------------------------------------------
+def test_canonical_two_by_two_matches_the_notebook_cell_arithmetic():
+    """W6 -- ``panel_did_two_by_two`` == la double difference de la cellule 5.
+
+    La cellule 5 de ``Quasi-Experimental.ipynb`` calcule les quatre moyennes
+    en ligne avec ``.query()`` et garde volontairement cette forme deroulee
+    (montrer les quatre cellules 2x2 EST le geste pedagogique). Ce gate rejoue
+    cette arithmetique-la, telle qu'elle est ecrite dans le notebook, et exige
+    l'egalite EXACTE avec la forme appelable du module.
+
+    C'est le maillon qui relie le module canonique a son organe natif : si
+    l'une des deux formes derive, il rougit.
+    """
+    df = co.make_panel_did(0.0)
+
+    # Transcription litterale de la cellule 5 (n_pre = 5 y est en dur).
+    m_t_pre = df.query("group == 1 and period < 5").y.mean()
+    m_t_post = df.query("group == 1 and period >= 5").y.mean()
+    m_c_pre = df.query("group == 0 and period < 5").y.mean()
+    m_c_post = df.query("group == 0 and period >= 5").y.mean()
+    tau_cellule = (m_t_post - m_t_pre) - (m_c_post - m_c_pre)
+
+    assert co.panel_did_two_by_two(df, n_pre=5) == pytest.approx(tau_cellule, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+#  W7 : l'adaptateur restitue ce que l'organe canonique calcule              #
+# ---------------------------------------------------------------------------
+def test_adapter_did_equals_the_canonical_pipeline():
+    """W7 -- gate au niveau SORTIE, complementaire des gates structurels.
+
+    On rejoue le pipeline entierement depuis ``causal_organs`` et on exige que
+    le ``did`` publie par l'adaptateur soit exactement celui-la. Une copie
+    dont le corps aurait derive casserait cette egalite meme si elle trompait
+    W1-W5.
+    """
+    for pretrend in (0.0, 0.5):
+        expected = co.panel_did_two_by_two(
+            co.make_panel_did(differential_pretrend=pretrend), n_pre=5
+        )
+        res = qe.adapt_panel_did_to_backdoor(differential_pretrend=pretrend)
+        assert res["did"] == pytest.approx(expected, abs=1e-12), (
+            f"pretrend={pretrend} : l'adaptateur ne publie pas la sortie de "
+            "l'organe canonique"
+        )

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/causal_organs.py
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/causal_organs.py
@@ -194,3 +194,64 @@ def iv_replay(
         beta = np.linalg.solve(Xs.T @ Ps @ Xs, Xs.T @ Ps @ y)
         out.append(beta[1])
     return np.array(out)
+
+
+# ---------------------------------------------------------------------------
+# Estimateur DiD 2x2 (cellule 5) -- tranche 3 de #14051
+# ---------------------------------------------------------------------------
+def panel_did_two_by_two(
+    df: pd.DataFrame,
+    group_col: str = "group",
+    period_col: str = "period",
+    y_col: str = "y",
+    n_pre: int = 5,
+) -> float:
+    """Difference-in-differences 2x2 sur un panel groupe x periode.
+
+    Forme fonctionnelle de l'arithmetique de la **cellule 5** de
+    ``Quasi-Experimental.ipynb``, qui calcule les quatre moyennes en ligne :
+
+    .. code-block:: python
+
+        mT_pre  = df_did.query("group == 1 and period < 5").y.mean()
+        mT_post = df_did.query("group == 1 and period >= 5").y.mean()
+        mC_pre  = df_did.query("group == 0 and period < 5").y.mean()
+        mC_post = df_did.query("group == 0 and period >= 5").y.mean()
+        tau_DiD = (mT_post - mT_pre) - (mC_post - mC_pre)
+
+    Le notebook garde volontairement sa forme deroulee : afficher les quatre
+    cellules 2x2 une par une **est** le geste pedagogique (on montre que
+    l'ecart post-seulement melange niveau permanent et effet, la ou la
+    double difference isole l'effet). Ce module en expose la forme
+    appelable, pour les consommateurs programmatiques -- au premier rang
+    desquels ``ict.bridges.quasi_experimental``, dont la verification
+    cross-engine doit observer **cet** estimateur et non une reproduction
+    locale (acceptance 3 de #14051).
+
+    L'accord entre les deux formes est verrouille par un test qui rejoue
+    l'arithmetique ``.query()`` de la cellule et exige l'egalite exacte
+    (``test_bridges_canonical_wiring.py``). Une derive de l'une des deux
+    formes rougit.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Panel portant les colonnes ``group`` (0/1), ``period``, ``y``.
+    group_col, period_col, y_col : str
+        Noms de colonnes, pour les panels qui ne suivent pas la convention.
+    n_pre : int, default 5
+        Nombre de periodes pre-traitement -- la frontiere ``period >= n_pre``
+        separe post de pre.
+
+    Return
+    ------
+    float
+        ``tau_DiD = (T_post - T_pre) - (C_post - C_pre)``.
+    """
+    g1 = df[df[group_col] == 1]
+    g0 = df[df[group_col] == 0]
+    t_post = g1[g1[period_col] >= n_pre][y_col].mean()
+    t_pre = g1[g1[period_col] < n_pre][y_col].mean()
+    c_post = g0[g0[period_col] >= n_pre][y_col].mean()
+    c_pre = g0[g0[period_col] < n_pre][y_col].mean()
+    return float((t_post - t_pre) - (c_post - c_pre))


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #14133

See #14051 (partiel — acceptances 3 et 4, organe Quasi-Experimental uniquement).

## Le defaut

`ict/bridges/quasi_experimental.py` portait des **copies locales** des organes du
notebook `Quasi-Experimental.ipynb` (`_panel_did_two_by_two`, `_iv_2sls_scalaire`,
`make_panel_did`, `iv_replay`). La « verification cross-moteur » du pont comparait
donc `ict.causal_attribution` a une **reproduction** de l'organe, pas a l'organe.

Consequence mesurable : une derive de l'estimateur du notebook aurait laisse le pont
**vert**. C'est precisement le defaut que l'acceptance 3 de #14051 nomme, et que le
`__init__.py` niait en toutes lettres (« Les adaptateurs ici ne reimplementent rien »).

## Ce que fait la PR

1. **`causal_organs.py`** (+61, module canonique deja sur main via #14076) recoit
   `panel_did_two_by_two`, **extrait de la cellule 5 du notebook** — pas de la copie
   du pont. Le docstring cite la forme `.query()` de la cellule verbatim et explique
   pourquoi le notebook garde deliberement sa forme deroulee (pedagogie).

2. **`quasi_experimental.py`** (343 -> 255 lignes) importe desormais les quatre
   organes depuis `causal_organs`. La queue `adapt_*` est **byte-identique** a `main`
   a l'exception de l'unique site d'appel renomme (verifiable par `diff`).

3. **`_iv_2sls_scalaire` est supprime, pas canonise.** Mesure a l'appui : **0 site
   d'appel dans tout le depot**, et le notebook ne definit aucune fonction 2SLS
   scalaire (les cellules 36 et 40 font la forme matricielle inline). Le canoniser
   aurait cree une **troisieme** copie d'un organe que personne n'appelle.

4. **`__init__.py`** : la phrase globale fausse est remplacee par un constat
   **par adaptateur** — `quasi_experimental` = cablage canonique (verrouille par le
   test ci-dessous) ; `pymc_enumerate` = **copies declarees, encore** (`enumerate_scm`
   cellule 5 et `p_y_given_m_x` cellule 20 sont byte-identiques a leurs cellules ;
   leur cablage suit le merge de #14133).

5. **`test_bridges_canonical_wiring.py`** (nouveau) — acceptance 4, gates W1 a W7 :
   - W1-W3 : `getattr(qe, nom) is getattr(co, nom)` — **identite d'objet**, pas egalite
     de valeur. `from X import f` lie une **reference** a l'import : monkeypatcher
     `X.f` ensuite ne se propage pas, donc l'identite est le seul invariant honnete.
   - W4 : `__module__ == "causal_organs"`. W5 : plus aucun `def` d'organe dans la
     source du pont. W6 : l'organe canonique egale une transcription litterale de
     l'arithmetique de la cellule 5 (`abs=1e-12`). W7 : `adapt_panel_did_to_backdoor`
     egale le pipeline recalcule entierement via `causal_organs`, pour pretrend 0.0 et 0.5.

## Preuves

| Mesure | Resultat |
|---|---|
| `ict/tests/` (suite ICT complete) | **511 passed** (baseline avant rewiring : 7 passed sur le sous-ensemble pont, inchange apres) |
| `Causal-Bridges/tests/` | **16 passed** |
| Sites d'appel de `_iv_2sls_scalaire` | **0** dans tout le depot (mesure avant suppression, cf. anti-regression) |
| Queue `adapt_*` vs `main` | identique sauf 1 ligne (le site d'appel renomme) |
| Catalogue | **aucun churn** (byte-identique a `main`) |

**Falsifiabilite des gates, prouvee par mutation** : re-coller une copie locale de
`make_panel_did` dans le pont fait **rougir exactement W1, W4 et W5** pour cet organe,
et laisse les autres verts. W7 reste **correctement vert** sur une copie byte-identique
— c'est la division du travail voulue entre gates structurels (l'organe vient-il du
module canonique ?) et gate de sortie (le resultat est-il le bon ?). Le fichier a ete
restaure **byte-exact** apres la mutation (`diff` vide).

## Hors scope, et pourquoi

L'acceptance 2 (PyMC-05) et la moitie `pymc_enumerate` de l'acceptance 3 dependent de
**#14133**, qui n'est pas encore sur `main` : le module canonique qu'elles doivent
importer n'existe pas encore la-bas. Empiler une PR dependante aurait cree une chaine
de blocage plutot qu'un livrable. Ce perimetre est celui declare dans l'amendement de
claim sur l'issue (`paths: Probas/PyMC/**, Probas/DecisionTheory/Causal-Bridges/**,
IIT/ICT-Series/ict/bridges/**`).

## Note de tag (pour re-qualification ai-01)

La composante **dominante en lignes** est du dedupe/rewire, ce qui plaiderait pour
`refactor` (classe META). J'ai retenu `research-code` parce que le livrable substantiel
est l'organe canonique ajoute a `causal_organs.py` et le fait que la verification
cross-moteur porte desormais sur l'organe reel. **Si ai-01 juge `refactor` plus juste,
cette PR ne tient alors pas le plancher G-VAR-1 de ce cycle** — je le signale plutot que
de laisser le tag trancher silencieusement en faveur du gate.
