### PR TITLE
feat(probas,#14049): DoWhy-2 contrefactuel individuel — echelon 3 de Pearl (slice 1/4)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/DoWhy-2-Contrefactuel-Individuel.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/DoWhy-2-Contrefactuel-Individuel.ipynb
@@ -1,0 +1,1073 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "56d95c6b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002534,
+     "end_time": "2026-09-02T11:58:27.859307",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:27.856773",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# DoWhy-2 — Le contrefactuel individuel : quand l'effet moyen cache tout\n",
+    "\n",
+    "**Serie** : Inference causale avec DoWhy (Probas, Python)\n",
+    "**Prerequis** : [DoWhy-1-Estimand-et-Intervention](DoWhy-1-Estimand-et-Intervention.ipynb) \n",
+    "(l'estimand, le do-calcul, l'ATE) et [Do-Calculus-Bridge](Do-Calculus-Bridge.ipynb) (backdoor).\n",
+    "\n",
+    "**Objet** : monter d'un cran sur l'echelle de Pearl. DoWhy-1 repondait a la question\n",
+    "« *le traitement a-t-il un effet moyen ?* » (l'**ATE**). Ce notebook pose la question\n",
+    "d'individu : « *que se serait-il passe pour CET etudiant, sans le traitement ?* » — le\n",
+    "**contrefactuel individuel**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35ed688c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002114,
+     "end_time": "2026-09-02T11:58:27.864514",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:27.862400",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le probleme — un programme dont l'effet moyen vaut zero\n",
+    "\n",
+    "Un projet pilote de **mentorat intensif** (`T`) est teste sur des etudiants ; le\n",
+    "**resultat** (`Y`) est la progression au semestre. Chaque etudiant a un trait\n",
+    "**`V`** (autonomie initiale, entre -1 et +1). Le programme est heterogene :\n",
+    "\n",
+    "| Effet | Valeur | Sens |\n",
+    "|---|---|---|\n",
+    "| **ATE** (effet moyen de `do(T:=1)` vs `do(T:=0)`) | **0** | ne dit rien |\n",
+    "| **CATE** `3.V` (effet selon l'autonomie) | **de -3 a +3** | tout dire, en sens inverse |\n",
+    "\n",
+    "Pour un etudiant a `V = +1`, le mentorat apporte **+3** points ; pour `V = -1`, il\n",
+    "**en coûte 3**. En moyenne, cela fait zero — et pourtant, personne n'est moyen.\n",
+    "L'**ATE** est honnête mais aveugle : il faut descendre a l'echelle de l'individu.\n",
+    "\n",
+    "Ce notebook fait ce que DoWhy-1 ne pouvait pas : utiliser la **structure du SCM\n",
+    "appris** pour rejouer le monde d'un individu sous une autre intervention\n",
+    "(abduction, action, prediction).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f547ef47",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002718,
+     "end_time": "2026-09-02T11:58:27.869523",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:27.866805",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le monde generatif — de l'heterogeneite qui s'annule en moyenne\n",
+    "\n",
+    "Le generateur (verite du monde, invisible du modele) :\n",
+    "\n",
+    "| Variable | Equation | Role |\n",
+    "|---|---|---|\n",
+    "| `V` | `V ~ U(-1, 1)` | modificateur d'effet (racine) |\n",
+    "| `T` | `T = 0.5 + 0.3 V + N(0, 0.2)` | traitement (confondu par `V`) |\n",
+    "| `Y` | `Y = 1 + 3.T.V + 0.5 V + N(0, 0.5)` | resultat (l'interaction `T.V` porte l'heterogeneite) |\n",
+    "\n",
+    "L'effet individuel d'un changement de traitement est `3.T.V` : positif pour `V > 0`,\n",
+    "negatif pour `V < 0`, de moyenne `3.E[T.V] = 0.3` — **petit en moyenne, enorme en\n",
+    "extreme**. Attention, conflit de definition : l'**ATE** canonique\n",
+    "`E[Y(T:=1) - Y(T:=0)] = 3.E[V] = 0`. Les deux chiffres (0.3 et 0) racontent la\n",
+    "meme histoire : la moyenne est minuscule, la dispersion est la vraie information.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "81a4426c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:27.876282Z",
+     "iopub.status.busy": "2026-09-02T11:58:27.875407Z",
+     "iopub.status.idle": "2026-09-02T11:58:31.437503Z",
+     "shell.execute_reply": "2026-09-02T11:58:31.436993Z"
+    },
+    "papermill": {
+     "duration": 3.56644,
+     "end_time": "2026-09-02T11:58:31.438632",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:27.872192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       V      T      Y\n",
+      "0 -0.251  0.319  0.360\n",
+      "1  0.901  0.612  2.770\n",
+      "2  0.464  0.618  2.079\n",
+      "3  0.197  0.352  1.893\n",
+      "4 -0.688  0.183  0.550\n",
+      "Pente naive Y ~ T (confondue) : +3.077\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# --- Acceptance #14049 slice 1/4 : import depuis dowhy_organs (module canonique)\n",
+    "from dowhy_organs import (\n",
+    "    generer_donnees, construire_scm, contrefactuel_individuel, ecarts_contrefactuels, BETA_INTERACTION,\n",
+    ")\n",
+    "\n",
+    "donnees = generer_donnees(n=600, seed=42)\n",
+    "print(donnees.head().round(3))\n",
+    "\n",
+    "# Premier nombre : la regression naive Y ~ T, aveugle au confondant V\n",
+    "pente_naive = float(np.polyfit(donnees[\"T\"], donnees[\"Y\"], 1)[0])\n",
+    "print(f\"Pente naive Y ~ T (confondue) : {pente_naive:+.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fa26862",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002281,
+     "end_time": "2026-09-02T11:58:31.443460",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.441179",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Lecture de la pente naive — le piege de la confusion\n",
+    "\n",
+    "`+3.08` : la regression simple conclurait a un **effet enormement positif**. C'est\n",
+    "le classique biais de confusion : `V` pousse `T` (les autonomes sont plus trays) ET\n",
+    "amplifie `Y` (interaction), la regression simple attribue a `T` ce qui vient du\n",
+    "couple `(T, V)`. DoWhy-1 a deja appele ce mecanisme : identifier avant d'estimer.\n",
+    "\n",
+    "La suite repond a la question : *quoi estimer pour ne pas etre piege, et qui\n",
+    "decrit-on quand on repond ?*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b476d7a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:31.448661Z",
+     "iopub.status.busy": "2026-09-02T11:58:31.448661Z",
+     "iopub.status.idle": "2026-09-02T11:58:31.454892Z",
+     "shell.execute_reply": "2026-09-02T11:58:31.454892Z"
+    },
+    "papermill": {
+     "duration": 0.010726,
+     "end_time": "2026-09-02T11:58:31.456588",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.445862",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OLS bien specific : T = +0.111 | V = +0.481 | T x V = +2.959\n",
+      "Observez T x V ~ 3 : la regression retrouve l'interaction SI on lui donne la forme.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specification qui CONNAIT la forme : Y ~ 1 + T + V + T.V (rung 1, bien posee)\n",
+    "X = np.column_stack([np.ones(len(donnees)), donnees[\"T\"], donnees[\"V\"], donnees[\"T\"] * donnees[\"V\"]])\n",
+    "beta = np.linalg.lstsq(X, donnees[\"Y\"].values, rcond=None)[0]\n",
+    "a, b_t, b_v, b_tv = beta\n",
+    "print(f\"OLS bien specific : T = {b_t:+.3f} | V = {b_v:+.3f} | T x V = {b_tv:+.3f}\")\n",
+    "print(f\"Observez T x V ~ {BETA_INTERACTION:.0f} : la regression retrouve l'interaction SI on lui donne la forme.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cbca8ca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002294,
+     "end_time": "2026-09-02T11:58:31.461285",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.458991",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Pourquoi cela ne suffit pas — connaitre la forme, c'est la tricher un peu\n",
+    "\n",
+    "L'estimation precedente est « reussie » parce que le monde est **exactement** de la\n",
+    "forme `T + V + T.V`. Sur un vrai terrain, on ne connait pas la forme : on la devine,\n",
+    "on la teste, on se trompe. Le SCM, lui, **apprend la mecanique** a partir du graphe\n",
+    "et d'une famille de mecanismes, puis l'utilise pour **rejouer** le monde d'un\n",
+    "individu sous une autre intervention.\n",
+    "\n",
+    "| Rung (Pearl) | Question | DoWhy-1 | DoWhy-2 |\n",
+    "|---|---|---|---|\n",
+    "| Rung 1 — observation | Que s'est-il passe (avec le traitement) ? | l'estimand | la pente naive + OLS |\n",
+    "| Rung 2 — intervention | Que se passerait-il si TOUS etaient traites ? | l'ATE, backdoor | l'ATE, decomposition |\n",
+    "| Rung 3 — contrefactuel | Que se serait-il passe pour CET individu SANS traitement ? | — | **ce notebook** |\n",
+    "\n",
+    "La mecanique de la rung 3, appliquee par le GCM :\n",
+    "\n",
+    "1. **Abduction** : a partir des observations de l'individu, retrouver son bruit individuel \n",
+    "2. **Action** : forcer le traitement a la valeur contre-factuelle (`T := 0`) ;\n",
+    "3. **Prediction** : re-simuler `Y` avec CE bruit, sous l'intervention.\n",
+    "\n",
+    "Condition technique : les mecanismes doivent etre **inversibles** (le bruit se\n",
+    "deduit de l'observation) — d'ou les `AdditiveNoiseModel` du module `dowhy_organs`,\n",
+    "assortis d'un **`InvertibleStructuralCausalModel`**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d0c6c791",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:31.467269Z",
+     "iopub.status.busy": "2026-09-02T11:58:31.466635Z",
+     "iopub.status.idle": "2026-09-02T11:58:31.503027Z",
+     "shell.execute_reply": "2026-09-02T11:58:31.502157Z"
+    },
+    "papermill": {
+     "duration": 0.04032,
+     "end_time": "2026-09-02T11:58:31.503882",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.463562",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal models:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node V:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node T:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node Y:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node Y: 100%|██████████| 3/3 [00:00<00:00, 103.58it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SCM inversible fitte (0.03s) :\n",
+      "  V ~ distribution empirique | T ~ lineaire + bruit | Y ~ polynomial deg 2 + bruit\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "t0 = time.time()\n",
+    "scm = construire_scm(donnees, degre_y=2)\n",
+    "print(f\"SCM inversible fitte ({time.time()-t0:.2f}s) :\")\n",
+    "print('  V ~ distribution empirique | T ~ lineaire + bruit | Y ~ polynomial deg 2 + bruit')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b89ef420",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002658,
+     "end_time": "2026-09-02T11:58:31.510295",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.507637",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Acte 1 — deux etudiants, deux verites opposees\n",
+    "\n",
+    "Parmi les etudiants **traites** (`T > 0.6`), prenons les deux extremes de `V` :\n",
+    "\n",
+    "- **idx 532**, `V = +0.99` : le programme, pour lui, devrait rapporter `3.T.V ~ +3.3` ;\n",
+    "- **idx 168**, `V = -0.92` : le programme, pour lui, devrait COUTER `3.T.V ~ -1.7`.\n",
+    "\n",
+    "L'**ATE** moyen vaut 0 ; ces deux-la ne sont « moyens » ni l'un ni l'autre. Le\n",
+    "contrefactuel du module calcule, pour chacun, `Y` sous `T := 0` (abduction de SON\n",
+    "bruit, intervention seule change)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "88e16aa1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:31.518840Z",
+     "iopub.status.busy": "2026-09-02T11:58:31.518329Z",
+     "iopub.status.idle": "2026-09-02T11:58:31.535540Z",
+     "shell.execute_reply": "2026-09-02T11:58:31.534975Z"
+    },
+    "papermill": {
+     "duration": 0.023978,
+     "end_time": "2026-09-02T11:58:31.536680",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.512702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " index     V   T  Y_obs  Y(T:=0)  ecart  effet vrai 3.T.V\n",
+      "   532  0.99 1.1   4.86     1.51   3.35              3.27\n",
+      "   168 -0.92 0.6  -0.80     0.81  -1.61             -1.66\n"
+     ]
+    }
+   ],
+   "source": [
+    "traites = donnees[donnees['T'] > 0.6]\n",
+    "idx_hi = int(traites['V'].idxmax())\n",
+    "idx_lo = int(traites['V'].idxmin())\n",
+    "\n",
+    "lignes = []\n",
+    "for idx in (idx_hi, idx_lo):\n",
+    "    ligne = donnees.loc[idx]\n",
+    "    cf = contrefactuel_individuel(scm, ligne)\n",
+    "    y0 = float(cf[\"Y\"].iloc[0])\n",
+    "    lignes.append({\n",
+    "        'index': idx, 'V': float(ligne['V']), 'T': float(ligne['T']),\n",
+    "        'Y_obs': float(ligne['Y']), 'Y(T:=0)': y0,\n",
+    "        'ecart': float(ligne['Y']) - y0,\n",
+    "        'effet vrai 3.T.V': BETA_INTERACTION * float(ligne['T']) * float(ligne['V']),\n",
+    "    })\n",
+    "table_etoiles = pd.DataFrame(lignes)\n",
+    "print(table_etoiles.round(2).to_string(index=False))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "742e37eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:31.542034Z",
+     "iopub.status.busy": "2026-09-02T11:58:31.542034Z",
+     "iopub.status.idle": "2026-09-02T11:58:31.813495Z",
+     "shell.execute_reply": "2026-09-02T11:58:31.812381Z"
+    },
+    "papermill": {
+     "duration": 0.275383,
+     "end_time": "2026-09-02T11:58:31.814422",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.539039",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABBAAAAGGCAYAAADCYnIJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAATlpJREFUeJzt3QmcTfX/x/HPMIx9RCJLoqRUVJYUqVDxKykt2vOjRYtKKmmTX0mbSn6pCCmVipJCC60q2oQQssu+ztgGM+f/eH/7n/u7M2bmzIy5c++Y1/PxuDXn3u8553u/zrnnez7nu8R5nucZAAAAAABANopl9yEAAAAAAAABBAAAAAAAkCO0QAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAGRh9OjRNn369Hwpnx9//NE++eSTdO+NGDHCFi1alKvt5GSdzPYVadHIV2pqqtvv1q1bbdOmTfbaa6/Z0qVLs0z/7rvv2tSpU60g7N2716ZMmeKOoV9//XW/z3fv3m3Dhw+3Xbt2FUh+AAAHbt68ee5as2fPngPeVkpKitvW6tWrQ+/9/vvv7lqVGzlZJ7N9HYi85DPSfvnlF/vyyy/d31988YWNGzcuy7Sqr6g8tmzZUiB5W7Zsmb3zzjv24YcfujpLRj/88IN9//33BZIXID8QQACycNddd9mYMWPypXzeeuste/LJJ9O9d9NNN+X6gpGTdTLbV6RFI19Dhgyxl19+2SpWrGiJiYn20EMPZbn9JUuW2JVXXmkLFy60SFMF7aSTTrIePXrY5MmTrV27dnbZZZfZvn37QmlKlSrlKl/PPPNMxPMDAMgfukG98cYbbefOnQe8reTkZLctBSV8CrL37t07V9vJyTqZ7etA5CWfkaR/j06dOoWC8vPnz7fLL7/c/v7770zTP/bYY9a3b1+rUKFCxPM2cOBAa9Cggb3//vs2aNAgq1u3rn399df7pevYsWOBBTSAA0UAAYiSbt262THHHBPxdQpCQedLlYV+/fq5oIHEx8fbNddc427K9XQ/o9dff90SEhJcECErv/32m2vVcKC6d+/uAgR6QqOgyU8//eQCCYMHD06X7sEHH7SnnnrKNm/efMD7BAAUfieffLJdccUVEV/nYPPf//7XKleubOeff75bvvrqq1294I033tgv7fbt2+2DDz6w6667zooXL57nff7xxx+Z1jfCqQXivffea6NGjXL7VOBA9RC9woNQp59+up144on29NNP5zk/QEEigADkgG4s1dxNzdBWrVplH330kXup6Xxmli9f7m4e1YQuqzSnnnqqValSxf393nvv2YwZM/ZLM3v2bHfzm9k6Od2XLlLK+7p169K9rxYDEydODPzuanan9dXkfsKECW5/2X2X3JSBn7/PPvvMXejVjC8n3n77bStWrFiosiD//ve/bdu2bTZ+/Ph0aT3PszfffNMuvvhi11ohuxv/mjVrWs+ePTPtdpAT69evd2V6++23u4CF1KlTxz0ZUfmFa9WqlVWrVs1GjhyZp30BAKLr559/djeG6ram65eulwoaZ0at0NS0XtcjdenLTI0aNVxAQP766y933dC2M9IN6axZs/ZbJzf7mjZtmgtuh9MTfF3v16xZY3mxYMECd33W0/aNGzfu9/mKFStcM36V2cqVK/O0jYzS0tLspZdecnUAn4IJF154oSunjLTdHTt2WJcuXfLUwvDZZ591rQx1w5+UlJRtenWzrFWrlmuF6OvVq5etXbvWJk2alC6t8qOyDwpKADHBA5CpypUre3feeaf7e9euXZ5Ol9atW3tHH32017lzZ+/kk0/2KlWq5P3+++/p1hs+fLhXokQJ76yzzvIuvPBCr0aNGi5tixYt0qUrXry4N3LkSPf3TTfd5J144on75aFt27be+eefn+k6Od3XypUrXd6/++67dNu++eabvTPPPDPwX//ee+/1unXr5l7t27f3Spcu7T3xxBNZfpfclMGUKVO8KlWqeMcee6x3+eWXe9WrV3f72L17d7Z5Uhr9G2TUtGlT77zzzkv33pdffum+/+eff57tNjdv3uy9+uqrrkzi4uK84447zuvfv7+3bNkyL6cmTZrk9jV79ux07w8aNMhtc8eOHene7969u3faaaflePsAgOgZPHiw+43fsmWLW+7du7dXrVo175RTTvHOOecc77LLLvPKli3rde3aNd16St+4cWPv8MMPd2kaNGjgru/a1hdffBFK99hjj3m1a9d2f69atcorVqyYN27cuHTbmjZtmlvv559/3m+d3OxL1/Q2bdqk2/aaNWtcuq+++irbcsi4z5SUFO/KK6/0SpUq5V1wwQVuu+XLl/c++eSTUJrnnnvOK1OmjKvT6HqvutSTTz6Zq21kZsaMGS7P8+fPT/f+xIkT3fs//vhjuvdbtWrlnX766V5OJScne6NGjXJlqH+PevXqeX379vUWLlwYuG6zZs28Tp067ff+IYcc4o6dcGvXrnX5/eyzz3KcNyBaCCAAuQgg6GZPf0taWprXsmVLd4H2rV692lUenn322dB7P/zwg7voZBdAmD59eroKgSxfvtyt98EHH2S6Tk73daABhIy+//57t48FCxYcUL7WrVvnVahQwZXf3r173XsbN270jjjiCG/gwIHZ5iExMdF7+umn93t/yJAhbj+qePmuu+46r1atWl5qamqOv+OKFSu8p556ymvUqJG78VeFY9iwYaFKY1ZGjBjhylqVsHBvvfWWez9jMEKBlvj4+MCACQAg+jILIGh5/PjxoTQKVuu9uXPnht7r2bOnu+HWNU50zdNNcnYBBGnXrl26hwii4ETDhg2zXCen+8rPAILKoWTJkunqMLpGK7jiB84rVqzovfLKK6HP9+3b53366ae52kZmnn/+eVfnUJ0snLavhxKq6/gWL17srum6nmdHZaYHAldddZULeigPqg/+9NNPXm6oPhO+f5+CEF26dNnvfdVVHn744VztA4gGujAAuaAmcurfLnFxcdayZct0A/Opib8CcxpAz3faaafZWWedle121QXg+OOPd83dfGrafuihh9oFF1yQ6Tp53VdeaEAiNTtUc0oNwqTm+Rrx+EDyNXbsWNf8T+MAqK+i3+xQAz0NGzYsy7yo6aG6KlStWnW/z9SvsGTJkq7Zpt/XUV0orr/+etflIafU5PC+++5z4xhobARtR/m6//77A5tS+sdGOH/fGcdYOOyww1xT04zdSwAAhUP16tXdAHjh3dMkvG6grg26hugaJ7rm6RoTpGvXrvbpp5+GuhTo+qcuj3o/K3nd14FQ3UXjMDRp0iT03p133umu8R9//LFb1mDH6qqp67do/IHzzjsvV9vIjAZK1LU043VX27/22mvTjY2kLg2lS5d2AyxmR2X+r3/9y3WvVL7UdfWFF16wpk2b5qpcVCfImC+/TpDZmEv6HtoXEOv+qbUDyJFDDjkk3bJupMP7q6nfvyoTuokNp37wf/75Z2Bw4vHHH7fnnnvObVcXOl38SpQokWn6A9lXTqnvpfruffXVVy5YonEO/Jv9DRs2HFC+NJ6EvmfGqRW1vqZj1IU3s5t+fzaDzAY/0hgHF110kSs73eznta+jAiDqH+r3w1Q5qMJ28803Z7tepUqV3P81TVN4gMOftsn/3Of/24bP0AAAKNz1AvHrBpryUX3ejzzyyP2uiUEUmNB1TWMEadYDXY+0PQ0anJkD2VdeaRwj1Qf88RPClStXzo3lIAp83HPPPe7aqPED2rZta3fccYcdfvjhOd5GZnT9zGowRNWr9JBCYyN17tzZleMll1wSOPtC8+bN7eGHH3bjOKkeprrAVVdd5cZVUAAip3TNz2zaRr2XsT7g1wmoD6AwIIAA5CNdGDMb9Cerm+1wukj16dPHPenXdnQTnd1Thpzuy7+wZox252QaKg10pEGWlBcFBUQXN12EdZN9IPlSpUsBgunTp++XVpUj3bT7FbFweoqhViBZDa6kCoOeami7GoBST4OOOuooy4k5c+a4ioJeeuKj7Wi6SFUa/JYn2WnYsKH7/9y5c61+/fqh97WsARozDuLofwc9dQAAHHwUTNdvf8ZrYE7qBVpXMwqoRaICCHoarqCC37rgQPalukFe6gUZ6dqolwYYzHg979ChQ2iGpmbNmtm3337rWhRoEGdNY6z3Fi1alONt5KbOIboOqwWk6gJKpwcX4S09s6LWn//5z3/cS3kdPXq03Xrrra5lhx5S6N9EAZCgWRwUKNFg2OGUVw24rM8y0md6WAPEOgIIQD46++yz3Sj+miPZ73qgG9EpU6bsN0pyRrqJ1KwCqijoQqcIuOYOPtB9aVu6EVfXgzPPPDNUSdB0QpqPODu6mJUtWzbdDa4i8pmNCp3bfOmmXNMw6qJ8yimnpNuGKhSZBQ98akaY8aLs00VdXRA0zeN3332Xo8qCaJYGPaVQdxJNu6SmlKpE5IYCFfouqqxo5gVRCwh111CFIyONoq1/Yz1hAQAcnNq0aeO6FuiJu9+yLrMZAjKjBwkvvviiC9zrmqbm9fmxryOOOMJdp/VQwG9ZmHFmgJzQPhTUUIuLjK0HNAOTmvCnpKS4rnrap57+t2/f3sqUKeO6NvotJoK2kRUFIfREX7M66Nqf2UMFzbKkhx7aT267ebZo0cK9Bg0a5MpHXSSVVz3MUKvKjC1QwqnVg+pM6grp13P076hgiepA4ZKTk23JkiXu+wCxjgACkI/0BPq2225zN5+6eOtCqYthdtMHZqwoKLqtpwiqMOTHvnRx18XzgQcecE8hdOFS5SKz/ncZKQCg9fR/BTc0FoKaIWb3ND6n+dKYD+pTeM4557imgXpSoKi8ujSoD6Qu1llRXoYOHZrpZ/q+mt+5f//+7sb80ksvtZxQueuJyNFHH20H4pVXXrHWrVu776QnH6o86Ls/+OCD+6VV15DwqSgBAAefAQMGuOC0bu71RF3B4y+//DJH6zZq1MjdfN5yyy3uBlnXzPzYl1o9qnm/bmTbtWvnru+a+jEvdL1WvvT0XPUF1RH00EIPDjSOgOo0Cu4r+K/vovqHHpYoj353i6BtZNbkX04//XR3jdX1VNf+zG7i77rrLvv888/t0UcfzTYYkR19B9UT9FLAQt1JglogqPy1f5WxxnNQMET1HnVVzTj1tVpnqAuDygSIdQQQgCzo4qpWAO5EiY+3bt267deP0L8QhtONvyLcesKvJ/WK/Ktff8Y5j7W9jM3yNGiP+tlrPd2AZ5RxnZzu6/nnn3cVCs1PrYuwbuhVWQia67l27dqu8qHtKr0qL4qk60J/wgknHHC+NNDiueee6wY6VEVB81nrwqq8BgVa+vbt68YpyKy53w033OCeamiu5pw+3ddAi/lBFSR1hdBTCj2dUMsDPQHJmA99prIcM2ZMvuwXABBZCnzreue3kNPT4sxayylNeNe5evXquWupWsSpP7+uTU8//bQLLOu651Mrvcyu/WpRpxZyauGXcWygjOvkdF9qDaCWfLpWqZti48aN3X700EDjEmQn4z7V0lEDK6sLpgZKFNWfdD33r33qyqdrvdLpxlvdA3QznpttZEaBBtUJ9GQ/swCCHmIoqKLvqmtxflDAQt0ZckIPbBRsUH1FeVW9yK9bhtO/g4INWQVKgFgSp6kYop0JAMitXr16ueZ+qmwURgpyqOmoujsAAIC80cOQY4891r755hsXMClsFMDRmAh6qJDdeA9ArGAaRwCF0iOPPOLGZtiyZYsVNurnqaaKeioCAADyTi0mNOBxVmMjxbqZM2e6lhYED1BY0AIBAAAAAABEvwWC+j8rKqgBUTSYiPoCAQCAokljhGisF/Xn1jgoGq8EAAAUDhENIKh/r0Z2HTx4sJvXXaOgavoZzS0PAACKlsmTJ7uBRjUomrohaSDaLl26RDtbAAAgFrowaKoSzfO+YMGCdCO/qv9vdtPAAQCAg4uu/Zqy7corr3Qzw4S/T50AAIDCIaItEDQlSceOHdMFD4SKAgAARYvmmF+3bp3deuut6d6nTgAAQOERH8mNa153zWmquV6/+uorN2L6pZdeapdddlmW66SkpLiXLy0tzTZv3myVK1e2uLi4SGYXAIAiQw0Qk5OTrXr16vvNLR+pOoHmZNfMKaoLbNu2zRo2bGj33HNPlvPOUycAACDG6gRehKSlpXlxcXFeYmKi17NnT2/KlCneiy++6JUtW9YbMGBAluv17dtXXSp4UQYcAxwDHAMcAxwDBXAMrFy50isIjz76qFeqVCnv+OOP98aMGeNNnjzZO++887zq1at7mzZtok7A+c75zjHAMcAxwDFgsV8niOgYCGo10KBBA/vuu+9C7z388MM2fPhwW716dY6eNugJxRFHHGErV650Ty4AAMCBS0pKslq1atnWrVstMTEx4kWqAZXvuOMOmzJlirVp08a9t2PHDjv00ENt0KBBdtNNN+23DnUCAABiq04Q0S4MTZo0sYoVK6Z7T80UlTHFLTLrkpCQkOBeGSl4QAABAID8VVDdA1UnEDWP9JUtW9bKly/vujVkhjoBAACxVSeIaKdHzfP8+eef26JFi9yy+lW88cYb7skD4xkAAFB0NG/e3I15MGTIEPcQQd5//33btGmTtW7dOtrZAwAAORDRFgidOnWyP/74w83zXKdOHVuxYoU1btzYhg4dGsndAgCAGKMHB2PHjnV1AzWTLFeunK1du9Zefvlla9q0abSzBwAAciCiYyCEj2OwdOlS132hatWque6PoX4Y2gZdGAAAyB/RvL4uXLjQUlNTrW7dupl2W8wKdQIAAPJfbq6vEW2B4FNmTjrppILYFQAAiHHHHHNMtLMAAADyIPITPwMAAAAAgEKPAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAIBABBAAAAAAAEAgAggAAAAAACBQvEXQF198YRMnTkz3XunSpW3AgAGR3C0AAIhBvXr1stTU1HTvXXzxxXbmmWdGLU8AACBGWiDMmDHDxo8fb0ceeWTodcQRR0RylwAAIEYNGjTIdu/ena5eUKFChWhnCwAAxEILBKlWrZrdddddkd4NAAAoBC666CJr165dtLMBAABiMYCwbt06e/jhh61UqVLWrFkzO+eccyK9SwAAEKPef/99+/rrr61OnToumFC1atVoZwkAAMTKIIqqGBQrVszWr19vl156qXXq1Mk8z8syfUpKiiUlJaV7AQCAwq98+fKuTlC2bFl755137Nhjj7Vvvvkmy/TUCQAAiC1xXnZ38wdo+fLlVrt27dDy3Llz7ZRTTrGhQ4fa9ddfn+k6jz76qPXr12+/97dt20Y/SQAA8okC9ImJiQV6fc1YL7jmmmvs+++/t6VLl2aanjoBAACxVSeIaAAhM6effro1aNDAXnvttSyfNugV/mVq1apFAAEAgEIeQMjo888/t/POO89WrlxpNWvW3O9z6gQAAMRWnSDiYyBktGfPHtu7d2+WnyckJLgXAAA4uKlOIFnVC6gTAABQhMZAmDJlSrplDZo0c+ZMO/fccyO5WwAAEGNmzZplGzduDC0raPDf//7X6tWr5wZUBAAARTyA8MYbb1jjxo2tW7du1rFjRzdt02233WZXXXVVrrelQRh9GzZscM0rZN++fbZmzZpQt4ft27fb2rVrQ2lVWdm6dav7OzU11aXVHNSyY8cOt+zbtGmTbdmyxf2dlpbmPtu1a5db3rlzp1v2e3xs3rzZvUTv6TOlEa2jZW1DtE1t26fPtG9RXrSsvInyGl7B0nfRdxJ9R6XVdxaVgcoifMaL5OTk0FMdpfWf6qhZSngZ6m9/gEqlUVr/SZC2oW1Fs7z9MvTLW+n88vbLMKflrfz55e2XoV/e+l7h5a3v7Ze3X4Z+eau8wstbZeiXt1+Gfnnr/YzHrF/efhn65a39hZe38uOXt1+Gfnnre4SXd06OWZ/Kz0/rH7MZy5tjlt8IfiOK1m9EQdL3aNWqlasP3HDDDXb88cfbX3/9ZW+//XaB5gMAAORdfKQDCPPnz7cZM2ZYmTJl7LnnnrOjjjoqT9t677337IEHHnB/jx071o488khr3769q3D5gzLqPT3hmDZtmvXu3dul/eijj6xKlSp24YUXusqS0l555ZXW69X5VqXEBqtVarX9ltzIpT2mzF+214u3pbuOtGKWaqdUmGOLdx5pW/ZVtMolNlmd0ivtlySljbOjSy9x6/y1q65ux6xJhVm2dFct27S3sh0Sv9WOKrPMfks60dKsuNUpvcxKxO2zhTuPduucUn6Wrdxd3TbsrWKJ8dusXpmlNiv5eNvrlbDapVZY6WK77c+dx7i0J5WfY2tSqtq6PYdZ+eLJVr/sYpuTfJyleAlWK2GVlY/fbvN2HOvSNiw31zburWSrUw63MsV2WoNyC23u9vq2K6201UhYbYeU2Gp/bG/g0p5Qdr5t3VfBVqXUsFLFdtkJ5RbY/B31bEdqWTu85FqrUnKjzd5+gkt7XNkF7v0Vu2taybgUa1h+vi3YcZQlp5a3qiXXW/WEtTYzuaFLW7/MIktJK2nLdte2+Lh9dlL5P2zRzjq2bV+iHVpio9Uutcp+TT7Jpa1XZrGlesVsya46ofJesrO2bd53iFUqsdnqll5hvyY1NM+K2VGll1qcef9f3mZNKvxuy3bVso17K1vF+K12dJllNjPpBEu1eKtTarmVLLbHFuys59KeXH62/Z1yuK3fU8UqFE+yY8ousVnJDWyvV9Jql1ppZYrvtPk76ru0jcrNcWW9dk9VK1d8ux1b9i+bs/1YS0krZTUT/rbE+GSb+//lfWK5ubYpQ3nP236M7UwrY9UT1ljlEpttzvbjXdrjy/5p2/aVd+WdUGy3nVjuT/tzx9G2PbWcVSu5zpXjrO0nhsp7Z2oZW767lpWI22ONys+zhTvqWlJqBTus5AarkbAmXXnvSStpS3fXtuK2z06u8If9tfNI27qvoh1aYpMd6Y7Zf8pbx6xncfbC43e5mw6dCxdffLE1bNjQVeI/+OAD69Onj5UsWdK1HtINiQY4k2HDhtm//vUva9KkiRsEbcyYMXbPPfe4kdTVskjBia5du7q0I0eOtLPOOstOO+00+/vvv+3NN9+0O++80ypWrOjOzVWrVtnNN9/s0o4ePdqaNm3qbip0gzRixAi75ZZb7LDDDrPp06fbwoUL7fbbb3dptU+Nn9K2bVu3P+VfNyE1atSwX3/91X777Te7++678+034phjjnEDv6qP9kMPPeTSTpw40X3nSy65xN0IKq1ml9GNkPKqbWna2ri4OPvss8/cOtqWAjZKqxunk046yZYsWeLyeP/997sm2l9++aW78bvuuuvcOsOHD3cttTT17YoVK9xo9fpuGsH+22+/dTebCszKqFGjrGXLltaiRQt3c6jlHj16WKVKleyHH36wZcuWuTKVt956yw1kq38fbUNj0XTv3t3NlvPTTz/ZvHnz7I477gj95qoMlA/dgCr/+jfWmDRqSfbzzz9br169XFodO+q/fv7557ubRKW99tprrW7dujZnzhx3jOjYkgkTJri8afo+BReV9oorrrD69eu768WkSZPskUcecWknT57syueyyy5zN9VKq5l8TjzxRFu0aJF9+OGH9uCDD1p8fLz7d9Jx7QeolbZDhw7u+6oM9H3uu+8+K126tH311VfuuOjSpYtLq+OuTZs2duqpp7q++Cqnnj17uj6AKm/dkN94442h61rz5s3tjDPOcO/reFdg/NBDD7Uff/zRFi9ebLfeeqtLqxtjnV+tW7d2N/3K00033WSHH364K7/Zs2fbXXfdFZraUNdHjQegIKzS/vvf/7YjjjjClbfOh3vvvdel1feuVq2a+346bpT26quvtqOPPtr++OMPmzp1auh6+fHHH7vvoXLTOa20l19+uR133HHumC1IOkZ/+eUXV/46VnVuqBz1mwMAAAqHAh9EMa8DOqiyqMqRqOKrCofeV6VSy6qQqqKpyqteqlyJKm2qXOrmRZVLPfE55JBD7LIHP3M3uLpB25VWxqVNKJZiKo09nsZg8KxMsV3uZlg3pcXj9llC3B7bmVbaBRAS4v552pMSntYraalevLuRSyj2v7S66Y6LM0tJ+2dsh9LFdrqb130ubarbr27ydXNXMm6PxcWluRvWf9LuckGNfV4Jd5NdyqUt5W6qlfficWm2Oyyttrk3y7SpttvlyVzQINUr7vIRZ2kuaLE7LcEFPErE7XVlsyuUdrelecVsTyZp4+P2uvT/K8Pd5nlxrgx1w186rAy1TX2/nTkp78zKMFTe5m7Y94TKMLPy9sLKUOVdItMyVH6KZSjDnJb3P2Xol3eaKyd9lubS7nXHzP/Ke7cLluzNsgwPvLwzluF+5R2XYjrZxz17ubuh1c2PzgvdUOmJpG5a/GlXdcOop5WVK1d266qyr5sQ3Tzrpk+f6ya/ePHibj2dh7qBEm23XLly7qUbFt3s6wZd56GemuqpqpZFQQMFF3VjrPf1tFTbKVGihDv3tS/tR3TulipVyuVDN+86t5U//Rboaa5u/v355PPjN0L70s2Z8qEbPlH+VD76XOWj/PtlqP3r+2m7CiD4LWa0X7+8lR99X8r7wMvbL0O/vHVMqpxV3v4xm9Py1r+NjkEd3/4x6x/f+jfV8eYf38qD0un49o9Z//hW3rW+f3zruymv2rZ/zPrHt45Z5cs/vnWM6vjU8e0fs/7xreNVZeMf39qOtqHv55ehf3wrnbbtH9/ZlaG+t8q6MM1yFAsDPwIAcLCJ6VkYYqWy0KHXR/m2LaAw+Xhgx2hnAUAMKIw344UxzwAAHEzX14iOgQAAAAAAAA4OBBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAABiJ4CwdetWGzNmjH3//fcFtUsAABCjpk2b5uoF27Zti3ZWAABADsVbAenWrZt98skn1qFDB2vRokVB7RYAAMSYX375xdq3b2/bt2+3OXPmWGJiYrSzBAAAYqUFwpAhQ2zz5s3Wpk2bgtgdAACIUcnJyXbVVVfZww8/HO2sAACAWAsgzJ492x5//HF78803rVgxhlwAAKAo6969u3Xs2NFat24d7awAAIBY6sKwc+dOu+KKK+yFF16wmjVr5midlJQU9/IlJSVFMIcAAKCgjBgxwubOnWsjR450DxiCUCcAACC2RLRJQI8ePaxp06Z2+eWX53idAQMGuL6Q/qtWrVqRzCIAACgAf/75p/Xu3dvefvttK1myZI7WoU4AAEARCSBodOXRo0dby5Yt3SjLeq1evdpWrVrl/t6xY0em6/Xp08eNyOy/Vq5cGaksAgCAAnL77bdb8+bNXcsD1QM+//xz9/6nn35qM2bMyHQd6gQAABSRLgylSpWyiy++2KZOnRp6b926dW4chPHjx7sBFcuWLbvfegkJCe4FAAAOHk2aNLFly5a5OoBs2bLF/V/1BNUHTj311P3WoU4AAEARCSCooqAnDOEuuOACF1jI+D4AADi4Pfnkk/tN5ahWCM8884ydcMIJUcsXAADIOaZFAAAAAAAA0Z2FIaNWrVrleOAkAABw8KpUqZJ17tzZKlasGO2sAACAWAwg3HfffQW5OwAAEKPq1q1Ll0YAAAoZujAAAAAAAIBABBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAAAAAggAAAAAAODA0QIBAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAIBABBAAAAAAAEAgAggAAAAAACA2Agj79u2zrVu3FsSuAABAjFOdQHUDAABQuEQ0gDBv3jy75JJL7NBDD7XatWvbYYcdZk8//XQkdwkAAGKQAgaDBw+2unXrulfZsmWtbdu2tmDBgmhnDQAAxEIA4fPPP7ebbrrJ1q9fb9u2bbNRo0bZAw88YGPHjo3kbgEAQIxZt26drV692r799lvbvHmzW05ISHAPGgAAQOEQH8mN33XXXemW27dvb9WrV3ctEwAAQNFRo0YNGzBgQGi5YsWKLnhw8803W1pamhUrxrBMAAAU6QCC32Rx7dq1tmPHDtfyYNeuXda5c+dI7xYAAMQgtT7Yvn27LVmyxAYNGmTdu3cneAAAQCER8QDC4sWLrU2bNq4Lg4IJ//3vf61+/fpZpk9JSXEvX1JSUqSzCAAACkifPn1swoQJrntjixYt7KGHHsoyLXUCAABiS8TbCypYsGrVKktOTrZx48bZ7bffbq+//nqW6dW8MTExMfSqVatWpLMIAAAKyKuvvmpr1qyxDRs2WOXKla1Vq1a2Z8+eTNNSJwAAILbEeZ7nFeQOL7/8ctca4bPPPsvx0wYFEbROhQoV8i0fHXp9lG/bAgqTjwd2jHYWAMQAXV8VqM/v62tuaEyk448/3n744Qc77bTTolYnAACgKEvKRZ0gol0YMhsUaePGjS5zWdGIzHoBAICDR1Z1AilTpkym61AnAAAgtkQ0gNC6dWs3OFKjRo3c4IlvvfWWm75p8uTJkdwtAACIMUOHDrVFixbZRRddZNWqVbO5c+da79697cwzz7SGDRtGO3sAACDaAYRhw4bZk08+aY8//riVKFHCNVOcMWOGNW7cOJK7BQAAMebGG2+0ESNGWN++fd3YSJrWUVM46kFDXFxctLMHAACiHUCoV6+eDR8+PJK7AAAAhUDx4sVdEEEvAABQOEV8FgYAAAAAAFD4EUAAAAAAAACBCCAAAAAAAIBABBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAACiG0BYtWqV9erVy5o0aWKNGjWyG264wZYtWxbJXQIAgBiUlpZmY8eOtQ4dOlj9+vXt7LPPtlGjRpnnedHOGgAAiIUAwmWXXWY1a9a0V155xV5//XVbv369tWzZ0jZu3BjJ3QIAgBijesC7775r3bt3twkTJli3bt3stttus6eeeiraWQMAADkUbxE0bdo0K168eGj57bfftooVK9qnn35q11xzTSR3DQAAYsj1119vXbt2DS2rFcKcOXPstddes/vvvz+qeQMAADHQAiE8eCB79+51TRVLlCgRyd0CAIAYk7FO4NcLqBMAAFB4RLQFQkYPPfSQHXLIIXbuuedmmSYlJcW9fElJSQWUOwAAUFCWLFniWh/ce++9WaahTgAAQBGdheGll16yYcOGuW4MCiJkZcCAAZaYmBh61apVq6CyCAAACoDGQrrgggusWbNm1qdPnyzTUScAAKAIBhCGDh1qd999t7333nvZtj4QVSS2bdsWeq1cubIgsggAAArApk2brE2bNnbYYYe5wRTj47NuDEmdAACAItaFQc0Te/ToYe+8845ddNFFgekTEhLcCwAAHFw2b95sbdu2dQMqT5w40cqUKZNteuoEAAAUoRYII0eOdFM0KXjQqVOnSO4KAADEsC1btrjgQYUKFWzSpElWtmzZaGcJAADEUgBBwYO4uDi74447rGbNmqHXc889F8ndAgCAGKNxkGbOnGnz5893UziG1wsAAEDhENEuDIsWLXLTNmakpw8AAKDouOWWW+yqq66KdjYAAECsBhBq1KgRyc0DAIBConz58u4FAAAKrwKbxhEAAAAAABReBBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAggAAAAAACAA0cLBAAAAAAAEIgAAgAAAAAACBQfnAQAYsOS/pdEOwtAVNR9cBwlDwAAoo4WCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAACiH0BYt26dPfHEE3bppZfad999F+ndAQCAGOV5nn3xxRfWpUsX69GjR7SzAwAAYimAMHr0aGvSpIklJSXZuHHjbPny5ZHcHQAAiGEnnHCCPfXUU+7hwuTJk6OdHQAAEEsBhLPOOssWL15sTz75ZCR3AwAACoFPPvnEpkyZYqeeemq0swIAAPIg3iKoZs2akdw8AAAoROrUqRPtLAAAgFgNIORFSkqKe/nU/QEAABQ91AkAAIgtMTcLw4ABAywxMTH0qlWrVrSzBAAAooA6AQAAsSXmAgh9+vSxbdu2hV4rV66MdpYAAEAUUCcAACC2xFwXhoSEBPcCAABFG3UCAABiS8y1QAAAAAAAAEWsBcKcOXOsX79+oeUXX3zRxo8fb23btrXu3btHctcAACDGPPzwwzZ//nybN2+erV271i699FL3/tChQ61SpUrRzh4AAIhmAKFq1ap2xRVXuL/9/wvTOAEAUPS0adPGGjVqtN/7pUuXjkp+AABADAUQDjvssNDTBQAAULSdddZZ0c4CAAA4mAZRBAAAAIAgS/pfQiGhSKr74Lio7ZtBFAEAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAIBABBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIHiLcL27t1rkydPtuXLl1u9evXs3HPPtWLFiFsAAFAU/fXXXzZ16lSLj4+38847z2rWrBntLAEAgByK6J18cnKynX766XbPPffY77//bjfddJO1a9fO9uzZE8ndAgCAGPTGG2/YiSeeaFOmTLHx48db/fr1bdKkSdHOFgAAiIUWCAMGDLB169bZ7NmzrWLFivb3339bgwYNbOjQoXb77bdHctcAACCGbN682W677Tbr37+/3X333e69Xr162Q033OBaKZYoUSLaWQQAANFsgfD+++9b586dXfBAatSoYRdccIG99957kdwtAACIMerOuHv3buvatWvove7du9uaNWvsu+++i2reAABAlAMI6qawePFi1zwx3LHHHmvz58/Pcr2UlBRLSkpK9wIAAIWbrv1Vq1YNPVSQo48+2o2FkFW9gDoBAABFpAvDjh07zPO8dBUF0bLGRsiu20O/fv0s0j4e2DHi+wCQv+o+OI4iBQopXfsz1gni4uKsQoUKWdYLCqpOIB16fVQg+wFiSWGvD1MvAA6iFghlypRx/8/YgmDbtm1WtmzZLNfr06ePS+O/Vq5cGaksAgCAAqJ6QWatChU8yKpeQJ0AAIAi0gIhISHBateu7boxhNOypnPMbj29AADAwUNdGjWwsloo+gEDDZ6o6Z6zqhdQJwAAoAgNotixY0c3kKIGTfJHYP7444/t4osvjuRuAQBAjNE0zuqyMGbMmNB7r7/+uh1yyCF25plnRjVvAAAgBqZxfOihh2zixImuYtC2bVubMGGCa5XAFI4AABQt1apVc2Ma9OjRw37//Xf3cOGNN96wESNGWOnSpaOdPQAAEO0WCFWqVLGZM2eGpmzSfM/ff/99tmMgAACAg1PPnj3tyy+/tMqVK7sHCj/99JNdffXV0c4WAACIhRYIUr58ebv55psjvRsAAFAING/e3L0AAEDhE9EWCAAAAAAA4OBAAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAIBABBAAAEChsn79+tDfGzZssG3btrm/9+3bZ2vWrLGUlBS3vH37dlu7dm0o7caNG23r1q3u79TUVJd29+7dbjk+bp+VLrYzlDahWIqVjPtnO2aelSm204rbPrdUPG6fW9b7Lm1cinulSxv3/2ktfVptU9v2aZ/xobSpLm1cKO0eSyi2OyztLouP2+v+LhZKm+aWS8TtsVIZ0pbINu2uUFr9rfdEaZRW6/yTdq/b1v/S7nb5yiyt8pa+DJX2n+8al6EM9Z3L5LS8MyvDUFpzn8VnW97h5aK0mZdLyUzKMKfl/U8Z+mn9cvHT7s1Q3ruzLO/4fCpvCyrvuP+Vt+d57lzYteuf/er/Wk5L+yf/W7ZssU2bNoXW1Wc7duxwf+v80bLOJ9H5pfPMp/NP56HovFRanaei81bnr2/dunWWnJzs/t6zZ49Lu3fvP2WalJSU7rzX33pPlEZptY5oG9pWfv9G6Dtr2acyUdmIyiq8DHfu3OmWVbayefNm9wovb6WhvPOnvP1j1i9vpfPL2z9mc1reOh7849s/Zv3jW8fRxrDjW8eZf3z7x6x/fOv4DD++dcz6x7d/zPrHt97PeF3zj2//mPWPb+0v/PhWfvzj2y9D//jW9wg/voOO2RzzYty2bdt0JLj/AwCAont99fPcv3//0HtDhgzxJk2a5P7etGmT9+ijj3pLly51y9OmTfOefPLJUNrXXnvN++ijj9zfSUlJLu2CBQvc8owZM7zHHnsslHbUqFHe2LFj3d+7d+92af/44w+3PHPmTLecmprqlt9++233Er2nz5RGtI6WtQ3RNrVtn/apfYvyorTKmyivyrNP30XfSfQdlVbfWVQGKgvfwIEDva+++sr9vWrVKpd27dq1bvmLL77wBg0aFEo7ePBg77PPPnN/r1u3zqVdsWKFW/7mm2+8Z599NpT2lVde8T755BP395YtW1zaxYsXu+UffvjBe+KJJ0Jphw8f7n344Yfu7+3bt7u0f/75p1v++eefvX79+oXSvvnmm957773n/k5JSXFpZ8+e7ZZnzZrllvfu3euWx4wZ47311luhdfXZr7/+6v6eN2+eW965c6dbHjdunDdy5MhQWh0706dPd38vWrTIpfXPgQkTJnhDhw4NpX366ae9b7/91v29fPlyl3bDhg1u+dNPP/VeeumlUNrnn3/emzp1qvt79erVLq3+L3pfn/u0ntYXbU9ptX3R/rRfn/KjfInyqbTKt+h7hJ8L+p76vqLvr7QqD1H5aNmn8lM5ispVn6mcReWuZf07iP5d9O/j07+b/v1E/55Kq39f0b+3/t19Oh50XIiOE6XVcSM6jnQ8+XSc6XgTHX9Kq+NRdHzqOPXp+NVxLDqulVbHuei41/Hv4zeC3wh+I4J/I3Tu5bROQAABAIAiqDAHEPwbKFm/fr23devW0I2Qbtr8m/Xk5GRvzZo1obS6WfNvXvbt2+fS7tq1yy3rBsi/4ZONGzd6mzdvDgUF9Jl/U7pjxw63nJaW5pZ1E+/fyOs9faY0onW07AcbtE1t26fP/Jsv5UXLypsor/4Nq+i76DuJvqPS+jfVKgOVhU83VX4gQjeCSrtnz55QOfo3ZqK//eNAaZTWv3nUNvzAQ7TK2y9Dv7yVzi9vvwxzWt7Kn1/efhn65a3vFV7e+t5+eftl6Je3yiu8vFWGfnn7ZeiXt94PL2+t55e3X4Z+eWt/4eWt/Pjl7ZehX976HuHlnZNj1qfy89P6x2zG8uaY5TeC34ii8xuxZs2aHNcJ4vQfizA1l5g/f77Vr1/fqlSpkqt11XwjMTHRNc2oUKFCxPIIAEBREs3r6++//+6aWjZu3DhX61EnAAAg/+Xm+hrRMRAWLFhg119/vZ144ol2xhln2GeffRbJ3QEAgBj20ksv2fHHH29nn322de7cOdrZAQAAuRTRAIJaHaiSsHjx4kjuBgAAFAJLliyxd9991+68885oZwUAAORBvEXQRRddFMnNAwCAQmTgwIHu/2PHjo12VgAAQKwFEPJC0074U0+IP4UFAAAoWqgTAABQiAMIK1ascK/saLwDDcCQVwMGDLB+/frleX0AAFAwpk2blu3nqg+oXpBX1AkAACjEAQQNgjhq1Khs0wwePNhOPvnkPGeoT58+dvfdd6drgVCrVq08bw8AAOQ/zaJw//33Z5tG9QHVC/KKOgEAAIU4gHDjjTe6VyQlJCS4FwAAiF3FixcPbIFwoKgTAABQhGZhAAAAAAAAB4eIDqK4bds2mzNnTmh54cKF7mlFtWrV7Oijj47krgEAQIxRnUB1A42ntHv37lALhmbNmlnJkiWjnT0AABAgzvM8zyLkl19+sbvuumu/9zt06GC9e/fO0TY0BoIGYVKFo0KFChHIJQAARU80rq+33nqrzZ49e7/3P/zwQ6tSpUrg+tQJAADIf7m5vka0BUKTJk0i3j8SAAAUDkOGDIl2FgAAwAFgDAQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEAEEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAIBABBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABDdAMJvv/1mnTt3tmrVqlnlypWtXbt2NnPmTP5ZAAAoYnbu3GkvvPCCnXzyyVa2bFmrV6+e9e/f3/bt2xftrAEAgFgIIDzyyCN26aWX2qxZs+zPP/+0WrVqWZs2bezvv/+O5G4BAECMGTdunC1fvtxef/1127Bhgw0bNswFFB544IFoZw0AAORQnOd5nhWQlJQUK1eunKs0dOnSJUfrJCUlWWJiom3bts0qVKgQ8TwCAFAUxML1VQ8a3njjDVu2bFmhyTMAAAeb3FxfC3QMhC1btlhqaqrLHAAAKNrUEoE6AQAAhUd8Qe7szjvvdN0YzjvvvGxbKegVHg0BAAAHF42JNGLECBs4cGCWaagTAAAQW3LVAuGhhx6yuLi4bF9ff/11pus++OCDNmnSJBs7dqyVKVMmy30MGDDAPY3wXwo4AACA2KLBD4PqBGeddVam6y5dutQ6dOhgnTp1sttuuy3LfVAnAACgCI6B8Oijj7onDJMnT7aWLVtmmzazpw0KItDfEQCA/BOt8QQ03oECC02bNrV33nnH4uOzbgxJnQAAgNiqE0S8C0O/fv1c8ECtD4KCB5KQkOBeAADg4KJZGM4++2xr0qRJYPBAqBMAABBbIjqIouZ3fvbZZ13w4IwzzojkrgAAQAxbtWqVCx40btzYxowZExg8AAAARSyA8Nhjj9n27dutVatW6fpEqksDAAAoOkaPHu3GPhg3bpyVKFEiXb0AAAAUDgUyBsKBYM5nAAC4vlInAAAg+vfcEW2BAAAAAAAADg4EEAAAAAAAQCACCAAAAAAAIBABBAAAAAAAEIgAAgAAAAAACEQAAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAIBABBAAAAAAAEAgAggAAAAAACAQAQQAAAAAABCIAAIAAAAAAAhEAAEAAAAAAAQigAAAAAAAAAIRQAAAAAAAAIEIIAAAAAAAgEDxFkFpaWn27rvv2kcffWQbN260Y445xm699VY74YQTIrlbAAAQg5YvX24vvfSSzZw508qXL2/nnnuude3a1UqWLBntrAEAgGi3QLjnnnvsyy+/tMsuu8x69+5tKSkp1qxZM5s1a1YkdwsAAGLM6tWrrWPHjla9enXr06ePXXjhhda/f3/r0qVLtLMGAABioQXC448/bmXKlAktn3POOfbpp5/axx9/bI0aNYrkrgEAQAypUqWK/fLLLxYf/7+qx969e+22226z0aNHW7Fi9KoEAKBIBxDCgwcyb94827RpE8EDAACKmBIlSqRbTk1Nte+//95OPPFEggcAABQSEQ0gyJIlS+yqq66yHTt22LJly1zfxw4dOmSZXt0c9PJt27bN/T8pKSnSWQUAoMjwr6ue5xXofh944AGbMmWKGw+hfv36NmnSpCzTUicAACC26gRxXi5qDq+++qqNHDky2zRDhgyxU045JbS8a9cuN+bB1q1b7b333rMJEybY1KlTs2yF8Oijj1q/fv1ymiUAAHAAVq5caTVr1sz1empB0KJFi2zTqD6gekG4RYsW2fr1623+/Pn2n//8xw2k+Nprr2W6PnUCAABiq06QqwDCqlWr3Cs7DRo0sAoVKmT5eatWrezwww93szPk5GmDZnLYvHmzVa5c2eLi4nKaVcRwdKtWrVru4MzuOAEQWzh3Dz66/CcnJ7tBDfM6/sD06dOz/Vy/86oXZEUPFNq2bWtz587NNB11goMfvy1A4cN5W7TrBLnqwqBoRF6eUoSrVq2am9IxKwkJCe4VrmLFige0T8QeVSoJIACFD+fuwSUxMfGA1m/evPkBra8HCqLxkTJDnaDo4LcFKHw4b4tmnSCiQx4/9dRTtnPnztDyDz/8YJMnT7b27dtHcrcAACDGaBamH3/8MbSs+sGAAQPc7AyNGzeOat4AAEAMDKJYsmRJO+qoo6xSpUpuLAQ9YbjzzjutZ8+ekdwtAACIMaoP3H777W5cpKpVq9rSpUvdDAx6sJBx1iYAAFAEAwgKFNxxxx1uwCRN36S+7woqoOhSc9S+ffvu100FQGzj3MWBqlevnn322WduXCONp1SjRg03vhGKNn5bgMKH87Zoy9UgigAAAAAAoGiK6BgIAAAAAADg4EAAAQAAAAAABCKAgAO2bt06GzNmDCUJFFLff/+9/fLLL9HOBoCDxNSpU+2PP/6IdjYA5MG2bdtcvX737t2UHzLFGAhFxIIFC9zI1506dbL4+PRjZ/7+++9uNOyLL744T9ueMmWKnXPOOcZwGkDkffTRR1azZs39pr1LTU21Dz74wE444QQ77rjjcrXNSy+91A499FB75ZVX0r2flpZm7733XuDI+k2bNrX8sGXLFjfdr36jWrZsaWXLls2X7QLYn34vdP42atQo3ft79+51n51yyilu4Mu80Pnbtm1be/TRRyl6IIIWL17sHgBcdNFF+w1QriDen3/+aZdcconFxcXleJtaTzPkrFmzxqpVq5bus9mzZ9u8efOyXb9jx45WunRpyw+//vqrrVixwo455hg7/vjj82WbiPFZGBA7dHOgKTR10odf0NV6QBf5++67L6r5A5Azy5Ytsy5duticOXNcIMH3zDPP2MCBA/P01E+V/fLly+/3voIS48ePT1dR0cX88ssvD73XunXrfAkgfPLJJ3bVVVe5AMjOnTtdxUXv5VdwAkB68+fPt+7du7vfjMMOOyz0fr9+/WzkyJG0IAAKgSpVqljv3r3t559/tmeffTb0vma7Offcc+2GG25wDwlyo2LFita5c+dMgwBz5851DzJ8+luBxgYNGoTe034PNICg1g96sKk6x8knn2zTp0933+O1117LVTAEkUELhCJk4sSJ7mTUE74mTZq49y688EL31O+bb76xYsWy7tGyZMkSF3VMTEy0008/PV2U02+BoKeVuqlRawbdBOjJRrgdO3bYTz/9ZCkpKe7pqX70wm3YsMF9XqpUKffk45BDDkkX6Pjqq6/siiuucD+Sy5cvtzPOOMO+/vprO/PMM9NFSPX0ZNy4cXbWWWeF3s9u20BhopY+CvrpfP3888/dhVTnnc7pd955x7Uyyoqm1NXTiOrVq9tJJ51kxYsXD3Vh0Dnt/y5kRS0Ubr/9dtu3b1++fqekpCQ78sgj3bS/foDz2muvdees8ktlAch/ChAqeKjr5Icffuje0znXokULF7w777zzslxX13HVJdTUuWHDhla3bt1MWyD06NHDtXLU71arVq32m8pb5/fChQvdNN9qCRFeD1GdQk9WV69e7eoTeiKasZtE1apVXf5nzJhh5cqVc3WUjRs3un2Hmzlzpm3atCn0ftC2gcJEdWEd219++aU7z+TKK69055ZuvEuUKJHpert27XLnjv6vurHOJ9F5PXnyZNeqQfXm7Oj8U73goYceytfv9Pjjj9tLL71kv/32mx1++OEucKF7h+HDh9vVV1+dr/tCHmgaRxQdN954o3fsscd6O3fu9IYPH+6VK1fOW7x4cbbr9OrVyytTpox3zjnneMccc4xXu3Ztb968eaHPv/jiC00F6rVv395r2LChd/bZZ3sJCQneCy+8EErz22+/eYceeqjXrFkz7/zzz/eOPPJIb8SIEaHPlTYxMdHtQ+tXqlTJ+/DDD/fbh9Y95ZRTvMsvv9xbtGiRd9JJJ3kPPvhguvxOmDDBK1mypLd58+YcbRsobFasWOGO6cGDB3t79uzxGjVq5F133XXZrtOjRw+vYsWKXocOHbxTTz3Va968ubd27Vr32SWXXOLdfPPNgft9+eWXveLFi+/3vs45neO+1NRU75133sn29dVXX4XSa1nb3bRpU+g9bU/n/PTp03NcLgByZ+HChe76PnLkSFcvqF+/vnfrrbdmu46u/0cccYSrD+i6qvXvueeedGlatGjhtWzZ0qtRo4bXrl07l75BgwbeunXrQmm6du3qVa5c2bvwwgu9pk2bemeccUbour1q1Sp3rdc+9HmtWrXcdpTHjPtQneSCCy7wBgwY4I0fP94rXbq0l5SUlC4/2ta9996b420DhU3Pnj1d3VrH/rvvvuuVKlXKmzt3brbncbVq1bzGjRu780frvvTSS+6zOXPmuOvvmjVrAvdbtWpV77HHHkv33pIlS9x1XfUT36xZswLrBRs2bAil12+RvlM4na86VxF9BBCKmOTkZK9u3brelVde6VWoUMEbOnRotumnTp3qKvYzZsxwy3v37nU/NLrQZ7y579atW+g9/RDoJn7ZsmVu+Zprrkl3g7N7925v0qRJ7u9vvvnG3Qz9+eefoc/Hjh3rbna2bNmSbh+9e/dOl79nnnnGq1OnTrr3Onfu7F188cU53jZQGI0aNcpVlK+99lpXAd66dWuWaVVp1/kze/bsdDfoS5cuzZcAgirwd955Z2hZlQadh9m9Hn/88VD6Bx54wH2HcPqtiYuL84YNG5aD0gCQV7ppUH3giiuu8OrVq+ft2LEj2/S6ae/YsaO3b98+t/zDDz94xYoVc/WF8Jt7/T4tWLDALWubumm/6aab3PJff/3lfpN0o+FTsPDvv/92f7du3dq75ZZbvLS0NLe8a9cur0mTJl7fvn3T7UMPBPx1JCUlxb33+uuvh96bP3++25duYHK6baCw0XGsIJ2u5wrMPffcc9mm7969u9epU6d01+2PP/44XwIICkhq/fB69ttvvx1YL/Dr6rpH0PVfDzrD6YGhgpKIPsZAKGLUxG/UqFGuiVP79u3txhtvzDa9mkS3adPGmjVr5pY1uNn999/vmieq6Z+aQvvuvffe0N/qaqB06j+tsRfUF0rNp9VdQt0H1Fxa+5fXX3/d6tev75phq5uEAltqXrh9+3bX7PDss88ObVdNnMOpz7T6fqkppbpWJCcn24QJE2z06NG53jZQmFx33XXu/HrzzTddU1413c2Kzlu9dA74TXXVpzC/dOjQwTV/9Km5ZG5mZlFzyUqVKu2XZ43LsHXr1nzLJ4D93Xrrra4fswZMVXemMmXKZFlMf//9t02bNs1dc/0uUKeddpobC0XnvP4fPpCaBj4TbVPNnO+++2579dVXXR1AXZM0uHOdOnVcmlNPPdX9XwOmqSn2v/71L9cd8f8fdrluEurKGD6OkwaHC6+HqIvEZZddZm+99ZZdf/317j39rd89dbXIzbaBwkRdDVQf0Hmkbkh33XVXtulVL1c9Xl1+NE6artsXXHBBvuRF57TGUAjvsqQuFXrlhOryOi8z1gsqV65MnSBGEEAognTzr4u5xi0IorEGMo5l4C/rs/ALt/owh9Oy0kjfvn2tW7duLr36WSt4cNttt7mbHg0Kp8DC2LFj062vikHGvlfqBxVO29NYB6ogKICgfpyqmJx//vnu89xsGyhsNFCRAmbhlfbM6CI8bNgwF2zTgKk6ZzTGQLt27fIlH4MHD8717A3qN6l8iM5ZBfXCqfKgwRQ5T4HIU31AfaGbN2+ebTr/mp5xzAPVCzT+UbiMdQLdVCggqDFPNADskCFD7JZbbnHjJCiYrxt+PbDQdVsUzNCYRz4FHDKO05KxTiDqH63trV271v3OvP3223bzzTe7z3KzbaCwUSBfN9kaDyFo7CA95NMAixp/RA8UNOaJgnxa/0BpbDK9cjt7g/KtYIY/zlrGeoGWqRPEBgIIyJZOZI3kGs5f1mfhdKMePpihlv00NWrUsE8//TQ0YONTTz3lbuo1OEqFChXs2GOPzdETy8x+EK+55hp3U/TCCy+4QIKePvg/PrnZNnAw08wNqqDrAv7xxx+7AVU1GJFa8eS3jLM3ZEZPBP0Agm4+NOuCBkD1B3vSk04N1pjxRgVA9PjXdNUD/AHX/OXM6gQZl3VtVktI0QwQurFXC0G1gNCDBdULjjjiCPe5BmULb9mU0zqBHpIoQKHrvp7GKmjg/86pTpDTbQMHM828ogcQagH43XffuZmcFGzTwKaRkHH2hswokKHfEbU+1EDrajGUMYBJnSA2EEBAtnQh1oVWzYn8ad7ef/999+Tfb3bo0w2DKgSikV81NdSLL74YuhlQEEHdFzSqq+Z3V7RTIznrKWjPnj3dFHHhrR0084J+SPxmkllRawI1wXzjjTdcU241T/Qd6LaBg4EqCOoSoPNO8yjrpea6Gp05PwIICkiowu53i8htFwadp3oKOWnSJNfsWd599113o+GPKA0g+lR51/X/gw8+sAcffDD0+/LFF1/YE088kS6tzuc9e/aEmjFrHXV30EwLCjioCbVe6lqglx4y6DdJLQhVX9CsL0OHDk23zYxdJ7MKKuh3TQ8U/vrrL/ck1J/yVoHLA9k2cLDw6+VqCayuC2p5oJa8GQN/eaHWSGrRpPq5/1AgN10YxO9mpJYS+s1Qi0TNDqNWS4g+AgjIlsZI0EVWTwrV1EnTOQ4aNMj1s9INSbj+/fu7p4i6MX/++efd0wS/CZPGR9CcrmpWqB8TXbzVb1pPI9S1QcEH9dlS8yk91VBTJ1Um9GQi6CZfTxS0LfX3UiVB0zv6DnTbwMFA56XOEV3M1SJHAb5vv/3WXZjzg27+FRjM67gKuinR+du1a1fXzUIVhSeffNLNae0/rQQQfbruP/fcc64LlLoj6NxV9yh1V1AdIZymhlPXCN3Ma8pEdWtS4NJ/kqg+0moxqDnk9XRS4xINHDjQXZfVOkqtpDT1oh42KOCgmwfNAx/Ut9tvmThgwAD3NFV1Fl9+bBs4GGi8Dz1MU7chBfJee+011x1SXR4VTDsQamn873//2wUjKlasmKdtqOuzxl/T1NQ6TzUmm+oDGlcN0fe/CXdRpOhCqcEFg+hmXwMm6WKsJwN6mqD5ZnXh96nbgpZ//PFHd3FWtwTdUChy6NOTAA36phsXDZqkHwC/j7T2MXHiRNdaQRFR9Uts0KCBmzva7+vk7yMrCg7oqcUjjzySrkljTrYNFFZHH310tueFT0EDncdqAaTAgcYo0PnqDyKqlkZNmzbN8/4yDqKYF7pxUGBRvxHqu6xWDTqvAUSefiMUYMwJ/QaoHqD6gOoFCiaoCXT4XPPqy/zyyy+7sY4UrFcrBI07oCecomCjgglqFaWbDa2r67M/BoNuGBRUUMsEradWkPqNCL/B1z5OOOGETPOo67zqIXqyqvpOuJxsGyisFMxXK8MgCvypC5EeDP76668uAKhAmuimX+e5Agt52V9mgyjmlrahoKLOcdVXdN7+9NNPeQ5IIH/FaSqGfN4mAAAAAAA4yNACAQAAAAAABCKAAAAAAAAAAhFAAAAAAAAAgQggAAAAAACAQAQQAAAAAABAIAIIAAAAAAAgEAEEAAAAAAAQiAACAAAAAAAIRAABAAAAAAAEIoAAAAAAAAACEUAAAAAAAACBCCAAAAAAAAAL8n9RgP19NXdhSwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1050x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(10.5, 4))\n",
+    "for axe, idx, titre in ((axes[0], idx_hi, 'Individu aide (V > 0)'), (axes[1], idx_lo, 'Individu lese (V < 0)')):\n",
+    "    ligne = donnees.loc[idx]\n",
+    "    cf = contrefactuel_individuel(scm, ligne)\n",
+    "    y0 = float(cf['Y'].iloc[0])\n",
+    "    axe.bar(['Y observe', 'Y si T:=0'], [float(ligne['Y']), y0], color=['#4C72B0', '#DD8452'])\n",
+    "    axe.axhline(float(ligne['Y']), color='grey', ls=':', lw=1)\n",
+    "    axe.set_title(titre, fontsize=11)\n",
+    "    axe.set_ylim(-3, 6)\n",
+    "plt.tight_layout()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9134163f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002554,
+     "end_time": "2026-09-02T11:58:31.819933",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.817379",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Lecture de l'acte 1 — aider l'un, nuire l'autre\n",
+    "\n",
+    "Le tableau et les barres racontent la meme chose :\n",
+    "\n",
+    "- **idx 532** (`V > 0`) : `Y_obs = 4.86`, mais sans le traitement il aurait eu ~`1.51`.\n",
+    "  Le mentorat lui a apporte **~+3.3** — proche de l'effet vrai `3.T.V = +3.27`.\n",
+    "- **idx 168** (`V < 0`) : `Y_obs = -0.80`, mais sans le traitement il aurait eu ~`0.81`.\n",
+    "  Le mentorat lui a **coute ~-1.6** : l'ecart mesure `-1.61` rejoint l'effet vrai\n",
+    "  `3.T.V = -1.66` — le signe ET la magnitude sont les bons.\n",
+    "\n",
+    "L'**ATE = 0** est donc vrai **et** inutile : il ne predit ni l'un ni l'autre. Le\n",
+    "contrefactuel individuel, lui, predit chacun."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b847c58c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002625,
+     "end_time": "2026-09-02T11:58:31.825204",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.822579",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 — le contrefactuel inverse (etudiant non traite)\n",
+    "\n",
+    "On a regarde des **traites** auxquels on arrete le traitement. Retournez le point\n",
+    "de vue : un etudiant **non traite** (`T < 0.4`) a `V > 0` aurait-il gagne a etre\n",
+    "traite ?\n",
+    "\n",
+    "- **Indice 1** : filtrer `donnees` sur `(T < 0.4) & (V > 0)`, en choisir un index.\n",
+    "- **Indice 2** : `contrefactuel_individuel(scm, ligne, variable=\"T\", valeur=1.0)`.\n",
+    "- **Indice 3** : comparer `Y` contrefactuel a `Y_obs` : ecart positif = il aurait gagne.\n",
+    "- **Etape 3** : verifier la coherence avec `3.V` (effet de `T:=1` vs `T:=0`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90fd1d0b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:31.833276Z",
+     "iopub.status.busy": "2026-09-02T11:58:31.833276Z",
+     "iopub.status.idle": "2026-09-02T11:58:31.838666Z",
+     "shell.execute_reply": "2026-09-02T11:58:31.837104Z"
+    },
+    "papermill": {
+     "duration": 0.011934,
+     "end_time": "2026-09-02T11:58:31.839865",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.827931",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : le contrefactuel inverse\n",
+    "idx_non_traite = None  # TODO etudiant : un index avec T < 0.4 et V > 0\n",
+    "\n",
+    "def ecart_sous_traitement(idx, valeur=1.0):\n",
+    "    resultat = None  # TODO etudiant : contrefactuel_individuel + difference\n",
+    "    return resultat\n",
+    "\n",
+    "print('Exercice a completer')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fd34c80",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003434,
+     "end_time": "2026-09-02T11:58:31.846303",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.842869",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. La decomposition — pourquoi la moyenne n'a rien dit\n",
+    "\n",
+    "L'**ATE** est aussi la moyenne des effets individuels : `E[Y(T:=1) - Y(T:=0)]`.\n",
+    "Ici, chaque individu a son propre ecart `Y(T_obs) - Y(T:=0) = 3.T_obs.V`. Le module\n",
+    "le calcule **par personne** (boucle row-wise : abduction du bruit pour CHAQUE\n",
+    "ligne, seule l'intervention change) :\n",
+    "\n",
+    "- la **moyenne** des ecarts est petite (coherence avec un ATE proche de 0) ;\n",
+    "- l'**ecart-type** et la moyenne des valeurs absolues sont grands : la dispersion\n",
+    "  est la vraie information, invisible dans l'ATE.\n",
+    "\n",
+    "`ecarts_contrefactuels(scm, donnees)` retourne une `Series` indexee comme\n",
+    "`donnees` — c'est notre outil de decomposition.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2c94427e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:31.853541Z",
+     "iopub.status.busy": "2026-09-02T11:58:31.853025Z",
+     "iopub.status.idle": "2026-09-02T11:58:34.018797Z",
+     "shell.execute_reply": "2026-09-02T11:58:34.018179Z"
+    },
+    "papermill": {
+     "duration": 2.170688,
+     "end_time": "2026-09-02T11:58:34.019953",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:31.849265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "moyenne des ecarts individuels  : +0.331\n",
+      "ecart-type des ecarts           : 1.006\n",
+      "moyenne des |ecarts|           : 0.799\n",
+      "min / max des ecarts           : -1.61 / +3.35\n"
+     ]
+    }
+   ],
+   "source": [
+    "ecarts = ecarts_contrefactuels(scm, donnees)\n",
+    "print(f'moyenne des ecarts individuels  : {ecarts.mean():+.3f}')\n",
+    "print(f'ecart-type des ecarts           : {ecarts.std():.3f}')\n",
+    "print(f'moyenne des |ecarts|           : {ecarts.abs().mean():.3f}')\n",
+    "print(f'min / max des ecarts           : {ecarts.min():+.2f} / {ecarts.max():+.2f}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "996959c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:34.027893Z",
+     "iopub.status.busy": "2026-09-02T11:58:34.027893Z",
+     "iopub.status.idle": "2026-09-02T11:58:34.238401Z",
+     "shell.execute_reply": "2026-09-02T11:58:34.237347Z"
+    },
+    "papermill": {
+     "duration": 0.216931,
+     "end_time": "2026-09-02T11:58:34.240138",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.023207",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAHqCAYAAACZcdjsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnQWYY+eRtU8zMzMMMzOP7TEzU4whxwEHN/mddbLrOLABZzcOG2KIHTtmhvGAZ8bDzNjMzKz/OaW5aklNklrN9fqRp3UlXd37ib7zVZ0qD5PJZIKiKIqiKIqiKEo/8OzPgxVFURRFURRFUVRYKIqiKIqiKIriFjRioSiKoiiKoihKv1FhoSiKoiiKoihKv1FhoSiKoiiKoihKv1FhoSiKoiiKoihKv1FhoSiKoiiKoihKv1FhoSiKoiiKoihKv1FhoSiKoiiKoihKv1FhoSi98Pzzz2P79u06Ri5SWFiIv//972hoaHDLGP773//G3r17+7V/Rx9j/1zDeVxGMu4c588//xxvvfUWBpPKykp5LfmvMnqxf28NxXvNWXh87733Xo+3Hzx4UN67TU1Ng3pcyuhGhYWi9MK3vvUtvPTSS2NqjAoKCuTHprGxsd/7OnHiBL74xS+ioqLCLcf28MMP2/yYu7J/Rx9j/1zuxN3jMpJx5zi/8MILeOyxxyzXt27dinfeeQcDSX5+vryW/HckMhhjNBqwf2/ZXx+OcFHspptuQl1dXbe3f/e738X//d//wd/ff9CPTRm9qLBQFMWGo0ePykSpurq63yOTkJCA++67D0FBQQMyyq7sf6CPSRk6li5diquvvtpy/bnnnsMvfvELfUl6Qcdo9HLPPfegvr4er7zySpfb8vLysH79etx7771DcmzK6MV7qA9AUUY6xcXFsurHFf6FCxdiwoQJNrfX1NTgs88+Q21tLaZPny4Xd+yXlJSUYNu2bWhtbcWSJUuQnJws2ykKjB8TLy8v2b5gwQKEh4dbHpubm4sPP/wQX/jCFyQV5dSpU4iNjcVHH30kt//zn/9EaGgowsLCcOONN7p0Lnz84sWL4efn1+U5uWpPERMVFYVVq1bBx8eny+N37dqFY8eOIS4uDmvWrOl1/1yVY3Tp4osvRkpKis393n//fRmHdevWdTkmR5+L48PX4+6777bZznHmazN79mynX7/+vk9efPFFEUqrV6/u8T6OHrezr42z5+foOHf3vpw6dSrmzZuHjo4ObNmyBVlZWYiOjpbzDgwMtDw2IyMDwcHBllSV48ePy3EyAkdmzZolnwODAwcO4PDhwyIyeSx8r/dFc3OzTMjKy8vlNepubFzd/+bNm2UiuHLlShknRkH4+kybNs3p/Rv74vadO3fKvjiOHAODgRgjR57XoK/X05l9uXoc/L7z9fW1+Qwxkvjaa6/J954j7wlrXHlP9fU4V8eBn8nly5fjH//4h4gMe0HJ78Tbb7/dqfNTlD4xKYrSI1FRUaZvfvObPd7+i1/8wuTr62tasWKF6ZprrjEFBweb/vu//9ty+8aNG02hoaFy+2233WaaPXu26dprr+1zxPvaL3nsscdMfn5+pmXLlpluvPFG07hx40x//etf5bbCwkLTfffdJ5e77rrLtGjRIjmXjz/+2PL4t99+28SvgIsuukiOi/f7wx/+YLr00ktlO4+Xj//hD3/o8rls2LBB9pWbm2vznJdccolp3rx5pltuucWUnJws+2poaLB5LI8nMDDQdPXVV5tWrlxpmjlzpik2Ntb0yCOP9Lj/8ePHmx566CGb/dTV1cn4/e53v+v2MY4+19NPPy3jbQ/H3f616ev1sz8GV98nSUlJpttvv73X+zh63M68No68P7vDkXHu7n35+uuvm4qKiuR6YmKivN+nTJliiouLM+3YscPy2K997WvyXicvvPCCafLkyXIf47Pw6quvym3V1dVyniEhIXIs/Azx87Ft27Zejz8vL880ceJEU1pamummm26SMbzwwgvleA8dOmS5n6v757lyn7xcfPHFpssuu8zk4+Nj+tGPfmRzP0f2b+xr6tSpsh++n/iaWe9rIMbIkecljryeju6rP8dx+eWXd/kM7du3T17TY8eOdfve6u66q+PlrteyJ5588kmTh4eH6ezZszbbJ02aZLruuuv6fLyiOIsKC0VxUVgYE6AnnnjCsm3Lli0mLy8v0/79++X6FVdcYbrjjjtsHvfOO+/0OuaO7Pe1116T+7z88suW+zQ3N5vWr1/f435/+tOfmtLT07s8z5e//GWb+1F8cDvFiTWunEtPwuJ73/ue5T4lJSWmoKAg01/+8hfLNk5ueL67d++2bHv00Uflsb0JC94nJibG1NLSYrnPU089JT/CpaWl3T7G0edydoLe2+tnfwyujC3hOP7973/v9T7OHndfr40j59cdjo5zT+9LCi5O6isqKuR6a2ur6corr5SJsfF620/2uA9O1OzhRI1C7uTJk5Zt3/72t2Vy29bW1uM53HrrrTIZrq2tleuNjY2mJUuWdBEWru6fj+O+nn/+ecs2iipu2759u1P753043lu3brXc59lnnzV5enpaPgsDMUaOPq8jr6ej++rPcbhLWPRnvNz1WnYH36v8DFt/xihaeH78rCmKu1GPhaK4yFNPPYVx48bhq1/9qmXbsmXLJPRspBUwnM20Eob6DS6//PJ+7/eZZ56R1CcjRYkwnL927VqbNAOmOjA9iI9juhSPg+lT1nzjG99w6HxdOZeesD63mJgYTJkyBSdPnrRJ8bnooosk/cXgO9/5jpxjbzDdhykqb7/9ts14XnXVVZJq0R2uPld/Xj93je2vfvUr8Yu4k75eG1fOz5Vxtn5ftre3S+rWgw8+iIiICNnm7e2N//iP/5BUnv379zt8fkzd4rF85StfsUnf+uEPfygpWkzN6Y62tjapYMVjMNKtaHp96KGH3LJ/A6YtWqenXHPNNZg0aRL+9a9/Ob1/psrQd2LAFCt+L5w+fXpAxsjR53Xm9XT1HPr7WGdwdbwG47Xke/WGG27As88+y4Vky+9HfHw8Lrnkkn6dt6J0h3osFMVFOAlkvv6TTz7ZZQJifNlz4sfKUsyR5oSBebxf/vKXMXfu3H7tNycnBzNnzuxxH9nZ2TKJYxlB5ktz4mqYsUtLS8VLYcAcfUdw5Vx6wphMGNDvYF3ykMdvPQE1JnF9HWtSUpL4KJ5++mlcd911Ml78cabHoidcfa7+vH4DObb9pa/XxpXzc2Wcrbczp5zCmB4KazIzMy3HZO0L6KvUb0tLi+TR2wshHg/Pgb6S7qql8RjS09Ntttsfk6v7N7Dfv7HNEJ3O7L+715L0VV60v+fQ1/M683q6eg79fawzuDpeg/FaEvor6LPYtGmT+MtefvllKdBBMaco7kbfVYriIvyi5wTfvs/F5MmTZUWXJCYmypc4fzz27NkjE15+sdOU2pM515H90lRbVFTU47E9+uijIiZowDV+PD755BMxJBqrVgYeHh4Ona8r5+IqNPZSAFnD4y4rK+vzsaxycuutt8qPNlfXOVGn2Ojvc9HoyBVCe+x7UTjy+g3m2Dp63I7iyvm58ppavy8phD09Pbs83rjO1VdHMQoYUOjYfxYYKbA3/ltHb3hMPR1Df/ff0/4Ix4gGeXfs3xEG+jnc+Xr2F34+GEHpz2fD1fEajNfSiG5QtDFSwe/FqqqqLsUcFMVdqLBQFBe59tpr8Zvf/Aa//e1vZQXXgJNDfnkTppBMnDhR0j2YusQVW670MtTf04TRkf2ypCbTSBguZ6qKASd8qampMhHhj5L1ihRXrBzBeE77H1dXzsVVLrjgAvznf/6nTDQ4oSOvvvqqVEbpC44Nf7D5I8rwP1frOInp73NxXLnKyipFRtrCvn37LK+JM6+fPa6OrSNVoRw9bkdx5fz6+5py9ZbpVqxkwwmRITr4nqbItq/IZcDjs38fR0ZGyiowV8v/8pe/dIlK9FTFJyAgQFJR2L/glltusWzne8wd+zdgShwrQhkr9keOHJHXi+kx7tj/QI6Ro7j6eg4E/Hyw6pI1vTWV6w5Xx2ugx9mA48tx/uUvf4mzZ89i0aJFUlVKUQYCFRaK0gf8YbcPU7MkIHPM+YPEdJXbbrtNVuH4pf3uu+/iZz/7GdLS0vD9739ffrS5YsQfcOb+M12HaUo94ch+eZ+PP/5YJjoMaXNyuXHjRlk15o8HH8fJD3OYOZnkfTlZcQT+4PDHncfOlX6uUNPL4cq5uArPj8KAkw96CJgqwAlcSEhIn4/l5JyrfYzaMIfZvsyiq8/F25nnzIm1cT/6V4x8e2deP3tcHdvvfe97Iip6ExaOHrejuHJ+/X1NCRt5cRLGcsKXXnqplOd8/vnne93HihUrRAD99Kc/lfE0SqlStHFsua8LL7xQVq25P5bPZSSmpx4nv/vd7+QYrrzySvEzMc2O5T/tcXX/hF4g+iq+9KUviSB+4oknRJRdf/31btn/QI+Ro7jyeg4E999/P/7617/i5ptvFp8QI4ZMGXIWV8droMfZ4K677sJPfvITKWn95z//2S37VJTuUPO2ovTCnXfeKRMlfsFbX7iCyB8Apq/87W9/k/xyrjTyvkw5olmOvPHGG/jBD34gebDnzp2TycHBgwclLaQnHNkvIxFvvvmm/BAzzcXo/ktRQSgEKDRYE555ujQvcxLECR1XyYyVOl637+fACSd/1LhSzh9Znqur52LfjK6n5+REzdqYyNt5DBRGTBPgajHH/Zvf/KaN76CnZnecxDId6pFHHrHkbff0GEefi2POMeREhOdPwcUf6a9//euYM2eOU6+f/TG4MraEE/vuekFY4+hxO/raOHJ+3eHoOPd0HJzwMrWPky9GX3g/popxDHpqkMdjf/3116XHyY4dO6RHBmHKFnsGUIDys8NICyd33NaTyZ9wws1JH4+FnyseC0WW9eeqP/s3ztPorcD+EhTIFG3WOLJ/Ttovu+wym8fx+4DHau1fcfcYOfq8jryeju6rv8fB7zga5Pm+5PF8+umncj/rvj/27y37666Olztfy97g+FJY8HvAOuKmKO7Gg6Wh3L5XRVEURVGcgukq7IhMkaYoijIS0YiFoiiKoiiKoij9Rj0WiqIoijIMYMpLZWXlUB+GoiiKy2gqlKIoiqIoiqIo/UZToRRFURRFURRF6TcqLBRFURRFURRF6TcqLBRFURRFURRF6TdjzrzNmv/saMkGPEa3T0VRFEVRFEVRusLOFLW1tUhMTJTGnb0x5oQFRUVKSspQH4aiKIqiKIqijBjYQDM5ObnX+4w5YcFIhTE4oaGhQ304iqIoiqIoijJsqampkUV5Yw7dG2NOWBjpTxQVKiwURVEURVEUpW8csRCoeVtRFEVRFEVRlH6jwkJRFEVRFEVRlH6jwkJRFEVRFEVRlH4z5jwWjpakbWlpGerDUJQxj4+PD7y8vMb8OCiKoijKSECFhR0UFOfOnRNxoSjK0BMeHo74+HjtO6MoiqIowxwVFnYNQAoLC2WFlGW1+moCoijKwH4eGxoaUFJSItcTEhJ0uBVFURRlGKPCwoq2tjaZyLCzYGBg4NC9KoqiCAEBAfIvxUVsbKymRSmKoijKMEaX5K1ob2+Xf319fYfq9VAUxQ5D5Le2turYKIqiKMowRoWFiw1AFEUZHPTzqCiKoigjAxUWijJCefLJJ/Hqq68OynM9//zz+Ne//jUoz6UoiqIoyshEPRaKU/ztb39DdHQ0rr322n6PXFNTE15++WXs3bsXd955J+bNm9fr/T/++GO8++67XXLwf/7zn/drvyOVt99+G8nJybj++uvd/trY88EHH8Df3x8333yzS49//PHHERkZiS984Qtdbquvr8fDDz+MO+64Y9S+VoqiKIoyFtCIheIUb775JjZt2tTvUXvrrbcwbtw4fPTRR/j973+PY8eO9fmYHTt24I033kB6errlkpqa2u/9jlTuu+8+3HDDDW5/bQYCFkV46KGH0Nzc3OU2isA//vGPSEtLG5JjUxRFURTFPWjEYhTwpz/9ScrjckV448aNYkK/9dZbMX78eJv7lZaWSjpLXl4eMjMzZfU5LCysy37i4uKwfv162c91112HKVOmyO3//Oc/cfToUeTn5+Nb3/qWbPvRj34k1Xr62rc9EyZMwMGDBxEVFYUXXnjB4XNlPwPjud21X0fG75VXXsHWrVvlb+578eLFuOiii3rcD1f4OY5f+9rXujzf//zP/2D+/PlYs2aNZduzzz4LPz8/S0Sgr9fCqJRkNHJ052tDDhw4IGlWISEhXc7TwJn93n333fjP//xPET833XRTl5Suq6++WqItiqIoijLWqW9uw5GCGrS0dWBKQgiigv0wUtCIxSiAE8AHH3wQX/ziF2WiyRSgWbNmyb8G/HvatGnYtm0bQkND8f7772Pq1KnIzc212c/Xv/512Rcr8Bw5cgRz5szB4cOH5XZO/Jh6xMcbEQN2RnZk3/ZwgswJurMUFxfjxz/+MX72s59JapQ79uvI+HGfxjlz9Z0pPd/+9re77McYP1YWoyjoDgqePXv22Gx77733bM6nr9fCSIXasGGD218biqIFCxYgOzsbNTU1kmplHwlxdr8s4XzppZfiqaeestl+4sQJEWz3339/j8ejKIqiKGOFktom/GXTGXx8tAibTpbgr5vP4kRRLUYKGrFwhPr6nm/z8gL8/R27Lxvuna/L3+t9g4LgLJwA7t+/X7oUE64ef//738cnn3xiWTH+zne+gx/84AeWx9xyyy145JFHbCZ7zKPfsmWLTErJypUrZUX5d7/7HdatW4eMjAxZybeOGqxatcqhfbsDTtbZuJCr9UwDuuCCC2QS3t/KQX2N39q1a+ViQO/GjBkz8L3vfc+mcRubun3++ecSfegvvb0W9rjrteHxUzBxH7/61a9k2z333INJkybZ3M/R95N96hZFCsUHozGE92UK1IUXXujCCCmKoijK6GLLqTI0tprbH5AOkwmfHCvGpPgQjARUWDhCcHDPt112GWBtKI6NZUJ59/ddtQrYuLHzeno6UFbW9X4mk0OHZXsYl1kmxYRGWKbOMIUmJycHhw4dklSZ7373uzJ55KWoqAgVFRU2+2HaizGRJVyV7m11+9y5cw7vu79wMk+Tr8GXvvQlzJ07V9KI7rrrrn7tu7fxYyd28umnn2L79u0oKytDR0eHiJnjx4/bCAtO8N0hKlx5Ldzx2jCVir4UplYZMM1p6dKl/dovueKKKyQ165lnnpGoExtS8rX7yle+ol3uFUVRFAVAWV1XL2JVQwva2jvg7TX8E41UWIwSYmJibK5zAseJW3l5uazuE64MM//fgMZnprFYY99xnJNq7qcnnNl3f7E393KizSpCn332Wb+FRW/jx7+ZqsN0H/oDmNbDCT8jJ9XV1TaPsx6D/uLsa+GO14apZj2NR3/2S7y9veV1evrpp0UgssIX98WIiKIoiqIoQHJEIEprbcVFXKj/iBAVRIWFI9TV9Xzb+dVsC+cnXT2mQlmTlQV3wZVma2ioZZ4/c+9ZfpVw1fmSSy7p1/PYpxwZq/Xu2Lcr0BPhjo7MvY0fxQNTdpjitGjRIrm9srJSqhy5Avdrf8x8juDeImOD9NokJSVZxsP42xgPw5jdn9ec6VC//OUvxRvCtC5GZewreymKoijKWGXFhGjkVDSg/HzkIsDHC5fO6MyMGO6MDPkz1NDz0NPF2l/R132t/RW93dcFuPprpMkwfefPf/4zLr/8cllV58RtyZIlePTRR9HY2Gh5TG1traXSkaMwXch6ld6d++7ORPzDH/7Qct3wOxiwgtO+ffsk/ai/9DZ+jBIw1cc6WvDb3/7W5ediatHOnTst15mqRi9Ff3HHa8OqWzRusyqVwe7du6XUb3/2a121i14R9h5hBEhN24qiKIrSSYi/D760IhO3LEzF9fOS8eDaCUgKt5s/DmM0YjFKoGl3+fLlYjBm/jsnydaTVXZOZo47K/ewzClX3FmW9bHHHnPai8DqSUzL4Qo7S5q6su+TJ09K7wLr4+MElhNWo+Qq/Qyc4BoN8JiPT7Pw7Nmzxefw4YcfSjnX2267zan9Ojt+rAhFfwcbz7Es6tmzZy0RDVegOZrPw9V+rv6zshLTq/qLu16b//3f/5VIAs+T6U4UcBMnTrS5T3/eT4xaMCWK0aCrrrqq3+etKIqiKMOdlrYOHCuskVKy42KDJb2pJzw9PTAupn9ZDEOFCotRAkt5fvnLX5Z0HU70OOmzzn/nKjknfkxBOX36tExkV6xYYXOfBx54oEuJVFZe4kq0Afs7cNWZkQJ2TKbXwJF928PSqCyJSqyrHFmXiuXE2/p4KCxoLObqOf0HjBqwGZ6z+3Vl/PjcLAfL82Mkg8fG9ChWhupt/Lpj4cKFYnzmeAUFBUn1JYofa6O2I68FJ+jsM+Hu14Y9OlgGlhEF7v8Xv/iFiC3DxE5c2a/BjTfeKCZvihVXxZmiKIqijBTqm9vwj8+zUFlv7j214UQJLp4Wj/np7vNlDhc8TMzxGEOwrChzxZkyYm80pReBFW9YtpOlPkcKLNXJhmucACo6fqONkfq5VBRFUUY37C9xtLAavl5emJcWgfiw7n+jNp0sxZZTpTbbfL098eWV49Da3oHIIN9+l80fqrmzPRqxUBRFURRFURQn2HamDBuOdxbsOZhfhTsWpSEl0raiIympMRfRseZUcR1+/dEJ+Hl7IjzQF9fMSRpRXoqeUPP2KIBpM1deeeVQH8aIRcdPURRFURRH6egwYfuZcvmbaT8lNc04WlCDP248jYKqzqImBvaCobyuRfpV+Hh5WPpUvLonT/Y70tGIxSiAjdwUHT9FURRFUQae1o4OS3fsnPIGFFabxURbe4d4Kb6wJN1GTMxLj8DJ4lrknxcd1Y2tSI8KhKdV+lNtUyuKa5uQEDayoxYqLBRFURRFURTFQfy8vZAaGYhzZQ0otkpzCg/0kajDznPluHZOss3971qajqzyBtQ1tSG7oh4Hcqts9kmPRaDvyJ+WayqUoiiKoiiKojjBFTMTxXTdYTLBAx7yd+L5KEV9szmaYS8cMqKDMCM5DMvHR8Pfx7bB8rTEUIQFdFaHHKmMfGk0AIyxQlmKMqzp6OgY6kNQFEVRFBsignzx4Nrx4rIorW2WKk8Gk+I7S8F3B83a9yzLwM5zFahpasW4mCDMSYnAaECFhRWs+09FWVpaipiYmGFd+ktRxoLAb2lpkc8jO6BrzwtFURRluHH7ojS8vi9ffBaenh6YnRyOeal9iwRGOC6ZHo/RhvaxsKOurk66KmvUQlGGB2yGyA7lKiwURVGU4QoN2X7enl1SnEYD2seiHwQHB0v34tbWVve9IoqiuAS7fXt7e2v0UFEURRnWjAZ/hDvQVKgeJjO8KIqiKIqiKIriGFoVSlEURVEURVGUfqPCQlEURVEURVGUfqPCQlEURVEURVGUfqPCQlEURVEURVGGiJa2DpwuqUNBVeOIfw1GnHl7z549+Oijj6Qs7LRp03DDDTdoGUpFURRFURRlxJFVVo9X9+ahqdXcrTstKgg3zU+xabg3khhRR/3QQw/hm9/8JpqamuDv749HH30U8+bNQ3V19VAfmqIoiqIoiqI4DHumvXOwwCIqSHZ5PXZnVWCkMqIiFg888ID0mDD42te+htjYWLz77ru47bbbhvTYFEVRFEVRFMWZpnq82JNV3oCl4zEiGVERC2tRQWpra9HR0YGoqKghOyZFURRFURRFcZYgP+9uU54ig3wxUhlREQty7NgxPPHEE9JefPv27fjlL3+Jiy++uMf7Nzc3y8WAj1MURVEURVGUocTHyxMrJsRg/bFiG7GxODMSI5URFbEgQUFBmDx5MjIzM+Hp6Yn169dL5KInfv7znyMsLMxySUlJGdTjVRRFURRFUZTuWJwZhS8sSZd/106OwxdXZCI8cORGLDxMdI6MUBh9mDhxongtfvzjHzscsaC4oOE7NDR0EI9WURRFURRFUUYWnDtzcd6RufOIS4Wyhic3adIknDx5ssf7+Pn5yUVRFEVRFEVRlIFjxKRCtbS0YNOmTTbbTp8+jb1790rJWUVRFEVRFEVRho4RkwrV2tqKq666CpWVlZg6dSqqqqqkUR63Pf300w5HJZwJ5yiKoiiKoijKWKbGibnziBEWBgcPHsS+ffvExD179myMH+9coV8VFoqiKIqiKIriGKPaYzFz5ky5KIqiKIqiKIoyfBgxHgtFURRFURRFUYYvIy5ioSiKoiiKoijuoKm1HUcKqlHf3I6JcSGID/MftIHt6DAhu6IBHgBSIwPh6cm/RjYqLBRFURRFUZQxR01TK/6xNUv+JZ+dKsXF0+IxP33gO19X1LfgxZ05qGpokeuRQX64bWEqwgJ9MJLRVChFURRFURRlzLHzbIVFVBhsPFGK1vYOp/fV2NKO3IoG+dcRPj5aZBEVpKK+GeuPF2OkoxELRVEURVEUZcxRVtfcZVtzWztqm9oQGeTr8H52nC3HhhOlaO/ogJenJy6YEosFfUQ9cioaHNo20tCIhaIoiqIoijLmSIoI6LItxN8H4QGOpyOV1jbjk2PFIioI//34aDHKuxEt1kQEdhUuUU6ImeGKCgtFURRFURRlzLEwIxJJ4Z3iwtvLE5fNiHfYRM20p80nS1HX3Gaz3WQy4VxZfa+PXT0p1uZ5GOlYOTEGIx1NhVIURVEURVHGHH7eXrhrabqkILEqVGZMEPx9vBx67ImiWryxPx8lNU04WVyLsABfTIoPgaEVwvswYY+PDcaXVmTicEGNVIWanhTmVPrVcEWFhaIoiqIoijIm8fDwQFpUkFOPaWvvwLuHCuXfiEAfBPt5o7qxBSW1TYgP9ZcoyLiY4D73ExXsh1WjIEphjQoLRVEURVEURXGQ8voWNLa0WYTJlIRQ8VqEBfhIudpZKeGyfSyiwkJRFEVRFEVRHIQCgn4MRiyIl6eHNNZbPiFmUHpgDGdUWCiKoiiKoiiKg9CHsWJ8NDacKLFsCw/0xfy0CIfHsLimCR8dKUJeVSNigv1wwZQ4ZEQ7l5I1HFFhoSiKoiiKoihOsHR8NFIiA3G6tA6h/t6YlhjmsPG7pa0D/9yRg4bz6VQUGf/alYuvrh4n0ZCRjAoLRVEURVEURXESCgtenOVMaZ1FVBiw/8Wxwhoszowa0a+DCgtFURRFURRFcTMmk0lERGG1uVoUS8zS1E1PBmloaUdVQwt8vb2k1KznKDB8q7BQFEVRFEVRFDdR3diK9ceK8f7hItQ1tSI5IlD6WkyMC8EN85KRGR2EmqY2HC2otun4zVSokY523lYURVEURVEUN0UpXtqZgx1ny1FU3ShduU8U10p0go30ssob0NZhQqCvF6KCfOHr7SnG7/SoQJwsqh3xr4FGLBRFURRFUZRhDSfoFXUtiA31c9gkPRTkVTairK5ZhIS12OC21MhA6Xfh5+0Jb08PTIgLsXlscW0TRjoqLBRFURRFUZRhy8YTJfj8TDk6TCb4eHlamtANZ4L9u59iJ0UEICrYHKlgdShrEsMCMNLRVChFURRFURRlWJJb0YCtp8tEVJDW9g68d6gQtU2tGI4ki3DwQ7CftzTNIzRsRwf7SfO8pPAA+Hl7Yd3UeBuzNn0Yc1Id74MxXNGIhaIoiqIoijIsOVdW32UbRUZORYP0jhhueHh44JYFKfj4aLGkbM1IDMe42GAsSI9AbKhZaBBGXNKjg+T82AeDzfH42JGOCgtFURRFURRlWNJTwzganocr4YG+uHF+ikPnNnuYp3Q5i6ZCKYqiKIqiKMOSqYmhiAnxs9nGfhBMKVKGHyosFEVRFEVRlGEJzdo3zE0Ww3NTa4ekDF09O2moD0vpARUWiqIoiqIoyrCkqbUdL+7KRXldC/x9PMWT8NrefIx0yuua8cnRYrx7sBBnS+swWlCPhaIoiqIoijIsqKhvwaniWgT6emNyQggO51ejqqHF5j7nyuqQX9U4YtOhiqqb8OznWVLhiuzPrcSFU+KwKDMKIx0VFoqiKIqiKMqQcyivGm8fLJCGcmTzKV9kxAR1e19zuVn3CYv65jYcL6qRErBTEkIHtAnf52fLLKLCgCV1WY7Wy3NkV4ZSYaEoiqIoiqIMKe0dJnxyrNgiKggjFTUNXas/eXt5Ij2qe8Hhaq+Ml3blWBrWbThegtsXpyHOqjysO6lu6NqDo7G1XZ4/wHf4dhV3BPVYKIqiKIqiKEMKIxANLW1dtneYgDWTYkVMkABfb1wzO8mtEYX1x4ptumBzks9u3wNFRkxwl23xYQEjXlQQjVgoiqIoiqIoQ0qovw+C/XxQ12y7mp8Q5o+l46MxNy0C1Y2tiArytYgMd1FU09xlW3E329zFkswoFFY14sx50zb7Xlw5MwGjARUWiqIoiqIoissw0uDn7dUvf4Cnpwcunh6H1/flo4NhCkD6Vyw+b2hmhGKgfA+J4f6SDmVNfJg/ThTV4lhhDfy8PUXYuCs1ytfbE7csTJXKUE1tHUgM8x8VXbeJh8k6mW0MUFNTg7CwMFRXVyM0NHSoD0dRFEVRFGVEUlLbhLf2F6C4pkkm/UvHRWPJuKh+p0SdKa1HkK8XxsUEi+AYaAqqGvHizhwpbUuC/LwxOT4Ee7IrLffhcdy5OA3JEYFuf/7qxlYxrrd2dGBqQuiAeTsGY+6swkJRFEVRFEVxCq5L/3HjmS6lYG9ekCqdsUcaFBUni2ulKtT4mGD8ceNp8VpYMzEuBDfOT3F76dnntmdZPB6MXNBDwo7jwwVnhIWmQimKoiiKoihOUVTT1EVUEKYOjURhwYjLzORw+bu5rb2LqCC1TV3N5d0JrgN51TheWCP7nJcWgZTInqMcn50qtTGO8/EbTpQMK2HhDCosFEVRFEVRFKfw9+7e7zCQ/R8GC/pFKAbsfReOCKaNJ0qx7UyZjdC6Y3Faj+KCDQHtoWBj+d2R2NNCy80qiqIoiqIoThER5IsJsSE221itaW6qedV/pHPFzEQxjxvpSZPiQ/v0j7S1d2BXVoXNtg6TCTvO2W6zJrUbwcGO4iNRVBCNWCiKoiiKoihOc+3cJGw/W46zpfUIC/CRCk5RwebJ+HDwTBwtrJEKU5MTQhHs59yUNzLIF19aOQ6ltc3w8/GUcrh90dpu6tJRm3TXn8Ng5cQY5Fc1igGesOTupTNGbulZFRaKoiiKoiiK0/h4eWLFhBi5DLdqVc9/nm3xSaw/XoJbF6QiNar7dCT6GlraOyQFyh4jauEIAb5eEoHIsUuhoum7J1iB6r7lGcirbBRRkhYVNGKjFUSFhaIoiqIoijJqoM/B2nzNFKVPjhXj3uUZXe57ILdK7s/GfOx+ffmMBOlh4SpXzUrC6/vyJArBErWzksOxMD2y18cw1ao3g/dIQoWFoiiKoiiKMuQwcvD5mXLsy62S65yULx0X5XQvi5LzaUXWFNc2ddu/4t1DhfK8pKi6Ef/alYsH1453OWoQFuiDu5dlSD8ORnRGg5ndGdS8rSiKoiiKogw5FBUstcqqSLxsOlmCLac7Kyw5SkJYQJdtid1sY8Um+z7RjFzYpzK5Qoi/z5gTFUQjFoqiKIqiKMqQY0QqrNmfWyUGZ2dYPSlGPAsUCYQT/AunxnW5n6939+vrPW0fSKoaWvDhkSKcLTMb4VdOiMH0pDCMGWGRlZWFvLw8+TslJQVpaWnuPC5FURRFURRljGMXUHAIVqZ6YM046aTNfhA0T3cXPWBDvB1nK6QhnkFieICUex1MTCYTXt6dKxWoSGV9C946UCACY6R5L5wSFtnZ2XjiiSfw0ksvITc31+Y2iovbbrsNX/3qV1VkKIqiKIqiKE4xIylMOlFbMzPFtVV7+humJfb+WE7cv7AkDVvPlKG8rkUqMq2YEI3Bprim2SIqrMXG4fzq0SssfvjDH+L//u//sHbtWjz88MNYsGAB4uLMYaXi4mLs3LkT77zzDqZNm4ZvfOMbeOyxxwbyuBVFURRFUZRRxPLx0WCAYn9OFUwwYVZKOFYNcCnb2FB/XDsnGUOJZw+ZV86a1keUsKioqMCJEyeQlJTU5bbExETMmTMHX/7yl5Gfn4//+q//cvdxKoqiKIqiKKMYTqRXTYyRy3CBpWqNruIDRWyIP5IjApFX2WAzFrNTRl4Xcw+TvR1+lFNTU4OwsDBUV1cjNDR0qA9HURRFURRlzMKSrxX1LZLyw9Sk4QKb1X1wuAiHC6rl+vTEMFwyPV5SrAaCxpZ2bDxRIubt0AAfid5kRAdhpM2dtSqUoiiKoijKEEKD8fGiGlTWtyItKnDE5dW7QkeHCa/vy5fzJp4eHlK5aUEfzeQGi0+Pl+BgXmeVKv7t5+2JddPiB+T5Any9cOmMBIx0nJZdO3bswK233ioGbX9/f/j5+cnf3EafhaIoiqIoiuL4yvizn2fhjX350reBf396vHjUD9/xolqLqCAdJpN0x65rbsNwgD0u7DnazTalHxGLN954AzfeeKMYt++8807ExMRIG/KSkhKsX78ey5YtwyuvvIJrrrnGmd0qiqIoiqKMSVj5h+lA1mw/W4F5aZHDKjXI3Vj7CayjGOx+PT42pMttB3KrsDenUqI77O+wKCNS5qADBXtZ1NsWaoKf99hreDegwuJHP/oRfvOb30jVJ3seffRR/O///i/+3//7fyosFEVRFEVRHKDErswoof2V5UdHs7CICfHrso1CISqo6/Z9OZV471Ch5XpxTZN4EpZPiB4wz8OkuBA8vz0bDS3tCPLzQnJ4ABakRwzIc40mnHo1zpw5I5GKnuBtp0+fdsdxKYqiKIqijHq6a8bGikAJYf4YzTDqkBBme+7z0yIQEeTb5b57sittUqbOltbjDxtO49cfnsDr+/LQ1NrZ4M4dcH+H8qtF2Hl5eqCptQOsDTUSqzQN64gFvRRMh7rnnnu6vZ23paenu+vYFEVRFEVRRjVTE0JxtKAGp0pqLav2F0yOQ5DfyK+vw8hLTWMbAv28ukQWeJ3N6ei1YFUomtbZoK472jo6C5jmVzaipLZJzN4UGRw7b09PXDkr0a3+ivrmNomqWEdWTpXUYUqCVhTtDafetY888gjuvvtuvPbaa1izZo14LEhpaSk2btyI999/H88884wzu1QURVEURRmzMDpx04IU5FY0oLKhBamRgQgP7LpqP9LILq/HOwcLUdXQIt6ElRNjsDDDtuITe0MwctEX0xJDsfmkuSN3eX2L/BttNeGnEHCnsLAWMvZGe8WNwuL2229HbGys+Cx++tOfSl1bwpq2S5YswXvvvYeLLrrImV0qiqIoiqKMeVhidrSUmeUE/NU9eWg8n6LU3NaOj48WSXqXK+e4bFw0mls7sC+3UsRIjL8P0iKDBsxUPSk+BOuPlaC9o8PGzD2hG1O5YovTcTYKB0M8NDSYHf2BgaPjg6AoiqIoiqL0j5yKBouosOZEUa1LwoJRHfa4uGBKrPSTYCTEmgUZ7jVVh/r74IZ5yVL+tryuWTpjr5sWJ70mlN7pVwKfCgpFURRFURTFZn7YwwS8p+2OQv/JrJQI+Hh5SelZejiYSjUn1TlhQU/HhuMlyK9qRGyIH1ZPikW8nVl+fGywXNraOyRKojiGyyP1ySefdPu3oiiKoiiKMnZhtSd7I3agrzdmuqmq0tTEUNyxOA13Lkl3WlQwTYtlZNmcr7apFWdK6/DCjmwxa3eHigrn8DBR7rmoGo2HWv893KEvJCwsDNXV1eINURRFURRFUdxLS1sHdp6rQHZFPaKCfLEoI6rbUrKDDY3er+3N67L9oqlxmJ8WKWlX/aGjw4TqxlYE+3sPWI+N4Tx3Hvm1zBRFURRFUZRhBc3ObGC3HNEO3Z8pR/Q0HMirBuf2s1MisHZyrPSRcCcsUWt/Pbu8Af/ckYNPj5ciPSoQizIjxRxuLTJOFdfiZHGdNMtjlKS75oXnyurxzoEC1DS1yvmvmBCDxZlRGEuosFAURVEURVGGlE+Pl9g0wtt5rhw+Xh7if3An9E0E+HhZzOV5lY3S5Tw+1B9HC6qx9XQp1h8vwYykMDFwJ4YHYNPJUmw5ZS53S/ZmV+LuZRmItIrAsPLVq3vy5F8jYrP+WLE0QBwt1b4cYXTEaBRFURRFUZQRy+H86i7bjhSY2xoYVNa34MMjRXh5V64Ij9MltXj7QD5e35snXglH0vJZmva2RWnSL8TL0xPNbR2YHB8ihm72ESFldc3iv3j7QIF04d5+ttxmHxQlfH5r2Iek+byosOZksbnx4VhhREYs2tra4OXlJd4ORVEURVGU4QS9BbuzK9Debq5axOZw7k7pGW2ISdquRK31mNG38NuPT6Cgqkm2N7a0S8qRkdrE1KTLZiTg5gWpfY41K0DR+E3+vOmMlJRl5MLyvOfnlxQYJbXNkqZlD4/H3pzeHT1tH62MqIjFm2++iRUrViA8PBxBQUG44IILcPDgwaE+LEVRFEVRFGFPdoU0g+PqOie+286UiXdA6Z253VR3mpfWue3FHdnYn1uFktom5FTU42hhDXIrG2DM+TnRZyoVzdnOMP/8c/j5dE6J40L9LdGNhFC/bjuhZ0QH21xnylSaXSWsID9vzEzuu7P4aGLECIv29nY8/fTT+MUvfoHy8nIUFRUhISEBF198sbjUFUVRFEVRhpp9OVVdtrGpm9I7y8ZH4aKp8TKp5+WS6QlYkB4pt7V3mERUGLS2m6Qrdmsb/+1Mf2poaUdRdZNTQz0/PRKXz0wUYUMBQcGQGG4WFkvHR8HH2wtXzUoUkWAwOT7URvQY3DQ/BWsmxWJcTLDs956lGTaPGwuMmLNl6tMbb7xhue7n54df/vKXSE5Oxo4dO7Bu3bohPT5FURRFUZTu4NyX+f+awt0zHJuFGZFysYdGaOsJuq+Xh1Rsoqjw8e5Mewr287ZEG5xhdkq4XO5oaBFhSA/FpPgQEQiE5uuvr52AgqpGOQ5r07Y1vt6eWDo+GksxdnFZWDzyyCPd/j2Y5OTkyL/R0Y6VMlMURVEURRlIZqWE46MjRbbbksNUVHQDBQMrP/UluAJ8vTAlIVSa2BVWN4kfIyrID/4+7ORtjljEhPhJ2hGb57kKIxZrJndfhYq+jbFU3WnQG+QNNc3NzeK38PHxwZYtW3p8U/J+vFg3+UhJSdEGeYqiKIqiuB1Oqz4/Wy4lSZmyw7KlqyfFaAdnK7LK6qW6E83RnMyzOd3EuJBex7Wkpgmv7MlDWV2TpEBNSwzFmimxOFpQg+bWDkyIC5YIg0aFhrZB3ogUFqwKdfPNN2P37t3YunWrpEP1xE9+8hP89Kc/7bJdO28riqIoiqIMLqzm9IcNpyRaYcC0pq+uGtetSdq+q3VhTRP8vT0RFew3CEerDJqwoHmaxMfH97ptIEzct99+O7Zt24ZNmzYhIyOj1/trxEJRFEVRFGV4cCivGm8dyO+y/cIpcVg0jLtUUxCxT0Vv4qe8rhkfHilGTkUDooKYVhWD8bG9R2JGm7Bw2WPBikzEWpd0t83douKOO+4QUbFx48Y+RYVh8uZFURRFURRFGVpocLaHE/aGljYMRxglef9wkVT2Ys8MmsOvm5vcxcDN+724M8fS34JlcZm6df/yTPF/jBWcEhanT5/G+PHj5e8XX3yxy+3dbXMXHR0duOuuu/Dpp5/i/fffR2RkJKqqzKXHAgMD4evbe/hMURRFURRlNFNa24zdWRWobW7DhNhgqXQ03DwH42ODZdW/qqFFJuOnSupQ19wmXbDPlNbjhnnJfaZE9RdWk9pyuky6fdM8ztKx89K6VqMiu7IqsD+30nK9uKYJb+3Px93LbBe3sysaujTN4/kdKajG6kndG8JHI06lQvHNOVSWjIqKCmRmZnZ72//93//hzjvvdHs4R1EURVEUZSRAI/TTW8/ZeBfYm+HSGeZskuEEGwduOVWGzSdLZaLu6eGBqoZWmGA2Zf/kqukD2qn8k6PF2HGu3GYbx6m7Jn3Pbc9GTnl9l+13L03HrqxK5Fc1IibYD+Nig/DBYdtqYGTFhBjpvD6SGZRUqMHGOkKhKIqiKIqidMJIhbWoIGwqx0ntcGvSFurvg8tmJEhfiNqmVvEkWB/z+mPFWDdt4Py6+6wiEJZtOVXdCosgX5a0tYVm81f35suxE0Zf2A08xN/Hso2wLC6rgo0lRkznbUVRFEVRlNFAW3sHtp4uw7OfZ+HN/fmyat9f6prbu2yjJ4DN3oYrIf7eKKltsdnm4+WJQ/nVA/aczLyxatZts90epjJNjA853ymjk5TwQBsBQZrbOqSPxrTEMBEYaVFBuG1hKiJ6aKY3WnFawj788MN93ufRRx919XgURVEURVFGNa/vy8fJ4lr5OxfAiaJa3Lc8o18lVOmpOFFUY7ONk1pWJxoI6CeoaWxFQpi/yz06lmRG47W9thWiEsMDJDXKnVAgNLS2S/SBaf0zk8KwN8c2ajEzOdzm+rmyerx9oEAEBEVDmL8PUiMDMTkhBN6eHjhTVofK+lYwY4vjzH/9vL1wzZyx46dwi7B4/vnn+7yPCgtFURRFUZSuVNa3WESFQWt7B/bmVEmjOFfhanlRTZNMmDmRjgzyw3Vzk9xu3ubK/ruHCnEwr1r+DvD1xrVzkpARHeT0vlKjAnHX0nS8uidPoisUQZykz061neT3B1Zz+vR4iXTt5r4vm56AC6fGybjQWO3t6Snm7QXpETavx2t789B0PtrDvhmsXLUwIxLp0UE4U1KHw3nVaGoz3+7r7SViZWqCenedFhZZWVlue7EVRVEURVHGElz97g5jEusqnChfPC0eKyfESOlWlkMdiIpQh/NrcCC30/Pa2NKGN/bl4xsXTHDJcH3p9HhEBPqK74HZSBRIy8ZFu+VYWfL1nYOFljQnirpX9uTi62sn4JLp8XLpjtyKhm5fDwpCCosNJ0owPi4Y2eUNqGtqkwhGYrg/wgJ9xOfCKAcrWw2kAX24MrzcPIqiKIqiKKOYuFA/S7lVaybHu6eRWoCvl1wGirNldV22UcgwWpIUHuD0/ih+loyLkou7YYqZvXeCE3+mOU3pJbrQk9k92N9b9kdPTLCft1SwMqBe3HmuAptOlshzBPvRoB6PCXEjv0GeM6h5W1EURVEUZZDgRPrGecnSaI0wL3/NpNgRMwENC/Dpso2eiFD/4bdWHeDTvcDy72G7AV8b9tuwFxuzks19QbpreOfr7YGPjxZZKnPVNbfitX35/Y5EjTScehc88sgjA3ckiqIoiqIoY4DYUH/cvyJT8v79vD2dMj/TP7EzqwJHC2qkizXz/icOoiihH4ElYXnsBnNSw6US0kDA52G/C5akZXoX+0LEh5lFWV+wQhMb4VkfK0VDelRgn4+9fm4ydmdXIqe8QbwZHGcjknHhlDi8vDsP7R1mERHo642YEH8UVTd1qf7VV3RkzDbIu+eee/DTn/4UqampfXoweL+nn34awxFtkKcoiqIoykjl46PF2GnX3O3G+SmDKi7oIWDfB1aGyowJEtPyQPg5OEV9css5m3K8FFNfWjmu28hJdzDlbNuZculKnhwRgKXjot2SKsYmf0y1or+CwoFdvD880rVB3heWpCMlsm8hM+Ya5KWnp2P69OlYtWoVrrzySsybNw9xcXHyohcVFWHXrl146623sHXrVnznO99xx3koiqIoiqIo52nvMHUpk0p2Z1UOqrBgdGIgu0kzfeh0SR1KappRWM3O3J23MdWIk/hl4x0zeNPPwmZ8A9Hkb35aBHZnV+DdgwWYkhgq2yg4DCgoRrqocBZvZ9Kg7r//fjzxxBP4xS9+gXPnztncnpmZiVtvvRVPPfUUEhMTB+JYFUVRFEVRxiwsyUpxYU/L+bKnowF2435pZ4409mO04WxpA6Ykhtj4JVrau6+sNZiw/Owjbx6RkrWEEZt1U2OxODMKZXXNSIkIxDyrErZjBYdToewpLCxEbm6uDGRycjISEtyvBgcCTYVSFEVRFMWZCSRTfiIDfV1uBOdOXt6di1N2fTDWTYvHgvRIjAbYjZzlXg0hxZQrRkgmxpnN1LVNbeKdYGnXWclh0uF6KHj7QD7+uvmszTZvT088fsvsITumEZUKRTo6OuDpaf5QUUiMFDGhKIqiKIriLM9vz8Y7BwvQ3NohhuGvrByHWW5s3uYKV8xMwLsHgVMldfDx8hAzNVNyBhL2bzhVXIcgPy/MSY1w2N/gCgVVTTbVpliGl+lQRg8QRityKuqBCvbUqMY1s5Mw1ars62BxvNBW3JG2jg7ZPtqEhTM4Jb1XrlyJs2dt1ZmiKIqiKMpog5WI/rUrRyoKccKYV9mAx9efsqkwNBSwAhHN2t+/eBK+c9EkrJ1s7iI9UGw8UYJXdudif24ltp4uw5OfnZVGcwNFrF0pV1ZiYiO7/7h0iqQXsTu3AZNutp0pw1DQXadxL08PaaA3lnFKWERERGDWrFn461//OnBHpCiKoiiKMsRsOlHaZVt5XbOsklfUt3RpvDbYMC3Lc4A7O9NEvf1shc02eh9Y7naguGBKrE3KGXtOrJ4UK5N2VqOyp6apf0KPJWGZeuWsWLp8ZiJSIztFhAc8pOKUkbI1VnEqFertt9/Gk08+iYceekgqQP39739HfHz37dAVRVEURVFGKv6+Xddea5vb8Pq+fIT4e0u1oatmJY7aqj/0lby1Px+7zpXL5J6lWkPPp0BVN3Sd4HcHvSCsYtXabsL0pDDMTgnvsTeHIZKYRvTA6nE4XlQrqVAsZWuUhx0fF4JDeVU2j7VvZNcbNINTD7IvBckqq5cmdo0tbRL1YSftK2cmOiTYeEyP3zwLnxwrRk5Fo/TyWJAe6dboEcf5QF6VVMJi1SlXOpuPCPM2e1Wwr8WhQ4ekUpS3t60+efTRRzFcUfO2oiiKoih9wQndo+8ctXROZn4/Z0yrJsXAwyot6etrxw8LU3df8DyYzsWSqGzQ1xucGv5l81mpbsRmeM2t7TLJn5kcJiLDEbP48aIavLonz2bbqomxWD6hs0wsIwXs/cA+FdHBfrhwahzGxfQsFBpa2vDq3nzklNfL9dSoIFw/N0leh95obGnHq3vzkH3+cRSD9GY8tfVcl9Q2RiJ6EkCDSXFNkxjZjU7eFCz018xMDh895m3rnhY33XQTNm/ejOeff35ECQtFURRFUZS+mJUcjm9fNBFv7MtHZUOrNGZjfr+H3UQ3v6px2Jt1ab7mebSeL9PKnhfXzU2W9KLuYJdrpn3x1vExwfJ4Pra0rhnrpsZjbmrfZvGd57qmS7GxnyEsKHRe2pVjmThTxLyyOw9fXd1z8zsKiDsXp1nSlozIQ1+sP15sERWGoGHkqTu/zLmyumEhLLacKrOMjSH2Np4oxYyksAH11PQXp4VFQUEB7rvvPmmE97e//Q333nvvwByZoiiKoijKELJkXLRcDDP3Z6e6+i76Wi0faugheOdAgUVUEAoFRmR6EgjWuSxM+2IlKE7Cl4+PxhWzHOtVZkR6rDFHfUwyMWaVKeuJM2nv6JBj6ysa4qigMGCzPXsoCJnyxDQsa6xFDc+B3bVp3p8UH4pgv8F7rSsbuno+6DFp6zBJNbDhilOxu5deekm6bzc2NuLgwYMqKhRFURRFGRPMTg1HgJ2ImBAXghi7KkYDRUlNE9YfK5YL/3b4cbXNYri2J6fc3CuiO1IjA8VDYsDABvtGLMqMcvh5J8d3TZmZFB9iWW337mFy3N5uwp7sSol40OfhDroTBIw+LUiL7FKBav55UcMIyp82npFywx8cLsITG07bRD0GmtRuvDsJYQHwGeZpd05Jr7vvvhs/+9nPxLxt9LNQFEVRFEUZ7dCbcM/SdOyQCW+LpD8NdP8Ig9MltZImxIZxhFWZbpqf0qsfwXoFvruV+cheVv15/1sXpuLjo0XIKm+QSfjqSTFOiahl46Olmd3B/CqJgDCl6tLpnf3PJsQGy7HZi4fNp0ot0ZVPj5fgpvnJyHTgPHuD6Vev7c2XaAk7lzOKs3RcFGYkh4vfghENc2QmXJrxkY+PFKOuqdVi5OZjPj5ajPtXZGIwWDkxRqIq7EROgv18cPnMhNFl3j5y5AimTZuGkYyatxVFURRFGUmww/OR/Co0tnYgVCpS+SApIhD3LMtw6PEbTpRg2+nOfg+MRty9NF1W6PvL0YJqbD1TLmlMF0yOkyiONUx3oiCi6bu7Kk2bT5WhsKoRsaF+qGlsE4O5NRQzX1o5rt/HyQgNPR1MtaKoyogOxtWzE5FoV2mJx/TWgQK5UEzEhfojJSJAIi28/OiyKRhMCqoaZQwpgHryxIxY8/ZIFxWKoiiKoigjCU4qN58ssazsF1aziZw/Av367n59pKBaTMBVja2ICPSVkrHxYQGW6k49QXP00cIaMGtpWmJYj2bq9UeL8fS2c5Zj+/BwMe5bnmHjw6DpvSeMkr0GTD2yp7S22eLL6A/Nbe0SCTEa21XUN+Pfe/Lw4JrxNuVlaermZJ7pUzSw82+OFRv3xfdRTWsgsBc+w53h7ThSFEVRFEUZJdAIfKK4FoE+XpibFtFrOpLBofxqeNmln3OyHd3HY1n5iJWgrM3AnORfNTup18edK6vHv3blSgSCUJjctigVyRG2Of80Nr97uNAmlYkm5zcP5GPFxJgexQihUDhbVo+SmmYkhvtbqmrxb074raEQckcVJI57d2bogupGy7nV8Pr51CN2+a5tbENLe7s0RKQou2hqXL+PY7SjwkJRFEVRFGWAsa8qtS+3EnctTZfoQ29w1TwtKlAM2GzkZjRnm5Ec1u3965rbJMrxt81nsT+vCt6eHkgI85eVb/ZG4IXpPT2x4XiJRVQQrvJvOlmK2xel2dyvoaVdJub0LHDab6z6N7V2oLS2qUdhQVHxyp48aZ5nMCslHFfMTMSqiTEiiAyx4ufthXVumswH9VC9y7qql+/5bub0o/j7eMpxUZClRwVKOpbRqE/pGRUWiqIoiqIoAwgn+p+fLe+yjZWPOKHuDa7m78qqkPSluiazsKDHghWW7NOX3thvTuNhZKS6sQ0dHR1oNXlIXwo/9uEI9pP0pt5gNaQu22q7lj6lI5v9PVh1igT6eon/gylXvTXgO1NabyMqyIHcKsxLi5CqR19ZNQ6nS+vQ1m6Srtq9pWw5A43ZrDbFlCgDlpC1jhrxuWYnh0u3cMICTEyBun5esogK6w7hygAKi+joaJSVdZqCFEVRFEVRFDOMNtAIbA/Nyn0xMS5YqhcdyquSykWc2F48Lb5L/wx6AwqrG9HSzgl/C1rbzdWPjFX20roWzEqJ6DNCwrQgNomz3dY1z5/mZlalYulbRi94YfUodsJmBa2e6KlUbnFNswgLdjHvrlRtfxHD+rJ07DhrLmNLr8WC9K5VvTi2FBs0eXOMF2ZEoqi6SfwYPMfM6CBcOiOh11SvsYxbhEV5ua0KVxRFURRFUcxwEhod7NclGpAZ03fHbvoLaHBekhllyfW3r+bEiTJFBfE8/xgu9Af5+Uqkgo3pmM5z4/zkPp+PPoJ/7mhGXXOrZUK+dnKszX3YLI+lUBmhuGhqPIqqG6VxG7uVr5pke197EnowIyeGDbwxmq9BXyVbKdzYr8Po2cHoyodHiiy3nymtw6t78nDvcscqco01NBVKURRFURRlgLl6dhJe3Zsn5Uw58Z+SENJnh2n7sqs99ZGgeDC8AWw8x8gBRQwn/kwn4vOxLwXTrz44nIfcikZEh/iKp8HelM3n+NqacWLi5uO4sm9f5pQmcEYWGBHhTUblongHxAEFzvSkMBzOr7ZsW5QR1W36FP0Yx4tqJQKTGBYgXhN3GLkdgd4R9rdggzxGKpjqZUARR5HniPl+rOEWYbFs2TJ37EZRFEVRFGVUwkn3A6vHScpPgI+XdLLuL0YZVnoD5qSYPQSEDeW4jWk78eEBWJwRKZ2c/7zpjAgbwohEfmUjvrxqXJe0HooG+34U1rD7M9OIPj9T3mWlvy94vBRZ7HDNtCiKku7M5DRx/+bjkzhTUivChvdbPSkWN85LHnBxQR/G89tzJBJDTwjN6OlRQTbCqa+eEmV1zfj0WIlEdijW1kyORZIrpWPZbm6QxNSwERZbtmxxx24URVEURVFGLZwQO7Kq3xecdH90tFgmvvRMXDg1DuumxkuqD8uqBvl6S6qO9USWq++GqLCu+MReF0vHRTt9DGsmxSIqyE+M4v6+XtKFvLueC6wcRSN2hN3qPo/N+vgaW9olEsIJOyMh/9iWJaLCiB7wnHdnVWB2Sjgm9iJ63MG+nCoZWxIXak5howE+OtjXLLpiQ3r1WLS2d+CF7TmWdLLs8jb8c0c2vrp6vPTHcIjDh4GXXgL+9S/g/feB8eMxEtBUKEVRFEVRlBECJ+DsM2FUNyqpbcILO7Kl18Tc1AiJBPQU3eh+u+siieVYeelpcv3W/gIROnxuio7r5iZ3mZAzavH2wUKZyDOSs2x8tEQwyuq6VqJi+hGN1L0JC3ogtp8tR0NzOybGh2DZuCgRA87ATuBFNU2oqGuRSAz7a7AiV4Cvt1SvWjEhptfHny6ps4gKA6ahHSus6T397fRps5CgoKCwMOC2//f/MBJQYaEoiqIoijLMYL8JRhM8PTwwMzncks9/qqTWIiqoCXLKG2QSXHx+wn3NnCSkRNr6Jgi9EsF+PjYTXjbem5rg3gpMbN5Hczcn+MeLaizbWQb3vUOF4vUwKKttwvM7skUsGdWzPjlWjHXT4hHk59VtClZvER+OBUWXIaIouliGl2PiDBzPrLJ6y/XqRg9MSwzFNy6Y0K/yt6beRNxXvwr8+c+d1319gUsvBW65BbjiCowUVFgoiqIoijJqYEO5A3lVkn4zLSnMtbz2IYYr2+ya3XF+JrrjXAVuW5gqgsE6t7+8rqWzGpSnh3SOZtnZB9eM79Jvgav2ty5KwSdHS5BbybQeP6yZFNMlRclVmL7E52aZVuMcGKWwjlDQEM771TS1SWWls2V1OJJfg8hgX4yLCRIRZYgq9u2gSDHOj6JiybgoTIgN7vEY9uRUdInM8DhYQtbR5nZMu2KVLaYssdmgYDJX9nJUVIyPDZZStQ3nGxoax0/DvlBSAvz738CNNwIx56MfM2cCXl7ABReYxcS11wLh3UeDxoSwKCoqQmRkJHypsBRFURRFUQYZ5uG/sCPH0jl6d3allGplFaKRxMYTpRZRQTgZ/+xUmaQ7MSoR4u8j3gXDM8FJa2SQj0yqOQafHi/BgozILmlH9GNwHwPBvtwqi6gglAg0PtNUbniPOTGnMGKlJUYTvD09YYJJxGCgjxeSzvfL8Pf2wiXT4pEaGWQWiR0dWDE+pse0KwP27rCH49ja0YEAOC4sOkyQCEVVY6ukMHEce+tWbo+PlyduX5wqIq7gvHn7ggRfhLz4vDnNaf16oL2dahD4ylfMD7r9duD664HY3sv1jkphceDAATzzzDP43e9+J9fvv/9+PPnkk4iIiMAHH3yAhQsXuvs4FUVRFEVRemXr6TKLqCCcaG86WdovYcGJJhf/B6vMKbE3WdM8nF3eIMcxOzUcdy5Ok/Oi54DnmBQRCE944Ghhrayyc3We3brZyI1m58GA0Qj7fhUsFcv0JqNU69JxUdJTg+KH+Pt4Sp8Mni9LylJYMLLCLtne5yMUvDgKxYB9V29GeXpr2GcPDeSMntAnwS7iBlOcTBmLpYibGQO8+Sbwp5fMBuwWq9d1/nwgyurcQkPNlxGOS8LiO9/5Dn784x/L30ePHsXLL7+MjRs34uOPP8Z//Md/4NNPP3X3cSqKoiiKovRKZYOtYZZw0mqUZXUGpsPQE8AJM1fa2aDOmUluf0iNCrTk+NOsnFVej5gQf/Et8HLlrETxDbAy05NbzsrkvbC6SaIYvB/7WnCl/uOjRZJ+4+ftui/AUSKtJuGEq/xMZ5qTYu5uPS0pVDpqU6jxeAyfCCMwXNXnhH5qYiiWZEYjKrj7fh19MS0xTF637WfK0dTWIQLhshm9N8TrjstnJuKdAwU4W1YvERaKs4VO9ByxUF8P3HGHOTpBpk0zpznxMkKqPDmLh6mnMgG9EBoaKqlPgYGBePzxx7F37148++yzqK2tRXJyMqqrO5ueDDdqamoQFhYmx8jzUBRFURRldPDB4UJLLweDtKgg3LE4zel9PbP1nPQgMLwMjBqwos8VsxLFCD2QMDXopV25IopY+tTb0wOTEkLh62UWR0zLuX9FpvzN++w8VyHpUzRNM+3GWkPdvcy27Kwr0OfA/ZfUNEtUgd4M+8k/J/RPbz0nx2DA6kkrJ8Z0G1naeKLEcp1+EEZh7Jv1uQqntkxn6qvXRF80tbbL2PdZVaqtzZze9NJLQGkp8M47nbcx1Sk62iwmpk/HSMSZubNLEQsKitzcXEyaNAnvvvsubmdeGJut1NUhKGhgP2yKoiiKoijdsWpirKzccwWcMM3m0unxTg8WJ+uGqOD+ssvN0YPd2RWobW7D9XOTMSl+4HopcNL+1VXjxGTN1CGu5ltPkY0qSsY5sopSsL83NhzvnKwTTojZhbs/UCiwJ4MRYThR1Crjy2Z/1hNuRigodg7kVqG2qU0MzLx0B0vKssoVjdWMXrCEqzv6exgwOnVeg/WLXs3aTLljHzeKiVdeAcrKOm/LyQFSz3tZrCs9jQFcEhbXXnstrrrqKsyaNQu7du3CSxxUAB999BEuvvhidx+joiiKoihKn9BbcM+yDEkfYh+F5IgAl7wRnDDzcVz5Lqxqsmz3PL+NfRIGUljIc3l6SLRlYUakTNat6e652cOCFZZoijZYNTGmX+VRydHCGouoIKW1LTiQVy19J5aMi8aFU+IsFZdYSYmiwRHoWXDWtzBsePppgJaA/PzObdHRaLrmOhxafgnySz0w3qtaPB+D6c0ZscKC6U+8ZGdn48MPP0TUefPJ/v378cgjj7j7GBVFURRFURymv6vfnCBPjg+RFXVWFCKcILILM2mwihgMNJy4N7d2SKM5eihoKI4P9RevgnWqDwXEPcvS5X41jW3iL4h1opJRT3Qwp+g8VQ2tOFNaa0kTOphXJWZx694UoxI2q2O1JqNik4+PWVSEhQHXXSdpTuULl+HpHXlmEVZUiyNFtSJw2RV9LOGSx2Ikox4LRVEURVH6ghEPegFe25uPivpmm54MNHGvnTy4E8b3DxVKpSdDTNCPcMO8JFTUt0ovCoohd58//QVM/frTxjNS8vZUcR3K65ulnCoNzcaxfP2CCU5VXhoRsAs2M3J4OXIE+OUvge9/33xbbS3AQkWXXAL4+Vlen705tv4eNiD81oX9a6o3JjwWpKqqCk8//TSOHTsm16dOnYq7774b4SOwmYeiKIqiKIo1nDyvnhQrhu039udLlSZGLVhliabkwYTdo9knwjpCsT+3CofzqxEe6CMpWosyI90idtiUjtWw8iobEOTnjRUTonHLghTpjcG+FKEBPkiza9TnjmQfRkB2Z1WioLpRIjIcd0eb2rmN3Fzg5ZfNYmL37s7t7NFGU7ZBSAhw9dU2D6WvpMNk7vbNvwN8vMRkz+jWSBcWzuCSsNi6dSuuuOIKMWrPmTNHtr333nv4r//6LzFzL1myxN3HqSiKoiiKMuhwcn37ojRJ+fHy8Oh2ssvb1h8rxtnzE29OxllG1RqWrT1RVCuP52q/ffO63mBFKusEE3YVP1taJxNXCguWlv38TDkyooP7VbGKz/HKnlwRMoZx+4PDRXL+9K6wwtNLO3NsHjMuJlga9vU33er57dnScZuwF8Xxohrcuyyj74pM7qKpCZgyxVwiljjZBXtcbBDePlhg04OE4xfgM0jHP5KFxQMPPIC77roLv/71r+Htbd5FW1sbvvvd78pt+/btc/dxKoqiKIqiDBm9pRr9e3eupYpUQ0sb/r0nD19Y0lk+lZP+T48XW+6/O6sCdy9N71KylRN6GsPL6luQGhmIRRmRstpNzwijEkY3bq7qszke+1Ww6hMrQhGKjf4IC1bAMkSFNfSapEcHiYi4enaSnA/FFMXTBVP63ymavTkMUWEdOTlZXCe9LdxOVRXw+uvAjh2dVZv8/YErrwQKCsxiwsku2PSz+Hh5gP+xmzirXbE0L83v89Jc6IExloTFyZMnsWHDBouokB15e0vTvL/+9a/uPD5FURRFUZRhCyfAhqiwXvk/lFctwsLwatin/Ww/W4HLZybYrG4/sy1LhAnJKa+X9Ku7lqZLRIBpWRtOlMgEnF24KTHYGO9IYQ0mxYVI5IKX/qZ/9bWdXcz708m8O+jj6A6KF7fBSMRbb5nTnD74oLML9je+wXx+89/PPccJrWu7b6ZhPhgpER1o6+iQVCimztU0ufEcRgAujd6ECROkIlRkpK0Cy8nJkdsURVEURVHGAlyd7g3m2FuXazWoarSNDBzKr7aICgP6HHIrGpASGSiGcVaq+s1HJySVir0kKs93FeffGTFB0nm6P7C5HiMTRtdvwlSkWSnhNqKInord2ZWSshTo5y1dyXmMrsIJuXVEhnBSzspW/WbXLuA3vwHefhtoaOjczmZ1jEycr2wquCgqSFpkkCVtyxedQmx8TPe9PEYrDo9gmVXjjwcffBA33ngjHnvsMSxYsEDe1Lt378aPfvQj/OAHPxioY1UURVEUZQzAleqPjhRJKkywnxeWjo+WPg3DkdgQf6kYZTTlMybFM5LNk/xQf29EBvlJZSlr0qNsJ83WTe8M2PH7zf35EvlgEzlO3un54AR8QlyIeC9oFI4J9sU9SzPcYhK+YV6yRFjoF6EPhGNPwUFT8jsHCqULd05Fg6T9JIQFWFKZ7lqSLuPgCnyeK2Ym4qOjRSJcmEbEFCv7VDGHaG01+yVosCaFhcC//mX+e9w44NZbgZtvdnsXbHpnrpqVKNWhGEliRahl4/snuEZ1uVlnGnwM5wq2Wm5WURRFUYY3z32eJZNXa25ekILxsQPblK4/QuiTo8UyweYkmU3irJu/MfJA3wXTZYwV+uvnJdukGFGYPL31nNV1cwfxOanmsq5c0ecYsHLSqRJzLwkD5vBf4kKHcWfmdX/ceEaMyS3tJuzLqZRtjKCw8zeZmRyOK2cl9ut5mDbGKAx7dfSUltVrF+wXXwT+/W/gy18GHn3UfFtzM8AeazfcAMybxwktBpK29g6U1jUjPMC3x6pWHLtdWZVS1cvby0NEY3+jTSOu3KwashVFURRFcTdcoWb9/5KaZiSE+cuk215UkIN51f0WFmwqx0mdK5WG+NjPTpXiWGEt/H08pSO2MRmksfuaOUk9PpYRh6+vnSACg5NNRjns4Wr/JdMTsOlECRpa21HR0IKJccGWsq5S+elsuazs1+5pk87XhJWgVk8a2PK3NHUb1Y5YwclYQC6vb7EIi+Y2cyPB/kAx0d3YdAuPgWlO9EwwIkHTtcH69Z3Cgn0mfvELDBbeXp6WSE5PbDpZauO7YbobT8fd3pWhwGFhMXv27IE9EkVRFEVRxhTtdmVGjxRUS38GTlvt15Wt+ya48jxMrTqQVy2eiKkJobLCz5QbR2HZ1f25nQ3Q3tiXD29PT0yKD5GV9gO5VTIBZwWnWcnh8PX27HL8aXbpT/Zw5Zr+CXbYfmLD6S63NzS3y7lcPiMBHA5OxNkcb6CxTrGiqAry9UZ9S5ucvwH7ewwanIUvXGjba4JdsFnJiWlOa9diuGKifSDLtpGeUSlsTAmL7sjNzcXx48dlkKZMmYKUlBT3HZmiKIqiKKMa9nWwLzNK30B4gA+qG1tt0rE54XaVzadKbboiSwqKp6dNVabeoHA4mF/VZfue7EqJKry4M0dWncnBPPP+6TnwdEEMUYAwCjA+NhinS+os2ykoWGb2TxvNgoP+gxvnJWMwiAyyPR76O7LK6xEb4ifijM35BjSV59Qps/n6oYfMqUy8cMH76FFzozqasC++2NIFe7jTytQt+23tw9dGMODCora2Fl/5ylfw4osvWsJh/NDfeuut+Mtf/oLg4LHlgFcURVEUxXlqmjrFgzVMM6psaJWJbJCv2bzd12p/bxwtqOm6rbDaYWHBNKTu7KPtJpN0ozZEhQG9EYcLqsUrwEk5DdfOcumMBLy+N1/SpzjHYvYWOzsblNc1491Dhbhpfoo8P5/DVfO0I1w3NxnbzpRLrwz6SL62ZryUt2XUpD/RpF67YDPFialOe/aYty1bBixaZP6bqU6PPw4EuaFy1CDi4eEhETOKT2umDUS/jpEiLL797W9j//79+Oijjyxdtj///HN885vflNu0l4WiKIqiKH2RGROE9cdst9GkPCkuFGGBPrh4mnvGkI3k7PFlZ2WHH+8lzeBOFNkKlBlJYTaRFYOSmiY8teWcVFNi1GL5+GismNDVB1FU3YSDeVUy2ZyZHCadtA1C/X2khwX37+3pIVER++gOe2VQxDCaYfgtbpxvawp3F9znqokxcnEUTp53nKsQHw2N3uzc3euxsQKpISZoxjbga3Xhhbb3jYvDSOXiafEiVNl4kKJsTmoEFmdalb0dC1WhrImKisKmTZsw3a5U1+HDh7F69Wqb0rTDDa0KpSiKoijDh53nKqTxG6vp0Jdw4ZQ4mWi5E/o23j1oZe4FsGZyLJaOi7aUeuUEn76BCbEh3ZYI5eT4wyNFYt6mUGFXbEZS2AH7z5vOWDI42LNif261iI5Aq6pAdy/LQJJVRIE9IFgpyujdQEFFUWAY1LmfTSdKcep81IaN1ui9MODDOHGfnhRqU7nzgilxfU5Seax8vCupWo5ysrgWr+zOtdlGDwE7d9sdTGelpo0bgTVrzH9z2/Ll5vKwrOgUM7AG9aGgvcMkXqKBfB2GbVUoa+rr65GQ0DV8GB8fj7q6znxARVEURVGU3mDaE1frOUGPCvZ1ylDtiDeCK/7TE0Nl1Z9lUrm4zwkujdKEtz+zNQt1zeZJ++dnyrudnNPAzEnx1Xa1bJjqdNHUOHx63CyO6prbRZhYiwpyrrTeRlhsPlVm0xCOf28+WWYRFm/uLxDxQaoajC7UHtLXg7BXAiMi9u0AWFGrJ2HBiewnx4rNBnkZh1BZPR+ICAfHuruUND6ff3NjZxfsiROBX//afIcVK4DLLgMuuAC46SYgeXA8JEOF1zAXFK7gkrBYuHAhfvrTn+K3v/0tvM93KWxra8NPfvITLDJy3xRFURRFURyAk3Z3+wM4seVkn5GGAF9vXDwtDncuSe9yvx1nyy2iwoBlZdmQz76yU08sSI/E9MQwMZ4z+vHKHtuVekI/gjXV58u3WlN1Pq2KkQlr47ZR0paChelSLW0dmBAXLOKDYsaaqF6qRPG8WH3IgJWsKLhY5tbd2B0WvFqaMX7PFvg89Z/Ae+8CjY2dKU2//KU53YmXd991+7Eow1xY/O53v8O6devw2muvYe7cubJt7969aGpqwocffujuY1QURVEURXEYTvDfP1xkSU9qbGnDWwcKkBoZKP0WmNvu6+UpkQtGSuzhxJ0Rgkhvx0u5sj+FkUJFr8O5sk5hQDFAj4E16dFBchzWZESbH8+oSneZ6kEikDob4VVMaMGG4yWW6yH+PliQEdnjMR7pxsTObf0VFkx72niiBBX1rTLGFHGMQhljsObp32Dee/+CX2N954PGjzdXc+LFCb+LMgqFxbx583D69Gk8+eSTOHLkiIThvvWtb+H+++9HeLjr5eAURVEURVH6C1f77SfmbOy2/liJTOaNFCQ2KZts1SHbeoLOkreuctP8ZBzKr0Z+VSNigv0wOzW8S1O+C6fGobyuBSW1TRbxwRQswqpLqVFByCm3mohLd2vbkq70iKREBEon7iBfb+l+3VO3Z+Lj1TX1pr9pUDz+V628IlnF1dj8+We4+oGb0DA1XiJCPqYOERWm5GR4GGKCC9MD3AVbGSHmbUe55ppr8MYbb2A4oeZtRVEURRndsFrSWwfybbZxusNIgH1eO/tQNLeZkH1+Ek+Px3Vzk5AZM/Cl83lMbKpH7FPB6pvbxCx+srhOfBVLxkVbfCGuwr4bHxwutNm2ZlKsmNBdhRGTbadLkXjyEKZufg9TP/sQIRUlKHrlLcTfcKX5TmfOAIWFwNKldCr36xyUUWjedpQ333xzIHevKIqiKMoohhPvrPIGNLS0ITM6uNfVeAP2fcitbJC0nAAfT8tjYkL8UVrb3OX+VQ1t+OLKTIkuNDS3ITUq0K0G8t5gxkdP3hL2pWDvCHdCYeJlZWKfldxpYncarksfOoRxf3wKs994FRHFeZabGoNC4VNkVYVr3DjzRRn1DKiwUBRFURRFcQWarp/fnm3p3cBUouvnshxrz5EEll+ll4KCJMTfW9J0ZkaEY1pSqBisrfdnkBJpnthbV2wazbCDeX+6mFs4fBiYNQup56+2+AXg5OI1OLryMtSsXIP7LpjS/+dQRhwqLBRFURRljMEGbkyLqW9px6S4kC69EPoLu0KX1jUjISxA/AKOwmpIHxwukm7WZbXNaOvokJKqhNWP3j9UKB2fe6r7v+lkqcVbQT8BxQKrMRnN6S6ZHo+Xd+VKqVYSHeyH5d00rlPsyMkxN65rbgYefti8jb3MZswQE3bZFdfik8z5KG33lojPTZNj3fp+chWWt91yuhQ1jW3IiA7CRdPipPGgMnCosFAURVGUMQRX7J/ZlmUpU8pu0qV1TVg72T2djJnDT9FiNH1bPSkWS8Y51lWYDePYSZoU1jSiprFVSr4a4qSmqRW1zW3dihUKiu66YFc2dG5LjgjEg2sn4FxZvQiP9KigYd+cbMgoKgL+/W/gxReBbdvM25hf/93vAv7+ZuP1vn1S0YkOjVswvMitaMAb+/MtQvN4UY2U871vecZQH9qoZsQ5aNic7+9//zu++93v4gzNQIqiKIqiOMyOcxVdeh/syqqUTs/9hRN2Q1QQVgpiV+2qbno2dBflMEQFCfQx+xzK6jofy34U7OfQHVwhZ6lTe4wSrgYUKpPiQ8ScraKiG1h058ILgaQk4OtfN4sKiohVq4Bf/crsrTAYxmVimRZnX5+oqLpRonXKwDGiIhZPPfUUHn74YSxduhSvvvoqrrjiCoxTM5CiKIqiOExdEzs420Khwf4O/TUtc5XYHk7ucisaER7Ye08IRjesSQj3R4WVIKFwWDs5ttduxZdOj8e/duei8nxvCqZCrZoYC3dxprROqiBR7NCbwY7bsSH+GMz+HCyRyzK1yREBWD4hGoG+/ZzK1dYCfn6A7/nX58ABYP16898LFwK33grceKNZaIwgesrEGg4pWqMZp96NHR0d8HSiTNiXv/xluJPZs2fj2LFjqK2tFWGhKIqiKIpzsGOzdfM2o4eCO3LPo4K7Fw/RIX03mosI8pWmcVllnWVfaTKm6TrYzwcT44P7nMRHBfvhq6vGSYUn9mfgebkLNtJ7eXeu9MMgPM4Xd+TigdWZKKhuQn1zu+TxO1K5yhVYfvbZbVkWf0hhdSNyKhoktcfpyTK7Xr//PvDSS8A77wDPPQdcf735tjvuMIuMm28GMjMxUmFPj305VZb+GobQNDw7yjAQFitXrsSzzz6LTAffaH/+85/hTowu3xQWiqIoiqI4z7zUCPFZsNcDJ100MF892z2r0ZPjQ5EcUSklXw2mJYaJidsRWPWJHZxp3mbK07LxURgfa9uxuieYypVd3oBAXy/xUgyEEdgQFQbVjS34/fpTEu0xKlddNycJE+IcO2ZnYMM9Q1QY8HXkOVOQ9UlrK/DJJ2bPBNOdrOdSn37aKSyYCfLDH2KkwzK+N85PxmenysR7My4mWCJeyjASFhEREZg1axZ+85vf4Etf+hJGAs3NzXKxbvKhKIqiKGMV+gqumJkojdFY0pWr/O6CaUq3L0rFscJaMYRzgj+hl/Kw9vj7eOGS6QlOP+/Z0jq8tjff4hNh1+qb56eIn8JddJeBVVTdJP0mWHnKSCl791Ahvh4T3GvKliu0nBcvXbbb+WW6paICmDgRKC/v3JaSAtx0kznV6fzC7WiDotRRYaq4B6c+cW+//TYef/xxMU7T31DEigHDnJ///OfSLdC4pPCDpCiKoihjHE6I3SkqDLhqPyM5TKpMTYwLGfCcdkYR3jlYaGM+zymvx+6sCrc+z7SkMEmvsnlumLpUqGLKkiNmdWeZHN91LAN8vKSylQ1M/dm+HXjyyc5tkZFAejoQGws8+CCwZQuQlQX8+tfAvHk9GxIUxUk8TPaWeQfIysrCPffcg0OHDuH++++Ht7dt4OPRRx/FQJKXlycCYcOGDVi9erXTEQs+1pG25IqiKIqiDG/offjTxtNdtjP15ZaFRvs290DvxqYTpWKiZgUqGs4P5VfZ3IfekG9eOKGLCHFXpaNPj5dIvw96BS6dnoAUVsLiVO7gQbNngheKBhqyi4uBsDDzg/PygPh4wG7O1hss78tz7KkSlzI2qKmpkcV5R+bOLr1T0tPTcdNNN2Hz5s14/vnnB11YOIOfn59cFEVRFEUZfbDDNlOe7FOFIoP6Now7C82/ty3qFCuc4OdU1Nv0z1g6LgoHcqtQ19wmXcLd6feYnhSGaYmh4ulg2hhYdv//njeLiePHO+8YFARcfTVnhJ3CIjnZ4edh1OW1ffkS+WGUhOlsV81O7HfVMGX047SwKCgowH333YetW7fib3/7G+69996BOTJFURRFUZQ+YGSAJWU/PtqZns0qUosye2/Kx6pOp0vqJCVsZnKY/OssIf4+uH9FJo4U1MhkPCkiQLqDG0KDpWGZEuZog0BHYNKSiAry1lvAT35i/puLqJdfDtxyi/nfQNcFzYdHikRUECa2nCyuxeaTZVJeV1F6w6lP0UsvvYQHHngAM2fOxMGDByVyMZjs3r1bjqGuzlwm709/+hPeeecdrFu3Ti6KoiiKoow9FmZEIjHcH6eKzUJhRlJYr2VfOeFn9SmDnecqcM/ydJdK7nKSPy8tQv5mjwv77t+fnSrF3LTw/q3209P6yivmyMQXvwjcfbf0DDkxfRVmLVsD7ztuQ8RtN5k7Y7uBk8V13WyrVWGhuFdY3H333fjZz36Ghx56yKl+Fu4iICAA8cwPBPA///M/lu3BwY5XnFAURVEUZfTBlCNH0o5YCWvL6TKbbXXNrdh5tgIX9nNFvrSu09Np0NreIWIjNsRJYcFKTq+9ZhYTGzbQpW7eHhyMwxddi7cOFMBk8seOH/5BfBA3NnlifD90BStasS8GhVKQrxdqmsxNE0trm9HWYcLU/jbiU8YETr1L9uzZg2nTpmGo4HMP5fMriqIoijKyqW1qk0l0dybw/pISEYhTxbVdq28FOeH1bG8HrrvO3MCOvSfO0zhvAc5ecAUqLrsau48WS4qSAfuRMApDT4erpvSXd+WioaXNsr+GlnYcL6xFW0cHPOCBUH9v7MqqkIaFIw36XfZmV6KqsRXpUYGYnhgmZZeVIRYWOqlXFEVRFGUgYdO3zSdLZaLPyksrJsb0qyoRTd1M4+E8nF3Ho4J8xYPBKIU1qVG20Q42ENyfVyUVl2alhEsn595o7zBJcz72lWhsaZcytCy9e9mMhN57WrAL9s6dwKpV5uteXubmdRQVs2aJZ2LXwovwUeP5JoN1wJ7sUkxJCJXnM7BPwXKGdw8WWEQFYQSE5xMa4C3m7dgQPzkfvi5zUsLlvEYK9L48teWcGO3JobwqZJU34KpZiUN9aKMSjWspiqIoitLvXhJ1LW0I9vXu10owy5s+93m2pScF03D2ZFdifnoEIoJ8MTc1wqkyrnz8CzuyZXJp9H24bVEarpyVYNNQj6Vp55/3SRA+5weHCy3XmSLEtKCeVus5CX9+e7Z0HPf18kSzRwfiQv1xx+K0TqO1NRQNH39sTnNiF+z6eiA/31wOlvzqV+bKTlOmSCrVxk9OStcM60pYhdVNGBfT2cOC5+AKFEEcp+5W+dmHxD6NjN2/Q0aQsNiXU2URFdZle1eMj5b3lOJeVFgoiqIoiuIyJ4pqpYoQJ2+MBLBy0NRE15L9D+dV2zS6O11ah7zKRmw/Wy493OLDAvDjK6YgNdKuKVwPbDhRYhEVhJPij48V487FafjGBRNEMHCSThFgTXfN9Wjw7klYHC2oEVFhwH0y8sK0K4uwYIrT5s3Aiy8Cr75q9lAYpKaaS8cawmL+fJtjti+ly6Z41mKAvSzWTo6FK/h5eyLQ19smYmE8B0WNNdHBflIJayRBsWoP08i4XYWF+1FhoSiKoiiKS3By9tq+PIlYEKYXvbk/X/o9hAV2TkAr61uwP7dKVv3Zh0GaunUD04gMyupapCRsTWMrooJ9ZYJeVN2IP244g0evme5QOk5hVVM32xrlX/a+6MmTwON0ZFvnsTaDQ1Be14ymtg6E+XsjNMBHtrORnfD881LNyUJcHHDTTebysIsXAz0UxWGlKk7ouS8DHvsdS9Lk+Jm2xNtdhRGmVZNipEyuAcf6loUp2HiiVF4DwytyxQhMH8qMCcK+nEqbbTy/xPDzqWXK0AgLdtt2lMEuQ6soiqIoyuDDPhCGqDCg8fdkSa1ldb+wulHSm4zV7z3ZFeI7mJPamXq05VQZdp4rF18FjcTM62c5VV5vbTd1NoQDUNXQgqzyeoyPtU3T6Y64UD/UldquWNtHJ7qD/gUejzVTE3p+PnoQjuRXo56r/iYTfArOYM3hjUi7djVw3z3mO115pVlM8N9bbzV7KuincICrZyfhld25ltX3SfGhWJge6TavA1PMeA40a3OcZ6aEiaC5fVGaRF6YLkUx2KtXZJgyKS4E89MjxbzN9ybT4a6anTQgndEVJ4RFRkaGw+NlXalAURRFUZTRCSdpfW3ferq8S0rNppOlmJ0SLgKCq8lsblfZYK7K5O3pgVMldZKew8mft6e5QhGNyrzOSICjPSFWT4oVoUJvgLHS70jK0OpJMfKYwwXVcn1qQqg0uuuJxtY2ZJTnYfqW97Fy73qkFOfI9rbSE53CIjLS7KNwUExYEx/mj6+tGY/CmiYE+ngNSApPT+V6HRFiwxm+xy6eFi8d0Wlwjw/1H1Hm81ErLE6dOjWwR6IoiqIoyoiC5t7IID9JUSqvb4G3p6eknkyK71zdZ4TBHvoeGInw9faQaMWBvCoxQJOm1g5pbsemd8U1jdiTXSUrza1tJqRE+MtzJkcEODwhf2D1eBwtrOGyp6z0O1JhiseyKCMS66bGSapQr6vbv/89Jv757/j58cOWTa0+vji9YBUi7vsC4rnYSoMIcUFUGPA4mGKmuAa9ISPNHzKqhcX48eMH9kgURVEURRlRMDVmUnyw+CrohQj08xIzMIVDeKB5VT0jOkjSaazhBJnRA8K0KUNUEM7Ba5raZN9cQedkkKlP9GYsyYzG8gnRsgrtKBQpRmdsR6DQ2XqmTHpdiK9gZoJt2lVZGRAd3Xl9wwaEHj+Mdi9vnJuzFEdWXoqTi9eiPTgU37hgfKeoGGYwu4TGcH9vL+3poAy9ebupqQmbNm3C2bNn8dWvflW25eTkICUlxakPvKIoiqIoIxOmOP39s3Pw8fIQgzU5VlSD9w4VSllXsmx8NAqqGqUCE2E/hMtmJlj2EWTX0ZnChKlURjo/73/jvBTcOD9lwM+HRuVNJ0vOVw1qE0HEcrX/sTAWfm+9aS4Pu3EjcPIkMG6cPMb0jW/g3IKV+FvsHOR6BEiqDRvirZsaK+lcwxGe53uHC8VUz0peF0yJxfSksKE+LGUU4NI7/syZM7jkkktQVlaGqqoqi7D4/ve/jxtuuEEuiqIoiqIMPixNytKonMhHBvlicWakJXrgbth4zr5HACflh/LN3gRCM/CdS9Jlks5jY7SCaT0sK0uDNtOaKFDYl4GRCx7zqokxEmXgtoQwf5c7SrtkRjeZpIRuS2U1Fh3aIp4Jn+O7gHarcqybNlmExacJ07B9djx4hCnNbZLKdfH0eDFEOwrL2+7KqpRxoJ+DHo+B8gHQO/LKnlxLCVtW8nrrQIF4KSwVrBRlMIXFQw89hMsvvxy//e1v4WWVL/jtb38bDz74oAoLRVEURRkiOGk0SoSeKwOOFdbgiysz+9W9uie4Iu/v442mVtseCN1NUK1NwDy+V/fmySSXjdjoz5gcHyLpT0w/umBKnOxjgl2DtoEm2N8b5XUtSDiyF48+8RD8Wjv9Ie2zZsGLpWF5OV/9kkKIzfQsj/fzBiu/cswpLM6V1eOzU+Yu4uwLsXZKrFRbsuZAbpX0ATHYca5cyu6yctZAcLa0vktfDIpBikQVFkp/celbZsuWLXjmmWfgaVdzeerUqThw4EC/D0pRFEVRFOdhaVdDVBiw8dnBvCosHWflC3AT6VGBmJsaLg3suNJPgny9cfP81B4fw0nsu4cKLZWaOBnPiA6USk8+3h5IDAs436xtkFbPW1rMXbDb2jDr0isk9SkveQI6PLyQF5uKnYvXoeTSq3Hhdau7RE54zm125XZll20d0sDupV05lnK8RwqqZdv9KzJsUsbZ38Oeg3nVuGRa/IB4H/x9PJ3arigDLiza2trQ0WFWu9YfjtzcXISEDO7qgqIoiqIoZuqbO7tWW9PQw/b+wjnA1y+YgMkJIdiXU4WoIF/cMC8ZSXZVmzi5LqltFiM1TLaVojgJP5xfjcqGVoyLDUZ1Q6t03L5pfsrApUCxCzbTmeiZMLpgT5mCgKuuwq0LUvGPzzvwo/9+Ea1JyYgLC5ASuLGhXYUOq0VNiA2W1X5rmM50KL+qS4+PktomKX9rXda1pxL9A1W4n5GT2BB/ORYDRommJarHQhkiYbF27Vo8/vjjePTRRy3Cgl6Lb33rW7j44ovdcFiKoiiKojhLWlSgGJ9Z7cca6/Kv7oYRh2vnJMulpyjKq3vypIcA5wxsWMYJOf0EXPHnSn5uZYOkVLFsLftZzEoOl5QgtwuLnTuBF14AXn4ZKOpMP5LGdRdeKNELlrmlsMm16g5OA7p9CpPB5TSiH4T03qAAoTeE+1h/rKTb+9vriFkp4SI2rJmeFDpgzegYBbl9cSq2nS5HXmUDYkL8pceD0YBQUQZdWPzmN7/BqlWr8M4774jSvvTSS7F9+3aJVjBNSlEURVGUwYcT9uvnJeOdg4USFWB6EcuzsmuyAX+3s8obJC0nMdy/26Zo7oLP9ca+AhEVxvXjRTVIiQgUMcGqROaUKA+LB6S5tV08CTRtu+EAzP8a2RV/+APw3HPmvyMiABaboWfCqgs2j+KORWk4U1on3g+u8LMfRm8+E1asolDy9PCwCIIZyWHYlVVhSREj7Plh34ODHcgZtdmdXSn/Tk0MdaiJX3/gMV84teeGf0NFUXUTtpwuk/cFRfLKiTEqeEYYHiYX22RXVlaKz2L37t2SFjV37lzcf//9iOAHdRhTU1ODsLAwVFdXIzQ0dKgPR1EURVH6hJPv3VmVkr6SGB4gxmCjD0R38Kedk3mmuBjN3bgPH08PvLovH6esUnfmp0dKZ+KBgOLmiQ2nu2wfFxMsgodlaQ/kVaOqvgU1VtWl2Pvi+nkpUh3KJY4fN6c5GZfZs83bP/kE+Mc/gJtvBtatA3wHplqWAceZXcbFvB0dJA33BqpC10iHYuJvn5216dLOCmJ3L8sY0uNS4NTc2eUSERQQrA6lKIqiKMrAwUZt/9iWhbK6ZrnOikMsh/qFJWk99o3idmMCy1Xgdw4WSLlXiovqxjbEWfkFWOp0Tmq45N27G3oqWDaV52BNaICPREpuWZiK8vrTiA7ylVKvFBdc9afRfNm4KOeeLCsL+Ne/zEJi//7O7dbCgulOvAwSrGo12JWtRirsvm4tKghTxJhKlxCmHcdHCi4Ji+NcCeiFyZMnu3o8iqIoiqJY/+YW1VpEhQFz45nOxJX93mA51Jd351p6TZTVtchjA329EOLfOQUorm4eEGHBVCz6DbadLrPZtiA9Uv6mb+H6ucn48HCRRGB4WTc1HpkxQZIa1NZuktQg9rbokdxccwTi8887t3l7A/R8cvvVV7v9vBT3Y18Ct6/tyigSFlOmTOn1dhezqxRFURRFscM6Rchm+3nfQm9QRFg3sAvyM/sI6B2wFha9eQj4m55X2SiryWlRQU6bitdMipVu1KycFOTrjblpETZCYSJX9WODUd/SjkAfL5TWNeMvm85KAz3y2elS3DA3uXPlv7wcOH0aWLTo/MHHA6dOmX0Ua9aIZ6Lm0ivRFBoufRl6iur0BJv2scFgQ2s7JsYGiwgaiLKvii0UkBST1nNICk/6cZRRLixYVtYaeixOnTolDfK+8Y1vuOvYFEVRFGXMQz/ChuO2FYaYLpQR03u0wogOWBMe4COTemtxsDAjqsfGaPXNbXhxZ46kUZFgPx/cujAFsVbN7hxhSkKoXHqCk3/DvL35ZKlFVBCWbN285wwmlB8ypzV99BGQkGBOfWI/LR8fcwrUlCloi42TLtLHDlQgtyIPNU1tIlp4jhdNjevVl2Kk3jy/I9tSJjanvF5E2EA1q1M6YWrc5TMSxJNCMUx/BcddRd0YEBbJyV1LyqWmpuK5557Dvffei/vuu88dx6YoiqIoYx52rL5oajw2nCgRrwLFwrppcT2WP7WGkQhWhOIqvDGBn54UJs3Xmts6ZDJnHa2gB4OiwzB8c5JviApS19yK9w8X4a6l5s7T7oCeEXanZh+LjKggiY4Q7+YmjN+1CVM3v4/xuzcDLZ3pYKaoKCkX65GYaN6wdq38s/N0meyvoMrcL4KcKK61CAopDdsL9JvY955g7j+rNGk51oGHpXdnJodJ00HjPaiMLFw2b3dHZmZmn/4LRVEURVGcgz4FTriqGlol4tDXyjupa27D1tNlIiA4SWNEICHcH8vGRXeJODAyQYP3mdJ6iYbMTgmXCkY55wWJfXoVJ9/uWEkuqGrE6/vyLekvp0pqpZFeTLAv1vzjd1j41vOdd540CU033ISPZ6zCweAEBByuxZLGciyxMnmfOd913NqTwnNjGtfhguo+hYXRDdwanivHcKCFBZ+bY8uoUG+paaMdil8fL009w1gXFiw/+/Of/xzp6e5bxVAURVEUxQwntvFhvU9umULy8dFinCquw9HCahEh0cF+FiM3U0vs06PIu4cKpSqT3M9kwp7sCoQGeCMiyLeLcZzVptyVnsKO22hrQ9rhXZi26T0cuOg6NE+YCR8vLxxbtg4Tt3+KU2suR/qD9yFm2UL8c2uWVAkibAL46fFihAf6WNKsQs6nU1nbKhiBkYsDXovJ8aGWcTBgRaKwgL6jQ/3hdEmtCCzDqMzGgDS1s6KWoox6YdGTESo6OhovMf9RURRFUZRB59978iQKUFHfKr0TWAVKfp+D/cQEzjK1M5PDbR7D9Cr7yTQ5VlgrOe/Z5fWWCS9//1dPcr63hJFeZBEkHR3A9u2Y/MensPTdNxBcVW7e7O2N/CmzcefiNDTOS0LxnVdjdmywRFzY58AQFdYcLaixCIvFmVGS+sT0sbOldWD10qRwf4nCzE2zPe/uYFSovL4Zu7JYkcqcKnbVrPPpVgMEBR8bGlpXP+LrsTenSiJVijLqhcXHH3/cbV8LVosKDFT3vqIoiqIMNuykTVFBWtvbxbPA9BpWj0qNCsT42BA0tXYt3clJt6+Xp41hmvj7eEpKzpdWjMPB/CpL6VdO2h2FKUgfHSnGIUYm2GU6ygcXvfIXeL78LyAnB6nn79cQEobjy9bh8OorEB8WgES77tTE28tDhI195UnrtDAe773LMqTxHseDnhCmhKVFBmL1xL67WXP/ayfHYcWEGDl2dqgeaMrrmiVdyx4KOhUWykjDpU/MhYPYXEZR+OV+MK9KzHj8QZuVEtZtKF9RFGUsYwQDOO/OrWiUFX7CbBqKi6yyekyMC+4SSThTWifpRDnlrfDz8bRMsBee7zURFugjE21XYDWrk4fPoD3MvK/dJU1Y+c8XEVCQBwQHA9dei6JLr8EnSdNR0eoh3alplO6OEH8fTI4PEXN25zkzEhFhcz96SYpqmjAtsbMKVU5lIyoaWixpYX3BCMlgmYfZLLC7JoKOHquijEhh4YwpWxvkKe6CK1Mv7cyxMRAyJ5cVSZytpa4oijLaYBqN8V0YFeyH1KggbDlVioLqJlnJp+m4ubUDjS1t8Ar2w2t788WbMCkuBIsyI/GvXblS9YnftdWNrUjw85eme/PSIiXP32VYCvallzD7b//A8tJC/P65Tejw9hHzw+a7voWL56UDl10GBAQgHsAdDu6WaUk8z1PFtSIgaNxmWVJrKJTsJ+k8v5NFtYge7zcsvTM01G86WWIjouan2womRRlVwqKvpnjWaIM8xV2cK6vvUpWEObZstNRbTXRFUZThLAb4PRbi5yPRAEcoqWmSKILRb6KougnvHy6U1Ceaqel7mJYYJo3kWAnK18sDnh6eCPHzQmNrB6oa21BXWIsgP29JF9pxrhx72NmaXofzEYrYUD9Zpb9ubrJrq/UFBcArr5h7TWzfLpsYe2j39kbc2eMonDhDtp1ddw2wepzz+5d0KE+smhgjl57oqXpTgO/wjXQvnxCN5IgAEUUUTPTBDOfjVZR+C4vCwkLL32+99RYee+wxPProo1iwYIFs27VrFx5++GH86Ec/cnSXitInXEFzZruiKMpwhv0kXt2bJzn1nMwzXefKmYk9Vlnid90ru81RBUIz8bVzEvHSrhxLXn5VQwve3F+AmGA/KSPLiAMnp0wZKqxuQnNruwiIiEA/WaxhtSd6B44W1iAzOtCm8lBDcxveP1SIqsZWqYS0JDPKsWZ4f/0r8JWvmPOwCBvXrV6NMxdeiTcyFqIppNM4vWCAV+Izo4MQG+KPktommwjAcF+MYhoYL4oyJoRFfDyDlWaeeOIJvPrqq5g3b55l26RJkyQF6v7778eXvvQl9x+pMiZJjwrq1qzHHw5FUZTh6gnjhD4hzF9Wno3Vf/oZWFLUEAT8XmNqJxvYzU3tfrL90ZEimwZ17HPwyu7OfRhwX0cKa0QETE8Mw/7cSgT5eolQYPlY6haKlA6TSSpFpUZ6I8jPC7bfrMDZsnqYwPKsQC4g0eH7l2dK2VnjHM6dK4D3W28heu4M1M+dL8bv8MWLzaJi6VLglluAG2/kxAGMS6zJqcTB3Cp5/OzUCOmRMZBQpN2xOA2fny1DflWTCC6mTGmDO0UZpubtU6dOSTM8e7jt5MmT7jguRRH4Y8YmTeuPmzvOenl6YuXErs2dFEVRhhpOuv+5I0cm/+RALj1hNVI6lZPdsvpm6TNhz7nS+h6FBSf69hRUNXQb4eAEn7ArN2DCZydLpZ+DvxdTakxobTeJv8IQJUvHRaOhpU2qJ5HimmYpUdvUWi3fvRRGLIG6P7cKa1KD0fLm28j/89NI+3wDvFtb8NnCdXjt279EdLAvJsSE45pz2fBNN+o8dcJz6+n8BgqmEbG6kzJy4edod1alvGcnxoVgbmp4j+0OlBEuLMaPHy/N8H7xi1/Ak+FO+ULtkOsTJkxw9zEqY5z56ZGYnhQmP35Rwb6DUv5PURTFWc6W1VlEhQGvM29+QlyIeCooCIyeDga9NV8L9fdBRb1tgzqWjqVIsI5k0KQd4u8tCzCMkKyaFCvN44prmy3dpE38z2SS71B+p66bGi8Gb/a2YGSivK5EIhosz8pLS2s7Ljq3GxP/tB7Y9BF86+qQcf75CuJScSphnFSaYhO+U6V12BoajTX6tlHcAD83z23PtnxW2JOEVc4unKpicbjj0gztD3/4A6688kq88sormDt3rnxR7d27F1VVVXjnnXfcf5TKmIchbKYLKIqiDFeqGrr3ftGvYKyiL0iLFOO0QYCvd6/Vf1ZMiMZbBwos6aAsr7p8QgziQ/3x2alSnCmpw6mSOoks/PrDE/Jdee/yDCzKiBQB4eVhLp1KweDj4YmIIB9868IJmJoYZnkO9qY4XMAu3X7w9WpAy/mKSiV1LVj9j8cRl31KrtclpuDA0otxZMUleBsx5vbWHR0iXAJ9vURAremhVKwyfGGK3JH8akmZm5oQKlW3hppdWRVdBPienEqsnBhj07dEGSXCYuXKlTh79iyeeuopHD16VLZ97Wtfw3333YfISO0SqSiKoow90qKCevSKGXDFNSkiQDorM8IwJzWi14gFIwu8nV4MpoHQn8CqTuSS6QnSJ+J4cS1yrSIlv/v4JP7r6umSPrLzXIX0b6AuocAYHxMCP/uqSR0dCN27Cxe//Sq+umszHvrRP1Dp4QMvDw/U3HUf4qoLkXfRFXi6I0G6WkcF+cKnslH8JExPNbwLjK4oI4v8qka8sD1bXkuy5XQZbpyX0r9Sw26gocW2WSNhNI7HqcJieONyTklUVBS+973vufdoFEVRFGWEwlKwF0yJw8YTpWjvME+6WQbWKBFrwOpEzlQoYrTWOmLLldzsigaZaJ0rq5PmodbQN7HpRAlmpoRj6fhoSSHhhCzEzxvSeJsLwVQa+/aZS8P+61+4JCfH8vhr8vfh4LJLZHI5YfEPpLrUa3vzJOrR0m4S3wfL1rZ1mKSjNe0eTPGiQVoZWWw6UWoRFcZ7i2J1qIUFRTHT7KxhvxK+75ThjcOvUBab3XDlJT3d8ndP8D6KoiiKMtZYnBmFmclmTxgFRX88YexdwZKwjDTMSA6TiEBNUyue2ZolZWuZWlVS2yxCwtvKzM37M52J0Q32quBteZWNOFpkjjZse+Z1JPzppwjMOmN5jCkkBMVrL8HW+Rfh1MxFkhJz2cwEuY1RD+Lt5YEZSWFi8GaK1S0LU82N+Lw8JPISN4hFNTgBZooZK1v5eWu/B1cpr7P17xAWGRhq5qVGoLyuBftyK+W1TgwPwDVzkob6sBQHcPgbLyPDbNlinqfxd09ogzxFURRlrEIxkRbVv5XVowU1eHN/vkQJyLYzZbhzcTr+se0cNpwolXKwjIiwIpP0uLNKO2ejtcnxoWa/xbIMbF+/C+uzs+A/fpIIi+qOOBEVJn9/eFx5pZSH9bj0UsQHBODaDpM8p3VvC8P8Tahf+JyMUMxLi8D8IajSw5Xstw8UiMiiiFo2PlouivMwEnakoNp2W8TQ+xn5/rpkerxE/CTapml2IwZvZ0rMdve34hpieM+plFKEXAXiFzR/CBRFUZShhdWW2NGaK/C8ePXQvG4g2XDCXKHJgObsP286jQ+PFMtEi0dEjwZ/S6YkhCA80EdSolg5b35aJFYGtQCPP46Al17Cmh07kLRwNV75zydkX9XxyXjpkT8h87pLsHBmepcJnafsvZNJ8SEoO227ij0pLmRISn/y3JmWxRKkxvWNJ0pkRZuNARXnoNm+oLpR0uVIsJ/P+XLFwwOKY+0/MkqFBUvMWnfhXr58udYT7gc0SG0+WWqzAsMw3zSrSh2KoijK4MKGdKxIU17fIv0lIgJ9xKdw8bR4t1Sm+/xMOXZnVUiqErtus9eCvRlV0nwazBM9A6Y77cupFkM1a0xRctQ0tYkRmxGSn1w1HdknspD/t+eR9JO34HN4t6ULtsnTE54Ma/ByvkT8mQUrMT/eMU/E8vHRqG1qk8pR3OX4mGBcOt2cJjXYMKXLEBXWsFyuCgvnYWGAr6wch6zyerAIE8dwKIS0MnpwKVa7evVqpKSk4Pbbb8cdd9yBKVOmuP/IRjm7zues2m9TYaEoijI0FFU3iaigf2FvTpVEDAqqPWTyzlKyD64d36/VU/od2FvC+jr7UVw+I0F6YFQ2tEoFKXozaFRlxR6D6oZWhAd4yzE117cbmkEiGUwXae8wwfvGG7H00G7LY/KmzEHYvV9A8O03Y09eK+vHWm5Ljw6SaEx2eb38y/OimNl+tkI8FCmRAViYESn+BaZFXTkrUVay+bxDuYLMbuLdEaymXpdhlCozZmjN2soYFxbZ2dl48cUX8cILL+Cxxx6TXhYUGLfeeivi4+Pdf5SjDIaum62qMBgYtcMVRVGUwYcpIWwMx9VvIw2JE/aTRbVS4pUlYln+1VUO5VV1u628vhn5lY026SmXzkjAiztzpDmet6cn4sMCpL8Ae0UEtDZj9sEtWLN/A3b98Oe4cEqcrDifWroOng0NOLryUhxdcQlqYhOl58WqhBjcGGfC8aJaFFabU7xo2v3DhtMSHaFwYFSCosroys1qU1nlDdI13KA3kzT3w2Ngo77MmKB+G6qb29plTJhbb11VKzbUXyoW8bUwYMRmVkp4v59vb3YVimoaER8agDmp4ZqCoyiDJSySk5Ol1CwvR44cEYHx+9//Xq5fcMEF+PDDD13Z7ZiBealT4kO7GKacKT+oKIqioNeJbnFtEwJ8vBAe6OvQUMWG+EnUwN47QB8zm4jRKOzKcbCBXUltk6RXGZVeOYH39fJETXObNCZj4zuDTSdLkRgWAH9vTzS2sG4/sDYjFO0ffIQb338DE3ZsgF/zeSGybyPenZaB1MhA7L78Vuy+8nab5zeyWrgqzUZ4vDASQmO4dTTkzxvPICHc36anRk55vdyX0RMuiBXXNEuajH35XJ7LCzuypRIWoai4eUGKy6ljp0tq8ca+ApnsE/oPmSpspOhcPzcZu7IqkVPBVDVfiaz0J2LB1+iF7TkiugzjPH+f71mWoWlBiuIk/S4IPG3aNDz66KO46KKL8NBDD+Gjjz7q7y7HBKx2ICthxbXnmx6FYek491S14A8Aw9lsqMQfk7mp4VIKUFEUZaykNP17T66IAWNievXsRJtKR92RHBGIyXEhkgpFTwGjFpzc0wPBakrO1vbnhPW3n5zE4bxqKdLBsq8ULoxOswcFv/ujg/0QHWTbWK69vUMm6iS1rhQrXvwTJm37BAH1NZb7VMQl4ejyS7A+dgqObMuSY0wM90d4gI9FGPF8WR7WHqM/AEXO2dJ6lNY2yfkyYjMhNthGEDS2tEmK1Mu7c0U41LeYu2zfMDcZk88vhtEzaIgKQkHw/uFCfGnluB7HhhWdDuRWobGlXV6f1Cjzc3Jc3j5QaBEV5HhRDQ7kBWHu+d8xnhd7ZrirbwajQIaosDbwnyqp1aIqijKYwuLAgQMSrWBaVFFRkYiL73//+/3Z5ZiBOarXz0u2VPegCY9fxGW1zfKlTpHBGuWusPlUGbac6jSGv3eoUUxZrDylKIoy2uFqvCEqjIlpYlaAQxPRr6weh+qmVuSWN6CmuVVm3+yo/eDaCb2uXtPrQIN1mNXE/sVdOdKozoDb65paERrgI6v6rODEKEhZXUtnFKCjA94VZWiKiIGPlwfafP0wc/0bYr5ujI5FwB23IXfdlXi2PQ65VY3mFKq2dpmI1zf7IDbEX6I0TJtaOTG6S7TGXDrWZDZ/N7aKqCB+5w3kjFBEh/jJPvg7lRoZhJd35SC7vEHuW1jdZBEn66bG44Z5yWKotodCg8/VnR+DaVjPbMuylLFlCtZFU+Ml8lBaZ+7LYQ+9IIawcDcUOd1BsaUoyiAIi5///OciKJgGtWjRIhETt9xyC2JiYlzZ3ZiGPyoMI/9jW5bly5Rf7PwSv2dZukuVt/ZmV3bZti+nUoWFoiijHk4Sy7pp+kVzdG/CgpFempbZ2fehiyZix9kKmQAzirEgI6JXz8C202XYesa8as9I9LqpceJt2H6mvIv4oFnbMGgTLvpUN7Qg/vQRTN38PqZ+9j460jPwp588KcfUEB6FT+77PoozJyPm0gtxyawkVOdXA/vzbaIEhM/NifzXL5jQ7fmtP1aCXdkVEhVg92xRF+fh8TCtKLeyAXVNbUgICxBT+e7sCvx7b74cO70gof7e8hwUblzRP1FcK30tiuxW/NnMzxAr9nx+ttymNwb57FSpRNcpzBhpZ7THGh7bQJEZHSy/tdY9uHg9U8vXKsrgCIunn35aKkK98cYbNmVoFdc4lF/dZYWGYdmcigZZKXOWNumWZAt/zBRFUUY7XGlnWhAnwvYT3Z5g6tNbBwok5YdN56YlhKLNxIl0i3gfDuZ6ijBpau2Qng4L0yNl8kvOltZJzwkuBhnpNOfK6nG8uLZLGVnui/Nlww8QeuYExn/6Lpbu/gRh+ebUJ6G1CbPDPLGvql2e8721NyHY3xuXZJrTZZmSJfu2VIYyobqxBW3t/LdVFpHsG8YdKajBjnPlluPIiApCUU2TCIoQP2+JUnA7fSY3LUjFxLhgiURsOF4iaVz1zR0iXFgdKzbUnB5mpJ3R+H2mtF7Spoz9r50S2+PCGNPB7KHQYBlZmrUXZ0RJQ0ADbpufHomBIiLIV8oJs2IX3zdc8Fs7OVaiPoqiDIKwOHnypCsPU3qAVTSc2d4X0xPDpPmeNd3l2SqKoow2OClcnBll0yeIk+BFmd1PTDlZfm1vPuqaWyU1iBHjdw4WiBl6cnyIpOAwpWlWcrikJuVVNsjkmj45Qp8cv6s5STdgimvB+YpGPB422zOqFy1Ii5A019WPP4Jln/y78zF+/mi77HIUXHwVzsxfiaTYcBSbKvHpiRJ53iA/L5nkM/WIEYOb5qdIxOJgXjVK65oQ6OMtYicyyFcaxrGK1TirEqLWVZQI07oSw/wRE+JvE+GZnRoh4okwIkGSwwPQ0GyOMJjOL1TR0E1YYYoT8K+syhTx0nxefNkbvK1JjwoUY7g1kUF+lu7KrIrFlGB6HygIZ6WEydgNJBRj7CvCqBXHUJuyKYprOPxJzcrKkn/T09Mtf/cE76M4Dn+8tp4uswnD8kuN4XJXuHBqnHz5MxLCZkosm7fUTSa32qZWZJU1SMfXtKjAMdMk8URRraz2GT+aXA3UJkKKMjxZMSFGJrz83NJozOIVnCx2B6MMFBUsM3usqFbMxFw9Z0oQzdaEqUNMA4oP9Zfr+3OrcMGUWBENnPDy/sb3N//PyAHgIalANBpnNldh8Z5PsX3eWsxOTROvwP7M6Vjk9QZOz12O46suxYkFa1AMHzGJo6gBLXl1EgXh74MBJ/pHC2uk5C2j2XcuScOvPjguJWlpCG9ubUdkoHlyfqq41kZYcBzsaWjpEAHA8+D4sGQrJ/0G7MJMeB/+Jh0r9JCoztSEEElZ4v6N4xPR5GBUYVFGlETkDRM5H3vlLNuGe4zKOGuW7y88R3bwVhRlEIRFRkaG/MsvT+PvnrCeICt9wx9A5rIynE6/BVd/eN0+jO4o/JG4bEaCXNwJq0y9fbDAkvvKFaVbFqS6fJwjBZY+ZIUZA5aNpKnv8plD03lWUZS+mRgXIpfeYCThs1NlIkAoDhi9MNuaIYsylQ0tlgm5dcp/e4c5LYi+5Nmp4dh+tlzSf1gxialIvl4eyD+VjRnHt+C2PZ8i5egeeJpMCPLxwNvxCfDx9kThuivw+7Xr0BRsjibTwE2fggiL8522Rcw0+ctCjgEjKhQW/J3deLxUBAYjKJZzqm6SCXmA3Qo/U4kY3TCqLfHcKutbcazQXGmKEZfJCSE2i0WMdPPcuKDEY6C5ml4H7ou+CnZpdmVxib8Zty9Kk8pLDS3tSIkI6LNil6Ioo0xYnDp1qtu/FffAlSJ+iTPHlObB3uCXMXNfmQvrap1wZ2Fo/8MjRTaGOnN32kpJOxjNsGmSPQfzq3DR1LhRL6oUZbTC76/nd2TLdxpFBT0R1BRGNT4j9SY8wBdNrU2IsjIPs2u1kSrDVJ37V2SKt+P1z0/j+kMbcdHBjZh9cg+8OjoNykczZ6AkIl56WHCl3jc4CE1tnavjTXbf/dyfBzzEYxFiDpQI/N4nTL+iUZ3342SfQoHwN4THNtuuYRwjEiwIwgpMrEJ4vLBWzs2AQuWzk2U25VU5FnfzMecqxG/C9DCmDLnSz6OnRTVFUcaosLA2aathe2BgfmxfouKTo8UWAx5hs6NrZicNeEoS807tq3gQI3d4NNPajRmekwOjM6+iKMMDLoBwVZ6egeSIAGlEys/p+uMl0vSMqU3z0iMQE+yLP248Iws0IX4+Eh0I9fNGdWObpC8xWsEiGPzoc3JNIcHoAUu5MhXSJlppMsmk/aJpcagtrcB3/uv38Gk1exay06dg45w12DRrDUoj42RbwnlDMNOhuDBDszDXa/gNXlHfivrmaiSEB0jkgmk5oQGdvwkxwX6SlsTULIoH/k2fxYS4EDFRM1pCnwAbu1k3ujNgNPyS6eZjf/yTk5Yu2wbWJXoNKJwumGI+dkVRFLcJi+PHjzt6V0yePNnh+yqOwxQca1FB+GM5MzncJpd2IOCPFEPV/EGzpjeD3mhhWmKYJRfYYFxM54qloiiDD1OR2J+CE2uKiLTIQDy7PcdS9nR3FnAsvhZBvl42xSze2l8g6TfsycDFEi6a0DvFykCMQNI7xapFCf4BYECSPgemFrH/BI3bqybFwLe9FXjrfeCll9CclYP8Nz+QlClTSAh2X3kbWgKCcGTlZShPTIW3pycqzpXD67wwSIkMkEUkRnrp1aJBeevpcnjAJB24C6uaxB/hkxiG+1dkyKo+j4HfQfR9sDQ5oylXzEzApdMTpHEdz4PN8WhyZopRXwtUhGlMTG+1JjPGNV+foiiK08JiypQpjt5VPRYDBH9weto+0MKCk+jVE2PwybFim9Wv+WkDVwJwuMCUAtZ130nzdluH5G1fOsNcEUZRlKERFf/cmWNTWYiLH/Yr7scL6SkwpzrxNj8fc4UmehLoGWB1IwZ7m9ror/CRSko0bzNqQRHAakuMeDB9KMwHmHlqHwKe+RmwZwNQa/YmcGnlg9c/Q0vmOOmi/em937U8P6MO9y3PwLbT5eJV4L4oXlja1Jj887ubYodRZ6YaxYX6obGlQ1JjjRKrbR0mbDrZ2WiPEZY39ufjGxdMwINrx0t5W/bZoPHa0eg1oxDldS2WErkUMCz8oSiKMijCorCw0PL3W2+9hcceewyPPvooFixYINt27dqFhx9+GD/60Y/6dUBKz/BHrzv4QzQYLMqMEqMgV9j4ozwlIdRtubbd+Ug4AeA5s1HTULN8QjSWjY+SFCijfr2iKAMPo6THCmvFQ8BVdvrKaLa2L1d6uKAakYF+UpbVmnNldRbBwcpP9AoE+nghwMcT9S1t8jejFIw4pEcG4lBBDfx8vBHI/dRxEt+OC3e8hwc//DvC6zr9Vg0xcdi98CIcWHYxqhNT4dHchiBfb1w6I0H8GxQZTHfihJ/lU+enR4hZOjbUXGHJgN8p1kmVvD8v1lXnztiViiVMoeLzjI8NsfFF2EPvBJvh8fuUqVwTYoPlO4y9NO5dnoGSmiZ5fvU7KIoyqMIiPr5zhfaJJ57Aq6++innz5lm2TZo0SVKg7r//fnzpS19yy8EptvCL38jLNZgQGzKoJfk40e9J4LiLj44UyQqhtbH9ipmJGGq4EjhGqusqyrCAFYye+zxbFhrIphMlmJkSjrBumt1xG0WAtbBg1VfrxY/65nap3uRx/vMcHuAjHgKKAX6XcvW+sbUDE/NPot43EjkeATIxbw4MFlFRExSG4yvW4eDyS/Fx5AQ0tJklgX9eDaYkhEi66tSEUPmetoc9Gow+DdbQw8HUSvs+E+xH1PnY7n+qu9ufPWz8Z53ylBEdjFsWpFgWSGLVQK0oihtxqeMMq0JlZmZ22c5t2jxvYOEPIEsNsuQg/Q2ZLpb7G67QgGgtKsiB3CppTjVYFbAURRkeHMqrtogKrqznVDRiV3alTN7Zt8EozUrCAn1lO/s8UAywg/bc1DBw/sz0o7LaZvmbfR5YRYmrBDR7R55PVwo5cxL46CW0/fNFeJ89g89u/SoKrv6ilG89NGsZ/jvk16heugIR4cHSZdqv3YSGNrNJu6m1DTnlDdIvg2lUznLVrCR8cKQQx4tqpcoT+zzMSO4UFvTR7TzHak6dqV4UQn1FGRilsPdRMIJzurSuz1K8iqIogyYsWBXq5z//OX7xi1/A09P8JdrR0SHXJ0yY4NKBKI7DCfZonWRTMPW03ZVzplBhfXZ2mNWVOUUZWdCYTRiJOFfWYOkxQa9CbWMbQvy8RTRwcWXVxBgxQ6+eFCM9IRLC/OU2doOmd4EXFqCgUGEfCXobEsvzcdnu9xHy87uAw4ctP4qmgADMiPBB5sWTkRDqj82nSrErKxmebR0ID/RFYli7HEtNU4v4PUhtc6s8tyMLPfRIfHKsRFKcGI1YOi4a185J7vH+jGrcszwDu7MqxGzOc6GIcXT8uts+UoUFIzuM2nPcGdWxFmCKooxQYfGHP/wBV155JV555RXMnTtXVof27t2LqqoqvPPOO+4/SmXM0JNfxKjd7gzvHizE/tzOtLGFGVHSe2Ksw7r9zLnmDzOrwAyUT0ZR+ktSRIBMItnt2RAVTGUK8vUW8zN9DCwLy7Ky7K9AOPHnxYClYZkOVFnfIh226V2g1+JoTjl+/PDN8K8zm7DbvX1wZt5yVFx5HWZ85Q6ER4XD6ASxelIslo+PlgZ4of7eeGprllSfmpkchrLaFqnmxEgy0zYd4dW9+RaPiGHEpuch1arrtT28ncfh7Ph1u32EdpdmFbBX9+RZrp8trZPXcsm40d1LSVFGvbBYuXIlzp49i6eeegpHjx6VbV/72tdw3333ITJy9FcJGonwR5WrfKzkNJxJjgiUH2jr8D1X1mjadAaaGq1FBWFVJ1ZaGWiPiCNwUs80jMEuWctUiue3Z8v7gbBs5a0LU4fFmChKd6We2cjNWHlnNIAFJOgPOJJfLaVbKSKYPplT0YB7l2XIbfxsMVppFJnIMDVgy8//jFsO7MK73/+V+CgoMLJWXYKkmlJsmrMWJ5ZeYOmCffZ0DW6LshUJjHaEBZhFOKMjr+zJFZM1J+9Mu7pqlmM+MH727I3nXJzbn1fVq7BwBQqv5RNisPV0maVa4+yUCOnLMRLZcbai67Zz5SosFGWkCwsSFRWF733ve+49GsXtsMziq3vzLH0YuFJ1/bxkh0x/Q8XVs5PEU1FQ3Sg5xK74SHpLqRrqSfTnZ8qx7UyZvDZ8Pa6clThogm/jiVKLqDBWSz84XIi7l2UMyvMrijNw8n/TghQszIjA01uzJGZBDwMrO/FvNrxjagzTgwijFyvGx+CDI0UwVVZi0vZPsWjHR4jZuQUXtpsbfO697i4UTpguf7/xwE+QGhUkvgNreJ2fDaP7tj0smHH/8kwcKaiW7yYuWNCrMRyhCJqeGIqCqiapSDWSqz+xq7gj2xRFGYHCorm5GWfOnEFFRdcVhOXLl/f3uBQ38enxEpvmbpxYf3SkWMTFcIYrav1ZVespdcqVlCp3wsZXnx4vtnk9/r0nD19amTkoJnw2+LKHx8DVzNFUBEAZXaRHB+P7l0wWAzMrL5WfLZc0mP25VRKJZalYVng6zK7b67fgxo+fw7jdn8G7rdPsXDllJvYsuRjVMQkiQCrqWhAT4o+y2ibpwE0RwxV+Hy8PiXow5ao3WDzD2dQkwkZ89EgwwmLAz96sAfQKcOFiuEerHWFSXAi21TV32aYoyggXFhs2bMCtt96K4uLOCZI1RshVGXq6q3/OPhSjHaZOTYgLkYm8dVrFUJveWbHGnrK6Zkn1GAxzOSdO1hELwgmHigplMKFnoqS2WVbP2djOEeipYD+IY4XVeG5btuTWU1T4tLbAu6EZtR4RUp62qbJKIhWkNHWcdMBuv+lmLLhoIc7syEEVKyXlmSMNbJD3WWmdpCbSIM0qSvyeWJgROaBpitfNTZZmo2bztg+Wjjf3CFJ6Z8WEaNQ2t0kaHGcZjGaz+7iiKCNcWHzjG98QYfH9738fERF9V6YYCFiFyqhIpfQMc4ytSxSatw3fNCh3wUnDjfOSpSwky1QmhAdIV9qhhjnZzmwfiLQIlsXkBIxwZfaCyc6vuiqKq2w4USLpgFyAYlSAzSdXTIiR25jSdDCvSprGTUsKlYZu9rx3qBCVNQ1YdnYvLjm8CetObMOrMy/En65+ECaTBw5PmIMNtz2IU0svRGm6uUrhyokx0q+CkcEXd+ZI+kyIn49EPFg5qq3dJBWm2PeC35mXTu/s2zQQUCQx5VNxDvpc6GVZNzVO3iMUg4qijAJhQeP2f//3fyM4ePAasxmwzO3jjz+OsrIyTJ06Fb///e+xdu3aQT+OkQLLL76yJ88misTqJmMBigvmQg9mA8G+mJsWLpOZ9o4OG3N6WODgiD2uEH9l9Tgxx3MyNTUxdNjmhiujDzag23a6zHKdEYfNJ0sxKT4EjS3teHFnruWzsf1sOS6ZFo/61jYxcDe3tMHn822Y8P4beHv/RkQ2dBZ4mJt3VPZFoTwnIxrbxn3VZiHFKM3K7wR+EzJKwvd/y3nfhbeX+bvCz8dLUpw4gVWGL4Nd9EJRlAEWFhMnTkReXp502h5M/vznP+Oxxx7D66+/jsWLF+N//ud/cMUVV+DIkSPIyFDzaXcwHejOxWk4kMdcZGBmUtiIrQgyGuAK7J1L0rD9TLlEklhLf7BLJbJs5eJMLc+oDD6MllnDFCR+L7GK29HCWrS1t6OyoRV1Ta1S2pWV3BhByCpvwBP/+wBm5J+wPLYiIBTvT1mOt6asxL7UaQho60BORT1unp+E+PBAZJU1iICYkxouEQIDFkyg74xiIsDXG40tbRK14IWkRAx9ZFNRFGWk4mFywRDx9NNP4y9/+Qt+97vfSbM8+/zs6OiBWRGnoLnsssskYkF46GlpaZKW9ctf/tKhfdTU1CAsLAzV1dUIDQ0dkONUuqe2qRX7cqpQ3dgqHohpiaGa268oY4jTJbX4165ctLebcLy4VprVtbV3YHZquJSI3Z9bjaqGVmQWncVFJz7HU6tuhY+vj0QxHnr3T7jmwCf4ePJSfDR9FfZkzkGdBDcoELykqzZ/i6KD2Uk7EzfOT+n2GFiNjSWX+dy1TW04VVKLjKggMVUzonf7ojRNsVEURXFx7uxSxOLee++Vf5cuXTpo5u3y8nKcOnUKq1atsmyTbqurVuHzzz93+/Mp7hcVT23JkgZVhHnUXKW8dIYa7xRlrMAIAqs5bTtTIRN8Lkkxq+Xz022IKMjF9Uc24cqjmzCxLEfuvzdlKnZnzpH7/XHFbfjl6nvQ4esLb09PJEX4w7uh9bwJuzO1sKaxDftyKrEgPbLb6CzTaO5bnoFzZfXS0Ts5IgDFNc1SxjYtKlAXOxRFUfqBS4mk+/bt6/UyEBgVqGJizCY/g9jY2B6rUxllcam0rC+kpKTEcp/S0lJRYaStrQ2FhYXyOFJXV4eioiLLfentYIdx0t7eLvdtamqS6/X19XLdWgxVVlZazOa8rbHR3F+hoaFBrhsijGV7jdK93MbbeB/Cx/A690G4T+7bgLfll1ZJTvLesyXIzcuXYyM8Vh6zAc+F52SMDR/LcyYcA46F9ZjX1pqrKrW0tMh9W1vNwoDjaD2G/NsYW96H9+VjCPex+cBpi6gwNdbA1NyAfblVqKhrHJTxNsbQGG/ez7pUsiPjzfxwGk8/3HUcJRXVNmNojDfH0Hq8OYbGeBtjaIw3x8t6vDmGxngbY2iMN7fbv2eN8Tbes8Z48/msPxM8HuP9bYyhMd4cQ+vxduQ9a8DxM+5rvGftx7u39yyfm/D1tB7D4fKetR5DZ74jzuUVYv+ZAtQ3tw2r74j+jjf7Ovxr23E89toO/O/6U9KUzpnxfm3bUXzvn9ux+WQZWlpbEelRj6iGStz5+ev4wzPfxbOv/T98Z/NzIioK4uLwzsxVaPTxg7eHCWGoR31AIDz8/eDv0YYozwZpSkd/UIRnEwJM5vH1MHUgyrNezrG0rrnH8aYYYTEH7sfPo108HnFBnnLu/fmOsB5DY7z1O0K/I0bKPGK0ficPp3nESP2OsD72AREWs2fP7vUykBgvkvX13kpl0uzN8I1xSUkxh8dffvlly33+/e9/Y9u2bfI3B/mvf/2r5Y124MAB/OMf/7Dc980338TmzZvlb76BeN+cHPPqGr0eTz75pOW+7777Lj791Fz2kC8s70vjOzl58qRcN96gH374oVwIt/E23ofwMbxuvDm4T+7b4O9/fxJPvbMZ648V493PD+GpJ/+O0irzm4XHymM24LnwnAjPkfs13lgcA46FwQsvvIA9e/ZY3oC8r/Eh2rlzJ1566SXLfTme27dvt3yAeF/jTUmxuX/D25b7tp/bgY6i43KexeVVct/8/Hy57dChQ5JqZ/DWW29h48aN8je/CHjf7OxsuX7s2DH87W9/s9z3/fffxyeffGL5kPC+p0+fluuMdvG68cH96KOP8MEHH1gey9uOHz8uf2dlZcl140uK5ZVf/Pfr0qCLxtPtH/xbxpsVbHJzc+W+xhcEx5seIINnn33WIrb5RcL7Gl9wjLS98sorlvv+85//xK5du+RvfqnwvsaXC7fzdgM+zojUcX+8r/FFyufj8xrweIz3LI+T9+Vxk8OHD+Opp56y3Pftt9+W8yU8f96X40E4PrxuwPHjOMpr2t4ut3GcCced140vP74ufH0M+Lrx9SN8PXlf44uerzdfdwO+H/i+IHyf8L7Gl+yWLVvw2muvWe77/PPPW8ab7z/e1/iR4PvT+nPP9y/fx4Tva97X+ILm+57vf2e/Iz46UoTnXnoVb33wCf7v09PYfrJwWHxH8Dn53ITHwvsaP4COfke8ub8AJw7sQevpzyUCyXP9x3PPO/QdwSjFoc3vo63opKQ+hXg04yr/YxjfVIiHNzyJpqQIPHfHHfgsYy5+cMW38OsvPYQXr74Zh5KnICkYWOd1GAneDQjw8cJ0/0qs9DgiVd8eu3YGprWdwiST+f0c4mPC/KZ9CGmrkkjEYH5H8LNjwM8UP1tEvyP0O2IkzCPc8R0x0PMIfr8b8Huf3/+EvwcjYR7x9gj+jrA+drd5LIzJRXp6uuXvnuB93A3fZJGRkTIQN9xwg2X77bffLm8m401jD19U44UlfPNTXPANQn+I8Wb39fUV4cE3Eq/zufz8/OQNy0t8vLn8IF8gb29vhIeHy5uL6o8ld/39/eVNwf0nJCRYFB5L4vJ2CiB+QPi4gIAA+cBSlXK/FEbGB43Py5eELy6PJzAwUJQvX/S4uDjZH8eC+2P3c5off/fmDjR5+MHDxw8mNoRqrsOiaRm4aFqiPI7nZPheuF9W8+KF48LnZRSI58TjoVo1okI8Xj5/SEiIbOf5cD8+Pj5ynvyAMmJEOA4cA+be8YuL48Tj47hSJR88V4yNuS2WiAU8vREUEoqvrkxHZUV5t+PNVIldx7PR4eGJOeOTEOTj6fJ4G2NojDfHkOPM5zW+HHsa77LyCjyz9SyavcymTlNDFeDjjzmZCbhwUqSMIcfBy8tLxpDnb4w3jyEoKEjG2xhDY7x57HwNjPHmufFYOd7GGBrjzTHkcRnjzfcox4vj3dLSirzCIiQnxMl4c/w4Njx+4z3LffD8jPesMd68H/dtvL8dec8a483z5ljyvsZ71n68u3vPGuPNY+fY8H3E240xHC7vWZ6vMYaOfEc0eofgnzuyYWqqBTw84eEXxC9Y3DQ9FMnxMUP2HeGO8Q4MjcAfNp6FqaUBaG+DR4A5xzbFvxXXLszsc7y37DqF3H++iNj1H6LIKxT/efEDCPdoRHWHH3779m+xK3Mm9k2bhyz/eEl7CuxoQLuHF1LiojAzKQTzYr3k81fb5oEgjzZMjfHBjAnm35k3th/HO4eKUNDgBW9PE8YFt+HiOeNxyezUQfuOsB9vjiHHhONtjOFQfkcY71nj/a3fEUPzHTFc5xGj9TvZ3eM9lr8jzp07h8zMTIc8Fg4LCyMq4EiH3oFqkDdt2jSsXr0aTzzxhFzni5ScnIx77rkHP/vZz8akeZuNpp7YYFbT1jC3mCbE4QLfE+8dKpLqVPyb1ViumZ2IzJjuS8GW1zXj2c+zJf2CMO3hxvnJUkVpsGEjrt9/Yl71sYbN9r6wxP0i2hmYS77xRKmME5vfXTYjoUsTQDb9Ygd2mlUTwgJwwZRYMakq7mXjiRJstSqlanDNnCRpujZY0G/AEq4ni+ukIzUrgDHVx1H4+WRFpkAfLynfSlgK9nefnOzy3T4pPhQzk0Lx9y3n5HOydFwUbpqXAl8aJ7j6xlWul15Cx/vvw/N8iL3aLwjzvv4C2rw6LX40XC/KiEBFfat4JMjctAhcPTsRM5LD+uzzwqaPp0rqRJTwu48lYxVFUZRhbN42Uhzs/x5MfvCDH+DLX/6y9K1YsmQJfvWrX4mq+upXO2uWj1b4w77jXDkKqpoQF+qHRZlRUjaUTZ+C/Xws/gWDxLAADAfYUZodZvMqGxAT7IerZiUgLMAXCWH+vdaK33zKPFk2YFWYT44WY9yqwRcWQb5eUjHGvmP1UHfxpmB4/3BnTjg7eL+yOxdfv2ACfM6PLd83/9yRY2mId66sDi9sb8QDa8a7pRY890/fCTsIhwb4SN+UnvqG8BjWHyvB0YIaKe1Jc+1gl9oljPIdL6qRVLbUyEC3dTzuqR9IVNDATnJZZY2pRizLmhkdjLcPFODY+Q7vFfXAq3sbcevCVKnE1hcsw/ruoUJZsGCJ1rWTYzEzOVyqJE2OD7Hst6WtAxUNLfKe+8lbh2VM2exu17kK7Mmuwu/2vgj84Q/M85D7891YkTkR2xdciL/Ez4fJ21u2eXt6YGpiCL55wUR5Ho4hy896nRc0jsLPJ7tlK4qiKEOLw8LCSBuy/3sw+cIXviBC4oc//KGEhmbMmIGPP/5YohajmY4Ok5RHLKltskwOjxfVShdZTiAvnh6H1/fly/0IV+uc6VPAlCOucrq7IzdzqTmpNURPflUjig814yurxvXZgKqkpjN9zYCTGJ6jsYo6WDBCd8WMRLyyJ1fGyqiFv2QQekHwfE8U16KkthmJYf4yaTcihieKarusILOjcHZ5PcbHmleojxXVWESF9X1OFdfJSnB/+feeXORUmCeP7MtBYXPX0nQkhncVth8cLpLGfITH9OnxYvj7eFqalw0GfE/ys8T3ogEFzrpp/e+0PDUhFDvPVUhkyGBKQijiwwYuOsTqau8eLJTmcIRRq+LaJnhZRZX5HmFkqy9hwfc23+MUDaSsthm//ugEJsQGy+sZ5OuNplb2imhAbkU9WtpMYpA2tbZiRe4h7E6bjgYPP+zOqkBZKxBNUTFuHHDLLXIJmTIVCfnVuLeiAcXVTeAhMsIxNTHMJgruNbgfb0VRFMWNuFRudih54IEH5DKWOFNaZxEVBlxRZDdaTg4nx4fiwTUBOFNaL6vrTBfqbfLNScburEqZ3DW3dqC5vUMmH5w8XDM7SVb/3MHZsvoukRRO7I4UVGPpuN57nSSEB4iQsIbpOwMhKhhV+fxsuYwpJ1+LMqIszbIMUqMC8fW1E2TSzpX+wYhWUFS8uCtHVpEN2Cn72jlmIe3n4zmkXWn5+hiiwoATXE527YUFX/ej51e7rTmYV+0WYcHSxUxD4uo9U2FWTYzpdhwOF9TYiAqyO9tcmrS/73uKZabGHcqvlrFhozWu8g8UXAz4+GixRVSQguomlNY2ifC1pq3DhNMldSJ8KCB4XFx8sP48sfyqISq4T4pSXmeU9EhBjUSnZiaHyfuxuaUVs7MPY/me9bj0+BZENdbgwRsfxvpJS9Hc1oFT19yK6FtvAObPpzKXfXLZgq/1YApJRVEUZXAZccJiLMJ85+63d6YKMdowOyW8z30dyqvGe4fM1Wy4ssrJBCfsnFAztebN/fm4e5l7upj3JAE8erylk5UTopFdVi+r4IQT/YvdsKpsT3VDK/6xLcuyqs8Jam5FI25blNrlvjwGdjIfLE6X1tmICsI0ogXpDUiOCJTUEXbwZgTCgBNK3mYwJT4Unx4rsYlasLLOhLj+p5QZETJ7rFoKWOCKtPl1t32MO4QiheELO3IkXY5wUs/3dnf+F67C20NRzcdYCwuzAK6R7RzPiXGdkaLe4HtkXtrgTJyZmmdE0CzPz27S3Qiq8AAfMZYbKUYsnUwRZvSROZBbJSltTHWKpT/BwwNltS3y3jI8DyH+XvDduwdfXP8OLjq8CXE1nX6SssAwhDXWWZrVTV8wjW+0AR4BRVEUZbihwmIEMC4mSCZg1hM5TnKYouAs+3LNpTcJc8yNiRnzzDnn4GouTZj0b/QXihV6QAxxQJi6NS2pb9N8eKAvvrp6nBgy29pNMhEeiJX4/XlVXVKFmGrGCFFsyNAanLubBMv2uhaZ7PI1YtrRtjPlFr+AvWeBkzyKJHvzdk9jyVVppl5xss1IGB/fE7Gh/iJKrVN/+L6ckdQ1xYoTWq52M1pmzRwHxHBfcFJsiAoDCsTuXsPuUrToDbBOV6KoeG57tghtM+VivqYJm/D9TC9BOV+HyACJdhielr6gEGBEg8UJ+BoyfcpVccXPCIWMEWUwuGR6vHSU5usY6OMt5/bvPXkiJvh6Gp9LvvfXTonFvpwqKVXNbxd+1viZ45hw4YL/0gdR3dSKlLJc/Ph/7rE8T61/ENZPXoY3Ji3HtrRZ8PL1EbP419eOR4iKCkVRlDGJS7PHK664Au+8847TtymuwWgEU5Q+PFIkTbdYUenCKbGICnbeFGotTgyfg/UaMqsv+bgpyZn7v31xmkxa8iobxfuxelKMTGocfTxz1AcSTqS7gyliQ4115MEa6zQXvgeunJXY6344mb5jcd8Vwoqqm/DCjmzLKjjFCEUJxUhP3LQgBR8eLpK0N76uKyZES9pYd6ybGier6UyJ8vXyxIKMSEzvRoQ4S5udqLBsb+8aUWEKEAUTzduGEKJB2dpfdKyw1kpUmGH6HkUbz/GZrVnSx4GcKqnF2dJ6h8aXAuDZz7NEyJM92ZU4WVyL6+a65hGjqFg7OU6+FygEaaDOr2pCVWMRUiKCcP3cZIQH+uDvn52zFEIQ4VhUi7nn05E4dEyPkrE47wnJKq9Hxf4juOvQRoS1NeH5ax+Q206HJyF7yhzkBkXh9YnLcWrOMjR7+YowvzAhFJnRQbh7eTqig7XimKIoyljFJWFh3VTFGpZ/tW6CpbgP/uBPjAtBTWOrVH/py/zcEzOSwy055vGhfrLSTcOnsWg6NzW8z9KOzsAqLzfONzclHI5worknu7NzJmGVre5WtgcbTtCZVsMJqDEJZtWlgSqluf54sU1qDf9mFafeJs2caDv6+vI9u2ZyrFzcCaMJxhgZRAb5SeUxexgduH5esnwGKupakBIZICv/1pTX9xQpakZ2eYNFVBjQd8P92fsa7KE4MUSFAVOPGPFxtfwv3x9pUYGyH6b0FVU3oqDKQ/xXNMpTNFF0sDIVU58IBQj/ZjlXRjCMiF1IaSEmb/4QN3/8FibnnZBtTd6++OvKWxEfFw1fbw88/6vn5Psh3ccLfjVNCPHzxhWzEjAjqf+RJ0VRFGWMCYu8vLxu/zZExdatW5GY2PvqqeI6TCfpr8GUExFOJGjeZjrMzUkUEp5oaTdJrXsKi7EEjb4XTonDltP/v73zAI+rPtb+qPfee7HkIvcm916wMYRmMDYdm3CpFwg3Icl34QKXkEBuCJCEhE5oBtMMBmMb4957k4sky+q997rf887qrM6udle76mV+z7O2dLTlnLNHq3n/M+9MEQfS/q0ZAGvbXfYUy8aEcACIgBQthLvLWG8MdOppt01V5tRfgZH+mnGhPLsBZUoo68M8D3OeCIgAU0IAJWX7DLahJAgZpOMGAkYBmcSOKK3Rb1esUFbT2KW5IrhmkQHKr6in2sYWPm5ne1vKq6hjwYHMRoCnEzdpQFYKxmxkF66boC3tWnBuDwW+80+KTDque84mW1s6EjuRtoxdQGRvT2E+LnT7tEgWEG5Odp1e2BAEQRAGN1YJC0ysNva1Aqb1vfLKK92zZ0KPgY5MHXVlGkpgJggEV11TS7d4S7ob+AR6w+8R7OXC/hL9bQOjrGV8hDffzLUjhscAGToIBC8THgB0WkKAjraqEFU4fpRvLRoVxI+B12d/qv4QPATuECMdEe3nRgdSi/W2YV/DfbQCB/t+uaiKahtaKDbAjedIWArKy/IqaklpEIV2syiTg+fB0d6OS6EifFwo3NuFQqmO7pkeRjZO9pzNiCjLp6Ck49RiY0MX4sbT5tHz6NjUhZTn6EE1raWC8HkhW2aJgV0QBEEYulgVRZ0/f57/HzVqlO5rBYwLR7YCo8SFvgWrts72CChkVdFSsALrPsRXYWHqxvA8pcsUB9Qjg2ggYUxUIGD/5mS2brgbsg9LEoJoSnT7gWobjmaxuMJ8DXRHQqC+dnYMG9UBRAlExp7kQvZMoGxuxbhgixoLwDQNozfa2yKgxzW3bHQwCwh4H9SzauB1umlSmMVdyDCAElkLtHoFzRoNt3qeFRfALYoPnk4n1y0/UMKuHyhg3w6yefttDAbiYXiXh82kUet+TWdnLqUir0BKyqtgAzumXmDfbG1saU1ipIgKQRAEoXuFxciRI/n/jz76SPe10H8oqKijjSdzODhB0DItxpfmj+jeenZh8IJyHEzkhqEYwNPT0zMxEPSnl9RwIIuyNEu7K6nBY9GTwJSQxjBJRVTwa2o0tO18Po0M8dTLUCGjoc7YwH+AFXt0cVqkKlXC/IeJkd7cecnX1bHDrk4ZxTW0NSlP56XA9Hk3Jwf2gCjn9+DlYr1ZNehyhYGCHc2k4eNp0bC5GsIF7YmRecP3AfYaKv5oPRXs/IGWHtpB9vVtz9+wdx+VXX8Ld9Qi/2A6fP1dvN2xuYW7zcG8juPDOUDJVJiJRgKCIAiCoKZTdR933XUXrVmzRlaw+hFYAf3ieBb3tleCLQwMQwkNViwFwRIQ6GI+Rm8AEzQmsyuDEF0d7Wl1YqTF5Ve4xr8+kUUX86u49AcB8bBAd8osreWyJfiFrhTVcCYgrbia/Nwc2VeBah4E4zA6KxPKDX0S8Ntcyq/iEiLsX2lNI103IVQnfGBgdnLvWHThOdcfyeASKwBx8cOZPHpoQZyeaDMc2qdkHivrm/TKtvD7feRKCZuvYdqeHOlDdna2FOSJ47Lhkizsc1NpGf3pyevJrUYrEkFBYDhdXLCCjkxfQvXDE+gaI/4ZLEgsTvBvNXtjYKR7hxO7BUEQBKFLwmLYsGGUlJREo0eP7szDhR6gEMFPq6hQg9VnERZCf2TXpUK96eoIiH88m2vRgEbMqfjrT5f4+kZpU4C7IwfcKE8aFeLBnZ62nM3lQLmusYlqG5ooCwF3i4ai/Vw5CEfwbGgCh2BAcwNMsVdatPq4OtLFvAo6kOpEc4cH6D3mZGYZC3iIAGQXMENC3U4Z+6eICgV8jxkTSstXgE5f6C6lBkJLnVHBMMf39qWxCRztfdEhDpmEdTOj6JrSS3Ru8246dO3tXL6UVOVKBdHDya8gmw4nLqbvE+ZSSsQIcnN20Aqo1CLd8RlmpWL93SmuEzNyBEEQBKFTwuLXv/413XHHHfTSSy9RQkICm7bV+PuLMbi3QXCAYAmZCzXmBpwJgjHQOSi7rIazXQi2ewpMODcEK/fmDNi4vndeLKQ3dqZSZmkND29Dl6JTWRU8zwLdvJCRQBejytomcne2Z8NyQWU9B/+5ZbUU5etKU6J92nXYgqi4cVIY+zGQTdF2gnLh9s4gpaBKT1hcLqyi70/n6L5Pzq/koP0elTCytzVenoX9Vo4np7yO4gLc+fFKS1j8LsPzghIuiAhkLarqGtn/wpmU+kaKzzhPc7/+mYb/507yLCmgYDs7KrvuJnILD+X5Fd/87hWq8fShrPJ69mBg8CWfnFZgUMf8DhwnysMAslUwaguCIAhCrwmLdevW8f9Lliwx+nPD4FboebBKOjrUk3vXK2C1Vr0q2p2gHnzLuXxeOcasigUjArldrTCw2Xouj1f+FZDtwnDGnugG5OfuSCUGMyMQ7JvzFBy5UsoD4WobWwe+NTbzDWIE2QilVCm3rE7bRhl+AxutCRkTy5tamsnJwZYSDYzbyFJABMQGuNOjC+Kppr6Zg21122GIFDXwXhgCbwKmaivDK4cHu5PbBXu9MivsC+ZnYBr2ptM5vO8QQsP83SgxIZjnTAwPcqeDl0voZGYpP19ueR13tBpXnU837fqW5p74mYKLc3XPWefmQRdnLKbcvFKqaHFhsdDk5cfzaXCeIdjUIsfRzo48XRz4+B6cH0dZZTUU4O6kM6kLgiAIQq8JixMnTnTqxYSeBb38YQ5NLazilcjpMb6dHqYGUyemE2MVF6u7yhRolGscQ3CXlE/uTnYsKhD4fHU8i9bOiemVtqjWgsBtV3IhzyBA8Dkm1Iu7AknXrPbmf7WoAEk5Fa2r2B2XxsCXsCe5iK8RXBdoT2puPsO84QFsbFYGtCEY7qgLFYJ53A/BNwL0spoGfl2ICAyMd2vN0EEUYJUfJmlkK+BtQKcnf3cXFhtfn8ime2fHcIYAwT1Mz7ge0LUJDQ/Q+ennC/m614XYmRHrp7cviujA68M8jtau6u0Avz93zoimXZcKWBwEezrzcX99PIcnm8PHAJBNQRYDpU3Lx4bwfp3KKmMxgUwGiqlgpvY8vJ9u+elj7es6OtORcXMoY8m1tHfYZAoPbvPG4PiVgZroEDUuzIt2XCig7PI6zsCg9S12E5kNL751fQK6IAiCIHRKWEyYMEHOXD8EAQ061uDWFXZeLOC6cQWUY9w2LYoDwA3HtAbxnLIa/hk6+SBYQiCDIDRwRP8TFgfTimm/6niwCgxWjAvpw73qfyDwNbq9rM4iYbH+cIbOhIxAHgL3l3OHmZwZAdFx/7xYFgtNzRqeLm9OCEMgwuuA67GkupE0pM0oNGuIxUKknxs52tmweMTshmvHhXLQ/MGBKyxGkEWA4Vl7rLUczG88mc1ZN4DnwHUPT8WMYX680o9rGqIFQwoNRRK8HJ8fydQNvoMn4qrRwe0meUNkIesDHxSEBkqSlNdXgFDCz2EyB5WXUmnUx/+ihN2b6fuJS2n9tOv4d2znmDk0I/kI/Tx+Pl1OXEDRUdrJ2j5Gsjw+rg60amrbvKGZcf708aEMNr0DZKHmD5eucYIgCEL30f+mgQkMVikPpZXwaujIYE8OdKydBo0ABoES6soRFGEoHgItcyDoMFy1RkCD4Bz7giBGvRs5pdpVWNAX06pTCiopOb+KXJ3suQWo2jiroC4P023LKRdhYYCpbkzBXh1nvSAoDDsboVXr5jO5tHBkoMkSG2TWLB3WiGuwqLKeJ0ojQ4DZD7jihge6kZujPXdQwuvgWr9pUjgPzANltY3trgFkIBoaW/j3LKOkRtdaFUPkIFzwWKz442aKy4U1/FoNzS38GpghgdIu/I6oS8cwNf3L41mc2dOaxh117XHrW2eGALfSYko8+QPR/9tK4fv2UXjr9io7J3pr/NU8V8TG35/+dN8f+LFoV5sQ4kGTo33p25M5Op+EqfcTWcf75sTS6awyFjKjQ70GzABEQRAEYRALi5aWFnrnnXdow4YNlJGRQU1NbfXDICUlpbv2b8iBP/goK/rqRDaXdiB4wOovVjevHhti1fOgzSaCGYCgL7mgileIsWpqCqz2YuXWkJr6Jqpt1G5HKQVWZ9FVprFFuw217WPDerecYvelQh5UpnDsSgkbZ3EMMCAjaMIKuDEDLdqTmjMJdxUEvScySqmkpoHLTuB/6e9TixEkw5NzPEOb0QEIrC3JVhheM8XVDZRaUEXZpbWcuRgR7Ek3TAyzWnwiSEfnJUyWxtRqGJ29nB2puqGJ6m1aWORi/5CNwPWIa/up5aP0ytwwCA+Px/utMDHCh4UEZlxAMIPG2hY6X9dkcbtdmLfRNAEZPGQt8P7+cCaX9+eGSYosIPruVI7u9xCfnXgcfCERPq58bqi5mf77zado8oXDZNv6+6SxsaHLoyZxN6evY6bxNlyrOB8wXaOsC6VT8I1A2CMbsVf1u4DsTUJI+zbTyJ7IbBtBEAShXwmLP/7xj/TGG2/QQw89RL/97W/plVdeocOHD9Nnn31GjzzySPfv5RACQ7EQiKADDKiobaKRIR5cb40uMeZEgRoELAhmsIgJQ2lhVQMHYWjLuXpalMnHIVBCUJJh0PpyeLAHd8o5l13GK8MQFwhuIDAQSM0ZHtCuBKQnQVnW9vP5VFHXRB5O9mzIRbD2r92XebiYQmKMH5exfH+6Vi/oR3D24ubznOFApx9ldbs7wPO/uy+N6/8Vvwo6+/xifCj1d1DfPybMi68ZrP4rrVk7AvMTMIUa054Rv6cVVvO1h9V5gBKm01luNNHKZgLwbCjiEXMn0J4WBm9/d6z6a1gsINsAYYFrEf8bemdwXwyLRNYChmV4bCZH+XBLWWRMFGEBID0c7GzYII4uULjOkVExbL8KPwpE086L+ezhQHURTlNtgx19fjSTA30INVwLKHsCMHCjo5NNdSVNuHKWCmYvpJHBHnwtBnm7akVFYiJVX38TvRM6lSr9g/hcRhZUUnVuJR8XFgyQdbQhGz4PuOb3pxbTteNDaUSQB/tbUMKF38n+LmQFQRCEwUenhIWSrZg+fToLi8cee4y3z507l77++uvu3schA4Ll09llbLZUQB05MhYI2q1ptqUES2jJiSBRAaVREAmTo/S74qj5xbhQHjyGLAdq08eGe9G0GD/68MAVqqxv5mFhWDnFSukLN4zlVVBrgCEVAupKsbaNJsysCGYtBa/91fFs3co6Aiis/nq62FNWaS0HawqH04rZpLtiXCibtxubmymtqIaN5wCZIJh3cQzd1VoVK+yKqFBAUDs7zt/qc9UX4DxYey6QiUA9P1bstbMliKIC3PQ6KaHkyBphgfdZXZYX6u1CV4prOEB3tndkszR+J9RzGCAY1KAMCZk7ZWZDY7OGn0cbdGt4+JuLgy1fk8i6Ict1Ma9K15UV7+OG0ky6Y0aUroEBpmRD1KYUVrIvBckaJYSv0TRzBgPXAPwW0DiOdrbUXFtLvlu30H8e3kqJZ/eTU2M9/W3SVho3awLNHRFANPZVIldXothYQrNX592pVFlZz+cRWSOIFGTZUMKHDBy6SikzLrDvAPsupU2CIAjCgBMW6enpNHnyZP7axcWFKisrycPDg6dxP/nkk929j0MGrEZiBdbfzYm7uai3x/q7tRtkZQ6ssKLdbEFFWztPBFNY5TyRUWZWWGBFFEPKEHQjKMLrwuAKoYE2mA3NGg76YGpVOgAZA6u1ygAztN1EtgWPwyRiZZgfArdvT+XwfmEqsqXZmNSCSt0wMzwnBFRIi7NRozDEBrr9TIjw5mN4f19au/ucyym3Kpg2VkaF/UgrquYMBertcX7UP0Onn/4mLHBt4T3Ee4SsQ1dKwxDUQsQh2/Xcd0lctgQRilkQEAGGA+k6Aqv1OI8KaIfq7eLAZVYVtk0U6u3M+wxxgGsdHhvD63rHxQKdqFAE90/n87lTE0rUcL3gkCE2AEzkuKbUv2vIjEAoQFhU1TVxdyVkKS4XVvM+AvyH0kV8hfI3+CH2JuVQ/tff05wfN9L4ozvIpU5rEgdFwZHkWZhHV0qqaS4FEI0Zo7ffN04Kp29OZPOiAo5t+ZgQmj8igF7dnqybsaEQ2WpIFwRBEIQBKSyam5vJwUEbwEVFRdGBAwdo6dKldPnyZXJy6lx7U0HbVQZdlhCkwBAKnwCyF1jlRamDtc+1cnI41/k31bdwGQUGgyFgMjR5mkJthFZ3sEHnHWWNFmUoxkAA/+mhDF0rUdfz9nT7dG1nKcMJ4Qi6saJvqbCAUIBIigt049ISTDLGc4R4uRit4UdAquBg5Oc4BmRyUBqDleAwb1c+3lAvF4oPdNcLtjG/A9kWCC1kkZRsC47rwwPpvB2mefhZMME4wEMrJHD+EQj3J1Aqt/5Ipi67AnF3W2JUhwb/jgTX5rN5ZGdnw9OucYOgmjfcnyZFeZt9HAQjznuMvzsLMLyXEMgwWIP0khouvxsV7MHXMW5osYwyPFOgo5Wp7lcI2FcnRrLQwPvm7+5EkyK96fszbfMh1IIEWbwjaSXcxQrXjJ2NrVZR6GHDogKCreiDT+mml9oWWgq8A+n49KWUuugaKhs5hmunxpjomIV9WTcnlq8lCFRlPgdM6RuOZnIJFIDYMWyDKwiCIAgDtivUfffdR7feeiuXQe3fv59uueWW7tmzIcp1E8J4mi9WJGMD3HR99TsD6qzvmhHF3aVg9FRqrq0pO1LA6q6dLWq89U26hrXnCj8l5etEBcCqMVaP58YHmJ1EbAkIugDq47FKjeDLwdaWHpgfS7suFekCUYAyEog1BfgGkJlQWowiQIOBF+bq0up6LnNpbGqhMeFe2o5DQR5085QIXfD72eFMnchSsi2+bg68uoyBgRBtWJ3HfID0Em29OwJNCENL/TG9BfYd2QXMg0AQD8H388V8umFim/HYUiDu8J7vTSniFq1Bnk5cklZeqw2MJ0X6stg1Bq6TTw5l6Er2cJ2ijAhlTSvGhtB3raIDRuUgLxfdDAZwMb/SrLBAR6uUgjZRDIJULW1h7oe4gBBANyh4OJRuTWqPQnFVA/8MXh4Y1XHN4X22t7eh5qYWGpd7iX5xfjflBEVS/br7WFjnJM6j0qBwSpkyhw4mLqVDwcMpOtCDrweA1+lIFCjlTgq4dh9ZFE/pxVqRpZRnCYIgCMKAFRYofVJ44oknKCwsjLMWy5Yt003lFjoHAolVUyM5UENNdVe7Fi1JCCYbG1vOCCB4hJG5MyucCJQ8ne35ebzdHHXeCKWExJKZCEqnJtSL43lwjAjAPZwdO+zEg0wBSk/wugj2EVBlldZwsI8EDMzXQZ4udPPkcDbd4vXRUcuY8LllSgTtulTIQ9GwTyOD3TlIhFBQVu9hzoWpFq+B7jqjw7y43EqduQHIlGw+k8fiTckEoc0qVq7HhnnS1WODaWyYd78axod9hjl548kcFoq4LjBxGkZrBKydAaICnheULjW1tPD1gjIlZW6EOR8xSvPUPiDsHzwMEHsQPbcmRnLmA2VAEABq1CVBxsBEeJislRV+vA8YfmfYYhk+DKVdLo4B76Wboz2bt3EcaBcLfwbOUZSfC2d7IrNS6b4zO2j+yR0UUZbHj82JjKPG2S/Socsl1OjsSs/9dSOdyangEivXumYKaWymaF83ignQGtk7UxqH7IUpQS8IgiAIA05YuLvr/1FbtWoV34SugaAW5TgI4JFt6I5WqCj3WDYmmG+WgtVhrDojCENGILWgWjeFOMTbmRqaNLRychgNCzDd4z/Y06ndXAOYvbHSq9xQIoOuV7dNDzA7GE0xyypAmKyZFsklSdiOlXCUHuFrBI3xrVkKBIjGOuOghAYr4gCPwfMrnhBFGMDA62ivfey7+67Qb5aN4HNpDHgJsA+KiVb7HMii2HF2qD+JCoDysWPppbziXV3fwsE6WqB6ufhwV6XOAGGF7EdNYzOfPzw3MgwQngj+MfwOWaITmZih0MKdmfA+AYg7QyA64aVQyuNcHO25Fa7hjJUJkeYFKTJUDy6I42wENAmyKBAras7nVupdq4o3BqVImIz92ZFMzrxgv+FvuPPAl/TMzo0UlntF95h6J2cqXrCMXO+5nbx9XVmE7E4upDNZ5dwaVwGD+yByMNtDujYJgiAIg41OCYuqqirasmUL3XTTTXrbv/zyS7rqqqvaCQ+hY2AORUcdrNYC+AVumx7Z6+UzCNy2ntOuvgJ0UoKBFMEiykBQhoSg8Xh6mVlhgQAfJm1lvgECQ5hP0aUJXX1guFU4l1PB91fqyNUg2N95sa0/P8D+oNYdZTBKxgTnDQIBggy1+IdQ0tTcwiIE5WWmhAuGhCEoxuPRwQj/K2UuzRoY17W3falFXCKE90VpHwogNrAqj/kExdX1OnGCoHHByIB+V/4EYDAHGAZ3Mb+KjxniAvs+z0SpmjlwvmB+VzqR4X2srm/m7Bt8G4tGBrGIhDdAyepAuELswmyN9wiPB8h2IFPnYA+zt/5qPq4RJwc7znahJWykrxvvNwSLOeM9hKS5blQocVKA+EAnqcKKOnp3bxpfq54l+RTk4ckCEgQmJ7GoaHZ0osI5C6n6+pUUfsdKCvVqmxuBNr3IdiAbhDI9XENuzvZ87eDawjlDKZ8gCIIg0FAXFr/+9a9p7Nix7bYXFBTQU089RX/729+6Y9+GDAi+UUqiiAqAAASrypZOJe4OUFa0N7lIb1tKfiUHnz5u2iAor7yexoR5mjRtKyDQe2hBHPsXsGKNlWIEeIUXC/jn6HoFsaK0I8X3xlbLEfQZ+jpAUm6l3sAzhZ2XCrj0RS1CMHDw/nnDjO4nSrMwuA2lUdjPYC8Xyimv1x0fSlXQGaukWlsChZaqmKuAtqe+ro40O96fg8crRTU8IBBZC7yfs+ICaHYngvTeAOVn2v8daVyYFxVV17Of5JdzYzvVYQiTnHGelHImBP0OdvZ014xounqctunAhwfT2zUN2JdSzMICpm6cU4haiBNcJ2sSI9t1QcN5RvkdbhDhx9LbshfIDEFAdgZ0rQL1jS3czhW/e55lxeS17TP6xYntNOryWXrjta/IwS+Kr8efF99CMWtupMh7V1Owl3G/ErISEFbDAtxY6OISVrpcYd6Hmwm/iSAIgiAMZDr11+3zzz+n559/vt12GLdHjx4twsJKEIyqjc4KxkpEehJMrFa35sQ+YbCevbaPJlPX2EQ5pbUc9L22PZlXpOfG+1OUX1sGQsG1tXxFDXwPm8/kcpmLAh5rargeT862s+U6eDUx/q5UUt220qxg2HEKIBjEKrSprAXKdHDD8eKY8BzwUmDlHcFsXkUdCwiAMpplY9pPQL9rZhQdTivhlej4QA+aYjBPoT+BtrsQrSi9w/TpCEdXGhvuzT4LS4Cgq2tqZhMyMjMIljFHBOcKbVhhfkcWAvNSFNCm1RBkAwD8BxAdyEDgPYDwuZBfyVkOw/bB3FoYJVWq6eAAWQwcl7HrEPuLLmum2jXDr4Dj37YniWbv3kKzjm2nKWmnyE6jveZabGzI9/QxCrl+BF+/8ROvosipWkO/KZCNwDVdVlvGx8HekFrtwMDFCYE9NvFdEARBEAacsGhqaqLy8nLy89M3AZeVlVFtrX5dvdAxyAagDl8pG1J7EnoT7IO6YxJWcDGgD2VLyC5oRYcNr3CHN7pwsI+a809La2ndnBhdtyZz4D51quNEYIrXhRkW9fCGIBhcPCqQOy4pGR0Yt1EWU1UPL0SF7r4QDiGeznQ6W1tWo34NBNAdUV7TyO/BiGAPuphXycEoQPnNrDjzmSOUSHV2xby3wTm9d1YMncgspdLqRor2d2WDuiUggN9+voAnbENUXj0mhEYFe9KB1GJehW9urmORACEHoYUOThCGaNt7KE1fCA5rNSDDbI/AG921iBx0YgAzUNAVTQEZDWTU0oq0HaLQNU3psARg2DcUFigx3HmxgEUMxM6KcSH8Xilghgemog/POE8rHr+a7JrazPkXohJoz6SFdGHOMmoMDqVgGxvOQOA5LAGlZjgOtDtGJgYlUJiOjZsgCIIgDEY6JSwWLlzIJU8ffPABD8gDEBQokcLPBOtAHT7MnOrgOdDDmTs4dQcwripmbDynuXkRaO/5+dEszga4OtmxEMBcAdgfIC4QICFwVK+4olQJJtUFIztui4uSIpStIIiHB8LLFaVGNhwUGhMWAOUymAmBABAr2AjuIBZunBhG53I8uFsT9nNcuBdnGpLyKvUyHOguZNi20xgIlJVVbZiCeVaBrQ23irVmOOFAAELL2jI7ZH6+O5WjK2lCZmfDsUx6ZGE8+yVe+vECeyTgp8FAR3g5jmeUUWKML80Z7s+D4yAicI3jGlze2lDAlLkdJWgKeJzi/XFztKe0umo2oeM9tzEhxGHIVvuWUBb3+ZEsenhGGNlt+ZHOpRXQNyPn8s9sm/3oUWdXqvALom3j5tPuiQsp3x/vuz03MLh3VjRfH9Z4ZtBVDNcRsliYlg1hweetptFsswJBEARBGFLC4uWXX6Y5c+ZQTEwMTZkyhf9wHz16lOzs7GjPnj3dv5dDAATPWG1FS1WYPtFS1diwN6V0Spl4baz0Qw1WkpWOTsqKM/r2q2c7qIHP4T/mxVJ+hbafP+rmMTAMgToCIwSMavOygmEbUAVkOU5nlbMxOD7InecK2Kjq/BVQYmIOBHWTDcy8EDdjw734pgABgNr+Q2nF3DoV5xIdiACyK6jrR4AJb8XMYX56BlqUPi1NCKZNp3P4e4gYmMMxT6G/gvMK0zgC1Z42il/Kq2znk0CGB13E4FMYGezJmSd4VZRMwpXiahYW2De0+YXwa27W8PupgGwGlw21tvoFbo72FOipXenHewpxrABfDo4XWRGIXTdHO0oI9Wx3TZ/PqdCJCtumRoo5eZASdv1ANkd2EFVVUlhQGNHbW7gXbouDI73++jdU5ObDjykpqibbFg2NCHKnq8eGsPfGWgI8nSi5wEZv0CTOg7Hp8IIgCIIwZIXFsGHD6MyZM/Tuu+/S8ePHefX4ySefpLVr15Kvb1vpgmAZKJdAu1QEVig7MrVyD9D56OcLBbqACXXxCNiMiRDc50CqvhkbgSGew5SwAHg/EXgDiBfUoGOeg5eLI/m7O9Ibu1L1vAwIJI0N3UNW4r392s46YH9qES1JCKIRwZ56JUwQVeaO2Vqw71jthpDADd2p4HsorKqjshptqQuOB6vg98+N1WsjC5ES5e/KAk8x3/bXtqCYFr4nuYgzRhCBEEWY59FToCuY0e32duyNgGhVvELpJTDse7br7KQOshVw/u+YEUX7kos4y4AOShAN6MoE8Tg1ypcN4WrQ/SvQw4kWjQzk69OYwMb+hp0/QeO2b6SR+7aSa2VbiVxTWDidn7aE7OvrqMlZKxqaAwJpVognxQV6sPk6xMuJy6ZMtRnuiMRoXxZEyu+K0imsv7UfFgRBEITuotOtSeCv+K//+q9u25GhCsqBPlYN51KGes00UtOPkgpMr1Z3j8L8AbTqNDZgDlkEtZ9B/TzWgBVjBFsKq6dG0takPEorquG6+HnDA3VCRM2By9rWsmp2XyqiRxfFUU6UDxt9w3xczJZmdQaY3jGsTTlPCOgOXC7ichR1pgRCDi1r0XLWMPiFEbgnQWka3jcuT4v0Mdsu1RjIJME7oM4coOwHvoOeamOK8wQho35PkTlAFuuL41n8NQSbcu3B9D41xrKFBpzz5WND+D37x87U1iGDWtGN7NPc4QHtJr+jhazhsDuelghsbPh3wmPnJprw4wbeVOXtR5mLVtCoJ+6n5ilTae+OVGoy+P2ICYCR2/rJ9MaA0X/d7FgWFzhnEEDdKaAFQRAEYdAIi7q6Otq1axddvnyZHnjgAd6WkZFBERER/XaFtz+CVp2Gg+R2JRfyyrMyyAs/T86v5JasCCDtDbITOWV1NC68/XNjpRXmWZhd1XR1ai/KWDAdvCPUA+MUsKKNoBEZE3NZk66QU1bDBnQEtqjQwqo5yrgaSDvp27AOvrdB5mbHhQI9kYHp0urZHh2BjIohyEZx29tuCowNUcrM9qcWU2FlHYX5uHI5GbIKEHMoh0LpWWlNA2eMUD5kLENhDmQq1CVRan/H7dMj+bXxe4CMxcw4vzYxcfo00fr12ttHHxHNmsUlR5H/+Uu64kCUNG8FOS9aQDNHBqPmjeBwWD4mhL47naNrW4yBfWgZ3J1AOPZkFkkQBEEQBrywSE1NpWXLllFRURF3glKEBczbK1eu5JtgGZgLYQgCHQRYEBborLMtSWtahajAMDmYkdXlFEGepo2g6GDz5bEs9kXYtM6T6KjDUXcR4evSTtQg2OvpGnNkQtRiDUGpt4sDB8JqEBDD99FbYDUe5Vcwx6OqCOcB7wkEAbww1ggLTxfjv7o9fW4hKo11RULGCmVn6ve3M5komMpxTtRZOeDmaM/dwG6ZonoPL15sExMXLrRt//xzFhbAd8kCvkUbeS2U7+GcZ5TUsOBUd4syRnNr9gReE1cne5oR62d1pkkQBEEQBjOdEhaPP/44rVixgv7yl7+wYVvhiSeeoIcffliEhRWEeDvTyUz9bSj5gHEVQmLXpbaVbYgJfw/H1raarrrgzZi/QQFB3r2zY7jOG/MoenPaL0y7V4qqOXBTavFXjAu1OqMFQzBq3kO9XCzq/48MTpCnC+VXqCZk29vSHdOj2J8CAzHOy9LRwVavqKtL2JA5svRYECh/cSyLBwaifA3fwygP4zJQzw+xBMzdgFcGAlQBPoPODLjrDjBVHYMJlePAtbo4waBMyQJwfaLT06nMMt02PNcUVdtZys0lWrGC6MSJtm1OTtptt96q/d9CIN5xLi1h89lcvf1KLahibwgEjyAIgiAInRQWe/fupffff59sbfVNiAkJCXTq1Ck5rxaAbjcw3yLwLqtt5NIRlOuwwXNEAA+XQ0BtONsCg8gQFKO8AjXtwwM9Ogy2URaEydLFVQ2cRUBrW1MD6boTCIk7ZkRz9qCmvomDXms6FyF4//p4NiUXVPL3EAE3T4kw6udQA6MvBugFeDiyn8TN0Z783B05gET3IJRi4VxjUbygso6f19J2svAQ/Hg2jztL4RziXFoSmGJSN+Yy4K3C+4dyH7y/yDbh9VGGYw3oYHXnjGj2kkBcoAxpvBGfTW+B9sgPzB/Gx4jKIsxqsGR2iDEwGwPZAwTuKK2a6tJAvkf2E82fr71DUBBRYSHUItGSJVoxcf31RJ6WCYTOdt9CS2U1yDRh0KAIC0EQBEHo4oC8llYTpXrFNjMzkzw8ZPiTJXx6OIMNuACBJoQGDKoYVIaVbIDA1d3JgYeRKYF2amE1B6IYDjchwou7HZkDnZle3Z5MBRV13Dkqt7yGMx4PzBvWa9N/O2vOPnS5hEUFRlJgJbyxWUPfnsqmX84dZvZxmNWBLAm6OinzKyZG+OiOF6vUmLHw7ckcPrfIEM0Y5kfzhgeYfV6IvM+PZHL2BEAcfHMimwVeR8MBcf4VUH6TUqDh0qHahhaaHutJs4bpD5s0B0q7kHnB9YOAHp2GOirj6W5wLWKIYH3rQEGcZ4gzY00ElMAc07IxcR3ZNrQANnX9YftkDw1N3vqjtsxp504idJtDpgJiAgsaGzYQxcUR+fdOWR+GJRq22lWGSAqCIAiC0MUBeX/961/pf//3f3XCAl6Lxx57jK666qrOPOWQAhkERVQAnEH0/bezsdGJCgAhsGJcMH11PJsDORh24b/ABGF0x8FqKUSGsQ5SCmi1qm7tisAOK8qYL4BWtUqgCu8GXn9MmGevZDMsIa24micsQwTgeHGt5Ve4cEBurqQL3YsQAx69UsJiBJ6U6bFtgTvO5VfHs1jMATz33uRCFkAI+tFtCROb8Rwoy0FWAkZ47IciKhQQbF7IraTZ8eaFBeZhKDjZ2/I+ISi/e2a07n2wBOz7RwfTdZ2Z0uqrKOdgLWcLFLN/TwOx+u8DV7ikDGxLyqebp4SzodoYOM9oO6y0XUXDAnhNbpxk0HGgspJo40atmNiyBSsYbT8bNkwrLCIitN9Pn069CcQ/rg/DRgsjQ2QhRRAEQRAUOhWJ/N///R/NmzePNm3axLXiy5cvp4MHD3K2AmVSgnkQUFq6HW1eH10Uz0PIPjyQzqUhapJyK0wKC4gQ/FwN3i9kLJR5dikFlbThWJauM86+1CK6bVpkvyjvcLa3ZT+CslKs3fdaFkIdeUXgOzHlPckqrdWJCjUIdlHqBO+CwpErJTynA34Bw1kKCqa2q4HJF4P2IAYVZsf5mxUVKLfC/iAbosxpSM6vYlEBIzFW9m1aO22hpanah4D7/HQ+n8uJPF0c2LBvqZegI/akFOpEhSLMtp7LpwfmGz+WM9nlOlGB97KpWcP7izI0ZFx0vPAC0Z/+pPu2YfRYujD/akpZsILCJ42mKWE+1JcTIG6YGE7fns5hoY6FgNnxASYzNIIgCIIwFOnSgDz4LDBxG2VRv/vd72jdunXk49N/pxT3F1AKAg+F2rDLHZtMrH6ixGRUsCcHmMoAMgVzdewI4hBUGnbZQaCsdCDacaFQJyoAJmzDj3HbtCjqa1DewwkxVQUKVo0xUTvGv/PdnJTyKEM8ne3Zs2AsMIawQOteZeKzAgJMc+Z5NcvGhPDsBbRmxaRxczMNMK9kf0rbcEN4MFZOCqe88lqeZI5rB34V+FbQTtewSGfD0Uzd6jqyLF+fyObj7o4uRth/Q0qq6/naNOahQYYDIEvH+9TYSNNSjhO9fZjo4V8SLVqkveOqVURff020ejVlX3UtvZGnncbt2GxHPudyuY3tVaOD9Z4br4mMEUqVMK2+J7tiNbW0UG1DEwtJnG/sGwSeseGUgiAIgjAU6XTtBAQEukMJ1gPj7S1TI+iH07m8aosSFgzFM1cnzxOIY3y5ZEcBggHTfU2B8h0IkrqGZsosreE6dwiNlZPDdcEQSqMMKalqv60jkAFAx5zSmkYWLcOD3Ls8zyQmwI3nCqB9LFa5MYwPZVrWBI8QShBS6np+Nr0HebDRWAHvwbgIbzqZ1db1R0GZG4LnWDMtit+DzJJa7tA1Oy7AqhIklLHh1tH8D7SfVYM5JmdzyunIlVIuh1KCamRZvCJ9uI2wAjI6hiU7EJYQJN0hLGCeRzZFja+bk0ljPuaVbD2TTV4H99K1x7fTzJO7yLNGm0nTeDiTjSIsJkzQto21saEPN1+gU1lt1zpEka2NLf+eKK2WkQX594F0nQcJGRqIL2uN8Jby7akcFpUYtAgwaRzX0sxhvePzEARBEIT+Tu8UZQvtwMr7fXNjOSBHRyhLjNRz4/25FAp+CEc7G5oc5dvhsLtrxodwIIo+/Qiw0RVp+Zi2VV90iUJnKjXWtizFMby7r62G/lh6CU+TxiTlrqC00kXwrA5gcQyW7BO6N6HkBud2YoQ3LR4VpDvPqO+HmRi+CV83RxZtCF6x39vP5+s9F7IMCrgPMg89Ccq9DOc4gJMZZbxqDhGRXlLD5U7ImIyP8OrVNsJz4gIorbBaVw4F8/vS0SZay9bXU9wLv6enP/yE3EvbMjAVXn50ce4yirz9XtI9slWIIhuDqeRq0N0L5wUZAoW9KUU6UQGQedualM+/E909pBP7pPZFKeDaFGEhCIIgCFpEWPQxlrY5BQiWEPjiZikwd981M5rKaxu5hAMlWGqWJgTT+sMZuiARgfv8EYFWHAGx0VkRFQonMsu401JXjeArJ0fQqawyNrwHuDtxxydLWtZuOZenC05bmjXslcCxz47Xri4jYwNPgt58BCKaFuPLP0MQryEN19BjW28SbCKjgUwBMk/IkKB7mIKhHwYlc4ZGY1w7MKJ3B16uDvQf84e16wrFQBBlZbWZrB0dibZtY1FR4+5JZ6YvoUvzrqbMcVNJY2dHv5zRvsMX2iL7uGpb8qrB+6cu/TPMmgA8BmVR1rQ1tgSIf2RKDNs/G3qeBEEQBGEoI38VhwimyodQyvHggjhKL67mjEakr6vVbWgNA0CAFXeURXVVWCDIt1ZM4bXP57aVOSkk5ZbrhIUpEIBPjfblW1+BzmDTYvx4yrMCOi4tHBHIGRaUOqmDbXTBMgTzPti8ze2J7dm8rS6DQhYL3gvDAYEoZ4N5HdmQ4cEenOVRi19kDraczaPkgipyc7TjxgEsKi5epJoPPiTN+s/IKT+XCpPTKSTUT5uF+MMfqKqF6E3HYVRr0/ZcyCzg+jME2yCM6hpbWDwoXqFrDCZ+o3TQUFxAVFkqKuCnOZ5eSk0tGi65wyRtU9c+ygrxnuxRlSIiU4NtgiAIgiBoEWEhcPBuTctTQyJ93fS6HSk+EhiU+wKIA5SK1Ro02cI+DRRgFh8V6klZJTXk7+FEsf5ufFy3TYfHo4i7RSEAR2cpYwZ+ZDWumxBm9Ln3pxbR/pRi9mggQ/WLCaEcyMPHsel0jp7IqKlvZj+QAtr0InvEZGRR+UdvUN3R7eR89jQpsqXJwZG2frKFpq65Rlu2dv31hKvr9so6Oni5hMprGth3oW4BrAZCBsfffC6fxRCEBXw7yICpmTPcn9smK8IWwT+mqVsCyuA2n8nVfY8WwzgfC0eanhaOOTMQLhfyKngf0eWrI7+MIAiCIAwlRFgMUFBPjqAKpSixAW4WrdJiJb+7a8/BqBAPulzkzeZgvAYC+BXjQqwq8+puUOKkXl0GfZmF6AwI9g2HC2o9HpYFz8ZA+94dFwr0ujl9cTSLHl4YxyVthqQUVnGWAq+L7k6KqBi/9Uu65rWndfdrsbOn1EmzKGnucro0bQE1uLpT5cV8vjaV6wCtZX8xPtSi/YR/KNbfnWeZeLs4sLAwvHaRbbl/bixnT1CiFB/k3q7UzxSGQhicyCgzKywAhJIlHh9BEARBGIqIsBiAoEzlk0MZ3FEKQFSsmhphsuMPugxtPpvLbVpRFoOV1+7sv4+A75pxoWxixeoxhsFZKyogSPIq6riWXT0ksLPMideu5KNzD1ayJ0V6Gy0ZGmqoO2EpwABtzJisYFNcTPT9t+QQGU02NuH8XmWMmUIttrb8f9l1N9HRSQso30Hbwhj26oziGiq4Us9iBNmJa8eHtiu76ggfN0e+mYM7n3ViPoexKdooiRIEQRAEofOIsBiA7Esp0okKgBKOH87k0v3z2hthEQR+fjSTilvr8mHi3nQ6l3xcHXVCBC008RyhXi5W+yvUoLsSbkpGBcEbAr+OwOtvOJapM4DDT3DDpLAuGXB7yiuBwJxX9jVE4yO82bg8kDAl+LB9YqS3Tng41lTT8EM/09SDW8n10G6egl2/9GqKeu4f3EWsNDSKXv1wF9V6+9Ht06IoJLuc8jO1WYCCijru4ARfD2L1PclFtOdSEftbpseik1nfnzN0G1NnbgB8FoIgCIIgdB4RFgMQTI42BIZetFhVAkeUvKC0o7i6nmvnlYBfERvomBTo6URfHMvStZuF0frmyeFmB7dZAkqQDqeVaMu0/N24LMpcO9TvT+fodZXClPH9qcU8s6A/cTqrjL471eZBSC6opBXjQmlChH72B1mS3cmFVFHbRDH+rmw8RgcltEpF1mTRqMA+83ugdS7KgNSTxxUTdYC7I92efZSaP/mEIg/sJPuGNpN4XuxIOh01lgoq6jkAzyytJXefcPY98JA+d0fOOGGAH2aj4DpE+RKuQ8VsnlpQSRklNbQmMZKzGNYAoXohr1LnLYEw6Mo5hFEb5VMwbzdrNDQm1It9HYIgCIIgdB4RFgMQmHmxIqwGgbtT6+AwzG6AyRbUNDTzKjSCPLXRFEO+YOBVz7BAGROyGffOjun0vsHwu/tSoZ5I2Hgyh26fbnySNzIlhsPcwOXCalowgvoMTJdWZlzEB7pzJgfdkgzBIDu1sIAHAYPUlDkUey4VUlFVA41tbfWKGR9Id/T0LAxTIItw98xoNlFjknWsrwtNVQa82dhQ1Lv/IDp0iL9tiR9O+xOX0NnZy6g4IlZ7n4YmvtYeWhDWziy+dnYMl1RBfBVW1hHm+CkDGPF1TlkdOTnYcbcra4UFJofDNK0A0XznjCiLMmKmMlpoq2xta2VBEARBEEwjwmIAgk5AqQVVPLQLoE3swpGBOnOremqzq6MdB4II6hRhgTaZ4yK8aNOptq44ChAs6syHtUDUGIJWtooB2BAHW1s23CrHomDNdO3uBhkXtTiCgRrdmCDSDKk12G9kNZB9aWzW8FDCwqoGPrbqhmZuz6q9T3mfCQvg52JPK4rOE61fT5pNm6j+5GlyCGwVFw8+SDRvHtHq1VQUM4J27U1r93h1u1tD4K+BuRweoMaWFhZYOHZMQFdm3kFMItNj7HowBsSKWlQo1ykyGMhcCIIgCILQPxBhMQDBKvr982J5AjfakcJ0imAPGQeUMxkG6fABQFigtSgCdhib0aEHga9h5gNBPgzUHYESFwydw6wBmGenRPnwqr6x8hRstzfh3cDPUHu/9VyebhtWoWcatBbtLSrrGrmdqxpkVCAGRgR58OwDNSOC24zDEGQ7LhZw2ZMi+BQ7sProsb3XQQbl4EGiTz8l2rCBKE97vrEn2/74FjXefgcb8B3vvFP3EL8WjVHRF+VnPtuAn69OjKTDV0o4c4GMGZoGqMXu4bTiDjswqZsPGEPJhgiCIAiC0D8QYTFAQcCHADWpNUOA4A2B/p0zoik+0IOOcsmNFgT1y8cE0/UT9ctX0MUppaCKh6UpQHR0ZOBGidD6I5m6ch/UvUPUYIbAlGgfuphfqfsZQE0+xArmJ1zIreQJxokxvjQ8SGvihcHaz82RjwWGbZQWGRuc1hugbMlYxyAYkheMDOTMC9qbKt6E2XF+PLUcHY8OpZXwcSJzhOPH8zQ0acjXzYGDaQWYpDsCvhg8X21DMwtDCC1TZT8oZzuTXc7zSHDukDXQY/9+ojVriNLTdZsaPL3p3IzFdG7ucsoYM5U0uRWcQVDPgcDzYSgdypCUayTG373d/qNLGbJkOeW1LFjhu0CpE8+qiPGl//fNWSqraeTnC/F25lkQRZWWiwI0GcC1bvi+RJnogiYIgiAIQt9go1FHgEOAiooK8vLyovLycvL0HLj96GFmfXV7st5qMkpw6ppaKNDDiQNkNyc7DhYRDN4wMczoIDWsBp/MLKX61syDJbXvnx/JZOOyGgS9TywZzhkL+Cpg3kbpEFb5EWhiCvTRK21iB9wyJYLiW8WFMSBY8DwIXNFJCGIEwWlPgtd67edkPr9q1CZtBPtNLS20+1IRlz4h4EUWKa2ohgoqarnUDCVSDc0azhDhONNLqim/vI5FGwQJJombOnYIt08PZ+iJM7QHRstWY54W9VA7BOC3eddQJHTZ5MnajchOhIURubrysDqUOf2lJUJvCjaAOHpkUXy710AmBq2K3Z3t283VwHl6e+9l7uylfp5fzotlkQjD+us/J3MmCO+cUq4HYz6mdlsKRDOuIbwengMZMkuH4QmCIAiC0Duxs2QsBigNzS16ogLB36WCKl4Zx8TrIE8nDjIR4Pm5mV79R0BsaUmK7rWa2nsNEEDiBmsG2sXipoD6emPD146ml5oMrlGi9eHBdF2Aj25CKPcyFlx3JzAhLxwRSNsvFOgCe4itMaqhaBBo+1NL2YiNgBoZi/yKeg6c7e20gTP8LKP93cjFwY67QCEbo3SUQpYINxyLsXkiEGCGeh+dppYkBLXzvuxN0ZZteeVnU8KezZSwezMFX75AtHAh0fbtfM4O5LeQw6sfk8vsGTRtdDg/h9OOFKptnVitPi5j4P6m2upCRKpFBcD5OJ9byUIMQnD5GG3Wo7lFm/WAOJkc7UPWgKwWhC+6TuF67mi+hSAIgiAIvY8IiwEKgr1gLxcOtJTMA4JRtekZK+n55fVmhUVnQICnTGBWiPZrm7AMIHrQ1hT7hdIciAtD0O7TFEevlLbLGiC4hkkdwX93gvN2Kb+KxQuEFlqyQvBgsjnmfUT7ubab+pyUXU5nc8o5e1FR28gGZRx/kIcTi76CynoK93GlFeOCOJujNtQroMuUMWFhbFAb3ksINz1ycmj4+ndp1K4fKPziKd3mZjt7snNzo8yCCnpjXzqXwjnFjCPKrqb02kwul8M8iR/PtvlawPRY630ttaq2tXrbVUZ3iJJHF8VxJgYZtEjf9ufTEvDY/jADQxAEQRAE44iwGMCg/v2zI5lcZoLsBOYlGNbXO7SuoHcnKENBMI2MA4JdtLLFvqizJ+/tu8K+C0UQVNahTan+5TZalQUwRD1nQUHrWWihbtZJ3GIXJU0KJzJKOfhGuZIpSmoadcEz5iAo3Y7gG6lp1HZBWjUlgka1HqOxjlLV9caDcpwXmOPVIGvSTlDdfTct2baNv9TY2NCVsYmUNHc5Oa9aSTb+/vTFtmQWgAjiw71dKMzHhb9Hl6XJUb7k4mBPZ7LL+OcTI7zNlqWZAmVdEE5q4Yhr0TDDAU+QTD4XBEEQhMGNCIsBDMptHl4Qx12LEOBjdoV6BRkdomJVJUndBQLRRaOCaN7wAF5dNyzPQdmTIioUnB1sKcTLhfIr6tiHMTnKh2+mGBnsqZsCrT7e7i6BQRmPWlQA7COyEeaERai3s86kDS8BumO5Odrz+YDHBT4DdXANwQEvixrFvG4IshgQYocuF7NnZqSrhq4+t4PouQ1Eb71FFNpaDrZ6NTVVVtHhaUvoyOSFVOUbwAIEw9/g0Whq1goe7GNmaQ35ujtyaZYi2hJCPfnWFSAYbpoUTlvO5fF77u7kwKVf6oGMgiAIgiAMDURYDHDKaxv5/3AfF7p9RhS3SkWwjMzFvBEBPWp2xkq1vZGyfGQzDIGYmDs8gLMb2KOOOk9hoBymhsO8jY5EqMv/xQT9rlaWgHKqg2nF3AIWQTUM4GqxhSFxxiipMt+1CCv+Z7MrWIRg/9DVCmZtlOtAVNwwKUzvGBFswxie0pqJiAtw522mmBXmRjNP7CD6dD3Z/PA9UX2rj+Hzz4kee0z79d13k/0999BMIoqvrOf3GgG9UnaFblRKO2FIDPg6cJ+fzxdwtkQZ2tdVkLUYFjCMy8FcHew6fG8FQRAEQRiciLAYoCBg/u50Ds+ywIq0i6M93TgxjG6cFN5n+3O5qIrbihrLKqDFLMRPR0IHx4IMDKqLkBGZFefPgTtWxjsDVtLVsycuF1XTmsRIXfcrCBYEwoZ+jig/861MRwZ78L4p2Q50gpo/wp9i/d25naphcI2szi1TI1hcAJM+kcxMot/+lmjjRrKpUpVDjRjBGQq69tq2bSqfgro9r5+79vxjMCKEXFZpLZu47WxsaFSIB+VX1tG3p7LJ1hZlV90jLpC9sXTgnSAIgiAIgxOJBAYop7LK2LuggPamG0/m0CML43p9xRiBPyYtoz2sAkzPyKbAF4GgGsPXOprmDa/I+sOZVFBZp30ON0daPTWy0+VP8DycNChzgnCBN0QRFgjwl40Opi3n8nVdiyZE+PAqfEeBNLo6Yb4Esh5h3q4muyqpaScompuJcnOJwlsFIdq4YYBdQwNRVBTRqlVaQTF+vJ6QMAeyIZF+bpRRXM3lYxAaKQXVLIbUHM8oE9+DIAiCIAjdhgiLAQo67BhSVd9IhVX1HEz2Jli1V4sKUFHXRGvnxLDZGvtjbCK3IT9fKNCJCmUux9akPFo1NbJT+wXfiWEmQhEcatAFCn4HmJpRSuTnbrk7HPe15v4MBAymYK9fry1tioggOnJE+zMvL6K//51ozBiiadMsFhNqICyRlUnK0ZZqBXo60aZTuaTRzQHX0mykU5cgCIIgCEJnEWExQFG3lVUHlIadl3qD3PI2MaCA1X90TYry63jgngKGsBlyxcg2S0H5FF4/vVhfhCWEeBrNJHSmK5LFoLbr5EmtmMAtI6PtZ42NRCUlRL6+2u/Xrevyy6HkDB6KseSlmzcBoaGmuzwWgiAIgiAIoONlZKHHwaq6tQPQp0T7tvMdJBrZ1htgIJ8h8Byo6/4tASVPOAvqJIOva9e6C103IZTN2ihdgs8Dvghlgnav8uijRJMmEb30klZUeHgQ3XEH0fffaydjK6KiB0BJGsrV4F25kFdJjc0aNtKb63olCIIgCIIw6DMWdXV19MUXX9CFCxdo7dq1FBMTQwMVrOhvPpvLHYsQ9GK68Jx4f4uGhyFjsW5ODJ3IKOPWpPAEmJqO3NOgPSo6JKnLoeaPCLBa5EBEbDyRzaVKmMmB6d3obNUVYGBenRjJJVlYxe/JLlk60tK0WYlbbiEaNky7bd48orff1pqvb72VaPlyIhf9mSM9JVrhfymprmejutLNa2yYV6eG1AmCIAiCIAwKYfHhhx/SU089RZMmTaJNmzbR4sWLB7Sw2HQ6RzerAbMF9iQXckmOufkOhkEzVp77Gvgn7pgexeU2ZbWNPIXb2mwFPCOY8wCDMXwiSOB4OttTfAcmakuBcOtRcnK0putPPyU6dKitxOnpp7VfQ1AUFGgzFb0IpolDVKjBMLsz2eU0J77vrx1BEARBEAYPA0pYjBgxgk6dOsVZCwiLgQxW5ZML9Kcrg3M55RYLi/4E/B1d8SjguAE6K0X6alu91je1UEFl75vROwIm770pRVRZWkHT9/1AI3f9QHa7dml9FAB9XBcsIBo7tu1BTk7aWy+DrlzGt/f6rgiCIAiCMMgZUMIiMTGR/8/KyqKBDmYK2NrYULNB4GePoHQIYuq4Lekm1ZuUVtTSRwfT2bNgX19PcS89S3a1rebwmTO17WFRAhUc3GP7AD/OkSuluhkaEyO9eWCfMWBex8C+irpGPRE4posTtwVBEARBEAa0sOgM9fX1fFOoqNDvjNNXoM59QoQXHUtvG94GpkT332wFhruhdAvBPvwc3Rn0T4r0phOZpXrtYWP83bn9a59TU0OEDNn69eRw/hI1vvwZt4FtcnKmgzfeTU0OTjTm8V9S0LgRvbI7mKy942KB7vsfz+YROsdiqrgh8JSsnhZJW8/lc1mUv7sjzR8RaH2LXEEQBEEQhP4sLL766is6fvy42fs88cQT5NuFjjkvvvgiPfvss9QfWZIQTO5ODnQ+t4KcHLTmbcxT6I9cKaqmz45mcn2+4u+4c0YUeXexa5NCoKcz3T4tivalFPHqOozb6ODUZ0CMbt2qNWFv3EhUrc1KwPERkJ5MhdHD+fu9qx/k/+PCem/iuaEYVbYZExYAk8DXTOvcLBBBEARBEIQBISwcHBzI2dl8/XxXO9f89re/ZXGizlhEYCBZPwCrybPj/fnW38GgOkVUKFOydycX0S/Gh3bba0T4utKtif0gAH7/faLHHycqU03tjo7mbk75V19PRRX64g+lRhE+Wl9Ib9BkxCChfm8EQRAEQRCGnLC49tpr+daTODk58U3QB1OtodksyTggaC2s1O8sBPLKawf+acUU7AMHiEJCiGJjtdtCQ7WiAtvgl0B72NYp2EG4brPKaefFAs6shPu40vKxwexb6C3GhHnR4bRi/W0mht3BaI4OUNi78RHe/c4ILwiCIAjC4GHQeywGGs0tGi5rQetWrISjvMXa1q0d+SS+PJ5FmSXamRPR/m5048Rw7sZkzg+CcpqiKn1xYWmQWl7TSCmFVeTuZM/zNiydJQGT8tH0Ui4Vc7Sz5aGAeDyAF2PXpUI6nlHK5wxzGRYnBFnm+4BhHiV4KHP67DOizEyiX/2K6M9/1v584UKiHTuI5swhsmt/XniidbgXCy6cm95mwYgAPmaYtyEOo9BFS0N08HIxnwe0LAaYj/LV8SxdZyhcVzdPidCdQ0EQBEEQhCErLE6cOEFffvklVVZqZz+888479NNPP9HChQv5NhjAbIuz2drWqyApt5zWzo7tNhPztqR8nahQvBM/XyigFeNCzD5uSUIQbTiWpSu5gTdkrgVzEM5klfMxKcEtRNId06PNChkFGJRhVFa4XFRNt0wJp7hADzpwuZj2pxbpfgaBgSB72Rgzx5GUpBUTuCUnt23HbAm1gLC3J5o/v8P96wtRobzusjHBfDuVWUbfn8nVtS7G+bprZjRfL5iLom43i6/3JheKsBAEQRAEoUcYUMLCzs6OPRm4Pf/887rt9ggEBwEorTmXo9+1ChOjsdKMwL47SDEyO8PYNkNiA9zpoQVx2inhdrY0PNidnOzNiwOIkG1JeXrBLUqqDl8poXkdDPbDivzRK6VG26xCWKjFlwJKfkwKi+ZmbSYiP1/7Pbw9KMNDe9irr+6VKdjdDbI2EF84Lwo1DU0suK4ZF0plNW0tZhUwwFAQBEEQBKEnGFAR+bhx4/g2WKltaNYLEvGVTWuw2F14ONtTfVWz3jZ3Z8suA5QydTS8DxPEMeMBXaPKaxuptlH/tSz1ZkCMGDMp17c+n7FyKjtlFkZ2tnYK9vbtRN98o81G4HbbbdpMBTwTEBW9PAW7u8G5RWmbIcVVDfx/jL8bXcjTF6rYJgiCIAiCQENdWAx2Aj2c2EydVlRN6cU1VNfYxMH87G5su4oWrhtPZut13ZoV59fl50WGYfPZXC59giiAqfnacSHk4mDXTlwEe3WcHYBXIi7AnZILtGVvCiNDtIPdJkb60I9nc3XbXcpL6Zrk/UQvfE+0e3fbFOy9e4nmzdN+DQ9FF7uM9SdcHe3I182JSqr1vS8RvtrzC89JSXUDFVTW6TwxC0cG9sm+CoIgCIIw+BFh0Y9AkL9oZCA98+05FhWYzO3l4sClUDOG+ZOjvW23dBSCuVdr/LWhCeHeFOnX9Vaphy4Xc72/QlZpDW0+l8fB7abTubpMDEzgidGWzSWB72PTaQ2lFlZzhmJihLfusUrmJOvHnTTx3b9SxLF9ZINyJ4VZs7SZidGj27YNIlEB8P6tGBtCG45lcqYIhHi50MxhWiGKa+e+ubGUW15LNmRDwV7SEUoQBEEQhJ7DRqOuvRkCYI6Fl5cXlZeXk6endvW7P7E/pYjr5hEoYtVeKflZOTmCp12bI6+8ji7mV/JK9phQL4sM0t3Fe/vSuLWpIU9eNYJq6pu5y5Wroz0fg6VdoRTqm5rJzsZGa5bGFGyY94NaPScHDxLNmMFfNk+YQDnLrqfya2+gYVNG9+rx9yU4P8hwOdvbcbaiq7NfBEEQBEEQOhM7S8ain6EE3c4O+kFxR8H4iYxS2nw2T5cZwATru2dGd9tk7I6AmDEE5m57W1vycbOjKW6dn57u1NxEtGWLtpvTt99qvRL/+pf2h5gv8ec/U+6cxfRhiRP7O6iUyGVnCt0+PYonevc26Lq1N6WIzdMx/q40b3hgj4ocnOf+OrFdEARBEIShQ9/0yxRMMjrMq52o8HFzpFgzplv4G3Zc0O8OBFMv5hr0xmo5yqAqaps4Y4J9UZga42t1dkJHUxPRtm1Ea9cSBQcTXXcd0aefElVXa2dQKMeK1flf/Yp+bPTUiopW4OvYebGQehvM+vj4UAZdLqxi7wPK2D47ktHr+yEIgiAIgtDbSMainwGz9h3To2h3chG3Zg33caF5IwLMTnaubmgy2n2psLU7UE+2O/3kUIauBArejeLqBpoe60ujQ71oXLh355987lztRGwFTMFGa1j4JhIT2/kl8ivaTwbPr9CalnsTeFeaMc1bRXZZLYsu8TgIgiAIgjCYEWHRD0H5zsrJ4Rbf38PJnkueymr0hUSET8/OZrhcVKXnq0ArW9zQsWlksIX+FWQejh0j+vJLomefJXJsLd1asIDo0iWilSuJVq8mmj3b6BRshVBvZ73Bf6AvAvnGZuOWpSYDsSEIgiAIgjDYkFKoQQDMulePDdHrGhXq7ULTY7veRtYc5bX6MxTQZhY3lEV1CKZg//d/Ew0fTjR1KtEf/6j1USj85jdEublE//yntl2sGVEBFo8K0ishQ/akL1qrjg71bGeeRilbmPfAG8AnCIIgCIJgDZKxGCRg8NkjC+O5OxBmR3R3dyC0jy2orKdQLxddJgC+D7xGY3MzpRVWU0lNI7fIHRXiSVOifNqXb2Hq9TvvaE3YZ860bcfUawysa+30hNkL2y+VU1ZpHvl7ONH84QEU4Wu+JS6EFCaDJ+dXEebkwcyMrlq9DeZ3/GJ8KO26VMgDAqP8XGnZ6GDp1CQIgiAIwqBH2s0OIM7nVtDmM7l0pbiawrxdac20yA4D7u4AA/XOZpfrvp8a7UtLRwfz1zAn/3NXCnsIICowEyPY05k7Ic2O9yfCbAkl23DuHNGYMdqvHRyIli3TljlBVLi782aYv/+xI4Uq6hp1rweB8B/zh5GnswMNJGCml9avgiAIgiAMZKTd7CAE07jf3H2Z50EgYMX3SXkV9Oy1oynaTMeornKlqFpPVIAjV0pofIQ3T3KeFOlNUb5uPPgOpUj2tjbkWl5Cmn9+SXT0J6KwMKJPPtE+EMPq7ruPaPp0arnuejpaQTxZ2yO1gqbF2PPzoZuSWlQAdHs6l11BM4b5saejoamFBVWnO071EiIqBEEQBEEYSkgpVD8CQ/EQxFfWNdGwAHe9idgnM0sps7RGr6VsaVUDbT+fT2vnxPbYPuWU1xrfXlbLQgDBM2Y0OFdXUMT2rTR692YalXSE7Fpau1S5uTuE8F0AACIJSURBVBHV1RE5txqp33yT//v+VA53UFJnY+6ZFU0aM21t39+Xxh2WgLuTA62aGiGdlgRBEARBEPoJIiz6CZg78f7+K7rOTvtTi9rKibi1K/FKvRoNabiOvyeBeOho+y2fv07BH7xJDk1t+5IVm0C+6+4k19vXtImKVqrqm+iMQRakqbmFjl0ppSUJQSwaqurbngsTt0uqGrjrk+LbwM+/P5NLa2fHdNuxCoIgCIIgCJ1HhEU/AeVFhu1iMb15SrQPlxiNC/ciLxcHvfvg+4RQC9u6dhIYtGGEvpRfyd/bNTbQwvSTFDo3QnefkNgwsm9qpKyQaDqQuISSF6wgTVw8TY7yoWURIbr7HU4roQOpxVRcXU8ZxTVcwuVg11bOVNPQzCIC3hFkYrJKa8nHzYFsyIY2HMvieR1+bo5sVEcZVF55LWcyMHlaEARBEARB6FtEWPQT0AnJEAxaQ0YCwiI+yIPumxND7+xN420+ro40M86Psxo9CUqdVo4Ppryvj5Pdhs/Jf+v3ZFtRThTgSLRmDd+nes0d9LnnSCqIHq43uK60pi3rcC6nnLYl5fHXjnY2VNPYxH6RkcEeuvuMaP06wMOJbk2M5K9/SsqnQ2nF5GRvS1X1Gp5sDVEBcYHMhmMfdH4SBEEQBEEQ2iPCop8AMzJ8BmpcHO15hV5h7vBAmhMfwFOmEVwjAO8xUHu1bx+3hrXZsIFCCgvbfhYaqvVNtOIZFUYNo+uQctB7CrRaVVAbwCFW4gPdKaWgmgfKwaORGO1LY8K82u2Gck5CfVyorLaBu0YVVzVQbIA7TyQXg7QgCIIgCEL/QIRFP2FihDelFlTxKj5ASdCKsSH8vxoE0r0yUTo7m2ju3Lbv/f31p2BjWIRqnzC74YtjWVTToB2OFx/owWJBob6xhc3pyhA7V0d7mhDhTevmxJCni4PJciYnB1uiOiI3RzsaF+ZNhVX1/Bx3zYwecEPn0ouraXdyEftFILoWjgoccC10BUEQBEEQTCFzLPoZ6LYEc3Okr6veJOkeBfMlPv2UqLiY6I032rZfcw1RQADRrbcSLVyonT1hBhiw0bUJokHJpsADsfFEDntILuZXskCAZwNTwkeHetH1E8PMPueJjFL64Uyu3rYlCcGUGNMmWgYCxVX19NaeNC5vU8A5um9OrGRdBEEQBEHot8gciwEMJkj3Cqmp2gnYuJ09q91mb0/0/PPa7ATYtMmqp0R2JcpPf6bGnktFPKvC29WBy58gnPIr6+iWKRFc1tUREyN9eEDeycwybkU7LsyLZ2gMNNAFSy0qQGFlPRvUe2PIoSAIgiAIQk8jpVBDjS++IHrpJaIjR9q2IROxfLm2zAlzJ7qRlNbSLuDr5sg3lE4tGBFo8Uo9vBfG/BcDCdX4ET1aTP1AEARBEARhgCHCYrAD0zXmSHi0dl8qKNCKCngkFi3Sionrryfy8emRl3d3sucyIDVujvZDrvxndKgnHbxcrCckfNwcKcJHshWCIAiCIAwOpFdnP6alRcPzI46ll1o3CK+sjOj994muuoooJIToo4/afnbzzUR//ztRbi7R1q1E99zTY6ICzBzmR7YGImJ2vB8NNQI9nWnl5HAeLIiSsbhAd7p1aqRu4J8gCIIgCMJARzIW/RR0UProYDrlV2jbuiI4v3Z8qOmSoOpqou++03omNm8malC1fj15su1rmLEffJB6C7SFvWNGFJ3IKKOmlhYaG+ZFcYFtsyuGEphFgpsgCIIgCMJgRIRFPwVTqhVRAVBCs/VcHg+UM2xBSzU1RGFhROVtsyIoIUFb5rRqFVF8fLftl0ajoeMZZTzwzt7WlqdrK4PtTBHu48o3QRAEQRAEYfAiwqKfklfeJioUahubqayylvwP7SU6epTo97/X/sDVlWjmTKKLF7WtYSEoxozpkf3al1JMuy4V6L5PK6rilrFoHWtIQ1MLd4QCKP0xNatCEARBEARBGPiIsOinBHk564JyTMGOSDpB4/ZuJr+7txEVFWm333knUUSE9utPPiHy8sK0uh7dr8Npxe22HUkraScs0Er140PpVF2vHZiH2Ra3TYtkr4EgCIIgCIIw+BBh0U/B1Oq8gyco6utPKGHPj+RZnN/2Q8yZgAlbPRfBu+dnO6AMqr5ZfxYDqG9qv+3nC/k6UQEwkfun8wW0Zlpkj++nIAiCIAiC0PuIsOhvNDXxoDoXRztaaZNPdt98wJtbvLzI9sYb26ZgY5hdL4MWsaOCPdlfoWZUiGe7++aUtS/lwnA8QRAEQRAEYXAi7Wb7AykpRC+8QDR2LNFf/qLbbIf5EmvWEH3zDdnm5xO9+y7R0qV9IioUlo0JppHBntylyq7VvD0rrnVSt4pATyeLtgmCIAiCIAiDAxsN6luGEBUVFeTl5UXl5eXk6dl+pb3XyMoi+uwzbXtYGLEVEhOJDh2i/g6M2RjB0K5DlSo78cmhDKpvaubvHe1teW5DhK90hxIEQRAEQRiMsbOUQvU20HHLlxNt2dK2zc5Ofwr2AABCwRyh3i70wPxhdD63gjSt5VKYwi0IgiAIgiAMTiTS623QtQndm8CcOVoxcdNNRIGBNNhwc7KnKdG+fb0bgiAIgiAIQi8gpVB9QXIykYsLUXh4n7y8IAiCIAiCIFiClEL1d7pxErYgCIIgCIIg9AekK5QgCIIgCIIgCF1GPBaDFDT7yiqtZUtHmLcLz6AQBEEQBEEQhJ5ChMUgpKymgT49nEkl1fX8fYCHE92aGEmezg5G759SUEl7kouovLaRYvzdaNGoIOngJAiCIAiCIFiFlEINQrYm5etEBSisrKefzxeYnDex4WgW/19d30Rns8tpw9HMXtxbQRAEQRAEYTAgwmIQkl5c3W7bFSPbwOmscmoxmJEIkVFQUddj+ycIgiAIgiAMPkRYDEJ8XB0t2qbF+OD1ITWOXRAEQRAEQegyIiwGIfOGB5Ctyqxta2tDc4cHGL3v2HDvdsbuIE9nvgmCIAiCIAiCpYh5exASH+RBa2fH0NmccrIhGxoT5sUGbmOgY9QNE8Nob6t5OzbAjRYnBPX6PguCIAiCIAgDGxEWg5RAT2daaGHWYVSIJ98EQRAEQRAEobNIKZQgCIIgCIIgCF1GhIUgCIIgCIIgCF1GhIUgCIIgCIIgCCIsBEEQBEEQBEHoeyRjIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhClxFhIQiCIAiCIAhCl7GnIYZGo+H/Kyoq+npXBEEQBEEQBKFfo8TMSgxtjiEnLCorK/n/iIiIvt4VQRAEQRAEQRgwMbSXl5fZ+9hoLJEfg4iWlhbKyckhDw8PsrGx6RPVB1GTmZlJnp6evf76gwU5j3Ie+xNyPco57C/ItSjnsT8h1+PgOIeQChAVoaGhZGtr3kUx5DIWOCHh4eF9vRt8cYiwkPPYX5DrUc5jf0GuRTmP/Qm5HuU89hc8+zhu7ChToSDmbUEQBEEQBEEQuowIC0EQBEEQBEEQuowIi17GycmJnnnmGf5fkPPY18j1KOexvyDXopzH/oRcj3Ie+wtOAyxuHHLmbUEQBEEQBEEQuh/JWAiCIAiCIAiC0GVEWAiCIAiCIAiC0GVEWAiCIAiCIAiC0GWG3ByL3iQjI4NvkyZNIldXV4sek5aWRiUlJTRy5Ehyc3Pr9H0G00DDc+fO8XCW0aNHk52dncn7lpWV0dmzZ43+bMyYMeTt7c1fHzp0iBobG/V+HhkZybfBSk1NDZ0/f57PwbBhwzq87/Hjx9ttHzt2bLs+1tY872CgsLCQrly5QlFRURQYGNjh/XHd4v44Tzg/zs7Oej/Pzc2l1NTUdo+bPXs2DQY681kln4Gd/wxUqK6upuTkZL5GMdDKkKH4GYhzcuHCBfLx8aHY2NgO73vixIl228eNG9dujoA1zzsYKCgooPT0dIs+A0+dOsVD1QzB3xH8PQEYWHz58mW9n2N48axZs2gwk56ezgPvJk+eTC4uLhY9BueptLTU7OepJffpcWDeFrqX3bt3a1asWKHx8/ODMV5z5syZDh9TXl6uWbx4scbd3V0zfPhw/v/f//631fcZTJw+fVozbNgwTUhIiCYsLEwTFRWlOX78uMn7Hzx4UDNr1iy9W0xMDL8Hx44d090P78uIESP07vfOO+9oBivr16/XeHp6auLj4zUeHh6aefPmaUpKSkzeH9crzlliYqLeOTI899Y+70DnySef1Dg5OWkSEhL4/0ceeUTT0tJi8v4ffPABX7+4BkeNGqXx8vLS/O1vf9O7z+uvv65xcXFpd90OdDrzWSWfgV3/DMzKytLcdtttfK1NmDCB/8fvZWZmpt79htpn4Mcff8yfUbgW8f+CBQs0ZWVlJu9/4sQJ/gycNm2a3jnC+9GV5x3oPPbYY3qfgfjeHGvXrm332WZra6u54YYbdPd55ZVXNK6urnr3wTU7WNm5c6dm+fLluvjw/PnzHT4G1xSuLfW1hmvP2vv0FiIseoC///3vmu+++46DWUuFxbp16/iDXgnM3nrrLY29vb3m4sWLVt1nsNDc3KwZOXKkZtWqVbrg7fbbb9fExsZqGhsbLX6eG2+8UTN27Fi9bfiF/vTTTzVDgcuXL2scHR01//jHP3TBG/4o3HHHHR0Ki9zc3G593oHMRx99xAJAEainTp3iP4bmgrE//OEPmrS0NN33n3/+ucbGxkazd+9ePWGB3+nBRmc+q+QzsOufgbi2EEw0NTXx9xUVFZrp06drlixZMmQ/A5OTkzUODg6aN998k78vLS3la/Oee+7pUFgUFhZ26/MOZN5//33+zDt58iR/D4GLz0QsoFgKHoPzunHjRj1hMXr0aM1Q4fXXX9ds2rRJc+jQIYuFxd13381/XxXR+sYbb/C1l5KSYtV9egsRFj2I8uHUkbCoq6vjX1j1aib+kISGhmp+//vfW3yfwZb1wbk7e/asbhuCEmzbtm2bRc9RUFDAv1ivvfZauz+qr776qubIkSN8n8HMc889pwkMDOQgReGf//wnrzZVVVWZFRb79u3ja7iysrJbnncgs3DhQs3KlSv1tt16661WZxf8/f01f/rTn/T+yMTFxfFKaFJSkqahoUEz0OnMZ5V8BvbMZyDA+4D3Y6h+Bj799NOc8VFnF3FOnJ2dNTU1NWb/diMLbuozsDPPO5CZO3cuf+apwWeiNdmFhx56iD8HFOGrCAsIaCzWDJbPQEvA754lwgLXEq4p/H1VwN/doKAgzTPPPGPxfXoTMW/3Ay5evMg12Ki1U9cYTpkyRVfnacl9BhM4JgyDQU2xwvDhw7m+1dLj/fe//831yLfffnu7nz399NO0bt06rhNdsmQJ1zoORnCuJk6cSLa2bb/qiYmJVF9fT0lJSWYfe8stt9CaNWvI19eXHnroIWpoaOiW5x2I4HjVv3vK8Vrzu4faV/gN4uLi9LbDY4FzvWzZMvL396d//vOfNJDpzGeVfAb2zGcgOHLkiFH/01D6DITPEdeg+ne3rq6OvRHmWLlyJa1evZo/Ax955BE9X0pXnncofgbivHzyySd0zz33tPMJ4ff/1ltvpauuuooCAgLorbfe6tZ9H8icP3+ez5363OPvLr5Xzr0l9+lNxLxtAQiUEBCYY8aMGRaZ6oyhPLefn5/ednyPC8bS+/R3Dhw4QM3NzSZ/7u7uThMmTNAdr+GxAmzr6L1QePfdd/kPA0x1av70pz/R3Xffze8XjGjXXHMN//HYu3cv9Xeqqqro5MmTZu8TFhZGMTEx/DXOFb5Xo5xXU+cRgcvmzZs50AX4YFq4cCEbtF944YVOP29/Ijs7m03C5khISOCAApldNAYw9ruHABpiqqOJqAhIcM3B/HnttdfqNRVAEIKAEbz33nt07733sgl06dKlNBDpzGfVUPkMtIbu+Az84Ycf6MMPP6T169cPms9Aa8G5MhRWHX1WwVy8ZcsW3e/gsWPH+DMQnwfPPvtsp593oNLU1MQmbGO/exUVFfx3vaP456uvvuLP0bVr1+ptx2fipUuXdAsuEBX3338/n1uc86FOiZnPPeVvmCX36U1EWFjABx98QPv27TN7nx9//JED487g4ODA/0NxqqmtrSVHR0eL79PfwUh6BGKmiI+P58BKOV7DY7XmeCFiIAjfeOONdj9Tf7Chq8Vzzz1Hy5cv5xW7iIgI6u8B8VNPPWX2Plj9fvTRR02eR5xDYOo8GnaHQWYCH/QIThRh0Znn7U/s2bOH/va3v5m9z4svvkhz5szhFUl7e3uTx6v8bpoCf3SR+UEXkN27d+vdf/78+Xr3xWrev/71L/rss88GrLDozGfVUPkMtIaufgbibxY+C/77v/+bbr755kHzGWgtnfmswsKMsjgDsPJ733338WegIiwG+megNUA0YAXc2PFiuyWLqu+88w4tXrxY77wCQ/GA86x8BoqwoAH52SjCwgKwutOTIBWtBI1KCzble+Vnltynv7N161aL74tjQss0CBGlVS9WhouLiy1qiYgPMawCz507t8P7BgUF6c5lf/+jOmLECKtWFXEeDVvw4jiBNa0lcY6Ux3Xn8/YVSLvjZik4JvXxA3wfHh6uVw5mTFTcdttt3N5z586dFv2uGp7rgUZnPquGymegNXTlMxALKxAKjz32GP3P//zPoPoM7Mx5TElJ6ZHPwO543oEAFldwXRj7DLTkWLFqvmPHDhYLljDQPwO7E/Xn3qhRo3Tb8T3iAUvv05uIx6KPQOr+zJkz/DWCE/Qc/vbbb3U/R3oafxxQ+2rpfQYTWKlAwLZp0ya9tD5SsosWLdJtO3jwIM8KMSwXwgcYVj4MQc9xY4IHir8vfgF7GlwbR48e5XkJChs3buRVIyWNj3MCsVJeXq773pBt27Zx2Y41zzuYwPHiWkRZFMD/+F1U/+6hH7ta9EFUwN+zf/9+FhXGetwbnmuUFUCEqM/1QMPSzyr5DOyZz0B8jzJGeAL+93//t93zDsXPQPxO4RpUf1YhQ64EZPibgd9d/P5Z8xnY0fMO9s/A7777Tu93GoGsseoOLPTBP3bddde1+5nhucbfocOHDw/oz8CugmoLZeEuOjqay8TUn6f4u4tzpJx7S+7Tq/S6XXwIgF7ie/bs0bz33nvs+kf/dnyfk5Oju891112n103h66+/1tjZ2Wmef/55/nrGjBma8ePH63VIsOQ+g4nHH3+cu+jgPOIcosPBgw8+qHcf9Gk37Hrw9ttvczcoY91OvvnmG83SpUv5OX/88UfuUoNORs8++6xmMILuG1OnTuXbV199pXnxxRe57ednn33WrgPKjh07dPMafvnLX3J7VLQFXL16NbeW3bp1q1XPO5hA21gfHx+eEfDtt99q7rrrLp7hgZaT6u4m6o9UtJ3EtYV2jPj9V25o1auAvuO4ftF+8JNPPtFMmTJFEx4ersnOztYMZCz5rJLPwO7/DER3MXx/1VVX6V1zuCmdeIbaZyBa806aNInb7uKz6oUXXuBr84svvmjXoQfnCWA+w/3336/ZsGEDfwai5S/O0fbt26163sFEamqqxtvbW3PnnXfyZyBai+N7bFd4+eWX+RyowXWHzzT8XTHVbQrX3vfff8+tknFOIyMjzbY7H8hkZmbydYY4Bdccjhnfq48Xc9AWLVqk+x7XFP6+4hrDtYYZUzhP6rbTltynt7DBP70vZwY3qMM0Vr/9xBNP0I033shf/+53v2Mz1Ouvv663IgLjEow46KDym9/8pp3x2JL7DKaJs2+++SarcFymK1asoAceeECvnhPpftQPw/CqPs+4z8svv2z0ebEy9f7773M9MVaWUKoyb948GqxgBeill17i1TUYsFFfjfOmgHQ+jJy4FuGnwHlH9w6sTuEaxSrmww8/3G7FvaPnHWzAYIhrCl2ckJl58skn9dLOGzZsoFdffVWXtcDqHMpWzHlgcH7/8Y9/8CofamHRZQbn2nC670Cko88q+Qzs/s9ArJib+txT+wCH2mcgTMMoaUaHLFyD6IaFDkTqrkT4/IInD2V2OO8fffQRff/997yijgwcfi+xMmzN8w420Gjiz3/+M3e4w98DfAbi3KhjH3S1Q4ZWPX0bXQXRTEVpUqEGWaK///3vnNlFEwz4WXCuPTw8aDDy8ccfG/V+/td//Zcuo4PPSnRhfOWVV3Q/RzOBt99+m8sjp06dyvfB3101ltynNxBhIQiCIAiCIAhClxGPhSAIgiAIgiAIXUaEhSAIgiAIgiAIXUaEhSAIgiAIgiAIXUaEhSAIgiAIgiAIXUaEhSAIgiAIgiAIXUaEhSAIgiAIgiAIXUaEhSAIgiAIgiAIXUaEhSAIQh/T1NREn3/+OTU2NvbJ62N4WnJysu777777jodgqcnLy+PtGIKFYW1ffvklZWdn01DA8Px0FpxDDF1TziE4d+4cffXVV7Rr164uPfcXX3zBw9wEQRD6EhEWgiAIXQBTej/77DOTgSembyOQxARqU2Dy7L///W9ycHDok/cCE3QxtVXhkUceoZ9//ln3/dGjR3kCO6bqfvPNNxwU33XXXTxxuDvBhOm0tDTqbxienx9++IGysrKseo7Dhw/z5GFMWlfO4R//+EeaP38+T7o/cOBAl84TBMsLL7xg1T4JgiB0NyIsBEEQuvIhamtLb7zxBv3mN78x+nME4w8//DC5ubkZ/XlNTQ0999xz9Pvf/77fvA/XXnstDRs2TPc9RM/ixYt1q+045pUrV1J4eHi3vu6DDz7Y5ZX73uCJJ56ggwcPWvWYjz76iJYsWaJ3Dt9880166aWXONvw1FNPdek84fGvvPIKFRYWWrVfgiAI3Yl9tz6bIAjCEGTt2rV8KygooMDAQN12rEq/9957dPvtt5OTk5PRx2K12t/fn2bMmKHb9vXXX9PkyZM5g3Hq1CkWJbNmzeJgND09nU6ePEkRERE0adKkds9XWVlJ+/fvp/r6epo2bRoFBQW1u09+fj4HxqGhoTR+/Ph2P1+6dClFRUXx1wiEkbFwdnbmgFhh2bJlFBISovc4lHJhZb60tJSmTp2q99o//fQTFRUVkY2NDT9u4sSJ5OHhofs5MgK1tbV06NAhfi07Ozu6+eab+WcNDQ28v+Xl5ZSQkKAnegD2a8GCBXqvh6xCfHw839TnFK9//PhxioyM5H0wRkfnxxjm9tHUOczNzeVSKGxLTEyk2NjYDp/L1HlCRmncuHH0zjvvWCVSBEEQuhMRFoIgCF0Eq/ePPvooffjhh/SrX/1Kt33nzp2UmppK69atM/nYTZs20cKFC/W23XfffTRq1Cj2MIwePZr27dvHQTHKZiBURo4cSXv27KF77rmH/vrXv+oet337dt4XBKLu7u4c5P/lL3+h//iP/9ALcm+55RYOQu3t7amqqoqFgBqUQv2///f/ONDdtm0b7wfuixIeBXgsNmzYQGFhYfz9iRMn6MYbb2Txg/3Dczz//PMsqgBW2FEuBrEF/0ZGRgY/x+zZs/nnO3bs4IAZQT/2x9HRkQNmiKjrr7+efH19+bUQcN90002cCVJYvXo176daWCCrgEyRIixwTnEOL168yILihhtuMCosLDk/hnS0j6bOIbw1EAgoq8K+43x39FymzhPAdYTrSYSFIAh9hkYQBEHoMg8++KAmISFBb9ttt92mmTZtmtnHRUREaF577TW9bX5+fprp06dramtr+fsjR47A6auZO3eupr6+nrft2LFDY2trq8nNzeXvcV8815NPPql7nvfff1/j5OSkuXz5su4+YWFhmmeeeUZ3n5dffpmf+/XXX9dti4qK0rz11lu671etWqVZu3at3j66ublpvv76a/66rq6OX/vuu+/WNDU16V7rxx9/NHncL7zwgmbMmDF627Bv7733nu77hoYGTXR0tOaVV17RbSsoKNCEhIRoPv30U9027P+2bdv0nmvEiBF6x4RziterqKgwuU+Wnp8nnnhCc/DgQav2saNzaM1zGZ4nhY8//pjfb0EQhL5CPBaCIAjdAEqhkpKSdLX3KGNBtx9sNwfKg3x8fNptv/POO7nUBWClHSvTd999N/8PUDoF43hKSgp/j6xGZmYm/fa3v9V7DpRmoQwI7N27l3JycvSyKsgsuLi4dOnYYfTGa8OMjNIcgH2/6qqr9O6HLAVKeWB2R5nX2bNn2WNiCqzOo/QLxwAfAjIk2IaMDP63FmR41OVXhlh6fv7v//6Py8y6ex+7+ly4jlACh3I4QRCEvkBKoQRBELoB+B1QWvPuu+/S9OnT2TuBsqBbb73V7ONQsmSsTahabMAXgEBcvU3xbNTV1fH/CEi9vb25hEb9OJTX4GdKYO/n56cXXON54CXoCnheT09Po34OdYCOMi54L+ApQTkPgNlY8XMYcuXKFRZS6IKkBiVC6LBkLYaeEGPHYe356c597Opz4TrCNefq6mrV6wqCIHQXIiwEQRC6CWQnfve737HvASZa1OqbWyEHCBi7o8UqgnWsVKNuH7X8Cmhzi58BBM0VFRWc6UAAqtCRh6AjIGjgRcBquTGTOvwAaKkLj4ViREZmB34GZZ6DMSBWYGR+++23WYCZAgIKx6RGEVyG9zNHZ86PpftoCV19LlxHcXFxuqyRIAhCbyOlUIIgCN3Ebbfdxp2RYHw+duyYWdO2wqJFi7iMqasgEwBBsXHjRt22CxcucNchxSCN+ygdkxRgqjY3Y8MS5s2bx6/98ccf621XWp9iMBzKidSZCZT6GIJgWi0IYFbHCj7asqppbm7mzk3qFX2lJAzAMI/SLGvpzPmxdB8twdLnMjxPCriO0BZYEAShr5CMhSAIQjeBlXt08ME8AXR1mjlzZoePuffee+nFF1/kMhy0QO0sKPNBtgQ+AggKZErgBUCHIbRiBSjpefzxx+mOO+7gzkEQA6+++mqXV9qDg4Pp5ZdfpgceeIDOnDnDLVLR8haZEmyHHwSvgQzONddcw52Q4B8wZMqUKVxKhlIeCBF0O0L2B2VUOCb4GtBBCd2k/vCHP/BzKV6S//mf/2FRhwwIVvw74xvpzPnBsVuyj5aeR0uey9h5gqcH/hWcd0EQhL5CMhaCIAjdCNrOrlq1igNdS8AqPlqyvv7667ptaNtq6DswNpAOr4NgVOHpp5/mrAFW69G29JlnnmGjtBqIGATLCFwxFRztSdGOVl3DbzggDwIJcxbM7Q+OWzEYo80txAyGvwF4Q1D6hDIdtOCFgNq9ezfvv3pw4GuvvUa/+MUvuG3ud999x9uwb3g+eEfwGABRog7Y0dYWxwUzOI4Jgfj999+vd0zGzqkxLDk/hliyj5acQ0ufy9h5euutt7jdrKnZHIIgCL2BDVpD9corCYIgCEZBmQu6Of3rX/9ik7YgWAtmdvznf/6nbm6HIAhCXyDCQhAEQRAEQRCELiOlUIIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgdBkRFoIgCIIgCIIgUFf5/4laXBIxNbgfAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "ax.scatter(donnees['V'], ecarts, s=18, alpha=0.55, edgecolors='none')\n",
+    "pente_ecart = np.polyfit(donnees['V'], ecarts, 1)[0]\n",
+    "vs = np.linspace(-1, 1, 100)\n",
+    "ax.plot(vs, pente_ecart * vs, 'r--', lw=1.5, label=f'pente {pente_ecart:.2f} par unite de V')\n",
+    "ax.axhline(0, color='grey', ls=':', lw=1)\n",
+    "ax.set_xlabel('V (modificateur d\\'effet)')\n",
+    "ax.set_ylabel('ecart individuel Y_obs - Y(T:=0)')\n",
+    "ax.set_title('Les ecarts individuels : une droite de pente non nulle en V', fontsize=11)\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48424cf0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003557,
+     "end_time": "2026-09-02T11:58:34.248262",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.244705",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Lecture de la decomposition — une CATE lineaire redécouverte\n",
+    "\n",
+    "La moyenne des ecarts (`+0.33`) joint l'**ATE** (`0`) : a trois decimales pres, le\n",
+    "traitement n'a « pas d'effet moyen ». Mais la **dispersion** (`ecart-type ~1.0`,\n",
+    "extremes `+3.3` / `-1.6`) et la **droite de pente non nulle en `V`** racontent la\n",
+    "vraie structure : l'effet croit lineairement avec `V`. Le SCM a **redécouvert**,\n",
+    "sans qu'on lui donne la forme, la `CATE(v) = 3.v` du monde.\n",
+    "\n",
+    "Un ATE seul n'aurait jamais montre la droite. Un estimand chiffre est honnête ;\n",
+    "une **fonction d'effet** (CATE) est actionnable : pour `V > 0.5`, la decision de\n",
+    "traiter s'impose ; pour `V < -0.5`, elle se discute."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2b857bd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003398,
+     "end_time": "2026-09-02T11:58:34.255171",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.251773",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 — la CATE par sous-groupe, sans nouvelle boucle\n",
+    "\n",
+    "La `Series ecarts` de la cellule precedente est **indexee comme `donnees`** : on\n",
+    "peut en deduire l'effet moyen par sous-groupe de `V` sans recalculer.\n",
+    "\n",
+    "- **Indice 1** : masque = `donnees['V'].loc[ecarts.index] > 0.5` (et `< -0.5`).\n",
+    "- **Indice 2** : `ecarts[mask].mean()` vs `ecarts[~mask].mean()`.\n",
+    "- **Etape 3** : interpreter le signe de la difference en une phrase.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "929cec4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:34.263202Z",
+     "iopub.status.busy": "2026-09-02T11:58:34.262668Z",
+     "iopub.status.idle": "2026-09-02T11:58:34.267163Z",
+     "shell.execute_reply": "2026-09-02T11:58:34.266592Z"
+    },
+    "papermill": {
+     "duration": 0.009704,
+     "end_time": "2026-09-02T11:58:34.268460",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.258756",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : CATE par sous-groupe\n",
+    "cate_plus = None  # TODO etudiant : moyenne des ecarts pour V > 0.5\n",
+    "cate_moins = None  # TODO etudiant : moyenne des ecarts pour V < -0.5\n",
+    "\n",
+    "print('Exercice a completer')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d850d9f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003312,
+     "end_time": "2026-09-02T11:58:34.275468",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.272156",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Conditions de validite — et quand ne pas croire le contrefactuel\n",
+    "\n",
+    "Le chiffre individuel est seduisant, il doit etre **honnete**. Pour qu'il tienne :\n",
+    "\n",
+    "1. **Le graphe causal est connu** (ici : toujours celui de DoWhy-1, `V -> {T, Y}`, `T -> Y`) ;\n",
+    "2. **La famille de mecanismes est adequate** : le bruit doit etre additif et le\n",
+    "   regresseur capable de la vraie forme — polynomial degre 2 pour une interaction ;\n",
+    "3. **L'abduction est exacte** : le bruit individuel est parfaitement deduit de\n",
+    "   l'observation (il n'est pas identifie en general — ici la forme additive le\n",
+    "   rend identifiable).\n",
+    "\n",
+    "La demonstration du point 2 : on refitte avec un mecanisme **lineaire** (`degre_y=1`, \n",
+    "incapable de `T.V`) et on reprend le meme individu `idx_hi`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "97e5d26a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:34.283115Z",
+     "iopub.status.busy": "2026-09-02T11:58:34.283115Z",
+     "iopub.status.idle": "2026-09-02T11:58:34.299067Z",
+     "shell.execute_reply": "2026-09-02T11:58:34.299067Z"
+    },
+    "papermill": {
+     "duration": 0.021472,
+     "end_time": "2026-09-02T11:58:34.300474",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.279002",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal models:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node V:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node T:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node Y:   0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Fitting causal mechanism of node Y: 100%|██████████| 3/3 [00:00<00:00, 513.76it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Meme individu (idx 532), mecanisme LINEAIRE : ecart = +0.12\n",
+      "A comparer au mecanisme polynomial      : ecart = +3.35\n",
+      "Effet vrai 3.T.V                       : +3.27\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "scm_lineaire = construire_scm(donnees, degre_y=1)\n",
+    "cf_lin = contrefactuel_individuel(scm_lineaire, donnees.loc[idx_hi])\n",
+    "ecart_lin = float(donnees.loc[idx_hi, 'Y']) - float(cf_lin['Y'].iloc[0])\n",
+    "print(f'Meme individu (idx {idx_hi}), mecanisme LINEAIRE : ecart = {ecart_lin:+.2f}')\n",
+    "print(f'A comparer au mecanisme polynomial      : ecart = {ecarts.loc[idx_hi]:+.2f}')\n",
+    "print(f'Effet vrai 3.T.V                       : {BETA_INTERACTION * donnees.loc[idx_hi, \"T\"] * donnees.loc[idx_hi, \"V\"]:+.2f}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e4e29eb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004365,
+     "end_time": "2026-09-02T11:58:34.308295",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.303930",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. Lecture de la fragilite — un mecanisme faux tue un chiffre juste\n",
+    "\n",
+    "`+0.12` contre `+3.3` : le mecanisme **lineaire écrase** l'interaction — le\n",
+    "contrefactuel individuel devient inoffensif mais faux. La machine n'a pas\n",
+    "« menti » : elle a repondu dans la famille qu'on lui a confiee. Le contrefactuel\n",
+    "de rung 3 est un **chiffre fragile** : il depend de la specification du mecanisme,\n",
+    "du graphe et de l'identifiabilite du bruit. C'est un outil de decision individuel\n",
+    "(et un instrument de jugement), pas un oracle.\n",
+    "\n",
+    "La parade est a la hauteur du risque : diagnostiquer les mecanismes (evaluation\n",
+    "hors-echantillon, comparaison de famille), et ne jamais livrer un chiffre de\n",
+    "rung 3 sans avoir montre la sensibilite de la specification — comme ici.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fa325f6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004165,
+     "end_time": "2026-09-02T11:58:34.316031",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.311866",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 — la methode survit-elle au tirage ?\n",
+    "\n",
+    "Re-generer le monde avec un autre seed (`seed=7`), refitter le SCM, re-mesurer\n",
+    "**moyenne** et **ecart-type** des ecarts individuels. La STRUCTURE (CATE lineaire\n",
+    "en `V`) doit survivre ; les deux etoiles, elles, changent.\n",
+    "\n",
+    "- **Indice 1** : `generer_donnees(n=600, seed=7)` puis `construire_scm(...)`.\n",
+    "- **Indice 2** : `ecarts_contrefactuels(scm7, donnees7)`.\n",
+    "- **Etape 3** : comparer aux valeurs de la section 7 (moyenne ~0.3, ecart-type ~1).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7c5d0f37",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:34.325376Z",
+     "iopub.status.busy": "2026-09-02T11:58:34.324844Z",
+     "iopub.status.idle": "2026-09-02T11:58:34.330187Z",
+     "shell.execute_reply": "2026-09-02T11:58:34.329122Z"
+    },
+    "papermill": {
+     "duration": 0.011181,
+     "end_time": "2026-09-02T11:58:34.331146",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.319965",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : stabilite de la decomposition sur un autre tirage\n",
+    "donnees7 = None  # TODO etudiant : generer_donnees(n=600, seed=7)\n",
+    "scm7 = None  # TODO etudiant : construire_scm(donnees7, degre_y=2)\n",
+    "ecarts7 = None  # TODO etudiant : ecarts_contrefactuels(scm7, donnees7)\n",
+    "\n",
+    "print('Exercice a completer')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfa2b7e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004589,
+     "end_time": "2026-09-02T11:58:34.339899",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.335310",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 11. Synthese — ce que le contrefactuel individuel a apporte\n",
+    "\n",
+    "Trois nombres encadrent le notebook :\n",
+    "\n",
+    "1. **`+3.08`** — la pente naive : trompeuse, confondue (rung 1, sans caution) ;\n",
+    "2. **`+3.3` et `-1.6`** — deux individus, deux verites opposees : l'effet moyen\n",
+    "   cache une CATE lineaire en `V` (rung 3) ;\n",
+    "3. **`~0.3` en moyenne, ecart-type ~1** — l'ATE amerite le zero, la dispersion\n",
+    "   est la vraie information (rung 2, par decomposition).\n",
+    "\n",
+    "**Verdict honnete** : le contrefactuel individuel est exact ici parce que le\n",
+    "monde est connu, l'interaction polynomiale bien approchee et le bruit additive.\n",
+    "Sur le terrain, exiger : graphe identifie, mecanismes diagnostiques, sensibilite\n",
+    "de specification. La suite de la serie (DoWhy-3) apprendra a **decouvrir** le\n",
+    "graphe quand il est inconnu — la derniere carte non jouee ici.\n",
+    "\n",
+    "**Pour aller plus loin** : `dowhy_organs.py` (module canonique de ce notebook) —\n",
+    "`generer_donnees`, `construire_scm`, `contrefactuel_individuel`, \n",
+    "`ecarts_contrefactuels` : importables par le prochain notebook de la serie.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1d1d8072",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T11:58:34.349355Z",
+     "iopub.status.busy": "2026-09-02T11:58:34.349355Z",
+     "iopub.status.idle": "2026-09-02T11:58:34.354672Z",
+     "shell.execute_reply": "2026-09-02T11:58:34.354128Z"
+    },
+    "papermill": {
+     "duration": 0.011861,
+     "end_time": "2026-09-02T11:58:34.355619",
+     "exception": false,
+     "start_time": "2026-09-02T11:58:34.343758",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. pente naive confondue  : +3.077\n",
+      "2. individu aide (idx 532)  : +3.35   (V = +0.99)\n",
+      "   individu lese (idx 6)  : -1.61   (V = -0.88)\n",
+      "3. moyenne des ecarts      : +0.331  (ecart-type 1.006)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Recapitulatif executable des trois nombres du notebook\n",
+    "h = int(ecarts.idxmax())\n",
+    "b = int(ecarts.idxmin())\n",
+    "print('1. pente naive confondue  : %+.3f' % pente_naive)\n",
+    "print('2. individu aide (idx %d)  : %+.2f   (V = %+.2f)' % (h, float(ecarts.loc[h]), donnees.loc[h, 'V']))\n",
+    "print('   individu lese (idx %d)  : %+.2f   (V = %+.2f)' % (b, float(ecarts.loc[b]), donnees.loc[b, 'V']))\n",
+    "print('3. moyenne des ecarts      : %+.3f  (ecart-type %.3f)' % (float(ecarts.mean()), float(ecarts.std())))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (coursia-ml-training)",
+   "language": "python",
+   "name": "coursia-ml-training"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.16"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.803669,
+   "end_time": "2026-09-02T11:58:35.016672",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "DoWhy-2-Contrefactuel-Individuel.ipynb",
+   "output_path": "DoWhy-2-Contrefactuel-Individuel_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T11:58:25.213003",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/README.md
@@ -12,6 +12,7 @@
 |----------|-------|----------|
 | [Do-Calculus-Bridge](Do-Calculus-Bridge.ipynb) | ~55 min | Échelle de Pearl, trois règles du do-calculus, critères *backdoor* / *front-door* exécutés avec `dowhy`, Pearl (intervention) vs Hoel (émergence causale) |
 | [DoWhy-1 — Exiger un estimand](DoWhy-1-Estimand-et-Intervention.ipynb) | ~45 min | Identification causale **nommée** via `dowhy` (backdoor, front-door, instrumentale) sur un cas complet ; sensibilité au graphe **mesurée** quand une hypothèse saute |
+| [DoWhy-2 — Le contrefactuel individuel](DoWhy-2-Contrefactuel-Individuel.ipynb) | ~40 min | Troisième échelon de Pearl : `dowhy.gcm` (abduction-action-prédiction) sur **un individu** ; l'effet moyen nul cache une CATE linéaire ±3 ; fragilité du chiffre individuel à la spécification du mécanisme |
 | [Quasi-Experimental](Quasi-Experimental.ipynb) | ~50 min | Méthodes quasi-expérimentales (DiD, contrôle synthétique, RDD, variables instrumentales) sur données réalistes ; estimands et hypothèses d'identification explicités |
 
 **Prérequis** : probabilités conditionnelles, graphes orientés acycliques (DAG), notions d'inférence bayésienne. Une lecture préalable de l'un des quatre notebooks de la constellation (ci-dessous) rend le pont plus concret.
@@ -44,3 +45,9 @@ Le notebook suit la convention du dépôt (stubs à compléter, sans erreur volo
 1. **Ajouter un second confondeur à la backdoor** — étendre l'ensemble d'ajustement à `{aptitude, motivation}`.
 2. **Rompre le critère front-door** — ajouter un chemin direct qui contourne le médiateur et vérifier que l'identification front-door échoue.
 3. **Comparer effet naïf et effet ajusté** — générer un nouveau jeu à effet vrai connu, mesurer l'écart dû au confondeur.
+
+Exercices de DoWhy-2 :
+
+1. **Le contrefactuel inverse** — pour un étudiant non traité à `V > 0`, estimer son `Y` sous `T := 1` et comparer à son observation : aurait-il gagné au mentorat ?
+2. **La CATE par sous-groupe** — déduire de la série d'écarts individuels l'effet moyen pour `V > 0.5` vs `V < -0.5`, interpréter le signe.
+3. **La méthode survit-elle au tirage ?** — re-générer le monde (`seed=7`), refitter, re-mesurer moyenne et écart-type des écarts : la structure doit survivre, pas les individus.

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/dowhy_organs.py
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/dowhy_organs.py
@@ -94,15 +94,25 @@ def contrefactuel_individuel(scm, individu, variable="T", valeur=0.0, seed=42):
     Retourne un DataFrame des tirages (colonnes = variables descendantes)
     ; l'effectif des tirages est fixe par dowhy (API 0.14 : pas de
     ``num_samples`` sur ``counterfactual_samples``).
+
+    ``counterfactual_samples`` (API 0.14) n'expose pas non plus de
+    ``random_state`` injectable : le seed global est pose TEMPORAIREMENT,
+    l'etat du RNG de l'appelant etant sauvegarde puis restaure -- la
+    doctrine du module (aucune dependance au seed global) reste tenue :
+    zero effet de bord sur les tirages ulterieurs de l'appelant.
     """
     if isinstance(individu, pd.Series):
         individu = individu.to_frame().T
-    np.random.seed(seed)
-    return gcm.counterfactual_samples(
-        scm,
-        interventions={variable: lambda _: valeur},
-        observed_data=individu,
-    )
+    etat_rng_appelant = np.random.get_state()
+    try:
+        np.random.seed(seed)
+        return gcm.counterfactual_samples(
+            scm,
+            interventions={variable: lambda _: valeur},
+            observed_data=individu,
+        )
+    finally:
+        np.random.set_state(etat_rng_appelant)
 
 
 def ecarts_contrefactuels(scm, donnees, variable="T", valeur=0.0, seed=42):

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/dowhy_organs.py
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/dowhy_organs.py
@@ -1,0 +1,119 @@
+"""Organes canoniques de la ligne dowhy -- contrefactuel individuel (DoWhy-2).
+
+Issue #14049 (slice 1/4, DoWhy-2-Contrefactuel-Individuel) : chaque notebook
+de la serie DoWhy expose son organe des sa livraison -- une petite API
+importable a cote du notebook, que le notebook consomme et qu'un tiers
+(ICT, un autre notebook) peut appeler sans recopier (lecon #13921 :
+la duplication se cree quand un consommateur recopie une fonction
+cell-scoped parce qu'il n'y a rien d'appelable).
+
+Ce module est le frere de ``causal_organs.py`` (scope : Quasi-Experimental,
+issue #14051) -- scope distinct, fichier distinct, zero collision avec la
+tranche 2/2 de #14051.
+
+Fonctions exposees
+------------------
+
+- ``generer_donnees(n, seed)`` -- monde generatif a heterogeneite qui
+  s'annule en moyenne : V ~ U(-1, 1), T = 0.5 + 0.3 V + N(0, 0.2),
+  Y = 1 + 3 T V + 0.5 V + N(0, 0.5). ATE vrai = 3 E[V] = 0,
+  CATE(v) = 3v (effect modification pure).
+- ``construire_scm(donnees, degre_y)`` -- InvertibleStructuralCausalModel
+  fitte : V racine (distribution empirique), T bruit additif lineaire,
+  Y bruit additif polynomial de degre ``degre_y``. L'inversibilite des
+  mecanismes a bruit additif est la condition pour abduction du bruit
+  INDIVIDUEL (``counterfactual_samples`` avec ``observed_data`` l'exige).
+- ``contrefactuel_individuel(scm, individu, variable, valeur)`` -- un
+  contrefactuel pour UNE ligne : retourne les tirages de Y sous
+  l'intervention ``variable = valeur`` (abduction sur l'individu observe).
+- ``ecarts_contrefactuels(scm, donnees, variable, valeur, sous_echantillon)``
+  -- boucle ROW-WISE (la version batch de ``counterfactual_samples`` ne
+  fait pas l'abduction par individu) et retourne la Serie des ecarts
+  Y_obs - Y_contrefactuel.
+
+Doctrine de parametrisation (cf. ``causal_organs.py``, L532 MEMORY) :
+RandomState LOCAL par fonction, jamais de dependance au seed global ;
+les constantes du monde generatif vivent en constantes de module
+documentees, les fonctions ne les exposent que par kwargs par defaut.
+
+References
+----------
+
+- Notebook consommateur : ``DoWhy-2-Contrefactuel-Individuel.ipynb``.
+- Precedent d'architecture : issue #14051 / ``causal_organs.py``.
+- API dowhy 0.14 : ``gcm.InvertibleStructuralCausalModel``,
+  ``gcm.AdditiveNoiseModel``, ``gcm.counterfactual_samples``.
+"""
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from dowhy import gcm
+
+# Monde generatif -- constantes documentees (l'unique verite du simulateur)
+GRAPHE = [("V", "T"), ("V", "Y"), ("T", "Y")]
+BETA_INTERACTION = 3.0  # CATE(v) = BETA_INTERACTION * v
+COEF_V_Y = 0.5          # effet direct V -> Y
+COEF_V_T = 0.3          # confondant V -> T
+BRUIT_T = 0.2
+BRUIT_Y = 0.5
+
+
+def generer_donnees(n=600, seed=42):
+    """Genere le DataFrame (V, T, Y) du monde a ATE nul, CATE heterogene."""
+    rng = np.random.RandomState(seed)
+    v = rng.uniform(-1, 1, n)
+    t = 0.5 + COEF_V_T * v + rng.normal(0, BRUIT_T, n)
+    y = 1.0 + BETA_INTERACTION * t * v + COEF_V_Y * v + rng.normal(0, BRUIT_Y, n)
+    return pd.DataFrame({"V": v, "T": t, "Y": y})
+
+
+def construire_scm(donnees, degre_y=2):
+    """Construit et fitte le SCM a mecanismes inversibles.
+
+    ``degre_y=2`` (polynomial) capte l'interaction T x V ; ``degre_y=1``
+    (lineaire) ne le peut pas -- c'est le diagnostic de fragilite du
+    notebook (un mecanisme mal specifie ecrase le contrefactuel).
+    """
+    scm = gcm.InvertibleStructuralCausalModel(nx.DiGraph(GRAPHE))
+    scm.set_causal_mechanism("V", gcm.EmpiricalDistribution())
+    scm.set_causal_mechanism("T", gcm.AdditiveNoiseModel(gcm.ml.create_linear_regressor()))
+    if degre_y >= 2:
+        regresseur_y = gcm.ml.create_polynom_regressor(degree=degre_y)
+    else:
+        regresseur_y = gcm.ml.create_linear_regressor()
+    scm.set_causal_mechanism("Y", gcm.AdditiveNoiseModel(regresseur_y))
+    gcm.fit(scm, donnees)
+    return scm
+
+
+def contrefactuel_individuel(scm, individu, variable="T", valeur=0.0, seed=42):
+    """Contrefactuel pour UNE ligne : tirages de Y sous variable=valeur.
+
+    ``individu`` : DataFrame d'une ligne (ou Series convertie ici).
+    Retourne un DataFrame des tirages (colonnes = variables descendantes)
+    ; l'effectif des tirages est fixe par dowhy (API 0.14 : pas de
+    ``num_samples`` sur ``counterfactual_samples``).
+    """
+    if isinstance(individu, pd.Series):
+        individu = individu.to_frame().T
+    np.random.seed(seed)
+    return gcm.counterfactual_samples(
+        scm,
+        interventions={variable: lambda _: valeur},
+        observed_data=individu,
+    )
+
+
+def ecarts_contrefactuels(scm, donnees, variable="T", valeur=0.0, seed=42):
+    """Serie des ecarts individuels Y_obs - Y_contrefactuel (boucle row-wise).
+
+    La version batch de ``counterfactual_samples`` ne fait pas l'abduction
+    par individu -- la boucle est la semantique voulue : CHAQUE ligne garde
+    son bruit propre (abduction), seule l'intervention change.
+    """
+    ecarts = []
+    for _, ligne in donnees.iterrows():
+        tirages = contrefactuel_individuel(scm, ligne, variable, valeur, seed=seed)
+        ecarts.append(float(ligne["Y"]) - float(tirages["Y"].mean()))
+    return pd.Series(ecarts, index=donnees.index, name="ecart_individuel")

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/tests/test_dowhy_organs.py
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/tests/test_dowhy_organs.py
@@ -138,6 +138,25 @@ def test_contrefactuel_individuel_recupere_la_cate():
     assert ecart_lo < -1.0, f"V<0 : ecart {ecart_lo:+.3f} attendu < -1.0"
 
 
+def test_contrefactuel_individuel_ne_polue_pas_le_rng_global():
+    """Le seed pose pour dowhy (API 0.14 sans ``random_state`` injectable)
+    ne doit pas fuiter : l'etat du RNG global de l'appelant est restaure
+    a l'identique apres l'appel (doctrine du module, reserve PR #14305).
+    """
+    df = do.generer_donnees()
+    scm = do.construire_scm(df, degre_y=2)
+    idx_hi, _ = _individus_extremes(df)
+    np.random.seed(1234)
+    etat_avant = np.random.get_state()
+    do.contrefactuel_individuel(scm, df.loc[idx_hi], seed=42)
+    etat_apres = np.random.get_state()
+    assert etat_avant[0] == etat_apres[0]
+    assert np.array_equal(etat_avant[1], etat_apres[1])
+    assert etat_avant[2] == etat_apres[2]
+    assert etat_avant[3] == etat_apres[3]
+    assert etat_avant[4] == etat_apres[4]
+
+
 def test_ecarts_contrefactuels_boucle_row_wise():
     """La decomposition boucle par individu : |ecart| moyen net > 0.5 et
     variance reelle (std > 0.5) sur un sous-echantillon de 60 lignes.

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/tests/test_dowhy_organs.py
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/tests/test_dowhy_organs.py
@@ -1,0 +1,170 @@
+"""Tests pytest pour dowhy_organs.py -- slice 1/4 #14049 (DoWhy-2-Contrefactuel-Individuel).
+
+Issue #14049 §1 acceptance : « ...chaque notebook de la serie DoWhy expose
+un organe importable des sa livraison, et les tests verifient la sortie du
+module contre la valeur attendue ».
+
+Strategie de test (meme convention que test_causal_organs.py) : on
+**execute reellement** le SCM dowhy-gcm (pas de mock, H.1) et on verifie
+que :
+
+(a) les formes DataFrame / Series retournees correspondent aux dimensions
+    consommees par le notebook ;
+(b) le monde generatif repond aux trois nombres du notebook : pente naive
+    confondue > 2, specification bien posee (interaction) ~ 3.0, ATE vrai 0
+    cache dans une CATE(v) = 3v ;
+(c) la boucle row-wise redonne l'effet individuel : ecart positif pour
+    V > 0, negatif pour V < 0, |ecart| moyen net > 0 ; le mecanisme
+    LINEAIRE ecrase le contrefactuel (fragilite du notebook) ;
+(d) reproductibilite par seed LOCAL -- deux appels retournent la meme
+    sortie (doctrine RandomState, cf. docstring du module).
+
+Les tolérances sont larges : l'estimation est Monte-Carlo avec un seed
+unique, le test pertinent est « ordre de grandeur et signe corrects ».
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import direct sans packaging : on ajoute le dossier parent
+# (Probas/DecisionTheory/Causal-Bridges/) au sys.path.
+_PARENT_DIR = Path(__file__).resolve().parent.parent
+if str(_PARENT_DIR) not in sys.path:
+    sys.path.insert(0, str(_PARENT_DIR))
+
+import dowhy_organs as do
+
+
+def _pente_naive(df):
+    """Pente OLS de Y ~ T (estimateur confondu du notebook)."""
+    return float(np.polyfit(df["T"], df["Y"], 1)[0])
+
+
+def _individus_extremes(df):
+    """Les deux individus traites aux V extremes (les deux etoiles du notebook)."""
+    traites = df[df["T"] > 0.6]
+    idx_hi = int(traites["V"].idxmax())
+    idx_lo = int(traites["V"].idxmin())
+    return idx_hi, idx_lo
+
+
+# ---------------------------------------------------------------------------
+# generer_donnees
+# ---------------------------------------------------------------------------
+def test_generer_donnees_shape():
+    """Dimensions par defaut : n=600 x 3 colonnes (V, T, Y)."""
+    df = do.generer_donnees()
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (600, 3)
+    assert list(df.columns) == ["V", "T", "Y"]
+
+
+def test_generer_donnees_seed_reproductible():
+    """RandomState LOCAL -> deux appels avec meme seed retournent la meme DataFrame."""
+    df_a = do.generer_donnees(seed=42)
+    df_b = do.generer_donnees(seed=42)
+    pd.testing.assert_frame_equal(df_a, df_b)
+
+
+def test_generer_donnees_naive_confoundee():
+    """La pente naive Y ~ T est confondue : > 2, alors que l'ATE vrai est 0.
+
+    C'est le premier nombre du notebook : le confondant V -> {T, Y} gonfle
+    la regression simple (0.3 * 3 = +0.9 de covariance + borne).
+    """
+    df = do.generer_donnees()
+    pente = _pente_naive(df)
+    assert pente > 2.0, f"pente naive {pente:.3f} attendue confondue (trap du notebook)"
+
+
+def test_generer_donnees_specification_bien_posee():
+    """Y ~ 1 + T + V + T:V avec interaction : coefficient T:V ~ 3.0, T ~ 0.
+
+    Le notebook montre qu'une specification qui CONNAIT la forme (rung 1)
+    recupere la mecanique ; c'est la verification de coherence du DGP.
+    """
+    df = do.generer_donnees()
+    X = np.column_stack([np.ones(len(df)), df["T"], df["V"], df["T"] * df["V"]])
+    beta = np.linalg.lstsq(X, df["Y"].values, rcond=None)[0]
+    _, b_t, b_v, b_tv = beta
+    assert abs(b_tv - do.BETA_INTERACTION) < 0.5, f"T:V {b_tv:.3f} ~ 3.0 attendu"
+    assert abs(b_t) < 0.5, f"T direct {b_t:.3f} ~ 0 attendu"
+    assert abs(b_v - do.COEF_V_Y) < 0.5, f"V direct {b_v:.3f} ~ 0.5 attendu"
+
+
+# ---------------------------------------------------------------------------
+# construire_scm + contrefactuel_individuel
+# ---------------------------------------------------------------------------
+def test_construire_scm_fit_sans_erreur():
+    """Le SCM inversible se fitte sur le monde generatif (reellement, H.1)."""
+    df = do.generer_donnees()
+    scm = do.construire_scm(df, degre_y=2)
+    assert scm is not None
+
+
+def test_contrefactuel_individuel_shape():
+    """Un contrefactuel pour UNE ligne retourne un DataFrame (1, 3)."""
+    df = do.generer_donnees()
+    scm = do.construire_scm(df, degre_y=2)
+    idx_hi, _ = _individus_extremes(df)
+    cf = do.contrefactuel_individuel(scm, df.loc[idx_hi])
+    assert isinstance(cf, pd.DataFrame)
+    assert cf.shape == (1, 3)
+    assert list(cf.columns) == ["V", "T", "Y"]
+    # l'intervention T:=0 est bien visible DANS la sortie
+    assert abs(float(cf["T"].iloc[0])) < 1e-9
+
+
+def test_contrefactuel_individuel_recupere_la_cate():
+    """V > 0 : Y_0 < Y_obs (le traitement a aide) ; V < 0 : Y_0 > Y_obs (il a nui).
+
+    C'est le deuxieme nombre du notebook : les deux etoiles +3.35 / -1.61.
+    Seuil conservateur (2.0) pour le V positif, signe seul pour le negatif.
+    """
+    df = do.generer_donnees()
+    scm = do.construire_scm(df, degre_y=2)
+    idx_hi, idx_lo = _individus_extremes(df)
+    cf_hi = do.contrefactuel_individuel(scm, df.loc[idx_hi])
+    ecart_hi = float(df.loc[idx_hi, "Y"]) - float(cf_hi["Y"].iloc[0])
+    assert ecart_hi > 2.0, f"V>0 : ecart {ecart_hi:+.3f} attendu > +2.0"
+    cf_lo = do.contrefactuel_individuel(scm, df.loc[idx_lo])
+    ecart_lo = float(df.loc[idx_lo, "Y"]) - float(cf_lo["Y"].iloc[0])
+    assert ecart_lo < -1.0, f"V<0 : ecart {ecart_lo:+.3f} attendu < -1.0"
+
+
+def test_ecarts_contrefactuels_boucle_row_wise():
+    """La decomposition boucle par individu : |ecart| moyen net > 0.5 et
+    variance reelle (std > 0.5) sur un sous-echantillon de 60 lignes.
+    """
+    df = do.generer_donnees()
+    scm = do.construire_scm(df, degre_y=2)
+    ec = do.ecarts_contrefactuels(scm, df.iloc[:60])
+    assert isinstance(ec, pd.Series)
+    assert len(ec) == 60
+    assert ec.abs().mean() > 0.5, f"|ecart| moyen {ec.abs().mean():.3f} attendu net"
+    assert ec.std() > 0.5, f"dispersion {ec.std():.3f} attendue reelle"
+
+
+def test_mecanisme_lineaire_ecrase_le_contrefactuel():
+    """degre_y=1 (lineaire) ne capte pas l'interaction : l'ecart du V positif
+    s'effondre par rapport au poly2 -- la demonstration de fragilite.
+    """
+    df = do.generer_donnees()
+    scm_poly = do.construire_scm(df, degre_y=2)
+    scm_lin = do.construire_scm(df, degre_y=1)
+    idx_hi, _ = _individus_extremes(df)
+    ecart_poly = float(df.loc[idx_hi, "Y"]) - float(
+        do.contrefactuel_individuel(scm_poly, df.loc[idx_hi])["Y"].iloc[0]
+    )
+    ecart_lin = float(df.loc[idx_hi, "Y"]) - float(
+        do.contrefactuel_individuel(scm_lin, df.loc[idx_hi])["Y"].iloc[0]
+    )
+    assert abs(ecart_lin) < abs(ecart_poly) / 2, (
+        f"lineaire {ecart_lin:+.3f} doit ecraser poly2 {ecart_poly:+.3f}"
+    )


### PR DESCRIPTION
Grain: DEEP/notebook-python -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #14290

## Summary

Slice 1/4 de l'EPIC DoWhy (#14049) : `DoWhy-2-Contrefactuel-Individuel.ipynb` — le troisième échelon de Pearl (contrefactuel) sur la ligne `dowhy`, qui s'arrêtait à l'intervention. Le contraste pédagogique porteur de l'issue : **l'effet moyen peut être nul et le contrefactuel individuel non nul**.

Le notebook monte l'échelle sur un monde à ATE = 0, CATE(v) = 3v : pente naïve confondue +3.08 (piège), spécification bien posée qui retrouve T.V ≈ 2.96 (mais il faut CONNAÎTRE la forme), SCM `dowhy.gcm` inversible (abduction-action-prédiction), deux individus aux effets opposés (+3.35 / −1.61 vs vrais +3.27 / −1.66), décomposition row-wise (moyenne +0.33, écart-type 1.01 — la dispersion est la vraie information), et la démonstration de fragilité : un mécanisme linéaire écrase le contrefactuel (+3.35 → +0.12).

## Livrable

- `DoWhy-2-Contrefactuel-Individuel.ipynb` (nouveau, 27 cellules dont 3 exercices stubs répartis)
- `dowhy_organs.py` (nouveau) — organe canonique de la série, frère de `causal_organs.py` (#14051) : `generer_donnees`, `construire_scm`, `contrefactuel_individuel`, `ecarts_contrefactuels` ; doctrine RandomState local
- `tests/test_dowhy_organs.py` (nouveau) — 9 tests pytest, estimation réelle (pas de mock, H.1)
- `README.md` (Causal-Bridges) — ligne du notebook dans le tableau « Contenu » + 3 exercices ajoutés à la section dédiée (acceptance #14049 §5)

## Réparation env — règle F (pas une dérogation)

Le kernel `coursia-ml-training` exigé par l'acceptance §1 de #14049 n'existait pas sur po-2023 (kernelspec absent, env conda absent, cf docs/reference/kernels-runtime.md). Réparé plutôt que contourné : env conda `coursia-ml-training` créé (python 3.11, dowhy installé), kernel enregistré, **re-exécution du notebook sur ce kernel** — pas de fallback vers un autre kernel.

## Test plan

- [x] Kernel `coursia-ml-training` (acceptance §1), exécution réelle end-to-end : 12/12 cellules code, `execution_count` non nuls, **0 erreur**
- [x] 3 exercices stubs C.1 (`pass`/`return None`, zéro `raise NotImplementedError`), répartis (cellules 13/19/24)
- [x] `tests/test_dowhy_organs.py` : **9 passed** (pente naïve confondue > 2 ; T:V ~ 2.96 ; étoiles +3.3/−1.6 ; boucle row-wise |écart| moyen > 0.5 avec dispersion ; linéaire < poly2/2)
- [x] Organe importable (acceptance §4) : le notebook consomme `dowhy_organs` dès la cellule 3 ; un consommateur externe existe (les tests importent le module)
- [x] Verdict honnête (acceptance §3) : section 10 « quand ne pas croire le contrefactuel » + fragilité mesurée (+0.12 vs +3.35)
- [x] C.1/H.3 : `notebook_tools.py validate` = OK, 0 erreur 0 warning
- [x] Scan path-leak sur toutes les sorties + métadonnées : 0 hit ; `metadata.papermill.input/output_path` normalisés en basename (seule normalisation tolérée)
- [x] Interprétations recoupées contre les sorties réelles (3 cellules de lecture corrigées pour coller aux nombres mesurés, pas l'inverse)
- [x] README français (règle readme-french-first), catalogue byte-identique à main (aucune régénération)

## Résiduel #14049 (mesuré, non claimé)

- Slices DoWhy-3 (découverte de structure, causal-learn), DoWhy-4 (E-value), DoWhy-5 (instrument faible) — suggérés dans l'ordre de l'issue, DoWhy-5 en attente de la matière Greffe 5.

See #14049