### PR TITLE
test(guard,#14541): controle jumeau edit_comment + note d'appel post_comment

### DIFF
--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -564,6 +564,14 @@ def post_comment(repo: str, number: int, body: str, dry_run: bool) -> bool:
     ``NOT_FOUND`` rather than ``403``, which is what made the failure
     unreadable. REST returns the real status code, so if this still fails the
     next log names the actual cause instead of masking it.
+
+    The payload travels by ``--input <json>``, never ``-f body=@<file>``.
+    ``gh api`` expands a leading ``@`` for ``-F``/``--field`` only; ``-f``
+    posts the path as a literal string, which is how every marker came to
+    read ``@/tmp/tmpXXXXXXXX.md`` instead of the report (#14541). ``-F``
+    would read the file but also coerces ``true``/``123``/``null`` to
+    non-string JSON, and a comment body is always a string. ``--input``
+    avoids both, and is what the PATCH sibling already used.
     """
     if dry_run:
         return True

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -590,6 +590,47 @@ class TestWriteChannelAndMuteVisibility(unittest.TestCase):
             "the body must not be passed as a literal @path",
         )
 
+    def test_edit_comment_payload_carries_the_body(self):
+        """The PATCH sibling was already correct -- and nothing pinned it.
+
+        Both writers now build the same ``--input <json>`` payload, so the
+        next reader is invited to factor them together. The POST control
+        above would keep such a refactor honest on its own half only: with
+        no control here, ``edit_comment`` could slide into the very
+        ``-f body=@<tmp>`` form that was just removed and the suite would
+        stay green. The PATCH case is the worse of the two -- it overwrites
+        the existing marker with the name of a temp file, destroying the
+        report instead of merely duplicating it.
+        """
+        seen = {}
+
+        def _capture(argv, **kwargs):
+            argv = list(argv)
+            seen["argv"] = argv
+            self.assertIn(
+                "--input", argv,
+                "the PATCH writer must send a JSON payload, not a -f/-F field",
+            )
+            idx = argv.index("--input")
+            seen["payload"] = json.loads(
+                Path(argv[idx + 1]).read_text(encoding="utf-8")
+            )
+            return self._proc(0)
+
+        with mock.patch.object(_mod.subprocess, "run", side_effect=_capture):
+            ok = _mod.edit_comment(
+                "owner/repo", 4242, "id-901", "updated #901", dry_run=False
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(seen["argv"][:4], ["gh", "api", "--method", "PATCH"])
+        self.assertIn("repos/owner/repo/issues/comments/id-901", seen["argv"])
+        self.assertEqual(seen["payload"]["body"], "updated #901")
+        self.assertFalse(
+            [a for a in seen["argv"] if a.startswith("body=@")],
+            "the body must not be passed as a literal @path",
+        )
+
     def test_failed_write_is_warned_and_returns_false(self):
         buf = io.StringIO()
         with mock.patch.object(


### PR DESCRIPTION
Grain: LIGHT/test -- lane myia-ai-01:CoursIA -- prev: MED/guard #14542

See #14541 (livree par #14542, mergee).

## Ce qui reste apres #14542

J'ai diagnostique le defaut `@/tmp/` a 01h40Z et ouvert #14555 + cette PR
**sans avoir passe le preflight L1356** (`--state all`). Ma propre lane avait
deja livre #14542 deux heures plus tot, avec le meme diff de code et un
controle positif plus fort (`GH_DEBUG=api`). #14555 est ferme comme doublon,
#14542 est mergee. Cette PR est rebasee pour ne garder que **ce que #14542 ne
portait pas** : `+49 / -0`, deux fichiers, aucun changement de comportement.

## 1. Le controle jumeau sur `edit_comment`

`post_comment` (POST) est desormais epingle par
`test_post_comment_transmits_the_body_not_the_temp_path` (#14542). Le writer
PATCH `edit_comment` portait **deja** la bonne forme -- et c'est precisement
pourquoi rien ne l'epinglait : ses deux tests
(`test_edit_comment_warns_and_reports_failure`,
`test_edit_comment_success_silent`) sont cables sur le `returncode`.

Les deux fonctions construisent maintenant la **meme** charge utile
`--input <json>`. Le prochain lecteur sera invite a les factoriser. Le
controle POST tiendrait sa moitie ; l'autre pourrait glisser vers la forme
qu'on vient de retirer, en silence.

### Controle positif (mesure sur cet arbre)

En regressant **uniquement** `edit_comment` vers `-f f"body=@{tmp_path}"` --
la forme exacte que #14542 vient de retirer de `post_comment` :

| Suite | Resultat |
|---|---|
| celle de `main` (mon test deselectionne) | **47 passed** -- aveugle |
| avec `test_edit_comment_payload_carries_the_body` | **1 failed, 47 passed** |

Le message d'echec nomme l'argv fautif :

```
AssertionError: '--input' not found in ['gh', 'api', '--method', 'PATCH',
'repos/owner/repo/issues/comments/id-901', '-f', 'body=@C:\...\tmp5d_qm954.json']
: the PATCH writer must send a JSON payload, not a -f/-F field
```

Le cas PATCH est le pire des deux : il **ecrase** le marqueur existant par le
nom d'un fichier temporaire -- il detruit le rapport au lieu de le dupliquer.

## 2. La note d'appel dans `post_comment`

L'explication de *pourquoi ni `-f` ni `-F`* vit aujourd'hui dans la docstring
d'un test, dans un autre fichier. Le lecteur qui « simplifiera » `--input` en
`-f` lit `post_comment`, pas la suite de tests. Huit lignes de docstring
mettent l'avertissement au point de tentation, et nomment le second piege que
personne n'a encore paye : `-F` **lit** bien le fichier, mais coerce
`true`/`123`/`null` en JSON non-string -- un corps de commentaire est toujours
une chaine.

## Verification

```
python -m pytest scripts/tests/test_check_pr_path_collisions.py -q
48 passed in 0.36s
```
