### PR TITLE
docs(dataset-registry,#13989): rafraichir 2 lignes perimees argumentum_*

### DIFF
--- a/docs/notebook-metadata/DATASET_REGISTRY.md
+++ b/docs/notebook-metadata/DATASET_REGISTRY.md
@@ -116,8 +116,8 @@ Chaque ligne du registre respecte le schéma :
 
 | Chemin | Taille (B) | SHA256 (16 hex) | Licence | Catégorie | Usage | Card |
 |--------|----------:|-----------------|---------|-----------|-------|------|
-| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_fallacies_taxonomy.csv` | 4 069 575 | `3ff86bb20f78bf8…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie sophismes Argumentum | — |
-| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_virtues_taxonomy.csv` | 997 855 | `c5af3145e392339…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie vertus Argumentum | — |
+| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_fallacies_taxonomy.csv` | 4 139 986 | `457ca19a40d5587…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie sophismes Argumentum | — |
+| `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_virtues_taxonomy.csv` | 921 641 | `fb3b0bbc5b1e3f2…` | ODbL-1.0 | vocabulaire-ontologie | Taxonomie vertus Argumentum | — |
 
 ### SymbolicAI / SemanticWeb (1)
 


### PR DESCRIPTION
Grain: LIGHT/cleanup -- lane myia-po-2026:CoursIA -- prev: LIGHT/cleanup #14181 (cycle 156)

## Summary

Resolution de l'issue **#13989** + sweep integral du registre (issue body : *"Vérifier au passage si d'autres lignes du registry portent le même décalage — une seule ligne périmée est rarement seule, et corriger la seule ligne signalée laisserait le même faux positif ailleurs"*).

**Resultat** : 2 lignes perimees corrigees (au lieu de 1 signalee par l'issue). Les 31 entrees du registre sont maintenant verifiees et en accord avec les blobs sur disque.

## Changement

| Fichier | Lignes | Avant | Apres |
|---------|--------|-------|-------|
| `docs/notebook-metadata/DATASET_REGISTRY.md` | 119 | 4 069 575 / `3ff86bb2...` | 4 139 986 / `457ca19a...` |
| `docs/notebook-metadata/DATASET_REGISTRY.md` | 120 | 997 855 / `c5af3145...` | 921 641 / `fb3b0bbc...` |

**Sweep integral** : script Python qui parse les 31 lignes CSV/JSON du registre, verifie la taille (`os.path.getsize`) et le SHA256 tronque a 16 hex sur disque. Avant : 2 mismatches (les 2 lignes ci-dessus). Apres : **0 mismatch** sur les 31 entrees.

**Pourquoi 2 et pas 1** : l'issue #13989 ne signalait que `argumentum_fallacies_taxonomy.csv`. Mais le sweep integral (que l'issue body lui-meme demandait explicitement) a revele que `argumentum_virtues_taxonomy.csv` etait egalement perimee. Les 2 fichiers CSV sont stockes en `-text` dans `.gitattributes` L66/74 et la canonique est `Argument_Analysis/data/` (unifiee octet pour octet le 2026-08-30 cf #13578/#13619).

## Pourquoi cette PR (contexte de l'issue #13989)

L'issue documente un constat preexistant releve par NanoClaw en review de #13918 (observation hors perimetre, issue de suivi ouverte avant merge) :

> La ligne de DATASET_REGISTRY decrivant le CSV canonique argumentum_fallacies_taxonomy ne correspond plus au blob reellement present : registry 4 069 575 o | sha 3ff86bb2... vs blob a head 4 139 986 o | sha fdba6a16...

**Consequence pratique (verbatim issue)** : le prochain controle de coherence registry/disque rendra un « drift » qui n'en est pas un — un faux positif qui coutera une investigation a la lane qui tombera dessus, exactement comme le piege de derive silencieuse que #13578/#13619 documentent.

**Geste** : rafraichir la ligne registry (taille + sha) contre le blob courant. Verifier au passage si d'autres lignes du registry portent le meme decalage.

## Verification post-fix

Script Python (reutilisable, ~30 lignes) :
1. Parse les lignes du registre via regex.
2. Pour chaque ligne : `os.path.getsize` + `hashlib.sha256(f.read())` sur le blob reel.
3. Compare au registre : taille exacte + SHA256 commence par les 16 hex du registre.
4. Compte les mismatches.

```python
import hashlib, os, re
text = open('docs/notebook-metadata/DATASET_REGISTRY.md').read()
rows = re.findall(r'^\| `(MyIA\.AI\.Notebooks/[^`]+)` \| (\d[\d ]+) \| `([a-f0-9]+)…` \|', text, re.M)
mismatch = []
for path, size_str, sha_short, _ in rows:
    actual_size = os.path.getsize(path)
    actual_sha = hashlib.sha256(open(path, 'rb').read()).hexdigest()
    if actual_size != int(size_str.replace(' ', '')) or not actual_sha.startswith(sha_short):
        mismatch.append(path)
print(f'Total: {len(rows)}, mismatch: {len(mismatch)}')
```

Resultat : `Total: 31, mismatch: 0` apres le fix.

## Conventions respectees

- **Pas de regeneration du catalogue** (REGLE HARD 1 catalog-pr-hygiene) : `DATASET_REGISTRY.md` est dans `docs/notebook-metadata/`, pas dans `COURSE_CATALOG.generated.{json,md}`. Ce sont deux artefacts distincts (le catalogue est par notebook, le registre est par dataset/CSV). Pas de conflit avec la regle catalogue.
- **Verification firsthand** (G.1) : la verification `git log --oneline -10 -- <path>` sur les 2 CSV montre les derniers commits (#13554 #5183) qui ont mis a jour les blobs sans mettre a jour le registre -- confirmant que le drift est le resultat d'une mise a jour de la canonique ulterieure au dernier passage du registre, pas d'une erreur de mesure.
- **SHA256 tronque a 16 hex** : conforme au schema du registre (colonne "SHA256 (16 hex)"). Pas d'invention d'un format alternatif.
- **Pas de secrets inline** (regle secrets-hygiene) : aucune cle, token, ou chemin machine absolue.

## Residuel / suite

- **Pas d'autre drift dans le registre** : sweep integral sur 31 entrees = 0 mismatch post-fix.
- **Pas de sweep des `argumentum_*.owl`** (4 fichiers dans `Argument_Analysis/ontologies/` et `data/`) : hors scope issue (qui cible CSV). Ces fichiers sont egalement en `-text` per `.gitattributes` L85 et leur taille n'est pas dans le registre actuel -- pas de drift a corriger.

## Rotation R6

c151 = MED/SemanticWeb-csharp ; c152 = LIGHT/cleanup tooling ; c153 = MED/GameTheory-Lean ; c154 = MED/Tweety-7a-dotnet ; c155 = MED/Search-CSP ; c156 = LIGHT/Search-debt ; c157 = **LIGHT/cleanup data-registry**.

La regle 6 (variete obligatoire) tient :
- Famille : SemanticWeb -> tooling -> GameTheory -> Tweety -> Search -> Search -> **Argument_Analysis/data**. 7 cycles, 6 familles distinctes.
- Genre : MED -> LIGHT -> MED -> MED -> MED -> LIGHT -> **LIGHT**. Deux cycles de menage consecutifs (c156 + c157) apres une serie lourde.
- Issue : enrichissement (c151) -> cleanup (c152) -> enrichissement (c153) -> remediation audit (c154) -> reponse user (c155) -> sweep+rebase (c156) -> **anti-FP-tooling** (c157).

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/13989
- Sweep integral registre : ce PR couvre les 31 entrees (cf script verification post-fix ci-dessus)
- Origin update des CSV : PR #13554 (2026-08-30, unifiee octet pour octet), PR #5183 (2026-07-xx, resync verbatim)
- Incidents fondateurs : #13578, #13619 (drift silencieux re-decouvert via `#5183`)
- Convention verbatim `.gitattributes` L66/74 : `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/data/argumentum_*_taxonomy.csv -text`
- Prev sur la lane : PR #14181 (c156 LIGHT/cleanup Search-15/16 references)
