### PR TITLE
feat(notebooks,#13410): GameTheory-13b -- 4 transitions markdown, runs consecutifs 4 a 0

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb
@@ -93,6 +93,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2d707135",
+   "source": "L'environnement est en place : numpy pour le calcul numérique, le RNG avec une graine fixée pour la reproductibilité. La cellule suivante définit le terrain de toute la démonstration -- la classe `KuhnPoker`, volontairement minimale (3 cartes J/Q/K, 2 actions Pass/Bet). Son rôle est d'encoder les conventions dont chaque mesure ultérieure dépend : les 5 histoires terminales (`pp`, `pbp`, `pbb`, `bp`, `bb`), les payoffs en chip net, et la fonction `get_payoff` qui distingue les chemins déterministes (`bp`, `pbp` : le miseur prend l'ante adverse) des showdowns (`pp`, `bb`, `pbb` : signés par la carte haute). Ce format compact n'est pas un choix de commodité : un jeu assez petit s'évalue par énumération EXACTE, sans échantillonnage ni approximation, et chaque convention payoff reste vérifiable contre la table de référence de Zinkevich et al. 2007.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "10dc71dd",
@@ -334,6 +340,12 @@
     "print(f'(strategie mixte sur Q). Les mesures EV ci-dessous utilisent le vrai Nash de')\n",
     "print(f'Zinkevich et al. 2007, Table 1 -- voir nash_strategy dans la cellule suivante.')\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "463162e6",
+   "source": "`cfr_vanilla` a livré le **blueprint** -- l'objet global que Brown-Sandholm raffinent localement -- mais sous une forme volontairement simplifiée : le cœur de la boucle CFR est omis pour la lisibilité (l'implémentation complète est dans GameTheory-13), et la sortie n'est PAS le Nash exact de Kuhn, comme la cellule l'annonce elle-même. C'est exactement pourquoi la cellule suivante construit une chaîne de mesure indépendante du solveur : `ev_P1_at_deal` évalue une paire de stratégies par énumération exacte des 5 chemins terminaux (chaque chemin pondéré par sa probabilité jointe, masse totale égale à 1 par deal), puis `exploitability` mesure la vraie marge adverse en énumérant les 64 stratégies pures de P2. Séparer le solveur du mètre est le geste méthodologique décisif : un solveur qui se note lui-même ne peut pas révéler ses propres artefacts. La cellule pose enfin l'étalon `nash_strategy` -- la famille de Zinkevich et al. 2007 Table 1 à `alpha = 1/3` -- qui servira à la fois de baseline, de stratégie de P2 lors des recollements, et de terrain des trois exercices.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -718,6 +730,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a306b38b",
+   "source": "Le recollement naïf est matérialisé : les clés `p1pb|*` sont forcées à 100% call -- seules J et Q s'écartent réellement du Nash, K callait déjà. La cellule suivante mesure le coût de ce geste en deux temps. D'abord l'EV(P1) par la même énumération exacte des 5 chemins terminaux, P2 restant au Nash : cela quantifie la perte immédiate, avant même qu'un adversaire ne s'adapte. Puis l'exploitabilité par best response sur les 64 stratégies pures P2 : c'est la mesure décisive, car un recollement peut sembler rentable dans le sous-arbre local tout en ouvrant une déviation profitable à P2 dans le jeu global -- le témoin adversarial annoncé par la Section 2. Le cliquet `exp_naive >= -1e-9` vérifie au passage que l'énumération ne régresse pas vers l'artefact négatif documenté par le REPAIR #13480.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "e79fdf5f",
@@ -1011,6 +1029,12 @@
     "print()\n",
     "print('Strategie safe = strategie Nash (degeneree mais certifiee safe).')\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21928c63",
+   "source": "Contrairement au recollement naïf, la stratégie locale construite ici reste SOUS CONTRAINTE : un voisinage du blueprint sur le sous-arbre `pb`, borné par la probabilité d'atteinte (reach). La variante `safe_with_margin` affichée ci-dessus montre ce que cette marge autoriserait -- une déviation clippée par `delta_bound` puis renormalisée -- mais la mesure qui suit porte sur le cas limite `safe_strategy` = Nash exact, safe par construction. Ce qu'on attend de cette mesure : la même énumération des 5 chemins terminaux et le même best response sur les 64 stratégies pures P2 que pour le naïf, mais un verdict opposé -- une exploitabilité qui reste au niveau du baseline au lieu de monter. C'est toute la différence avec la Section 2 : les conditions de bord garantissent que le raffinement local ne crée jamais de marge exploitable pour P2, même si le cas démontré ici est volontairement trivial.",
+   "metadata": {}
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/docs #14098

# GameTheory-13b : résoudre les 4 runs de cellules code consécutives (#12797, contribution #13410)

`See #13410` (contribution partielle : le présent grain traite l'axe « cellules consécutives » du notebook 13b ; l'umbrella encodage/prose reste ouverte).

## Ce que fait la PR

`GameTheory-13b-Safe-Subgame-Solving.ipynb` portait **4 runs de cellules code consécutives** (détection instrument canonique `detect_consecutive_code_cells.py`). Chaque run est résolu par **une cellule markdown de transition** insérée entre les deux cellules code :

| Position d'insertion | Contenu de la transition |
|---|---|
| Entre imports et classe `KuhnPoker` | Rôle de la classe : conventions payoff, 5 histoires terminales, pourquoi un jeu minimal s'évalue par **énumération exacte** |
| Entre `cfr_vanilla` et `ev_P1_at_deal` | Blueprint ≠ Nash exact ; pourquoi la chaîne de mesure (EV/64 BR/étalon alpha=1/3) doit être **indépendante du solveur** |
| Entre recollement naïf et calcul d'EV | La mesure du coût en deux temps (EV immédiate puis exploitabilité BR) ; le cliquet anti-artefact #13480 |
| Entre safe recollement et EV | Contrainte de voisinage bornée par le reach ; verdict attendu **opposé** au naïf |

Prose spécifique au contenu (aucun « Suite du traitement » générique) ; les interprétations de résultats existantes (« Lecture du baseline », etc.) ne sont ni déplacées ni modifiées.

## Validation

- **Détection avant/après** : `detect_consecutive_code_cells.py` → `Run >= 2: 4` (2+2+2+2) → **`Run >= 2: 0`**.
- **Densité** (instrument `pedagogy_density.py`) : 1221 → **1524** chars prose/cellule code (seuil 1200).
- **Markdown-only (exception C.2)** : diff = **24 insertions, 0 suppression, 1 fichier** ; les 12 cellules code gardent `execution_count` 1..12 et leurs outputs intacts — aucune re-exécution requise, aucune cellule code touchée.
- **Claims factuels vérifiés contre le code (G.1)** : « K callait déjà » confirmé par l'output réel (`p1pb|2 : nash=[0. 1.]`) ; cliquet `exp_naive >= -1e-9` présent dans la cellule EV ; énumération des 64 stratégies pures P2, étalon `alpha = 1/3`, variantes `safe_with_margin`/`delta_bound` — tous ancrés dans les cellules code existantes.
- **Accents** : le premier jet du sous-agent était désaccentué (0 char accentué) alors que la prose existante en porte 43 — corrigé avant commit : les 4 nouvelles cellules portent désormais **100 caractères accentués**, convention du fichier respectée (français accentué, §E). Pattern « ajout de cellules neuves = propre » de l'arbitrage #13410 respecté (aucune réécriture de prose existante).
- **Encodage** : UTF-8 littéral sans BOM, `ensure_ascii=False`, indent nbformat préservé — le re-dump ne produit **aucun churn** (diff reste 24 insertions pures).
- Cellules d'exercice (TODO étudiant) intactes ; aucun `raise NotImplementedError` ajouté (C.1).

## Périmètre : 1 fichier

- `MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb` (+24)

Catalogue byte-identique à main (aucune entrée touched). Anti-padding vérifié à la sélection : la cible initiale 08c-Python a été **abandonnée honnêtement** (0 run détecté → enrichir aurait été de la prose redondante, claim libéré) ; 13b portait les gaps réels.

## Preuve d'identité

- Branche `feature/13410-13b-enrich`, base `origin/main` (`21c2a324c4`), 1 commit `190a10c9ac`.
- `[CLAIMED] paths:` posé avant édition ([comment](https://github.com/jsboige/CoursIA/issues/13410#issuecomment-5510511245)).
- Grain CONTENU demandé par ai-01 pour la dette G-VAR-1 de la lane ; il débloque aussi la séquence de merge (#14263 → CONTENU → #14281 dont le rouge G-VAR-3 « guard succède à guard » attend ce grain).