### PR TITLE
fix(ci,#14283): sparse-checkout en non-cone sur les 6 blocs qui listent des fichiers

### DIFF
--- a/.github/workflows/concurrency-conj-guard.yml
+++ b/.github/workflows/concurrency-conj-guard.yml
@@ -39,6 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Cone mode (le defaut) n'accepte que des REPERTOIRES : une entree de
+          # fichier fait echouer le checkout (`fatal: ... is not a directory`).
+          # Mesure : en non-cone ces chemins se listent SANS slash initial -- la
+          # forme `/chemin` que suggere l'avertissement de git rend un checkout VIDE.
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/workflows
             scripts/ci/check_concurrency_conj.py

--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -65,11 +65,21 @@ jobs:
       - name: Checkout the lane-claim helper (sparse)
         uses: actions/checkout@v4
         with:
+          # Cone mode (le defaut) n'accepte que des REPERTOIRES : une entree de
+          # fichier fait echouer le checkout (`fatal: ... is not a directory`).
+          # Mesure : en non-cone ces chemins se listent SANS slash initial -- la
+          # forme `/chemin` que suggere l'avertissement de git rend un checkout VIDE.
+          # `pytest.ini` etait fourni IMPLICITEMENT par le cone mode (qui inclut
+          # les fichiers racine) ; en non-cone il doit etre liste, sinon l'etape
+          # pytest ci-dessous tourne sans sa config (`--import-mode importlib`,
+          # markers, filterwarnings).
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             scripts/ci/lane_claim_required.py
             scripts/check_lane_claim.py
             scripts/grain_tag.py
             scripts/tests/test_check_lane_claim.py
+            pytest.ini
       - name: 'Resolve closing-ref vs other lanes active claims (block on collision)'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -208,8 +218,17 @@ jobs:
       - name: Checkout the lane-claim helper (sparse)
         uses: actions/checkout@v4
         with:
+          # Cone mode (le defaut) n'accepte que des REPERTOIRES : une entree de
+          # fichier fait echouer le checkout (`fatal: ... is not a directory`).
+          # Mesure : en non-cone ces chemins se listent SANS slash initial -- la
+          # forme `/chemin` que suggere l'avertissement de git rend un checkout VIDE.
+          # `emit_dead_scope_warnings.py` est appele par l'etape ci-dessous mais
+          # n'etait pas liste : son absence est avalee par le `|| true`, donc les
+          # annotations dead-scope disparaissaient en silence. Liste-le.
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             scripts/ci/lane_claim_required.py
+            scripts/ci/emit_dead_scope_warnings.py
             scripts/check_lane_claim.py
             scripts/grain_tag.py
       - name: 'Apply lane-claim advisory labels'

--- a/.github/workflows/stale-guard-red-sweep.yml
+++ b/.github/workflows/stale-guard-red-sweep.yml
@@ -69,6 +69,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Cone mode (le defaut) n'accepte que des REPERTOIRES : une entree de
+          # fichier fait echouer le checkout (`fatal: ... is not a directory`).
+          # Mesure : en non-cone ces chemins se listent SANS slash initial -- la
+          # forme `/chemin` que suggere l'avertissement de git rend un checkout VIDE.
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             scripts/check_stale_guard_reds.py
 

--- a/.github/workflows/unique-check-run-names-guard.yml
+++ b/.github/workflows/unique-check-run-names-guard.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Checkout workflows + script
         uses: actions/checkout@v4
         with:
+          # Cone mode (le defaut) n'accepte que des REPERTOIRES : une entree de
+          # fichier fait echouer le checkout (`fatal: ... is not a directory`).
+          # Mesure : en non-cone ces chemins se listent SANS slash initial -- la
+          # forme `/chemin` que suggere l'avertissement de git rend un checkout VIDE.
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/workflows
             scripts/ci/check_unique_check_run_names.py

--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Checkout the cap detector (sparse)
         uses: actions/checkout@v4
         with:
+          # Cone mode (le defaut) n'accepte que des REPERTOIRES : une entree de
+          # fichier fait echouer le checkout (`fatal: ... is not a directory`).
+          # Mesure : en non-cone ces chemins se listent SANS slash initial -- la
+          # forme `/chemin` que suggere l'avertissement de git rend un checkout VIDE.
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             scripts/variation_light_cap.py
             scripts/grain_tag.py


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc #14369

## Le symptôme : un garde requis qui échoue à son **checkout**, pas à sa vérification

`unique-check-run-names-guard` est rouge sur `main` depuis ce soir, et il ne rougit pas sur ce qu'il mesure — il n'arrive jamais jusque-là :

```
fatal: 'scripts/ci/check_unique_check_run_names.py' is not a directory;
to treat it as a directory anyway, rerun with --skip-checks
```

Le `sparse-checkout` de l'étape liste **un fichier**. Le **cone mode** — le défaut d'`actions/checkout@v4` — n'accepte que des **répertoires**, et il avorte le checkout entier sur la première entrée de fichier. Aucune des étapes suivantes ne tourne.

## Pourquoi maintenant, alors que le fichier n'a pas bougé

Le défaut est **latent depuis l'écriture du bloc** et n'a rien à voir avec le contenu du garde. Il a surfacé quand la **tranche 3 de #14283** (`ba7a151372`, PR #14336, mergée aujourd'hui à 18:36:12 +0200) a routé le job vers `[self-hosted, coursia-ephemeral, coursia-linux]`, dont l'image porte un git plus récent — un git qui refuse là où l'ancien laissait passer.

Le seul diff de `ba7a151372` sur ce fichier est le runner :

```diff
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
```

**Falsifié dans les deux sens** sur ma propre branche, parce qu'un rouge n'appartient à une PR que s'il passe sur `main` et échoue en isolation — ici c'est la base qui bascule :

| run sur la même branche | base | verdict |
|---|---|---|
| 18:36:22Z | avant `ba7a151372` | **SUCCESS** |
| 20:05:19Z | après `ba7a151372` | **FAILURE** (checkout) |

Et le frère qui **passe** sur le même runner tranche la question du runner lui-même : `translation-guard.yml` liste `.github` et `scripts/ci` — **deux répertoires**, aucun fichier. Même image, même action, même version. La variable n'est pas le runner, c'est la forme de la liste.

## La mesure, pas la supposition

Reproduit localement (git 2.51.0.windows.1) sur un dépôt jouet, message d'erreur **verbatim**. Puis les deux formes non-cone comparées, parce que je m'attendais à ce que la forme recommandée par l'avertissement de git soit la bonne :

| forme | résultat mesuré |
|---|---|
| `--no-cone`, chemins **tels quels** (`scripts/ci/tool.py`) | fichiers **matérialisés** (avertissement cosmétique) |
| `--no-cone`, chemins **avec slash initial** (`/scripts/ci/tool.py`) | checkout **VIDE**, en silence |

C'est la forme sans slash qui est retenue. La forme que git suggère lui-même est celle qui casse — d'où les quatre lignes de commentaire à chaque bloc : sans elles, la prochaine lane « corrigera » vers `/chemin` et obtiendra un vert vide.

Deux contrôles complémentaires, parce qu'un correctif qui remplace un rouge par un **faux vert** serait pire que le rouge :

- **Un motif de répertoire recurse bien en non-cone** — `.github/workflows` a ramené les trois fichiers, y compris un `sub/w3.yml` imbriqué. Les deux blocs qui mêlent répertoire et fichier gardent leur sémantique.
- **Le cone mode fournit implicitement les fichiers racine, le non-cone non** — mesuré : `pytest.ini` et `requirements.txt` présents en cone, absents en non-cone. C'est ce qui a motivé l'audit ci-dessous.

## Deux défauts de complétude trouvés en vérifiant ce que le cone fournissait en douce

Passer en non-cone rend la liste **autoritaire** : ce qui n'y est pas n'existe plus. J'ai donc vérifié, pour chacun des 6 blocs, que tout ce que le job exécute est couvert. Deux trous :

1. **`lane-claim-guard :: check-lane-claim-required` exécute `pytest`** — `pytest.ini` (seule config pytest du dépôt : `--import-mode importlib`, markers, filterwarnings) lui venait du cone mode. Il est désormais **listé**. Le test lui-même s'en sort par son propre `sys.path.insert` (vérifié ligne 20), donc l'absence n'aurait pas cassé l'import — mais un job qui lance pytest doit avoir sa config, pas en hériter par accident.

2. **`lane-claim-guard :: check-lane-claim-advisory` invoque `scripts/ci/emit_dead_scope_warnings.py` sans le lister.** Son absence est avalée par le `|| true` documenté juste au-dessus : le job reste **vert** et les annotations dead-scope (#13129) disparaissent **en silence**. Ajouté à la liste.

Le second est un vrai défaut préexistant, pas une conséquence de ce changement — le non-cone le rend simplement conséquent au lieu d'invisible.

## Périmètre : 6 blocs, 5 fichiers, +39 lignes, 0 suppression

Tous les blocs modifiés sont routés vers `self-hosted` (là où le cone avorte aujourd'hui) :

| workflow | blocs | état aujourd'hui |
|---|---|---|
| `unique-check-run-names-guard.yml` | 1 | **rouge en ce moment** sur toute PR touchant `.github/workflows/**` |
| `stale-guard-red-sweep.yml` | 1 | casse au prochain cron |
| `concurrency-conj-guard.yml` · `lane-claim-guard.yml` · `variation-light-genre.yml` | 4 | doublons dormants, absorbés par `always-on-guards.yml` — corrigés pour ne pas laisser une mine sous un futur réveil |

Contrôle d'acceptance rejoué après coup, sur les 6 blocs : chaque motif existe dans le dépôt, chaque script invoqué par un `run:` est couvert par un motif, et `sparse-checkout-cone-mode: false` est bien présent. Verdict `OK` sur 6/6.

Le diff est **+39/−0** et n'a pas touché une seule ligne existante — je le précise parce qu'une première tentative avait réécrit les fins de ligne des 5 fichiers (`872 insertions / 842 deletions` de pur bruit CRLF) ; elle a été jetée et refaite à l'ancre de contenu.

## Ce que je n'ai pas fait, et pourquoi

**`variation-tag-guard.yml` porte le même défaut sur 7 blocs (15 entrées de fichier) et n'est pas corrigé ici.** Il est resté sur `ubuntu-latest` : il **fonctionne aujourd'hui**, et le basculer en non-cone serait un changement à risque sur un garde requis vert, sans bénéfice présent. Il casse au moment où une tranche de #14283 le routera — c'est à ce moment-là, dans la PR de routage, que le bloc doit basculer. Signalé ici pour que ce ne soit pas une surprise.

Observation annexe, non corrigée (hors sujet de cette PR) : `scripts/check_lane_claim.py:1697-1704` a un `try` dont le `except` réessaie **le même import à l'identique** — le fallback annoncé par le commentaire n'existe pas. Sans conséquence (le second échec retombe sur `return None`), mais c'est du code mort déguisé en garde-fou.

See #14283
