### PR TITLE
fix(slides): scinder Extensions 2020+ (2/2) — resorber le hors-cadre de la slide 58

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -1645,12 +1645,6 @@ layout: section
 - Conditionnement multimodal
 - Mécanisme attentionnel (cross-attention Q/K/V)
 
-**Alignement et produit grand public**
-
-- RLHF (2022, InstructGPT) : affinage par retour humain
-- ChatGPT (nov. 2022, OpenAI) : 100 M d'utilisateurs en 2 mois
-- Modèles open-weight : Llama 2 (2023), Mistral, Mixtral (MoE 2023-2024)
-
 <div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
 <img src="./images/img_110.png" class="max-h-[190px] w-full object-contain" alt="Trois paires image-légende : rue de Kyoto, aigle en vol, paysage montagneux" />
 <img src="./images/img_111.png" class="max-h-[190px] w-full object-contain" alt="CLIP : plongements image et texte comparés, mise à jour des modèles, verdict similaire ou non" />
@@ -1658,8 +1652,23 @@ layout: section
 <img src="./images/img_113.png" class="max-h-[190px] w-full object-contain" alt="U-Net de débruitage latent : encodeur, décodeur, attention croisée Q/K/V, conditionnements et pas de temps" />
 </div>
 
-<!-- Multimodaux : CLIP (2021) contraste texte-image, DALL-E (2022), GPT-4V / Gemini (2023). Diffusion latente (LDM / Stable Diffusion, Rombach 2021-2022) : bruit latent + U-Net + cross-attention. Alignement : RLHF (InstructGPT 2022), ChatGPT (nov 2022), Llama 2 / Mistral / Mixtral (2023-2024). -->
+<!-- Multimodaux : CLIP (2021) contraste texte-image, DALL-E (2022), GPT-4V / Gemini (2023). Diffusion latente (LDM / Stable Diffusion, Rombach 2021-2022) : bruit latent + U-Net + cross-attention. -->
 ---
+
+
+# Extensions 2020+ (2/2)
+
+**Alignement et produit grand public**
+
+- RLHF (2022, InstructGPT) : affinage par retour humain
+- ChatGPT (nov. 2022, OpenAI) : 100 M d'utilisateurs en 2 mois
+- Modèles open-weight : Llama 2 (2023), Mistral, Mixtral (MoE 2023-2024)
+
+<!-- Alignement : RLHF (InstructGPT 2022), ChatGPT (nov 2022), Llama 2 / Mistral / Mixtral (2023-2024). -->
+---
+
+
+
 
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2023:CoursIA-2 — prev: DEEP/qc #14217

## Résumé

Scinder la slide « Extensions 2020+ » en **« Extensions 2020+ (2/2) »** pour resorber le hors-cadre de la slide 58 du deck `slides/S3-acculturation/slides.md`.

**Problème** : la slide 58 débordait du canevas déclaré (980×552). La section « Alignement et produit grand public » (RLHF / ChatGPT / Llama 2) sortait sous le pli — `content_bottom` **668 > 552**, **6 éléments hors-canvas** (le `P`, le `STRONG` et le `UL` + 3 `LI` de cette sous-section s'étendaient de y=552 à y=673).

**Solution (voie « scinder en 2/2 »)** : la slide 58 ne porte plus que « Modèles multimodaux » + « Modèles de diffusion » + la grille des 4 images (img_110-113, toutes multimodal/diffusion) ; la sous-section « Alignement et produit grand public » part sur une nouvelle slide dédiée. Le petit paragraphe de source (`<!-- ... -->`) est scindé en deux afin que chaque slide cite uniquement ses sources.

## Mesure (scan_slidev_composition.py, Playwright headless + dev server slidev 51.8.2)

| Métrique | Avant | Après |
|---|---|---|
| `n_hors_canvas` (deck) | **1** (slide 58) | **0** |
| slide 58 `content_bottom` | **668** | **547** (< 552) |
| slides (parse `@slidev/parser`) | 100 | 101 |
| slide 58 hors-canvas | 6 éléments | 0 |
| slide 59 (nouvelle « 2/2 ») | — | hors-cadre 0 |

Le découpage source ↔ rendu est vérifié : le parseur ne re-tranche plus le bloc `---`/titre comme un frontmatter (le titre est désormais précédé de lignes vides, convention du deck) — c'était le piège `Unresolved alias *Alignement` détecté au premier essai et corrigé.

## Scope

- **Modifié** : `slides/S3-acculturation/slides.md` (+16 / −7), une seule slide scindée, aucun contenu supprimé (RLHF/ChatGPT/Llama 2 préservés sur la nouvelle slide).
- **Non touché** : `#14192` (branche `fix/slides-10950-extensions-refresh`, autre lane) — ce fix part de `main` et ne le modifie pas.

## Validation

- `scan_slidev_composition.py` **exit 1 attendu** (constats occupation préexistants sur les slides à grille d'images à droite : {7, 23, 57}), mais **`n_hors_canvas == 0`** — le critère demandé.
- Parse `@slidev/parser` **OK (101 slides)** sans erreur YAML.
- Vérification visuelle Slidev manuelle recommandée avant merge (QA esthétique), l'instrument étant advisory.
