### PR TITLE
fix(check-nits,#14089): _coordinator_emission_informal herite du miroir _lift_participle_after de _block_emitted

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1590,12 +1590,46 @@ def _coordinator_emission_informal(body: str) -> bool:
     # nomme l'injonction levee (« BLOCAGE leve ») reste muet.
     if has_live_lift(normalised):
         return False
+    # #14089 -- chemin different : l'injonction peut etre ANNONCEE puis LEVEE
+    # dans la meme phrase, sans LIFT_MARKER (qui exige la graphie complete
+    # « levee »). Cas fondateur : « HOLD leve -- le remplacement est nomme,
+    # vous pouvez merger. » -- la voie _block_emitted reconnait le motif via
+    # `_lift_participle_after` (leve / levee / lifted post-marker), mais la
+    # voie `_coordinator_emission_informal` n'en herite pas : elle conclut a
+    # une emission et classifie BOT-CONCERN, donc la PR que le commentaire
+    # vient de DEBLOQUER reste BLOQUEE. Meme classe de defaut que celle
+    # corrigee dans #13912 : un chemin qui n'a pas herite de la garde de
+    # son jumeau. On ajoute ici le MEME test post-marker que porte
+    # `_block_emitted` (point B), sur l'INJONCTION structurellement matchee
+    # (toutes les positions), pas seulement sur le head. Si TOUTES les
+    # injonctions sont suivies d'un participe de levee, c'est une levee.
+    if _every_injunction_followed_by_lift(normalised):
+        return False
     # Un [OVERRIDE] pose en tete (arbretage tiers de B.0) EMET une levee,
     # jamais une reserve — garde-fou de l'override, deja documente en
     # `_block_emitted` point A.
     head = normalised[:60].lstrip(" \t*_").upper()
     if head.startswith("[OVERRIDE]"):
         return False
+    return True
+
+
+def _every_injunction_followed_by_lift(normalised: str) -> bool:
+    """#14089 : toute occurrence d'injonction structurelle est-elle suivie
+    d'un participe de levee (`leve` / `levee` / `lifted`) ?
+
+    Renvoie True si le body NE porte aucune injonction (defaut : pas une
+    levee) OU si chaque occurrence matchee par `_COORDINATOR_INJUNCTION_RE`
+    est immediatement suivie d'un participe de levee (miroir de la borne
+    `_lift_participle_after` que porte `_block_emitted` point B).
+    """
+    matches = list(_COORDINATOR_INJUNCTION_RE.finditer(normalised))
+    if not matches:
+        return False
+    for m in matches:
+        end = m.end()
+        if not _lift_participle_after(normalised, end):
+            return False
     return True
 
 

--- a/scripts/tests/test_check_unaddressed_nits_hold.py
+++ b/scripts/tests/test_check_unaddressed_nits_hold.py
@@ -133,3 +133,66 @@ def test_13779_blocage_lane_emet_toujours():
 
 def test_13779_blocage_leve_ne_pose_toujours_rien():
     assert mod._block_emitted("**BLOCAGE leve** — le point est traite, je merge.") is False
+
+
+# #14089 — chemin different : l'injonction structurelle en francais courant
+# (« HOLD leve ») doit aussi etre reconnue comme LEVEE par la voie
+# `_coordinator_emission_informal`, pas seulement par `_block_emitted`.
+# Cas fondateur : `classify("myia-ai-01", "HOLD leve -- le remplacement est
+# nomme, vous pouvez merger.")` rendait `BOT-CONCERN` au lieu de `None`.
+
+
+def test_14089_fondateur_hold_leve_ne_bloque_plus():
+    # Le commentaire du coord qui LEVE le hold ne doit pas lui-meme bloquer
+    # la PR qu'il vient de debloquer.
+    body = "HOLD leve -- le remplacement est nomme, vous pouvez merger."
+    assert mod._coordinator_emission_informal(body) is False
+    assert mod.classify("myia-ai-01", body) is None
+
+
+def test_14089_hold_lifted_anglais_leve_aussi():
+    body = "HOLD lifted -- the coordinator named the replacement grain."
+    assert mod._coordinator_emission_informal(body) is False
+
+
+def test_14089_hold_leve_sans_tiret_double_leve():
+    body = "HOLD leve la condition est resolue."
+    assert mod._coordinator_emission_informal(body) is False
+
+
+def test_14089_hold_leve_dans_phrase_longue_leve():
+    body = "Suite au greenlight recu, le HOLD leve ; vous pouvez merger."
+    assert mod._coordinator_emission_informal(body) is False
+
+
+# Contre-contrôles obligatoires (acceptance #14089 point 2) : le correctif
+# desserre un predicat, il doit prouver qu'il n'eteint rien. Les formes
+# ci-dessous CONTINUENT de rendre une emission (BOT-CONCERN).
+
+
+def test_14009_hold_simple_reste_bot_concern():
+    body = "HOLD coordinateur -- budget G-VAR-2 atteint."
+    assert mod._coordinator_emission_informal(body) is True
+
+
+def test_14089_hold_lane_strict_reste_bot_concern():
+    body = "HOLD lane myia-po-2024:CoursIA-2 -- scope non tenu."
+    assert mod._coordinator_emission_informal(body) is True
+
+
+def test_14089_ne_pas_merger_reste_bot_concern():
+    body = "Ne pas merger sur les verts tant que le preflight n'est pas vert."
+    assert mod._coordinator_emission_informal(body) is True
+
+
+def test_14089_hold_sans_participe_reste_bot_concern():
+    # Le mot `leve` peut apparaitre dans la phrase SANS etre le participe
+    # du HOLD. Le predicat post-marker doit alors classer l'injonction.
+    body = "HOLD user -- l'override leve un autre point que celui-ci."
+    assert mod._coordinator_emission_informal(body) is True
+
+
+def test_14089_contre_controle_blocage_leve_reste_muet():
+    # Le pendant `_block_emitted` -- miroir exact de la borne.
+    body = "**BLOCAGE leve** -- le point est clos, je merge."
+    assert mod._block_emitted(body) is False


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #14279

Closes #14089

## Summary

Le gate B.0 (`scripts/check_unaddressed_nits.py`) classifie `BOT-CONCERN` un commentaire du coordinateur qui **lève** un hold — donc il **bloque la PR que ce commentaire vient de débloquer**. La voie `_coordinator_emission_informal` (chemin informel) ne reconnaît pas le motif « BLOCAGE/HOLD + participe de levée » que la voie `_block_emitted` (chemin formel) reconnaît déjà via `_lift_participle_after` (leve / levee / lifted post-marker).

**Mesure (avant le fix)** : sur `origin/main`, `classify("myia-ai-01", "HOLD leve -- le remplacement est nomme, vous pouvez merger.")` rendait `BOT-CONCERN`. Le commentaire du coord qui ARBITRAIT la levée bloquait lui-même la PR — exactement la classe de défaut que B.0 existe pour empêcher (Tell c.589-L1, c.589-L1 ★★★★).

**Fix narrow** : ajouter à `_coordinator_emission_informal` le même test post-marker que porte `_block_emitted` point B. Si TOUTES les injonctions structurelles du body sont suivies d'un participe de levée, c'est une levée — pas une émission.

## Cause — l'asymétrie de deux chemins frères

Deux fonctions traitent la levée, et une seule connaît le participe :

| Chemin | Fonction de levée | Connaît `HOLD leve` ? |
|---|---|---|
| `_block_emitted` | `_lift_participle_after` (leve / levee / lifted) | **oui** |
| `_coordinator_emission_informal` | `has_live_lift` (`LIFT_MARKER`) | **non** |

Donc `_block_emitted` rend bien `False` — le corps n'émet pas de blocage — mais l'exécution retombe ensuite sur `_coordinator_emission_informal`, qui ne reconnaît pas cette forme de levée et conclut à une émission informelle. **Même classe de défaut que celle corrigée dans #13912** : un chemin qui n'a pas hérité de la garde de son jumeau.

## Pourquoi ne pas élargir `has_live_lift`

`has_live_lift` est un marqueur de levée à portée générale, employé ailleurs. Le point 5 de `verify-before-claiming` s'applique : **élargir une neutralisation ouvre le sens dangereux, le faux négatif** (une réserve vivante rendue muette). La voie étroite est d'ajouter au chemin informel le **même** test de participe que porte `_block_emitted` — pas de rendre `has_live_lift` plus permissif.

## Acceptance

1. `classify("myia-ai-01", "HOLD leve -- le remplacement est nomme, vous pouvez merger.")` rend `None` ✓
2. **Contre-contrôles obligatoires** (acceptance #14089 point 2) — le correctif desserre un prédicat, il doit prouver qu'il n'éteint rien :
   - `HOLD coordinateur -- budget G-VAR-2 atteint.` (sans levée) → `_coordinator_emission_informal = True` ✓
   - `[BLOCAGE] lane myia-po-2023 -- scope non tenu.` → `_block_emitted = True` ✓ (déjà couvert par test #13779)
   - `HOLD lane myia-po-2024:CoursIA-2 -- scope non tenu.` (sans levée) → True ✓
   - `Ne pas merger sur les verts` (injonction nue) → True ✓
   - `HOLD user -- l'override leve un autre point que celui-ci.` (le mot `leve` n'est pas le participe du HOLD) → True ✓
3. La garde de casse et de position de #13784 reste intacte : `hold on, je regarde` ne pose rien (test #13779_frontiere_de_mot_holder_ne_pose_rien toujours vert).

## Vérifications

- **Tests** : 9 nouveaux tests dans `scripts/tests/test_check_unaddressed_nits_hold.py` (4 cas fondateurs + 4 contre-contrôles + 1 miroir `_block_emitted`).
- **Régression** : `pytest scripts/tests/test_check_unaddressed_nits*.py` → **347 passed** (338 avant + 9 nouveaux), 0 fail.
- **Scope strict** : 1 fichier de prod (`scripts/check_unaddressed_nits.py`, +34 lignes) + 1 fichier de tests (+63 lignes). Aucune autre ligne touchée.
- **No regression check** : `git diff --stat` = 2 files, 97 insertions, 0 deletions — pas de suppression.

## Hors périmètre

- `has_live_lift` n'est **pas** élargi (voir « Pourquoi ne pas élargir » ci-dessus).
- Les autres chemins de levée (LIFT_MARKER, EXPLICIT_LIFT_MARKERS, `[OVERRIDE]`, `_lift_is_narrated`) ne sont pas touchés.
- Le fix ne touche pas la discrimination `#13912` hold nominal / émission (qui reste sur `_hold_match_is_emission`).

## Référence croisée

- Issue #14089 — bug fondateur
- Issue #13912 — correctif de la classe symétrique (cette PR reste dans le sillon)
- Issue #13784 — introduction de `HOLD_HEAD`
- Issue #13598 — EMISSION informelle d'un LIFT_OVERRIDE_LOGINS (1ʳᵉ instance de la classe)
- PR `fix(check-nits,#13951)` — 4ᵉ instance résolue par ai-01 c.176
- `verify-before-claiming.md` — point 5 (élargir une neutralisation = ouvrir le faux négatif)
- Tell c.589-L1 ★★★★ — B.0 classe de défaut que cette PR ferme
- Tell c.835 amend. — instrument à consommateurs live (ne pas élargir un marqueur, ajouter une borne étroite)
