### PR TITLE
fix(infer,#14122): Infer-7 a zero CS1701 -- DisplayAs au lieu de display(HTML(...))

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/FactorGraphHelper.cs
+++ b/MyIA.AI.Notebooks/Probas/Infer/FactorGraphHelper.cs
@@ -115,7 +115,11 @@ public static class FactorGraphHelper
 
     /// <summary>
     /// Retourne le HTML pour afficher le dernier fichier SVG genere par Infer.NET
-    /// Usage: display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))
+    /// Usage: FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs("text/html")
+    /// display(HTML(...)) lie IHtmlContent, type porte par un assemblage compile
+    /// contre Microsoft.AspNetCore.Html.Abstractions 2.x : chaque cellule qui
+    /// l'emploie declenche un CS1701. DisplayAs ne prend qu'une chaine et un
+    /// type MIME, et rend le meme SVG sans le div d'enrobage (cf #14122).
     /// </summary>
     public static string GetLatestFactorGraphHtml(int maxWidth = 800)
     {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
@@ -5,10 +5,10 @@
    "id": "acede045",
    "metadata": {
     "papermill": {
-     "duration": 0.005585,
-     "end_time": "2026-06-22T19:15:51.123187",
+     "duration": 0.006322,
+     "end_time": "2026-09-02T22:23:48.958977",
      "exception": false,
-     "start_time": "2026-06-22T19:15:51.117602",
+     "start_time": "2026-09-02T22:23:48.952655",
      "status": "completed"
     },
     "tags": []
@@ -54,10 +54,10 @@
    "id": "82c317c2",
    "metadata": {
     "papermill": {
-     "duration": 0.00566,
-     "end_time": "2026-06-22T19:15:51.135334",
+     "duration": 0.00713,
+     "end_time": "2026-09-02T22:23:48.971231",
      "exception": false,
-     "start_time": "2026-06-22T19:15:51.129674",
+     "start_time": "2026-09-02T22:23:48.964101",
      "status": "completed"
     },
     "tags": []
@@ -77,16 +77,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:51.153654Z",
-     "iopub.status.busy": "2026-06-22T19:15:51.150084Z",
-     "iopub.status.idle": "2026-06-22T19:15:53.776569Z",
-     "shell.execute_reply": "2026-06-22T19:15:53.773568Z"
+     "iopub.execute_input": "2026-09-02T22:23:48.989848Z",
+     "iopub.status.busy": "2026-09-02T22:23:48.984193Z",
+     "iopub.status.idle": "2026-09-02T22:23:54.116670Z",
+     "shell.execute_reply": "2026-09-02T22:23:54.112525Z"
     },
     "papermill": {
-     "duration": 2.635604,
-     "end_time": "2026-06-22T19:15:53.776569",
+     "duration": 5.140465,
+     "end_time": "2026-09-02T22:23:54.116849",
      "exception": false,
-     "start_time": "2026-06-22T19:15:51.140965",
+     "start_time": "2026-09-02T22:23:48.976384",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -103,10 +103,11 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-100524.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -116,7 +117,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -131,6 +135,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -142,11 +147,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '100524.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '31412.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -190,11 +197,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -241,10 +250,10 @@
    "id": "b161447f",
    "metadata": {
     "papermill": {
-     "duration": 0.012005,
-     "end_time": "2026-06-22T19:15:53.801574",
+     "duration": 0.005393,
+     "end_time": "2026-09-02T22:23:54.129260",
      "exception": false,
-     "start_time": "2026-06-22T19:15:53.789569",
+     "start_time": "2026-09-02T22:23:54.123867",
      "status": "completed"
     },
     "tags": []
@@ -259,16 +268,16 @@
    "id": "ny2wcgc1uwe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:53.826608Z",
-     "iopub.status.busy": "2026-06-22T19:15:53.826608Z",
-     "iopub.status.idle": "2026-06-22T19:15:54.542940Z",
-     "shell.execute_reply": "2026-06-22T19:15:54.542940Z"
+     "iopub.execute_input": "2026-09-02T22:23:54.140968Z",
+     "iopub.status.busy": "2026-09-02T22:23:54.140791Z",
+     "iopub.status.idle": "2026-09-02T22:23:54.945529Z",
+     "shell.execute_reply": "2026-09-02T22:23:54.945379Z"
     },
     "papermill": {
-     "duration": 0.729883,
-     "end_time": "2026-06-22T19:15:54.543456",
+     "duration": 0.811042,
+     "end_time": "2026-09-02T22:23:54.945600",
      "exception": false,
-     "start_time": "2026-06-22T19:15:53.813573",
+     "start_time": "2026-09-02T22:23:54.134558",
      "status": "completed"
     },
     "tags": [],
@@ -305,10 +314,10 @@
    "id": "m107lfympo",
    "metadata": {
     "papermill": {
-     "duration": 0.010917,
-     "end_time": "2026-06-22T19:15:54.564409",
+     "duration": 0.00528,
+     "end_time": "2026-09-02T22:23:54.963800",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.553492",
+     "start_time": "2026-09-02T22:23:54.958520",
      "status": "completed"
     },
     "tags": []
@@ -330,10 +339,10 @@
    "id": "x170007hb78",
    "metadata": {
     "papermill": {
-     "duration": 0.010584,
-     "end_time": "2026-06-22T19:15:54.586248",
+     "duration": 0.005372,
+     "end_time": "2026-09-02T22:23:54.974380",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.575664",
+     "start_time": "2026-09-02T22:23:54.969008",
      "status": "completed"
     },
     "tags": []
@@ -354,10 +363,10 @@
    "id": "6e446418",
    "metadata": {
     "papermill": {
-     "duration": 0.011788,
-     "end_time": "2026-06-22T19:15:54.608993",
+     "duration": 0.005391,
+     "end_time": "2026-09-02T22:23:54.984969",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.597205",
+     "start_time": "2026-09-02T22:23:54.979578",
      "status": "completed"
     },
     "tags": []
@@ -390,7 +399,16 @@
   {
    "cell_type": "markdown",
    "id": "origine-mbml-ch2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00529,
+     "end_time": "2026-09-02T22:23:54.996255",
+     "exception": false,
+     "start_time": "2026-09-02T22:23:54.990965",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Origine pedagogique : Model-Based Machine Learning (Chap. 2)\n",
     "\n",
@@ -409,10 +427,10 @@
    "id": "40c04fbd",
    "metadata": {
     "papermill": {
-     "duration": 0.010819,
-     "end_time": "2026-06-22T19:15:54.631166",
+     "duration": 0.0057,
+     "end_time": "2026-09-02T22:23:55.007232",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.620347",
+     "start_time": "2026-09-02T22:23:55.001532",
      "status": "completed"
     },
     "tags": []
@@ -448,16 +466,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:54.657348Z",
-     "iopub.status.busy": "2026-06-22T19:15:54.656842Z",
-     "iopub.status.idle": "2026-06-22T19:15:54.936156Z",
-     "shell.execute_reply": "2026-06-22T19:15:54.936156Z"
+     "iopub.execute_input": "2026-09-02T22:23:55.019483Z",
+     "iopub.status.busy": "2026-09-02T22:23:55.019296Z",
+     "iopub.status.idle": "2026-09-02T22:23:55.191284Z",
+     "shell.execute_reply": "2026-09-02T22:23:55.191151Z"
     },
     "papermill": {
-     "duration": 0.292713,
-     "end_time": "2026-06-22T19:15:54.936156",
+     "duration": 0.178605,
+     "end_time": "2026-09-02T22:23:55.191346",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.643443",
+     "start_time": "2026-09-02T22:23:55.012741",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -537,10 +555,10 @@
    "id": "frj93ftqzui",
    "metadata": {
     "papermill": {
-     "duration": 0.016079,
-     "end_time": "2026-06-22T19:15:54.969909",
+     "duration": 0.005215,
+     "end_time": "2026-09-02T22:23:55.203361",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.953830",
+     "start_time": "2026-09-02T22:23:55.198146",
      "status": "completed"
     },
     "tags": []
@@ -573,10 +591,10 @@
    "id": "9qvij59ix7n",
    "metadata": {
     "papermill": {
-     "duration": 0.016075,
-     "end_time": "2026-06-22T19:15:54.997326",
+     "duration": 0.005504,
+     "end_time": "2026-09-02T22:23:55.213964",
      "exception": false,
-     "start_time": "2026-06-22T19:15:54.981251",
+     "start_time": "2026-09-02T22:23:55.208460",
      "status": "completed"
     },
     "tags": []
@@ -602,16 +620,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:55.024966Z",
-     "iopub.status.busy": "2026-06-22T19:15:55.024455Z",
-     "iopub.status.idle": "2026-06-22T19:15:57.267318Z",
-     "shell.execute_reply": "2026-06-22T19:15:57.267318Z"
+     "iopub.execute_input": "2026-09-02T22:23:55.225457Z",
+     "iopub.status.busy": "2026-09-02T22:23:55.225228Z",
+     "iopub.status.idle": "2026-09-02T22:23:59.279459Z",
+     "shell.execute_reply": "2026-09-02T22:23:59.279323Z"
     },
     "papermill": {
-     "duration": 2.257345,
-     "end_time": "2026-06-22T19:15:57.267318",
+     "duration": 4.060352,
+     "end_time": "2026-09-02T22:23:59.279535",
      "exception": false,
-     "start_time": "2026-06-22T19:15:55.009973",
+     "start_time": "2026-09-02T22:23:55.219183",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1153,10 +1171,10 @@
    "id": "1b88a77c",
    "metadata": {
     "papermill": {
-     "duration": 0.013005,
-     "end_time": "2026-06-22T19:15:57.294323",
+     "duration": 0.00771,
+     "end_time": "2026-09-02T22:23:59.295813",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.281318",
+     "start_time": "2026-09-02T22:23:59.288103",
      "status": "completed"
     },
     "tags": []
@@ -1171,16 +1189,16 @@
    "id": "nc0ppf2w6q",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:57.322850Z",
-     "iopub.status.busy": "2026-06-22T19:15:57.322850Z",
-     "iopub.status.idle": "2026-06-22T19:15:57.457950Z",
-     "shell.execute_reply": "2026-06-22T19:15:57.457950Z"
+     "iopub.execute_input": "2026-09-02T22:23:59.323344Z",
+     "iopub.status.busy": "2026-09-02T22:23:59.323014Z",
+     "iopub.status.idle": "2026-09-02T22:24:00.185412Z",
+     "shell.execute_reply": "2026-09-02T22:24:00.185138Z"
     },
     "papermill": {
-     "duration": 0.150604,
-     "end_time": "2026-06-22T19:15:57.457950",
+     "duration": 0.87689,
+     "end_time": "2026-09-02T22:24:00.185670",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.307346",
+     "start_time": "2026-09-02T22:23:59.308780",
      "status": "completed"
     },
     "tags": [],
@@ -1192,14 +1210,14 @@
     {
      "data": {
       "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_55_19.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_09_03_26_00_23_55_33.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       "<!-- Generated by graphviz version 16.0.0 (20260814.1018)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"416pt\" height=\"663pt\"\r\n",
@@ -1430,27 +1448,18 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
+       "\n",
+       "    </div>\n",
        "</div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
     "// Visualisation du graphe de facteurs IRT\n",
-    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+    "FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs(\"text/html\");"
    ]
   },
   {
@@ -1458,10 +1467,10 @@
    "id": "vhz59h176p",
    "metadata": {
     "papermill": {
-     "duration": 0.013035,
-     "end_time": "2026-06-22T19:15:57.485661",
+     "duration": 0.010203,
+     "end_time": "2026-09-02T22:24:00.207254",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.472626",
+     "start_time": "2026-09-02T22:24:00.197051",
      "status": "completed"
     },
     "tags": []
@@ -1488,10 +1497,10 @@
    "id": "2219d280",
    "metadata": {
     "papermill": {
-     "duration": 0.013293,
-     "end_time": "2026-06-22T19:15:57.513572",
+     "duration": 0.010875,
+     "end_time": "2026-09-02T22:24:00.229752",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.500279",
+     "start_time": "2026-09-02T22:24:00.218877",
      "status": "completed"
     },
     "tags": []
@@ -1522,10 +1531,10 @@
    "id": "u7e3glgtzcm",
    "metadata": {
     "papermill": {
-     "duration": 0.015733,
-     "end_time": "2026-06-22T19:15:57.544831",
+     "duration": 0.01138,
+     "end_time": "2026-09-02T22:24:00.250957",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.529098",
+     "start_time": "2026-09-02T22:24:00.239577",
      "status": "completed"
     },
     "tags": []
@@ -1549,10 +1558,10 @@
    "id": "46lkoyw14mo",
    "metadata": {
     "papermill": {
-     "duration": 0.013691,
-     "end_time": "2026-06-22T19:15:57.572691",
+     "duration": 0.006408,
+     "end_time": "2026-09-02T22:24:00.263817",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.559000",
+     "start_time": "2026-09-02T22:24:00.257409",
      "status": "completed"
     },
     "tags": []
@@ -1575,16 +1584,16 @@
    "id": "e4imjob0vqj",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:57.603502Z",
-     "iopub.status.busy": "2026-06-22T19:15:57.603502Z",
-     "iopub.status.idle": "2026-06-22T19:15:57.761035Z",
-     "shell.execute_reply": "2026-06-22T19:15:57.761035Z"
+     "iopub.execute_input": "2026-09-02T22:24:00.281188Z",
+     "iopub.status.busy": "2026-09-02T22:24:00.281013Z",
+     "iopub.status.idle": "2026-09-02T22:24:00.392416Z",
+     "shell.execute_reply": "2026-09-02T22:24:00.392291Z"
     },
     "papermill": {
-     "duration": 0.175281,
-     "end_time": "2026-06-22T19:15:57.761035",
+     "duration": 0.120243,
+     "end_time": "2026-09-02T22:24:00.392475",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.585754",
+     "start_time": "2026-09-02T22:24:00.272232",
      "status": "completed"
     },
     "tags": [],
@@ -1756,10 +1765,10 @@
    "id": "i17w6q3o1nj",
    "metadata": {
     "papermill": {
-     "duration": 0.015001,
-     "end_time": "2026-06-22T19:15:57.790034",
+     "duration": 0.006537,
+     "end_time": "2026-09-02T22:24:00.409687",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.775033",
+     "start_time": "2026-09-02T22:24:00.403150",
      "status": "completed"
     },
     "tags": []
@@ -1796,10 +1805,10 @@
    "id": "ul9hjtw90cc",
    "metadata": {
     "papermill": {
-     "duration": 0.014013,
-     "end_time": "2026-06-22T19:15:57.818448",
+     "duration": 0.007071,
+     "end_time": "2026-09-02T22:24:00.424248",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.804435",
+     "start_time": "2026-09-02T22:24:00.417177",
      "status": "completed"
     },
     "tags": []
@@ -1815,10 +1824,10 @@
    "id": "716de205",
    "metadata": {
     "papermill": {
-     "duration": 0.014,
-     "end_time": "2026-06-22T19:15:57.846165",
+     "duration": 0.006833,
+     "end_time": "2026-09-02T22:24:00.438115",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.832165",
+     "start_time": "2026-09-02T22:24:00.431282",
      "status": "completed"
     },
     "tags": []
@@ -1848,16 +1857,16 @@
    "id": "5af1325d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:57.875165Z",
-     "iopub.status.busy": "2026-06-22T19:15:57.875165Z",
-     "iopub.status.idle": "2026-06-22T19:15:57.937855Z",
-     "shell.execute_reply": "2026-06-22T19:15:57.937855Z"
+     "iopub.execute_input": "2026-09-02T22:24:00.452397Z",
+     "iopub.status.busy": "2026-09-02T22:24:00.452240Z",
+     "iopub.status.idle": "2026-09-02T22:24:00.480909Z",
+     "shell.execute_reply": "2026-09-02T22:24:00.480792Z"
     },
     "papermill": {
-     "duration": 0.077689,
-     "end_time": "2026-06-22T19:15:57.937855",
+     "duration": 0.036595,
+     "end_time": "2026-09-02T22:24:00.480968",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.860166",
+     "start_time": "2026-09-02T22:24:00.444373",
      "status": "completed"
     },
     "tags": []
@@ -1897,10 +1906,10 @@
    "id": "3957a447",
    "metadata": {
     "papermill": {
-     "duration": 0.015208,
-     "end_time": "2026-06-22T19:15:57.968065",
+     "duration": 0.00684,
+     "end_time": "2026-09-02T22:24:00.495716",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.952857",
+     "start_time": "2026-09-02T22:24:00.488876",
      "status": "completed"
     },
     "tags": []
@@ -1934,10 +1943,10 @@
    "id": "56ikmnn0zn4",
    "metadata": {
     "papermill": {
-     "duration": 0.01516,
-     "end_time": "2026-06-22T19:15:57.998598",
+     "duration": 0.007146,
+     "end_time": "2026-09-02T22:24:00.509131",
      "exception": false,
-     "start_time": "2026-06-22T19:15:57.983438",
+     "start_time": "2026-09-02T22:24:00.501985",
      "status": "completed"
     },
     "tags": []
@@ -1963,16 +1972,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:58.029560Z",
-     "iopub.status.busy": "2026-06-22T19:15:58.029560Z",
-     "iopub.status.idle": "2026-06-22T19:15:58.090561Z",
-     "shell.execute_reply": "2026-06-22T19:15:58.090561Z"
+     "iopub.execute_input": "2026-09-02T22:24:00.524108Z",
+     "iopub.status.busy": "2026-09-02T22:24:00.523939Z",
+     "iopub.status.idle": "2026-09-02T22:24:00.555324Z",
+     "shell.execute_reply": "2026-09-02T22:24:00.555222Z"
     },
     "papermill": {
-     "duration": 0.076896,
-     "end_time": "2026-06-22T19:15:58.090561",
+     "duration": 0.039458,
+     "end_time": "2026-09-02T22:24:00.555379",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.013665",
+     "start_time": "2026-09-02T22:24:00.515921",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2095,10 +2104,10 @@
    "id": "37dr139eft",
    "metadata": {
     "papermill": {
-     "duration": 0.015004,
-     "end_time": "2026-06-22T19:15:58.121565",
+     "duration": 0.007991,
+     "end_time": "2026-09-02T22:24:00.570709",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.106561",
+     "start_time": "2026-09-02T22:24:00.562718",
      "status": "completed"
     },
     "tags": []
@@ -2129,16 +2138,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:58.155704Z",
-     "iopub.status.busy": "2026-06-22T19:15:58.155704Z",
-     "iopub.status.idle": "2026-06-22T19:15:58.213847Z",
-     "shell.execute_reply": "2026-06-22T19:15:58.213847Z"
+     "iopub.execute_input": "2026-09-02T22:24:00.587475Z",
+     "iopub.status.busy": "2026-09-02T22:24:00.587285Z",
+     "iopub.status.idle": "2026-09-02T22:24:00.616125Z",
+     "shell.execute_reply": "2026-09-02T22:24:00.616000Z"
     },
     "papermill": {
-     "duration": 0.076148,
-     "end_time": "2026-06-22T19:15:58.213847",
+     "duration": 0.037308,
+     "end_time": "2026-09-02T22:24:00.616192",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.137699",
+     "start_time": "2026-09-02T22:24:00.578884",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2253,10 +2262,10 @@
    "id": "pa9lh196gh",
    "metadata": {
     "papermill": {
-     "duration": 0.015007,
-     "end_time": "2026-06-22T19:15:58.244105",
+     "duration": 0.007646,
+     "end_time": "2026-09-02T22:24:00.631920",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.229098",
+     "start_time": "2026-09-02T22:24:00.624274",
      "status": "completed"
     },
     "tags": []
@@ -2274,10 +2283,10 @@
    "id": "7w0uplcpe3i",
    "metadata": {
     "papermill": {
-     "duration": 0.014999,
-     "end_time": "2026-06-22T19:15:58.273104",
+     "duration": 0.007387,
+     "end_time": "2026-09-02T22:24:00.647068",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.258105",
+     "start_time": "2026-09-02T22:24:00.639681",
      "status": "completed"
     },
     "tags": []
@@ -2303,16 +2312,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:58.302527Z",
-     "iopub.status.busy": "2026-06-22T19:15:58.302527Z",
-     "iopub.status.idle": "2026-06-22T19:15:58.922803Z",
-     "shell.execute_reply": "2026-06-22T19:15:58.922803Z"
+     "iopub.execute_input": "2026-09-02T22:24:00.665489Z",
+     "iopub.status.busy": "2026-09-02T22:24:00.665319Z",
+     "iopub.status.idle": "2026-09-02T22:24:01.637974Z",
+     "shell.execute_reply": "2026-09-02T22:24:01.637733Z"
     },
     "papermill": {
-     "duration": 0.635698,
-     "end_time": "2026-06-22T19:15:58.922803",
+     "duration": 0.982573,
+     "end_time": "2026-09-02T22:24:01.638374",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.287105",
+     "start_time": "2026-09-02T22:24:00.655801",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2441,10 +2450,10 @@
    "id": "6f09167c",
    "metadata": {
     "papermill": {
-     "duration": 0.015763,
-     "end_time": "2026-06-22T19:15:58.954112",
+     "duration": 0.008152,
+     "end_time": "2026-09-02T22:24:01.661058",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.938349",
+     "start_time": "2026-09-02T22:24:01.652906",
      "status": "completed"
     },
     "tags": []
@@ -2459,16 +2468,16 @@
    "id": "rg8nejotm0r",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:58.987114Z",
-     "iopub.status.busy": "2026-06-22T19:15:58.987114Z",
-     "iopub.status.idle": "2026-06-22T19:15:59.094172Z",
-     "shell.execute_reply": "2026-06-22T19:15:59.094172Z"
+     "iopub.execute_input": "2026-09-02T22:24:01.681758Z",
+     "iopub.status.busy": "2026-09-02T22:24:01.681379Z",
+     "iopub.status.idle": "2026-09-02T22:24:02.427739Z",
+     "shell.execute_reply": "2026-09-02T22:24:02.427332Z"
     },
     "papermill": {
-     "duration": 0.124059,
-     "end_time": "2026-06-22T19:15:59.094172",
+     "duration": 0.757023,
+     "end_time": "2026-09-02T22:24:02.427879",
      "exception": false,
-     "start_time": "2026-06-22T19:15:58.970113",
+     "start_time": "2026-09-02T22:24:01.670856",
      "status": "completed"
     },
     "tags": [],
@@ -2480,14 +2489,14 @@
     {
      "data": {
       "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_58_37.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_09_03_26_00_24_00_74.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       "<!-- Generated by graphviz version 16.0.0 (20260814.1018)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"338pt\" height=\"535pt\"\r\n",
@@ -2729,27 +2738,18 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
+       "\n",
+       "    </div>\n",
        "</div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
     "// Visualisation du graphe de facteurs DINA simplifie\n",
-    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+    "FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs(\"text/html\");"
    ]
   },
   {
@@ -2757,10 +2757,10 @@
    "id": "i0jolbjmfoq",
    "metadata": {
     "papermill": {
-     "duration": 0.016003,
-     "end_time": "2026-06-22T19:15:59.126178",
+     "duration": 0.014594,
+     "end_time": "2026-09-02T22:24:02.456574",
      "exception": false,
-     "start_time": "2026-06-22T19:15:59.110175",
+     "start_time": "2026-09-02T22:24:02.441980",
      "status": "completed"
     },
     "tags": []
@@ -2790,10 +2790,10 @@
    "id": "kpx19prqge",
    "metadata": {
     "papermill": {
-     "duration": 0.016604,
-     "end_time": "2026-06-22T19:15:59.158292",
+     "duration": 0.016211,
+     "end_time": "2026-09-02T22:24:02.486859",
      "exception": false,
-     "start_time": "2026-06-22T19:15:59.141688",
+     "start_time": "2026-09-02T22:24:02.470648",
      "status": "completed"
     },
     "tags": []
@@ -2823,10 +2823,10 @@
    "id": "0893ac42",
    "metadata": {
     "papermill": {
-     "duration": 0.016,
-     "end_time": "2026-06-22T19:15:59.190296",
+     "duration": 0.010066,
+     "end_time": "2026-09-02T22:24:02.510818",
      "exception": false,
-     "start_time": "2026-06-22T19:15:59.174296",
+     "start_time": "2026-09-02T22:24:02.500752",
      "status": "completed"
     },
     "tags": []
@@ -2848,10 +2848,10 @@
    "id": "cwx0zd56zi",
    "metadata": {
     "papermill": {
-     "duration": 0.016006,
-     "end_time": "2026-06-22T19:15:59.222300",
+     "duration": 0.012118,
+     "end_time": "2026-09-02T22:24:02.533754",
      "exception": false,
-     "start_time": "2026-06-22T19:15:59.206294",
+     "start_time": "2026-09-02T22:24:02.521636",
      "status": "completed"
     },
     "tags": []
@@ -2878,16 +2878,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:15:59.256401Z",
-     "iopub.status.busy": "2026-06-22T19:15:59.256401Z",
-     "iopub.status.idle": "2026-06-22T19:15:59.972150Z",
-     "shell.execute_reply": "2026-06-22T19:15:59.971628Z"
+     "iopub.execute_input": "2026-09-02T22:24:02.550680Z",
+     "iopub.status.busy": "2026-09-02T22:24:02.550514Z",
+     "iopub.status.idle": "2026-09-02T22:24:03.381469Z",
+     "shell.execute_reply": "2026-09-02T22:24:03.381343Z"
     },
     "papermill": {
-     "duration": 0.733766,
-     "end_time": "2026-06-22T19:15:59.972150",
+     "duration": 0.839653,
+     "end_time": "2026-09-02T22:24:03.381532",
      "exception": false,
-     "start_time": "2026-06-22T19:15:59.238384",
+     "start_time": "2026-09-02T22:24:02.541879",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3156,10 +3156,10 @@
    "id": "c7755942",
    "metadata": {
     "papermill": {
-     "duration": 0.017001,
-     "end_time": "2026-06-22T19:16:00.005374",
+     "duration": 0.00862,
+     "end_time": "2026-09-02T22:24:03.399845",
      "exception": false,
-     "start_time": "2026-06-22T19:15:59.988373",
+     "start_time": "2026-09-02T22:24:03.391225",
      "status": "completed"
     },
     "tags": []
@@ -3174,16 +3174,16 @@
    "id": "ww8hj4x0bi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:00.040996Z",
-     "iopub.status.busy": "2026-06-22T19:16:00.040996Z",
-     "iopub.status.idle": "2026-06-22T19:16:00.150348Z",
-     "shell.execute_reply": "2026-06-22T19:16:00.149342Z"
+     "iopub.execute_input": "2026-09-02T22:24:03.419044Z",
+     "iopub.status.busy": "2026-09-02T22:24:03.418893Z",
+     "iopub.status.idle": "2026-09-02T22:24:03.939937Z",
+     "shell.execute_reply": "2026-09-02T22:24:03.939760Z"
     },
     "papermill": {
-     "duration": 0.126906,
-     "end_time": "2026-06-22T19:16:00.150348",
+     "duration": 0.531184,
+     "end_time": "2026-09-02T22:24:03.940001",
      "exception": false,
-     "start_time": "2026-06-22T19:16:00.023442",
+     "start_time": "2026-09-02T22:24:03.408817",
      "status": "completed"
     },
     "tags": [],
@@ -3195,14 +3195,14 @@
     {
      "data": {
       "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_15_59_33.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_09_03_26_00_24_02_59.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       "<!-- Generated by graphviz version 16.0.0 (20260814.1018)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"2361pt\" height=\"526pt\"\r\n",
@@ -4007,27 +4007,18 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
+       "\n",
+       "    </div>\n",
        "</div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
     "// Visualisation du graphe de facteurs many-to-many\n",
-    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+    "FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs(\"text/html\");"
    ]
   },
   {
@@ -4035,10 +4026,10 @@
    "id": "qt7qfg804tg",
    "metadata": {
     "papermill": {
-     "duration": 0.019592,
-     "end_time": "2026-06-22T19:16:00.192447",
+     "duration": 0.026371,
+     "end_time": "2026-09-02T22:24:03.983370",
      "exception": false,
-     "start_time": "2026-06-22T19:16:00.172855",
+     "start_time": "2026-09-02T22:24:03.956999",
      "status": "completed"
     },
     "tags": []
@@ -4069,10 +4060,10 @@
    "id": "s8m8es9flxa",
    "metadata": {
     "papermill": {
-     "duration": 0.018016,
-     "end_time": "2026-06-22T19:16:00.228468",
+     "duration": 0.014808,
+     "end_time": "2026-09-02T22:24:04.014437",
      "exception": false,
-     "start_time": "2026-06-22T19:16:00.210452",
+     "start_time": "2026-09-02T22:24:03.999629",
      "status": "completed"
     },
     "tags": []
@@ -4103,10 +4094,10 @@
    "id": "af5487bb",
    "metadata": {
     "papermill": {
-     "duration": 0.017068,
-     "end_time": "2026-06-22T19:16:00.263972",
+     "duration": 0.013944,
+     "end_time": "2026-09-02T22:24:04.042134",
      "exception": false,
-     "start_time": "2026-06-22T19:16:00.246904",
+     "start_time": "2026-09-02T22:24:04.028190",
      "status": "completed"
     },
     "tags": []
@@ -4129,10 +4120,10 @@
    "id": "qrpczbu0bnm",
    "metadata": {
     "papermill": {
-     "duration": 0.024,
-     "end_time": "2026-06-22T19:16:00.304904",
+     "duration": 0.014848,
+     "end_time": "2026-09-02T22:24:04.073767",
      "exception": false,
-     "start_time": "2026-06-22T19:16:00.280904",
+     "start_time": "2026-09-02T22:24:04.058919",
      "status": "completed"
     },
     "tags": []
@@ -4160,16 +4151,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:00.343422Z",
-     "iopub.status.busy": "2026-06-22T19:16:00.343422Z",
-     "iopub.status.idle": "2026-06-22T19:16:01.043519Z",
-     "shell.execute_reply": "2026-06-22T19:16:01.039519Z"
+     "iopub.execute_input": "2026-09-02T22:24:04.101626Z",
+     "iopub.status.busy": "2026-09-02T22:24:04.101427Z",
+     "iopub.status.idle": "2026-09-02T22:24:05.212682Z",
+     "shell.execute_reply": "2026-09-02T22:24:05.206590Z"
     },
     "papermill": {
-     "duration": 0.72061,
-     "end_time": "2026-06-22T19:16:01.043519",
+     "duration": 1.123028,
+     "end_time": "2026-09-02T22:24:05.212847",
      "exception": false,
-     "start_time": "2026-06-22T19:16:00.322909",
+     "start_time": "2026-09-02T22:24:04.089819",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -4672,10 +4663,10 @@
    "id": "v3r2vdr56k",
    "metadata": {
     "papermill": {
-     "duration": 0.022001,
-     "end_time": "2026-06-22T19:16:01.085520",
+     "duration": 0.017557,
+     "end_time": "2026-09-02T22:24:05.246937",
      "exception": false,
-     "start_time": "2026-06-22T19:16:01.063519",
+     "start_time": "2026-09-02T22:24:05.229380",
      "status": "completed"
     },
     "tags": []
@@ -4712,10 +4703,10 @@
    "id": "vo8ev1ov9x",
    "metadata": {
     "papermill": {
-     "duration": 0.021004,
-     "end_time": "2026-06-22T19:16:01.127524",
+     "duration": 0.029478,
+     "end_time": "2026-09-02T22:24:05.291311",
      "exception": false,
-     "start_time": "2026-06-22T19:16:01.106520",
+     "start_time": "2026-09-02T22:24:05.261833",
      "status": "completed"
     },
     "tags": []
@@ -4743,16 +4734,16 @@
    "id": "n2ogxky9k6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:01.167659Z",
-     "iopub.status.busy": "2026-06-22T19:16:01.167659Z",
-     "iopub.status.idle": "2026-06-22T19:16:01.271288Z",
-     "shell.execute_reply": "2026-06-22T19:16:01.270617Z"
+     "iopub.execute_input": "2026-09-02T22:24:05.313072Z",
+     "iopub.status.busy": "2026-09-02T22:24:05.312896Z",
+     "iopub.status.idle": "2026-09-02T22:24:05.739126Z",
+     "shell.execute_reply": "2026-09-02T22:24:05.738988Z"
     },
     "papermill": {
-     "duration": 0.12463,
-     "end_time": "2026-06-22T19:16:01.271288",
+     "duration": 0.43784,
+     "end_time": "2026-09-02T22:24:05.739194",
      "exception": false,
-     "start_time": "2026-06-22T19:16:01.146658",
+     "start_time": "2026-09-02T22:24:05.301354",
      "status": "completed"
     },
     "tags": [],
@@ -4764,14 +4755,14 @@
     {
      "data": {
       "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_00_40.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_09_03_26_00_24_04_16.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       "<!-- Generated by graphviz version 16.0.0 (20260814.1018)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"313pt\" height=\"535pt\"\r\n",
@@ -4975,27 +4966,18 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
+       "\n",
+       "    </div>\n",
        "</div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
     "// Visualisation du graphe de facteurs pour l'estimation slip/guess\n",
-    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+    "FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs(\"text/html\");"
    ]
   },
   {
@@ -5003,10 +4985,10 @@
    "id": "21617812",
    "metadata": {
     "papermill": {
-     "duration": 0.021998,
-     "end_time": "2026-06-22T19:16:01.313516",
+     "duration": 0.013422,
+     "end_time": "2026-09-02T22:24:05.764220",
      "exception": false,
-     "start_time": "2026-06-22T19:16:01.291518",
+     "start_time": "2026-09-02T22:24:05.750798",
      "status": "completed"
     },
     "tags": []
@@ -5024,16 +5006,16 @@
    "id": "9d7o2300545",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:01.358754Z",
-     "iopub.status.busy": "2026-06-22T19:16:01.357832Z",
-     "iopub.status.idle": "2026-06-22T19:16:01.998393Z",
-     "shell.execute_reply": "2026-06-22T19:16:01.988492Z"
+     "iopub.execute_input": "2026-09-02T22:24:05.788445Z",
+     "iopub.status.busy": "2026-09-02T22:24:05.788212Z",
+     "iopub.status.idle": "2026-09-02T22:24:06.627661Z",
+     "shell.execute_reply": "2026-09-02T22:24:06.624240Z"
     },
     "papermill": {
-     "duration": 0.663526,
-     "end_time": "2026-06-22T19:16:01.999046",
+     "duration": 0.851684,
+     "end_time": "2026-09-02T22:24:06.627725",
      "exception": false,
-     "start_time": "2026-06-22T19:16:01.335520",
+     "start_time": "2026-09-02T22:24:05.776041",
      "status": "completed"
     },
     "tags": [],
@@ -5521,10 +5503,10 @@
    "id": "754ff5d2",
    "metadata": {
     "papermill": {
-     "duration": 0.024639,
-     "end_time": "2026-06-22T19:16:02.049136",
+     "duration": 0.018658,
+     "end_time": "2026-09-02T22:24:06.661627",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.024497",
+     "start_time": "2026-09-02T22:24:06.642969",
      "status": "completed"
     },
     "tags": []
@@ -5539,16 +5521,16 @@
    "id": "spbj44wip9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:02.098924Z",
-     "iopub.status.busy": "2026-06-22T19:16:02.098924Z",
-     "iopub.status.idle": "2026-06-22T19:16:02.199826Z",
-     "shell.execute_reply": "2026-06-22T19:16:02.199826Z"
+     "iopub.execute_input": "2026-09-02T22:24:06.697868Z",
+     "iopub.status.busy": "2026-09-02T22:24:06.697514Z",
+     "iopub.status.idle": "2026-09-02T22:24:07.321718Z",
+     "shell.execute_reply": "2026-09-02T22:24:07.321429Z"
     },
     "papermill": {
-     "duration": 0.126578,
-     "end_time": "2026-06-22T19:16:02.199826",
+     "duration": 0.643898,
+     "end_time": "2026-09-02T22:24:07.321844",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.073248",
+     "start_time": "2026-09-02T22:24:06.677946",
      "status": "completed"
     },
     "tags": [],
@@ -5560,14 +5542,14 @@
     {
      "data": {
       "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_01_42.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_09_03_26_00_24_05_82.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       "<!-- Generated by graphviz version 16.0.0 (20260814.1018)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"330pt\" height=\"535pt\"\r\n",
@@ -5771,27 +5753,18 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
+       "\n",
+       "    </div>\n",
        "</div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
     "// Visualisation du graphe avec priors informatifs\n",
-    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+    "FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs(\"text/html\");"
    ]
   },
   {
@@ -5799,10 +5772,10 @@
    "id": "zmk2ata5wth",
    "metadata": {
     "papermill": {
-     "duration": 0.025106,
-     "end_time": "2026-06-22T19:16:02.250592",
+     "duration": 0.020828,
+     "end_time": "2026-09-02T22:24:07.362509",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.225486",
+     "start_time": "2026-09-02T22:24:07.341681",
      "status": "completed"
     },
     "tags": []
@@ -5827,10 +5800,10 @@
    "id": "ywp5qszj2y",
    "metadata": {
     "papermill": {
-     "duration": 0.024998,
-     "end_time": "2026-06-22T19:16:02.298888",
+     "duration": 0.022557,
+     "end_time": "2026-09-02T22:24:07.411476",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.273890",
+     "start_time": "2026-09-02T22:24:07.388919",
      "status": "completed"
     },
     "tags": []
@@ -5857,10 +5830,10 @@
    "id": "07a89284",
    "metadata": {
     "papermill": {
-     "duration": 0.023513,
-     "end_time": "2026-06-22T19:16:02.346402",
+     "duration": 0.021331,
+     "end_time": "2026-09-02T22:24:07.452072",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.322889",
+     "start_time": "2026-09-02T22:24:07.430741",
      "status": "completed"
     },
     "tags": []
@@ -5882,10 +5855,10 @@
    "id": "ojqirwmvivb",
    "metadata": {
     "papermill": {
-     "duration": 0.02504,
-     "end_time": "2026-06-22T19:16:02.396446",
+     "duration": 0.024757,
+     "end_time": "2026-09-02T22:24:07.494720",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.371406",
+     "start_time": "2026-09-02T22:24:07.469963",
      "status": "completed"
     },
     "tags": []
@@ -5918,10 +5891,10 @@
    "id": "34cb88fb",
    "metadata": {
     "papermill": {
-     "duration": 0.023832,
-     "end_time": "2026-06-22T19:16:02.444940",
+     "duration": 0.023768,
+     "end_time": "2026-09-02T22:24:07.540464",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.421108",
+     "start_time": "2026-09-02T22:24:07.516696",
      "status": "completed"
     },
     "tags": []
@@ -5946,10 +5919,10 @@
    "id": "9i2dyfdr6q9",
    "metadata": {
     "papermill": {
-     "duration": 0.024002,
-     "end_time": "2026-06-22T19:16:02.494947",
+     "duration": 0.013243,
+     "end_time": "2026-09-02T22:24:07.566373",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.470945",
+     "start_time": "2026-09-02T22:24:07.553130",
      "status": "completed"
     },
     "tags": []
@@ -5981,16 +5954,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:02.548462Z",
-     "iopub.status.busy": "2026-06-22T19:16:02.548462Z",
-     "iopub.status.idle": "2026-06-22T19:16:03.025013Z",
-     "shell.execute_reply": "2026-06-22T19:16:03.024464Z"
+     "iopub.execute_input": "2026-09-02T22:24:07.592968Z",
+     "iopub.status.busy": "2026-09-02T22:24:07.592668Z",
+     "iopub.status.idle": "2026-09-02T22:24:08.386719Z",
+     "shell.execute_reply": "2026-09-02T22:24:08.386591Z"
     },
     "papermill": {
-     "duration": 0.50399,
-     "end_time": "2026-06-22T19:16:03.025013",
+     "duration": 0.806879,
+     "end_time": "2026-09-02T22:24:08.386790",
      "exception": false,
-     "start_time": "2026-06-22T19:16:02.521023",
+     "start_time": "2026-09-02T22:24:07.579911",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6126,10 +6099,10 @@
    "id": "diat8qdrbpt",
    "metadata": {
     "papermill": {
-     "duration": 0.02326,
-     "end_time": "2026-06-22T19:16:03.073749",
+     "duration": 0.012495,
+     "end_time": "2026-09-02T22:24:08.412470",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.050489",
+     "start_time": "2026-09-02T22:24:08.399975",
      "status": "completed"
     },
     "tags": []
@@ -6161,10 +6134,10 @@
    "id": "qlxdvvpoxyj",
    "metadata": {
     "papermill": {
-     "duration": 0.022215,
-     "end_time": "2026-06-22T19:16:03.118558",
+     "duration": 0.012039,
+     "end_time": "2026-09-02T22:24:08.436973",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.096343",
+     "start_time": "2026-09-02T22:24:08.424934",
      "status": "completed"
     },
     "tags": []
@@ -6196,19 +6169,19 @@
    "id": "qrvzgbgjpk",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:03.170812Z",
-     "iopub.status.busy": "2026-06-22T19:16:03.169812Z",
-     "iopub.status.idle": "2026-06-22T19:16:03.270002Z",
-     "shell.execute_reply": "2026-06-22T19:16:03.270002Z"
+     "iopub.execute_input": "2026-09-02T22:24:08.462589Z",
+     "iopub.status.busy": "2026-09-02T22:24:08.462417Z",
+     "iopub.status.idle": "2026-09-02T22:24:08.864420Z",
+     "shell.execute_reply": "2026-09-02T22:24:08.864604Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.12452,
-     "end_time": "2026-06-22T19:16:03.270002",
+     "duration": 0.416011,
+     "end_time": "2026-09-02T22:24:08.864704",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.145482",
+     "start_time": "2026-09-02T22:24:08.448693",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6223,14 +6196,14 @@
     {
      "data": {
       "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_16_02_60.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
+       "\n",
+       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
+       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_09_03_26_00_24_07_63.svg</div>\n",
+       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
        "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
        "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
        " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
+       "<!-- Generated by graphviz version 16.0.0 (20260814.1018)\r\n",
        " -->\r\n",
        "<!-- Title: Model Pages: 1 -->\r\n",
        "<svg width=\"855pt\" height=\"453pt\"\r\n",
@@ -6649,27 +6622,18 @@
        "</g>\r\n",
        "</g>\r\n",
        "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
+       "\n",
+       "    </div>\n",
        "</div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
     "// Visualisation du graphe de facteurs de l'exercice\n",
-    "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
+    "FactorGraphHelper.GetLatestFactorGraphHtml().DisplayAs(\"text/html\");"
    ]
   },
   {
@@ -6677,10 +6641,10 @@
    "id": "p8ydm8z0cti",
    "metadata": {
     "papermill": {
-     "duration": 0.024881,
-     "end_time": "2026-06-22T19:16:03.319883",
+     "duration": 0.026525,
+     "end_time": "2026-09-02T22:24:08.916738",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.295002",
+     "start_time": "2026-09-02T22:24:08.890213",
      "status": "completed"
     },
     "tags": []
@@ -6709,10 +6673,10 @@
    "id": "f670c385",
    "metadata": {
     "papermill": {
-     "duration": 0.026001,
-     "end_time": "2026-06-22T19:16:03.370673",
+     "duration": 0.012001,
+     "end_time": "2026-09-02T22:24:08.941920",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.344672",
+     "start_time": "2026-09-02T22:24:08.929919",
      "status": "completed"
     },
     "tags": []
@@ -6746,10 +6710,10 @@
    "id": "h7zoj7d20kv",
    "metadata": {
     "papermill": {
-     "duration": 0.027965,
-     "end_time": "2026-06-22T19:16:03.424677",
+     "duration": 0.0152,
+     "end_time": "2026-09-02T22:24:08.971409",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.396712",
+     "start_time": "2026-09-02T22:24:08.956209",
      "status": "completed"
     },
     "tags": []
@@ -6776,19 +6740,19 @@
    "id": "37ww41xdon2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:03.475223Z",
-     "iopub.status.busy": "2026-06-22T19:16:03.475223Z",
-     "iopub.status.idle": "2026-06-22T19:16:03.519569Z",
-     "shell.execute_reply": "2026-06-22T19:16:03.519569Z"
+     "iopub.execute_input": "2026-09-02T22:24:09.003546Z",
+     "iopub.status.busy": "2026-09-02T22:24:09.003369Z",
+     "iopub.status.idle": "2026-09-02T22:24:09.031983Z",
+     "shell.execute_reply": "2026-09-02T22:24:09.031825Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.071643,
-     "end_time": "2026-06-22T19:16:03.519569",
+     "duration": 0.046183,
+     "end_time": "2026-09-02T22:24:09.032101",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.447926",
+     "start_time": "2026-09-02T22:24:08.985918",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6804,7 +6768,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fichiers .gv et .svg nettoyes : 85\r\n"
+      "Fichiers .gv et .svg nettoyes : 12\r\n"
      ]
     }
    ],
@@ -6819,10 +6783,10 @@
    "id": "d6c96c7e",
    "metadata": {
     "papermill": {
-     "duration": 0.027001,
-     "end_time": "2026-06-22T19:16:03.571654",
+     "duration": 0.023583,
+     "end_time": "2026-09-02T22:24:09.072115",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.544653",
+     "start_time": "2026-09-02T22:24:09.048532",
      "status": "completed"
     },
     "tags": []
@@ -6850,19 +6814,19 @@
    "id": "fe2a415e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:03.623202Z",
-     "iopub.status.busy": "2026-06-22T19:16:03.622685Z",
-     "iopub.status.idle": "2026-06-22T19:16:03.657790Z",
-     "shell.execute_reply": "2026-06-22T19:16:03.657274Z"
+     "iopub.execute_input": "2026-09-02T22:24:09.118918Z",
+     "iopub.status.busy": "2026-09-02T22:24:09.118616Z",
+     "iopub.status.idle": "2026-09-02T22:24:09.144624Z",
+     "shell.execute_reply": "2026-09-02T22:24:09.144409Z"
     },
     "language_info": {
      "name": "polyglot-notebook"
     },
     "papermill": {
-     "duration": 0.061135,
-     "end_time": "2026-06-22T19:16:03.657790",
+     "duration": 0.049412,
+     "end_time": "2026-09-02T22:24:09.144737",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.596655",
+     "start_time": "2026-09-02T22:24:09.095325",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -6911,10 +6875,10 @@
    "id": "44d03a9a",
    "metadata": {
     "papermill": {
-     "duration": 0.025126,
-     "end_time": "2026-06-22T19:16:03.711737",
+     "duration": 0.01383,
+     "end_time": "2026-09-02T22:24:09.175885",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.686611",
+     "start_time": "2026-09-02T22:24:09.162055",
      "status": "completed"
     },
     "tags": []
@@ -6960,16 +6924,16 @@
    "id": "d90576d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:03.760834Z",
-     "iopub.status.busy": "2026-06-22T19:16:03.760834Z",
-     "iopub.status.idle": "2026-06-22T19:16:03.789536Z",
-     "shell.execute_reply": "2026-06-22T19:16:03.789536Z"
+     "iopub.execute_input": "2026-09-02T22:24:09.206127Z",
+     "iopub.status.busy": "2026-09-02T22:24:09.205791Z",
+     "iopub.status.idle": "2026-09-02T22:24:09.228490Z",
+     "shell.execute_reply": "2026-09-02T22:24:09.228258Z"
     },
     "papermill": {
-     "duration": 0.05347,
-     "end_time": "2026-06-22T19:16:03.789536",
+     "duration": 0.037358,
+     "end_time": "2026-09-02T22:24:09.228589",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.736066",
+     "start_time": "2026-09-02T22:24:09.191231",
      "status": "completed"
     },
     "tags": []
@@ -7010,10 +6974,10 @@
    "id": "b15384df",
    "metadata": {
     "papermill": {
-     "duration": 0.025038,
-     "end_time": "2026-06-22T19:16:03.841759",
+     "duration": 0.015202,
+     "end_time": "2026-09-02T22:24:09.260469",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.816721",
+     "start_time": "2026-09-02T22:24:09.245267",
      "status": "completed"
     },
     "tags": []
@@ -7043,16 +7007,16 @@
    "id": "5b18e940",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:16:03.894718Z",
-     "iopub.status.busy": "2026-06-22T19:16:03.894718Z",
-     "iopub.status.idle": "2026-06-22T19:16:03.919401Z",
-     "shell.execute_reply": "2026-06-22T19:16:03.919401Z"
+     "iopub.execute_input": "2026-09-02T22:24:09.295633Z",
+     "iopub.status.busy": "2026-09-02T22:24:09.295252Z",
+     "iopub.status.idle": "2026-09-02T22:24:09.316532Z",
+     "shell.execute_reply": "2026-09-02T22:24:09.316405Z"
     },
     "papermill": {
-     "duration": 0.054034,
-     "end_time": "2026-06-22T19:16:03.920435",
+     "duration": 0.041147,
+     "end_time": "2026-09-02T22:24:09.316597",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.866401",
+     "start_time": "2026-09-02T22:24:09.275450",
      "status": "completed"
     },
     "tags": []
@@ -7098,10 +7062,10 @@
    "id": "d866a5ed",
    "metadata": {
     "papermill": {
-     "duration": 0.024456,
-     "end_time": "2026-06-22T19:16:03.969680",
+     "duration": 0.022209,
+     "end_time": "2026-09-02T22:24:09.356312",
      "exception": false,
-     "start_time": "2026-06-22T19:16:03.945224",
+     "start_time": "2026-09-02T22:24:09.334103",
      "status": "completed"
     },
     "tags": []
@@ -7136,21 +7100,21 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
    "api_provider": "none",
+   "api_usd_est": 0.0,
    "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
    "external_account": "none",
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-24",
+   "network": false,
+   "notes": "Item Response Theory (IRT) — modeles de competence, estimation des parametres difficulte/competence. Re-exec mesure : 15s.",
    "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
    "reproducibility": "HIGH",
-   "metadata_written": "2026-07-24",
    "validator": "papermill",
-   "notes": "Item Response Theory (IRT) — modeles de competence, estimation des parametres difficulte/competence. Re-exec mesure : 15s."
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": ".NET (C#)",
@@ -7166,14 +7130,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 14.824848,
-   "end_time": "2026-06-22T19:16:04.345504",
+   "duration": 22.992743,
+   "end_time": "2026-09-02T22:24:09.626928",
    "environment_variables": {},
    "exception": null,
    "input_path": "Infer-7-Skills-IRT.ipynb",
    "output_path": "Infer-7-Skills-IRT.ipynb",
    "parameters": {},
-   "start_time": "2026-06-22T19:15:49.520656",
+   "start_time": "2026-09-02T22:23:46.634185",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
@@ -41,7 +41,21 @@
       csharp_sha: b3b109def79703b68add789b5b44ea1501ec34a4
       content_python_sha: 81fde360a3cab1a935f7d0afbb20a8a88c0a18e02cdbf280f15403e60b709476
       content_csharp_sha: 4d560f59dc09d87060d09801e4b323292fec62c5c7b4107c40b4161f530e93d8
+    - date: "2026-09-03"
+      by: myia-po-2023:CoursIA-2
+      reason: "See #14122 : suppression des 6 CS1701 du jumeau C# en cessant de lier IHtmlContent -- display(HTML(x)) -> x.DisplayAs(\"text/html\") sur les 6 cellules d'affichage de graphe (15/34/41/49/53/63), plus le docstring de FactorGraphHelper qui recommandait la forme fautive. Substitution du mecanisme d'affichage, contenu pedagogique INCHANGE : 75 cellules avant comme apres, 52 cellules markdown identiques au caractere pres, 6 cellules code modifiees d'une seule ligne chacune, toutes la meme. Jumeau Python NON touche -- python_sha et content_python_sha identiques. Re-execution papermill SUCCESS 25 s ; les 6 graphes de facteurs sont intacts (class=\"node\" 18/19/63/16/16/33 des deux cotes), regeneres par Graphviz 16.0.0 la ou main portait du 14.1.2. --update en dernier, apres les strips pre-commit (#8957)."
+      python_sha: 378707a64be71dac488e45e2d9962cca1d1bb44f
+      csharp_sha: 36808d55b1fcc3ee3259b5c7b4421ed5d5a47b69
+      content_python_sha: 81fde360a3cab1a935f7d0afbb20a8a88c0a18e02cdbf280f15403e60b709476
+      content_csharp_sha: 58b6a8f101b25c8087f4a075c76e4dee32019bb817d630d9eab916c32d9f01cd
   known_differences:
+  - '2026-09-03 (myia-po-2023) See #14122 : csharp_sha rebaseline suite a la suppression des 6 avertissements
+    CS1701 du jumeau C# -- display(HTML(x)) remplace par x.DisplayAs("text/html"). CS1701 nomme le CONSOMMATEUR
+    qui lie la reference perimee, et ce consommateur est le kernel lui-meme (Microsoft.DotNet.Interactive liant
+    IHtmlContent contre Microsoft.AspNetCore.Html.Abstractions 2.x sous un hote 10.0) : le seul levier qui marche
+    est de ne pas lier le type. Aucune asymetrie introduite -- PyMC-7 n''emet pas de CS1701 (pas de kernel .NET),
+    la difference est intrinseque au stack et non un ecart de contenu. Prose, exercices et sorties utiles
+    inchanges des deux cotes.'
   - '2026-07-28 (myia-po-2023) #8711 / See #8081 : FERME l''asymetrie creee par #8530 -- le backfill attribution MBML
     Ch.2 n''avait touche que le twin C# (Infer-7), laissant PyMC-7 sans rattachement au chapitre alors que son jumeau
     l''avait. Ajout cote PyMC d''une cellule "Origine pedagogique : MBML Ch.2" (distillation PyMC du Ch.2 Assessing


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #14361

## Résumé

Premier notebook remis à zéro CS1701, et le seul levier qui marche appliqué à la famille la plus nombreuse.

Les 6 avertissements d'`Infer-7` sont tous de **famille A** : CS1701 en français nomme deux assemblages — la référence périmée, et **le consommateur qui la lie** — et ici le consommateur est le kernel lui-même. `display(HTML(x))` construit un `IHtmlContent`, type porté par `Microsoft.AspNetCore.Html.Abstractions` 2.x alors que l'hôte porte la 10.0. Chaque cellule qui l'emploie déclenche un avertissement : corrélation 1:1 dans les deux sens entre les 6 cellules et les 6 lignes.

`x.DisplayAs("text/html")` ne prend qu'une chaîne et un type MIME. Aucun type de l'assemblage périmé n'est lié, et le rendu est le même — sans le `<div>` d'enrobage.

Le docstring de `FactorGraphHelper` **recommandait la forme fautive**. C'est la cause de récurrence, corrigée ici aussi : sans cela, la prochaine cellule d'affichage réintroduit le motif.

## Pourquoi ce levier et pas ceux de l'issue

Les trois leviers nommés par #14122 sont réfutés par sonde, verdict T0 complet en [issuecomment-5517219569](https://github.com/jsboige/CoursIA/issues/14122#issuecomment-5517219569) :

| levier | résultat |
|---|---|
| (a) épingler une version | `#r "nuget: Newtonsoft.Json, 13.0.4"` → **5**, inchangé |
| (b) `#pragma warning disable` | absent / cellule d'usage / cellule `#r` / les deux → **5** partout. CS1701 **ne porte pas de position source** |
| (c) `<NoWarn>` côté kernel | `#!lsmagic` = 24 magics, aucune ne touche aux diagnostics |
| **(d) ne pas lier le type** | **le seul qui marche** — sonde A/B : `display(HTML(...))` **1**, `DisplayAs("text/html")` **0**, rendu identique |

## Mesure

Ré-exécution papermill `--cwd notebook`, `SUCCESS (25 s)`, `Degraded: 0`.

| | avant | après |
|---|---|---|
| **CS1701** | **6** | **0** |
| erreurs | 0 | 0 |
| `execution_count` nuls | 0 | 0 |
| sorties `display_data` | 8 | **8** |
| sorties `stream` | 282 | 276 |

La baisse de `stream` est **exactement** les 6 sorties portant CS1701 (6 → 0 en compte de sorties). Les 8 `display_data` — dont les 6 graphes de facteurs — sont toutes là.

## Charge utile préservée, pas remplacée par un talon

C'est le point qui comptait, et il est vérifié graphe par graphe contre `origin/main` :

| cellule | `text/html` | `<svg` | `class="node"` | talon Graphviz |
|---|---|---|---|---|
| 15 | 17 752 → 17 758 | oui / oui | **18 / 18** | absent / absent |
| 34 | 19 364 → 19 370 | oui / oui | **19 / 19** | absent / absent |
| 41 | 65 669 → 65 675 | oui / oui | **63 / 63** | absent / absent |
| 49 | 16 387 → 16 393 | oui / oui | **16 / 16** | absent / absent |
| 53 | 16 426 → 16 432 | oui / oui | **16 / 16** | absent / absent |
| 63 | 33 848 → 33 854 | oui / oui | **33 / 33** | absent / absent |

Le `+6` est **uniforme et entièrement comptabilisé**, indépendant de la taille du graphe : `−6` CR dans le préambule (bloc d'en-tête de taille fixe) `+12` pour la chaîne de version — les graphes sont régénérés par **Graphviz 16.0.0** là où `main` portait du **14.1.2**. Nombre de lignes identique de part et d'autre.

Le diff est en `deletions > insertions` (400 / 432), motif red-flag par défaut. L'excédent est **entièrement** les 18 lignes de flux supprimées (307 → 289) — les 6 avertissements — plus la re-sérialisation JSON ; aucune source, aucune sortie utile, aucune cellule ne disparaît. Les 75 cellules sont là avant comme après.

## Prérequis réparé, pas contourné — `RECOVERABLE-LOCAL`, règle F

`dot` était **absent** de cette machine. La ré-exécution de contrôle sortait **verte sur tous les signaux** — 0 erreur, aucun `execution_count` nul, `outputs` en **hausse** 290 → 314 — en ayant détruit le livrable : `text/html` 194 409 → 6 856, cellules 15 et 34 passées de 17 752 / 19 364 caractères de graphe à un talon de **323 caractères** `<strong>Graphviz non disponible.</strong>`. Le notebook avait alors été restauré à l'identique de `main` depuis une sauvegarde `cp` (jamais `git checkout --`).

Graphviz 16.0.0 a donc été installé (archive portable, sans droits admin, `dot -c` exécuté, PATH utilisateur persistant) **avant** la ré-exécution livrée ici.

**Toute tranche famille A ultérieure doit installer Graphviz avant de ré-exécuter un notebook Infer/Probas**, sous peine de committer des talons sous une ré-exécution d'apparence verte.

## Portée

**Trois fichiers**, un notebook, 6 lignes substituées + 6 lignes de docstring :

| fichier | diff | rôle |
|---|---|---|
| `MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb` | 395+ / 431− | le pilote : 6 substitutions + ré-exécution |
| `MyIA.AI.Notebooks/Probas/Infer/FactorGraphHelper.cs` | 5+ / 1− | la docstring qui **recommandait** la forme fautive — cause de récurrence |
| `scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml` | 14+ / 0− | attestation de parité jumelle (second commit) |

Le corps annonçait « deux fichiers » : il était antérieur au second commit, et la garde de périmètre (#11268) a eu raison de le contredire. Corrigé ici.

### Mouvement de baseline — direction qualifiée

Le YAML de parité enregistre l'empreinte git de chaque jumeau ; *toute* édition la déplace. La nouvelle entrée d'audit déplace **les deux empreintes C#** (`csharp_sha`, `content_csharp_sha`) et **laisse les deux empreintes Python strictement identiques** — c'est la preuve mécanique que le jumeau `PyMC-07-Skills-IRT.ipynb` n'a **pas** été touché ; son diff est vide. La direction est donc : rebaseline **unilatérale du côté édité**, jamais une ré-attestation de la paire entière.

L'attestation `--update` est passée **en dernier**, après les normalisations de pre-commit (`strip_probe_banner`, `scrub_papermill_paths`) : attester puis normaliser invaliderait l'attestation (#8957). Le `[DRIFT] ML-5 TimeSeries` restant préexiste sur `origin/main` et est hors périmètre.

Les 41 autres notebooks de famille A restent à faire — même substitution, mécanique, mais chacun exige sa ré-exécution (C.2) donc la machine qui la porte doit avoir `dot`.

See #14122

