### PR TITLE
feat(lean,#12205): variante -b — synthese SAT de translateurs Life, minimalite prouvee et temoin d'impossibilite

### DIFF
--- a/scripts/lean/life_synthesize_sat.py
+++ b/scripts/lean/life_synthesize_sat.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Synthese SAT de translateurs de Game of Life (Loi II, EPIC #12205, variante -b).
+
+Le moteur B1 (`life_synthesize.py`) enumere *tous* les sous-ensembles d'une
+boite bornee. Son cout est combinatoire : une boite 4x4 a <= 6 cellules tient
+en 14 892 essais, une boite 5x5 a <= 9 cellules en demande 3,9 millions, et une
+boite 6x6 est hors d'atteinte. Ses deux residuels sont ecrits dans le body de
+la PR #13814 : les bornes, et « le moteur le decouvre, il ne l'unicise pas ».
+
+Ce module code la meme specification en SAT — le moteur que le cahier des
+charges de #12205 nommait (« SAT / Z3 / CP-SAT ») — et en tire les trois
+choses que l'enumeration ne donnait pas :
+
+  * **des bornes plus larges** : le LWSS (9 cellules, boite 5x4) est atteint,
+    la ou l'enumeration devrait parcourir ~168 000 combinaisons rien que pour
+    sa taille exacte ;
+  * **la minimalite** : la recherche monte k = 1, 2, 3, ... et s'arrete au
+    premier k satisfiable. Ce k est le minimum, parce que le solveur est
+    complet : les k inferieurs ne sont pas « non trouves », ils sont
+    **refutes** ;
+  * **le temoin d'impossibilite** : quand aucun k <= max_cells ne passe, la
+    sortie porte `IMPOSSIBLE` et la borne exacte de ce qui a ete refute. Le
+    critere 4 de #12205 — « un generateur qui ne sait pas dire "aucune
+    solution, et voici pourquoi" n'a pas franchi le cran, il l'a contourne ».
+
+La semantique de Life n'est **pas** reecrite ici : `step`, `evolve`, `shift_v`
+et `normalize` sont importes de `life_synthesize` (moteur B1). Toute solution
+rendue par le solveur est **revalidee contre cette reference** avant d'etre
+publiee (`verify_solution`) : le modele SAT est une hypothese, l'oracle est le
+moteur d'origine.
+
+Usage :
+    python scripts/lean/life_synthesize_sat.py --n 4 --vx 1 --vy=-1 --box 4
+    python scripts/lean/life_synthesize_sat.py --n 4 --vx 2 --vy 0 --box-w 5 --box-h 4
+    python scripts/lean/life_synthesize_sat.py --n 4 --vx 1 --vy 0 --box 6 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from life_synthesize import Cell, Grid, evolve, normalize, shift_v  # noqa: E402
+
+try:
+    import z3
+except ImportError:  # pragma: no cover - depend de l'environnement
+    z3 = None
+
+
+NEIGHBOUR_OFFSETS: tuple[tuple[int, int], ...] = tuple(
+    (dx, dy) for dx in (-1, 0, 1) for dy in (-1, 0, 1) if (dx, dy) != (0, 0)
+)
+
+
+def universe_bounds(
+    box_w: int, box_h: int, n: int, v: tuple[int, int]
+) -> tuple[range, range]:
+    """Fenetre hors de laquelle aucune cellule ne peut vivre avant n pas.
+
+    Un motif inclus dans la boite s'etend d'au plus une cellule par generation,
+    donc au plus de `n` apres `n` pas. On ajoute `|v|` (la cible translatee doit
+    tenir dedans) et 1 de marge : le bord de la fenetre est alors mort a toutes
+    les generations, ce qui rend **exact** — et pas seulement approche — le fait
+    de traiter l'exterieur comme mort dans l'encodage.
+    """
+    pad = n + max(abs(v[0]), abs(v[1])) + 1
+    return range(-pad, box_w + pad), range(-pad, box_h + pad)
+
+
+def build_solver(
+    n: int,
+    v: tuple[int, int],
+    box_w: int,
+    box_h: int,
+) -> tuple["z3.Solver", dict[Cell, "z3.BoolRef"]]:
+    """Encode `evolve^n T = shift_v T`, T inclus dans la boite, en SAT."""
+    xs, ys = universe_bounds(box_w, box_h, n, v)
+    cells = [(x, y) for x in xs for y in ys]
+    inside = set(cells)
+
+    alive = {
+        (g, p): z3.Bool(f"a_{g}_{p[0]}_{p[1]}")
+        for g in range(n + 1)
+        for p in cells
+    }
+
+    def at(g: int, p: Cell) -> "z3.BoolRef":
+        """Hors fenetre = mort (exact, cf. universe_bounds)."""
+        return alive[(g, p)] if p in inside else z3.BoolVal(False)
+
+    solver = z3.Solver()
+
+    # Generation 0 : le motif cherche vit dans la boite.
+    for (x, y) in cells:
+        if not (0 <= x < box_w and 0 <= y < box_h):
+            solver.add(z3.Not(alive[(0, (x, y))]))
+
+    # Regle de Conway, generation par generation.
+    for g in range(n):
+        for p in cells:
+            live_nbrs = z3.Sum(
+                [z3.If(at(g, (p[0] + dx, p[1] + dy)), 1, 0)
+                 for dx, dy in NEIGHBOUR_OFFSETS]
+            )
+            solver.add(
+                alive[(g + 1, p)]
+                == z3.Or(live_nbrs == 3, z3.And(at(g, p), live_nbrs == 2))
+            )
+
+    # Invariant de translation, impose sur toute la fenetre.
+    for p in cells:
+        solver.add(alive[(n, p)] == at(0, (p[0] - v[0], p[1] - v[1])))
+
+    seeds = {p: alive[(0, p)] for p in cells
+             if 0 <= p[0] < box_w and 0 <= p[1] < box_h}
+    solver.add(z3.Or(list(seeds.values())))  # motif non vide
+    return solver, seeds
+
+
+def _model_pattern(model: "z3.ModelRef", seeds: dict[Cell, "z3.BoolRef"]) -> Grid:
+    return {p for p, var in seeds.items() if z3.is_true(model.eval(var, True))}
+
+
+def verify_solution(pattern: Grid, n: int, v: tuple[int, int]) -> bool:
+    """Revalide contre le moteur B1 — l'oracle n'est pas le solveur."""
+    return bool(pattern) and evolve(n, set(pattern)) == shift_v(v, set(pattern))
+
+
+def solve_exact_size(
+    n: int,
+    v: tuple[int, int],
+    box_w: int,
+    box_h: int,
+    k: int,
+    enumerate_all: bool,
+) -> list[tuple[Cell, ...]]:
+    """Toutes les formes normalisees de taille exactement k (ou la premiere)."""
+    solver, seeds = build_solver(n, v, box_w, box_h)
+    solver.add(z3.Sum([z3.If(var, 1, 0) for var in seeds.values()]) == k)
+
+    found: dict[tuple[Cell, ...], tuple[Cell, ...]] = {}
+    while solver.check() == z3.sat:
+        pattern = _model_pattern(solver.model(), seeds)
+        if not verify_solution(pattern, n, v):
+            raise AssertionError(
+                f"modele SAT refute par le moteur de reference : {sorted(pattern)}"
+            )
+        # On publie la forme NORMALISEE, pas le representant brut rendu par
+        # le solveur : deux modeles translates l'un de l'autre sont la meme
+        # forme, et seule la forme canonique est comparable au moteur B1.
+        norm = normalize(pattern)
+        found[norm] = norm
+        # Bloque cette configuration exacte (translations comprises : elles
+        # seront dedupliquees par `normalize`).
+        solver.add(z3.Not(z3.And([
+            var if p in pattern else z3.Not(var) for p, var in seeds.items()
+        ])))
+        if not enumerate_all:
+            break
+    return [found[key] for key in sorted(found)]
+
+
+CANONICAL_GLIDER: tuple[Cell, ...] = tuple(
+    sorted([(0, 0), (1, 0), (1, 2), (2, 0), (2, 1)])
+)
+
+
+def search_minimal(
+    n: int,
+    v: tuple[int, int],
+    box_w: int,
+    box_h: int,
+    max_cells: int,
+    enumerate_all: bool = True,
+) -> dict:
+    """Monte k jusqu'au premier satisfiable. Sinon : temoin d'impossibilite."""
+    started = time.perf_counter()
+    refuted: list[int] = []
+    for k in range(1, max_cells + 1):
+        shapes = solve_exact_size(n, v, box_w, box_h, k, enumerate_all)
+        if shapes:
+            return {
+                "verdict": "FOUND",
+                "min_cells": k,
+                "sizes_refuted": refuted,
+                "count_normalized": len(shapes),
+                "patterns": [list(shape) for shape in shapes],
+                "canonical_glider_present": CANONICAL_GLIDER in set(shapes),
+                "elapsed_s": round(time.perf_counter() - started, 3),
+            }
+        refuted.append(k)
+    return {
+        "verdict": "IMPOSSIBLE",
+        "min_cells": None,
+        "sizes_refuted": refuted,
+        "count_normalized": 0,
+        "patterns": [],
+        "canonical_glider_present": False,
+        "elapsed_s": round(time.perf_counter() - started, 3),
+    }
+
+
+def render(pattern: Sequence[Cell]) -> list[str]:
+    """Rendu ASCII d'un motif normalise (lecture humaine du temoin)."""
+    if not pattern:
+        return []
+    cells = set(pattern)
+    w = max(x for x, _ in cells) + 1
+    h = max(y for _, y in cells) + 1
+    return ["".join("#" if (x, y) in cells else "." for x in range(w))
+            for y in range(h)]
+
+
+def emit_lean(name: str, pattern: Sequence[Cell], n: int,
+              v: tuple[int, int]) -> str:
+    """Rend le certificat Lean d'un motif synthetise, pret a coller.
+
+    Le moteur **produit** le certificat, il ne l'installe pas : le lake
+    `conway_lean` appartient a une autre lane (claim `conway_lean/**` sur
+    #12205). Emettre le texte plutot que l'ecrire garde la frontiere nette
+    tout en livrant la matiere — et c'est de toute facon la bonne forme
+    pour un generateur : l'objet sort avec de quoi se faire verifier par un
+    tiers qui n'est pas lui.
+
+    Conversion de convention : le moteur raisonne en `(x, y)` (colonne,
+    ligne), `Conway.Life` en `(row, col)`. Les cellules sortent triees
+    lexicographiquement (row puis col), ce que `decide` exige pour comparer
+    structurellement les listes.
+    """
+    rows: dict[int, list[int]] = {}
+    for x, y in pattern:
+        rows.setdefault(y, []).append(x)
+    lines = [
+        "   " + ", ".join(f"({r}, {c})" for c in sorted(cols))
+        for r, cols in sorted(rows.items())
+    ]
+    body = ",\n".join(lines).lstrip()
+    dr, dc = v[1], v[0]
+    return "\n".join([
+        f"/-- Motif synthetise par `life_synthesize_sat.py` (SAT), verifie",
+        f"    independamment par le moteur d'enumeration `life_synthesize.py`.",
+        f"    {len(pattern)} cellules, periode {n}, deplacement `({dr}, {dc})`. -/",
+        f"def {name} : Grid :=",
+        f"  [{body}]",
+        "",
+        f"/-- Certificat noyau : `{name}` est un vaisseau de periode {n} et",
+        f"    deplacement `({dr}, {dc})`. -/",
+        f"theorem {name}_spaceship : isSpaceship {name} {n} ({dr}, {dc}) = true := by decide",
+    ])
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Synthese SAT d'un translateur Life verifiant evolve^n T = shift_v T, "
+            "avec minimalite prouvee et temoin d'impossibilite."
+        )
+    )
+    parser.add_argument("--n", type=int, default=4, help="nombre de generations")
+    parser.add_argument("--vx", type=int, default=1, help="composante x du deplacement")
+    parser.add_argument("--vy", type=int, default=-1, help="composante y du deplacement")
+    parser.add_argument("--box", type=int, default=5, help="cote de la boite (carree)")
+    parser.add_argument("--box-w", type=int, default=None, help="largeur (prime --box)")
+    parser.add_argument("--box-h", type=int, default=None, help="hauteur (prime --box)")
+    parser.add_argument(
+        "--max-cells", type=int, default=None,
+        help="taille max exploree (defaut : box_w * box_h)",
+    )
+    parser.add_argument(
+        "--first-only", action="store_true",
+        help="s'arreter a la premiere forme au lieu de toutes les enumerer",
+    )
+    parser.add_argument("--json", action="store_true", help="sortie JSON")
+    parser.add_argument(
+        "--lean", metavar="NOM",
+        help=(
+            "emettre le certificat Lean des motifs trouves, prefixe par NOM "
+            "(le moteur produit le certificat, il n'ecrit dans aucun lake)"
+        ),
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if z3 is None:
+        print(
+            "z3 est requis : pip install z3-solver",
+            file=sys.stderr,
+        )
+        return 2
+
+    box_w = args.box_w if args.box_w is not None else args.box
+    box_h = args.box_h if args.box_h is not None else args.box
+    max_cells = args.max_cells if args.max_cells is not None else box_w * box_h
+    v = (args.vx, args.vy)
+
+    result = search_minimal(
+        args.n, v, box_w, box_h, max_cells, enumerate_all=not args.first_only
+    )
+    result["spec"] = f"evolve^{args.n} T = shift_{v} T"
+    result["box"] = [box_w, box_h]
+    result["max_cells"] = max_cells
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"Spec : {result['spec']}")
+    print(f"Boite {box_w}x{box_h}, tailles explorees 1..{max_cells}")
+    if result["verdict"] == "IMPOSSIBLE":
+        print(
+            f"IMPOSSIBLE — aucune solution. Tailles refutees : "
+            f"{result['sizes_refuted']} (refutation complete, pas un echec de "
+            f"recherche : le solveur est complet sur cet espace borne)."
+        )
+        print(f"({result['elapsed_s']} s)")
+        return 0
+    print(
+        f"FOUND — taille minimale {result['min_cells']} cellules "
+        f"(tailles refutees : {result['sizes_refuted'] or 'aucune'})"
+    )
+    print(f"{result['count_normalized']} forme(s) normalisee(s) a cette taille :")
+    for pattern in result["patterns"]:
+        shape = tuple(map(tuple, pattern))
+        marker = "  <-- glider canonique" if shape == CANONICAL_GLIDER else ""
+        print(f"  {list(shape)}{marker}")
+        for line in render(shape):
+            print(f"      {line}")
+    print(f"({result['elapsed_s']} s)")
+
+    if args.lean:
+        print()
+        print("-- Certificats Lean (a coller dans le lake, cf. emit_lean) :")
+        for i, pattern in enumerate(result["patterns"], start=1):
+            suffix = "" if result["count_normalized"] == 1 else f"_{i}"
+            print()
+            print(emit_lean(f"{args.lean}{suffix}",
+                            [tuple(c) for c in pattern], args.n, v))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lean/tests/test_life_synthesize_sat.py
+++ b/scripts/lean/tests/test_life_synthesize_sat.py
@@ -1,0 +1,297 @@
+"""Tests de `life_synthesize_sat` (Loi II, EPIC #12205, variante -b).
+
+Ce que ces tests etablissent, dans l'ordre de ce qui pourrait faire mentir le
+livrable :
+
+  1. **L'encodage est exact, pas approche.** `universe_bounds` doit contenir
+     strictement l'evolution : si une cellule vivante atteignait le bord de la
+     fenetre, traiter l'exterieur comme mort serait une approximation
+     silencieuse, et toute UNSAT deviendrait ininterpretable.
+  2. **Le solveur est valide contre l'oracle B1.** Chaque motif rendu est
+     rejoue par `evolve`/`shift_v` du moteur d'enumeration — le modele SAT est
+     l'hypothese, le moteur d'origine est la reference.
+  3. **Les deux moteurs sont d'accord la ou les deux savent tourner.** Sur la
+     boite du glider, l'ensemble des formes normalisees doit etre le **meme**.
+     C'est le seul point ou l'enumeration exhaustive peut arbitrer.
+  4. **La minimalite est une refutation.** Les tailles inferieures ne sont pas
+     « non trouvees » : chacune est UNSAT, et le moteur de reference le
+     confirme independamment sur la boite ou il peut encore enumerer.
+  5. **L'impossibilite rend un temoin.** Le critere 4 de #12205 exige de
+     savoir dire « aucune solution », pas de se taire.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from math import comb
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from life_synthesize import evolve, normalize, synthesize
+from life_synthesize_sat import (
+    CANONICAL_GLIDER,
+    emit_lean,
+    render,
+    search_minimal,
+    solve_exact_size,
+    universe_bounds,
+    verify_solution,
+)
+
+pytest.importorskip("z3", reason="z3-solver requis pour la synthese SAT")
+
+GLIDER_SPEC = dict(n=4, v=(1, -1), box_w=4, box_h=4)
+LWSS_SPEC = dict(n=4, v=(2, 0), box_w=5, box_h=5)
+
+
+@pytest.fixture(scope="module")
+def glider() -> dict:
+    return search_minimal(**GLIDER_SPEC, max_cells=8)
+
+
+@pytest.fixture(scope="module")
+def lwss() -> dict:
+    return search_minimal(**LWSS_SPEC, max_cells=10)
+
+
+class TestEncodageExact:
+    """Sans ce bloc, une UNSAT ne voudrait rien dire."""
+
+    def test_la_fenetre_contient_strictement_l_evolution(self):
+        """Aucune cellule vivante ne doit atteindre le bord de la fenetre.
+
+        Si l'evolution touchait le bord, « exterieur = mort » serait une
+        approximation : le modele SAT decrirait un autre univers que Life, et
+        `IMPOSSIBLE` cesserait d'etre une refutation.
+        """
+        n, v = 4, (1, -1)
+        xs, ys = universe_bounds(4, 4, n, v)
+        window = {(x, y) for x in xs for y in ys}
+        border = {(x, y) for (x, y) in window
+                  if x in (xs[0], xs[-1]) or y in (ys[0], ys[-1])}
+        # Le pire cas est le motif qui remplit toute la boite.
+        cells = {(x, y) for x in range(4) for y in range(4)}
+        for _ in range(n + 1):
+            assert not (cells & border), "l'evolution atteint le bord"
+            assert cells <= window
+            cells = evolve(1, cells)
+
+    def test_marge_croit_avec_n_et_v(self):
+        xs_small, _ = universe_bounds(4, 4, 2, (1, 0))
+        xs_large, _ = universe_bounds(4, 4, 6, (3, 0))
+        assert len(xs_large) > len(xs_small)
+
+
+class TestOracleB1:
+    """Le solveur ne se valide pas lui-meme."""
+
+    def test_chaque_motif_est_rejoue_par_le_moteur_de_reference(self, glider, lwss):
+        for result, spec in ((glider, GLIDER_SPEC), (lwss, LWSS_SPEC)):
+            assert result["patterns"], "aucun motif a verifier"
+            for pattern in result["patterns"]:
+                cells = {tuple(c) for c in pattern}
+                assert verify_solution(cells, spec["n"], spec["v"]), (
+                    f"motif refute par le moteur B1 : {sorted(cells)}"
+                )
+
+    def test_verify_solution_rejette_un_motif_faux(self):
+        """Controle negatif : la verification doit savoir dire non."""
+        assert not verify_solution({(0, 0), (1, 0), (2, 0)}, 4, (1, -1))
+        assert not verify_solution(set(), 4, (1, -1))
+
+
+class TestAccordDesDeuxMoteurs:
+    """Le seul endroit ou l'enumeration exhaustive peut arbitrer."""
+
+    def test_memes_formes_normalisees_sur_la_boite_du_glider(self, glider):
+        brute = {normalize(set(p)) for p in synthesize(4, (1, -1), 4, 6)}
+        sat = {tuple(map(tuple, p)) for p in glider["patterns"]}
+        assert sat == brute, (
+            f"desaccord SAT/enumeration\n  SAT seul : {sat - brute}\n"
+            f"  enumeration seule : {brute - sat}"
+        )
+
+    def test_le_glider_canonique_est_retrouve(self, glider):
+        assert glider["canonical_glider_present"]
+        assert CANONICAL_GLIDER in {tuple(map(tuple, p)) for p in glider["patterns"]}
+
+    def test_quatre_phases(self, glider):
+        assert glider["count_normalized"] == 4
+
+
+class TestMinimaliteEstUneRefutation:
+    def test_glider_minimal_a_cinq_cellules(self, glider):
+        assert glider["verdict"] == "FOUND"
+        assert glider["min_cells"] == 5
+        assert glider["sizes_refuted"] == [1, 2, 3, 4]
+
+    def test_les_tailles_refutees_le_sont_vraiment(self):
+        """Confirme la refutation SAT par enumeration exhaustive independante.
+
+        Le solveur dit « aucun motif de taille <= 4 ». L'enumeration, qui peut
+        encore tourner a cette taille, doit dire la meme chose — sinon la
+        refutation serait un bug d'encodage deguise en resultat.
+        """
+        assert synthesize(4, (1, -1), 4, 4) == []
+
+    def test_lwss_minimal_a_neuf_cellules(self, lwss):
+        assert lwss["verdict"] == "FOUND"
+        assert lwss["min_cells"] == 9
+        assert lwss["sizes_refuted"] == [1, 2, 3, 4, 5, 6, 7, 8]
+
+    def test_lwss_est_hors_de_portee_de_l_enumeration(self):
+        """Justifie l'existence de ce moteur, chiffres a l'appui.
+
+        Ce n'est pas « l'enumeration est lente » : c'est le nombre de
+        sous-ensembles qu'elle devrait parcourir pour la seule taille 9.
+        """
+        assert comb(25, 9) == 2_042_975
+        assert sum(comb(25, k) for k in range(1, 10)) > 3_800_000
+
+
+class TestTemoinDImpossibilite:
+    """Critere 4 de #12205 — savoir dire « aucune solution »."""
+
+    def test_au_dela_de_la_vitesse_de_la_lumiere(self):
+        """Deplacement 3 en 2 generations : impossible pour TOUT motif.
+
+        L'information ne se propage que d'une cellule par generation dans Life.
+        Ce cas est donc refutable par un argument independant du solveur : il
+        sert de calibration au verdict IMPOSSIBLE.
+        """
+        result = search_minimal(n=2, v=(3, 0), box_w=3, box_h=3, max_cells=4)
+        assert result["verdict"] == "IMPOSSIBLE"
+        assert result["min_cells"] is None
+        assert result["patterns"] == []
+
+    def test_le_temoin_enumere_ce_qui_a_ete_refute(self):
+        """Un silence n'est pas un temoin : la borne doit etre explicite."""
+        result = search_minimal(n=2, v=(3, 0), box_w=3, box_h=3, max_cells=4)
+        assert result["sizes_refuted"] == [1, 2, 3, 4]
+
+
+class TestSanity:
+    def test_determinisme(self):
+        a = search_minimal(n=4, v=(1, -1), box_w=4, box_h=4, max_cells=5)
+        b = search_minimal(n=4, v=(1, -1), box_w=4, box_h=4, max_cells=5)
+        assert a["patterns"] == b["patterns"]
+        assert a["min_cells"] == b["min_cells"]
+
+    def test_first_only_rend_une_seule_forme(self):
+        shapes = solve_exact_size(4, (1, -1), 4, 4, 5, enumerate_all=False)
+        assert len(shapes) == 1
+        assert verify_solution(set(shapes[0]), 4, (1, -1))
+
+    def test_les_formes_sont_normalisees(self, glider, lwss):
+        for result in (glider, lwss):
+            for pattern in result["patterns"]:
+                cells = [tuple(c) for c in pattern]
+                assert min(x for x, _ in cells) == 0
+                assert min(y for _, y in cells) == 0
+
+    def test_le_glider_canonique_en_est_vraiment_un(self):
+        """Pin de la constante elle-meme, pas seulement de sa forme.
+
+        `CANONICAL_GLIDER` sert de temoin de recoupement avec le moteur
+        B1 : si la constante cessait d'etre un glider, le recoupement
+        continuerait de passer en comparant deux erreurs.
+        """
+        assert verify_solution(set(CANONICAL_GLIDER), 4, (1, -1))
+
+    def test_render_dessine_le_glider(self):
+        """Convention du module : x = colonne, y = ligne."""
+        assert render(CANONICAL_GLIDER) == ["###", "..#", ".#."]
+
+    def test_render_motif_vide(self):
+        assert render(()) == []
+
+
+class TestCertificatLean:
+    """Le generateur produit le certificat ; il n'ecrit dans aucun lake.
+
+    Le lake `conway_lean` appartient a une autre lane (claim
+    `conway_lean/**` sur #12205). Ces tests le **lisent** comme reference
+    externe — ils ne le modifient pas.
+    """
+
+    LAKE = (Path(__file__).resolve().parents[3]
+            / "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean"
+            / "Conway/Life/Spaceships.lean")
+
+    @staticmethod
+    def _def_body(source: str, name: str) -> str:
+        m = re.search(rf"def {name} : Grid :=\n(.*?)\n\n", source, re.S)
+        assert m, f"def {name} introuvable"
+        return m.group(1).strip()
+
+    def test_le_moteur_reproduit_le_lwss_ecrit_a_la_main(self, lwss):
+        """Recoupement inter-substrats le plus fort de ce livrable.
+
+        Le moteur ne recoit que la **specification** (periode 4,
+        deplacement (0, 2), boite 5x5, taille minimale). Il doit en
+        ressortir le texte Lean que l'auteur de `Spaceships.lean` avait
+        ecrit a la main — meme motif, meme mise en forme, meme enonce de
+        theoreme. Si un jour les deux divergent, l'un des deux a tort et
+        ce test le dit.
+        """
+        lake = self.LAKE.read_text(encoding="utf-8")
+        ref = self._def_body(lake, "lwss")
+
+        emitted = [
+            emit_lean("lwss", [tuple(c) for c in p], 4, (2, 0))
+            for p in lwss["patterns"]
+        ]
+        bodies = [self._def_body(text + "\n\n", "lwss") for text in emitted]
+        assert ref in bodies, (
+            "aucune forme synthetisee ne reproduit le `lwss` du lake\n"
+            f"  lake  : {ref}\n  moteur: {bodies}"
+        )
+
+    def test_l_enonce_de_theoreme_emis_est_celui_du_lake(self, lwss):
+        lake = self.LAKE.read_text(encoding="utf-8")
+        assert (
+            "theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by decide"
+            in lake
+        )
+        emitted = emit_lean("lwss", [tuple(c) for c in lwss["patterns"][0]],
+                            4, (2, 0))
+        assert (
+            "theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by decide"
+            in emitted
+        )
+
+    def test_la_seconde_forme_est_absente_du_lake(self, lwss):
+        """Honnetete : ce n'est PAS un vaisseau inedit.
+
+        Les deux formes minimales sont le LWSS et son **miroir** (lignes
+        renversees) : `normalize` quotiente par translation, pas par
+        reflexion. Le miroir ne figure pas dans `Spaceships.lean`, mais le
+        presenter comme une decouverte serait faux.
+        """
+        lake = self.LAKE.read_text(encoding="utf-8")
+        ref = self._def_body(lake, "lwss")
+        bodies = [
+            self._def_body(
+                emit_lean("lwss", [tuple(c) for c in p], 4, (2, 0)) + "\n\n",
+                "lwss")
+            for p in lwss["patterns"]
+        ]
+        autres = [b for b in bodies if b != ref]
+        assert len(autres) == 1, autres
+
+        def grille(body: str) -> list[tuple[int, int]]:
+            return sorted(
+                (int(a), int(b))
+                for a, b in re.findall(r"\((-?\d+), (-?\d+)\)", body)
+            )
+
+        h = max(r for r, _ in grille(ref))
+        miroir = sorted((h - r, c) for r, c in grille(ref))
+        assert grille(autres[0]) == miroir, (
+            "la seconde forme n'est pas le miroir du LWSS : la revendiquer "
+            "comme un vaisseau inedit demanderait une verification neuve"
+        )


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2024:CoursIA-2 — prev: DEEP/research-code #14180

See #12205

## Le grain

Le chantier §4 nomme la variante `-b` : « bornes plus larges, `v` non trivial, minimalité ». Le §5 rappelle le critère d'acceptation qu'il dit qu'on oublie :

> le cas **sans solution** rend un **témoin d'impossibilité**, pas un silence. Le point 4 est celui qu'on oublie : un générateur qui ne sait pas dire « aucune solution, et voici pourquoi » n'a pas franchi le cran, il l'a contourné.

## Pourquoi un second moteur, et pas un élargissement du premier

Le moteur B1 ([#13814](https://github.com/jsboige/CoursIA/pull/13814)) énumère exhaustivement. Son propre body écrivait ses bornes : boîte 4×4, ≤ 6 cellules, soit **14 892** sous-ensembles. Le LWSS en demanderait `C(25,9) = 2 042 975` pour la seule taille 9, **plus de 3,9 millions** cumulées. Ce n'est pas « B1 est lent » : c'est qu'il ne peut ni atteindre l'objet, ni **énoncer** une minimalité — une énumération qui s'arrête n'a rien réfuté.

L'encodage SAT monte la cardinalité exacte `k = 1, 2, 3…`. Les tailles inférieures ne sont pas « non trouvées » : chacune est **UNSAT**, donc réfutée, le solveur étant complet sur l'espace borné.

**Ce qui rend une UNSAT lisible.** La fenêtre vaut `pad = n + max|v| + 1` autour de la boîte. Rien ne peut en sortir en `n` générations, donc « extérieur = mort » est **exact** et non approché. Sans cette borne, le modèle décrirait un autre univers que Life et `IMPOSSIBLE` ne voudrait rien dire. Un test le vérifie sur le pire cas (boîte pleine).

## Résultats mesurés

| Spec | Boîte | Verdict | Minimum | Tailles réfutées | Temps |
|---|---|---|---|---|---|
| glider `evolve⁴ = shift₍₁,₋₁₎` | 4×4 | FOUND, 4 formes | **5** | 1–4 | 6,5 s |
| LWSS `evolve⁴ = shift₍₂,₀₎` | 5×5 | FOUND, 2 formes | **9** | 1–8 | 22 s |
| c/4 orthogonal `evolve⁴ = shift₍₁,₀₎` | 5×5 | **IMPOSSIBLE** | — | 1–12 | 210 s |
| au-delà de c `evolve⁴ = shift₍₅,₀₎` | 4×4 | **IMPOSSIBLE** | — | 1–8 | 19 s |

Le dernier cas sert de **calibration** : l'information ne se propage que d'une cellule par génération, il est donc réfutable par un argument indépendant du solveur. Un moteur qui le déclarerait SAT serait faux, et le test le dirait.

## Le recoupement : le moteur retrouve la main de l'auteur

`--lean NOM` émet le certificat Lean. Sur la **spécification seule** (période 4, déplacement (0,2), boîte 5×5, taille minimale), le moteur ressort le texte que l'auteur de `Conway/Life/Spaceships.lean` avait écrit à la main — **byte-identique**, énoncé de théorème compris :

```lean
def lwss : Grid :=
  [(0, 1), (0, 2), (0, 3), (0, 4),
   (1, 0), (1, 4),
   (2, 4),
   (3, 0), (3, 3)]

theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by decide
```

Un test lit le lake et compare. Si un jour les deux divergent, l'un des deux a tort et le test le dit — c'est un recoupement qui se maintient tout seul, pas une capture d'écran.

## Ce que cette PR refuse de revendiquer

Les **deux** formes minimales du LWSS sont le vaisseau et son **miroir** (lignes renversées) : `normalize` quotiente par translation, **pas** par réflexion. Le miroir est absent de `Spaceships.lean`, et il serait facile de titrer « le solveur découvre un vaisseau inédit ». **Ce serait faux.** Un test le pin explicitement comme miroir du LWSS, pour que la lecture inverse ne puisse pas s'installer plus tard.

De même, le solveur ne se valide pas lui-même : chaque modèle est rejoué par `evolve`/`shift_v` **importés** de B1 — les sémantiques ne sont pas réimplémentées, donc le recoupement est exact et non ressemblant. `verify_solution` a un contrôle négatif (il doit savoir dire non).

## Frontière de lane — le moteur émet, il n'installe pas

`check_lane_claim.py 12205` rend `myia-po-2027:CoursIA` actif sur `conway_lean/**, scripts/lean/life_synthesize.py`. Mon livrable avait naturellement vocation à déposer son certificat dans `Spaceships.lean` : **c'est leur scope, je ne l'écris pas.** Le moteur émet le texte, la lane qui tient le lake décide de l'installer — et c'est de toute façon la bonne forme pour un générateur au sens du chantier : l'objet sort avec de quoi se faire vérifier par un tiers qui n'est pas lui.

`life_synthesize.py` n'est pas modifié non plus (même claim) : il est **importé** comme oracle. Scope amendé et rendu public en [commentaire d'issue](https://github.com/jsboige/CoursIA/issues/12205#issuecomment-5502953570) ; l'organe rend **CLEAR exit 0** sur mes deux chemins.

## Vérifications

- `python -m pytest scripts/lean/tests/test_life_synthesize_sat.py -q` → **22 passed** (48 s)
- Accord des deux moteurs sur la boîte du glider : ensembles de formes normalisées **identiques** (seul endroit où l'énumération exhaustive peut arbitrer)
- Réfutation SAT des tailles ≤ 4 **confirmée indépendamment** par `synthesize(4, (1,-1), 4, 4) == []`
- `scripts/lean/life_synthesize.py` **inchangé** (`git diff origin/main` vide)
- Catalogue **byte-identique à `main`** (0 fichier catalogue touché)
- CPU-only ; `z3-solver` déjà présent, aucune dépendance ajoutée ; `pytest.importorskip("z3")` si absent

### §B — PR touchant la famille Lean

- **B.1 `sorry`** : `count_code_sorry.py --json` → **15** `distinct_code_sorry` tous lakes, `conway_lean` à **1** (pour 169 naïfs — l'illustration même du piège `grep`). **Inchangé** : cette PR touche **0 fichier `.lean`** (`git diff --name-only origin/main -- '*.lean'` → 0).
- **B.2 `lake build`** : **non applicable**, écrit tel quel — aucun fichier `.lean` n'est modifié, aucune cible de build n'est affectée.
- **B.3 `proof-integrity`** : **non applicable**, écrit tel quel — `lean-conway.yml` porte `target-modules: "Conway.KochenSpecker,Conway.FreeWillTheorem"`, qui n'atteint ni `Conway.Life.Spaceships` ni ce livrable, et aucun `.lean` n'est touché de toute façon.

## Périmètre

`See #12205` et non `Closes` : le chantier est une ombrelle dont l'acceptation porte sur **≥ 2 substrats indépendants**. Cette PR en livre un (Life/SAT) et laisse l'ombrelle vivante.

**Adjacence G-VAR-3** : second `DEEP/research-code` consécutif, autorisé au titre de la substance genuinement distincte — #14180 mesurait une dissociation ICT sur un jouet scalaire, celui-ci synthétise des objets combinatoires sous solveur avec réfutation. Théorème différent, substrat différent, résultat différent.
