### PR TITLE
feat(lean,#2874): Alexander du mutant du trèfle (r12) — preuve sans sorry

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
@@ -478,6 +478,22 @@ theorem trefoil_ne_unknot_alexander :
   have h2 := congrArg (fun p : Polynomial ℤ => p.coeff 2) h
   simp [Polynomial.coeff_X] at h2
 
+/-- Invariance sous mutation : le mutant du trèfle (fenêtre pleine, r12) a le
+même polynôme d'Alexander que le trèfle — le polynôme d'Alexander est
+invariant par mutation (Conway 1970), et le trèfle étant amphichiral, son
+mutant reste un trèfle. -/
+theorem alexander_trefoilMutant :
+    alexanderPolynomial trefoilMutant = Polynomial.X ^ 2 - Polynomial.X + 1 := by
+  have hp : arcPartition trefoilMutantDiagram = [[1, 2], [3, 4], [5, 6]] := by
+    decide
+  simp only [alexanderPolynomial, alexanderPolynomialAux, trefoilMutant, hp]
+  dsimp [trefoilMutantDiagram, mutateWindow, KleinRot.apply, trefoilDiagram]
+  simp (config := { decide := true })
+  rw [det_two_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntry]
+  ring
+
 /-- Polynôme d'Alexander trivial du nœud de Conway — contenu classique
 Δ(t) = 1 ; sous la normalisation désignée, le mineur vaut l'unité −t⁶
 (arbitrage de la note de §4 tranché : valeur désignée exacte). -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -483,6 +483,22 @@ theorem trefoil_ne_unknot_alexander :
   have h2 := congrArg (fun p : Polynomial ℤ => p.coeff 2) h
   simp [Polynomial.coeff_X] at h2
 
+/-- Invariance under mutation: the mutant of the trefoil (full window, r12)
+has the same Alexander polynomial as the trefoil — the Alexander polynomial
+is invariant under mutation (Conway 1970), and the trefoil being
+amphichiral, its mutant remains a trefoil. -/
+theorem alexander_trefoilMutant :
+    alexanderPolynomial trefoilMutant = Polynomial.X ^ 2 - Polynomial.X + 1 := by
+  have hp : arcPartition trefoilMutantDiagram = [[1, 2], [3, 4], [5, 6]] := by
+    decide
+  simp only [alexanderPolynomial, alexanderPolynomialAux, trefoilMutant, hp]
+  dsimp [trefoilMutantDiagram, mutateWindow, KleinRot.apply, trefoilDiagram]
+  simp (config := { decide := true })
+  rw [det_two_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntry]
+  ring
+
 /-- Trivial Alexander polynomial of the Conway knot — classical content
 Δ(t) = 1; under the designated normalization, the minor equals the unit
 −t⁶ (§4 note arbitration settled: exact designated value). -/


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2023:CoursIA-2 — prev: LIGHT/docs #14239

## Résumé

Ajoute `alexander_trefoilMutant` (FR + sibling EN) : le polynôme d'Alexander du
mutant du trèfle (fenêtre pleine, rotation `r12` du groupe de Klein) vaut
**X² − X + 1**, égalant le trèfle. Trois lectures du même résultat :

1. **Invariance sous mutation** (Conway 1970) : le polynôme d'Alexander est
   invariant par mutation ; le trèfle étant amphichiral, son mutant reste un
   trèfle.
2. **Exercice de la machinerie** `arcPartition` / `alexanderEntry` / déterminant
   du mineur d'Alexander (Dehn) sur un cas où la passe réduit à un mineur 2×2 —
   le même canal que la cible `conway_trivial_alexander` (mineur 10×10) mais sur
   un cas entièrement résoluble.
3. **Preuve computationnelle effective** : `dsimp [trefoilMutantDiagram,
   mutateWindow, KleinRot.apply, trefoilDiagram]` réduit rédéfinitionnellement la
   liste de croisements du mutant ; `decide` résout `arcPartition` et les
   appartenances de `alexanderEntry` ; `ring` clôt.

## Contexte mission (honnêteté)

La mission DEEP/lean du coordinateur (DM msg-20260902T030403-cdv821) vise
`conway_trivial_alexander` (−t⁶) et `KT_trivial_alexander` (t⁵). **Ces deux
théorèmes restent `exact sorry`** dans cette PR. Le présent théorème est un
**support CONTENU** (titre annonce ce qu'il prouve) qui avance le programme
knot_lean vers la cible sans la livrer. La voie directe (déterminant 10×10,
développement 10! = 3 628 800 termes) déborde la profondeur de récursion du
noyau (`maxRecDepth`), et `native_decide` est interdit (axiome). Ce théorème est
le grain délivré du cycle ; la cible reste un travail multi-cycle.

## Preuves Lean (pr-review-discipline §B)

- **B.1 compte `sorry` réel** (`count_code_sorry.py --json`, champ
  `distinct_code_sorry`) : `knot_lean` = **11 distinct**, **inchangé** par cette
  PR (le diff n'ajoute qu'un théorème sans `sorry`, il n'en retire ni n'en
  ajoute). Le `naive_sorry` (60) sur-compte la prose documentaire — non utilisé.
  Les 6 `sorry` pré-existants de `Conway.lean` (L500/510/525/533/557/587) et leurs
  jumeaux EN sont inchangés.
- **B.2 Lake build SUCCESS local** : `lake build Knots.Conway Knots.Conway_en`
  → `Build completed successfully` (3000 jobs, la passe FR 76 s, la passe EN
  11 s), base `9bac9cd5d` (origin/main). Sortie sans aucune erreur ; seuls les
  warnings `declaration uses sorry` pré-existants subsistent.
- **B.3 proof-integrity** : le gate est câblé à ce lake —
  `lean-knot.yml` → `lean-axiom.yml` avec `target-modules: "*"` (L136) et la
  dérivation runtime depuis le glob lakefile `.submodules Knots, Knots_en`
  (L140-141, #8787) : `Knots.Conway` et `Knots.Conway_en` sont **dans la cible**.
  Vérification axiome locale (`#print axioms Knots.alexander_trefoilMutant`) :
  ```
  'Knots.alexander_trefoilMutant' depends on axioms: [propext, Classical.choice, Quot.sound]
  ```
  → fondation standard Mathlib seule, **ni `sorryAx` ni `native_decide`**.

## i18n (§E)

Sibling pair #4980 : `Conway.lean` (FR canonique) / `Conway_en.lean` (miroir EN).
Corps **byte-identique** vérifié par `check_i18n_siblings.py` :
`OK .../Knots/Conway_en.lean — 1/1 pairs byte-identical | 0 drift | 0 orphan | 0 unbuilt`.
Seule la docstring diffère (FR / EN). Import graph inchangé.

## Régression

- Diff = **+32 insertions, 0 deletion** (16 lignes par fichier), purement additif.
- Aucun symbole modifié/supprimé : `git grep` sur les identifiants touchés
  (`alexanderPolynomial`, `arcPartition`, `alexanderEntry`, `mutateWindow`,
  `KleinRot`, `trefoilMutant`) — aucun ne change de définition.
- `distinct_code_sorry` de `knot_lean` stable (11).

See #2874
