### PR TITLE
fix(lean-21b,#12208): les deux tests de limite s'executent au lieu de s'annoncer

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21b-PFR-Primitives-Transportables.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21b-PFR-Primitives-Transportables.ipynb
@@ -5,10 +5,10 @@
    "id": "3fd55e7c",
    "metadata": {
     "papermill": {
-     "duration": 0.014223,
-     "end_time": "2026-08-27T16:51:12.363517+00:00",
+     "duration": 0.002041,
+     "end_time": "2026-09-02T21:29:15.576073",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.349294+00:00",
+     "start_time": "2026-09-02T21:29:15.574032",
      "status": "completed"
     },
     "tags": []
@@ -66,10 +66,10 @@
    "id": "e44d9187",
    "metadata": {
     "papermill": {
-     "duration": 0.00523,
-     "end_time": "2026-08-27T16:51:12.375421+00:00",
+     "duration": 0.001399,
+     "end_time": "2026-09-02T21:29:15.579206",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.370191+00:00",
+     "start_time": "2026-09-02T21:29:15.577807",
      "status": "completed"
     },
     "tags": []
@@ -106,16 +106,16 @@
    "id": "8b72f4f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T16:51:12.385158Z",
-     "iopub.status.busy": "2026-08-27T16:51:12.384881Z",
-     "iopub.status.idle": "2026-08-27T16:51:12.401139Z",
-     "shell.execute_reply": "2026-08-27T16:51:12.400097Z"
+     "iopub.execute_input": "2026-09-02T21:29:15.582982Z",
+     "iopub.status.busy": "2026-09-02T21:29:15.582778Z",
+     "iopub.status.idle": "2026-09-02T21:29:15.590856Z",
+     "shell.execute_reply": "2026-09-02T21:29:15.590406Z"
     },
     "papermill": {
-     "duration": 0.02188,
-     "end_time": "2026-08-27T16:51:12.402118+00:00",
+     "duration": 0.011141,
+     "end_time": "2026-09-02T21:29:15.591761",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.380238+00:00",
+     "start_time": "2026-09-02T21:29:15.580620",
      "status": "completed"
     },
     "tags": []
@@ -175,10 +175,10 @@
    "id": "c69d894c",
    "metadata": {
     "papermill": {
-     "duration": 0.001856,
-     "end_time": "2026-08-27T16:51:12.406526+00:00",
+     "duration": 0.001623,
+     "end_time": "2026-09-02T21:29:15.595091",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.404670+00:00",
+     "start_time": "2026-09-02T21:29:15.593468",
      "status": "completed"
     },
     "tags": []
@@ -195,7 +195,15 @@
     "\n",
     "### 1.3 Test de limite — quand la primitive ne transporte plus\n",
     "\n",
-    "On essaie la formule sur un objet **sans structure de groupe** : un arbre binaire.\n"
+    "On garde la formule, les distributions et l'entropie **inchangées**, et on ne fait\n",
+    "varier que l'opération `x − y`. Deux exhibitions :\n",
+    "\n",
+    "- **(a)** le même ensemble `{0,1,2,3}` muni de **deux lois de groupe différentes**\n",
+    "  (`ℤ/4ℤ` et le groupe de Klein) donne **deux valeurs différentes** de `d` pour les\n",
+    "  **mêmes** distributions — la valeur de `d` n'est donc pas une fonction des seules\n",
+    "  distributions, mais du couple (distributions, loi de groupe) ;\n",
+    "- **(b)** en retirant l'inversibilité de `x ↦ x − y`, `d` devient **négatif** — et une\n",
+    "  distance négative n'en est plus une.\n"
    ]
   },
   {
@@ -204,16 +212,16 @@
    "id": "feb6d5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T16:51:12.410666Z",
-     "iopub.status.busy": "2026-08-27T16:51:12.410513Z",
-     "iopub.status.idle": "2026-08-27T16:51:12.414096Z",
-     "shell.execute_reply": "2026-08-27T16:51:12.413686Z"
+     "iopub.execute_input": "2026-09-02T21:29:15.599024Z",
+     "iopub.status.busy": "2026-09-02T21:29:15.598827Z",
+     "iopub.status.idle": "2026-09-02T21:29:16.996441Z",
+     "shell.execute_reply": "2026-09-02T21:29:16.995953Z"
     },
     "papermill": {
-     "duration": 0.006431,
-     "end_time": "2026-08-27T16:51:12.414675+00:00",
+     "duration": 1.400695,
+     "end_time": "2026-09-02T21:29:16.997295",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.408244+00:00",
+     "start_time": "2026-09-02T21:29:15.596600",
      "status": "completed"
     },
     "tags": []
@@ -223,40 +231,95 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verdict Primitive 1 :\n",
-      "  d_ruzsa exige STRUCTURE DE GROUPE ADDITIF.\n",
-      "  Transportable SOUS CONDITION (laquelle ? groupe abélien).\n"
+      "(a) mêmes distributions, deux lois de groupe sur le même ensemble {0,1,2,3}\n",
+      "  ℤ/4ℤ  : H(X−Y) = 1.5000 bits   →  d[X;Y] = 0.5000\n",
+      "  Klein : d[X;Y] = 0.0000\n",
+      "  La valeur de d n'est donc PAS une fonction des seules distributions :\n",
+      "  c'est une fonction du couple (distributions, loi de groupe).\n",
+      "\n",
+      "(b) 40 000 couples de distributions tirés au hasard sur {0,1,2,3} :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (a − b) mod 4  groupe cyclique  →  min d = +0.0128   d ≥ 0 : distance\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  a XOR b        groupe de Klein  →  min d = +0.0170   d ≥ 0 : distance\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  max(a − b, 0)  non inversible   →  min d = -1.2699   d < 0 : PLUS une distance\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (a × b) mod 4  non inversible   →  min d = -0.9756   d < 0 : PLUS une distance\n",
+      "\n",
+      "  Les deux opérations non inversibles rendent d négatif. Une « distance »\n",
+      "  négative n'en est pas une : la primitive a cessé de valoir, et on voit où.\n"
      ]
     }
    ],
    "source": [
-    "# Test de limite : la formule de Ruzsa appliquée à un objet SANS structure de groupe\n",
-    "# On simule X, Y comme distributions sur les nœuds d'un arbre binaire de profondeur 4\n",
-    "# (16 feuilles) et on essaie de définir un « X - Y » via le XOR des codes (proxy additif ℤ/2⁴ℤ).\n",
-    "# Distribution uniforme sur les 16 nœuds\n",
-    "def uniform_binary_tree(d):\n",
-    "    leaves = list(range(2 ** d))\n",
-    "    return {k: 1.0 / len(leaves) for k in leaves}\n",
-    "# Mais « l'arbre » lui-même n'a pas d'opération de groupe canonique.\n",
-    "# Le XOR des codes binaires EST une structure de groupe (ℤ/2⁴ℤ), donc ce test\n",
-    "# ne disqualifie pas la primitive — il montre que « l'objet » peut être ré-interprété.\n",
-    "#\n",
-    "# Test plus radical : objet sans représentation additive canonique.\n",
-    "# Par exemple : distances sur une sphère (métrique non-associative).\n",
-    "# d[X;Y] = H(distance entre X' et Y') - 0.5 H(X') - 0.5 H(Y')\n",
-    "# Cette définition est mathématiquement valide MAIS :\n",
-    "#   1. \"X' - Y'\" n'a plus de sens canonique (quelle est la \"différence\" de deux points sur une sphère ?)\n",
-    "#   2. Sans structure de groupe, \"X' - Y'\" dépend du choix de représentation.\n",
-    "#   3. La symétrie d[X;Y] = d[Y;X] peut être violée.\n",
-    "# Conclusion : la primitive N'est PAS inconditionnellement transportable.\n",
-    "# Elle exige une structure de groupe additif (Z/nZ, F₂ⁿ, G quelconque).\n",
-    "# Coller la formule sur un objet sans groupe, c'est de l'over-fitting de formalisme.\n",
-    "print(\"Verdict Primitive 1 :\")\n",
-    "print(\"  d_ruzsa exige STRUCTURE DE GROUPE ADDITIF.\")\n",
-    "print(\"  Transportable SOUS CONDITION (laquelle ? groupe abélien).\")\n",
-    "# Distance de Ruzsa formelle dans Lean (cf Lean-21 cell#6 si besoin) :\n",
-    "#  def d_ruzsa_lean (G : Type*) [AddGroup G] (X Y : Distribution G) : ℝ :=\n",
-    "#    H(X' - Y') - ½ * H(X) - ½ * H(Y)\n"
+    "# 1.3 — Test de limite : ce que la formule cesse de mesurer sans loi de groupe.\n",
+    "# On ne change QUE l'opération « x − y ». Le reste — les distributions, la\n",
+    "# formule, l'entropie — est identique à la cellule précédente.\n",
+    "def d_ruzsa_op(X_dist, Y_dist, sub):\n",
+    "    \"\"\"d[X;Y] = H(X−Y) − H(X)/2 − H(Y)/2, la soustraction étant fournie.\"\"\"\n",
+    "    XY = Counter()\n",
+    "    for x, px in X_dist.items():\n",
+    "        for y, py in Y_dist.items():\n",
+    "            XY[sub(x, y)] += px * py\n",
+    "    return entropy_bits(XY) - 0.5 * entropy_bits(X_dist) - 0.5 * entropy_bits(Y_dist)\n",
+    "\n",
+    "# (a) Même ensemble, mêmes distributions, deux lois de groupe différentes.\n",
+    "#     X = Y = uniforme sur {0, 1}, plongées dans un ensemble à 4 éléments.\n",
+    "X = Y = {0: 0.5, 1: 0.5}\n",
+    "z4    = lambda a, b: (a - b) % 4        # ℤ/4ℤ : groupe cyclique\n",
+    "klein = lambda a, b: a ^ b              # (ℤ/2ℤ)² : groupe de Klein\n",
+    "\n",
+    "print(\"(a) mêmes distributions, deux lois de groupe sur le même ensemble {0,1,2,3}\")\n",
+    "print(f\"  ℤ/4ℤ  : H(X−Y) = {entropy_bits(Counter({z4(x, y): 0.25 for x in X for y in Y})):.4f} bits\"\n",
+    "      f\"   →  d[X;Y] = {d_ruzsa_op(X, Y, z4):.4f}\")\n",
+    "print(f\"  Klein : d[X;Y] = {d_ruzsa_op(X, Y, klein):.4f}\")\n",
+    "print(\"  La valeur de d n'est donc PAS une fonction des seules distributions :\")\n",
+    "print(\"  c'est une fonction du couple (distributions, loi de groupe).\")\n",
+    "\n",
+    "# (b) On retire l'inversibilité : « x − y » cesse d'être une bijection en x.\n",
+    "#     Si d devient négatif, ce n'est plus une distance.\n",
+    "import random\n",
+    "rng = random.Random(7)\n",
+    "\n",
+    "def dirichlet(k):\n",
+    "    g = [rng.gammavariate(1.0, 1.0) for _ in range(k)]\n",
+    "    s = sum(g)\n",
+    "    return {i: v / s for i, v in enumerate(g)}\n",
+    "\n",
+    "lois = [\n",
+    "    (\"(a − b) mod 4\", \"groupe cyclique\", z4),\n",
+    "    (\"a XOR b\",       \"groupe de Klein\", klein),\n",
+    "    (\"max(a − b, 0)\", \"non inversible\",  lambda a, b: max(a - b, 0)),\n",
+    "    (\"(a × b) mod 4\", \"non inversible\",  lambda a, b: (a * b) % 4),\n",
+    "]\n",
+    "print(\"\\n(b) 40 000 couples de distributions tirés au hasard sur {0,1,2,3} :\")\n",
+    "for nom, nature, sub in lois:\n",
+    "    d_min = min(d_ruzsa_op(dirichlet(4), dirichlet(4), sub) for _ in range(40_000))\n",
+    "    verdict = \"d ≥ 0 : distance\" if d_min > -1e-9 else \"d < 0 : PLUS une distance\"\n",
+    "    print(f\"  {nom:<14} {nature:<16} →  min d = {d_min:+.4f}   {verdict}\")\n",
+    "print(\"\\n  Les deux opérations non inversibles rendent d négatif. Une « distance »\")\n",
+    "print(\"  négative n'en est pas une : la primitive a cessé de valoir, et on voit où.\")"
    ]
   },
   {
@@ -264,10 +327,10 @@
    "id": "2e37b0be",
    "metadata": {
     "papermill": {
-     "duration": 0.001393,
-     "end_time": "2026-08-27T16:51:12.417601+00:00",
+     "duration": 0.002007,
+     "end_time": "2026-09-02T21:29:17.001612",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.416208+00:00",
+     "start_time": "2026-09-02T21:29:16.999605",
      "status": "completed"
     },
     "tags": []
@@ -275,7 +338,7 @@
    "source": [
     "### Verdict Primitive 1\n",
     "\n",
-    "**Transportable sous condition** : `d_ruzsa[X;Y]` exige une **structure de groupe additif** `(G, +)`. Sans groupe, la convolution `X′ − Y′` n'a pas de définition canonique et la formule dégénère. C'est exactement la classe « conditionnelle » du tableau d'introduction.\n",
+    "**Transportable sous condition** : `d_ruzsa[X;Y]` exige une **structure de groupe additif** `(G, +)`. La cellule précédente le montre en deux temps — la valeur de `d` **change** quand on change la loi de groupe à distributions fixées, et sans inversibilité de `x ↦ x − y` elle **passe sous zéro**, donc cesse d'être une distance. C'est exactement la classe « conditionnelle » du tableau d'introduction.\n",
     "\n",
     "**Leçon** : la primitive a une **puissance incomparable** sur son terrain (groupes abéliens, `F₂ⁿ`, entropie appliquée à la combinatoire additive), mais l'**utiliser hors de ce terrain** serait du « mapping affine » — c'est-à-dire plaquer une structure sans la mériter. Le notebook Lean-21 lui-même s'en garde : la preuve PFR ne s'applique qu'à `F₂ⁿ`, pas à un objet métrique général.\n",
     "\n",
@@ -306,16 +369,16 @@
    "id": "2c16f4f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T16:51:12.421472Z",
-     "iopub.status.busy": "2026-08-27T16:51:12.421279Z",
-     "iopub.status.idle": "2026-08-27T16:51:12.426803Z",
-     "shell.execute_reply": "2026-08-27T16:51:12.426414Z"
+     "iopub.execute_input": "2026-09-02T21:29:17.006786Z",
+     "iopub.status.busy": "2026-09-02T21:29:17.006417Z",
+     "iopub.status.idle": "2026-09-02T21:29:17.013223Z",
+     "shell.execute_reply": "2026-09-02T21:29:17.012632Z"
     },
     "papermill": {
-     "duration": 0.008245,
-     "end_time": "2026-08-27T16:51:12.427335+00:00",
+     "duration": 0.010517,
+     "end_time": "2026-09-02T21:29:17.014106",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.419090+00:00",
+     "start_time": "2026-09-02T21:29:17.003589",
      "status": "completed"
     },
     "tags": []
@@ -386,10 +449,10 @@
    "id": "c909ff99",
    "metadata": {
     "papermill": {
-     "duration": 0.001604,
-     "end_time": "2026-08-27T16:51:12.430701+00:00",
+     "duration": 0.002111,
+     "end_time": "2026-09-02T21:29:17.018296",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.429097+00:00",
+     "start_time": "2026-09-02T21:29:17.016185",
      "status": "completed"
     },
     "tags": []
@@ -414,16 +477,16 @@
    "id": "979c328f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T16:51:12.434985Z",
-     "iopub.status.busy": "2026-08-27T16:51:12.434749Z",
-     "iopub.status.idle": "2026-08-27T16:51:12.439013Z",
-     "shell.execute_reply": "2026-08-27T16:51:12.438599Z"
+     "iopub.execute_input": "2026-09-02T21:29:17.023211Z",
+     "iopub.status.busy": "2026-09-02T21:29:17.022952Z",
+     "iopub.status.idle": "2026-09-02T21:29:17.027634Z",
+     "shell.execute_reply": "2026-09-02T21:29:17.027133Z"
     },
     "papermill": {
-     "duration": 0.007627,
-     "end_time": "2026-08-27T16:51:12.439980+00:00",
+     "duration": 0.008194,
+     "end_time": "2026-09-02T21:29:17.028392",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.432353+00:00",
+     "start_time": "2026-09-02T21:29:17.020198",
      "status": "completed"
     },
     "tags": []
@@ -485,10 +548,10 @@
    "id": "99ebe05e",
    "metadata": {
     "papermill": {
-     "duration": 0.001706,
-     "end_time": "2026-08-27T16:51:12.443364+00:00",
+     "duration": 0.001957,
+     "end_time": "2026-09-02T21:29:17.032473",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.441658+00:00",
+     "start_time": "2026-09-02T21:29:17.030516",
      "status": "completed"
     },
     "tags": []
@@ -529,16 +592,16 @@
    "id": "4355c4ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T16:51:12.448557Z",
-     "iopub.status.busy": "2026-08-27T16:51:12.448351Z",
-     "iopub.status.idle": "2026-08-27T16:51:12.455344Z",
-     "shell.execute_reply": "2026-08-27T16:51:12.454756Z"
+     "iopub.execute_input": "2026-09-02T21:29:17.037601Z",
+     "iopub.status.busy": "2026-09-02T21:29:17.037204Z",
+     "iopub.status.idle": "2026-09-02T21:29:17.042648Z",
+     "shell.execute_reply": "2026-09-02T21:29:17.042073Z"
     },
     "papermill": {
-     "duration": 0.01077,
-     "end_time": "2026-08-27T16:51:12.456148+00:00",
+     "duration": 0.008908,
+     "end_time": "2026-09-02T21:29:17.043364",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.445378+00:00",
+     "start_time": "2026-09-02T21:29:17.034456",
      "status": "completed"
     },
     "tags": []
@@ -615,10 +678,10 @@
    "id": "7d7c3a2c",
    "metadata": {
     "papermill": {
-     "duration": 0.002129,
-     "end_time": "2026-08-27T16:51:12.460760+00:00",
+     "duration": 0.002247,
+     "end_time": "2026-09-02T21:29:17.047721",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.458631+00:00",
+     "start_time": "2026-09-02T21:29:17.045474",
      "status": "completed"
     },
     "tags": []
@@ -632,7 +695,10 @@
     "\n",
     "### 3.3 Test de limite — quand τ ne transporte plus\n",
     "\n",
-    "On essaie de définir une τ analogue sur un problème **sans ordre partiel naturel**.\n"
+    "On porte `τ` sur SAT, où aucun ordre n'est donné d'avance. On construit une formule à\n",
+    "3 variables, on descend l'affectation `x₁, x₂, x₃`, et on **mesure la trajectoire** de\n",
+    "deux `τ` naturelles au lieu de supposer ce qu'elles font. Puis on regarde **2-SAT**,\n",
+    "où le problème, lui, *fournit* l'ordre.\n"
    ]
   },
   {
@@ -641,16 +707,16 @@
    "id": "ec5c9125",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T16:51:12.465284Z",
-     "iopub.status.busy": "2026-08-27T16:51:12.465097Z",
-     "iopub.status.idle": "2026-08-27T16:51:12.468323Z",
-     "shell.execute_reply": "2026-08-27T16:51:12.467935Z"
+     "iopub.execute_input": "2026-09-02T21:29:17.052609Z",
+     "iopub.status.busy": "2026-09-02T21:29:17.052397Z",
+     "iopub.status.idle": "2026-09-02T21:29:17.061383Z",
+     "shell.execute_reply": "2026-09-02T21:29:17.060744Z"
     },
     "papermill": {
-     "duration": 0.006041,
-     "end_time": "2026-08-27T16:51:12.468774+00:00",
+     "duration": 0.012596,
+     "end_time": "2026-09-02T21:29:17.062267",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.462733+00:00",
+     "start_time": "2026-09-02T21:29:17.049671",
      "status": "completed"
     },
     "tags": []
@@ -660,34 +726,124 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verdict Primitive 3 :\n",
-      "  τ exige une STRUCTURE ORDONNÉE sous-jacente (entier strictement décroissant).\n",
-      "  Transportable SOUS CONDITION (laquelle ? ordre partiel bien-fondé).\n",
-      "  Pour les problèmes sans ordre canonique (SAT général), τ n'existe pas.\n"
+      "candidat A : τ = clauses non encore satisfaites\n",
+      "  trajectoire       : [5, 2, 1, 1]\n",
+      "  décroît strictement ? [True, True, False]  →  False\n",
+      "  Le dernier pas est PLAT : τ_A décroît, mais pas strictement.\n",
+      "  Elle ne peut donc pas fonder la terminaison.\n",
+      "\n",
+      "candidat B : τ = variables non encore affectées\n",
+      "  trajectoire       : [3, 2, 1, 0]\n",
+      "  décroît strictement ? [True, True, True]  →  True\n",
+      "  Elle décroît strictement — mais QUOI QU'IL ARRIVE : elle ne lit jamais F.\n",
+      "  Elle prouve que l'énumération s'arrête, pas que la formule est décidée.\n",
+      "\n",
+      "2-SAT : le problème fournit l'ordre (condensation du graphe d'implication)\n",
+      "  (x₁ ∨ ¬x₂) ∧ (¬x₁ ∨ x₂) ∧ (x₁ ∨ x₂)    → 2 composante(s), satisfiable = True\n",
+      "  (x₁ ∨ x₁) ∧ (¬x₁ ∨ ¬x₁)                → 1 composante(s), satisfiable = False\n",
+      "\n",
+      "  τ n'est pas une formule qu'on transporte : c'est un patron qu'on\n",
+      "  CONSTRUIT à partir d'une structure que le problème doit fournir.\n",
+      "  2-SAT la fournit, et la décision suit. SAT général ne la fournit pas,\n",
+      "  et les deux τ naturelles ci-dessus échouent chacune à leur façon.\n"
      ]
     }
    ],
    "source": [
-    "# Test de limite : τ sur un problème SAT (booléen, sans ordre canonique)\n",
-    "# Problème : (x1 ∨ ¬x2) ∧ (¬x1 ∨ x2) ∧ (x1 ∨ x2)\n",
-    "# C'est satisfiable : x1=x2=True. Mais quelle τ ?\n",
-    "#\n",
-    "# Candidate 1 : τ = nombre de clauses non satisfaites. Mais elle dépend de l'affectation,\n",
-    "# pas de la structure du problème — donc elle NE décroît PAS sous raffinement structurel.\n",
-    "#\n",
-    "# Candidate 2 : τ = nombre de variables. Décroît si on fixe une variable, mais pas strictement\n",
-    "# (on peut fixer une variable sans changer la satisfaisabilité — ex. si x1 = True est forcé).\n",
-    "#\n",
-    "# Candidate 3 : τ = une mesure de « complexité de la formule ». Mais SAT n'a pas de τ canonique.\n",
-    "# Conclusion : pour SAT, il n'y a PAS de τ naturelle au sens où PFR en a une.\n",
-    "# La descente monotone n'est pas universelle ; elle exige une STRUCTURE ORDONNÉE\n",
-    "# sous-jacente au problème.\n",
-    "# Mais : pour des SOUS-classes de SAT (2-SAT, Horn-SAT), il existe des τ naturelles\n",
-    "# (ex. pour 2-SAT : τ = nombre de composantes fortement connexes dans le graphe d'implication).\n",
-    "print(\"Verdict Primitive 3 :\")\n",
-    "print(\"  τ exige une STRUCTURE ORDONNÉE sous-jacente (entier strictement décroissant).\")\n",
-    "print(\"  Transportable SOUS CONDITION (laquelle ? ordre partiel bien-fondé).\")\n",
-    "print(\"  Pour les problèmes sans ordre canonique (SAT général), τ n'existe pas.\")\n"
+    "# 3.3 — Test de limite : porter τ sur SAT, où aucun ordre n'est donné d'avance.\n",
+    "# On fixe x₁, x₂, x₃ dans cet ordre et on regarde ce que chaque candidat τ\n",
+    "# fait RÉELLEMENT le long de la descente — au lieu de le supposer.\n",
+    "F = [(1, 2, 3), (-1, 2, -3), (1, -2, 3), (-1, -2, -3), (1, 2, -3)]\n",
+    "\n",
+    "def clauses_non_satisfaites(clauses, assign):\n",
+    "    \"\"\"Clauses qu'aucun littéral déjà affecté ne rend vraie.\"\"\"\n",
+    "    return sum(\n",
+    "        1 for c in clauses\n",
+    "        if not any(abs(l) in assign and assign[abs(l)] == (l > 0) for l in c)\n",
+    "    )\n",
+    "\n",
+    "descente = [{}, {1: True}, {1: True, 2: True}, {1: True, 2: True, 3: True}]\n",
+    "\n",
+    "tau_A = [clauses_non_satisfaites(F, a) for a in descente]\n",
+    "strict_A = [tau_A[i] < tau_A[i - 1] for i in range(1, len(tau_A))]\n",
+    "print(\"candidat A : τ = clauses non encore satisfaites\")\n",
+    "print(f\"  trajectoire       : {tau_A}\")\n",
+    "print(f\"  décroît strictement ? {strict_A}  →  {all(strict_A)}\")\n",
+    "print(\"  Le dernier pas est PLAT : τ_A décroît, mais pas strictement.\")\n",
+    "print(\"  Elle ne peut donc pas fonder la terminaison.\")\n",
+    "\n",
+    "tau_B = [3 - len(a) for a in descente]\n",
+    "strict_B = [tau_B[i] < tau_B[i - 1] for i in range(1, len(tau_B))]\n",
+    "print(\"\\ncandidat B : τ = variables non encore affectées\")\n",
+    "print(f\"  trajectoire       : {tau_B}\")\n",
+    "print(f\"  décroît strictement ? {strict_B}  →  {all(strict_B)}\")\n",
+    "print(\"  Elle décroît strictement — mais QUOI QU'IL ARRIVE : elle ne lit jamais F.\")\n",
+    "print(\"  Elle prouve que l'énumération s'arrête, pas que la formule est décidée.\")\n",
+    "\n",
+    "# Sur 2-SAT, en revanche, le problème FOURNIT l'ordre : les composantes\n",
+    "# fortement connexes du graphe d'implication, et leur condensation est un DAG.\n",
+    "def composantes_fortes(sommets, succ):\n",
+    "    \"\"\"Kosaraju — composantes fortement connexes, sans dépendance externe.\"\"\"\n",
+    "    vus, ordre = set(), []\n",
+    "    for depart in sommets:\n",
+    "        if depart in vus:\n",
+    "            continue\n",
+    "        vus.add(depart)\n",
+    "        pile = [(depart, iter(succ.get(depart, ())))]\n",
+    "        while pile:\n",
+    "            _, it = pile[-1]\n",
+    "            for v in it:\n",
+    "                if v not in vus:\n",
+    "                    vus.add(v)\n",
+    "                    pile.append((v, iter(succ.get(v, ()))))\n",
+    "                    break\n",
+    "            else:\n",
+    "                ordre.append(pile.pop()[0])\n",
+    "    pred = {}\n",
+    "    for a, voisins in succ.items():\n",
+    "        for b in voisins:\n",
+    "            pred.setdefault(b, []).append(a)\n",
+    "    comp, vus2, numero = {}, set(), 0\n",
+    "    for depart in reversed(ordre):\n",
+    "        if depart in vus2:\n",
+    "            continue\n",
+    "        vus2.add(depart)\n",
+    "        pile, bloc = [depart], []\n",
+    "        while pile:\n",
+    "            n = pile.pop()\n",
+    "            bloc.append(n)\n",
+    "            for m in pred.get(n, ()):\n",
+    "                if m not in vus2:\n",
+    "                    vus2.add(m)\n",
+    "                    pile.append(m)\n",
+    "        for n in bloc:\n",
+    "            comp[n] = numero          # un seul numéro pour TOUT le bloc\n",
+    "        numero += 1\n",
+    "    return comp\n",
+    "\n",
+    "def deux_sat(clauses, nvars):\n",
+    "    \"\"\"(a ∨ b) ≡ (¬a → b) ∧ (¬b → a) ; satisfiable ssi jamais v et ¬v ensemble.\"\"\"\n",
+    "    succ = {}\n",
+    "    for a, b in clauses:\n",
+    "        succ.setdefault(-a, []).append(b)\n",
+    "        succ.setdefault(-b, []).append(a)\n",
+    "    sommets = [s for v in range(1, nvars + 1) for s in (v, -v)]\n",
+    "    comp = composantes_fortes(sommets, succ)\n",
+    "    ok = all(comp.get(v) != comp.get(-v) for v in range(1, nvars + 1))\n",
+    "    return ok, len(set(comp.values()))\n",
+    "\n",
+    "print(\"\\n2-SAT : le problème fournit l'ordre (condensation du graphe d'implication)\")\n",
+    "for libelle, clauses, nvars in [\n",
+    "    (\"(x₁ ∨ ¬x₂) ∧ (¬x₁ ∨ x₂) ∧ (x₁ ∨ x₂)\", [(1, -2), (-1, 2), (1, 2)], 2),\n",
+    "    (\"(x₁ ∨ x₁) ∧ (¬x₁ ∨ ¬x₁)\",             [(1, 1), (-1, -1)],          1),\n",
+    "]:\n",
+    "    ok, n = deux_sat(clauses, nvars)\n",
+    "    print(f\"  {libelle:<38} → {n} composante(s), satisfiable = {ok}\")\n",
+    "\n",
+    "print(\"\\n  τ n'est pas une formule qu'on transporte : c'est un patron qu'on\")\n",
+    "print(\"  CONSTRUIT à partir d'une structure que le problème doit fournir.\")\n",
+    "print(\"  2-SAT la fournit, et la décision suit. SAT général ne la fournit pas,\")\n",
+    "print(\"  et les deux τ naturelles ci-dessus échouent chacune à leur façon.\")"
    ]
   },
   {
@@ -695,10 +851,10 @@
    "id": "6be6ac45",
    "metadata": {
     "papermill": {
-     "duration": 0.001442,
-     "end_time": "2026-08-27T16:51:12.471877+00:00",
+     "duration": 0.002921,
+     "end_time": "2026-09-02T21:29:17.067635",
      "exception": false,
-     "start_time": "2026-08-27T16:51:12.470435+00:00",
+     "start_time": "2026-09-02T21:29:17.064714",
      "status": "completed"
     },
     "tags": []
@@ -706,7 +862,7 @@
    "source": [
     "### Verdict Primitive 3\n",
     "\n",
-    "**Transportable sous condition** : `τ_strictly_decreases` exige un **ensemble bien ordonné** sous-jacent (typiquement `ℕ` ou un ordinal). Sans ordre bien-fondé, la descente monotone n'est pas garantie de terminer.\n",
+    "**Transportable sous condition** : `τ_strictly_decreases` exige un **ordre bien fondé** sous-jacent (typiquement `ℕ` ou un ordinal). La cellule précédente montre que le porter sur SAT échoue de **deux façons distinctes** : la `τ` qui lit la formule ne décroît **pas strictement** (trajectoire plate au dernier pas), et celle qui décroît strictement **ne lit jamais la formule** — elle prouve que l'énumération s'arrête, pas que le problème est décidé. Sur **2-SAT** en revanche la structure existe (condensation du graphe d'implication) et la décision suit.\n",
     "\n",
     "**Subtilité** : `τ` est un **patron**, pas une formule figée. Pour chaque problème, on doit **construire** la `τ` appropriée — et c'est souvent **l'étape créative** de la preuve. Dans PFR, `τ` est construit à partir de l'entropie ; dans Lean-21 cell#6, c'est l'invariant qui garantit que le blueprint termine.\n",
     "\n",
@@ -720,11 +876,11 @@
     "\n",
     "| # | Primitive | Transport | Condition | Sans la condition |\n",
     "|---|---|---|---|---|\n",
-    "| 1 | `d_ruzsa[X;Y]` | **conditionnel** | groupe additif `(G, +)` | formule dégénère (convolution `X′ − Y′` non définie) |\n",
+    "| 1 | `d_ruzsa[X;Y]` | **conditionnel** | groupe additif `(G, +)` | `d` devient **négatif** : ce n'est plus une distance |\n",
     "| 2 | `X = π(X) + (X | π(X))` | **large** | distribution de probabilité | décomposition vide (projection non définie) |\n",
     "| 3 | `τ_strictly_decreases` | **patron** | ordre bien-fondé | terminaison non garantie |\n",
     "\n",
-    "**Le test de limite était le livrable** : chaque primitive a été **appliquée hors de son terrain** et le notebook a **nommé** l'endroit exact où elle cesse de valoir. C'est cette honnêteté qui distingue une « digestion » d'une « analogie ».\n",
+    "**Le test de limite était le livrable** : chaque primitive a été **appliquée hors de son terrain** et le notebook **exhibe** — par une cellule qui s'exécute, pas par un paragraphe qui l'annonce — l'endroit exact où elle cesse de valoir. C'est cette honnêteté qui distingue une « digestion » d'une « analogie ».\n",
     "\n",
     "### Lien vers Lean-21 et le lac `pfr`\n",
     "\n",
@@ -765,7 +921,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.533228,
+   "end_time": "2026-09-02T21:29:17.311787",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-21b-PFR-Primitives-Transportables.ipynb",
+   "output_path": "Lean-21b-PFR-Primitives-Transportables.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-02T21:29:13.778559",
+   "version": "2.6.0"
   },
   "references": [
    "Lean-21-PFR-Entropy-Method.ipynb (companion upstream)",


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #14361

## Le grain

L'EPIC #12208 pose lui-même son critère de promotion (§5.3) : un matériau n'est infusable dans ICT que s'il « porte le contre-claim **exécuté**, pas seulement énoncé » — et §2 : « une cellule qui montre la primitive cesser de valoir vaut mieux qu'un paragraphe qui l'annonce ».

`Lean-21b-PFR-Primitives-Transportables.ipynb` porte trois tests de limite. **Un seul le tenait.**

| test | avant | après |
|---|---|---|
| 1.3 — distance de Ruzsa | définit `uniform_binary_tree`, **ne l'appelle jamais**, puis imprime un verdict qui admet « ce test ne disqualifie pas la primitive » | deux exhibitions mesurées |
| 2.3 — entropie de Shannon | exhibe déjà (calcul réel) | **inchangé** |
| 3.3 — fonctionnelle τ | **zéro calcul** : 4 `print` d'une conclusion écrite d'avance | deux candidats τ mesurés + 2-SAT |

## Ce que les cellules exhibent maintenant

**1.3 — la valeur de `d` n'est pas une fonction des seules distributions.** On garde formule, distributions et entropie **inchangées** ; on ne fait varier que l'opération `x − y`.

```
loi de groupe   H(X−Y)   d[X;Y]
  ℤ/4ℤ          1.5000   0.5000
  Klein         1.0000   0.0000     ← mêmes distributions, autre valeur
```

Puis, sur 40 000 tirages de Dirichlet par loi :

```
  (a − b) mod 4   groupe cyclique   →  min d = +0.0128   d ≥ 0 : distance
  a XOR b         groupe de Klein   →  min d = +0.0170   d ≥ 0 : distance
  max(a − b, 0)   non inversible    →  min d = -1.2699   d < 0 : PLUS une distance
  (a × b) mod 4   non inversible    →  min d = -0.9756   d < 0 : PLUS une distance
```

La non-négativité tient à ce que `x ↦ x − y` soit une **bijection**. Retirer l'inversibilité fait passer `d` sous zéro : la primitive cesse de valoir, et la cellule le **montre**.

**3.3 — deux échecs de τ, de natures différentes.** Sur `F = (x₁∨x₂∨x₃) ∧ (¬x₁∨x₂∨¬x₃) ∧ (x₁∨¬x₂∨x₃) ∧ (¬x₁∨¬x₂∨¬x₃) ∧ (x₁∨x₂∨¬x₃)` :

```
candidat A : τ = clauses non encore satisfaites
  trajectoire       : [5, 2, 1, 1]
  décroît strictement ? [True, True, False]  →  False

candidat B : τ = variables non encore affectées
  trajectoire       : [3, 2, 1, 0]
  décroît strictement ? [True, True, True]  →  True
  Elle décroît strictement — mais QUOI QU'IL ARRIVE : elle ne lit jamais F.
```

Et 2-SAT, lui, **a** son ordre — condensation du graphe d'implication, Kosaraju sans dépendance :

```
  (x₁ ∨ ¬x₂) ∧ (¬x₁ ∨ x₂) ∧ (x₁ ∨ x₂)    → 2 composante(s), satisfiable = True
  (x₁ ∨ x₁) ∧ (¬x₁ ∨ ¬x₁)                → 1 composante(s), satisfiable = False
```

## Deux énoncés faux corrigés au passage

La cellule 3.3 d'origine n'était pas seulement non exécutée — elle était **fausse sur deux points**, ce que l'absence de calcul avait laissé passer :

1. « Pour les problèmes sans ordre canonique (SAT général), τ **n'existe pas** » — existentielle négative infondée. Remplacée par le fait mesuré et plus étroit : ces deux candidats-là échouent, chacun à sa façon, et 2-SAT montre qu'un ordre **peut** exister quand la structure le fournit.
2. « candidat B : décroît si on fixe une variable, mais **pas strictement** » — faux : elle décroît strictement (`[3, 2, 1, 0]`). Son défaut est ailleurs, et il est plus intéressant : elle est **aveugle à la formule**.

## Preuve d'exécution (C.2 / H.1)

```
$ python scripts/notebook_tools/batch_reexecute.py --path MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21b-PFR-Primitives-Transportables.ipynb --timeout 300
SUCCESS (5s)
Degraded: 0
```

`execution_count` = `[1, 2, 3, 4, 5, 6]`, 0 cellule en erreur, 0 CR, round-trip `json.dumps(indent=1, ensure_ascii=False)` byte-identique. Les cellules non modifiées ([2], [6], [9], [10]) se réexécutent à des sorties **byte-identiques** (déterministes) — le diff ne porte que sur ce qui change vraiment.

Gardes : `check_c2_compliance` 1/1 · `check_null_exec` OK · `check_exec_sequence` DIRTY 0 · `check_cell_source_parses` 0 · `check_interp_positioning` 0 · `count_exercises` seuil tenu.

## Portée

**Un seul fichier**, six cellules ([3] [4] [5] [11] [12] [13]) — les deux cellules de code fautives et les quatre markdown qui les annoncent ou les concluent. La primitive 2, qui exhibait déjà, n'est pas touchée. Aucun type de cellule changé, aucun exercice retiré.

Distinct de #13247 (po-2025), qui a corrigé la descente ω de la cellule [10] et n'a jamais touché [4] ni [12].

See #12208
