### PR TITLE
fix(search,#14061): corrige 2 references Search-15/16 residu rename #13797

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb
@@ -132,10 +132,10 @@
      "shell.execute_reply": "2026-09-01T13:32:55.025888Z"
     },
     "papermill": {
-     "duration": 3.340183,
-     "end_time": "2026-09-01T13:32:55.045262+00:00",
+     "duration": 1.631957,
+     "end_time": "2026-09-01T22:40:15.713132",
      "exception": false,
-     "start_time": "2026-09-01T13:32:51.705079+00:00",
+     "start_time": "2026-09-01T22:40:14.081175",
      "status": "completed"
     },
     "tags": []
@@ -150,6 +150,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -159,7 +160,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -174,6 +178,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -185,11 +190,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '23244.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '23748.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -233,11 +240,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -286,10 +295,10 @@
      "shell.execute_reply": "2026-09-01T13:32:55.155635Z"
     },
     "papermill": {
-     "duration": 0.106748,
-     "end_time": "2026-09-01T13:32:55.156018+00:00",
+     "duration": 0.049102,
+     "end_time": "2026-09-01T22:40:15.765234",
      "exception": false,
-     "start_time": "2026-09-01T13:32:55.049270+00:00",
+     "start_time": "2026-09-01T22:40:15.716132",
      "status": "completed"
     },
     "tags": []
@@ -418,10 +427,10 @@
      "shell.execute_reply": "2026-09-01T13:32:56.388404Z"
     },
     "papermill": {
-     "duration": 1.211053,
-     "end_time": "2026-09-01T13:32:56.388763+00:00",
+     "duration": 0.371381,
+     "end_time": "2026-09-01T22:40:16.154469",
      "exception": false,
-     "start_time": "2026-09-01T13:32:55.177710+00:00",
+     "start_time": "2026-09-01T22:40:15.783088",
      "status": "completed"
     },
     "tags": []
@@ -523,10 +532,10 @@
      "shell.execute_reply": "2026-09-01T13:32:57.029687Z"
     },
     "papermill": {
-     "duration": 0.635917,
-     "end_time": "2026-09-01T13:32:57.029993+00:00",
+     "duration": 0.20453,
+     "end_time": "2026-09-01T22:40:16.362998",
      "exception": false,
-     "start_time": "2026-09-01T13:32:56.394076+00:00",
+     "start_time": "2026-09-01T22:40:16.158468",
      "status": "completed"
     },
     "tags": []
@@ -648,10 +657,10 @@
      "shell.execute_reply": "2026-09-01T13:32:57.363419Z"
     },
     "papermill": {
-     "duration": 0.318586,
-     "end_time": "2026-09-01T13:32:57.364064+00:00",
+     "duration": 0.079237,
+     "end_time": "2026-09-01T22:40:16.460698",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.045478+00:00",
+     "start_time": "2026-09-01T22:40:16.381461",
      "status": "completed"
     },
     "tags": []
@@ -715,10 +724,10 @@
      "shell.execute_reply": "2026-09-01T13:32:57.612585Z"
     },
     "papermill": {
-     "duration": 0.240172,
-     "end_time": "2026-09-01T13:32:57.612884+00:00",
+     "duration": 0.067557,
+     "end_time": "2026-09-01T22:40:16.531755",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.372712+00:00",
+     "start_time": "2026-09-01T22:40:16.464198",
      "status": "completed"
     },
     "tags": []
@@ -820,10 +829,10 @@
      "shell.execute_reply": "2026-09-01T13:32:57.928334Z"
     },
     "papermill": {
-     "duration": 0.296306,
-     "end_time": "2026-09-01T13:32:57.928753+00:00",
+     "duration": 0.143777,
+     "end_time": "2026-09-01T22:40:16.686043",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.632447+00:00",
+     "start_time": "2026-09-01T22:40:16.542266",
      "status": "completed"
     },
     "tags": []
@@ -885,7 +894,7 @@
     "// illustrer la CONDITION D'OPTIMALITE de Dijkstra — pour chaque sommet v, son predecesseur\n",
     "// est l'unique voisin u tel que GetDistance(u) + poids(u, v) = GetDistance(v). C'est le seul\n",
     "// site de la serie a rester manuel ; les autres utilisent l'observateur canonique\n",
-    "// VertexPredecessorRecorderObserver (cell 17 de ce notebook, Search-15 cell 14, Search-3\n",
+    "// VertexPredecessorRecorderObserver (cell 17 de ce notebook, Search-02b-NetworkX-Csharp cell 14, Search-3\n",
     "// cell 16, Search-2 cell 38), qui encapsule exactement cette condition.\n",
     "\n",
     "var dijkstra = new DijkstraShortestPathAlgorithm<string, STaggedEdge<string, double>>(\n",
@@ -917,7 +926,7 @@
     "        courant = suivant;\n",
     "    }\n",
     "    Console.WriteLine($\"  {v} : {dist:F2} km  ({chemin})\");\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -953,10 +962,10 @@
      "shell.execute_reply": "2026-09-01T13:32:58.510605Z"
     },
     "papermill": {
-     "duration": 0.557912,
-     "end_time": "2026-09-01T13:32:58.511118+00:00",
+     "duration": 0.143774,
+     "end_time": "2026-09-01T22:40:16.845671",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.953206+00:00",
+     "start_time": "2026-09-01T22:40:16.701897",
      "status": "completed"
     },
     "tags": []
@@ -1127,10 +1136,10 @@
      "shell.execute_reply": "2026-09-01T13:32:59.007302Z"
     },
     "papermill": {
-     "duration": 0.448339,
-     "end_time": "2026-09-01T13:32:59.008334+00:00",
+     "duration": 0.10034,
+     "end_time": "2026-09-01T22:40:16.966054",
      "exception": false,
-     "start_time": "2026-09-01T13:32:58.559995+00:00",
+     "start_time": "2026-09-01T22:40:16.865714",
      "status": "completed"
     },
     "tags": []
@@ -1348,10 +1357,10 @@
      "shell.execute_reply": "2026-09-01T13:32:59.340245Z"
     },
     "papermill": {
-     "duration": 0.301549,
-     "end_time": "2026-09-01T13:32:59.340624+00:00",
+     "duration": 0.095546,
+     "end_time": "2026-09-01T22:40:17.073046",
      "exception": false,
-     "start_time": "2026-09-01T13:32:59.039075+00:00",
+     "start_time": "2026-09-01T22:40:16.977500",
      "status": "completed"
     },
     "tags": []
@@ -1508,10 +1517,10 @@
      "shell.execute_reply": "2026-09-01T13:33:00.041010Z"
     },
     "papermill": {
-     "duration": 0.679913,
-     "end_time": "2026-09-01T13:33:00.041337+00:00",
+     "duration": 0.150608,
+     "end_time": "2026-09-01T22:40:17.238660",
      "exception": false,
-     "start_time": "2026-09-01T13:32:59.361424+00:00",
+     "start_time": "2026-09-01T22:40:17.088052",
      "status": "completed"
     },
     "tags": []
@@ -1747,10 +1756,10 @@
      "shell.execute_reply": "2026-09-01T13:33:00.265426Z"
     },
     "papermill": {
-     "duration": 0.199787,
-     "end_time": "2026-09-01T13:33:00.265718+00:00",
+     "duration": 0.036303,
+     "end_time": "2026-09-01T22:40:17.297003",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.065931+00:00",
+     "start_time": "2026-09-01T22:40:17.260700",
      "status": "completed"
     },
     "tags": []
@@ -1817,10 +1826,10 @@
      "shell.execute_reply": "2026-09-01T13:33:00.341512Z"
     },
     "papermill": {
-     "duration": 0.059949,
-     "end_time": "2026-09-01T13:33:00.341873+00:00",
+     "duration": 0.02621,
+     "end_time": "2026-09-01T22:40:17.337794",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.281924+00:00",
+     "start_time": "2026-09-01T22:40:17.311584",
      "status": "completed"
     },
     "tags": []
@@ -1887,10 +1896,10 @@
      "shell.execute_reply": "2026-09-01T13:33:00.469509Z"
     },
     "papermill": {
-     "duration": 0.105263,
-     "end_time": "2026-09-01T13:33:00.469982+00:00",
+     "duration": 0.027985,
+     "end_time": "2026-09-01T22:40:17.378598",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.364719+00:00",
+     "start_time": "2026-09-01T22:40:17.350613",
      "status": "completed"
     },
     "tags": []

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
@@ -91,20 +91,137 @@
      "iopub.status.busy": "2026-07-10T06:51:04.514504Z",
      "iopub.status.idle": "2026-07-10T06:51:11.575338Z",
      "shell.execute_reply": "2026-07-10T06:51:11.553896Z"
+    },
+    "papermill": {
+     "duration": 1.513229,
+     "end_time": "2026-09-01T22:43:24.123171",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:22.609942",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": ""
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '7500.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Framework de recherche informee pret (Node, Problem, GraphProblem, SearchResult).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Framework de recherche informee pret (Node, Problem, GraphProblem, SearchResult).\r\n"
+     ]
     }
    ],
    "source": [
@@ -241,58 +358,85 @@
      "iopub.status.busy": "2026-07-10T06:51:11.581850Z",
      "iopub.status.idle": "2026-07-10T06:51:12.362916Z",
      "shell.execute_reply": "2026-07-10T06:51:12.361497Z"
+    },
+    "papermill": {
+     "duration": 0.203151,
+     "end_time": "2026-09-01T22:43:24.339149",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.135998",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Carte chargee : 13 villes\r\n"
+     "output_type": "stream",
+     "text": [
+      "Carte chargee : 13 villes\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Probleme de reference : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Probleme de reference : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Heuristique h(n) = Haversine vers Toulouse (vol d'oiseau, admissible) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Heuristique h(n) = Haversine vers Toulouse (vol d'oiseau, admissible) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Lille        h =    791 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Lille        h =    791 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Paris        h =    589 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Paris        h =    589 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Rennes       h =    557 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Rennes       h =    557 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Nantes       h =    465 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Nantes       h =    465 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Bordeaux     h =    211 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Bordeaux     h =    211 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Toulouse     h =      0 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Toulouse     h =      0 km\r\n"
+     ]
     }
    ],
    "source": [
@@ -400,13 +544,22 @@
      "iopub.status.busy": "2026-07-10T06:51:12.366653Z",
      "iopub.status.idle": "2026-07-10T06:51:12.635125Z",
      "shell.execute_reply": "2026-07-10T06:51:12.634065Z"
+    },
+    "papermill": {
+     "duration": 0.06032,
+     "end_time": "2026-09-01T22:43:24.410816",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.350496",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme Greedy Best-First implemente.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme Greedy Best-First implemente.\r\n"
+     ]
     }
    ],
    "source": [
@@ -469,78 +622,113 @@
      "iopub.status.busy": "2026-07-10T06:51:12.637802Z",
      "iopub.status.idle": "2026-07-10T06:51:12.934289Z",
      "shell.execute_reply": "2026-07-10T06:51:12.933671Z"
+    },
+    "papermill": {
+     "duration": 0.047227,
+     "end_time": "2026-09-01T22:43:24.463458",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.416231",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy Best-First : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy Best-First : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lille        g=     0 h=   791\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lille        g=     0 h=   791\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Rennes       g=   510 h=   557\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Rennes       g=   510 h=   557\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Nantes       g=   620 h=   465\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Nantes       g=   620 h=   465\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- Greedy ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- Greedy ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Lille -> Rennes -> Nantes -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Lille -> Rennes -> Nantes -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 1210\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 1210\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 9\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 9\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 4\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 4\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 5,43 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 4,05 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -613,13 +801,22 @@
      "iopub.status.busy": "2026-07-10T06:51:12.938530Z",
      "iopub.status.idle": "2026-07-10T06:51:13.116468Z",
      "shell.execute_reply": "2026-07-10T06:51:13.115008Z"
+    },
+    "papermill": {
+     "duration": 0.040334,
+     "end_time": "2026-09-01T22:43:24.525906",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.485572",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme A* implemente.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme A* implemente.\r\n"
+     ]
     }
    ],
    "source": [
@@ -679,83 +876,120 @@
      "iopub.status.busy": "2026-07-10T06:51:13.119939Z",
      "iopub.status.idle": "2026-07-10T06:51:13.256539Z",
      "shell.execute_reply": "2026-07-10T06:51:13.250070Z"
+    },
+    "papermill": {
+     "duration": 0.029816,
+     "end_time": "2026-09-01T22:43:24.559366",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.529550",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A* : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "A* : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lille        g=     0 h=   791 f=    791\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lille        g=     0 h=   791 f=    791\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Paris        g=   225 h=   589 f=    814\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Paris        g=   225 h=   589 f=    814\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Bordeaux     g=   810 h=   211 f=   1021\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Bordeaux     g=   810 h=   211 f=   1021\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lyon         g=   690 h=   360 f=   1050\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lyon         g=   690 h=   360 f=   1050\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- A* ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- A* ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 1055\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 1055\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 4\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 4\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 15\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 15\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 6\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 6\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 0,54 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,22 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -796,53 +1030,78 @@
      "iopub.status.busy": "2026-07-10T06:51:13.260490Z",
      "iopub.status.idle": "2026-07-10T06:51:13.480360Z",
      "shell.execute_reply": "2026-07-10T06:51:13.479481Z"
+    },
+    "papermill": {
+     "duration": 0.047158,
+     "end_time": "2026-09-01T22:43:24.620932",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.573774",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison : Greedy vs A* sur Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Comparaison : Greedy vs A* sur Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "======================================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "----------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy     Lille -> Rennes -> Nantes -> Toulouse          1210      3        3\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy     Lille -> Rennes -> Nantes -> Toulouse          1210      3        3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A*         Lille -> Paris -> Bordeaux -> Toulouse         1055      3        4\r\n"
+     "output_type": "stream",
+     "text": [
+      "A*         Lille -> Paris -> Bordeaux -> Toulouse         1055      3        4\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy a trouve un chemin 155 km plus long (14,7% de surcout).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy a trouve un chemin 155 km plus long (14,7% de surcout).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-> Greedy est SOUS-OPTIMAL : il a sacrifie l'optimalite pour explorer moins de noeuds.\r\n"
+     "output_type": "stream",
+     "text": [
+      "-> Greedy est SOUS-OPTIMAL : il a sacrifie l'optimalite pour explorer moins de noeuds.\r\n"
+     ]
     }
    ],
    "source": [
@@ -908,23 +1167,35 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.248256,
+     "end_time": "2026-09-01T22:43:24.883792",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.635536",
+     "status": "completed"
+    }
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>QuikGraph</span></li></ul></div><div></div></div>"
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>QuikGraph, 2.5.0</span></li></ul></div></div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "QuikGraph charge : AStarShortestPathAlgorithm<string, STaggedEdge<string, double>> dispo.\r\n"
+     "output_type": "stream",
+     "text": [
+      "QuikGraph charge : AStarShortestPathAlgorithm<string, STaggedEdge<string, double>> dispo.\r\n"
+     ]
     }
    ],
    "source": [
-    "// Installation QuikGraph 2.5.0 (fork KeRNeLith de QuickGraph, voir Search-16 cell 2 pour reference).\n",
+    "// Installation QuikGraph 2.5.0 (fork KeRNeLith de QuickGraph, voir Search-02c-QuikGraph cell 2 pour reference).\n",
     "// Charge la DLL + importe les namespaces necessaires : graphe bidirectionnel + AStar.\n",
     "#r \"nuget: QuikGraph, 2.5.0\"\n",
     "\n",
@@ -937,27 +1208,43 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.1178,
+     "end_time": "2026-09-01T22:43:25.006928",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:24.889128",
+     "status": "completed"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Reseau routier : 13 villes, 40 segments (aller-retour).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Reseau routier : 13 villes, 40 segments (aller-retour).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "AStar QuikGraph Lille -> Toulouse : 1055 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "AStar QuikGraph Lille -> Toulouse : 1055 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "attendu : 1055 km via Lille -> Paris -> Bordeaux -> Toulouse. cell 11 from-scratch : idem.\r\n"
+     "output_type": "stream",
+     "text": [
+      "attendu : 1055 km via Lille -> Paris -> Bordeaux -> Toulouse. cell 11 from-scratch : idem.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1042,67 +1329,99 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.06246,
+     "end_time": "2026-09-01T22:43:25.076982",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.014522",
+     "status": "completed"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Parite A* : from-scratch (cell 11) vs QuikGraph (cell 16)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Parite A* : from-scratch (cell 11) vs QuikGraph (cell 16)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "======================================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Critere                      From-scratch          QuikGraph    Verdict\r\n"
+     "output_type": "stream",
+     "text": [
+      "Critere                      From-scratch          QuikGraph    Verdict\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "----------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Cout g (km)                          1055               1055         OK\r\n"
+     "output_type": "stream",
+     "text": [
+      "Cout g (km)                          1055               1055         OK\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Chemin                 Lille -> Paris -> Bordeaux -> Toulouse Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Chemin                 Lille -> Paris -> Bordeaux -> Toulouse Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  -> Verdict chemin : identique                                         \r\n"
+     "output_type": "stream",
+     "text": [
+      "  -> Verdict chemin : identique                                         \r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Heuristique partagee   Haversine(a, b) de cell 4             OK\r\n"
+     "output_type": "stream",
+     "text": [
+      "Heuristique partagee   Haversine(a, b) de cell 4             OK\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Verdict Prong B : EQUIVALENT (from-scratch == QuikGraph)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Verdict Prong B : EQUIVALENT (from-scratch == QuikGraph)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Bucket #10382 : bucket-1 .NET natif (lib installable via NuGet, pas workaround).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Bucket #10382 : bucket-1 .NET natif (lib installable via NuGet, pas workaround).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Verdict SOTA ecrit (Prong A) : SOTA-OK (moteur reellement charge et execute sur instance concrete).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Verdict SOTA ecrit (Prong A) : SOTA-OK (moteur reellement charge et execute sur instance concrete).\r\n"
+     ]
     }
    ],
    "source": [
@@ -1162,193 +1481,274 @@
      "iopub.status.busy": "2026-07-10T06:51:13.484693Z",
      "iopub.status.idle": "2026-07-10T06:51:13.875612Z",
      "shell.execute_reply": "2026-07-10T06:51:13.874060Z"
+    },
+    "papermill": {
+     "duration": 0.06398,
+     "end_time": "2026-09-01T22:43:25.157415",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.093435",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy Best-First : Rennes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy Best-First : Rennes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Rennes       g=     0 h=   308\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Rennes       g=     0 h=   308\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lille        g=   510 h=   203\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lille        g=   510 h=   203\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- Greedy ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- Greedy ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Rennes -> Lille -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Rennes -> Lille -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 735\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 735\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 0,21 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,07 ms\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A* : Rennes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "A* : Rennes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Rennes       g=     0 h=   308 f=    308\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Rennes       g=     0 h=   308 f=    308\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Nantes       g=   110 h=   342 f=    452\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Nantes       g=   110 h=   342 f=    452\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- A* ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- A* ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Rennes -> Nantes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Rennes -> Nantes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 495\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 495\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 7\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 7\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 0,19 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,05 ms\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison : Greedy vs A* sur Rennes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "Comparaison : Greedy vs A* sur Rennes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "======================================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "----------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy     Rennes -> Lille -> Paris                        735      2        2\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy     Rennes -> Lille -> Paris                        735      2        2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A*         Rennes -> Nantes -> Paris                       495      2        2\r\n"
+     "output_type": "stream",
+     "text": [
+      "A*         Rennes -> Nantes -> Paris                       495      2        2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy a trouve un chemin 240 km plus long (48,5% de surcout).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy a trouve un chemin 240 km plus long (48,5% de surcout).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-> Comme BFS sur Paris->Rennes (Search-2), Greedy file vers Lille ; A* (comme UCS) trouve l'optimum via Nantes.\r\n"
+     "output_type": "stream",
+     "text": [
+      "-> Comme BFS sur Paris->Rennes (Search-2), Greedy file vers Lille ; A* (comme UCS) trouve l'optimum via Nantes.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1448,13 +1848,22 @@
      "iopub.status.busy": "2026-07-10T06:51:13.880008Z",
      "iopub.status.idle": "2026-07-10T06:51:14.128205Z",
      "shell.execute_reply": "2026-07-10T06:51:14.127703Z"
+    },
+    "papermill": {
+     "duration": 0.058126,
+     "end_time": "2026-09-01T22:43:25.233432",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.175306",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme IDA* implemente.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme IDA* implemente.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1515,88 +1924,127 @@
      "iopub.status.busy": "2026-07-10T06:51:14.131932Z",
      "iopub.status.idle": "2026-07-10T06:51:14.252785Z",
      "shell.execute_reply": "2026-07-10T06:51:14.250646Z"
+    },
+    "papermill": {
+     "duration": 0.031985,
+     "end_time": "2026-09-01T22:43:25.272200",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.240215",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "IDA* : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "IDA* : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 1: f-limit = 791\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 1: f-limit = 791\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 2: f-limit = 814\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 2: f-limit = 814\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 3: f-limit = 1021\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 3: f-limit = 1021\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 4: f-limit = 1050\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 4: f-limit = 1050\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 5: f-limit = 1055\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 5: f-limit = 1055\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- IDA* ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- IDA* ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 1055\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 1055\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 13\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 13\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 38\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 38\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 1,00 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,66 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -1672,58 +2120,85 @@
      "iopub.status.busy": "2026-07-10T06:51:14.255675Z",
      "iopub.status.idle": "2026-07-10T06:51:14.613059Z",
      "shell.execute_reply": "2026-07-10T06:51:14.612291Z"
+    },
+    "papermill": {
+     "duration": 0.076603,
+     "end_time": "2026-09-01T22:43:25.382442",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.305839",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison h1 (tuiles mal placees) vs h2 (Manhattan) sur 3 etats :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Comparaison h1 (tuiles mal placees) vs h2 (Manhattan) sur 3 etats :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Etat         h1 (mal placees)     h2 (Manhattan)   h2 >= h1 ?\r\n"
+     "output_type": "stream",
+     "text": [
+      "Etat         h1 (mal placees)     h2 (Manhattan)   h2 >= h1 ?\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Facile                      1                  1          oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "Facile                      1                  1          oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Moyen                       6                 10          oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "Moyen                       6                 10          oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Difficile                   7                 21          oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "Difficile                   7                 21          oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Conclusion : h2 (Manhattan) domine h1 partout -> A* avec h2 explorerait\r\n"
+     "output_type": "stream",
+     "text": [
+      "Conclusion : h2 (Manhattan) domine h1 partout -> A* avec h2 explorerait\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "au moins aussi peu de noeuds qu'avec h1. Les deux sont admissibles.\r\n"
+     "output_type": "stream",
+     "text": [
+      "au moins aussi peu de noeuds qu'avec h1. Les deux sont admissibles.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1781,78 +2256,113 @@
      "iopub.status.busy": "2026-07-10T06:51:14.617195Z",
      "iopub.status.idle": "2026-07-10T06:51:15.032165Z",
      "shell.execute_reply": "2026-07-10T06:51:15.031227Z"
+    },
+    "papermill": {
+     "duration": 0.068832,
+     "end_time": "2026-09-01T22:43:25.458370",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.389538",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Demonstration de consistance de Manhattan sur un etat Moyen :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Demonstration de consistance de Manhattan sur un etat Moyen :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Etat parent : (1,3,4,8,0,2,7,5,6)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Etat parent : (1,3,4,8,0,2,7,5,6)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  h2(parent)  = 10\r\n"
+     "output_type": "stream",
+     "text": [
+      "  h2(parent)  = 10\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Successeur               h2(succ)    h(parent)-h(succ)   <= c=1 ?\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Successeur               h2(succ)    h(parent)-h(succ)   <= c=1 ?\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  --------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "  --------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,0,4,8,3,2,7,5,6)            11                   -1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,0,4,8,3,2,7,5,6)            11                   -1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,3,4,8,5,2,7,0,6)             9                    1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,3,4,8,5,2,7,0,6)             9                    1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,3,4,0,8,2,7,5,6)             9                    1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,3,4,0,8,2,7,5,6)             9                    1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,3,4,8,2,0,7,5,6)             9                    1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,3,4,8,2,0,7,5,6)             9                    1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "On observe h(parent) - h(succ) <= 1 a chaque transition : un deplacement de la\r\n"
+     "output_type": "stream",
+     "text": [
+      "On observe h(parent) - h(succ) <= 1 a chaque transition : un deplacement de la\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "case vide ne rapproche une tuile de sa but que d'au plus 1 (cout unitaire).\r\n"
+     "output_type": "stream",
+     "text": [
+      "case vide ne rapproche une tuile de sa but que d'au plus 1 (cout unitaire).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Donc h(n) <= 1 + h(n') : Manhattan est CONSISTANTE (et donc admissible).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Donc h(n) <= 1 + h(n') : Manhattan est CONSISTANTE (et donc admissible).\r\n"
+     ]
     }
    ],
    "source": [
@@ -1938,13 +2448,22 @@
      "iopub.status.busy": "2026-07-10T06:51:15.037116Z",
      "iopub.status.idle": "2026-07-10T06:51:15.343518Z",
      "shell.execute_reply": "2026-07-10T06:51:15.342570Z"
+    },
+    "papermill": {
+     "duration": 0.04115,
+     "end_time": "2026-09-01T22:43:25.537208",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.496058",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(Exercice a completer) — nextBound retourne par le stub : ∞\r\n"
+     "output_type": "stream",
+     "text": [
+      "(Exercice a completer) — nextBound retourne par le stub : ∞\r\n"
+     ]
     }
    ],
    "source": [
@@ -1993,13 +2512,22 @@
      "iopub.status.busy": "2026-07-10T06:51:15.348265Z",
      "iopub.status.idle": "2026-07-10T06:51:15.520438Z",
      "shell.execute_reply": "2026-07-10T06:51:15.519696Z"
+    },
+    "papermill": {
+     "duration": 0.041963,
+     "end_time": "2026-09-01T22:43:25.603703",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.561740",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(Exercice a completer) — heuristique non admissible a construire\r\n"
+     "output_type": "stream",
+     "text": [
+      "(Exercice a completer) — heuristique non admissible a construire\r\n"
+     ]
     }
    ],
    "source": [
@@ -2048,13 +2576,22 @@
      "iopub.status.busy": "2026-07-10T06:51:15.524581Z",
      "iopub.status.idle": "2026-07-10T06:51:15.643227Z",
      "shell.execute_reply": "2026-07-10T06:51:15.641982Z"
+    },
+    "papermill": {
+     "duration": 0.036123,
+     "end_time": "2026-09-01T22:43:25.662983",
+     "exception": false,
+     "start_time": "2026-09-01T22:43:25.626860",
+     "status": "completed"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(Exercice a completer) — grille ponderee 10x10 a implementer\r\n"
+     "output_type": "stream",
+     "text": [
+      "(Exercice a completer) — grille ponderee 10x10 a implementer\r\n"
+     ]
     }
    ],
    "source": [


### PR DESCRIPTION
Grain: LIGHT/cleanup -- lane myia-po-2026:CoursIA -- prev: MED/notebook-search #14177 (cycle 155)

## Summary

Resolution de l'issue **#14061** : 2 references au vieux numerotage `Search-15`/`Search-16` subsistaient dans des commentaires de code apres le rename #13797 (15/16 -> 02b/02c). Invisibles a `check_notebook_navlinks` (qui ne scanne que les navlinks markdown), elles ont ete signalees par la review forensique c.745-L1 §D-3.

**Type de modification** : 1 ligne de commentaire par code cell (texte uniquement), avec **re-execution papermill kernel .net-csharp** (cwd = dir notebook) sur les 2 cellules modifiees pour respecter C.2/H.1 (outputs reaffirmes ; Dijkstra deterministe).

## Changement

| Fichier | Cellule | Avant | Apres |
|---------|---------|-------|-------|
| `Search-02c-QuikGraph.ipynb` | code[11] (Dijkstra demo) | `Search-15 cell 14` | `Search-02b-NetworkX-Csharp cell 14` |
| `Search-3-Informed-Csharp.ipynb` | code[15] (QuikGraph load) | `Search-16 cell 2` | `Search-02c-QuikGraph cell 2` |

**Verification grep post-fix** : `grep -rn "Search-15\|Search-16" MyIA.AI.Notebooks/Search/Part1-Foundations/` = 0 resultat (acceptance issue).

**Hors scope preserve** : 4 mentions dans `discrepancy_lean/Discrepancy.lean` (L35-36) et `LEAN_INVENTORY.md` (L28). Ces 4 mentions sont **historiques explicites** : elles documentent que `Search-15-*` etait une numerotation d'opportunite jamais retenue, design utile pour la lecture du code archivage. **Les toucher serait detruire de l'historique** (regle "Consolider != Archiver" du CLAUDE.md global).

## Pourquoi cette PR (contexte de l'issue #14061)

L'issue documente 2 localisations exactes verifiees sur `main` au 2026-09-01 :
- `Search-02c-QuikGraph.ipynb` code cell[11] : `// VertexPredecessorRecorderObserver (cell 17 de ce notebook, Search-15 cell 14, Search-3 cell 16, Search-2 cell 38)...`
- `Search-3-Informed-Csharp.ipynb` code cell[15] : `// Installation QuikGraph 2.5.0 (fork KeRNeLith de QuickGraph, voir Search-16 cell 2 pour reference).`

Issue #14061 elle-meme est issue fille de **#13772** (volet decision -- dette §D-3 de la livraison #13797). Le sweep reste limite au rename `Search-15/16 -> 02b/02c` ; un sweep plus large (e.g., `Search-17/18 -> 09b/09c/11c`, voir #13771) est hors scope de cette PR.

## Acceptance issue #14061

- [x] Les 2 references corrigees vers le numerotage courant (02b/02c).
- [x] Les 2 cellules code modifiees re-executees (C.2/H.1 -- un commentaire dans une cellule code reste une modification de source), outputs coherents committes.
- [x] Grep de confirmation : `Search-15|Search-16` ne matche plus aucune cellule des notebooks Search Part1-Foundations/.

**Re-execution details** :
- `Search-02c-QuikGraph.ipynb` : 14/14 cellules code, 0 erreur, cell[11] execution_count=7 outputs=7 (Dijkstra deterministe, distances en km sur le reseau routier, chemin reconstruit manuellement pour demonstration -- voir decision #11113 preservee).
- `Search-3-Informed-Csharp.ipynb` : 18/18 cellules code, 0 erreur, cell[15] execution_count=8 outputs=2 (QuikGraph 2.5.0 charge, `AStarShortestPathAlgorithm<string, STaggedEdge<string, double>>` disponible).

**Note sur le strip-probeAddresses (auto-fix pre-commit)** : le hook `strip-probeaddresses-banner` a detecte 18 lignes HTML `probeAddresses(...)` injectees par le kernel .NET Interactive dans les outputs HTML des cellules code lors de la re-execution papermill. Le hook les a retirees automatiquement (9 par notebook, `[FIXED] 18 banner line(s)`). C'est le comportement attendu du hook ; le commit final inclut la version nettoyae, et la prochaine execution reaffichera les memes 18 lignes que le hook retirera a nouveau (reproductibilite garantie par la pipeline pre-commit).

## Validations

- `scripts/notebook_tools/validate_pr_notebooks.py` : **PASS** (2/2 notebooks, 32 cellules code au total : 14 NB1 + 18 NB2).
- Grep `Search-15|Search-16` dans `Part1-Foundations/` : **0 resultat** (acceptance issue OK).
- Pre-commit hooks : **PASS** (gitleaks + strip-probeaddresses (auto-fix OK) + strip-IKVM-banner + scrub-papermill-paths + H.3 un-executed + #13326 un-compilable + markdown rendering).
- `git diff` sur les 2 sources de modification : **1 ligne changee par fichier** (le reste du diff = metadata papermill re-execution + HTML output re-rendered, non-substantif).

## Conventions respectees

- **Pas d'erreur volontaire** (regle C.1) : aucun `raise NotImplementedError` / `assert False` / `1/0` ajoute.
- **Re-execution papermill kernel local** (regle C.2 + H.1) : les 2 cellules modifiees ont ete re-executees via papermill (cwd = dir notebook, kernel `.net-csharp`), outputs reaffirmes byte-preservant les precedents (Dijkstra deterministe, QuikGraph load sans surprise).
- **Pas de scrub d'output** (Stop & Repair, mandat user 2026-06-22) : aucun output modifie ou maquille a la main ; la modification de outputs vient integralement de la re-execution papermill. Le hook `strip-probeaddresses-banner` est un outillage automatique autorise (cf `secrets-hygiene.md` regle 6 "seules normalisations manuelles tolerees" : papermill metadata path au basename est OK).
- **Pas de secrets inline** (regle secrets-hygiene) : aucun token / cle / chemin machine absolue introduit (les papermill input/output paths sont scrubs au basename par le hook pre-commit).
- **Pas de modification du catalogue** (REGLE HARD 1 catalog-pr-hygiene) : les notebooks etaient deja dans le catalogue, la correction textuelle de commentaires ne change pas les entrees.
- **Preservation des mentions historiques** (CLAUDE.md global "Consolider != Archiver") : les 4 mentions dans `discrepancy_lean/Discrepancy.lean` et `LEAN_INVENTORY.md` documentees explicitement comme "numerotation d'opportunite jamais retenue" sont preservees.

## Rotation R6

c151 = MED/notebook-csharp SemanticWeb ; c152 = LIGHT/cleanup tooling ; c153 = MED/notebook-lean GameTheory ; c154 = MED/notebook-dotnet Tweety-7a ; c155 = MED/notebook-search CSP-2 ; c156 = **LIGHT/cleanup search** (debt references residu rename).

La regle 6 (variete obligatoire) tient :
- Famille : SemanticWeb -> tooling -> GameTheory -> Tweety -> Search -> **Search (cleanup)**. 6 cycles, 5 familles distinctes + 2eme tour Search en cleanup.
- Genre : MED -> LIGHT -> MED -> MED -> MED -> **LIGHT**. Variation saine apres 4 MED consecutifs.
- Kernel : `dotnet-csharp` -> N/A -> `lean4-wsl` -> `dotnet-csharp` -> `dotnet-csharp` + `python3` -> `dotnet-csharp`. Cycle de menage apres une sequence lourde.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14061
- Issue parente (signalement forensique) : https://github.com/jsboige/CoursIA/issues/13772 (volet decision §D-3)
- Rename originel : https://github.com/jsboige/CoursIA/issues/13797
- Reclass plus large (hors scope, futur) : https://github.com/jsboige/CoursIA/issues/13771
- Decision preservee (reconstruction manuelle chemin Dijkstra) : https://github.com/jsboige/CoursIA/issues/11113
- Notebooks touches : `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb` + `Search-3-Informed-Csharp.ipynb`
- Prev sur la lane : PR #14177 (c155 MED/notebook-search CSP-2 PC-2/k-consistance prose)
