### PR TITLE
fix(merge-gate,#13904): re-appliquer l'alias Hermes/NanoClaw cross-login sur main

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -132,6 +132,27 @@ AGENT_PREFIXES = (
 # « overrides » jsboige 02:40/02:41 ; classe #12798, l'auto-levee). L'arbitre
 # tiers de B.0 est la lane coordinateur dediee, et elle seule.
 LIFT_OVERRIDE_LOGINS = {"myia-ai-01"}
+# #13609 -- alias de persona Hermes/NanoClaw cross-login. La persona de
+# reviewer Hermes parle sous DEUX logins -- clusterManager-Myia (reviewer
+# principal) et jsboige (self-bot). Quand elle pose une reserve sous l'un
+# puis leve sous l'autre, sa propre levee n'etait pas creditee par
+# `_lift_eligible` (borne d'auteur stricte #11145 / #12836), et la reserve
+# restait vivante : aucun geste de la lane ne pouvait la lever hors
+# `[OVERRIDE]` coordinateur (coûteux, exige re-verif tierce, ne s'applique
+# pas sur PR lane-coordinateur -- cf #13316). La composition des deux
+# decisions est juste ; seule leur intersection est un faux negatif.
+#
+# On declare donc que les deux logins sont la MEME persona au sens de la
+# borne d'auteur, mais UNIQUEMENT quand le corps du lifter porte un marqueur
+# explicite `[Hermes]` / `[NanoClaw]` / `[Hermes self-bot]`. Sans marqueur,
+# `jsboige` reste l'identite de poussee partagee des lanes (#13316) et un
+# commentaire sans marqueur ne leve rien. LIFT_OVERRIDE_LOGINS reste
+# inchange : un override `[OVERRIDE]` jsboige n'entre pas, alias de persona
+# != droit d'override coordinateur.
+PERSONA_ALIAS_LOGINS = {"clusterManager-Myia"}
+_PERSONA_MARKERS_RE = re.compile(
+    r"(?m)(?:^|\s)\[(?:Hermes|NanoClaw|Hermes self-bot)(?:\s+[^\]]*)?\]"
+)
 # #13030 -- le marqueur doit etre POSE, pas CITE. L'ancien pattern sans
 # ancre matchait n'importe quelle mention dans le corps : le commentaire de
 # la lane #12872 qui DOCUMENTAIT l'option « (b) `[OVERRIDE] lane x` par
@@ -2095,6 +2116,20 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
     def _lift_eligible(lift_author: str, nit_author: str,
                        lift_body: str = "") -> bool:
         if lift_author == nit_author:
+            return True
+        # #13609 -- alias de persona Hermes/NanoClaw cross-login. La persona
+        # parle sous clusterManager-Myia ET jsboige. Quand elle leve SA
+        # propre reserve sous l'autre login, c'est sa levee. Le marqueur
+        # `[Hermes]` / `[NanoClaw]` / `[Hermes self-bot]` dans le corps
+        # identifie la source ; l'autre cote de l'alias est dans
+        # `PERSONA_ALIAS_LOGINS` (= clusterManager-Myia) pour eviter qu'une
+        # lane (qui pousse sous jsboige) s'auto-promeuve en collant le
+        # marqueur dans un commentaire ordinaire. Les deux conditions sont
+        # obligatoires : sans marqueur, jsboige reste l'identite de poussee
+        # partagee des lanes (#13316), rien n'est leve.
+        if (lift_author == "jsboige"
+                and nit_author in PERSONA_ALIAS_LOGINS
+                and _PERSONA_MARKERS_RE.search(lift_body or "")):
             return True
         # #13495 — la trappe coordinateur ci-dessous ne s'ouvre pas pour
         # l'auteur de la PR : sinon la voie 3 (report par issue nommee) serait

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -658,6 +658,95 @@ def test_channel_reflects_origin_surface():
     assert run([], threads=[thread])["blocking"][0]["channel"] == "review"
 
 
+
+# --- #13609 : alias de persona Hermes/NanoClaw cross-login. La persona
+# reviewer parle sous deux logins (clusterManager-Myia + jsboige self-bot).
+# Quand elle leve SA propre reserve sous l'autre login en portant un
+# marqueur explicite `[Hermes]` / `[NanoClaw]` / `[Hermes self-bot]`, c'est
+# sa levee -- la borne d'auteur stricte #11145/#12836 etait un faux negatif
+# structurel : la reserve restait vivante, et seul un `[OVERRIDE]`
+# coordinateur (coûteux, exige re-verif tierce, ne s'applique pas sur PR
+# lane-coordinateur) pouvait la fermer. Le marqueur est obligatoire :
+# sans lui, jsboige reste l'identite de poussee partagee des lanes (#13316)
+# et rien n'est leve -- une lane ne peut pas s'auto-promeuve en collant
+# le marqueur dans un commentaire ordinaire.
+
+
+def test_persona_alias_cross_login_leves_own_reserve():
+    """#13609 cas fondateur : reserve posee par clusterManager-Myia, levee
+    par un commentaire jsboige marque `[Hermes]` -- c'est la meme persona,
+    la levee est creditee, l'organe rend vert. PR par jsboige (cas le plus
+    frequent : lanes poussent sous jsboige)."""
+    reserve = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "COMMENTED", "submittedAt": at(10),
+        "body": "[Hermes] - COMMENT_WITH_CONCERNS\nCI catalog-drift FAIL.",
+    }
+    # Le lift doit etre un COMMENTAIRE (pas un verdict BOT) avec phrase de
+    # levee explicite ; le marqueur `[Hermes]` identifie la persona, le corps
+    # ne porte pas le mot CHANGES_REQUESTED (sinon classify le rendrait
+    # BOT-CONCERN et le filtre l'ecarterait avant _lift_eligible).
+    lift = {
+        "author": {"login": "jsboige"}, "createdAt": at(12),
+        "body": ("[Hermes] Je leve le concern -- drift corrige "
+                 "au commit c506d04b."),
+    }
+    res = run([lift], reviews=[reserve])
+    assert res["blocked"] is False
+
+
+def test_persona_alias_lift_without_marker_does_not_leve():
+    """#13609 controle negatif : sans marqueur `[Hermes]`/`[NanoClaw]`/`[Hermes
+    self-bot]`, le commentaire jsboige ne leve pas -- c'est l'identite de
+    poussee partagee des lanes (#13316), l'auteur de la reserve est distinct
+    (clusterManager-Myia), le predicat d'alias ne s'applique pas. La
+    protection #13316 tient."""
+    reserve = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "COMMENTED", "submittedAt": at(10),
+        "body": "[Hermes] - COMMENT_WITH_CONCERNS\nCI catalog-drift FAIL.",
+    }
+    lift = {
+        "author": {"login": "jsboige"}, "createdAt": at(12),
+        "body": ("Je leve la CHANGES_REQUESTED -- drift corrige "
+                 "au commit c506d04b."),
+    }
+    res = run([lift], reviews=[reserve])
+    assert res["blocked"] is True
+
+
+def test_persona_alias_only_when_reserve_author_is_in_alias_set():
+    """#13609 garde anti-usurpation : l'alias ne s'active que quand
+    `nit_author` est dans `PERSONA_ALIAS_LOGINS` (= clusterManager-Myia).
+    Une lane qui pousserait sous jsboige ne peut pas eteindre la reserve
+    d'un AUTRE reviewer (ex. ai-01) en collant le marqueur `[Hermes]` dans
+    un commentaire ordinaire -- l'alias est bidirectionnel uniquement entre
+    la persona Hermes et son self-bot, pas une cle d'auto-levee."""
+    reserve = {
+        "author": {"login": "myia-ai-01"},
+        "state": "COMMENTED", "submittedAt": at(10),
+        "body": "CHANGES_REQUESTED : notebook non execute.",
+    }
+    lift = {
+        "author": {"login": "jsboige"}, "createdAt": at(12),
+        "body": ("[Hermes] Je leve le concern de ai-01 -- la lane a "
+                 "re-execute, EXEC_PROVED au commit abc."),
+    }
+    res = run([lift], reviews=[reserve])
+    assert res["blocked"] is True
+
+
+def test_persona_alias_lift_override_logins_unchanged():
+    """#13609 controle structurel : `LIFT_OVERRIDE_LOGINS` reste inchange.
+    L'alias de persona NE confere PAS un droit d'override coordinateur : un
+    `[OVERRIDE] lane` sous jsboige ne leve pas (cf ligne de garde dans
+    `_lift_eligible`). La composition des deux decisions #11145 (borne
+    d'auteur) et #13316 (exclusion jsboige) tient, l'alias est strictement
+    une troisieme voie pour le dialogue Hermes <-> Hermes self-bot."""
+    assert "jsboige" not in mod.LIFT_OVERRIDE_LOGINS
+    assert mod.LIFT_OVERRIDE_LOGINS == {"myia-ai-01"}
+
+
 # --- #11201 : le faux negatif « corrige X et je merge ». Le test LIFT_MARKERS
 # passait AVANT toute recherche de reserve, et « je merge » couvre deux sens
 # opposes : « c'est bon, je merge » (annonce, levant) et « Change la ligne 19


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: HEAVY/consolidation #14268 (cycle 176)

## Summary

Réparation de la PR #13904 (DIRTY, age 67h, mergeable=CONFLICTING avec main) signalée par ai-01 dans son DM du 02/09 à 10:11Z (msg-20260902T081157-4fy6sr) :

> **#13904** (`fix(merge-gate,#13609): alias de persona Hermes/NanoClaw cross-login`) — **DIRTY** aussi, même traitement.

Le commit original `5c1769f1e` ajoute l'alias de persona Hermes/NanoClaw cross-login dans `_lift_eligible` mais ne mergait plus sur main à cause d'un conflit dans `scripts/tests/test_check_unaddressed_nits.py`. La branche upstream main avait déjà intégré d'autres tests (notamment la gate #11201 sur le faux négatif « corrige X et je merge ») au même endroit.

## Approche : fresh-branch + cherry-pick equivalent

Plutôt qu'un `git rebase origin/main` interactif (qui produit un fichier test corrompu de 6715 lignes en sortie de l'auto-merge), j'ai opté pour :

1. `git checkout origin/main -b fix/13904-on-main`
2. `git format-patch -1 5c1769f1e` puis `git apply --3way <patch>` — succès sur `scripts/check_unaddressed_nits.py` (35 insertions)
3. Pour `scripts/tests/test_check_unaddressed_nits.py` : `git checkout HEAD -- <file>` puis insertion manuelle des 4 nouveaux tests au marqueur `# --- #11201` (ligne 661) en respectant la syntaxe Python verbatim

## Diff

| Fichier | Avant (commit 5c1769f1e original) | Cette PR | Notes |
|---|---|---|---|
| `scripts/check_unaddressed_nits.py` | +35 | +35 | `git apply --3way` propre |
| `scripts/tests/test_check_unaddressed_nits.py` | +89 | +89 | réinsertion manuelle, AST parse OK |
| **Total** | **+124** | **+124** | bit-équivalent au commit original sur le contenu |

## Tests ajoutés (4)

| Test | Rôle |
|---|---|
| `test_persona_alias_cross_login_leves_own_reserve` | Cas fondateur : reserve clusterManager-Myia levée par jsboige marquant `[Hermes]` → vert |
| `test_persona_alias_lift_without_marker_does_not_leve` | Contrôle négatif : sans marqueur `[Hermes]`, jsboige ne lève pas (protection #13316 tient) |
| `test_persona_alias_only_when_reserve_author_is_in_alias_set` | Garde anti-usurpation : alias bidirectionnel uniquement entre Hermes et son self-bot, pas une clé d'auto-levée |
| `test_persona_alias_lift_override_logins_unchanged` | Contrôle structurel : `LIFT_OVERRIDE_LOGINS` reste `{"myia-ai-01"}` (alias de persona ≠ droit d'override coordinateur) |

## Validations

- `pytest scripts/tests/test_check_unaddressed_nits.py -q` → **270 passed in 0.54s**
- AST parse sur le test file → OK
- `check_unaddressed_nits.py` : constante `PERSONA_ALIAS_LOGINS = {"clusterManager-Myia"}` + helper `_PERSONA_MARKERS_RE` + branche dans `_lift_eligible` (lift jsboige + nit_author dans PERSONA_ALIAS_LOGINS + match du marqueur → levée)

## Décisions-clés

**Fresh-branch plutôt que rebase interactif** : le conflit sur le test file est un *overlapping hunks* classique — main et la branche ont tous deux ajouté du contenu au même endroit, mais avec des contextes différents (gate #11201 côté main, gate #13609 côté #13904). Le merge auto de git produit un fichier valide au sens git mais sémantiquement cassé (lignes dupliquées, ordre incohérent). Re-ancrer sur HEAD main + réinsérer au bon marqueur est plus rapide et plus sûr.

**Pas de modification du contenu substantif** : le but est de merger le travail déjà écrit de la PR originale. Les 124 insertions sont identiques au commit original `5c1769f1e` ; seule la **manière de les obtenir** change (rebase vs fresh-branch + apply).

**Tests verts comme garde anti-régression** : 270 tests passent, dont les 4 nouveaux + tous les anciens. Aucune suppression de test (cf. `anti-regression.md`).

## Liens

- PR originale DIRTY : #13904 (cycle 37, age 67h)
- Commit original : `5c1769f1e` sur `cycle-37-pioche`
- Issue parente : #13609 (alias de persona Hermes/NanoClaw cross-login)
- PR bénéficiaire c.176 : #14268 (réparation #13831, HEAVY/consolidation)
- DM ai-01 10:11Z : msg-20260902T081157-4fy6sr (« #13904 te revient vraiment »)
- DM ai-01 10:43Z : msg-20260902T084329-ah5sdf (« ton grain de ce cycle n'est pas un grain neuf »)
- Convention : `.claude/rules/git-workflow.md`, `.claude/rules/anti-regression.md` (cherry-pick = préserver le travail existant)
