### PR TITLE
docs(qc,#14142): post-backtest measurement gates - read_backtest post-completion + account currency

### DIFF
--- a/docs/qc/quantconnect.md
+++ b/docs/qc/quantconnect.md
@@ -35,6 +35,29 @@ Toute modification d'une stratégie QC (main.py, paramètres, périodes) **DOIT*
 
 **Changer une date ou un paramètre sans backtest = travail invalide.**
 
+### Mesures post-backtest : gates minimaux (`read_backtest` post-completion, #14142)
+
+`read_backtest` appelé **pendant qu'un backtest tourne encore** rend `totalOrders: 0` et des `statistics` à `"-"` / `"0%"` / `"$0.00"` — un état **indiscernable d'un run terminé sans aucun ordre**. Incident fondateur (PR #14012, 2026-09-01) : la conclusion « la condition OR n'a JAMAIS été vraie sur 1 461 jours BTC/ETH minute » a été publiée sur un `totalOrders=0` lu en cours d'exécution ; la relecture **post-completion** (commit `71849ef20`) a trouvé **487 172 ordres** — la conclusion inverse.
+
+**Garde obligatoire avant de citer `totalOrders` ou `statistics`** (invariant cross-lane, tout `read_backtest` cité dans une PR/issue/JSON la porte) :
+
+```python
+result = read_backtest(project_id=..., backtest_id=...)
+
+# GARDE : tant que le backtest n'a pas termine, totalOrders=0 et statistics="-"
+# sont des artefacts d'etat, pas des mesures.
+assert result["status"] == "Completed.", \
+    f"backtest pas termine : status={result['status']!r}"
+assert result["progress"] == 1, \
+    f"progress != 1 : progress={result['progress']!r}"
+
+# Ici seulement, totalOrders / statistics sont fiables.
+```
+
+**Seconde cause de « remplissage nul » à écarter avant toute conclusion stratégique** : la devise de compte (#14215). Sur `AccountType.CASH`, LEAN exige le solde de la **devise de cotation** ; un compte financé en USD qui négocie des paires USDT (`BTCUSDT`/`ETHUSDT`) voit chaque achat rejeté — 0 fill, quelle que soit la condition d'entrée. Le backtest de contrôle B3 (une seule variable changée : `set_account_currency("USDT")` avant `set_cash`) est passé de 0 ordre à **917 199 ordres** (net −99,88 %) — preuve que le « signal absent » était un compte dans la mauvaise devise. Un verdict « aucun remplissement » sur paires crypto DOIT donc vérifier devise de cotation ↔ devise de compte avant d'inférer quoi que ce soit sur la stratégie.
+
+Ces deux gates se vérifient **en session via le MCP** (snippet ci-dessus à coller dans l'appel) — pas via un script REST direct, interdit par la règle d'accès ci-dessous.
+
 ### Convention `SetEndDate` — fenêtre figée vs flottante (mécanisme D2, #9768)
 
 L'absence d'un appel `SetEndDate` (Python : `self.set_end_date(...)`) **n'est pas toujours un défaut** : elle ouvre la fenêtre de backtest à la date courante, ce qui est un comportement légitime **selon le type de notebook**. La classification (audit #9772 Phase 0) distingue deux régimes :


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: LIGHT/refactor #14276

## Summary

Dernier item non livré du scope Phase E de #14142 (c.914, item 1) : la section **« Mesures post-backtest : gates minimaux »** dans `docs/qc/quantconnect.md` — absente de main malgré la merge de #14215 (qui a couvert concerns 3+4 côté notebook/JSON).

Deux gates, nées toutes deux du fil #14142 :

1. **`read_backtest` post-completion** — un appel passé pendant que le backtest tourne rend `totalOrders: 0` et `statistics: "-"`, indiscernable d'un run terminé sans ordre. Incident fondateur : PR #14012 Phase D B2 a publié « la condition OR n'a JAMAIS été vraie sur 1 461 jours » sur une lecture en vol ; la relecture post-completion (`71849ef20`) a trouvé **487 172 ordres** — la conclusion inverse. Garde obligatoire (invariant cross-lane c.909-L1) : `status == "Completed."` **ET** `progress == 1` avant de citer `totalOrders`/`statistics`.
2. **Devise de compte** (#14215) — sur `AccountType.CASH`, LEAN exige le solde de la devise de cotation : un compte USD négociant des paires USDT rejette chaque achat. Backtest de contrôle B3 (une seule variable : `set_account_currency("USDT")`) : 0 → **917 199 ordres** (net −99,88 %). Un verdict « aucun remplissement » sur paires crypto DOIT vérifier devise de cotation ↔ devise de compte avant d'inférer quoi que ce soit sur la stratégie.

Pas de wrapper script : l'accès QC est MCP-only (pas de REST direct) — la gate vit comme snippet en session, dit explicitement dans la section.

## Grounding (firsthand ce cycle)

- `gh issue view 14142` : 4 commentaires lus — c.909/c.914 (concerns 1-3 traités, scope Phase E), c.929 (status narratif), c.929+ (Phase E livrée par #14215 : **concern 4 infirmé**, les 6 `liquidate()` sont déjà gardés, fixer aurait été un fix sans objet).
- `gh pr view 14215` : MERGED 05:51Z, fichiers = notebook + `_results/QC-Py-40-Phase-D.json` seulement.
- `git show origin/main:docs/qc/quantconnect.md | grep` : aucune section « gates minimaux » → cet item restait à livrer.

## Note scope

Les compteurs `Log()` (`n_bars_total`, `n_either`) restent le seul reliquat de l'issue — jugés « plus nécessaires au diagnostic » par le dernier commentaire (la cardinalité 487 172/151 653 = 3,21 établit déjà le point). Après cette PR, l'issue est fermable par le coordinateur si arbitré ainsi (règle #1502 : pas de close worker).

## Test plan

- [x] Section insérée dans « Backtests obligatoires », avant « Convention SetEndDate » (lieu canonique : le point 3 de la liste y cite déjà `read_backtest`)
- [x] Chiffres cités vérifiés contre #14142 c.909 (487 172 / 151 653, `71849ef20`) et c.14215 (B3 : 917 199, −99,88 %)
- [x] +23 lignes, 1 fichier, 0 code touché

See #14142
