### PR TITLE
feat(ict,#11601): ICT-20 FeatureCatastrophes — 5 interpretations ancrees (densite 1204->1656)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb
@@ -143,6 +143,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "318e371c",
+   "metadata": {},
+   "source": [
+    "### Lecture du panneau généré\n",
+    "\n",
+    "Les statistiques confirment que le générateur fait exactement ce qu'il annonce : la moyenne pré-transition vaut `mu_pre = -0.026` (dispersion autour de 0) et bascule à `mu_post = 0.959`, avec l'index de transition à 100 — la position attendue. Les trois valeurs autour du pli (`-0.38`, `-0.079`, `+0.634`) méritent une seconde lecture : elles chevauchent les deux régimes, signe que la fenêtre du pli est **intrinsèquement ambiguë** pour tout détecteur — c'est précisément cette zone que les expériences suivantes demandent aux indicateurs de traverser sans faux positif. Un générateur honnête expose l'ambiguïté au lieu de la cacher : c'est la propriété qui rend la calibration significative."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d72f5d32",
    "metadata": {},
    "source": [
@@ -224,6 +234,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8ff304e4",
+   "metadata": {},
+   "source": [
+    "### Interprétation — le signal critique est bien détecté\n",
+    "\n",
+    "Les deux indicateurs EWS montent **ensemble** sur la fenêtre pré-transition : `tau_var = +0.595` et `tau_ar1 = +0.612`, tous deux à `p ≈ 0`. C'est la signature canonique du *critical slowing down* : quand l'autocorrélation passe de `phi = 0.5` à `phi = 0.95`, le système met plus de temps à oublier ses perturbations (AR1 qui monte) et s'écarte davantage de son attracteur (variance qui monte). La **concordance des deux tau** est ce qui distingue un vrai signal d'un artefact : un seul indicateur qui bouge peut refléter n'importe quelle dérive, deux indicateurs théoriquement indépendants qui montent ensemble pointent vers le ralentissement. Le verdict `critical_slowing` n'est donc pas une lubie du classifieur — il est porté par la structure des deux tendances."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2a8b301b",
    "metadata": {},
    "source": [
@@ -284,6 +304,16 @@
     "    f\"got {rep2.verdict}\"\n",
     ")\n",
     "print(f\"PASSED (verdict honnete : {rep2.verdict})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e23a73b4",
+   "metadata": {},
+   "source": [
+    "### Interprétation — le contrôle négatif tient : pas de faux signal\n",
+    "\n",
+    "C'est l'expérience qui protège toute la série du reproche « les EWS détectent n'importe quoi ». Ici la moyenne saute de 0 à 2 sans qu'AR(1) bouge (`phi = 0.5` constant), et les indicateurs restent plats : `tau_var = +0.054` et `tau_ar1 = -0.101` — des **magnitudes dix fois plus faibles** que celles de l'expérience 1, et de signes incohérents. La subtilité mérite d'être dite : les p-values restent minuscules (`5.3e-07`, `1.2e-20`) parce que Kendall tau détecte n'importe quelle tendance non nulle sur un grand échantillon — mais **la significativité statistique n'est pas le signal**. Le classifieur juge sur l'ampleur (`|tau|`), pas sur la p-value, et rend honnêtement `no_signal`. Sans ce contrôle, un seuil mal calibré sur p-value transformerait chaque dérive bénigne en alerte."
    ]
   },
   {
@@ -364,6 +394,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f82a2f3e",
+   "metadata": {},
+   "source": [
+    "### Interprétation — Gate 14 : la détection fonctionne, avec un faux positif instructif\n",
+    "\n",
+    "Le bilan est nuancé, et c'est le but du gate : `5/5` détections, délai médian `+33` indices, `4/5` dans la fenêtre tolérée de ±50. Le cas `seed = 47` est le point pédagogique fort : CUSUM déclenche à `t = 9` alors que le vrai saut est à `t = 200` — soit 191 indices **trop tôt**, un faux positif pur sur bruit stationnaire. Le détecteur cumule la dérive du bruit et franchit son seuil sans qu'il y ait quoi que ce soit à détecter. La leçon opérationnelle : un CUSUM réglé pour détecter vite (seuil bas) achète sa réactivité en faux positifs ; le critère du gate (`≥ 3/5` dans la fenêtre) est passé avec marge (`4/5`), mais le verdict refuse de maquiller ce `1/5` en succès — c'est exactement la discipline de verdict honnête que la série ICT exige à chaque gate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "758c4f12",
    "metadata": {},
    "source": [
@@ -429,6 +469,16 @@
     "# le residu peut fluctuer autour de 0 -- on accepte |moyenne| < 0.15\n",
     "assert abs(np.mean(residus)) < 0.15, f\"Hysteresis residuelle moyenne trop elevee : {np.mean(residus):.4f}\"\n",
     "print(\"PASSED (Gate bonus -- hysteresis residuelle ~ 0 sur boucle symetrique)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "491415a1",
+   "metadata": {},
+   "source": [
+    "### Interprétation — pas d'hystérèse systématique sur boucle symétrique\n",
+    "\n",
+    "Les résidus aller-retour s'annulent en moyenne : `+0.0921` d'écart-type `0.3344`, avec des signes mixtes (3 positifs, 2 négatifs sur 5 graines). Une hystérèse réelle — un chemin de retour qui ne repasse pas par les états de l'aller — produirait un résidu **systématiquement signé** et du même ordre que l'écart des régimes (ici ~1). On observe l'inverse : la moyenne est ~3,6 fois plus petite que l'écart-type de l'estimateur, donc compatible avec zéro. Le gate bonus est passé au sens strict (`hysteresis residuelle ~ 0`), mais la taille de l'échantillon (5 graines) invite à la prudence : cette expérience **écarte** une hystérèse forte, elle ne la borne pas finement. Sur panneau réel, la question sera relancée avec les asymétries du substrat."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/tooling #14341

See #11601 (umbrella densité round 2 — tranche, l'issue reste ouverte) · zone chaude ICT-Series (consolidation).

## Tranche : ICT-20-FeatureCatastrophes — densité 1204 → 1656

**Gap réel mesuré** (anti-padding vérifié) : les 4 cellules code d'expérience (EWS/AR1, contrôle négatif, CUSUM Gate 14, hystérèse Gate bonus) et la cellule démo du générateur n'avaient **aucune interprétation après leur output** — les markdown suivants introduisent l'expérience suivante au lieu d'interpréter la précédente. 5 cellules d'interprétation insérées, chacune ancrée sur les **valeurs réelles des outputs committés** (C.5, prose quantitative) :

- générateur : `mu_pre=-0.026 → mu_post=0.959`, l'ambiguïté intrinsèque de la fenêtre du pli (valeurs `-0.38/+0.634`) comme propriété de calibration ;
- Exp 1 : concordance des deux tau (`+0.595`/`+0.612`, p≈0) = signature canonique du critical slowing ;
- Exp 2 : **le contrôle négatif** — magnitudes 10× plus faibles (`+0.054`/`-0.101`), p-values minuscules mais sans ampleur : significativité statistique ≠ signal ;
- Exp 3 (Gate 14) : `4/5` dans la fenêtre ±50, délai médian `+33`, et le faux positif `seed=47` (détection à t=9 vs vrai t=200) lu comme leçon de réactivité/seuil ;
- Exp 4 : résidus `+0.092 ± 0.334` → écarte une hystérèse forte sans la borner finement (n=5).

## Mesures

| Critère | Avant | Après |
|---|---|---|
| densité (c/cellule code) | 1204 | **1656** ✓ (cible ≥1500) |
| markdown rendering | 0 violation | **0 violation** |
| cellules code | 9, outputs intacts, `execution_count` 1..9 non touchés | idem (aucune re-exec requise : diff markdown-only) |
| diff | — | **50 insertions, 0 suppression** (pur ajout de cellules md) |
| accents | — | é/è/à/ô présents (audit numérique) |

## Contexte de la tranche (issue #11601)

- La pool prioritaire c.1331p258 (QC-Py-26, QC-Py-21, SW-10/12/13, DecInfer-9/10, rlpt_4) est **entièrement ≥ 1500 à re-mesure de ce jour** (min : DecInfer-10 à 1717) — mon claim initial sur QC-Py-26 (3065) a été relevé en `[CLAIMED-AMEND]` plutôt que d'enrichir un notebook déjà dense (anti-padding).
- **Re-mesure corpus** : **242 notebooks dans [1200,1500)** = la vraie pool round 2 restante (le compte « 189 en 1200-2000 » était périmé).
- Claim : `[CLAIMED-AMEND]` paths `ICT-20-FeatureCatastrophes.ipynb` (issuecomment-5513044436).
