### PR TITLE
feat(ci,#14201): stale-sweep sur coursia-linux + bootstrap gh en toolcache (#12728)

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -92,9 +92,13 @@ on:
     # them. Matching the cadence to the observed service time is what stops the
     # sweeps killing each other.
     #
-    # This does NOT fix the queue wait. The final timing step below measures the
-    # run-created -> job-started queue separately from observed execution time;
-    # #12728 requires that evidence before any further cadence or runner change.
+    # This does NOT fix the queue wait BY ITSELF. The cadence change stopped the
+    # sweeps killing each other; the wait itself is addressed by routing this
+    # job to the dedicated coursia-linux pool (see runs-on). The final timing
+    # step below keeps measuring the run-created -> job-started queue separately
+    # from observed execution time: #12728's acceptance is read on THAT step,
+    # post-routing (expected: queue collapses from ~6000-8000 s to near zero;
+    # cancellations from 19/30 to ~0).
     - cron: '7 * * * *'
   workflow_dispatch:
     inputs:
@@ -119,9 +123,52 @@ concurrency:
 jobs:
   sweep:
     name: Re-aggregate stale PR gate verdicts
-    runs-on: ubuntu-latest
+    # Routed to the self-hosted Linux pool (#14201 PART 2, #12728 acceptance) :
+    # this sweep is a 2-minute job that waited 1.6-2.2 h for a GitHub-hosted
+    # slot (98-99 % queue, measured on 30 runs, see #12728) and was cancelled
+    # 19/30 by its own successor -- the organ went quiet precisely under the
+    # congestion it exists to absorb. The coursia-linux pool is dedicated
+    # capacity (mandat user : consommer les runs conteneurises, ce sont les
+    # GitHub-hosted qui coutent), so the queue wait collapses at the source.
+    # Coupling assumed: a dead supervisor now starves this sweep too -- covered
+    # by TWO independent observers, linux-runner-starvation-advisory.yml
+    # (#14263, extinction/starvation) and pr-gate-sweep-health-advisory.yml
+    # (last successful sweep > 1 h, runs on ubuntu-latest so it survives what
+    # it watches).
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
     steps:
+      - name: Bootstrap gh into the persistent toolcache
+        # The coursia-linux image (#14171: ubuntu:24.04 + python3/jq/curl/git)
+        # deliberately does not ship gh, and this sweep is gh-driven. The
+        # binary is installed ONCE into the toolcache volume: the volume
+        # persists across ephemeral containers -- that is its purpose -- so
+        # every sweep after the first reuses it. No setup-python / pip here on
+        # purpose either: the image's python3 suffices, which keeps this sweep
+        # immune to the RUNNER_TOOL_CACHE bug class that broke Python tooling
+        # on mangled generations (2026-09-02) -- the bootstrap hardcodes the
+        # mount point and its worst case is a re-download, never a break.
+        env:
+          GH_BOOTSTRAP_VERSION: "2.80.0"
+        run: |
+          set -uo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            echo "[gh] preinstalled on this runner"
+            gh --version
+            exit 0
+          fi
+          GH_BIN="/opt/hostedtoolcache/bin/gh"
+          if [ ! -x "$GH_BIN" ]; then
+            VER="${GH_BOOTSTRAP_VERSION}"
+            echo "[gh] bootstrapping v${VER} into toolcache (one-time, cached for every later sweep)"
+            curl -fsSL "https://github.com/cli/cli/releases/download/v${VER}/gh_${VER}_linux_amd64.tar.gz" -o /tmp/gh.tgz
+            tar -xzf /tmp/gh.tgz -C /tmp
+            mkdir -p /opt/hostedtoolcache/bin
+            mv "/tmp/gh_${VER}_linux_amd64/bin/gh" "$GH_BIN"
+          fi
+          echo "/opt/hostedtoolcache/bin" >> "$GITHUB_PATH"
+          "$GH_BIN" --version
+
       # No checkout / setup-python / pip here on purpose. This sweep no longer
       # runs `pr_gate.py`: it re-runs the original workflow run (see the note in
       # the re-aggregation step). That removes ~40 s of runner time per sweep,

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -51,10 +51,20 @@ def _extract_selector() -> str:
     ce qui est teste est ce que GitHub rend, convention test_workflow_expression_escapes)."""
     with open(WORKFLOW, encoding="utf-8") as f:
         doc = yaml.safe_load(f)
-    run = doc["jobs"]["sweep"]["steps"][0]["run"]
-    m = re.search(r"python - <<'PY'[^\n]*\n(.*?)\nPY\n", run, re.S)
-    assert m, "heredoc python introuvable dans pr-gate-stale-sweep.yml"
-    return m.group(1)
+    # Le heredoc est localise par contenu, pas par index : une etape
+    # d'amorcage (bootstrap gh, #14267) precede desormais le selecteur sans
+    # que ce contrat doive bouger.
+    for step in doc["jobs"]["sweep"]["steps"]:
+        m = re.search(
+            r"python - <<'PY'[^\n]*\n(.*?)\nPY\n",
+            str(step.get("run", "")),
+            re.S,
+        )
+        if m:
+            return m.group(1)
+    raise AssertionError(
+        "heredoc python introuvable dans pr-gate-stale-sweep.yml"
+    )
 
 
 SELECTOR = _extract_selector()

--- a/scripts/tests/test_pr_gate_sweep_timing.py
+++ b/scripts/tests/test_pr_gate_sweep_timing.py
@@ -25,8 +25,16 @@ JOB_NAME = "Re-aggregate stale PR gate verdicts"
 def _extract_instrument() -> str:
     with WORKFLOW.open(encoding="utf-8") as stream:
         document = yaml.safe_load(stream)
-    step = document["jobs"]["sweep"]["steps"][1]
-    assert step["if"] == "always()"
+    # L'instrument de timing est l'unique etape `if: always()` -- localisee
+    # par contenu, pas par index (une etape d'amorcage precede desormais le
+    # selecteur, #14267).
+    candidates = [
+        s
+        for s in document["jobs"]["sweep"]["steps"]
+        if s.get("if") == "always()"
+    ]
+    assert len(candidates) == 1, "expected exactly one if: always() step"
+    step = candidates[0]
     run = step["run"]
     assert "jobs?filter=latest&per_page=100" in run
     assert "jobs?filter=all" not in run


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/guard #14263

# Stale-sweep sur `coursia-linux` + bootstrap gh en toolcache (#14201 PART 2, acceptance #12728)

`See #14201` — la partie restante après #14242 (tranche 2 triggers) : router `pr-gate-stale-sweep.yml` sur le pool self-hosted et porter la mesure d'acceptance #12728. GO ai-01 (msg-20260902T082738 : « d'accord pour la queue, et ton constat que le sweep n'utilise pas setup-python donc est immune au bug toolcache est exactement le genre de chose qui mérite d'être écrit avant d'être utile » — écrit ci-dessous).

## Le défaut mesuré (#12728, non estimé)

Le sweep est **un job de 2 minutes qui attendait 1,6 à 2,2 heures un runner GitHub-hosted** :

```
file= 7832 s   execution= 110 s   total= 7942 s   (99 % d'attente)
file= 5823 s   execution= 122 s   total= 5945 s   (98 % d'attente)
```

Conséquence : 19/30 runs `cancelled` (durée de vie médiane 1228 s = exactement un intervalle de cron) — l'organe qui répare les `PR gate` périmés se taisait précisément sous la congestion qui les produit. La bascule horaire (déjà sur main) a arrêté les sweeps de s'entre-tuer ; **cette PR attaque l'attente elle-même** en routant vers le pool dédié `coursia-linux` (8 slots self-hosted post-redémarrage, mandat user : consommer les runs conteneurisés — ce sont les GitHub-hosted qui coûtent).

## Ce que la PR change (3 fichiers)

1. **`runs-on: [self-hosted, coursia-ephemeral, coursia-linux]`** — même forme que les 11 workflows routés par #14148. Pas de garde fork nécessaire : ce workflow est `schedule`/`workflow_dispatch` uniquement, jamais déclenché par une PR.
2. **Étape « Bootstrap gh into the persistent toolcache »** — l'image #14171 (ubuntu:24.04 + python3/jq/curl/git) ne porte volontairement pas `gh`, et ce sweep est gh-driven. Le binaire (pin `2.80.0`, URL vérifiée résoudre) s'installe **une fois** dans le volume toolcache — le volume persiste entre conteneurs éphémères, c'est sa raison d'être — puis chaque sweep suivant le réutilise via `GITHUB_PATH`. Garde `command -v gh` d'abord : no-op sur tout runner qui aurait déjà gh.

## L'immunité toolcache, écrite (le point demandé par ai-01)

Ce sweep n'utilise **ni `setup-python` ni pip** — le `python3` de l'image suffit (il n'exécute que des scripts stdlib inline). Il est donc **immunisé contre la classe du bug RUNNER_TOOL_CACHE** qui a cassé l'outillage Python sur les générations manglées du 2026-09-02 : le bootstrap code en dur le point de montage `/opt/hostedtoolcache` et son pire cas est un re-téléchargement par conteneur, jamais une rupture. (Le fix MSYS racine est par ailleurs déployé et mesuré ce cycle : `RUNNER_TOOL_CACHE=/opt/hostedtoolcache` ×4, msg-20260902T085802.)

## Couplage assumé et couvert

Router le sweep le rend dépendant de la santé des runners. Deux observateurs indépendants couvrent : `linux-runner-starvation-advisory.yml` (#14263, extinction/starvation, `ubuntu-latest`) et `pr-gate-sweep-health-advisory.yml` (dernier sweep réussi > 1 h, `ubuntu-latest` — survit à ce qu'il observe, et son alarme couvre désormais la mort de runners comme cause). Si tout le pool meurt : le sweep cale, l'advisory sweep-health rougit en ≤ 1 h, la starvation advisory en ≤ 30 min.

## Acceptance #12728 — portée par l'étape timing existante

Le workflow mesure déjà file vs exécution à chaque run (étape finale, job-level timestamps). Attendu post-merge, lu sur les prochains runs : **file ~6000-8000 s → ~0-60 s ; cancellations 19/30 → ~0**. Je posterai la mesure sur #12728 après quelques runs post-merge.

## Validation

- `bash -n` sur le bloc bootstrap extrait → exit 0.
- `python scripts/ci/check_self_hosted_runner_policy.py` → `self_hosted=15` (le sweep est le 15ᵉ), `OK` exit 0 — ses triggers `schedule`/`workflow_dispatch` passent le policy gate.
- URL du tarball gh 2.80.0 : HTTP 302 (redirect asset, sain).
- YAML re-sérialisé et relu : 3 étapes dans l'ordre (bootstrap → sweep → timing).

## Genre / tier

**`guard` (META)** — ne tient pas le plancher G-VAR-1, side-track de l'arc URGENT #13378. Le plat principal du cycle reste la remédiation runners (redémarrage N=4 + persistance + mesures). Domaine-cœur de la lane (CI/infra) : 2ᵉ `guard` MED consécutif, substances distinctes (#14263 = nouvel organe de mesure ; celle-ci = routage d'un organe existant).

## Périmètre : 3 fichiers

- `.github/workflows/pr-gate-stale-sweep.yml` (+51 / −4)
- `scripts/tests/test_pr_gate_sweep_select.py`
- `scripts/tests/test_pr_gate_sweep_timing.py`

## Preuve d'identité

- Branche `feature/14201-sweep-selfhosted`, base `origin/main` (`0a4b7a5ce3`), 1 commit `399e687520`.
- `[CLAIMED] paths:` posé sur #14201 avant push ([comment](https://github.com/jsboige/CoursIA/issues/14201#issuecomment-5507285228)).

