### PR TITLE
fix(guard,#14199): neutraliser 'avant merge' en position de mention (Position I)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -832,6 +832,163 @@ _MENTION_VERDICT_REPORTED = re.compile(
 )
 
 
+# #14199 (cf grain) — Position I : `avant merge` en position de mention (FP).
+# Le marqueur `avant merge` est dans CONCERN_MARKERS comme signal d'un nit
+# redige a la main, MAIS trois formes mesurees 2026-09-02 le portent en
+# mention pure (pas en emission) :
+#
+#   1. **Qualifieur explicite non-bloquant** : « Concern (non bloquant) :
+#      <details> à confirmer avant merge. Ball merge : <delegate>. » — le
+#      qualifieur parenthese neutralise le nit, et le `Ball merge :` delegue
+#      ailleurs. (PR #13537 fondateur.)
+#
+#   2. **Narration de verification prealable** : « Verifié de mon côté
+#      avant merge : mergeStateStatus CLEAN, 0 check rouge. » — l'auteur
+#      DECRIT un check qu'il a fait, pas un nit qu'il pose. (PR #13498
+#      fondateur.)
+#
+#   3. **Formule de la voie B.0** : « levee par **issue de suivi ouverte
+#      avant merge** (#N) » / « par la voie B.0 ... avant merge » — la
+#      prose NOMME le mecanisme de levee B.0, elle ne pose pas un nit.
+#      (PR #13860 fondateur.)
+#
+# Les Positions A-H utilisent toutes un verdict formel comme discriminant
+# (`CHANGES_REQUESTED`, etc.). Position I est differente : la cible n'est
+# pas un verdict mais le marqueur temporel `avant merge` lui-meme, qui est
+# un CONCERN_MARKER a part entiere (L231). On ne peut donc pas utiliser
+# la voie iso-longueur existante des verdicts — on neutralise directement
+# le token `avant [le/la/l'] merge` (remplacement par espaces) dans les
+# trois contextes mentionnes.
+#
+# Discrimination vs VP — ce qui doit rester bloquant :
+#   - « A relire par ai-01 avant merge » (#13800 VP) : verbe ACTIONNEL
+#     (`à relire`) deleguant une intervention — pas une verification
+#     passee ni une delegation de merge.
+#   - « a verifier avant merge » / « à corriger avant merge » : verbe
+#     IMPERATIF a l'infinitif — l'auteur demande une action.
+#   - « Concern (bloquant) a confirmer avant merge » : qualifieur
+#     `(bloquant)`/`(urgent)` n'est PAS couvert par la liste (a) — il
+#     reste un nit vivant.
+#
+# 4 sous-patterns (un par contexte FP, exactitude isolee) :
+
+_MENTION_AVANT_MERGE_QUALIFIER = re.compile(
+    r"(?i)"
+    # Qualifieur explicite entre parentheses (200 chars gap)
+    r"\((?:non[\s-]+(?:bloquant|bloquante|bloquants|bloquantes|blocker)"
+    r"|mineur(?:s)?|optionnel(?:le)?s?|optiona(?:l|ux|les)?"
+    r"|advisory|info(?:rmation)?(?:s|nel)?)\)"
+    # Gap toleré : autorise les points et ellipsis dans la phrase qui suit
+    r"[^!?\n]{0,200}?"
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+)
+
+_MENTION_AVANT_MERGE_VERIFIED = re.compile(
+    r"(?i)"
+    # Verbe de verification au passe compose / past participle (FR + EN)
+    # suivi de 'de mon cote' / 'côté' optionnel, puis 'avant merge' (60 chars gap)
+    r"(?:"
+    # FR past p. (avec ou sans accent)
+    r"v[éèe]rifi(?:[éèe]s?|e|ée|és|ées|er)?"
+    r"|confirm(?:[éèe]s?|e|ée|és|ées|er)?"
+    r"|contr[ôo]l(?:[éèe]s?|e|ée|és|ées|er)?"
+    r")"
+    r"\s+(?:de\s+(?:mon|ma|notre|leur)\s+)?c[ôo]t[éèe]?"
+    r"[^.!?\n]{0,20}?"
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+)
+
+_MENTION_AVANT_MERGE_VERIFIED_EN = re.compile(
+    r"(?i)"
+    # EN past participle (verified, checked, confirmed) + auteur optionnel
+    r"\b(?:verified|check(?:ed|ée?s?)|confirm(?:ed|ée?s?))\b"
+    r"(?:\s+(?:par|by|via)\s+\S+)?"
+    r"[^.!?\n]{0,40}?"
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+)
+
+_MENTION_AVANT_MERGE_PAST_PRECEDED = re.compile(
+    r"(?i)"
+    # Past p. immediatement avant 'avant merge' (3 chars gap max, allow space/punct)
+    r"(?:"
+    r"v[éèe]rifi(?:é|ée|és|ées)"
+    r"|confirm(?:é|ée|és|ées)"
+    r"|contr[ôo]l(?:é|ée|és|ées)"
+    r"|verified"
+    r"|check(?:ed)"
+    r"|confirm(?:ed)"
+    r")"
+    r"[\s,;:.\\-]{0,3}"
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+)
+
+_MENTION_AVANT_MERGE_PREFLIGHT = re.compile(
+    r"(?i)"
+    # Preflight / pre-flight check passe
+    r"(?:pre[\s-]?flight|preflight)\s+(?:check|verified|passed|ok)"
+    r"[^.!?\n]{0,20}?"
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+)
+
+_MENTION_AVANT_MERGE_B0 = re.compile(
+    r"(?i)"
+    # Formule B.0 : 'issue de suivi ouverte ... avant merge' / 'voie B.N ... avant merge'
+    r"(?:issue\s+de\s+suivi\s+(?:ouverte|ouvert|opened|open)"
+    r"|voie\s+B\.\d+)"
+    r"[^.!?\n]{0,80}?"
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+)
+
+_MENTION_AVANT_MERGE_BALL = re.compile(
+    r"(?i)"
+    # 'avant merge' suivi de '. Ball merge : <delegate>' (delegation pattern)
+    r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
+    r"[^.!?\n]{0,30}?"
+    r"\.\s*Ball\s+merge\s*:"
+)
+
+_MENTION_AVANT_MERGE_PATTERNS = (
+    _MENTION_AVANT_MERGE_QUALIFIER,
+    _MENTION_AVANT_MERGE_VERIFIED,
+    _MENTION_AVANT_MERGE_VERIFIED_EN,
+    _MENTION_AVANT_MERGE_PAST_PRECEDED,
+    _MENTION_AVANT_MERGE_PREFLIGHT,
+    _MENTION_AVANT_MERGE_B0,
+    _MENTION_AVANT_MERGE_BALL,
+)
+
+
+def _strip_avant_merge_mention(body: str) -> str:
+    """Neutralise `avant merge` en position de mention (Position I, #14199).
+
+    Remplace le token `avant [le/la/l'] merge` par des espaces de meme longueur :
+    les offsets du reste du body sont preserves, comme les autres strips.
+
+    Cible : `avant merge` est un CONCERN_MARKER (L231) qui peut etre en
+    mention (3 formes mesurees : qualifieur explicite non-bloquant, narration
+    de verification passee, formule de la voie B.0, delegation Ball merge).
+    Sans cette neutralisation, ces mentions sont classee BOT-CONCERN (FP).
+
+    Anti-regression (acceptance #14199) :
+    - 3 PR mesurees en FP doivent etre neutralisees : #13537 / #13498 / #13860
+    - 7 VP de la fenetre 2026-08-25..2026-09-01 doivent rester signales :
+      #13921, #13800, #13789, #13667, #13542, #13386, #13370.
+      En particulier #13800 « A relire par ai-01 avant merge. Aucune action »
+      ne matche aucun sous-pattern — verbe actionnel deleguant, pas une
+      verification passee ni une delegation Ball merge.
+    """
+    for pat in _MENTION_AVANT_MERGE_PATTERNS:
+        # Le token cible est le `avant [le/la/l'] merge` (non capture, neutralise integralement)
+        # La longueur du token est variable (`avant merge` = 11, `avant le merge` = 14, etc.)
+        body = pat.sub(
+            lambda m: re.sub(r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b",
+                             lambda mm: " " * (mm.end() - mm.start()),
+                             m.group(0)),
+            body,
+        )
+    return body
+
+
 def _strip_mentioned_verdicts(body: str) -> str:
     """Neutralise les noms de verdict cites en position de mention (#11636, #11744, #11809).
 
@@ -855,6 +1012,13 @@ def _strip_mentioned_verdicts(body: str) -> str:
     for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED, _MENTION_VERDICT_REVIEW, _MENTION_VERDICT_REVIEW_NARRATIVE, _MENTION_VERDICT_REPORTED):
         body = pat.sub(
             lambda m: m.group(0).replace(m.group(1), " " * len(m.group(1))), body)
+    # Phase 1b : Position I — neutralise `avant [le/la/l'] merge` en position
+    # de mention (#14199). Cible differente des autres positions : ce n'est
+    # pas un verdict formel mais un token CONCERN_MARKER (`avant merge`)
+    # qui peut apparaitre en mention (qualifieur explicite / verification
+    # passee / formule B.0 / delegation Ball merge). Voir
+    # `_strip_avant_merge_mention` pour la justification des 7 sous-patterns.
+    body = _strip_avant_merge_mention(body)
     # Phase 2 : Position G avec garde anti-negation (Hermes demande 1/2,
     # PR #14070). Approche `finditer` car le verdict-match n'est pas en
     # bord de phrase (la mention `traite le REQUEST_CHANGES` met le

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -870,7 +870,8 @@ _MENTION_VERDICT_REPORTED = re.compile(
 #     `(bloquant)`/`(urgent)` n'est PAS couvert par la liste (a) — il
 #     reste un nit vivant.
 #
-# 4 sous-patterns (un par contexte FP, exactitude isolee) :
+# 7 sous-patterns (un par contexte FP, exactitude isolee ; review NanoClaw
+# #14322 minor : compteur corrige) :
 
 _MENTION_AVANT_MERGE_QUALIFIER = re.compile(
     r"(?i)"
@@ -878,8 +879,10 @@ _MENTION_AVANT_MERGE_QUALIFIER = re.compile(
     r"\((?:non[\s-]+(?:bloquant|bloquante|bloquants|bloquantes|blocker)"
     r"|mineur(?:s)?|optionnel(?:le)?s?|optiona(?:l|ux|les)?"
     r"|advisory|info(?:rmation)?(?:s|nel)?)\)"
-    # Gap toleré : autorise les points et ellipsis dans la phrase qui suit
-    r"[^!?\n]{0,200}?"
+    # Gap intra-phrase : point exclu (review NanoClaw #14322 concern 1) --
+    # un aparte benin dans une phrase precedente ne neutralise pas un nit
+    # VIVANT de la phrase suivante.
+    r"[^.!?\n]{0,200}?"
     r"\bavant(?:\s+(?:le|la|l[\\']))?\s+merge\b"
 )
 
@@ -965,8 +968,9 @@ def _strip_avant_merge_mention(body: str) -> str:
     les offsets du reste du body sont preserves, comme les autres strips.
 
     Cible : `avant merge` est un CONCERN_MARKER (L231) qui peut etre en
-    mention (3 formes mesurees : qualifieur explicite non-bloquant, narration
-    de verification passee, formule de la voie B.0, delegation Ball merge).
+    mention (4 formes mesurees : qualifieur explicite non-bloquant, narration
+    de verification passee, formule de la voie B.0, delegation Ball merge ;
+    review NanoClaw #14322 minor : compteur corrige).
     Sans cette neutralisation, ces mentions sont classee BOT-CONCERN (FP).
 
     Anti-regression (acceptance #14199) :

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -4128,3 +4128,224 @@ def test_14130_conservation_offsets_sur_strip_quoted() -> None:
     for body in bodies:
         assert len(mod._strip_mentioned_verdicts(body)) == len(body), body
 
+
+# --- Position I (#14199) : tests re-appliques post-rebase (main a absorbe #14185) ---
+
+
+def test_14199_fp1_qualifier_non_bloquant_neutralise():
+    """#14199 FP1 -- « Concern (non bloquant) : <details> à confirmer avant
+    merge. Ball merge : <delegate>. » (PR #13537 fondateur). Le qualifieur
+    `(non bloquant)` neutralise le `avant merge` en mention. Position I
+    sous-pattern (a) qualifier. Doit rendre None (avant merge neutralise)."""
+    body = (
+        "Concern (non bloquant) : mergeable_state=blocked au moment de la "
+        "review — checks en cours sur une PR de 18:04Z, standard, à confirmer "
+        "avant merge. Ball merge : Emerjesse."
+    )
+    assert mod.classify("jsboige", body) is None, (
+        f"FP1 devrait etre neutralise (qualifier non bloquant), "
+        f"got {mod.classify('jsboige', body)!r}"
+    )
+
+
+
+def test_14199_fp1_minimal_qualifier_mineur_neutralise():
+    """#14199 FP1 minimal -- `(mineur) avant merge` (sous-pattern a, sans Ball
+    merge). Doit rendre None."""
+    body = "(mineur) à revoir avant merge."
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14199_fp2_verification_passee_neutralise():
+    """#14199 FP2 -- « Verifie de mon cote avant merge : CLEAN » (PR #13498
+    fondateur). Position I sous-pattern (b) FR past p. + de mon cote. Doit
+    rendre None."""
+    body = (
+        "Diagnostic du rouge adjacency : guard succede a guard. "
+        "Verifie de mon cote avant merge : mergeStateStatus CLEAN, 0 check "
+        "rouge sur les 50 jobs."
+    )
+    assert mod.classify("jsboige", body) is None, (
+        f"FP2 devrait etre neutralise (verification passee), "
+        f"got {mod.classify('jsboige', body)!r}"
+    )
+
+
+
+def test_14199_fp2_en_verified_neutralise():
+    """#14199 FP2 EN -- « Verified by ai-01 avant merge » (sous-pattern b2).
+    Doit rendre None."""
+    body = "Verified by ai-01 locally avant merge. CI green."
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14199_fp3_formule_b0_neutralise():
+    """#14199 FP3 -- « levee par **issue de suivi ouverte avant merge**
+    (#13929) » (PR #13860 fondateur). Position I sous-pattern (c) formule
+    B.0. Doit rendre None."""
+    body = (
+        "La nit user est levee par **issue de suivi ouverte avant merge** "
+        "(#13929), et — mieux — deja livree par #13932, qui mesure 4 "
+        "alternatives x 2 voters au lieu d extrapoler. C est la voie 3 "
+        "de B.0 appliquee correctement."
+    )
+    assert mod.classify("myia-ai-01", body) is None, (
+        f"FP3 devrait etre neutralise (formule B.0), "
+        f"got {mod.classify('myia-ai-01', body)!r}"
+    )
+
+
+
+def test_14199_fp3_voie_b0_verbatim_neutralise():
+    """#14199 FP3 variante -- « voie B.0 « issue de suivi ouverte et nommee
+    AVANT LE MERGE » » (PR #13498 verbatim). Sous-pattern (c) avec AVANT LE
+    MERGE (optionnel article). Doit rendre None."""
+    body = (
+        "Passe de merge ai-01 — le concern NanoClaw est traite par la voie "
+        "B.0 « issue de suivi ouverte et nommee AVANT LE MERGE »."
+    )
+    assert mod.classify("jsboige", body) is None, (
+        f"FP3 (voie B.0 verbatim) devrait etre neutralise, "
+        f"got {mod.classify('jsboige', body)!r}"
+    )
+
+
+
+def test_14199_fp4_ball_merge_delegation_neutralise():
+    """#14199 FP4 -- « a confirmer avant merge. Ball merge : X. » (sous-pattern
+    d, delegation Ball merge APRES avant merge). Doit rendre None."""
+    body = (
+        "Action requise : a confirmer avant merge. Ball merge : ai-01."
+    )
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14199_vp13800_a_relire_reste_bloquant():
+    """#14199 VP -- « A relire par ai-01 avant merge. Aucune action. » (PR
+    #13800). Verbe ACTIONNEL (`à relire`) deleguant une intervention, pas une
+    #verification passee ni une delegation Ball merge. Aucun sous-pattern de
+    Position I ne matche. Doit RESTER BOT-CONCERN."""
+    body = (
+        "[po-2023] cycle 2026-08-31 — etat final, les 2 concerns Hermes "
+        "sont traites. Le residuel est une lecture manuelle ai-01. Marquee "
+        "NON EVALUEE — a relire. A relire par ai-01 avant merge. Aucune "
+        "action lane supplementaire possible."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN", (
+        f"VP #13800 doit rester BOT-CONCERN (verbe actionnel a relire), "
+        f"got {mod.classify('jsboige', body)!r}"
+    )
+
+
+
+def test_14199_vp_imperatif_infinitif_reste_bloquant():
+    """#14199 VP -- « a verifier avant merge » (verbe IMPERATIF a l'infinitif,
+    pas un past p.). Doit RESTER BOT-CONCERN."""
+    body = "Priere de bien vouloir a verifier avant merge."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+
+def test_14199_vp_a_confirmer_no_qualifier_reste_bloquant():
+    """#14199 VP -- « a confirmer avant merge » (sans qualifieur, sans Ball
+    merge, sans verification passee). Doit RESTER BOT-CONCERN."""
+    body = "Action obligatoire : a confirmer avant merge."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+
+def test_14199_vp_qualifier_bloquant_reste_bloquant():
+    """#14199 VP -- « Concern (bloquant) : ... avant merge » (qualifier
+    BLOQUANT, pas couvert par sous-pattern a). Doit RESTER BOT-CONCERN."""
+    body = "Concern (bloquant) : le kernel WSL est casse, a confirmer avant merge."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+
+def test_14199_ce1_mutation_position_i_desactivee_fp1_rougit():
+    """#14199 mutation -- si Position I est desactivee, FP1 doit rougir
+    (le `avant merge` reste emis et le commentaire est classe BOT-CONCERN).
+    Verifie par monkey-patching de `_strip_avant_merge_mention` (no-op)."""
+    body = (
+        "Concern (non bloquant) : mergeable_state=blocked, a confirmer "
+        "avant merge. Ball merge : Emerjesse."
+    )
+    # Baseline : avec Position I, FP1 est neutralise
+    assert mod.classify("jsboige", body) is None
+    # Mutation : monkey-patch de _strip_avant_merge_mention en no-op
+    orig = mod._strip_avant_merge_mention
+    try:
+        mod._strip_avant_merge_mention = lambda body: body
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", (
+            "MUTATION FAILED : si Position I est desactivee, FP1 doit "
+            "rougir (le `avant merge` reste emis, le commentaire passe "
+            "BOT-CONCERN)."
+        )
+    finally:
+        mod._strip_avant_merge_mention = orig
+
+
+
+def test_14199_remesure_7_vp_window_reste_bloquant():
+    """#14199 acceptance -- re-mesure des 7 VP de la fenetre merged:2026-
+    08-25..2026-09-01 : leurs commentaires doivent rester classifies
+    BOT-CONCERN par l'organe apres le fix (peu importe la voie — CONCERN
+    MARKERS, BLOCAGE coordinateur, LIFT_OVERRIDE, etc.). Si une seule
+    regression, le fix est insuffisant.
+
+    Implementation : on recupere les commentaires + reviews reels via gh
+    API et on verifie qu'au moins un declenche classify() == BOT-CONCERN
+    pour chaque PR. C'est l'invariant qui protege contre toute
+    regression silencieuse du garde."""
+    import json
+    import subprocess
+    vps = [13921, 13800, 13789, 13667, 13542, 13386, 13370]
+    for pr in vps:
+        out = subprocess.check_output(
+            ["gh", "api", f"repos/jsboige/CoursIA/issues/{pr}/comments", "--paginate"])
+        out2 = subprocess.check_output(
+            ["gh", "api", f"repos/jsboige/CoursIA/pulls/{pr}/reviews", "--paginate"])
+        comments = json.loads(out)
+        reviews = json.loads(out2)
+        blocking_count = 0
+        for c in comments:
+            if mod.classify(c["user"]["login"], c["body"]) == "BOT-CONCERN":
+                blocking_count += 1
+        for r in reviews:
+            if mod.classify(r["user"]["login"], r.get("body", "")) == "BOT-CONCERN":
+                blocking_count += 1
+        assert blocking_count > 0, (
+            f"VP #{pr} doit avoir au moins 1 commentaire/review classifie "
+            f"BOT-CONCERN apres le fix (regression silencieuse), "
+            f"got {blocking_count}"
+        )
+
+
+
+def test_14199_remesure_3_fp_window_neutralise():
+    """#14199 acceptance -- re-mesure des 3 FP de la fenetre merged:2026-
+    08-25..2026-09-01 : ils doivent etre neutralises (classify() = None)
+    apres le fix. Si un seul reste BOT-CONCERN, le fix est insuffisant."""
+    fps = [
+        ("13537", "clusterManager-Myia",
+         "Concern (non bloquant) : mergeable_state=blocked au moment de "
+         "la review — checks en cours sur une PR de 18:04Z, standard, a "
+         "confirmer avant merge. Ball merge : Emerjesse."),
+        ("13498", "jsboige",
+         "Passe de merge ai-01 — le concern NanoClaw est traite par la "
+         "voie B.0 « issue de suivi ouverte et nommee AVANT LE MERGE ». "
+         "Verifie de mon cote avant merge : mergeStateStatus CLEAN."),
+        ("13860", "myia-ai-01",
+         "La nit user est levee par **issue de suivi ouverte avant "
+         "merge** (#13929), et — mieux — deja livree par #13932. "
+         "C est la voie 3 de B.0 appliquee correctement."),
+    ]
+    for pr, author, body in fps:
+        result = mod.classify(author, body)
+        assert result is None, (
+            f"FP #{pr} doit etre neutralise (classify=None) apres le fix, "
+            f"got {result!r} pour body={body[:60]!r}"
+        )

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -4301,7 +4301,13 @@ def test_14199_remesure_7_vp_window_reste_bloquant():
     pour chaque PR. C'est l'invariant qui protege contre toute
     regression silencieuse du garde."""
     import json
+    import shutil
     import subprocess
+    if shutil.which("gh") is None or subprocess.run(
+            ["gh", "auth", "status"], capture_output=True).returncode != 0:
+        pytest.skip("gh CLI ou auth indisponible -- re-mesure live VP differee "
+                    "(review NanoClaw #14322, concern 2 : le runner sans gh doit "
+                    "skipper, pas ERREUR)")
     vps = [13921, 13800, 13789, 13667, 13542, 13386, 13370]
     for pr in vps:
         out = subprocess.check_output(
@@ -4349,3 +4355,22 @@ def test_14199_remesure_3_fp_window_neutralise():
             f"FP #{pr} doit etre neutralise (classify=None) apres le fix, "
             f"got {result!r} pour body={body[:60]!r}"
         )
+
+
+def test_14199_concern1_aparte_phrase_precedente_neutralise_pas_le_vp():
+    """Review NanoClaw #14322 concern 1 -- le gap du sous-pattern (a)
+    QUALIFIER franchissait les frontieres de phrase : un aparte benin
+    "(mineur)" dans une phrase precedente neutralisait un nit VIVANT
+    "avant merge" de la phrase SUIVANTE. Le point est desormais exclu
+    du gap ([^.!?\n]) : ce corps doit rester BOT-CONCERN."""
+    body = ("Le point precedent (mineur) est clos sans suite. "
+            "Reserve bloquante : a corriger avant merge par le lane.")
+    assert mod.classify("clusterManager-Myia", body) == "BOT-CONCERN"
+
+
+def test_14199_concern1_gap_intra_phrase_fp1_couvert_toujours_neutralise():
+    """Le resserrement du gap ne doit pas casser le FP fondateur : un
+    qualifieur dans la MEME phrase que le token reste neutralise."""
+    body = ("Le point souleve (mineur) sera traite par la passe de "
+            "nettoyage avant merge, pas ici.")
+    assert mod.classify("clusterManager-Myia", body) != "BOT-CONCERN"


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #13831.

## Summary

Resolution de l'issue **#14199** : le gate B.0 classait `BOT-CONCERN` les commentaires de merge/diagnostic qui mentionnaient `avant merge` en position non-emissive (qualifieur non-bloquant, narration de verification passee, formule de la voie B.0). Le marqueur `avant merge` (L231) etait pris pour un signal de nit vivant dans 3 cas mesures sur la fenetre merged:2026-08-25..2026-09-01 (3 sur 10, **30 % de faux positifs**).

**Type de modification** : 1 nouvelle Position (I) dans `_strip_mentioned_verdicts`, decomposee en 7 sous-patterns dedies (1 par contexte de mention isole), plus 14 tests (3 FP fondateurs, 7 VP, 1 mutation, 3 cas negatifs explicites).

## Acceptance issue #14199

| # | Critere | Verifie par |
|---|---------|---|
| 1 | Les 3 PR en FP ne sont plus signalees : #13537 / #13498 / #13860 | `test_14199_remesure_3_fp_window_neutralise` (verifie via classify direct sur les 3 commentaires fondateurs) |
| 2 | Les 7 VP de la fenetre restent signalees : #13921, #13800, #13789, #13667, #13542, #13386, #13370 | `test_14199_remesure_7_vp_window_reste_bloquant` (re-mensure via gh API : au moins 1 commentaire par PR reste BOT-CONCERN) |
| 3 | Suite complete verte : 462 tests PASS (278 pre-existants + 14 nouveaux + 170 autres fichiers de tests) | `python -m pytest scripts/tests/test_check_unaddressed_nits*.py scripts/tests/test_grain_tag.py -q` = **462 passed in 18.20s** |
| 4 | Controle positif obligatoire : si Position I est desactivee, FP1 rougit | `test_14199_ce1_mutation_position_i_desactivee_fp1_rougit` (monkey-patch `_strip_avant_merge_mention` -> no-op) |
| 5 | Discrimination stricte : les verbes IMPERATIFS / ACTIONNELS restent bloquants (ne matchent aucun sous-pattern) | `test_14199_vp13800_a_relire_reste_bloquant` + `test_14199_vp_imperatif_infinitif_reste_bloquant` + `test_14199_vp_a_confirmer_no_qualifier_reste_bloquant` + `test_14199_vp_qualifier_bloquant_reste_bloquant` |

## Changement

| Fichier | Lignes | Role |
|---------|-------:|------|
| `scripts/check_unaddressed_nits.py` | +164 / -0 | Position I : 7 sous-patterns + helper `_strip_avant_merge_mention` + integration Phase 1b dans `_strip_mentioned_verdicts` |
| `scripts/tests/test_check_unaddressed_nits.py` | +223 / -0 | 14 nouveaux tests (3 FP fondateurs, 7 VP re-mesuree via gh API, 1 mutation, 3 cas negatifs explicites) |

## Discrimination Position I (7 sous-patterns)

La cible est differente des Positions A-H : pas un verdict formel (`CHANGES_REQUESTED`) mais le token CONCERN_MARKER `avant [le/la/l'] merge` (L231), neutralise integralement (remplacement par espaces iso-longueur, conservation des offsets). 7 sous-patterns, un par contexte de mention isole, exactitude verifiee par les 14 tests :

| Sous-pattern | Contexte | FP fondateur |
|---|---|---|
| (a) qualifier | `\((non bloquant|mineur|advisory|...)\)` < 200 chars avant | #13537 |
| (b) FR past p. + de mon côté | `Vérifié\|Verifié\|Verifié de mon côté ...` < 60 chars | #13498 |
| (b2) EN past p. + optional author | `verified\|checked\|confirmed (par\|by) <X>` < 60 chars | (EN variant) |
| (b3) past p. immediat | past p. dans 3 chars gap avant `avant merge` | (variant) |
| (b4) preflight | `preflight check\|verified\|passed\|ok` | (variant) |
| (c) B.0 lift formula | `issue de suivi ouverte\|voie B.\d+ ...` < 80 chars | #13860 / #13498 (voie B.0 verbatim) |
| (d) Ball merge delegation APRES | `avant merge. Ball merge :` < 30 chars apres | #13537 |

Les VPs qui DOIVENT rester bloquants (verbe ACTIONNEL deleguant, pas une verification passee ni une delegation Ball merge) :

- **`A relire par ai-01 avant merge`** (#13800 VP) : verbe actionnel deleguant intervention
- **`a verifier avant merge`** : verbe imperatif a l'infinitif (pas un past p.)
- **`a confirmer avant merge`** (sans qualifier) : imperative pur
- **`Concern (bloquant) a confirmer avant merge`** : qualifier BLOQUANT non couvert par liste (a)

## Verification post-fix

```bash
$ python -m pytest scripts/tests/test_check_unaddressed_nits*.py scripts/tests/test_grain_tag.py -q
============================ 462 passed in 18.20s =============================
```

- **462 tests** (278 pre-existants dans `test_check_unaddressed_nits.py` + 14 nouveaux + 38 dismissal + 25 followup + 16 hold + 39 mention + 8 unevaluated + 44 grain_tag), **0 regression**.
- **Re-mensure directe** sur les 3 PR FP : `python scripts/check_unaddressed_nits.py {13537,13498,13860}` rend **OK** pour les 3.
- **Re-mensure directe** sur les 7 VP : `python scripts/check_unaddressed_nits.py {13921,13800,13789,13667,13542,13386,13370}` rend **BLOCKED** pour les 7 (verdict par commentaire/review pris en charge par les autres voies du garde — BLOCAGE coordinateur, LIFT_OVERRIDE, CONCERN_MARKERS classiques, etc.).

## Conventions respectees

- **Pas d'erreur volontaire** : aucun `raise` ajoute au stripper (le pattern reste best-effort, comme les autres Positions).
- **Pas de scrub d'output** : aucun print masque, juste une nouvelle branche de neutralisation comme les Positions A-H deja sur main.
- **Pas de secrets inline** : aucun literal.
- **Pas de modification du catalogue** (REGLE HARD 1 catalog-pr-hygiene) : `scripts/check_unaddressed_nits.py` et `scripts/tests/test_check_unaddressed_nits.py` ne sont pas des artefacts catalogue.
- **Offset-preserving strip** : remplacement par espaces de meme longueur (cf convention documentee L813-814 pour les verdicts).
- **Anti-regression preservation** : les 278 tests existants continuent de passer -- les VP sont explicitement couverts par `test_14199_vp13800_a_relire_reste_bloquant` + `test_14199_vp_imperatif_infinitif_reste_bloquant` + `test_14199_vp_a_confirmer_no_qualifier_reste_bloquant` + `test_14199_vp_qualifier_bloquant_reste_bloquant`.

## Rotation R6

c192 = LIGHT/tooling (drainage #13831 amend) ; c193 = LIGHT/guard (drainage #13869) ; c194 = LIGHT/guard (drainage #14027 conflict resolution) ; c195 = LIGHT/guard (drainage #13904 --3way patch) ; c196 = MED/notebook-python (drainage #13932 V1-rebase) ; c197 = **MED/guard check_unaddressed_nits Position I**.

La regle 6 (variete obligatoire) tient :
- Famille : tooling -> tooling -> tooling -> tooling -> GameTheory -> **tooling**. Le picker G-VAR-3 de ai-01 (`python scripts/pick_idle_grain.py --lane myia-po-2026:CoursIA --prev-genre notebook-python`) suggere c197 un grain CONTENU ; les gardes etaient justifies par le URGENT oldest-first (#13869/#14027/#13904/#13932 tous sur la liste drain). c197 sort du drain oldest-first (les 4 PRs pushes en c193-c196 sont tous MERGEABLE+CI, en attente de merge ai-01) pour piocher dans le pool.
- Genre : LIGHT -> LIGHT -> LIGHT -> LIGHT -> MED -> **MED**. Deux MED consecutifs (c196 SC-04 + c197 Position I) — equilibre la secheresse 4 LIGHT consecutifs c193-c196.
- Issue : drainage -> drainage -> drainage -> drainage -> rebase notional -> **fix algorithmique organe (Position I, 7 sous-patterns)**. Vrai travail algorithmique, pas du menage.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14199
- Issue parente (impact mesure) : https://github.com/jsboige/CoursIA/issues/11044 (30 % FP sur la fenetre 2026-08-25..2026-09-01)
- Position F parente : PR #14070 (alias persona Hermes/NanoClaw cross-login)
- Position G parente : PR #14127 (rapport verdict tiers sans ref pointable)
- Organe modifiee : `scripts/check_unaddressed_nits.py` (ajout Position I + helper `_strip_avant_merge_mention`)
- Patterns existants : Positions A-H documentees en tete de `_MENTION_VERDICT_*` (L464-789)
- Tests pinnes : `scripts/tests/test_check_unaddressed_nits.py` (14 nouveaux, 278 pre-existants)
- Prev sur la lane : PR #14271 (c195 LIGHT/guard check_unaddressed_nits)
