### PR TITLE
chore(ml,#14209): normaliser les cellules source string vers forme liste sur ML/ML.Net

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
@@ -48,7 +48,14 @@
    "cell_type": "markdown",
    "id": "f3127450",
    "metadata": {},
-   "source": "- **Étape 1 :** Référencer les bibliothèques\n\nEn Python, on importe les modules. **NumPy** pour les tableaux numériques,\n**scikit-learn** (`sklearn`) pour les algorithmes et métriques, **Matplotlib** pour les\nvisualisations.\n"
+   "source": [
+    "- **Étape 1 :** Référencer les bibliothèques\n",
+    "\n",
+    "En Python, on importe les modules. **NumPy** pour les tableaux numériques,\n",
+    "**scikit-learn** (`sklearn`) pour les algorithmes et métriques, **Matplotlib** pour les\n",
+    "visualisations.\n",
+    ""
+   ]
   },
   {
    "cell_type": "code",
@@ -110,7 +117,16 @@
    "cell_type": "markdown",
    "id": "233d552c",
    "metadata": {},
-   "source": "- **Étape 2 :** Définir les structures de données\n\nEn ML.NET on définit des classes POCO (`HouseData`, `Prediction`). En Python on travaille\ndirectement avec des **tableaux NumPy** : un tableau 2D `X` pour les features (ici la\ntaille) et un vecteur 1D `y` pour les étiquettes (ici le prix). C'est la convention\nuniverselle de scikit-learn : `X` de forme `(n_samples, n_features)`, `y` de forme\n`(n_samples,)`.\n"
+   "source": [
+    "- **Étape 2 :** Définir les structures de données\n",
+    "\n",
+    "En ML.NET on définit des classes POCO (`HouseData`, `Prediction`). En Python on travaille\n",
+    "directement avec des **tableaux NumPy** : un tableau 2D `X` pour les features (ici la\n",
+    "taille) et un vecteur 1D `y` pour les étiquettes (ici le prix). C'est la convention\n",
+    "universelle de scikit-learn : `X` de forme `(n_samples, n_features)`, `y` de forme\n",
+    "`(n_samples,)`.\n",
+    ""
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -195,7 +195,11 @@
      ]
     }
    ],
-   "source": "using Microsoft.ML;\nusing Microsoft.ML.Data;\nConsole.WriteLine(\"Espaces de noms Microsoft.ML importes\");"
+   "source": [
+    "using Microsoft.ML;\n",
+    "using Microsoft.ML.Data;\n",
+    "Console.WriteLine(\"Espaces de noms Microsoft.ML importes\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -252,7 +256,10 @@
      ]
     }
    ],
-   "source": "MLContext mlContext = new MLContext();\nConsole.WriteLine($\"MLContext cree (seed: {mlContext})\");"
+   "source": [
+    "MLContext mlContext = new MLContext();\n",
+    "Console.WriteLine($\"MLContext cree (seed: {mlContext})\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -309,7 +316,14 @@
      ]
     }
    ],
-   "source": "public class HouseData\n{\n    public float Size { get; set; }\n    public float Price { get; set; }\n}\nConsole.WriteLine(\"Classe HouseData definie (Size, Price)\");"
+   "source": [
+    "public class HouseData\n",
+    "{\n",
+    "    public float Size { get; set; }\n",
+    "    public float Price { get; set; }\n",
+    "}\n",
+    "Console.WriteLine(\"Classe HouseData definie (Size, Price)\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -366,7 +380,14 @@
      ]
     }
    ],
-   "source": "public class Prediction\n{\n    [ColumnName(\"Score\")]\n    public float Price { get; set; }\n}\nConsole.WriteLine(\"Classe Prediction definie (Score -> Price)\");"
+   "source": [
+    "public class Prediction\n",
+    "{\n",
+    "    [ColumnName(\"Score\")]\n",
+    "    public float Price { get; set; }\n",
+    "}\n",
+    "Console.WriteLine(\"Classe Prediction definie (Score -> Price)\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -423,7 +444,17 @@
      ]
     }
    ],
-   "source": "HouseData[] houseData = {\n    new HouseData() { Size = 1.1F, Price = 1.2F },\n    new HouseData() { Size = 1.9F, Price = 2.3F },\n    new HouseData() { Size = 2.8F, Price = 3.0F },\n    new HouseData() { Size = 3.4F, Price = 3.7F }\n};\n\nIDataView trainingData = mlContext.Data.LoadFromEnumerable(houseData);\nConsole.WriteLine($\"Donnees d'entrainement chargees : {houseData.Length} exemples\");"
+   "source": [
+    "HouseData[] houseData = {\n",
+    "    new HouseData() { Size = 1.1F, Price = 1.2F },\n",
+    "    new HouseData() { Size = 1.9F, Price = 2.3F },\n",
+    "    new HouseData() { Size = 2.8F, Price = 3.0F },\n",
+    "    new HouseData() { Size = 3.4F, Price = 3.7F }\n",
+    "};\n",
+    "\n",
+    "IDataView trainingData = mlContext.Data.LoadFromEnumerable(houseData);\n",
+    "Console.WriteLine($\"Donnees d'entrainement chargees : {houseData.Length} exemples\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -497,7 +528,11 @@
      ]
     }
    ],
-   "source": "var pipeline = mlContext.Transforms.Concatenate(\"Features\", new[] { \"Size\" })\n               .Append(mlContext.Regression.Trainers.Sdca(labelColumnName: \"Price\", maximumNumberOfIterations: 100));\nConsole.WriteLine(\"Pipeline ML.NET cree : Concatenate + SDCA Regression\");"
+   "source": [
+    "var pipeline = mlContext.Transforms.Concatenate(\"Features\", new[] { \"Size\" })\n",
+    "               .Append(mlContext.Regression.Trainers.Sdca(labelColumnName: \"Price\", maximumNumberOfIterations: 100));\n",
+    "Console.WriteLine(\"Pipeline ML.NET cree : Concatenate + SDCA Regression\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -554,7 +589,10 @@
      ]
     }
    ],
-   "source": "var model = pipeline.Fit(trainingData);\nConsole.WriteLine(\"Modele entraite avec succes\");"
+   "source": [
+    "var model = pipeline.Fit(trainingData);\n",
+    "Console.WriteLine(\"Modele entraite avec succes\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -715,7 +753,10 @@
      ]
     }
    ],
-   "source": "var predictionEngine = mlContext.Model.CreatePredictionEngine<HouseData, Prediction>(model);\nConsole.WriteLine(\"PredictionEngine cree\");"
+   "source": [
+    "var predictionEngine = mlContext.Model.CreatePredictionEngine<HouseData, Prediction>(model);\n",
+    "Console.WriteLine(\"PredictionEngine cree\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -781,7 +822,22 @@
   {
    "cell_type": "markdown",
    "id": "70618d7d",
-   "source": "### Interprétation : la prédiction, l'interpolation et l'extrapolation\n\nLa prédiction de **276,18 €k** pour 2 500 pieds carrés (Size = 2,5) tombe **entre** les données d'entraînement : le jeu d'apprentissage couvre les tailles 1,1 à 3,4 (soit 1 100 à 3 400 pieds carrés). Il s'agit d'une **interpolation** — la zone où un modèle linéaire est le plus fiable, car il n'a pas à deviner la pente au-delà de ce qu'il a vu.\n\nLa droite apprise passe environ par `Prix ≈ 1,05 × Size + 0,14` (soit ~2,76 à Size = 2,5, ce qui correspond bien à la sortie ci-dessus). À l'inverse, les données de test s'étendent jusqu'à Size = 8,0 (8 000 pieds carrés), largement au-delà de la plage d'entraînement : c'est de l'**extrapolation**. Les grands points de test s'écartent alors de la droite :\n\n| Size | Prix réel (test) | Prix prédit par la droite | Écart |\n|------|------------------|---------------------------|-------|\n| 4,0 | 6,1 | ~4,3 | sous-estimé |\n| 8,0 | 10,3 | ~8,5 | sous-estimé |\n\nLe vrai prix monte **plus vite** qu'une ligne droite — effet « premium » des grandes surfaces. C'est précisément ce phénomène non linéaire qui plafonne le R² à 0,85 plutôt qu'à 1 : la droite, ajustée sur le segment 1,1–3,4, sous-estime systématiquement les grandes maisons.\n\n**Règle pratique** : un modèle de régression linéaire mérite une confiance élevée à l'**intérieur** du domaine d'entraînement (interpolation) et doit être utilisé avec prudence dès qu'on **extrapole** au-delà. C'est pourquoi la prédiction à 2 500 pieds carrés est crédible, tandis qu'une prédiction pour 9 000 pieds carrés le serait beaucoup moins.",
+   "source": [
+    "### Interprétation : la prédiction, l'interpolation et l'extrapolation\n",
+    "\n",
+    "La prédiction de **276,18 €k** pour 2 500 pieds carrés (Size = 2,5) tombe **entre** les données d'entraînement : le jeu d'apprentissage couvre les tailles 1,1 à 3,4 (soit 1 100 à 3 400 pieds carrés). Il s'agit d'une **interpolation** — la zone où un modèle linéaire est le plus fiable, car il n'a pas à deviner la pente au-delà de ce qu'il a vu.\n",
+    "\n",
+    "La droite apprise passe environ par `Prix ≈ 1,05 × Size + 0,14` (soit ~2,76 à Size = 2,5, ce qui correspond bien à la sortie ci-dessus). À l'inverse, les données de test s'étendent jusqu'à Size = 8,0 (8 000 pieds carrés), largement au-delà de la plage d'entraînement : c'est de l'**extrapolation**. Les grands points de test s'écartent alors de la droite :\n",
+    "\n",
+    "| Size | Prix réel (test) | Prix prédit par la droite | Écart |\n",
+    "|------|------------------|---------------------------|-------|\n",
+    "| 4,0 | 6,1 | ~4,3 | sous-estimé |\n",
+    "| 8,0 | 10,3 | ~8,5 | sous-estimé |\n",
+    "\n",
+    "Le vrai prix monte **plus vite** qu'une ligne droite — effet « premium » des grandes surfaces. C'est précisément ce phénomène non linéaire qui plafonne le R² à 0,85 plutôt qu'à 1 : la droite, ajustée sur le segment 1,1–3,4, sous-estime systématiquement les grandes maisons.\n",
+    "\n",
+    "**Règle pratique** : un modèle de régression linéaire mérite une confiance élevée à l'**intérieur** du domaine d'entraînement (interpolation) et doit être utilisé avec prudence dès qu'on **extrapole** au-delà. C'est pourquoi la prédiction à 2 500 pieds carrés est crédible, tandis qu'une prédiction pour 9 000 pieds carrés le serait beaucoup moins."
+   ],
    "metadata": {}
   },
   {
@@ -1073,25 +1129,70 @@
   {
    "cell_type": "markdown",
    "id": "3cfd39af",
-   "source": "### Interpretation : Evaluation du modèle de classification\n\n**résultats obtenus** : Le modèle de classification binaire atteint une precision parfaite sur les données de test.\n\n| Metrique | Valeur | Signification |\n|----------|--------|---------------|\n| Accuracy | 100 % | Toutes les transactions sont correctement classees |\n| AUC | 100 % | Separation parfaite entre transactions normales et suspectes |\n| Probabilite suspecte | 99,99 % | Forte confiance pour Montant=3500, Heure=3h |\n| Probabilite normale | ~0,04 % | Forte confiance pour Montant=150, Heure=10h |\n\n**Points cles** :\n\n1. **Separation nette** : Les transactions suspectes (montant eleve + heures nocturnes) sont clairement distinctes des normales dans ce jeu de données\n2. **Surapprentissage probable** : Performance parfaite sur les données d'entrainement — un jeu de test indépendant serait necessaire pour evaluer la generalisation\n3. **Features discriminantes** : Le montant et l'heure suffisent a separer les deux classes dans cet exemple simplifie\n4. **Limites** : En conditions reelles, les motifs de fraude sont plus subtils et les données sont souvent fortement desequilibrees\n5. **Variance d'execution** : la probabilite exacte pour une transaction normale fluctue d'une execution a l'autre (observe entre ~0,04 % et ~0,11 % sur 3 runs, malgre `new MLContext(seed: 0)` -- SDCA n'est pas pleinement deterministe). Seul l'ordre de grandeur (bien inferieur a 1 %) est stable ; la decision de classification (False) ne change pas.",
+   "source": [
+    "### Interpretation : Evaluation du modèle de classification\n",
+    "\n",
+    "**résultats obtenus** : Le modèle de classification binaire atteint une precision parfaite sur les données de test.\n",
+    "\n",
+    "| Metrique | Valeur | Signification |\n",
+    "|----------|--------|---------------|\n",
+    "| Accuracy | 100 % | Toutes les transactions sont correctement classees |\n",
+    "| AUC | 100 % | Separation parfaite entre transactions normales et suspectes |\n",
+    "| Probabilite suspecte | 99,99 % | Forte confiance pour Montant=3500, Heure=3h |\n",
+    "| Probabilite normale | ~0,04 % | Forte confiance pour Montant=150, Heure=10h |\n",
+    "\n",
+    "**Points cles** :\n",
+    "\n",
+    "1. **Separation nette** : Les transactions suspectes (montant eleve + heures nocturnes) sont clairement distinctes des normales dans ce jeu de données\n",
+    "2. **Surapprentissage probable** : Performance parfaite sur les données d'entrainement — un jeu de test indépendant serait necessaire pour evaluer la generalisation\n",
+    "3. **Features discriminantes** : Le montant et l'heure suffisent a separer les deux classes dans cet exemple simplifie\n",
+    "4. **Limites** : En conditions reelles, les motifs de fraude sont plus subtils et les données sont souvent fortement desequilibrees\n",
+    "5. **Variance d'execution** : la probabilite exacte pour une transaction normale fluctue d'une execution a l'autre (observe entre ~0,04 % et ~0,11 % sur 3 runs, malgre `new MLContext(seed: 0)` -- SDCA n'est pas pleinement deterministe). Seul l'ordre de grandeur (bien inferieur a 1 %) est stable ; la decision de classification (False) ne change pas."
+   ],
    "metadata": {}
   },
   {
    "cell_type": "markdown",
    "id": "f8ab79f9",
-   "source": "## Exercices supplementaires\n\nLes exercices suivants approfondissent les concepts vus dans ce notebook. Ils utilisent les données et le contexte ML.NET définis precedemment.",
+   "source": [
+    "## Exercices supplementaires\n",
+    "\n",
+    "Les exercices suivants approfondissent les concepts vus dans ce notebook. Ils utilisent les données et le contexte ML.NET définis precedemment."
+   ],
    "metadata": {}
   },
   {
    "cell_type": "markdown",
    "id": "97b53a6e",
-   "source": "### Exercice 1 : Analyse de l'importance des features\n\nEntrainement d'un modèle de regression, puis analyse de l'importance relative de chaque feature avec `PermutationFeatureImportance` (PFI).\n\n**Objectifs** :\n1. Reutiliser le MLContext et les données `HouseData` définis precedemment\n2. Entrainer un modèle de regression (SDCA ou FastTree)\n3. Appeler `PermutationFeatureImportance` pour classer les features par impact\n4. Afficher les résultats tries par importance decroissante\n\n**Indice** : Utilisez `mlContext.Regression.PermutationFeatureImportance(model, data, permutationCount: 3)`. Chaque résultat contient un dictionnaire de metriques par feature.",
+   "source": [
+    "### Exercice 1 : Analyse de l'importance des features\n",
+    "\n",
+    "Entrainement d'un modèle de regression, puis analyse de l'importance relative de chaque feature avec `PermutationFeatureImportance` (PFI).\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Reutiliser le MLContext et les données `HouseData` définis precedemment\n",
+    "2. Entrainer un modèle de regression (SDCA ou FastTree)\n",
+    "3. Appeler `PermutationFeatureImportance` pour classer les features par impact\n",
+    "4. Afficher les résultats tries par importance decroissante\n",
+    "\n",
+    "**Indice** : Utilisez `mlContext.Regression.PermutationFeatureImportance(model, data, permutationCount: 3)`. Chaque résultat contient un dictionnaire de metriques par feature."
+   ],
    "metadata": {}
   },
   {
    "cell_type": "code",
    "id": "e184983e",
-   "source": "// Exercice 1 : Analyse de l'importance des features\n// TODO etudiant : Entrainez un modele et analysez l'importance des features\n// Indice : utilisez mlContext.Regression.PermutationFeatureImportance()\n// Etape 1 : reutilisez le MLContext et les donnees HouseData definis plus haut\n// Etape 2 : entrainez un modele FastTree ou SDCA sur les donnees de test\n// Etape 3 : appelez PermutationFeatureImportance pour obtenir les scores\n// Etape 4 : affichez les features triees par importance (descroissante)\n// var featureImportance = ... // TODO etudiant : resultat PFI\nConsole.WriteLine(\"Exercice a completer : analyse de l'importance des features\");",
+   "source": [
+    "// Exercice 1 : Analyse de l'importance des features\n",
+    "// TODO etudiant : Entrainez un modele et analysez l'importance des features\n",
+    "// Indice : utilisez mlContext.Regression.PermutationFeatureImportance()\n",
+    "// Etape 1 : reutilisez le MLContext et les donnees HouseData definis plus haut\n",
+    "// Etape 2 : entrainez un modele FastTree ou SDCA sur les donnees de test\n",
+    "// Etape 3 : appelez PermutationFeatureImportance pour obtenir les scores\n",
+    "// Etape 4 : affichez les features triees par importance (descroissante)\n",
+    "// var featureImportance = ... // TODO etudiant : resultat PFI\n",
+    "Console.WriteLine(\"Exercice a completer : analyse de l'importance des features\");"
+   ],
    "metadata": {},
    "execution_count": 14,
    "outputs": [
@@ -1107,13 +1208,35 @@
   {
    "cell_type": "markdown",
    "id": "27191ce8",
-   "source": "### Exercice 2 : Exploration statistique des données\n\ncréez un `DataFrame` avec des données d'employes et calculez des statistiques descriptives pour mieux comprendre vos données avant l'entrainement.\n\n**Objectifs** :\n1. créer un `DataFrame` avec des colonnes numériques (expérience, salaire) et categorielles (departement, niveau)\n2. Calculer les statistiques descriptives (moyenne, ecart-type, min, max) pour chaque colonne numérique\n3. Compter les valeurs uniques pour les colonnes categorielles\n4. Afficher un resume structure des résultats\n\n**Indice** : Utilisez `DataFrameColumn.Create()` pour construire le DataFrame, puis les méthodes `.Mean()`, `.StandardDeviation()`, `.Min()`, `.Max()` sur chaque colonne.",
+   "source": [
+    "### Exercice 2 : Exploration statistique des données\n",
+    "\n",
+    "créez un `DataFrame` avec des données d'employes et calculez des statistiques descriptives pour mieux comprendre vos données avant l'entrainement.\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. créer un `DataFrame` avec des colonnes numériques (expérience, salaire) et categorielles (departement, niveau)\n",
+    "2. Calculer les statistiques descriptives (moyenne, ecart-type, min, max) pour chaque colonne numérique\n",
+    "3. Compter les valeurs uniques pour les colonnes categorielles\n",
+    "4. Afficher un resume structure des résultats\n",
+    "\n",
+    "**Indice** : Utilisez `DataFrameColumn.Create()` pour construire le DataFrame, puis les méthodes `.Mean()`, `.StandardDeviation()`, `.Min()`, `.Max()` sur chaque colonne."
+   ],
    "metadata": {}
   },
   {
    "cell_type": "code",
    "id": "5a7dc6fd",
-   "source": "// Exercice 2 : Exploration statistique des donnees\n// TODO etudiant : Utilisez DataFrame pour calculer des statistiques descriptives\n// Indice : DataFrame.LoadCsv() puis df[\\\"col\\\"].Mean(), df[\\\"col\\\"].StdDev(), df[\\\"col\\\"].Min(), df[\\\"col\\\"].Max()\n// Etape 1 : creer un DataFrame avec des donnees d'employes (experience, education, taille societe, salaire)\n// Etape 2 : calculer mean, std, min, max pour chaque colonne numerique\n// Etape 3 : compter les valeurs uniques pour les colonnes categorielles\n// Etape 4 : afficher un resume sous forme de tableau\n\nConsole.WriteLine(\"Exercice a completer : exploration statistique des donnees\");",
+   "source": [
+    "// Exercice 2 : Exploration statistique des donnees\n",
+    "// TODO etudiant : Utilisez DataFrame pour calculer des statistiques descriptives\n",
+    "// Indice : DataFrame.LoadCsv() puis df[\\\"col\\\"].Mean(), df[\\\"col\\\"].StdDev(), df[\\\"col\\\"].Min(), df[\\\"col\\\"].Max()\n",
+    "// Etape 1 : creer un DataFrame avec des donnees d'employes (experience, education, taille societe, salaire)\n",
+    "// Etape 2 : calculer mean, std, min, max pour chaque colonne numerique\n",
+    "// Etape 3 : compter les valeurs uniques pour les colonnes categorielles\n",
+    "// Etape 4 : afficher un resume sous forme de tableau\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : exploration statistique des donnees\");"
+   ],
    "metadata": {},
    "execution_count": 15,
    "outputs": [
@@ -1195,7 +1318,34 @@
      ]
     }
    ],
-   "source": "// Exercice : Regression multi-features - Prediction de salaire\nConsole.WriteLine(\"Exercice a completer\");\n\n// TODO: Definir EmployeeData avec AnneeExperience (float), NiveauEducation (float),\n//       TailleSociete (float), Salaire (float)\n\n\n// TODO: Definir SalairePrediction\n// Indice: [ColumnName(\"Score\")] public float Salaire\n\n\n// TODO: Creer un dataset de 10+ employes\n// Exemples de valeurs :\n//   {AnneeExperience=2, NiveauEducation=1, TailleSociete=1, Salaire=32000}\n//   {AnneeExperience=10, NiveauEducation=3, TailleSociete=3, Salaire=110000}\n\n\n// TODO: Construire le pipeline (Concatenate + NormalizeMeanVariance + Sdca Regression)\n// Indice: mlContext.Regression.Trainers.Sdca(labelColumnName: nameof(EmployeeData.Salaire))\n\n\n// TODO: Entrainer le modele et evaluer\n// Afficher: metrics.RSquared, metrics.MeanAbsoluteError, metrics.RootMeanSquaredError\n\n\n// TODO: Predire le salaire pour AnneeExperience=5, NiveauEducation=2 (Master), TailleSociete=2 (Grande)"
+   "source": [
+    "// Exercice : Regression multi-features - Prediction de salaire\n",
+    "Console.WriteLine(\"Exercice a completer\");\n",
+    "\n",
+    "// TODO: Definir EmployeeData avec AnneeExperience (float), NiveauEducation (float),\n",
+    "//       TailleSociete (float), Salaire (float)\n",
+    "\n",
+    "\n",
+    "// TODO: Definir SalairePrediction\n",
+    "// Indice: [ColumnName(\"Score\")] public float Salaire\n",
+    "\n",
+    "\n",
+    "// TODO: Creer un dataset de 10+ employes\n",
+    "// Exemples de valeurs :\n",
+    "//   {AnneeExperience=2, NiveauEducation=1, TailleSociete=1, Salaire=32000}\n",
+    "//   {AnneeExperience=10, NiveauEducation=3, TailleSociete=3, Salaire=110000}\n",
+    "\n",
+    "\n",
+    "// TODO: Construire le pipeline (Concatenate + NormalizeMeanVariance + Sdca Regression)\n",
+    "// Indice: mlContext.Regression.Trainers.Sdca(labelColumnName: nameof(EmployeeData.Salaire))\n",
+    "\n",
+    "\n",
+    "// TODO: Entrainer le modele et evaluer\n",
+    "// Afficher: metrics.RSquared, metrics.MeanAbsoluteError, metrics.RootMeanSquaredError\n",
+    "\n",
+    "\n",
+    "// TODO: Predire le salaire pour AnneeExperience=5, NiveauEducation=2 (Master), TailleSociete=2 (Grande)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
@@ -28,6 +28,12 @@
       csharp_sha: badb7ba30e145498996a823e9d2b69e8fb31ea1a
       content_python_sha: ecd3798935d81f107d9318130f2c68e29e483b8f6ab06bae62668ee9621a9151
       content_csharp_sha: 38238ddf5cbe7c38ee7dbd223bceb742dd35aff85828528be5dc111ee9725bfa
+    - date: "2026-09-02"
+      by: myia-po-2023:CoursIA
+      python_sha: 98c13304b83c09ff521ccbb3e42c20df4a117e14
+      csharp_sha: 0aa813e2da6ef0fa5afac9ad7e98d557cc2d9dd4
+      content_python_sha: 0694e285f5ca044c3aaf81caaf973739652e75bcb8a993107f6b2874515c99f9
+      content_csharp_sha: b52736f474751642d6afac107f15c3b7d83ce6a8e33d962895c61948381e6d62
   known_differences:
     - "2026-08-15 : correction d'auteurs falsifies (issue #11044, tranche W3C SPARQL / ML.NET KDD) — citations remises a leurs auteurs reels (Amizadeh S., DOI KDD, Protocol et al., etc.), markdown-only, aucun changement d'engine/outputs. Parite semantique conservee ; rebaseline content SHA (re-audit 2026-08-15, myia-po-2026:CoursIA-2)."
     - "Socle pedagogique commun : regression lineaire (R2, MAE) + regression logistique (accuracy, ROC-AUC). Dataset : prediction de prix / classification binaire."


### PR DESCRIPTION
Grain: LIGHT/refactor -- lane myia-po-2023:CoursIA

## Scope

Tranche familiale de **#14209** (normalisation des cellules source string → liste). Clause `paths: MyIA.AI.Notebooks/ML/ML.Net/`. **2 notebooks, 18 cellules converties** — mesure sur base fraîche origin/main `0a4b7a5ce3` :

| Notebook | cellules string | total cellules |
|---|---|---|
| `ML/ML.Net/ML-1-Introduction.ipynb` | 16 | 41 |
| `ML/ML.Net/ML-1-Introduction-Python.ipynb` | 2 | 36 |
| `ML/ML.Net/ML-4-Evaluation.ipynb` | 0 (déjà propre sur main) | 87 |

(Note : mon [CLAIMED] citait 26 cellules/3 fichiers — chiffres mesurés par erreur sur un arbre local stale ; la base fraîche donne 18/2. La clause `paths:` famille ML.Net reste exacte et la tranche est complète sur cette base.)

## Geste

Outil existant `scripts/notebook_tools/fix_string_cells.py` (aucune réécriture, cf corps de l'issue). Conversion de forme seule, convention nbformat (retour ligne sur toutes les lignes sauf la dernière, élément final `""` pour une source finissant par `\n`).

## Gardes #14209 — vérifiées par digest par cellule (snapshot avant/après)

| Garde | Résultat |
|---|---|
| `source` **rejoint** byte-identique par cellule | **PASS** (sha1 du concat identique sur les 18 cellules converties + toutes les autres) |
| `outputs` / `execution_count` inchangés | **PASS** (sha1 des outputs + exec_count identiques sur toutes les cellules) |
| nombre de cellules / metadata notebook inchangés | **PASS** |
| aucune cellule au contenu modifié → **pas de re-exécution** | **PASS** (C.3 respecté — diff = forme seule) |

Diff : `+184/−18` sur 2 fichiers, hunks = uniquement `"source": "..."` → `"source": [...]`.

## Interdits respectés

- Aucune prose / sortie / accent touché (les 3 gardes ci-dessus le prouvent par digest).
- Catalogue non touché (byte-identique à main).

See #14209 (tranche ML/ML.Net ; les autres familles de la partition restent au pool)
