### PR TITLE
ci(lean,#11703): signal advisory des declarations ajoutees non citees (acceptance 3 — mode --pr-base + workflow label)

### DIFF
--- a/.github/workflows/lean-visibility-advisory.yml
+++ b/.github/workflows/lean-visibility-advisory.yml
@@ -1,0 +1,109 @@
+name: Lean Visibility Advisory
+
+# Acceptance 3 de l'EPIC #11703 : « signal CI advisory listant les déclarations
+# ajoutées non citées sur les PR `*_lean/**` ». L'organe canonique
+# scripts/lean/scan_lake_notebook_visibility.py (versionné par #11704) mesure
+# la visibilité repo-wide ; ce workflow en déroule le mode PR (--pr-base) sur
+# chaque PR qui enrichit un lake, pour que la métrique ne re-dérive pas entre
+# deux re-mesures manuelles — exactement ce que la passe de curation #13906 a
+# constaté (chaque ligne du tableau du 2026-08-19 était fausse le 2026-09-02).
+#
+# ADVISORY, jamais bloquant : le job sort TOUJOURS 0. Le payload actionnable
+# est la paire de LABELS (drift / unmeasured), jamais la conclusion verte du
+# job (vert par construction — le même piège que #8797).
+#
+# L'extraction et le filtre (DECL_RE, exclusions, `_en.lean`) sont CONSOMMÉS
+# depuis l'organe par import du même module — jamais réimplémentés ici, pour
+# que le label et la métrique de tête ne puissent pas diverger.
+#
+# Hors scope (student-pr-reviews.md) : les forks (PRs étudiantes) sautent.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '**/*_lean/**/*.lean'
+      # Self-cover (#8822) : un label-poser filtré par paths doit se lister
+      # lui-même, sinon il ne peut plus re-tourner (donc plus retirer son
+      # propre label) une fois les paths hors diff. Exigé par
+      # scripts/check_workflow_label_paths.py.
+      - '.github/workflows/lean-visibility-advisory.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lean-visibility-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lean-visibility-advisory:
+    name: "Lean visibility drift (advisory label, non-blocking)"
+    # Routage #14283 tranche 3 : jambe Linux auto-hébergée. Le `if:` est la
+    # garde anti-fork exigée par scripts/ci/check_self_hosted_runner_policy.py
+    # (runs-on STATIQUE = auditable). Les PRs de fork sautent le job --
+    # pr_gate.py compte `skipped` comme OK.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Le mode --pr-base fait un diff 3-points base...HEAD : il faut
+          # l'historique.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Advisory check on added lake declarations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Sans contexte git GH_REPO, `gh pr edit` / `gh label create` ne
+          # peuvent pas inférer le repo cible et échouent en silence (piège
+          # documenté firsthand par variation-tag-guard après #8765).
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          LABEL_DRIFT: lean-visibility-drift
+          LABEL_UNMEASURED: lean-visibility-unmeasured
+        run: |
+          set -uo pipefail
+
+          ensure_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          ensure_label "$LABEL_DRIFT" \
+            "La PR ajoute des declarations lake non citees par AUCUN notebook (borne large) (#11703)" "D4A64C"
+          ensure_label "$LABEL_UNMEASURED" \
+            "Le scan de visibilite n'a pas pu mesurer cette PR -- NON VERIFIE (#8819)" "BFD4F2"
+
+          # Advisory : TOUJOURS exit 0. Le signal est la paire de labels.
+          if ! python scripts/lean/scan_lake_notebook_visibility.py \
+              --pr-base "$BASE" --pr-head "$HEAD" --json payload.json; then
+            echo "::warning::scan_lake_notebook_visibility (mode PR) a echoue -- non mesure, pas sans defaut (#8819)."
+            unset_label "$LABEL_DRIFT"
+            set_label "$LABEL_UNMEASURED"
+            exit 0
+          fi
+
+          UNCITED=$(python -c "import json; print(json.load(open('payload.json'))['uncited'])")
+          echo "Declarations ajoutees non citees (borne large): $UNCITED"
+
+          if [ "$UNCITED" -gt 0 ]; then
+            echo "::warning::$UNCITED declaration(s) ajoutee(s) sur un lake sans aucune citation notebook (EPIC #11703) -- un compagnon notebook les rend visibles."
+            set_label "$LABEL_DRIFT"
+          else
+            unset_label "$LABEL_DRIFT"
+          fi
+          unset_label "$LABEL_UNMEASURED"

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -226,6 +226,16 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     #   pour les forks PRs qui se font skipper proprement par pr_gate.
     #   Rollback = revert de cette PR (l'entree disparait de l'allowlist).
     "notebook-link-render-check.yml",
+    # tranche 7 (acceptance 3 #11703, owner myia-po-2027:CoursIA) : garde
+    #   advisory pur-Python declenchee sur pull_request filtrant les
+    #   `**/*_lean/**/*.lean`, mode --pr-base de l'organe canonique
+    #   scan_lake_notebook_visibility.py (diff 3-points, DECL_RE partage --
+    #   aucune reimplementation), pose une paire de labels signes (drift /
+    #   unmeasured), jamais exit != 0. Meme profil que la tranche 6 :
+    #   stdlib-only, aucun GITHUB_TOKEN hors gh label/pr edit, garde same-repo
+    #   au niveau job pour les forks. Rollback = revert de la PR (l'entree
+    #   disparait de l'allowlist).
+    "lean-visibility-advisory.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",

--- a/scripts/lean/scan_lake_notebook_visibility.py
+++ b/scripts/lean/scan_lake_notebook_visibility.py
@@ -20,6 +20,14 @@ mesure -- c'est exactement le defaut que ce garde ferme (cf EPIC #11703).
 
 Usage:
     python scripts/lean/scan_lake_notebook_visibility.py [--json OUT] [--lake NAME]
+    python scripts/lean/scan_lake_notebook_visibility.py --pr-base <sha> [--pr-head <sha>] [--json OUT]
+
+Mode --pr-base (acceptance 3 de l'EPIC #11703) : liste les declarations
+AJOUTEES par le diff base...head sur les lakes `*_lean/` qui ne sont citees
+dans AUCUN notebook du checkout, a la borne large (tout nom trouve). Un nom
+invisible meme a la borne large est invisible partout : c'est le signal
+le moins bruite possible, et le payload du workflow advisory
+lean-visibility-advisory.yml.
 """
 from __future__ import annotations
 
@@ -27,6 +35,7 @@ import argparse
 import collections
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -101,11 +110,99 @@ def collect_notebook_tokens(names: set[str]):
     return seen, per_nb, count
 
 
+def names_from_unified_diff(diff_text: str) -> dict[str, set[str]]:
+    """Declarations AJOUTEES par un diff unifie, par fichier lake.
+
+    Meme filtre que collect_declarations (exclusions canoniques, suffixe
+    `_lean`, siblings `_en.lean` ignores) et meme DECL_RE : le signal PR et
+    la metrique de tete ne peuvent pas diverger d'extracteur.
+    """
+    added: dict[str, set[str]] = collections.defaultdict(set)
+    path: str | None = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if path is None:
+            continue
+        if not line.startswith("+"):
+            if line.startswith("diff --git"):
+                path = None
+            continue
+        m = DECL_RE.match(line[1:])
+        if m:
+            added[path].add(m.group(2))
+    out: dict[str, set[str]] = {}
+    for p, names in added.items():
+        if p.endswith("_en.lean") or _excluded(p):
+            continue
+        parts = p.split("/")
+        if not any(seg.endswith("_lean") for seg in parts):
+            continue
+        out[p] = names
+    return out
+
+
+def run_pr_diff(base: str, head: str) -> str:
+    """Diff unifie 3-points base...head limite aux .lean (depuis ROOT)."""
+    proc = subprocess.run(
+        ["git", "diff", "--unified=0", f"{base}...{head}", "--", "*.lean"],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git diff {base}...{head} a echoue: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def main_pr_mode(base: str, head: str, out_path: str | None) -> int:
+    diff_text = run_pr_diff(base, head)
+    added = names_from_unified_diff(diff_text)
+    all_names = set().union(*added.values()) if added else set()
+    seen, _, n_notebooks = collect_notebook_tokens(all_names)
+    if n_notebooks == 0:
+        print("ERREUR: aucun notebook lu -- instrument casse, pas un resultat.", file=sys.stderr)
+        return 2
+
+    rows = []
+    for p in sorted(added):
+        lake = next(seg for seg in p.split("/") if seg.endswith("_lean"))
+        for n in sorted(added[p]):
+            rows.append({"lake": lake, "file": p, "name": n, "cited": n in seen})
+    uncited = [r for r in rows if not r["cited"]]
+
+    print(f"{n_notebooks} notebooks lus ; {len(rows)} declaration(s) ajoutee(s) "
+          f"sur les lakes dans base...{head[:10]}")
+    if not rows:
+        print("Aucune declaration ajoutee sur un lake -- rien a signaler.")
+    for r in uncited:
+        print(f"  AJOUTEE NON CITEE: {r['name']}  ({r['lake']}/{Path(r['file']).name})")
+    if rows:
+        print(f"TOTAL ajoutees: {len(rows)}  non citees (borne large): {len(uncited)}")
+
+    if out_path:
+        Path(out_path).write_text(
+            json.dumps({"added": len(rows), "uncited": len(uncited), "detail": uncited},
+                       indent=1, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        print(f"detail -> {out_path}")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--json", dest="out", help="ecrire le detail machine-lisible ici")
     ap.add_argument("--lake", help="restreindre l'affichage a un lake")
+    ap.add_argument("--pr-base", dest="pr_base",
+                    help="mode PR : declarations ajoutees par le diff base...HEAD non citees")
+    ap.add_argument("--pr-head", dest="pr_head", default="HEAD",
+                    help="tete du diff en mode PR (defaut: HEAD)")
     args = ap.parse_args()
+
+    if args.pr_base:
+        return main_pr_mode(args.pr_base, args.pr_head, args.out)
 
     lakes = collect_declarations()
     if not lakes:

--- a/scripts/tests/test_scan_lake_visibility_pr_mode.py
+++ b/scripts/tests/test_scan_lake_visibility_pr_mode.py
@@ -1,0 +1,91 @@
+"""Tests du mode PR de scan_lake_notebook_visibility (acceptance 3, #11703).
+
+L'extraction des declarations ajoutees par un diff unifie est une fonction
+PURE (names_from_unified_diff) : testable sans git, sur un diff embarque.
+Les fixtures vivent ICI, pas sur le disque (lecon fixture-embarquee : un
+test lisant un fichier muté in-place par un run vivant race ce run).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "scan_lake_visibility",
+    Path(__file__).resolve().parents[1] / "lean" / "scan_lake_notebook_visibility.py",
+)
+MOD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MOD)
+
+DIFF = """\
+diff --git a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core.lean b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core.lean
+index 1111111..2222222 100644
+--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core.lean
++++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core.lean
+@@ -12,0 +13,2 @@
++theorem mimoThm_new : True := trivial
++def flipAux2 (n : Nat) := n + 1
+@@ -40,1 +43,0 @@
+-theorem mimoThm_old : True := trivial
+diff --git a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core_en.lean b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core_en.lean
+index 3333333..4444444 100644
+--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core_en.lean
++++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core_en.lean
+@@ -12,0 +13,1 @@
++theorem englishOnlyThm : True := trivial
+diff --git a/src/PlainCode.lean b/src/PlainCode.lean
+index 5555555..6666666 100644
+--- a/src/PlainCode.lean
++++ b/src/PlainCode.lean
+@@ -1,0 +2,1 @@
++theorem notALakeThm : True := trivial
+diff --git a/.lake/packages/mathlib/Mathlib/Order/Basic.lean b/.lake/packages/mathlib/Mathlib/Order/Basic.lean
+index 7777777..8888888 100644
+--- a/.lake/packages/mathlib/Mathlib/Order/Basic.lean
++++ b/.lake/packages/mathlib/Mathlib/Order/Basic.lean
+@@ -1,0 +2,1 @@
++theorem vendoredThm : True := trivial
+"""
+
+
+def test_added_names_extracted_per_file():
+    added = MOD.names_from_unified_diff(DIFF)
+    core = "MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core.lean"
+    assert added == {core: {"mimoThm_new", "flipAux2"}}
+
+
+def test_en_sibling_ignored():
+    added = MOD.names_from_unified_diff(DIFF)
+    assert not any(p.endswith("_en.lean") for p in added)
+
+
+def test_non_lake_path_ignored():
+    added = MOD.names_from_unified_diff(DIFF)
+    assert "src/PlainCode.lean" not in added
+
+
+def test_vendored_excluded():
+    added = MOD.names_from_unified_diff(DIFF)
+    assert not any(".lake/packages" in p for p in added)
+
+
+def test_removed_lines_do_not_count():
+    added = MOD.names_from_unified_diff(DIFF)
+    core = "MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Mimo/Core.lean"
+    assert "mimoThm_old" not in added[core]
+
+
+def test_modifiers_and_annotations_still_match():
+    local_diff = (
+        "--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/G.lean\n"
+        "+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/G.lean\n"
+        "@@ -1,0 +2,2 @@\n"
+        "+@[simp] theorem annotatedThm : True := trivial\n"
+        "+private def hiddenDef2 := 5\n"
+    )
+    added = MOD.names_from_unified_diff(local_diff)
+    assert added == {
+        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/G.lean":
+            {"annotatedThm", "hiddenDef2"}
+    }


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA — prev: MED/notebook-python #14434

## Summary

Tranche **acceptance 3** de l'EPIC #11703 — le seul critère restant non tenu selon la passe de curation #13906 : *« signal CI advisory listant les déclarations ajoutées non citées sur les PR `*_lean/**` »*. Jusqu'ici `grep -rli 'scan_lake_notebook_visibility' .github/workflows/` rendait 0 : l'organe versionné (#11704) mesurait la visibilité repo-wide mais rien n'empêchait la métrique de re-dériver entre deux re-mesures manuelles — c'est exactement ce que la curation a constaté (chaque ligne du tableau du 2026-08-19 était fausse le 2026-09-02, toutes dans le même sens).

- **`scripts/lean/scan_lake_notebook_visibility.py` — nouveau mode `--pr-base <sha> [--pr-head <sha>]`** : déclarations **ajoutées** par le diff 3-points sur les lakes, non citées dans **aucun** notebook du checkout, à la **borne large** (tout nom trouvé — si même elle ne trouve pas, le nom est invisible partout : le signal le moins bruité possible). L'extraction consomme `DECL_RE`, `_excluded`, le suffixe `_lean` et l'ignore des siblings `_en.lean` de l'organe canonique — **zéro réimplémentation**, le signal PR et la métrique de tête ne peuvent pas diverger d'extracteur. Le mode repo-wide d'origine est inchangé (vérifié : contrôle positif intégré PASS, 1219 notebooks lus, 21/214 modules invisibles — cohérent avec la re-mesure 02/09 du body).
- **`.github/workflows/lean-visibility-advisory.yml`** : advisory **jamais bloquant** (le job sort toujours 0) sur le modèle `consecutive-code-cells-advisory.yml` (#12797) — le payload actionnable est la **paire de labels** : `lean-visibility-drift` (déclarations ajoutées non citées > 0) / `lean-visibility-unmeasured` (l'organe a échoué — #8819 : « n'a pas pu mesurer » ≠ « sans défaut »). Self-cover dans `paths:` (#8822), garde anti-fork au niveau job, runs-on statique `[self-hosted, coursia-ephemeral, coursia-linux]`.
- **`scripts/ci/check_self_hosted_runner_policy.py`** : entrée allowlist tranche 7 avec commentaire owner/profil/rollback (fail-closed, PR 14228).
- **`scripts/tests/test_scan_lake_visibility_pr_mode.py`** : 6 tests de la fonction pure `names_from_unified_diff` (fixture diff **embarquée** — leçon fixture-in-place), couvrant : extraction par fichier, `_en.lean` ignoré, chemin hors-lake ignoré, `.lake/packages` exclu, lignes supprimées non comptées, modificateurs/annotations (`@[simp]`, `private`) toujours matchés.

## Validation

- `pytest scripts/tests/test_scan_lake_visibility_pr_mode.py` → **6 passed** ; `pytest scripts/tests/test_check_self_hosted_runner_policy.py` → **49 passed** (post-allowlist).
- `check_self_hosted_runner_policy.py` → **OK** (139 workflows scannés, 0 violation) ; `check_workflow_label_paths.py` → **self-covered (pass)**.
- **Contrôle de vie sur un diff réel** : `--pr-base c6bea663a8c3^ --pr-head c6bea663a8c3` (commit #14381, parité des inversions game_theory_lean) → « 25 ajoutées, 21 non citées (borne large) » — le signal est **vrai et actionnable** (les 21 noms de Parite.lean n'apparaissent dans aucun notebook), pas du bruit.
- **Anti-régression organe** : mode repo-wide inchangé, sortie et contrôle positif intacts.
- YAML validé (safe_load), workflow dispatch-able.

## Pourquoi MED et pas LIGHT

Le litmus LIGHT (« générable en scannant l'instance suivante ? ») ne tient pas : le mode PR réutilise l'extracteur de l'organe par import du même module (pas un grep rejouable), la sémantique borne-large-vs-strict est une décision instrument (anti-bruit), et le workflow porte la paire de labels #8819. Le grain change quelque chose de durable : la métrique de tête ne peut plus re-dériver en silence.

See #11703 — tranche acceptance 3 ; l'EPIC reste ouverte (discrepancy_lean 6/8 noirs porté par #12823, enrichissements en flight par d'autres lanes).
