### PR TITLE
fix(guards,#14292): liste effective VIDE = non-mesure — verdict PERIMETRE NON MESURABLE, exit 0

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -1921,6 +1921,38 @@ def is_pr_own_file(pr: int, path: str, head: Optional[str] = None, base_ref: str
     return None
 
 
+def unmeasurable_perimeter(
+    files: list[dict], carried: Optional[CarriedNote]
+) -> Optional[str]:
+    """#14292: when the effective file list is EMPTY, no count can be true.
+
+    An empty list is the ABSENCE of measurement (closed/emptied PR, base that
+    absorbed the whole diff), not a measurement of zero -- confronting body
+    counts against it can only fabricate a verdict (#11956's honest "5
+    fichiers" failed against a non-measurement). Distinguishes the two causes
+    `_classify_carried` already separates:
+
+    - the API list itself is empty (PR fermée/vidée, base qui a tout absorbé);
+    - the API list is NOT empty but every file is carried from main
+      (``carried.charries`` non-empty, ``propres == []``) -- the STALE-BASE
+      extreme.
+
+    Returns the reason when unmeasurable, None when the perimeter is
+    measurable (negative control: a real list never yields a reason).
+    """
+    if files:
+        return None
+    if carried is not None and carried.charries:
+        return (
+            "liste API non vide mais tout charrié de main (périmètre propre vide, "
+            "cf. STALE-BASE) : la tête est déjà d'accord avec main sur chaque fichier"
+        )
+    return (
+        "liste API vide (PR fermée ou vidée, base qui a tout absorbé) : "
+        "aucune confrontation de compte n'est possible"
+    )
+
+
 def fetch_report(pr: int) -> Report:
     # ``gh pr view --json files`` caps at 100 entries (single page), so the
     # guard used to confront bodies against a TRUNCATED list on >100-file PRs:
@@ -2225,6 +2257,15 @@ def main() -> int:
                 else:
                     signals.append(line)
 
+    # #14292: an EMPTY effective list is the absence of measurement, not a
+    # zero. Count problems confronting a body against it are fabricated --
+    # reclassify them as signals (the detection stays visible, only the exit
+    # code moves -- same safety order as #11985/#11712).
+    unmeasurable = unmeasurable_perimeter(report.files, report.carried)
+    if unmeasurable:
+        signals.extend(report.problems)
+        report.problems = []
+
     blocking = list(report.problems)
     if not args.justified and not args.scan_thread:
         for m in report.moves:
@@ -2235,6 +2276,11 @@ def main() -> int:
                 )
 
     print(format_report(report, args.assertion))
+    if unmeasurable:
+        print("")
+        print(f"PERIMETRE NON MESURABLE: {unmeasurable}")
+        print("  -> les comptes du body restent visibles sous SIGNAL ci-dessous ;")
+        print("     seule la consequence bouge, pas la detection (#14292).")
     if signals:
         print("")
         print("SIGNAL (non bloquant -- assertion d'un tiers non editable par l'auteur,")
@@ -2246,7 +2292,10 @@ def main() -> int:
         # signals. All body+incidental -> "not a perimeter claim, just a
         # note"; all thread -> "tier to correct"; mixed -> both. The old
         # blanket phrase was wrong for the all-body case (#11786 / #11775).
-        print(f"  -> {_format_signal_explanation(candidates)}")
+        # #14292: candidates n'existe que sous --scan-thread ; la voie
+        # --assert d'une PR non mesurable produit des signals sans lui.
+        if args.scan_thread:
+            print(f"  -> {_format_signal_explanation(candidates)}")
     if orphan_opener is not None:
         # #11678: the body scanned had an unterminated fence. CommonMark
         # renders it to EOF (correct behaviour, what GitHub does), but the

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -38,6 +38,7 @@ from check_pr_perimeter import (  # noqa: E402
     _is_incidental_assertion,
     _normalize_rest_files,
     _paragraph_block,
+    unmeasurable_perimeter,
     _paragraph_prefix,
     _word_form_count,
     _word_form_is_indef_non_pr_subject,
@@ -3599,3 +3600,71 @@ def test_13946_negative_real_perimeter_still_blocks():
         f"un vrai claim de 3 fichiers doit rester rouge quand 2 diff, "
         f"obtenu {problems!r}"
     )
+
+
+# #14292 — une liste effective VIDE est une non-mesure, pas un zéro.
+def test_14292_empty_api_list_is_unmeasurable():
+    """Cause 1 : la liste API elle-même est vide (PR fermée/vidée, base qui a
+    tout absorbé) — mesuré sur #11956 (main @ 84d6a974d9) et sur le FAIL
+    fantôme post-merge de #14536 (run 33849858765)."""
+    reason = unmeasurable_perimeter([], None)
+    assert reason is not None and "liste API vide" in reason
+    # Même cause quand la classification a tourné sur une liste API vide
+    # (_classify_carried rend propres=[], charries=[] dans ce cas).
+    reason2 = unmeasurable_perimeter([], CarriedNote(propres=[], charries=[]))
+    assert reason2 is not None and "liste API vide" in reason2
+
+
+def test_14292_all_carried_is_unmeasurable():
+    """Cause 2 : liste API non vide mais tout charrié de main (STALE-BASE
+    extrême, carried.propres == [])."""
+    carried = CarriedNote(
+        propres=[], charries=[{"path": "a.py"}], base_age_hours=None
+    )
+    reason = unmeasurable_perimeter([], carried)
+    assert reason is not None and "charrié" in reason
+
+
+def test_14292_measurable_perimeter_returns_none():
+    """Contrôle négatif obligatoire (#14292 acceptance 2) : un périmètre réel
+    ne rend jamais de raison — sans lui, « ne bloque plus » serait
+    indiscernable d'un garde débranché."""
+    assert unmeasurable_perimeter([{"path": "a.py"}], None) is None
+    # Même avec des charriés, un périmètre propre non vide reste mesurable.
+    mixed = CarriedNote(
+        propres=[{"path": "b.py"}], charries=[{"path": "a.py"}], base_age_hours=3
+    )
+    assert unmeasurable_perimeter([{"path": "b.py"}], mixed) is None
+
+
+def test_14292_ghost_fail_shape_becomes_signal(monkeypatch, capsys):
+    """La forme exacte mesurée sur #11956 (issue body) : body honnête
+    « Fichiers touchés : 5 fichiers », liste effective vide → le garde rendait
+    « VERDICT: FAIL / l'assertion pretend 5 fichier(s), la liste effective en
+    compte 0 ». Après #14292 : exit 0, PERIMETRE NON MESURABLE imprimé,
+    l'assertion visible sous SIGNAL (pas effacée)."""
+    import check_pr_perimeter as cpp
+
+    body = "**Fichiers touchés : 5 fichiers**\n- real.py\n"
+    monkeypatch.setattr(
+        cpp, "fetch_report",
+        lambda pr: cpp.Report(
+            files=[], moves=[],
+            carried=CarriedNote(propres=[], charries=[]),
+        ),
+    )
+    monkeypatch.setattr(cpp, "fetch_review_thread", lambda pr: [{
+        "kind": "PR body", "author": "jsboige", "body": body,
+        "source": "body", "ts": "",
+    }])
+    monkeypatch.setattr(
+        sys, "argv", ["check_pr_perimeter.py", "11956", "--scan-thread"]
+    )
+    rc = cpp.main()
+    out = capsys.readouterr().out
+    assert rc == 0, f"une non-mesure ne doit plus tenir la PR, obtenu :\n{out}"
+    assert "PERIMETRE NON MESURABLE" in out and "liste API vide" in out
+    assert (
+        "l'assertion pretend 5 fichier(s), la liste effective en compte 0" in out
+    ), "la détection doit rester visible sous SIGNAL, pas être effacée"
+    assert "VERDICT: OK" in out


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #14536

## #14292 — une liste effective VIDE est une non-mesure : verdict `PERIMETRE NON MESURABLE`, exit 0

Correctif prescrit par l'issue, implémenté au cordeau. Verrou de lane vérifié : #14261 (tenant précédent du fichier, po-2027/#13610) MERGED 2026-09-02T18:26Z.

## Diff

- `scripts/check_pr_perimeter.py` (+33) : prédicat pur `unmeasurable_perimeter(files, carried) -> Optional[str]` distinguant les **deux causes** que `_classify_carried` sépare déjà — (1) liste API vide (PR fermée/vidée, base qui a tout absorbé), (2) liste API non vide mais tout charrié de main (`carried.charries` non vide, `propres == []`, extrême STALE-BASE). Dans `main()` : si non mesurable → les problèmes de compte passent en `signals`, le rapport imprime `PERIMETRE NON MESURABLE: <raison>` — la détection reste visible, seul le code de sortie bouge (même ordre de sûreté que #11985/#11712).
- `scripts/tests/test_check_pr_perimeter.py` (+86) : 4 tests — un par cause + contrôle négatif + la forme fantôme complète via `main()` monkeypatché.

## Acceptance #14292 (vérifiée)

1. **`python scripts/check_pr_perimeter.py 11956 --scan-thread` → exit 0** :

```
Périmètre effectif : 0 fichier(s)
PERIMETRE NON MESURABLE: liste API vide (PR fermée ou vidée, base qui a tout absorbé) : aucune confrontation de compte n'est possible
SIGNAL (non bloquant ...) :
  ~~ [PR body / jsboige] l'assertion pretend 5 fichier(s), la liste effective en compte 0 :
VERDICT: OK
```

L'assertion reste visible sous SIGNAL (pas effacée) — la ligne exacte mesurée dans l'issue.

2. **Contrôles négatifs** :
   - `unmeasurable_perimeter([{"path": "a.py"}], None)` → `None` (test) ; périmètre propre non vide avec charriés mixtes → `None` (test)
   - `pytest scripts/tests/test_check_pr_perimeter.py` : **197/197 passed** — dont `test_13946_negative_real_perimeter_still_blocks` et `test_13791_digit_scope_with_zero_result_still_blocks` (un body menteur sur périmètre réel **reste rouge**)
   - Contrôle live : garde sur PR #14573 (périmètre réel) → `Périmètre effectif : 1 fichier(s)` mesuré correctement, VERDICT OK

3. **Un test par cause avec la ligne exacte mesurée** : `test_14292_ghost_fail_shape_becomes_signal` asserte verbatim `l'assertion pretend 5 fichier(s), la liste effective en compte 0` + exit 0 + `PERIMETRE NON MESURABLE`.

## Repro firsthand de la cause 1 (contexte)

Le FAIL fantôme post-merge de #14536 : edit du body d'une PR **déjà mergée** → run `edited`-event dont le diff vs main s'est collapsé à 0 fichiers → le garde accusait « l'assertion pretend 1 fichier(s), la liste effective en compte 0 ». Ce correctif rend ce run-là vert sans désarmer le garde pour les périmètres réels.

Closes #14292

