### PR TITLE
feat(notebook-tools,#14064): durcir le detecteur de desaccentuation de prose markdown

### DIFF
--- a/scripts/notebook_tools/detect_markdown_deaccent.py
+++ b/scripts/notebook_tools/detect_markdown_deaccent.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Detect desaccented words in notebook markdown prose.
+
+A "desaccented" word is an unaccented surface form whose accent-stripped twin
+exists (accented) elsewhere in the *same* notebook -- the internal positive
+control: without an accented twin, nothing is asserted. E.g. `theoreme` is
+flagged only if `theoreme`'s strip equals `theoreme` (no accents) and an
+accented `theoreme` (the `theoreme` spelling, stripped) was seen in that
+notebook.
+
+This is the family seated by #14064: the user's coquille `individaux` was the
+visible tip of a systematic markdown desaccentuation. The historical,
+unhardened detector (the inline script in the issue) reported a raw
+`37 286 occurrences` across `946/1219` notebooks -- but that count is a
+*ceiling of candidates*, not a defect count. The three biggest hits
+(`des` -> `des`, `sur` -> `sur`, `mesure` -> `mesure`) are legitimate
+homographs / partitive articles / nouns that are genuinely different French
+words, not typos, and together accounted for `6 084` (16%) of the ceiling.
+
+Hardening therefore does NOT try to raise precision by scoring context (that
+would overfit). It does two things, and validates by FALSE NEGATIVES (never by
+hits):
+
+1. **Exclusion lists.** A closed set of unaccented forms that are either (a)
+   legitimate homographs of a distinct French word (`des`/`dès`, `sur`/`sûr`,
+   `mesure`/`mesuré`, `cote`/`côté`, `tache`/`tâche`, `marche`/`marché`,
+   `base`/`basé`, `type`/`typé`, ...), or (b) English technical cognats that
+   legitimately survive unaccented in French prose (`inference`, `decision`,
+   `precision`, `reference`, `regression`, `detection`, `generation`, `video`,
+   `regime`, `complete`). These are reported in a separate "excluded" bucket,
+   never as auto-flagged candidates.
+2. **FR/EN prose gate.** A notebook whose markdown is English-dominant is not a
+   French-desaccentuation candidate at all; it is skipped with `language=en`.
+
+Acceptance is by the forms it MUST catch, written as tests, never by its hit
+count: `theoreme`, `etat`, `donnees`, `equilibre`, `entrainement` must be
+flagged in a French notebook, and must NOT be flagged in an English one or when
+the word is a homograph that only looks desaccented.
+
+Usage: python detect_markdown_deaccent.py <notebook-or-dir> [more...] [--json]
+                                   [--fail-on-findings]
+
+Output: one line per notebook `COUNT TOTAL (AUTO auto / HOM homograph / COG
+en-cognat), PATH`, then a machine-readable summary. A scan that matches no
+notebook is an error (exit 1) -- a vacuous `0/0` is never a clean scan (the
+scan_md_hierarchy.py lesson, #3968). `--fail-on-findings` exits 2 when any
+notebook has auto-flagged candidates (PR-gate use).
+"""
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+_WORD_RE = re.compile(r"[A-Za-zÀ-ÿ]{3,}")
+# Inline code, fenced code blocks, and inline math. Desaccented words inside
+# code/math are not prose defects; stripping them mirrors the issue's
+# `re.sub(r"`[^`]*`", " ", text)` guard and extends it to fenced blocks.
+_CODE_RE = re.compile(r"`[^`]*`|```.*?```|\$\$.*?\$\$|\$[^$]*\$", re.DOTALL)
+
+
+def _strip_accents(s: str) -> str:
+    """Remove combining diaeresis marks (NFD, drop category Mn)."""
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn"
+    )
+
+
+# Unaccented forms that are a *legitimately different* French word from their
+# accented twin -- an homograph, not a desaccentuation typo. `des` (partitive)
+# vs `dès` (since), `sur` (preposition) vs `sûr` (sure), `mesure` (noun) vs
+# `mesuré` (participle). The issue named these as the guaranteed false
+# positives (16% of the raw ceiling). Add a form here rather than teach the
+# detector to read context.
+HOMOGRAPH_EXCLUSIONS = {
+    "des", "sur", "mesure", "mesures",
+    "cote", "cotes", "tache", "taches",
+    "marche", "marches", "base", "bases",
+    "type", "types", "structure", "structures",
+    "analyse", "analyses", "attaque", "attaques",
+    "complete", "completes", "utilise", "utilises",
+}
+
+# English technical cognats that legitimately survive unaccented in French
+# prose. Not defects either (e.g. "l'algorithme de detection").
+EN_COGNAT_EXCLUSIONS = {
+    "inference", "decision", "decisions", "precision", "reference",
+    "references", "regression", "regressions", "detection", "generation",
+    "video", "regime", "complete", "algorithm", "implementation",
+}
+
+FR_STOPWORDS = {
+    "le", "la", "les", "des", "une", "un", "est", "sont", "pour", "avec",
+    "dans", "par", "sur", "que", "qui", "cette", "ces", "ce", "il", "elle",
+    "nous", "vous", "ils", "elles", "se", "ne", "pas", "plus", "comme", "ou",
+    "si", "mais", "donc", "ainsi", "etre", "avoir", "fait", "faire", "entre",
+    "toute", "tout", "meme", "on", "au", "aux", "du", "de", "en", "une",
+}
+EN_STOPWORDS = {
+    "the", "of", "and", "to", "in", "is", "are", "for", "on", "with", "that",
+    "it", "as", "at", "by", "an", "be", "this", "from", "or", "we", "they",
+    "not", "can", "but", "what", "have", "has", "was", "were", "which", "will",
+    "their", "if", "when", "into", "these", "then", "than", "its",
+}
+
+
+def _classify_language(texts: list[str]) -> str:
+    """Return 'fr' or 'en' by counting stopword occurrences in the prose."""
+    fr = en = 0
+    for t in texts:
+        for word in _WORD_RE.findall(t):
+            w = word.lower()
+            if w in FR_STOPWORDS:
+                fr += 1
+            elif w in EN_STOPWORDS:
+                en += 1
+    return "fr" if fr >= en else "en"
+
+
+def _markdown_texts(nb: dict) -> list[str]:
+    """Collect de-coded markdown cell text from a notebook dict."""
+    texts = []
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+        source = cell.get("source", "")
+        if isinstance(source, list):
+            source = "".join(source)
+        texts.append(_CODE_RE.sub(" ", source))
+    return texts
+
+
+def find_candidates(nb: dict) -> dict:
+    """Return {language, auto, homograph, en_cognat} candidate word->count maps.
+
+    Each bucket maps the *stripped lowercase key* to the number of unaccented
+    surface occurrences. `auto` only, is what a PR gate should fail on; the
+    other buckets are transparency, not defects.
+    """
+    texts = _markdown_texts(nb)
+    # Internal positive control: strip(key) -> an accented surface form.
+    accented = {}
+    for t in texts:
+        for m in _WORD_RE.finditer(t):
+            word = m.group(0)
+            if word != _strip_accents(word):
+                accented.setdefault(_strip_accents(word).lower(), word)
+
+    result = {"language": _classify_language(texts), "auto": {}, "homograph": {},
+              "en_cognat": {}}
+    if result["language"] != "fr":
+        return result
+
+    for t in texts:
+        for m in _WORD_RE.finditer(t):
+            word = m.group(0)
+            if word != _strip_accents(word):
+                continue
+            key = word.lower()
+            if key not in accented:
+                continue
+            bucket = (
+                "auto"
+                if key not in HOMOGRAPH_EXCLUSIONS and key not in EN_COGNAT_EXCLUSIONS
+                else ("homograph" if key in HOMOGRAPH_EXCLUSIONS else "en_cognat")
+            )
+            result[bucket][key] = result[bucket].get(key, 0) + 1
+    return result
+
+
+def _total(counts: dict) -> int:
+    return sum(v for v in counts.values())
+
+
+def analyze_notebook(path: Path) -> tuple[dict, bool]:
+    """Return (result, discovered) -- discovered=False on a vacuous/empty scan."""
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"{path}: cannot read notebook: {exc}")
+    result = find_candidates(nb)
+    return result, True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("paths", nargs="*", help="notebook(s) or directory(ies)")
+    parser.add_argument("--json", action="store_true", help="emit JSON report")
+    parser.add_argument("--fail-on-findings", action="store_true",
+                        help="exit 2 when any notebook has auto-flagged candidates")
+    args = parser.parse_args(argv)
+
+    if not args.paths:
+        print("error: no path given (a vacuous /0 is never a clean scan)",
+              file=sys.stderr)
+        return 1
+
+    files: list[Path] = []
+    for raw in args.paths:
+        p = Path(raw)
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.ipynb")))
+        elif p.is_file():
+            files.append(p)
+
+    if not files:
+        print(f"error: no notebooks under {args.paths} (vacuous scan)",
+              file=sys.stderr)
+        return 1
+
+    report = {}
+    exit_code = 0
+    for path in files:
+        try:
+            result, _ = analyze_notebook(path)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            exit_code = 1
+            continue
+        rel = path.as_posix()
+        report[rel] = result
+        n_auto = _total(result["auto"])
+        n_hom = _total(result["homograph"])
+        n_cog = _total(result["en_cognat"])
+        n_tot = n_auto + n_hom + n_cog
+        if not args.json:
+            print(f"{n_tot} TOTAL ({n_auto} auto / {n_hom} hom / {n_cog} cog) "
+                  f"[{result['language']}], {rel}")
+        if n_auto and args.fail_on_findings:
+            exit_code = 2
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_markdown_deaccent.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_deaccent.py
@@ -1,0 +1,149 @@
+"""Acceptance tests for scripts/notebook_tools/detect_markdown_deaccent.py
+
+The #14064 hardening is validated by FALSE NEGATIVES, never by hits (the
+issue's explicit rule: "le durcissement se valide par ses faux négatifs ...
+jamais par ses hits"). So the suite pins the forms the instrument MUST catch
+and the homographs it MUST NOT auto-flag, plus the FR/EN prose gate.
+
+Pure functions with tmp_path fixtures -- no I/O on the real repo.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+import detect_markdown_deaccent as dmd
+from detect_markdown_deaccent import (
+    EN_COGNAT_EXCLUSIONS,
+    FR_STOPWORDS,
+    EN_STOPWORDS,
+    HOMOGRAPH_EXCLUSIONS,
+    find_candidates,
+)
+
+
+def _write_nb(path: Path, cells: list[dict]) -> Path:
+    """Write a minimal nbformat-4 notebook with the given cells to path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _md(source: str) -> dict:
+    return {"cell_type": "markdown", "metadata": {}, "source": [source]}
+
+
+def _notebook(cells: list[dict]) -> dict:
+    return {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+# --- False negatives: the forms the instrument MUST catch (issue §acceptance) --
+
+ACCEPTANCE_FORMS = ["theoreme", "etat", "donnees", "equilibre", "entrainement"]
+
+
+def test_acceptance_forms_not_excluded():
+    """The 5 mandated forms must never be silently excluded by a list."""
+    for form in ACCEPTANCE_FORMS:
+        assert form not in HOMOGRAPH_EXCLUSIONS, (
+            f"{form} should be auto-flagged, but it is in HOMOGRAPH_EXCLUSIONS"
+        )
+        assert form not in EN_COGNAT_EXCLUSIONS, (
+            f"{form} should be auto-flagged, but it is in EN_COGNAT_EXCLUSIONS"
+        )
+
+
+def test_false_negatives_caught():
+    """A French notebook with the 5 forms (accented twin present) → auto-flagged."""
+    accented = "Le théorème de Sen, l'état stable, les données, un équilibre et l'entraînement."
+    unaccented = "Le theoreme est faux; l'etat change; les donnees manquent; un equilibre existe; l'entrainement dure."
+    nb = _notebook([_md(accented), _md(unaccented)])
+    result = find_candidates(nb)
+    assert result["language"] == "fr", "this notebook must classify as French prose"
+    for form in ACCEPTANCE_FORMS:
+        assert form in result["auto"], (
+            f"false negative: {form} must be auto-flagged, got auto={sorted(result['auto'])}"
+        )
+
+
+def test_homographs_never_auto_flagged():
+    """des/sur/mesure/mesures are legitimately-different words → homograph bucket,
+    never auto-flagged, even when the accented twin (dès/sûr/mesuré/mesurés) appears."""
+    accented = "Dès le départ il est sûr, un résultat mesuré; des mesures précises."
+    unaccented = "le des partitif, sur la table, une mesure exacte, ces mesures."
+    nb = _notebook([_md(accented), _md(unaccented)])
+    result = find_candidates(nb)
+    assert result["language"] == "fr"
+    for form in ("des", "sur", "mesure", "mesures"):
+        assert form not in result["auto"], (
+            f"homograph {form} must NOT be auto-flagged"
+        )
+    # They ARE reported, but only as homographs (transparency, not defects).
+    assert "mesure" in result["homograph"] or "mesures" in result["homograph"]
+
+
+def test_english_notebook_gate_skips():
+    """English-dominant prose → language=en, desaccented word with accented twin
+    present is NOT flagged (the FR/EN gate prevents false positives on EN prose)."""
+    en_prose = "The state is stable and the theorem is true. The etat here."
+    accented_twin = "état"
+    nb = _notebook([_md(en_prose), _md(accented_twin)])
+    result = find_candidates(nb)
+    assert result["language"] == "en", (
+        f"expected en, got {result['language']}"
+    )
+    assert "etat" not in result["auto"], (
+        "an English-dominant notebook must not flag a desaccented word"
+    )
+    assert result["auto"] == {}
+
+
+def test_inline_code_not_flagged():
+    """A desaccented word inside an inline-code span is not prose → ignored."""
+    accented = "le théorème de Sen"
+    code = "use `theoreme` as an identifier here"
+    nb = _notebook([_md(accented), _md(code)])
+    result = find_candidates(nb)
+    assert "theoreme" not in result["auto"]
+
+
+def test_english_cognat_excluded():
+    """An English technical cognat (e.g. detection) with an accented French twin
+    (détection) is NOT auto-flagged -- it is a legitimately unaccented EN term."""
+    accented = "la détection d'anomalies est l'objectif"
+    unaccented = "l'etape de detection est cruciale"
+    nb = _notebook([_md(accented), _md(unaccented)])
+    result = find_candidates(nb)
+    assert "detection" not in result["auto"]
+
+
+# --- Language gate: the stopword sets are non-empty and disjoint enough to be
+# --- a real signal (guards against a later accidental emptying of the lists). --
+
+
+def test_language_stopwords_nonempty():
+    assert len(FR_STOPWORDS) > 20
+    assert len(EN_STOPWORDS) > 20
+
+
+def test_french_stopword_shared_word_not_in_both_notably():
+    """A word used as an FR stopword should not be double-qualifying as EN. This is
+    a soft guard: `sur` is an FR preposition and happens to be `sur` as a verb; the
+    gate only needs *relative* dominance, but a single word dominating both sets
+    would mute the signal."""
+    overlap = FR_STOPWORDS & EN_STOPWORDS
+    # `on`, `sur`, `des` are legitimate in both; allow a tiny overlap but not a
+    # large one that would let a single word decide both directions.
+    assert len(overlap) < 5, f"FR/EN stopword overlap too large: {sorted(overlap)}"


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA

## Summary

Hardenne le detecteur de desaccentuation de la prose markdown des notebooks. Nouveau scanner autonome `scripts/notebook_tools/detect_markdown_deaccent.py` (famille de `scan_md_hierarchy.py`), avec suite de tests d'acceptation par **faux-negatifs** (regle explicite de l'issue : « le durcissement se valide par ses faux negatifs ... jamais par ses hits »).

**Durcissement apporte :**
1. **Listes d'exclusion** — les formes unaccentuees qui sont un *mot francais legitime distinct* (homographes : `des`/`dès`, `sur`/`sûr`, `mesure`/`mesuré`, `cote`/`côté`, `tache`/`tâche`, `marche`/`marché`, `base`/`basé`, `type`/`typé`, …) et les *cognats anglais* (`inference`, `decision`, `precision`, `reference`, `regression`, `detection`, `generation`, `video`, `regime`) sont **blacklistes du bucket auto** et rapportes separement (homograph / en-cognat). C'est ce qui ecarte les 3 plus gros faux positifs de l'issue (`des` 4321, `sur` 907, `mesure` 856).
2. **Gate FR/EN** — seuls les notebooks a prose **francaise dominante** sont analyses (classe par ratio de stopwords FR vs EN) ; un notebook anglais est ignore (`language=en`).
3. **Code inline ignore** — les mots dans les spans \`code\`, blocs fenced et maths ne sont pas de la prose.

**L'instrument ne pretend pas compter les defauts** : il rapporte un *plafond de candidats* (le chiffre brut de l'issue 37 286 est un plafond, pas des coquilles). Le durcissement separe ce plafond en buckets transparents pour que le rollout par serie (jamais en une passe, cf issue) parte de candidats auto a forte confiance.

## Validation

**Acceptation (faux-negatifs, testee) — 8 tests PASS :**
- `theoreme` / `etat` / `donnees` / `equilibre` / `entrainement` doivent etre attrapes dans un notebook FR → **attrapes** (auto).
- `des` / `sur` / `mesure` / `mesures` ne doivent **jamais** etre auto-flagges (bucket homograph).
- Un notebook a prose anglaise dominante est skippe (`language=en`), meme si un twin accentue existe.
- Un cognat anglais (`detection` + `détection` present) n'est pas auto-flagge.
- Les formes d'acceptation sont **verrouillees hors des listes d'exclusion** (test de garde).

**Verite terrain — SC-04** (`04-Computational-Aggregation-SAT-Z3.ipynb`), le notebook hand-verifie par l'issue (31 formes / 157 occurrences) : **match exact** — `157 TOTAL` (auto=29 formes / hom=2 formes `mesure`,`mesures`, 0 cognat), `fr`. Chaque forme auto (theoreme, simultanement, croit, decide, cout, electeurs, …) est une vraie desaccentuation.

**Corpus complet** (`MyIA.AI.Notebooks`, 1212 notebooks) : **0 erreur**. `FR=1194 / EN=18` ; `AUTO=27499` (924 notebooks) / `HOM=8443` (488) / `COG=2269` (281).

## Perimetre

- `scripts/notebook_tools/detect_markdown_deaccent.py` (nouveau)
- `scripts/notebook_tools/tests/test_detect_markdown_deaccent.py` (nouveau)

2 fichiers, +388 lignes, un seul sujet. `pytest scripts/notebook_tools/tests/test_detect_markdown_deaccent.py` → 8 passed.

## Voir / Note de sequencing

`See #14064`. Livraison partielle : l'**instrument** est livre. La **tranche contenu SC-04** (les 157 occurrences + `individaux`→`individuels`) est **differee** : le body de l'issue impose d'attendre le merge de **#13932** (OPEN/BLOCKED, extends z3 sur SC-04, cellule 52) sinon conflit JSON sur le meme `.ipynb`. Le rollout par serie est a enchainer apres, sur la base de ce detecteur.

Base = origin/main `44cb924068`, rebase frais, un push.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
