### PR TITLE
chore(twin-parity,#8057): re-attest ML-5 TimeSeries — seul drift restant du registre (cf #8264)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
@@ -24,7 +24,15 @@
       csharp_sha: b0c0a5297ace0d8fe490901b3dc8e522af15d649
       content_python_sha: 083c392f8d9070ae5b22b7bfcbb6b57c5a6a5f8365929cf45134c5a93f2ca3eb
       content_csharp_sha: e24fbc32219e7ebaeea9223982e906434465dd83c3394fc9a3be59b3d0384db0
+    - date: "2026-09-03"
+      by: myia-po-2026:CoursIA
+      python_sha: 5e863ede175ce3bf689752df4e3750ac08f2a71f
+      csharp_sha: 1b66717cf364decb17a23edbd87c1df5df9099cb
+      content_python_sha: 083c392f8d9070ae5b22b7bfcbb6b57c5a6a5f8365929cf45134c5a93f2ca3eb
+      content_csharp_sha: 5f5671cb8d5021a4237c9f61a1a47f29baf213a6baf32c90bbe5383868081f85
+      reason: "Re-attestation drift pre-existant (PR dediee cf #8264) : #13001 (fix eval SSA #12988, commit 9e03b82e3) a modifie le twin C# SANS re-attester -- csharp b0c0a529 -> 1b66717c, python 5e863ede inchange (cote OK). Audit firsthand du delta : moteurs intacts (ForecastBySsa + Microsoft.ML.TimeSeries 5.0.0), 16/16 cellules code execution_count non-null, 0 output erreur, SelectMany.Zip buggé absent (0 occurrence), protocole origine-horizon explicite + baseline naive executee (verifie grep), +1 Exercice 6 temperature (stub TODO C.1-compliant). Parite native-both intacte."
   known_differences:
+    - "2026-09-03 : protocole d evaluation C# refondu par #13001 (#12988) sans changement de moteur : table alignee (origine x horizon, reel vs predit vs naive) remplace le SelectMany.Zip non aligne (MAE 33,8 / RMSE 41,8 bugges), baseline naive executee, + Exercice 6 temperature. Les metriques C# ne sont PAS comparables au twin Python (STL/SARIMAX, cf non-comparabilite documentee ci-dessus) -- divergence de protocole d evaluation, pas de parite de moteur."
     - "2026-08-19 : reclassification surface -> native-both (adjudication dispatch #10382 '3 paires surface', lane myia-po-2026:CoursIA). Les DEUX cotes font le travail du notebook au moyen d'un moteur de production nomme de leur ecosysteme : C# = Microsoft.ML.TimeSeries 5.0.0 ForecastBySsa (15/15 cellules code executees), Python = statsmodels STL + SARIMAX (12/12 executees). La difference de famille algorithmique reste documentee ci-dessous -- difference de METHODE, pas absence de moteur."
     - "2026-08-15 : correction d'auteurs falsifies (issue #11044, tranche W3C SPARQL / ML.NET KDD) — citations remises a leurs auteurs reels (Amizadeh S., DOI KDD, Protocol et al., etc.), markdown-only, aucun changement d'engine/outputs. Parite semantique conservee ; rebaseline content SHA (re-audit 2026-08-15, myia-po-2026:CoursIA-2)."
     - "FAMILLES ALGORITHMIQUES DIFFERENTES (pas un simple idiome swap) : C# = `Microsoft.ML.Transforms.TimeSeries` -> `ForecastBySsa` (Singular Spectrum Analysis, decomposition spectrale ML.NET-native). Python = `statsmodels` -> `STL` (seasonal-trend LOESS decomposition) + `SARIMAX` (seasonal ARIMA classique)."


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14152 (cycle 153)

## Summary

Re-attestation de la paire jumelle `ML-5 TimeSeries` (ML.NET/Python, `native-both`) — le **seul drift pre-existant** du registre a origin/main (`dc4467519`), releve dans une PR dediee conformement a #8264.

**Cause racine** : #13001 (fix eval SSA #12988, commit `9e03b82e3`, 2026-08-29) a modifie `ML-5-TimeSeries.ipynb` (C#) **sans re-attester** la paire : `csharp_sha b0c0a529 -> 1b66717c`. Cote Python inchange (`5e863ede` = SHA enregistre).

**Audit firsthand du delta C#** (46784fe72 -> 9e03b82e3) avant attestation :
- Moteurs intacts : `ForecastBySsa` + `Microsoft.ML.TimeSeries 5.0.0` presents (verifie grep sur source HEAD)
- 16/16 cellules code `execution_count` non-null, **0 output erreur**
- Le `SelectMany.Zip` non aligne (MAE 33,8 / RMSE 41,8 bugges) est bien absent (0 occurrence)
- Protocole origine x horizon explicite (24 occurrences `horizon`), baseline naive executee (9 occurrences)
- +1 cellule : Exercice 6 temperature (stub `TODO`, pattern C.1-compliant, jamais `raise`)
- 15 -> 16 cellules code, 26 -> 27 md — delta = execution reelle + protocole + exercice, pas de changement de moteur

**Changement** : 1 fichier, +8 lignes — entree d'audit append-only (SHAs HEAD + `reason`) + 1 entree `known_differences` (protocole d'evaluation C# refondu, non-comparabilite numerique avec le twin Python STL/SARIMAX deja documentee — divergence de protocole, pas de parite de moteur).

## Test plan

- [x] `check_twin_parity.py --check` au HEAD de la branche : **157/157 OK, DRIFT=0, MISSING=0** (avant : OK=156 DRIFT=1)
- [x] `git ls-tree origin/main` cote Python = SHA enregistre (drift purement C#)
- [x] Catalogue byte-identique a main (aucun fichier catalogue touche)
- [ ] CI twin parity + PR gate verts

See #8264 (processus drifts pre-existants), refs #12988 (issue d'origine du fix eval), refs #8057 (registre).
