### PR TITLE
fix(qc,#14142): Phase E — la cause du remplissage nul est la devise de compte, pas un guard manquant

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -440,6 +440,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pourquoi une deuxieme version de l'algorithme\n",
+    "\n",
+    "La cellule precedente porte **deux** chaines : `LEAN_ALGORITHM`, la strategie enseignee, et `LEAN_ALGORITHM_B1`, la meme strategie **instrumentee** de compteurs de diagnostic. Toutes deux exigent `price < BB_lower` **ET** `RSI < 35` pour entrer en position.\n",
+    "\n",
+    "La cellule suivante definit `LEAN_ALGORITHM_B2`, identique a B1 sur tout **sauf un operateur** : la condition d'entree y devient `price < BB_lower` **OU** `RSI < 35`. Cette variante n'est pas une amelioration proposee — c'est un **instrument de mesure**. Elle repond a une question precise : l'absence de trades vient-elle d'une conjonction trop stricte pour etre satisfaite, ou d'autre chose ?\n",
+    "\n",
+    "Comparer deux programmes qui ne different que par **un seul element** est ce qui rend la reponse attribuable : si le comportement change, on sait a quoi l'imputer. La section 3 montre ou cette methode a mene — et pourquoi la reponse s'est revelee etre « autre chose »."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "qc-py-40-b2-lean",
@@ -1339,6 +1352,19 @@
     "\n",
     "result = None  # TODO etudiant : remplacer par le detecteur de deviation\n",
     "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Du detecteur d'alerte au rapport quotidien\n",
+    "\n",
+    "L'exercice ci-dessus demande de **detecter** une derive. La cellule suivante montre ce qu'on fait du resultat une fois detecte : un **rapport quotidien** qui condense une journee de paper trading en quatre nombres (valeur du portefeuille, nombre de trades, erreurs, positions ouvertes).\n",
+    "\n",
+    "Les deux repondent a des besoins distincts, et un systeme de paper trading a besoin des deux. Le detecteur repond a « dois-je aller regarder ? » : il se tait tant que rien ne depasse le seuil. Le rapport repond a « qu'est-ce qui s'est passe ? » : il sort tous les jours, y compris quand tout va bien. Sans detecteur, on lit des rapports d'apparence saine pendant que la strategie derive ; sans rapport, on ne sait pas ce qui a change le jour ou l'alerte tombe.\n",
+    "\n",
+    "La fonction ci-dessous est un **exemple illustre a valeurs simulees**, pas la sortie d'un deploiement reel — la lecture qui suit la cellule le detaille."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -5,19 +5,6 @@
    "execution_count": 1,
    "id": "9be7293c",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:53.922114Z",
-     "iopub.status.busy": "2026-09-01T21:02:53.921813Z",
-     "iopub.status.idle": "2026-09-01T21:02:53.925501Z",
-     "shell.execute_reply": "2026-09-01T21:02:53.924955Z"
-    },
-    "papermill": {
-     "duration": 0.009169,
-     "end_time": "2026-09-01T21:02:53.926388",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:53.917219",
-     "status": "completed"
-    },
     "tags": [
      "injected-parameters"
     ]
@@ -32,13 +19,6 @@
    "cell_type": "markdown",
    "id": "0bfe4aa3",
    "metadata": {
-    "papermill": {
-     "duration": 0.002556,
-     "end_time": "2026-09-01T21:02:53.931789",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:53.929233",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -68,19 +48,6 @@
    "execution_count": 2,
    "id": "7cf1a8c4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:53.938565Z",
-     "iopub.status.busy": "2026-09-01T21:02:53.938153Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.600611Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.600191Z"
-    },
-    "papermill": {
-     "duration": 0.667007,
-     "end_time": "2026-09-01T21:02:54.601329",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:53.934322",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -88,7 +55,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "QC-Py-40 Paper Trading Binance - 2026-09-01\n"
+      "QC-Py-40 Paper Trading Binance - 2026-09-02\n"
      ]
     }
    ],
@@ -117,13 +84,6 @@
    "cell_type": "markdown",
    "id": "5a3bfb5d",
    "metadata": {
-    "papermill": {
-     "duration": 0.00262,
-     "end_time": "2026-09-01T21:02:54.606619",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.603999",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -149,19 +109,6 @@
    "execution_count": 3,
    "id": "cabb4d3d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.614386Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.614117Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.618105Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.617685Z"
-    },
-    "papermill": {
-     "duration": 0.009788,
-     "end_time": "2026-09-01T21:02:54.618828",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.609040",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -205,13 +152,6 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-config",
    "metadata": {
-    "papermill": {
-     "duration": 0.002422,
-     "end_time": "2026-09-01T21:02:54.623876",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.621454",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -226,13 +166,6 @@
    "cell_type": "markdown",
    "id": "ad0c6f29",
    "metadata": {
-    "papermill": {
-     "duration": 0.002857,
-     "end_time": "2026-09-01T21:02:54.629274",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.626417",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -256,19 +189,6 @@
    "execution_count": 4,
    "id": "a28a5593",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.635283Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.635062Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.639671Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.639286Z"
-    },
-    "papermill": {
-     "duration": 0.008742,
-     "end_time": "2026-09-01T21:02:54.640463",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.631721",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -524,19 +444,6 @@
    "execution_count": 5,
    "id": "qc-py-40-b2-lean",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.648365Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.648072Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.652227Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.651823Z"
-    },
-    "papermill": {
-     "duration": 0.008497,
-     "end_time": "2026-09-01T21:02:54.652925",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.644428",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -680,13 +587,6 @@
    "cell_type": "markdown",
    "id": "a408fdba",
    "metadata": {
-    "papermill": {
-     "duration": 0.002555,
-     "end_time": "2026-09-01T21:02:54.658117",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.655562",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -713,19 +613,6 @@
    "execution_count": 6,
    "id": "1bd078ca",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.664438Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.664134Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.670961Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.670574Z"
-    },
-    "papermill": {
-     "duration": 0.011019,
-     "end_time": "2026-09-01T21:02:54.671659",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.660640",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -765,9 +652,9 @@
       "  Avg Trade Duration: N/A (0 trades filled)\n",
       "\n",
       "Verdict : INCONCLUSIVE\n",
-      "Raison : 4 backtests executes sur QC Cloud avec fee model 0.1%, warmup timedelta(days=2) AVANT indicators, RSI threshold assoupli a 40 (vs 35). Aucun trade rempli. La condition d'entree (price < lower BB AND RSI < 40) est trop stricte pour la granularite Minute sur 2021-2024. Cause profonde = overfitting de la strategie au cas trivial (paper trading showcase) sans validation sur donnees reelles.\n",
+      "Raison : 4 backtests executes sur QC Cloud avec fee model 0.1%, warmup timedelta(days=2) AVANT indicators, RSI threshold assoupli a 40 (vs 35). Aucun trade rempli. [FALSIFIE en Phase D/E -- conserve pour la trace] L'explication avancee alors etait que la condition d'entree (price < lower BB AND RSI < 40) serait trop stricte pour la granularite Minute. La mesure la contredit dans la cellule meme qui la porte : v4 rapporte 151 653 ordres emis, ce qui est incompatible avec une condition qui ne se declencherait pas. Cause reelle etablie en Phase E : devise de compte USD contre paires reglees en USDT.\n",
       "\n",
-      "Path forward : Pour #13117 : accepter INCONCLUSIVE comme verdict final OU dispatcher vers QC-strategy-analyzer subagent pour parameter sweep (BB period 10-30, RSI threshold 30-45, OR au lieu de AND sur entry). Le narrow worker (30 min) ne peut pas iterer sur cette grille dans son cycle budget.\n",
+      "Path forward : [SUPERSEDE par les Phases D et E] La voie envisagee alors -- balayer la grille de parametres (BB period 10-30, RSI 30-45, OR au lieu de AND) -- aurait ete inutile : B2 a effectivement teste OR et a produit 3,2x PLUS d'ordres pour toujours zero fill. Aucun reglage de la condition d'entree n'aurait debloque le remplissage, parce que le blocage n'etait pas la. Voir la cellule Phase D/E.\n",
       "\n",
       "Detail dans _results/QC-Py-40-Re-Phase-C.json (4 attempts trail).\n"
      ]
@@ -779,16 +666,20 @@
     "# AUCUN trade execute. Voir `_results/QC-Py-40-Re-Phase-C.json` pour le\n",
     "# diagnostic detaille (warmup order, fee model API, entry condition).\n",
     "#\n",
-    "# Verdict honnete : la strategie mean-reversion Bollinger Bands specifiee\n",
-    "# (BB 20-period 2-sigma + RSI 14 <40 entry sur donnees Minute 2021-2024)\n",
-    "# ne produit AUCUN fill sur la periode. Cause probable : la condition\n",
-    "# d'entree (price < lower BB AND RSI < 40 simultanement) est trop stricte\n",
-    "# pour la granularite Minute sur 4 ans.\n",
+    "# Verdict de l'epoque : la strategie ne produit AUCUN fill sur la periode,\n",
+    "# la condition d'entree etant supposee \"trop stricte\" pour la granularite\n",
+    "# Minute sur 4 ans.\n",
     "#\n",
-    "# Scope narrow worker (30 min/cycle) ne permet pas d'iterer sur la grille\n",
-    "# de parametres (BB period, RSI threshold, OR au lieu de AND). Escalade\n",
-    "# ai-01 pour QC-strategy-analyzer subagent ou acceptation INCONCLUSIVE\n",
-    "# comme verdict final de #13117.\n",
+    "# ATTENTION -- CE VERDICT EST FALSIFIE. Il est conserve ici tel qu'il a ete\n",
+    "# ecrit, parce que la maniere dont il a ete infirme est le vrai contenu\n",
+    "# pedagogique de la section. Les Phases D et E (cellules plus bas) le\n",
+    "# reprennent sur mesure :\n",
+    "#   - \"la condition ne se declenche jamais\" est faux : elle se declenche\n",
+    "#     151 653 fois en AND (v4/B1) et 487 172 fois en OR (B2) ;\n",
+    "#   - la cause du remplissage nul n'etait pas le signal mais la DEVISE DE\n",
+    "#     COMPTE (USD contre paires reglees en USDT, sur un compte sans marge).\n",
+    "# Ne pas reutiliser le champ `verdict_reason` ci-dessous comme une\n",
+    "# conclusion : lire la cellule Phase D/E qui suit.\n",
     "backtest_results = {\n",
     "    \"strategy\": \"Binance Mean-Reversion BB (20, 2.0)\",\n",
     "    \"period\": \"2021-01-01 to 2024-12-31\",\n",
@@ -835,16 +726,19 @@
     "    \"verdict_reason\": (\n",
     "        \"4 backtests executes sur QC Cloud avec fee model 0.1%, warmup timedelta(days=2) \"\n",
     "        \"AVANT indicators, RSI threshold assoupli a 40 (vs 35). Aucun trade rempli. \"\n",
-    "        \"La condition d'entree (price < lower BB AND RSI < 40) est trop stricte pour \"\n",
-    "        \"la granularite Minute sur 2021-2024. Cause profonde = overfitting de la \"\n",
-    "        \"strategie au cas trivial (paper trading showcase) sans validation sur \"\n",
-    "        \"donnees reelles.\"\n",
+    "        \"[FALSIFIE en Phase D/E -- conserve pour la trace] L'explication avancee alors \"\n",
+    "        \"etait que la condition d'entree (price < lower BB AND RSI < 40) serait trop \"\n",
+    "        \"stricte pour la granularite Minute. La mesure la contredit dans la cellule \"\n",
+    "        \"meme qui la porte : v4 rapporte 151 653 ordres emis, ce qui est incompatible \"\n",
+    "        \"avec une condition qui ne se declencherait pas. Cause reelle etablie en \"\n",
+    "        \"Phase E : devise de compte USD contre paires reglees en USDT.\"\n",
     "    ),\n",
     "    \"path_forward\": (\n",
-    "        \"Pour #13117 : accepter INCONCLUSIVE comme verdict final OU dispatcher vers \"\n",
-    "        \"QC-strategy-analyzer subagent pour parameter sweep (BB period 10-30, \"\n",
-    "        \"RSI threshold 30-45, OR au lieu de AND sur entry). Le narrow worker (30 min) \"\n",
-    "        \"ne peut pas iterer sur cette grille dans son cycle budget.\"\n",
+    "        \"[SUPERSEDE par les Phases D et E] La voie envisagee alors -- balayer la grille \"\n",
+    "        \"de parametres (BB period 10-30, RSI 30-45, OR au lieu de AND) -- aurait ete \"\n",
+    "        \"inutile : B2 a effectivement teste OR et a produit 3,2x PLUS d'ordres pour \"\n",
+    "        \"toujours zero fill. Aucun reglage de la condition d'entree n'aurait debloque \"\n",
+    "        \"le remplissage, parce que le blocage n'etait pas la. Voir la cellule Phase D/E.\"\n",
     "    ),\n",
     "}\n",
     "\n",
@@ -931,12 +825,17 @@
     "# Tell c.866-L4 (corrige c.909) : les ordres des deux variantes sont emis puis non\n",
     "# remplis -- pour B1 (151653) comme pour B2 (487172). L'hypothese \"B2 discriminant\n",
     "# par 0 entry\" tombe avec la mesure corrigee : B2 emet PLUS que B1, pas moins.\n",
-    "# Cause-racine restant la plus probable : `liquidate(sym)` appele sans guard\n",
-    "# `if self.portfolio[sym].invested:`, qui soumet un ordre a chaque barre sur une\n",
-    "# position vide. Elle explique un volume d'ordres proportionnel aux barres traitees\n",
-    "# et un remplissage nul, dans les deux variantes. Verification directe (lecture des\n",
-    "# ordres un par un) hors scope Phase D : elle demande read_backtest_orders, que le\n",
-    "# MCP qc-mcp-lite n'expose pas. Suivi : issue #14142.\n",
+    "# Cause-racine avancee en Phase D : `liquidate(sym)` appele sans guard\n",
+    "# `if self.portfolio[sym].invested:`. Elle etait explicitement marquee \"probable,\n",
+    "# NON VERIFIEE\".\n",
+    "#\n",
+    "# ECARTEE c.931 (Phase E) : la verification l'infirme. Les 6 appels liquidate() du\n",
+    "# notebook sont deja tous gardes par `if self.portfolio[sym].invested:` -- lignes\n",
+    "# 166/172/179 (LEAN_ALGORITHM), 291/295/300 (B1), 414/418/423 (B2). Le guard\n",
+    "# n'a jamais manque. Un correctif \"ajouter le guard\" aurait ete du travail fabrique.\n",
+    "#\n",
+    "# CAUSE REELLE (Phase E, backtest B3) : la devise de compte. Voir la cellule\n",
+    "# Phase D/E ci-dessous.\n",
     "#\n",
     "# Le notebook reste pedagogique (code correct, pas PNL).\n"
    ]
@@ -945,52 +844,169 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-backtest",
    "metadata": {
-    "papermill": {
-     "duration": 0.002703,
-     "end_time": "2026-09-01T21:02:54.677228",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.674525",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : backtest Re-Phase C INCONCLUSIVE (issue #13117, c.701)\n",
+    "### Lecture du resultat : backtest Re-Phase C INCONCLUSIVE (issue #13117, c.701)\n",
     "\n",
-    "La cellule precedente affiche maintenant le verdict **INCONCLUSIVE** issu de 4 executions reelles sur QC Cloud (v3-v6), pas des placeholders. Chaque tentative a reussi a compiler et a executer sur le moteur LEAN, mais **aucune n'a produit un seul trade rempli** :\n",
+    "La cellule precedente affiche le verdict **INCONCLUSIVE** issu de 4 executions reelles sur QC Cloud (v3-v6), pas des placeholders. Chaque tentative a reussi a compiler et a executer sur le moteur LEAN, mais **aucune n'a produit un seul trade rempli** :\n",
     "\n",
     "- **v3** (close vs price + warmup manquant) : 181K ordres envoyes, 0 fill\n",
     "- **v4** (set_warm_up APRES indicators) : 151K ordres, 0 fill\n",
     "- **v5** (warmup corrige, mais crash sur `self.trades` diagnostic) : Runtime Error 2025-01-01\n",
-    "- **v6** (warmup corrige + sans crash) : 0 ordres envoyes (entry condition trop stricte)\n",
+    "- **v6** (warmup corrige + sans crash) : 0 ordres envoyes\n",
     "\n",
-    "**Lecture honnete de l'etat Re-Phase C** : la strategie mean-reversion Bollinger Bands specifiee (BB 20-period 2-sigma + RSI 14 < 40 simultanement sur donnees Minute 2021-2024) **ne produit aucun fill**. La condition d'entree est trop stricte pour la granularite Minute sur 4 ans : il faut que le prix touche la bande inferieure ET que le RSI passe sous 40 dans la meme barre minute, ce qui est rare.\n",
+    "**Ce que ces quatre lignes disent deja, et qu'on n'a pas lu.** Un backtest qui envoie 151 000 ordres et n'en remplit aucun n'est pas un backtest ou \"la condition d'entree ne se declenche jamais\" : c'est un backtest ou elle se declenche 151 000 fois et ou quelque chose empeche l'execution. Les deux enonces sont incompatibles, et ils cohabitaient dans la meme cellule. L'explication \"condition trop stricte\" a tenu quatre iterations parce qu'elle etait plausible, pas parce qu'elle etait compatible avec le chiffre affiche juste au-dessus d'elle.\n",
     "\n",
-    "**Ce que cet INCONCLUSIVE revele** : la strategie etait calibree pour illustrer le **workflow** paper trading (comment lancer un backtest QC, comment lire ses sorties, comment brancher un fee model, comment deployer sur le testnet Binance), pas pour produire un edge rentable. La Phase B (PR #13153) avait corrige le masquage `self.bb` / `self.rsi`, mais n'avait pas valide la **faisabilite** du signal sur 4 ans de donnees Minute.\n",
+    "**Ce que le blocage revele quand meme sur la strategie** : elle a ete calibree pour illustrer le **workflow** paper trading (lancer un backtest QC, lire ses sorties, brancher un fee model, deployer sur le testnet Binance), pas pour produire un edge rentable. La Phase B (PR #13153) avait corrige le masquage `self.bb` / `self.rsi`, mais n'avait valide ni la faisabilite du signal, ni -- on le verra -- la coherence du compte avec les paires tradees.\n",
     "\n",
-    "**Scope narrow worker (30 min/cycle) ne permet pas d'iterer** sur la grille de parametres (BB period 10-30, RSI threshold 30-45, OR au lieu de AND sur entry). Le narrow worker a fait 4 tentatives et a epuise la fenetre budget. La voie juste est : escalader a ai-01 pour dispatch vers `qc-strategy-analyzer` (async, run_in_background) qui peut iterer sur 5-10 configurations en ~30-45 min, OU accepter INCONCLUSIVE comme verdict final de #13117.\n",
+    "**Distinction pedagogique preservee.** Un verdict INCONCLUSIVE **est** une mesure : il est strictement plus informatif qu'un placeholder `PENDING -- Phase C`. On sait que le code compile, que les indicateurs se remplissent, que le warmup fonctionne. Ce qu'on ne savait pas encore, c'est *pourquoi* les ordres ne se remplissaient pas -- et c'est l'objet des deux phases suivantes, qui reprennent ce diagnostic et le corrigent sur mesure.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Phases D et E : instrumenter, puis trouver la vraie cause\n",
     "\n",
-    "**Distinction pedagogique preservee** : la methode de lecture reste transferable. Un verdict INCONCLUSIVE (pas de trades) **est** une mesure : elle dit que la strategie ne genere pas de signaux a la granularite Minute sur cette periode. C'est strictement plus informatif qu'un placeholder `PENDING -- Phase C` -- on sait que le code compile, que les indicateurs se remplissent, que le warmup fonctionne, mais que la logique d'entree ne se declenche jamais. La section suivante tracera la courbe d'equity reelle (constante, $10,000) et l'histogramme (vide) sans maquiller.</cell>\n"
+    "Les phases D et E reprennent le verdict ci-dessus et le soumettent a la mesure. Elles illustrent une methode transferable : **quand une explication et un chiffre se contredisent, c'est l'explication qui cede**.\n",
+    "\n",
+    "**Phase D -- discriminer par une variable.** Plutot que de balayer une grille de parametres, on change **une seule chose** et on regarde ce que le compte d'ordres devient.\n",
+    "\n",
+    "| Run | Condition d'entree | Ordres emis | Fills |\n",
+    "|---|---|---|---|\n",
+    "| **B1** | `price < BB_lower` **AND** `RSI < 35` | 151 653 | 0 |\n",
+    "| **B2** | `price < BB_lower` **OR** `RSI < 35` | 487 172 | 0 |\n",
+    "\n",
+    "Le rapport 487 172 / 151 653 = **3,2** est exactement ce qu'on attend en relachant une conjonction : la condition OR est satisfaite par strictement plus de barres que la condition AND. Donc l'hypothese *\"la conjonction stricte est trop rare\"* est **falsifiee** -- relacher la conjonction multiplie les ordres et ne produit toujours aucun fill. Le blocage n'est pas le **signal**, c'est le **remplissage**.\n",
+    "\n",
+    "**Phase E -- localiser le remplissage.** L'hypothese suivante etait un `liquidate()` sans garde, qui aurait re-emis un ordre a chaque barre sur une position vide. Elle etait notee *probable, non verifiee*. La verification l'infirme : les six appels `liquidate()` du notebook sont **deja tous gardes** par `if self.portfolio[sym].invested:`. Corriger ce \"bug\" aurait produit un correctif sans objet.\n",
+    "\n",
+    "L'hypothese retenue porte sur la **devise du compte** : les paires `BTCUSDT` et `ETHUSDT` se reglent en **USDT**, alors que `set_cash(10000)` finance le compte dans la devise LEAN par defaut, l'**USD**. En `AccountType.CASH` -- c'est-a-dire **sans marge** -- LEAN exige le solde de la devise de cotation pour acheter. Ce solde est nul, donc chaque ordre d'achat est rejete. Et comme la position ne devient jamais `invested`, la garde d'entree reste ouverte : `set_holdings` est re-emis a la barre suivante, puis a la suivante. Le compte d'ordres ne mesure pas un bug de boucle, il mesure **le nombre de barres qui satisfont la condition**.\n",
+    "\n",
+    "**Le test.** B3 = B1 avec **une seule ligne changee** :\n",
+    "\n",
+    "```python\n",
+    "self.set_account_currency(\"USDT\")   # AVANT set_cash\n",
+    "self.set_cash(10000)\n",
+    "```\n",
+    "\n",
+    "Prediction falsifiable posee avant le run : *si l'hypothese est juste, des fills apparaissent ; sinon elle tombe, et on le dit.* La cellule suivante lit le resultat depuis le fichier de mesures, sans le retaper.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Phases D et E -- mesures QC Cloud (projet 35674722) ===\n",
+      "\n",
+      "Run  Backtest                                     Ordres   Resultat net\n",
+      "------------------------------------------------------------------------------\n",
+      "B1   B1_PhaseD_instrumented                      151 653   0%\n",
+      "B2   B2 OR condition (Phase D B2 narrow wor      487 172   0%\n",
+      "B3   B3_PhaseE_account_currency_USDT             917 199   -99.880%\n",
+      "\n",
+      "--- B3 : la variable changee ---\n",
+      "self.set_account_currency('USDT') place AVANT set_cash(10000). Rien d'autre ne change : meme condition d'entree AND, memes indicateurs BB(20,2.0)/RSI(14), meme resolution Minute, meme fee model 0.1%, meme AccountType.CASH.\n",
+      "\n",
+      "--- Verdict de l'hypothese : HYPOTHESE CONFIRMEE ---\n",
+      "Deux signaux concordants, tous deux absents de B1 et B2. (1) La devise du P&L bascule de $ a ₮ (USDT) : la configuration a bien pris effet. (2) Les statistiques cessent d'etre nulles -- sharpeRatio -2.961, drawdown 99.900%, totalNetProfit -99.880%, netProfitAbsolute ₮-9,986.50. Un compte qui perd 99,88% de sa valeur a NECESSAIREMENT execute des trades ; B1 et B2 rendaient 0% partout, ce qui est la signature du remplissage nul.\n",
+      "\n",
+      "--- Ce que la correction revele ensuite ---\n",
+      "Une fois le remplissage debloque, la strategie ne devient pas rentable -- elle devient ruineuse : 917 199 ordres sur 4 ans, soit ~628 ordres par jour de bourse, a 0,1% de frais par ordre. Le capital passe de ₮10 000 a ₮13,50. Le probleme reel du notebook n'etait donc pas 'la condition d'entree ne se declenche jamais' (elle se declenche constamment) mais un sur-trading massif : `set_holdings` est appele a chaque barre Minute qui satisfait la condition, sans aucun controle de frequence.\n",
+      "\n",
+      "--- Hypothese ecartee en chemin ---\n",
+      "`liquidate(sym)` sans guard `if self.portfolio[sym].invested:` -- ECARTEE par verification mecanique du source : les 6 appels liquidate du notebook sont tous gardes. L'hypothese avait ete avancee comme 'probable, non verifiee' ; la verification l'infirme.\n",
+      "\n",
+      "--- Ce qui reste ouvert ---\n",
+      "  * RESTE OUVERT : le sur-trading. 917 199 ordres pour ₮10 000 de capital est le vrai defaut pedagogique de la strategie. Piste : throttling (une entree par jour maximum), ou passage en resolution Hour, ou un filtre de cooldown apres sortie. C'est un grain distinct, a traiter en PR separee -- il change la strategie, pas le diagnostic.\n",
+      "  * RESTE OUVERT : les compteurs custom (n_bars_total, n_either, B1_DIAG) sortent par `Log()`, que le MCP qc-mcp-lite n'expose pas. Leur lecture demande l'interface QC Cloud (RECOVERABLE-USER-HAND). Ils ne sont plus necessaires au diagnostic, mais confirmeraient la cardinalite des barres.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Phases D et E : les resultats sont LUS depuis le fichier de mesures,\n",
+    "# jamais retapes a la main. Le fichier est ecrit a partir des reponses de\n",
+    "# l'API QuantConnect ; le notebook n'en est que le lecteur.\n",
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "CANDIDATS = [\n",
+    "    Path(\"../_results/QC-Py-40-Phase-D.json\"),\n",
+    "    Path(\"_results/QC-Py-40-Phase-D.json\"),\n",
+    "    Path(\"MyIA.AI.Notebooks/QuantConnect/_results/QC-Py-40-Phase-D.json\"),\n",
+    "]\n",
+    "chemin = next((p for p in CANDIDATS if p.exists()), None)\n",
+    "\n",
+    "if chemin is None:\n",
+    "    print(\"Fichier de mesures introuvable depuis\", Path.cwd())\n",
+    "    print(\"Attendu : MyIA.AI.Notebooks/QuantConnect/_results/QC-Py-40-Phase-D.json\")\n",
+    "    phase_d = None\n",
+    "else:\n",
+    "    phase_d = json.loads(chemin.read_text(encoding=\"utf-8\"))\n",
+    "\n",
+    "    runs = phase_d[\"results_summary\"]\n",
+    "    print(\"=== Phases D et E -- mesures QC Cloud (projet %s) ===\" % phase_d[\"qc_project_id\"])\n",
+    "    print()\n",
+    "    print(\"%-4s %-38s %12s   %s\" % (\"Run\", \"Backtest\", \"Ordres\", \"Resultat net\"))\n",
+    "    print(\"-\" * 78)\n",
+    "    for nom in (\"B1\", \"B2\", \"B3\"):\n",
+    "        r = runs[nom]\n",
+    "        print(\"%-4s %-38s %12s   %s\" % (\n",
+    "            nom,\n",
+    "            r[\"backtest_name\"][:38],\n",
+    "            format(r[\"totalOrders\"], \",d\").replace(\",\", \" \"),\n",
+    "            r[\"statistics\"][\"totalNetProfit\"],\n",
+    "        ))\n",
+    "    print()\n",
+    "\n",
+    "    b3 = runs[\"B3\"]\n",
+    "    print(\"--- B3 : la variable changee ---\")\n",
+    "    print(b3[\"variable_unique_changee_vs_B1\"])\n",
+    "    print()\n",
+    "    print(\"--- Verdict de l'hypothese : %s ---\" % b3[\"verdict\"])\n",
+    "    print(b3[\"preuve\"])\n",
+    "    print()\n",
+    "    print(\"--- Ce que la correction revele ensuite ---\")\n",
+    "    print(b3[\"second_enseignement\"])\n",
+    "    print()\n",
+    "    print(\"--- Hypothese ecartee en chemin ---\")\n",
+    "    print(phase_d[\"cause_racine_etablie_c931\"][\"hypothese_ecartee\"])\n",
+    "    print()\n",
+    "    print(\"--- Ce qui reste ouvert ---\")\n",
+    "    for item in phase_d[\"path_forward\"]:\n",
+    "        if item.startswith(\"RESTE OUVERT\"):\n",
+    "            print(\"  *\", item)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : ce que B3 a tranche\n",
+    "\n",
+    "Les deux signaux qui comptent dans la sortie ci-dessus sont **absents de B1 et B2**, et c'est leur apparition simultanee qui fait la preuve.\n",
+    "\n",
+    "1. **La devise du P&L bascule de `$` a `₮`.** C'est le controle que la configuration a bien pris effet -- sans lui, un resultat inchange serait indiscernable d'un `set_account_currency` sans effet.\n",
+    "2. **Les statistiques cessent d'etre nulles.** B1 et B2 rendaient `0%` partout : c'est la signature du remplissage nul. B3 rend un Sharpe de **-2,961**, un drawdown de **99,900 %** et un resultat net de **-99,880 %**. Un compte qui perd 99,88 % de sa valeur a necessairement execute des trades.\n",
+    "\n",
+    "L'hypothese de la devise est donc **confirmee**. Elle n'etait pas la premiere : la precedente -- un `liquidate()` sans garde -- a ete ecartee par une lecture du source, pas par un run. Les deux ont coute le meme effort ; seule la seconde a survecu a la verification.\n",
+    "\n",
+    "**Et le resultat corrige est pire que le blocage.** Une fois le remplissage debloque, la strategie emet **917 199 ordres en quatre ans**, soit environ 628 par jour de bourse, chacun ponctionne de 0,1 % de frais. Le capital passe de ₮10 000 a ₮13,50. Le defaut reel du notebook n'etait donc ni \"la condition ne se declenche jamais\", ni un guard manquant : c'est un **sur-trading massif**, `set_holdings` etant appele a chaque barre Minute qui satisfait la condition, sans le moindre controle de frequence.\n",
+    "\n",
+    "C'est le point pedagogique de toute la section. Un backtest a `0 %` ressemble a une strategie neutre ; il cachait ici une strategie qui detruit 99,9 % du capital. **Un blocage technique peut masquer un desastre strategique**, et la seule facon de le savoir est de lever le blocage. Le correctif du sur-trading (throttling, resolution horaire, cooldown apres sortie) change la strategie elle-meme : il releve d'un travail distinct, trace comme tel dans le fichier de mesures.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "e3635270",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.683291Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.683111Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.817587Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.816993Z"
-    },
-    "papermill": {
-     "duration": 0.138672,
-     "end_time": "2026-09-01T21:02:54.818457",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.679785",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1047,13 +1063,6 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-equity",
    "metadata": {
-    "papermill": {
-     "duration": 0.003025,
-     "end_time": "2026-09-01T21:02:54.824812",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.821787",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1072,13 +1081,6 @@
    "cell_type": "markdown",
    "id": "7146d537",
    "metadata": {
-    "papermill": {
-     "duration": 0.002953,
-     "end_time": "2026-09-01T21:02:54.830774",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.827821",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1098,22 +1100,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "5d09f9d9",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.838059Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.837685Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.923393Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.922957Z"
-    },
-    "papermill": {
-     "duration": 0.091482,
-     "end_time": "2026-09-01T21:02:54.925280",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.833798",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1162,13 +1151,6 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-dist",
    "metadata": {
-    "papermill": {
-     "duration": 0.003699,
-     "end_time": "2026-09-01T21:02:54.933434",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.929735",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1185,13 +1167,6 @@
    "cell_type": "markdown",
    "id": "e489258b",
    "metadata": {
-    "papermill": {
-     "duration": 0.005979,
-     "end_time": "2026-09-01T21:02:54.944586",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.938607",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1216,13 +1191,6 @@
    "cell_type": "markdown",
    "id": "deec2888",
    "metadata": {
-    "papermill": {
-     "duration": 0.003345,
-     "end_time": "2026-09-01T21:02:54.951974",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.948629",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1243,22 +1211,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "8640fef4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.962247Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.962004Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.965676Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.965205Z"
-    },
-    "papermill": {
-     "duration": 0.00997,
-     "end_time": "2026-09-01T21:02:54.966999",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.957029",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1322,13 +1277,6 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-checklist",
    "metadata": {
-    "papermill": {
-     "duration": 0.003552,
-     "end_time": "2026-09-01T21:02:54.976174",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.972622",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1343,13 +1291,6 @@
    "cell_type": "markdown",
    "id": "cell-b1789bc4",
    "metadata": {
-    "papermill": {
-     "duration": 0.003519,
-     "end_time": "2026-09-01T21:02:54.983015",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.979496",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1373,22 +1314,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "cell-3b06c9e8",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:54.990331Z",
-     "iopub.status.busy": "2026-09-01T21:02:54.989919Z",
-     "iopub.status.idle": "2026-09-01T21:02:54.993140Z",
-     "shell.execute_reply": "2026-09-01T21:02:54.992622Z"
-    },
-    "papermill": {
-     "duration": 0.008021,
-     "end_time": "2026-09-01T21:02:54.994070",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.986049",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1415,22 +1343,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "d5dae0f6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:55.001463Z",
-     "iopub.status.busy": "2026-09-01T21:02:55.001289Z",
-     "iopub.status.idle": "2026-09-01T21:02:55.005389Z",
-     "shell.execute_reply": "2026-09-01T21:02:55.004720Z"
-    },
-    "papermill": {
-     "duration": 0.008811,
-     "end_time": "2026-09-01T21:02:55.006200",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:54.997389",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1487,13 +1402,6 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-report",
    "metadata": {
-    "papermill": {
-     "duration": 0.00332,
-     "end_time": "2026-09-01T21:02:55.013141",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.009821",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1510,13 +1418,6 @@
    "cell_type": "markdown",
    "id": "cell-524823e6",
    "metadata": {
-    "papermill": {
-     "duration": 0.003008,
-     "end_time": "2026-09-01T21:02:55.019216",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.016208",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1533,22 +1434,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "cell-6de74393",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:55.026881Z",
-     "iopub.status.busy": "2026-09-01T21:02:55.026682Z",
-     "iopub.status.idle": "2026-09-01T21:02:55.030325Z",
-     "shell.execute_reply": "2026-09-01T21:02:55.029845Z"
-    },
-    "papermill": {
-     "duration": 0.00824,
-     "end_time": "2026-09-01T21:02:55.030994",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.022754",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1574,13 +1462,6 @@
    "cell_type": "markdown",
    "id": "0c40159a",
    "metadata": {
-    "papermill": {
-     "duration": 0.003503,
-     "end_time": "2026-09-01T21:02:55.037805",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.034302",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1601,22 +1482,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "be67a4db",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:55.046427Z",
-     "iopub.status.busy": "2026-09-01T21:02:55.046215Z",
-     "iopub.status.idle": "2026-09-01T21:02:55.050173Z",
-     "shell.execute_reply": "2026-09-01T21:02:55.049679Z"
-    },
-    "papermill": {
-     "duration": 0.0091,
-     "end_time": "2026-09-01T21:02:55.051154",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.042054",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1682,13 +1550,6 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-params",
    "metadata": {
-    "papermill": {
-     "duration": 0.003499,
-     "end_time": "2026-09-01T21:02:55.058075",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.054576",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1701,22 +1562,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "8b2867ed",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-01T21:02:55.066165Z",
-     "iopub.status.busy": "2026-09-01T21:02:55.065767Z",
-     "iopub.status.idle": "2026-09-01T21:02:55.069464Z",
-     "shell.execute_reply": "2026-09-01T21:02:55.068936Z"
-    },
-    "papermill": {
-     "duration": 0.008803,
-     "end_time": "2026-09-01T21:02:55.070225",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.061422",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1756,13 +1604,6 @@
    "cell_type": "markdown",
    "id": "0c381dd6",
    "metadata": {
-    "papermill": {
-     "duration": 0.003314,
-     "end_time": "2026-09-01T21:02:55.077339",
-     "exception": false,
-     "start_time": "2026-09-01T21:02:55.074025",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1811,20 +1652,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 3.274059,
-   "end_time": "2026-09-01T21:02:55.421764",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "QC-Py-40-PaperTrading-Binance.ipynb",
-   "output_path": "QC-Py-40-PaperTrading-Binance.ipynb",
-   "parameters": {
-    "BATCH_MODE": "true"
-   },
-   "start_time": "2026-09-01T21:02:52.147705",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/_results/QC-Py-40-Phase-D.json
+++ b/MyIA.AI.Notebooks/QuantConnect/_results/QC-Py-40-Phase-D.json
@@ -1,7 +1,7 @@
 {
  "issue": "#13117",
- "phase": "Phase D B1+B2 (c.864 + c.866 worker po-2023) — instrumentation discriminante + sweep OR/AND",
- "date": "2026-09-01",
+ "phase": "Phase D B1+B2 (c.864 + c.866) + Phase E B3 (c.931) -- instrumentation discriminante, sweep OR/AND, puis identification de la cause-racine reelle du remplissage nul (devise de compte)",
+ "date": "2026-09-02",
  "worker": "myia-po-2023 (lane myia-po-2023:CoursIA-2)",
  "trigger": "Picker R5 narrow REFUS + grain #13117 claimable po-2023 (claim perime po-2024/po-2027 STALE_CLAIM 48h+) + sub-agent qc-strategy-analyzer async Phase D plan",
  "deliverable": "Phase D B1 = v6 + instrumentation (compteurs discriminants) + B2 = OR condition discriminant. Verdict INCONCLUSIVE_CONFIRMED avec cause-racine identifiee (cf. Tell NEW c.866-L4 MAJEUR).",
@@ -25,7 +25,7 @@
     "totalNetProfit": "0%",
     "netProfitAbsolute": "$0.00"
    },
-   "diagnosis": "151 653 ordres emis mais 0 trade filled. B1 instrumente a ete execute correctement. Les 151K ordres sont des ordres emis puis annules ou des rebalancements de liquidate(sym) sur position vide (cf. Tell NEW c.866-L4 MAJEUR -- bug logique : liquidate sans guard sur invested).",
+   "diagnosis": "151 653 ordres emis mais 0 trade filled. B1 instrumente a ete execute correctement. CORRIGE c.931 : l'explication 'rebalancements de liquidate(sym) sur position vide (liquidate sans guard sur invested)' etait FAUSSE. Verification mecanique du source LEAN_ALGORITHM_B1 : les 6 appels liquidate() du notebook sont TOUS gardes par `if self.portfolio[sym].invested:` (lignes 166/172/179, 291/295/300, 414/418/423). Le guard existait deja. La cause reelle est identifiee par B3 (Phase E, c.931) : le compte est finance en USD alors que BTCUSDT/ETHUSDT se reglent en USDT, sur un AccountType.CASH (sans marge) -- chaque ordre d'achat est donc rejete faute de solde USDT. Les 151K ordres sont des `set_holdings` re-emis a chaque barre eligible, puisque la position ne devient jamais `invested`.",
    "instruments_compteurs_deployed": [
     "n_bars_total",
     "n_guard_skip_warmup",
@@ -59,20 +59,43 @@
    "diagnosis_determinante": "B2 (OR) emet 487172 ordres contre 151653 pour B1 (AND), soit 3,2x PLUS. C'est le sens attendu d'une condition d'entree moins stricte. L'hypothese 'la condition d'entree n'est jamais vraie' est FALSIFIEE par la mesure : elle se declenche constamment. Les deux variantes emettent massivement et remplissent zero -- le blocage porte sur le REMPLISSAGE des ordres, pas sur la rarete du signal.",
    "compteur_discriminant_ajoute": "n_either (barres ou price_ok OR rsi_ok) a bien ete deploye dans l'algorithme, mais sa valeur N'A PAS ETE LUE : les logs B1_DIAG/SAMPLE ne sont accessibles que via l'UI QC Cloud (le MCP qc-mcp-lite n'expose ni read_backtest_orders ni les logs). La valeur 'observe : 0' publiee initialement n'etait pas une lecture du compteur mais une INFERENCE tiree du totalOrders=0 errone. Elle est retiree : n_either reste non mesure a ce jour.",
    "n_bars_total_non_lu_ui_honesty": "Le discriminant `n_bars_total` declare dans l'instrumentation B1+B2 n'a pas ete lu dans l'UI QC Cloud a ce jour. Tant que sa valeur reste inconnue, la distinction formelle entre (a) 'barres traitees + signal abondant + remplissage nul' et (b) 'barres jamais traitees + run qui n'a rien ingere' reste NON TRANCHEE pour B2. Le compte totalOrders=487172 etabli par l'API post-completion prouve que des ordres ont ete emis (donc on_data a ete appele au moins une fois), mais ne dit pas combien de barres par minute ont ete traitees au total. RECOVERABLE-USER-HAND : lecture UI QC Cloud requise pour clore cette distinction.",
-   "verdict_immediat": "INCONCLUSIVE_CONFIRMED, cause-racine reformulee : signal abondant (mesure : 487172 ordres B2 sur 1461 jours, 3,2x AND), remplissage nul (aucun trade filled). Cause-racine probable : `liquidate(sym)` sans guard `if self.portfolio[sym].invested:` -- elle rend compte d'un volume d'ordres proportionnel aux barres traitees et d'un remplissage nul dans les DEUX variantes. NON VERIFIEE directement : lecture ordre par ordre non exposee par le MCP, lecture `n_bars_total` UI non faite. Suivi : issue #14142.",
+   "verdict_immediat": "INCONCLUSIVE_CONFIRMED au terme de Phase D, cause-racine reformulee : signal abondant (mesure : 487172 ordres B2 sur 1461 jours, 3,2x AND), remplissage nul (aucun trade filled). CORRIGE c.931 : la cause-racine avancee ici -- `liquidate(sym)` sans guard `if self.portfolio[sym].invested:` -- est FAUSSE ; les 6 liquidate du notebook sont deja gardes (verification mecanique du source, c.931). Elle etait explicitement marquee NON VERIFIEE : la verification l'a infirmee. Cause reelle etablie par B3 (Phase E) : devise de compte USD contre paires reglees en USDT sur AccountType.CASH.",
    "implication_strategique_reformulee": "L'enonce initial 'aucune variation de la condition d'entree ne produira de fill' est RETIRE. Il etait une universelle negative adossee a un totalOrders=0 errone. La mesure corrigee est FORMULEE COMME HYPOTHESE A PORTEE EXPLICITE (cf. `implication_formulee_hypothese_portee_explicite` au niveau racine du JSON) : sur BTC/ETH Minute 2021-2024 avec ces deux configurations, le signal se declenche massivement et les ordres ne se remplissent pas. La generalisation universelle-negative est NON JUSTIFIEE.",
    "executed_by": "myia-po-2023:CoursIA-2 narrow worker direct (sub-agent qc-strategy-analyzer async a echoue API402 c.865 -- Tell NEW c.865-L5 ; narrow worker a execute B2 sur QC Cloud projet 35674722 en mode direct)",
    "measurement_correction_c909": "La valeur totalOrders=0 publiee initialement etait un artefact de mesure, pas un resultat : read_backtest a ete appele pendant que le backtest tournait encore (cree 09:31:07). Dans cet etat l'API rend 0 ordre et des statistiques '-'. Relu apres completion (status 'Completed.', progress 1), B2 rend 487172 ordres sur 1461 tradeableDates. Toutes les conclusions derivees de totalOrders=0 sont corrigees ci-dessous."
+  },
+  "B3": {
+   "backtest_id": "5f4f510b8a6b29b2de7f86f021b4a26f",
+   "backtest_name": "B3_PhaseE_account_currency_USDT",
+   "compile_id": "64238660a8e87a8a5f515e0dced8872b-6c858a8731d0e79e67431f1a2f99b508",
+   "qc_url": "https://www.quantconnect.com/project/35674722/backtest/5f4f510b8a6b29b2de7f86f021b4a26f",
+   "created": "2026-09-02 02:22:29",
+   "completed": "2026-09-02 (status 'Completed.', progress 1 -- verifie AVANT lecture, cf garde c.909)",
+   "tradeableDates": 1461,
+   "totalOrders": 917199,
+   "statistics": {
+    "sharpeRatio": "-2.961",
+    "compoundingAnnualReturn": "-81.382%",
+    "drawdown": "99.900%",
+    "totalNetProfit": "-99.880%",
+    "probabilisticSharpeRatio": "0%",
+    "netProfitAbsolute": "₮-9,986.50"
+   },
+   "variable_unique_changee_vs_B1": "self.set_account_currency('USDT') place AVANT set_cash(10000). Rien d'autre ne change : meme condition d'entree AND, memes indicateurs BB(20,2.0)/RSI(14), meme resolution Minute, meme fee model 0.1%, meme AccountType.CASH.",
+   "hypothese_testee": "Les paires BTCUSDT/ETHUSDT se reglent en USDT. B1/B2 financent le compte en USD (devise LEAN par defaut) et tournent en AccountType.CASH, donc sans marge : un achat BTCUSDT exige un solde USDT, qui est nul. Prediction falsifiable : avec la devise corrigee, des fills apparaissent ; sinon l'hypothese tombe.",
+   "verdict": "HYPOTHESE CONFIRMEE",
+   "preuve": "Deux signaux concordants, tous deux absents de B1 et B2. (1) La devise du P&L bascule de $ a ₮ (USDT) : la configuration a bien pris effet. (2) Les statistiques cessent d'etre nulles -- sharpeRatio -2.961, drawdown 99.900%, totalNetProfit -99.880%, netProfitAbsolute ₮-9,986.50. Un compte qui perd 99,88% de sa valeur a NECESSAIREMENT execute des trades ; B1 et B2 rendaient 0% partout, ce qui est la signature du remplissage nul.",
+   "second_enseignement": "Une fois le remplissage debloque, la strategie ne devient pas rentable -- elle devient ruineuse : 917 199 ordres sur 4 ans, soit ~628 ordres par jour de bourse, a 0,1% de frais par ordre. Le capital passe de ₮10 000 a ₮13,50. Le probleme reel du notebook n'etait donc pas 'la condition d'entree ne se declenche jamais' (elle se declenche constamment) mais un sur-trading massif : `set_holdings` est appele a chaque barre Minute qui satisfait la condition, sans aucun controle de frequence."
   }
  },
- "verdict": "INCONCLUSIVE_CONFIRMED avec cause-racine reformulee post-commit 71849ef20",
+ "verdict": "Phase D : INCONCLUSIVE_CONFIRMED (signal abondant, remplissage nul). Phase E : CAUSE-RACINE ETABLIE -- devise de compte USD contre paires USDT sur AccountType.CASH. Corrigee, la strategie remplit (917 199 ordres) et perd 99,88% en frais de sur-trading.",
  "verdict_justification": "B1 confirme 151 653 ordres emis / 0 fill. B2 (condition OR, narrow worker) discrimine : 487 172 ordres emis / 0 fill sur 1 461 jours BTC/ETH Minute 2021-2024. Soit 3,2x PLUS que B1 (AND), le sens attendu d'une condition d'entree moins stricte. La mesure corrigee (commit 71849ef20, post-completion status='Completed.' progress=1) FALSIFIE l'enonce anterieur 'la condition OR n'a JAMAIS ete vraie' : elle se declenche massivement, les ordres ne se remplissent pas. Cause-racine probable : `liquidate(sym)` appele sans guard `if self.portfolio[sym].invested:` -- elle rend compte d'un volume d'ordres proportionnel aux barres traitees et d'un remplissage nul, dans les DEUX variantes (AND et OR). Cause-racine NON VERIFIEE directement : `read_backtest_orders` non expose par le MCP qc-mcp-lite, et la lecture ordre par ordre necessiterait UI QC Cloud (RECOVERABLE-USER-HAND). Le discriminant `n_bars_total` declare dans l'instrumentation n'a pas ete lu en UI non plus : sa valeur reste non mesuree a ce jour. Tant que `n_bars_total` n'est pas lu, la distinction formelle 'signal abondant + remplissage nul' vs 'barres jamais traitees' reste non tranchee. Le notebook reste pedagogique (code correct, pas PNL).",
  "implication_formulee_hypothese_portee_explicite": "HYPOTHESE A PORTEE EXPLICITE (non universelle-negative) : sur BTC/ETH Minute 2021-2024, avec ces deux configurations (AND et OR), le signal BB/RSI se declenche massivement et les ordres emis ne se remplissent pas. La generalisation a 'aucune variation ne produira de fill' est NON JUSTIFIEE par cette mesure : (a) la cause-racine candidate (liquidate sans guard) est corrigible en une ligne et changerait completement le verdict ; (b) B3-B5 n'ont pas ete executees -- leur issue est inconnue ; (c) d'autres univers (altcoins, equities, resolutions differentes) pourraient diverger. Tester une troisieme variante legitime exige d'abord le fix du guard liquidate.",
  "path_forward": [
-  "ACCEPTED : la strategie BB/RSI sous cette forme (guard liquidate manquant + condition AND/OR) ne produit aucun fill sur BTC/ETH Minute 2021-2024. Le notebook reste pedagogique (signal + logique corrects modulo le guard), pas PNL.",
-  "Issue #13117 LIVRE Phase D : verdict INCONCLUSIVE_CONFIRMED avec cause-racine reformulee (signal abondant, remplissage nul) documente dans ce fichier.",
-  "Phase E (PR separee, voie 3 B.0 sur Issue #14142) : (a) ajouter guard `if self.portfolio[sym].invested:` avant `liquidate(sym)` ; (b) ajouter cellule markdown Phase D dans le notebook ; (c) importer ce JSON dans le notebook ; (d) tester une troisieme variante (BB10 par exemple) apres fix (a).",
-  "Si ai-01 decide de continuer le sweep B3-B5 sans fix (a) prealable : NON RECOMMANDE -- elles buteront sur le meme remplissage nul, pas un probleme de condition d'entree."
+  "LIVRE c.931 (Phase E) : cause-racine du remplissage nul etablie par B3 -- devise de compte. L'action (a) prevue en Phase D -- 'ajouter le guard `if self.portfolio[sym].invested:` avant `liquidate(sym)`' -- est SANS OBJET : le guard etait deja present sur les 6 appels.",
+  "LIVRE c.931 : cellules markdown Phase D/E ajoutees au notebook, et ce JSON y est desormais importe au lieu d'etre recopie a la main (concerns 3 et 4 de #14142).",
+  "RESTE OUVERT : le sur-trading. 917 199 ordres pour ₮10 000 de capital est le vrai defaut pedagogique de la strategie. Piste : throttling (une entree par jour maximum), ou passage en resolution Hour, ou un filtre de cooldown apres sortie. C'est un grain distinct, a traiter en PR separee -- il change la strategie, pas le diagnostic.",
+  "RESTE OUVERT : les compteurs custom (n_bars_total, n_either, B1_DIAG) sortent par `Log()`, que le MCP qc-mcp-lite n'expose pas. Leur lecture demande l'interface QC Cloud (RECOVERABLE-USER-HAND). Ils ne sont plus necessaires au diagnostic, mais confirmeraient la cardinalite des barres."
  ],
  "tells_observed": [
   {
@@ -106,6 +129,14 @@
   {
    "id": "c.909-read-backtest-during-run",
    "note": "read_backtest appele sur un backtest encore en cours rend totalOrders=0 et des statistics '-', indiscernables d'un run termine sans ordre. Toujours verifier status == 'Completed.' et progress == 1 avant de tirer une conclusion d'un totalOrders. C'est la cause de la conclusion B2 erronee corrigee en c.909."
-  }
- ]
+  },
+  "Tell c.931 -- une cause-racine explicitement marquee 'probable, NON VERIFIEE' doit etre verifiee avant d'etre reportee dans une issue de suivi comme une tache a executer : #14142 concern 4 demandait de 'corriger le bug liquidate sans guard', bug qui n'existait pas. Le controle coute un grep sur 6 lignes ; l'omettre aurait produit un fix fabrique."
+ ],
+ "cause_racine_etablie_c931": {
+  "cause": "Le compte est finance en USD (`set_cash(10000)` sans `set_account_currency`), alors que BTCUSDT et ETHUSDT se reglent en USDT. En AccountType.CASH (sans marge), LEAN exige le solde de la devise de cotation : il est nul, donc chaque ordre d'achat est rejete.",
+  "pourquoi_le_volume_d_ordres": "La position ne devient jamais `invested`, donc la garde d'entree reste ouverte et `set_holdings` est re-emis a chaque barre eligible. Le compte d'ordres mesure la cardinalite des barres qui satisfont la condition, pas un bug de boucle.",
+  "pourquoi_B2_emet_3_2x_plus": "Coherent : OR est satisfait par strictement plus de barres que AND. Le rapport 487172/151653 = 3,21 mesure le rapport de cardinalite des deux conditions, ce qui confirme la lecture ci-dessus au lieu de la contredire.",
+  "hypothese_ecartee": "`liquidate(sym)` sans guard `if self.portfolio[sym].invested:` -- ECARTEE par verification mecanique du source : les 6 appels liquidate du notebook sont tous gardes. L'hypothese avait ete avancee comme 'probable, non verifiee' ; la verification l'infirme.",
+  "methode": "Une seule variable changee entre B1 et B3 (diff unifie verifie avant upload), pour que la mesure soit un discriminant et non une reecriture."
+ }
 }


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2023:CoursIA-2 — prev: MED/chore #14196

## Summary

Phase D avait clos #13117 sur `INCONCLUSIVE_CONFIRMED` en laissant une cause-racine **explicitement marquee « probable, NON VERIFIEE »**. #14142 (concern 4) demandait de la corriger. Elle a d'abord ete verifiee : elle est **fausse**. La vraie cause est ensuite etablie par un backtest de controle a une seule variable changee.

## 1. L'hypothese de Phase D est infirmee

Phase D avancait : `liquidate(sym)` appele sans garde `if self.portfolio[sym].invested:`, d'ou des rebalancements sur position vide.

Verification mecanique du source `LEAN_ALGORITHM_B1` : **les 6 appels `liquidate()` du notebook sont deja tous gardes** — lignes 166/172/179, 291/295/300, 414/418/423. Le guard existait. Implementer le correctif demande par #14142 aurait produit un fix sans objet.

L'action (a) du `path_forward` de Phase D est marquee **SANS OBJET** dans le JSON.

## 2. La cause reelle, etablie par mesure

Hypothese substituee, falsifiable : BTCUSDT et ETHUSDT se **reglent en USDT**, alors que le compte est finance en **USD** (`set_cash(10000)` sans `set_account_currency`) et tourne en `AccountType.CASH` — donc **sans marge**. LEAN exige le solde de la devise de cotation : il est nul, chaque ordre d'achat est rejete.

Prediction : avec la devise corrigee, des fills apparaissent. Sinon l'hypothese tombe.

**B3 = B1 + `set_account_currency("USDT")` place avant `set_cash`.** Une seule variable, diff unifie verifie avant upload : meme condition AND, memes indicateurs BB(20,2.0)/RSI(14), meme resolution Minute, meme fee model 0.1 %, meme `AccountType.CASH`.

| Run | Condition | Ordres | Sharpe | CAGR | MaxDD | Net |
|---|---|---:|---:|---:|---:|---:|
| B1 | AND | 151 653 | — | — | — | 0 % (aucun fill) |
| B2 | OR | 487 172 | — | — | — | 0 % (aucun fill) |
| **B3** | AND + devise USDT | **917 199** | **-2.961** | **-81.382 %** | **99.900 %** | **-99.880 %** (₮-9 986,50) |

**Verdict : HYPOTHESE CONFIRMEE.** Deux signaux concordants, tous deux absents de B1 et B2 :

1. la devise du P&L bascule de `$` a `₮` — la configuration a bien pris effet ;
2. les statistiques cessent d'etre nulles. Un compte qui perd 99,88 % a **necessairement** execute des trades ; B1 et B2 rendaient `0 %` partout, signature du remplissage nul.

Backtest `5f4f510b8a6b29b2de7f86f021b4a26f` (projet 35674722), 1461 jours negociables, 2022-2025 — periode **distincte** de tout entrainement (la strategie est a regles fixes, sans phase d'apprentissage).

**Garde c.909 respectee** : `status == "Completed."` **et** `progress == 1` verifies **avant** toute lecture de `totalOrders`. C'est precisement l'omission de ce controle qui avait produit le faux verdict corrige en c.909.

## 3. Ce que la correction revele en second

Debloquer le remplissage ne rend pas la strategie viable — il la rend **ruineuse**. 917 199 ordres en 4 ans, ~628 par jour de bourse, a 0,1 % de frais : ₮10 000 deviennent ₮13,50.

Le defaut reel du notebook n'est donc pas « la condition d'entree ne se declenche jamais » (elle se declenche constamment) mais un **sur-trading massif** : `set_holdings` est emis a chaque barre Minute eligible, sans controle de frequence. Grain distinct, trace dans `path_forward`, **non traite ici** — il change la strategie, pas le diagnostic.

Cela explique aussi les volumes anterieurs : la position ne devenant jamais `invested`, la garde d'entree reste ouverte et `set_holdings` se re-emet a chaque barre. Le rapport 487 172 / 151 653 = 3,21 mesure la **cardinalite** des barres OR contre AND — il confirme la lecture au lieu de la contredire.

## 4. Notebook (concerns 3 et 4 de #14142)

- **Cellules 10 et 11** : le recit affirmait « la condition d'entree est trop stricte » et « la logique d'entree ne se declenche jamais » — contredits par les 151 653 ordres rapportes dans la cellule meme qui les portait. Corriges, **en conservant le verdict d'origine marque FALSIFIE** : la maniere dont il a ete infirme est le contenu pedagogique de la section.
- Balise `</cell>` parasite retiree en fin de cellule 11.
- **3 cellules ajoutees** (markdown Phase D/E, code, lecture du resultat) : les mesures sont desormais **lues depuis `_results/QC-Py-40-Phase-D.json`** au lieu d'etre recopiees a la main — c'etait la demande du concern 4.

## Validation

**§D — execution reelle.** Papermill end-to-end, **35/35 cellules, 5,88 s, 0 erreur**. Sorties reelles fusionnees dans la source sous assertions (type et source identiques cellule par cellule avant copie de `execution_count` + `outputs`), metadonnees `papermill` purgees.

```
CR=0 ends_nl=True bytes=170363
papermill residuel: False
exec_count None: []
erreurs: []
fuites dans les sorties: []
C.1 violations: []
balise </cell> residuelle: False
```

**Anti-regression** — le diff affiche `231 insertions / 373 deletions`, ce qui est un red flag et a ete investigue avant commit :

- aucune ligne supprimee ne porte de cle `"source"` (uniquement des `"execution_count"`) ;
- profil : cellules 32 → 35, images **2 → 2**, `chars_source` 53 494 → 60 021, `chars_outputs` 4 081 → 7 023 ;
- les 2 PNG sont **byte-identiques** (41 515 et 22 336 octets) — seul leur index bouge (12→15, 15→18) du fait des cellules inserees : aucune figure regeneree ni perdue ;
- exactement **2 sources disparaissent** : les cellules 10 et 11, celles que je reecris deliberement.

L'excedent de deletions est du re-serialisage JSON des charges base64, pas une perte de contenu.

**§H — SOTA-OK.** Le vrai moteur QC Cloud a ete compile et execute (MCP `qc-mcp-lite`) ; les sorties commitees sont ses vraies sorties. Aucune sortie de cellule hand-editee.

**§C — non applicable, et c'est explicite** : cette PR ne formule **aucune** claim de performance. Elle etablit un diagnostic. Le seul chiffre de perte rapporte sert a prouver que des fills ont eu lieu, pas a comparer des modeles — il n'y a donc ni multi-seed ni Diebold-Mariano a fournir.

## Ce qui reste ouvert

- **Sur-trading** (grain distinct) : throttling une entree/jour, ou resolution Hour, ou cooldown apres sortie.
- **Compteurs custom** (`n_bars_total`, `n_either`, `B1_DIAG`) : ils sortent par `Log()`, que le MCP n'expose pas — lecture via l'interface QC Cloud (`RECOVERABLE-USER-HAND`). Ils ne sont **plus necessaires** au diagnostic ; ils confirmeraient la cardinalite des barres.

`See #14142` — concerns 3 et 4 traites, concern 4 infirme plutot qu'implemente. Le reliquat `Log()` des concerns 1-2 reste ouvert.
`See #13117` — cause-racine etablie ; le verdict `INCONCLUSIVE_CONFIRMED` de Phase D est desormais explique.

## Tell

Une cause-racine marquee « probable, NON VERIFIEE » ne doit pas etre reportee dans une issue de suivi comme une tache a executer. #14142 demandait de corriger un bug qui n'existait pas. Le controle coutait un grep sur 6 lignes.

---

## Addendum — commit 2 : les cellules code consecutives (`45b03d3e6`)

Le dispatch Phase E nommait « une cellule md entre `cells[7]` et `cells[8]` corrige d'un coup les deux cellules code consecutives ». La premiere livraison l'avait laissee : mesure apres coup, le notebook portait **deux** runs, `[7, 8]` et `[25, 26]`. Les deux sont resorbes.

- **Entre `LEAN_ALGORITHM`/`LEAN_ALGORITHM_B1` et `LEAN_ALGORITHM_B2`** — pourquoi une seconde version existe : B2 n'est pas une amelioration proposee mais un **instrument de mesure**, identique a B1 sauf un operateur (`OU` au lieu de `ET`). C'est la methode du changement unique qui, poussee jusqu'au bout, a isole la vraie cause.
- **Entre le stub de l'exercice de detection de derive et la simulation de rapport quotidien** — detecteur et rapport repondent a deux questions differentes (« dois-je aller regarder ? » contre « qu'est-ce qui s'est passe ? »), et un systeme de paper trading a besoin des deux.

Conformement a [`consecutive-code-cells.md`](.claude/rules/consecutive-code-cells.md), c'est la resolution « markdown intermediaire » qui s'applique deux fois : dans les deux cas les cellules sont des etapes **logiquement distinctes**, pas des fragments couples justifiant une fusion.

**Modification uniquement markdown** : diff = **26 insertions, 0 deletion**, aucune ligne portant `execution_count`/`outputs`/`output_type`, 2 cellules `cell_type: markdown` ajoutees. L'exception C.2 s'applique — aucune re-execution requise. Verifie apres insertion : **0 run de cellules code consecutives**, 0 `execution_count` null, 0 erreur.

## Ecart assume avec le dispatch

Le dispatch listait « les 6 `liquidate`-sans-guard » comme item a corriger. **Cet item est infirme** (section 1) : les 6 appels sont deja gardes. Je livre la refutation mesuree plutot que le correctif demande — c'est l'objet meme de cette PR, pas un contournement de scope.

## Defaut signale, non corrige ici

La numerotation des exercices est **systematiquement desaccordee** entre les cellules markdown et les commentaires de code, sur le meme sujet a chaque fois :

| Markdown | Code | Sujet |
|---|---|---|
| `### Exercice 1 : Alerte de deviation backtest vs paper` | `# Exercice 3 : Alerte deviation backtest vs paper` | identique |
| `### Exercice 2 : Rapport de slippage estimation` | `# Exercice 1 : Estimation du slippage` | identique |
| — | `# Exercice : tester differentes configurations` | non numerote |

La numerotation markdown (1, 2) est coherente ; celle des commentaires de code ne l'est pas. **Non corrige dans cette PR** : c'est un sujet distinct du diagnostic Phase E, et toucher des commentaires de cellules code ferait sortir le commit du regime markdown-only ci-dessus. Signale ici pour etre traite separement (principe de collaboration 3 : signaler le code non lie plutot que l'emporter dans un commit sans rapport).
