### PR TITLE
ci(#14283): route golden-set-execute vers le pool self-hosted Linux

### DIFF
--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -228,11 +228,18 @@ jobs:
   # A broken notebook makes this job RED, then GREEN once repaired.
   golden-set-execute:
     name: Golden-set execution (H.7 P3)
-    runs-on: ubuntu-latest
+    # Routage #14283 fin de chantier (ai-01 dispatch 2026-09-02, item 1) :
+    # dernier job trivialement migrable — setup-python (toolcache monte) et
+    # github-script (node embarque du runner) sont servis par l'image.
+    # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
+    # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     # Independent of notebook-change detection: the golden-set is a FIXED
     # certified core, re-executed whenever the manifest/lockfile/workflow
-    # change (PR + main push) or on manual dispatch. No `if:` needed — the
-    # workflow triggers above already gate this job's execution.
+    # change (PR + main push) or on manual dispatch. The trigger paths above
+    # already gate this job's execution; the if: only carries the fork guard.
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2024:CoursIA — prev: MED/test #14383

See #14283 (fin de chantier, item 1 du dispatch ai-01 du 2026-09-02) — l'epic reste ouverte : item 2 (mesure quarto-actions/setup) en cours.

## Ce que fait cette PR

Migration du dernier job trivialement migrable de `notebook-execution-required.yml` vers le pool self-hosted Linux : `golden-set-execute` (3ᵉ job, ligne ~229). Les deux jobs frères (`detect-changes`, `validate-static`) roulent sur le pool depuis la tranche 3c ; celui-ci est le dernier qui restait sur `ubuntu-latest`.

Pourquoi trivial : ses seules dépendances actions sont `actions/setup-python@v5` (toolcache monté dans l'image) et `actions/github-script@v7` (node embarqué du runner) — pas de Docker, pas de GPU.

La forme est la forme canonique du chantier :

- `runs-on: [self-hosted, coursia-ephemeral, coursia-linux]` **statique** (une expression lèverait `DYNAMIC_RUNS_ON` dans `check_self_hosted_runner_policy.py`) ;
- garde anti-fork **au niveau job** : `if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository` ;
- rien à ajouter côté politique : le workflow est déjà dans `SELF_HOSTED_WORKFLOW_ALLOWLIST`.

Le workflow liste son propre chemin dans ses triggers `pull_request` → **cette PR exerce le job migré de bout en bout**.

## Produit à vérifier (pas seulement le vert)

Le dispatch le dit : un job routé vers une machine sans l'outil attendu peut être **muet** (sortie `|| true` → exit 0 sans rien poster). Le produit attendu de ce run est le **commentaire PR « Golden-Set Execution (H.7 P3) »** avec la table des notebooks certifiés — posté par le job migré lui-même. La vérification post-merge se fait sur ce commentaire, pas sur la couleur du check.

## Retour arrière

Remettre `runs-on: ubuntu-latest` + retirer le workflow de l'allowlist (documenté en commentaire dans le YAML, même forme que les tranches précédentes).

## Validation

- Diff = 1 fichier, 9 lignes (runs-on + garde + commentaires de routage) — aucune logique du job modifiée.
- Le run de la PR elle-même est la validation : le job exécutera le golden-set Papermill sur le pool (timeout 20 min inchangé).
