### PR TITLE
fix(sudoku,#11451): separateurs --- vers *** — 3 notebooks, 16 conversions, markdown-only

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "**Duree estimee** : ~10 min | **Prerequis** : [Sudoku-00 Environment](Sudoku-00-Environment-Csharp.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "Ce notebook implemente un solveur de Sudoku utilisant **Z3** (prouveur SMT issu de Microsoft Research, desormais open-source sous licence MIT), un solveur **SMT** (Satisfiable Modulo Theories).\n",
     "\n",
@@ -807,7 +807,7 @@
     "\n",
     "Le Sudoku est un excellent problème pedagogique pour comprendre la différence entre SAT (propositionnel) et SMT (théories).\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<< OR-Tools Python](Sudoku-10-ORTools-Python.ipynb) | [Index](README.md) | [Infer Python >>](Sudoku-15-Infer-Python.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
@@ -17,7 +17,7 @@
     "***\n",
     "**Navigation** : [<< Sudoku-12 Z3 Python](Sudoku-12-Z3-Python.ipynb) | [Index](README.md) | [Sudoku-14 BDD Python >>](Sudoku-14-BDD-Python.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "# Sudoku-13 : Le Sudoku comme Regex Symbolique — twin Python (Conway -> BREX/Rex -> RE#)\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -78,7 +78,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction - BDD vs Z3 (10 min)\n",
     "\n",
@@ -135,7 +135,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Implémentation d'un BDD Simple (15 min)\n",
     "\n",
@@ -538,7 +538,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Opérations sur les BDD (15 min)\n",
     "\n",
@@ -809,7 +809,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. MDD pour Sudoku (20 min)\n",
     "\n",
@@ -1250,7 +1250,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Produit d'Automates Explicite (15 min)\n",
     "\n",
@@ -1569,7 +1569,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Solveur Sudoku avec MDD (20 min)\n",
     "\n",
@@ -2479,7 +2479,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Comparaison Sudoku-12 vs Sudoku-14 (10 min)\n",
     "\n",
@@ -2532,7 +2532,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",
@@ -2588,7 +2588,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercices : BDD et MDD\n",
     "\n",
@@ -2627,7 +2627,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Solveur BDD avec Propagation de Contraintes\n",
     "\n",
@@ -2684,7 +2684,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Références\n",
     "\n",
@@ -2705,11 +2705,11 @@
     "- [Sudoku-12-Z3](Sudoku-12-Z3-Csharp.ipynb) - Z3 SMT direct\n",
     "- [Search-10-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Théorie approfondie\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Sudoku README](README.md) | [Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb) | [Fin](README.md)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Retour au sommaire** : [Index Sudoku](README.md)\n"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
@@ -45,7 +45,14 @@
       csharp_sha: 556dc0e05867c09834cbae74a1892ca780bceac8
       content_python_sha: e413e3bc5da8c47f2f2f03a8169bc96c73506723bacc1f8c7da53a4449bf1119
       content_csharp_sha: b9149a63924e4e645534c78fa4a195ee51bb1569d278074a33a0ddbd5fcc755f
+    - date: "2026-09-02"
+      by: myia-po-2027:CoursIA
+      python_sha: 46906eee5801fd85010b5a835fbafafe09cd453a
+      csharp_sha: 556dc0e05867c09834cbae74a1892ca780bceac8
+      content_python_sha: 5cfb106fd53a7889213d4f622171d9083277351233920fdddb8929276e05857e
+      content_csharp_sha: b9149a63924e4e645534c78fa4a195ee51bb1569d278074a33a0ddbd5fcc755f
   known_differences:
+    - "2026-09-02 (grain hr-separateurs famille Sudoku, myia-po-2027:CoursIA) : conversion des separateurs markdown --- vers *** via fix_hr_separator.py (incident #11451 : un --- seul ouvre un bloc YAML Pandoc et casse quarto render) -- jumeau Python seul (2 separateurs). Cellules markdown uniquement, aucune source de code ni output modifiee, pas de re-exec (C.2 exception markdown-only). Les blob et content SHAs deplaces dans l audit ci-dessus sont des artefacts de cette conversion markdown (le content_sha hashe le JSON canonique des cellules), pas une divergence pedagogique."
     - "Socle pedagogique commun : resolution de Sudoku par SMT (Satisfiability Modulo Theories) avec le vrai solveur Z3 (Microsoft Research) -- modelisation des contraintes Sudoku comme formules logiques (BitVec, contraintes all-different sur lignes/colonnes/carres), resolution par le solveur SMT. Les deux cotes utilisent le VRAI Z3 SOTA (meme moteur sous-jacent), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, BitVec, Solver."
     - "Divergence de binding : le C# accede a Z3 via Microsoft.Z3 (NuGet, bindings .NET natifs, 19 cellules code) ; le Python accede a Z3 via pyz3 (import z3, bindings Python, 11 cellules). C'est le meme solveur Z3 avec deux bindings idiomatiques -- c'est la definition meme de parity_level semantic (meme moteur, API idiomatique differente). Note : le Python reference aussi ortools (OR-Tools, alternative CP-SAT) en complement."
     - "Idiomes framework : C# = Microsoft.Z3 (NuGet) + System.*, 19 cellules code ; Python = pyz3 + ortools, 11 cellules code. Vrai Z3 SMT solver des deux cotes (SOTA veritable, pas de workaround), bindings langage differents."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
@@ -95,7 +95,14 @@
       csharp_sha: 5c3fed39821b242bb269c1d579c91d2241ef5d33
       content_python_sha: 48c7c5a685b64aff0d09c568a5eef72b541133103c1a03afe31f87a80ae9537b
       content_csharp_sha: 68b076ef17f9e9a8af10d7c95168edb2a28fba54836af7c8358ad94bf3f07947
+    - date: "2026-09-02"
+      by: myia-po-2027:CoursIA
+      python_sha: e0734d1d9a5ed84e1c02c102e376b3d3b174b73c
+      csharp_sha: 5c3fed39821b242bb269c1d579c91d2241ef5d33
+      content_python_sha: ae2ab9d9b24d012856319a9c09750a5643fc74017e3390247345438a1166a271
+      content_csharp_sha: 68b076ef17f9e9a8af10d7c95168edb2a28fba54836af7c8358ad94bf3f07947
   known_differences:
+    - "2026-09-02 (grain hr-separateurs famille Sudoku, myia-po-2027:CoursIA) : conversion des separateurs markdown --- vers *** via fix_hr_separator.py (incident #11451 : un --- seul ouvre un bloc YAML Pandoc et casse quarto render) -- jumeau Python seul (1 separateur). Cellules markdown uniquement, aucune source de code ni output modifiee, pas de re-exec (C.2 exception markdown-only). Les blob et content SHAs deplaces dans l audit ci-dessus sont des artefacts de cette conversion markdown (le content_sha hashe le JSON canonique des cellules), pas une divergence pedagogique."
     - "Socle pedagogique commun : automates symboliques et resolution de Sudoku via Z3 (automates finis symboliques, representation symbolique des contraintes, liens avec SMT). Meme concept (automates symboliques + Z3 comme backend de decision), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, symbolic, Solver."
     - "Divergence d'implementation : le C# (Microsoft.Z3 via NuGet + auto-suffisant en annexe S10, 19 cellules code apres #10459) utilise la theorie des chaines Z3 et la regle `re.++` / `re.*` / `re.range` / `str.to_re` pour la partie symbolique. Le Python (pyz3, 10 cellules code) utilise les bindings Z3 directement. Meme enseignement (automates symboliques + Z3), deux niveaux."
     - "Plafond academique documente (issue AutomataDotNet/Automata#6, voir SOTA ledger Entry #008) : la voie SFAz3 d'origine a un cap du temoin a ~21 caracteres (SFAz3 + Z3 'monstre regex tronque'). Ce plafond est **academique** et frappe les deux jumeaux a l'identique ; il est documente ici et **ne peut pas** motiver un verdict de parite. Le contournement par la theorie des chaines directe (annexe S10 du notebook C#) montre la lib Microsoft.Z3 sans ce plafond."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
@@ -40,7 +40,14 @@
       csharp_sha: b3409ceb045ac914bfaf99b88f41ddde337b0a1d
       content_python_sha: 1bfc5722a332acb62b38fc19af0f8a32cdddb604b0867e3949607b1897c9db07
       content_csharp_sha: 446cef50dfe882e404b29cec87b90368c118a557f58d04f091e4bae248960474
+    - date: "2026-09-02"
+      by: myia-po-2027:CoursIA
+      python_sha: 8672bbe7b5508c8dbca73e17d6d1a0af2f68ab00
+      csharp_sha: c775d10f267b1f873363ed224142b1a9db1e6b18
+      content_python_sha: 1bfc5722a332acb62b38fc19af0f8a32cdddb604b0867e3949607b1897c9db07
+      content_csharp_sha: 3ff7d1ebf2cb288eb4cac3801ed13d2dd6be6c60b05d8770459009acef63cc20
   known_differences:
+    - "2026-09-02 (grain hr-separateurs famille Sudoku, myia-po-2027:CoursIA) : conversion des separateurs markdown --- vers *** via fix_hr_separator.py (incident #11451 : un --- seul ouvre un bloc YAML Pandoc et casse quarto render) -- jumeau C# seul (13 separateurs). Cellules markdown uniquement, aucune source de code ni output modifiee, pas de re-exec (C.2 exception markdown-only). Les blob et content SHAs deplaces dans l audit ci-dessus sont des artefacts de cette conversion markdown (le content_sha hashe le JSON canonique des cellules), pas une divergence pedagogique."
     - "Socle pedagogique commun : resolution du Sudoku par automates a decision binaire (BDD / MDD, Binary/Multi-valued Decision Diagrams), meme concept (codage booleen des contraintes, reduction canonique du graphe de decision, satisfaction via parcours). Le notebook Python declare explicitement etre le jumeau du C# (« Jumeau Python du notebook Sudoku-14-BDD-Csharp.ipynb »)."
     - "Divergence d'implementation : les deux cotes hand-rollent les BDD/MDD from scratch (pas de lib BDD tierce) -- le Python via dataclasses/typing, le C# via System.Collections.Generic + System.Linq. Meme reconstruction pedagogique de l'automate, idiomes de langage differents."
     - "Parite structurelle proche : Python 14 cellules code / 19 markdown ; C# 15 cellules code / 25 markdown. Arc pedagogique identique (construction du BDD -> reduction -> resolution)."


### PR DESCRIPTION
Grain: LIGHT/refactor — lane myia-po-2027:CoursIA — prev: LIGHT/tooling #14266

Conversion des séparateurs horizontaux `---` en `***` sur la famille Sudoku, avec l'outil dédié [`scripts/notebook_tools/fix_hr_separator.py`](scripts/notebook_tools/fix_hr_separator.py) (aucune réécriture). Motivation : une ligne `---` seule ouvre un bloc de métadonnées YAML au sens Pandoc → `YAMLException` → `quarto render` échoue (incident #11451, 2026-08-17) ; `***` rend le même `<hr>` sans sémantique YAML.

## Mesure (dry-run sur base da1d250936af = origin/main)

| Notebook | Séparateurs convertis |
|---|---|
| `Sudoku-12-Z3-Python.ipynb` | 2 |
| `Sudoku-13-SymbolicAutomata-Python.ipynb` | 1 |
| `Sudoku-14-BDD-Csharp.ipynb` | 13 |
| **Total** | **16** |

C'est le pattern signalé en exclusion de #14266 (le hook pre-commit `fix-hr-separator` convertissait 13 `---` de 14-BDD = changement de contenu, incompatible avec une tranche forme-seule). Ici la conversion est **assumée comme l'unique sujet** de la PR.

## Gardes

- **Diff = exactement la conversion** : `git diff -U0` → 16 insertions / 16 suppressions, toutes de la forme `"---\n",` → `"***\n",` (aucune autre ligne touchée).
- **Cellules modifiées = markdown uniquement** : digest sha1 par cellule avant/après (97 cellules / 3 notebooks) — 0 cellule code modifiée, 0 changement de nombre de cellules.
- **Pas de re-exec** (règle C.2, exception modifs uniquement markdown) : aucune source de code, output ni `execution_count` touché.
- Catalogue byte-identique à main (rien hors `MyIA.AI.Notebooks/Sudoku/`).

## Attestations twin-parity (3 paires, recette #14266)

`Sudoku-12 Z3`, `Sudoku-13 SymbolicAutomata`, `Sudoku-14 BDD` : `check_twin_parity.py --update --pair … --by myia-po-2027:CoursIA` (lecture des blobs HEAD) + ligne `known_differences` datée par paire. Les `content_*_sha` déplacés sont des artefacts de la conversion markdown (l'organe hashe le JSON canonique des cellules) — la parité pédagogique est inchangée.

## Résiduel

- Les 2 cellules string de `Sudoku-14-BDD-Csharp` restent à normaliser (tranche #14209) : **après merge de cette PR**, le hook n'y conflituera plus (plus aucun `---` dans le fichier).
- Autres familles avec `---` restants : mesurables par `fix_hr_separator.py --check <série>` (grains similaires, à prendre par famille).

See #14209 · See #11451
