### PR TITLE
fix(guard,#13610): _NAMED_FILE_BODY accepte les symboles pointes (l'underscore renversait le verdict)

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -717,10 +717,25 @@ _EDIT_VERB = re.compile(
     r"\b(?:editer|modifier|toucher|ouvrir|créer|creer|ajouter|changer|mettre\s+à\s+jour|mettre\s+a\s+jour|update|edit|modify|touch|open|create|add|change)\b",
     re.IGNORECASE,
 )
-# A named file as it would appear in a body: backticked path, bare basename
+# A named referent as it would appear in a body: backticked path, backticked
+# DOTTED SYMBOL (`pick_idle_grain.upsert_orphans_comment`), bare basename
 # (.py/.cs/.yml/.json/.md/.ipynb/.sh), or a known scripts/<x>.py shape.
+#
+# #13610 residual (measured 2026-09-02, po-2024): the tail class was
+# `[A-Za-z0-9]+`, which excludes the underscore. A dotted symbol -- the most
+# common way a French technical body points at code -- was therefore NOT a
+# named referent, and the FN-safety branch kept the rouge on the FOUNDING
+# sentence of #13539, whose referent was named but named as a SYMBOL:
+#   « L'upsert vit dans `pick_idle_grain.upsert_orphans_comment` ; le
+#     generaliser demanderait d'editer un fichier deja porteur de deux PRs »
+# The boundary this drew was arbitrary AND invisible: `pick_idle_grain.upsert`
+# passed while `pick_idle_grain.upsert_orphans` rouged, on the sole strength
+# of one underscore -- two spellings of the same code reference, opposite
+# verdicts. Widening the tail to `\w+` removes the inversion. It does NOT
+# touch the deliberate FN-safety choice of #13612: an ANONYMOUS referent
+# ("editer un fichier", nothing named on the line) still keeps the rouge.
 _NAMED_FILE_BODY = re.compile(
-    r"(?:`([^`]+\.[A-Za-z0-9]+)`|"  # backticked: `pick_idle_grain.py`
+    r"(?:`([^`]+\.\w+)`|"  # backticked: `pick_idle_grain.py`, `mod.fn_name`
     r"\b([\w./-]+\.(?:py|cs|yml|yaml|json|md|ipynb|ts|js|sh|toml|cfg|ini))\b)"  # bare basename
 )
 # A cited threshold ("< 15 fichiers", ">= 10 fichiers") quotes a rule, it does

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -2866,6 +2866,110 @@ def test_13610_predicate_unit_unanimous():
 
 
 # ---------------------------------------------------------------------------
+# #13610 residual (2026-09-02, measured by po-2024) -- the referent is named,
+# but named as a SYMBOL, not as a file. The tail class of _NAMED_FILE_BODY was
+# `[A-Za-z0-9]+`, which excludes the underscore; a dotted symbol was therefore
+# not recognized as a named referent, and the FN-safety branch kept the rouge
+# on the FOUNDING sentence of #13539 itself. The boundary was arbitrary AND
+# invisible: the same code reference passed or rouged on the sole strength of
+# one underscore. The pair below is the proof -- the first test alone would be
+# satisfied by simply disabling the guard, which is why the positive control
+# and the anonymous-referent control are pinned alongside it.
+# ---------------------------------------------------------------------------
+
+# The two rows of the #13610 table, verbatim in shape: same sentence, same
+# referent, one underscore apart.
+_SYMBOL_SHAPE = (
+    "L'upsert vit dans `pick_idle_grain.{symbole}` ; le generaliser "
+    "demanderait d'editer un fichier deja porteur de deux PRs ouvertes "
+    "de la meme lane"
+)
+
+
+def test_13610_symbol_referent_without_underscore_passes():
+    """Table row 1: `pick_idle_grain.upsert` -- passed even before the fix.
+    Pinned so a future tightening of the tail class cannot silently take it
+    back, which would re-open the inversion from the other side."""
+    line = _SYMBOL_SHAPE.format(symbole="upsert")
+    problems = check_assertion(FILES_13610, line)
+    assert problems == [], (
+        "a dotted symbol without underscore must not rouge; got: "
+        + repr(problems)
+    )
+
+
+def test_13610_symbol_referent_with_underscore_passes():
+    """Table row 2: `pick_idle_grain.upsert_orphans` -- ROUGED before the fix,
+    on the sole strength of the underscore. This is the regression the
+    residual names."""
+    line = _SYMBOL_SHAPE.format(symbole="upsert_orphans")
+    problems = check_assertion(FILES_13610, line)
+    assert problems == [], (
+        "a dotted symbol with an underscore must not rouge -- the underscore "
+        "is not a semantic boundary; got: " + repr(problems)
+    )
+
+
+def test_13610_founding_sentence_of_13539_passes():
+    """The sentence of #13539 that founded the whole thread. Its referent was
+    named all along -- named as a symbol. Acceptance line 1 of #13610."""
+    line = _SYMBOL_SHAPE.format(symbole="upsert_orphans_comment")
+    problems = check_assertion(FILES_13610, line)
+    assert problems == [], (
+        "the founding sentence of #13539 must pass the guard; got: "
+        + repr(problems)
+    )
+
+
+def test_13610_symbol_widening_keeps_positive_control_rouge():
+    """Acceptance line 2 of #13610, stated as a PAIR with the three tests
+    above: widening the tail class must NOT extinguish the positive control.
+    A fix that made the symbol cases pass by weakening the guard would pass
+    those three and fail this one -- which is the whole point of pinning it
+    here rather than relying on the older copy elsewhere in the file."""
+    problems = check_assertion(FILES_13610, "Cette PR ne touche qu'un fichier.")
+    assert problems, (
+        "the positive control must still rouge after the widening -- "
+        "3 files in the PR, assertion claims 1"
+    )
+
+
+def test_13610_symbol_widening_keeps_anonymous_referent_rouge():
+    """FN-safety, restated post-widening: widening WHAT counts as a named
+    referent must not turn an ANONYMOUS referent into a named one. #13612's
+    deliberate default-fail-loud on ambiguous shapes is untouched."""
+    line = (
+        "le generaliser demanderait d'editer un fichier deja porteur de "
+        "deux PRs ouvertes"
+    )
+    problems = check_assertion(FILES_13610, line)
+    assert problems, (
+        "an anonymous referent must keep the rouge after the widening"
+    )
+
+
+def test_13610_symbol_predicate_unit_pair():
+    """Direct unit test of the predicate on the two table rows, decoupled from
+    check_assertion so a pipeline change cannot mask a predicate regression --
+    same rationale as test_13610_predicate_unit_unanimous."""
+    files = FILES_13610
+    assert _word_form_is_indef_non_pr_subject(
+        _SYMBOL_SHAPE.format(symbole="upsert"), files
+    ) is True
+    assert _word_form_is_indef_non_pr_subject(
+        _SYMBOL_SHAPE.format(symbole="upsert_orphans"), files
+    ) is True
+    assert _word_form_is_indef_non_pr_subject(
+        _SYMBOL_SHAPE.format(symbole="upsert_orphans_comment"), files
+    ) is True
+    # The widening is about the TAIL of a dotted referent, nothing else:
+    # an anonymous referent stays False.
+    assert _word_form_is_indef_non_pr_subject(
+        "editer un fichier quelque part", files
+    ) is False
+
+
+# ---------------------------------------------------------------------------
 # #13637 -- carried-from-main files. GitHub's /pulls/N/files diffs base-tip ->
 # head, so a branch that merged main gets main's own changes attributed to it
 # (founder #13601: 04-7 showed +2708/-2708 although the PR did not touch it).


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA-2 — prev: DEEP/notebook-python #14243

## Résumé

`_NAMED_FILE_BODY` acceptait, après le point d'un jeton backtické, une queue `[A-Za-z0-9]+` — **qui exclut l'underscore**. Un renvoi `module.fonction`, la façon la plus courante de désigner du code dans un corps technique français, n'était donc pas « un référent nommé », et la branche FN-safety de #13612 maintenait le rouge sur la phrase **fondatrice de #13539 elle-même**.

`See #13610` — je livre la **sortie 1** de l'arbitrage posé par po-2024 le 02/09 00:08Z (étendre `_NAMED_FILE_BODY` aux symboles pointés), en gardant B et le contrôle positif comme paire de non-régression.

2 fichiers : l'organe et son fichier de tests.

## Le défaut, reproduit avant d'être corrigé

La frontière que tirait `[A-Za-z0-9]+` était arbitraire **et invisible** : deux orthographes du même renvoi de code donnaient deux verdicts opposés, sur la seule force d'un underscore.

| Ligne testée | Avant | Après |
|---|---|---|
| `` `pick_idle_grain.upsert` `` (queue sans underscore) | passe | passe |
| `` `pick_idle_grain.upsert_orphans` `` (queue **avec** underscore) | **ROUGIT** | passe |
| phrase entière de #13539 (`upsert_orphans_comment`) | **ROUGIT** | passe |
| `Cette PR ne touche qu'un fichier.` — contrôle positif | ROUGIT | **ROUGIT** |
| référent **anonyme** (rien de nommé) — FN-safety #13612 | ROUGIT | **ROUGIT** |

Sortie de la sonde à six cas après le fix : `les 6 cas sont conformes`. Les deux dernières lignes sont ce qui rend la première utile — un fix obtenu en affaiblissant le garde les aurait éteintes.

## Le changement est *exactement* l'underscore — mesuré, pas supposé

`r"(?:`([^`]+\.[A-Za-z0-9]+)`|"` → `r"(?:`([^`]+\.\w+)`|"`, une ligne. Diff des deux regex sur 7 jetons :

| Jeton | Avant | Après |
|---|---|---|
| `` `pick_idle_grain.upsert` `` | match | match |
| `` `pick_idle_grain.upsert_orphans` `` | — | **match** |
| `` `pick_idle_grain.upsert_orphans_comment` `` | — | **match** |
| `` `pick_idle_grain.py` `` | match | match |
| `` `la phrase.Ensuite` `` | match | match |
| `` `pandas.2` `` | match | match |
| `scripts/check_epic_charter.py` (branche nue) | match | match |

**Deux formes lâches passent** (`pandas.2`, prose backtickée avec un point) — elles passaient **déjà avant** : `Ensuite` et `2` sont alphanumériques. C'est du pré-existant, **pas un coût introduit ici**. Je le dis plutôt que de le taire : la mesure les a fait apparaître, et les attribuer à ce changement serait faux dans l'autre sens.

## Ce que le fix n'ouvre pas — voie de contournement testée

La crainte légitime d'un élargissement est qu'il permette d'éteindre un rouge légitime en glissant un jeton pointé dans la phrase. Testé :

| Forme adverse | Verdict |
|---|---|
| `Cette PR ne touche qu'un fichier, cf `numpy.array`.` | **ROUGIT** |
| référent pointé désignant un fichier **réellement dans la PR** | **ROUGIT** |

La branche d'exclusivité n'est pas atteinte par l'élargissement, et un référent en périmètre ne déclenche pas l'exemption. La voie de contournement est fermée.

## Non-regression a l'echelle de la flotte : 0 verdict change sur 60 PR ouvertes

`check_pr_perimeter.py` alimente un check **requis** sur toutes les PR : une regression y couterait un blocage generalise. Plutot que de l'affirmer, mesure directe -- les deux versions de l'organe chargees cote a cote, confrontees ligne a ligne aux corps des PR **reellement ouvertes** :

```
PRs ouvertes evaluees : 60   lignes de corps confrontees : 3321
verdicts qui CHANGENT entre main et le fix : 0
```

Aucun corps vivant ne bascule dans un sens ni dans l'autre. L'elargissement debloque la forme signalee et **ne touche rien d'autre de ce qui circule aujourd'hui** -- y compris les corps qui doivent rester rouges.

## Tests (6 ajoutés, 184 au total)

`pytest scripts/tests/test_check_pr_perimeter.py` → **184 passed** (dont `-k 13610` → 12 passed).

- `test_13610_symbol_referent_without_underscore_passes` — ligne 1 du tableau de l'acceptance, épinglée pour qu'un resserrage futur ne la reprenne pas par l'autre côté
- `test_13610_symbol_referent_with_underscore_passes` — ligne 2, la régression que le résiduel nomme
- `test_13610_founding_sentence_of_13539_passes` — acceptance 1, phrase réelle
- `test_13610_symbol_widening_keeps_positive_control_rouge` — acceptance 2, **épinglé ici** et pas seulement dans la copie plus ancienne du fichier : c'est la paire qui prouve le fix
- `test_13610_symbol_widening_keeps_anonymous_referent_rouge` — FN-safety de #13612 restatée après élargissement
- `test_13610_symbol_predicate_unit_pair` — test direct du prédicat, découplé de `check_assertion`, même raison que `test_13610_predicate_unit_unanimous`

## Ce qui reste ouvert — au coordinateur de trancher, pas à moi

`See`, pas `Closes`, parce que l'acceptance a **deux lectures** et que je ne choisis pas à la place du coordinateur :

- **Lecture D** (« la phrase de #13539 » = la phrase *réelle*, qui nomme le symbole dans la proposition précédente) : **tenue par cette PR**. C'est la lecture que po-2024 a mesurée et sur laquelle l'arbitrage a été posé.
- **Lecture A** (« la phrase de #13539 » = la forme *abrégée citée dans le body de l'issue*, au référent **anonyme**) : **non tenue**, et délibérément. po-2024 écrit : « Que le référent anonyme reste bloquant est un choix assumé de #13612 (FN-safety) — je ne le conteste pas. » Je ne le conteste pas non plus, et je ne l'ai pas touché.

Si la lecture D est retenue, l'issue est close par cette PR. Si c'est la lecture A, il reste à **requalifier l'acceptance** en actant que la forme anonyme reste hors périmètre — auquel cas le contournement « une cible » de #13539 devient permanent et mérite d'être dit, exactement comme po-2024 le formule.

## L898 — collision mesurée, non supposée

#14228 (`myia-po-2024:CoursIA`) touche le **même fichier**. Hunks comparés : #14228 porte sur les lignes 368 / 396 / 446 / 1047 / 1882 / 1950 / 2038 et, côté tests, en fin de fichier (3148) ; mon changement porte sur ~717 (organe) et ~2869 (tests). **Aucun recouvrement** — les deux PR restent mergeables dans un ordre quelconque. Signalé pour que le coordinateur n'ait pas à le redécouvrir.

## Note d'hygiène

`scripts/check_pr_perimeter.py` est en **LF** sur `main` alors que son fichier de tests est en CRLF. Une première écriture avait retourné tout le fichier en CRLF (4479 lignes de diff pour un changement d'une ligne) ; normalisé avant commit. Le diff livré est **17 insertions / 2 suppressions** sur l'organe (le `19` de `git diff --stat` est le total des lignes touchées, pas les insertions -- vérifié contre la sortie du garde lui-même : `17+/2-`).

Catalogue byte-identique à `main` (0 fichier touché).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
