### PR TITLE
docs(rules,#14519): repointer le registre axe-2 SOTA hors de l'EPIC close

### DIFF
--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -1,6 +1,6 @@
 # SOTA : vrai outil + probleme non-trivial — install/invoke/re-plug, faire valoir le moteur (HARD)
 
-S'applique a **tous les agents** (workers po-* + coordinateur ai-01) **ET a tous les reviewers (humains ET bots** clusterManager-Myia : Hermes primaire, NanoClaw audit). Source : mandat user 2026-06-21, 3 messages — verbatim en [detail §1](../../docs/reference/sota-verdicts-detail.md). Registre = **EPIC #3801**. Consolide CLAUDE.md section F (reparer, jamais contourner) + [repair-not-consecrate](../../docs/reference/regles-validation-detail.md) + l'audit a 2 axes (committed <-> achievable).
+S'applique a **tous les agents** (workers po-* + coordinateur ai-01) **ET a tous les reviewers (humains ET bots** clusterManager-Myia : Hermes primaire, NanoClaw audit). Source : mandat user 2026-06-21, 3 messages — verbatim en [detail §1](../../docs/reference/sota-verdicts-detail.md). Registre = [`docs/ledgers/3801-sota-axe2.md`](../../docs/ledgers/3801-sota-axe2.md) (l'EPIC #3801 est **close depuis le 2026-07-09** : elle reste la provenance doctrinale du mandat, elle n'est plus le tracker). Consolide CLAUDE.md section F (reparer, jamais contourner) + [repair-not-consecrate](../../docs/reference/regles-validation-detail.md) + l'audit a 2 axes (committed <-> achievable).
 
 **Verbatims du mandat, incidents d'axes, mesures anti-fabrication** : [docs/reference/sota-verdicts-detail.md](../../docs/reference/sota-verdicts-detail.md).
 
@@ -68,10 +68,46 @@ Les bots **DOIVENT** poster `CHANGES_REQUESTED` quand une PR notebook (interne/c
 
 **Exception PR etudiante** (cf [student-pr-reviews.md](student-pr-reviews.md)) : NE PAS appliquer A/B — review bienveillante, pas de CHANGES_REQUESTED sur scaffolding.
 
+## Ou se depose une entree de registre, et quand l'axe-2 sera fini
+
+**Une entree va dans le fichier, jamais dans un commentaire d'issue.** Le registre est
+[`docs/ledgers/3801-sota-axe2.md`](../../docs/ledgers/3801-sota-axe2.md) ; une entree y est une section
+`## Entry #NNN — <Famille> (owner <lane>, c.NNN)` suivant la « Convention d'entree » que le ledger
+documente lui-meme en tete. Elle arrive **par PR**, comme tout fichier du depot.
+
+La regle le precise parce que l'inverse s'est produit : **sept entrees ont ete postees en commentaires
+sur l'EPIC #3801 apres sa fermeture** (la derniere le 2026-08-07). Elles existent, elles sont perdues —
+aucune requete `--state open` ne les atteint, et le `grep` d'un auditeur sur le depot ne les voit pas.
+
+**Critere de fin de l'axe-2** — trois conditions, toutes verifiables :
+
+1. **chaque famille de notebooks du depot porte une entree** ;
+2. **chaque entree porte un verdict agrege** (un des 5) ;
+3. **chaque verdict != `SOTA-OK` est solde** : soit une PR de fix **mergee** citee dans l'entree, soit un
+   `INTRINSIC` etabli par la checklist 6 axes ci-dessus.
+
+La condition 1 se **mesure**, elle ne se recopie pas — le denominateur est la liste des familles telle
+qu'elle est sur le disque au moment de la mesure, pas un compte fige dans un document :
+
+```bash
+grep -c '^## Entry #' docs/ledgers/3801-sota-axe2.md          # entrees au registre
+grep -oE '^## Entry #[0-9]+ — [^(]+' docs/ledgers/3801-sota-axe2.md   | sed 's/^## Entry #[0-9]* — //;s/ *$//' | sort -u          # familles couvertes
+```
+
+**Attention au grain** : le ledger indexe par **famille** (`Search`, `Tweety`), pas par repertoire.
+Comparer son compte a un `find MyIA.AI.Notebooks -name '*.ipynb'` agrege par repertoire donne deux
+nombres qui ne se soustraient pas — c'est un piege de denominateur, pas un ecart de couverture.
+
+**Le tableau « Cumul entries » du ledger n'est pas cet instrument** : mesure du 2026-09-03, il s'arrete
+a l'entree **8** alors que le fichier en porte **30**. Il ne peut donc pas repondre a la condition 1, et
+un auditeur qui s'y fierait conclurait une couverture quatre fois trop faible. Le rafraichir est un grain
+a part, hors du perimetre de #14519 qui portait sur l'ancre de cette regle.
+
 ## Voir aussi
 - CLAUDE.md section F — env/kernel : reparer, jamais contourner
 - [pr-review-discipline.md](pr-review-discipline.md) §H — critere bots SOTA + non-trivialite
 - [anti-regression.md](anti-regression.md) — ne pas stripper le code reel
 - [three-exercises-per-notebook.md](three-exercises-per-notebook.md) — richesse pedagogique (exercices)
-- **EPIC #3801** — registre axe-2 SOTA + problem-richness, par famille (GenAI/po-2023 en tete)
+- [`docs/ledgers/3801-sota-axe2.md`](../../docs/ledgers/3801-sota-axe2.md) — **le registre** axe-2 SOTA + problem-richness, par famille (30 entrees au 2026-09-03)
+- **EPIC #3801** (CLOSE le 2026-07-09) — provenance doctrinale du mandat user 2026-06-21. **Ne rien y deposer** : sept entrees y ont ete postees apres sa fermeture, ou aucune requete `--state open` ne les voit.
 - **#10459** — omission d'axe PythonNet, close par la checklist 6 axes ([detail §2](../../docs/reference/sota-verdicts-detail.md))

--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -98,10 +98,14 @@ grep -oE '^## Entry #[0-9]+ — [^(]+' docs/ledgers/3801-sota-axe2.md   | sed 's
 Comparer son compte a un `find MyIA.AI.Notebooks -name '*.ipynb'` agrege par repertoire donne deux
 nombres qui ne se soustraient pas — c'est un piege de denominateur, pas un ecart de couverture.
 
-**Le tableau « Cumul entries » du ledger n'est pas cet instrument** : mesure du 2026-09-03, il s'arrete
-a l'entree **8** alors que le fichier en porte **30**. Il ne peut donc pas repondre a la condition 1, et
-un auditeur qui s'y fierait conclurait une couverture quatre fois trop faible. Le rafraichir est un grain
-a part, hors du perimetre de #14519 qui portait sur l'ancre de cette regle.
+**Les tableaux « Cumul entries » du ledger ne sont pas cet instrument** : il y en a **deux**, tous deux
+perimes, mesure du 2026-09-03 — `## Cumul entries` (l.485) s'arrete a l'entree **8**, datee du 2026-07-10,
+et `### Cumul entries (registre axe-2 SOTA)` (l.854) s'arrete a l'entree **22**, datee du 2026-07-11 —
+alors que le fichier porte **30** entrees. Le plus recent des deux, le seul qu'un auditeur presse
+consulterait, sous-compte donc d'un facteur ~1,4 ; le plus ancien, si c'est celui qu'il trouve en premier,
+d'un facteur ~3,8. Aucun des deux ne repond a la condition 1. Le rafraichir — et **fusionner les deux
+tableaux dupliques en un seul**, la duplication etant elle-meme la cause du piege de lecture — est un
+grain a part, hors du perimetre de #14519 qui portait sur l'ancre de cette regle.
 
 ## Voir aussi
 - CLAUDE.md section F — env/kernel : reparer, jamais contourner


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/tooling #14508

## Le defaut

`.claude/rules/sota-not-workaround.md` est **auto-chargee** : son texte est en contexte de chaque session du cluster. Sa ligne 3 disait `Registre = **EPIC #3801**`, et son bloc « Voir aussi » repetait `**EPIC #3801** — registre axe-2 SOTA`.

**L'EPIC #3801 est CLOSE depuis le 2026-07-09** (verifie `gh issue view 3801 --json state,closedAt` : `CLOSED`, `2026-07-09T…`). Consequences mesurees :

- une lane qui suit l'ancre depose son entree en **commentaire d'issue close** — **sept** entrees y sont, qu'aucune requete `--state open` ne voit ;
- un reviewer qui verifie la reference tombe sur `CLOSED` et ne sait pas ou est le registre reel ;
- le registre reel — [`docs/ledgers/3801-sota-axe2.md`](docs/ledgers/3801-sota-axe2.md), **326 Ko, 2782 lignes, 30 entrees**, dernier commit 2026-08-31 — n'etait nomme qu'a la ligne 34, dans un exemple d'axe IKVM, jamais comme *le* registre.

## Ce que fait la PR

| # | Item | Ou |
|---|---|---|
| 1 | Ancre principale repointee sur le fichier de registre ; l'EPIC gardee comme **provenance doctrinale** avec sa date de fermeture ecrite | l. 3 |
| 2 | Bullet « Voir aussi » dedoublee : le ledger d'un cote, l'EPIC de l'autre avec **« Ne rien y deposer »** et le compte des sept entrees perdues | l. 111-112 |
| 3 | Section neuve **« Ou se depose une entree de registre, et quand l'axe-2 sera fini »** : forme `## Entry #NNN — <Famille> (owner <lane>, c.NNN)`, **par PR**, jamais en commentaire d'issue | avant `## Voir aussi` |
| 4 | **Critere de fin en 3 conditions verifiables** + la commande qui les mesure | meme section |

Le point 4 est ce qui manquait vraiment : le mandat user 2026-06-21 disait *quoi* faire, jamais *quand c'est fini*. Un critere de fin sans son instrument se recopie au lieu de se mesurer — les trois conditions sont donc livrees **avec** la commande qui rend leur denominateur.

## Controle positif — la commande documentee, executee telle qu'ecrite

Extraite du fichier livre et lancee verbatim depuis la racine du worktree :

```
$ grep -c '^## Entry #' docs/ledgers/3801-sota-axe2.md
30

$ grep -oE '^## Entry #[0-9]+ — [^(]+' docs/ledgers/3801-sota-axe2.md \
    | sed 's/^## Entry #[0-9]* — //;s/ *$//' | sort -u
Audio (GenAI)
CSP / MiniZinc
GameTheory / OpenSpiel
GenAI Image
…
rc=0
```

J'ai exerce le **remede**, pas seulement le diagnostic : la commande que la regle prescrit tourne depuis le fichier tel qu'il sera merge.

## Piege de denominateur, consigne dans la section

Le ledger indexe par **famille** (30), un `find MyIA.AI.Notebooks -name '*.ipynb'` compte des **repertoires** (56). **Les deux ne se soustraient pas** — « 26 restants » serait faux. La section nomme la maille de chaque compte a cote du compte.

## Constat annexe — signale, PAS corrige (hors perimetre)

Le tableau `## Cumul entries` du ledger (l. 485) s'arrete a l'**entree 8** alors que le fichier en porte **30**. Un auditeur qui s'y fierait conclurait une couverture ~4x trop faible — c'est-a-dire que le tableau de synthese du registre ne sait plus repondre a la question pour laquelle il existe. Corriger ce tableau est un grain a part entiere (`ledger`), pas un rider de cette PR.

## Ce que la PR ne touche pas

Les cinq occurrences de `3801` dans `.claude/rules/*.md` sont classees :

| Fichier:ligne | Nature | Traitement |
|---|---|---|
| `sota-not-workaround.md:3` | ancre **operationnelle** | **repointee** |
| `sota-not-workaround.md:111-112` | ancre **operationnelle** | **repointee** |
| `sota-not-workaround.md:34` | pointait deja le ledger | inchangee |
| `notebook-conventions.md:40` | provenance historique | **inchangee, legitime** |
| `pr-review-discipline.md:52` | provenance historique | **inchangee, legitime** |

Citer #3801 comme *origine du mandat* reste juste ; la citer comme *tracker courant* ne l'est plus. Seule la seconde lecture est corrigee.

Closes #14519
