### PR TITLE
fix(guards,#14550): une clause `prev:` entre backticks est une citation, pas une declaration

### DIFF
--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -168,6 +168,37 @@ _PREV_PR_REF_RE = re.compile(
 )
 
 
+# Inline code spans and fenced blocks. A `prev:` clause written INSIDE
+# backticks is a CITATION (documentation of another grain's tag), never a
+# declaration -- the canonical tag line is plain text. #14550 measured the
+# cost of conflating the two: a lane that documented its successor, or that
+# explained WHY it did not point `prev:` at a still-open PR, had its own
+# correct tag overruled by its own prose. Masking preserves offsets so the
+# slices reported in the verdict stay meaningful.
+_CODE_SPAN_RE = re.compile(r"```.*?```|`[^`\n]*`", re.DOTALL)
+
+
+def _mask_code_spans(text: str) -> str:
+    r"""Blank out inline code spans / fenced blocks, preserving length."""
+    return _CODE_SPAN_RE.sub(lambda m: " " * len(m.group(0)), text)
+
+
+def _declared_prev_pr(text: str | None) -> int | None:
+    r"""The single `prev:` PR the canonical tag reader sees (#14550).
+
+    `grain_tag.parse_prev` strips backticks before reading, so it finds the
+    declaration even when a lane wraps its whole tag line in code marks.
+    Unioning it back in is what keeps the mask from creating a BLIND SPOT:
+    masking alone would let a backticked tag skip every invariant.
+    """
+    if not text:
+        return None
+    try:
+        return gt.parse_prev(text).get("pr_number")
+    except Exception:
+        return None
+
+
 def find_prev_self_references(text: str | None, current_pr: int | None) -> list[dict]:
     r"""Return every `prev:` whose PR reference equals `current_pr` (#13475 invariant 1).
 
@@ -185,10 +216,12 @@ def find_prev_self_references(text: str | None, current_pr: int | None) -> list[
     if not text or current_pr is None:
         return []
     out: list[dict] = []
-    for m in _PREV_PR_REF_RE.finditer(text):
+    for m in _PREV_PR_REF_RE.finditer(_mask_code_spans(text)):
         n = int(m.group(1))
         if n == current_pr:
             out.append({"prev_pr": n, "match": m.group(0)})
+    if not out and _declared_prev_pr(text) == current_pr:
+        out.append({"prev_pr": current_pr, "match": "prev: (tag)"})
     return out
 
 
@@ -204,11 +237,15 @@ def find_prev_target_pr_numbers(text: str | None) -> list[int]:
         return []
     seen: set[int] = set()
     out: list[int] = []
-    for m in _PREV_PR_REF_RE.finditer(text):
+    for m in _PREV_PR_REF_RE.finditer(_mask_code_spans(text)):
         n = int(m.group(1))
         if n not in seen:
             seen.add(n)
             out.append(n)
+    declared = _declared_prev_pr(text)
+    if declared is not None and declared not in seen:
+        seen.add(declared)
+        out.append(declared)
     return out
 
 

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -445,3 +445,81 @@ def test_check_passes_on_a_prev_pointing_at_a_resolved_merged_pr():
     v = vpg.check(body, current_pr=13922, prev_targets=targets)
     assert v["hits"]["prev_invalid"] == []
     assert v["guard_pass"] is True
+
+
+# --------------------------------------------------------------------------
+# #14550 -- a `prev:` clause inside backticks is a CITATION, not a declaration
+# --------------------------------------------------------------------------
+
+# Shape of the real #14559 body: a valid tag pointing at a MERGED PR, and a
+# quoted tag of ANOTHER grain in the prose. Before the fix, the quotation won:
+# `finditer` swept the whole body, found #14548 (still open), and the guard
+# rejected the PR on `prev-not-merged` -- accusing a lane of a defect it had
+# taken care to avoid.
+CITING_BODY = (
+    "Grain: DEEP/research-code -- lane myia-po-2026:CoursIA-2 -- "
+    "prev: DEEP/research-code #14501\n"
+    "\n"
+    "## Cause instrumentale\n"
+    "Le meme defaut que NanoClaw a nomme sur `Grain: MED/qc -- lane a:b -- "
+    "prev: MED/qc #14548` : `play_round` echantillonne `x` puis le jette.\n"
+)
+
+
+def test_backticked_prev_is_a_citation_not_a_declaration():
+    # The real #14559 case. `prev:` is declared at #14501 (merged); the body
+    # also QUOTES another lane's tag pointing at #14548 (open).
+    targets = {"14501": {"kind": "pr", "merged": True},
+               "14548": {"kind": "pr", "merged": False}}
+    v = vpg.check(CITING_BODY, current_pr=14559, prev_targets=targets)
+    assert 14548 not in vpg.find_prev_target_pr_numbers(CITING_BODY)
+    assert v["hits"]["prev_invalid"] == []
+    assert v["guard_pass"] is True
+
+
+def test_backticked_self_reference_does_not_trip_prev_self():
+    # Symmetric half: quoting a tag that happens to name the CURRENT PR is
+    # documentation, not a self-reference.
+    body = ("Grain: MED/guard -- lane myia-ai-01:CoursIA -- prev: MED/test #14501\n"
+            "Le garde a rejete `prev: MED/guard #4242` sur cette PR.\n")
+    assert vpg.find_prev_self_references(body, 4242) == []
+
+
+def test_fenced_block_is_masked_too():
+    body = ("Grain: MED/guard -- lane a:b -- prev: MED/guard #14501\n"
+            "```\n"
+            "Grain: MED/qc -- lane c:d -- prev: MED/qc #14548\n"
+            "```\n")
+    assert vpg.find_prev_target_pr_numbers(body) == [14501]
+
+
+def test_plain_prev_at_an_open_pr_still_fails():
+    # NEGATIVE CONTROL -- the invariant is not weakened. A `prev:` written in
+    # plain text (the canonical tag) at a still-open PR must still be rejected.
+    body = "Grain: MED/guard -- lane a:b -- prev: MED/guard #14548"
+    v = vpg.check(body, current_pr=99999,
+                  prev_targets={"14548": {"kind": "pr", "merged": False}})
+    assert v["hits"]["prev_invalid"] == [
+        {"location": "body", "kind": "prev-not-merged", "prev_pr": 14548}]
+    assert v["guard_pass"] is False
+
+
+def test_plain_prev_self_still_fails():
+    # NEGATIVE CONTROL -- prev-self stays blocking.
+    body = "Grain: MED/guard -- lane a:b -- prev: MED/guard #4242"
+    v = vpg.check(body, current_pr=4242)
+    assert v["guard_pass"] is False
+
+
+def test_fully_backticked_tag_is_still_evaluated():
+    # BLIND-SPOT CONTROL -- this is what `_declared_prev_pr` exists for.
+    #
+    # Masking alone would hand any lane a trivial bypass: wrap the tag line in
+    # backticks and every `prev:` invariant goes silent. `grain_tag.parse_prev`
+    # strips backticks before reading, so the DECLARATION is unioned back in.
+    # Remove that union and this test goes green in the wrong direction.
+    body = "`Grain: MED/guard -- lane a:b -- prev: MED/guard #14548`\nSuite."
+    assert vpg.find_prev_target_pr_numbers(body) == [14548]
+    v = vpg.check(body, current_pr=99999,
+                  prev_targets={"14548": {"kind": "pr", "merged": False}})
+    assert v["guard_pass"] is False


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/docs #14524

See #14550

## Le défaut

`_PREV_PR_REF_RE` était passé à `finditer` sur **le corps entier**, dans les deux
scanners (`find_prev_self_references` et `find_prev_target_pr_numbers`), sans rien
qui l'ancre à la ligne de tag `Grain:`. Une clause `prev:` **bien formée mais citée
en prose** créait donc une déclaration.

Conséquence mesurée : une lane qui documente le tag d'un autre grain — ou qui
explique *pourquoi* elle ne pointe pas vers une PR encore ouverte — se fait
contredire par sa propre prose.

## La mesure

Corps réel de #14559 : le tag déclare `#14501` (mergée), la prose cite le tag d'une
autre lane pointant `#14548` (ouverte).

| Organe | Verdict sur le corps réel de #14559 |
|---|---|
| `origin/main` (`e6a89d01f`) | `guard_pass=False` — `prev-not-merged -> [14548]` |
| cette PR | `guard_pass=True`, `prev_invalid == []` |

La PR accusée déclarait un `prev:` **correct**. C'est l'organe qui lisait la
citation comme une déclaration.

## Le correctif

Masquer les spans de code (inline et blocs fencés) **avant** le scan, en préservant
les offsets, puis **réunir** la déclaration unique que lit `grain_tag.parse_prev`.

L'union n'est pas redondante — elle ferme un angle mort que le masque seul
ouvrirait : `parse_prev` neutralise les backticks (`_NOISE`), donc masquer **sans**
réunir donnerait à n'importe quelle lane un contournement trivial — entourer sa
ligne de tag de backticks et tous les invariants `prev:` deviennent muets.
`test_fully_backticked_tag_is_still_evaluated` verrouille cet angle mort.

**Pourquoi pas simplement converger sur `parse_prev`** : `find_prev_self_references`
porte un contrat multi-hits **délibéré** — son propre test énonce que « the regex
must not stop at the first hit » (corps multi-grain). Converger aurait cassé ce
contrat ; le discriminant honnête est ailleurs, et il est net : **une déclaration ne
s'écrit jamais en code inline.**

## Contrôles

Six tests ajoutés, et ils se valident **par leurs faux négatifs** :

| Test | Sans le patch | Avec |
|---|---|---|
| `backticked_prev_is_a_citation_not_a_declaration` (corps réel #14559) | **échoue** | passe |
| `backticked_self_reference_does_not_trip_prev_self` | **échoue** | passe |
| `fenced_block_is_masked_too` | **échoue** | passe |
| `plain_prev_at_an_open_pr_still_fails` (contrôle négatif) | passe | passe |
| `plain_prev_self_still_fails` (contrôle négatif) | passe | passe |
| `fully_backticked_tag_is_still_evaluated` (angle mort) | passe | passe |

Les trois premiers prouvent que le patch **fait** quelque chose ; les trois derniers
prouvent qu'il ne **desserre** rien — ils pinnent un comportement qui ne doit pas
changer, donc ils passent dans les deux sens, par construction.

```
33 passed in 0.09s
```

(l'unique warning résiduel est un `SyntaxWarning` préexistant à `scripts/grain_tag.py:102`,
sans rapport.)

## Portée

Genre **META** (`guard`) : ce grain **ne tient pas** le plancher G-VAR-1 de ma lane,
qui reste dû sur un genre de contenu.

Ce corps de PR cite lui-même une clause `prev:` entre backticks à plusieurs endroits —
c'est précisément ce que le correctif rend inoffensif.

## G-VAR-3 : bloquée, puis débloquée sans levée — mise à jour

À l'ouverture, l'organe rendait `guard_pass: false` : `guard` succédait à `guard`
(#14542), ban absolu du §2. Je détiens l'instrument `[G-VAR-3 OVERRIDE]` et **je ne
l'ai pas employé sur ma propre lane** — un garde qui ne mord pas sur celui qui le
tient ne mord sur personne.

Le déblocage est venu de la séquence, pas d'une exception : **#14524 (`MED/docs`) a
mergé à 03:50:50Z**, donc le prédécesseur réel de ma lane est maintenant `docs`, et
`guard` après `docs` satisfait l'adjacence. La déclaration `prev:` ci-dessus est mise
à jour en conséquence — elle nomme le prédécesseur **réel**, pas celui qui arrangeait.

**Ce qui reste dû, et que ce déblocage ne paie pas** : #14524 est de genre `docs`,
donc **META**. Ma dette **G-VAR-1** — un plat principal DEEP ou MED dans un genre de
**CONTENU** — n'est pas éteinte par ce merge, et ne l'est pas davantage par celui-ci.
Les deux gates sont distincts ; confondre « adjacence propre » et « plancher tenu »
serait exactement l'échappatoire que le §2 décrit.
