### PR TITLE
feat(training): revalidate M16 against debiased HAR

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -13,8 +13,32 @@ Updated: 2026-08-23 — backlog à déposer : M15 h=32 NO BEATS (#11468) et barr
 Updated: 2026-08-24 — Re-validation hors-biais des keepers BTC (issues #11041/#11034/#11036) : M15 `refuted-de-biased` 3/3 (l'edge publié = biais² de HAR, var_ratio > 1 partout) ; M4 confirmé h=1/h=5, INCONCLUSIVE h=10 (p_median 0,0598, var_ratio < 1)
 Updated: 2026-08-24 — M15 LSTM-vol patch persistance biais + slice 2/2 dé-biaisé symétrique (issue #12734): patch livré, run complet dispatché au prochain cycle
 Updated: 2026-09-01 — PatchTST BTC log-RV revalidé contre HAR débiaisé train-only (#14081) : h=1 INCONCLUSIVE, h=5/h=10 NO BEATS ; var_ratio > 1 aux trois horizons
+Updated: 2026-09-02 — M16 HAR asymétrique BTC revalidé contre HAR débiaisé train-only (#1454) : h=1 INCONCLUSIVE, h=5/h=10 BEATS ; verdict brut 3/3 réfuté
 
 Total checkpoints: 70 (20 legacy ARCHIVED + 50 panier baselines)
+
+## M16 HAR asymétrique — re-test débiaisé BTC (2026-09-02) — Epic #1454
+
+Le keeper historique M16 annonçait **3/3 BEATS** sur BTC face à HAR classique brut. Le re-test applique
+la même calibration train-only de 60 observations aux deux modèles, persiste leurs prévisions OOS sur
+les mêmes dates et évalue `dm_verdict(..., loss_fn="mse")`. Walk-forward expanding 5 folds, horizons
+{1,5,10}, quatre seeds {0,7,42,99}. OLS étant déterministe, les seeds sont bit-identiques : `edge/σ`
+cross-seed est **non applicable**, pas artificiellement infini.
+
+| Horizon | MSE HAR débiaisé | MSE asym. débiaisé | edge | biais asym. | biais HAR | dm_p_median | Verdict |
+|---:|---:|---:|---:|---:|---:|---:|---|
+| h=1 | 0,843774 | 0,848154 | −0,52 % | −0,005109 | −0,003880 | 0,244862 | **INCONCLUSIVE** |
+| h=5 | 0,417886 | 0,403593 | +3,42 % | −0,003967 | −0,001552 | 0,011363 | **BEATS** |
+| h=10 | 0,389457 | 0,369614 | +5,10 % | −0,004194 | −0,002419 | 0,005123 | **BEATS** |
+
+**Décomposition `MSE = biais² + variance`** : les biais résiduels sont proches de zéro (biais² ≤ 2,6e-5),
+donc l'écart restant porte essentiellement sur la variance. Le résultat brut était gonflé, surtout aux
+horizons longs (+23,6 %/+36,7 % → +3,4 %/+5,1 %), mais le signal ne disparaît pas : **2/3 BEATS,
+1/3 INCONCLUSIVE, 0/3 NO BEATS**. M16 BTC reste un keeper moyen/long horizon ; h=1 est retiré du claim.
+
+- **Run** : `python scripts/har_asymmetric.py --coins BTC-USD --horizons 1 5 10 --seeds 0 7 42 99 --n-splits 5 --skip-remote --debias --calibration-size 60 --out-json scripts/results/m16_har_asymmetric_btc_debiased.json`
+- **Notebook** : `m3_har_asymmetric_semivariance.ipynb`, 8/8 cellules code exécutées, recalcul indépendant depuis les séries persistées
+- **Coûts** : non applicables au verdict de forecast pur ; aucun claim Sharpe/P&L
 
 ## M4 DLinear-vol — entrée §C (2026-08-14) — issue #10908
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M16_HAR_ASYMMETRIC.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M16_HAR_ASYMMETRIC.md
@@ -1,6 +1,6 @@
 # M16 HAR-RV Asymmetric Semivariance — Andersen-Bollerslev-Diebold-Patton (2007)
 
-**Status:** NO BEATS CLUSTER (Cycle 33, 2026-05-13) — BTC standalone BEATS robuste sur 3 horizons, **mais 1/7 coins seulement = sign-test cluster non-significatif**. Pas de PR M16 standalone — features RV+/RV- à intégrer en ensemble (M17 candidate).
+**Statut cluster historique : NO BEATS** (Cycle 33, 2026-05-13) — 1/7 coins seulement. **Re-test BTC débiaisé (2026-09-02) : 2/3 BEATS, 1/3 INCONCLUSIVE** ; le claim brut 3/3 ne survit pas intégralement.
 
 ## Verdict (G.2 metrics honnêtes — 7-coin full sweep)
 
@@ -124,6 +124,34 @@ Note : les autres coins (LTC/SOL/MATIC/XRP/ADA/DOT) attendent le résultat full 
 4. ☐ **M16-Kelly BTC-only** (optionnel) : utiliser M16 forecast pour un sleeve Kelly **BTC standalone** dans Portfolio Hybride sleeve crypto. Tester si MSE-BEATS BTC se traduit en Sharpe-BEATS net 50bps.
 5. ☐ **Documenter dans BOOK_MAPPING.md Ch05** (Model Choice) — HAR family confirmée comme only consistently winning family sur RV crypto (M2/M11/M12) vs DL (NO BEATS M5-M9-M10). M16 standalone = échec famille HAR (premier).
 6. ☐ **DOT h=5 close à significance (p=0.076)** : retest avec période étendue ou horizons intermédiaires (h=3, h=7) pour confirmer absence d'edge.
+
+## Re-test BTC symétriquement débiaisé (2026-09-02, Epic #1454)
+
+Le sweep historique comparait les MSE de deux prévisionneurs dont les biais OOS différaient. Comme `MSE = biais² + variance`, le re-test calibre désormais **HAR classique et HAR asymétrique selon le même protocole train-only** : queue de calibration de 60 observations, walk-forward expanding 5 folds, refit tous les 22 jours, horizons {1,5,10}, quatre seeds de contrôle {0,7,42,99}, puis DM avec `loss_fn="mse"` sur des séries OOS strictement alignées par date.
+
+| Horizon | MSE HAR débiaisé | MSE asym. débiaisé | edge | biais asym. | biais HAR | DM p médiane | Verdict |
+|---:|---:|---:|---:|---:|---:|---:|---|
+| h=1 | 0,843774 | 0,848154 | −0,52 % | −0,005109 | −0,003880 | 0,244862 | **INCONCLUSIVE** |
+| h=5 | 0,417886 | 0,403593 | +3,42 % | −0,003967 | −0,001552 | 0,011363 | **BEATS** |
+| h=10 | 0,389457 | 0,369614 | +5,10 % | −0,004194 | −0,002419 | 0,005123 | **BEATS** |
+
+Les biais résiduels sont proches de zéro (`biais² ≤ 2,6e-5`) : l'écart restant porte essentiellement sur la variance des erreurs. Le résultat brut était gonflé, surtout aux horizons longs (+23,6 %/+36,7 % → +3,4 %/+5,1 %), mais le signal ne disparaît pas. **Verdict BTC révisé : 2/3 BEATS, 1/3 INCONCLUSIVE, 0/3 NO BEATS.** M16 reste un keeper BTC moyen/long horizon ; h=1 est retiré du claim. Le verdict cluster historique reste `NO BEATS`.
+
+L'OLS est déterministe : les quatre seeds sont bit-identiques et servent de contrôle de reproductibilité. `edge/σ` cross-seed est donc non applicable, pas artificiellement infini. Le notebook `m3_har_asymmetric_semivariance.ipynb` recalcule les MSE depuis les prévisions persistées et porte 8/8 cellules code exécutées.
+
+```bash
+python scripts/har_asymmetric.py \
+  --coins BTC-USD \
+  --horizons 1 5 10 \
+  --seeds 0 7 42 99 \
+  --n-splits 5 \
+  --skip-remote \
+  --debias \
+  --calibration-size 60 \
+  --out-json scripts/results/m16_har_asymmetric_btc_debiased.json
+```
+
+Ce run évalue un **forecast pur**, pas une stratégie : coûts de transaction, Sharpe et drawdown restent hors du verdict. Aucun actif FAANG/Mag7 n'entre dans l'entraînement.
 
 ## References
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m3_har_asymmetric_semivariance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m3_har_asymmetric_semivariance.ipynb
@@ -5,34 +5,38 @@
    "id": "e060538e",
    "metadata": {
     "papermill": {
-     "duration": 0.004146,
-     "end_time": "2026-05-12T06:35:33.702356+00:00",
+     "duration": 0.002183,
+     "end_time": "2026-09-02T08:40:09.787659+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:33.698210+00:00",
+     "start_time": "2026-09-02T08:40:09.785476+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# M3b - HAR Asymetrique : Decomposition Semivariance et Effet de Levier\n",
+    "# M16 — HAR asymétrique débiaisé : le signal survit-il hors biais ?\n",
     "\n",
-    "Ce notebook presente les résultats du modèle HAR asymetrique (M3b) qui decompose\n",
-    "la variance realisee (RV) en semivariances positive (RV+) et negative (RV-).\n",
+    "Ce notebook réévalue le modèle HAR asymétrique fondé sur les semivariances positive (RV+) et négative (RV-) face à une baseline HAR classique **débiaisée selon le même protocole train-only**.\n",
     "\n",
-    "**Contexte** : Le modèle HAR classique (Corsi 2009) traite la volatilite de facon\n",
-    "symetrique. L'**effet de levier** (Black 1976) suggere que la volatilite a la\n",
-    "baisse porte plus d'information sur la volatilite future que la volatilite a la\n",
-    "hausse.\n",
+    "## Objectif\n",
     "\n",
-    "**Objectif** : Tester si la decomposition asymetrique RV-/RV+ ameliore\n",
-    "significativement les previsions HAR sur 7 cryptomonnaies.\n",
+    "Le résultat historique sur BTC annonçait trois horizons gagnants, mais comparait deux prévisionneurs dont les biais OOS différaient. Comme `MSE = biais² + variance`, une baseline biaisée peut gonfler artificiellement l'avantage apparent du modèle asymétrique.\n",
     "\n",
-    "**Modelisation** :\n",
-    "```\n",
-    "log RV_{t+h} = b0 + b1*log(RV-_t) + b2*log(RV+_t) + b3*mean(log RV_{t-5..t-1}) + b4*mean(log RV_{t-22..t-6}) + e\n",
-    "```\n",
+    "Nous testons donc une question plus stricte : après calibration sur la seule queue d'entraînement, l'asymétrie RV-/RV+ conserve-t-elle un avantage de précision sur BTC ?\n",
     "\n",
-    "Si b1 > b2 (coefficient downside > upside), l'effet de levier est confirme."
+    "## Protocole\n",
+    "\n",
+    "- walk-forward expanding, 5 folds ;\n",
+    "- horizons 1, 5 et 10 jours ;\n",
+    "- quatre seeds de contrôle (OLS déterministe : elles doivent être identiques) ;\n",
+    "- calibration du biais sur 60 observations train-only ;\n",
+    "- test Diebold-Mariano sur la perte MSE ;\n",
+    "- biais signé et variance des erreurs reportés séparément.\n",
+    "\n",
+    "```text\n",
+    "log RV_{t+h} = b0 + b1 log(RV-_t) + b2 log(RV+_t)\n",
+    "               + b3 moyenne_5j(log RV) + b4 moyenne_22j(log RV) + e\n",
+    "```"
    ]
   },
   {
@@ -41,16 +45,16 @@
    "id": "b86f2e9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T02:53:45.139491Z",
-     "iopub.status.busy": "2026-08-18T02:53:45.139491Z",
-     "iopub.status.idle": "2026-08-18T02:53:45.509237Z",
-     "shell.execute_reply": "2026-08-18T02:53:45.508704Z"
+     "iopub.execute_input": "2026-09-02T08:40:09.791988Z",
+     "iopub.status.busy": "2026-09-02T08:40:09.791754Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.148125Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.147612Z"
     },
     "papermill": {
-     "duration": 0.710208,
-     "end_time": "2026-05-12T06:35:34.416233+00:00",
+     "duration": 0.359095,
+     "end_time": "2026-09-02T08:40:10.148533+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:33.706025+00:00",
+     "start_time": "2026-09-02T08:40:09.789438+00:00",
      "status": "completed"
     },
     "tags": []
@@ -60,46 +64,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[INFO] Artefact manquant : scripts\\results\\m3_har_asymmetric_full.json\n",
-      "       Produit par : python scripts/har_asymmetric.py\n",
-      "       Runtime au run d'origine : ~512s (CPU, 7 coins x 3 horizons x 4 seeds, WF 5-fold).\n",
-      "       RECOVERABLE-MACHINE (lane training, env conda coursia-ml-training).\n",
-      "       Note de portee : issue #11574 (verdict ecrit).\n"
+      "Résultats chargés : 12 lignes, 1 actif, 3 horizons, 4 seeds.\n",
+      "Configuration : {'coins': ['BTC-USD'], 'horizons': [1, 5, 10], 'seeds': [0, 7, 42, 99], 'n_splits': 5, 'refit_every': 22, 'debias': True, 'calibration_size': 60}\n"
      ]
     }
    ],
    "source": [
     "import json\n",
+    "import subprocess\n",
+    "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "import pandas as pd\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "\n",
-    "# Charger les resultats complets (7 coins x 3 horizons x 4 seeds)\n",
-    "results_path = Path(\"scripts/results/m3_har_asymmetric_full.json\")\n",
+    "results_path = Path(\"scripts/results/m16_har_asymmetric_btc_debiased.json\")\n",
     "if not results_path.exists():\n",
-    "    # RECOVERABLE-MACHINE (cf. issues #11417/#11574) : artefact produit par\n",
-    "    # `python scripts/har_asymmetric.py` (gitignore, politique scripts/results/ de la serie, non commite\n",
-    "    # sur main ; il se regenere a chaque run). Precedent : PR #11420 (m15).\n",
-    "    # Sur un clone frais, ce notebook s'execute sans exception ici, mais les\n",
-    "    # cellules aval n'ont rien a traiter tant que l'artefact n'est pas produit.\n",
-    "    print('[INFO] Artefact manquant : ' + str(results_path))\n",
-    "    print('       Produit par : python scripts/har_asymmetric.py')\n",
-    "    print(\"       Runtime au run d'origine : ~512s (CPU, 7 coins x 3 horizons x 4 seeds, WF 5-fold).\")\n",
-    "    print('       RECOVERABLE-MACHINE (lane training, env conda coursia-ml-training).')\n",
-    "    print('       Note de portee : issue #11574 (verdict ecrit).')\n",
-    "    data = None\n",
-    "    df = None\n",
-    "else:\n",
-    "    with open(results_path) as f:\n",
-    "        data = json.load(f)\n",
+    "    command = [\n",
+    "        sys.executable,\n",
+    "        \"scripts/har_asymmetric.py\",\n",
+    "        \"--coins\", \"BTC-USD\",\n",
+    "        \"--horizons\", \"1\", \"5\", \"10\",\n",
+    "        \"--seeds\", \"0\", \"7\", \"42\", \"99\",\n",
+    "        \"--n-splits\", \"5\",\n",
+    "        \"--skip-remote\",\n",
+    "        \"--debias\",\n",
+    "        \"--calibration-size\", \"60\",\n",
+    "        \"--out-json\", str(results_path),\n",
+    "    ]\n",
+    "    subprocess.run(command, check=True)\n",
     "\n",
-    "    df = pd.DataFrame(data[\"rows\"])\n",
-    "    print(f\"Resultats charges : {len(df)} lignes ({df['coin'].nunique()} coins x {df['horizon'].nunique()} horizons x {df['seed'].nunique()} seeds)\")\n",
-    "    print(f\"Runtime total : {data['elapsed_s']:.1f}s\")\n",
-    "    print(f\"\\nCoins : {sorted(df['coin'].unique())}\")\n",
-    "    print(f\"Horizons : {sorted(df['horizon'].unique())}\")\n",
-    "    print(f\"Seeds : {sorted(df['seed'].unique())}\")\n"
+    "with results_path.open(encoding=\"utf-8\") as stream:\n",
+    "    data = json.load(stream)\n",
+    "\n",
+    "df = pd.DataFrame(data[\"rows\"])\n",
+    "aggregated = pd.DataFrame(data[\"aggregated\"])\n",
+    "print(\n",
+    "    f\"Résultats chargés : {len(df)} lignes, \"\n",
+    "    f\"{df['coin'].nunique()} actif, {df['horizon'].nunique()} horizons, \"\n",
+    "    f\"{df['seed'].nunique()} seeds.\"\n",
+    ")\n",
+    "print(f\"Configuration : {data['config']}\")"
    ]
   },
   {
@@ -107,19 +112,18 @@
    "id": "6ffce72c",
    "metadata": {
     "papermill": {
-     "duration": 0.004831,
-     "end_time": "2026-05-12T06:35:34.425491+00:00",
+     "duration": 0.001504,
+     "end_time": "2026-09-02T08:40:10.151762+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.420660+00:00",
+     "start_time": "2026-09-02T08:40:10.150258+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 1. Agregation des résultats par (coin, horizon)\n",
+    "## 1. Contrôle de stabilité des quatre seeds\n",
     "\n",
-    "Le modèle HAR utilise OLS (déterministe), donc les 4 seeds produisent des\n",
-    "résultats identiques. On agrege en prenant la première valeur par groupe."
+    "Les seeds ne créent pas quatre expériences indépendantes : l'estimation OLS est déterministe. Elles servent ici de contrôle de reproductibilité. Une différence entre seeds signalerait une source de non-déterminisme inattendue."
    ]
   },
   {
@@ -128,16 +132,16 @@
    "id": "62ca0983",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.437076Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.436562Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.455842Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.454447Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.155643Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.155384Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.166603Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.166049Z"
     },
     "papermill": {
-     "duration": 0.026882,
-     "end_time": "2026-05-12T06:35:34.457132+00:00",
+     "duration": 0.013844,
+     "end_time": "2026-09-02T08:40:10.167037+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.430250+00:00",
+     "start_time": "2026-09-02T08:40:10.153193+00:00",
      "status": "completed"
     },
     "tags": []
@@ -147,47 +151,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Resultats HAR Asymetrique vs HAR Classique (21 configs) ===\n",
+      "=== Stabilité exacte entre seeds ===\n",
+      "         asym_spread  classic_spread\n",
+      "horizon                             \n",
+      "1          0.000e+00       0.000e+00\n",
+      "5          0.000e+00       0.000e+00\n",
+      "10         0.000e+00       0.000e+00\n",
       "\n",
-      "   Coin  h  Classic MSE  Asym MSE  Reduction %  DM stat  DM p-value        Verdict\n",
-      "ADA-USD  1       0.6925    0.7033      -1.5643   0.7221      0.4705   INCONCLUSIVE\n",
-      "ADA-USD  5       0.4114    0.3803       7.5484  -1.1049      0.2697   INCONCLUSIVE\n",
-      "ADA-USD 10       0.3725    0.3450       7.3897  -0.8033      0.4222   INCONCLUSIVE\n",
-      "BTC-USD  1       0.8877    0.8425       5.0903  -4.0004      0.0001 BEATS baseline\n",
-      "BTC-USD  5       0.5220    0.3986      23.6401  -4.5458      0.0000 BEATS baseline\n",
-      "BTC-USD 10       0.5707    0.3610      36.7423  -4.8913      0.0000 BEATS baseline\n",
-      "DOT-USD  1       0.6383    0.6310       1.1534  -0.6592      0.5100   INCONCLUSIVE\n",
-      "DOT-USD  5       0.3802    0.3403      10.4951  -1.7637      0.0783   INCONCLUSIVE\n",
-      "DOT-USD 10       0.3587    0.3242       9.6180  -1.3106      0.1905   INCONCLUSIVE\n",
-      "ETH-USD  1       0.6844    0.6884      -0.5795   0.5143      0.6071   INCONCLUSIVE\n",
-      "ETH-USD  5       0.3736    0.3726       0.2854  -0.0605      0.9517   INCONCLUSIVE\n",
-      "ETH-USD 10       0.3745    0.3777      -0.8586   0.1066      0.9151   INCONCLUSIVE\n",
-      "LTC-USD  1       0.6564    0.6521       0.6509  -0.3337      0.7388   INCONCLUSIVE\n",
-      "LTC-USD  5       0.4304    0.4018       6.6465  -0.8107      0.4179   INCONCLUSIVE\n",
-      "LTC-USD 10       0.4225    0.3804       9.9601  -0.8481      0.3968   INCONCLUSIVE\n",
-      "SOL-USD  1       0.6132    0.6196      -1.0469   0.8144      0.4158   INCONCLUSIVE\n",
-      "SOL-USD  5       0.2835    0.2900      -2.2886   0.5786      0.5631   INCONCLUSIVE\n",
-      "SOL-USD 10       0.2378    0.2470      -3.8719   0.6042      0.5460   INCONCLUSIVE\n",
-      "XRP-USD  1       0.8501    0.8621      -1.4055   1.0627      0.2884   INCONCLUSIVE\n",
-      "XRP-USD  5       0.5227    0.4912       6.0380  -0.8713      0.3839   INCONCLUSIVE\n",
-      "XRP-USD 10       0.5246    0.4737       9.6989  -0.9094      0.3635   INCONCLUSIVE\n"
+      "Contrôle réussi : les quatre seeds OLS sont bit-identiques.\n"
      ]
     }
    ],
    "source": [
-    "# Agreger : OLS deterministe donc toutes les seeds identiques\n",
-    "agg = df.drop_duplicates(subset=[\"coin\", \"horizon\"], keep=\"first\").copy()\n",
-    "agg = agg.sort_values([\"coin\", \"horizon\"]).reset_index(drop=True)\n",
-    "\n",
-    "# Tableau recapitulatif\n",
-    "summary = agg[[\"coin\", \"horizon\", \"classic_mse_logrv\", \"asym_mse_logrv\",\n",
-    "               \"mse_reduction_pct\", \"dm_stat\", \"dm_pvalue\", \"dm_verdict\"]].copy()\n",
-    "summary.columns = [\"Coin\", \"h\", \"Classic MSE\", \"Asym MSE\", \"Reduction %\",\n",
-    "                    \"DM stat\", \"DM p-value\", \"Verdict\"]\n",
-    "\n",
-    "print(\"=== Resultats HAR Asymetrique vs HAR Classique (21 configs) ===\")\n",
-    "print()\n",
-    "print(summary.to_string(index=False, float_format=\"%.4f\"))"
+    "stability = (\n",
+    "    df.groupby(\"horizon\")\n",
+    "    .agg(\n",
+    "        asym_mse_min=(\"asym_mse_logrv\", \"min\"),\n",
+    "        asym_mse_max=(\"asym_mse_logrv\", \"max\"),\n",
+    "        classic_mse_min=(\"classic_mse_logrv\", \"min\"),\n",
+    "        classic_mse_max=(\"classic_mse_logrv\", \"max\"),\n",
+    "    )\n",
+    ")\n",
+    "stability[\"asym_spread\"] = stability[\"asym_mse_max\"] - stability[\"asym_mse_min\"]\n",
+    "stability[\"classic_spread\"] = stability[\"classic_mse_max\"] - stability[\"classic_mse_min\"]\n",
+    "print(\"=== Stabilité exacte entre seeds ===\")\n",
+    "print(stability[[\"asym_spread\", \"classic_spread\"]].to_string(float_format=\"%.3e\"))\n",
+    "assert (stability[[\"asym_spread\", \"classic_spread\"]].to_numpy() == 0.0).all()\n",
+    "print(\"\\nContrôle réussi : les quatre seeds OLS sont bit-identiques.\")"
    ]
   },
   {
@@ -195,20 +185,18 @@
    "id": "da571b3c",
    "metadata": {
     "papermill": {
-     "duration": 0.00451,
-     "end_time": "2026-05-12T06:35:34.465698+00:00",
+     "duration": 0.001478,
+     "end_time": "2026-09-02T08:40:10.170151+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.461188+00:00",
+     "start_time": "2026-09-02T08:40:10.168673+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 2. Verdicts Diebold-Mariano\n",
+    "## 2. Résultats débiaisés et test Diebold-Mariano\n",
     "\n",
-    "Le test DM compare les erreurs de prevision du modèle asymetrique contre le\n",
-    "modèle HAR classique. Un verdict **BEATS** signifie que l'asymetrique est\n",
-    "significativement meilleur (p < 0.05, HAC Newey-West)."
+    "Chaque modèle soustrait un biais estimé sur une queue de calibration appartenant exclusivement à l'entraînement. Le test DM compare ensuite les pertes quadratiques sur les mêmes dates OOS. Le verdict `BEATS` exige une amélioration positive et un DM significatif ; pour l'OLS déterministe, le ratio cross-seed en σ est non applicable plutôt qu'artificiellement infini."
    ]
   },
   {
@@ -217,16 +205,16 @@
    "id": "eaea6d17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.474549Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.474041Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.487782Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.486528Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.174264Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.174098Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.180051Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.179605Z"
     },
     "papermill": {
-     "duration": 0.02019,
-     "end_time": "2026-05-12T06:35:34.489268+00:00",
+     "duration": 0.008861,
+     "end_time": "2026-09-02T08:40:10.180584+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.469078+00:00",
+     "start_time": "2026-09-02T08:40:10.171723+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,34 +224,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Synthese des verdicts DM ===\n",
-      "  INCONCLUSIVE: 18/21\n",
-      "  BEATS baseline: 3/21\n",
+      "=== HAR asymétrique contre HAR classique, calibration symétrique ===\n",
+      " Horizon  MSE HAR débiaisé  MSE asymétrique débiaisé  Réduction MSE (%)  DM p médiane  Seeds stables      Verdict\n",
+      "       1          0.843774                  0.848154          -0.519177      0.244862           True INCONCLUSIVE\n",
+      "       5          0.417886                  0.403593           3.420461      0.011363           True        BEATS\n",
+      "      10          0.389457                  0.369614           5.095250      0.005123           True        BEATS\n",
       "\n",
-      "Configurations BEATS :\n",
-      "  BTC-USD h=1: MSE 0.8877 -> 0.8425 (+5.1%, p=0.0001)\n",
-      "  BTC-USD h=5: MSE 0.5220 -> 0.3986 (+23.6%, p=0.0000)\n",
-      "  BTC-USD h=10: MSE 0.5707 -> 0.3610 (+36.7%, p=0.0000)\n",
-      "\n",
-      "Configurations INCONCLUSIVE : 18/21\n"
+      "Synthèse : 2/3 BEATS, 1/3 INCONCLUSIVE.\n"
      ]
     }
    ],
    "source": [
-    "# Synthese des verdicts\n",
-    "verdict_counts = agg[\"dm_verdict\"].value_counts()\n",
-    "print(\"=== Synthese des verdicts DM ===\")\n",
-    "for v, count in verdict_counts.items():\n",
-    "    print(f\"  {v}: {count}/21\")\n",
-    "\n",
-    "print(\"\\nConfigurations BEATS :\")\n",
-    "beats = agg[agg[\"dm_verdict\"] == \"BEATS baseline\"]\n",
-    "for _, row in beats.iterrows():\n",
-    "    print(f\"  {row['coin']} h={row['horizon']}: MSE {row['classic_mse_logrv']:.4f} -> {row['asym_mse_logrv']:.4f} \"\n",
-    "          f\"({row['mse_reduction_pct']:+.1f}%, p={row['dm_pvalue']:.4f})\")\n",
-    "\n",
-    "n_inc = len(agg[agg['dm_verdict'] == 'INCONCLUSIVE'])\n",
-    "print(f\"\\nConfigurations INCONCLUSIVE : {n_inc}/21\")"
+    "table = aggregated[[\n",
+    "    \"horizon\",\n",
+    "    \"mean_classic_mse\",\n",
+    "    \"mean_asym_mse\",\n",
+    "    \"mean_reduction_pct\",\n",
+    "    \"median_dm_pvalue\",\n",
+    "    \"seed_stable\",\n",
+    "    \"verdict\",\n",
+    "]].copy()\n",
+    "table.columns = [\n",
+    "    \"Horizon\", \"MSE HAR débiaisé\", \"MSE asymétrique débiaisé\",\n",
+    "    \"Réduction MSE (%)\", \"DM p médiane\", \"Seeds stables\", \"Verdict\",\n",
+    "]\n",
+    "print(\"=== HAR asymétrique contre HAR classique, calibration symétrique ===\")\n",
+    "print(table.to_string(index=False, float_format=\"%.6f\"))\n",
+    "print(\n",
+    "    \"\\nSynthèse : \"\n",
+    "    f\"{int((table['Verdict'] == 'BEATS').sum())}/3 BEATS, \"\n",
+    "    f\"{int((table['Verdict'] == 'INCONCLUSIVE').sum())}/3 INCONCLUSIVE.\"\n",
+    ")"
    ]
   },
   {
@@ -271,18 +262,18 @@
    "id": "24f4f027",
    "metadata": {
     "papermill": {
-     "duration": 0.003571,
-     "end_time": "2026-05-12T06:35:34.496541+00:00",
+     "duration": 0.001552,
+     "end_time": "2026-09-02T08:40:10.183753+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.492970+00:00",
+     "start_time": "2026-09-02T08:40:10.182201+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 3. Reduction MSE par coin et horizon\n",
+    "## 3. Décomposition `MSE = biais² + variance`\n",
     "\n",
-    "Valeurs negatives = l'asymetrique bat le classique. Astérisque = significatif (BEATS)."
+    "Le débiaisage doit ramener le biais signé près de zéro sans éditer les erreurs OOS. Cette décomposition distingue un gain de niveau moyen d'un véritable gain de dispersion des erreurs."
    ]
   },
   {
@@ -291,16 +282,16 @@
    "id": "3f8508c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.506815Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.506297Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.527165Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.525723Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.188081Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.187827Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.194130Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.193552Z"
     },
     "papermill": {
-     "duration": 0.028251,
-     "end_time": "2026-05-12T06:35:34.528236+00:00",
+     "duration": 0.009238,
+     "end_time": "2026-09-02T08:40:10.194598+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.499985+00:00",
+     "start_time": "2026-09-02T08:40:10.185360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -310,45 +301,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Reduction MSE (%) : Asymetrique - Classique ===\n",
-      "(Negatif = asymetrique meilleur. * = BEATS significatif)\n",
+      "=== Biais signé et variance des erreurs OOS ===\n",
+      " horizon  asym_bias_oos  classic_bias_oos  asym_error_variance  classic_error_variance  asym_bias_squared  classic_bias_squared\n",
+      "       1      -0.005109         -0.003880             0.848128                0.843759           0.000026              0.000015\n",
+      "       5      -0.003967         -0.001552             0.403577                0.417884           0.000016              0.000002\n",
+      "      10      -0.004194         -0.002419             0.369596                0.389452           0.000018              0.000006\n",
       "\n",
-      "  ADA-USD         -1.6%      +7.5%      +7.4%\n",
-      "  BTC-USD       +5.1% *   +23.6% *   +36.7% *\n",
-      "  DOT-USD         +1.2%     +10.5%      +9.6%\n",
-      "  ETH-USD         -0.6%      +0.3%      -0.9%\n",
-      "  LTC-USD         +0.7%      +6.6%     +10.0%\n",
-      "  SOL-USD         -1.0%      -2.3%      -3.9%\n",
-      "  XRP-USD         -1.4%      +6.0%      +9.7%\n",
-      "\n",
-      "* = DM BEATS (p < 0.05)\n"
+      "Les biais résiduels sont petits ; l'écart restant porte surtout sur la variance.\n"
      ]
     }
    ],
    "source": [
-    "# Tableau croise coin x horizon\n",
-    "pivot = agg.pivot_table(index=\"coin\", columns=\"horizon\", values=\"mse_reduction_pct\")\n",
-    "pivot.columns = [f\"h={c}\" for c in pivot.columns]\n",
-    "\n",
-    "print(\"=== Reduction MSE (%) : Asymetrique - Classique ===\")\n",
-    "print(\"(Negatif = asymetrique meilleur. * = BEATS significatif)\")\n",
-    "print()\n",
-    "\n",
-    "# Construire le masque BEATS manuellement (pivot_table sur string echoue en pandas 2.x/3.13)\n",
-    "beats_lookup = {}\n",
-    "for _, row in agg.iterrows():\n",
-    "    beats_lookup[(row[\"coin\"], row[\"horizon\"])] = row[\"dm_verdict\"] == \"BEATS baseline\"\n",
-    "\n",
-    "for coin in pivot.index:\n",
-    "    vals = []\n",
-    "    for h_col in pivot.columns:\n",
-    "        v = pivot.loc[coin, h_col]\n",
-    "        h_val = int(h_col.split(\"=\")[1])\n",
-    "        marker = \" *\" if beats_lookup.get((coin, h_val), False) else \"\"\n",
-    "        vals.append(f\"{v:+.1f}%{marker}\")\n",
-    "    print(f\"  {coin:10s} {vals[0]:>10s} {vals[1]:>10s} {vals[2]:>10s}\")\n",
-    "\n",
-    "print(\"\\n* = DM BEATS (p < 0.05)\")"
+    "bias_variance = (\n",
+    "    df.drop_duplicates(subset=[\"horizon\"])\n",
+    "    [[\n",
+    "        \"horizon\", \"asym_bias_oos\", \"classic_bias_oos\",\n",
+    "        \"asym_error_variance\", \"classic_error_variance\",\n",
+    "    ]]\n",
+    "    .sort_values(\"horizon\")\n",
+    "    .copy()\n",
+    ")\n",
+    "bias_variance[\"asym_bias_squared\"] = bias_variance[\"asym_bias_oos\"] ** 2\n",
+    "bias_variance[\"classic_bias_squared\"] = bias_variance[\"classic_bias_oos\"] ** 2\n",
+    "print(\"=== Biais signé et variance des erreurs OOS ===\")\n",
+    "print(bias_variance.to_string(index=False, float_format=\"%.6f\"))\n",
+    "print(\"\\nLes biais résiduels sont petits ; l'écart restant porte surtout sur la variance.\")"
    ]
   },
   {
@@ -356,20 +333,18 @@
    "id": "45de2521",
    "metadata": {
     "papermill": {
-     "duration": 0.003391,
-     "end_time": "2026-05-12T06:35:34.535388+00:00",
+     "duration": 0.001486,
+     "end_time": "2026-09-02T08:40:10.197805+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.531997+00:00",
+     "start_time": "2026-09-02T08:40:10.196319+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. Analyse BTC : Effet de levier confirme\n",
+    "## 4. Ce qui change par rapport au résultat historique\n",
     "\n",
-    "BTC est la seule cryptomonnaie avec assez de données (2278 jours RV, ~10 ans)\n",
-    "pour detecter l'effet de levier. La decomposition semivariance capture des\n",
-    "reductions de MSE allant de 5% (h=1) a 37% (h=10)."
+    "Le verdict historique brut était `BEATS` sur les trois horizons BTC. Après calibration symétrique et sans fuite, l'horizon court ne montre plus d'avantage : l'asymétrie conserve un signal uniquement aux horizons 5 et 10 jours."
    ]
   },
   {
@@ -378,16 +353,16 @@
    "id": "28f2a6e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.544999Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.544657Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.555631Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.554222Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.201915Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.201759Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.207826Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.207288Z"
     },
     "papermill": {
-     "duration": 0.017776,
-     "end_time": "2026-05-12T06:35:34.556603+00:00",
+     "duration": 0.008773,
+     "end_time": "2026-09-02T08:40:10.208234+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.538827+00:00",
+     "start_time": "2026-09-02T08:40:10.199461+00:00",
      "status": "completed"
     },
     "tags": []
@@ -397,41 +372,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== BTC-USD : Decomposition Semivariance ===\n",
+      "=== Verdict BTC après débiaisage symétrique ===\n",
+      " Horizon  Réduction MSE (%)  DM p médiane      Verdict\n",
+      "       1          -0.519177      0.244862 INCONCLUSIVE\n",
+      "       5           3.420461      0.011363        BEATS\n",
+      "      10           5.095250      0.005123        BEATS\n",
       "\n",
-      "Donnees : 2278 jours RV, 1890 previsions\n",
-      "Source : Bitstamp hourly OHLCV\n",
-      "\n",
-      "h= 1 | Classique MSE: 0.8877 | Asymetrique MSE: 0.8425 | Reduction: +5.1% | DM stat: -4.000 | p: 0.0001 | BEATS baseline\n",
-      "h= 5 | Classique MSE: 0.5220 | Asymetrique MSE: 0.3986 | Reduction: +23.6% | DM stat: -4.546 | p: 0.0000 | BEATS baseline\n",
-      "h=10 | Classique MSE: 0.5707 | Asymetrique MSE: 0.3610 | Reduction: +36.7% | DM stat: -4.891 | p: 0.0000 | BEATS baseline\n",
-      "\n",
-      "Conclusion BTC : L'asymetrique bat le classique a TOUS les horizons (p < 0.001).\n",
-      "L'effet de levier est fortement confirme sur BTC.\n"
+      "Verdict mesuré : 2/3 BEATS (h=5, h=10), h=1 INCONCLUSIVE.\n"
      ]
     }
    ],
    "source": [
-    "# Focus BTC\n",
-    "btc = agg[agg[\"coin\"] == \"BTC-USD\"].sort_values(\"horizon\")\n",
+    "comparison = table[[\n",
+    "    \"Horizon\", \"Réduction MSE (%)\", \"DM p médiane\", \"Verdict\",\n",
+    "]].copy()\n",
+    "print(\"=== Verdict BTC après débiaisage symétrique ===\")\n",
+    "print(comparison.to_string(index=False, float_format=\"%.6f\"))\n",
     "\n",
-    "print(\"=== BTC-USD : Decomposition Semivariance ===\")\n",
-    "print()\n",
-    "print(f\"Donnees : {btc.iloc[0]['n_rv_days']} jours RV, {btc.iloc[0]['n_predictions']} previsions\")\n",
-    "print(f\"Source : Bitstamp hourly OHLCV\")\n",
-    "print()\n",
-    "\n",
-    "for _, row in btc.iterrows():\n",
-    "    h = row[\"horizon\"]\n",
-    "    print(f\"h={h:2d} | Classique MSE: {row['classic_mse_logrv']:.4f} | \"\n",
-    "          f\"Asymetrique MSE: {row['asym_mse_logrv']:.4f} | \"\n",
-    "          f\"Reduction: {row['mse_reduction_pct']:+.1f}% | \"\n",
-    "          f\"DM stat: {row['dm_stat']:.3f} | p: {row['dm_pvalue']:.4f} | \"\n",
-    "          f\"{row['dm_verdict']}\")\n",
-    "\n",
-    "print()\n",
-    "print(\"Conclusion BTC : L'asymetrique bat le classique a TOUS les horizons (p < 0.001).\")\n",
-    "print(\"L'effet de levier est fortement confirme sur BTC.\")"
+    "h1 = comparison.loc[comparison[\"Horizon\"] == 1].iloc[0]\n",
+    "assert h1[\"Verdict\"] == \"INCONCLUSIVE\"\n",
+    "assert float(h1[\"Réduction MSE (%)\"]) < 0.0\n",
+    "assert set(comparison.loc[comparison[\"Verdict\"] == \"BEATS\", \"Horizon\"]) == {5, 10}\n",
+    "print(\"\\nVerdict mesuré : 2/3 BEATS (h=5, h=10), h=1 INCONCLUSIVE.\")"
    ]
   },
   {
@@ -439,20 +401,18 @@
    "id": "d996a361",
    "metadata": {
     "papermill": {
-     "duration": 0.003361,
-     "end_time": "2026-05-12T06:35:34.563525+00:00",
+     "duration": 0.001607,
+     "end_time": "2026-09-02T08:40:10.211529+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.560164+00:00",
+     "start_time": "2026-09-02T08:40:10.209922+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Impact de la longueur des données\n",
+    "## 5. Audit des séries persistées\n",
     "\n",
-    "BTC dispose de 2278 jours de données RV (~10 ans), tandis que les coins\n",
-    "yfinance n'ont que ~725 jours (~2 ans). Cette différence explique pourquoi\n",
-    "seul BTC atteint la significativite statistique."
+    "Le script conserve les dates, les cibles et les deux prévisions sur un support strictement commun. Cela permet de recalculer le MSE et le biais indépendamment du résumé JSON, plutôt que de faire confiance à un verdict opaque."
    ]
   },
   {
@@ -461,16 +421,16 @@
    "id": "78d536f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.571821Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.571387Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.594538Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.593661Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.215510Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.215321Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.222196Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.221772Z"
     },
     "papermill": {
-     "duration": 0.029158,
-     "end_time": "2026-05-12T06:35:34.595922+00:00",
+     "duration": 0.009595,
+     "end_time": "2026-09-02T08:40:10.222699+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.566764+00:00",
+     "start_time": "2026-09-02T08:40:10.213104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -480,50 +440,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Impact de la longueur des donnees ===\n",
-      "\n",
-      "   Coin  RV jours  Reduction moy %  Reduction min %  Reduction max %  DM p-value min\n",
-      "ADA-USD       725             4.46            -1.56             7.55          0.2697\n",
-      "BTC-USD      2278            21.82             5.09            36.74          0.0000\n",
-      "DOT-USD       725             7.09             1.15            10.50          0.0783\n",
-      "ETH-USD      1495            -0.38            -0.86             0.29          0.6071\n",
-      "LTC-USD       725             5.75             0.65             9.96          0.3968\n",
-      "SOL-USD       725            -2.40            -3.87            -1.05          0.4158\n",
-      "XRP-USD       725             4.78            -1.41             9.70          0.2884\n",
-      "\n",
-      "Observation :\n",
-      "  BTC (2278 jours) : reduction moyenne +21.8%, TOUS significatifs\n",
-      "  yfinance (725 jours) : reductions numeriques mais non significatives\n",
-      "  DOT h=5 (p=0.0783) : proche de la significativite\n"
+      "=== Recalcul indépendant depuis les séries persistées ===\n",
+      " horizon    n  asym_mse_recalculé  classic_mse_recalculé  dates_uniques\n",
+      "       1 1890            0.848154               0.843774           True\n",
+      "       5 1870            0.403593               0.417886           True\n",
+      "      10 1845            0.369614               0.389457           True\n"
      ]
     }
    ],
    "source": [
-    "# Longueur des donnees par coin\n",
-    "coin_data = []\n",
-    "for coin in sorted(agg[\"coin\"].unique()):\n",
-    "    sub = agg[agg[\"coin\"] == coin]\n",
-    "    coin_data.append({\n",
-    "        \"Coin\": coin,\n",
-    "        \"RV jours\": int(sub[\"n_rv_days\"].iloc[0]),\n",
-    "        \"Reduction moy %\": round(float(sub[\"mse_reduction_pct\"].mean()), 2),\n",
-    "        \"Reduction min %\": round(float(sub[\"mse_reduction_pct\"].min()), 2),\n",
-    "        \"Reduction max %\": round(float(sub[\"mse_reduction_pct\"].max()), 2),\n",
-    "        \"DM p-value min\": round(float(sub[\"dm_pvalue\"].min()), 4),\n",
+    "checks = []\n",
+    "for _, row in df.drop_duplicates(subset=[\"horizon\"]).iterrows():\n",
+    "    pred_asym = np.asarray(row[\"pred_asym\"], dtype=float)\n",
+    "    pred_classic = np.asarray(row[\"pred_classic_har\"], dtype=float)\n",
+    "    target = np.asarray(row[\"pred_target\"], dtype=float)\n",
+    "    dates = row[\"pred_dates\"]\n",
+    "    assert len(dates) == len(pred_asym) == len(pred_classic) == len(target)\n",
+    "    asym_mse = float(np.mean((pred_asym - target) ** 2))\n",
+    "    classic_mse = float(np.mean((pred_classic - target) ** 2))\n",
+    "    assert np.isclose(asym_mse, row[\"asym_mse_logrv\"])\n",
+    "    assert np.isclose(classic_mse, row[\"classic_mse_logrv\"])\n",
+    "    checks.append({\n",
+    "        \"horizon\": int(row[\"horizon\"]),\n",
+    "        \"n\": len(target),\n",
+    "        \"asym_mse_recalculé\": asym_mse,\n",
+    "        \"classic_mse_recalculé\": classic_mse,\n",
+    "        \"dates_uniques\": len(set(dates)) == len(dates),\n",
     "    })\n",
-    "coin_info = pd.DataFrame(coin_data)\n",
-    "\n",
-    "print(\"=== Impact de la longueur des donnees ===\")\n",
-    "print()\n",
-    "print(coin_info.to_string(index=False))\n",
-    "\n",
-    "btc_row = coin_info[coin_info[\"Coin\"] == \"BTC-USD\"].iloc[0]\n",
-    "dot_pval = float(agg[(agg[\"coin\"] == \"DOT-USD\") & (agg[\"horizon\"] == 5)][\"dm_pvalue\"].values[0])\n",
-    "print()\n",
-    "print(\"Observation :\")\n",
-    "print(f\"  BTC ({int(btc_row['RV jours'])} jours) : reduction moyenne {btc_row['Reduction moy %']:+.1f}%, TOUS significatifs\")\n",
-    "print(f\"  yfinance (725 jours) : reductions numeriques mais non significatives\")\n",
-    "print(f\"  DOT h=5 (p={dot_pval:.4f}) : proche de la significativite\")"
+    "checks = pd.DataFrame(checks)\n",
+    "print(\"=== Recalcul indépendant depuis les séries persistées ===\")\n",
+    "print(checks.to_string(index=False, float_format=\"%.6f\"))"
    ]
   },
   {
@@ -531,20 +477,18 @@
    "id": "41cb2bc2",
    "metadata": {
     "papermill": {
-     "duration": 0.003285,
-     "end_time": "2026-05-12T06:35:34.602895+00:00",
+     "duration": 0.001615,
+     "end_time": "2026-09-02T08:40:10.226053+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.599610+00:00",
+     "start_time": "2026-09-02T08:40:10.224438+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Analyse par horizon\n",
+    "## 6. Lecture par horizon\n",
     "\n",
-    "L'avantage du modèle asymetrique augmente avec l'horizon de prevision,\n",
-    "coherent avec l'hypothese que la volatilite a la baisse est un signal plus\n",
-    "persistant."
+    "La calibration change fortement l'interprétation : le modèle asymétrique est légèrement moins précis à un jour, puis meilleur à cinq et dix jours. Le résultat soutient un signal de persistance à moyen terme, pas un avantage universel de la décomposition asymétrique."
    ]
   },
   {
@@ -553,16 +497,16 @@
    "id": "9a9eabf6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.611210Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.610855Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.625859Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.624516Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.230213Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.229994Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.235137Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.234687Z"
     },
     "papermill": {
-     "duration": 0.020645,
-     "end_time": "2026-05-12T06:35:34.626801+00:00",
+     "duration": 0.007918,
+     "end_time": "2026-09-02T08:40:10.235590+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.606156+00:00",
+     "start_time": "2026-09-02T08:40:10.227672+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,40 +516,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Performance par horizon de prevision ===\n",
-      "\n",
-      "Horizon  Reduction moy %  Std %  Min %  Max %  Nb BEATS\n",
-      "    h=1             0.33   2.34  -1.56   5.09         1\n",
-      "    h=5             7.48   8.37  -2.29  23.64         1\n",
-      "   h=10             9.81  13.12  -3.87  36.74         1\n",
-      "\n",
-      "Tendance : l'avantage asymetrique croit avec l'horizon.\n",
-      "La volatilite downside est un signal plus persistant pour les previsions longues.\n"
+      "=== Lecture par horizon ===\n",
+      " Horizon  Réduction MSE (%)  DM p médiane      Verdict                         Lecture\n",
+      "       1          -0.519177      0.244862 INCONCLUSIVE aucun avantage après débiaisage\n",
+      "       5           3.420461      0.011363        BEATS    gain modeste et significatif\n",
+      "      10           5.095250      0.005123        BEATS gain persistant et significatif\n"
      ]
     }
    ],
    "source": [
-    "# Reduction moyenne par horizon\n",
-    "horizon_data = []\n",
-    "for h in sorted(agg[\"horizon\"].unique()):\n",
-    "    sub = agg[agg[\"horizon\"] == h]\n",
-    "    horizon_data.append({\n",
-    "        \"Horizon\": f\"h={h}\",\n",
-    "        \"Reduction moy %\": round(float(sub[\"mse_reduction_pct\"].mean()), 2),\n",
-    "        \"Std %\": round(float(sub[\"mse_reduction_pct\"].std()), 2),\n",
-    "        \"Min %\": round(float(sub[\"mse_reduction_pct\"].min()), 2),\n",
-    "        \"Max %\": round(float(sub[\"mse_reduction_pct\"].max()), 2),\n",
-    "        \"Nb BEATS\": int((sub[\"dm_verdict\"] == \"BEATS baseline\").sum()),\n",
-    "    })\n",
-    "horizon_stats = pd.DataFrame(horizon_data)\n",
-    "\n",
-    "print(\"=== Performance par horizon de prevision ===\")\n",
-    "print()\n",
-    "print(horizon_stats.to_string(index=False))\n",
-    "\n",
-    "print()\n",
-    "print(\"Tendance : l'avantage asymetrique croit avec l'horizon.\")\n",
-    "print(\"La volatilite downside est un signal plus persistant pour les previsions longues.\")"
+    "horizon_reading = table[[\n",
+    "    \"Horizon\", \"Réduction MSE (%)\", \"DM p médiane\", \"Verdict\",\n",
+    "]].copy()\n",
+    "horizon_reading[\"Lecture\"] = horizon_reading[\"Horizon\"].map({\n",
+    "    1: \"aucun avantage après débiaisage\",\n",
+    "    5: \"gain modeste et significatif\",\n",
+    "    10: \"gain persistant et significatif\",\n",
+    "})\n",
+    "print(\"=== Lecture par horizon ===\")\n",
+    "print(horizon_reading.to_string(index=False, float_format=\"%.6f\"))"
    ]
   },
   {
@@ -613,35 +542,27 @@
    "id": "b68e5083",
    "metadata": {
     "papermill": {
-     "duration": 0.003423,
-     "end_time": "2026-05-12T06:35:34.633813+00:00",
+     "duration": 0.001602,
+     "end_time": "2026-09-02T08:40:10.238964+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.630390+00:00",
+     "start_time": "2026-09-02T08:40:10.237362+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## Conclusion et recommandations\n",
+    "## Conclusion\n",
     "\n",
-    "**Résultats cles** :\n",
-    "1. **3/21 BEATS** (BTC a tous les horizons), **18/21 INCONCLUSIVE**, **0/21 NO BEATS**\n",
-    "2. L'effet de levier est **confirme sur BTC** (5-37% reduction MSE, p<0.001)\n",
-    "3. Les autres coins montrent des ameliorations numériques aux horizons longs\n",
-    "   mais pas assez de données pour la significativite statistique\n",
-    "4. L'avantage asymetrique **croit avec l'horizon** (coherent avec la persistance\n",
-    "   de la volatilite downside)\n",
+    "Le re-test symétriquement débiaisé **réfute le verdict brut 3/3** :\n",
     "\n",
-    "**Recommandations** :\n",
-    "- Pour le trading BTC : utiliser le modèle HAR asymetrique (gain substantiel)\n",
-    "- Pour les autres coins : rester sur le HAR classique (pas de gain prouve)\n",
-    "- Les futures données plus longues pourraient confirmer l'effet sur LTC, DOT, XRP\n",
-    "- Les seeds OLS sont redondants (déterministe) : preferer des intervalles bootstrap\n",
+    "- h=1 devient `INCONCLUSIVE` et l'avantage numérique s'inverse légèrement ;\n",
+    "- h=5 et h=10 restent `BEATS` sous DM-MSE ;\n",
+    "- les quatre seeds sont bit-identiques, comme attendu pour OLS ;\n",
+    "- les biais OOS résiduels sont proches de zéro, donc le résultat restant porte surtout sur la variance des erreurs.\n",
     "\n",
-    "**References** :\n",
-    "- Black (1976), *Studies of Stock Price Volatility Changes*\n",
-    "- Corsi (2009), *A Simple Approximate Long-Memory Model of Realized Volatility*\n",
-    "- Patton & Sheppard (2009), *Good Volatility, Bad Volatility: Signed Jumps*"
+    "**Verdict M16 BTC : 2/3 BEATS, 1/3 INCONCLUSIVE, 0/3 NO BEATS.**\n",
+    "\n",
+    "La décomposition RV-/RV+ reste utile pour les horizons moyens et longs, mais ne doit plus être présentée comme supérieure à tous les horizons. Ce notebook évalue une prévision de volatilité, pas une stratégie : coûts de transaction, Sharpe et drawdown sont donc hors de ce verdict et devront être mesurés avant tout claim de performance de trading."
    ]
   },
   {
@@ -650,16 +571,16 @@
    "id": "8163d950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T06:35:34.642815Z",
-     "iopub.status.busy": "2026-05-12T06:35:34.642524Z",
-     "iopub.status.idle": "2026-05-12T06:35:34.655405Z",
-     "shell.execute_reply": "2026-05-12T06:35:34.654246Z"
+     "iopub.execute_input": "2026-09-02T08:40:10.242997Z",
+     "iopub.status.busy": "2026-09-02T08:40:10.242832Z",
+     "iopub.status.idle": "2026-09-02T08:40:10.248034Z",
+     "shell.execute_reply": "2026-09-02T08:40:10.247565Z"
     },
     "papermill": {
-     "duration": 0.019038,
-     "end_time": "2026-05-12T06:35:34.656329+00:00",
+     "duration": 0.008043,
+     "end_time": "2026-09-02T08:40:10.248589+00:00",
      "exception": false,
-     "start_time": "2026-05-12T06:35:34.637291+00:00",
+     "start_time": "2026-09-02T08:40:10.240546+00:00",
      "status": "completed"
     },
     "tags": []
@@ -669,59 +590,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Tableau final : HAR Asymetrique vs Classique ==="
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "=== Synthèse finale M16 BTC débiaisé ===\n",
+      " Horizon  MSE HAR débiaisé  MSE asymétrique débiaisé  Réduction MSE (%)  DM p médiane  Seeds stables      Verdict  Biais² asym.  Biais² HAR\n",
+      "       1          0.843774                  0.848154          -0.519177      0.244862           True INCONCLUSIVE      0.000026    0.000015\n",
+      "       5          0.417886                  0.403593           3.420461      0.011363           True        BEATS      0.000016    0.000002\n",
+      "      10          0.389457                  0.369614           5.095250      0.005123           True        BEATS      0.000018    0.000006\n",
       "\n",
-      "   coin horizon  asym_mse_logrv  classic_mse_logrv  mse_reduction_pct     dm_verdict\n",
-      "ADA-USD     h=1          0.7033             0.6925            -1.5643   INCONCLUSIVE\n",
-      "ADA-USD     h=5          0.3803             0.4114             7.5484   INCONCLUSIVE\n",
-      "ADA-USD    h=10          0.3450             0.3725             7.3897   INCONCLUSIVE\n",
-      "BTC-USD     h=1          0.8425             0.8877             5.0903 BEATS baseline\n",
-      "BTC-USD     h=5          0.3986             0.5220            23.6401 BEATS baseline\n",
-      "BTC-USD    h=10          0.3610             0.5707            36.7423 BEATS baseline\n",
-      "DOT-USD     h=1          0.6310             0.6383             1.1534   INCONCLUSIVE\n",
-      "DOT-USD     h=5          0.3403             0.3802            10.4951   INCONCLUSIVE\n",
-      "DOT-USD    h=10          0.3242             0.3587             9.6180   INCONCLUSIVE\n",
-      "ETH-USD     h=1          0.6884             0.6844            -0.5795   INCONCLUSIVE\n",
-      "ETH-USD     h=5          0.3726             0.3736             0.2854   INCONCLUSIVE\n",
-      "ETH-USD    h=10          0.3777             0.3745            -0.8586   INCONCLUSIVE\n",
-      "LTC-USD     h=1          0.6521             0.6564             0.6509   INCONCLUSIVE\n",
-      "LTC-USD     h=5          0.4018             0.4304             6.6465   INCONCLUSIVE\n",
-      "LTC-USD    h=10          0.3804             0.4225             9.9601   INCONCLUSIVE\n",
-      "SOL-USD     h=1          0.6196             0.6132            -1.0469   INCONCLUSIVE\n",
-      "SOL-USD     h=5          0.2900             0.2835            -2.2886   INCONCLUSIVE\n",
-      "SOL-USD    h=10          0.2470             0.2378            -3.8719   INCONCLUSIVE\n",
-      "XRP-USD     h=1          0.8621             0.8501            -1.4055   INCONCLUSIVE\n",
-      "XRP-USD     h=5          0.4912             0.5227             6.0380   INCONCLUSIVE\n",
-      "XRP-USD    h=10          0.4737             0.5246             9.6989   INCONCLUSIVE\n",
-      "\n",
-      "Total : 21 configurations | BEATS: 3 | INCONCLUSIVE: 18\n"
+      "Verdict final : 2/3 BEATS, 1/3 INCONCLUSIVE, 0/3 NO BEATS.\n"
      ]
     }
    ],
    "source": [
-    "# Resume final sous forme de tableau\n",
-    "final_summary = agg[[\"coin\", \"horizon\", \"asym_mse_logrv\", \"classic_mse_logrv\",\n",
-    "                      \"mse_reduction_pct\", \"dm_verdict\"]].copy()\n",
-    "final_summary[\"horizon\"] = final_summary[\"horizon\"].map({1: \"h=1\", 5: \"h=5\", 10: \"h=10\"})\n",
-    "\n",
-    "print(\"=== Tableau final : HAR Asymetrique vs Classique ===\")\n",
-    "print(final_summary.to_string(index=False, float_format=\"%.4f\"))\n",
-    "n_beats = int((agg['dm_verdict'] == 'BEATS baseline').sum())\n",
-    "n_inc = int((agg['dm_verdict'] == 'INCONCLUSIVE').sum())\n",
-    "print(f\"\\nTotal : {len(agg)} configurations | BEATS: {n_beats} | INCONCLUSIVE: {n_inc}\")"
+    "final_summary = table.copy()\n",
+    "final_summary[\"Biais² asym.\"] = bias_variance[\"asym_bias_squared\"].to_numpy()\n",
+    "final_summary[\"Biais² HAR\"] = bias_variance[\"classic_bias_squared\"].to_numpy()\n",
+    "print(\"=== Synthèse finale M16 BTC débiaisé ===\")\n",
+    "print(final_summary.to_string(index=False, float_format=\"%.6f\"))\n",
+    "print(\"\\nVerdict final : 2/3 BEATS, 1/3 INCONCLUSIVE, 0/3 NO BEATS.\")"
    ]
   }
  ],
  "metadata": {
   "cost": {
    "api_provider": "none",
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "cpu_min": 3,
    "external_account": "none",
    "free_alternative": "self",
@@ -752,7 +644,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2.415002,
+   "end_time": "2026-09-02T08:40:10.486916+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "m3_har_asymmetric_semivariance.ipynb",
+   "output_path": "m3_har_asymmetric_semivariance.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T08:40:08.071914+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/har_asymmetric.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/har_asymmetric.py
@@ -16,7 +16,8 @@ Walk-forward 5-fold x 4 seeds x 3 horizons x 7 coins.
 Diebold-Mariano vs HAR classic (PR #938 baseline).
 
 Usage:
-    python har_asymmetric.py --horizons 1 5 10 --seeds 0 7 42 99 --skip-remote
+    python har_asymmetric.py --coins BTC-USD --horizons 1 5 10 \
+        --seeds 0 7 42 99 --skip-remote --debias --calibration-size 60
     python har_asymmetric.py --horizons 1 5 10 --seeds 0 7 42 99
 """
 
@@ -194,6 +195,41 @@ def _make_split_indices(n: int, n_splits: int) -> list[tuple[int, int, int]]:
     return splits
 
 
+def _fit_asymmetric_with_train_calibration(
+    rv_neg_train: pd.Series,
+    rv_pos_train: pd.Series,
+    rv_train: pd.Series,
+    horizon: int,
+    calibration_size: int,
+) -> tuple[AsymmetricHARModel, float]:
+    """Fit before a train-tail holdout and estimate a signed forecast offset."""
+    calibration_size = min(calibration_size, max(0, len(rv_train) - 60))
+    if calibration_size < max(10, horizon + 1):
+        model = AsymmetricHARModel().fit(rv_neg_train, rv_pos_train, rv_train)
+        return model, 0.0
+
+    fit_end = len(rv_train) - calibration_size
+    model = AsymmetricHARModel().fit(
+        rv_neg_train.iloc[:fit_end],
+        rv_pos_train.iloc[:fit_end],
+        rv_train.iloc[:fit_end],
+    )
+    log_rv = np.log(rv_train.clip(lower=1e-12))
+    errors: list[float] = []
+    for i in range(fit_end, len(rv_train) - horizon):
+        prediction = model.predict_h_step(
+            rv_neg_train.iloc[:i],
+            rv_pos_train.iloc[:i],
+            rv_train.iloc[:i],
+            horizon=horizon,
+        )
+        target = float(log_rv.iloc[i:i + horizon].mean())
+        errors.append(prediction - target)
+
+    bias = float(np.mean(errors)) if errors else 0.0
+    return model, bias
+
+
 def walk_forward_asymmetric_har(
     rv_neg: pd.Series,
     rv_pos: pd.Series,
@@ -202,13 +238,14 @@ def walk_forward_asymmetric_har(
     n_splits: int = 5,
     refit_every: int = 22,
     seed: int = 0,
+    calibrate_bias: bool = False,
+    calibration_size: int = 60,
 ) -> dict:
     """Walk-forward evaluation of asymmetric HAR.
 
     Returns MSE on log-RV scale, forecasts and targets for DM testing.
     """
-    rng = np.random.RandomState(seed)
-
+    # OLS is deterministic; seed is retained to verify exact cross-seed stability.
     rv = rv.dropna().astype(float)
     rv_neg = rv_neg.reindex(rv.index).fillna(0.0).astype(float)
     rv_pos = rv_pos.reindex(rv.index).fillna(0.0).astype(float)
@@ -223,6 +260,7 @@ def walk_forward_asymmetric_har(
     preds: list[float] = []
     truths: list[float] = []
     pred_dates: list[pd.Timestamp] = []
+    initial_calibration_bias_by_fold: list[float] = []
 
     for fold_idx, (train_end, test_start, test_end) in enumerate(splits):
         rv_train = rv.iloc[:train_end]
@@ -231,7 +269,18 @@ def walk_forward_asymmetric_har(
         if len(rv_train) < 60:
             continue
 
-        model = AsymmetricHARModel().fit(rv_neg_train, rv_pos_train, rv_train)
+        if calibrate_bias:
+            model, bias = _fit_asymmetric_with_train_calibration(
+                rv_neg_train,
+                rv_pos_train,
+                rv_train,
+                horizon=horizon,
+                calibration_size=calibration_size,
+            )
+        else:
+            model = AsymmetricHARModel().fit(rv_neg_train, rv_pos_train, rv_train)
+            bias = 0.0
+        initial_calibration_bias_by_fold.append(bias)
 
         for i in range(test_start, test_end - horizon):
             target_window = log_rv.iloc[i:i + horizon].mean()
@@ -240,16 +289,29 @@ def walk_forward_asymmetric_har(
             tail_pos = rv_pos.iloc[:i]
             tail_rv = rv.iloc[:i]
 
-            log_pred = model.predict_h_step(tail_neg, tail_pos, tail_rv, horizon=horizon)
+            log_pred = (
+                model.predict_h_step(tail_neg, tail_pos, tail_rv, horizon=horizon)
+                - bias
+            )
 
             preds.append(log_pred)
             truths.append(float(target_window))
             pred_dates.append(rv.index[i])
 
             if (i - test_start) % refit_every == 0 and i > test_start:
-                model = AsymmetricHARModel().fit(
-                    rv_neg.iloc[:i], rv_pos.iloc[:i], rv.iloc[:i],
-                )
+                if calibrate_bias:
+                    model, bias = _fit_asymmetric_with_train_calibration(
+                        rv_neg.iloc[:i],
+                        rv_pos.iloc[:i],
+                        rv.iloc[:i],
+                        horizon=horizon,
+                        calibration_size=calibration_size,
+                    )
+                else:
+                    model = AsymmetricHARModel().fit(
+                        rv_neg.iloc[:i], rv_pos.iloc[:i], rv.iloc[:i],
+                    )
+                    bias = 0.0
 
     preds_arr = np.asarray(preds)
     truths_arr = np.asarray(truths)
@@ -264,6 +326,9 @@ def walk_forward_asymmetric_har(
         "n_splits": n_splits,
         "n_total_preds": len(preds_arr),
         "aggregate_mse_logrv": aggregate_mse,
+        "calibrate_bias": calibrate_bias,
+        "calibration_size": calibration_size,
+        "initial_calibration_bias_by_fold": initial_calibration_bias_by_fold,
         "forecasts": forecasts,
         "targets": targets,
     }
@@ -302,6 +367,8 @@ def _eval_one_coin(
     seeds: list[int],
     n_splits: int = 5,
     refit_every: int = 22,
+    debias: bool = False,
+    calibration_size: int = 60,
 ) -> list[dict]:
     """Run asymmetric HAR + classic HAR for one coin, all horizons/seeds."""
     rv = daily_realized_variance(hourly_rets)
@@ -324,7 +391,14 @@ def _eval_one_coin(
     for h in horizons:
         # Classic HAR baseline (seed 0 only for baseline reference)
         try:
-            classic_out = walk_forward_har(rv, horizon=h, n_splits=n_splits, refit_every=refit_every)
+            classic_out = walk_forward_har(
+                rv,
+                horizon=h,
+                n_splits=n_splits,
+                refit_every=refit_every,
+                calibrate_bias=debias,
+                calibration_size=calibration_size,
+            )
             classic_mse = classic_out["aggregate_mse_logrv"]
             classic_forecasts = classic_out["forecasts"]
             classic_targets = classic_out["targets"]
@@ -337,16 +411,52 @@ def _eval_one_coin(
             classic_forecasts = None
             classic_targets = None
 
+        if classic_forecasts is None or classic_targets is None:
+            rows.extend({
+                "coin": coin,
+                "horizon": h,
+                "seed": seed,
+                "asym_mse_logrv": float("nan"),
+                "classic_mse_logrv": classic_mse,
+                "dm_verdict": "BASELINE_FAILED",
+            } for seed in seeds)
+            continue
+
         for seed in seeds:
             try:
                 asym_out = walk_forward_asymmetric_har(
-                    rv_neg, rv_pos, rv,
-                    horizon=h, n_splits=n_splits, refit_every=refit_every, seed=seed,
+                    rv_neg,
+                    rv_pos,
+                    rv,
+                    horizon=h,
+                    n_splits=n_splits,
+                    refit_every=refit_every,
+                    seed=seed,
+                    calibrate_bias=debias,
+                    calibration_size=calibration_size,
                 )
-                asym_mse = asym_out["aggregate_mse_logrv"]
                 asym_forecasts = asym_out["forecasts"]
                 asym_targets = asym_out["targets"]
-                asym_errors = (asym_forecasts - asym_targets).dropna().values
+                common_dates = asym_forecasts.index.intersection(asym_targets.index)
+                if classic_forecasts is not None and classic_targets is not None:
+                    common_dates = common_dates.intersection(classic_forecasts.index)
+                    common_dates = common_dates.intersection(classic_targets.index)
+                pred_asym = asym_forecasts.reindex(common_dates).to_numpy(dtype=float)
+                pred_classic = classic_forecasts.reindex(common_dates).to_numpy(dtype=float)
+                pred_target = asym_targets.reindex(common_dates).to_numpy(dtype=float)
+                finite = (
+                    np.isfinite(pred_asym)
+                    & np.isfinite(pred_classic)
+                    & np.isfinite(pred_target)
+                )
+                common_dates = common_dates[finite]
+                pred_asym = pred_asym[finite]
+                pred_classic = pred_classic[finite]
+                pred_target = pred_target[finite]
+                asym_errors = pred_asym - pred_target
+                classic_errors_aligned = pred_classic - pred_target
+                asym_mse = float(np.mean(asym_errors ** 2))
+                classic_mse_aligned = float(np.mean(classic_errors_aligned ** 2))
             except Exception as exc:
                 print(f"  h={h} seed={seed} asym HAR FAILED: {exc}")
                 rows.append({
@@ -358,10 +468,14 @@ def _eval_one_coin(
 
             # DM test: asymmetric vs classic
             dm_info = {}
-            if classic_errors is not None and len(asym_errors) >= 10 and len(classic_errors) >= 10:
-                min_len = min(len(asym_errors), len(classic_errors))
+            if classic_errors is not None and len(asym_errors) >= 10:
                 try:
-                    dm = dm_verdict(asym_errors[:min_len], classic_errors[:min_len], horizon=h)
+                    dm = dm_verdict(
+                        asym_errors,
+                        classic_errors_aligned,
+                        horizon=h,
+                        loss_fn="mse",
+                    )
                     dm_info = {
                         "dm_stat": dm["dm_statistic"],
                         "dm_pvalue": dm["p_value"],
@@ -382,10 +496,23 @@ def _eval_one_coin(
                 "horizon": h,
                 "seed": seed,
                 "n_rv_days": int(len(rv)),
-                "n_predictions": int(asym_out["n_total_preds"]),
+                "n_predictions": int(len(pred_target)),
+                "debias": debias,
+                "calibration_size": calibration_size,
                 "asym_mse_logrv": float(asym_mse),
-                "classic_mse_logrv": float(classic_mse),
-                "mse_reduction_pct": float((classic_mse - asym_mse) / classic_mse * 100) if classic_mse > 0 else float("nan"),
+                "classic_mse_logrv": float(classic_mse_aligned),
+                "mse_reduction_pct": (
+                    float((classic_mse_aligned - asym_mse) / classic_mse_aligned * 100)
+                    if classic_mse_aligned > 0 else float("nan")
+                ),
+                "asym_bias_oos": float(np.mean(asym_errors)),
+                "classic_bias_oos": float(np.mean(classic_errors_aligned)),
+                "asym_error_variance": float(np.var(asym_errors)),
+                "classic_error_variance": float(np.var(classic_errors_aligned)),
+                "pred_dates": [date.strftime("%Y-%m-%d") for date in common_dates],
+                "pred_asym": pred_asym.tolist(),
+                "pred_classic_har": pred_classic.tolist(),
+                "pred_target": pred_target.tolist(),
                 **dm_info,
             })
 
@@ -421,6 +548,16 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
         mean_asym = float(np.nanmean(asym_mses))
         mean_classic = float(np.nanmean(classic_mses))
         std_asym = float(np.nanstd(asym_mses))
+        mse_edges = np.asarray(classic_mses) - np.asarray(asym_mses)
+        mean_edge = float(np.nanmean(mse_edges))
+        std_edge = float(np.nanstd(mse_edges))
+        median_pvalue = float(np.nanmedian(p_values))
+        seed_stable = bool(
+            np.allclose(asym_mses, asym_mses[0], rtol=0.0, atol=1e-12)
+        )
+        edge_sigma = None if seed_stable else (
+            mean_edge / std_edge if std_edge > 0.0 else 0.0
+        )
 
         mean_reduction = (mean_classic - mean_asym) / mean_classic * 100 if mean_classic > 0 else 0.0
 
@@ -430,10 +567,12 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
 
         if n_beaten > 0:
             agg_verdict = "NO BEATS"
-        elif n_beats == n_seeds and std_asym < abs(mean_classic - mean_asym):
+        elif (
+            n_beats == n_seeds
+            and median_pvalue < 0.05
+            and (seed_stable or edge_sigma >= 2.0)
+        ):
             agg_verdict = "BEATS"
-        elif n_beats > 0:
-            agg_verdict = "INCONCLUSIVE"
         else:
             agg_verdict = "INCONCLUSIVE"
 
@@ -445,6 +584,11 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
             "std_asym_mse": std_asym,
             "mean_classic_mse": mean_classic,
             "mean_reduction_pct": mean_reduction,
+            "mean_mse_edge": mean_edge,
+            "std_mse_edge": std_edge,
+            "edge_sigma": edge_sigma,
+            "median_dm_pvalue": median_pvalue,
+            "seed_stable": seed_stable,
             "n_beats": n_beats,
             "n_beaten": n_beaten,
             "n_inconclusive": n_inconclusive,
@@ -463,11 +607,20 @@ def main() -> None:
     parser.add_argument("--refit-every", type=int, default=22)
     parser.add_argument("--skip-remote", action="store_true")
     parser.add_argument("--extra-coins", type=str, nargs="*", default=None)
+    parser.add_argument("--coins", type=str, nargs="*", default=None)
+    parser.add_argument("--debias", action="store_true")
+    parser.add_argument("--calibration-size", type=int, default=60)
     parser.add_argument("--out-json", type=str, default="results/m3_har_asymmetric.json")
     args = parser.parse_args()
 
     t0 = time.time()
     panel = _load_panel(args.skip_remote, extra_coins=args.extra_coins)
+    if args.coins:
+        requested = set(args.coins)
+        missing = sorted(requested.difference(panel))
+        if missing:
+            raise ValueError(f"requested coins unavailable: {missing}")
+        panel = {coin: returns for coin, returns in panel.items() if coin in requested}
 
     all_rows: list[dict] = []
     for coin, rets in panel.items():
@@ -478,6 +631,8 @@ def main() -> None:
             seeds=args.seeds,
             n_splits=args.n_splits,
             refit_every=args.refit_every,
+            debias=args.debias,
+            calibration_size=args.calibration_size,
         )
         all_rows.extend(rows)
 
@@ -501,10 +656,13 @@ def main() -> None:
         "aggregated": agg,
         "elapsed_s": time.time() - t0,
         "config": {
+            "coins": list(panel),
             "horizons": args.horizons,
             "seeds": args.seeds,
             "n_splits": args.n_splits,
             "refit_every": args.refit_every,
+            "debias": args.debias,
+            "calibration_size": args.calibration_size,
         },
     }, indent=2))
     print(f"\n[done] {time.time() - t0:.1f}s -- wrote {out_path}")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_har_asymmetric.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_har_asymmetric.py
@@ -1,0 +1,167 @@
+"""Tests for asymmetric HAR walk-forward evaluation and M16 verdicts."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import har_asymmetric
+from har_asymmetric import (
+    AsymmetricHARModel,
+    _eval_one_coin,
+    _fit_asymmetric_with_train_calibration,
+    aggregate_verdicts,
+    walk_forward_asymmetric_har,
+)
+
+
+@pytest.fixture
+def asymmetric_rv() -> tuple[pd.Series, pd.Series, pd.Series]:
+    rng = np.random.default_rng(17)
+    index = pd.date_range("2020-01-01", periods=360, freq="D")
+    log_rv = np.empty(len(index))
+    log_rv[0] = -7.5
+    for i in range(1, len(index)):
+        log_rv[i] = -1.2 + 0.84 * log_rv[i - 1] + rng.normal(0.0, 0.12)
+    rv = pd.Series(np.exp(log_rv), index=index, name="RV")
+    downside_share = np.clip(0.55 + rng.normal(0.0, 0.05, len(index)), 0.2, 0.8)
+    rv_neg = pd.Series(rv.to_numpy() * downside_share, index=index, name="RV_neg")
+    rv_pos = pd.Series(rv.to_numpy() * (1.0 - downside_share), index=index, name="RV_pos")
+    return rv_neg, rv_pos, rv
+
+
+def test_walk_forward_predictions_align_and_are_finite(asymmetric_rv):
+    rv_neg, rv_pos, rv = asymmetric_rv
+    out = walk_forward_asymmetric_har(
+        rv_neg,
+        rv_pos,
+        rv,
+        horizon=1,
+        n_splits=4,
+        refit_every=22,
+        calibrate_bias=True,
+        calibration_size=40,
+    )
+
+    forecasts = out["forecasts"]
+    targets = out["targets"]
+    assert len(forecasts) == len(targets) > 0
+    assert forecasts.index.equals(targets.index)
+    assert np.isfinite(forecasts).all()
+    assert np.isfinite(targets).all()
+    assert np.isfinite(out["aggregate_mse_logrv"])
+
+
+def test_ols_predictions_are_exactly_seed_stable(asymmetric_rv):
+    rv_neg, rv_pos, rv = asymmetric_rv
+    first = walk_forward_asymmetric_har(
+        rv_neg, rv_pos, rv, n_splits=4, seed=0,
+    )
+    second = walk_forward_asymmetric_har(
+        rv_neg, rv_pos, rv, n_splits=4, seed=99,
+    )
+
+    np.testing.assert_array_equal(first["forecasts"], second["forecasts"])
+    np.testing.assert_array_equal(first["targets"], second["targets"])
+
+
+def test_train_tail_calibration_returns_signed_forecast_bias(
+    asymmetric_rv,
+    monkeypatch,
+):
+    rv_neg, rv_pos, rv = asymmetric_rv
+    constant_prediction = float(np.log(rv.iloc[-80:]).mean() + 0.4)
+
+    monkeypatch.setattr(
+        AsymmetricHARModel,
+        "predict_h_step",
+        lambda self, rv_neg_history, rv_pos_history, rv_history, horizon: (
+            constant_prediction
+        ),
+    )
+    _, bias = _fit_asymmetric_with_train_calibration(
+        rv_neg,
+        rv_pos,
+        rv,
+        horizon=1,
+        calibration_size=60,
+    )
+
+    expected_targets = np.log(rv.iloc[-60:-1]).to_numpy()
+    expected_bias = float(np.mean(constant_prediction - expected_targets))
+    assert bias == pytest.approx(expected_bias)
+    assert bias > 0.0
+
+
+def test_eval_persists_strictly_aligned_predictions(asymmetric_rv, monkeypatch):
+    rv_neg, rv_pos, rv = asymmetric_rv
+    hours = pd.date_range(
+        rv.index[0], periods=len(rv) * 24, freq="h",
+    )
+    hourly_returns = pd.Series(np.zeros(len(hours)), index=hours)
+    monkeypatch.setattr(har_asymmetric, "daily_realized_variance", lambda _: rv)
+    monkeypatch.setattr(
+        har_asymmetric, "daily_semivariance_negative", lambda _: rv_neg,
+    )
+    monkeypatch.setattr(
+        har_asymmetric, "daily_semivariance_positive", lambda _: rv_pos,
+    )
+
+    row = _eval_one_coin(
+        "BTC-USD",
+        hourly_returns,
+        horizons=[1],
+        seeds=[0],
+        n_splits=4,
+        refit_every=22,
+        debias=True,
+        calibration_size=40,
+    )[0]
+
+    n_predictions = row["n_predictions"]
+    assert n_predictions > 0
+    assert len(row["pred_dates"]) == n_predictions
+    assert len(row["pred_asym"]) == n_predictions
+    assert len(row["pred_classic_har"]) == n_predictions
+    assert len(row["pred_target"]) == n_predictions
+    assert np.isfinite(row["pred_asym"]).all()
+    assert np.isfinite(row["pred_classic_har"]).all()
+    assert np.isfinite(row["pred_target"]).all()
+    assert row["debias"] is True
+
+
+def _verdict_row(seed: int, asym_mse: float, classic_mse: float, pvalue: float) -> dict:
+    return {
+        "coin": "BTC-USD",
+        "horizon": 1,
+        "seed": seed,
+        "asym_mse_logrv": asym_mse,
+        "classic_mse_logrv": classic_mse,
+        "dm_verdict": "MODEL BEATS BASELINE",
+        "dm_pvalue": pvalue,
+    }
+
+
+def test_aggregate_marks_deterministic_seed_stability():
+    rows = [
+        _verdict_row(seed, 0.80, 1.0, 0.01)
+        for seed in (0, 7, 42, 99)
+    ]
+    aggregate = aggregate_verdicts(rows)[0]
+
+    assert aggregate["median_dm_pvalue"] < 0.05
+    assert aggregate["seed_stable"] is True
+    assert aggregate["edge_sigma"] is None
+    assert aggregate["verdict"] == "BEATS"
+
+
+def test_aggregate_rejects_significant_but_unstable_edge():
+    rows = [
+        _verdict_row(seed, asym_mse, 1.0, 0.01)
+        for seed, asym_mse in zip((0, 7, 42, 99), (0.60, 1.20, 0.70, 1.10))
+    ]
+    aggregate = aggregate_verdicts(rows)[0]
+
+    assert aggregate["edge_sigma"] < 2.0
+    assert aggregate["verdict"] == "INCONCLUSIVE"


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2025:CoursIA — prev: MED/notebook-python #14202

## Summary

- add symmetric train-only bias calibration to classic and asymmetric HAR
- persist date-aligned OOS predictions, targets, signed biases, and error variances
- re-run BTC over 5 expanding folds, 4 deterministic control seeds, and horizons 1/5/10
- replace the historical 3/3 BTC claim with the measured 2/3 BEATS verdict
- re-execute the research notebook with all 8 code-cell outputs

## Measured result

| Horizon | MSE HAR debiased | MSE asymmetric debiased | Edge | Median DM p | Verdict |
|---:|---:|---:|---:|---:|---|
| 1 | 0.843774 | 0.848154 | -0.52% | 0.244862 | INCONCLUSIVE |
| 5 | 0.417886 | 0.403593 | +3.42% | 0.011363 | BEATS |
| 10 | 0.389457 | 0.369614 | +5.10% | 0.005123 | BEATS |

The four seeds are bit-identical because OLS is deterministic. They are reproducibility controls, not independent stochastic runs; cross-seed edge/sigma is explicitly not applicable. Residual signed biases are close to zero, so the surviving edge is carried primarily by error variance rather than a baseline offset.

## Validation

- `python .../har_asymmetric.py --coins BTC-USD --horizons 1 5 10 --seeds 0 7 42 99 --n-splits 5 --skip-remote --debias --calibration-size 60 ...`: SUCCESS, 12/12 combinations, 332.6 s final run
- `python -m pytest scripts/tests/test_har_model.py scripts/tests/test_har_asymmetric.py -q`: 25 passed
- notebook execution via `notebook_tools.py execute ... --kernel python3 --cwd ...`: SUCCESS, 8/8 code cells
- `validate_pr_notebooks.py`: EXEC_PROVED, 8/8 code cells, 0 errors
- `scan_cell_ordering.py --fail-on HIGH`: 0 findings
- `scrub_papermill_paths.py --scan`: 0 absolute metadata paths
- `git diff --check`: clean

## Diagnostic dérive

- Cause: **b — claim antérieure fabriquée par une comparaison asymétrique**. The historical result compared candidate and baseline forecasts with different OOS bias components, so `MSE = bias^2 + variance` inflated the apparent edge.
- Verdict: **CAUSE_FIXED**. Both forecasts now use the same train-tail calibration protocol, and the notebook recomputes MSE from persisted aligned OOS series.

## SOTA verdict

**SOTA-OK** — the real NumPy/Pandas/SciPy HAR and Diebold-Mariano pipeline ran locally. No degraded substitute or hand-edited cell output was used.

## Scope

Forecast accuracy only; this is not a trading backtest. Transaction costs, Sharpe, CAGR, and drawdown are not claimed. The historical cluster-level verdict remains NO BEATS; this PR revalidates only BTC, the sole previously significant asset.

See #1454
