### PR TITLE
ci(#14283): router les 32 balayages cron pur-Python vers la jambe Linux

### DIFF
--- a/.github/workflows/ascii-flowchart-advisory.yml
+++ b/.github/workflows/ascii-flowchart-advisory.yml
@@ -57,7 +57,12 @@ concurrency:
 jobs:
   ascii-flowchart-advisory:
     name: "ASCII flowchart introductions (#11962 advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/candidate-delivered-advisory.yml
+++ b/.github/workflows/candidate-delivered-advisory.yml
@@ -53,7 +53,12 @@ concurrency:
 jobs:
   sweep:
     name: "Label delivered-but-unclosed issues (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -74,7 +74,12 @@ concurrency:
 jobs:
   regen:
     name: Regenerate catalog on long-lived PR
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout main (history only)
         uses: actions/checkout@v4

--- a/.github/workflows/check-resync-only.yml
+++ b/.github/workflows/check-resync-only.yml
@@ -48,7 +48,12 @@ concurrency:
 jobs:
   resync-only-advisory:
     name: "Resync-only advisory"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -48,7 +48,12 @@ concurrency:
 jobs:
   cjk-residue-advisory:
     name: "CJK residue advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/degraded-mode-advisory.yml
+++ b/.github/workflows/degraded-mode-advisory.yml
@@ -52,7 +52,12 @@ concurrency:
 jobs:
   degraded-mode-advisory:
     name: "Degraded-mode confessions (#11754 advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/detect-dup-selftest.yml
+++ b/.github/workflows/detect-dup-selftest.yml
@@ -39,7 +39,12 @@ concurrency:
 jobs:
   self-test:
     name: "Live positive control #13050/#13051 (detect-dup self-test)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -52,7 +52,12 @@ concurrency:
 jobs:
   dotnet-nuget-block-advisory:
     name: ".NET exec-block-without-nuget advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/epic-charter-advisory.yml
+++ b/.github/workflows/epic-charter-advisory.yml
@@ -54,7 +54,12 @@ concurrency:
 jobs:
   charter:
     name: "Parite expansion / consolidation des EPICs ouverts"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout (sparse, scripts only)
         uses: actions/checkout@v4

--- a/.github/workflows/epic-neglect-sweep.yml
+++ b/.github/workflows/epic-neglect-sweep.yml
@@ -40,7 +40,12 @@ concurrency:
 jobs:
   sweep:
     name: "Name EPICs no merged PR cites lately (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout (sparse, scripts only)
         uses: actions/checkout@v4

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -44,7 +44,12 @@ concurrency:
 jobs:
   exercises-advisory:
     name: "Exercises >= 3 advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/grain-orphans-sweep.yml
+++ b/.github/workflows/grain-orphans-sweep.yml
@@ -40,7 +40,12 @@ concurrency:
 jobs:
   sweep:
     name: "Route untagged blocked PRs to the coordinator (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout (sparse, scripts only)
         uses: actions/checkout@v4

--- a/.github/workflows/h1-hygiene-advisory.yml
+++ b/.github/workflows/h1-hygiene-advisory.yml
@@ -27,7 +27,12 @@ concurrency:
 jobs:
   h1-hygiene:
     name: H1 hygiene advisory (label, non-blocking, #11840)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/leaky-fixture-sweep.yml
+++ b/.github/workflows/leaky-fixture-sweep.yml
@@ -52,7 +52,12 @@ concurrency:
 jobs:
   sweep:
     name: Date-window sweep
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/machine-dep-timing-advisory.yml
+++ b/.github/workflows/machine-dep-timing-advisory.yml
@@ -44,7 +44,12 @@ concurrency:
 jobs:
     machine-dep-timing:
         name: machine-dep-timing (advisory)
-        runs-on: ubuntu-latest
+        # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+        # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+        # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+        # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+        # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+        runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
         permissions:
             pull-requests: write
         steps:

--- a/.github/workflows/machine-dep-timing-inventory.yml
+++ b/.github/workflows/machine-dep-timing-inventory.yml
@@ -29,7 +29,12 @@ permissions:
 
 jobs:
   inventory:
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout main
         uses: actions/checkout@v4

--- a/.github/workflows/orphan-branch-scan.yml
+++ b/.github/workflows/orphan-branch-scan.yml
@@ -45,7 +45,12 @@ concurrency:
 jobs:
   sweep:
     name: "Scan orphaned branch deliverables (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@v4

--- a/.github/workflows/outputs-text-fragmentation-advisory.yml
+++ b/.github/workflows/outputs-text-fragmentation-advisory.yml
@@ -34,7 +34,12 @@ concurrency:
 jobs:
   outputs-text-fragmentation-advisory:
     name: "Outputs text fragmentation (#11667 advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pedagogy-density-advisory.yml
+++ b/.github/workflows/pedagogy-density-advisory.yml
@@ -46,7 +46,12 @@ concurrency:
 jobs:
   pedagogy-density-advisory:
     name: "Pedagogy density >= 1200 c/cell advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/pr-gate-missing-advisory.yml
+++ b/.github/workflows/pr-gate-missing-advisory.yml
@@ -50,7 +50,12 @@ concurrency:
 jobs:
   sweep:
     name: "Flag PRs without PR gate (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-gate-sweep-health-advisory.yml
+++ b/.github/workflows/pr-gate-sweep-health-advisory.yml
@@ -38,7 +38,12 @@ concurrency:
 jobs:
   health:
     name: PR gate sweep health advisory
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 5
     steps:
       - name: Check age of last successful sweep run

--- a/.github/workflows/pr-path-collision-advisory.yml
+++ b/.github/workflows/pr-path-collision-advisory.yml
@@ -71,7 +71,12 @@ permissions:
 jobs:
   advisory:
     name: List open-PR path collisions
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/qc-research-monitor.yml
+++ b/.github/workflows/qc-research-monitor.yml
@@ -27,7 +27,12 @@ concurrency:
 
 jobs:
   monitor:
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-size-advisory.yml
+++ b/.github/workflows/repo-size-advisory.yml
@@ -28,7 +28,12 @@ concurrency:
 jobs:
   large-blob-advisory:
     name: Large blob advisory (>= 10 MiB)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout PR (full history for blob diff)
         uses: actions/checkout@v4

--- a/.github/workflows/review-coverage-advisory.yml
+++ b/.github/workflows/review-coverage-advisory.yml
@@ -51,7 +51,12 @@ concurrency:
 jobs:
   sweep:
     name: "Flag large PRs with no review (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -70,7 +70,12 @@ concurrency:
 jobs:
   slides-build-advisory:
     name: "Slidev build advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/slow-lane.yml
+++ b/.github/workflows/slow-lane.yml
@@ -70,7 +70,12 @@ jobs:
   # deplacera reellement le trigger `pull_request` d'`ict-tests.yml` ici.
   ict-tests-pilot:
     name: Slow-lane ICT-Series pilot
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
     steps:
       - name: Checkout main

--- a/.github/workflows/stale-guard-red-sweep.yml
+++ b/.github/workflows/stale-guard-red-sweep.yml
@@ -59,7 +59,12 @@ concurrency:
 jobs:
   sweep:
     name: Signal PRs blocked on a pre-fix red
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -31,7 +31,12 @@ concurrency:
 jobs:
   parity:
     name: parity (advisory)
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/twin-parity-cron.yml
+++ b/.github/workflows/twin-parity-cron.yml
@@ -57,7 +57,12 @@ permissions:
 jobs:
   twin-parity-cron:
     name: "Twin parity CI-derived SHA (#9399 b)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout main

--- a/.github/workflows/twin-parity-drift-audit.yml
+++ b/.github/workflows/twin-parity-drift-audit.yml
@@ -40,7 +40,12 @@ permissions:
 jobs:
   drift-audit:
     name: "Fleet-wide drift count (advisory)"
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
 
     steps:
       - name: Checkout

--- a/.github/workflows/workflow-path-filter-audit.yml
+++ b/.github/workflows/workflow-path-filter-audit.yml
@@ -34,7 +34,12 @@ permissions:
 
 jobs:
   audit-workflow-path-filters:
-    runs-on: ubuntu-latest
+    # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
+    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
+    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
+    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     timeout-minutes: 5
     steps:
       - name: Checkout repo

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -121,6 +121,44 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     #   PAS -- il porte pull_request_review, classe FORK_REACHABLE (#14294).
     "always-on-metadata-guards.yml",
     "twin-parity.yml",
+    # tranche 4 (#14283, meme decision, meme owner) : balayages cron pur-Python.
+    #   Declencheur `schedule` seul -- pas de contexte pull_request, donc aucune
+    #   garde same-repo requise. 33 creneaux distincts, au plus 2 simultanes
+    #   (mesure 2026-09-02) : ils ne peuvent pas affamer les gardes de PR.
+    #   Exclus : markdown-table-guard / render-volume-delta-advisory (lourds),
+    #   slides-composition-advisory (navigateurs hors image).
+    "ascii-flowchart-advisory.yml",
+    "candidate-delivered-advisory.yml",
+    "catalog-cron.yml",
+    "check-resync-only.yml",
+    "cjk-residue-advisory.yml",
+    "degraded-mode-advisory.yml",
+    "detect-dup-selftest.yml",
+    "dotnet-nuget-block-advisory.yml",
+    "epic-charter-advisory.yml",
+    "epic-neglect-sweep.yml",
+    "exercises-advisory.yml",
+    "grain-orphans-sweep.yml",
+    "h1-hygiene-advisory.yml",
+    "leaky-fixture-sweep.yml",
+    "machine-dep-timing-advisory.yml",
+    "machine-dep-timing-inventory.yml",
+    "orphan-branch-scan.yml",
+    "outputs-text-fragmentation-advisory.yml",
+    "pedagogy-density-advisory.yml",
+    "pr-gate-missing-advisory.yml",
+    "pr-gate-sweep-health-advisory.yml",
+    "pr-path-collision-advisory.yml",
+    "qc-research-monitor.yml",
+    "repo-size-advisory.yml",
+    "review-coverage-advisory.yml",
+    "slides-build-advisory.yml",
+    "slow-lane.yml",
+    "stale-guard-red-sweep.yml",
+    "translation-parity.yml",
+    "twin-parity-cron.yml",
+    "twin-parity-drift-audit.yml",
+    "workflow-path-filter-audit.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/tooling #14336

## Summary

Les **32 balayages cron pur-Python** passent sur la jambe Linux auto-hebergee.
**Perimetre effectif : 33 fichiers** -- ces 32 workflows plus
`scripts/ci/check_self_hosted_runner_policy.py` (leur inscription a l'allowlist). Un seul geste
mecanique par fichier : `runs-on: ubuntu-latest` -> `[self-hosted, coursia-ephemeral, coursia-linux]`.

**Aucune garde same-repo ici, et c'est voulu** : ces workflows n'ont que `schedule`. Un cron ne
tourne que sur la branche par defaut, donc aucun code de fork ne peut l'atteindre et il n'existe
aucun contexte `pull_request` a garder. L'en-tete de `check_self_hosted_runner_policy.py` le dit :
la garde n'est exigee que des jobs `pull_request`.

## Le plafond de slots que j'attendais a poser n'a pas lieu d'etre

Je pensais devoir brider ce lot pour ne pas affamer les gardes de PR. La mesure dit le contraire :

```
33 creneaux cron distincts ; au plus 2 workflows tirent au meme instant
```

Les schedules sont deja etales (un par minute dans la fenetre 03:0x, puis des creneaux isoles).
Deux slots occupes sur vingt : les gardes de PR ne voient pas la difference. Pas de plafond,
donc — le poser aurait ete une precaution contre un probleme que la mesure ne trouve pas.

Les deux plus frequents restent modestes : `pr-gate-sweep-health-advisory` (toutes les 30 min)
et `pr-path-collision-advisory` (toutes les 20 min), un slot chacun.

## Les 32 workflows

- `ascii-flowchart-advisory.yml`, `candidate-delivered-advisory.yml`, `catalog-cron.yml`, `check-resync-only.yml`
- `cjk-residue-advisory.yml`, `degraded-mode-advisory.yml`, `detect-dup-selftest.yml`, `dotnet-nuget-block-advisory.yml`
- `epic-charter-advisory.yml`, `epic-neglect-sweep.yml`, `exercises-advisory.yml`, `grain-orphans-sweep.yml`
- `h1-hygiene-advisory.yml`, `leaky-fixture-sweep.yml`, `machine-dep-timing-advisory.yml`, `machine-dep-timing-inventory.yml`
- `orphan-branch-scan.yml`, `outputs-text-fragmentation-advisory.yml`, `pedagogy-density-advisory.yml`, `pr-gate-missing-advisory.yml`
- `pr-gate-sweep-health-advisory.yml`, `pr-path-collision-advisory.yml`, `qc-research-monitor.yml`, `repo-size-advisory.yml`
- `review-coverage-advisory.yml`, `slides-build-advisory.yml`, `slow-lane.yml`, `stale-guard-red-sweep.yml`
- `translation-parity.yml`, `twin-parity-cron.yml`, `twin-parity-drift-audit.yml`, `workflow-path-filter-audit.yml`

## Exclus, et pourquoi

| Workflow | Raison |
|---|---|
| `markdown-table-guard.yml`, `render-volume-delta-advisory.yml` | dependances lourdes |
| `slides-composition-advisory.yml` | navigateurs Playwright hors image |

## Verification

- `python scripts/ci/check_self_hosted_runner_policy.py` -> **rc=0**, `self_hosted=75`.
- Les 32 fichiers de workflow se re-parsent ; **0** `runs-on` dynamique.
- Le 33e fichier du diff est `scripts/ci/check_self_hosted_runner_policy.py` : il ne porte
  aucun `runs-on`, seulement les 32 entrees d'allowlist qui autorisent les blocs ci-dessus.
- Aucun ne porte `pull_request_target` ni de declencheur hors `schedule`/`workflow_dispatch`.

## Retour arriere

Revert de la PR. Chaque bloc porte en commentaire la manoeuvre exacte.

See #14283

