### PR TITLE
fix(ci-runner,#14283): PEP 668 -- rendre pip utilisable dans le conteneur Linux

### DIFF
--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -27,9 +27,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 # upload-artifact l'utilisent, sinon repli gzip (fonctionne, plus lent).
 # Deliberement PAS sudo : les conteneurs tournent en --security-opt=no-new-
 # privileges, il serait inerte et affaiblirait la posture.
+# PEP 668 : Debian marque son Python systeme `externally-managed`, donc
+# `pip install <x>` est REFUSE la ou il passe sur ubuntu-latest -- un workflow
+# qui fait `import yaml || pip install pyyaml` meurt sur le pip (run
+# 33651913220, Unique Check-Run Names Guard). Le conteneur est jetable : lui
+# rendre le comportement de la machine GitHub-hosted qu'il remplace est le
+# but, pas un risque. python3-yaml en plus, pour que le cas courant n'ait meme
+# pas besoin de pip (pas d'aller-retour reseau).
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip python-is-python3 \
+       ca-certificates curl git jq unzip tar gzip xz-utils python3 python3-pip python-is-python3 python3-yaml \
        libicu74 \
        lsb-release zstd wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #14336

See #14283, #14337.

## Le defaut

`python3 -c "import yaml" || pip install --quiet pyyaml` -- idiome present dans
plusieurs workflows -- **meurt sur le pip** dans le conteneur :

```
error: externally-managed-environment
x This environment is externally managed
```

Debian marque son Python systeme `externally-managed` (PEP 668). Sur
`ubuntu-latest`, pip fonctionne parce que le Python de GitHub n'est pas le Python
systeme. Le conteneur remplace cette machine : il doit lui rendre ce comportement.

Mesure : run 33651913220 (`Unique Check-Run Names Guard`), un des 19 gardes routes
par #14336.

## Le correctif

| Changement | Effet |
|---|---|
| `ENV PIP_BREAK_SYSTEM_PACKAGES=1` | **tout** `pip install` de workflow refonctionne, pas seulement PyYAML |
| `python3-yaml` | le cas courant n'a meme plus besoin de pip -- pas d'aller-retour reseau par job |

« Casser le Python systeme » est ici sans portee : le conteneur est `--ephemeral`
et meurt apres un job.

## Controle positif

Image construite, puis executee sur les deux daemons ai-01 :

```
yaml 6.0.1
PIP_BREAK=1
lsb=Ubuntu
gh OK
pip rc=0
```

Les cinq outils de la classe verifies d'un coup, pas seulement celui du jour.

## Image roulee avant merge -- je le dis explicitement

Comme pour #14334, l'image est **deja roulee sur les deux daemons ai-01** et les 15
slots inactifs recycles dessus. Sans cela #14336 ne peut pas verdir : son garde
s'execute dans un conteneur qui n'a pas le correctif. Piege circulaire, casse par
le seul cote qui n'est pas dans le depot -- l'infra. **po-2024 doit rebuild** pour
que ses slots cessent de porter l'ancienne image.

## Portee

Ce ping-pong outil-par-outil est exactement ce que #14337 propose de remplacer
(pools specialises par labels, cache Mathlib chaud) plutot que d'epaissir sans fin
une image commune. Ce correctif-ci reste utile dans les deux mondes : il porte sur
le comportement de pip, pas sur un outil.

Tag **META/guard** : ne tient pas le plancher G-VAR-1. Chantier CI sous mandat user.