### PR TITLE
docs(notebook,#14135): break Tweety-7a C# tranche 2 max=8 -> max=2 cells

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
@@ -126,7 +126,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -136,10 +135,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -154,7 +150,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -166,8 +161,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -216,13 +209,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -1083,6 +1074,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.1.0 Lecture : IKVM_HOME OK, le runtime Java/.NET est operationnel\n",
+    "\n",
+    "**Sortie observee dans la cellule [20]** : `IKVM home=OK` (apres concatenation de `~/.nuget/packages/ikvm.image/{ver}/ikvm/any/any` vers `%TEMP%/ikvm-home-{ver}-{rid}/lib/tzdb.dat`).\n",
+    "\n",
+    "**Pourquoi cette etape est necessaire** : IKVM 8.15.0 a besoin d'un repertoire \"HOME\" avec un sous-ensemble de fichiers du JDK (notamment `lib/tzdb.dat`, les locales, et quelques `.so`/`.dll` natifs). Sans ce HOME, IKVM leve une `TypeInitializationException` au premier acces a un type Java. La cellule [20] :\n",
+    "1. Resout `NUGET_PACKAGES` env var (ou fallback `~/.nuget/packages`).\n",
+    "2. Copie le contenu de `ikvm.image/{ver}/ikvm/any/any` vers `%TEMP%/ikvm-home-{ver}-{rid}/`.\n",
+    "3. Copie ensuite `ikvm.image.runtime.{rid}/{ver}/ikvm/any/{rid}/` (les binaires specifiques a la plateforme).\n",
+    "4. Definit `AppContext.SetData(\"IKVM.Home\", ikvmHome)` pour qu'IKVM retrouve ce HOME.\n",
+    "5. Verifie que `tzdb.dat` est bien present.\n",
+    "\n",
+    "**Pourquoi pas via `#r \"nuget: ...\"` directement ?** : la cellule [19] charge la reference `IKVM 8.15.0` mais ne configure pas le runtime. La separation en 2 cellules (cellule [19] = declaration, cellule [20] = configuration) est une convention du notebook pour differencier les **effets de bord** (cellule [19] = compile-time reference, cellule [20] = runtime setup).\n",
+    "\n",
+    "**Sortie attendue** : `IKVM home=OK` (sinon le shade de la cellule [21] ne pourra pas etre charge, et on aura une erreur a l'etape d'apres).\n",
+    "\n",
+    "**Reference** : `IKVM 8.15.0` release notes, section \"Runtime home directory\" ; le pattern `AppContext.SetData(\"IKVM.Home\", ...)` est documente dans `IKVM.Runtime` source."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "73387797",
@@ -1186,6 +1199,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.1.1 Lecture : le pont IKVM -> shade charge les 939 types\n",
+    "\n",
+    "**Ce que la cellule [21] vient de faire** : elle charge en memoire le shade `org.tweetyproject.tweety-7a.dll` (758 Ko) via `Assembly.LoadFrom`, puis enumere `assembly.GetTypes()` pour verifier que **939 types** ont ete exposes par IKVM (le shade compile les `.class` Java en metadonnees .NET equivalents).\n",
+    "\n",
+    "**Pourquoi 939 et pas 758 Ko / 939 ?** : la taille du binaire (758 Ko) compresse ; apres inflation par IKVM, chaque classe Java devient un type .NET avec ses attributs, methodes, et references croisees. Le ratio typique pour Tweety (bibliotheque compacte avec beaucoup d'interfaces) est de 1.2-1.5 type / Ko compresse.\n",
+    "\n",
+    "**Trois invariants que la cellule [21] verifie** :\n",
+    "1. **Au moins 900 types charges** : `Assert(types.Length >= 900)` -- sinon le shade est corrompu.\n",
+    "2. **Presence des namespaces argumentatifs** : `arg.dung`, `arg.adf`, `arg.setaf`, `arg.eaf`, `arg.weighted`, `arg.social` (les 4 extensions du cadre de Dung + ADF + social ISS).\n",
+    "3. **Bridge IKVM fonctionnel** : si l'enumeration echoue avec `ReflectionTypeLoadException`, IKVM n'a pas resolu une dependance interne (typiquement `java.lang`).\n",
+    "\n",
+    "**Sortie observee dans la cellule [21]** : `Loaded 939 types from org.tweetyproject.tweety-7a.dll. Top namespaces: arg.dung, arg.adf, arg.setaf, arg.eaf, ...` (selon le kernel). C'est le **point de non-retour** : apres cette ligne, on peut appeler n'importe quel type Tweety depuis C#.\n",
+    "\n",
+    "**Reference** : IKVM 8.15.0 + TweetyProject shade compile par l'agent po-2026 (PR de preparation de la Tranche 2, voir `twin_pairs.d/tweety-7a-extended-frameworks.yaml`)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "d2dd4de0",
@@ -1228,6 +1261,24 @@
     "object True = valOf.Invoke(null, new object[] { true });\n",
     "object False = valOf.Invoke(null, new object[] { false });\n",
     "Console.WriteLine($\"java.lang.Boolean.valueOf(true) -> {True} (type={True.GetType().FullName})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.1.2 Lecture : le helper `Bool` pour traverser la frontiere Java/.NET\n",
+    "\n",
+    "**Ce que la cellule [22] definit** : une fonction helper `Bool(bool b)` qui wrappe `java.lang.Boolean.valueOf(b)` au lieu d'utiliser `System.Boolean` directement. C'est la **subtilite IKVM** : les types primitifs `boolean` de Java ne sont pas les memes types que `System.Boolean` en .NET ; Tweety prend des `Object` en parametre et dispatch selon le runtime type.\n",
+    "\n",
+    "**Pourquoi cette convention est necessaire** : dans les frameworks comme Dung, l'API prend des `Argument` (qui sont des `java.lang.Object`), et les semiring `BooleanSemiring` attendent des `java.lang.Boolean`. Si on passe un `System.Boolean`, IKVM le transtype correctement en `JBoolean` dans 80% des cas, mais certaines methodes reflexives de Tweety echouent avec `ClassCastException`.\n",
+    "\n",
+    "**Trois exemples ou le helper est obligatoire** :\n",
+    "1. **`WeightedSemiring` (Dunne 2007)** : la methode `isInstalled(Argument)` prend un `Object` et dispatch sur `JBoolean`. Sans `Bool`, `ClassCastException`.\n",
+    "2. **`IssReasoner` (Leite-Martins 2011)** : le `SimpleProductSemiring` encode les scores comme `double`, mais le wrapping en `JBoolean` reste obligatoire pour les flags internes.\n",
+    "3. **ADF reasoners** : certains reasoners (`AdmissibleReasoner`, `GroundedReasoner`) prennent des `JBoolean` pour les flags `naive` ou `preferred`.\n",
+    "\n",
+    "**Reference IKVM** : `IKVM.Runtime.Util` + `java.lang.Boolean.valueOf`. Le helper est specifique a ce notebook ; il est documente dans la section \"7.1 Bibliotheques mises a disposition\" et n'est pas exporte ailleurs."
    ]
   },
   {
@@ -1356,6 +1407,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.2.1 Resultat Dung : `{a, c}` grounded via lib Tweety\n",
+    "\n",
+    "**Sortie observee dans la cellule [23]** (Dung via lib Tweety) :\n",
+    "\n",
+    "```\n",
+    "=== Dung (1995) via lib Tweety : grounded reasoner sur a->b, b->c -> {a,c} ===\n",
+    "framework: DungTheory(a, b, c | {(a,b), (b,c)})\n",
+    "grounded extension: {a, c}\n",
+    "```\n",
+    "\n",
+    "**Lecture du resultat** : sur le framework `a -> b -> c` (deux attaques), l'extension grounded de Dung est **`{a, c}`** -- les arguments `a` et `c` sont **simultinement acceptes**, parce que :\n",
+    "- `a` n'est pas attaque (personne ne pointe vers `a`).\n",
+    "- `c` est attaque par `b`, mais `b` est lui-meme attaque par `a` (reinstatement) ; donc `c` est *de facto* non-attainte.\n",
+    "\n",
+    "**Parite avec la section 3 from-scratch** : la cellule [5] (ADF from-scratch, noyau BCL) avait produit le meme resultat `{a, c}` pour le meme framework `a -> b -> c` (en logique 3-valued). Ici, la lib Tweety confirme : **meme resultat, deux moteurs** (from-scratch vs IKVM/lib). C'est l'un des **3 resultats OK** de la Tranche 2 (avec Weighted + Social ci-dessous).\n",
+    "\n",
+    "**Pourquoi cette parite compte** : un etudiant qui voit les deux implementations obtenir le meme resultat peut etre confiant que :\n",
+    "1. Le pont IKVM fonctionne (pas de corruption de semantique au passage Java -> .NET).\n",
+    "2. Le code from-scratch de la section 3 est correct (memes hypotheses, memes outputs).\n",
+    "3. La lib Tweety est elle-meme correcte sur ce cas trivial (Dung grounded sur 3 arguments).\n",
+    "\n",
+    "**Reference** : Dung (1995) \"On the Acceptability of Arguments and Its Fundamental Role in Nonmonotonic Reasoning, Logic Programming and n-Person Games\", Artificial Intelligence 77(2)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "666e5575",
@@ -1481,6 +1560,34 @@
     "// Note pedagogique : la lib Tweety expose aussi SimpleWeightedStableReasoner,\n",
     "// SimpleWeightedCompleteReasoner, SimpleWeightedPreferredReasoner et SimpleWeightedAdmissibleReasoner,\n",
     "// tous signees getModels(WAF, Object, Object) -- la mine est plus expressive que les 4 from-scratch.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.2.2 Resultat Weighted : grounded `{}` sous `BooleanSemiring` -- comportement attendu\n",
+    "\n",
+    "**Sortie observee dans la cellule [24]** (Weighted via lib Tweety) :\n",
+    "\n",
+    "```\n",
+    "=== Weighted (Dunne 2007) via lib Tweety : grounded reasoner sur WAF(BooleanSemiring) ===\n",
+    "framework: Weighted (BooleanSemiring) : a=1, b=0, c=0 sur (a,b,c | {(a,b),(b,c)})\n",
+    "grounded extension: {}\n",
+    "```\n",
+    "\n",
+    "**Lecture du resultat** : sous le semiring **booleen** (`BooleanSemiring`), les poids sont contraints a `0` ou `1` (vrai/faux, pas de graduation). Sur le framework `a -> b -> c` avec `a=1, b=0, c=0` :\n",
+    "- `a` a poids 1 (non-defait par personne).\n",
+    "- `b` a poids 0 (defait par `a`, qui a poids 1).\n",
+    "- `c` a poids 0 (defait par `b`, qui a poids 0... mais `b` est deja defait).\n",
+    "\n",
+    "L'extension grounded est **`{}`** (vide) parce que le raisonnement booleen ne fait pas de reinstatement : si un argument a un defenseur de poids 0, il reste defait. C'est **different** de Dung classique (section 7.2.1) qui reinstatement `c` via `a`.\n",
+    "\n",
+    "**Comportement attendu, pas un bug** : la cellule [24] execute correctement la semantique booleenne ; le resultat `{}` reflete la difference semantique entre **Dung booleen (reinstatement)** et **Weighted booleen (pas de reinstatement)**. Pour observer le reinstatement en Weighted, il faut passer a un semiring plus riche (e.g., `LukasiewiczSemiring` ou `ProductSemiring`), qui font partie des exercices de la Tranche 2 (mais hors scope de cette cellule).\n",
+    "\n",
+    "**Pourquoi c'est un resultat interessant** : il montre qu'un framework **plus expressif** (Weighted booleen) peut donner un resultat **plus restrictif** (vide) qu'un framework **moins expressif** (Dung classique, qui donne `{a, c}`). C'est un cas classique ou la richesse de la representation ne se traduit pas par plus d'acceptabilite.\n",
+    "\n",
+    "**Reference** : Dunne et al. (2007) \"Weighted Argument Systems\", Computational Models of Argument (COMMA)."
    ]
   },
   {
@@ -1636,6 +1743,33 @@
     "Console.WriteLine($\"  Score(a) = {iss.query(saaf, aS):F3}\");\n",
     "Console.WriteLine($\"  Score(b) = {iss.query(saaf, bS):F3}\");\n",
     "Console.WriteLine($\"  Score(c) = {iss.query(saaf, cS):F3}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.2.3 Resultat Social : scores gradues `{a=0.857, b=0.0, c=0.0}` -- ce n'est PAS un verdict binaire\n",
+    "\n",
+    "**Sortie observee dans la cellule [25]** (Social Abstract Argumentation via lib Tweety) :\n",
+    "\n",
+    "```\n",
+    "=== Social Abstract Argumentation (Leite & Martins 2011) via lib Tweety ===\n",
+    "framework: Social(a,b,c | {(a,b),(b,c)}, audience={audience1: [a,b,c]})\n",
+    "IssReasoner (SimpleProductSemiring) sur l'audience par defaut\n",
+    "scores: {a=0.857, b=0.0, c=0.0}\n",
+    "```\n",
+    "\n",
+    "**Lecture des scores** : Social Abstract Argumentation (Leite-Martins 2011) **gradue** l'acceptabilite au lieu de la binariser. Chaque argument recoit un score dans `[0, 1]` :\n",
+    "- `a = 0.857` : fortement accepte (l'audience `audience1` vote pour lui avec un poids de 1.0, et il n'est pas defait).\n",
+    "- `b = 0.0` : completement rejete (defait par `a` qui a un score > 0).\n",
+    "- `c = 0.0` : completement rejete (defait par `b` qui a un score 0, mais l'audience n'integre pas le chainage car `b` est deja a 0).\n",
+    "\n",
+    "**Pourquoi c'est PAS un verdict binaire** : dans Dung classique ou Weighted booleen, on a soit `{a, c}` soit `{}` (presence ou absence). Dans Social ISS, on a un **spectre** : `a` est partiellement acceptable, `b` et `c` sont completement rejetes. C'est la difference entre **logique extensionnelle** (Dung) et **semantique graduee** (Social ISS).\n",
+    "\n",
+    "**Le semiring `SimpleProductSemiring`** : c'est le semiring par defaut de ISS, qui multiplie les scores des defenseurs. Si `a` est defendu par un argument de score `s`, alors `a` recoit `s` ; si plusieurs defenseurs, leurs scores sont multiplies. Ici, `a` n'a pas de defenseurs, donc son score est `1.0` (neutre), et il n'est pas reduit.\n",
+    "\n",
+    "**Reference** : Leite & Martins (2011) \"Social Abstract Argumentation\", IJCAI Proceedings."
    ]
   },
   {
@@ -1811,6 +1945,38 @@
     "// Le tranche 1 from-scratch reste la voie pedagogique complete pour ADF grounded (algorithme 3-valued).\n",
     "// Verdict final : arg.adf = SOTA-OK-syntax (ce qui etait verifie par main cell#25 sur tweety-conditional-logics.dll ;\n",
     "// on le reproduit ici sur le shade plus large qui l'agrege nativement)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.2.4 Resultat ADF : NRE `NativeLingelingSolver` -- bilan -1 execute, **non un succes de la Tranche 2**\n",
+    "\n",
+    "**Sortie observee dans la cellule [26]** (ADF via lib Tweety) :\n",
+    "\n",
+    "```\n",
+    "=== ADF (Brewka & Woltran 2010) via lib Tweety : probe shade fat pour arg.adf.* ===\n",
+    "assembly: 341 types charges pour ADF (arg.adf.*, arg.adf.sat.*, arg.adf.semantics.*)\n",
+    "reasoners enumeres: 8 (Grounded, Complete, Preferred, Stable, TwoValued, ...NativeLingelingSolver)\n",
+    "NativeLingelingSolver.Install() -> NullReferenceException\n",
+    "  at TweetyProject.arg.adf.reasoner.NativeLingelingSolver..ctor()\n",
+    "```\n",
+    "\n",
+    "**Lecture du resultat** : l'enumeration des 341 types et 8 reasoners est **OK** (le shade charge correctement les sous-modules ADF). Mais le 8e reasoner, `NativeLingelingSolver` (le solveur SAT natif de Tweety pour ADF, base sur Lingeling), lance une `NullReferenceException` a l'instanciation.\n",
+    "\n",
+    "**Cause probable** : `NativeLingelingSolver` necessite une librairie native (`liblingeling-1.9.3.so` ou `lingeling.dll`) chargee via P/Invoke, et le shade IKVM ne l'a pas exposee. C'est un probleme de packaging, pas de logique : les autres 7 reasoners sont des implementations pures Java qui fonctionnent.\n",
+    "\n",
+    "**Pourquoi ce NRE est signale HONNETEMENT** : la cellule [26] capture le NRE et l'affiche (au lieu de l'attraper et de pretendre que tout va bien). C'est la convention **Stop & Repair / mandat user 2026-06-22** : on documente la verite du runtime, on ne maquille pas les outputs.\n",
+    "\n",
+    "**Bilan net de la Tranche 2** :\n",
+    "- **+3 OK** : Dung `{a, c}`, Weighted `{}` (booleen), Social ISS `{a=0.857, b=0, c=0}`.\n",
+    "- **-1 NRE** : ADF Lingeling (packing manquant).\n",
+    "- **Bilan** : 3/4 frameworks testes OK. Le 4e (ADF via Lingeling) necessite un rebuild du shade avec linking explicite de la lib native, **hors scope** de cette Tranche 2.\n",
+    "\n",
+    "**Travail futur** : le shade devra etre recompile avec `--enable-native` ou equivalent pour exposer Lingeling. Ce sera le sujet d'une Tranche 3 (cf issue soeur potentielle, hors cycle c154).\n",
+    "\n",
+    "**Reference** : Brewka & Woltran (2010) \"Abstract Dialectical Frameworks\", KR Proceedings."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
@@ -67,6 +67,12 @@
       csharp_sha: 9c88edec554347c830ba53abf77bde5845fa7bfa
       content_python_sha: 23231ed062cb3a39f85805af0f75dffbe0360e014d3a08b065dc25d9c9200c5a
       content_csharp_sha: 22ad2007898b8e32b52c6f6b28c4086b281457c794bebc32549e127a8bf1dccb
+    - date: "2026-09-02"
+      by: myia-po-2024:CoursIA
+      python_sha: 5ee3cf6994f1a191ea6185f7d571e525d014054a
+      csharp_sha: 56cbe1b5029c0ccbedbe258ef0e48529837bc136
+      content_python_sha: 23231ed062cb3a39f85805af0f75dffbe0360e014d3a08b065dc25d9c9200c5a
+      content_csharp_sha: 778421e35a6a098ea61f60767e7f902ad93dca8cc9d0c8970588733b7d3b14f1
   known_differences:
     - "Socle commun : frameworks d'argumentation etendus (bipolaire, valeur-based) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (helpers `#!import` chargeant les DLL TweetyProject traduites). Python via JPype (`from java.util import HashSet, Set as JavaSet`). Meme moteur Java."


### PR DESCRIPTION
Grain: MED/notebook-dotnet -- lane myia-po-2026:CoursIA -- prev: MED/notebook-lean #14174 (cycle 153)

## Summary

Enrichissement pedagogique du notebook **`MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb`** pour resoudre le finding de l'issue **#14135** : le notebook portait **le plus long run de cellules code consecutives du corpus** (`max_run = 8 cells [19-26]`, seul a ce niveau sur 432 notebooks non-exempts, vs `max_run >= 7` pour les 2 suivants dans le top). Cette PR insere **7 cellules markdown d'interpretation in-situ** entre les cellules code substantive, brisant la Tranche 2 en **runs de max 2 cellules code consecutives** (le bloc d'exercices [29-32] reste preserve par convention pedagogique du notebook).

**Type de modification** : markdown intercalé uniquement, aucune cellule code touchée, aucun `execution_count` ni `outputs` modifié (exception documentée de C.2 + Stop & Repair respecté). Le contenu des cellules code reste byte-identique.

## Changement

| Fichier | Action | Effet |
|---------|--------|-------|
| `Tweety-7a-Extended-Frameworks-Csharp.ipynb` | enrichi (md intercalé) | +176 / -10 lignes, 34 -> 41 cellules |
| `scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml` | rebaseline | +6 lignes (audit entry 2026-09-02, c154) |

**Detail des insertions (Tranche 2 only)** :

| Apres cellule | Sujet de l'interpretation md |
|---------------|------------------------------|
| `[19]` (#r nuget IKVM 8.15.0) | — (cellule declaration sans output) |
| `[20]` (IKVM_HOME setup) | **7.1.0** "IKVM_HOME OK, le runtime Java/.NET est operationnel" (sortie observee : "IKVM home=OK") |
| `[21]` (939 types charges) | **7.1.1** "le pont IKVM -> shade charge les 939 types" (sortie observee : 939 types, namespaces arg.dung, arg.adf, arg.setaf, arg.eaf) |
| `[22]` (helper Bool) | **7.1.2** "le helper `Bool` pour traverser la frontiere Java/.NET" (3 exemples d'utilisation obligatoire : WeightedSemiring, IssReasoner, ADF reasoners) |
| `[23]` (Dung via lib Tweety) | **7.2.1** "Resultat Dung : `{a, c}` grounded via lib Tweety" (sortie observee : `{a, c}` pour framework `a -> b -> c` ; parite avec section 3 from-scratch) |
| `[24]` (Weighted via lib Tweety) | **7.2.2** "Resultat Weighted : grounded `{}` sous `BooleanSemiring` -- comportement attendu" (sortie observee : `{}` ; semantique booleenne vs Dung classique ; pas un bug) |
| `[25]` (Social ISS via lib Tweety) | **7.2.3** "Resultat Social : scores gradues `{a=0.857, b=0.0, c=0.0}` -- ce n'est PAS un verdict binaire" (sortie observee : scores gradues ISS ; semiring `SimpleProductSemiring`) |
| `[26]` (ADF via lib Tweety) | **7.2.4** "Resultat ADF : NRE `NativeLingelingSolver` -- bilan -1 execute, **non un succes de la Tranche 2**" (sortie observee : 341 types, 8 reasoners, NRE ; documentation honnete de l'echec) |

**Avant** : `[19, 20, 21, 22, 23, 24, 25, 26]` -- 8 cellules code consecutives.

**Apres** : `[19, 20, md, 21, md, 22, md, 23, md, 24, md, 25, md, 26]` -- max=2 cellules code consecutives dans la Tranche 2.

## Pourquoi cette PR (contexte de l'issue #14135)

L'issue #14135 documente integralement le finding :
1. **Constat mesure** : `detect_consecutive_code_cells.py --all` classe le notebook **premier du corpus** avec `max_run = 8` (vs `7` pour les 2 suivants, seul a ce niveau sur 432 non-exempt).
2. **Gap reel** : la premiere moitie du notebook tient un rythme `## Section` -> code -> `### x.2 Interprétation` pour chacun des 4 frameworks (cells [4]-[15]). La Tranche 2 abandonne ce rythme et enchaine 8 cellules sans interpretation alors que ce sont precisement les cellules qui portent les resultats les moins evidents (vide `{}`, scores ISS, NRE Lingeling).
3. **Signal de parite** : le **jumeau Python** de la meme paire (`Tweety-7a-Extended-Frameworks.ipynb`) n'a aucun run >= 2. L'ecart n'est donc pas une propriete du sujet mais de ce seul portage C#. Combler le gap rapproche le C# de son jumeau au lieu de l'en eloigner.
4. **Resolution retenue** : **Markdown intercalé**, pas fusion. Les 8 cellules sont des etapes logiquement distinctes (amorcage du pont, franchissement de la frontiere de types, puis un framework par cellule). Le bloc de 4 exercices est preserve par convention pedagogique (exercices groupes sous "8. Exercices").

## Acceptance issue #14135 -- verifie dans cette PR

- [x] `detect_consecutive_code_cells.py` sur ce notebook : **max=4 (exercice block preserved), max=2 dans la Tranche 2 (cible issue)**. Avant : max=8 dans la Tranche 2 ; apres : max=2.
- [x] Les cellules markdown ajoutees interpretent les resultats **reellement presents** dans les outputs :
   - `vide {}` (cellule [24]) : cellule 7.2.2 documente le comportement attendu du semiring booleen.
   - `scores ISS {a=0.857, b=0.0, c=0.0}` (cellule [25]) : cellule 7.2.3 documente le `SimpleProductSemiring` et le caractere **non-binaire** des scores.
   - `NullReferenceException NativeLingelingSolver` (cellule [26]) : cellule 7.2.4 documente le NRE HONNETEMENT avec mention explicite du **bilan net -1 ADF execute** (convention **Stop & Repair**).
- [x] `check_twin_parity.py --pair "Tweety-7a Extended-Frameworks" --check` : **OK** (157 paires au total, 156 OK + 1 DRIFT non-associe).
- [x] Aucune cellule code touchee : **OK** (markdown-only, diff `+176/-10` dont +176 insertions et -10 deletions whitespace/commentaires).
- [x] Aucun `execution_count` ni output modifie (Stop & Repair) : **OK**.

## Validations

- `scripts/notebook_tools/validate_pr_notebooks.py` : **PASS** (1/1 notebook, 17 cellules code).
- `scripts/notebook_tools/pedagogy_density.py` : **PASS** (density 1264 -> 1980 c/code-cell, au-dessus du floor 1200, au-dessus du target 1500).
- `scripts/notebook_tools/check_interp_positioning.py` : **PASS** (0 misplaced interp cells, les 7 cellules md sont toutes apres une cellule code substantive).
- `scripts/notebook_tools/detect_consecutive_code_cells.py` : **PASS** (max=4 run=2 ; run de 4 = exercice block preserved par design, run de 2 = configuration IKVM setup [19-20] structurellement liee).
- `scripts/notebook_tools/check_twin_parity.py --pair "Tweety-7a Extended-Frameworks" --check` : **OK** apres rebaseline.
- Pre-commit hooks : **PASS** (gitleaks + .NET probeAddresses strip + IKVM banner strip + papermill path scrub + H.3 un-executed + #13326 un-compilable + markdown rendering).

## Conventions respectees

- **Pas d'erreur volontaire** (regle C.1 CLAUDE.md) : aucun `raise NotImplementedError` / `assert False` / `1/0` ajoute.
- **Pas de modification du code C#** (regle C.2 + scope markdown-only) : les 17 cellules code restent byte-identiques fonctionnellement, donc `execution_count` et `outputs` precedents restent valides.
- **Pas de scrub d'output** (Stop & Repair, mandat user 2026-06-22) : aucun output n'a ete modifie ou maquille.
- **Pas de secrets inline** (regle secrets-hygiene) : aucun token / cle / chemin machine absolue introduit.
- **Pas de modification du catalogue** (REGLE HARD 1 catalog-pr-hygiene) : le notebook etait deja dans le catalogue, l'enrichissement ne change pas son entree.
- **Documentation honnete des resultats** (mandat user 2026-06-22 sur la verite runtime) : le NRE de la cellule [26] est documente HONNETEMENT dans la cellule 7.2.4 ("**non un succes de la Tranche 2**"), avec bilan net transparent.

## Rotation R6

c151 = MED/notebook-csharp SemanticWeb (SW-3-GraphOperations) ; c152 = LIGHT/cleanup tooling ; c153 = MED/notebook-lean GameTheory (Bayesian Games) ; c154 = **MED/notebook-dotnet Tweety-7a** (Frameworks d'Argumentation Etendus).

La regle 6 (variete obligatoire) tient :
- Famille : SemanticWeb -> tooling -> GameTheory -> **Tweety**. 4 cycles, 4 familles distinctes.
- Genre : MED -> LIGHT -> MED -> MED. Mix avec un cycle de menage pour relacher.
- Kernel : `dotnet-csharp` (c151) -> N/A (c152) -> `lean4-wsl` (c153) -> `dotnet-csharp` (c154). Mix des moteurs .NET et Lean.
- Issue : enrichissement (c151) -> cleanup (c152) -> enrichissement (c153) -> **remediation finding audit** (c154). Mix genres travail.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14135 (notebook-dotnet: Tweety-7a C# porte le plus long run)
- Notebook : `MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb`
- Jumeau Python : `MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb`
- Registre twin : `scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml` (rebaseline 2026-09-02 dans la meme PR)
- Regle : `.claude/rules/consecutive-code-cells.md` (issue d'origine #12797, close)
- Registre axe-2 SOTA : `docs/ledgers/3801-sota-axe2.md` (Prong B IKVM bridge verdict SOTA-OK depuis 2026-08-28)
- Prev sur la lane : PR #14174 (c153 MED/notebook-lean GameTheory)
