### PR TITLE
ci(guards,#10600): tranche 2 residuelle -- paths ratchet + filtre-par-base orphan scan (#12773)

### DIFF
--- a/.github/workflows/orphaned-delivery-scan.yml
+++ b/.github/workflows/orphaned-delivery-scan.yml
@@ -32,6 +32,14 @@ on:
     - cron: '17 6 * * *'
   pull_request:
     types: [closed]
+    # #10600 tranche 2, filter PAR LA BASE, pas par paths : un orphelin est
+    # par definition une PR mergee dont la base != main -- une PR visee sur
+    # main ne peut PAS orpheliner (son merge atteint main directement). Le
+    # filtre paths propose par #12773 aurait rendu l'alerte precoce aveugle
+    # sur la classe canonique (PRs notebooks vers base feature). Ici la
+    # jambe [closed] ne fire QUE la population a risque (~x20 moins de runs,
+    # zero cecite) ; le sweep quotidien reste l'organe primaire inchange.
+    branches-ignore: [main]
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/source-output-ratchet.yml
+++ b/.github/workflows/source-output-ratchet.yml
@@ -34,6 +34,14 @@ name: Source-Output Ratchet
 on:
   pull_request:
     branches: [ main ]
+    # #10600 tranche 2: the ratchet only has something to diff when a
+    # notebook changed -- a PR without .ipynb made it pay a full-history
+    # checkout + python setup to render "no changed notebooks". Script and
+    # workflow self-cover included.
+    paths:
+      - '**/*.ipynb'
+      - 'scripts/notebook_tools/check_source_output_ratchet.py'
+      - '.github/workflows/source-output-ratchet.yml'
   workflow_dispatch:
 
 permissions:

--- a/docs/audit/workflow-path-filters/latest.json
+++ b/docs/audit/workflow-path-filters/latest.json
@@ -1,17 +1,101 @@
 {
-  "generated_at": "2026-08-13T16:57:42.851482+00:00",
+  "checkout_hygiene_positive_control": {
+    "detected": [
+      "bad-clone.yml",
+      "bad-target.yml"
+    ],
+    "expected": [
+      "bad-clone.yml",
+      "bad-target.yml"
+    ],
+    "ok": true,
+    "ran": true
+  },
+  "generated_at": "2026-09-02T09:57:04.838900+00:00",
   "summary": {
-    "filtered": 62,
-    "no_pr_trigger": 10,
-    "total": 82,
-    "unfiltered": 10,
-    "unfiltered_optional": 0,
-    "unfiltered_required": 10,
-    "with_pr_trigger": 72
+    "checkout_hygiene_conforming": 16,
+    "checkout_hygiene_excluded": 1,
+    "checkout_hygiene_machines": 22,
+    "checkout_hygiene_nonconforming": 5,
+    "filtered": 64,
+    "no_pr_trigger": 62,
+    "total": 131,
+    "unfiltered": 5,
+    "unfiltered_optional": 1,
+    "unfiltered_required": 4,
+    "with_pr_trigger": 69
   },
   "workflows": [
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "required",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": true,
+      "name": "always-on-guards.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "required",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": true,
+      "name": "always-on-metadata-guards.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "arxiv-attributions-guard.yml",
+      "paths_count": 10,
+      "paths_list": [
+        "arxiv_attributions_registry.yaml",
+        "scripts/check_arxiv_attributions.py",
+        "scripts/tests/test_check_arxiv_attributions.py",
+        ".github/workflows/arxiv-attributions-guard.yml",
+        "MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb",
+        "MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.5-Phenomenes-de-Generalisation.ipynb",
+        "MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb",
+        "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb",
+        "MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb",
+        "MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "ascii-flowchart-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "banner-guard.yml",
@@ -23,7 +107,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "bare-cross-dir-load-gate.yml",
@@ -35,7 +124,41 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "base-not-main-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "bash-syntax-advisory.yml",
+      "paths_count": 2,
+      "paths_list": [
+        "scripts/**",
+        ".github/workflows/bash-syntax-advisory.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "candidate-delivered-advisory.yml",
@@ -43,7 +166,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "catalog-cron.yml",
@@ -51,7 +179,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "catalog-drift.yml",
@@ -65,15 +198,12 @@
       ]
     },
     {
-      "classification": "required",
-      "has_filter": false,
-      "has_pr_trigger": true,
-      "name": "catalog-pr-guard.yml",
-      "paths_count": 0,
-      "paths_list": []
-    },
-    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "cell-order-gate.yml",
@@ -85,99 +215,236 @@
       ]
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "check-resync-only.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "cjk-residue-advisory.yml",
-      "paths_count": 7,
-      "paths_list": [
-        "**/*.ipynb",
-        "**/*.md",
-        "**/*.py",
-        "**/*.cs",
-        ".github/workflows/cjk-residue-advisory.yml",
-        "scripts/notebook_tools/detect_cjk_residue.py",
-        "scripts/notebook_tools/tests/test_detect_cjk_residue.py"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "degenerate-figure-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_blank_figures.py",
-        ".github/workflows/degenerate-figure-gate.yml"
-      ]
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "concurrency-conj-guard.yml",
+      "paths_count": 0,
+      "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": true,
+      "checkout_hygiene_reason": "nonconforming_full_clone",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
-      "name": "docs-link-check.yml",
-      "paths_count": 7,
-      "paths_list": [
-        "CLAUDE.md",
-        "index.md",
-        "PARCOURS.md",
-        ".claude/rules/**",
-        "docs/**",
-        "**/README.md",
-        "scripts/check_docs_links.py"
-      ]
-    },
-    {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "dotnet-nuget-block-advisory.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "**/*.ipynb",
-        ".github/workflows/dotnet-nuget-block-advisory.yml",
-        "scripts/notebook_tools/check_pr_dotnet_nuget_block.py"
-      ]
-    },
-    {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "exercise-leak-ci.yml",
-      "paths_count": 4,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_solution_leaks.py",
-        "scripts/notebook_tools/exercise_leak_delta.py",
-        ".github/workflows/exercise-leak-ci.yml"
-      ]
-    },
-    {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "exercises-advisory.yml",
+      "name": "consecutive-code-cells-advisory.yml",
       "paths_count": 2,
       "paths_list": [
         "**/*.ipynb",
-        ".github/workflows/exercises-advisory.yml"
+        ".github/workflows/consecutive-code-cells-advisory.yml"
       ]
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "degenerate-figure-gate.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "degraded-mode-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "detect-dup-selftest.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "docs-link-check.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "dotnet-nuget-block-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "epic-charter-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "epic-neglect-sweep.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "exercise-leak-ci.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "exercises-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "fabricated-output-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_fabricated_outputs.py",
-        ".github/workflows/fabricated-output-gate.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "fast-lane-shadow.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "grain-orphans-sweep.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "h1-hygiene-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": true,
+      "checkout_hygiene_reason": "nonconforming_full_clone",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "harness-coauthor-guard.yml",
@@ -193,7 +460,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "hooks-parity.yml",
@@ -206,7 +478,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "ict-tests.yml",
@@ -217,7 +494,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "label-paths-guard.yml",
@@ -229,15 +511,25 @@
       ]
     },
     {
-      "classification": "required",
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
-      "has_pr_trigger": true,
+      "has_pr_trigger": false,
       "name": "lane-claim-guard.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-argumentation.yml",
@@ -250,7 +542,57 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "lean-assignment.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "MyIA.AI.Notebooks/GameTheory/assignment_lean/**.lean",
+        "MyIA.AI.Notebooks/GameTheory/assignment_lean/lakefile.lean",
+        "MyIA.AI.Notebooks/GameTheory/assignment_lean/lakefile.toml",
+        "MyIA.AI.Notebooks/GameTheory/assignment_lean/lean-toolchain"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "lean-asymmetric-information.yml",
+      "paths_count": 13,
+      "paths_list": [
+        "MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean/**.lean",
+        "MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean/lakefile.toml",
+        "MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean/lean-toolchain",
+        "MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean/lake-manifest.json",
+        "MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/**.lean",
+        "MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lakefile.toml",
+        "MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lakefile.lean",
+        "MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain",
+        ".github/workflows/lean-asymmetric-information.yml",
+        ".github/workflows/lean-axiom.yml",
+        ".github/workflows/lean-build.yml",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "lean-axiom.yml",
@@ -258,7 +600,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "lean-build.yml",
@@ -266,7 +613,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-calibration.yml",
@@ -279,20 +631,31 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-conway-cgt.yml",
-      "paths_count": 4,
+      "paths_count": 5,
       "paths_list": [
         "MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/**.lean",
         "MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean",
         "MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.toml",
-        "MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain"
+        "MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain",
+        "MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lake-manifest.json"
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-conway.yml",
@@ -308,7 +671,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-decision-theory.yml",
@@ -321,7 +689,30 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "lean-discrepancy.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "MyIA.AI.Notebooks/Search/discrepancy_lean/**.lean",
+        "MyIA.AI.Notebooks/Search/discrepancy_lean/lakefile.lean",
+        "MyIA.AI.Notebooks/Search/discrepancy_lean/lakefile.toml",
+        "MyIA.AI.Notebooks/Search/discrepancy_lean/lean-toolchain"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-erc20.yml",
@@ -334,7 +725,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-finiteness.yml",
@@ -347,7 +743,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-galois.yml",
@@ -365,7 +766,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-game-defs-ext.yml",
@@ -377,7 +783,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-game-defs.yml",
@@ -389,7 +800,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-game-theory.yml",
@@ -403,16 +819,22 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-grothendieck.yml",
-      "paths_count": 9,
+      "paths_count": 10,
       "paths_list": [
         "MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/**.lean",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.lean",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.toml",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lean-toolchain",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lake-manifest.json",
         ".github/workflows/lean-grothendieck.yml",
         ".github/workflows/lean-axiom.yml",
         ".github/workflows/lean-build.yml",
@@ -421,7 +843,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-i18n-drift.yml",
@@ -433,7 +860,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-kelly.yml",
@@ -446,7 +878,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-knot.yml",
@@ -465,7 +902,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-learning-theory.yml",
@@ -478,7 +920,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-mathlib-examples.yml",
@@ -491,7 +938,30 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "lean-mimo.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/**.lean",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.toml",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lean-toolchain"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-minimax.yml",
@@ -504,7 +974,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-planning.yml",
@@ -517,7 +992,12 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-search.yml",
@@ -530,20 +1010,34 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-sensitivity.yml",
-      "paths_count": 4,
+      "paths_count": 8,
       "paths_list": [
         "MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/**.lean",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.toml",
-        "MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain"
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain",
+        ".github/workflows/lean-sensitivity.yml",
+        ".github/workflows/lean-axiom.yml",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py"
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-social-choice-peters.yml",
@@ -556,20 +1050,38 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-social-choice.yml",
-      "paths_count": 4,
+      "paths_count": 12,
       "paths_list": [
         "MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/**.lean",
+        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt",
         "MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice.lean",
+        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/Abstraction.lean",
+        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/Abstraction/**.lean",
         "MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean",
-        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/lean-toolchain"
+        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/lean-toolchain",
+        ".github/workflows/lean-social-choice.yml",
+        ".github/workflows/lean-axiom.yml",
+        "scripts/lean/check_certified_sorry.py",
+        "scripts/lean/count_code_sorry.py",
+        "scripts/tests/test_check_certified_sorry.py"
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "lean-sudoku.yml",
@@ -582,19 +1094,51 @@
       ]
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "machine-dep-timing-advisory.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/check_machine_dep_timing.py",
-        "scripts/notebook_tools/tests/test_check_machine_dep_timing.py"
-      ]
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "linux-self-hosted-tests.yml",
+      "paths_count": 0,
+      "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "machine-dep-timing-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "machine-dep-timing-inventory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "manifest-description-visuelle-gate.yml",
@@ -606,13 +1150,37 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "markdown-claims-output-advisory.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "MyIA.AI.Notebooks/**/*.ipynb",
+        "scripts/check_markdown_claims_output.py",
+        "scripts/tests/test_check_markdown_claims_output.py",
+        ".github/workflows/markdown-claims-output-advisory.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "markdown-rendering-guard.yml",
-      "paths_count": 5,
+      "paths_count": 6,
       "paths_list": [
         "**.ipynb",
+        "_quarto.yml",
         "scripts/notebook_tools/detect_markdown_rendering.py",
         "scripts/notebook_tools/scan_md_hierarchy.py",
         "scripts/notebook_tools/markdown_rendering_baseline.json",
@@ -620,32 +1188,38 @@
       ]
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "markdown-table-guard.yml",
-      "paths_count": 4,
-      "paths_list": [
-        "**/*.ipynb",
-        "**/*.md",
-        "**/README*",
-        ".github/workflows/markdown-table-guard.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "md-content-loss-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_md_content_loss.py",
-        ".github/workflows/md-content-loss-gate.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "ml-tests.yml",
@@ -658,7 +1232,47 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": true,
+      "checkout_hygiene_reason": "nonconforming_full_clone",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "notebook-cell-source-parses.yml",
+      "paths_count": 3,
+      "paths_list": [
+        "**.ipynb",
+        "scripts/notebook_tools/check_cell_source_parses.py",
+        ".github/workflows/notebook-cell-source-parses.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "notebook-exec-sequence-ratchet.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "**.ipynb",
+        "scripts/notebook_tools/check_exec_sequence.py",
+        "scripts/notebook_tools/check_exec_ratchet.py",
+        ".github/workflows/notebook-exec-sequence-ratchet.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "notebook-execution-required.yml",
@@ -672,7 +1286,30 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "notebook-interp-positioning.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "MyIA.AI.Notebooks/**/*.ipynb",
+        "scripts/notebook_tools/check_interp_positioning.py",
+        "scripts/notebook_tools/interp_positioning_baseline.json",
+        ".github/workflows/notebook-interp-positioning.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "notebook-navlink-check.yml",
@@ -685,7 +1322,42 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "notebook-output-failure-ratchet.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "notebook-papermill-ratchet.yml",
+      "paths_count": 3,
+      "paths_list": [
+        "**.ipynb",
+        "scripts/notebook_tools/check_papermill_ratchet.py",
+        ".github/workflows/notebook-papermill-ratchet.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "notebook-validation.yml",
@@ -695,7 +1367,51 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "orphan-branch-scan.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "optional",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": true,
+      "name": "orphaned-delivery-scan.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "outputs-text-fragmentation-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "owui-playwright-check.yml",
@@ -706,7 +1422,38 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "pedagogy-density-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "perimeter-review-guard.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "pip-leak-guard.yml",
@@ -719,7 +1466,25 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "pr-gate-missing-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "pr-gate-rerun.yml",
@@ -727,7 +1492,38 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "pr-gate-stale-sweep.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": false,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "pr-gate-sweep-health-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "required",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": true,
       "name": "pr-gate.yml",
@@ -735,7 +1531,25 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "pr-path-collision-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "prose-counts-guard.yml",
@@ -746,35 +1560,138 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": false,
-      "name": "quarto-pages-deploy.yml",
+      "name": "qc-research-monitor.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
-      "classification": "required",
-      "has_filter": false,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
       "has_pr_trigger": true,
+      "name": "quantconnect-notebook-freshness.yml",
+      "paths_count": 4,
+      "paths_list": [
+        "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/**/*.ipynb",
+        "scripts/check_quantconnect_notebook_freshness.py",
+        "scripts/tests/test_check_quantconnect_notebook_freshness.py",
+        ".github/workflows/quantconnect-notebook-freshness.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "quarto-pages-deploy.yml",
+      "paths_count": 8,
+      "paths_list": [
+        "_quarto.yml",
+        "**.qmd",
+        "MyIA.AI.Notebooks/**/index.qmd",
+        "MyIA.AI.Notebooks/**/*.ipynb",
+        "MyIA.AI.Notebooks/**/_output.ipynb",
+        "MyIA.AI.Notebooks/**/README.md",
+        "docs/**",
+        "scripts/quarto_yaml_safe.py"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "regression-guard.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
-      "classification": "required",
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": false,
-      "has_pr_trigger": true,
+      "has_pr_trigger": false,
+      "name": "render-volume-delta-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "repo-size-advisory.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "review-coverage-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": true,
+      "checkout_hygiene_reason": "nonconforming_full_clone",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "scan-md-hierarchy-drift.yml",
+      "paths_count": 3,
+      "paths_list": [
+        "MyIA.AI.Notebooks/**/*.ipynb",
+        "scripts/notebook_tools/scan_md_hierarchy.py",
+        "scripts/notebook_tools/md_hierarchy_baseline.json"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "scripts-tests.yml",
-      "paths_count": 11,
+      "paths_count": 18,
       "paths_list": [
         "scripts/**",
         "tests/**",
@@ -786,11 +1703,23 @@
         "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tree_lock.py",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/forensic_guards.py",
-        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py"
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain",
+        "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py",
+        ".github/workflows/pr-gate-rerun.yml",
+        ".github/workflows/**"
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "excluded_full_history",
       "classification": "required",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": false,
       "has_pr_trigger": true,
       "name": "secret-scan.yml",
@@ -798,18 +1727,64 @@
       "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "slides-build-advisory.yml",
-      "paths_count": 2,
-      "paths_list": [
-        "slides/**",
-        ".github/workflows/slides-build-advisory.yml"
-      ]
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "series-naming-gate.yml",
+      "paths_count": 0,
+      "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "slides-build-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "slides-composition-advisory.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "slow-lane.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "solution-leak-guard.yml",
@@ -822,63 +1797,120 @@
       ]
     },
     {
-      "classification": "required",
-      "has_filter": false,
+      "checkout_hygiene_nonconforming": true,
+      "checkout_hygiene_reason": "nonconforming_full_clone",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
       "has_pr_trigger": true,
+      "name": "source-output-ratchet.yml",
+      "paths_count": 3,
+      "paths_list": [
+        "**/*.ipynb",
+        "scripts/notebook_tools/check_source_output_ratchet.py",
+        ".github/workflows/source-output-ratchet.yml"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "stale-base-warning.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "stale-guard-red-sweep.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "svg-broken-geometry-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_svg_broken_geometry.py",
-        ".github/workflows/svg-broken-geometry-gate.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "svg-decimal-comma-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_svg_decimal_commas.py",
-        ".github/workflows/svg-decimal-comma-gate.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "svg-empty-display-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_svg_empty_display.py",
-        ".github/workflows/svg-empty-display-gate.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
       "name": "svg-offscreen-flat-gate.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "MyIA.AI.Notebooks/**/*.ipynb",
-        "scripts/notebook_tools/detect_svg_offscreen_flat.py",
-        ".github/workflows/svg-offscreen-flat-gate.yml"
-      ]
+      "paths_count": 0,
+      "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "testpaths-coverage-guard.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "translation-drift.yml",
@@ -890,27 +1922,50 @@
       ]
     },
     {
-      "classification": "required",
-      "has_filter": false,
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
+      "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": true,
       "has_pr_trigger": true,
       "name": "translation-guard.yml",
+      "paths_count": 11,
+      "paths_list": [
+        ".github/workflows/translation-guard.yml",
+        "scripts/ci/translation_override_required.py",
+        "scripts/tests/test_translation_override_required.py",
+        "translations/**",
+        "MyIA.AI.Notebooks/**/*_en.ipynb",
+        "MyIA.AI.Notebooks/**/*_es.ipynb",
+        "MyIA.AI.Notebooks/**/*_ar.ipynb",
+        "MyIA.AI.Notebooks/**/*_fa.ipynb",
+        "MyIA.AI.Notebooks/**/*_zh.ipynb",
+        "MyIA.AI.Notebooks/**/*_ru.ipynb",
+        "MyIA.AI.Notebooks/**/*_pt.ipynb"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "translation-parity.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
-      "classification": "filtered",
-      "has_filter": true,
-      "has_pr_trigger": true,
-      "name": "translation-parity.yml",
-      "paths_count": 3,
-      "paths_list": [
-        "*.ipynb",
-        "scripts/translation/check_translation_parity.py",
-        ".github/workflows/translation-parity.yml"
-      ]
-    },
-    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "translation-sync.yml",
@@ -918,7 +1973,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "twin-parity-cron.yml",
@@ -926,7 +1986,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "twin-parity-drift-audit.yml",
@@ -934,7 +1999,12 @@
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "conforming_blob_none",
       "classification": "filtered",
+      "has_blob_none_filter": true,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": true,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "twin-parity.yml",
@@ -946,7 +2016,29 @@
       ]
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
       "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": true,
+      "has_pr_trigger": true,
+      "name": "unique-check-run-names-guard.yml",
+      "paths_count": 3,
+      "paths_list": [
+        ".github/workflows/**",
+        "scripts/ci/check_unique_check_run_names.py",
+        "scripts/pr_gate.py"
+      ]
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_fetch_depth_zero",
+      "classification": "filtered",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": true,
       "has_pr_trigger": true,
       "name": "validation-matrix.yml",
@@ -957,23 +2049,51 @@
       ]
     },
     {
-      "classification": "required",
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
-      "has_pr_trigger": true,
+      "has_pr_trigger": false,
       "name": "variation-light-genre.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
-      "classification": "required",
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
-      "has_pr_trigger": true,
+      "has_pr_trigger": false,
       "name": "variation-tag-guard.yml",
       "paths_count": 0,
       "paths_list": []
     },
     {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
       "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
+      "has_filter": false,
+      "has_pr_trigger": false,
+      "name": "windows-self-hosted-tests.yml",
+      "paths_count": 0,
+      "paths_list": []
+    },
+    {
+      "checkout_hygiene_nonconforming": false,
+      "checkout_hygiene_reason": "no_pr_trigger",
+      "classification": "no_pr_trigger",
+      "has_blob_none_filter": false,
+      "has_checkout_step": true,
+      "has_fetch_depth_0": false,
       "has_filter": false,
       "has_pr_trigger": false,
       "name": "workflow-path-filter-audit.yml",
@@ -981,5 +2101,5 @@
       "paths_list": []
     }
   ],
-  "workflows_dir": "C:\\dev\\CoursIA-2-c1331x134-workflow-audit\\.github\\workflows"
+  "workflows_dir": "C:\\dev\\CoursIA-12773-tranche2b\\.github\\workflows"
 }

--- a/docs/audit/workflow-path-filters/latest.md
+++ b/docs/audit/workflow-path-filters/latest.md
@@ -1,98 +1,122 @@
 # Audit workflow path-filters
 
-**Generated** : 2026-08-13T16:57:42.851482+00:00
-**Workflows dir** : `C:\dev\CoursIA-2-c1331x134-workflow-audit\.github\workflows`
+**Generated** : 2026-09-02T09:57:04.838900+00:00
+**Workflows dir** : `C:\dev\CoursIA-12773-tranche2b\.github\workflows`
 
 ## Summary
 
 | Metrique | Valeur |
 |---|---|
-| Total workflows | 82 |
-| Avec `pull_request` trigger | 72 |
-| **Avec filtre paths/paths-ignore** | **62** |
-| Sans filtre | 10 |
-| - dont required (gates/advisories) | 10 |
-| - dont optional (a investiguer) | 0 |
-| Sans `pull_request` trigger | 10 |
+| Total workflows | 131 |
+| Avec `pull_request` trigger | 69 |
+| **Avec filtre paths/paths-ignore** | **64** |
+| Sans filtre | 5 |
+| - dont required (gates/advisories) | 4 |
+| - dont optional (a investiguer) | 1 |
+| Sans `pull_request` trigger | 62 |
 
 ## Sans filtre `paths`/`paths-ignore`
 
 ### Required (gates/advisories - non-concerne par l'audit)
 
-- `catalog-pr-guard.yml`
-- `lane-claim-guard.yml`
+- `always-on-guards.yml`
+- `always-on-metadata-guards.yml`
 - `pr-gate.yml`
-- `regression-guard.yml`
-- `repo-size-advisory.yml`
 - `secret-scan.yml`
-- `stale-base-warning.yml`
-- `translation-guard.yml`
-- `variation-light-genre.yml`
-- `variation-tag-guard.yml`
+
+### Optional (a investiguer - devrait avoir un filtre)
+
+- `orphaned-delivery-scan.yml`
 
 ## Avec filtre `paths`/`paths-ignore`
 
 | Workflow | paths_count |
 |---|---|
+| `arxiv-attributions-guard.yml` | 10 |
 | `banner-guard.yml` | 3 |
 | `bare-cross-dir-load-gate.yml` | 3 |
+| `bash-syntax-advisory.yml` | 2 |
 | `catalog-drift.yml` | 5 |
 | `cell-order-gate.yml` | 3 |
-| `cjk-residue-advisory.yml` | 7 |
-| `degenerate-figure-gate.yml` | 3 |
-| `docs-link-check.yml` | 7 |
-| `dotnet-nuget-block-advisory.yml` | 3 |
-| `exercise-leak-ci.yml` | 4 |
-| `exercises-advisory.yml` | 2 |
-| `fabricated-output-gate.yml` | 3 |
+| `consecutive-code-cells-advisory.yml` | 2 |
 | `harness-coauthor-guard.yml` | 7 |
 | `hooks-parity.yml` | 4 |
 | `ict-tests.yml` | 2 |
 | `label-paths-guard.yml` | 3 |
 | `lean-argumentation.yml` | 4 |
+| `lean-assignment.yml` | 4 |
+| `lean-asymmetric-information.yml` | 13 |
 | `lean-calibration.yml` | 4 |
-| `lean-conway-cgt.yml` | 4 |
+| `lean-conway-cgt.yml` | 5 |
 | `lean-conway.yml` | 7 |
 | `lean-decision-theory.yml` | 4 |
+| `lean-discrepancy.yml` | 4 |
 | `lean-erc20.yml` | 4 |
 | `lean-finiteness.yml` | 4 |
 | `lean-galois.yml` | 9 |
 | `lean-game-defs-ext.yml` | 3 |
 | `lean-game-defs.yml` | 3 |
 | `lean-game-theory.yml` | 5 |
-| `lean-grothendieck.yml` | 9 |
+| `lean-grothendieck.yml` | 10 |
 | `lean-i18n-drift.yml` | 3 |
 | `lean-kelly.yml` | 4 |
 | `lean-knot.yml` | 10 |
 | `lean-learning-theory.yml` | 4 |
 | `lean-mathlib-examples.yml` | 4 |
+| `lean-mimo.yml` | 4 |
 | `lean-minimax.yml` | 4 |
 | `lean-planning.yml` | 4 |
 | `lean-search.yml` | 4 |
-| `lean-sensitivity.yml` | 4 |
+| `lean-sensitivity.yml` | 8 |
 | `lean-social-choice-peters.yml` | 4 |
-| `lean-social-choice.yml` | 4 |
+| `lean-social-choice.yml` | 12 |
 | `lean-sudoku.yml` | 4 |
-| `machine-dep-timing-advisory.yml` | 3 |
 | `manifest-description-visuelle-gate.yml` | 3 |
-| `markdown-rendering-guard.yml` | 5 |
-| `markdown-table-guard.yml` | 4 |
-| `md-content-loss-gate.yml` | 3 |
+| `markdown-claims-output-advisory.yml` | 4 |
+| `markdown-rendering-guard.yml` | 6 |
 | `ml-tests.yml` | 4 |
+| `notebook-cell-source-parses.yml` | 3 |
+| `notebook-exec-sequence-ratchet.yml` | 4 |
 | `notebook-execution-required.yml` | 5 |
+| `notebook-interp-positioning.yml` | 4 |
 | `notebook-navlink-check.yml` | 4 |
+| `notebook-papermill-ratchet.yml` | 3 |
 | `notebook-validation.yml` | 1 |
 | `owui-playwright-check.yml` | 2 |
 | `pip-leak-guard.yml` | 4 |
 | `prose-counts-guard.yml` | 2 |
-| `scripts-tests.yml` | 11 |
-| `slides-build-advisory.yml` | 2 |
+| `quantconnect-notebook-freshness.yml` | 4 |
+| `quarto-pages-deploy.yml` | 8 |
+| `scan-md-hierarchy-drift.yml` | 3 |
+| `scripts-tests.yml` | 18 |
 | `solution-leak-guard.yml` | 4 |
-| `svg-broken-geometry-gate.yml` | 3 |
-| `svg-decimal-comma-gate.yml` | 3 |
-| `svg-empty-display-gate.yml` | 3 |
-| `svg-offscreen-flat-gate.yml` | 3 |
+| `source-output-ratchet.yml` | 3 |
 | `translation-drift.yml` | 3 |
-| `translation-parity.yml` | 3 |
+| `translation-guard.yml` | 11 |
 | `twin-parity.yml` | 3 |
+| `unique-check-run-names-guard.yml` | 3 |
 | `validation-matrix.yml` | 2 |
+
+## Hygiene de checkout (fetch-depth: 0 sans filter: blob:none)
+
+| Metrique | Valeur |
+|---|---|
+| Workflows PR clonant sans clone partiel | **5** |
+| - conformes (blob:none present) | 16 |
+| - exclus (clone complet necessaire) | 1 |
+| Machines a clone (PR trigger + fetch-depth: 0) | 22 |
+
+### Non conformes (a corriger en clone partiel)
+
+- `consecutive-code-cells-advisory.yml`
+- `harness-coauthor-guard.yml`
+- `notebook-cell-source-parses.yml`
+- `scan-md-hierarchy-drift.yml`
+- `source-output-ratchet.yml`
+
+### Controle positif hygiene-checkout
+
+- Ran : `True`
+- Attendu : `bad-clone.yml, bad-target.yml`
+- Detecte : `bad-clone.yml, bad-target.yml`
+- **OK**

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -910,7 +910,11 @@ def test_derive_always_on_reads_real_workflows_and_excludes_self():
     includes the gate's own job. Run against the live .github/workflows.
     """
     jobs = pr_gate.derive_always_on_jobs()
-    assert len(jobs) >= 6, "expected at least the catalog/secret/regression/" \
+    # #12773 tranche 2b made Source-Output Ratchet path-filtered, dropping the
+    # roster from 6 to 5.  5 is the floor for THIS roster; the assertion exists
+    # to trip on decay to "no always-on jobs at all" (partial delivery, #9858),
+    # so a future tranche shrinking it further must update this number too.
+    assert len(jobs) >= 5, "expected at least the catalog/secret/regression/" \
         "stale-base/variation always-on jobs from the real repo"
     assert all(pr_gate.DEFAULT_SELF_NAME not in j for j in jobs), \
         "the gate must never canary itself"


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA — prev: MED/guard #14267

# Tranche 2 résiduelle #12773 : le body disait 11, le réel dit 2 — dont 1 traité mieux que par paths

`See #12773` (contribution partielle à l'epic #10600 ; fermeture de #12773 au coordinateur — voir « Acceptance » ci-dessous).

## Confrontation body vs réel (pré-qualifiée le cycle précédent)

L'inventaire de l'issue (2026-08-31) listait **13 unfiltered / 11 éligibles**. Mesure du jour via l'instrument tranche 1 (`audit_workflow_path_filters.py`) : **6 unfiltered dont 4 required exemptés by-design** (always-on-guards, always-on-metadata-guards, pr-gate, secret-scan — l'exemption est dans le titre même de l'issue). Les 9 autres éligibles ont été livrés par les PRs récentes (#14065 + suivantes). Résidu réel : **2 workflows**.

## Les deux traitements — différents, par design

### 1. `source-output-ratchet.yml` — paths, la proposition de l'issue s'applique

L'advisory diff les **notebooks changés** ; une PR sans `.ipynb` lui faisait payer un checkout full-history (`fetch-depth: 0`) + setup-python pour rendre « no changed notebooks ». Filtre : `**/*.ipynb` + le script + self-cover du workflow. **Zéro perte sémantique** — sans notebook changé, il n'existe rien à checker.

### 2. `orphaned-delivery-scan.yml` — la proposition paths de l'issue était un piège ; filtre par la BASE à la place

Un orphelin (#10981) est par définition une PR mergée dont la **base != main**. Un filtre paths aurait rendu la jambe `[closed]` aveugle sur la classe canonique (PRs notebooks vers bases feature — incident fondateur #10972 : du contenu quarto/yml, pas du markdown). Le bon discriminant : **`branches-ignore: [main]`** — la jambe `[closed]` ne fire QUE la population à risque (~x20 moins de runs, **zéro cécité** : une PR visée sur main ne peut pas orpheliner, son merge atteint main directement). Le sweep quotidien 06:17 UTC, organe primaire selon l'en-tête du workflow, reste inchangé.

**Conséquence métrique, écrite** : l'instrument compte `paths/paths-ignore` uniquement — orphaned-delivery-scan restera « optional unfiltered » dans le rapport alors que sa jambe PR est désormais plus ciblée qu'un paths. La métrique dit 6→5 (optional 2→1) ; la réduction réelle de runs est supérieure à ce que la métrique montre.

## Mesure avant/après (worktree, même instrument)

| | avant | après |
|---|---|---|
| Sans filtre | 6 | **5** |
| - dont required (exempts by-design) | 4 | 4 |
| - dont optional | 2 | **1** (orphaned-delivery-scan, volontairement branches-filtré) |

`latest.json`/`latest.md` régénérés dans le worktree — ils portent aussi le rattrapage des transitions livrées par les PRs récentes (l'artefact commité datait d'avant), pas seulement mes 2 fichiers.

## Repair post-CI : `scripts/tests/test_pr_gate.py` (commit `d134afe9f2`)

`Scripts Tests (CPU)` échouait sur `test_derive_always_on_reads_real_workflows_and_excludes_self` : le test pinnaît `len(jobs) >= 6` always-on, mais **cette PR elle-même** retire `source-output-ratchet` du roster always-on (il devient path-filtré) → 6→5. Racine = interaction, pas staleness. Fix : seuil abaissé à `>= 5` avec commentaire documentant pourquoi 5 est le plancher de CE roster et que le test existe pour détecter la décroissance vers « aucun always-on » (delivery partielle, #9858) — une future tranche qui le réduit encore doit mettre à jour ce nombre.

## Validation

- YAML parse des deux workflows : OK.
- Instrument audit re-run dans le worktree : contrôle positif interne OK (`bad-clone`/`bad-target` détectés).
- Policy gate self-hosted : `workflows=131 jobs=159 self_hosted=14 OK`.
- **Regression check (leçon #14267 appliquée d'abord)** : `grep -r 'source-output-ratchet|orphaned-delivery-scan' scripts/` → hit unique = docstring de l'instrument. Aucun test ne pinne la forme de ces workflows — le piège de ce matin n'existe pas ici.
- **Scripts Tests (CPU) post-repair : SUCCESS** (head `d134afe9f2`).

## Acceptance — pourquoi `See` et pas `Closes`

L'acceptance littérale (11 paths) aboutit à **10 paths + 1 branches-filter supérieur**. Le but de l'epic #10600 (réduire le stampede per-PR) est atteint au-delà de la lettre. La déviation sur orphaned-delivery-scan et la fermeture de #12773 relèvent du coordinateur.

## Périmètre : 5 fichiers

- `.github/workflows/source-output-ratchet.yml` (+8)
- `.github/workflows/orphaned-delivery-scan.yml` (+8)
- `docs/audit/workflow-path-filters/latest.json` (+1307/-187)
- `docs/audit/workflow-path-filters/latest.md` (+63/-39)
- `scripts/tests/test_pr_gate.py` (+5/-1, repair post-CI documenté ci-dessus)

## Preuve d'identité

- Branche `feature/12773-tranche2b-filters`, base `origin/main` (`da1d250936`), 2 commits : `fe35bc3044` (tranche) + `d134afe9f2` (repair test threshold).
- `[CLAIMED] paths:` posé avant édition ([comment](https://github.com/jsboige/CoursIA/issues/12773#issuecomment-5507783409)) — claim précédent (po-2024:CoursIA-2) périmé 172,8 h, reprise autorisée par l'organe.
