### PR TITLE
fix(ci,#14476): prune_merged_worktrees — résolution par numéro puis égalité, jamais par intersection de jetons

### DIFF
--- a/scripts/ci/prune_merged_worktrees.py
+++ b/scripts/ci/prune_merged_worktrees.py
@@ -315,12 +315,25 @@ def lookup_pr_for_branch(branch: str) -> Optional[dict]:
     return rows[0]
 
 
+def _normalize_subject(s: str) -> str:
+    """Sujet/titre normalise : casse bassee, espaces collapses, suffixe (#N) retire."""
+    s = re.sub(r"\(#\d+\)\s*$", "", s.strip())
+    return re.sub(r"\s+", " ", s).strip().lower()
+
+
 def lookup_pr_for_detached_head(wt_path: str) -> Optional[dict]:
     """Verdict par contenu pour HEAD detaché : sujet de commit = titre PR ?
 
     Le squash-merge efface l'ascendance, donc `git merge-base --is-ancestor`
-    ne marche pas. On cherche dans les messages de commit du HEAD du
-    worktree un motif qui ressemble a un titre de PR recente.
+    ne marche pas. Mais il produit un sujet de squash au format
+    ``<titre de PR> (#N)`` (#14476) :
+
+    1. un sujet finissant par ``(#N)`` resout la PR par son NUMERO --
+       sans liste tronquee des 50 recentes, sans heuristique ;
+    2. a defaut, EGALITE du sujet normalise avec le titre de PR normalise
+       (jamais une intersection de jetons : un mot du domaine partage par
+       hasard -- notebook, guard, training -- suffisait a tout attribuer) ;
+    3. sinon None -> no_pr_match -> REFUSE (fail-closed).
     """
     log_proc = run_git(
         wt_path, "log", "HEAD", "--format=%s", "-n", "20", check=False
@@ -331,7 +344,23 @@ def lookup_pr_for_detached_head(wt_path: str) -> Optional[dict]:
     if not subjects:
         return None
 
-    # Match contre titres PR recents (limite 50) pour eviter explosion
+    # 1. Resolution par numero extrait du sujet (le format du squash-merge)
+    for subj in subjects:
+        m = re.search(r"\(#(\d+)\)$", subj)
+        if not m:
+            continue
+        view_proc = run_gh(
+            "pr", "view", m.group(1),
+            "--json", "number,state,url,title", check=False,
+        )
+        if view_proc.returncode != 0:
+            continue
+        try:
+            return json.loads(view_proc.stdout)
+        except json.JSONDecodeError:
+            continue
+
+    # 2. Fallback : egalite stricte du sujet normalise vs titres recents
     pr_proc = run_gh(
         "pr", "list", "--state", "all", "--limit", "50",
         "--json", "number,state,url,title",
@@ -344,17 +373,10 @@ def lookup_pr_for_detached_head(wt_path: str) -> Optional[dict]:
     except json.JSONDecodeError:
         return None
 
-    # Heuristique : on prend la 1ere PR dont un mot-clé du titre matche un
-    # mot du commit subject. Conservateur : on exige au moins 4 chars
-    # communs, ce qui limite les faux positifs sur "fix", "test", etc.
+    subj_norms = {_normalize_subject(s) for s in subjects}
     for pr in prs:
-        title_tokens = {
-            t.lower() for t in re.findall(r"[A-Za-z0-9-]{4,}", pr["title"])
-        }
-        for subj in subjects:
-            subj_tokens = {t.lower() for t in re.findall(r"[A-Za-z0-9-]{4,}", subj)}
-            if title_tokens & subj_tokens:
-                return pr
+        if _normalize_subject(pr["title"]) in subj_norms:
+            return pr
     return None
 
 

--- a/scripts/tests/test_prune_merged_worktrees.py
+++ b/scripts/tests/test_prune_merged_worktrees.py
@@ -306,3 +306,130 @@ class TestEndToEnd:
         assert proc.returncode != 2, f"stderr: {proc.stderr}"
         # Au moins 1 ligne REFUSE dans la sortie (le run reel)
         assert "REFUSE" in proc.stdout or "applied=0" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# lookup_pr_for_detached_head -- resolution par numero puis egalite (#14476)
+# ---------------------------------------------------------------------------
+
+class TestDetachedHeadLookup:
+    """Le predicat d'intersection de jetons attribuait n'importe quelle PR
+    recente partageant UN mot du domaine (notebook, guard, training) a un
+    worktree HEAD detache -> retraits destructeurs faux. Contrat #14476 :
+
+    1. sujet en "(#N)" -> resolution par NUMERO (gh pr view), la liste des
+       50 recentes n'est meme pas consultee ;
+    2. sinon EGALITE du sujet normalise avec le titre de PR (le suffixe
+       "(#N)" est retire de la normalisation) ;
+    3. sinon None (no_pr_match -> REFUSE, fail-closed).
+    """
+
+    @staticmethod
+    def _fake_procs(subjects, pr_view=None, pr_list=None):
+        """Fakes pour run_git (log sujets) et run_gh (pr view / pr list)."""
+        import subprocess as sp
+
+        calls = {"view": [], "list": 0}
+
+        def fake_run_git(cwd, *args, check=True):
+            assert args[:2] == ("log", "HEAD")
+            return sp.CompletedProcess(args, 0, stdout="\n".join(subjects))
+
+        def fake_run_gh(*args, check=True):
+            if args[1] == "view":
+                calls["view"].append(args[2])
+                if pr_view is None:
+                    return sp.CompletedProcess(args, 1, stdout="")
+                return sp.CompletedProcess(
+                    args, 0, stdout=json.dumps(pr_view))
+            calls["list"] += 1
+            if pr_list is None:
+                return sp.CompletedProcess(args, 1, stdout="")
+            return sp.CompletedProcess(
+                args, 0, stdout=json.dumps(pr_list))
+
+        return fake_run_git, fake_run_gh, calls
+
+    def test_resolution_par_numero_sans_consulter_la_liste(self, monkeypatch):
+        """Un sujet de squash "titre (#N)" resout par numero : la PR est
+        ramenee par gh pr view N, la liste des 50 n'est JAMAIS appelee."""
+        fg, fgh, calls = self._fake_procs(
+            subjects=["fix(ml,#14470): L1 graines vivantes (#14496)",
+                      "intermediate commit subject"],
+            pr_view={"number": 14496, "state": "MERGED",
+                     "url": "https://github.com/x/y/pull/14496",
+                     "title": "fix(ml,#14470): L1 graines vivantes"},
+        )
+        monkeypatch.setattr(pmw, "run_git", fg)
+        monkeypatch.setattr(pmw, "run_gh", fgh)
+        pr = pmw.lookup_pr_for_detached_head("C:/fake/wt")
+        assert pr is not None and pr["number"] == 14496 and pr["state"] == "MERGED"
+        assert calls["view"] == ["14496"]
+        assert calls["list"] == 0
+
+    def test_faux_positif_mot_courant_refuse(self, monkeypatch):
+        """CONTROLE POSITIF DU FAUX POSITIF (#14476) : un worktree dont les
+        sujets partagent seulement un mot du domaine ("notebook", "fix"...)
+        avec une PR recente ouverte N'EST PAS attribue -- l'ancienne
+        heuristique d'intersection rendait la PR ici."""
+        fg, fgh, calls = self._fake_procs(
+            subjects=["enrich(sw): notebook density pass",
+                      "fix navlinks in notebook"],
+            pr_list=[{"number": 14472, "state": "OPEN",
+                      "url": "https://github.com/x/y/pull/14472",
+                      "title": "Enrich Planners-8-Temporal-Csharp notebook density"},
+                     {"number": 14474, "state": "MERGED",
+                      "url": "https://github.com/x/y/pull/14474",
+                      "title": "fix(ml): notebook guard training"}],
+        )
+        monkeypatch.setattr(pmw, "run_git", fg)
+        monkeypatch.setattr(pmw, "run_gh", fgh)
+        assert pmw.lookup_pr_for_detached_head("C:/fake/wt") is None
+
+    def test_egalite_sujet_normalise_en_fallback(self, monkeypatch):
+        """Sans (#N) : casse et espaces normalises, le sujet DOIT etre le
+        titre de la PR a l'identique pres de la normalisation."""
+        fg, fgh, _ = self._fake_procs(
+            subjects=["Fix   ML: L1 graines vivantes"],
+            pr_list=[{"number": 14496, "state": "MERGED",
+                      "url": "https://github.com/x/y/pull/14496",
+                      "title": "fix ml: L1 graines vivantes"},
+                     {"number": 14000, "state": "MERGED",
+                      "url": "https://github.com/x/y/pull/14000",
+                      "title": "autre chose"}],
+        )
+        monkeypatch.setattr(pmw, "run_git", fg)
+        monkeypatch.setattr(pmw, "run_gh", fgh)
+        pr = pmw.lookup_pr_for_detached_head("C:/fake/wt")
+        assert pr is not None and pr["number"] == 14496
+
+    def test_suffixe_numero_retire_de_l_egalite(self, monkeypatch):
+        """Sujet "titre (#N)" mais la PR N n'existe plus (gh pr view echoue) :
+        le fallback d'egalite doit matcher le titre SANS le suffixe."""
+        fg, fgh, _ = self._fake_procs(
+            subjects=["fix(ml): L1 graines vivantes (#99999)"],
+            pr_list=[{"number": 14496, "state": "MERGED",
+                      "url": "https://github.com/x/y/pull/14496",
+                      "title": "fix(ml): L1 graines vivantes"}],
+        )
+        monkeypatch.setattr(pmw, "run_git", fg)
+        monkeypatch.setattr(pmw, "run_gh", fgh)
+        pr = pmw.lookup_pr_for_detached_head("C:/fake/wt")
+        assert pr is not None and pr["number"] == 14496
+
+    def test_fail_closed_sans_correspondance(self, monkeypatch):
+        """Aucun sujet en (#N), aucun titre egal -> None -> no_pr_match ->
+        REFUSE (le defaut safe)."""
+        fg, fgh, _ = self._fake_procs(
+            subjects=["commit sans rapport"],
+            pr_list=[{"number": 14472, "state": "MERGED",
+                      "url": "https://github.com/x/y/pull/14472",
+                      "title": "titre totalement different"}],
+        )
+        monkeypatch.setattr(pmw, "run_git", fg)
+        monkeypatch.setattr(pmw, "run_gh", fgh)
+        assert pmw.lookup_pr_for_detached_head("C:/fake/wt") is None
+
+    def test_normalize_subject(self):
+        assert pmw._normalize_subject("Fix  X (#123) ") == "fix x"
+        assert pmw._normalize_subject("Fix X (#123)") != "fix x (#123)"


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/strategy-ml #14496 (cycle 155)

## Summary

Repare l'attribution **fausse et destructive** des PRs aux worktrees HEAD detaches dans `prune_merged_worktrees.py` (outil de purge disque deploie sur les 4 lanes en crise disque). **2 fichiers, +162/-13.**

**Defaut** (mesure de l'issue sur ai-01) : `lookup_pr_for_detached_head` attribuait une PR des qu'UN jeton >= 4 chars d'un sujet de commit partageait un jeton du titre d'une des 50 PRs recentes. Les jetons de 4+ chars sont les mots du domaine (`notebook`, `guard`, `training`) — sur ai-01, **4 des 6 retraits --apply portaient une attribution fausse** (`pr=#14471`), et le verdict d'un worktree basculait selon les PRs ouvertes par d'autres lanes dans les minutes precedentes (auto-aggravant). Premise reverifiee firsthand : l'heuristique d'intersection etait bien l.347-357 a origin/main.

**Fix (prescription exacte de l'issue)** :
1. sujet finissant par `(#N)` -> `gh pr view N` : **resolution par numero**, sans liste tronquee — le squash-merge produit exactement le sujet `<titre PR> (#N)` ;
2. sinon **egalite du sujet normalise** (casse/espaces normalises, suffixe `(#N)` retire) avec le titre de PR — jamais une intersection de jetons ;
3. sinon `None` -> `no_pr_match` -> **REFUSE** (fail-closed, le defaut deja en place).

Le chemin par branche (`lookup_pr_for_branch`, ancre `--search head:<branch>`), correct selon l'issue, reste intouche.

## Test plan

- [x] `pytest scripts/tests/test_prune_merged_worktrees.py` : **32 passed, 1 skipped** (destructive, garde `RUN_DESTRUCTIVE_TESTS=1`)
- [x] 6 nouveaux tests `TestDetachedHeadLookup` avec run_git/run_gh monkeypatches, dont :
  - **controle positif du faux positif** (acceptance de l'issue) : sujets partageant seulement "notebook" avec des PRs recentes -> **aucune attribution**
  - resolution par numero sans consulter la liste des 50 (assert calls list == 0)
  - egalite normalisee en fallback (casse + espaces multiples)
  - suffixe `(#N)` retire de l'egalite (PR numero supprimee -> fallback titre)
  - fail-closed sans correspondance
- [x] Contrat de retour inchange (meme dict shape) — consommateur `diagnose_worktree` intact
- [ ] CI verte

Closes #14476
