### PR TITLE
feat(ci-runner,#14283): lsb-release + zstd + wget dans l'image runner

### DIFF
--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -20,10 +20,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 # python-is-python3 : les workflows stdlib-only appellent `python` nu
 # (check-navlinks, job 100021313259 : exit 127 "python: not found" alors
 # que python3 etait present).
+# lsb-release : actions/setup-python@v5 avec `cache: pip` appelle
+# `lsb_release -i -r -s` pour construire la cle de cache -- sans lui, le job
+# meurt sur "Unable to locate executable file: lsb_release" APRES avoir installe
+# Python (Scripts Tests (CPU), run 33618470607). zstd : actions/cache et
+# upload-artifact l'utilisent, sinon repli gzip (fonctionne, plus lent).
+# Deliberement PAS sudo : les conteneurs tournent en --security-opt=no-new-
+# privileges, il serait inerte et affaiblirait la posture.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip python-is-python3 \
        libicu74 \
+       lsb-release zstd wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Tarball runner epingle par SHA-256 (meme discipline que les profils


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/test #14331

## Le defaut, et pourquoi c'est une classe et non un incident

**3e occurrence du meme motif** : l'image runner est volontairement minimale, et une action GitHub-hosted suppose un outil qu'elle ne porte pas.

| # | Outil absent | Symptome | Fix |
|---|---|---|---|
| 1 | `python` nu | `exit 127 python: not found` | `python-is-python3` |
| 2 | `gh` | organe **muet** : `exit 0` **sans poster** — vert fabrique | #14302 |
| 3 | `lsb_release` | job mort **apres** avoir installe Python | **cette PR** |

La 2e est la plus dangereuse (un vert qui ment) ; la 3e est honnete (elle rougit). Mais les trois ont la meme racine, et **chaque workflow que je migre vers le leg Linux peut en revele une nouvelle**. C'est le cout recurrent du chantier #13378, pas un accident.

## Cause mesuree, pas supposee

`actions/setup-python@v5` avec `cache: pip` appelle `lsb_release -i -r -s` pour construire la cle de cache. Le job **reussit** l'installation de Python, puis meurt :

```
Successfully set up CPython (3.11.16)
##[error]Unable to locate executable file: lsb_release
```

Run `33618470607`, job `Scripts Tests (CPU)` sur #14284 — c'est ce qui tenait cette PR au rouge.

## Controle positif — invocation exacte, avant/apres

```
ancienne image : $ lsb_release -i -r -s
                 lsb_release: command not found      EXIT=127

nouvelle image : $ lsb_release -i -r -s
                 Ubuntu
                 24.04                               EXIT=0
```

## Ce que je n'ajoute pas, et pourquoi

- **`sudo`** — les conteneurs tournent en `--security-opt=no-new-privileges`. Il serait **inerte** *et* affaiblirait la posture. Refus deliberé.
- **`build-essential`** — ~200 MB pour un besoin **non constate** : les dependances de `Scripts Tests` ont toutes des wheels. Je l'ajouterai si un echec reel le demande, pas par anticipation.
- `ssh` / `rsync` / `gpg` — aucun workflow du depot ne les appelle.

`zstd` et `wget` entrent parce qu'ils sont peu couteux et effectivement supposes (`actions/cache`, `upload-artifact`, plusieurs `setup-*`).

## Rappel operationnel — merger ceci ne roule rien

Un runner `--ephemeral` **inactif** ne sort jamais : il tient l'ancienne image **indefiniment**. Apres merge, sur **chaque** daemon : rebuild, puis **recyclage des slots** avec `busy=0` verifie AVANT (ne jamais tuer un job en cours). C'est l'etape que #14302 a failli manquer.

See #14283, #13378
