### PR TITLE
feat(ci,#13378): image runner Linux — python nu + toolcache persistant + état déployé

### DIFF
--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -1,6 +1,6 @@
 # Préparation des runners GitHub Actions auto-hébergés
 
-Cette page décrit les mesures et les garde-fous du chantier #12704. **État au 2026-09-01 : activation partielle sur po-2024, volet Linux non déployé** (runner `fast-guards` live, tool-cache seedé — cf section Provisionnement ; ré-enregistrement sans UAC opérationnel), les autres profils du registre restant en préparation. Le dépôt `jsboige/CoursIA` est public : une PR de fork peut contenir du code non fiable. Toute exécution auto-hébergée reste réservée aux branches du dépôt lui-même, avec une garde YAML explicite en plus des réglages GitHub.
+Cette page décrit les mesures et les garde-fous du chantier #12704. **État au 2026-09-01 : activation partielle sur po-2024, volet Linux conteneurisé en ligne** (2 slots Docker, preuve d'identité `RUNNER_OS = Linux` rendue — cf section Runner Linux conteneurisé ; runner `fast-guards` live, tool-cache seedé, ré-enregistrement sans UAC opérationnel), les autres profils du registre restant en préparation. Le dépôt `jsboige/CoursIA` est public : une PR de fork peut contenir du code non fiable. Toute exécution auto-hébergée reste réservée aux branches du dépôt lui-même, avec une garde YAML explicite en plus des réglages GitHub.
 
 ## Mesurer avant de dimensionner
 
@@ -240,17 +240,26 @@ Trois points de conception qui ne sont pas négociables :
 
 **Labels dédiés** : le jeu `{self-hosted, coursia-ephemeral, coursia-linux}` (second jeu admis par `check_self_hosted_runner_policy.py`) route uniquement vers le conteneur — un dispatch Windows ne peut jamais y atterrir, un job Linux ne peut jamais atterrir sur un runner Windows. Mélanger les deux jeux reste une violation (`RUNNER_LABELS`).
 
-**État réel mesuré le 2026-09-01 (po-2024, inventaire GitHub firsthand)** : le registre du dépôt ne contient **qu'un seul runner**, `myia-po-2024-fast-guards`, **Windows**. Aucun runner ne porte le label `coursia-linux` — nulle part. L'image n'a jamais été construite.
+**État déployé le 2026-09-01 (po-2024, inventaire GitHub firsthand ~20:27Z)** : 2 slots `myia-po-2024-linux-docker-1/-2` `[online]`, labels `{self-hosted, coursia-ephemeral, coursia-linux}`, image 2.336.0, lancés par `supervise.sh start 2`. **Preuve d'identité rendue** : run 33554804211 — `Runner name: 'myia-po-2024-linux-docker-1'`, `runner.os=Linux`, job 1 m 51 s, conclusion success. Empreinte au repos mesurée sur les deux conteneurs : ~40,5 MiB / 4 GiB chacun, CPU ~0 %, PIDS 14-18. **Empreinte sous charge** (deux jobs organiques concurrents, ~21:55Z) : CPU 113 % et 161 % (cap 300 %), MEM 187 MiB et 498 MiB (cap 4 GiB), PIDS 52 et 50 (cap 384) — la jambe tient N=2 concurrent sans approcher les caps. La boucle de supervision est prouvée : après la mort éphémère du conteneur post-job, ré-enregistrement automatique observé et runners repassés `[online]`.
 
-Conséquence à écrire noir sur blanc, parce que la version précédente de cette page décrivait la conception comme un état déployé : `linux-self-hosted-tests.yml` (dispatch-ONLY, zéro fan-out, pattern #13097) cible un **label orphelin**. Un dispatch y mettrait le job en file **indéfiniment** — pas d'échec, pas de rouge, une attente muette. Le piège est aujourd'hui dormant (0 run en file, vérifié), il ne l'est plus dès qu'on dispatche.
+La leçon qui a fondé cette preuve reste écrite noir sur blanc : cette page a déjà décrit une conception comme un état déployé — l'inventaire du matin même (2026-09-01) montrait un registre à **un seul** runner Windows, label `coursia-linux` orphelin nulle part, image jamais construite. Tant qu'aucun job n'a rendu la preuve d'identité (`RUNNER_OS = Linux` dans les logs), aucun vert de cette chaîne ne prouve quoi que ce soit — leçon po-2024 du run 33178577527, où l'échec s'était produit *pour la mauvaise raison* (ACE manquante) et aurait pu passer pour un succès de routage.
 
-Le `docker build` + `supervise.sh start` ci-dessus est donc la **précondition** du pilote, pas son prolongement. Tant qu'aucun job n'a rendu la preuve d'identité (`RUNNER_OS = Linux` dans les logs), aucun vert de cette chaîne ne prouve quoi que ce soit — leçon po-2024 du run 33178577527, où l'échec s'était produit *pour la mauvaise raison* (ACE manquante) et aurait pu passer pour un succès de routage.
+L'image expose `python` nu (`python-is-python3`) pour les workflows stdlib-only (le `check-navlinks` du job 100021313259 avait échoué `exit 127 "python: not found"` avant cela), et les slots montent le volume `coursia-runner-toolcache` sur `/opt/hostedtoolcache` (`RUNNER_TOOL_CACHE`) pour que les actions `setup-*` ne re-téléchargent pas leurs outils à chaque conteneur éphémère. Après toute modification du Dockerfile : rebuild (même tag), puis roulement des slots — `stop`, `docker kill` des conteneurs vérifiés `busy=false`, `start N`.
 
-Les 93 jobs `ubuntu-latest` du census #13378 restent sur GitHub-hosted tant que l'empreinte n'a pas été mesurée sur des jobs réels — décision coordinateur, pas worker.
+Routage (décision coordinateur) — **tranche 1 portée par #14148 (PR ouverte au 2026-09-01)** : 11 workflows y passent sur les labels `coursia-linux`, sous la règle « allowlist du checker `check_self_hosted_runner_policy.py` + garde universelle de fork/payload + timeout + `permissions: read` ». Tant qu'elle n'est pas mergée, ces workflows restent sur GitHub-hosted. Le reste des 93 jobs `ubuntu-latest` du census #13378 demeure sur GitHub-hosted tant que l'empreinte n'a pas été mesurée sur des jobs réels — l'élargissement (tranche 2, N slots) reste décision coordinateur après 24 h de vert sur la tranche 1.
 
 **Le gestionnaire ne bloque pas.** `manage_self_hosted_runner.py` et `self_hosted_runner_profiles.json` sont Windows-only *par validation* (« must pin an official Windows x64 archive ») : ils ne peuvent pas porter un profil Linux aujourd'hui. Ce n'est pas un blocage — `supervise.sh` fonctionne sans eux, sans aucune PR préalable. Étendre le gestionnaire aux profils Linux est une **PR de suivi**, jamais la condition du débrayage.
 
 Si l'empreinte mesurée pendant un job gêne la workstation (training GPU, sessions interactives), on **réduit les caps ou on arrête**, et on le signale à ai-01.
+
+### Persistance du superviseur — pas encore posée (en attente de go)
+
+`supervise.sh` vit dans une session : si elle meurt, les slots en ligne consomment leur inscription au prochain job et rien ne les relance. Le déploiement durable prévu :
+
+- **voie WSL** : service utilisateur systemd (`systemctl --user`, unit lançant `supervise.sh start 2`) + `loginctl enable-linger <user>` pour survivre aux déconnexions ;
+- **voie Windows** (alternative) : tâche planifiée au logon via `schtasks`, même invocation.
+
+Aucun des deux n'est installé sur po-2024 à date : l'installation d'un mécanisme permanent d'enregistrement est un geste explicite (coordinateur ou user), jamais silencieux.
 
 ## Tranches suivantes, activation partielle
 
@@ -259,7 +268,7 @@ La préparation complète reste découpée :
 1. **Mesure** — instrument de cette page.
 2. **Isolation statique** — scanner fail-closed, allowlist et labels dépôt.
 3. **Cycle de vie local** — gestionnaire, profils, probes et teardown décrits ci-dessus.
-4. **Commutation** — un seul point de bascule et garde `github.event.pull_request.head.repo.full_name == github.repository`; aucun `pull_request_target` auto-hébergé.
+4. **Commutation** — un seul point de bascule et garde **universelle** de fork/payload sur chaque workflow routé : `github.event.pull_request.head.repo.full_name == github.repository` ; aucun `pull_request_target` auto-hébergé. C'est la forme appliquée par #14148 aux 11 workflows de la tranche 1.
 5. **Preuve contrôlée** — autorisation explicite, une exécution légère réussie, contrôle négatif fork/payload (livré : garde #13387, simulation run 33185586681), puis teardown et preuve que l'état initial est restauré.
 6. **Capacité** — le contrôleur ci-dessus ; son test de bout en bout (tâche posée → tick → job consommé → ré-enregistrement observé → tâche retirée) exige une session élevée : c'est la checklist de la session d'activation, le bouton appartient au coordinateur ou au user.
 
@@ -271,7 +280,7 @@ La préparation complète reste découpée :
 | `myia-po-2024-fast-guards` | **actif** — seul runner du dépôt ; Windows ; tool-cache seedé (a2), ré-enregistrement sans UAC, jobs réels consommés |
 | `myia-po-2025-fast-guards` | en préparation (aucun runner enregistré) |
 | `myia-po-2026-fast-guards` | en préparation (aucun runner enregistré ; profil vérifié dans le registre) |
-| `coursia-linux` (conteneur) | **inexistant** — label ciblé par `linux-self-hosted-tests.yml`, aucun runner ne le porte. Image non construite |
+| `coursia-linux` (conteneur) | **en ligne** — 2 slots conteneurisés sur po-2024 (`myia-po-2024-linux-docker-1/-2`), preuve d'identité run 33554804211 (`RUNNER_OS = Linux`) |
 
 La colonne est datée d'une **mesure**, pas d'une intention : le tableau précédent portait « actif » et « en préparation » sans dire ce qui avait été compté, ce qui a laissé lire une conception comme un déploiement.
 

--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -17,9 +17,12 @@ ARG RUNNER_VERSION=2.336.0
 ARG RUNNER_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
 
 ENV DEBIAN_FRONTEND=noninteractive
+# python-is-python3 : les workflows stdlib-only appellent `python` nu
+# (check-navlinks, job 100021313259 : exit 127 "python: not found" alors
+# que python3 etait present).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip \
+       ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip python-is-python3 \
        libicu74 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -31,9 +34,13 @@ RUN echo "${RUNNER_SHA256}  /tmp/runner.tar.gz" | sha256sum -c - \
     && tar xzf /tmp/runner.tar.gz -C /opt/runner \
     && rm /tmp/runner.tar.gz
 
+# /opt/hostedtoolcache : point de montage du volume persistant (supervise.sh).
+# Cree ET possede par runner ici pour que le volume nomme herite cette
+# propriete a sa premiere creation -- sinon il serait root:root et les
+# actions setup-* echoueraient en EACCES sous l'utilisateur non-root.
 RUN useradd -m -u 1001 runner \
-    && mkdir -p /home/runner/_work \
-    && chown -R runner:runner /opt/runner /home/runner
+    && mkdir -p /home/runner/_work /opt/hostedtoolcache \
+    && chown -R runner:runner /opt/runner /home/runner /opt/hostedtoolcache
 
 USER runner
 WORKDIR /opt/runner

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -49,6 +49,14 @@ TOOLCACHE_MOUNT="${COURSIA_RUNNER_TOOLCACHE_MOUNT:-/opt/hostedtoolcache}"
 
 mkdir -p "$STATE_DIR"
 
+# Git Bash (MSYS) sous Windows reecrit les arguments de forme /posix/path des
+# appels a docker.exe : -e RUNNER_TOOL_CACHE=/opt/hostedtoolcache devenait
+# "C:/Program Files/Git/opt/hostedtoolcache" dans le conteneur (mesure :
+# docker inspect Config.Env apres le premier demarrage). Ces deux variables
+# sont inertes sous Linux et figent la conversion cote Windows.
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
 die() { echo "ERREUR: $*" >&2; exit 1; }
 
 fetch_token() {

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -40,6 +40,13 @@ CPUS="${COURSIA_RUNNER_CPUS:-3}"
 MEMORY="${COURSIA_RUNNER_MEMORY:-4g}"
 PIDS="${COURSIA_RUNNER_PIDS:-384}"
 
+# Toolcache persistant : sans lui, chaque conteneur ephemere (un par job)
+# re-telechargerait interpretes et outils via les actions setup-*. Le volume
+# nomme survit aux conteneurs ; RUNNER_TOOL_CACHE dit aux actions ou chercher.
+# Sa propriete runner:runner vient du point de montage du Dockerfile.
+TOOLCACHE_VOLUME="${COURSIA_RUNNER_TOOLCACHE_VOLUME:-coursia-runner-toolcache}"
+TOOLCACHE_MOUNT="${COURSIA_RUNNER_TOOLCACHE_MOUNT:-/opt/hostedtoolcache}"
+
 mkdir -p "$STATE_DIR"
 
 die() { echo "ERREUR: $*" >&2; exit 1; }
@@ -70,6 +77,8 @@ slot_loop() {
       --name "$name" \
       --cpus="$CPUS" --memory="$MEMORY" --pids-limit="$PIDS" \
       --security-opt=no-new-privileges \
+      -v "$TOOLCACHE_VOLUME":"$TOOLCACHE_MOUNT" \
+      -e RUNNER_TOOL_CACHE="$TOOLCACHE_MOUNT" \
       -e ACTIONS_RUNNER_INPUT_TOKEN="$token" \
       -e ACTIONS_RUNNER_INPUT_URL="https://github.com/$REPO" \
       -e ACTIONS_RUNNER_INPUT_NAME="$name" \
@@ -91,8 +100,10 @@ cmd_start() {
   docker image inspect "$IMAGE" >/dev/null 2>&1 \
     || die "image $IMAGE absente -- construire d'abord :
     docker build -t $IMAGE scripts/ci/docker/linux-runner/"
+  docker volume create "$TOOLCACHE_VOLUME" >/dev/null \
+    || die "volume $TOOLCACHE_VOLUME impossible a creer -- docker volume create"
   rm -f "$STOP_FILE"
-  echo "demarrage de $n slot(s) ; caps par conteneur : cpus=$CPUS memory=$MEMORY pids=$PIDS"
+  echo "demarrage de $n slot(s) ; caps par conteneur : cpus=$CPUS memory=$MEMORY pids=$PIDS ; toolcache=$TOOLCACHE_VOLUME -> $TOOLCACHE_MOUNT"
   for i in $(seq 1 "$n"); do
     slot_loop "$i" &
     echo "$!" >> "$STATE_DIR/pids"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/qc #14095

## Summary

Grain image délégué par ai-01 (DM 2026-09-01T21:25Z), volet Linux conteneurisé #13378 :

- **Dockerfile** : `python-is-python3` ajouté — l'image portait déjà `python3`/`python3-pip`, mais pas l'alias nu `python` qu'appellent les workflows stdlib-only (mesuré : job 100021313259, `check-navlinks` exit 127 `python: not found`). Nouveau répertoire `/opt/hostedtoolcache` créé **et possédé** `runner:runner` : à la première création d'un volume nommé, Docker copie contenu et propriété du point de montage de l'image — sans ce chown, le volume serait `root:root` et les actions `setup-*` échoueraient en EACCES sous l'utilisateur non-root.
- **supervise.sh** : volume `coursia-runner-toolcache` monté sur `/opt/hostedtoolcache` + `RUNNER_TOOL_CACHE` exporté au conteneur — sans lui, chaque conteneur éphémère (un par job) re-télécharge interprètes et outils via les actions `setup-*`. `docker volume create` idempotent au `start` ; noms configurables (`COURSIA_RUNNER_TOOLCACHE_VOLUME`, `COURSIA_RUNNER_TOOLCACHE_MOUNT`).
- **docs/ci/self-hosted-runners.md** :
  - état **déployé** réel (2 slots online, preuve d'identité run 33554804211 `RUNNER_OS = Linux`, empreinte au repos ~40,5 MiB/4 GiB CPU~0 % **et sous charge** CPU 113 %/161 %, MEM 187/498 MiB, PIDS 52/50 — 2 jobs organiques concurrents) ;
  - la page disait « volet Linux non déployé » / label `coursia-linux` « inexistant » : corrigé vers **en ligne** ;
  - routage tranche 1 : **#14148 est PR ouverte** (pas « livrée ») — 11 workflows, règle allowlist du checker + garde universelle fork/payload + timeout + `permissions: read` ;
  - §Tranches suivantes : forme de la garde universelle explicitée ;
  - nouvelle sous-section **Persistance du superviseur** (systemd user + `loginctl enable-linger`, alternative `schtasks`) — **non installée**, geste explicite coord/user attendu, jamais silencieux ;
  - procédure de roulement après modification du Dockerfile (rebuild même tag → stop → kill idle vérifiés `busy=false` → start).

## Validation

- `bash -n supervise.sh` : OK (avant et après le fix MSYS).
- Image rebuildée même tag (2.336.0) ; `docker run --rm --entrypoint python coursia-linux-runner:2.336.0 --version` → `Python 3.12.3` (sous uid 1001 runner).
- `ls -ld /opt/hostedtoolcache` dans l'image → `drwxr-xr-x runner runner` ; après première création du volume, propriété mesurée `runner:runner` **dans le volume monté** (conteneur jetable).
- **Roulement live complet** : sentinel posé → 2 jobs organiques en vol laissés à leur terme (exit 0, boucles sorties propres) → `docker kill` des idle vérifiés `busy=false` → sentinel levé → `start 2`. État final mesuré : 2× `[online]` `busy=false`, `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` dans `Config.Env`, montage `coursia-runner-toolcache->/opt/hostedtoolcache` sur les deux conteneurs.
- **Bug attrapé au roulement (commit 2)** : Git Bash/MSYS réécrivait `-e RUNNER_TOOL_CACHE=/opt/hostedtoolcache` en `C:/Program Files/Git/opt/hostedtoolcache` (mesuré par `docker inspect Config.Env` au premier démarrage). Fix : `MSYS_NO_PATHCONV=1` + `MSYS2_ARG_CONV_EXCL='*'` exportés dans le script (inertes sous Linux). Les conteneurs à env corrompu ont été tués idle et remplacés.
- Checker : `grep -n coursia-linux scripts/ci/check_self_hosted_runner_policy.py` → admis (ligne 43).

## Notes

- Le tag image suit la version du runner (2.336.0), pas le contenu de l'image : le rebuild même tag + roulement des slots est la procédure documentée pour propager un changement de Dockerfile.
- Empreinte mesurée pendant le cycle : la jambe a tenu 2 jobs organiques concurrents sans approcher les caps (hôte GPU non sollicité).

See #13378
