### PR TITLE
feat(qc,#13117): Phase F - edge-trigger and cooldown both falsified as sur-trading remedies

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -5,6 +5,19 @@
    "execution_count": 1,
    "id": "9be7293c",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:09.367029Z",
+     "iopub.status.busy": "2026-09-02T10:11:09.366727Z",
+     "iopub.status.idle": "2026-09-02T10:11:09.376587Z",
+     "shell.execute_reply": "2026-09-02T10:11:09.376036Z"
+    },
+    "papermill": {
+     "duration": 0.015619,
+     "end_time": "2026-09-02T10:11:09.377790",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:09.362171",
+     "status": "completed"
+    },
     "tags": [
      "injected-parameters"
     ]
@@ -19,6 +32,13 @@
    "cell_type": "markdown",
    "id": "0bfe4aa3",
    "metadata": {
+    "papermill": {
+     "duration": 0.003233,
+     "end_time": "2026-09-02T10:11:09.384636",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:09.381403",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -48,6 +68,19 @@
    "execution_count": 2,
    "id": "7cf1a8c4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:09.393774Z",
+     "iopub.status.busy": "2026-09-02T10:11:09.393336Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.824729Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.824036Z"
+    },
+    "papermill": {
+     "duration": 2.437513,
+     "end_time": "2026-09-02T10:11:11.825660",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:09.388147",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -84,6 +117,13 @@
    "cell_type": "markdown",
    "id": "5a3bfb5d",
    "metadata": {
+    "papermill": {
+     "duration": 0.003588,
+     "end_time": "2026-09-02T10:11:11.832816",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.829228",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -109,6 +149,19 @@
    "execution_count": 3,
    "id": "cabb4d3d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.840270Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.839964Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.845105Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.844425Z"
+    },
+    "papermill": {
+     "duration": 0.009947,
+     "end_time": "2026-09-02T10:11:11.845940",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.835993",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -152,6 +205,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-config",
    "metadata": {
+    "papermill": {
+     "duration": 0.003875,
+     "end_time": "2026-09-02T10:11:11.853704",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.849829",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -166,6 +226,13 @@
    "cell_type": "markdown",
    "id": "ad0c6f29",
    "metadata": {
+    "papermill": {
+     "duration": 0.00326,
+     "end_time": "2026-09-02T10:11:11.860408",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.857148",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -189,6 +256,19 @@
    "execution_count": 4,
    "id": "a28a5593",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.869413Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.868964Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.875207Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.874711Z"
+    },
+    "papermill": {
+     "duration": 0.012326,
+     "end_time": "2026-09-02T10:11:11.876179",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.863853",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -441,7 +521,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5bb9ead3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003954,
+     "end_time": "2026-09-02T10:11:11.883488",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.879534",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Pourquoi une deuxieme version de l'algorithme\n",
     "\n",
@@ -457,6 +547,19 @@
    "execution_count": 5,
    "id": "qc-py-40-b2-lean",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.891395Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.891004Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.896460Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.895757Z"
+    },
+    "papermill": {
+     "duration": 0.010485,
+     "end_time": "2026-09-02T10:11:11.897396",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.886911",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -600,6 +703,13 @@
    "cell_type": "markdown",
    "id": "a408fdba",
    "metadata": {
+    "papermill": {
+     "duration": 0.003318,
+     "end_time": "2026-09-02T10:11:11.904742",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.901424",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -626,6 +736,19 @@
    "execution_count": 6,
    "id": "1bd078ca",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.913054Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.912638Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.920926Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.920149Z"
+    },
+    "papermill": {
+     "duration": 0.013756,
+     "end_time": "2026-09-02T10:11:11.921817",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.908061",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -857,6 +980,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-backtest",
    "metadata": {
+    "papermill": {
+     "duration": 0.00332,
+     "end_time": "2026-09-02T10:11:11.928782",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.925462",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -878,7 +1008,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "89d61357",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0052,
+     "end_time": "2026-09-02T10:11:11.937781",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.932581",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Phases D et E : instrumenter, puis trouver la vraie cause\n",
     "\n",
@@ -910,7 +1050,23 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "id": "70d7e356",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.946469Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.946268Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.953327Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.952895Z"
+    },
+    "papermill": {
+     "duration": 0.01271,
+     "end_time": "2026-09-02T10:11:11.954062",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.941352",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -999,7 +1155,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "99e6c77b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003472,
+     "end_time": "2026-09-02T10:11:11.961199",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.957727",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : ce que B3 a tranche\n",
     "\n",
@@ -1016,10 +1182,505 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-qcpy40-phasef-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003667,
+     "end_time": "2026-09-02T10:11:11.968516",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.964849",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Phase F : corriger le sur-trading -- deux remedes, une variable chacun\n",
+    "\n",
+    "B3 a etabli le diagnostic : `set_holdings` etait appele a chaque barre Minute ou la condition d'entree tenait, d'ou 917 199 ordres en quatre ans -- environ 628 par jour -- chacun ponctionne de 0,1 % de frais, pour un resultat net de -99,88 %. La Phase F teste deux remedes candidats, en conservant la discipline des runs B : **une seule variable changee par backtest**.\n",
+    "\n",
+    "**B4 -- entrer sur front montant (edge-triggered).** Un circuit numerique peut reagir au *niveau* d'un signal (tant que la condition tient, j'agis -- a chaque barre) ou a son *front* (j'agis une seule fois, a l'instant precis ou la condition passe de fausse a vraie). B4 memorise l'etat de la condition AND a la barre precedente et n'emet un ordre que sur la transition `False -> True`. Tant que la condition reste vraie, plus aucun ordre n'est emis. Un detail d'implementation compte : l'etat du signal est mis a jour **chaque barre, avant le traitement des sorties** -- le `continue` des sorties ne doit jamais sauter cette mise a jour, sinon la sortie laisse un etat perime qui fabrique, ou avale, un front a la barre suivante.\n",
+    "\n",
+    "**B5 -- cooldown de 60 minutes apres sortie.** Apres chaque sortie (stop-loss ou retour a la mediane), aucune re-entree sur le symbole pendant une heure. Ce garde est strictement plus restrictif que B4 sur les entrees : il plafonne theoriquement la frequence a ~24 entrees par jour et par symbole.\n",
+    "\n",
+    "Les deux algoritmes sont ceux des backtests QC Cloud du projet 35674722 (`B4_PhaseF_edge_triggered_entry`, `B5_PhaseF_cooldown_60min`)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "cell-qcpy40-phasef-algo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.976289Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.976092Z",
+     "iopub.status.idle": "2026-09-02T10:11:11.981845Z",
+     "shell.execute_reply": "2026-09-02T10:11:11.981227Z"
+    },
+    "papermill": {
+     "duration": 0.010508,
+     "end_time": "2026-09-02T10:11:11.982533",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.972025",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LEAN_ALGORITHM_B4 + B5 (Phase F remediation sur-trading) prets pour backtest QC Cloud.\n",
+      "Taille B4: 5863 caracteres ; B5: 6824 caracteres\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Algorithmes LEAN Phase F : B4 (edge-triggered) puis B5 (+ cooldown 60 min)\n",
+    "# Ce code est celui du projet QC Cloud 35674722, une variable par run.\n",
+    "\n",
+    "LEAN_ALGORITHM_B4 = \"\"\"# region imports\n",
+    "from AlgorithmImports import *\n",
+    "# endregion\n",
+    "\n",
+    "\n",
+    "class BinanceMeanReversionBB_B4(QCAlgorithm):\n",
+    "    '''\n",
+    "    Phase F B4 = B3 a UNE seule variable pres : l'entree devient EDGE-TRIGGERED.\n",
+    "    B3 entrait sur NIVEAU (set_holdings a chaque barre Minute ou la condition\n",
+    "    AND tient, tant que la position est plate) : 917 199 ordres en 4 ans,\n",
+    "    628/jour, chaque remplissage ponctionne de 0,1% de frais -> net -99,88%.\n",
+    "    B4 entre sur TRANSITION (front montant de la condition AND, false -> true).\n",
+    "    Tout le reste (dates, devise USDT, indicateurs, sorties, compteurs) est B3.\n",
+    "    '''\n",
+    "\n",
+    "    def initialize(self):\n",
+    "        self.set_start_date(2021, 1, 1)\n",
+    "        self.set_end_date(2024, 12, 31)\n",
+    "        self.set_account_currency(\"USDT\")\n",
+    "        self.set_cash(10000)\n",
+    "        self.set_brokerage_model(BrokerageName.BINANCE, AccountType.CASH)\n",
+    "\n",
+    "        self.btc = self.add_crypto(\"BTCUSDT\", Resolution.MINUTE, Market.BINANCE)\n",
+    "        self.eth = self.add_crypto(\"ETHUSDT\", Resolution.MINUTE, Market.BINANCE)\n",
+    "        self.symbols = [self.btc.symbol, self.eth.symbol]\n",
+    "\n",
+    "        self.bb_period = 20\n",
+    "        self.bb_std = 2.0\n",
+    "        self.bb_indicator = {}\n",
+    "        for sym in self.symbols:\n",
+    "            self.bb_indicator[sym] = self.bb(sym, self.bb_period, self.bb_std, resolution=Resolution.MINUTE)\n",
+    "\n",
+    "        self.rsi_indicator = {}\n",
+    "        for sym in self.symbols:\n",
+    "            self.rsi_indicator[sym] = self.rsi(sym, 14, resolution=Resolution.MINUTE)\n",
+    "\n",
+    "        self.stop_loss_pct = 0.05\n",
+    "        self.position_weight = 0.4\n",
+    "        self.entry_prices = {}\n",
+    "\n",
+    "        self.set_warm_up(self.bb_period, Resolution.MINUTE)\n",
+    "\n",
+    "        # === B1 INSTRUMENTATION : compteurs (inchanges) ===\n",
+    "        self.n_bars_total = 0\n",
+    "        self.n_guard_skip_warmup = 0\n",
+    "        self.n_guard_skip_no_data = 0\n",
+    "        self.n_guard_skip_not_ready = 0\n",
+    "        self.n_price_below = 0\n",
+    "        self.n_rsi_below = 0\n",
+    "        self.n_both = 0\n",
+    "        self.n_entry_attempts = 0\n",
+    "        self.n_trades_filled = 0\n",
+    "        self.sample_log_counter = 0\n",
+    "\n",
+    "        # === B4 : SEULE VARIABLE CHANGEE vs B3 ===\n",
+    "        # Etat du signal d'entree a la barre precedente, par symbole.\n",
+    "        # L'entree se declenche uniquement sur front montant (False -> True).\n",
+    "        self.prev_entry_signal = {sym: False for sym in self.symbols}\n",
+    "        self.n_entry_edges = 0\n",
+    "\n",
+    "    def on_data(self, data):\n",
+    "        if self.is_warming_up:\n",
+    "            self.n_guard_skip_warmup += 1\n",
+    "            return\n",
+    "\n",
+    "        for sym in self.symbols:\n",
+    "            if sym not in data or data[sym] is None:\n",
+    "                self.n_guard_skip_no_data += 1\n",
+    "                continue\n",
+    "            if not self.bb_indicator[sym].is_ready or not self.rsi_indicator[sym].is_ready:\n",
+    "                self.n_guard_skip_not_ready += 1\n",
+    "                continue\n",
+    "\n",
+    "            self.n_bars_total += 1\n",
+    "\n",
+    "            price = data[sym].price\n",
+    "            bb_lower = self.bb_indicator[sym].lower_band.current.value\n",
+    "            bb_middle = self.bb_indicator[sym].middle_band.current.value\n",
+    "            rsi_val = self.rsi_indicator[sym].current.value\n",
+    "\n",
+    "            price_ok = price < bb_lower\n",
+    "            rsi_ok = rsi_val < 35\n",
+    "            entry_signal = price_ok and rsi_ok\n",
+    "            if price_ok:\n",
+    "                self.n_price_below += 1\n",
+    "            if rsi_ok:\n",
+    "                self.n_rsi_below += 1\n",
+    "            if entry_signal:\n",
+    "                self.n_both += 1\n",
+    "\n",
+    "            self.sample_log_counter += 1\n",
+    "            if self.sample_log_counter >= 10000:\n",
+    "                self.sample_log_counter = 0\n",
+    "                self.log(f\"SAMPLE {self.Time} {sym} price={price:.2f} bb_low={bb_lower:.2f} rsi={rsi_val:.1f} bb_ready={self.bb_indicator[sym].is_ready} rsi_ready={self.rsi_indicator[sym].is_ready} price_ok={price_ok} rsi_ok={rsi_ok}\")\n",
+    "\n",
+    "            # === B4 : entree sur FRONT MONTANT uniquement ===\n",
+    "            # L'etat du signal est mis a jour CHAQUE barre, AVANT les sorties :\n",
+    "            # le `continue` des sorties ne doit jamais laisser un etat stale\n",
+    "            # qui fabrique (ou avale) un front a la barre suivante.\n",
+    "            entry_edge = entry_signal and not self.prev_entry_signal[sym]\n",
+    "            self.prev_entry_signal[sym] = entry_signal\n",
+    "            if entry_edge:\n",
+    "                self.n_entry_edges += 1\n",
+    "\n",
+    "            if self.portfolio[sym].invested:\n",
+    "                entry = self.entry_prices.get(sym, price)\n",
+    "                pnl = (price - entry) / entry\n",
+    "                if pnl < -self.stop_loss_pct:\n",
+    "                    self.liquidate(sym)\n",
+    "                    self.entry_prices.pop(sym, None)\n",
+    "                    self.log(f\"STOP-LOSS {sym}: pnl={pnl:.2%}\")\n",
+    "                    continue\n",
+    "                if price > bb_middle:\n",
+    "                    self.liquidate(sym)\n",
+    "                    self.entry_prices.pop(sym, None)\n",
+    "                    self.log(f\"EXIT {sym}: price={price:.2f} > BB mid={bb_middle:.2f}\")\n",
+    "                    continue\n",
+    "\n",
+    "            if not self.portfolio[sym].invested:\n",
+    "                if entry_edge:\n",
+    "                    self.n_entry_attempts += 1\n",
+    "                    self.set_holdings(sym, self.position_weight)\n",
+    "                    self.entry_prices[sym] = price\n",
+    "                    self.log(f\"ENTER {sym}: front montant a price={price:.2f} < BB low={bb_lower:.2f}, RSI={rsi_val:.1f}\")\n",
+    "\n",
+    "    def on_order_event(self, order_event):\n",
+    "        if order_event.status == OrderStatus.FILLED:\n",
+    "            self.n_trades_filled += 1\n",
+    "\n",
+    "    def on_end_of_algorithm(self):\n",
+    "        self.log(f\"B4_DIAG n_bars={self.n_bars_total} warmup={self.n_guard_skip_warmup} no_data={self.n_guard_skip_no_data} not_ready={self.n_guard_skip_not_ready} price_below={self.n_price_below} rsi_below={self.n_rsi_below} both={self.n_both} entry_edges={self.n_entry_edges} entry_attempts={self.n_entry_attempts} fills={self.n_trades_filled}\")\n",
+    "        final = self.portfolio.total_portfolio_value\n",
+    "        ret = (final - 10000) / 10000\n",
+    "        self.log(f\"B4_FINAL ${final:,.2f} return={ret:.2%}\")\n",
+    "\"\"\"\n",
+    "\n",
+    "LEAN_ALGORITHM_B5 = \"\"\"# region imports\n",
+    "from AlgorithmImports import *\n",
+    "# endregion\n",
+    "\n",
+    "\n",
+    "class BinanceMeanReversionBB_B5(QCAlgorithm):\n",
+    "    '''\n",
+    "    Phase F B5 = B4 a UNE seule variable pres : un COOLDOWN de 60 minutes apres sortie.\n",
+    "    B3 entrait sur NIVEAU (set_holdings a chaque barre Minute ou la condition\n",
+    "    AND tient, tant que la position est plate) : 917 199 ordres en 4 ans,\n",
+    "    628/jour, chaque remplissage ponctionne de 0,1% de frais -> net -99,88%.\n",
+    "    B4 etait deja edge-triggered mais le resultat a falsifie l'hypothese : 879 847\n",
+    "    ordres contre 917 199 pour B3 (-4 % seulement) -- la condition AND clignote\n",
+    "    deja barre apres barre au granularity Minute, chaque front est une entree,\n",
+    "    et le cycle entree->sortie (bande basse -> mediane) dure quelques minutes.\n",
+    "    Le defaut est la FREQUENCE des allers-retours (~300/jour), pas le niveau.\n",
+    "    B5 ajoute donc : apres une sortie (stop-loss ou retour a la mediane), aucun\n",
+    "    re-entree sur ce symbole pendant 60 minutes. Tout le reste est B4.\n",
+    "    '''\n",
+    "\n",
+    "    def initialize(self):\n",
+    "        self.set_start_date(2021, 1, 1)\n",
+    "        self.set_end_date(2024, 12, 31)\n",
+    "        self.set_account_currency(\"USDT\")\n",
+    "        self.set_cash(10000)\n",
+    "        self.set_brokerage_model(BrokerageName.BINANCE, AccountType.CASH)\n",
+    "\n",
+    "        self.btc = self.add_crypto(\"BTCUSDT\", Resolution.MINUTE, Market.BINANCE)\n",
+    "        self.eth = self.add_crypto(\"ETHUSDT\", Resolution.MINUTE, Market.BINANCE)\n",
+    "        self.symbols = [self.btc.symbol, self.eth.symbol]\n",
+    "\n",
+    "        self.bb_period = 20\n",
+    "        self.bb_std = 2.0\n",
+    "        self.bb_indicator = {}\n",
+    "        for sym in self.symbols:\n",
+    "            self.bb_indicator[sym] = self.bb(sym, self.bb_period, self.bb_std, resolution=Resolution.MINUTE)\n",
+    "\n",
+    "        self.rsi_indicator = {}\n",
+    "        for sym in self.symbols:\n",
+    "            self.rsi_indicator[sym] = self.rsi(sym, 14, resolution=Resolution.MINUTE)\n",
+    "\n",
+    "        self.stop_loss_pct = 0.05\n",
+    "        self.position_weight = 0.4\n",
+    "        self.entry_prices = {}\n",
+    "\n",
+    "        self.set_warm_up(self.bb_period, Resolution.MINUTE)\n",
+    "\n",
+    "        # === B1 INSTRUMENTATION : compteurs (inchanges) ===\n",
+    "        self.n_bars_total = 0\n",
+    "        self.n_guard_skip_warmup = 0\n",
+    "        self.n_guard_skip_no_data = 0\n",
+    "        self.n_guard_skip_not_ready = 0\n",
+    "        self.n_price_below = 0\n",
+    "        self.n_rsi_below = 0\n",
+    "        self.n_both = 0\n",
+    "        self.n_entry_attempts = 0\n",
+    "        self.n_trades_filled = 0\n",
+    "        self.sample_log_counter = 0\n",
+    "\n",
+    "        # === B4 : SEULE VARIABLE CHANGEE vs B3 ===\n",
+    "        # Etat du signal d'entree a la barre precedente, par symbole.\n",
+    "        # L'entree se declenche uniquement sur front montant (False -> True).\n",
+    "        self.prev_entry_signal = {sym: False for sym in self.symbols}\n",
+    "        self.n_entry_edges = 0\n",
+    "\n",
+    "        # === B5 : SEULE VARIABLE CHANGEE vs B4 ===\n",
+    "        # Cooldown par symbole apres sortie : re-entree interdite pendant 60 min.\n",
+    "        from datetime import timedelta as _td\n",
+    "        self.cooldown = _td(minutes=60)\n",
+    "        self.last_exit_time = {}\n",
+    "\n",
+    "    def on_data(self, data):\n",
+    "        if self.is_warming_up:\n",
+    "            self.n_guard_skip_warmup += 1\n",
+    "            return\n",
+    "\n",
+    "        for sym in self.symbols:\n",
+    "            if sym not in data or data[sym] is None:\n",
+    "                self.n_guard_skip_no_data += 1\n",
+    "                continue\n",
+    "            if not self.bb_indicator[sym].is_ready or not self.rsi_indicator[sym].is_ready:\n",
+    "                self.n_guard_skip_not_ready += 1\n",
+    "                continue\n",
+    "\n",
+    "            self.n_bars_total += 1\n",
+    "\n",
+    "            price = data[sym].price\n",
+    "            bb_lower = self.bb_indicator[sym].lower_band.current.value\n",
+    "            bb_middle = self.bb_indicator[sym].middle_band.current.value\n",
+    "            rsi_val = self.rsi_indicator[sym].current.value\n",
+    "\n",
+    "            price_ok = price < bb_lower\n",
+    "            rsi_ok = rsi_val < 35\n",
+    "            entry_signal = price_ok and rsi_ok\n",
+    "            if price_ok:\n",
+    "                self.n_price_below += 1\n",
+    "            if rsi_ok:\n",
+    "                self.n_rsi_below += 1\n",
+    "            if entry_signal:\n",
+    "                self.n_both += 1\n",
+    "\n",
+    "            self.sample_log_counter += 1\n",
+    "            if self.sample_log_counter >= 10000:\n",
+    "                self.sample_log_counter = 0\n",
+    "                self.log(f\"SAMPLE {self.Time} {sym} price={price:.2f} bb_low={bb_lower:.2f} rsi={rsi_val:.1f} bb_ready={self.bb_indicator[sym].is_ready} rsi_ready={self.rsi_indicator[sym].is_ready} price_ok={price_ok} rsi_ok={rsi_ok}\")\n",
+    "\n",
+    "            # === B4 : entree sur FRONT MONTANT uniquement ===\n",
+    "            # L'etat du signal est mis a jour CHAQUE barre, AVANT les sorties :\n",
+    "            # le `continue` des sorties ne doit jamais laisser un etat stale\n",
+    "            # qui fabrique (ou avale) un front a la barre suivante.\n",
+    "            entry_edge = entry_signal and not self.prev_entry_signal[sym]\n",
+    "            self.prev_entry_signal[sym] = entry_signal\n",
+    "            if entry_edge:\n",
+    "                self.n_entry_edges += 1\n",
+    "\n",
+    "            if self.portfolio[sym].invested:\n",
+    "                entry = self.entry_prices.get(sym, price)\n",
+    "                pnl = (price - entry) / entry\n",
+    "                if pnl < -self.stop_loss_pct:\n",
+    "                    self.liquidate(sym)\n",
+    "                    self.entry_prices.pop(sym, None)\n",
+    "                    self.last_exit_time[sym] = self.time\n",
+    "                    self.log(f\"STOP-LOSS {sym}: pnl={pnl:.2%}\")\n",
+    "                    continue\n",
+    "                if price > bb_middle:\n",
+    "                    self.liquidate(sym)\n",
+    "                    self.entry_prices.pop(sym, None)\n",
+    "                    self.last_exit_time[sym] = self.time\n",
+    "                    self.log(f\"EXIT {sym}: price={price:.2f} > BB mid={bb_middle:.2f}\")\n",
+    "                    continue\n",
+    "\n",
+    "            if not self.portfolio[sym].invested:\n",
+    "                en_cooldown = (\n",
+    "                    sym in self.last_exit_time\n",
+    "                    and (self.time - self.last_exit_time[sym]) < self.cooldown\n",
+    "                )\n",
+    "                if entry_edge and not en_cooldown:\n",
+    "                    self.n_entry_attempts += 1\n",
+    "                    self.set_holdings(sym, self.position_weight)\n",
+    "                    self.entry_prices[sym] = price\n",
+    "                    self.log(f\"ENTER {sym}: front montant a price={price:.2f} < BB low={bb_lower:.2f}, RSI={rsi_val:.1f}\")\n",
+    "\n",
+    "    def on_order_event(self, order_event):\n",
+    "        if order_event.status == OrderStatus.FILLED:\n",
+    "            self.n_trades_filled += 1\n",
+    "\n",
+    "    def on_end_of_algorithm(self):\n",
+    "        self.log(f\"B5_DIAG n_bars={self.n_bars_total} warmup={self.n_guard_skip_warmup} no_data={self.n_guard_skip_no_data} not_ready={self.n_guard_skip_not_ready} price_below={self.n_price_below} rsi_below={self.n_rsi_below} both={self.n_both} entry_edges={self.n_entry_edges} entry_attempts={self.n_entry_attempts} fills={self.n_trades_filled}\")\n",
+    "        final = self.portfolio.total_portfolio_value\n",
+    "        ret = (final - 10000) / 10000\n",
+    "        self.log(f\"B5_FINAL ${final:,.2f} return={ret:.2%}\")\n",
+    "\"\"\"\n",
+    "\n",
+    "print(\"LEAN_ALGORITHM_B4 + B5 (Phase F remediation sur-trading) prets pour backtest QC Cloud.\")\n",
+    "print(f\"Taille B4: {len(LEAN_ALGORITHM_B4)} caracteres ; B5: {len(LEAN_ALGORITHM_B5)} caracteres\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-qcpy40-phasef-reader",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:11.990872Z",
+     "iopub.status.busy": "2026-09-02T10:11:11.990560Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.004376Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.003836Z"
+    },
+    "papermill": {
+     "duration": 0.018754,
+     "end_time": "2026-09-02T10:11:12.005150",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:11.986396",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Phase F -- remediation du sur-trading (projet 35674722) ===\n",
+      "\n",
+      "Run  Backtest                             Ordres   Sharpe     MaxDD   Resultat net\n",
+      "----------------------------------------------------------------------------------------\n",
+      "B3   B3_PhaseE_account_currency_USD      917 199   -2.961   99.900%   -99.880%\n",
+      "B4   B4_PhaseF_edge_triggered_entry      879 847   -2.963   99.900%   -99.877%\n",
+      "B5   B5_PhaseF_cooldown_60min          1 140 574   -2.527   99.900%   -99.874%\n",
+      "\n",
+      "--- B4 : la variable changee ---\n",
+      "Entree EDGE-TRIGGERED : l'ordre n'est emis que sur le front montant de la condition AND (False -> True), l'etat du signal etant memorise par symbole et mis a jour chaque barre AVANT le traitement des sorties (le continue des sorties ne doit jamais laisser un etat stale). Tout le reste (dates, devise USDT, indicateurs, sorties, compteurs) est B3.\n",
+      "\n",
+      "--- B4 : verdict HYPOTHESE FALSIFIEE -- NO BEATS vs B3 ---\n",
+      "879 847 ordres contre 917 199 pour B3 : -4 % seulement. L'entree sur niveau n'etait PAS le moteur du volume. Au granularity Minute la condition AND clignote deja barre apres barre : chaque front montant est une entree possible, et la position etant plate apres chaque sortie rapide (retour a la mediane en quelques minutes), les fronts se convertissent en entrees presque 1:1. Net (-99,877 %), Sharpe (-2,963) et drawdown (99,900 %) indiscernables de B3.\n",
+      "\n",
+      "--- B5 : la variable changee ---\n",
+      "COOLDOWN de 60 minutes par symbole apres chaque sortie (stop-loss ou retour a la mediane) : aucune re-entree pendant le delai. Strictement plus restrictif que B4 sur les entrees.\n",
+      "\n",
+      "--- B5 : verdict HYPOTHESE FALSIFIEE AUSSI -- NO BEATS vs B3, ordres EN HAUSSE ---\n",
+      "1 140 574 ordres : PLUS que B3 (917 199) et B4 (879 847), alors que le cooldown ne peut que reduire les entrees. Le volume d'ordres n'est donc pas pilote par la frequence des decisions d'entree mais par un mecanisme d'un autre ordre. Candidat le plus plausible (HYPOTHESE, non tranchee par ces runs) : tempete de re-soumissions en fin de vie du compte -- quand l'equity tombe a quelques dizaines de USDT, des positions ciblees a 40 % x equity passent sous le montant minimal d'ordre Binance, l'ordre est rejete, la position reste invested, et chaque barre re-emet liquidate. Les trois runs convergent vers la meme equity finale (~13,50 USDT) : la queue du backtest est identique, seule sa longueur varie.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Phase F : les resultats sont LUS depuis le fichier de mesures, jamais\n",
+    "# retapes a la main (meme convention que la Phase D/E, cellule precedente).\n",
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "def _trouver(nom_fichier):\n",
+    "    candidats = [\n",
+    "        Path(\"../_results\") / nom_fichier,\n",
+    "        Path(\"_results\") / nom_fichier,\n",
+    "        Path(\"MyIA.AI.Notebooks/QuantConnect/_results\") / nom_fichier,\n",
+    "    ]\n",
+    "    return next((p for p in candidats if p.exists()), None)\n",
+    "\n",
+    "\n",
+    "chemin_f = _trouver(\"QC-Py-40-Phase-F.json\")\n",
+    "chemin_d = _trouver(\"QC-Py-40-Phase-D.json\")\n",
+    "\n",
+    "if chemin_f is None or chemin_d is None:\n",
+    "    print(\"Fichier de mesures introuvable depuis\", Path.cwd())\n",
+    "    phase_f = None\n",
+    "else:\n",
+    "    phase_f = json.loads(chemin_f.read_text(encoding=\"utf-8\"))\n",
+    "    phase_d = json.loads(chemin_d.read_text(encoding=\"utf-8\"))\n",
+    "\n",
+    "    runs = [\n",
+    "        (\"B3\", phase_d[\"results_summary\"][\"B3\"]),\n",
+    "        (\"B4\", phase_f[\"results_summary\"][\"B4\"]),\n",
+    "        (\"B5\", phase_f[\"results_summary\"][\"B5\"]),\n",
+    "    ]\n",
+    "\n",
+    "    print(\"=== Phase F -- remediation du sur-trading (projet %s) ===\" % phase_f[\"qc_project_id\"])\n",
+    "    print()\n",
+    "    print(\"%-4s %-30s %12s %8s %9s   %s\" % (\"Run\", \"Backtest\", \"Ordres\", \"Sharpe\", \"MaxDD\", \"Resultat net\"))\n",
+    "    print(\"-\" * 88)\n",
+    "    for nom, r in runs:\n",
+    "        print(\"%-4s %-30s %12s %8s %9s   %s\" % (\n",
+    "            nom,\n",
+    "            r[\"backtest_name\"][:30],\n",
+    "            format(r[\"totalOrders\"], \",d\").replace(\",\", \" \"),\n",
+    "            r[\"statistics\"][\"sharpeRatio\"],\n",
+    "            r[\"statistics\"][\"drawdown\"],\n",
+    "            r[\"statistics\"][\"totalNetProfit\"],\n",
+    "        ))\n",
+    "    print()\n",
+    "    for nom in (\"B4\", \"B5\"):\n",
+    "        r = phase_f[\"results_summary\"][nom]\n",
+    "        print(\"--- %s : la variable changee ---\" % nom)\n",
+    "        print(r[\"variable_unique_changee_vs_\" + (\"B3\" if nom == \"B4\" else \"B4\")])\n",
+    "        print()\n",
+    "        print(\"--- %s : verdict %s ---\" % (nom, r[\"verdict\"]))\n",
+    "        print(r[\"preuve\"])\n",
+    "        print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-qcpy40-phasef-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003729,
+     "end_time": "2026-09-02T10:11:12.012642",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.008913",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat : deux remedes evidents, deux falsifications\n",
+    "\n",
+    "Le tableau ci-dessus est la lecon la plus utile de toute la section : **les deux corrections \"evidentes\" du sur-trading ont ete mesurees, et aucune des deux ne le corrige.**\n",
+    "\n",
+    "- **B4 (entree sur front montant)** : 879 847 ordres contre 917 199 pour B3, soit **-4 %**. Au granularity Minute, la condition AND clignote deja barre apres barre -- chaque front montant est une nouvelle entree possible. Entrer sur le front plutot que sur le niveau ne change presque rien quand le signal lui-meme oscille a chaque barre.\n",
+    "- **B5 (cooldown de 60 minutes apres sortie)** : **1 140 574 ordres** -- *plus* que B3 et B4. Le cooldown est pourtant strictement plus restrictif que B4 sur les entrees. Le volume d'ordres n'est donc pas pilote par la frequence des decisions de la strategie : il est domine par un mecanisme d'un autre ordre, dont le candidat le plus plausible est la **tempete de re-soumissions en fin de vie du compte** -- quand l'equity tombe a quelques dizaines de USDT, des positions de 40 % x equity passent sous le montant minimal d'ordre Binance, les ordres sont rejete, la position reste `invested`, et chaque barre re-emet `liquidate`. Les trois runs convergent d'ailleurs vers la meme equity finale (~13,50 USDT) : la queue du backtest est identique, seule sa longueur varie.\n",
+    "\n",
+    "**Verdict honnete : NO BEATS.** Ni B4 ni B5 n'amelioore B3 sur aucune metrique (net, Sharpe, drawdown statistiquement indiscernables ; volume non reduit). Ce n'est pas un echec de methode mais le resultat lui-meme : la discipline une-variable-par-run a converti deux intuitions raisonnables en deux falsifications mesurees. C'est exactement ce qu'un backtest est cense faire.\n",
+    "\n",
+    "**Ce qui discriminerait la suite** : le detail par ordre (combien d'entrees vs combien de re-soumissions de `liquidate`) est accessible par les compteurs `B4_DIAG`/`B5_DIAG` (`entry_edges`, `entry_attempts`, `fills`) dans les logs QC Cloud, ou par `read_backtest_orders` -- ni l'un ni l'autre n'est expose par le MCP (`qc-mcp-lite`), la lecture demande l'interface QC Cloud (RECOVERABLE-USER-HAND). Le suspect structurel reste l'economie par trade au granularity Minute : les bandes de Bollinger 20-period Minute sont si etroites que le captage du retour a la moyenne (~0,1-0,3 %) ne couvre pas les frais aller-retour (0,2 %) -- aucune strategie de cette forme ne peut etre profitable a cette resolution, quel que soit son filtrage de frequence. Le remede structurel (resolution Hour, ou bandes elargies) est un grain ulterieur, a ne tenter qu'apres la lecture des compteurs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "e3635270",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.021300Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.020937Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.226641Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.226209Z"
+    },
+    "papermill": {
+     "duration": 0.210945,
+     "end_time": "2026-09-02T10:11:12.227440",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.016495",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1076,6 +1737,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-equity",
    "metadata": {
+    "papermill": {
+     "duration": 0.004584,
+     "end_time": "2026-09-02T10:11:12.236173",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.231589",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1094,6 +1762,13 @@
    "cell_type": "markdown",
    "id": "7146d537",
    "metadata": {
+    "papermill": {
+     "duration": 0.00421,
+     "end_time": "2026-09-02T10:11:12.244271",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.240061",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1113,9 +1788,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "5d09f9d9",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.253504Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.253220Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.342983Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.342247Z"
+    },
+    "papermill": {
+     "duration": 0.095698,
+     "end_time": "2026-09-02T10:11:12.343937",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.248239",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1164,6 +1852,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-dist",
    "metadata": {
+    "papermill": {
+     "duration": 0.004162,
+     "end_time": "2026-09-02T10:11:12.354170",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.350008",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1180,6 +1875,13 @@
    "cell_type": "markdown",
    "id": "e489258b",
    "metadata": {
+    "papermill": {
+     "duration": 0.003822,
+     "end_time": "2026-09-02T10:11:12.362100",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.358278",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1204,6 +1906,13 @@
    "cell_type": "markdown",
    "id": "deec2888",
    "metadata": {
+    "papermill": {
+     "duration": 0.003992,
+     "end_time": "2026-09-02T10:11:12.370455",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.366463",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1224,9 +1933,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "8640fef4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.379883Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.379386Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.383586Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.382887Z"
+    },
+    "papermill": {
+     "duration": 0.01026,
+     "end_time": "2026-09-02T10:11:12.384580",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.374320",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1290,6 +2012,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-checklist",
    "metadata": {
+    "papermill": {
+     "duration": 0.00384,
+     "end_time": "2026-09-02T10:11:12.392686",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.388846",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1304,6 +2033,13 @@
    "cell_type": "markdown",
    "id": "cell-b1789bc4",
    "metadata": {
+    "papermill": {
+     "duration": 0.004156,
+     "end_time": "2026-09-02T10:11:12.401378",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.397222",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1327,9 +2063,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "cell-3b06c9e8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.410807Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.410605Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.413913Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.413211Z"
+    },
+    "papermill": {
+     "duration": 0.008994,
+     "end_time": "2026-09-02T10:11:12.414769",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.405775",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1356,7 +2105,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7d045fb5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00405,
+     "end_time": "2026-09-02T10:11:12.423290",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.419240",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Du detecteur d'alerte au rapport quotidien\n",
     "\n",
@@ -1369,9 +2128,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "d5dae0f6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.434397Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.433957Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.438912Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.438406Z"
+    },
+    "papermill": {
+     "duration": 0.012187,
+     "end_time": "2026-09-02T10:11:12.439806",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.427619",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1428,6 +2200,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-report",
    "metadata": {
+    "papermill": {
+     "duration": 0.004272,
+     "end_time": "2026-09-02T10:11:12.448568",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.444296",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1444,6 +2223,13 @@
    "cell_type": "markdown",
    "id": "cell-524823e6",
    "metadata": {
+    "papermill": {
+     "duration": 0.003956,
+     "end_time": "2026-09-02T10:11:12.456612",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.452656",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1460,9 +2246,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "cell-6de74393",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.466221Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.465990Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.469616Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.469059Z"
+    },
+    "papermill": {
+     "duration": 0.009432,
+     "end_time": "2026-09-02T10:11:12.470413",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.460981",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1488,6 +2287,13 @@
    "cell_type": "markdown",
    "id": "0c40159a",
    "metadata": {
+    "papermill": {
+     "duration": 0.004139,
+     "end_time": "2026-09-02T10:11:12.479260",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.475121",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1508,9 +2314,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "be67a4db",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.489124Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.488687Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.493215Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.492507Z"
+    },
+    "papermill": {
+     "duration": 0.010339,
+     "end_time": "2026-09-02T10:11:12.494014",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.483675",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1576,6 +2395,13 @@
    "cell_type": "markdown",
    "id": "qcpy40-density-params",
    "metadata": {
+    "papermill": {
+     "duration": 0.004421,
+     "end_time": "2026-09-02T10:11:12.503205",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.498784",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1588,9 +2414,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "8b2867ed",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:11:12.512915Z",
+     "iopub.status.busy": "2026-09-02T10:11:12.512548Z",
+     "iopub.status.idle": "2026-09-02T10:11:12.516458Z",
+     "shell.execute_reply": "2026-09-02T10:11:12.515961Z"
+    },
+    "papermill": {
+     "duration": 0.009725,
+     "end_time": "2026-09-02T10:11:12.517143",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.507418",
+     "status": "completed"
+    },
     "tags": []
    },
    "outputs": [
@@ -1630,6 +2469,13 @@
    "cell_type": "markdown",
    "id": "0c381dd6",
    "metadata": {
+    "papermill": {
+     "duration": 0.004207,
+     "end_time": "2026-09-02T10:11:12.526176",
+     "exception": false,
+     "start_time": "2026-09-02T10:11:12.521969",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -1678,6 +2524,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.424994,
+   "end_time": "2026-09-02T10:11:12.878538",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "QC-Py-40-PaperTrading-Binance.ipynb",
+   "output_path": "qcpy40_phasef_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T10:11:07.453544",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/_results/QC-Py-40-Phase-F.json
+++ b/MyIA.AI.Notebooks/QuantConnect/_results/QC-Py-40-Phase-F.json
@@ -1,0 +1,62 @@
+{
+  "issue": "#13117 / #14142",
+  "phase": "Phase F B4+B5 -- remedier au sur-trading diagnostique par B3 (917 199 ordres, net -99,88 %)",
+  "date": "2026-09-02",
+  "worker": "myia-po-2023 (lane myia-po-2023:CoursIA)",
+  "trigger": "Grain nomme RESTE OUVERT dans QC-Py-40-Phase-D.json path_forward (c.14215) : 'le sur-trading... grain distinct, a traiter en PR separee -- il change la strategie, pas le diagnostic'",
+  "deliverable": "Deux runs a une variable chacun : B4 = B3 + entree edge-triggered (front montant au lieu de niveau) ; B5 = B4 + cooldown 60 min apres sortie. Discipline B-serie conservee : une seule variable changee par run, garde c.909 (status 'Completed.' ET progress 1) sur chaque lecture.",
+  "qc_project_id": 35674722,
+  "qc_project_url": "https://www.quantconnect.com/project/35674722",
+  "results_summary": {
+    "B4": {
+      "backtest_id": "6d4f9086dc27e16eca7e4d47e7edb667",
+      "backtest_name": "B4_PhaseF_edge_triggered_entry",
+      "compile_id": "e0bc007e2e0fead3ade9455504dbc6c7-7f666075bc6df353d209554c3c25e4ca",
+      "qc_url": "https://www.quantconnect.com/project/35674722/backtest/6d4f9086dc27e16eca7e4d47e7edb667",
+      "created": "2026-09-02 10:03:50",
+      "completed": "2026-09-02 (status 'Completed.', progress 1 -- verifie AVANT lecture, cf garde c.909)",
+      "tradeableDates": 1461,
+      "totalOrders": 879847,
+      "statistics": {
+        "sharpeRatio": "-2.963",
+        "compoundingAnnualReturn": "-81.233%",
+        "drawdown": "99.900%",
+        "totalNetProfit": "-99.877%",
+        "netProfitAbsolute": "₮-9,986.37"
+      },
+      "variable_unique_changee_vs_B3": "Entree EDGE-TRIGGERED : l'ordre n'est emis que sur le front montant de la condition AND (False -> True), l'etat du signal etant memorise par symbole et mis a jour chaque barre AVANT le traitement des sorties (le continue des sorties ne doit jamais laisser un etat stale). Tout le reste (dates, devise USDT, indicateurs, sorties, compteurs) est B3.",
+      "verdict": "HYPOTHESE FALSIFIEE -- NO BEATS vs B3",
+      "preuve": "879 847 ordres contre 917 199 pour B3 : -4 % seulement. L'entree sur niveau n'etait PAS le moteur du volume. Au granularity Minute la condition AND clignote deja barre apres barre : chaque front montant est une entree possible, et la position etant plate apres chaque sortie rapide (retour a la mediane en quelques minutes), les fronts se convertissent en entrees presque 1:1. Net (-99,877 %), Sharpe (-2,963) et drawdown (99,900 %) indiscernables de B3."
+    },
+    "B5": {
+      "backtest_id": "081e8b389b3b723a24490d1b42b19073",
+      "backtest_name": "B5_PhaseF_cooldown_60min",
+      "compile_id": "cb88acc00bb4d2d67cd24b5c99b4c8fe-53863a12c36f4aee859a2e3bf7e58ee6",
+      "qc_url": "https://www.quantconnect.com/project/35674722/backtest/081e8b389b3b723a24490d1b42b19073",
+      "created": "2026-09-02 10:07:36",
+      "completed": "2026-09-02 (status 'Completed.', progress 1 -- verifie AVANT lecture, cf garde c.909)",
+      "tradeableDates": 1461,
+      "totalOrders": 1140574,
+      "statistics": {
+        "sharpeRatio": "-2.527",
+        "compoundingAnnualReturn": "-81.149%",
+        "drawdown": "99.900%",
+        "totalNetProfit": "-99.874%",
+        "netProfitAbsolute": "₮-9,987.03"
+      },
+      "variable_unique_changee_vs_B4": "COOLDOWN de 60 minutes par symbole apres chaque sortie (stop-loss ou retour a la mediane) : aucune re-entree pendant le delai. Strictement plus restrictif que B4 sur les entrees.",
+      "verdict": "HYPOTHESE FALSIFIEE AUSSI -- NO BEATS vs B3, ordres EN HAUSSE",
+      "preuve": "1 140 574 ordres : PLUS que B3 (917 199) et B4 (879 847), alors que le cooldown ne peut que reduire les entrees. Le volume d'ordres n'est donc pas pilote par la frequence des decisions d'entree mais par un mecanisme d'un autre ordre. Candidat le plus plausible (HYPOTHESE, non tranchee par ces runs) : tempete de re-soumissions en fin de vie du compte -- quand l'equity tombe a quelques dizaines de USDT, des positions ciblees a 40 % x equity passent sous le montant minimal d'ordre Binance, l'ordre est rejete, la position reste invested, et chaque barre re-emet liquidate. Les trois runs convergent vers la meme equity finale (~13,50 USDT) : la queue du backtest est identique, seule sa longueur varie."
+    }
+  },
+  "verdict": "NO BEATS (les deux remediation une-variable echouent a reduire le volume d'ordres ; net/Sharpe/drawdown inchanges). Valeur livree : deux intuitions raisonnables converties en deux falsifications mesurees -- c'est le fonctionnement normal de la methode une-variable-par-run.",
+  "path_forward": [
+    "RESTE OUVERT (RECOVERABLE-USER-HAND) : la lecture des compteurs B4_DIAG / B5_DIAG (entry_edges, entry_attempts, fills) ou de read_backtest_orders dans l'interface QC Cloud trancherait entre 'entrees massives' et 're-soumissions de liquidate'. Le MCP qc-mcp-lite n'expose ni l'un ni l'autre.",
+    "SUSPECT STRUCTUREL (hypothese) : au granularity Minute, les bandes BB 20-period sont si etroites que le captage du retour a la moyenne (~0,1-0,3 %) ne couvre pas les frais aller-retour (2 x 0,1 %). Aucune strategie de cette forme ne peut etre profitable a cette resolution. Remede structurel a tester APRES lecture des compteurs : resolution Hour (bandes plus larges) ou parametrage BB elargi.",
+    "LIVRE : la section docs 'Mesures post-backtest : gates minimaux' (docs/qc/quantconnect.md, PR separee) documente la garde c.909 appliquee sur chacune des lectures de cette phase."
+  ],
+  "tells_observed": [
+    "Garde c.909 appliquee sur B4 et B5 : chaque read_backtest coute status=='Completed.' ET progress==1 avant lecture des metriques.",
+    "Regne la regle C (verdict honnete) : NO BEATS explicite, aucun 'promising'."
+  ]
+}


### PR DESCRIPTION
Grain: MED/qc -- lane myia-po-2023:CoursIA -- prev: LIGHT/docs #14280

## Summary

Phase F de QC-Py-40 — le grain « sur-trading » nommé `RESTE OUVERT` dans `QC-Py-40-Phase-D.json` (c.14215) : B3 avait établi que la stratégie émettait **917 199 ordres en 4 ans** (net −99,88 %) une fois la devise de compte corrigée. Cette PR teste les **deux remèdes évidents**, discipline B-série conservée (**une seule variable changée par run**), sur QC Cloud projet 35674722 :

| Run | Variable unique | Ordres | Sharpe | MaxDD | Net |
|---|---|---:|---:|---:|---:|
| B3 (réf.) | — | 917 199 | −2.961 | 99.900% | −99.880% |
| **B4** | entrée edge-triggered (front montant) | 879 847 | −2.963 | 99.900% | −99.877% |
| **B5** | B4 + cooldown 60 min après sortie | **1 140 574** | −2.527 | 99.900% | −99.874% |

**Verdict : NO BEATS — les deux hypothèses sont falsifiées par la mesure.**

- **B4 (−4 % d'ordres seulement)** : au granularity Minute, la condition AND clignote déjà barre après barre — chaque front montant est une entrée possible. Entrer sur le front plutôt que sur le niveau ne change presque rien.
- **B5 (+30 % d'ordres !)** : le cooldown est strictement plus restrictif que B4 sur les entrées, pourtant le volume **monte**. Le volume d'ordres n'est donc pas piloté par la fréquence des décisions d'entrée. Candidat (hypothèse, non tranchée) : tempête de re-soumissions en fin de vie — equity effondrée → cibles 40 % × equity sous le minimum Binance → ordres rejetés → position reste `invested` → `liquidate` ré-émis chaque barre. Les trois runs convergent vers la même equity finale (~13,50 USDT).
- **Suspect structurel** : bandes BB 20-period Minute trop étroites pour couvrir 2 × 0,1 % de frais aller-retour — aucune stratégie de cette forme ne peut être profitable à cette résolution.

## Livrables

- `main.py` B4/B5 exécutés sur QC Cloud 35674722 — backtests `6d4f9086dc27e16eca7e4d47e7edb667` (B4) et `081e8b389b3b723a24490d1b42b19073` (B5), **chaque lecture sous la garde c.909** (`status == "Completed."` ET `progress == 1` vérifiés avant lecture).
- `_results/QC-Py-40-Phase-F.json` — fichier de mesures (même convention que Phase D ; path_forward : lecture des compteurs `B4_DIAG`/`B5_DIAG` = RECOVERABLE-USER-HAND UI).
- 4 cellules notebook (intro deux-remèdes, algos B4+B5, lecteur de résultats, interprétation pédagogique des deux falsifications).

## Test plan

- [x] 2 compiles BuildSuccess, 2 backtests Completed (garde c.909 sur chaque lecture)
- [x] Papermill re-exec end-to-end : 17 cellules code, **0 erreur**, `execution_count` partout, sorties du lecteur vérifiées (tableau B3/B4/B5 conforme aux mesures)
- [x] Scan path-leak sur outputs : aucun
- [x] C.1 : aucun `raise NotImplementedError`/`assert False` introduit
- [x] Diff : 2 fichiers (notebook + JSON), un seul sujet

## Note

Le point pédagogique assumé : la valeur livrée est la **paire de falsifications mesurées** (deux intuitions raisonnables converties en deux réfutations), pas une stratégie améliorée — il n'y en a pas, et le dire est le résultat.

See #13117
See #14142
