### PR TITLE
fix(tooling,#14314): ENV_RE tire sur les formes table/backtick + interprets

### DIFF
--- a/scripts/notebook_tools/check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/check_prose_quantitative_claims.py
@@ -50,8 +50,9 @@ ne se recalculent pas a l'execution) :
                     (« 140 lignes », « 224 notebooks »). Derive a chaque commit.
   - ``machine``    (#9434) : duree absolue machine-dependante (« 24-127 ms »,
                     « ~530 ms », « 1.9 s »). Derive avec la charge machine.
-  - ``env``        (#9434) : version de librairie/ecosystem figee en prose
-                    (« NumPy 2.4.2 », « Mathlib v4.31.0-rc1 »). Derive quand
+  - ``env``        (#9434) : version de librairie / ecosystem / interprete
+                    figee en prose (« NumPy 2.4.2 », « Python 3.13.3 », ligne
+                    de tableau « | numpy | 2.2.6 | »). Derive quand
                     l'environnement monte de version -- doit etre tenu par le
                     fichier d'environnement (toolchain, requirements), pas la prose.
   - ``stochastic`` (#9434) : valeur a flotant non reproductible (« fitness 41.71 »)
@@ -160,20 +161,32 @@ MACHINE_RE = re.compile(
 )
 
 # ----------------------------------------------------------------------------
-# Classe « env » (#9434) -- versions de librairie/ecosystem figees en prose
+# Classe « env » (#9434) -- versions de librairie / ecosystem / interprete
 # ----------------------------------------------------------------------------
 # Formes attrapees : « NumPy 2.4.2 », « JAX 0.4 », « Mathlib v4.31.0-rc1 »,
 # « PyTorch 2.1.0 ». Une version en prose derive quand l'env monte ; elle doit
 # etre portee par le fichier d'environnement (lean-toolchain, requirements,
-# .csproj), pas par la prose. Liste curee des libs presentes dans le depot.
+# .csproj), pas par la prose. Liste curee des libs presentes dans le depot,
+# interprete « Python » compris : sa version est une mesure env au meme titre.
+#
+# Note fix (#14314) : le separateur nom/version ne se limite plus a l'espace
+# simple. Le critere 2 de #9434 (tableaux de regression env) presente la forme
+# « | numpy | 2.2.6 | » : nom et version separes par « | », spans code
+# « `numpy` `2.2.6` » compris (le nom ET la version peuvent etre trenchés).
+# Le separateur tolere tout melange espace/pipeline/backtick -- c'est la forme
+# reelle d'une ligne de tableau markdown. Un FP residuel (ligne de statistiques
+# « | numpy | 2.2.6 | 0.1 | » voisine) est advisory, l'arbitrage est humain.
+# Garde anti-FP (le mot le plus courant de la liste) : « X.Y (fois|×) » est un
+# multiplicateur, pas une version citee -- « Python 2.5 fois plus rapide » ne
+# doit pas matcher comme version d'interpreteur.
 ENV_LIBS = (
     r"NumPy|Pandas|PyTorch|TensorFlow|Keras|scikit-learn|sklearn|SciPy|"
     r"Transformers|LangChain|spaCy|OpenCV|cv2|Matplotlib|Seaborn|NetworkX|"
     r"SymPy|PyMC|ArviZ|Statsmodels|XGBoost|LightGBM|ONNX|vLLM|fastembed|"
-    r"jpype|Tweety|OpenSpiel|SemanticKernel|Mathlib|JAX|PyPhi|pyphi"
+    r"jpype|Tweety|OpenSpiel|SemanticKernel|Mathlib|JAX|PyPhi|pyphi|Python"
 )
 ENV_RE = re.compile(
-    r"\b(?:" + ENV_LIBS + r")\s+v?\d+(?:\.\d+){1,3}\b",
+    r"\b(?:" + ENV_LIBS + r")[|`\s]+v?\d+(?:\.\d+){1,3}(?!\s*(?:fois\b|×))\b",
     re.IGNORECASE,
 )
 

--- a/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
@@ -227,6 +227,54 @@ def test_env_re_spares_library_without_version():
     assert cqc.ENV_RE.search("NumPy 2") is None
 
 
+def test_env_re_flags_table_and_backtick_forms():
+    """Le critere 2 de #9434 presente les versions de lib en tableau markdown
+    (« | numpy | 2.2.6 | Tirages gaussiens | ») : nom et version separes par
+    « | », non par un espace simple. ENV_RE etait aveugle a cette forme (#14314)
+    -- le guard rendait [OK] avant ET apres le drainage du critere 2. Les spans
+    code (`` ` ``) autour du nom et/ou de la version sont tires aussi."""
+    for snippet in ["| numpy | 2.2.6 |",
+                    "| numpy | 2.2.6 | Tirages gaussiens |",
+                    "| Mathlib | v4.31.0-rc1 |",
+                    "`numpy` 2.2.6",
+                    "`numpy` `2.2.6`",
+                    "NumPy `2.4.2`",
+                    "`numpy` | `2.2.6` |"]:
+        assert cqc.ENV_RE.search(snippet) is not None, (
+            f"devrait flagger la version en forme table/spans {snippet!r}"
+        )
+    m = cqc.ENV_RE.search("| numpy | 2.2.6 | Tirages gaussiens |")
+    assert m.group(0) == "numpy | 2.2.6"
+
+
+def test_env_re_flags_interpreter_version():
+    """L'interpreteur Python porte une version au meme titre qu'une lib :
+    « Python 3.13.3 » en prose est une mesure env figee (#14314). Meme seuil
+    que les libs : le couple majeure.mineure est requis, « Python 3 » seul
+    (adjectif/prefixe) suffit pas."""
+    for snippet in ["Python 3.13.3", "environnement Python 3.13",
+                    "python 3.12.2", "| Python | 3.13.3 |"]:
+        assert cqc.ENV_RE.search(snippet) is not None, (
+            f"devrait flagger la version d'interpreteur {snippet!r}"
+        )
+    for snippet in ["Python 3", "Nous codons en Python depuis 2019",
+                    "Python est un langage interprete"]:
+        assert cqc.ENV_RE.search(snippet) is None, (
+            f"ne doit PAS flagger {snippet!r} (pas de version citee)"
+        )
+
+
+def test_env_re_spares_multiplier_reading():
+    """Garde anti-FP du mot le plus courant de la liste : « X.Y fois/× » est un
+    multiplicateur, pas une version d'interpreteur citee. Une version reelle
+    reste capturee sur la meme ligne."""
+    for snippet in ["Python 2.5 fois plus rapide", "Python 2.5× plus rapide"]:
+        assert cqc.ENV_RE.search(snippet) is None, (
+            f"ne doit PAS lire « fois » comme une version {snippet!r}"
+        )
+    assert cqc.ENV_RE.search("NumPy 2.4.2, Python 3.13.3") is not None
+
+
 # --------------------------------------------------------------------------- #
 #  Classe stochastic : co-occurrence mot-clef + nombre (meme ligne)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: MED/tooling #14319

## Summary

Fix de #14314 : `ENV_RE` (classe env de `check_prose_quantitative_claims.py`) exigeait un **espace simple** entre le nom de lib et sa version — aveugle aux formes du **critere 2 de #9434**, qui presente les versions de lib en **ligne de tableau markdown** (`| numpy | 2.2.6 | Tirages gaussiens |`) et en **spans code** (`` `numpy` `2.2.6` ``). Il ne listait pas non plus l'**interpreteur Python** (sa version est une mesure env au meme titre qu'une lib).

Consequence mesuree dans l'issue : le guard rendait `[OK]` **avant ET apres** le drainage du critere 2 — un controle qui ne tire pas sur ce qu'il est cense garder. Reproduit sur origin/main (avant-fix : `| numpy | 2.2.6 |`, `` `numpy` `2.2.6` `` et `Python 3.13.3` rendent tous `None`).

## Geste

- **Separateur nom/version tolerant** : `\s+` → `[|`\s]+` (espace / pipeline / backtick), la forme reelle d'une ligne de tableau markdown. Les formes adjacentes (`NumPy 2.4.2`), table (`| numpy | 2.2.6 |`) et spans (`` `numpy` `2.2.6` ``, `` NumPy `2.4.2` ``) sont tirees.
- **`Python` ajoute a `ENV_LIBS`** — meme seuil que les libs : le couple majeure.mineure est requis (`Python 3.13.3`, `Python 3.13` tires ; `Python 3` seul suffit pas).
- **Garde anti-FP** (le mot le plus courant de la liste) : `(?!\s*(?:fois\b|×))` — « Python 2.5 fois/× plus rapide » est un multiplicateur, pas une version d'interpreteur citee.
- Docstring du module + du bloc env mis a jour (l'interpreteur et la forme tableau).

## Tests

- 3 tests de regression ajoutes dans `scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py` :
  1. formes table/spans (7 snippets + `numpy | 2.2.6` exact)
  2. version d'interpreteur (tiree vs `Python 3` seul / annee / sans version)
  3. garde multiplicateur (`fois`/`×`)
- **24/24 tests** passent (`test_check_prose_quantitative_claims.py`).
- Smoke `--all --class env` sur origin/main : les formes critere 2 (`PyTorch | 2.6.0`, `Python | 3.12.3`, `` Mathlib `v4.32.0 ``), les versions interpreteur (`Python 3.13.3`, `Python 3.12`) et les versions en clair (`PyTorch 2.6.0`) sont desormais inventoriees ; rc=0 (advisory, classe env audit-only, `--strict` non engage).

## Test plan

- [x] Causalite (#14314 : `\s+` trop strict, `Python` absent de `ENV_LIBS` — ligne de `ENV_RE`)
- [x] 3 tests de regression reproduisant la cecite (avant : `None` sur table/backtick/Python)
- [x] 24/24 tests suite prose-claims
- [x] Garde anti-FP `fois`/`×` (multiplicateur jamais lu comme version)
- [x] Catalogue byte-identique a main, 2 fichiers touches (organe + tests)
- [x] Gate CI inchange : contrat `--diff` (classe artifact par defaut) non affecte — la classe env est audit-only opt-in

## Residuel note (advisory, arbitrage humain)

Sur le depot entier, `--class env` inventorie aussi quelques lectures marginales en mode advisory (ls values de table de scores `XGBoost | 0.571`, et une adresse IP trenchée `vLLM \`192.168.0.47\``) — coherant avec la politique `MACHINE_RE` documentee du meme organe (« un FP residuel est acceptable, l'arbitrage est humain »). La classe env est audit-only ; le CI (`--diff`, defaut artifact) reste intact.

Closes #14314
