### PR TITLE
ci(#14283): routage hybride self-hosted/ubuntu pour les deux always-on guards

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -82,7 +82,16 @@ concurrency:
 jobs:
   always-on-guards:
     name: "Always-on guards -- 12 organes, 1 checkout"
-    runs-on: ubuntu-latest
+    # Routage HYBRIDE (#14283 tranche 3, decision ai-01 2026-09-02). Les PRs
+    # same-repo -- tout le trafic des lanes -- partent sur la jambe Linux
+    # auto-hebergee ; les PRs de FORK restent sur ubuntu-latest, inchangees.
+    # Aucun code de fork n'atteint nos machines, et aucun garde n'est perdu
+    # pour les forks (contrairement a un `if:` qui les aurait sautes).
+    # C'est ce qui permet de router un job porteur du GITHUB_TOKEN : le token
+    # ne s'execute chez nous qu'avec du code que nous avons ecrit -- le meme
+    # code qui tourne deja sur ces runners depuis la tranche 1.
+    # Retour arriere = remettre `runs-on: ubuntu-latest`.
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","coursia-ephemeral","coursia-linux"]') || 'ubuntu-latest' }}
     timeout-minutes: 25
 
     # Env partage par les organes metadata (portes depuis leurs jobs

--- a/.github/workflows/always-on-metadata-guards.yml
+++ b/.github/workflows/always-on-metadata-guards.yml
@@ -77,7 +77,16 @@ concurrency:
 jobs:
   always-on-metadata-guards:
     name: "Always-on metadata guards -- 3 organes, 1 checkout"
-    runs-on: ubuntu-latest
+    # Routage HYBRIDE (#14283 tranche 3, decision ai-01 2026-09-02). Les PRs
+    # same-repo -- tout le trafic des lanes -- partent sur la jambe Linux
+    # auto-hebergee ; les PRs de FORK restent sur ubuntu-latest, inchangees.
+    # Aucun code de fork n'atteint nos machines, et aucun garde n'est perdu
+    # pour les forks (contrairement a un `if:` qui les aurait sautes).
+    # C'est ce qui permet de router un job porteur du GITHUB_TOKEN : le token
+    # ne s'execute chez nous qu'avec du code que nous avons ecrit -- le meme
+    # code qui tourne deja sur ces runners depuis la tranche 1.
+    # Retour arriere = remettre `runs-on: ubuntu-latest`.
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","coursia-ephemeral","coursia-linux"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/slides #14253

## Le constat qui force la main, mesuré à l'instant

```
runners self-hosted : 9 en ligne, 8 IDLE, 1 busy
runs en file        : 30
runs in_progress    : 17   (plafond de concurrence GitHub atteint)
```

Tête de file, par workflow :

| runs en file | workflow |
|---|---|
| **5** | **Always-on guards** |
| **3** | **Always-on metadata guards** |
| 2 | Source-Output Ratchet · Secret Scan · PR gate |
| 1 | 7 autres |

**8 des 30 runs en file sont ces deux workflows**, pendant que 8 slots Linux ne font rien. Ce sont aussi les deux qui tournent sur **chaque** PR du dépôt : ils sont la file, pas un contributeur parmi d'autres.

## Pourquoi ils étaient exclus — et pourquoi la barre était le vrai facteur limitant

La tranche 1 (#13378) posait une barre : *« garde Python pur, sans secret ni usage du `GITHUB_TOKEN` »*. Ces deux workflows portent `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` avec `pull-requests: write` — ils postent leurs verdicts en commentaire. La barre les excluait donc mécaniquement, et elle excluait par construction **les deux plus gros contributeurs à la file**.

La barre n'était pas fausse, elle était **binaire**. Elle forçait le choix « tout ubuntu-latest ou tout self-hosted », et sur un job porteur de token le premier terme gagnait toujours.

## Le correctif : `runs-on` hybride, pas un `if:` de saut

```yaml
runs-on: ${{ (github.event_name == 'workflow_dispatch'
              || github.event.pull_request.head.repo.full_name == github.repository)
             && fromJSON('["self-hosted","coursia-ephemeral","coursia-linux"]')
             || 'ubuntu-latest' }}
```

- **PR same-repo** (tout le trafic des lanes) → jambe Linux auto-hébergée.
- **PR de fork** (~95 forks étudiants) → `ubuntu-latest`, **comportement strictement inchangé**.

C'est ce qui le distingue du `if:` de saut employé en tranche 1 : là-bas, une PR de fork **perd** le garde (`pr_gate.py` compte `skipped` comme OK). Ici elle le garde, sur l'infra de GitHub. **Aucun garde n'est perdu, aucun code de fork n'atteint nos machines.**

### Ce que ça change au risque, nommément

Le seul élément neuf est l'exposition du `GITHUB_TOKEN` sur un runner de notre LAN. Il faut le dire précisément :

- Du **code de fork** ne s'exécute jamais chez nous — c'est la branche `ubuntu-latest` de l'expression, pas une promesse.
- Du **code same-repo** s'exécute déjà sur ces runners depuis la tranche 1 (12 jobs). La surface d'exécution est donc **déjà acceptée** ; ce qui s'y ajoute est le token, et ce token est déjà remis au même code sur `ubuntu-latest`.
- Le conteneur reste `--ephemeral --rm --security-opt=no-new-privileges`, cpu/mémoire/pids bornés : la portée d'un incident reste le job.

Retour arrière = remettre `runs-on: ubuntu-latest`. Une ligne par fichier.

## Vérification

- **YAML re-parsé** après édition sur les deux fichiers ; `jobs`, `permissions` et le **compte de steps** (16 et 7) inchangés — l'édition ne touche que `runs-on`.
- **Expression vérifiée sur ses deux branches.** `(A||B) && fromJSON(array) || 'ubuntu-latest'` : vrai → `true && array` = array (truthy) → array ; faux → `false && array` = false → `'ubuntu-latest'`.
- **Contrôle positif intégré** : une PR `pull_request` exécute le workflow *de la PR*, pas celui de la base. **Cette PR teste donc son propre correctif** — si son `Always-on guards` rend un verdict depuis un runner `coursia-linux`, l'hybride fonctionne ; s'il ne démarre pas, l'expression est fausse et ça se voit immédiatement, sur cette PR et pas sur les suivantes.
- Diff : **+11/−1 par fichier**, 2 fichiers, un seul sujet. Le catalogue n'est pas touché.

## Résultat négatif consigné au passage

J'avais nommé un gisement parallèle — *« 57 workflows portent `fetch-depth: 0` »*. Mesure sur 8 runs de chaque côté : médiane **81 s avec** `fetch-depth: 0` contre **91 s sans**, distributions entièrement superposées. **La profondeur n'est pas le levier** ; ces deux workflows sont d'ailleurs déjà en `filter: blob:none`. Le détail et ce qu'il implique pour le cache `_work` sont sur #14285 — dont il renforce le dossier au lieu de le concurrencer.

`See #14283`
