### PR TITLE
fix(notebook-tools,#14297): ratchet — appariement cellule par id nbformat, 0 FP sur enrichissement

### DIFF
--- a/scripts/notebook_tools/check_source_output_ratchet.py
+++ b/scripts/notebook_tools/check_source_output_ratchet.py
@@ -49,11 +49,13 @@ An optional notebook qualifier disambiguates multi-notebook PRs:
 
 A bare ``[12]`` matches any notebook of the PR.
 
-Index pairing caveat: cells are paired by position over the full cell
-list. An insertion shifts later indices; a shifted code cell then
-compares against a different base cell, which can fabricate a
-source-changed/outputs-identical pair. Rare, visible in the diff, and
-liftable through the body door - a re-execution also dissolves it.
+Cell pairing: code cells pair by their nbformat ``id`` when the base
+notebook carries ids, so inserted cells (fresh ids, unpaired) or shifted
+cells (stable ids, paired to their real base partner) no longer
+fabricate source-changed/outputs-identical pairs on enrichment PRs
+(#14297). Legacy notebooks whose base carries no id pair by position
+over the full cell list, as before - an insertion there still shifts
+later indices, and the body door lifts any residual pair.
 
 Usage:
     python check_source_output_ratchet.py <base-ref> [--json] [--body-file F]
@@ -198,11 +200,26 @@ def classify_cells(base_nb, head_nb):
     """
     base_cells = base_nb.get("cells", [])
     head_cells = head_nb.get("cells", [])
+    # nbformat 4.5+ stamps every cell with a stable `id`: pair by id so an
+    # insertion shifts indices but never the pairing itself (#14297 - the
+    # positional pairing fabricated 3/3 STALE_OUTPUT on enrichment PRs).
+    # Legacy notebooks whose base carries no id keep the positional
+    # pairing, and a head cell with a fresh id (inserted) has no partner.
+    base_by_id = {c.get("id"): c for c in base_cells if c.get("id")}
+    use_ids = bool(base_by_id)
     records = []
     for i, hcell in enumerate(head_cells):
         if hcell.get("cell_type") != "code":
             continue
-        bcell = base_cells[i] if i < len(base_cells) else None
+        bcell = None
+        if use_ids:
+            hid = hcell.get("id")
+            if hid and hid in base_by_id:
+                bcell = base_by_id[hid]
+            elif not hid:
+                bcell = base_cells[i] if i < len(base_cells) else None
+        else:
+            bcell = base_cells[i] if i < len(base_cells) else None
         if bcell is None or bcell.get("cell_type") != "code":
             records.append({"index": i, "verdict": "UNPAIRED",
                             "regression": False})

--- a/scripts/tests/test_check_source_output_ratchet.py
+++ b/scripts/tests/test_check_source_output_ratchet.py
@@ -215,6 +215,45 @@ class TestClassifyCells(unittest.TestCase):
         self.assertEqual([r["verdict"] for r in recs], ["UNPAIRED"])
         self.assertFalse(any(r["regression"] for r in recs))
 
+    def test_insertion_with_ids_does_not_fabricate_stale_pair(self):
+        # #14297: positional pairing fabricated 3/3 STALE_OUTPUT on
+        # enrichment PRs. Two base code cells share byte-identical
+        # outputs (conforming C.1 stubs); a PR inserts an untested stub
+        # between them. With ids, the inserted cell has a fresh id
+        # (UNPAIRED) and the shifted originals pair to their true base
+        # partner (UNCHANGED) - never a fabricated stale pair.
+        base = nb([dict(code("print(1)", OUT_BASE), id="c1"),
+                   dict(code("print(2)", OUT_BASE), id="c2")])
+        head = nb([dict(code("print(1)", OUT_BASE), id="c1"),
+                   dict(code("pass", OUT_BASE), id="c3"),
+                   dict(code("print(2)", OUT_BASE), id="c2")])
+        recs = CSR.classify_cells(base, head)
+        self.assertEqual([r["verdict"] for r in recs],
+                         ["UNCHANGED", "UNPAIRED", "UNCHANGED"])
+        self.assertFalse(any(r["regression"] for r in recs))
+
+    def test_shifted_cells_pair_by_id_after_conforming_insertion(self):
+        # The same insertion with a copied base stub in the middle: the
+        # stub is NEW (fresh id) -> UNPAIRED, the originals keep their id
+        # identity -> UNCHANGED despite the index shift.
+        base = nb([dict(code("print(1)", OUT_BASE), id="c1")])
+        head = nb([dict(code("print(1)", OUT_BASE), id="c1"),
+                   dict(code("print(1)", OUT_BASE), id="c2"),
+                   md("indice")])
+        recs = CSR.classify_cells(base, head)
+        self.assertEqual([r["verdict"] for r in recs],
+                         ["UNCHANGED", "UNPAIRED"])
+        self.assertFalse(any(r["regression"] for r in recs))
+
+    def test_id_pairing_still_flags_real_stale_output(self):
+        # Pairing by id must NOT mask a genuine stale output: same id,
+        # changed source, byte-identical outputs -> STALE_OUTPUT.
+        base = nb([dict(code("print(1)", OUT_BASE), id="c1")])
+        head = nb([dict(code("print(2)", OUT_BASE), id="c1")])
+        recs = CSR.classify_cells(base, head)
+        self.assertEqual(recs[0]["verdict"], "STALE_OUTPUT")
+        self.assertTrue(recs[0]["regression"])
+
 
 class TestNotebookExemptions(unittest.TestCase):
     """validate_pr_notebooks' predicates, reused not duplicated."""


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #14316

## Summary

Fix de #14297 : `check_source_output_ratchet.py` (classify_cells) apparie les cellules code base/head **par index positionnel brut**. Une PR qui insère des cellules décale tout ce qui suit ; l'organe compare alors `head[i]` à `base[i]` — deux cellules sans rapport — et rend `STALE_OUTPUT` chaque fois que leurs sorties sont byte-identiques. Ce n'est pas rare : les stubs conformes C.1 impriment tous `print("Exercice a completer")` → 3/3 faux positifs sur les PR d'enrichissement `*-density` (cellules déplacées, pas modifiées).

## Geste

- **Appariement par id nbformat** : les cellules portent un `id` stable (nbformat 4.5+) ; on construit `base_by_id` et on apparie par id quand la base en porte. Une cellule insérée (id frais) → `UNPAIRED` (clean), une cellule décalée conserve son identité → `UNCHANGED`/`EXECUTED` correct.
- **Fallback positionnel conservé** pour les notebooks legacy sans id sur la base (comportement historique inchangé).
- Docstring du module mise à jour (le caveat « Index pairing caveat » décrivait exactement ce défaut).

## Tests

- 3 tests de régression ajoutés dans `scripts/tests/test_check_source_output_ratchet.py` :
  1. insertion entre deux cellules à sorties identiques → pas de STALE_OUTPUT fabriqué (before : 1, after : 0)
  2. stub inséré (id frais) → `UNPAIRED`
  3. même id, source changée, sorties identiques → `STALE_OUTPUT` **toujours** détecté (le fix ne masque pas la vraie règle C.2)
- **22/22 tests** passent (`test_check_source_output_ratchet.py`), 15/15 `test_check_papermill_ratchet.py` inchangés.
- Smoke test CLI sur la branche AIRL : `check_source_output_ratchet.py origin/main` → `stale cells: 0` (charge réelle, noté dans le commit de cette PR — indépendant, 1 notebook re-exécuté).

## Test plan

- [x] Cause nommée (#14297 : appariement positionnel brut, ligne de `classify_cells`)
- [x] 3 tests de régression reproduisant le FP 3/3 → 0
- [x] 22/22 tests suite ratchet, 15/15 papermill adjacent
- [x] Catelogue byte-identique, 2 fichiers touchés (organe + tests)
- [x] Même-id stale output toujours détecté (anti-régression de la règle C.2)

See #14297