### PR TITLE
feat(ci-runner,#14294): installer gh CLI dans l'image runner (pin SHA-256)

### DIFF
--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -42,6 +42,17 @@ RUN useradd -m -u 1001 runner \
     && mkdir -p /home/runner/_work /opt/hostedtoolcache \
     && chown -R runner:runner /opt/runner /home/runner /opt/hostedtoolcache
 
+# gh CLI : requis par les guards metadata (check_pr_perimeter POST sa label
+# via gh ; sans gh, les organs sous `2>/dev/null || true` rendent exit 0 SANS
+# poster -- un vert fabrique, cf #14294). Pin SHA-256 comme le tarball runner.
+ARG GH_VERSION=2.99.0
+ARG GH_SHA256=ed4960225d2833e04a61590d9fa2b5773d147f3aa375459e5466a40c102f3832
+ADD https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz /tmp/gh.tar.gz
+RUN echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/gh.tar.gz -C /tmp \
+    && install -m 0755 /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
 USER runner
 WORKDIR /opt/runner
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/tooling #14288

See #14294 (blocage : gh absent de l'image runner) · See #13363 (volet runners).

## Résumé

Les guards metadata (ex. `check_pr_perimeter.py`) doivent **POSTer** leur label via `gh`. Sans `gh` dans l'image runner, les organs lancés sous `2>/dev/null || true` rendent `exit 0` **sans poster rien** — un vert fabriqué : tout semble vert, aucune preuve n'existe. C'est la 2ᵉ occurrence de cette classe (la 1ʳᵉ : `python-is-python3`, déjà dans l'image).

Bloc fourni par ai-01 (DM msg-20260902T111322-y6hwux), inséré **avant `USER runner`** (install root), épinglé SHA-256 comme le tarball runner.

## Changement (1 fichier, +11)

- `scripts/ci/docker/linux-runner/Dockerfile` : `gh 2.99.0` (`ARG GH_VERSION`/`GH_SHA256` + `ADD` + `sha256sum -c` + `install` dans `/usr/local/bin`), commentaire de justification.

Aucun credential dans l'image (testé : `gh auth status` répond "not logged in") — les guards utilisent le `GITHUB_TOKEN` du job, jamais des credentials embarqués.

## Validation locale (exécutée, cette machine)

1. `docker build -t coursia-linux-runner:gh-test scripts/ci/docker/linux-runner/` → **SUCCESS** (le `sha256sum -c` du pin valide le téléchargement).
2. `docker run --rm --user runner --entrypoint /bin/bash <image> -c 'gh --version'` → **`gh version 2.99.0`** sous l'utilisateur runner (la couche est avant `USER runner`, mais /usr/local/bin reste lisible par l'utilisateur non-root).
3. `gh auth status` dans le conteneur → "You are not logged into any GitHub hosts" (aucun secret).
4. Image de test supprimée après validation.
5. Aucun test structurel ne pine le Dockerfile (greppé).

## Ordre de merge recommandé (roll ai-01)

**1. #14288 (volume _work) → 2. cette PR (gh) → 3. PR waiters (#13363).** Les trois branches ont les mêmes fichiers (supervise.sh/Dockerfile) mais des régions disjointes : le rebase des PRs 2-3 sur un main contenant la précédente est contextuel.

## Acceptance post-merge (déploiement)

Le déploiement = rebuild + roulement (la boucle vivante ne relit jamais son fichier). Après roll :
- `docker run --rm --entrypoint /bin/bash <image> -c 'gh --version'` → 2.99.0 ;
- un job d'un guard metadata passe vert **et** lève sa label (pas seulement vert).

Grain : MED/tooling — steering URGENT ai-01 (DM msg-20260902T111322-y6hwux, prime sur le tirage ; dette G-VAR-1 contenu maintenue pour le prochain grain frais).