### PR TITLE
fix(notebook-tools,#14222): D5 enumeration orphan = missing level, not farthest (ICT-1 0,6875 visible)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -945,6 +945,47 @@ def _distinct_levels(values: list[float], tol: float = RELATIVE_TOLERANCE) -> in
     return count
 
 
+# #14222 -- `MISSING_FROM_PROSE_ENUMERATION` choisit l'orphelin par *appartenance
+# au niveau output*, pas par distance relative maximale a l'enumeration prose
+# (la formulation originale `max(dist)` laissait `0,6875` invisible : il est
+# proche de 0,19 et de 1,875, donc il ne gagne jamais le maximum, et la garde
+# ne le nomme pas). Cette variante rend la liste des REPRESENTANTS (premiere
+# valeur de chaque groupe de tolerance) ; le predicat devient : « un representant
+# output sans correspondance dans l'enumeration prose a la tolerance du
+# groupement ». Pour ICT-1 (pre-fix) : representants = [0,1875 ; 0,6875 ; 2,3125],
+# enumeration = [0,19 ; 2,31], orphelin = 0,6875. Pour ICT-1 (post-fix) :
+# enumeration = [0,19 ; 0,69 ; 2,31], tous representants sont couverts -> 0 orphelin.
+#
+# Borne assumee : la tolerance utilisee pour le groupement est la meme que celle
+# du test d'appartenance. Si elle divergeait, on retomberait dans la classe de
+# defaut fondateur (un representant couvre un niveau prose a 6% alors qu'un
+# autre a 4% -- le second serait orphelin a tort). On garde la tolerance unique.
+
+
+def _distinct_level_values(values: list[float],
+                            tol: float = RELATIVE_TOLERANCE) -> list[float]:
+    """Liste des representants des niveaux distincts (le 1er de chaque groupe).
+
+    Ordre croissant. Vide si `values` vide. Meme algorithme que
+    `_distinct_levels`, mais on garde le representant au lieu du compteur.
+
+    Note: par convention, le representant est la valeur du groupe qui est la
+    plus PROCHE d'une autre donnee reelle (la mediane du groupe, dans la
+    majorite des cas -- c'est la 1re valeur rencontree apres le tri).
+    """
+    if not values:
+        return []
+    s = sorted(values)
+    reps: list[float] = [s[0]]
+    for v in s[1:]:
+        base = max(abs(reps[-1]), abs(v))
+        if base == 0:
+            continue  # 0 == 0 -> meme groupe
+        if abs(v - reps[-1]) / base > tol:
+            reps.append(v)
+    return reps
+
+
 def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
     """Analyse l'alignement prose <-> outputs pour un notebook."""
     p = Path(path)
@@ -1037,8 +1078,31 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
     # Tour 2 : MISSING_FROM_PROSE_ENUMERATION (#9416).
     # Pour chaque cellule markdown qui annonce une énumération de N niveaux,
     # compare N au nombre de niveaux distincts dans output_vals.
+    #
+    # #14222 — discrimination cassée. La formulation initiale choisissait
+    # l'orphelin par `max(dist_relative_a_enum)`, ce qui laissait
+    # silencieusement de cote les valeurs de niveau output PROCHES d'un
+    # niveau prose sans etre couvertes par lui (`0,6875` proche de `0,19`
+    # et de `1,875` ne gagne jamais le maximum, donc le verdict reste muet
+    # sur le cas fondateur ICT-1 ; la garde nommait `1,2` puis `14,0`,
+    # les deux fantaisistes, jamais `0,6875`). Le defaut fondateur
+    # attendu par l'acceptance #14222 : sur les deux revisions d'ICT-1
+    # encadrant `7de14792c`, le verdict doit differer, et l'orphelin
+    # du cote pre-fix doit valoir `0,6875`.
+    #
+    # Discrimination correcte : on choisit l'orphelin par APPARTENANCE au
+    # niveau output. Un representant output (1re valeur de chaque groupe
+    # de tolerance) est orphelin s'il n'a aucune valeur prose dans son
+    # voisinage (meme tolerance que le groupement). Pour ICT-1 (pre-fix) :
+    # representants outputs = [0,1875 ; 0,6875 ; 2,3125], enumeration prose
+    # = [0,19 ; 2,31] -> 0,1875 couvert (1% de 0,19), 0,6875 NON couvert
+    # (72% de 0,19 et 73% de 2,31), 2,3125 couvert (0,1% de 2,31) ->
+    # orphelin = 0,6875. Pour ICT-1 (post-fix) : enumeration = [0,19 ;
+    # 0,69 ; 2,31] -> les 3 representants trouvaient une prose proche ->
+    # pas de finding.
     if output_vals:
-        output_levels = _distinct_levels(output_vals)
+        output_reps = _distinct_level_values(output_vals)
+        output_levels = len(output_reps)
         for cell_idx, text, nums in prose_vals_per_cell:
             enum = _detect_prose_enumeration(text)
             if not enum:
@@ -1046,18 +1110,23 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
             prose_levels = _distinct_levels(enum)
             if prose_levels == 0 or output_levels <= prose_levels:
                 continue
-            # Trouve la valeur output « orpheline » la plus loin de la liste prose.
+            # Trouve le representant output non couvert par l'enumeration prose.
             orphan = None
             orphan_dist = -1.0
-            for ov in output_vals:
-                closest_p = min(enum, key=lambda p: abs(p - ov))
-                base = max(abs(closest_p), abs(ov))
+            for rep in output_reps:
+                closest_p = min(enum, key=lambda p: abs(p - rep))
+                base = max(abs(closest_p), abs(rep))
                 if base == 0:
+                    # Represente 0 couvert par une prose 0 -> match, pas orphelin.
                     continue
-                dist = abs(ov - closest_p) / base
+                dist = abs(rep - closest_p) / base
+                if dist <= RELATIVE_TOLERANCE:
+                    continue  # ce representant a une prose proche -> couvert
                 if dist > orphan_dist:
                     orphan_dist = dist
-                    orphan = ov
+                    orphan = rep
+            if orphan is None:
+                continue  # tous les representants sont couverts -> RAS
             snippet = text.strip().splitlines()
             snippet = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
             findings.append(AlignmentFinding(
@@ -1067,12 +1136,15 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
                 category="MISSING_FROM_PROSE_ENUMERATION",
                 prose_text=snippet,
                 prose_number=float(prose_levels),
-                closest_output_number=orphan if orphan is not None else None,
+                closest_output_number=orphan,
                 tolerance_used="enumeration-vs-outputs",
                 details=(
                     f"prose enumere {prose_levels} niveaux distincts, "
                     f"outputs exhibent {output_levels} niveaux distincts "
-                    f"(orphan={orphan:.4g}, dist={orphan_dist:.1%})"
+                    f"({len(output_reps)} representants: "
+                    f"{', '.join(f'{r:.4g}' for r in output_reps)}) "
+                    f"-- orphelin {orphan:.4g} non couvert "
+                    f"(min dist prose = {orphan_dist:.1%}, > tol {RELATIVE_TOLERANCE:.0%})"
                 ),
             ))
     return NotebookAlignment(
@@ -1206,32 +1278,48 @@ def main(argv: Iterable[str] | None = None) -> int:
         if args.limit > 0:
             results = results[:args.limit]
     if args.json_out:
-        Path(args.json_out).write_text(json.dumps([
-            {
-                "path": r.path,
-                "total_findings": r.total_findings,
-                "n_prose_numbers": r.n_prose_numbers,
-                "n_output_numbers": r.n_output_numbers,
-                "n_markdown_cells": r.n_markdown_cells,
-                "n_code_cells": r.n_code_cells,
-                "findings": [
-                    {
-                        "cell_index": f.cell_index,
-                        "category": f.category,
-                        "prose_number": f.prose_number,
-                        "closest_output_number": f.closest_output_number,
-                        "prose_text": f.prose_text,
-                    }
-                    for f in r.findings
-                ],
-                "error": r.error,
-            }
-            for r in results
-        ], indent=2, ensure_ascii=False), encoding="utf-8")
+        _dump_json(results, args.json_out)
     print(render_text_report(results))
     if args.check and any(r.is_pathological for r in results):
         return 1
     return 0
+
+
+def _dump_json(results: list, json_out: str) -> None:
+    """Serialise la liste des `NotebookAlignment` au format JSON prevu par
+    `--json-out`. Helper isole du CLI pour permettre les tests directs
+    (cf `TestJsonOutDetails`, #14222)."""
+    Path(json_out).write_text(json.dumps([
+        {
+            "path": r.path,
+            "total_findings": r.total_findings,
+            "n_prose_numbers": r.n_prose_numbers,
+            "n_output_numbers": r.n_output_numbers,
+            "n_markdown_cells": r.n_markdown_cells,
+            "n_code_cells": r.n_code_cells,
+            "findings": [
+                {
+                    "cell_index": f.cell_index,
+                    "cell_kind": f.cell_kind,
+                    "category": f.category,
+                    "prose_number": f.prose_number,
+                    "closest_output_number": f.closest_output_number,
+                    "prose_text": f.prose_text,
+                    # #14222 -- `--json-out` ne serialisait PAS `details`
+                    # (ni `tolerance_used`, ni `cell_kind`), ce qui obligeait
+                    # a re-invoquer `analyze_notebook` pour trier. Champs
+                    # completes maintenant -- le test d'acceptance a besoin
+                    # de `details` (porte l'orphelin a la tolerance pres) et
+                    # de `tolerance_used` (porte la regle appliquee).
+                    "tolerance_used": f.tolerance_used,
+                    "details": f.details,
+                }
+                for f in r.findings
+            ],
+            "error": r.error,
+        }
+        for r in results
+    ], indent=2, ensure_ascii=False), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -633,6 +633,166 @@ class TestMissingFromProseEnumeration:
             f"MISSING_FROM_PROSE_ENUMERATION, trouve {len(enum_findings)}"
         )
 
+    # --- #14222 : discrimination cassée vs discrimination honnete ---------
+
+    def test_14222_orphan_named_is_the_missing_level_not_a_far_outlier(self, tmp_path):
+        """Acceptance #14222 stricte : sur le cas fondateur ICT-1 (pre-fix),
+        l'orphelin nomme vaut ``0,6875`` -- le niveau output reellement absent
+        de l'enumeration prose. La formulation `max(dist)` precedente nommait
+        ``1,2`` ou ``14,0`` -- des valeurs fantaisistes proches d'un representant
+        par accident arithmetique, jamais le niveau manquant.
+
+        La discrimination correcte est par APPARTENANCE : un representant
+        output est orphelin s'il n'a aucune valeur prose dans son voisinage
+        (meme tolerance que le groupement). Pour ICT-1 (pre-fix) :
+        representants = [0,1875 ; 0,6875 ; 2,3125], enumeration = [0,19 ;
+        2,31] -> 0,1875 couvert, 0,6875 NON couvert (72% de 0,19) -> orphelin.
+        """
+        nb = tmp_path / "ict1_pre_fix.ipynb"
+        _make_notebook([
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
+            _code_cell("print(0.1875); print(0.6875); print(2.3125)",
+                       [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        enum_findings = [f for f in result.findings
+                         if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        assert len(enum_findings) == 1
+        f = enum_findings[0]
+        assert f.closest_output_number == pytest.approx(0.6875, abs=1e-4), (
+            f"Acceptance #14222 : orphelin doit etre 0,6875 (le niveau "
+            f"manquant de l'enumeration prose), pas {f.closest_output_number}. "
+            f"La formulation `max(dist)` precedente nommait une valeur fantaisiste ; "
+            f"le predicat correct est par appartenance au niveau output."
+        )
+        assert "0,6875" in f.details or "0.6875" in f.details, (
+            f"Le champ `details` doit citer 0,6875 (l'orphelin) -- lu par "
+            f"le test d'acceptance de #14222 et la garde `details` JSON."
+        )
+
+    def test_14222_discrimination_pre_fix_vs_post_fix(self, tmp_path):
+        """Acceptance #14222 : sur les DEUX revisions d'ICT-1 encadrant
+        ``7de14792c``, le verdict doit DIFFERER :
+
+        - pre-fix : 2 niveaux prose, 3 niveaux outputs -> 1 finding
+          MISSING_FROM_PROSE_ENUMERATION (orphelin = 0,6875) ;
+        - post-fix : 3 niveaux prose, 3 niveaux outputs -> 0 finding
+          (les 3 representants trouvent une prose proche).
+
+        Avant le fix, les DEUX revisions rendaient le meme verdict
+        (1 finding), avec des orphelins fantaisistes (``1,2`` puis ``14,0``).
+        Apres le fix, pre-fix signale, post-fix est muet.
+        """
+        # PRE-FIX (cas fondateur)
+        pre = tmp_path / "ict1_pre_fix.ipynb"
+        _make_notebook([
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
+            _code_cell("print(0.1875); print(0.6875); print(2.3125)",
+                       [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+        ], pre)
+        # POST-FIX (prose ajoute le relief intermediaire)
+        post = tmp_path / "ict1_post_fix.ipynb"
+        _make_notebook([
+            _markdown_cell("un pic a 2,31, le reste a 0,19, un relief "
+                          "intermediaire a 0,69"),
+            _code_cell("print(0.1875); print(0.6875); print(2.3125)",
+                       [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+        ], post)
+
+        enum_pre = [f for f in mod.analyze_notebook(pre).findings
+                    if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        enum_post = [f for f in mod.analyze_notebook(post).findings
+                     if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+
+        assert len(enum_pre) == 1, (
+            f"Pre-fix doit signaler 1 manquant, pas {len(enum_pre)}."
+        )
+        assert enum_pre[0].closest_output_number == pytest.approx(0.6875, abs=1e-4), (
+            f"Pre-fix orphelin doit etre 0,6875, pas "
+            f"{enum_pre[0].closest_output_number}."
+        )
+        assert enum_post == [], (
+            f"Post-fix (3 niveaux prose + 3 niveaux outputs) ne doit PAS "
+            f"signaler de manquant, trouve {len(enum_post)} findings."
+        )
+
+    def test_14222_orphan_is_a_representant_not_an_arbitrary_value(self, tmp_path):
+        """L'orphelin nomme est UN REPRESENTANT d'un groupe de niveaux
+        output (cf `_distinct_level_values`), pas n'importe quelle valeur
+        du notebook : si la cellule code exhibe ``0,60`` et ``0,80`` (meme
+        representant ``0,70``), l'orphelin est ``0,70``, pas la moyenne
+        arithmetique ``0,70`` non plus -- mais JAMAIS l'un des deux valeurs
+        distinctes ``0,60`` ou ``0,80`` choisies arbitrairement."""
+        nb = tmp_path / "representant_picks.ipynb"
+        _make_notebook([
+            _markdown_cell("les 2 valeurs sont 0.19 et 2.31."),
+            # Outputs : 4 valeurs -> 3 niveaux distincts (tol 5%)
+            # groupe 1 : 0.18 ; groupe 2 : 0.69 ; groupe 3 : 2.30
+            # representants : [0.18, 0.69, 2.30]
+            _code_cell("a=0.180; b=0.700; c=2.300; print(a); print(b); print(c)",
+                       [{"text": "0.18\n0.70\n2.30\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        enum_findings = [f for f in result.findings
+                         if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        assert len(enum_findings) == 1
+        # 2 prose (0.19, 2.31), 3 output (0.18, 0.70, 2.30) :
+        #   - 0.18 couvert par 0.19 (~5.3%, juste hors tol)
+        #   - 0.70 NON couvert (~260%, tres loin)
+        #   - 2.30 couvert par 2.31 (~0.4%)
+        # ATTENTION : 0.18 vs 0.19 -> base = 0.19, diff = 0.01, ratio = 5.3%
+        # HORS tolerance 5% -> represente 0.18 EST orphelin. Le test attend
+        # que l'un des deux (0.18 ou 0.70) soit l'orphelin, pas une autre valeur.
+        f = enum_findings[0]
+        assert f.closest_output_number is not None
+        # soit 0.18, soit 0.70 -- pas 2.30 (couvert) et pas une moyenne.
+        assert f.closest_output_number in (pytest.approx(0.18, abs=1e-3),
+                                           pytest.approx(0.7, abs=1e-3)), (
+            f"Orphelin doit etre un representant non couvert (0,18 ou 0,70), "
+            f"pas une moyenne ou une autre valeur : {f.closest_output_number}"
+        )
+
+
+# --- #14222 -- champ `details` serialise dans `--json-out` --------------------
+#
+# L'ancien export incluait `cell_index`, `category`, `prose_number`,
+# `closest_output_number`, `prose_text` -- mais PAS `details`,
+# `tolerance_used`, ni `cell_kind`. Le champ `details` est la charge utile
+# du test d'acceptance (cite le representant orphelin) ; sans lui, lire
+# le verdict exigeait de re-invoquer `analyze_notebook`.
+
+
+class TestJsonOutDetails:
+    """#14222 -- `--json-out` doit inclure `details` (et `tolerance_used`,
+    `cell_kind`) pour que le test d'acceptance se lise depuis le JSON."""
+
+    def test_json_includes_details_and_tolerance_used(self, tmp_path):
+        """Lecture du dump JSON via le helper `_dump_json` (extrait du CLI
+        -- pas de subprocess, pas de dependance de version de Python ni
+        d'encoding cp1252). Le test verifie les 3 champs ajoutes."""
+        nb = tmp_path / "ict1_pre_fix.ipynb"
+        _make_notebook([
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
+            _code_cell("print(0.1875); print(0.6875); print(2.3125)",
+                       [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+        ], nb)
+        out = tmp_path / "out.json"
+        results = [mod.analyze_notebook(nb)]
+        mod._dump_json(results, str(out))
+        data = json.loads(out.read_text(encoding="utf-8"))
+        enum_findings = [f for f in data[0]["findings"]
+                         if f["category"] == "MISSING_FROM_PROSE_ENUMERATION"]
+        assert len(enum_findings) == 1
+        f = enum_findings[0]
+        assert "details" in f and f["details"], (
+            "Le JSON doit inclure `details` (charge utile du test d'acceptance).")
+        assert "tolerance_used" in f, (
+            "Le JSON doit inclure `tolerance_used`.")
+        assert "cell_kind" in f, (
+            "Le JSON doit inclure `cell_kind` (markdown / code).")
+        assert "0.6875" in f["details"], (
+            f"Le champ `details` doit citer l'orphelin 0.6875, trouve {f['details']!r}.")
+
 
 # --------------------------------------------------------------------------- #
 #  Tolerances
@@ -1629,6 +1789,7 @@ class TestCLI:
             [sys.executable, "-m", "scan_d5_prose_outputs_alignment",
              "--root", str(tmp_path / "absent"), "--check"],
             cwd=_ROOT, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
         )
         assert result.returncode == 2, f"attendu 2, obtenu {result.returncode}\n{result.stderr}"
 
@@ -1643,6 +1804,7 @@ class TestCLI:
             [sys.executable, "-m", "scan_d5_prose_outputs_alignment",
              "--root", str(tmp_path), "--check"],
             cwd=_ROOT, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
         )
         assert result.returncode == 1
 
@@ -1656,5 +1818,6 @@ class TestCLI:
             [sys.executable, "-m", "scan_d5_prose_outputs_alignment",
              "--root", str(tmp_path), "--check"],
             cwd=_ROOT, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
         )
         assert result.returncode == 0


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #14218 (cycle 167)

## Summary

Resolution de l'issue **#14222** (dette instrument issue de la cloture Phase 0 de l'EPIC #9768) : `MISSING_FROM_PROSE_ENUMERATION` choisissait l'orphelin par `max(dist_relative_a_enum)`, ce qui laissait silencieusement invisibles les niveaux output PROCHES d'un niveau prose sans etre couverts par lui. Le `0,6875` fondateur (cas ICT-1-PhiTrajectories) ne gagnait jamais le maximum, donc la garde ne le nommait pas -- le verdict restait muet sur la classe de defaut que l'instrument pretendait detecter.

Acceptance #14222 stricte : sur les DEUX revisions d'ICT-1 encadrant `7de14792c`, le verdict doit **differer**, et l'orphelin du cote pre-fix doit valoir **`0,6875`**.

Sortie : +282/-31 sur 2 fichiers (1 sweep-fix bundle : 3 pre-existing `text=True` violations dans `TestCLI` qui bloquaient le commit pre-commit, fixees avec `encoding="utf-8", errors="replace"`).

## Acceptance #14222

| # | Critere | Resultat |
|---|---------|----------|
| 1 | Discrimination pre-fix vs post-fix | **OK** : `test_14222_discrimination_pre_fix_vs_post_fix` -- pre-fix signale 1 finding orphelin=0,6875 ; post-fix (prose ajoute "relief intermediaire a 0,69") silencieux, 0 finding |
| 2 | Orphelin nomme = niveau output manquant (pas fantaisiste) | **OK** : `test_14222_orphan_named_is_the_missing_level_not_a_far_outlier` -- assertions strictes sur `closest_output_number == 0.6875` (tol 1e-4) et presence de `"0.6875"` dans `details` |
| 3 | Orphelin = representant de groupe (1re valeur du groupe de tolerance), pas une moyenne / valeur arbitraire | **OK** : `test_14222_orphan_is_a_representant_not_an_arbitrary_value` |
| 4 | `--json-out` serialise `details` (charge utile du test d'acceptance) | **OK** : `TestJsonOutDetails.test_json_includes_details_and_tolerance_used` -- verifie `details`, `tolerance_used`, `cell_kind` dans le dump JSON |
| 5 | Suite complete verte | **OK** : `pytest scripts/notebook_tools/ scripts/tests/ -q` -> **9489 passed, 31 skipped, 5 xfailed, 0 failed** (avant : 9485 passed). Les 4 nouvelles entrees sont les 4 tests ci-dessus ; les 9485 anciens toujours verts |
| 6 | Pas de regression sur le cas fondateur existant (`test_ict1_founder_signaled`) | **OK** : passe tel quel -- la nouvelle formulation produit bien 1 finding avec `prose_number==2`, `details contient "3 niveaux distincts" et "2 niveaux"` |
| 7 | Pas de regression sur les 3 tests `TestCLI` (subprocess) | **OK** : passes apres sweep-fix des 3 pre-existing `text=True` -> `text=True, encoding="utf-8", errors="replace"` |

## Architecture du fix

### `_distinct_level_values(values, tol)` -- nouveau helper (lignes ~948-985)

Retourne la liste des REPRESENTANTS (1re valeur de chaque groupe de tolerance), pas le seul compteur. Meme algorithme que `_distinct_levels` (tri + groupement lineaire, ratio <= tol), mais avec conservation des valeurs.

```python
def _distinct_level_values(values, tol=RELATIVE_TOLERANCE):
    if not values: return []
    s = sorted(values)
    reps = [s[0]]
    for v in s[1:]:
        base = max(abs(reps[-1]), abs(v))
        if base == 0: continue
        if abs(v - reps[-1]) / base > tol:
            reps.append(v)
    return reps
```

### Tour 2 : orphan par APPARTENANCE, pas par `max(dist)` (lignes ~1090-1145)

**Avant** (heuristique `max(dist)`) :
- choisissait `orphan = ov` qui maximise `abs(ov - closest_prose) / base`
- `0,6875` proche de `0,19` (ratio 72%) et de `1,875` (73%) ne gagne jamais le maximum
- verdict muet sur la classe de defaut

**Apres** (appartenance au niveau output) :
- `_distinct_level_values(output_vals)` rend les representants : `[0,1875 ; 0,6875 ; 2,3125]`
- pour chaque representant, calcule la distance a la prose enum la plus proche
- un representant est orphelin ssi `distance > RELATIVE_TOLERANCE` (5%)
- Pour ICT-1 pre-fix : `0,1875` couvert (1,3% de `0,19`), `0,6875` NON couvert (72% de `0,19`), `2,3125` couvert (0,1% de `2,31`) -> orphelin = `0,6875`
- Pour ICT-1 post-fix : enumeration ajoute `0,69` -> tous les representants sont couverts -> 0 finding

### Helper `_dump_json(results, json_out)` -- isole du CLI (lignes ~1288-1322)

Extraction du JSON dump dans une fonction dediee pour permettre les tests directs (cf `TestJsonOutDetails.test_json_includes_details_and_tolerance_used`) -- elimine le besoin d'un `subprocess.run` qui contournait la detection `text=True`/`encoding=`.

Champs serialises ajoutes (3) :
- `cell_kind` : "markdown" ou "code"
- `tolerance_used` : regle de tolerance appliquee (ex: "enumeration-vs-outputs")
- `details` : chaine de caracteres avec l'orphelin, la distance min, le contexte

Les 3 champs sont deja sur l'objet `AlignmentFinding` (`__slots__` lignes 345-356), donc rien a modifier dans le dataclass -- uniquement le dict-builder du JSON.

### Sweep-fix pre-existing `text=True` (3 sites dans TestCLI)

Les 3 tests `TestCLI::test_exit_code_*` utilisent `subprocess.run(..., text=True, ...)` sans `encoding=`. Le hook pre-commit `check-subprocess-encoding` (#13140) refuse les `NEW` occurrences ET scan les fichiers touches par le commit (meme pre-existing). Sweep tranche-fix ajoute `encoding="utf-8", errors="replace"` aux 3 sites.

Mention explicite dans le commit : ce sweep est un effet de bord necessaire pour passer le pre-commit, PAS un changement de comportement ; les tests utilisent des paths de notebooks ABSENTS ou de tmp_path avec caracteres ASCII, le risque cp1252 etait marginal en pratique mais le hook refuse juste.

## Verification post-fix (acceptance live)

| Mesure | Avant (origin/main) | Apres (cette PR) |
|--------|---------------------|-----------------|
| ICT-1 pre-fix `closest_output_number` | `1,2` ou `14,0` (fantaisiste) | **`0,6875`** (le vrai manquant) |
| ICT-1 pre-fix `details` | "orphan=1.2, dist=..." | **`"orphelin 0.6875 non couvert (min dist prose = 72.4%, > tol 5%)"`** |
| ICT-1 post-fix (prose ajoute 0,69) `total_findings` | 1 (verdict muet sur le defect) | **0** (couverture complete) |
| Discrimination pre vs post | **Identique** (les 2 revisions rend le meme verdict) | **Differente** (acceptance #14222) |
| `--json-out` champs serialises | 5 (`cell_index`, `category`, `prose_number`, `closest_output_number`, `prose_text`) | **8** (+`cell_kind`, +`tolerance_used`, +`details`) |
| `_distinct_level_values` (nouveau) | absent | present |
| Suite `pytest scripts/notebook_tools/ scripts/tests/ -q` | 9485 passed | **9489 passed (+4 nouveaux)** |

## Verdicts

- **SOTA-OK** : pas de workaround degrade, pas de stub -- l'extension naturelle du predicat « output sans correspondance prose ». La formulation initiale `max(dist)` etait une heuristique, pas un predicat ; le predicat correct est « APPARTENANCE au niveau output » (`exists(not covered)`), pas « DISSONANCE maximale ».
- **Anti-regression D** : 9485 tests anciens toujours verts, pas de suppression de tests existants. Les 9485 -> 9489 transitions sont +4 nouveaux tests uniquement.
- **Stop & Repair** : pas de scrub d'output (cf secrets-hygiene regle 6). Le helper `_dump_json` n'edite aucune sortie de cellule.
- **catalog-pr-hygiene R1** : aucun marqueur `CATALOG-STATUS` touche.
- **pr-review-discipline section B** : ce n'est PAS un notebook, c'est un script tooling avec tests d'integration. Pas de papermill, pas de notebook exec, pas de QC. Verification standard (parse + pytest + scan acceptance).
- **Convention Exemple/Exercice** : N/A.
- **3 exercices par notebook** : N/A.

## Recette morale (qui fait quoi)

L'issue #14222 specifie explicitement « deux retours de terrain reportes depuis #9790 ». Le PR est signee par `myia-po-2026:CoursIA`, distincte de la PRuteure de la dette (les 4 classes SAFE FP ont ete relevees par une lane tierce). Le sweep-fix des `text=True` est un effet de bord de pre-commit, pas une initiative d'auto-levee.

## Residuel / suite

- **Filtres SAFE FP Sudoku** : 4 classes signalees dans l'issue (« deux retours de terrain », `auto-reference au numero de serie` + `reference de cellule en prose` + `arrondi FR avec mot-unite` + `enonce normatif`). Sortie de scope pour cette PR -- PR soeur prevoit leur implementation comme dette technique distincte (cycle a venir). Chaque filtre peut etre isole (1 PR par SAFE filter ou 1 PR globale selon importance).
- **Mesure de la fenetre post-merge** : `analyze_notebook` sur les 1221 notebooks main, distribution avant/apres sur la categorie `MISSING_FROM_PROSE_ENUMERATION` (attendu : effondrement des ~298 findings actuels). Hermes fera cette mesure au prochain cycle coord post-merge. Cf acceptance #14222 section « Ce qui est decide en amont ».
- **`scan_d1_d3_d4_d5` (parent)** : la dette d'instrument etait isolee par issue #14222 ; les detecteurs D1/D3/D4 ne sont PAS en cause ici (cf issue body « aucun des trois `scan_*.py` ne devient un gate CI »). Aucun suivi a prevoir sur D1/D3/D4.

## Lecons

- **Heuristique `max(dist)` cache un predicat `exists(not covered)`** : la formulation initiale etait « la plus loin » -- un proxy de « la plus dissonante » qui echoue quand la dissonance est partagee entre plusieurs valeurs proches. Le predicat correct est par ENSEMBLE : un representant est orphelin s'il n'a aucune prose proche, pas s'il a la plus grande distance. Meme piege qu'un test d'inegalite sur les quantiles vs un test d'appartenance au 1er quartile -- l'heuristique de distance ignore le cas « plusieurs consecutifs au-dessus du seuil ».
- **`_distinct_level_values` vs `_distinct_levels`** : le compteur precede la liste (invariant de la conversation exhaustive). Quand on a besoin de la liste, on derive un helper de representation ; on ne change pas la signature de l'existant. Pattern : « ajouter un partenaire qui rend les valeurs, garder le compteur comme avant ». 9485 tests anciens utilisent l'ancien helper, qui reste intact.
- **Champ `details` dans JSON = lecture d'acceptance autonome** : sans `details` dans le dump, lire « l'orphelin vaut `0,6875` » exigeait de re-executor `analyze_notebook`. Le test d'acceptance se lit maintenant depuis le fichier JSON directement -- la garantie de non-regression n'est plus dependante de l'exec runtime. Pattern applicable aux autres detecteurs (`scan_d1_d3_d4_d5`, scanners similaires) : serialiser les champs diagnostiques comme `details`, pas comme un pretty-print informatif.
- **Defaut fondateur dans la forme d'un verdict identique** : la garde rendait le meme verdict des deux cotes du fix (1 finding, 1 cellule, 1 ancre), avec un orphelin fantaisiste different (`1,2` puis `14,0`). Une forme « qui ressemble a une confirmation » peut cacher un detecteur qui ne mesure plus rien. Cf `anti-regression.md` (motifs red-flag) : « assertion identique sur les deux etats d'un fix = la garde ne mesure plus la propriete qu'elle pretend verifier ». Le test `test_14222_discrimination_pre_fix_vs_post_fix` pose ce discriminant en POSITIF (les 2 cotes du fix doivent differer) -- pas juste en intolerant d'un orphelin fantaisiste.
- **Sweep-fix tranche par tranche via `text=True`** : le hook `#13140` est concu pour que le sweep des `text=True` pre-existants se fasse « tranche by tranche » -- un fichier touche par un commit amene ses pre-existants avec lui. Cette PR re-amene 3 sites dans `TestCLI::test_exit_code_*`. Strategie : fixer `encoding="utf-8", errors="replace"` localement plutot que de re-orchestrer en branche. Cout : 1 ligne par site ; benefice : tranche verifiee, prochain sweep-amene-amene-amene n'aura plus rien a signaler.
- **Pourquoi `_dump_json` est testable directement** : extraire le dump inline vers une fonction dediee elimine le besoin du `subprocess.run` pour tester la serialisation. Pattern : « serialiser est une responsabilite separee de la CLI ; la CLI la consume, les tests aussi ». Voir aussi `refactor-pur-pour-test` dans claude.md.

## Rotation R6

c155 = MED/notebook-search CSP-2 ; c156 = LIGHT/cleanup Search-debt ; c157 = LIGHT/cleanup data-registry ; c158 = LIGHT/tooling pick_idle_grain ; c159 = MED/tooling check_unaddressed_nits Position F ; c160 = LIGHT/cleanup test dedup ; c161 = LIGHT/notebook-cleanup Tweety-7a parite ; c162 = MED/docs README Mermaid ; c163 = MED/audio-tooling p6_compile chapitrage ; c164 = LIGHT/cleanup Search-15/16 ; c165 = LIGHT/docs DSWA README 04-Vision ; c166 = LIGHT/tooling check_unaddressed_nits Position H ; c167 = **MED/guard check_unaddressed_nits Voie 3** ; c168 = **LIGHT/tooling scan_d5 orphan set-membership (#14222)**.

Regle 6 (variete obligatoire) :

- **Famille** : notebook-tools (dette d'instrument Phase 0 cloture #9768) -- distincte du tooling merge-gate de c166-c167 et de la doc de c165. Acceptable equilibre : un cycle sur trois familles differentes sur les 3 derniers.
- **Genre** : LIGHT -- un seul predicat a corriger, scope borne par acceptance stricte. Pas une refonte (cf `_distinct_level_values` ajoute, `_distinct_levels` reste intact).
- **Issue** : dette instrument, pas de contenu ; ne tient pas le plancher G-VAR-1 (l'issue body le dit : « il ne tient donc pas le plancher G-VAR-1 d'un cycle »).

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14222
- EPIC parent (cloture Phase 0) : https://github.com/jsboige/CoursIA/issues/9768
- EPIC ancetre : https://github.com/jsboige/CoursIA/issues/9790
- Issue fondatrice D5 : https://github.com/jsboige/CoursIA/issues/9416 (cas ICT-1-PhiTrajectories commit `7de14792c`)
- Filtre SAFE FP (4 classes signalees, sortie de scope) : `script.scan_d5_prose_outputs_alignment.SAFE_FP_FILTERS` (a creer en PR soeur)
- Convention : `pr-review-discipline.md` section B (verification du predicat)
- Hook lie : `#13140` `check_subprocess_encoding.py` (3 sites sweep-fix dans cette PR)
