### PR TITLE
feat(gametheory,#12205): GT-24b temoin d'impossibilite certifie - point 4 Loi II

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
@@ -1,0 +1,680 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f91e5398",
+   "metadata": {},
+   "source": [
+    "# GameTheory 24b : Le temoin d'impossibilite\n",
+    "\n",
+    "> **Grain1 d'ai-01 sur #12205 §6** : Robinson-Goforth (#12364, GT-24 chemin minimal) porte les points 1-3 du critere d'acceptance mais pas le **point 4** (temoin d'impossibilite). Ce notebook ferme le point 4 en s'appuyant sur la **structure produit** des chambres : `d_chambre(G,H) = d_perm(row_G,row_H) + d_perm(col_G,col_H)`.\n",
+    "\n",
+    "**Conventions reprises de GT-24** : `canonique`, `swap_valeurs_adjacentes`, `swap_jeu(cote, k)`, 24 ordres stricts sur 4 cases, 576 chambres, 6 voisins par jeu (3 swaps x {ligne, colonne})."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8af66af",
+   "metadata": {},
+   "source": [
+    "## 0. Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1c0dec02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:09.407419Z",
+     "iopub.status.busy": "2026-09-02T12:13:09.406872Z",
+     "iopub.status.idle": "2026-09-02T12:13:09.427243Z",
+     "shell.execute_reply": "2026-09-02T12:13:09.425865Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GameTheory 24b : temoin d'impossibilite certifie sur R-G (point 4)\n",
+      "\n",
+      "Permutaedre : 24 ordres stricts, 3 voisins / ordre\n",
+      "Chambres : 576 sommets, 6 voisins / chambre\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Configuration : GameTheory 24b ===\n",
+    "from itertools import permutations\n",
+    "from collections import deque, Counter\n",
+    "\n",
+    "print(\"GameTheory 24b : temoin d'impossibilite certifie sur R-G (point 4)\")\n",
+    "print()\n",
+    "\n",
+    "def canonique(t):\n",
+    "    vals = sorted(set(t))\n",
+    "    return tuple(vals.index(v) + 1 for v in t)\n",
+    "\n",
+    "def swap_valeurs_adjacentes(t, k):\n",
+    "    pk, pk1 = t.index(k), t.index(k + 1)\n",
+    "    l = list(t)\n",
+    "    l[pk], l[pk1] = l[pk1], l[pk]\n",
+    "    return tuple(l)\n",
+    "\n",
+    "def swap_jeu(jeu, cote, k):\n",
+    "    row, col = jeu\n",
+    "    if cote == \"ligne\":\n",
+    "        return (swap_valeurs_adjacentes(row, k), col)\n",
+    "    return (row, swap_valeurs_adjacentes(col, k))\n",
+    "\n",
+    "def adj_chambre(g):\n",
+    "    return [swap_jeu(g, cote, k) for cote in (\"ligne\", \"colonne\") for k in (1, 2, 3)]\n",
+    "\n",
+    "def adj_perm(t):\n",
+    "    return {swap_valeurs_adjacentes(t, k) for k in (1, 2, 3)}\n",
+    "\n",
+    "def bfs(depart, voisins_fn):\n",
+    "    dist = {depart: 0}\n",
+    "    q = deque([depart])\n",
+    "    while q:\n",
+    "        u = q.popleft()\n",
+    "        for v in voisins_fn(u):\n",
+    "            if v not in dist:\n",
+    "                dist[v] = dist[u] + 1\n",
+    "                q.append(v)\n",
+    "    return dist\n",
+    "\n",
+    "stricts = sorted({canonique(t) for t in permutations(range(1, 5))})\n",
+    "chambres = [(r, c) for r in stricts for c in stricts]\n",
+    "print(f\"Permutaedre : {len(stricts)} ordres stricts, {len(adj_perm(stricts[0]))} voisins / ordre\")\n",
+    "print(f\"Chambres : {len(chambres)} sommets, {len(adj_chambre(chambres[0]))} voisins / chambre\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19206b70",
+   "metadata": {},
+   "source": [
+    "## 1. La structure produit\n",
+    "\n",
+    "Le graphe des chambres est un **produit cartesien** de deux copies du permutaedre `S_4`. Les generateurs ne touchent qu'un seul cote a la fois, donc la distance dans le produit est exactement la somme des distances dans chaque facteur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a124e9f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:09.431312Z",
+     "iopub.status.busy": "2026-09-02T12:13:09.430715Z",
+     "iopub.status.idle": "2026-09-02T12:13:09.452129Z",
+     "shell.execute_reply": "2026-09-02T12:13:09.450259Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification exhaustive sur 576 chambres : 0 ecarts\n",
+      "Structure produit : EXACTE\n",
+      "Diametre permutaedre : 6\n",
+      "Diametre chambres : 12\n",
+      "ASSERTION PASS : structure produit verifiee sur 576/576\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 1.1 : verification exhaustive ===\n",
+    "IDENTITE = ((1, 2, 3, 4), (1, 2, 3, 4))\n",
+    "dist_perm = {o: bfs(o, adj_perm) for o in stricts}\n",
+    "dist_chambre = bfs(IDENTITE, lambda g: adj_chambre(g))\n",
+    "\n",
+    "ecarts = []\n",
+    "for (r, c) in chambres:\n",
+    "    d_ch = dist_chambre[(r, c)]\n",
+    "    d_calc = dist_perm[IDENTITE[0]][r] + dist_perm[IDENTITE[1]][c]\n",
+    "    if d_ch != d_calc:\n",
+    "        ecarts.append(((r, c), d_ch, d_calc))\n",
+    "\n",
+    "print(f\"Verification exhaustive sur 576 chambres : {len(ecarts)} ecarts\")\n",
+    "print(f\"Structure produit : {'EXACTE' if not ecarts else 'NON'}\")\n",
+    "print(f\"Diametre permutaedre : {max(max(d.values()) for d in dist_perm.values())}\")\n",
+    "print(f\"Diametre chambres : {max(dist_chambre.values())}\")\n",
+    "assert not ecarts\n",
+    "print(\"ASSERTION PASS : structure produit verifiee sur 576/576\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e196d81",
+   "metadata": {},
+   "source": [
+    "## 2. Le certificat analytique\n",
+    "\n",
+    "Pour `(G, H, k_max)` :\n",
+    "\n",
+    "- **`IMPOSSIBLE`** : `d_row + d_col > k_max`\n",
+    "- **`POSSIBLE`** : `d_row + d_col <= k_max`\n",
+    "\n",
+    "Verification de la table 24x24 (symetrique, triangulaire) :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d94e881d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:09.456247Z",
+     "iopub.status.busy": "2026-09-02T12:13:09.455661Z",
+     "iopub.status.idle": "2026-09-02T12:13:09.477471Z",
+     "shell.execute_reply": "2026-09-02T12:13:09.472994Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Symetrie 24x24 : 0 asymetries\n",
+      "Inegalite triangulaire : 0 violations sur 13824 triplets\n",
+      "ASSERTION PASS : table 24x24 symetrique et triangulaire\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 2.1 : precalcul 24x24 ===\n",
+    "D = {(o1, o2): dist_perm[o1][o2] for o1 in stricts for o2 in stricts}\n",
+    "non_sym = [(o1, o2) for o1 in stricts for o2 in stricts if D[(o1,o2)] != D[(o2,o1)]]\n",
+    "print(f\"Symetrie 24x24 : {len(non_sym)} asymetries\")\n",
+    "\n",
+    "import itertools\n",
+    "violations = sum(1 for o1, o2, o3 in itertools.product(stricts, repeat=3)\n",
+    "                 if D[(o1, o3)] > D[(o1, o2)] + D[(o2, o3)])\n",
+    "print(f\"Inegalite triangulaire : {violations} violations sur {24**3} triplets\")\n",
+    "assert violations == 0\n",
+    "print(\"ASSERTION PASS : table 24x24 symetrique et triangulaire\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69962315",
+   "metadata": {},
+   "source": [
+    "## 3. Le temoin en action\n",
+    "\n",
+    "- **Cas A** : antipode `IDENTITE -> RENVERS`, k_max=5 -> IMPOSSIBLE\n",
+    "- **Cas B** : row identique, col antipode, k_max=3 -> IMPOSSIBLE\n",
+    "- **Cas C** : frontiere POSSIBLE, k_max=1 -> POSSIBLE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dc0c6cfc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:09.484217Z",
+     "iopub.status.busy": "2026-09-02T12:13:09.483638Z",
+     "iopub.status.idle": "2026-09-02T12:13:09.494335Z",
+     "shell.execute_reply": "2026-09-02T12:13:09.492840Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CAS A (antipode, k_max=5) : IMPOSSIBLE - d_perm(row) + d_perm(col) = 6 + 6 = 12 > 5\n",
+      "CAS B (row identique, k_max=3) : IMPOSSIBLE - d_perm(row) + d_perm(col) = 0 + 4 = 4 > 3\n",
+      "CAS C (frontiere, k_max=1) : POSSIBLE - d_perm(row) + d_perm(col) = 1 + 0 = 1 <= 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 3.1 : certifier_impossibilite ===\n",
+    "def certifier_impossibilite(G, H, k_max, table=D):\n",
+    "    d_row = table[(G[0], H[0])]\n",
+    "    d_col = table[(G[1], H[1])]\n",
+    "    d_min = d_row + d_col\n",
+    "    if d_min > k_max:\n",
+    "        return {'verdict': 'IMPOSSIBLE', 'd_row': d_row, 'd_col': d_col,\n",
+    "                'd_min': d_min, 'k_max': k_max,\n",
+    "                'preuve': f'd_perm(row) + d_perm(col) = {d_row} + {d_col} = {d_min} > {k_max}'}\n",
+    "    else:\n",
+    "        return {'verdict': 'POSSIBLE', 'd_row': d_row, 'd_col': d_col,\n",
+    "                'd_min': d_min, 'k_max': k_max,\n",
+    "                'preuve': f'd_perm(row) + d_perm(col) = {d_row} + {d_col} = {d_min} <= {k_max}'}\n",
+    "\n",
+    "RENVERS = ((4, 3, 2, 1), (4, 3, 2, 1))\n",
+    "cas_A = certifier_impossibilite(IDENTITE, RENVERS, 5)\n",
+    "print(\"CAS A (antipode, k_max=5) :\", cas_A['verdict'], \"-\", cas_A['preuve'])\n",
+    "\n",
+    "H_B = ((1, 2, 3, 4), (3, 4, 1, 2))\n",
+    "cas_B = certifier_impossibilite(IDENTITE, H_B, 3)\n",
+    "print(\"CAS B (row identique, k_max=3) :\", cas_B['verdict'], \"-\", cas_B['preuve'])\n",
+    "\n",
+    "H_C = ((1, 2, 4, 3), (1, 2, 3, 4))\n",
+    "cas_C = certifier_impossibilite(IDENTITE, H_C, 1)\n",
+    "print(\"CAS C (frontiere, k_max=1) :\", cas_C['verdict'], \"-\", cas_C['preuve'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c60a7859",
+   "metadata": {},
+   "source": [
+    "## 4. Verification BFS tronque\n",
+    "\n",
+    "Pour chaque cas IMPOSSIBLE, on verifie par BFS tronque que `H` n'est **jamais** dans les sommets a distance `<= k_max` de `G`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d1fa2c6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:09.499462Z",
+     "iopub.status.busy": "2026-09-02T12:13:09.498863Z",
+     "iopub.status.idle": "2026-09-02T12:13:09.512595Z",
+     "shell.execute_reply": "2026-09-02T12:13:09.511576Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CAS A : sommets a <= 5 pas = 235, RENVERS present ? False\n",
+      "  Temoin IMPOSSIBLE verifie : True\n",
+      "CAS B : sommets a <= 3 pas = 68, H_B present ? False\n",
+      "  Temoin IMPOSSIBLE verifie : True\n",
+      "CAS C : sommets a <= 1 pas = 7, H_C present ? True\n",
+      "  Temoin POSSIBLE verifie : True\n",
+      "ASSERTION PASS : 3 cas (2 IMPOSSIBLE, 1 POSSIBLE) verifies\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 4.1 : BFS tronque ===\n",
+    "def bfs_tronque(depart, voisins_fn, profondeur_max):\n",
+    "    atteints = {depart}\n",
+    "    frontiere = {depart}\n",
+    "    for d in range(profondeur_max):\n",
+    "        nouvelle_frontiere = set()\n",
+    "        for u in frontiere:\n",
+    "            for v in voisins_fn(u):\n",
+    "                if v not in atteints:\n",
+    "                    atteints.add(v)\n",
+    "                    nouvelle_frontiere.add(v)\n",
+    "        frontiere = nouvelle_frontiere\n",
+    "        if not frontiere:\n",
+    "            break\n",
+    "    return atteints\n",
+    "\n",
+    "atte_A = bfs_tronque(IDENTITE, lambda g: adj_chambre(g), 5)\n",
+    "verif_A = RENVERS not in atte_A\n",
+    "print(f\"CAS A : sommets a <= 5 pas = {len(atte_A)}, RENVERS present ? {RENVERS in atte_A}\")\n",
+    "print(f\"  Temoin IMPOSSIBLE verifie : {verif_A}\")\n",
+    "\n",
+    "atte_B = bfs_tronque(IDENTITE, lambda g: adj_chambre(g), 3)\n",
+    "verif_B = H_B not in atte_B\n",
+    "print(f\"CAS B : sommets a <= 3 pas = {len(atte_B)}, H_B present ? {H_B in atte_B}\")\n",
+    "print(f\"  Temoin IMPOSSIBLE verifie : {verif_B}\")\n",
+    "\n",
+    "atte_C = bfs_tronque(IDENTITE, lambda g: adj_chambre(g), 1)\n",
+    "verif_C = H_C in atte_C\n",
+    "print(f\"CAS C : sommets a <= 1 pas = {len(atte_C)}, H_C present ? {H_C in atte_C}\")\n",
+    "print(f\"  Temoin POSSIBLE verifie : {verif_C}\")\n",
+    "\n",
+    "assert verif_A and verif_B and verif_C\n",
+    "print(\"ASSERTION PASS : 3 cas (2 IMPOSSIBLE, 1 POSSIBLE) verifies\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ad810d5",
+   "metadata": {},
+   "source": [
+    "## 5. Inventaire -- combien de triplets sont IMPOSSIBLE ?\n",
+    "\n",
+    "Echantillon de 100 chambres representatives, balayage des `k_max ∈ {0..11}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f0f69adf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:09.517333Z",
+     "iopub.status.busy": "2026-09-02T12:13:09.516790Z",
+     "iopub.status.idle": "2026-09-02T12:13:10.517800Z",
+     "shell.execute_reply": "2026-09-02T12:13:10.515043Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "k_max | IMPOSSIBLE / Total | %\n",
+      "--------------------------------------------------\n",
+      "   0  |  57500 /  57500 | 100.0%\n",
+      "   1  |  56900 /  57500 |  99.0%\n",
+      "   2  |  55000 /  57500 |  95.7%\n",
+      "   3  |  50800 /  57500 |  88.3%\n",
+      "   4  |  43700 /  57500 |  76.0%\n",
+      "   5  |  34100 /  57500 |  59.3%\n",
+      "   6  |  23500 /  57500 |  40.9%\n",
+      "   7  |  13900 /  57500 |  24.2%\n",
+      "   8  |   6800 /  57500 |  11.8%\n",
+      "   9  |   2600 /  57500 |   4.5%\n",
+      "  10  |    700 /  57500 |   1.2%\n",
+      "  11  |    100 /  57500 |   0.2%\n",
+      "\n",
+      "A k_max=5 : 59.3% des paires sont IMPOSSIBLE -- le temoin tranche souvent\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 5.1 : inventaire ===\n",
+    "import random\n",
+    "random.seed(42)\n",
+    "echantillon = random.sample(chambres, 100)\n",
+    "\n",
+    "resultats_par_k = {}\n",
+    "for k_max in range(0, 12):\n",
+    "    compteur_imp = 0\n",
+    "    compteur_tot = 0\n",
+    "    for G in echantillon:\n",
+    "        for H in chambres:\n",
+    "            if G == H:\n",
+    "                continue\n",
+    "            d_min = D[(G[0], H[0])] + D[(G[1], H[1])]\n",
+    "            compteur_tot += 1\n",
+    "            if d_min > k_max:\n",
+    "                compteur_imp += 1\n",
+    "    resultats_par_k[k_max] = (compteur_imp, compteur_tot)\n",
+    "\n",
+    "print(\"k_max | IMPOSSIBLE / Total | %\")\n",
+    "print(\"-\" * 50)\n",
+    "for k_max in (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11):\n",
+    "    imp, tot = resultats_par_k[k_max]\n",
+    "    pct = 100.0 * imp / tot\n",
+    "    print(f\"  {k_max:>2}  | {imp:>6} / {tot:>6} | {pct:>5.1f}%\")\n",
+    "\n",
+    "imp5, tot5 = resultats_par_k[5]\n",
+    "print()\n",
+    "print(f\"A k_max=5 : {100*imp5/tot5:.1f}% des paires sont IMPOSSIBLE -- le temoin tranche souvent\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50eac580",
+   "metadata": {},
+   "source": [
+    "## 6. Frontiere et bornes\n",
+    "\n",
+    "**Certifie** : pour `k_max < 12`, IMPOSSIBLE est certain.\n",
+    "\n",
+    "**Non certifie** : un cas POSSIBLE garantit l'existence, pas un chemin explicite (le constructeur de GT-24 produit le chemin). Au-dela de `k_max = 12`, tout est POSSIBLE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "78422445",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:10.522411Z",
+     "iopub.status.busy": "2026-09-02T12:13:10.521849Z",
+     "iopub.status.idle": "2026-09-02T12:13:10.532992Z",
+     "shell.execute_reply": "2026-09-02T12:13:10.531570Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RESUME -- Le point 4 du critere #12205 est TENU sur Robinson-Goforth\n",
+      "\n",
+      "Verdict par cas :\n",
+      "  CAS A : IMPOSSIBLE\n",
+      "  CAS B : IMPOSSIBLE\n",
+      "  CAS C : POSSIBLE\n",
+      "\n",
+      "Verification par BFS tronque :\n",
+      "  CAS A IMPOSSIBLE verifie : True\n",
+      "  CAS B IMPOSSIBLE verifie : True\n",
+      "  CAS C POSSIBLE verifie   : True\n",
+      "\n",
+      "Structure produit : 576/576 chambres, 0 ecart\n",
+      "Table 24x24 : symetrique et triangulaire\n",
+      "A k_max=5 : 59.3% des paires sont IMPOSSIBLE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 6.1 : resume final ===\n",
+    "print(\"RESUME -- Le point 4 du critere #12205 est TENU sur Robinson-Goforth\")\n",
+    "print()\n",
+    "print(\"Verdict par cas :\")\n",
+    "print(f\"  CAS A : {cas_A['verdict']}\")\n",
+    "print(f\"  CAS B : {cas_B['verdict']}\")\n",
+    "print(f\"  CAS C : {cas_C['verdict']}\")\n",
+    "print()\n",
+    "print(\"Verification par BFS tronque :\")\n",
+    "print(f\"  CAS A IMPOSSIBLE verifie : {verif_A}\")\n",
+    "print(f\"  CAS B IMPOSSIBLE verifie : {verif_B}\")\n",
+    "print(f\"  CAS C POSSIBLE verifie   : {verif_C}\")\n",
+    "print()\n",
+    "print(f\"Structure produit : 576/576 chambres, 0 ecart\")\n",
+    "print(f\"Table 24x24 : symetrique et triangulaire\")\n",
+    "print(f\"A k_max=5 : {100*imp5/tot5:.1f}% des paires sont IMPOSSIBLE\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "877d7f4b",
+   "metadata": {},
+   "source": [
+    "## Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f8e35c6",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 -- Un autre cas IMPOSSIBLE\n",
+    "\n",
+    "Choisir un autre couple `(G, H)` et un `k_max` tels que le temoin certifie IMPOSSIBLE. Verifier par BFS tronque."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "65e46361",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:10.537477Z",
+     "iopub.status.busy": "2026-09-02T12:13:10.536891Z",
+     "iopub.status.idle": "2026-09-02T12:13:10.545620Z",
+     "shell.execute_reply": "2026-09-02T12:13:10.544035Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Certificat Exercice 1 : {'verdict': 'IMPOSSIBLE', 'd_row': 6, 'd_col': 0, 'd_min': 6, 'k_max': 3, 'preuve': 'd_perm(row) + d_perm(col) = 6 + 0 = 6 > 3'}\n",
+      "BFS tronque : H dans sommets a <= 3 pas ? False\n",
+      "Verifie : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : choisir un cas IMPOSSIBLE et verifier\n",
+    "G_exo1 = ((1, 2, 3, 4), (1, 2, 3, 4))  # Identite\n",
+    "H_exo1 = ((4, 3, 2, 1), (1, 2, 3, 4))  # row antipode, col identique -> d_min = 6\n",
+    "k_max_exo1 = 3                           # IMPOSSIBLE : 6 > 3\n",
+    "cert = certifier_impossibilite(G_exo1, H_exo1, k_max_exo1)\n",
+    "print(\"Certificat Exercice 1 :\", cert)\n",
+    "atteints = bfs_tronque(G_exo1, lambda g: adj_chambre(g), k_max_exo1)\n",
+    "verif = H_exo1 not in atteints\n",
+    "print(f\"BFS tronque : H dans sommets a <= {k_max_exo1} pas ? {H_exo1 in atteints}\")\n",
+    "print(f\"Verifie : {verif}\")\n",
+    "# resultat = None  # pour exercice etudiant\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c28a3f4",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 -- Trouver le plus petit k_max POSSIBLE pour un antipode\n",
+    "\n",
+    "Pour `(IDENTITE, RENVERSEMENT)`, trouver le plus petit `k_max` tel que `certifier_impossibilite` rend POSSIBLE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b2ffb18d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:10.549700Z",
+     "iopub.status.busy": "2026-09-02T12:13:10.549151Z",
+     "iopub.status.idle": "2026-09-02T12:13:10.562912Z",
+     "shell.execute_reply": "2026-09-02T12:13:10.560132Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plus petit k_max rendant POSSIBLE : 12 (distance = 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : trouver la distance de l'antipode\n",
+    "G = IDENTITE\n",
+    "H = RENVERS\n",
+    "resultat = None  # TODO etudiant\n",
+    "for k in range(0, 13):\n",
+    "    c = certifier_impossibilite(G, H, k)\n",
+    "    if c['verdict'] == 'POSSIBLE':\n",
+    "        resultat = k\n",
+    "        print(f\"Plus petit k_max rendant POSSIBLE : {k} (distance = {c['d_min']})\")\n",
+    "        break\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fb2b184",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 -- Trois paires d_row=0 et d_col=6\n",
+    "\n",
+    "Trouver 3 paires distinctes avec `d_row=0` (row identique) et `d_col=6` (antipode colonne)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7ecfe61e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:13:10.567254Z",
+     "iopub.status.busy": "2026-09-02T12:13:10.566720Z",
+     "iopub.status.idle": "2026-09-02T12:13:10.576129Z",
+     "shell.execute_reply": "2026-09-02T12:13:10.574728Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paire 1 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n",
+      "Paire 2 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n",
+      "Paire 3 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : trois paires d_row=0 et d_col=6\n",
+    "candidates = []\n",
+    "for G in chambres:\n",
+    "    for H in chambres:\n",
+    "        if G == H:\n",
+    "            continue\n",
+    "        if D[(G[0], H[0])] == 0 and D[(G[1], H[1])] == 6:\n",
+    "            candidates.append((G, H))\n",
+    "            if len(candidates) >= 3:\n",
+    "                break\n",
+    "    if len(candidates) >= 3:\n",
+    "        break\n",
+    "\n",
+    "resultat = None  # pour exercice etudiant\n",
+    "for i, (G, H) in enumerate(candidates, 1):\n",
+    "    c5 = certifier_impossibilite(G, H, 5)\n",
+    "    c6 = certifier_impossibilite(G, H, 6)\n",
+    "    print(f\"Paire {i} : k_max=5 -> {c5['verdict']}, k_max=6 -> {c6['verdict']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3b4f6df",
+   "metadata": {},
+   "source": [
+    "## Conclusion -- le point 4 sur Robinson-Goforth est tenu\n",
+    "\n",
+    "**Acceptance #12205 §5** :\n",
+    "\n",
+    "1. Substrat dont le verificateur existe sur main : GT-24 porte les points 1-3. **OUI**.\n",
+    "2. Generateur != verificateur : `certifier_impossibilite` (O(1)) != BFS exhaustif (O(576^k_max)). **OUI**.\n",
+    "3. Temoin certifie : verdict IMPOSSIBLE porte certificat analytique (d_row, d_col, k_max). **OUI**.\n",
+    "4. Cas sans solution = temoin d'impossibilite, pas silence : section 4 verifie par BFS tronque. Section 5 : plus de la moitie des paires a k_max=5 sont IMPOSSIBLE. **OUI**.\n",
+    "\n",
+    "**Substrats independants portant les 4 points** :\n",
+    "- Life/Conway (PR #14205, #12395)\n",
+    "- AMD (`impossibility_strict_payments`)\n",
+    "- Robinson-Goforth (ce notebook)\n",
+    "- Tweety-5d (`afB_no_stable`, PR #13628)\n",
+    "\n",
+    "Reference croisee : #12205 - #12364 - #13628."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
@@ -690,7 +690,7 @@
    "source": [
     "## 6. Inventaire -- combien de triplets sont IMPOSSIBLE ?\n",
     "\n",
-    "Echantillon aleatoire de 100 chambres representatives (seed=42 pour la reproductibilite), balayage des `k_max ∈ {0..11}`. La proportion d'IMPOSSIBLE **decroît quand `k_max` augmente** (plus la borne est large, plus il est facile de tomber dans la zone POSSIBLE ; plus elle est serree, plus l'impossibilite est facile a prouver), puis sature vers 100 % au-dela du diametre.\n",
+    "Echantillon aleatoire de 100 chambres representatives (seed=42 pour la reproductibilite), balayage des `k_max ∈ {0..11}`. La proportion d'IMPOSSIBLE **decroît quand `k_max` augmente** (plus la borne est large, plus il est facile de tomber dans la zone POSSIBLE ; plus elle est serree, plus l'impossibilite est facile a prouver), puis s'annule au-dela du diametre (`k_max >= 12` : tout couple devient POSSIBLE).\n",
     "\n",
     "La sortie de la cellule code plus loin trace les valeurs reelles sur le sous-echantillon :\n",
     "\n",
@@ -703,7 +703,9 @@
     "| 4 | 43 700 / 57 500 | 76,0 % |\n",
     "| 5 | 34 100 / 57 500 | 59,3 % |\n",
     "\n",
-    "Ces valeurs sont celles qu'imprime la cellule code qui suit immediatement (cellule de substance preservee, byte-identique au commit `6b190bffb0`)."
+    "Ces valeurs sont celles qu'imprime la cellule code qui suit immediatement (cellule de substance preservee depuis le commit `6b190bffb0` ; seule la\n",
+    "reference de section de son commentaire d'en-tete a ete renumerotee,\n",
+    "`5.1` -> `6.1` -- ses sorties commitees n'ont pas bouge)."
    ]
   },
   {
@@ -902,11 +904,11 @@
     "\n",
     "Trouver un couple `(G, H)` et un `k_max` tels que le verdict est `IMPOSSIBLE`, avec une **structure differente** des cas fondateurs suivants :\n",
     "\n",
-    "- **Cas A** : antipode integral (les deux cotes a distance 6) -- la sortie certifiee le plus tot (cellule 8) ;\n",
+    "- **Cas A** : antipode integral (les deux cotes a distance 6) -- exhibe en cellule 8 ;\n",
     "- **Cas B** (`d_row = 0, d_col = 4`) : un seul cote avec une distance **non antipode** (4 < 6) ; aussi exhibe en cellule 8 ;\n",
     "- **Exemple 5.1** (`H_exemple` = `((4, 3, 2, 1), (1, 2, 3, 4))`) : un seul cote **antipode** (`d_perm(row_G, row_H) = 6`, `d_perm(col_G, col_H) = 0`) -- l'exemple guide de la section 5.\n",
     "\n",
-    "L'enonce de l'exercice exclut donc l'antipode integral (Cas A) **et** les mono-cotes antipodes (exemple 5.1) **et** les mono-cotes non antipodes (Cas B). Reste ce qui n'est ni l'un ni l'autre : par exemple, les deux cotes a des distances intermediaires (3 et 4, par exemple) pour un `k_max = 5`. Verifier par BFS tronque que le verdict certifie est bien `IMPOSSIBLE`."
+    "L'enonce de l'exercice exclut donc l'antipode integral (Cas A) **et** les mono-cotes antipodes (exemple 5.1) **et** les mono-cotes non antipodes (Cas B). Reste ce qui n'appartient a aucune de ces trois familles : par exemple, les deux cotes a des distances intermediaires (3 et 4, par exemple) pour un `k_max = 5`. Verifier par BFS tronque que le verdict certifie est bien `IMPOSSIBLE`."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "81681540",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006393,
+     "end_time": "2026-09-02T13:23:35.294164+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.287771+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GameTheory 24b : Le temoin d'impossibilite\n",
     "\n",
@@ -15,7 +24,16 @@
   {
    "cell_type": "markdown",
    "id": "3d03454d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004833,
+     "end_time": "2026-09-02T13:23:35.306855+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.302022+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 0. Configuration"
    ]
@@ -26,11 +44,19 @@
    "id": "1c0dec02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.151267Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.150794Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.168860Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.167535Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.319402Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.318857Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.337065Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.335901Z"
+    },
+    "papermill": {
+     "duration": 0.025976,
+     "end_time": "2026-09-02T13:23:35.338055+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.312079+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -94,7 +120,16 @@
   {
    "cell_type": "markdown",
    "id": "2f6dbd8c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004661,
+     "end_time": "2026-09-02T13:23:35.347771+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.343110+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. La structure produit\n",
     "\n",
@@ -104,7 +139,9 @@
     "\n",
     "**Demonstration par double inegalite** :\n",
     "\n",
-    "- **Borne inferieure (par projection)** : tout chemin de `G` a `H` dans le graphe produit se projette sur un chemin dans chaque facteur (la projection d'un swap sur un cote est un swap dans le permutaedre correspondant, et l'inverse). La projection est surjective et preserve la longueur, donc `d_chambre(G, H) >= d_perm(row_G, row_H) + d_perm(col_G, col_H)`.\n",
+    "- **Borne inferieure (par comptage des pas de chaque cote)** : soit un chemin de `G` a `H` de longueur `L` dans le produit. Chaque generateur ne touche qu'un seul cote, donc les `L` pas se repartissent en `n_row` pas cote ligne et `n_col` pas cote colonne, avec `L = n_row + n_col`. En ne gardant que les pas cote ligne, on obtient un chemin de `row_G` a `row_H` dans le permutaedre, de longueur `n_row` : donc `n_row >= d_perm(row_G, row_H)`, et symetriquement `n_col >= d_perm(col_G, col_H)`. En sommant : `L >= d_perm(row_G, row_H) + d_perm(col_G, col_H)`.\n",
+    "\n",
+    "  *Pourquoi la projection seule ne suffit pas* : projeter le chemin **entier** sur le facteur ligne ne preserve pas la longueur — les pas cote colonne projettent sur du surplace. On en tire `d_perm(row_G, row_H) <= L`, et de meme `d_perm(col_G, col_H) <= L` : cela borne `L` par le **maximum** des deux distances, pas par leur **somme**. C'est le comptage `L = n_row + n_col`, et lui seul, qui donne l'additivite.\n",
     "\n",
     "- **Borne superieure (par concatenation)** : reciproquement, un chemin optimal dans le facteur ligne (longueur `d_perm(row_G, row_H)`) et un chemin optimal dans le facteur colonne (longueur `d_perm(col_G, col_H)`) peuvent etre concatenes cote par cote pour produire un chemin de longueur `d_perm(row_G, row_H) + d_perm(col_G, col_H)` dans le produit (l'independance des cotes permet l'entrelacement arbitraire). Donc `d_chambre(G, H) <= d_perm(row_G, row_H) + d_perm(col_G, col_H)`.\n",
     "\n",
@@ -117,11 +154,19 @@
    "id": "a124e9f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.172258Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.171797Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.187653Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.186463Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.360510Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.360196Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.372327Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.371384Z"
+    },
+    "papermill": {
+     "duration": 0.019917,
+     "end_time": "2026-09-02T13:23:35.373231+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.353314+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -160,7 +205,16 @@
   {
    "cell_type": "markdown",
    "id": "b1d28dfa",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004996,
+     "end_time": "2026-09-02T13:23:35.382771+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.377775+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Le certificat analytique\n",
     "\n",
@@ -180,11 +234,19 @@
    "id": "d94e881d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.191657Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.191170Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.210051Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.208364Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.393104Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.392640Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.406248Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.405189Z"
+    },
+    "papermill": {
+     "duration": 0.020422,
+     "end_time": "2026-09-02T13:23:35.407052+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.386630+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -214,7 +276,16 @@
   {
    "cell_type": "markdown",
    "id": "ae493cbc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005144,
+     "end_time": "2026-09-02T13:23:35.417359+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.412215+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Le temoin en action\n",
     "\n",
@@ -233,11 +304,19 @@
    "id": "dc0c6cfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.213851Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.213388Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.223473Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.221912Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.428063Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.427746Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.437038Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.435746Z"
+    },
+    "papermill": {
+     "duration": 0.016587,
+     "end_time": "2026-09-02T13:23:35.437975+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.421388+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -281,7 +360,16 @@
   {
    "cell_type": "markdown",
    "id": "db95dd2c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005106,
+     "end_time": "2026-09-02T13:23:35.448031+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.442925+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Verification BFS tronque\n",
     "\n",
@@ -294,11 +382,19 @@
    "id": "d1fa2c6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.227078Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.226640Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.237307Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.235657Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.462969Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.462435Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.471500Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.470387Z"
+    },
+    "papermill": {
+     "duration": 0.017597,
+     "end_time": "2026-09-02T13:23:35.472346+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.454749+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -354,7 +450,16 @@
   {
    "cell_type": "markdown",
    "id": "dc999b6a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006458,
+     "end_time": "2026-09-02T13:23:35.485103+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.478645+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Exemples guides -- le temoin en action\n",
     "\n",
@@ -364,9 +469,18 @@
   {
    "cell_type": "markdown",
    "id": "7f85012b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005071,
+     "end_time": "2026-09-02T13:23:35.497753+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.492682+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### 4.1 Exemple guide -- Un autre cas IMPOSSIBLE\n",
+    "### 5.1 Exemple guide -- Un autre cas IMPOSSIBLE\n",
     "\n",
     "**Demarche** : on choisit une chambre `H` dont la structure est *differente* de l'antipode du Cas A — par exemple, `H` a la **ligne antipode** mais la **colonne identique** a `G`. Alors `d_perm(row_G, row_H) = 6` (antipode du permutaedre) et `d_perm(col_G, col_H) = 0` (meme colonne), donc `d_min = 6 + 0 = 6`. Pour `k_max = 3`, le verdict est `IMPOSSIBLE` puisque `6 > 3`.\n",
     "\n",
@@ -381,11 +495,19 @@
    "id": "c4c2adf1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.241284Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.240885Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.248066Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.247328Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.511429Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.511026Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.517744Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.516730Z"
+    },
+    "papermill": {
+     "duration": 0.0141,
+     "end_time": "2026-09-02T13:23:35.518743+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.504643+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -400,7 +522,7 @@
     }
    ],
    "source": [
-    "# === Exemple guide 4.1 : un autre cas IMPOSSIBLE (row antipode, col identique) ===\n",
+    "# === Exemple guide 5.1 : un autre cas IMPOSSIBLE (row antipode, col identique) ===\n",
     "G_exemple = IDENTITE\n",
     "H_exemple = ((4, 3, 2, 1), (1, 2, 3, 4))  # row antipode, col identique\n",
     "k_max_exemple = 3                          # 6 > 3 -> IMPOSSIBLE\n",
@@ -420,9 +542,18 @@
   {
    "cell_type": "markdown",
    "id": "cbb8dbda",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005426,
+     "end_time": "2026-09-02T13:23:35.529923+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.524497+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### 4.2 Exemple guide -- Distance d'un antipode\n",
+    "### 5.2 Exemple guide -- Distance d'un antipode\n",
     "\n",
     "**Demarche** : la distance entre deux sommets `G` et `H` est le plus petit `k` tel que `H` appartient aux sommets a distance `<= k` de `G`. Pour l'antipode `(IDENTITE, RENVERS)`, le certificat analytique donne `d_min = 6 + 6 = 12` — c'est le diametre du graphe produit. Le plus petit `k_max` qui rend `POSSIBLE` est donc `k_max = 12` (a `k_max < 12`, IMPOSSIBLE est certain ; a `k_max >= 12`, POSSIBLE est garanti par concatenation des deux chemins optimaux).\n",
     "\n",
@@ -435,11 +566,19 @@
    "id": "032cae33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.251804Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.251469Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.257471Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.256288Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.542309Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.542003Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.547837Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.546828Z"
+    },
+    "papermill": {
+     "duration": 0.013541,
+     "end_time": "2026-09-02T13:23:35.548823+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.535282+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -452,7 +591,7 @@
     }
    ],
    "source": [
-    "# === Exemple guide 4.2 : distance de l'antipode (IDENTITE, RENVERS) ===\n",
+    "# === Exemple guide 5.2 : distance de l'antipode (IDENTITE, RENVERS) ===\n",
     "seuil = None\n",
     "for k in range(0, 13):\n",
     "    c = certifier_impossibilite(IDENTITE, RENVERS, k)\n",
@@ -466,9 +605,18 @@
   {
    "cell_type": "markdown",
    "id": "49a2f235",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004671,
+     "end_time": "2026-09-02T13:23:35.558108+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.553437+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### 4.3 Exemple guide -- Paires `d_row=0, d_col=6`\n",
+    "### 5.3 Exemple guide -- Paires `d_row=0, d_col=6`\n",
     "\n",
     "**Demarche** : `d_row = 0` signifie que la ligne de `G` est identique a la ligne de `H` ; `d_col = 6` signifie que la colonne de `G` est l'antipode de la colonne de `H`. Ce sont donc les paires ou seul le cote colonne doit etre parcoure dans toute sa longueur.\n",
     "\n",
@@ -481,11 +629,19 @@
    "id": "18fe66a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.260687Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.260295Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.267501Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.266323Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.567922Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.567650Z",
+     "iopub.status.idle": "2026-09-02T13:23:35.574344Z",
+     "shell.execute_reply": "2026-09-02T13:23:35.573132Z"
+    },
+    "papermill": {
+     "duration": 0.012879,
+     "end_time": "2026-09-02T13:23:35.575303+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.562424+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -499,7 +655,7 @@
     }
    ],
    "source": [
-    "# === Exemple guide 4.3 : trois paires d_row=0, d_col=6 ===\n",
+    "# === Exemple guide 5.3 : trois paires d_row=0, d_col=6 ===\n",
     "candidates_43 = []\n",
     "for G in chambres:\n",
     "    for H in chambres:\n",
@@ -521,11 +677,33 @@
   {
    "cell_type": "markdown",
    "id": "dd8ade85",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.0058,
+     "end_time": "2026-09-02T13:23:35.586330+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.580530+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Inventaire -- combien de triplets sont IMPOSSIBLE ?\n",
     "\n",
-    "Echantillon aleatoire de 100 chambres representatives (seed=42 pour la reproductibilite), balayage des `k_max ∈ {0..11}`. La proportion d'IMPOSSIBLE croıt avec `k_max` (plus la borne est petite, plus il est facile de prouver l'impossibilite), puis sature vers 100 % au-dela du diametre."
+    "Echantillon aleatoire de 100 chambres representatives (seed=42 pour la reproductibilite), balayage des `k_max ∈ {0..11}`. La proportion d'IMPOSSIBLE **decroît quand `k_max` augmente** (plus la borne est large, plus il est facile de tomber dans la zone POSSIBLE ; plus elle est serree, plus l'impossibilite est facile a prouver), puis sature vers 100 % au-dela du diametre.\n",
+    "\n",
+    "La sortie de la cellule code plus loin trace les valeurs reelles sur le sous-echantillon :\n",
+    "\n",
+    "| `k_max` | IMPOSSIBLE / Total | % |\n",
+    "|---:|---:|---:|\n",
+    "| 0 | 57 500 / 57 500 | 100,0 % |\n",
+    "| 1 | 56 900 / 57 500 | 99,0 % |\n",
+    "| 2 | 55 000 / 57 500 | 95,7 % |\n",
+    "| 3 | 50 800 / 57 500 | 88,3 % |\n",
+    "| 4 | 43 700 / 57 500 | 76,0 % |\n",
+    "| 5 | 34 100 / 57 500 | 59,3 % |\n",
+    "\n",
+    "Ces valeurs sont celles qu'imprime la cellule code qui suit immediatement (cellule de substance preservee, byte-identique au commit `6b190bffb0`)."
    ]
   },
   {
@@ -534,11 +712,19 @@
    "id": "f0f69adf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.270535Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.270097Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.824294Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.822869Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:35.597784Z",
+     "iopub.status.busy": "2026-09-02T13:23:35.597419Z",
+     "iopub.status.idle": "2026-09-02T13:23:36.083531Z",
+     "shell.execute_reply": "2026-09-02T13:23:36.082304Z"
+    },
+    "papermill": {
+     "duration": 0.493434,
+     "end_time": "2026-09-02T13:23:36.084486+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:35.591052+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -565,7 +751,7 @@
     }
    ],
    "source": [
-    "# === Section 5.1 : inventaire ===\n",
+    "# === Section 6.1 : inventaire ===\n",
     "import random\n",
     "random.seed(42)\n",
     "echantillon = random.sample(chambres, 100)\n",
@@ -599,7 +785,16 @@
   {
    "cell_type": "markdown",
    "id": "9721729c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004906,
+     "end_time": "2026-09-02T13:23:36.094348+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.089442+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Frontiere et bornes\n",
     "\n",
@@ -616,11 +811,19 @@
    "id": "78422445",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.828241Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.827752Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.836452Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.834984Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:36.108052Z",
+     "iopub.status.busy": "2026-09-02T13:23:36.107647Z",
+     "iopub.status.idle": "2026-09-02T13:23:36.114705Z",
+     "shell.execute_reply": "2026-09-02T13:23:36.113306Z"
+    },
+    "papermill": {
+     "duration": 0.016098,
+     "end_time": "2026-09-02T13:23:36.115901+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.099803+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -646,7 +849,7 @@
     }
    ],
    "source": [
-    "# === Section 6.1 : resume final ===\n",
+    "# === Section 7.1 : resume final ===\n",
     "print(\"RESUME -- Le point 4 du critere #12205 est TENU sur Robinson-Goforth\")\n",
     "print()\n",
     "print(\"Verdict par cas :\")\n",
@@ -667,7 +870,16 @@
   {
    "cell_type": "markdown",
    "id": "a9d2074b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007278,
+     "end_time": "2026-09-02T13:23:36.130453+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.123175+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Exercices"
    ]
@@ -675,11 +887,26 @@
   {
    "cell_type": "markdown",
    "id": "2076c249",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004768,
+     "end_time": "2026-09-02T13:23:36.140765+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.135997+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice A -- Un cas IMPOSSIBLE non antipode\n",
     "\n",
-    "Trouver un couple `(G, H)` et un `k_max` tels que le verdict est `IMPOSSIBLE`, avec une **structure differente** de l'antipode : ni les deux cotes antipodes (Cas A), ni un seul cote antipode (Cas B / exemple 3.1). Par exemple : les deux cotes a des distances intermediaires (3 et 4, par exemple) pour un `k_max = 5`. Verifier par BFS tronque."
+    "Trouver un couple `(G, H)` et un `k_max` tels que le verdict est `IMPOSSIBLE`, avec une **structure differente** des cas fondateurs suivants :\n",
+    "\n",
+    "- **Cas A** : antipode integral (les deux cotes a distance 6) -- la sortie certifiee le plus tot (cellule 8) ;\n",
+    "- **Cas B** (`d_row = 0, d_col = 4`) : un seul cote avec une distance **non antipode** (4 < 6) ; aussi exhibe en cellule 8 ;\n",
+    "- **Exemple 5.1** (`H_exemple` = `((4, 3, 2, 1), (1, 2, 3, 4))`) : un seul cote **antipode** (`d_perm(row_G, row_H) = 6`, `d_perm(col_G, col_H) = 0`) -- l'exemple guide de la section 5.\n",
+    "\n",
+    "L'enonce de l'exercice exclut donc l'antipode integral (Cas A) **et** les mono-cotes antipodes (exemple 5.1) **et** les mono-cotes non antipodes (Cas B). Reste ce qui n'est ni l'un ni l'autre : par exemple, les deux cotes a des distances intermediaires (3 et 4, par exemple) pour un `k_max = 5`. Verifier par BFS tronque que le verdict certifie est bien `IMPOSSIBLE`."
    ]
   },
   {
@@ -688,17 +915,25 @@
    "id": "1885a64e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.840662Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.840133Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.846350Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.844726Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:36.155991Z",
+     "iopub.status.busy": "2026-09-02T13:23:36.155517Z",
+     "iopub.status.idle": "2026-09-02T13:23:36.161230Z",
+     "shell.execute_reply": "2026-09-02T13:23:36.159877Z"
+    },
+    "papermill": {
+     "duration": 0.016228,
+     "end_time": "2026-09-02T13:23:36.162296+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.146068+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Exercice A : cas IMPOSSIBLE non antipode\n",
     "# A l'etudiant : choisir G, H, k_max de sorte que d_row + d_col > k_max\n",
-    "# avec une structure differente des Cas A/B/3.1.\n",
+    "# avec une structure differente des Cas A/B/5.1.\n",
     "G_A = None  # TODO etudiant\n",
     "H_A = None  # TODO etudiant\n",
     "k_max_A = None  # TODO etudiant\n",
@@ -713,7 +948,16 @@
   {
    "cell_type": "markdown",
    "id": "fd439ec5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005796,
+     "end_time": "2026-09-02T13:23:36.173970+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.168174+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice B -- Structure produit pour un G arbitraire\n",
     "\n",
@@ -726,11 +970,19 @@
    "id": "544788c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.850201Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.849642Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.856211Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.854823Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:36.185951Z",
+     "iopub.status.busy": "2026-09-02T13:23:36.185671Z",
+     "iopub.status.idle": "2026-09-02T13:23:36.189898Z",
+     "shell.execute_reply": "2026-09-02T13:23:36.188825Z"
+    },
+    "papermill": {
+     "duration": 0.011953,
+     "end_time": "2026-09-02T13:23:36.190722+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.178769+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -749,11 +1001,20 @@
   {
    "cell_type": "markdown",
    "id": "9e960407",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005502,
+     "end_time": "2026-09-02T13:23:36.201177+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.195675+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice C -- Densite d'IMPOSSIBLE a k_max=7 par echantillonnage stratifie\n",
     "\n",
-    "La section 5 a montre une densite a `k_max=5` sur 100 chambres aleatoires. Estimer la densite a `k_max=7` en utilisant un echantillon **stratifie** : tirer 25 chambres dans chaque quartile du permutaedre (par distance a `IDENTITE`), puis compter la proportion d'IMPOSSIBLE. Comparer au chiffre donne par la section 5 (qui utilise un echantillon aleatoire non stratifie)."
+    "La section 6 a montre une densite a `k_max=5` sur 100 chambres aleatoires. Estimer la densite a `k_max=7` en utilisant un echantillon **stratifie** : le scaffold ci-dessous partitionne le permutaedre en **7 strates** selon la distance a `IDENTITE` (0 a 6) et tire **4 chambres dans chaque strate**. Completer le comptage de la proportion d'IMPOSSIBLE, puis comparer au chiffre donne par la section 6 (qui utilise un echantillon aleatoire non stratifie)."
    ]
   },
   {
@@ -762,17 +1023,25 @@
    "id": "e4ccfd20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:50:18.859675Z",
-     "iopub.status.busy": "2026-09-02T12:50:18.859174Z",
-     "iopub.status.idle": "2026-09-02T12:50:18.866747Z",
-     "shell.execute_reply": "2026-09-02T12:50:18.865504Z"
-    }
+     "iopub.execute_input": "2026-09-02T13:23:36.217499Z",
+     "iopub.status.busy": "2026-09-02T13:23:36.216983Z",
+     "iopub.status.idle": "2026-09-02T13:23:36.223790Z",
+     "shell.execute_reply": "2026-09-02T13:23:36.222544Z"
+    },
+    "papermill": {
+     "duration": 0.017337,
+     "end_time": "2026-09-02T13:23:36.224876+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.207539+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Exercice C : densite IMPOSSIBLE a k_max=7 par echantillonnage stratifie\n",
     "import random\n",
-    "random.seed(2025)  # graine differente de la section 5 (seed=42)\n",
+    "random.seed(2025)  # graine differente de la section 6 (seed=42)\n",
     "\n",
     "# Stratification par distance a IDENTITE dans le permutaedre\n",
     "def dist_id(t):\n",
@@ -787,29 +1056,39 @@
     "# A l'etudiant :\n",
     "# 1. Pour chaque G dans echantillon_stratifie, pour chaque H dans chambres,\n",
     "#    compter les IMPOSSIBLE a k_max=7 (en evitant G == H)\n",
-    "# 2. Comparer au chiffre aleatoire de la section 5\n",
+    "# 2. Comparer au chiffre aleatoire de la section 6\n",
     "resultat_C = None  # TODO etudiant\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "1538c555",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005351,
+     "end_time": "2026-09-02T13:23:36.235687+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T13:23:36.230336+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion -- le point 4 sur Robinson-Goforth est tenu\n",
     "\n",
     "**Acceptance #12205 §5** :\n",
     "\n",
     "1. Substrat dont le verificateur existe sur main : GT-24 porte les points 1-3. **OUI**.\n",
-    "2. Generateur != verificateur : `certifier_impossibilite` (O(1)) != BFS exhaustif (O(576^k_max)). **OUI**.\n",
+    "2. Generateur != verificateur : `certifier_impossibilite` (O(1)) != BFS exhaustif (O(V + E) sur la boule visitée, ici O(576 + 3 456) par palier). **OUI**.\n",
     "3. Temoin certifie : verdict IMPOSSIBLE porte certificat analytique (d_row, d_col, k_max). **OUI**.\n",
-    "4. Cas sans solution = temoin d'impossibilite, pas silence : section 4 verifie par BFS tronque. Section 5 : plus de la moitie des paires a k_max=5 sont IMPOSSIBLE. **OUI**.\n",
+    "4. Cas sans solution = temoin d'impossibilite, pas silence : section 4 verifie par BFS tronque. Section 6 : plus de la moitie des paires a k_max=5 sont IMPOSSIBLE. **OUI**.\n",
     "\n",
     "**Structure du notebook** :\n",
     "- Sections 1-2 : preuve analytique de la structure produit (borne inf + borne sup) ;\n",
     "- Section 3 : 3 cas fondateurs A/B/C ;\n",
-    "- Section 4 : 3 exemples guides integres a la narration (4.1, 4.2, 4.3) ;\n",
-    "- Sections 5-7 : verification operationnelle, inventaire, frontiere et bornes ;\n",
+    "- Section 4 : verification operationnelle par BFS tronque ;\n",
+    "- Section 5 : 3 exemples guides integres a la narration (5.1, 5.2, 5.3) ;\n",
+    "- Sections 6-7 : inventaire, frontiere et bornes ;\n",
     "- Section 8 : 3 exercices non corriges (A, B, C) avec stubs `TODO etudiant`.\n",
     "\n",
     "**Substrats independants portant les 4 points** :\n",
@@ -839,6 +1118,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.609875,
+   "end_time": "2026-09-02T13:23:36.794320+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb",
+   "output_path": "GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T13:23:33.184445+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f91e5398",
+   "id": "81681540",
    "metadata": {},
    "source": [
     "# GameTheory 24b : Le temoin d'impossibilite\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8af66af",
+   "id": "3d03454d",
    "metadata": {},
    "source": [
     "## 0. Configuration"
@@ -26,10 +26,10 @@
    "id": "1c0dec02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:09.407419Z",
-     "iopub.status.busy": "2026-09-02T12:13:09.406872Z",
-     "iopub.status.idle": "2026-09-02T12:13:09.427243Z",
-     "shell.execute_reply": "2026-09-02T12:13:09.425865Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.151267Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.150794Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.168860Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.167535Z"
     }
    },
    "outputs": [
@@ -93,12 +93,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19206b70",
+   "id": "2f6dbd8c",
    "metadata": {},
    "source": [
     "## 1. La structure produit\n",
     "\n",
-    "Le graphe des chambres est un **produit cartesien** de deux copies du permutaedre `S_4`. Les generateurs ne touchent qu'un seul cote a la fois, donc la distance dans le produit est exactement la somme des distances dans chaque facteur."
+    "Le graphe des chambres est un **produit cartesien** de deux copies du permutaedre `S_4` : chaque chambre `(row, col)` est une paire d'ordres stricts sur 4 cases, et les generateurs ne touchent qu'un **seul cote a la fois** (un swap sur la ligne laisse la colonne intacte, et reciproquement).\n",
+    "\n",
+    "**Theoreme cle** : pour tous `G = (row_G, col_G)` et `H = (row_H, col_H)` dans `chambres`, la distance dans le produit est exactement la somme des distances dans chaque facteur : `d_chambre(G, H) = d_perm(row_G, row_H) + d_perm(col_G, col_H)`.\n",
+    "\n",
+    "**Demonstration par double inegalite** :\n",
+    "\n",
+    "- **Borne inferieure (par projection)** : tout chemin de `G` a `H` dans le graphe produit se projette sur un chemin dans chaque facteur (la projection d'un swap sur un cote est un swap dans le permutaedre correspondant, et l'inverse). La projection est surjective et preserve la longueur, donc `d_chambre(G, H) >= d_perm(row_G, row_H) + d_perm(col_G, col_H)`.\n",
+    "\n",
+    "- **Borne superieure (par concatenation)** : reciproquement, un chemin optimal dans le facteur ligne (longueur `d_perm(row_G, row_H)`) et un chemin optimal dans le facteur colonne (longueur `d_perm(col_G, col_H)`) peuvent etre concatenes cote par cote pour produire un chemin de longueur `d_perm(row_G, row_H) + d_perm(col_G, col_H)` dans le produit (l'independance des cotes permet l'entrelacement arbitraire). Donc `d_chambre(G, H) <= d_perm(row_G, row_H) + d_perm(col_G, col_H)`.\n",
+    "\n",
+    "- **Conclusion** : l'egalite stricte est prouvee pour **toute** paire `(G, H)`. Le produit cartesien preserve exactement la distance metrique — c'est la structure produit du graphe."
    ]
   },
   {
@@ -107,10 +117,10 @@
    "id": "a124e9f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:09.431312Z",
-     "iopub.status.busy": "2026-09-02T12:13:09.430715Z",
-     "iopub.status.idle": "2026-09-02T12:13:09.452129Z",
-     "shell.execute_reply": "2026-09-02T12:13:09.450259Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.172258Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.171797Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.187653Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.186463Z"
     }
    },
    "outputs": [
@@ -149,17 +159,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e196d81",
+   "id": "b1d28dfa",
    "metadata": {},
    "source": [
     "## 2. Le certificat analytique\n",
     "\n",
-    "Pour `(G, H, k_max)` :\n",
+    "Pour un triplet `(G, H, k_max)`, on definit le verdict par comparaison :\n",
     "\n",
-    "- **`IMPOSSIBLE`** : `d_row + d_col > k_max`\n",
-    "- **`POSSIBLE`** : `d_row + d_col <= k_max`\n",
+    "- **`IMPOSSIBLE`** si `d_row + d_col > k_max` (la distance minimale theorique depasse la borne, donc aucun chemin de longueur `<= k_max` n'existe) ;\n",
+    "- **`POSSIBLE`** si `d_row + d_col <= k_max` (un chemin de cette longueur existe, par concatenation des chemins optimaux dans chaque facteur).\n",
     "\n",
-    "Verification de la table 24x24 (symetrique, triangulaire) :"
+    "Le verdict `IMPOSSIBLE` porte un **certificat analytique** : les valeurs `(d_row, d_col, k_max)` qui le justifient. Le verdict `POSSIBLE` porte la meme garantie d'existence, mais ne fournit pas le chemin explicite — celui-ci est produit par le constructeur de GT-24 (point 1 du critere #12205 §5).\n",
+    "\n",
+    "**Verification de la table 24x24** : le tableau `D` des distances dans le permutaedre doit etre symetrique et triangulaire pour que le certificat soit coherent."
    ]
   },
   {
@@ -168,10 +180,10 @@
    "id": "d94e881d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:09.456247Z",
-     "iopub.status.busy": "2026-09-02T12:13:09.455661Z",
-     "iopub.status.idle": "2026-09-02T12:13:09.477471Z",
-     "shell.execute_reply": "2026-09-02T12:13:09.472994Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.191657Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.191170Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.210051Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.208364Z"
     }
    },
    "outputs": [
@@ -201,14 +213,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69962315",
+   "id": "ae493cbc",
    "metadata": {},
    "source": [
     "## 3. Le temoin en action\n",
     "\n",
-    "- **Cas A** : antipode `IDENTITE -> RENVERS`, k_max=5 -> IMPOSSIBLE\n",
-    "- **Cas B** : row identique, col antipode, k_max=3 -> IMPOSSIBLE\n",
-    "- **Cas C** : frontiere POSSIBLE, k_max=1 -> POSSIBLE"
+    "Trois cas fondateurs illustrent les regimes du certificat :\n",
+    "\n",
+    "- **Cas A** : antipode `IDENTITE -> RENVERS`, `k_max=5` -> verdict `IMPOSSIBLE` (distance 12 > 5) ;\n",
+    "- **Cas B** : `IDENTITE` vers une chambre a `d_row=0, d_col=4`, `k_max=3` -> verdict `IMPOSSIBLE` (distance 4 > 3) ;\n",
+    "- **Cas C** : frontiere `d_row=0, d_col=1`, `k_max=1` -> verdict `POSSIBLE` (distance 1 <= 1).\n",
+    "\n",
+    "L'exemple ci-dessous montre comment le verdict est obtenu a partir de la table `D`. Le retour est un dictionnaire `{'verdict', 'd_row', 'd_col', 'd_min', 'k_max', 'preuve'}` ou `preuve` est la chaine qui materialise l'inegalite."
    ]
   },
   {
@@ -217,10 +233,10 @@
    "id": "dc0c6cfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:09.484217Z",
-     "iopub.status.busy": "2026-09-02T12:13:09.483638Z",
-     "iopub.status.idle": "2026-09-02T12:13:09.494335Z",
-     "shell.execute_reply": "2026-09-02T12:13:09.492840Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.213851Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.213388Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.223473Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.221912Z"
     }
    },
    "outputs": [
@@ -264,12 +280,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c60a7859",
+   "id": "db95dd2c",
    "metadata": {},
    "source": [
     "## 4. Verification BFS tronque\n",
     "\n",
-    "Pour chaque cas IMPOSSIBLE, on verifie par BFS tronque que `H` n'est **jamais** dans les sommets a distance `<= k_max` de `G`."
+    "Pour chaque cas IMPOSSIBLE, on verifie par BFS tronque que `H` n'est **jamais** dans les sommets a distance `<= k_max` de `G`. Le BFS tronque collecte tous les sommats atteignables en au plus `k_max` pas, sans reconstruire le graphe entier — c'est un outil de verification operationnelle, distinct du certificat analytique et utile comme contre-controle."
    ]
   },
   {
@@ -278,10 +294,10 @@
    "id": "d1fa2c6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:09.499462Z",
-     "iopub.status.busy": "2026-09-02T12:13:09.498863Z",
-     "iopub.status.idle": "2026-09-02T12:13:09.512595Z",
-     "shell.execute_reply": "2026-09-02T12:13:09.511576Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.227078Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.226640Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.237307Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.235657Z"
     }
    },
    "outputs": [
@@ -337,24 +353,191 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ad810d5",
+   "id": "dc999b6a",
    "metadata": {},
    "source": [
-    "## 5. Inventaire -- combien de triplets sont IMPOSSIBLE ?\n",
+    "## 5. Exemples guides -- le temoin en action\n",
     "\n",
-    "Echantillon de 100 chambres representatives, balayage des `k_max ∈ {0..11}`."
+    "Trois exemples guident pas-a-pas l'utilisation du temoin sur des structures differentes des Cas A/B/C (section 3). Chaque exemple combine verification analytique (via la table `D`) et verification operationnelle (via BFS tronque) pour montrer que les deux voies sont d'accord."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f85012b",
+   "metadata": {},
+   "source": [
+    "### 4.1 Exemple guide -- Un autre cas IMPOSSIBLE\n",
+    "\n",
+    "**Demarche** : on choisit une chambre `H` dont la structure est *differente* de l'antipode du Cas A — par exemple, `H` a la **ligne antipode** mais la **colonne identique** a `G`. Alors `d_perm(row_G, row_H) = 6` (antipode du permutaedre) et `d_perm(col_G, col_H) = 0` (meme colonne), donc `d_min = 6 + 0 = 6`. Pour `k_max = 3`, le verdict est `IMPOSSIBLE` puisque `6 > 3`.\n",
+    "\n",
+    "**Verification operationnelle** par BFS tronque : on enumere tous les sommets atteignables en `k_max = 3` pas depuis `G`. Si `H` n'y figure pas, le verdict analytique est confirme operationnellement — c'est un **contre-controle** independant du certificat.\n",
+    "\n",
+    "L'exemple ci-dessous execute cette verification et imprime les deux verifications (analytique + operationnelle) ; elles doivent etre d'accord."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "c4c2adf1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:50:18.241284Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.240885Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.248066Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.247328Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Certificat analytique : IMPOSSIBLE - d_perm(row) + d_perm(col) = 6 + 0 = 6 > 3\n",
+      "BFS tronque : 68 sommets a <= 3 pas\n",
+      "H present dans le voisinage ? False (attendu : False)\n",
+      "Verifications d'accord : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Exemple guide 4.1 : un autre cas IMPOSSIBLE (row antipode, col identique) ===\n",
+    "G_exemple = IDENTITE\n",
+    "H_exemple = ((4, 3, 2, 1), (1, 2, 3, 4))  # row antipode, col identique\n",
+    "k_max_exemple = 3                          # 6 > 3 -> IMPOSSIBLE\n",
+    "\n",
+    "# Verification analytique (via la table D)\n",
+    "cert_exemple = certifier_impossibilite(G_exemple, H_exemple, k_max_exemple)\n",
+    "print(\"Certificat analytique :\", cert_exemple['verdict'], \"-\", cert_exemple['preuve'])\n",
+    "\n",
+    "# Verification operationnelle (BFS tronque, independante de la table)\n",
+    "atteints_exemple = bfs_tronque(G_exemple, lambda g: adj_chambre(g), k_max_exemple)\n",
+    "h_present = H_exemple in atteints_exemple\n",
+    "print(f\"BFS tronque : {len(atteints_exemple)} sommets a <= {k_max_exemple} pas\")\n",
+    "print(f\"H present dans le voisinage ? {h_present} (attendu : False)\")\n",
+    "print(f\"Verifications d'accord : {cert_exemple['verdict'] == 'IMPOSSIBLE' and not h_present}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbb8dbda",
+   "metadata": {},
+   "source": [
+    "### 4.2 Exemple guide -- Distance d'un antipode\n",
+    "\n",
+    "**Demarche** : la distance entre deux sommets `G` et `H` est le plus petit `k` tel que `H` appartient aux sommets a distance `<= k` de `G`. Pour l'antipode `(IDENTITE, RENVERS)`, le certificat analytique donne `d_min = 6 + 6 = 12` — c'est le diametre du graphe produit. Le plus petit `k_max` qui rend `POSSIBLE` est donc `k_max = 12` (a `k_max < 12`, IMPOSSIBLE est certain ; a `k_max >= 12`, POSSIBLE est garanti par concatenation des deux chemins optimaux).\n",
+    "\n",
+    "L'exemple ci-dessous balaie les `k` de 0 a 12 et identifie le seuil de bascule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "032cae33",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:50:18.251804Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.251469Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.257471Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.256288Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bascule IMPOSSIBLE -> POSSIBLE a k=12 (d_min = 12)\n",
+      "Seuil exact : 12, distance de l'antipode = 12\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Exemple guide 4.2 : distance de l'antipode (IDENTITE, RENVERS) ===\n",
+    "seuil = None\n",
+    "for k in range(0, 13):\n",
+    "    c = certifier_impossibilite(IDENTITE, RENVERS, k)\n",
+    "    if c['verdict'] == 'POSSIBLE':\n",
+    "        seuil = k\n",
+    "        print(f\"Bascule IMPOSSIBLE -> POSSIBLE a k={k} (d_min = {c['d_min']})\")\n",
+    "        break\n",
+    "print(f\"Seuil exact : {seuil}, distance de l'antipode = {c['d_min']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49a2f235",
+   "metadata": {},
+   "source": [
+    "### 4.3 Exemple guide -- Paires `d_row=0, d_col=6`\n",
+    "\n",
+    "**Demarche** : `d_row = 0` signifie que la ligne de `G` est identique a la ligne de `H` ; `d_col = 6` signifie que la colonne de `G` est l'antipode de la colonne de `H`. Ce sont donc les paires ou seul le cote colonne doit etre parcoure dans toute sa longueur.\n",
+    "\n",
+    "Pour les trouver : on balaie toutes les chambres et on garde celles ou la ligne est inchangee et la colonne est antipode (par convention, l'antipode est `(4, 3, 2, 1)` a droite comme a gauche). Le balayage donne plusieurs solutions ; l'exemple en garde 3 et imprime leur verdict aux seuils `k_max=5` (IMPOSSIBLE) et `k_max=6` (frontiere, POSSIBLE)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "18fe66a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T12:50:18.260687Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.260295Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.267501Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.266323Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paire 1 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n",
+      "Paire 2 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n",
+      "Paire 3 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Exemple guide 4.3 : trois paires d_row=0, d_col=6 ===\n",
+    "candidates_43 = []\n",
+    "for G in chambres:\n",
+    "    for H in chambres:\n",
+    "        if G == H:\n",
+    "            continue\n",
+    "        if D[(G[0], H[0])] == 0 and D[(G[1], H[1])] == 6:\n",
+    "            candidates_43.append((G, H))\n",
+    "            if len(candidates_43) >= 3:\n",
+    "                break\n",
+    "    if len(candidates_43) >= 3:\n",
+    "        break\n",
+    "\n",
+    "for i, (G, H) in enumerate(candidates_43, 1):\n",
+    "    c5 = certifier_impossibilite(G, H, 5)\n",
+    "    c6 = certifier_impossibilite(G, H, 6)\n",
+    "    print(f\"Paire {i} : k_max=5 -> {c5['verdict']}, k_max=6 -> {c6['verdict']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd8ade85",
+   "metadata": {},
+   "source": [
+    "## 6. Inventaire -- combien de triplets sont IMPOSSIBLE ?\n",
+    "\n",
+    "Echantillon aleatoire de 100 chambres representatives (seed=42 pour la reproductibilite), balayage des `k_max ∈ {0..11}`. La proportion d'IMPOSSIBLE croıt avec `k_max` (plus la borne est petite, plus il est facile de prouver l'impossibilite), puis sature vers 100 % au-dela du diametre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "id": "f0f69adf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:09.517333Z",
-     "iopub.status.busy": "2026-09-02T12:13:09.516790Z",
-     "iopub.status.idle": "2026-09-02T12:13:10.517800Z",
-     "shell.execute_reply": "2026-09-02T12:13:10.515043Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.270535Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.270097Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.824294Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.822869Z"
     }
    },
    "outputs": [
@@ -415,26 +598,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50eac580",
+   "id": "9721729c",
    "metadata": {},
    "source": [
-    "## 6. Frontiere et bornes\n",
+    "## 7. Frontiere et bornes\n",
     "\n",
-    "**Certifie** : pour `k_max < 12`, IMPOSSIBLE est certain.\n",
+    "**Certifie** : pour `k_max < 12`, IMPOSSIBLE est certain des que `d_min > k_max`.\n",
     "\n",
-    "**Non certifie** : un cas POSSIBLE garantit l'existence, pas un chemin explicite (le constructeur de GT-24 produit le chemin). Au-dela de `k_max = 12`, tout est POSSIBLE."
+    "**Non certifie** : un cas POSSIBLE garantit l'**existence** d'un chemin, pas un chemin explicite. La construction explicite est deléguée au constructeur de GT-24 (point 1 du critere #12205 §5) qui produit le chemin par concatenation des chemins optimaux dans chaque facteur.\n",
+    "\n",
+    "**Au-dela de `k_max = 12`** (le diametre du produit), tout est POSSIBLE par definition : le chemin existe toujours en au plus 12 pas."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "78422445",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:10.522411Z",
-     "iopub.status.busy": "2026-09-02T12:13:10.521849Z",
-     "iopub.status.idle": "2026-09-02T12:13:10.532992Z",
-     "shell.execute_reply": "2026-09-02T12:13:10.531570Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.828241Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.827752Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.836452Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.834984Z"
     }
    },
    "outputs": [
@@ -481,160 +666,134 @@
   },
   {
    "cell_type": "markdown",
-   "id": "877d7f4b",
+   "id": "a9d2074b",
    "metadata": {},
    "source": [
-    "## Exercices"
+    "## 8. Exercices"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5f8e35c6",
+   "id": "2076c249",
    "metadata": {},
    "source": [
-    "### Exercice 1 -- Un autre cas IMPOSSIBLE\n",
+    "### Exercice A -- Un cas IMPOSSIBLE non antipode\n",
     "\n",
-    "Choisir un autre couple `(G, H)` et un `k_max` tels que le temoin certifie IMPOSSIBLE. Verifier par BFS tronque."
+    "Trouver un couple `(G, H)` et un `k_max` tels que le verdict est `IMPOSSIBLE`, avec une **structure differente** de l'antipode : ni les deux cotes antipodes (Cas A), ni un seul cote antipode (Cas B / exemple 3.1). Par exemple : les deux cotes a des distances intermediaires (3 et 4, par exemple) pour un `k_max = 5`. Verifier par BFS tronque."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "65e46361",
+   "execution_count": 11,
+   "id": "1885a64e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:10.537477Z",
-     "iopub.status.busy": "2026-09-02T12:13:10.536891Z",
-     "iopub.status.idle": "2026-09-02T12:13:10.545620Z",
-     "shell.execute_reply": "2026-09-02T12:13:10.544035Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.840662Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.840133Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.846350Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.844726Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Certificat Exercice 1 : {'verdict': 'IMPOSSIBLE', 'd_row': 6, 'd_col': 0, 'd_min': 6, 'k_max': 3, 'preuve': 'd_perm(row) + d_perm(col) = 6 + 0 = 6 > 3'}\n",
-      "BFS tronque : H dans sommets a <= 3 pas ? False\n",
-      "Verifie : True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Exercice 1 : choisir un cas IMPOSSIBLE et verifier\n",
-    "G_exo1 = ((1, 2, 3, 4), (1, 2, 3, 4))  # Identite\n",
-    "H_exo1 = ((4, 3, 2, 1), (1, 2, 3, 4))  # row antipode, col identique -> d_min = 6\n",
-    "k_max_exo1 = 3                           # IMPOSSIBLE : 6 > 3\n",
-    "cert = certifier_impossibilite(G_exo1, H_exo1, k_max_exo1)\n",
-    "print(\"Certificat Exercice 1 :\", cert)\n",
-    "atteints = bfs_tronque(G_exo1, lambda g: adj_chambre(g), k_max_exo1)\n",
-    "verif = H_exo1 not in atteints\n",
-    "print(f\"BFS tronque : H dans sommets a <= {k_max_exo1} pas ? {H_exo1 in atteints}\")\n",
-    "print(f\"Verifie : {verif}\")\n",
-    "# resultat = None  # pour exercice etudiant\n"
+    "# Exercice A : cas IMPOSSIBLE non antipode\n",
+    "# A l'etudiant : choisir G, H, k_max de sorte que d_row + d_col > k_max\n",
+    "# avec une structure differente des Cas A/B/3.1.\n",
+    "G_A = None  # TODO etudiant\n",
+    "H_A = None  # TODO etudiant\n",
+    "k_max_A = None  # TODO etudiant\n",
+    "resultat_A = None  # TODO etudiant\n",
+    "\n",
+    "# Verification par l'etudiant :\n",
+    "# 1. cert = certifier_impossibilite(G_A, H_A, k_max_A)\n",
+    "# 2. atteints = bfs_tronque(G_A, lambda g: adj_chambre(g), k_max_A)\n",
+    "# 3. assert cert['verdict'] == 'IMPOSSIBLE' and H_A not in atteints\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6c28a3f4",
+   "id": "fd439ec5",
    "metadata": {},
    "source": [
-    "### Exercice 2 -- Trouver le plus petit k_max POSSIBLE pour un antipode\n",
+    "### Exercice B -- Structure produit pour un G arbitraire\n",
     "\n",
-    "Pour `(IDENTITE, RENVERSEMENT)`, trouver le plus petit `k_max` tel que `certifier_impossibilite` rend POSSIBLE."
+    "Verifier que la structure produit reste valide pour un `G` de depart qui n'est **pas** `IDENTITE` — par exemple `G = ((2, 1, 4, 3), (3, 4, 1, 2))`. La structure produit est-elle toujours `d_chambre(G, H) = d_perm(row_G, row_H) + d_perm(col_G, col_H)`, ou faut-il la reformuler ?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "b2ffb18d",
+   "execution_count": 12,
+   "id": "544788c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:10.549700Z",
-     "iopub.status.busy": "2026-09-02T12:13:10.549151Z",
-     "iopub.status.idle": "2026-09-02T12:13:10.562912Z",
-     "shell.execute_reply": "2026-09-02T12:13:10.560132Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.850201Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.849642Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.856211Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.854823Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Plus petit k_max rendant POSSIBLE : 12 (distance = 12)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Exercice 2 : trouver la distance de l'antipode\n",
-    "G = IDENTITE\n",
-    "H = RENVERS\n",
-    "resultat = None  # TODO etudiant\n",
-    "for k in range(0, 13):\n",
-    "    c = certifier_impossibilite(G, H, k)\n",
-    "    if c['verdict'] == 'POSSIBLE':\n",
-    "        resultat = k\n",
-    "        print(f\"Plus petit k_max rendant POSSIBLE : {k} (distance = {c['d_min']})\")\n",
-    "        break\n"
+    "# Exercice B : verifier la structure produit pour un G != IDENTITE\n",
+    "G_B = ((2, 1, 4, 3), (3, 4, 1, 2))  # un G arbitraire (non IDENTITE)\n",
+    "\n",
+    "# A l'etudiant :\n",
+    "# 1. Calculer dist_chambre_G = bfs(G_B, lambda g: adj_chambre(g))\n",
+    "# 2. Pour chaque H in chambres, comparer dist_chambre_G[H] a\n",
+    "#    D[(G_B[0], H[0])] + D[(G_B[1], H[1])]\n",
+    "# 3. Conclure : la structure produit tient-elle ? Pourquoi ?\n",
+    "ecarts_B = None  # TODO etudiant\n",
+    "resultat_B = None  # TODO etudiant\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1fb2b184",
+   "id": "9e960407",
    "metadata": {},
    "source": [
-    "### Exercice 3 -- Trois paires d_row=0 et d_col=6\n",
+    "### Exercice C -- Densite d'IMPOSSIBLE a k_max=7 par echantillonnage stratifie\n",
     "\n",
-    "Trouver 3 paires distinctes avec `d_row=0` (row identique) et `d_col=6` (antipode colonne)."
+    "La section 5 a montre une densite a `k_max=5` sur 100 chambres aleatoires. Estimer la densite a `k_max=7` en utilisant un echantillon **stratifie** : tirer 25 chambres dans chaque quartile du permutaedre (par distance a `IDENTITE`), puis compter la proportion d'IMPOSSIBLE. Comparer au chiffre donne par la section 5 (qui utilise un echantillon aleatoire non stratifie)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "7ecfe61e",
+   "execution_count": 13,
+   "id": "e4ccfd20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T12:13:10.567254Z",
-     "iopub.status.busy": "2026-09-02T12:13:10.566720Z",
-     "iopub.status.idle": "2026-09-02T12:13:10.576129Z",
-     "shell.execute_reply": "2026-09-02T12:13:10.574728Z"
+     "iopub.execute_input": "2026-09-02T12:50:18.859675Z",
+     "iopub.status.busy": "2026-09-02T12:50:18.859174Z",
+     "iopub.status.idle": "2026-09-02T12:50:18.866747Z",
+     "shell.execute_reply": "2026-09-02T12:50:18.865504Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Paire 1 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n",
-      "Paire 2 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n",
-      "Paire 3 : k_max=5 -> IMPOSSIBLE, k_max=6 -> POSSIBLE\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Exercice 3 : trois paires d_row=0 et d_col=6\n",
-    "candidates = []\n",
-    "for G in chambres:\n",
-    "    for H in chambres:\n",
-    "        if G == H:\n",
-    "            continue\n",
-    "        if D[(G[0], H[0])] == 0 and D[(G[1], H[1])] == 6:\n",
-    "            candidates.append((G, H))\n",
-    "            if len(candidates) >= 3:\n",
-    "                break\n",
-    "    if len(candidates) >= 3:\n",
-    "        break\n",
+    "# Exercice C : densite IMPOSSIBLE a k_max=7 par echantillonnage stratifie\n",
+    "import random\n",
+    "random.seed(2025)  # graine differente de la section 5 (seed=42)\n",
     "\n",
-    "resultat = None  # pour exercice etudiant\n",
-    "for i, (G, H) in enumerate(candidates, 1):\n",
-    "    c5 = certifier_impossibilite(G, H, 5)\n",
-    "    c6 = certifier_impossibilite(G, H, 6)\n",
-    "    print(f\"Paire {i} : k_max=5 -> {c5['verdict']}, k_max=6 -> {c6['verdict']}\")\n"
+    "# Stratification par distance a IDENTITE dans le permutaedre\n",
+    "def dist_id(t):\n",
+    "    return D[(IDENTITE[0], t)]\n",
+    "\n",
+    "stricts_par_dist = {d: [t for t in stricts if dist_id(t) == d] for d in range(7)}\n",
+    "echantillon_stratifie = []\n",
+    "for d in range(7):\n",
+    "    echantillon_stratifie.extend(random.sample(stricts_par_dist[d],\n",
+    "                                              min(4, len(stricts_par_dist[d]))))\n",
+    "\n",
+    "# A l'etudiant :\n",
+    "# 1. Pour chaque G dans echantillon_stratifie, pour chaque H dans chambres,\n",
+    "#    compter les IMPOSSIBLE a k_max=7 (en evitant G == H)\n",
+    "# 2. Comparer au chiffre aleatoire de la section 5\n",
+    "resultat_C = None  # TODO etudiant\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f3b4f6df",
+   "id": "1538c555",
    "metadata": {},
    "source": [
     "## Conclusion -- le point 4 sur Robinson-Goforth est tenu\n",
@@ -645,6 +804,13 @@
     "2. Generateur != verificateur : `certifier_impossibilite` (O(1)) != BFS exhaustif (O(576^k_max)). **OUI**.\n",
     "3. Temoin certifie : verdict IMPOSSIBLE porte certificat analytique (d_row, d_col, k_max). **OUI**.\n",
     "4. Cas sans solution = temoin d'impossibilite, pas silence : section 4 verifie par BFS tronque. Section 5 : plus de la moitie des paires a k_max=5 sont IMPOSSIBLE. **OUI**.\n",
+    "\n",
+    "**Structure du notebook** :\n",
+    "- Sections 1-2 : preuve analytique de la structure produit (borne inf + borne sup) ;\n",
+    "- Section 3 : 3 cas fondateurs A/B/C ;\n",
+    "- Section 4 : 3 exemples guides integres a la narration (4.1, 4.2, 4.3) ;\n",
+    "- Sections 5-7 : verification operationnelle, inventaire, frontiere et bornes ;\n",
+    "- Section 8 : 3 exercices non corriges (A, B, C) avec stubs `TODO etudiant`.\n",
     "\n",
     "**Substrats independants portant les 4 points** :\n",
     "- Life/Conway (PR #14205, #12395)\n",


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #14309 (self-repair)

## Résumé

Notebook neuf : **GT-24b, témoin d'impossibilité certifié** — point 4 du critère d'acceptance de #12205 (Loi II) sur Robinson-Goforth.

La PR a connu **quatre rondes** : la création, deux réparations pédagogiques (commentaire user 12:19:49Z, puis revue po-2025 du 13:05Z qui a corrigé une **preuve fausse** introduite par la première), puis deux rondes markdown-only sur contradictions prose↔sortie relevées par DM po-2025.

## Ronde 1 — `6b190bffb0`

1. Densification de la prose preuve-produit (§1) : double inégalité + conclusion d'égalité stricte.
2. Conversion des 3 cellules « exercices livrés corrigés » en **3 exemples guidés intégrés à la narration** (§5.1–5.3), vérification analytique **et** opérationnelle croisée.
3. Ajout de **3 vrais exercices non résolus** (§8 Ex A/B/C), stubs `resultat = None  # TODO etudiant` — jamais `raise NotImplementedError` (C.1).

## Ronde 2 — la borne inférieure était fausse (intégrée à `f126213b36` par amend)

La revue po-2025 (DM `msg-20260902T130551-4wmpdj`) a relevé quatre points. **Les quatre tiennent**, vérifiés firsthand avant action ; le premier est une erreur de démonstration, pas une imprécision de rédaction.

**1. La borne inférieure par projection ne démontre pas l'additivité.** La ronde 1 écrivait : *« en projetant le chemin sur chaque facteur, on obtient `d_perm(row_G, row_H) ≤ L` et `d_perm(col_G, col_H) ≤ L` »*. C'est vrai, et **insuffisant** : la projection du chemin **entier** ne préserve pas la longueur — les pas côté colonne projettent sur du surplace. Ces deux inégalités bornent `L` par le **maximum** des deux distances, jamais par leur **somme**, qui est précisément ce que le théorème affirme.

La démonstration est remplacée par un **comptage des pas de chaque côté** : chaque générateur ne touche qu'un seul facteur, donc les `L` pas d'un chemin se répartissent en `n_row + n_col = L` ; ne garder que les pas côté ligne donne un chemin `row_G → row_H` de longueur `n_row`, d'où `n_row ≥ d_perm(row_G, row_H)`, symétriquement pour la colonne, et la somme donne la borne. **La raison de l'échec de la projection est écrite dans le notebook**, pas seulement corrigée en silence : c'est le piège naturel sur un produit cartésien, et un lecteur qui refait la preuve seul y tombera.

**2. Renvois de section morts.** La ronde 1 avait renuméroté les sections sans que les renvois suivent : `### 4.1/4.2/4.3`, « exemple 3.1 », « Section 5.1 : inventaire », « Exemple guidé 4.x » ne désignaient plus rien. Réalignés sur les titres réels (§4 BFS tronqué, §5 exemples guidés, §6–7 inventaire et frontière), **y compris dans les commentaires de code** de la cellule d'inventaire et de la cellule de résumé.

**3. Énoncé de l'exercice C incohérent avec son scaffold.** Il demandait un échantillonnage « 25 paires par quartile » que le squelette ne réalise pas (il stratifie en 7 strates de 4 paires). L'énoncé est réaligné sur ce que le code fait ; le scaffold n'a pas été changé pour suivre l'énoncé, l'inverse.

**4. Liste « Structure du notebook » de la conclusion.** Elle décrivait un plan qui n'existe plus. Réécrite depuis les titres effectifs.

## Ronde 3 — `f126213b36` : trois contradictions prose↔sortie (DM po-2025 exact-head)

Deux DM HIGH (`msg-20260902T133749-ksibyl`, `msg-20260902T134237-pbwtah`) sur le diff du head `d323316ab1`. Trois points, **tous vérifiés firsthand contre les sorties committées** :

1. **§6 disait « la proportion d'IMPOSSIBLE croît avec `k_max` »** alors que le tableau exécuté décroît de 100,0 % à 0,2 %. Corrigé, avec une table des valeurs réelles ancrée sur la sortie de la cellule d'inventaire.
2. **Exercice A rangeait le Cas B (`d_col = 4`) dans la famille « un seul côté antipode »** — l'antipode est à distance 6 ; seul l'exemple 5.1 est mono-côté antipode. Reformulé en **trois familles disjointes** (Cas A antipode intégral · Cas B mono-côté non antipode · exemple 5.1 mono-côté antipode), l'exercice excluant les trois.
3. **Conclusion qualifiait le BFS d'exponentiel `O(576^k_max)`** — faux sur graphe fini : `bfs_tronque` est `O(V + E)` sur la boule visitée (≤ 576 sommets, 3 456 arcs).

**Note d'historique** : la ronde 3 a été **amendée** dans `f126213b36` avec la ronde 2 (le SHA intermédiaire `d323316ab1` n'est plus un ancêtre de la branche ; son contenu est intégralement contenu dans `f126213b36`).

## Ronde 4 — `6e93de2a34` : résidus trouvés en relecture du diff avant ack

Relecture du diff de la ronde 3 contre les sorties committées, avant d'acquitter les DM :

1. La même phrase §6 gardait « **sature vers 100 % au-delà du diamètre** » — contredit par la sortie (k=11 → 0,2 %) et par la direction corrigée : au-delà du diamètre (`k_max ≥ 12`, `d_min` max = 6+6), tout couple est POSSIBLE, la proportion **s'annule**.
2. La revendication de provenance « cellule byte-identique au commit `6b190bffb0` » était **fausse** : son commentaire d'en-tête a été renuméroté (`5.1` → `6.1`). Corrigée en citant l'exception exacte — les sorties, elles, sont vérifiées stables depuis `6b190bffb0`.
3. Deux reformulations : « ni l'un ni l'autre » (trois familles exclues) → « n'appartient à aucune de ces trois familles » ; « la sortie certifiée le plus tôt » → « exhibé en cellule 8 ».

**Rondes 3-4 : markdown-only, prouvé** — invariance de `(execution_count, len(outputs), source)` de chaque cellule de code, et sérialisation vérifiée byte-identique au blob `f126213b36` **avant** édition (le diff de la ronde 4 est exactement +6/−4).

## Validation (H.1 / C.1 / C.2)

La ronde 2 a modifié le **source** de cellules de code (les commentaires d'en-tête renumérotés), donc une **re-exécution complète était due** — pas une retouche de sorties. Le DM le demandait explicitement, et c'est la règle (secrets-hygiene §6 : on corrige la cause et on ré-exécute, on ne hand-édite jamais une sortie).

- `papermill <nb> <nb> --kernel python3 --cwd .` : **30/30 cellules**, 3,6 s, `exception: null`.
- **13 cellules de code**, `execution_count` non nul sur les 13, **0 sortie `output_type: error`**.
- **10/13 portent des sorties** ; les 3 sans sortie sont les stubs d'exercice §8 A/B/C (`resultat = None  # TODO etudiant`) — par design, l'étudiant complète.
- `validate_pr_notebooks.py` : **1/1 passed**, 13 cellules.
- C.1 : **0** `raise NotImplementedError` / `assert False` / `1/0`.
- Sorties après re-exécution, inchangées par rapport à la ronde 1 : structure produit **576/576 chambres, 0 écart** · table 24×24 **0 asymétrie**, **0 violation sur 13824 triplets** · CAS A IMPOSSIBLE (12 > 5), CAS B IMPOSSIBLE (4 > 3), CAS C POSSIBLE (1 ≤ 1), les trois confirmés par BFS tronqué · **59,3 %** des paires IMPOSSIBLE à `k_max = 5`.

Le fait que ces valeurs soient **identiques** à celles de la ronde 1 est ce qui prouve que la ronde 2 n'a touché que de la prose et des commentaires : une renumérotation qui aurait déplacé une cellule de substance les aurait fait bouger.

**Les rondes 3-4 sont markdown-only** (exception C.2) : aucune cellule de code n'a bougé, l'exécution committée reste la preuve.

## Périmètre

- **1 fichier**, ajouté : `MyIA.AI.Notebooks/GameTheory/GameTheory-24b-Chemin-Minimal-Temoins-Impossibilite.ipynb` — **+1139/−0** contre `origin/main`, 30 cellules (13 code, 17 markdown).
- Aucun autre fichier ; catalogue byte-identique à `main`.
- Les cellules de code de **substance** (structure produit, certificat analytique, 3 cas fondateurs, BFS tronqué) sont byte-identiques à `3d7eb690a9`. Les cellules d'inventaire et de résumé ont vu leur **commentaire d'en-tête** renuméroté (`Section 5.1` → `6.1`, `6.1` → `7.1`) : leur code est inchangé, seul le libellé suit la nouvelle numérotation.

## Ce que cette PR ne fait pas

- Elle ne clôt pas #12205 : seul le **point 4** du critère est livré.
- **Univers complet 5625** : dette hors grain.
- **Frontière coût SAT** (#12205 §6 grain3) : non couverte ici.

## Référence croisée

- Issue #12205 — EPIC Loi II (§5 critère, §6 grain1 nommé par ai-01 c.861)
- Issue #12364 — GT-24 chemin minimal · Issue #13628 — Tweety-5d synthèse certifiée
- Commentaire user 12:19:49Z — [#14309 (comment)](https://github.com/jsboige/CoursIA/pull/14309#issuecomment-5509420800)
- DM po-2025 : `msg-20260902T123603-jtbtza` (ronde 1) · `msg-20260902T130551-4wmpdj` (ronde 2) · `msg-20260902T133749-ksibyl` + `msg-20260902T134237-pbwtah` (ronde 3)

See #12205
