### PR TITLE
ci(#14283): route quarto build/validate-pr vers le pool via tarball officiel

### DIFF
--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -39,6 +39,9 @@ on:
       - "MyIA.AI.Notebooks/**/_output.ipynb"
       - "MyIA.AI.Notebooks/**/README.md"
       - "docs/**"
+      # Auto-couverture : une PR qui ne touche QUE ce workflow doit quand meme
+      # emettre l'evenement pull_request (asymetrie push/pull_request, #14391).
+      - ".github/workflows/quarto-pages-deploy.yml"
       - "scripts/quarto_yaml_safe.py"
   workflow_dispatch:
 

--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -59,9 +59,17 @@ jobs:
     # Sans cette garde, build + validate-PR tournent en double sur PR, et deploy
     # cascadant sur build se fait rejeter par la protection env (refs/pull/.../merge
     # non autorise). #11616 rouge 1.
-    if: github.event_name == 'push'
+    # La garde same-repo MENE (forme universelle #13874, exigee par
+    # check_self_hosted_runner_policy) ; la selection push-only suit en &&.
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'push'
     name: Build Quarto site
-    runs-on: ubuntu-latest
+    # Routage #14283 fin de chantier (feu vert ai-01 2026-09-02) : setup
+    # Quarto par tarball auto-contenu (voir le step Set up Quarto). Garde
+    # push-only = jamais de contexte fork ici. runs-on STATIQUE.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de
+    # l'allowlist.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -69,15 +77,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          # Version alignée sur local (cf. po-2023-c160/c161 Quarto tranches).
-          # Bump 1.7.32 -> 1.10.18 (issue #10968) : le filtre lua 1.7.32 pend sur
-          # les cellules echo:true dont une ligne de source se termine par \n et
-          # suivies d'un output display_data (mini-repro #10968) — corrigé en
-          # 1.10.18 (App-9b rend en 6 s). Les 7 notebooks exclus du pilote par
-          # #10979 redeviennent rendables (NOTEBOOK_EXCLUDE_FILES vidé, #10968).
-          version: 1.10.18
+        # Routage #14283 (feu vert ai-01 2026-09-02) : PAS quarto-dev/quarto-actions/setup@v2 —
+        # elle installe un .deb via `sudo apt -y install`, et l'image du pool self-hosted est
+        # no-new-privileges sans sudo ni dpkg (mesure : issuecomment-5516335275). Le tarball
+        # officiel embarque le MEME binaire sans privilege — ne pas « corriger » vers l'action.
+        # Version epinglee en clair (meme discipline que les pins gitleaks) : un tiers ne doit
+        # pas pouvoir changer notre binaire sans commit chez nous.
+        # 1.10.18 = aligne local (cf. po-2023-c160/c161) ; le filtre lua 1.7.32 pendait sur les
+        # cellules echo:true a source finissant par \n suivies d'un display_data (#10968),
+        # corrige en 1.10.18 (App-9b rend en 6 s ; NOTEBOOK_EXCLUDE_FILES vide, #10979).
+        run: |
+          QUARTO_VERSION=1.10.18
+          curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" -o /tmp/quarto.tar.gz
+          tar -xzf /tmp/quarto.tar.gz -C /tmp
+          echo "/tmp/quarto-${QUARTO_VERSION}/bin" >> "$GITHUB_PATH"
+          "/tmp/quarto-${QUARTO_VERSION}/bin/quarto" --version
 
       - name: Regenerate render list
         # _quarto.yml porte une liste render: EXPLICITE des READMEs + notebooks
@@ -176,8 +190,13 @@ jobs:
     # le push, mais sans deploy : juste le rendu + check output. Si le rendu
     # passe en PR, le push sur main passera aussi.
     name: Validate Quarto build (PR)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    # Routage #14283 fin de chantier (feu vert ai-01 2026-09-02) : setup par
+    # tarball (voir le job `build`). Garde anti-fork au niveau job + runs-on
+    # STATIQUE — une expression leverait DYNAMIC_RUNS_ON dans
+    # check_self_hosted_runner_policy.py.
+    if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'pull_request'
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write  # pour poster le commentaire de gate
@@ -189,9 +208,15 @@ jobs:
           filter: blob:none
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: 1.10.18
+        # Tarball auto-contenu, pas quarto-actions/setup@v2 (.deb + sudo apt,
+        # inapplicable sur l'image no-new-privileges du pool) — voir le job
+        # `build` ci-dessus pour la rationale complete et le pin.
+        run: |
+          QUARTO_VERSION=1.10.18
+          curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" -o /tmp/quarto.tar.gz
+          tar -xzf /tmp/quarto.tar.gz -C /tmp
+          echo "/tmp/quarto-${QUARTO_VERSION}/bin" >> "$GITHUB_PATH"
+          "/tmp/quarto-${QUARTO_VERSION}/bin/quarto" --version
 
       - name: Regenerate render list
         run: python scripts/regen_quarto_render.py

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -169,9 +169,10 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     #   gardes routables. Exclus et pourquoi : pr-gate.yml (agregateur qui
     #   poll jusqu'a 28 min -- le router reproduirait la famine mesuree en
     #   #11405), lean-axiom/lean-build (builds Lean sans cache mathlib, cf
-    #   #14337 pools specialises), quarto-pages-deploy (quarto CLI + deploy
-    #   Pages), slides-composition-advisory (playwright --with-deps exige
-    #   root, le conteneur tourne en uid 1001).
+    #   #14337 pools specialises), slides-composition-advisory (playwright
+    #   --with-deps exige root, le conteneur tourne en uid 1001).
+    #   quarto-pages-deploy : jobs build/validate-pr routes en fin de chantier
+    #   (tarball, voir l'entree dediee) ; seul `deploy` reste exclu (Pages/OIDC).
     "bare-cross-dir-load-gate.yml",
     "base-not-main-advisory.yml",
     "concurrency-conj-guard.yml",
@@ -196,6 +197,13 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "scripts-tests.yml",
     "series-naming-gate.yml",
     "stale-base-warning.yml",
+    # fin de chantier #14283 (feu vert ai-01 2026-09-02) : les jobs
+    #   quarto-pages-deploy `build` et `validate-pr` passent au pool — le
+    #   setup Quarto se fait par tarball auto-contenu (l'action canonique
+    #   exige sudo apt + dpkg, absents de l'image no-new-privileges, mesure
+    #   issuecomment-5516335275). Le job `deploy` RESTE ubuntu-latest :
+    #   deploy-pages + OIDC/env github-pages, question separee.
+    "quarto-pages-deploy.yml",
     "svg-broken-geometry-gate.yml",
     "svg-decimal-comma-gate.yml",
     "svg-empty-display-gate.yml",


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: LIGHT/tooling #14386

See #14283 (fin de chantier, item 2 — feu vert ai-01 2026-09-02, DM msg-20260902T214024-w7e46l).

## Ce que fait cette PR

Suite et fin de l'item 2 du dispatch : la mesure avait établi que `quarto-dev/quarto-actions/setup@v2` installe un `.deb` via `sudo apt -y install` — structurellement inapplicable à l'image du pool (no-new-privileges, ni sudo ni dpkg). Le feu vert d'ai-01 pose le tarball officiel comme verdict **RECOVERABLE-LOCAL** (le même binaire, sans privilège), pas un workaround dégradé.

- **`build` + `validate-pr`** : setup Quarto par tarball **épinglé en clair** (`1.10.18` — même discipline que les deux pins gitleaks : un tiers ne doit pas changer notre binaire sans commit chez nous), commentaire 5 lignes au point d'appel disant *pourquoi* on n'utilise pas l'action canonique (sinon le prochain agent « corrigera » vers l'action et rougira — condition (b) du feu vert).
- **Routage** : les deux jobs passent sur `[self-hosted, coursia-ephemeral, coursia-linux]` STATIQUE, garde same-repo **universelle en tête** (forme #13874 exigée par `check_self_hosted_runner_policy`), sélection (`push` / `pull_request`) en `&&` derrière. Timeout 30 min.
- **`deploy` reste `ubuntu-latest`** : deploy-pages + OIDC/env github-pages = question séparée (non contestée par le feu vert).
- **Allowlist** : entrée `quarto-pages-deploy.yml` + motif d'exclusion tranche 5 mis à jour (le motif « quarto CLI + deploy Pages » ne tient plus que pour deploy).

## Vérifications (mesurées, pas supposées)

- `python scripts/ci/check_self_hosted_runner_policy.py` → **OK** (134 workflows / 163 jobs) — première itération avec la garde en non-position rejetée par l'organe, corrigée vers la forme canonique.
- Layout du tarball exécuté en Linux réel (WSL, même environnement que le pool) : `quarto-1.10.18/bin/quarto --version` → **1.10.18**.
- `pyyaml 6.0.1` + python 3.12 présents dans l'image du pool (requis par `regen_quarto_render.py`).
- curl/tar présents dans l'image (mesurés en conteneur jetable).

## Produit à vérifier sur cette PR

Le workflow `quarto-pages-deploy.yml` est dans ses propres triggers `pull_request` → **cette PR exécute `validate-pr` sur le pool** : le check « Validate Quarto build (PR) » doit passer avec le rendu complet du site via le tarball (preuve que le setup non-action fonctionne de bout en bout, `_site/` produit).

## Retour arrière

Remettre `runs-on: ubuntu-latest` + l'action canonique dans les 2 jobs + retirer l'entrée allowlist (documenté dans les commentaires du YAML).
