### PR TITLE
fix(ci,#14507): SKIP_CURRENT etait inatteignable sous Windows -- --apply pouvait retirer son propre repertoire

### DIFF
--- a/scripts/ci/prune_merged_worktrees.py
+++ b/scripts/ci/prune_merged_worktrees.py
@@ -222,6 +222,39 @@ def is_source_dirty(path: str) -> bool:
     return any(p.endswith(ext) for ext in SOURCE_EXTENSIONS)
 
 
+def same_worktree_path(a: str, b: str) -> bool:
+    """Deux chemins de worktree designent-ils le meme repertoire ?
+
+    Les deux cotes de la comparaison `is_current` viennent de sources qui
+    n'ecrivent PAS les chemins de la meme facon :
+
+    - `git worktree list --porcelain` rend toujours des slash avant
+      (`D:/CoursIA/.worktrees/x`), y compris sur Windows ;
+    - `Path(cwd).resolve()` rend la forme native, donc a antislash sur
+      Windows (`D:` + separateur natif + `CoursIA` + ...).
+
+    Une egalite de chaines entre ces deux formes est donc **toujours fausse
+    sur Windows** : `SKIP_CURRENT` etait inatteignable. Mesure du 2026-09-03
+    sur ai-01 (64 worktrees) : `skipped=0` meme en lancant le script depuis
+    `.worktrees/ai01-gate-current`, dont la PR #14459 est MERGED -- ce
+    worktree etait donc programme `WOULD REMOVE`, c'est-a-dire que `--apply`
+    aurait tente `git worktree remove` sur le repertoire courant du process.
+
+    Ce garde n'est pas fail-closed : il ne refuse pas trop, il ne refuse
+    jamais. La comparaison se fait donc sur les chemins **resolus**, et
+    `Path.__eq__` est insensible a la casse sous Windows (ce qui couvre au
+    passage `d:/` vs `D:/`).
+    """
+    try:
+        return Path(a).resolve() == Path(b).resolve()
+    except OSError:
+        # Chemin inaccessible (lecteur demonte, worktree efface a la main) :
+        # on retombe sur une normalisation textuelle plutot que de rendre
+        # False, qui reintroduirait exactement le defaut ci-dessus.
+        return (a.replace("\\", "/").rstrip("/").lower()
+                == b.replace("\\", "/").rstrip("/").lower())
+
+
 def get_worktree_info(wt_path: str, current_path: str) -> dict:
     """Recupere branch + ahead count + dirty status d'un worktree."""
     # Branche (peut etre None si HEAD detaché)
@@ -281,7 +314,7 @@ def get_worktree_info(wt_path: str, current_path: str) -> dict:
         "ahead_count": ahead_count,
         "untracked": untracked,
         "has_source_dirty": has_source,
-        "is_current": wt_path == current_path,
+        "is_current": same_worktree_path(wt_path, current_path),
     }
 
 

--- a/scripts/tests/test_prune_merged_worktrees.py
+++ b/scripts/tests/test_prune_merged_worktrees.py
@@ -194,6 +194,56 @@ class TestDecisionContract:
 
 
 # ---------------------------------------------------------------------------
+# same_worktree_path -- le drapeau is_current se CALCULE
+# ---------------------------------------------------------------------------
+
+
+class TestSameWorktreePath:
+    r"""`test_skip_current` ne pinne que l'AVAL du drapeau, jamais son calcul.
+
+    Le drapeau etait `wt_path == current_path`, entre deux ecritures
+    differentes du meme chemin : `git worktree list --porcelain` rend des
+    slash avant, `Path(cwd).resolve()` rend la forme native (antislash sous
+    Windows). L'egalite ne pouvait donc jamais etre vraie sur Windows, et
+    `SKIP_CURRENT` etait inatteignable -- mesure du 2026-09-03 sur ai-01,
+    64 worktrees, `skipped=0` meme lance depuis un worktree dont la PR est
+    MERGED, c'est-a-dire un `--apply` qui aurait tente `worktree remove`
+    sur son propre repertoire courant.
+    """
+
+    def test_separator_mismatch_is_the_same_worktree(self, tmp_path):
+        native = str(tmp_path)
+        porcelain = native.replace(os.sep, "/")
+        if os.sep != "/":
+            # Controle positif : sans ca, le test passerait sur une paire
+            # identique et ne mesurerait rien du defaut qu'il pinne.
+            assert porcelain != native, "le cas teste ne se reproduit pas ici"
+        assert pmw.same_worktree_path(porcelain, native) is True
+
+    def test_trailing_separator_is_the_same_worktree(self, tmp_path):
+        assert pmw.same_worktree_path(str(tmp_path) + "/", str(tmp_path)) is True
+
+    def test_distinct_worktrees_are_not_current(self, tmp_path):
+        a = tmp_path / "wt-a"
+        b = tmp_path / "wt-b"
+        a.mkdir()
+        b.mkdir()
+        assert pmw.same_worktree_path(str(a), str(b)) is False
+
+    def test_get_worktree_info_uses_the_comparison(self, monkeypatch, tmp_path):
+        """Pinne le CABLAGE : un retour a `==` en l.284 doit rougir ici."""
+        class _Proc:
+            returncode = 0
+            stdout = ""
+
+        monkeypatch.setattr(pmw, "run_git", lambda *a, **k: _Proc())
+        native = str(tmp_path)
+        porcelain = native.replace(os.sep, "/")
+        info = pmw.get_worktree_info(porcelain, native)
+        assert info["is_current"] is True
+
+
+# ---------------------------------------------------------------------------
 # Tests lookup_pr_for_detached_head (#14476) -- anti faux-positifs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/research-code #14471

Closes #14507. See #14195, #14476.

## Le défaut

`prune_merged_worktrees.py` décidait `is_current` par une égalité de chaînes entre deux sources qui n'écrivent pas les chemins de la même façon :

```
current_path = 'D:\CoursIA\.worktrees\ai01-wtprune'   # str(Path(cwd).resolve())
wt_path      = 'D:/CoursIA/.worktrees/ai01-wtprune'   # git worktree list --porcelain
```

Sous Windows l'égalité est **toujours fausse**, donc `SKIP_CURRENT` n'était jamais atteint.

Ce garde n'est pas fail-closed. Il ne refuse pas trop : il ne refuse jamais. Le worktree depuis lequel le script tourne était traité comme n'importe quel autre, et si sa PR est MERGED il passait en `REMOVE` — c'est-à-dire qu'un `--apply` aurait tenté `git worktree remove` sur le répertoire courant du process.

## Contrôle positif (ai-01, 2026-09-03, 64 worktrees)

`.worktrees/ai01-gate-current` est en HEAD détaché, PR #14459 MERGED, donc `WOULD REMOVE`. Le lancer **depuis lui** doit rendre `SKIP_CURRENT`.

Avant :

```
$ python scripts/ci/prune_merged_worktrees.py --path "D:/CoursIA/.worktrees/ai01-gate-current"
WOULD REMOVE D:/CoursIA/.worktrees/ai01-gate-current  no_branch  pr=#14459(MERGED)
total=64  removable=23  refused=41  failed=0  skipped=0
```

Après :

```
SKIP        D:/CoursIA/.worktrees/ai01-gate-current  reason=current_worktree
total=64  removable=22  refused=41  failed=0  skipped=1
```

Identique en passant le chemin en antislash — `Path.resolve()` renormalise l'argument dans la forme native quelle que soit celle reçue, donc les deux orthographes échouaient avant et passent après.

**Contrôle négatif** — lancé d'ailleurs, le même worktree redevient candidat, ce qui vérifie que le correctif n'a pas simplement rendu le prédicat permissif :

```
$ python scripts/ci/prune_merged_worktrees.py --path "D:/CoursIA"
WOULD REMOVE D:/CoursIA/.worktrees/ai01-gate-current  no_branch  pr=#14459(MERGED)
total=64  removable=23  refused=40  failed=0  skipped=1
```

(`skipped=1` y désigne `D:/CoursIA` lui-même, désormais reconnu — il était auparavant refusé par le garde `protected_branch:main`, qui masquait le défaut sur le seul worktree où un autre garde couvrait la même erreur.)

## Ce que les tests couvraient, et ce qu'ils ne couvraient pas

`TestDecisionContract::test_skip_current` construit le statut avec `is_current=True` **déjà posé** et vérifie la décision qui en découle. Il pinne l'aval du drapeau ; son **calcul** n'avait jamais été mesuré. Le critère était pourtant écrit — point 8 de l'en-tête du module de test, hérité de l'acceptance de #14195.

C'est la forme exacte de #14476 sur ce même fichier : une acceptance écrite, une implémentation qui ne la réalise pas, et aucun contrôle positif pour distinguer les deux.

Quatre tests ajoutés (`TestSameWorktreePath`) :

| Test | Rôle |
|---|---|
| `test_separator_mismatch_is_the_same_worktree` | le cas mesuré, avec assertion préalable que la paire testée est bien dissemblable sur cette plateforme |
| `test_trailing_separator_is_the_same_worktree` | variante d'écriture |
| `test_get_worktree_info_uses_the_comparison` | pinne le **câblage** — un retour à `==` en l.284 rougit ici |
| `test_distinct_worktrees_are_not_current` | contrôle négatif |

**Falsification** : sur le prédicat d'avant reconstitué, `3 failed, 1 passed` — les trois premiers rougissent, le contrôle négatif passe des deux côtés, comme attendu d'un contrôle négatif.

## Validation

```
$ python -m pytest scripts/tests/test_prune_merged_worktrees.py -q
34 passed, 1 skipped in 147.00s
```

## Note de contexte

Ce défaut a été trouvé en cherchant à réparer `lookup_pr_for_detached_head` sur une **copie périmée** de l'arbre (`D:\CoursIA` était à `6d0bd0209`, `origin/main` à `750ba5818`). Ce défaut-là était déjà corrigé par #14481, et le diagnostic était donc caduc avant d'être écrit. La mesure qui l'a établi vaut d'être conservée : sous le code périmé, trois worktrees d'historiques distincts (`CoursIA-wt/tpx`, `CoursIA-wt10496`, `dev/CoursIA-b0merge`) résolvaient tous vers `#14506`, la PR ouverte la plus récente ; sous `origin/main` ils résolvent respectivement vers `#10532`, `#10491` et `#12779`, toutes MERGED. #14481 fait ce qu'il annonce.
