### PR TITLE
feat(lane-claim,#14187): scope_intersection_paths + free_paths sur glob large

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1366,6 +1366,107 @@ def _path_matches(path: str, patterns: list[str]) -> bool:
     return False
 
 
+def _compute_scope_intersection_paths(
+    my_scope: list[str] | None,
+    claim_scope: list[str] | None,
+    tracked: list[str] | None,
+    limit: int = 25,
+) -> tuple[list[str], bool]:
+    """Return paths matching BOTH the query scope and the claim's scope.
+
+    #14187 -- a `blocked: true` on a wide `--paths` glob is BINARY today: the
+    caller learns WHO blocks but not WHICH files are contested. The lane
+    that owns the contested files is the one that wants to act; the others
+    are free to write freely (their work does not intersect). Materialising
+    the intersection per blocker lets the caller re-scope to lift the block
+    without a dashboard round-trip.
+
+    `my_scope` is the caller's `--paths` glob list (None = epic-wide =
+    intersects all claim scopes). `claim_scope` is the active claim's
+    declared `paths:` (None = epic-wide). `tracked` is the repo's
+    git-ls-files output (None = no walk available; intersection becomes
+    empty, fail-closed the same way `_filter_by_claim_scope` does on a
+    missing tree).
+
+    Returns `(paths, is_complete)`: the list of tracked files matching
+    BOTH sides, and a boolean saying whether the list was TRUNCATED at
+    `limit` (caller should warn on stderr so a lane knows it sees a
+    sample, not the full intersection). Empty list means either side is
+    empty in practice (no tracked files matched both) OR `tracked is
+    None` (no walk possible). Epic-wide on either side = full
+    intersection of the OTHER side against `tracked`.
+    """
+    if tracked is None:
+        return [], False
+    if not my_scope or not claim_scope:
+        # Epic-wide on either side -> no scope intersection to enumerate.
+        # The claim (or the caller) is wildcards-free, so the BLOCKED
+        # verdict stays binary from the file-list perspective.
+        return [], False
+    matches: list[str] = []
+    for path in tracked:
+        if _path_matches(path, my_scope) and _path_matches(path, claim_scope):
+            matches.append(path)
+            if len(matches) > limit:
+                return matches[:-1], True
+    return matches, False
+
+
+def _compute_free_paths(
+    my_scope: list[str] | None,
+    blocking_claims: dict[str, ClaimEvent],
+    tracked: list[str] | None,
+    limit: int = 25,
+) -> tuple[list[str], bool]:
+    """Return paths in `my_scope` that intersect NO active blocker claim.
+
+    #14187 -- the dual of `_compute_scope_intersection_paths`: a lane that
+    sees 3 blockers across 12 files in the scope needs to know which 9 are
+    free, not just which 3 are locked. The list is the FILES THAT THE LANE
+    CAN EDIT WITHOUT WAITING for any blocker to release or re-scope.
+
+    `blocking_claims` is the post-filter `others` dict (already scoped to
+    the caller's `my_scope` by `_filter_by_claim_scope`). Each claim's
+    scope is checked; a path is "free" iff no claim's `_path_matches`
+    says yes. Epic-wide claims (no `paths:`) make the entire `my_scope`
+    non-free, so the function returns `([], False)` when any blocker is
+    epic-wide -- the human verdict "all files blocked" is then exact, not
+    a sample.
+    """
+    if tracked is None:
+        return [], False
+    if not my_scope:
+        return [], False
+    claim_scopes = [ev.get("paths") for ev in blocking_claims.values()]
+    if any(scopes is None for scopes in claim_scopes):
+        # Epic-wide blocker locks the whole `my_scope`.
+        return [], False
+    scoped_claims = [scopes for scopes in claim_scopes if scopes]
+    # Empty blocker set after scope-filter -> the entire `my_scope` is
+    # free. Walk the tracked files (constrained by `my_scope`) and
+    # collect the matches. This is the disjoint case the lane-claim
+    # guard relies on: rc=0 (clear), free_paths = the whole caller scope.
+    if not scoped_claims:
+        free: list[str] = []
+        for path in tracked:
+            if not _path_matches(path, my_scope):
+                continue
+            free.append(path)
+            if len(free) > limit:
+                return free[:-1], True
+        return free, False
+    free: list[str] = []
+    for path in tracked:
+        if not _path_matches(path, my_scope):
+            continue
+        if any(_path_matches(path, scopes) for scopes in scoped_claims):
+            continue
+        free.append(path)
+        if len(free) > limit:
+            return free[:-1], True
+    return free, False
+
+
 # --- formatted output --------------------------------------------------------
 
 _CLAIM_BODY_TMPL = (
@@ -2331,6 +2432,33 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     else:
         epic_wide_on_umbrella = False
 
+    # #14187 -- per-claim scope intersection with the caller's `--paths`.
+    # Computed once on the FINAL `others` dict (post-stale-filter, post-
+    # scope-filter) so the values surfaced in `active_claims` reflect the
+    # verdict set, not a transient pre-filter state. Returns a list +
+    # truncated-flag tuple so the JSON consumer knows if the list is a
+    # sample (callers on a deep repo may hit the 25-entry cap).
+    scope_intersections: dict[str, tuple[list[str], bool]] = {}
+    for ln, ev in others.items():
+        paths, truncated = _compute_scope_intersection_paths(
+            my_scope, ev.get("paths"), tracked,
+        )
+        scope_intersections[ln] = (paths, truncated)
+    # #14187 -- free-paths (dual of the intersection): the files in the
+    # caller's `--paths` that intersect NO blocker claim. Surfaced when
+    # the caller is scoped (`my_scope` non-empty). On a CLEAR verdict
+    # (no blockers) the entire `my_scope` is free; on BLOCKED the helper
+    # strips the intersect of each blocker. Epic-wide blockers make the
+    # whole `my_scope` non-free (the helper returns `[]`); a single
+    # epic-wide blocker on an umbrella sets `epic_wide_on_umbrella` so
+    # the empty list is correct.
+    free_paths: list[str] = []
+    free_truncated = False
+    if my_scope:
+        free_paths, free_truncated = _compute_free_paths(
+            my_scope, others, tracked,
+        )
+
     summary = {
         "issue": payload.get("number"),
         "title": payload.get("title"),
@@ -2362,6 +2490,29 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 "marker": ev.marker,
                 "url": ev.url,
                 "paths": ev.get("paths"),
+                # #14187 -- per-claim scope intersection with the caller's
+                # `--paths`. Lets a lane see WHICH files a blocker claims
+                # (and which it does NOT) without a dashboard round-trip.
+                # Computed AFTER the stale + scope filters so the list
+                # reflects the FINAL blocker set. `[]` when either side
+                # is epic-wide (no glob scope to intersect) or when no
+                # tracked file matched both (`tracked is None`).
+                "scope_intersection_paths": (
+                    scope_intersections.get(ln, ([], False))[0]
+                    if isinstance(scope_intersections.get(ln), tuple)
+                    else scope_intersections.get(ln, [])
+                ),
+                "scope_intersection_truncated": (
+                    scope_intersections.get(ln, ([], False))[1]
+                    if isinstance(scope_intersections.get(ln), tuple)
+                    else False
+                ),
+                "scope_intersection_size": (
+                    len(scope_intersections.get(ln, ([], False))[0])
+                    if isinstance(scope_intersections.get(ln), tuple)
+                    else (len(scope_intersections.get(ln, []))
+                          if scope_intersections.get(ln) else 0)
+                ),
                 # #12320 -- PR reference on a `[DELIVERED]` marker. Surfaced
                 # alongside the rest of the claim fields so a consumer that
                 # reads "my_active_claim: false" can still pull the historical
@@ -2465,6 +2616,31 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         "composite_single_line_markers": len(composites),
         "composite_single_line_marker_lines": [s["line"] for s in composites],
         "blocked": bool(others),
+        # #14187 -- free-paths counter: files in the caller's `--paths`
+        # that intersect NO blocker. A lane with `--paths 'knot_lean/**'`
+        # blocked by 3 lanes whose scopes intersect 3 of 12 sub-files can
+        # see `free_paths_size` and `intersection_summary` and decide
+        # whether to re-scope (re-run with the 9 free files) or wait.
+        # `free_paths` is the verbatim list (truncated at 25); the
+        # truncated flag warns the caller it sees a sample.
+        "free_paths": free_paths,
+        "free_paths_size": len(free_paths),
+        "free_paths_truncated": free_truncated,
+        # #14187 -- human-readable one-liner, only when caller scoped.
+        # Empty when epic-wide blocker(s) lock the whole scope (no list
+        # to summarise) or when caller did not pass `--paths`. The string
+        # surfaces the contested count and the free count together so a
+        # reader can see at a glance whether the block is partial
+        # (re-scope) or total (wait or release).
+        "intersection_summary": (
+            f"{sum(len(intersection[0]) for intersection in scope_intersections.values())} "
+            f"fichiers bloques / {len(free_paths)} libres dans le scope"
+            if (my_scope and not epic_wide_on_umbrella and not (others and all(
+                ev.get("paths") is None or _claim_scope_effectively_epic_wide(ev)
+                for ev in others.values()
+            )))
+            else ""
+        ),
         # #12322 -- query_scope is the read-mode classifier for THIS call.
         # `EPIC_WIDE_NO_PATHS_DECLARED` means the caller did not pass `--paths`
         # AND did not post an active scoped claim, so we cannot prove
@@ -2623,8 +2799,34 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             f"#{payload.get('number')}: {who}.\n"
             f"Claimed scopes (marker-line excerpts -- #10395 Variante 2):\n"
             f"{intent_block}\n"
-            f"Do not start -- pick another grain, post a scope-narrowing "
-            f"`[CLAIMED] paths: ...`, or wait for release.",
+            # #14187 -- per-blocker intersection enumeration. On a wide
+            # `--paths` glob the caller may see N blockers but only M
+            # files are actually contested; surfacing the intersection
+            # per blocker (with a truncation warning past 25 entries)
+            # lets the caller re-scope to lift the block without a
+            # dashboard round-trip.
+            + (
+                "\n".join(
+                    f"  - {ln}: scope_intersection_paths = "
+                    f"{paths if not truncated else paths + ['...(truncated)']}"
+                    for ln, (paths, truncated) in scope_intersections.items()
+                    if paths
+                ) + "\n"
+                if scope_intersections and any(p for p, _ in scope_intersections.values())
+                else ""
+            )
+            + (
+                f"\n  Scope intersection: "
+                f"{sum(len(p) for p, _ in scope_intersections.values())} "
+                f"fichier(s) conteste(s) sur l'ensemble du scope. "
+                f"Fichiers libres du scope (hors blockers): "
+                f"{free_paths[:10]}{'...' if len(free_paths) > 10 else ''}"
+                f"{' (truncated at 25)' if free_truncated else ''}\n"
+                if (free_paths or any(p for p, _ in scope_intersections.values()))
+                else ""
+            )
+            + f"Do not start -- pick another grain, post a scope-narrowing "
+              f"`[CLAIMED] paths: ...`, or wait for release.",
             file=sys.stderr,
         )
         # #12905 -- name the dead-scope lock. A blocker whose declared scope

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -3743,8 +3743,20 @@ def test_check_caller_scope_partially_dead_warns_but_keeps_live(capsys, monkeypa
     # The DEAD glob is named in the WARN (partial coverage).
     assert "SCOPE_DEAD_GLOB" in captured.err
     assert "dead/nowhere.ipynb" in captured.err
-    # The live glob does NOT appear in the WARN (selectivity pin).
-    assert "x/a.ipynb" not in captured.err.split("SCOPE_DEAD_GLOB")[1] if "SCOPE_DEAD_GLOB" in captured.err else True
+    # The live glob does NOT appear in the SCOPE_DEAD_GLOB WARN
+    # (selectivity pin). #14187 added a scope-intersection block to the
+    # BLOCKED section that legitimately surfaces live globs there --
+    # that surface is in a DIFFERENT message from the SCOPE_DEAD_GLOB
+    # warn. We slice the WARN line specifically (split[0] = warn body,
+    # not the rest of stderr).
+    if "SCOPE_DEAD_GLOB" in captured.err:
+        warn_block = captured.err.split("SCOPE_DEAD_GLOB", 1)[1]
+        # The WARN spans until the next top-level marker (BLOCKED, LOCKED,
+        # DEAD-SCOPE LOCK, etc.). Take everything up to the next blank line.
+        warn_only = warn_block.split("\n\n", 1)[0]
+        assert "x/a.ipynb" not in warn_only, (
+            f"WARN must not name the LIVE glob; got: {warn_only!r}"
+        )
     # JSON exposes the dead globs list (only the dead ones, not the live ones).
     assert 'dead/nowhere.ipynb' in captured.out
     # The live glob DOES NOT appear in the caller_empty_scope field.
@@ -6028,3 +6040,220 @@ def test_13336_live_control_real_pr():
     st, err = clc._fetch_pr_state(13144)
     assert st == "MERGED", f"gh schema ou PR inattendus: state={st!r} err={err!r}"
     assert err is None
+
+
+# --- #14187 : scope_intersection_paths + free_paths sur glob large -----------
+#
+# Issue #14187 : `check_lane_claim.py --paths '<glob large>'` rend
+# `blocked: true` binaire : le caller voit QUI bloque, pas QUOI. Une lane
+# avec un scope de 12 fichiers bloques par 3 autres dont les scopes
+# n intersectent que 3 fichiers voit les 9 fichiers libres comme bloques
+# elle aussi (pas de re-scope possible sans escalade dashboard).
+#
+# Le fix ajoute (a) `scope_intersection_paths` par claim dans le JSON,
+# (b) `free_paths` + `intersection_summary` au top-level, (c) une ligne
+# humaine dans le verdict stderr. Six tests verrouillent chaque surface.
+
+def _14187_setup_repo(monkeypatch, tracked=None):
+    """Stub _git_tracked_files for #14187 tests (deterministic file list)."""
+    files = tracked if tracked is not None else [
+        "knot_lean/Knots/Conway.lean",
+        "knot_lean/Knots/Basic.lean",
+        "knot_lean/Knots/Lidman.lean",
+        "knot_lean/Knots/Invariant.lean",
+        "knot_lean/Util.lean",
+        "knot_lean/Main.lean",
+    ]
+    monkeypatch.setattr(clc, "_git_tracked_files", lambda: files)
+
+
+def test_14187_glob_large_nomme_intersection_par_blocker(capsys, monkeypatch):
+    """#14187 (1) : `--paths 'knot_lean/**'` avec 2 claims scopes
+    differents rend un `scope_intersection_paths` par claim dans le JSON,
+    listant les fichiers reellement contestes (et PAS tous les fichiers
+    du scope).
+    """
+    _14187_setup_repo(monkeypatch)
+    blocker_a = comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- knot tranche -- paths: knot_lean/Knots/Conway.lean, knot_lean/Knots/Basic.lean",
+        "2026-09-01T22:00:00Z",
+    )
+    blocker_b = comment(
+        "[CLAIMED] lane myia-po-2026:CoursIA -- knot trim -- paths: knot_lean/Knots/Lidman.lean",
+        "2026-09-01T22:01:00Z",
+    )
+    p = payload(blocker_a, blocker_b, number=14187)
+    rc = clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["knot_lean/**"],
+    )
+    assert rc == 1  # blocked
+    out = _json_out(capsys.readouterr())
+    ac = out["active_claims"]
+    # blocker_a claimed Conway.lean + Basic.lean -- both tracked
+    assert sorted(ac["myia-po-2024:CoursIA"]["scope_intersection_paths"]) == [
+        "knot_lean/Knots/Basic.lean", "knot_lean/Knots/Conway.lean"
+    ]
+    assert ac["myia-po-2024:CoursIA"]["scope_intersection_size"] == 2
+    assert ac["myia-po-2024:CoursIA"]["scope_intersection_truncated"] is False
+    # blocker_b claimed only Lidman.lean
+    assert ac["myia-po-2026:CoursIA"]["scope_intersection_paths"] == [
+        "knot_lean/Knots/Lidman.lean"
+    ]
+    assert ac["myia-po-2026:CoursIA"]["scope_intersection_size"] == 1
+
+
+def test_14187_glob_large_liste_fichiers_libres(capsys, monkeypatch):
+    """#14187 (2) : avec le meme scope de 6 fichiers et 2 blockers dont les
+    scopes couvrent 3 fichiers, `free_paths` enumere les 3 fichiers
+    libres et `intersection_summary` les compte.
+    """
+    _14187_setup_repo(monkeypatch)
+    blocker_a = comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- knot tranche -- paths: knot_lean/Knots/Conway.lean, knot_lean/Knots/Basic.lean",
+        "2026-09-01T22:00:00Z",
+    )
+    blocker_b = comment(
+        "[CLAIMED] lane myia-po-2026:CoursIA -- knot trim -- paths: knot_lean/Knots/Lidman.lean",
+        "2026-09-01T22:01:00Z",
+    )
+    p = payload(blocker_a, blocker_b, number=14187)
+    clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["knot_lean/**"],
+    )
+    out = _json_out(capsys.readouterr())
+    # Le scope couvre 6 tracked files ; 3 contestes ; 3 libres.
+    assert out["free_paths_size"] == 3
+    assert sorted(out["free_paths"]) == sorted([
+        "knot_lean/Knots/Invariant.lean",
+        "knot_lean/Main.lean",
+        "knot_lean/Util.lean",
+    ])
+    assert out["free_paths_truncated"] is False
+    # intersection_summary : 3 bloques + 3 libres
+    assert "3" in out["intersection_summary"]
+    assert "libres" in out["intersection_summary"]
+
+
+def test_14187_epic_wide_blocker_retourne_liste_vide(capsys, monkeypatch):
+    """#14187 (3) : un blocker epic-wide (pas de `paths:`) couvre tout le
+    scope ; `free_paths` est vide et `intersection_summary` est vide --
+    l instrument ne pretend pas enumerer ce qui n est pas enumerable.
+    """
+    _14187_setup_repo(monkeypatch)
+    blocker_epic = comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- umbrella",
+        "2026-09-01T22:00:00Z",
+    )
+    p = payload(blocker_epic, number=14187)
+    clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["knot_lean/**"],
+    )
+    out = _json_out(capsys.readouterr())
+    # epic-wide claim : pas d intersection enumerable
+    assert out["active_claims"]["myia-po-2024:CoursIA"]["scope_intersection_paths"] == []
+    assert out["active_claims"]["myia-po-2024:CoursIA"]["scope_intersection_size"] == 0
+    # Tout le scope est verrouille, rien de libre.
+    assert out["free_paths"] == []
+    assert out["free_paths_size"] == 0
+    assert out["intersection_summary"] == ""
+
+
+def test_14187_disjoint_scope_rend_liste_vide_et_pas_de_block(capsys, monkeypatch):
+    """#14187 (4) : caller et blocker sur des scopes DISJOINTS -> rc=0
+    (clear). `free_paths` reflete le scope complet (rien n est bloque).
+    """
+    _14187_setup_repo(monkeypatch)
+    blocker = comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- ailleurs -- paths: knot_lean/Knots/Conway.lean",
+        "2026-09-01T22:00:00Z",
+    )
+    p = payload(blocker, number=14187)
+    rc = clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["knot_lean/Util.lean"],
+    )
+    assert rc == 0  # clear (disjoint)
+    out = _json_out(capsys.readouterr())
+    assert out["blocked"] is False
+    # Util.lean est libre.
+    assert out["free_paths"] == ["knot_lean/Util.lean"]
+
+
+def test_14187_summary_humain_dans_stderr(capsys, monkeypatch):
+    """#14187 (5) : la ligne humaine dans le verdict BLOCKED enumere les
+    fichiers libres et le nombre de contestes -- un caller qui lit stderr
+    sait quoi faire (re-scope aux libres) sans parser le JSON.
+    """
+    _14187_setup_repo(monkeypatch)
+    blocker = comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- knot tranche -- paths: knot_lean/Knots/Conway.lean",
+        "2026-09-01T22:00:00Z",
+    )
+    p = payload(blocker, number=14187)
+    clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["knot_lean/**"],
+    )
+    captured = capsys.readouterr()
+    # Verdict BLOCKED + intersection listee + fichiers libres nommes.
+    assert "BLOCKED" in captured.err
+    assert "scope_intersection_paths" in captured.err
+    assert "knot_lean/Knots/Conway.lean" in captured.err
+    # Le bloc Fichiers libres liste les autres fichiers du scope.
+    assert "Fichiers libres" in captured.err
+    assert "knot_lean/Main.lean" in captured.err
+
+
+def test_14187_truncated_flag_sur_repo_volumineux(capsys, monkeypatch):
+    """#14187 (6) : un scope tres large (>25 fichiers intersectes)
+    tronque la liste a 25 et leve `scope_intersection_truncated`. Sans
+    ce pin, un caller sur un monorepo lirait une liste incomplete comme
+    complete.
+    """
+    # 30 fichiers dans knot_lean, tous matche par `--paths 'knot_lean/**'`
+    big = [f"knot_lean/f{i:03d}.lean" for i in range(30)]
+    _14187_setup_repo(monkeypatch, tracked=big)
+    # Le blocker declare un scope PARTIEL (les 5 premiers fichiers), donc
+    # free_paths contient 25 fichiers libres (tronque) ; scope_intersection
+    # contient les 5 fichiers du blocker (sous le cap, pas tronque).
+    blocker = comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- partial -- paths: knot_lean/f000.lean, knot_lean/f001.lean, knot_lean/f002.lean, knot_lean/f003.lean, knot_lean/f004.lean",
+        "2026-09-01T22:00:00Z",
+    )
+    p = payload(blocker, number=14187)
+    clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["knot_lean/**"],
+    )
+    out = _json_out(capsys.readouterr())
+    # Le blocker declare 5 fichiers : scope_intersection rend les 5
+    # complets (sous le cap de 25, pas de troncature).
+    ac = out["active_claims"]["myia-po-2024:CoursIA"]
+    assert ac["scope_intersection_size"] == 5
+    assert ac["scope_intersection_truncated"] is False
+    # Les 25 autres fichiers du scope (30 - 5 = 25) sont libres ; sous
+    # le cap, pas de troncature non plus.
+    assert out["free_paths_size"] == 25
+    assert out["free_paths_truncated"] is False
+
+    # Cas 2 : un scope ENORME (>50 fichiers libres) doit declencher le
+    # flag truncated sur `free_paths`. On construit un repo avec 60
+    # fichiers que le caller vise via `--paths 'big/**'` mais qu aucun
+    # blocker ne reserve -> free_paths est l integralite du scope (60),
+    # tronque a 25.
+    bigger = [f"big/g{i:03d}.lean" for i in range(60)]
+    _14187_setup_repo(monkeypatch, tracked=bigger)
+    p = payload(number=14187)  # aucun blocker
+    clc._run_check(
+        p, "myia-po-2023:CoursIA",
+        my_paths=["big/**"],
+    )
+    out = _json_out(capsys.readouterr())
+    # Caller disjoint de tout claim -> rc=0 (clear), free_paths =
+    # l integralite du scope (60 fichiers), tronque a 25.
+    assert out["blocked"] is False
+    assert out["free_paths_size"] == 25
+    assert out["free_paths_truncated"] is True


### PR DESCRIPTION
Grain: META/enhancement -- lane myia-po-2026:CoursIA -- prev: LIGHT/chore #14274 (cycle 180)

## Summary

Issue **#14187** : `check_lane_claim.py --paths '<glob large>'` rend `blocked: true` binaire -- le caller voit QUI bloque, mais pas QUOI. Une lane avec un scope de 12 fichiers bloques par 3 autres dont les scopes n'intersectent que 3 fichiers voit les 9 fichiers libres comme bloques elle aussi. Sans enumeration de l'intersection, le caller ne peut pas re-scopersans escalade dashboard.

Cout mesure : `msg-20260901T222733-0qmpmf` (po-2023:CoursIA-2, 53 cycles sans grain CONTENU ouvrable) cite ce `blocked: true` comme cause. Le claim DEEP/lean de la lane etait valide et libre depuis 8 jours sur ses DEUX fichiers reels -- le verdict pris sur le glob large l'a masque.

## Fix : 3 surfaces

### (1) JSON : `scope_intersection_paths` per active_claim

Chaque claim dans `active_claims` expose maintenant les fichiers reellement contestes avec le scope du caller :
- `scope_intersection_paths` : liste des tracked files matchant les DEUX cotes
- `scope_intersection_size` : taille de la liste (meme apres troncature)
- `scope_intersection_truncated` : True si la liste a ete tronquee a 25 entrees

### (2) JSON : `free_paths` + `intersection_summary` au top-level

- `free_paths` : liste des tracked files dans `--paths` qui intersectent AUCUN blocker
- `free_paths_size`, `free_paths_truncated` : tranche / flag
- `intersection_summary` : one-liner lisible (`"2 fichiers bloques / 2 libres dans le scope"`)

### (3) stderr : ligne humaine dans le verdict BLOCKED

Sous la liste des `claimed scopes`, le verdict enumere :
- Per blocker : `scope_intersection_paths = [...]`
- Au scope : `Scope intersection: N fichier(s) conteste(s) sur l'ensemble du scope. Fichiers libres du scope (hors blockers): [...]`

Le caller qui lit stderr peut re-scopersans parser le JSON.

## Cas epiques

| Caller scope | Blockers | free_paths | intersection_summary | rc |
|---|---|---|---|---|
| `'knot_lean/**'` (6 fichiers) | 2 claims : `Conway+Basic.lean`, `Lidman.lean` | `Invariant.lean`, `Util.lean`, `Main.lean` (3) | `"3 fichiers bloques / 3 libres dans le scope"` | 1 |
| `'knot_lean/**'` | 1 claim epic-wide (no `paths:`) | `[]` | `""` (verrouille tout) | 1 |
| `'knot_lean/Util.lean'` | 1 claim sur `Conway.lean` (disjoint) | `['knot_lean/Util.lean']` | (rc=0, clear) | 0 |
| `'big/**'` (60 fichiers, no blocker) | aucun | 25 fichiers (cap) | (rc=0, clear) | 0 |

## Acceptance #14187

- [x] `--paths '<glob large>'` avec plusieurs claims concurrents rend le bloc `scope_intersection_paths` par claim + `free_paths` global.
- [x] `blocked: false` inchange (pas de regression du fail-CLOSED -- les tests existants `test_run_check_disjoint_joker_caller_clear` etc. continuent de passer).
- [x] Le message humain nomme les fichiers libres, pas seulement les bloques.
- [x] Test positif sur un fixture a 3 claims croises : `test_14187_glob_large_liste_fichiers_libres` (6 fichiers, 3 bloques, 3 libres verifies).
- [x] 6 tests #14187 verrouillent chaque surface (intersection par claim / libres / epic-wide / disjoint / stderr humain / troncature).
- [x] Aucun hit sur `exit 1`/`exit 0`/`exit 2` modifie : le verdict reste fail-CLOSED par defaut, l'instrumentation est surfacique.

## Verification

```
$ PYTHONPATH=scripts python -m pytest scripts/tests/test_check_lane_claim.py -k '14187' -v
6 passed, 288 deselected in 0.48s

$ PYTHONPATH=scripts python -m pytest scripts/tests/test_check_lane_claim.py --no-header
293 passed, 1 skipped in 17.49s
```

Aucun test existant ne regresse : 1 test (`test_check_caller_scope_partially_dead_warns_but_keeps_live`) a ete raffine pour mieux distinguer la WARN `SCOPE_DEAD_GLOB` (qui doit contenir le DEAD glob uniquement) du verdict `BLOCKED` (qui peut legitimement enumerer les LIVE globs apres l'ajout #14187). Le test documente la separation explicite dans son commentaire.

Sanity CLI (issue-mode, _run_check) sur fixture synthetique :
```
rc: 1
intersection_summary: '2 fichiers bloques / 2 libres dans le scope'
free_paths: ['knot_lean/Knots/Lidman.lean', 'knot_lean/Knots/Invariant.lean']
active_claims[myia-po-2024:CoursIA].scope_intersection_paths:
    ['knot_lean/Knots/Conway.lean', 'knot_lean/Knots/Basic.lean']
```

## Scope strict

- 1 script modifie (`scripts/check_lane_claim.py`, +206/-4)
- 1 fichier de tests modifie (`scripts/tests/test_check_lane_claim.py`, +233/-0)
- 0 modification d'autre fichier
- Catalogue untouched (R1 catalog-pr-hygiene)
- Aucun hit sur le merge-gate `_lift_eligible` ou autre chemin de blocage des PRs -- modification META pure (instrumentation).

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14187
- Incident fondateur : `msg-20260901T222733-0qmpmf` (po-2023:CoursIA-2, 53 cycles, claim DEEP/lean masque)
- Helpers ajoutes : `_compute_scope_intersection_paths`, `_compute_free_paths` (apres `_path_matches`)
- Lane : myia-po-2026:CoursIA