### PR TITLE
fix(ml,#14470): L1_tsmom — graines vivantes (sous-panier + offset) + coûts proportionnels au turnover

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L1_tsmom.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L1_tsmom.md
@@ -11,38 +11,59 @@ Time-Series Momentum (Moskowitz-Ooi-Pedersen 2012) on 25-symbol anti-bias panier
 - **Position sizing**: volatility-scaled to 15% annualized target
 - **Portfolio**: equal-weight across assets
 - **Validation**: walk-forward expanding, 5 folds, gap=21d
-- **Transaction costs**: 5bps equity, 10bps crypto, 50bps stress test
-- **Benchmark**: equal-weight buy-and-hold (Sharpe 1.15)
+- **Seeds** (live, #14470): each seed draws a 21-symbol sub-basket (80% of 26,
+  without replacement) + an origin offset of 0-40 business days; the SAME view
+  feeds TSMOM and its B&H baseline (paired comparison)
+- **Transaction costs** (#14470): proportional to the notional actually moved
+  (daily turnover, `sum |Δposition|`), at 5bps equity / 10bps crypto / 50bps
+  stress. The legacy L1 convention (one full round-trip per moving line per
+  day) is kept as the diagnostic column `Net Sharpe (L1 conv.)`
+- **Benchmark**: equal-weight buy-and-hold (Sharpe 1.09, per-seed views)
 
 ## Results
 
-| Lookback | Gross Sharpe | Net Sharpe | B&H Sharpe | Delta | Trades | Verdict |
-|----------|-------------|-----------|-----------|-------|--------|---------|
-| 21d      | 0.18        | -2.56     | 1.15      | -3.71 | 5519   | NO BEATS |
-| 63d      | 0.15        | -2.40     | 1.15      | -3.55 | 5519   | NO BEATS |
-| 126d     | 0.12        | -2.26     | 1.15      | -3.41 | 5519   | NO BEATS |
-| 252d     | 0.14        | -2.37     | 1.15      | -3.52 | 5519   | NO BEATS |
+| Lookback | Gross Sharpe | Net Sharpe | Net Sharpe (L1 conv.) | B&H Sharpe | Delta | Avg daily turnover | Verdict |
+|----------|-------------|-----------|----------------------|-----------|-------|--------------------|---------|
+| 21d      | 0.51        | 0.43      | -2.42                | 1.09      | -0.66 | 0.18               | NO BEATS |
+| 63d      | 0.52        | 0.49      | -2.41                | 1.09      | -0.60 | 0.09               | NO BEATS |
+| 126d     | 0.84        | 0.81      | -2.20                | 1.09      | -0.28 | 0.07               | NO BEATS |
+| 252d     | 0.75        | 0.73      | -2.28                | 1.09      | -0.36 | 0.05               | NO BEATS |
+| 126d stress | 0.84     | 0.62      | -19.07               | 1.09      | -0.47 | 0.07               | NO BEATS |
 | 126d stress | 0.81     | -19.13    | 1.15      | -20.28| 5519   | NO BEATS |
 
 ## Key Findings
 
-1. **TSMOM is profitable gross but destroyed by costs**. Even moderate costs (~5-10bps)
-   erase the thin momentum signal, producing deeply negative net Sharpe.
+1. **The verdict does not change, but the margin does**. Under the turnover-proportional
+   cost convention (#14470), TSMOM is net-positive (0.43-0.81) instead of deeply negative,
+   yet still fails to beat B&H by -0.28 to -0.66 Sharpe. The `Net Sharpe (L1 conv.)`
+   column shows what the legacy full round-trip-per-moving-line convention billed — that
+   convention overstated rebalancing cost and was the sole source of the previously
+   published deeply-negative net Sharpes.
 
-2. **High trade frequency kills performance**. TSMOM generates ~5500 trades over the
-   OOS period (daily rebalancing across 25 assets). Daily position changes compound costs.
+2. **Costs still drag, but proportionally to what is moved**. Daily rebalancing moves
+   0.05-0.18 of notional per day (vol-scaled weights drift); at 5-10bps this costs
+   0.02-0.11 Sharpe, not the 3+ Sharpe the legacy convention implied. Testing the
+   article's monthly rebalancing remains the open question (out of scope here, cf #14470
+   third lead).
 
-3. **Longer lookbacks slightly reduce losses** (126d: -2.26 vs 21d: -2.56) because
-   fewer position flips, but still deeply negative.
+3. **Longer lookbacks do better** (126d net 0.81 vs 21d net 0.43) — fewer position flips
+   and a more stable signal.
 
-4. **B&H benchmark is strong** (Sharpe 1.15) because the panier includes the 2015-2025
+4. **B&H benchmark is strong** (Sharpe 1.09) because the panier includes the 2015-2025
    bull market in equities + crypto. Active strategies face a high hurdle.
+
+5. **The multi-seed gate now measures something** (#14470). Before the fix, the seed
+   loop built an rng that was never consumed: the 4 seeds ran byte-identical
+   computations, cross-seed std was exactly 0, and the `t_stat >= 2.0` BEATS gate was
+   structurally unreachable. Live sub-basket + origin-offset views give per-seed
+   dispersion (t-stats -7.1 to -14.8 on this run) — the gate can now, in principle,
+   return BEATS.
 
 ## Data
 
 - 25 of 26 panier symbols loaded (VIX excluded as it has no price return)
 - Date range: 2015-01-02 to 2026-05-23
-- OOS observations: 1656 per seed
+- OOS observations: ~1650 per seed (varies slightly with the seed's origin offset)
 
 ## Script
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1_tsmom.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1_tsmom.py
@@ -9,6 +9,13 @@ Compares TSMOM portfolio (equal-weight across assets) vs equal-weight
 buy-and-hold benchmark. Transaction costs: 5bps equity, 10bps crypto,
 50bps stress test.
 
+Seeds are LIVE (#14470): each seed draws a sub-basket (80% of symbols,
+without replacement) and an origin offset (0-40 business days). The same
+view feeds the model and its buy-and-hold baseline, so the comparison
+stays paired. Transaction costs are proportional to the notional actually
+moved (turnover); the legacy per-moving-line round-trip convention is kept
+as a diagnostic column (``net_sharpe_l1_convention``).
+
 Usage:
     python L1_tsmom.py
     python L1_tsmom.py --dry-run
@@ -61,6 +68,25 @@ DEFAULT_LOOKBACKS = [21, 63, 126, 252]  # ~1/3/6/12 months
 DEFAULT_SEEDS = [0, 1, 7, 42]
 TARGET_VOL = 0.15  # annualized target volatility
 VOL_LOOKBACK = 63  # vol estimation window
+
+# Live-seed view parameters (#14470): sub-basket share and max origin offset.
+SUBBASKET_SHARE = 0.8
+MAX_ORIGIN_OFFSET = 40  # business days, drawn in [0, MAX_ORIGIN_OFFSET]
+
+
+def draw_seed_view(rng: np.random.Generator, symbols: list[str]) -> tuple[list[str], int]:
+    """Draw the per-seed view: sub-basket without replacement + origin offset.
+
+    The rng consumption order (subset first, then offset) is part of the
+    contract: ``run_tsmom_single_lookback`` and ``run_buyhold_baseline`` both
+    call this with identically-seeded generators so seed k yields the SAME
+    view on both sides — the comparison stays paired (#14470 defaut 1).
+    """
+    n_sub = max(2, int(round(SUBBASKET_SHARE * len(symbols))))
+    idx = rng.choice(len(symbols), size=min(n_sub, len(symbols)), replace=False)
+    subset = sorted(symbols[i] for i in idx)
+    offset = int(rng.integers(0, MAX_ORIGIN_OFFSET + 1))
+    return subset, offset
 
 
 def get_cost_model(symbol: str, stress: bool = False) -> TransactionCostModel:
@@ -122,19 +148,26 @@ def run_tsmom_single_lookback(
 
     for seed in seeds:
         rng = np.random.default_rng(seed)
-        n_samples = len(returns)
+        subset, offset = draw_seed_view(rng, symbols)
+
+        # Apply the seed's view: sub-basket columns + origin offset
+        view_returns = returns[subset].iloc[offset:]
+        view_signals = signals_df[subset].iloc[offset:]
+        view_vol = vol_df[subset].iloc[offset:]
 
         # Walk-forward expanding
         splitter = WalkForwardSplitter(n_splits=n_splits, gap=gap)
 
         # Use aligned numpy arrays
-        ret_arr = returns.values
-        sig_arr = signals_df.values
-        vol_arr = vol_df.values
+        ret_arr = view_returns.values
+        sig_arr = view_signals.values
+        vol_arr = view_vol.values
 
         fold_returns_gross = []
         fold_returns_net = []
+        fold_returns_net_l1 = []
         fold_trades = []
+        fold_turnover = []
 
         for train_idx, test_idx in splitter.split(ret_arr):
             if len(test_idx) == 0:
@@ -155,9 +188,10 @@ def run_tsmom_single_lookback(
             # Portfolio gross return per day
             port_gross = np.nansum(positions * test_ret, axis=1) / n_assets
 
-            # Detect trades (position changes across all assets)
-            pos_changes = np.abs(np.diff(positions, axis=0, prepend=np.zeros_like(positions[0:1])))
-            trades_per_day = np.sum(pos_changes > 0, axis=1)
+            # Notional actually moved per day (turnover) and legacy line-count
+            deltas = np.abs(np.diff(positions, axis=0, prepend=np.zeros_like(positions[0:1])))
+            turnover_per_day = np.sum(deltas, axis=1)
+            trades_per_day = np.sum(deltas > 0, axis=1)  # diagnostic: moving lines
 
             # Apply transaction costs
             if stress:
@@ -170,41 +204,58 @@ def run_tsmom_single_lookback(
                             n_crypto * CRYPTO_COST.cost_per_trade(100)) / len(symbols)
                 cost_per_trade = avg_cost
 
-            trade_costs = trades_per_day * 2 * cost_per_trade / n_assets
+            # Costs proportional to the notional actually moved (#14470 defaut 2)
+            trade_costs = turnover_per_day * cost_per_trade / n_assets
             port_net = port_gross - trade_costs
+
+            # Legacy L1 convention kept as diagnostic: one full round-trip per
+            # moving line, per day (overstates rebalancing cost)
+            l1_costs = trades_per_day * 2 * cost_per_trade / n_assets
+            port_net_l1 = port_gross - l1_costs
 
             # Remove NaN
             valid = ~(np.isnan(port_gross) | np.isnan(port_net))
             fold_returns_gross.extend(port_gross[valid].tolist())
             fold_returns_net.extend(port_net[valid].tolist())
+            fold_returns_net_l1.extend(port_net_l1[valid].tolist())
             fold_trades.extend(trades_per_day[valid].tolist())
+            fold_turnover.extend(turnover_per_day[valid].tolist())
 
         gross_arr = np.array(fold_returns_gross)
         net_arr = np.array(fold_returns_net)
+        net_l1_arr = np.array(fold_returns_net_l1)
 
         if len(gross_arr) > 10:
             gross_sharpe = sharpe_from_returns(pd.Series(gross_arr))
             net_sharpe = sharpe_from_returns(pd.Series(net_arr))
+            net_sharpe_l1 = sharpe_from_returns(pd.Series(net_l1_arr))
             gross_cagr = float(np.prod(1 + gross_arr) ** (252 / max(len(gross_arr), 1)) - 1)
             net_cagr = float(np.prod(1 + net_arr) ** (252 / max(len(net_arr), 1)) - 1)
             total_trades = int(np.sum(fold_trades))
             trade_freq = total_trades / max(len(gross_arr), 1)
+            avg_turnover = float(np.mean(fold_turnover)) if fold_turnover else 0.0
         else:
             gross_sharpe = 0.0
             net_sharpe = 0.0
+            net_sharpe_l1 = 0.0
             gross_cagr = 0.0
             net_cagr = 0.0
             total_trades = 0
             trade_freq = 0.0
+            avg_turnover = 0.0
 
         all_seed_results.append({
             "seed": seed,
+            "view_n_symbols": len(subset),
+            "view_offset": offset,
             "gross_sharpe": round(float(gross_sharpe), 4),
             "net_sharpe": round(float(net_sharpe), 4),
+            "net_sharpe_l1_convention": round(float(net_sharpe_l1), 4),
             "gross_cagr": round(float(gross_cagr), 4),
             "net_cagr": round(float(net_cagr), 4),
             "total_trades": total_trades,
             "trade_freq": round(float(trade_freq), 4),
+            "avg_daily_turnover": round(avg_turnover, 4),
             "n_oos": len(gross_arr),
         })
 
@@ -231,8 +282,12 @@ def run_buyhold_baseline(
     all_seed_results = []
 
     for seed in seeds:
+        rng = np.random.default_rng(seed)
+        subset, offset = draw_seed_view(rng, symbols)
+        view_returns = returns[subset].iloc[offset:]
+
         splitter = WalkForwardSplitter(n_splits=n_splits, gap=gap)
-        ret_arr = returns.values
+        ret_arr = view_returns.values
         n_assets = ret_arr.shape[1]
 
         fold_returns = []
@@ -254,6 +309,8 @@ def run_buyhold_baseline(
 
         all_seed_results.append({
             "seed": seed,
+            "view_n_symbols": len(subset),
+            "view_offset": offset,
             "sharpe": round(float(bh_sharpe), 4),
             "cagr": round(float(bh_cagr), 4),
             "n_oos": len(ret_arr_bh),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_l1_tsmom.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_l1_tsmom.py
@@ -10,15 +10,15 @@ This suite covers the three pure functions that carry the baseline's logic:
 - ``compute_vol_scale``: target-vol position sizing, clipped to [0.1, 3.0]
 - ``compute_verdict``: BEATS / NO BEATS / INCONCLUSIVE gate
 
-It also pins a **methodology finding** (see ``TestComputeVerdict``): because
-TSMOM and buy-and-hold are deterministic (no stochastic training), the 4 seeds
-produce identical Sharpes, the cross-seed std collapses to 0, and
-``compute_verdict``'s t_stat is structurally 0 — so the ``t_stat >= 2.0`` gate
-is unreachable for this class of strategy. This test documents the current
-behavior so any future methodology fix (e.g. switching to a paired t-test on
-daily return differences) is a deliberate, detected change rather than a
-silent regression. The fix itself is out of scope (it changes how a KEEPER's
-verdict is computed and needs a methodology decision, not a unilateral edit).
+It also pins a **methodology property** (see ``TestComputeVerdict``):
+``compute_verdict`` maps zero cross-seed dispersion to ``t_stat = 0`` and
+therefore can never return BEATS on identical Sharpes. That state was the
+nominal behavior of L1 until #14470: the seed loop built an rng that was
+never consumed, so the 4 seeds ran byte-identical computations. Since #14470
+the seeds are LIVE (``draw_seed_view``: sub-basket 80% without replacement +
+origin offset 0-40 business days, same view for model and baseline), so real
+runs produce non-zero dispersion and the gate measures something — the
+integration tests in ``TestLiveSeeds`` pin exactly that.
 
 All fixtures are deterministic synthetic series — no network, no GPU, no data
 files. Runs in well under a second on CPU.
@@ -38,11 +38,17 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from L1_tsmom import (  # noqa: E402
+    MAX_ORIGIN_OFFSET,
+    SUBBASKET_SHARE,
     TARGET_VOL,
     compute_tsmom_signal,
     compute_verdict,
     compute_vol_scale,
+    draw_seed_view,
+    run_buyhold_baseline,
+    run_tsmom_single_lookback,
 )
+from panier_loader import get_panier_symbols  # noqa: E402
 
 
 def _closes(n: int = 200, drift: float = 0.0, vol: float = 0.01, seed: int = 0) -> pd.Series:
@@ -186,7 +192,7 @@ class TestComputeVerdict:
         changes how a KEEPER's verdict is computed (needs a methodology
         decision, not a unilateral edit).
         """
-        # Identical TSMOM sharpes (as a real deterministic run produces),
+        # Identical TSMOM sharpes (a zero-dispersion input),
         # a large positive delta, every seed beats bh+0.10 — yet NOT BEATS.
         out = compute_verdict(
             _tsmom_results([1.5, 1.5, 1.5, 1.5]),
@@ -195,3 +201,111 @@ class TestComputeVerdict:
         assert out["delta_sharpe"] == pytest.approx(1.0)  # large edge
         assert out["t_stat"] == 0.0  # structurally zero (std collapsed)
         assert out["verdict"] == "INCONCLUSIVE"  # BEATS unreachable despite the edge
+
+    def test_verdict_reachable_with_live_dispersion(self) -> None:
+        """Mirror of the zero-dispersion pin: with the dispersion that live
+        seeds produce (#14470), the same large edge DOES reach BEATS."""
+        out = compute_verdict(
+            _tsmom_results([1.4, 1.5, 1.45, 1.55]),
+            _bh_results([0.5, 0.5, 0.5, 0.5]),
+        )
+        assert out["t_stat"] >= 2.0
+        assert out["verdict"] == "BEATS"
+
+
+# ── live seeds (#14470) ─────────────────────────────────────────────────────
+
+_SYMBOLS = get_panier_symbols()
+
+
+def _synthetic_closes(n_rows: int = 900, n_syms: int = 10, seed: int = 5) -> pd.DataFrame:
+    """Synthetic closes on REAL panier column names (run_tsmom_single_lookback
+    filters columns against ALL_SYMBOLS, so synthetic names would be dropped)."""
+    rng = np.random.default_rng(seed)
+    idx = pd.bdate_range("2015-01-01", periods=n_rows)
+    rets = rng.standard_normal((n_rows, n_syms)) * 0.01
+    cols = _SYMBOLS[:n_syms]
+    return pd.DataFrame(100 * np.exp(np.cumsum(rets, axis=0)), index=idx, columns=cols)
+
+
+class TestDrawSeedView:
+    def test_subset_share_and_offset_range(self) -> None:
+        n = len(_SYMBOLS)
+        expected_sub = max(2, int(round(SUBBASKET_SHARE * n)))
+        for seed in range(20):
+            subset, offset = draw_seed_view(np.random.default_rng(seed), _SYMBOLS)
+            assert len(subset) == expected_sub  # 21 of 26
+            assert set(subset) <= set(_SYMBOLS)
+            assert len(subset) == len(set(subset))  # without replacement
+            assert 0 <= offset <= MAX_ORIGIN_OFFSET
+
+    def test_small_symbol_list_is_not_emptied(self) -> None:
+        subset, _ = draw_seed_view(np.random.default_rng(0), _SYMBOLS[:3])
+        # round(0.8 * 3) = 2, floored at max(2, ...) and capped by len
+        assert len(subset) == 2
+        assert set(subset) <= set(_SYMBOLS[:3])
+
+    def test_same_seed_same_view_for_model_and_baseline(self) -> None:
+        """Pairing contract: identically-seeded draws give the identical view,
+        so the model and its B&H baseline are compared on the same slice."""
+        for seed in (0, 1, 7, 42):
+            v_model = draw_seed_view(np.random.default_rng(seed), _SYMBOLS)
+            v_bh = draw_seed_view(np.random.default_rng(seed), _SYMBOLS)
+            assert v_model == v_bh
+
+    def test_different_seeds_draw_different_views(self) -> None:
+        views = {(tuple(sub), off)
+                 for sub, off in (draw_seed_view(np.random.default_rng(s), _SYMBOLS)
+                                  for s in range(8))}
+        assert len(views) > 1
+
+
+class TestLiveSeeds:
+    def test_cross_seed_dispersion_is_nonzero(self) -> None:
+        """The #14470 defect 1, written as a test: before the fix, the rng
+        was never consumed and the 4 seeds produced EXACTLY the same Sharpe
+        (std = 0.0000000000). With live views, dispersion must be > 0."""
+        closes = _synthetic_closes()
+        res = run_tsmom_single_lookback(closes, lookback=63, seeds=[0, 1, 7, 42],
+                                        n_splits=4, gap=10)
+        sharpes = [s["net_sharpe"] for s in res["seeds"]]
+        assert len(sharpes) == 4
+        assert float(np.std(sharpes)) > 0.0
+        # the per-seed views actually differ and are recorded
+        views = [(s["view_n_symbols"], s["view_offset"]) for s in res["seeds"]]
+        assert len(set(views)) > 1
+
+    def test_baseline_uses_the_same_views_as_the_model(self) -> None:
+        closes = _synthetic_closes()
+        seeds = [0, 1, 7, 42]
+        res = run_tsmom_single_lookback(closes, lookback=63, seeds=seeds,
+                                        n_splits=4, gap=10)
+        bh = run_buyhold_baseline(closes, seeds=seeds, n_splits=4, gap=10)
+        model_views = {(s["seed"], s["view_n_symbols"], s["view_offset"])
+                       for s in res["seeds"]}
+        bh_views = {(s["seed"], s["view_n_symbols"], s["view_offset"])
+                    for s in bh["seeds"]}
+        assert model_views == bh_views  # paired comparison
+        assert len(bh_views) > 1  # baseline is no longer seed-blind either
+
+
+class TestTurnoverCosts:
+    def test_l1_convention_diagnostic_column_present(self) -> None:
+        closes = _synthetic_closes()
+        res = run_tsmom_single_lookback(closes, lookback=63, seeds=[0, 1],
+                                        n_splits=3, gap=10)
+        for s in res["seeds"]:
+            assert "net_sharpe_l1_convention" in s
+            assert "avg_daily_turnover" in s
+            # turnover-proportional costs are strictly lower than the legacy
+            # full round-trip per moving line (which overstates rebalancing)
+            assert s["net_sharpe"] >= s["net_sharpe_l1_convention"] - 1e-9
+
+    def test_turnover_metric_is_within_notional_bounds(self) -> None:
+        closes = _synthetic_closes()
+        res = run_tsmom_single_lookback(closes, lookback=63, seeds=[0],
+                                        n_splits=3, gap=10)
+        s = res["seeds"][0]
+        # position weights are vol-scaled in [0.1, 3.0] per asset; daily total
+        # notionnel moved stays bounded by n_assets * max_scale * 2
+        assert 0.0 <= s["avg_daily_turnover"] <= s["view_n_symbols"] * 3.0 * 2 + 1e-9


### PR DESCRIPTION
Grain: MED/strategy-ml -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14494 (cycle 154)

## Summary

Repare les deux defauts mesures de l'issue #14470 dans `L1_tsmom.py` (baseline de reference TSMOM, epic Curriculum-V3 #1409). **3 fichiers, +227/-35** : script, tests, doc.

**Defaut 1 — boucle multi-graines inerte** : le `rng` construit l.124 n'etait jamais consomme (grep : 1 occurrence). Les 4 graines parcouraient le meme calcul, std inter-graines = 0.0 exactement, `t_stat = 0` structurellement ⇒ verdict `BEATS` inatteignable quel que soit l'ecart. Fix : `draw_seed_view(rng, symbols)` — sous-panier 80 % sans remise (21/26 symboles) + decalage d'origine 0-40 j ouvrables. **Meme vue pour le modele ET sa baseline B&H** (consommation rng identique des deux cotes ⇒ comparaison appariee) ; vues tracees par seed dans les resultats (`view_n_symbols`, `view_offset`).

**Defaut 2 — couts factures en aller-retour plein notionnel** : `trades_per_day * 2 * cost_per_trade / n_assets` comptait un aller-retour complet par ligne bougeant d'un iota, chaque jour. Fix (formule exacte de l'issue) : `turnover = sum |Delta position|` par jour, `couts = turnover * cost_per_trade / n_assets`. Convention L1 conservee en colonne diagnostic `net_sharpe_l1_convention` (comme le fait L1b).

Hors scope (3e piste de l'issue) : rebalancement mensuel vs quotidien.

## Preuve d'execution (panier reel 26 symboles, `--stress`, re-exec complete)

| Lookback | Gross | Net (turnover) | Net (L1 conv.) | B&H | t-stat | Verdict |
|---|---|---|---|---|---|---|
| 21d | 0.51 | **0.43** | -2.42 | 1.09 | -14.8 | NO BEATS |
| 63d | 0.52 | **0.49** | -2.41 | 1.09 | -7.7 | NO BEATS |
| 126d | 0.84 | **0.81** | -2.20 | 1.09 | -7.1 | NO BEATS |
| 252d | 0.75 | **0.73** | -2.28 | 1.09 | -8.5 | NO BEATS |
| 126d stress | 0.84 | **0.62** | -19.07 | 1.09 | -12.2 | NO BEATS |

- Graines vivantes : 4 Sharpes distincts par lookback, vues par seed `[(21,1),(21,30),(21,8),(21,31)]` ; le `-2.26/-2.56` publie provenait uniquement de la convention de couts legacy.
- **Verdicts inchanges (NO BEATS)** : le fix rend le gate mesurant, il ne change pas la conclusion — delta net negatif (-0.28/-0.66) sur ce panier.
- Doc `docs/L1_tsmom.md` re-synchronisee : tableau + Key Findings sous la nouvelle convention primaire, colonne L1 conv. en diagnostic, methode (views par graine + convention de couts).

## Test plan

- [x] `pytest tests/test_l1_tsmom.py` : **22 passed** — nouveaux : dispersion inter-graines > 0 (miroir `test_l1b_tsmom_cf::test_zero_dispersion_can_never_reach_beats`), vue partagee modele/baseline par seed, bornes sous-panier/offset, colonne diagnostic + turnover borne, verdict BEATS atteignable avec dispersion vive
- [x] `pytest tests/test_l1b_tsmom_cf.py` : 23 passed (pas de regression voisine)
- [x] Re-execution reelle end-to-end `python L1_tsmom.py --stress` (checkpoint `checkpoints/l1_tsmom/`, gitignore)
- [x] `python L1_tsmom.py --dry-run` : OK
- [x] Consommateur unique (`L1b_tsmom.py`) : reference docstring seulement, 0 import casse
- [ ] CI verte

Closes #14470
