### PR TITLE
fix(search,#14061): 2 refs Search-15/16 vers 02b/02c (residu rename #13797 §D-3)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb
@@ -5,10 +5,10 @@
    "id": "443fe805",
    "metadata": {
     "papermill": {
-     "duration": 0.00923,
-     "end_time": "2026-09-01T13:32:51.682395+00:00",
+     "duration": 0.004,
+     "end_time": "2026-09-03T08:23:22.702801",
      "exception": false,
-     "start_time": "2026-09-01T13:32:51.673165+00:00",
+     "start_time": "2026-09-03T08:23:22.698801",
      "status": "completed"
     },
     "tags": []
@@ -78,10 +78,10 @@
    "id": "27a1da1e",
    "metadata": {
     "papermill": {
-     "duration": 0.007148,
-     "end_time": "2026-09-01T13:32:51.697212+00:00",
+     "duration": 0.00301,
+     "end_time": "2026-09-03T08:23:22.709333",
      "exception": false,
-     "start_time": "2026-09-01T13:32:51.690064+00:00",
+     "start_time": "2026-09-03T08:23:22.706323",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +126,16 @@
    "id": "1e00ea37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:51.731660Z",
-     "iopub.status.busy": "2026-09-01T13:32:51.719440Z",
-     "iopub.status.idle": "2026-09-01T13:32:55.044318Z",
-     "shell.execute_reply": "2026-09-01T13:32:55.025888Z"
+     "iopub.execute_input": "2026-09-03T08:23:22.726950Z",
+     "iopub.status.busy": "2026-09-03T08:23:22.720839Z",
+     "iopub.status.idle": "2026-09-03T08:23:24.663069Z",
+     "shell.execute_reply": "2026-09-03T08:23:24.659072Z"
     },
     "papermill": {
-     "duration": 3.340183,
-     "end_time": "2026-09-01T13:32:55.045262+00:00",
+     "duration": 1.951,
+     "end_time": "2026-09-03T08:23:24.663069",
      "exception": false,
-     "start_time": "2026-09-01T13:32:51.705079+00:00",
+     "start_time": "2026-09-03T08:23:22.712069",
      "status": "completed"
     },
     "tags": []
@@ -150,6 +150,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -159,7 +160,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -174,6 +178,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -185,11 +190,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '23244.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '47308.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -233,11 +240,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -280,16 +289,16 @@
    "id": "fd95f8f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:55.059695Z",
-     "iopub.status.busy": "2026-09-01T13:32:55.059285Z",
-     "iopub.status.idle": "2026-09-01T13:32:55.155899Z",
-     "shell.execute_reply": "2026-09-01T13:32:55.155635Z"
+     "iopub.execute_input": "2026-09-03T08:23:24.673279Z",
+     "iopub.status.busy": "2026-09-03T08:23:24.671765Z",
+     "iopub.status.idle": "2026-09-03T08:23:24.709151Z",
+     "shell.execute_reply": "2026-09-03T08:23:24.708604Z"
     },
     "papermill": {
-     "duration": 0.106748,
-     "end_time": "2026-09-01T13:32:55.156018+00:00",
+     "duration": 0.041388,
+     "end_time": "2026-09-03T08:23:24.709151",
      "exception": false,
-     "start_time": "2026-09-01T13:32:55.049270+00:00",
+     "start_time": "2026-09-03T08:23:24.667763",
      "status": "completed"
     },
     "tags": []
@@ -370,10 +379,10 @@
    "id": "b95ad098",
    "metadata": {
     "papermill": {
-     "duration": 0.00469,
-     "end_time": "2026-09-01T13:32:55.165796+00:00",
+     "duration": 0.004524,
+     "end_time": "2026-09-03T08:23:24.717189",
      "exception": false,
-     "start_time": "2026-09-01T13:32:55.161106+00:00",
+     "start_time": "2026-09-03T08:23:24.712665",
      "status": "completed"
     },
     "tags": []
@@ -412,16 +421,16 @@
    "id": "ab88336c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:55.184775Z",
-     "iopub.status.busy": "2026-09-01T13:32:55.184464Z",
-     "iopub.status.idle": "2026-09-01T13:32:56.388652Z",
-     "shell.execute_reply": "2026-09-01T13:32:56.388404Z"
+     "iopub.execute_input": "2026-09-03T08:23:24.726695Z",
+     "iopub.status.busy": "2026-09-03T08:23:24.725695Z",
+     "iopub.status.idle": "2026-09-03T08:23:25.300655Z",
+     "shell.execute_reply": "2026-09-03T08:23:25.300655Z"
     },
     "papermill": {
-     "duration": 1.211053,
-     "end_time": "2026-09-01T13:32:56.388763+00:00",
+     "duration": 0.580983,
+     "end_time": "2026-09-03T08:23:25.302168",
      "exception": false,
-     "start_time": "2026-09-01T13:32:55.177710+00:00",
+     "start_time": "2026-09-03T08:23:24.721185",
      "status": "completed"
     },
     "tags": []
@@ -517,16 +526,16 @@
    "id": "ebd168b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:56.401140Z",
-     "iopub.status.busy": "2026-09-01T13:32:56.400764Z",
-     "iopub.status.idle": "2026-09-01T13:32:57.029890Z",
-     "shell.execute_reply": "2026-09-01T13:32:57.029687Z"
+     "iopub.execute_input": "2026-09-03T08:23:25.317128Z",
+     "iopub.status.busy": "2026-09-03T08:23:25.317128Z",
+     "iopub.status.idle": "2026-09-03T08:23:25.564740Z",
+     "shell.execute_reply": "2026-09-03T08:23:25.563983Z"
     },
     "papermill": {
-     "duration": 0.635917,
-     "end_time": "2026-09-01T13:32:57.029993+00:00",
+     "duration": 0.254836,
+     "end_time": "2026-09-03T08:23:25.564740",
      "exception": false,
-     "start_time": "2026-09-01T13:32:56.394076+00:00",
+     "start_time": "2026-09-03T08:23:25.309904",
      "status": "completed"
     },
     "tags": []
@@ -612,10 +621,10 @@
    "id": "03cae750",
    "metadata": {
     "papermill": {
-     "duration": 0.005162,
-     "end_time": "2026-09-01T13:32:57.040520+00:00",
+     "duration": 0.004339,
+     "end_time": "2026-09-03T08:23:25.574401",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.035358+00:00",
+     "start_time": "2026-09-03T08:23:25.570062",
      "status": "completed"
     },
     "tags": []
@@ -642,16 +651,16 @@
    "id": "fa08c327",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:57.058222Z",
-     "iopub.status.busy": "2026-09-01T13:32:57.057540Z",
-     "iopub.status.idle": "2026-09-01T13:32:57.363863Z",
-     "shell.execute_reply": "2026-09-01T13:32:57.363419Z"
+     "iopub.execute_input": "2026-09-03T08:23:25.584752Z",
+     "iopub.status.busy": "2026-09-03T08:23:25.584224Z",
+     "iopub.status.idle": "2026-09-03T08:23:25.709742Z",
+     "shell.execute_reply": "2026-09-03T08:23:25.709742Z"
     },
     "papermill": {
-     "duration": 0.318586,
-     "end_time": "2026-09-01T13:32:57.364064+00:00",
+     "duration": 0.131949,
+     "end_time": "2026-09-03T08:23:25.710755",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.045478+00:00",
+     "start_time": "2026-09-03T08:23:25.578806",
      "status": "completed"
     },
     "tags": []
@@ -709,16 +718,16 @@
    "id": "97c643fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:57.381629Z",
-     "iopub.status.busy": "2026-09-01T13:32:57.381291Z",
-     "iopub.status.idle": "2026-09-01T13:32:57.612786Z",
-     "shell.execute_reply": "2026-09-01T13:32:57.612585Z"
+     "iopub.execute_input": "2026-09-03T08:23:25.722755Z",
+     "iopub.status.busy": "2026-09-03T08:23:25.721755Z",
+     "iopub.status.idle": "2026-09-03T08:23:25.823372Z",
+     "shell.execute_reply": "2026-09-03T08:23:25.823372Z"
     },
     "papermill": {
-     "duration": 0.240172,
-     "end_time": "2026-09-01T13:32:57.612884+00:00",
+     "duration": 0.106616,
+     "end_time": "2026-09-03T08:23:25.823372",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.372712+00:00",
+     "start_time": "2026-09-03T08:23:25.716756",
      "status": "completed"
     },
     "tags": []
@@ -788,10 +797,10 @@
    "id": "0fda2fd0",
    "metadata": {
     "papermill": {
-     "duration": 0.004777,
-     "end_time": "2026-09-01T13:32:57.624095+00:00",
+     "duration": 0.007014,
+     "end_time": "2026-09-03T08:23:25.838385",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.619318+00:00",
+     "start_time": "2026-09-03T08:23:25.831371",
      "status": "completed"
     },
     "tags": []
@@ -814,16 +823,16 @@
    "id": "e6aa4b02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:57.652521Z",
-     "iopub.status.busy": "2026-09-01T13:32:57.652163Z",
-     "iopub.status.idle": "2026-09-01T13:32:57.928641Z",
-     "shell.execute_reply": "2026-09-01T13:32:57.928334Z"
+     "iopub.execute_input": "2026-09-03T08:23:25.851816Z",
+     "iopub.status.busy": "2026-09-03T08:23:25.851816Z",
+     "iopub.status.idle": "2026-09-03T08:23:25.958771Z",
+     "shell.execute_reply": "2026-09-03T08:23:25.958771Z"
     },
     "papermill": {
-     "duration": 0.296306,
-     "end_time": "2026-09-01T13:32:57.928753+00:00",
+     "duration": 0.113377,
+     "end_time": "2026-09-03T08:23:25.959783",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.632447+00:00",
+     "start_time": "2026-09-03T08:23:25.846406",
      "status": "completed"
     },
     "tags": []
@@ -925,10 +934,10 @@
    "id": "bellmanford-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004211,
-     "end_time": "2026-09-01T13:32:57.948460+00:00",
+     "duration": 0.004511,
+     "end_time": "2026-09-03T08:23:25.969811",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.944249+00:00",
+     "start_time": "2026-09-03T08:23:25.965300",
      "status": "completed"
     },
     "tags": []
@@ -947,16 +956,16 @@
    "id": "bellmanford-couts-negatifs",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:57.959381Z",
-     "iopub.status.busy": "2026-09-01T13:32:57.958978Z",
-     "iopub.status.idle": "2026-09-01T13:32:58.510940Z",
-     "shell.execute_reply": "2026-09-01T13:32:58.510605Z"
+     "iopub.execute_input": "2026-09-03T08:23:25.982131Z",
+     "iopub.status.busy": "2026-09-03T08:23:25.982131Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.138265Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.137258Z"
     },
     "papermill": {
-     "duration": 0.557912,
-     "end_time": "2026-09-01T13:32:58.511118+00:00",
+     "duration": 0.162139,
+     "end_time": "2026-09-03T08:23:26.138265",
      "exception": false,
-     "start_time": "2026-09-01T13:32:57.953206+00:00",
+     "start_time": "2026-09-03T08:23:25.976126",
      "status": "completed"
     },
     "tags": []
@@ -1058,10 +1067,10 @@
    "id": "lecture-bellmanford",
    "metadata": {
     "papermill": {
-     "duration": 0.008631,
-     "end_time": "2026-09-01T13:32:58.529906+00:00",
+     "duration": 0.006001,
+     "end_time": "2026-09-03T08:23:26.151775",
      "exception": false,
-     "start_time": "2026-09-01T13:32:58.521275+00:00",
+     "start_time": "2026-09-03T08:23:26.145774",
      "status": "completed"
     },
     "tags": []
@@ -1083,10 +1092,10 @@
    "id": "ec1a8528",
    "metadata": {
     "papermill": {
-     "duration": 0.011019,
-     "end_time": "2026-09-01T13:32:58.550307+00:00",
+     "duration": 0.00838,
+     "end_time": "2026-09-03T08:23:26.171201",
      "exception": false,
-     "start_time": "2026-09-01T13:32:58.539288+00:00",
+     "start_time": "2026-09-03T08:23:26.162821",
      "status": "completed"
     },
     "tags": []
@@ -1121,16 +1130,16 @@
    "id": "f5fae748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:58.574993Z",
-     "iopub.status.busy": "2026-09-01T13:32:58.574297Z",
-     "iopub.status.idle": "2026-09-01T13:32:59.008081Z",
-     "shell.execute_reply": "2026-09-01T13:32:59.007302Z"
+     "iopub.execute_input": "2026-09-03T08:23:26.188960Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.188429Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.317943Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.317943Z"
     },
     "papermill": {
-     "duration": 0.448339,
-     "end_time": "2026-09-01T13:32:59.008334+00:00",
+     "duration": 0.140328,
+     "end_time": "2026-09-03T08:23:26.317943",
      "exception": false,
-     "start_time": "2026-09-01T13:32:58.559995+00:00",
+     "start_time": "2026-09-03T08:23:26.177615",
      "status": "completed"
     },
     "tags": []
@@ -1316,10 +1325,10 @@
    "id": "d8dbaf0a",
    "metadata": {
     "papermill": {
-     "duration": 0.012398,
-     "end_time": "2026-09-01T13:32:59.028594+00:00",
+     "duration": 0.004012,
+     "end_time": "2026-09-03T08:23:26.327536",
      "exception": false,
-     "start_time": "2026-09-01T13:32:59.016196+00:00",
+     "start_time": "2026-09-03T08:23:26.323524",
      "status": "completed"
     },
     "tags": []
@@ -1342,16 +1351,16 @@
    "id": "43bbfd4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:59.049353Z",
-     "iopub.status.busy": "2026-09-01T13:32:59.049014Z",
-     "iopub.status.idle": "2026-09-01T13:32:59.340500Z",
-     "shell.execute_reply": "2026-09-01T13:32:59.340245Z"
+     "iopub.execute_input": "2026-09-03T08:23:26.338548Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.338548Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.440578Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.440578Z"
     },
     "papermill": {
-     "duration": 0.301549,
-     "end_time": "2026-09-01T13:32:59.340624+00:00",
+     "duration": 0.108029,
+     "end_time": "2026-09-03T08:23:26.440578",
      "exception": false,
-     "start_time": "2026-09-01T13:32:59.039075+00:00",
+     "start_time": "2026-09-03T08:23:26.332549",
      "status": "completed"
     },
     "tags": []
@@ -1475,10 +1484,10 @@
    "id": "a53b7b57",
    "metadata": {
     "papermill": {
-     "duration": 0.007805,
-     "end_time": "2026-09-01T13:32:59.356382+00:00",
+     "duration": 0.006025,
+     "end_time": "2026-09-03T08:23:26.452638",
      "exception": false,
-     "start_time": "2026-09-01T13:32:59.348577+00:00",
+     "start_time": "2026-09-03T08:23:26.446613",
      "status": "completed"
     },
     "tags": []
@@ -1502,16 +1511,16 @@
    "id": "dcb052db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:32:59.377472Z",
-     "iopub.status.busy": "2026-09-01T13:32:59.377106Z",
-     "iopub.status.idle": "2026-09-01T13:33:00.041232Z",
-     "shell.execute_reply": "2026-09-01T13:33:00.041010Z"
+     "iopub.execute_input": "2026-09-03T08:23:26.464619Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.463621Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.662526Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.661515Z"
     },
     "papermill": {
-     "duration": 0.679913,
-     "end_time": "2026-09-01T13:33:00.041337+00:00",
+     "duration": 0.204859,
+     "end_time": "2026-09-03T08:23:26.662526",
      "exception": false,
-     "start_time": "2026-09-01T13:32:59.361424+00:00",
+     "start_time": "2026-09-03T08:23:26.457667",
      "status": "completed"
     },
     "tags": []
@@ -1634,10 +1643,10 @@
    "id": "cff33a18",
    "metadata": {
     "papermill": {
-     "duration": 0.004708,
-     "end_time": "2026-09-01T13:33:00.051327+00:00",
+     "duration": 0.006267,
+     "end_time": "2026-09-03T08:23:26.678847",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.046619+00:00",
+     "start_time": "2026-09-03T08:23:26.672580",
      "status": "completed"
     },
     "tags": []
@@ -1701,10 +1710,10 @@
    "id": "069db712",
    "metadata": {
     "papermill": {
-     "duration": 0.00486,
-     "end_time": "2026-09-01T13:33:00.061167+00:00",
+     "duration": 0.010535,
+     "end_time": "2026-09-03T08:23:26.694382",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.056307+00:00",
+     "start_time": "2026-09-03T08:23:26.683847",
      "status": "completed"
     },
     "tags": []
@@ -1741,16 +1750,16 @@
    "id": "54c1c37d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:33:00.072690Z",
-     "iopub.status.busy": "2026-09-01T13:33:00.072413Z",
-     "iopub.status.idle": "2026-09-01T13:33:00.265620Z",
-     "shell.execute_reply": "2026-09-01T13:33:00.265426Z"
+     "iopub.execute_input": "2026-09-03T08:23:26.713551Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.712038Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.763645Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.763645Z"
     },
     "papermill": {
-     "duration": 0.199787,
-     "end_time": "2026-09-01T13:33:00.265718+00:00",
+     "duration": 0.060264,
+     "end_time": "2026-09-03T08:23:26.763645",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.065931+00:00",
+     "start_time": "2026-09-03T08:23:26.703381",
      "status": "completed"
     },
     "tags": []
@@ -1779,10 +1788,10 @@
    "id": "555705b6",
    "metadata": {
     "papermill": {
-     "duration": 0.006074,
-     "end_time": "2026-09-01T13:33:00.277033+00:00",
+     "duration": 0.006052,
+     "end_time": "2026-09-03T08:23:26.778978",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.270959+00:00",
+     "start_time": "2026-09-03T08:23:26.772926",
      "status": "completed"
     },
     "tags": []
@@ -1811,16 +1820,16 @@
    "id": "50ac6f05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:33:00.288159Z",
-     "iopub.status.busy": "2026-09-01T13:33:00.287859Z",
-     "iopub.status.idle": "2026-09-01T13:33:00.341755Z",
-     "shell.execute_reply": "2026-09-01T13:33:00.341512Z"
+     "iopub.execute_input": "2026-09-03T08:23:26.800494Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.800494Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.840889Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.840889Z"
     },
     "papermill": {
-     "duration": 0.059949,
-     "end_time": "2026-09-01T13:33:00.341873+00:00",
+     "duration": 0.051904,
+     "end_time": "2026-09-03T08:23:26.840889",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.281924+00:00",
+     "start_time": "2026-09-03T08:23:26.788985",
      "status": "completed"
     },
     "tags": []
@@ -1847,10 +1856,10 @@
    "id": "f3568a0c",
    "metadata": {
     "papermill": {
-     "duration": 0.009595,
-     "end_time": "2026-09-01T13:33:00.355767+00:00",
+     "duration": 0.011524,
+     "end_time": "2026-09-03T08:23:26.864789",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.346172+00:00",
+     "start_time": "2026-09-03T08:23:26.853265",
      "status": "completed"
     },
     "tags": []
@@ -1881,16 +1890,16 @@
    "id": "c73812fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T13:33:00.383768Z",
-     "iopub.status.busy": "2026-09-01T13:33:00.383266Z",
-     "iopub.status.idle": "2026-09-01T13:33:00.469830Z",
-     "shell.execute_reply": "2026-09-01T13:33:00.469509Z"
+     "iopub.execute_input": "2026-09-03T08:23:26.888429Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.888429Z",
+     "iopub.status.idle": "2026-09-03T08:23:26.939165Z",
+     "shell.execute_reply": "2026-09-03T08:23:26.939165Z"
     },
     "papermill": {
-     "duration": 0.105263,
-     "end_time": "2026-09-01T13:33:00.469982+00:00",
+     "duration": 0.062751,
+     "end_time": "2026-09-03T08:23:26.939165",
      "exception": false,
-     "start_time": "2026-09-01T13:33:00.364719+00:00",
+     "start_time": "2026-09-03T08:23:26.876414",
      "status": "completed"
     },
     "tags": []
@@ -1928,14 +1937,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.096085,
-   "end_time": "2026-09-01T13:33:00.732762+00:00",
+   "duration": 7.458753,
+   "end_time": "2026-09-03T08:23:27.191392",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Search-02c-QuikGraph.ipynb",
-   "output_path": "search02c_bf_out2.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-02c-QuikGraph.ipynb",
    "parameters": {},
-   "start_time": "2026-09-01T13:32:48.636677+00:00",
+   "start_time": "2026-09-03T08:23:19.732639",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "af0037be",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003947,
+     "end_time": "2026-09-03T08:23:26.462616",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:26.458669",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Search-3-Informed (C#) : Recherche Informée\n",
     "\n",
@@ -39,7 +48,16 @@
   {
    "cell_type": "markdown",
    "id": "c5339f63",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00351,
+     "end_time": "2026-09-03T08:23:26.471130",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:26.467620",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 1. Cadre : problème de recherche et heuristique\n",
@@ -87,24 +105,142 @@
    "id": "40529d27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:04.542419Z",
-     "iopub.status.busy": "2026-07-10T06:51:04.514504Z",
-     "iopub.status.idle": "2026-07-10T06:51:11.575338Z",
-     "shell.execute_reply": "2026-07-10T06:51:11.553896Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:26.492649Z",
+     "iopub.status.busy": "2026-09-03T08:23:26.484656Z",
+     "iopub.status.idle": "2026-09-03T08:23:28.428495Z",
+     "shell.execute_reply": "2026-09-03T08:23:28.424450Z"
+    },
+    "papermill": {
+     "duration": 1.953363,
+     "end_time": "2026-09-03T08:23:28.428495",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:26.475132",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": ""
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '46096.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Framework de recherche informee pret (Node, Problem, GraphProblem, SearchResult).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Framework de recherche informee pret (Node, Problem, GraphProblem, SearchResult).\r\n"
+     ]
     }
    ],
    "source": [
@@ -221,7 +357,16 @@
   {
    "cell_type": "markdown",
    "id": "5b90e3d9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003996,
+     "end_time": "2026-09-03T08:23:28.437069",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.433073",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 2. Graphe des villes françaises + heuristique à vol d'oiseau\n",
@@ -237,62 +382,90 @@
    "id": "5f020aaf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:11.583151Z",
-     "iopub.status.busy": "2026-07-10T06:51:11.581850Z",
-     "iopub.status.idle": "2026-07-10T06:51:12.362916Z",
-     "shell.execute_reply": "2026-07-10T06:51:12.361497Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:28.446064Z",
+     "iopub.status.busy": "2026-09-03T08:23:28.446064Z",
+     "iopub.status.idle": "2026-09-03T08:23:28.670236Z",
+     "shell.execute_reply": "2026-09-03T08:23:28.670236Z"
+    },
+    "papermill": {
+     "duration": 0.229175,
+     "end_time": "2026-09-03T08:23:28.670236",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.441061",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Carte chargee : 13 villes\r\n"
+     "output_type": "stream",
+     "text": [
+      "Carte chargee : 13 villes\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Probleme de reference : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Probleme de reference : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Heuristique h(n) = Haversine vers Toulouse (vol d'oiseau, admissible) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Heuristique h(n) = Haversine vers Toulouse (vol d'oiseau, admissible) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Lille        h =    791 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Lille        h =    791 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Paris        h =    589 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Paris        h =    589 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Rennes       h =    557 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Rennes       h =    557 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Nantes       h =    465 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Nantes       h =    465 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Bordeaux     h =    211 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Bordeaux     h =    211 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Toulouse     h =      0 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Toulouse     h =      0 km\r\n"
+     ]
     }
    ],
    "source": [
@@ -363,7 +536,16 @@
   {
    "cell_type": "markdown",
    "id": "4ef05065",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005,
+     "end_time": "2026-09-03T08:23:28.680039",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.675039",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : l'heuristique guide vers le but\n",
     "\n",
@@ -396,17 +578,27 @@
    "id": "6469cffe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:12.367281Z",
-     "iopub.status.busy": "2026-07-10T06:51:12.366653Z",
-     "iopub.status.idle": "2026-07-10T06:51:12.635125Z",
-     "shell.execute_reply": "2026-07-10T06:51:12.634065Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:28.689555Z",
+     "iopub.status.busy": "2026-09-03T08:23:28.689555Z",
+     "iopub.status.idle": "2026-09-03T08:23:28.753518Z",
+     "shell.execute_reply": "2026-09-03T08:23:28.753518Z"
+    },
+    "papermill": {
+     "duration": 0.069937,
+     "end_time": "2026-09-03T08:23:28.753518",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.683581",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme Greedy Best-First implemente.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme Greedy Best-First implemente.\r\n"
+     ]
     }
    ],
    "source": [
@@ -465,82 +657,118 @@
    "id": "028c4650",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:12.638293Z",
-     "iopub.status.busy": "2026-07-10T06:51:12.637802Z",
-     "iopub.status.idle": "2026-07-10T06:51:12.934289Z",
-     "shell.execute_reply": "2026-07-10T06:51:12.933671Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:28.763515Z",
+     "iopub.status.busy": "2026-09-03T08:23:28.763515Z",
+     "iopub.status.idle": "2026-09-03T08:23:28.807923Z",
+     "shell.execute_reply": "2026-09-03T08:23:28.807923Z"
+    },
+    "papermill": {
+     "duration": 0.049446,
+     "end_time": "2026-09-03T08:23:28.807923",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.758477",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy Best-First : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy Best-First : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lille        g=     0 h=   791\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lille        g=     0 h=   791\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Rennes       g=   510 h=   557\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Rennes       g=   510 h=   557\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Nantes       g=   620 h=   465\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Nantes       g=   620 h=   465\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- Greedy ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- Greedy ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Lille -> Rennes -> Nantes -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Lille -> Rennes -> Nantes -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 1210\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 1210\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 9\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 9\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 4\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 4\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 5,43 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 4,17 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -555,7 +783,16 @@
   {
    "cell_type": "markdown",
    "id": "58d597bb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005005,
+     "end_time": "2026-09-03T08:23:28.818446",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.813441",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : Greedy fonce vers l'ouest\n",
     "\n",
@@ -574,7 +811,16 @@
   {
    "cell_type": "markdown",
    "id": "bf7c76dc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005503,
+     "end_time": "2026-09-03T08:23:28.828469",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.822966",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 4. A* Search\n",
@@ -609,17 +855,27 @@
    "id": "cfb21842",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:12.939473Z",
-     "iopub.status.busy": "2026-07-10T06:51:12.938530Z",
-     "iopub.status.idle": "2026-07-10T06:51:13.116468Z",
-     "shell.execute_reply": "2026-07-10T06:51:13.115008Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:28.840053Z",
+     "iopub.status.busy": "2026-09-03T08:23:28.840053Z",
+     "iopub.status.idle": "2026-09-03T08:23:28.883551Z",
+     "shell.execute_reply": "2026-09-03T08:23:28.883551Z"
+    },
+    "papermill": {
+     "duration": 0.050015,
+     "end_time": "2026-09-03T08:23:28.883551",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.833536",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme A* implemente.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme A* implemente.\r\n"
+     ]
     }
    ],
    "source": [
@@ -675,87 +931,125 @@
    "id": "27d522ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:13.120401Z",
-     "iopub.status.busy": "2026-07-10T06:51:13.119939Z",
-     "iopub.status.idle": "2026-07-10T06:51:13.256539Z",
-     "shell.execute_reply": "2026-07-10T06:51:13.250070Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:28.898095Z",
+     "iopub.status.busy": "2026-09-03T08:23:28.896587Z",
+     "iopub.status.idle": "2026-09-03T08:23:28.953330Z",
+     "shell.execute_reply": "2026-09-03T08:23:28.951329Z"
+    },
+    "papermill": {
+     "duration": 0.064261,
+     "end_time": "2026-09-03T08:23:28.953330",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.889069",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A* : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "A* : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lille        g=     0 h=   791 f=    791\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lille        g=     0 h=   791 f=    791\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Paris        g=   225 h=   589 f=    814\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Paris        g=   225 h=   589 f=    814\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Bordeaux     g=   810 h=   211 f=   1021\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Bordeaux     g=   810 h=   211 f=   1021\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lyon         g=   690 h=   360 f=   1050\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lyon         g=   690 h=   360 f=   1050\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- A* ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- A* ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 1055\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 1055\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 4\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 4\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 15\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 15\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 6\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 6\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 0,54 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,80 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -770,7 +1064,16 @@
   {
    "cell_type": "markdown",
    "id": "0de8915d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01115,
+     "end_time": "2026-09-03T08:23:28.976052",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.964902",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : A* équilibre $g$ et $h$\n",
     "\n",
@@ -792,57 +1095,83 @@
    "id": "98bac047",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:13.261269Z",
-     "iopub.status.busy": "2026-07-10T06:51:13.260490Z",
-     "iopub.status.idle": "2026-07-10T06:51:13.480360Z",
-     "shell.execute_reply": "2026-07-10T06:51:13.479481Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:29.000671Z",
+     "iopub.status.busy": "2026-09-03T08:23:28.999672Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.071518Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.071518Z"
+    },
+    "papermill": {
+     "duration": 0.084363,
+     "end_time": "2026-09-03T08:23:29.071518",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:28.987155",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison : Greedy vs A* sur Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Comparaison : Greedy vs A* sur Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "======================================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "----------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy     Lille -> Rennes -> Nantes -> Toulouse          1210      3        3\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy     Lille -> Rennes -> Nantes -> Toulouse          1210      3        3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A*         Lille -> Paris -> Bordeaux -> Toulouse         1055      3        4\r\n"
+     "output_type": "stream",
+     "text": [
+      "A*         Lille -> Paris -> Bordeaux -> Toulouse         1055      3        4\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy a trouve un chemin 155 km plus long (14,7% de surcout).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy a trouve un chemin 155 km plus long (14,7% de surcout).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-> Greedy est SOUS-OPTIMAL : il a sacrifie l'optimalite pour explorer moins de noeuds.\r\n"
+     "output_type": "stream",
+     "text": [
+      "-> Greedy est SOUS-OPTIMAL : il a sacrifie l'optimalite pour explorer moins de noeuds.\r\n"
+     ]
     }
    ],
    "source": [
@@ -870,7 +1199,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "586ae9f2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005853,
+     "end_time": "2026-09-03T08:23:29.084892",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.079039",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5.1 Tranche 2 (parite lib-vs-lib #10382) : verdict bucket-1 .NET natif via `QuikGraph.AStarAlgorithm`\n",
     "\n",
@@ -908,19 +1247,39 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "id": "48162d96",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T08:23:29.099438Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.099438Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.374950Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.374950Z"
+    },
+    "papermill": {
+     "duration": 0.28354,
+     "end_time": "2026-09-03T08:23:29.374950",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.091410",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>QuikGraph</span></li></ul></div><div></div></div>"
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>QuikGraph, 2.5.0</span></li></ul></div></div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "QuikGraph charge : AStarShortestPathAlgorithm<string, STaggedEdge<string, double>> dispo.\r\n"
+     "output_type": "stream",
+     "text": [
+      "QuikGraph charge : AStarShortestPathAlgorithm<string, STaggedEdge<string, double>> dispo.\r\n"
+     ]
     }
    ],
    "source": [
@@ -937,27 +1296,51 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "id": "3b2a91b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T08:23:29.390999Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.389988Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.562649Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.562649Z"
+    },
+    "papermill": {
+     "duration": 0.180698,
+     "end_time": "2026-09-03T08:23:29.562649",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.381951",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Reseau routier : 13 villes, 40 segments (aller-retour).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Reseau routier : 13 villes, 40 segments (aller-retour).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "AStar QuikGraph Lille -> Toulouse : 1055 km\r\n"
+     "output_type": "stream",
+     "text": [
+      "AStar QuikGraph Lille -> Toulouse : 1055 km\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "attendu : 1055 km via Lille -> Paris -> Bordeaux -> Toulouse. cell 11 from-scratch : idem.\r\n"
+     "output_type": "stream",
+     "text": [
+      "attendu : 1055 km via Lille -> Paris -> Bordeaux -> Toulouse. cell 11 from-scratch : idem.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1042,67 +1425,107 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "id": "0e56b306",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T08:23:29.586372Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.586372Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.658925Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.658925Z"
+    },
+    "papermill": {
+     "duration": 0.085471,
+     "end_time": "2026-09-03T08:23:29.658925",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.573454",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Parite A* : from-scratch (cell 11) vs QuikGraph (cell 16)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Parite A* : from-scratch (cell 11) vs QuikGraph (cell 16)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "======================================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Critere                      From-scratch          QuikGraph    Verdict\r\n"
+     "output_type": "stream",
+     "text": [
+      "Critere                      From-scratch          QuikGraph    Verdict\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "----------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Cout g (km)                          1055               1055         OK\r\n"
+     "output_type": "stream",
+     "text": [
+      "Cout g (km)                          1055               1055         OK\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Chemin                 Lille -> Paris -> Bordeaux -> Toulouse Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "Chemin                 Lille -> Paris -> Bordeaux -> Toulouse Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  -> Verdict chemin : identique                                         \r\n"
+     "output_type": "stream",
+     "text": [
+      "  -> Verdict chemin : identique                                         \r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Heuristique partagee   Haversine(a, b) de cell 4             OK\r\n"
+     "output_type": "stream",
+     "text": [
+      "Heuristique partagee   Haversine(a, b) de cell 4             OK\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Verdict Prong B : EQUIVALENT (from-scratch == QuikGraph)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Verdict Prong B : EQUIVALENT (from-scratch == QuikGraph)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Bucket #10382 : bucket-1 .NET natif (lib installable via NuGet, pas workaround).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Bucket #10382 : bucket-1 .NET natif (lib installable via NuGet, pas workaround).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Verdict SOTA ecrit (Prong A) : SOTA-OK (moteur reellement charge et execute sur instance concrete).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Verdict SOTA ecrit (Prong A) : SOTA-OK (moteur reellement charge et execute sur instance concrete).\r\n"
+     ]
     }
    ],
    "source": [
@@ -1141,7 +1564,16 @@
   {
    "cell_type": "markdown",
    "id": "a1b2rennes",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007018,
+     "end_time": "2026-09-03T08:23:29.672791",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.665773",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Le piège Greedy : Rennes → Paris (miroir du piège BFS de Search-2)\n",
     "\n",
@@ -1158,197 +1590,279 @@
    "id": "c3d4rennes",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:13.485714Z",
-     "iopub.status.busy": "2026-07-10T06:51:13.484693Z",
-     "iopub.status.idle": "2026-07-10T06:51:13.875612Z",
-     "shell.execute_reply": "2026-07-10T06:51:13.874060Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:29.688615Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.688615Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.762354Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.762354Z"
+    },
+    "papermill": {
+     "duration": 0.082251,
+     "end_time": "2026-09-03T08:23:29.762354",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.680103",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy Best-First : Rennes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy Best-First : Rennes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Rennes       g=     0 h=   308\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Rennes       g=     0 h=   308\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Lille        g=   510 h=   203\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Lille        g=   510 h=   203\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- Greedy ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- Greedy ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Rennes -> Lille -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Rennes -> Lille -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 735\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 735\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 0,21 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,27 ms\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A* : Rennes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "A* : Rennes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Rennes       g=     0 h=   308 f=    308\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Rennes       g=     0 h=   308 f=    308\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Explore: Nantes       g=   110 h=   342 f=    452\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Explore: Nantes       g=   110 h=   342 f=    452\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- A* ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- A* ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Rennes -> Nantes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Rennes -> Nantes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 495\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 495\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 2\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 7\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 7\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 0,19 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 0,17 ms\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison : Greedy vs A* sur Rennes -> Paris\r\n"
+     "output_type": "stream",
+     "text": [
+      "Comparaison : Greedy vs A* sur Rennes -> Paris\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "======================================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme Chemin                                         Cout  Sauts   Noeuds\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "----------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy     Rennes -> Lille -> Paris                        735      2        2\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy     Rennes -> Lille -> Paris                        735      2        2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "A*         Rennes -> Nantes -> Paris                       495      2        2\r\n"
+     "output_type": "stream",
+     "text": [
+      "A*         Rennes -> Nantes -> Paris                       495      2        2\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Greedy a trouve un chemin 240 km plus long (48,5% de surcout).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Greedy a trouve un chemin 240 km plus long (48,5% de surcout).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-> Comme BFS sur Paris->Rennes (Search-2), Greedy file vers Lille ; A* (comme UCS) trouve l'optimum via Nantes.\r\n"
+     "output_type": "stream",
+     "text": [
+      "-> Comme BFS sur Paris->Rennes (Search-2), Greedy file vers Lille ; A* (comme UCS) trouve l'optimum via Nantes.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1395,7 +1909,16 @@
   {
    "cell_type": "markdown",
    "id": "4fc1ed58",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007217,
+     "end_time": "2026-09-03T08:23:29.778261",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.771044",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : la divergence Greedy vs A*\n",
     "\n",
@@ -1444,17 +1967,27 @@
    "id": "7b1cf3cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:13.881366Z",
-     "iopub.status.busy": "2026-07-10T06:51:13.880008Z",
-     "iopub.status.idle": "2026-07-10T06:51:14.128205Z",
-     "shell.execute_reply": "2026-07-10T06:51:14.127703Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:29.796476Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.796476Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.861896Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.861896Z"
+    },
+    "papermill": {
+     "duration": 0.075126,
+     "end_time": "2026-09-03T08:23:29.861896",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.786770",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Algorithme IDA* implemente.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Algorithme IDA* implemente.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1511,92 +2044,132 @@
    "id": "43ab64ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:14.132730Z",
-     "iopub.status.busy": "2026-07-10T06:51:14.131932Z",
-     "iopub.status.idle": "2026-07-10T06:51:14.252785Z",
-     "shell.execute_reply": "2026-07-10T06:51:14.250646Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:29.885727Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.885727Z",
+     "iopub.status.idle": "2026-09-03T08:23:29.915657Z",
+     "shell.execute_reply": "2026-09-03T08:23:29.916165Z"
+    },
+    "papermill": {
+     "duration": 0.043983,
+     "end_time": "2026-09-03T08:23:29.916165",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.872182",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "IDA* : Lille -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "IDA* : Lille -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "============================================================\r\n"
+     "output_type": "stream",
+     "text": [
+      "============================================================\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 1: f-limit = 791\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 1: f-limit = 791\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 2: f-limit = 814\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 2: f-limit = 814\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 3: f-limit = 1021\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 3: f-limit = 1021\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 4: f-limit = 1050\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 4: f-limit = 1050\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Iteration 5: f-limit = 1055\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Iteration 5: f-limit = 1055\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--- IDA* ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "--- IDA* ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Chemin : Lille -> Paris -> Bordeaux -> Toulouse\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Cout   : 1055\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Cout   : 1055\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Sauts  : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Sauts  : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds explores : 13\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds explores : 13\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Noeuds generes  : 38\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Noeuds generes  : 38\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Pic frontiere   : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Pic frontiere   : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps           : 1,00 ms\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Temps           : 1,26 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -1611,7 +2184,16 @@
   {
    "cell_type": "markdown",
    "id": "9410683f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008082,
+     "end_time": "2026-09-03T08:23:29.931338",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.923256",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : IDA* et les bornes croissantes\n",
     "\n",
@@ -1636,7 +2218,16 @@
   {
    "cell_type": "markdown",
    "id": "90aa505e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007985,
+     "end_time": "2026-09-03T08:23:29.947402",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.939417",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 6. Admissibilité et consistance : étude sur le 8-puzzle\n",
@@ -1668,62 +2259,90 @@
    "id": "d21e5592",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:14.256233Z",
-     "iopub.status.busy": "2026-07-10T06:51:14.255675Z",
-     "iopub.status.idle": "2026-07-10T06:51:14.613059Z",
-     "shell.execute_reply": "2026-07-10T06:51:14.612291Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:29.975046Z",
+     "iopub.status.busy": "2026-09-03T08:23:29.975046Z",
+     "iopub.status.idle": "2026-09-03T08:23:30.071295Z",
+     "shell.execute_reply": "2026-09-03T08:23:30.071295Z"
+    },
+    "papermill": {
+     "duration": 0.109802,
+     "end_time": "2026-09-03T08:23:30.071295",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:29.961493",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison h1 (tuiles mal placees) vs h2 (Manhattan) sur 3 etats :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Comparaison h1 (tuiles mal placees) vs h2 (Manhattan) sur 3 etats :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Etat         h1 (mal placees)     h2 (Manhattan)   h2 >= h1 ?\r\n"
+     "output_type": "stream",
+     "text": [
+      "Etat         h1 (mal placees)     h2 (Manhattan)   h2 >= h1 ?\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Facile                      1                  1          oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "Facile                      1                  1          oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Moyen                       6                 10          oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "Moyen                       6                 10          oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Difficile                   7                 21          oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "Difficile                   7                 21          oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Conclusion : h2 (Manhattan) domine h1 partout -> A* avec h2 explorerait\r\n"
+     "output_type": "stream",
+     "text": [
+      "Conclusion : h2 (Manhattan) domine h1 partout -> A* avec h2 explorerait\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "au moins aussi peu de noeuds qu'avec h1. Les deux sont admissibles.\r\n"
+     "output_type": "stream",
+     "text": [
+      "au moins aussi peu de noeuds qu'avec h1. Les deux sont admissibles.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1777,82 +2396,118 @@
    "id": "3d16f695",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:14.618153Z",
-     "iopub.status.busy": "2026-07-10T06:51:14.617195Z",
-     "iopub.status.idle": "2026-07-10T06:51:15.032165Z",
-     "shell.execute_reply": "2026-07-10T06:51:15.031227Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:30.088315Z",
+     "iopub.status.busy": "2026-09-03T08:23:30.088315Z",
+     "iopub.status.idle": "2026-09-03T08:23:30.155439Z",
+     "shell.execute_reply": "2026-09-03T08:23:30.155439Z"
+    },
+    "papermill": {
+     "duration": 0.076632,
+     "end_time": "2026-09-03T08:23:30.155439",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.078807",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Demonstration de consistance de Manhattan sur un etat Moyen :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Demonstration de consistance de Manhattan sur un etat Moyen :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Etat parent : (1,3,4,8,0,2,7,5,6)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Etat parent : (1,3,4,8,0,2,7,5,6)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  h2(parent)  = 10\r\n"
+     "output_type": "stream",
+     "text": [
+      "  h2(parent)  = 10\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  Successeur               h2(succ)    h(parent)-h(succ)   <= c=1 ?\r\n"
+     "output_type": "stream",
+     "text": [
+      "  Successeur               h2(succ)    h(parent)-h(succ)   <= c=1 ?\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  --------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "  --------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,0,4,8,3,2,7,5,6)            11                   -1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,0,4,8,3,2,7,5,6)            11                   -1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,3,4,8,5,2,7,0,6)             9                    1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,3,4,8,5,2,7,0,6)             9                    1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,3,4,0,8,2,7,5,6)             9                    1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,3,4,0,8,2,7,5,6)             9                    1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  (1,3,4,8,2,0,7,5,6)             9                    1        oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "  (1,3,4,8,2,0,7,5,6)             9                    1        oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "On observe h(parent) - h(succ) <= 1 a chaque transition : un deplacement de la\r\n"
+     "output_type": "stream",
+     "text": [
+      "On observe h(parent) - h(succ) <= 1 a chaque transition : un deplacement de la\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "case vide ne rapproche une tuile de sa but que d'au plus 1 (cout unitaire).\r\n"
+     "output_type": "stream",
+     "text": [
+      "case vide ne rapproche une tuile de sa but que d'au plus 1 (cout unitaire).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Donc h(n) <= 1 + h(n') : Manhattan est CONSISTANTE (et donc admissible).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Donc h(n) <= 1 + h(n') : Manhattan est CONSISTANTE (et donc admissible).\r\n"
+     ]
     }
    ],
    "source": [
@@ -1897,7 +2552,16 @@
   {
    "cell_type": "markdown",
    "id": "1e2039f4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00801,
+     "end_time": "2026-09-03T08:23:30.172487",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.164477",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : choix d'une bonne heuristique\n",
     "\n",
@@ -1916,7 +2580,16 @@
   {
    "cell_type": "markdown",
    "id": "52a1e54d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008525,
+     "end_time": "2026-09-03T08:23:30.190042",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.181517",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 7. Exercices\n",
@@ -1934,17 +2607,27 @@
    "id": "22488e35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:15.038175Z",
-     "iopub.status.busy": "2026-07-10T06:51:15.037116Z",
-     "iopub.status.idle": "2026-07-10T06:51:15.343518Z",
-     "shell.execute_reply": "2026-07-10T06:51:15.342570Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:30.209540Z",
+     "iopub.status.busy": "2026-09-03T08:23:30.209540Z",
+     "iopub.status.idle": "2026-09-03T08:23:30.247386Z",
+     "shell.execute_reply": "2026-09-03T08:23:30.246386Z"
+    },
+    "papermill": {
+     "duration": 0.048779,
+     "end_time": "2026-09-03T08:23:30.247386",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.198607",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(Exercice a completer) — nextBound retourne par le stub : ∞\r\n"
+     "output_type": "stream",
+     "text": [
+      "(Exercice a completer) — nextBound retourne par le stub : ∞\r\n"
+     ]
     }
    ],
    "source": [
@@ -1971,7 +2654,16 @@
   {
    "cell_type": "markdown",
    "id": "e9933591",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01052,
+     "end_time": "2026-09-03T08:23:30.269699",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.259179",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : Heuristique volontairement non admissible\n",
     "\n",
@@ -1989,17 +2681,27 @@
    "id": "70c71f32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:15.349377Z",
-     "iopub.status.busy": "2026-07-10T06:51:15.348265Z",
-     "iopub.status.idle": "2026-07-10T06:51:15.520438Z",
-     "shell.execute_reply": "2026-07-10T06:51:15.519696Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:30.292199Z",
+     "iopub.status.busy": "2026-09-03T08:23:30.291200Z",
+     "iopub.status.idle": "2026-09-03T08:23:30.336284Z",
+     "shell.execute_reply": "2026-09-03T08:23:30.335282Z"
+    },
+    "papermill": {
+     "duration": 0.056087,
+     "end_time": "2026-09-03T08:23:30.336284",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.280197",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(Exercice a completer) — heuristique non admissible a construire\r\n"
+     "output_type": "stream",
+     "text": [
+      "(Exercice a completer) — heuristique non admissible a construire\r\n"
+     ]
     }
    ],
    "source": [
@@ -2026,7 +2728,16 @@
   {
    "cell_type": "markdown",
    "id": "446242f6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011252,
+     "end_time": "2026-09-03T08:23:30.356985",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.345733",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Pathfinding A* sur une grille pondérée 10×10\n",
     "\n",
@@ -2044,17 +2755,27 @@
    "id": "093ed9af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T06:51:15.525121Z",
-     "iopub.status.busy": "2026-07-10T06:51:15.524581Z",
-     "iopub.status.idle": "2026-07-10T06:51:15.643227Z",
-     "shell.execute_reply": "2026-07-10T06:51:15.641982Z"
-    }
+     "iopub.execute_input": "2026-09-03T08:23:30.377353Z",
+     "iopub.status.busy": "2026-09-03T08:23:30.377353Z",
+     "iopub.status.idle": "2026-09-03T08:23:30.411406Z",
+     "shell.execute_reply": "2026-09-03T08:23:30.411406Z"
+    },
+    "papermill": {
+     "duration": 0.04589,
+     "end_time": "2026-09-03T08:23:30.412406",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.366516",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(Exercice a completer) — grille ponderee 10x10 a implementer\r\n"
+     "output_type": "stream",
+     "text": [
+      "(Exercice a completer) — grille ponderee 10x10 a implementer\r\n"
+     ]
     }
    ],
    "source": [
@@ -2080,7 +2801,16 @@
   {
    "cell_type": "markdown",
    "id": "1f226681",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010532,
+     "end_time": "2026-09-03T08:23:30.432966",
+     "exception": false,
+     "start_time": "2026-09-03T08:23:30.422434",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## Conclusion\n",
@@ -2125,6 +2855,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 1,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -2137,22 +2884,17 @@
    "pygments_lexer": "csharp",
    "version": "13.0"
   },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 1,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-28",
-   "validator": "manual"
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.02684,
+   "end_time": "2026-09-03T08:23:30.569037",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-03T08:23:24.542197",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml
@@ -66,6 +66,14 @@
       csharp_sha: 9993af6a511d618d3a367c7efa61cae62b79799e
       content_python_sha: c2795ee971045d3f85e185e6c42fa0633230a70d5ea936b46b060eec49df0775
       content_csharp_sha: ea4e647e62c110746d15c79b2938134fd2a4049f3ab4d6eef0dee81d8dac9392
+      reason: "rebaseline post-merge origin/main (PR #14444 MERGED, ledger G1 #14169) -- le merge de Search-3-Informed-Csharp.ipynb a change le content_csharp_sha (substance bit-identique sur le bridgé QuikGraph A*, mais le papermill reformat a normalisé la clé `execution_count` + réordonné les metadata). csharp_sha inchangé en surface car la substance pédagogique n'a pas changé."
+    - date: "2026-09-03"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 6a38b61b2c754511513922466155023c4a39ae78
+      csharp_sha: 2577e0d116a98810b5603163423f91f85b6a3bd2
+      content_python_sha: c2795ee971045d3f85e185e6c42fa0633230a70d5ea936b46b060eec49df0775
+      content_csharp_sha: 39aa7e5b410e34780334368cd9093348972349958918ac9bee997a2fc339d0c2
+      reason: "rebaseline c.912 PR #14448 (rebasing pre-#14444-merge) -- edit legitime cell[15] L0 Search-3-Informed-Csharp (Search-16 -> Search-02c dans commentaire intra-cellule). Substance pedagogique inchangée, SHA jumeau deplace par reformatage papermill + edit semantique. Cet audit est anterieur au merge #14444 (sha c.914) -- preserve pour transparence cross-lane."
   known_differences:
     - "Socle pedagogique commun : A* et Greedy Best-First avec differentes heuristiques (distance Manhattan, euclidienne, h=0=degenere en UCS). Arrive en Roumanie + 8-puzzle."
     - "Idiomes framework : Python = `import heapq` (priority queue avec (f, tie_breaker, noeud)). C# = `PriorityQueue<AStarNode, double>` (f-cost = g + h)."


### PR DESCRIPTION
Grain: MED/notebook-python (REPAIR P0 twin parity) — lane myia-po-2026:CoursIA-2 — prev: MED/lean #14452

## Search debt §D-3 — 2 références Search-15/16 dans commentaires code (residu #13797)

Suite à la renumérotation #13797 (15/16 → 02b/02c) mergée le 2026-08-XX, deux références au vieux numérotage sont restées **dans des commentaires de cellules code** (donc invisibles à `check_notebook_navlinks.py` qui ne lit que les navlinks markdown). Issue #14061 (po-2025) a signalé ces deux résiduels via la review forensique c.745-L1 §D-3.

## c.912 — Rebaseline twin parity `Search-3 Informed` (REPAIR P0)

Le reformatage papermill + l'edit sémantique cell[15] L0 sur `Search-3-Informed-Csharp.ipynb` ont déplacé le blob SHA du jumeau .NET dans le registre twin parity (#8057). Le check CI `Twin parity audit (#8057)` a reporté `1 paire(s) mise(s) en DRIFT par cette PR` sur `Search-3 Informed` → cascade `PR gate` FAILURE.

**Geste** (commit `7783ac222`, post-c.910) :

```bash
python scripts/notebook_tools/check_twin_parity.py --update --pair "Search-3 Informed" --by "myia-po-2026:CoursIA-2"
```

**Vérification sémantique du rebaseline** (leçon #8570 — `--update` chirurgical préserve les commentaires du registre + ajoute une ligne audit) :

| Champ | Avant | Après | Justification |
|---|---|---|---|
| `python_sha` | `<sha c.910>` | `6a38b61b...` | Reformatage papermill (blob notebook Python) |
| `csharp_sha` | `<sha c.910>` | `2577e0d1...` | Reformatage papermill + edit légitime cell[15] L0 |
| `content_python_sha` | `c2795ee97...` | `c2795ee97...` | **inchangé** — jumeau Python non touché par la substance |
| `content_csharp_sha` | `7272c885bb...` | `39aa7e5b41...` | **changement légitime** — 1 ligne de commentaire intra-cellule (`voir Search-16 cell 2` → `voir Search-02c-QuikGraph cell 2`), pas une normalisation outillée |

Le `--update` est post-strip `probeAddresses` (c.910 a déjà strippé les 9 lignes bannières), donc l'ordre **rebaiser → stripper** n'est pas inversé (cf leçon #8957).

**Périmètre amendé (3 fichiers)** :

| Fichier | Modif | Substance |
|---|---|---|
| `Search/Part1-Foundations/Search-02c-QuikGraph.ipynb` | +157/-148 | Cell[11] L5 commentaire `Search-15` → `Search-02b` (reformatage papermill JSON = la majorité du diff) |
| `Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb` | +1159/-417 | Cell[15] L0 commentaire `Search-16` → `Search-02c` (reformatage papermill JSON = la majorité du diff) |
| `scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml` | +6/-0 | **c.912** rebaseline twin parity — append audit `date: 2026-09-03, by: myia-po-2026:CoursIA-2` |

**Substance (3 lignes modifiées à la racine, le reste = reformatage JSON papermill)** :

| Fichier | Cellule | Avant | Après |
|---|---|---|---|
| `Search/Part1-Foundations/Search-02c-QuikGraph.ipynb` | code cell[11] L5 | `VertexPredecessorRecorderObserver (cell 17 de ce notebook, Search-15 cell 14, Search-3 cell 16, Search-2 cell 38)` | `VertexPredecessorRecorderObserver (cell 17 de ce notebook, Search-02b-NetworkX-Csharp cell 14, Search-3 cell 16, Search-2 cell 38)` |
| `Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb` | code cell[15] L0 | `Installation QuikGraph 2.5.0 (fork KeRNeLith de QuickGraph, voir Search-16 cell 2 pour reference).` | `Installation QuikGraph 2.5.0 (fork KeRNeLith de QuickGraph, voir Search-02c-QuikGraph cell 2 pour reference).` |

Les autres références `Search-3 cell 16` et `Search-2 cell 38` du commentaire cell #11 de Search-02c sont **valides dans la nomenclature courante** (vérifié : Search-3-Informed-Csharp a 35 cellules, Search-2-Uninformed-Csharp a 40 cellules — les indices 16 et 38 existent).

### Acceptation

- [x] Les 2 références corrigées vers le numérotage courant (02b/02c).
- [x] Les 2 cellules code modifiées re-exécutées (C.2/H.1 — un commentaire dans une cellule code reste une modification de source), outputs cohérents commités.
- [x] Grep de confirmation : `Search-15|Search-16` ne matche plus aucune cellule des notebooks Search (les 3 résiduels dans `discrepancy_lean/Discrepancy.lean` et `LEAN_INVENTORY.md` documentent explicitement « numérotation d'opportunité jamais retenue » — mentions historiques type changelog, hors scope).
- [x] Twin parity `Search-3 Informed` rebaseline (c.912), `INTRO=0 PRE=1` localement vérifié.
- [x] Périmètre réel aligné avec body PR (3 fichiers, après amend).

### Re-exécution (C.2/H.1)

Papermill 2.6.0 + kernel `.net-csharp` local (`C:\Users\jsboi\AppData\Roaming\jupyter\kernels\.net-csharp`) :

- **Search-02c-QuikGraph.ipynb** : 14 cellules code re-exécutées, cell #11 (la cellule modifiée) reçoit un `execution_count` frais et préserve le `Console.WriteLine` Dijkstra output (`Dijkstra depuis A (distances en km) : ... chemin : ...`).
- **Search-3-Informed-Csharp.ipynb** : 18 cellules code re-exécutées, cell #15 (la cellule modifiée) reçoit un `execution_count` frais et confirme l'installation QuikGraph (`QuikGraph 2.5.0 installed`).

Pre-commit H.3 strippe les éventuelles bannières `probeAddresses` émises par le kernel .NET Interactive pendant le probing réseau pré-NuGet (cf leçon c.906).

### Périmètre (3 fichiers c.912)

```text
 .../Search/Part1-Foundations/Search-02c-QuikGraph.ipynb      | +157 -148
 .../Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb  | +1159 -417
 scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml   | +6 -0
 3 files changed, 1322 insertions(+), 565 deletions(-)
```

Aucun toucher du catalogue, des marqueurs `CATALOG-STATUS`, ou des autres notebooks de la série. `check_notebook_navlinks.py` n'est pas concerné (les corrections sont intra-cellule, pas dans des navlinks markdown — organe aveugle à cette classe de résiduels).

### Validation post-fix

- **TWin parity local** : `python scripts/notebook_tools/check_twin_parity.py --json --check --per-pair --base origin/main` rend `INTRO=0 PRE=1` (le PRE `ML-5 TimeSeries` est préexistant sur main, cf #8264, PR dédiée).
- **Perimeter guard** : `python scripts/check_pr_perimeter.py 14448 --scan-thread` rend `VERDICT: PASS` (3 fichiers, body amendé).
- **Nits** : `python scripts/check_unaddressed_nits.py 14448` rend `OK — aucun nit non leve`.
- **Grep validation** : `grep -rnE "Search-15|Search-16" MyIA.AI.Notebooks/Search/` rend 3 hits, **TOUS dans `discrepancy_lean/Discrepancy{,_en}.lean` + `LEAN_INVENTORY.md`** qui sont des **mentions historiques explicites** documentant « numérotation d'opportunité jamais retenue » (l'inverse d'une référence utilisante).
- **JSON validity** : `json.load()` sur les 2 notebooks modifiés = OK.
- **Cellules code avec `execution_count`** : 14/14 et 18/18 après re-exec, toutes fraîches.
- **Outputs préservés** : cellule #11 Search-02c émet le `Console.WriteLine` Dijkstra complet, cellule #15 Search-3 émet l'install QuikGraph.

### Cross-lane

- **po-2025** : issue #14061 ouverte par po-2025, claim pris par cette lane myia-po-2026:CoursIA-2 le 2026-09-03.
- **ai-01** : grain sortant du pool global (`pick_idle_grain.py`), pas de steering coordinateur direct. PR peut être mergée si CI verte.
- **Pas de doublon structurel** : ce grain est strictement un sweep de résiduels §D-3 de la livraison #13797, pas une reclassification de fichiers (cf #14247/#14311 et #14177/#14252 sur la famille Search — autres sujets).

### Plancher / G-VAR

- **R1 TENU** : PR livrée + REPAIR P0 c.912 dans le cycle.
- **G-VAR-1 TENU** : `MED/notebook-python` (REPAIR × 1 sur substance notebook-python, genre CONTENU). La dette était petite mais le contenu est sur main — REPAIR × notebook-* compte comme CONTENU (cf variation-protocol.md §G-VAR-1). G-VAR-3 OK : lean → notebook-python (varié, contigu MED/CONTENU).

### Tell ★★ MEMORY-bound

**`papermill-reformat-deplace-blob-sha-twin-parity-INTRO-even-when-substance-inchangee`** — le reformatage papermill complet d'un notebook (réorganisation JSON keys, espaces, normalisation) **déplace le blob SHA du notebook entier** même quand la substance sémantique (1 ligne de commentaire) est minime. Le jumeau Python twin voit son `python_sha` bouger même si **son contenu pédagogique est inchangé** (`content_python_sha` identique). C'est exactement le cas archétypal : reformatage papermill 2.6.0 + kernel `.net-csharp` local sur Search-02c + Search-3 a suffit à introduire un DRIFT sur la jumeauté `Search-3 Informed`. **Leçon** : après tout reformatage papermill post-edit, **anticiper** un rebaseline `--update` sur les paires twin du registre (vérifier le diff `python scripts/check_twin_parity.py --check --per-pair --base origin/main` AVANT le push, pas après le CI FAIL). Le coût d'anticipation : une commande `--update`. Le coût d'omission : un cycle complet (rebaseline + push + re-CI).

### Grain

`MED/notebook-python` — lane `myia-po-2026:CoursIA-2` — prev: `MED/lean` #14452 (c.911)
