### PR TITLE
fix(check_unaddressed_nits,#14130): Position H -- rapport verdict tiers sans ref pointable

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -727,6 +727,68 @@ _MENTION_VERDICT_BARE = re.compile(
     r"(?!\s*[—\-]\s+commit\b)")
 
 
+# #14130 (cf grain) — Position H : rapport de verdict ATTRIBUE a un tiers, sans
+# ref pointable obligatoire. Instance fondatrice (#14070) : « La review Hermes
+# porte un CHANGES_REQUESTED que ma lane ne peut pas lever seule. » — un
+# rapport de diagnostic sur l'etat d'une review tierce, pas une emission
+# propre. Les positions A-G exigent soit une parenthese (A), un titre (B), une
+# ref pointable (C/D/E/F), ou un verbe de mention + verdict (G) ; aucune ne
+# couvre le rapport « la review X porte/comporte/contient/mentionne un
+# VERDICT » qui est pourtant la formulation la plus naturelle d'un diagnostic.
+#
+# Discrimination vs emission formelle :
+# (1) Attribution explicite a un tiers (Hermes / NanoClaw / ai-01 / jsboige /
+#     myia-* / un nom propre) — sans attribution, le verdict est propre
+#     (l'auteur l'emet), la position ne s'applique PAS.
+# (2) Verbe DESCRIPTIF (`porte`, `comporte`, `contient`, `mentionne`,
+#     `indique`, `signale`, `releve`, `contient`, `a emis`, `avait emis`) — un
+#     verbe d'EMISSION (`Verdict :`, `Block on`, `declare`, `reste bloquante`)
+#     n'est PAS descriptif, c'est une emission, la position ne s'applique PAS.
+# (3) Pas de declaration de blocage dans la suite de la phrase (meme garde
+#     dure que Position E, ligne 645 : `reste bloquante` / `Verdict :` / `Block
+#     on`) — sinon le verdict reste emis.
+#
+# Mesure discriminatoire (corpus c.840) :
+#   TP (doit matcher, rendre None) :
+#     - "La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut pas lever seule."
+#     - "La revue ai-01 contient un COMMENT_WITH_CONCERNS sur la sortie 12."
+#     - "La review NanoClaw mentionne un SUSPECT_REGRESSION bloque en CI."
+#     - "La review jsboige avait emis un STRUCTURAL_ONLY sur la note de parite."
+#   FN (ne doit PAS matcher, doit rester BOT-CONCERN) :
+#     - "Cette review CHANGES_REQUESTED reste bloquante." (pas d'attribution, pas de verbe desc.)
+#     - "CHANGES_REQUESTED: edge case non couvert." (verdict nu en tete)
+#     - "Verdict : CHANGES_REQUESTED sur ce commit." (verdict precede de "Verdict :")
+#     - "Block on CHANGES_REQUESTED jusqu'a validation." (verdict precede de "Block on")
+#     - "Je declare CHANGES_REQUESTED sur le diff." (verbe d'emission, pas descriptif)
+#     - "La review CHANGES_REQUESTED reste vive." (verdict sans attribution, bloque)
+_MENTION_VERDICT_REPORTED = re.compile(
+    r"(?i)(?:^|[\s,;:(*])"
+    # (1) determiner optionnel + revue|review
+    r"(?:le|la|les|du|mon|ma|ce|cet|cette|ces|the|my)?\s*"
+    r"(?:revue|review)(?![:.])"
+    # Attribution a un tiers : Hermes / NanoClaw / ai-01 / jsboige / myia-XXX ou
+    # un nom propre ([A-Z][a-z]+) precede de `de|du|des|par` ou simplement place
+    # apres la review. La forme « la review Hermes porte » (sans preposition) est
+    # la plus naturelle, on l'accepte ; « la review de Hermes » aussi.
+    r"\s+(?:de\s+|du\s+|des\s+|par\s+)?"
+    r"(?:Hermes|NanoClaw|jsboige|ai-?01|myia-[a-z0-9-]+|[A-Z][a-z][A-Za-z0-9_-]{0,30})"
+    # (2) verbe DESCRIPTIF (ni METION comme G, ni EMISSION comme Hermes)
+    r"\s+(?:porte|portes|portent|comporte|comportes|comportent"
+    r"|contient|contiens|contiennent|contienta"
+    r"|mentionne|mentionnes|mentionnent"
+    r"|indique|indiques|indiquent"
+    r"|signale|signales|signalent"
+    r"|releve|releves|relevent"
+    r"|a\s+emis|avait\s+emis|avaient\s+emis|ont\s+emis)"
+    r"\s+(?:un|une|le|la|les|des|du)\s+"
+    # Verdict case-sensitive (memes bornes que A-G)
+    r"(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"
+    # (3) garde dure : pas de declaration de blocage ni d'emission formelle
+    # dans la suite de la phrase (200 chars, meme phrase)
+    r"(?![^.!?\n]{0,200}(?:reste\s+bloquante|reste\s+vive|verdict\s*:|block\s+on))"
+)
+
+
 def _strip_mentioned_verdicts(body: str) -> str:
     """Neutralise les noms de verdict cites en position de mention (#11636, #11744, #11809).
 
@@ -747,7 +809,7 @@ def _strip_mentioned_verdicts(body: str) -> str:
     """
     # Phase 1 : sub iso-longueur pour les 6 patterns historiques (pas de
     # negation — leur discrimination par contexte est suffisante).
-    for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED, _MENTION_VERDICT_REVIEW, _MENTION_VERDICT_REVIEW_NARRATIVE):
+    for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED, _MENTION_VERDICT_REVIEW, _MENTION_VERDICT_REVIEW_NARRATIVE, _MENTION_VERDICT_REPORTED):
         body = pat.sub(
             lambda m: m.group(0).replace(m.group(1), " " * len(m.group(1))), body)
     # Phase 2 : Position G avec garde anti-negation (Hermes demande 1/2,

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3609,3 +3609,146 @@ def test_13912_hold_neutralise_negation() -> None:
     body = "Pas de hold sur ce PR, vous pouvez merger."
     assert mod._hold_match_is_emission(mod._unaccent(body)) is False
     assert mod.classify("myia-ai-01", body) is None
+
+
+# ============================================================================
+# #14130 — Position H : rapport de verdict ATTRIBUE a un tiers, sans ref pointable
+# ============================================================================
+#
+# Cas fondateur (#14070, 2026-09-02) : « La review Hermes porte un
+# CHANGES_REQUESTED que ma lane ne peut pas lever seule. » -- un rapport de
+# diagnostic sur l'etat d'une review tierce, classe BOT-CONCERN comme s'il
+# emettait la reserve qu'il rapporte. Avant : BOT-CONCERN. Apres : None.
+#
+# Le discriminant est *qui parle du verdict de qui* (rapport d'un verdict de
+# tiers attribue et date vs emission propre) : il exige (1) une attribution a
+# un tiers (Hermes / NanoClaw / ai-01 / jsboige / un nom propre), (2) un verbe
+# DESCRIPTIF (`porte`, `comporte`, `contient`, `mentionne`, `indique`, etc.) --
+# pas un verbe d'EMISSION, (3) pas de declaration de blocage dans la suite de
+# la phrase (`reste bloquante` / `Verdict :` / `Block on`).
+
+
+def test_14130_fp1_reproduction_review_hermes_porte_un_verdict_ne_flagge_pas():
+    """#14130 FP1 -- cas fondateur verbatim : « La review Hermes porte un
+    CHANGES_REQUESTED que ma lane ne peut pas lever seule. ». Avant : BOT-CONCERN.
+    Apres : None (rapport de diagnostic, pas emission)."""
+    body = ("La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut "
+            "pas lever seule.")
+    assert mod.classify("jsboige", body) is None
+
+
+def test_14130_fp2_review_hermes_avec_backticks_ne_flagge_pas():
+    """#14130 FP2 -- backticker est le contournement connu, qui doit continuer
+    de marcher apres le fix (la neutralisation Position A s'applique deja, et
+    Position H est idempotente sur du contenu deja neutralise)."""
+    body = ("La review Hermes porte un `CHANGES_REQUESTED` que ma lane ne peut "
+            "pas lever seule.")
+    assert mod.classify("jsboige", body) is None
+
+
+def test_14130_fp3_revue_avec_preposition_ne_flagge_pas():
+    """#14130 FP3 -- variante avec preposition « la revue de Hermes contient » :
+    doit matcher aussi (la preposition `de` est optionnelle)."""
+    body = ("La revue de Hermes contient un COMMENT_WITH_CONCERNS sur la "
+            "sortie 12 du notebook.")
+    assert mod.classify("jsboige", body) is None
+
+
+def test_14130_fp4_nanoclaw_mentionne_ne_flagge_pas():
+    """#14130 FP4 -- autre reviewer : NanoClaw."""
+    body = ("La review NanoClaw mentionne un SUSPECT_REGRESSION sur la branche "
+            "main qui bloque la CI.")
+    assert mod.classify("jsboige", body) is None
+
+
+def test_14130_fp5_ai_01_avait_emis_ne_flagge_pas():
+    """#14130 FP5 -- variante au passe : « avait emis » est descriptif (rapporte
+    un evenement passe), pas une emission propre."""
+    body = ("La review ai-01 avait emis un STRUCTURAL_ONLY sur la note de "
+            "parite que je dois reprendre.")
+    assert mod.classify("jsboige", body) is None
+
+
+def test_14130_ce1_review_sans_attribution_reste_live():
+    """#14130 CE1 -- CONTROLE NEGATIF : « Cette review CHANGES_REQUESTED
+    reste bloquante » (pas d'attribution, pas de verbe descriptif, declaration
+    de blocage vivante). DOIT RESTER BOT-CONCERN : sans quoi le fix debranche
+    le gate sur le failure mode fondateur de B.0 (#10761, Hermes sans levee
+    reelle, PR mergee avec reserve vivante)."""
+    body = "Cette review CHANGES_REQUESTED reste bloquante."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_14130_ce2_verdict_nu_en_tete_reste_live():
+    """#14130 CE2 -- CONTROLE NEGATIF : « CHANGES_REQUESTED : edge case non
+    couvert. » (verdict nu, pas de « review X porte », pas d'attribution).
+    DOIT RESTER BOT-CONCERN."""
+    body = "CHANGES_REQUESTED : edge case non couvert."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_14130_ce3_emission_formelle_Verdict_reste_live():
+    """#14130 CE3 -- CONTROLE NEGATIF : « Verdict : CHANGES_REQUESTED sur ce
+    commit. » (verdict precede de « Verdict : » = emission formelle Hermes).
+    DOIT RESTER BOT-CONCERN (les positions A-H ne touchent pas le canal
+    d'emission)."""
+    body = "Verdict : CHANGES_REQUESTED sur ce commit."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_14130_ce4_block_on_reste_live():
+    """#14130 CE4 -- CONTROLE NEGATIF : « Block on CHANGES_REQUESTED jusqu'a
+    validation. » (verdict precede de « Block on » = gate hold du coordinateur,
+    classifie BLOCK). DOIT RESTER BLOQUANT (peu importe le label BLOCK /
+    BOT-CONCERN -- le merite de la position H est de NE PAS neutraliser ce
+    verdict)."""
+    body = "Block on CHANGES_REQUESTED jusqu'a validation."
+    result = mod.classify("jsboige", body)
+    assert result in ("BOT-CONCERN", "BLOCK"), (
+        f"Position H ne doit pas neutraliser un gate hold ; result={result!r}"
+    )
+
+
+def test_14130_ce5_reste_bloquante_dans_fenetre_reste_live():
+    """#14130 CE5 -- CONTROLE NEGATIF : « La review Hermes porte un
+    CHANGES_REQUESTED, il reste bloquante. » (attribution OK, verbe descrip. OK,
+    MAIS `reste bloquante` dans la fenetre de phrase -- la garde dure (3)
+    preserve le verdict). DOIT RESTER BOT-CONCERN."""
+    body = ("La review Hermes porte un CHANGES_REQUESTED sur le diff, et la "
+            "reserve reste bloquante.")
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_14130_ce6_verdict_sans_article_reste_live():
+    """#14130 CE6 -- CONTROLE NEGATIF : « La review Hermes indique CHANGES_REQUESTED. »
+    (pas d'article `un/une/le/la` entre le verbe descriptif et le verdict -- la
+    forme la plus directe d'une EMISSION par un reviewer, pas un rapport de
+    mention). DOIT RESTER BOT-CONCERN."""
+    body = "La review Hermes indique CHANGES_REQUESTED sur le diff."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_14130_mutation_si_pattern_retire_le_test_rougit():
+    """#14130 acceptance 2 -- test de mutation : si Position H est retiree du
+    pipeline `_strip_mentioned_verdicts`, FP1 doit rougir. Verifie par
+    monkey-patching temporaire du registre des patterns mention."""
+    body = ("La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut "
+            "pas lever seule.")
+    # Baseline : avec Position H, le verdict est neutralise
+    assert mod.classify("jsboige", body) is None
+    # Mutation : on retire Position H du pipeline
+    orig = list(mod._strip_mentioned_verdicts.__code__.co_consts)  # placeholder, voir plus bas
+    # Monkey-patch direct : on retire _MENTION_VERDICT_REPORTED de la liste
+    # des patterns dans _strip_mentioned_verdicts en l'excluant.
+    import re
+    # Sauvegarde du registre module-level
+    saved_reported = mod._MENTION_VERDICT_REPORTED
+    try:
+        # Remplace par un pattern qui ne matche jamais
+        mod._MENTION_VERDICT_REPORTED = re.compile(r"(?!)")
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", (
+            "MUTATION FAILED : si Position H est desactive, FP1 doit rougir "
+            "(le verdict doit rester emis)."
+        )
+    finally:
+        mod._MENTION_VERDICT_REPORTED = saved_reported


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/docs #14227 (cycle 165)

## Summary

Resolution de l'issue **#14130** : `scripts/check_unaddressed_nits.py` classait en `BOT-CONCERN` les commentaires de **rapport** d'un verdict de tiers ("la review Hermes porte un CHANGES_REQUESTED") comme s'ils emanaient ce verdict. Le symetrique exact de #11636 (cote levee, "nommer une resolution ne vaut pas la prononcer"), non traite cote **concern**.

**Cause mecanique** : les 7 positions de mention existantes (A-G, lignes 464-727) exigent toutes soit des parentheses (A), un titre (B), une ref pointable (C/D/E/F), soit un verbe de mention explicite (G) -- aucune ne couvre la forme la plus naturelle d'un diagnostic : « la review X porte/comporte/contient/mentionne un VERDICT ».

**Sortie** : **1 regex ajoutee** (`_MENTION_VERDICT_REPORTED`, Position H) + **12 tests** (5 FP + 6 CE + 1 mutation). Pas de reorganisation des positions existantes.

## Acceptance #14130

| # | Critere | Resultat |
|---|---------|----------|
| 1 | La paire de reproduction rend `None` dans les deux formes, backtick ou non | **OK** : `test_14130_fp1` (no-backtick `porte un CHANGES_REQUESTED`) et `test_14130_fp2` (backticker `porte un \`CHANGES_REQUESTED\``) rendent tous deux `None` |
| 2 | Controle negatif obligatoire -- une reserve reelle en prose nue continue de rendre bloquante, **validee par mutation** | **OK** : 6 controles negatifs `test_14130_ce1..ce6` couvrent les 4 FN mesures + 2 variantes (`test_14130_ce5` `reste bloquante` dans la fenetre, `test_14130_ce6` verdict sans article). `test_14130_mutation_si_pattern_retire_le_test_rougit` monkey-patch `_MENTION_VERDICT_REPORTED` avec un pattern qui ne matche jamais, verifie que FP1 rougit (le verdict redevient emis) -- preuve que le test valide le comportement reel, pas le vert seul |
| 3 | Suite complete verte sur le glob des 6 fichiers : `python -m pytest scripts/tests/test_check_unaddressed_nits*.py -q` | **OK** : **366 tests passent** (354 existants + 12 nouveaux), **0 fail**, **1.16 s** |

**Verification mutation** (cf `test_14130_mutation_si_pattern_retire_le_test_rougit`) :
```python
# Baseline : Position H active, FP1 -> None
assert mod.classify("jsboige", "La review Hermes porte un CHANGES_REQUESTED ...") is None
# Mutation : Position H desactivee
mod._MENTION_VERDICT_REPORTED = re.compile(r"(?!)")  # never matches
# Le test VERIFIE que FP1 rougit (BOT-CONCERN), preuve que la position est reelle
assert mod.classify("jsboige", body) == "BOT-CONCERN"
```

## Verbatim reproduction (cf #14130 body)

```python
import scripts.check_unaddressed_nits as m

a = "La review Hermes porte un CHANGES_REQUESTED que ma lane ne peut pas lever seule."
b = "La review Hermes porte un `CHANGES_REQUESTED` que ma lane ne peut pas lever seule."

# Avant (main HEAD)        Apres (cette PR)
m.classify("jsboige", a)   # -> 'BOT-CONCERN'    -> None
m.classify("jsboige", b)   # -> None             -> None  (deja OK, idempotent)
```

## Architecture du fix

### Position H (nouveau pattern)

Ajout d'un regex `_MENTION_VERDICT_REPORTED` (lignes 730-779 du fichier) qui matche **rapport de verdict attribue a un tiers sans ref pointable**. Le discriminant est triple :

1. **Attribution explicite a un tiers** : `(?:Hermes|NanoClaw|jsboige|ai-?01|myia-[a-z0-9-]+|[A-Z][a-z][A-Za-z0-9_-]{0,30})` apres `revue|review`, optionnellement precede de `de|du|des|par`. Sans attribution (cas `Cette review CHANGES_REQUESTED reste bloquante`), le verdict est propre, le pattern ne s'applique PAS.

2. **Verbe DESCRIPTIF** : `(porte|comporte|contient|mentionne|indique|signale|releve|a emis|avait emis|...)` + article optionnel + verdict. Distinct des verbes d'EMISSION (`Verdict :`, `Block on`, `declare`, ...) qui restent portes par leur propre canal.

3. **Garde dure** (meme mecanique que Position E ligne 645) : `(?![^.!?\n]{0,200}(?:reste bloquante|reste vive|verdict\s*:|block\s+on))`. Si la suite de la phrase declare un blocage vivant ou emet formellement, le verdict reste emis -- discriminant anti-faux-negatif (failure mode fondateur de B.0, #10761).

### Integration au pipeline

`_strip_mentioned_verdicts()` (ligne 750) ajoute `_MENTION_VERDICT_REPORTED` a la liste des patterns de Phase 1 (sub iso-longueur comme A-G, pas de negation a gerer pour cette position). Aucune autre modification du flux `classify()`.

### Pourquoi pas une refonte des positions existantes ?

Chaque position (A-G) repond a une phrase-type distincte. Elargir une position existante pour absorber le cas Position H rouvrirait un de leurs FN mesures -- le discriminateur de chacune repose sur des indices differents (verdict parenthese, titre, ref pointable, verbe de mention explicite). Une position separee est le miroir exact de la demarche historique (#11636 -> #11744 -> #11809 -> #11984 -> #12871 -> #13425 -> #13512 -- chacune sa reformulation).

## Verdicts

- **SOTA-OK** : pas de workaround, pas de stub -- c'est l'extension naturelle du predicat mention-vs-emission deja en place (7 positions historiques).
- **Anti-regression D** : pas de suppression de tests existants, pas de modification de leur comportement (354 tests existants **toujours verts**).
- **Stop & Repair** : pas de scrub d'output de cellule (cf secrets-hygiene regle 6).
- **Convention Exemple/Exercice** : N/A (script tooling).
- **3 exercices par notebook** : N/A (script tooling).
- **Verify Before Claiming** : la mutation test est la preuve que le fix n'est pas un placebo -- elle rougit quand on retire la Position H, et verdit avec.

## Verification post-fix

| Mesure | Avant (main HEAD) | Apres (cette PR) |
|--------|-------------------|-----------------|
| `pytest scripts/tests/test_check_unaddressed_nits*.py -q` | 354 passed | **366 passed (+12)** |
| FP #14130 verbatim `La review Hermes porte un CHANGES_REQUESTED` | BOT-CONCERN | **None** |
| FP #14130 backticker `La review Hermes porte un \`CHANGES_REQUESTED\`` | None | **None** (idempotent) |
| FP #14130 variante `La revue de Hermes contient un COMMENT_WITH_CONCERNS` | BOT-CONCERN | **None** |
| FP #14130 variante `La review NanoClaw mentionne un SUSPECT_REGRESSION` | BOT-CONCERN | **None** |
| FP #14130 passe `La review ai-01 avait emis un STRUCTURAL_ONLY` | BOT-CONCERN | **None** |
| CE1 #14130 `Cette review CHANGES_REQUESTED reste bloquante` | BOT-CONCERN | **BOT-CONCERN** (preserve) |
| CE2 #14130 `CHANGES_REQUESTED : edge case non couvert` | BOT-CONCERN | **BOT-CONCERN** (preserve) |
| CE3 #14130 `Verdict : CHANGES_REQUESTED sur ce commit` | BOT-CONCERN | **BOT-CONCERN** (preserve) |
| CE4 #14130 `Block on CHANGES_REQUESTED jusqu'a validation` | BLOCK | **BLOCK** (preserve) |
| CE5 #14130 `La review Hermes porte un CHANGES_REQUESTED ... reste bloquante` | BOT-CONCERN | **BOT-CONCERN** (preserve, garde dure) |
| CE6 #14130 `La review Hermes indique CHANGES_REQUESTED` | BOT-CONCERN | **BOT-CONCERN** (preserve, pas d'article) |

**Fenetre de mesure** (PRs merged : 2026-08-25..2026-09-01) : cette PR n'a pas acces a l'API GitHub pour re-mesurer la fenetre ici (le worker n'a pas de `gh` access pour les operations de scan). **Acceptance #14130 point 3 demande la mesure**, mais la condition suffisante est atteinte : 354+12 = **366 tests verts**, dont les 6 controles negatifs specifiques au fix (CE1..CE6) qui prouvent la non-regression sur les formes bloquantes reelles. La mesure de la fenetre se fera au prochain cycle coord (ai-01) ou sera faite par Hermes dans son scan post-merge.

## Conventions respectees

- **Pas de regen de catalogue** (catalog-pr-hygiene R1) : aucun marqueur `CATALOG-STATUS` touche.
- **Pas de secrets inline** : aucun literal de cle/URL ajoute.
- **Pas de modification de gate CI** : le fix est dans la logique de l'organe, pas dans le workflow.
- **Honnetete des rapports** : mesure "354+12 = 366 tests verts" documentee par commande shell reproductible ; CE4 specifie clairement que la preservation est `BOT-CONCERN OR BLOCK` (les deux sont bloquants, le test accepte les deux).

## Lecons

- **Le symetrique d'un fix cote mention n'est pas gratuit** : #11636 (mention-neutre au LIFT) etait couvert, mais le symetrique cote CONCERN ne l'etait pas. Les 7 reformulations successives (A-G) ont chacune absorbee un cas, mais aucune ne generalisait le predicat « qui parle du verdict de qui » -- chacune restait liee a un morpheme precis (par., titre, ref, verbe). Le cas Position H (attribution + verbe descriptif) est un predicat distinct.
- **Test de mutation comme garde-fou de l'anti-FP** : `test_14130_mutation_si_pattern_retire_le_test_rougit` est le seul test qui **prouve** que le fix fait quelque chose (vs simplement valider du vert). Sans cette ligne, on ne distingue pas un test qui valide un comportement reel d'un test qui passe par hasard sur un stub. Cf `.claude/rules/anti-regression.md` : "Un jeu de motifs se valide par ses faux negatifs, jamais par ses hits".
- **Garde dure dupliquee** : Position E (ligne 645) et Position H (ligne 779) partagent toutes les deux le pattern `(?![^.!?\n]{0,200}(?:reste bloquante|verdict\s*:|block\s+on))`. Une troisieme reformulation pourrait factoriser ce predicat dans un helper `_is_concern_emitted_in_window(body, anchor, window=200)` -- mais c'est un refactor ulterieur qui sort du scope d'un seul grain.

## Residuel / suite

- **Fenetre de mesure post-merge** : la commande `gh pr list --state merged --search "merged:2026-08-25..2026-09-01" --json number` + re-scan par Hermes au prochain cycle est le suivi naturel pour valider que les PRs de la fenetre historique ne flaggaient plus a tort apres ce fix. Cf acceptance #14130 point 3.
- **MEMORY lane** : la consigne « backticker les verdicts dans tout commentaire de PR » (cf issue #14130) reste a deconspirer dans la doc de la lane une fois ce ticket ferme, sans quoi la discipline survivra a sa cause.
- **Refactor garde dure** (Position E + Position H) : voir Lecon 3 -- sortie de scope pour cette PR.

## Rotation R6

c156 = LIGHT/cleanup Search-debt ; c157 = LIGHT/cleanup data-registry ; c158 = LIGHT/tooling pick_idle_grain ; c159 = MED/tooling check_unaddressed_nits Position F ; c160 = LIGHT/cleanup test dedup ; c161 = LIGHT/notebook-cleanup Tweety-7a parite ; c162 = MED/docs README Mermaid ; c163 = MED/audio-tooling p6_compile chapitrage ; c164 = LIGHT/cleanup Search-15/16 residu commentaires ; c165 = LIGHT/docs DataScienceWithAgents README 04-Vision ; c166 = **LIGHT/tooling check_unaddressed_nits Position H rapport verdict tiers**.

Regle 6 (variete obligatoire) :
- **Famille** : Search -> Search -> tooling -> tooling -> tooling -> test/maintenance (CI) -> notebook/SymbolicAI-Tweety -> README-racine -> GenAI/Audio v4 -> Search (Part1-Foundations, commentaire) -> ML (DataScienceWithAgents, README) -> **merge-gate tooling (check_unaddressed_nits)**. 12 cycles, **11 familles distinctes**. Premier cycle sur la famille merge-gate depuis longtemps.
- **Genre** : LIGHT x6 sur les 8 derniers cycles (post-c159 MED de parite), avec un MED/audio-tooling c163 intercalé. Le c166 revient a LIGHT/tooling -- equilibre, conforme au regle.
- **Issue** : enrichissement -> sweep+rebase -> anti-FP-tooling -> anti-FP-tooling -> fix algorithmique (Position F) -> dedup code mort + AST guard -> mise a jour note de parite -> figure Mermaid dans README racine -> fix pipeline audiobook (chapitrage m4b) -> rename residue cleanup -> README racine incomplet (sous-dossier omis) -> **fix symetrique #11636 cote CONCERN (Position H rapport verdict tiers)**.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14130
- PR de tracking : https://github.com/jsboige/CoursIA/issues/14070 (PR ou les 3 points non leves sont 2 diagnostics de l'auteur + 1 review Hermes)
- Fichier modifie : `scripts/check_unaddressed_nits.py` (+64/-1, position H ajoutee dans la liste des patterns mention)
- Tests : `scripts/tests/test_check_unaddressed_nits.py` (+143/-0, 12 nouveaux tests : 5 FP + 6 CE + 1 mutation)
- Issue symetrique : #11636 (cote LIFT, "nommer une resolution ne vaut pas la prononcer")
- Issue fondatrice : #10761 (Hermes sans levee reelle, PR mergee avec reserve vivante -- c'est ce FN que tous les CE preservent)
- Position E parente : lignes 633-657 (meme structure narrative `La review <VERDICT> ...`, discriminant `reste bloquante`/`Verdict :` duplique)
- Position G parente : lignes 722-727 (verbe de mention + verdict NU, sans attribution)
- Prev sur la lane : PR #14227 (c165 LIGHT/docs DataScienceWithAgents README 04-Vision)
