### PR TITLE
docs(dswa,#14190): ajouter 04-Vision au README racine (50 -> 52 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -24,7 +24,7 @@ La formation couvre deux stacks complémentaires :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 50 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning) |
+| Notebooks | 52 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 2 vision) |
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 
@@ -115,6 +115,10 @@ DataScienceWithAgents/
 │   ├── 3.7-Distillation-Maitre-Eleve.ipynb
 │   └── 3.8-Representations-Contrastives.ipynb
 │
+├── 04-Vision/                  # Vision par convolution (2 notebooks)
+│   ├── 4.1-Conv-NumPy-Torch-Allclose.ipynb
+│   └── 4.2-ConvNet-Profonde-Residuelles.ipynb
+│
 ├── Track1-LangChain/ # Track LangChain (7 labs)
 │   ├── Day1-Foundations/Labs/              # Revision
 │   ├── Day2-Document-Agents/Labs/              # Agents RFP et CV
@@ -182,6 +186,17 @@ Le prolongement direct du socle : là où [2.2](02-ML-Cours/2.2-Descente-de-grad
 | [3.8-Representations-Contrastives](03-DeepLearning/3.8-Representations-Contrastives.ipynb) | Pré-entraînement contrastif moderne : vues continues, encodeur MLP et loss InfoNCE from scratch, pont vers skip-gram | **Apprendre des représentations sans étiquettes** : deux vues attirent leurs embeddings, les autres repoussent |
 
 Documentation complète : [03-DeepLearning/README.md](03-DeepLearning/README.md)
+
+## Vision (04-Vision)
+
+Le pont entre le socle profond from-scratch et la vision par convolution : là où la série [03-DeepLearning](03-DeepLearning/README.md) ferme sur les représentations contrastives et la distillation, cette section ouvre la convolution — d'abord avec un neurone convolutif *à la main* (NumPy pur, parité exacte avec `torch.nn.functional.conv2d`), puis avec une ConvNet profonde où la résiduelle devient la condition de faisabilité. La section prépare aussi le transfer learning ResNet (4.3, PR suivante).
+
+| Notebook | Sujet | Concept-phare |
+|----------|-------|---------------|
+| [4.1-Conv-NumPy-Torch-Allclose](04-Vision/4.1-Conv-NumPy-Torch-Allclose.ipynb) | Neurone convolutif from scratch (NumPy) puis parité exacte avec `torch.nn.functional.conv2d` | **La boîte noire ouverte** : 10 convolutions NumPy reproduisent torch à 0.0 près (allclose 1e-12), gradient vérifié |
+| [4.2-ConvNet-Profonde-Residuelles](04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb) | ConvNet profonde : pourquoi le résiduel devient la condition de faisabilité (ResNet-18 sur CIFAR-10) | **La résiduelle n'est pas un gadget** : sans skip connection, 20 couches == divergence ; avec, accuracy test ≥ baseline |
+
+Documentation complète : [04-Vision/README.md](04-Vision/README.md)
 
 ## Workshop 3 Jours (Track1-LangChain)
 


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-cleanup #14244 (cycle 170)

## Summary

Resolution de l'issue **#14190** : la racine `MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md` omettait le sous-dossier `04-Vision/` entier — ni dans la ventilation du nombre de notebooks (ligne 27), ni dans l'arbre de structure, ni dans aucun sommaire de section. Un notebook absent du README de sa série est un notebook qu'aucun lecteur ne trouve.

Sortie : **1 commit**, **1 fichier modifie** (README.md, +16/-1), **0 notebook touche** (correction purement doc). Catalogue byte-identique a `main` (cf `catalog-pr-hygiene.md` R1 — la dette du catalogue est signalee, pas corrigee dans cette PR).

## Acceptance #14190 (4/4)

| # | Critere | Resultat |
|---|---------|----------|
| 1 | Ligne de synthese `README.md:27` compte **51** (issue) ou reel, et porte un terme pour `04-Vision` | **OK** : compte **52** (issue etait a 50+1=51 ; disk est a 52 avec 2 notebooks dans 04-Vision — voir verification), terme ajoute `+ 2 vision` dans la ventilation. Ventilation complete : `52 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 2 vision)` |
| 2 | `04-Vision/` apparait dans l'arbre / la table de structure du README racine, avec son notebook nomme | **OK** : entree ajoutee dans l'arbre (entre `03-DeepLearning/` et `Track1-LangChain/`) listant 4.1 + 4.2 ; nouvelle section `## Vision (04-Vision)` avec table de 2 notebooks (parallele a `## Fondations (01-PythonForDataScience)`, `## Fondations ML (02-ML-Cours)`, `## Deep Learning (03-DeepLearning)`) ; lien `Documentation complete : [04-Vision/README.md](04-Vision/README.md)` |
| 3 | Audit **fichier entier** du README racine | **OK** : audit `grep -c 'Vision' README.md` avant = 0, apres = 5 (mention + table + 2 cellules de nav) ; verification exhaustive des 6 sous-dossiers (cf `pr-review-discipline.md` §E — corriger l'intro sans toucher le corps = CHANGES_REQUESTED) : `01/02/03/04/Track1/Track2` ont tous un `README.md` listant leurs notebooks (cf verification ci-dessous) ; aucune autre section du README n'a ete impactee par la modification |
| 4 | Verifier que les 4 autres sous-dossiers (`01`, `Track1`, `Track2`, et `04` une fois ajoute) ont chacun un README | **OK** : 6/6 sous-dossiers ont un `README.md` (audite firsthand par `ls + wc + grep`.ipynb`)`). Issue ne demandait que 4 ; audit fichier-entier en valide 6. |

**Catalog-pr-hygiene R1** : `COURSE_CATALOG.generated.{json,md}` est byte-identique a `main` (le catalogue rend 50 DSWA notebooks, sans 04-Vision — conforme au README avant correction ; **incoherent maintenant** avec le disk reel). Conformement a la regle R1 (cf `catalog-pr-hygiene.md`), je **signale** la dette (cf Residuel ci-dessous), je ne **regenere pas** le catalogue sur la branche — le cron `catalog-cron.yml` quotidien sur `main` ou la CI `catalog-drift.yml` par-PR le regenerera avec le contenu mis a jour de la sub-serie. Risque catalogue-poison evite.

## Verification post-fix (acceptance live)

| Mesure | Avant (origin/main) | Apres (cette PR) | Source |
|--------|---------------------|------------------|--------|
| `grep -c 'Vision' DSWA/README.md` | 0 | 5 | (issue #14190, audit firsthand) |
| Comptage `.ipynb` DSWA total | 52 (disk) | 52 (disk) | `find ... -name "*.ipynb" \| wc -l` |
| Ventilation README ligne 27 | `50 (7+10+2+21+10)` | `52 (7+10+2+21+10+2)` | (apres patch) |
| 04-Vision notebooks sur disk | 2 (4.1, 4.2) | 2 (4.1, 4.2) | `find 04-Vision -name "*.ipynb"` |
| Catalog DSWA (bytes-identique a main ?) | 50 | **50 inchangé** | `python3 -c "...len(...DataScienceWithAgents...)"` |
| 01-PythonForDataScience README | 3667 B, 3 links | 3667 B, 3 links | (lecture unaffected) |
| 02-ML-Cours README | 33938 B, 36 links | 33938 B, 36 links | (lecture unaffected) |
| 03-DeepLearning README | 9429 B, 18 links | 9429 B, 18 links | (lecture unaffected) |
| 04-Vision README | 5904 B, 6 links | 5904 B, 6 links | (lecture unaffected — 4.1 x 3 + 4.2 x 3) |
| Track1-LangChain README | 4293 B, 7 links | 4293 B, 7 links | (lecture unaffected) |
| Track2-GoogleADK README | 15828 B, 10 links | 15828 B, 10 links | (lecture unaffected) |
| Pre-commit `fix-hr-separator` hook | n/a | OK | (les separateurs `---` du README ne sont pas dans les cellules ; le hook ne touche pas les README) |

**Note sur l'acceptance #1** : l'issue annonce `04-Vision/` avec 1 notebook et un total de 51 (= 50+1). La mesure firsthand sur `origin/main` (commit 44cb92406) montre 2 notebooks dans `04-Vision/` (`4.1-Conv-NumPy-Torch-Allclose.ipynb`, `4.2-ConvNet-Profonde-Residuelles.ipynb`), donc le total reel est **52**, pas 51. **J'ai documente le delta dans la PR** plutot que de m'aligner sur le 51 de l'issue. Le 4.2 est sans doute present depuis peu (le notebook pointe vers "4.3 - Transfer learning ResNet *(PR suivante)*", ce qui suggere une trajectoire en cours).

## Architecture du fix

### 1. Ligne 27 (count + term)

Avant : `| Notebooks | 50 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning) |`

Apres : `| Notebooks | 52 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 2 vision) |`

### 2. Arbre de structure (lignes 76-128)

Insertion d'un bloc `04-Vision/` entre `03-DeepLearning/` et `Track1-LangChain/`, parallele a la convention `XX-Nom/` :

```
├── 04-Vision/                  # Vision par convolution (2 notebooks)
│   ├── 4.1-Conv-NumPy-Torch-Allclose.ipynb
│   └── 4.2-ConvNet-Profonde-Residuelles.ipynb
```

### 3. Section `## Vision (04-Vision)`

Ajoutee entre `## Deep Learning (03-DeepLearning)` et `## Workshop 3 Jours (Track1-LangChain)`, parallele aux sections existantes :

- Paragraphe d'introduction : "Le pont entre le socle profond from-scratch et la vision par convolution..."
- Table 2 notebooks avec colonnes **Notebook | Sujet | Concept-phare** (parallele a `## Fondations ML (02-ML-Cours)`)
- Lien `Documentation complete : [04-Vision/README.md](04-Vision/README.md)`

**Pas de duplication** avec le sous-README de 04-Vision (le sous-README reste l'autorite detaillee ; le README racine donne la vue d'ensemble et le sommaire).

## Verdicts

- **SOTA-OK** : pas de workaround degrade ; la prose reflete le contenu reel des notebooks (4.1 + 4.2 verifies par lecture de la premiere cellule markdown de chaque notebook).
- **Anti-regression D** : 0 notebook touche, 0 cellule modifiee, 0 substance pedagogique alteree. Le seul livrable = correction de la documentation parente.
- **Stop & Repair** : N/A (README only).
- **catalog-pr-hygiene R1** : OK, `COURSE_CATALOG.generated.{json,md}` byte-identique a `main` ; dette signalee en Residuel, pas regeneree sur la branche.
- **pr-review-discipline** : PR docs/administration, scope 16 lignes ajoutees, **slime +5/-1** au sens de §E ; **mais** audit fichier-entier execute (la section 04-Vision inextante n'etait pas le seul defaut — verification exhaustive des 6 sous-dossiers). Pas un slim masque, un slim reel.
- **readme-french-first** : OK, prose en francais, pas de regression vers l'anglais.
- **Convention Exemple/Exercice** : N/A.
- **3 exercices par notebook** : N/A.

## Recette morale (issue fondateur explicite)

L'issue #14190 a ete ouverte par ai-01 le 2026-09-02 en cloturant #13780 (re-vérifié sur `main` : 04-Vision absent partout, pas de suivi). Defaut de **categorie specifique** : pas un chiffre faux, un sous-dossier absent. Le critere de sortie EPIC #13504 no 3 (« chaque notebook a une ligne dans le README de son dossier ») couvrait `02/03` mais pas la racine ni les sous-dossiers hors `02/03`. Cette PR retablit la racine + verifie les 6 sous-dossiers.

## Residuel / suite

- **Dette catalogue (signalee, non corrigee)** : `COURSE_CATALOG.generated.json` rend 50 DSWA notebooks (sans 04-Vision). Incoherent maintenant avec le disk reel (52). Conformement a `catalog-pr-hygiene.md` R1, je **signale sans regenerer** — le cron quotidien `catalog-cron.yml` sur `main` regenerera dans < 24h avec la coherence corrigee ; la CI `catalog-drift.yml` par-PR peut aussi regenerer. Cf issue soeur si souhaite acceleration : ouvrir un ticket dedie a "DSWA catalog needs regen after #14190 fix" pour que catalog-cron lane le pick.
- **Issue #14190 partiellement resolue** : 4/4 acceptance du corps resolue ; mais le delta 51→52 (4.2 ajoute recemment) **pourrait** faire l'objet d'un suivi dedie si l'audit veut documenter la trajectoire 04-Vision (4.1 livre, 4.2 livre, 4.3 "Transfer learning ResNet" annonce comme "PR suivante" dans le 4.2 markdown). Mon PR ne le fait pas — c'est hors scope.
- **Pas de regen du `02-ML-Cours/README.md`** : bien que la section 02 soit lourde (36 notebook links, 34 KB), elle est deja structuree, pas de defaut visible ; audit `wc -c` confirme la stabilite. Sortie de scope.

## Lecons

- **"Sous-dossier absent" ≠ "chiffre faux"** : la classe de derive documentee par #14190 (0 mention de `Vision` dans le README) est distincte de la classe #14211 (chiffre stale dans une prose). Toutes deux relevent du genre `prose qui cite un artefact` mais la parade est la meme : **ancrer sur le disque**. Mon audit a fait `find ... -name "*.ipynb"` par sous-dossier pour mesurer le reel ; ce shell est reproductible et idempotent (cf `prose-anchor-on-measuring-cell-not-frozen-number.md` du c170).
- **Issue self-stale** : l'acceptance #1 dit "compte **51**" mais le disk reel rend 52 (4.2 ajoute recemment). Faire confiance au disque, pas a l'issue — l'issue a ete ouverte le 2026-09-02 mais la trajectoire 04-Vision est en cours. J'ai documente le delta dans le body plutot que de m'aligner sur 51.
- **catalog-pr-hygiene R1 applique** : tentation naturelle quand on edite un README serait de regenerer aussi le catalogue. Refus actif : le catalogue appartient a l'automatisation (cron + catalog-drift), un humain sur une branche feature ne touche pas. Risque : PR avec 1090+ lignes de diff catalogue qui poisonne le merge. Verdict : signaler en Residuel, ne pas regenerer.
- **Audit fichier-entier (regle §E)** : pour une PR slim +5/-1 a 16 lignes ajoutees, l'audit a porte sur le fichier ENTIER (ligne 27 + arbre lignes 76-128 + 6 sections par sous-dossier) + sur les 6 sous-README (verification que chacun liste ses notebooks). Le format slim **plafonne mal** : quand une serie a subi un changement structurel (sous-dossier ajoute), la passe DOIT etre fichier-entier. Cf `pr-review-discipline.md` §E explicite.

## Rotation R6

c168 = LIGHT/tooling scan_d5 ; c169 = GUARD/ci slides-composition-advisory -- livraison verdict ; c170 = LIGHT/notebook-cleanup Tweety-7a parite (#14211) ; c171 = **LIGHT/docs DataScienceWithAgents README 04-Vision (#14190)**.

Regle 6 (variete obligatoire) :

- **Famille** : docs/ML (mise a jour d'un README de serie, scope borne par acceptance #14190 stricte, audit fichier-entier) — distincte du tooling merge-gate de c166-c167, du tooling scan_d5 c168, du CI workflow c169, du notebook-content c170. **4 familles distinctes sur les 4 derniers cycles** (tooling merge-gate / tooling scan / CI / notebook-content / docs).
- **Genre** : LIGHT — pas de substance code, scope borne par acceptance #14190 stricte.
- **Issue** : dette documentaire (sous-dossier non reference dans le README racine), distincte de #14222 (c168, dette d'instrument), #14218 (c167, dette de garde), #14211 (c170, prose perimee).

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14190
- Issue parente (EPIC) : https://github.com/jsboige/CoursIA/issues/13504
- Issue parente (immediate) : https://github.com/jsboige/CoursIA/issues/13780 (cloturee par ai-01 le 2026-09-02 sans suivi — voir note dans issue body)
- Issue parente (audit README) : cf le precedent de plomberie : `pr-review-discipline.md` §E (auditer le fichier ENTIER, pas seulement la ligne corrigee)
- Issue voisine (c170) : https://github.com/jsboige/CoursIA/issues/14211 (prose-figee cross-langage — meme classe de derive, parade differente car cellule, pas fichier)
- Issue 04-Vision 4.2 trajectory : `4.2-ConvNet-Profonde-Residuelles.ipynb` premiere cellule markdown reference "4.3 - Transfer learning ResNet *(PR suivante)*"
- Convention : `catalog-pr-hygiene.md` R1 ; `pr-review-discipline.md` §E ; CLAUDE.md section B/E
- PR beneficiaire c.170 (livre juste avant) : https://github.com/jsboige/CoursIA/pull/14244 (LIGHT/notebook-cleanup)
- PR beneficiaire c.169 : https://github.com/jsboige/CoursIA/pull/14240 (GUARD/ci slides-delivery)
