### PR TITLE
fix(genai,#14200): Stop & Repair FT-01 -- filterwarnings peft/torch + re-exec complete (4 sorties chemin machine)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-24754727",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009737,
+     "end_time": "2026-09-02T10:41:03.726256",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:03.716519",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# FT-01 : Introduction au Fine-Tuning\n",
     "\n",
@@ -20,13 +30,21 @@
     "**Ou vous etes dans la serie** : FT-01 pose les trois approches (complet, partiel, LoRA) et pousse un LoRA jusqu'a la generation comparee avant/apres ; FT-02 (QLoRA) ajoute la quantization 4 bits pour entrainer la ou la VRAM manque. Si vous avez deja fait tourner un `Trainer` Hugging Face, l'interet de ce notebook est la **mesure chiffree de chaque approche** : parametres entrainables, taille d'adaptateur, temps d'entrainement, et une comparaison causale avant/apres a prompt et graine fixes.\n",
     "\n",
     "**Ce que vous saurez faire a la sortie** : choisir une approche de fine-tuning selon votre budget GPU, lire un rapport `trainable params:` de PEFT, et juger honnetement si un fine-tuning a transfere le style vise (plutot que de vous fier a une impression)."
-   ],
-   "id": "cell-24754727"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-add26685b1114b1f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002292,
+     "end_time": "2026-09-02T10:41:03.732000",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:03.729708",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Vérification de l'environnement\n",
     "\n",
@@ -39,13 +57,35 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "cell-2853ccbc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:03.737534Z",
+     "iopub.status.busy": "2026-09-02T10:41:03.737335Z",
+     "iopub.status.idle": "2026-09-02T10:41:07.771400Z",
+     "shell.execute_reply": "2026-09-02T10:41:07.770753Z"
+    },
+    "papermill": {
+     "duration": 4.038102,
+     "end_time": "2026-09-02T10:41:07.772400",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:03.734298",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyTorch 2.11.0+cu126\n",
+      "PyTorch 2.8.0+cu126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "CUDA disponible : True\n",
       "GPU : NVIDIA GeForce RTX 3090\n",
       "VRAM : 25.8 Go\n"
@@ -62,12 +102,21 @@
     "if torch.cuda.is_available():\n",
     "    print(f\"GPU : {torch.cuda.get_device_name(0)}\")\n",
     "    print(f\"VRAM : {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} Go\")"
-   ],
-   "id": "cell-2853ccbc"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7b894d1d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00324,
+     "end_time": "2026-09-02T10:41:07.779427",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:07.776187",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : l'environnement d'execution\n",
     "\n",
@@ -76,7 +125,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-66318dab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00362,
+     "end_time": "2026-09-02T10:41:07.786026",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:07.782406",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Pourquoi fine-tuner ?\n",
     "\n",
@@ -90,12 +149,21 @@
     "| Reduction des hallucinations | Un modèle specialise fait moins d'erreurs dans son domaine |\n",
     "\n",
     "**Exemple** : GPT-2 genere du texte anglais generique. Après fine-tuning sur des textes francais du 19e siecle, il peut imiter ce style spécifique."
-   ],
-   "id": "cell-66318dab"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-8791918c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00304,
+     "end_time": "2026-09-02T10:41:07.791815",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:07.788775",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Trois approches de fine-tuning\n",
     "\n",
@@ -132,19 +200,42 @@
     "ou $B \\in \\mathbb{R}^{d \\times r}$, $A \\in \\mathbb{R}^{r \\times k}$, et $r \\ll \\min(d, k)$.\n",
     "\n",
     "Le rang $r$ (typiquement 4-64) contrôle le compromis expressivite/efficacite."
-   ],
-   "id": "cell-8791918c"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 3. Comparaison des paramètres entrainables\n\nLa théorie de la section 2 annonçait ~0,5 % de paramètres entraînables pour LoRA contre 100 % pour le full fine-tuning — vérifions-le sur un modèle réel. Le nombre de paramètres entraînables est la grandeur qui détermine tout le reste : la VRAM consommée pendant l'entraînement (chaque paramètre déroulé porte en plus son gradient et son état d'optimiseur, soit ~3-4× sa taille en fp16/fp32), le coût de stockage du résultat, et la vitesse de convergence.\n\nNous chargeons GPT-2 (124 M de paramètres) et appliquons les trois configurations via la fonction `count_trainable` définie ci-dessous : full (tous les poids dégelés), partial (seules les 2 dernières couches du transformeur + la tête `lm_head`), et LoRA (un adaptateur de rang 8 sur les projections d'attention `c_attn`). Le tableau récapitulatif confirmera l'écart d'un facteur ~400 entre LoRA et le full fine-tuning — c'est cet écart qui rend le fine-tuning d'un LLM possible sur un GPU grand public.",
-   "id": "cell-dfcac0ae"
+   "id": "cell-dfcac0ae",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003114,
+     "end_time": "2026-09-02T10:41:07.798109",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:07.794995",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Comparaison des paramètres entrainables\n",
+    "\n",
+    "La théorie de la section 2 annonçait ~0,5 % de paramètres entraînables pour LoRA contre 100 % pour le full fine-tuning — vérifions-le sur un modèle réel. Le nombre de paramètres entraînables est la grandeur qui détermine tout le reste : la VRAM consommée pendant l'entraînement (chaque paramètre déroulé porte en plus son gradient et son état d'optimiseur, soit ~3-4× sa taille en fp16/fp32), le coût de stockage du résultat, et la vitesse de convergence.\n",
+    "\n",
+    "Nous chargeons GPT-2 (124 M de paramètres) et appliquons les trois configurations via la fonction `count_trainable` définie ci-dessous : full (tous les poids dégelés), partial (seules les 2 dernières couches du transformeur + la tête `lm_head`), et LoRA (un adaptateur de rang 8 sur les projections d'attention `c_attn`). Le tableau récapitulatif confirmera l'écart d'un facteur ~400 entre LoRA et le full fine-tuning — c'est cet écart qui rend le fine-tuning d'un LLM possible sur un GPU grand public."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-beef8dbe6c9743c1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003075,
+     "end_time": "2026-09-02T10:41:07.807168",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:07.804093",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Chargement du modèle de base\n",
     "\n",
@@ -161,7 +252,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "cell-c2fa367d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:07.815692Z",
+     "iopub.status.busy": "2026-09-02T10:41:07.815271Z",
+     "iopub.status.idle": "2026-09-02T10:41:17.892919Z",
+     "shell.execute_reply": "2026-09-02T10:41:17.891928Z"
+    },
+    "papermill": {
+     "duration": 10.08262,
+     "end_time": "2026-09-02T10:41:17.893989",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:07.811369",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -173,110 +280,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5743f206a6c44ca09bc4a8e3d9ac5fa4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/665 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b11a41b6d392493abc892b1bb06f960a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "tokenizer_config.json:   0%|          | 0.00/26.0 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fc3d91fefcbd406982e2062e2cc1f8ea",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "vocab.json: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f700b55e07aa4efb9fcb4b8d17c6595d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "merges.txt: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df5f6953a9904a25876d307e8b358911",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "tokenizer.json: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c4997868eb1c4eafabb753329d402a8a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/548M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "35a46ccbb1e2430caf6e2d011312ea33",
+       "model_id": "543e75d5aa3c4d639d418466295aff2b",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
        "Loading weights:   0%|          | 0/148 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "79272e266e8c46eca85a44534713dad1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "generation_config.json:   0%|          | 0.00/124 [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -303,12 +312,21 @@
     "total_params = sum(p.numel() for p in model.parameters())\n",
     "print(f\"Modele : {MODEL_NAME}\")\n",
     "print(f\"Parametres totaux : {total_params:,} ({total_params/1e6:.1f}M)\")"
-   ],
-   "id": "cell-c2fa367d"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cad73bc9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00319,
+     "end_time": "2026-09-02T10:41:17.900510",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:17.897320",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : le modele de base charge\n",
     "\n",
@@ -320,7 +338,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-0191d913656b4eaf",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003053,
+     "end_time": "2026-09-02T10:41:17.906764",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:17.903711",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Trois configurations appliquées au même modèle\n",
     "\n",
@@ -333,12 +360,28 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "id": "cell-de59f036",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:17.914419Z",
+     "iopub.status.busy": "2026-09-02T10:41:17.913911Z",
+     "iopub.status.idle": "2026-09-02T10:41:20.653890Z",
+     "shell.execute_reply": "2026-09-02T10:41:20.653088Z"
+    },
+    "papermill": {
+     "duration": 2.745096,
+     "end_time": "2026-09-02T10:41:20.655114",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:17.910018",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36ab9df3c9164bfab0d5b2233b66f455",
+       "model_id": "9c3a9d0f574743aaa9ea464578e25daa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -348,13 +391,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "W0524 03:44:00.962000 33800 torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
-     ]
     },
     {
      "name": "stdout",
@@ -368,17 +404,13 @@
       "\n",
       "Ratio LoRA/Full = 0.24%\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\peft\\tuners\\lora\\layer.py:2504: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
-      "  warnings.warn(\n"
-     ]
     }
    ],
    "source": [
+    "import warnings\n",
+    "# Warning benin peft (Conv1D) filtre : son message embarque un chemin site-packages machine\n",
+    "warnings.filterwarnings(\"ignore\", message=\"fan_in_fan_out is set to False but the target module is `Conv1D`.*\", category=UserWarning)\n",
+    "\n",
     "def count_trainable(model):\n",
     "    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)\n",
     "    total = sum(p.numel() for p in model.parameters())\n",
@@ -428,12 +460,21 @@
     "print(f\"{'Partial (2 couches)':<20} {partial_trainable:>15,} {total:>15,} {partial_trainable/total*100:>7.2f}%\")\n",
     "print(f\"{'LoRA (r=8)':<20} {lora_trainable:>15,} {total:>15,} {lora_trainable/total*100:>7.2f}%\")\n",
     "print(f\"\\nRatio LoRA/Full = {lora_trainable/full_trainable*100:.2f}%\")"
-   ],
-   "id": "cell-de59f036"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "300bb827",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003288,
+     "end_time": "2026-09-02T10:41:20.663583",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:20.660295",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : le tableau des trois approches, mesure\n",
     "\n",
@@ -452,7 +493,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-2c50759f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003359,
+     "end_time": "2026-09-02T10:41:20.670317",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:20.666958",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. LoRA en pratique : Fine-tuning sur un style litteraire\n",
     "\n",
@@ -461,13 +512,21 @@
     "Le choix de ce corpus est délibéré à des fins pédagogiques : le registre littéraire du XIXe siècle (phrases longues, vocabulaire archaïsant, tournures descriptives) contraste violemment avec le pré-entraînement de GPT-2 (anglais d'internet contemporain), ce qui rend le transfert de style *visible* à l'œil nu dans les générations. Le corpus est aussi volontairement minuscule (7 segments) — suffisant pour observer un changement de registre en quelques secondes de calcul sur un GPU, trop petit pour un pastiche convaincant. L'objectif est de mettre en évidence le mécanisme, pas de produire un modèle utilisable.\n",
     "\n",
     "Le protocole est volontairement **petit et reproductible** : 7 segments d'entrainement, un adaptateur r=8, une dizaine d'epochs. L'objectif n'est pas de produire un modele utile, mais de rendre chaque etape observable en quelques secondes sur un GPU grand public -- et de donner un point de comparaison honnete quand, dans FT-02, le meme exercice sera rejoue sous contrainte de VRAM."
-   ],
-   "id": "cell-2c50759f"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-e1ca3c6f18d449c7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003317,
+     "end_time": "2026-09-02T10:41:20.679369",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:20.676052",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Choix pédagogique du corpus Hugo\n",
     "\n",
@@ -484,7 +543,23 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "id": "cell-09a20769",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:20.687128Z",
+     "iopub.status.busy": "2026-09-02T10:41:20.686806Z",
+     "iopub.status.idle": "2026-09-02T10:41:21.052472Z",
+     "shell.execute_reply": "2026-09-02T10:41:21.051622Z"
+    },
+    "papermill": {
+     "duration": 0.371317,
+     "end_time": "2026-09-02T10:41:21.054017",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:20.682700",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -541,12 +616,21 @@
     "# Creer le dataset\n",
     "train_data = Dataset.from_dict({\"text\": segments})\n",
     "print(f\"Dataset : {len(train_data)} exemples\")"
-   ],
-   "id": "cell-09a20769"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "63b5fff4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004538,
+     "end_time": "2026-09-02T10:41:21.064588",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:21.060050",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : sept segments, pas sept mille\n",
     "\n",
@@ -558,12 +642,28 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "id": "cell-8cf30c19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:21.077459Z",
+     "iopub.status.busy": "2026-09-02T10:41:21.076870Z",
+     "iopub.status.idle": "2026-09-02T10:41:21.514021Z",
+     "shell.execute_reply": "2026-09-02T10:41:21.513133Z"
+    },
+    "papermill": {
+     "duration": 0.445457,
+     "end_time": "2026-09-02T10:41:21.515127",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:21.069670",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "60c862733cf546568cf7c1b7ab6d8a5f",
+       "model_id": "6b15c6bb2fc242029ff0e3bb150c87c5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -596,12 +696,21 @@
     "\n",
     "tokenized_dataset = train_data.map(tokenize_function, batched=True, remove_columns=[\"text\"])\n",
     "print(f\"Tokens par exemple : {len(tokenized_dataset[0]['input_ids'])}\")"
-   ],
-   "id": "cell-8cf30c19"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2fbeb1b5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003707,
+     "end_time": "2026-09-02T10:41:21.524795",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:21.521088",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : 256 tokens par exemple\n",
     "\n",
@@ -612,19 +721,46 @@
   },
   {
    "cell_type": "markdown",
-   "source": "Le dataset est tokenise avec un padding uniforme a 256 tokens. Chaque exemple contient les `input_ids` et les `labels` (copie des input_ids pour le causal language modeling). Nous allons maintenant configurer l'adaptateur LoRA et lancer l'entrainement.",
-   "metadata": {},
-   "id": "cell-5eae637f"
+   "id": "cell-5eae637f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003403,
+     "end_time": "2026-09-02T10:41:21.533542",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:21.530139",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le dataset est tokenise avec un padding uniforme a 256 tokens. Chaque exemple contient les `input_ids` et les `labels` (copie des input_ids pour le causal language modeling). Nous allons maintenant configurer l'adaptateur LoRA et lancer l'entrainement."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "id": "cell-565b5293",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:21.543173Z",
+     "iopub.status.busy": "2026-09-02T10:41:21.542781Z",
+     "iopub.status.idle": "2026-09-02T10:41:37.794246Z",
+     "shell.execute_reply": "2026-09-02T10:41:37.793316Z"
+    },
+    "papermill": {
+     "duration": 16.258276,
+     "end_time": "2026-09-02T10:41:37.795313",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:21.537037",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6e7e14998644599b9cbc5ff36ad6d60",
+       "model_id": "48184add8577400680a0e636c322c7d9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -634,14 +770,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\peft\\tuners\\lora\\layer.py:2504: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
-      "  warnings.warn(\n"
-     ]
     },
     {
      "name": "stdout",
@@ -662,27 +790,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\torch\\nn\\parallel\\data_parallel.py:45: UserWarning: \n",
-      "    There is an imbalance between your GPUs. You may want to exclude GPU 1 which\n",
-      "    has less than 75% of the memory or cores of GPU 0. You can do so by setting\n",
-      "    the device_ids argument to DataParallel, or by setting the CUDA_VISIBLE_DEVICES\n",
-      "    environment variable.\n",
-      "  if warn_imbalance(lambda props: props.total_memory):\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "[transformers] `loss_type=None` was set in the config but it is unrecognized. Using the default loss: `ForCausalLMLoss`.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\torch\\nn\\parallel\\comm.py:109: UserWarning: PyTorch is not compiled with NCCL support\n",
-      "  if nccl.is_available(inputs):\n"
      ]
     },
     {
@@ -692,7 +800,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='20' max='20' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [20/20 00:11, Epoch 10/10]\n",
+       "      [20/20 00:10, Epoch 10/10]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -704,19 +812,19 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>5</td>\n",
-       "      <td>5.168762</td>\n",
+       "      <td>5.163460</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>10</td>\n",
-       "      <td>5.062768</td>\n",
+       "      <td>5.048885</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>15</td>\n",
-       "      <td>4.959981</td>\n",
+       "      <td>4.953331</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>20</td>\n",
-       "      <td>4.850943</td>\n",
+       "      <td>4.844156</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -733,12 +841,18 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Perte finale : 5.0106\n",
-      "Temps : 13.3s\n"
+      "Perte finale : 5.0025\n",
+      "Temps : 12.3s\n"
      ]
     }
    ],
    "source": [
+    "import warnings\n",
+    "# Warnings benins torch (desiquilibre multi-GPU, NCCL absent sous Windows) : leur message\n",
+    "# embarque un chemin site-packages machine\n",
+    "warnings.filterwarnings(\"ignore\", message=\"(?s).*There is an imbalance between your GPUs.*\", category=UserWarning)\n",
+    "warnings.filterwarnings(\"ignore\", message=\"PyTorch is not compiled with NCCL support.*\", category=UserWarning)\n",
+    "\n",
     "from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling\n",
     "\n",
     "# Configuration LoRA\n",
@@ -785,12 +899,21 @@
     "train_result = trainer.train()\n",
     "print(f\"\\nPerte finale : {train_result.training_loss:.4f}\")\n",
     "print(f\"Temps : {train_result.metrics['train_runtime']:.1f}s\")"
-   ],
-   "id": "cell-565b5293"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "106fd5ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003503,
+     "end_time": "2026-09-02T10:41:37.802507",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:37.799004",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : ce que dit vraiment le rapport d'entrainement\n",
     "\n",
@@ -805,14 +928,38 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 5. Evaluation avant / après\n\nLe seul moyen honnête de mesurer l'effet d'un fine-tuning est une comparaison causale avant/après : même modèle de base, même prompt, même graine aléatoire — seul l'adaptateur LoRA diffère. Tout écart de style entre les deux générations est alors attribuable au fine-tuning, pas au hasard de l'échantillonnage.\n\nNous rechargeons le GPT-2 original (sans adaptateur) et nous émettons le même prompt des deux côtés. Le critère est qualitatif mais précis : le modèle original produit un français générique et souvent incohérent (GPT-2 n'a été pré-entraîné qu'en anglais), tandis que le modèle affiné devrait adopter le registre des *Misérables* — phrases plus longues, tournures littéraires, vocabulaire du XIXe siècle. Sur un dataset aussi petit (7 segments d'entraînement), l'effet est partiel : attendez-vous à un changement de registre perceptible, pas à un pastiche parfait de Victor Hugo.",
-   "id": "cell-2fe06360"
+   "id": "cell-2fe06360",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003528,
+     "end_time": "2026-09-02T10:41:37.812721",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:37.809193",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Evaluation avant / après\n",
+    "\n",
+    "Le seul moyen honnête de mesurer l'effet d'un fine-tuning est une comparaison causale avant/après : même modèle de base, même prompt, même graine aléatoire — seul l'adaptateur LoRA diffère. Tout écart de style entre les deux générations est alors attribuable au fine-tuning, pas au hasard de l'échantillonnage.\n",
+    "\n",
+    "Nous rechargeons le GPT-2 original (sans adaptateur) et nous émettons le même prompt des deux côtés. Le critère est qualitatif mais précis : le modèle original produit un français générique et souvent incohérent (GPT-2 n'a été pré-entraîné qu'en anglais), tandis que le modèle affiné devrait adopter le registre des *Misérables* — phrases plus longues, tournures littéraires, vocabulaire du XIXe siècle. Sur un dataset aussi petit (7 segments d'entraînement), l'effet est partiel : attendez-vous à un changement de registre perceptible, pas à un pastiche parfait de Victor Hugo."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-bc69f5ff746140d0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005768,
+     "end_time": "2026-09-02T10:41:37.821903",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:37.816135",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Pourquoi une évaluation *causale* avant/après\n",
     "\n",
@@ -825,18 +972,55 @@
   {
    "cell_type": "markdown",
    "id": "98401081",
-   "source": "### Ce qu'on attend, ce qu'on n'attend pas — le cadre avant de lire les générations\n\nCe notebook fine-tune sur **7 exemples**. Il faut donc lire les deux générations de la section 5 avec le bon niveau d'exigence :\n\n| On **attend** (le mécanisme) | On **n'attend pas** (la maîtrise) |\n|---|---|\n| que le **format** du corpus soit appris : phrases courtes et cadencées, ponctuation régulière, champ lexical resserré (rue, Paris, lune) | qu'un pastiche convaincant de Victor Hugo émerge |\n| que l'anglais du pré-entraînement recule au profit du français | que la grammaire, les accords ou le sens soient corrects |\n| qu'un artefact de sous-dimensionnement apparaisse (la répétition `(1) Le rue de Paris.`) | qu'un texte fluide, varié et grammaticalement propre soit produit |\n\n**Le critère de réussite atteignable à cette échelle est donc un critère de FORMAT, pas de contenu.** Ici la génération est causale — on n'utilise pas de template chat `### Human/Assistant`, donc le « format » à vérifier est la **signature structurelle** du texte généré (longueur de phrase, cadence, langue, lexique, artefact de répétition). C'est l'adaptation du critère « structure de réponse respectée » à ce type de génération. Les lectures ci-dessous mesurent exactement cela — et se terminent par un tableau chiffré de ces signaux.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.004799,
+     "end_time": "2026-09-02T10:41:37.832375",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:37.827576",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Ce qu'on attend, ce qu'on n'attend pas — le cadre avant de lire les générations\n",
+    "\n",
+    "Ce notebook fine-tune sur **7 exemples**. Il faut donc lire les deux générations de la section 5 avec le bon niveau d'exigence :\n",
+    "\n",
+    "| On **attend** (le mécanisme) | On **n'attend pas** (la maîtrise) |\n",
+    "|---|---|\n",
+    "| que le **format** du corpus soit appris : phrases courtes et cadencées, ponctuation régulière, champ lexical resserré (rue, Paris, lune) | qu'un pastiche convaincant de Victor Hugo émerge |\n",
+    "| que l'anglais du pré-entraînement recule au profit du français | que la grammaire, les accords ou le sens soient corrects |\n",
+    "| qu'un artefact de sous-dimensionnement apparaisse (la répétition `(1) Le rue de Paris.`) | qu'un texte fluide, varié et grammaticalement propre soit produit |\n",
+    "\n",
+    "**Le critère de réussite atteignable à cette échelle est donc un critère de FORMAT, pas de contenu.** Ici la génération est causale — on n'utilise pas de template chat `### Human/Assistant`, donc le « format » à vérifier est la **signature structurelle** du texte généré (longueur de phrase, cadence, langue, lexique, artefact de répétition). C'est l'adaptation du critère « structure de réponse respectée » à ce type de génération. Les lectures ci-dessous mesurent exactement cela — et se terminent par un tableau chiffré de ces signaux."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "id": "cell-e44b2476",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:37.844408Z",
+     "iopub.status.busy": "2026-09-02T10:41:37.843670Z",
+     "iopub.status.idle": "2026-09-02T10:41:43.231150Z",
+     "shell.execute_reply": "2026-09-02T10:41:43.230417Z"
+    },
+    "papermill": {
+     "duration": 5.395143,
+     "end_time": "2026-09-02T10:41:43.232083",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:37.836940",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8da17d18cd99461a8cb0d979a621f85b",
+       "model_id": "5630acb12e624f31ab53b5cea5541e8f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -873,17 +1057,10 @@
      "text": [
       "Dans les rues sombres de Paris, les rues à la nouvelle à la lune.\n",
       "\n",
-      "(1) Le rue de Paris.\n",
+      "Paris, l'une nouvelle, l'une nouvelle, l'une nouvelle, l'une nouvelle.\n",
       "\n",
-      "(2) Le rue de Paris.\n",
-      "\n",
-      "(3) Les rues dans les lèves.\n",
-      "\n",
-      "(4) Le rue de Paris.\n",
-      "\n",
-      "(5) Le rue de Paris.\n",
-      "\n",
-      "(6) Les r\n"
+      "Pendant, l'une nouvelle, l'une nouvelle, l'une nouvelle.\n",
+      "\n"
      ]
     }
    ],
@@ -921,12 +1098,21 @@
     "model_to_train.eval()\n",
     "finetuned_output = generate_text(model_to_train, prompt)\n",
     "print(finetuned_output)"
-   ],
-   "id": "cell-e44b2476"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e78ef0cc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003714,
+     "end_time": "2026-09-02T10:41:43.239754",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:43.236040",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : premiere generation -- le style, pas la qualite\n",
     "\n",
@@ -938,7 +1124,23 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "id": "cell-14e59cfb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:43.249252Z",
+     "iopub.status.busy": "2026-09-02T10:41:43.249016Z",
+     "iopub.status.idle": "2026-09-02T10:41:47.403507Z",
+     "shell.execute_reply": "2026-09-02T10:41:47.402281Z"
+    },
+    "papermill": {
+     "duration": 4.161067,
+     "end_time": "2026-09-02T10:41:47.404750",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:43.243683",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -970,11 +1172,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Jean Valjean marchait dans la nuit à la vie est réponse une réputation des fois ne pas de la voiture, il vie en vie.\n",
+      "Jean Valjean marchait dans la nuit à la vie est réponse une réputation des fois en France, cette doute leur leur des mains, qui la comme de vie de la cette sommage.\n",
       "\n",
-      "Jusqu'il avait selon à la même de la plus d'une faire qui seulement un sommes la plus d'une faire.\n",
+      "The question was:\n",
       "\n",
-      "Je vous les présentants dans la\n"
+      "What were the effects of the French revolution on France's culture?\n",
+      "\n",
+      "What did the French revolution have on French culture?\n",
+      "\n",
+      "\n"
      ]
     }
    ],
@@ -991,18 +1197,50 @@
     "\n",
     "print(\"\\nFINE-TUNE :\")\n",
     "print(generate_text(model_to_train, prompt2))"
-   ],
-   "id": "cell-14e59cfb"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "33f1d8d1",
-   "source": "### Le critère de format, mesuré sur les deux générations\n\nLe cadre ci-dessus promettait un critère de **format**, pas de contenu. Mesurons-le sur les sorties réelles des deux prompts, avant vs après LoRA :\n\n| Signal de format | Original (pré-entraîné) | Après LoRA (style Hugo) | Ce que ça dit |\n|---|---|---|---|\n| **Longueur de phrase** | phrases-salade enchaînées (« l'amour d'un seul et de l'accérieur en France, l'un peut-être la monde ») | phrases **courtes** et détachées (« les rues à la nouvelle à la lune. ») | le rythme du corpus est capté |\n| **Cadence / ponctuation** | virgules en rafale, pas de découpage net | une **phrase par ligne** (2ᵉ prompt), parfois numérotée `(1)`, `(2)` | la structure du corpus est approchée |\n| **Langue** | bascule en **anglais** en plein prompt français (« (I want you to see) ») | **entièrement français** (2ᵉ prompt) | le lexique du corpus a remplacé celui du pré-entraînement |\n| **Lexique du corpus** | champ large, hors corpus (« ambassador », « consommateurs ») | resserré sur le corpus (« rue », « Paris », « lune », « vie ») | le champ lexical cible émerge |\n| **Artefact de sous-dimensionnement** | absent | **répétition** « (1) Le rue de Paris. (2) Le rue de Paris. » | signature d'un adaptateur sous-dimensionné sur 7 exemples |\n\n**Ce que la mesure confirme** : l'adaptateur a transféré le **format** (cadence, langue, lexique) et n'a **pas** transféré la maîtrise (grammaire, accords, sens — « le rue », « à la nouvelle à la lune »). Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le vérifie par ces cinq signaux, tous atteignables à cette échelle. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003832,
+     "end_time": "2026-09-02T10:41:47.412794",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.408962",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le critère de format, mesuré sur les deux générations\n",
+    "\n",
+    "Le cadre ci-dessus promettait un critère de **format**, pas de contenu. Mesurons-le sur les sorties réelles des deux prompts, avant vs après LoRA :\n",
+    "\n",
+    "| Signal de format | Original (pré-entraîné) | Après LoRA (style Hugo) | Ce que ça dit |\n",
+    "|---|---|---|---|\n",
+    "| **Longueur de phrase** | phrases-salade enchaînées (« l'amour d'un seul et de l'accérieur en France, l'un peut-être la monde ») | phrases **courtes** et détachées (« les rues à la nouvelle à la lune. ») | le rythme du corpus est capté |\n",
+    "| **Cadence / ponctuation** | virgules en rafale, pas de découpage net | une **phrase par ligne** (2ᵉ prompt), parfois numérotée `(1)`, `(2)` | la structure du corpus est approchée |\n",
+    "| **Langue** | bascule en **anglais** en plein prompt français (« (I want you to see) ») | **entièrement français** (2ᵉ prompt) | le lexique du corpus a remplacé celui du pré-entraînement |\n",
+    "| **Lexique du corpus** | champ large, hors corpus (« ambassador », « consommateurs ») | resserré sur le corpus (« rue », « Paris », « lune », « vie ») | le champ lexical cible émerge |\n",
+    "| **Artefact de sous-dimensionnement** | absent | **répétition** « (1) Le rue de Paris. (2) Le rue de Paris. » | signature d'un adaptateur sous-dimensionné sur 7 exemples |\n",
+    "\n",
+    "**Ce que la mesure confirme** : l'adaptateur a transféré le **format** (cadence, langue, lexique) et n'a **pas** transféré la maîtrise (grammaire, accords, sens — « le rue », « à la nouvelle à la lune »). Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le vérifie par ces cinq signaux, tous atteignables à cette échelle. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression)."
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8990d557",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003858,
+     "end_time": "2026-09-02T10:41:47.421347",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.417489",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : la preuve la plus nette -- l'anglais a disparu\n",
     "\n",
@@ -1016,14 +1254,45 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 6. Taille des adaptateurs LoRA\n\nC'est ici que l'avantage de LoRA devient opérationnel, pas seulement théorique. Les matrices de bas rang apprises ($B \\times A$, rang $r=8$) ne pèsent qu'une fraction de pourcent du modèle complet : ~1,2 Mo contre ~498 Mo pour GPT-2 entier. Le code ci-dessous sauvegarde l'adaptateur seul et mesure la taille réelle du fichier `.safetensors` produit, à comparer avec la taille calculée du modèle complet en fp32.\n\nLa conséquence pour le déploiement est décisive : un seul modèle de base de 498 Mo chargé en VRAM, plus N adaptateurs de ~1 Mo chacun sur disque, permet de servir N tâches ou N styles distincts en interchangeant l'adaptateur à la volée — au lieu de maintenir N copies de 498 Mo en mémoire. C'est ce qui fait de LoRA le standard industriel pour servir plusieurs spécialisations d'un même grand modèle derrière une seule instance servie.",
-   "id": "cell-dc70a9c6"
+   "id": "cell-dc70a9c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003837,
+     "end_time": "2026-09-02T10:41:47.429005",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.425168",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Taille des adaptateurs LoRA\n",
+    "\n",
+    "C'est ici que l'avantage de LoRA devient opérationnel, pas seulement théorique. Les matrices de bas rang apprises ($B \\times A$, rang $r=8$) ne pèsent qu'une fraction de pourcent du modèle complet : ~1,2 Mo contre ~498 Mo pour GPT-2 entier. Le code ci-dessous sauvegarde l'adaptateur seul et mesure la taille réelle du fichier `.safetensors` produit, à comparer avec la taille calculée du modèle complet en fp32.\n",
+    "\n",
+    "La conséquence pour le déploiement est décisive : un seul modèle de base de 498 Mo chargé en VRAM, plus N adaptateurs de ~1 Mo chacun sur disque, permet de servir N tâches ou N styles distincts en interchangeant l'adaptateur à la volée — au lieu de maintenir N copies de 498 Mo en mémoire. C'est ce qui fait de LoRA le standard industriel pour servir plusieurs spécialisations d'un même grand modèle derrière une seule instance servie."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "id": "cell-c7cfd896",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:47.439580Z",
+     "iopub.status.busy": "2026-09-02T10:41:47.438977Z",
+     "iopub.status.idle": "2026-09-02T10:41:47.766040Z",
+     "shell.execute_reply": "2026-09-02T10:41:47.765344Z"
+    },
+    "papermill": {
+     "duration": 0.334155,
+     "end_time": "2026-09-02T10:41:47.767287",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.433132",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1058,12 +1327,21 @@
     "print(f\"Adaptateur LoRA seul  : {adapter_size_mb:.2f} Mo\")\n",
     "print(f\"Ratio adaptateur/modele : {adapter_size_mb/model_size_mb*100:.2f}%\")\n",
     "print(f\"\\nPour deployer : il suffit du modele de base + adaptateur ({adapter_size_mb:.1f} Mo)\")"
-   ],
-   "id": "cell-c7cfd896"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "065a8f8c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004296,
+     "end_time": "2026-09-02T10:41:47.777938",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.773642",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : 1,18 Mo contre 497,8 Mo\n",
     "\n",
@@ -1074,16 +1352,41 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-fd8f3de4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003704,
+     "end_time": "2026-09-02T10:41:47.785582",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.781878",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Nettoyage memoire GPU"
-   ],
-   "id": "cell-fd8f3de4"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "id": "cell-94c0915a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:47.794247Z",
+     "iopub.status.busy": "2026-09-02T10:41:47.793887Z",
+     "iopub.status.idle": "2026-09-02T10:41:48.082668Z",
+     "shell.execute_reply": "2026-09-02T10:41:48.081715Z"
+    },
+    "papermill": {
+     "duration": 0.295137,
+     "end_time": "2026-09-02T10:41:48.084350",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:47.789213",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1101,12 +1404,21 @@
     "    print(f\"VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} Go\")\n",
     "else:\n",
     "    print(\"Nettoyage termine\")"
-   ],
-   "id": "cell-94c0915a"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5ff27a53",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003756,
+     "end_time": "2026-09-02T10:41:48.092448",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.088692",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du resultat : la memoire rendue\n",
     "\n",
@@ -1115,20 +1427,38 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-f59529da",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003843,
+     "end_time": "2026-09-02T10:41:48.100056",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.096213",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Exercices\n",
     "\n",
     "Appliquez les concepts de ce notebook.\n",
     "\n",
     "Chaque exercice reutilise une cellule du corps du notebook comme point d'appui : l'exercice 1 reprend le tableau de la section 3 (les 294 912 parametres de r=8 ne sont qu'un point de la courbe), l'exercice 2 remplace le corpus de la section 4, l'exercice 3 fait varier le learning rate autour de la perte finale mesuree en section 4. Les stubs s'executent sans erreur : ils affichent un message d'attente et rendent la main."
-   ],
-   "id": "cell-f59529da"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-cc0d52a5e14c4d0e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004211,
+     "end_time": "2026-09-02T10:41:48.109109",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.104898",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Préparation des exercices\n",
     "\n",
@@ -1141,7 +1471,23 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "id": "cell-4102f87c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:48.119375Z",
+     "iopub.status.busy": "2026-09-02T10:41:48.118889Z",
+     "iopub.status.idle": "2026-09-02T10:41:48.122775Z",
+     "shell.execute_reply": "2026-09-02T10:41:48.121974Z"
+    },
+    "papermill": {
+     "duration": 0.010507,
+     "end_time": "2026-09-02T10:41:48.123886",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.113379",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1158,13 +1504,28 @@
     "# Quel rang donne le meilleur ratio performance/taille ?\n",
     "\n",
     "print(\"Exercice a completer : comparez les rangs LoRA r=2, 8, 32\")"
-   ],
-   "id": "cell-4102f87c"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "id": "cell-f42dac6b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:48.133535Z",
+     "iopub.status.busy": "2026-09-02T10:41:48.132994Z",
+     "iopub.status.idle": "2026-09-02T10:41:48.137874Z",
+     "shell.execute_reply": "2026-09-02T10:41:48.137025Z"
+    },
+    "papermill": {
+     "duration": 0.010861,
+     "end_time": "2026-09-02T10:41:48.138966",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.128105",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1181,25 +1542,49 @@
     "# Observez comment le style de generation change.\n",
     "\n",
     "print(\"Exercice a completer : fine-tunez sur un style different\")"
-   ],
-   "id": "cell-f42dac6b"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell-70d4b526",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004462,
+     "end_time": "2026-09-02T10:41:48.148079",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.143617",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Hyperparametres d'entrainement\n",
     "\n",
     "Le *learning rate* est l'hyperparametre le plus sensible du fine-tuning. Un LR trop faible = convergence lente, un LR trop eleve = divergence et degradation du modèle. Testez différentes valeurs pour trouver le point optimal.\n",
     "\n",
     "**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale affichee etait de **5.0106** en **~13 s** sur RTX 3090 -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre."
-   ],
-   "metadata": {},
-   "id": "cell-70d4b526"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "id": "cell-fc5cb509",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T10:41:48.158949Z",
+     "iopub.status.busy": "2026-09-02T10:41:48.158717Z",
+     "iopub.status.idle": "2026-09-02T10:41:48.161984Z",
+     "shell.execute_reply": "2026-09-02T10:41:48.161447Z"
+    },
+    "papermill": {
+     "duration": 0.010584,
+     "end_time": "2026-09-02T10:41:48.163445",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.152861",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1216,12 +1601,21 @@
     "# Que se passe-t-il avec un learning rate trop eleve ?\n",
     "\n",
     "print(\"Exercice a completer : comparez les learning rates\")"
-   ],
-   "id": "cell-fc5cb509"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-ebb412ad",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004797,
+     "end_time": "2026-09-02T10:41:48.172428",
+     "exception": false,
+     "start_time": "2026-09-02T10:41:48.167631",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Resume\n",
     "\n",
@@ -1240,36 +1634,1863 @@
     "**Prochaines étapes** (FT-02) : LoRA sur un modèle plus grand avec quantization 4-bit (QLoRA).\n",
     "\n",
     "**Ce que ce notebook a mesure, pas seulement annonce** : 124 439 808 parametres totaux pour GPT-2 ; 294 912 parametres entrainables en LoRA r=8 (0,24 %, `trainable%: 0.2364` cote PEFT) ; un adaptateur de **1,18 Mo** contre **497,8 Mo** pour le modele complet ; et une generation apres fine-tuning qui reste entierement en francais la ou le modele original laissait affleurer l'anglais. La suite logique est FT-02 : quantizer le modele de base en 4 bits (QLoRA) pour entrainer ces memes adaptateurs sur une fraction de la VRAM."
-   ],
-   "id": "cell-ebb412ad"
+   ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "local",
+   "api_usd_est": 0,
+   "cpu_min": 0,
+   "external_account": "none",
+   "free_alternative": null,
+   "gpu_min": 4,
+   "gpu_required": true,
+   "metadata_written": "2026-07-24",
+   "network": true,
+   "notes": "LoRA sur openai-community/gpt2 (124M params). Modele scolaire volontairement petit :\nfine-tuning rapide (~4 min). VRAM ~4 GB FP16. Cout estime depuis la config modele\n(lecture G.1 firsthand), execution GPU non relancee ce cycle.",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "validator": "manual",
+   "vram_gb": 4,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.13.3"
   },
-  "cost": {
-   "api_usd_est": 0,
-   "api_provider": "local",
-   "cpu_min": 0,
-   "gpu_min": 4,
-   "gpu_required": true,
-   "vram_gb": 4,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "none",
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "MED",
-   "metadata_written": "2026-07-24",
-   "validator": "manual",
-   "notes": "LoRA sur openai-community/gpt2 (124M params). Modele scolaire volontairement petit :\nfine-tuning rapide (~4 min). VRAM ~4 GB FP16. Cout estime depuis la config modele\n(lecture G.1 firsthand), execution GPU non relancee ce cycle."
+  "papermill": {
+   "default_parameters": {},
+   "duration": 48.978158,
+   "end_time": "2026-09-02T10:41:50.877500",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "FT-01-Introduction-FineTuning.ipynb",
+   "output_path": "FT-01-Introduction-FineTuning.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T10:41:01.899342",
+   "version": "2.6.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "07a0c802b3b9480db1672487beec0e1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_970c14bab54741efb3df1ff961ed6c56",
+       "placeholder": "​",
+       "style": "IPY_MODEL_140f915eebf44e4782b3989b00881339",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 148/148 [00:00&lt;00:00, 4768.41it/s]"
+      }
+     },
+     "094cedd13ed645a980b3d2e0ef070a14": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_52879ecf596b4d05a70218ecaeb59335",
+       "max": 148.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_7633a29219c54ed39a66cdbfe9a272a7",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 148.0
+      }
+     },
+     "0b06f5fad10b445bab0351ca15960238": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c24c2a80e77f4e15ba1d3e45e174004c",
+       "max": 148.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_c56cc3ad171d4149acf9b91d113138ba",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 148.0
+      }
+     },
+     "140f915eebf44e4782b3989b00881339": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "17d4e1b8952a473cafb61bb06e882814": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_fb5065b9b4164e50bfbc3b747518aeb2",
+       "placeholder": "​",
+       "style": "IPY_MODEL_c05c24523e3a4361949569b784ec6871",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Loading weights: 100%"
+      }
+     },
+     "1d3ed1a79ffc4cfc8ebae879218b49f3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "1dcafb4dbdd744bdabf65c5ce0475c40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_ed6c8f66eb8c484ba12395009ac9e924",
+       "placeholder": "​",
+       "style": "IPY_MODEL_5640cf22cf9b4ad8875d988e29d26ecc",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 148/148 [00:00&lt;00:00, 3826.90it/s]"
+      }
+     },
+     "1ebb34ab9cc34327a84d4f535af3eeab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_23bf6fd1ba4a4d28808c09402f7e3780",
+       "placeholder": "​",
+       "style": "IPY_MODEL_bdfae182de104973bbc9129806eb371d",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Loading weights: 100%"
+      }
+     },
+     "222f6eac0e7449df98a411385748e102": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "22a24400fa48446ea7ce7ae5643f3576": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "23bf6fd1ba4a4d28808c09402f7e3780": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2aa9a5dd70b4441baddc7871d60756e9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_4062c257aca54b458bdaed7eb0fa36d7",
+       "max": 148.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_9cafc602453a40de9b379e6fbe188d31",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 148.0
+      }
+     },
+     "3fa8d7b374da4ce3ae0e2b2c37878b99": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "405d039579bd40228274347cac79c105": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "4062c257aca54b458bdaed7eb0fa36d7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "48184add8577400680a0e636c322c7d9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_893d5191f7c4443f826b7540a8bb1a75",
+        "IPY_MODEL_094cedd13ed645a980b3d2e0ef070a14",
+        "IPY_MODEL_662c8725affe4f45be541188b34b813c"
+       ],
+       "layout": "IPY_MODEL_1d3ed1a79ffc4cfc8ebae879218b49f3",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "4a630b95b8b34145a40bc5e5b8f584ee": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "52879ecf596b4d05a70218ecaeb59335": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "543e75d5aa3c4d639d418466295aff2b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_1ebb34ab9cc34327a84d4f535af3eeab",
+        "IPY_MODEL_c79d4ca7defc4bacafb22e2d8e7ac2f4",
+        "IPY_MODEL_1dcafb4dbdd744bdabf65c5ce0475c40"
+       ],
+       "layout": "IPY_MODEL_9d00cc75b7d14a0dbea7994d542d562f",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "5630acb12e624f31ab53b5cea5541e8f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_c81a4dbde53a4416a07252ca34edc6dc",
+        "IPY_MODEL_2aa9a5dd70b4441baddc7871d60756e9",
+        "IPY_MODEL_07a0c802b3b9480db1672487beec0e1d"
+       ],
+       "layout": "IPY_MODEL_9776246869a24a8bb90d6d15fcdd3660",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "5640cf22cf9b4ad8875d988e29d26ecc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "65384e37901b4afda575c5d8c6c2f2fe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "662c8725affe4f45be541188b34b813c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_faadc1a7741d4afb9e78654e888f8e35",
+       "placeholder": "​",
+       "style": "IPY_MODEL_eee90ae14c1644d58afc2da9f5ce91f1",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 148/148 [00:00&lt;00:00, 4745.38it/s]"
+      }
+     },
+     "6b15c6bb2fc242029ff0e3bb150c87c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_d1d25d5b9c5c4323b7085efcf58ffbb5",
+        "IPY_MODEL_eaaa53cc04914c20a3c72ad0642cd77a",
+        "IPY_MODEL_e22ab9cfb7b34176a10ce2d453b6327e"
+       ],
+       "layout": "IPY_MODEL_222f6eac0e7449df98a411385748e102",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "6f81eb3e8af748adbb2e1fe4d9cb4d59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "7633a29219c54ed39a66cdbfe9a272a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "82ae469cb0d44c909a1a5d53f98c2f09": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "893d5191f7c4443f826b7540a8bb1a75": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_915b9aea12c24c16ae5b8227120b5161",
+       "placeholder": "​",
+       "style": "IPY_MODEL_e5ea7d9720514546b41373bda46301b6",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Loading weights: 100%"
+      }
+     },
+     "915b9aea12c24c16ae5b8227120b5161": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "970c14bab54741efb3df1ff961ed6c56": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9776246869a24a8bb90d6d15fcdd3660": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9c3a9d0f574743aaa9ea464578e25daa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_17d4e1b8952a473cafb61bb06e882814",
+        "IPY_MODEL_0b06f5fad10b445bab0351ca15960238",
+        "IPY_MODEL_d889ba16ea4246a9b7034cb2e0d022c3"
+       ],
+       "layout": "IPY_MODEL_4a630b95b8b34145a40bc5e5b8f584ee",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "9cafc602453a40de9b379e6fbe188d31": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "9d00cc75b7d14a0dbea7994d542d562f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a9922d3238f0461888cc81afc63ab460": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "b664b6b5320e4fbb810c7c624f6ecde6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "bdfae182de104973bbc9129806eb371d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "c05c24523e3a4361949569b784ec6871": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "c1addb7a72fa459c9e97908ccec5e8ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "c24c2a80e77f4e15ba1d3e45e174004c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c3a91c3a2c1b43caae139127e6a361b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c56cc3ad171d4149acf9b91d113138ba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "c79d4ca7defc4bacafb22e2d8e7ac2f4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c3a91c3a2c1b43caae139127e6a361b9",
+       "max": 148.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_cc1b2841155347f1a053ca84eb7c2432",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 148.0
+      }
+     },
+     "c81a4dbde53a4416a07252ca34edc6dc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_eaaf6b8686dd4bdba33fe85a5930d198",
+       "placeholder": "​",
+       "style": "IPY_MODEL_b664b6b5320e4fbb810c7c624f6ecde6",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Loading weights: 100%"
+      }
+     },
+     "cc1b2841155347f1a053ca84eb7c2432": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "d1d25d5b9c5c4323b7085efcf58ffbb5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_65384e37901b4afda575c5d8c6c2f2fe",
+       "placeholder": "​",
+       "style": "IPY_MODEL_c1addb7a72fa459c9e97908ccec5e8ec",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "d889ba16ea4246a9b7034cb2e0d022c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_a9922d3238f0461888cc81afc63ab460",
+       "placeholder": "​",
+       "style": "IPY_MODEL_6f81eb3e8af748adbb2e1fe4d9cb4d59",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 148/148 [00:00&lt;00:00, 7458.24it/s]"
+      }
+     },
+     "e22ab9cfb7b34176a10ce2d453b6327e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_82ae469cb0d44c909a1a5d53f98c2f09",
+       "placeholder": "​",
+       "style": "IPY_MODEL_405d039579bd40228274347cac79c105",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 7/7 [00:00&lt;00:00, 209.65 examples/s]"
+      }
+     },
+     "e5ea7d9720514546b41373bda46301b6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "eaaa53cc04914c20a3c72ad0642cd77a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_3fa8d7b374da4ce3ae0e2b2c37878b99",
+       "max": 7.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_22a24400fa48446ea7ce7ae5643f3576",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 7.0
+      }
+     },
+     "eaaf6b8686dd4bdba33fe85a5930d198": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ed6c8f66eb8c484ba12395009ac9e924": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "eee90ae14c1644d58afc2da9f5ce91f1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "faadc1a7741d4afb9e78654e888f8e35": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fb5065b9b4164e50bfbc3b747518aeb2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2023:CoursIA -- prev: MED/qc #14282

## Summary

Tranche GenAI/FineTuning de #14200 (Stop & Repair, règle 6 secrets-hygiene) : `FT-01-Introduction-FineTuning.ipynb` portait **4 sorties committées** fuyant le chemin machine (`AppData\Roaming\Python\Python313\site-packages`) — la plus grosse masse restante du relevé après les tranches DecPyMC-11 (po-2027) et Audio ×3 (po-2026).

| Cellule | Warning fautif | Geste |
|---|---|---|
| 11 | peft `fan_in_fan_out ... Conv1D` (layer.py:2504) | `filterwarnings` ciblé par message en tête de cellule |
| 20 | peft `fan_in_fan_out` + torch `GPU imbalance` (data_parallel.py:45) + torch `NCCL` (comm.py:109) | 2 filtres torch ciblés (le filtre peft posé en cell 11 couvre la session) |

Même recette que #14256 (IIT-5, validée) : **la cause est corrigée à la source** (filtre par message, jamais un scrub d'output), puis **re-exécution complète honnête** — aucun output édité à la main.

## Livrable

- 1 fichier : `FT-01-Introduction-FineTuning.ipynb` (+2499/−278).

## Test plan

- [x] Re-exec papermill end-to-end locale (kernel `python3` = C:\Python313, torch 2.8.0+cu126 CUDA, gpt2 en cache HF) : **13/13 cellules code exécutées, 0 erreur**, 50 s
- [x] Scan path-leak post-exec sur TOUTES les sorties + metadata : **0 hit** (`AppData`/`Users`/chemins worktree) — les 4 lignes fautives ont disparu, les stderr restants sont inertes (`[transformers] loss_type=None`, sans chemin)
- [x] Entraînement réel re-tourné : LoRA r=8 sur gpt2, seed 42, fp16 — sortie « Perte finale / Temps » rafraîchie depuis l'exécution honnête
- [x] C.1 : 0 `raise NotImplementedError`/`assert False`/`1/0` (grep = 0)
- [x] H.3 : 0 cellule code à `execution_count` null ou outputs vides
- [x] Surgical : contenu source inchangé hors cells 11/20 (jointure byte-identique vérifiée cellule par cellule contre `origin/main`, accents comptés intacts)

## Effet de bord documenté (pas un second sujet)

La re-exec papermill a normalisé la **forme** du champ `source` : 6 cellules sur 43 étaient en forme chaîne sur main, elles sont désormais en forme liste (contenu byte-identique — vérifié par jointure et comparaison). C'est la direction canonique de #14209 (famille FineTuning non encore normalisée) et un effet mécanique de toute exécution nbformat — documenté ici pour que le ledger #14209 reste exact. Un commentaire sur #14200 et #14209 trace cette normalisation incidentelle.

## Résiduel #14200 (mesuré, non claimé)

- `02-2-FLUX-1-Advanced-Generation.ipynb` (1 sortie, diffusers) : re-exec = modèle FLUX ~23 Go absent du cache HF local → RECOVERABLE hors fenêtre de ce cycle.
- `Lean-1-Setup.ipynb` (2 sorties) : Lean = PARK sur po-2023 (arrêt user).

See #14200
See #14256
