### PR TITLE
refactor(notebook-tools): consolidate .NET executors

### DIFF
--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -19,7 +19,7 @@ Les scripts `scripts/fix_*.py` / `scripts/recycle_*.py` à la racine sont des on
 |--------|-------|
 | `wsl_papermill.py` | **Papermill INSIDE WSL** pour kernels GameTheory/Lean Python (`execute` / `batch` / `check-env`) — cf [.claude/rules/wsl-kernels.md](../../.claude/rules/wsl-kernels.md) |
 | `batch_reexecute.py` | Re-exécution Papermill en lot |
-| `dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py` | Exécution .NET Interactive (cell-by-cell, kernel persistant) |
+| `dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py` | Exécution .NET Interactive : moteur cell-by-cell canonique (`dotnet_executor.py`), wrapper CLI historique (`exec_dotnet_persist.py`) et exécution ciblée |
 | `execute_qcpy_docker.py`, `qc_quantbook_execute.py` | Exécution QuantConnect (Quantbooks via Docker/QC Cloud) |
 | `_exec_bdd_csharp.py` | Exécution C# BDD interne |
 

--- a/scripts/notebook_tools/dotnet_executor.py
+++ b/scripts/notebook_tools/dotnet_executor.py
@@ -67,15 +67,76 @@ def _wait_for_idle(kc, grace_s):
     return False
 
 
+def split_text_lines(text):
+    """Return text using the historical nbformat list-of-lines convention."""
+    lines = text.split("\n")
+    return [line + "\n" for line in lines[:-1]] + (
+        [lines[-1]] if lines[-1] else []
+    )
+
+
+def _normalize_output_data(data, text_as_lines=False, allowed_mime_types=None):
+    """Normalize an iopub data bundle for notebook persistence."""
+    if allowed_mime_types is not None:
+        data = {mime: value for mime, value in data.items()
+                if mime in allowed_mime_types}
+    if not text_as_lines:
+        return data
+    return {
+        mime: split_text_lines(value) if isinstance(value, str) else value
+        for mime, value in data.items()
+    }
+
+
+def _collect_late_outputs(kc, parent_msg_id, outputs, exec_counter,
+                          idle_grace, text_as_lines, allowed_mime_types):
+    """Collect display results flushed just after the matching idle message."""
+    deadline = time.time() + idle_grace
+    while time.time() < deadline:
+        try:
+            msg = kc.get_iopub_msg(timeout=min(0.3, idle_grace))
+        except Exception:
+            return
+        if msg.get("parent_header", {}).get("msg_id") != parent_msg_id:
+            continue
+        msg_type = msg.get("msg_type")
+        if msg_type not in ("display_data", "execute_result"):
+            continue
+        content = msg.get("content", {})
+        output = {
+            "output_type": msg_type,
+            "metadata": {},
+            "data": _normalize_output_data(
+                content.get("data", {}), text_as_lines, allowed_mime_types
+            ),
+        }
+        if msg_type == "execute_result":
+            output["execution_count"] = content.get(
+                "execution_count", exec_counter
+            )
+        outputs.append(output)
+
+
 def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
-                     verbose=False, dry_run=False, interrupt_grace=10):
+                     verbose=False, dry_run=False, interrupt_grace=10,
+                     ready_timeout=120, skip_empty_code_cells=False,
+                     text_as_lines=False, allowed_mime_types=None,
+                     idle_grace=0):
     """Execute a .NET notebook cell-by-cell and update outputs.
 
-    Returns dict with stats: total cells, executed, errors, time.
+    Compatibility options preserve the historical ``exec_dotnet_persist``
+    contract without maintaining a second kernel loop. Returns a dict with
+    total cells, executed cells, errors, elapsed time, and abort state.
     """
     notebook_path = Path(notebook_path)
     nb = json.loads(notebook_path.read_text(encoding="utf-8"))
-    code_cells = [(i, c) for i, c in enumerate(nb["cells"]) if c["cell_type"] == "code"]
+    code_cells = [(i, c) for i, c in enumerate(nb["cells"])
+                  if c["cell_type"] == "code"]
+    if skip_empty_code_cells:
+        code_cells = [
+            (i, cell) for i, cell in code_cells
+            if "".join(cell.get("source", [])).strip()
+        ]
 
     if not code_cells:
         print(f"  No code cells in {notebook_path.name}")
@@ -116,11 +177,15 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
         kc = km.client()
         kc.start_channels()
 
-        # Wait for kernel ready
-        time.sleep(3)
+        # A ready handshake avoids submitting the first cell while .NET is still
+        # warming up. Some test doubles do not implement it, so only call the
+        # method when it is present.
+        wait_for_ready = getattr(kc, "wait_for_ready", None)
+        if callable(wait_for_ready):
+            wait_for_ready(timeout=ready_timeout)
 
         for cell_idx, cell in code_cells:
-            source = "".join(cell["source"])
+            source = "".join(cell.get("source", []))
             exec_counter += 1
 
             if verbose:
@@ -131,6 +196,7 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
 
             outputs = []
             error_occurred = False
+            cell_completed = False
             deadline = time.time() + cell_timeout
 
             while time.time() < deadline:
@@ -157,18 +223,27 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
                     outputs.append({
                         "output_type": "stream",
                         "name": stream_name,
-                        "text": text,
+                        "text": (split_text_lines(text)
+                                 if text_as_lines else text),
                     })
                 elif msg_type == "execute_result":
-                    data = content.get("data", {})
+                    data = _normalize_output_data(
+                        content.get("data", {}), text_as_lines,
+                        allowed_mime_types
+                    )
                     outputs.append({
                         "output_type": "execute_result",
                         "data": data,
                         "metadata": {},
-                        "execution_count": exec_counter,
+                        "execution_count": content.get(
+                            "execution_count", exec_counter
+                        ),
                     })
                 elif msg_type == "display_data":
-                    data = content.get("data", {})
+                    data = _normalize_output_data(
+                        content.get("data", {}), text_as_lines,
+                        allowed_mime_types
+                    )
                     outputs.append({
                         "output_type": "display_data",
                         "data": data,
@@ -187,9 +262,15 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
                     })
                     print(f"    ERROR [{exec_counter}]: {ename}: {evalue[:100]}")
                 elif msg_type == "status" and content.get("execution_state") == "idle":
+                    cell_completed = True
+                    if idle_grace > 0:
+                        _collect_late_outputs(
+                            kc, msg_id, outputs, exec_counter, idle_grace,
+                            text_as_lines, allowed_mime_types
+                        )
                     break
 
-            if time.time() >= deadline:
+            if not cell_completed:
                 print(f"    TIMEOUT [{exec_counter}] after {cell_timeout}s")
                 # Interrupt the stuck execution so the next cell is not queued
                 # behind it. Defensive: wrapped against kernel managers that do

--- a/scripts/notebook_tools/exec_dotnet_persist.py
+++ b/scripts/notebook_tools/exec_dotnet_persist.py
@@ -1,205 +1,62 @@
 #!/usr/bin/env python3
-"""Execute .NET/C# notebooks cell-by-cell and persist outputs to disk."""
+"""Compatibility wrapper around the canonical .NET notebook executor.
+
+New callers should use ``dotnet_executor.py`` directly. This module preserves
+its historical positional CLI and ``execute_and_persist`` tuple return value.
+"""
 
 import json
 import sys
-import time
-import base64
 from pathlib import Path
 
 from _papermill_meta import strip_stale_papermill_metadata
+from dotnet_executor import execute_notebook, split_text_lines
+
+
+_LEGACY_MIME_TYPES = ("text/plain", "text/html", "image/svg+xml")
 
 
 def _save_executed(nb: dict, path: Path) -> None:
-    """Ecrit le notebook execute en retirant un bloc papermill perime (#12722).
+    """Persist a notebook after removing stale Papermill metadata.
 
-    Fonction separee pour etre testable sans kernel .NET : c'est le point
-    d'ecriture de cet executeur, le strip doit y vivre.
+    Kept as a public compatibility helper for callers and unit tests that use
+    the historical write boundary without starting a kernel.
     """
     strip_stale_papermill_metadata(nb)
-    with open(path, 'w', encoding='utf-8') as f:
-        json.dump(nb, f, indent=1, ensure_ascii=False)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(nb, handle, indent=1, ensure_ascii=False)
 
 
 def execute_and_persist(notebook_path: str, timeout_per_cell: int = 120):
-    """Execute a .NET notebook cell-by-cell and write outputs back."""
-    import jupyter_client
-
+    """Execute through the canonical engine and return ``(executed, errors)``."""
     path = Path(notebook_path)
-    with open(path, 'r', encoding='utf-8') as f:
-        nb = json.load(f)
+    with open(path, "r", encoding="utf-8") as handle:
+        nb = json.load(handle)
 
-    kernel_name = nb.get('metadata', {}).get('kernelspec', {}).get('name', '.net-csharp')
+    kernel_name = nb.get("metadata", {}).get("kernelspec", {}).get(
+        "name", ".net-csharp"
+    )
     print(f"Executing {path.name} (kernel={kernel_name})")
 
-    km = jupyter_client.KernelManager(kernel_name=kernel_name)
-    km.start_kernel()
-    kc = km.client()
-    kc.start_channels()
-    kc.wait_for_ready(timeout=120)
-    print(f"  Kernel ready")
-
-    nb_dir = str(path.parent)
-    if '.net' in kernel_name:
-        kc.execute(f'System.IO.Directory.SetCurrentDirectory(@"{nb_dir}")')
-        _wait_idle(kc, timeout=15)
-
-    cells = nb['cells']
-    executed = 0
-    errors = 0
-
-    for i, cell in enumerate(cells):
-        if cell.get('cell_type') != 'code':
-            continue
-
-        source = ''.join(cell.get('source', []))
-        if not source.strip():
-            continue
-
-        cell['outputs'] = []
-        executed += 1
-        # Assign cell-level execution_count (C.2: every executed code cell needs a
-        # coherent int). Previously omitted, so re-exec left counts stale / None.
-        cell['execution_count'] = executed
-        print(f"  Cell {i}: ", end='', flush=True)
-        t0 = time.time()
-
-        try:
-            # Attribute iopub messages strictly to THIS execute: .NET Interactive
-            # flushes display() outputs asynchronously, sometimes AFTER the kernel
-            # reports idle. Without the parent msg_id filter those late messages
-            # were captured by the NEXT cell's loop (output misattribution).
-            msg_id = kc.execute(source)
-            outputs = []
-            while True:
-                try:
-                    msg = kc.get_iopub_msg(timeout=timeout_per_cell)
-                    if msg.get('parent_header', {}).get('msg_id') != msg_id:
-                        continue
-                    msg_type = msg['msg_type']
-                    content = msg.get('content', {})
-
-                    if msg_type == 'stream':
-                        text = content.get('text', '')
-                        outputs.append({
-                            'output_type': 'stream',
-                            'name': content.get('name', 'stdout'),
-                            'text': _split_lines(text)
-                        })
-                    elif msg_type == 'execute_result':
-                        data = content.get('data', {})
-                        out = {
-                            'output_type': 'execute_result',
-                            'metadata': {},
-                            'data': {},
-                            'execution_count': content.get('execution_count', executed)
-                        }
-                        if 'text/plain' in data:
-                            out['data']['text/plain'] = _split_lines(data['text/plain'])
-                        if 'text/html' in data:
-                            out['data']['text/html'] = _split_lines(data['text/html'])
-                        if 'image/svg+xml' in data:
-                            out['data']['image/svg+xml'] = _split_lines(data['image/svg+xml'])
-                        outputs.append(out)
-                    elif msg_type == 'display_data':
-                        data = content.get('data', {})
-                        out = {'output_type': 'display_data', 'metadata': {}, 'data': {}}
-                        if 'text/plain' in data:
-                            out['data']['text/plain'] = _split_lines(data['text/plain'])
-                        if 'text/html' in data:
-                            out['data']['text/html'] = _split_lines(data['text/html'])
-                        if 'image/svg+xml' in data:
-                            out['data']['image/svg+xml'] = _split_lines(data['image/svg+xml'])
-                        outputs.append(out)
-                    elif msg_type == 'error':
-                        ename = content.get('ename', 'Error')
-                        evalue = content.get('evalue', '')
-                        traceback = content.get('traceback', [])
-                        outputs.append({
-                            'output_type': 'error',
-                            'ename': ename,
-                            'evalue': evalue,
-                            'traceback': traceback
-                        })
-                        errors += 1
-                    elif msg_type == 'status' and content.get('execution_state') == 'idle':
-                        # Grace drain: late display outputs of this same execute
-                        # can still arrive just after idle (async flush).
-                        import queue as _queue
-                        grace_deadline = time.time() + 2.0
-                        while time.time() < grace_deadline:
-                            try:
-                                late = kc.get_iopub_msg(timeout=0.3)
-                            except _queue.Empty:
-                                break
-                            if late.get('parent_header', {}).get('msg_id') != msg_id:
-                                continue
-                            ltype = late['msg_type']
-                            lcontent = late.get('content', {})
-                            if ltype == 'display_data' or ltype == 'execute_result':
-                                data = lcontent.get('data', {})
-                                out = {'output_type': ltype, 'metadata': {}, 'data': {}}
-                                if ltype == 'execute_result':
-                                    out['execution_count'] = lcontent.get('execution_count', executed)
-                                for mime in ('text/plain', 'text/html', 'image/svg+xml'):
-                                    if mime in data:
-                                        out['data'][mime] = _split_lines(data[mime])
-                                outputs.append(out)
-                        break
-                except Exception as e:
-                    if 'timeout' in str(e).lower():
-                        outputs.append({
-                            'output_type': 'error',
-                            'ename': 'TimeoutError',
-                            'evalue': f'Timeout after {timeout_per_cell}s',
-                            'traceback': []
-                        })
-                        errors += 1
-                    break
-
-            cell['outputs'] = outputs
-            elapsed = time.time() - t0
-            status = 'OK' if not any(o.get('output_type') == 'error' for o in outputs) else 'ERR'
-            print(f"{status} ({elapsed:.1f}s, {len(outputs)} outputs)")
-
-        except Exception as e:
-            errors += 1
-            cell['outputs'] = [{
-                'output_type': 'error',
-                'ename': type(e).__name__,
-                'evalue': str(e),
-                'traceback': []
-            }]
-            print(f"EXCEPTION: {e}")
-
-    kc.stop_channels()
-    km.shutdown_kernel(now=True)
-
-    _save_executed(nb, path)
-
-    print(f"  Done: {executed} cells executed, {errors} errors, saved to {path.name}")
-    return executed, errors
-
-
-def _wait_idle(kc, timeout=10):
-    """Wait for kernel idle state."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            msg = kc.get_iopub_msg(timeout=2)
-            if msg['msg_type'] == 'status' and msg['content'].get('execution_state') == 'idle':
-                return
-        except Exception:
-            pass
+    stats = execute_notebook(
+        path,
+        kernel_name=kernel_name,
+        cell_timeout=timeout_per_cell,
+        ready_timeout=120,
+        skip_empty_code_cells=True,
+        text_as_lines=True,
+        allowed_mime_types=_LEGACY_MIME_TYPES,
+        idle_grace=2.0,
+    )
+    return stats["executed"], stats["errors"]
 
 
 def _split_lines(text):
-    """Split text into list of lines (nbformat convention)."""
-    lines = text.split('\n')
-    return [l + '\n' for l in lines[:-1]] + ([lines[-1]] if lines[-1] else [])
+    """Preserve the historical helper name for downstream imports."""
+    return split_text_lines(text)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python exec_dotnet_persist.py <notebook.ipynb> [timeout]")
         sys.exit(1)

--- a/scripts/notebook_tools/tests/test_dotnet_executor.py
+++ b/scripts/notebook_tools/tests/test_dotnet_executor.py
@@ -243,6 +243,41 @@ def test_execution_count_increments_across_cells(tmp_path, _patch_kernelmanager)
     assert [c["execution_count"] for c in cells] == [1, 2, 3]
 
 
+def test_legacy_options_skip_empty_and_normalize_outputs(
+        tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [
+        _code_cell("  \n"),
+        _code_cell("display(42)"),
+    ])
+    _, kc = _patch_kernelmanager([[
+        _msg("stream", parent="msg-1", name="stdout", text="a\nb"),
+        _msg("execute_result", parent="msg-1", execution_count=7,
+             data={"text/plain": "42\n", "application/json": {"x": 1}}),
+        _msg("status", parent="msg-1", execution_state="idle"),
+        _msg("display_data", parent="msg-1",
+             data={"text/html": "<b>x</b>\n"}),
+    ]])
+
+    stats = dotnet_executor.execute_notebook(
+        nb,
+        skip_empty_code_cells=True,
+        text_as_lines=True,
+        allowed_mime_types=("text/plain", "text/html", "image/svg+xml"),
+        idle_grace=2.0,
+    )
+
+    assert stats["total"] == 1
+    assert stats["executed"] == 1
+    cells = json.loads(nb.read_text(encoding="utf-8"))["cells"]
+    assert cells[0]["execution_count"] is None
+    outputs = cells[1]["outputs"]
+    assert outputs[0]["text"] == ["a\n", "b"]
+    assert outputs[1]["data"] == {"text/plain": ["42\n"]}
+    assert outputs[1]["execution_count"] == 7
+    assert outputs[2]["data"] == {"text/html": ["<b>x</b>\n"]}
+    kc.wait_for_ready.assert_called_once_with(timeout=120)
+
+
 def test_timeout_interrupt_ignored_aborts_run(tmp_path, _patch_kernelmanager):
     """Timeout + interrupt not honored (kernel never idle) -> ABORT the run.
 

--- a/scripts/notebook_tools/tests/test_exec_dotnet_persist.py
+++ b/scripts/notebook_tools/tests/test_exec_dotnet_persist.py
@@ -1,11 +1,14 @@
 """Tests for exec_dotnet_persist.py — _split_lines helper."""
 
+import json
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+import exec_dotnet_persist
 from exec_dotnet_persist import _split_lines
 
 
@@ -50,3 +53,39 @@ class TestSplitLines:
         for line in result[:-1]:
             assert line.endswith("\n")
         assert not result[-1].endswith("\n")
+
+
+class TestCompatibilityWrapper:
+    def test_delegates_to_canonical_executor_with_legacy_options(self, tmp_path):
+        path = tmp_path / "legacy.ipynb"
+        path.write_text(json.dumps({
+            "cells": [],
+            "metadata": {"kernelspec": {"name": ".net-fsharp"}},
+        }), encoding="utf-8")
+
+        with patch.object(exec_dotnet_persist, "execute_notebook") as execute:
+            execute.return_value = {"executed": 4, "errors": 1}
+            result = exec_dotnet_persist.execute_and_persist(str(path), 45)
+
+        assert result == (4, 1)
+        execute.assert_called_once_with(
+            path,
+            kernel_name=".net-fsharp",
+            cell_timeout=45,
+            ready_timeout=120,
+            skip_empty_code_cells=True,
+            text_as_lines=True,
+            allowed_mime_types=("text/plain", "text/html", "image/svg+xml"),
+            idle_grace=2.0,
+        )
+
+    def test_kernel_defaults_when_metadata_is_absent(self, tmp_path):
+        path = tmp_path / "default.ipynb"
+        path.write_text(json.dumps({"cells": [], "metadata": {}}),
+                        encoding="utf-8")
+
+        with patch.object(exec_dotnet_persist, "execute_notebook") as execute:
+            execute.return_value = {"executed": 0, "errors": 0}
+            exec_dotnet_persist.execute_and_persist(str(path))
+
+        assert execute.call_args.kwargs["kernel_name"] == ".net-csharp"


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2025:CoursIA — prev: DEEP/lean #14132

## Résumé

- consolide les deux boucles d’exécution .NET derrière `dotnet_executor.py`, désormais moteur canonique unique ;
- transforme `exec_dotnet_persist.py` en wrapper de compatibilité mince, sans seconde gestion de kernel ;
- préserve explicitement le kernel lu depuis les métadonnées, l’ignorance des cellules vides, les textes nbformat en listes de lignes, la liste MIME historique, le drain des sorties tardives, le tuple `(executed, errors)` et la CLI positionnelle ;
- remplace l’attente fixe de trois secondes par `wait_for_ready(timeout=120)` et conserve le cycle de vie robuste du moteur canonique ;
- documente le rôle canonique/wrapper dans la référence des scripts.

## Preuve de consolidation fonction par fonction

| Capacité historique | Cible après consolidation |
|---|---|
| `_split_lines` | alias vers `dotnet_executor.split_text_lines` |
| `_save_executed` | conservé comme frontière publique/testable de compatibilité |
| kernel depuis `metadata.kernelspec.name` | lu par le wrapper puis transmis au moteur canonique |
| cellules code vides ignorées | option `skip_empty_code_cells=True` |
| `text/plain`, `text/html`, `image/svg+xml` uniquement | option `allowed_mime_types` |
| textes sous forme de listes de lignes | option `text_as_lines=True` |
| sorties `display_data`/`execute_result` tardives | option `idle_grace=2.0` avec filtrage par `parent_msg_id` |
| attente kernel 120 s | `ready_timeout=120` et `kc.wait_for_ready` |
| retour `(executed, errors)` | adaptation du dictionnaire de statistiques canonique |
| CLI `<notebook> [timeout]` et exit code | conservés byte-contractuellement |

La seconde boucle `KernelManager`/IOPub de `exec_dotnet_persist.py` est supprimée seulement après portage de toutes ces capacités. Les protections plus fortes du moteur canonique restent actives : attribution stricte des messages, interruption sur timeout, arrêt si l’interruption n’est pas honorée, nettoyage après setup partiel et retrait des métadonnées Papermill périmées.

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_dotnet_executor.py scripts/notebook_tools/tests/test_exec_dotnet_persist.py scripts/tests/test_papermill_meta_strip.py -q` — **45 passed** ;
- `python -m py_compile scripts/notebook_tools/dotnet_executor.py scripts/notebook_tools/exec_dotnet_persist.py` — **SUCCESS** ;
- `python scripts/notebook_tools/dotnet_executor.py --help` — CLI canonique disponible ;
- `python scripts/notebook_tools/exec_dotnet_persist.py` — usage positionnel historique préservé, exit 1 sans argument ;
- `git diff --check` — **SUCCESS**.

Contribution partielle à l’inventaire et aux fusions sélectives de l’Epic ; les autres orphelins restent ouverts.

See #13745
