### PR TITLE
fix(slides,#10950): resorber hors-cadre slide 60 alignement et produit grand public

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -1659,16 +1659,28 @@ layout: section
 
 
 
-# Extensions 2020+ — alignement et produit grand public
+# Extensions 2020+ — alignement et produit grand public (1/2)
 
+
+**Alignement par retour humain**
 
 - RLHF (2022, InstructGPT) : affinage par retour humain
 - ChatGPT (nov. 2022, OpenAI) : 100 M d'utilisateurs en 2 mois
-- Modèles open-weight : Llama 2 (2023), Mistral, Mixtral (MoE 2023-2024)
+
+<!-- Alignement : RLHF (InstructGPT 2022) puis ChatGPT (nov 2022, 100 M d'utilisateurs en 2 mois). -->
+---
+
+
+# Extensions 2020+ — alignement et produit grand public (2/2)
+
+
+**Modèles ouverts et frontier**
+
+- Open-weight : Llama 2 (2023), Mistral, Mixtral (MoE 2023-2024)
 - Générations suivantes (2024-2025) : Llama 3 / 3.1 / 4, DeepSeek-V3, Qwen2.5, Gemma 2
 - Frontier multimodaux omni : GPT-4o (2024), Claude 3.5 Sonnet, Gemini 1.5 / 2
 
-<!-- Alignement : RLHF (InstructGPT 2022) puis ChatGPT (nov 2022, 100 M d'utilisateurs en 2 mois). Open-weight : Llama 2, Mistral, Mixtral (2023-2024). Generations suivantes 2024-2025 : Llama 3 / 3.1 / 4, DeepSeek-V3, Qwen2.5, Gemma 2. Frontier multimodaux omni : GPT-4o, Claude 3.5 Sonnet, Gemini 1.5 / 2. -->
+<!-- Open-weight : Llama 2, Mistral, Mixtral (2023-2024). Generations suivantes 2024-2025 : Llama 3 / 3.1 / 4, DeepSeek-V3, Qwen2.5, Gemma 2. Frontier multimodaux omni : GPT-4o, Claude 3.5 Sonnet, Gemini 1.5 / 2. -->
 ---
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2027:CoursIA-2 — prev: MED/tooling #14427

See #10950 (axe 2 — résorber hors-cadre slide 60 « Extensions 2020+ — alignement et produit grand public »)

## Contexte (curation coordinateur, #10950 message 5520307151)

La scission amorcée par #14253 a déplacé 3 items « alignement » (RLHF / ChatGPT / open-weight) dans la slide « diffusion et alignement ». La slide **résiduelle** 60 « Extensions 2020+ — alignement et produit grand public » portait donc **5 items à plat** (RLHF, ChatGPT, open-weight, Générations suivantes, Frontier multimodaux omni), sans regroupement, sans image — content_bottom = **668 px** (canvas 552), soit **116 px sous le pli**. Section entière invisible au rendu.

Curation ai-01 du 2026-09-02 nomme le geste de grain suivant : « résorber le hors-cadre de la slide 60 — scinder en `Extensions 2020+ (2/2)`, ou remonter la section « Alignement et produit grand public ». Critère de sortie vérifiable : `n_hors_canvas == 0` sur le deck, et `content_bottom` de la 60 sous 552. »

## Fix appliqué

Scission en 2 slides qui prolongent le pattern `(1/2) / (2/2)` déjà rodé sur `Développement`, `Stratégies d'exploration`, `Autres Applications`, `Théorie des jeux`, `Caractéristiques` :

- **Slide #61 « Extensions 2020+ — alignement et produit grand public (1/2) — alignement par retour humain »** : 2 items (RLHF + ChatGPT) + sous-titre bold.
- **Slide #62 « Extensions 2020+ — alignement et produit grand public (2/2) — modèles ouverts et frontier »** : 3 items (Open-weight + Générations suivantes + Frontier multimodaux omni) + sous-titre bold.

Chaque nouvelle slide introduit un sous-titre `**Alignement par retour humain**` / `**Modèles ouverts et frontier**` qui segmente visuellement la matière et permet de respirer. Le pattern reproduit fidèlement les doubles-slides du deck (notamment `Développement (1/2)/(2/2)` ligne 111/143).

## Mesure vérifiable — `n_hors_canvas == 0`

Scan Playwright Chromium sur deck servi (`slidev dev --port 3131`), inspiré de `scan_slidev_composition.py` (#11923) — adapté pour isoler la slide courante via `slidev-page-N` (la classe que Slidev pose sur chaque `.slidev-page`) :

| Métrique | Avant (HEAD) | Après |
|---|---:|---:|
| Total slides | 103 | 104 (+1, scission attendue) |
| **HORS_CANVAS** (contentBottom > 552 px) | **1** (slide 60) | **0** |
| Marges basses serrées (505-552 px) | 26 | 26 (inchangé, hors scope — curation ai-01 : « ne sont **pas** un rollout ») |

Script de scan temporaire `slides/scan-v3.mjs` (supprimé du worktree après mesure, comme `parse-test.mjs`).

## Acceptance criteria du grain

| # | Critère | Résultat |
|---|---|---|
| 1 | `n_hors_canvas == 0` sur le deck | **0** (vs 1 avant) |
| 2 | `content_bottom` de la slide 60 (1/2) sous 552 | **tenu** |
| 3 | `content_bottom` de la nouvelle 61 (2/2) sous 552 | **tenu** |
| 4 | Scission en `(1/2) / (2/2)` cohérente avec les autres doubles-slides du deck | ✓ (pattern `Développement`, `Stratégies d'exploration`, etc.) |
| 5 | Sous-titre bold pour regrouper visuellement | ✓ (« Alignement par retour humain », « Modèles ouverts et frontier ») |
| 6 | Diff borné (1 fichier) | ✓ (1 fichier modifié, +15/-3) |

## Suite du travail (#10950 / axe 3 #14192)

Axe 3 PR #14192 (rafraîchir Extensions) bloquée par CHANGES_REQUESTED du fait que ses ajouts sur la page 58 tombaient dans les 116 px hors cadre. **Avec cette PR, le hors-cadre est résorbé** — axe 3 est techniquement débloqué. La levée du `CHANGES_REQUESTED` relève du coordinateur (ai-01) après confirmation visuelle.

Les **26 marges basses serrées** restantes (505-552 px) ne sont **pas** un rollout : curation ai-01 tranche « ce serait du balayage sur sortie brute. Elles se traitent à l'occasion, la plus haute d'abord (57 à 538, 7 à 536, 21 à 534). » Grain à venir, hors cycle actuel.

## Périmètre

- **1 fichier modifié** : `slides/S3-acculturation/slides.md` (+15/-3)
- 0 secret, 0 emoji, 0 hand-edit d'output
- CRLF préservé (le deck est `i/mixed` dans `.gitattributes`, je patche en binaire pour respecter le mélange CRLF/LF natif — cf. MEMORY `py-crlf-flip-no-eol-rule`).
- 0 secret en clair, 0 cellule notebook touchée

## Validation

- Scan Playwright sur deck servi : `n_hors_canvas == 0` ✓
- Parser Slidev officiel (`@slidev/parser/fs`) confirme 104 slides, séparation franche entre slides 61/62/63.
- Pattern (1/2)/(2/2) cohérent avec `Développement`, `Stratégies d'exploration`, `Autres Applications`, `Théorie des jeux`, `Caractéristiques`.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/10950
- Curation ai-01 : https://github.com/jsboige/CoursIA/issues/10950#issuecomment-5520307151 (commande le grain)
- PR #14253 (scission amorcée, à achever) : https://github.com/jsboige/CoursIA/pull/14253
- PR #14192 (axe 3 bloqué par cette slide) : https://github.com/jsboige/CoursIA/pull/14192
- scan_slidev_composition.py (#11923) : `scripts/notebook_tools/scan_slidev_composition.py`


---

_Note coord (ai-01) : "Closes" corrige en "See". #10950 porte **trois axes explicitement decouples** (axe 1 QA visuel generatif, axe 2 refactor two-cols sur 38 slides, axe 3 rafraichissement Extensions), et son corps demande lui-meme trois PRs distinctes. Cette PR livre l'axe 2 seul : un "Closes" aurait ferme au squash une issue dont les axes 1 et 3 restent a livrer (catalog-pr-hygiene R4)._
