### PR TITLE
feat(lean): expose Sendov and Analysis axiom footprints

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-19-Sendov-Complex-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-19-Sendov-Complex-Analysis.ipynb
@@ -5,10 +5,10 @@
    "id": "2d0ab3da",
    "metadata": {
     "papermill": {
-     "duration": 0.004835,
-     "end_time": "2026-08-15T14:25:53.866858",
+     "duration": 0.003023,
+     "end_time": "2026-09-03T09:57:44.847998+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.862023",
+     "start_time": "2026-09-03T09:57:44.844975+00:00",
      "status": "completed"
     },
     "tags": []
@@ -51,10 +51,10 @@
    "id": "d4f86c4a",
    "metadata": {
     "papermill": {
-     "duration": 0.005508,
-     "end_time": "2026-08-15T14:25:53.878619",
+     "duration": 0.002508,
+     "end_time": "2026-09-03T09:57:44.855480+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.873111",
+     "start_time": "2026-09-03T09:57:44.852972+00:00",
      "status": "completed"
     },
     "tags": []
@@ -91,16 +91,16 @@
    "id": "0d27b815",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:53.891363Z",
-     "iopub.status.busy": "2026-08-15T14:25:53.890823Z",
-     "iopub.status.idle": "2026-08-15T14:25:53.903384Z",
-     "shell.execute_reply": "2026-08-15T14:25:53.902261Z"
+     "iopub.execute_input": "2026-09-03T09:57:44.861704Z",
+     "iopub.status.busy": "2026-09-03T09:57:44.861510Z",
+     "iopub.status.idle": "2026-09-03T09:57:44.866338Z",
+     "shell.execute_reply": "2026-09-03T09:57:44.865323Z"
     },
     "papermill": {
-     "duration": 0.020038,
-     "end_time": "2026-08-15T14:25:53.903903",
+     "duration": 0.009035,
+     "end_time": "2026-09-03T09:57:44.867122+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.883865",
+     "start_time": "2026-09-03T09:57:44.858087+00:00",
      "status": "completed"
     },
     "tags": []
@@ -151,10 +151,10 @@
    "id": "ba182bd8",
    "metadata": {
     "papermill": {
-     "duration": 0.006353,
-     "end_time": "2026-08-15T14:25:53.914068",
+     "duration": 0.002014,
+     "end_time": "2026-09-03T09:57:44.871267+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.907715",
+     "start_time": "2026-09-03T09:57:44.869253+00:00",
      "status": "completed"
     },
     "tags": []
@@ -189,10 +189,10 @@
    "id": "16b4248d",
    "metadata": {
     "papermill": {
-     "duration": 0.006384,
-     "end_time": "2026-08-15T14:25:53.926447",
+     "duration": 0.00188,
+     "end_time": "2026-09-03T09:57:44.875213+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.920063",
+     "start_time": "2026-09-03T09:57:44.873333+00:00",
      "status": "completed"
     },
     "tags": []
@@ -242,10 +242,10 @@
    "id": "04aa2a4c",
    "metadata": {
     "papermill": {
-     "duration": 0.005297,
-     "end_time": "2026-08-15T14:25:53.936085",
+     "duration": 0.001908,
+     "end_time": "2026-09-03T09:57:44.879107+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.930788",
+     "start_time": "2026-09-03T09:57:44.877199+00:00",
      "status": "completed"
     },
     "tags": []
@@ -285,16 +285,16 @@
    "id": "24c749c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:53.946943Z",
-     "iopub.status.busy": "2026-08-15T14:25:53.946943Z",
-     "iopub.status.idle": "2026-08-15T14:25:53.951485Z",
-     "shell.execute_reply": "2026-08-15T14:25:53.951485Z"
+     "iopub.execute_input": "2026-09-03T09:57:44.884079Z",
+     "iopub.status.busy": "2026-09-03T09:57:44.883898Z",
+     "iopub.status.idle": "2026-09-03T09:57:44.887393Z",
+     "shell.execute_reply": "2026-09-03T09:57:44.886511Z"
     },
     "papermill": {
-     "duration": 0.011216,
-     "end_time": "2026-08-15T14:25:53.951485",
+     "duration": 0.006804,
+     "end_time": "2026-09-03T09:57:44.887929+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.940269",
+     "start_time": "2026-09-03T09:57:44.881125+00:00",
      "status": "completed"
     },
     "tags": []
@@ -341,10 +341,10 @@
    "id": "096ea6e7",
    "metadata": {
     "papermill": {
-     "duration": 0.005702,
-     "end_time": "2026-08-15T14:25:53.965427",
+     "duration": 0.001996,
+     "end_time": "2026-09-03T09:57:44.892139+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.959725",
+     "start_time": "2026-09-03T09:57:44.890143+00:00",
      "status": "completed"
     },
     "tags": []
@@ -387,16 +387,16 @@
    "id": "099949ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:53.974724Z",
-     "iopub.status.busy": "2026-08-15T14:25:53.974724Z",
-     "iopub.status.idle": "2026-08-15T14:25:54.044102Z",
-     "shell.execute_reply": "2026-08-15T14:25:54.043744Z"
+     "iopub.execute_input": "2026-09-03T09:57:44.897516Z",
+     "iopub.status.busy": "2026-09-03T09:57:44.897347Z",
+     "iopub.status.idle": "2026-09-03T09:57:45.033941Z",
+     "shell.execute_reply": "2026-09-03T09:57:45.032823Z"
     },
     "papermill": {
-     "duration": 0.074663,
-     "end_time": "2026-08-15T14:25:54.044102",
+     "duration": 0.140414,
+     "end_time": "2026-09-03T09:57:45.034592+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:53.969439",
+     "start_time": "2026-09-03T09:57:44.894178+00:00",
      "status": "completed"
     },
     "tags": []
@@ -463,10 +463,10 @@
    "id": "40e2df21",
    "metadata": {
     "papermill": {
-     "duration": 0.004191,
-     "end_time": "2026-08-15T14:25:54.052488",
+     "duration": 0.002347,
+     "end_time": "2026-09-03T09:57:45.039891+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:54.048297",
+     "start_time": "2026-09-03T09:57:45.037544+00:00",
      "status": "completed"
     },
     "tags": []
@@ -523,16 +523,16 @@
    "id": "6c5d0cf6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:54.063235Z",
-     "iopub.status.busy": "2026-08-15T14:25:54.062226Z",
-     "iopub.status.idle": "2026-08-15T14:25:54.973016Z",
-     "shell.execute_reply": "2026-08-15T14:25:54.971976Z"
+     "iopub.execute_input": "2026-09-03T09:57:45.045818Z",
+     "iopub.status.busy": "2026-09-03T09:57:45.045591Z",
+     "iopub.status.idle": "2026-09-03T09:57:45.611068Z",
+     "shell.execute_reply": "2026-09-03T09:57:45.609427Z"
     },
     "papermill": {
-     "duration": 0.917533,
-     "end_time": "2026-08-15T14:25:54.974029",
+     "duration": 0.570386,
+     "end_time": "2026-09-03T09:57:45.612696+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:54.056496",
+     "start_time": "2026-09-03T09:57:45.042310+00:00",
      "status": "completed"
     },
     "tags": []
@@ -606,10 +606,10 @@
    "id": "74a39e7e",
    "metadata": {
     "papermill": {
-     "duration": 0.004997,
-     "end_time": "2026-08-15T14:25:54.983656",
+     "duration": 0.003299,
+     "end_time": "2026-09-03T09:57:45.618893+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:54.978659",
+     "start_time": "2026-09-03T09:57:45.615594+00:00",
      "status": "completed"
     },
     "tags": []
@@ -662,16 +662,16 @@
    "id": "0f4688b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:54.994526Z",
-     "iopub.status.busy": "2026-08-15T14:25:54.994526Z",
-     "iopub.status.idle": "2026-08-15T14:25:55.000498Z",
-     "shell.execute_reply": "2026-08-15T14:25:55.000498Z"
+     "iopub.execute_input": "2026-09-03T09:57:45.624607Z",
+     "iopub.status.busy": "2026-09-03T09:57:45.624340Z",
+     "iopub.status.idle": "2026-09-03T09:57:45.629807Z",
+     "shell.execute_reply": "2026-09-03T09:57:45.628358Z"
     },
     "papermill": {
-     "duration": 0.01374,
-     "end_time": "2026-08-15T14:25:55.002020",
+     "duration": 0.00972,
+     "end_time": "2026-09-03T09:57:45.630996+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:54.988280",
+     "start_time": "2026-09-03T09:57:45.621276+00:00",
      "status": "completed"
     },
     "tags": []
@@ -684,8 +684,8 @@
       "Distances |omega - 0| pour les zeros de z^n - 1 :\n",
       "  n = 2: distances = [1.0, 1.0], max = 1.0000\n",
       "  n = 3: distances = [1.0, 0.9999999999999999, 1.0], max = 1.0000\n",
-      "  n = 5: distances = [1.0, 0.9999999999999999, 1.0, 0.9999999999999999, 1.0], max = 1.0000\n",
-      "  n = 10: distances = [1.0, 1.0, 0.9999999999999999, 1.0, 1.0, 1.0, 0.9999999999999999, 1.0, 1.0, 1.0], max = 1.0000\n",
+      "  n = 5: distances = [1.0, 1.0, 1.0, 1.0, 1.0], max = 1.0000\n",
+      "  n = 10: distances = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], max = 1.0000\n",
       "\n",
       "Conclusion : pour p(z) = z^n - 1, tous les points critiques sont en 0,\n",
       "donc |zeta - omega| = |0 - omega| = |omega| = 1 EXACTEMENT.\n",
@@ -729,10 +729,10 @@
    "id": "f3c66f84",
    "metadata": {
     "papermill": {
-     "duration": 0.005241,
-     "end_time": "2026-08-15T14:25:55.012796",
+     "duration": 0.002056,
+     "end_time": "2026-09-03T09:57:45.635870+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.007555",
+     "start_time": "2026-09-03T09:57:45.633814+00:00",
      "status": "completed"
     },
     "tags": []
@@ -774,16 +774,16 @@
    "id": "230ab85d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:55.023956Z",
-     "iopub.status.busy": "2026-08-15T14:25:55.023956Z",
-     "iopub.status.idle": "2026-08-15T14:25:55.032862Z",
-     "shell.execute_reply": "2026-08-15T14:25:55.032332Z"
+     "iopub.execute_input": "2026-09-03T09:57:45.640987Z",
+     "iopub.status.busy": "2026-09-03T09:57:45.640821Z",
+     "iopub.status.idle": "2026-09-03T09:57:45.647501Z",
+     "shell.execute_reply": "2026-09-03T09:57:45.646646Z"
     },
     "papermill": {
-     "duration": 0.016449,
-     "end_time": "2026-08-15T14:25:55.033876",
+     "duration": 0.010242,
+     "end_time": "2026-09-03T09:57:45.648168+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.017427",
+     "start_time": "2026-09-03T09:57:45.637926+00:00",
      "status": "completed"
     },
     "tags": []
@@ -793,9 +793,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "a (zero complexe) = (0.28284271247461906+0.28284271247461906j)\n",
+      "a (zero complexe) = (0.28284271247461906+0.282842712474619j)\n",
       "|a| = 0.4000\n",
-      "Zeros de p = [0, np.complex128(0.3535533905932738+0.3535533905932738j), np.complex128(0.23570226039551584+0.23570226039551584j)], tous dans D_bar : True\n",
+      "Zeros de p = [0, np.complex128(0.3535533905932738+0.35355339059327373j), np.complex128(0.23570226039551584+0.2357022603955158j)], tous dans D_bar : True\n",
       "\n",
       "Zeros de p_omega = [np.complex128(0j), np.complex128(0.5+0j), np.complex128(0.3333333333333333+0j)]\n",
       "r = 0.4 est bien un zero de p_omega : False\n",
@@ -803,8 +803,8 @@
       "Points critiques de p_omega : [np.complex128(0.41666666666666663+0j), np.complex128(0.16666666666666666+0j), np.complex128(0.25+0j)]\n",
       "Distances au zero reel r = 0.4 : [np.float64(0.016666666666666607), np.float64(0.23333333333333336), np.float64(0.15000000000000002)]\n",
       "\n",
-      "Points critiques de p (transport) : [np.complex128(0.2946278254943948+0.2946278254943948j), np.complex128(0.11785113019775792+0.11785113019775792j), np.complex128(0.1767766952966369+0.1767766952966369j)]\n",
-      "Distances au zero complexe a = (0.28284271247461906+0.28284271247461906j) : [np.float64(0.016666666666666607), np.float64(0.23333333333333342), np.float64(0.15000000000000005)]\n",
+      "Points critiques de p (transport) : [np.complex128(0.2946278254943948+0.29462782549439476j), np.complex128(0.11785113019775792+0.1178511301977579j), np.complex128(0.1767766952966369+0.17677669529663687j)]\n",
+      "Distances au zero complexe a = (0.28284271247461906+0.282842712474619j) : [np.float64(0.016666666666666607), np.float64(0.2333333333333334), np.float64(0.15000000000000005)]\n",
       "\n",
       "Conclusion : par rotation + transport, on a |zeta_p - a| = |zeta_pomega - r| <= 1.\n",
       "Sendov est verifie pour le zero complexe a, via le cas reel r.\n"
@@ -862,13 +862,122 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c3e0bfb2",
+   "source": "### 8.5 Du récit mathématique au certificat du noyau\n\nLes sections précédentes expliquent comment la preuve se décompose et se recolle. Il reste à poser une question différente : **de quels axiomes le théorème final dépend-il transitivement ?** La cellule suivante quitte le pseudo-Lean pédagogique, importe le module réel `Sendov.Conjecture` et demande directement à Lean l’empreinte de `Sendov.sendov`.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "40cb37d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T09:57:45.654241Z",
+     "iopub.status.busy": "2026-09-03T09:57:45.654076Z",
+     "iopub.status.idle": "2026-09-03T09:57:47.057533Z",
+     "shell.execute_reply": "2026-09-03T09:57:47.056619Z"
+    },
+    "papermill": {
+     "duration": 1.407585,
+     "end_time": "2026-09-03T09:57:47.058130+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T09:57:45.650545+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@Sendov.sendov : ∀ {n : ℕ},\n",
+      "  2 ≤ n →\n",
+      "    ∀ {p : Polynomial ℂ},\n",
+      "      p.natDegree = n →\n",
+      "        (∀ w ∈ p.roots, ‖w‖ ≤ 1) →\n",
+      "          ∀ {a : ℂ}, Polynomial.eval a p = 0 → ∃ ζ, Polynomial.eval ζ (Polynomial.derivative p) = 0 ∧ ‖ζ - a‖ ≤ 1\n",
+      "'Sendov.sendov' depends on axioms: [propext, Classical.choice, Quot.sound]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code 8.2 — Empreinte axiomatique réelle du théorème principal\n",
+    "#\n",
+    "# Le notebook conserve son kernel Python et invoque le vrai compilateur Lean\n",
+    "# dans le lac externe construit sous WSL. La sortie provient directement de\n",
+    "# `#print axioms`, et non d'une transcription manuelle.\n",
+    "\n",
+    "import os\n",
+    "import subprocess\n",
+    "import textwrap\n",
+    "\n",
+    "lean_source = textwrap.dedent(\"\"\"\n",
+    "    import Sendov.Conjecture\n",
+    "\n",
+    "    #check @Sendov.sendov\n",
+    "    #print axioms Sendov.sendov\n",
+    "\"\"\").strip()\n",
+    "\n",
+    "lean_command = f\"\"\"\n",
+    "cd ~/lean-projects/sendov\n",
+    "cat > /tmp/coursia_sendov_axioms.lean <<'LEAN_EOF'\n",
+    "{lean_source}\n",
+    "LEAN_EOF\n",
+    "lake env lean /tmp/coursia_sendov_axioms.lean 2>&1\n",
+    "\"\"\"\n",
+    "\n",
+    "if os.name == \"nt\":\n",
+    "    command = [\"wsl\", \"-d\", \"Ubuntu\", \"--\", \"bash\", \"-lc\", lean_command]\n",
+    "else:\n",
+    "    command = [\"bash\", \"-lc\", lean_command]\n",
+    "\n",
+    "result = subprocess.run(\n",
+    "    command,\n",
+    "    capture_output=True,\n",
+    "    text=True,\n",
+    "    encoding=\"utf-8\",\n",
+    "    errors=\"replace\",\n",
+    "    timeout=600,\n",
+    ")\n",
+    "lean_output = (result.stdout + result.stderr).strip()\n",
+    "print(lean_output)\n",
+    "if result.returncode != 0:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Lean a échoué avec le code {result.returncode}; voir la sortie ci-dessus.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64b5e302",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002143,
+     "end_time": "2026-09-03T09:57:47.062838+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T09:57:47.060695+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : une clôture classique, sans axiome de secours\n",
+    "\n",
+    "Le relevé exécuté ci-dessus donne exactement `[propext, Classical.choice, Quot.sound]`, la même empreinte que `PFR_conjecture` dans Lean-21. `Classical.choice` rend explicite le caractère non constructif de certains choix utilisés par l'analyse classique ; `propext` et `Quot.sound` accompagnent respectivement l'extensionalité propositionnelle et les constructions par quotient.\n",
+    "\n",
+    "Deux absences sont décisives : ni `sorryAx` ni aucun axiome `native_decide.*` n'apparaissent. Le verdict est donc **SOTA-OK pour le théorème ciblé** : `Sendov.sendov` est clos par des axiomes standards explicitement nommés, sans trou transitif et sans décision native non certifiée par le noyau."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "44b9ac0f",
    "metadata": {
     "papermill": {
-     "duration": 0.006364,
-     "end_time": "2026-08-15T14:25:55.044720",
+     "duration": 0.002179,
+     "end_time": "2026-09-03T09:57:47.067854+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.038356",
+     "start_time": "2026-09-03T09:57:47.065675+00:00",
      "status": "completed"
     },
     "tags": []
@@ -889,20 +998,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "794d0033",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:55.055340Z",
-     "iopub.status.busy": "2026-08-15T14:25:55.055340Z",
-     "iopub.status.idle": "2026-08-15T14:25:55.060859Z",
-     "shell.execute_reply": "2026-08-15T14:25:55.059849Z"
+     "iopub.execute_input": "2026-09-03T09:57:47.073284Z",
+     "iopub.status.busy": "2026-09-03T09:57:47.073112Z",
+     "iopub.status.idle": "2026-09-03T09:57:47.077031Z",
+     "shell.execute_reply": "2026-09-03T09:57:47.076083Z"
     },
     "papermill": {
-     "duration": 0.012637,
-     "end_time": "2026-08-15T14:25:55.061857",
+     "duration": 0.007513,
+     "end_time": "2026-09-03T09:57:47.077646+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.049220",
+     "start_time": "2026-09-03T09:57:47.070133+00:00",
      "status": "completed"
     },
     "tags": []
@@ -914,6 +1023,16 @@
      "text": [
       "Exercice 1 : voir rubinstein_one dans Sendov/Boundary.lean\n",
       "Indication : factoriser p(z) = (z - a)^m * q(z) puis raisonner sur q.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:7: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "<>:7: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "/tmp/ipykernel_30400/4253923250.py:7: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "  \"\"\"\n"
      ]
     }
    ],
@@ -958,10 +1077,10 @@
    "id": "a14624e8",
    "metadata": {
     "papermill": {
-     "duration": 0.004718,
-     "end_time": "2026-08-15T14:25:55.072167",
+     "duration": 0.002205,
+     "end_time": "2026-09-03T09:57:47.082288+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.067449",
+     "start_time": "2026-09-03T09:57:47.080083+00:00",
      "status": "completed"
     },
     "tags": []
@@ -978,20 +1097,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "627e9920",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:55.083406Z",
-     "iopub.status.busy": "2026-08-15T14:25:55.083406Z",
-     "iopub.status.idle": "2026-08-15T14:25:55.089199Z",
-     "shell.execute_reply": "2026-08-15T14:25:55.089199Z"
+     "iopub.execute_input": "2026-09-03T09:57:47.087735Z",
+     "iopub.status.busy": "2026-09-03T09:57:47.087575Z",
+     "iopub.status.idle": "2026-09-03T09:57:47.091866Z",
+     "shell.execute_reply": "2026-09-03T09:57:47.091000Z"
     },
     "papermill": {
-     "duration": 0.013099,
-     "end_time": "2026-08-15T14:25:55.090772",
+     "duration": 0.00782,
+     "end_time": "2026-09-03T09:57:47.092402+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.077673",
+     "start_time": "2026-09-03T09:57:47.084582+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1056,10 +1175,10 @@
    "id": "d803d838",
    "metadata": {
     "papermill": {
-     "duration": 0.005383,
-     "end_time": "2026-08-15T14:25:55.101965",
+     "duration": 0.002219,
+     "end_time": "2026-09-03T09:57:47.097206+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.096582",
+     "start_time": "2026-09-03T09:57:47.094987+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1072,20 +1191,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "82116b0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T14:25:55.114805Z",
-     "iopub.status.busy": "2026-08-15T14:25:55.114270Z",
-     "iopub.status.idle": "2026-08-15T14:25:55.120151Z",
-     "shell.execute_reply": "2026-08-15T14:25:55.119086Z"
+     "iopub.execute_input": "2026-09-03T09:57:47.103074Z",
+     "iopub.status.busy": "2026-09-03T09:57:47.102907Z",
+     "iopub.status.idle": "2026-09-03T09:57:47.106455Z",
+     "shell.execute_reply": "2026-09-03T09:57:47.105752Z"
     },
     "papermill": {
-     "duration": 0.014948,
-     "end_time": "2026-08-15T14:25:55.121268",
+     "duration": 0.007715,
+     "end_time": "2026-09-03T09:57:47.107285+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.106320",
+     "start_time": "2026-09-03T09:57:47.099570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1099,6 +1218,16 @@
       "Indication : la cle est q'(zeta) = p'(h(zeta)) * h'(zeta).\n",
       "Si zeta est tel que h(zeta) = w (zero de p), et zeta critique de h,\n",
       "alors zeta est critique de q.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:7: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "<>:7: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "/tmp/ipykernel_30400/1547187100.py:7: SyntaxWarning: invalid escape sequence '\\ '\n",
+      "  \"\"\"\n"
      ]
     }
    ],
@@ -1146,10 +1275,10 @@
    "id": "3eeaea2c",
    "metadata": {
     "papermill": {
-     "duration": 0.004096,
-     "end_time": "2026-08-15T14:25:55.131158",
+     "duration": 0.002491,
+     "end_time": "2026-09-03T09:57:47.112475+00:00",
      "exception": false,
-     "start_time": "2026-08-15T14:25:55.127062",
+     "start_time": "2026-09-03T09:57:47.109984+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1203,18 +1332,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.117355,
-   "end_time": "2026-08-15T14:25:55.470303",
+   "duration": 3.579109,
+   "end_time": "2026-09-03T09:57:47.334760+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Lean-19-Sendov-Complex-Analysis.ipynb",
-   "output_path": "Lean-19.ipynb",
+   "output_path": "Lean-19-Sendov-Complex-Analysis.ipynb",
    "parameters": {},
-   "start_time": "2026-08-15T14:25:52.352948",
+   "start_time": "2026-09-03T09:57:43.755651+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-20-Analysis-I-Tao-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-20-Analysis-I-Tao-Workflow.ipynb
@@ -5,10 +5,10 @@
    "id": "5f2bed35",
    "metadata": {
     "papermill": {
-     "duration": 0.009111,
-     "end_time": "2026-08-21T03:07:33.961963+00:00",
+     "duration": 0.002669,
+     "end_time": "2026-09-03T10:15:18.278844+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:33.952852+00:00",
+     "start_time": "2026-09-03T10:15:18.276175+00:00",
      "status": "completed"
     },
     "tags": []
@@ -48,10 +48,10 @@
    "id": "b3979839",
    "metadata": {
     "papermill": {
-     "duration": 0.00305,
-     "end_time": "2026-08-21T03:07:33.972508+00:00",
+     "duration": 0.002933,
+     "end_time": "2026-09-03T10:15:18.284484+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:33.969458+00:00",
+     "start_time": "2026-09-03T10:15:18.281551+00:00",
      "status": "completed"
     },
     "tags": []
@@ -108,16 +108,16 @@
    "id": "a389e509",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:33.981222Z",
-     "iopub.status.busy": "2026-08-21T03:07:33.981022Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.032311Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.031725Z"
+     "iopub.execute_input": "2026-09-03T10:15:18.289267Z",
+     "iopub.status.busy": "2026-09-03T10:15:18.289087Z",
+     "iopub.status.idle": "2026-09-03T10:15:18.297754Z",
+     "shell.execute_reply": "2026-09-03T10:15:18.296991Z"
     },
     "papermill": {
-     "duration": 0.057189,
-     "end_time": "2026-08-21T03:07:34.032856+00:00",
+     "duration": 0.012281,
+     "end_time": "2026-09-03T10:15:18.298616+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:33.975667+00:00",
+     "start_time": "2026-09-03T10:15:18.286335+00:00",
      "status": "completed"
     },
     "tags": []
@@ -217,10 +217,10 @@
    "id": "5dca5044",
    "metadata": {
     "papermill": {
-     "duration": 0.001861,
-     "end_time": "2026-08-21T03:07:34.036785+00:00",
+     "duration": 0.002136,
+     "end_time": "2026-09-03T10:15:18.302785+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.034924+00:00",
+     "start_time": "2026-09-03T10:15:18.300649+00:00",
      "status": "completed"
     },
     "tags": []
@@ -266,16 +266,16 @@
    "id": "ba3ddc61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.041430Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.041176Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.045854Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.045311Z"
+     "iopub.execute_input": "2026-09-03T10:15:18.307599Z",
+     "iopub.status.busy": "2026-09-03T10:15:18.307428Z",
+     "iopub.status.idle": "2026-09-03T10:15:18.311621Z",
+     "shell.execute_reply": "2026-09-03T10:15:18.310923Z"
     },
     "papermill": {
-     "duration": 0.007596,
-     "end_time": "2026-08-21T03:07:34.046287+00:00",
+     "duration": 0.007955,
+     "end_time": "2026-09-03T10:15:18.312587+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.038691+00:00",
+     "start_time": "2026-09-03T10:15:18.304632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -341,10 +341,10 @@
    "id": "fd0b0455",
    "metadata": {
     "papermill": {
-     "duration": 0.00184,
-     "end_time": "2026-08-21T03:07:34.050222+00:00",
+     "duration": 0.002523,
+     "end_time": "2026-09-03T10:15:18.317187+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.048382+00:00",
+     "start_time": "2026-09-03T10:15:18.314664+00:00",
      "status": "completed"
     },
     "tags": []
@@ -414,16 +414,16 @@
    "id": "06877377",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.055219Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.055003Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.140603Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.140064Z"
+     "iopub.execute_input": "2026-09-03T10:15:18.322725Z",
+     "iopub.status.busy": "2026-09-03T10:15:18.322554Z",
+     "iopub.status.idle": "2026-09-03T10:15:18.456538Z",
+     "shell.execute_reply": "2026-09-03T10:15:18.455746Z"
     },
     "papermill": {
-     "duration": 0.088609,
-     "end_time": "2026-08-21T03:07:34.141086+00:00",
+     "duration": 0.137945,
+     "end_time": "2026-09-03T10:15:18.457390+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.052477+00:00",
+     "start_time": "2026-09-03T10:15:18.319445+00:00",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +512,10 @@
    "id": "8430577e",
    "metadata": {
     "papermill": {
-     "duration": 0.001804,
-     "end_time": "2026-08-21T03:07:34.145061+00:00",
+     "duration": 0.001946,
+     "end_time": "2026-09-03T10:15:18.461805+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.143257+00:00",
+     "start_time": "2026-09-03T10:15:18.459859+00:00",
      "status": "completed"
     },
     "tags": []
@@ -588,16 +588,16 @@
    "id": "82c569b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.149728Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.149507Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.155692Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.155238Z"
+     "iopub.execute_input": "2026-09-03T10:15:18.466861Z",
+     "iopub.status.busy": "2026-09-03T10:15:18.466694Z",
+     "iopub.status.idle": "2026-09-03T10:15:18.472804Z",
+     "shell.execute_reply": "2026-09-03T10:15:18.472116Z"
     },
     "papermill": {
-     "duration": 0.009186,
-     "end_time": "2026-08-21T03:07:34.156160+00:00",
+     "duration": 0.009894,
+     "end_time": "2026-09-03T10:15:18.473713+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.146974+00:00",
+     "start_time": "2026-09-03T10:15:18.463819+00:00",
      "status": "completed"
     },
     "tags": []
@@ -711,10 +711,10 @@
    "id": "c17aea13",
    "metadata": {
     "papermill": {
-     "duration": 0.001953,
-     "end_time": "2026-08-21T03:07:34.160060+00:00",
+     "duration": 0.002011,
+     "end_time": "2026-09-03T10:15:18.477931+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.158107+00:00",
+     "start_time": "2026-09-03T10:15:18.475920+00:00",
      "status": "completed"
     },
     "tags": []
@@ -760,16 +760,16 @@
    "id": "385b44c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.164877Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.164644Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.168327Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.167934Z"
+     "iopub.execute_input": "2026-09-03T10:15:18.482929Z",
+     "iopub.status.busy": "2026-09-03T10:15:18.482753Z",
+     "iopub.status.idle": "2026-09-03T10:15:18.486484Z",
+     "shell.execute_reply": "2026-09-03T10:15:18.485738Z"
     },
     "papermill": {
-     "duration": 0.006894,
-     "end_time": "2026-08-21T03:07:34.168928+00:00",
+     "duration": 0.007144,
+     "end_time": "2026-09-03T10:15:18.487076+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.162034+00:00",
+     "start_time": "2026-09-03T10:15:18.479932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -819,13 +819,136 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6427af69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002131,
+     "end_time": "2026-09-03T10:15:18.491329+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T10:15:18.489198+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.7 Du comptage des `sorry` à la dépendance transitive\n",
+    "\n",
+    "La cartographie du lac compte de nombreux `sorry` pédagogiques, mais ce total global ne dit pas si le théorème des valeurs intermédiaires en dépend transitivement. Pour distinguer dette locale et dépendance réelle, la cellule suivante importe `Analysis.Section_9_7` et demande directement à Lean l’empreinte de `Chapter9.intermediate_value`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "52652565",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T10:15:18.496959Z",
+     "iopub.status.busy": "2026-09-03T10:15:18.496786Z",
+     "iopub.status.idle": "2026-09-03T10:15:34.068921Z",
+     "shell.execute_reply": "2026-09-03T10:15:34.068062Z"
+    },
+    "papermill": {
+     "duration": 15.576183,
+     "end_time": "2026-09-03T10:15:34.069794+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T10:15:18.493611+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@Chapter9.intermediate_value : ∀ {a b : ℝ},\n",
+      "  a < b →\n",
+      "    ∀ {f : ℝ → ℝ},\n",
+      "      ContinuousOn f (Set.Icc a b) →\n",
+      "        ∀ {y : ℝ}, y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f b) (f a) → ∃ c ∈ Set.Icc a b, f c = y\n",
+      "'Chapter9.intermediate_value' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code 5.2 — Empreinte axiomatique réelle du théorème principal\n",
+    "#\n",
+    "# Le notebook conserve son kernel Python et invoque le vrai compilateur Lean\n",
+    "# dans le lac externe construit sous WSL. La sortie provient directement de\n",
+    "# `#print axioms`, et non d'une transcription manuelle.\n",
+    "\n",
+    "import os\n",
+    "import subprocess\n",
+    "import textwrap\n",
+    "\n",
+    "lean_source = textwrap.dedent(\"\"\"\n",
+    "    import Analysis.Section_9_7\n",
+    "\n",
+    "    #check @Chapter9.intermediate_value\n",
+    "    #print axioms Chapter9.intermediate_value\n",
+    "\"\"\").strip()\n",
+    "\n",
+    "lean_command = f\"\"\"\n",
+    "cd ~/lean-projects/analysis\n",
+    "cat > /tmp/coursia_analysis_axioms.lean <<'LEAN_EOF'\n",
+    "{lean_source}\n",
+    "LEAN_EOF\n",
+    "lake env lean /tmp/coursia_analysis_axioms.lean 2>&1\n",
+    "\"\"\"\n",
+    "\n",
+    "if os.name == \"nt\":\n",
+    "    command = [\"wsl\", \"-d\", \"Ubuntu\", \"--\", \"bash\", \"-lc\", lean_command]\n",
+    "else:\n",
+    "    command = [\"bash\", \"-lc\", lean_command]\n",
+    "\n",
+    "result = subprocess.run(\n",
+    "    command,\n",
+    "    capture_output=True,\n",
+    "    text=True,\n",
+    "    encoding=\"utf-8\",\n",
+    "    errors=\"replace\",\n",
+    "    timeout=600,\n",
+    ")\n",
+    "lean_output = (result.stdout + result.stderr).strip()\n",
+    "print(lean_output)\n",
+    "if result.returncode != 0:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Lean a échoué avec le code {result.returncode}; voir la sortie ci-dessus.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c61b4ff1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002024,
+     "end_time": "2026-09-03T10:15:34.074714+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T10:15:34.072690+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : un théorème localement prouvé, mais transitivement admis\n",
+    "\n",
+    "Le relevé exécuté ci-dessus donne exactement `[propext, sorryAx, Classical.choice, Quot.sound]`. Comme dans Lean-19 et Lean-21, `Classical.choice` signale l’usage explicite de raisonnement classique, tandis que `propext` et `Quot.sound` sont les axiomes standards liés à l’extensionalité propositionnelle et aux quotients.\n",
+    "\n",
+    "La différence pédagogique majeure est `sorryAx`. Sa présence établit que `Chapter9.intermediate_value` dépend transitivement d’au moins une déclaration admise dans le lac, même si le corps local du théorème ne contient pas de `sorry`. Aucun axiome `native_decide.*` n’apparaît. Le verdict est donc **empreinte non close** : ce relevé documente honnêtement la vocation de manuel à exercices d’Analysis I, mais il interdit de présenter ce théorème ciblé comme certifié sans trou par le noyau.\n",
+    "\n",
+    "La comparaison des trois digestions devient explicite : Sendov (Lean-19) et PFR (Lean-21) exposent seulement les trois axiomes standards, tandis qu’Analysis I ajoute `sorryAx`; aucune des trois empreintes n’utilise `native_decide.*`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4deb8c6c",
    "metadata": {
     "papermill": {
-     "duration": 0.001795,
-     "end_time": "2026-08-21T03:07:34.172776+00:00",
+     "duration": 0.002102,
+     "end_time": "2026-09-03T10:15:34.079317+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.170981+00:00",
+     "start_time": "2026-09-03T10:15:34.077215+00:00",
      "status": "completed"
     },
     "tags": []
@@ -842,20 +965,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "8d0bf737",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.178053Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.177811Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.181460Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.181006Z"
+     "iopub.execute_input": "2026-09-03T10:15:34.085367Z",
+     "iopub.status.busy": "2026-09-03T10:15:34.085201Z",
+     "iopub.status.idle": "2026-09-03T10:15:34.088496Z",
+     "shell.execute_reply": "2026-09-03T10:15:34.087618Z"
     },
     "papermill": {
-     "duration": 0.007322,
-     "end_time": "2026-08-21T03:07:34.182034+00:00",
+     "duration": 0.007386,
+     "end_time": "2026-09-03T10:15:34.089599+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.174712+00:00",
+     "start_time": "2026-09-03T10:15:34.082213+00:00",
      "status": "completed"
     },
     "tags": []
@@ -907,10 +1030,10 @@
    "id": "70718d1b",
    "metadata": {
     "papermill": {
-     "duration": 0.001894,
-     "end_time": "2026-08-21T03:07:34.186056+00:00",
+     "duration": 0.002147,
+     "end_time": "2026-09-03T10:15:34.093867+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.184162+00:00",
+     "start_time": "2026-09-03T10:15:34.091720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -927,20 +1050,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "82528214",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.191126Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.190885Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.194342Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.193878Z"
+     "iopub.execute_input": "2026-09-03T10:15:34.099661Z",
+     "iopub.status.busy": "2026-09-03T10:15:34.099461Z",
+     "iopub.status.idle": "2026-09-03T10:15:34.103449Z",
+     "shell.execute_reply": "2026-09-03T10:15:34.102551Z"
     },
     "papermill": {
-     "duration": 0.006893,
-     "end_time": "2026-08-21T03:07:34.195046+00:00",
+     "duration": 0.007534,
+     "end_time": "2026-09-03T10:15:34.103927+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.188153+00:00",
+     "start_time": "2026-09-03T10:15:34.096393+00:00",
      "status": "completed"
     },
     "tags": []
@@ -997,10 +1120,10 @@
    "id": "873e0ae8",
    "metadata": {
     "papermill": {
-     "duration": 0.001999,
-     "end_time": "2026-08-21T03:07:34.199268+00:00",
+     "duration": 0.002064,
+     "end_time": "2026-09-03T10:15:34.108213+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.197269+00:00",
+     "start_time": "2026-09-03T10:15:34.106149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1019,20 +1142,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "f41bde19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T03:07:34.204648Z",
-     "iopub.status.busy": "2026-08-21T03:07:34.204327Z",
-     "iopub.status.idle": "2026-08-21T03:07:34.208956Z",
-     "shell.execute_reply": "2026-08-21T03:07:34.208440Z"
+     "iopub.execute_input": "2026-09-03T10:15:34.113372Z",
+     "iopub.status.busy": "2026-09-03T10:15:34.113215Z",
+     "iopub.status.idle": "2026-09-03T10:15:34.117694Z",
+     "shell.execute_reply": "2026-09-03T10:15:34.115923Z"
     },
     "papermill": {
-     "duration": 0.008144,
-     "end_time": "2026-08-21T03:07:34.209434+00:00",
+     "duration": 0.008045,
+     "end_time": "2026-09-03T10:15:34.118526+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.201290+00:00",
+     "start_time": "2026-09-03T10:15:34.110481+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1088,10 +1211,10 @@
    "id": "87f5224e",
    "metadata": {
     "papermill": {
-     "duration": 0.002012,
-     "end_time": "2026-08-21T03:07:34.213746+00:00",
+     "duration": 0.002237,
+     "end_time": "2026-09-03T10:15:34.123064+00:00",
      "exception": false,
-     "start_time": "2026-08-21T03:07:34.211734+00:00",
+     "start_time": "2026-09-03T10:15:34.120827+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1153,18 +1276,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.12.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.781623,
-   "end_time": "2026-08-21T03:07:34.347575+00:00",
+   "duration": 17.039968,
+   "end_time": "2026-09-03T10:15:34.344381+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Lean-20-Analysis-I-Tao-Workflow.ipynb",
-   "output_path": "Lean-20-Analysis-I-Tao-Workflow_output_20260821_050732.ipynb",
+   "output_path": "Lean-20-Analysis-I-Tao-Workflow.ipynb",
    "parameters": {},
-   "start_time": "2026-08-21T03:07:32.565952+00:00",
+   "start_time": "2026-09-03T10:15:17.304413+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2025:CoursIA — prev: LIGHT/guard #14428

Closes #14451
See #13105

## Résumé

- exécute réellement `#print axioms Sendov.sendov` dans Lean-19 depuis le lac Sendov construit sous WSL ;
- exécute réellement `#print axioms Chapter9.intermediate_value` dans Lean-20 depuis le lac Analysis I construit sous WSL ;
- committe les sorties produites par Lean et place immédiatement après chacune une lecture pédagogique ;
- compare explicitement Sendov, Analysis I et PFR sur `sorryAx`, `native_decide.*` et `Classical.choice`, sans modifier la mathématique ni aucun fichier `.lean`.

## Empreintes observées

| Digestion | Théorème ciblé | Sortie `#print axioms` | Verdict |
|---|---|---|---|
| Lean-19 / Sendov | `Sendov.sendov` | `[propext, Classical.choice, Quot.sound]` | **SOTA-OK pour le théorème ciblé** : axiomes standards nommés, aucun `sorryAx`, aucun `native_decide.*` |
| Lean-20 / Analysis I | `Chapter9.intermediate_value` | `[propext, sorryAx, Classical.choice, Quot.sound]` | **empreinte non close** : dépendance transitive à une déclaration admise ; aucun `native_decide.*` |
| Lean-21 / PFR (référence inchangée) | `PFR_conjecture` | `[propext, Classical.choice, Quot.sound]` | même empreinte standard que Sendov |

`Classical.choice` est donc explicite dans les trois cas. Le résultat important n'est pas masqué : Analysis I expose bien `sorryAx`, malgré l'absence de `sorry` dans le corps local du théorème ciblé.

## Exécution réelle

Architecture conservée : notebooks `python3` → `subprocess` → WSL Ubuntu → `lake env lean`. Aucun output n'a été fabriqué ni édité à la main.

Sources externes interrogées :

- Sendov HEAD `1ddea92d89f951a0a7cbbffa6c267cf7e6640b1d` ; build réussi ;
- Analysis HEAD `2351317a4416aa52554f29b6adc0af63dc488eff` ; toolchain canonique restaurée `leanprover/lean4:v4.29.0-rc8` ; build ciblé `Analysis.Section_9_7` réussi.

Papermill complet :

```text
Lean-19-Sendov-Complex-Analysis.ipynb
  OK: 10/10 cells executed, 0 errors

Lean-20-Analysis-I-Tao-Workflow.ipynb
  OK: 9/9 cells executed, 0 errors
```

Les trois exercices de Lean-20 restent exécutables et produisent leurs sorties ; aucune erreur volontaire n'a été ajoutée.

## Validation

```text
python scripts/notebook_tools/validate_pr_notebooks.py origin/main --json
  passed: true
  Lean-19: EXEC_PROVED, 10 code cells
  Lean-20: EXEC_PROVED, 9 code cells

python scripts/notebook_tools/check_output_failure_text.py origin/main --json
  changed: 2
  regressions: 0
  TOOL_FAILURE: 0 -> 0 (les deux notebooks)
  MACHINE_PATH: 0 -> 0 (les deux notebooks)

python scripts/notebook_tools/scan_cell_ordering.py <notebook>
  Lean-19: 1 clean, 0 findings
  Lean-20: 1 clean, 0 findings

python scripts/notebook_tools/detect_consecutive_code_cells.py <notebook>
  Lean-19: Run >= 2: 0
  Lean-20: Run >= 2: 0

python scripts/notebook_tools/detect_papermill_path_leak.py --scan <notebook> --check
  aucun chemin Papermill absolu détecté dans les deux notebooks

git diff origin/main...HEAD --check
  success
```

Les lectures axiomatiques suivent immédiatement les cellules productrices, et les empreintes citées apparaissent mot pour mot dans l'output précédent.

## Intégrité Lean et portée CI

Preuve que la mathématique n'a pas bougé :

```text
git diff origin/main...HEAD -- '*.lean'
  (sortie vide)
```

Aucun fichier `.lean` n'est touché.

**B.3 — non applicable :** `lean-axiom.yml` n'est pas câblé sur les lacs Sendov, Analysis I ou PFR. Conformément au garde-fou de l'issue, cette PR ne modifie aucun workflow et ne câble pas ce gate ; ce serait un grain `guard` distinct.

## Verdict SOTA

**SOTA-OK pour l'instrumentation exécutée** : les deux cellules invoquent le vrai compilateur Lean dans les lacs sources construits et committent sa sortie réelle. Le verdict mathématique reste différencié : Sendov est clos sur les axiomes standards observés ; le théorème Analysis I ciblé dépend transitivement de `sorryAx`.
