### PR TITLE
fix(secrets,#14373): verdict --check honnete + mode --strict (une cle declaree hors master ne dit plus 'No drift')

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -29,6 +29,12 @@ MODES
   --check     report drift only (any service .env whose value for a
               SECRET key differs from master), exit 1 on drift. Use as a
               CI / pre-commit gate.
+  --strict    exit 1 when a SECRET key declared in SECRET_KEYS is absent
+              from master.env (so a CI can distinguish "in sync" from
+              "in sync on what I watch" -- a declared key that drifts can
+              only drift if master actually serves it, #14373). Combines
+              with --check. Without --strict, --check stays exit 0 on a
+              declared-but-absent key and only NAMES it.
   --bootstrap ONE-SHOT: scan existing .env files, extract SECRET values,
               write master.env (first-seen value per key; conflicts
               reported). Use only to initialize master.env from a legacy
@@ -341,12 +347,13 @@ def bootstrap() -> int:
 # --------------------------------------------------------------------------- #
 # sync: propagate master.env -> every .env
 # --------------------------------------------------------------------------- #
-def sync(check_only: bool) -> int:
+def sync(check_only: bool, strict: bool = False) -> int:
     if not MASTER_ENV.exists():
         print(f"[X] {MASTER_ENV} not found. Run with --bootstrap first.")
         return 1
     master = read_env(MASTER_ENV)
     missing_in_master = SECRET_KEYS - master.keys()
+    propagated = len(master)
     if missing_in_master:
         print(f"[!] {len(missing_in_master)} declared SECRET keys are absent from "
               f"master.env (left untouched in services): {sorted(missing_in_master)}")
@@ -390,8 +397,16 @@ def sync(check_only: bool) -> int:
         print("\n[i] Restart impacted containers (ComfyUI-Login hashes regen at restart).")
         return 0
 
-    print(f"[OK] All {len(TARGET_ENVS)} target .env in sync with master.env "
-          f"({len(master)} secret keys). No drift.")
+    if missing_in_master:
+        print(f"[OK] All {len(TARGET_ENVS)} target .env in sync with master.env "
+              f"within the {propagated} propagated key(s). "
+              f"{len(missing_in_master)} declared secret key(s) are OUT OF SCOPE "
+              f"(absent from master.env): {sorted(missing_in_master)}.")
+    else:
+        print(f"[OK] All {len(TARGET_ENVS)} target .env in sync with master.env "
+              f"({len(master)} secret keys). No drift.")
+    if strict and missing_in_master:
+        return 1
     return 0
 
 
@@ -528,6 +543,9 @@ def main() -> int:
                       help="auto-create .env for service dirs that have a "
                            "docker-compose.yml but no .env (closes the "
                            "--check blind spot, cf #9351)")
+    p.add_argument("--strict", action="store_true",
+                   help="exit 1 if a declared SECRET key is absent from "
+                        "master.env (CI gate, #14373)")
     args = p.parse_args()
     if args.bootstrap:
         return bootstrap()
@@ -536,7 +554,7 @@ def main() -> int:
         # successful no-op, list on writes. Map None -> 1 (cannot run),
         # otherwise -> 0 (success regardless of whether anything was written).
         return 1 if bootstrap_missing_envs() is None else 0
-    return sync(check_only=args.check)
+    return sync(check_only=args.check, strict=args.strict)
 
 
 if __name__ == "__main__":

--- a/scripts/secrets/tests/test_render_envs.py
+++ b/scripts/secrets/tests/test_render_envs.py
@@ -470,6 +470,48 @@ class TestSync:
         assert render_envs.sync(check_only=False) == 0
         assert "HF_TOKEN=stable" in targets[0].read_text(encoding="utf-8")
 
+    def test_missing_master_keys_named_not_drift(self, tmp_path, monkeypatch, capsys):
+        """#14373 geste 1 : une clé déclarée dans SECRET_KEYS mais absente du
+        master est NOMÉE, et le verdict cesse de dire 'No drift' (le vert ne
+        couvrait que les clés propagées). Sans --strict, exit 0 (découverte,
+        pas garde)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\n",
+            [("svc", "HF_TOKEN=stable\n")],
+        )
+        # SECRET_KEYS réelle porte des clés (QWEN, IBKR, ...) absentes de ce
+        # master minimal : le [OK] ne doit plus être un no-drift naïf.
+        assert render_envs.sync(check_only=True) == 0
+        out = capsys.readouterr().out
+        assert "OUT OF SCOPE" in out
+        assert "declared secret key(s) are OUT OF SCOPE" in out
+        assert "No drift." not in out
+
+    def test_strict_exit1_when_declared_key_absent(self, tmp_path, monkeypatch):
+        """#14373 geste 2 : --strict sort 1 quand une clé déclarée manque au
+        master, même sans le moindre drift -- distinguer 'en phase' de 'en
+        phase sur ce que je regarde' (contrôle FP de l'issue)."""
+        self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\n",
+            [("svc", "HF_TOKEN=stable\n")],
+        )
+        assert render_envs.sync(check_only=True, strict=True) == 1
+
+    def test_strict_exit0_when_all_declared_present(self, tmp_path, monkeypatch):
+        """Contrôle FP de --strict : quand master sert TOUTES les clés
+        déclarées, --strict reste 0 (le durcissement ne casse pas l'état
+        nominal)."""
+        self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\n",
+            [("svc", "HF_TOKEN=stable\n")],
+        )
+        monkeypatch.setattr(render_envs, "SECRET_KEYS", frozenset({"HF_TOKEN"}))
+        assert render_envs.sync(check_only=True, strict=True) == 0
+        assert render_envs.sync(check_only=False, strict=True) == 0
+
     def test_non_secret_key_untouched(self, tmp_path, monkeypatch):
         # A KEY present in service .env but ABSENT from master must be left
         # untouched (master only governs its own declared keys).
@@ -506,6 +548,19 @@ class TestMain:
         # Drift in check mode -> exit 1, no write.
         assert render_envs.main() == 1
         assert "HF_TOKEN=old" in svc.read_text(encoding="utf-8")
+
+    def test_strict_flag_routes_to_sync_strict(self, tmp_path, monkeypatch):
+        """#14373 geste 2 : --check --strict route vers strict=True et sort 1
+        quand une clé déclarée est absente du master (pas de drift) -- la CI
+        peut distinguer 'en phase' de 'en phase sur ce que je regarde'."""
+        master = tmp_path / "master.env"
+        master.write_text("HF_TOKEN=stable\n", encoding="utf-8")
+        svc = _svc_env(tmp_path, "svc")
+        svc.write_text("HF_TOKEN=stable\n", encoding="utf-8")
+        monkeypatch.setattr(render_envs, "MASTER_ENV", master)
+        monkeypatch.setattr(render_envs, "TARGET_ENVS", [svc])
+        monkeypatch.setattr(sys, "argv", ["render_envs.py", "--check", "--strict"])
+        assert render_envs.main() == 1
 
     def test_bootstrap_flag_routes_to_bootstrap(self, tmp_path, monkeypatch):
         master = tmp_path / "master.env"


### PR DESCRIPTION
Grain: MED/genai -- lane myia-po-2023:CoursIA -- prev: MED/guard #14454

## Summary

`python scripts/secrets/render_envs.py --check` sortait **exit 0 + « No drift »** alors qu'il imprimait lui-même le `[!]` de M clés déclarées absentes de `master.env` : le `[!]` disait « ces clés peuvent dériver » et le verdict disait « tout est en phase ». Le vert ne couvrait que les clés **propagées**, pas le périmètre **déclaré** (#14373). Cette PR traite les gestes 1 et 2 de l'issue ; le geste 3 (rapatrier vs retirer les 7) reste une décision de périmètre, laissée au coordonnateur (résiduel ci-dessous).

## Changements

- **`scripts/secrets/render_envs.py`** :
  - **Geste 1 — verdict honnête.** Quand `missing_in_master` est non vide, le `[OK]` final devient « All N target .env in sync ... within the P propagated key(s). M declared secret key(s) are OUT OF SCOPE (absent from master.env): [...] » — un lecteur cesse de croire que le vert couvre tout. Le cas nominal (toutes les clés présentes) garde « No drift. ». Docstring `MODES` enrichie.
  - **Geste 2 — mode strict.** `sync(check_only, strict=False)` + option CLI `--strict` : sort `1` quand une clé déclarée dans `SECRET_KEYS` est absente du master, **même sans le moindre drift** — une CI distingue « en phase » de « en phase sur ce que je regarde ». Aucune valeur de secret n'est changée ni imprimée (noms de clés uniquement, comme le `[!]` existant).
- **`scripts/secrets/tests/test_render_envs.py`** : 4 nouveaux tests — `test_missing_master_keys_named_not_drift` (verdict contient `OUT OF SCOPE`, plus de `No drift.` naïf), `test_strict_exit1_when_declared_key_absent` (contrôle FP : exit 1 sans drift), `test_strict_exit0_when_all_declared_present` (nominal), `test_strict_flag_routes_to_sync_strict` (CLI).

## Verification

- [x] 80/80 tests `scripts/secrets/tests/test_render_envs.py` passent (avant/après).
- [x] `py_compile` OK ; diff +77/-4, 2 fichiers, un seul sujet (verdict/strict du garde secrets).
- [x] Seul consommateur de `sync()` = l'appel CLI (mis à jour) ; `strict=False` par défaut, aucun appelant existant cassé.
- [x] Cas nominal préservé : toutes les clés déclarées présentes dans le master -> `No drift.` + exit 0 (testé).
- [x] Aucune valeur de secret écrite, imprimée ou committée ; uniquement des noms de clés (et réaffectation du `--check`).

## Residuel — geste 3 (decision de perimetre, NON tranche ici)

L'issue liste 7 clés déclarées absentes du master (`QWEN_API_TOKEN`, `OWUI_API_KEY`, `QDRANT_API_KEY`, `MISTRAL_API_KEY`, `IBKR_USERNAME`, `IBKR_PASSWORD`, `COMFYUI_VIDEO_PASSWORD`). **Chacune a déjà, dans `SECRET_KEYS`, un commentaire justifiant sa centralisation** (Qdrant client-side partagé, OWUI partagé, COMFYUI_VIDEO_PASSWORD centralisé par décision user #10985, QWEN bearer #10265, IBKR #1199, MISTRAL Leanstral #5475) : la bonne action à long terme est donc **les rapatrier dans `master.env`** (édit master + `render`, rotation centralisée), **pas** les retirer de `SECRET_KEYS`. Le retrait perdrait la rotation centralisée ; le rapatriement est un acte **par machine** (valeur gitignorée, hors scope PR). `COMFYUI_AUTH_TOKEN` (classe « inconnue du pipeline » de l'issue) est traité à part : le carrier est la PR #14426 (alias `COMFYUI_AUTH_TOKEN` -> `COMFYUI_API_TOKEN` + entrée `SECRET_KEYS`), déjà ouverte — ne pas dupliquer ici. Une fois ces clés rapatriées, `--check --strict` devient vert, ce qui est le vrai contrôle de la source unique.

Voir #14373 (gestes 1+2 livrés ; geste 3 ouvert)