### PR TITLE
fix(notebook-tools,#14212): STUB_PATTERNS sur-tire — deux PRs sur la meme issue, main rouge une fois les deux dessus

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -360,25 +360,6 @@ STUB_PATTERNS = [
     # `display("Exercice 2 a completer ...")` with no `// TODO`/`// Indice`).
     re.compile(r'(?:Console\.WriteLine|display)\(\$?["\']Exercice', re.IGNORECASE),
     re.compile(r"^\s*result\s*=\s*None\b", re.MULTILINE | re.IGNORECASE),
-    # Typed-empty return literals (#14212): the canonical ``return None`` was
-    # the only neutral-empty marker, so a function whose contract is a list /
-    # dict / tuple / numeric / set / string and that returns the typed empty
-    # literal (``return []``, ``return {}``, ``return ()``, ``return 0``,
-    # ``return set()``, ``return ""``) read as 'multi-line real code' to the
-    # stub gate and was under-counted. Example: ``auditer-la-conformite-visuelle``
-    # cell 38/39 (`return []` / `return {}`) escaped the gate while cell 40
-    # (`return None`) was caught -- three structurally identical stubs rendered
-    # 1/3. ``\b`` boundaries keep the match tight: ``return 100`` or
-    # ``return False`` are NOT matched (those are real values, not empty).
-    # ``return ""`` is rare enough that it is included for symmetry; pedagogically
-    # it is the string-equivalent of `return None` -- keeps the notebook
-    # executable end-to-end while being an obvious TODO marker.
-    re.compile(r"\breturn\s+\[\]"),
-    re.compile(r"\breturn\s+\{\}"),
-    re.compile(r"\breturn\s+\(\)"),
-    re.compile(r"\breturn\s+0\b"),
-    re.compile(r"\breturn\s+set\(\)"),
-    re.compile(r'\breturn\s+""'),
     re.compile(r"^\s*raise\s+NotImplementedError", re.MULTILINE),
     re.compile(r"^\s*assert\s+False\b", re.MULTILINE),
     # "a completer" / "to complete" LINE-COMMENT stub markers. A scaffolded


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #14375

`Scripts Tests (CPU)` echoue sur **toutes** les PRs ouvertes. La cause est sur `main`, elle n'appartient a aucune lane, et elle vient de ma propre passe de merge.

## Deux PRs pour la meme issue, a 26 minutes d'ecart

| commit | PR | merge | ce qu'elle fait |
|---|---|---|---|
| `769ce3250` | #14232 | 20:25 | cree `EMPTY_RETURN_PATTERNS`, liste **separee** — et pose le test qui garde la distinction |
| `c9001b985` | #14265 | 20:51 | re-verse les **six memes motifs** dans `STUB_PATTERNS` |

Chacune verte isolement. `main` rouge une fois les deux dessus.

## Pourquoi la seconde casse la premiere

#14232 n'a pas mis ces motifs dans `STUB_PATTERNS` par oubli — elle les en a **tenus a l'ecart deliberement**, et son commentaire le dit :

> Unlike the STUB_PATTERNS above, a bare `return []` is NOT only a stub marker: an MST base case `return 0`, `return float('inf')`... So these are applied [to the] last effective line (not the whole source).

`STUB_PATTERNS` est balaye sur la source entiere (`pat.search(source)`). `EMPTY_RETURN_PATTERNS` n'est teste que sur `code_lines[-1]`, et seulement si `len(code_lines) <= 4`. Ces deux bornes sont **toute** la distinction entre un squelette d'exercice et un exemple resolu qui contient un `return []` quelque part.

Verser les motifs dans `STUB_PATTERNS` les court-circuite : le plafond de 4 lignes ne s'applique plus, la restriction a la derniere ligne non plus.

Le test qui tombe est celui que #14232 avait ecrit pour ca :

```
FAILED test_count_exercises.py::TestStubClassification::test_empty_return_inside_worked_example_is_not_a_stub
assert True is False
 +  where True = _is_stub_code("class Node:\n ... def children(self):\n        return []\n ...")
```

Une classe `Node` complete — constructeur, trois methodes, un `print` final — lue comme un stub d'etudiant.

## Le corps de #14265 n'a pas menti

Il affirme « 93 passed [...] aucun existant casse ». C'etait **vrai dans son arbre** : le test qu'il casse avait ete merge 26 minutes plus tot. La mesure etait honnete et le resultat faux — c'est la signature d'une collision de cascade, pas d'une negligence d'auteur.

C'est **ma** faute de coordination : j'ai merge deux PRs sur la meme issue sans re-mesurer entre les deux.

## Le correctif

Retrait des 6 motifs de `STUB_PATTERNS`. Ils restent **inchanges** dans `EMPTY_RETURN_PATTERNS`, ou #14232 les avait places. 19 lignes supprimees, zero ajoutee.

## Mesure — a arbre constant

Meme HEAD, meme corpus, seul ce fichier varie (les chiffres du corps de #14265 datent d'un corpus a 1041 notebooks ; comparer a eux serait confondu par les 2 notebooks arrives depuis) :

| | exercices | conformes | sous-seuil |
|---|---|---|---|
| avant (motifs dupliques) | 3494 | 1012 | 31 |
| apres | **3490** | 1012 | 31 |

**Quatre cellules** sur 1043 notebooks etaient sur-comptees. **Aucun verdict de conformite ne change** — ce qui explique qu'aucun garde de corpus n'ait rougi : le defaut ne se voyait que dans la suite de tests.

## Acceptance de #14265 preservee — verifiee firsthand

```
$ python scripts/notebook_tools/count_exercises.py .../auditer-la-conformite-visuelle.ipynb
Total exercises     : 3
Conforming          : 1
Sub-threshold       : 0
```

Les cellules 38/39 (`return []` / `return {}`) qui motivaient #14265 sont deja attrapees par le design de #14232 : elles sont compactes et le retour est la derniere ligne. Le doublon n'ajoutait rien a ce cas — il n'ajoutait que le faux positif.

## Tests

```
$ python -m pytest scripts/notebook_tools/tests/test_count_exercises.py -q
89 passed in 0.50s
```

Dont `test_empty_return_inside_worked_example_is_not_a_stub`, rouge sur `main`.

See #14212
