### PR TITLE
feat(search): ajouter 3 exercices à MGS-17b

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-17b-Empirical-Algorithm-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-17b-Empirical-Algorithm-Selection.ipynb
@@ -5,10 +5,10 @@
    "id": "mgs17b-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002054,
-     "end_time": "2026-08-27T21:07:59.117191+00:00",
+     "duration": 0.002295,
+     "end_time": "2026-09-02T00:04:50.686456+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:07:59.115137+00:00",
+     "start_time": "2026-09-02T00:04:50.684161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -51,10 +51,10 @@
    "id": "mgs17b-cadre",
    "metadata": {
     "papermill": {
-     "duration": 0.001625,
-     "end_time": "2026-08-27T21:07:59.120637+00:00",
+     "duration": 0.001812,
+     "end_time": "2026-09-02T00:04:50.692664+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:07:59.119012+00:00",
+     "start_time": "2026-09-02T00:04:50.690852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -128,16 +128,16 @@
    "id": "mgs17b-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T21:07:59.125068Z",
-     "iopub.status.busy": "2026-08-27T21:07:59.124048Z",
-     "iopub.status.idle": "2026-08-27T21:08:00.755013Z",
-     "shell.execute_reply": "2026-08-27T21:08:00.755013Z"
+     "iopub.execute_input": "2026-09-02T00:04:50.695485Z",
+     "iopub.status.busy": "2026-09-02T00:04:50.695485Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.742119Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.742119Z"
     },
     "papermill": {
-     "duration": 1.634188,
-     "end_time": "2026-08-27T21:08:00.756452+00:00",
+     "duration": 2.048967,
+     "end_time": "2026-09-02T00:04:52.743684+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:07:59.122264+00:00",
+     "start_time": "2026-09-02T00:04:50.694717+00:00",
      "status": "completed"
     },
     "tags": []
@@ -147,8 +147,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python : 3.11.15 | packaged by conda-forge | (main, Jun 11 2026, 03:27:10) [MSC v.1944 64 bit (AMD64)]\n",
-      "Plateforme : Windows 10 (AMD64)\n"
+      "Python : 3.12.13 | packaged by Anaconda, Inc. | (main, Mar 19 2026, 20:16:45) [MSC v.1942 64 bit (AMD64)]\n",
+      "Plateforme : Windows 11 (AMD64)\n"
      ]
     },
     {
@@ -157,11 +157,11 @@
      "text": [
       "\n",
       "--- Modules presents ---\n",
-      "  numpy               2.4.6  (tableaux numeriques)\n",
-      "  pandas              3.0.3  (tables de resultats / CSV)\n",
-      "  matplotlib         3.11.0  (visualisations)\n",
-      "  scipy              1.17.1  (solveurs numeriques (recuit simule, etc.))\n",
-      "  sklearn             1.9.0  (selection algo / portfolio / features)\n",
+      "  numpy               2.4.4  (tableaux numeriques)\n",
+      "  pandas              3.0.2  (tables de resultats / CSV)\n",
+      "  matplotlib         3.10.9  (visualisations)\n",
+      "  scipy              1.15.3  (solveurs numeriques (recuit simule, etc.))\n",
+      "  sklearn             1.8.0  (selection algo / portfolio / features)\n",
       "  ortools         9.15.6755  (CP-SAT (Sudoku, Puissance 4))\n",
       "  pysat           1.9.dev15  (SAT/SMT (Sudoku encode SAT))\n",
       "  z3                      ?  (SMT (Sudoku encode SMT))\n",
@@ -221,10 +221,10 @@
    "id": "mgs17b-t2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.001839,
-     "end_time": "2026-08-27T21:08:00.760298+00:00",
+     "duration": 0.001773,
+     "end_time": "2026-09-02T00:04:52.747568+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.758459+00:00",
+     "start_time": "2026-09-02T00:04:52.745795+00:00",
      "status": "completed"
     },
     "tags": []
@@ -258,16 +258,16 @@
    "id": "mgs17b-t2-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T21:08:00.764630Z",
-     "iopub.status.busy": "2026-08-27T21:08:00.764105Z",
-     "iopub.status.idle": "2026-08-27T21:08:00.770948Z",
-     "shell.execute_reply": "2026-08-27T21:08:00.770395Z"
+     "iopub.execute_input": "2026-09-02T00:04:52.751743Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.751743Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.757155Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.757155Z"
     },
     "papermill": {
-     "duration": 0.009786,
-     "end_time": "2026-08-27T21:08:00.771706+00:00",
+     "duration": 0.008899,
+     "end_time": "2026-09-02T00:04:52.758346+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.761920+00:00",
+     "start_time": "2026-09-02T00:04:52.749447+00:00",
      "status": "completed"
     },
     "tags": []
@@ -338,16 +338,16 @@
    "id": "mgs17b-t2-structures",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T21:08:00.776104Z",
-     "iopub.status.busy": "2026-08-27T21:08:00.775101Z",
-     "iopub.status.idle": "2026-08-27T21:08:00.783989Z",
-     "shell.execute_reply": "2026-08-27T21:08:00.783454Z"
+     "iopub.execute_input": "2026-09-02T00:04:52.762189Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.762189Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.770025Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.769404Z"
     },
     "papermill": {
-     "duration": 0.011602,
-     "end_time": "2026-08-27T21:08:00.785107+00:00",
+     "duration": 0.010573,
+     "end_time": "2026-09-02T00:04:52.770796+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.773505+00:00",
+     "start_time": "2026-09-02T00:04:52.760223+00:00",
      "status": "completed"
     },
     "tags": []
@@ -447,16 +447,16 @@
    "id": "mgs17b-t2-helpers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T21:08:00.789469Z",
-     "iopub.status.busy": "2026-08-27T21:08:00.788468Z",
-     "iopub.status.idle": "2026-08-27T21:08:00.856777Z",
-     "shell.execute_reply": "2026-08-27T21:08:00.856268Z"
+     "iopub.execute_input": "2026-09-02T00:04:52.775770Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.775770Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.840546Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.839505Z"
     },
     "papermill": {
-     "duration": 0.071144,
-     "end_time": "2026-08-27T21:08:00.858064+00:00",
+     "duration": 0.068415,
+     "end_time": "2026-09-02T00:04:52.841438+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.786920+00:00",
+     "start_time": "2026-09-02T00:04:52.773023+00:00",
      "status": "completed"
     },
     "tags": []
@@ -466,7 +466,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sudoku     CP-SAT or-tools    Easy      cpu=0.0000 +/- 0.0000 s,  wall=0.0102 +/- 0.0001 s,  rss=n/a (Windows) MB,  succes=100%\n"
+      "Sudoku     CP-SAT or-tools    Easy      cpu=0.0000 +/- 0.0000 s,  wall=0.0103 +/- 0.0001 s,  rss=n/a (Windows) MB,  succes=100%\n"
      ]
     }
    ],
@@ -568,13 +568,77 @@
   },
   {
    "cell_type": "markdown",
+   "id": "957d37c9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002183,
+     "end_time": "2026-09-02T00:04:52.846141+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:04:52.843958+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : auditer l'équité des budgets\n",
+    "\n",
+    "Écrivez une fonction qui groupe des `TerrainConfig` par `(terrain, difficulté)` et signale les groupes où les solveurs ne partagent pas le même `timeout_s` ou le même budget d'évaluations.\n",
+    "\n",
+    "- **Étape 1** : construisez les groupes de configurations comparables.\n",
+    "- **Étape 2** : retournez, pour chaque groupe inéquitable, les budgets observés.\n",
+    "- **Indice** : traitez explicitement `budget_evaluations=None`, qui désigne un budget non renseigné et non un budget nul."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8f4f81ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T00:04:52.851386Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.851386Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.856439Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.855181Z"
+    },
+    "papermill": {
+     "duration": 0.009153,
+     "end_time": "2026-09-02T00:04:52.857505+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:04:52.848352+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : audit d'équité None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO étudiant : valider l'équité d'un protocole multi-solveurs.\n",
+    "def verifier_equite(configurations):\n",
+    "    # Étape 1 : comparer les budgets par terrain et difficulté.\n",
+    "    # Étape 2 : signaler les groupes dont les solveurs n'ont pas le même timeout.\n",
+    "    # Indice : regroupez les configurations par (terrain, difficulte).\n",
+    "    return None\n",
+    "\n",
+    "rapport_equite = verifier_equite([])\n",
+    "print(\"Exercice à compléter : audit d'équité\", rapport_equite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "mgs17b-t3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.001758,
-     "end_time": "2026-08-27T21:08:00.861828+00:00",
+     "duration": 0.002076,
+     "end_time": "2026-09-02T00:04:52.861793+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.860070+00:00",
+     "start_time": "2026-09-02T00:04:52.859717+00:00",
      "status": "completed"
     },
     "tags": []
@@ -602,20 +666,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "mgs17b-t3-pareto",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T21:08:00.865208Z",
-     "iopub.status.busy": "2026-08-27T21:08:00.865208Z",
-     "iopub.status.idle": "2026-08-27T21:08:00.874809Z",
-     "shell.execute_reply": "2026-08-27T21:08:00.873797Z"
+     "iopub.execute_input": "2026-09-02T00:04:52.866798Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.866798Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.872916Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.872916Z"
     },
     "papermill": {
-     "duration": 0.01207,
-     "end_time": "2026-08-27T21:08:00.875478+00:00",
+     "duration": 0.010801,
+     "end_time": "2026-09-02T00:04:52.874711+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.863408+00:00",
+     "start_time": "2026-09-02T00:04:52.863910+00:00",
      "status": "completed"
     },
     "tags": []
@@ -716,13 +780,77 @@
   },
   {
    "cell_type": "markdown",
+   "id": "73a81f74",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003627,
+     "end_time": "2026-09-02T00:04:52.882355+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:04:52.878728+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : étendre la frontière de Pareto à la mémoire\n",
+    "\n",
+    "Le calcul précédent utilise le temps et le taux de succès. Ajoutez un troisième axe `memoire_rss_mb` à minimiser, puis identifiez les solveurs non dominés selon les trois critères.\n",
+    "\n",
+    "- **Étape 1** : définissez la règle de dominance en trois dimensions.\n",
+    "- **Étape 2** : vérifiez qu'une égalité sur deux axes n'empêche pas une domination stricte sur le troisième.\n",
+    "- **Indice** : commencez par un petit profil synthétique de quatre solveurs dont vous connaissez la frontière attendue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f2435565",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T00:04:52.888115Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.888115Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.894082Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.893046Z"
+    },
+    "papermill": {
+     "duration": 0.008879,
+     "end_time": "2026-09-02T00:04:52.894706+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:04:52.885827+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : frontière Pareto 3D None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO étudiant : généraliser la dominance à trois critères.\n",
+    "def frontiere_pareto_3d(points):\n",
+    "    # Étape 1 : ajouter la mémoire comme troisième objectif à minimiser.\n",
+    "    # Étape 2 : conserver uniquement les points non dominés.\n",
+    "    # Indice : une domination exige au moins une inégalité stricte.\n",
+    "    return None\n",
+    "\n",
+    "front_3d = frontiere_pareto_3d([])\n",
+    "print(\"Exercice à compléter : frontière Pareto 3D\", front_3d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "mgs17b-t3-discriminant-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.001746,
-     "end_time": "2026-08-27T21:08:00.879235+00:00",
+     "duration": 0.001903,
+     "end_time": "2026-09-02T00:04:52.899260+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.877489+00:00",
+     "start_time": "2026-09-02T00:04:52.897357+00:00",
      "status": "completed"
     },
     "tags": []
@@ -746,20 +874,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "mgs17b-t3-discriminant",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T21:08:00.883370Z",
-     "iopub.status.busy": "2026-08-27T21:08:00.883370Z",
-     "iopub.status.idle": "2026-08-27T21:08:00.888811Z",
-     "shell.execute_reply": "2026-08-27T21:08:00.888811Z"
+     "iopub.execute_input": "2026-09-02T00:04:52.903739Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.903739Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.910533Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.910015Z"
     },
     "papermill": {
-     "duration": 0.009189,
-     "end_time": "2026-08-27T21:08:00.890190+00:00",
+     "duration": 0.011499,
+     "end_time": "2026-09-02T00:04:52.912603+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.881001+00:00",
+     "start_time": "2026-09-02T00:04:52.901104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -860,13 +988,77 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b876ae26",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002828,
+     "end_time": "2026-09-02T00:04:52.919829+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:04:52.917001+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : choisir un solveur sous budget\n",
+    "\n",
+    "Construisez un sélecteur qui reçoit un profil de solveurs, un budget maximal et une fiabilité minimale. Il doit retourner le candidat admissible le plus rapide, ou `None` si aucun candidat ne respecte les contraintes.\n",
+    "\n",
+    "- **Étape 1** : filtrez simultanément sur `wall_moy_s` et `succes_rate`.\n",
+    "- **Étape 2** : triez les candidats admissibles par temps croissant.\n",
+    "- **Indice** : testez aussi un budget trop strict afin de vérifier le cas sans solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0f3487df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T00:04:52.928782Z",
+     "iopub.status.busy": "2026-09-02T00:04:52.928782Z",
+     "iopub.status.idle": "2026-09-02T00:04:52.934104Z",
+     "shell.execute_reply": "2026-09-02T00:04:52.933531Z"
+    },
+    "papermill": {
+     "duration": 0.011986,
+     "end_time": "2026-09-02T00:04:52.935562+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:04:52.923576+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : sélection sous budget None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO étudiant : compléter le sélecteur sous contraintes.\n",
+    "def choisir_solveur(profil, budget_s, fiabilite_min):\n",
+    "    # Étape 1 : filtrer les solveurs qui respectent les deux contraintes.\n",
+    "    # Étape 2 : départager les candidats par temps croissant.\n",
+    "    # Indice : chaque ligne de profil contient terrain, solveur, temps et fiabilité.\n",
+    "    return None\n",
+    "\n",
+    "selection = choisir_solveur(PROFIL_SYNTHETIQUE, budget_s=0.5, fiabilite_min=0.99)\n",
+    "print(\"Exercice à compléter : sélection sous budget\", selection)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "mgs17b-plan",
    "metadata": {
     "papermill": {
-     "duration": 0.001854,
-     "end_time": "2026-08-27T21:08:00.893850+00:00",
+     "duration": 0.002588,
+     "end_time": "2026-09-02T00:04:52.940445+00:00",
      "exception": false,
-     "start_time": "2026-08-27T21:08:00.891996+00:00",
+     "start_time": "2026-09-02T00:04:52.937857+00:00",
      "status": "completed"
     },
     "tags": []
@@ -909,18 +1101,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.488069,
-   "end_time": "2026-08-27T21:08:01.241030+00:00",
+   "duration": 4.510644,
+   "end_time": "2026-09-02T00:04:53.391955+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-17b-Empirical-Algorithm-Selection.ipynb",
-   "output_path": "output_t3.ipynb",
+   "input_path": "MGS-17b-Empirical-Algorithm-Selection.ipynb",
+   "output_path": "MGS-17b-Empirical-Algorithm-Selection.ipynb",
    "parameters": {},
-   "start_time": "2026-08-27T21:07:57.752961+00:00",
+   "start_time": "2026-09-02T00:04:48.881311+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/tooling #14183

## Résumé

- ajoute trois exercices répartis après leurs exemples guides respectifs ;
- couvre l'équité des budgets expérimentaux, la dominance de Pareto en trois dimensions et la sélection de solveur sous contraintes ;
- conserve des stubs étudiants exécutables (`return None`) avec `TODO`, étapes et indices ;
- ré-exécute le notebook complet et committe les sorties réelles.

## Validation

- `notebook_tools.py execute ... --kernel coursia-ml-training --cwd ... --timeout 300` : SUCCESS, 1/1 notebook, 5.6 s au niveau CLI ; métadonnée Papermill du notebook : 4,51 s ;
- environnement réparé avant le run : `python-sat 1.9.dev15`, output `[OK] pysat` ;
- `validate_pr_notebooks.py origin/main ...` : PASS, 9 cellules code sur 9 ;
- `count_exercises.py ... --json` : 3/3, conforme ;
- `scan_cell_ordering.py ...` : 1 clean, 0 finding ;
- `check_exec_sequence.py ... --json` : CLEAN, séquence 1–9 ;
- scan C.1 : aucune erreur volontaire ;
- détection de fuite Papermill : aucune fuite après normalisation autorisée des métadonnées `input_path`/`output_path` ;
- `python -m pre_commit run --files ...` : tous les hooks applicables passent ;
- revue indépendante `notebook-validator` : PASS structure, pédagogie, C.1/C.2 et diff hygiene.

## Périmètre

Un seul notebook source est modifié. Aucun catalogue généré ni README n'est régénéré.

See #1203
See #2161
