### PR TITLE
fix(check-nits,#14277): Position J — glyphe de sévérité en position de mention (méta-nom / item d'énumération)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -275,9 +275,11 @@ CONCERN_MARKERS = (
 #     1 NON levee = #12059 fondateur, defaut B.0 = merge avec constat sans
 #     reponse, defaut pedagogique en production (hyperparametres GRPO contredits).
 #   🔴 (U+1F534) : bloquant strict, 1/35 (vrai bloquant).
-# `_unaccent` preserve les glyphes (categorie So, pas Mn), `_strip_mentioned_verdicts`
-# ne les neutralise pas (regex _MENTION_VERDICT* ciblent ASCII verdict formel),
-# `_is_cited` reste symetrique via CITERS ascii.
+# `_unaccent` preserve les glyphes (categorie So, pas Mn), `_is_cited` reste
+# symetrique via CITERS ascii. Les positions A-I (regex `_MENTION_VERDICT*`)
+# ciblent l'ASCII formel et ignorent les glyphes ; la Position J
+# (`_strip_glyphe_mentions`, #14277) les neutralise en position de MENTION
+# (méta-nom sur la même ligne), l'émission en tête de ligne restant vive.
 SEVERITY_GLYPHS = (
     "🟡",  # constat substantiel (fondateur #12059)
     "🔴",  # bloquant strict
@@ -993,6 +995,58 @@ def _strip_avant_merge_mention(body: str) -> str:
     return body
 
 
+# #14277 — Position J : glyphe de sévérité en position de MENTION. Les
+# SEVERITY_GLYPHS (🟡/🔴) sont concaténés dans CONCERN_MARKERS mais restent
+# invisibles aux positions A-H (regex `_MENTION_VERDICT*` ciblant l'ASCII
+# formel) : un compte-rendu technique qui NOMME le glyphe qu'il décrit est
+# classé BOT-CONCERN à tort. 3 FP mesurés (sweep 264 corps / 61 PRs,
+# fenêtre 2026-08-23..2026-09-02 ; 0 VP glyph-only sur la même fenêtre) :
+#   FP1 (#13951 c.869, issuecomment-5506801880) : « variante glyphe 🟡. »
+#   FP2 (#13951 c.872, issuecomment-5507737699) : « 2 cas (prose
+#        contradictoire + glyphe 🟡) ajoutes. »
+#   FP3 (#13951 c.871) : « les **glyphes de severite** (🟡 constat
+#        substantiel #12059, 🔴 bloquant) »
+#
+# Discriminateurs LIGNE-PORTÉS (le glyphe est une mention si l'un des deux
+# tient sur sa ligne) :
+#   (A) MÉTA-NOM — un nom nommant le glyphe précède sur la même ligne
+#       (« glyphe 🟡 », « glyphes de severite (🟡 ..., 🔴 ...) », FP1-3).
+#   (B) ITEM D'ÉNUMÉRATION — le glyphe est immédiatement précédé d'un
+#       séparateur `,` ou `+` (modulo espaces) : « (prose, 🟡, 🔴, +
+#       controle positif) », cellule de tableau « **CWC + 🟡** » (formes
+#       résiduelles de FP3, 5503423343).
+# L'émission réelle (mesurée #12059 / #12083 / #12077 — scan 35 reviews
+# Hermes de #12143) est un en-tête de verdict en tête de ligne (« **🟡
+# FINDING — ... », « LGTM structural / 🟡 ... »), jamais un item de liste :
+# ni méta-nom avant, ni séparateur `,`/`+` immédiat — le séparateur `/`
+# (VP #12083) est délibérément EXCLU du set d'énumération. Substitution
+# iso-longueur (1 char -> 1 espace) : les offsets du reste du body sont
+# préservés, comme les autres strips.
+_GLYPH_META_NOUN_RE = re.compile(
+    r"(?i)\b(?:glyphes?|glyphs?|marqueurs?|markers?|badges?|symboles?|emojis?)\b"
+)
+_GLYPH_ENUM_PRECEDER_RE = re.compile(r"[,+]\s+$")
+_SEVERITY_GLYPH_CLASS_RE = re.compile(f"[{''.join(SEVERITY_GLYPHS)}]")
+
+
+def _strip_glyphe_mentions(body: str) -> str:
+    """Neutralise les glyphes de sévérité en position de mention (Position J, #14277).
+
+    Chaque glyphe (🟡/🔴) dont la ligne porte un méta-nom le nommant (A) ou
+    qui est un item d'énumération `,`/`+` (B) est remplacé par une espace :
+    c'est une mention, pas une émission. Le glyphe en tête de ligne
+    (en-tête de verdict Hermes) reste vivant.
+    """
+    out = list(body)
+    for m in _SEVERITY_GLYPH_CLASS_RE.finditer(body):
+        line_start = body.rfind("\n", 0, m.start()) + 1
+        prefix = body[line_start:m.start()]
+        if (_GLYPH_META_NOUN_RE.search(prefix)
+                or _GLYPH_ENUM_PRECEDER_RE.search(prefix)):
+            out[m.start()] = " "
+    return "".join(out)
+
+
 def _strip_mentioned_verdicts(body: str) -> str:
     """Neutralise les noms de verdict cites en position de mention (#11636, #11744, #11809).
 
@@ -1023,6 +1077,12 @@ def _strip_mentioned_verdicts(body: str) -> str:
     # passee / formule B.0 / delegation Ball merge). Voir
     # `_strip_avant_merge_mention` pour la justification des 7 sous-patterns.
     body = _strip_avant_merge_mention(body)
+    # Phase 1j : Position J — neutralise les glyphes de sévérité (🟡/🔴) en
+    # position de mention (#14277). Cible distincte des positions A-H : pas
+    # un verdict ASCII formel mais un glyphe concaténé dans CONCERN_MARKERS,
+    # invisible aux regex de mention. Discriminateur ligne-portée : voir
+    # `_strip_glyphe_mentions`.
+    body = _strip_glyphe_mentions(body)
     # Phase 2 : Position G avec garde anti-negation (Hermes demande 1/2,
     # PR #14070). Approche `finditer` car le verdict-match n'est pas en
     # bord de phrase (la mention `traite le REQUEST_CHANGES` met le

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -4374,3 +4374,128 @@ def test_14199_concern1_gap_intra_phrase_fp1_couvert_toujours_neutralise():
     body = ("Le point souleve (mineur) sera traite par la passe de "
             "nettoyage avant merge, pas ici.")
     assert mod.classify("clusterManager-Myia", body) != "BOT-CONCERN"
+
+
+# ============================================================================
+# #14277 — Position J : glyphe de sévérité en position de mention
+# ============================================================================
+# Fondateurs mesurés (sweep 264 corps / 61 PRs, fenêtre 2026-08-23..2026-09-02,
+# différentiel old-vs-new : exactement 3 diffs = les 3 FP, 261 corps inchangés) :
+#   FP1 #13951 c.869 (issuecomment-5506801880) : « variante glyphe 🟡. »
+#   FP2 #13951 c.872 (issuecomment-5507737699) : « 2 cas (prose
+#        contradictoire + glyphe 🟡) ajoutes. »
+#   FP3 #13951 c.870 (issuecomment-5503423343) : « glyphes de severite (🟡
+#        ..., 🔴 ...) » + formes résiduelles : énumération « (prose, 🟡, 🔴,
+#        + controle) » et cellules tableau « **CWC + 🟡** ».
+# VP d'émission (doivent rester BOT-CONCERN) : #12059 « **🟡 FINDING — »,
+# #12083 « LGTM structural / 🟡 », glyphe en tête de ligne.
+
+# --- Position J (#14277) : tests re-appliques post-rebase (main a absorbe #14322) ---
+
+
+def test_14277_fp1_meta_nom_glyphe_neutralise():
+    body = ("2. **2 tests manquants** que NanoClaw a explicitement demandés —\n"
+            "   - variante glyphe 🟡.\n"
+            "3. **Vérification first-hand (avant commit)** : OK.")
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14277_fp2_meta_nom_parentheses_neutralise():
+    body = ("- Tests : 2 cas (prose contradictoire + glyphe 🟡) ajoutes.\n"
+            "6/6 PASSED en local.")
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14277_fp3_enumeration_double_glyphe_neutralise():
+    body = ("Deux surfaces : la **prose** (commentaire Hermes) et les "
+            "**glyphes de severite** (🟡 constat substantiel #12059, "
+            "🔴 bloquant).")
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14277_fp3bis_enum_items_separateurs_neutralise():
+    # Formes résiduelles de FP3 : glyphe item d'énumération (séparateur `,`)
+    # et cellule de tableau (séparateur `+`), sans méta-nom sur la ligne.
+    body = ("- 4 tests ajoutes (prose, 🟡, 🔴, + controle positif) verbatim.\n"
+            "| 4 | **CWC + 🟡** | OK |")
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14277_contretemoin_sans_marqueurs_reste_none():
+    # Acceptance #14277 : le contre-mesure c.871 (paraphrase SANS aucun
+    # marqueur verbatim) doit rester None (déjà correct avant le fix).
+    body = ("## Cycle c.871 — état post-merge avec main, 2 points de revue "
+            "toujours présents, lane irréductible.\n"
+            "Tête de branche 15e478afe. mergeable: MERGEABLE. 6/6 PASSED.")
+    assert mod.classify("jsboige", body) is None
+
+
+
+def test_14277_vp12059_emission_tete_de_ligne_reste_bloquant():
+    # VP fondateur #12059 : en-tête de verdict, glyphe en tête de ligne,
+    # jamais précédé d'un méta-nom ni d'un séparateur d'énumération.
+    body = ("**[NanoClaw]** structural review.\n"
+            "**LGTM structural + 1 FINDING.**\n"
+            "**🟡 FINDING — les 5 hyperparametres enseignes par la nouvelle "
+            "md#19 contredisent le run mesure (cf tableau).**")
+    assert mod.classify("clusterManager-Myia", body) == "BOT-CONCERN"
+
+
+
+def test_14277_vp12083_lgtm_scoped_slash_reste_bloquant():
+    # VP #12083 : « LGTM structural / 🟡 ... » — le séparateur `/` est
+    # délibérément EXCLU du set d'énumération (B) : ce glyphe est une
+    # émission scopée, pas un item de liste.
+    body = "LGTM structural / 🟡 SPY 6/8 contredit par le walk-forward."
+    assert mod.classify("clusterManager-Myia", body) == "BOT-CONCERN"
+
+
+
+def test_14277_vp_meta_nom_apres_glyphe_reste_bloquant():
+    # Un méta-nom APRÈS le glyphe n'en fait pas une mention : c'est une
+    # émission avec parenthèse explicative.
+    body = "🟡 — constat substantiel (cf glyphe)"
+    assert mod.classify("clusterManager-Myia", body) == "BOT-CONCERN"
+
+
+
+def test_14277_vp_ligne_suivante_sans_meta_nom_reste_bloquant():
+    # Le méta-nom sur la ligne PRÉCÉDENTE ne ouvre pas la mention : la
+    # portée est la ligne, pas le paragraphe.
+    body = "Le glyphe de severite :\n🟡 FINDING — hyperparametres contredits."
+    assert mod.classify("clusterManager-Myia", body) == "BOT-CONCERN"
+
+
+
+def test_14277_ce1_mutation_position_j_desactivee_fp1_rougit():
+    # Contrôle positif : sans Position J, FP1 doit rougir (BOT-CONCERN).
+    saved = mod._strip_glyphe_mentions
+    mod._strip_glyphe_mentions = lambda b: b
+    try:
+        body = ("- variante glyphe 🟡.\nVérification OK.")
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", (
+            "MUTATION FAILED : si Position J est desactivee, FP1 doit "
+            "rougir (le glyphe mentionné doit rester un marqueur vivant)."
+        )
+    finally:
+        mod._strip_glyphe_mentions = saved
+
+
+
+def test_14277_ce2_enum_separateur_rouge_si_b_desactivee():
+    # Contrôle positif règle B : sans le séparateur d'énumération, la forme
+    # résiduelle FP3 (item de liste sans méta-nom) doit rougir.
+    saved = mod._GLYPH_ENUM_PRECEDER_RE
+    mod._GLYPH_ENUM_PRECEDER_RE = __import__("re").compile(r"(?!x)x")
+    try:
+        body = "- 4 tests ajoutes (prose, 🟡, controle positif)."
+        assert mod.classify("jsboige", body) == "BOT-CONCERN", (
+            "MUTATION FAILED : sans la règle B (séparateur énumération), "
+            "la forme item-de-liste doit rougir."
+        )
+    finally:
+        mod._GLYPH_ENUM_PRECEDER_RE = saved


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/guard #14199.

## Summary

Resolution de l'issue **#14277** : les SEVERITY_GLYPHS (🟡/🔴) etaient concatenes dans `CONCERN_MARKERS` **sans aucun discriminateur use-vs-mention** (les positions A-H ciblent l'ASCII formel). Un compte-rendu technique qui NOMME le glyphe qu'il decrit etait classe `BOT-CONCERN` a tort.

**Type de modification** : 1 nouvelle Position (J) dans `_strip_mentioned_verdicts` — `_strip_glyphe_mentions`, 2 discriminateurs ligne-portes, plus 11 tests (4 FP, 1 contre-temoin, 4 VP, 2 controles positifs par mutation).

## Mesure fondatrice (sweep 264 corps / 61 PRs, fenetre 2026-08-23..2026-09-02)

| FP | Commentaire | Forme | Verdict avant | Verdict apres |
|---|---|---|---|---|
| FP1 | #13951 c.869 (`issuecomment-5506801880`) | « variante glyphe 🟡. » | BOT-CONCERN | None |
| FP2 | #13951 c.872 (`issuecomment-5507737699`) | « 2 cas (prose contradictoire + glyphe 🟡) ajoutes. » | BOT-CONCERN | None |
| FP3 | #13951 c.870 (`issuecomment-5503423343`) | « glyphes de severite (🟡 ..., 🔴 bloquant) » + formes residuelles : enumeration « (prose, 🟡, 🔴, + controle) », cellules tableau « **CWC + 🟡** » | BOT-CONCERN | None |

**0 VP glyph-only sur la meme fenetre** : les vraies reserves portent toujours d'autres marqueurs vivants.

## Discrimination Position J (2 regles ligne-portees)

Le glyphe est une MENTION si sa LIGNE porte, AVANT lui :

| Regle | Contexte | FP fondateur |
|---|---|---|
| (A) META-NOM | un nom nommant le glyphe : `glyphe(s)/glyph(s)/marqueur(s)/marker(s)/badge(s)/symbole(s)/emoji(s)` | FP1, FP2, FP3 |
| (B) ITEM D'ENUMERATION | separateur `,` ou `+` immediat (modulo espaces) : listes « (prose, 🟡, 🔴) », cellules « **CWC + 🟡** » | FP3 (formes residuelles) |

L'EMISSION reelle (mesuree #12059 / #12083 / #12077, scan 35 reviews Hermes #12143) est un **en-tete de verdict en tete de ligne** — « **🟡 FINDING — ... » — ni meta-nom avant, ni separateur `,`/`+`. Le separateur `/` (VP #12083 « LGTM structural / 🟡 ») est **deliberement EXCLU** du set d'enumeration.

Substitution iso-longueur (1 char -> 1 espace) : les offsets du reste du body sont preserves, comme les autres strips.

## Mesure anti-regression : differentiel old-vs-new

Code main (`git show origin/main:...`) charge en parallele, chaque corps du corpus classe par les deux versions :

```
--- 264 bodies differentially classified over 61 PRs ---
#13951 comment 5503423343: 'BOT-CONCERN' -> None
#13951 comment 5506801880: 'BOT-CONCERN' -> None
#13951 comment 5507737699: 'BOT-CONCERN' -> None
total diffs: 3
```

**Exactement 3 diffs = les 3 FP visés. 261 corps inchangés.** Aucun effet de bord hors cible.

## Acceptance issue #14277

| # | Critere | Resultat |
|---|---------|----------|
| 1 | Tests verrouillant les 3 corps (paraphrase CONCERN_MARKERS verbatim / sans marqueurs / verdict verbatim) | 11 tests : 4 FP neutralises, 1 contre-temoin None, 4 VP emission BOT-CONCERN (dont #12059 et #12083 verbatim), 2 mutations |
| 2 | Suite complete verte | **293/293 PASS** post-rebase sur main frais (`pytest scripts/tests/test_check_unaddressed_nits.py -q`) ; 289/289 a la creation. Rebase : union append (main a absorbe le rewrite du fichier de tests par #13904, 0 nom de test perdu, verifie `comm`) |
| 3 | `check_unaddressed_nits.py 13951` post-fix | **`OK — aucun nit non leve` (exit 0)**. L'issue prevoit « 1 nit restant (verdict NanoClaw) » : mesure reelle = 0, car ce verdict est deja absorbe comme mention sur main (corpus cite, independent de ce fix). Delta documente — strictement mieux que la prediction, regression nommee par l'issue totalement eliminee |

## Changement

| Fichier | Lignes | Role |
|---------|-------:|------|
| `scripts/check_unaddressed_nits.py` | +66/-3 | Position J : `_GLYPH_META_NOUN_RE` + `_GLYPH_ENUM_PRECEDER_RE` + `_strip_glyphe_mentions` + integration Phase 1j + docstring SEVERITY_GLYPHS mis a jour |
| `scripts/tests/test_check_unaddressed_nits.py` | +113/-0 | 11 nouveaux tests |

## Note scope : #14277 vs PR #13951

L'issue decrit la regression comme introduite par la branche #13951 (`_sole_live_concern_is_comment_prefix`, absent de main). **Verifie firsthand : la regression existe aussi sur main** (les 3 fondateurs classent BOT-CONCERN avec le code main pur — mesure ci-dessus). Ce fix sur main elimine la classe pour toutes les branches, #13951 inclus.

## Rotation R6

c193-195 = LIGHT/guard (drainage oldest-first) ; c196 = MED/notebook-python ; c197 = MED/guard (Position I) ; **c199 = MED/guard (Position J)** — 2 MED consecutifs, meme famille tooling mais organes algorithmiques distincts (Position I = token `avant merge` ; Position J = glyphes). Pool source : `gh issue list --state open` (cross-lane). Pivot c198 : #14297 deja livre par PR #14319 (po-2023, verifie preflight) → #14277 sans PR concurrente (verifie).

Closes #14277.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/14277
- VP emission fondateurs : #12059 (🟡 hyperparametres GRPO), #12083 (🟡 SPY 6/8), #12077 (🟡 claim img_020)
- Positions parentes : A-H (`_MENTION_VERDICT*`), Position I (PR #14322, `avant merge`)
- Corpus differentiel : 60 PRs merged fenetre 2026-08-23..2026-09-02 + PR 13951



## Rebase post-#14322 (2026-09-03, 5b55b37f2)

Ordre 3 de la sérialisation check-nits (msg-20260902T210049) : #14185 ✅ puis #14322 ✅ MERGED (02:40Z) → rebase de Position J sur le main résultant.

- **Conflits** : `check_unaddressed_nits.py` ×2 (additifs purs — Position I de main et Position J de la branche insérées au même point) → **union I+J** : les deux blocs de patterns + les deux phases d'appel (`_strip_avant_merge_mention` puis `_strip_glyphe_mentions`) en séquence.
- **Test file** (hotspot, conflit entier) : **append-union** — base main 297 tests (281 + 14 de #14199 + 2 de la review #14322) + les 11 tests `test_14277_*` de la branche, comm des noms vérifié, 0 test perdu. 308 defs, **328/328 PASS** (8.4 s).
- Garde : le BLOCKED résiduel porte sur les commentaires `[G-VAR-3 OVERRIDE]` d'ai-01 (des **grants** G-VAR-3, pas des réserves) — le parser main cherche `[OVERRIDE]` bracket-exact ; #14345 (fin de file) reconnaît la forme `G-VAR-3`. Même exposition documentée sur #14322 avant son merge.
