### PR TITLE
fix(comfyui-qwen,#3164): install libgl1 in entrypoint so opencv (PuLID/IPAdapter) imports

### DIFF
--- a/docker-configurations/services/comfyui-qwen/entrypoint.sh
+++ b/docker-configurations/services/comfyui-qwen/entrypoint.sh
@@ -20,6 +20,14 @@ if [ "$(id -u)" = "0" ]; then
         echo "📦 Installation de gosu..."
         apt-get update -qq && apt-get install -y -qq gosu >/dev/null
     fi
+    # opencv-python (PuLID / IPAdapter custom nodes) needs libGL.so.1 from
+    # libgl1; the python:3.11 base image does not ship it, so `import cv2`
+    # fails and every PuLID/IPAdapter node dies. Idempotent: only installs
+    # when libGL.so.1 is absent.
+    if ! ldconfig -p | grep -q libGL.so.1; then
+        echo "📦 Installation de libgl1 (libGL.so.1 pour opencv)..."
+        apt-get update -qq && apt-get install -y -qq libgl1 >/dev/null
+    fi
     # Ensure uid-1000 user exists (for getpass.getuser() in torch._inductor)
     if ! getent passwd 1000 >/dev/null 2>&1; then
         useradd -u 1000 -o -m -s /bin/sh bonsai || true


### PR DESCRIPTION
Grain: LIGHT/genai -- lane myia-po-2023:CoursIA

## Summary

`comfyui-qwen` container: the `python:3.11` base image does not ship `libGL.so.1`, so `import cv2` (opencv-python) fails with:

```
libGL.so.1: cannot open shared object file
```

Every custom node that imports opencv — **PuLID** and **IPAdapter** — is dead as a result. This adds an idempotent `libgl1` install to the root privilege-drop block of `entrypoint.sh`, gated on `ldconfig -p | grep -q libGL.so.1`, matching the existing `gosu` install pattern. Only installs when the library is absent (one-time per container lifecycle, re-runs after `compose up --force-recreate` just like gosu).

## Verified against the running container

- `docker exec comfyui-qwen python -c "import cv2"` → `libGL.so.1: cannot open shared object file`
- `docker exec comfyui-qwen ldconfig -p | grep libGL` → `libglib-2.0.so.0` present, **`libGL.so.1` absent**
- `ctypes.util.find_library("GL")` → `None`

## Scope

- Docker config only (`docker-configurations/services/comfyui-qwen/entrypoint.sh`), 8 insertions.
- No Dockerfile exists for the main service (`image: python:3.11` directly; only the `idle-monitor` sidecar builds), so the runtime apt-get is the correct fix location — same pattern as gosu.
- `bash -n` syntax check: OK.

## Not addressed (out of scope — tracked separately)

The **Z-Image INT4** loader (`NunchakuZImageDiTLoader`) is a different defect: `cannot import name 'patch_scale_key' from 'nunchaku.models.transformers.utils'`. Root cause is a torch/nunchaku **version** mismatch, not a missing system lib:
- container torch = `2.6.0+cu124` (CUDA 12.4)
- `patch_scale_key` only ships in nunchaku backend builds whose released wheels target `cu12.8 + torch 2.10/2.11` (v1.2.x); the only CUDA-13 nightly is incompatible with our CUDA 12.4.

Fixing Z-Image therefore requires a **torch 2.6 → 2.10/2.11 upgrade** in the live `comfyui-qwen` service (which also serves `qwen-image-edit`). That is a coordinated stack migration needing a GPU maintenance window and ai-01 greenlight — deliberately not bundled into this safe libgl1 PR.

See #3164 (axe-2 service hardening).
