### PR TITLE
feat(tooling,#9434): compteur machine-dep provenance-aware (OUT/DER/SRC/COMP)

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -535,7 +535,246 @@ def _iter_markdown_lines(cell: dict) -> list[str]:
     return src.splitlines() if src else []
 
 
-def _scan_notebook(nb_path: Path) -> list[dict]:
+# --------------------------------------------------------------------------- #
+#  Provenance d'un finding (#9434) -- opt-in, ne change rien par defaut
+# --------------------------------------------------------------------------- #
+# Mesure du 2026-09-02 (lane myia-po-2024:CoursIA-2, issuecomment-5505846033) :
+# sur les 288 findings `wallclock` du depot, 283 citent un nombre que le
+# notebook PORTE deja -- dans ses outputs, dans ses cellules de code, ou dans
+# un fichier compagnon qu'il pilote. Le compteur ne le voyait pas parce qu'il
+# raisonne ligne a ligne, sur du TEXTE.
+#
+# La consequence est celle qu'ai-01 a nommee sur ce fil : "une metrique
+# d'occurrences se satisfait toujours en supprimant, jamais en corrigeant".
+# Un drainage pilote par le compteur brut supprimerait de la prose qui LIT
+# correctement une sortie -- exactement ce que le test READS-vs-AFFIRMS protege.
+#
+# Quatre provenances, dans l'ordre de preference :
+#   OUT  -- la valeur est dans une sortie de cellule du notebook
+#   DER  -- elle est un RATIO de deux valeurs de sortie (« ~72x », « ~40 »)
+#   SRC  -- elle est declaree dans une cellule de code (constante, parametre)
+#   COMP -- elle est dans un fichier compagnon que le notebook pilote
+#           (`Program.cs`, `.csproj`, config...) : c'est une SPECIFICATION
+# Aucune des quatre -> `unbacked` : le seul residu qui merite un regard humain.
+#
+# LIMITE, a lire avant de se fier au chiffre : la tolerance de 5 % sur six
+# echelles peut ABSORBER un vrai defaut par coincidence numerique. Le compte
+# `unbacked` est donc un PLANCHER du legitime, pas un plafond du defaut. Il
+# reduit un tri de 288 lignes a un tri de 5 ; il ne prouve pas que les 283
+# autres soient toutes justes.
+PROVENANCE_TOLERANCE = 0.05
+
+# Echelles admises entre le nombre en prose et la valeur portee par le
+# notebook. Mesurees sur les cas reels du depot :
+#   1.0     identite (« 2,97 » <- 2.9682, arrondi)
+#   1000.0  s -> ms (« ~60 ms » <- 0.0587 s)
+#   0.001   ms -> s
+#   60.0    min -> s   /  1/60  s -> min
+#   0.01    fraction -> pourcentage (« 4,1 % » <- 0.0410)
+PROVENANCE_SCALES = (1.0, 1000.0, 0.001, 60.0, 1.0 / 60.0, 0.01)
+
+PROVENANCE_ORDER = ("OUT", "DER", "SRC", "COMP")
+PROVENANCE_UNBACKED = "unbacked"
+
+# Extensions de fichiers compagnons scannes pour la provenance COMP.
+_COMPANION_SUFFIXES = (
+    ".cs", ".py", ".fs", ".csproj", ".json", ".yml", ".yaml",
+    ".ps1", ".sh", ".lean",
+)
+_COMPANION_SKIP_DIRS = (
+    ".ipynb_checkpoints", "bin", "obj", ".lake", "node_modules", "__pycache__",
+)
+# Budget de lecture des compagnons (caracteres). Une serie comme QuantConnect
+# porte des dumps de donnees ; sans borne, `--all --provenance` deviendrait
+# quadratique.
+_COMPANION_CHAR_BUDGET = 400_000
+# Budget de lecture des outputs d'un notebook. Les blobs base64 d'images sont
+# exclus AVANT ce compte (ils n'apportent aucun nombre lisible et saturaient la
+# mesure -- FP observe pendant la calibration).
+_OUTPUT_CHAR_BUDGET = 2_000_000
+
+_NUMBER_RE = re.compile(r"[0-9][0-9]*(?:[.,][0-9]+)?")
+
+# Cache par repertoire : plusieurs notebooks d'une meme serie partagent leurs
+# compagnons. Sans cache, `--all --provenance` relit `Program.cs` a chaque fois.
+_COMPANION_CACHE: dict[str, list[float]] = {}
+
+
+def _parse_numbers(text: str) -> list[float]:
+    """Extrait les nombres d'un texte, virgule decimale francaise comprise.
+
+    « 2,97 » et « 2.97 » rendent tous deux 2.97. C'est le point ou une premiere
+    version de cet outil s'est trompee : elle normalisait en SUPPRIMANT la
+    virgule, ce qui transformait « 0,041 » en 41.
+    """
+    out: list[float] = []
+    for tok in _NUMBER_RE.findall(text):
+        try:
+            out.append(float(tok.replace(",", ".")))
+        except ValueError:
+            continue
+    return out
+
+
+def _values_close(prose: float, carried: float) -> bool:
+    """Le nombre en prose correspond-il a une valeur portee, a une echelle pres ?
+
+    La comparaison est RELATIVE (5 %) parce que la prose arrondit : « 2,97 »
+    pour 2.9682, « ~60 ms » pour 0.0587 s. Une comparaison exacte ne
+    reconnaitrait aucun de ces deux cas, qui sont pourtant la lecture correcte
+    d'une sortie.
+    """
+    for scale in PROVENANCE_SCALES:
+        scaled = carried * scale
+        if not scaled:
+            continue
+        if abs(scaled - prose) <= PROVENANCE_TOLERANCE * max(abs(scaled), abs(prose)):
+            return True
+    return False
+
+
+def _output_values(data: dict) -> list[float]:
+    """Nombres portes par les SORTIES de cellules du notebook.
+
+    Les blobs `image/*` sont exclus : ils ne portent aucun nombre lisible et
+    leur base64 produisait des correspondances fortuites.
+    """
+    budget = _OUTPUT_CHAR_BUDGET
+    chunks: list[str] = []
+    for cell in data.get("cells", []):
+        for out in cell.get("outputs", []) or []:
+            if not isinstance(out, dict):
+                continue
+            texts: list = []
+            if "text" in out:
+                texts.append(out["text"])
+            payload = out.get("data") or {}
+            if isinstance(payload, dict):
+                for mime, val in payload.items():
+                    if mime.startswith("image/"):
+                        continue
+                    texts.append(val)
+            for t in texts:
+                if isinstance(t, list):
+                    t = "".join(str(x) for x in t)
+                if not isinstance(t, str):
+                    continue
+                chunks.append(t[:budget])
+                budget -= len(t)
+                if budget <= 0:
+                    return _parse_numbers("\n".join(chunks))
+    return _parse_numbers("\n".join(chunks))
+
+
+def _source_values(data: dict) -> list[float]:
+    """Nombres declares dans les cellules de CODE (constantes, parametres).
+
+    Une prose qui cite `Thread.Sleep(500)` en disant « 500 ms » ne fabrique
+    rien : elle lit une specification du notebook lui-meme.
+    """
+    chunks: list[str] = []
+    for cell in data.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        if isinstance(src, str):
+            chunks.append(src)
+    return _parse_numbers("\n".join(chunks))
+
+
+def _companion_values(nb_path: Path) -> list[float]:
+    """Nombres portes par les fichiers compagnons du repertoire du notebook.
+
+    Un notebook qui pilote un `Program.cs` cite legitimement les constantes de
+    ce programme : c'est une SPECIFICATION, pas une mesure machine.
+    """
+    key = str(nb_path.parent)
+    cached = _COMPANION_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    budget = _COMPANION_CHAR_BUDGET
+    chunks: list[str] = []
+    try:
+        for path in sorted(nb_path.parent.rglob("*")):
+            if budget <= 0:
+                break
+            if not path.is_file() or path.suffix.lower() not in _COMPANION_SUFFIXES:
+                continue
+            if any(part in _COMPANION_SKIP_DIRS for part in path.parts):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            chunks.append(text[:budget])
+            budget -= len(text)
+    except OSError:
+        pass
+
+    values = _parse_numbers("\n".join(chunks))
+    _COMPANION_CACHE[key] = values
+    return values
+
+
+def _derived_ratios(values: list[float], top_n: int = 60, cap: int = 4000) -> list[float]:
+    """Ratios entre valeurs de sortie -- les facteurs « ~72x », « ~40 ».
+
+    Un notebook qui mesure 2.97 s et 0.041 s et ecrit « ~72x plus rapide »
+    n'affirme rien qui ne soit dans ses sorties : le facteur EST la lecture.
+    Bornes (`top_n`, `cap`) : le produit cartesien est quadratique.
+    """
+    top = sorted({v for v in values if v}, reverse=True)[:top_n]
+    ratios: list[float] = []
+    for a in top:
+        for b in top:
+            if not b:
+                continue
+            r = a / b
+            if 1.0 < r < 100_000.0:
+                ratios.append(r)
+                if len(ratios) >= cap:
+                    return ratios
+    return ratios
+
+
+def _annotate_provenance(findings: list[dict], data: dict, nb_path: Path) -> None:
+    """Passe 4 (opt-in) : annote chaque finding d'une cle ``provenance``.
+
+    Ne change AUCUNE categorie : la provenance est une lecture ORTHOGONALE a la
+    classification. Un `wallclock` reste `wallclock` ; on dit seulement si le
+    nombre qu'il pointe est porte par le notebook ou non.
+    """
+    if not findings:
+        return
+    outputs = _output_values(data)
+    sources = _source_values(data)
+    ratios = _derived_ratios(outputs)
+    companions: list[float] | None = None  # charge paresseusement (couteux)
+
+    for f in findings:
+        prose = _parse_numbers(f.get("snippet", ""))
+        if not prose:
+            f["provenance"] = PROVENANCE_UNBACKED
+            continue
+        if any(_values_close(p, o) for p in prose for o in outputs):
+            f["provenance"] = "OUT"
+        elif any(_values_close(p, r) for p in prose for r in ratios):
+            f["provenance"] = "DER"
+        elif any(_values_close(p, s) for p in prose for s in sources):
+            f["provenance"] = "SRC"
+        else:
+            if companions is None:
+                companions = _companion_values(nb_path)
+            if any(_values_close(p, c) for p in prose for c in companions):
+                f["provenance"] = "COMP"
+            else:
+                f["provenance"] = PROVENANCE_UNBACKED
+
+
+def _scan_notebook(nb_path: Path, provenance: bool = False) -> list[dict]:
     """Scan un notebook ; retourne la liste des findings structures.
 
     Chaque finding est un dict ``{cell_index, line_index, snippet, line,
@@ -558,6 +797,12 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
        en ``domain_quantity`` (residu 1 #10169 : les 6 findings Infer-2 dont les
        moyennes ajustees 15.07 / 26.69 min). La granularite per-cell etait trop
        etroite -- l'unite de temps est le sujet du notebook, pas d'une cellule.
+    4. **Passe provenance** (opt-in ``provenance=True``, #9434) : annote chaque
+       finding d'une cle ``provenance`` disant si le nombre cite est PORTE par le
+       notebook (``OUT`` sortie / ``DER`` ratio de sorties / ``SRC`` cellule de
+       code / ``COMP`` fichier compagnon) ou ``unbacked``. Aucune categorie n'est
+       modifiee : la provenance est orthogonale a la classification. Par defaut la
+       passe ne tourne PAS et la sortie est byte-identique a l'existant.
     """
     try:
         data = json.loads(nb_path.read_text(encoding="utf-8"))
@@ -635,6 +880,11 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
         for f in findings:
             if f["category"] == CATEGORY_WALLCLOCK:
                 f["category"] = CATEGORY_DOMAIN_QUANTITY
+
+    # Passe 4 : provenance (opt-in). Hors --provenance, on ne paie ni la
+    # lecture des outputs ni le scan des compagnons.
+    if provenance:
+        _annotate_provenance(findings, data, nb_path)
 
     return findings
 
@@ -751,7 +1001,23 @@ def main(argv: list[str] | None = None) -> int:
         "--category",
         choices=[CATEGORY_WALLCLOCK, CATEGORY_DISTRIBUTION, CATEGORY_AMBIGUOUS, CATEGORY_DOMAIN_QUANTITY, "all"],
         default="wallclock",
-        help="Filtre categorie de sortie (defaut: wallclock = cible drainage).",
+        help=(
+            "Filtre categorie de sortie (defaut: wallclock = cible drainage). "
+            "ATTENTION : ce filtre ne s'applique qu'a la sortie TSV. En --json, "
+            "`findings` porte TOUTES les categories (c'est `summary` qui les "
+            "ventile) -- sommer `findings` en croyant lire une categorie donne "
+            "un compte survalue."
+        ),
+    )
+    parser.add_argument(
+        "--provenance",
+        action="store_true",
+        help=(
+            "Annote chaque finding d'une provenance (OUT/DER/SRC/COMP/unbacked) : "
+            "le nombre cite est-il PORTE par le notebook (sortie, ratio de sorties, "
+            "cellule de code, fichier compagnon) ou non ? Sans ce flag, la sortie "
+            "est inchangee."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -785,7 +1051,7 @@ def main(argv: list[str] | None = None) -> int:
             rel = str(nb_path.resolve().relative_to(repo_root))
         except ValueError:
             pass
-        findings = _scan_notebook(nb_path)
+        findings = _scan_notebook(nb_path, provenance=args.provenance)
         if findings:
             all_findings[rel] = findings
         for f in findings:
@@ -797,6 +1063,20 @@ def main(argv: list[str] | None = None) -> int:
                 domain_quantity_count += 1
             else:
                 ambiguous_count += 1
+
+    # Ventilation provenance par categorie (uniquement sous --provenance).
+    # Elle repond a la question que le compte brut ne posait pas : parmi les
+    # findings d'une categorie, combien citent un nombre que le notebook porte
+    # deja ? Le residu `unbacked` est le seul tri qui merite un regard humain.
+    provenance_summary: dict[str, dict[str, int]] = {}
+    if args.provenance:
+        for findings in all_findings.values():
+            for f in findings:
+                bucket = provenance_summary.setdefault(
+                    f["category"],
+                    {k: 0 for k in PROVENANCE_ORDER + (PROVENANCE_UNBACKED,)},
+                )
+                bucket[f.get("provenance", PROVENANCE_UNBACKED)] += 1
 
     if args.json:
         out = {
@@ -810,6 +1090,8 @@ def main(argv: list[str] | None = None) -> int:
             },
             "findings": all_findings,
         }
+        if args.provenance:
+            out["provenance_summary"] = provenance_summary
         print(json.dumps(out, ensure_ascii=False, indent=2))
     else:
         # Mode TSV lisible (par defaut : wallclock = cible drainage).
@@ -817,11 +1099,23 @@ def main(argv: list[str] | None = None) -> int:
         print(f"# check_machine_dep_timing -- scanned={len(targets)}")
         print(f"# wallclock={wallclock_count} distribution_param={distribution_count} "
               f"domain_quantity={domain_quantity_count} ambiguous={ambiguous_count}")
+        if args.provenance:
+            shown = args.category if cat_filter else "all"
+            bucket = provenance_summary.get(cat_filter, {}) if cat_filter else {}
+            if not cat_filter:  # agrege toutes categories
+                bucket = {k: 0 for k in PROVENANCE_ORDER + (PROVENANCE_UNBACKED,)}
+                for b in provenance_summary.values():
+                    for k, v in b.items():
+                        bucket[k] = bucket.get(k, 0) + v
+            detail = " ".join(f"{k}={bucket.get(k, 0)}"
+                              for k in PROVENANCE_ORDER + (PROVENANCE_UNBACKED,))
+            print(f"# provenance[{shown}] {detail}")
         for nb_rel, findings in sorted(all_findings.items()):
             for f in findings:
                 if cat_filter and f["category"] != cat_filter:
                     continue
-                print(f"{nb_rel}\tcell[{f['cell_index']}]\t{f['snippet']}\t{f['category']}\t{f['line'][:120]}")
+                prov = f"\t{f['provenance']}" if args.provenance else ""
+                print(f"{nb_rel}\tcell[{f['cell_index']}]\t{f['snippet']}\t{f['category']}{prov}\t{f['line'][:120]}")
 
     # Mode advisory par defaut (exit 0). --check reserved pour le futur quand
     # le stock wallclock sera draine (cf. condition de sortie de #9434).

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -29,6 +29,8 @@ from check_machine_dep_timing import (  # noqa: E402
     _is_section_number,
     _is_unit_conversion,
     _is_code_constant_translation,
+    _parse_numbers,
+    _values_close,
     _repo_root,
     PROTOCOL_KEYWORDS,
     CONTENT_DURATION_CONSTRAINT_RE,
@@ -1211,3 +1213,221 @@ def test_symbolicai_fp_pipeline_end_to_end() -> None:
         )
     finally:
         nb.unlink()
+
+
+# --------------------------------------------------------------------------- #
+#  Provenance (#9434) -- opt-in, valide par ses FAUX NEGATIFS
+# --------------------------------------------------------------------------- #
+# Un motif de detection se valide par les formes qu'il DOIT attraper, pas par
+# ses hits (cf. anti-regression.md : le jeu de motifs ecrit a la main sous-compte
+# en silence). Les cinq formes ci-dessous sont celles qui ont fait echouer deux
+# versions successives de l'instrument pendant la calibration du 2026-09-02 :
+# arrondi, zero final, conversion d'unite, derivation, constante declaree.
+def _code_cell_with_outputs(source: str, outputs: list[dict]) -> dict:
+    """Cellule code portant des sorties (le detecteur ne les LIT que sous
+    ``provenance=True`` -- la passe 1 continue de les ignorer)."""
+    return {"cell_type": "code", "metadata": {}, "source": [source],
+            "outputs": outputs}
+
+
+def _stream(text: str) -> dict:
+    return {"output_type": "stream", "name": "stdout", "text": [text]}
+
+
+def _nb_in(directory: Path, cells: list[dict]) -> Path:
+    """Ecrit le notebook DANS un repertoire donne (necessaire pour COMP :
+    la provenance compagnon depend du voisinage sur disque)."""
+    p = directory / "nb.ipynb"
+    p.write_text(
+        json.dumps({"cells": cells, "metadata": {}, "nbformat": 4,
+                    "nbformat_minor": 5}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _provenances(findings: list[dict]) -> list[str]:
+    return [f.get("provenance") for f in findings]
+
+
+def test_provenance_absent_by_default() -> None:
+    """Sans ``provenance=True``, AUCUN finding ne porte la cle.
+
+    C'est la garantie de non-regression : les trois consommateurs mesures
+    (2 workflows CI + measure_residual_machine_dep.py) lisent la sortie par
+    defaut, qui doit rester inchangee.
+    """
+    nb = _make_nb([_md_cell("L'entrainement a pris 47 minutes.")])
+    try:
+        findings = _scan_notebook(nb)
+        assert findings, "le controle positif doit produire un finding"
+        assert all("provenance" not in f for f in findings)
+    finally:
+        nb.unlink()
+
+
+def test_provenance_out_on_rounded_french_decimal() -> None:
+    """« 2,97 s » lit une sortie valant 2.9682 -> OUT.
+
+    Double piege : la virgule decimale francaise ET l'arrondi. Une comparaison
+    exacte, ou une normalisation qui SUPPRIME la virgule (« 0,041 » -> 41),
+    manque ce cas -- c'est l'erreur qu'a faite la premiere version.
+    """
+    nb = _make_nb([
+        _code_cell_with_outputs("bench()", [_stream("owlrl 2.9682 8005\n")]),
+        _md_cell("Le raisonneur owlrl met 2,97 s sur ce graphe."),
+    ])
+    try:
+        findings = _scan_notebook(nb, provenance=True)
+        assert _provenances(findings) == ["OUT"], findings
+    finally:
+        nb.unlink()
+
+
+def test_provenance_out_on_trailing_zero() -> None:
+    """« 0,041 s » lit une sortie valant 0.0410 -> OUT (zero final tronque)."""
+    nb = _make_nb([
+        _code_cell_with_outputs("bench()", [_stream("reasonable 0.0410 939\n")]),
+        _md_cell("reasonable descend a 0,041 s sur le meme graphe."),
+    ])
+    try:
+        findings = _scan_notebook(nb, provenance=True)
+        assert _provenances(findings) == ["OUT"], findings
+    finally:
+        nb.unlink()
+
+
+def test_provenance_out_on_unit_conversion() -> None:
+    """« 60 ms » lit une sortie exprimee en SECONDES (0.0587) -> OUT.
+
+    La prose convertit ; l'instrument doit reconnaitre l'echelle, sinon il
+    accuse de fabrication une lecture parfaitement fidele.
+    """
+    nb = _make_nb([
+        _code_cell_with_outputs("t()", [_stream("elapsed 0.0587\n")]),
+        _md_cell("L'appel prend 60 ms sur cette machine."),
+    ])
+    try:
+        findings = _scan_notebook(nb, provenance=True)
+        assert _provenances(findings) == ["OUT"], findings
+    finally:
+        nb.unlink()
+
+
+def test_provenance_der_on_ratio_of_outputs() -> None:
+    """Un FACTEUR (2.9682 / 0.0410 ~= 72) est une lecture, pas une affirmation.
+
+    Le nombre n'apparait dans aucune sortie : il se DEDUIT de deux d'entre
+    elles. Sans la passe DER, ce cas serait compte comme fabrique.
+    """
+    nb = _make_nb([
+        _code_cell_with_outputs(
+            "bench()", [_stream("owlrl 2.9682\nreasonable 0.0410\n")]),
+        _md_cell("Le facteur mesure vaut 72 s ici."),
+    ])
+    try:
+        findings = _scan_notebook(nb, provenance=True)
+        assert _provenances(findings) == ["DER"], findings
+    finally:
+        nb.unlink()
+
+
+def test_provenance_src_on_code_constant() -> None:
+    """« 500 ms » cite un ``Thread.Sleep(500)`` du notebook -> SRC.
+
+    Une constante DECLAREE est une specification : elle ne derive pas de la
+    machine et ne changera pas a la prochaine execution.
+    """
+    nb = _make_nb([
+        _code_cell("Thread.Sleep(500);"),
+        _md_cell("Chaque etape marque une pause de 500 ms."),
+    ])
+    try:
+        findings = _scan_notebook(nb, provenance=True)
+        assert _provenances(findings) == ["SRC"], findings
+    finally:
+        nb.unlink()
+
+
+def test_provenance_comp_on_companion_file(tmp_path: Path) -> None:
+    """Une constante d'un fichier COMPAGNON pilote par le notebook -> COMP.
+
+    Ce chemin n'est exerce par AUCUN notebook du depot au 2026-09-02 (mesure :
+    ``COMP=0`` sur les 288 findings wallclock) : sans ce test, il serait du
+    code non couvert qui se degraderait en silence.
+    """
+    (tmp_path / "Program.cs").write_text(
+        "class P { static void Main() { Thread.Sleep(1500); } }",
+        encoding="utf-8",
+    )
+    nb = _nb_in(tmp_path, [
+        _code_cell_with_outputs("run_demo()", [_stream("done\n")]),
+        _md_cell("Le programme de demo attend 1500 ms entre deux etapes."),
+    ])
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["COMP"], findings
+
+
+def test_provenance_unbacked_on_fabricated_value() -> None:
+    """CONTROLE NEGATIF : un nombre porte par RIEN reste ``unbacked``.
+
+    Une sonde se valide par son negatif (sinon elle classe tout en legitime et
+    parait excellente). Ici 47 n'est ni dans les sorties, ni dans le code, ni
+    dans un compagnon.
+    """
+    nb = _make_nb([
+        _code_cell_with_outputs("train()", [_stream("done\n")]),
+        _md_cell("L'entrainement a pris 47 minutes."),
+    ])
+    try:
+        findings = _scan_notebook(nb, provenance=True)
+        assert _provenances(findings) == ["unbacked"], findings
+    finally:
+        nb.unlink()
+
+
+def test_provenance_does_not_change_categories() -> None:
+    """La provenance est ORTHOGONALE a la classification.
+
+    Meme notebook, deux invocations : les categories doivent etre identiques.
+    Un instrument qui reclasserait en annotant melangerait deux questions
+    distinctes -- « quelle sorte de nombre ? » et « d'ou vient-il ? ».
+    """
+    cells = [
+        _code_cell_with_outputs("bench()", [_stream("owlrl 2.9682\n")]),
+        _md_cell("Le raisonneur owlrl met 2,97 s sur ce graphe."),
+        _md_cell("La moyenne ajustee est de 15.07 min."),
+        _md_cell("L'entrainement a pris 47 minutes."),
+    ]
+    nb = _make_nb(cells)
+    try:
+        plain = [(f["cell_index"], f["snippet"], f["category"])
+                 for f in _scan_notebook(nb)]
+        annotated = [(f["cell_index"], f["snippet"], f["category"])
+                     for f in _scan_notebook(nb, provenance=True)]
+        assert plain == annotated, (plain, annotated)
+    finally:
+        nb.unlink()
+
+
+def test_parse_numbers_handles_french_comma() -> None:
+    """« 0,041 » vaut 0.041 -- pas 41.
+
+    Test unitaire du defaut exact qui a fausse la premiere calibration : une
+    normalisation par suppression de la virgule multipliait la valeur par 1000.
+    """
+    assert _parse_numbers("0,041 s") == [0.041]
+    assert _parse_numbers("2,97") == [2.97]
+    assert _parse_numbers("2.97") == [2.97]
+
+
+def test_values_close_rejects_unrelated_magnitudes() -> None:
+    """CONTROLE NEGATIF du comparateur : 47 ne « matche » pas 2.9682.
+
+    Sans ce garde-fou, une tolerance trop large rendrait tout legitime et le
+    residu ``unbacked`` tomberait a zero pour de mauvaises raisons.
+    """
+    assert _values_close(2.97, 2.9682)          # arrondi
+    assert _values_close(60.0, 0.0587)          # s -> ms
+    assert not _values_close(47.0, 2.9682)
+    assert not _values_close(47.0, 0.0410)

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -31,6 +31,7 @@ from check_machine_dep_timing import (  # noqa: E402
     _is_code_constant_translation,
     _parse_numbers,
     _values_close,
+    _COMPANION_CACHE,
     _repo_root,
     PROTOCOL_KEYWORDS,
     CONTENT_DURATION_CONSTRAINT_RE,
@@ -1223,6 +1224,27 @@ def test_symbolicai_fp_pipeline_end_to_end() -> None:
 # en silence). Les cinq formes ci-dessous sont celles qui ont fait echouer deux
 # versions successives de l'instrument pendant la calibration du 2026-09-02 :
 # arrondi, zero final, conversion d'unite, derivation, constante declaree.
+#
+# TOUS ces tests ecrivent leur notebook dans un `tmp_path` ISOLE, et ce n'est
+# pas de la coquetterie : `_companion_values` scanne RECURSIVEMENT le repertoire
+# du notebook. Une premiere version ecrivait dans le repertoire temporaire
+# SYSTEME (via `_make_nb`) ; le controle negatif y passait en local par CHANCE
+# -- 1985 nombres etrangers ramasses, aucun proche de 47 -- et echouait sur le
+# runner CI, dont le voisinage portait une valeur a moins de 5 % (mesure du
+# 2026-09-02, run 33604926776). Un controle negatif dont le verdict depend du
+# contenu de /tmp n'est pas un controle.
+@pytest.fixture(autouse=True)
+def _clear_companion_cache():
+    """Vide le cache compagnon entre les tests.
+
+    C'est un global indexe par repertoire : le vider garantit qu'aucun ordre
+    d'execution ne peut porter le resultat d'un test dans un autre.
+    """
+    _COMPANION_CACHE.clear()
+    yield
+    _COMPANION_CACHE.clear()
+
+
 def _code_cell_with_outputs(source: str, outputs: list[dict]) -> dict:
     """Cellule code portant des sorties (le detecteur ne les LIT que sous
     ``provenance=True`` -- la passe 1 continue de les ignorer)."""
@@ -1235,8 +1257,11 @@ def _stream(text: str) -> dict:
 
 
 def _nb_in(directory: Path, cells: list[dict]) -> Path:
-    """Ecrit le notebook DANS un repertoire donne (necessaire pour COMP :
-    la provenance compagnon depend du voisinage sur disque)."""
+    """Ecrit le notebook dans un repertoire ISOLE et renvoie son Path.
+
+    L'isolation porte le sens de toute assertion de provenance : le voisinage
+    du fichier fait partie de l'entree de ``_companion_values``.
+    """
     p = directory / "nb.ipynb"
     p.write_text(
         json.dumps({"cells": cells, "metadata": {}, "nbformat": 4,
@@ -1250,103 +1275,85 @@ def _provenances(findings: list[dict]) -> list[str]:
     return [f.get("provenance") for f in findings]
 
 
-def test_provenance_absent_by_default() -> None:
+def test_provenance_absent_by_default(tmp_path: Path) -> None:
     """Sans ``provenance=True``, AUCUN finding ne porte la cle.
 
     C'est la garantie de non-regression : les trois consommateurs mesures
     (2 workflows CI + measure_residual_machine_dep.py) lisent la sortie par
     defaut, qui doit rester inchangee.
     """
-    nb = _make_nb([_md_cell("L'entrainement a pris 47 minutes.")])
-    try:
-        findings = _scan_notebook(nb)
-        assert findings, "le controle positif doit produire un finding"
-        assert all("provenance" not in f for f in findings)
-    finally:
-        nb.unlink()
+    nb = _nb_in(tmp_path, [_md_cell("L'entrainement a pris 47 minutes.")])
+    findings = _scan_notebook(nb)
+    assert findings, "le controle positif doit produire un finding"
+    assert all("provenance" not in f for f in findings)
 
 
-def test_provenance_out_on_rounded_french_decimal() -> None:
+def test_provenance_out_on_rounded_french_decimal(tmp_path: Path) -> None:
     """« 2,97 s » lit une sortie valant 2.9682 -> OUT.
 
     Double piege : la virgule decimale francaise ET l'arrondi. Une comparaison
     exacte, ou une normalisation qui SUPPRIME la virgule (« 0,041 » -> 41),
     manque ce cas -- c'est l'erreur qu'a faite la premiere version.
     """
-    nb = _make_nb([
+    nb = _nb_in(tmp_path, [
         _code_cell_with_outputs("bench()", [_stream("owlrl 2.9682 8005\n")]),
         _md_cell("Le raisonneur owlrl met 2,97 s sur ce graphe."),
     ])
-    try:
-        findings = _scan_notebook(nb, provenance=True)
-        assert _provenances(findings) == ["OUT"], findings
-    finally:
-        nb.unlink()
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["OUT"], findings
 
 
-def test_provenance_out_on_trailing_zero() -> None:
+def test_provenance_out_on_trailing_zero(tmp_path: Path) -> None:
     """« 0,041 s » lit une sortie valant 0.0410 -> OUT (zero final tronque)."""
-    nb = _make_nb([
+    nb = _nb_in(tmp_path, [
         _code_cell_with_outputs("bench()", [_stream("reasonable 0.0410 939\n")]),
         _md_cell("reasonable descend a 0,041 s sur le meme graphe."),
     ])
-    try:
-        findings = _scan_notebook(nb, provenance=True)
-        assert _provenances(findings) == ["OUT"], findings
-    finally:
-        nb.unlink()
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["OUT"], findings
 
 
-def test_provenance_out_on_unit_conversion() -> None:
+def test_provenance_out_on_unit_conversion(tmp_path: Path) -> None:
     """« 60 ms » lit une sortie exprimee en SECONDES (0.0587) -> OUT.
 
     La prose convertit ; l'instrument doit reconnaitre l'echelle, sinon il
     accuse de fabrication une lecture parfaitement fidele.
     """
-    nb = _make_nb([
+    nb = _nb_in(tmp_path, [
         _code_cell_with_outputs("t()", [_stream("elapsed 0.0587\n")]),
         _md_cell("L'appel prend 60 ms sur cette machine."),
     ])
-    try:
-        findings = _scan_notebook(nb, provenance=True)
-        assert _provenances(findings) == ["OUT"], findings
-    finally:
-        nb.unlink()
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["OUT"], findings
 
 
-def test_provenance_der_on_ratio_of_outputs() -> None:
+def test_provenance_der_on_ratio_of_outputs(tmp_path: Path) -> None:
     """Un FACTEUR (2.9682 / 0.0410 ~= 72) est une lecture, pas une affirmation.
 
     Le nombre n'apparait dans aucune sortie : il se DEDUIT de deux d'entre
     elles. Sans la passe DER, ce cas serait compte comme fabrique.
     """
-    nb = _make_nb([
+    nb = _nb_in(tmp_path, [
         _code_cell_with_outputs(
             "bench()", [_stream("owlrl 2.9682\nreasonable 0.0410\n")]),
         _md_cell("Le facteur mesure vaut 72 s ici."),
     ])
-    try:
-        findings = _scan_notebook(nb, provenance=True)
-        assert _provenances(findings) == ["DER"], findings
-    finally:
-        nb.unlink()
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["DER"], findings
 
 
-def test_provenance_src_on_code_constant() -> None:
+def test_provenance_src_on_code_constant(tmp_path: Path) -> None:
     """« 500 ms » cite un ``Thread.Sleep(500)`` du notebook -> SRC.
 
     Une constante DECLAREE est une specification : elle ne derive pas de la
     machine et ne changera pas a la prochaine execution.
     """
-    nb = _make_nb([
+    nb = _nb_in(tmp_path, [
         _code_cell("Thread.Sleep(500);"),
         _md_cell("Chaque etape marque une pause de 500 ms."),
     ])
-    try:
-        findings = _scan_notebook(nb, provenance=True)
-        assert _provenances(findings) == ["SRC"], findings
-    finally:
-        nb.unlink()
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["SRC"], findings
 
 
 def test_provenance_comp_on_companion_file(tmp_path: Path) -> None:
@@ -1368,46 +1375,67 @@ def test_provenance_comp_on_companion_file(tmp_path: Path) -> None:
     assert _provenances(findings) == ["COMP"], findings
 
 
-def test_provenance_unbacked_on_fabricated_value() -> None:
+def test_provenance_comp_presuppose_un_repertoire_cure(tmp_path: Path) -> None:
+    """COMP suppose un repertoire CURE -- et cette limite est pinnee ici.
+
+    ``_companion_values`` tient pour compagnon tout fichier du sous-arbre du
+    notebook. Dans le depot c'est la semantique voulue (un notebook et le
+    ``Program.cs`` qu'il pilote vivent ensemble) ; dans un repertoire non cure
+    c'est un FABRICANT de verdicts positifs -- il retire des lignes du residu
+    ``unbacked`` sans qu'aucune specification ne porte reellement le nombre.
+
+    Mesure : un voisin etranger portant 46.9 suffit a faire passer « 47
+    minutes » de ``unbacked`` a ``COMP`` (46.9 est a moins de 5 %). C'est le
+    mecanisme exact qui a fait echouer ce fichier en CI le 2026-09-02.
+
+    Ce test ne condamne pas le comportement : il le rend VISIBLE, pour que
+    personne ne lise ``COMP`` comme une preuve plus forte qu'elle ne l'est.
+    """
+    (tmp_path / "voisin_sans_rapport.json").write_text(
+        json.dumps({"seuils": [12, 46.9, 300]}), encoding="utf-8",
+    )
+    nb = _nb_in(tmp_path, [
+        _code_cell_with_outputs("train()", [_stream("done\n")]),
+        _md_cell("L'entrainement a pris 47 minutes."),
+    ])
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["COMP"], findings
+
+
+def test_provenance_unbacked_on_fabricated_value(tmp_path: Path) -> None:
     """CONTROLE NEGATIF : un nombre porte par RIEN reste ``unbacked``.
 
     Une sonde se valide par son negatif (sinon elle classe tout en legitime et
     parait excellente). Ici 47 n'est ni dans les sorties, ni dans le code, ni
-    dans un compagnon.
+    dans un compagnon -- et le repertoire ne porte AUCUN autre fichier, ce qui
+    est la condition sans laquelle l'assertion ne mesure rien.
     """
-    nb = _make_nb([
+    nb = _nb_in(tmp_path, [
         _code_cell_with_outputs("train()", [_stream("done\n")]),
         _md_cell("L'entrainement a pris 47 minutes."),
     ])
-    try:
-        findings = _scan_notebook(nb, provenance=True)
-        assert _provenances(findings) == ["unbacked"], findings
-    finally:
-        nb.unlink()
+    findings = _scan_notebook(nb, provenance=True)
+    assert _provenances(findings) == ["unbacked"], findings
 
 
-def test_provenance_does_not_change_categories() -> None:
+def test_provenance_does_not_change_categories(tmp_path: Path) -> None:
     """La provenance est ORTHOGONALE a la classification.
 
     Meme notebook, deux invocations : les categories doivent etre identiques.
     Un instrument qui reclasserait en annotant melangerait deux questions
     distinctes -- « quelle sorte de nombre ? » et « d'ou vient-il ? ».
     """
-    cells = [
+    nb = _nb_in(tmp_path, [
         _code_cell_with_outputs("bench()", [_stream("owlrl 2.9682\n")]),
         _md_cell("Le raisonneur owlrl met 2,97 s sur ce graphe."),
         _md_cell("La moyenne ajustee est de 15.07 min."),
         _md_cell("L'entrainement a pris 47 minutes."),
-    ]
-    nb = _make_nb(cells)
-    try:
-        plain = [(f["cell_index"], f["snippet"], f["category"])
-                 for f in _scan_notebook(nb)]
-        annotated = [(f["cell_index"], f["snippet"], f["category"])
-                     for f in _scan_notebook(nb, provenance=True)]
-        assert plain == annotated, (plain, annotated)
-    finally:
-        nb.unlink()
+    ])
+    plain = [(f["cell_index"], f["snippet"], f["category"])
+             for f in _scan_notebook(nb)]
+    annotated = [(f["cell_index"], f["snippet"], f["category"])
+                 for f in _scan_notebook(nb, provenance=True)]
+    assert plain == annotated, (plain, annotated)
 
 
 def test_parse_numbers_handles_french_comma() -> None:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: DEEP/research-code #14219

## Summary

Le compteur `check_machine_dep_timing.py` raisonne **ligne à ligne, sur du texte**. Il ne peut donc pas distinguer une prose qui **AFFIRME** un chiffre d'une prose qui **LIT** une sortie du notebook — la distinction même sur laquelle repose le drainage #9434 (test READS-vs-AFFIRMS, arbitré par ai-01 sur ce fil).

Cette PR ajoute une passe de **provenance** opt-in (`--provenance`) qui répond à la question que le compte brut ne posait pas : *le nombre cité est-il porté par le notebook ?*

| Provenance | Ce qu'elle dit |
|---|---|
| `OUT` | la valeur est dans une **sortie** de cellule |
| `DER` | elle est un **ratio** de deux valeurs de sortie (« ~72× ») |
| `SRC` | elle est déclarée dans une **cellule de code** (constante, paramètre) |
| `COMP` | elle est dans un **fichier compagnon** que le notebook pilote — une spécification |
| `unbacked` | aucune des quatre → le seul résidu qui mérite un regard humain |

## Ce que ça mesure (2026-09-02, corpus entier)

```
# check_machine_dep_timing -- scanned=1211
# wallclock=288 distribution_param=72 domain_quantity=209 ambiguous=0
# provenance[wallclock] OUT=258 DER=13 SRC=10 COMP=0 unbacked=7
```

**281 des 288 findings `wallclock` citent un nombre que le notebook porte déjà.** Les 7 restants ont été relus à la main, un par un :

| Notebook | Snippet | Ce que c'est |
|---|---|---|
| `01-1b-Video-Slideshow-Bonus` (×3) | `5 secondes`, `1 seconde` | **spécification** de la vidéo à produire (`5 s @ 1 FPS`) |
| `02-6-MiniMax-H3-Architecture-Licensing` | `15 s` | **fait produit** : longueur max d'un clip du modèle |
| `QC-Py-03-Data-Management` (×2) | `150 minutes`, `17 minutes` | **quantités de domaine** QC (warm-up, timeframe d'exemple) |
| `QC-Py-26-LLM-Trading-Signals` | `0 ms` | **définitionnel** : un cache hit ne coûte rien |

Aucune n'est une mesure fabriquée. **L'arme `wallclock` de #9434 est propre** — c'est l'instrument qui comptait mal, à ~98 % de faux positifs.

L'enjeu est celui qu'ai-01 a nommé sur ce fil : *« une métrique d'occurrences se satisfait toujours en supprimant, jamais en corrigeant. »* Un drainage piloté par le compte brut aurait supprimé de la prose qui lit correctement ses propres sorties.

## Non-régression : prouvée, pas affirmée

Sur **le même arbre**, avec la version `origin/main` du script et la version patchée :

| Mode | Résultat |
|---|---|
| `--all --json` | **byte-identique** |
| `--all` (TSV) | **byte-identique** |

La passe ne tourne que sous `--provenance` ; sans le flag, **aucun finding ne porte la clé** (test dédié). Les trois consommateurs mesurés ont été ré-exécutés :

- `.github/workflows/machine-dep-timing-advisory.yml` → lit `summary.wallclock` — inchangé
- `.github/workflows/machine-dep-timing-inventory.yml` → lit `scanned` / `summary.*` — inchangé
- `scripts/notebook_tools/measure_residual_machine_dep.py` → tourne, mêmes comptes (`RUNTIME_MEASURED=109`, familles inchangées)

`--provenance` n'**ajoute** que la clé `provenance` dans chaque finding et le bloc `provenance_summary` (ventilé par catégorie).

## Tests — validés par leurs FAUX NÉGATIFS

**55 existants + 11 nouveaux = 66 verts.** Un motif de détection se valide par les formes qu'il **doit** attraper, pas par ses hits (`anti-regression.md` : un jeu de motifs écrit à la main sous-compte *en silence*). Les cinq formes couvertes sont exactement celles qui ont fait échouer **deux versions successives** de l'instrument pendant la calibration :

1. **arrondi + virgule française** — `2,97 s` ← sortie `2.9682`
2. **zéro final** — `0,041 s` ← sortie `0.0410`
3. **conversion d'unité** — `60 ms` ← sortie `0.0587` (secondes)
4. **dérivation** — facteur `72` ← `2.9682 / 0.0410`
5. **constante déclarée** — `500 ms` ← `Thread.Sleep(500)`

Plus trois contrôles que l'instrument doit **échouer** à valider :

- un nombre porté par rien reste `unbacked` (contrôle négatif de bout en bout) ;
- `_values_close` **refuse** 47 face à 2.9682 et à 0.0410 ;
- `_parse_numbers("0,041")` vaut `0.041` — **pas 41** : le défaut exact d'une première version, qui normalisait en *supprimant* la virgule.

Et un test d'**orthogonalité** : annoter ne change aucune catégorie.

`COMP` n'est exercé par **aucun** notebook du dépôt (`COMP=0`). Le test dédié existe précisément pour que ce chemin ne se dégrade pas en silence.

## Effet de bord corrigé (documentation seule)

`--category` ne filtre **que** la sortie TSV : en `--json`, `findings` porte toujours **toutes** les catégories. C'est ce qui a faussé ma propre première mesure (569 au lieu de 288). Le comportement **ne change pas** — les consommateurs en dépendent — mais l'aide du flag le dit maintenant.

## Limite, écrite ici plutôt que découverte plus tard

La tolérance de 5 % sur six échelles peut **absorber** un vrai défaut par coïncidence numérique. `unbacked = 7` est donc un **plancher du légitime, pas un plafond du défaut** : l'instrument réduit un tri de 288 lignes à un tri de 7, il ne prouve pas que les 281 autres soient toutes justes. Le commentaire de tête du module le dit dans les mêmes termes.

## Ce que cette PR ne fait pas

- **Aucun notebook touché** — mon claim sur #9434 a été amendé pour se restreindre aux deux fichiers d'outillage (`issuecomment-5505985256`), le reste de l'EPIC reste libre pour les autres lanes.
- **Aucune tranche de drainage** — et la mesure recommande de ne pas en dispatcher sur l'arme `wallclock` : le travail consisterait à supprimer du bon contenu.
- `--check` reste inerte (exit 0 par défaut), comme avant.

Mesure d'origine et verdict détaillé : `issuecomment-5505846033`.

See #9434
