### PR TITLE
fix(runner,#14285): desarmer l'etat sparse-checkout residuel entre deux jobs d'un slot

### DIFF
--- a/scripts/ci/docker/linux-runner/entrypoint.sh
+++ b/scripts/ci/docker/linux-runner/entrypoint.sh
@@ -17,6 +17,38 @@ export ACTIONS_RUNNER_INPUT_EPHEMERAL=true
 export ACTIONS_RUNNER_INPUT_REPLACE=true
 export ACTIONS_RUNNER_INPUT_WORK=/home/runner/_work
 
+# --- Desarmement de l'etat sparse-checkout residuel (slot poisoning) ---------
+# Le volume _work est persistant PAR SLOT (#14285/#14288) et le conteneur est
+# recree a chaque job : ce bloc est donc un hook job-started, sans plomberie.
+#
+# actions/checkout ne desarme le sparse qu'AU DEBUT du job suivant -- trop tard.
+# Sequence mesuree (job 100417132588, slot myia-ai-01-linux-docker-2) :
+#   git reset --hard HEAD        <- sparse encore ACTIF : ne reset que le sous-ensemble
+#   git sparse-checkout disable  <- leve les skip-worktree ; l index reclame les absents
+#   git checkout --force <ref>
+#     error: Path '...test_hmm_regime_vol.py' not uptodate; will not remove from working tree.
+#                                <- git ABANDONNE la materialisation, HEAD bouge quand meme
+# Le job herite alors de l arbre sparse du precedent -- 1 fichier sous scripts/
+# au lieu de 1087 -- et echoue en [Errno 2] sur un fichier pourtant versionne.
+#
+# Deux cas, deux couts : le flag arme est le seul etat cassant (git materialise
+# le sous-ensemble), le fichier de motifs seul est inerte (flag absent = motifs
+# ignores -- mesure du 2026-09-02 : slots 3-8 le portent avec un arbre complet).
+# On ne purge donc le clone que dans le premier cas ; sinon on retire le fichier
+# et on garde le cache incremental que #14285 a achete (~40-51 s/job).
+for gitdir in "$ACTIONS_RUNNER_INPUT_WORK"/*/*/.git; do
+  [ -e "$gitdir" ] || continue
+  repo="${gitdir%/.git}"
+  if [ -n "$(git -C "$repo" config --local --get core.sparseCheckout 2>/dev/null || true)" ]; then
+    echo "entrypoint: sparse ARME dans $repo -- purge du clone (le checkout suivant reclonera)"
+    rm -rf "$repo"
+  elif [ -f "$gitdir/info/sparse-checkout" ]; then
+    echo "entrypoint: motifs sparse inertes dans $repo -- retrait du fichier, clone conserve"
+    rm -f "$gitdir/info/sparse-checkout"
+  fi
+done
+# ---------------------------------------------------------------------------
+
 cd /opt/runner
 ./config.sh --unattended --ephemeral --replace
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/tooling #14379

## Le defaut

Deux workflows **sans lien** ont echoue coup sur coup sur un **seul slot**
(`myia-ai-01-linux-docker-2`), sur des fichiers pourtant versionnes :

| Job | Erreur |
|---|---|
| `Label-poser workflows self-cover (blocking)` | `scripts/check_workflow_label_paths.py: [Errno 2] No such file or directory` |
| `Gitleaks positive controls (#10143)` | `file or directory not found: scripts/secrets/tests/test_gitleaks_qwen_rule.py` |

Meme branche, sans changement de contenu : **succes a 20:31:20Z, echec a 20:43:14Z**.
La defaillance est localisee au **slot**, pas au workflow.

## La cause, mesuree

Inspection du volume `coursia-runner-work-2` : `core.sparseCheckout=true` persistant,
`.git/info/sparse-checkout` portant la liste non-cone de `unique-check-run-names-guard.yml`,
et **1 fichier sous `scripts/` au lieu de 1087**.

Le log du job 100417132588 donne la sequence exacte :

```
git reset --hard HEAD        <- sparse encore ACTIF : ne reset que le sous-ensemble
git sparse-checkout disable  <- leve les skip-worktree ; l'index reclame les absents
git checkout --force <ref>
  error: Path '...test_hmm_regime_vol.py' not uptodate; will not remove from working tree.
```

`git` **abandonne la materialisation** de l'arbre, `HEAD` bouge quand meme. Le job
tourne alors sur l'arbre sparse de son predecesseur. `actions/checkout` ne desarme
le sparse qu'**au debut du job suivant** — trop tard, et son propre `checkout --force`
est justement ce qui echoue.

Condition habilitante : le volume `_work` **persistant par slot** (#14285/#14288).
Sans lui, chaque job repartait d'un `_work` vide.

**Ce que j'ai d'abord cru, et qui etait faux** : mon premier replay a rendu
`fatal: could not fetch ... from promisor remote`, d'ou une theorie de clone partiel.
C'etait un artefact de mon `docker exec` sans credentials sur un commit hors du
`--depth=1`. Le job reel fetch **sans `--filter`** : tous les blobs sont locaux.
La theorie promisor est morte, et n'a pas ete relayee.

## Le correctif

Le conteneur etant recree a chaque job (`--ephemeral` + `--rm`), `entrypoint.sh`
**est deja un hook job-started** : le desarmement s'y ancre sans plomberie nouvelle,
sans `ACTIONS_RUNNER_HOOK_*`, sans fichier supplementaire.

Deux cas, deux couts — c'est le point de conception :

| Etat residuel | Effet reel | Geste | Cout |
|---|---|---|---|
| `core.sparseCheckout` **arme** | git materialise le sous-ensemble = arbre casse | purge du clone | un clone complet, **uniquement** sur un slot reellement empoisonne |
| fichier de motifs **seul** | inerte (flag absent = motifs ignores) | retrait du fichier | nul, le cache incremental est conserve |

Le second cas n'est pas une precaution : c'est ce que portent les slots 3-8
**avec un arbre complet** (mesure du 2026-09-02). Purger dessus jetterait les
~40-51 s/job que #14285 a achetees, a chaque job suivant un job sparse.

## Controle positif

Passe dans l'image reelle `coursia-linux-runner:2.336.0`, sur un etat fabrique,
en executant le bloc **extrait du fichier livre** (pas une reecriture) :

```
avant : A(flag arme)=present  B(fichier seul)=present  fichierB=oui
entrypoint: sparse ARME dans /w/A/A -- purge du clone (le checkout suivant reclonera)
entrypoint: motifs sparse inertes dans /w/B/B -- retrait du fichier, clone conserve
apres : A=PURGE-OK  B=PRESENT-OK  fichierB=RETIRE-OK
```

## Portee

L'image est partagee avec po-2024 : leurs slots portent le meme defaut et
demandent le meme rebuild. Dispatch envoye.

See #14285
