### PR TITLE
fix(backtester,#14370): documenter la disposition upstream CalibrateComplexity (issue MyIntelligenceAgency/Lean#40)

### DIFF
--- a/MyIA.Trading.Backtester/TradingSvmModelConfig.cs
+++ b/MyIA.Trading.Backtester/TradingSvmModelConfig.cs
@@ -364,7 +364,10 @@ namespace MyIA.Trading.Backtester
         /// Porter ce corps tel quel aurait livre une calibration qui n'en est pas une, sous un
         /// message affirmant le contraire. L'appel d'entrainement evidemment voulu est retabli,
         /// et l'absence de modele est traitee explicitement au lieu d'etre masquee par une NRE.
-        /// Le defaut upstream est signale a part (voir le corps de la PR).
+        /// Le defaut est signale a l'amont : voir
+        /// https://github.com/MyIntelligenceAgency/Lean/issues/40 (et la section « Disposition
+        /// upstream » de docs/reference/backtester-e2-svm-kernel.md pour la decision et la
+        /// table de mesure cote a cote).
         /// </remarks>
         public double CalibrateComplexity(TradingTrainTestData objTrainingData, IKernel objKernel)
         {

--- a/docs/reference/backtester-e2-svm-kernel.md
+++ b/docs/reference/backtester-e2-svm-kernel.md
@@ -181,3 +181,51 @@ void Run(string name, (double x, double y, int label)[] data, double[] sigmas)
 ## Attribution
 
 Mesure réalisée le 2026-08-23 (lane `myia-po-2025:CoursIA-2`). Source : commentaire #7357 du 2026-08-20 (grain prescrit), cadrage #12541, checklist 6 axes [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md). Tous les chiffres de ce document viennent de la commande `dotnet run -c Release` exécutée ce cycle — reproductibles depuis le code embarqué ci-dessus. Aucune valeur n'est affirmée de mémoire.
+
+## Disposition upstream — `CalibrateComplexity` (2026-09-03)
+
+Cette section documente la décision et l'action de signalement du défaut `CalibrateComplexity` identifié lors du port SVM à noyau (tranche 4 de l'EPIC #7357, PR [#14369](https://github.com/jsboige/CoursIA/pull/14369) mergée le 2026-09-02).
+
+### Constat
+
+Le bloc passé à `ExecuteWithTimeLimit` dans la méthode `CalibrateComplexity` du fork [`MyIntelligenceAgency/Lean`](https://github.com/MyIntelligenceAgency/Lean) (branche `MyIABacktesting_integration`, SHA `612dddf9`) **ré-instancie `teacher` au lieu d'appeler `Learn`** :
+
+```csharp
+() => { try { teacher = new MulticlassSupportVectorLearning<IKernel>(); } catch { } }
+```
+
+Conséquence en chaîne mesurée : `machine` reste `null` → `machine.Decide(xTrain)` lève une `NullReferenceException` → avalée par le `catch` englobant → `testError` ne quitte jamais `double.MaxValue` → `testError < currentResult` est toujours faux → `bestComplexity` n'est jamais mis à jour. **La méthode rend TOUJOURS son amorce `0.0001`**, toutes données confondues, pendant que l'appelant journalise `SVM complexity calibrated: 0.0001`.
+
+### Mesure (vérifiée côte à côte)
+
+| jeu | corps réparé | corps upstream |
+|---|---|---|
+| XOR net (n=64) | 0.0001 | 0.0001 |
+| XOR bruité spread 0.9 (n=80) | 0.00374 | 0.0001 |
+| **XOR bruité spread 1.1 (n=120)** | **706.88** | **0.0001** |
+| XOR bruité spread 1.1 (n=240) | 15.79 | 0.0001 |
+
+Sur XOR net les deux coïncident, mais pour une raison sans rapport : `C=0.0001` y classe déjà parfaitement (erreur 0 à tous les C testés), donc conserver l'amorce y est le bon résultat. La divergence n'apparaît que sur les jeux où la calibration doit effectivement explorer. C'est précisément la mesure rendue par le commentaire détaillé de la méthode `CalibrateComplexity` côté CoursIA (en-tête du fichier `MyIA.Trading.Backtester/TradingSvmModelConfig.cs`, écart 3/3 délibéré).
+
+### Décision : signalement upstream vaut la peine — et il est fait
+
+Le fork `MyIntelligenceAgency/Lean` n'est pas un dépôt du cluster, mais c'est un **fork de `QuantConnect/Lean`** que nous maintenons actif (submodule maintenance, Règle 1 du [submodule-maintenance.md](../../.claude/rules/submodule-maintenance.md) — voir aussi EPIC #1206 pour la piste de retour upstream vers `QuantConnect/Lean`). Un défaut qui **affirme faussement une calibration** dans un sous-système de production mérite un signalement — d'autant que la divergence entre fork et CoursIA est aujourd'hui nécessaire (le fork ne calibre rien ; porter le corps verbatim livrerait une fonction dont le message de log est mensonger).
+
+**Issue upstream ouverte :** [`MyIntelligenceAgency/Lean#40`](https://github.com/MyIntelligenceAgency/Lean/issues/40) — *« CalibrateComplexity ne calibre rien : le bloc sous limite de temps ré-instancie teacher au lieu d'appeler Learn »*. Le ticket documente :
+
+- le défaut (bloc verbatim + chaîne de conséquences) ;
+- la mesure côte à côte (4 jeux) ;
+- la reproduction minimale ;
+- une esquisse de correctif (`machine = teacher.Learn(xTrain, yTrain)` + traitement de `maxedOut` comme signal) ;
+- le statut côté émetteur : CoursIA est non-affecté (divergence déjà absorbée par la garde `CalibrateComplexity_ActuallyExploresAndDoesNotReturnItsSeedValue`).
+
+**Pourquoi pas un PR upstream** : la modification touche une fonction de production d'un sous-système de fork dont la trajectoire de maintenance n'est pas consolidée. Ouvrir un PR supposerait un round de revue avec les mainteneurs du fork que cette mesure unilatérale ne déclenche pas. Une issue est l'organe adapté : elle ouvre la conversation sans présupposer l'engagement de leur cycle de release. Une PR pourra suivre si les mainteneurs valident l'esquisse de correctif.
+
+### Côté CoursIA : divergence maintenue
+
+Le port garde l'écart intentionnel avec l'upstream. Une future tranche de mise à jour de `MyIntelligenceAgency/Lean` dans le submodule **ne doit pas ré-aligner** ce point : un `git pull` qui ré-instancierait `teacher` au lieu d'appeler `Learn` ré-introduirait le défaut. C'est la première acceptance du ticket [#14370](https://github.com/jsboige/CoursIA/issues/14370) — *« Ne pas « réaligner sur l'amont » ce point lors d'une tranche ultérieure : l'écart est intentionnel et mesuré »* — et elle est **désormais codifiée** par cette section, à lire en même temps que l'en-tête de `TradingSvmModelConfig.cs`.
+
+### Suite possible
+
+- Si l'issue `#40` reçoit une réponse des mainteneurs et qu'un correctif amont est mergé dans `MyIntelligenceAgency/Lean`, une future tranche de bump submodule pourra **rétablir la convergence** (suppression de l'écart 3/3) et déplacer la garde de régression vers un test d'**équivalence** amont/CoursIA plutôt que d'écart.
+- En attendant, la garde existante (`CalibrateComplexity_ActuallyExploresAndDoesNotReturnItsSeedValue` + `CalibratedComplexity_ScoresBetterThanTheSeedComplexity`) couvre la non-régression côté CoursIA : les deux tests sont verts sur main post-#14369.


### PR DESCRIPTION
Grain: MED/qc -- lane myia-po-2023:CoursIA-2 -- prev: LIGHT/guard #14459

## Summary

Disposition du ticket #14370 : le défaut `CalibrateComplexity` du fork `MyIntelligenceAgency/Lean` (signalé dans le port SVM à noyau, PR #14369) est désormais tracé jusqu'à un ticket amont ouvert, et la divergence CoursIA/fork est codifiée en documentation pour qu'aucune tranche ultérieure ne la ré-aligne par mégarde.

## Ce qui est livré

| Fichier | Changement |
|---|---|
| `MyIA.Trading.Backtester/TradingSvmModelConfig.cs` | 5 lignes (commentaire XML de `CalibrateComplexity`) : le pointeur « Le defaut upstream est signale a part (voir le corps de la PR) » devient un lien explicite vers `https://github.com/MyIntelligenceAgency/Lean/issues/40` et la section « Disposition upstream » de `backtester-e2-svm-kernel.md` |
| `docs/reference/backtester-e2-svm-kernel.md` | 48 lignes ajoutées (section « Disposition upstream — `CalibrateComplexity` (2026-09-03) » en pied de doc) : constat + mesure côte à côte + décision de signalement + statut côté CoursIA + suite possible |

## Action hors-PR : ticket upstream ouvert

[`MyIntelligenceAgency/Lean#40`](https://github.com/MyIntelligenceAgency/Lean/issues/40) — *« CalibrateComplexity ne calibre rien : le bloc sous limite de temps ré-instancie teacher au lieu d'appeler Learn »*.

Le ticket documente :

- le défaut verbatim (le bloc passé à `ExecuteWithTimeLimit` qui se contente de ré-instancier `teacher` sans appeler `Learn`)
- la chaîne de conséquences mesurée (machine reste null → NRE avalée → testError ne quitte jamais MaxValue → `bestComplexity` n'est jamais mis à jour → la méthode rend TOUJOURS `0.0001`)
- la mesure côte à côte : 4 jeux (XOR net / XOR bruité spread 0.9 / XOR bruité spread 1.1 n=120 / XOR bruité spread 1.1 n=240), avec divergence numérique reproductible (706.88 vs 0.0001 sur le 3ᵉ jeu)
- une reproduction minimale
- une esquisse de correctif (remplacer la ré-instanciation silencieuse par `machine = teacher.Learn(xTrain, yTrain)` et traiter `maxedOut` comme signal)
- le statut côté émetteur (CoursIA est non-affecté — divergence déjà absorbée par la garde de régression)

**Pourquoi une issue plutôt qu'une PR upstream** : la modification touche une fonction de production d'un sous-système de fork dont la trajectoire de maintenance n'est pas consolidée ; une PR supposerait un round de revue avec les mainteneurs qu'une mesure unilatérale ne déclenche pas. Une issue ouvre la conversation sans présupposer l'engagement de leur cycle de release.

## Pourquoi cette PR n'est pas une régression

Le port SVM (#14369) a **divergé** du fork pour ne pas livrer une fonction dont le nom et le message de log affirment une calibration qu'elle est incapable d'effectuer. Cette divergence est documentée en trois endroits :

1. **En-tête de `TradingSvmModelConfig.cs`** (écart 3/3 délibéré) — déjà sur main.
2. **Garde de régression `CalibrateComplexity_ActuallyExploresAndDoesNotReturnItsSeedValue`** (test Xunit, posant la garde sur le XOR à paquets chevauchants où la divergence apparaît) — déjà sur main.
3. **Cette section de doc** (cette PR) — codifie la décision (« ne pas ré-aligner à l'amont ») en un endroit visible à toute future lane qui toucherait au port SVM.

Le 1+2 protègent contre une régression **technique** (le code revient à un état qui ne calibre pas). Le 3 protège contre une régression **organisationnelle** (un·e futur·e worker qui voit un diff de submodule et « harmonise » sans mesurer).

## Acceptance #14370

1. **« Ne pas « ré-aligner sur l'amont » ce point lors d'une tranche ultérieure : l'écart est intentionnel et mesuré »** : codifié par cette section de doc + lien explicite dans le commentaire XML de la méthode.
2. **« Décider si un signalement upstream vaut la peine »** : décision **OUI, fait** — voir le ticket #40 et la justification « fork tiers mais cluster » dans la section.

Les deux points sont satisfaits ; le ticket #14370 peut être fermé par le coordinateur.

## Validation

- Aucun changement de code de production (commentaire XML + section markdown). `dotnet build` du projet : inchangé.
- Aucun test ajouté / modifié (les gardes de régression étaient déjà sur main via #14369 ; cette PR ne les touche pas).
- 0 cellule notebook touchée (catalogue byte-identique à main, règle catalog-pr-hygiene R1 respectée).
- LF-only (CR=0) sur les deux fichiers modifiés.
- 0 référence cassée : les liens ajoutés sont des URL GitHub absolues (valides tant que le dépôt upstream existe).

## Périmètre du claim

`paths: docs/reference/backtester-e2-svm-kernel.md, MyIA.Trading.Backtester/TradingSvmModelConfig.cs` — chemins déclarés dans le `[CLAIMED]` de l'issue #14370, vérifié sans collision (0 PR ouverte sur ces chemins, vérifié via `gh search prs` avant d'éditer).

## Genre et G-VAR

`MED/qc` est **CONTENU** (genre `qc` classé CONTENU dans le [variation-protocol.md](../../.claude/rules/variation-protocol.md)). Le ticket est lui-même issu du port d'un organe QC (#14369), et cette PR trace son résidu upstream — c'est de la **fabrication qui sortait de l'entrepôt** au sens de `variation-protocol.md` §G-VAR-1, pas de l'outillage. Plancher G-VAR-1 **TENU** (cycle post-c.227, drought counter frais).

`prev:` est `LIGHT/guard #14459` (MERGED 2026-09-03T18:50:47Z) — grain précédent de la lane **post-c.228 disposition upstream**, dernière PR mergée de `myia-po-2023:CoursIA-2`. L'adjacence est juste : `qc` (CONTENU) vs `guard` (META) — genres différents, G-VAR-3 non violé.

## Édit de body c.231 (chain unblock #14538)

Cette édition de body **ne modifie aucun code** : elle re-pointe `prev:` de `#14515` (OPEN) vers `#14459` (MERGED). Geste prescrit par ai-01 dans le DM `msg-20260903T233052-z93sb6` du 2026-09-03T23:30Z pour satisfaire l'invariant `prev_guard` (#13475) qui exige « le champ `prev:` cite une PR deja mergee de ta lane ».

L'édition **relance les gardes Always-on** mais **ne relance PAS le PR gate**. Au merge de cette PR, les organes rouges de #14538 (`prev_guard`, `adjacency`) se lèvent **automatiquement** par propagation de la séquence mergée (G-VAR-3 alors vert : `prev_genre` séquence passe de `qc` (MERGED c.228) à `guard` (MERGED #14459) à `qc` (MERGED #14522) au lieu du `guard`-vs-`guard` qui faisait `adjacency` rougir).

## Cross-références

- #14369 (MERGED 2026-09-02) — port SVM à noyau (tranche 4 EPIC #7357) où le défaut a été trouvé et la divergence introduite.
- #7357 — EPIC E2 Backtester Aricie (tranches 1-4 livrées, tranche 5 = `BackTesting.cs` à porter).
- `MyIntelligenceAgency/Lean#40` — ticket amont ouvert par cette PR.
- `docs/reference/backtester-e2-svm-kernel.md` — doc de cadrage du port SVM, où la disposition est désormais tracée.
- #14459 (MERGED 2026-09-03T18:50:47Z) — `LIGHT/guard -- lane myia-po-2023:CoursIA-2` MSYS2 path-conv fix, précédente PR mergée de la lane au moment de l'édit c.231.
- #14538 — Position I' (`MED/guard -- prev pointant MED/qc #14522`) qui se débloque tout seul au merge de celle-ci (ne pas toucher à son tag).
- msg-20260903T233052-z93sb6 — DM ai-01 du 2026-09-03T23:30Z prescrivant ce geste.

See #14370
