### PR TITLE
feat(probas,#14051): PyMC-05 importe pymc_causal_organs + gate anti-derive (5 gates)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-05-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-05-Causal-Inference.ipynb
@@ -79,10 +79,10 @@
    "id": "463b8439",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:02.525049Z",
-     "iopub.status.busy": "2026-06-29T01:41:02.525049Z",
-     "iopub.status.idle": "2026-06-29T01:41:05.808122Z",
-     "shell.execute_reply": "2026-06-29T01:41:05.808122Z"
+     "iopub.execute_input": "2026-09-01T21:29:10.089179Z",
+     "iopub.status.busy": "2026-09-01T21:29:10.088838Z",
+     "iopub.status.idle": "2026-09-01T21:29:12.968884Z",
+     "shell.execute_reply": "2026-09-01T21:29:12.967668Z"
     }
    },
    "outputs": [
@@ -127,10 +127,10 @@
    "id": "a89a0117",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:05.810200Z",
-     "iopub.status.busy": "2026-06-29T01:41:05.810200Z",
-     "iopub.status.idle": "2026-06-29T01:41:05.815584Z",
-     "shell.execute_reply": "2026-06-29T01:41:05.815584Z"
+     "iopub.execute_input": "2026-09-01T21:29:12.971820Z",
+     "iopub.status.busy": "2026-09-01T21:29:12.971340Z",
+     "iopub.status.idle": "2026-09-01T21:29:12.983070Z",
+     "shell.execute_reply": "2026-09-01T21:29:12.981922Z"
     }
    },
    "outputs": [
@@ -138,46 +138,63 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "def enumerate_scm(\n",
+      "    nodes: SCM,\n",
+      "    query: str,\n",
+      "    evidence: Optional[Dict[str, bool]] = None,\n",
+      "    do_vars: Optional[Dict[str, bool]] = None,\n",
+      ") -> float:\n",
+      "    \"\"\"Inference exacte par enumeration sur un SCM discret booleen.\n",
+      "\n",
+      "    Reprise byte-identique de la cellule 5 de ``PyMC-05-Causal-Inference.ipynb``.\n",
+      "\n",
+      "    nodes    : liste ordonnee (topologique) de (nom, proba_true_fn). proba_true_fn(assign)\n",
+      "               renvoie P(nom=True | parents) en lisant les parents dans le dict `assign`.\n",
+      "    query    : nom du noeud dont on veut P(query=True).\n",
+      "    evidence : dict {nom: bool} de variables OBSERVEES (conditionnement / niveau 1).\n",
+      "    do_vars  : dict {nom: bool} de variables INTERVENUES (mutilation / niveau 2).\n",
+      "\n",
+      "    Retourne P(query=True | evidence, do(do_vars)).\n",
+      "    \"\"\"\n",
+      "    evidence = evidence or {}\n",
+      "    do_vars = do_vars or {}\n",
+      "    names = [n for n, _ in nodes]\n",
+      "    num = 0.0  # masse de (query=True, evidence)\n",
+      "    den = 0.0  # masse de (evidence)\n",
+      "    for bits in itertools.product([False, True], repeat=len(names)):\n",
+      "        assign = dict(zip(names, bits))\n",
+      "        # incompatibilite avec une intervention forcee -> proba nulle\n",
+      "        if any(assign[k] != v for k, v in do_vars.items()):\n",
+      "            continue\n",
+      "        if any(assign[k] != v for k, v in evidence.items()):\n",
+      "            continue\n",
+      "        p = 1.0\n",
+      "        for name, fn in nodes:\n",
+      "            if name in do_vars:        # arc parent coupe : la CPT devient une constante\n",
+      "                continue\n",
+      "            pt = fn(assign)\n",
+      "            p *= pt if assign[name] else (1.0 - pt)\n",
+      "        den += p\n",
+      "        if assign[query]:\n",
+      "            num += p\n",
+      "    return num / den if den > 0 else float(\"nan\")\n",
+      "\n",
       "Moteur enumerate_scm pret (inference exacte par sommation sur 2^n configurations).\n"
      ]
     }
    ],
    "source": [
-    "def enumerate_scm(nodes, query, evidence=None, do_vars=None):\n",
-    "    \"\"\"Inference exacte par enumeration sur un SCM discret booleen.\n",
+    "# --- Acceptance #14051 : le moteur d'enumeration vit desormais dans le module\n",
+    "# canonique pymc_causal_organs.py, a cote de ce notebook. Le notebook l'IMPORTE\n",
+    "# au lieu de le redefinir, de sorte que ict.bridges.pymc_enumerate et tout autre\n",
+    "# consommateur observent la MEME implementation que celle executee ici.\n",
+    "import inspect\n",
     "\n",
-    "    nodes    : liste ordonnee (topologique) de (nom, proba_true_fn). proba_true_fn(assign)\n",
-    "               renvoie P(nom=True | parents) en lisant les parents dans le dict `assign`.\n",
-    "    query    : nom du noeud dont on veut P(query=True).\n",
-    "    evidence : dict {nom: bool} de variables OBSERVEES (conditionnement / niveau 1).\n",
-    "    do_vars  : dict {nom: bool} de variables INTERVENUES (mutilation / niveau 2).\n",
+    "from pymc_causal_organs import enumerate_scm\n",
     "\n",
-    "    Retourne P(query=True | evidence, do(do_vars)).\n",
-    "    \"\"\"\n",
-    "    evidence = evidence or {}\n",
-    "    do_vars = do_vars or {}\n",
-    "    names = [n for n, _ in nodes]\n",
-    "    num = 0.0  # masse de (query=True, evidence)\n",
-    "    den = 0.0  # masse de (evidence)\n",
-    "    for bits in itertools.product([False, True], repeat=len(names)):\n",
-    "        assign = dict(zip(names, bits))\n",
-    "        # incompatibilite avec une intervention forcee -> proba nulle\n",
-    "        if any(assign[k] != v for k, v in do_vars.items()):\n",
-    "            continue\n",
-    "        if any(assign[k] != v for k, v in evidence.items()):\n",
-    "            continue\n",
-    "        p = 1.0\n",
-    "        for name, fn in nodes:\n",
-    "            if name in do_vars:        # arc parent coupe : la CPT devient une constante\n",
-    "                continue\n",
-    "            pt = fn(assign)\n",
-    "            p *= pt if assign[name] else (1.0 - pt)\n",
-    "        den += p\n",
-    "        if assign[query]:\n",
-    "            num += p\n",
-    "    return num / den if den > 0 else float(\"nan\")\n",
-    "\n",
-    "\n",
+    "# La valeur pedagogique est preservee : on affiche le code de l'organe REELLEMENT\n",
+    "# execute -- inspect.getsource lit l'objet importe, ce n'est pas une transcription.\n",
+    "print(inspect.getsource(enumerate_scm))\n",
     "print(\"Moteur enumerate_scm pret (inference exacte par sommation sur 2^n configurations).\")"
    ]
   },
@@ -210,10 +227,10 @@
    "id": "60980a51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:05.817589Z",
-     "iopub.status.busy": "2026-06-29T01:41:05.817589Z",
-     "iopub.status.idle": "2026-06-29T01:41:05.823674Z",
-     "shell.execute_reply": "2026-06-29T01:41:05.823674Z"
+     "iopub.execute_input": "2026-09-01T21:29:12.985519Z",
+     "iopub.status.busy": "2026-09-01T21:29:12.985267Z",
+     "iopub.status.idle": "2026-09-01T21:29:12.992247Z",
+     "shell.execute_reply": "2026-09-01T21:29:12.991345Z"
     }
    },
    "outputs": [
@@ -256,10 +273,10 @@
    "id": "0f273ae3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:05.823674Z",
-     "iopub.status.busy": "2026-06-29T01:41:05.823674Z",
-     "iopub.status.idle": "2026-06-29T01:41:05.845672Z",
-     "shell.execute_reply": "2026-06-29T01:41:05.845672Z"
+     "iopub.execute_input": "2026-09-01T21:29:12.994664Z",
+     "iopub.status.busy": "2026-09-01T21:29:12.994447Z",
+     "iopub.status.idle": "2026-09-01T21:29:13.032095Z",
+     "shell.execute_reply": "2026-09-01T21:29:13.031113Z"
     }
    },
    "outputs": [
@@ -309,10 +326,10 @@
    "id": "b4477684",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:05.845672Z",
-     "iopub.status.busy": "2026-06-29T01:41:05.845672Z",
-     "iopub.status.idle": "2026-06-29T01:41:09.125085Z",
-     "shell.execute_reply": "2026-06-29T01:41:09.125085Z"
+     "iopub.execute_input": "2026-09-01T21:29:13.034865Z",
+     "iopub.status.busy": "2026-09-01T21:29:13.034586Z",
+     "iopub.status.idle": "2026-09-01T21:29:36.412201Z",
+     "shell.execute_reply": "2026-09-01T21:29:36.410880Z"
     }
    },
    "outputs": [
@@ -386,10 +403,10 @@
    "id": "58f301e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:09.125085Z",
-     "iopub.status.busy": "2026-06-29T01:41:09.125085Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.239455Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.238943Z"
+     "iopub.execute_input": "2026-09-01T21:29:36.414711Z",
+     "iopub.status.busy": "2026-09-01T21:29:36.414276Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.343500Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.342033Z"
     }
    },
    "outputs": [
@@ -446,8 +463,14 @@
   {
    "cell_type": "markdown",
    "id": "2c2259ea",
-   "source": "### Lecture du résultat — la requête inverse rend le contraste flagrant\n\nSur le baromètre, l'observation et l'intervention différaient (`0.656` vs `0.310`) mais restaient toutes deux des probabilités de tempête « plausibles ». Ici le contraste est plus net : **observer** la pluie fait monter `P(Cloudy)` à `0.800` — la pluie est un excellent indice de nuages — tandis que **provoquer** la pluie (arroseur géant) laisse `P(Cloudy)` à sa marginale `0.500`. L'information remonte l'arc `Cloudy → Rain` quand on observe, mais aucun mécanisme physique ne la fait redescendre quand on intervient : `do(Rain)` coupe l'arc entrant, et `Cloudy` redevient une pièce non biaisée.\n\nC'est la signature directionnelle de la causalité que les probabilités classiques ne peuvent pas exprimer : `P(Cloudy|Rain)` et `P(Rain|Cloudy)` vivent dans la même table jointe, mais `P(Cloudy|do(Rain))` **n'est pas** une lecture de cette table — c'est une propriété du graphe orienté. L'échantillonnage `pm.do` (~`0.503` sur 40 000 tirages) confirme la valeur exacte `0.500` à la fluctuation d'échantillonnage près : le `do` natif de PyMC exécute bien la mutilation, pas un simple conditionnement.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — la requête inverse rend le contraste flagrant\n",
+    "\n",
+    "Sur le baromètre, l'observation et l'intervention différaient (`0.656` vs `0.310`) mais restaient toutes deux des probabilités de tempête « plausibles ». Ici le contraste est plus net : **observer** la pluie fait monter `P(Cloudy)` à `0.800` — la pluie est un excellent indice de nuages — tandis que **provoquer** la pluie (arroseur géant) laisse `P(Cloudy)` à sa marginale `0.500`. L'information remonte l'arc `Cloudy → Rain` quand on observe, mais aucun mécanisme physique ne la fait redescendre quand on intervient : `do(Rain)` coupe l'arc entrant, et `Cloudy` redevient une pièce non biaisée.\n",
+    "\n",
+    "C'est la signature directionnelle de la causalité que les probabilités classiques ne peuvent pas exprimer : `P(Cloudy|Rain)` et `P(Rain|Cloudy)` vivent dans la même table jointe, mais `P(Cloudy|do(Rain))` **n'est pas** une lecture de cette table — c'est une propriété du graphe orienté. L'échantillonnage `pm.do` (~`0.503` sur 40 000 tirages) confirme la valeur exacte `0.500` à la fluctuation d'échantillonnage près : le `do` natif de PyMC exécute bien la mutilation, pas un simple conditionnement."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -471,10 +494,10 @@
    "id": "8e4b4a3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.241356Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.241356Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.244994Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.244994Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.347378Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.346750Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.358530Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.356316Z"
     }
    },
    "outputs": [
@@ -506,8 +529,14 @@
   {
    "cell_type": "markdown",
    "id": "90cb61d3",
-   "source": "### Lecture du résultat — deux routes, un même nombre\n\nL'ajustement backdoor `0.80*0.3 + 0.10*0.7 = 0.310` coïncide **exactement** avec le `do(barometro)` direct par mutilation (`0.310`). Ce n'est pas une coïncidence numérique : les deux expriment la même quantité `P(tempete | do(barometre))`, l'une en **transformant le graphe** (mutilation : on coupe l'arc `BassePression → Barometre`), l'autre en **corrigeant l'observation** (on conditionne sur le confondeur puis on moyenne selon sa distribution `P(pression)`).\n\nLa condition de validité est graphique : `BassePression` bloque **tous** les chemins backdoor de `Barometre` (ici il n'y en a qu'un, `Barometre ← BassePression → Tempete`), et l'indépendance conditionnelle `tempete ⊥ barometre | pression` justifie la simplification `P(tempete|barometre, pression) = P(tempete|pression)` utilisée dans le calcul. Retenez l'économie de la méthode : **pas besoin de manipuler le modèle** — avec des données observationnelles et la bonne liste de variables d'ajustement, l'effet causal se calcule par une somme pondérée. C'est le fondement de l'inférence causale en épidémiologie et en économétrie (variables de contrôle).",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — deux routes, un même nombre\n",
+    "\n",
+    "L'ajustement backdoor `0.80*0.3 + 0.10*0.7 = 0.310` coïncide **exactement** avec le `do(barometro)` direct par mutilation (`0.310`). Ce n'est pas une coïncidence numérique : les deux expriment la même quantité `P(tempete | do(barometre))`, l'une en **transformant le graphe** (mutilation : on coupe l'arc `BassePression → Barometre`), l'autre en **corrigeant l'observation** (on conditionne sur le confondeur puis on moyenne selon sa distribution `P(pression)`).\n",
+    "\n",
+    "La condition de validité est graphique : `BassePression` bloque **tous** les chemins backdoor de `Barometre` (ici il n'y en a qu'un, `Barometre ← BassePression → Tempete`), et l'indépendance conditionnelle `tempete ⊥ barometre | pression` justifie la simplification `P(tempete|barometre, pression) = P(tempete|pression)` utilisée dans le calcul. Retenez l'économie de la méthode : **pas besoin de manipuler le modèle** — avec des données observationnelles et la bonne liste de variables d'ajustement, l'effet causal se calcule par une somme pondérée. C'est le fondement de l'inférence causale en épidémiologie et en économétrie (variables de contrôle)."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -531,10 +560,10 @@
    "id": "ca712ea1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.247373Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.246006Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.253951Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.253951Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.364640Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.363032Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.377711Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.376607Z"
     }
    },
    "outputs": [
@@ -542,6 +571,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "CPT du SCM front-door (lues depuis le module canonique) :\n",
+      "  P(u=1 | parents) in [0.2]\n",
+      "  P(smoke=1 | parents) in [0.3, 0.8]\n",
+      "  P(tar=1 | parents) in [0.1, 0.9]\n",
+      "  P(cancer=1 | parents) in [0.05, 0.5, 0.7, 0.95]\n",
+      "\n",
       "P(X=smoke) marginal = 0.400\n",
       "P(M=1|X=1) = 0.900 ; P(M=0|X=1) = 0.100\n",
       "Front-door  P(Cancer | do(Smoke)) = 0.689  (ajustement SANS acceder a U)\n",
@@ -553,21 +588,24 @@
    "source": [
     "# FRONT-DOOR : X=smoke, M=tar, Y=cancer, U=genotype (non observe)\n",
     "# SCM complet (U inclus) pour la verification do() directe\n",
-    "front_scm = [\n",
-    "    (\"u\",      lambda a: 0.20),                          # genotype (latent)\n",
-    "    (\"smoke\",  lambda a: 0.80 if a[\"u\"] else 0.30),      # U -> X\n",
-    "    (\"tar\",    lambda a: 0.90 if a[\"smoke\"] else 0.10),  # X -> M\n",
-    "    (\"cancer\", lambda a: (0.95 if a[\"u\"] else 0.70) if a[\"tar\"]      # {M,U} -> Y\n",
-    "                          else (0.50 if a[\"u\"] else 0.05)),\n",
-    "]\n",
+    "# --- Acceptance #14051 : le SCM front-door et P(Y|M,X) viennent du module\n",
+    "# canonique. Une SEULE definition existe desormais : si les CPT changent dans\n",
+    "# pymc_causal_organs.py, ce notebook ET ict.bridges le voient ensemble.\n",
+    "from pymc_causal_organs import FRONT_SCM as front_scm, p_y_given_m_x\n",
+    "\n",
+    "# Les CPT restent lisibles -- lues sur l'objet IMPORTE, jamais recopiees ici :\n",
+    "_names = [n for n, _ in front_scm]\n",
+    "print(\"CPT du SCM front-door (lues depuis le module canonique) :\")\n",
+    "for _name, _fn in front_scm:\n",
+    "    _vals = sorted({round(_fn(dict(zip(_names, _bits))), 4)\n",
+    "                    for _bits in itertools.product([False, True], repeat=len(front_scm))})\n",
+    "    print(f\"  P({_name}=1 | parents) in {_vals}\")\n",
+    "print()\n",
     "\n",
     "# Quantites observationnelles (U JAMAIS utilise — c'est tout l'interet du front-door)\n",
     "p_x1 = enumerate_scm(front_scm, \"smoke\")                                   # P(X=1) marginal\n",
     "p_m1_given_x1 = enumerate_scm(front_scm, \"tar\", evidence={\"smoke\": True})  # P(M=1|X=1)\n",
     "p_m0_given_x1 = 1 - p_m1_given_x1\n",
-    "\n",
-    "def p_y_given_m_x(mval, xval):\n",
-    "    return enumerate_scm(front_scm, \"cancer\", evidence={\"tar\": mval, \"smoke\": xval})\n",
     "\n",
     "inner_m1 = p_y_given_m_x(True,  True) * p_x1 + p_y_given_m_x(True,  False) * (1 - p_x1)\n",
     "inner_m0 = p_y_given_m_x(False, True) * p_x1 + p_y_given_m_x(False, False) * (1 - p_x1)\n",
@@ -586,8 +624,14 @@
   {
    "cell_type": "markdown",
    "id": "422398fa",
-   "source": "### Lecture du résultat — identifier l'effet causal sans voir le confondeur\n\nLe résultat clé est l'égalité parfaite `0.689 = 0.689` : la formule front-door, construite **uniquement** à partir de quantités observationnelles (`P(X=1) = 0.400`, `P(M=1|X=1) = 0.900`, et les conditionnelles `P(Y|M,X)`), restitue exactement l'effet de la mutilation `do(Smoke=True)` — alors même que cette mutilation « triche » en utilisant le SCM complet, `U` compris.\n\nDécomposons pourquoi ça marche : le goudron `M` capture **tout** l'effet de `X` sur `Y` (il n'y a pas d'arc direct `Smoke → Cancer`), et `X` n'a pas de parent observé qui corrompe `P(M|X)`. Le premier facteur `P(M=m|X)` mesure donc l'effet causal `X → M` non biaisé ; la somme interne `Somme_x' P(Y|M=m, x') P(x')` « re-randomise » `X` pour neutraliser le biais du confondeur sur `M → Y`. C'est une **décomposition** de l'effet total en deux morceaux identifiés séparément — l'astuce de Pearl qui rend l'inference causale possible même quand `U` (génétique, statut socio-économique...) n'est **pas mesurable**.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — identifier l'effet causal sans voir le confondeur\n",
+    "\n",
+    "Le résultat clé est l'égalité parfaite `0.689 = 0.689` : la formule front-door, construite **uniquement** à partir de quantités observationnelles (`P(X=1) = 0.400`, `P(M=1|X=1) = 0.900`, et les conditionnelles `P(Y|M,X)`), restitue exactement l'effet de la mutilation `do(Smoke=True)` — alors même que cette mutilation « triche » en utilisant le SCM complet, `U` compris.\n",
+    "\n",
+    "Décomposons pourquoi ça marche : le goudron `M` capture **tout** l'effet de `X` sur `Y` (il n'y a pas d'arc direct `Smoke → Cancer`), et `X` n'a pas de parent observé qui corrompe `P(M|X)`. Le premier facteur `P(M=m|X)` mesure donc l'effet causal `X → M` non biaisé ; la somme interne `Somme_x' P(Y|M=m, x') P(x')` « re-randomise » `X` pour neutraliser le biais du confondeur sur `M → Y`. C'est une **décomposition** de l'effet total en deux morceaux identifiés séparément — l'astuce de Pearl qui rend l'inference causale possible même quand `U` (génétique, statut socio-économique...) n'est **pas mesurable**."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -605,10 +649,10 @@
    "id": "df8d337b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.256887Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.256383Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.261769Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.261769Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.379891Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.379569Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.390205Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.388269Z"
     }
    },
    "outputs": [
@@ -666,8 +710,18 @@
   {
    "cell_type": "markdown",
    "id": "37b96f91",
-   "source": "### Lecture du résultat — l'agrégé ment, le `do` rétablit\n\nTrois lectures du **même** SCM, trois verdicts :\n\n- **Agrégé** : `P(Rec|Drug) = 0.580` < `P(Rec|NoDrug) = 0.620` — le médicament semble **nuire**. C'est le chiffre qu'une analyse naïve du tableau croisé rapporterait.\n- **Conditionnel** : dans **chaque** sous-groupe le médicament aide (`0.50 > 0.30` chez les graves, `0.90 > 0.70` chez les légers). Le renversement est le mécanisme exact du paradoxe de Simpson : les graves, qui guérissent moins bien quel que soit le traitement, reçoivent le médicament dans 80 % des cas — l'agrégé est dominé par ce mélange de populations.\n- **Interventionnel** : `P(Rec|do(Drug)) = 0.700` contre `0.500` — l'effet causal vrai, obtenu en coupant l'arc `Severité → Drug` (mutilation) ou, de façon équivalente, par l'ajustement backdoor sur la sévérité de la section 5.\n\nLa leçon pratique : **aucun intervalle de confiance sur l'agrégé ne corrige ce biais** — c'est un défaut de structure du graphe, pas un problème de taille d'échantillon. Seule la question causale bien posée (`do`, ou ajustement sur un ensemble Z validé par le critère backdoor) restaure le bon signe.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — l'agrégé ment, le `do` rétablit\n",
+    "\n",
+    "Trois lectures du **même** SCM, trois verdicts :\n",
+    "\n",
+    "- **Agrégé** : `P(Rec|Drug) = 0.580` < `P(Rec|NoDrug) = 0.620` — le médicament semble **nuire**. C'est le chiffre qu'une analyse naïve du tableau croisé rapporterait.\n",
+    "- **Conditionnel** : dans **chaque** sous-groupe le médicament aide (`0.50 > 0.30` chez les graves, `0.90 > 0.70` chez les légers). Le renversement est le mécanisme exact du paradoxe de Simpson : les graves, qui guérissent moins bien quel que soit le traitement, reçoivent le médicament dans 80 % des cas — l'agrégé est dominé par ce mélange de populations.\n",
+    "- **Interventionnel** : `P(Rec|do(Drug)) = 0.700` contre `0.500` — l'effet causal vrai, obtenu en coupant l'arc `Severité → Drug` (mutilation) ou, de façon équivalente, par l'ajustement backdoor sur la sévérité de la section 5.\n",
+    "\n",
+    "La leçon pratique : **aucun intervalle de confiance sur l'agrégé ne corrige ce biais** — c'est un défaut de structure du graphe, pas un problème de taille d'échantillon. Seule la question causale bien posée (`do`, ou ajustement sur un ensemble Z validé par le critère backdoor) restaure le bon signe."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -712,10 +766,10 @@
    "id": "77ffc216",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.262795Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.262795Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.268093Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.268093Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.394365Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.394047Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.406274Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.404962Z"
     }
    },
    "outputs": [
@@ -754,8 +808,14 @@
   {
    "cell_type": "markdown",
    "id": "415c6890",
-   "source": "### Lecture du résultat — le contrefactuel est un nombre, pas une vague\n\nL'abduction renverse la flèche informationnelle : sachant que le patient a pris le médicament **et** a guéri, la probabilité qu'il soit un cas grave passe de `0.5` (prior) à `0.690` — les guérisons sous médicament sont plus fréquentes chez les légers, donc une guérison observée penche vers « léger », mais le médicament est plus prescrit aux graves... le posterieur `0.690` est le compromis exact de ces deux forces.\n\nLa prédiction contrefactuelle donne `0.424` : ce patient précis, re-placé dans le monde contrefactuel `do(NoDrug)` avec **son** profil abduit, n'aurait eu qu'environ 42 % de chances de guérison — contre 100 % dans le monde factual (il a guéri). C'est la lecture niveau 3 de Pearl : **la même personne**, deux mondes, deux nombres. Ni l'observation (`P(rec|nodrug)` agrégé) ni l'intervention (`do(nodrug)` sur la population) ne répondent à cette question — seuls les **deux temps** abduction → prediction y répondent, et c'est pourquoi le niveau 3 est strictement plus expressif que le niveau 2.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — le contrefactuel est un nombre, pas une vague\n",
+    "\n",
+    "L'abduction renverse la flèche informationnelle : sachant que le patient a pris le médicament **et** a guéri, la probabilité qu'il soit un cas grave passe de `0.5` (prior) à `0.690` — les guérisons sous médicament sont plus fréquentes chez les légers, donc une guérison observée penche vers « léger », mais le médicament est plus prescrit aux graves... le posterieur `0.690` est le compromis exact de ces deux forces.\n",
+    "\n",
+    "La prédiction contrefactuelle donne `0.424` : ce patient précis, re-placé dans le monde contrefactuel `do(NoDrug)` avec **son** profil abduit, n'aurait eu qu'environ 42 % de chances de guérison — contre 100 % dans le monde factual (il a guéri). C'est la lecture niveau 3 de Pearl : **la même personne**, deux mondes, deux nombres. Ni l'observation (`P(rec|nodrug)` agrégé) ni l'intervention (`do(nodrug)` sur la population) ne répondent à cette question — seuls les **deux temps** abduction → prediction y répondent, et c'est pourquoi le niveau 3 est strictement plus expressif que le niveau 2."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -780,10 +840,10 @@
    "id": "374ff75a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.270052Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.270052Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.273794Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.273794Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.409810Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.409455Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.416292Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.414375Z"
     }
    },
    "outputs": [
@@ -813,10 +873,10 @@
    "id": "864e0205",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.275306Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.275306Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.279098Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.279098Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.420038Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.419442Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.428105Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.425544Z"
     }
    },
    "outputs": [
@@ -844,10 +904,10 @@
    "id": "c937d336",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.279098Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.279098Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.284292Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.284292Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.432762Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.431250Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.440843Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.439680Z"
     }
    },
    "outputs": [
@@ -875,10 +935,10 @@
    "id": "1e976e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T01:41:10.284292Z",
-     "iopub.status.busy": "2026-06-29T01:41:10.284292Z",
-     "iopub.status.idle": "2026-06-29T01:41:10.289510Z",
-     "shell.execute_reply": "2026-06-29T01:41:10.289510Z"
+     "iopub.execute_input": "2026-09-01T21:29:40.444082Z",
+     "iopub.status.busy": "2026-09-01T21:29:40.443788Z",
+     "iopub.status.idle": "2026-09-01T21:29:40.450522Z",
+     "shell.execute_reply": "2026-09-01T21:29:40.449014Z"
     }
    },
    "outputs": [
@@ -945,6 +1005,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "notes": "Inference causale, do-calculus (intervention counterfactuelle), ajustement backdoor sur confondeur. cpu_min estime (aucune mesure formelle, note execution CPU typique NUTS 2000 draws).",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-01-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -960,24 +1037,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
-  },
-  "cost": {
-   "api_usd_est": 0,
-   "api_provider": "none",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reproducibility": "HIGH",
-   "validator": "papermill",
-   "notes": "Inference causale, do-calculus (intervention counterfactuelle), ajustement backdoor sur confondeur. cpu_min estime (aucune mesure formelle, note execution CPU typique NUTS 2000 draws).",
-   "reduced_pedagogical": "Probas/PyMC/PyMC-01-Setup.ipynb",
-   "metadata_written": "2026-07-28"
+   "version": "3.13.15"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/tests/test_pymc05_notebook_wiring.py
+++ b/MyIA.AI.Notebooks/Probas/PyMC/tests/test_pymc05_notebook_wiring.py
@@ -1,0 +1,160 @@
+"""Gate anti-derive du cablage PyMC-05 -> pymc_causal_organs (acceptance 2 et 4 de #14051).
+
+Ce que ce fichier verifie, et pourquoi il existe
+------------------------------------------------
+
+L'acceptance 2 de #14051 demande que le notebook natif **importe** son module
+canonique au lieu de redefinir les organes. Une telle exigence, laissee en
+prose, est invisible : rien n'empeche une edition ulterieure de recoller un
+``def enumerate_scm`` dans la cellule 5, et le notebook continuerait de
+s'executer sans erreur. C'est precisement le mode de defaillance que
+l'issue #14051 decrit pour ``ict.bridges`` -- une copie qui derive en
+silence pendant que tout reste vert.
+
+Les gates N1-N3 verrouillent donc la **forme** du cablage (import, pas
+definition), et N4 verrouille sa **consequence numerique** : les nombres
+publies dans les sorties committees du notebook doivent etre ceux que le
+module canonique calcule aujourd'hui. Si ``pymc_causal_organs.py`` change
+ses CPT ou son estimateur, N4 rougit -- ce qui est exactement le sens du
+mot « anti-derive » de l'acceptance 4.
+
+Note de lecture : N4 lit les **sorties committees** (le livrable
+pedagogique, cf C.2), pas une re-execution. Un test qui re-executerait le
+notebook mesurerait l'environnement du runner, pas la coherence du
+livrable ; et il exigerait ``pymc`` en CI la ou ces organes n'en ont aucun
+besoin (``enumerate_scm`` est une sommation exhaustive sans RNG).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_PYMC_DIR = Path(__file__).resolve().parent.parent
+if str(_PYMC_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYMC_DIR))
+
+import pymc_causal_organs as pco  # noqa: E402
+
+_NOTEBOOK = _PYMC_DIR / "PyMC-05-Causal-Inference.ipynb"
+
+
+def _code_cells() -> list[str]:
+    nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
+    return ["".join(c["source"]) for c in nb["cells"] if c["cell_type"] == "code"]
+
+
+def _cell_outputs_text(predicate) -> str:
+    """Texte concatene des sorties de la premiere cellule code satisfaisant `predicate`."""
+    nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
+    for cell in nb["cells"]:
+        if cell["cell_type"] != "code":
+            continue
+        if not predicate("".join(cell["source"])):
+            continue
+        chunks = []
+        for out in cell.get("outputs", []):
+            chunks.append("".join(out.get("text", [])))
+        return "".join(chunks)
+    raise AssertionError("aucune cellule ne satisfait le predicat")
+
+
+# ---------------------------------------------------------------------------
+# N1-N3 : la FORME du cablage -- importer, ne pas redefinir
+# ---------------------------------------------------------------------------
+
+def test_n1_engine_is_imported_not_defined():
+    """N1 -- le moteur d'enumeration est importe du module, pas redefini."""
+    cells = _code_cells()
+    assert any("from pymc_causal_organs import enumerate_scm" in c for c in cells), (
+        "la cellule 5 doit importer enumerate_scm depuis le module canonique"
+    )
+    offenders = [i for i, c in enumerate(cells) if re.search(r"^def enumerate_scm\(", c, re.M)]
+    assert not offenders, (
+        f"enumerate_scm est redefini dans le notebook (cellules code {offenders}) : "
+        "c'est la duplication que #14051 supprime"
+    )
+
+
+def test_n2_front_door_scm_and_helper_are_imported():
+    """N2 -- le SCM front-door et P(Y|M,X) viennent du module."""
+    cells = _code_cells()
+    assert any("from pymc_causal_organs import FRONT_SCM as front_scm" in c for c in cells), (
+        "la cellule 20 doit importer FRONT_SCM depuis le module canonique"
+    )
+    redefined_scm = [i for i, c in enumerate(cells) if re.search(r"^front_scm\s*=\s*\[", c, re.M)]
+    assert not redefined_scm, (
+        f"front_scm est redeclare en litteral (cellules {redefined_scm}) : deux definitions "
+        "peuvent diverger sans que rien ne rougisse"
+    )
+    redefined_fn = [i for i, c in enumerate(cells) if re.search(r"^def p_y_given_m_x\(", c, re.M)]
+    assert not redefined_fn, f"p_y_given_m_x est redefini (cellules {redefined_fn})"
+
+
+def test_n3_no_organ_is_shadowed_anywhere():
+    """N3 -- aucune cellule, meme d'exercice, ne redefinit un organe canonique.
+
+    Gate large a dessein : les cellules d'exercice (31, 32) invitent le lecteur
+    a reutiliser ``enumerate_scm``. Si l'une d'elles finissait par en recoller
+    une copie, la propriete « une seule definition » tomberait sans bruit.
+    """
+    for name in ("enumerate_scm", "p_y_given_m_x"):
+        offenders = [i for i, c in enumerate(_code_cells()) if re.search(rf"^def {name}\(", c, re.M)]
+        assert not offenders, f"{name} redefini dans les cellules {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# N4 : la CONSEQUENCE -- les nombres publies sont ceux du module
+# ---------------------------------------------------------------------------
+
+def test_n4_published_numbers_match_the_canonical_module():
+    """N4 -- anti-derive : les sorties committees == ce que le module calcule.
+
+    C'est le gate qui donne son sens a « cross-engine » : il echoue si le
+    module derive de ce que le notebook publie, dans un sens comme dans
+    l'autre.
+    """
+    text = _cell_outputs_text(lambda s: "Front-door  P(Cancer | do(Smoke))" in s)
+
+    def published(pattern: str) -> float:
+        m = re.search(pattern, text)
+        assert m, f"motif absent des sorties committees : {pattern}\n--- sorties ---\n{text}"
+        return float(m.group(1))
+
+    p_x1 = pco.enumerate_scm(pco.FRONT_SCM, "smoke")
+    p_m1 = pco.enumerate_scm(pco.FRONT_SCM, "tar", evidence={"smoke": True})
+    do_direct = pco.enumerate_scm(pco.FRONT_SCM, "cancer", do_vars={"smoke": True})
+
+    p_m0 = 1 - p_m1
+    inner_m1 = pco.p_y_given_m_x(True, True) * p_x1 + pco.p_y_given_m_x(True, False) * (1 - p_x1)
+    inner_m0 = pco.p_y_given_m_x(False, True) * p_x1 + pco.p_y_given_m_x(False, False) * (1 - p_x1)
+    front_door = p_m1 * inner_m1 + p_m0 * inner_m0
+
+    # Les sorties sont formatees en .3f : on compare a cette precision.
+    assert published(r"P\(X=smoke\) marginal = ([0-9.]+)") == pytest.approx(p_x1, abs=5e-4)
+    assert published(r"P\(M=1\|X=1\) = ([0-9.]+)") == pytest.approx(p_m1, abs=5e-4)
+    assert published(r"Front-door  P\(Cancer \| do\(Smoke\)\) = ([0-9.]+)") == pytest.approx(
+        front_door, abs=5e-4
+    )
+    assert published(r"do\(X=1\) direct \(mutilation\)       = ([0-9.]+)") == pytest.approx(
+        do_direct, abs=5e-4
+    )
+
+
+def test_n5_front_door_identity_holds_on_the_published_scm():
+    """N5 -- la propriete que la section 6 demontre tient sur le SCM importe.
+
+    Complement de N4 : N4 verifie l'accord notebook/module ; N5 verifie que
+    ce sur quoi ils s'accordent est bien l'identite front-door de Pearl.
+    """
+    p_x1 = pco.enumerate_scm(pco.FRONT_SCM, "smoke")
+    p_m1 = pco.enumerate_scm(pco.FRONT_SCM, "tar", evidence={"smoke": True})
+    inner_m1 = pco.p_y_given_m_x(True, True) * p_x1 + pco.p_y_given_m_x(True, False) * (1 - p_x1)
+    inner_m0 = pco.p_y_given_m_x(False, True) * p_x1 + pco.p_y_given_m_x(False, False) * (1 - p_x1)
+    front_door = p_m1 * inner_m1 + (1 - p_m1) * inner_m0
+    do_direct = pco.enumerate_scm(pco.FRONT_SCM, "cancer", do_vars={"smoke": True})
+    assert front_door == pytest.approx(do_direct, abs=1e-12)

--- a/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
@@ -41,7 +41,22 @@
       csharp_sha: 9cf206efaa5feacea5e42311add4ed99ff68837d
       content_python_sha: e6f81df80b812e7b6f54573f12cbfe0c5f53dea2f60484dad064d7b66e58cf0e
       content_csharp_sha: 4b99b6834c86238b1602de1d0795ee13b0c173a457c743d8a015fb22d5df8a62
+    - date: "2026-09-02"
+      by: myia-po-2027:CoursIA-2
+      reason: "Attestation post-#14051 (PR #14163) : le jumeau Python importe desormais enumerate_scm et FRONT_SCM/p_y_given_m_x depuis le module canonique pymc_causal_organs.py au lieu de les redefinir, pour que le notebook et ict.bridges.pymc_enumerate observent la MEME implementation. Re-audit firsthand : structure identique avant/apres (35 cellules Python, 14 code / 21 markdown ; sections 1 a 10 en regard des memes sections du jumeau C#), seules les cellules code 5 et 20 changent, et la visibilite pedagogique y est preservee par inspect.getsource(enumerate_scm) et la lecture des CPT sur l'objet importe. Jumeau C# NON touche : content_csharp_sha identique a l'audit du 2026-08-31. Le moteur reste inline cote C# -- asymetrie de factorisation consignee en tete de known_differences. --update en dernier, aucun strip outille applique apres (#8957)."
+      python_sha: 093bb4584f619e18c4f1c4b470ecd014b5803aee
+      csharp_sha: 9cf206efaa5feacea5e42311add4ed99ff68837d
+      content_python_sha: ea8259fafa11a8718f512ce1aedf4df4b648eac21c88243947090cf6daa3c561
+      content_csharp_sha: 4b99b6834c86238b1602de1d0795ee13b0c173a457c743d8a015fb22d5df8a62
   known_differences:
+  - 'Asymetrie de FACTORISATION introduite par #14051 (PR #14163), sans effet sur le contenu enseigne :
+    cote Python le moteur enumerate_scm et le SCM front-door vivent dans le module canonique
+    MyIA.AI.Notebooks/Probas/PyMC/pymc_causal_organs.py, que le notebook IMPORTE au lieu de les redefinir,
+    afin que ict.bridges.pymc_enumerate et le notebook observent la meme implementation ; cote C# le moteur
+    reste defini inline dans le carnet. La visibilite pedagogique est preservee cote Python par
+    inspect.getsource(enumerate_scm) et par la lecture des CPT sur l''objet importe (jamais recopiees).
+    Structure inchangee des deux cotes : sections 1 a 10 identiques, 35 cellules Python (14 code / 21 markdown)
+    avant comme apres.'
   - 'Socle pedagogique commun : inference causale (do-calculus, ajustement) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
     Message Passing, modele compile en code d''inference) ; Python PyMC = echantillonnage MCMC (NUTS/HMC par defaut) + ADVI


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/tooling #14154

## Summary

Seconde moitie de l'**acceptance 2** de #14051 : `PyMC-05-Causal-Inference.ipynb` **importe** desormais les organes de `pymc_causal_organs.py` (module canonique livre par #14133) au lieu de les redefinir.

Le notebook portait sa propre copie de `enumerate_scm`, du SCM front-door et de `p_y_given_m_x`. Deux definitions du meme organe = deux verites possibles ; c'est precisement la derive que l'acceptance vise. Il n'en reste qu'une.

| Cellule | Avant | Apres |
|---|---|---|
| 5 | `def enumerate_scm(...)` (36 lignes) | `from pymc_causal_organs import enumerate_scm` + `inspect.getsource(...)` |
| 20 | litteral `front_scm = [...]` + `def p_y_given_m_x(...)` | `from pymc_causal_organs import FRONT_SCM as front_scm, p_y_given_m_x` |

**La valeur pedagogique est preservee sans transcription.** La cellule 5 *est* la lecon (le markdown 4 enseigne le moteur d'enumeration) : un import nu aurait fait disparaitre le code de la page. `inspect.getsource` affiche le code de l'objet **reellement execute** — il ne peut pas deriver du module, contrairement a un copier-coller. Meme logique cellule 20 : les CPT restent lisibles, mais lues sur l'objet importe.

C'est un ecart assume avec le twin #14092 (`make_panel_did`), qui utilisait un import nu — la, l'organe est un generateur auxiliaire, pas le sujet enseigne. L'issue #14051 anticipait explicitement cette distinction.

## Equivalence : mesuree, pas supposee

Les CPT du module *ressemblaient* au litteral d'origine. Verifie plutot que suppose : litteral extrait de `git show HEAD:`, puis compare au module sur les **64 configurations** du SCM front-door -> **0 divergence**. Les valeurs recalculees (0.400 / 0.900 / 0.689) correspondent exactement aux sorties committees.

## Gate anti-derive (`tests/test_pymc05_notebook_wiring.py`)

5 gates qui rougissent si la separation se defait :

| Gate | Rougit si |
|---|---|
| N1 | l'import disparait, ou un `def enumerate_scm` reapparait |
| N2 | idem pour `FRONT_SCM` / `p_y_given_m_x` |
| N3 | un organe est shadowe **n'importe ou** (couvre les cellules d'exercice 31/32) |
| N4 | un nombre publie s'ecarte du module (`abs=5e-4`, les sorties sont en `.3f`) |
| N5 | l'identite front-door cesse de tenir sur le SCM publie (`abs=1e-12`) |

**Falsifiabilite prouvee par mutation**, pas affirmee : CPT `0.20 -> 0.25` rougit **N4** (`Obtained: 0.4, Expected: 0.425`) ; recoller un `def enumerate_scm` rougit **N1 + N3**. Arbre restaure byte-exact ensuite (`diff` vide).

N4 lit les **sorties committees** plutot que de re-executer : c'est le livrable pedagogique (C.2) qui doit rester vrai, et un test re-executant mesurerait l'environnement du runner tout en exigeant `pymc` en CI — dont ces organes n'ont aucun besoin.

## Validation (C.2 / H.1)

Re-execution complete sous `pymc 5.28.5 / arviz 0.23.4 / numpy 2.4.4` (versions ayant produit les sorties d'origine) : **14/14 cellules, exec_counts 1..14, 0 erreur**.

Preuve de fidelite la plus forte disponible — hash SHA-256 des sorties **par cellule** contre `main` :

```
cells with ANY output byte difference: [5, 20]
```

Seules les deux cellules editees bougent. Tout le reste — echantillonnages seedes, figures matplotlib — est **byte-identique**. Tests : **13 passed** (5 nouveaux + 8 existants).

## Note d'environnement (regle F : reparer, pas contourner)

La premiere re-execution a introduit une banniere `WARNING (pytensor.configdefaults): g++ not available` : po-2027 n'avait aucun toolchain C++. Committer cet artefact d'environnement dans un notebook pedagogique aurait ete une regression, et maquiller la sortie est interdit ([secrets-hygiene](.claude/rules/secrets-hygiene.md) regle 6).

Repare a la source : `m2w64-gcc` installe via conda-forge dans un env compilateur **autonome**, mis sur le PATH de la re-execution. PyTensor detecte le compilateur, la banniere disparait, et le notebook compile ses graphes au lieu de retomber en Python pur. Les tentatives precedentes echouaient parce qu'elles installaient le toolchain *dans le meme env que pymc* (conflits `msys2-conda-epoch` / `pytensor-base` / `python_abi`) — un env compilateur seul n'a rien avec quoi entrer en conflit.

`PYTENSOR_FLAGS=cxx=` a ete ecarte : il supprime la seconde ligne de la banniere mais pas la premiere, et n'aurait fait que masquer une provision manquante.

## Residuel #14051

Acceptance 3 (`ict/bridges/pymc_enumerate.py`) reste ouverte, **volontairement non prise ici** : elle touche `ict/bridges/__init__.py`, que ma PR ouverte #14150 modifie deja — la livrer depuis `main` entrerait en conflit avec ma propre PR. A prendre apres merge de #14150.

See #14051
