### PR TITLE
fix(docs,#13751): repointer les 4 refs stale docs/ict vers ict/results/ post-move #14289

### DIFF
--- a/docs/ict/command-following-observers-pre-enregistrement.md
+++ b/docs/ict/command-following-observers-pre-enregistrement.md
@@ -73,6 +73,6 @@ La tranche suivante, dans un commit distinct, portera :
 
 - `MyIA.AI.Notebooks/IIT/ICT-Series/ict/command_following_observers.py` ;
 - `MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_command_following_observers.py` ;
-- `MyIA.AI.Notebooks/IIT/ICT-Series/ict/command_following_observers_results.json`.
+- `MyIA.AI.Notebooks/IIT/ICT-Series/ict/results/command_following_observers_results.json`.
 
 Aucun notebook ni sortie de cellule n'est modifié. Le registre [`dissociations-matrix.md`](dissociations-matrix.md) reste hors scope pour éviter les claims périmés qui le couvrent encore ; le résultat pourra y être relié par une tranche ultérieure de sa lane propriétaire.

--- a/docs/ict/dissociations-matrix.md
+++ b/docs/ict/dissociations-matrix.md
@@ -468,7 +468,7 @@ Cette case **active** le hook Gómez-Emilsson & Percy comme aiguillon de lecture
 
 #### Exécution c.431 (chantier 6/3) — verdict INCONCLUSIF
 
-Première exécution du protocole ci-dessus, **sans retouche post-hoc** : script [`MyIA.AI.Notebooks/IIT/ICT-Series/ict/kuramoto_boundary.py`](../../MyIA.AI.Notebooks/IIT/ICT-Series/ict/kuramoto_boundary.py), sortie brute [`kuramoto_boundary_results.json`](../../MyIA.AI.Notebooks/IIT/ICT-Series/ict/kuramoto_boundary_results.json), CPU-only, déterministe (5 graines 0/1/7/42/99, numpy seul). Calibration null exécutée **avant** le test principal (anti-HARKing) : σ_Δ = 0.0104 → ε_topo = 0.0052.
+Première exécution du protocole ci-dessus, **sans retouche post-hoc** : script [`MyIA.AI.Notebooks/IIT/ICT-Series/ict/kuramoto_boundary.py`](../../MyIA.AI.Notebooks/IIT/ICT-Series/ict/kuramoto_boundary.py), sortie brute [`kuramoto_boundary_results.json`](../../MyIA.AI.Notebooks/IIT/ICT-Series/ict/results/kuramoto_boundary_results.json), CPU-only, déterministe (5 graines 0/1/7/42/99, numpy seul). Calibration null exécutée **avant** le test principal (anti-HARKing) : σ_Δ = 0.0104 → ε_topo = 0.0052.
 
 | Mesure | Valeur | Cible pré-enregistrée |
 |---|---|---|

--- a/docs/ict/strates-as-adjunctions-prototype.md
+++ b/docs/ict/strates-as-adjunctions-prototype.md
@@ -66,7 +66,7 @@ Le substrat **ICT-12c `PregnanceAnimat`** (`MyIA.AI.Notebooks/IIT/ICT-Series/ict
 
 **Null adversarial** : un animat dont `f_aj` est un **foncteur sans adjoint** (par exemple une composition libre sans co-unit) ne modifie ni (P1) ni (P2) — c'est l'**absence d'adjonction** qui tue la prédiction.
 
-**Statut au 2026-08-30** : prédiction originale **EXÉCUTÉE ET FALSIFIÉE COMME SPÉCIFICATION** ; signature empirique plus faible du canal couplé **SUPPORTÉE**. Le protocole, les tests et les résultats reproductibles vivent dans `ict/adjonction_saillance_pregnance.py`, `ict/tests/test_adjonction_saillance_pregnance.py` et `ict/adjonction_saillance_pregnance_results.json`.
+**Statut au 2026-08-30** : prédiction originale **EXÉCUTÉE ET FALSIFIÉE COMME SPÉCIFICATION** ; signature empirique plus faible du canal couplé **SUPPORTÉE**. Le protocole, les tests et les résultats reproductibles vivent dans `ict/adjonction_saillance_pregnance.py`, `ict/tests/test_adjonction_saillance_pregnance.py` et `ict/results/adjonction_saillance_pregnance_results.json`.
 
 ### 4.1 Amendement pré-exécution — observables et frontières
 

--- a/docs/ict/threshold-alignment-pre-enregistrement.md
+++ b/docs/ict/threshold-alignment-pre-enregistrement.md
@@ -96,6 +96,6 @@ La tranche suivante, dans un commit distinct, portera :
 
 - `MyIA.AI.Notebooks/IIT/ICT-Series/ict/threshold_alignment.py` ;
 - `MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_threshold_alignment.py` ;
-- `MyIA.AI.Notebooks/IIT/ICT-Series/ict/threshold_alignment_results.json`, produit par exécution réelle du module.
+- `MyIA.AI.Notebooks/IIT/ICT-Series/ict/results/threshold_alignment_results.json`, produit par exécution réelle du module.
 
 Aucun notebook ni sortie de cellule n'est modifié. Le registre [`dissociations-matrix.md`](dissociations-matrix.md) reste hors scope : le rattachement éventuel de ce résultat relève d'une tranche ultérieure de sa lane propriétaire.


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: MED/tooling #14358

## Sujet unique

Repointer les 4 références stale de `docs/ict/` vers `ict/results/` après le déplacement des 8 `*_results.json` (#14289, tranche IIT de #13751).

## Cause racine mesurée

`616429e43d` (#14289) déplace les 8 `*_results.json` de `ict/` vers `ict/results/` (R100, renames purs). `docs/ict/dissociations-matrix.md:471` pointe encore l'ancien chemin — **seul lien markdown cassé** : `check_docs_links.py --check` sur main rend `REGRESSION: 1 new broken link(s)` + exit 1. Le défaut vit sur **main** : toute PR courante dont l'arbre porte `docs/` hérite du rouge `check-links` (cas mesuré : #14303, vérifié sur son merge-ref via `commits/<sha>/check-runs`).

## Diff (4 fichiers, prose-only, zéro notebook)

| Fichier | Nature |
|---|---|
| `docs/ict/dissociations-matrix.md:471` | lien markdown cassé → `ict/results/` (le seul détecté par le checker) |
| `docs/ict/command-following-observers-pre-enregistrement.md:76` | mention backtick stale |
| `docs/ict/strates-as-adjunctions-prototype.md:69` | mention backtick stale |
| `docs/ict/threshold-alignment-pre-enregistrement.md:99` | mention backtick stale |

Même classe (paths stale post-move), même geste, un sujet.

## Validation post-fix (relancée APRÈS le commit)

```
$ python scripts/check_docs_links.py --check
OK: No new broken links. (0 pre-existing, 5420 total)
exit 0
```

Balayage élargi `ict/*_results.json` hors `ict/results/` sous `docs/` : vide (propre).

## Périmètre

- Pas de `Closes` : #13751 porte d'autres résiduels (Search naming, Lean README index, Argumentum dossier vide, QC hub links) — contribution partielle `See #13751`.
- Pas de catalogue touché. Aucun notebook. Collision vérifiée : zéro PR ouverte sur `docs/ict/`.
