### PR TITLE
docs(ict-25,#13596): tranches 2+4 — calibration cap 1024 sur la mesure EOS + limitation budget 80 écrite

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-25-InoculationRL.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-25-InoculationRL.ipynb
@@ -4781,6 +4781,21 @@
     "comparaison du verdict N/I avant/apres — points 2 et 3 de l acceptance\n",
     "#13596, sur machine GPU dediee."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5.2. Calibration du budget (tranche 2) et limitation (tranche 4)\n",
+    "\n",
+    "**Decision (tranche 2)** : a la re-execution des bras (tranche 3), `max_completion_length` passe de **80 a 1024**. Justification sur la mesure 5.1 : **p95 mesure = 1024** -- censure au garde-fou, donc bas de fourchette ; **p50 = 626** est le seul quantile non censure robuste. Un budget plus court (640, a peu pres p50) laisserait ~50 % des completions tronquees et sans marge sur la mediane ; 1024 couvre la mediane avec 1,6x de marge et aligne le cap sur le garde-fou de la mesure. Cout documente : les completions effectives passent de 80 tokens (systematiquement tronquees) a ~600-1024, soit **~8-12x le temps de generation par step** -- des runs multi-heures par bras au lieu de ~57 min.\n",
+    "\n",
+    "**Alternatives pesees et ecartees pour la tranche 3** (cf 5.1) : pression vers EOS (stop-strings, penalite de longueur, reward troncation-aware) et reformulation du prompt. Chacune changerait une **seconde variable en meme temps que le budget** : la comparaison avant/apres exigee par l acceptance (#13596, point 3) doit isoler le budget seul. Elles restent les candidates naturelles si le verdict N/I bascule a cap 1024 -- la decouverte appellerait alors une decompression du mecanisme.\n",
+    "\n",
+    "**Limitation (tranche 4 -- a lire sur toute metrique GRPO de ce notebook)** : les metriques GRPO des bras ci-dessus (sections 3-4) sont mesurees a **budget 80, donc sur des prefixes systematiquement tronques** : min=max=80 sur 40/40 steps, mean_terminated_length ~ 0 (#13596). Le verdict N/I porte par ces cellules est **non conclusif dans ce perimetre, pas refute** -- l issue exige la comparaison a budget corrige avant toute affirmation dans un sens ou l autre. Ce n est pas un defaut de reward (elle discrimine : reward 0.2667-0.4167 selon les steps) ni du signal few-shot : c est le budget qui coupe la completion avant la reponse.\n",
+    "\n",
+    "**Tranche 3 (en cours, gatee GPU-temps)** : re-run des bras canoniques a cap 1024 -- bras-N-signal multi-seed 0/1/42 @120 steps lance en run de fond le 2026-09-04 sur RTX 4060 locale (~10 h estimees), bras-I apparie a suivre sur la meme machine. Les outputs reels a cap 1024 seront livres avec la source des bras mise a jour (cap + commentaire de calibration) quand les deux bras auront termine."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-lean #14540

## Summary

Tranches 2 et 4 de l'acceptance #13596 (la tranche 1 — mesure EOS — était #14523) : une cellule markdown 5.2 ajoutée en fin de notebook (markdown-only, aucune cellule code touchée).

- **T2 — calibration tranchée** : à la re-exécution des bras (T3), `max_completion_length` passe de 80 à **1024**. Justification sur la mesure #14523 : p95 mesuré = 1024 (censuré au garde-fou, donc bas de fourchette), p50 = 626 seul quantile non censuré robuste. Un budget plus court (640 ≈ p50) laisserait ~50 % des completions tronquées sans marge sur la médiane ; 1024 couvre la médiane à 1,6× et aligne le cap sur le garde-fou de la mesure. Coût documenté : completions effectives ~600-1024 tokens = ~8-12× le temps de génération par step.
- **Alternatives pesées et écartées pour T3** (pression vers EOS : stop-strings/pénalité/reward troncation-aware ; reformulation du prompt) : chacune change une **seconde variable** en même temps que le budget — la comparaison avant/après exigée par l'acceptance (point 3) doit isoler le budget seul. Elles restent les candidates si le verdict bascule à cap 1024.
- **T4 — limitation écrite dans le notebook** : les métriques GRPO des sections 3-4 sont mesurées à budget 80 = **préfixes systématiquement tronqués** (min=max=80 sur 40/40 steps, cf 5.1) ; le verdict N/I est **non conclusif dans ce périmètre, pas réfuté** — l'issue interdit de le fermer comme « faux ».
- **T3 — lancée, gated GPU-temps** : bras-N-signal multi-seed 0/1/42 @120 steps à cap 1024 **tourne en run de fond sur RTX 4060 locale au moment de la création de cette PR** (seed 0 en génération, log scratchpad) ; bras-I apparié à suivre. Les outputs réels à cap 1024 + la source des bras mise à jour (valeur + commentaire de calibration) seront la PR suivante — la source des bras n'est PAS modifiée ici (C.2 : pas de source changée sans ses outputs).

## Validation

- **Markdown-only** : 1 cellule markdown ajoutée (5.2, index 49, fin de notebook), diff +15 lignes, 1 fichier — aucune cellule code touchée (C.3 scope strict ; C.2 re-exec non applicable).
- Séquence d'exécution inchangée (execution_count des cellules code identiques), round-trip JSON vérifié avant écriture.
- **Claims ancrés** : p50=626, p95=1024, distribution triée — présents dans les outputs de la cellule de mesure (ec=19) ; reward 0.2667-0.4167 cité sous la forme exacte des outputs ; min=max=80 sur 40/40 renvoie à la section 5.1 préexistante.
- Pre-commit H.3 : PASS (0b5247f9d80e).
- Runner T3 extrait **verbatim** de la cellule 25 (seule différence : cap 1024 + patch SSL Windows documenté cellule 31 + dump JSON des métriques), py_compile OK, exécution confirmée en cours (modèle chargé, dataset 36 prompts, seed 0).

See #13596 (tranches 2 et 4 livrées ; tranche 3 en cours, run de fond multi-heures).
