### PR TITLE
feat(ci-runner,#13378): persistance systemd+holder des slots Linux — recette repliquable + mesure du reaping WSL

### DIFF
--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -244,7 +244,14 @@ Trois points de conception qui ne sont pas négociables :
 
 La leçon qui a fondé cette preuve reste écrite noir sur blanc : cette page a déjà décrit une conception comme un état déployé — l'inventaire du matin même (2026-09-01) montrait un registre à **un seul** runner Windows, label `coursia-linux` orphelin nulle part, image jamais construite. Tant qu'aucun job n'a rendu la preuve d'identité (`RUNNER_OS = Linux` dans les logs), aucun vert de cette chaîne ne prouve quoi que ce soit — leçon po-2024 du run 33178577527, où l'échec s'était produit *pour la mauvaise raison* (ACE manquante) et aurait pu passer pour un succès de routage.
 
-L'image expose `python` nu (`python-is-python3`) pour les workflows stdlib-only (le `check-navlinks` du job 100021313259 avait échoué `exit 127 "python: not found"` avant cela), et les slots montent le volume `coursia-runner-toolcache` sur `/opt/hostedtoolcache` (`RUNNER_TOOL_CACHE`) pour que les actions `setup-*` ne re-téléchargent pas leurs outils à chaque conteneur éphémère. Après toute modification du Dockerfile : rebuild (même tag), puis roulement des slots — `stop`, `docker kill` des conteneurs vérifiés `busy=false`, `start N`.
+L'image expose `python` nu (`python-is-python3`) pour les workflows stdlib-only (le `check-navlinks` du job 100021313259 avait échoué `exit 127 "python: not found"` avant cela), et les slots montent le volume `coursia-runner-toolcache` sur `/opt/hostedtoolcache` (`RUNNER_TOOL_CACHE`) pour que les actions `setup-*` ne re-téléchargent pas leurs outils à chaque conteneur éphémère. Après toute modification du Dockerfile : rebuild (même tag), puis roulement des slots — `docker kill` des conteneurs vérifiés `busy=false` (la boucle relance sur la nouvelle image ; les slots occupés se soignent seuls au tour suivant). **Le check `busy=false` échoue en silence par deux chemins mesurés** : `jq` est absent de l'hôte Ubuntu (il vit dans l'image), et `gh api` ne supporte pas `--arg`. Forme canonique — côté Windows (gh embarque jq), nom littéral interpolé, **fail-closed** :
+
+```bash
+busy=$(gh api repos/jsboige/CoursIA/actions/runners --jq ".runners[] | select(.name==\"$name\") | .busy")
+rc=$?; [ $rc -eq 0 ] && [ -n "$busy" ] || { echo "check FAILED rc=$rc busy='$busy'"; exit 1; }
+```
+
+Re-vérifier **par slot juste avant chaque kill** : un job peut être pris entre l'inventaire et le geste. Un `busy` vide capturé sans contrôle de `rc` n'est pas une vérification — l'égalité `!= "true"` passe et le kill part non vérifié.
 
 Routage (décision coordinateur) — **tranche 1 portée par #14148 (PR ouverte au 2026-09-01)** : 11 workflows y passent sur les labels `coursia-linux`, sous la règle « allowlist du checker `check_self_hosted_runner_policy.py` + garde universelle de fork/payload + timeout + `permissions: read` ». Tant qu'elle n'est pas mergée, ces workflows restent sur GitHub-hosted. Le reste des 93 jobs `ubuntu-latest` du census #13378 demeure sur GitHub-hosted tant que l'empreinte n'a pas été mesurée sur des jobs réels — l'élargissement (tranche 2, N slots) reste décision coordinateur après 24 h de vert sur la tranche 1.
 

--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -252,14 +252,24 @@ Routage (décision coordinateur) — **tranche 1 portée par #14148 (PR ouverte 
 
 Si l'empreinte mesurée pendant un job gêne la workstation (training GPU, sessions interactives), on **réduit les caps ou on arrête**, et on le signale à ai-01.
 
-### Persistance du superviseur — pas encore posée (en attente de go)
+### Persistance du superviseur — déployée sur po-2024 (systemd dans Ubuntu + holder WSL)
 
-`supervise.sh` vit dans une session : si elle meurt, les slots en ligne consomment leur inscription au prochain job et rien ne les relance. Le déploiement durable prévu :
+`supervise.sh` vit dans une session : si elle meurt, les slots en ligne consomment leur inscription au prochain job et rien ne les relance. Le déploiement durable est **posé et mesuré sur po-2024** (2026-09-02, mandat user « Il faut du persistant !!! ») : les slots ont quitté Docker Desktop pour la distro **Ubuntu sous systemd**, et le réveil de la distro est **tenu** par un processus holder Windows. Copies de référence committées dans `scripts/ci/docker/linux-runner/persist/`.
 
-- **voie WSL** : service utilisateur systemd (`systemctl --user`, unit lançant `supervise.sh start 2`) + `loginctl enable-linger <user>` pour survivre aux déconnexions ;
-- **voie Windows** (alternative) : tâche planifiée au logon via `schtasks`, même invocation.
+**Architecture (3 étages)** :
 
-Aucun des deux n'est installé sur po-2024 à date : l'installation d'un mécanisme permanent d'enregistrement est un geste explicite (coordinateur ou user), jamais silencieux.
+1. **Étage Linux (systemd)** — la distro Ubuntu tourne avec systemd en PID 1. `docker-ce` (pas Docker Desktop) est épinglé sur `/var/run/docker-ce.sock` via un drop-in `docker.service.d/coursia-socket.conf`. L'unité système `coursia-runner.service` (`Requires=docker.service`, `Restart=always`, `TimeoutStopSec=900`) exécute le wrapper `/usr/local/bin/coursia-runner-start.sh start 4` : il relit le token admin GitHub à **chaque invocation** depuis `master.env` côté Windows (`/mnt/c/...` via `sed` + `tr -d '\r'` — un CRLF tuerait la valeur ; le token ne vit jamais dans la distro ni dans un argv), exporte `DOCKER_HOST`/`GH_TOKEN`/`COURSIA_RUNNER_STATE_DIR=/var/lib/coursia-runner`, puis `exec supervise.sh start N`. `ExecStop` passe par l'arrêt gracieux (sentinel) : un job en vol va à son terme.
+2. **Étage pont (tâche planifiée)** — `CoursIA-LinuxRunners` (`InteractiveToken`, `LeastPrivilege`, logon) exécute `launch-runner.sh` : il ne fait rien lui-même, il invoque le holder et rend son rc.
+3. **Étage holder (la pièce non négociable)** — `hold-runner.ps1` spawn un processus `wsl.exe` **détaché** qui exécute `systemctl start coursia-runner.service && exec sleep infinity`. Tant que ce processus vit, une session client WSL existe et **la distro ne peut pas être reapée**.
+
+**Pourquoi le holder est obligatoire — mesure décisive du 2026-09-02** : un appel `wsl.exe` one-shot ne suffit **jamais**. Séquence mesurée : 4 slots `[online]` → sortie du dernier client wsl → **moins de 3 minutes plus tard, distro morte** (`wsl -l --running` : Ubuntu absente ; GitHub : `online: 0`) — avec systemd en PID 1, le service actif et les conteneurs lancés. WSL reape la distro au départ du dernier client, quel que soit son état interne. Ce constat **unifie** tous les échecs de réveil one-shot observés : le pont logon qui « rend rc=0 » sans jamais remonter les slots, et la tâche S4U d'un autre hôte « rc=0 sans rien démarrer » — le rc=0 dit que la demande a été acceptée, pas que la distro a survécu au client. `wsl -l --running` (listage pur, qui ne réveille pas les distros) est le seul instrument de liveness qui ne confonde pas la mesure.
+
+**Mesures d'appoint** :
+
+- **Guerre de flap name-replace** : enregistrer un runner sous un nom existant **remplace** l'entrée (« Successfully replaced the runner »). Deux superviseurs sur les mêmes noms → boucle auto-entretenue `Error: Conflict / Retrying until reconnected` (cadence ~2 min < TTL session ~3 min : ça ne converge jamais). Correctif mesuré : arrêt complet **~5 min** (purger TOUTES les sessions), puis start unique → 4/4 online en 20 s. Corollaire : la bascule Docker Desktop → Ubuntu **remplace** les entrées, elle ne les duplique pas.
+- **S4U exige l'élévation** : `Register-ScheduledTask -LogonType S4U` est refusé sans admin (« Accès refusé », même `RunLevel Limited`). La tâche boot `CoursIA-LinuxRunners-Boot` (S4U + `AtStartup`, script prêt) attend **un clic UAC** du user — le pont logon couvre le cas nominal en attendant. Limite connue du pont `InteractiveToken` : le holder meurt à la fermeture de session ; la tâche S4U boot la relance avant le logon.
+
+**Recette de réplication** (un autre worker) : installer docker-ce dans la distro + drop-in socket → poser le wrapper et l'unité (`persist/coursia-runner-start.sh`, `persist/coursia-runner.service`, en adaptant `NAME_PREFIX` et N) → `systemctl enable --now coursia-runner` → créer la tâche logon qui appelle `persist/launch-runner.sh` (elle appelle le holder local) → valider par le protocole de mesure ci-dessus (tuer la distro, déclencher la tâche, **attendre 3+ min sans aucun appel wsl**, puis lister). L'installation d'un mécanisme permanent d'enregistrement reste un geste explicite (coordinateur ou user), jamais silencieux.
 
 ## Tranches suivantes, activation partielle
 
@@ -280,7 +290,7 @@ La préparation complète reste découpée :
 | `myia-po-2024-fast-guards` | **actif** — seul runner du dépôt ; Windows ; tool-cache seedé (a2), ré-enregistrement sans UAC, jobs réels consommés |
 | `myia-po-2025-fast-guards` | en préparation (aucun runner enregistré) |
 | `myia-po-2026-fast-guards` | en préparation (aucun runner enregistré ; profil vérifié dans le registre) |
-| `coursia-linux` (conteneur) | **en ligne** — 2 slots conteneurisés sur po-2024 (`myia-po-2024-linux-docker-1/-2`), preuve d'identité run 33554804211 (`RUNNER_OS = Linux`) |
+| `coursia-linux` (conteneur) | **en ligne + persistant** — 4 slots conteneurisés sur po-2024 (`myia-po-2024-linux-docker-1..4`) sous systemd dans Ubuntu (holder WSL, cf section Persistance), preuve d'identité run 33554804211 (`RUNNER_OS = Linux`) |
 
 La colonne est datée d'une **mesure**, pas d'une intention : le tableau précédent portait « actif » et « en préparation » sans dire ce qui avait été compté, ce qui a laissé lire une conception comme un déploiement.
 

--- a/scripts/ci/docker/linux-runner/persist/coursia-runner-start.sh
+++ b/scripts/ci/docker/linux-runner/persist/coursia-runner-start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Wrapper de demarrage du superviseur de runners Linux CoursIA sous systemd.
+# Deploiement po-2024 (2026-09-02) : copie de reference -- l'original vit
+# dans la distro Ubuntu de l'hote, sous /usr/local/bin/coursia-runner-start.sh.
+#
+# Design :
+#   - le token admin GitHub ne vit JAMAIS dans la distro ni dans un argv :
+#     il est relu a CHAQUE invocation depuis master.env cote Windows
+#     (/mnt/c/... via sed + tr -d '\r' -- CRLF tuerait la valeur) ;
+#   - DOCKER_HOST epingle le socket docker-ce, pas le Docker Desktop ;
+#   - l'etat superviseur (sentinel, logs slots) vit sous /var/lib/coursia-runner.
+set -euo pipefail
+
+TOKEN_FILE="/mnt/c/dev/CoursIA/.secrets/master.env"
+TOKEN="$(sed -n 's/^GH_RUNNERS_ADMIN_TOKEN=//p' "$TOKEN_FILE" | tr -d '\r')"
+if [ -z "$TOKEN" ]; then
+    echo "FATAL: GH_RUNNERS_ADMIN_TOKEN absent de $TOKEN_FILE" >&2
+    exit 1
+fi
+
+export DOCKER_HOST="unix:///var/run/docker-ce.sock"
+export GH_TOKEN="$TOKEN"
+export COURSIA_RUNNER_REPO="jsboige/CoursIA"
+export COURSIA_RUNNER_NAME_PREFIX="myia-po-2024-linux-docker"
+export COURSIA_RUNNER_STATE_DIR="/var/lib/coursia-runner"
+export COURSIA_RUNNER_TOOLCACHE_VOLUME="coursia-runner-toolcache"
+
+SUPERVISE="/mnt/c/dev/CoursIA/scripts/ci/docker/linux-runner/supervise.sh"
+mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+
+exec "$SUPERVISE" "$@"

--- a/scripts/ci/docker/linux-runner/persist/coursia-runner.service
+++ b/scripts/ci/docker/linux-runner/persist/coursia-runner.service
@@ -1,0 +1,25 @@
+# Unite systemd de persistance du superviseur de runners Linux CoursIA.
+# Deploiement po-2024 (2026-09-02, mission persistance #13378) : copie de
+# reference -- l'original vit dans la distro Ubuntu de l'hote, sous
+# /etc/systemd/system/coursia-runner.service (systemctl enable --now).
+#
+# Parametres machine : NAME_PREFIX (po-2024 -> myia-po-2024-linux-docker) et
+# N slots (po-2024 -> 4) vivent dans le wrapper coursia-runner-start.sh.
+[Unit]
+Description=CoursIA Linux runners supervisor (docker slots)
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/coursia-runner-start.sh start 4
+ExecStop=/usr/local/bin/coursia-runner-start.sh stop
+Restart=always
+RestartSec=30
+Nice=10
+# ExecStop est gracieux (sentinel supervise.sh) : un job en vol va a son
+# terme, ce qui peut prendre des dizaines de minutes sur un build Lean.
+TimeoutStopSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ci/docker/linux-runner/persist/hold-runner.ps1
+++ b/scripts/ci/docker/linux-runner/persist/hold-runner.ps1
@@ -1,0 +1,49 @@
+# Holder WSL pour coursia-runner -- copie de reference genrique.
+# Deploiement po-2024 (2026-09-02) : l'original vit sur l'hote sous
+# %USERPROFILE%\.coursia-runner\hold-myia-po-2024.ps1 (noms hardcodes).
+#
+# RAISON D'ETRE (mesure 2026-09-02, decisive) : un appel wsl.exe one-shot ne
+# maintient PAS la distro. WSL REAPE la distro quand le dernier client sort,
+# MEME avec systemd en PID 1, le service actif et les slots online :
+#   4/4 online -> exit du client -> < 3 min : distro morte
+#   (wsl -l --running : Ubuntu absente, GitHub online: 0).
+# Consequence : tout reveil doit etre TENU par une session client ouverte
+# indefiniment. Ce script spawn un processus wsl.exe DETACHE qui demarre le
+# service puis dort -- la distro ne meurt plus tant que le holder vit.
+# C'est aussi la cause racine des echecs de reveil one-shot (pont logon,
+# tache S4U "rc=0 sans rien demarrer") : le rc=0 dit seulement que la
+# demande a ete acceptee, pas que la distro a survécu au client.
+#
+# Parametres : DISTRO (defaut Ubuntu), SERVICE (defaut coursia-runner.service).
+param(
+    [string]$Distro = 'Ubuntu',
+    [string]$Service = 'coursia-runner.service'
+)
+$ErrorActionPreference = 'Stop'
+$log = "$env:USERPROFILE\.coursia-runner\holder.log"
+function Log($msg) { "$(Get-Date -Format o) $msg" | Add-Content -Encoding utf8 $log }
+
+$wsl = "$env:WINDIR\System32\wsl.exe"
+
+# Garde anti-doublon : re-invoquer la tache ne doit pas empiler les holders.
+$existing = Get-CimInstance Win32_Process -Filter "Name='wsl.exe'" |
+    Where-Object { $_.CommandLine -match 'sleep infinity' -and $_.CommandLine -match $Distro }
+if ($existing) {
+    Log "holder deja vivant pid=$($existing.ProcessId) - start one-shot du service seulement"
+    & $wsl -d $Distro -u root -- /bin/systemctl start $Service
+    Log "systemctl start (one-shot) rc=$LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+$p = Start-Process -WindowStyle Hidden -PassThru -FilePath $wsl -ArgumentList @(
+    '-d', $Distro, '-u', 'root', '--', '/bin/bash', '-c',
+    "systemctl start $Service && exec sleep infinity"
+)
+Log "holder spawn pid=$($p.Id) (systemd start + sleep infinity) [distro=$Distro]"
+Start-Sleep -Seconds 3
+if ($p.HasExited) {
+    Log "ERREUR: holder pid=$($p.Id) mort prematurément (exit=$($p.ExitCode))"
+    exit 1
+}
+Log "holder pid=$($p.Id) vivant a t+3s"
+exit 0

--- a/scripts/ci/docker/linux-runner/persist/launch-runner.sh
+++ b/scripts/ci/docker/linux-runner/persist/launch-runner.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pont logon -> holder : action de la tache planifiee "CoursIA-LinuxRunners"
+# (InteractiveToken, LeastPrivilege). Copie de reference genrique -- sur
+# po-2024 l'original vit sous %USERPROFILE%\.coursia-runner\launch-myia-po-2024.sh
+# et appelle le holder machine-local hold-myia-po-2024.ps1.
+#
+#   schtasks action : C:\Program Files\Git\bin\bash.exe -lc "<ce script> 4"
+#
+# Le pont ne fait RIEN lui-meme : il invoque le holder PowerShell (spawn wsl
+# detache) et rend son rc. Toute la logique vit dans hold-runner.ps1.
+set -uo pipefail
+
+LOG="$HOME/.coursia-runner/launcher.log"
+mkdir -p "$(dirname "$LOG")"
+exec >>"$LOG" 2>&1
+echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) pont logon->holder (args: $*) ==="
+
+# cygpath : powershell.exe -File exige un chemin Windows, $HOME est posix.
+WINPS1="$(cygpath -w "$HOME/.coursia-runner/hold-myia-po-2024.ps1")"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$WINPS1"
+rc=$?
+echo "holder spawn -> rc=$rc"
+exit $rc


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2024:CoursIA — prev: MED/tooling #14302

See #13378 (chantier runners — volet persistance) · Mission ai-01 HIGH « persistance » (mandat user 2026-09-02 : « Il faut du persistant !!! » / « Tu feras faire toute la persistance a po-2024 »).

## Ce que la PR livre

Le déploiement de persistance des slots Linux est **posé et mesuré sur po-2024** depuis ce cycle ; cette PR en committre les **copies de référence répliquables** + la **documentation mesurée** :

1. `scripts/ci/docker/linux-runner/persist/` (4 fichiers) :
   - `coursia-runner.service` — unité systemd (`Requires=docker.service`, `Restart=always`, arrêt gracieux `TimeoutStopSec=900`) ;
   - `coursia-runner-start.sh` — wrapper : relit `GH_RUNNERS_ADMIN_TOKEN` à chaque invocation depuis `master.env` côté Windows (`sed` + `tr -d '\r'`), épingle `DOCKER_HOST` sur le socket docker-ce, `exec supervise.sh start N` ;
   - `hold-runner.ps1` — **le holder** : spawn un `wsl.exe` détaché `systemctl start … && exec sleep infinity`, avec garde anti-doublon ;
   - `launch-runner.sh` — pont logon (action de la tâche planifiée), invoque le holder.
2. `docs/ci/self-hosted-runners.md` — la section « Persistance — pas encore posée » devient « **déployée sur po-2024 (systemd + holder WSL)** » : architecture 3 étages, mesures, recette de réplication. Tableau d'état : `coursia-linux` = 4 slots persistants.

## La mesure qui fonde le design (reaping WSL)

Un appel `wsl.exe` **one-shot ne suffit jamais**. Séquence mesurée le 2026-09-02 :

| Temps | Événement | Preuve |
|---|---|---|
| T0 | 4 slots `[online]` (distre Ubuntu, systemd, service actif) | inventaire GitHub |
| T0 | sortie du dernier client wsl (fin du pont one-shot) | — |
| < T0+3 min | **distro reapée** : `wsl -l --running` = Ubuntu absente, GitHub `online: 0` | sonde idle 3 min |
| T1 | nouveau design : tâche → holder détaché (`sleep infinity`) | `holder.log` pid vivant |
| T1+90 s | slots remontés | `online=21` (fleet + mes 4) |
| T1+4,5 min | **distro toujours vivante**, zéro autre appel wsl | `wsl -l --running` = « Ubuntu (par défaut) » + `myia-po-2024-linux-docker-1..4` online |

WSL reape la distro au départ du **dernier client**, quel que soit l'état interne (systemd PID 1, conteneurs lancés). Ce constat **unifie** les échecs de réveil one-shot observés : pont logon « rc=0 sans jamais remonter », et tâche S4U d'un autre hôte « rc=0 sans rien démarrer » — le rc=0 dit que la demande a été acceptée, pas que la distro a survécu au client. **Toute réplication doit inclure le holder.**

## Mesures d'appoint

- **Flap name-replace** : enregistrer un runner sous un nom existant **remplace** l'entrée. Deux superviseurs sur les mêmes noms → boucle auto-entretenue `Conflict/Retrying` (cadence ~2 min < TTL ~3 min). Correctif mesuré : stop complet ~5 min puis start unique → 4/4 online en 20 s.
- **S4U exige l'élévation** : `Register-ScheduledTask -LogonType S4U` refusé sans admin (2 essais). Script d'enregistrement prêt, attend 1 clic UAC ([ASK USER] signalé). En attendant, le pont logon couvre le cas nominal ; limite connue : le holder meurt à la fermeture de session, la tâche S4U boot la relancerait avant logon.

## Validation

- Aucun secret dans le diff (le chemin `master.env` est cité, jamais la valeur ; gitleaks Passed).
- Le token admin vit dans `.secrets/master.env` (gitignored), relu à chaque invocation par le wrapper.
- État live au moment du push : 4/4 slots online depuis le déploiement holder (16:14Z→16:18Z mesuré, toujours vivant).
