### PR TITLE
fix(ci,#14283): plafonds Quarto 60 min ET PR gate 45 min -- la meme calibration perimee sur les deux

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -112,7 +112,32 @@ jobs:
     # concludes CANCELLED (sweep-recoverable) instead of FAILURE (a red
     # lie). The runner-killed case this ceiling prevents is different: no
     # verdict is printed at all, which stays worth avoiding.
-    timeout-minutes: 35
+    # #14283/#14412: re-measured 2026-09-03 over the 116 completed Quarto
+    # Pages Deploy runs since the self-hosted pool switch. The #11770
+    # calibration is stale -- it was taken on ubuntu-latest, and the
+    # self-hosted pool sits a tier slower: 30 of those 116 runs (26%) exceed
+    # 28 min from run creation, so the bounded wait now expires BELOW the
+    # distribution it was sized to clear. The numbers are right-censored:
+    # Quarto's own 30-min ceiling killed 27 of the 69 runs that were not
+    # concurrency-cancelled (39%), so their true durations are unknown and
+    # any observed p75 is a floor, not a measurement -- the 42 successes
+    # (median 24.9 min, p75 26.4 min) are conditional on surviving that
+    # ceiling, hence biased low. #14412 raises Quarto's ceiling to 60 min,
+    # and raising it ALONE does nothing while this aggregator self-cancels at
+    # 28 waiting for it. Measured on this very PR, both runs from the same
+    # push at 02:34:55Z: PR gate cancelled at 29m23s (03:04:18Z) while its
+    # own Quarto run went on to SUCCEED at 33m10s (03:08:05Z). That is the
+    # whole defect in one pair of timestamps -- the raised Quarto ceiling
+    # worked (under the old 30-min cut that run would have been killed), and
+    # the aggregator threw the PR away 3m47s before the evidence arrived,
+    # because the gate that waits for Quarto carried the same stale ceiling
+    # as the job it waits on. 45 covers the censored mass that sat just above
+    # the old 30-min cut -- and the one uncensored post-fix observation we
+    # have, 33m10s, sits ~12 min inside it -- without widening the budget to
+    # Quarto's full 60; the genuine tail stays on the STARVED -> self-cancel
+    # path (#13510). Worth re-measuring once more uncensored data exists
+    # under the 60-min ceiling.
+    timeout-minutes: 52
     steps:
       - uses: actions/checkout@v4
 
@@ -153,7 +178,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
             --self-name "PR gate" \
-            --timeout-min 28 \
+            --timeout-min 45 \
             --poll-sec 30 \
             --settle-polls 2 \
             $IS_FORK_ARG

--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -72,7 +72,11 @@ jobs:
     # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de
     # l'allowlist.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
-    timeout-minutes: 30
+    # 60 et non 30 depuis #14283 : le meme rendu prend 19-24 min sur
+    # `ubuntu-latest` et 25-31 min sur le pool auto-heberge. Le plafond de 30
+    # etait calibre sur la machine d'avant la bascule ; apres elle, il tombe
+    # AU MILIEU de la distribution et coupe le job a 30 min 19 s.
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -199,7 +203,11 @@ jobs:
     # check_self_hosted_runner_policy.py.
     if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'pull_request'
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
-    timeout-minutes: 30
+    # 60 et non 30 depuis #14283 : le meme rendu prend 19-24 min sur
+    # `ubuntu-latest` et 25-31 min sur le pool auto-heberge. Le plafond de 30
+    # etait calibre sur la machine d'avant la bascule ; apres elle, il tombe
+    # AU MILIEU de la distribution et coupe le job a 30 min 19 s.
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write  # pour poster le commentaire de gate

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -171,7 +171,7 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
 
     # - tranche 5 (#13378/#14283, decision ai-01 2026-09-02) : le solde des
     #   gardes routables. Exclus et pourquoi : pr-gate.yml (agregateur qui
-    #   poll jusqu'a 28 min -- le router reproduirait la famine mesuree en
+    #   poll jusqu'a 45 min -- le router reproduirait la famine mesuree en
     #   #11405), lean-axiom/lean-build (builds Lean sans cache mathlib, cf
     #   #14337 pools specialises), slides-composition-advisory (playwright
     #   --with-deps exige root, le conteneur tourne en uid 1001).


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #14398

## Correctif 14283 — le plafond tombait au milieu de la distribution, pas apres

`Validate Quarto build (PR)` et son jumeau `build` portaient `timeout-minutes: 30`,
calibre du temps ou tous deux tournaient sur `ubuntu-latest`. **Ma propre PR #14391**
les a routes vers `[self-hosted, coursia-ephemeral, coursia-linux]` en mergeant a
**2026-09-02T23:05Z**. La premiere annulation a **30 min 19 s** est tombee a **23:20Z**,
quinze minutes plus tard.

### Mesure — durees du meme job de part et d'autre de la bascule

| Runner | Duree observee | Verdict |
|---|---|---|
| `ubuntu-latest` (avant 23:05Z) | 1158-1432 s — **19 a 24 min** | `success`, sans exception |
| pool auto-heberge (apres 23:05Z) | 1817-1825 s — **30 min pile** | `cancelled` au plafond |
| pool auto-heberge, rescapes | 1513-1713 s — **25 a 28 min** | `success` (5 runs, passes de justesse) |

Le meme rendu Quarto coute **25 a 31 min** sur le pool contre 19 a 24 sur `ubuntu-latest`.
Un plafond de 30 min ne coupe donc pas la queue de distribution : il la coupe **au milieu**.
Environ **80 % des runs** le franchissent, et les 20 % restants ne prouvent rien — ils
mesurent la variance, pas la marge.

### Pourquoi ca n'a pas ete vu tout de suite

Le symptome se rend `cancelled`, pas `failure`. Un `cancelled` se lit spontanement comme du
bruit d'infra — un slot repris, un `cancel-in-progress`, un runner recycle — pas comme une
regression. J'ai d'abord ecarte deux hypotheses avant d'arriver a celle-ci :

- **concurrence** : le groupe est `pages-deploy-${{ github.event_name }}-${{ github.ref }}`,
  donc **par-PR** — une PR n'annule que ses propres runs, pas ceux des voisines ;
- **redemarrage du pool** : les annulations se repartissent **continument** de 23:50Z a
  02:27Z, sans grappe — pas un evenement ponctuel.

Ce qui a tranche est la **constance de la duree** : toutes les annulations tombent a
30 min 19 s ± quelques secondes. Un plafond, pas un incident.

### Portee

**19 des 81 PRs ouvertes** sont bloquees la-dessus a l'instant du recensement (le rouge
visible y est le plus souvent `PR gate`, qui n'est qu'un agregateur : il echoue *parce que*
Quarto est `cancelled`). Liste mesuree : #13891 #14096 #14101 #14106 #14113 #14116 #14117
#14118 #14119 #14121 #14123 #14124 #14127 #14128 #14129 #14131 #14399 #14405 #14409.

### Le correctif -- en deux temps, parce que le premier etait incomplet

**1. Le plafond de Quarto (commit `a1ccf28b6`).** `timeout-minutes: 30` -> `60` sur les
**deux** jobs du pool, avec la mesure consignee en commentaire a cote de la valeur -- pour
que le prochain qui la relise sache sur quelle machine elle a ete calibree. 60 laisse **le
double** de la duree observee la plus longue : c'est un plafond de securite contre un job
vraiment fige, plus une contrainte de debit.

**2. Le plafond du `PR gate` (commit `c4b684eab`).** Le point 1 seul ne debloque **rien**,
et cette PR l'a prouve sur elle-meme.

### Controle positif -- tout le defaut tient dans une paire d'horodatages

Les deux runs partent du **meme push, a la meme seconde** (02:34:55Z) sur le head `a1ccf28b6`,
c'est-a-dire **apres** le correctif 1 :

| Run | Verdict | Fin | Duree |
|---|---|---|---|
| `PR gate` (`33708173197`) | **`cancelled`** | 03:04:18Z | **29 min 23 s** |
| `Quarto Pages Deploy` (`33708173199`) | **`success`** | 03:08:05Z | **33 min 10 s** |

Le correctif 1 **a fonctionne** : sous l'ancienne coupe a 30 min, ce run Quarto aurait ete
tue ; il est alle au bout et a conclu vert. Et la PR est restee rouge quand meme, parce que
l'agregateur **a jete la PR 3 min 47 s avant que la preuve n'arrive**.

L'agregateur qui *attend* Quarto porte la **meme calibration perimee** que le job qu'il
attend : `--timeout-min 28`, dimensionne en #11770 sur le p75 d'`ubuntu-latest` (mesure
2026-08-20 : median 1217 s, p75 1478 s). Monter le plafond de Quarto a 60 pendant que
l'agregateur s'auto-annule a 28 ne change **rien** au verdict de la PR.

Le remede se testait donc dans l'organe reel, sans rien avoir a simuler : tant que le second
volet manquait, cette PR ne **pouvait pas** passer au vert. C'est cette propriete
auto-bloquante qui a servi de controle positif -- pas un argument.

### Re-mesure -- et pourquoi le p75 de #11770 ne se remplace pas par un autre p75

Sur les **116 runs Quarto termines** depuis la bascule :

| Population | n | Ce qu'elle mesure |
|---|---|---|
| succes | 42 | median **24,9 min**, p75 **26,4 min** -- mais **conditionnel a la survie du plafond** |
| tues au plafond (29,5-35,4 min) | 27 | duree reelle **inconnue** (censure a droite) |
| annules par concurrence (< 29,5 min) | 47 | non informatif |

Le 33 min 10 s ci-dessus n'est pas un cas isole. **30 des 116 (26 %) depassent deja 28 min** depuis la creation du run : le budget de #11770
est tombe *sous* la distribution qu'il etait cense couvrir. Et le p75 des succes ne peut pas
le remplacer -- **27 des 69 runs non annules par concurrence (39 %) ont ete tues au
plafond**, donc leur duree vraie est inconnue et tout p75 observe est un **plancher, pas une
mesure**. Le vrai p75 n'est pas mesurable tant que la censure dure : a re-mesurer une fois
que des donnees non censurees existeront sous le plafond de 60.

`--timeout-min 28` -> **45** et `timeout-minutes: 35` -> **52**, en lockstep (les memes 7 min
de marge que #11770 laissait entre le budget du script et le plafond du job -- sans elle, le
runner tue le job avant que le script n'imprime son verdict). 45 couvre la masse censuree qui
siegeait juste au-dessus de la coupe a 30 -- et la seule observation **non censuree**
post-correctif dont on dispose, les 33 min 10 s du tableau, y tient avec 12 min de marge --
**sans** elargir le budget aux 60 min pleins de
Quarto : la queue genuine reste sur le chemin `STARVED` -> auto-annulation de #13510, qui est
concu pour ca (log lisible nommant les constituants, jambe recuperable par le sweep, pas de
rouge mensonger).

Le nom du check requis (`PR gate`) et le `runs-on: ubuntu-latest` sont **inchanges** : le
premier detacherait la protection de branche, le second ferait tenir a l'agregateur un slot
du pool qu'il passe son temps a attendre.

`scripts/ci/check_self_hosted_runner_policy.py` cite ce budget dans sa justification
d'exclusion de `pr-gate.yml` du routage : mis a jour en lockstep (une ligne).

### Variation

`MED/guard` : REPAIR d'une PR `ci`/`guard` (#14391), donc genre herite **META** — cette PR
**ne tient pas** le plancher G-VAR-1 de ma lane, dont la secheresse de contenu reste
declaree et impayee.

Adjacence G-VAR-3 avec #14398 (`guard` egalement) : assumee et declaree ici plutot que
maquillee. Deux raisons, dans cet ordre. (1) **Reparer son propre rouge passe avant tout**
— c'est la seule exception que R5 de `proactive-coordination` place devant le tirage, et
elle est mecanique : personne d'autre que la lane qui a introduit la regression ne peut la
retirer. (2) La substance est **genuinement distincte** : #14398 routait des gardes vers le
pool, celle-ci retire un plafond que cette meme classe de routage a rendu faux. Tenir cette
PR pour respecter une regle d'alternance laisserait 19 PRs gelees — ce serait payer la
variete avec le debit qu'elle est censee servir.

See #14283

