### PR TITLE
ci(#14283): route the last 32 routable guards to the self-hosted Linux pool (tranche 5)

### DIFF
--- a/.github/workflows/bare-cross-dir-load-gate.yml
+++ b/.github/workflows/bare-cross-dir-load-gate.yml
@@ -93,7 +93,12 @@ concurrency:
 jobs:
   bare-cross-dir-load:
     name: "No bare cross-dir #load in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/base-not-main-advisory.yml
+++ b/.github/workflows/base-not-main-advisory.yml
@@ -45,10 +45,14 @@ concurrency:
 jobs:
   signal:
     name: "Flag PR targeting a non-main base (advisory)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     # Skip the runner entirely for the ~95% of PRs whose base is main. The
     # event's OWN base ref drives the guard (not whatever main is at run time).
-    if: github.event.pull_request.base.ref != 'main'
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && github.event.pull_request.base.ref != 'main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/concurrency-conj-guard.yml
+++ b/.github/workflows/concurrency-conj-guard.yml
@@ -29,7 +29,12 @@ concurrency:
 jobs:
   guard:
     name: concurrency-conj-guard
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/degenerate-figure-gate.yml
+++ b/.github/workflows/degenerate-figure-gate.yml
@@ -67,7 +67,12 @@ concurrency:
 jobs:
   degenerate-figure:
     name: "No degenerate figure in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 2/2 de #12384 (clone partiel, suite c.518 tranche 1/2 #12884

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -19,7 +19,12 @@ concurrency:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/exercise-leak-ci.yml
+++ b/.github/workflows/exercise-leak-ci.yml
@@ -38,7 +38,12 @@ concurrency:
 jobs:
   exercise-leak-delta:
     name: "Exercice-solution HIGH delta guard (#8053)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/fabricated-output-gate.yml
+++ b/.github/workflows/fabricated-output-gate.yml
@@ -72,7 +72,12 @@ concurrency:
 jobs:
   fabricated-output:
     name: "No fabricated text output in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -88,7 +88,12 @@ concurrency:
 jobs:
   fast-lane:
     name: "Fast lane (ombre) -- 22 gardes, 1 checkout"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -55,7 +55,12 @@ jobs:
   # (cf pr-gate.yml, #10045 regle 2).
   check-lane-claim-required:
     name: 'Require no closing-ref against another lane active claim (block on lane collision, #10223)'
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout the lane-claim helper (sparse)
         uses: actions/checkout@v4
@@ -193,7 +198,12 @@ jobs:
   # pattern des autres jobs advisory (exercises-advisory, markdown-table-guard).
   check-lane-claim-advisory:
     name: 'Advisory lane-claim labels (adoption telemetry, non-blocking, #10223)'
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout the lane-claim helper (sparse)
         uses: actions/checkout@v4

--- a/.github/workflows/linux-runner-starvation-advisory.yml
+++ b/.github/workflows/linux-runner-starvation-advisory.yml
@@ -38,7 +38,12 @@ concurrency:
 jobs:
   starve:
     name: Linux runner starvation advisory
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/markdown-rendering-guard.yml
+++ b/.github/workflows/markdown-rendering-guard.yml
@@ -65,7 +65,12 @@ concurrency:
 jobs:
   render-scan:
     name: "markdown-rendering guard (main-repo notebooks)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -57,7 +57,12 @@ concurrency:
 jobs:
   md-table-syntax-advisory:
     name: "Markdown table syntax advisory (label, non-blocking)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/md-content-loss-gate.yml
+++ b/.github/workflows/md-content-loss-gate.yml
@@ -55,7 +55,12 @@ concurrency:
 jobs:
   md-content-loss:
     name: "No markdown content loss in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/ml-tests.yml
+++ b/.github/workflows/ml-tests.yml
@@ -27,7 +27,12 @@ concurrency:
 jobs:
   ml-tests:
     name: ML Pipeline Tests (CPU)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
 
     steps:
@@ -54,7 +59,11 @@ jobs:
 
   prover-tests:
     name: Prover Tests (placeholder)
-    runs-on: ubuntu-latest
-    if: false  # Enable when tests/prover/ has tests
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && false  # Enable when tests/prover/ has tests
     steps:
       - run: echo "Prover tests not yet available"

--- a/.github/workflows/notebook-output-failure-ratchet.yml
+++ b/.github/workflows/notebook-output-failure-ratchet.yml
@@ -42,7 +42,12 @@ concurrency:
 jobs:
   ratchet:
     name: Output-failure ratchet (base vs PR)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/notebook-validation.yml
+++ b/.github/workflows/notebook-validation.yml
@@ -24,7 +24,12 @@ concurrency:
 
 jobs:
   validate-notebooks:
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/owui-playwright-check.yml
+++ b/.github/workflows/owui-playwright-check.yml
@@ -40,7 +40,12 @@ concurrency:
 jobs:
   compile-collect:
     name: Compile & Collect (no live server)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -70,7 +70,12 @@ on:
 jobs:
   perimeter:
     name: "perimeter review guard (#11268)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/pr-gate-rerun.yml
+++ b/.github/workflows/pr-gate-rerun.yml
@@ -59,7 +59,12 @@ concurrency:
 jobs:
   reaggregate:
     name: Re-aggregate a PR gate verdict (manual)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Re-run the original PR gate for the PR head
         env:

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -57,7 +57,12 @@ concurrency:
 jobs:
   guard:
     name: "No notebook health regression"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 2/2 de #12383 (tranche 1/2 = #12810 sur translation-guard) :

--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -47,7 +47,12 @@ concurrency:
 jobs:
   render-volume-delta-advisory:
     name: "Render volume delta (#11656 advisory)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -110,7 +110,12 @@ concurrency:
 jobs:
   scripts-tests:
     name: Scripts Tests (CPU)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/series-naming-gate.yml
+++ b/.github/workflows/series-naming-gate.yml
@@ -44,7 +44,12 @@ concurrency:
 jobs:
   zero-pad-scan:
     name: "zero-pad guard (GameTheory serie)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/stale-base-warning.yml
+++ b/.github/workflows/stale-base-warning.yml
@@ -21,7 +21,12 @@ concurrency:
 jobs:
   check-base-age:
     name: Check base branch staleness
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       # Ce garde ne lit AUCUN contenu de fichier : `git rev-list --count` et
       # `git show -s --format=%ct` n'interrogent que le graphe de commits

--- a/.github/workflows/svg-broken-geometry-gate.yml
+++ b/.github/workflows/svg-broken-geometry-gate.yml
@@ -67,7 +67,12 @@ concurrency:
 jobs:
   svg-broken-geometry:
     name: "No SVG broken-geometry (negative-dim) defect in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 2/2 de #12384 (clone partiel, suite c.518 tranche 1/2 #12884

--- a/.github/workflows/svg-decimal-comma-gate.yml
+++ b/.github/workflows/svg-decimal-comma-gate.yml
@@ -62,7 +62,12 @@ concurrency:
 jobs:
   svg-decimal-comma:
     name: "No SVG decimal-comma defect in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 2/2 de #12384 (clone partiel, suite c.518 tranche 1/2 #12884

--- a/.github/workflows/svg-empty-display-gate.yml
+++ b/.github/workflows/svg-empty-display-gate.yml
@@ -117,7 +117,12 @@ concurrency:
 jobs:
   svg-empty-display:
     name: "No SVG empty-display defect in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 2/2 de #12384 (clone partiel, suite c.518 tranche 1/2 #12884

--- a/.github/workflows/svg-offscreen-flat-gate.yml
+++ b/.github/workflows/svg-offscreen-flat-gate.yml
@@ -58,7 +58,12 @@ concurrency:
 jobs:
   svg-offscreen-flat:
     name: "No offscreen-flat SVG in changed notebooks"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       # Tranche 2/2 de #12384 (clone partiel, suite c.518 tranche 1/2 #12884

--- a/.github/workflows/testpaths-coverage-guard.yml
+++ b/.github/workflows/testpaths-coverage-guard.yml
@@ -19,7 +19,12 @@ concurrency:
 jobs:
   guard:
     name: testpaths vs CI coverage
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -34,7 +34,12 @@ concurrency:
 jobs:
   translation-drift:
     name: "Translation drift (read-only)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -136,7 +136,12 @@ concurrency:
 jobs:
   translation-sync:
     name: "Translation auto-sync (long-lived PR)"
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     # workflow_dispatch (manual maintainer trigger) always allowed.
     # Note: prior versions carried `[skip ci]` in the bot commit message;
     # removed in #10421. The bot pushes to `chore/translation-sync-pending`,

--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -49,7 +49,12 @@ concurrency:
 jobs:
   check-light-genre-signals:
     name: G-VAR-2/3 GENRE signals (advisory, #10020)
-    runs-on: ubuntu-latest
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       # variation_light_cap.py importe grain_tag.py (#9485 : extracteur
       # partage avec le guard tag). Les deux modules sont checkout ensemble

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -159,6 +159,46 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "twin-parity-cron.yml",
     "twin-parity-drift-audit.yml",
     "workflow-path-filter-audit.yml",
+
+    # - tranche 5 (#13378/#14283, decision ai-01 2026-09-02) : le solde des
+    #   gardes routables. Exclus et pourquoi : pr-gate.yml (agregateur qui
+    #   poll jusqu'a 28 min -- le router reproduirait la famine mesuree en
+    #   #11405), lean-axiom/lean-build (builds Lean sans cache mathlib, cf
+    #   #14337 pools specialises), quarto-pages-deploy (quarto CLI + deploy
+    #   Pages), slides-composition-advisory (playwright --with-deps exige
+    #   root, le conteneur tourne en uid 1001).
+    "bare-cross-dir-load-gate.yml",
+    "base-not-main-advisory.yml",
+    "concurrency-conj-guard.yml",
+    "degenerate-figure-gate.yml",
+    "docs-link-check.yml",
+    "exercise-leak-ci.yml",
+    "fabricated-output-gate.yml",
+    "fast-lane-shadow.yml",
+    "lane-claim-guard.yml",
+    "linux-runner-starvation-advisory.yml",
+    "markdown-rendering-guard.yml",
+    "markdown-table-guard.yml",
+    "md-content-loss-gate.yml",
+    "ml-tests.yml",
+    "notebook-output-failure-ratchet.yml",
+    "notebook-validation.yml",
+    "owui-playwright-check.yml",
+    "perimeter-review-guard.yml",
+    "pr-gate-rerun.yml",
+    "regression-guard.yml",
+    "render-volume-delta-advisory.yml",
+    "scripts-tests.yml",
+    "series-naming-gate.yml",
+    "stale-base-warning.yml",
+    "svg-broken-geometry-gate.yml",
+    "svg-decimal-comma-gate.yml",
+    "svg-empty-display-gate.yml",
+    "svg-offscreen-flat-gate.yml",
+    "testpaths-coverage-guard.yml",
+    "translation-drift.yml",
+    "translation-sync.yml",
+    "variation-light-genre.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/tooling #14343

## Summary

Tranche 5 route **32 workflows / 34 declarations de job** de `ubuntu-latest` vers
`[self-hosted, coursia-ephemeral, coursia-linux]`, chacune avec la garde same-repo
universelle. C'est le **solde des gardes routables** : apres cette PR, tout ce qui
reste sur `ubuntu-latest` y reste pour une raison nommee et mesuree.

Moteur de politique : `workflows=134 jobs=162 self_hosted=109` (etait 75), rc=0.

**Perimetre effectif : 33 fichiers** -- les 32 workflows plus
`scripts/ci/check_self_hosted_runner_policy.py` (leur inscription a l'allowlist).

## Ce qui a rendu la mesure possible

`gh api "actions/runs?status=completed&per_page=N"` **ne rend pas les N runs les
plus recents** -- il a rendu des runs du 2026-08-03, donc un faux « 0 % ». La
fenetre doit etre **bornee dans le temps** (`created=%3E<ISO>` + `--paginate`),
jamais un compte de runs sous filtre de statut. Et `runner_name` est le champ
decisif (`.labels` ne dit que ce qui a ete *demande*), avec les runners
GitHub-hosted nommes `GitHub Actions <id>` -- d'ou une classification `~ /^myia-/`.

## Controle positif (pas un argument, une mesure)

`setup-python` et `pip install` sont **prouves sur le conteneur** : 61 workflows
deja routes utilisent `setup-python`, 31 utilisent `pip install`, tous verts sur
`coursia-linux`. Sur la fenetre 17:00Z, 112 succes sur 113 jobs executes chez
nous -- l'unique non-succes etant un **vrai finding de contenu** (`Twin parity
audit (#8057)` attrapant un DRIFT sur `feature/11601-csp1-density`), c'est-a-dire
exactement le contraire d'un garde rendu muet par un outil manquant.

## Exclusions -- chacune mesuree, aucune supposee

| Workflow | Pourquoi il reste GitHub-hosted |
|---|---|
| `pr-gate.yml` | Agregateur qui **poll jusqu'a 28 min**. Son propre commentaire relate l'incident que ce routage reproduirait : *« under runner starvation (11+/14 runners held by PR gate) the queue wait alone exceeded that budget »* (#11405). Un agregateur qui attend tient le slot qu'il attend. |
| `lean-axiom.yml`, `lean-build.yml` | `elan` + `lake build` sans cache mathlib sur un conteneur ephemere. Releve du design des pools specialises (#14337). |
| `quarto-pages-deploy.yml` | `quarto-dev/quarto-actions/setup@v2` + deploy Pages. |
| `slides-composition-advisory.yml` | `playwright install --with-deps` exige root ; le conteneur tourne en uid 1001. |

**Structurellement non-routables**, laisses tels quels : `always-on-guards.yml`
(`pull_request_review`) et `variation-tag-guard.yml` (`issue_comment`) sont
FORK_REACHABLE par politique -- ce n'est pas l'image du conteneur qui bloque,
c'est le declencheur. Les 4 jobs CodeQL `Analyze (*)` sont en *default setup*,
configures hors du depot.

## Verification

- `python3 scripts/ci/check_self_hosted_runner_policy.py` -> rc=0, `self_hosted=109`
- Parse YAML des 134 workflows -> 0 fichier KO
- Parite garde/routage : 1 `if:` same-repo par job route, sur les 32 fichiers
- Les deux `if:` preexistants sont fusionnes en `(<universelle>) && <selection>`
  (parentheses requises : `&&` lie plus fort que `||`, cf #14148)

## Retour arriere

Revert de cette PR. Aucune autre dependance.

See #14283
