### PR TITLE
fix(guard,#14541): le garde de collision postait le nom du fichier temporaire au lieu du rapport

### DIFF
--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -568,15 +568,15 @@ def post_comment(repo: str, number: int, body: str, dry_run: bool) -> bool:
     if dry_run:
         return True
     with tempfile.NamedTemporaryFile(
-        "w", suffix=".md", encoding="utf-8", delete=False
+        "w", suffix=".json", encoding="utf-8", delete=False
     ) as tf:
-        tf.write(body)
+        json.dump({"body": body}, tf, ensure_ascii=False)
         tmp_path = tf.name
     try:
         proc = subprocess.run(
             ["gh", "api", "--method", "POST",
              f"repos/{repo}/issues/{number}/comments",
-             "-f", f"body=@{tmp_path}"],
+             "--input", tmp_path],
             capture_output=True, text=True, check=False, encoding="utf-8",
         )
     finally:

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import json
 import subprocess as _subprocess
 import sys
 import unittest
@@ -550,6 +551,44 @@ class TestWriteChannelAndMuteVisibility(unittest.TestCase):
         # The channel that masked the failure must be gone, not merely
         # supplemented: a fallback would restore the masking on the retry.
         self.assertNotIn("comment", argv[:3])
+
+    def test_post_comment_transmits_the_body_not_the_temp_path(self):
+        """The endpoint assertion above is blind to what is actually SENT.
+
+        ``gh api -f key=@path`` sends the literal string ``@path``; only
+        ``-F`` dereferences it, and ``--input <json>`` -- what the PATCH
+        sibling ``edit_comment`` already used -- sidesteps the ``@``
+        semantics entirely. Under ``-f body=@<tmp>`` every marker posted the
+        name of a temporary file instead of the report, and, since the marker
+        string was then absent from the body, ``find_marker_entry`` could no
+        longer find its own comment and posted a fresh one on each run.
+
+        Measured on 2026-09-03: #14447 carried 4 such comments, and 7 of the
+        40 most recent PRs were affected. The test therefore reads the
+        payload back rather than trusting the argv shape."""
+        seen = {}
+
+        def _capture(argv, **kwargs):
+            argv = list(argv)
+            seen["argv"] = argv
+            # The temp file still exists here: post_comment unlinks it in its
+            # `finally`, after subprocess.run returns.
+            idx = argv.index("--input")
+            seen["payload"] = json.loads(
+                Path(argv[idx + 1]).read_text(encoding="utf-8")
+            )
+            return self._proc(0)
+
+        with mock.patch.object(_mod.subprocess, "run", side_effect=_capture):
+            ok = _mod.post_comment("owner/repo", 4242, "hello #900", dry_run=False)
+
+        self.assertTrue(ok)
+        self.assertEqual(seen["payload"]["body"], "hello #900")
+        # No argument may carry the "@<path>" form that caused the defect.
+        self.assertFalse(
+            [a for a in seen["argv"] if a.startswith("body=@")],
+            "the body must not be passed as a literal @path",
+        )
 
     def test_failed_write_is_warned_and_returns_false(self):
         buf = io.StringIO()


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/refactor #14520

Closes #14541.

## Le defaut

`gh api -f key=@path` envoie la chaine **litterale** `@path` ; seul `-F` la dereference. Depuis #14236, `post_comment` passait `-f body=@<tmp>` — donc chaque commentaire du garde de collision portait `@/tmp/tmpXXXX.md` a la place du rapport.

Il se compose : le marqueur du garde vit **dans le corps**, donc `find_marker_entry` ne retrouvait plus son propre commentaire et en **reposait un neuf a chaque passage**. Muet et accumulateur a la fois.

## Mesure (2026-09-03)

| | |
|---|---|
| PR touchees sur les 40 dernieres | **7** |
| doublons max sur une PR | **3** |
| #14447 | **4** commentaires vides |
| occurrences de `body=@` dans le depot | **1** (celle-ci) |

## Controle positif de la cause

`GH_DEBUG=api`, POST vers une issue inexistante (404, aucun effet de bord) :

```
-f body=@<path>  ->  "body": "@C:/.../ctl_body.md"
-F body=@<path>  ->  "body": "CONTROLE-POSITIF: ceci est le corps attendu.\n..."
```

## La correction

Le jumeau PATCH `edit_comment` ecrivait **deja** un fichier JSON passe en `--input`, ce qui contourne entierement la semantique du `@`. Le POST est aligne dessus plutot que de basculer sur `-F` : une seule forme d'ecriture dans le module, celle qui a fait ses preuves.

```diff
-        "w", suffix=".md", encoding="utf-8", delete=False
+        "w", suffix=".json", encoding="utf-8", delete=False
-        tf.write(body)
+        json.dump({"body": body}, tf, ensure_ascii=False)
-             "-f", f"body=@{tmp_path}"],
+             "--input", tmp_path],
```

## Pourquoi la suite ne l'avait pas vu

`test_post_comment_uses_the_rest_endpoint_not_gh_pr_comment` verifie l'**endpoint** et la forme de l'argv — jamais la charge utile. Il est reste vert pendant toute la duree du defaut. Un test qui certifie le canal ne certifie pas ce qui y transite.

Le test ajoute **relit le payload JSON reellement envoye** (le fichier temporaire vit encore quand le mock s'execute : `post_comment` le supprime dans son `finally`, apres le retour de `subprocess.run`), et refuse tout argument de forme `body=@`.

**Controle negatif verifie** : la forme cassee restauree, le nouveau test **echoue** (`ValueError: list.index(x): x not in list` sur `--input`). Il mesure donc bien le defaut, il ne l'accompagne pas.

## Validation

```
python -m pytest scripts/tests/test_check_pr_path_collisions.py -q
47 passed in 0.44s
```

## Portee

Genre `guard` = classe **META** : cette PR ne tient pas le plancher G-VAR-1 du cycle, et n'y pretend pas. Le nettoyage des doublons deja postes est porte par la 3e ligne d'acceptance de #14541, hors de cette PR.
