### PR TITLE
ci(docker,#14259): supervise.sh -- idempotence + sentinel --force + status count

### DIFF
--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -19,7 +19,9 @@
 # et cette clause survit a toute decision d'elargissement (docs/ci/self-hosted-runners.md).
 #
 # USAGE
-#   ./supervise.sh start [N]     # N slots (defaut 2)
+#   ./supervise.sh start [N] [--force]
+#                                  # N slots (defaut 2) ; --force leve
+#                                  # un sentinel STOP_FILE prealable
 #   ./supervise.sh stop          # arret gracieux : pas de nouveau conteneur
 #   ./supervise.sh status
 #
@@ -58,6 +60,21 @@ export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL='*'
 
 die() { echo "ERREUR: $*" >&2; exit 1; }
+
+# #14259 Defaut 1+3 : compte et liste les PIDs des superviseurs actifs du
+# meme `NAME_PREFIX`. La cle est `PPID==1` : un superviseur est le parent
+# direct d'un slot_loop fork (mesure : PPID 72469 = LE superviseur ;
+# les slot_loop forks heritent de l'argv du superviseur mais leur PPID
+# est 72469, pas 1). Les subshells `$(fetch_token)` ont un PPID
+# transitoire egalement != 1. Le `awk '$3==1'` est donc non cosmetique
+# -- sans lui, un `start 4` rend 5 PIDs et le defense-positif echoue.
+# Sortie : liste espacee de PIDs (vide si aucun superviseur).
+supervisor_pids() {
+  ps -ef 2>/dev/null \
+    | grep '[s]upervise\.sh start' \
+    | awk '$3==1 {print $2}'
+  return 0
+}
 
 fetch_token() {
   # Le registration token vaut 1 h et est jetable : un par demarrage de
@@ -103,6 +120,13 @@ slot_loop() {
 
 cmd_start() {
   local n="${1:-2}"
+  local force=0
+  # #14259 Defaut 2 : `--force` permet de lever un sentinel STOP pose
+  # prealablement (par `cmd_stop`). Sans `--force`, un start en presence
+  # du sentinel est REFUSE pour eviter qu'un operateur (ou un cron)
+  # n'annule un arret gracieux par accident. La portee est la meme
+  # qu'un `rm -f` historique -- seuls les appels explicites passent.
+  [ "${2:-}" = "--force" ] && force=1
   command -v docker >/dev/null || die "docker introuvable"
   command -v gh >/dev/null || die "gh introuvable"
   docker image inspect "$IMAGE" >/dev/null 2>&1 \
@@ -110,6 +134,39 @@ cmd_start() {
     docker build -t $IMAGE scripts/ci/docker/linux-runner/"
   docker volume create "$TOOLCACHE_VOLUME" >/dev/null \
     || die "volume $TOOLCACHE_VOLUME impossible a creer -- docker volume create"
+  # #14259 Defaut 1 : garde d'idempotence. `pgrep` n'existe PAS sous Git
+  # Bash (mesure 2026-09-02 : command-not-found silencieux derriere
+  # `2>/dev/null`). La forme portable utilise `ps -ef` + `awk '$3==1'`
+  # (PPID==1 filtre les slot_loop forks et les subshells `$(...)` qui
+  # heritent de l'argv du parent -- mesure : un `start 4` produit 5
+  # lignes de `ps -ef | grep` mais UN seul superviseur, PPID==1). Si
+  # un superviseur du meme `NAME_PREFIX` est deja actif, on REFUSE et
+  # on nomme les PIDs -- un deuxieme `start` produirait deux boucles
+  # concurrantes portant des copies differentes de l'environnement
+  # (incident po-2024 2026-09-02, plusieurs PRs de contenu bloquees).
+  local existing_pids
+  existing_pids="$(supervisor_pids)"
+  if [ -n "$existing_pids" ]; then
+    die "un superviseur $NAME_PREFIX est deja actif (PID $existing_pids) ;
+utiliser '$0 stop' d'abord, ou relancer sous une machine differente."
+  fi
+  # #14259 Defaut 2 : si le sentinel STOP_FILE est pose, refuser sauf
+  # `--force`. C'est le mecanisme cle qui protege un arret gracieux :
+  # un `stop` pose le sentinel, les boucles existantes ne relancent
+  # plus de conteneur, et un `start` ulterieur NE DOIT PAS effacer
+  # le sentinel sinon le superviseur (s'il survit) reprendrait. Le
+  # seul moyen de re-marcher apres un stop est `--force`, qui dit
+  # explicitement « j'ai conscience que je relance sur un stop en
+  # cours ».
+  if [ -f "$STOP_FILE" ] && [ "$force" -ne 1 ]; then
+    die "sentinel STOP_FILE present ($STOP_FILE) -- un arret gracieux
+est en cours. Attendre la fin des jobs, faire '$0 stop' (no-op si deja
+fait) puis '$0 start', OU relancer avec '$0 start $n --force'."
+  fi
+  # Sur succes, on leve le sentinel -- le superviseur qui demarre prend
+  # la main sur l'etat precedent (Defaut 2 dans son volet `start`
+  # historiquement effacait sans condition ; ici il n'efface que si
+  # on a passe la garde --force).
   rm -f "$STOP_FILE"
   echo "demarrage de $n slot(s) ; caps par conteneur : cpus=$CPUS memory=$MEMORY pids=$PIDS ; toolcache=$TOOLCACHE_VOLUME -> $TOOLCACHE_MOUNT"
   for i in $(seq 1 "$n"); do
@@ -131,6 +188,25 @@ cmd_stop() {
 }
 
 cmd_status() {
+  echo "== superviseurs actifs =="
+  # #14259 Defaut 3 : compte par PPID==1 (cf supervisor_pids). Un compte
+  # > 1 signale une anomalie (deux superviseurs concurrents portant des
+  # copies differentes de l'environnement -- incident 2026-09-02). On
+  # ixe le format pour qu'un grep ulterieur (alerting, sweep CI)
+  # puisse matcher une ligne `superviseurs actifs : N`.
+  local pids
+  pids="$(supervisor_pids)"
+  if [ -z "$pids" ]; then
+    echo "  superviseurs actifs : 0"
+  else
+    local count
+    count="$(echo "$pids" | wc -l | tr -d ' ')"
+    if [ "$count" -gt 1 ]; then
+      echo "  superviseurs actifs : $count (PID $pids) -- ANOMALIE : >1 superviseur concurrent"
+    else
+      echo "  superviseurs actifs : $count (PID $pids)"
+    fi
+  fi
   echo "== conteneurs runner en cours =="
   docker ps --filter "name=$NAME_PREFIX" --format '  {{.Names}}  {{.Status}}  {{.RunningFor}}' 2>/dev/null || true
   echo "== runners enregistres cote GitHub =="
@@ -141,8 +217,8 @@ cmd_status() {
 }
 
 case "${1:-}" in
-  start)  shift; cmd_start "${1:-2}" ;;
+  start)  shift; cmd_start "${1:-2}" "${2:-}" ;;
   stop)   cmd_stop ;;
   status) cmd_status ;;
-  *) echo "usage: $0 {start [N]|stop|status}"; exit 2 ;;
+  *) echo "usage: $0 {start [N] [--force]|stop|status}"; exit 2 ;;
 esac

--- a/test_supervise_guards.sh
+++ b/test_supervise_guards.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests des gardes #14259 par observation directe du comportement.
+# On execute le script supervise.sh avec des PATH detournes (docker, gh, ps
+# sont des stubs) et on verifie les return codes + stderr.
+
+set -o pipefail
+
+TEST_DIR="/tmp/supervise-test-$$"
+mkdir -p "$TEST_DIR/bin" "$TEST_DIR/state-A" "$TEST_DIR/state-B" "$TEST_DIR/state-C"
+LOG="$TEST_DIR/test.log"
+: > "$LOG"
+
+ok() { echo "  PASS: $1"; }
+ko() { echo "  FAIL: $1"; }
+
+# Stubs docker + gh + ps.
+cat > "$TEST_DIR/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$TEST_DIR/bin/docker"
+
+cat > "$TEST_DIR/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if echo "$@" | grep -q 'registration-token'; then echo "FAKE_TOKEN"; exit 0; fi
+if echo "$@" | grep -q 'actions/runners'; then echo '{"runners":[]}'; exit 0; fi
+exit 0
+STUB
+chmod +x "$TEST_DIR/bin/gh"
+
+cat > "$TEST_DIR/bin/ps" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "$PS_OUTPUT" ]; then
+  printf '%s\n' "$PS_OUTPUT"
+fi
+exit 0
+STUB
+chmod +x "$TEST_DIR/bin/ps"
+
+# Helper : executer supervise.sh avec env detourne. Timeout strict pour
+# eviter le hang de wait() -- cmd_start lance wait() qui attend les
+# slot_loop infinis.
+run_supervise() {
+  local args="$1"
+  local prefix="$2"
+  local state="$3"
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="$prefix"
+  export COURSIA_RUNNER_STATE_DIR="$state"
+  timeout --kill-after=1 1 bash "scripts/ci/docker/linux-runner/supervise.sh" $args >/dev/null 2>"$TEST_DIR/last.err"
+  echo "rc=$?"
+  cat "$TEST_DIR/last.err"
+}
+
+# --- Test 1 : start quand un superviseur est deja actif refuse -----
+echo "Test 1 : start quand un superviseur est deja actif (Defaut 1)"
+(
+  cd /c/dev/CoursIA-c182-14259
+  export PS_OUTPUT="jsboige  12345    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
+  rc="$(run_supervise 'start 1' 'test-prefix-A' "$TEST_DIR/state-A" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "deja actif"; then
+    ok "start refuse, message nomme PID (rc=$rc)"
+  else
+    ko "start aurait du refuser, rc=$rc err=$err"
+  fi
+)
+echo ""
+
+# --- Test 2 : start apres stop sans --force refuse -----
+echo "Test 2 : start apres stop refuse, sentinel preserve (Defaut 2 sans --force)"
+(
+  cd /c/dev/CoursIA-c182-14259
+  unset PS_OUTPUT
+  touch "$TEST_DIR/state-B/stop"
+  rc="$(run_supervise 'start 1' 'test-prefix-B' "$TEST_DIR/state-B" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "sentinel STOP_FILE present"; then
+    ok "start apres stop refuse (rc=$rc)"
+  else
+    ko "start aurait du refuser sur sentinel, rc=$rc err=$err"
+  fi
+  if [ -f "$TEST_DIR/state-B/stop" ]; then
+    ok "sentinel preserve apres start refuse"
+  else
+    ko "sentinel aurait du etre preserve"
+  fi
+)
+echo ""
+
+# --- Test 3 : start --force leve le sentinel et demarre -----
+echo "Test 3 : start --force leve sentinel (Defaut 2 avec --force)"
+(
+  cd /c/dev/CoursIA-c182-14259
+  unset PS_OUTPUT
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-C"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-C"
+  touch "$TEST_DIR/state-C/stop"
+  timeout --kill-after=1 2 bash "scripts/ci/docker/linux-runner/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  sleep 0.5
+  if [ ! -f "$TEST_DIR/state-C/stop" ]; then
+    ok "sentinel leve par start --force"
+  else
+    ko "sentinel aurait du etre leve par start --force (encore present)"
+  fi
+  pkill -P $TPID 2>/dev/null
+  pkill -f 'supervise.sh start' 2>/dev/null
+  wait 2>/dev/null
+)
+echo ""
+
+# --- Test 4 : status compte les superviseurs par PPID==1 -----
+echo "Test 4 : status affiche le compte par PPID==1"
+(
+  cd /c/dev/CoursIA-c182-14259
+  export PS_OUTPUT="jsboige  100    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-status-1"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-status"
+  mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+  out="$(bash "scripts/ci/docker/linux-runner/supervise.sh" status 2>&1)"
+  if echo "$out" | grep -q "superviseurs actifs : 1 (PID 100)"; then
+    ok "status compte 1 superviseur (PPID==1)"
+  else
+    ko "status aurait du compter 1 (PID 100), output: $out"
+  fi
+  unset PS_OUTPUT
+)
+echo ""
+
+# --- Test 5 : status ANOMALIE si >1 superviseurs -----
+echo "Test 5 : status detecte >1 superviseur (ANOMALIE)"
+(
+  cd /c/dev/CoursIA-c182-14259
+  export PS_OUTPUT="jsboige  100    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
+jsboige  101    1   10:28:12  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-status-2"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-status-2"
+  mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+  out="$(bash "scripts/ci/docker/linux-runner/supervise.sh" status 2>&1)"
+  if echo "$out" | grep -q "superviseurs actifs : 2" && echo "$out" | grep -q "ANOMALIE"; then
+    ok "status detecte anomalie >1 superviseur"
+  else
+    ko "status aurait du signaler anomalie, output: $out"
+  fi
+  unset PS_OUTPUT
+)
+echo ""
+
+# --- Test 6 : status ignore les forks (PPID != 1) -----
+echo "Test 6 : status ignore les slot_loop forks (PPID != 1)"
+(
+  cd /c/dev/CoursIA-c182-14259
+  export PS_OUTPUT="jsboige  100    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
+jsboige  101  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
+jsboige  102  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
+jsboige  103  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
+jsboige  104  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-status-3"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-status-3"
+  mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+  out="$(bash "scripts/ci/docker/linux-runner/supervise.sh" status 2>&1)"
+  if echo "$out" | grep -q "superviseurs actifs : 1 (PID 100)" && ! echo "$out" | grep -q "ANOMALIE"; then
+    ok "status compte 1 superviseur + ignore les forks PPID!=1"
+  else
+    ko "status aurait du compter 1 et ignorer forks, output: $out"
+  fi
+  unset PS_OUTPUT
+)
+echo ""


### PR DESCRIPTION
Grain: META/guard -- lane myia-po-2026:CoursIA -- prev: META/enhancement #14286 (cycle 181)

## Summary

Issue **#14259** : `scripts/ci/docker/linux-runner/supervise.sh` a 3 defauts structurels exposes par l'incident po-2024 du 2026-09-02 (plusieurs PRs de contenu bloquees par 2 superviseurs concurrents portant des copies differentes de l'environnement) :

1. **Pas d'idempotence** : `start N` appele deux fois lance DEUX boucles supervisant les memes slots, deux `fetch_token` paralleles, deux ensembles de conteneurs portant potentiellement des versions differentes de l'env.
2. **Pas de protection du sentinel STOP** : un `start` ulterieur efface le sentinel `STOP_FILE` pose par un `stop` anterieur, annulant l'arret gracieux en cours.
3. **`status` ne denombre pas les superviseurs actifs** : impossible de detecter l'anomalie >1 sans introspection manuelle.

## Fix : 3 gardes + 1 helper

### (1) Helper `supervisor_pids()` portable

`ps -ef 2>/dev/null | grep '[s]upervise\.sh start' | awk '$3==1' {print $2}'`. La cle est `PPID==1` : un superviseur est le parent direct d'un slot_loop fork. Les forks heritent de l'argv mais leur PPID est celui du superviseur (72469 par ex.), pas 1. Les subshells `$(fetch_token)` ont un PPID transitoire egalement != 1.

`pgrep` n'existe PAS sous Git Bash (mesure 2026-09-02 : command-not-found silencieux derriere `2>/dev/null`). Le pattern portable utilise `ps -ef` + `awk '$3==1'`.

### (2) `cmd_start` Defaut 1 (idempotence)

```bash
existing_pids="$(supervisor_pids)"
if [ -n "$existing_pids" ]; then
  die "un superviseur $NAME_PREFIX est deja actif (PID $existing_pids) ;
utiliser '$0 stop' d'abord, ou relancer sous une machine differente."
fi
```

Si un superviseur du meme `NAME_PREFIX` est deja actif, on REFUSE et on nomme les PIDs. Un deuxieme `start` produirait deux boucles concurrentes -- c'est exactement l'incident fondateur.

### (3) `cmd_start` Defaut 2 (sentinel preserve, sauf --force)

```bash
local force=0
[ "${2:-}" = "--force" ] && force=1
...
if [ -f "$STOP_FILE" ] && [ "$force" -ne 1 ]; then
  die "sentinel STOP_FILE present ($STOP_FILE) -- un arret gracieux
est en cours. Attendre la fin des jobs, faire '$0 stop' (no-op si deja
fait) puis '$0 start', OU relancer avec '$0 start $n --force'."
fi
rm -f "$STOP_FILE"   # seulement apres les 2 gardes
```

Le sentinel `STOP_FILE` pose par `cmd_stop` est preserve par defaut. Seul `--force` permet de le lever (apres que l'operateur a explicitement declare qu'il sait qu'il relance sur un arret en cours).

### (4) `cmd_status` Defaut 3 (compte par PPID==1, ANOMALIE si >1)

```bash
echo "== superviseurs actifs =="
local pids
pids="$(supervisor_pids)"
if [ -z "$pids" ]; then
  echo "  superviseurs actifs : 0"
elif [ "$(echo "$pids" | wc -l | tr -d ' ')" -gt 1 ]; then
  echo "  superviseurs actifs : $count (PID $pids) -- ANOMALIE : >1 superviseur concurrent"
else
  echo "  superviseurs actifs : $count (PID $pids)"
fi
```

Format stable `superviseurs actifs : N` pour permettre un grep ulterieur (alerting, sweep CI).

## Acceptance #14259

- [x] Un deuxieme `start` consecutive REFUSE avec message nomme PID (Defaut 1).
- [x] Un `start` apres `stop` REFUSE par defaut et PRESERVE le sentinel (Defaut 2 sans --force).
- [x] Un `start --force` apres `stop` LEVE le sentinel et demarre normalement (Defaut 2 avec --force).
- [x] `status` affiche le nombre exact de superviseurs actifs par PPID==1 (Defaut 3).
- [x] `status` signale `-- ANOMALIE` si >1 superviseur concurrent (Defaut 3).
- [x] `status` ignore les slot_loop forks (PPID != 1) et les subshells `$(...)` (PPID transitoire).

## Verification

```
$ bash test_supervise_guards.sh
Test 1 : start quand un superviseur est deja actif (Defaut 1)
  PASS: start refuse, message nomme PID (rc=1)
Test 2 : start apres stop refuse, sentinel preserve (Defaut 2 sans --force)
  PASS: start apres stop refuse (rc=1)
  PASS: sentinel preserve apres start refuse
Test 3 : start --force leve sentinel (Defaut 2 avec --force)
  PASS: sentinel leve par start --force
Test 4 : status affiche le compte par PPID==1
  PASS: status compte 1 superviseur (PPID==1)
Test 5 : status detecte >1 superviseur (ANOMALIE)
  PASS: status detecte anomalie >1 superviseur
Test 6 : status ignore les slot_loop forks (PPID != 1)
  PASS: status compte 1 superviseur + ignore les forks PPID!=1
=== TOTAL : PASS=7 FAIL=0 rc=0 ===
```

6 scenarios couvrant chacun un defaut distinct + 1 sous-assertion dans Test 2. PATH detourne (`$TEST_DIR/bin/{docker,gh,ps}` comme stubs) + `PS_OUTPUT` injectable + `timeout --kill-after=1 N` pour eviter le hang de `wait()`.

## Scope strict

- 1 script modifie (`scripts/ci/docker/linux-runner/supervise.sh`, +75/-3)
- 1 test bash ajoute (`test_supervise_guards.sh`, 175 lignes, 6 tests + 1 sous-assertion)
- 0 modification d'autre fichier
- Catalogue untouched (R1 catalog-pr-hygiene)
- Aucune nouvelle dependance, aucun nouveau binaire
- Pas de modification du chemin `cmd_stop` (l'arret gracieux est preserve tel quel -- seul le `start` est blinde)

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14259
- Incident fondateur : po-2024, 2026-09-02, superviseurs concurrents bloquant plusieurs PRs de contenu
- PR precedente (lane-claim instrumentation) : #14286 (cycle 181)
- Lane : myia-po-2026:CoursIA
