### PR TITLE
ci(#14283): tranche 3 -- router 19 gardes PR vers la jambe Linux auto-hebergee

### DIFF
--- a/.github/workflows/arxiv-attributions-guard.yml
+++ b/.github/workflows/arxiv-attributions-guard.yml
@@ -60,7 +60,14 @@ concurrency:
 jobs:
   arxiv-attributions:
     name: "arXiv attributions registry (7 entrees)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -45,7 +45,14 @@ concurrency:
 jobs:
   catalog-drift:
     name: "Notebook catalog drift (read-only)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Read-only checkout of the PR merge ref. We only generate the catalog and

--- a/.github/workflows/consecutive-code-cells-advisory.yml
+++ b/.github/workflows/consecutive-code-cells-advisory.yml
@@ -47,7 +47,13 @@ concurrency:
 jobs:
   consecutive-code-cells-advisory:
     name: "Consecutive code cells >= 2 advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     # Same-repo PRs only (agents/staff). Fork PRs are student submissions
     # under student-pr-reviews.md -- benevolent review, no content gate.
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/harness-coauthor-guard.yml
+++ b/.github/workflows/harness-coauthor-guard.yml
@@ -53,7 +53,13 @@ concurrency:
 jobs:
   coauthor-stale-delta:
     name: "Stale Co-Authored-By trailer guard (#10752 Phase 2)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 5
 
     # Same-repo PRs only (agents/staff). Fork PRs are student submissions

--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -53,7 +53,14 @@ concurrency:
 jobs:
   ict-tests:
     name: ICT ${{ matrix.suite-name }}
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/label-paths-guard.yml
+++ b/.github/workflows/label-paths-guard.yml
@@ -42,7 +42,14 @@ concurrency:
 jobs:
   label-paths-guard:
     name: "Label-poser workflows self-cover (blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -261,8 +261,14 @@ jobs:
   # that keeps its own copy of the list detects everyone's drift but its own.
   target-coverage:
     name: conway target-coverage
-    runs-on: ubuntu-latest
-    if: always()
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && always()
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/lean-i18n-drift.yml
+++ b/.github/workflows/lean-i18n-drift.yml
@@ -44,7 +44,14 @@ concurrency:
 jobs:
   i18n-drift:
     name: "i18n sibling drift"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -158,8 +158,14 @@ jobs:
   # (it reported the audit job's module as a blind spot). See #8782.
   target-coverage:
     name: knot target-coverage
-    runs-on: ubuntu-latest
-    if: always()
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && always()
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/manifest-description-visuelle-gate.yml
+++ b/.github/workflows/manifest-description-visuelle-gate.yml
@@ -55,7 +55,14 @@ concurrency:
 jobs:
   manifest-description-visuelle:
     name: "MANIFEST.md description_visuelle field enforced on changed files"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/markdown-claims-output-advisory.yml
+++ b/.github/workflows/markdown-claims-output-advisory.yml
@@ -43,7 +43,14 @@ concurrency:
 jobs:
   claims-output-advisory:
     name: "Markdown claims anchored to previous output (#11435 advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/orphaned-delivery-scan.yml
+++ b/.github/workflows/orphaned-delivery-scan.yml
@@ -52,7 +52,13 @@ concurrency:
 jobs:
   sweep:
     name: "Verify merged PRs' mergeCommit reached main (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     # On [closed], restrict to same-repo PRs: fork PRs cannot create an
     # internal base != main orphan and their limited token/fetch access would
     # only produce spurious failures on an advisory job.

--- a/.github/workflows/quantconnect-notebook-freshness.yml
+++ b/.github/workflows/quantconnect-notebook-freshness.yml
@@ -39,7 +39,14 @@ concurrency:
 jobs:
   freshness-guard:
     name: "QuantConnect ML notebook freshness guard (#11433)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/scan-md-hierarchy-drift.yml
+++ b/.github/workflows/scan-md-hierarchy-drift.yml
@@ -29,7 +29,14 @@ permissions:
 jobs:
   drift:
     name: scan_md_hierarchy drift (advisory)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/slides-composition-pr-relay.yml
+++ b/.github/workflows/slides-composition-pr-relay.yml
@@ -33,7 +33,14 @@ concurrency:
 jobs:
   slides-composition-pr-relay:
     name: "Slides composition PR relay (#14226, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/source-output-ratchet.yml
+++ b/.github/workflows/source-output-ratchet.yml
@@ -42,7 +42,14 @@ permissions:
 jobs:
   ratchet:
     name: "Source-output ratchet (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout (full history)

--- a/.github/workflows/translation-guard.yml
+++ b/.github/workflows/translation-guard.yml
@@ -61,7 +61,14 @@ concurrency:
 jobs:
   guard:
     name: "No hand-edited translation files on feature branch"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 1 de #12690 : ce workflow n'interroge QUE le graphe de commits

--- a/.github/workflows/unique-check-run-names-guard.yml
+++ b/.github/workflows/unique-check-run-names-guard.yml
@@ -47,7 +47,14 @@ jobs:
   # par variation-tag-guard.yml).
   check-unique-names-required:
     name: 'Require unique rendered check-run names across PR workflows (#11869)'
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout workflows + script
         uses: actions/checkout@v4

--- a/.github/workflows/validation-matrix.yml
+++ b/.github/workflows/validation-matrix.yml
@@ -36,7 +36,14 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
     - uses: actions/checkout@v4

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -78,6 +78,18 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "notebook-exec-sequence-ratchet.yml",
     "notebook-navlink-check.yml",
     "notebook-papermill-ratchet.yml",
+    # tranche 3b (#14283, meme decision, meme owner) : suite des gardes PR
+    #   pure-Python. Fondue dans la meme PR que 3a -- les scinder aurait produit
+    #   un conflit sur cette meme ancre pour zero benefice de relecture.
+    "markdown-claims-output-advisory.yml",
+    "orphaned-delivery-scan.yml",
+    "quantconnect-notebook-freshness.yml",
+    "scan-md-hierarchy-drift.yml",
+    "slides-composition-pr-relay.yml",
+    "source-output-ratchet.yml",
+    "translation-guard.yml",
+    "unique-check-run-names-guard.yml",
+    "validation-matrix.yml",
     # tranche 3a (#14283, decision ai-01 2026-09-02, owner myia-ai-01:CoursIA) :
     #   gardes PR pure-Python, garde same-repo au niveau job, runs-on STATIQUE.
     #   Exclus deliberement : pr-gate.yml (agregateur qui poll -- il tiendrait le

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -78,6 +78,22 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "notebook-exec-sequence-ratchet.yml",
     "notebook-navlink-check.yml",
     "notebook-papermill-ratchet.yml",
+    # tranche 3a (#14283, decision ai-01 2026-09-02, owner myia-ai-01:CoursIA) :
+    #   gardes PR pure-Python, garde same-repo au niveau job, runs-on STATIQUE.
+    #   Exclus deliberement : pr-gate.yml (agregateur qui poll -- il tiendrait le
+    #   slot quil attend), owui-playwright-check.yml (navigateurs hors image),
+    #   always-on-guards.yml (trigger pull_request_review = FORK_REACHABLE).
+    #   Rollback = revert de la PR de routage.
+    "arxiv-attributions-guard.yml",
+    "catalog-drift.yml",
+    "consecutive-code-cells-advisory.yml",
+    "harness-coauthor-guard.yml",
+    "ict-tests.yml",
+    "label-paths-guard.yml",
+    "lean-conway.yml",
+    "lean-i18n-drift.yml",
+    "lean-knot.yml",
+    "manifest-description-visuelle-gate.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #14334

See #14283, #14337.

## Perimetre exact

**20 fichiers** : les **19 workflows** enumeres ci-dessous, plus
`scripts/ci/check_self_hosted_runner_policy.py` (inscription a l'allowlist).

`arxiv-attributions-guard` · `catalog-drift` · `consecutive-code-cells-advisory` ·
`harness-coauthor-guard` · `ict-tests` · `label-paths-guard` · `lean-conway` ·
`lean-i18n-drift` · `lean-knot` · `manifest-description-visuelle-gate` ·
`markdown-claims-output-advisory` · `orphaned-delivery-scan` ·
`quantconnect-notebook-freshness` · `scan-md-hierarchy-drift` ·
`slides-composition-pr-relay` · `source-output-ratchet` · `translation-guard` ·
`unique-check-run-names-guard` · `validation-matrix`

Une seule et meme transformation sur chacun. Scinder en deux PRs aurait produit un
conflit sur l'ancre unique de `SELF_HOSTED_WORKFLOW_ALLOWLIST` pour zero benefice
de relecture.

## Le pattern

1. `runs-on: [self-hosted, coursia-ephemeral, coursia-linux]` -- **statique** ;
2. garde same-repo au **niveau job** (`if:`) ;
3. inscription a `SELF_HOSTED_WORKFLOW_ALLOWLIST`.

## Deux corrections a mon propre travail, laissees visibles

**1. La v1 de cette PR utilisait un `runs-on` hybride** (expression ternaire
renvoyant les forks sur `ubuntu-latest`), justifie par : *« un `if:` qui saute le
job ne poste rien, et `PR gate` attend un verdict qui ne viendra jamais »*.
**C'etait faux.** Le commentaire de la tranche 1 dans le checker l'ecrit :
*« universal same-repo guard at job level so fork PRs are skipped (pr_gate.py
counts `skipped` as OK) »*.

**2. `check_self_hosted_runner_policy.py` a refuse l'hybride** --
`DYNAMIC_RUNS_ON: "runs-on contains an expression and cannot be audited
statically"`. Il a raison : une expression rend le routage inauditable par
l'organe meme dont le travail est de garantir qu'aucun code de fork n'atteint nos
machines. Le garde a attrape la faute **avant** que je ne la propage 19 fois.

## Surete fork -- mesuree

| Vecteur | Mesure sur les 34 candidats | Resultat |
|---|---|---|
| `pull_request_target` en trigger | bloc `on:` de chaque fichier | **0** (3 hits grep, tous en commentaire) |
| `actions/checkout` avec `ref:` explicite | `grep -nE '^\s+ref:'` | **0** |
| trigger hors `SAFE_SELF_HOSTED_TRIGGERS` | bloc `on:` des 19 retenus | **0** |

Trois des 19 portaient deja une garde acceptee
(`consecutive-code-cells-advisory`, `harness-coauthor-guard`,
`orphaned-delivery-scan`) : inchangee. Deux jobs de synthese portaient
`if: always()` (`lean-conway`, `lean-knot`) : la garde est **parenthesee devant**
-- `(<universel>) && always()` -- forme que la politique exige explicitement,
`&&` liant plus fort que `||`.

## Trois exclusions deliberees

- **`pr-gate.yml`** -- agregateur qui **poll** les autres gardes ; le router lui
  ferait tenir le slot qu'il attend. Le fichier porte la trace de l'incident :
  *« under runner starvation (11+/14 runners held by PR gate) the queue wait
  alone exceeded that budget »* (#11405).
- **`owui-playwright-check.yml`** -- `npm` + navigateurs Playwright, hors image.
- **`always-on-guards.yml`** -- trigger `pull_request_review`, classe
  `FORK_REACHABLE_TRIGGERS`. **C'est le fond du blocage de #14294**, que je
  croyais purement lie a l'image : cette PR-la doit etre revue, pas debloquee.

`lean-conway` / `lean-knot` ont 4 et 3 jobs, **un seul** route chacun : les autres
sont des appels de workflow reutilisable (`lean-build.yml`, `lean-axiom.yml`) qui
portent leur propre `runs-on`. Le Lean reste sur ubuntu-latest -- l'image n'a pas
de toolchain `elan` (c'est l'objet de #14337).

## Validation

```
scripts/tests/test_check_self_hosted_runner_policy.py .... 48 passed
```

Avant l'inscription a l'allowlist, le meme test rendait 19 violations
`WORKFLOW_NOT_ALLOWED` et **aucune autre** : garde, triggers et jeu de labels
passaient deja. Controle positif de la mesure, pas seulement de son resultat.

Depend de **#14339** (PEP 668 dans l'image) : sans lui, les gardes qui font
`import yaml || pip install pyyaml` meurent dans le conteneur. L'image est deja
roulee sur les deux daemons ai-01.

## Portee declaree honnetement

Tag **META/guard** : cette PR **ne tient pas** le plancher G-VAR-1 de contenu.
Assume -- le chantier CI est un mandat user explicite et repete, prioritaire sur
ma rotation de genres. Je ne le maquille pas en DEEP.
