### PR TITLE
feat(audit,#11554): mesurer la surface reellement auto-chargee (auto vs path-gated)

### DIFF
--- a/scripts/audit/measure_autoloaded_harness.py
+++ b/scripts/audit/measure_autoloaded_harness.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""measure_autoloaded_harness.py -- mesure la surface de harnais REELLEMENT auto-chargee.
+
+Issue #11554 ("compacter les 195 Ko auto-charges, en mesurant ce qui est
+reellement envoye"). Le ticket et son apport de mesure du 2026-08-19 comptent
+tous deux `.claude/rules/*.md` en entier. Or CLAUDE.md pose la distinction :
+
+    "Les regles sans frontmatter `paths:` sont auto-chargees [...] Celles qui
+     portent un frontmatter `paths:` ne se chargent que si la session touche
+     les fichiers vises."
+
+Une regle path-gated ne coute donc RIEN a une session qui ne touche pas ses
+chemins. Les additionner au total auto-charge surestime la surface, et surtout
+deplace la priorite : `notebook-conventions.md` est le plus gros fichier de
+`.claude/rules/` (12 738 o), l'apport du 2026-08-19 le met en tete des cibles
+au titre d'un bloc "charge par toutes les lanes" -- or il est path-gated depuis
+au moins le 2026-07-08 (plus ancien point mesurable dans ce clone), donc jamais
+auto-charge sur toute la fenetre decrite. Compacter la mesure du ticket ne
+rendrait pas un octet aux sessions qui ne touchent pas de notebook.
+
+Ce script mesure la bonne quantite, et la mesure au lieu de la relire : un
+compte derive a la main se refait faux a chaque PR -- c'est exactement ce qui
+est arrive a celui du ticket.
+
+Usage :
+    py scripts/audit/measure_autoloaded_harness.py
+    py scripts/audit/measure_autoloaded_harness.py --json
+    py scripts/audit/measure_autoloaded_harness.py --ref origin/main
+    py scripts/audit/measure_autoloaded_harness.py --self-check
+    py scripts/audit/measure_autoloaded_harness.py --max-bytes 170000
+
+Exit codes :
+    0 -- mesure rendue (et sous le seuil si --max-bytes est passe)
+    1 -- --max-bytes depasse
+    2 -- mesure impossible : self-check en echec, aucun fichier de regle trouve
+         (une mesure vide n'est pas une mesure a zero), ou --ref inatteignable
+         (typiquement hors de la greffe d'un clone superficiel)
+
+Aucun workflow CI n'appelle ce script : --max-bytes existe pour cabler le
+garde-fou de non-regression demande par #11554, il ne rougit nulle part tant
+que personne ne l'a cable.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+RULES_GLOB = ".claude/rules/*.md"
+PROJECT_ROOT_FILE = "CLAUDE.md"
+
+
+def is_path_gated(text):
+    """Vrai si le fichier porte un frontmatter YAML declarant `paths:`.
+
+    La detection porte sur le BLOC de tete delimite par `---`, pas sur les N
+    premieres lignes : un `paths:` cite dans la prose ne gate rien, et un
+    frontmatter de plus de cinq lignes gate quand meme. Ce sont les deux faux
+    negatifs qu'un `head -5 | grep '^paths:'` produit en silence.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return False
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return False          # fin du frontmatter, `paths:` absent
+        if line.startswith("paths:"):
+            return True
+    return False                   # frontmatter jamais referme
+
+
+def _read_worktree(root):
+    for p in sorted(root.glob(RULES_GLOB)):
+        yield p.name, p.read_text(encoding="utf-8", errors="replace")
+    cm = root / PROJECT_ROOT_FILE
+    if cm.exists():
+        yield PROJECT_ROOT_FILE, cm.read_text(encoding="utf-8", errors="replace")
+
+
+class RefUnavailable(Exception):
+    """Le ref demande n'est pas atteignable (inconnu, ou hors greffe d'un clone
+    superficiel). Un clone `--depth N` rend une erreur de ref sur tout ce qui
+    precede sa greffe : c'est une LIMITE DE MESURE, a dire comme telle, pas un
+    plantage a laisser filer en trace d'exception."""
+
+
+def _read_ref(root, ref):
+    def git(*args):
+        return subprocess.run(["git", "-C", str(root), *args],
+                              capture_output=True, text=True, check=True).stdout
+
+    try:
+        listing = git("ls-tree", "-r", "--name-only", ref, "--", ".claude/rules")
+    except subprocess.CalledProcessError as exc:
+        raise RefUnavailable(exc.stderr.strip().splitlines()[0]
+                             if exc.stderr.strip() else "ref illisible")
+    for path in sorted(x for x in listing.splitlines() if x.endswith(".md")):
+        yield Path(path).name, git("show", ref + ":" + path)
+    try:
+        yield PROJECT_ROOT_FILE, git("show", ref + ":" + PROJECT_ROOT_FILE)
+    except subprocess.CalledProcessError:
+        pass
+
+
+def measure(root, ref=None):
+    auto, gated = [], []
+    root_file = None
+    reader = _read_ref(root, ref) if ref else _read_worktree(root)
+    for name, text in reader:
+        size = len(text.encode("utf-8"))
+        if name == PROJECT_ROOT_FILE:
+            root_file = {"name": name, "bytes": size}
+        elif is_path_gated(text):
+            gated.append({"name": name, "bytes": size})
+        else:
+            auto.append({"name": name, "bytes": size})
+
+    auto.sort(key=lambda e: -e["bytes"])
+    gated.sort(key=lambda e: -e["bytes"])
+    auto_bytes = sum(e["bytes"] for e in auto)
+    gated_bytes = sum(e["bytes"] for e in gated)
+    root_bytes = root_file["bytes"] if root_file else 0
+    return {
+        "ref": ref or "(worktree)",
+        "autoloaded_rules": auto,
+        "path_gated_rules": gated,
+        "root_file": root_file,
+        "n_autoloaded": len(auto),
+        "n_path_gated": len(gated),
+        "autoloaded_rules_bytes": auto_bytes,
+        "path_gated_rules_bytes": gated_bytes,
+        "root_file_bytes": root_bytes,
+        "autoloaded_total_bytes": auto_bytes + root_bytes,
+        "all_rules_bytes": auto_bytes + gated_bytes,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Controle : valide par ses FAUX NEGATIFS, jamais par ses hits
+# --------------------------------------------------------------------------- #
+CONTROL_CASES = [
+    ("gate nominal", "---\npaths: a/**/*.ipynb\n---\n\n# X\n", True),
+    ("aucun frontmatter", "# X\n\nDu texte.\n", False),
+    ("frontmatter sans paths", "---\ndescription: x\n---\n\n# X\n", False),
+    # Les deux cas qu'un `head -5 | grep '^paths:'` classe a l'envers :
+    ("paths: en PROSE, pas en frontmatter",
+     "# X\n\npaths: ceci n'est pas un gate\n", False),
+    ("paths: au-dela de la 5e ligne du frontmatter",
+     "---\na: 1\nb: 2\nc: 3\nd: 4\ne: 5\npaths: z/**\n---\n\n# X\n", True),
+]
+
+
+def self_check():
+    bad = [(label, expected, is_path_gated(text))
+           for label, text, expected in CONTROL_CASES
+           if is_path_gated(text) != expected]
+    for label, expected, got in bad:
+        print("  ECHEC  %s : attendu gated=%s, obtenu %s" % (label, expected, got))
+    if bad:
+        print("self-check : %d/%d cas en echec -- instrument invalide"
+              % (len(bad), len(CONTROL_CASES)))
+        return 2
+    # Le classifieur peut etre juste et la MESURE vide : un repertoire sans
+    # regle doit lever, pas rendre "0 octet, tout va bien".
+    with tempfile.TemporaryDirectory() as tmp:
+        empty = measure(Path(tmp))
+    if empty["n_autoloaded"] or empty["n_path_gated"]:
+        print("  ECHEC  un repertoire vide rend des regles")
+        return 2
+    print("self-check : %d/%d cas OK (dont 2 faux negatifs d'un grep naif) ;"
+          " mesure vide detectable" % (len(CONTROL_CASES), len(CONTROL_CASES)))
+    return 0
+
+
+def render(m, top):
+    print("Harnais auto-charge -- ref %s" % m["ref"])
+    print()
+    print("  %3d regles auto-chargees   %8d o"
+          % (m["n_autoloaded"], m["autoloaded_rules_bytes"]))
+    print("  %3d regles path-gated      %8d o   (cout nul hors des chemins vises)"
+          % (m["n_path_gated"], m["path_gated_rules_bytes"]))
+    if m["root_file"]:
+        print("      %-20s   %8d o" % (PROJECT_ROOT_FILE, m["root_file_bytes"]))
+    print("      TOTAL AUTO-CHARGE      %8d o" % m["autoloaded_total_bytes"])
+    print("      (total brut des rules  %8d o -- la valeur qu'on obtient en"
+          " oubliant le gating)" % m["all_rules_bytes"])
+    print()
+    print("  Top %d auto-charges :" % top)
+    for e in m["autoloaded_rules"][:top]:
+        print("    %7d o  %s" % (e["bytes"], e["name"]))
+    if m["path_gated_rules"]:
+        print("  Path-gated (hors total) :")
+        for e in m["path_gated_rules"]:
+            print("    %7d o  %s" % (e["bytes"], e["name"]))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", default=".", help="racine du depot (defaut : .)")
+    ap.add_argument("--ref", help="mesurer un ref git au lieu de l'arbre de travail")
+    ap.add_argument("--json", action="store_true", help="sortie JSON")
+    ap.add_argument("--json-out", help="ecrire le JSON dans ce fichier")
+    ap.add_argument("--top", type=int, default=10, help="taille du palmares (defaut : 10)")
+    ap.add_argument("--self-check", action="store_true",
+                    help="valider l'instrument et sortir (0 = sain, 2 = invalide)")
+    ap.add_argument("--max-bytes", type=int,
+                    help="exit 1 si le total auto-charge depasse ce seuil")
+    args = ap.parse_args()
+
+    if args.self_check:
+        return self_check()
+
+    try:
+        m = measure(Path(args.root), args.ref)
+    except RefUnavailable as exc:
+        print("ref %r inatteignable (%s) -- mesure impossible." % (args.ref, exc),
+              file=sys.stderr)
+        print("Sur un clone superficiel, tout ce qui precede la greffe est hors"
+              " de portee : `git fetch --unshallow` d'abord.", file=sys.stderr)
+        return 2
+    if not m["n_autoloaded"] and not m["n_path_gated"]:
+        sys.stderr.write("aucun fichier de regle sous %s -- mesure impossible,"
+                         " pas une mesure a zero\n" % RULES_GLOB)
+        return 2
+
+    if args.json_out:
+        Path(args.json_out).write_text(
+            json.dumps(m, indent=2, ensure_ascii=False), encoding="utf-8")
+    if args.json:
+        print(json.dumps(m, indent=2, ensure_ascii=False))
+    else:
+        render(m, args.top)
+
+    if args.max_bytes is not None and m["autoloaded_total_bytes"] > args.max_bytes:
+        sys.stderr.write("\nDEPASSEMENT : %d o > seuil %d o\n"
+                         % (m["autoloaded_total_bytes"], args.max_bytes))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/slides #14270

## Ce que livre cette PR

Un instrument, `scripts/audit/measure_autoloaded_harness.py`, qui mesure la surface de harnais **réellement** auto-chargée — en séparant les règles auto-chargées de celles que leur frontmatter `paths:` rend conditionnelles.

La Phase 1 de #11554 demande de « mesurer au lieu d'estimer ». Elle vise le trafic claudish côté hub (po-2023), que je ne peux pas instrumenter d'ici. Ce que je peux mesurer d'ici, c'est la **surface repo-side**, et il se trouve que le chiffre qui sert de base au ticket y comporte un biais systématique.

## Le biais mesuré

CLAUDE.md pose la distinction :

> Les règles sans frontmatter `paths:` sont auto-chargées [...] Celles qui portent un frontmatter `paths:` ne se chargent que si la session touche les fichiers visés.

Une règle path-gated ne coûte donc **rien** à une session qui ne touche pas ses chemins. Le ticket compte `.claude/rules/*.md` en entier.

| Mesure sur `2c914708b2` (2026-08-21) | Octets |
|---|---:|
| Naïf (`rules` + `CLAUDE.md`) — la valeur du ticket | 168 435 |
| Réellement auto-chargé | **138 337** |
| Écart | 30 098 (**17,9 %**) |

Le ticket mesurait 167 032 o le 2026-08-18 sur `aa4a45d80`. Mon instrument rend **168 435 o** trois jours plus tard sur le même mode de comptage : **0,8 % d'écart**, cohérent avec la dérive de trois jours. Autrement dit il reproduit la mesure du ticket là où elle porte, et ne diverge que là où le gating mord. **Cette PR affine la mesure de #11554, elle ne la contredit pas.**

## Ce que le biais change pour la Phase 2

Le ticket énonce son critère de tri ainsi :

> Le critère de tri n'est pas la taille mais le **taux d'usage réel** : une règle qui ne se déclenche que sur une famille (`lean-merge-discipline`, `student-pr-reviews`, `genai-config`, `wsl-kernels`) coûte à **toutes** les sessions de toutes les lanes.

Le raisonnement est juste, et c'est exactement le bon critère. Mais mesuré fichier par fichier, **trois des quatre exemples sont déjà path-gated** :

| Règle citée | Octets | État réel |
|---|---:|---|
| `lean-merge-discipline` | 3 503 | **path-gated** |
| `genai-config` | 1 662 | **path-gated** |
| `wsl-kernels` | 1 949 | **path-gated** |
| `student-pr-reviews` | 2 629 | auto-chargé |

Elles ne coûtent donc rien aux sessions qui ne touchent pas Lean / GenAI / WSL — c'est-à-dire à la quasi-totalité d'entre elles.

Plus net encore : `notebook-conventions.md` est le **plus gros fichier de `.claude/rules/`** (12 738 o) et l'apport de mesure du 2026-08-19 le place en tête des cibles, au titre d'un bloc « chargé par toutes les lanes ». Or il est path-gated depuis **au moins le 2026-07-08** — le plus ancien point mesurable dans ce clone. Il ne l'est pas devenu depuis : il l'était déjà sur toute la fenêtre que le ticket décrit. Le compacter ne rendrait pas un octet aux sessions qui ne touchent pas de notebook.

Ce n'est pas un reproche à l'apport du 2026-08-19 : c'est précisément le défaut qu'un compte dérivé à la main finit toujours par produire, et la raison pour laquelle le ticket demandait un instrument.

## La courbe, sur ce que ce clone permet de mesurer

Le clone est superficiel ; les points ci-dessous sont les greffes atteignables, mesurées une par une (pas d'interpolation) :

| Date | Auto-chargé | dont `rules` | path-gated (hors total) |
|---|---:|---:|---:|
| 2026-07-08 | 94 317 | 68 762 (18) | 16 225 (5) |
| 2026-07-23 | 125 789 | 99 262 (20) | 24 141 (5) |
| 2026-07-30 | 133 697 | 106 965 (20) | 26 640 (5) |
| 2026-08-21 | 138 337 | 117 512 (19) | 30 098 (7) |
| 2026-08-23 | 142 770 | 121 945 (19) | 30 098 (7) |
| **2026-09-02** | **161 572** | 139 171 (22) | 30 100 (7) |

Soit **+67 255 o en 56 jours (≈ +8,4 Ko/semaine)** sur l'ensemble, et **+23 235 o sur les 12 derniers jours (≈ +13,6 Ko/semaine)** — la pente s'accentue. La compaction `lane-claim-protocol` livrée par #13134 (−62,3 % sur ce fichier) est réelle et visible ; elle est reprise par la croissance en une semaine environ. C'est l'argument du ticket pour un garde-fou, chiffré.

Une réserve honnête sur ce tableau : entre 2026-07-30 et 2026-08-21, `CLAUDE.md` **baisse** de 26 732 à 20 825 o. Une compaction a donc eu lieu dans cette fenêtre, dont je n'ai pas cherché l'auteur — le tableau la montre, il ne l'explique pas.

## L'instrument, et pourquoi on peut s'y fier

Le classifieur est validé **par ses faux négatifs**, jamais par ses hits (`--self-check`, 5 cas). Les deux qui comptent sont ceux qu'un `head -5 | grep '^paths:'` classe à l'envers, en silence :

- `paths:` **cité en prose** hors frontmatter → ne gate rien, un grep le compte comme gate ;
- `paths:` **au-delà de la 5ᵉ ligne** d'un frontmatter plus long → gate quand même, un grep le rate.

Deux gardes de plus, appris de cycles précédents :

- **une mesure vide n'est pas une mesure de zéro** : un répertoire sans règle sort en **2**, il ne rend pas « 0 octet, tout va bien ». Ce garde a servi pendant l'écriture — une greffe du clone (`1c5231f6f8`) n'a pas de `.claude/rules/` du tout, et l'instrument l'a dit au lieu de l'ajouter à la courbe comme un point à zéro ;
- un `--ref` **hors de la greffe** d'un clone superficiel est signalé comme une limite de mesure, avec le geste (`git fetch --unshallow`), au lieu de laisser filer une trace d'exception.

```
$ python scripts/audit/measure_autoloaded_harness.py --self-check
self-check : 5/5 cas OK (dont 2 faux negatifs d'un grep naif) ; mesure vide detectable   → 0

$ python scripts/audit/measure_autoloaded_harness.py --max-bytes 200000   → 0
$ python scripts/audit/measure_autoloaded_harness.py --max-bytes 100000   → 1
$ python scripts/audit/measure_autoloaded_harness.py --root /tmp          → 2
$ python scripts/audit/measure_autoloaded_harness.py --ref 5240f477e1^    → 2
```

## Périmètre

**1 fichier, +244/−0.** Aucun texte de règle n'est touché, aucun `paths:` n'est ajouté ou retiré : la surface auto-chargée est strictement inchangée par cette PR. `--max-bytes` porte le garde-fou de non-régression demandé par le ticket, mais **aucun workflow ne l'appelle** — il ne rougit nulle part tant que personne ne l'a câblé. C'est du `tooling`, pas un `guard`, et le tag le déclare comme tel.

## Ce que cette PR ne fait pas

- **Elle ne compacte rien.** Le verdict par fichier est la Phase 2, explicitement attribuée à ai-01 ; trancher quelles règles déporter à sa place serait substituer mon jugement au sien.
- **Elle ne câble pas la CI.** Le seuil de non-régression demande une valeur de référence, qui se choisit après le verdict Phase 2 — la poser maintenant figerait un plafond avant la compaction.
- **Elle ne mesure pas le trafic claudish.** La Phase 1 porte sur les corps de requête au hub po-2023 ; elle reste ouverte et n'est pas adressée ici. La surface repo-side est un minorant du préfixe stable, pas le coût en tokens tel que facturé.

À ce titre : `See #11554`, pas `Closes`.

## Suivi suggéré (non créé par cette PR)

L'apport de mesure du 2026-08-19 mérite une note rectificative sur le ticket, pour que la Phase 2 ne parte pas d'une liste de cibles dont la première ligne est déjà gated. Je poste la mesure en commentaire sur l'issue plutôt que de modifier un apport qui n'est pas le mien.

See #11554
