### PR TITLE
feat(training,#14462): ablation TSMOM-CF a quatre configurations (Baltas & Kosowski 2017)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L1b_tsmom_cf.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L1b_tsmom_cf.md
@@ -1,0 +1,207 @@
+# L1b — TSMOM-CF (Baltas & Kosowski 2017), ablation à quatre configurations
+
+Distillation de l'article QC research [#15272](https://www.quantconnect.com/research/15272/)
+*« Improved momentum strategy on commodities futures »*, sous l'EPIC #11698.
+Lecture analytique et verdict de différenciation : issue #14462.
+
+## Verdict
+
+| Instrument | Verdict |
+|---|---|
+| **Stratégie** (gate Sharpe, règle C) | **NO BEATS** — les quatre configurations, aux deux fréquences |
+| **Estimateur de volatilité** (Diebold-Mariano) | **NON CONCLUANT** — 0 / 0 / 26 symboles, p médiane 0,579 |
+
+Aucune des trois corrections proposées par l'article ne fait passer le TSMOM
+au-dessus du buy-and-hold sur notre panier. La correction qui change réellement
+le résultat n'est **aucune des trois** : c'est la **fréquence de rebalancement**,
+que l'article ne présente pas comme un levier parce qu'il rebalance mensuellement
+depuis le départ.
+
+## Ce que l'article corrige, et où ça tombe dans notre code
+
+L'article nomme trois faiblesses du TSMOM de Moskowitz-Ooi-Pedersen (2012). Elles
+tombent chacune sur une ligne de notre propre baseline `L1_tsmom.py` :
+
+| axe | `L1_tsmom.py` (Moskowitz 2012) | TSMOM-CF (l'article) |
+|---|---|---|
+| signal | `np.sign(past_return)`, binaire | t-stat 12 mois, capée sur [−1, +1] |
+| volatilité | close-to-close, écart-type glissant | Yang-Zhang (2000), OHLC |
+| allocation | equal-weight 1/N | `CF(rho) = sqrt(N / (1 + (N−1) rho))` |
+
+Un TSMOM-CF complet qui battrait la baseline ne dirait pas **lequel** des trois
+leviers porte l'effet. D'où l'ablation :
+
+    A  sign   + close-to-close + 1/N   (= L1, contrôle de reproduction)
+    B  t-stat + close-to-close + 1/N   (levier 1 seul)
+    C  t-stat + Yang-Zhang     + 1/N   (leviers 1+2)
+    D  t-stat + Yang-Zhang     + CF    (TSMOM-CF complet)
+
+## Résultats — rebalancement mensuel (la fréquence de l'article)
+
+26 symboles à OHLC complet, 2015-01-02 → 2026-05-22, 5 graines (0/1/7/42/99),
+walk-forward 5 folds, gap 21 j, coûts 5 bps actions / 10 bps crypto.
+
+| config | Sharpe brut | Sharpe net | σ inter-graines | Δ vs B&H | edge | turnover/j | net (conv. L1) | verdict |
+|---|---|---|---|---|---|---|---|---|
+| A `sign` + c2c + 1/N | +0,3791 | **+0,3509** | 0,1028 | −0,7101 | −5,76σ | 0,126 | +0,1456 | NO BEATS |
+| B `t-stat` + c2c + 1/N | +0,4748 | **+0,4467** | 0,0810 | −0,6143 | −5,80σ | 0,102 | +0,1324 | NO BEATS |
+| C `t-stat` + YZ + 1/N | +0,4207 | **+0,3878** | 0,1477 | −0,6732 | −4,14σ | 0,116 | +0,0788 | NO BEATS |
+| D `t-stat` + YZ + CF | +0,3995 | **+0,3678** | 0,1546 | −0,6932 | −4,10σ | 0,133 | +0,1593 | NO BEATS |
+
+Baseline buy-and-hold equal-weight, mêmes vues, mêmes graines :
+**Sharpe 1,0610** (écart-type inter-graines 0,0682).
+
+`net (conv. L1)` est le **même résultat** facturé selon la convention de
+`L1_tsmom.py` — un aller-retour plein notionnel par ligne touchée, chaque jour.
+La colonne est là pour que l'écart entre les deux conventions reste **mesuré**
+plutôt qu'affirmé (voir « Deux défauts de `L1_tsmom.py` » plus bas).
+
+## Sensibilité — rebalancement journalier (la fréquence de `L1_tsmom.py`)
+
+| config | Sharpe brut | Sharpe net | Δ vs B&H | edge | turnover/j | net (conv. L1) |
+|---|---|---|---|---|---|---|
+| A | +0,4948 | **−0,5620** | −1,6230 | −18,07σ | 4,606 | −5,4184 |
+| B | +0,5263 | **−0,4508** | −1,5118 | −17,60σ | 3,533 | −7,4136 |
+| C | +0,5813 | **−0,4368** | −1,4978 | −16,91σ | 3,579 | −7,5391 |
+| D | +0,5400 | **−0,4286** | −1,4896 | −16,91σ | 4,129 | −5,4914 |
+
+## Trois lectures
+
+### 1. La fréquence de rebalancement domine les trois leviers de l'article
+
+Le notionnel déplacé par jour passe de **3,5-4,6 en journalier à 0,10-0,13 en
+mensuel** — un facteur 31 à 37. C'est assez pour retourner le **signe** du Sharpe
+net : les mêmes quatre configurations rendent −0,43 à −0,56 en journalier et
++0,35 à +0,45 en mensuel.
+
+Le mécanisme est mécanique et n'a rien de subtil : la position est
+`signal × (vol_cible / vol_estimée)`. Les deux facteurs bougent tous les jours,
+donc une position recalculée quotidiennement **dérive tous les jours** et se
+refacture tous les jours, même quand le signal ne change pas de camp. Une
+position tenue entre deux dates de rebalancement ne coûte rien.
+
+Le TSMOM de Moskowitz (2012) comme celui de Baltas & Kosowski (2017) sont des
+stratégies à rebalancement **mensuel**. Tester l'article à une fréquence qu'il
+n'emploie pas ne serait pas un test de l'article.
+
+### 2. Sous la bonne fréquence, seul le levier 1 travaille — et le classement s'inverse
+
+| levier | effet sur le Sharpe brut (mensuel) | effet (journalier) |
+|---|---|---|
+| 1 — t-stat au lieu de `sign` (B−A) | **+0,096** | +0,032 |
+| 2 — Yang-Zhang au lieu de c2c (C−B) | **−0,054** | +0,055 |
+| 3 — CF au lieu de 1/N (D−C) | **−0,021** | −0,041 |
+
+Le levier 2 **change de signe** entre les deux fréquences. Lu en journalier
+seulement, on conclurait que Yang-Zhang améliore la performance brute ; lu à la
+fréquence de l'article, il la dégrade. C'est le contrôle qui justifie de ne pas
+publier une ablation sans avoir vérifié qu'elle est menée à la fréquence de la
+stratégie testée.
+
+Le levier 1 est le seul qui tienne aux deux fréquences, et c'est cohérent avec sa
+nature : passer de `sign` (binaire) à une t-stat capée conserve l'information
+d'**intensité** de la tendance, là où le signe la jette.
+
+### 3. Yang-Zhang est moins biaisé, pas plus précis
+
+Test de Diebold-Mariano sur une perte de **précision** (`loss_fn="mse"`),
+Yang-Zhang contre close-to-close, cible = volatilité réalisée sur les 21 jours
+**suivants**, HAC à `max_lag = 20` pour couvrir le recouvrement des fenêtres.
+
+- **0 victoire Yang-Zhang, 0 victoire close-to-close, 26 non concluants** sur 26
+  symboles ; p médiane **0,579**.
+- Biais signé moyen — `mean(estimateur − réalisé)` : **YZ +0,002512**,
+  **c2c +0,012828**. Yang-Zhang est ~5× moins biaisé.
+
+Les deux mesures ne disent pas la même chose et ne se remplacent pas : le DM
+mesure la **précision** (l'erreur quadratique), le biais mesure le **décalage
+systématique**. Yang-Zhang gagne sur le second sans gagner sur le premier — un
+écart qu'un rapport ne citant que le DM effacerait, et qu'un rapport ne citant
+que le biais surinterpréterait (cf #10938 / #10956 : `loss_fn="linear"` est un
+contrôle de biais, jamais la jambe de précision d'un verdict).
+
+Le DM ne dit **rien** de la stratégie. Il tranche la claim (b) de l'article, et
+rien d'autre : l'estimateur de volatilité est le seul des trois leviers qui soit
+une **prévision** au sens propre, donc le seul auquel un DM s'applique
+honnêtement.
+
+## Portée — ce que ce module ne teste pas
+
+L'article backteste des **futures de matières premières** sur **janvier 2018 →
+septembre 2019**, soit 20 mois, et y rapporte Sharpe 0,198 pour TSMOM-CF contre
+−0,746 pour le TSMOM de base et 0,46 pour SPY sur la même fenêtre. Notre panier
+anti-biais est à dominante **actions + crypto** sur **11 ans**, et son
+buy-and-hold rend 1,06 : la barre est incomparablement plus haute.
+
+Un NO BEATS ici ne réfute donc pas l'article ; il dit que **les trois corrections
+ne transportent pas leur effet** de son univers au nôtre. Le seul résultat qui se
+transporte est le classement des leviers entre eux, et il est mesuré ci-dessus.
+
+À noter que l'article, dans sa propre fenêtre, ne bat pas non plus son benchmark :
+0,198 contre 0,46 pour SPY.
+
+## Ce que les graines perturbent
+
+Une graine tire une **vue du problème**, et la même vue sert au modèle et à sa
+baseline (comparaison appariée) :
+
+- un sous-panier de 80 % des symboles, sans remise ;
+- un décalage d'origine de 0 à 40 jours ouvrés — qui décale aussi la **grille de
+  rebalancement**, donc la date d'entrée.
+
+C'est ce qui rend le σ inter-graines du gate mesurable. Voir le défaut symétrique
+de `L1_tsmom.py` ci-dessous.
+
+## Deux défauts de `L1_tsmom.py`, signalés et non corrigés ici
+
+Suivis dans l'issue **#14470** (mesures reproduites, acceptance écrite).
+
+Trouvés en construisant le contrôle de reproduction (config A). Ils ne sont
+**pas** corrigés dans ce module — principe 3 du `CLAUDE.md` : signaler le mauvais
+code découvert, le traiter en sujet séparé.
+
+1. **Boucle de graines inerte.** `L1_tsmom.py:124` construit
+   `rng = np.random.default_rng(seed)` et ne s'en sert jamais (le symbole
+   n'apparaît qu'une fois dans le fichier) ; sa boucle buy-and-hold (l. 233) n'en
+   construit même pas. Le splitter walk-forward étant déterministe, les quatre
+   graines rendent des nombres **identiques** : l'écart-type inter-graines y vaut
+   0, donc `t_stat = delta / 0 → 0`, donc la clause `t_stat >= 2.0` de son gate
+   rend le verdict `BEATS` **structurellement inatteignable**. Son gate
+   multi-graines ne mesure rien. Écrit comme test :
+   `test_zero_dispersion_can_never_reach_beats`.
+
+2. **Modèle de coûts sur-facturé.** `L1_tsmom.py:158-173` compte un ordre dès
+   qu'une position bouge, puis facture un aller-retour **plein notionnel** :
+   `trades_per_day * 2 * cost_per_trade / n_assets`. Comme la position dérive
+   chaque jour avec la volatilité estimée, chaque ligne est facturée chaque jour.
+   Mesuré sur notre panier en journalier : 13,5 « ordres » par jour pour 21
+   lignes. L'écart est la colonne `net (conv. L1)` des deux tableaux ci-dessus.
+
+Le second explique en partie le NO BEATS publié de L1 — mais **en partie
+seulement** : sous facturation proportionnelle au turnover **et** rebalancement
+mensuel, le Sharpe net redevient positif (+0,35 à +0,45) et le verdict reste
+NO BEATS, cette fois pour la bonne raison — la stratégie est simplement
+en dessous du buy-and-hold.
+
+## Reproduction
+
+```bash
+cd MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts
+
+# tests (23, chacun avec son contrôle positif)
+python -m pytest tests/test_l1b_tsmom_cf.py -q
+
+# ablation à la fréquence de l'article (défaut)
+python L1b_tsmom_cf.py --seeds 0 1 7 42 99
+
+# sensibilité à la fréquence de L1_tsmom.py
+python L1b_tsmom_cf.py --seeds 0 1 7 42 99 --rebalance 1 \
+    --output ../checkpoints/l1b_tsmom_cf/l1b_results_daily.json
+```
+
+Sorties dans `checkpoints/l1b_tsmom_cf/` (répertoire gitignoré — les nombres de
+cette page sont donc la trace committée de la mesure).
+
+## Script
+
+`scripts/L1b_tsmom_cf.py` · tests `scripts/tests/test_l1b_tsmom_cf.py`

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1b_tsmom_cf.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1b_tsmom_cf.py
@@ -1,0 +1,686 @@
+"""L1b -- TSMOM-CF : time-series momentum corrige (Baltas & Kosowski, 2017).
+
+Distillation de l'article QC research #15272 ("Improved momentum strategy on
+commodities futures"), sous l'EPIC #11698 -- voir l'issue #14462 pour la lecture
+analytique et le verdict de differenciation.
+
+L'article nomme TROIS faiblesses du TSMOM traditionnel. Elles tombent une par une
+sur trois lignes de notre propre baseline `L1_tsmom.py`, qui a rendu NO BEATS :
+
+    axe          L1_tsmom.py (Moskowitz 2012)      TSMOM-CF (l'article)
+    ---------    ------------------------------    ----------------------------
+    signal       np.sign(past_return), binaire     t-stat 12 m capee sur [-1,+1]
+    volatilite   close-to-close rolling std        Yang-Zhang OHLC (2000)
+    allocation   equal-weight 1/N                  CF(rho) = sqrt(N/(1+(N-1)rho))
+
+Ce module ne remplace pas L1 : il l'entoure d'une ABLATION a quatre configurations
+qui isole la contribution de chaque correctif -- un TSMOM-CF complet qui battrait
+la baseline ne dirait pas LEQUEL des trois leviers porte l'effet.
+
+    A  sign      + close-to-close + 1/N     (= L1, controle de reproduction)
+    B  t-stat    + close-to-close + 1/N     (levier 1 seul)
+    C  t-stat    + Yang-Zhang     + 1/N     (leviers 1+2)
+    D  t-stat    + Yang-Zhang     + CF      (TSMOM-CF complet)
+
+Deux verdicts distincts, sur deux instruments distincts -- ils ne se remplacent
+pas l'un l'autre :
+
+  * VERDICT STRATEGIE -- gate Sharpe de la regle C : walk-forward 5 folds,
+    >= 4 graines, couts de transaction, baseline buy-and-hold equal-weight,
+    edge >= 2 sigma inter-graines. Rend BEATS / NO BEATS / INCONCLUSIVE.
+
+  * VERDICT ESTIMATEUR -- test de Diebold-Mariano sur une perte de PRECISION
+    (`loss_fn="mse"`), Yang-Zhang contre close-to-close, cible = volatilite
+    realisee forward. C'est le seul des trois leviers qui soit une PREVISION au
+    sens propre, donc le seul auquel un DM s'applique honnetement. Le DM ne dit
+    RIEN de la strategie : il tranche la claim (b) de l'article, et rien d'autre.
+    Un rapport de biais signe accompagne chaque estimateur, pour que le cas
+    "l'ecart est porte par le biais et non par la precision" reste visible
+    (cf #10938/#10956 : `loss_fn="linear"` est un controle de biais, jamais la
+    jambe de precision d'un verdict).
+
+CE QUE LES GRAINES PERTURBENT -- et pourquoi ce n'est pas ce que fait L1
+-----------------------------------------------------------------------
+`L1_tsmom.py:124` construit `rng = np.random.default_rng(seed)` et ne s'en sert
+jamais ; sa boucle buy-and-hold (l. 233) n'en construit meme pas. Le splitter
+walk-forward etant deterministe, les quatre graines de L1 rendent des nombres
+IDENTIQUES : l'ecart-type inter-graines y vaut 0, donc `t_stat = delta/0 -> 0`,
+donc la clause `t_stat >= 2.0` de son gate rend le verdict BEATS structurellement
+inatteignable. Son gate multi-graines ne mesure rien.
+
+Ici la graine tire une VUE du probleme, et la meme vue sert au modele et a sa
+baseline (comparaison appariee) :
+
+  * un sous-panier de PANEL_FRACTION des symboles, sans remise ;
+  * un decalage d'origine de 0 a MAX_ORIGIN_OFFSET jours ouvres.
+
+Ce sont deux perturbations de robustesse usuelles, et elles produisent une
+dispersion REELLE : le sigma du gate redevient une mesure. Le defaut de L1 est
+signale a part -- ce module ne le corrige pas chez lui (hors scope, cf principe 3
+du CLAUDE.md : signaler le mauvais code decouvert, le traiter en sujet separe).
+Les deux defauts de L1 sont mesures et suivis dans l'issue #14470.
+
+Usage :
+    python L1b_tsmom_cf.py
+    python L1b_tsmom_cf.py --dry-run
+    python L1b_tsmom_cf.py --seeds 0 1 7 42 99
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+CHECKPOINTS_DIR = SCRIPTS_DIR.parent / "checkpoints" / "l1b_tsmom_cf"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from panier_loader import PANIER_GROUPS, get_panier_symbols, load_panier  # noqa: E402
+from walk_forward import WalkForwardSplitter  # noqa: E402
+from transaction_costs import TransactionCostModel  # noqa: E402
+from baselines import sharpe_from_returns  # noqa: E402
+from dm_test import diebold_mariano_test  # noqa: E402
+
+ALL_SYMBOLS = get_panier_symbols()
+CRYPTO_SYMBOLS = set(PANIER_GROUPS.get("crypto", []))
+
+# Cost models -- identiques a L1_tsmom.py, pour que la comparaison A-vs-L1 tienne.
+EQUITY_COST = TransactionCostModel(
+    commission_bps=1.0, bid_ask_spread_bps=2.0,
+    market_impact_coeff=0.05, daily_volume=5_000_000, slippage_bps=2.0,
+)
+CRYPTO_COST = TransactionCostModel(
+    commission_bps=2.0, bid_ask_spread_bps=3.0,
+    market_impact_coeff=0.05, daily_volume=1_000_000, slippage_bps=5.0,
+)
+
+TARGET_VOL = 0.15      # volatilite annualisee cible (identique a L1)
+VOL_WINDOW_YZ = 21     # fenetre Yang-Zhang -- valeur de l'article
+VOL_WINDOW_C2C = 63    # fenetre close-to-close -- valeur de L1, preservee
+CORR_WINDOW = 63       # ~3 mois de correlation par paires -- valeur de l'article
+TSTAT_LOOKBACK = 252   # 12 mois -- valeur de l'article
+CF_BOUNDS = (0.5, 3.0)
+ANNUALISE = np.sqrt(252.0)
+
+PANEL_FRACTION = 0.8     # part du panier tiree par graine
+MAX_ORIGIN_OFFSET = 40   # decalage d'origine maximal, en jours ouvres
+REBALANCE_MONTHLY = 21   # frequence de l'article : mensuelle (~21 jours ouvres)
+REBALANCE_DAILY = 1      # frequence de L1_tsmom.py : quotidienne
+
+CONFIGS = {
+    "A_sign_c2c_eqw":  {"signal": "sign",  "vol": "c2c", "alloc": "eqw"},
+    "B_tstat_c2c_eqw": {"signal": "tstat", "vol": "c2c", "alloc": "eqw"},
+    "C_tstat_yz_eqw":  {"signal": "tstat", "vol": "yz",  "alloc": "eqw"},
+    "D_tstat_yz_cf":   {"signal": "tstat", "vol": "yz",  "alloc": "cf"},
+}
+
+
+# --------------------------------------------------------------------------
+# Levier 2 -- estimateurs de volatilite
+# --------------------------------------------------------------------------
+
+def yang_zhang_vol(df: pd.DataFrame, window: int = VOL_WINDOW_YZ) -> pd.Series:
+    """Volatilite annualisee de Yang-Zhang (2000), a partir de l'OHLC.
+
+    sigma_YZ^2 = sigma_OJ^2 + k * sigma_SD^2 + (1 - k) * sigma_RS^2
+    k = 0.34 / (1.34 + (N+1)/(N-1))
+
+    - sigma_OJ : saut overnight, log(open_t / close_{t-1})
+    - sigma_SD : open-to-close, log(close_t / open_t)
+    - sigma_RS : Rogers-Satchell (1991), insensible a la derive
+    """
+    o, h, low, c = df["Open"], df["High"], df["Low"], df["Close"]
+    prev_c = c.shift(1)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        log_oc_prev = np.log(o / prev_c)
+        log_co = np.log(c / o)
+        rs = (np.log(h / c) * np.log(h / o) + np.log(low / c) * np.log(low / o))
+
+    var_oj = log_oc_prev.rolling(window).var(ddof=1)
+    var_sd = log_co.rolling(window).var(ddof=1)
+    var_rs = rs.rolling(window).mean()
+
+    k = 0.34 / (1.34 + (window + 1.0) / (window - 1.0))
+    var_yz = (var_oj + k * var_sd + (1.0 - k) * var_rs).clip(lower=0.0)
+    return np.sqrt(var_yz) * ANNUALISE
+
+
+def close_to_close_vol(closes: pd.Series, window: int = VOL_WINDOW_C2C) -> pd.Series:
+    """Volatilite annualisee close-to-close -- l'estimateur de `L1_tsmom.py`."""
+    return closes.pct_change().rolling(window).std() * ANNUALISE
+
+
+def realised_forward_vol(closes: pd.Series, window: int = VOL_WINDOW_YZ) -> pd.Series:
+    """Cible du DM : volatilite realisee sur les `window` jours SUIVANTS.
+
+    Decalee de -window pour que la valeur a t soit strictement posterieure a t --
+    sans ce decalage, l'estimateur se comparerait a une fenetre qui le contient,
+    et l'exercice ne serait plus une prevision.
+    """
+    daily = closes.pct_change()
+    return (daily.rolling(window).std() * ANNUALISE).shift(-window)
+
+
+# --------------------------------------------------------------------------
+# Levier 1 -- signaux
+# --------------------------------------------------------------------------
+
+def sign_signal(closes: pd.Series, lookback: int = TSTAT_LOOKBACK) -> pd.Series:
+    """TSMOM classique : sign(rendement passe). Binaire, +/-1."""
+    return np.sign(closes.pct_change(lookback))
+
+
+def tstat_signal(closes: pd.Series, lookback: int = TSTAT_LOOKBACK) -> pd.Series:
+    """TREND de l'article : t-stat des log-rendements quotidiens, capee sur [-1,+1].
+
+    t = mean(r) / (std(r) / sqrt(n)) sur la fenetre. |t| > 1 sature a +/-1 ; en
+    deca, la t-stat elle-meme est le signal -- l'exposition devient CONTINUE et se
+    reduit quand la tendance est faiblement etablie.
+    """
+    log_ret = np.log(closes / closes.shift(1))
+    mean = log_ret.rolling(lookback).mean()
+    std = log_ret.rolling(lookback).std(ddof=1)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        t = mean / (std / np.sqrt(float(lookback)))
+    return t.clip(lower=-1.0, upper=1.0)
+
+
+# --------------------------------------------------------------------------
+# Levier 3 -- facteur de correlation
+# --------------------------------------------------------------------------
+
+def correlation_factor(signals: pd.DataFrame, returns: pd.DataFrame,
+                       window: int = CORR_WINDOW) -> pd.Series:
+    """CF(rho_bar) = sqrt(N / (1 + (N-1) rho_bar)), rho_bar ponderee par les signaux.
+
+    rho_bar = 2 * sum_{i<j} X_i X_j rho_ij / (N (N-1)) : la correlation moyenne par
+    paires PONDEREE par le produit des signaux -- deux actifs correles tenus en sens
+    opposes se diversifient, et rho_bar doit le voir.
+
+    CF monte le levier quand le panier se decorrele et le baisse quand il se
+    synchronise. Borne a CF_BOUNDS : sans borne, un rho_bar proche de -1/(N-1)
+    envoie le denominateur vers zero et le levier vers l'infini.
+    """
+    cols = [c for c in returns.columns if c in signals.columns]
+    ret = returns[cols].to_numpy(dtype=float)
+    sig = signals[cols].reindex(returns.index).to_numpy(dtype=float)
+    n_days = ret.shape[0]
+    out = np.full(n_days, np.nan)
+
+    for t in range(window, n_days):
+        win = ret[t - window:t]
+        x = sig[t]
+        usable = ~np.isnan(x) & (np.isfinite(win).sum(axis=0) == window)
+        n_eff = int(usable.sum())
+        if n_eff < 2:
+            continue
+        sub = win[:, usable]
+        if np.any(sub.std(axis=0) < 1e-12):
+            continue
+        rho = np.corrcoef(sub, rowvar=False)
+        xv = x[usable]
+        pair = (np.outer(xv, xv) * rho)[np.triu_indices(n_eff, k=1)]
+        pair = pair[np.isfinite(pair)]
+        if pair.size == 0:
+            continue
+        rho_bar = float(2.0 * pair.sum() / (n_eff * (n_eff - 1)))
+        denom = 1.0 + (n_eff - 1) * rho_bar
+        out[t] = (CF_BOUNDS[1] if denom <= 1e-6
+                  else float(np.clip(np.sqrt(n_eff / denom), *CF_BOUNDS)))
+
+    return pd.Series(out, index=returns.index).ffill()
+
+
+# --------------------------------------------------------------------------
+# Pre-calcul -- une seule passe par symbole, reutilisee par les 4 configs
+# --------------------------------------------------------------------------
+
+def precompute(panier: dict) -> dict:
+    """Signaux et volatilites des deux variantes, alignes sur un index commun."""
+    symbols = [s for s in ALL_SYMBOLS if s in panier]
+    frames = {"close": {}, "sign": {}, "tstat": {}, "yz": {}, "c2c": {}}
+    for sym in symbols:
+        df = panier[sym]
+        frames["close"][sym] = df["Close"]
+        frames["sign"][sym] = sign_signal(df["Close"])
+        frames["tstat"][sym] = tstat_signal(df["Close"])
+        frames["yz"][sym] = yang_zhang_vol(df)
+        frames["c2c"][sym] = close_to_close_vol(df["Close"])
+
+    out = {k: pd.DataFrame(v).sort_index() for k, v in frames.items()}
+    index = out["close"].index
+    for key in list(out):
+        out[key] = out[key].reindex(index)
+    # rendement du LENDEMAIN : la position de t est realisee en t+1
+    out["fwd"] = out["close"].pct_change().shift(-1)
+    out["daily"] = out["close"].pct_change()
+    return out
+
+
+def seed_view(pre: dict, seed: int) -> tuple:
+    """Vue tiree par la graine : sous-panier + decalage d'origine.
+
+    La MEME vue sert au modele et a sa baseline : la comparaison reste appariee,
+    et le sigma inter-graines mesure la sensibilite au panier et a la fenetre,
+    pas un bruit de tirage non partage.
+    """
+    rng = np.random.default_rng(seed)
+    symbols = list(pre["close"].columns)
+    k = max(3, int(round(PANEL_FRACTION * len(symbols))))
+    chosen = sorted(rng.choice(symbols, size=k, replace=False).tolist())
+    offset = int(rng.integers(0, MAX_ORIGIN_OFFSET + 1))
+    return chosen, offset
+
+
+# --------------------------------------------------------------------------
+# Construction des positions
+# --------------------------------------------------------------------------
+
+def build_positions(pre: dict, config: dict, symbols: list,
+                    offset: int = 0, rebalance: int = REBALANCE_MONTHLY) -> tuple:
+    """Rend (positions, rendements_forward) pour une configuration et une vue.
+
+    La position est `signal * (vol_cible / vol_estimee)`, clippee sur [-1, +1]
+    comme dans l'article, puis multipliee par CF si l'allocation le demande.
+
+    REBALANCEMENT -- ce parametre decide le verdict, il n'est pas cosmetique.
+    Le TSMOM de Moskowitz (2012) comme celui de Baltas & Kosowski (2017) sont
+    des strategies a rebalancement MENSUEL. Une position gardee telle quelle
+    entre deux dates de rebalancement ne coute rien ; recalculee chaque jour,
+    elle derive avec la volatilite estimee et se refacture chaque jour.
+    Mesure sur notre panier (26 symboles, 5 graines, 2015-2026) : le notionnel
+    deplace par jour passe de 3,5-4,6 en journalier a 0,10-0,13 en mensuel, un
+    facteur 31 a 37. C'est assez pour retourner le SIGNE du Sharpe net : les memes
+    quatre configurations rendent -0,43 a -0,56 en journalier et +0,35 a +0,45
+    en mensuel. Le verdict contre la baseline reste NO BEATS dans les deux cas,
+    mais pour deux raisons opposees -- en journalier les couts mangeaient un
+    brut positif, en mensuel la strategie est simplement en dessous du
+    buy-and-hold (Sharpe 1,06 sur un panier a dominante actions).
+    Tester l'article a une frequence qu'il n'emploie pas ne serait pas un test
+    de l'article. Le journalier reste disponible en sensibilite (--rebalance).
+    """
+    sig_df = pre[config["signal"]][symbols]
+    vol_df = pre[config["vol"]][symbols]
+    fwd = pre["fwd"][symbols]
+
+    vol_scale = TARGET_VOL / vol_df.clip(lower=0.01)
+    positions = (sig_df * vol_scale).clip(lower=-1.0, upper=1.0)
+
+    if config["alloc"] == "cf":
+        # CF depend de la COMPOSITION du panier (le N de la formule) : il se
+        # recalcule sur le sous-panier de la graine, jamais sur le panier entier.
+        cf = correlation_factor(sig_df, pre["daily"][symbols])
+        positions = positions.mul(cf, axis=0).clip(lower=-1.0, upper=1.0)
+
+    keep = positions.notna().any(axis=1) & fwd.notna().any(axis=1)
+    positions, fwd = positions.loc[keep], fwd.loc[keep]
+    if offset:
+        positions, fwd = positions.iloc[offset:], fwd.iloc[offset:]
+
+    if rebalance > 1:
+        # La grille part du debut de la vue : le decalage d'origine tire par la
+        # graine perturbe donc aussi le CALENDRIER de rebalancement, ce qui est
+        # une sensibilite reelle et souhaitable.
+        held = pd.DataFrame(np.nan, index=positions.index,
+                            columns=positions.columns)
+        held.iloc[::rebalance] = positions.iloc[::rebalance]
+        positions = held.ffill()
+
+    return positions, fwd
+
+
+def _avg_cost_rate(symbols: list) -> float:
+    """Cout unitaire moyen, en fraction du notionnel deplace (aller simple)."""
+    n_crypto = sum(1 for s in symbols if s in CRYPTO_SYMBOLS)
+    n_equity = len(symbols) - n_crypto
+    return ((n_equity * EQUITY_COST.cost_per_trade(100)
+             + n_crypto * CRYPTO_COST.cost_per_trade(100)) / max(len(symbols), 1))
+
+
+def _walk_forward_returns(pos, ret, cost_rate: float,
+                          n_splits: int, gap: int) -> dict:
+    """Rendements OOS bruts / nets, turnover et ordres, concatenes sur les folds.
+
+    COUT PROPORTIONNEL AU TURNBOVER -- et pourquoi ce n'est pas ce que fait L1.
+
+    `L1_tsmom.py:158-173` compte un ordre des que la position bouge
+    (`pos_changes > 0`) puis facture un aller-retour sur 100 % du notionnel :
+    `trades_per_day * 2 * cost_per_trade / n_assets`. Or la position est
+    `signal * vol_cible / vol_estimee` : la volatilite estimee derive tous les
+    jours, donc la position bouge tous les jours, donc CHAQUE actif est facture
+    tous les jours comme s'il etait entierement liquide et rachete. Mesure sur
+    notre panier (config A, graine 0) : 13,5 "ordres" par jour pour 21 actifs,
+    Sharpe brut +0,573 -> net -5,59. Le -5,59 ne mesure pas la strategie, il
+    mesure la facturation.
+
+    Le cout reel d'un rebalancement est proportionnel a la TAILLE du deplacement :
+    `|delta position| * cout_unitaire`. C'est la convention retenue ici.
+
+    La convention de L1 est conservee en colonne `net_l1_convention`, non pour
+    l'utiliser mais pour que l'ecart reste chiffre : c'est la preuve du defaut,
+    et elle appartient au dossier plutot qu'a une affirmation.
+    """
+    n_assets = pos.shape[1]
+    gross_all, net_all, net_l1_all, turnover_all, trades_all = [], [], [], [], []
+
+    splitter = WalkForwardSplitter(n_splits=n_splits, gap=gap)
+    for _train_idx, test_idx in splitter.split(pos):
+        if len(test_idx) == 0:
+            continue
+        p = np.nan_to_num(pos[test_idx], nan=0.0)
+        r = ret[test_idx]
+        gross = np.nansum(p * r, axis=1) / n_assets
+
+        deltas = np.abs(np.diff(p, axis=0, prepend=np.zeros_like(p[0:1])))
+        turnover = np.sum(deltas, axis=1)          # notionnel reellement deplace
+        trades = np.sum(deltas > 1e-9, axis=1)     # nombre de lignes touchees
+
+        net = gross - turnover * cost_rate / n_assets
+        net_l1 = gross - trades * 2 * cost_rate / n_assets
+
+        ok = ~(np.isnan(gross) | np.isnan(net))
+        gross_all.extend(gross[ok].tolist())
+        net_all.extend(net[ok].tolist())
+        net_l1_all.extend(net_l1[ok].tolist())
+        turnover_all.extend(turnover[ok].tolist())
+        trades_all.extend(trades[ok].tolist())
+
+    return {"gross": np.array(gross_all), "net": np.array(net_all),
+            "net_l1": np.array(net_l1_all),
+            "turnover": np.array(turnover_all), "trades": trades_all}
+
+
+def run_config(pre: dict, config: dict, seeds: list, n_splits: int = 5,
+               gap: int = 21, rebalance: int = REBALANCE_MONTHLY) -> dict:
+    """Walk-forward multi-graines pour une configuration de l'ablation."""
+    seed_results = []
+    for seed in seeds:
+        symbols, offset = seed_view(pre, seed)
+        positions, fwd = build_positions(pre, config, symbols, offset, rebalance)
+        res = _walk_forward_returns(
+            positions.to_numpy(dtype=float), fwd.to_numpy(dtype=float),
+            _avg_cost_rate(symbols), n_splits, gap)
+        gross, net = res["gross"], res["net"]
+
+        if len(gross) > 10:
+            entry = {
+                "seed": seed, "n_symbols": len(symbols), "origin_offset": offset,
+                "gross_sharpe": round(float(sharpe_from_returns(pd.Series(gross))), 4),
+                "net_sharpe": round(float(sharpe_from_returns(pd.Series(net))), 4),
+                "net_sharpe_l1_convention": round(
+                    float(sharpe_from_returns(pd.Series(res["net_l1"]))), 4),
+                "net_cagr": round(float(np.prod(1 + net) ** (252 / len(net)) - 1), 4),
+                "mean_daily_turnover": round(float(np.mean(res["turnover"])), 4),
+                "total_trades": int(np.sum(res["trades"])), "n_oos": int(len(gross)),
+            }
+        else:
+            entry = {"seed": seed, "n_symbols": len(symbols), "origin_offset": offset,
+                     "gross_sharpe": 0.0, "net_sharpe": 0.0,
+                     "net_sharpe_l1_convention": 0.0, "net_cagr": 0.0,
+                     "mean_daily_turnover": 0.0, "total_trades": 0,
+                     "n_oos": int(len(gross))}
+        seed_results.append(entry)
+
+    return {"config": config, "rebalance": rebalance, "seeds": seed_results}
+
+
+def run_buyhold_baseline(pre: dict, seeds: list,
+                         n_splits: int = 5, gap: int = 21) -> dict:
+    """Buy-and-hold equal-weight, sur EXACTEMENT les vues tirees par les graines."""
+    seed_results = []
+    for seed in seeds:
+        symbols, offset = seed_view(pre, seed)
+        fwd = pre["fwd"][symbols].dropna(how="all")
+        if offset:
+            fwd = fwd.iloc[offset:]
+        ret_arr = fwd.to_numpy(dtype=float)
+
+        fold = []
+        splitter = WalkForwardSplitter(n_splits=n_splits, gap=gap)
+        for _tr, te in splitter.split(ret_arr):
+            if len(te) == 0:
+                continue
+            port = np.nanmean(ret_arr[te], axis=1)
+            fold.extend(port[~np.isnan(port)].tolist())
+
+        arr = np.array(fold)
+        sharpe = float(sharpe_from_returns(pd.Series(arr))) if len(arr) > 10 else 0.0
+        seed_results.append({"seed": seed, "n_symbols": len(symbols),
+                             "origin_offset": offset, "sharpe": round(sharpe, 4),
+                             "n_oos": int(len(arr))})
+    return {"model": "equal_weight_bh", "seeds": seed_results}
+
+
+# --------------------------------------------------------------------------
+# Verdicts
+# --------------------------------------------------------------------------
+
+def compute_verdict(cfg_results: dict, bh_results: dict) -> dict:
+    """Gate Sharpe de la regle C -- meme forme que `L1_tsmom.compute_verdict`.
+
+    A la difference de L1, `std_net_sharpe` y est une VRAIE dispersion : les
+    graines tirent des vues distinctes (cf le docstring du module). Un
+    `edge_sigma` nul signalerait donc un probleme, la ou chez L1 c'etait l'etat
+    nominal.
+    """
+    model = [s["net_sharpe"] for s in cfg_results["seeds"]]
+    base = [s["sharpe"] for s in bh_results["seeds"]]
+    mean_m, mean_b = float(np.mean(model)), float(np.mean(base))
+    std_m = float(np.std(model, ddof=1)) if len(model) > 1 else 0.0
+    std_b = float(np.std(base, ddof=1)) if len(base) > 1 else 0.0
+    delta = mean_m - mean_b
+    delta_std = float(np.sqrt(std_m ** 2 + std_b ** 2))
+    t_stat = delta / delta_std if delta_std > 1e-10 else 0.0
+    positive = sum(1 for m, b in zip(model, base) if m > b + 0.10)
+
+    if delta > 0.10 and t_stat >= 2.0 and positive >= max(len(model) * 3 // 4, 1):
+        verdict = "BEATS"
+    elif delta <= 0:
+        verdict = "NO BEATS"
+    else:
+        verdict = "INCONCLUSIVE"
+
+    return {"verdict": verdict,
+            "mean_net_sharpe": round(mean_m, 4), "std_net_sharpe": round(std_m, 4),
+            "mean_bh_sharpe": round(mean_b, 4), "std_bh_sharpe": round(std_b, 4),
+            "delta_sharpe": round(delta, 4), "edge_sigma": round(t_stat, 4),
+            "seeds_positive": positive, "n_seeds": len(model)}
+
+
+def vol_estimator_dm(panier: dict) -> dict:
+    """Verdict ESTIMATEUR : Yang-Zhang contre close-to-close, par symbole.
+
+    Le DM se fait PAR SYMBOLE puis s'agrege : mettre bout a bout 26 series
+    d'erreurs produirait une serie dont les ruptures inter-symboles ne sont pas
+    de l'autocorrelation, et la correction HAC les lirait comme telles.
+
+    Le biais signe de chaque estimateur est rapporte a cote de la precision :
+    un estimateur peut gagner en MSE tout en etant systematiquement bas.
+    """
+    per_symbol, wins_yz, wins_c2c, inconclusive = [], 0, 0, 0
+    bias_yz_all, bias_c2c_all = [], []
+
+    for sym in [s for s in ALL_SYMBOLS if s in panier]:
+        df = panier[sym]
+        frame = pd.DataFrame({
+            "t": realised_forward_vol(df["Close"]),
+            "yz": yang_zhang_vol(df),
+            "c2c": close_to_close_vol(df["Close"]),
+        }).dropna()
+        if len(frame) < 100:
+            continue
+        e_yz = (frame["yz"] - frame["t"]).to_numpy()
+        e_c2c = (frame["c2c"] - frame["t"]).to_numpy()
+        try:
+            # horizon = VOL_WINDOW_YZ : la cible est une vol realisee a 21 jours,
+            # donc les erreurs de dates voisines se recouvrent sur 20 jours. Le
+            # lag de troncature HAC est fixe a ce recouvrement plutot que laisse
+            # a la regle n^(1/3), qui rend 14 pour n ~ 2800 et sous-couvre la
+            # dependance -- elle rendrait des p-values trop petites.
+            dm = diebold_mariano_test(e_yz, e_c2c, loss_fn="mse",
+                                      max_lag=VOL_WINDOW_YZ - 1,
+                                      horizon=VOL_WINDOW_YZ)
+        except (ValueError, ZeroDivisionError):
+            continue
+
+        bias_yz, bias_c2c = float(np.mean(e_yz)), float(np.mean(e_c2c))
+        bias_yz_all.append(bias_yz)
+        bias_c2c_all.append(bias_c2c)
+
+        if dm.p_value < 0.05 and dm.mean_loss_diff < 0:
+            wins_yz += 1
+        elif dm.p_value < 0.05 and dm.mean_loss_diff > 0:
+            wins_c2c += 1
+        else:
+            inconclusive += 1
+
+        per_symbol.append({
+            "symbol": sym, "n_obs": dm.n_observations,
+            "lag_truncation": dm.lag_truncation,
+            "dm_stat": round(dm.dm_statistic, 4),
+            "p_value": round(dm.p_value, 6),
+            "mean_loss_diff": float(dm.mean_loss_diff),
+            "rmse_yz": round(float(np.sqrt(np.mean(e_yz ** 2))), 6),
+            "rmse_c2c": round(float(np.sqrt(np.mean(e_c2c ** 2))), 6),
+            "bias_yz": round(bias_yz, 6), "bias_c2c": round(bias_c2c, 6),
+        })
+
+    n = len(per_symbol)
+    if n == 0:
+        return {"verdict": "NO DATA", "per_symbol": []}
+
+    if wins_yz >= max(1, n * 3 // 4):
+        overall = "YANG-ZHANG PLUS PRECIS"
+    elif wins_c2c >= max(1, n * 3 // 4):
+        overall = "CLOSE-TO-CLOSE PLUS PRECIS"
+    else:
+        overall = "MIXTE / NON CONCLUANT"
+
+    return {
+        "verdict": overall, "n_symbols": n,
+        "wins_yang_zhang": wins_yz, "wins_close_to_close": wins_c2c,
+        "inconclusive": inconclusive,
+        "median_p_value": round(float(np.median([r["p_value"] for r in per_symbol])), 6),
+        "mean_bias_yang_zhang": round(float(np.mean(bias_yz_all)), 6),
+        "mean_bias_close_to_close": round(float(np.mean(bias_c2c_all)), 6),
+        "bias_note": ("Biais signe = mean(estimateur - realise forward). Negatif = "
+                      "sous-estime la volatilite a venir. Rapporte a cote du MSE "
+                      "pour que la precision ne soit pas confondue avec le biais."),
+        "per_symbol": per_symbol,
+    }
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 7, 42],
+                        help="graines walk-forward (>= 4 exigees par la regle C)")
+    parser.add_argument("--n-splits", type=int, default=5)
+    parser.add_argument("--gap", type=int, default=21)
+    parser.add_argument("--rebalance", type=int, default=REBALANCE_MONTHLY,
+                        help="periode de rebalancement en jours ouvres. 21 = "
+                             "mensuel (frequence de l'article, defaut), "
+                             "1 = quotidien (frequence de L1_tsmom.py).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="charge les donnees et sort sans backtester")
+    parser.add_argument("--panier-dir", type=str, default=None,
+                        help="repertoire des CSV du panier. Les donnees ne sont "
+                             "pas versionnees (seul le README l'est) : depuis un "
+                             "worktree, pointer le checkout principal.")
+    parser.add_argument("--output", type=str, default=None)
+    args = parser.parse_args()
+
+    print("Chargement du panier anti-biais (OHLC complet requis pour Yang-Zhang)...")
+    panier_dir = Path(args.panier_dir) if args.panier_dir else None
+    panier = load_panier(panier_dir=panier_dir)
+    usable = {s: df for s, df in panier.items()
+              if {"Open", "High", "Low", "Close"} <= set(df.columns)}
+    print(f"  {len(usable)}/{len(panier)} symboles avec OHLC complet")
+    if usable:
+        idx = next(iter(usable.values())).index
+        print(f"  periode : {idx[0].date()} -> {idx[-1].date()}")
+
+    if args.dry_run:
+        print("--dry-run : sortie avant backtest.")
+        return 0
+
+    if len(usable) < 3:
+        print("ERREUR : moins de 3 symboles avec OHLC complet -- rien a mesurer.\n"
+              "  Les CSV du panier ne sont pas versionnes (le .gitignore ne garde\n"
+              "  que le README). Passer --panier-dir <chemin du checkout principal>\n"
+              "  /MyIA.AI.Notebooks/QuantConnect/datasets/panier, ou reconstruire le\n"
+              "  panier avec scripts/datasets/build_panier_anti_bias.py.")
+        return 2
+
+    if len(args.seeds) < 4:
+        print(f"ATTENTION : {len(args.seeds)} graine(s) -- la regle C en exige >= 4. "
+              "Le verdict rendu ne satisfait pas le gate.")
+
+    print("\nVerdict ESTIMATEUR -- Diebold-Mariano Yang-Zhang vs close-to-close")
+    dm_result = vol_estimator_dm(usable)
+    print(f"  {dm_result['verdict']}  "
+          f"(YZ {dm_result.get('wins_yang_zhang')} / C2C {dm_result.get('wins_close_to_close')}"
+          f" / nc {dm_result.get('inconclusive')} sur {dm_result.get('n_symbols')} symboles)")
+    print(f"  biais moyen  YZ={dm_result.get('mean_bias_yang_zhang')}  "
+          f"C2C={dm_result.get('mean_bias_close_to_close')}")
+
+    print("\nPre-calcul des signaux et volatilites...")
+    pre = precompute(usable)
+
+    print("Baseline buy-and-hold equal-weight (memes vues que le modele)...")
+    bh = run_buyhold_baseline(pre, args.seeds, args.n_splits, args.gap)
+    bh_sharpes = [s["sharpe"] for s in bh["seeds"]]
+    print(f"  Sharpe moyen = {np.mean(bh_sharpes):.4f} "
+          f"(ecart-type inter-graines {np.std(bh_sharpes, ddof=1):.4f})")
+
+    freq = ("mensuel" if args.rebalance == REBALANCE_MONTHLY
+            else "quotidien" if args.rebalance == REBALANCE_DAILY
+            else f"tous les {args.rebalance} jours ouvres")
+    print(f"\nAblation -- verdict STRATEGIE par configuration"
+          f" (rebalancement {freq})")
+    print(f"  {'config':18s} {'brut':>8s} {'net':>8s} {'+/-':>7s} {'delta':>8s} "
+          f"{'edge':>8s} {'turnover':>9s} {'net(L1)':>9s}  verdict")
+    configs_out, verdicts = {}, {}
+    for name, cfg in CONFIGS.items():
+        res = run_config(pre, cfg, args.seeds, args.n_splits, args.gap,
+                         args.rebalance)
+        verdict = compute_verdict(res, bh)
+        configs_out[name], verdicts[name] = res, verdict
+        gross = np.mean([s["gross_sharpe"] for s in res["seeds"]])
+        turn = np.mean([s["mean_daily_turnover"] for s in res["seeds"]])
+        net_l1 = np.mean([s["net_sharpe_l1_convention"] for s in res["seeds"]])
+        print(f"  {name:18s} {gross:+8.4f} {verdict['mean_net_sharpe']:+8.4f} "
+              f"{verdict['std_net_sharpe']:7.4f} {verdict['delta_sharpe']:+8.4f} "
+              f"{verdict['edge_sigma']:+7.2f}s {turn:9.3f} {net_l1:+9.4f}  "
+              f"{verdict['verdict']}")
+    print("  net(L1) = le meme resultat sous la facturation de L1_tsmom.py "
+          "(un aller-retour plein notionnel par ligne touchee, chaque jour).")
+
+    payload = {
+        "module": "L1b_tsmom_cf",
+        "source_article": "https://www.quantconnect.com/research/15272/",
+        "issue": 14462, "epic": 11698,
+        "seeds": args.seeds, "n_splits": args.n_splits, "gap": args.gap,
+        "rebalance_days": args.rebalance,
+        "seed_perturbation": {"panel_fraction": PANEL_FRACTION,
+                              "max_origin_offset": MAX_ORIGIN_OFFSET},
+        "buyhold": bh, "vol_estimator_dm": dm_result,
+        "configs": configs_out, "verdicts": verdicts,
+    }
+    out = Path(args.output) if args.output else CHECKPOINTS_DIR / "l1b_results.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"\nResultats ecrits dans {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_l1b_tsmom_cf.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_l1b_tsmom_cf.py
@@ -1,0 +1,417 @@
+"""Tests de `L1b_tsmom_cf` -- chaque assertion porte son controle positif.
+
+Un test qui verifie seulement qu'une fonction "rend un nombre" ne mesure rien :
+il passerait sur une implementation debranchee. Chaque bloc ci-dessous ecrit donc
+l'ORDRE DE GRANDEUR attendu a cote de la mesure, et plusieurs verifient qu'une
+forme volontairement corrompue est bien rejetee.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from L1b_tsmom_cf import (  # noqa: E402
+    CF_BOUNDS,
+    REBALANCE_MONTHLY,
+    TARGET_VOL,
+    TSTAT_LOOKBACK,
+    VOL_WINDOW_YZ,
+    build_positions,
+    close_to_close_vol,
+    compute_verdict,
+    correlation_factor,
+    realised_forward_vol,
+    seed_view,
+    sign_signal,
+    tstat_signal,
+    yang_zhang_vol,
+)
+
+
+# --------------------------------------------------------------------------
+# Fabriques de series synthetiques
+# --------------------------------------------------------------------------
+
+def make_ohlc(n=600, daily_vol=0.01, drift=0.0, seed=0):
+    """OHLC coherent (Low <= Open,Close <= High) tire d'un mouvement brownien."""
+    rng = np.random.default_rng(seed)
+    log_ret = rng.normal(drift, daily_vol, n)
+    close = 100.0 * np.exp(np.cumsum(log_ret))
+    prev_close = np.concatenate([[100.0], close[:-1]])
+    # ouverture = saut overnight de meme echelle, puis extremes intraday
+    open_ = prev_close * np.exp(rng.normal(0.0, daily_vol / 2, n))
+    hi_extra = np.abs(rng.normal(0.0, daily_vol / 2, n))
+    lo_extra = np.abs(rng.normal(0.0, daily_vol / 2, n))
+    high = np.maximum(open_, close) * np.exp(hi_extra)
+    low = np.minimum(open_, close) * np.exp(-lo_extra)
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    return pd.DataFrame({"Open": open_, "High": high, "Low": low,
+                         "Close": close, "Volume": 1e6}, index=idx)
+
+
+def make_trending(n=600, slope=0.0015, noise=0.004, seed=0):
+    """Serie a tendance nette : la t-stat doit y saturer."""
+    rng = np.random.default_rng(seed)
+    log_ret = slope + rng.normal(0.0, noise, n)
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    return pd.Series(100.0 * np.exp(np.cumsum(log_ret)), index=idx)
+
+
+# --------------------------------------------------------------------------
+# Levier 2 -- Yang-Zhang
+# --------------------------------------------------------------------------
+
+def test_yang_zhang_recovers_the_injected_volatility():
+    """Controle positif : la vol injectee est connue, l'estimation doit la retrouver.
+
+    daily_vol = 1 % -> vol annualisee attendue ~= 0.01 * sqrt(252) ~= 0.159.
+    Tolerance large (+/- 40 %) : Yang-Zhang agrege trois composantes dont deux
+    sont ici simulees, pas mesurees sur un vrai carnet d'ordres.
+    """
+    df = make_ohlc(daily_vol=0.01, seed=1)
+    est = yang_zhang_vol(df).dropna()
+    attendu = 0.01 * np.sqrt(252)
+    assert 0.6 * attendu < est.median() < 1.4 * attendu, (
+        f"YZ median={est.median():.4f}, attendu ~{attendu:.4f}")
+
+
+def test_yang_zhang_scales_with_volatility():
+    """Controle positif d'ECART : doubler la vol doit ~doubler l'estimation.
+
+    C'est le controle qui distingue un estimateur d'une constante : une fonction
+    qui rendrait toujours 0.16 passerait le test precedent et echouerait ici.
+    """
+    calme = yang_zhang_vol(make_ohlc(daily_vol=0.01, seed=2)).dropna().median()
+    agite = yang_zhang_vol(make_ohlc(daily_vol=0.02, seed=2)).dropna().median()
+    ratio = agite / calme
+    assert 1.6 < ratio < 2.4, f"ratio={ratio:.3f}, attendu ~2.0"
+
+
+def test_yang_zhang_uses_the_intraday_range():
+    """YZ doit differer de close-to-close : sinon les deux leviers sont le meme.
+
+    Une implementation qui ignorerait High/Low rendrait exactement close-to-close,
+    et l'ablation C-vs-B ne mesurerait rien.
+    """
+    df = make_ohlc(seed=3)
+    yz = yang_zhang_vol(df, window=VOL_WINDOW_YZ).dropna()
+    c2c = close_to_close_vol(df["Close"], window=VOL_WINDOW_YZ).dropna()
+    commun = yz.index.intersection(c2c.index)
+    ecart = (yz.loc[commun] - c2c.loc[commun]).abs().median()
+    assert ecart > 1e-4, "YZ est indiscernable de close-to-close"
+
+
+def test_realised_forward_vol_is_strictly_forward():
+    """La cible du DM ne doit contenir aucune information disponible a t.
+
+    Si le decalage etait absent, la valeur a t recouvrirait la fenetre qui la
+    precede, et le "test de prevision" comparerait un estimateur a lui-meme.
+    """
+    df = make_ohlc(n=400, seed=4)
+    fwd = realised_forward_vol(df["Close"], window=VOL_WINDOW_YZ)
+    trailing = close_to_close_vol(df["Close"], window=VOL_WINDOW_YZ)
+    # la cible a t doit egaler la vol trailing mesuree window jours plus tard
+    aligne = trailing.shift(-VOL_WINDOW_YZ)
+    pd.testing.assert_series_equal(fwd.dropna(), aligne.dropna(),
+                                   check_names=False)
+    assert fwd.iloc[-VOL_WINDOW_YZ:].isna().all(), (
+        "les dernieres dates devraient etre NaN : leur futur n'existe pas")
+
+
+# --------------------------------------------------------------------------
+# Levier 1 -- signaux
+# --------------------------------------------------------------------------
+
+def test_tstat_signal_saturates_on_a_clear_trend():
+    """Tendance nette -> |t| > 1 -> le signal doit saturer a +1."""
+    closes = make_trending(slope=0.0015, noise=0.003, seed=5)
+    sig = tstat_signal(closes).dropna()
+    assert sig.iloc[-1] == pytest.approx(1.0), f"signal={sig.iloc[-1]:.4f}"
+
+
+def test_tstat_signal_stays_inside_the_cap():
+    for seed in (6, 7, 8):
+        sig = tstat_signal(make_trending(slope=0.004, seed=seed)).dropna()
+        assert sig.min() >= -1.0 and sig.max() <= 1.0
+
+
+def test_tstat_signal_is_continuous_where_sign_is_binary():
+    """Le point de l'article : sur une tendance FAIBLE, l'exposition se reduit.
+
+    `sign` rend +/-1 quel que soit le niveau de preuve ; la t-stat doit rendre
+    des valeurs strictement interieures. Sans cette difference, l'ablation B-vs-A
+    ne mesurerait rien.
+    """
+    closes = make_trending(slope=0.00005, noise=0.012, seed=9)
+    t = tstat_signal(closes).dropna()
+    s = sign_signal(closes).dropna()
+    interieurs = ((t.abs() > 1e-9) & (t.abs() < 0.999)).sum()
+    assert interieurs > 0.5 * len(t), (
+        f"seulement {interieurs}/{len(t)} valeurs strictement interieures")
+    assert set(np.unique(s.to_numpy())) <= {-1.0, 0.0, 1.0}
+
+
+def test_signals_need_a_full_lookback():
+    closes = make_trending(n=TSTAT_LOOKBACK + 5, seed=10)
+    assert tstat_signal(closes).iloc[:TSTAT_LOOKBACK - 1].isna().all()
+
+
+# --------------------------------------------------------------------------
+# Levier 3 -- facteur de correlation
+# --------------------------------------------------------------------------
+
+def _cf_on(returns: pd.DataFrame, signal_value: float = 1.0) -> float:
+    signals = pd.DataFrame(signal_value, index=returns.index,
+                           columns=returns.columns)
+    return correlation_factor(signals, returns).dropna().median()
+
+
+def test_cf_is_one_when_everything_moves_together():
+    """rho_bar = 1 -> CF = sqrt(N/(1+(N-1))) = 1 : aucun benefice de diversification."""
+    n, k = 400, 5
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    base = np.random.default_rng(11).normal(0, 0.01, n)
+    ret = pd.DataFrame({f"A{i}": base for i in range(k)}, index=idx)
+    assert _cf_on(ret) == pytest.approx(1.0, abs=0.05)
+
+
+def test_cf_approaches_sqrt_n_when_uncorrelated():
+    """rho_bar = 0 -> CF = sqrt(N). Avec N=5, attendu ~2.24 (borne haute 3.0)."""
+    n, k = 600, 5
+    rng = np.random.default_rng(12)
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    ret = pd.DataFrame({f"A{i}": rng.normal(0, 0.01, n) for i in range(k)},
+                       index=idx)
+    cf = _cf_on(ret)
+    assert 1.8 < cf < 2.7, f"CF={cf:.3f}, attendu ~{np.sqrt(k):.2f}"
+
+
+def test_cf_stays_inside_its_bounds():
+    """Sans borne, un rho_bar proche de -1/(N-1) envoie le levier a l'infini."""
+    n, k = 300, 4
+    rng = np.random.default_rng(13)
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    base = rng.normal(0, 0.01, n)
+    # deux paires anti-correlees : rho_bar tres negatif
+    ret = pd.DataFrame({"A0": base, "A1": -base,
+                        "A2": base, "A3": -base}, index=idx)
+    series = correlation_factor(
+        pd.DataFrame(1.0, index=idx, columns=ret.columns), ret).dropna()
+    assert series.min() >= CF_BOUNDS[0] - 1e-9
+    assert series.max() <= CF_BOUNDS[1] + 1e-9
+    assert len(series) > 0
+
+
+def test_cf_reads_opposite_positions_as_diversification():
+    """Deux actifs correles tenus en sens OPPOSES se diversifient.
+
+    C'est ce que la ponderation par X_i X_j apporte : une correlation brute de +1
+    donnerait CF = 1, alors que le portefeuille reel est neutre.
+    """
+    n = 400
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    base = np.random.default_rng(14).normal(0, 0.01, n)
+    ret = pd.DataFrame({"A": base, "B": base}, index=idx)
+    memes = correlation_factor(
+        pd.DataFrame({"A": 1.0, "B": 1.0}, index=idx), ret).dropna().median()
+    opposes = correlation_factor(
+        pd.DataFrame({"A": 1.0, "B": -1.0}, index=idx), ret).dropna().median()
+    assert memes == pytest.approx(1.0, abs=0.05)
+    assert opposes > memes + 0.2, (
+        f"memes={memes:.3f} opposes={opposes:.3f} : la ponderation par signal "
+        "n'est pas prise en compte")
+
+
+# --------------------------------------------------------------------------
+# Graines -- la regression que L1 porte encore
+# --------------------------------------------------------------------------
+
+def _fake_pre(n_symbols=20):
+    idx = pd.bdate_range("2015-01-01", periods=100)
+    cols = [f"S{i:02d}" for i in range(n_symbols)]
+    return {"close": pd.DataFrame(1.0, index=idx, columns=cols)}
+
+
+def test_seed_view_is_deterministic():
+    pre = _fake_pre()
+    assert seed_view(pre, 42) == seed_view(pre, 42)
+
+
+def test_distinct_seeds_give_distinct_views():
+    """LA regression que ce module existe pour ne pas reproduire.
+
+    Dans `L1_tsmom.py`, le `rng` de la graine n'est jamais consomme : les quatre
+    graines rendent des nombres identiques, l'ecart-type vaut 0, et la clause
+    `t_stat >= 2.0` du gate rend BEATS inatteignable. Si ce test venait a passer
+    avec des vues identiques, notre gate serait aussi vide que le sien.
+    """
+    pre = _fake_pre()
+    vues = [seed_view(pre, s) for s in (0, 1, 7, 42)]
+    assert len({tuple(v[0]) for v in vues}) > 1, "sous-paniers tous identiques"
+    assert len({v[1] for v in vues}) > 1, "decalages d'origine tous identiques"
+
+
+def test_seed_view_keeps_a_usable_panel():
+    pre = _fake_pre(n_symbols=26)
+    for s in (0, 1, 7, 42, 99):
+        symbols, offset = seed_view(pre, s)
+        assert 3 <= len(symbols) <= 26
+        assert len(set(symbols)) == len(symbols), "tirage avec remise"
+        assert 0 <= offset <= 40
+
+
+# --------------------------------------------------------------------------
+# Gate de verdict
+# --------------------------------------------------------------------------
+
+def _cfg(sharpes):
+    return {"seeds": [{"net_sharpe": v} for v in sharpes]}
+
+
+def _bh(sharpes):
+    return {"seeds": [{"sharpe": v} for v in sharpes]}
+
+
+def test_verdict_no_beats_when_delta_is_negative():
+    v = compute_verdict(_cfg([0.10, 0.12, 0.09, 0.11]),
+                        _bh([0.40, 0.42, 0.39, 0.41]))
+    assert v["verdict"] == "NO BEATS"
+
+
+def test_verdict_beats_needs_the_full_conjunction():
+    """Edge large ET dispersion faible ET 3/4 graines positives."""
+    v = compute_verdict(_cfg([0.80, 0.82, 0.79, 0.81]),
+                        _bh([0.40, 0.42, 0.39, 0.41]))
+    assert v["verdict"] == "BEATS"
+    assert v["edge_sigma"] >= 2.0
+    assert v["seeds_positive"] == 4
+
+
+def test_verdict_inconclusive_when_dispersion_swallows_the_edge():
+    """Meme delta moyen, dispersion 20x : le verdict doit basculer.
+
+    C'est le controle qui prouve que `edge_sigma` porte quelque chose -- sans lui,
+    un gate qui ne regarderait que `delta` rendrait BEATS dans les deux cas.
+    """
+    v = compute_verdict(_cfg([0.05, 1.60, -0.20, 1.75]),
+                        _bh([0.40, 0.42, 0.39, 0.41]))
+    assert v["verdict"] == "INCONCLUSIVE"
+    assert v["edge_sigma"] < 2.0
+
+
+def test_zero_dispersion_can_never_reach_beats():
+    """Le defaut de `L1_tsmom.py`, ecrit comme un test.
+
+    Graines identiques -> std = 0 -> edge_sigma = 0 -> BEATS impossible, quel que
+    soit l'ecart. Un module dont les graines ne perturbent rien tombe ici.
+    """
+    v = compute_verdict(_cfg([2.0, 2.0, 2.0, 2.0]),
+                        _bh([0.4, 0.4, 0.4, 0.4]))
+    assert v["std_net_sharpe"] == 0.0
+    assert v["edge_sigma"] == 0.0
+    assert v["verdict"] != "BEATS"
+    assert v["delta_sharpe"] > 1.5, (
+        "l'ecart est enorme et le gate refuse quand meme : c'est exactement "
+        "l'etat nominal de L1")
+
+
+# --------------------------------------------------------------------------
+# Frequence de rebalancement -- le parametre qui decide le verdict
+# --------------------------------------------------------------------------
+
+def _flat_pre(n=252, seed=3):
+    """Un `pre` minimal ou la position EST le signal.
+
+    La volatilite est constante et vaut exactement TARGET_VOL, donc le facteur
+    d'echelle `TARGET_VOL / vol` vaut 1 : ce que `build_positions` rend est le
+    signal lui-meme, non deforme. C'est ce qui rend la mesure de turnover
+    ci-dessous lisible -- sur un `pre` realiste, l'effet du rebalancement serait
+    melange a celui de la derive de volatilite.
+    """
+    rng = np.random.default_rng(seed)
+    idx = pd.bdate_range("2015-01-01", periods=n)
+    cols = ["AAA", "BBB"]
+    sig = pd.DataFrame(rng.uniform(-1.0, 1.0, size=(n, 2)), index=idx,
+                       columns=cols)
+    vol = pd.DataFrame(TARGET_VOL, index=idx, columns=cols)
+    fwd = pd.DataFrame(rng.normal(0.0, 0.01, size=(n, 2)), index=idx,
+                       columns=cols)
+    return {"tstat": sig, "c2c": vol, "fwd": fwd}, cols
+
+
+_EQW_TSTAT = {"signal": "tstat", "vol": "c2c", "alloc": "eqw"}
+
+
+def _mean_turnover(positions):
+    """Notionnel moyen deplace par jour, toutes lignes confondues."""
+    return positions.diff().abs().sum(axis=1).iloc[1:].mean()
+
+
+def test_daily_rebalance_leaves_positions_untouched():
+    """Controle negatif : `rebalance=1` ne doit RIEN maintenir.
+
+    Sans lui, un bloc de hold accidentellement toujours actif passerait le test
+    de constance ci-dessous sans que personne ne s'en apercoive.
+    """
+    pre, cols = _flat_pre()
+    daily, _ = build_positions(pre, _EQW_TSTAT, cols, rebalance=1)
+    pd.testing.assert_frame_equal(daily, pre["tstat"][cols], check_freq=False)
+
+
+def test_monthly_rebalance_holds_positions_between_dates():
+    """Sous rebalancement mensuel, la position ne bouge qu'aux dates de grille."""
+    pre, cols = _flat_pre()
+    held, _ = build_positions(pre, _EQW_TSTAT, cols,
+                              rebalance=REBALANCE_MONTHLY)
+    assert held.notna().all().all(), "aucun trou ne doit subsister apres ffill"
+    for i in range(len(held)):
+        anchor = (i // REBALANCE_MONTHLY) * REBALANCE_MONTHLY
+        np.testing.assert_allclose(held.iloc[i].to_numpy(),
+                                   held.iloc[anchor].to_numpy())
+    # et la valeur tenue est bien celle du signal a la date de rebalancement
+    np.testing.assert_allclose(held.iloc[0].to_numpy(),
+                               pre["tstat"][cols].iloc[0].to_numpy())
+
+
+def test_monthly_rebalance_divides_turnover_by_the_period():
+    """Ordre de grandeur attendu : le turnover chute d'un facteur ~= la periode.
+
+    Le signal est tire i.i.d., donc l'amplitude d'un saut ne depend pas de
+    l'intervalle : en mensuel, seul 1 jour sur 21 porte un saut de meme loi
+    qu'en journalier. Le rapport attendu est donc ~21, pas ~sqrt(21) (qui serait
+    la reponse si le signal etait une marche aleatoire). Une implementation qui
+    "tiendrait" les positions sans reduire le turnover -- par exemple en
+    reinterpolant entre les dates -- tomberait ici.
+    """
+    pre, cols = _flat_pre()
+    daily, _ = build_positions(pre, _EQW_TSTAT, cols, rebalance=1)
+    held, _ = build_positions(pre, _EQW_TSTAT, cols,
+                              rebalance=REBALANCE_MONTHLY)
+    ratio = _mean_turnover(daily) / _mean_turnover(held)
+    assert 12.0 < ratio < 32.0, f"rapport de turnover mesure : {ratio:.1f}"
+
+
+def test_origin_offset_shifts_the_rebalance_calendar():
+    """Le decalage tire par la graine perturbe aussi le CALENDRIER.
+
+    Deux graines ne doivent pas seulement voir un sous-panier different : elles
+    doivent aussi rebalancer des jours differents, sinon la dispersion mesuree
+    sous-estime la sensibilite reelle a la date d'entree.
+    """
+    pre, cols = _flat_pre()
+    a, _ = build_positions(pre, _EQW_TSTAT, cols, offset=0,
+                           rebalance=REBALANCE_MONTHLY)
+    b, _ = build_positions(pre, _EQW_TSTAT, cols, offset=5,
+                           rebalance=REBALANCE_MONTHLY)
+    common = a.index.intersection(b.index)
+    assert len(common) > 100, "les deux vues doivent se recouvrir largement"
+    diff = (a.loc[common] - b.loc[common]).abs().to_numpy().sum()
+    assert diff > 1.0, (
+        "positions identiques malgre un decalage de 5 jours : la grille de "
+        "rebalancement ne suit pas l'origine de la vue")

--- a/docs/qc/qc-research-seeded.json
+++ b/docs/qc/qc-research-seeded.json
@@ -729,8 +729,8 @@
   "15272": {
    "url": "https://www.quantconnect.com/research/15272/improved-momentum-strategy-on-commodities-futures/",
    "lastmod": "2019-09-17T00:00:00+00:00",
-   "seeded_at": null,
-   "issue": null
+   "seeded_at": "2026-09-03",
+   "issue": 14462
   },
   "15270": {
    "url": "https://www.quantconnect.com/research/15270/gradient-boosting-model/",


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-ai-01:CoursIA — prev: MED/ledger #14444

Distille l'article QC research [#15272](https://www.quantconnect.com/research/15272/improved-momentum-strategy-on-commodities-futures/) (*TSMOM-CF*, d'après Baltas & Kosowski 2017) sous l'EPIC #11698 — en **ablation** plutôt qu'en implémentation monolithique. L'article nomme trois correctifs au TSMOM de Moskowitz-Ooi-Pedersen (2012) ; ces trois-là tombent exactement sur trois lignes de notre propre `L1_tsmom.py`, qui a rendu `NO BEATS`. Un TSMOM-CF complet qui battrait la baseline ne dirait pas **lequel** des trois leviers porte l'effet, d'où les quatre configurations.

Rapport complet : [`docs/L1b_tsmom_cf.md`](../blob/feature/qcr-15272-tsmom-cf/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L1b_tsmom_cf.md).

## Verdicts

| Instrument | Verdict |
|---|---|
| **Stratégie** (gate Sharpe, règle C) | **NO BEATS** — les 4 configurations, aux 2 fréquences |
| **Estimateur de volatilité** (Diebold-Mariano) | **NON CONCLUANT** — 0 / 0 / 26 symboles, p médiane 0,579 |

## Conformité règle C — point par point

| # | Exigence | Ce qui est livré |
|---|---|---|
| 1 | walk-forward 5 folds | `WalkForwardSplitter(n_splits=5, gap=21)`, harnais existant, non réécrit |
| 2 | ≥ 4 graines | **5** (0/1/7/42/99), et elles **perturbent réellement** — voir « ce que les graines perturbent » |
| 3 | conjonction edge ≥ 2σ **ET** DM | edge mesuré **−4,10 à −5,80σ** ; **déviation déclarée ci-dessous** sur la jambe DM |
| 4 | baseline + coûts | B&H equal-weight sur **la même vue par graine** (comparaison appariée) ; 5 bps actions / 10 bps crypto |
| 5 | pas de FAANG/Mag7 | panier anti-biais existant, filtre inchangé |
| 6 | verdict honnête | `NO BEATS` écrit tel quel, jamais « prometteur » |
| 7 | **rapport de biais par modèle** | biais signé `mean(estimateur − réalisé)` : **YZ +0,002512**, **c2c +0,012828** |

### Déviation déclarée sur la jambe DM (point 3) — à contester si elle ne convient pas

Le DM est câblé sur l'**estimateur de volatilité**, pas sur la série de rendements de la stratégie. Raison : le DM est un test d'**exactitude de prévision** ; parmi les trois leviers de l'article, l'estimateur de volatilité est le seul qui soit une prévision au sens propre (il prédit une quantité — la volatilité des 21 jours suivants — qui se réalise ensuite et se mesure). Un signal de momentum et un facteur d'allocation ne prédisent aucune quantité observable : leur appliquer un DM produirait un nombre sans référent.

**Conséquence sur la portée du verdict** : la conjonction de la règle C est une condition pour **affirmer** `BEATS`. Cette PR affirme `NO BEATS`, et ce verdict repose sur la jambe σ seule, où la marge n'est pas discutable — Δ vs B&H de **−0,61 à −0,71** avec un edge de **−4,10 à −5,80σ**, sur les quatre configurations et aux deux fréquences. Si un reviewer estime que la jambe DM doit malgré tout porter sur les rendements, le dire : c'est un ajout, pas une reprise.

## Résultats — rebalancement mensuel (la fréquence de l'article)

26 symboles à OHLC complet, 2015-01-02 → 2026-05-22, 5 graines, 5 folds, gap 21 j.

| config | brut | net | σ inter-graines | Δ vs B&H | edge | turnover/j | net (conv. L1) | verdict |
|---|---|---|---|---|---|---|---|---|
| A `sign` + c2c + 1/N | +0,3791 | **+0,3509** | 0,1028 | −0,7101 | −5,76σ | 0,126 | +0,1456 | NO BEATS |
| B `t-stat` + c2c + 1/N | +0,4748 | **+0,4467** | 0,0810 | −0,6143 | −5,80σ | 0,102 | +0,1324 | NO BEATS |
| C `t-stat` + YZ + 1/N | +0,4207 | **+0,3878** | 0,1477 | −0,6732 | −4,14σ | 0,116 | +0,0788 | NO BEATS |
| D `t-stat` + YZ + CF | +0,3995 | **+0,3678** | 0,1546 | −0,6932 | −4,10σ | 0,133 | +0,1593 | NO BEATS |

Baseline buy-and-hold : **Sharpe 1,0610** (σ inter-graines 0,0682).

## Le résultat principal n'est aucun des trois leviers de l'article

**C'est la fréquence de rebalancement.** Le notionnel déplacé par jour passe de **3,5-4,6** (journalier) à **0,10-0,13** (mensuel) — facteur 31 à 37 —, assez pour retourner le **signe** du Sharpe net : les mêmes quatre configurations rendent **−0,43 à −0,56** en journalier et **+0,35 à +0,45** en mensuel.

La position est `signal × (vol_cible / vol_estimée)` : les deux facteurs bougent tous les jours, donc une position recalculée quotidiennement dérive et se refacture tous les jours, même quand le signal ne change pas de camp. Moskowitz (2012) comme Baltas-Kosowski (2017) rebalancent **mensuellement** — c'est le défaut ici ; le journalier reste accessible en sensibilité (`--rebalance 1`) et ses chiffres sont dans le doc.

Et le contrôle qui rend ce point non négociable : **le levier 2 change de signe entre les deux fréquences.**

| levier | effet sur le Sharpe brut (mensuel) | (journalier) |
|---|---|---|
| 1 — t-stat au lieu de `sign` | **+0,096** | +0,032 |
| 2 — Yang-Zhang au lieu de c2c | **−0,054** | **+0,055** |
| 3 — CF au lieu de 1/N | **−0,021** | −0,041 |

Lu en journalier seulement, on conclurait que Yang-Zhang améliore la performance brute. Lu à la fréquence de l'article, il la dégrade.

## Yang-Zhang est moins biaisé, pas plus précis

DM sur perte de précision (`loss_fn="mse"`), cible = volatilité réalisée sur les 21 jours **suivants** (`shift(-window)`, strictement postérieure), HAC à `max_lag = 20` pour couvrir le recouvrement des fenêtres.

- **0 / 0 / 26** non concluants, p médiane **0,579**.
- Biais signé : **YZ +0,002512** contre **c2c +0,012828** — ~5× moins biaisé.

Les deux mesures ne se remplacent pas et sont rapportées séparément : le DM mesure la précision, le biais mesure le décalage systématique. Yang-Zhang gagne le second sans gagner le premier (cf #10938 / #10956 : `loss_fn="linear"` est un contrôle de biais, jamais la jambe de précision).

## Ce que les graines perturbent — et pourquoi ce n'est pas ce que fait L1

Chaque graine tire une **vue du problème**, la même pour le modèle et pour sa baseline : sous-panier de 80 % des symboles sans remise, et décalage d'origine de 0 à 40 jours ouvrés (qui décale aussi la grille de rebalancement). Le σ inter-graines mesuré est **0,081 à 0,155** — le gate mesure donc quelque chose.

## Deux défauts de `L1_tsmom.py` — mesurés, non corrigés ici → #14470

Trouvés en construisant le contrôle de reproduction (config A). Non corrigés dans cette PR (principe 3 du `CLAUDE.md` : signaler le mauvais code découvert, le traiter en sujet séparé).

**1. Boucle multi-graines inerte.** `rng` est construit l. 124 et **jamais consommé** (unique occurrence dans le fichier). Mesure, 4 graines, lookback 252 j :

```
{'seed':  0, 'gross_sharpe': 0.6884, 'net_sharpe': -2.3778}
{'seed':  1, 'gross_sharpe': 0.6884, 'net_sharpe': -2.3778}
{'seed':  7, 'gross_sharpe': 0.6884, 'net_sharpe': -2.3778}
{'seed': 42, 'gross_sharpe': 0.6884, 'net_sharpe': -2.3778}
ecart-type inter-graines : 0.0000000000
```

Contrôle positif : avec des graines vivantes, cet écart-type vaut 0,081 à 0,155 (mesuré par cette PR, même panier). Zéro **exactement** sur quatre graines n'est pas du bruit faible. Conséquence : `t_stat = delta / 0 → 0` ⇒ la clause `t_stat >= 2.0` du gate rend `BEATS` **structurellement inatteignable**.

**2. Coûts en aller-retour plein notionnel.** `pos_changes > 0` compte une ligne dès qu'elle bouge d'un iota, puis `trades_per_day * 2 * cost_per_trade / n_assets` facture 100 % du notionnel sans regarder la **taille** du déplacement. Mesuré : 13,5 « ordres »/jour pour 21 lignes.

La convention de L1 est **conservée en colonne de diagnostic** (`net (conv. L1)` dans les deux tableaux) : l'écart entre les deux facturations reste mesuré plutôt qu'affirmé.

## Tests

**23 tests**, chacun avec son **contrôle positif** et son **ordre de grandeur attendu** écrit à côté de la mesure.

```
$ python -m pytest tests/test_l1b_tsmom_cf.py -q
tests\test_l1b_tsmom_cf.py .......................                       [100%]
23 passed in 3.78s
```

Les plus significatifs :
- `test_yang_zhang_recovers_the_injected_volatility` — vol quotidienne injectée 1 % → ~0,159 annualisé (±40 %)
- `test_cf_approaches_sqrt_n_when_uncorrelated` — N = 5 décorrélés → CF ≈ 2,24 ; `test_cf_is_one_when_everything_moves_together` → ρ̄ = 1 → CF = 1
- `test_realised_forward_vol_is_strictly_forward` — la cible du DM ne peut pas contenir l'estimateur
- `test_distinct_seeds_give_distinct_views` — la régression de L1, prise à la source
- `test_zero_dispersion_can_never_reach_beats` — **le défaut de L1 écrit comme test**
- `test_monthly_rebalance_divides_turnover_by_the_period` — rapport attendu ≈ 21 (signal i.i.d. ⇒ pas √21), mesuré dans [12, 32]
- `test_daily_rebalance_leaves_positions_untouched` — contrôle **négatif** : sans lui, un hold accidentellement toujours actif passerait le test de constance

## Reproduction

```bash
cd MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts
python -m pytest tests/test_l1b_tsmom_cf.py -q
python L1b_tsmom_cf.py --seeds 0 1 7 42 99                       # fréquence de l'article
python L1b_tsmom_cf.py --seeds 0 1 7 42 99 --rebalance 1 \       # sensibilité
    --output ../checkpoints/l1b_tsmom_cf/l1b_results_daily.json
```

`checkpoints/` est gitignoré : les nombres du doc sont la **trace committée** de la mesure.

## Portée — ce que cette PR ne prétend pas

L'article backteste des **futures de matières premières** sur **20 mois** (jan 2018 → sep 2019) et y rapporte Sharpe 0,198 pour TSMOM-CF, −0,746 pour le TSMOM de base, 0,46 pour SPY. Notre panier est à dominante **actions + crypto** sur **11 ans**, et son buy-and-hold rend 1,06.

Un `NO BEATS` ici **ne réfute pas l'article** : il dit que les trois corrections ne transportent pas leur effet d'un univers à l'autre. Ce qui se transporte est le **classement des leviers entre eux**, mesuré ci-dessus. (À noter que l'article, dans sa propre fenêtre, ne bat pas non plus son benchmark : 0,198 contre 0,46.)

## Fichiers

| Fichier | Rôle |
|---|---|
| `scripts/L1b_tsmom_cf.py` | module d'ablation (686 l.) — réutilise `walk_forward`, `transaction_costs`, `baselines`, `panier_loader`, `dm_test`, **aucun harnais réécrit** |
| `scripts/tests/test_l1b_tsmom_cf.py` | 23 tests avec contrôles positifs (417 l.) |
| `docs/L1b_tsmom_cf.md` | rapport, verdicts, portée, les deux défauts de L1 |
| `docs/qc/qc-research-seeded.json` | article 15272 → issue #14462 (diff de 2 lignes) |

Closes #14462
See #11698
