### PR TITLE
fix(slides): scinder les 2 slides Extensions 2015+/2020+ qui debordaient sous le pli

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -1567,7 +1567,7 @@ layout: section
 
 
 
-# Extensions 2015+
+# Extensions 2015+ — au-delà de la grille
 
 
 - Modèles Bayésiens
@@ -1576,6 +1576,21 @@ layout: section
 - Graph Neural Networks
   - Généralisation géométrique
   - Agrégation de voisinage
+
+<div class="grid grid-cols-3 gap-4 absolute bottom-[40px] left-[50px] right-[50px]">
+<img src="./images/img_106.png" class="max-h-[190px] w-full object-contain" alt="Autoencodeur variationnel : encodeur, mu/sigma, échantillonnage, décodeur, perte reconstruction + KL" />
+<img src="./images/img_107.png" class="max-h-[190px] w-full object-contain" alt="Graphe irrégulier versus grille de texte séquentielle — deux structures de données" />
+<img src="./images/img_108.png" class="max-h-[190px] w-full object-contain" alt="Pipeline GNN : graphe d'entrée, blocs GNN, graphe transformé, couche de classification, prédiction" />
+</div>
+
+<!-- Auto-encodeurs variationnels : encodeur mu/sigma, echantillonnage, perte reconstruction + KL. GNN : donnees en graphe irregulier plutot qu'en grille, agregation de voisinage. -->
+---
+
+
+
+# Extensions 2015+ — attention et LLMs
+
+
 - Réseaux attentionnels
   - Économie de ressources
   - Séquences
@@ -1587,13 +1602,10 @@ layout: section
 - Modèles efficients (2020+)
   - Reformer, Longformer : attention linéaire ou par fenêtres
 
-<div class="grid grid-cols-3 gap-2 absolute top-[130px] right-[20px] w-[600px]">
-<img src="./images/img_104.png" class="max-h-[150px] w-full object-contain" alt="Deux photos d'une femme lançant un frisbee dans un parc, légendées en anglais" />
-<img src="./images/img_105.jpg" class="max-h-[150px] w-full object-contain" alt="Attention mot à mot : traduction de « How was your day » avec poids d'importance colorés" />
-<img src="./images/img_106.png" class="max-h-[150px] w-full object-contain" alt="Autoencodeur variationnel : encodeur, mu/sigma, échantillonnage, décodeur, perte reconstruction + KL" />
-<img src="./images/img_107.png" class="max-h-[150px] w-full object-contain" alt="Graphe irrégulier versus grille de texte séquentielle — deux structures de données" />
-<img src="./images/img_108.png" class="max-h-[150px] w-full object-contain" alt="Pipeline GNN : graphe d'entrée, blocs GNN, graphe transformé, couche de classification, prédiction" />
-<img src="./images/img_109.png" class="max-h-[150px] w-full object-contain" alt="Architecture Transformer encodeur-décodeur avec auto-attention, exemple de traduction du tchèque" />
+<div class="grid grid-cols-3 gap-4 absolute bottom-[35px] left-[50px] right-[50px]">
+<img src="./images/img_104.png" class="max-h-[135px] w-full object-contain" alt="Deux photos d'une femme lançant un frisbee dans un parc, légendées en anglais" />
+<img src="./images/img_105.jpg" class="max-h-[135px] w-full object-contain" alt="Attention mot à mot : traduction de « How was your day » avec poids d'importance colorés" />
+<img src="./images/img_109.png" class="max-h-[135px] w-full object-contain" alt="Architecture Transformer encodeur-décodeur avec auto-attention, exemple de traduction du tchèque" />
 </div>
 
 <!-- Transformer : encodeur-decodeur, self-attention multi-tetes, positional encoding. LLMs : GPT-2 (2019) zero-shot, GPT-3 (2020) in-context few-shot, T5 (2019) text-to-text unifie. Modeles efficients 2020+ : Reformer, Longformer. -->
@@ -1601,7 +1613,7 @@ layout: section
 
 
 
-# Extensions 2020+
+# Extensions 2020+ — modèles multimodaux
 
 
 **Modèles multimodaux**
@@ -1614,6 +1626,19 @@ layout: section
 - Génération conditionnelle
   - DALL-E (2022, OpenAI), Imagen (2022, Google)
   - GPT-4V (2023), Gemini (2023) : compréhension multimodale
+
+<div class="grid grid-cols-2 gap-4 absolute bottom-[35px] left-[50px] right-[50px]">
+<img src="./images/img_110.png" class="max-h-[160px] w-full object-contain" alt="Trois paires image-légende : rue de Kyoto, aigle en vol, paysage montagneux" />
+<img src="./images/img_111.png" class="max-h-[160px] w-full object-contain" alt="CLIP : plongements image et texte comparés, mise à jour des modèles, verdict similaire ou non" />
+</div>
+
+<!-- Multimodaux : CLIP (2021) contraste texte-image sur 400 M de paires, ALIGN / Florence, DALL-E (2022), Imagen (2022), GPT-4V / Gemini (2023). -->
+---
+
+
+
+# Extensions 2020+ — diffusion et alignement
+
 
 **Modèles de diffusion**
 
@@ -1630,14 +1655,12 @@ layout: section
 - ChatGPT (nov. 2022, OpenAI) : 100 M d'utilisateurs en 2 mois
 - Modèles open-weight : Llama 2 (2023), Mistral, Mixtral (MoE 2023-2024)
 
-<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
-<img src="./images/img_110.png" class="max-h-[190px] w-full object-contain" alt="Trois paires image-légende : rue de Kyoto, aigle en vol, paysage montagneux" />
-<img src="./images/img_111.png" class="max-h-[190px] w-full object-contain" alt="CLIP : plongements image et texte comparés, mise à jour des modèles, verdict similaire ou non" />
-<img src="./images/img_112.png" class="max-h-[190px] w-full object-contain" alt="Chaîne de Markov de diffusion : bruitage progressif de xT vers x0 puis débruitage inverse" />
-<img src="./images/img_113.png" class="max-h-[190px] w-full object-contain" alt="U-Net de débruitage latent : encodeur, décodeur, attention croisée Q/K/V, conditionnements et pas de temps" />
+<div class="grid grid-cols-2 gap-4 absolute bottom-[25px] left-[50px] right-[50px]">
+<img src="./images/img_112.png" class="max-h-[100px] w-full object-contain" alt="Chaîne de Markov de diffusion : bruitage progressif de xT vers x0 puis débruitage inverse" />
+<img src="./images/img_113.png" class="max-h-[100px] w-full object-contain" alt="U-Net de débruitage latent : encodeur, décodeur, attention croisée Q/K/V, conditionnements et pas de temps" />
 </div>
 
-<!-- Multimodaux : CLIP (2021) contraste texte-image, DALL-E (2022), GPT-4V / Gemini (2023). Diffusion latente (LDM / Stable Diffusion, Rombach 2021-2022) : bruit latent + U-Net + cross-attention. Alignement : RLHF (InstructGPT 2022), ChatGPT (nov 2022), Llama 2 / Mistral / Mixtral (2023-2024). -->
+<!-- Diffusion latente (LDM / Stable Diffusion, Rombach 2021-2022) : bruit latent + U-Net + cross-attention. Alignement : RLHF (InstructGPT 2022), ChatGPT (nov 2022), Llama 2 / Mistral / Mixtral (2023-2024). -->
 ---
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/tooling #14148

## Le defaut, mesure au rendu

En faisant le QA visuel demande par #14192 (dont le body declarait honnetement « Axe 1 — QA visuel : non verifie, lane vision requise »), j'ai installe Slidev et rendu les pages touchees. Le fait decisif :

| page | rendu avant vs apres #14192 | ce que le lecteur voyait du contenu ajoute |
|---|---|---|
| 6 | CHANGED | visible |
| 57 | CHANGED | « Mamba (2023) et State Space Models… » coupe par le bord bas ; « Hyena, RWKV… » entierement sous le pli |
| 58 | **IDENTIQUE au bit pres** (`sha1 a342b44d47e0` des deux cotes) | **rien** |

Un ajout de texte qui ne change **aucun pixel** est un ajout que personne ne lira. La cause n'etait pas dans #14192 : elle etait deja sur `main`.

Sur `main`, avant cette PR, la page 58 portait **sous le pli** la section entiere « **Alignement et produit grand public** » — son titre et ses trois bullets, dont « Modeles open-weight : Llama 2 (2023), Mistral, Mixtral ». La derniere ligne visible etait « Mecanisme attentionnel (cross-attention Q/K/V) », coupee contre le pied de page. Deux bullets de plus etaient **occultes** par la grille d'images en `position: absolute` : « CLIP (2021, OpenAI) : contraste texte-… » et « DALL-E (2022, OpenAI), Imagen (2022… ». Meme defaut page 57 sur « Transformers, Multi-tetes (2017 : « At… ».

## Correctif

- **2 slides -> 4**, decoupees sur une frontiere semantique et non a l'aveugle : *au-dela de la grille* (bayesiens, GNN) / *attention et LLMs* ; *modeles multimodaux* / *diffusion et alignement*.
- **Grilles d'images re-ancrees en bas** (`bottom-[Npx] left-[50px] right-[50px]`) au lieu de `top-[130px] right-[20px] w-[600px]`. C'est ce qui supprime l'occlusion : l'espace libre de ces slides est **vertical**, pas horizontal — les lignes longues couraient sous une grille qui occupait 61 % de la largeur.
- **Les 10 images sont preservees** avec leurs `alt`, redistribuees selon le propos de leur moitie (VAE/graphe/GNN d'un cote, captioning/attention/Transformer de l'autre). Assertion automatique dans le script de patch : les 10 noms de fichier sont re-verifies presents apres reecriture.
- Presenter-notes (`<!-- ... -->`) redistribuees de meme, aucune perdue.

## Verification — axe 1, execute

Les **4 slides** ont ete rendues en PNG et relues **une par une** sur ai-01 (lane vision), en trois passes : decoupe seule, puis re-ancrage des grilles, puis marge de respiration. Verdict final : aucun debordement, aucune occlusion, tout le texte atteint le lecteur.

```bash
cd slides && ./node_modules/.bin/slidev export S3-acculturation/slides.md \
    --format png --range "57,58,59,60" --output <dir> --timeout 60000
```

Les numeros de page reels viennent de `@slidev/parser` : le comptage naif des `---` donne 122 blocs pour 100 slides et decale de 16 pages.

## Rapport a #14192

Cette PR traite l'**axe 2** que #14192 nommait lui-meme hors scope (« Refonte layout `two-cols` → `position: absolute` »). Le rendu a montre que ce n'etait pas une question esthetique differable : c'etait ce qui rendait sa tranche de contenu inoperante. Une fois celle-ci mergee, la tranche de #14192 atteindra le lecteur — son `CHANGES_REQUESTED` pourra etre leve par son auteur sur une simple re-verification, sans reecriture de contenu.

`See #14192`
