### PR TITLE
feat(notebook-lean,#11703): Search-09d exécute la machinerie prouvée discrepancy_lean (Beck-Fiala b1-b4 + Erdos-Spencer p1a-p4)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-09d-Lean-Discrepancy-Komlos.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-09d-Lean-Discrepancy-Komlos.ipynb
@@ -5,10 +5,10 @@
    "id": "f779357e",
    "metadata": {
     "papermill": {
-     "duration": 0.008096,
-     "end_time": "2026-08-31T20:36:46.304890+00:00",
+     "duration": 0.003455,
+     "end_time": "2026-09-03T05:21:20.759833+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:36:46.296794+00:00",
+     "start_time": "2026-09-03T05:21:20.756378+00:00",
      "status": "completed"
     },
     "tags": []
@@ -51,10 +51,10 @@
    "id": "07a4c523",
    "metadata": {
     "papermill": {
-     "duration": 0.004976,
-     "end_time": "2026-08-31T20:36:46.315987+00:00",
+     "duration": 0.002634,
+     "end_time": "2026-09-03T05:21:20.777613+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:36:46.311011+00:00",
+     "start_time": "2026-09-03T05:21:20.774979+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "0de98741",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:36:46.330633Z",
-     "iopub.status.busy": "2026-08-31T20:36:46.330269Z",
-     "iopub.status.idle": "2026-08-31T20:41:26.495321Z",
-     "shell.execute_reply": "2026-08-31T20:41:26.478333Z"
+     "iopub.execute_input": "2026-09-03T05:21:20.783638Z",
+     "iopub.status.busy": "2026-09-03T05:21:20.783337Z",
+     "iopub.status.idle": "2026-09-03T05:22:13.198106Z",
+     "shell.execute_reply": "2026-09-03T05:22:13.188828Z"
     },
     "papermill": {
-     "duration": 280.458095,
-     "end_time": "2026-08-31T20:41:26.780397+00:00",
+     "duration": 52.591802,
+     "end_time": "2026-09-03T05:22:13.371013+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:36:46.322302+00:00",
+     "start_time": "2026-09-03T05:21:20.779211+00:00",
      "status": "completed"
     },
     "tags": []
@@ -117,11 +117,17 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Discrepancy.Komlos</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- La machinerie prouvee du lake, interrogee en section 6 :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Discrepancy.Kernel</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Discrepancy.Partial</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Discrepancy.Progress</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Discrepancy.BeckFiala</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Discrepancy.ErdosSpencer</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"import Discrepancy.Komlos\"}</code>\n",
+       "            <code>{\"cmd\": \"import Discrepancy.Komlos\\n-- La machinerie prouvee du lake, interrogee en section 6 :\\nimport Discrepancy.Kernel\\nimport Discrepancy.Partial\\nimport Discrepancy.Progress\\nimport Discrepancy.BeckFiala\\nimport Discrepancy.ErdosSpencer\"}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -131,10 +137,16 @@
       ],
       "text/plain": [
        "import Discrepancy.Komlos\n",
+       "-- La machinerie prouvee du lake, interrogee en section 6 :\n",
+       "import Discrepancy.Kernel\n",
+       "import Discrepancy.Partial\n",
+       "import Discrepancy.Progress\n",
+       "import Discrepancy.BeckFiala\n",
+       "import Discrepancy.ErdosSpencer\n",
        "--% env 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"import Discrepancy.Komlos\"}\n",
+       "{\"cmd\": \"import Discrepancy.Komlos\\n-- La machinerie prouvee du lake, interrogee en section 6 :\\nimport Discrepancy.Kernel\\nimport Discrepancy.Partial\\nimport Discrepancy.Progress\\nimport Discrepancy.BeckFiala\\nimport Discrepancy.ErdosSpencer\"}\n",
        "Raw output:\n",
        "{\"env\": 0}"
       ]
@@ -144,7 +156,13 @@
     }
    ],
    "source": [
-    "import Discrepancy.Komlos"
+    "import Discrepancy.Komlos\n",
+    "-- La machinerie prouvee du lake, interrogee en section 6 :\n",
+    "import Discrepancy.Kernel\n",
+    "import Discrepancy.Partial\n",
+    "import Discrepancy.Progress\n",
+    "import Discrepancy.BeckFiala\n",
+    "import Discrepancy.ErdosSpencer"
    ]
   },
   {
@@ -152,10 +170,10 @@
    "id": "0eff5c27",
    "metadata": {
     "papermill": {
-     "duration": 0.016007,
-     "end_time": "2026-08-31T20:41:26.829338+00:00",
+     "duration": 0.005485,
+     "end_time": "2026-09-03T05:22:13.397948+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:26.813331+00:00",
+     "start_time": "2026-09-03T05:22:13.392463+00:00",
      "status": "completed"
     },
     "tags": []
@@ -173,16 +191,16 @@
    "id": "0c29f129",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:26.884667Z",
-     "iopub.status.busy": "2026-08-31T20:41:26.881489Z",
-     "iopub.status.idle": "2026-08-31T20:41:27.747420Z",
-     "shell.execute_reply": "2026-08-31T20:41:27.744692Z"
+     "iopub.execute_input": "2026-09-03T05:22:13.419624Z",
+     "iopub.status.busy": "2026-09-03T05:22:13.418949Z",
+     "iopub.status.idle": "2026-09-03T05:22:14.055300Z",
+     "shell.execute_reply": "2026-09-03T05:22:14.053110Z"
     },
     "papermill": {
-     "duration": 0.914645,
-     "end_time": "2026-08-31T20:41:27.753501+00:00",
+     "duration": 0.655867,
+     "end_time": "2026-09-03T05:22:14.056310+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:26.838856+00:00",
+     "start_time": "2026-09-03T05:22:13.400443+00:00",
      "status": "completed"
     },
     "tags": []
@@ -344,10 +362,10 @@
    "id": "9cfff9e2",
    "metadata": {
     "papermill": {
-     "duration": 0.004027,
-     "end_time": "2026-08-31T20:41:27.766368+00:00",
+     "duration": 0.00181,
+     "end_time": "2026-09-03T05:22:14.064141+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:27.762341+00:00",
+     "start_time": "2026-09-03T05:22:14.062331+00:00",
      "status": "completed"
     },
     "tags": []
@@ -382,10 +400,10 @@
    "id": "c3b6409d",
    "metadata": {
     "papermill": {
-     "duration": 0.004585,
-     "end_time": "2026-08-31T20:41:27.775100+00:00",
+     "duration": 0.001377,
+     "end_time": "2026-09-03T05:22:14.067083+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:27.770515+00:00",
+     "start_time": "2026-09-03T05:22:14.065706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -405,16 +423,16 @@
    "id": "cb0da49f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:27.790589Z",
-     "iopub.status.busy": "2026-08-31T20:41:27.790300Z",
-     "iopub.status.idle": "2026-08-31T20:41:28.219695Z",
-     "shell.execute_reply": "2026-08-31T20:41:28.217520Z"
+     "iopub.execute_input": "2026-09-03T05:22:14.072281Z",
+     "iopub.status.busy": "2026-09-03T05:22:14.072098Z",
+     "iopub.status.idle": "2026-09-03T05:22:14.466912Z",
+     "shell.execute_reply": "2026-09-03T05:22:14.464765Z"
     },
     "papermill": {
-     "duration": 0.439712,
-     "end_time": "2026-08-31T20:41:28.220810+00:00",
+     "duration": 0.398793,
+     "end_time": "2026-09-03T05:22:14.467752+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:27.781098+00:00",
+     "start_time": "2026-09-03T05:22:14.068959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -539,10 +557,10 @@
    "id": "f3773d33",
    "metadata": {
     "papermill": {
-     "duration": 0.003043,
-     "end_time": "2026-08-31T20:41:28.228529+00:00",
+     "duration": 0.00232,
+     "end_time": "2026-09-03T05:22:14.474001+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.225486+00:00",
+     "start_time": "2026-09-03T05:22:14.471681+00:00",
      "status": "completed"
     },
     "tags": []
@@ -571,10 +589,10 @@
    "id": "2825ee39",
    "metadata": {
     "papermill": {
-     "duration": 0.002878,
-     "end_time": "2026-08-31T20:41:28.234464+00:00",
+     "duration": 0.002572,
+     "end_time": "2026-09-03T05:22:14.478815+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.231586+00:00",
+     "start_time": "2026-09-03T05:22:14.476243+00:00",
      "status": "completed"
     },
     "tags": []
@@ -595,16 +613,16 @@
    "id": "40abdde1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:28.245431Z",
-     "iopub.status.busy": "2026-08-31T20:41:28.245255Z",
-     "iopub.status.idle": "2026-08-31T20:41:28.548455Z",
-     "shell.execute_reply": "2026-08-31T20:41:28.541916Z"
+     "iopub.execute_input": "2026-09-03T05:22:14.485022Z",
+     "iopub.status.busy": "2026-09-03T05:22:14.484861Z",
+     "iopub.status.idle": "2026-09-03T05:22:14.709403Z",
+     "shell.execute_reply": "2026-09-03T05:22:14.707642Z"
     },
     "papermill": {
-     "duration": 0.311987,
-     "end_time": "2026-08-31T20:41:28.550057+00:00",
+     "duration": 0.229232,
+     "end_time": "2026-09-03T05:22:14.710354+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.238070+00:00",
+     "start_time": "2026-09-03T05:22:14.481122+00:00",
      "status": "completed"
     },
     "tags": []
@@ -684,10 +702,10 @@
    "id": "eb4e4ba9",
    "metadata": {
     "papermill": {
-     "duration": 0.007834,
-     "end_time": "2026-08-31T20:41:28.566080+00:00",
+     "duration": 0.002479,
+     "end_time": "2026-09-03T05:22:14.715951+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.558246+00:00",
+     "start_time": "2026-09-03T05:22:14.713472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -708,16 +726,16 @@
    "id": "509562b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:28.593947Z",
-     "iopub.status.busy": "2026-08-31T20:41:28.593725Z",
-     "iopub.status.idle": "2026-08-31T20:41:28.871870Z",
-     "shell.execute_reply": "2026-08-31T20:41:28.870484Z"
+     "iopub.execute_input": "2026-09-03T05:22:14.721708Z",
+     "iopub.status.busy": "2026-09-03T05:22:14.721550Z",
+     "iopub.status.idle": "2026-09-03T05:22:15.004943Z",
+     "shell.execute_reply": "2026-09-03T05:22:15.002452Z"
     },
     "papermill": {
-     "duration": 0.298747,
-     "end_time": "2026-08-31T20:41:28.875979+00:00",
+     "duration": 0.289006,
+     "end_time": "2026-09-03T05:22:15.006586+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.577232+00:00",
+     "start_time": "2026-09-03T05:22:14.717580+00:00",
      "status": "completed"
     },
     "tags": []
@@ -805,10 +823,10 @@
    "id": "5c34fa2a",
    "metadata": {
     "papermill": {
-     "duration": 0.003665,
-     "end_time": "2026-08-31T20:41:28.884401+00:00",
+     "duration": 0.002044,
+     "end_time": "2026-09-03T05:22:15.013096+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.880736+00:00",
+     "start_time": "2026-09-03T05:22:15.011052+00:00",
      "status": "completed"
     },
     "tags": []
@@ -835,16 +853,16 @@
    "id": "262cafa7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:28.905612Z",
-     "iopub.status.busy": "2026-08-31T20:41:28.904893Z",
-     "iopub.status.idle": "2026-08-31T20:41:29.212276Z",
-     "shell.execute_reply": "2026-08-31T20:41:29.211169Z"
+     "iopub.execute_input": "2026-09-03T05:22:15.023946Z",
+     "iopub.status.busy": "2026-09-03T05:22:15.023773Z",
+     "iopub.status.idle": "2026-09-03T05:22:15.305973Z",
+     "shell.execute_reply": "2026-09-03T05:22:15.304191Z"
     },
     "papermill": {
-     "duration": 0.317699,
-     "end_time": "2026-08-31T20:41:29.214149+00:00",
+     "duration": 0.28992,
+     "end_time": "2026-09-03T05:22:15.306679+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:28.896450+00:00",
+     "start_time": "2026-09-03T05:22:15.016759+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +978,10 @@
    "id": "8364ace4",
    "metadata": {
     "papermill": {
-     "duration": 0.012281,
-     "end_time": "2026-08-31T20:41:29.239193+00:00",
+     "duration": 0.003434,
+     "end_time": "2026-09-03T05:22:15.315182+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.226912+00:00",
+     "start_time": "2026-09-03T05:22:15.311748+00:00",
      "status": "completed"
     },
     "tags": []
@@ -988,10 +1006,10 @@
    "id": "76f0c474",
    "metadata": {
     "papermill": {
-     "duration": 0.006724,
-     "end_time": "2026-08-31T20:41:29.255148+00:00",
+     "duration": 0.002202,
+     "end_time": "2026-09-03T05:22:15.320298+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.248424+00:00",
+     "start_time": "2026-09-03T05:22:15.318096+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1012,16 +1030,16 @@
    "id": "9a9cce86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:29.275789Z",
-     "iopub.status.busy": "2026-08-31T20:41:29.275424Z",
-     "iopub.status.idle": "2026-08-31T20:41:29.583108Z",
-     "shell.execute_reply": "2026-08-31T20:41:29.581354Z"
+     "iopub.execute_input": "2026-09-03T05:22:15.327552Z",
+     "iopub.status.busy": "2026-09-03T05:22:15.327244Z",
+     "iopub.status.idle": "2026-09-03T05:22:15.678143Z",
+     "shell.execute_reply": "2026-09-03T05:22:15.675665Z"
     },
     "papermill": {
-     "duration": 0.321742,
-     "end_time": "2026-08-31T20:41:29.584291+00:00",
+     "duration": 0.356569,
+     "end_time": "2026-09-03T05:22:15.680334+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.262549+00:00",
+     "start_time": "2026-09-03T05:22:15.323765+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1161,10 +1179,10 @@
    "id": "e679e0ea",
    "metadata": {
     "papermill": {
-     "duration": 0.003504,
-     "end_time": "2026-08-31T20:41:29.592756+00:00",
+     "duration": 0.002442,
+     "end_time": "2026-09-03T05:22:15.686714+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.589252+00:00",
+     "start_time": "2026-09-03T05:22:15.684272+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1196,10 +1214,10 @@
    "id": "e61247ae",
    "metadata": {
     "papermill": {
-     "duration": 0.009291,
-     "end_time": "2026-08-31T20:41:29.607708+00:00",
+     "duration": 0.002536,
+     "end_time": "2026-09-03T05:22:15.691932+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.598417+00:00",
+     "start_time": "2026-09-03T05:22:15.689396+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1220,16 +1238,16 @@
    "id": "bcbcaf29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:29.617847Z",
-     "iopub.status.busy": "2026-08-31T20:41:29.617678Z",
-     "iopub.status.idle": "2026-08-31T20:41:29.833731Z",
-     "shell.execute_reply": "2026-08-31T20:41:29.831923Z"
+     "iopub.execute_input": "2026-09-03T05:22:15.702371Z",
+     "iopub.status.busy": "2026-09-03T05:22:15.702118Z",
+     "iopub.status.idle": "2026-09-03T05:22:15.948153Z",
+     "shell.execute_reply": "2026-09-03T05:22:15.945715Z"
     },
     "papermill": {
-     "duration": 0.222861,
-     "end_time": "2026-08-31T20:41:29.834890+00:00",
+     "duration": 0.252229,
+     "end_time": "2026-09-03T05:22:15.948861+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.612029+00:00",
+     "start_time": "2026-09-03T05:22:15.696632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1349,10 +1367,10 @@
    "id": "275f3bfb",
    "metadata": {
     "papermill": {
-     "duration": 0.00818,
-     "end_time": "2026-08-31T20:41:29.855669+00:00",
+     "duration": 0.001833,
+     "end_time": "2026-09-03T05:22:15.956291+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.847489+00:00",
+     "start_time": "2026-09-03T05:22:15.954458+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1371,19 +1389,418 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21a53ede",
+   "id": "disc-machinerie-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.013253,
-     "end_time": "2026-08-31T20:41:29.883534+00:00",
+     "duration": 0.002239,
+     "end_time": "2026-09-03T05:22:15.960351+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.870281+00:00",
+     "start_time": "2026-09-03T05:22:15.958112+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Exercices\n",
+    "## 6. La machinerie prouvée : Beck–Fiala (b1–b4) et Erdős–Spencer (p1a–p4)\n",
+    "\n",
+    "Les sections précédentes interrogeaient les **fondations** (P0, section 5) et les\n",
+    "**conjectures** (Komlós, Bansal–Jiang, section 1). Le lake porte aussi deux résultats\n",
+    "**prouvés de bout en bout**, assemblés boute par boute (voir\n",
+    "[`FORMAL_STATUS.md`](../discrepancy_lean/FORMAL_STATUS.md)) — et jusqu'ici aucune de leurs\n",
+    "déclarations n'était citée par le moindre notebook du corpus : c'était le plus grand trou de\n",
+    "visibilité de l'EPIC #11703 (6 modules noirs sur 8 au rejeu du 2026-09-02).\n",
+    "\n",
+    "- **Beck–Fiala classique** (`disc ≤ 2k − 1`) : la « noix » du lake, prouvée en quatre boutes —\n",
+    "  b1 le double comptage dimensionnel (`Kernel.lean`), b2 l'invariant de coloration partielle\n",
+    "  (`Partial.lean`), b3 le progrès d'une phase (`Progress.lean`), b4 la terminaison et\n",
+    "  l'assemblage (`BeckFiala.lean`).\n",
+    "- **Erdős–Spencer inférieur** (`√k/14` explicite) : la borne inférieure par méthode\n",
+    "  probabiliste (`ErdosSpencer.lean`, assemblage p1a–p4) — pour `k ≤ n`, il existe une famille\n",
+    "  de degré `≤ k` qu'aucune coloration ne discipline à mieux que `√k/14`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "disc-beckfiala-checks",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T05:22:15.966258Z",
+     "iopub.status.busy": "2026-09-03T05:22:15.966041Z",
+     "iopub.status.idle": "2026-09-03T05:22:16.230565Z",
+     "shell.execute_reply": "2026-09-03T05:22:16.228964Z"
+    },
+    "papermill": {
+     "duration": 0.26904,
+     "end_time": "2026-09-03T05:22:16.231345+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T05:22:15.962305+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 6 : les quatre boutes de la preuve Beck-Fiala, interrogees nativement.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- b1 : s'il reste plus de flottants que d'elements, une direction du noyau meurt</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.card_dangerous_lt_card_floating</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Discrepancy.card_dangerous_lt_card_floating<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>DecidableEq<span class=\"w\"> </span>α]<span class=\"w\"> </span>(F<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(Finset<span class=\"w\"> </span>α))\n",
+       "<span class=\"w\">  </span>(X<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>α)<span class=\"w\"> </span>(k<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),<span class=\"w\"> </span>X.Nonempty<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span>Discrepancy.degree<span class=\"w\"> </span>F<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>k)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>{S<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>F<span class=\"w\"> </span><span class=\"bp\">|</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>(S<span class=\"w\"> </span><span class=\"bp\">∩</span><span class=\"w\"> </span>X)<span class=\"bp\">.</span>card}<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>X.card</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.exists_dangerous_kernel_vec</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Discrepancy.exists_dangerous_kernel_vec<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>DecidableEq<span class=\"w\"> </span>α]<span class=\"w\"> </span>(F<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(Finset<span class=\"w\"> </span>α))\n",
+       "<span class=\"w\">  </span>(X<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>α)<span class=\"w\"> </span>(k<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),\n",
+       "<span class=\"w\">  </span>X.Nonempty<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span>Discrepancy.degree<span class=\"w\"> </span>F<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>k)<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">      </span><span class=\"bp\">∃</span><span class=\"w\"> </span>v,<span class=\"w\"> </span>(<span class=\"bp\">∃</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span>v<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"bp\">∧</span><span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>{S<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>F<span class=\"w\"> </span><span class=\"bp\">|</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>(S<span class=\"w\"> </span><span class=\"bp\">∩</span><span class=\"w\"> </span>X)<span class=\"bp\">.</span>card},<span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span>(<span class=\"k\">if</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>v<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- b2 : une ligne figee preserve sa somme initiale a 2k-1 pres</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.frozen_line_sum_le</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Discrepancy.frozen_line_sum_le<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>α]<span class=\"w\"> </span>(c₀<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℚ)<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℤ)<span class=\"w\"> </span>(Y<span class=\"w\"> </span>S<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>α)<span class=\"w\"> </span>(k<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),\n",
+       "<span class=\"w\">  </span>Y<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span>Y.card<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">      </span>Discrepancy.IsColoring<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">        </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Y,<span class=\"w\"> </span><span class=\"bp\">|</span>c₀<span class=\"w\"> </span>x<span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>S,<span class=\"w\"> </span>c₀<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>S,<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∉</span><span class=\"w\"> </span>Y<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"bp\">↑</span>(c<span class=\"w\"> </span>x)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>c₀<span class=\"w\"> </span>x)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(<span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>S,<span class=\"w\"> </span>c<span class=\"w\"> </span>x)<span class=\"bp\">.</span>natAbs<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span><span class=\"mi\">1</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- b3 : chaque phase avance jusqu'au premier contact avec le bord du cube</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.exists_step_hits_boundary</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Discrepancy.exists_step_hits_boundary<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[DecidableEq<span class=\"w\"> </span>α]<span class=\"w\"> </span>(c₀<span class=\"w\"> </span>v<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℚ)<span class=\"w\"> </span>(X<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>α),\n",
+       "<span class=\"w\">  </span>X.Nonempty<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span><span class=\"bp\">|</span>c₀<span class=\"w\"> </span>x<span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">      </span>(<span class=\"bp\">∃</span><span class=\"w\"> </span>x₀<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span>v<span class=\"w\"> </span>x₀<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>t,<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>t<span class=\"w\"> </span><span class=\"bp\">∧</span><span class=\"w\"> </span>(<span class=\"bp\">∀</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span><span class=\"bp\">|</span>c₀<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>t<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>v<span class=\"w\"> </span>x<span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">∧</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>x₁<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>X,<span class=\"w\"> </span><span class=\"bp\">|</span>c₀<span class=\"w\"> </span>x₁<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>t<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>v<span class=\"w\"> </span>x₁<span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">1</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- b4 : l'assemblage -- le theoreme classique, disc &lt;= 2k - 1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.beck_fiala_classic</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.beck_fiala_classic<span class=\"w\"> </span>:<span class=\"w\"> </span>Discrepancy.BeckFialaClassic</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le certificat : de quoi la preuve depend-elle, exactement ?</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>Discrepancy.beck_fiala_classic</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>Discrepancy.beck_fiala_classic'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Section 6 : les quatre boutes de la preuve Beck-Fiala, interrogees nativement.\\n-- b1 : s'il reste plus de flottants que d'elements, une direction du noyau meurt\\n#check @Discrepancy.card_dangerous_lt_card_floating\\n#check @Discrepancy.exists_dangerous_kernel_vec\\n-- b2 : une ligne figee preserve sa somme initiale a 2k-1 pres\\n#check @Discrepancy.frozen_line_sum_le\\n-- b3 : chaque phase avance jusqu'au premier contact avec le bord du cube\\n#check @Discrepancy.exists_step_hits_boundary\\n-- b4 : l'assemblage -- le theoreme classique, disc <= 2k - 1\\n#check @Discrepancy.beck_fiala_classic\\n-- Le certificat : de quoi la preuve depend-elle, exactement ?\\n#print axioms Discrepancy.beck_fiala_classic\", \"env\": 7}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.card_dangerous_lt_card_floating : ∀ {α : Type u_1} [inst : DecidableEq α] (F : Finset (Finset α))\\n  (X : Finset α) (k : ℕ), X.Nonempty → (∀ x ∈ X, Discrepancy.degree F x ≤ k) → {S ∈ F | k < (S ∩ X).card}.card < X.card\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.exists_dangerous_kernel_vec : ∀ {α : Type u_1} [inst : DecidableEq α] (F : Finset (Finset α))\\n  (X : Finset α) (k : ℕ),\\n  X.Nonempty →\\n    (∀ x ∈ X, Discrepancy.degree F x ≤ k) →\\n      ∃ v, (∃ x ∈ X, v x ≠ 0) ∧ ∀ S ∈ {S ∈ F | k < (S ∩ X).card}, ∑ x ∈ X, (if x ∈ S then 1 else 0) * v x = 0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.frozen_line_sum_le : ∀ {α : Type u_1} [DecidableEq α] (c₀ : α → ℚ) (c : α → ℤ) (Y S : Finset α) (k : ℕ),\\n  Y ⊆ S →\\n    Y.card ≤ k →\\n      Discrepancy.IsColoring c →\\n        (∀ x ∈ Y, |c₀ x| < 1) → ∑ x ∈ S, c₀ x = 0 → (∀ x ∈ S, x ∉ Y → ↑(c x) = c₀ x) → (∑ x ∈ S, c x).natAbs ≤ 2 * k - 1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.exists_step_hits_boundary : ∀ {α : Type u_1} [DecidableEq α] (c₀ v : α → ℚ) (X : Finset α),\\n  X.Nonempty →\\n    (∀ x ∈ X, |c₀ x| < 1) →\\n      (∃ x₀ ∈ X, v x₀ ≠ 0) → ∃ t, 0 < t ∧ (∀ x ∈ X, |c₀ x + t * v x| ≤ 1) ∧ ∃ x₁ ∈ X, |c₀ x₁ + t * v x₁| = 1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"Discrepancy.beck_fiala_classic : Discrepancy.BeckFialaClassic\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Discrepancy.beck_fiala_classic' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 8}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Section 6 : les quatre boutes de la preuve Beck-Fiala, interrogees nativement.\n",
+       "-- b1 : s'il reste plus de flottants que d'elements, une direction du noyau meurt\n",
+       "#check @Discrepancy.card_dangerous_lt_card_floating\n",
+       "──────▶  @Discrepancy.card_dangerous_lt_card_floating : ∀ {α : Type u_1} [inst : DecidableEq α] (F : Finset (Finset α))\n",
+       "  (X : Finset α) (k : ℕ), X.Nonempty → (∀ x ∈ X, Discrepancy.degree F x ≤ k) → {S ∈ F | k < (S ∩ X).card}.card < X.card\n",
+       "#check @Discrepancy.exists_dangerous_kernel_vec\n",
+       "──────▶  @Discrepancy.exists_dangerous_kernel_vec : ∀ {α : Type u_1} [inst : DecidableEq α] (F : Finset (Finset α))\n",
+       "  (X : Finset α) (k : ℕ),\n",
+       "  X.Nonempty →\n",
+       "    (∀ x ∈ X, Discrepancy.degree F x ≤ k) →\n",
+       "      ∃ v, (∃ x ∈ X, v x ≠ 0) ∧ ∀ S ∈ {S ∈ F | k < (S ∩ X).card}, ∑ x ∈ X, (if x ∈ S then 1 else 0) * v x = 0\n",
+       "-- b2 : une ligne figee preserve sa somme initiale a 2k-1 pres\n",
+       "#check @Discrepancy.frozen_line_sum_le\n",
+       "──────▶  @Discrepancy.frozen_line_sum_le : ∀ {α : Type u_1} [DecidableEq α] (c₀ : α → ℚ) (c : α → ℤ) (Y S : Finset α) (k : ℕ),\n",
+       "  Y ⊆ S →\n",
+       "    Y.card ≤ k →\n",
+       "      Discrepancy.IsColoring c →\n",
+       "        (∀ x ∈ Y, |c₀ x| < 1) → ∑ x ∈ S, c₀ x = 0 → (∀ x ∈ S, x ∉ Y → ↑(c x) = c₀ x) → (∑ x ∈ S, c x).natAbs ≤ 2 * k - 1\n",
+       "-- b3 : chaque phase avance jusqu'au premier contact avec le bord du cube\n",
+       "#check @Discrepancy.exists_step_hits_boundary\n",
+       "──────▶  @Discrepancy.exists_step_hits_boundary : ∀ {α : Type u_1} [DecidableEq α] (c₀ v : α → ℚ) (X : Finset α),\n",
+       "  X.Nonempty →\n",
+       "    (∀ x ∈ X, |c₀ x| < 1) →\n",
+       "      (∃ x₀ ∈ X, v x₀ ≠ 0) → ∃ t, 0 < t ∧ (∀ x ∈ X, |c₀ x + t * v x| ≤ 1) ∧ ∃ x₁ ∈ X, |c₀ x₁ + t * v x₁| = 1\n",
+       "-- b4 : l'assemblage -- le theoreme classique, disc <= 2k - 1\n",
+       "#check @Discrepancy.beck_fiala_classic\n",
+       "──────▶  Discrepancy.beck_fiala_classic : Discrepancy.BeckFialaClassic\n",
+       "-- Le certificat : de quoi la preuve depend-elle, exactement ?\n",
+       "#print axioms Discrepancy.beck_fiala_classic\n",
+       "──────▶  'Discrepancy.beck_fiala_classic' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 8\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Section 6 : les quatre boutes de la preuve Beck-Fiala, interrogees nativement.\\n-- b1 : s'il reste plus de flottants que d'elements, une direction du noyau meurt\\n#check @Discrepancy.card_dangerous_lt_card_floating\\n#check @Discrepancy.exists_dangerous_kernel_vec\\n-- b2 : une ligne figee preserve sa somme initiale a 2k-1 pres\\n#check @Discrepancy.frozen_line_sum_le\\n-- b3 : chaque phase avance jusqu'au premier contact avec le bord du cube\\n#check @Discrepancy.exists_step_hits_boundary\\n-- b4 : l'assemblage -- le theoreme classique, disc <= 2k - 1\\n#check @Discrepancy.beck_fiala_classic\\n-- Le certificat : de quoi la preuve depend-elle, exactement ?\\n#print axioms Discrepancy.beck_fiala_classic\", \"env\": 7}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.card_dangerous_lt_card_floating : ∀ {α : Type u_1} [inst : DecidableEq α] (F : Finset (Finset α))\\n  (X : Finset α) (k : ℕ), X.Nonempty → (∀ x ∈ X, Discrepancy.degree F x ≤ k) → {S ∈ F | k < (S ∩ X).card}.card < X.card\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.exists_dangerous_kernel_vec : ∀ {α : Type u_1} [inst : DecidableEq α] (F : Finset (Finset α))\\n  (X : Finset α) (k : ℕ),\\n  X.Nonempty →\\n    (∀ x ∈ X, Discrepancy.degree F x ≤ k) →\\n      ∃ v, (∃ x ∈ X, v x ≠ 0) ∧ ∀ S ∈ {S ∈ F | k < (S ∩ X).card}, ∑ x ∈ X, (if x ∈ S then 1 else 0) * v x = 0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.frozen_line_sum_le : ∀ {α : Type u_1} [DecidableEq α] (c₀ : α → ℚ) (c : α → ℤ) (Y S : Finset α) (k : ℕ),\\n  Y ⊆ S →\\n    Y.card ≤ k →\\n      Discrepancy.IsColoring c →\\n        (∀ x ∈ Y, |c₀ x| < 1) → ∑ x ∈ S, c₀ x = 0 → (∀ x ∈ S, x ∉ Y → ↑(c x) = c₀ x) → (∑ x ∈ S, c x).natAbs ≤ 2 * k - 1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@Discrepancy.exists_step_hits_boundary : ∀ {α : Type u_1} [DecidableEq α] (c₀ v : α → ℚ) (X : Finset α),\\n  X.Nonempty →\\n    (∀ x ∈ X, |c₀ x| < 1) →\\n      (∃ x₀ ∈ X, v x₀ ≠ 0) → ∃ t, 0 < t ∧ (∀ x ∈ X, |c₀ x + t * v x| ≤ 1) ∧ ∃ x₁ ∈ X, |c₀ x₁ + t * v x₁| = 1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"Discrepancy.beck_fiala_classic : Discrepancy.BeckFialaClassic\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Discrepancy.beck_fiala_classic' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 8}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Section 6 : les quatre boutes de la preuve Beck-Fiala, interrogees nativement.\n",
+    "-- b1 : s'il reste plus de flottants que d'elements, une direction du noyau meurt\n",
+    "#check @Discrepancy.card_dangerous_lt_card_floating\n",
+    "#check @Discrepancy.exists_dangerous_kernel_vec\n",
+    "-- b2 : une ligne figee preserve sa somme initiale a 2k-1 pres\n",
+    "#check @Discrepancy.frozen_line_sum_le\n",
+    "-- b3 : chaque phase avance jusqu'au premier contact avec le bord du cube\n",
+    "#check @Discrepancy.exists_step_hits_boundary\n",
+    "-- b4 : l'assemblage -- le theoreme classique, disc <= 2k - 1\n",
+    "#check @Discrepancy.beck_fiala_classic\n",
+    "-- Le certificat : de quoi la preuve depend-elle, exactement ?\n",
+    "#print axioms Discrepancy.beck_fiala_classic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "disc-beckfiala-lecture",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002116,
+     "end_time": "2026-09-03T05:22:16.236739+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T05:22:16.234623+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Les quatre `#check` tracent la colonne vertébrale de l'algorithme : tant qu'une ligne garde\n",
+    "plus de `k` éléments flottants, le noyau dimensionnel (b1) fournit une direction qui préserve\n",
+    "exactement les sommes des lignes dangereuses ; la phase (b3) avance le long de cette direction\n",
+    "jusqu'au premier contact avec le bord du cube `[-1,1]^X` et fige au moins un nouveau flottant\n",
+    "en `±1` ; l'invariant (b2) garantit qu'une ligne figée ne dérive jamais de plus de `2k − 1`.\n",
+    "Le nombre de flottants décroît strictement à chaque phase, donc la boucle termine et l'arrondi\n",
+    "final produit la coloration (b4). Le `#print axioms` rend le certificat ci-dessus : la preuve\n",
+    "repose sur les trois axiomes standard de Mathlib (`propext`, `Classical.choice`,\n",
+    "`Quot.sound`) — **aucun `sorry`**, aucun `native_decide` : `beck_fiala_classic` est un\n",
+    "théorème au sens plein, pas un énoncé espéré."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "disc-erdosspencer-checks",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T05:22:16.241525Z",
+     "iopub.status.busy": "2026-09-03T05:22:16.241394Z",
+     "iopub.status.idle": "2026-09-03T05:22:16.468722Z",
+     "shell.execute_reply": "2026-09-03T05:22:16.464313Z"
+    },
+    "papermill": {
+     "duration": 0.230703,
+     "end_time": "2026-09-03T05:22:16.469525+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T05:22:16.238822+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- La borne inferieure d'Erdos-Spencer, a constante explicite (assemblage p1a-p4) :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- pour 1 &lt;= k &lt;= n il existe une famille de degre &lt;= k telle que TOUTE coloration</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- garde une ligne a somme &gt;= sqrt(k)/14</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.erdos_spencer_lb_explicit</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.erdos_spencer_lb_explicit<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(n<span class=\"w\"> </span>k<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),\n",
+       "<span class=\"w\">  </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span>k<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">      </span><span class=\"bp\">∃</span><span class=\"w\"> </span>F,\n",
+       "<span class=\"w\">        </span>Discrepancy.maxDegree<span class=\"w\"> </span>F<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">∧</span>\n",
+       "<span class=\"w\">          </span><span class=\"bp\">∀</span><span class=\"w\"> </span>(C<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℤ),<span class=\"w\"> </span>Discrepancy.IsColoring<span class=\"w\"> </span>C<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>k.sqrt<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"mi\">14</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Discrepancy.discrepancy<span class=\"w\"> </span>F<span class=\"w\"> </span>C</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>Discrepancy.erdos_spencer_lb_explicit</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>Discrepancy.erdos_spencer_lb_explicit'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- La forme optimiste sqrt(k)/2 reste une Prop OUVERTE -- jamais pretendue prouvee :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"k\">#check</span><span class=\"w\"> </span>Discrepancy.ErdosSpencerLB</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.ErdosSpencerLB<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- La borne inferieure d'Erdos-Spencer, a constante explicite (assemblage p1a-p4) :\\n-- pour 1 <= k <= n il existe une famille de degre <= k telle que TOUTE coloration\\n-- garde une ligne a somme >= sqrt(k)/14\\n#check @Discrepancy.erdos_spencer_lb_explicit\\n#print axioms Discrepancy.erdos_spencer_lb_explicit\\n-- La forme optimiste sqrt(k)/2 reste une Prop OUVERTE -- jamais pretendue prouvee :\\n#check Discrepancy.ErdosSpencerLB\", \"env\": 8}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Discrepancy.erdos_spencer_lb_explicit : ∀ (n k : ℕ),\\n  1 ≤ k →\\n    k ≤ n →\\n      ∃ F,\\n        Discrepancy.maxDegree F ≤ k ∧\\n          ∀ (C : Fin n → ℤ), Discrepancy.IsColoring C → k.sqrt ≤ 14 * Discrepancy.discrepancy F C\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Discrepancy.erdos_spencer_lb_explicit' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\": \"Discrepancy.ErdosSpencerLB : Prop\"}],\r\n",
+       " \"env\": 9}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- La borne inferieure d'Erdos-Spencer, a constante explicite (assemblage p1a-p4) :\n",
+       "-- pour 1 <= k <= n il existe une famille de degre <= k telle que TOUTE coloration\n",
+       "-- garde une ligne a somme >= sqrt(k)/14\n",
+       "#check @Discrepancy.erdos_spencer_lb_explicit\n",
+       "──────▶  Discrepancy.erdos_spencer_lb_explicit : ∀ (n k : ℕ),\n",
+       "  1 ≤ k →\n",
+       "    k ≤ n →\n",
+       "      ∃ F,\n",
+       "        Discrepancy.maxDegree F ≤ k ∧\n",
+       "          ∀ (C : Fin n → ℤ), Discrepancy.IsColoring C → k.sqrt ≤ 14 * Discrepancy.discrepancy F C\n",
+       "#print axioms Discrepancy.erdos_spencer_lb_explicit\n",
+       "──────▶  'Discrepancy.erdos_spencer_lb_explicit' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "-- La forme optimiste sqrt(k)/2 reste une Prop OUVERTE -- jamais pretendue prouvee :\n",
+       "#check Discrepancy.ErdosSpencerLB\n",
+       "──────▶  Discrepancy.ErdosSpencerLB : Prop\n",
+       "--% env 9\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- La borne inferieure d'Erdos-Spencer, a constante explicite (assemblage p1a-p4) :\\n-- pour 1 <= k <= n il existe une famille de degre <= k telle que TOUTE coloration\\n-- garde une ligne a somme >= sqrt(k)/14\\n#check @Discrepancy.erdos_spencer_lb_explicit\\n#print axioms Discrepancy.erdos_spencer_lb_explicit\\n-- La forme optimiste sqrt(k)/2 reste une Prop OUVERTE -- jamais pretendue prouvee :\\n#check Discrepancy.ErdosSpencerLB\", \"env\": 8}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"Discrepancy.erdos_spencer_lb_explicit : ∀ (n k : ℕ),\\n  1 ≤ k →\\n    k ≤ n →\\n      ∃ F,\\n        Discrepancy.maxDegree F ≤ k ∧\\n          ∀ (C : Fin n → ℤ), Discrepancy.IsColoring C → k.sqrt ≤ 14 * Discrepancy.discrepancy F C\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Discrepancy.erdos_spencer_lb_explicit' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\": \"Discrepancy.ErdosSpencerLB : Prop\"}],\r\n",
+       " \"env\": 9}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- La borne inferieure d'Erdos-Spencer, a constante explicite (assemblage p1a-p4) :\n",
+    "-- pour 1 <= k <= n il existe une famille de degre <= k telle que TOUTE coloration\n",
+    "-- garde une ligne a somme >= sqrt(k)/14\n",
+    "#check @Discrepancy.erdos_spencer_lb_explicit\n",
+    "#print axioms Discrepancy.erdos_spencer_lb_explicit\n",
+    "-- La forme optimiste sqrt(k)/2 reste une Prop OUVERTE -- jamais pretendue prouvee :\n",
+    "#check Discrepancy.ErdosSpencerLB"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "disc-erdosspencer-lecture",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00389,
+     "end_time": "2026-09-03T05:22:16.477668+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T05:22:16.473778+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "`erdos_spencer_lb_explicit` est le second sommet prouvé : moments de la somme de Rademacher,\n",
+    "Paley–Zygmund, union bound sur les `2^n` colorations — la méthode probabiliste construit une\n",
+    "famille de degré `≤ k` qu'aucune coloration ne discipline à mieux que `√k/14`. La constante\n",
+    "`14` n'est pas celle de l'énoncé optimal (`√k/2`) : l'écart est documenté dans le statut du\n",
+    "module (Paley–Zygmund force `≥ 12t` tirages par bloc quand le contrôle de degré n'en\n",
+    "autorise que `k`), et le lake ne le masque pas — `ErdosSpencerLB`, la forme `√k/2`, reste\n",
+    "une `Prop` **ouverte**, chargée ici comme conjecture. C'est la même hiérarchie honnête que\n",
+    "celle de la section 1 : petits théorèmes prouvés, grandes conjectures nommées, aucun flou\n",
+    "entre les deux — et le même certificat d'axiomes que Beck–Fiala."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21a53ede",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004232,
+     "end_time": "2026-09-03T05:22:16.486480+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T05:22:16.482248+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
     "\n",
     "Trois preuves à compléter. Les indices sont dans les commentaires ; les `#check` en fin de cellule\n",
     "servent d'**ancres d'exécution** — la cellule reste une commande Lean valide même non complétée."
@@ -1394,10 +1811,10 @@
    "id": "3f651e93",
    "metadata": {
     "papermill": {
-     "duration": 0.011413,
-     "end_time": "2026-08-31T20:41:29.903056+00:00",
+     "duration": 0.00312,
+     "end_time": "2026-09-03T05:22:16.493624+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.891643+00:00",
+     "start_time": "2026-09-03T05:22:16.490504+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1412,20 +1829,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "5b916ac0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:29.931718Z",
-     "iopub.status.busy": "2026-08-31T20:41:29.931369Z",
-     "iopub.status.idle": "2026-08-31T20:41:30.132292Z",
-     "shell.execute_reply": "2026-08-31T20:41:30.129445Z"
+     "iopub.execute_input": "2026-09-03T05:22:16.500579Z",
+     "iopub.status.busy": "2026-09-03T05:22:16.500273Z",
+     "iopub.status.idle": "2026-09-03T05:22:16.749352Z",
+     "shell.execute_reply": "2026-09-03T05:22:16.748087Z"
     },
     "papermill": {
-     "duration": 0.223575,
-     "end_time": "2026-08-31T20:41:30.135193+00:00",
+     "duration": 0.255624,
+     "end_time": "2026-09-03T05:22:16.752454+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:29.911618+00:00",
+     "start_time": "2026-09-03T05:22:16.496830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1450,12 +1867,12 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--   sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- ancre d'execution (cellule valide meme non completee) :</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.discrepancy_empty</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Discrepancy.discrepancy_empty<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>DecidableEq<span class=\"w\"> </span>α]<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℤ),<span class=\"w\"> </span>Discrepancy.discrepancy<span class=\"w\"> </span><span class=\"bp\">∅</span><span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Discrepancy.discrepancy_empty</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>Discrepancy.discrepancy_empty<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>DecidableEq<span class=\"w\"> </span>α]<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℤ),<span class=\"w\"> </span>Discrepancy.discrepancy<span class=\"w\"> </span><span class=\"bp\">∅</span><span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 1 : le systeme vide a discrepance 0\\n-- TODO etudiant\\n-- example (c : Fin 3 \\u2192 \\u2124) :\\n--     Discrepancy.discrepancy (\\u2205 : Finset (Finset (Fin 3))) c = 0 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check @Discrepancy.discrepancy_empty\", \"env\": 7}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : le systeme vide a discrepance 0\\n-- TODO etudiant\\n-- example (c : Fin 3 \\u2192 \\u2124) :\\n--     Discrepancy.discrepancy (\\u2205 : Finset (Finset (Fin 3))) c = 0 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check @Discrepancy.discrepancy_empty\", \"env\": 9}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1465,7 +1882,7 @@
        "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"@Discrepancy.discrepancy_empty : ∀ {α : Type u_1} [inst : DecidableEq α] (c : α → ℤ), Discrepancy.discrepancy ∅ c = 0\"}],\r\n",
-       " \"env\": 8}</code>\n",
+       " \"env\": 10}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1479,10 +1896,10 @@
        "-- ancre d'execution (cellule valide meme non completee) :\n",
        "#check @Discrepancy.discrepancy_empty\n",
        "──────▶  @Discrepancy.discrepancy_empty : ∀ {α : Type u_1} [inst : DecidableEq α] (c : α → ℤ), Discrepancy.discrepancy ∅ c = 0\n",
-       "--% env 8\n",
+       "--% env 10\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 1 : le systeme vide a discrepance 0\\n-- TODO etudiant\\n-- example (c : Fin 3 \\u2192 \\u2124) :\\n--     Discrepancy.discrepancy (\\u2205 : Finset (Finset (Fin 3))) c = 0 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check @Discrepancy.discrepancy_empty\", \"env\": 7}\n",
+       "{\"cmd\": \"-- Exercice 1 : le systeme vide a discrepance 0\\n-- TODO etudiant\\n-- example (c : Fin 3 \\u2192 \\u2124) :\\n--     Discrepancy.discrepancy (\\u2205 : Finset (Finset (Fin 3))) c = 0 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check @Discrepancy.discrepancy_empty\", \"env\": 9}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -1490,7 +1907,7 @@
        "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"@Discrepancy.discrepancy_empty : ∀ {α : Type u_1} [inst : DecidableEq α] (c : α → ℤ), Discrepancy.discrepancy ∅ c = 0\"}],\r\n",
-       " \"env\": 8}"
+       " \"env\": 10}"
       ]
      },
      "metadata": {},
@@ -1513,10 +1930,10 @@
    "id": "e28c7e48",
    "metadata": {
     "papermill": {
-     "duration": 0.015691,
-     "end_time": "2026-08-31T20:41:30.166107+00:00",
+     "duration": 0.003505,
+     "end_time": "2026-09-03T05:22:16.759237+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:30.150416+00:00",
+     "start_time": "2026-09-03T05:22:16.755732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1531,20 +1948,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "d9a572fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:30.184536Z",
-     "iopub.status.busy": "2026-08-31T20:41:30.184318Z",
-     "iopub.status.idle": "2026-08-31T20:41:30.363648Z",
-     "shell.execute_reply": "2026-08-31T20:41:30.362224Z"
+     "iopub.execute_input": "2026-09-03T05:22:16.765883Z",
+     "iopub.status.busy": "2026-09-03T05:22:16.765745Z",
+     "iopub.status.idle": "2026-09-03T05:22:16.939327Z",
+     "shell.execute_reply": "2026-09-03T05:22:16.935850Z"
     },
     "papermill": {
-     "duration": 0.191056,
-     "end_time": "2026-08-31T20:41:30.365773+00:00",
+     "duration": 0.178417,
+     "end_time": "2026-09-03T05:22:16.939774+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:30.174717+00:00",
+     "start_time": "2026-09-03T05:22:16.761357+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1568,12 +1985,12 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--   sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- ancre d'execution (cellule valide meme non completee) :</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"k\">#check</span><span class=\"w\"> </span>Discrepancy.KomlosConjecture</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.KomlosConjecture<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1e\"><span class=\"k\">#check</span><span class=\"w\"> </span>Discrepancy.KomlosConjecture</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.KomlosConjecture<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 11</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 2 : la colonne (3/5, 4/5) est unitaire\\n-- TODO etudiant\\n-- example : (3 : \\u211a) / 5 * (3 / 5) + 4 / 5 * (4 / 5) = 1 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosConjecture\", \"env\": 8}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : la colonne (3/5, 4/5) est unitaire\\n-- TODO etudiant\\n-- example : (3 : \\u211a) / 5 * (3 / 5) + 4 / 5 * (4 / 5) = 1 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosConjecture\", \"env\": 10}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1582,7 +1999,7 @@
        "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
        "   \"data\": \"Discrepancy.KomlosConjecture : Prop\"}],\r\n",
-       " \"env\": 9}</code>\n",
+       " \"env\": 11}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1595,17 +2012,17 @@
        "-- ancre d'execution (cellule valide meme non completee) :\n",
        "#check Discrepancy.KomlosConjecture\n",
        "──────▶  Discrepancy.KomlosConjecture : Prop\n",
-       "--% env 9\n",
+       "--% env 11\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 2 : la colonne (3/5, 4/5) est unitaire\\n-- TODO etudiant\\n-- example : (3 : \\u211a) / 5 * (3 / 5) + 4 / 5 * (4 / 5) = 1 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosConjecture\", \"env\": 8}\n",
+       "{\"cmd\": \"-- Exercice 2 : la colonne (3/5, 4/5) est unitaire\\n-- TODO etudiant\\n-- example : (3 : \\u211a) / 5 * (3 / 5) + 4 / 5 * (4 / 5) = 1 := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosConjecture\", \"env\": 10}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
        "   \"data\": \"Discrepancy.KomlosConjecture : Prop\"}],\r\n",
-       " \"env\": 9}"
+       " \"env\": 11}"
       ]
      },
      "metadata": {},
@@ -1627,10 +2044,10 @@
    "id": "ac98b949",
    "metadata": {
     "papermill": {
-     "duration": 0.008053,
-     "end_time": "2026-08-31T20:41:30.384740+00:00",
+     "duration": 0.002364,
+     "end_time": "2026-09-03T05:22:16.945405+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:30.376687+00:00",
+     "start_time": "2026-09-03T05:22:16.943041+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1646,20 +2063,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "e4d54b32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T20:41:30.400601Z",
-     "iopub.status.busy": "2026-08-31T20:41:30.400448Z",
-     "iopub.status.idle": "2026-08-31T20:41:30.581789Z",
-     "shell.execute_reply": "2026-08-31T20:41:30.580564Z"
+     "iopub.execute_input": "2026-09-03T05:22:16.951486Z",
+     "iopub.status.busy": "2026-09-03T05:22:16.951335Z",
+     "iopub.status.idle": "2026-09-03T05:22:17.137042Z",
+     "shell.execute_reply": "2026-09-03T05:22:17.135784Z"
     },
     "papermill": {
-     "duration": 0.19476,
-     "end_time": "2026-08-31T20:41:30.586176+00:00",
+     "duration": 0.190297,
+     "end_time": "2026-09-03T05:22:17.137980+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:30.391416+00:00",
+     "start_time": "2026-09-03T05:22:16.947683+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1687,12 +2104,12 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--   sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- ancre d'execution (cellule valide meme non completee) :</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"k\">#check</span><span class=\"w\"> </span>Discrepancy.KomlosBansalJiangWeak</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.KomlosBansalJiangWeak<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1f\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1f\"><span class=\"k\">#check</span><span class=\"w\"> </span>Discrepancy.KomlosBansalJiangWeak</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Discrepancy.KomlosBansalJiangWeak<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 12</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 3 : KomlosConjecture specialisee a n = 2\\n-- TODO etudiant\\n-- example (h : Discrepancy.KomlosConjecture) :\\n--     \\u2203 C : \\u211a, \\u2200 (m : \\u2115) (A : Matrix (Fin m) (Fin 2) \\u211a),\\n--       (\\u2200 j, \\u2211 i, A i j * A i j = 1) \\u2192\\n--         \\u2203 c : Fin 2 \\u2192 \\u211a,\\n--           (\\u2200 j, c j = 1 \\u2228 c j = -1) \\u2227 \\u2200 i, |\\u2211 j, A i j * c j| \\u2264 C := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosBansalJiangWeak\", \"env\": 9}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : KomlosConjecture specialisee a n = 2\\n-- TODO etudiant\\n-- example (h : Discrepancy.KomlosConjecture) :\\n--     \\u2203 C : \\u211a, \\u2200 (m : \\u2115) (A : Matrix (Fin m) (Fin 2) \\u211a),\\n--       (\\u2200 j, \\u2211 i, A i j * A i j = 1) \\u2192\\n--         \\u2203 c : Fin 2 \\u2192 \\u211a,\\n--           (\\u2200 j, c j = 1 \\u2228 c j = -1) \\u2227 \\u2200 i, |\\u2211 j, A i j * c j| \\u2264 C := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosBansalJiangWeak\", \"env\": 11}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1701,7 +2118,7 @@
        "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 6},\r\n",
        "   \"data\": \"Discrepancy.KomlosBansalJiangWeak : Prop\"}],\r\n",
-       " \"env\": 10}</code>\n",
+       " \"env\": 12}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1718,17 +2135,17 @@
        "-- ancre d'execution (cellule valide meme non completee) :\n",
        "#check Discrepancy.KomlosBansalJiangWeak\n",
        "──────▶  Discrepancy.KomlosBansalJiangWeak : Prop\n",
-       "--% env 10\n",
+       "--% env 12\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 3 : KomlosConjecture specialisee a n = 2\\n-- TODO etudiant\\n-- example (h : Discrepancy.KomlosConjecture) :\\n--     \\u2203 C : \\u211a, \\u2200 (m : \\u2115) (A : Matrix (Fin m) (Fin 2) \\u211a),\\n--       (\\u2200 j, \\u2211 i, A i j * A i j = 1) \\u2192\\n--         \\u2203 c : Fin 2 \\u2192 \\u211a,\\n--           (\\u2200 j, c j = 1 \\u2228 c j = -1) \\u2227 \\u2200 i, |\\u2211 j, A i j * c j| \\u2264 C := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosBansalJiangWeak\", \"env\": 9}\n",
+       "{\"cmd\": \"-- Exercice 3 : KomlosConjecture specialisee a n = 2\\n-- TODO etudiant\\n-- example (h : Discrepancy.KomlosConjecture) :\\n--     \\u2203 C : \\u211a, \\u2200 (m : \\u2115) (A : Matrix (Fin m) (Fin 2) \\u211a),\\n--       (\\u2200 j, \\u2211 i, A i j * A i j = 1) \\u2192\\n--         \\u2203 c : Fin 2 \\u2192 \\u211a,\\n--           (\\u2200 j, c j = 1 \\u2228 c j = -1) \\u2227 \\u2200 i, |\\u2211 j, A i j * c j| \\u2264 C := by\\n--   sorry\\n\\n-- ancre d'execution (cellule valide meme non completee) :\\n#check Discrepancy.KomlosBansalJiangWeak\", \"env\": 11}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 6},\r\n",
        "   \"data\": \"Discrepancy.KomlosBansalJiangWeak : Prop\"}],\r\n",
-       " \"env\": 10}"
+       " \"env\": 12}"
       ]
      },
      "metadata": {},
@@ -1754,34 +2171,38 @@
    "id": "499ec9fe",
    "metadata": {
     "papermill": {
-     "duration": 0.005378,
-     "end_time": "2026-08-31T20:41:30.595860+00:00",
+     "duration": 0.002247,
+     "end_time": "2026-09-03T05:22:17.142906+00:00",
      "exception": false,
-     "start_time": "2026-08-31T20:41:30.590482+00:00",
+     "start_time": "2026-09-03T05:22:17.140659+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Ce que ce compagnon a rendu visible\n",
+    "## 8. Ce que ce compagnon a rendu visible\n",
     "\n",
     "Avant ce notebook, le module `Discrepancy/Komlos.lean` était **noir** : aucune de ses trois\n",
     "déclarations — `KomlosConjecture`, `BansalJiangLargeDegree`, `KomlosBansalJiangWeak` — n'était citée\n",
-    "par le moindre notebook du corpus (mesure `scan_lake_notebook_visibility.py`). La frontière SOTA\n",
-    "formalisée du sujet existait sans lecteur.\n",
+    "par le moindre notebook du corpus (mesure `scan_lake_notebook_visibility.py`). Puis la section 6\n",
+    "a ouvert la moitié restante du lake : `Kernel`, `Partial`, `Progress`, `BeckFiala` (b1–b4) et\n",
+    "`ErdosSpencer` (p1a–p4) — dont les deux sommets **prouvés**, `beck_fiala_classic` et\n",
+    "`erdos_spencer_lb_explicit`, désormais chargés avec leur certificat d'axiomes.\n",
     "\n",
     "Ce compagnon l'exécute : les trois `Prop` rendues avec leurs signatures complètes, la condition\n",
     "unitaire **décidée** sur des témoins pythagoriciens et hadamardiens, la discrépance optimale\n",
     "**calculée par énumération exhaustive dans le noyau** (`1/5` puis `1`), les théorèmes P0 relus\n",
-    "avec leur témoin. Relié au corpus :\n",
+    "avec leur témoin, et la machinerie prouvée interrogée boute par boute. Relié au corpus :\n",
     "\n",
     "- [Search-09c](Search-09c-CombinatorialDiscrepancy.ipynb) mesure les **mêmes objets en numérique**\n",
     "  (numpy, arrondi Beck–Fiala, oracle CP-SAT) — la discrépance exacte qu'il approche par solver,\n",
-    "  ce compagnon l'énumère in-kernel sur des petits témoins ;\n",
+    "  ce compagnon l'énumère in-kernel sur des petits témoins, et sa borne `2k − 1` est maintenant\n",
+    "  le théorème exécuté de la section 6 ;\n",
     "- [Search-13](../Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb) rappelle que « discrepancy » a aussi une\n",
     "  vie d'heuristique de parcours — sans rapport ;\n",
-    "- le lake [discrepancy_lean](../discrepancy_lean/README.md) garde ses conjectures en `Prop` nommées :\n",
-    "  quand l'étage SDP existera en Mathlib, la preuve remplacera la déclaration sans changer l'énoncé."
+    "- le lake [discrepancy_lean](../discrepancy_lean/README.md) garde ses conjectures en `Prop` nommée :\n",
+    "  quand l'étage SDP existera en Mathlib, la preuve remplacera la déclaration sans changer\n",
+    "  l'énoncé — et ce notebook montrera le basculement."
    ]
   }
  ],
@@ -1799,14 +2220,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 295.313454,
-   "end_time": "2026-08-31T20:41:32.333826+00:00",
+   "duration": 64.839371,
+   "end_time": "2026-09-03T05:22:17.934779+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Search-18b-Lean-Discrepancy-Komlos.ipynb",
-   "output_path": "Search-18b-Lean-Discrepancy-Komlos.ipynb",
+   "input_path": "Search-09d-run.ipynb",
+   "output_path": "Search-09d-out.ipynb",
    "parameters": {},
-   "start_time": "2026-08-31T20:36:37.020372+00:00",
+   "start_time": "2026-09-03T05:21:13.095408+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/notebook-lean — lane myia-po-2027:CoursIA — prev: DEEP/notebook-lean #14424

See #11703 (sous-grain visibilité `discrepancy_lean` — le « vrai trou » du rejeu 2026-09-02 : 6 modules noirs sur 8). See #12823.

## Livrable

`Search-09d-Lean-Discrepancy-Komlos.ipynb` exécute désormais **nativement la machinerie prouvée** du lake `discrepancy_lean` : les cinq modules noirs (`Kernel`, `Partial`, `Progress`, `BeckFiala`, `ErdosSpencer`) sont importés et leurs théorèmes jalons interrogés avec certificat d'axiomes. Avant cette PR, le compagnon n'atteignait que `Komlos` (conjectures) + `Basic` (fondations P0) — les deux sommets **prouvés** du lake (`beck_fiala_classic` b1–b4, `erdos_spencer_lb_explicit` p1a–p4) étaient cités par **zéro** notebook du corpus (grep : 0 hit).

### Changements (notebook seul — 0 fichier `.lean` modifié, lake byte-identique à main)

1. **Cellule d'imports** : les 5 modules de la machinerie ajoutés (convention imports-en-tête du kernel respectée).
2. **Nouvelle section 6** « La machinerie prouvée : Beck–Fiala (b1–b4) et Erdős–Spencer (p1a–p4) » — 5 cellules :
   - **intro** : les deux résultats prouvés de bout en bout, leur découpage en boutes, et pourquoi c'était le plus grand trou de visibilité de l'EPIC ;
   - **code b1–b4** : `#check` sur les quatre briques (`card_dangerous_lt_card_floating`+`exists_dangerous_kernel_vec`, `frozen_line_sum_le`, `exists_step_hits_boundary`) puis le sommet `beck_fiala_classic` + `#print axioms` ;
   - **lecture** : la colonne vertébrale de l'algorithme de Beck–Fiala tracée par les quatre checks, et le certificat lu ;
   - **code p1a–p4** : `#check @erdos_spencer_lb_explicit` + `#print axioms` + `#check ErdosSpencerLB` (la forme `√k/2` ouverte, jamais prétendue prouvée) ;
   - **lecture** : la méthode probabiliste, l'écart documenté `√k/14` vs `√k/2`, la hiérarchie honnête.
3. **Renumérotation** : Exercices → section 7, conclusion → section 8 (étendue : la section 6 nommée dans le récap de visibilité, lien vers Search-09c enrichi de la borne `2k−1` désormais exécutée).

## Exécution réelle (H.1 — preuves)

- `lake build Discrepancy.Kernel Discrepancy.Partial Discrepancy.Progress Discrepancy.BeckFiala Discrepancy.ErdosSpencer` **as pinned** (toolchain `v4.32.1`, mathlib v4.32.1, cross-dep `learning_theory_lean` par chemin relatif) : `Build completed successfully (8671 jobs)`, exit 0 — miroir WSL FS natif `~/lean-projects/lakeroot/Search/discrepancy_lean` (md5 des 7 fichiers source + lakefile + manifest **byte-identiques à main**, vérifié avant build).
- papermill (kernel `lean4-wsl` natif WSL, cwd = racine du lake, repl matché `repl-4.32.1`) : exit 0 — 35 cellules, 13 cellules code `ec=1..13` monotones, 0 `❌`.
- Sorties réelles (extrait verbatim de la section 6) :
  ```
  #check @Discrepancy.beck_fiala_classic
  Discrepancy.beck_fiala_classic : Discrepancy.BeckFialaClassic
  #print axioms Discrepancy.beck_fiala_classic
  'Discrepancy.beck_fiala_classic' depends on axioms: [propext, Classical.choice, Quot.sound]
  #check @Discrepancy.erdos_spencer_lb_explicit
  Discrepancy.erdos_spencer_lb_explicit : ∀ (n k : ℕ), 1 ≤ k → k ≤ n → ∃ F,
    maxDegree F ≤ k ∧ ∀ (C : Fin n → ℤ), IsColoring C → k.sqrt ≤ 14 * discrepancy F C
  #print axioms Discrepancy.erdos_spencer_lb_explicit
  'Discrepancy.erdos_spencer_lb_explicit' depends on axioms: [propext, Classical.choice, Quot.sound]
  #check Discrepancy.ErdosSpencerLB
  Discrepancy.ErdosSpencerLB : Prop
  ```
  Les quatre briques intermédiaires b1–b3 résolvent aussi avec signatures complètes (`card_dangerous_lt_card_floating`, `exists_dangerous_kernel_vec`, `frozen_line_sum_le` ≤ 2k−1, `exists_step_hits_boundary`).

## Validation

- Section B (Lean) : **N/A** — aucun fichier `.lean` modifié ; compte de `sorry` du lake inchangé (byte-identique à main).
- SOTA : **SOTA-OK** — les théorèmes prouvés du lake sont chargés depuis les oleans compilés du pin, pas réimplémentés.
- `check_exec_sequence.py` (invocation directe, verbose) : **CLEAN (1..N)** — 13 cellules code `ec=1..13` · grep `raise NotImplementedError|assert False|1/0` : 0 hit · pre-commit H.3 : commit ci-dessous.
- `git diff --stat` : 1 fichier, +595/−174 (notebook seul).
