### PR TITLE
fix(guard,#14384): perimeter enumeration -- word-form sum + widened additive connectors

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -816,8 +816,12 @@ COUNTERFACTUAL_MARKER = re.compile(
 # body enumerates 1 + 2 = 3 (exact), the guard reads the sub-sum 2 and can
 # never validate it (#11935). Requires a NAMED file before the "+ N fichiers
 # de tests" tail: the shape is an enumeration of components, not a total.
+# #14384 (A) : l'exemption tenait a la ponctuation, pas a la semantique --
+# le meme inventory avec ", plus" / ", et" / ", ainsi que" restait bloquant.
+# Jeu fermé de connecteurs additifs, l'ancre nom de fichier reste exigée.
 ENUMERATION_TAIL = re.compile(
-    r"\+\s*\d+\s*fichiers?\s+de\s+tests?\b", re.IGNORECASE
+    r"(?:\+|,\s*(?:plus|et|ainsi\s+que))\s*\d+\s*fichiers?\s+de\s+tests?\b",
+    re.IGNORECASE,
 )
 NAMED_FILE = re.compile(
     r"\b[\w.-]+\.(?:py|cs|yml|yaml|json|md|ipynb|ts|js|sh|toml|cfg|ini)\b",
@@ -1178,8 +1182,14 @@ def _additive_line_sum(line: str) -> int:
     locative scope, ...) never joins the sum. #12201: a count inside a
     citation span or followed by a name range is reported speech, not an
     additive term -- same skip as the claim selection, so the two paths
-    read the same body the same way."""
-    return sum(
+    read the same body the same way.
+    #14384 (B): the word-form cardinal joins the sum, reusing the exact
+    WORD_FORM_TRIGGERS of _word_form_count -- the two halves of the organ
+    now agree on what a word count is at LINE scope too, closing the
+    docstring/extraction divergence ("1 fichier modifie, plus deux fichiers
+    de tests" = 1 + 2 = 3, not 1). Post-#14438 vocabulary: deux..dix and
+    "un seul"; the bare article "un/une" never sums."""
+    total = sum(
         int(m.group(1))
         for m in COUNT_CLAIM.finditer(line)
         if not _count_is_exempt(line, m)
@@ -1187,6 +1197,11 @@ def _additive_line_sum(line: str) -> int:
         and not _count_is_range_enum(line, m)
         and not _count_is_out_of_scope_annotation(line, m)
     )
+    low = line.lower()
+    for _word, n, trig in WORD_FORM_TRIGGERS:
+        if trig.search(low):
+            return total + n
+    return total
 
 
 def _word_form_count(text: str) -> int | None:

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1510,6 +1510,117 @@ def test_11985_enumeration_tail_without_named_file_still_blocks():
     assert cand.blocking is True
 
 
+# ---------------------------------------------------------------------------
+# #14384 -- the forme-1 neighborhood. (A) the enumeration exemption held to
+# PUNCTUATION, not semantics: the same just enumeration with ", plus" / ",
+# et" / ", ainsi que" instead of "+" stayed blocking -- widened to a closed
+# connector set, named-file anchor kept. (B) the additive sum was blind to
+# word-form cardinals while _word_form_count saw them -- the two halves of
+# the organ now agree at line scope (shared WORD_FORM_TRIGGERS).
+# Measured AFTER #14438/#14454: "un/une" are articles, not cardinals, so
+# the issue's L3 extracts nothing and L5's "un fichier" term is invisible
+# BY DESIGN (reproducteur #14430) -- the surviving fixable defects are the
+# connectors and the sum, pinned here at the post-#14454 vocabulary. The
+# six #11985 forms and its positive controls stay pinned by the tests above.
+# ---------------------------------------------------------------------------
+
+
+def test_14384_five_literal_lines_at_head():
+    """Recette 1: the issue's five table lines, literally, with the behavior
+    fixed at HEAD (post-#14454 vocabulary)."""
+    assert _count_is_incidental(
+        "check_twin_parity.py (_shas_match) + 2 fichiers de tests"
+    ) is True
+    assert _count_is_incidental(
+        "variation_light_cap.py (+100/-0) + 1 fichier de tests"
+    ) is True
+    # L3: post-#14454 "un fichier" is an article -> no count extracted at
+    # all (the pre-#14438 word_count=1 reading is superseded by #14438).
+    assert extract_perimeter_assertions(
+        "variation_light_cap.py (+100/-0), plus un fichier de tests neuf."
+    ) == []
+    # L4: two digits already sum exactly (unchanged by this fix).
+    assert _additive_line_sum("1 fichier modifie, 1 fichier de tests neuf.") == 2
+    # L5: "un fichier" is invisible as a count (#14438) -> declared 1, the
+    # escape for a counted file + article term is the digit form or naming.
+    assert _additive_line_sum(
+        "1 fichier modifie, plus un fichier de tests neuf."
+    ) == 1
+    assert _count_is_incidental(
+        "1 fichier modifie, plus un fichier de tests neuf."
+    ) is False
+
+
+def test_14384_A_widened_connectors_are_incidental_with_named_file():
+    """(A): ', plus' / ', et' / ', ainsi que' between a NAMED file and an
+    'N fichiers de tests' tail classify like the '+' form -- SIGNAL, not
+    blocking (the sub-sum can never be validated by the confrontation)."""
+    for line in [
+        "variation_light_cap.py (+100/-0), plus 2 fichiers de tests neufs.",
+        "variation_light_cap.py (+100/-0), et 1 fichier de test neuf.",
+        "variation_light_cap.py (+100/-0), ainsi que 3 fichiers de tests.",
+    ]:
+        cand = Candidate(line, "body", "author", "body")
+        assert cand.blocking is False, line[:60]
+
+
+def test_14384_A_connector_without_named_file_still_blocks():
+    """(A) garde-fou: without the named-file anchor the exemption would
+    swallow sub-sums that enumerate nothing -- a bare connector line stays
+    authorial."""
+    line = "1 fichier de tests modifie, et 1 autre fichier"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True
+
+
+def test_14384_A_word_form_tail_is_not_exempt():
+    """(A)+(B) recette 2 -- the exemption stays DIGIT-only: a word-form
+    enumeration tail joins the additive sum and is confronted, so the
+    exemption can re-close (the issue's re-closing mutation, expressed in
+    the post-#14438 vocabulary)."""
+    line = "variation_light_cap.py (+100/-0), plus trois fichiers de tests neufs."
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True
+
+
+def test_14384_B_word_form_joins_additive_sum():
+    """(B): '1 fichier modifie, plus deux fichiers de tests' declares
+    1 + 2 = 3 -- the sum was 1 (digit-only), contradicting the docstring
+    agreement of the organ's two halves."""
+    assert _additive_line_sum(
+        "1 fichier modifie, plus deux fichiers de tests neufs."
+    ) == 3
+    assert _additive_line_sum("deux fichiers de tests neufs.") == 2
+
+
+def test_14384_B_rescue_and_reclose_end_to_end():
+    """(B) recette 2, both directions: the just enumeration passes, the
+    count-mutation blocks again."""
+    files = [{"path": "a.py"}, {"path": "b.py"}, {"path": "c.py"}]
+    assert check_assertion(
+        files, "1 fichier modifie, plus deux fichiers de tests neufs."
+    ) == []
+    assert check_assertion(
+        files, "1 fichier modifie, plus trois fichiers de tests neufs."
+    ) != []
+
+
+def test_14384_A_digit_line_silent_word_mutation_recloses():
+    """(A) recette 2 end-to-end: the widened digit line stays incidental
+    (silent sub-sum), its word-form mutation on a 2-file perimeter speaks
+    again (1 named + trois = 4 != 2 via the word branch)."""
+    files = [{"path": "scripts/notebook_tools/variation_light_cap.py"},
+             {"path": "scripts/tests/test_variation_light_cap.py"}]
+    silent = Candidate(
+        "variation_light_cap.py (+100/-0), plus 2 fichiers de tests neufs.",
+        "body", "author", "body",
+    )
+    assert silent.blocking is False
+    assert check_assertion(
+        files, "variation_light_cap.py (+100/-0), plus trois fichiers de tests neufs."
+    ) != []
+
+
 def test_11985_form_produced_artifacts_is_incidental():
     """#11956: '2 fichiers audio generes, HTTP/1.1 200 OK' attests REAL
     EXECUTION -- the artifacts are cell outputs, not repo files (real PR:


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14502 (cycle 157)

## Summary

Les deux mécanismes de #14384, dans l'ordre de sûreté prescrit, dans `scripts/check_pr_perimeter.py` (+129/-3 avec les tests) :

**(B) — la somme additive voit les cardinaux en toutes lettres.** `_additive_line_sum` somme maintenant le terme forme-mot en réutilisant le `WORD_FORM_TRIGGERS` exact de `_word_form_count` (premier déclencheur, miroir de la demi-organe) : « 1 fichier modifie, plus deux fichiers de tests neufs » = 1 + 2 = **3** (avant : 1). La promesse de la docstring — *« both halves of the organ agree on what a word count is »* — tient désormais au niveau ligne.

**(A) — l'exemption d'énumération tient à la sémantique, plus à la ponctuation.** `ENUMERATION_TAIL` passe de l'adjacence nue `+` à un jeu fermé de connecteurs additifs — `+`, `, plus`, `, et`, `, ainsi que` — avec l'ancre **nom de fichier** inchangée : sans elle, l'exemption avalerait des sous-sommes qui n'énumèrent rien.

Seuls les codes de sortie bougent : les comptes restent extraits, confrontés et imprimés sous SIGNAL (règle #11985 ; la détection n'est jamais rétrécie).

## Interaction #14438/#14454 — mesurée, pas supposée

L'issue a été déposée le 02/09 ; **#14454 (mergé le 03/09, post-constat)** a retiré « un/une » du vocabulaire cardinal FR (article ≠ cardinal, reproducteur #14430). Conséquences vérifiées firsthand à HEAD (`750ba5818`) :

| Ligne de l'issue | Constat pré-#14454 | À HEAD | Après cette PR |
|---|---|---|---|
| L1 `check_twin_parity.py (...) + 2 fichiers de tests` | incidental | incidental | incidental (inchangé) |
| L2 `variation_light_cap.py (...) + 1 fichier de tests` | incidental | incidental | incidental (inchangé) |
| L3 `..., plus un fichier de tests neuf.` | additive 0, rouge | **extraction `[]`** — « un » article → plus aucun compte extrait | **bénigne par construction** (épinglé en test) |
| L4 `1 fichier modifie, 1 fichier de tests neuf.` | additive 2 | additive 2 | additive 2 (inchangé) |
| L5 `1 fichier modifie, plus un fichier de tests neuf.` | additive 1, rouge | additive 1, rouge | additive 1, rouge — **supplanté par #14438** : rendre « un » sommable réouvrirait le FP fondateur #14430 |

Les attentes littérales L3/L5 du constat sont donc **supplantées sur l'axe « un fichier »** par une décision plus récente et mergée ; les deux mécanismes que l'issue nomme ((A) connecteurs, (B) divergence de somme) restent vitaux à HEAD et sont réparés intégralement. La mutation de re-fermeture de la recette (« doit rester BLOQUANT ») est réexprimée dans le vocabulaire post-#14454 : « plus **trois** fichiers de tests » (forme-mot non exemptée, 4 ≠ 2 → rouge) — recette 2 satisfaite dans les deux directions (voir tests).

## Preuves

```
$ python -m pytest scripts/tests/test_check_pr_perimeter.py -q
193 passed in 4.63s   (186 vertes AVANT les edits + 7 nouvelles #14384)
```

Recette couverte :
1. ✅ les 5 lignes littéralement (attentes ancrées au vocabulaire HEAD, #14438 documenté dans le test) ;
2. ✅ contrôles négatifs bidirectionnels : sauvetage « 1 + deux = 3 » sur périmètre 3 vs mutation « trois » → 4 ≠ 3 **rouge** ; ligne digit élargie silencieuse vs sa mutation forme-mot sur périmètre 2 → **rouge** ; sans ancre nom de fichier → **bloquant** ; queue forme-mot non exemptée → **bloquant** ;
3. ✅ les 6 formes #11985 + contrôles positifs (`<=15 fichiers`, `scan sur 73 fichiers`, `22 fichiers MP3`) restent incidentes — tests existants verts à l'identique ;
4. ✅ consommateurs (`perimeter-review-guard.yml`, `always-on-guards.yml`) : aucun changement d'interface — les fonctions pures et le routing `Candidate.blocking` conservent leurs contrats (tests de composition scan-thread verts) ; un corps volontairement faux reste rouge (tests fondateurs #11227/#11268 verts).

## Verdict SOTA : SOTA-OK (aucun workaround — correctif des deux demi-organes sur leur contrat documenté)

See #14384
