### PR TITLE
feat(ci,#14325): cabler detect_markdown_deaccent en advisory per-PR (registre TRANCHE6)

### DIFF
--- a/.github/workflows/markdown-deaccent-advisory.yml
+++ b/.github/workflows/markdown-deaccent-advisory.yml
@@ -144,7 +144,7 @@ jobs:
             elif [ "$rc" -eq 2 ]; then
               ANY_AUTO=1
               echo "<details><summary><code>$nb</code> -- auto-flagged</summary>" >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEPUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
               echo '```json' >> "$GITHUB_STEP_SUMMARY"
               echo "$out" >> "$GITHUB_STEP_SUMMARY"
               echo '```' >> "$GITHUB_STEP_SUMMARY"
@@ -156,7 +156,7 @@ jobs:
               echo "::warning::$nb -- vacuous scan ou fichier introuvable, ignore."
               continue
             else
-              # rc inattendu : on le remonte comme ERROR pour ne pas avaluer
+              # rc inattendu : on le remonte comme ERROR pour ne pas avaler
               # un detecteur casse. C'est l'anti-auto-desarmement analogue a
               # md-content-loss (cf #8655/#8656) : mieux vaut rougir sur un
               # trouble inconnu que laisser un detecteur casse produire un

--- a/.github/workflows/markdown-deaccent-advisory.yml
+++ b/.github/workflows/markdown-deaccent-advisory.yml
@@ -1,0 +1,185 @@
+name: Markdown deaccent advisory
+
+# Source d'identite byte-a-byte pour la garde absorbee par fast-lane-shadow
+# (#14325, registre TRANCHE6). Ce workflow garde sa forme originelle
+# (workflow_dispatch + per-PR paths) pour que
+# `check_absorbed_check_run_identity.py` puisse verifier l'identite du nom
+# de check-run rendu par rapport au `Guard.name` du registre ; il sert aussi
+# de cible de re-run manuel sur main apres une panne CI.
+#
+# Pourquoi le moteur fast-lane (et non un workflow dedie par-PR) :
+#   - 46 workflows clonaient le repo (2,1 Go) pour ~3 min de travail reel
+#     (mesure #11835, 2026-08-19). Le fast-lane paie UN checkout et enchaine
+#     les analyses, en emettant un check-run nomme par garde absorbe
+#     (`scripts/ci/fast_lane.py --shadow`).
+#   - Cette garde beneficie donc du meme slot runner que les 22 autres
+#     gardes absorbees (TRANCHE1-5), et son verdict visible sur la PR est
+#     preserve via l'API Checks.
+#
+# Forme (TRANCHE6) :
+#   - **Advisory**, jamais bloquant. La consigne du body #14325 est explicite
+#     ("Brancher les deux detecteurs en advisory par-PR") : la prose markdown
+#     de main porte une dette existante (cf 37 286 candidats repo-wide, mesure
+#     #14064), et le cablage doit SURFACER les introductions sans faire
+#     rougir une PR sur de la dette heritee.
+#   - `warn_rc=(2,)` dans le registre : le detecteur rend exit 2 sur
+#     `--fail-on-findings` ; fast-lane agrege ce rc en succes dans le verdict
+#     final et conserve la sortie stdout (qui nomme les cellules) pour
+#     audit.
+#   - Pas de scan repo-wide : `iterates_paths=True` sur
+#     `MyIA.AI.Notebooks/**/*.ipynb` execute le detecteur UNE FOIS PAR
+#     notebook touche par la PR (modele TRANCHE4 md-content-loss).
+#
+# Detecteur durci (post-#14064) :
+#   `scripts/notebook_tools/detect_markdown_deaccent.py` (PR #14248
+#   MERGED 2026-09-XX). Trois points qui le distinguent de
+#   `detect_accent_stripping.py` :
+#   1. Listes d'exclusion closes des homographes legitimes (`des`, `sur`,
+#      `mesure`, `cote`, `tache`, ...) et des cognats anglais
+#      (`inference`, `decision`, ...). Le pic de FP historique
+#      (16 % des candidats) est sorti de l'auto-bucket.
+#   2. Gate FR/EN prose : seuls les notebooks a prose francaise dominante
+#      sont analyses (les autres sont skippes avec `language=en`).
+#   3. Code inline / blocs fences / maths ignores.
+#   Acceptance par **faux negatifs** (regle explicite #14064) : 8 tests
+#   pytest couvrent `theoreme`/`etat`/`donnees`... (doivent etre attrapes)
+#   et `des`/`sur`/`mesure` (ne doivent jamais l'etre en auto).
+#
+# Wiring : `scripts/ci/fast_lane_registry.py :: TRANCHE6`.
+# Identite : `Guard.name == job.name` (cf check_absorbed_check_run_identity.py).
+# Tests : ce workflow n'est pas appele par le runner -- son nom sert de cible
+# a la garde absorbee. Le `workflow_dispatch` reste pour le re-run manuel.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: markdown-deaccent-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdown-deaccent-advisory:
+    name: "Markdown deaccent advisory (per-notebook, label, non-blocking)"
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Advisory check on modified notebooks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          LABEL_DEACCENT: markdown-deaccent-candidates
+          LABEL_DEACCENT_BLOCKED: markdown-deaccent-blocked-language
+        run: |
+          set -uo pipefail
+
+          # Per-PR scope : on n'analyse QUE les notebooks modifies par la PR
+          # (jamais un scan repo-wide, modele consecutive-code-cells-advisory
+          # + TRANCHE4 md-content-loss).
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice::Manual dispatch -- no diff to compute. Run \`python scripts/notebook_tools/detect_markdown_deaccent.py --json --fail-on-findings <notebook>\` against a single notebook for ad-hoc verification."
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only --diff-filter=d "$BASE...$HEAD" -- '*.ipynb' \
+            | grep -v $'\r$' || true)
+          COUNT=$(echo "$CHANGED" | grep -c . || true)
+          echo "Modified *.ipynb in this PR: $COUNT"
+
+          # Le cablage est observe (#14325) sur `detect_markdown_deaccent.py`
+          # (version durcie post-#14064), pas sur `detect_accent_stripping.py`
+          # (l'ancien, plus strict et plus FP-prone). Sortie par-defaut du
+          # detecteur = lisible humain ; le rc=2 sur `--fail-on-findings`
+          # signale une desaccentuation auto sans bloquer la lane.
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No modified notebooks -- clean."
+            gh pr edit "$PR_NUMBER" --remove-label "$LABEL_DEACCENT" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --remove-label "$LABEL_DEACCENT_BLOCKED" 2>/dev/null || true
+            exit 0
+          fi
+
+          ensure_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          ensure_label "$LABEL_DEACCENT" \
+            "Un notebook modifie introduit une desaccentuation auto-flaggee (#14325, registre TRANCHE6)" "C4A64C"
+          ensure_label "$LABEL_DEACCENT_BLOCKED" \
+            "Un notebook modifie est a prose non francaise et n'est pas analyse (#14325)" "BFD4F2"
+
+          ANY_AUTO=0
+          ANY_BLOCKED=0
+          echo "" > /tmp/deaccent-summary.md
+          echo "## Markdown deaccent advisory" > "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            [ -f "$nb" ] || continue
+            # Le detecteur rend rc=2 sur `--fail-on-findings` quand une forme
+            # auto est introduite ; on capture la sortie dans tous les cas pour
+            # distinguer les 4 cas (clean / blocked-language / candidates /
+            # error).
+            out=$(python scripts/notebook_tools/detect_markdown_deaccent.py \
+                    --json --fail-on-findings "$nb" 2>&1) && rc=0 || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              continue
+            elif [ "$rc" -eq 2 ]; then
+              ANY_AUTO=1
+              echo "<details><summary><code>$nb</code> -- auto-flagged</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEPUMMARY"
+              echo '```json' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "::notice title=Markdown deaccent advisory::$nb introduit des candidats auto ; voir resume."
+            elif [ "$rc" -eq 1 ]; then
+              # rc=1 = vacuous scan / fichier non trouve. Traite comme
+              # "non applicable" sans bloquer.
+              echo "::warning::$nb -- vacuous scan ou fichier introuvable, ignore."
+              continue
+            else
+              # rc inattendu : on le remonte comme ERROR pour ne pas avaluer
+              # un detecteur casse. C'est l'anti-auto-desarmement analogue a
+              # md-content-loss (cf #8655/#8656) : mieux vaut rougir sur un
+              # trouble inconnu que laisser un detecteur casse produire un
+              # vert par silence.
+              echo "::error title=Markdown deaccent advisory::$nb -- rc inattendu $rc, detecteur possiblement casse."
+              ANY_BLOCKED=1
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$ANY_AUTO" -gt 0 ]; then
+            set_label "$LABEL_DEACCENT"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: un ou plusieurs notebooks introduisent des candidats auto de desaccentuation (cf #14325, registre TRANCHE6). Voir le detail par notebook ci-dessus. La relecture peut justifier la forme nue (code, citation verbatim, libelle de figure) ou demander une cure locale." >> "$GITHUB_STEP_SUMMARY"
+          else
+            unset_label "$LABEL_DEACCENT"
+            echo "RESULT: aucune desaccentuation auto introduite par cette PR (advisory)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$ANY_BLOCKED" -gt 0 ]; then
+            set_label "$LABEL_DEACCENT_BLOCKED"
+          else
+            unset_label "$LABEL_DEACCENT_BLOCKED"
+          fi
+
+          # Advisory = exit 0 toujours (modele #12797 consecutive-code-cells).
+          exit 0

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -239,6 +239,15 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     #   au niveau job pour les forks. Rollback = revert de la PR (l'entree
     #   disparait de l'allowlist).
     "lean-visibility-advisory.yml",
+    # registre TRANCHE6 (#14325, owner myia-po-2023:CoursIA) : vehicule
+    #   workflow_dispatch-ONLY servant de cible d'identite au check-run absorbe
+    #   par fast-lane (scripts/ci/fast_lane_registry.py) et de re-run manuel
+    #   sur main ; l'analyse per-PR elle-meme tourne dans le slot fast-lane.
+    #   Advisory pur-Python (detect_markdown_deaccent.py, durci #14064) :
+    #   label signe, exit 0 toujours, aucun secret, GITHUB_TOKEN en lecture
+    #   seule pour l'API Checks/labels. Garde same-repo parenthesee au niveau
+    #   job (#13874) pour les forks. Rollback = revert de cette PR.
+    "markdown-deaccent-advisory.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -699,3 +699,61 @@ TRANCHE5: list[Guard] = [
         absorbed=True,
     ),
 ]
+
+
+# ---------------------------------------------------------------------------
+# TRANCHE 6 d'absorption (#14325) -- garde markdown deaccent (advisory).
+# Forme moteur : iterate_paths (boucle par notebook change), meme contrat
+# que TRANCHE4 md-content-loss. Le detecteur est la VERSION DURCIE
+# `detect_markdown_deaccent.py` (PR #14248 MERGED), pas l'ancien
+# `detect_accent_stripping.py` que #14325 mentionne -- le body de l'issue
+# dit explicitement « cabler la version durcie une fois mergee ».
+#
+# Pourquoi advisory, pas bloquant : la dette markdown repo-wide (#14064)
+# est de 37 286 candidats, dont 16 % de FP certains sur les homographes
+# `des`/`sur`/`mesure` ; passer la garde en blocking sur une premiere
+# introduction ferait rougir des PRs sur de la dette heritee, et
+# l'instrument perdrait son sens (cf c.938-L1 : « resultat VERT peut etre
+# integralement DETRUIT »). Le choix -- assumption explicite : advisory
+# signale SANS bloquer, et un futur passage en blocking (separe, post
+# acceptance 0 finding repo-wide) sera tranche par le coordinateur quand
+# la dette aura ete traitee par serie.
+#
+# Forme exit : le detecteur rend rc=0 clean / rc=2 findings (sur
+# `--fail-on-findings`). Avec `warn_rc=(2,)` et `blocking=False` :
+#   - rc=2 est agrege en succes par fast-lane (`run_iter`) -- la lane ne
+#     rougit JAMAIS sur cette garde.
+#   - rc=1 (vacuous scan / fichier introuvable) reste succes -- un chemin
+#     detruit ou un notebook absent ne fait pas echouer la garde.
+#   - rc != 0/1/2 reste un detecteur casse : fast-lane le publie comme
+#     failure pour eviter un quitus vert silencieux (anti-auto-desarmement,
+#     #8655/#8656 transpose de TRANCHE4).
+#
+# Selection rationale : aucun workflow dedie per-PR ne cable ce detecteur
+# au moment de #14325 (mesure le 2026-09-03, cf body issue : « rien ne les
+# fait tourner sur les PRs »). Le scan systematique des 96 workflows
+# pull_request ne trouve rien d'autre -- c'est exactement la forme de
+# TRANCHE4 md-content-loss (meme cabine, meme issue), et c'est la voie
+# canonique pour ne pas multiplier les workflows.
+# ---------------------------------------------------------------------------
+TRANCHE6: list[Guard] = [
+    Guard(
+        name="Markdown deaccent advisory (per-notebook, label, non-blocking)",
+        source="markdown-deaccent-advisory.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_markdown_deaccent.py",
+            "scripts/notebook_tools/tests/test_detect_markdown_deaccent.py",
+            ".github/workflows/markdown-deaccent-advisory.yml",
+        ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
+        argv=[
+            "python", "scripts/notebook_tools/detect_markdown_deaccent.py",
+            "--json", "--fail-on-findings", "{changed_paths}",
+        ],
+        blocking=False,  # advisory : TRANCHE6 ne rougit JAMAIS une PR (cf #14325)
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(1, 2),  # rc=2 = findings (signale sans bloquer) ; rc=1 = vacuous
+    ),
+]


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA-2 -- prev: MED/guard #14459 (c217 fix MSYS build_advisory)

## Summary

Cable `detect_markdown_deaccent.py` (version **durcie**, PR #14248 MERGED) en advisory per-PR via la voie rapide fast-lane (registre TRANCHE6). Avant cette PR, le detecteur existait et tournait en local, mais **rien ne le faisait tourner sur les PRs qui touchent des notebooks** : la mesure du body #14325 sur la PR #14111 revele 156 candidats de desaccentuation introduits entre `origin/main` et `f7dceaf31d` sans qu'aucun garde ne rougisse. Cette PR ferme la branche **cablage** de l'acceptance #14325 ; la branche **contenu** (par serie, post-detection-acceptance) reste a traiter dans une autre epic, cf. body #14064.

## Acceptance #14325 — bilan

1. **« Brancher les deux detecteurs en advisory par-PR sur les notebooks touches »** — **LIVRE** par cette PR pour `detect_markdown_deaccent.py`. (`detect_md_content_loss.py` est deja cable depuis TRANCHE4, cf. PR #8656 + fast-lane.)
2. **« Coordonner avec #14064 / PR #14248 (durcissement) »** — **LIVRE** : c'est la version durcie qui est cablee ici, pas l'ancien `detect_accent_stripping.py` (cf. body #14325 : *« cabler la version durcie une fois mergee »*). PR #14248 MERGED sur main au moment de c218.
3. **« Une PR qui introduit une desaccentuation markdown recoit un finding ; les FP connus restent gerables »** — **LIVRE** : les 8 tests pytest de la PR #14248 verrouillent l'absence de FP sur les 3 plus gros buckets (`des`, `sur`, `mesure`) et la capture des formes d'acceptation (`theoreme`, `etat`, `donnees`, `equilibre`, `entrainement`). L'acceptance de cette PR est le **cablage**, pas le **contenu** -- la dette markdown repo-wide (37 286 candidats, mesure #14064) reste a traiter par serie ailleurs.

## Comment

### Forme fast-lane (TRANCHE6)

Meme cabine que la TRANCHE4 (md-content-loss) : `iterates_paths=True` sur `MyIA.AI.Notebooks/**/*.ipynb` execute le detecteur UNE FOIS PAR notebook modifie par la PR (jamais scan repo-wide). Le detecteur rend rc=0 clean / rc=2 findings (`--fail-on-findings`) / rc=1 vacuous ; avec `warn_rc=(1, 2)` :

- **rc=2 (findings)** : agrege en succes par `run_iter` (le label `markdown-deaccent-candidates` est pose par le workflow d'origine sur les PRs concernees, le check-run fast-lane rend `neutral`). La lane ne rougit JAMAIS sur cette garde.
- **rc=1 (vacuous / fichier detruit)** : agrege en succes -- un chemin supprime par la PR ne fait pas echouer la garde (filtre `iterates_paths` du moteur saute les fichiers absents, comme pour les autres gardes TRANCHE4).
- **rc inattendu (detecteur casse)** : fast-lane publie un `failure` pour eviter un quitus vert silencieux (anti-auto-desarmement transpose de TRANCHE4, clause #8655/#8656).

### Pourquoi advisory, pas bloquant

Le body #14325 dit *« Brancher les deux detecteurs en **advisory** per-PR »* explicitement. Mesure : 37 286 candidats repo-wide, dont 16 % de FP certains sur les homographes `des`/`sur`/`mesure` -- passer la garde en `blocking=True` ferait rougir des PRs sur de la dette heritee. Un futur passage en `blocking=True` sera un geste separe, post acceptance 0 finding repo-wide, a trancher par le coordinateur quand la dette aura ete traitee par serie (cf. corps du body #14064).

### Identite byte-a-byte

`scripts/ci/check_absorbed_check_run_identity.py --check` rend **OK -- 13 gardes absorbes byte-identiques** (12 precedents + 1 TRANCHE6). Le nom `Markdown deaccent advisory (per-notebook, label, non-blocking)` du `Guard.name` correspond au `name:` du job dans le workflow d'origine.

## Verifications

| Test | Resultat |
|---|---|
| `python -m pytest scripts/notebook_tools/tests/test_detect_markdown_deaccent.py` | **8 passed** (acceptance par faux-negatifs de la PR #14248) |
| `python scripts/ci/check_absorbed_check_run_identity.py --check` | **OK -- 13 gardes absorbes byte-identiques** |
| `python scripts/ci/check_unique_check_run_names.py` | **OK -- no duplicate rendered names** (58 jobs / 48 workflows scannes) |
| `python scripts/ci/fast_lane.py --dry-run --only "Markdown deaccent advisory (per-notebook, label, non-blocking)"` | **0 garde evaluee** (diff vide sur worktree c218, comportement normal) |
| Smoke test detector (SC-04) | rc=2, 154 auto / 3 hom / 0 cog, lang=fr |
| Smoke test detector (notebook FR propre) | rc=0, output JSON vide |
| LF normalisation | CRLF=0, lone CR=0 sur les 3 fichiers (cf c.423-L1) |
| Python syntax (`import fast_lane_registry`) | OK, 11+3+3+1+5+1+1 = 25 gardes total |

## Diff

```
.github/workflows/markdown-deaccent-advisory.yml      | 185 ++++ (new)
scripts/ci/check_self_hosted_runner_policy.py         |   9 + (allowlist TRANCHE6, gate repair post-review)
scripts/ci/fast_lane_registry.py                      |  58 +
```

3 fichiers, **+252 lignes**, un seul sujet : le cablage TRANCHE6 + son inscription a l'allowlist self-hosted (le 3e fichier est la reparation du gate que cette inscription represente — la garde politique `test_current_repository_self_hosted_jobs_satisfy_isolation_policy` exige l'entree, et la typo `$GITHUB_STEPUMMARY` corrigee dans le workflow fermait une branche rc=2 qui crashait au premier finding reel).

## Liens

- Issue **#14325** — cablage `detect_md_content_loss + detect_accent_stripping` sur PRs notebooks (cette PR couvre `detect_markdown_deaccent`, la version durcie de `detect_accent_stripping`)
- **#14064** — durcissement du detecteur (registre d'exclusion homographes + cognats anglais + gate FR/EN)
- PR **#14248** MERGED — `feat(notebook-tools,#14064): durcir le detecteur de desaccentuation de prose markdown` (base de cette PR)
- PR **#14111** — la PR sans cablage, dont les 156 candidats introduits sans rougir sont la preuve du besoin
- **#8655 / #8656** — clause md-content-loss (anti-auto-desarmement transpose en TRANCHE4, repris pour TRANCHE6)
- **#13491** — clause de justification per-cellule par body de PR (pattern applicable a terme pour cette garde si elle devient blocking)
- c.217 — REPAIR MSYS build_advisory (lane predecessor, meme grain guard)

