### PR TITLE
fix(symbolicai,#14200): Lean-1-Setup chemins machine normalises a la source + re-execution

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -5,10 +5,10 @@
    "id": "6ff81c19",
    "metadata": {
     "papermill": {
-     "duration": 0.002743,
-     "end_time": "2026-08-19T07:35:18.480466",
+     "duration": 0.004004,
+     "end_time": "2026-09-02T15:33:52.332169",
      "exception": false,
-     "start_time": "2026-08-19T07:35:18.477723",
+     "start_time": "2026-09-02T15:33:52.328165",
      "status": "completed"
     },
     "tags": []
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : ← (debut) | [Index](Lean-1-Setup.ipynb) | [Lean-2-Dependent-Types →](Lean-2-Dependent-Types.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "\n",
     "Ce notebook configure l'environnement pour la serie de notebooks Lean qui explore le proof assistant **Lean 4** pour la verification formelle de preuves mathematiques.\n",
@@ -53,7 +53,7 @@
     "\n",
     "*(Base sur Lean 4 - syntaxe moderne)*\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Plan de ce Notebook\n",
     "\n",
@@ -65,7 +65,7 @@
     "6. [Configuration VSCode (optionnel)](#vscode)\n",
     "7. [Ressources et documentation](#ressources)\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -73,10 +73,10 @@
    "id": "e6d4bff8",
    "metadata": {
     "papermill": {
-     "duration": 0.002042,
-     "end_time": "2026-08-19T07:35:18.484637",
+     "duration": 0.003001,
+     "end_time": "2026-09-02T15:33:52.340676",
      "exception": false,
-     "start_time": "2026-08-19T07:35:18.482595",
+     "start_time": "2026-09-02T15:33:52.337675",
      "status": "completed"
     },
     "tags": []
@@ -113,7 +113,7 @@
     "- **Integration LLM** (LeanCopilot, AlphaProof)\n",
     "- **Verification formelle** garantie (impossible de prouver du faux)\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -121,10 +121,10 @@
    "id": "7c05c5e5",
    "metadata": {
     "papermill": {
-     "duration": 0.002455,
-     "end_time": "2026-08-19T07:35:18.489164",
+     "duration": 0.004516,
+     "end_time": "2026-09-02T15:33:52.349703",
      "exception": false,
-     "start_time": "2026-08-19T07:35:18.486709",
+     "start_time": "2026-09-02T15:33:52.345187",
      "status": "completed"
     },
     "tags": []
@@ -153,10 +153,10 @@
    "id": "5241b28010e04157",
    "metadata": {
     "papermill": {
-     "duration": 0.002072,
-     "end_time": "2026-08-19T07:35:18.493246",
+     "duration": 0.004,
+     "end_time": "2026-09-02T15:33:52.357703",
      "exception": false,
-     "start_time": "2026-08-19T07:35:18.491174",
+     "start_time": "2026-09-02T15:33:52.353703",
      "status": "completed"
     },
     "tags": []
@@ -185,16 +185,16 @@
    "id": "78848c0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:18.498943Z",
-     "iopub.status.busy": "2026-08-19T07:35:18.498734Z",
-     "iopub.status.idle": "2026-08-19T07:35:19.665654Z",
-     "shell.execute_reply": "2026-08-19T07:35:19.665191Z"
+     "iopub.execute_input": "2026-09-02T15:33:52.367211Z",
+     "iopub.status.busy": "2026-09-02T15:33:52.367211Z",
+     "iopub.status.idle": "2026-09-02T15:33:56.878782Z",
+     "shell.execute_reply": "2026-09-02T15:33:56.878782Z"
     },
     "papermill": {
-     "duration": 1.170766,
-     "end_time": "2026-08-19T07:35:19.666596",
+     "duration": 4.518096,
+     "end_time": "2026-09-02T15:33:56.879799",
      "exception": false,
-     "start_time": "2026-08-19T07:35:18.495830",
+     "start_time": "2026-09-02T15:33:52.361703",
      "status": "completed"
     },
     "tags": []
@@ -208,7 +208,7 @@
       "    DIAGNOSTIC DE L'ENVIRONNEMENT LEAN 4\n",
       "============================================================\n",
       "\n",
-      "Systeme: Windows 11\n",
+      "Systeme: Windows 10\n",
       "Architecture: AMD64\n",
       "\n"
      ]
@@ -220,11 +220,11 @@
       "------------------------------------------------------------\n",
       "Composant              Status       Version/Info\n",
       "------------------------------------------------------------\n",
-      "Python                [OK]         3.13.3\n",
-      "elan                  [OK]         elan 4.2.1 (3d5138e15 2026-03-18)\n",
-      "Lean 4                [OK]         Lean (version 4.32.1, x86_64-w64-windows\n",
+      "Python                [OK]         3.11.9\n",
+      "elan                  [OK]         elan 4.1.2 (58e8d545e 2025-05-26)\n",
+      "Lean 4                [OK]         Lean (version 4.33.1, x86_64-w64-windows\n",
       "lean4_jupyter         [OK]         0.0.2\n",
-      "Kernel Jupyter        [OK]         cleanenv-k\n",
+      "Kernel Jupyter        [OK]         lean4\n",
       "------------------------------------------------------------\n",
       "\n",
       "[OK] Tous les composants sont installes !\n",
@@ -449,16 +449,16 @@
    "id": "32da08bb",
    "metadata": {
     "papermill": {
-     "duration": 0.002342,
-     "end_time": "2026-08-19T07:35:19.671618",
+     "duration": 0.004021,
+     "end_time": "2026-09-02T15:33:56.887831",
      "exception": false,
-     "start_time": "2026-08-19T07:35:19.669276",
+     "start_time": "2026-09-02T15:33:56.883810",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Installation automatique\n",
     "<a id=\"installation\"></a>\n",
@@ -484,16 +484,16 @@
    "id": "39b2473c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:19.677239Z",
-     "iopub.status.busy": "2026-08-19T07:35:19.676890Z",
-     "iopub.status.idle": "2026-08-19T07:35:19.693269Z",
-     "shell.execute_reply": "2026-08-19T07:35:19.692741Z"
+     "iopub.execute_input": "2026-09-02T15:33:56.898372Z",
+     "iopub.status.busy": "2026-09-02T15:33:56.898372Z",
+     "iopub.status.idle": "2026-09-02T15:33:56.921138Z",
+     "shell.execute_reply": "2026-09-02T15:33:56.921138Z"
     },
     "papermill": {
-     "duration": 0.020169,
-     "end_time": "2026-08-19T07:35:19.694014",
+     "duration": 0.029302,
+     "end_time": "2026-09-02T15:33:56.922156",
      "exception": false,
-     "start_time": "2026-08-19T07:35:19.673845",
+     "start_time": "2026-09-02T15:33:56.892854",
      "status": "completed"
     },
     "tags": []
@@ -811,10 +811,10 @@
    "id": "590f0c15",
    "metadata": {
     "papermill": {
-     "duration": 0.002491,
-     "end_time": "2026-08-19T07:35:19.698946",
+     "duration": 0.004063,
+     "end_time": "2026-09-02T15:33:56.930931",
      "exception": false,
-     "start_time": "2026-08-19T07:35:19.696455",
+     "start_time": "2026-09-02T15:33:56.926868",
      "status": "completed"
     },
     "tags": []
@@ -859,7 +859,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d9f8d71e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004506,
+     "end_time": "2026-09-02T15:33:56.940945",
+     "exception": false,
+     "start_time": "2026-09-02T15:33:56.936439",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Aide-mémoire : commande equivalente selon votre plateforme\n",
     "\n",
@@ -878,12 +888,57 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "id": "162f291d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T15:33:56.952151Z",
+     "iopub.status.busy": "2026-09-02T15:33:56.952151Z",
+     "iopub.status.idle": "2026-09-02T15:33:56.970730Z",
+     "shell.execute_reply": "2026-09-02T15:33:56.969883Z"
+    },
+    "papermill": {
+     "duration": 0.025106,
+     "end_time": "2026-09-02T15:33:56.970730",
+     "exception": false,
+     "start_time": "2026-09-02T15:33:56.945624",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "================================================================\n    AIDE-MEMOIRE : commande equivalente pour VOTRE machine\n================================================================\n\nOS detecte : Windows (11, AMD64)\n\nPlateforme : Windows\n\n  # Installation elan (PowerShell)\n  iwr -useb https://raw.githubusercontent.com/leanprover/elan/master/elan-init.ps1 -OutFile elan-init.ps1\n  ./elan-init.ps1 -DefaultToolchain none\n\n  # Relancer PowerShell, puis :\n  elan default leanprover/lean4:stable\n\n  # Kernel Jupyter\n  pip install lean4-jupyter\n  python -m lean4_jupyter install\n\n  Note : si le kernel lean4 natif echoue avec\n  'signal.SIGPIPE not found', utilisez le kernel lean4-wsl\n  (voir section 5 ci-dessous).\n\n================================================================\n\nEtat actuel de l'installation :\n  elan : elan.EXE\n  lean : lean.EXE\n"
+     "output_type": "stream",
+     "text": [
+      "================================================================\n",
+      "    AIDE-MEMOIRE : commande equivalente pour VOTRE machine\n",
+      "================================================================\n",
+      "\n",
+      "OS detecte : Windows (10, AMD64)\n",
+      "\n",
+      "Plateforme : Windows\n",
+      "\n",
+      "  # Installation elan (PowerShell)\n",
+      "  iwr -useb https://raw.githubusercontent.com/leanprover/elan/master/elan-init.ps1 -OutFile elan-init.ps1\n",
+      "  ./elan-init.ps1 -DefaultToolchain none\n",
+      "\n",
+      "  # Relancer PowerShell, puis :\n",
+      "  elan default leanprover/lean4:stable\n",
+      "\n",
+      "  # Kernel Jupyter\n",
+      "  pip install lean4-jupyter\n",
+      "  python -m lean4_jupyter install\n",
+      "\n",
+      "  Note : si le kernel lean4 natif echoue avec\n",
+      "  'signal.SIGPIPE not found', utilisez le kernel lean4-wsl\n",
+      "  (voir section 5 ci-dessous).\n",
+      "\n",
+      "================================================================\n",
+      "\n",
+      "Etat actuel de l'installation :\n",
+      "  elan : elan.EXE\n",
+      "  lean : lean.EXE\n"
+     ]
     }
    ],
    "source": [
@@ -983,16 +1038,16 @@
    "id": "87568df1",
    "metadata": {
     "papermill": {
-     "duration": 0.002294,
-     "end_time": "2026-08-19T07:35:19.703695",
+     "duration": 0.004007,
+     "end_time": "2026-09-02T15:33:56.979587",
      "exception": false,
-     "start_time": "2026-08-19T07:35:19.701401",
+     "start_time": "2026-09-02T15:33:56.975580",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Verification de l'installation\n",
     "<a id=\"verification\"></a>\n",
@@ -1006,16 +1061,16 @@
    "id": "e2362b95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:19.709579Z",
-     "iopub.status.busy": "2026-08-19T07:35:19.709209Z",
-     "iopub.status.idle": "2026-08-19T07:35:20.756390Z",
-     "shell.execute_reply": "2026-08-19T07:35:20.755954Z"
+     "iopub.execute_input": "2026-09-02T15:33:56.991672Z",
+     "iopub.status.busy": "2026-09-02T15:33:56.990665Z",
+     "iopub.status.idle": "2026-09-02T15:33:58.619472Z",
+     "shell.execute_reply": "2026-09-02T15:33:58.618465Z"
     },
     "papermill": {
-     "duration": 1.051009,
-     "end_time": "2026-08-19T07:35:20.757131",
+     "duration": 1.635816,
+     "end_time": "2026-09-02T15:33:58.620476",
      "exception": false,
-     "start_time": "2026-08-19T07:35:19.706122",
+     "start_time": "2026-09-02T15:33:56.984660",
      "status": "completed"
     },
     "tags": []
@@ -1037,11 +1092,11 @@
      "text": [
       "Composant            Status       Version/Info\n",
       "------------------------------------------------------------\n",
-      "Python 3.8+          [OK]         3.13\n",
-      "elan                 [OK]         4.2.1\n",
-      "Lean 4               [OK]         Lean (version 4.32.1, x86_64-w64-windows-gnu, commit f054605aea4b840552cca2e725580bffd1e1b704, Release)\n",
+      "Python 3.8+          [OK]         3.11\n",
+      "elan                 [OK]         4.1.2\n",
+      "Lean 4               [OK]         Lean (version 4.33.1, x86_64-w64-windows-gnu, commit 819816b2e0a3bf405af45ae5c7af2491d8f5bee6, Release)\n",
       "lean4_jupyter        [OK]         0.0.2\n",
-      "Kernel Jupyter       [OK]         cleanenv-k\n",
+      "Kernel Jupyter       [OK]         lean4\n",
       "------------------------------------------------------------\n",
       "\n",
       "************************************************************\n",
@@ -1186,16 +1241,16 @@
    "id": "b9e6bb41",
    "metadata": {
     "papermill": {
-     "duration": 0.002488,
-     "end_time": "2026-08-19T07:35:20.762132",
+     "duration": 0.00816,
+     "end_time": "2026-09-02T15:33:58.637945",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.759644",
+     "start_time": "2026-09-02T15:33:58.629785",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Premiers tests avec LeanRunner\n",
     "<a id=\"tests\"></a>\n",
@@ -1222,10 +1277,10 @@
    "id": "c18c40b2",
    "metadata": {
     "papermill": {
-     "duration": 0.002419,
-     "end_time": "2026-08-19T07:35:20.766942",
+     "duration": 0.008664,
+     "end_time": "2026-09-02T15:33:58.655811",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.764523",
+     "start_time": "2026-09-02T15:33:58.647147",
      "status": "completed"
     },
     "tags": []
@@ -1258,10 +1313,10 @@
    "id": "b3ddcf38",
    "metadata": {
     "papermill": {
-     "duration": 0.00229,
-     "end_time": "2026-08-19T07:35:20.771559",
+     "duration": 0.008039,
+     "end_time": "2026-09-02T15:33:58.672499",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.769269",
+     "start_time": "2026-09-02T15:33:58.664460",
      "status": "completed"
     },
     "tags": []
@@ -1286,16 +1341,16 @@
    "id": "341ed37b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:20.777708Z",
-     "iopub.status.busy": "2026-08-19T07:35:20.777420Z",
-     "iopub.status.idle": "2026-08-19T07:35:20.785937Z",
-     "shell.execute_reply": "2026-08-19T07:35:20.785475Z"
+     "iopub.execute_input": "2026-09-02T15:33:58.691481Z",
+     "iopub.status.busy": "2026-09-02T15:33:58.690481Z",
+     "iopub.status.idle": "2026-09-02T15:33:58.706516Z",
+     "shell.execute_reply": "2026-09-02T15:33:58.705984Z"
     },
     "papermill": {
-     "duration": 0.012875,
-     "end_time": "2026-08-19T07:35:20.786687",
+     "duration": 0.026853,
+     "end_time": "2026-09-02T15:33:58.707525",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.773812",
+     "start_time": "2026-09-02T15:33:58.680672",
      "status": "completed"
     },
     "tags": []
@@ -1417,10 +1472,10 @@
    "id": "5dde083b",
    "metadata": {
     "papermill": {
-     "duration": 0.002399,
-     "end_time": "2026-08-19T07:35:20.791436",
+     "duration": 0.007509,
+     "end_time": "2026-09-02T15:33:58.723623",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.789037",
+     "start_time": "2026-09-02T15:33:58.716114",
      "status": "completed"
     },
     "tags": []
@@ -1439,16 +1494,16 @@
    "id": "981fa813",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:20.796946Z",
-     "iopub.status.busy": "2026-08-19T07:35:20.796729Z",
-     "iopub.status.idle": "2026-08-19T07:35:20.812793Z",
-     "shell.execute_reply": "2026-08-19T07:35:20.812349Z"
+     "iopub.execute_input": "2026-09-02T15:33:58.732971Z",
+     "iopub.status.busy": "2026-09-02T15:33:58.732971Z",
+     "iopub.status.idle": "2026-09-02T15:33:58.756213Z",
+     "shell.execute_reply": "2026-09-02T15:33:58.756213Z"
     },
     "papermill": {
-     "duration": 0.019833,
-     "end_time": "2026-08-19T07:35:20.813528",
+     "duration": 0.030596,
+     "end_time": "2026-09-02T15:33:58.757220",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.793695",
+     "start_time": "2026-09-02T15:33:58.726624",
      "status": "completed"
     },
     "tags": []
@@ -1462,7 +1517,7 @@
       "    PATCH DU KERNEL LEAN4 POUR WINDOWS\n",
       "============================================================\n",
       "\n",
-      "[OK] kernel.py deja patche: <USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\lean4_jupyter\\kernel.py\n",
+      "[OK] kernel.py deja patche: ~\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\site-packages\\lean4_jupyter\\kernel.py\n",
       "\n",
       "============================================================\n",
       "[OK] Kernel lean4 pret a l'emploi !\n",
@@ -1497,9 +1552,11 @@
     "    try:\n",
     "        import lean4_jupyter\n",
     "        kernel_file = Path(lean4_jupyter.__file__).parent / \"kernel.py\"\n",
+    "        # Chemin normalise pour l'affichage (home -> ~, pas de chemin machine commite)\n",
+    "        kernel_display = str(kernel_file).replace(str(Path.home()), \"~\")\n",
     "        \n",
     "        if not kernel_file.exists():\n",
-    "            print(f\"[!] Fichier kernel.py introuvable: {kernel_file}\")\n",
+    "            print(f\"[!] Fichier kernel.py introuvable: {kernel_display}\")\n",
     "            return False\n",
     "        \n",
     "        # Lire le fichier\n",
@@ -1508,7 +1565,7 @@
     "        \n",
     "        # Verifier si deja patche\n",
     "        if \"hasattr(signal, 'SIGPIPE')\" in content:\n",
-    "            print(f\"[OK] kernel.py deja patche: {kernel_file}\")\n",
+    "            print(f\"[OK] kernel.py deja patche: {kernel_display}\")\n",
     "            return True\n",
     "        \n",
     "        # Verifier si le bug existe\n",
@@ -1517,7 +1574,7 @@
     "            return True\n",
     "        \n",
     "        # Appliquer le patch\n",
-    "        print(f\"[*] Patch de {kernel_file}...\")\n",
+    "        print(f\"[*] Patch de {kernel_display}...\")\n",
     "        \n",
     "        # Ligne 51: old_sigpipe_handler = signal.signal(signal.SIGPIPE, signal.SIG_DFL)\n",
     "        old_line = \"        old_sigpipe_handler = signal.signal(signal.SIGPIPE, signal.SIG_DFL)\"\n",
@@ -1571,16 +1628,16 @@
    "id": "a8ce86b1",
    "metadata": {
     "papermill": {
-     "duration": 0.002266,
-     "end_time": "2026-08-19T07:35:20.818309",
+     "duration": 0.004515,
+     "end_time": "2026-09-02T15:33:58.766239",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.816043",
+     "start_time": "2026-09-02T15:33:58.761724",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Configuration du kernel Lean 4 (WSL) — Windows uniquement\n",
     "\n",
@@ -1597,16 +1654,16 @@
    "id": "ea71e7c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:20.824056Z",
-     "iopub.status.busy": "2026-08-19T07:35:20.823779Z",
-     "iopub.status.idle": "2026-08-19T07:35:22.501325Z",
-     "shell.execute_reply": "2026-08-19T07:35:22.500718Z"
+     "iopub.execute_input": "2026-09-02T15:33:58.777524Z",
+     "iopub.status.busy": "2026-09-02T15:33:58.777524Z",
+     "iopub.status.idle": "2026-09-02T15:34:02.641170Z",
+     "shell.execute_reply": "2026-09-02T15:34:02.640164Z"
     },
     "papermill": {
-     "duration": 1.6818,
-     "end_time": "2026-08-19T07:35:22.502338",
+     "duration": 3.870671,
+     "end_time": "2026-09-02T15:34:02.641677",
      "exception": false,
-     "start_time": "2026-08-19T07:35:20.820538",
+     "start_time": "2026-09-02T15:33:58.771006",
      "status": "completed"
     },
     "tags": []
@@ -1620,13 +1677,7 @@
       "    DIAGNOSTIC ET CONFIGURATION KERNEL LEAN4 VIA WSL\n",
       "============================================================\n",
       "\n",
-      "[1/4] Verification de WSL...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "[1/4] Verification de WSL...\n",
       "      [OK] WSL disponible\n",
       "\n",
       "[2/4] Verification de Lean dans WSL...\n"
@@ -1636,7 +1687,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      [OK] Lean (version 4.33.0, x86_64-unknown-linux-gnu, commit d8b18978322de05a8f3dba51ef03cf5461676c17, Release)\n",
+      "      [OK] Lean (version 4.33.1, x86_64-unknown-linux-gnu, commit 819816b2e0a3bf405af45ae5c7af2491d8f5bee6, Release)\n",
       "\n",
       "[3/4] Installation du kernel Jupyter...\n"
      ]
@@ -1645,19 +1696,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      [OK] Kernel enregistre: C:\\Users\\jsboi\\AppData\\Roaming\\jupyter\\kernels\\lean4-wsl\n",
+      "      [OK] Kernel enregistre: ~\\AppData\\Roaming\\jupyter\\kernels\\lean4-wsl\n",
       "      [*] Mise a jour du wrapper robuste...\n",
       "[*] Installation du kernel Lean4-WSL...\n",
-      "[+] Wrapper robuste deploye: /root/.lean4-kernel-wrapper.py\n",
-      "[+] Kernel cree: C:\\Users\\jsboi\\AppData\\Roaming\\jupyter\\kernels\\lean4-wsl\\kernel.json\n",
+      "[+] Wrapper robuste deploye: ~/.lean4-kernel-wrapper.py\n",
+      "[+] Kernel cree: ~\\AppData\\Roaming\\jupyter\\kernels\\lean4-wsl\\kernel.json\n",
       "\n",
-      "[4/4] Test du kernel WSL...\n",
-      "      [!] Erreur: \n",
+      "[4/4] Test du kernel WSL...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      [OK] lean4_jupyter fonctionne dans WSL\n",
       "\n",
       "============================================================\n",
-      "[~] Kernel installe mais test echoue.\n",
-      "    Redemarrez VSCode et reessayez.\n",
-      "    Verifiez les logs: wsl cat ~/.lean4-wrapper.log\n",
+      "[OK] Kernel Lean4-WSL pret a l'emploi !\n",
+      "\n",
+      "     Dans VSCode:\n",
+      "     1. Rechargez la fenetre: Ctrl+Shift+P > 'Reload Window'\n",
+      "     2. Ouvrez un notebook .ipynb\n",
+      "     3. Cliquez sur 'Select Kernel' en haut a droite\n",
+      "     4. Choisissez 'Lean 4 (WSL)'\n",
+      "\n",
+      "     Logs de debug: wsl cat ~/.lean4-wrapper.log\n",
       "============================================================\n"
      ]
     }
@@ -1711,6 +1774,12 @@
     "    # Last resort: use /root (WSL default when no user is set up)\n",
     "    return \"/root\"\n",
     "\n",
+    "def _display_path(p) -> str:\n",
+    "    \"\"\"Normalise un chemin pour l'affichage (home -> ~, pas de chemin machine).\"\"\"\n",
+    "    home = str(Path.home())\n",
+    "    s = str(p)\n",
+    "    return \"~\" + s[len(home):] if s.startswith(home) else s\n",
+    "\n",
     "class WSLKernelManager:\n",
     "    \"\"\"Gestionnaire du kernel Lean4 via WSL avec wrapper robuste\"\"\"\n",
     "    \n",
@@ -1719,6 +1788,7 @@
     "        self.kernel_name = \"lean4-wsl\"\n",
     "        self.kernel_path = Path(os.environ.get(\"APPDATA\", \"\")) / \"jupyter\" / \"kernels\" / self.kernel_name\n",
     "        wsl_home = _detect_wsl_user() if self.is_windows else str(Path.home())\n",
+    "        self.wsl_home = wsl_home\n",
     "        self.wrapper_path_wsl = f\"{wsl_home}/.lean4-kernel-wrapper.py\"\n",
     "        self.venv_python = f\"{wsl_home}/.lean4-venv/bin/python3\"\n",
     "    \n",
@@ -1769,7 +1839,7 @@
     "                timeout=10\n",
     "            )\n",
     "            if result.returncode == 0:\n",
-    "                print(f\"[+] Wrapper robuste deploye: {self.wrapper_path_wsl}\")\n",
+    "                print(f\"[+] Wrapper robuste deploye: {self.wrapper_path_wsl.replace(self.wsl_home, '~')}\")\n",
     "                return True\n",
     "            print(f\"[!] Erreur creation wrapper: {self._safe_decode(result.stderr)[:200]}\")\n",
     "            return False\n",
@@ -1864,7 +1934,7 @@
     "        with open(kernel_file, 'w') as f:\n",
     "            json.dump(kernel_json, f, indent=2)\n",
     "        \n",
-    "        print(f\"[+] Kernel cree: {kernel_file}\")\n",
+    "        print(f\"[+] Kernel cree: {_display_path(kernel_file)}\")\n",
     "        return True\n",
     "    \n",
     "    def run_diagnostic(self):\n",
@@ -1909,7 +1979,7 @@
     "        print(\"\\n[3/4] Installation du kernel Jupyter...\")\n",
     "        kernel_status = self.check_wsl_kernel_registered()\n",
     "        if kernel_status.get(\"registered\"):\n",
-    "            print(f\"      [OK] Kernel enregistre: {kernel_status['path']}\")\n",
+    "            print(f\"      [OK] Kernel enregistre: {_display_path(kernel_status['path'])}\")\n",
     "            print(\"      [*] Mise a jour du wrapper robuste...\")\n",
     "        else:\n",
     "            print(\"      [!] Kernel non enregistre\")\n",
@@ -1965,10 +2035,10 @@
    "id": "9f3d4507",
    "metadata": {
     "papermill": {
-     "duration": 0.002519,
-     "end_time": "2026-08-19T07:35:22.507573",
+     "duration": 0.00454,
+     "end_time": "2026-09-02T15:34:02.650868",
      "exception": false,
-     "start_time": "2026-08-19T07:35:22.505054",
+     "start_time": "2026-09-02T15:34:02.646328",
      "status": "completed"
     },
     "tags": []
@@ -1996,16 +2066,16 @@
    "id": "baaf4a4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T07:35:22.513507Z",
-     "iopub.status.busy": "2026-08-19T07:35:22.513307Z",
-     "iopub.status.idle": "2026-08-19T07:35:22.603524Z",
-     "shell.execute_reply": "2026-08-19T07:35:22.602831Z"
+     "iopub.execute_input": "2026-09-02T15:34:02.661645Z",
+     "iopub.status.busy": "2026-09-02T15:34:02.661645Z",
+     "iopub.status.idle": "2026-09-02T15:34:06.724084Z",
+     "shell.execute_reply": "2026-09-02T15:34:06.724084Z"
     },
     "papermill": {
-     "duration": 0.094422,
-     "end_time": "2026-08-19T07:35:22.604510",
+     "duration": 4.070182,
+     "end_time": "2026-09-02T15:34:06.725781",
      "exception": false,
-     "start_time": "2026-08-19T07:35:22.510088",
+     "start_time": "2026-09-02T15:34:02.655599",
      "status": "completed"
     },
     "tags": []
@@ -2025,16 +2095,15 @@
      "output_type": "stream",
      "text": [
       "=== Configuration Python 3 (WSL) pour notebooks Lean ===\n",
-      "Creation du venv: /root/.python3-wsl-venv\n",
       "Installation des dependances Python...\n",
       "Installation de Semantic Kernel...\n",
       "\n",
       "=== Verification ===\n",
-      "- python-dotenv 1.2.3\n",
-      "- openai 3.3.0\n",
-      "- anthropic 0.122.0\n",
-      "- matplotlib 3.11.1\n",
-      "- semantic-kernel 1.44.1\n",
+      "- python-dotenv 1.2.2\n",
+      "- openai 2.38.0\n",
+      "- anthropic 0.105.2\n",
+      "- matplotlib 3.10.9\n",
+      "- semantic-kernel 1.42.0\n",
       "\n",
       "=== Configuration terminee ===\n",
       "Le kernel Python 3 (WSL) est pret pour les notebooks Lean 7-8\n",
@@ -2156,16 +2225,16 @@
    "id": "12b7cc45",
    "metadata": {
     "papermill": {
-     "duration": 0.002715,
-     "end_time": "2026-08-19T07:35:22.610174",
+     "duration": 0.005512,
+     "end_time": "2026-09-02T15:34:06.737301",
      "exception": false,
-     "start_time": "2026-08-19T07:35:22.607459",
+     "start_time": "2026-09-02T15:34:06.731789",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Configuration VSCode (optionnel)\n",
     "<a id=\"vscode\"></a>\n",
@@ -2206,10 +2275,10 @@
    "id": "87fdc737",
    "metadata": {
     "papermill": {
-     "duration": 0.002476,
-     "end_time": "2026-08-19T07:35:22.615204",
+     "duration": 0.007137,
+     "end_time": "2026-09-02T15:34:06.749531",
      "exception": false,
-     "start_time": "2026-08-19T07:35:22.612728",
+     "start_time": "2026-09-02T15:34:06.742394",
      "status": "completed"
     },
     "tags": []
@@ -2287,7 +2356,7 @@
     "\n",
     "Comparez votre preuve avec celle de Mathlib (`Nat.add_comm`).\n",
     "\n",
-    "---\n"
+    "***\n"
    ]
   },
   {
@@ -2295,16 +2364,16 @@
    "id": "b96f7760",
    "metadata": {
     "papermill": {
-     "duration": 0.003069,
-     "end_time": "2026-08-19T07:35:22.620816",
+     "duration": 0.009582,
+     "end_time": "2026-09-02T15:34:06.768057",
      "exception": false,
-     "start_time": "2026-08-19T07:35:22.617747",
+     "start_time": "2026-09-02T15:34:06.758475",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",
@@ -2344,7 +2413,7 @@
     "\n",
     "Dans le notebook **[Lean-2-Dependent-Types](Lean-2-Dependent-Types.ipynb)**, vous decouvrirez le coeur du système de types de Lean 4 : le **Calcul des Constructions**. Vous apprendrez a manipuler les types de base (`Nat`, `Bool`, fonctions, produits), a comprendre la hiérarchie des univers (`Type 0`, `Type 1`, ...), et a utiliser les **types dependants** qui distinguent Lean des langages de programmation traditionnels. Cette étape pose les fondations necessaires pour aborder l'isomorphisme de Curry-Howard et la construction de preuves formelles dans Lean-3.\n",
     "\n",
-    "---\n"
+    "***\n"
    ]
   },
   {
@@ -2352,16 +2421,16 @@
    "id": "42ff9202",
    "metadata": {
     "papermill": {
-     "duration": 0.004301,
-     "end_time": "2026-08-19T07:35:22.627939",
+     "duration": 0.00544,
+     "end_time": "2026-09-02T15:34:06.781484",
      "exception": false,
-     "start_time": "2026-08-19T07:35:22.623638",
+     "start_time": "2026-09-02T15:34:06.776044",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Ressources et documentation\n",
     "<a id=\"ressources\"></a>\n",
@@ -2389,7 +2458,7 @@
     "- [lean4_jupyter GitHub](https://github.com/utensil/lean4_jupyter) - Ce kernel Jupyter\n",
     "- [LeanCopilot](https://github.com/lean-dojo/LeanCopilot) - Assistance LLM (notebook 7)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Notebooks suivants\n",
     "\n",
@@ -2406,7 +2475,7 @@
     "- **[Lean-7-LLM-Integration.ipynb](Lean-7-LLM-Integration.ipynb)** - Integration LLM\n",
     "- **[Lean-8-Agentic-Proving.ipynb](Lean-8-Agentic-Proving.ipynb)** - Agents autonomes\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : ← (debut) | [Index](Lean-1-Setup.ipynb) | [Lean-2-Dependent-Types →](Lean-2-Dependent-Types.ipynb)"
    ]
@@ -2445,7 +2514,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 16.153277,
+   "end_time": "2026-09-02T15:34:07.028275",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-1-Setup.ipynb",
+   "output_path": "Lean-1-Setup.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T15:33:50.874998",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #14277.

Quoi: Stop & Repair categorie C sur Lean-1-Setup — les cellules 17 (patch kernel Windows) et 19 (WSLKernelManager) imprimaient des chemins machine bruts ; normalisation a la source (home -> ~) puis re-execution complete.
Preuve: notebook_tools execute --kernel python3 SUCCESS (20.5 s, 8/8 cellules, 0 erreur, exec_count 1..8) ; scan fuites = 0 hit (jsboi/jesse//home/<u>//root/) ; strip_machine_paths --scan : 0 fuite ; validate_pr_notebooks : PASS.
Perimetre: 1 fichier — MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb (+239/-158 : +15/-6 de source, le reste = sorties re-executees + auto-fix pre-commit --- -> *** sur regles horizontales markdown).

## Summary

Contribution partielle a l'issue #14200 (1 notebook sur 9) : elimination des 2 sorties flaggees de Lean-1-Setup.

Triage de cause (regle 6 secrets-hygiene) : **categorie C — la SOURCE imprime le chemin**. L'outil `strip_machine_paths.py` (voie sanctionnee categorie A) ne couvre pas ces lignes : `AppData\Roaming\jupyter` ne porte aucun token de categorie (nuget/pip/ipykernel/conda/hf/temp), donc `_has_leak` les rejette. La sortie cellule 17 deja propre sur main etait la forme outil (`<USER_PATH>\...`, token pip) ; les 2 sorties restantes exigent le correctif a la source + re-execution (jamais de maquillage de sortie).

## Changement (cause C, a la source)

| Cellule | Avant (print brut) | Apres |
|---|---|---|
| 17 | `{kernel_file}` (3 sites : introuvable / deja patche / Patch de) | `kernel_display = str(kernel_file).replace(str(Path.home()), "~")` |
| 19 | `{self.wrapper_path_wsl}` | `.replace(self.wsl_home, "~")` (via `self.wsl_home` stocke) |
| 19 | `{kernel_file}` (Kernel cree) | `_display_path(kernel_file)` — helper module `~` + reste |
| 19 | `{kernel_status['path']}` (Kernel enregistre) | `_display_path(...)` |

## Execution reelle (preuve D/H.1)

```
[Lean-1-Setup.ipynb] (kernel: python3)
  [+] SUCCESS
  Success: 1 / Failed: 0 / Total time: 20.5s
```

Sorties normalisees (remplacent les 2 fuites `C:\Users\<u>\AppData\Roaming\jupyter\kernels\lean4-wsl`) :

```
[OK] kernel.py deja patche: ~\AppData\Local\Programs\Python\Python311\Lib\site-packages\lean4_jupyter\kernel.py
      [OK] Kernel enregistre: ~\AppData\Roaming\jupyter\kernels\lean4-wsl
[+] Wrapper robuste deploye: ~/.lean4-kernel-wrapper.py
[+] Kernel cree: ~\AppData\Roaming\jupyter\kernels\lean4-wsl\kernel.json
```

- `execution_count` 1..8 sequentiels, 0 output d'erreur, C.1 CLEAN (pas d'erreur volontaire).
- Scan post-exec : 0 occurrence de `jsboi|jesse|/home/<u>|/root/|C:\Users` dans TOUTES les sorties (y compris cellules non modifiees 4/6/9/11/15/21).
- `strip_machine_paths.py --scan` : 0 fuite residuelle ; `validate_pr_notebooks.py` : 1/1 PASS.
- Kernelspec metadata preserve (`python3-wsl`, kernel declare de la serie) ; cellule 19 `_test_kernel` passe desormais (`lean4_jupyter fonctionne dans WSL`) — etat machine ameliore depuis la derniere execution commitee.
- Churn de sorties honnete sur les cellules non modifiees : timestamps frais, versions mesurees (Python 3.11.9, elan 4.1.2, Lean 4.33.1), `Kernel Jupyter: lean4`.

## Verdict SOTA (regle H / axe A)

**SOTA-OK** — vrai kernel python3 execute localement (regle F), sorties committee = vraies sorties du code corrige. Axe B non applicable (notebook de setup, pas de demo de moteur).

## Rotation R6

c197 = MED/guard ; c199 = MED/guard (Position J, #14330, en attente override G-VAR-3) ; **c200 = MED/notebook-python** — genre distinct conformement au verdict G-VAR-3 (pas de retag). Pool : tranche non-clamee de #14200 (preflight c200 : Lean-1-Setup sans PR concurrente).

See #14200 (contribution partielle : 1 notebook sur 9).
