### PR TITLE
ci(runners,#14283): router always-on-guards vers le pool Linux -- partage de declencheur avec perimeter-review-guard

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -56,12 +56,20 @@ on:
     branches: [ main ]
     types: [ opened, synchronize, edited, reopened ]
     # PAS de `paths:` ici -- cf en-tete + regle 2 d'#10045 + #13232.
-  pull_request_review:
-    branches: [ main ]
-    types: [ submitted, edited ]
-    # Porte le perimeter review guard : une review qui affirme un perimetre
-    # doit etre confrontee (fondateur #11268). Les autres organes sont
-    # `if:`-gates hors de cet evenement.
+  # PAS de `pull_request_review` ici : c'est un declencheur fork-reachable
+  # (FORK_REACHABLE_TRIGGERS, #14201 tranche 2), interdit sur un runner
+  # auto-heberge -- et le check_self_hosted_runner_policy.py evalue les
+  # declencheurs au niveau WORKFLOW, pas par job : le garder ici, meme gate
+  # `if:` sur un seul job, rendrait TOUT le fichier inadmissible au pool.
+  # Le perimeter review guard reprend donc SA surface d'origine sur cet
+  # evenement : perimeter-review-guard.yml, ravive sur `pull_request_review`
+  # (ubuntu-latest). Aucune double execution -- les deux fichiers se
+  # partagent les evenements, ils ne les dupliquent pas :
+  #   pull_request        -> always-on-guards (organe perimeter inclus)
+  #   pull_request_review -> perimeter-review-guard uniquement
+  # C'est exactement la condition posee par l'en-tete de ce fichier-la
+  # ("NE PAS reinscrire ... sans retirer l'organe perimeter d'always-on-guards") :
+  # ici l'organe n'est pas retire, il est RESTREINT a `pull_request`.
   workflow_dispatch:
 
 permissions:
@@ -82,7 +90,36 @@ concurrency:
 jobs:
   always-on-guards:
     name: "Always-on guards -- 12 organes, 1 checkout"
-    runs-on: ubuntu-latest
+    # Routage #14283 : premier consommateur GitHub-hosted du depot une fois
+    # secret-scan bascule -- 2650 runs same-repo en 5 jours (2026-08-28 ->
+    # 2026-09-02), timeout 25 min, aucun filtre `paths:`. Le pool Linux
+    # auto-heberge sert sa demande instantanement pendant que 23 runners
+    # restaient IDLE : le defaut etait le ROUTAGE de la file, pas la capacite.
+    #
+    # Garde anti-fork au niveau JOB (pas au niveau step) : un garde
+    # `IS_FORK` dans un `run:` laisse le job DEMARRER et le checkout
+    # s'executer -- du code de fork atteindrait le volume de travail
+    # persistant par slot (#14285). Seul un `if:` de job l'empeche.
+    # runs-on STATIQUE : une expression leverait DYNAMIC_RUNS_ON dans
+    # scripts/ci/check_self_hosted_runner_policy.py (violation bloquante).
+    #
+    # Pas de jambe fork de remplacement, et c'est MESURE, pas suppose :
+    # sur 2651 runs, le seul run de fork (33531051061, jsboigeEpita, PR
+    # interne poussee depuis un fork) est mort AU DEMARRAGE -- `jobs`
+    # total_count = 0, conclusion `startup_failure`. Or `startup_failure`
+    # est dans CONCLUSION_BAD de scripts/pr_gate.py alors que `skipped`
+    # est dans CONCLUSION_OK : la garde de job REMPLACE un rouge par un
+    # vert sur les PRs de fork, elle ne leur retire aucune capacite.
+    # Les 9 organes de substance sortent deja `exit 0` sur un fork
+    # (garde `IS_FORK` interne) ; seuls perimeter et fastlane tournaient,
+    # et le token read-only d'un fork leur refuse `checks: write`.
+    #
+    # Controle positif in-artefact : secret-scan.yml :: positive-controls
+    # fait tourner `actions/setup-python@v5` sur CE pool -- run
+    # 33691615314, runner myia-ai-01-linux-docker-6, success en 34 s.
+    # Retour arriere = remettre `runs-on: ubuntu-latest` + retirer le `if:`.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 25
 
     # Env partage par les organes metadata (portes depuis leurs jobs
@@ -893,13 +930,13 @@ jobs:
 
           exit 1
 
-      # Porte de perimeter-review-guard.yml :: perimeter. Tourne AUSSI sur
-      # pull_request_review (submitted/edited) : une review qui affirme un
-      # perimetre doit etre confrontee (#11268). Les autres organes sont
-      # if:-gates hors de cet evenement.
+      # Porte de perimeter-review-guard.yml :: perimeter, sur `pull_request`
+      # SEULEMENT. La surface `pull_request_review` est revenue au fichier
+      # d'origine (declencheur fork-reachable, incompatible avec le pool
+      # auto-heberge) : voir le bloc `on:` ci-dessus.
       - name: "perimeter review guard (#11268)"
         id: perimeter
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+        if: github.event_name == 'pull_request'
         continue-on-error: true
         run: |
           PR="${{ github.event.pull_request.number }}"

--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -53,28 +53,45 @@ name: perimeter-review-guard
 # "fix" a future false-positive by narrowing the detection -- that loses both
 # properties at once (#11648, point 2).
 
-# DORMANT depuis #13384 : le job perimeter est absorbe (run block porte
-# verbatim, declencheurs pull_request + pull_request_review repris) par
-# always-on-guards.yml -- un seul workflow, un seul checkout, un seul slot
-# de runner par PR (37 % de la file CI etait les cinq gardes always-on pour
-# ~3 min de travail reel, mesure #13384). Le job reste ICI en copie de
-# reference pour la tracabilite (et l'identite du registre fast-lane, qui
-# lit ce fichier comme source du garde pilot). NE PAS reinscrire
-# pull_request/pull_request_review ici sans retirer l'organe perimeter
-# d'always-on-guards -- les deux surfaces executeraient le meme verdict en
-# double.
+# PARTIELLEMENT RAVIVE (#14283) : ce fichier reprend la surface
+# `pull_request_review`, et ELLE SEULE. `pull_request` reste absorbe par
+# always-on-guards.yml (organe `perimeter`, desormais `if:`-gate sur
+# `pull_request` uniquement) -- la condition posee par la note de dormance
+# d'origine est donc tenue : les deux surfaces se PARTAGENT les evenements,
+# aucune ne les duplique.
+#
+#   pull_request        -> always-on-guards.yml :: perimeter   (self-hosted)
+#   pull_request_review -> ce fichier                          (ubuntu-latest)
+#
+# Pourquoi ce partage : `pull_request_review` est un declencheur
+# fork-reachable (FORK_REACHABLE_TRIGGERS, #14201 tranche 2). Le laisser sur
+# always-on-guards interdisait a CE workflow-la le pool auto-heberge --
+# check_self_hosted_runner_policy.py evalue les declencheurs au niveau
+# WORKFLOW, pas par job. always-on-guards etant le premier consommateur
+# GitHub-hosted du depot (2650 runs same-repo en 5 jours, timeout 25 min),
+# c'est lui qu'il fallait pouvoir router ; le garde perimeter revient donc
+# ici pour la seule surface qui l'empechait.
+#
+# Ce job repasse sur ubuntu-latest POUR LA MEME RAISON : un declencheur
+# fork-reachable ne doit jamais atteindre un runner auto-heberge (volume de
+# travail persistant par slot, #14285). Le `runs-on` self-hosted precedent
+# datait de la periode dormante, ou aucun evenement ne l'atteignait.
 
 on:
+  pull_request_review:
+    branches: [ main ]
+    types: [ submitted, edited ]
   workflow_dispatch:
 
 jobs:
   perimeter:
     name: "perimeter review guard (#11268)"
-    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
-    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
-    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
-    # fork n'atteint le runner. Retour arriere = revert de la PR.
-    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    # ubuntu-latest OBLIGATOIRE ici : `pull_request_review` est fork-reachable
+    # (#14201 tranche 2). Le `runs-on` self-hosted qui figurait ici datait de
+    # la periode dormante (#13378 tranche 5) : aucun evenement ne l'atteignait
+    # alors. Le ravivage de la surface le rend inadmissible -- et
+    # check_self_hosted_runner_policy.py le refuse (FORK_REACHABLE_TRIGGER).
+    runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
 

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -64,6 +64,10 @@ DEDICATED_LABEL_SETS = (REQUIRED_LABELS, LINUX_RUNNER_LABELS)
 #   `skipped` as OK). Routed to the containerized Linux leg to relieve the
 #   GitHub-hosted queue. Rollback = revert of the routing PR.
 SELF_HOSTED_WORKFLOW_ALLOWLIST = {
+    # tranche 3d (#14283) : premier consommateur GitHub-hosted du depot une
+    # fois secret-scan bascule -- 2650 runs same-repo du 2026-08-28 au
+    # 2026-09-02, timeout 25 min, aucun filtre `paths:`.
+    "always-on-guards.yml",
     "pr-gate-stale-sweep.yml",
     "windows-self-hosted-tests.yml",
     "linux-self-hosted-tests.yml",

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -741,12 +741,38 @@ def test_pull_request_trigger_includes_edited_type():
     )
 
 
+def _read_review_trigger_workflow() -> str:
+    """Read the workflow that carries the ``pull_request_review`` trigger.
+
+    #14283 : always-on-guards.yml a bascule sur le pool auto-heberge, et
+    `check_self_hosted_runner_policy.py` evalue les declencheurs au niveau
+    du FICHIER, pas du job -- un `pull_request_review` (fork-reachable)
+    n'importe ou dans le fichier rend TOUT le fichier inadmissible au pool.
+    Le declencheur a donc ete rendu a perimeter-review-guard.yml, qui reste
+    sur GitHub-hosted. Les deux surfaces ne se doublent pas : always-on-guards
+    ne garde que `pull_request`, perimeter-review-guard que
+    `pull_request_review` -- c'est la condition que l'en-tete de ce dernier
+    posait deja (« NE PAS reinscrire pull_request/pull_request_review ici sans
+    retirer l'organe perimeter d'always-on-guards »).
+
+    L'invariant teste est inchange : `types: [submitted, edited]` doit rester
+    declare, ou une review corrigee ne re-declenche pas le gate.
+    """
+    here = pathlib.Path(__file__).resolve()
+    repo_root = here.parents[2]
+    wf = repo_root / ".github" / "workflows" / "perimeter-review-guard.yml"
+    return wf.read_text(encoding="utf-8")
+
+
 def test_pull_request_review_trigger_includes_edited_type():
     """Sibling invariant — the review trigger already had ``edited`` from the
     start (c.342 acceptance), so this test pins that property against
     accidental regression when editing the workflow.
+
+    Depuis #14283 le declencheur vit dans perimeter-review-guard.yml (cf
+    ``_read_review_trigger_workflow``) ; l'invariant, lui, ne bouge pas.
     """
-    text = _read_perimeter_workflow()
+    text = _read_review_trigger_workflow()
     import re
     rv_block = re.search(
         r"^  pull_request_review:\s*\n((?:    [^\n]*\n)+)", text, re.MULTILINE


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/guard #14375

## Le grain

`always-on-guards.yml` est, depuis la bascule de `secret-scan` (#14375), **le premier consommateur GitHub-hosted du depot** : **2650 runs same-repo** du 2026-08-28 au 2026-09-02, `timeout-minutes: 25`, **aucun filtre `paths:`** -- il tourne sur chaque PR. Pendant ce temps le pool Linux auto-heberge servait sa demande instantanement.

## Ce qui bloquait -- et ce n'etait pas le fork-guard

Le diagnostic evident (« il faut une garde anti-fork au niveau job ») etait **insuffisant**. Le vrai blocage est le declencheur `pull_request_review`, qui est dans `FORK_REACHABLE_TRIGGERS` (#14201 tranche 2) :

> `check_self_hosted_runner_policy.py` evalue les declencheurs au niveau **WORKFLOW**, pas par job.

Le garder rendait **tout le fichier** inadmissible au pool, quel que soit le gate `if:` pose sur un job. C'est l'organe qui me l'a appris -- ma premiere version ne changeait que `runs-on` + le gate de job, et il l'a refusee :

```
VIOLATION FORK_REACHABLE_TRIGGER: always-on-guards.yml:always-on-guards
VIOLATION WORKFLOW_NOT_ALLOWED:   always-on-guards.yml:always-on-guards
```

## La forme retenue : partage de declencheur, pas duplication

`perimeter-review-guard.yml` existe toujours (dormant depuis #13384) et **pose lui-meme la condition** :

> « NE PAS reinscrire pull_request/pull_request_review ici sans retirer l'organe perimeter d'always-on-guards -- les deux surfaces executeraient le meme verdict en double. »

Elle est tenue : l'organe n'est pas retire, il est **restreint** a `pull_request`. Les deux fichiers se **partagent** les evenements.

| evenement | qui execute le perimeter guard | runner |
|---|---|---|
| `pull_request` | `always-on-guards.yml` :: `perimeter` | self-hosted Linux |
| `pull_request_review` | `perimeter-review-guard.yml` | `ubuntu-latest` |

Aucun evenement n'est servi deux fois ; aucun n'est orphelin. `perimeter-review-guard` **repasse sur `ubuntu-latest`** : son `runs-on` self-hosted datait de la periode dormante (#13378 tranche 5), ou aucun evenement ne l'atteignait -- ravivee, la surface le rend inadmissible.

## Pas de jambe fork -- et c'est MESURE, pas suppose

Sur **2651** runs, **un seul** vient d'un fork (`33531051061`, `jsboigeEpita`, une PR interne poussee depuis un fork, pas un TP etudiant). Il est mort **au demarrage** : `jobs` `total_count = 0`, conclusion `startup_failure`.

Or dans `scripts/pr_gate.py` : `startup_failure` est dans `CONCLUSION_BAD`, `skipped` est dans `CONCLUSION_OK`. **La garde de job remplace donc un rouge par un vert sur les PRs de fork** -- elle ne leur retire aucune capacite. Les 9 organes de substance sortent deja `exit 0` sur un fork ; seuls `perimeter` et `fastlane` tournaient, et le token read-only d'un fork refuse a `fastlane` le `checks: write` dont il a besoin pour publier.

## Controles

- **Policy** : `check_self_hosted_runner_policy.py` -> `OK -- all self-hosted jobs satisfy isolation policy` (les 2 violations ci-dessus levees).
- **Identite d'absorption** : `check_absorbed_check_run_identity.py --check` -> `OK -- 13 gardes absorbes byte-identiques a leur source` (le run block n'a pas bouge).
- **Tests** : `pytest scripts/tests/test_check_self_hosted_runner_policy.py` -> **49 passed**.
- **Controle positif in-artefact** : `secret-scan.yml` :: `positive-controls` fait deja tourner `actions/setup-python@v5` sur CE pool -- run `33691615314`, runner `myia-ai-01-linux-docker-6`, **success en 34 s**. C'etait le seul risque d'image (le pool est un container ; `gh`, `git`, `jq`, `python3` y sont deja verifies).
- **Auto-test end-to-end** : pour un evenement `pull_request`, GitHub lit la definition du workflow **sur la tete de la PR**. Cette PR execute donc sa propre migration : le check `Always-on guards -- 12 organes, 1 checkout` ci-dessous tourne deja sur le pool Linux. Un vert ici **est** la preuve de la bascule.
- **Surface `pull_request_review`** : testable avant merge en postant une review sur cette PR -- `perimeter-review-guard` doit apparaitre et rester vert.

## Portee

4 fichiers, +112/-28 : `always-on-guards.yml` (+49/-12), `perimeter-review-guard.yml` (+32/-15), `scripts/ci/check_self_hosted_runner_policy.py` (+4/-0), `scripts/tests/test_check_pr_perimeter.py` (+27/-1). Aucune logique de garde modifiee : `runs-on`, declencheurs, un `if:` d'organe, une entree d'allowlist, et le pin de trigger qui suit le trigger.

Le 4e fichier est arrive apres coup, et c'est l'organe `perimeter` de cette PR meme qui l'a signale : le corps annoncait encore « 3 fichiers, +85/-27 » une fois le test ajoute. Corrige ici plutot que contourne -- une assertion de perimetre fausse est exactement ce que cet organe existe pour attraper, y compris sur la PR qui le deplace.

## Reserve honnete -- G-VAR-1

Ce grain est **META** (`tooling`). Il ne tient donc **pas** le plancher G-VAR-1 du cycle, et je le declare plutot que de le maquiller : les 5 derniers grains de ma lane sont `guard`/`tooling` x4 -- une secheresse de contenu sur ma propre lane, exactement ce que le compteur de #13086 est fait pour attraper. La dette d'interleave CONTENT reste due (elle bloque deja #14060), et ce travail-ci est pris sur mandat user explicite (« tirage a fond de tous les runners »), pas en substitution.

See #14283
See #14395

