### PR TITLE
feat(audiobook,#1028): section Chapitrage .m4b exécutée dans le compagnon 04-12 (P5, moitié notebook)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
@@ -1282,18 +1282,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 5.706412,
-   "end_time": "2026-08-16T00:26:52.764216",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "04-12-Compilation-Audio.ipynb",
-   "output_path": "04-12-Compilation-Audio.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-16T00:26:47.057804",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
@@ -1004,6 +1004,216 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chapitrage .m4b — le conteneur audiobook natif\n",
+    "\n",
+    "Le compilateur de la chaine v4 (`v4/p6_compile.py`) ne produit pas seulement le\n",
+    "`.mp3` concatene ci-dessus : depuis #14224 il emet aussi un **`.m4b` chapitre** —\n",
+    "le format conteneur natif des lecteurs d'audiobooks (Apple Books, BookPlayer,\n",
+    "VLC), ou la navigation par chapitre est une primitive du lecteur, pas un\n",
+    "signet pose a la main.\n",
+    "\n",
+    "La mecanique, bouclee de bout en bout dans le module de production :\n",
+    "\n",
+    "1. **Positions d'actes** — pendant la concatenation, la boucle enregistre\n",
+    "   `act_start_ms[acte] = len(audiobook)` au passage du premier segment de chaque\n",
+    "   acte (les quatre actes de Boule de Suif, issus de `p3_dramatic_context.py`) ;\n",
+    "2. **FFMETADATA** — ces timestamps deviennent un fichier `FFMETADATA1` avec un\n",
+    "   bloc `[CHAPTER]` par acte (TIMEBASE 1/1000, START/END en ms, title) ;\n",
+    "3. **Remux AAC** — `ffmpeg` transcode le mp3 vers AAC dans le conteneur MPEG-4\n",
+    "   avec `-map_metadata 1 -map_chapters 1`.\n",
+    "\n",
+    "Cette section execute le **vrai `run()` de production** sur une **fixture\n",
+    "autonome** — 8 segments de silence (2 par acte), meme topologie que le test\n",
+    "d'integration du chapitrage — reproductible sur toute machine avec `ffmpeg`,\n",
+    "sans aucun service GenAI. Le run complet sur le livre entier (385 paragraphes,\n",
+    "94,7 min, 4 chapitres reels) est documente dans #14059 et vit sur la machine\n",
+    "de la chaine ; les outputs ci-dessous sont ceux de la fixture locale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fixture prete : 8 segments (2 par acte), dramatic_context.json valide\n",
+      "[P6] Compiling audiobook...\n",
+      "  Segments to compile: 8\n",
+      "  Act boundary: act1_diligence_aller -> act2_auberge_jours at seg 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Act boundary: act2_auberge_jours -> act3_pressing_collectif at seg 4\n",
+      "  Act boundary: act3_pressing_collectif -> act4_diligence_retour at seg 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [P6] m4b: m4b_fixture\\outputs\\boule_de_suif_v4.m4b (0.0 MB, 4 chapitres)\n",
+      "[P6] Done: m4b_fixture\\outputs\\boule_de_suif_v4.mp3\n",
+      "  Compiled: 8, Skipped: 0\n",
+      "  Duration: 24.2s (0.4min)\n",
+      "  Size: 0.5 MB\n",
+      "Compile par le module de production : boule_de_suif_v4.mp3\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import subprocess\n",
+    "import sys\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Filtre cible : le schema pydantic de la v4 emet un UserWarning de shadowing dont le\n",
+    "# prefixe contient le chemin absolu du module -- on l'exclut pour garder des sorties\n",
+    "# relocalisables (il n'apporte rien a la demonstration du chapitrage).\n",
+    "warnings.filterwarnings(\"ignore\", message='Field name \"register\" in \"VoiceReference\"')\n",
+    "\n",
+    "# ffmpeg : build statique local (regle F -- on installe l'outil, on ne le contourne pas).\n",
+    "# Sur une machine ou ffmpeg est deja dans le PATH, ce bloc est sans effet.\n",
+    "FFMPEG_DIR = Path(os.environ.get(\"LOCALAPPDATA\", \"\")) / \"ffmpeg-local\" / \"ffmpeg-master-latest-win64-gpl\" / \"bin\"\n",
+    "if FFMPEG_DIR.exists():\n",
+    "    os.environ[\"PATH\"] = str(FFMPEG_DIR) + os.pathsep + os.environ[\"PATH\"]\n",
+    "FFMPEG = \"ffmpeg\"\n",
+    "FFPROBE = \"ffprobe\"\n",
+    "\n",
+    "# Module de PRODUCTION v4/p6_compile.py (le chapitrage .m4b y vit depuis #14224).\n",
+    "sys.path.insert(0, str(Path.cwd()))\n",
+    "from v4 import p6_compile\n",
+    "from v4.schemas import DramaticContext, DramaticContextBatch\n",
+    "\n",
+    "# Fixture autonome, reproductible sans aucun service GenAI : 8 segments de silence\n",
+    "# (2 par acte), meme topologie que le test d'integration du chapitrage.\n",
+    "FIX = Path(\"m4b_fixture\")\n",
+    "(FIX / \"outputs\").mkdir(parents=True, exist_ok=True)\n",
+    "ACTS = [\"act1_diligence_aller\", \"act2_auberge_jours\", \"act3_pressing_collectif\", \"act4_diligence_retour\"]\n",
+    "POSITIONS = [\"exposition\", \"rising\", \"climax\", \"falling\"]\n",
+    "\n",
+    "tts_results = []\n",
+    "for i in range(8):\n",
+    "    mp3 = FIX / f\"seg_{i:02d}.mp3\"\n",
+    "    subprocess.run(\n",
+    "        [FFMPEG, \"-y\", \"-loglevel\", \"error\", \"-f\", \"lavfi\",\n",
+    "         \"-i\", \"anullsrc=r=24000:cl=mono\", \"-t\", \"2\", \"-b:a\", \"128k\", str(mp3)],\n",
+    "        check=True,\n",
+    "    )\n",
+    "    tts_results.append({\"seg_index\": i, \"mp3_path\": str(mp3)})\n",
+    "(FIX / \"outputs\" / \"tts_results.json\").write_text(json.dumps(tts_results), encoding=\"utf-8\")\n",
+    "\n",
+    "contexts = [\n",
+    "    DramaticContext(\n",
+    "        seg_index=i,\n",
+    "        act=ACTS[i // 2],\n",
+    "        scene_label=f\"Scene fixture {i // 2 + 1}\",\n",
+    "        tension_0_10=4,\n",
+    "        character_state={},\n",
+    "        narrative_position=POSITIONS[i // 2],\n",
+    "    )\n",
+    "    for i in range(8)\n",
+    "]\n",
+    "batch = DramaticContextBatch(contexts=contexts)\n",
+    "(FIX / \"outputs\" / \"dramatic_context.json\").write_text(batch.model_dump_json(), encoding=\"utf-8\")\n",
+    "print(\"Fixture prete : 8 segments (2 par acte), dramatic_context.json valide\")\n",
+    "\n",
+    "# Execution du VRAI run() de production sur la fixture : BASE_DIR repointe vers FIX,\n",
+    "# tout le reste (boucle act_start_ms, FFMETADATA, remux AAC) est le code de #14224.\n",
+    "p6_compile.BASE_DIR = FIX\n",
+    "mp3_out = p6_compile.run(force=True)\n",
+    "print(f\"Compile par le module de production : {mp3_out.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verification du chapitrage\n",
+    "\n",
+    "`ffprobe -show_chapters` est l'organe de preuve : il lit les chapitres **dans\n",
+    "le conteneur produit** — si le `.m4b` ne portait pas ses marqueurs, cette\n",
+    "commande ne rendrait rien. On attend 4 chapitres, des timestamps de debut\n",
+    "monotones, et les titres des quatre actes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 chapitres dans boule_de_suif_v4.m4b (6 Ko) :\n",
+      "  Acte I -- La diligence de l'aller: 0.00s -> 5.30s\n",
+      "  Acte II -- L'auberge, les jours: 5.30s -> 11.61s\n",
+      "  Acte III -- Le pressing collectif: 11.61s -> 17.91s\n",
+      "  Acte IV -- La diligence du retour: 17.91s -> 24.22s\n",
+      "Verifie : les 4 actes sont des chapitres natifs du conteneur, monotones, a duree strictement positive.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "m4b = FIX / \"outputs\" / \"boule_de_suif_v4.m4b\"\n",
+    "probe = subprocess.run(\n",
+    "    [FFPROBE, \"-v\", \"error\", \"-show_chapters\", \"-of\", \"json\", str(m4b)],\n",
+    "    capture_output=True, text=True, check=True,\n",
+    ")\n",
+    "chapters = json.loads(probe.stdout)[\"chapters\"]\n",
+    "print(f\"{len(chapters)} chapitres dans {m4b.name} ({m4b.stat().st_size / 1024:.0f} Ko) :\")\n",
+    "for ch in chapters:\n",
+    "    print(f\"  {ch['tags']['title']}: {float(ch['start_time']):.2f}s -> {float(ch['end_time']):.2f}s\")\n",
+    "\n",
+    "titles = [ch[\"tags\"][\"title\"] for ch in chapters]\n",
+    "starts = [float(ch[\"start_time\"]) for ch in chapters]\n",
+    "ends = [float(ch[\"end_time\"]) for ch in chapters]\n",
+    "assert len(chapters) == 4, f\"attendu 4 actes, trouve {len(chapters)}\"\n",
+    "assert starts == sorted(starts), \"timestamps de debut non monotones\"\n",
+    "assert all(e > s for s, e in zip(starts, ends)), \"chapitre a duree nulle\"\n",
+    "assert titles == [\"Acte I -- La diligence de l'aller\",\n",
+    "                  \"Acte II -- L'auberge, les jours\",\n",
+    "                  \"Acte III -- Le pressing collectif\",\n",
+    "                  \"Acte IV -- La diligence du retour\"], titles\n",
+    "print(\"Verifie : les 4 actes sont des chapitres natifs du conteneur, monotones, a duree strictement positive.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la sortie\n",
+    "\n",
+    "Les quatre actes sont des **chapitres natifs du conteneur** : un lecteur\n",
+    "d'audiobooks proposera « Acte I — La diligence de l'aller » comme borne de\n",
+    "navigation directe, avec le timescode exact capte pendant la concatenation\n",
+    "(5,30 s, 11,61 s, 17,91 s — chaque frontiere d'acte herite aussi du silence\n",
+    "d'1,5 s insere par la boucle). La duree totale du chapitre IV couvre\n",
+    "exactement la fin de l'audiobook : le dernier bloc `END` est cale sur la\n",
+    "duree compilee, pas sur une valeur arrondie.\n",
+    "\n",
+    "Avec ce chapitrage, la case P5 de l'EPIC #1028 est livree de bout en bout :\n",
+    "le script produit le conteneur (#14224), le companion le demontre, et la\n",
+    "suspension du monitor d'idle pour les chaines longues est automatisee\n",
+    "(#14415). Les objectifs de ce notebook couvraient « duree, clipping,\n",
+    "niveaux » ; le conteneur ajoute la **navigation** — la derniere brique du\n",
+    "« livre audio pour publics empches » que l'EPIC poursuit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3fa40461",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2027:CoursIA — prev: MED/notebook-lean #14540

## Summary

Le script `v4/p6_compile.py` produit un `.m4b` chapitre depuis #14224, mais le **compagnon pédagogique `04-12-Compilation-Audio.ipynb` ne le démontrait pas** : il s'arrête à `audiobook_raw.mp3` (l'ancienne approche), avec zéro mention du chapitrage hors faux-amis `m4b` dans les PNG base64 des outputs (mesuré). La case P5 de l'EPIC #1028 exigeait « 04-12-Compilation-Audio.ipynb **et** v4/p6_compile.py » — la moitié notebook manquait.

Section « ## Chapitrage .m4b — le conteneur audiobook natif » insérée avant la conclusion :

1. **md intro** — la mécanique en 3 temps : positions d'actes captées pendant la concaténation (`act_start_ms`), fichier FFMETADATA1 (`[CHAPTER]` TIMEBASE 1/1000), remux AAC (`-map_metadata 1 -map_chapters 1`).
2. **code ec=12** — fixture autonome (8 segments de silence, 2 par acte, topologie du test d'intégration #14224) puis exécution du **vrai `run()` de production** (`p6_compile.BASE_DIR` repointé) : concaténation pydub + production du mini `.m4b` 4 chapitres par le code de #14224, pas une réimplémentation.
3. **md transition** — `ffprobe -show_chapters` comme organe de preuve.
4. **code ec=13** — ffprobe sur le conteneur produit : 4 chapitres réels (Acte I-IV, 0.00→5.30→11.61→17.91→24.22 s), asserts (4 actes, starts monotones, durées strictement positives, titres exacts).
5. **md lecture** — navigation native lecteur, frontières d'acte héritant du silence 1,5 s, clôture P5 (#14224 script + ce compagnon + #14415 monitor).

See #1028 (la case P5 — les autres cases sont déjà cochées dans le body de l'EPIC).

## Validation

- **Exécution réelle** : cellules exécutées via `papermill -k python3` (kernel python3 = venv projet) dans le cwd `04-Applications/` du worktree, sur un clone frais `origin/main`. Sorties transplantées avec `execution_count` 12/13 (pattern compagnons #14540/#14552).
- **SOTA-OK (Prong A)** : le vrai module de production `v4/p6_compile.py` est importé et son `run()` exécuté ; ffmpeg/ffprobe = outils canoniques, installés localement (règle F : build statique BtbN win64 dans `%LOCALAPPDATA%\ffmpeg-local` — aucune UAC nocturne). pydub + audioop-lts (Python 3.13 a retiré `audioop`, PEP 594) installés dans le venv.
- **Vérifieur** : `ffprobe -show_chapters` lit les chapitres DANS le conteneur produit — 4 chapitres mesurés, timestamps monotones, titres exacts des quatre actes.
- **Zéro machine-path** : fixture et sorties en chemins relatifs (`m4b_fixture/...`) ; le seul warning à préfixe absolu (pydantic shadowing dans `schemas.py`) est filtré de façon ciblée (`filterwarnings` sur le message exact) — sorties relocalisables.
- **Séquence d'exécution** : CLEAN 1..13.
- **Ratchet output-failure** (`check_output_failure_text.py origin/main --json`) : `changed: 0, regressions: 0`.
- **Pre-commit H.3** : PASS (commit 7c840b6a7dca, tous hooks).
- **Consecutive-code-cells** : les deux cellules code sont séparées par un md de transition.
- **Fixtures non committées** : `m4b_fixture/` est un side-effect d'exécution, non stagé.
- Diff : 210 insertions, 1 file — un seul livrable.

## Périmètre & non-goals

- Le notebook entier n'est pas re-exécutable hors machine de chaîne (dépend de `tts_output/` gitignoré, artefacts FishAudio po-2023) — les cellules existantes conservent leurs outputs committés (C.3 : seules les cellules ajoutées sont exécutées), la section ajoutée est autonome et reproductible partout avec ffmpeg.
- Pas de modification de `v4/p6_compile.py` (livré et mergé, #14224).
- Claim : [CLAIMED] paths `04-12-Compilation-Audio.ipynb` posé sur #1028 (2026-09-04T01:45Z) — hors du paths `v4/**` du claim périmé po-2023:CoursIA-2, `check_lane_claim` CLEAR.
