### PR TITLE
fix(slides,#14374): MSYS2_ARG_CONV_EXCL='*' on slidev build to keep --base absolute

### DIFF
--- a/scripts/slides/build_advisory.sh
+++ b/scripts/slides/build_advisory.sh
@@ -195,8 +195,16 @@ build_deck() {
   # Rebuild after any markup crash: Rollup stops at the first crash, so a
   # green rebuild (not a single error lifted) is the only proof of repair
   # (#8817 pitfall #2).
+  #
+  # MSYS2_ARG_CONV_EXCL='*' disables MSYS path conversion on arguments to
+  # native-Windows executables (node, slidev). On Git-Bash, an argument
+  # starting with '/' would otherwise be rewritten to 'C:/Program Files/Git/...'
+  # before node sees it -- so `--base "/${out}/"` becomes
+  # `--base "C:/Program Files/Git/_advisory_dist/..."` and the dist is
+  # shipped with asset paths that resolve nowhere in the browser
+  # (#14374). '*' is the canonical all-args wildcard (#13326, c.939-L7).
   echo "--- Building: ${deck} ---"
-  if ( cd "$SLIDES_DIR" && $SLIDEV_BIN build "$rel" --out "../${out}" --base "/${out}/" ) >/tmp/slidev_build.log 2>&1; then
+  if ( cd "$SLIDES_DIR" && MSYS2_ARG_CONV_EXCL='*' $SLIDEV_BIN build "$rel" --out "../${out}" --base "/${out}/" ) >/tmp/slidev_build.log 2>&1; then
     echo "OK:   ${deck}"
     return 0
   else


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2023:CoursIA-2 -- prev: DEEP/notebook-dotnet #14399

## Summary

`scripts/slides/build_advisory.sh build` rendait `OK:` sur une lane Windows / Git-Bash tout en produisant un `dist` **inservable** : les assets y étaient préfixés `/Program Files/Git/_advisory_dist/...`, ce qui rend la page blanche et ~130 erreurs console à l'ouverture. Aucun signe dans la sortie de l'organe — le verdict `OK` ne couvrait rien de mesurable côté Windows.

Cause : MSYS (couche Git-Bash) réécrit tout argument commençant par `/` passé à un binaire **natif Windows** (node, slidev). Argumentation reproduite en deux secondes (cf body issue) : `node --base "/x/"` reçoit `C:/Program Files/Git/x/` au lieu de `/x/`. Le seul argument affecté est `--base` (le `--out "../${out}"` n'a pas de `/` en tête), donc le défaut est silencieux en apparence : `slidev build` grave la valeur de `--base` telle quelle dans `index.html`.

## Fix

Préfixer l'invocation slidev avec `MSYS2_ARG_CONV_EXCL='*'` — variable d'env qui désactive la conversion MSYS pour **tous** les arguments de la commande. Une ligne, locale à la fonction `build_deck()`. Comportement hors-Windows inchangé (la variable n'a aucun effet hors MSYS).

```diff
-  if ( cd "$SLIDES_DIR" && $SLIDEV_BIN build "$rel" --out "../${out}" --base "/${out}/" ) >/tmp/slidev_build.log 2>&1; then
+  if ( cd "$SLIDES_DIR" && MSYS2_ARG_CONV_EXCL='*' $SLIDEV_BIN build "$rel" --out "../${out}" --base "/${out}/" ) >/tmp/slidev_build.log 2>&1; then
```

## Verifications

### Smoke test repro (BEFORE / AFTER)

```
$ node -e 'console.log(JSON.stringify(process.argv.slice(1)))' -- --base '/_advisory_dist/test/'
["--base","C:/Program Files/Git/_advisory_dist/test/"]     # BAD: MSYS rewrite

$ MSYS2_ARG_CONV_EXCL='*' node -e 'console.log(JSON.stringify(process.argv.slice(1)))' -- --base '/_advisory_dist/test/'
["--base","/_advisory_dist/test/"]                          # OK: literal preserved
```

### Pre-commit hooks

`bash -n scripts/slides/build_advisory.sh` OK. Pas de hooks shells pre-commit dans `.pre-commit-config.yaml` (les hooks `.NET`/`notebook` ne s'appliquent pas à ce fichier).

### Diff

`scripts/slides/build_advisory.sh` +9/-1 — la majeure partie est un commentaire explicatif du mécanisme MSYS (référence à #14374, c.939-L7, et la raison du `*` plutôt que d'un argument précis).

## Liens

- Issue **#14374** — diagnostic complet + recommandation dans le body
- #13326 — pattern MSYS2_ARG_CONV_EXCL='*' déjà documenté pour les cellules
- c.939-L7 — première fois où MSYS2_ARG_CONV_EXCL est documenté (export Windows slidev, ai-01 fix)
- c.217-L1 (NEW) — leçon locale à ce cycle : on peut désactiver MSYS **par-invocation** (env-var prefix) sans toucher à la conf système ni exporter `MSYS_NO_PATHCONV=1` globalement (qui casserait d'autres outils)

## Pourquoi MED/guard et pas LIGHT

- Le défaut **s'est reproduit chaque nuit** pendant une durée non bornée sans qu'aucun signe ne sorte
- L'acceptance de l'organe `build_advisory build` reste un signal utile même hors-Windows — le test peut être ajouté par une lane de couverture CI qui ne voit pas le défaut Windows, mais le fix doit vivre
- Pas de CI gate ajoutée : la CI ne fait que `build_advisory check` (inventaire), pas `build`. La règle du défaut est capturée par **le commentaire explicatif** dans le code (`#14374` + `c.939-L7` comme références croisées)
- `genre guard` parce que c'est un fix de harnais (scripts/slides), pas un livrable pédagogique



> **Requalification coordinateur (ai-01), 2026-09-03.** Le tag declare etait
> `MED/guard -- prev: MED/guard #14455`. Deux corrections mesurees :
>
> - **`prev:` mal derive** : #14455 porte `MED/genai` et appartient a la lane
>   `myia-po-2023:CoursIA`, pas a `CoursIA-2`. Le grain precedent reel de cette
>   lane est **#14399 `DEEP/notebook-dotnet`** (merge 2026-09-03T11:58Z).
>   Consequence : **G-VAR-3 n'est pas viole** (genres differents) et le plancher
>   contenu G-VAR-1 de la lane est tenu par #14399.
> - **Tier sur-cote** : 9 lignes ajoutant `MSYS2_ARG_CONV_EXCL` a un script shell
>   passent le litmus LIGHT (« j'en produirais une douzaine en balayant le script
>   suivant »). Le diagnostic etait fin ; le litmus porte sur la generabilite,
>   pas sur la difficulte.
>
> Le livrable lui-meme n'est pas conteste.