### PR TITLE
refactor(bridges,#14051): cabler pymc_enumerate sur l'organe canonique pymc_causal_organs

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/__init__.py
@@ -31,14 +31,16 @@ natifs, faute de cible importable. L'etat reel, adaptateur par adaptateur :
   et que le notebook lui-meme consomme (PR #14076, #14092). Verrouille par
   ``ict/tests/test_bridges_canonical_wiring.py`` : identite d'objet,
   ``__module__``, absence de redefinition dans la source.
-- :mod:`~ict.bridges.pymc_enumerate` -- **copies declarees, encore**. Detient
-  toujours des reproductions byte-identiques de ``enumerate_scm`` (cellule 5)
-  et ``p_y_given_m_x`` (cellule 20) de ``PyMC-05-Causal-Inference.ipynb``. La
-  cible importable ``pymc_causal_organs.py`` est portee par la PR #14133 ; le
-  cablage suivra son merge. Tant que ce point n'est pas ferme, la verification
-  cross-engine de cet adaptateur compare ``ict.causal_attribution`` a une
-  reproduction de l'organe, et non a l'organe -- un changement d'estimateur
-  dans PyMC-05 la laisserait verte.
+- :mod:`~ict.bridges.pymc_enumerate` -- **cablage canonique**. Importe
+  ``enumerate_scm`` (cellule 5), ``p_y_given_m_x`` et ``FRONT_SCM``
+  (cellule 20) depuis ``pymc_causal_organs``, le module qui vit a cote de
+  ``PyMC-05-Causal-Inference.ipynb`` (PR #14133, mergee). ``FRONT_DOOR_SCM``
+  survit comme **alias** du meme objet : c'est le nom que consomme
+  ``ict/tests/test_bridges.py``. Verrouille par les memes gates que
+  l'adaptateur ci-dessus (identite d'objet, ``__module__``, absence de
+  redefinition dans la source), plus un gate propre au SCM -- une table de
+  CPT recopiee ne se voit ni dans un ``def`` ni dans ``__module__``, donc
+  seule l'identite d'objet peut l'attraper.
 
 Inventaire des estimateurs exposes par organe natif (mesure c.293) :
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/pymc_enumerate.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridges/pymc_enumerate.py
@@ -22,110 +22,76 @@ P(Y=1 | do(X=1)) - P(Y=1 | do(X=0)) par enumeration, puis le compare a
 tire du meme SCM (pour verifier que les deux estimateurs convergent sur
 la meme cible d'intervention).
 
-Pourquoi pas de reexecution ?
------------------------------
-Les fonctions ``enumerate_scm`` et ``p_y_given_m_x`` sont **internes au
-notebook** (cell-scoped) ; on les reproduit ici en copiant leur corps
-(anti-regression : regle D -- pas de duplication du code reel, mais
-ici on **redeclare** des fonctions pedagogiques du notebook pour les
-rendre testables en module ; le code est byte-identique a la cellule
-source, ce qui est le pattern autorise pour les notebooks non-importables).
+Cablage sur l'organe canonique (issue #14051, tranche 4)
+--------------------------------------------------------
+Ce module a longtemps porte des reproductions byte-identiques de
+``enumerate_scm`` (cellule 5) et ``p_y_given_m_x`` (cellule 20), au motif
+que ces fonctions etaient **internes au notebook** (cell-scoped) donc
+inaccessibles a un ``import``. Le diagnostic etait juste ; il a cesse de
+l'etre quand la PR #14133 a extrait ``Probas/PyMC/pymc_causal_organs.py``,
+le module qui vit a cote de ``PyMC-05-Causal-Inference.ipynb`` et que le
+notebook lui-meme consomme.
+
+Le defaut que la copie entretenait n'etait pas le rangement mais le
+**cablage du verdict** : cet adaptateur porte le nom de *cross-engine
+verification* et comparait :mod:`ict.causal_attribution` non pas a l'organe
+natif, mais a une reproduction de cet organe. Consequence mecanique --
+enoncee par ``bridges/__init__.py`` avant meme d'etre corrigee : un
+changement d'estimateur dans PyMC-05 aurait laisse ce pont **vert**.
+
+Les trois organes sont desormais **importes** ; le pont et le notebook
+designent le meme objet. Verrouille par
+``ict/tests/test_bridges_canonical_wiring.py`` (gates W7-W12 : identite
+d'objet, ``__module__``, absence de redefinition dans la source).
+
+``FRONT_DOOR_SCM`` reste expose comme **alias** de ``FRONT_SCM`` : le nom
+est consomme par ``ict/tests/test_bridges.py`` et le renommer aurait ete un
+churn sans rapport avec le cablage. L'alias designe l'objet canonique, donc
+une derive des CPT du notebook se propage ici aussi.
 """
 
 from __future__ import annotations
 
-import itertools
-from typing import Callable, Dict, List, Optional, Sequence, Tuple  # noqa: F401
+import sys
+from pathlib import Path
+from typing import Dict, Tuple  # noqa: F401
 
 import numpy as np
 
 from ict import causal_attribution as ca
 
-
 # ---------------------------------------------------------------------------
-# Copie byte-identique de enumerate_scm (cellule 5 PyMC-05)
+# Organe natif canonique : le module qui vit a cote de PyMC-05-Causal-Inference
 # ---------------------------------------------------------------------------
-def enumerate_scm(
-    nodes: Sequence[Tuple[str, Callable]],
-    query: str,
-    evidence: Optional[Dict[str, bool]] = None,
-    do_vars: Optional[Dict[str, bool]] = None,
-) -> float:
-    """Inference exacte par enumeration sur un SCM booleen.
+# `pymc_causal_organs` n'est pas un package installable -- c'est un module pose
+# a cote de son notebook, pour que le notebook ET les tiers consomment le meme
+# objet. Le pont traverse donc l'arbre pour l'atteindre.
+#
+#   pymc_enumerate.py -> bridges -> ict -> ICT-Series -> IIT -> MyIA.AI.Notebooks
+#                                                               ^ parents[4]
+_PYMC_DIR = Path(__file__).resolve().parents[4] / "Probas" / "PyMC"
+if str(_PYMC_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYMC_DIR))
 
-    Parameters
-    ----------
-    nodes : sequence of (nom, proba_true_fn)
-        Liste ordonnee topologiquement. ``proba_true_fn(assign)`` renvoie
-        ``P(nom=True | parents)`` en lisant les parents dans ``assign``.
-    query : str
-        Nom du noeud dont on veut ``P(query=True)``.
-    evidence : dict or None
-        ``{nom: bool}`` : variables **observees** (conditionnement, niveau 1).
-    do_vars : dict or None
-        ``{nom: bool}`` : variables **intervenues** (mutilation, niveau 2).
+from pymc_causal_organs import (  # noqa: E402  (import differe : sys.path ci-dessus)
+    FRONT_SCM,
+    enumerate_scm,
+    p_y_given_m_x,
+)
 
-    Returns
-    -------
-    float
-        ``P(query=True | evidence, do(do_vars))``.
+# Le SCM front-door de la cellule 20, sous le nom historique de ce pont.
+# C'est le MEME objet que `pymc_causal_organs.FRONT_SCM` (pas une copie).
+FRONT_DOOR_SCM = FRONT_SCM
 
-    Notes
-    -----
-    Byte-identique a PyMC-05 cellule 5 ; voir commentaire du module pour
-    la justification de la copie (organe notebook non-importable).
-    """
-    evidence = evidence or {}
-    do_vars = do_vars or {}
-    names = [n for n, _ in nodes]
-    num = 0.0
-    den = 0.0
-    for bits in itertools.product([False, True], repeat=len(names)):
-        assign = dict(zip(names, bits))
-        if any(assign[k] != v for k, v in do_vars.items()):
-            continue
-        if any(assign[k] != v for k, v in evidence.items()):
-            continue
-        p = 1.0
-        for name, fn in nodes:
-            if name in do_vars:
-                continue
-            pt = fn(assign)
-            p *= pt if assign[name] else (1.0 - pt)
-        den += p
-        if assign[query]:
-            num += p
-    return num / den if den > 0 else float("nan")
-
-
-def p_y_given_m_x(
-    nodes: Sequence[Tuple[str, Callable]],
-    mval: bool,
-    xval: bool,
-    query: str = "cancer",
-    m_name: str = "tar",
-    x_name: str = "smoke",
-) -> float:
-    """Helper : ``P(query=True | tar=mval, smoke=xval)``.
-
-    Byte-identique a PyMC-05 cellule 20.
-    """
-    return enumerate_scm(
-        nodes,
-        query,
-        evidence={m_name: mval, x_name: xval},
-    )
-
-
-# ---------------------------------------------------------------------------
-# SCM front-door canonique (cellule 20 PyMC-05)
-# ---------------------------------------------------------------------------
-FRONT_DOOR_SCM: List[Tuple[str, Callable]] = [
-    ("u",      lambda a: 0.20),
-    ("smoke",  lambda a: 0.80 if a["u"] else 0.30),
-    ("tar",    lambda a: 0.90 if a["smoke"] else 0.10),
-    ("cancer", lambda a: (0.95 if a["u"] else 0.70) if a["tar"]
-                          else (0.50 if a["u"] else 0.05)),
+__all__ = [
+    "FRONT_DOOR_SCM",
+    "FRONT_SCM",
+    "adapt_enumerate_scm_to_backdoor",
+    "do_direct_p_cancer_given_smoke",
+    "enumerate_scm",
+    "front_door_estimate",
+    "observational_p_cancer_given_smoke",
+    "p_y_given_m_x",
 ]
 
 
@@ -176,19 +142,21 @@ def front_door_estimate() -> Tuple[float, float]:
     p_x1 = enumerate_scm(FRONT_DOOR_SCM, "smoke")
     p_x0 = 1.0 - p_x1
 
-    def p_y_given_m_x_native(mval, xval):
-        return p_y_given_m_x(FRONT_DOOR_SCM, mval, xval)
+    # Epingle le SCM front-door sur l'organe canonique. Ce n'est PAS une
+    # reimplementation : le corps appelle `pymc_causal_organs.p_y_given_m_x`.
+    def _p_y_front(mval, xval):
+        return p_y_given_m_x(mval, xval, FRONT_SCM)
 
     # inner_m : E[Y | M=m] = sum_x P(Y=1 | M=m, X=x) * P(X=x)
     # (independant de do(X) car on marginalise sur X apres conditionnement
     # sur M ; le chemin X -> Y direct est coupe par le conditionnement sur M)
     inner_m1 = (
-        p_y_given_m_x_native(True, True) * p_x1
-        + p_y_given_m_x_native(True, False) * p_x0
+        _p_y_front(True, True) * p_x1
+        + _p_y_front(True, False) * p_x0
     )
     inner_m0 = (
-        p_y_given_m_x_native(False, True) * p_x1
-        + p_y_given_m_x_native(False, False) * p_x0
+        _p_y_front(False, True) * p_x1
+        + _p_y_front(False, False) * p_x0
     )
 
     # P(M=m | do(X=x)) : tar n'a que smoke comme parent, donc

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bridges_canonical_wiring.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bridges_canonical_wiring.py
@@ -12,7 +12,11 @@ passaient donc au vert en comparant ``ict.causal_attribution`` a une
 reproduction de l'organe natif, et non a l'organe natif. Un changement
 d'estimateur dans ``Quasi-Experimental.ipynb`` les aurait laisses verts.
 
-Les gates W1-W6 ci-dessous ferment exactement cet angle mort.
+Les gates W1-W7 ferment exactement cet angle mort pour ``quasi_experimental``.
+Les gates W8-W12 font de meme pour ``pymc_enumerate``, cable sur
+``pymc_causal_organs`` (PR #14133) par la tranche 4 de #14051 : jusque-la, ce
+second pont detenait encore des reproductions byte-identiques des cellules 5
+et 20 de ``PyMC-05-Causal-Inference.ipynb``.
 
 Note de conception -- pourquoi l'IDENTITE et non un ``monkeypatch``
 -------------------------------------------------------------------
@@ -42,12 +46,17 @@ _ROOT = os.path.dirname(_HERE)
 if _ROOT not in sys.path:
     sys.path.insert(0, _ROOT)
 
+from ict.bridges import pymc_enumerate as pe  # noqa: E402
 from ict.bridges import quasi_experimental as qe  # noqa: E402
 
 # `causal_organs` est rendu importable par le bootstrap sys.path de
 # `quasi_experimental` lui-meme : l'importer ICI apres coup verifie, en
 # passant, que ce bootstrap fonctionne hors du module qui le pose.
 import causal_organs as co  # noqa: E402
+
+# Idem pour l'organe PyMC : le bootstrap sys.path est pose par
+# `pymc_enumerate` lui-meme.
+import pymc_causal_organs as pco  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -155,3 +164,82 @@ def test_adapter_did_equals_the_canonical_pipeline():
             f"pretrend={pretrend} : l'adaptateur ne publie pas la sortie de "
             "l'organe canonique"
         )
+
+
+# ---------------------------------------------------------------------------
+#  W8-W10 : identite d'objet cote PyMC -- le pont ne detient aucune copie     #
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["enumerate_scm", "p_y_given_m_x"])
+def test_pymc_bridge_exposes_the_canonical_object_itself(name):
+    """W8-W9 -- ``pe.<f>`` EST ``pymc_causal_organs.<f>``.
+
+    Symetrique de W1-W3. Gate falsifiable : re-coller un
+    ``def enumerate_scm(...)`` dans ``pymc_enumerate.py`` rebind le nom sur un
+    objet local et rougit immediatement.
+    """
+    bridged = getattr(pe, name)
+    canonical = getattr(pco, name)
+    assert bridged is canonical, (
+        f"{name} : le pont PyMC expose un objet distinct du module canonique -- "
+        "une copie a probablement ete reintroduite"
+    )
+
+
+def test_pymc_front_door_scm_is_the_canonical_table():
+    """W10 -- ``FRONT_DOOR_SCM`` est un ALIAS de ``FRONT_SCM``, pas une copie.
+
+    Le SCM est une **donnee**, pas une fonction : une copie des CPT ne se voit
+    ni dans ``__module__`` ni dans un ``def``. C'est donc le seul gate qui
+    puisse l'attraper. Il compte : les quatre CPT de la cellule 20 sont
+    precisement ce que la verification cross-engine suppose partage.
+    """
+    assert pe.FRONT_DOOR_SCM is pco.FRONT_SCM, (
+        "FRONT_DOOR_SCM a ete redeclare : une derive des CPT du notebook ne se "
+        "propagerait plus au pont"
+    )
+
+
+# ---------------------------------------------------------------------------
+#  W11 : provenance declaree cote PyMC                                        #
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["enumerate_scm", "p_y_given_m_x"])
+def test_pymc_bridged_callables_declare_the_canonical_module(name):
+    """W11 -- ``__module__`` nomme ``pymc_causal_organs``."""
+    assert getattr(pe, name).__module__ == "pymc_causal_organs"
+
+
+# ---------------------------------------------------------------------------
+#  W12 : aucune redefinition residuelle dans la source du pont PyMC           #
+# ---------------------------------------------------------------------------
+def test_pymc_bridge_source_defines_no_organ_of_its_own():
+    """W12 -- la source du pont ne (re)definit aucun organe natif.
+
+    Les seuls ``def`` legitimes ici sont les compositions propres au pont
+    (``do_direct_*``, ``observational_*``, ``front_door_estimate``,
+    ``_sample_from_scm``, ``adapt_*``) : elles ne vivent dans aucune cellule
+    de PyMC-05 et n'ont donc pas d'organe canonique a importer.
+    """
+    import inspect
+    import re
+
+    src = inspect.getsource(pe)
+    for name in ("enumerate_scm", "p_y_given_m_x"):
+        motif = re.compile(r"^\s*def %s\s*\(" % re.escape(name), re.M)
+
+        # Controle positif : un motif valide par ses seuls hits peut ne rien
+        # attraper. On verifie d'abord qu'il attrape la forme qu'il cible,
+        # et qu'il laisse passer un helper dont le nom la PREFIXE (le pont en
+        # detient un : `_p_y_front` -- et, avant lui, un `..._native` qu'un
+        # simple `in` faisait rougir a tort).
+        assert motif.search("def %s(a, b):" % name)
+        assert motif.search("    def %s (a, b):" % name)
+        assert not motif.search("def %s_native(a, b):" % name)
+
+        assert not motif.search(src), (
+            f"def {name}(...) redefini dans le pont PyMC : l'organe natif doit "
+            "etre importe depuis pymc_causal_organs, pas reimplemente"
+        )
+    assert "FRONT_DOOR_SCM: List" not in src, (
+        "FRONT_DOOR_SCM redeclare comme table litterale au lieu d'aliaser "
+        "pymc_causal_organs.FRONT_SCM"
+    )


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2027:CoursIA-2 — prev: MED/guard #14261

## Résumé

Câble `ict/bridges/pymc_enumerate.py` sur l'organe canonique `pymc_causal_organs`. **Symétrique de #14150** (mergée), qui a fait de même pour `quasi_experimental` — c'est l'autre moitié de la tranche 4 de #14051.

`See #14051`

## Le défaut fermé : une vérification cross-engine qui ne pouvait pas rougir

Le pont détenait des **reproductions byte-identiques** des cellules 5 et 20 de `PyMC-05-Causal-Inference.ipynb` (`enumerate_scm`, `p_y_given_m_x`, les CPT front-door). Conséquence : sa vérification « cross-engine » comparait `ict.causal_attribution` à une **reproduction** de l'organe, pas à l'organe. Un changement d'estimateur dans PyMC-05 l'aurait laissée **verte** — elle ne testait plus rien de ce qu'elle prétendait tester.

Ce n'est pas un diagnostic que je pose après coup : **le docstring de `ict/bridges/__init__.py` le déclarait lui-même**, en nommant la condition de levée (« la cible importable `pymc_causal_organs.py` est portée par la PR #14133 ; le câblage suivra son merge »). #14133 a mergé le 2026-09-01T21:07:26Z. La condition écrite est levée ; cette PR fait le geste qu'elle annonçait, et met à jour la déclaration devenue périmée.

## Équivalence **mesurée** avant substitution, pas supposée

Les deux implémentations ont des signatures différentes (`p_y_given_m_x(nodes, mval, xval, query, m_name, x_name)` côté copie contre `(mval, xval, scm=None)` côté canonique) : la substitution n'était **pas** un drop-in, et le site d'appel dans `front_door_estimate` a dû être réécrit. D'où deux mesures indépendantes avant de committer :

| Mesure | Portée | Écart max |
|---|---|---|
| Sonde d'équivalence sur l'espace d'entrée | 16 assignations de CPT × 4 nœuds, **836 cas** `enumerate_scm` + 4 cas helper | `0.00e+00` |
| Comparaison avant/après contre `origin/main` | **17 grandeurs** : `front_door_estimate()`, `adapt_enumerate_scm_to_backdoor` aux graines 0/42/7 | `0.000e+00` |

`FRONT_DOOR_SCM` survit comme **alias** du même objet (`FRONT_DOOR_SCM is FRONT_SCM`) : c'est le nom que consomme `ict/tests/test_bridges.py:189`.

## Gates W8-W12 — vérifiés **par mutation**, pas par leurs seuls hits

Symétriques de W1-W5. Un gate validé par ses hits peut être vacuant ; celui-ci a été testé sur des mutants, et le résultat est ce qui justifie sa forme :

| Mutant introduit | Gates qui rougissent |
|---|---|
| Copie de fonction réintroduite (`def p_y_given_m_x` local) | **3** — identité d'objet (W9), `__module__` (W11), scan de source (W12) |
| Copie de la table de CPT, **à valeurs identiques** (`list(FRONT_SCM)`) | **1 seul — W10** (14 autres verts) |

Le second mutant est la raison d'être de W10, et elle est maintenant **mesurée** : un SCM recopié est une **donnée**, il ne se voit ni dans un `def` ni dans `__module__`. Seule l'identité d'objet peut l'attraper — or les quatre CPT sont précisément ce que la vérification cross-engine suppose partagé.

## Un faux positif attrapé en cours de route

Le scan de source W12 est ancré sur une **définition** (`^\s*def <nom>\(`, multiline) et non sur un substring. Un `in` naïf faisait rougir le closure `p_y_given_m_x_native`, qui **appelle** l'organe canonique — un `def` dont le nom *préfixe* la cible n'est pas une réimplémentation. C'est la classe de défaut que `anti-regression.md` documente pour `grep -c sorry` : un motif se valide **par ses faux négatifs**. Le gate porte donc un **contrôle positif** explicite (il vérifie qu'il attrape la forme visée, et qu'il laisse passer le helper qui la préfixe).

Le closure est renommé `_p_y_front` : `_native` était devenu un contresens une fois le corps câblé sur le canonique.

## Validation

| Contrôle | Résultat |
|---|---|
| `pytest ict/tests/` | **539 passed** |
| `pytest ict/tests/test_bridges_canonical_wiring.py -v` | 15 passed (W1-W7 + W8-W12) |
| `pytest MyIA.AI.Notebooks/Probas/PyMC/tests/` | 8 passed |
| Organe canonique modifié ? | **non** — `git status` ne montre que les 3 fichiers `ict/` |
| Identité d'objet post-câblage | `pe.enumerate_scm is pco.enumerate_scm`, `pe.p_y_given_m_x is pco.p_y_given_m_x`, `pe.FRONT_DOOR_SCM is pco.FRONT_SCM` : **True** |
| `__module__` | `pymc_causal_organs` sur les deux callables |
| Fins de ligne | **LF préservé** sur les 3 fichiers (`.py` n'a pas de règle `eol=lf` dans `.gitattributes`, un flip CRLF se committerait verbatim) |
| `COURSE_CATALOG.generated.{json,md}` | byte-identiques à `main` |

Diff : 166 insertions / 108 suppressions. Le pont passe de 319 à 285 lignes — les suppressions sont les trois copies, pas de la substance.

## Ce que cette PR **ne** fait pas

Elle ne câble pas les adaptateurs dans le corps du notebook Greffe-5 (critère d'acceptation 1 de #13903). Ce geste-là ne devient honnête **qu'une fois** `pymc_enumerate` canoniquement câblé — c'est-à-dire après cette PR, pas avec elle. Une PR = un sujet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
