### PR TITLE
fix(ci,#13607): identity-proof python probe non fatale sur le job dotnet

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -107,8 +107,16 @@ jobs:
           Write-Output "runner.arch=$env:RUNNER_ARCH"
           Write-Output "runner.temp=$env:RUNNER_TEMP"
           dotnet --info | Out-String | Write-Output
-          python --version
-          python -m pip --version
+          # Sonde python non fatale : ce job .NET n'exécute pas python (pas de
+          # setup-python ici, contrairement au job confinement). Sur le runner
+          # fast-guards, python est absent du PATH -- l'identité le CAPTURE
+          # (run 33720594511 : la sonde fatale tuait le job avant restore).
+          if (Get-Command python -ErrorAction SilentlyContinue) {
+            python --version
+            python -m pip --version
+          } else {
+            Write-Output "python: absent du PATH (non requis par ce job .NET)"
+          }
 
       - name: Set up .NET 9
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2025:CoursIA — prev: LIGHT/tooling #13607

## Fix ci(#13607): sonde python non fatale dans l'identity proof du job dotnet

### Summary

Le geste de #13607 (run réel du véhicule de #13605, gate levé par merge + ai-01 « actionnable ») a été exécuté : dispatch `windows-self-hosted-tests.yml` `target=dotnet` sur `main` → **run 33720594511 ECHEC à l'étape 3 « Identity proof »**. Cause racine : la preuve d'identité appelle `python --version` sans garde, or le job dotnet n'a **pas** de `setup-python` (contrairement au job confinement qui en dépend pour pytest) et le runner `myia-po-2024-fast-guards` n'a pas python sur son PATH → sonde fatale, étapes 4-7 (setup .NET / restore / build / test) toutes **skipped**. Le défaut était latent : c'était le premier dispatch du job dotnet depuis le merge de #13605.

### Changement

Un seul fichier, job `windows-dotnet-tests` uniquement (job confinement intact — lui a `setup-python` et exécute pytest) :

- `python --version` + `python -m pip --version` → sonde gardée `if (Get-Command python -ErrorAction SilentlyContinue)` qui capture `python: absent du PATH (non requis par ce job .NET)` en cas d'absence.

L'item d'acceptance « identity proof capturée (runner + dotnet --info + python) » est satisfait par la **capture** de l'état réel — la mission #13378 est de valider l'absorption d'un job **.NET 9** par le runner, python n'y est pas requis.

### Preuves du run réel (avant fix)

- Runner attribué : `myia-po-2024-fast-guards` (online+idle au dispatch, consommé par le job — cycle éphéméral nominal)
- Capturé : `runner.name=myia-po-2024-fast-guards`, `runner.os=Windows`, `runner.arch=X64`, SDK .NET 8.0.424 / **9.0.317** / 10.0.111
- Échec : `python: The term 'python' is not recognized` (pwsh, exit 1) → étapes restore/build/test skipped

### Validation

- `yaml.safe_load` OK sur le workflow modifié (15 lignes dans le bloc identity)
- Re-dispatch de validation : **gated** sur ré-enregistrement du runner éphéméral par la lane po-2024 (le run a consommé l'enregistrement courant, le runner n'est plus dans `actions/runners` au moment de cette PR). Après merge + ré-enregistrement : `gh workflow run windows-self-hosted-tests.yml --ref main -f target=dotnet` complète l'acceptance #13607 (restore/build/test + verdict).

See #13607
See #13378
Refs #13605
