### PR TITLE
fix(notebook-tools,#14356): cwd explicite + garde de vraisemblance sur batch_reexecute

### DIFF
--- a/scripts/notebook_tools/batch_reexecute.py
+++ b/scripts/notebook_tools/batch_reexecute.py
@@ -11,12 +11,17 @@ Usage:
     python batch_reexecute.py --path <file.ipynb>      # Single notebook
     python batch_reexecute.py --max 5                  # Limit to 5 notebooks
     python batch_reexecute.py --timeout 300            # Per-notebook timeout (seconds)
+    python batch_reexecute.py --cwd notebook           # Kernel cwd = notebook dir (#14356)
 
 Safety:
     - Dry-run mode shows what would be executed without running
     - Creates backup before each execution
     - Skips notebooks requiring API keys, GPU, or cloud services
     - Respects C.3: only re-executes notebooks with source changes
+    - Refuses a run whose output census collapsed (#14356): papermill reports
+      SUCCESS even when a notebook took its `except` branch and produced
+      nothing, so the exit code alone never proves the notebook did what it
+      announces.
 """
 
 import argparse
@@ -103,13 +108,71 @@ def read_kernelspec_name(nb_path: Path) -> str:
     return spec.get("name") or "python3"
 
 
-def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
-    """Execute a single notebook with papermill."""
+def _output_census(nb_path: Path) -> dict:
+    """Count the outputs and embedded images a notebook currently carries.
+
+    Baseline for the cause-agnostic plausibility guard (#14356). A run that
+    silently loses its results -- a ``.env`` the kernel could not find from its
+    cwd, a service that answered 401, a dependency that fell back to a stub --
+    still exits 0 with ``metadata.papermill.exception: None`` and a clean
+    ``execution_count`` sequence. What such a run cannot fake is the census:
+    the images stop being there. Counting is therefore the only signal that
+    does not need to know *why* the run degraded, which is what makes it worth
+    having over a detector tied to one mechanism.
+
+    An unreadable notebook yields ``readable: False`` so the comparison
+    abstains rather than accuses.
+    """
+    try:
+        data = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {"readable": False, "outputs": 0, "images": 0}
+    outputs = 0
+    images = 0
+    for cell in data.get("cells", []):
+        for out in cell.get("outputs") or []:
+            outputs += 1
+            if "image/png" in (out.get("data") or {}):
+                images += 1
+    return {"readable": True, "outputs": outputs, "images": images}
+
+
+def _degradation(before: dict, after: dict) -> str:
+    """Name the collapse between two censuses, or "" when there is none.
+
+    Only a *drop* is a signal: this tool exists to re-execute notebooks whose
+    outputs are missing, so a rise is the nominal outcome. And a notebook that
+    carried no images to begin with gives no baseline -- the guard stays silent
+    there instead of inventing one, which is why it catches regressions and not
+    absences.
+    """
+    if not (before["readable"] and after["readable"]):
+        return ""
+    if before["images"] > 0 and after["images"] == 0:
+        return "images %d -> 0" % before["images"]
+    if before["outputs"] > 0 and after["outputs"] * 2 < before["outputs"]:
+        return "outputs %d -> %d" % (before["outputs"], after["outputs"])
+    return ""
+
+
+def execute_notebook(nb_path: Path, kernel: str, timeout: int,
+                     cwd_mode: str = "repo", allow_degraded: bool = False) -> dict:
+    """Execute a single notebook with papermill.
+
+    ``cwd_mode`` selects the kernel working directory (#14356): ``repo`` (the
+    historical default) or ``notebook``, needed by notebooks that resolve a
+    ``.env``, a dataset or a config by walking up the parents of ``Path.cwd()``
+    -- from the repository root that walk never descends into the subtree, and
+    the notebook degrades without failing. Both conventions exist in this
+    repository, so the choice is explicit rather than a reversed default.
+    """
     # Bound OpenMP/BLAS pools before spawning papermill: the kernel it
     # launches inherits the environment; unbounded native training cells
     # oversubscribe many-core hosts and look frozen (#11111).
     bound_native_thread_pools()
     backup_path = nb_path.with_suffix(".ipynb.bak")
+    run_dir = nb_path.parent if cwd_mode == "notebook" else REPO_ROOT
+    before = _output_census(nb_path)
 
     # Create backup
     shutil.copy2(nb_path, backup_path)
@@ -120,6 +183,10 @@ def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
             str(nb_path), str(nb_path),
             "--kernel", kernel,
             "--execution-timeout", str(timeout),  # per-cell budget, seconds
+            # Explicit even in "repo" mode: papermill otherwise leaves the
+            # kernel in the process cwd, which made the working directory an
+            # implicit consequence of how the tool was launched (#14356).
+            "--cwd", str(run_dir),
         ]
 
         result = subprocess.run(
@@ -131,10 +198,21 @@ def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
         )
 
         if result.returncode == 0:
+            collapse = _degradation(before, _output_census(nb_path))
+            if collapse and not allow_degraded:
+                # Keeping this result would be worse than keeping none: it
+                # looks green to every downstream guard.
+                shutil.copy2(backup_path, nb_path)
+                backup_path.unlink(missing_ok=True)
+                return {"path": str(nb_path), "status": "DEGRADED",
+                        "error": "output census collapsed (%s) despite papermill "
+                                 "exit 0 -- cwd=%s; restored backup, see #14356"
+                                 % (collapse, cwd_mode)}
             normalized = _normalize_kernel_paths(nb_path)
             backup_path.unlink(missing_ok=True)
             return {"path": str(nb_path), "status": "SUCCESS",
-                    "normalized": normalized}
+                    "normalized": normalized,
+                    "degraded": collapse or None}
         else:
             # Restore backup on failure
             shutil.copy2(backup_path, nb_path)
@@ -168,6 +246,15 @@ def main():
                         help="Max notebooks to execute (0=all)")
     parser.add_argument("--timeout", type=int, default=300,
                         help="Per-notebook timeout in seconds (default: 300)")
+    parser.add_argument("--cwd", choices=["repo", "notebook"], default="repo",
+                        help="Working directory given to the papermill kernel: "
+                             "repo (default, historical behaviour) or notebook. "
+                             "Notebooks that resolve a .env or a dataset by "
+                             "walking up from Path.cwd() need notebook (#14356).")
+    parser.add_argument("--allow-degraded", action="store_true",
+                        help="Keep a result whose output census collapsed "
+                             "instead of restoring the backup (#14356). For the "
+                             "case where the drop is legitimate.")
     parser.add_argument("--skip-external", action="store_true", default=True,
                         help="Skip notebooks requiring API/GPU/cloud (default: True)")
     args = parser.parse_args()
@@ -227,7 +314,7 @@ def main():
         return 0
 
     # Execute
-    results = {"success": 0, "failed": 0, "timeout": 0, "error": 0}
+    results = {"success": 0, "failed": 0, "timeout": 0, "error": 0, "degraded": 0}
     start = datetime.now()
 
     for i, entry in enumerate(targets, 1):
@@ -236,7 +323,9 @@ def main():
         kernel = get_kernel_name(entry)
         print(f"\n[{i}/{len(targets)}] {name} (kernel={kernel})...")
 
-        result = execute_notebook(nb_path, kernel, args.timeout)
+        result = execute_notebook(nb_path, kernel, args.timeout,
+                                  cwd_mode=args.cwd,
+                                  allow_degraded=args.allow_degraded)
         status = result["status"]
         results[status.lower()] = results.get(status.lower(), 0) + 1
 
@@ -254,8 +343,10 @@ def main():
     print(f"  Failed:  {results.get('failed', 0)}")
     print(f"  Timeout: {results.get('timeout', 0)}")
     print(f"  Error:   {results.get('error', 0)}")
+    print(f"  Degraded: {results.get('degraded', 0)}")
 
-    return 1 if results.get("failed", 0) + results.get("error", 0) > 0 else 0
+    return 1 if (results.get("failed", 0) + results.get("error", 0)
+                 + results.get("degraded", 0)) > 0 else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_reexecute.py
+++ b/tests/test_batch_reexecute.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+test_batch_reexecute.py — garde de vraisemblance et cwd explicite (#14356).
+
+Couvre :
+  - _output_census : recensement outputs / image/png, abstention si illisible
+  - _degradation : ne signale qu'une CHUTE, et seulement avec une reference
+  - execute_notebook : un papermill sortant 0 en ayant perdu les images rend
+    DEGRADED et restaure la sauvegarde
+  - execute_notebook : --cwd transmis a papermill, valeur selon cwd_mode
+
+Le troisieme test est la reproduction du defaut mesure le 2026-09-02 sur
+``01-5-Qwen-Image-Edit.ipynb`` : 9 s, 0 image, ``SUCCESS`` affiche, tous les
+gardes CI verts. C'est le seul cas ou le code de sortie ment sans qu'aucun
+autre signal ne bronche.
+
+Usage :
+    pytest tests/test_batch_reexecute.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "notebook_tools"))
+
+import batch_reexecute  # noqa: E402
+from batch_reexecute import _degradation, _output_census  # noqa: E402
+
+
+def _nb(n_images: int = 0, n_text: int = 0) -> dict:
+    """Minimal notebook carrying the requested output census."""
+    outputs = [{"output_type": "display_data", "data": {"image/png": "iVBORw0KGgo="}}
+               for _ in range(n_images)]
+    outputs += [{"output_type": "stream", "name": "stdout", "text": ["ok\n"]}
+                for _ in range(n_text)]
+    return {
+        "cells": [{"cell_type": "code", "source": ["pass"],
+                   "execution_count": 1, "outputs": outputs, "metadata": {}}],
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+
+
+def _write(path: Path, nb: dict) -> Path:
+    path.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    return path
+
+
+# --- _output_census ---
+
+def test_census_counts_images_and_outputs(tmp_path: Path) -> None:
+    nb = _write(tmp_path / "a.ipynb", _nb(n_images=2, n_text=3))
+    assert _output_census(nb) == {"readable": True, "outputs": 5, "images": 2}
+
+
+def test_census_handles_null_outputs(tmp_path: Path) -> None:
+    """``outputs: null`` occurs in hand-edited notebooks; it must not raise."""
+    raw = _nb()
+    raw["cells"][0]["outputs"] = None
+    nb = _write(tmp_path / "b.ipynb", raw)
+    assert _output_census(nb)["outputs"] == 0
+
+
+def test_census_abstains_on_unreadable(tmp_path: Path) -> None:
+    nb = tmp_path / "c.ipynb"
+    nb.write_text("{not json", encoding="utf-8")
+    assert _output_census(nb)["readable"] is False
+
+
+# --- _degradation ---
+
+def test_degradation_flags_images_lost() -> None:
+    before = {"readable": True, "outputs": 5, "images": 2}
+    after = {"readable": True, "outputs": 5, "images": 0}
+    assert _degradation(before, after) == "images 2 -> 0"
+
+
+def test_degradation_silent_without_image_baseline() -> None:
+    """No images before means no reference: the guard catches regressions, not
+    absences — which is the nominal state of the notebooks this tool targets."""
+    before = {"readable": True, "outputs": 4, "images": 0}
+    after = {"readable": True, "outputs": 4, "images": 0}
+    assert _degradation(before, after) == ""
+
+
+def test_degradation_silent_on_rise() -> None:
+    """A rise is the nominal outcome: the tool exists to fill missing outputs."""
+    before = {"readable": True, "outputs": 0, "images": 0}
+    after = {"readable": True, "outputs": 12, "images": 3}
+    assert _degradation(before, after) == ""
+
+
+def test_degradation_flags_output_collapse() -> None:
+    before = {"readable": True, "outputs": 20, "images": 0}
+    after = {"readable": True, "outputs": 4, "images": 0}
+    assert _degradation(before, after) == "outputs 20 -> 4"
+
+
+def test_degradation_tolerates_minor_drop() -> None:
+    """A deprecation warning that stops being emitted is not a collapse."""
+    before = {"readable": True, "outputs": 20, "images": 0}
+    after = {"readable": True, "outputs": 19, "images": 0}
+    assert _degradation(before, after) == ""
+
+
+def test_degradation_abstains_when_either_side_unreadable() -> None:
+    unreadable = {"readable": False, "outputs": 0, "images": 0}
+    populated = {"readable": True, "outputs": 9, "images": 2}
+    assert _degradation(unreadable, populated) == ""
+    assert _degradation(populated, unreadable) == ""
+
+
+# --- execute_notebook ---
+
+@pytest.fixture
+def fake_papermill(monkeypatch):
+    """Replace subprocess.run with a stub that writes a chosen result."""
+    captured: dict = {}
+
+    def install(result_nb: dict | None, returncode: int = 0):
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            if result_nb is not None:
+                Path(cmd[4]).write_text(json.dumps(result_nb, indent=1), encoding="utf-8")
+            return SimpleNamespace(returncode=returncode, stdout="", stderr="")
+
+        monkeypatch.setattr(batch_reexecute.subprocess, "run", fake_run)
+        return captured
+
+    return install
+
+
+def test_zero_exit_with_lost_images_is_degraded(tmp_path: Path, fake_papermill) -> None:
+    """The measured incident: papermill exits 0, exception None, clean
+    execution_count — and zero images. Only the census tells them apart."""
+    nb = _write(tmp_path / "d.ipynb", _nb(n_images=2, n_text=1))
+    fake_papermill(_nb(n_images=0, n_text=1))
+
+    result = batch_reexecute.execute_notebook(nb, "python3", 60)
+
+    assert result["status"] == "DEGRADED"
+    assert "images 2 -> 0" in result["error"]
+    # The backup is restored: a green-looking empty notebook is worse than none.
+    assert _output_census(nb)["images"] == 2
+    assert not nb.with_suffix(".ipynb.bak").exists()
+
+
+def test_allow_degraded_keeps_the_result(tmp_path: Path, fake_papermill) -> None:
+    nb = _write(tmp_path / "e.ipynb", _nb(n_images=2, n_text=1))
+    fake_papermill(_nb(n_images=0, n_text=1))
+
+    result = batch_reexecute.execute_notebook(nb, "python3", 60, allow_degraded=True)
+
+    assert result["status"] == "SUCCESS"
+    assert result["degraded"] == "images 2 -> 0"
+    assert _output_census(nb)["images"] == 0
+
+
+def test_healthy_run_reports_success_without_degradation(tmp_path: Path, fake_papermill) -> None:
+    nb = _write(tmp_path / "f.ipynb", _nb(n_images=0, n_text=0))
+    fake_papermill(_nb(n_images=2, n_text=4))
+
+    result = batch_reexecute.execute_notebook(nb, "python3", 60)
+
+    assert result["status"] == "SUCCESS"
+    assert result["degraded"] is None
+
+
+def test_cwd_repo_is_the_default(tmp_path: Path, fake_papermill) -> None:
+    nb = _write(tmp_path / "g.ipynb", _nb(n_images=1))
+    captured = fake_papermill(_nb(n_images=1))
+
+    batch_reexecute.execute_notebook(nb, "python3", 60)
+
+    cmd = captured["cmd"]
+    assert "--cwd" in cmd, "papermill must be told the cwd explicitly (#14356)"
+    assert cmd[cmd.index("--cwd") + 1] == str(batch_reexecute.REPO_ROOT)
+
+
+def test_cwd_notebook_mode_passes_notebook_dir(tmp_path: Path, fake_papermill) -> None:
+    nb = _write(tmp_path / "h.ipynb", _nb(n_images=1))
+    captured = fake_papermill(_nb(n_images=1))
+
+    batch_reexecute.execute_notebook(nb, "python3", 60, cwd_mode="notebook")
+
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--cwd") + 1] == str(nb.parent)


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/genai #14352

## Résumé

`execute_notebook` figeait `cwd=str(REPO_ROOT)` et ne transmettait **jamais** `--cwd` à papermill. Pour tout notebook qui résout une ressource en **remontant les parents depuis `Path.cwd()`**, la ressource devient introuvable — et la dégradation est **silencieuse** : le notebook prend sa branche `except`, papermill écrit `exception: None`, l'outil affiche `SUCCESS`, et le fichier commité a perdu son contenu.

Rencontré en réparant le ratchet de #14352 : la première passe via cet outil rendait `SUCCESS (9s)` avec **0 image** là où l'invocation correcte prenait 6 min 40 et en produisait 2. Elle serait passée **tous** les gardes CI — `execution_count [1..13]` propre, 0 cellule en erreur, bloc `metadata.papermill` frais. Elle a été jetée après vérification du livrable, pas commitée.

## Ce que la PR change

**Remède 1 — `--cwd {repo,notebook}`**, défaut `repo`. Le défaut reste **byte-identique au comportement historique** : papermill sans `--cwd` laisse le kernel dans le cwd du processus, qui était déjà `REPO_ROOT` ; le passer explicitement ne change rien, sinon que le répertoire de travail cesse d'être une conséquence implicite de la façon dont l'outil a été lancé. Les deux conventions de résolution de chemin coexistent dans le dépôt — basculer le défaut casserait symétriquement les notebooks qui résolvent depuis la racine — donc le choix est **explicite**, pas un renversement.

**Remède 3 — garde de vraisemblance agnostique de la cause.** Recensement des `outputs` et des `image/png` avant/après. Une chute (`images N>0 → 0`, ou `outputs` divisés par plus de deux) rend **`DEGRADED`** et **restaure la sauvegarde** : garder un résultat vide d'apparence verte est pire que n'en garder aucun, puisqu'il satisfait tous les gardes en aval. Échappatoire `--allow-degraded` pour le cas où la baisse est légitime.

Deux abstentions délibérées dans la garde, qui sont ce qui la rend utilisable :
- elle ne signale qu'une **chute** — une hausse est le résultat nominal, l'outil existant pour remplir des sorties manquantes ;
- sans image préalable elle **se tait** — pas de référence, pas d'accusation. Elle attrape donc les **régressions**, pas les **absences**, qui sont l'état nominal des notebooks qu'elle cible.

**Remède 2 non pris** (détection heuristique de la remontée de parents) : son faux positif choisirait en silence un cwd contre l'intention de l'auteur du notebook, et il devient largement inutile une fois le 3 en place.

## Preuve — contrôle end-to-end, papermill réel, une seule variable changée

Notebook sonde qui remonte les parents vers un marqueur, placé dans un sous-répertoire (visible depuis le notebook, invisible depuis la racine) — le mécanisme du `.env` GenAI, sans la stack GenAI :

| invocation | ressource | images produites | verdict | notebook sur disque |
|---|---|---|---|---|
| `--cwd notebook` | trouvée | 1 | `SUCCESS` | résultat gardé |
| `--cwd repo` | perdue | 0 | **`DEGRADED`** (`images 1 -> 0`) | **bon état restauré** (images=1) |

**Avant ce correctif, les deux passes sortaient `0` et affichaient `SUCCESS`.** C'est la ligne du bas qui est le livrable : le mécanisme est évité par le remède 1, et attrapé par le remède 3 quand le remède 1 n'a pas été employé.

## Tests

`tests/test_batch_reexecute.py` — **14 tests, 14 passent** (0,64 s) :

```
$ python -m pytest tests/test_batch_reexecute.py -q
14 passed in 0.64s
```

Couvrent le recensement (images, `outputs: null` des notebooks hand-édités, abstention sur illisible), les six cas de `_degradation` (chute d'images, chute d'outputs, hausse, baisse mineure, absence de référence, illisible), le câblage `--cwd` dans les deux modes, et — c'est le test qui compte — la reproduction de l'incident : papermill sort 0 en ayant effacé les images, la garde rend `DEGRADED` et la sauvegarde est restaurée.

## Portée

Deux fichiers, aucun notebook touché, aucun comportement modifié en mode par défaut hors la détection de dégradation. Le compteur `Degraded:` est ajouté au résumé et compte dans le code de sortie.

See #14356
See #11112
