### PR TITLE
fix(tooling,#14130): mention d'un verdict attribuee a un tiers = pas emission

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -775,9 +775,11 @@ _MENTION_VERDICT_BARE = re.compile(
 #     myia-* / un nom propre) — sans attribution, le verdict est propre
 #     (l'auteur l'emet), la position ne s'applique PAS.
 # (2) Verbe DESCRIPTIF (`porte`, `comporte`, `contient`, `mentionne`,
-#     `indique`, `signale`, `releve`, `contient`, `a emis`, `avait emis`) — un
-#     verbe d'EMISSION (`Verdict :`, `Block on`, `declare`, `reste bloquante`)
-#     n'est PAS descriptif, c'est une emission, la position ne s'applique PAS.
+#     `indique`, `signale`, `releve`, `contient`, `a emis`, `avait emis`, et
+#     ext. #14185 `conclut`, `declare` — conclusifs/declaratifs acceptes
+#     UNIQUEMENT sous attribution tierce + article, cf pattern) — un verbe
+#     d'EMISSION (`Verdict :`, `Block on`, `reste bloquante`) n'est PAS
+#     descriptif, c'est une emission, la position ne s'applique PAS.
 # (3) Pas de declaration de blocage dans la suite de la phrase (meme garde
 #     dure que Position E, ligne 645 : `reste bloquante` / `Verdict :` / `Block
 #     on`) — sinon le verdict reste emis.
@@ -813,7 +815,14 @@ _MENTION_VERDICT_REPORTED = re.compile(
     r"|indique|indiques|indiquent"
     r"|signale|signales|signalent"
     r"|releve|releves|relevent"
-    r"|a\s+emis|avait\s+emis|avaient\s+emis|ont\s+emis)"
+    r"|a\s+emis|avait\s+emis|avaient\s+emis|ont\s+emis"
+    # Ext. #14185 : verbes conclusifs/declaratifs sous attribution tierce —
+    # « La review NanoClaw conclut un SUSPECT_REGRESSION » est un rapport de
+    # verdict de tiers, pas une emission propre. Surs sous ce pattern car
+    # l'attribution (1) et l'article (garde ce6) sont exigees en amont :
+    # « Je declare CHANGES_REQUESTED » ne peut pas matcher (pas de
+    # « review/revue » + tiers avant le verbe).
+    r"|conclut|concluent|declare|declarent)"
     r"\s+(?:un|une|le|la|les|des|du)\s+"
     # Verdict case-sensitive (memes bornes que A-G)
     r"(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3993,3 +3993,138 @@ def test_13951_concern1_glyphe_severite_avec_rien_de_bloquant_ne_passe_pas():
     # Le glyphe est dans CONCERN_MARKERS (cf. PR #12143) :
     assert mod._sole_live_concern_is_comment_prefix(body_glyphe) is False
     assert mod.classify("jsboige", body_glyphe) == "BOT-CONCERN"
+# ---------------------------------------------------------------------------
+# #14130 - Position F : verdict attribue a un tiers sans quote ni crochet.
+# Bug fondateur (#14070, 2026-09-01) : 2 des 3 points non leves sur #14070
+# etaient les commentaires de diagnostic de la lane elle-meme, qui NOMMAIENT
+# le verdict d'un tiers sans le quoter -- le gate les comptait comme reserves
+# vives, et chaque cycle de commentaire AJOUTAIT un point au compte qu'il
+# decrivait. Mesure verbatim issue : "La review Hermes porte un
+# CHANGES_REQUESTED que ma lane ne peut pas lever seule."
+# ---------------------------------------------------------------------------
+
+
+def test_14130_paire_reproduction_rend_none_dans_les_deux_formes() -> None:
+    """#14130 acceptance #1 : la paire reproduction doit rendre `None` dans
+    les deux formes (backtickee et nue). Discrimination : le predicat
+    porte sur **qui parle de quoi**, pas sur la simple presence du nom.
+    """
+    bare = "La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut pas lever seule."
+    backt = "La review Hermes porte un `CHANGES_REQUESTED` que ma lane ne peut pas lever seule."
+    assert mod.classify("jsboige", bare) is None, bare
+    assert mod.classify("jsboige", backt) is None, backt
+
+
+def test_14130_variantes_attribution_verdict_tiers_ne_flagge_pas() -> None:
+    """#14130 : variantes structurelles -- attribution explicite d'un verdict
+    FORMEL a un reviewer/agent tiers. Les formes AVEC article sont neutralisees
+    par `_MENTION_VERDICT_REPORTED` (Position H ; ext. #14185 : verbes
+    conclusifs/declaratifs `conclut`/`declare`).
+    """
+    bodies = [
+        # #14130 fondateur (Position H, verbe porte + article)
+        "La review Hermes porte un CHANGES_REQUESTED sur la cellule 12.",
+        # ext. #14185 : verbes conclusifs/declaratifs + article (rapport de tiers)
+        "La review NanoClaw conclut un SUSPECT_REGRESSION sur le test.",
+        "La review Hermes declare un CHANGES_REQUESTED sur la cellule 12.",
+        # deja couverts par la Position H (verbes descriptifs + article)
+        "Verdict Hermes a rendu COMMENT_WITH_CONCERNS.",
+        "La revue Claude signale un CONCERN dans le diff.",
+    ]
+    for body in bodies:
+        assert mod.classify("jsboige", body) is None, body
+    # Alignement ce6 (Position H) : sans article entre le verbe et le
+    # verdict, la forme est une EMISSION directe, pas un rapport -- elle
+    # reste BOT-CONCERN.
+    emissions = [
+        "La revue Claude mentionne NEEDS_CHANGES dans son rapport.",
+        "Review Hermes a emis REQUEST_CHANGES sur la branche.",
+    ]
+    for body in emissions:
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", body
+
+
+def test_14130_emission_formelle_avec_prefixe_agent_ne_seutralise_pas() -> None:
+    """#14130 contre-positif : un `[Hermes]` (prefixe d'agent) suivi d'un
+    verdict est une EMISSION formelle, couverte par AGENT_PREFIXES -- la
+    Position F doit la laisser intacte (le `(?<!\\[)` borne le non-match).
+    """
+    bodies = [
+        "[Hermes] CHANGES_REQUESTED sur la cellule 12.",
+        "[Hermes] Review — CHANGES_REQUESTED.",
+        "## [Hermes] **[COMMENT_WITH_CONCERNS]** — notebook solide, 2 concerns FYI.",
+        "[NanoClaw] SUSPECT_REGRESSION sur le test.",
+    ]
+    for body in bodies:
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", body
+
+
+def test_14130_reserve_formelle_en_prose_nue_reste_bloquante() -> None:
+    """#14130 contre-positif : une reserve emise directement (sans nom de
+    tiers, sans quote, sans prefixe) reste bloquee. Le discriminant est
+    l'attribution a un tiers -- son absence = emission propre.
+    """
+    bodies = [
+        "CHANGES_REQUESTED: la cellule 12 casse le kernel.",
+        "2 CONCERNS ouverts, non adresses avant merge.",
+        "REQUEST_CHANGES sur la logique de l'exercice 3.",
+        "NEEDS_CHANGES: le test d'integration manque.",
+    ]
+    for body in bodies:
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", body
+
+
+def test_14130_mutation_position_f_neutralisee_rougit_le_test() -> None:
+    """#14130 acceptance #2 (valide par mutation) : si l'extension #14185
+    (verbes conclusifs/declaratifs `conclut`/`declare` de
+    `_MENTION_VERDICT_REPORTED`) est retiree du stripper, la variante
+    conclusive redevient 'BOT-CONCERN' -- preuve que le test depend de
+    l'extension. On recompile le pattern sans les verbes ajoutes, on
+    re-tourne le strip sur la variante, on compare. In-place, sans
+    monkeypatch global (la fonction est appelee par d'autres tests dans
+    la meme run).
+    """
+    variant = "La review NanoClaw conclut un SUSPECT_REGRESSION sur le test."
+    stripped = mod._strip_quoted(variant)
+    # Composant determinant : le pattern REPORTED AVEC l'extension #14185
+    full = mod._MENTION_VERDICT_REPORTED
+    with_ext = full.sub(
+        lambda mm: mm.group(0).replace(mm.group(1), " " * len(mm.group(1))),
+        stripped,
+    )
+    # Sanity : avec l'extension, le verdict est neutralise (espaces)
+    assert "SUSPECT_REGRESSION" not in with_ext, with_ext
+
+    # Reconstruction SANS l'extension (= simule son retrait)
+    mutated = mod.re.compile(full.pattern.replace(
+        "|conclut|concluent|declare|declarent", ""))
+    without_ext = mutated.sub(
+        lambda mm: mm.group(0).replace(mm.group(1), " " * len(mm.group(1))),
+        stripped,
+    )
+    # Sanity : sans l'extension, le verdict reste vivant
+    assert "SUSPECT_REGRESSION" in without_ext, without_ext
+    # Et donc classify re-rougit (CONCERN_MARKERS inclut SUSPECT_REGRESSION)
+    assert mod.has_live_marker(without_ext, mod.CONCERN_MARKERS)
+    # Avec l'extension, classify rend None (sanity inverse -- miroir du test variantes)
+    assert not mod.has_live_marker(with_ext, mod.CONCERN_MARKERS)
+    # Et les longueurs sont preservees (les fenetres `_is_cited` restent calibrees)
+    assert len(with_ext) == len(without_ext)
+
+
+def test_14130_conservation_offsets_sur_strip_quoted() -> None:
+    """#14130 acceptance implicite : le strip preserve les offsets (les
+    fenetres de `_is_cited` restent calibrees sur la vraie position des
+    occurrences survivantes). Verification mecanique : remplacer les
+    matches par des espaces de meme longueur ne change pas la longueur
+    totale de la chaine.
+    """
+    bodies = [
+        "La review Hermes porte un CHANGES_REQUESTED.",
+        "La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut pas lever seule.",
+        "Review Hermes declare un SUSPECT_REGRESSION. Et puis autre chose.",
+        "La review [Hermes] declare un CHANGES_REQUESTED.",  # non match -> pas de strip
+    ]
+    for body in bodies:
+        assert len(mod._strip_mentioned_verdicts(body)) == len(body), body
+


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #14184 (cycle 158)

## Summary

Resolution de l'issue #14130 : le gate classait BOT-CONCERN toute phrase qui nommait un verdict formel sans le quoter, y compris quand elle rapportait le verdict d'un tiers. Cas fondateur (#14070) :

> La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut pas lever seule.

**Harmonisation au rebase (2026-09-03)** : main a implemente la Position H (`_MENTION_VERDICT_REPORTED`) entre le fork initial et ce rebase -- la meme discrimination avec une structure plus riche (attribution tierce + verbe descriptif + article obligatoire + garde dure anti-blocage). Un rebase literal aurait cree une 2e `def _strip_mentioned_verdicts` ecrasant la version main au runtime (Python : derniere def gagne). La PR devient donc une **extension** de la Position H au lieu d'un pattern concurrent :

- Ajout des verbes conclusifs/declaratifs `conclut|concluent|declare|declarent` a la liste des verbes descriptifs de `_MENTION_VERDICT_REPORTED` -- variantes mesurees GAP sur main (`mod.classify` = BOT-CONCERN a tort) : « La review NanoClaw conclut un SUSPECT_REGRESSION sur le test. », « La review Hermes declare un CHANGES_REQUESTED sur la cellule 12. »
- Ces verbes sont surs sous ce pattern : l'attribution tierce (1) et l'article (garde ce6) sont exiges en amont -- « Je declare CHANGES_REQUESTED » (emission 1re personne, FN de la Position H) ne peut pas matcher.
- Alignement des formes sans article sur le contre-positif ce6 : « La revue Claude mentionne NEEDS_CHANGES » reste BOT-CONCERN (emission directe).
- 6 tests (bloc Position F aligne sur la conception main : reproduction, variantes + alignement ce6, contre-positifs emission formelle `[Hermes]` et prose nue, mutation sur l'extension, conservation des offsets).

## Acceptance issue #14130

| # | Critere | Test |
|---|---------|------|
| 1 | La paire reproduction rend None dans les deux formes | `test_14130_paire_reproduction_rend_none_dans_les_deux_formes` |
| 2 | Une vraie reserve en prose nue reste bloquante (valide par mutation) | `test_14130_reserve_formelle_en_prose_nue_reste_bloquante` + `test_14130_mutation_position_f_neutralisee_rougit_le_test` |
| 3 | Suite complete verte | `pytest scripts/tests/test_check_unaddressed_nits.py -q` = **301 passed** (0 failed) |

## Preuves

- `python scripts/check_unaddressed_nits.py 14185` -> `OK PR #14185 -- aucun nit non leve` (rc=0)
- Diff vs main : `scripts/check_unaddressed_nits.py` +17/-4 (extension verbes + commentaires), `scripts/tests/test_check_unaddressed_nits.py` +135 (bloc Position F aligne)
