### PR TITLE
fix(asipre,#14396): Exercice 1 cellule 10 — Verifier exige args.Length >= 2 (Hermes c.883)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/06-Aspire-GardeFous-Roslyn.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/06-Aspire-GardeFous-Roslyn.ipynb
@@ -62,10 +62,10 @@
    "id": "ag-02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:32:59.287617Z",
-     "iopub.status.busy": "2026-08-28T21:32:59.279566Z",
-     "iopub.status.idle": "2026-08-28T21:33:02.184370Z",
-     "shell.execute_reply": "2026-08-28T21:33:02.174704Z"
+     "iopub.execute_input": "2026-09-03T10:36:51.988268Z",
+     "iopub.status.busy": "2026-09-03T10:36:51.973156Z",
+     "iopub.status.idle": "2026-09-03T10:36:55.269005Z",
+     "shell.execute_reply": "2026-09-03T10:36:55.261289Z"
     },
     "papermill": {
      "duration": 2.916814,
@@ -78,16 +78,126 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": ""
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-326048.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '326048.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Repertoire de travail : Aspire\r\n"
+     "output_type": "stream",
+     "text": [
+      "Repertoire de travail : Aspire\r\n"
+     ]
     }
    ],
    "source": [
@@ -152,10 +262,10 @@
    "id": "ag-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:02.214920Z",
-     "iopub.status.busy": "2026-08-28T21:33:02.214920Z",
-     "iopub.status.idle": "2026-08-28T21:33:02.279257Z",
-     "shell.execute_reply": "2026-08-28T21:33:02.279257Z"
+     "iopub.execute_input": "2026-09-03T10:36:55.272241Z",
+     "iopub.status.busy": "2026-09-03T10:36:55.271684Z",
+     "iopub.status.idle": "2026-09-03T10:36:55.382144Z",
+     "shell.execute_reply": "2026-09-03T10:36:55.381265Z"
     },
     "papermill": {
      "duration": 0.075947,
@@ -168,9 +278,166 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "// Terrain fautif : copie de demo du motif StreamingAgent.App (notebook 04).\n// Un worker d'agent consomme une Channel -- motif canonique de la serie --\n// mais ici le code genere \"dans le style synchrone\" BLOQUE la tache d'appel\n// au LLM avec .Result au lieu de l'attendre. C'est le defaut que l'analyseur\n// AGENTGUARD001 doit attraper au `dotnet build` (ce fichier ne leve PAS\n// d'exception : le blocage ne deadlock ici qu'un contexte reduit -- le\n// notebook explique pourquoi le pattern reste mortel en production).\n\nusing System;\nusing System.Threading.Channels;\nusing System.Threading.Tasks;\n\nvar channel = Channel.CreateUnbounded<string>();\n_ = Producer.ProduceAsync(channel.Writer, \"traduis cette phrase en anglais\");\n\nConsole.WriteLine(AgentWorker.TranslateSync(channel.Reader));\n\npublic static class AgentWorker\n{\n    // Genere par agent \"pour simplifier\" : la tache async est bloquee.\n    // Deux blocages .Result -- deux diagnostics attendus au build.\n    public static string TranslateSync(ChannelReader<string> inbound)\n    {\n        var prompt = inbound.ReadAsync().AsTask().Result;   // AGENTGUARD001\n        return CallLlmAsync(prompt).Result;                 // AGENTGUARD001\n    }\n\n    private static async Task<string> CallLlmAsync(string prompt)\n    {\n        await Task.Delay(50);            // simule la latence de l'appel LLM\n        return $\"[LLM] {prompt}\";\n    }\n}\n\npublic static class Producer\n{\n    public static async Task ProduceAsync(ChannelWriter<string> writer, string prompt)\n        => await writer.WriteAsync(prompt);\n}\n\n// Second terrain fautif (AGENTGUARD002) : le meme agent, une autre vitesse.\n// \"Lancer et oublier\" un traitement en ecrivant async void -- la signature\n// ressemble a une async Task, mais la methode n'est pas attendable et ses\n// exceptions ne sont observees par personne. Un diagnostic AGENTGUARD002\n// attendu au build (et aucun ici n'est un handler d'evenement : pas de\n// signature (object, EventArgs)).\npublic static class AgentFireAndForget\n{\n    public static void Demarrer()\n    {\n        SurveillerCanalAsync();            // \"rendu la main\" -- silencieusement\n    }\n\n    // Genere par agent \"pour simplifier\" : async void hors handler.\n    public static async void SurveillerCanalAsync()\n    {\n        await Task.Delay(200);             // simule une boucle de surveillance\n        // Si l'appel LLM leve ici, personne ne l'observe : process mort.\n    }\n}\n\n// Troisieme terrain fautif (AGENTGUARD003) : le meme agent, troisieme\n// vitesse. `Task.Run(() => ...)` est appele comme enonce autonome -- la\n// signature est honnete (Task, pas void), mais le retour est jete a la\n// corbeille : pas de await, pas d'affectation, pas de `_ =`, pas de\n// return. La tache s'execute en arriere-plan, ses exceptions ne sont\n// observees par personne. Un diagnostic AGENTGUARD003 attendu au build\n// (et c'est la seule forme signalee : `await Task.Run(...)`, `var t =\n// Task.Run(...)`, `_ = Task.Run(...)` et `return Task.Run(...)` sont\n// exemptes).\npublic static class AgentTaskRunFire\n{\n    public static void Demarrer()\n    {\n        Task.Run(() => Console.WriteLine(\"ping\"));   // AGENTGUARD003\n    }\n}\n\n// Quatrieme terrain fautif (AGENTGUARD004) : la requete fournit un\n// CancellationToken, et la cible sait le recevoir, mais le code genere omet\n// l'argument optionnel. L'annulation est perdue au milieu de la chaine.\npublic static class AgentCancellation\n{\n    public static async Task RepondreAsync(\n        string prompt,\n        System.Threading.CancellationToken cancellationToken)\n    {\n        await CallLlmAsync(prompt);                    // AGENTGUARD004\n    }\n\n    private static Task<string> CallLlmAsync(\n        string prompt,\n        System.Threading.CancellationToken cancellationToken = default)\n        => Task.FromResult($\"[LLM] {prompt}\");\n}\n\n// Cinquieme terrain fautif (AGENTGUARD005) : variante syntaxique d'\n// AGENTGUARD001, meme defaut semantique. Au lieu de `.Result`, l'agent\n// decompile explicitement la machine a etats de la tache :\n// `tache.GetAwaiter().GetResult()`. Meme consequence en production\n// (deadlock sur un SynchronizationContext), mais un chemin syntaxique\n// distinct qui justifie un analyseur dedie -- AGENTGUARD001 ne regarde\n// que `.Result` / `.Wait()`. Diagnostic attendu sur la derniere ligne.\npublic static class AgentSyncOverAsync\n{\n    // Genere par agent \"pour eviter un await\" : la tache est \"synchronisee\"\n    // en traversant manuellement la machine a etats. C'est exactement le\n    // defaut que AGENTGUARD005 attrape.\n    public static string ReponseSynchrone(string prompt)\n    {\n        return CallLlmAsync(prompt).GetAwaiter().GetResult();   // AGENTGUARD005\n    }\n\n    private static async Task<string> CallLlmAsync(string prompt)\n    {\n        await Task.Delay(50);\n        return $\"[LLM] {prompt}\";\n    }\n}\n\n// Sixieme terrain fautif (AGENTGUARD005b) : variante\n// `ConfigureAwait(false).GetAwaiter().GetResult()`, ecappee au filtre\n// semantique d'AGENTGUARD005 (le receiver du GetAwaiter y est de type\n// `ConfiguredTaskAwaitable`, pas `Task`). L'agent genere cette forme en\n// CROYANT que `ConfigureAwait(false)` \"rend ca safe\". Faux : ConfigureAwait\n// reduit la capture du SynchronizationContext, mais le\n// `.GetAwaiter().GetResult()` BLOQUE TOUJOURS le thread -- le\n// sync-over-async reste entier. C'est precisement la confusion que la\n// regle AGENTGUARD005b doit denoncer. Deux diagnostics attendus : un par\n// ligne fautive (deux formes explicitement testees : `ConfigureAwait(false)`\n// et `ConfigureAwait(true)`).\npublic static class AgentSyncOverAsyncConfigureAwait\n{\n    // Forme \"rassurante\" classique : l'agent a lu sur Stack Overflow que\n    // ConfigureAwait(false) est une bonne pratique et l'a ajoute \"pour\n    // etre safe\". Le defaut est exactement le meme que la variante\n    // nue -- diagnostic AGENTGUARD005b attendu.\n    public static string ReponseSynchroneSafeFalse(string prompt)\n    {\n        return CallLlmAsync(prompt).ConfigureAwait(false).GetAwaiter().GetResult();   // AGENTGUARD005b\n    }\n\n    // Forme `true` (explicite) -- meme defaut, l'analyseur doit le voir\n    // aussi (le literal n'est pas blanchi : seul compte le pattern).\n    public static string ReponseSynchroneSafeTrue(string prompt)\n    {\n        return CallLlmAsync(prompt).ConfigureAwait(true).GetAwaiter().GetResult();    // AGENTGUARD005b\n    }\n\n    private static async Task<string> CallLlmAsync(string prompt)\n    {\n        await Task.Delay(50);\n        return $\"[LLM] {prompt}\";\n    }\n}\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "// Terrain fautif : copie de demo du motif StreamingAgent.App (notebook 04).\n",
+      "// Un worker d'agent consomme une Channel -- motif canonique de la serie --\n",
+      "// mais ici le code genere \"dans le style synchrone\" BLOQUE la tache d'appel\n",
+      "// au LLM avec .Result au lieu de l'attendre. C'est le defaut que l'analyseur\n",
+      "// AGENTGUARD001 doit attraper au `dotnet build` (ce fichier ne leve PAS\n",
+      "// d'exception : le blocage ne deadlock ici qu'un contexte reduit -- le\n",
+      "// notebook explique pourquoi le pattern reste mortel en production).\n",
+      "\n",
+      "using System;\n",
+      "using System.Threading.Channels;\n",
+      "using System.Threading.Tasks;\n",
+      "\n",
+      "var channel = Channel.CreateUnbounded<string>();\n",
+      "_ = Producer.ProduceAsync(channel.Writer, \"traduis cette phrase en anglais\");\n",
+      "\n",
+      "Console.WriteLine(AgentWorker.TranslateSync(channel.Reader));\n",
+      "\n",
+      "public static class AgentWorker\n",
+      "{\n",
+      "    // Genere par agent \"pour simplifier\" : la tache async est bloquee.\n",
+      "    // Deux blocages .Result -- deux diagnostics attendus au build.\n",
+      "    public static string TranslateSync(ChannelReader<string> inbound)\n",
+      "    {\n",
+      "        var prompt = inbound.ReadAsync().AsTask().Result;   // AGENTGUARD001\n",
+      "        return CallLlmAsync(prompt).Result;                 // AGENTGUARD001\n",
+      "    }\n",
+      "\n",
+      "    private static async Task<string> CallLlmAsync(string prompt)\n",
+      "    {\n",
+      "        await Task.Delay(50);            // simule la latence de l'appel LLM\n",
+      "        return $\"[LLM] {prompt}\";\n",
+      "    }\n",
+      "}\n",
+      "\n",
+      "public static class Producer\n",
+      "{\n",
+      "    public static async Task ProduceAsync(ChannelWriter<string> writer, string prompt)\n",
+      "        => await writer.WriteAsync(prompt);\n",
+      "}\n",
+      "\n",
+      "// Second terrain fautif (AGENTGUARD002) : le meme agent, une autre vitesse.\n",
+      "// \"Lancer et oublier\" un traitement en ecrivant async void -- la signature\n",
+      "// ressemble a une async Task, mais la methode n'est pas attendable et ses\n",
+      "// exceptions ne sont observees par personne. Un diagnostic AGENTGUARD002\n",
+      "// attendu au build (et aucun ici n'est un handler d'evenement : pas de\n",
+      "// signature (object, EventArgs)).\n",
+      "public static class AgentFireAndForget\n",
+      "{\n",
+      "    public static void Demarrer()\n",
+      "    {\n",
+      "        SurveillerCanalAsync();            // \"rendu la main\" -- silencieusement\n",
+      "    }\n",
+      "\n",
+      "    // Genere par agent \"pour simplifier\" : async void hors handler.\n",
+      "    public static async void SurveillerCanalAsync()\n",
+      "    {\n",
+      "        await Task.Delay(200);             // simule une boucle de surveillance\n",
+      "        // Si l'appel LLM leve ici, personne ne l'observe : process mort.\n",
+      "    }\n",
+      "}\n",
+      "\n",
+      "// Troisieme terrain fautif (AGENTGUARD003) : le meme agent, troisieme\n",
+      "// vitesse. `Task.Run(() => ...)` est appele comme enonce autonome -- la\n",
+      "// signature est honnete (Task, pas void), mais le retour est jete a la\n",
+      "// corbeille : pas de await, pas d'affectation, pas de `_ =`, pas de\n",
+      "// return. La tache s'execute en arriere-plan, ses exceptions ne sont\n",
+      "// observees par personne. Un diagnostic AGENTGUARD003 attendu au build\n",
+      "// (et c'est la seule forme signalee : `await Task.Run(...)`, `var t =\n",
+      "// Task.Run(...)`, `_ = Task.Run(...)` et `return Task.Run(...)` sont\n",
+      "// exemptes).\n",
+      "public static class AgentTaskRunFire\n",
+      "{\n",
+      "    public static void Demarrer()\n",
+      "    {\n",
+      "        Task.Run(() => Console.WriteLine(\"ping\"));   // AGENTGUARD003\n",
+      "    }\n",
+      "}\n",
+      "\n",
+      "// Quatrieme terrain fautif (AGENTGUARD004) : la requete fournit un\n",
+      "// CancellationToken, et la cible sait le recevoir, mais le code genere omet\n",
+      "// l'argument optionnel. L'annulation est perdue au milieu de la chaine.\n",
+      "public static class AgentCancellation\n",
+      "{\n",
+      "    public static async Task RepondreAsync(\n",
+      "        string prompt,\n",
+      "        System.Threading.CancellationToken cancellationToken)\n",
+      "    {\n",
+      "        await CallLlmAsync(prompt);                    // AGENTGUARD004\n",
+      "    }\n",
+      "\n",
+      "    private static Task<string> CallLlmAsync(\n",
+      "        string prompt,\n",
+      "        System.Threading.CancellationToken cancellationToken = default)\n",
+      "        => Task.FromResult($\"[LLM] {prompt}\");\n",
+      "}\n",
+      "\n",
+      "// Cinquieme terrain fautif (AGENTGUARD005) : variante syntaxique d'\n",
+      "// AGENTGUARD001, meme defaut semantique. Au lieu de `.Result`, l'agent\n",
+      "// decompile explicitement la machine a etats de la tache :\n",
+      "// `tache.GetAwaiter().GetResult()`. Meme consequence en production\n",
+      "// (deadlock sur un SynchronizationContext), mais un chemin syntaxique\n",
+      "// distinct qui justifie un analyseur dedie -- AGENTGUARD001 ne regarde\n",
+      "// que `.Result` / `.Wait()`. Diagnostic attendu sur la derniere ligne.\n",
+      "public static class AgentSyncOverAsync\n",
+      "{\n",
+      "    // Genere par agent \"pour eviter un await\" : la tache est \"synchronisee\"\n",
+      "    // en traversant manuellement la machine a etats. C'est exactement le\n",
+      "    // defaut que AGENTGUARD005 attrape.\n",
+      "    public static string ReponseSynchrone(string prompt)\n",
+      "    {\n",
+      "        return CallLlmAsync(prompt).GetAwaiter().GetResult();   // AGENTGUARD005\n",
+      "    }\n",
+      "\n",
+      "    private static async Task<string> CallLlmAsync(string prompt)\n",
+      "    {\n",
+      "        await Task.Delay(50);\n",
+      "        return $\"[LLM] {prompt}\";\n",
+      "    }\n",
+      "}\n",
+      "\n",
+      "// Sixieme terrain fautif (AGENTGUARD005b) : variante\n",
+      "// `ConfigureAwait(false).GetAwaiter().GetResult()`, ecappee au filtre\n",
+      "// semantique d'AGENTGUARD005 (le receiver du GetAwaiter y est de type\n",
+      "// `ConfiguredTaskAwaitable`, pas `Task`). L'agent genere cette forme en\n",
+      "// CROYANT que `ConfigureAwait(false)` \"rend ca safe\". Faux : ConfigureAwait\n",
+      "// reduit la capture du SynchronizationContext, mais le\n",
+      "// `.GetAwaiter().GetResult()` BLOQUE TOUJOURS le thread -- le\n",
+      "// sync-over-async reste entier. C'est precisement la confusion que la\n",
+      "// regle AGENTGUARD005b doit denoncer. Deux diagnostics attendus : un par\n",
+      "// ligne fautive (deux formes explicitement testees : `ConfigureAwait(false)`\n",
+      "// et `ConfigureAwait(true)`).\n",
+      "public static class AgentSyncOverAsyncConfigureAwait\n",
+      "{\n",
+      "    // Forme \"rassurante\" classique : l'agent a lu sur Stack Overflow que\n",
+      "    // ConfigureAwait(false) est une bonne pratique et l'a ajoute \"pour\n",
+      "    // etre safe\". Le defaut est exactement le meme que la variante\n",
+      "    // nue -- diagnostic AGENTGUARD005b attendu.\n",
+      "    public static string ReponseSynchroneSafeFalse(string prompt)\n",
+      "    {\n",
+      "        return CallLlmAsync(prompt).ConfigureAwait(false).GetAwaiter().GetResult();   // AGENTGUARD005b\n",
+      "    }\n",
+      "\n",
+      "    // Forme `true` (explicite) -- meme defaut, l'analyseur doit le voir\n",
+      "    // aussi (le literal n'est pas blanchi : seul compte le pattern).\n",
+      "    public static string ReponseSynchroneSafeTrue(string prompt)\n",
+      "    {\n",
+      "        return CallLlmAsync(prompt).ConfigureAwait(true).GetAwaiter().GetResult();    // AGENTGUARD005b\n",
+      "    }\n",
+      "\n",
+      "    private static async Task<string> CallLlmAsync(string prompt)\n",
+      "    {\n",
+      "        await Task.Delay(50);\n",
+      "        return $\"[LLM] {prompt}\";\n",
+      "    }\n",
+      "}\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -229,10 +496,10 @@
    "id": "ag-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:02.326377Z",
-     "iopub.status.busy": "2026-08-28T21:33:02.325352Z",
-     "iopub.status.idle": "2026-08-28T21:33:02.380044Z",
-     "shell.execute_reply": "2026-08-28T21:33:02.380044Z"
+     "iopub.execute_input": "2026-09-03T10:36:55.385464Z",
+     "iopub.status.busy": "2026-09-03T10:36:55.384895Z",
+     "iopub.status.idle": "2026-09-03T10:36:55.489040Z",
+     "shell.execute_reply": "2026-09-03T10:36:55.488528Z"
     },
     "papermill": {
      "duration": 0.064056,
@@ -245,9 +512,71 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "using System.Collections.Immutable;\nusing Microsoft.CodeAnalysis;\nusing Microsoft.CodeAnalysis.CSharp;\nusing Microsoft.CodeAnalysis.Diagnostics;\n\nnamespace AgentGuard.Analyzers;\n\n/// <summary>\n/// AGENTGUARD001 : blocage synchrone d'une Task (.Result / .Wait()).\n///\n/// Pattern typique du code d'agent genere : appeler une tache asynchrone\n/// (appel LLM, streaming, canal) depuis du code synchrone en la bloquant.\n/// Le garde-fou vit DANS la compilation -- `dotnet build` rend le diagnostic\n/// sans aucun outil supplementaire (la these du notebook 06 de la serie Aspire,\n/// Epic #10473 axe Roslyn).\n/// </summary>\n[DiagnosticAnalyzer(LanguageNames.CSharp)]\npublic sealed class TaskResultBlockAnalyzer : DiagnosticAnalyzer\n{\n    public const string DiagnosticId = \"AGENTGUARD001\";\n\n    private static readonly DiagnosticDescriptor Rule = new(\n        DiagnosticId,\n        \"Blocage synchrone d'une Task\",\n        \"Task bloquee de maniere synchrone ({0}) : deadlock potentiel en code d'agent\",\n        \"Agentisme\",\n        DiagnosticSeverity.Warning,\n        isEnabledByDefault: true,\n        description: \"Le code genere par agent qui bloque une Task via .Result/.Wait() expose au deadlock.\");\n\n    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n        => ImmutableArray.Create(Rule);\n\n    public override void Initialize(AnalysisContext context)\n    {\n        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n        context.EnableConcurrentExecution();\n        // Le membre accede (.Result, .Wait) est un MemberAccessExpression --\n        // on s'abonne a CE noeud syntaxique, pas a toute l'arborescence.\n        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);\n    }\n\n    private static void AnalyzeNode(SyntaxNodeAnalysisContext ctx)\n    {\n        var node = (Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax)ctx.Node;\n\n        // 1. Filtre syntaxique bon marche : le membre s'appelle Result ou Wait.\n        if (node.Name is not { Identifier.ValueText: \"Result\" or \"Wait\" }) return;\n\n        // 2. Filtre semantique : le membre appartient bien a Task / Task<T>.\n        //    (Evince les faux positifs : un Result<T> monadique, un .Wait()\n        //    de type custom.) C'est le modele semantique qui tranchera.\n        if (ctx.SemanticModel.GetSymbolInfo(node).Symbol is not { } member) return;\n        if (member.ContainingType is not INamedTypeSymbol ct\n            || ct.MetadataName is not (\"Task\" or \"Task`1\")) return;\n\n        ctx.ReportDiagnostic(Diagnostic.Create(\n            Rule, node.GetLocation(), \".\" + node.Name.Identifier.ValueText));\n    }\n}\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "using System.Collections.Immutable;\n",
+      "using Microsoft.CodeAnalysis;\n",
+      "using Microsoft.CodeAnalysis.CSharp;\n",
+      "using Microsoft.CodeAnalysis.Diagnostics;\n",
+      "\n",
+      "namespace AgentGuard.Analyzers;\n",
+      "\n",
+      "/// <summary>\n",
+      "/// AGENTGUARD001 : blocage synchrone d'une Task (.Result / .Wait()).\n",
+      "///\n",
+      "/// Pattern typique du code d'agent genere : appeler une tache asynchrone\n",
+      "/// (appel LLM, streaming, canal) depuis du code synchrone en la bloquant.\n",
+      "/// Le garde-fou vit DANS la compilation -- `dotnet build` rend le diagnostic\n",
+      "/// sans aucun outil supplementaire (la these du notebook 06 de la serie Aspire,\n",
+      "/// Epic #10473 axe Roslyn).\n",
+      "/// </summary>\n",
+      "[DiagnosticAnalyzer(LanguageNames.CSharp)]\n",
+      "public sealed class TaskResultBlockAnalyzer : DiagnosticAnalyzer\n",
+      "{\n",
+      "    public const string DiagnosticId = \"AGENTGUARD001\";\n",
+      "\n",
+      "    private static readonly DiagnosticDescriptor Rule = new(\n",
+      "        DiagnosticId,\n",
+      "        \"Blocage synchrone d'une Task\",\n",
+      "        \"Task bloquee de maniere synchrone ({0}) : deadlock potentiel en code d'agent\",\n",
+      "        \"Agentisme\",\n",
+      "        DiagnosticSeverity.Warning,\n",
+      "        isEnabledByDefault: true,\n",
+      "        description: \"Le code genere par agent qui bloque une Task via .Result/.Wait() expose au deadlock.\");\n",
+      "\n",
+      "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n",
+      "        => ImmutableArray.Create(Rule);\n",
+      "\n",
+      "    public override void Initialize(AnalysisContext context)\n",
+      "    {\n",
+      "        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n",
+      "        context.EnableConcurrentExecution();\n",
+      "        // Le membre accede (.Result, .Wait) est un MemberAccessExpression --\n",
+      "        // on s'abonne a CE noeud syntaxique, pas a toute l'arborescence.\n",
+      "        context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);\n",
+      "    }\n",
+      "\n",
+      "    private static void AnalyzeNode(SyntaxNodeAnalysisContext ctx)\n",
+      "    {\n",
+      "        var node = (Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax)ctx.Node;\n",
+      "\n",
+      "        // 1. Filtre syntaxique bon marche : le membre s'appelle Result ou Wait.\n",
+      "        if (node.Name is not { Identifier.ValueText: \"Result\" or \"Wait\" }) return;\n",
+      "\n",
+      "        // 2. Filtre semantique : le membre appartient bien a Task / Task<T>.\n",
+      "        //    (Evince les faux positifs : un Result<T> monadique, un .Wait()\n",
+      "        //    de type custom.) C'est le modele semantique qui tranchera.\n",
+      "        if (ctx.SemanticModel.GetSymbolInfo(node).Symbol is not { } member) return;\n",
+      "        if (member.ContainingType is not INamedTypeSymbol ct\n",
+      "            || ct.MetadataName is not (\"Task\" or \"Task`1\")) return;\n",
+      "\n",
+      "        ctx.ReportDiagnostic(Diagnostic.Create(\n",
+      "            Rule, node.GetLocation(), \".\" + node.Name.Identifier.ValueText));\n",
+      "    }\n",
+      "}\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -305,10 +634,10 @@
    "id": "ag-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:02.455348Z",
-     "iopub.status.busy": "2026-08-28T21:33:02.454797Z",
-     "iopub.status.idle": "2026-08-28T21:33:02.512459Z",
-     "shell.execute_reply": "2026-08-28T21:33:02.512459Z"
+     "iopub.execute_input": "2026-09-03T10:36:55.492352Z",
+     "iopub.status.busy": "2026-09-03T10:36:55.491734Z",
+     "iopub.status.idle": "2026-09-03T10:37:07.720064Z",
+     "shell.execute_reply": "2026-09-03T10:37:07.719565Z"
     },
     "papermill": {
      "duration": 0.088129,
@@ -321,14 +650,22 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "usage: dotnet run -- <fautif.cs> <corrige.cs> [autres.cs ...]\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "[SyncOverAsyncConfigureAwaitFautif.cs] VERDICT : 2 diagnostic(s) -- AGENTGUARD005b x2\r\n",
+      "    AGENTGUARD005b @ 25:16  ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n",
+      "    AGENTGUARD005b @ 32:16  ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n",
+      "[SyncOverAsyncConfigureAwaitValueTask.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : citer pour chaque cas la clause d'exemption gagnee\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : citer pour chaque cas la clause d'exemption gagnee\r\n"
+     ]
     }
    ],
    "source": [
@@ -351,8 +688,17 @@
     "// rares, mais pas gratuits : les nommer dans la reponse est la\n",
     "// moitie de l'exercice.\n",
     "\n",
+    "// Note : le Verifier exige args.Length >= 2 (Program.cs:13 retourne\n",
+    "// exit 2 + banner usage sinon). On lance donc la paire fautif/valueTask :\n",
+    "// la fautive produit 2 diagnostics AGENTGUARD005b (preuve que\n",
+    "// l'analyseur fonctionne sur ConfigureAwait(false)/(true).GetAwaiter()\n",
+    "// .GetResult()) ; la valueTask produit 3 diagnostics PROPRE (preuve\n",
+    "// des 3 clauses d'exemption : ValueTask != Task, literal non-bool,\n",
+    "// pas de GetResult dans la chaine). La confrontation pedagogique\n",
+    "// predire/executer/verifier est donc possible sur le terrain.\n",
     "var verdictsValueTask = Shell.Run(here, \"dotnet\",\n",
     "    \"run --project AgentGuard.Verifier -- \" +\n",
+    "    \"AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitFautif.cs \" +\n",
     "    \"AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitValueTask.cs\");\n",
     "Console.WriteLine(verdictsValueTask);\n",
     "\n",
@@ -391,10 +737,10 @@
    "id": "ag-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:02.547787Z",
-     "iopub.status.busy": "2026-08-28T21:33:02.546182Z",
-     "iopub.status.idle": "2026-08-28T21:33:10.279594Z",
-     "shell.execute_reply": "2026-08-28T21:33:10.279594Z"
+     "iopub.execute_input": "2026-09-03T10:37:07.723005Z",
+     "iopub.status.busy": "2026-09-03T10:37:07.722514Z",
+     "iopub.status.idle": "2026-09-03T10:37:11.944506Z",
+     "shell.execute_reply": "2026-09-03T10:37:11.944228Z"
     },
     "papermill": {
      "duration": 7.741769,
@@ -407,9 +753,34 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "AgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(88,15): warning AGENTGUARD004: L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(111,16): warning AGENTGUARD005: GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(140,16): warning AGENTGUARD005b: ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(147,16): warning AGENTGUARD005b: ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n\r\nLa génération a réussi.\r\n\r\nAgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(88,15): warning AGENTGUARD004: L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(111,16): warning AGENTGUARD005: GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(140,16): warning AGENTGUARD005b: ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(147,16): warning AGENTGUARD005b: ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\nAgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n    8 Avertissement(s)\r\n    0 Erreur(s)\r\n\r\nTemps écoulé 00:00:03.12\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "AgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(111,16): warning AGENTGUARD005: GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(140,16): warning AGENTGUARD005b: ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(147,16): warning AGENTGUARD005b: ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(88,15): warning AGENTGUARD004: L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante [AgentGuard.Demo]\r\n",
+      "\r\n",
+      "La génération a réussi.\r\n",
+      "\r\n",
+      "AgentGuard.Demo\\Program.cs(55,30): warning AGENTGUARD002: La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(111,16): warning AGENTGUARD005: GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(140,16): warning AGENTGUARD005b: ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(24,22): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(25,16): warning AGENTGUARD001: Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(75,9): warning AGENTGUARD003: Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(147,16): warning AGENTGUARD005b: ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await [AgentGuard.Demo]\r\n",
+      "AgentGuard.Demo\\Program.cs(88,15): warning AGENTGUARD004: L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante [AgentGuard.Demo]\r\n",
+      "    8 Avertissement(s)\r\n",
+      "    0 Erreur(s)\r\n",
+      "\r\n",
+      "Temps écoulé 00:00:03.30\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -488,10 +859,10 @@
    "id": "ag-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:10.331547Z",
-     "iopub.status.busy": "2026-08-28T21:33:10.331547Z",
-     "iopub.status.idle": "2026-08-28T21:33:16.297443Z",
-     "shell.execute_reply": "2026-08-28T21:33:16.296919Z"
+     "iopub.execute_input": "2026-09-03T10:37:11.946349Z",
+     "iopub.status.busy": "2026-09-03T10:37:11.946110Z",
+     "iopub.status.idle": "2026-09-03T10:37:18.831182Z",
+     "shell.execute_reply": "2026-09-03T10:37:18.830654Z"
     },
     "papermill": {
      "duration": 5.977317,
@@ -504,9 +875,21 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[Program.cs] VERDICT : 8 diagnostic(s) -- AGENTGUARD001 x2, AGENTGUARD002 x1, AGENTGUARD003 x1, AGENTGUARD004 x1, AGENTGUARD005 x1, AGENTGUARD005b x2\r\n    AGENTGUARD001 @ 24:22  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n    AGENTGUARD001 @ 25:16  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n    AGENTGUARD002 @ 55:30  La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort\r\n    AGENTGUARD003 @ 75:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n    AGENTGUARD004 @ 88:15  L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante\r\n    AGENTGUARD005 @ 111:16  GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await\r\n    AGENTGUARD005b @ 140:16  ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n    AGENTGUARD005b @ 147:16  ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n[AgentWorkerCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "[Program.cs] VERDICT : 8 diagnostic(s) -- AGENTGUARD001 x2, AGENTGUARD002 x1, AGENTGUARD003 x1, AGENTGUARD004 x1, AGENTGUARD005 x1, AGENTGUARD005b x2\r\n",
+      "    AGENTGUARD001 @ 24:22  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n",
+      "    AGENTGUARD001 @ 25:16  Task bloquee de maniere synchrone (.Result) : deadlock potentiel en code d'agent\r\n",
+      "    AGENTGUARD002 @ 55:30  La methode async void 'SurveillerCanalAsync' echappe a toute attente -- exceptions non observees, process mort\r\n",
+      "    AGENTGUARD003 @ 75:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n",
+      "    AGENTGUARD004 @ 88:15  L'appel à 'Task<string> AgentCancellation.CallLlmAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante\r\n",
+      "    AGENTGUARD005 @ 111:16  GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await\r\n",
+      "    AGENTGUARD005b @ 140:16  ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n",
+      "    AGENTGUARD005b @ 147:16  ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n",
+      "[AgentWorkerCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -545,10 +928,10 @@
    "id": "ag-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:16.327846Z",
-     "iopub.status.busy": "2026-08-28T21:33:16.326829Z",
-     "iopub.status.idle": "2026-08-28T21:33:16.387155Z",
-     "shell.execute_reply": "2026-08-28T21:33:16.386647Z"
+     "iopub.execute_input": "2026-09-03T10:37:18.833896Z",
+     "iopub.status.busy": "2026-09-03T10:37:18.833409Z",
+     "iopub.status.idle": "2026-09-03T10:37:18.889854Z",
+     "shell.execute_reply": "2026-09-03T10:37:18.889333Z"
     },
     "papermill": {
      "duration": 0.068804,
@@ -561,9 +944,38 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "// Version corrigee du terrain fautif (AgentGuard.Demo/Program.cs) :\n// le worker attend la tache au lieu de la bloquer. C'est la version\n// attendue \"propre\" au verdict du Verifier.\n\nusing System;\nusing System.Threading;\nusing System.Threading.Channels;\nusing System.Threading.Tasks;\n\npublic static class AgentWorkerCorrige\n{\n    // Le fix : async/await de bout en bout. Le thread rend la main pendant\n    // l'attente au lieu de se bloquer -- plus de deadlock possible, et le\n    // pipeline reste fluide sous charge.\n    public static async Task<string> TranslateAsync(\n        ChannelReader<string> inbound, CancellationToken ct = default)\n    {\n        var prompt = await inbound.ReadAsync(ct);\n        return await CallLlmAsync(prompt, ct);\n    }\n\n    private static async Task<string> CallLlmAsync(string prompt, CancellationToken ct)\n    {\n        await Task.Delay(50, ct);       // simule la latence de l'appel LLM\n        return $\"[LLM] {prompt}\";\n    }\n}\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "// Version corrigee du terrain fautif (AgentGuard.Demo/Program.cs) :\n",
+      "// le worker attend la tache au lieu de la bloquer. C'est la version\n",
+      "// attendue \"propre\" au verdict du Verifier.\n",
+      "\n",
+      "using System;\n",
+      "using System.Threading;\n",
+      "using System.Threading.Channels;\n",
+      "using System.Threading.Tasks;\n",
+      "\n",
+      "public static class AgentWorkerCorrige\n",
+      "{\n",
+      "    // Le fix : async/await de bout en bout. Le thread rend la main pendant\n",
+      "    // l'attente au lieu de se bloquer -- plus de deadlock possible, et le\n",
+      "    // pipeline reste fluide sous charge.\n",
+      "    public static async Task<string> TranslateAsync(\n",
+      "        ChannelReader<string> inbound, CancellationToken ct = default)\n",
+      "    {\n",
+      "        var prompt = await inbound.ReadAsync(ct);\n",
+      "        return await CallLlmAsync(prompt, ct);\n",
+      "    }\n",
+      "\n",
+      "    private static async Task<string> CallLlmAsync(string prompt, CancellationToken ct)\n",
+      "    {\n",
+      "        await Task.Delay(50, ct);       // simule la latence de l'appel LLM\n",
+      "        return $\"[LLM] {prompt}\";\n",
+      "    }\n",
+      "}\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -631,10 +1043,10 @@
    "id": "ag-20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:16.431954Z",
-     "iopub.status.busy": "2026-08-28T21:33:16.431445Z",
-     "iopub.status.idle": "2026-08-28T21:33:16.713064Z",
-     "shell.execute_reply": "2026-08-28T21:33:16.711435Z"
+     "iopub.execute_input": "2026-09-03T10:37:18.892709Z",
+     "iopub.status.busy": "2026-09-03T10:37:18.892244Z",
+     "iopub.status.idle": "2026-09-03T10:37:19.176185Z",
+     "shell.execute_reply": "2026-09-03T10:37:19.175789Z"
     },
     "papermill": {
      "duration": 0.291289,
@@ -647,14 +1059,18 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Outcome<string>.Result = aucun blocage ici\r\n"
+     "output_type": "stream",
+     "text": [
+      "Outcome<string>.Result = aucun blocage ici\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : passer ce type au Verifier et nommer la ligne de l'exemption\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : passer ce type au Verifier et nommer la ligne de l'exemption\r\n"
+     ]
     }
    ],
    "source": [
@@ -696,10 +1112,10 @@
    "id": "ag-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:16.741786Z",
-     "iopub.status.busy": "2026-08-28T21:33:16.740778Z",
-     "iopub.status.idle": "2026-08-28T21:33:16.881159Z",
-     "shell.execute_reply": "2026-08-28T21:33:16.881159Z"
+     "iopub.execute_input": "2026-09-03T10:37:19.178907Z",
+     "iopub.status.busy": "2026-09-03T10:37:19.178445Z",
+     "iopub.status.idle": "2026-09-03T10:37:19.513814Z",
+     "shell.execute_reply": "2026-09-03T10:37:19.513326Z"
     },
     "papermill": {
      "duration": 0.148598,
@@ -712,14 +1128,19 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Information : impossible de trouver des fichiers pour le(s) modèle(s) spécifié(s).\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "Information : impossible de trouver des fichiers pour le(s) modèle(s) spécifié(s).\r\n",
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-> ruff ABSENT : en Python le garde-fou est un outil a installer soi-meme\r\n"
+     "output_type": "stream",
+     "text": [
+      "-> ruff ABSENT : en Python le garde-fou est un outil a installer soi-meme\r\n"
+     ]
     }
    ],
    "source": [
@@ -807,12 +1228,31 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "8d4eecd3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T10:37:19.516581Z",
+     "iopub.status.busy": "2026-09-03T10:37:19.516144Z",
+     "iopub.status.idle": "2026-09-03T10:37:26.922071Z",
+     "shell.execute_reply": "2026-09-03T10:37:26.921636Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[SyncOverAsyncFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD005 x1\r\n    AGENTGUARD005 @ 21:9  GetAwaiter().GetResult() bloque une Task/Task de maniere synchrone : remplacer par await\r\n[SyncOverAsyncCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[SyncOverAsyncGenericFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD005 x1\r\n    AGENTGUARD005 @ 21:16  GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await\r\n[SyncOverAsyncSansGetResult.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[SyncOverAsyncAwaiterPersonnalise.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[SyncOverAsyncConfigureAwaitFautif.cs] VERDICT : 2 diagnostic(s) -- AGENTGUARD005b x2\r\n    AGENTGUARD005b @ 25:16  ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n    AGENTGUARD005b @ 32:16  ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "[SyncOverAsyncFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD005 x1\r\n",
+      "    AGENTGUARD005 @ 21:9  GetAwaiter().GetResult() bloque une Task/Task de maniere synchrone : remplacer par await\r\n",
+      "[SyncOverAsyncCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[SyncOverAsyncGenericFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD005 x1\r\n",
+      "    AGENTGUARD005 @ 21:16  GetAwaiter().GetResult() bloque une Task/Task`1 de maniere synchrone : remplacer par await\r\n",
+      "[SyncOverAsyncSansGetResult.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[SyncOverAsyncAwaiterPersonnalise.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[SyncOverAsyncConfigureAwaitFautif.cs] VERDICT : 2 diagnostic(s) -- AGENTGUARD005b x2\r\n",
+      "    AGENTGUARD005b @ 25:16  ConfigureAwait(False) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n",
+      "    AGENTGUARD005b @ 32:16  ConfigureAwait(True) ne protege pas du sync-over-async : .GetAwaiter().GetResult() bloque toujours le thread, remplacer par await\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -904,10 +1344,10 @@
    "id": "ag-26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:16.931527Z",
-     "iopub.status.busy": "2026-08-28T21:33:16.931005Z",
-     "iopub.status.idle": "2026-08-28T21:33:21.348232Z",
-     "shell.execute_reply": "2026-08-28T21:33:21.348232Z"
+     "iopub.execute_input": "2026-09-03T10:37:26.924667Z",
+     "iopub.status.busy": "2026-09-03T10:37:26.924205Z",
+     "iopub.status.idle": "2026-09-03T10:37:34.274339Z",
+     "shell.execute_reply": "2026-09-03T10:37:34.273890Z"
     },
     "papermill": {
      "duration": 4.425443,
@@ -920,24 +1360,49 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "// --- l'exemption, extraite de AsyncVoidAnalyzer.cs ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "// --- l'exemption, extraite de AsyncVoidAnalyzer.cs ---\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "private static bool EstHandlerEvenement(MethodDeclarationSyntax method, SyntaxNodeAnalysisContext ctx)\n    {\n        var parameters = method.ParameterList.Parameters;\n        if (parameters.Count < 2) return false;\n\n        // Premier parametre exactement object (le \"sender\").\n        var senderType = ctx.SemanticModel.GetTypeInfo(parameters[0].Type).Type;\n        if (senderType?.SpecialType != SpecialType.System_Object) return false;\n\n        // Second parametre derive de System.EventArgs (ou l'est lui-meme).\n        var argsType = ctx.SemanticModel.GetTypeInfo(parameters[1].Type).Type;\n        if (argsType is null || argsType.TypeKind == TypeKind.Error) return false;\n        return EstEventArgsOuDerive(argsType, ctx.Compilation);\n    }\r\n"
+     "output_type": "stream",
+     "text": [
+      "private static bool EstHandlerEvenement(MethodDeclarationSyntax method, SyntaxNodeAnalysisContext ctx)\n",
+      "    {\n",
+      "        var parameters = method.ParameterList.Parameters;\n",
+      "        if (parameters.Count < 2) return false;\n",
+      "\n",
+      "        // Premier parametre exactement object (le \"sender\").\n",
+      "        var senderType = ctx.SemanticModel.GetTypeInfo(parameters[0].Type).Type;\n",
+      "        if (senderType?.SpecialType != SpecialType.System_Object) return false;\n",
+      "\n",
+      "        // Second parametre derive de System.EventArgs (ou l'est lui-meme).\n",
+      "        var argsType = ctx.SemanticModel.GetTypeInfo(parameters[1].Type).Type;\n",
+      "        if (argsType is null || argsType.TypeKind == TypeKind.Error) return false;\n",
+      "        return EstEventArgsOuDerive(argsType, ctx.Compilation);\n",
+      "    }\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[AsyncVoidFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD002 x1\r\n    AGENTGUARD002 @ 13:30  La methode async void 'TraiterCommande' echappe a toute attente -- exceptions non observees, process mort\r\n[AsyncVoidCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[AsyncVoidHandlerExempt.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "[AsyncVoidFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD002 x1\r\n",
+      "    AGENTGUARD002 @ 13:30  La methode async void 'TraiterCommande' echappe a toute attente -- exceptions non observees, process mort\r\n",
+      "[AsyncVoidCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[AsyncVoidHandlerExempt.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -1017,10 +1482,10 @@
    "id": "ft06_exo3_v2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:21.391989Z",
-     "iopub.status.busy": "2026-08-28T21:33:21.391989Z",
-     "iopub.status.idle": "2026-08-28T21:33:21.424306Z",
-     "shell.execute_reply": "2026-08-28T21:33:21.423764Z"
+     "iopub.execute_input": "2026-09-03T10:37:34.277213Z",
+     "iopub.status.busy": "2026-09-03T10:37:34.276601Z",
+     "iopub.status.idle": "2026-09-03T10:37:34.381453Z",
+     "shell.execute_reply": "2026-09-03T10:37:34.380999Z"
     },
     "papermill": {
      "duration": 0.042088,
@@ -1033,9 +1498,100 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "using System.Collections.Immutable;\nusing Microsoft.CodeAnalysis;\nusing Microsoft.CodeAnalysis.CSharp;\nusing Microsoft.CodeAnalysis.CSharp.Syntax;\nusing Microsoft.CodeAnalysis.Diagnostics;\n\nnamespace AgentGuard.Analyzers;\n\n/// <summary>\n/// AGENTGUARD003 : invocation nue de Task.Run, tache non observee.\n///\n/// Troisieme pattern typique du code genere par agent : ecrire\n/// `Task.Run(() => Travail())` comme enonce autonome. La signature est\n/// honnete (la methode rend une Task, pas void), MAIS la tache resultante\n/// n'est ni attendue (await), ni affectee a une variable, ni retournee,\n/// ni explicitement ignoree via discard (`_ =`). Elle s'execute en arriere-\n/// plan ; ses exceptions ne sont observees par personne. A la finalisation\n/// d'une telle tache fautive, le runtime declenche\n/// `TaskScheduler.UnobservedTaskException`, un evenement qui porte une\n/// `AggregateException` collectant les exceptions internes -- le defaut\n/// (.NET 4.5+) est d'absorber l'evenement et de laisser le process vivre,\n/// mais ce comportement est configurable et n'est pas garanti.\n///\n/// Formes LEGITIMES (a ne PAS signaler) :\n///   - `await Task.Run(...)`            -- tache observee\n///   - `var t = Task.Run(...)`          -- tache recuperee (composee ou attendue plus tard)\n///   - `_ = Task.Run(...)`              -- discard explicite (assume, volontaire)\n///   - `return Task.Run(...)`           -- tache retournee a l'appelant\n///   - homonyme custom (autre type, autre signature) -- filtre semantique\n/// </summary>\n[DiagnosticAnalyzer(LanguageNames.CSharp)]\npublic sealed class TaskRunFireAnalyzer : DiagnosticAnalyzer\n{\n    public const string DiagnosticId = \"AGENTGUARD003\";\n\n    private static readonly DiagnosticDescriptor Rule = new(\n        DiagnosticId,\n        \"Task.Run feu, tache non observee\",\n        \"Task.Run '{0}' lance une tache non observee -- exceptions perdues, comportement indefini\",\n        \"Agentisme\",\n        DiagnosticSeverity.Warning,\n        isEnabledByDefault: true,\n        description: \"Une invocation nue de Task.Run execute la tache en arriere-plan ; ses exceptions ne sont observees par personne. Utiliser await, affecter a une variable, retourner ou discarder explicitement (_ =).\");\n\n    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n        => ImmutableArray.Create(Rule);\n\n    public override void Initialize(AnalysisContext context)\n    {\n        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n        context.EnableConcurrentExecution();\n        // On s'abonne aux INVOCATIONS (le noeud Task.Run(...)). Le diagnostic\n        // porte sur l'invocation, pas sur un membre -- le membre ici est un\n        // IdentifierName (Run), pas un MemberAccessExpression, donc on ne peut\n        // pas reutiliser la strategie d'AGENTGUARD001.\n        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);\n    }\n\n    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)\n    {\n        var inv = (InvocationExpressionSyntax)ctx.Node;\n\n        // 1. Filtre semantique : la methode invoquee est bien Task.Run.\n        //    Reutilise le pattern d'AGENTGUARD001 : resoudre le symbole et\n        //    verifier que la ContainingType est Task (non-generique).\n        //    Evince les methodes homonymes : un type custom `MonService.Run`\n        //    ne doit PAS declencher AGENTGUARD003.\n        if (ctx.SemanticModel.GetSymbolInfo(inv).Symbol is not IMethodSymbol method) return;\n        if (method.ContainingType is not INamedTypeSymbol ct\n            || ct.MetadataName is not \"Task\"\n            || ct.ContainingNamespace?.ToDisplayString() != \"System.Threading.Tasks\") return;\n        if (method.MetadataName is not \"Run\") return;\n\n        // 2. Filtre syntaxique : la seule forme signalee est l'ExpressionStatement\n        //    nu (l'invocation est l'integralite de l'enonce). Les autres formes\n        //    -- await, affectation, discard, return, argument d'une autre\n        //    invocation -- ne sont JAMAIS signalees.\n        //\n        //    Cas particulier `_ = Task.Run(...)` : Roslyn represente le discard\n        //    comme un AssignmentExpression avec Left = IdentifierName(\"_\"),\n        //    donc le parent n'est PAS un ExpressionStatement nu -- il est\n        //    rattrape par le filtre \"n'est pas ExpressionStatement\" et tombe\n        //    naturellement dans la branche exempt. Le test terrain le verifie.\n        if (inv.Parent is not ExpressionStatementSyntax) return;\n\n        ctx.ReportDiagnostic(Diagnostic.Create(\n            Rule, inv.GetLocation(), inv.ToString()));\n    }\n}\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "using System.Collections.Immutable;\n",
+      "using Microsoft.CodeAnalysis;\n",
+      "using Microsoft.CodeAnalysis.CSharp;\n",
+      "using Microsoft.CodeAnalysis.CSharp.Syntax;\n",
+      "using Microsoft.CodeAnalysis.Diagnostics;\n",
+      "\n",
+      "namespace AgentGuard.Analyzers;\n",
+      "\n",
+      "/// <summary>\n",
+      "/// AGENTGUARD003 : invocation nue de Task.Run, tache non observee.\n",
+      "///\n",
+      "/// Troisieme pattern typique du code genere par agent : ecrire\n",
+      "/// `Task.Run(() => Travail())` comme enonce autonome. La signature est\n",
+      "/// honnete (la methode rend une Task, pas void), MAIS la tache resultante\n",
+      "/// n'est ni attendue (await), ni affectee a une variable, ni retournee,\n",
+      "/// ni explicitement ignoree via discard (`_ =`). Elle s'execute en arriere-\n",
+      "/// plan ; ses exceptions ne sont observees par personne. A la finalisation\n",
+      "/// d'une telle tache fautive, le runtime declenche\n",
+      "/// `TaskScheduler.UnobservedTaskException`, un evenement qui porte une\n",
+      "/// `AggregateException` collectant les exceptions internes -- le defaut\n",
+      "/// (.NET 4.5+) est d'absorber l'evenement et de laisser le process vivre,\n",
+      "/// mais ce comportement est configurable et n'est pas garanti.\n",
+      "///\n",
+      "/// Formes LEGITIMES (a ne PAS signaler) :\n",
+      "///   - `await Task.Run(...)`            -- tache observee\n",
+      "///   - `var t = Task.Run(...)`          -- tache recuperee (composee ou attendue plus tard)\n",
+      "///   - `_ = Task.Run(...)`              -- discard explicite (assume, volontaire)\n",
+      "///   - `return Task.Run(...)`           -- tache retournee a l'appelant\n",
+      "///   - homonyme custom (autre type, autre signature) -- filtre semantique\n",
+      "/// </summary>\n",
+      "[DiagnosticAnalyzer(LanguageNames.CSharp)]\n",
+      "public sealed class TaskRunFireAnalyzer : DiagnosticAnalyzer\n",
+      "{\n",
+      "    public const string DiagnosticId = \"AGENTGUARD003\";\n",
+      "\n",
+      "    private static readonly DiagnosticDescriptor Rule = new(\n",
+      "        DiagnosticId,\n",
+      "        \"Task.Run feu, tache non observee\",\n",
+      "        \"Task.Run '{0}' lance une tache non observee -- exceptions perdues, comportement indefini\",\n",
+      "        \"Agentisme\",\n",
+      "        DiagnosticSeverity.Warning,\n",
+      "        isEnabledByDefault: true,\n",
+      "        description: \"Une invocation nue de Task.Run execute la tache en arriere-plan ; ses exceptions ne sont observees par personne. Utiliser await, affecter a une variable, retourner ou discarder explicitement (_ =).\");\n",
+      "\n",
+      "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n",
+      "        => ImmutableArray.Create(Rule);\n",
+      "\n",
+      "    public override void Initialize(AnalysisContext context)\n",
+      "    {\n",
+      "        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n",
+      "        context.EnableConcurrentExecution();\n",
+      "        // On s'abonne aux INVOCATIONS (le noeud Task.Run(...)). Le diagnostic\n",
+      "        // porte sur l'invocation, pas sur un membre -- le membre ici est un\n",
+      "        // IdentifierName (Run), pas un MemberAccessExpression, donc on ne peut\n",
+      "        // pas reutiliser la strategie d'AGENTGUARD001.\n",
+      "        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);\n",
+      "    }\n",
+      "\n",
+      "    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)\n",
+      "    {\n",
+      "        var inv = (InvocationExpressionSyntax)ctx.Node;\n",
+      "\n",
+      "        // 1. Filtre semantique : la methode invoquee est bien Task.Run.\n",
+      "        //    Reutilise le pattern d'AGENTGUARD001 : resoudre le symbole et\n",
+      "        //    verifier que la ContainingType est Task (non-generique).\n",
+      "        //    Evince les methodes homonymes : un type custom `MonService.Run`\n",
+      "        //    ne doit PAS declencher AGENTGUARD003.\n",
+      "        if (ctx.SemanticModel.GetSymbolInfo(inv).Symbol is not IMethodSymbol method) return;\n",
+      "        if (method.ContainingType is not INamedTypeSymbol ct\n",
+      "            || ct.MetadataName is not \"Task\"\n",
+      "            || ct.ContainingNamespace?.ToDisplayString() != \"System.Threading.Tasks\") return;\n",
+      "        if (method.MetadataName is not \"Run\") return;\n",
+      "\n",
+      "        // 2. Filtre syntaxique : la seule forme signalee est l'ExpressionStatement\n",
+      "        //    nu (l'invocation est l'integralite de l'enonce). Les autres formes\n",
+      "        //    -- await, affectation, discard, return, argument d'une autre\n",
+      "        //    invocation -- ne sont JAMAIS signalees.\n",
+      "        //\n",
+      "        //    Cas particulier `_ = Task.Run(...)` : Roslyn represente le discard\n",
+      "        //    comme un AssignmentExpression avec Left = IdentifierName(\"_\"),\n",
+      "        //    donc le parent n'est PAS un ExpressionStatement nu -- il est\n",
+      "        //    rattrape par le filtre \"n'est pas ExpressionStatement\" et tombe\n",
+      "        //    naturellement dans la branche exempt. Le test terrain le verifie.\n",
+      "        if (inv.Parent is not ExpressionStatementSyntax) return;\n",
+      "\n",
+      "        ctx.ReportDiagnostic(Diagnostic.Create(\n",
+      "            Rule, inv.GetLocation(), inv.ToString()));\n",
+      "    }\n",
+      "}\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -1102,10 +1658,10 @@
    "id": "a5ea7c5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:21.466983Z",
-     "iopub.status.busy": "2026-08-28T21:33:21.466983Z",
-     "iopub.status.idle": "2026-08-28T21:33:25.377842Z",
-     "shell.execute_reply": "2026-08-28T21:33:25.377842Z"
+     "iopub.execute_input": "2026-09-03T10:37:34.384643Z",
+     "iopub.status.busy": "2026-09-03T10:37:34.384125Z",
+     "iopub.status.idle": "2026-09-03T10:37:41.409640Z",
+     "shell.execute_reply": "2026-09-03T10:37:41.408878Z"
     },
     "papermill": {
      "duration": 3.919631,
@@ -1118,9 +1674,17 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[TaskRunFireFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD003 x1\r\n    AGENTGUARD003 @ 14:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n[TaskRunFireCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[TaskRunFireAssignation.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[TaskRunFireDiscard.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[TaskRunFireHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "[TaskRunFireFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD003 x1\r\n",
+      "    AGENTGUARD003 @ 14:9  Task.Run 'Task.Run(() => Console.WriteLine(\"ping\"))' lance une tache non observee -- exceptions perdues, comportement indefini\r\n",
+      "[TaskRunFireCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[TaskRunFireAssignation.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[TaskRunFireDiscard.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[TaskRunFireHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -1199,10 +1763,10 @@
    "id": "4ccf84dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T21:33:25.415485Z",
-     "iopub.status.busy": "2026-08-28T21:33:25.415485Z",
-     "iopub.status.idle": "2026-08-28T21:33:25.439909Z",
-     "shell.execute_reply": "2026-08-28T21:33:25.439909Z"
+     "iopub.execute_input": "2026-09-03T10:37:41.411761Z",
+     "iopub.status.busy": "2026-09-03T10:37:41.411383Z",
+     "iopub.status.idle": "2026-09-03T10:37:41.452745Z",
+     "shell.execute_reply": "2026-09-03T10:37:41.452454Z"
     },
     "papermill": {
      "duration": 0.03179,
@@ -1215,9 +1779,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : etendre AGENTGUARD003 a Task.Factory.StartNew nu\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : etendre AGENTGUARD003 a Task.Factory.StartNew nu\r\n"
+     ]
     }
    ],
    "source": [
@@ -1245,12 +1811,112 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "24a493a4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T10:37:41.455088Z",
+     "iopub.status.busy": "2026-09-03T10:37:41.454653Z",
+     "iopub.status.idle": "2026-09-03T10:37:41.498290Z",
+     "shell.execute_reply": "2026-09-03T10:37:41.497987Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "using System.Collections.Immutable;\nusing System.Linq;\nusing Microsoft.CodeAnalysis;\nusing Microsoft.CodeAnalysis.Diagnostics;\nusing Microsoft.CodeAnalysis.Operations;\n\nnamespace AgentGuard.Analyzers;\n\n/// <summary>\n/// AGENTGUARD004 : perte d'un CancellationToken disponible.\n///\n/// Une méthode d'agent reçoit souvent un token depuis la requête HTTP ou le\n/// BackgroundService. Si elle appelle une opération dont la signature expose\n/// explicitement CancellationToken mais omet cet argument optionnel, l'arrêt\n/// demandé ne traverse plus la chaîne. L'analyse est entièrement sémantique :\n/// le type doit être System.Threading.CancellationToken, sans heuristique sur\n/// le nom de la méthode ni du paramètre.\n/// </summary>\n[DiagnosticAnalyzer(LanguageNames.CSharp)]\npublic sealed class CancellationTokenPropagationAnalyzer : DiagnosticAnalyzer\n{\n    public const string DiagnosticId = \"AGENTGUARD004\";\n\n    private static readonly DiagnosticDescriptor Rule = new(\n        DiagnosticId,\n        \"CancellationToken disponible mais non propage\",\n        \"L'appel à '{0}' omet CancellationToken alors que '{1}' est disponible dans la méthode englobante\",\n        \"Agentisme\",\n        DiagnosticSeverity.Warning,\n        isEnabledByDefault: true,\n        description: \"Propager le CancellationToken disponible aux opérations annulables afin que l'arrêt traverse toute la chaîne d'agent.\");\n\n    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n        => ImmutableArray.Create(Rule);\n\n    public override void Initialize(AnalysisContext context)\n    {\n        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n        context.EnableConcurrentExecution();\n        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);\n    }\n\n    private static void AnalyzeInvocation(OperationAnalysisContext ctx)\n    {\n        var invocation = (IInvocationOperation)ctx.Operation;\n        var cancellationToken = ctx.Compilation.GetTypeByMetadataName(\n            \"System.Threading.CancellationToken\");\n        if (cancellationToken is null) return;\n\n        var tokenParameter = invocation.TargetMethod.Parameters.FirstOrDefault(\n            parameter => SymbolEqualityComparer.Default.Equals(\n                parameter.Type, cancellationToken));\n        if (tokenParameter is null) return;\n\n        // Roslyn matérialise un argument optionnel omis avec ArgumentKind.DefaultValue.\n        // Seul un argument Explicit prouve que l'appelant a propagé un token.\n        var tokenIsExplicit = invocation.Arguments.Any(argument =>\n            SymbolEqualityComparer.Default.Equals(argument.Parameter, tokenParameter)\n            && argument.ArgumentKind == ArgumentKind.Explicit);\n        if (tokenIsExplicit) return;\n\n        var availableToken = FindAvailableToken(ctx.ContainingSymbol, cancellationToken);\n        if (availableToken is null) return;\n\n        ctx.ReportDiagnostic(Diagnostic.Create(\n            Rule,\n            invocation.Syntax.GetLocation(),\n            invocation.TargetMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),\n            availableToken.Name));\n    }\n\n    private static IParameterSymbol FindAvailableToken(\n        ISymbol symbol,\n        INamedTypeSymbol cancellationToken)\n    {\n        // Une lambda ou une fonction locale peut capturer le token de sa méthode\n        // englobante : on remonte donc la chaîne de symboles, sans sortir du type.\n        for (var current = symbol; current is not null && current is not INamedTypeSymbol;\n             current = current.ContainingSymbol)\n        {\n            if (current is not IMethodSymbol method) continue;\n\n            var token = method.Parameters.FirstOrDefault(parameter =>\n                SymbolEqualityComparer.Default.Equals(\n                    parameter.Type, cancellationToken));\n            if (token is not null) return token;\n        }\n\n        return null;\n    }\n}\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "using System.Collections.Immutable;\n",
+      "using System.Linq;\n",
+      "using Microsoft.CodeAnalysis;\n",
+      "using Microsoft.CodeAnalysis.Diagnostics;\n",
+      "using Microsoft.CodeAnalysis.Operations;\n",
+      "\n",
+      "namespace AgentGuard.Analyzers;\n",
+      "\n",
+      "/// <summary>\n",
+      "/// AGENTGUARD004 : perte d'un CancellationToken disponible.\n",
+      "///\n",
+      "/// Une méthode d'agent reçoit souvent un token depuis la requête HTTP ou le\n",
+      "/// BackgroundService. Si elle appelle une opération dont la signature expose\n",
+      "/// explicitement CancellationToken mais omet cet argument optionnel, l'arrêt\n",
+      "/// demandé ne traverse plus la chaîne. L'analyse est entièrement sémantique :\n",
+      "/// le type doit être System.Threading.CancellationToken, sans heuristique sur\n",
+      "/// le nom de la méthode ni du paramètre.\n",
+      "/// </summary>\n",
+      "[DiagnosticAnalyzer(LanguageNames.CSharp)]\n",
+      "public sealed class CancellationTokenPropagationAnalyzer : DiagnosticAnalyzer\n",
+      "{\n",
+      "    public const string DiagnosticId = \"AGENTGUARD004\";\n",
+      "\n",
+      "    private static readonly DiagnosticDescriptor Rule = new(\n",
+      "        DiagnosticId,\n",
+      "        \"CancellationToken disponible mais non propage\",\n",
+      "        \"L'appel à '{0}' omet CancellationToken alors que '{1}' est disponible dans la méthode englobante\",\n",
+      "        \"Agentisme\",\n",
+      "        DiagnosticSeverity.Warning,\n",
+      "        isEnabledByDefault: true,\n",
+      "        description: \"Propager le CancellationToken disponible aux opérations annulables afin que l'arrêt traverse toute la chaîne d'agent.\");\n",
+      "\n",
+      "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics\n",
+      "        => ImmutableArray.Create(Rule);\n",
+      "\n",
+      "    public override void Initialize(AnalysisContext context)\n",
+      "    {\n",
+      "        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n",
+      "        context.EnableConcurrentExecution();\n",
+      "        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);\n",
+      "    }\n",
+      "\n",
+      "    private static void AnalyzeInvocation(OperationAnalysisContext ctx)\n",
+      "    {\n",
+      "        var invocation = (IInvocationOperation)ctx.Operation;\n",
+      "        var cancellationToken = ctx.Compilation.GetTypeByMetadataName(\n",
+      "            \"System.Threading.CancellationToken\");\n",
+      "        if (cancellationToken is null) return;\n",
+      "\n",
+      "        var tokenParameter = invocation.TargetMethod.Parameters.FirstOrDefault(\n",
+      "            parameter => SymbolEqualityComparer.Default.Equals(\n",
+      "                parameter.Type, cancellationToken));\n",
+      "        if (tokenParameter is null) return;\n",
+      "\n",
+      "        // Roslyn matérialise un argument optionnel omis avec ArgumentKind.DefaultValue.\n",
+      "        // Seul un argument Explicit prouve que l'appelant a propagé un token.\n",
+      "        var tokenIsExplicit = invocation.Arguments.Any(argument =>\n",
+      "            SymbolEqualityComparer.Default.Equals(argument.Parameter, tokenParameter)\n",
+      "            && argument.ArgumentKind == ArgumentKind.Explicit);\n",
+      "        if (tokenIsExplicit) return;\n",
+      "\n",
+      "        var availableToken = FindAvailableToken(ctx.ContainingSymbol, cancellationToken);\n",
+      "        if (availableToken is null) return;\n",
+      "\n",
+      "        ctx.ReportDiagnostic(Diagnostic.Create(\n",
+      "            Rule,\n",
+      "            invocation.Syntax.GetLocation(),\n",
+      "            invocation.TargetMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),\n",
+      "            availableToken.Name));\n",
+      "    }\n",
+      "\n",
+      "    private static IParameterSymbol FindAvailableToken(\n",
+      "        ISymbol symbol,\n",
+      "        INamedTypeSymbol cancellationToken)\n",
+      "    {\n",
+      "        // Une lambda ou une fonction locale peut capturer le token de sa méthode\n",
+      "        // englobante : on remonte donc la chaîne de symboles, sans sortir du type.\n",
+      "        for (var current = symbol; current is not null && current is not INamedTypeSymbol;\n",
+      "             current = current.ContainingSymbol)\n",
+      "        {\n",
+      "            if (current is not IMethodSymbol method) continue;\n",
+      "\n",
+      "            var token = method.Parameters.FirstOrDefault(parameter =>\n",
+      "                SymbolEqualityComparer.Default.Equals(\n",
+      "                    parameter.Type, cancellationToken));\n",
+      "            if (token is not null) return token;\n",
+      "        }\n",
+      "\n",
+      "        return null;\n",
+      "    }\n",
+      "}\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -1282,12 +1948,27 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "87b32afa",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T10:37:41.500757Z",
+     "iopub.status.busy": "2026-09-03T10:37:41.500247Z",
+     "iopub.status.idle": "2026-09-03T10:37:48.080032Z",
+     "shell.execute_reply": "2026-09-03T10:37:48.079582Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[CancellationTokenFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD004 x1\r\n    AGENTGUARD004 @ 10:15  L'appel à 'Task AgentCancellationFautif.EnvoyerAuModeleAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante\r\n[CancellationTokenCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[CancellationTokenSansTokenDisponible.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[CancellationTokenSurchargeSansToken.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n[CancellationTokenHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "[CancellationTokenFautif.cs] VERDICT : 1 diagnostic(s) -- AGENTGUARD004 x1\r\n",
+      "    AGENTGUARD004 @ 10:15  L'appel à 'Task AgentCancellationFautif.EnvoyerAuModeleAsync(string prompt, CancellationToken cancellationToken = default(CancellationToken))' omet CancellationToken alors que 'cancellationToken' est disponible dans la méthode englobante\r\n",
+      "[CancellationTokenCorrige.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[CancellationTokenSansTokenDisponible.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[CancellationTokenSurchargeSansToken.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "[CancellationTokenHomonyme.cs] VERDICT : PROPRE -- aucun garde-fou AgentGuard declenche\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -1334,12 +2015,21 @@
    "cell_type": "code",
    "execution_count": 17,
    "id": "905bc07f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T10:37:48.082230Z",
+     "iopub.status.busy": "2026-09-03T10:37:48.081929Z",
+     "iopub.status.idle": "2026-09-03T10:37:48.118269Z",
+     "shell.execute_reply": "2026-09-03T10:37:48.117968Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : verifier la propagation dans une fonction locale\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : verifier la propagation dans une fonction locale\r\n"
+     ]
     }
    ],
    "source": [


### PR DESCRIPTION
Grain: MED/notebook-dotnet (REPAIR P0) — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #14419

fix(asipre,#14396): Exercice 1 cellule 10 — Verifier exige args.Length >= 2

## Grain

`MED/notebook-dotnet` (REPAIR P0) — lane `myia-po-2024:CoursIA-2` — prev: `MED/notebook-python #14419`

## Constat (Hermes 2026-09-03T00:25:18Z)

Le review Hermes de la PR #14396 a identifié un défaut fonctionnel dans la cellule 10 (Exercice 1) :

> « Elle invoque `dotnet run --project AgentGuard.Verifier -- AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitValueTask.cs` — **1 seul argument**. Or `AgentGuard.Verifier/Program.cs` au head exige `args.Length >= 2` sinon il imprime `usage: dotnet run -- <fautif.cs> <corrige.cs> ...` et sort. L'output **réellement committé** dans la cellule 10 le prouve : premier stream = banner `usage:`, pas le verdict `PROPRE -- aucun garde-fou AgentGuard declenche` que le body annonce et que l'étudiant doit confronter à sa prédiction. »

**Cause-racine** : la cellule a été écrite avec un seul argument alors que `Program.cs:13` est strict :

```csharp
if (args.Length < 2)
{
    Console.WriteLine("usage: dotnet run -- <fautif.cs> <corrige.cs> [autres.cs ...]");
    return 2;
}
```

L'output réellement committé était donc `usage:` (sortie du programme au lieu d'un verdict) — la confrontation pédagogique prédire/exécuter/vérifier était inopérante.

## Fix (c.883, commit `567ae21286`)

**Patch cellule 10** : ajouter `SyncOverAsyncConfigureAwaitFautif.cs` comme 2ᵉ argument du `dotnet run`. La cellule passe de :

```csharp
var verdictsValueTask = Shell.Run(here, "dotnet",
    "run --project AgentGuard.Verifier -- " +
    "AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitValueTask.cs");
```

à :

```csharp
var verdictsValueTask = Shell.Run(here, "dotnet",
    "run --project AgentGuard.Verifier -- " +
    "AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitFautif.cs " +
    "AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitValueTask.cs");
```

Plus un commentaire explicatif de 9 lignes documentant la contrainte `args.Length >= 2` et le choix pédagogique de la paire fautif/valueTask.

**Valeur pédagogique** : la nouvelle sortie livre
- **2 diagnostics AGENTGUARD005b** sur `ConfigureAwait(false).GetAwaiter().GetResult()` et `ConfigureAwait(true).GetAwaiter().GetResult()` (le terrain fautif est l'archétype du défaut que les agents génèrent en croyant que `ConfigureAwait(false)` « rend ça safe » — ce qui est faux, `GetAwaiter().GetResult()` BLOQUE TOUJOURS le thread).
- **VERDICT PROPRE** sur le terrain `ValueTask` (3 cas : `ValueTaskSync`, `AvecCondition`, `SansGetResult` — chacun couvert par une clause d'exemption distincte).

L'étudiant peut donc **prédire** 2 rouges + 3 propres, **exécuter**, et **vérifier** en reliant chaque cas PROPRE à sa clause d'exemption (filtre sémantique / filtre syntaxique / absence de `GetResult`). La confrontation redevient possible.

## Périmètre

| Fichier | Substance | JSON reformat |
|---|---|---|
| `06-Aspire-GardeFous-Roslyn.ipynb` | cellule 10 : +11 lignes (9 commentaire + 1 argument CLI + 1 ligne cassée) | 796 insertions / 106 suppressions (réorganisation clés nbconvert, normalisation whitespace, 9 lignes probeAddresses banner strippées via `strip_probe_banner.py --apply`) |

**Substance diff vs HEAD de la branche c873** : **cellule 10 uniquement** (toutes les 16 autres cellules code byte-identiques — vérifié par diff programmatique).

## Vérifications

| Check | Résultat |
|---|---|
| `check_exec_ratchet.py origin/main` | CLEAN→CLEAN (séquence `execution_count` 1..17 préservée) |
| `check_papermill_ratchet.py origin/main` | BLOCK_REMOVED (autorisé par #11155 — pas de `metadata.papermill` après nbconvert) |
| `check_source_output_ratchet.py origin/main` | 0 stale cells |
| `check_notebook_navlinks.py 06-…-Roslyn.ipynb` | OK, 0 lien cassé |
| C.1 grep (`raise NotImplementedError\|assert False\|1/0`) | 0 violation (le seul hit `001/002` est dans markdown, pas un `1/0`) |
| `check_pr_perimeter.py 14396 --scan-thread` | VERDICT OK |
| Re-exécution cellule 10 kernel `.net-csharp` local | ec=4, output = `2 diagnostics AGENTGUARD005b` + `VERDICT PROPRE` (au lieu du banner `usage:`) |

## Pourquoi REPAIR, pas un nouveau grain

Le finding Hermes est **un défaut ciblé** sur une cellule précise d'une PR pré-existante. Le reste de la section D1 est solide (le review le dit explicitement : « D1.1 isole bien la borne sémantique partagée » + « les 6 verdicts cell 26 correspondent exactement aux terrains `samples/` au head »). La levée du finding tient le **plancher B.0** (cf CLAUDE.md §B.0 : aucun nit non levé ne survit à un merge).

## Genre / G-VAR

- Tier : MED (ré-exécution complète + change quelque chose : la sortie de la cellule 10)
- Genre : **notebook-dotnet** (REPAIR hérite du genre substance de la PR originale — `variation-protocol.md` §1)
- G-VAR-1 TENU : genre CONTENU

## Voir aussi

- PR **#14396** — PR parente (Hermes LGTM sauf finding cellule 10)
- Issue **#10473** — The Unexpected AI Stack (EPIC parente de l'analyseur AGENTGUARD005b)
- `AgentGuard.Verifier/Program.cs:13` — la garde `args.Length < 2` qui retournait `exit 2` + banner `usage:`
- `AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitFautif.cs` — terrain fautif ajouté (2 diagnostics AGENTGUARD005b)
- `AgentGuard.Verifier/samples/SyncOverAsyncConfigureAwaitValueTask.cs` — terrain valueTask (3 cas PROPRE)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
