### PR TITLE
ci(guard,#14206): leaky fixture sweep — date-window bomb detector (advisory)

### DIFF
--- a/.github/workflows/leaky-fixture-sweep.yml
+++ b/.github/workflows/leaky-fixture-sweep.yml
@@ -1,0 +1,102 @@
+name: Leaky Fixture Sweep (date-window)
+
+# Advisory detector for the date-bomb defect class that reddened main at
+# 2026-09-02T00:24Z (picker, #14206): a test fixture pinning an ABSOLUTE date
+# (e.g. mergedAt: "2026-09-01T00:00:00Z") while its module derives a sliding
+# window from the REAL clock (NOW - timedelta(days=1)). On the next calendar
+# boundary the fixture falls out of the window and the test fails, breaking
+# main for the whole fleet with no push, no review, no guard able to catch it.
+#
+# The organ proves the class by doing the thing that breaks it: advance the
+# clock (libfaketime) and run the clock-windowed test surface. A test that
+# survives +8d/+31d is not a bomb; one that fails IS, and needs triage (make
+# the fixture relative to NOW, or justify the absolute date on the issue).
+#
+# Advisory BY CONSTRUCTION: schedule- + dispatch-only, never on
+# pull_request/push, so a red run can never block a PR on an unrelated diff —
+# the exact failure mode #14206 is built to avoid. A red run here means a real
+# date-window fixture exists and must be triaged.
+#
+# Scope: the date-windowed test files only (not the full suite), for two
+# reasons honored firsthand (2026-09-02, po-2024):
+#   (1) scripts/audit/tests + scripts/quantconnect/tests are CI-EXCLUDED from
+#       scripts-tests.yml (#2037/#2871): their suites need yfinance, external
+#       data files or an OpenAI key at collection. Targeting the individual
+#       hermetic file (not the directory) keeps collection clean (verified:
+#       test_nit_lift_authorship.py + test_audit_projects.py collect with
+#       pytest alone).
+#   (2) the full scripts/tests suite bails at import (test_check_workflow_
+#       label_paths.py triggers sys.exit(2) at load), which would mask the
+#       date-bomb signal in collection-noise. The date-windowed surface re-
+#       scopes the sweep to the files that actually derive windows from NOW.
+#
+# The candidate list below comes from the #14206 table (date-fragile files
+# identified by their pinned absolute dates). Sweeping them daily catches a
+# REGRESSION (future change re-introducing a bomb) without the collection
+# noise of the full suite. A new date-fragile file should be added here when
+# a new date-window test lands.
+
+on:
+  schedule:
+    # Daily, off-:00 minute (avoid the :00/:30 API spike).
+    - cron: '43 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: leaky-fixture-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Date-window sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install pytest + libfaketime
+        run: |
+          python -m pip install --quiet pytest
+          sudo apt-get update
+          sudo apt-get install --yes libfaketime
+
+      # The date-windowed surface. Each file is a single target so collection
+      # stays hermetic (no sibling deps). 189 tests green on main under both
+      # horizons (validated 2026-09-02, po-2024).
+      # Native FAKETIME offset format (+8d, +31d): passed through the wrapper
+      # verbatim. Matches the validated evidence (2026-09-02: both horizons
+      # green, 189 tests).
+      - name: Sweep clock-windowed surface at +8 days
+        run: |
+          faketime '+8d' python -m pytest \
+            scripts/tests/test_pick_idle_grain.py \
+            scripts/tests/test_pick_idle_grain_cache.py \
+            scripts/tests/test_pick_nanoclaw_concerns.py \
+            scripts/tests/test_pick_claim_filter.py \
+            scripts/tests/test_substance_drought.py \
+            scripts/tests/test_coordination_budget.py \
+            scripts/audit/tests/test_nit_lift_authorship.py \
+            scripts/quantconnect/tests/test_audit_projects.py \
+            --tb=short -q
+
+      - name: Sweep clock-windowed surface at +31 days
+        run: |
+          faketime '+31d' python -m pytest \
+            scripts/tests/test_pick_idle_grain.py \
+            scripts/tests/test_pick_idle_grain_cache.py \
+            scripts/tests/test_pick_nanoclaw_concerns.py \
+            scripts/tests/test_pick_claim_filter.py \
+            scripts/tests/test_substance_drought.py \
+            scripts/tests/test_coordination_budget.py \
+            scripts/audit/tests/test_nit_lift_authorship.py \
+            scripts/quantconnect/tests/test_audit_projects.py \
+            --tb=short -q


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/guard #14201

# Organe pour la classe bombe-a-retardement « fixture datée absolue » (#14206)

`See #14206` — l'organe demandé par l'issue : un **workflow advisory quotidien** qui fait tourner la surface sous une **horloge avancée** (`libfaketime`) et prouve qu'un test n'est pas une bombe au lieu de le présumer.

## La classe de défaut fermée

Le 2026-09-02T00:24Z, `main` est passé au rouge **sans qu'aucune PR soit poussée** : les fixtures de `test_pick_idle_grain_cache.py` épinglaient `mergedAt: "2026-09-01T00:00:00Z"` alors que `pick_idle_grain.fetch_visits` dérive une fenêtre glissante de 24 h de l'horloge réelle. Le 02/09 à 00:00, la date est sortie de la fenêtre et le compteur a rendu `{}` au lieu de `{13920: 1}`. Ni review, ni garde, ni reviewer humain ne pouvait l'attraper — le diff fautif avait été mergé la veille en étant vert.

Le code n'était pas en cause (à `miss`, le filtre serveur est déjà passé ; à `hit`, la charge utile plus vieille que le cutoff **doit** être re-filtrée — asymétrie délibérée et documentée). C'est la **fixture** qui est la bombe. Réparé par **#14197** (fixtures rendues relatives à `pig.NOW`).

## L'organe livré

`.github/workflows/leaky-fixture-sweep.yml` — **advisory par construction** : `schedule:` quotidien (03:43 UTC) + `workflow_dispatch` uniquement, **jamais sur `pull_request`/`push`**, donc un run rouge ne peut jamais bloquer une PR sur un diff sans rapport — le mode d'échec que #14206 veut éviter. Il installe `libfaketime` (paquet apt, aucune dépendance Python nouvelle, pas de `freezegun` dans la suite) et balaie la surface à **deux horizons** : `+8d` (fenêtres courtes : 24 h / 7 j — la classe de cette nuit) et `+31d` (fenêtres mensuelles et bascules de mois).

## Validation — le contrôle positif, obligatoire (acceptance 2)

Un détecteur se valide par ses **faux négatifs**. L'organe en a un gratuit : sur le **parent de #14197** (fixtures encore épinglées), il **doit** reproduire les deux échecs de la nuit. Exécuté — `scripts/tests/test_pick_idle_grain_cache.py`, `FAKETIME=+1d` (équivalent natif de `faketime '+1 day'`) :

```
HEAD=32a824137c   # parent exact de #14197
collected 14 items
scripts/tests/test_pick_idle_grain_cache.py ............FF
FAILED test_three_shared_payloads_are_reused_without_changing_derivations
    At index 1 diff: ({13920: 1}, None) != ({}, None)
FAILED test_stale_visits_are_used_but_reported_as_unmeasured
    assert {} == {13920: 1}
========================= 2 failed, 12 passed in 2.03s =========================
(POSCONTROL_EXIT=1)
```

Les deux échecs de cette nuit sont **reproduits** sur le commit parent — l'organe mesure bien ce qu'on croit.

## Contrôle négatif (même commit convenable, main après fix)

Les deux mêmes tests sur `main` post-#14197 sous `+1d` passent :

```
2 passed, 12 deselected in 2.18s
(NEGCONTROL_EXIT=0)
```

## Balayage complet à deux horizons (acceptance 3 — triage)

La surface candidate de #14206 (8 fichiers qui épinguent une date absolue **et** importent un module à fenêtre glissante) exécutée sous `+8d` **et** `+31d`, invocation exacte du workflow (cwd repo-root, pytest seul) :

```
+8d  : 189 passed in 6.48s
+31d : 189 passed in 6.75s
```

**0 échec découvert.** Le triage est donc : la seule bombe réelle était celle de `test_pick_idle_grain_cache.py` (réparée par #14197) ; les 7 autres candidats sont **sains** sous les deux horizons — une date épinglée n'est pas une bombe quand elle n'est jamais comparée à la fenêtre. **Aucune conversion en masse, aucune modification de fixture** : la règle #14206 l'interdit explicitement.

## Décision de périmètre : 8 fichiers, pas les répertoires entiers

L'issue proposait `pytest scripts/tests scripts/audit/tests -q`. Le balayage visa **les 8 fichiers candidats**, pour deux raisons vérifiées :

1. **Le tableau de #14206 EST la surface** — il énumère les 8 fichiers qui épinguent une date absolue ET importent un module à fenêtre glissante. Balayer les répertoires entiers balaierait des dizaines de fichiers sans date épinglée.
2. **Les répertoires entiers ne se collectent pas sur un runner nu** — `test_check_workflow_label_paths.py` importe `check_workflow_label_paths.py`, qui fait `sys.exit(2)` **à l'import** quand PyYAML est absent ([line 56-64](scripts/check_workflow_label_paths.py#L56-L64)). Sur un runner avec `pytest` seul, la session entière s'abrège en erreur de collection et **masque le signal bombe**. Éviter cela exigerait d'installer tout le stack `scripts-tests.yml` (numpy/pandas/torch/arch/bcrypt/…), contraire à l'esprit « aucune dépendance Python nouvelle » de l'issue et au coût d'un run quotidien.

Chaque fichier est donc ciblé individuellement → collection **hermétique** avec `pytest` seul (vérifié : 189 verts aux deux horizons), bas-bruit, cohérent avec la table de l'issue.

## Notes pour ai-01

- **Genre `guard` (META)** — ne tient pas le plancher G-VAR-1 ; à traiter en side-track, pas en plat principal (comme l'annonce #14206 elle-même).
- **Rien d'autre ne change** : aucune fixture ni module modifié — il n'y a rien à corriger (le tri a rendu 0 échec). Le livrable est **l'organe seul**.
- **`See #14206`** et non `Closes` : l'issue porte l'acceptance 3 (triage) qui est une posture continue; le coordinateur tranche la fermeture.

**Périmètre : 1 fichier** — `.github/workflows/leaky-fixture-sweep.yml` (+102).

Les « 8 fichiers » du body désignent la **surface de scan de l'issue #14206** (les fichiers candidats balayés), jamais le périmètre de cette PR — qui est le workflow ci-dessus, seul modifié.
