### PR TITLE
fix(notebook,#14157): corriger l'attribution GPU de la jambe LLamaSharp dans 10f §5

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10f_ORTGenAI_DotNet_BakeOff.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10f_ORTGenAI_DotNet_BakeOff.ipynb
@@ -525,18 +525,7 @@
    "cell_type": "markdown",
    "id": "c11-lecture-bakeoff",
    "metadata": {},
-   "source": [
-    "### Lecture du résultat : débit et qualité\n",
-    "\n",
-    "Ce que montre la sortie ci-dessus (les valeurs font foi, la prose ne les recopie pas — elles bougeraient à la re-exécution) :\n",
-    "\n",
-    "1. **Débit décodé** : l'agrégat se situe nettement au-dessus de la jambe LLamaSharp de référence (14,14 tok/s committés dans 10e), sur le même GPU mais avec des conditions VRAM différentes (16 Go libres ici contre 6,2 Go). C'est un point de mesure, pas un benchmark contrôlé.\n",
-    "2. **TTFT** : le premier thème paie le warm-up CUDA ; les suivants descendent en dessous de la centaine de millisecondes — le préfill d'un prompt court est négligeable devant le décodage.\n",
-    "3. **Qualité syntaxique** : zéro jeton `<pad>` sur les quatre sorties — la pathologie de la Phase 1 est absente.\n",
-    "4. **Qualité sémantique — à lire avec les yeux** : les réponses sont en français grammatical, mais le modèle *base* (non instruct) se trompe de domaine sur certains thèmes (le batching continu décrit comme une chaîne de production, la quantification Q4 comme de la compression d'images). C'est une **limite du modèle, pas du moteur** : la variante [Qwen3-4B-Instruct-2507-ONNX](https://huggingface.co/onnx-community/Qwen3-4B-Instruct-2507-ONNX) existe sur le même dépôt.\n",
-    "\n",
-    "Un moteur d'inférence se juge sur la **fidélité du décodage** (jetons propres, débit, latence) ; la justesse factuelle appartient au modèle choisi."
-   ]
+   "source": "### Lecture du résultat : débit et qualité\n\nCe que montre la sortie ci-dessus (les valeurs font foi, la prose ne les recopie pas — elles bougeraient à la re-exécution) :\n\n1. **Débit décodé** : l'agrégat se situe nettement au-dessus de la jambe LLamaSharp de **référence CPU** (14,14 tok/s committés dans 10e, vérifié post-correction comme ayant tourné sur CPU et non sur GPU — voir cellule §5 et #14157 (a) pour le détail de la mesure de réattribution). Conditions VRAM différentes (16 Go libres ici contre 6,2 Go côté LLamaSharp, qui dans les deux cas étaient en surplus inutilisé puisque la jambe n'a pas chargé le backend CUDA). C'est un point de mesure, pas un benchmark contrôlé.\n2. **TTFT** : le premier thème paie le warm-up CUDA ; les suivants descendent en dessous de la centaine de millisecondes — le préfill d'un prompt court est négligeable devant le décodage.\n3. **Qualité syntaxique** : zéro jeton `<pad>` sur les quatre sorties — la pathologie de la Phase 1 est absente.\n4. **Qualité sémantique — à lire avec les yeux** : les réponses sont en français grammatical, mais le modèle *base* (non instruct) se trompe de domaine sur certains thèmes (le batching continu décrit comme une chaîne de production, la quantification Q4 comme de la compression d'images). C'est une **limite du modèle, pas du moteur** : la variante [Qwen3-4B-Instruct-2507-ONNX](https://huggingface.co/onnx-community/Qwen3-4B-Instruct-2507-ONNX) existe sur le même dépôt.\n\nUn moteur d'inférence se juge sur la **fidélité du décodage** (jetons propres, débit, latence) ; la justesse factuelle appartient au modèle choisi."
   },
   {
    "cell_type": "markdown",
@@ -589,11 +578,7 @@
    "cell_type": "markdown",
    "id": "c14-tableau-intro",
    "metadata": {},
-   "source": [
-    "## 5. Tableau comparatif à trois moteurs\n",
-    "\n",
-    "Les colonnes TensorSharp et LLamaSharp reproduisent les **mesures committées** (10d/PR #12645 et 10e/PR #12759) ; la colonne ORT GenAI injecte les valeurs mesurées par la cellule bake-off ci-dessus. Les conditions (VRAM, modèle exact, in-process vs serveur) sont rappelées ligne par ligne : comparer des tok/s sans lire cette ligne est la première erreur de bake-off."
-   ]
+   "source": "## 5. Tableau comparatif à trois moteurs\n\nLes colonnes TensorSharp et LLamaSharp reproduisent les **mesures committées** (10d/PR #12645 et 10e/PR #12759) ; la colonne ORT GenAI injecte les valeurs mesurées par la cellule bake-off ci-dessus. Les conditions (VRAM, modèle exact, in-process vs serveur) sont rappelées ligne par ligne : comparer des tok/s sans lire cette ligne est la première erreur de bake-off.\n\n> **Note d'attribution (cf #14157 (a), vérification 2026-09-01)** : la ligne LLamaSharp du tableau ci-dessous a été corrigée pour refléter que la mesure 14,14 tok/s est un débit **CPU** (backend CUDA jamais chargé sur le harnais de référence — voir cellule §5 du tableau), et non GPU comme la version antérieure l'annonçait. Le débit reste authentique ; seule l'attribution change. La cellule markdown suivante (`### Lecture du résultat : trois moteurs, trois profils`) consigne la correction en miroir."
   },
   {
    "cell_type": "code",
@@ -619,7 +604,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "| LLamaSharp 0.27.0    | Qwen3-4B Q4_K_M (GGUF)   | in-process, RTX 3080 Ti, 6,2 Go VRAM libres |    353 | 14,14 tok/s            | 0 (0 %)            | propre, français   |\r\n"
+     "text": "| LLamaSharp 0.27.0    | Qwen3-4B Q4_K_M (GGUF)   | in-process, CPU (CUDA jamais chargé ; voir #14157 (a)) |    353 | 14,14 tok/s (CPU)      | 0 (0 %)            | propre, français   |\r\n"
     },
     {
      "output_type": "stream",
@@ -634,12 +619,18 @@
    ],
    "source": [
     "// Valeurs committées : 10d (PR #12645) et 10e cellule 7 (PR #12759). Valeurs ORT : run courant.\n",
+    "// Note attribution GPU (cf #14157 (a), verification 2026-09-01) : la ligne LLamaSharp ci-dessous a ete corrigee\n",
+    "// de \"in-process, RTX 3080 Ti, 6,2 Go VRAM libres\" vers \"in-process, CPU (CUDA jamais charge)\"\n",
+    "// car la mesure sur le meme harnais a montre `backend_ptrs.size() = 1` (CPU seul), 0/36 couches\n",
+    "// sur GPU, VRAM plate pendant l'inference, debit reproduit 13,90 et 11,51 tok/s. La jambe n'a\n",
+    "// jamais utilise le GPU. Le debit 14,14 tok/s reste authentique ; c'est son attribution qui etait\n",
+    "// fausse. La cellule [c11-lecture-bakeoff] corrige la meme assertion en miroir.\n",
     "var lignes = new (string Moteur, string Modele, string Conditions, string Jetons, string Debit, string Pads, string Qualite)[]\n",
     "{\n",
     "    (\"TensorSharp 3.2.1.0\", \"Gemma 4 E4B Q8_0 (GGUF)\", \"serveur HTTP distant, RTX 3080 16 Go\",\n",
     "     \"160\", \"~50 tok/s (côté serveur)\", \"159/160 (99,4 %)\", \"dégénérée (<pad>)\"),\n",
-    "    (\"LLamaSharp 0.27.0\", \"Qwen3-4B Q4_K_M (GGUF)\", \"in-process, RTX 3080 Ti, 6,2 Go VRAM libres\",\n",
-    "     \"353\", \"14,14 tok/s\", \"0 (0 %)\", \"propre, français\"),\n",
+    "    (\"LLamaSharp 0.27.0\", \"Qwen3-4B Q4_K_M (GGUF)\", \"in-process, CPU (CUDA jamais chargé ; voir #14157 (a))\",\n",
+    "     \"353\", \"14,14 tok/s (CPU)\", \"0 (0 %)\", \"propre, français\"),\n",
     "    (\"ORT GenAI 0.15.2\", \"Qwen3-4B int4 (ONNX)\", \"in-process, RTX 3080 Ti, 16 Go VRAM libres\",\n",
     "     $\"{totalJetons10f}\", $\"{totalJetons10f / totalSecondes10f:F2} tok/s\", $\"{totalPads10f} ({100.0 * totalPads10f / totalJetons10f:F1} %)\", \"propre, français\"),\n",
     "};\n",
@@ -647,22 +638,14 @@
     "Console.WriteLine($\"|{\"\",-22}|{\"\",-26}|{\"\",-40}|{\"\",-8}|{\"\",-24}|{\"\",-20}|{\"\",-20}|\");\n",
     "foreach (var l in lignes)\n",
     "    Console.WriteLine($\"| {l.Moteur,-20} | {l.Modele,-24} | {l.Conditions,-38} | {l.Jetons,6} | {l.Debit,-22} | {l.Pads,-18} | {l.Qualite,-18} |\");\n",
-    "Console.WriteLine(\"\\nLecture : les trois moteurs n'ont PAS servi le même format de modèle (GGUF vs ONNX), ni le même déploiement (distant vs in-process), ni la même VRAM disponible. Le seul axe strictement comparable est le taux de jetons <pad>.\");"
+    "Console.WriteLine(\"\\nLecture : les trois moteurs n'ont PAS servi le même format de modèle (GGUF vs ONNX), ni le même déploiement (distant vs in-process), ni la même VRAM disponible. Le seul axe strictement comparable est le taux de jetons <pad>.\");\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "c16-lecture-tableau",
    "metadata": {},
-   "source": [
-    "### Lecture du résultat : trois moteurs, trois profils\n",
-    "\n",
-    "- **TensorSharp** (Phase 1) : le seul à proposer un serveur HTTP avec batching continu intégré — mais la jambe locale a produit une sortie dégénérée, ce qui disqualifie l'onboarding en l'état (verdict `RECOVERABLE-LOCAL` dans 10d, réparation toujours ouverte).\n",
-    "- **LLamaSharp** (Phase 2) : binding mature de llama.cpp, écosystème GGUF immense, sortie propre — débit in-process mesuré avec 6,2 Go de VRAM libres seulement.\n",
-    "- **ORT GenAI** (ce notebook) : un NuGet Microsoft, un dossier ONNX officiel, l'EP CUDA prouvée par module chargé, sortie propre, et un débit in-process dans les conditions les plus favorables des trois jambes.\n",
-    "\n",
-    "La ligne « Qualité » est le discriminant du bake-off : deux moteurs sur trois produisent du texte exploitable ; c'est entre eux (LLamaSharp vs ORT GenAI) que se joue la décision."
-   ]
+   "source": "### Lecture du résultat : trois moteurs, trois profils\n\n- **TensorSharp** (Phase 1) : le seul à proposer un serveur HTTP avec batching continu intégré — mais la jambe locale a produit une sortie dégénérée, ce qui disqualifie l'onboarding en l'état (verdict `RECOVERABLE-LOCAL` dans 10d, réparation toujours ouverte).\n- **LLamaSharp** (Phase 2) : binding mature de llama.cpp, écosystème GGUF immense, sortie propre. **Note d'attribution (cf #14157 (a))** : le débit 14,14 tok/s reporté ici est un débit **CPU** — vérification du 2026-09-01 sur le même harnais (mêmes GGUF, 3 runs) a montré `backend_ptrs.size() = 1`, `0/36` couches assignées au GPU, VRAM plate pendant l'inférence. La colonne « Conditions » du tableau §5 reflète maintenant cette réalité (« in-process, CPU (CUDA jamais chargé) »). Le débit reste authentique ; c'est son attribution GPU qui était fausse.\n- **ORT GenAI** (ce notebook) : un NuGet Microsoft, un dossier ONNX officiel, l'EP CUDA prouvée par module chargé, sortie propre, et un débit in-process dans les conditions les plus favorables des trois jambes.\n\nLa ligne « Qualité » est le discriminant du bake-off : deux moteurs sur trois produisent du texte exploitable ; c'est entre eux (LLamaSharp vs ORT GenAI) que se joue la décision."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Résumé

Corrige l'**attribution GPU** de la jambe LLamaSharp dans le tableau comparatif §5 du notebook `10f_ORTGenAI_DotNet_BakeOff.ipynb`, suite à la vérification 2026-09-01 (cf issue de suivi **#14157 (a)**).

**Contexte** : la mesure 14,14 tok/s reportée pour LLamaSharp dans le tableau était présentée comme « in-process, RTX 3080 Ti, 6,2 Go VRAM libres ». Vérification sur le même harnais (`C:/dev/_scratch/llamasharp-test/`, mêmes GGUF, 3 runs) : `backend_ptrs.size() = 1`, **0 / 36** couches assignées au GPU, VRAM plate pendant l'inférence, débit reproduit 13,90 et 11,51 tok/s. Le backend CUDA n'a **jamais été chargé** — le repli CPU de llama.cpp est silencieux.

Le débit 14,14 tok/s reste authentique ; c'est son **attribution** GPU qui était fausse.

## Fichiers touchés

| Action | Chemin | Note |
|--------|--------|------|
| Edit | `MyIA.AI.Notebooks/GenAI/Texte/10f_ORTGenAI_DotNet_BakeOff.ipynb` cellule `c15-tableau` (code, exécution 6) | Libellé LLamaSharp Conditions : `"in-process, RTX 3080 Ti, 6,2 Go VRAM libres"` → `"in-process, CPU (CUDA jamais chargé ; voir #14157 (a))"`. Libellé Débit : `"14,14 tok/s"` → `"14,14 tok/s (CPU)"`. Commentaire d'attribution ajouté en tête de cellule (8 lignes). |
| Edit | même notebook, cellule `c14-tableau-intro` (markdown §5 intro) | Bloc de citation `>` annonçant la correction, avec lien #14157 (a). |
| Edit | même notebook, cellule `c11-lecture-bakeoff` (markdown, lecture du résultat §4) | Phrase « sur le même GPU » corrigée pour refléter la réalité CPU de la jambe LLamaSharp. |
| Edit | même notebook, cellule `c16-lecture-tableau` (markdown, lecture du résultat §5) | Note d'attribution ajoutée en miroir pour le profil LLamaSharp. |

**1 fichier indexé / 4 cellules modifiées** — bien sous le seuil G.4 (< 3000 lignes / < 15 fichiers / 1 feature / 1 domaine).

## Vérification — ré-exécution cellule [15] seule

Tell c.854-L4 durable « corriger-une-attribution-n'est-pas-re-mesurer » : la **chaîne bake-off** (cellules [2] à [13]) **n'est pas** ré-exécutée — ses valeurs sont déjà committées sur le disque (`execution_count: 4`, etc.). Seule la cellule [15] (construction du tableau) est ré-exécutée.

**Voie utilisée** : le cache modèle (~2,8 Go) étant absent de la machine, ré-exécuter les cellules [2]+[7]+[10] aurait relancé le téléchargement HF depuis zéro (interdit). L'alternative choisie est un **préambule de kernel** qui sème `totalJetons10f=160`, `totalSecondes10f=1.9034`, `totalPads10f=0` — **valeurs reconstituées de l'AGRÉGAT committé** de la cellule [10] (160 jetons / 1,90 s / 84,06 tok/s / 0 pad). La cellule [15] produit alors un tableau strictement identique à l'original pour les lignes TensorSharp et ORT GenAI ; seule la ligne LLamaSharp change (libellé `Conditions` et `Débit`).

Cette voie est conforme à l'**acceptance #14157 (a)** qui demandait « ré-exécution cellule [15] seule » et « pas de régression sur les 2 autres lignes » — les valeurs ORT GenAI reproduites **sont** l'AGRÉGAT committé, pas une mesure refaite. La transparence est consignée ici pour audit (Tell c.1356 ★★★ sustained first-hand).

## Acceptance #14157 (a)

- [x] Cellule code §5 ligne LLamaSharp « Conditions » corrigée : `"in-process, CPU (CUDA jamais chargé ; voir #14157 (a))"`
- [x] Cellule code §5 ligne LLamaSharp « Débit » annotée : `"14,14 tok/s (CPU)"`
- [x] Cellule markdown §5 intro ajoute un bloc de citation explicite
- [x] Cellule markdown §4 lecture du résultat dit « référence CPU » et non « même GPU »
- [x] Cellule markdown §5 lecture du tableau consigne la correction en miroir avec observables vérifiés
- [x] Sortie ré-exécutée de cellule [15] contient le texte `"CUDA jamais chargé"` et `"14,14 tok/s (CPU)"` (vérifié post-re-exécution)
- [x] Cellule [15] `execution_count: 6`, 6 outputs stream conservés (style conforme à HEAD)
- [x] Pas de cellule `# Solution` / `# Exemple résolu` supprimée
- [x] Pas de régression sur les 2 autres lignes du tableau (TensorSharp, ORT GenAI inchangées — TensorSharp `~50 tok/s (côté serveur)`, `159/160 (99,4 %)` ; ORT GenAI `84,06 tok/s`, `0 (0,0 %)`)
- [x] Pas de mesure re-faite (Tell c.854-L4) — la chaîne est coûteuse et les nombres stockés restent valides
- [x] Voie de reconstruction préambule-kernel documentée explicitement (audit trail)

## Tell NEW c.855

### c.855-L1 ★ sustained durable : la violation d'attribution se corrige **dans le notebook qui énonce la règle**

Tell c.854-L3 durable (cycle c.854, « chercher-la-violation-dans-le-notebook-qui-enonce-la-regle ») : 10f §2 énonce « Prouver le backend GPU se fait par observation (modules + VRAM), jamais par déduction du débit », mais sa propre ligne LLamaSharp du tableau §5 violait précisément ce principe en annonçant GPU sans preuve. La correction **dans** 10f (pas dans 10e qui est un autre notebook) est canonique — le notebook doit être cohérent avec sa propre règle.

### c.855-L2 ★ sustained durable : C.2 notebook-only n'interdit pas l'edit d'une cellule-code de **construction**

C.2 demande la ré-exécution des cellules modifiées. La cellule [15] est une cellule **de construction de tableau** (string interpolation, pas un appel de mesure). Sa ré-exécution produit un tableau identique (mêmes `totalJetons10f` etc.) avec un libellé corrigé. **Pas besoin** de relancer la chaîne bake-off complète — c'est conforme à C.2 et à Tell c.854-L4 durable « corriger-une-attribution-n'est-pas-re-mesurer ».

### c.855-L3 ★ sustained durable : le sous-agent `notebook-cell-iterator` est le bon outil pour cibler **une seule cellule**

Plutôt que Papermill (qui re-exécute tout) ou Jupyter API brut (verbeux), le sous-agent `notebook-cell-iterator` accepte un brief ciblé « cellule X seule » et orchestre la préservation du kernel state. C'est le bon outil pour les corrections attribution-only.

## Liens

- Issue de suivi : **#14157** « 10e/10f (#12353) : 4 residus apres la correction d'attribution CPU de la jambe LLamaSharp »
- Issue parent : #12353 (bake-off .NET Text GenAI)
- PR corrigeant 10e (à venir, séparée — cf #14157 (b)/(c)) : « AppLocker désactivé » et « deux runs présentés comme un »
- PR future CUDA activation (cf #14157 (d), RECOVERABLE-LOCAL hors dépôt) : `C:/dev/_scratch/llamasharp-test/Program.cs` avec `NativeLibraryConfig.All.WithCuda(true)`
- PR parent LLamaSharp committée : #12759 (Phase 2 du bake-off)
- PR parent ORT GenAI : ce notebook 10f + PR #14158 (issue de suivi c.854)
- EPIC #3801 (axe-2 SOTA) — ce notebook est axe-2 GenAI/Texte
- Tell c.854-L4 durable « corriger-une-attribution-n'est-pas-re-mesurer »
- Tell c.854-L3 durable « chercher-la-violation-dans-le-notebook-qui-enonce-la-regle »

## Workflow

- Worktree : `C:/dev/CoursIA-14157-fix-10f-attribution` (Tell c.806 LEÇON DURABLE ✓)
- Body PR : scratchpad `c855_pr_body.md` (Tell c.677-L4 sustained — HORS worktree)
- Branch : `fix/14157-10f-llamasharp-attribution` depuis `origin/main` à jour (pull frais)
- 4 cellules éditées via NotebookEdit (lecture kernel-state préservée)
- Ré-exécution cellule [15] seule via sous-agent `notebook-cell-iterator` (Tell c.855-L3)
- pre-commit : à valider (gitleaks + papermill + subprocess text=True encoding)

---

`Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA-2 — prev: LIGHT/refactor #14144`