### PR TITLE
feat(game-theory): add safe solving exercises

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "b6d1f7c7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002755,
+     "end_time": "2026-09-02T00:35:06.760994+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:06.758239+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GameTheory-13b : Safe Subgame Solving -- quand le mauvais recollement produit un temoin adversarial\n",
     "\n",
@@ -52,18 +61,26 @@
    "id": "200da7d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.660368Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.659987Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.806202Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.805095Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:06.767713Z",
+     "iopub.status.busy": "2026-09-02T00:35:06.767542Z",
+     "iopub.status.idle": "2026-09-02T00:35:06.932868Z",
+     "shell.execute_reply": "2026-09-02T00:35:06.932109Z"
+    },
+    "papermill": {
+     "duration": 0.169155,
+     "end_time": "2026-09-02T00:35:06.933456+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:06.764301+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numpy=2.4.2\n"
+      "numpy=2.4.4\n"
      ]
     }
    ],
@@ -81,11 +98,19 @@
    "id": "10dc71dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.808641Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.808265Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.818448Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.817540Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:06.939710Z",
+     "iopub.status.busy": "2026-09-02T00:35:06.939415Z",
+     "iopub.status.idle": "2026-09-02T00:35:06.949091Z",
+     "shell.execute_reply": "2026-09-02T00:35:06.947052Z"
+    },
+    "papermill": {
+     "duration": 0.014693,
+     "end_time": "2026-09-02T00:35:06.950279+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:06.935586+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -186,7 +211,16 @@
   {
    "cell_type": "markdown",
    "id": "cc0b1847",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002295,
+     "end_time": "2026-09-02T00:35:06.955322+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:06.953027+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Section 1 -- Blueprint : strategie globale et exploitabilite baseline\n",
     "\n",
@@ -205,11 +239,19 @@
    "id": "7d62e47a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.820792Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.820416Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.899836Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.898828Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:06.960904Z",
+     "iopub.status.busy": "2026-09-02T00:35:06.960718Z",
+     "iopub.status.idle": "2026-09-02T00:35:06.989841Z",
+     "shell.execute_reply": "2026-09-02T00:35:06.988941Z"
+    },
+    "papermill": {
+     "duration": 0.033265,
+     "end_time": "2026-09-02T00:35:06.990797+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:06.957532+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -299,11 +341,19 @@
    "id": "5af1fb7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.903038Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.902585Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.924573Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.923748Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:06.996214Z",
+     "iopub.status.busy": "2026-09-02T00:35:06.996038Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.007501Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.006774Z"
+    },
+    "papermill": {
+     "duration": 0.015113,
+     "end_time": "2026-09-02T00:35:07.008095+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:06.992982+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -497,7 +547,16 @@
   {
    "cell_type": "markdown",
    "id": "aa552d84",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002061,
+     "end_time": "2026-09-02T00:35:07.012231+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.010170+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du baseline\n",
     "\n",
@@ -522,8 +581,81 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b0340bea",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001852,
+     "end_time": "2026-09-02T00:35:07.016037+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.014185+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : vérifier les invariants de l'équilibre de Nash\n",
+    "\n",
+    "À partir de `nash_strategy`, reconstruisez les trois contrôles qui certifient le baseline : valeur du jeu pour P1, somme nulle des gains et exploitabilité nulle.\n",
+    "\n",
+    "- **Étape 1** : calculez l'espérance moyenne de P1 face à la stratégie de Nash.\n",
+    "- **Étape 2** : appelez `exploitability` et vérifiez les trois invariants avec une tolérance numérique.\n",
+    "- **Indice** : la valeur théorique de P1 dans Kuhn Poker est `-1 / 18` chip par donne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "790240b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T00:35:07.020654Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.020494Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.023605Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.022813Z"
+    },
+    "papermill": {
+     "duration": 0.006141,
+     "end_time": "2026-09-02T00:35:07.024076+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.017935+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : invariants de Nash None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO étudiant : reconstruire les trois invariants du baseline Nash.\n",
+    "def verifier_invariants_nash(strategy, tolerance=1e-9):\n",
+    "    # Étape 1 : mesurer EV(P1) et la meilleure réponse de P2.\n",
+    "    # Étape 2 : vérifier valeur du jeu, somme nulle et exploitabilité nulle.\n",
+    "    # Indice : utilisez _ev_p1_average et exploitability.\n",
+    "    return None\n",
+    "\n",
+    "invariants_nash = verifier_invariants_nash(nash_strategy)\n",
+    "print(\"Exercice à compléter : invariants de Nash\", invariants_nash)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "30b59cdf",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002134,
+     "end_time": "2026-09-02T00:35:07.028954+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.026820+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Section 2 -- Raffinement naif : detruire l'equilibre sans conditions de bord\n",
     "\n",
@@ -541,15 +673,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "284c0056",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.926772Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.926546Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.933796Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.932837Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:07.034201Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.034022Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.038769Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.037742Z"
+    },
+    "papermill": {
+     "duration": 0.008341,
+     "end_time": "2026-09-02T00:35:07.039396+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.031055+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -579,15 +719,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "e79fdf5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.935930Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.935624Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.945740Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.944772Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:07.045278Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.045113Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.051192Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.050325Z"
+    },
+    "papermill": {
+     "duration": 0.009664,
+     "end_time": "2026-09-02T00:35:07.051732+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.042068+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -655,7 +803,8 @@
     "# ici plutot que confondue avec une mesure valide dans la prose voisine.\n",
     "assert exp_naive >= -1e-9, (\n",
     "    f\"exploitabilite negative ({exp_naive:+.6f}) : pas une mesure\"\n",
-    ")\n",    "print(f'EV(P2) contre recollement naif (BR pure) = {ev_p2_naive:+.4f} chips/deal')\n",
+    ")\n",
+    "print(f'EV(P2) contre recollement naif (BR pure) = {ev_p2_naive:+.4f} chips/deal')\n",
     "print(f'Exploitabilite reelle du recollement naif = {exp_naive:+.4f} chips/deal')\n",
     "print()\n",
     "print('Best response pure P2 face au recollement naif :')\n",
@@ -670,7 +819,16 @@
   {
    "cell_type": "markdown",
    "id": "22e92139",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00209,
+     "end_time": "2026-09-02T00:35:07.056037+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.053947+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du recollement naif\n",
     "\n",
@@ -699,8 +857,88 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f62624c9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002126,
+     "end_time": "2026-09-02T00:35:07.060268+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.058142+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : mesurer les informations sets modifiés\n",
+    "\n",
+    "Comparez la stratégie de Nash et le recollement naïf sur les informations sets `p1pb`, puis reliez le nombre de changements à l'augmentation d'exploitabilité.\n",
+    "\n",
+    "- **Étape 1** : listez les clés dont les probabilités d'action diffèrent.\n",
+    "- **Étape 2** : calculez le delta `exp_naive - exp_baseline`.\n",
+    "- **Indice** : utilisez `np.allclose` pour comparer deux vecteurs de probabilités."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "97cae92b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T00:35:07.065384Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.065218Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.068507Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.067776Z"
+    },
+    "papermill": {
+     "duration": 0.00683,
+     "end_time": "2026-09-02T00:35:07.069205+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.062375+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : infosets modifiés None\n",
+      "Exercice à compléter : delta d'exploitabilité None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO étudiant : retrouver les changements introduits par le recollement naïf.\n",
+    "def analyser_recollement_naif(reference, candidate, cartes):\n",
+    "    # Étape 1 : comparer les vecteurs associés aux clés p1pb.\n",
+    "    # Étape 2 : retourner les clés réellement modifiées.\n",
+    "    # Indice : utilisez np.allclose pour ignorer les écarts d'arrondi.\n",
+    "    return None\n",
+    "\n",
+    "cles_modifiees = analyser_recollement_naif(\n",
+    "    nash_strategy,\n",
+    "    naive_strategy,\n",
+    "    GAME.cards,\n",
+    ")\n",
+    "delta_exploitabilite = None  # TODO étudiant : calculer exp_naive - exp_baseline.\n",
+    "print(\"Exercice à compléter : infosets modifiés\", cles_modifiees)\n",
+    "print(\"Exercice à compléter : delta d'exploitabilité\", delta_exploitabilite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3a42dfc8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002165,
+     "end_time": "2026-09-02T00:35:07.073539+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.071374+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Section 3 -- Safe subgame solving : recollement AVEC conditions de bord\n",
     "\n",
@@ -716,15 +954,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "db335abb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.948156Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.947787Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.954816Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.953838Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:07.078664Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.078501Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.083774Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.082328Z"
+    },
+    "papermill": {
+     "duration": 0.008957,
+     "end_time": "2026-09-02T00:35:07.084594+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.075637+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -768,15 +1014,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "75b87fd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.956938Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.956625Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.966221Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.965016Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:07.091555Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.091380Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.097544Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.096660Z"
+    },
+    "papermill": {
+     "duration": 0.010821,
+     "end_time": "2026-09-02T00:35:07.098111+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.087290+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -827,21 +1081,204 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c604ac5b",
-   "metadata": {},
-   "source": "## Conclusion -- La loi obstruction -> temoin exploitable\n\n**Trois resultats chiffres** sur Kuhn Poker (convention Kuhn 1950 / Zinkevich 2007 Table 1,\nchip net par deal, enumeration complete 6 deals) :\n\n| Recollement | EV(P1) | Exploitabilite | Lecture |\n|---|---|---|---|\n| Baseline (Nash Kuhn, Zinkevich 2007, alpha = 1/3) | -1/18 = -0.0556 | 0.0000 | equilibre exact, aucune deviation profitable (assertion `exploitability(Nash) == 0`) |\n| Naif (call toujours sur pb) | -0.1667 | +0.2778 | recollement detruit l'equilibre ; P2 best response revele un delta de +0.2778 |\n| Safe (= Nash sur le sous-arbre) | -1/18 = -0.0556 | 0.0000 | Nash preserve, recollement trivial (cas limite, assertion `exploitability(safe) == 0`) |\n\n**Convention** : Kuhn 1950 / Zinkevich 2007 Table 1 -- chaque ante = 1 chip, chaque mise\nsupplementaire = 1 chip. Le Nash Kuhn donne `EV(P1) = -1/18` et `EV(P2) = +1/18` chip net\npar deal (zero-sum, jeu asymetrique, strategies mixtes). Cette convention est la plus\nstandard et livre une **exploitabilite >= 0** par construction (la BR ne peut pas etre\ninferieure au Nash Kuhn).\n\n**Strategie de Nash authentique** : famille parametree par `alpha in [0, 1/3]`\n(Zinkevich et al. 2007, Table 1). A `alpha = 1/3`, on obtient la strategie mixte\nqui reellement equilibre Kuhn : P1 bet J avec 1/3 + Q jamais + K bet, P2 bet J avec\n1/3 + Q jamais + K bet a `p_at_p`, et reactions mixtes analogues a `p1pb`/`p2root`.\nLa valeur du jeu `EV(P1) = -1/18` est constante sur toute la famille, mais l'exploitabilite\nne s'annule QU'A `alpha = 1/3` (mesure verifiee par enumeration des 64 strategies\npures P2 : `exploitability(nash_strategy) = 0.0000`).\n\n**Calcul de l'exploitabilite** : enumeration exhaustive des **64 strategies pures P2**\n(= 2^6 combinaisons : 6 decisions P2 = 2 info-sets 'p_at_p'/'p2root' x 3 cartes J/Q/K).\nPour chaque strategie pure, on evalue `EV(P2)` face a la strategie P1 fixee ; on garde\nle max. Pas d'optimisation par info-set (qui sur-optimisait dans la version precedente\net pouvait retourner des exploitabilites negatives -- artefact numerique, pas une mesure).\n\n**Tests d'equilibre executes** dans la cellule baseline :\n- `assert abs(EV(P1) Nash - (-1/18)) < 1e-9` -- valeur du jeu = -1/18 ;\n- `assert abs(EV(P1) + EV(P2)) < 1e-9` -- zero-sum ;\n- `assert abs(exploitability(Nash)) < 1e-9` -- Nash authentique = 0.\n\nLe recollement naif **ne se signale pas numeriquement dans le sous-arbre local** -- l'EV local\ndu sous-jeu peut paraitre positif. Ce qui compte, c'est la **difference d'exploitabilite**\nentre les deux recollements : la deviation concrete de P2 (best response face a la strategie\nnaive recalculee par enumeration) est le temoin adversarial. Ici, **delta(exploitabilite)\n= +0.2778 chips/deal** : c'est la marge profitable pour P2 quand P1 recolle naivement le\nsous-arbre `pb`.\n\n**La loi (2 attestations)** :\n\n1. **Finetti (Lean-27 Coherence et Temoin, po-2025 c.1301+315)** : un systeme de paris incoherent\n   admet une strategie d'adversaire qui garantit un gain positif (temoin exploitable logique).\n\n2. **Brown-Sandholm (GameTheory-13b Safe Subgame Solving, ce notebook)** : un recollement mal\n   fait admet une strategie d'adversaire qui exploite le blueprint (temoin exploitable causal).\n\n**Le patron commun** : `obstruction abstraite -> temoin exploitable concret`. Deux attestations\nsur des lakes differents, dans des langages differents (Lean + Python), dans des registres\ndifferents (logique + causal). Le patron devient une loi : **chaque fois qu'un objet\npretendument compatible ne l'est pas, il existe un acteur externe qui le demontre en exploit.**\n\n**Limites du notebook** :\n- Le twin C# (#13317) utilise une convention de payoff differente et obtient un delta EV\n  plus prononce. Les deux conventions s'accordent sur le **signe** du delta d'exploitabilite\n  (le recollement naif detruit l'equilibre, le recollement safe le preserve).\n- Kuhn Poker est un jeu minimal (3 cartes, 2 actions). Le passage a Leduc Hold'em ou\n  Heads-Up Limit Hold'em necessiterait l'algorithme Brown-Sandholm depth-first solving +\n  alternate optimized re-solving (leur methode Libratus et Pluribus, 2017-2019).\n- Le recollement safe est ici trivial (= Nash) ; un cas non-trivial montrerait la borne\n  d'exploitabilite explicitement preservee par les conditions de bord `reach` (probabilite\n  qu'un info-set soit atteint avec la carte en main, Brown-Sandholm 2017 §3).\n\n**Suite suggeree** : un notebook 13c sur **re-solving depth-first** -- construire recursivement\ndes sous-arbres ou on calcule la strategie exacte du sous-jeu tout en propageant les bornes\nd'exploitabilite au blueprint global (algorithme de Brown-Sandholm, sous-game resolution avec\nreach reweighting).\n\n**Reparations successives** (issue #13468, PR #13480) :\n\n1. **REPAIR c.656** (commit `d1dd9cff`) : correction de 4 defauts pivots signales par\n   preflight cross-lane po-2025 (issuecomment-5461577663) :\n   - Arbre Kuhn a 5 terminales standard (pas 6 avec un bb prolonge fictif).\n   - Payoffs `pbp`/`pbb` corrigees (pbp = -1/+1 fold, pbb = +/-2 confrontation).\n   - Exploitabilite par enumeration exhaustive 64 strategies pures P2 (plus d'optimisation\n     par info-set qui sur-optimisait).\n   - Convention Kuhn standard chip net, EV(P1) Nash annoncee comme -1/18.\n\n2. **REPAIR c.664** (ce commit) : la valeur `-1/18` etait **annoncee mais pas mesuree**.\n   Le `nash_strategy` dict precedent etait un coin deterministe (`p_at_p|0` = J bet,\n   `p_at_p|2` = K bet) hors famille d'equilibre ; il produisait `EV(P1) = -1/6 = -0.1667`\n   que la cellule [5] masquait en imprimant la constante `-ev_p2_nash` au lieu de la\n   mesure `_self_ev_nash`. Ce REPAIR :\n   - Remplace le dict par la **famille Zinkevich parametree `alpha = 1/3`** (la seule\n     qui annule l'exploitabilite) ;\n   - Imprime la **mesure reelle** `_self_ev_nash` (et non la constante) -- `EV(P1) Nash = -0.0556`\n     est desormais une mesure, pas un mensonge ;\n   - Ajoute **3 assertions d'equilibre** (`EV(P1) = -1/18`, zero-sum, `exploitability(Nash) == 0`)\n     qui verifient au runtime que le dict est bien un Nash authentique ;\n   - Les cellules [9][13][15] reimpriment toutes `-0.0556 / 0.0000 / +0.2778 / 0.0000`,\n     sans aucune contradiction interne (la cellule [15] ne dit plus \"-0.1667 = -1/18\"\n     facteur 3 sur la meme ligne).\n\n**Source du calcul de reference** : issuecomment-5463662330 (ai-01) -- solveur ecrit\nde zero, 5 terminales, 6 donnes equiprobables, 64 strategies pures P2 enumerees.\n`EV(P1) Nash = -1/18` constant sur toute la famille alpha ; `exploitability(Nash) = 0.0000`\npour les deux joueurs ; `exploitability(x) >= 0` pour 4000 strategies aleatoires testees."
+   "id": "07ec2d0c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002441,
+     "end_time": "2026-09-02T00:35:07.103068+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.100627+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : contrôler la garantie du recollement sûr\n",
+    "\n",
+    "Écrivez un comparateur qui détermine si l'exploitabilité d'une stratégie recollée reste sous celle du baseline, à une tolérance numérique près.\n",
+    "\n",
+    "- **Étape 1** : recevez l'exploitabilité du baseline, celle du recollement et une tolérance.\n",
+    "- **Étape 2** : retournez un booléen indiquant si la garantie est respectée.\n",
+    "- **Indice** : la condition attendue compare `exp_recollement` à `exp_baseline + tolerance`."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
+   "id": "7097df7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T00:35:07.108679Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.108510Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.111744Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.110861Z"
+    },
+    "papermill": {
+     "duration": 0.007055,
+     "end_time": "2026-09-02T00:35:07.112276+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.105221+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : garantie du recollement sûr None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO étudiant : vérifier qu'un recollement respecte la borne du baseline.\n",
+    "def garantie_preservee(exp_baseline, exp_recollement, tolerance=1e-9):\n",
+    "    # Étape 1 : tenir compte de la tolérance numérique.\n",
+    "    # Étape 2 : retourner le verdict booléen.\n",
+    "    # Indice : comparez la valeur recollée à la borne autorisée.\n",
+    "    return None\n",
+    "\n",
+    "verdict_safe = garantie_preservee(exp_baseline, exp_safe)\n",
+    "print(\"Exercice à compléter : garantie du recollement sûr\", verdict_safe)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c604ac5b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002237,
+     "end_time": "2026-09-02T00:35:07.116880+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.114643+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion -- La loi obstruction -> temoin exploitable\n",
+    "\n",
+    "**Trois resultats chiffres** sur Kuhn Poker (convention Kuhn 1950 / Zinkevich 2007 Table 1,\n",
+    "chip net par deal, enumeration complete 6 deals) :\n",
+    "\n",
+    "| Recollement | EV(P1) | Exploitabilite | Lecture |\n",
+    "|---|---|---|---|\n",
+    "| Baseline (Nash Kuhn, Zinkevich 2007, alpha = 1/3) | -1/18 = -0.0556 | 0.0000 | equilibre exact, aucune deviation profitable (assertion `exploitability(Nash) == 0`) |\n",
+    "| Naif (call toujours sur pb) | -0.1667 | +0.2778 | recollement detruit l'equilibre ; P2 best response revele un delta de +0.2778 |\n",
+    "| Safe (= Nash sur le sous-arbre) | -1/18 = -0.0556 | 0.0000 | Nash preserve, recollement trivial (cas limite, assertion `exploitability(safe) == 0`) |\n",
+    "\n",
+    "**Convention** : Kuhn 1950 / Zinkevich 2007 Table 1 -- chaque ante = 1 chip, chaque mise\n",
+    "supplementaire = 1 chip. Le Nash Kuhn donne `EV(P1) = -1/18` et `EV(P2) = +1/18` chip net\n",
+    "par deal (zero-sum, jeu asymetrique, strategies mixtes). Cette convention est la plus\n",
+    "standard et livre une **exploitabilite >= 0** par construction (la BR ne peut pas etre\n",
+    "inferieure au Nash Kuhn).\n",
+    "\n",
+    "**Strategie de Nash authentique** : famille parametree par `alpha in [0, 1/3]`\n",
+    "(Zinkevich et al. 2007, Table 1). A `alpha = 1/3`, on obtient la strategie mixte\n",
+    "qui reellement equilibre Kuhn : P1 bet J avec 1/3 + Q jamais + K bet, P2 bet J avec\n",
+    "1/3 + Q jamais + K bet a `p_at_p`, et reactions mixtes analogues a `p1pb`/`p2root`.\n",
+    "La valeur du jeu `EV(P1) = -1/18` est constante sur toute la famille, mais l'exploitabilite\n",
+    "ne s'annule QU'A `alpha = 1/3` (mesure verifiee par enumeration des 64 strategies\n",
+    "pures P2 : `exploitability(nash_strategy) = 0.0000`).\n",
+    "\n",
+    "**Calcul de l'exploitabilite** : enumeration exhaustive des **64 strategies pures P2**\n",
+    "(= 2^6 combinaisons : 6 decisions P2 = 2 info-sets 'p_at_p'/'p2root' x 3 cartes J/Q/K).\n",
+    "Pour chaque strategie pure, on evalue `EV(P2)` face a la strategie P1 fixee ; on garde\n",
+    "le max. Pas d'optimisation par info-set (qui sur-optimisait dans la version precedente\n",
+    "et pouvait retourner des exploitabilites negatives -- artefact numerique, pas une mesure).\n",
+    "\n",
+    "**Tests d'equilibre executes** dans la cellule baseline :\n",
+    "- `assert abs(EV(P1) Nash - (-1/18)) < 1e-9` -- valeur du jeu = -1/18 ;\n",
+    "- `assert abs(EV(P1) + EV(P2)) < 1e-9` -- zero-sum ;\n",
+    "- `assert abs(exploitability(Nash)) < 1e-9` -- Nash authentique = 0.\n",
+    "\n",
+    "Le recollement naif **ne se signale pas numeriquement dans le sous-arbre local** -- l'EV local\n",
+    "du sous-jeu peut paraitre positif. Ce qui compte, c'est la **difference d'exploitabilite**\n",
+    "entre les deux recollements : la deviation concrete de P2 (best response face a la strategie\n",
+    "naive recalculee par enumeration) est le temoin adversarial. Ici, **delta(exploitabilite)\n",
+    "= +0.2778 chips/deal** : c'est la marge profitable pour P2 quand P1 recolle naivement le\n",
+    "sous-arbre `pb`.\n",
+    "\n",
+    "**La loi (2 attestations)** :\n",
+    "\n",
+    "1. **Finetti (Lean-27 Coherence et Temoin, po-2025 c.1301+315)** : un systeme de paris incoherent\n",
+    "   admet une strategie d'adversaire qui garantit un gain positif (temoin exploitable logique).\n",
+    "\n",
+    "2. **Brown-Sandholm (GameTheory-13b Safe Subgame Solving, ce notebook)** : un recollement mal\n",
+    "   fait admet une strategie d'adversaire qui exploite le blueprint (temoin exploitable causal).\n",
+    "\n",
+    "**Le patron commun** : `obstruction abstraite -> temoin exploitable concret`. Deux attestations\n",
+    "sur des lakes differents, dans des langages differents (Lean + Python), dans des registres\n",
+    "differents (logique + causal). Le patron devient une loi : **chaque fois qu'un objet\n",
+    "pretendument compatible ne l'est pas, il existe un acteur externe qui le demontre en exploit.**\n",
+    "\n",
+    "**Limites du notebook** :\n",
+    "- Le twin C# (#13317) utilise une convention de payoff differente et obtient un delta EV\n",
+    "  plus prononce. Les deux conventions s'accordent sur le **signe** du delta d'exploitabilite\n",
+    "  (le recollement naif detruit l'equilibre, le recollement safe le preserve).\n",
+    "- Kuhn Poker est un jeu minimal (3 cartes, 2 actions). Le passage a Leduc Hold'em ou\n",
+    "  Heads-Up Limit Hold'em necessiterait l'algorithme Brown-Sandholm depth-first solving +\n",
+    "  alternate optimized re-solving (leur methode Libratus et Pluribus, 2017-2019).\n",
+    "- Le recollement safe est ici trivial (= Nash) ; un cas non-trivial montrerait la borne\n",
+    "  d'exploitabilite explicitement preservee par les conditions de bord `reach` (probabilite\n",
+    "  qu'un info-set soit atteint avec la carte en main, Brown-Sandholm 2017 §3).\n",
+    "\n",
+    "**Suite suggeree** : un notebook 13c sur **re-solving depth-first** -- construire recursivement\n",
+    "des sous-arbres ou on calcule la strategie exacte du sous-jeu tout en propageant les bornes\n",
+    "d'exploitabilite au blueprint global (algorithme de Brown-Sandholm, sous-game resolution avec\n",
+    "reach reweighting).\n",
+    "\n",
+    "**Reparations successives** (issue #13468, PR #13480) :\n",
+    "\n",
+    "1. **REPAIR c.656** (commit `d1dd9cff`) : correction de 4 defauts pivots signales par\n",
+    "   preflight cross-lane po-2025 (issuecomment-5461577663) :\n",
+    "   - Arbre Kuhn a 5 terminales standard (pas 6 avec un bb prolonge fictif).\n",
+    "   - Payoffs `pbp`/`pbb` corrigees (pbp = -1/+1 fold, pbb = +/-2 confrontation).\n",
+    "   - Exploitabilite par enumeration exhaustive 64 strategies pures P2 (plus d'optimisation\n",
+    "     par info-set qui sur-optimisait).\n",
+    "   - Convention Kuhn standard chip net, EV(P1) Nash annoncee comme -1/18.\n",
+    "\n",
+    "2. **REPAIR c.664** (ce commit) : la valeur `-1/18` etait **annoncee mais pas mesuree**.\n",
+    "   Le `nash_strategy` dict precedent etait un coin deterministe (`p_at_p|0` = J bet,\n",
+    "   `p_at_p|2` = K bet) hors famille d'equilibre ; il produisait `EV(P1) = -1/6 = -0.1667`\n",
+    "   que la cellule [5] masquait en imprimant la constante `-ev_p2_nash` au lieu de la\n",
+    "   mesure `_self_ev_nash`. Ce REPAIR :\n",
+    "   - Remplace le dict par la **famille Zinkevich parametree `alpha = 1/3`** (la seule\n",
+    "     qui annule l'exploitabilite) ;\n",
+    "   - Imprime la **mesure reelle** `_self_ev_nash` (et non la constante) -- `EV(P1) Nash = -0.0556`\n",
+    "     est desormais une mesure, pas un mensonge ;\n",
+    "   - Ajoute **3 assertions d'equilibre** (`EV(P1) = -1/18`, zero-sum, `exploitability(Nash) == 0`)\n",
+    "     qui verifient au runtime que le dict est bien un Nash authentique ;\n",
+    "   - Les cellules [9][13][15] reimpriment toutes `-0.0556 / 0.0000 / +0.2778 / 0.0000`,\n",
+    "     sans aucune contradiction interne (la cellule [15] ne dit plus \"-0.1667 = -1/18\"\n",
+    "     facteur 3 sur la meme ligne).\n",
+    "\n",
+    "**Source du calcul de reference** : issuecomment-5463662330 (ai-01) -- solveur ecrit\n",
+    "de zero, 5 terminales, 6 donnes equiprobables, 64 strategies pures P2 enumerees.\n",
+    "`EV(P1) Nash = -1/18` constant sur toute la famille alpha ; `exploitability(Nash) = 0.0000`\n",
+    "pour les deux joueurs ; `exploitability(x) >= 0` pour 4000 strategies aleatoires testees."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "55b30cf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T23:19:27.968579Z",
-     "iopub.status.busy": "2026-08-29T23:19:27.968225Z",
-     "iopub.status.idle": "2026-08-29T23:19:27.975723Z",
-     "shell.execute_reply": "2026-08-29T23:19:27.974583Z"
-    }
+     "iopub.execute_input": "2026-09-02T00:35:07.122292Z",
+     "iopub.status.busy": "2026-09-02T00:35:07.122125Z",
+     "iopub.status.idle": "2026-09-02T00:35:07.126493Z",
+     "shell.execute_reply": "2026-09-02T00:35:07.125687Z"
+    },
+    "papermill": {
+     "duration": 0.008025,
+     "end_time": "2026-09-02T00:35:07.127101+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T00:35:07.119076+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -915,7 +1352,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.12.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.573178,
+   "end_time": "2026-09-02T00:35:07.344840+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-13b-Safe-Subgame-Solving.ipynb",
+   "output_path": "GameTheory-13b-Safe-Subgame-Solving.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T00:35:05.771662+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python #14193

## Résumé

- ajoute trois exercices répartis après les exemples résolus baseline, recollement naïf et recollement sûr ;
- exerce les invariants de Nash, l'identification des informations sets modifiés et le contrôle de la borne d'exploitabilité ;
- conserve des stubs étudiants exécutables avec `TODO`, étapes, indices et `return None` ;
- ré-exécute intégralement le notebook et committe les sorties réelles.

## Validation

- `wsl_papermill.py execute ... --timeout 300` : SUCCESS, 12/12 cellules code, 0 erreur, 2,2 s ;
- `validate_pr_notebooks.py origin/main ...` : PASS, 12 cellules code sur 12 ;
- `count_exercises.py ... --json` : 3/3, conforme ;
- `scan_cell_ordering.py ...` : 1 clean, 0 finding ;
- `check_exec_sequence.py ... --json` : CLEAN, séquence 1–12 ;
- scan C.1 : aucune erreur volontaire ;
- détection de fuite Papermill : aucune fuite après normalisation autorisée des métadonnées `input_path`/`output_path` ;
- `python -m pre_commit run --files ...` : tous les hooks applicables passent.

## Périmètre

Un seul notebook source est modifié. Les exemples résolus et leurs résultats mathématiques restent inchangés. Aucun catalogue généré ni README n'est régénéré.

See #12208
See #2161
