### PR TITLE
fix(guard,#14421): le marqueur de collision etait adresse par son id GraphQL sur une route REST

### DIFF
--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -525,10 +525,36 @@ def list_open_prs(repo: str, limit: int) -> list[PrRow]:
 
 
 def find_marker(repo: str, number: int) -> tuple[str, str] | None:
-    """(id, body) of the marker comment on PR ``number``, or None."""
-    comments = _gh_json(["pr", "view", str(number), "--repo", repo,
-                         "--json", "comments"]) or {}
-    return find_marker_entry(comments.get("comments") or [])
+    """(id, body) of the marker comment on PR ``number``, or None.
+
+    Reads the REST collection, NOT ``gh pr view --json comments`` (#14421).
+    The two routes disagree on what ``id`` means, and only one of them is
+    addressable by the writer:
+
+    ==========================================  ==========================
+    source                                      ``id`` of a comment
+    ==========================================  ==========================
+    ``gh pr view --json comments`` (GraphQL)    ``IC_kwDOH2Odns8AAAAB...``
+    ``gh api repos/O/R/issues/N/comments``      ``5535634631``
+    ==========================================  ==========================
+
+    ``edit_comment`` spends that id on ``PATCH /repos/{repo}/issues/comments/
+    {id}``, a REST route that only accepts the database id. Fed a GraphQL
+    node id it answers ``404 Not Found`` -- deterministically, for every
+    update and every retract, while POST (which needs no id at all) keeps
+    succeeding. That asymmetry is the whole signature of #14421: run 364
+    reported ``post=13 update=0 retract=0``, 13/13 creations confirmed and
+    0/10 in-place writes, and the organ stayed mute ~39 h because it could
+    never refresh a marker it had already posted.
+
+    ``--paginate`` matters: a PR whose marker sits past the first page of
+    comments would otherwise read as "no marker" and be re-POSTED as a
+    duplicate. ``--slurp`` wraps the pages in an outer list, flattened here.
+    """
+    pages = _gh_json(["api", "--paginate", "--slurp",
+                      f"repos/{repo}/issues/{number}/comments"]) or []
+    comments = [c for page in pages for c in page]
+    return find_marker_entry(comments)
 
 
 def scan_markers(

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -431,6 +431,49 @@ class TestThreeVerbs(unittest.TestCase):
         self.assertEqual(_mod.find_marker_entry([{"id": 55, "body": body}]), ("55", body))
         self.assertIsNone(_mod.find_marker_entry([{"id": 1, "body": "plain"}]))
 
+    def test_find_marker_reads_the_rest_route_not_graphql(self):
+        """The id must be spendable by the PATCH writer (#14421).
+
+        ``find_marker_entry`` is pure and cannot tell a database id from a
+        GraphQL node id -- both are truthy strings, so every unit test above
+        passes under either source. The defect therefore lives entirely in
+        the *fetch*, which is why this test asserts on the argv rather than
+        on the returned tuple.
+
+        Measured 2026-09-04 on #14495: ``gh pr view --json comments`` renders
+        ``IC_kwDOH2Odns8AAAABSfMUxw`` where the REST collection renders
+        ``5535634631``; ``GET /repos/.../issues/comments/IC_kwDO...`` answers
+        ``404 Not Found``. ``edit_comment`` spends this id on that very route,
+        so a GraphQL id makes every update and retract 404 while POST keeps
+        working -- ``post=13 update=0 retract=0`` in run 364.
+        """
+        seen = {}
+
+        def _capture(argv, **kwargs):
+            argv = list(argv)
+            seen["argv"] = argv
+            page = [{"id": 5535634631,
+                     "body": "x " + _mod.COMMENT_MARKER_START + " y"}]
+            return _subprocess.CompletedProcess(
+                argv, 0, stdout=json.dumps([page]), stderr="")
+
+        with mock.patch.object(_mod.subprocess, "run", side_effect=_capture):
+            entry = _mod.find_marker("owner/repo", 4242)
+
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry[0], "5535634631")
+        # The REST collection, addressable by the PATCH sibling ...
+        self.assertIn("api", seen["argv"][:2])
+        self.assertIn("repos/owner/repo/issues/4242/comments", seen["argv"])
+        # ... paginated, so a marker past page 1 is not misread as absent ...
+        self.assertIn("--paginate", seen["argv"])
+        # ... and never the GraphQL projection, whose ids are not spendable.
+        self.assertNotIn("view", seen["argv"])
+        self.assertFalse(
+            [a for a in seen["argv"] if a == "comments"],
+            "'--json comments' returns GraphQL node ids the writer cannot use",
+        )
+
 
 class TestGhRowExtraction(unittest.TestCase):
     def test_from_gh_dict_reads_body_and_refs(self):


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #14560

## Le defaut

`find_marker` lisait les commentaires de PR par une projection **GraphQL** ; `edit_comment` depense l'id obtenu sur une route **REST**. Les deux routes ne rendent pas le meme genre d'id :

| Route | Appel | Champ `id` rendu |
|---|---|---|
| GraphQL (avant) | `gh pr view N --json comments` | `IC_kwDOH2Odns8AAAABSfMUxw` (node id) |
| REST (apres) | `gh api repos/{O}/{R}/issues/{N}/comments` | `5535634631` (database id) |

`edit_comment` fait `PATCH /repos/{repo}/issues/comments/{id}`. Cette route n'accepte **que** le database id. Mesure firsthand du 2026-09-04 : un GET REST sur le node id rend **404 Not Found**, de facon deterministe.

## Pourquoi c'est exactement la signature de #14421

`post=13 update=0 retract=0` au run 364. POST n'a besoin d'**aucun** id — il passe a 100 %. Update et retract passent tous les deux par `find_marker`, donc tous les deux par un id que la route refuse — 0 sur 0. L'asymetrie n'est pas un taux d'echec, c'est un mur : l'organe pouvait poser un marqueur, jamais le rafraichir ni le retirer, pendant ~39 h.

## Ce que #14542 a corrige — et ce qu'elle n'a pas touche

#14542 a change `post_comment` de `-f body=@{tmp}` (qui envoie la chaine litterale `@chemin`) vers `--input tmp`. C'est le **payload du POST**. Le 404 du PATCH ne passe pas par la : il est en amont, dans le choix de la route de lecture. La lecture « merger #14542 deploie le fix de #14421 » est un verdict non cable a sa preuve — les deux defauts vivent dans deux verbes differents.

## Le correctif

```python
pages = _gh_json(["api", "--paginate", "--slurp",
                  f"repos/{repo}/issues/{number}/comments"]) or []
comments = [c for page in pages for c in page]
return find_marker_entry(comments)
```

- `--paginate` : sans lui, un marqueur au-dela de la page 1 se lit comme **absent** — et l'organe le re-POSTE en doublon.
- `--slurp` : enveloppe les pages ; d'ou l'aplatissement. (`--slurp` est incompatible avec `--jq`/`--template`, d'ou le parsing en Python.)

## Controle positif

Le test assert sur l'**argv**, pas sur le tuple rendu : `find_marker_entry` est pure et ne peut pas distinguer un node id d'un database id — les deux sont des chaines truthy. C'est precisement pourquoi le defaut a traverse toute la suite sans jamais rougir.

| Etat du code | Resultat |
|---|---|
| Correctif en place, suite complete | **48 passed** |
| Regression vers la lecture GraphQL, avec le nouveau test | **1 failed, 47 passed** (detecte) |
| Regression vers la lecture GraphQL, nouveau test deselectionne | **47 passed, 1 deselected** |

La troisieme ligne est la mesure qui compte : la suite pre-existante est **entierement aveugle** au defaut. Le vert d'avant ne disait rien.

## Notes de protocole

- **G-VAR-3** : c'est le 2e `guard` consecutif de la lane (prev #14560). Substances genuinement distinctes — #14560 corrigeait le parsing d'une clause `prev:` entre backticks dans le garde d'adjacence, celle-ci corrige la route de lecture de l'organe de collision. Domaine-coeur de la lane coordinateur.
- **G-VAR-1** : `guard` est un genre **META** — ce grain **ne tient pas** le plancher du cycle. La lane doit nommer un grain DEEP/MED de CONTENU dans le meme cycle ; ce n'est pas cette PR qui le portera.

See #14421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
