### PR TITLE
Fix: D5 enumerator scopes output_vals + filters print artifacts (#14222)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -1000,6 +1000,30 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
     n_md = sum(1 for c in cells if c.get("cell_type") == "markdown")
     n_code = sum(1 for c in cells if c.get("cell_type") == "code")
     output_vals: list[float] = []
+    # #14222 -- discriminant pre/post `7de14792c`. La detection
+    # `MISSING_FROM_PROSE_ENUMERATION` ne discrimine pas l'etat casse de
+    # l'etat repare quand `output_vals` agrege TOUT le notebook : la prose
+    # d'une cellule Conclusion enumere des niveaux concernant UNE section,
+    # pas l'ensemble du notebook. L'ICT-1 pre-fix enumere [2,31 ; 0,19]
+    # sur cell[24] mais les output_vals globaux contiennent 12 reps
+    # (notamment 1.2, 14, 7, 4) -- aucun n'a de lien causal avec la
+    # cellule Conclusion. Le verdict designe alors l'orphelin "le plus
+    # loin" (1.2) au lieu de l'orphelin qui EST conceptuellement absent
+    # de l'enumeration (0.6875 dans cell[7] de la meme section).
+    #
+    # Fix : fenetrer `output_vals` par cellule markdown = cumul des
+    # outputs des N DERNIERES cellules code NON-STUB (N = ENUM_SCOPE_LAST_N)
+    # AVANT la cellule markdown analysee. On n'utilise PAS toutes les
+    # cellules code du notebook : (a) c'est trop large (inclut les
+    # composants d'autres sections), (b) le verdict sur ICT-1 pre-fix
+    # designe alors 1.2 (rep fantaisiste d'une cellule de trajectoire)
+    # au lieu de 0.6875 (rep conceptuellement absent de l'enumeration).
+    #
+    # Cas fondateur : sur ICT-1 pre/post `7de14792c`, le verdict doit
+    # differer (pre-fix orphelin = 0.6875, post-fix orphelin distinct).
+    ENUM_SCOPE_LAST_N = 3
+    output_vals_per_md_cell: dict[int, list[float]] = {}
+    rolling_window: list[list[float]] = []  # outputs des N dernieres code non-stub
     prose_vals_per_cell: list[tuple[int, str, list[float]]] = []
     for i, c in enumerate(cells):
         ctype = c.get("cell_type")
@@ -1011,10 +1035,35 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
         if ctype == "code":
             for out in (c.get("outputs") or []):
                 output_vals.extend(_extract_output_numbers(out))
+            # Maintient la fenetre des N dernieres cellules NON-STUB. Les
+            # stubs d'exercice (cell[19/21/23] d'ICT-1) sont ignores
+            # (_is_stub_code_cell) -- ils ne produisent pas de niveaux.
+            if not _is_stub_code_cell(c):
+                cell_outs: list[float] = []
+                for out in (c.get("outputs") or []):
+                    cell_outs.extend(_extract_output_numbers(out))
+                rolling_window.append(cell_outs)
+                if len(rolling_window) > ENUM_SCOPE_LAST_N:
+                    rolling_window.pop(0)
         elif ctype == "markdown":
             nums = _extract_prose_numbers(text)
             if nums:
                 prose_vals_per_cell.append((i, text, nums))
+        # Capture le cumul fenetre APRES chaque cellule (incluse si code).
+        # Au moment ou on traite une cellule markdown d'index i, la fenetre
+        # contient les outputs des N dernieres cellules code non-stub
+        # d'index < i. C'est ce que MISSING_FROM_PROSE_ENUMERATION utilise
+        # pour discriminer l'etat casse de l'etat repare (cf #14222).
+        #
+        # Filtre #14222 : exclure les valeurs ENTIERES (iteration index,
+        # compteur, taille d'un basin, cle d'un dict). Ces valeurs ne
+        # representent pas une mesure output -- elles sont des arte
+        # facts de print, et elles ombragent systematiquement les
+        # niveaux reels (mesure : sur ICT-1, le `1.0` d'iteration index
+        # de cell[7] ecrase `0,6875` dans la liste des reps par groupe
+        # de tolerance -- la garde nommait `1.0`, jamais `0,6875`).
+        raw_window = [v for outs in rolling_window for v in outs]
+        output_vals_per_md_cell[i] = [v for v in raw_window if v != round(v)]
     # Alignement : pour chaque cellule markdown, pour chaque nombre,
     # cherche le plus proche dans output_vals.
     findings: list[AlignmentFinding] = []
@@ -1094,59 +1143,69 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
     # niveau output. Un representant output (1re valeur de chaque groupe
     # de tolerance) est orphelin s'il n'a aucune valeur prose dans son
     # voisinage (meme tolerance que le groupement). Pour ICT-1 (pre-fix) :
-    # representants outputs = [0,1875 ; 0,6875 ; 2,3125], enumeration prose
-    # = [0,19 ; 2,31] -> 0,1875 couvert (1% de 0,19), 0,6875 NON couvert
-    # (72% de 0,19 et 73% de 2,31), 2,3125 couvert (0,1% de 2,31) ->
-    # orphelin = 0,6875. Pour ICT-1 (post-fix) : enumeration = [0,19 ;
-    # 0,69 ; 2,31] -> les 3 representants trouvaient une prose proche ->
-    # pas de finding.
-    if output_vals:
-        output_reps = _distinct_level_values(output_vals)
+    # fenetre = cell[11+12+15] (3 dernieres cellules code non-stub), filtre
+    # entiers (iteration index, compteur de basin) -> representants
+    # = [0,188 ; 0,687 ; 2,312] (= 0,6875 redonde par cell[11] a 0,687),
+    # enumeration prose = [0,19 ; 2,31] -> 0,188 couvert (1% de 0,19),
+    # 2,312 couvert (0,1% de 2,31), 0,687 NON couvert (72% de 0,19) ->
+    # orphelin = 0,687 (= 0,6875 du niveau logique). Pour ICT-1 (post-fix)
+    # : enumeration = [0,19 ; 0,69 ; 2,31] -> 0,687 couvert (0,4% de 0,69),
+    # tous representants sont couverts -> verdict different.
+    for cell_idx, text, nums in prose_vals_per_cell:
+        enum = _detect_prose_enumeration(text)
+        if not enum:
+            continue
+        # #14222 -- output_vals est fenetre par cellule markdown (cf bloc
+        # ci-dessus) : on ne confronte pas l'enumeration aux outputs du
+        # notebook entier, mais aux outputs des N dernieres cellules code
+        # non-stub avant cette cellule markdown. C'est ce qui permet la
+        # discrimination pre/post `7de14792c` sur ICT-1.
+        output_vals_local = output_vals_per_md_cell.get(cell_idx, [])
+        if not output_vals_local:
+            continue
+        output_reps = _distinct_level_values(output_vals_local)
         output_levels = len(output_reps)
-        for cell_idx, text, nums in prose_vals_per_cell:
-            enum = _detect_prose_enumeration(text)
-            if not enum:
+        prose_levels = _distinct_levels(enum)
+        if prose_levels == 0 or output_levels <= prose_levels:
+            continue
+        # Trouve le representant output non couvert par l'enumeration prose.
+        orphan = None
+        orphan_dist = -1.0
+        for rep in output_reps:
+            closest_p = min(enum, key=lambda p: abs(p - rep))
+            base = max(abs(closest_p), abs(rep))
+            if base == 0:
+                # Represente 0 couvert par une prose 0 -> match, pas orphelin.
                 continue
-            prose_levels = _distinct_levels(enum)
-            if prose_levels == 0 or output_levels <= prose_levels:
-                continue
-            # Trouve le representant output non couvert par l'enumeration prose.
-            orphan = None
-            orphan_dist = -1.0
-            for rep in output_reps:
-                closest_p = min(enum, key=lambda p: abs(p - rep))
-                base = max(abs(closest_p), abs(rep))
-                if base == 0:
-                    # Represente 0 couvert par une prose 0 -> match, pas orphelin.
-                    continue
-                dist = abs(rep - closest_p) / base
-                if dist <= RELATIVE_TOLERANCE:
-                    continue  # ce representant a une prose proche -> couvert
-                if dist > orphan_dist:
-                    orphan_dist = dist
-                    orphan = rep
-            if orphan is None:
-                continue  # tous les representants sont couverts -> RAS
-            snippet = text.strip().splitlines()
-            snippet = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
-            findings.append(AlignmentFinding(
-                notebook=str(path),
-                cell_index=cell_idx,
-                cell_kind="markdown",
-                category="MISSING_FROM_PROSE_ENUMERATION",
-                prose_text=snippet,
-                prose_number=float(prose_levels),
-                closest_output_number=orphan,
-                tolerance_used="enumeration-vs-outputs",
-                details=(
-                    f"prose enumere {prose_levels} niveaux distincts, "
-                    f"outputs exhibent {output_levels} niveaux distincts "
-                    f"({len(output_reps)} representants: "
-                    f"{', '.join(f'{r:.4g}' for r in output_reps)}) "
-                    f"-- orphelin {orphan:.4g} non couvert "
-                    f"(min dist prose = {orphan_dist:.1%}, > tol {RELATIVE_TOLERANCE:.0%})"
-                ),
-            ))
+            dist = abs(rep - closest_p) / base
+            if dist <= RELATIVE_TOLERANCE:
+                continue  # ce representant a une prose proche -> couvert
+            if dist > orphan_dist:
+                orphan_dist = dist
+                orphan = rep
+        if orphan is None:
+            continue  # tous les representants sont couverts -> RAS
+        snippet = text.strip().splitlines()
+        snippet = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
+        findings.append(AlignmentFinding(
+            notebook=str(path),
+            cell_index=cell_idx,
+            cell_kind="markdown",
+            category="MISSING_FROM_PROSE_ENUMERATION",
+            prose_text=snippet,
+            prose_number=float(prose_levels),
+            closest_output_number=orphan,
+            tolerance_used="enumeration-vs-outputs",
+            details=(
+                f"prose enumere {prose_levels} niveaux distincts, "
+                f"outputs (fenetre N={ENUM_SCOPE_LAST_N} cellules code "
+                f"non-stub) exhibent {output_levels} niveaux distincts "
+                f"({len(output_reps)} representants: "
+                f"{', '.join(f'{r:.4g}' for r in output_reps)}) "
+                f"-- orphelin {orphan:.4g} non couvert "
+                f"(min dist prose = {orphan_dist:.1%}, > tol {RELATIVE_TOLERANCE:.0%})"
+            ),
+        ))
     return NotebookAlignment(
         path=str(path),
         total_findings=len(findings),

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -597,12 +597,16 @@ class TestMissingFromProseEnumeration:
 
     def test_ict1_founder_signaled(self, tmp_path):
         """Cas fondateur #9416 : prose dit « 2,31 + 0,19 » (2 niveaux)
-        mais outputs exhibent 3 niveaux dont 0.6875 omis."""
+        mais outputs exhibent 3 niveaux dont 0.6875 omis.
+
+        Scoping (#14222) : la cellule code precede la cellule markdown
+        pour que la fenetre d'output_vals capture les niveaux exhibes.
+        """
         nb = tmp_path / "ict1_founder.ipynb"
         _make_notebook([
-            _markdown_cell("un pic a 2,31, le reste a 0,19"),
             _code_cell("print(0.1875); print(0.6875); print(2.3125)",
                        [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
         ], nb)
         result = mod.analyze_notebook(nb)
         assert result.total_findings >= 1
@@ -618,12 +622,15 @@ class TestMissingFromProseEnumeration:
         assert "2 niveaux" in f.details
 
     def test_no_signal_when_outputs_match_prose(self, tmp_path):
-        """Si la prose enumere N niveaux ET outputs en exhibent N, RAS."""
+        """Si la prose enumere N niveaux ET outputs en exhibent N, RAS.
+
+        Scoping (#14222) : la cellule code precede la cellule markdown.
+        """
         nb = tmp_path / "clean_enum.ipynb"
         _make_notebook([
-            _markdown_cell("les 3 valeurs sont 0.19, 0.69 et 2.31."),
             _code_cell("print(0.19); print(0.69); print(2.31)",
                        [{"text": "0.19\n0.69\n2.31\n"}]),
+            _markdown_cell("les 3 valeurs sont 0.19, 0.69 et 2.31."),
         ], nb)
         result = mod.analyze_notebook(nb)
         enum_findings = [f for f in result.findings
@@ -647,12 +654,16 @@ class TestMissingFromProseEnumeration:
         (meme tolerance que le groupement). Pour ICT-1 (pre-fix) :
         representants = [0,1875 ; 0,6875 ; 2,3125], enumeration = [0,19 ;
         2,31] -> 0,1875 couvert, 0,6875 NON couvert (72% de 0,19) -> orphelin.
+
+        Scoping : l'enumeration est confrontee aux outputs des cellules code
+        NON-STUB PRECEDANT la cellule markdown (cf #14222). Le test place
+        donc la cellule code AVANT la cellule markdown.
         """
         nb = tmp_path / "ict1_pre_fix.ipynb"
         _make_notebook([
-            _markdown_cell("un pic a 2,31, le reste a 0,19"),
             _code_cell("print(0.1875); print(0.6875); print(2.3125)",
                        [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
         ], nb)
         result = mod.analyze_notebook(nb)
         enum_findings = [f for f in result.findings
@@ -682,21 +693,23 @@ class TestMissingFromProseEnumeration:
         Avant le fix, les DEUX revisions rendaient le meme verdict
         (1 finding), avec des orphelins fantaisistes (``1,2`` puis ``14,0``).
         Apres le fix, pre-fix signale, post-fix est muet.
+
+        Scoping : la cellule code precede la cellule markdown (cf #14222).
         """
         # PRE-FIX (cas fondateur)
         pre = tmp_path / "ict1_pre_fix.ipynb"
         _make_notebook([
-            _markdown_cell("un pic a 2,31, le reste a 0,19"),
             _code_cell("print(0.1875); print(0.6875); print(2.3125)",
                        [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
         ], pre)
         # POST-FIX (prose ajoute le relief intermediaire)
         post = tmp_path / "ict1_post_fix.ipynb"
         _make_notebook([
-            _markdown_cell("un pic a 2,31, le reste a 0,19, un relief "
-                          "intermediaire a 0,69"),
             _code_cell("print(0.1875); print(0.6875); print(2.3125)",
                        [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+            _markdown_cell("un pic a 2,31, le reste a 0,19, un relief "
+                          "intermediaire a 0,69"),
         ], post)
 
         enum_pre = [f for f in mod.analyze_notebook(pre).findings
@@ -725,12 +738,12 @@ class TestMissingFromProseEnumeration:
         distinctes ``0,60`` ou ``0,80`` choisies arbitrairement."""
         nb = tmp_path / "representant_picks.ipynb"
         _make_notebook([
-            _markdown_cell("les 2 valeurs sont 0.19 et 2.31."),
             # Outputs : 4 valeurs -> 3 niveaux distincts (tol 5%)
             # groupe 1 : 0.18 ; groupe 2 : 0.69 ; groupe 3 : 2.30
             # representants : [0.18, 0.69, 2.30]
             _code_cell("a=0.180; b=0.700; c=2.300; print(a); print(b); print(c)",
                        [{"text": "0.18\n0.70\n2.30\n"}]),
+            _markdown_cell("les 2 valeurs sont 0.19 et 2.31."),
         ], nb)
         result = mod.analyze_notebook(nb)
         enum_findings = [f for f in result.findings
@@ -772,9 +785,9 @@ class TestJsonOutDetails:
         d'encoding cp1252). Le test verifie les 3 champs ajoutes."""
         nb = tmp_path / "ict1_pre_fix.ipynb"
         _make_notebook([
-            _markdown_cell("un pic a 2,31, le reste a 0,19"),
             _code_cell("print(0.1875); print(0.6875); print(2.3125)",
                        [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
         ], nb)
         out = tmp_path / "out.json"
         results = [mod.analyze_notebook(nb)]
@@ -1648,10 +1661,37 @@ class TestICT1CounterEvidence:
     _CANDIDATE_ROOTS = (
         Path("D:/dev/CoursIA-2"),
         Path("D:/dev/CoursIA"),
+        Path("C:/dev/CoursIA-2"),
+        Path("C:/dev/CoursIA-d5fix"),
         Path(os.environ.get("COURSIA_ROOT", "") or "_/_"),
     )
     REPO_ROOT = next((p for p in _CANDIDATE_ROOTS if p.exists() and p.is_dir()), _CANDIDATE_ROOTS[0])
     NB_PATH = "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb"
+
+    def _git_show(self, ref: str) -> bytes:
+        """git show <ref>:<path> depuis la racine repo ; bytes bruts."""
+        if not self.REPO_ROOT.exists():
+            pytest.skip(f"Repo root {self.REPO_ROOT} absent")
+        try:
+            return subprocess.check_output(
+                ["git", "show", f"{ref}:{self.NB_PATH}"],
+                cwd=str(self.REPO_ROOT),
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as exc:
+            pytest.skip(f"git show {ref}:{self.NB_PATH} impossible : {exc}")
+
+    def _analyze_ref(self, ref: str):
+        """Retourne NotebookAlignment pour la révision git `ref`."""
+        content = self._git_show(ref)
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as f:
+            f.write(content)
+            tmp_path = Path(f.name)
+        try:
+            return mod.analyze_notebook(tmp_path)
+        finally:
+            tmp_path.unlink()
 
     def test_pre_fix_ict_1_signaled(self):
         """Lecture du notebook a la revision parente du fix #9416 via git show.
@@ -1664,25 +1704,7 @@ class TestICT1CounterEvidence:
         Skip si aucune racine de repo n'est accessible (path developper-specific
         sur le runner CI). Cf Hermes review nit PR #9793.
         """
-        if not self.REPO_ROOT.exists():
-            pytest.skip(f"Repo root {self.REPO_ROOT} absent (developper-specific path)")
-        try:
-            content = subprocess.check_output(
-                ["git", "show", "7de14792c^:MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb"],
-                cwd=str(self.REPO_ROOT),
-                stderr=subprocess.PIPE,
-            )
-        except subprocess.CalledProcessError:
-            pytest.skip("ICT-1 absent ou commit absent localement")
-        # Ecriture dans un tmp pour analyse via le module.
-        import tempfile
-        with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as f:
-            f.write(content)
-            tmp_path = Path(f.name)
-        try:
-            result = mod.analyze_notebook(tmp_path)
-        finally:
-            tmp_path.unlink()
+        result = self._analyze_ref("7de14792c^")
         # La prose pre-#9416 inclut « 2,31 » et « 0,19 » mais PAS « 0,69 ».
         # Les outputs incluent 0.6875 (avec arrondi). Le detecteur DOIT
         # signaler au moins un finding MISSING_FROM_OUTPUTS sur la valeur
@@ -1709,6 +1731,54 @@ class TestICT1CounterEvidence:
             f"MISSING_FROM_PROSE_ENUMERATION (cas fondateur #9416), "
             f"aucun trouve parmi {len(result.findings)} findings. "
             f"categories={[f.category for f in result.findings]}"
+        )
+
+    def test_14222_discrimination_pre_vs_post_real_notebook(self):
+        """Acceptance #14222 END-TO-END sur le vrai ICT-1 (`7de14792c^`
+        pre-fix vs `7de14792c` post-fix) :
+
+        - pre-fix : 1 finding MISSING_FROM_PROSE_ENUMERATION, orphelin = 0.6875
+          (le niveau `0,6875` omis par la prose « un pic a 2,31, le reste a 0,19 »).
+        - post-fix : 0 finding MISSING_FROM_PROSE_ENUMERATION
+          (la prose « un relief intermediaire a 0,69 » couvre les 3 niveaux).
+
+        Verdict doit DIFFERER entre les deux revisions. Avant le fix
+        (#14222), les DEUX revisions rendaient 1 finding avec des orphelins
+        fantaisistes (`1,2` puis `14,0`). Apres le fix, pre-fix signale avec
+        l'orphelin conceptuellement correct, post-fix est muet.
+
+        Le `closest_output_number` peut etre 0.687 (cell[11] redonde a 3
+        decimales via `round(p, 3)`) au lieu de 0.6875 (cell[7]). On accepte
+        l'un OU l'autre (meme niveau logique, dans la tolerance 5% du groupement
+        `_distinct_level_values`).
+        """
+        pre = self._analyze_ref("7de14792c^")
+        post = self._analyze_ref("7de14792c")
+
+        enum_pre = [f for f in pre.findings
+                    if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        enum_post = [f for f in post.findings
+                     if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+
+        # Verdict doit DIFFERER : pre-fix a un finding enum, post-fix aucun.
+        assert len(enum_pre) == 1, (
+            f"Pre-fix ICT-1 (`7de14792c^`) doit signaler exactement 1 manquant "
+            f"enumere, pas {len(enum_pre)}. details pre={[f.details for f in enum_pre]}"
+        )
+        assert len(enum_post) == 0, (
+            f"Post-fix ICT-1 (`7de14792c`) ne doit signaler AUCUN manquant "
+            f"enumere (la prose enumere 3 niveaux : 0,19, 0,69, 2,31), "
+            f"trouve {len(enum_post)}. details post={[f.details for f in enum_post]}"
+        )
+        # L'orphelin du cote pre-fix doit etre le niveau 0,6875 (tolere :
+        # 0.687 cell[11] redonde par round(p,3), 0.6875 cell[7] brut -- meme
+        # niveau logique dans le groupement `_distinct_level_values`).
+        orphan = enum_pre[0].closest_output_number
+        assert orphan is not None and (orphan == pytest.approx(0.6875, abs=1e-3)
+                                       or orphan == pytest.approx(0.687, abs=1e-3)), (
+            f"Acceptance #14222 : orphelin pre-fix doit etre 0.6875 (ou 0.687 "
+            f"via cell[11] redonde), pas {orphan}. "
+            f"Avant le fix, l'orphelin etait 1.2 ou 14.0 (fantaisistes)."
         )
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA-2 — prev: MED/qc #14317

Closes #14222

## Acceptance #14222 — discriminator pre/post `7de14792c`

Verifie via le test `TestICT1CounterEvidence::test_14222_discrimination_pre_vs_post_real_notebook` qui extrait le notebook ACTUEL via `git show 7de14792c^:...` et `git show 7de14792c:...` :

| Revision | enum findings | orphan | prose_number |
|---|---:|---:|---:|
| **pre-fix** (`7de14792c^`) | 1 | **0.687** (= 0.6875 redonde par cell[11] `round(p, 3)`) | 2.0 |
| **post-fix** (`7de14792c`) | 0 | — | — |

**Verdict DIFFER.** Le discriminateur prevu par #14222 est operationnel :
avant le fix, les DEUX revisions rendaient 1 finding avec des orphelins
fantaisistes (`1.2` puis `14.0`), jamais le niveau reellement absent de
l'enumeration. Apres le fix, pre-fix signale avec l'orphelin conceptuellement
correct (= 0.6875), post-fix est muet.

## Deux changements structurels dans `scan_d5_prose_outputs_alignment.py`

1. **Fenetre d'`output_vals` par cellule markdown** : au lieu d'agreger
   toutes les sorties du notebook (meme celles d'autres sections non
   liees a la prose analysee), chaque cellule markdown voit le cumul
   des outputs des N=3 dernieres cellules code NON-STUB qui la precedent.
   Le predicat fondateur devient « l'enumeration prose est-elle couverte
   par les niveaux exhibes juste au-dessus dans le notebook ? », pas «
   par tous les niveaux exhibes n'importe ou dans le notebook ».

2. **Filtre des valeurs entieres** : les indices d'iteration de boucle
   (`print(...)` dans une comprehension), les compteurs de bassin
   (`{((0, 0, 0),): 1, ...}`), les cles de dictionnaire, etc. ne sont
   pas des mesures. Sur ICT-1, le `1.0` d'iteration index de cell[7]
   eclipserait systematiquement `0.6875` dans `_distinct_level_values`
   (meme groupe de tolerance au sens large, premier rep gagne). Le
   filtre `v != round(v)` elimine ces artefacts avant le groupement.

## Tests verts

```
163 passed, 1 skipped in 2.04s
```

- **Nouveau** : `TestICT1CounterEvidence::test_14222_discrimination_pre_vs_post_real_notebook`
  -- acceptance end-to-end sur le vrai notebook extrait via git show.
- **Mis a jour** : 4 tests existants dont les fixtures plaçaient
  markdown AVANT code. La nouvelle semantique exige que le code precede
  le markdown pour que la fenetre d'`output_vals` capture les niveaux.
- `check_lane_claim` pre-flight OK (cf commentaire de claim #14222).

## Suite du travail (#14222 / #9768 Phase 3)

Le fix ferme la dette de l'instrument. La Phase 3 de l'EPIC #9768
(28 notebooks DRIFT) reste a traiter comme travail de fond -- ce n'est
plus bloque par ce discriminateur.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
