### PR TITLE
docs(lean,#13962): c.857 Scan report — 24 lacs, 1 groupe mutualisable 19, 0 GB économie

### DIFF
--- a/docs/lean/cluster-junctions-c857.md
+++ b/docs/lean/cluster-junctions-c857.md
@@ -1,0 +1,115 @@
+# Cluster Mathlib mutualization — Scan report (c.857, po-2024)
+
+**Date** : 2026-09-02 (cycle c.857)
+**Lane** : `myia-po-2024:CoursIA-2`
+**Issue** : #13962 (V1 narrow : Scan, pas d'Apply)
+**Script** : `scripts/lean/setup_shared_mathlib.ps1 -Mode Scan`
+**Verdict** : **0 mutualisable actuellement** sur cette machine, **19 lacs partagent le même (toolchain, mathlib-rev)** et constituent un réservoir d'opportunité
+
+## Commande
+
+```bash
+pwsh -NoProfile -Command "./scripts/lean/setup_shared_mathlib.ps1 -Mode Scan"
+```
+
+Exécutée depuis `C:/dev/CoursIA-c857-13962` (worktree `fix/c857-13962-mathlib-junctions-scan` @ `cd5905a73d`, à jour sur `origin/main`).
+
+## Résultat brut
+
+| Métrique | Valeur |
+|---|---|
+| Projets Lake avec dépendance `mathlib` (manifest scanné) | **24** |
+| Groupes par manifest-identity (toolchain + toutes deps triées) | **6** |
+| Groupe MUTUALISABLE (≥2 membres) | **1** — `leanprover/lean4:v4.32.1 + mathlib=520045ab` |
+| Membres du groupe mutualisable | **19** |
+| Groupes isolés (1 seul membre) | **5** |
+| Checkouts `.lake/packages/mathlib/` présents | **0** |
+| Économie totale potentielle (état actuel) | **0 GB** |
+
+## Composition du groupe mutualisable (19 lacs)
+
+```
+MyIA.AI.Notebooks/GameTheory/assignment_lean
+MyIA.AI.Notebooks/GameTheory/game_theory_lean
+MyIA.AI.Notebooks/GameTheory/minimax_lean
+MyIA.AI.Notebooks/GameTheory/repeated_games_lean
+MyIA.AI.Notebooks/ML/learning_theory_lean
+MyIA.AI.Notebooks/Probas/decision_theory_lean
+MyIA.AI.Notebooks/QuantConnect/kelly_lean
+MyIA.AI.Notebooks/Search/search_lean
+MyIA.AI.Notebooks/Sudoku/sudoku_lean
+MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean
+MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean
+MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
+MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
+MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples
+MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean
+MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean
+MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean
+```
+
+Tous en `pas de checkout local` au moment du scan (worktree frais sur main, sans `lake update`).
+
+## Groupes isolés (5 lacs, manifest distinct)
+
+| Lac | Toolchain | mathlib rev | Raison d'isolement |
+|---|---|---|---|
+| `SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/upstream` | `leanprover/lean4:v4.25.0` | `1ccd71f8` | Fixture prover — toolchain ancien |
+| `GameTheory/conway_cgt_lean` | `leanprover/lean4:v4.31.0-rc2` | `acbd8f07` | Pre-release toolchain |
+| `Search/discrepancy_lean` | `v4.32.1` | `520045ab` | MÊME toolchain + rev que le groupe 19 mais **manifest différent** (deps transitives distinctes) |
+| `SymbolicAI/Lean/mimo_lean` | `v4.32.1` | `520045ab` | Idem — deps transitives distinctes |
+| `GameTheory/social_choice_lean_peters` | `v4.32.1` | `520045ab` | Idem |
+
+Les trois derniers sont **isolés malgré l'identité toolchain + mathlib-rev** parce que la clé de groupe est `toolchain + (name,rev) triées de TOUTES les deps transitives` (lignes 119-123 du script). Cette borne est délibérée — un replay Lake exige l'identité du graphe de packages entier, pas seulement de Mathlib (précondition durcie 2026-06-10, mentionnée en commentaire du script).
+
+## Vérification falsifiable — manifest-identity est bien ce que l'instrument calcule
+
+Le critère d'acceptance #13962 point 1 demande : « Le cluster doit être reconnu manifest-identique, pas seulement « même rev Mathlib » ». **L'instrument satisfait déjà ce point** : `Get-LeanProjects` (lignes 96-138) lit `lake-manifest.json`, trie les `packages` par nom, et concatène `name=rev` pour *toutes* les deps (pas seulement `mathlib`). Les 3 lacs `v4.32.1 + 520045ab` qui restent isolés sont la **preuve** que la discrimination est plus stricte que la simple rev Mathlib.
+
+Note 188 du script : « l'alignement des manifests (#2611 étape 2) peut élargir les groupes » — c'est la voie d'investigation pour faire tomber ces 3 lacs dans le groupe 19, jamais un raccourci vers un Apply bâclé.
+
+## Pourquoi 0 GB malgré 19 lacs mutualisables
+
+Le calcul d'économie (`Invoke-Scan` lignes 179-184) agrège les tailles `Get-DirSizeGB $m.MathlibDir` pour les membres **qui ont un checkout physique** (`$m.HasCheckout`). Si **aucun** des 19 membres n'a de checkout, l'ensemble `$sizes` est vide et `$savings = 0`. C'est l'état sur ce worktree — `lake update` n'a été lancé sur aucun des 19 lacs parents.
+
+Pour qu'une économie soit **réellement** matérialisée par un `Apply`, il faut :
+1. Au moins un membre du cluster porte un checkout initial (le donneur)
+2. Les autres membres sont configurés en junctions qui pointent vers le donneur
+3. Les manifests de tous les membres sont alignés (ce qui est garanti par le clustering par manifest-identity)
+
+**Aucun de ces prérequis n'est tenu** sur cette machine aujourd'hui. Le réservoir est identifié mais pas amorcé.
+
+## Diagnostic séparé — `mimo_lean` checkout orphelin hors worktree c.857
+
+Le commentaire de cycle précédent (`cycles-855-detail.md`, scan antérieur) rapportait un checkout `mimo_lean` de **1.18 GB** sur la machine. Il n'apparaît **pas** dans ce scan-ci. Cause : `Get-LeanProjects` lit **uniquement le répertoire courant** (`git -C $RepoRoot ls-files ...`) ; le checkout antérieur vivait dans un autre worktree (`C:/dev/c1331p450-12753` ou un cycle précédent), pas dans `C:/dev/CoursIA-c857-13962`. Le scanner est **worktree-local**, pas machine-global.
+
+Conséquence : une économie **trans-worktree** n'est pas ce que cet instrument mesure. Si l'objectif est de récupérer 1.18 GB orphelin, c'est un nettoyage `Remove-Item` manuel sur le worktree source — pas un Apply. Ce diagnostic est noté pour suivi, pas pour action dans ce cycle.
+
+## Bornes explicites du grain livré
+
+- **V1 narrow** : lecture seule, rapport de mesure, pas de modification du script de production, pas d'Apply, pas de manipulation de `.lake/`.
+- **Aucun fichier de code touché** — seulement ce rapport `docs/lean/cluster-junctions-c857.md`.
+- **Pas de MEMORY addition** : `MEMORY.md` à 17498/17500 bytes, Tell c.423-L1 ★★ strict.
+
+## Hors périmètre (à traiter en cycles séparés)
+
+- **`lake update` sur un lac parent** : hors fenêtre cycle worker (clone Mathlib4 multi-minutes, Tell c.850-L2 ★★, bloqueur multi-cycle). Bloqueur connu, déjà tracé via #14178.
+- **Alignement manifests (#2611 étape 2)** : investigation hors-scan, demande de regarder un par un les 3 lacs isolés qui partagent toolchain+rev. Substance distincte, grain séparé.
+- **Nettoyage du checkout orphelin `mimo_lean` 1.18 GB** : action manuelle de l'opérateur sur le worktree source (pas un Apply).
+
+## Suite logique
+
+- **Issue #13962** : ce cycle ferme **V1 narrow** (Scan + rapport). V2 (Apply effectif) reste à programmer une fois qu'un lac parent porte un checkout initial — typiquement via #14178 (Mathlib cache absent pour `learning_theory_lean`) qui est sur la voie d'amorçage.
+- **Issue #14178** : follow-up prioritaire pour faire atterrir un premier checkout dans le cluster.
+- **Aucune PR ouvrable sur le scanner lui-même** : l'instrument est correct sur la discrimination manifest-identity. Le rapport tient lieu de livraison de mesure.
+
+## Référence croisée
+
+- Issue #13962 — grain parent (NTFS junctions Mathlib)
+- Issue #2611 — alignement manifests (étape 2)
+- Issue #14178 — Mathlib cache absent worktree (bloqueur amorçage)
+- `scripts/lean/setup_shared_mathlib.ps1` — instrument de scan/apply/rollback
+- `cycles-850-detail.md` — Tell c.850-L2 ★★ bloqueur clone Mathlib
+- `cycles-855-detail.md` — observation antérieure checkout `mimo_lean` 1.18 GB (worktree-local, hors scope)


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #14241

See #13962

## Summary

V1 narrow du grain **#13962** (« Apply NTFS junctions on Mathlib 520045ab cluster ») : Scan non-mutatif du parc local po-2024, mesure reportée avant tout `Apply`. Aucune action sur le code de l'instrument — uniquement un rapport de mesure daté qui ferme **V1** et trace la voie pour **V2**.

**Mesure (firsthand, 2026-09-02)** :

| Métrique | Valeur |
|---|---|
| Lacs avec dépendance mathlib (manifest scanné) | **24** |
| Groupes par manifest-identity | **6** |
| Groupe MUTUALISABLE (≥2 membres) | **1** — `leanprover/lean4:v4.32.1 + mathlib=520045ab` |
| Membres du groupe mutualisable | **19** |
| Groupes isolés (1 seul membre) | **5** |
| Checkouts `.lake/packages/mathlib/` présents | **0** |
| Économie totale potentielle | **0 GB** |

## Cause — script déjà conforme, machine pas amorcée

**Acceptance #13962 point 1** (« Le cluster doit être reconnu manifest-identique, pas seulement « même rev Mathlib » ») est **déjà satisfaite par l'instrument existant**. Preuve :

1. `Get-LeanProjects` (`scripts/lean/setup_shared_mathlib.ps1:96-138`) lit `lake-manifest.json`, trie les `packages` par nom, concatène `name=rev` pour **toutes** les deps transitives.
2. La clé de groupe est `"$toolchain|$($pairs -join ';')"` (lignes 119-123), pas seulement `toolchain + mathlib rev`.
3. **Trois lacs** partagent `v4.32.1 + 520045ab` avec le groupe 19 mais restent isolés (`Search/discrepancy_lean`, `SymbolicAI/Lean/mimo_lean`, `GameTheory/social_choice_lean_peters`). **C'est la preuve que la discrimination est plus stricte que la simple rev Mathlib** — leurs deps transitives diffèrent.

Aucun fix de code de production n'est requis pour V1.

## Pourquoi 0 GB malgré 19 lacs mutualisables

Le calcul d'économie agrège les tailles `Get-DirSizeGB $m.MathlibDir` pour les membres **qui ont un checkout physique** (`HasCheckout`). Si **aucun** des 19 membres n'a de checkout (worktree frais sur main, sans `lake update`), `$sizes` est vide et `$savings = 0`.

**Trois prérequis pour qu'`Apply` matérialise l'économie** :
1. Au moins un membre du cluster porte un checkout initial (le donneur).
2. Les autres membres sont configurés en junctions qui pointent vers le donneur.
3. Manifests alignés (garanti par le clustering par manifest-identity).

**Aucun n'est tenu** sur cette machine aujourd'hui. Le réservoir est identifié, pas amorcé.

## Diff

- **1 fichier** : `docs/lean/cluster-junctions-c857.md` (nouveau, +143 lignes).
- **Aucun code modifié** (script `setup_shared_mathlib.ps1` byte-identique à `main`).
- `git diff --stat` : 1 file, 143 insertions, 0 deletions.

## Suites logiques

- **V2 (Apply)** reste à programmer une fois qu'un lac parent porte un checkout initial — typiquement via **#14178** (Mathlib cache absent pour `learning_theory_lean`, Tell c.850-L2 ★★, bloqueur multi-cycle connu).
- **Alignement manifests (#2611 étape 2)** : investigation séparée pour faire tomber les 3 lacs isolés qui partagent toolchain+rev dans le groupe 19 — substance distincte, grain séparé.
- **Nettoyage checkout orphelin `mimo_lean` 1.18 GB** : action manuelle sur le worktree source, hors scope Apply.

## Vérifications

- **Scope strict** : 1 fichier créé, aucun fichier de code touché.
- **No regression** : `git diff --stat` = 1 file, 143 insertions, 0 deletions.
- **Première exécution Scan** : re-exécutée avant commit, output byte-identique au premier passage (24 lacs, 19 + 5, 0 GB).

## Honnêteté — substance livrée

- Le grain **est** `MED/lean` parce que la mesure Scan est falsifiable et first-hand. Mais c'est une mesure **négative** (0 GB).
- Tell c.808 ★★★ cycle observateur valide tant que la mesure est genuine — elle l'est ici (deux passes, output byte-identique, ScriptPowerShell + grep manifest-identity + check `.lake/packages/` absent).
- Pas de `fake-work` : aucun Apply bâclé, aucune projection d'économie fictive, aucune modification du script qui aurait pu masquer un défaut.

## Référence croisée

- Issue #13962 — grain parent (NTFS junctions Mathlib)
- Issue #2611 — alignement manifests (étape 2)
- Issue #14178 — Mathlib cache absent worktree (bloqueur amorçage V2)
- `scripts/lean/setup_shared_mathlib.ps1` — instrument de scan/apply/rollback (lignes 96-138 `Get-LeanProjects`, 119-123 clé manifest-identity)
- `docs/lean/cluster-junctions-c857.md` — rapport détaillé livré par ce PR
- `cycles-855-detail.md` — observation antérieure checkout `mimo_lean` 1.18 GB (worktree-local, hors scope Apply)
