### PR TITLE
test(qc,#7357): tranche 5 -- couverture unitaire Order/OrderTrade/UnixTime/FastRandom

### DIFF
--- a/MyIA.Trading.Backtester.Tests/Core/OrderTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Core/OrderTests.cs
@@ -1,0 +1,130 @@
+using System;
+using MyIA.Trading.Backtester;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Core
+{
+    /// <summary>
+    /// Tests unitaires de Order (MyIA.Trading.Backtester.Core/Order.cs).
+    /// Fichier porte verbatim depuis la tranche 2 (#7357), aucun test a ce jour.
+    /// Surface testee :
+    /// - constructeurs (sans argument, complet, complet + date)
+    /// - getters/setters (Time, OrderType, IsCancel, Value)
+    /// - IComparable&lt;Order&gt;.CompareTo (signature explicite, sur Price)
+    /// - FriendlyId (concatene les champs)
+    /// Comportements NON testes :
+    /// - Equals/GetHashCode (non overrides -> reference, valeur non pertinente)
+    /// - CompareDates / CompareOrderDates (static interne, exposure privee)
+    /// </summary>
+    public sealed class OrderTests
+    {
+        [Fact]
+        public void DefaultConstructor_SetsOrderTypeToBuy()
+        {
+            var order = new Order();
+            Assert.Equal(OrderType.Buy, order.OrderType);
+            Assert.False(order.IsCancel);
+        }
+
+        [Fact]
+        public void FullConstructor_AssignsAllProvidedFields()
+        {
+            var price = 123.45m;
+            var amount = 0.5m;
+            var order = new Order(OrderType.Sell, price, amount);
+
+            Assert.Equal(OrderType.Sell, order.OrderType);
+            Assert.Equal(price, order.Price);
+            Assert.Equal(amount, order.Amount);
+            Assert.False(order.IsCancel);
+        }
+
+        [Fact]
+        public void ConstructorWithDate_StoresUnixTimestamp()
+        {
+            var date = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+            var order = new Order(OrderType.Buy, 100m, 1m, date);
+
+            Assert.Equal(MyIA.Trading.Backtester.UnixTime.ConvertToUnixTimestamp(date), order.Date);
+        }
+
+        [Fact]
+        public void Value_IsProductOfPriceAndAmount()
+        {
+            var order = new Order(OrderType.Buy, 100m, 2.5m);
+            Assert.Equal(250m, order.Value);
+        }
+
+        [Fact]
+        public void Time_GetterSetterRoundTripsUnixTimestamp()
+        {
+            var original = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            var order = new Order { Time = original };
+            Assert.Equal(original, order.Time);
+        }
+
+        [Fact]
+        public void OrderType_GetterReturnsTypeUnlessIsCancel()
+        {
+            var order = new Order { Type = (int)OrderType.Sell };
+            Assert.Equal(OrderType.Sell, order.OrderType);
+
+            order.IsCancel = true;
+            Assert.Equal(OrderType.Cancel, order.OrderType);
+        }
+
+        [Fact]
+        public void OrderType_SetterCancelSetsIsCancelTrue()
+        {
+            var order = new Order();
+            order.OrderType = OrderType.Cancel;
+            Assert.True(order.IsCancel);
+            Assert.NotEqual((int)OrderType.Cancel, order.Type);
+        }
+
+        [Fact]
+        public void OrderType_SetterNonCancelStoresType()
+        {
+            var order = new Order { IsCancel = true };
+            order.OrderType = OrderType.Buy;
+            Assert.False(order.IsCancel);
+            Assert.Equal((int)OrderType.Buy, order.Type);
+        }
+
+        [Fact]
+        public void CompareTo_NegativeWhenThisPriceLower()
+        {
+            var a = new Order(OrderType.Buy, 100m, 1m);
+            var b = new Order(OrderType.Buy, 110m, 1m);
+            Assert.Equal(-1, ((IComparable<Order>)a).CompareTo(b));
+        }
+
+        [Fact]
+        public void CompareTo_PositiveWhenThisPriceHigher()
+        {
+            var a = new Order(OrderType.Buy, 110m, 1m);
+            var b = new Order(OrderType.Buy, 100m, 1m);
+            Assert.Equal(1, ((IComparable<Order>)a).CompareTo(b));
+        }
+
+        [Fact]
+        public void CompareTo_ZeroWhenPricesEqual()
+        {
+            var a = new Order(OrderType.Buy, 100m, 1m);
+            var b = new Order(OrderType.Sell, 100m, 5m);
+            // CompareTo ne regarde QUE Price, ignore OrderType et Amount.
+            Assert.Equal(0, ((IComparable<Order>)a).CompareTo(b));
+        }
+
+        [Fact]
+        public void FriendlyId_ContainsOidTypeAmountPrice()
+        {
+            var order = new Order(OrderType.Buy, 100m, 2m) { Oid = "OID-42" };
+            string id = order.FriendlyId;
+            Assert.Contains("OID-42", id);
+            Assert.Contains("Buy", id);
+            Assert.Contains("100", id);
+            Assert.Contains("2", id);
+        }
+    }
+}

--- a/MyIA.Trading.Backtester.Tests/Core/OrderTradeTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Core/OrderTradeTests.cs
@@ -1,0 +1,159 @@
+using System;
+using MyIA.Trading.Backtester;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Core
+{
+    /// <summary>
+    /// Tests unitaires de OrderTrade (MyIA.Trading.Backtester.Core/OrderTrade.cs).
+    /// Fichier porte verbatim depuis la tranche 2 (#7357), aucun test a ce jour.
+    /// Surface testee :
+    /// - constructeur par defaut (TradeType=Buy, Time=MinValue)
+    /// - UnixTime (getter/setter round-trip via UnixTime.ConvertTo)
+    /// - Equals (IEquatable&lt;OrderTrade&gt; + override object.Equals)
+    /// - GetHashCode (coherence : egaux -> meme hash)
+    /// - ToOrder (mapping des champs vers Order)
+    /// - FriendlyId (concatene Time, Amount, Price)
+    /// </summary>
+    public sealed class OrderTradeTests
+    {
+        private static OrderTrade MakeTrade(DateTime time, decimal price, decimal amount, TradeType type = TradeType.Buy)
+        {
+            return new OrderTrade
+            {
+                Time = time,
+                Price = price,
+                Amount = amount,
+                TradeType = type,
+                InitialOrderType = type,
+            };
+        }
+
+        [Fact]
+        public void DefaultConstructor_SetsBuyAndMinValueTime()
+        {
+            var t = new OrderTrade();
+            Assert.Equal(TradeType.Buy, t.TradeType);
+            Assert.Equal(TradeType.Buy, t.InitialOrderType);
+            Assert.Equal(DateTime.MinValue, t.Time);
+        }
+
+        [Fact]
+        public void UnixTime_RoundTripsThroughUnixSeconds()
+        {
+            var t = new OrderTrade { Time = new DateTime(2024, 6, 1, 12, 0, 0, DateTimeKind.Utc) };
+            long unix = t.UnixTime;
+            Assert.Equal(MyIA.Trading.Backtester.UnixTime.ConvertToUnixTimestamp(t.Time), unix);
+            t.UnixTime = unix + 3600;
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(unix + 3600).UtcDateTime, t.Time);
+        }
+
+        [Fact]
+        public void Equals_TrueWhenTimePriceAmountMatch()
+        {
+            var time = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var a = MakeTrade(time, 100m, 1m);
+            var b = MakeTrade(time, 100m, 1m, TradeType.Sell); // TradeType different : pas dans Equals
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_FalseWhenPriceDiffers()
+        {
+            var time = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var a = MakeTrade(time, 100m, 1m);
+            var b = MakeTrade(time, 101m, 1m);
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_FalseWhenAmountDiffers()
+        {
+            var time = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var a = MakeTrade(time, 100m, 1m);
+            var b = MakeTrade(time, 100m, 2m);
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_FalseWhenTimeDiffers()
+        {
+            var a = MakeTrade(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), 100m, 1m);
+            var b = MakeTrade(new DateTime(2024, 1, 1, 0, 0, 1, DateTimeKind.Utc), 100m, 1m);
+            Assert.False(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equals_ObjectOverloadDelegatesToTypedEquals()
+        {
+            var time = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var a = MakeTrade(time, 100m, 1m);
+            object boxed = MakeTrade(time, 100m, 1m);
+            Assert.True(a.Equals(boxed));
+        }
+
+        [Fact]
+        public void Equals_ObjectOverloadFalseOnNonOrderTrade()
+        {
+            var a = MakeTrade(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), 100m, 1m);
+            // Le cast (OrderTrade) d'un string leve InvalidCastException ; le test observe donc
+            // que Equals(object) delega au Equals(OrderTrade) qui caste -> exception attendue.
+            Assert.Throws<InvalidCastException>(() => a.Equals("not a trade"));
+        }
+
+        [Fact]
+        public void GetHashCode_ConsistentWithEquals()
+        {
+            var time = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var a = MakeTrade(time, 100m, 1m);
+            var b = MakeTrade(time, 100m, 1m);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void ToOrder_MapsIdTimeAmountPriceAndForcesOrderType()
+        {
+            var time = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var t = new OrderTrade
+            {
+                Id = "T-1",
+                Time = time,
+                Price = 200m,
+                Amount = 3m,
+                TradeType = TradeType.Sell,
+            };
+
+            var order = t.ToOrder(OrderType.Buy);
+
+            Assert.Equal("T-1", order.Oid);
+            Assert.Equal(time, order.Time);
+            Assert.Equal(200m, order.Price);
+            Assert.Equal(3m, order.Amount);
+            Assert.Equal(OrderType.Buy, order.OrderType); // force la valeur passee, pas TradeType
+        }
+
+        [Fact]
+        public void FriendlyId_SellWhenAmountNegative()
+        {
+            var time = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var t = MakeTrade(time, 100m, -1m, TradeType.Buy);
+            Assert.Contains("Sell", t.FriendlyId);
+        }
+
+        [Fact]
+        public void FriendlyId_SellWhenTradeTypeSell()
+        {
+            var time = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var t = MakeTrade(time, 100m, 1m, TradeType.Sell);
+            Assert.Contains("Sell", t.FriendlyId);
+        }
+
+        [Fact]
+        public void FriendlyId_BuyOtherwise()
+        {
+            var time = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var t = MakeTrade(time, 100m, 1m, TradeType.Buy);
+            Assert.Contains("Buy", t.FriendlyId);
+        }
+    }
+}

--- a/MyIA.Trading.Backtester.Tests/Core/UnixTimeTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Core/UnixTimeTests.cs
@@ -1,0 +1,75 @@
+using System;
+using MyIA.Trading.Backtester;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Core
+{
+    /// <summary>
+    /// Tests unitaires de UnixTime (MyIA.Trading.Backtester.Core/UnixTime.cs).
+    /// Helper local substitut de Aricie.Common.ConvertToUnixTimestamp / ConvertFromUnixTimestamp
+    /// (source Aricie non disponible). Le contrat documente dans la XML doc de la classe :
+    /// ((DateTimeOffset) targetTime.ToUniversalTime()).ToUnixTimeSeconds() pour toUnix,
+    /// DateTimeOffset.FromUnixTimeSeconds(unixTime).UtcDateTime pour fromUnix.
+    /// </summary>
+    public sealed class UnixTimeTests
+    {
+        [Fact]
+        public void ConvertToUnixTimestamp_EpochIsZero()
+        {
+            Assert.Equal(0L, UnixTime.ConvertToUnixTimestamp(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+        }
+
+        [Fact]
+        public void ConvertToUnixTimestamp_KnownTimestamp()
+        {
+            // 2020-01-01T00:00:00Z == 1577836800
+            Assert.Equal(1577836800L, UnixTime.ConvertToUnixTimestamp(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+        }
+
+        [Fact]
+        public void ConvertToUnixTimestamp_LocalTimeIsNormalizedToUtc()
+        {
+            // Une DateTime en Unspecified OU Local doit etre convertie en UTC avant epoch.
+            // Local time UTC+1 de 2024-01-01 01:00:00 == 2024-01-01 00:00:00 UTC == 1704067200.
+            var local = new DateTime(2024, 1, 1, 1, 0, 0, DateTimeKind.Local);
+            Assert.Equal(1704067200L, UnixTime.ConvertToUnixTimestamp(local));
+        }
+
+        [Fact]
+        public void ConvertFromUnixTimestamp_ZeroIsEpoch()
+        {
+            Assert.Equal(
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                UnixTime.ConvertFromUnixTimestamp(0));
+        }
+
+        [Fact]
+        public void ConvertFromUnixTimestamp_KnownTimestamp()
+        {
+            Assert.Equal(
+                new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                UnixTime.ConvertFromUnixTimestamp(1577836800L));
+        }
+
+        [Fact]
+        public void RoundTrip_PreservesDateTimeAcrossThreshold()
+        {
+            // 2038-01-19T03:14:07Z = 2147483647 (Int32.MaxValue, bord du bug Y2K38)
+            DateTime[] samples =
+            {
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                new DateTime(2000, 2, 29, 23, 59, 59, DateTimeKind.Utc), // bissextile
+                new DateTime(2024, 6, 15, 12, 34, 56, DateTimeKind.Utc),
+                new DateTime(2038, 1, 19, 3, 14, 7, DateTimeKind.Utc), // Int32.MaxValue
+                new DateTime(2100, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            };
+
+            foreach (var dt in samples)
+            {
+                long unix = UnixTime.ConvertToUnixTimestamp(dt);
+                DateTime round = UnixTime.ConvertFromUnixTimestamp(unix);
+                Assert.Equal(dt, round);
+            }
+        }
+    }
+}

--- a/MyIA.Trading.Backtester.Tests/Utils/FastRandomTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Utils/FastRandomTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using MyIA.Trading.Backtester;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Utils
+{
+    /// <summary>
+    /// Tests unitaires de FastRandom (MyIA.Trading.Backtester/FastRandom.cs).
+    /// Generateur xorshift128 substitut local du type Aricie.DNN FastRandom.
+    /// Le contrat est : constructeur depuis int seed, Next(min, max) avec min inclusif
+    /// et max exclusif. La sequence produite n'est PAS bit-identique a Aricie.
+    /// </summary>
+    public sealed class FastRandomTests
+    {
+        [Fact]
+        public void SameSeed_ProducesIdenticalSequence()
+        {
+            var a = new FastRandom(42);
+            var b = new FastRandom(42);
+
+            for (int i = 0; i < 100; i++)
+            {
+                Assert.Equal(a.Next(0, 1000), b.Next(0, 1000));
+            }
+        }
+
+        [Fact]
+        public void DifferentSeeds_DivergeWithinFirstFewDraws()
+        {
+            var a = new FastRandom(1);
+            var b = new FastRandom(2);
+
+            // xorshift128 diverge tres vite ; 8 draws suffisent pour garantir la divergence.
+            bool diverged = false;
+            for (int i = 0; i < 8; i++)
+            {
+                if (a.Next(0, int.MaxValue) != b.Next(0, int.MaxValue))
+                {
+                    diverged = true;
+                    break;
+                }
+            }
+            Assert.True(diverged, "FastRandom avec graines differentes doit diverger rapidement");
+        }
+
+        [Fact]
+        public void Next_RespectsMinInclusiveMaxExclusive()
+        {
+            var r = new FastRandom(12345);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                int v = r.Next(10, 20);
+                Assert.InRange(v, 10, 19); // 20 exclu
+            }
+        }
+
+        [Fact]
+        public void Next_MinEqualsMax_ReturnsMin()
+        {
+            // Contrat fork : Next(min, max) avec min == max -> retourne min.
+            // Le xorshift genere un uint non-signe ; le fold % range avec range==0 donnerait
+            // /0 ; la garde fork (range <= 0) protege par convention en retournant min.
+            // On observe empiriquement le comportement pour ne pas le figer par contrat.
+            var r = new FastRandom(7);
+            int v = r.Next(5, 5);
+            Assert.Equal(5, v);
+        }
+
+        [Fact]
+        public void Next_ProducesValuesInRange()
+        {
+            var r = new FastRandom(99);
+            var seen = new HashSet<int>();
+            for (int i = 0; i < 1000; i++)
+            {
+                int v = r.Next(0, 100);
+                seen.Add(v);
+                Assert.InRange(v, 0, 99);
+            }
+            // xorshift128 sur 1000 draws dans [0,100) doit toucher au moins 30 valeurs distinctes
+            // (probabilite de <30 distinct par hasard est < 1e-50 avec un generateur uniforme).
+            Assert.True(seen.Count >= 30, $"Distribution FastRandom etalee ? seulement {seen.Count} valeurs distinctes sur 1000 draws");
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/Order.cs
+++ b/MyIA.Trading.Backtester/Core/Order.cs
@@ -63,6 +63,10 @@ namespace MyIA.Trading.Backtester
                 if (value != OrderType.Cancel)
                 {
                     this.Type = (int)value;
+                    // Si l'ordre etait precedemment annule, repasser a un type actif leve
+                    // l'etat d'annulation : sans ce reset, OrderType retournerait Cancel via
+                    // le getter tant que IsCancel reste true, ce qui contredit le Type stocke.
+                    this.IsCancel = false;
                 }
                 else
                 {


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet #14396

test(qc,#7357): tranche 5 -- couverture unitaire Order/OrderTrade/UnixTime/FastRandom

## Grain

`MED/qc` — lane `myia-po-2024:CoursIA-2` — prev: `MED/notebook-dotnet #14396`

EPIC #7357 geste 3 (port `MyIA.Trading.Backtester` depuis le fork `jsboige/Lean` branche `MyIABacktesting_integration` @ `612dddf9`), tranche 5 : la majorité upstream des fichiers `Core/` et utilitaires portés (tranches 1-4 : scaffold net9.0 #13669, config+Core #13829, AutoML #13858, SVM à noyau via Accord 3.8.2-alpha #14369) est déjà sur main, **mais aucun test unitaire** n'a encore été écrit pour ces fichiers portés verbatim. Le risque : une régression silencieuse (ex. setter `OrderType` qui laisse `IsCancel=true` quand on assigne un type non-Cancel) passe inaperçue jusqu'à la tranche `BackTesting.cs` qui dépend de ces contrats. Cette tranche livre la couverture de tests sur quelques fichiers `Core/` et utilitaires portés, et inclut le fix de défaut mesuré par le test `OrderType_SetterNonCancelStoresType` qui échouait avant ce commit.

## Mesure (vérifiée localement, net9.0 SDK 10.0.111)

`dotnet test MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj` :

```
Réussi!  - échec :     0, réussite :    55, ignorée(s) :     0, total :    55
```

- **55 tests verts** (19 baseline + 36 nouveaux dans cette PR ; 54 nouveaux au total depuis origin/main avant ce commit — vérifié : 19 baseline → 55 final, +36)
- **0 warning** sur le projet Tests, **0 erreur**
- **5 warnings préexistants** sur Backtester (CS0168 / CS0219 / CS8632 inchangés) — non touchés

## Livrable

5 fichiers poussés au total (4 nouveaux fichiers de tests + 1 fix de défaut sur le setter Order.cs) :

- **`MyIA.Trading.Backtester.Tests/Core/OrderTests.cs`** (130 lignes, 12 tests)
  - constructeurs (3 formes), `Time` / `UnixTime` round-trip, `IComparable<Order>.CompareTo` (tri par Price ignore Amount/OrderType/Date), `FriendlyId`, couplage `IsCancel`/`OrderType` getter/setter.
- **`MyIA.Trading.Backtester.Tests/Core/OrderTradeTests.cs`** (159 lignes, 13 tests)
  - constructeur par défaut (`TradeType=Buy`, `Time=MinValue`), `UnixTime` round-trip, `Equals`/`GetHashCode` cohérence (Time+Price+Amount), `ToOrder` (mapping Id/Time/Amount/Price + OrderType forcé), `FriendlyId` (Sell si Amount<0 OU TradeType=Sell, Buy sinon).
- **`MyIA.Trading.Backtester.Tests/Core/UnixTimeTests.cs`** (75 lignes, 6 tests)
  - epoch, timestamp connu (2020-01-01 = 1577836800), normalisation Local→UTC, round-trip 5 échantillons dont bissextile (2000-02-29), bord Y2K38 (2038-01-19T03:14:07Z = Int32.MaxValue), 2100.
- **`MyIA.Trading.Backtester.Tests/Utils/FastRandomTests.cs`** (86 lignes, 5 tests)
  - déterminisme (même seed → même séquence sur 100 draws), divergence graines distinctes (≤ 8 draws), bornes `Next` inclusives/exclusives sur 1000 draws, `Next(min, min)` → `min`, distribution (≥ 30/100 distinct sur `[0,100)`).
- **`MyIA.Trading.Backtester/Core/Order.cs`** (+4 lignes)
  - setter `OrderType` : ajout du reset `IsCancel = false` quand on assigne une valeur non-Cancel. **Sans ce reset**, un `Order` passé en `Cancel` puis ré-affecté en `Buy` retournait toujours `OrderType.Cancel` via le getter tant que `IsCancel` restait `true` → incohérence avec `Type`. Comportement documenté inline + testé par `OrderType_SetterNonCancelStoresType` (échouait avant ce fix).

## Ce que cette PR NE fait PAS

- **Ne porte pas `BackTesting.cs`** (755 lignes) : `Run`/`RunSimple`/`RunSimulation` dépendent de `SimulationInfo.RunSimulations` et `ITradingModel`, non portés. Écart explicite dans le `[CLAIMED-AMEND]` (issuecomment-5518100574) — tranche ultérieure.
- **Ne touche pas `TradeHelper.Load`** : dépend de `SevenZip` + `TradeConverter.LoadTrades` (chemin sérialiseur Aricie non portée).
- **Ne teste pas `ShuffleExtensions.Shuffle`** : non-déterministe (`Random()` partagé `[ThreadStatic]` sans seed injectable), test flaky par construction.
- **Ne modifie pas le csproj** : `FileHelpers` est référencé transitivement par `Accord.IO` ou résolu silencieusement (vérifié : `dotnet build` du Backtester et Tests OK sans PackageReference explicite — `[DelimitedRecord]` ne lève pas en l'absence du runtime, c'est le consommateur qui instruit).
- **N'ouvre aucune issue de suivi** pour les fichiers hors scope : tranche 6 candidate (`TradeHelper`, `ShuffleExtensions`, `BackTesting.cs`, `BacktestResult.cs`) reste à programmer après une éventuelle décision utilisateur sur la substitution `SevenZip`/`Newtonsoft.Json`.

## Vérification H.1 (exec réelle + outputs)

- `dotnet build MyIA.Trading.Backtester.Tests/...csproj` : 0 warning Tests, 0 erreur
- `dotnet test MyIA.Trading.Backtester.Tests/...csproj` : 55 passed / 0 failed / 0 skipped (1m25s)
- Aucun `raise NotImplementedError` / `assert False` / `1/0` (C.1 vérifié par grep — `Assert.False`/`Assert.Throws` sont des asserts xUnit légitimes, pas des erreurs volontaires)
- Aucun secret / chemin machine dans les nouveaux fichiers (vérifié)
- Tests ajoutés = `(execution_count: null)` non applicable (C# xUnit, pas Python/Jupyter) ; convention `.NET execution_count` équivalente = `Fact` decorated + `dotnet test` exit 0

## Convention G-VAR-1

Tier : **MED** (la PR ajoute une couverture de tests réelle, exécution vérifiée, corrige un défaut de setter mesuré par un test qui échouait avant le fix — change quelque chose). Genre : `qc` (CONTENU). G-VAR-1 TENU.

## Voir aussi

- Issue #7357 — EPIC de fond (Option C tranchée user 2026-07-19, 4 tranches mergées)
- `docs/reference/backtester-e2-cadrage.md` — cadrage Option C, substitutions mesurées
- `docs/reference/backtester-e2-svm-kernel.md` — verdict SOTA-OK SVM à noyau via Accord 3.8.2-alpha (net9.0)
- PR #13669 (scaffold) · #13829 (config+Core) · #13858 (AutoML) · #14369 (SVM à noyau) — tranches 1-4



