### PR TITLE
docs(genai,#13581): T3a — deplacer INDEX.md/DEPLOYMENT.md dans Image/ et resynchroniser INDEX (18->20 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/DEPLOYMENT.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/DEPLOYMENT.md
@@ -44,9 +44,9 @@ Development  →  Staging  →  Production
 
 ### Prérequis Production
 
-- ✅ Environnement configuré ([`00-1-Environment-Setup.ipynb`](00-GenAI-Environment/00-1-Environment-Setup.ipynb))
-- ✅ APIs validées ([`00-4-Environment-Validation.ipynb`](00-GenAI-Environment/00-4-Environment-Validation.ipynb))
-- ✅ Tests passés (voir [TROUBLESHOOTING.md (archive)](../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md))
+- ✅ Environnement configuré ([`00-1-Environment-Setup.ipynb`](../00-GenAI-Environment/00-1-Environment-Setup.ipynb))
+- ✅ APIs validées ([`00-4-Environment-Validation.ipynb`](../00-GenAI-Environment/00-4-Environment-Validation.ipynb))
+- ✅ Tests passés (voir [TROUBLESHOOTING.md (archive)](../../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md))
 - ✅ Budget configuré (alertes activées)
 - ✅ Monitoring en place
 

--- a/MyIA.AI.Notebooks/GenAI/Image/INDEX.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/INDEX.md
@@ -1,7 +1,7 @@
 # 📑 INDEX COMPLET - GenAI Images Ecosystem CoursIA
 
 > **Guide de navigation complet de l'écosystème GenAI Images**  
-> Production-ready | 18 Notebooks | APIs Externes | Documentation Complète
+> Production-ready | 20 Notebooks | APIs Externes | Documentation Complète
 
 ---
 
@@ -41,9 +41,9 @@ L'écosystème **GenAI Images CoursIA** est une plateforme modulaire complète p
 
 | Métrique | Valeur |
 |----------|--------|
-| **Notebooks totaux** | 18 |
+| **Notebooks totaux** | 20 |
 | **Tutoriels complets** | 4 (8500+ lignes) |
-| **Exemples sectoriels** | 4 domaines |
+| **Exemples sectoriels** | 3 domaines |
 | **APIs configurées** | 3 (OpenAI, OpenRouter, GPT-5) |
 | **Niveaux formation** | 4 (00-04) |
 | **Documentation** | 15+ documents |
@@ -106,48 +106,55 @@ print(f"✅ Image générée: {response.data[0].url}")
 ```
 MyIA.AI.Notebooks/GenAI/
 │
-├── 00-GenAI-Environment/          # 🟢 Setup & Configuration
+├── 00-GenAI-Environment/             # 🟢 Setup & Configuration (prérequis, hors Image/)
 │   ├── 00-1-Environment-Setup.ipynb
 │   ├── 00-2-Docker-Services-Management.ipynb
 │   ├── 00-3-API-Endpoints-Configuration.ipynb
 │   └── 00-4-Environment-Validation.ipynb
 │
-├── 01-Images-Foundation/          # 🟢 Fondamentaux
-│   ├── 01-1-OpenAI-DALL-E-3.ipynb
-│   ├── 01-2-GPT-5-Image-Generation.ipynb
-│   ├── 01-3-Basic-Image-Operations.ipynb
-│   └── 01-5b-Qwen-Image-Edit-2509.ipynb
-├── 02-Images-Advanced/            # 🟠 Avancé (Docker)
-│   ├── 02-2-FLUX-1-Advanced-Generation.ipynb
-│   └── 02-3-Stable-Diffusion-3-5.ipynb
+├── tutorials/                        # 📚 Guides — dupliqués dans Image/tutorials/ (cf. #13581 T3)
 │
-├── 03-Images-Orchestration/       # 🔴 Orchestration (Docker)
-│   ├── 03-1-Multi-Model-Comparison.ipynb
-│   ├── 03-2-Workflow-Orchestration.ipynb
-│   └── 03-3-Performance-Optimization.ipynb
-│
-├── 04-Images-Applications/        # 🔴 Applications Métier
-│   ├── 04-1-Educational-Content-Generation.ipynb
-│   ├── 04-2-Creative-Workflows.ipynb
-│   └── 04-3-Production-Integration.ipynb
-│
-├── tutorials/                     # 📚 Guides Complets
-│   ├── dalle3-complete-guide.md
-│   ├── gpt5-image-analysis-guide.md
-│   ├── openrouter-ecosystem-guide.md
-│   └── educational-workflows.md
-│
-├── examples/                      # 🎯 Exemples Sectoriels
-│   ├── science-diagrams.ipynb
-│   ├── history-geography.ipynb
-│   ├── literature-visual.ipynb
-│   └── mathematics-physics.ipynb
-│
-└── docs/                          # 📖 Documentation Technique
-    ├── architecture.md
-    ├── deployment-guide.md
-    ├── development-standards.md
-    └── integration-procedures.md
+└── Image/                            # 🖼️ Écosystème Images — racine de ce document
+    │
+    ├── 01-Foundation/                # 🟢 Fondamentaux
+    │   ├── 01-1-OpenAI-DALL-E-3.ipynb
+    │   ├── 01-2-GPT-5-Image-Generation.ipynb
+    │   ├── 01-3-Basic-Image-Operations.ipynb
+    │   ├── 01-4-Forge-SD-XL-Turbo.ipynb
+    │   ├── 01-5-Qwen-Image-Edit.ipynb
+    │   └── 01-5b-Qwen-Image-Edit-2509.ipynb
+    │
+    ├── 02-Advanced/                  # 🟠 Avancé (Docker)
+    │   ├── 02-2-FLUX-1-Advanced-Generation.ipynb
+    │   ├── 02-3-Stable-Diffusion-3-5.ipynb
+    │   ├── 02-4-Z-Image-Lumina2.ipynb
+    │   └── 02-5-Bonsai-Image-Ternary.ipynb
+    │
+    ├── 03-Orchestration/             # 🔴 Orchestration (Docker)
+    │   ├── 03-1-Multi-Model-Comparison.ipynb
+    │   ├── 03-2-Workflow-Orchestration.ipynb
+    │   └── 03-3-Performance-Optimization.ipynb
+    │
+    ├── 04-Applications/              # 🔴 Applications Métier
+    │   ├── 04-1-Educational-Content-Generation.ipynb
+    │   ├── 04-2-Creative-Workflows.ipynb
+    │   ├── 04-3-Production-Integration.ipynb
+    │   └── 04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
+    │
+    ├── examples/                     # 🎯 Exemples Sectoriels
+    │   ├── science-diagrams.ipynb
+    │   ├── history-geography.ipynb
+    │   └── literature-visual.ipynb
+    │
+    ├── tutorials/                    # 📚 Guides Complets (copie locale)
+    │   ├── dalle3-complete-guide.md
+    │   ├── gpt5-image-analysis-guide.md
+    │   ├── openrouter-ecosystem-guide.md
+    │   └── educational-workflows.md
+    │
+    ├── INDEX.md                      # 📑 Ce document
+    ├── DEPLOYMENT.md                 # 🚀 Guide production
+    └── README.md
 ```
 
 ---
@@ -175,6 +182,8 @@ MyIA.AI.Notebooks/GenAI/
 | **01-1-OpenAI-DALL-E-3** | DALL-E 3 | 2h | ⭐ | Génération images haute qualité |
 | **01-2-GPT-5-Image-Generation** | GPT-5 Vision | 2h | ⭐ | Analyse multimodale avancée |
 | **01-3-Basic-Image-Operations** | PIL/OpenCV | 1h30 | ⭐ | Manipulation images basique |
+| **01-4-Forge-SD-XL-Turbo** | SD XL Turbo (Forge) | — | ⭐ | Génération locale via Stable Diffusion Forge |
+| **01-5-Qwen-Image-Edit** | Qwen-Image-Edit 2.5 | — | ⭐ | Génération et édition via API ComfyUI |
 
 **Compétences Acquises** :
 - ✅ Prompt engineering images
@@ -191,6 +200,8 @@ MyIA.AI.Notebooks/GenAI/
 | **01-5b-Qwen-Image-Edit-2509** | Qwen 2.5 | 3h | ⭐⭐ | ✅ Requis |
 | **02-2-FLUX-1-Advanced-Generation** | FLUX.1 | 3h | ⭐⭐ | ✅ Requis |
 | **02-3-Stable-Diffusion-3-5** | SD 3.5 | 3h | ⭐⭐ | ✅ Requis |
+| **02-4-Z-Image-Lumina2** | Z-Image (Lumina-2) | — | ⭐⭐ | ✅ Requis (ComfyUI) |
+| **02-5-Bonsai-Image-Ternary** | Bonsai-Image (1.58-bit) | — | ⭐⭐ | ✅ Requis (quantization ternaire) |
 
 **Status** : 🚧 Infrastructure Docker en cours de déploiement (agent parallèle)
 
@@ -227,6 +238,7 @@ MyIA.AI.Notebooks/GenAI/
 | **04-1-Educational-Content-Generation** | Contenu pédagogique | 3h | ⭐⭐⭐ | ✅ Production |
 | **04-2-Creative-Workflows** | Workflows créatifs | 3h | ⭐⭐⭐ | ✅ Production |
 | **04-3-Production-Integration** | Intégration systèmes | 2h30 | ⭐⭐⭐ | ✅ Production |
+| **04-4-Cross-Stitch-Pattern-Maker-Legacy** | Patron de point de croix | — | ⭐⭐⭐ | ✅ Production (legacy) |
 
 **Status APIs Externes** : ✅ 100% Opérationnel
 
@@ -243,7 +255,7 @@ MyIA.AI.Notebooks/GenAI/
 ### Tutoriels Complets (1000-1600 lignes)
 
 #### 1. **DALL-E 3 Complete Guide** 📘
-**Fichier** : [`tutorials/dalle3-complete-guide.md`](tutorials/dalle3-complete-guide.md)  
+**Fichier** : [`tutorials/dalle3-complete-guide.md`](../tutorials/dalle3-complete-guide.md)  
 **Temps lecture** : 30min | **Niveau** : Débutant → Intermédiaire
 
 **Sections Principales** :
@@ -261,7 +273,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 2. **GPT-5 Image Analysis Guide** 📙
-**Fichier** : [`tutorials/gpt5-image-analysis-guide.md`](tutorials/gpt5-image-analysis-guide.md)  
+**Fichier** : [`tutorials/gpt5-image-analysis-guide.md`](../tutorials/gpt5-image-analysis-guide.md)  
 **Temps lecture** : 35min | **Niveau** : Intermédiaire
 
 **Sections Principales** :
@@ -280,7 +292,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 3. **OpenRouter Ecosystem Guide** 📗
-**Fichier** : [`tutorials/openrouter-ecosystem-guide.md`](tutorials/openrouter-ecosystem-guide.md)  
+**Fichier** : [`tutorials/openrouter-ecosystem-guide.md`](../tutorials/openrouter-ecosystem-guide.md)  
 **Temps lecture** : 40min | **Niveau** : Intermédiaire → Avancé
 
 **Sections Principales** :
@@ -299,7 +311,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 4. **Educational Workflows Tutorial** 📕
-**Fichier** : [`tutorials/educational-workflows.md`](tutorials/educational-workflows.md)  
+**Fichier** : [`tutorials/educational-workflows.md`](../tutorials/educational-workflows.md)  
 **Temps lecture** : 45min | **Niveau** : Avancé
 
 **Sections Principales** :
@@ -322,7 +334,7 @@ MyIA.AI.Notebooks/GenAI/
 ### Exemples Prêts-à-l'Emploi
 
 #### 1. **Science Diagrams** 🔬
-**Fichier** : [`Image/examples/science-diagrams.ipynb`](Image/examples/science-diagrams.ipynb)
+**Fichier** : [`Image/examples/science-diagrams.ipynb`](examples/science-diagrams.ipynb)
 
 **Applications** :
 - Diagrammes cellule végétale/animale
@@ -336,7 +348,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 2. **History & Geography** 🗺️
-**Fichier** : [`Image/examples/history-geography.ipynb`](Image/examples/history-geography.ipynb)
+**Fichier** : [`Image/examples/history-geography.ipynb`](examples/history-geography.ipynb)
 
 **Applications** :
 - Reconstitutions événements historiques
@@ -350,7 +362,7 @@ MyIA.AI.Notebooks/GenAI/
 ---
 
 #### 3. **Literature & Visual Arts** 📖
-**Fichier** : [`Image/examples/literature-visual.ipynb`](Image/examples/literature-visual.ipynb)
+**Fichier** : [`Image/examples/literature-visual.ipynb`](examples/literature-visual.ipynb)
 
 **Applications** :
 - Illustrations scènes littéraires
@@ -518,13 +530,12 @@ MyIA.AI.Notebooks/GenAI/
 4. `examples/science-diagrams.ipynb`
 5. `examples/history-geography.ipynb`
 6. `examples/literature-visual.ipynb`
-7. `examples/mathematics-physics.ipynb`
 
 **Module 3 : Production Cours (4h)**
-8. Templates réutilisables par discipline
-9. Génération par lots de supports complets
-10. Quality assurance pédagogique
-11. Accessibilité et inclusivité
+7. Templates réutilisables par discipline
+8. Génération par lots de supports complets
+9. Quality assurance pédagogique
+10. Accessibilité et inclusivité
 
 **Livrables** :
 - ✅ Pack visuels pour 1 cours complet
@@ -684,7 +695,7 @@ print("✅ OpenAI API opérationnelle")
 
 **Documentation** :
 - [OpenAI Images API](https://platform.openai.com/docs/guides/images)
-- Tutorial : [`dalle3-complete-guide.md`](tutorials/dalle3-complete-guide.md)
+- Tutorial : [`dalle3-complete-guide.md`](../tutorials/dalle3-complete-guide.md)
 
 ---
 
@@ -722,7 +733,7 @@ print("✅ OpenRouter API opérationnelle")
 
 **Documentation** :
 - [OpenRouter Docs](https://openrouter.ai/docs)
-- Tutorial : [`openrouter-ecosystem-guide.md`](tutorials/openrouter-ecosystem-guide.md)
+- Tutorial : [`openrouter-ecosystem-guide.md`](../tutorials/openrouter-ecosystem-guide.md)
 
 ---
 
@@ -788,10 +799,10 @@ execute_notebook(
 
 ## Documentation Technique
 
-- [docs/genai/genai-services.md](../../docs/genai/genai-services.md) — Architecture services GenAI, GPU, modèles, configurations Docker
-- [TROUBLESHOOTING.md (archive)](../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md) — Resolution problemes courants, erreurs APIs, scripts diagnostiques
+- [docs/genai/genai-services.md](../../../docs/genai/genai-services.md) — Architecture services GenAI, GPU, modèles, configurations Docker
+- [TROUBLESHOOTING.md (archive)](../../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md) — Resolution problemes courants, erreurs APIs, scripts diagnostiques
 
-> Historique des investigations (phases 12a/29/30/31 ComfyUI-Qwen) : archive dans [docs/archive/suivis/genai-image/](../../docs/archive/suivis/genai-image/)
+> Historique des investigations (phases 12a/29/30/31 ComfyUI-Qwen) : archive dans [docs/archive/suivis/genai-image/](../../../docs/archive/suivis/genai-image/)
 
 ---
 
@@ -799,7 +810,7 @@ execute_notebook(
 
 ### Accès Rapide
 
-**Guide Complet** : [`TROUBLESHOOTING.md` (archive)](../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md)
+**Guide Complet** : [`TROUBLESHOOTING.md` (archive)](../../../docs/archive/suivis/genai-image/TROUBLESHOOTING.md)
 
 ### Problèmes Fréquents
 
@@ -907,7 +918,7 @@ img.save('optimized.png')
 **R:** Jusqu'à 10 images en contexte unique avec 200K tokens context window.
 
 **Q: Comment optimiser les coûts ?**  
-**R:** Voir tutorial [`openrouter-ecosystem-guide.md`](tutorials/openrouter-ecosystem-guide.md) section cost optimization.
+**R:** Voir tutorial [`openrouter-ecosystem-guide.md`](../tutorials/openrouter-ecosystem-guide.md) section cost optimization.
 
 **Q: Peut-on fine-tuner DALL-E 3 ?**  
 **R:** Non directement, mais techniques prompt engineering très efficaces. Pour fine-tuning custom, voir niveau 02 (FLUX.1, SD 3.5).
@@ -920,7 +931,7 @@ img.save('optimized.png')
 **R:** Sciences, Histoire, Géographie, Littérature, Mathématiques, Physique. Voir [`examples/`](examples/).
 
 **Q: Accessibilité pour élèves handicapés ?**  
-**R:** Oui, génération automatique alt-text via GPT-5. Voir tutorial [`educational-workflows.md`](tutorials/educational-workflows.md).
+**R:** Oui, génération automatique alt-text via GPT-5. Voir tutorial [`educational-workflows.md`](../tutorials/educational-workflows.md).
 
 **Q: Peut-on générer QCM automatiquement ?**  
 **R:** Oui ! Voir `04-1-Educational-Content-Generation.ipynb` section "Visual Assessments".
@@ -936,8 +947,8 @@ img.save('optimized.png')
 
 1. **Configuration** : Suivre [Quick Start](#quick-start)
 2. **Premier Notebook** : `01-1-OpenAI-DALL-E-3.ipynb`
-3. **Tutorial** : Lire [`dalle3-complete-guide.md`](tutorials/dalle3-complete-guide.md)
-4. **Exemple** : Exécuter [`Image/examples/science-diagrams.ipynb`](Image/examples/science-diagrams.ipynb)
+3. **Tutorial** : Lire [`dalle3-complete-guide.md`](../tutorials/dalle3-complete-guide.md)
+4. **Exemple** : Exécuter [`Image/examples/science-diagrams.ipynb`](examples/science-diagrams.ipynb)
 
 ### Parcours Recommandé
 
@@ -965,7 +976,7 @@ img.save('optimized.png')
 
 ### Contributions
 
-Contributions welcomes ! Voir [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+Contributions welcomes ! Voir [`CONTRIBUTING.md`](../../../CONTRIBUTING.md)
 
 ---
 
@@ -977,13 +988,13 @@ Serie pedagogique pour apprendre Playwright en testant une application GenAI ré
 
 | Module | Nom | Duree | Niveau | Tests |
 |--------|-----|-------|--------|-------|
-| 01 | [Decouverte](Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/01-decouverte/) | 2-3h | Debutant | 4 |
-| 02 | [Navigation & Auth](Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/02-navigation-authentification/) | 2-3h | Debutant+ | 8 |
-| 03 | [Chat & Streaming](Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/03-chat-streaming/) | 3h | Intermediaire | 7 |
-| 04 | [RAG, MCP & Avances](Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/04-rag-tools-avances/) | 3h | Intermediaire+ | 7 |
-| 05 | [Multi-tenant & CI/CD](Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/05-multi-tenant-ci/) | 3-4h | Expert | 8 |
+| 01 | [Decouverte](../Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/01-decouverte/) | 2-3h | Debutant | 4 |
+| 02 | [Navigation & Auth](../Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/02-navigation-authentification/) | 2-3h | Debutant+ | 8 |
+| 03 | [Chat & Streaming](../Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/03-chat-streaming/) | 3h | Intermediaire | 7 |
+| 04 | [RAG, MCP & Avances](../Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/04-rag-tools-avances/) | 3h | Intermediaire+ | 7 |
+| 05 | [Multi-tenant & CI/CD](../Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/05-multi-tenant-ci/) | 3-4h | Expert | 8 |
 
-[README Playwright-OWUI](Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/README.md)
+[README Playwright-OWUI](../Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/README.md)
 
 ---
 

--- a/docs/archive/genai-images-mission-complete.md
+++ b/docs/archive/genai-images-mission-complete.md
@@ -117,9 +117,9 @@ MyIA.AI.Notebooks/GenAI/
   - [`educational-workflows.md`](../MyIA.AI.Notebooks/GenAI/tutorials/educational-workflows.md) (1400 lignes)
 
 - ✅ Documentation technique (3000+ lignes)
-  - [`INDEX.md`](../MyIA.AI.Notebooks/GenAI/INDEX.md) : Navigation complète (1242 lignes)
+  - [`INDEX.md`](../../MyIA.AI.Notebooks/GenAI/Image/INDEX.md) : Navigation complète (1242 lignes)
   - [`TROUBLESHOOTING.md`](../MyIA.AI.Notebooks/GenAI/TROUBLESHOOTING.md) : Résolution problèmes (1286 lignes)
-  - [`DEPLOYMENT.md`](../MyIA.AI.Notebooks/GenAI/DEPLOYMENT.md) : Guide production (1491 lignes)
+  - [`DEPLOYMENT.md`](../../MyIA.AI.Notebooks/GenAI/Image/DEPLOYMENT.md) : Guide production (1491 lignes)
   - Architecture, standards, intégration (8 docs)
 
 **Qualité** :
@@ -965,7 +965,7 @@ La mission **GenAI Images CoursIA** a **dépassé ses objectifs initiaux** avec 
 ---
 
 **📧 Contact** : genai-team@coursia.ai  
-**📚 Documentation** : [INDEX Complet](../MyIA.AI.Notebooks/GenAI/INDEX.md)  
+**📚 Documentation** : [INDEX Complet](../../MyIA.AI.Notebooks/GenAI/Image/INDEX.md)  
 **🐛 Issues** : [GitHub Issues](https://github.com/coursia/genai/issues)
 
 ---


### PR DESCRIPTION
Grain: MED/docs -- lane myia-po-2023:CoursIA-2 -- prev: MED/qc #14012

## Sujet

T3a de #13581 : `INDEX.md` et `DEPLOYMENT.md` decrivent exclusivement l'ecosysteme Image mais vivaient a la racine `MyIA.AI.Notebooks/GenAI/`.

La PR porte **les deux volets, indissociables** : le deplacement **et** la resynchronisation d'`INDEX.md`. Deplacer sans resynchroniser n'aurait fait que ranger une information fausse -- `INDEX.md` annoncait 18 notebooks quand `Image/` en porte 20.

Scope volontairement etroit : **T3a seul**. T2, le reste de T3 (dont les tutoriels) et T4 restent libres pour d'autres lanes.

## Deplacement

`git mv`, renames detectes par git (`R081` / `R098`) :

| Avant | Apres |
|---|---|
| `MyIA.AI.Notebooks/GenAI/INDEX.md` | `MyIA.AI.Notebooks/GenAI/Image/INDEX.md` |
| `MyIA.AI.Notebooks/GenAI/DEPLOYMENT.md` | `MyIA.AI.Notebooks/GenAI/Image/DEPLOYMENT.md` |

**Liens sortants** -- 27 liens relatifs re-profondeur (24 dans INDEX, 3 dans DEPLOYMENT), puis **re-resolus un a un depuis le nouvel emplacement** : `0 lien mort`. Un `git grep` repo-wide des anciens chemins ne rend plus rien hors de `Image/`.

Detail notable : les liens `](Image/examples/...)` d'`INDEX.md` etaient **morts avant** le deplacement (`GenAI/examples` n'existe pas). Le deplacement les repare de lui-meme -- signe que le fichier avait ete redige comme s'il vivait deja dans `Image/`.

**Liens entrants** -- 3 references re-pathees dans `docs/archive/genai-images-mission-complete.md`. Elles etaient **deja mortes sur `main`** : la profondeur y est `../` alors que depuis `docs/archive/` il faut `../../`. Comme je reecris ces trois lignes, je corrige aussi la profondeur plutot que de laisser mortes des lignes que je viens d'ecrire. Le fichier passe de **19 a 16 liens morts**.

## Resynchronisation `INDEX.md`

Mesure disque : `find MyIA.AI.Notebooks/GenAI/Image -name '*.ipynb' | wc -l` -> **20** (6 + 4 + 3 + 4 en serie 01-04, + 3 dans `examples/`).

| Axe | Avant | Apres |
|---|---|---|
| En-tete | `18 Notebooks` | `20 Notebooks` |
| Statistiques | `Notebooks totaux : 18` / `Exemples : 4 domaines` | `20` / `3 domaines` |
| Arbre | racine `GenAI/`, repertoires `01-Images-Foundation/` ... | racine reelle `GenAI/Image/`, repertoires reels `01-Foundation/`, `02-Advanced/`, `03-Orchestration/`, `04-Applications/` |
| Arbre | repertoire `docs/` fantome | retire (n'existe pas) |
| Tables de niveau | 5 notebooks absents | `01-4`, `01-5`, `02-4`, `02-5`, `04-4` ajoutes |
| Parcours Enseignant | `7. examples/mathematics-physics.ipynb` (fantome) | retire, Module 3 renumerote 8-11 -> 7-10 |

**Titres des 5 notebooks ajoutes** : releves dans la premiere cellule markdown de chaque notebook, pas inventes. Les colonnes `Temps` et `Difficulte` que je ne peux pas mesurer portent `—` plutot qu'une valeur fabriquee.

## Verification (sur l'artefact, pas sur l'intention)

```
INDEX.md      : 25 liens relatifs, 0 morts
DEPLOYMENT.md :  3 liens relatifs, 0 morts
archive       : 19 morts sur main -> 16 apres (les 3 que je touche sont reparees)

find .../Image -name '*.ipynb' | wc -l  ->  20   (= le compte annonce)
mathematics-physics restant : 0 | '18 Notebooks' restant : 0 | '01-Images-Foundation' restant : 0
CR = 0 sur les 3 fichiers, fin de ligne finale preservee
```

`COURSE_CATALOG.generated.*` et les marqueurs `CATALOG-STATUS` sont **byte-identiques a `main`** (absents du diff) -- ils appartiennent a l'automatisation.

## Hors scope -- signale, pas corrige

1. **`Image/tutorials/` duplique `GenAI/tutorials/`** (memes 4 guides). Les liens `](tutorials/...)` d'INDEX pointent vers **le meme fichier qu'avant le deplacement** (`../tutorials/`) : je n'ai pas re-pointe vers la copie locale, ce serait trancher la duplication en silence. C'est le sous-item "tutoriels" de T3, a traiter separement.
2. **`docs/archive/genai-images-mission-complete.md:121`** pointe `GenAI/TROUBLESHOOTING.md` ; la cible reelle est `docs/archive/suivis/genai-image/TROUBLESHOOTING.md`. Anterieur, sans rapport avec ce deplacement.
3. **16 liens morts residuels** dans ce meme fichier archive (`tutorials/`, `examples/`, `scripts/`, `genai-suivis/`) -- meme rot de profondeur, anterieur.
4. **`01-5b-Qwen-Image-Edit-2509`** vit dans `01-Foundation/` mais figure dans la table Niveau 02. Je ne le reclasse pas : la colonne discriminante de cette table est le prerequis Docker, pas le repertoire. Observation, pas defaut.

## Note sur le fichier archive

J'ai distingue deux choses dans ce document archive : les **pointeurs de navigation** (re-pathes, c'est leur fonction de mener au fichier) et les **affirmations historiques** -- ce qu'une PR passee a fait, y compris la mention de `mathematics-physics.ipynb`, laissee intacte. Un ledger ne se reecrit pas.

See #13581
