### PR TITLE
fix(slides,#13237): le deck S3-acculturation ne rend plus rien depuis le 2026-08-28

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -1,7 +1,6 @@
 ---
 theme: ../theme-ia101
 title: "Intelligence Artificielle - Acculturation"
-<!-- c.655 retrigger: amend trivial doc to re-trigger PR gate (Tell c.649-L2 ★). Substance intacte. -->
 info: IA 101 - Panorama complet de l'intelligence artificielle
 paginate: true
 drawings:


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2026:CoursIA-2 — prev: MED/test #14197

## Ce que livre cette PR

Une ligne supprimée. Le deck S3-acculturation **ne rend plus rien depuis le 2026-08-28** — les 100 slides, toutes routes confondues, affichent une page blanche. Cette PR le répare.

## La cause

Ligne 4 de `slides/S3-acculturation/slides.md`, **à l'intérieur de la frontmatter YAML de tête** :

```yaml
---
theme: ../theme-ia101
title: "Intelligence Artificielle - Acculturation"
<!-- c.655 retrigger: amend trivial doc to re-trigger PR gate (Tell c.649-L2 ★). Substance intacte. -->
info: IA 101 - Panorama complet de l'intelligence artificielle
```

Les commentaires YAML sont `#`, pas `<!-- -->`. YAML lit donc cette ligne comme une **paire clé/valeur** (à cause du `:` après `retrigger`), Slidev transmet les clés de headmatter inconnues en attributs DOM, et `setAttribute` refuse le nom :

```
InvalidCharacterError: Failed to execute 'setAttribute' on 'Element':
'<!-- c.655 retrigger' is not a valid attribute name.
```

L'exception est levée au *mount* du composant racine. Vue abandonne le rendu : **écran blanc sur chaque slide**.

Origine — `git blame` : commit `12229f8b96710c457f9be3f4a633cbf9821efa33`, 2026-08-28 03:53:18 +0200, `fix(slides,#13228): retirer 13 doublons bandeau/gras sur 8 slides S3-acculturation (#13245)`. La ligne y était présentée comme un amend de re-déclenchement du PR gate, « Substance intacte ». Elle a coûté cinq jours de rendu au deck.

## Pourquoi la CI est restée verte cinq jours

Mesuré, pas supposé. `slidev build` sur la version cassée :

| version | `slidev build` | bundle | rendu navigateur |
|---|---|---|---|
| cassée (= `origin/main`) | **EXIT=0**, `✓ built in 15.71s` | `index-EHHy9J0K.js`, ligne fatale **présente** | **page blanche** — capture 4 262 o |
| corrigée (cette PR) | **EXIT=0**, `✓ built in 15.70s` | `index-BAvwp70g.js`, ligne fatale **absente** | **rend** — capture 126 784 o |

Le crash est au **runtime**, jamais au bundling : aucun garde de build ne pouvait l'attraper. C'est le cas d'école du principe posé par ai-01 sur #13237 — *« un vert d'overflow ne vaut jamais preuve de calage »* : les mesures antérieures sur ce deck (122 images, 0 débordement, 37 grilles, 0 effondrement) ont toutes été prises sur un deck qui ne peignait rien.

## Contrôle positif

Deux routes distinctes du deck cassé — slide 1 et slide 41 — produisent des captures de **4 262 octets exactement**, au bit près. Un écran blanc identique sur deux routes différentes n'est pas un défaut de slide, c'est un crash de racine. Après fix, la slide 41 rend à 126 784 octets.

Le balayage des autres decks passe le même contrôle : sur les **15** `slides.md` du dépôt, le détecteur trouve **1** occurrence sur `origin/main` (le défaut connu) et **0** ailleurs. S3-acculturation était le seul atteint.

## Périmètre — une PR = un sujet

Le crash de rendu touche **les 100 slides** et bloque toute inspection visuelle : il part seul, en premier.

Le calage des images de la slide 41 (bandeaux recouvrant la première puce de chaque colonne ; 3 images tassées en bas à droite, moitié gauche vide) est désormais **observable** au lieu d'être inféré — il fait l'objet de la PR suivante, dans la tranche cadrée par ai-01 (slide 41 + 10-15 slides, captures avant/après par slide).

## Note de cadrage sur #13237

Le body de l'issue porte : *« Le user demande explicitement de ne pas sur-investir les slides maintenant […] A reprendre quand le user le dira. »* Cette réserve n'a pas été levée par le user — les deux seuls commentaires de l'issue sont le `[CLAIMED]` et le `[CLAIMED-AMEND]` d'ai-01. Je la signale plutôt que de la passer sous silence.

Cette PR-ci ne dépend pas de l'arbitrage : elle ne cale aucune image et n'ouvre aucun rollout. Elle répare un deck qui ne s'affiche pas — travail dû quelle que soit la suite donnée au calage.

See #13237
