### PR TITLE
ci(#10643): widen bash syntax guard to every tracked .sh (10 -> 54 files)

### DIFF
--- a/.github/workflows/bash-syntax-advisory.yml
+++ b/.github/workflows/bash-syntax-advisory.yml
@@ -12,8 +12,11 @@ name: Bash Syntax Advisory
 #
 # Layering:
 #   - syntax-check: FAILS on a broken .sh (that is the point -- it must be
-#     visible), but it is paths-scoped to scripts/** so it only gates PRs
-#     that touch scripts/.
+#     visible). Scope repo-wide since #10643 (2026-09-04): every tracked .sh,
+#     not just scripts/ -- 46 of the 56 companions lived outside scripts/
+#     and were never read by this guard. The EPIC body's out-of-scope zones
+#     (Vibe-Coding, docs/archive/, _archive/) are excluded: frozen
+#     inheritance + one known-broken teaching artefact tracked separately.
 #   - shebang-dry-run-advisory: continue-on-error -- never fails the PR;
 #     warns + posts a PR comment when a shebang / executable-bit issue is
 #     found, and dry-runs the one script that exposes a no-build `check`
@@ -23,12 +26,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'scripts/**'
+      - '**/*.sh'
       - '.github/workflows/bash-syntax-advisory.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'scripts/**'
+      - '**/*.sh'
       - '.github/workflows/bash-syntax-advisory.yml'
   workflow_dispatch:
 
@@ -42,7 +45,7 @@ concurrency:
 
 jobs:
   syntax-check:
-    name: bash -n every scripts .sh (advisory)
+    name: bash -n every tracked .sh (advisory)
     # Routage #14283 tranche 3c (ai-01 2026-09-02) : jambe Linux auto-hebergee.
     # Garde anti-fork au niveau job + runs-on STATIQUE (une expression leverait
     # DYNAMIC_RUNS_ON dans check_self_hosted_runner_policy.py).
@@ -62,7 +65,7 @@ jobs:
               echo "::error::bash syntax error: $f"
               FAILED=1
             fi
-          done < <(find scripts -name '*.sh' -type f | sort)
+          done < <(git ls-files '*.sh' | grep -v -E '^(MyIA.AI.Notebooks/GenAI/Vibe-Coding/|docs/archive/)|(^|/)_archive/' | sort)
           exit "$FAILED"
 
   shebang-dry-run-advisory:
@@ -90,7 +93,7 @@ jobs:
               echo "::warning::not executable (chmod +x): $f"
               WARN=1
             fi
-          done < <(find scripts -name '*.sh' -type f | sort)
+          done < <(git ls-files '*.sh' | grep -v -E '^(MyIA.AI.Notebooks/GenAI/Vibe-Coding/|docs/archive/)|(^|/)_archive/' | sort)
           echo "warnings=$WARN" >> "$GITHUB_OUTPUT"
       - name: Dry-run build_advisory.sh check (no build)
         run: |


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #14568

## Summary

Tranche résiduelle 1 du corps #10643 (mise à jour 2026-09-02 : « Le défaut réel : le garde CI ne couvre que 18 % des .sh ») : le garde `bash-syntax-advisory.yml` voit désormais **tout le dépôt actif**, pas seulement `scripts/`.

| Avant | Après |
|---|---|
| `find scripts -name '*.sh'` → **10 .sh analysés** | `git ls-files '*.sh'` moins les zones hors-scope du corps EPIC → **54 .sh analysés** |
| paths filter `scripts/**` | paths filter `**/*.sh` (ne déclenche QUE sur modif de .sh) |

**Exclusions alignées sur le corps de l'EPIC** (« 39 orphelins hors scope par le corps lui-même ») : `MyIA.AI.Notebooks/GenAI/Vibe-Coding/`, `docs/archive/`, `_archive/` — frozen inheritance, plus un artefact d'enseignement connu cassé → issue dédiée **#14574**.

## Validation (gate FP avant câblage, mémoire gate-fp)

- **Mesure locale pré-câblage sur les 59 .sh trackés** : `bash -n` → **1 échec** (`automatisation-mac.sh`, Vibe-Coding, l.101 — diagnostic complet dans #14574 : assemblage éclaté, parsing tronqué + 2 fragments orphelins). Sur le **scope câblé (54 .sh)** : **0 échec**, 0 avertissement shebang. Le garde est câblé delta-0.
- **YAML** : workflow édité à la main, 2 jobs inchangés par ailleurs (runs-on self-hosted statique #14283 inchangé).
- La couverture monte de 10 → 54 : les 44 compagnons P0/P1 livrés par l'EPIC (GameTheory, ML-Training-Pipeline launchers, SmartContracts, Lean, IIT, Infer…) entrent dans le champ du garde — c'était le critère d'acceptance 4.

## Tranche 2 (exécuter plutôt que parser) — mesurée, reportée avec preuve

Les 4 compagnons portant un mode sec ne sont **pas CI-safe** sur le runner ephemeral :
- 3 launchers ML-Training-Pipeline (`launch_ai01_lstm_run5.sh` etc.) : `--dry-run` **délègue** à `"${PYTHON_EXE}" "${TRAIN_SCRIPT}" --dry-run` → exige l'env training complet (torch) absent du runner.
- `docker-configurations/notebook-runner/h7_p3_notebook_runner.sh` : `--check-env` vérifie les kernels jupyter **locaux du runner** — par construction variable sur ephemeral.

Le dry-run CI-safe existant (`build_advisory.sh check`, no-build) reste câblé. Étendre l'exécution réelle exige un env conteneurisé dédié — grain séparé, pas un rider de ce garde.

## Verdict SOTA

**SOTA-OK** — le garde exécute le vrai `bash -n` (parsing réel GNU bash) sur le vrai corpus tracké ; aucune simulation.

See #10643 (critère 4 : le garde couvre désormais le corpus actif ; tranche 2 documentée avec preuves, non câblée à juste titre).


