### PR TITLE
fix(slides,#13224): 04-probabilites -- 2 figures sortaient de la slide

### DIFF
--- a/slides/04-probabilites/slides.md
+++ b/slides/04-probabilites/slides.md
@@ -670,8 +670,8 @@ layout: two-cols
 ::right::
 
 
-<img src="./images/img_025.png" width="380">
-<img src="./images/img_026.png" width="380">
+<img src="./images/img_025.png" width="240">
+<img src="./images/img_026.png" width="250">
 
 
 
@@ -1510,9 +1510,9 @@ layout: two-cols
 ::right::
 
 
-<img src="./images/img_085.png" width="420">
-<img src="./images/img_086.png" width="420">
-<img src="./images/img_087.png" width="420">
+<img src="./images/img_085.png" width="270">
+<img src="./images/img_086.png" width="270">
+<img src="./images/img_087.png" width="270">
 
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #14241

See #13224 (tranche 5 — `04-probabilites`).

## Ce qui était cassé

Deux slides de `04-probabilites` laissaient une partie de leur figure **hors de la slide**, invisible à la projection. Mesuré au rendu (Playwright headless sur le dev server, pas au diff) :

| Slide | Bas de la pile d'images | Hauteur de slide | Débordement |
|---|---|---|---|
| 39 — *Réseau bayésien hybride* | 976 px | 721 px | **255 px** |
| 94 — *Fonctions d'utilité* | 934 px | 721 px | **213 px** |

Ce que le public ne voyait pas :

- **Slide 39** : le graphe des relations entre distributions était tranché sous la boîte `Exponential`, dont la flèche λ ne menait à rien. **Lognormal, Gamma, Poisson, Normal** et leurs arêtes λ/τ/μ/β étaient entièrement sous le bord.
- **Slide 94** : la troisième image (`img_087`) — l'inégalité de dominance stochastique `∀x ∫p₁ ≤ ∫p₂`, qui donne son sens à la slide — n'était **pas rendue du tout**, et le graphe de probabilités au-dessus était coupé sous l'axe.

## Cause

`layout: two-cols` + `::right::` avec des images empilées à largeur fixe. La somme des hauteurs dépasse la colonne :

- slide 39 : `380 → 182 + 537 = 719 px` pour ~492 px disponibles ;
- slide 94 : trois `width="420"` clampées à la colonne de 396 px → `290 + 294 + 103 = 687 px`.

## Le correctif

Cinq attributs `width`, choisis pour que la somme des hauteurs tienne dans la colonne. Ils tombent au passage **à la résolution native des PNG** : les images cessent d'être upscalées, donc elles gagnent en netteté en même temps qu'elles redeviennent visibles.

| Image | Avant | Après | Natif | Facteur |
|---|---|---|---|---|
| `img_025` | 380 | 240 | 230 | 1,65× → **1,04×** |
| `img_026` | 380 | 250 | 384 | 0,99× → **0,65×** |
| `img_085` | 420 (clampé 396) | 270 | 267 | 1,48× → **1,01×** |
| `img_086` | 420 (clampé 396) | 270 | 250 | 1,58× → **1,08×** |
| `img_087` | 420 (clampé 396) | 270 | 288 | 1,37× → **0,94×** |

## Vérification — par instance, au rendu

Le critère de #13224 est explicite : « vérifier chaque slide au rendu, pas au diff. Une même transformation peut améliorer une slide et en détruire une autre ».

- **39** : bas 976 → **648** px. Graphe complet visible, vérifié à l'écran.
- **94** : bas 934 → **650** px. Les **trois** images rendues, `img_087` incluse.
- **36 / 85 / 101** — non modifiées, re-mesurées comme témoins : bas 566 / 209 / 685, inchangées. Pas de régression.

Contrôle positif **armé** (`--baseline-slide 36`) : le premier passage tournait sans, et le scanner le disait lui-même — « rien à signaler » y était indistinguable d'un chemin de flagging mort. C'est exactement ce que #13223 existe pour empêcher, donc la mesure retenue ici est celle du second passage.

## Mesure du scanner, avant / après

`scan_slidev_composition.py` sur les 116 slides, même deck, même URL :

| | avant | après |
|---|---|---|
| `n_hors_canvas` | **2** | **0** |
| `n_chevauchements` | 0 | 0 |
| `n_occupation_flagged` | 28 | 28 *(inchangé — voir plus bas)* |
| `controle_positif_armed` | `false` | **`true`** |
| `controle_positif_ok` | `null` | **`true`** |

Code de sortie **1** (constats résiduels), pas 2 : l'instrument est sain, ce sont les 28 OCCUPATION qui restent.

Le compte `n_hors_canvas` vaut 2 alors que quatre slides portent des entrées brutes (39, 85, 94, 101) : le scanner ne compte que les débordements **visibles**, et écarte les boîtes CSS dont le dépassement ne l'est pas. Les deux qu'il comptait sont exactement 39 et 94 — corroboration indépendante de la lecture faite ici, puisque 85 et 101 ont leurs images à 209 et 685 px, dans la slide.

## Constat rapporté, pas « corrigé » : OCCUPATION sur `two-cols`

Le scan signale **28 slides** en OCCUPATION, toutes à `gap_left_pct = 55,6 %`. Trois d'entre elles ont été vérifiées au rendu (36, 85, 101) : **aucune n'est défectueuse**. La bande gauche est vide *d'images* parce qu'elle porte le **texte** — c'est l'intention de `two-cols`.

Le signal OCCUPATION a été calibré sur S3, un deck en `image-overlay`/`absolute`. Sur un deck `two-cols` il produit un faux positif systématique. Je le **signale** sans y toucher : 3 slides sur 28 ont été vérifiées, ce qui ne suffit pas à conclure pour les 25 autres, et re-calibrer le signal est un sujet distinct de cette tranche.

Les deux vrais défauts ont été trouvés par HORS_CANVAS, pas par OCCUPATION.

## Hors périmètre

- **Le thème `theme-ia101` n'est pas touché** : 15 decks en dépendent, et une règle CSS globale sur `img` est précisément la « même transformation » dont #13224 dit qu'elle peut réparer une slide et en casser une autre.
- **Les 14 autres decks ne sont pas mesurés** — ils ne sont donc pas déclarés sains. La claim est amendée à `paths: slides/04-probabilites/slides.md` pour les laisser libres.

`See #13224` et non `Closes` : l'acceptance porte sur l'ensemble des decks.
