### PR TITLE
enrich(csp,#11601): CSP-1-Fundamentals-Csharp density 1477 -> 1571

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -472,6 +472,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e1f7a3c9",
+   "metadata": {},
+   "source": [
+    "**Lecture de l'instance** (cellule ci-dessus) :\n",
+    "\n",
+    "L'instance affichée fixe le cadre de toute la suite du notebook :\n",
+    "\n",
+    "- **Espace brut = 2187 combinaisons** : 3 couleurs élevées à 7 variables (3⁷). C'est ce chiffre que la recherche exhaustive de la section suivante balaiera intégralement — et la raison pour laquelle une instance aussi petite reste démonstrative.\n",
+    "- **SA est le hub du graphe** : 5 voisins (WA, NT, Q, NSW, V) contre 2 à 3 pour les autres — c'est lui que l'heuristique MRV de la section 5 sélectionnera en premier.\n",
+    "- **La Tasmanie (T) est isolée** : aucune adjacence, donc aucune contrainte — elle colorie librement et forme un sous-problème indépendant.\n",
+    "- Le graphe de contraintes compte 9 arêtes (chaque adjacence comptée une fois) — c'est exactement le graphe visualisé et interprété dans les deux cellules suivantes."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "1484605f",
@@ -748,6 +763,20 @@
     "Console.WriteLine($\"Solutions trouvees    : {nValid}\");\n",
     "Console.WriteLine($\"Ratio solutions       : {(double)nValid / nTotal:P2}\");\n",
     "Console.WriteLine($\"Temps brute force     : {swBF.Elapsed.TotalMilliseconds:F1} ms\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e6f2b8",
+   "metadata": {},
+   "source": [
+    "**Lecture du brute force** (cellule ci-dessus) :\n",
+    "\n",
+    "La sortie quantifie le coût de l'approche exhaustive : **2187 combinaisons testées pour 18 solutions**, soit un ratio de **0,82 %** — les solutions sont rares dans l'espace brut, l'essentiel du travail de l'énumération est rejeté par le filtre de cohérence.\n",
+    "\n",
+    "Les **3,9 ms** mesurés semblent négligeables, mais la croissance est en 3ⁿ : chaque variable ajoutée triple l'espace. À 15 variables, le même balayage vaut ~14 millions de combinaisons ; à 20, ~3,5 milliards — là où le backtracking de la cellule suivante, en coupant des sous-arbres entiers dès la première incohérence partielle, reste dans des tailles polynomiales en pratique sur ces instances.\n",
+    "\n",
+    "Les **18 solutions** serviront d'étalon : c'est exactement le compte que Choco-solver énumérera en section 6 (cf. la sortie d'énumération complète), ce qui validera la chaîne brute force → backtracking → solveur industriel sur une même instance."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
@@ -64,6 +64,12 @@
     csharp_sha: 930c8ed44a629d66427c71f771d7ffdf390af98e
     content_python_sha: 92361e667ccd83cc3f736b746d8208cbdb880d4e543db881cff4885a4921448c
     content_csharp_sha: 3604b60dbe7a425027f0af141d63e70e794c3eed5032b9c8a4b2ed1edfce77fb
+  - date: "2026-09-02"
+    by: myia-po-2023:CoursIA
+    python_sha: 78e8bf8bf0a418500e22d8c27503de1ada431790
+    csharp_sha: d28258b5bf051c88bab479530ff862f8713a1c6f
+    content_python_sha: 92361e667ccd83cc3f736b746d8208cbdb880d4e543db881cff4885a4921448c
+    content_csharp_sha: fd37f9f14401b3501d2545453fdc8426915f313c7c0c2adfad859490c5836bbb
   known_differences:
   - 'Correction 2026-08-19 (myia-po-2025:CoursIA-2, review #11789 / NanoClaw + ai-01 re-derive) : la contrainte anti-diagonale 8-Reines etait mal ecrite dans les DEUX jumeaux (q_i + q_j != i + j au lieu de q_i + i != q_j + j) ; les solutions committees etaient invalides (Python : 6 paires en attaque, C# : 1 paire). Fixe des deux cotes en `scalar [1,-1] + arithm != j-i` (equivalent exact de q_i + i != q_j + j) puis re-execute : Python [4,6,1,5,2,0,7,3] et C# [4,6,1,5,2,0,3,7], toutes deux 0 attaque (verifie).'
   - 'Edition 2026-08-19 (myia-po-2025:CoursIA-2, #10382 tranche lib-vs-lib) : section 6bis ajoutee au jumeau Python -- Choco via pychoco (binding officiel PyPI MIT), miroir de la section 6 du jumeau C# (Choco via IKVM). Memes modeles, memes instances : enumeration Australie = 18 solutions des deux cotes (convergence verifiee sur grandeur observable), 8-Reines solution valide. La premiere solution 8-Reines differe potentiellement entre jumeaux (ordre de creation des variables auxiliaires diagonales influence lheuristique par defaut) -- documente dans la cellule dinterpretation. Temps de resolution en prose = descripteurs machine-dep renvoyant aux sorties live (regle #9434). Re-exec complete du notebook (86 cellules, 33 code, 0 erreur). Verdict RECOVERABLE-LOCAL -> SOTA-OK.'


### PR DESCRIPTION
Grain: MED/notebook-csharp -- lane myia-po-2023:CoursIA -- prev: MED/notebook-csharp #14348

## Summary

Tranche densité round 2 de #11601 sur **CSP-1-Fundamentals-Csharp.ipynb** (kernel `.net-csharp`, Choco-solver via IKVM) : densité mesurée **1477 → 1571** (cible ≥1500). Gap mesuré avant geste : les sorties de la **cellule d'instance** (problème de coloration de l'Australie : espace brut, adjacences) et du **brute force** (2187 testées / 18 solutions / 3,9 ms) étaient sans interprétation — tous les autres outputs du notebook (graphe, backtracking, MRV, Choco, énumération, 8-Reines) en avaient déjà.

## Geste

**2 cellules « Lecture » insérées** (markdown-only, pur-ajout +29/0), ancrées sur les outputs réels committés :

- **Lecture de l'instance** (après la cellule de modélisation) : espace brut **2187 = 3⁷** qui cadre toute la suite, **SA hub** du graphe (5 voisins — exactement la variable que MRV choisira en section 5), **Tasmanie isolée** (sous-problème indépendant), 9 arêtes rejoignant la visualisation interprétée en aval.
- **Lecture du brute force** (après la cellule d'énumération exhaustive) : ratio **0,82 %** (18/2187 — solutions rares dans l'espace brut), **3,9 ms** qui semblent négligeables mais croissent en **3ⁿ** (~14 M combinaisons à 15 variables, ~3,5 milliards à 20) — l'argument qui motive le backtracking de la cellule suivante ; les **18 solutions** comme étalon que Choco retrouvera en section 6.

Références **relatives uniquement** (« cellule ci-dessus / suivante ») — vérifié : aucune référence numérique absolue dans le notebook, aucune cassure d'ancrage.

## Validation

- [x] Densité : 1477 → **1571** (`pedagogy_density.py`)
- [x] Markdown rendering : **0 violation** (baseline main = 0, donc 0 nouvelle)
- [x] Anchor check : **0 finding** (`check_interp_positioning.py`)
- [x] Accents audités **numériquement** : 439 → 481 (M+n), cellules non touchées identiques — pas de régression #13410, `source` en forme liste
- [x] Cells code **intactes** : `execution_count` 1-19 séquentiels, outputs inchangés, tous présents (exception markdown-only C.2)
- [x] Catalogue byte-identique à main, 2 fichiers (notebook + entrée registre twin `twin_pairs.d/csp-1-fundamentals.yaml` — rebaseline #8057 post-livraison, cf commentaire Twin parity), diff +35/0 (pur-ajout)

## Residuel

Cellule « Interprétation » existante du comparatif heuristiques contient une désaccentuation préexistante (« n amelioresent ») — hors scope de cette tranche densité, à traiter par la veine dédiée #2876 (accents), pas par une PR densité.

See #11601
