### PR TITLE
fix(slides,#11508): restaure 11 figures piegees du deck 06-apprentissage

### DIFF
--- a/slides/06-apprentissage/slides.md
+++ b/slides/06-apprentissage/slides.md
@@ -177,7 +177,7 @@ layout: dense
 - Exemple pour le restaurant
 - La classification est positive ou négative
 
-<!-- Image: images/img_004.png -->
+<img src="./images/img_004.png" alt="Table des 12 exemples du restaurant : attributs d'entree et but Attendre" style="display:block; margin:10px auto; max-width:100%;" width="656">
 
 
 ---
@@ -190,7 +190,7 @@ layout: dense
 - But  (Chemin1 ∨ Chemin2 ∨ Chemin3)
 - Exemple du restaurant:
 
-<!-- Image: images/img_005.png -->
+<img src="./images/img_005.png" alt="Arbre de decision du restaurant : Clients, AttenteEstimee, Faim, Reservation" style="display:block; margin:10px auto; max-width:100%;" width="422">
 
 <!-- Frontiere de decision : arbre = decoupage orthogonal, foret = ensemble lisse -->
 
@@ -207,7 +207,7 @@ layout: dense
 - un chemin pour chaque exemple, mais il ne généralisera pas
 - On préfère un arbre plus compact
 
-<!-- Image: images/img_006.png -->
+<img src="./images/img_006.png" alt="Table de verite de A xor B et l'arbre de decision equivalent" style="display:block; margin:10px auto; max-width:100%;" width="628">
 
 
 ---
@@ -238,7 +238,7 @@ layout: dense
 - But: trouver un petit arbre consistant avec les exemples
 - Idée: choisir (récursivement) l’attribut le plus important comme racine de l’arbre (du sous arbre)
 
-<!-- Image: images/img_007.png -->
+<img src="./images/img_007.png" alt="Pseudocode APPRENTISSAGE-ARBRE-DECISION (AIMA)" style="display:block; margin:10px auto; max-width:100%;" width="762">
 
 
 ---
@@ -249,7 +249,7 @@ layout: dense
 - Idée: un bon attribut  divise les exemples en sous-ensembles discriminants (positifs ou négatifs)
 - Clients ? Est un meilleur choix
 
-<!-- Image: images/img_008.png -->
+<img src="./images/img_008.png" alt="Deux splits compares : Clients separe mieux les exemples que Type" style="display:block; margin:10px auto; max-width:100%;" width="900">
 
 
 ---
@@ -328,7 +328,7 @@ layout: dense
 - Substantiellement plus simple que l’arbre « naturel »
 - Une hypothèse plus complexe n’est pas requise par les données
 
-<!-- Image: images/img_010.png -->
+<img src="./images/img_010.png" alt="Arbre appris sur les 12 exemples du restaurant" style="display:block; margin:10px auto; max-width:100%;" width="482">
 
 
 ---
@@ -648,7 +648,7 @@ layout: section
 - Fonction de decision : f(x) = sign(w . x + b)
 - Limite : ne fonctionne que si les données sont lineairement separables
 
-<!-- Image: images/img_021.png -->
+<img src="./images/img_021.png" alt="Nuage a deux classes et frontiere de decision lineaire d'erreur minimale" style="display:block; margin:10px auto; max-width:100%;" width="372">
 
 
 ---
@@ -660,7 +660,7 @@ layout: section
 - Frontiere de decision lisse, interpretable, rapide a entrainer
 - Base des classificateurs lineaires modernes
 
-<!-- Image: images/img_022.png -->
+<img src="./images/img_022.png" alt="Seuil abrupt, sigmoide, et surface logistique en deux dimensions" style="display:block; margin:10px auto; max-width:100%;" width="900">
 
 <!-- Regression : lineaire = droite, polynomiale = courbe, risque de surapprentissage -->
 
@@ -762,7 +762,7 @@ layout: two-cols
 - Mise a jour des poids : W_j ← W_j - alpha * dE/dW_j
 - Permet d'entrainer des réseaux multi-couches (invention cle du deep learning)
 
-<!-- Image: images/img_031.png -->
+<img src="./images/img_031.png" alt="Pseudocode BACK-PROP-LEARNING (AIMA)" style="display:block; margin:10px auto; max-width:100%;" width="326">
 
 
 ---
@@ -1350,7 +1350,7 @@ $$y_i(w \cdot x_i + b) \geq 1 \quad \forall i$$
 
 <!-- SVM : hyperplan optimal, vecteurs supports sur la marge maximale -->
 
-<!-- Image: images/img_086.png -->
+<img src="./images/img_086.png" alt="Astuce du noyau : donnees non separables projetees en surface de decision" style="display:block; margin:10px auto; max-width:100%;" width="526">
 </div>
 ---
 
@@ -2236,7 +2236,7 @@ layout: dense
 ---
 
 
-<!-- Image: images/img_136.png -->
+<img src="./images/img_136.png" alt="Fiche recapitulative AlphaGo Zero : self-play, reseau, MCTS" style="display:block; margin:10px auto; max-width:100%;" width="555">
 
 
 ---


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #14279

## Ce que livre cette PR

Onze figures du cours `06-apprentissage` étaient présentes sur disque, référencées dans la source, et **invisibles au rendu** : la conversion PPTX les avait laissées sous forme de marqueurs `<!-- Image: images/img_NNN.png -->`. Cette PR les rend actives.

Le deck compte 140 références d'images pour **15** réellement rendues. C'est le gros du gisement L4 de #11508, et le fait que le contenu existe déjà sur disque est ce qui rend la tranche livrable sans rien inventer.

## Périmètre : 11 des 17 diapositives mono-image, et pourquoi pas les 17

Le deck porte 45 diapositives à marqueur piégé. Je n'ai pris que celles à **une seule** image — au-delà, remettre plusieurs figures demande de décider d'une grille, ce qui est une autre classe d'édition. Restent 17 candidates ; j'en livre 11.

Le discriminant est la place disponible dans le texte déjà présent :

| Classe | Diapositives | Traitement |
|---|---|---|
| Texte léger (≤ 6 lignes) ou vide | 11 — slides 10, 11, 12, 14, 15, 19, 35, 36, 40, 64, 109 | **livrées ici** |
| Texte dense (10 à 23 puces) | 6 — `img_009`, `img_020`, `img_032`, `img_054`, `img_087`, `img_097` | **différées** : elles demandent un `two-cols` ou une refonte, pas une insertion |

Insérer une figure dans une diapositive déjà pleine la réduirait à une vignette illisible : ce serait exactement le workaround dégradé que [sota-not-workaround.md](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/sota-not-workaround.md) interdit de consacrer. Le sous-lot dense est nommé ci-dessous, pas oublié.

Le cas `img_136` mérite d'être signalé à part : sa diapositive (109, « AlphaGo Zero ») ne contient **aucun** texte. Elle se rend aujourd'hui entièrement blanche.

## Vérification visuelle des 11 figures — préalable, pas formalité

#11508 met en garde contre les marqueurs mal appariés (des images décoratives « QUIZ TIME » atterries dans des colonnes de contenu sur le deck S3). Restaurer sans regarder aurait donc pu rendre visible une image sans rapport avec sa diapositive.

J'ai monté les 11 en planche contact et je les ai lues une par une. Toutes sont des figures authentiques du cours (AIMA), et chacune correspond au titre de sa diapositive :

| Diapo | Image | Contenu vérifié |
|---:|---|---|
| 10 | `img_004` | table des 12 exemples du restaurant |
| 11 | `img_005` | arbre de décision du restaurant |
| 12 | `img_006` | table de vérité de `A xor B` + arbre équivalent |
| 14 | `img_007` | pseudocode APPRENTISSAGE-ARBRE-DÉCISION |
| 15 | `img_008` | comparaison de deux découpages (Clients vs Type) |
| 19 | `img_010` | arbre appris sur les 12 exemples |
| 35 | `img_021` | nuage à deux classes + frontière linéaire |
| 36 | `img_022` | seuil abrupt, sigmoïde, surface logistique |
| 40 | `img_031` | pseudocode BACK-PROP-LEARNING |
| 64 | `img_086` | astuce du noyau |
| 109 | `img_136` | fiche récapitulative AlphaGo Zero |

Aucune vignette décorative dans le lot.

## Mesure de l'effet

`scripts/notebook_tools/scan_slides_image_refs.py`, avant puis après :

| | ACTIVE | COMMENT_TRAPPED |
|---|---:|---:|
| deck `06-apprentissage` | 15 → **26** | 125 → **114** |
| dépôt entier | 393 → **404** | 216 → **205** |

Exactement +11 / −11 : aucun autre deck n'a bougé.

## Mesure de composition — avant / après, avec le contrôle du scanner armé

`scripts/notebook_tools/scan_slidev_composition.py`, deck servi par Slidev et rendu par Playwright, sur le deck non modifié puis sur le deck édité :

| | diapos | HORS_CANVAS | CHEVAUCHEMENT | OCCUPATION |
|---|---:|---:|---:|---:|
| avant (`84d6a974d9`) | 121 | 0 | 0 | 5 |
| après | 122 (canari inclus) | **0** | **0** | **5** |

Les 5 diapositives à composition déséquilibrée sont **le même ensemble** avant et après — `{28, 29, 30, 37, 48}` — et **aucune des onze** n'y entre. Rien n'apparaît, rien ne disparaît.

Le scan après est armé : `--baseline-slide 29 --baseline-commit 84d6a974d9` → `controle_positif_armed: true`, `controle_positif_ok: true`. C'est ce qui distingue « rien à signaler » d'un chemin de détection mort — le scan avant, lui, portait l'avertissement `controle_positif_armed: false`, et son zéro n'aurait rien prouvé seul.

**Deux réserves, à dire plutôt qu'à taire :**

1. **Mon canari n'a pas armé le chemin HORS_CANVAS.** J'avais ajouté une diapositive temporaire avec `<img width="1600">` sur un canvas de 980 px, pour vérifier que ce chemin-là n'est pas mort non plus. Il n'a pas levé de signal, et la mesure dit pourquoi : le rendu donne `img_span: [48, 932]`, soit **884 px** — le thème clamp toute image à la largeur de la colonne de contenu. Sur ce deck, un attribut `width` surdimensionné **ne peut pas** produire de débordement horizontal ; le canari était donc structurellement incapable de faire ce que j'attendais de lui. Le chemin HORS_CANVAS reste non exercé par ce deck, avant comme après. (Effet de bord rassurant pour cette PR : même une largeur mal calculée serait rattrapée par le thème.)
2. **Les diapositives 64 et 109 gagnent un débordement de conteneur.** Le `div.slidev-layout` y passe à 568 et 584 px de haut pour un canvas de 552. Le scanner les classe `container_only` et les exclut de `n_hors_canvas`, à raison : leur `content_bottom` vaut 526 et 542, tous deux **sous** 552 — le conteneur déborde par ses marges, le contenu non, rien n'est coupé. Je le signale parce que le compte agrégé ne le montre pas.

Le scanner se déclare lui-même ADVISORY et « ne remplace pas le QA visuel humain » : la vérification visuelle ci-dessus est la mesure principale, celle-ci est le garde-fou.

## Comment l'édition a été faite

Script d'édition avec, pour chaque image, une **assertion d'unicité** sur le marqueur ciblé (le remplacement échoue si le marqueur apparaît zéro ou plusieurs fois) et, en sortie, une **preuve de périmètre** : le nombre de lignes du fichier est inchangé et exactement 11 lignes diffèrent. Le diff le confirme — 11 insertions, 11 suppressions, un seul fichier.

Chaque largeur est calculée depuis les dimensions réelles du PNG et un budget de hauteur propre à la diapositive, plafonnée à 900 px (largeur utile du canvas 980 moins les marges du thème). Rien n'est écrit en dur.

## Ce que cette PR ne fait pas

- **Elle ne traite pas les 6 diapositives à texte dense** (`img_009`, `img_020`, `img_032`, `img_054`, `img_087`, `img_097`) : elles demandent un arbitrage de mise en page.
- **Elle ne traite pas les 28 diapositives multi-images** du même deck (2 à 9 figures piégées chacune) : même raison, une grille se décide.
- **Elle ne touche ni `05-theorie-des-jeux` ni `04-probabilites`**, qui portent le reste du gisement L4 (respectivement 54 `MARP_ONLY` et 51 marqueurs piégés).
- **Elle ne traite pas L6** (fichiers de rapport et répertoires de bruit sous `slides/`).

À ce titre : `See #11508`, pas `Closes`.

See #11508
