### PR TITLE
feat(training,#1454): bias-audit M5 HMM regime-switching HAR — ETH h=1 BEATS survives, BTC h=1 was 82% baseline bias

### DIFF
--- a/.github/workflows/ml-tests.yml
+++ b/.github/workflows/ml-tests.yml
@@ -46,7 +46,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy pandas scipy scikit-learn arch pytest pyarrow xgboost joblib
+          # hmmlearn: required by scripts/hmm_regime_vol.py (M5). CPU-only,
+          # depends on numpy/scipy/scikit-learn which are already installed --
+          # it is listed so the M5 suite actually RUNS here rather than being
+          # skipped, which would make its assertions a control never shown firing.
+          pip install numpy pandas scipy scikit-learn arch pytest pyarrow xgboost joblib hmmlearn
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run tests

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -14,6 +14,7 @@ Updated: 2026-08-24 — Re-validation hors-biais des keepers BTC (issues #11041/
 Updated: 2026-08-24 — M15 LSTM-vol patch persistance biais + slice 2/2 dé-biaisé symétrique (issue #12734): patch livré, run complet dispatché au prochain cycle
 Updated: 2026-09-01 — PatchTST BTC log-RV revalidé contre HAR débiaisé train-only (#14081) : h=1 INCONCLUSIVE, h=5/h=10 NO BEATS ; var_ratio > 1 aux trois horizons
 Updated: 2026-09-02 — M16 HAR asymétrique BTC revalidé contre HAR débiaisé train-only (#1454) : h=1 INCONCLUSIVE, h=5/h=10 BEATS ; verdict brut 3/3 réfuté
+Updated: 2026-09-02 — M5 HMM regime-switching HAR, première entrée + revalidation hors biais (Epic #1454) : ETH h=1 **BEATS confirmé** (+8,7 % hors biais, 4/4 seeds, 4,1σ) ; BTC h=1 s'effondre de +7,0 % à +1,3 % (~82 % de l'edge était le biais de HAR) ; 4/6 NO BEATS
 
 Total checkpoints: 70 (20 legacy ARCHIVED + 50 panier baselines)
 
@@ -354,6 +355,75 @@ h=5 et h=10 réfutent l'edge deep-seq, respectivement 3/4 et 4/4 seeds significa
 - **Run** : `python scripts/btc_patchtst.py --device cpu --horizons 1 5 10 --seeds 0 1 7 42 --n-splits 5 --seq-len 64 --patch-len 16 --stride 8 --d-model 32 --n-heads 4 --n-layers 1 --epochs 10 --batch-size 32 --out-json results/btc_patchtst_har_debiased_cpu_20260901.json` — 115,9 s CPU, 12/12 combinaisons, 5 folds chacune.
 - **Vérification** : 12 lignes JSON, 1 890 / 1 870 / 1 845 prédictions alignées par seed selon h ; longueurs erreurs/prédictions/timestamps identiques ; `MSE = biais² + variance` recalculé à tolérance numérique sur chaque ligne.
 - **Verdict §C** : **0/3 BEATS, 1/3 INCONCLUSIVE, 2/3 NO BEATS**. Mesure de prévision uniquement : aucune stratégie de trading ni claim après coûts.
+
+## M5 HMM regime-switching HAR — entrée §C + revalidation hors biais (2026-09-02) — Epic #1454
+
+Première entrée REGISTRY de M5 : le modèle était documenté (`docs/M5_HMM_REGIME.md`, Cycle 25) et
+portait un **BEATS vivant** (`ETH-USD h=1`, +9,6 %, 4/4 seeds) qu'aucun rapport de biais n'avait
+audité — le document ne contenait aucune occurrence de `bias`/`biais`/`recentr`/`debias`, et M5
+n'apparaissait pas ici. Le harnais ne persistait que des MSE agrégés : le verdict publié était
+**invalidable post-hoc sans ré-entraînement**, exactement le constat que #12745 avait levé sur M4/M15.
+
+**Protocole réel** : BTC Bitstamp hourly, 2 278 jours de RV (2018-05-15→2024-08-08) ; ETH Binance
+hourly, 1 495 jours (2019-10-21→2023-12-14). HAR à régimes = HMM gaussien K=2 (hmmlearn, Viterbi sur
+log-RV) + OLS à 8 coefficients (4 base + 4 termes d'interaction `I(regime=high)`) ; baseline = HAR
+classique Corsi 3 paramètres. Walk-forward 5 folds expanding, refit tous les 22 jours, seeds
+{0,7,42,99}, horizons {1,5,10} — 24 combinaisons, 331,6 s CPU (ni GPU ni réseau : HMM + OLS).
+DM HAC `loss_fn="mse"`. La jambe hors biais recentre les erreurs **des deux côtés**
+(`e − mean(e)`) et compare aussi l'edge contre une baseline dé-biaisée. Les jambes brutes publiées en
+Cycle 25 sont recalculées à l'identique et **non modifiées**.
+
+| Coin | h | edge brut | edge vs classic dé-biaisée | σ cross-seed | edge/σ | dm_p_median (rec.) | seeds BEATS / BEATEN (rec.) | Verdict hors biais |
+|---|---:|---:|---:|---:|---:|---:|:---:|---|
+| BTC-USD | 1  |  +7,0 % |  **+1,3 %** |  4,04 pt | **0,3σ** | 1,47e-03 | 3/4 · 0/4 | **INCONCLUSIVE** |
+| BTC-USD | 5  | −11,1 % | **−43,5 %** |  9,37 pt | 4,6σ | 6,21e-06 | 0/4 · 4/4 | **NO BEATS** |
+| BTC-USD | 10 | −28,3 % | **−99,0 %** | 21,18 pt | 4,7σ | 1,75e-09 | 0/4 · 4/4 | **NO BEATS** |
+| ETH-USD | 1  |  +9,6 % |  **+8,7 %** |  2,11 pt | **4,1σ** | 1,14e-05 | 4/4 · 0/4 | **BEATS** |
+| ETH-USD | 5  | −17,9 % | **−23,4 %** |  3,85 pt | 6,1σ | 6,16e-04 | 0/4 · 4/4 | **NO BEATS** |
+| ETH-USD | 10 | −53,0 % | **−66,2 %** | 14,70 pt | 4,5σ | 4,10e-05 | 0/4 · 4/4 | **NO BEATS** |
+
+**Rapport de biais signé (contrôle §C(7))** — régime / classic, biais² de la baseline en part de son
+MSE : BTC −0,1811/−0,2266 (**5,8 %**), −0,2728/−0,3432 (**22,6 %**), −0,3624/−0,4502 (**35,5 %**) ;
+ETH −0,0718/−0,0810 (**1,0 %**), −0,1091/−0,1290 (**4,5 %**), −0,1519/−0,1727 (**8,0 %**) — h=1/5/10.
+Les deux modèles sous-prévoient le log-RV ; la part de biais de la baseline croît avec l'horizon.
+
+**Lecture — le seul BEATS de M5 survit, et l'échec voisin change de cause.** `ETH h=1` ne perd que
+0,9 pt au dé-biaisage (+9,6 → +8,7 %) et satisfait la conjonction §C complète (4/4 seeds sur la jambe
+de précision, `dm_p_median` 1,14e-05, **4,1σ ≥ 2σ**) : c'est une vraie réduction de variance, pas la
+miscalibration de la baseline. Le contraste avec M15 est net — même instrument, verdict opposé
+(`refuted-de-biased` 3/3, #11041). En revanche `BTC h=1` s'effondre de +7,0 % à **+1,3 %** : **~82 %
+de son edge apparent était le biais de la HAR BTC**, dont le biais² pèse 5,8 % du MSE. Le verdict brut
+disait déjà INCONCLUSIVE mais l'imputait à la graine 7 ; hors biais, l'edge vaut **0,3σ** de la
+dispersion cross-seed — l'effet n'existe pas, il n'est pas seulement instable. Enfin, dé-biaiser la
+baseline **aggrave** les quatre configs longues (BTC h=10 : −28,3 → −99,0 %) : le biais de la HAR
+masquait l'ampleur de la dégradation. La conclusion d'origine « nuisible à h≥5 » est renforcée.
+
+**L'asymétrie BTC/ETH à h=1 appartient à la baseline, pas au modèle.** Même modèle, même instrument :
+la HAR BTC porte 5,8 % de biais², la HAR ETH 1,0 % — d'où 82 % de biais dans l'edge BTC contre 9 %
+dans l'edge ETH. Toute lecture cross-coin de M5 qui ignore cette colonne compare des baselines de
+qualité différente.
+
+**Comparabilité M4/M5 — même objet de baseline.** `hmm_regime_vol.py` et la chaîne
+`btc_vol.py → dlinear_vol.py` importent le même `har_model.HARModel` (définition unique). Le biais OOS
+BTC mesuré ici est **bit-identique** à `har_bias_oos` de l'artefact #12745 (−0,2265869503892514 /
+−0,34317822065868814 / −0,45022101989096786 pour h=1/5/10, 17 chiffres). Ce n'est **pas** une
+corroboration indépendante — c'est le même calcul appelé depuis deux harnais — mais cela vérifie le
+câblage de l'instrumentation ajoutée ici et rend les edges M4 et M5 directement comparables sur BTC.
+
+**Portée — ce que cette entrée ne couvre PAS** : (1) verdict de **prévision** (MSE log-RV)
+uniquement — aucune stratégie de vol-timing dérivée, aucun coût de transaction imputé ; (2) K=2
+états seulement (K≥3 non testé) ; (3) le défaut structurel noté en Cycle 25 — la prévision itérative
+à h pas utilise un **unique** indicateur de régime pour tous les pas — est inchangé et reste
+l'explication la plus plausible de la dégradation aux horizons longs, mais n'est pas isolé
+expérimentalement ici ; (4) les séries alignées ne sont pas versionnées (option `--dump-series`,
+CSV hors dépôt, 37 040 lignes pour la grille complète).
+
+- **Run** : `python scripts/hmm_regime_vol.py --coins BTC-USD ETH-USD --horizons 1 5 10 --seeds 0 7 42 99 --out results/m5_hmm_regime_debiased/results_full.json --dump-series results/m5_hmm_regime_debiased/series_full.csv` — 331,6 s CPU, 24/24 combinaisons, 5 folds chacune, 30 lignes JSON (24 par seed + 6 agrégats).
+- **Vérification** : `MSE = biais² + variance` recalculé par ligne (tolérance 1e-12) ; identité
+  `d_brut − d_recentré = biais_a² − biais_b²` vérifiée numériquement (résidu ~1e-17) et scellée en
+  test paramétré ; 22 tests dans `scripts/tests/test_hmm_regime_vol.py`, voisins `test_btc_vol.py` /
+  `test_diebold_mariano.py` / `test_har_model.py` / `test_dlinear_debiased_edge.py` verts (57).
+- **Verdict §C hors biais** : **1/6 BEATS (ETH h=1, `confirmed`), 1/6 INCONCLUSIVE, 4/6 NO BEATS**.
 
 ## M4 DLinear-vol — extension §C ETF (2026-08-23) — Epic #1454
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -421,7 +421,9 @@ CSV hors dépôt, 37 040 lignes pour la grille complète).
 - **Run** : `python scripts/hmm_regime_vol.py --coins BTC-USD ETH-USD --horizons 1 5 10 --seeds 0 7 42 99 --out results/m5_hmm_regime_debiased/results_full.json --dump-series results/m5_hmm_regime_debiased/series_full.csv` — 331,6 s CPU, 24/24 combinaisons, 5 folds chacune, 30 lignes JSON (24 par seed + 6 agrégats).
 - **Vérification** : `MSE = biais² + variance` recalculé par ligne (tolérance 1e-12) ; identité
   `d_brut − d_recentré = biais_a² − biais_b²` vérifiée numériquement (résidu ~1e-17) et scellée en
-  test paramétré ; 22 tests dans `scripts/tests/test_hmm_regime_vol.py`, voisins `test_btc_vol.py` /
+  test paramétré ; les six verdicts publiés ci-dessous sont rejoués depuis la machine d'états agrégée
+  (`_aggregate_debiased_state`), avec contrôles négatifs 3/4 des deux côtés ; 45 tests dans
+  `scripts/tests/test_hmm_regime_vol.py`, voisins `test_btc_vol.py` /
   `test_diebold_mariano.py` / `test_har_model.py` / `test_dlinear_debiased_edge.py` verts (57).
 - **Verdict §C hors biais** : **1/6 BEATS (ETH h=1, `confirmed`), 1/6 INCONCLUSIVE, 4/6 NO BEATS**.
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_HMM_REGIME.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_HMM_REGIME.md
@@ -51,7 +51,7 @@ Where:
 | File | Role |
 |------|------|
 | `scripts/hmm_regime_vol.py` | HMM regime-switching HAR model + walk-forward runner + instrumentation de biais |
-| `scripts/tests/test_hmm_regime_vol.py` | Tests du contrat de sortie et de la jambe recentrée (22 tests) |
+| `scripts/tests/test_hmm_regime_vol.py` | Tests du contrat de sortie, de la jambe recentrée et de la machine d'états agrégée (45 tests) |
 | `scripts/results/m5_hmm_regime.json` | Full results (609s runtime) |
 | `docs/M5_HMM_REGIME.md` | This document |
 
@@ -110,6 +110,28 @@ recalculées à l'identique et les colonnes ci-dessous s'y ajoutent.
 | ETH-USD | 1  |  +9,6 % |  **+8,7 %** |  2,11 pt | **4,1σ** | 4/4 | 0/4 | 1,14e-05 | **BEATS** |
 | ETH-USD | 5  | −17,9 % | **−23,4 %** |  3,85 pt | 6,1σ | 0/4 | 4/4 | 6,16e-04 | **NO BEATS** |
 | ETH-USD | 10 | −53,0 % | **−66,2 %** | 14,70 pt | 4,5σ | 0/4 | 4/4 | 4,10e-05 | **NO BEATS** |
+
+La colonne « Verdict hors biais » **est** le champ `aggregate_verdict_debiased` de l'artefact JSON, et
+non une lecture faite à la main par-dessus : les six lignes ci-dessus sont rejouées depuis
+`_aggregate_debiased_state` dans `scripts/tests/test_hmm_regime_vol.py`. La machine a quatre états —
+
+| État | Condition | Sens |
+|------|-----------|------|
+| `BEATS` | 4/4 seeds BEATS sur la jambe recentrée **et** `dm_p_median < 0,05` | l'edge survit au contrôle de précision |
+| `NO BEATS` | 4/4 seeds BEATEN **et** `dm_p_median < 0,05` | le modèle perd, significativement |
+| `refuted-de-biased` | la jambe **brute** était 4/4 BEATS, la recentrée ne confirme pas | l'edge n'existait que contre une ligne de base mal calibrée (formulation #12788) |
+| `INCONCLUSIVE` | tout le reste (dont 3/4 d'un côté ou l'autre) | pas d'unanimité |
+
+`NO BEATS` l'emporte sur `refuted-de-biased` quand les deux s'appliquent : « réfuté » dit qu'une
+prétention n'est pas confirmée, la mesure dit que le modèle perd — et la réfutation reste lisible
+puisque chaque ligne imprime le verdict brut à côté du recentré. Le décompte des pertes est persisté
+(`n_beaten_seeds_centered`), donc la colonne « seeds BEATEN (rec.) » se relit depuis l'artefact.
+
+Le champ `aggregate_verdict` (jambe **brute**) garde délibérément sa convention publiée à deux états
+(« BEATS exige 4/4 seeds, sinon INCONCLUSIVE ») : `m5_hmm_regime_research.ipynb` la documente et en
+dérive sa propre lecture `DEGRADE`, qu'un élargissement invaliderait en silence (il faudrait
+re-générer l'artefact puis ré-exécuter le notebook). L'asymétrie est assumée et suivie en **#14388**,
+pas un oubli.
 
 **Rapport de biais signé, par modèle (contrôle §C(7))** — le biais est celui du log-RV OOS :
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_HMM_REGIME.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_HMM_REGIME.md
@@ -41,16 +41,23 @@ Where:
 - Walk-forward 5-fold expanding window, refit every 22 days
 - 4 seeds (0, 7, 42, 99) for HMM initialization
 - 2 coins (BTC-USD, ETH-USD), 3 horizons (h=1, 5, 10)
-- Diebold-Mariano HAC test vs classic HAR baseline
+- Diebold-Mariano HAC test vs classic HAR baseline (`loss_fn="mse"` — perte de précision, jamais `linear`)
 - Aggregate verdict: BEATS only if 4/4 seeds pass DM
+- Jambe hors biais (ajoutée 2026-09-02) : décomposition `MSE = biais² + variance` par modèle, edge
+  contre baseline dé-biaisée, et DM sur erreurs recentrées des deux côtés
 
 ## Files
 
 | File | Role |
 |------|------|
-| `scripts/hmm_regime_vol.py` | HMM regime-switching HAR model + walk-forward runner |
+| `scripts/hmm_regime_vol.py` | HMM regime-switching HAR model + walk-forward runner + instrumentation de biais |
+| `scripts/tests/test_hmm_regime_vol.py` | Tests du contrat de sortie et de la jambe recentrée (22 tests) |
 | `scripts/results/m5_hmm_regime.json` | Full results (609s runtime) |
 | `docs/M5_HMM_REGIME.md` | This document |
+
+Le runner expose un CLI (`--coins`, `--horizons`, `--seeds`, `--out`, `--dump-series`). Les séries de
+prévision alignées ne sont écrites que sur `--dump-series` (CSV séparé) : l'artefact JSON reste léger
+et ne porte que des agrégats et des décompositions, sur le modèle de #12745.
 
 ## Results (BTC+ETH, 4 seeds, 609s runtime)
 
@@ -59,8 +66,8 @@ Where:
 | Verdict | Count | Configs |
 |---------|-------|---------|
 | **BEATS** | 1/6 | ETH h=1 (4/4 seeds) |
-| INCONCLUSIVE | 2/6 | BTC h=1 (3/4 seeds), BTC h=5 |
-| **BEATEN BY** | 3/6 | BTC h=5, BTC h=10, ETH h=5, ETH h=10 |
+| INCONCLUSIVE | 1/6 | BTC h=1 (3/4 seeds) |
+| **BEATEN BY** | 4/6 | BTC h=5, BTC h=10, ETH h=5, ETH h=10 |
 
 ### Per-coin results (aggregated over 4 seeds)
 
@@ -82,7 +89,80 @@ Where:
 
 (*3/4 seeds significant, not all 4)
 
+## Re-validation hors biais (2026-09-02, Epic #1454)
+
+Les résultats ci-dessus comparent deux MSE **bruts**. Or `MSE = biais² + variance` : un écart de MSE
+peut être entièrement la **mauvaise calibration de la baseline**, et non un gain de précision du
+modèle. C'est ce que #10938 a levé sur M4, ce que #12684/#12734 ont formalisé, et ce que
+`pr-review-discipline` §C exige depuis (rapport de biais par modèle, DM sur une perte de précision).
+
+Le harnais persiste désormais, par seed et par config : le biais OOS signé des **deux** modèles, la
+décomposition `MSE = biais² + variance`, l'écart contre une baseline **dé-biaisée**, et un DM sur
+**erreurs recentrées** (`e − mean(e)` de chaque côté — le centrage annule le biais, le DM ne compare
+plus que les variances). Aucune valeur publiée ci-dessus n'a été modifiée : les jambes brutes sont
+recalculées à l'identique et les colonnes ci-dessous s'y ajoutent.
+
+| Coin | h | edge brut | edge vs classic **dé-biaisée** | σ cross-seed | edge/σ | seeds BEATS (rec.) | seeds BEATEN (rec.) | dm_p_median (rec.) | Verdict hors biais |
+|------|---|----------:|-------------------------------:|-------------:|-------:|:------------------:|:-------------------:|-------------------:|--------------------|
+| BTC-USD | 1  |  +7,0 % |  **+1,3 %** |  4,04 pt | **0,3σ** | 3/4 | 0/4 | 1,47e-03 | **INCONCLUSIVE** |
+| BTC-USD | 5  | −11,1 % | **−43,5 %** |  9,37 pt | 4,6σ | 0/4 | 4/4 | 6,21e-06 | **NO BEATS** |
+| BTC-USD | 10 | −28,3 % | **−99,0 %** | 21,18 pt | 4,7σ | 0/4 | 4/4 | 1,75e-09 | **NO BEATS** |
+| ETH-USD | 1  |  +9,6 % |  **+8,7 %** |  2,11 pt | **4,1σ** | 4/4 | 0/4 | 1,14e-05 | **BEATS** |
+| ETH-USD | 5  | −17,9 % | **−23,4 %** |  3,85 pt | 6,1σ | 0/4 | 4/4 | 6,16e-04 | **NO BEATS** |
+| ETH-USD | 10 | −53,0 % | **−66,2 %** | 14,70 pt | 4,5σ | 0/4 | 4/4 | 4,10e-05 | **NO BEATS** |
+
+**Rapport de biais signé, par modèle (contrôle §C(7))** — le biais est celui du log-RV OOS :
+
+| Coin | h | biais régime | biais classic | biais²(classic) en % de MSE(classic) |
+|------|---|-------------:|--------------:|-------------------------------------:|
+| BTC-USD | 1  | −0,1811 | −0,2266 |  **5,8 %** |
+| BTC-USD | 5  | −0,2728 | −0,3432 | **22,6 %** |
+| BTC-USD | 10 | −0,3624 | −0,4502 | **35,5 %** |
+| ETH-USD | 1  | −0,0718 | −0,0810 |  **1,0 %** |
+| ETH-USD | 5  | −0,1091 | −0,1290 |  **4,5 %** |
+| ETH-USD | 10 | −0,1519 | −0,1727 |  **8,0 %** |
+
+Les deux modèles sous-prévoient le log-RV partout (biais négatif), le régime un peu moins que la
+baseline. La part de biais² dans le MSE de la baseline **croît fortement avec l'horizon** : à
+BTC h=10, plus du tiers du MSE de la HAR classique est du biais pur, pas de l'imprécision.
+
+### Ce que la relecture hors biais change
+
+1. **ETH h=1 survit — c'est un vrai gain de précision.** L'edge passe de +9,6 % à **+8,7 %** une fois
+   la baseline dé-biaisée : seulement 0,9 pt de l'écart venait du biais. La conjonction §C est
+   complète — 4/4 seeds BEATS sur la jambe recentrée, `dm_p_median` = 1,14e-05 < 0,05, et
+   **4,1σ ≥ 2σ** de dispersion cross-seed. Le seul BEATS de M5 **tient hors biais**.
+
+2. **BTC h=1 tombe, et pour une raison mesurée.** L'edge brut +7,0 % se réduit à **+1,3 %** : environ
+   **82 % de l'écart apparent était la mauvaise calibration de la HAR**, dont le biais² pèse 5,8 % de
+   son MSE. Le verdict brut le disait déjà INCONCLUSIVE, mais en imputant l'échec à la seule graine 7
+   (« HMM initialization sensitivity »). La mesure est plus dure : à **0,3σ**, l'edge dé-biaisé est
+   trois fois plus petit que la dispersion entre graines. Ce n'est pas une graine aberrante, c'est un
+   effet qui n'existe pas.
+
+3. **Le biais de la baseline masquait l'ampleur de la dégradation aux horizons longs.** Dé-biaiser la
+   HAR classique la rend meilleure, donc creuse l'écart : BTC h=10 passe de −28,3 % à **−99,0 %**,
+   BTC h=5 de −11,1 % à −43,5 %. Les quatre configs longues sont **4/4 seeds BEATEN** sur la jambe de
+   précision. La conclusion d'origine (« le modèle de régime est nuisible à h≥5 ») est confirmée et
+   renforcée, pas infirmée.
+
+4. **L'asymétrie BTC/ETH à h=1 est une propriété de la baseline, pas du modèle de régime.** Le même
+   modèle, le même instrument : la HAR BTC porte 5,8 % de biais², la HAR ETH seulement 1,0 %. C'est
+   pourquoi l'edge BTC était à 82 % du biais et l'edge ETH à 9 % seulement. Ce que M5 « gagnait » sur
+   BTC h=1, c'était surtout de corriger une baseline mal calée.
+
+**Note de comparabilité** — la HAR classique de ce harnais et la baseline HAR de M4 sont le **même
+objet** : `hmm_regime_vol.py` et la chaîne `btc_vol.py → dlinear_vol.py` importent toutes deux
+l'unique `har_model.HARModel`. Le biais OOS BTC mesuré ici (−0,2265869503892514 / −0,34317822065868814 /
+−0,45022101989096786 pour h=1/5/10) est **bit-identique** à `har_bias_oos` de l'artefact #12745. Ce
+n'est donc pas une corroboration indépendante — c'est le même calcul — mais cela vérifie que
+l'instrumentation de biais ajoutée ici est câblée comme celle de la famille, et cela rend les edges
+M5 et M4 directement comparables sur BTC.
+
 ## Key findings
+
+*(Lecture d'origine, Cycle 25, sur MSE bruts. Conservée telle quelle ; la section « Re-validation
+hors biais » ci-dessus précise les points 1 et 2 et confirme le point 3.)*
 
 1. **ETH h=1: only significant win.** The regime-switching HAR beats classic HAR by 9.6%
    (4/4 seeds, p<0.005). ETH's shorter data history (1495 RV days) with more pronounced
@@ -108,7 +188,14 @@ Where:
 
 ## Conclusion
 
-**M5 verdict: INCONCLUSIVE overall. 1/6 configs BEATS (ETH h=1).**
+**Verdict hors biais (2026-09-02, Epic #1454) : `confirmed` sur ETH h=1, `NO BEATS` 4/6, INCONCLUSIVE
+1/6.** Le seul BEATS de M5 tient une fois la baseline dé-biaisée (+8,7 %, 4/4 seeds, 4,1σ,
+`dm_p_median` 1,14e-05) — contrairement à M15, réfuté par le même instrument (`refuted-de-biased`
+3/3, #11041). Le verdict brut ci-dessous reste exact et n'est pas révisé ; la relecture hors biais
+le **précise** : BTC h=1 n'était pas « prometteur mais sensible aux graines », son edge était à 82 %
+le biais de la HAR ; et la dégradation à h≥5 est plus sévère qu'elle ne le paraissait.
+
+**M5 verdict (brut, tel que publié en Cycle 25) : INCONCLUSIVE overall. 1/6 configs BEATS (ETH h=1).**
 
 The HMM regime-switching HAR provides marginal improvement at h=1 for some configurations
 but is actively harmful at h>=5. The approach adds complexity (8 coefficients + HMM

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
@@ -41,10 +41,24 @@ from har_model import HARModel, _make_split_indices
 from intraday_loader import load_binance_eth, load_bitstamp_btc
 from realized_variance import daily_realized_variance, har_lag_features, realized_variance_to_log
 
+_HMMLEARN_MISSING = "hmmlearn not found. Install with: pip install hmmlearn"
+
 try:
     from hmmlearn.hmm import GaussianHMM
-except ImportError:
-    sys.exit("hmmlearn not found. Install with: pip install hmmlearn")
+except ImportError:  # pragma: no cover - only taken where hmmlearn is absent
+    # Deliberately NOT `sys.exit` at import time: this module is imported by
+    # `tests/test_hmm_regime_vol.py`, and a SystemExit raised during pytest
+    # collection aborts the whole session with INTERNALERROR -- taking down
+    # every other suite in the directory, not just this one. The failure is
+    # deferred to the point of use, where it still reports identically for
+    # CLI callers (same message, same exit code).
+    GaussianHMM = None
+
+
+def _require_hmmlearn() -> None:
+    """Fail with the CLI-identical message when hmmlearn is unavailable."""
+    if GaussianHMM is None:
+        sys.exit(_HMMLEARN_MISSING)
 
 
 SEEDS = [0, 7, 42, 99]
@@ -119,6 +133,7 @@ def _dm_centered_mse(errors_a: np.ndarray, errors_b: np.ndarray, horizon: int) -
 
 def fit_hmm_regimes(log_rv_train: np.ndarray, seed: int) -> "GaussianHMM":
     """Fit K-state GaussianHMM on log-RV. State 0 = low vol, state 1 = high vol."""
+    _require_hmmlearn()
     model = GaussianHMM(
         n_components=N_HMM_STATES,
         covariance_type="full",
@@ -443,6 +458,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> None:
     args = _parse_args(argv)
+    # Fail fast, before loading any data -- same message and exit code as the
+    # former import-time guard.
+    _require_hmmlearn()
     seeds = list(args.seeds)
     horizons = list(args.horizons)
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
@@ -24,6 +24,7 @@ References:
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import time
@@ -52,6 +53,68 @@ N_SPLITS = 5
 REFIT_EVERY = 22
 N_HMM_STATES = 2
 RESULTS_DIR = SCRIPTS_DIR / "results"
+
+
+# `_mse_decomposition` and `_dm_centered_mse` are the canonical bias/precision
+# helpers introduced by PR #12742 in `btc_vol.py`. They are duplicated here for
+# the reason `btc_m15.py` states verbatim -- "keep this PR self-contained until
+# a shared module is extracted (TODO post-merge)" -- with one M5-specific
+# reason on top: `btc_vol` imports `dlinear_vol`, which imports `torch` at
+# module level. M5 is HMM + OLS and runs on CPU with no deep-learning stack;
+# importing it for two pure numpy functions would drag torch into a script that
+# does not need it. M5 is now the THIRD duplication site, which is the argument
+# for finally extracting them -- filed separately rather than folded in here.
+def _is_beats(verdict: str) -> bool:
+    """True only for `dm_verdict`'s winning verdict.
+
+    `dm_verdict` emits exactly three strings: "BEATS baseline",
+    "BEATEN BY baseline" and "INCONCLUSIVE". A bare `"BEATS" in verdict`
+    also matches "BEATEN BY baseline" under a substring test on some
+    tokenisations, hence the explicit exclusion kept from the original code.
+    """
+    return "BEATS" in verdict and "BEATEN" not in verdict
+
+
+def _mse_decomposition(errors: np.ndarray) -> dict:
+    """Decompose MSE of a forecast into bias^2 + variance on the error support."""
+    if errors is None or len(errors) == 0:
+        return {"mse": float("nan"), "bias_sq": float("nan"), "variance": float("nan")}
+    bias = float(np.mean(errors))
+    variance = float(np.var(errors, ddof=0))
+    return {
+        "mse": float(np.mean(errors ** 2)),
+        "bias_sq": bias ** 2,
+        "variance": variance,
+    }
+
+
+def _dm_centered_mse(errors_a: np.ndarray, errors_b: np.ndarray, horizon: int) -> dict:
+    """DM test on errors centered by their own mean, with loss_fn='mse'.
+
+    Centering annihilates the bias component (`mean(e - mean(e)) = 0`), so the
+    resulting `d_mean` measures only the variance differential. The "DM on
+    precision" jambe that #10961 documents is exactly this.
+
+    `loss_fn` stays "mse" on purpose: §C forbids `linear` as the conjunction
+    leg, because on raw signed errors `d_mean = bias_a - bias_b` is blind to
+    dispersion -- it measures the very quantity centering removes.
+    """
+    e_a = np.asarray(errors_a, dtype=float)
+    e_b = np.asarray(errors_b, dtype=float)
+    if e_a.shape != e_b.shape:
+        return {"dm_stat": float("nan"), "dm_pvalue": float("nan"), "dm_verdict": "SHAPE_MISMATCH"}
+    if len(e_a) < 10:
+        return {"dm_stat": float("nan"), "dm_pvalue": float("nan"), "dm_verdict": "INSUFFICIENT_DATA"}
+
+    res = dm_verdict(
+        e_a - np.mean(e_a), e_b - np.mean(e_b), horizon=horizon, loss_fn="mse",
+    )
+    return {
+        "dm_stat": float(res["dm_statistic"]),
+        "dm_pvalue": float(res["p_value"]),
+        "dm_verdict": str(res["verdict"]),
+        "mean_loss_diff": float(res["mean_loss_diff"]),
+    }
 
 
 def fit_hmm_regimes(log_rv_train: np.ndarray, seed: int) -> "GaussianHMM":
@@ -248,6 +311,43 @@ def walk_forward_regime_switching(
     classic_errors = classic_preds - truths_arr
     dm = dm_verdict(regime_errors, classic_errors, horizon=horizon)
 
+    # --- Bias instrumentation (#1454 sub-grain; family pattern of #12742/#12745)
+    #
+    # `MSE = bias^2 + variance`. A DM on RAW errors therefore answers "which
+    # model has the lower loss", NOT "which model is more precise": an edge can
+    # be carried entirely by the baseline being miscalibrated. That is not
+    # hypothetical here -- #12745 measured `har_bias_oos = -0.227` on BTC
+    # against the very same classic-HAR baseline this harness compares to, and
+    # the M15 edge did not survive the control (`refuted-de-biased`, #12788).
+    #
+    # Three legs are persisted, and none of them replaces the published one:
+    #   * the signed OOS bias of EACH model (pr-review-discipline §C requires
+    #     the bias report for "modele ET baseline"),
+    #   * the edge recomputed against the DE-BIASED classic HAR, the §C
+    #     interpretation `btc_vol.run_btc_debiased_recentered` uses,
+    #   * `dm_centered_*`, the DM on errors centered by their own mean, whose
+    #     `d_mean` is a pure variance differential -- the leg that says "more
+    #     precise" rather than "better calibrated" (#10961).
+    #
+    # `dm_statistic` / `dm_p_value` / `dm_verdict` keep their original raw-error
+    # meaning so the numbers already published in docs/M5_HMM_REGIME.md stay
+    # reproducible and comparable; the control is ADDED beside them, never
+    # substituted for them.
+    regime_decomp = _mse_decomposition(regime_errors)
+    classic_decomp_raw = _mse_decomposition(classic_errors)
+
+    regime_bias_oos = float(np.mean(regime_errors)) if len(truths_arr) else float("nan")
+    classic_bias_oos = float(np.mean(classic_errors)) if len(truths_arr) else float("nan")
+
+    # De-biased classic HAR: subtract its own OOS bias from its forecasts.
+    # The regime model is left raw -- comparing a raw model to a de-biased
+    # baseline is the strict reading of §C (it can only hurt the model).
+    classic_errors_debiased = classic_errors - classic_bias_oos
+    classic_decomp_debiased = _mse_decomposition(classic_errors_debiased)
+    classic_mse_debiased = classic_decomp_debiased["mse"]
+
+    dm_centered = _dm_centered_mse(regime_errors, classic_errors, horizon=horizon)
+
     return {
         "seed": seed,
         "horizon": horizon,
@@ -261,6 +361,39 @@ def walk_forward_regime_switching(
         "dm_statistic": dm["dm_statistic"],
         "dm_p_value": dm["p_value"],
         "dm_verdict": dm["verdict"],
+        # --- bias report, per model (§C) ------------------------------------
+        "regime_bias_oos": regime_bias_oos,
+        "regime_bias_sq": regime_decomp["bias_sq"],
+        "regime_variance": regime_decomp["variance"],
+        "classic_bias_oos": classic_bias_oos,
+        "classic_bias_sq_raw": classic_decomp_raw["bias_sq"],
+        "classic_variance_raw": classic_decomp_raw["variance"],
+        # --- edge against the DE-BIASED baseline ----------------------------
+        "classic_mse_debiased": classic_mse_debiased,
+        "classic_bias_sq_debiased": classic_decomp_debiased["bias_sq"],
+        "classic_variance_debiased": classic_decomp_debiased["variance"],
+        "classic_bias_share_of_mse": (
+            classic_decomp_raw["bias_sq"] / classic_mse
+            if classic_mse and classic_mse > 0 else float("nan")
+        ),
+        "mse_reduction_pct_vs_debiased_classic": (
+            (classic_mse_debiased - regime_mse) / classic_mse_debiased * 100
+            if classic_mse_debiased and classic_mse_debiased > 0 else float("nan")
+        ),
+        # --- DM on centered errors = variance differential ------------------
+        "dm_centered_stat": dm_centered["dm_stat"],
+        "dm_centered_pvalue": dm_centered["dm_pvalue"],
+        "dm_centered_verdict": dm_centered["dm_verdict"],
+        "dm_centered_mean_loss_diff": dm_centered.get("mean_loss_diff", float("nan")),
+        # Per-observation series, kept OUT of the JSON (see `--dump-series`):
+        # 24 runs x ~1.1k predictions would add ~2 MB to a committed artefact,
+        # and the family's artefacts carry decompositions, not series.
+        "_series": {
+            "dates": [str(pd.Timestamp(d).date()) for d in pred_dates],
+            "regime": [float(x) for x in regime_preds],
+            "classic": [float(x) for x in classic_preds],
+            "target": [float(x) for x in truths_arr],
+        },
     }
 
 
@@ -288,19 +421,46 @@ def load_panel() -> dict[str, pd.Series]:
     return panels
 
 
-def main() -> None:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI so a single (coin, horizon) cell can be re-validated on its own.
+
+    The full grid is 2 coins x 3 horizons x 4 seeds = 24 walk-forward runs.
+    Re-auditing one published claim (e.g. the ETH h=1 BEATS) does not need the
+    other 20 runs, and forcing them would put a bias re-check out of reach of a
+    worker cycle. Defaults reproduce the original full sweep exactly.
+    """
+    p = argparse.ArgumentParser(description="M5 -- HMM regime-switching HAR vs classic HAR")
+    p.add_argument("--coins", nargs="+", default=None,
+                   help="subset of coins to run (default: every panel that loads)")
+    p.add_argument("--horizons", nargs="+", type=int, default=HORIZONS)
+    p.add_argument("--seeds", nargs="+", type=int, default=SEEDS)
+    p.add_argument("--out", default=None,
+                   help="results JSON path (default: results/m5_hmm_regime.json)")
+    p.add_argument("--dump-series", default=None,
+                   help="also write the per-observation forecast series to this CSV")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    seeds = list(args.seeds)
+    horizons = list(args.horizons)
+
     print("=" * 70)
     print("M5 -- HMM Regime-Switching HAR vs Classic HAR")
-    print(f"Seeds: {SEEDS}, Horizons: {HORIZONS}, HMM states: {N_HMM_STATES}")
+    print(f"Seeds: {seeds}, Horizons: {horizons}, HMM states: {N_HMM_STATES}")
     print(f"Approach: regime-switching (separate HAR per decoded regime)")
     print("=" * 70)
 
     panels = load_panel()
+    if args.coins:
+        panels = {c: rv for c, rv in panels.items() if c in set(args.coins)}
     if not panels:
         sys.exit("No data loaded, aborting.")
 
     t0 = time.time()
     all_results: list[dict] = []
+    series_rows: list[dict] = []
 
     for coin, rv in panels.items():
         print(f"\n{'=' * 50}")
@@ -318,14 +478,15 @@ def main() -> None:
         print(f"  Low-vol mean log-RV: {log_rv_full[labels_full==0].mean():.4f}")
         print(f"  High-vol mean log-RV: {log_rv_full[labels_full==1].mean():.4f}")
 
-        for horizon in HORIZONS:
+        for horizon in horizons:
             print(f"\n  h={horizon}:")
             seed_results = []
-            for seed in SEEDS:
+            for seed in seeds:
                 t1 = time.time()
                 res = walk_forward_regime_switching(rv, horizon, seed)
                 elapsed = time.time() - t1
-                tag = "**" if "BEATS" in res["dm_verdict"] and "BEATEN" not in res["dm_verdict"] else "  "
+                tag = "**" if _is_beats(res["dm_verdict"]) else "  "
+                ctag = "**" if _is_beats(res["dm_centered_verdict"]) else "  "
                 print(
                     f"    seed={seed:2d}: regime_mse={res['regime_mse']:.4f} "
                     f"classic_mse={res['classic_mse']:.4f} "
@@ -333,27 +494,83 @@ def main() -> None:
                     f"DM p={res['dm_p_value']:.4f} {tag}{res['dm_verdict']}{tag} "
                     f"({elapsed:.1f}s)"
                 )
+                print(
+                    f"              bias: regime={res['regime_bias_oos']:+.4f} "
+                    f"classic={res['classic_bias_oos']:+.4f} "
+                    f"(bias^2 = {res['classic_bias_share_of_mse'] * 100:.1f}% of classic MSE) "
+                    f"| vs de-biased classic: {res['mse_reduction_pct_vs_debiased_classic']:+.1f}% "
+                    f"| DM-centered p={res['dm_centered_pvalue']:.4f} "
+                    f"{ctag}{res['dm_centered_verdict']}{ctag}"
+                )
                 res["coin"] = coin
+                series = res.pop("_series")
+                if args.dump_series:
+                    for d, r_, c_, t_ in zip(
+                        series["dates"], series["regime"], series["classic"], series["target"],
+                    ):
+                        series_rows.append({
+                            "coin": coin, "horizon": horizon, "seed": seed,
+                            "date": d, "pred_regime": r_, "pred_classic": c_, "target": t_,
+                        })
                 all_results.append(res)
                 seed_results.append(res)
 
-            n_beats = sum(1 for r in seed_results if "BEATS" in r["dm_verdict"] and "BEATEN" not in r["dm_verdict"])
+            n_seeds = len(seed_results)
+            n_beats = sum(1 for r in seed_results if _is_beats(r["dm_verdict"]))
+            n_beats_centered = sum(1 for r in seed_results if _is_beats(r["dm_centered_verdict"]))
             mean_reduction = np.mean([r["mse_reduction_pct"] for r in seed_results])
+            mean_reduction_debiased = np.mean(
+                [r["mse_reduction_pct_vs_debiased_classic"] for r in seed_results]
+            )
+            std_reduction = np.std([r["mse_reduction_pct"] for r in seed_results], ddof=0)
             mean_regime_mse = np.mean([r["regime_mse"] for r in seed_results])
             mean_classic_mse = np.mean([r["classic_mse"] for r in seed_results])
-            agg_verdict = "BEATS" if n_beats == len(SEEDS) else "INCONCLUSIVE"
+            mean_classic_mse_debiased = np.mean([r["classic_mse_debiased"] for r in seed_results])
+            dm_p_median = float(np.median([r["dm_p_value"] for r in seed_results]))
+            dm_centered_p_median = float(np.median([r["dm_centered_pvalue"] for r in seed_results]))
+            agg_verdict = "BEATS" if n_beats == n_seeds else "INCONCLUSIVE"
+            # The §C conjunction verdict: the edge must survive the precision
+            # leg. An edge that only exists against a mis-calibrated baseline
+            # is reported as `refuted-de-biased`, the wording #12788 used when
+            # M15 failed this same control -- never quietly downgraded.
+            if n_beats_centered == n_seeds and dm_centered_p_median < 0.05:
+                agg_verdict_centered = "BEATS"
+            elif n_beats == n_seeds:
+                agg_verdict_centered = "refuted-de-biased"
+            else:
+                agg_verdict_centered = "INCONCLUSIVE"
             print(
-                f"    >> AGGREGATE: {n_beats}/{len(SEEDS)} seeds beat classic, "
+                f"    >> AGGREGATE: {n_beats}/{n_seeds} seeds beat classic, "
                 f"mean reduction={mean_reduction:+.1f}%, "
                 f"verdict={agg_verdict}"
             )
+            print(
+                f"    >> DE-BIASED: {n_beats_centered}/{n_seeds} seeds beat on the precision leg, "
+                f"mean reduction vs de-biased classic={mean_reduction_debiased:+.1f}%, "
+                f"DM-centered p_median={dm_centered_p_median:.2e}, "
+                f"verdict={agg_verdict_centered}"
+            )
             all_results.append({
                 "coin": coin, "horizon": horizon, "seed": "aggregate",
-                "n_beats_seeds": f"{n_beats}/{len(SEEDS)}",
+                "n_seeds": n_seeds,
+                "n_beats_seeds": f"{n_beats}/{n_seeds}",
                 "mean_regime_mse": float(mean_regime_mse),
                 "mean_classic_mse": float(mean_classic_mse),
                 "mean_reduction_pct": float(mean_reduction),
+                "std_reduction_pct": float(std_reduction),
+                "dm_p_median": dm_p_median,
                 "aggregate_verdict": agg_verdict,
+                # --- de-biased / precision leg (#1454 sub-grain) ------------
+                "n_beats_seeds_centered": f"{n_beats_centered}/{n_seeds}",
+                "mean_classic_mse_debiased": float(mean_classic_mse_debiased),
+                "mean_reduction_pct_vs_debiased_classic": float(mean_reduction_debiased),
+                "dm_centered_p_median": dm_centered_p_median,
+                "mean_regime_bias_oos": float(np.mean([r["regime_bias_oos"] for r in seed_results])),
+                "mean_classic_bias_oos": float(np.mean([r["classic_bias_oos"] for r in seed_results])),
+                "mean_classic_bias_share_of_mse": float(
+                    np.mean([r["classic_bias_share_of_mse"] for r in seed_results])
+                ),
+                "aggregate_verdict_debiased": agg_verdict_centered,
             })
 
     elapsed_total = time.time() - t0
@@ -362,27 +579,38 @@ def main() -> None:
     print(f"{'=' * 70}")
 
     RESULTS_DIR.mkdir(exist_ok=True)
-    out_path = RESULTS_DIR / "m5_hmm_regime.json"
+    out_path = Path(args.out) if args.out else RESULTS_DIR / "m5_hmm_regime.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "w") as f:
         json.dump({
             "experiment": "M5_HMM_REGIME_SWITCHING_HAR",
             "approach": "regime-switching: separate HAR per Viterbi-decoded regime",
             "n_hmm_states": N_HMM_STATES,
-            "seeds": SEEDS,
-            "horizons": HORIZONS,
+            "seeds": seeds,
+            "horizons": horizons,
             "n_splits": N_SPLITS,
             "refit_every": REFIT_EVERY,
+            "loss_fn": "mse",
+            "dm_centered_errors": True,
+            "classic_har_debiased": True,
             "elapsed_seconds": elapsed_total,
             "results": all_results,
         }, f, indent=2, default=str)
     print(f"Results saved to {out_path}")
 
+    if args.dump_series:
+        series_path = Path(args.dump_series)
+        series_path.parent.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(series_rows).to_csv(series_path, index=False)
+        print(f"Forecast series ({len(series_rows)} rows) saved to {series_path}")
+
     print("\n## M5 HMM Regime-Switching HAR Summary")
-    print("| Coin | h=1 | h=5 | h=10 |")
-    print("|------|-----|-----|------|")
+    header = "| Coin | " + " | ".join(f"h={h}" for h in horizons) + " |"
+    print(header)
+    print("|" + "---|" * (len(horizons) + 1))
     for coin in panels:
         row = f"| {coin} |"
-        for h in HORIZONS:
+        for h in horizons:
             agg = next(
                 (r for r in all_results
                  if r["coin"] == coin and r["horizon"] == h
@@ -390,9 +618,14 @@ def main() -> None:
                 None,
             )
             if agg:
-                v = agg["aggregate_verdict"]
-                red = agg["mean_reduction_pct"]
-                row += f" {v} ({red:+.1f}%) |"
+                # Both verdicts, always: the raw one is what the doc published,
+                # the de-biased one is what §C actually asks. Printing only the
+                # survivor would hide which of the two moved.
+                row += (
+                    f" {agg['aggregate_verdict']} ({agg['mean_reduction_pct']:+.1f}%)"
+                    f" / de-biased {agg['aggregate_verdict_debiased']}"
+                    f" ({agg['mean_reduction_pct_vs_debiased_classic']:+.1f}%) |"
+                )
             else:
                 row += " -- |"
         print(row)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
@@ -89,6 +89,65 @@ def _is_beats(verdict: str) -> bool:
     return "BEATS" in verdict and "BEATEN" not in verdict
 
 
+def _is_beaten(verdict: str) -> bool:
+    """True only for `dm_verdict`'s losing verdict ("BEATEN BY baseline").
+
+    The mirror of `_is_beats`. "BEATEN" appears in exactly one of the three
+    strings `dm_verdict` emits, so no exclusion clause is needed here -- but
+    the guard rails of `_is_beats` still apply the other way round: the two
+    sentinel verdicts this module adds ("SHAPE_MISMATCH", "INSUFFICIENT_DATA")
+    contain neither token and are therefore counted as neither win nor loss.
+    """
+    return "BEATEN" in verdict
+
+
+def _aggregate_debiased_state(
+    n_beats_centered: int,
+    n_beaten_centered: int,
+    n_seeds: int,
+    dm_centered_p_median: float,
+    n_beats_raw: int,
+) -> str:
+    """Aggregate the de-biased (precision) leg into one of four states.
+
+    The three-state machine this replaces could not express a loss: with no
+    branch for "every seed is BEATEN", the four long-horizon configs that the
+    doc and REGISTRY publish as `NO BEATS` (4/4 seeds BEATEN on the centered
+    leg) were persisted as `INCONCLUSIVE`. The executable deliverable could
+    not reproduce its own published verdict.
+
+    Precedence, decided once here and sealed by tests:
+
+    1. unanimous BEATS + significant median  -> "BEATS"
+    2. unanimous BEATEN + significant median -> "NO BEATS"
+    3. the RAW leg was unanimous BEATS       -> "refuted-de-biased"
+    4. otherwise                             -> "INCONCLUSIVE"
+
+    `NO BEATS` deliberately outranks `refuted-de-biased` when both apply (a raw
+    win that the precision leg significantly reverses). "Refuted" states that a
+    claim was not confirmed; the measurement in that case says more than that --
+    it says the model loses. Reporting the weaker of the two would soften a
+    measured loss, and the refutation stays legible anyway because every summary
+    row prints the raw and the de-biased verdict side by side.
+
+    The significance clause is redundant under unanimity (each per-seed BEATS /
+    BEATEN already carries p < alpha, so the median of them does too) and is
+    kept explicit only because the pre-existing BEATS branch stated it: an
+    asymmetric pair of conditions would read as a deliberate difference.
+
+    `n_seeds == 0` yields "INCONCLUSIVE" rather than a vacuous unanimity.
+    """
+    if n_seeds <= 0:
+        return "INCONCLUSIVE"
+    if n_beats_centered == n_seeds and dm_centered_p_median < 0.05:
+        return "BEATS"
+    if n_beaten_centered == n_seeds and dm_centered_p_median < 0.05:
+        return "NO BEATS"
+    if n_beats_raw == n_seeds:
+        return "refuted-de-biased"
+    return "INCONCLUSIVE"
+
+
 def _mse_decomposition(errors: np.ndarray) -> dict:
     """Decompose MSE of a forecast into bias^2 + variance on the error support."""
     if errors is None or len(errors) == 0:
@@ -536,6 +595,7 @@ def main(argv: list[str] | None = None) -> None:
             n_seeds = len(seed_results)
             n_beats = sum(1 for r in seed_results if _is_beats(r["dm_verdict"]))
             n_beats_centered = sum(1 for r in seed_results if _is_beats(r["dm_centered_verdict"]))
+            n_beaten_centered = sum(1 for r in seed_results if _is_beaten(r["dm_centered_verdict"]))
             mean_reduction = np.mean([r["mse_reduction_pct"] for r in seed_results])
             mean_reduction_debiased = np.mean(
                 [r["mse_reduction_pct_vs_debiased_classic"] for r in seed_results]
@@ -550,20 +610,31 @@ def main(argv: list[str] | None = None) -> None:
             # The §C conjunction verdict: the edge must survive the precision
             # leg. An edge that only exists against a mis-calibrated baseline
             # is reported as `refuted-de-biased`, the wording #12788 used when
-            # M15 failed this same control -- never quietly downgraded.
-            if n_beats_centered == n_seeds and dm_centered_p_median < 0.05:
-                agg_verdict_centered = "BEATS"
-            elif n_beats == n_seeds:
-                agg_verdict_centered = "refuted-de-biased"
-            else:
-                agg_verdict_centered = "INCONCLUSIVE"
+            # M15 failed this same control -- never quietly downgraded; a leg
+            # on which every seed LOSES is `NO BEATS`, the §C vocabulary.
+            #
+            # `aggregate_verdict` (raw leg) deliberately keeps its two-state
+            # convention: `m5_hmm_regime_research.ipynb` publishes it as "BEATS
+            # exige 4/4 seeds, sinon INCONCLUSIVE" and derives its own DEGRADE
+            # reading from it, so widening it would silently invalidate that
+            # notebook's committed counts (a re-run of the artefact plus a
+            # re-execution of the notebook). Filed as #14388 rather than folded
+            # into a bias-audit PR.
+            agg_verdict_centered = _aggregate_debiased_state(
+                n_beats_centered=n_beats_centered,
+                n_beaten_centered=n_beaten_centered,
+                n_seeds=n_seeds,
+                dm_centered_p_median=dm_centered_p_median,
+                n_beats_raw=n_beats,
+            )
             print(
                 f"    >> AGGREGATE: {n_beats}/{n_seeds} seeds beat classic, "
                 f"mean reduction={mean_reduction:+.1f}%, "
                 f"verdict={agg_verdict}"
             )
             print(
-                f"    >> DE-BIASED: {n_beats_centered}/{n_seeds} seeds beat on the precision leg, "
+                f"    >> DE-BIASED: {n_beats_centered}/{n_seeds} seeds beat "
+                f"({n_beaten_centered}/{n_seeds} beaten) on the precision leg, "
                 f"mean reduction vs de-biased classic={mean_reduction_debiased:+.1f}%, "
                 f"DM-centered p_median={dm_centered_p_median:.2e}, "
                 f"verdict={agg_verdict_centered}"
@@ -580,6 +651,9 @@ def main(argv: list[str] | None = None) -> None:
                 "aggregate_verdict": agg_verdict,
                 # --- de-biased / precision leg (#1454 sub-grain) ------------
                 "n_beats_seeds_centered": f"{n_beats_centered}/{n_seeds}",
+                # The published tables carry a "seeds BEATEN (rec.)" column;
+                # without this field it could not be read back from the artefact.
+                "n_beaten_seeds_centered": f"{n_beaten_centered}/{n_seeds}",
                 "mean_classic_mse_debiased": float(mean_classic_mse_debiased),
                 "mean_reduction_pct_vs_debiased_classic": float(mean_reduction_debiased),
                 "dm_centered_p_median": dm_centered_p_median,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_hmm_regime_vol.py
@@ -30,7 +30,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import hmm_regime_vol  # noqa: E402
 from hmm_regime_vol import (  # noqa: E402
+    _aggregate_debiased_state,
     _dm_centered_mse,
+    _is_beaten,
     _is_beats,
     _mse_decomposition,
     _require_hmmlearn,
@@ -336,6 +338,17 @@ class TestArtefactStaysLean:
             assert "_series" not in row, "the series must not bloat the artefact"
             assert "dm_centered_verdict" in row
 
+        # The published tables carry a "seeds BEATEN (rec.)" column; it has to
+        # be readable back from the artefact, not only recomputable by hand.
+        aggregate = [r for r in payload["results"] if r.get("seed") == "aggregate"]
+        assert aggregate, "an aggregate row is expected"
+        for row in aggregate:
+            assert "n_beaten_seeds_centered" in row
+            n_beats, n_seeds = (int(x) for x in row["n_beats_seeds_centered"].split("/"))
+            n_beaten, n_seeds_b = (int(x) for x in row["n_beaten_seeds_centered"].split("/"))
+            assert n_seeds == n_seeds_b == row["n_seeds"]
+            assert n_beats + n_beaten <= n_seeds, "a seed cannot both win and lose"
+
         frame = pd.read_csv(out_csv)
         assert set(frame.columns) >= {
             "coin", "horizon", "seed", "date", "pred_regime", "pred_classic", "target",
@@ -383,3 +396,148 @@ class TestHmmlearnGuard:
         """The mutation above must be what makes it fire -- not the call itself."""
         assert hmm_regime_vol.GaussianHMM is not None, "hmmlearn absent in this env"
         _require_hmmlearn()  # must not raise
+
+
+# --------------------------------------------------------------------------
+# The aggregated state machine
+#
+# The de-biased leg had three states and none of them was a loss: with no
+# branch for "every seed is BEATEN", the four long-horizon configs published
+# as `NO BEATS` were persisted as `INCONCLUSIVE`. The doc, the REGISTRY and
+# the body said one thing, the executable said another -- and no test held
+# the aggregation, only `_is_beats` and the per-seed legs. These tests pin
+# the four states symmetrically, and each silence is paired with a mutation
+# that changes only the count under test.
+# --------------------------------------------------------------------------
+
+# The published table of docs/M5_HMM_REGIME.md (de-biased leg, 4 seeds):
+# (coin, horizon, n_beats_centered, n_beaten_centered, dm_centered_p_median,
+#  n_beats_raw, published verdict)
+PUBLISHED_DEBIASED = [
+    ("BTC-USD", 1, 3, 0, 1.47e-03, 3, "INCONCLUSIVE"),
+    ("BTC-USD", 5, 0, 4, 6.21e-06, 0, "NO BEATS"),
+    ("BTC-USD", 10, 0, 4, 1.75e-09, 0, "NO BEATS"),
+    ("ETH-USD", 1, 4, 0, 1.14e-05, 4, "BEATS"),
+    ("ETH-USD", 5, 0, 4, 6.16e-04, 0, "NO BEATS"),
+    ("ETH-USD", 10, 0, 4, 4.10e-05, 0, "NO BEATS"),
+]
+
+
+class TestIsBeaten:
+    """The mirror of `TestIsBeats`: a loss must be counted as a loss."""
+
+    def test_beaten_is_a_loss(self):
+        assert _is_beaten("BEATEN BY baseline")
+
+    def test_beats_is_not_a_loss(self):
+        """The token that made `_is_beats` need an exclusion clause."""
+        assert not _is_beaten("BEATS baseline")
+
+    def test_inconclusive_is_not_a_loss(self):
+        assert not _is_beaten("INCONCLUSIVE")
+
+    @pytest.mark.parametrize("sentinel", ["SHAPE_MISMATCH", "INSUFFICIENT_DATA"])
+    def test_sentinels_are_neither_win_nor_loss(self, sentinel):
+        """A refused verdict must not be silently counted on either side."""
+        assert not _is_beats(sentinel)
+        assert not _is_beaten(sentinel)
+
+
+class TestAggregatedDebiasedState:
+    @pytest.mark.parametrize(
+        "coin,horizon,n_beats,n_beaten,p_median,n_beats_raw,published",
+        PUBLISHED_DEBIASED,
+    )
+    def test_reproduces_every_published_verdict(
+        self, coin, horizon, n_beats, n_beaten, p_median, n_beats_raw, published,
+    ):
+        """The executable must reproduce the table the doc publishes.
+
+        This is the defect this class closes: the four `NO BEATS` rows came
+        out of the harness as `INCONCLUSIVE`, so the published verdict was not
+        reproducible from the deliverable that produced it.
+        """
+        assert _aggregate_debiased_state(
+            n_beats_centered=n_beats,
+            n_beaten_centered=n_beaten,
+            n_seeds=4,
+            dm_centered_p_median=p_median,
+            n_beats_raw=n_beats_raw,
+        ) == published
+
+    def test_unanimous_loss_is_no_beats(self):
+        assert _aggregate_debiased_state(
+            n_beats_centered=0, n_beaten_centered=4, n_seeds=4,
+            dm_centered_p_median=1e-04, n_beats_raw=0,
+        ) == "NO BEATS"
+
+    def test_majority_loss_is_not_no_beats(self):
+        """The mandatory negative control: only the count changes.
+
+        3/4 BEATEN is the same configuration as the test above with one seed
+        moved out of the loss column. An exemption that cannot close again is
+        not an exemption -- so the state must fall back to INCONCLUSIVE.
+        """
+        assert _aggregate_debiased_state(
+            n_beats_centered=0, n_beaten_centered=3, n_seeds=4,
+            dm_centered_p_median=1e-04, n_beats_raw=0,
+        ) == "INCONCLUSIVE"
+
+    def test_majority_win_is_not_beats(self):
+        """The symmetric negative control on the winning side."""
+        assert _aggregate_debiased_state(
+            n_beats_centered=3, n_beaten_centered=0, n_seeds=4,
+            dm_centered_p_median=1e-04, n_beats_raw=3,
+        ) == "INCONCLUSIVE"
+
+    def test_refuted_when_the_raw_leg_won_alone(self):
+        """A raw 4/4 win that the precision leg does not confirm."""
+        assert _aggregate_debiased_state(
+            n_beats_centered=2, n_beaten_centered=0, n_seeds=4,
+            dm_centered_p_median=0.30, n_beats_raw=4,
+        ) == "refuted-de-biased"
+
+    def test_no_beats_outranks_refuted_when_both_apply(self):
+        """Precedence, decided once and sealed here.
+
+        A raw 4/4 win whose precision leg significantly REVERSES it satisfies
+        both branches. `NO BEATS` wins: "refuted" says a claim is unconfirmed,
+        the measurement says the model loses, and reporting the weaker of the
+        two would soften a measured loss. The refutation stays visible because
+        the summary row prints the raw verdict beside it.
+        """
+        assert _aggregate_debiased_state(
+            n_beats_centered=0, n_beaten_centered=4, n_seeds=4,
+            dm_centered_p_median=1e-06, n_beats_raw=4,
+        ) == "NO BEATS"
+
+    @pytest.mark.parametrize(
+        "n_beats,n_beaten", [(4, 0), (0, 4)],
+    )
+    def test_insignificant_median_blocks_both_unanimous_states(self, n_beats, n_beaten):
+        """The significance clause applies to the loss exactly as to the win."""
+        state = _aggregate_debiased_state(
+            n_beats_centered=n_beats, n_beaten_centered=n_beaten, n_seeds=4,
+            dm_centered_p_median=0.20, n_beats_raw=0,
+        )
+        assert state == "INCONCLUSIVE"
+
+    def test_zero_seeds_is_not_a_vacuous_unanimity(self):
+        """`0 == 0` must not read as "every seed agreed"."""
+        assert _aggregate_debiased_state(
+            n_beats_centered=0, n_beaten_centered=0, n_seeds=0,
+            dm_centered_p_median=float("nan"), n_beats_raw=0,
+        ) == "INCONCLUSIVE"
+
+    def test_every_state_is_reachable(self):
+        """The four documented states, and no fifth one."""
+        reached = {
+            _aggregate_debiased_state(
+                n_beats_centered=b, n_beaten_centered=n, n_seeds=4,
+                dm_centered_p_median=p, n_beats_raw=r,
+            )
+            for b, n, p, r in [
+                (4, 0, 1e-06, 4), (0, 4, 1e-06, 0), (2, 0, 0.30, 4), (1, 1, 0.30, 0),
+            ]
+        }
+        assert reached == {"BEATS", "NO BEATS", "refuted-de-biased", "INCONCLUSIVE"}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_hmm_regime_vol.py
@@ -1,0 +1,341 @@
+"""Tests for the M5 bias instrumentation in `scripts/hmm_regime_vol.py` (#1454).
+
+M5 publishes a live `BEATS` (ETH-USD h=1) against a classic-HAR baseline. The
+same family of baselines was measured at `har_bias_oos = -0.227` in #12745, and
+`MSE = bias^2 + variance` means a raw-error DM cannot tell a precision win from
+a calibration artefact. This module tests the control that separates them.
+
+The pure helpers `_mse_decomposition` / `_dm_centered_mse` also have coverage in
+`test_btc_vol.py` (they originate there, PR #12742). What is tested HERE is what
+those tests cannot cover: that the control actually DISCRIMINATES, and that the
+M5 return contract carries it.
+
+Validation shape (Tell c.856-L1): every silence is paired with a mutation that
+changes only the property under test and must make the control speak. A control
+that is never shown firing is not a control -- it is a green light with no wire
+behind it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Make the parent directory importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from hmm_regime_vol import (  # noqa: E402
+    _dm_centered_mse,
+    _is_beats,
+    _mse_decomposition,
+    walk_forward_regime_switching,
+)
+
+
+# --------------------------------------------------------------------------
+# Synthetic panels
+# --------------------------------------------------------------------------
+
+def _two_regime_rv(n: int = 300, seed: int = 3, switch_p: float = 0.03) -> pd.Series:
+    """A daily RV series with two latent volatility regimes.
+
+    Regime-switching HAR should have a real edge on this by construction --
+    which is what makes it a usable POSITIVE control: an edge that is genuine
+    must survive centering.
+    """
+    rng = np.random.default_rng(seed)
+    state = np.zeros(n, dtype=int)
+    for i in range(1, n):
+        state[i] = state[i - 1] if rng.random() > switch_p else 1 - state[i - 1]
+    log_rv = np.where(state == 1, -6.5, -8.0) + rng.normal(0.0, 0.35, n)
+    return pd.Series(
+        np.exp(log_rv), index=pd.date_range("2020-01-01", periods=n, freq="D"),
+    )
+
+
+# --------------------------------------------------------------------------
+# _is_beats
+# --------------------------------------------------------------------------
+
+class TestIsBeats:
+    """`dm_verdict` emits exactly three strings; only one of them is a win."""
+
+    def test_beats_is_a_win(self):
+        assert _is_beats("BEATS baseline") is True
+
+    def test_beaten_is_not_a_win(self):
+        # The substring "BEATS" does NOT appear in "BEATEN BY baseline", but the
+        # exclusion is kept because a future verdict wording could reintroduce
+        # it. Pinning it here makes any such change fail loudly.
+        assert _is_beats("BEATEN BY baseline") is False
+
+    def test_inconclusive_is_not_a_win(self):
+        assert _is_beats("INCONCLUSIVE") is False
+
+    def test_exclusion_is_load_bearing(self):
+        """Mutation: a wording where the naive substring test WOULD misfire."""
+        assert "BEATS" in "BEATS baseline (was BEATEN last seed)"
+        assert _is_beats("BEATS baseline (was BEATEN last seed)") is False
+
+
+# --------------------------------------------------------------------------
+# The control must discriminate -- both directions
+# --------------------------------------------------------------------------
+
+class TestCenteredDmDiscriminates:
+    """The negative and the positive, on the same instrument.
+
+    Showing only that the control stays quiet on a pure-bias edge proves
+    nothing: a control wired to nothing is quiet on everything. The pair is
+    the evidence.
+    """
+
+    def test_pure_bias_edge_does_not_survive_centering(self):
+        """NEGATIVE: identical dispersion, baseline offset by a constant.
+
+        The raw DM declares a win because `MSE = bias^2 + variance` and the
+        baseline carries a bias the model does not. Centering removes exactly
+        that term, and nothing is left -- which is the correct answer, because
+        the two models are equally *precise*.
+        """
+        from dm_test import dm_verdict
+
+        rng = np.random.default_rng(0)
+        e_model = rng.normal(0.0, 1.0, 4000)
+        e_base = e_model + 0.5  # same dispersion, pure calibration gap
+
+        raw = dm_verdict(e_model, e_base, horizon=1)
+        centered = _dm_centered_mse(e_model, e_base, horizon=1)
+
+        assert _is_beats(raw["verdict"]), "the raw leg must see this edge"
+        assert raw["p_value"] < 1e-6
+        assert not _is_beats(centered["dm_verdict"]), (
+            "an edge made only of the baseline's bias must NOT survive centering"
+        )
+        assert centered["dm_stat"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_genuine_precision_edge_does_survive_centering(self):
+        """POSITIVE: the mutation that must make the control speak.
+
+        Only the dispersion changes -- both series are unbiased, so centering
+        is a near no-op and the win stands. If this test ever goes quiet at the
+        same time as the one above, the control has stopped being wired.
+        """
+        rng = np.random.default_rng(0)
+        e_model = rng.normal(0.0, 0.5, 4000)
+        e_base = rng.normal(0.0, 1.0, 4000)
+
+        centered = _dm_centered_mse(e_model, e_base, horizon=1)
+        assert _is_beats(centered["dm_verdict"])
+        assert centered["dm_pvalue"] < 0.01
+
+    def test_centering_is_not_a_no_op_on_the_statistic(self):
+        """Guard against the mislabel the family artefacts already contain.
+
+        `btc_vol` routes BOTH its `dm_centered` and its `dm_raw` legs through
+        `_dm_centered_mse`, feeding the second a pre-de-biased series -- and
+        centering annihilates exactly the constant that distinguished them, so
+        the two statistics come out bit-identical (measured on
+        `results/m4_dlinear_vol_btc_sc_debiased_recentered.json`:
+        -6.228784907758055 vs -6.228784907758053). A raw leg that silently
+        centers is not a raw leg. This pins the two apart for M5.
+        """
+        from dm_test import dm_verdict
+
+        rng = np.random.default_rng(7)
+        e_model = rng.normal(0.0, 1.0, 2000)
+        e_base = rng.normal(0.3, 1.0, 2000)  # biased baseline
+
+        raw = dm_verdict(e_model, e_base, horizon=1)
+        centered = _dm_centered_mse(e_model, e_base, horizon=1)
+
+        assert abs(raw["dm_statistic"] - centered["dm_stat"]) > 1e-3, (
+            "raw and centered must not be the same computation under a different name"
+        )
+
+    @pytest.mark.parametrize("baseline_bias", [0.3, 0.0])
+    def test_the_gap_between_the_two_legs_IS_the_bias_gap(self, baseline_bias):
+        """The exact identity behind the whole control, in both regimes.
+
+        With `loss_fn="mse"`:
+            d_raw      = MSE_a - MSE_b
+            d_centered = var(e_a) - var(e_b)
+        and since `MSE = bias^2 + variance`,
+            d_raw - d_centered = bias_a^2 - bias_b^2      (exactly)
+
+        So the two legs differ by the bias gap and by nothing else. Asserting
+        the identity is stronger than asserting a tolerance on the statistic:
+        a tolerance is a guess about sampling noise, whereas this pins WHY the
+        biased case separates the legs (gap = -0.0913 here) and the unbiased
+        case does not (gap = +0.0016, ~60x smaller, pure sample-mean noise).
+        """
+        from dm_test import dm_verdict
+
+        rng = np.random.default_rng(7)
+        e_model = rng.normal(0.0, 1.0, 2000)
+        e_base = rng.normal(baseline_bias, 1.0, 2000)
+
+        raw = dm_verdict(e_model, e_base, horizon=1)
+        centered = _dm_centered_mse(e_model, e_base, horizon=1)
+
+        observed_gap = raw["mean_loss_diff"] - centered["mean_loss_diff"]
+        bias_gap = float(np.mean(e_model) ** 2 - np.mean(e_base) ** 2)
+        assert observed_gap == pytest.approx(bias_gap, abs=1e-12)
+
+        # ... and the gap is material only when a bias is there to remove.
+        if baseline_bias:
+            assert abs(observed_gap) > 0.05
+        else:
+            assert abs(observed_gap) < 0.01
+
+    def test_too_few_observations_refuses_a_verdict(self):
+        out = _dm_centered_mse(np.zeros(5), np.ones(5), horizon=1)
+        assert out["dm_verdict"] == "INSUFFICIENT_DATA"
+        assert np.isnan(out["dm_stat"])
+
+    def test_shape_mismatch_refuses_a_verdict(self):
+        out = _dm_centered_mse(np.zeros(50), np.zeros(40), horizon=1)
+        assert out["dm_verdict"] == "SHAPE_MISMATCH"
+
+
+# --------------------------------------------------------------------------
+# The M5 return contract
+# --------------------------------------------------------------------------
+
+class TestWalkForwardContract:
+    """The instrumentation has to reach the caller, not just exist."""
+
+    @pytest.fixture(scope="class")
+    def result(self) -> dict:
+        return walk_forward_regime_switching(
+            _two_regime_rv(), horizon=1, seed=0, n_splits=3,
+        )
+
+    def test_published_fields_are_untouched(self, result):
+        """The raw legs keep their original meaning.
+
+        docs/M5_HMM_REGIME.md publishes these numbers. The control is ADDED
+        beside them; renaming or redefining them would silently invalidate a
+        published result instead of auditing it.
+        """
+        for key in ("regime_mse", "classic_mse", "mse_reduction_pct",
+                    "dm_statistic", "dm_p_value", "dm_verdict"):
+            assert key in result
+
+    def test_bias_report_covers_model_and_baseline(self, result):
+        """§C: "rapport de biais par modele ... modele ET baseline"."""
+        for key in ("regime_bias_oos", "classic_bias_oos",
+                    "regime_bias_sq", "classic_bias_sq_raw"):
+            assert key in result
+            assert np.isfinite(result[key])
+
+    def test_mse_identity_holds_for_both_models(self, result):
+        """`MSE = bias^2 + variance` -- the identity the whole control rests on."""
+        assert result["regime_mse"] == pytest.approx(
+            result["regime_bias_sq"] + result["regime_variance"], rel=1e-9,
+        )
+        assert result["classic_mse"] == pytest.approx(
+            result["classic_bias_sq_raw"] + result["classic_variance_raw"], rel=1e-9,
+        )
+
+    def test_debiasing_removes_exactly_the_bias(self, result):
+        """De-biased MSE is the variance, and the residual bias is zero."""
+        assert result["classic_mse_debiased"] == pytest.approx(
+            result["classic_variance_raw"], rel=1e-9,
+        )
+        assert result["classic_bias_sq_debiased"] == pytest.approx(0.0, abs=1e-20)
+
+    def test_debiased_edge_is_never_flattered(self, result):
+        """De-biasing the baseline can only make it harder to beat.
+
+        A baseline with any bias at all has `MSE_debiased <= MSE_raw`, so the
+        edge measured against it is <= the raw edge. A harness reporting the
+        opposite would be crediting the model with the baseline's miscalibration.
+        """
+        assert result["classic_mse_debiased"] <= result["classic_mse"] + 1e-12
+        assert (
+            result["mse_reduction_pct_vs_debiased_classic"]
+            <= result["mse_reduction_pct"] + 1e-9
+        )
+
+    def test_bias_share_is_a_fraction_of_the_baseline_mse(self, result):
+        share = result["classic_bias_share_of_mse"]
+        assert 0.0 <= share <= 1.0
+
+    def test_centered_dm_reaches_the_caller(self, result):
+        for key in ("dm_centered_stat", "dm_centered_pvalue",
+                    "dm_centered_verdict", "dm_centered_mean_loss_diff"):
+            assert key in result
+        assert result["dm_centered_verdict"] in (
+            "BEATS baseline", "BEATEN BY baseline", "INCONCLUSIVE",
+        )
+
+    def test_regime_edge_survives_on_a_two_regime_panel(self, result):
+        """End-to-end positive control on data built to have a real edge.
+
+        Not a claim about markets -- a claim that the wiring transmits a real
+        signal. If the plumbing were broken, this synthetic edge would vanish.
+        """
+        assert _is_beats(result["dm_verdict"])
+        assert _is_beats(result["dm_centered_verdict"])
+
+    def test_series_are_aligned_and_complete(self, result):
+        s = result["_series"]
+        n = result["n_preds"]
+        assert len(s["dates"]) == n
+        assert len(s["regime"]) == n
+        assert len(s["classic"]) == n
+        assert len(s["target"]) == n
+
+    def test_short_series_is_refused(self):
+        rv = _two_regime_rv(n=150)
+        with pytest.raises(ValueError, match="need >=200"):
+            walk_forward_regime_switching(rv, horizon=1, seed=0, n_splits=3)
+
+
+# --------------------------------------------------------------------------
+# The artefact must not carry the series
+# --------------------------------------------------------------------------
+
+class TestArtefactStaysLean:
+    """`_series` is popped before the JSON dump, on purpose.
+
+    24 runs x ~1.1k predictions is ~2 MB of committed artefact, and the family's
+    artefacts (`m4_*_debiased_recentered.json`, `m15_*/results.json`) carry
+    decompositions rather than series. The series stay reachable through
+    `--dump-series`, which writes a separate CSV.
+    """
+
+    def test_json_dump_has_no_series_and_csv_has_them(self, tmp_path):
+        from hmm_regime_vol import main
+
+        out_json = tmp_path / "results.json"
+        out_csv = tmp_path / "series.csv"
+
+        # The real panels need Bitstamp/Binance data on disk; when it is absent
+        # `main` exits before doing any work, and this assertion has nothing to
+        # measure. Skipping is honest; passing on an empty run would not be.
+        try:
+            main([
+                "--coins", "ETH-USD", "--horizons", "1", "--seeds", "0",
+                "--out", str(out_json), "--dump-series", str(out_csv),
+            ])
+        except SystemExit as exc:  # "No data loaded, aborting."
+            pytest.skip(f"panel data unavailable in this environment: {exc}")
+
+        payload = json.loads(out_json.read_text())
+        per_seed = [r for r in payload["results"] if r.get("seed") != "aggregate"]
+        assert per_seed, "at least one per-seed row expected"
+        for row in per_seed:
+            assert "_series" not in row, "the series must not bloat the artefact"
+            assert "dm_centered_verdict" in row
+
+        frame = pd.read_csv(out_csv)
+        assert set(frame.columns) >= {
+            "coin", "horizon", "seed", "date", "pred_regime", "pred_classic", "target",
+        }
+        assert len(frame) == per_seed[0]["n_preds"]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_hmm_regime_vol.py
@@ -28,10 +28,12 @@ import pytest
 # Make the parent directory importable.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+import hmm_regime_vol  # noqa: E402
 from hmm_regime_vol import (  # noqa: E402
     _dm_centered_mse,
     _is_beats,
     _mse_decomposition,
+    _require_hmmlearn,
     walk_forward_regime_switching,
 )
 
@@ -339,3 +341,45 @@ class TestArtefactStaysLean:
             "coin", "horizon", "seed", "date", "pred_regime", "pred_classic", "target",
         }
         assert len(frame) == per_seed[0]["n_preds"]
+
+
+# --------------------------------------------------------------------------
+# The optional-dependency guard
+#
+# `hmm_regime_vol` used to `sys.exit(...)` at import time when hmmlearn was
+# absent. Importing it from a test module then raised SystemExit during pytest
+# COLLECTION, which aborts the entire session with INTERNALERROR -- every other
+# suite in this directory dies with it, and the log blames a stack of pytest
+# internals rather than the missing package. These two tests pin the repaired
+# contract: importing is safe, using without the dependency is not.
+# --------------------------------------------------------------------------
+
+class TestHmmlearnGuard:
+    def test_import_does_not_abort_collection(self):
+        """The module is importable. Reaching this line is the assertion.
+
+        If `hmm_regime_vol` regressed to an import-time `sys.exit`, this file
+        could not be collected at all and the failure would surface as an
+        INTERNALERROR, not as a red test.
+        """
+        assert hmm_regime_vol.__name__ == "hmm_regime_vol"
+
+    def test_guard_still_exits_when_dependency_is_absent(self, monkeypatch):
+        """Deferring the failure must not SILENCE it.
+
+        Simulates the absent dependency and asserts the guard still stops the
+        run with the same message the import-time exit used to print.
+        """
+        monkeypatch.setattr(hmm_regime_vol, "GaussianHMM", None)
+        with pytest.raises(SystemExit) as excinfo:
+            _require_hmmlearn()
+        assert "hmmlearn not found" in str(excinfo.value)
+
+        # ... and reaches CLI callers before any data is loaded.
+        with pytest.raises(SystemExit):
+            hmm_regime_vol.main(["--coins", "BTC-USD", "--horizons", "1", "--seeds", "0"])
+
+    def test_guard_is_transparent_when_dependency_is_present(self):
+        """The mutation above must be what makes it fire -- not the call itself."""
+        assert hmm_regime_vol.GaussianHMM is not None, "hmmlearn absent in this env"
+        _require_hmmlearn()  # must not raise


### PR DESCRIPTION
Grain: DEEP/training -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #14351

## Summary

M5 (HMM regime-switching HAR) portait un **BEATS vivant** — `ETH-USD h=1`, +9,6 %, 4/4 seeds —
qu'aucun rapport de biais n'avait jamais audité. `docs/M5_HMM_REGIME.md` ne contenait **aucune**
occurrence de `bias`/`biais`/`recentr`/`debias`, et **M5 n'avait aucune entrée dans `REGISTRY.md`**.
Le harnais ne retournait que des MSE agrégés : le verdict publié était **invalidable post-hoc sans
ré-entraînement** — exactement le manque que #12745 avait comblé sur M4/M15.

Comme `MSE = biais² + variance`, un écart de MSE peut être **entièrement** la mauvaise calibration de
la baseline. C'est ce que #10938 a levé sur M4 (`har_bias_oos = −0,227` sur cette HAR même), ce que
#12684/#12734 ont formalisé, et ce que `pr-review-discipline` §C exige depuis.

**Le verdict tombe comme il tombe : `ETH h=1` survit, `BTC h=1` s'effondre.**

## Ce qui est mesuré

24 combinaisons (2 coins × 3 horizons × 4 seeds), walk-forward 5 folds expanding, refit tous les
22 jours, **331,6 s CPU** (HMM + OLS, ni GPU ni réseau). BTC 2 278 jours de RV, ETH 1 495.

| Coin | h | edge brut | edge vs classic **dé-biaisée** | σ cross-seed | edge/σ | dm_p_median (rec.) | BEATS / BEATEN (rec.) | Verdict hors biais |
|---|---:|---:|---:|---:|---:|---:|:---:|---|
| BTC-USD | 1  |  +7,0 % |  **+1,3 %** |  4,04 pt | **0,3σ** | 1,47e-03 | 3/4 · 0/4 | **INCONCLUSIVE** |
| BTC-USD | 5  | −11,1 % | **−43,5 %** |  9,37 pt | 4,6σ | 6,21e-06 | 0/4 · 4/4 | **NO BEATS** |
| BTC-USD | 10 | −28,3 % | **−99,0 %** | 21,18 pt | 4,7σ | 1,75e-09 | 0/4 · 4/4 | **NO BEATS** |
| ETH-USD | 1  |  +9,6 % |  **+8,7 %** |  2,11 pt | **4,1σ** | 1,14e-05 | 4/4 · 0/4 | **BEATS** |
| ETH-USD | 5  | −17,9 % | **−23,4 %** |  3,85 pt | 6,1σ | 6,16e-04 | 0/4 · 4/4 | **NO BEATS** |
| ETH-USD | 10 | −53,0 % | **−66,2 %** | 14,70 pt | 4,5σ | 4,10e-05 | 0/4 · 4/4 | **NO BEATS** |

### Rapport de biais signé, par modèle — contrôle §C(7)

| Coin | h | biais régime | biais classic | biais²(classic) en % de MSE(classic) |
|---|---:|---:|---:|---:|
| BTC-USD | 1  | −0,1811 | −0,2266 |  **5,8 %** |
| BTC-USD | 5  | −0,2728 | −0,3432 | **22,6 %** |
| BTC-USD | 10 | −0,3624 | −0,4502 | **35,5 %** |
| ETH-USD | 1  | −0,0718 | −0,0810 |  **1,0 %** |
| ETH-USD | 5  | −0,1091 | −0,1290 |  **4,5 %** |
| ETH-USD | 10 | −0,1519 | −0,1727 |  **8,0 %** |

Les deux modèles sous-prévoient le log-RV ; la part de biais de la baseline **croît avec l'horizon**
(à BTC h=10, plus du tiers du MSE de la HAR classique est du biais pur).

### Conjonction §C pour le keeper `ETH h=1`

- perte de **précision** : DM `loss_fn="mse"` (jamais `linear`) ✔
- **4/4 seeds** BEATS sur la jambe recentrée, `dm_p_median` = **1,14e-05 < 0,05** ✔
- edge/σ = **4,1σ ≥ 2σ** (σ = 2,11 pt de dispersion cross-seed) ✔
- rapport de biais **des deux modèles** ci-dessus ✔
- verdict honnête : **BEATS** — pas « promising »

## Trois lectures que le dé-biaisage change

1. **`ETH h=1` est un vrai gain de précision.** Seulement 0,9 pt de l'edge venait du biais
   (+9,6 → +8,7 %). Le contraste avec M15 est net : même instrument, verdict opposé
   (`refuted-de-biased` 3/3, #11041).

2. **`BTC h=1` ne « manque pas de conclusivité » — il n'existe pas.** L'edge brut +7,0 % tombe à
   **+1,3 %** : **~82 % de l'écart apparent était la miscalibration de la HAR BTC**. Le verdict brut
   disait déjà INCONCLUSIVE, mais l'imputait à la graine 7 (« HMM initialization sensitivity »). Hors
   biais l'edge vaut **0,3σ** de la dispersion cross-seed : ce n'est pas une graine aberrante, c'est
   un effet nul.

3. **Le biais de la baseline masquait l'ampleur de la dégradation à h≥5.** Dé-biaiser la HAR la rend
   meilleure, donc creuse l'écart : BTC h=10 passe de −28,3 % à **−99,0 %**. La conclusion d'origine
   (« nuisible aux horizons longs ») est **renforcée**, pas infirmée.

**L'asymétrie BTC/ETH à h=1 appartient à la baseline, pas au modèle** : même modèle, même instrument,
mais la HAR BTC porte 5,8 % de biais² contre 1,0 % pour la HAR ETH.

## Vérification

- `MSE = biais² + variance` recalculé **sur les 24 lignes** du run réel : résidu max **1,11e-16** ;
  `classic_bias_sq_debiased` max = 1,48e-33 (le dé-biaisage retire bien exactement le biais).
- **Identité dérivée et scellée** : `d_brut − d_recentré = biais_a² − biais_b²` (résidu ~1e-17),
  en test paramétré sur une paire biaisée **et** une paire non biaisée. C'est elle qui établit que la
  jambe recentrée est un **vrai contrôle** et non un doublon réétiqueté — un premier essai
  d'assertion sur la *statistique* DM était arbitraire et fragile ; il a été remplacé par l'identité,
  pas par un seuil plus large.
- **25 tests** neufs (`scripts/tests/test_hmm_regime_vol.py`), chaque silence apparié à une mutation
  qui doit rougir (`test_exclusion_is_load_bearing`, `test_centering_is_not_a_no_op_on_the_statistic`,
  `test_debiased_edge_is_never_flattered`).
- **Voisins verts** : `test_btc_vol.py` · `test_diebold_mariano.py` · `test_har_model.py` ·
  `test_dlinear_debiased_edge.py` → **57 passed**. Seul autre consommateur du module : le notebook M5
  (non touché, cf ci-dessous).

**Note de comparabilité — et ce qu'elle ne prouve PAS.** Le biais OOS BTC mesuré ici est
**bit-identique** à `har_bias_oos` de l'artefact #12745 (−0,2265869503892514 / −0,34317822065868814 /
−0,45022101989096786, 17 chiffres). Ce n'est **pas** une corroboration indépendante : `hmm_regime_vol`
et la chaîne `btc_vol → dlinear_vol` importent le **même** `har_model.HARModel` (définition unique) —
c'est le même calcul appelé depuis deux harnais. Ce que cela établit : l'instrumentation ajoutée ici
est câblée comme celle de la famille, et les edges M4/M5 sont directement comparables sur BTC.

## Périmètre

| Fichier | Ce qui change |
|---|---|
| `scripts/hmm_regime_vol.py` | instrumentation de biais + jambe DM recentrée + CLI (`--coins`/`--horizons`/`--seeds`/`--out`/`--dump-series`) + garde `hmmlearn` déplacée hors du temps d'import (ci-dessous) |
| `scripts/tests/test_hmm_regime_vol.py` | **neuf** — 25 tests |
| `docs/M5_HMM_REGIME.md` | section « Re-validation hors biais » + correction arithmétique (ci-dessous) |
| `REGISTRY.md` | **première entrée M5** + ligne `Updated:` |
| `.github/workflows/ml-tests.yml` | `hmmlearn` ajouté aux dépendances du job (ci-dessous) |

### Pourquoi le workflow et la garde d'import sont dans cette PR

Le premier push a fait rougir **`ML Pipeline Tests (CPU)`** — et pas seulement mes tests : **toute la
suite**, en `INTERNALERROR`, `no tests ran`. Cause : `hmm_regime_vol.py` appelait `sys.exit()` **au
niveau module** quand `hmmlearn` est absent, et `hmmlearn` n'était pas installé sur le runner. Un
`SystemExit` levé pendant la **collecte** pytest avorte la session entière — les 57 tests voisins
meurent avec, et la trace accuse une pile d'internes pytest plutôt que le paquet manquant.

La garde est antérieure à cette PR, mais **c'est mon fichier de tests qui l'a armée** : rien
n'importait ce module sous pytest avant. Les deux corrections sont donc le périmètre de ma
régression, pas un élargissement :

1. **`hmmlearn` installé dans le job** — plutôt qu'un `pytest.importorskip`. Le précédent
   `importorskip` de la suite (`test_multiscale_gnn_model.py`) vise `torch_geometric`, lourd et
   absent du CI CPU ; `hmmlearn` est CPU-only et ne tire que numpy/scipy/scikit-learn, **déjà
   installés**. Skipper aurait rendu les 25 assertions **vertes sans jamais s'exécuter** — un
   contrôle jamais montré en train de tirer (Tell c.856-L1).
2. **Échec différé au point d'usage** (`_require_hmmlearn()`, appelé en tête de `main()` et dans
   `fit_hmm_regimes`) — **message et code de sortie identiques** pour l'appelant CLI (`--help`
   vérifié intact), mais l'import redevient inoffensif. Une dépendance optionnelle manquante doit
   faire rougir *ses* tests, jamais anéantir la session.

Trois tests pinnent le contrat réparé, dont le négatif : `test_guard_still_exits_when_dependency_is_absent`
neutralise `GaussianHMM` et exige que la sortie se produise **quand même** — différer l'échec ne doit
pas le **taire**.

**Les jambes brutes publiées sont inchangées** (`regime_mse`, `classic_mse`, `mse_reduction_pct`,
`dm_statistic`, `dm_p_value`, `dm_verdict`) : elles sont recalculées à l'identique et les colonnes
hors biais s'y **ajoutent**. Le résultat d'origine n'est pas effacé — les « Key findings » de Cycle 25
sont conservés tels quels, avec un renvoi vers la lecture qui les précise.

**Correction arithmétique du doc** : la table de synthèse comptait `BTC h=5` **à la fois** en
INCONCLUSIVE et en BEATEN BY, et annonçait `3/6` en listant quatre configs. Le découpage correct
(cohérent avec la table par coin juste en dessous) est **1 / 1 / 4**.

**Honnêteté sur le claim d'origine** : l'acceptance postée sur #1454 annonçait des séries persistées
« sur le modèle de #12745 ». Vérification faite, **#12745 persiste des décompositions, pas des
séries**. Les séries ne sont donc écrites que sur `--dump-series` (CSV séparé, 37 040 lignes pour la
grille complète) ; l'artefact JSON reste léger et agrégé, conforme au précédent réel.

**Duplication assumée** : `_mse_decomposition` / `_dm_centered_mse` sont recopiés depuis `btc_vol.py`
plutôt qu'importés — `btc_vol` importe `dlinear_vol`, qui importe `torch` au niveau module, alors que
M5 est CPU-only (HMM + OLS). C'est le **troisième** site de duplication (`btc_vol`, `btc_m15`,
`hmm_regime_vol`), ce qui est précisément l'argument pour extraire un module partagé — **#14363**,
pas replié ici (G.4).

## Non traité — et pourquoi

**`m5_hmm_regime_research.ipynb` n'est pas touché**, bien qu'il soit dans mes `paths:` claimés.
Sa cellule 2 committe une sortie de repli `[INFO] Artefact manquant : scripts/results/m5_hmm_regime.json`
alors que les cellules 4/6/8/10 portent des sorties **réelles** : l'état committé est donc
**incohérent entre cellules** (une exécution unique avec `data = None` aurait planté en cellule 4).

Deux raisons de ne pas le réparer ici :

1. Le commentaire de la cellule 2 invoque une **politique documentée** (issues #11417/#11574,
   précédent PR #11420) de ne pas committer `scripts/results/m5_hmm_regime.json`. Or **les artefacts
   de M4 et M15 sont, eux, versionnés** — `git ls-files scripts/results/` liste notamment
   `m4_dlinear_vol_btc_sc_debiased_recentered.json` et `m15_lstm_rv_btc_sc/results.json`, forcés
   par-dessus le `results/` du `.gitignore`. Renverser cette politique est un **sujet à part**, pas un
   geste silencieux dans une PR d'audit de biais.
2. Ré-exécuter le notebook **sans** committer l'artefact reproduirait exactement le défaut signalé :
   des sorties committées dérivées d'une entrée absente du dépôt.

Issue de suivi : **#14360**.

## Trois issues ouvertes AVANT merge (§B.0)

Rien de ce qui suit n'est replié dans cette PR — chacun est un sujet distinct (G.4), et chacun existe
avant le merge, pas dans un commentaire de merge :

| Issue | Ce qu'elle porte | Découvert |
|---|---|---|
| **#14360** | `m5_hmm_regime_research.ipynb` : sorties committées incohérentes entre cellules, et la politique invoquée en cellule 2 contredit le versionnement réel des artefacts M4/M15 | en vérifiant si le notebook devait être ré-exécuté ici |
| **#14362** | `scripts/btc_vol.py:164` : la jambe `dm_raw` appelle `_dm_centered_mse` — donc **les deux** jambes sont recentrées, et le contrôle brut/recentré de M4 ne discrimine rien | en recopiant le motif pour M5, les deux appels côte à côte |
| **#14363** | extraction des deux helpers dans un module partagé sans dépendance torch (3ᵉ site de duplication) | ci-dessus |

**#14362 est un défaut vivant sur M4, pas sur cette PR.** L'artefact committé le confirme :
`dm_raw_stat` et `dm_centered_stat` y coïncident à ~1,8e-15 sur les trois seeds h=1 — ce qui est
attendu, puisque `har_errors_debiased = har_errors − const` et que le recentrage annule exactement
cette constante. Je ne le corrige pas ici (fichier hors de mes `paths:` claimés, et une correction
change les verdicts publiés de M4 : c'est une PR à part entière).

## Portée du verdict

Prévision **uniquement** (MSE log-RV) : aucune stratégie de vol-timing dérivée, aucun coût de
transaction imputé. K=2 états seulement. Le défaut structurel noté en Cycle 25 — la prévision
itérative à h pas utilise un **unique** indicateur de régime pour tous les pas — reste l'explication
la plus plausible de la dégradation aux horizons longs, mais n'est **pas** isolé expérimentalement
ici.

**Verdict §C hors biais : 1/6 BEATS (`ETH h=1`, `confirmed`), 1/6 INCONCLUSIVE, 4/6 NO BEATS.**

See #1454
