### PR TITLE
feat(sc7c,#14326): pas burn execute (80/80) + solution exo2 en annexe

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7c-ERC20-Lean-Native-Companion.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7c-ERC20-Lean-Native-Companion.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "2c45e064",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01003,
+     "end_time": "2026-09-03T16:56:28.634655+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T16:56:28.624625+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# SC-7c : ERC-20 — compagnon natif Lean (kernel `lean4-wsl`)\n",
     "\n",
@@ -35,8 +44,7 @@
     "\n",
     "**Différence avec SC-7b** : SC-7b lit le **texte** des sources et affiche la signature regexée. SC-7c **exécute** le code Lean sous le vrai noyau — toute différence entre ce que SC-7b *croit* voir et ce que SC-7c *vérifie* signalerait une divergence (lake modifié, doc obsolète, ou pire : une preuve qui ne type-checke plus en silence). C'est le filet de sécurité formel du notebook.\n",
     "\n",
-    "**Pour aller plus loin** : pour un traitement complet de la sémantique des smart contracts, voir les Foundations of Blockchain (Anthropic, 2024) et l'EPIC #4980 i18n qui documente la convention bilingue (FR/EN sibling-pair) appliquée à ce lake.\n",
-    ""
+    "**Pour aller plus loin** : pour un traitement complet de la sémantique des smart contracts, voir les Foundations of Blockchain (Anthropic, 2024) et l'EPIC #4980 i18n qui documente la convention bilingue (FR/EN sibling-pair) appliquée à ce lake.\n"
    ]
   },
   {
@@ -45,11 +53,19 @@
    "id": "522f3648",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:28.443865Z",
-     "iopub.status.busy": "2026-08-20T10:58:28.443739Z",
-     "iopub.status.idle": "2026-08-20T10:58:31.911808Z",
-     "shell.execute_reply": "2026-08-20T10:58:31.910971Z"
-    }
+     "iopub.execute_input": "2026-09-03T16:56:28.650054Z",
+     "iopub.status.busy": "2026-09-03T16:56:28.649866Z",
+     "iopub.status.idle": "2026-09-03T16:59:58.705737Z",
+     "shell.execute_reply": "2026-09-03T16:59:58.688949Z"
+    },
+    "papermill": {
+     "duration": 210.432993,
+     "end_time": "2026-09-03T16:59:59.074796+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T16:56:28.641803+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -64,12 +80,12 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Verification de l&#39;environnement : import du lake erc20_lean construit.</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Si cette cellule affiche une erreur d&#39;import, le lake n&#39;est pas dans le</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Verification de l'environnement : import du lake erc20_lean construit.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Si cette cellule affiche une erreur d'import, le lake n'est pas dans le</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- LEAN_PATH du kernel (executer depuis le repertoire du lake, cf. README).</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Ops</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Invariant</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20.State</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20.Ops</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20.Invariant</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
        "        </div>\n",
@@ -115,7 +131,16 @@
   {
    "cell_type": "markdown",
    "id": "bbcd1b52",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.019035,
+     "end_time": "2026-09-03T16:59:59.128266+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T16:59:59.109231+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. L'état du contrat et l'invariant (module `State`)\n",
     "\n",
@@ -123,8 +148,7 @@
     "\n",
     "**Pourquoi `Fin n` plutôt que `ℕ` ou `String`** : un contrat ERC-20 gère un nombre fini de détenteurs (les `mapping(address => uint256) balances` du Solidity). Modéliser `Address` comme `Fin n` capture cette finitude au niveau du type — `Finset.univ : Finset (Fin n)` est alors bien défini et la sommation `∑ a, s.balances a` est une opération mathématiquement légitime. Un modèle en `ℕ` (adresse numérique arbitraire) demanderait des hypothèses de bornitude ailleurs ; un modèle en `String` perdrait la structure discrète nécessaire aux preuves de majoration.\n",
     "\n",
-    "**Pourquoi l'invariant est une `Prop`** : en Solidity, l'invariant de conservation vit dans une `assert` runtime (coûteuse en gas, parfois désactivée). En Lean, il vit dans le **type** : `supplyInvariant : State n → Prop` est une proposition que chaque état doit satisfaire pour être *bien-formé*. La différence est philosophique : Solidity vérifie à l'exécution, Lean vérifie à la **compilation**. Un état `s : State n` qui ne satisfait pas `supplyInvariant s` n'est pas *faute de calcul* — il n'a simplement pas le droit d'exister dans une trace valide.\n",
-    ""
+    "**Pourquoi l'invariant est une `Prop`** : en Solidity, l'invariant de conservation vit dans une `assert` runtime (coûteuse en gas, parfois désactivée). En Lean, il vit dans le **type** : `supplyInvariant : State n → Prop` est une proposition que chaque état doit satisfaire pour être *bien-formé*. La différence est philosophique : Solidity vérifie à l'exécution, Lean vérifie à la **compilation**. Un état `s : State n` qui ne satisfait pas `supplyInvariant s` n'est pas *faute de calcul* — il n'a simplement pas le droit d'exister dans une trace valide.\n"
    ]
   },
   {
@@ -133,11 +157,19 @@
    "id": "2de7d0cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:31.913335Z",
-     "iopub.status.busy": "2026-08-20T10:58:31.913198Z",
-     "iopub.status.idle": "2026-08-20T10:58:32.130043Z",
-     "shell.execute_reply": "2026-08-20T10:58:32.129043Z"
-    }
+     "iopub.execute_input": "2026-09-03T16:59:59.192313Z",
+     "iopub.status.busy": "2026-09-03T16:59:59.190051Z",
+     "iopub.status.idle": "2026-09-03T17:00:00.056271Z",
+     "shell.execute_reply": "2026-09-03T17:00:00.054465Z"
+    },
+    "papermill": {
+     "duration": 0.918273,
+     "end_time": "2026-09-03T17:00:00.062602+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T16:59:59.144329+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -153,9 +185,9 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module State : 3 declarations (Address = abbrev, State, supplyInvariant)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.Address</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.Address<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.State</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.State<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.supplyInvariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.supplyInvariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
        "        </div>\n",
@@ -225,7 +257,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7bcad24c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011738,
+     "end_time": "2026-09-03T17:00:00.090869+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.079131+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie (State + supplyInvariant)\n",
     "\n",
@@ -236,14 +278,22 @@
     "\n",
     "**Pourquoi `Prop` plutôt que `Bool`** : la `Prop` est *non-computable* — Lean ne peut pas l'évaluer à `true`/`false` à l'exécution (sauf cas triviaux). C'est volontaire : une preuve est un objet logique, pas une valeur booléenne. `decide` permet de *réduire* une `Prop` close à un `Bool`, mais c'est une opération de *réflexion*, pas d'exécution.\n",
     "\n",
-    "**Différence avec SC-7b (companion python3)** : SC-7b aurait affiché les signatures regex-extraites du source — `\"ERC20.State (n : Nat) : Type\"`. SC-7c les affiche telles que le **noyau Lean** les produit — ce qui inclut les arguments implicites, la distinction `abbrev`/`structure`, et les notations. Si les deux divergent, c'est que le regex de SC-7b est obsolète ou que le lake a changé.\n",
-    ""
+    "**Différence avec SC-7b (companion python3)** : SC-7b aurait affiché les signatures regex-extraites du source — `\"ERC20.State (n : Nat) : Type\"`. SC-7c les affiche telles que le **noyau Lean** les produit — ce qui inclut les arguments implicites, la distinction `abbrev`/`structure`, et les notations. Si les deux divergent, c'est que le regex de SC-7b est obsolète ou que le lake a changé.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "295115d1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.013464,
+     "end_time": "2026-09-03T17:00:00.119216+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.105752+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie\n",
     "\n",
@@ -253,14 +303,22 @@
     "\n",
     "**`Address n := Fin n`** : la notation `abbrev` (vs `def`) garantit que `ERC20.Address` est **définitionnellement égal** à `Fin n` — le simplifieur `simp` peut remplacer `ERC20.Address n` par `Fin n` dans les preuves sans déclencher d'erreur de *definitional unfolding*. C'est une distinction Mathlib subtile mais critique pour l'automatisation des preuves.\n",
     "\n",
-    "**Pourquoi pas `n : Type` (universel)** : on pourrait imaginer `State : Type → Type` mais cela perdrait la garantie de finitude. `Fin n` force `n : ℕ`, ce qui rend la sommation `Finset.sum` légitime. C'est le pont entre *cardinalité finie* et *rigueur de la sommation*.\n",
-    ""
+    "**Pourquoi pas `n : Type` (universel)** : on pourrait imaginer `State : Type → Type` mais cela perdrait la garantie de finitude. `Fin n` force `n : ℕ`, ce qui rend la sommation `Finset.sum` légitime. C'est le pont entre *cardinalité finie* et *rigueur de la sommation*.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "6a2faa7e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006872,
+     "end_time": "2026-09-03T17:00:00.132701+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.125829+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Les opérations standard (module `Ops`)\n",
     "\n",
@@ -283,11 +341,19 @@
    "id": "406d9e85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:32.131298Z",
-     "iopub.status.busy": "2026-08-20T10:58:32.131155Z",
-     "iopub.status.idle": "2026-08-20T10:58:32.339102Z",
-     "shell.execute_reply": "2026-08-20T10:58:32.338167Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:00.140906Z",
+     "iopub.status.busy": "2026-09-03T17:00:00.140742Z",
+     "iopub.status.idle": "2026-09-03T17:00:00.347062Z",
+     "shell.execute_reply": "2026-09-03T17:00:00.345197Z"
+    },
+    "papermill": {
+     "duration": 0.211866,
+     "end_time": "2026-09-03T17:00:00.348769+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.136903+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -303,9 +369,9 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module Ops : 3 declarations</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>mint<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>burn</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>burn<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.mint</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.mint<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.burn</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.burn<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.transfer</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.transfer<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -379,7 +445,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6879d3b7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004583,
+     "end_time": "2026-09-03T17:00:00.362241+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.357658+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie (mint/burn/transfer)\n",
     "\n",
@@ -390,14 +466,22 @@
     "\n",
     "**Pourquoi pas `Option State n` en retour** : un `transfer` avec solde insuffisant produirait en pratique un état *mal-formé* (soldes tronqués). Modéliser cela avec `Option` forcerait tous les appels à gérer le cas d'erreur, polluant les preuves. Le compromis (retourner un `State n` et laisser les théorèmes imposer la garde) est le standard ERC-20 — y compris dans OpenZeppelin où `transfer` retourne `bool` (true = OK, false = underflow), pas `Option`.\n",
     "\n",
-    "**Lien avec Solidity** : le `bool` de retour Solidity est l'équivalent exact d'un `Option State n` : `true` ↔ `Some s'`, `false` ↔ `None`. Lean choisit l'omission du `bool` (toujours retourner `State n`), Solidity choisit l'explicitation (toujours retourner `bool`). Les deux approches permettent la garde ; seul le lieu de la décision diffère (à l'appelant vs au site d'appel).\n",
-    ""
+    "**Lien avec Solidity** : le `bool` de retour Solidity est l'équivalent exact d'un `Option State n` : `true` ↔ `Some s'`, `false` ↔ `None`. Lean choisit l'omission du `bool` (toujours retourner `State n`), Solidity choisit l'explicitation (toujours retourner `bool`). Les deux approches permettent la garde ; seul le lieu de la décision diffère (à l'appelant vs au site d'appel).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "81a76330",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003658,
+     "end_time": "2026-09-03T17:00:00.369790+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.366132+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie\n",
     "\n",
@@ -407,14 +491,22 @@
     "\n",
     "**`{dst : Address n}` vs `{dst : Address m}`** : l'unification est résolue par inférence du contexte. Si `s : State n` est connu, alors `dst` doit être `Address n`. Si une preuve utilise `mint` sur deux états de tailles différentes, le compilateur refuse — garantissant que les soldes ne débordent pas du `Fin n` actif.\n",
     "\n",
-    "**Pourquoi `ℕ` et pas `Int`** : ERC-20 Solidity utilise `uint256` (entier non-signé 256 bits). Modéliser en `ℕ` capture exactement cette restriction ; utiliser `Int` introduirait la possibilité de soldes négatifs, qu'aucun contrat ERC-20 décent n'autorise. La troncature silencieuse `n - m` quand `m > n` (en `ℕ`) est l'exact pendant du *underflow* Solidity — sauf qu'en Lean on **peut le prouver impossible** sous garde, alors qu'en Solidity on dépend d'un `SafeMath` ou d'un `require`.\n",
-    ""
+    "**Pourquoi `ℕ` et pas `Int`** : ERC-20 Solidity utilise `uint256` (entier non-signé 256 bits). Modéliser en `ℕ` capture exactement cette restriction ; utiliser `Int` introduirait la possibilité de soldes négatifs, qu'aucun contrat ERC-20 décent n'autorise. La troncature silencieuse `n - m` quand `m > n` (en `ℕ`) est l'exact pendant du *underflow* Solidity — sauf qu'en Lean on **peut le prouver impossible** sous garde, alors qu'en Solidity on dépend d'un `SafeMath` ou d'un `require`.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b4637c7d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006325,
+     "end_time": "2026-09-03T17:00:00.380874+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.374549+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Les lemmes auxiliaires de sommation (module `Invariant`, 1/3)\n",
     "\n",
@@ -440,11 +532,19 @@
    "id": "ddd87332",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:32.340539Z",
-     "iopub.status.busy": "2026-08-20T10:58:32.340406Z",
-     "iopub.status.idle": "2026-08-20T10:58:32.561959Z",
-     "shell.execute_reply": "2026-08-20T10:58:32.561226Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:00.399311Z",
+     "iopub.status.busy": "2026-09-03T17:00:00.398974Z",
+     "iopub.status.idle": "2026-09-03T17:00:00.633188Z",
+     "shell.execute_reply": "2026-09-03T17:00:00.631370Z"
+    },
+    "papermill": {
+     "duration": 0.246814,
+     "end_time": "2026-09-03T17:00:00.635876+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.389062+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -460,12 +560,12 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Lemmes auxiliaires (3)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>sum_split_mem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>sum_split_mem<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n))<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)\n",
-       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s,<span class=\"w\"> </span>f<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>erase<span class=\"w\"> </span>a,<span class=\"w\"> </span>f<span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>sum_univ_split</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>sum_univ_split<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x,<span class=\"w\"> </span>f<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Finset<span class=\"bp\">.</span>univ<span class=\"bp\">.</span>erase<span class=\"w\"> </span>a,<span class=\"w\"> </span>f<span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>balance_le_totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>balance_le_totalSupply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>totalSupply</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.sum_split_mem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.sum_split_mem<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(ERC20.Address<span class=\"w\"> </span>n))<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)\n",
+       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s,<span class=\"w\"> </span>f<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s.erase<span class=\"w\"> </span>a,<span class=\"w\"> </span>f<span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.sum_univ_split</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.sum_univ_split<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x,<span class=\"w\"> </span>f<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Finset.univ.erase<span class=\"w\"> </span>a,<span class=\"w\"> </span>f<span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.balance_le_totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.balance_le_totalSupply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>s.balances<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>s.totalSupply</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -542,7 +642,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "09028438",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008241,
+     "end_time": "2026-09-03T17:00:00.651599+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.643358+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie (sum_split_mem / sum_univ_split / balance_le_totalSupply)\n",
     "\n",
@@ -562,7 +672,16 @@
   {
    "cell_type": "markdown",
    "id": "f2f524c4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008323,
+     "end_time": "2026-09-03T17:00:00.670977+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.662654+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Les théorèmes de préservation (module `Invariant`, 2/3)\n",
     "\n",
@@ -590,11 +709,19 @@
    "id": "69f9095d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:32.563264Z",
-     "iopub.status.busy": "2026-08-20T10:58:32.563136Z",
-     "iopub.status.idle": "2026-08-20T10:58:32.783651Z",
-     "shell.execute_reply": "2026-08-20T10:58:32.782827Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:00.696781Z",
+     "iopub.status.busy": "2026-09-03T17:00:00.696382Z",
+     "iopub.status.idle": "2026-09-03T17:00:00.896916Z",
+     "shell.execute_reply": "2026-09-03T17:00:00.891458Z"
+    },
+    "papermill": {
+     "duration": 0.215054,
+     "end_time": "2026-09-03T17:00:00.898968+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.683914+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -610,17 +737,17 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Theoremes de preservation par operation (4)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>mint_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
-       "<span class=\"w\">  </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>mint<span class=\"w\"> </span>s<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>burn_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>burn_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
-       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>burn<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>transfer_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
-       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>(hne<span class=\"w\"> </span>:<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>dst)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer_no_underflow</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>transfer_no_underflow<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
-       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>(ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">∧</span>\n",
-       "<span class=\"w\">    </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.mint_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.mint_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>(ERC20.mint<span class=\"w\"> </span>s<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.burn_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.burn_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s.balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>(ERC20.burn<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.transfer_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.transfer_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s.balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>(hne<span class=\"w\"> </span>:<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>dst)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>ERC20.supplyInvariant<span class=\"w\"> </span>(ERC20.transfer<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.transfer_no_underflow</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.transfer_no_underflow<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s.balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>(ERC20.transfer<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>s.balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">∧</span>\n",
+       "<span class=\"w\">    </span>s.balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>s.balances<span class=\"w\"> </span>src</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -714,7 +841,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cfb74643",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014103,
+     "end_time": "2026-09-03T17:00:00.926060+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.911957+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie (preservation theorems)\n",
     "\n",
@@ -772,7 +909,16 @@
   {
    "cell_type": "markdown",
    "id": "ec73427f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.012275,
+     "end_time": "2026-09-03T17:00:00.950041+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.937766+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie\n",
     "\n",
@@ -782,14 +928,22 @@
     "\n",
     "**Coût d'une telle preuve** : développer et maintenir `erc20_lean` représente environ 200-300 lignes de Lean 4 + Mathlib. C'est significatif, mais incomparable au coût d'un audit de sécurité ERC-20 sur un vrai contrat (50 000-200 000 USD chez Trail of Bits, OpenZeppelin, ou Sigma Prime). La preuve est **durable** : le théorème est vrai pour toute évolution future du contrat tant que `mint`/`burn`/`transfer` gardent leurs signatures.\n",
     "\n",
-    "**Comparaison avec CertiK et Runtime Verification** : ces firmes utilisent des frameworks similaires (DeepSEA, Simplicity, Michelson) pour des smart contracts Cardano, Algorand, Tezos. Pour Ethereum, l'écosystème penche plutôt vers K-framework (formalisation de l'EVM elle-même) plutôt que vers la preuve directe du contrat — c'est plus léger en expertise mathématique mais moins *comprehensive* (K-framework vérifie l'exécution EVM pas la sémantique métier ERC-20).\n",
-    ""
+    "**Comparaison avec CertiK et Runtime Verification** : ces firmes utilisent des frameworks similaires (DeepSEA, Simplicity, Michelson) pour des smart contracts Cardano, Algorand, Tezos. Pour Ethereum, l'écosystème penche plutôt vers K-framework (formalisation de l'EVM elle-même) plutôt que vers la preuve directe du contrat — c'est plus léger en expertise mathématique mais moins *comprehensive* (K-framework vérifie l'exécution EVM pas la sémantique métier ERC-20).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8dca04d1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011532,
+     "end_time": "2026-09-03T17:00:00.974941+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.963409+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. La fermeture par atteignabilité (module `Invariant`, 3/3)\n",
     "\n",
@@ -801,7 +955,7 @@
     "\n",
     "**Pourquoi pas un type `Trace n s s'`** : on pourrait formaliser une trace comme une liste explicite `[Op, Op, Op]` ou un vecteur `Vector (Op n) k`. Mais cela forcerait à choisir une longueur *a priori*, ce qui briserait la généralité (combien d'opérations faut-il autoriser ? 10 ? 1000 ? infinité ?). L'inductive `Reachable` est la *fermeture par Kleene* de `Op` — elle accepte toute longueur, y compris nulle (`refl`).\n",
     "\n",
-    "**Application concrète** : la trace `s0 → mint → transfer` de la section 7 est un témoin de `ERC20.Reachable 3 s0 s2` — deux pas, donc deux `Reachable.step` avant le `Reachable.refl` final. Le `3` est le paramètre `n`, le nombre d'adresses, et non la longueur de la trace. Donné `supplyInvariant s0`, `reachable_preserves_invariant` en tire `supplyInvariant s2` sans qu'on ait à ré-examiner chaque pas.\n",
+    "**Application concrète** : la trace `s0 → mint → transfer → burn` de la section 7 est un témoin de `ERC20.Reachable 3 s0 s3` — trois pas, donc trois `Reachable.step` avant le `Reachable.refl` final. Le `3` est le paramètre `n`, le nombre d'adresses, et non la longueur de la trace. Donné `supplyInvariant s0`, `reachable_preserves_invariant` en tire `supplyInvariant s2` sans qu'on ait à ré-examiner chaque pas.\n",
     "\n",
     "**Lien avec le model-checking** : un model-checker (Spin, NuSMV, Isabelle) explorerait exhaustivement toutes les traces jusqu'à une profondeur bornée ; le théorème Lean prouve la propriété pour **toute** profondeur en une seule preuve close. C'est la supériorité logique de la preuve inductive sur le model-checking pour les invariants *reachability*.\n"
    ]
@@ -812,11 +966,19 @@
    "id": "99e21ac8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:32.784965Z",
-     "iopub.status.busy": "2026-08-20T10:58:32.784827Z",
-     "iopub.status.idle": "2026-08-20T10:58:33.016355Z",
-     "shell.execute_reply": "2026-08-20T10:58:33.015125Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:00.994414Z",
+     "iopub.status.busy": "2026-09-03T17:00:00.994243Z",
+     "iopub.status.idle": "2026-09-03T17:00:01.191302Z",
+     "shell.execute_reply": "2026-09-03T17:00:01.188898Z"
+    },
+    "papermill": {
+     "duration": 0.208729,
+     "end_time": "2026-09-03T17:00:01.192685+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:00.983956+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -832,13 +994,13 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Inductives : une etape, puis la fermeture transitive</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Op</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>Op<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Reachable</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>Reachable<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.Op</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.Op<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.Reachable</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.Reachable<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Preservation : un pas, puis une suite entiere</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>op_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>op_preserves_invariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>s&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(hop<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Op<span class=\"w\"> </span>n<span class=\"w\"> </span>s<span class=\"w\"> </span>s&#39;)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s&#39;</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>reachable_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>reachable_preserves_invariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>s&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)\n",
-       "<span class=\"w\">  </span>(hr<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Reachable<span class=\"w\"> </span>n<span class=\"w\"> </span>s<span class=\"w\"> </span>s&#39;)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s&#39;</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.op_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.op_preserves_invariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>s'<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(hop<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Op<span class=\"w\"> </span>n<span class=\"w\"> </span>s<span class=\"w\"> </span>s')<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>ERC20.supplyInvariant<span class=\"w\"> </span>s'</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"k\">#check</span><span class=\"w\"> </span>ERC20.reachable_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20.reachable_preserves_invariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>s'<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s)\n",
+       "<span class=\"w\">  </span>(hr<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.Reachable<span class=\"w\"> </span>n<span class=\"w\"> </span>s<span class=\"w\"> </span>s')<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s'</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -925,7 +1087,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "0bc1f7df",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003841,
+     "end_time": "2026-09-03T17:00:01.201759+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.197918+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie (inductives + preservation by reachability)\n",
     "\n",
@@ -958,7 +1130,16 @@
   {
    "cell_type": "markdown",
    "id": "47788069",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01632,
+     "end_time": "2026-09-03T17:00:01.228955+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.212635+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie\n",
     "\n",
@@ -970,14 +1151,22 @@
     "\n",
     "**Application à SC-7a (Solidity + Foundry)** : le test Foundry `invariant_preservation()` de SC-7a fait exactement la même chose pour Solidity — il lance 1000 traces aléatoires et vérifie `assert(balances_sum == totalSupply)` à la fin de chaque trace. C'est l'équivalent Solidity de `reachable_preserves_invariant`, mais limité à 1000 traces. Lean prouve la propriété pour l'infinité des traces en une démonstration close.\n",
     "\n",
-    "**Métriques pratiques** : la preuve complète (modules `State` + `Ops` + `Invariant`) fait environ 200 lignes de Lean, et la compilation avec `lake build` prend moins de 5 secondes sur un laptop standard. C'est le **coût marginal** de la certification formelle : faible au regard de l'enjeu financier (les pertes ERC-20 par bug d'invariant dépassent $1B cumulés — voir le rapport Chainalysis 2024).\n",
-    ""
+    "**Métriques pratiques** : la preuve complète (modules `State` + `Ops` + `Invariant`) fait environ 200 lignes de Lean, et la compilation avec `lake build` prend moins de 5 secondes sur un laptop standard. C'est le **coût marginal** de la certification formelle : faible au regard de l'enjeu financier (les pertes ERC-20 par bug d'invariant dépassent $1B cumulés — voir le rapport Chainalysis 2024).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "51897bed",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008702,
+     "end_time": "2026-09-03T17:00:01.247334+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.238632+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Axiomes et intégrité des preuves\n",
     "\n",
@@ -997,8 +1186,7 @@
     "- Présence de `Classical.em` ou `Classical.byContradiction` : preuve par tiers-exclu sur une propriété qui devrait être constructivement prouvable. Pas une erreur en soi, mais un indicateur qu'on pourrait raffiner.\n",
     "- Présence de `decidable_of_decidable_of_irrel` : usage intensif du `Decidable` typeclass, qui force une décision binaire. À surveiller pour les preuves qui pourraient être non-constructives.\n",
     "\n",
-    "**Méta-propriété** : pour chaque théorème du lake, la liste des axiomes devrait être **stable** au fil des mises à jour Mathlib. Si `lake update` change les axiomes d'un théorème ERC-20, c'est un signal que la preuve utilise désormais une hypothèse implicite supplémentaire — à investiguer.\n",
-    ""
+    "**Méta-propriété** : pour chaque théorème du lake, la liste des axiomes devrait être **stable** au fil des mises à jour Mathlib. Si `lake update` change les axiomes d'un théorème ERC-20, c'est un signal que la preuve utilise désormais une hypothèse implicite supplémentaire — à investiguer.\n"
    ]
   },
   {
@@ -1007,11 +1195,19 @@
    "id": "38855c00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:33.017940Z",
-     "iopub.status.busy": "2026-08-20T10:58:33.017783Z",
-     "iopub.status.idle": "2026-08-20T10:58:33.223722Z",
-     "shell.execute_reply": "2026-08-20T10:58:33.222932Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:01.295842Z",
+     "iopub.status.busy": "2026-09-03T17:00:01.295395Z",
+     "iopub.status.idle": "2026-09-03T17:00:01.510521Z",
+     "shell.execute_reply": "2026-09-03T17:00:01.509365Z"
+    },
+    "papermill": {
+     "duration": 0.247307,
+     "end_time": "2026-09-03T17:00:01.515516+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.268209+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1027,10 +1223,10 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Axiomes utilises par les theoremes cles</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>mint_preserves_supply&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>burn_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>burn_preserves_supply&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>transfer_preserves_supply&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>reachable_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>reachable_preserves_invariant&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>ERC20.mint_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>ERC20.mint_preserves_supply'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>ERC20.burn_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>ERC20.burn_preserves_supply'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>ERC20.transfer_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>ERC20.transfer_preserves_supply'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>ERC20.reachable_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">'</span>ERC20.reachable_preserves_invariant'<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -1118,7 +1314,16 @@
   {
    "cell_type": "markdown",
    "id": "149d1c86",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007728,
+     "end_time": "2026-09-03T17:00:01.532420+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.524692+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la sortie\n",
     "\n",
@@ -1132,14 +1337,22 @@
     "\n",
     "**Audit formel d'un contrat Solidity** : la méthodologie ERC-20 ci-dessus (vérifier que les `#print axioms` n'introduisent pas de nouveaux axiomes) est analogue à un audit Trail of Bits qui vérifierait qu'aucune *unchecked low-level call* ne contourne le typage. Les deux vérifient que le code ne dépend pas d'hypothèses implicites non documentées.\n",
     "\n",
-    "**Maintenance à long terme** : un changement de Mathlib (rare mais réel) peut *ajouter* un axiome à une preuve existante, sans casser la preuve. C'est pourquoi une CI devrait regénérer le `#print axioms` à chaque mise à jour — un *regression test* sur la liste des axiomes.\n",
-    ""
+    "**Maintenance à long terme** : un changement de Mathlib (rare mais réel) peut *ajouter* un axiome à une preuve existante, sans casser la preuve. C'est pourquoi une CI devrait regénérer le `#print axioms` à chaque mise à jour — un *regression test* sur la liste des axiomes.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "80a8680e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006437,
+     "end_time": "2026-09-03T17:00:01.546957+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.540520+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Une trace concrète sous le noyau\n",
     "\n",
@@ -1149,8 +1362,7 @@
     "\n",
     "**Pourquoi la notation `![0, 0, 0]`** : c'est la *vector notation* de Mathlib, qui produit un `Vector ℕ 3` convertible en `Address 3 → ℕ`. Le `def s0 : State 3 := ⟨![0, 0, 0], 0⟩` utilise la notation de structure anonyme `⟨_, _⟩` — `balances = ![0, 0, 0]`, `totalSupply = 0`. Lean peut inférer `n = 3` depuis la longueur du vecteur.\n",
     "\n",
-    "**Performance de `#eval`** : pour des `ℕ` de taille 100, `#eval` est quasi-instantané. Pour des `ℕ` de taille 10^6 (cas pathologiques d'attaques real-world), `#eval` peut prendre plusieurs secondes — Mathlib ne fait pas d'arithmétique efficace pour les très grands entiers. Pour les cas ERC-20 réels (soldes ≤ 10^18), `#eval` reste rapide.\n",
-    ""
+    "**Performance de `#eval`** : pour des `ℕ` de taille 100, `#eval` est quasi-instantané. Pour des `ℕ` de taille 10^6 (cas pathologiques d'attaques real-world), `#eval` peut prendre plusieurs secondes — Mathlib ne fait pas d'arithmétique efficace pour les très grands entiers. Pour les cas ERC-20 réels (soldes ≤ 10^18), `#eval` reste rapide.\n"
    ]
   },
   {
@@ -1159,11 +1371,19 @@
    "id": "ba0c0e80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:33.225038Z",
-     "iopub.status.busy": "2026-08-20T10:58:33.224909Z",
-     "iopub.status.idle": "2026-08-20T10:58:33.469632Z",
-     "shell.execute_reply": "2026-08-20T10:58:33.468805Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:01.564671Z",
+     "iopub.status.busy": "2026-09-03T17:00:01.564332Z",
+     "iopub.status.idle": "2026-09-03T17:00:01.900484Z",
+     "shell.execute_reply": "2026-09-03T17:00:01.895248Z"
+    },
+    "papermill": {
+     "duration": 0.348778,
+     "end_time": "2026-09-03T17:00:01.901451+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.552673+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1179,9 +1399,9 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Etat initial : 3 adresses, soldes nuls, offre 0</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s0<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"bp\">⟨!</span>[<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>],<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">⟩</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s0<span class=\"bp\">.</span>totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s0<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s0<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s0<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>s0<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>⟨<span class=\"bp\">!</span>[<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>],<span class=\"w\"> </span><span class=\"mi\">0</span>⟩</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s0.totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s0.balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s0.balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s0.balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -1244,11 +1464,19 @@
    "id": "6d706208",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:33.470794Z",
-     "iopub.status.busy": "2026-08-20T10:58:33.470677Z",
-     "iopub.status.idle": "2026-08-20T10:58:33.688622Z",
-     "shell.execute_reply": "2026-08-20T10:58:33.687890Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:01.918000Z",
+     "iopub.status.busy": "2026-09-03T17:00:01.917739Z",
+     "iopub.status.idle": "2026-09-03T17:00:02.119552Z",
+     "shell.execute_reply": "2026-09-03T17:00:02.118741Z"
+    },
+    "papermill": {
+     "duration": 0.213456,
+     "end_time": "2026-09-03T17:00:02.122247+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:01.908791+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1263,10 +1491,10 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 1 : mint de 100 tokens a l&#39;adresse 0</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s1<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint<span class=\"w\"> </span>s0<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">100</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s1<span class=\"bp\">.</span>totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s1<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s1<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s1<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 1 : mint de 100 tokens a l'adresse 0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>s1<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20.mint<span class=\"w\"> </span>s0<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">100</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s1.totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s1.balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s1.balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s1.balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -1329,11 +1557,19 @@
    "id": "10b53a19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:33.690448Z",
-     "iopub.status.busy": "2026-08-20T10:58:33.690312Z",
-     "iopub.status.idle": "2026-08-20T10:58:33.912124Z",
-     "shell.execute_reply": "2026-08-20T10:58:33.911312Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:02.132228Z",
+     "iopub.status.busy": "2026-09-03T17:00:02.132067Z",
+     "iopub.status.idle": "2026-09-03T17:00:02.320114Z",
+     "shell.execute_reply": "2026-09-03T17:00:02.318762Z"
+    },
+    "papermill": {
+     "duration": 0.195135,
+     "end_time": "2026-09-03T17:00:02.321972+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.126837+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1348,10 +1584,10 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 2 : transfer de 30 de l&#39;adresse 0 vers l&#39;adresse 1</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s2<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>s1<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"mi\">30</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s2<span class=\"bp\">.</span>totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s2<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s2<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s2<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 2 : transfer de 30 de l'adresse 0 vers l'adresse 1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>s2<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20.transfer<span class=\"w\"> </span>s1<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"mi\">30</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s2.totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s2.balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s2.balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s2.balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -1409,20 +1645,125 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "024e25a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T17:00:02.338887Z",
+     "iopub.status.busy": "2026-09-03T17:00:02.338692Z",
+     "iopub.status.idle": "2026-09-03T17:00:02.529993Z",
+     "shell.execute_reply": "2026-09-03T17:00:02.529210Z"
+    },
+    "papermill": {
+     "duration": 0.203496,
+     "end_time": "2026-09-03T17:00:02.534261+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.330765+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 3 : burn de 20 tokens a l'adresse 0 (destruction definitive)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>s3<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20.burn<span class=\"w\"> </span>s2<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">20</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s3.totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">80</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"k\">#eval</span><span class=\"w\"> </span>s3.balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s3.balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s3.balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">80</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Pas 3 : burn de 20 tokens a l'adresse 0 (destruction definitive)\\ndef s3 : ERC20.State 3 := ERC20.burn s2 0 20\\n#eval s3.totalSupply\\n#eval s3.balances 0 + s3.balances 1 + s3.balances 2\\n\", \"env\": 9}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"80\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"80\"}],\r\n",
+       " \"env\": 10}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Pas 3 : burn de 20 tokens a l'adresse 0 (destruction definitive)\n",
+       "def s3 : ERC20.State 3 := ERC20.burn s2 0 20\n",
+       "#eval s3.totalSupply\n",
+       "─────▶  80\n",
+       "#eval s3.balances 0 + s3.balances 1 + s3.balances 2\n",
+       "─────▶  80\n",
+       "\n",
+       "--% env 10\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Pas 3 : burn de 20 tokens a l'adresse 0 (destruction definitive)\\ndef s3 : ERC20.State 3 := ERC20.burn s2 0 20\\n#eval s3.totalSupply\\n#eval s3.balances 0 + s3.balances 1 + s3.balances 2\\n\", \"env\": 9}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"80\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"80\"}],\r\n",
+       " \"env\": 10}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Pas 3 : burn de 20 tokens a l'adresse 0 (destruction definitive)\n",
+    "def s3 : ERC20.State 3 := ERC20.burn s2 0 20\n",
+    "#eval s3.totalSupply\n",
+    "#eval s3.balances 0 + s3.balances 1 + s3.balances 2\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "bdace94f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004177,
+     "end_time": "2026-09-03T17:00:02.543434+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.539257+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la trace\n",
     "\n",
-    "À l'état initial, offre `0`, somme des soldes `0`. Après le `mint` : offre `100`, somme `100 + 0 + 0 = 100` — les deux bougent **ensemble**. Après le `transfer` : offre toujours `100`, somme `70 + 30 + 0 = 100` — l'offre n'a pas bougé, les soldes se sont déplacés. La conservation tient à chaque pas, et les théorèmes de la section 4 garantissent qu'elle tiendra pour **toute** trace gardée : le Monte-Carlo de SC-7b suggérait la propriété, le noyau la certifie.\n",
+    "À l'état initial, offre `0`, somme des soldes `0`. Après le `mint` : offre `100`, somme `100 + 0 + 0 = 100` — les deux bougent **ensemble**. Après le `transfer` : offre toujours `100`, somme `70 + 30 + 0 = 100` — l'offre n'a pas bougé, les soldes se sont déplacés. Après le `burn` : offre `80`, somme `50 + 30 + 0 = 80` — les deux bougent encore **ensemble**, mais cette fois vers le bas : le `burn` détruit des tokens, il retire le même montant des soldes **et** de l'offre. La conservation tient à chaque pas, et les théorèmes de la section 4 garantissent qu'elle tiendra pour **toute** trace gardée : le Monte-Carlo de SC-7b suggérait la propriété, le noyau la certifie.\n",
     "\n",
-    "*Pour aller plus loin* : la trace `s0 → mint → transfer` exécutée ci-dessus est un témoin de `ERC20.Reachable 3 s0 s2`. La prolonger par le `burn` de l'exercice 2 donne un témoin jusqu'à `ERC20.burn s2 0 20` — un état que le notebook ne nomme pas. `reachable_preserves_invariant` s'y applique alors mécaniquement (voir l'exercice 2).\n",
+    "*Pour aller plus loin* : la trace `s0 → mint → transfer → burn` exécutée ci-dessus est un témoin de `ERC20.Reachable 3 s0 s3`. `reachable_preserves_invariant` s'y applique mécaniquement, et c'est exactement ce que l'exercice 2 certifie sur le dernier pas (voir l'annexe pour la structure détaillée).\n",
     "\n",
     "**Détails arithmétiques de la trace** :\n",
     "- État `s0` : `balances = ![0, 0, 0]`, `totalSupply = 0`. Invariant `0 = 0` trivial.\n",
     "- État `s1 = mint s0 0 100` : `balances = ![100, 0, 0]`, `totalSupply = 100`. Invariant `100 = 100` ✓.\n",
     "- État `s2 = transfer s1 0 1 30` : `balances = ![70, 30, 0]`, `totalSupply = 100`. Invariant `70 + 30 + 0 = 100 = 100` ✓.\n",
+    "- État `s3 = burn s2 0 20` : `balances = ![50, 30, 0]`, `totalSupply = 80`. Invariant `50 + 30 + 0 = 80 = 80` ✓.\n",
     "\n",
     "**Pourquoi `#eval` est certifié** : `#eval` ne se contente pas d'*afficher* un résultat — il passe par le moteur de normalisation Lean qui produit une *valeur close* close par `rfl`. Si `#eval` affiche `100`, c'est que `rfl` peut vérifier `s1.totalSupply = 100` sans hypothèse. C'est plus fort qu'un test, plus faible qu'une preuve formelle (qui dirait `supplyInvariant s1`).\n",
     "\n",
@@ -1434,7 +1775,16 @@
   {
    "cell_type": "markdown",
    "id": "b4e1d1ab",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00471,
+     "end_time": "2026-09-03T17:00:02.552489+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.547779+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -1444,14 +1794,22 @@
     "\n",
     "**Stratégie générale** : pour chaque exercice, identifier d'abord les *hypothèses disponibles* (`supplyInvariant s0`, `s0.balances 0 = 0`, etc.) puis les *théorèmes applicables* (`supplyInvariant` lui-même, `mint_preserves_supply`, `transfer_preserves_supply`, `decide`). Enchaîner par `apply`/`exact`/`simp`/`decide` selon le contexte.\n",
     "\n",
-    "**Pourquoi `sorry` est légitime ici mais pas ailleurs** : dans un *exercice étudiant*, `sorry` est le contrat pédagogique — l'étudiant doit remplacer le `sorry` par sa preuve. Dans une *lib de production*, `sorry` est interdit (cf règle D du CLAUDE.md et la convention Mathlib : `sorry` est uniquement toléré en `lake exe` pour des scripts utilitaires). Ce notebook est explicitement un *pédagogique*, pas une lib de production.\n",
-    ""
+    "**Pourquoi `sorry` est légitime ici mais pas ailleurs** : dans un *exercice étudiant*, `sorry` est le contrat pédagogique — l'étudiant doit remplacer le `sorry` par sa preuve. Dans une *lib de production*, `sorry` est interdit (cf règle D du CLAUDE.md et la convention Mathlib : `sorry` est uniquement toléré en `lake exe` pour des scripts utilitaires). Ce notebook est explicitement un *pédagogique*, pas une lib de production.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "426a3c6f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005826,
+     "end_time": "2026-09-03T17:00:02.566333+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.560507+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 : certifier l'invariant de l'état initial\n",
     "\n",
@@ -1466,21 +1824,28 @@
     "\n",
     "**Pourquoi `simp` suffit ici** : l'état initial est purement littéral (soldes `0`, offre `0`), donc toutes les réductions sont *definitionnelles*. Le simplifieur n'a besoin d'aucun lemme non-trivial — juste des unfoldings de base.\n",
     "\n",
-    "**Pourquoi `decide` ne fonctionne PAS directement** : `decide` réduit à `True` une `Prop` close par *procédure de décision*. Ici le but est `0 = 0` après dépliage, qui est `True` — `decide` devrait fonctionner. En pratique, la communauté Mathlib recommande `simp` pour ce genre de cas, plus rapide que `decide` qui passe par `dec_trivial` et la `Bool` reflection.\n",
-    ""
+    "**Pourquoi `decide` ne fonctionne PAS directement** : `decide` réduit à `True` une `Prop` close par *procédure de décision*. Ici le but est `0 = 0` après dépliage, qui est `True` — `decide` devrait fonctionner. En pratique, la communauté Mathlib recommande `simp` pour ce genre de cas, plus rapide que `decide` qui passe par `dec_trivial` et la `Bool` reflection.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5ca75b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:33.913537Z",
-     "iopub.status.busy": "2026-08-20T10:58:33.913398Z",
-     "iopub.status.idle": "2026-08-20T10:58:34.117337Z",
-     "shell.execute_reply": "2026-08-20T10:58:34.116449Z"
-    }
+     "iopub.execute_input": "2026-09-03T17:00:02.587425Z",
+     "iopub.status.busy": "2026-09-03T17:00:02.587124Z",
+     "iopub.status.idle": "2026-09-03T17:00:02.789334Z",
+     "shell.execute_reply": "2026-09-03T17:00:02.787855Z"
+    },
+    "papermill": {
+     "duration": 0.220356,
+     "end_time": "2026-09-03T17:00:02.794622+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.574266+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1497,14 +1862,14 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : a completer</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>exo1_s0_invariant<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s0<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"kd\">theorem</span><span class=\"w\"> </span>exo1_s0_invariant<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>s0<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 11</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 1 : a completer\\n-- TODO etudiant\\ntheorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\\n  sorry\", \"env\": 9}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : a completer\\n-- TODO etudiant\\ntheorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\\n  sorry\", \"env\": 10}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1518,7 +1883,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 10}</code>\n",
+       " \"env\": 11}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1528,11 +1893,11 @@
        "theorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\n",
        "        ─────────────────▶ 🟨 declaration uses `sorry`\n",
        "  sorry\n",
-       "--% env 10\n",
+       "--% env 11\n",
        "--% prove 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 1 : a completer\\n-- TODO etudiant\\ntheorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\\n  sorry\", \"env\": 9}\n",
+       "{\"cmd\": \"-- Exercice 1 : a completer\\n-- TODO etudiant\\ntheorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\\n  sorry\", \"env\": 10}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
        " [{\"proofState\": 0,\r\n",
@@ -1544,7 +1909,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 10}"
+       " \"env\": 11}"
       ]
      },
      "metadata": {},
@@ -1561,13 +1926,270 @@
   {
    "cell_type": "markdown",
    "id": "b1253738",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004401,
+     "end_time": "2026-09-03T17:00:02.808671+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.804270+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : certifier le burn en bout de trace\n",
     "\n",
     "Prouver que brûler 20 tokens à l'adresse 0 depuis `s2` préserve l'invariant.\n",
     "\n",
     "*Etape 1* : prouver `supplyInvariant s2` en remontant la trace (exo 1 + `mint_preserves_supply` + `transfer_preserves_supply`, la garde `s1.balances 0 ≥ 30` et la distinction `0 ≠ 1` se montrent par `rfl`/`decide`). *Etape 2* : appliquer `burn_preserves_supply` avec la garde `s2.balances 0 ≥ 20`.\n",
+    "\n",
+    "La structure détaillée de la preuve, ses étapes intermédiaires et leurs justifications sont regroupées en **annexe** en fin de notebook — essayez d'écrire la preuve vous-même avant de la consulter.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "439259e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T17:00:02.818362Z",
+     "iopub.status.busy": "2026-09-03T17:00:02.817883Z",
+     "iopub.status.idle": "2026-09-03T17:00:03.020712Z",
+     "shell.execute_reply": "2026-09-03T17:00:03.019326Z"
+    },
+    "papermill": {
+     "duration": 0.209069,
+     "end_time": "2026-09-03T17:00:03.021681+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:02.812612+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : a completer</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1e\"><span class=\"kd\">theorem</span><span class=\"w\"> </span>exo2_burn_preserved<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>(ERC20.burn<span class=\"w\"> </span>s2<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">20</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 12</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : a completer\\n-- TODO etudiant\\ntheorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\\n  sorry\", \"env\": 11}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"sorries\":\r\n",
+       " [{\"proofState\": 1,\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant (ERC20.burn s2 0 20)\",\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 12}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 2 : a completer\n",
+       "-- TODO etudiant\n",
+       "theorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\n",
+       "        ───────────────────▶ 🟨 declaration uses `sorry`\n",
+       "  sorry\n",
+       "--% env 12\n",
+       "--% prove 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 2 : a completer\\n-- TODO etudiant\\ntheorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\\n  sorry\", \"env\": 11}\n",
+       "Raw output:\n",
+       "{\"sorries\":\r\n",
+       " [{\"proofState\": 1,\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant (ERC20.burn s2 0 20)\",\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 12}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 2 : a completer\n",
+    "-- TODO etudiant\n",
+    "theorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\n",
+    "  sorry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11712508",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010994,
+     "end_time": "2026-09-03T17:00:03.039523+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:03.028529+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : un état de votre choix\n",
+    "\n",
+    "`monEtat` distribue 50 tokens sur 4 adresses. (a) Vérifier par `#eval` que la somme des soldes vaut 50. (b) Prouver `supplyInvariant monEtat`. (c) Bonus : minté 10 et appliquer le théorème de préservation.\n",
+    "\n",
+    "*Indice* : la somme sur `Fin 4` se calcule comme sur `Fin 3` — `simp` déplie la notation `![...]`.\n",
+    "\n",
+    "**Stratégie de preuve pour (b)** : exactement la même que l'exercice 1, mais avec une distribution non triviale `![10, 15, 20, 5]`. La somme vaut `10 + 15 + 20 + 5 = 50 = totalSupply`. `simp` devrait fermer après dépliage de `monEtat` et `supplyInvariant`.\n",
+    "\n",
+    "**Stratégie pour (c) Bonus** : appliquer `mint_preserves_supply` sur `monEtat` après avoir minté 10 à l'adresse 0. Le théorème s'applique sans condition : `mint` préserve toujours l'invariant (pas de garde contrairement à `burn`/`transfer`).\n",
+    "\n",
+    "**Pourquoi 4 adresses au lieu de 3** : passer à `Fin 4` force la preuve à ne pas se reposer sur des particularités de `Fin 3` (où la somme a une structure particulière `a + b + c`). C'est un test que la preuve est *générique* en `n`, pas seulement valable pour 3.\n",
+    "\n",
+    "**Pédagogie de l'exercice 3** : contrairement aux exercices 1 et 2 où la réponse est fortement contrainte par la trace, l'exercice 3 invite l'étudiant à *composer* sa propre preuve en assemblant les briques des exercices précédents. C'est la transition vers l'autonomie — typique des derniers exercices d'une série.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "4e39c0bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T17:00:03.064945Z",
+     "iopub.status.busy": "2026-09-03T17:00:03.064704Z",
+     "iopub.status.idle": "2026-09-03T17:00:03.306687Z",
+     "shell.execute_reply": "2026-09-03T17:00:03.301388Z"
+    },
+    "papermill": {
+     "duration": 0.263048,
+     "end_time": "2026-09-03T17:00:03.314313+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:03.051265+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : a completer</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>monEtat<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.State<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>⟨<span class=\"bp\">!</span>[<span class=\"mi\">10</span>,<span class=\"w\"> </span><span class=\"mi\">15</span>,<span class=\"w\"> </span><span class=\"mi\">20</span>,<span class=\"w\"> </span><span class=\"mi\">5</span>],<span class=\"w\"> </span><span class=\"mi\">50</span>⟩</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1f\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1f\"><span class=\"kd\">theorem</span><span class=\"w\"> </span>exo3_monEtat_invariant<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20.supplyInvariant<span class=\"w\"> </span>monEtat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 13</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : a completer\\n-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\\ndef monEtat : ERC20.State 4 := \\u27e8![10, 15, 20, 5], 50\\u27e9\\n-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\\ntheorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\\n  sorry\", \"env\": 12}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"sorries\":\r\n",
+       " [{\"proofState\": 2,\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant monEtat\",\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 30},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 13}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 3 : a completer\n",
+       "-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\n",
+       "def monEtat : ERC20.State 4 := ⟨![10, 15, 20, 5], 50⟩\n",
+       "-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\n",
+       "theorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\n",
+       "        ──────────────────────▶ 🟨 declaration uses `sorry`\n",
+       "  sorry\n",
+       "--% env 13\n",
+       "--% prove 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 3 : a completer\\n-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\\ndef monEtat : ERC20.State 4 := \\u27e8![10, 15, 20, 5], 50\\u27e9\\n-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\\ntheorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\\n  sorry\", \"env\": 12}\n",
+       "Raw output:\n",
+       "{\"sorries\":\r\n",
+       " [{\"proofState\": 2,\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant monEtat\",\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 30},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 13}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 3 : a completer\n",
+    "-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\n",
+    "def monEtat : ERC20.State 4 := ⟨![10, 15, 20, 5], 50⟩\n",
+    "-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\n",
+    "theorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\n",
+    "  sorry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14afbe8c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007004,
+     "end_time": "2026-09-03T17:00:03.330152+00:00",
+     "exception": false,
+     "start_time": "2026-09-03T17:00:03.323148+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Annexe — structure de la preuve de l'exercice 2\n",
+    "\n",
+    "*Cette annexe est séparée de l'énoncé pour que la solution ne soit pas sous les yeux avant l'effort (pattern #14161).*\n",
     "\n",
     "**Structure de la preuve attendue** :\n",
     "```lean\n",
@@ -1589,209 +2211,6 @@
     "\n",
     "**Pourquoi `by decide` pour la garde** : la garde `s2.balances 0 ≥ 20` est arithmétique : `s2.balances 0 = 70`, `70 ≥ 20` est `True` pour `decide`. Aucun lemme non-trivial nécessaire.\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "439259e4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:34.118587Z",
-     "iopub.status.busy": "2026-08-20T10:58:34.118429Z",
-     "iopub.status.idle": "2026-08-20T10:58:34.332683Z",
-     "shell.execute_reply": "2026-08-20T10:58:34.331564Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : a completer</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>exo2_burn_preserved<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>burn<span class=\"w\"> </span>s2<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">20</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 11</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 2 : a completer\\n-- TODO etudiant\\ntheorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\\n  sorry\", \"env\": 10}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
-       "   \"goal\": \"⊢ ERC20.supplyInvariant (ERC20.burn s2 0 20)\",\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 11}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Exercice 2 : a completer\n",
-       "-- TODO etudiant\n",
-       "theorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\n",
-       "        ───────────────────▶ 🟨 declaration uses `sorry`\n",
-       "  sorry\n",
-       "--% env 11\n",
-       "--% prove 1\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 2 : a completer\\n-- TODO etudiant\\ntheorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\\n  sorry\", \"env\": 10}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
-       "   \"goal\": \"⊢ ERC20.supplyInvariant (ERC20.burn s2 0 20)\",\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 11}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Exercice 2 : a completer\n",
-    "-- TODO etudiant\n",
-    "theorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\n",
-    "  sorry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11712508",
-   "metadata": {},
-   "source": [
-    "### Exercice 3 : un état de votre choix\n",
-    "\n",
-    "`monEtat` distribue 50 tokens sur 4 adresses. (a) Vérifier par `#eval` que la somme des soldes vaut 50. (b) Prouver `supplyInvariant monEtat`. (c) Bonus : minté 10 et appliquer le théorème de préservation.\n",
-    "\n",
-    "*Indice* : la somme sur `Fin 4` se calcule comme sur `Fin 3` — `simp` déplie la notation `![...]`.\n",
-    "\n",
-    "**Stratégie de preuve pour (b)** : exactement la même que l'exercice 1, mais avec une distribution non triviale `![10, 15, 20, 5]`. La somme vaut `10 + 15 + 20 + 5 = 50 = totalSupply`. `simp` devrait fermer après dépliage de `monEtat` et `supplyInvariant`.\n",
-    "\n",
-    "**Stratégie pour (c) Bonus** : appliquer `mint_preserves_supply` sur `monEtat` après avoir minté 10 à l'adresse 0. Le théorème s'applique sans condition : `mint` préserve toujours l'invariant (pas de garde contrairement à `burn`/`transfer`).\n",
-    "\n",
-    "**Pourquoi 4 adresses au lieu de 3** : passer à `Fin 4` force la preuve à ne pas se reposer sur des particularités de `Fin 3` (où la somme a une structure particulière `a + b + c`). C'est un test que la preuve est *générique* en `n`, pas seulement valable pour 3.\n",
-    "\n",
-    "**Pédagogie de l'exercice 3** : contrairement aux exercices 1 et 2 où la réponse est fortement contrainte par la trace, l'exercice 3 invite l'étudiant à *composer* sa propre preuve en assemblant les briques des exercices précédents. C'est la transition vers l'autonomie — typique des derniers exercices d'une série.\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "4e39c0bc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-20T10:58:34.334109Z",
-     "iopub.status.busy": "2026-08-20T10:58:34.333957Z",
-     "iopub.status.idle": "2026-08-20T10:58:34.547148Z",
-     "shell.execute_reply": "2026-08-20T10:58:34.546150Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : a completer</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>monEtat<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"bp\">⟨!</span>[<span class=\"mi\">10</span>,<span class=\"w\"> </span><span class=\"mi\">15</span>,<span class=\"w\"> </span><span class=\"mi\">20</span>,<span class=\"w\"> </span><span class=\"mi\">5</span>],<span class=\"w\"> </span><span class=\"mi\">50</span><span class=\"bp\">⟩</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>exo3_monEtat_invariant<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>monEtat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 12</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 3 : a completer\\n-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\\ndef monEtat : ERC20.State 4 := \\u27e8![10, 15, 20, 5], 50\\u27e9\\n-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\\ntheorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\\n  sorry\", \"env\": 11}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 6, \"column\": 2},\r\n",
-       "   \"goal\": \"⊢ ERC20.supplyInvariant monEtat\",\r\n",
-       "   \"endPos\": {\"line\": 6, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 5, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 5, \"column\": 30},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 12}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Exercice 3 : a completer\n",
-       "-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\n",
-       "def monEtat : ERC20.State 4 := ⟨![10, 15, 20, 5], 50⟩\n",
-       "-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\n",
-       "theorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\n",
-       "        ──────────────────────▶ 🟨 declaration uses `sorry`\n",
-       "  sorry\n",
-       "--% env 12\n",
-       "--% prove 2\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 3 : a completer\\n-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\\ndef monEtat : ERC20.State 4 := \\u27e8![10, 15, 20, 5], 50\\u27e9\\n-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\\ntheorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\\n  sorry\", \"env\": 11}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 6, \"column\": 2},\r\n",
-       "   \"goal\": \"⊢ ERC20.supplyInvariant monEtat\",\r\n",
-       "   \"endPos\": {\"line\": 6, \"column\": 7}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 5, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 5, \"column\": 30},\r\n",
-       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 12}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Exercice 3 : a completer\n",
-    "-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\n",
-    "def monEtat : ERC20.State 4 := ⟨![10, 15, 20, 5], 50⟩\n",
-    "-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\n",
-    "theorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\n",
-    "  sorry"
-   ]
   }
  ],
  "metadata": {
@@ -1801,10 +2220,22 @@
    "name": "lean4-wsl"
   },
   "language_info": {
-   "codemirror_mode": "lean4",
+   "codemirror_mode": "python",
    "file_extension": ".lean",
    "mimetype": "text/x-lean4",
    "name": "lean4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 228.548703,
+   "end_time": "2026-09-03T17:00:05.303185+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7c-ERC20-Lean-Native-Companion.ipynb",
+   "output_path": "SC-7c-ERC20-Lean-Native-Companion.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-03T16:56:16.754482+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2027:CoursIA — prev: MED/notebook-python #14491

## Périmètre

1 fichier : `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7c-ERC20-Lean-Native-Companion.ipynb` (36 -> 38 cellules).

## Summary

Branche B différée de #14326 (le corps de l'issue documentait deux motifs de report : fuite de solution + sorties non produisibles localement sur la machine d'origine) — les deux sont levés ici :

1. **Solution migrée en annexe** (pattern #14161) : la « Structure de la preuve attendue » de l'exercice 2 quitte l'énoncé pour une annexe en fin de notebook — lève le motif 1 (la réponse n'est plus sous les yeux avant l'énoncé). L'énoncé garde les *Etape 1/Etape 2* + un pointeur explicite vers l'annexe.
2. **Pas 3 `burn` exécuté sous le vrai noyau** (lève le motif 2) : nouvelle cellule `def s3 := ERC20.burn s2 0 20` + `#eval s3.totalSupply` / somme des soldes — sorties réelles **80 / 80** produites par papermill kernel `lean4-wsl` end-to-end. Le témoin de la trace est désormais complet : `s0 → mint → transfer → burn`.
3. **Rebasage md[17]/md[28]** sur le témoin complet (ce que l'issue appelle le point 3) : la section 5 parle maintenant de `Reachable 3 s0 s3` (trois pas) ; la lecture de la trace décrit le burn (offre `80`, somme `50 + 30 + 0 = 80`, « les deux bougent ensemble, vers le bas ») ; le paragraphe « Pour aller plus loin » qui qualifiait le burn de « prolongation non exécutée … un état que le notebook ne nomme pas » est réécrit — il était exact hier, il ne l'est plus ; l'état `s3` rejoint les détails arithmétiques.

**Exécution** : miroir d'exécution WSL natif `~/lean-projects/lakeroot/SC/erc20_lean` monté pour l'occasion — packages hardlinkés depuis le miroir discrepancy_lean (les 9 revs du manifest sont identiques, vérifié package par package), 7 modules ERC20 construits par tiers `lean -o` en ~1 min (log `NO_FAIL`, 7/7 OK). Papermill `--cwd` sur le miroir.

## Validation

- Papermill kernel `lean4-wsl` end-to-end : 14/14 cellules code, 0 erreur, `execution_count` continus.
- Sorties du pas 3 vérifiées **en valeurs** (pas juste au statut) : `totalSupply = 80`, `50 + 30 + 0 = 80` — cohérentes avec `burn_preserves_supply` (l'invariant tient, à la baisse cette fois).
- Aucune cellule code d'exercice modifiée dans son contenu Lean (stubs `sorry` intacts, C.1 respecté) ; round-trip JSON byte-identique vérifié avant/après édition.
- Grep anti-régression : aucun `# Solution`/`# Exemple résolu` supprimé (la solution migrée est **ajoutée** en annexe, pas retirée du notebook).

Closes #14326
