### PR TITLE
fix(lean,#14191): 2.8b #check/#print axioms natifs — imports sous-modules, Run All lean4-wsl

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb
@@ -2512,8 +2512,8 @@
    "end_time": "2026-09-02T16:02:32.525249+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-worktree-14191\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\02-ML-Cours\\2.8b-Theorie-PAC-Lean.ipynb",
-   "output_path": "D:\\dev\\CoursIA-worktree-14191\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\02-ML-Cours\\2.8b-Theorie-PAC-Lean_output.ipynb",
+   "input_path": "2.8b-Theorie-PAC-Lean.ipynb",
+   "output_path": "2.8b-Theorie-PAC-Lean_output.ipynb",
    "parameters": {},
    "start_time": "2026-09-02T15:56:11.081568+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb
@@ -5,10 +5,10 @@
    "id": "3adf5a2c",
    "metadata": {
     "papermill": {
-     "duration": 0.025155,
-     "end_time": "2026-08-23T02:22:38.199300+00:00",
+     "duration": 0.020225,
+     "end_time": "2026-09-02T15:56:31.356927+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:38.174145+00:00",
+     "start_time": "2026-09-02T15:56:31.336702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -40,10 +40,10 @@
    "id": "11958f3a",
    "metadata": {
     "papermill": {
-     "duration": 0.011608,
-     "end_time": "2026-08-23T02:22:38.245631+00:00",
+     "duration": 0.024351,
+     "end_time": "2026-09-02T15:56:31.406444+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:38.234023+00:00",
+     "start_time": "2026-09-02T15:56:31.382093+00:00",
      "status": "completed"
     },
     "tags": []
@@ -79,10 +79,10 @@
    "id": "1c602b6a",
    "metadata": {
     "papermill": {
-     "duration": 0.021056,
-     "end_time": "2026-08-23T02:22:38.298347+00:00",
+     "duration": 0.018958,
+     "end_time": "2026-09-02T15:56:31.461655+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:38.277291+00:00",
+     "start_time": "2026-09-02T15:56:31.442697+00:00",
      "status": "completed"
     },
     "tags": []
@@ -125,16 +125,16 @@
    "id": "4c6d5c61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:22:38.359473Z",
-     "iopub.status.busy": "2026-08-23T02:22:38.359304Z",
-     "iopub.status.idle": "2026-08-23T02:22:59.557674Z",
-     "shell.execute_reply": "2026-08-23T02:22:59.556869Z"
+     "iopub.execute_input": "2026-09-02T15:56:31.404419Z",
+     "iopub.status.busy": "2026-09-02T15:56:31.404129Z",
+     "iopub.status.idle": "2026-09-02T16:02:27.927275Z",
+     "shell.execute_reply": "2026-09-02T16:02:27.926373Z"
     },
     "papermill": {
-     "duration": 21.231164,
-     "end_time": "2026-08-23T02:22:59.558822+00:00",
+     "duration": 356.455456,
+     "end_time": "2026-09-02T16:02:27.927024+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:38.327658+00:00",
+     "start_time": "2026-09-02T15:56:31.471568+00:00",
      "status": "completed"
     },
     "tags": []
@@ -152,126 +152,138 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Tete de session : le vrai lake. Le module racine `PacLearning` n&#39;est pas construit</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- par le lakefile (glob `.submodules` l&#39;exclut), donc import des sous-modules reels.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Data</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Sample</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Concentration</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hoeffding</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>PacFiniteBound</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>UniformConcentration</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>PacLearning</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Serrement de main du cadre : chaque #check rend la signature du module compile.</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>Distribution</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>:<span class=\"w\"> </span>(X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>Hypothesis</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>trueError</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>trueError<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
-       "<span class=\"w\">  </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleProb</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleProb<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>Hypothesis</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Hypothesis<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>trueError</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>trueError<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Hypothesis<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Hypothesis<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleProb</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>sampleProb<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
        "<span class=\"w\">  </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(Q<span class=\"w\"> </span>:<span class=\"w\"> </span>(Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[DecidablePred<span class=\"w\"> </span>Q]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>uniform_concentration<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}\n",
-       "<span class=\"w\">  </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X)<span class=\"w\"> </span>(Hs<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X))<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ},\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>sampleWeight<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>uniform_concentration<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Hypothesis<span class=\"w\"> </span>X)\n",
+       "<span class=\"w\">  </span>(Hs<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(Hypothesis<span class=\"w\"> </span>X))<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ},\n",
        "<span class=\"w\">  </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
        "<span class=\"w\">    </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{ε<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ},\n",
        "<span class=\"w\">      </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
-       "<span class=\"w\">        </span>(PacLearning<span class=\"bp\">.</span>sampleProb<span class=\"w\"> </span>D<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Hs,<span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">|</span>PacLearning<span class=\"bp\">.</span>empError<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>trueError<span class=\"w\"> </span>D<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"bp\">|</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span>\n",
+       "<span class=\"w\">        </span>(sampleProb<span class=\"w\"> </span>D<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Hs,<span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">|</span>empError<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>trueError<span class=\"w\"> </span>D<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"bp\">|</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span>\n",
        "<span class=\"w\">          </span><span class=\"bp\">↑</span>Hs<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Real<span class=\"bp\">.</span>exp<span class=\"w\"> </span>(<span class=\"bp\">-</span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span><span class=\"mi\">2</span>)))</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\\nimport PacLearning.UniformConcentration\\n\\n-- Serrement de main du cadre : chaque #check rend la signature du module compile.\\n#check @PacLearning.Distribution\\n#check @PacLearning.Hypothesis\\n#check @PacLearning.trueError\\n#check @PacLearning.sampleProb\\n#check @PacLearning.sampleWeight\\n#check @PacLearning.uniform_concentration\"}</code>\n",
+       "            <code>{\"cmd\": \"-- Tete de session : le vrai lake. Le module racine `PacLearning` n'est pas construit\\n-- par le lakefile (glob `.submodules` l'exclut), donc import des sous-modules reels.\\nimport PacLearning.Data\\nimport PacLearning.Sample\\nimport PacLearning.Concentration\\nimport PacLearning.Hoeffding\\nimport PacLearning.PacFiniteBound\\nimport PacLearning.UniformConcentration\\nopen PacLearning\\n\\n-- Serrement de main du cadre : chaque #check rend la signature du module compile.\\n#check @PacLearning.Distribution\\n#check @PacLearning.Hypothesis\\n#check @PacLearning.trueError\\n#check @PacLearning.sampleProb\\n#check @PacLearning.sampleWeight\\n#check @PacLearning.uniform_concentration\"}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
        "            <code>{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"PacLearning.Distribution : (X : Type u_1) → [Fintype X] → Type u_1\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
-       "   \"data\": \"PacLearning.Hypothesis : Type u_1 → Type u_1\"},\r\n",
+       "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
+       "   \"data\": \"Hypothesis : Type u_1 → Type u_1\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 14, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 14, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.trueError : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → PacLearning.Hypothesis X → PacLearning.Hypothesis X → ℝ\"},\r\n",
+       "   \"@trueError : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → Hypothesis X → Hypothesis X → ℝ\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleProb : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\"},\r\n",
+       "   \"@sampleProb : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\"},\r\n",
+       "   \"@sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 17, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X}\\n  (f : PacLearning.Hypothesis X) (Hs : Finset (PacLearning.Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (PacLearning.sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |PacLearning.empError f h S - PacLearning.trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"}],\r\n",
+       "   \"@uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f : Hypothesis X)\\n  (Hs : Finset (Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"}],\r\n",
        " \"env\": 0}</code>\n",
        "        </details>\n",
        "    "
       ],
       "text/plain": [
-       "-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\n",
+       "-- Tete de session : le vrai lake. Le module racine `PacLearning` n'est pas construit\n",
+       "-- par le lakefile (glob `.submodules` l'exclut), donc import des sous-modules reels.\n",
+       "import PacLearning.Data\n",
+       "import PacLearning.Sample\n",
+       "import PacLearning.Concentration\n",
+       "import PacLearning.Hoeffding\n",
+       "import PacLearning.PacFiniteBound\n",
        "import PacLearning.UniformConcentration\n",
+       "open PacLearning\n",
        "\n",
        "-- Serrement de main du cadre : chaque #check rend la signature du module compile.\n",
        "#check @PacLearning.Distribution\n",
        "──────▶  PacLearning.Distribution : (X : Type u_1) → [Fintype X] → Type u_1\n",
        "#check @PacLearning.Hypothesis\n",
-       "──────▶  PacLearning.Hypothesis : Type u_1 → Type u_1\n",
+       "──────▶  Hypothesis : Type u_1 → Type u_1\n",
        "#check @PacLearning.trueError\n",
-       "──────▶  @PacLearning.trueError : {X : Type u_1} →\n",
-       "  [inst : Fintype X] → PacLearning.Distribution X → PacLearning.Hypothesis X → PacLearning.Hypothesis X → ℝ\n",
+       "──────▶  @trueError : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → Hypothesis X → Hypothesis X → ℝ\n",
        "#check @PacLearning.sampleProb\n",
-       "──────▶  @PacLearning.sampleProb : {X : Type u_1} →\n",
+       "──────▶  @sampleProb : {X : Type u_1} →\n",
        "  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\n",
        "#check @PacLearning.sampleWeight\n",
-       "──────▶  @PacLearning.sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\n",
+       "──────▶  @sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\n",
        "#check @PacLearning.uniform_concentration\n",
-       "──────▶  @PacLearning.uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X}\n",
-       "  (f : PacLearning.Hypothesis X) (Hs : Finset (PacLearning.Hypothesis X)) {n : ℕ},\n",
+       "──────▶  @uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f : Hypothesis X)\n",
+       "  (Hs : Finset (Hypothesis X)) {n : ℕ},\n",
        "  0 < n →\n",
        "    ∀ {ε : ℝ},\n",
        "      0 < ε →\n",
-       "        (PacLearning.sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |PacLearning.empError f h S - PacLearning.trueError D f h|) ≤\n",
+       "        (sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤\n",
        "          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\n",
        "--% env 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\\nimport PacLearning.UniformConcentration\\n\\n-- Serrement de main du cadre : chaque #check rend la signature du module compile.\\n#check @PacLearning.Distribution\\n#check @PacLearning.Hypothesis\\n#check @PacLearning.trueError\\n#check @PacLearning.sampleProb\\n#check @PacLearning.sampleWeight\\n#check @PacLearning.uniform_concentration\"}\n",
+       "{\"cmd\": \"-- Tete de session : le vrai lake. Le module racine `PacLearning` n'est pas construit\\n-- par le lakefile (glob `.submodules` l'exclut), donc import des sous-modules reels.\\nimport PacLearning.Data\\nimport PacLearning.Sample\\nimport PacLearning.Concentration\\nimport PacLearning.Hoeffding\\nimport PacLearning.PacFiniteBound\\nimport PacLearning.UniformConcentration\\nopen PacLearning\\n\\n-- Serrement de main du cadre : chaque #check rend la signature du module compile.\\n#check @PacLearning.Distribution\\n#check @PacLearning.Hypothesis\\n#check @PacLearning.trueError\\n#check @PacLearning.sampleProb\\n#check @PacLearning.sampleWeight\\n#check @PacLearning.uniform_concentration\"}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"PacLearning.Distribution : (X : Type u_1) → [Fintype X] → Type u_1\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
-       "   \"data\": \"PacLearning.Hypothesis : Type u_1 → Type u_1\"},\r\n",
+       "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
+       "   \"data\": \"Hypothesis : Type u_1 → Type u_1\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 14, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 14, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.trueError : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → PacLearning.Hypothesis X → PacLearning.Hypothesis X → ℝ\"},\r\n",
+       "   \"@trueError : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → Hypothesis X → Hypothesis X → ℝ\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleProb : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\"},\r\n",
+       "   \"@sampleProb : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\"},\r\n",
+       "   \"@sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 17, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X}\\n  (f : PacLearning.Hypothesis X) (Hs : Finset (PacLearning.Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (PacLearning.sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |PacLearning.empError f h S - PacLearning.trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"}],\r\n",
+       "   \"@uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f : Hypothesis X)\\n  (Hs : Finset (Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"}],\r\n",
        " \"env\": 0}"
       ]
      },
@@ -280,8 +292,13 @@
     }
    ],
    "source": [
-    "-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\n",
-    "import PacLearning\n",
+    "-- Tete de session : le vrai lake. Le module racine `PacLearning` n'est pas construit\n",
+    "-- par le lakefile (glob `.submodules` l'exclut), donc import des sous-modules reels.\n",
+    "import PacLearning.Data\n",
+    "import PacLearning.Sample\n",
+    "import PacLearning.Concentration\n",
+    "import PacLearning.Hoeffding\n",
+    "import PacLearning.PacFiniteBound\n",
     "import PacLearning.UniformConcentration\n",
     "open PacLearning\n",
     "\n",
@@ -299,10 +316,10 @@
    "id": "2dd80053",
    "metadata": {
     "papermill": {
-     "duration": 0.025504,
-     "end_time": "2026-08-23T02:22:59.597735+00:00",
+     "duration": 0.002725,
+     "end_time": "2026-09-02T16:02:27.932721+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:59.572231+00:00",
+     "start_time": "2026-09-02T16:02:27.929996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -327,16 +344,16 @@
    "id": "fb2a7d70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:22:59.633036Z",
-     "iopub.status.busy": "2026-08-23T02:22:59.632844Z",
-     "iopub.status.idle": "2026-08-23T02:22:59.900714Z",
-     "shell.execute_reply": "2026-08-23T02:22:59.899595Z"
+     "iopub.execute_input": "2026-09-02T16:02:27.942925Z",
+     "iopub.status.busy": "2026-09-02T16:02:27.942759Z",
+     "iopub.status.idle": "2026-09-02T16:02:28.452558Z",
+     "shell.execute_reply": "2026-09-02T16:02:28.451805Z"
     },
     "papermill": {
-     "duration": 0.286401,
-     "end_time": "2026-08-23T02:22:59.901672+00:00",
+     "duration": 0.508523,
+     "end_time": "2026-09-02T16:02:28.443803+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:59.615271+00:00",
+     "start_time": "2026-09-02T16:02:27.935280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -437,10 +454,10 @@
    "id": "39b06518",
    "metadata": {
     "papermill": {
-     "duration": 0.020336,
-     "end_time": "2026-08-23T02:22:59.933964+00:00",
+     "duration": 0.002762,
+     "end_time": "2026-09-02T16:02:28.449901+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:59.913628+00:00",
+     "start_time": "2026-09-02T16:02:28.447139+00:00",
      "status": "completed"
     },
     "tags": []
@@ -456,10 +473,10 @@
    "id": "0a214bdb",
    "metadata": {
     "papermill": {
-     "duration": 0.019755,
-     "end_time": "2026-08-23T02:22:59.967261+00:00",
+     "duration": 0.002813,
+     "end_time": "2026-09-02T16:02:28.455796+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:59.947506+00:00",
+     "start_time": "2026-09-02T16:02:28.452983+00:00",
      "status": "completed"
     },
     "tags": []
@@ -482,16 +499,16 @@
    "id": "49cb78fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:00.007809Z",
-     "iopub.status.busy": "2026-08-23T02:23:00.007575Z",
-     "iopub.status.idle": "2026-08-23T02:23:00.285660Z",
-     "shell.execute_reply": "2026-08-23T02:23:00.284840Z"
+     "iopub.execute_input": "2026-09-02T16:02:28.472331Z",
+     "iopub.status.busy": "2026-09-02T16:02:28.472160Z",
+     "iopub.status.idle": "2026-09-02T16:02:28.826017Z",
+     "shell.execute_reply": "2026-09-02T16:02:28.825182Z"
     },
     "papermill": {
-     "duration": 0.300053,
-     "end_time": "2026-08-23T02:23:00.286167+00:00",
+     "duration": 0.355051,
+     "end_time": "2026-09-02T16:02:28.813519+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:22:59.986114+00:00",
+     "start_time": "2026-09-02T16:02:28.458468+00:00",
      "status": "completed"
     },
     "tags": []
@@ -628,10 +645,10 @@
    "id": "b7390996",
    "metadata": {
     "papermill": {
-     "duration": 0.02181,
-     "end_time": "2026-08-23T02:23:00.324588+00:00",
+     "duration": 0.003915,
+     "end_time": "2026-09-02T16:02:28.822594+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:00.302778+00:00",
+     "start_time": "2026-09-02T16:02:28.818679+00:00",
      "status": "completed"
     },
     "tags": []
@@ -648,10 +665,10 @@
    "id": "a508deec",
    "metadata": {
     "papermill": {
-     "duration": 0.025846,
-     "end_time": "2026-08-23T02:23:00.371514+00:00",
+     "duration": 0.003373,
+     "end_time": "2026-09-02T16:02:28.830644+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:00.345668+00:00",
+     "start_time": "2026-09-02T16:02:28.827271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -679,16 +696,16 @@
    "id": "b2b63745",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:00.420753Z",
-     "iopub.status.busy": "2026-08-23T02:23:00.420578Z",
-     "iopub.status.idle": "2026-08-23T02:23:00.664798Z",
-     "shell.execute_reply": "2026-08-23T02:23:00.663724Z"
+     "iopub.execute_input": "2026-09-02T16:02:28.854086Z",
+     "iopub.status.busy": "2026-09-02T16:02:28.853928Z",
+     "iopub.status.idle": "2026-09-02T16:02:29.110086Z",
+     "shell.execute_reply": "2026-09-02T16:02:29.109306Z"
     },
     "papermill": {
-     "duration": 0.269605,
-     "end_time": "2026-08-23T02:23:00.665432+00:00",
+     "duration": 0.259276,
+     "end_time": "2026-09-02T16:02:29.093510+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:00.395827+00:00",
+     "start_time": "2026-09-02T16:02:28.834234+00:00",
      "status": "completed"
     },
     "tags": []
@@ -829,16 +846,16 @@
    "id": "c80cd797",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:00.707929Z",
-     "iopub.status.busy": "2026-08-23T02:23:00.707752Z",
-     "iopub.status.idle": "2026-08-23T02:23:00.951501Z",
-     "shell.execute_reply": "2026-08-23T02:23:00.950738Z"
+     "iopub.execute_input": "2026-09-02T16:02:29.118625Z",
+     "iopub.status.busy": "2026-09-02T16:02:29.118449Z",
+     "iopub.status.idle": "2026-09-02T16:02:29.397182Z",
+     "shell.execute_reply": "2026-09-02T16:02:29.396223Z"
     },
     "papermill": {
-     "duration": 0.272746,
-     "end_time": "2026-08-23T02:23:00.952601+00:00",
+     "duration": 0.281169,
+     "end_time": "2026-09-02T16:02:29.378096+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:00.679855+00:00",
+     "start_time": "2026-09-02T16:02:29.096927+00:00",
      "status": "completed"
     },
     "tags": []
@@ -942,10 +959,10 @@
    "id": "067fb150",
    "metadata": {
     "papermill": {
-     "duration": 0.020108,
-     "end_time": "2026-08-23T02:23:00.986533+00:00",
+     "duration": 0.003626,
+     "end_time": "2026-09-02T16:02:29.385631+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:00.966425+00:00",
+     "start_time": "2026-09-02T16:02:29.382005+00:00",
      "status": "completed"
     },
     "tags": []
@@ -972,16 +989,16 @@
    "id": "dd78bb46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:01.029672Z",
-     "iopub.status.busy": "2026-08-23T02:23:01.029489Z",
-     "iopub.status.idle": "2026-08-23T02:23:01.397745Z",
-     "shell.execute_reply": "2026-08-23T02:23:01.396897Z"
+     "iopub.execute_input": "2026-09-02T16:02:29.414638Z",
+     "iopub.status.busy": "2026-09-02T16:02:29.414457Z",
+     "iopub.status.idle": "2026-09-02T16:02:29.814430Z",
+     "shell.execute_reply": "2026-09-02T16:02:29.813602Z"
     },
     "papermill": {
-     "duration": 0.396125,
-     "end_time": "2026-08-23T02:23:01.398436+00:00",
+     "duration": 0.400822,
+     "end_time": "2026-09-02T16:02:29.789514+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:01.002311+00:00",
+     "start_time": "2026-09-02T16:02:29.388692+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1085,10 +1102,10 @@
    "id": "a5d2899b",
    "metadata": {
     "papermill": {
-     "duration": 0.02401,
-     "end_time": "2026-08-23T02:23:01.437349+00:00",
+     "duration": 0.00296,
+     "end_time": "2026-09-02T16:02:29.795753+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:01.413339+00:00",
+     "start_time": "2026-09-02T16:02:29.792793+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1109,16 +1126,16 @@
    "id": "669e68e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:01.479313Z",
-     "iopub.status.busy": "2026-08-23T02:23:01.479137Z",
-     "iopub.status.idle": "2026-08-23T02:23:01.724817Z",
-     "shell.execute_reply": "2026-08-23T02:23:01.723810Z"
+     "iopub.execute_input": "2026-09-02T16:02:29.828428Z",
+     "iopub.status.busy": "2026-09-02T16:02:29.828271Z",
+     "iopub.status.idle": "2026-09-02T16:02:30.074466Z",
+     "shell.execute_reply": "2026-09-02T16:02:30.073674Z"
     },
     "papermill": {
-     "duration": 0.267338,
-     "end_time": "2026-08-23T02:23:01.725427+00:00",
+     "duration": 0.247976,
+     "end_time": "2026-09-02T16:02:30.046608+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:01.458089+00:00",
+     "start_time": "2026-09-02T16:02:29.798632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1234,10 +1251,10 @@
    "id": "ad97cc47",
    "metadata": {
     "papermill": {
-     "duration": 0.024168,
-     "end_time": "2026-08-23T02:23:01.763340+00:00",
+     "duration": 0.0033,
+     "end_time": "2026-09-02T16:02:30.053335+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:01.739172+00:00",
+     "start_time": "2026-09-02T16:02:30.050035+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1260,16 +1277,16 @@
    "id": "5123c14b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:01.820326Z",
-     "iopub.status.busy": "2026-08-23T02:23:01.820120Z",
-     "iopub.status.idle": "2026-08-23T02:23:02.103394Z",
-     "shell.execute_reply": "2026-08-23T02:23:02.102377Z"
+     "iopub.execute_input": "2026-09-02T16:02:30.092554Z",
+     "iopub.status.busy": "2026-09-02T16:02:30.092376Z",
+     "iopub.status.idle": "2026-09-02T16:02:30.390661Z",
+     "shell.execute_reply": "2026-09-02T16:02:30.389925Z"
     },
     "papermill": {
-     "duration": 0.311388,
-     "end_time": "2026-08-23T02:23:02.103953+00:00",
+     "duration": 0.301159,
+     "end_time": "2026-09-02T16:02:30.359366+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:01.792565+00:00",
+     "start_time": "2026-09-02T16:02:30.058207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1412,10 +1429,10 @@
    "id": "7779a4b3",
    "metadata": {
     "papermill": {
-     "duration": 0.018363,
-     "end_time": "2026-08-23T02:23:02.136614+00:00",
+     "duration": 0.003283,
+     "end_time": "2026-09-02T16:02:30.366447+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:02.118251+00:00",
+     "start_time": "2026-09-02T16:02:30.363164+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1440,16 +1457,16 @@
    "id": "32373861",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:02.182190Z",
-     "iopub.status.busy": "2026-08-23T02:23:02.182003Z",
-     "iopub.status.idle": "2026-08-23T02:23:02.392360Z",
-     "shell.execute_reply": "2026-08-23T02:23:02.391521Z"
+     "iopub.execute_input": "2026-09-02T16:02:30.406311Z",
+     "iopub.status.busy": "2026-09-02T16:02:30.406096Z",
+     "iopub.status.idle": "2026-09-02T16:02:30.635284Z",
+     "shell.execute_reply": "2026-09-02T16:02:30.634483Z"
     },
     "papermill": {
-     "duration": 0.230345,
-     "end_time": "2026-08-23T02:23:02.393014+00:00",
+     "duration": 0.231622,
+     "end_time": "2026-09-02T16:02:30.601248+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:02.162669+00:00",
+     "start_time": "2026-09-02T16:02:30.369626+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1541,10 +1558,10 @@
    "id": "1096f082",
    "metadata": {
     "papermill": {
-     "duration": 0.028219,
-     "end_time": "2026-08-23T02:23:02.441853+00:00",
+     "duration": 0.003477,
+     "end_time": "2026-09-02T16:02:30.608479+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:02.413634+00:00",
+     "start_time": "2026-09-02T16:02:30.605002+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1564,10 +1581,10 @@
    "id": "d759b48b",
    "metadata": {
     "papermill": {
-     "duration": 0.023527,
-     "end_time": "2026-08-23T02:23:02.490999+00:00",
+     "duration": 0.003163,
+     "end_time": "2026-09-02T16:02:30.614740+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:02.467472+00:00",
+     "start_time": "2026-09-02T16:02:30.611577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1628,16 +1645,16 @@
    "id": "b724ecca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:02.535883Z",
-     "iopub.status.busy": "2026-08-23T02:23:02.535703Z",
-     "iopub.status.idle": "2026-08-23T02:23:02.743885Z",
-     "shell.execute_reply": "2026-08-23T02:23:02.742881Z"
+     "iopub.execute_input": "2026-09-02T16:02:30.656898Z",
+     "iopub.status.busy": "2026-09-02T16:02:30.656747Z",
+     "iopub.status.idle": "2026-09-02T16:02:30.888594Z",
+     "shell.execute_reply": "2026-09-02T16:02:30.887709Z"
     },
     "papermill": {
-     "duration": 0.230586,
-     "end_time": "2026-08-23T02:23:02.744829+00:00",
+     "duration": 0.234159,
+     "end_time": "2026-09-02T16:02:30.851896+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:02.514243+00:00",
+     "start_time": "2026-09-02T16:02:30.617737+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1655,43 +1672,100 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 10 : les declarations des deux modules noirs, interrogees nativement.</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le module Sample : la distribution produit D^m et sa normalisation.</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_nonneg</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_nonneg<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}\n",
-       "<span class=\"w\">  </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X),<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight<span class=\"w\"> </span>D<span class=\"w\"> </span>S</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),\n",
-       "<span class=\"w\">  </span><span class=\"bp\">∑</span><span class=\"w\"> </span>S,<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight<span class=\"w\"> </span>D<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">1</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 10 : les declarations des modules exposes par le lake, interrogees nativement.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- La bibliotheque est ouverte par `open PacLearning` en cell[3], donc les noms resolvent ici</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- depuis le namespace PacLearning, et le defaut documente par #13958 (markup Unknown identifier</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- sur hoeffding_concentration) est depanne par l&#39;import explicite des sous-modules en tete de</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- session : le module racine n&#39;est pas construit par le lakefile (glob `.submodules`).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module Sample : la distribution produit D^m et sa normalisation.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_nonneg</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>sampleWeight_nonneg<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X),\n",
+       "<span class=\"w\">  </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>sampleWeight<span class=\"w\"> </span>D<span class=\"w\"> </span>S</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>sampleWeight_sum_one<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∑</span><span class=\"w\"> </span>S,<span class=\"w\"> </span>sampleWeight<span class=\"w\"> </span>D<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">1</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module Hoeffding : la borne de concentration parametrique sur une hypothese unique.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>hoeffding_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>hoeffding_concentration<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>(f<span class=\"w\"> </span>h<span class=\"w\"> </span>:<span class=\"w\"> </span>Hypothesis<span class=\"w\"> </span>X)\n",
+       "<span class=\"w\">  </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ},\n",
+       "<span class=\"w\">  </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{ε<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ},<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(sampleProb<span class=\"w\"> </span>D<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">|</span>empError<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>trueError<span class=\"w\"> </span>D<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"bp\">|</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Real<span class=\"bp\">.</span>exp<span class=\"w\"> </span>(<span class=\"bp\">-</span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span><span class=\"mi\">2</span>))</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module PacFiniteBound : le theoreme PAC du cas fini realisable.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>pac_finite_class_bound</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>pac_finite_class_bound<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>(D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X)<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}\n",
+       "<span class=\"w\">  </span>(Hs<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(Hypothesis<span class=\"w\"> </span>X))<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Hypothesis<span class=\"w\"> </span>X)<span class=\"w\"> </span>(ε<span class=\"w\"> </span>δ<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ),\n",
+       "<span class=\"w\">  </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>δ<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">      </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span><span class=\"bp\">↑</span>Hs<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">        </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">          </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(Real<span class=\"bp\">.</span>log<span class=\"w\"> </span><span class=\"bp\">↑</span>Hs<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>Real<span class=\"bp\">.</span>log<span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>δ))<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">            </span>(sampleProb<span class=\"w\"> </span>D<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>hyp<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Hs,<span class=\"w\"> </span>empError<span class=\"w\"> </span>f<span class=\"w\"> </span>hyp<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">∧</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>trueError<span class=\"w\"> </span>D<span class=\"w\"> </span>f<span class=\"w\"> </span>hyp)<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>δ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module UniformConcentration : la concentration uniforme sur une classe finie d&#39;hypotheses.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>uniform_concentration<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Hypothesis<span class=\"w\"> </span>X)\n",
+       "<span class=\"w\">  </span>(Hs<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(Hypothesis<span class=\"w\"> </span>X))<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ},\n",
+       "<span class=\"w\">  </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{ε<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ},\n",
+       "<span class=\"w\">      </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">        </span>(sampleProb<span class=\"w\"> </span>D<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Hs,<span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">|</span>empError<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>trueError<span class=\"w\"> </span>D<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"bp\">|</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span>\n",
+       "<span class=\"w\">          </span><span class=\"bp\">↑</span>Hs<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Real<span class=\"bp\">.</span>exp<span class=\"w\"> </span>(<span class=\"bp\">-</span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span><span class=\"mi\">2</span>)))</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Les certificats : de quoi chaque preuve depend-elle, exactement ?</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>uniform_concentration&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>hoeffding_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>hoeffding_concentration&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>pac_finite_class_bound</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>pac_finite_class_bound&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>uniform_concentration&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\\n-- Le module Sample : la distribution produit D^m et sa normalisation.\\n#check @PacLearning.sampleWeight_nonneg\\n#check @PacLearning.sampleWeight_sum_one\\n\\n-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\\n#print axioms PacLearning.sampleWeight_sum_one\\n#print axioms PacLearning.uniform_concentration\", \"env\": 8}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 10 : les declarations des modules exposes par le lake, interrogees nativement.\\n-- La bibliotheque est ouverte par `open PacLearning` en cell[3], donc les noms resolvent ici\\n-- depuis le namespace PacLearning, et le defaut documente par #13958 (markup Unknown identifier\\n-- sur hoeffding_concentration) est depanne par l'import explicite des sous-modules en tete de\\n-- session : le module racine n'est pas construit par le lakefile (glob `.submodules`).\\n\\n-- Module Sample : la distribution produit D^m et sa normalisation.\\n#check @PacLearning.sampleWeight_nonneg\\n#check @PacLearning.sampleWeight_sum_one\\n\\n-- Module Hoeffding : la borne de concentration parametrique sur une hypothese unique.\\n#check @PacLearning.hoeffding_concentration\\n\\n-- Module PacFiniteBound : le theoreme PAC du cas fini realisable.\\n#check @PacLearning.pac_finite_class_bound\\n\\n-- Module UniformConcentration : la concentration uniforme sur une classe finie d'hypotheses.\\n#check @PacLearning.uniform_concentration\\n\\n-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\\n#print axioms PacLearning.sampleWeight_sum_one\\n#print axioms PacLearning.hoeffding_concentration\\n#print axioms PacLearning.pac_finite_class_bound\\n#print axioms PacLearning.uniform_concentration\", \"env\": 8}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
        "            <code>{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ}\\n  (S : Fin n → X), 0 ≤ PacLearning.sampleWeight D S\"},\r\n",
+       "   \"@sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ} (S : Fin n → X),\\n  0 ≤ sampleWeight D S\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\\n  ∑ S, PacLearning.sampleWeight D S = 1\"},\r\n",
+       "   \"@sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\\n  ∑ S, sampleWeight D S = 1\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@hoeffding_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f h : Hypothesis X)\\n  {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ}, 0 < ε → (sampleProb D fun S => ε ≤ |empError f h S - trueError D f h|) ≤ 2 * Real.exp (-(2 * ↑n * ε ^ 2))\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@pac_finite_class_bound : ∀ {X : Type u_1} [inst : Fintype X] (D : PacLearning.Distribution X) {n : ℕ}\\n  (Hs : Finset (Hypothesis X)) (f : Hypothesis X) (ε δ : ℝ),\\n  0 < ε →\\n    0 < δ →\\n      0 < ↑Hs.card →\\n        0 < n →\\n          1 / ε * (Real.log ↑Hs.card + Real.log (1 / δ)) ≤ ↑n →\\n            (sampleProb D fun S => ∃ hyp ∈ Hs, empError f hyp S = 0 ∧ ε < trueError D f hyp) ≤ δ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 18, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 18, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f : Hypothesis X)\\n  (Hs : Finset (Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 21, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 21, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"'PacLearning.sampleWeight_sum_one' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 22, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 22, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.hoeffding_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 23, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 23, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.pac_finite_class_bound' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 24, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 24, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"'PacLearning.uniform_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
        " \"env\": 9}</code>\n",
@@ -1699,44 +1773,106 @@
        "    "
       ],
       "text/plain": [
-       "-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\n",
-       "-- Le module Sample : la distribution produit D^m et sa normalisation.\n",
+       "-- Section 10 : les declarations des modules exposes par le lake, interrogees nativement.\n",
+       "-- La bibliotheque est ouverte par `open PacLearning` en cell[3], donc les noms resolvent ici\n",
+       "-- depuis le namespace PacLearning, et le defaut documente par #13958 (markup Unknown identifier\n",
+       "-- sur hoeffding_concentration) est depanne par l'import explicite des sous-modules en tete de\n",
+       "-- session : le module racine n'est pas construit par le lakefile (glob `.submodules`).\n",
+       "\n",
+       "-- Module Sample : la distribution produit D^m et sa normalisation.\n",
        "#check @PacLearning.sampleWeight_nonneg\n",
-       "──────▶  @PacLearning.sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ}\n",
-       "  (S : Fin n → X), 0 ≤ PacLearning.sampleWeight D S\n",
+       "──────▶  @sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ} (S : Fin n → X),\n",
+       "  0 ≤ sampleWeight D S\n",
        "#check @PacLearning.sampleWeight_sum_one\n",
-       "──────▶  @PacLearning.sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\n",
-       "  ∑ S, PacLearning.sampleWeight D S = 1\n",
+       "──────▶  @sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\n",
+       "  ∑ S, sampleWeight D S = 1\n",
+       "\n",
+       "-- Module Hoeffding : la borne de concentration parametrique sur une hypothese unique.\n",
+       "#check @PacLearning.hoeffding_concentration\n",
+       "──────▶  @hoeffding_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f h : Hypothesis X)\n",
+       "  {n : ℕ},\n",
+       "  0 < n →\n",
+       "    ∀ {ε : ℝ}, 0 < ε → (sampleProb D fun S => ε ≤ |empError f h S - trueError D f h|) ≤ 2 * Real.exp (-(2 * ↑n * ε ^ 2))\n",
+       "\n",
+       "-- Module PacFiniteBound : le theoreme PAC du cas fini realisable.\n",
+       "#check @PacLearning.pac_finite_class_bound\n",
+       "──────▶  @pac_finite_class_bound : ∀ {X : Type u_1} [inst : Fintype X] (D : PacLearning.Distribution X) {n : ℕ}\n",
+       "  (Hs : Finset (Hypothesis X)) (f : Hypothesis X) (ε δ : ℝ),\n",
+       "  0 < ε →\n",
+       "    0 < δ →\n",
+       "      0 < ↑Hs.card →\n",
+       "        0 < n →\n",
+       "          1 / ε * (Real.log ↑Hs.card + Real.log (1 / δ)) ≤ ↑n →\n",
+       "            (sampleProb D fun S => ∃ hyp ∈ Hs, empError f hyp S = 0 ∧ ε < trueError D f hyp) ≤ δ\n",
+       "\n",
+       "-- Module UniformConcentration : la concentration uniforme sur une classe finie d'hypotheses.\n",
+       "#check @PacLearning.uniform_concentration\n",
+       "──────▶  @uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f : Hypothesis X)\n",
+       "  (Hs : Finset (Hypothesis X)) {n : ℕ},\n",
+       "  0 < n →\n",
+       "    ∀ {ε : ℝ},\n",
+       "      0 < ε →\n",
+       "        (sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤\n",
+       "          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\n",
        "\n",
        "-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\n",
        "#print axioms PacLearning.sampleWeight_sum_one\n",
        "──────▶  'PacLearning.sampleWeight_sum_one' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms PacLearning.hoeffding_concentration\n",
+       "──────▶  'PacLearning.hoeffding_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms PacLearning.pac_finite_class_bound\n",
+       "──────▶  'PacLearning.pac_finite_class_bound' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
        "#print axioms PacLearning.uniform_concentration\n",
        "──────▶  'PacLearning.uniform_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
        "--% env 9\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\\n-- Le module Sample : la distribution produit D^m et sa normalisation.\\n#check @PacLearning.sampleWeight_nonneg\\n#check @PacLearning.sampleWeight_sum_one\\n\\n-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\\n#print axioms PacLearning.sampleWeight_sum_one\\n#print axioms PacLearning.uniform_concentration\", \"env\": 8}\n",
+       "{\"cmd\": \"-- Section 10 : les declarations des modules exposes par le lake, interrogees nativement.\\n-- La bibliotheque est ouverte par `open PacLearning` en cell[3], donc les noms resolvent ici\\n-- depuis le namespace PacLearning, et le defaut documente par #13958 (markup Unknown identifier\\n-- sur hoeffding_concentration) est depanne par l'import explicite des sous-modules en tete de\\n-- session : le module racine n'est pas construit par le lakefile (glob `.submodules`).\\n\\n-- Module Sample : la distribution produit D^m et sa normalisation.\\n#check @PacLearning.sampleWeight_nonneg\\n#check @PacLearning.sampleWeight_sum_one\\n\\n-- Module Hoeffding : la borne de concentration parametrique sur une hypothese unique.\\n#check @PacLearning.hoeffding_concentration\\n\\n-- Module PacFiniteBound : le theoreme PAC du cas fini realisable.\\n#check @PacLearning.pac_finite_class_bound\\n\\n-- Module UniformConcentration : la concentration uniforme sur une classe finie d'hypotheses.\\n#check @PacLearning.uniform_concentration\\n\\n-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\\n#print axioms PacLearning.sampleWeight_sum_one\\n#print axioms PacLearning.hoeffding_concentration\\n#print axioms PacLearning.pac_finite_class_bound\\n#print axioms PacLearning.uniform_concentration\", \"env\": 8}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ}\\n  (S : Fin n → X), 0 ≤ PacLearning.sampleWeight D S\"},\r\n",
+       "   \"@sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ} (S : Fin n → X),\\n  0 ≤ sampleWeight D S\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
        "   \"data\":\r\n",
-       "   \"@PacLearning.sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\\n  ∑ S, PacLearning.sampleWeight D S = 1\"},\r\n",
+       "   \"@sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\\n  ∑ S, sampleWeight D S = 1\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@hoeffding_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f h : Hypothesis X)\\n  {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ}, 0 < ε → (sampleProb D fun S => ε ≤ |empError f h S - trueError D f h|) ≤ 2 * Real.exp (-(2 * ↑n * ε ^ 2))\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@pac_finite_class_bound : ∀ {X : Type u_1} [inst : Fintype X] (D : PacLearning.Distribution X) {n : ℕ}\\n  (Hs : Finset (Hypothesis X)) (f : Hypothesis X) (ε δ : ℝ),\\n  0 < ε →\\n    0 < δ →\\n      0 < ↑Hs.card →\\n        0 < n →\\n          1 / ε * (Real.log ↑Hs.card + Real.log (1 / δ)) ≤ ↑n →\\n            (sampleProb D fun S => ∃ hyp ∈ Hs, empError f hyp S = 0 ∧ ε < trueError D f hyp) ≤ δ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 18, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 18, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f : Hypothesis X)\\n  (Hs : Finset (Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |empError f h S - trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 21, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 21, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"'PacLearning.sampleWeight_sum_one' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"pos\": {\"line\": 22, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 22, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.hoeffding_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 23, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 23, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.pac_finite_class_bound' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 24, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 24, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"'PacLearning.uniform_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
        " \"env\": 9}"
@@ -1750,7 +1886,8 @@
     "-- Section 10 : les declarations des modules exposes par le lake, interrogees nativement.\n",
     "-- La bibliotheque est ouverte par `open PacLearning` en cell[3], donc les noms resolvent ici\n",
     "-- depuis le namespace PacLearning, et le defaut documente par #13958 (markup Unknown identifier\n",
-    "-- sur hoeffding_concentration sous REPL casse) est depanne par cet alignement.\n",
+    "-- sur hoeffding_concentration) est depanne par l'import explicite des sous-modules en tete de\n",
+    "-- session : le module racine n'est pas construit par le lakefile (glob `.submodules`).\n",
     "\n",
     "-- Module Sample : la distribution produit D^m et sa normalisation.\n",
     "#check @PacLearning.sampleWeight_nonneg\n",
@@ -1776,9 +1913,18 @@
    "cell_type": "markdown",
    "id": "e0cf8eed",
    "metadata": {
+    "papermill": {
+     "duration": 0.004096,
+     "end_time": "2026-09-02T16:02:30.860212+00:00",
+     "exception": false,
+     "start_time": "2026-09-02T16:02:30.856116+00:00",
+     "status": "completed"
+    },
     "tags": []
    },
-   "source": "**Pourquoi cette section n'interroge pas encore `Hoeffding.lean` ni `PacFiniteBound.lean`.** Les deux théorèmes existent dans le lake — `hoeffding_concentration` ([Hoeffding.lean:318](../../learning_theory_lean/PacLearning/Hoeffding.lean)) et `pac_finite_class_bound` ([PacFiniteBound.lean:377](../../learning_theory_lean/PacLearning/PacFiniteBound.lean)) — mais toute ré-exécution du notebook via le kernel `lean4-wsl` est pour l'instant impossible : le diagnostic à contrôle positif (`scripts/notebook_tools/check_lean4_wsl_repl.py`) rend `REPL_STDLIB_BROKEN` — même `#eval 2+2` échoue sur `Unknown constant 'OfNat'`, sur les trois chemins sondés, y compris via `lake env repl` (toolchain résolue `v4.32.1`). C'est la pathologie documentée sur l'issue #11874 : le binaire `repl` ne trouve sa stdlib que si le toolchain résolu par le répertoire courant correspond à sa version de compilation.\n\nLes directives différées — les briques interrogation + certificats des deux modules — à ré-exécuter dès que le kernel est réparé, suivi sur #13958 :\n\n```lean\n#check @PacLearning.hoeffding_concentration\n#check @PacLearning.pac_finite_class_bound\n#print axioms PacLearning.hoeffding_concentration\n#print axioms PacLearning.pac_finite_class_bound\n```"
+   "source": [
+    "**Vérification native de `Hoeffding.lean` et `PacFiniteBound.lean`.** La cellule précédente interroge désormais directement `PacLearning.hoeffding_concentration` et `PacLearning.pac_finite_class_bound`, puis affiche leurs certificats avec `#print axioms`. L'exécution complète sous le kernel `lean4-wsl`, depuis le lake `learning_theory_lean` et son toolchain v4.32.1, confirme donc dans ce notebook les quatre déclarations de la section 10 : `sampleWeight_sum_one`, `hoeffding_concentration`, `pac_finite_class_bound` et `uniform_concentration`."
+   ]
   },
   {
    "cell_type": "code",
@@ -1786,16 +1932,16 @@
    "id": "7e6302d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:02.787503Z",
-     "iopub.status.busy": "2026-08-23T02:23:02.787322Z",
-     "iopub.status.idle": "2026-08-23T02:23:03.015508Z",
-     "shell.execute_reply": "2026-08-23T02:23:03.014484Z"
+     "iopub.execute_input": "2026-09-02T16:02:30.906565Z",
+     "iopub.status.busy": "2026-09-02T16:02:30.906399Z",
+     "iopub.status.idle": "2026-09-02T16:02:31.165392Z",
+     "shell.execute_reply": "2026-09-02T16:02:31.164252Z"
     },
     "papermill": {
-     "duration": 0.254178,
-     "end_time": "2026-08-23T02:23:03.016138+00:00",
+     "duration": 0.261766,
+     "end_time": "2026-09-02T16:02:31.125738+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:02.761960+00:00",
+     "start_time": "2026-09-02T16:02:30.863972+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1818,11 +1964,11 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>tailBound<span class=\"w\"> </span>(cardH<span class=\"w\"> </span>n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(eps<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>cardH<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>exp<span class=\"w\"> </span>(<span class=\"bp\">-</span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps))</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\">   </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- ponctuel : 2*exp(-2) ~ 0.27</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.270671</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\">  </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- classe de 10 : ~2.7, borne vide (&gt; 1)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">2.706706</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- classe de 100 : ~27, le facteur |Hs| se paie comptant</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">27.067057</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">415</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- ~0.05 : la borne retombe sous delta = 5%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.049703</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">600</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">   </span><span class=\"c1\">-- queue exponentielle : ~0.0012</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.001229</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\">   </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- ponctuel : 2*exp(-2) ~ 0.27</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.270671</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\">  </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- classe de 10 : ~2.7, borne vide (&gt; 1)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">2.706706</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1e\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- classe de 100 : ~27, le facteur |Hs| se paie comptant</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">27.067057</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1f\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1f\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">415</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- ~0.05 : la borne retombe sous delta = 5%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.049703</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk20\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk20\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">600</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">   </span><span class=\"c1\">-- queue exponentielle : ~0.0012</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.001229</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -1923,25 +2069,47 @@
    "id": "0e241a04",
    "metadata": {
     "papermill": {
-     "duration": 0.01633,
-     "end_time": "2026-08-23T02:23:03.044826+00:00",
+     "duration": 0.004126,
+     "end_time": "2026-09-02T16:02:31.134337+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.028496+00:00",
+     "start_time": "2026-09-02T16:02:31.130211+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "**Lecture du prix de l'uniformité.** À `n = 100` exemples et `ε = 0.1`, l'hypothèse\nseule porte une queue d'environ 0.27 : c'est Hoeffding ponctuel, déjà lâche. Dix\nhypothèses : environ 2.7 — la borne dépasse 1 et n'enseigne plus rien ; cent :\nenviron 27. Le facteur `|Hs|` se paie comptant, et c'est exactement ce que la\ncomplexité d'échantillon traduit en `ln |H|` : il faut `n ≈ ln(2|H|/δ)/(2ε²)`\nexemples pour que le produit `|H| · exp(−2nε²)` passe sous `δ`. À `|Hs| = 100`,\n`δ = 5%` : `n = 415` suffit (quatrième ligne, rendu `0.049703`), et `n = 600`\nl'écrase (cinquième ligne, rendu `0.001229`) — la queue exponentielle gagne\ntoujours à la fin. La comparaison avec la\nsection 8 est le recto de la même feuille : là, la cellule de complexité résout le\nbudget `m` requis ; ici, on évalue la borne résiduelle à `m` donné.\n\n**Réalisable contre agnostique, en nombres.** Les deux régimes ne paient pas le même\nprix par chiffre : pour `|H| = 100`, `ε = 0.1`, `δ = 5%`, le budget réalisable est\n`ln(|H|/δ)/ε ≈ 76` exemples, l'agnostique `ln(2|H|/δ)/(2ε²) ≈ 415` — un rapport de\n5.5. L'écart n'est pas une subtilité : le réalisable profite d'une concentration\n**géométrique** `(1−μ)^n ≤ e^{−εn}` (l'hypothèse cible est parfaitement apprise, il\nne reste que le risque qu'une mauvaise hypothèse paraisse bonne), l'agnostique paie\nla concentration **quadratique** de Hoeffding sur les deux directions de la\ndéviation. C'est toute la différence entre « il existe une hypothèse parfaite » et\n« on ne garantit que la meilleure disponible »."
+   "source": [
+    "**Lecture du prix de l'uniformité.** À `n = 100` exemples et `ε = 0.1`, l'hypothèse\n",
+    "seule porte une queue d'environ 0.27 : c'est Hoeffding ponctuel, déjà lâche. Dix\n",
+    "hypothèses : environ 2.7 — la borne dépasse 1 et n'enseigne plus rien ; cent :\n",
+    "environ 27. Le facteur `|Hs|` se paie comptant, et c'est exactement ce que la\n",
+    "complexité d'échantillon traduit en `ln |H|` : il faut `n ≈ ln(2|H|/δ)/(2ε²)`\n",
+    "exemples pour que le produit `|H| · exp(−2nε²)` passe sous `δ`. À `|Hs| = 100`,\n",
+    "`δ = 5%` : `n = 415` suffit (quatrième ligne, rendu `0.049703`), et `n = 600`\n",
+    "l'écrase (cinquième ligne, rendu `0.001229`) — la queue exponentielle gagne\n",
+    "toujours à la fin. La comparaison avec la\n",
+    "section 8 est le recto de la même feuille : là, la cellule de complexité résout le\n",
+    "budget `m` requis ; ici, on évalue la borne résiduelle à `m` donné.\n",
+    "\n",
+    "**Réalisable contre agnostique, en nombres.** Les deux régimes ne paient pas le même\n",
+    "prix par chiffre : pour `|H| = 100`, `ε = 0.1`, `δ = 5%`, le budget réalisable est\n",
+    "`ln(|H|/δ)/ε ≈ 76` exemples, l'agnostique `ln(2|H|/δ)/(2ε²) ≈ 415` — un rapport de\n",
+    "5.5. L'écart n'est pas une subtilité : le réalisable profite d'une concentration\n",
+    "**géométrique** `(1−μ)^n ≤ e^{−εn}` (l'hypothèse cible est parfaitement apprise, il\n",
+    "ne reste que le risque qu'une mauvaise hypothèse paraisse bonne), l'agnostique paie\n",
+    "la concentration **quadratique** de Hoeffding sur les deux directions de la\n",
+    "déviation. C'est toute la différence entre « il existe une hypothèse parfaite » et\n",
+    "« on ne garantit que la meilleure disponible »."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "d2ef4b1c",
    "metadata": {
     "papermill": {
-     "duration": 0.015803,
-     "end_time": "2026-08-23T02:23:03.080303+00:00",
+     "duration": 0.003789,
+     "end_time": "2026-09-02T16:02:31.142028+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.064500+00:00",
+     "start_time": "2026-09-02T16:02:31.138239+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1959,16 +2127,16 @@
    "id": "64d7074a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:03.113811Z",
-     "iopub.status.busy": "2026-08-23T02:23:03.113618Z",
-     "iopub.status.idle": "2026-08-23T02:23:03.328224Z",
-     "shell.execute_reply": "2026-08-23T02:23:03.327405Z"
+     "iopub.execute_input": "2026-09-02T16:02:31.194400Z",
+     "iopub.status.busy": "2026-09-02T16:02:31.194226Z",
+     "iopub.status.idle": "2026-09-02T16:02:31.406310Z",
+     "shell.execute_reply": "2026-09-02T16:02:31.405382Z"
     },
     "papermill": {
-     "duration": 0.232675,
-     "end_time": "2026-08-23T02:23:03.328839+00:00",
+     "duration": 0.218067,
+     "end_time": "2026-09-02T16:02:31.363637+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.096164+00:00",
+     "start_time": "2026-09-02T16:02:31.145570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1988,7 +2156,7 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : esperance bornee</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : completer la preuve</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>expectBounded<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk21\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk21\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>expectBounded<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (h<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>f<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>:<span class=\"w\"> </span>expect<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>c<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice a completer (voir indice ci-dessus)</span></span></span></pre>\n",
@@ -2005,7 +2173,7 @@
        " [{\"proofState\": 0,\r\n",
        "   \"pos\": {\"line\": 5, \"column\": 2},\r\n",
        "   \"goal\":\r\n",
-       "   \"f : Bool → Float\\nc : Float\\nh : ∀ (b : Bool), f b ≤ c\\n⊢ expect f ≤ c\",\r\n",
+       "   \"f : Bool → Float\\nc : Float\\nh : ∀ (b : Bool), f b ≤ c\\n⊢ _root_.expect f ≤ c\",\r\n",
        "   \"endPos\": {\"line\": 5, \"column\": 7}}],\r\n",
        " \"messages\":\r\n",
        " [{\"severity\": \"warning\",\r\n",
@@ -2034,7 +2202,7 @@
        " [{\"proofState\": 0,\r\n",
        "   \"pos\": {\"line\": 5, \"column\": 2},\r\n",
        "   \"goal\":\r\n",
-       "   \"f : Bool → Float\\nc : Float\\nh : ∀ (b : Bool), f b ≤ c\\n⊢ expect f ≤ c\",\r\n",
+       "   \"f : Bool → Float\\nc : Float\\nh : ∀ (b : Bool), f b ≤ c\\n⊢ _root_.expect f ≤ c\",\r\n",
        "   \"endPos\": {\"line\": 5, \"column\": 7}}],\r\n",
        " \"messages\":\r\n",
        " [{\"severity\": \"warning\",\r\n",
@@ -2062,10 +2230,10 @@
    "id": "90ed226c",
    "metadata": {
     "papermill": {
-     "duration": 0.016006,
-     "end_time": "2026-08-23T02:23:03.361212+00:00",
+     "duration": 0.004507,
+     "end_time": "2026-09-02T16:02:31.373074+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.345206+00:00",
+     "start_time": "2026-09-02T16:02:31.368567+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2084,16 +2252,16 @@
    "id": "8f85a3ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:03.396247Z",
-     "iopub.status.busy": "2026-08-23T02:23:03.396067Z",
-     "iopub.status.idle": "2026-08-23T02:23:03.602042Z",
-     "shell.execute_reply": "2026-08-23T02:23:03.601278Z"
+     "iopub.execute_input": "2026-09-02T16:02:31.426505Z",
+     "iopub.status.busy": "2026-09-02T16:02:31.426314Z",
+     "iopub.status.idle": "2026-09-02T16:02:31.651698Z",
+     "shell.execute_reply": "2026-09-02T16:02:31.650727Z"
     },
     "papermill": {
-     "duration": 0.225279,
-     "end_time": "2026-08-23T02:23:03.602830+00:00",
+     "duration": 0.22924,
+     "end_time": "2026-09-02T16:02:31.606439+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.377551+00:00",
+     "start_time": "2026-09-02T16:02:31.377199+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2113,7 +2281,7 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : linearite de l&#39;esperance</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>expectAdd<span class=\"w\"> </span>(f<span class=\"w\"> </span>g<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk22\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk22\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>expectAdd<span class=\"w\"> </span>(f<span class=\"w\"> </span>g<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    expect<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>f<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>g<span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>g<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice a completer</span></span></span></pre>\n",
@@ -2130,7 +2298,7 @@
        " [{\"proofState\": 1,\r\n",
        "   \"pos\": {\"line\": 5, \"column\": 2},\r\n",
        "   \"goal\":\r\n",
-       "   \"f g : Bool → Float\\n⊢ (expect fun b => f b + g b) = expect f + expect g\",\r\n",
+       "   \"f g : Bool → Float\\n⊢ (_root_.expect fun b => f b + g b) = _root_.expect f + _root_.expect g\",\r\n",
        "   \"endPos\": {\"line\": 5, \"column\": 7}}],\r\n",
        " \"messages\":\r\n",
        " [{\"severity\": \"warning\",\r\n",
@@ -2159,7 +2327,7 @@
        " [{\"proofState\": 1,\r\n",
        "   \"pos\": {\"line\": 5, \"column\": 2},\r\n",
        "   \"goal\":\r\n",
-       "   \"f g : Bool → Float\\n⊢ (expect fun b => f b + g b) = expect f + expect g\",\r\n",
+       "   \"f g : Bool → Float\\n⊢ (_root_.expect fun b => f b + g b) = _root_.expect f + _root_.expect g\",\r\n",
        "   \"endPos\": {\"line\": 5, \"column\": 7}}],\r\n",
        " \"messages\":\r\n",
        " [{\"severity\": \"warning\",\r\n",
@@ -2187,10 +2355,10 @@
    "id": "35069cac",
    "metadata": {
     "papermill": {
-     "duration": 0.019198,
-     "end_time": "2026-08-23T02:23:03.641365+00:00",
+     "duration": 0.004321,
+     "end_time": "2026-09-02T16:02:31.615139+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.622167+00:00",
+     "start_time": "2026-09-02T16:02:31.610818+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2208,16 +2376,16 @@
    "id": "bb413c79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T02:23:03.688055Z",
-     "iopub.status.busy": "2026-08-23T02:23:03.687872Z",
-     "iopub.status.idle": "2026-08-23T02:23:03.888443Z",
-     "shell.execute_reply": "2026-08-23T02:23:03.887635Z"
+     "iopub.execute_input": "2026-09-02T16:02:31.671133Z",
+     "iopub.status.busy": "2026-09-02T16:02:31.670965Z",
+     "iopub.status.idle": "2026-09-02T16:02:31.878461Z",
+     "shell.execute_reply": "2026-09-02T16:02:31.877735Z"
     },
     "papermill": {
-     "duration": 0.222993,
-     "end_time": "2026-08-23T02:23:03.889014+00:00",
+     "duration": 0.211357,
+     "end_time": "2026-09-02T16:02:31.830735+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.666021+00:00",
+     "start_time": "2026-09-02T16:02:31.619378+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2238,7 +2406,7 @@
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : capacite maximale sous budget</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : remplacer 0 par le calcul (budget 0.05 / delta0 0.001)</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>kMax<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1e\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>kMax<span class=\"w\">   </span><span class=\"c1\">-- doit rendre 50</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk23\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk23\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>kMax<span class=\"w\">   </span><span class=\"c1\">-- doit rendre 50</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 13</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -2291,10 +2459,10 @@
    "id": "1b5b7d4e",
    "metadata": {
     "papermill": {
-     "duration": 0.025931,
-     "end_time": "2026-08-23T02:23:03.931607+00:00",
+     "duration": 0.005383,
+     "end_time": "2026-09-02T16:02:31.840945+00:00",
      "exception": false,
-     "start_time": "2026-08-23T02:23:03.905676+00:00",
+     "start_time": "2026-09-02T16:02:31.835562+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2340,14 +2508,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.348895,
-   "end_time": "2026-08-23T02:23:07.010040+00:00",
+   "duration": 381.443681,
+   "end_time": "2026-09-02T16:02:32.525249+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "2.8b-Theorie-PAC-Lean.ipynb",
-   "output_path": "2.8b-Theorie-PAC-Lean.ipynb",
+   "input_path": "D:\\dev\\CoursIA-worktree-14191\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\02-ML-Cours\\2.8b-Theorie-PAC-Lean.ipynb",
+   "output_path": "D:\\dev\\CoursIA-worktree-14191\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\02-ML-Cours\\2.8b-Theorie-PAC-Lean_output.ipynb",
    "parameters": {},
-   "start_time": "2026-08-23T02:22:33.661145+00:00",
+   "start_time": "2026-09-02T15:56:11.081568+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb
@@ -523,13 +523,13 @@
    "source": [
     "## Comment vérifier sur main ?\n",
     "\n",
-    "Les vérifications mécaniques étaient historiquement dans ce notebook : existence des théorèmes cités et `sorry = 0` dans le lake. Elles sont désormais portées par les instruments suivants :\n",
+    "Les vérifications mécaniques du triptyque sont portées par les instruments suivants :\n",
     "\n",
-    "- **Existence des théorèmes** : vérifiée par les `#check` explicites dans [2.8d](2.8d-Lean-Novikoff-Convergence.ipynb) (`PerceptronRun.novikoff_mistake_bound`, `tightnessRun_saturates`, ...) et [2.8b](2.8b-Theorie-PAC-Lean.ipynb) (`PacLearning.uniform_concentration`, `PacLearning.sampleWeight_nonneg`, `PacLearning.sampleWeight_sum_one`, ...). Les théorèmes `hoeffding_concentration` et `pac_finite_class_bound` existent dans le lake (PacLearning/Hoeffding.lean:318, PacLearning/PacFiniteBound.lean:377) mais ne sont **pas** interrogés par les `#check` du notebook 2.8b — la note antérieure les attribuait par erreur (#13862). Vérification native : `#print axioms PacLearning.sampleWeight_sum_one` + `#print axioms PacLearning.uniform_concentration`.\n",
-    "- **Zéro `sorry` réel dans le lake** : porté par l'organe `python scripts/lean/count_code_sorry.py --json` (champ `distinct_code_sorry`), mesuré en CI par le job `proof-integrity`. **Pas de `grep -c sorry`** : il sur-compte la prose (docstrings, commentaires).\n",
-    "- **Pas de `native_decide` / `sorryAx` dans le chemin des théorèmes cités** : porté par le job CI `lean-axiom.yml` (catégorie `forbidden`, pas seulement `sorry`).\n",
+    "- **Existence des théorèmes** : les `#check` explicites de [2.8d](2.8d-Lean-Novikoff-Convergence.ipynb) couvrent `PerceptronRun.novikoff_mistake_bound`, `tightnessRun_saturates` et leurs compagnons. Ceux de [2.8b](2.8b-Theorie-PAC-Lean.ipynb) couvrent notamment `PacLearning.sampleWeight_sum_one`, `PacLearning.hoeffding_concentration`, `PacLearning.pac_finite_class_bound` et `PacLearning.uniform_concentration`. La même cellule 2.8b exécute leurs `#print axioms` afin d'exposer les certificats utilisés.\n",
+    "- **Zéro `sorry` réel dans le lake** : `python scripts/lean/count_code_sorry.py --json` publie le champ `distinct_code_sorry`, mesuré en CI par le job `proof-integrity`. **Pas de `grep -c sorry`** : il sur-compte la prose, les docstrings et les commentaires.\n",
+    "- **Pas de `native_decide` / `sorryAx` dans le chemin des théorèmes cités** : le job CI `lean-axiom.yml` contrôle la catégorie `forbidden`, pas seulement `sorry`.\n",
     "\n",
-    "Pour une **revue complète** du triplet BORNE/TÉMOIN/CONCENTRATION sur le lake courant, suivre les **Voir aussi** internes de chaque sibling.\n"
+    "Pour une **revue complète** du triplet BORNE/TÉMOIN/CONCENTRATION sur le lake courant, exécuter 2.8b depuis `MyIA.AI.Notebooks/ML/learning_theory_lean` avec le kernel `lean4-wsl`, puis suivre les **Voir aussi** internes de chaque sibling."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2025:CoursIA — prev: MED/notebook-lean #14457

Closes #14191

## Cause racine : le « fix » #13958 ne pouvait pas fonctionner

Le prétendu dépannage #13958 importait le **module racine** `PacLearning`. Or le lakefile de `learning_theory_lean` ne le construit pas :

```lean
@[default_target]
lean_lib «PacLearning» where
  globs := #[.submodules `PacLearning, `PacLearning_en]
```

Le glob `.submodules` exclut la racine — `.lake/build/lib/lean/` ne contient que `PacLearning_en.olean` et `Perceptron_en.olean`, jamais `PacLearning.olean`. Donc `import PacLearning` ne résout pas : l'exécution rendait `❌ unknown namespace PacLearning` puis `Unknown identifier` sur toutes les déclarations. Les sorties committées prédataient leurs sources (l'ancienne cellule « deux modules noirs ») : la version #13958 n'avait jamais été exécutée avec succès.

**Fix** : import explicite des six sous-modules réellement référencés par le notebook (`Data`, `Sample`, `Concentration`, `Hoeffding`, `PacFiniteBound`, `UniformConcentration`) + correction du commentaire de section 10 qui attribuait le dépannage au mauvais mécanisme.

## Sorties réelles (acceptance #14191)

Run All kernel `lean4-wsl` depuis le lake `learning_theory_lean` (toolchain v4.32.1), 2 exécutions complètes (318 s puis 381 s après correction du commentaire), sorties non éditées à la main :

```
#check @PacLearning.hoeffding_concentration
──────▶  @hoeffding_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (f h : Hypothesis X)
  {n : ℕ},
  0 < n →
    ∀ {ε : ℝ}, 0 < ε → (sampleProb D fun S => ε ≤ |empError f h S - trueError D f h|) ≤ 2 * Real.exp (-(2 * ↑n * ε ^ 2))

#check @PacLearning.pac_finite_class_bound
──────▶  @pac_finite_class_bound : ∀ {X : Type u_1} [inst : Fintype X] (D : PacLearning.Distribution X) {n : ℕ}
  (Hs : Finset (Hypothesis X)) (f : Hypothesis X) (ε δ : ℝ),
  0 < ε →
    0 < δ →
      0 < ↑Hs.card →
        0 < n →
          1 / ε * (Real.log ↑Hs.card + Real.log (1 / δ)) ≤ ↑n →
            (sampleProb D fun S => ∃ hyp ∈ Hs, empError f hyp S = 0 ∧ ε < trueError D f hyp) ≤ δ

#print axioms PacLearning.hoeffding_concentration
──────▶  'PacLearning.hoeffding_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]
#print axioms PacLearning.pac_finite_class_bound
──────▶  'PacLearning.pac_finite_class_bound' depends on axioms: [propext, Classical.choice, Quot.sound]
```

Les quatre certificats de la cellule section 10 (avec `sampleWeight_sum_one` et `uniform_concentration`, déjà interrogés avant) rendent tous `[propext, Classical.choice, Quot.sound]` — aucun `sorryAx`, aucun `native_decide`.

## execution_count

14/14 cellules code `execution_count` non nul, 0 output d'erreur, 0 markup `❌` sur l'ensemble des sorties.

## Diff de la note 2.8c

```diff
commit 35d997fbf86db0b8129e3f8881dc4be5da5a4c64
Author: jsboige <jsboige@gmail.com>
Date:   Wed Sep 2 18:04:30 2026 +0200

    fix(lean,#14191): notebooks 2.8b/2.8c executes sous kernel lean4-wsl avec certificats natifs
    
    Le pretendu depannage #13958 (import racine `PacLearning`) ne peut pas
    resoudre : le lakefile ne construit pas le module racine (glob
    `.submodules` l'exclut, seul `PacLearning_en` est construit en racine).
    Les outputs committes predataient leurs sources et n'avaient jamais
    verifie la section 10.
    
    2.8b : import explicite des six sous-modules reels (Data, Sample,
    Concentration, Hoeffding, PacFiniteBound, UniformConcentration),
    commentaire de section 10 corrige, Run All kernel lean4-wsl depuis le
    lake learning_theory_lean. 14/14 cellules executees, 0 erreur, les cinq
    #check rendent leurs signatures completes et les quatre #print axioms
    rendent [propext, Classical.choice, Quot.sound] (sampleWeight_sum_one,
    hoeffding_concentration, pac_finite_class_bound, uniform_concentration).
    Aucun sorryAx, aucun native_decide. Sources : 3 cellules modifiees
    uniquement (4c6d5c61, b724ecca, e0cf8eed).
    
    2.8c : prose de verification alignee (les #check/#print axioms vivent
    dans la cellule section 10 de 2.8b, instruments count_code_sorry +
    lean-axiom.yml conserves).
    
    Invariant lake : count_code_sorry --lake learning_theory_lean ->
    distinct_code_sorry=0 (37 modules Lean du lake, 0 sorry reel, inchange).
    
    Co-Authored-By: Claude-Code <noreply@anthropic.com>

diff --git a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb
index f5f5ddbd7..270fcc6fe 100644
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb
@@ -523,13 +523,13 @@
    "source": [
     "## Comment vérifier sur main ?\n",
     "\n",
-    "Les vérifications mécaniques étaient historiquement dans ce notebook : existence des théorèmes cités et `sorry = 0` dans le lake. Elles sont désormais portées par les instruments suivants :\n",
+    "Les vérifications mécaniques du triptyque sont portées par les instruments suivants :\n",
     "\n",
-    "- **Existence des théorèmes** : vérifiée par les `#check` explicites dans [2.8d](2.8d-Lean-Novikoff-Convergence.ipynb) (`PerceptronRun.novikoff_mistake_bound`, `tightnessRun_saturates`, ...) et [2.8b](2.8b-Theorie-PAC-Lean.ipynb) (`PacLearning.uniform_concentration`, `PacLearning.sampleWeight_nonneg`, `PacLearning.sampleWeight_sum_one`, ...). Les théorèmes `hoeffding_concentration` et `pac_finite_class_bound` existent dans le lake (PacLearning/Hoeffding.lean:318, PacLearning/PacFiniteBound.lean:377) mais ne sont **pas** interrogés par les `#check` du notebook 2.8b — la note antérieure les attribuait par erreur (#13862). Vérification native : `#print axioms PacLearning.sampleWeight_sum_one` + `#print axioms PacLearning.uniform_concentration`.\n",
-    "- **Zéro `sorry` réel dans le lake** : porté par l'organe `python scripts/lean/count_code_sorry.py --json` (champ `distinct_code_sorry`), mesuré en CI par le job `proof-integrity`. **Pas de `grep -c sorry`** : il sur-compte la prose (docstrings, commentaires).\n",
-    "- **Pas de `native_decide` / `sorryAx` dans le chemin des théorèmes cités** : porté par le job CI `lean-axiom.yml` (catégorie `forbidden`, pas seulement `sorry`).\n",
+    "- **Existence des théorèmes** : les `#check` explicites de [2.8d](2.8d-Lean-Novikoff-Convergence.ipynb) couvrent `PerceptronRun.novikoff_mistake_bound`, `tightnessRun_saturates` et leurs compagnons. Ceux de [2.8b](2.8b-Theorie-PAC-Lean.ipynb) couvrent notamment `PacLearning.sampleWeight_sum_one`, `PacLearning.hoeffding_concentration`, `PacLearning.pac_finite_class_bound` et `PacLearning.uniform_concentration`. La même cellule 2.8b exécute leurs `#print axioms` afin d'exposer les certificats utilisés.\n",
+    "- **Zéro `sorry` réel dans le lake** : `python scripts/lean/count_code_sorry.py --json` publie le champ `distinct_code_sorry`, mesuré en CI par le job `proof-integrity`. **Pas de `grep -c sorry`** : il sur-compte la prose, les docstrings et les commentaires.\n",
+    "- **Pas de `native_decide` / `sorryAx` dans le chemin des théorèmes cités** : le job CI `lean-axiom.yml` contrôle la catégorie `forbidden`, pas seulement `sorry`.\n",
     "\n",
-    "Pour une **revue complète** du triplet BORNE/TÉMOIN/CONCENTRATION sur le lake courant, suivre les **Voir aussi** internes de chaque sibling.\n"
+    "Pour une **revue complète** du triplet BORNE/TÉMOIN/CONCENTRATION sur le lake courant, exécuter 2.8b depuis `MyIA.AI.Notebooks/ML/learning_theory_lean` avec le kernel `lean4-wsl`, puis suivre les **Voir aussi** internes de chaque sibling."
    ]
   }
  ],

```

## Validation

- Exécution canonique : `python scripts/notebook_tools/notebook_tools.py execute …2.8b-Theorie-PAC-Lean.ipynb --kernel lean4-wsl --cwd …/learning_theory_lean` — SUCCESS 2×.
- `python scripts/lean/count_code_sorry.py --lake MyIA.AI.Notebooks/ML/learning_theory_lean --json` → `distinct_code_sorry: 0` (37 modules Lean du lake, inchangés ; les 2 `sorry` du notebook sont les exercices pédagogiques embarqués, hors périmètre lake).
- `git diff --check` propre ; garde markdown locale `detect_markdown_rendering.py --check --baseline …` → OK ; aucune paire twin enregistrée sur ces deux notebooks.
- Sources pédagogiques : seules 3 cellules source de 2.8b modifiées (`4c6d5c61` imports, `b724ecca` commentaire, `e0cf8eed` prose) ; le reste du diff est constitué des sorties rafraîchies et de la normalisation autorisée des deux champs `metadata.papermill.input_path` / `output_path` aux basenames.

Worktree : `D:/dev/CoursIA-worktree-14191` · branche `issue-14191-pac-lean-notebooks` · base grain `21c2a324c`.

md-content-loss: reecriture assumee -- MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb cell 24 : la prose d'avant-fix expliquait pourquoi la section n'interrogeait PAS encore Hoeffding.lean / PacFiniteBound.lean (etat casse herite de #13958, imports racine non resolus) ; le fix rendant la verification native fonctionnelle, cette explication d'absence est devenue fausse et est remplacee par la description de la verification effective -- reecriture assumee, pas une perte de contenu.
