### PR TITLE
fix(readme,#14190): DataScienceWithAgents racine omet 04-Vision -> ajout complet

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -24,7 +24,7 @@ La formation couvre deux stacks complémentaires :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 50 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning) |
+| Notebooks | 52 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 2 vision) |
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 
@@ -115,6 +115,11 @@ DataScienceWithAgents/
 │   ├── 3.7-Distillation-Maitre-Eleve.ipynb
 │   └── 3.8-Representations-Contrastives.ipynb
 │
+│
+├── 04-Vision/                # Vision par ordinateur : du neurone convolutif au transfer learning (2 notebooks)
+│   ├── 4.1-Conv-NumPy-Torch-Allclose.ipynb
+│   └── 4.2-ConvNet-Profonde-Residuelles.ipynb
+│
 ├── Track1-LangChain/ # Track LangChain (7 labs)
 │   ├── Day1-Foundations/Labs/              # Revision
 │   ├── Day2-Document-Agents/Labs/              # Agents RFP et CV
@@ -182,6 +187,18 @@ Le prolongement direct du socle : là où [2.2](02-ML-Cours/2.2-Descente-de-grad
 | [3.8-Representations-Contrastives](03-DeepLearning/3.8-Representations-Contrastives.ipynb) | Pré-entraînement contrastif moderne : vues continues, encodeur MLP et loss InfoNCE from scratch, pont vers skip-gram | **Apprendre des représentations sans étiquettes** : deux vues attirent leurs embeddings, les autres repoussent |
 
 Documentation complète : [03-DeepLearning/README.md](03-DeepLearning/README.md)
+
+
+## Vision par ordinateur (04-Vision)
+
+[`03-DeepLearning`](#deep-learning-03-deeplearning) a ouvert la rétropropagation sur des **vecteurs** tabulaires (MLP, gradient vérifié, parité NumPy ↔ torch). Le passage à l'image demande une primitive nouvelle : le neurone **convolutif**, qui partage ses poids spatialement. Cette série reprend la **même discipline** (from scratch PUIS framework, parité epsilon machine) et l'applique à la convolution, l'empilement profond, et au skip-connection qui rend les réseaux entraînables.
+
+| Notebook | Sujet | Concept-phare |
+|----------|-------|---------------|
+| [4.1-Conv-NumPy-Torch-Allclose](04-Vision/4.1-Conv-NumPy-Torch-Allclose.ipynb) | Conv2d NumPy pur (single + multi-canal), gradient vérifié par différence finie, parité epsilon machine avec `torch.nn.Conv2d`, pooling et invariance par translation | **La convolution n'est pas magique** : un produit scalaire local, partagé spatialement |
+| [4.2-ConvNet-Profonde-Residuelles](04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb) | 20 conv2d empilées nues (effondrement du gradient), skip naïf (gradient réparé mais passe avant qui dérive), bloc pré-norme (les deux réparés), puis accuracy CIFAR-10 sur 3 graines | **Le skip-connection n'est pas un détail architectural** : c'est le mécanisme qui rend les réseaux profonds entraînables |
+
+Documentation complète : [04-Vision/README.md](04-Vision/README.md)
 
 ## Workshop 3 Jours (Track1-LangChain)
 
@@ -256,7 +273,7 @@ Documentation complète : [Track2-GoogleADK/README.md](Track2-GoogleADK/README.m
 
 | Catégorie | Technologies |
 |-----------|--------------|
-| **Data Science** | NumPy, Pandas, Matplotlib, Seaborn |
+| **Data Science** | NumPy, Pandas, Matplotlib, Seaborn, Pillow, PyTorch (parité 04-Vision) |
 | **Machine Learning** | Scikit-Learn |
 | **Agents IA** | LangChain, OpenAI GPT |
 | **Orchestration** | python-dotenv |


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2026:CoursIA -- prev: LIGHT/cleanup #14225 (cycle 164)

## Summary

Resolution de l'issue **#14190** : le README racine de `MyIA.AI.Notebooks/ML/DataScienceWithAgents/` omettait **integralement** le sous-dossier `04-Vision/` alors que celui-ci contient 2 notebooks (4.1 et 4.2) avec leur propre README (47 lignes) deja ecrit.

L'omission etait systemique : synthese `50` au lieu de `52`, ventilation sans terme pour la vision, arbre de structure sans bloc `04-Vision/`, aucun lien `Vision` dans le corps du fichier (`grep -c 'Vision' = 0`), aucune section `## Vision` dans la liste des sous-series. Conséquence : un lecteur arrivant sur le README racine ne pouvait pas trouver 2 notebooks presents sur disque.

Sortie : **1 fichier, +19/-2**. Aucune regeneration de catalogue (Règle HARD 1 catalog-pr-hygiene).

## Acceptance #14190

| # | Critere | Resultat |
|---|---------|----------|
| 1 | La ligne de synthese compte **52** et porte un terme pour `04-Vision` | **OK** : L27 -> `\| Notebooks \| 52 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 2 vision) \|` ; verification arithmetique : 7+10+2+21+10+2 = 52 OK |
| 2 | `04-Vision/` apparait dans l'arbre / la table de structure du README racine, avec son notebook nomme | **OK** : nouveau bloc dans l'arbre (apres `03-DeepLearning/`, avant `Track1-LangChain/`) listant 4.1 et 4.2 |
| 3 | Audit **fichier entier** du README racine (cf pr-review-discipline §E) | **OK** : verifie disque ↔ prose sur les 411 lignes du README (cf section Audit ci-dessous). Pas d'autre liste de notebooks obsolete plus bas (les 02/03/Tracks listes sont completes) |
| 4 | Verifier que les quatre autres sous-dossiers ont chacun un README | **OK** : 01 (41L) / 02 (176L) / 03 (65L) / Track1 (53L) / Track2 (337L) / 04 (47L, deja present). Tous couverts |
| 5 | **Ne pas regenerer le catalogue** sur la branche | **OK** : aucun marqueur `CATALOG-STATUS` touche (le fichier n'en porte pas). Le marqueur du parent `MyIA.AI.Notebooks/ML/README.md` n'a pas ete modifie (j'avais commence par Edit 5 sur ce fichier, je l'ai annule apres avoir identifie le conflit avec catalog-pr-hygiene) |

## Audit fichier entier du README racine (411 lignes)

Mesures firsthand sur `origin/main` (commit `7dc162675`) :

| Section | Lignes | Couverture actuelle | Apres PR |
|---------|-------:|---------------------|----------|
| Synthese Vue d'ensemble | L25-29 | **50** (7+10+2+21+10) | **52** (+2 vision) |
| Arbre de structure | L76-128 | 5 sous-dossiers (01/02/03/Track1/Track2) | 6 sous-dossiers (+04-Vision) |
| Fondations (01) | L130-135 | 2 notebooks listes | inchange |
| Fondations ML (02) | L137-165 | 21 notebooks listes | inchange |
| Deep Learning (03) | L167-184 | 10 notebooks listes | inchange |
| **Vision par ordinateur (04)** | **absente** | **0 notebook** | **2 notebooks listes (4.1, 4.2)** |
| Workshop 3 Jours (Track1) | L186-208 | 7 labs listes | inchange |
| Track Track2-GoogleADK | L210-253 | 10 labs listes | inchange |
| Technologies | L255-263 | Data Science sans PyTorch | Data Science + PyTorch/Pillow (parite 04-Vision) |
| Installation / FAQ / Conclusion | L264-411 | intact | inchange |

**Verification disque vs prose** : `find ... -name "*.ipynb"` -> 52 notebooks sur disque (2/21/10/2/7/10). Le compte de la synthese est desormais coherent.

**Reconciliation CATALOG-STATUS** : `MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md` **ne porte pas** de bloc `CATALOG-STATUS`. Le parent `MyIA.AI.Notebooks/ML/README.md` en porte un (L5-11) qui dit `breakdown: DataScienceWithAgents=50, ML.Net=21` -> **desynchronise** avec la nouvelle valeur 52. **Resolution** : ce marqueur est gere par `catalog-cron.yml` (cron quotidien sur `main`) qui regenerera la valeur 52 dans les 24h. Cf Règle HARD 1 catalog-pr-hygiene : "**Si le catalogue est faux, le signaler, ne pas s'aligner dessus**".

## Changement

| Fichier | Lignes | Role |
|---------|-------:|------|
| `MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md` | +19 / -2 | (1) synthese 50 -> 52 + mention `2 vision` ; (2) arbre +bloc `04-Vision/` avec 4.1 et 4.2 ; (3) section `## Vision par ordinateur (04-Vision)` avec table 2 lignes + lien vers `04-Vision/README.md` ; (4) technologies Data Science +PyTorch/Pillow |

**Sortie produite** :
```
MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md  (411 -> 428 lignes, +19/-2)
```

## Architecture du fix

L'edition preserve CRLF (le fichier est en CRLF d'apres `git show HEAD:... | od -c | head`) :

1. **Sythese** (L27, 0-indexed L26) : remplacement in-place, meme nombre de lignes
2. **Arbre de structure** (apres L116 `3.8-Representations-Contrastives.ipynb`) : insertion d'un bloc de 6 lignes (entete vide `│` + `├── 04-Vision/...` + 2 sous-lignes + fermeture `│`) avant `├── Track1-LangChain/`
3. **Section Vision** (apres L184 `Documentation complète : 03-DeepLearning/README.md`) : insertion de 13 lignes (titre H2 + paragraphe d'introduction + table 2 colonnes + lien doc complete) avant `## Workshop 3 Jours`
4. **Technologies** (L259) : remplacement in-place de la ligne Data Science

Fix script `fix_14190.py` (byte-preserving, dans scratchpad) :
- Detection LE = `b'\r\n' in data` -> `le = b'\r\n'`, sinon `b'\n'`
- Split en lignes, modifications sur la liste, `le.join(lines)` pour reassembler
- Append `le` final si `data.endswith(le)` (preserve le trailing newline)

## Verdicts

- **SOTA-OK** : pas de workaround -- c'est un edit README doc-only.
- **Anti-regression D** : aucun code de production touche, aucune preuve Lean/stub `pass`/`return None`/`sorry` introduit.
- **Stop & Repair** : aucun scrub d'output de cellule (cf secrets-hygiene regle 6). Pas de cellule touchee.
- **catalog-pr-hygiene R1** : **OK**, aucun marqueur `CATALOG-STATUS` regenere (j'avais commence par Edit 5 sur `ML/README.md`, annule apres detection).
- **pr-review-discipline §E (README whole-file audit)** : **OK**, audit documenté ci-dessus.
- **Convention Exemple/Exercice** : N/A (pas un notebook).
- **3 exercices par notebook** : N/A (pas un notebook).

## Residuel / suite

- **`MyIA.AI.Notebooks/ML/README.md` marqueur CATALOG-STATUS** reste a `DataScienceWithAgents=50`. **Resolution automatique** : le cron `catalog-cron.yml` (workflow quotidien sur `main`, commit `[skip ci]` par `github-actions[bot]`) regenerera la valeur 52 dans les 24h suivant le merge de cette PR. Pas d'action worker.
- **04-Vision/README.md feuille de route** mentionne un futur `4.3 — Transfer learning ResNet` (PR suivante). Hors scope de cette PR (issue #14190 cible uniquement l'inclusion du dossier dans le README racine, pas la completion du 4.3).
- **02-ML-Cours/README.md et 03-DeepLearning/README.md** mentionnent deja 04-Vision en prerequis/extension (cf `04-Vision/README.md` L5-7). Pas de modification requise.

## Lecons

- **Detection des angles morts en audit fichier-entier** : le README racine omet un sous-dossier present sur disque et portant deja son propre README. Le defaut n'est pas un oubli arithmetique (la somme 7+10+2+21+10 = 50 est correcte), mais un **angle mort structurel** : aucun terme pour 04 dans la synthese, aucun bloc dans l'arbre, aucune section dans le corps. La regle pr-review-discipline §E ("corriger l'intro en laissant une liste obsolete plus bas vaut CHANGES_REQUESTED") vise exactement ce cas.
- **Catalog-pr-hygiene R1 en pratique** : j'avais commence par modifier le bloc `CATALOG-STATUS` du parent `ML/README.md` sans reflechir. Detection au moment du `git diff` (le bloc apparait explicitement dans la sortie diff). Annulation immediate via `git checkout HEAD -- MyIA.AI.Notebooks/ML/README.md`. **Resultat** : la PR est 1 fichier au lieu de 2, et le marqueur sera regenere par le cron dans les 24h. **Lecon** : avant `git add`, `git diff --stat` doit montrer UNIQUEMENT le contenu de la prose, pas les blocs generes.

## Rotation R6

c155 = MED/notebook-search CSP-2 ; c156 = LIGHT/cleanup Search-debt ; c157 = LIGHT/cleanup data-registry ; c158 = LIGHT/tooling pick_idle_grain ; c159 = MED/tooling check_unaddressed_nits Position F ; c160 = LIGHT/cleanup test dedup ; c161 = LIGHT/notebook-cleanup Tweety-7a parite ; c162 = MED/docs README Mermaid ; c163 = MED/audio-tooling p6_compile chapitrage ; c164 = LIGHT/cleanup Search-15/16 residu commentaires ; c165 = **LIGHT/docs DataScienceWithAgents README 04-Vision omis**.

Regle 6 (variete obligatoire) :
- **Famille** : Search -> Search -> Argument_Analysis -> tooling -> tooling -> test/maintenance (CI) -> notebook/SymbolicAI-Tweety -> README-racine -> GenAI/Audio v4 -> Search (Part1-Foundations, commentaire) -> **ML (DataScienceWithAgents, README racine)**. 11 cycles, **10 familles distinctes**. Premier cycle sur la famille ML depuis longtemps -- equilibre.
- **Genre** : MED -> LIGHT -> LIGHT -> LIGHT -> MED -> LIGHT -> LIGHT -> MED -> MED -> LIGHT -> **LIGHT**. 5 LIGHT consecutifs sur les 7 derniers -- ok, on alterne avec les MED precedents.
- **Issue** : enrichissement -> sweep+rebase -> anti-FP-tooling -> anti-FP-tooling -> fix algorithmique (Position F) -> dedup code mort + AST guard -> mise a jour note de parite -> figure Mermaid dans README racine -> fix pipeline audiobook (chapitrage m4b) -> rename residue cleanup -> **README racine incomplet (sous-dossier omis)**.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14190 (Fille de l'EPIC #13504)
- Fichier modifie : `MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md` (+19/-2)
- Fichier REFERENCE (non modifie) : `MyIA.AI.Notebooks/ML/DataScienceWithAgents/04-Vision/README.md` (47 lignes, deja complet)
- EPIC parent : https://github.com/jsboige/CoursIA/issues/13504
- Cron catalog : `.github/workflows/catalog-cron.yml` (regenerera `DataScienceWithAgents=52` sur main dans les 24h)
- Convention : `catalog-pr-hygiene.md` R1 (ne pas regenerer le catalogue sur branche)
- Convention : `pr-review-discipline.md` §E (audit fichier-entier README)
- Prev sur la lane : PR #14225 (c164 LIGHT/cleanup Search-15/16 residu commentaires)
