### PR TITLE
ci(#14283): routage par job -- 8 jobs de plus + la moitie routable de #14294

### DIFF
--- a/.github/workflows/always-on-metadata-guards.yml
+++ b/.github/workflows/always-on-metadata-guards.yml
@@ -77,7 +77,12 @@ concurrency:
 jobs:
   always-on-metadata-guards:
     name: "Always-on metadata guards -- 3 organes, 1 checkout"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/bash-syntax-advisory.yml
+++ b/.github/workflows/bash-syntax-advisory.yml
@@ -43,7 +43,12 @@ concurrency:
 jobs:
   syntax-check:
     name: bash -n every scripts .sh (advisory)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
       - name: bash -n
@@ -62,7 +67,12 @@ jobs:
 
   shebang-dry-run-advisory:
     name: Shebang + dry-run advisory (non-blocking)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -62,7 +62,12 @@ jobs:
   #     name "Proof integrity" finally means what B.3 says it means.
   certified-no-sorry:
     name: "Certified modules: no code sorry (SocialChoice)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -51,7 +51,12 @@ concurrency:
 jobs:
   detect-changes:
     name: Detect notebook changes
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       notebooks: ${{ steps.detect.outputs.notebooks }}
       has_notebooks: ${{ steps.detect.outputs.has_notebooks }}
@@ -90,9 +95,13 @@ jobs:
 
   validate-static:
     name: Static validation (H.1/H.3/C.1)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     needs: detect-changes
-    if: needs.detect-changes.outputs.has_notebooks > 0
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && needs.detect-changes.outputs.has_notebooks > 0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -90,7 +90,12 @@ jobs:
   # true but unguarded, cf c.10143 comment 5255089235). See #10143.
   positive-controls:
     name: Gitleaks positive controls (#10143)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     env:
       GITLEAKS_VERSION: 8.24.3
     steps:

--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -60,7 +60,12 @@ concurrency:
 jobs:
   twin-parity:
     name: "Twin parity audit (#8057)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -176,7 +181,12 @@ jobs:
     # `exit 1` au lieu de `echo "::warning..."`. Cf twin-parity-drift-audit
     # pour le precedent advisory-then-blocking.
     name: "Twin parity SHA mismatch (#9399 volet b, advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -106,6 +106,17 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "lean-i18n-drift.yml",
     "lean-knot.yml",
     "manifest-description-visuelle-gate.yml",
+    # tranche 3c (#14283, meme decision, meme owner) : jobs individuels d'un
+    #   workflow dont les autres jobs restent sur ubuntu-latest.
+    #   Exclus deliberement : ml-tests (torch retelecharge a chaque run, pas de
+    #   cache persistant), secret-scan/gitleaks (socket Docker), lean-social-
+    #   choice/build (merite un pool a cache Mathlib chaud, cf #14337),
+    #   notebook-execution-required/golden-set-execute (execution lourde).
+    "bash-syntax-advisory.yml",
+    "lean-social-choice.yml",
+    "notebook-execution-required.yml",
+    "secret-scan.yml",
+    "twin-parity.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -116,6 +116,10 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "lean-social-choice.yml",
     "notebook-execution-required.yml",
     "secret-scan.yml",
+    # always-on-metadata-guards.yml : routable (triggers pull_request +
+    #   workflow_dispatch seulement). Son jumeau always-on-guards.yml ne l'est
+    #   PAS -- il porte pull_request_review, classe FORK_REACHABLE (#14294).
+    "always-on-metadata-guards.yml",
     "twin-parity.yml",
 }
 GITHUB_HOSTED_LABELS = {


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/tooling #14336

## Summary

Deux gestes, un seul sujet : **adresser davantage de travail aux runners auto-heberges**.

1. **Routage par job** (8 jobs dans 5 workflows) — la difference avec #14336, ou chaque
   workflow basculait en entier. Ici les workflows gardent certains jobs sur `ubuntu-latest`
   et ne deplacent que les jobs pur-Python.
2. **`always-on-metadata-guards.yml`** — la moitie routable de #14294.

### 1. Les 8 jobs

| Workflow | Jobs routes | Jobs laisses sur `ubuntu-latest` |
|---|---|---|
| `bash-syntax-advisory.yml` | `syntax-check`, `shebang-dry-run-advisory` | — |
| `lean-social-choice.yml` | `certified-no-sorry` | `build` (merite un pool a cache Mathlib chaud, cf #14337) |
| `notebook-execution-required.yml` | `detect-changes`, `validate-static` | `golden-set-execute` (execution lourde) |
| `secret-scan.yml` | `positive-controls` | `gitleaks` (a besoin du socket Docker) |
| `twin-parity.yml` | `twin-parity`, `twin-parity-sha-mismatch` | — |

Chaque job route porte la garde same-repo universelle au niveau job et un `runs-on` **statique**.
`validate-static` avait deja un `if:` : il devient `(<garde>) && <condition d'origine>` — la
parenthese est obligatoire, `&&` lie plus fort que `||` en expression GHA.

### 2. `always-on-metadata-guards.yml`, et pourquoi son jumeau ne suit pas

#14294 voulait router **les deux** always-on guards. Ce n'etait pas possible, et l'image du
conteneur n'y etait pour rien :

| Workflow | Declencheurs | Routable ? |
|---|---|---|
| `always-on-metadata-guards.yml` | `pull_request`, `workflow_dispatch` | **oui** |
| `always-on-guards.yml` | `pull_request`, **`pull_request_review`**, `workflow_dispatch` | **non** |

`pull_request_review` est dans `FORK_REACHABLE_TRIGGERS` : un job peut y faire
`checkout refs/pull/N/head` et executer du code de fork sur nos machines. Le depot porte
~95 forks etudiants. `always-on-guards.yml` reste donc sur `ubuntu-latest`, et **#14294 est
close par cette PR** — sa moitie realisable est ici, sa moitie irrealisable est documentee
dans l'allowlist.

## Verification

- `python scripts/ci/check_self_hosted_runner_policy.py` -> **rc=0**, `self_hosted=43`.
- Les 5 workflows se re-parsent en YAML ; **0** `runs-on` dynamique (une expression leverait
  `DYNAMIC_RUNS_ON` : c'est ce qui a fait abandonner le motif hybride de #14294/#14336).
- Aucun des workflows touches ne porte `pull_request_target` ni de `ref:` explicite au checkout.

## Retour arriere

Revert de la PR. Chaque bloc route porte en commentaire la manoeuvre exacte
(`runs-on: ubuntu-latest` + retrait de l'allowlist).

Cette PR remplace la PR 14294 (numero sans diese : un mot-cle fermant suivi
de #<numero-de-PR> auto-fermerait la PR au squash, cf #10101) -- 14294 est
fermee a la main a la place.

See #14283

