### PR TITLE
feat(gametheory,#11703): GameTheory-08d importe et exécute CGTTour depuis le lake

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-08d-Lean-CGT-Native.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-08d-Lean-CGT-Native.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "1fd93193",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001929,
+     "end_time": "2026-09-03T04:58:43.819786+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:43.817857+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GameTheory 8d - Combinatorial Games natif : le lake `conway_cgt_lean`\n",
     "\n",
@@ -31,7 +40,16 @@
   {
    "cell_type": "markdown",
    "id": "a99d1e7c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001025,
+     "end_time": "2026-09-03T04:58:43.822442+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:43.821417+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -56,11 +74,19 @@
    "id": "1f85dec0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:13:51.113909Z",
-     "iopub.status.busy": "2026-08-23T00:13:51.112908Z",
-     "iopub.status.idle": "2026-08-23T00:17:48.291100Z",
-     "shell.execute_reply": "2026-08-23T00:17:48.289984Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:43.825831Z",
+     "iopub.status.busy": "2026-09-03T04:58:43.825636Z",
+     "iopub.status.idle": "2026-09-03T04:58:52.574649Z",
+     "shell.execute_reply": "2026-09-03T04:58:52.573815Z"
+    },
+    "papermill": {
+     "duration": 8.754395,
+     "end_time": "2026-09-03T04:58:52.577869+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:43.823474+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -77,45 +103,47 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Toutes les importations de la session viennent en tete (convention du kernel) :</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- theorie des jeux, surreals, nimbers, plus les modules des exercices.</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Basic</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Birthday</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Order</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Canonical</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Player</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Surreal<span class=\"bp\">.</span>Basic</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Surreal<span class=\"bp\">.</span>Multiplication</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Surreal<span class=\"bp\">.</span>Division</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Surreal<span class=\"bp\">.</span>Dyadic</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Surreal<span class=\"bp\">.</span>Ordinal</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Nimber<span class=\"bp\">.</span>Basic</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Nimber<span class=\"bp\">.</span>Field</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>Grundy</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Specific<span class=\"bp\">.</span>Nim</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames<span class=\"bp\">.</span>Game<span class=\"bp\">.</span>Specific<span class=\"bp\">.</span>Domineering</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Birthday</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Order</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Canonical</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Player</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Surreal.Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Surreal.Multiplication</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Surreal.Division</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Surreal.Dyadic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Surreal.Ordinal</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Nimber.Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Nimber.Field</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Impartial.Grundy</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Specific.Nim</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CombinatorialGames.Game.Specific.Domineering</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le module de visite du lake lui-meme (section 7) :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>CGTTour</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IGame<span class=\"w\">                    </span><span class=\"c1\">-- le type des pre-jeux concrets</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>{u}<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>(u<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Game<span class=\"w\">                     </span><span class=\"c1\">-- le type quotient des jeux</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Game<span class=\"bp\">.</span>{u}<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>(u<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy<span class=\"w\">   </span><span class=\"c1\">-- la valeur de Grundy d&#39;un jeu impartial</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span>[x<span class=\"bp\">.</span>Impartial]<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"k\">#check</span><span class=\"w\"> </span>IGame<span class=\"w\">                    </span><span class=\"c1\">-- le type des pre-jeux concrets</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>{u}<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>(u<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"k\">#check</span><span class=\"w\"> </span>Game<span class=\"w\">                     </span><span class=\"c1\">-- le type quotient des jeux</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Game<span class=\"bp\">.</span>{u}<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>(u<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"k\">#check</span><span class=\"w\"> </span>IGame.Impartial.grundy<span class=\"w\">   </span><span class=\"c1\">-- la valeur de Grundy d'un jeu impartial</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame.Impartial.grundy<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span>[x.Impartial]<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Toutes les importations de la session viennent en tete (convention du kernel) :\\n-- theorie des jeux, surreals, nimbers, plus les modules des exercices.\\nimport CombinatorialGames.Game.Basic\\nimport CombinatorialGames.Game.Birthday\\nimport CombinatorialGames.Game.Order\\nimport CombinatorialGames.Game.Canonical\\nimport CombinatorialGames.Game.Player\\nimport CombinatorialGames.Surreal.Basic\\nimport CombinatorialGames.Surreal.Multiplication\\nimport CombinatorialGames.Surreal.Division\\nimport CombinatorialGames.Surreal.Dyadic\\nimport CombinatorialGames.Surreal.Ordinal\\nimport CombinatorialGames.Nimber.Basic\\nimport CombinatorialGames.Nimber.Field\\nimport CombinatorialGames.Game.Impartial.Grundy\\nimport CombinatorialGames.Game.Specific.Nim\\nimport CombinatorialGames.Game.Specific.Domineering\\n\\n#check IGame                    -- le type des pre-jeux concrets\\n#check Game                     -- le type quotient des jeux\\n#check IGame.Impartial.grundy   -- la valeur de Grundy d'un jeu impartial\"}</code>\n",
+       "            <code>{\"cmd\": \"-- Toutes les importations de la session viennent en tete (convention du kernel) :\\n-- theorie des jeux, surreals, nimbers, plus les modules des exercices.\\nimport CombinatorialGames.Game.Basic\\nimport CombinatorialGames.Game.Birthday\\nimport CombinatorialGames.Game.Order\\nimport CombinatorialGames.Game.Canonical\\nimport CombinatorialGames.Game.Player\\nimport CombinatorialGames.Surreal.Basic\\nimport CombinatorialGames.Surreal.Multiplication\\nimport CombinatorialGames.Surreal.Division\\nimport CombinatorialGames.Surreal.Dyadic\\nimport CombinatorialGames.Surreal.Ordinal\\nimport CombinatorialGames.Nimber.Basic\\nimport CombinatorialGames.Nimber.Field\\nimport CombinatorialGames.Game.Impartial.Grundy\\nimport CombinatorialGames.Game.Specific.Nim\\nimport CombinatorialGames.Game.Specific.Domineering\\n-- Le module de visite du lake lui-meme (section 7) :\\nimport CGTTour\\n\\n#check IGame                    -- le type des pre-jeux concrets\\n#check Game                     -- le type quotient des jeux\\n#check IGame.Impartial.grundy   -- la valeur de Grundy d'un jeu impartial\"}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
        "            <code>{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 19, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 19, \"column\": 6},\r\n",
-       "   \"data\": \"IGame.{u} : Type (u + 1)\"},\r\n",
-       "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 20, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 20, \"column\": 6},\r\n",
-       "   \"data\": \"Game.{u} : Type (u + 1)\"},\r\n",
-       "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 21, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 21, \"column\": 6},\r\n",
+       "   \"data\": \"IGame.{u} : Type (u + 1)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 22, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 22, \"column\": 6},\r\n",
+       "   \"data\": \"Game.{u} : Type (u + 1)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 23, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 23, \"column\": 6},\r\n",
        "   \"data\": \"IGame.Impartial.grundy.{u_1} (x : IGame) [x.Impartial] : Nimber\"}],\r\n",
        " \"env\": 0}</code>\n",
        "        </details>\n",
@@ -139,6 +167,8 @@
        "import CombinatorialGames.Game.Impartial.Grundy\n",
        "import CombinatorialGames.Game.Specific.Nim\n",
        "import CombinatorialGames.Game.Specific.Domineering\n",
+       "-- Le module de visite du lake lui-meme (section 7) :\n",
+       "import CGTTour\n",
        "\n",
        "#check IGame                    -- le type des pre-jeux concrets\n",
        "──────▶  IGame.{u} : Type (u + 1)\n",
@@ -149,20 +179,20 @@
        "--% env 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Toutes les importations de la session viennent en tete (convention du kernel) :\\n-- theorie des jeux, surreals, nimbers, plus les modules des exercices.\\nimport CombinatorialGames.Game.Basic\\nimport CombinatorialGames.Game.Birthday\\nimport CombinatorialGames.Game.Order\\nimport CombinatorialGames.Game.Canonical\\nimport CombinatorialGames.Game.Player\\nimport CombinatorialGames.Surreal.Basic\\nimport CombinatorialGames.Surreal.Multiplication\\nimport CombinatorialGames.Surreal.Division\\nimport CombinatorialGames.Surreal.Dyadic\\nimport CombinatorialGames.Surreal.Ordinal\\nimport CombinatorialGames.Nimber.Basic\\nimport CombinatorialGames.Nimber.Field\\nimport CombinatorialGames.Game.Impartial.Grundy\\nimport CombinatorialGames.Game.Specific.Nim\\nimport CombinatorialGames.Game.Specific.Domineering\\n\\n#check IGame                    -- le type des pre-jeux concrets\\n#check Game                     -- le type quotient des jeux\\n#check IGame.Impartial.grundy   -- la valeur de Grundy d'un jeu impartial\"}\n",
+       "{\"cmd\": \"-- Toutes les importations de la session viennent en tete (convention du kernel) :\\n-- theorie des jeux, surreals, nimbers, plus les modules des exercices.\\nimport CombinatorialGames.Game.Basic\\nimport CombinatorialGames.Game.Birthday\\nimport CombinatorialGames.Game.Order\\nimport CombinatorialGames.Game.Canonical\\nimport CombinatorialGames.Game.Player\\nimport CombinatorialGames.Surreal.Basic\\nimport CombinatorialGames.Surreal.Multiplication\\nimport CombinatorialGames.Surreal.Division\\nimport CombinatorialGames.Surreal.Dyadic\\nimport CombinatorialGames.Surreal.Ordinal\\nimport CombinatorialGames.Nimber.Basic\\nimport CombinatorialGames.Nimber.Field\\nimport CombinatorialGames.Game.Impartial.Grundy\\nimport CombinatorialGames.Game.Specific.Nim\\nimport CombinatorialGames.Game.Specific.Domineering\\n-- Le module de visite du lake lui-meme (section 7) :\\nimport CGTTour\\n\\n#check IGame                    -- le type des pre-jeux concrets\\n#check Game                     -- le type quotient des jeux\\n#check IGame.Impartial.grundy   -- la valeur de Grundy d'un jeu impartial\"}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 19, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 19, \"column\": 6},\r\n",
-       "   \"data\": \"IGame.{u} : Type (u + 1)\"},\r\n",
-       "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 20, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 20, \"column\": 6},\r\n",
-       "   \"data\": \"Game.{u} : Type (u + 1)\"},\r\n",
-       "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 21, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 21, \"column\": 6},\r\n",
+       "   \"data\": \"IGame.{u} : Type (u + 1)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 22, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 22, \"column\": 6},\r\n",
+       "   \"data\": \"Game.{u} : Type (u + 1)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 23, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 23, \"column\": 6},\r\n",
        "   \"data\": \"IGame.Impartial.grundy.{u_1} (x : IGame) [x.Impartial] : Nimber\"}],\r\n",
        " \"env\": 0}"
       ]
@@ -189,6 +219,8 @@
     "import CombinatorialGames.Game.Impartial.Grundy\n",
     "import CombinatorialGames.Game.Specific.Nim\n",
     "import CombinatorialGames.Game.Specific.Domineering\n",
+    "-- Le module de visite du lake lui-meme (section 7) :\n",
+    "import CGTTour\n",
     "\n",
     "#check IGame                    -- le type des pre-jeux concrets\n",
     "#check Game                     -- le type quotient des jeux\n",
@@ -198,7 +230,16 @@
   {
    "cell_type": "markdown",
    "id": "ccb43730",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00121,
+     "end_time": "2026-09-03T04:58:52.581759+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:52.580549+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture.** Les trois declarations chargées couvrent les trois couches que la\n",
     "suite detaille : le jeu concret (`IGame`), le jeu a l'equivalence pres (`Game`),\n",
@@ -223,11 +264,19 @@
    "id": "860e11da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:48.293442Z",
-     "iopub.status.busy": "2026-08-23T00:17:48.293258Z",
-     "iopub.status.idle": "2026-08-23T00:17:48.745376Z",
-     "shell.execute_reply": "2026-08-23T00:17:48.744481Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:52.585433Z",
+     "iopub.status.busy": "2026-09-03T04:58:52.585259Z",
+     "iopub.status.idle": "2026-09-03T04:58:52.781780Z",
+     "shell.execute_reply": "2026-09-03T04:58:52.780969Z"
+    },
+    "papermill": {
+     "duration": 0.199396,
+     "end_time": "2026-09-03T04:58:52.782347+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:52.582951+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -243,9 +292,9 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le quotient et ses structures :</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>Game<span class=\"bp\">.</span>mk<span class=\"w\">                                </span><span class=\"c1\">-- IGame -&gt; Game (application du quotient)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Game<span class=\"bp\">.</span>mk<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Game</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>AddCommGroupWithOne<span class=\"w\"> </span>Game)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>AddCommGroupWithOne<span class=\"w\"> </span>Game</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>PartialOrder<span class=\"w\"> </span>Game)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>PartialOrder<span class=\"w\"> </span>Game</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Game.mk<span class=\"w\">                                </span><span class=\"c1\">-- IGame -&gt; Game (application du quotient)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Game.mk<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Game</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"k\">#check</span><span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>AddCommGroupWithOne<span class=\"w\"> </span>Game)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>AddCommGroupWithOne<span class=\"w\"> </span>Game</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"k\">#check</span><span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>PartialOrder<span class=\"w\"> </span>Game)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>PartialOrder<span class=\"w\"> </span>Game</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -314,7 +363,16 @@
   {
    "cell_type": "markdown",
    "id": "ea82ecd1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00163,
+     "end_time": "2026-09-03T04:58:52.785535+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:52.783905+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture.** `Game.mk : IGame → Game` applique le quotient ; `Game` porte une\n",
     "structure de groupe abelien ordonne (`AddCommGroupWithOne` + `PartialOrder`) :\n",
@@ -341,11 +399,19 @@
    "id": "39a5b360",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:48.748478Z",
-     "iopub.status.busy": "2026-08-23T00:17:48.748161Z",
-     "iopub.status.idle": "2026-08-23T00:17:48.951808Z",
-     "shell.execute_reply": "2026-08-23T00:17:48.951084Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:52.789312Z",
+     "iopub.status.busy": "2026-09-03T04:58:52.789074Z",
+     "iopub.status.idle": "2026-09-03T04:58:52.949241Z",
+     "shell.execute_reply": "2026-09-03T04:58:52.948349Z"
+    },
+    "papermill": {
+     "duration": 0.163178,
+     "end_time": "2026-09-03T04:58:52.949853+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:52.786675+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -360,10 +426,10 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>Surreal<span class=\"bp\">.</span>mk<span class=\"w\">                            </span><span class=\"c1\">-- IGame -&gt; [Numeric] -&gt; Surreal</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Surreal<span class=\"bp\">.</span>mk<span class=\"w\"> </span>:<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[h<span class=\"w\"> </span>:<span class=\"w\"> </span>x<span class=\"bp\">.</span>Numeric]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>LinearOrder<span class=\"w\"> </span>Surreal)<span class=\"w\">   </span><span class=\"c1\">-- ordre total sur les surreals</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>LinearOrder<span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>Fits<span class=\"bp\">.</span>equiv_of_forall_not_fits<span class=\"w\">    </span><span class=\"c1\">-- theoreme de simplicite</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>Fits<span class=\"bp\">.</span>equiv_of_forall_not_fits<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{x<span class=\"w\"> </span>y<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame}<span class=\"w\"> </span>[x<span class=\"bp\">.</span>Numeric],\n",
-       "<span class=\"w\">  </span>x<span class=\"bp\">.</span>Fits<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>Player),<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>z<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>IGame<span class=\"bp\">.</span>moves<span class=\"w\"> </span>p<span class=\"w\"> </span>x,<span class=\"w\"> </span><span class=\"bp\">¬</span>z<span class=\"bp\">.</span>Fits<span class=\"w\"> </span>y)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Surreal.mk<span class=\"w\">                            </span><span class=\"c1\">-- IGame -&gt; [Numeric] -&gt; Surreal</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Surreal.mk<span class=\"w\"> </span>:<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[h<span class=\"w\"> </span>:<span class=\"w\"> </span>x.Numeric]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"k\">#check</span><span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>LinearOrder<span class=\"w\"> </span>Surreal)<span class=\"w\">   </span><span class=\"c1\">-- ordre total sur les surreals</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>LinearOrder<span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>IGame.Fits.equiv_of_forall_not_fits<span class=\"w\">    </span><span class=\"c1\">-- theoreme de simplicite</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>IGame.Fits.equiv_of_forall_not_fits<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{x<span class=\"w\"> </span>y<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame}<span class=\"w\"> </span>[x.Numeric],\n",
+       "<span class=\"w\">  </span>x.Fits<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>Player),<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>z<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>IGame.moves<span class=\"w\"> </span>p<span class=\"w\"> </span>x,<span class=\"w\"> </span><span class=\"bp\">¬</span>z.Fits<span class=\"w\"> </span>y)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span>y</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -433,7 +499,16 @@
   {
    "cell_type": "markdown",
    "id": "a1d2bade",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00121,
+     "end_time": "2026-09-03T04:58:52.952538+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:52.951328+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture.** `Surreal.mk` requiert une preuve `Numeric` : on ne quotientte que\n",
     "les jeux numeriques. `equiv_of_forall_not_fits` est le theoreme de simplicite —\n",
@@ -453,11 +528,19 @@
    "id": "09605eba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:48.954090Z",
-     "iopub.status.busy": "2026-08-23T00:17:48.953945Z",
-     "iopub.status.idle": "2026-08-23T00:17:49.121365Z",
-     "shell.execute_reply": "2026-08-23T00:17:49.120706Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:52.955976Z",
+     "iopub.status.busy": "2026-09-03T04:58:52.955839Z",
+     "iopub.status.idle": "2026-09-03T04:58:53.123412Z",
+     "shell.execute_reply": "2026-09-03T04:58:53.122513Z"
+    },
+    "papermill": {
+     "duration": 0.170261,
+     "end_time": "2026-09-03T04:58:53.123963+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:52.953702+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -472,9 +555,9 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>CommRing<span class=\"w\"> </span>Surreal)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>CommRing<span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>Dyadic<span class=\"bp\">.</span>toIGame<span class=\"w\">        </span><span class=\"c1\">-- plongement : rationnel dyadique -&gt; IGame</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Dyadic<span class=\"bp\">.</span>toIGame<span class=\"w\"> </span>:<span class=\"w\"> </span>Dyadic<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>IGame</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>NatOrdinal<span class=\"bp\">.</span>toSurreal<span class=\"w\">  </span><span class=\"c1\">-- plongement : NatOrdinal -&gt;o Surreal</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> NatOrdinal<span class=\"bp\">.</span>toSurreal<span class=\"w\"> </span>:<span class=\"w\"> </span>NatOrdinal<span class=\"w\"> </span><span class=\"bp\">↪</span>o<span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"k\">#check</span><span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>CommRing<span class=\"w\"> </span>Surreal)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>CommRing<span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Dyadic.toIGame<span class=\"w\">        </span><span class=\"c1\">-- plongement : rationnel dyadique -&gt; IGame</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Dyadic.toIGame<span class=\"w\"> </span>:<span class=\"w\"> </span>Dyadic<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>IGame</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>NatOrdinal.toSurreal<span class=\"w\">  </span><span class=\"c1\">-- plongement : NatOrdinal -&gt;o Surreal</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> NatOrdinal.toSurreal<span class=\"w\"> </span>:<span class=\"w\"> </span>NatOrdinal<span class=\"w\"> </span><span class=\"bp\">↪</span>o<span class=\"w\"> </span>Surreal</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -541,7 +624,16 @@
   {
    "cell_type": "markdown",
    "id": "5c3c123b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001622,
+     "end_time": "2026-09-03T04:58:53.127200+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.125578+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture.** `Dyadic.toIGame` realise 1/2, 3/4, ... comme jeux ; le theoreme\n",
     "d'anniversaire fini (module `Surreal.Dyadic`) dit que ce sont exactement les\n",
@@ -563,11 +655,19 @@
    "id": "5ef43d72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:49.123618Z",
-     "iopub.status.busy": "2026-08-23T00:17:49.123487Z",
-     "iopub.status.idle": "2026-08-23T00:17:49.342915Z",
-     "shell.execute_reply": "2026-08-23T00:17:49.340964Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:53.131049Z",
+     "iopub.status.busy": "2026-09-03T04:58:53.130877Z",
+     "iopub.status.idle": "2026-09-03T04:58:53.297873Z",
+     "shell.execute_reply": "2026-09-03T04:58:53.297239Z"
+    },
+    "papermill": {
+     "duration": 0.169789,
+     "end_time": "2026-09-03T04:58:53.298386+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.128597+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -582,9 +682,9 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>Nimber<span class=\"bp\">.</span>add_def<span class=\"w\">           </span><span class=\"c1\">-- definition de l&#39;addition par mex</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Nimber<span class=\"bp\">.</span>add_def<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber),<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>sInf<span class=\"w\"> </span>{x<span class=\"w\"> </span><span class=\"bp\">|</span><span class=\"w\"> </span>(<span class=\"bp\">∃</span><span class=\"w\"> </span>a&#39;<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a,<span class=\"w\"> </span>a&#39;<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>x)<span class=\"w\"> </span><span class=\"bp\">∨</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>b&#39;<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b&#39;<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>x}<span class=\"bp\">ᶜ</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>Nimber<span class=\"bp\">.</span>exists_of_lt_add<span class=\"w\">  </span><span class=\"c1\">-- reciproque : toute valeur plus petite est atteinte</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Nimber<span class=\"bp\">.</span>exists_of_lt_add<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber},<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∃</span><span class=\"w\"> </span>a&#39;<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a,<span class=\"w\"> </span>a&#39;<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>c)<span class=\"w\"> </span><span class=\"bp\">∨</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>b&#39;<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b&#39;<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>c</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>Field<span class=\"w\"> </span>Nimber)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>Field<span class=\"w\"> </span>Nimber</blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Nimber.add_def<span class=\"w\">           </span><span class=\"c1\">-- definition de l'addition par mex</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Nimber.add_def<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber),<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>sInf<span class=\"w\"> </span>{x<span class=\"w\"> </span><span class=\"bp\">|</span><span class=\"w\"> </span>(<span class=\"bp\">∃</span><span class=\"w\"> </span>a'<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a,<span class=\"w\"> </span>a'<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>x)<span class=\"w\"> </span><span class=\"bp\">∨</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>b'<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b'<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>x}<span class=\"bp\">ᶜ</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Nimber.exists_of_lt_add<span class=\"w\">  </span><span class=\"c1\">-- reciproque : toute valeur plus petite est atteinte</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Nimber.exists_of_lt_add<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber},<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∃</span><span class=\"w\"> </span>a'<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>a,<span class=\"w\"> </span>a'<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>c)<span class=\"w\"> </span><span class=\"bp\">∨</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>b'<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b'<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>c</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"k\">#check</span><span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>Field<span class=\"w\"> </span>Nimber)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>Field<span class=\"w\"> </span>Nimber</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -655,7 +755,16 @@
   {
    "cell_type": "markdown",
    "id": "38156d43",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001465,
+     "end_time": "2026-09-03T04:58:53.301508+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.300043+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture.** `Field Nimber` : les nimbers forment un corps de **caracteristique 2**\n",
     "(chaque element est son propre oppose). L'objectif a long terme du projet upstream\n",
@@ -677,11 +786,19 @@
    "id": "853e15ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:49.346947Z",
-     "iopub.status.busy": "2026-08-23T00:17:49.346692Z",
-     "iopub.status.idle": "2026-08-23T00:17:49.522050Z",
-     "shell.execute_reply": "2026-08-23T00:17:49.521242Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:53.304952Z",
+     "iopub.status.busy": "2026-09-03T04:58:53.304828Z",
+     "iopub.status.idle": "2026-09-03T04:58:53.456904Z",
+     "shell.execute_reply": "2026-09-03T04:58:53.456329Z"
+    },
+    "papermill": {
+     "duration": 0.154755,
+     "end_time": "2026-09-03T04:58:53.457631+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.302876+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -696,11 +813,11 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>nim<span class=\"w\">                                  </span><span class=\"c1\">-- Nimber -&gt; IGame : le jeu de nim a un tas</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>nim<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>IGame</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy<span class=\"w\">                     </span><span class=\"c1\">-- la valeur de Grundy d&#39;un jeu impartial</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy<span class=\"w\"> </span>:<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[x<span class=\"bp\">.</span>Impartial]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Nimber</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>nim_grundy_equiv<span class=\"w\">           </span><span class=\"c1\">-- SPRAGUE-GRUNDY : nim (grundy x) ≈ x</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>nim_grundy_equiv<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>x<span class=\"bp\">.</span>Impartial],<span class=\"w\"> </span>IGame<span class=\"bp\">.</span>nim<span class=\"w\"> </span>(IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy<span class=\"w\"> </span>x)<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>nim_add_equiv<span class=\"w\">                        </span><span class=\"c1\">-- nim a + nim b ≈ nim (a + b)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame<span class=\"bp\">.</span>nim_add_equiv<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber),<span class=\"w\"> </span>IGame<span class=\"bp\">.</span>nim<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>IGame<span class=\"bp\">.</span>nim<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span>IGame<span class=\"bp\">.</span>nim<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy_eq_zero_iff<span class=\"w\">         </span><span class=\"c1\">-- grundy x = 0 ↔ x ≈ 0 (P-positions)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy_eq_zero_iff<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>x<span class=\"bp\">.</span>Impartial],<span class=\"w\"> </span>IGame<span class=\"bp\">.</span>Impartial<span class=\"bp\">.</span>grundy<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>IGame.nim<span class=\"w\">                                  </span><span class=\"c1\">-- Nimber -&gt; IGame : le jeu de nim a un tas</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame.nim<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>IGame</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>IGame.Impartial.grundy<span class=\"w\">                     </span><span class=\"c1\">-- la valeur de Grundy d'un jeu impartial</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame.Impartial.grundy<span class=\"w\"> </span>:<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[x.Impartial]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Nimber</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>IGame.Impartial.nim_grundy_equiv<span class=\"w\">           </span><span class=\"c1\">-- SPRAGUE-GRUNDY : nim (grundy x) ≈ x</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame.Impartial.nim_grundy_equiv<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame)<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>x.Impartial],<span class=\"w\"> </span>IGame.nim<span class=\"w\"> </span>(IGame.Impartial.grundy<span class=\"w\"> </span>x)<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>IGame.nim_add_equiv<span class=\"w\">                        </span><span class=\"c1\">-- nim a + nim b ≈ nim (a + b)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> IGame.nim_add_equiv<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nimber),<span class=\"w\"> </span>IGame.nim<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>IGame.nim<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span>IGame.nim<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>IGame.Impartial.grundy_eq_zero_iff<span class=\"w\">         </span><span class=\"c1\">-- grundy x = 0 ↔ x ≈ 0 (P-positions)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>IGame.Impartial.grundy_eq_zero_iff<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{x<span class=\"w\"> </span>:<span class=\"w\"> </span>IGame}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>x.Impartial],<span class=\"w\"> </span>IGame.Impartial.grundy<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≈</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -795,7 +912,16 @@
   {
    "cell_type": "markdown",
    "id": "afd967f5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003398,
+     "end_time": "2026-09-03T04:58:53.462606+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.459208+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture.** Les trois enonces se lisent ensemble :\n",
     "\n",
@@ -821,11 +947,19 @@
    "id": "e1aba92a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:49.524722Z",
-     "iopub.status.busy": "2026-08-23T00:17:49.524596Z",
-     "iopub.status.idle": "2026-08-23T00:17:49.714127Z",
-     "shell.execute_reply": "2026-08-23T00:17:49.713297Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:53.470417Z",
+     "iopub.status.busy": "2026-09-03T04:58:53.470270Z",
+     "iopub.status.idle": "2026-09-03T04:58:53.621330Z",
+     "shell.execute_reply": "2026-09-03T04:58:53.620545Z"
+    },
+    "papermill": {
+     "duration": 0.157906,
+     "end_time": "2026-09-03T04:58:53.621906+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.464000+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -840,14 +974,14 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : quelle est la base d&#39;axiomes de Sprague-Grundy ?</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : quelle est la base d'axiomes de Sprague-Grundy ?</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Decommentez et executez :</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #print axioms IGame.Impartial.nim_grundy_equiv</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Indice : attendez-vous au triplet standard de Mathlib (propext, Classical.choice,</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Quot.sound) — et a AUCUN sorryAx.</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>True<span class=\"w\"> </span>:=<span class=\"w\"> </span>trivial<span class=\"w\">    </span><span class=\"c1\">-- cellule neutre tant que la solution est commentee</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>True<span class=\"w\"> </span>:=<span class=\"w\"> </span>trivial<span class=\"w\">    </span><span class=\"c1\">-- cellule neutre tant que la solution est commentee</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -898,11 +1032,19 @@
    "id": "12b60c8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:49.716335Z",
-     "iopub.status.busy": "2026-08-23T00:17:49.716217Z",
-     "iopub.status.idle": "2026-08-23T00:17:49.884410Z",
-     "shell.execute_reply": "2026-08-23T00:17:49.883650Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:53.627109Z",
+     "iopub.status.busy": "2026-09-03T04:58:53.626977Z",
+     "iopub.status.idle": "2026-09-03T04:58:53.776843Z",
+     "shell.execute_reply": "2026-09-03T04:58:53.776076Z"
+    },
+    "papermill": {
+     "duration": 0.154151,
+     "end_time": "2026-09-03T04:58:53.777800+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.623649+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -925,10 +1067,10 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #check IGame.Domineering.right    -- les coups du joueur Droite (dominos horizontaux)</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Indice : left/right ne sont PAS symetriques — contrairement au Nim de 8b,</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Domineering est partizan : c&#39;est exactement pour ca que IGame distingue</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- les deux ensembles d&#39;options.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Domineering est partizan : c'est exactement pour ca que IGame distingue</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- les deux ensembles d'options.</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>True<span class=\"w\"> </span>:=<span class=\"w\"> </span>trivial<span class=\"w\">    </span><span class=\"c1\">-- cellule neutre tant que la solution est commentee</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>True<span class=\"w\"> </span>:=<span class=\"w\"> </span>trivial<span class=\"w\">    </span><span class=\"c1\">-- cellule neutre tant que la solution est commentee</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -987,11 +1129,19 @@
    "id": "5adff0fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T00:17:49.887301Z",
-     "iopub.status.busy": "2026-08-23T00:17:49.887153Z",
-     "iopub.status.idle": "2026-08-23T00:17:50.061374Z",
-     "shell.execute_reply": "2026-08-23T00:17:50.060748Z"
-    }
+     "iopub.execute_input": "2026-09-03T04:58:53.784538Z",
+     "iopub.status.busy": "2026-09-03T04:58:53.784415Z",
+     "iopub.status.idle": "2026-09-03T04:58:53.929913Z",
+     "shell.execute_reply": "2026-09-03T04:58:53.929273Z"
+    },
+    "papermill": {
+     "duration": 0.150731,
+     "end_time": "2026-09-03T04:58:53.930482+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.779751+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1006,15 +1156,15 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : l&#39;anniversaire du nim. Le module Specific.Nim demontre que le</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- nim de taille o a exactement l&#39;anniversaire o. Decommentez et executez :</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : l'anniversaire du nim. Le module Specific.Nim demontre que le</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- nim de taille o a exactement l'anniversaire o. Decommentez et executez :</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #check @IGame.birthday_nim</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Indice : rapprochez du theoreme dyadique de la section 3 — l&#39;anniversaire</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- mesure la profondeur de l&#39;arbre de jeu, et le nim a un tas est l&#39;arbre le</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- plus simple d&#39;anniversaire donne.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Indice : rapprochez du theoreme dyadique de la section 3 — l'anniversaire</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- mesure la profondeur de l'arbre de jeu, et le nim a un tas est l'arbre le</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- plus simple d'anniversaire donne.</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>True<span class=\"w\"> </span>:=<span class=\"w\"> </span>trivial<span class=\"w\">    </span><span class=\"c1\">-- cellule neutre tant que la solution est commentee</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>True<span class=\"w\"> </span>:=<span class=\"w\"> </span>trivial<span class=\"w\">    </span><span class=\"c1\">-- cellule neutre tant que la solution est commentee</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -1063,8 +1213,165 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cgt-tour-intro",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001872,
+     "end_time": "2026-09-03T04:58:53.934329+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.932457+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Le module de visite `CGTTour`, chargé depuis le lake\n",
+    "\n",
+    "La section 1 présentait `CGTTour` comme le module de visite du lake\n",
+    "`conway_cgt_lean`. Sa vraie nature est double : un **agrégateur** — ses douze\n",
+    "`import CombinatorialGames.*` rendent toute la théorie disponible en une\n",
+    "seule ligne, celle chargée en tête de session — et une **lecture guidée** :\n",
+    "le fichier `.lean` n'ajoute aucune déclaration, il documente chaque résultat\n",
+    "et l'accompagne d'un `#check`. Les sections 2 à 5 de ce notebook ont rejoué\n",
+    "ces checks une à une.\n",
+    "\n",
+    "Reste ce que la visite n'embarque pas : le **certificat d'axiomes**. Les deux\n",
+    "théorèmes phares — le théorème de simplicité et l'addition de nim par mex —\n",
+    "sont-ils prouvés, ou simplement énoncés ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cgt-tour-axioms",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T04:58:53.938299Z",
+     "iopub.status.busy": "2026-09-03T04:58:53.938137Z",
+     "iopub.status.idle": "2026-09-03T04:58:54.095078Z",
+     "shell.execute_reply": "2026-09-03T04:58:54.094314Z"
+    },
+    "papermill": {
+     "duration": 0.159553,
+     "end_time": "2026-09-03T04:58:54.095529+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:53.935976+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le certificat d'axiomes que la visite n'embarque pas :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- sur quoi les deux théorèmes phares reposent-ils ?</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>IGame.Fits.equiv_of_forall_not_fits<span class=\"w\">   </span><span class=\"c1\">-- theoreme de simplicite</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>IGame.Fits.equiv_of_forall_not_fits'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>Nimber.add_def<span class=\"w\">                        </span><span class=\"c1\">-- addition de nim par mex</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>Nimber.add_def'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Le certificat d'axiomes que la visite n'embarque pas :\\n-- sur quoi les deux th\\u00e9or\\u00e8mes phares reposent-ils ?\\n#print axioms IGame.Fits.equiv_of_forall_not_fits   -- theoreme de simplicite\\n#print axioms Nimber.add_def                        -- addition de nim par mex\", \"env\": 8}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'IGame.Fits.equiv_of_forall_not_fits' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Nimber.add_def' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 9}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Le certificat d'axiomes que la visite n'embarque pas :\n",
+       "-- sur quoi les deux théorèmes phares reposent-ils ?\n",
+       "#print axioms IGame.Fits.equiv_of_forall_not_fits   -- theoreme de simplicite\n",
+       "──────▶  'IGame.Fits.equiv_of_forall_not_fits' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms Nimber.add_def                        -- addition de nim par mex\n",
+       "──────▶  'Nimber.add_def' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 9\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Le certificat d'axiomes que la visite n'embarque pas :\\n-- sur quoi les deux th\\u00e9or\\u00e8mes phares reposent-ils ?\\n#print axioms IGame.Fits.equiv_of_forall_not_fits   -- theoreme de simplicite\\n#print axioms Nimber.add_def                        -- addition de nim par mex\", \"env\": 8}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'IGame.Fits.equiv_of_forall_not_fits' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Nimber.add_def' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 9}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Le certificat d'axiomes que la visite n'embarque pas :\n",
+    "-- sur quoi les deux théorèmes phares reposent-ils ?\n",
+    "#print axioms IGame.Fits.equiv_of_forall_not_fits   -- theoreme de simplicite\n",
+    "#print axioms Nimber.add_def                        -- addition de nim par mex"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cgt-tour-lecture",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003491,
+     "end_time": "2026-09-03T04:58:54.100865+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:54.097374+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Chaque `#print axioms` rend le même triplet — `propext`,\n",
+    "`Classical.choice`, `Quot.sound` — les trois axiomes standard de Lean : la\n",
+    "chaîne de preuve traverse CombinatorialGames sans `sorryAx` ni\n",
+    "`native_decide`. La promesse de la section 1 est maintenant littéralement\n",
+    "tenue : ce notebook importe et exécute le module de visite depuis les\n",
+    "oleans du lake."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4f866474",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001467,
+     "end_time": "2026-09-03T04:58:54.103824+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T04:58:54.102357+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -1096,10 +1403,22 @@
    "name": "lean4-wsl"
   },
   "language_info": {
-   "codemirror_mode": "lean4",
+   "codemirror_mode": "python",
    "file_extension": ".lean",
    "mimetype": "text/x-lean4",
    "name": "lean4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 17.011293,
+   "end_time": "2026-09-03T04:58:54.422147+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-08d-Lean-CGT-Native.ipynb",
+   "output_path": "GameTheory-08d-Lean-CGT-Native_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-03T04:58:37.410854+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: DEEP/notebook-lean — lane myia-po-2027:CoursIA — prev: MED/tooling #14351

## Livrable

`GameTheory-08d-Lean-CGT-Native.ipynb` importe et exécute désormais le module racine `CGTTour` du lake `conway_cgt_lean` : le notebook réalise enfin littéralement la phrase de sa section 1 (« ... un module de visite, `CGTTour`, dont ce notebook est l'exécution interactive »). See #11703 (sous-grain d'exposition ; l'EPIC reste ouverte).

### Changements (notebook seul — 0 fichier `.lean` modifié, lake byte-identique à main)

1. **Cellule d'imports (première cellule code)** : `import CGTTour` ajouté, avec un commentaire le reliant à la section 7 (convention imports-en-tête du kernel respectée).
2. **Nouvelle section 7** « Le module de visite `CGTTour`, chargé depuis le lake » — 3 cellules insérées entre l'Exercice 3 et la Conclusion :
   - **intro** : la vraie nature double de `CGTTour` — **agrégateur** (ses douze `import CombinatorialGames.*` rendent toute la théorie disponible en une seule ligne, celle chargée en tête de session) et **lecture guidée** (le `.lean` n'ajoute aucune déclaration : chaque résultat documenté est accompagné d'un `#check`, ceux-là mêmes que les sections 2 à 5 ont rejoués) ;
   - **code** : le **certificat d'axiomes** que la visite n'embarque pas — `#print axioms IGame.Fits.equiv_of_forall_not_fits` (théorème de simplicité) et `#print axioms Nimber.add_def` (addition de nim par mex) ;
   - **lecture** : les deux théorèmes reposent sur le triplet standard (`propext`, `Classical.choice`, `Quot.sound`) — zéro `sorryAx`, zéro `native_decide`.

### Pourquoi ce grain

#11703 : les notebooks citent en prose des lakes Lean sans jamais les importer — `08d` citait `CGTTour` (x2) et `conway_cgt_lean` (x5) mais le module n'était jamais chargé. Le lake `conway_cgt_lean` n'avait aucun consommateur in-kernel dans tout le dépôt.

## Exécution réelle (H.1 — preuves)

- `lake build` du lake **as pinned** (toolchain `v4.31.0-rc2`, CombinatorialGames `@3c6dcdbc`, mathlib transitif) : `Build completed successfully (1674 jobs)`, exit 0 — miroir WSL en FS natif `~/lean-projects/lakeroot/GameTheory/conway_cgt_lean` (miroir obligatoire : REPL crash sur import DrvFS `/mnt/c`).
- Pré-vérification compilateur (`lake env lean`) : `import CGTTour` + `#check @Game.mk` rend `Game.mk : IGame → Game` — la chaîne oleans est saine.
- papermill (kernel `lean4-wsl`, cwd = racine du lake) : **exit 0** — 21 cellules, 10 cellules code `ec=1..10` monotones, 0 erreur, 0 `❌` (le style d'output « flèche + Raw input/output » est celui des cellules déjà committées sur main).
- Sorties réelles de la cellule certificat (extrait verbatim) :
  ```
  'IGame.Fits.equiv_of_forall_not_fits' depends on axioms: [propext, Classical.choice, Quot.sound]
  'Nimber.add_def'                        depends on axioms: [propext, Classical.choice, Quot.sound]
  ```

## Env — réparations locales (règle F, non committées)

- REPL matché `repl-4.31.0-rc2` rebuildé **proprement** depuis le tag (le premier build avait silencieusement produit un repl v4.32.1 version-skewé : checkout bloqué par un `lean-toolchain` résiduel modifié — la classe d'incident documentée dans `setup_native_lean4_import.py` ; rebuild avec vérification `HEAD == tag`).
- Kernelspec `lean4-wsl` **natif** enregistré dans WSL (`~/.local/share/jupyter/kernels/lean4-wsl`) : appel direct du wrapper, sans le saut `wsl.exe` — le saut ne propage pas un cwd FS-natif (le kernel héritait de `/mnt/c/dev/CoursIA` et tombait sur le stub vide `notebook_context`, d'où LEAN_PATH vide).
- Mapping `repl.py` du venv : entrée `v4.31.0-rc2` ajoutée (site-packages).
- Follow-up non bloquant : `REPL_TOOLCHAIN_TAGS` de `scripts/lean/setup_native_lean4_import.py` ne connaît pas `v4.31.0-rc2` (le sous-ensemble rc1/rc2 taggé du repo repl contient pourtant le tag direct) — `build-repl v4.31.0-rc2` via le script est aujourd'hui refusé.

## Validation

- Section B (Lean) : **N/A** — aucun fichier `.lean` modifié ; le compte de `sorry` du lake est inchangé (byte-identique à main).
- SOTA : **SOTA-OK** — le module réel du lake est importé et ses théorèmes certifiés depuis les oleans compilés du pin, pas une réimplémentation.
- `check_exec_sequence.py --tracked-only` : **CLEAN** ; grep `raise NotImplementedError|assert False|1/0` : 0 hit ; pre-commit H.3 (notebook non-exécuté) : **Passed** (commit 1989cb0db585, hooks 13/13).
- `git diff --stat` : 1 fichier, +435/−116 (notebook seul).
