### PR TITLE
ci(#13363): PR gate jambe B — pull_request leg to the coursia-waiter pool

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -85,7 +85,26 @@ jobs:
     # references a check nobody produces -- pending forever, the very deadlock
     # this workflow exists to avoid.
     name: PR gate
-    runs-on: ubuntu-latest
+    # #13363 (arbitrage ai-01 2026-09-02, jambes A+B): under load this
+    # aggregator held 11/14 self-hosted runners just waiting (famine #11405),
+    # while a short timeout made it FAIL below the Quarto duration it waited
+    # for (false negative #11770). The third term dissolves the tension: a
+    # dedicated waiter pool -- waiting costs no CPU.
+    #   - Jambe A (po-2024, #14303 merged + deployed 2026-09-04): 24 waiter
+    #     slots (label coursia-waiter, 1 vCPU / 1 GiB / 128 pids) online via
+    #     coursia-waiters.service -- supervise.sh waiters.
+    #   - Jambe B (this PR): the pull_request leg leaves the shared GitHub-
+    #     hosted queue AND the self-hosted work pool, and waits on the waiter
+    #     pool. Forks stay on ubuntu-latest (fork code never reaches cluster
+    #     runners -- the reason for the same-repo guard #13874), and so do
+    #     workflow_dispatch runs (github.event.pull_request.head is null ->
+    #     the guard is false -> fallback). Semantics unchanged:
+    #     unsettled = FAIL = BLOCKED (#13363 acceptance).
+    # The form is audited by scripts/ci/check_self_hosted_runner_policy.py:
+    # exactly this pattern (same-repo guard -> fromJSON coursia-waiter,
+    # fallback ubuntu-latest); any other expression remains a fail-closed
+    # DYNAMIC_RUNS_ON violation. Rollback of this leg = revert of this PR.
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","coursia-waiter"]') || 'ubuntu-latest' }}
     # Above the script's own budget, so the script prints its verdict
     # instead of the runner killing it mid-poll (a runner-killed job reports
     # `cancelled`, which is far less legible than "timed out waiting for X").

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -49,7 +49,16 @@ LINUX_RUNNER_LABELS = {
     "coursia-ephemeral",
     "coursia-linux",
 }
-DEDICATED_LABEL_SETS = (REQUIRED_LABELS, LINUX_RUNNER_LABELS)
+# Dedicated label set for the PR-gate waiter pool (#13363 jambe A, po-2024):
+# 24 slots deployed via `supervise.sh waiters` (1 vCPU / 1 GiB / 128 pids,
+# coursia-waiters.service). A waiter never carries coursia-linux -- the
+# distinct label is what lets the gate WAIT without holding a work slot
+# (arbitrage ai-01 2026-09-02: "attendre ne coute pas de CPU").
+WAITER_LABELS = {
+    "self-hosted",
+    "coursia-waiter",
+}
+DEDICATED_LABEL_SETS = (REQUIRED_LABELS, LINUX_RUNNER_LABELS, WAITER_LABELS)
 # Owner-approved additions must cite the lane that owns the runner deployment:
 # - pr-gate-stale-sweep.yml: schedule-mutualized re-aggregation (pre-existing).
 # - windows-self-hosted-tests.yml: workflow_dispatch-ONLY vehicle for the 9
@@ -248,6 +257,15 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     #   seule pour l'API Checks/labels. Garde same-repo parenthesee au niveau
     #   job (#13874) pour les forks. Rollback = revert de cette PR.
     "markdown-deaccent-advisory.yml",
+    # #13363 jambe B (arbitrage ai-01 2026-09-02, owner myia-po-2024:CoursIA) :
+    #   pr-gate.yml routes its pull_request leg to the waiter pool via the ONE
+    #   audited hybrid runs-on form (_hybrid_runs_on) -- the same-repo guard
+    #   lives inside the expression itself, forks and workflow_dispatch fall
+    #   back to ubuntu-latest. Excluded until now because the polling
+    #   aggregator must not hold the work slot it waits for (#11405); the
+    #   waiter pool (1 vCPU / 1 GiB, #14303) is exactly the third term that
+    #   removes the objection. Rollback = revert of the routing PR.
+    "pr-gate.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",
@@ -427,6 +445,48 @@ def _runner_selection(
     return False, None, set(), "runs-on has an unsupported type"
 
 
+# Audited hybrid runs-on (#13363 jambe B). Exactly ONE dynamic form is
+# statically provable: the self-hosted leg is reached ONLY when the exact
+# same-repo guard is true; everything else falls back to a GitHub-hosted
+# label. Guard, label set and fallback are enumerated -- any variation
+# (different guard, different labels, different fallback) stays an
+# unauditable expression and keeps the DYNAMIC_RUNS_ON rejection.
+HYBRID_RUNS_ON_GUARD = SAME_REPO_GUARD
+HYBRID_RUNS_ON_LABELS = WAITER_LABELS
+HYBRID_RUNS_ON_FALLBACK = "ubuntu-latest"
+_HYBRID_PATTERN = re.compile(
+    r"^\s*\("
+    r"(?P<guard>[^()]+)"
+    r"\)\s*&&\s*fromJSON\(\s*(?P<q1>['\"])(?P<labels>.*?)(?P=q1)\s*\)"
+    r"\s*\|\|\s*(?P<q2>['\"])(?P<fallback>.*?)(?P=q2)\s*$"
+)
+
+
+def _hybrid_runs_on(runs_on: Any) -> dict[str, set[str]] | None:
+    """Return the audited hybrid legs for ``runs_on``, or None if it is not
+    the exact #13363 form. The caller keeps the DYNAMIC_RUNS_ON rejection
+    for every other expression."""
+    if not isinstance(runs_on, str):
+        return None
+    text = runs_on.strip()
+    if not (text.startswith("${{") and text.endswith("}}")):
+        return None
+    match = _HYBRID_PATTERN.match(text[3:-2].strip())
+    if match is None:
+        return None
+    if " ".join(match.group("guard").split()) != HYBRID_RUNS_ON_GUARD:
+        return None
+    if match.group("fallback") != HYBRID_RUNS_ON_FALLBACK:
+        return None
+    try:
+        labels = {str(item) for item in json.loads(match.group("labels"))}
+    except json.JSONDecodeError:
+        return None
+    if labels != HYBRID_RUNS_ON_LABELS:
+        return None
+    return {"labels": labels}
+
+
 def _normalise_condition(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -591,21 +651,39 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                 broken.append(f"{path.name}:{job_name}: missing runs-on")
                 continue
 
-            if _contains_expression(runs_on):
+            hybrid = _hybrid_runs_on(runs_on)
+            if _contains_expression(runs_on) and hybrid is None:
                 violations.append(Violation(
                     path.name,
                     str(job_name),
                     "DYNAMIC_RUNS_ON",
-                    "runs-on contains an expression and cannot be audited statically",
+                    "runs-on contains an expression other than the single audited "
+                    "hybrid form (same-repo guard -> self-hosted coursia-waiter, "
+                    "else ubuntu-latest; see #13363) and cannot be audited "
+                    "statically",
                 ))
                 continue
 
-            is_self_hosted, group, labels, selection_error = _runner_selection(runs_on)
-            if selection_error is not None:
-                broken.append(f"{path.name}:{job_name}: {selection_error}")
-                continue
-            if not is_self_hosted:
-                continue
+            if hybrid is not None:
+                # Audited hybrid leg (#13363): self-hosted by construction, and
+                # the same-repo guard lives inside the expression itself -- the
+                # self-hosted labels are unreachable for any fork payload. All
+                # other invariants (triggers, allowlist, label set) apply as
+                # for a static leg; only the job-level SAME_REPO_GUARD check is
+                # carried by the runs-on instead of `if:`.
+                is_self_hosted = True
+                group = None
+                labels = hybrid["labels"]
+                selection_error = None
+                hybrid_leg = True
+            else:
+                is_self_hosted, group, labels, selection_error = _runner_selection(runs_on)
+                hybrid_leg = False
+                if selection_error is not None:
+                    broken.append(f"{path.name}:{job_name}: {selection_error}")
+                    continue
+                if not is_self_hosted:
+                    continue
             self_hosted_jobs += 1
 
             if "pull_request_target" in triggers:
@@ -694,7 +772,8 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                     "dedicated labels must match exactly (" + "; ".join(detail) + ")",
                 ))
 
-            if "pull_request" in triggers:
+            if "pull_request" in triggers and not hybrid_leg:
+                # Hybrid legs carry the guard in their runs-on expression.
                 condition = _normalise_condition(job.get("if"))
                 # Accept either the bare guard or the guard followed by a
                 # selection predicate (e.g. `&& inputs.target == '...'`)

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -559,6 +559,127 @@ def test_dynamic_runs_on_is_rejected_fail_closed(tmp_path):
     assert result.self_hosted_jobs == 0
 
 
+HYBRID_RUNS_ON = (
+    "${{ (github.event.pull_request.head.repo.full_name == github.repository)"
+    " && fromJSON('[\"self-hosted\",\"coursia-waiter\"]') || 'ubuntu-latest' }}"
+)
+
+
+def test_hybrid_runs_on_waiter_form_is_accepted(tmp_path):
+    # #13363 jambe B: the ONE audited dynamic form. pr-gate.yml is the only
+    # consumer; the same-repo guard lives inside the expression, so no job
+    # `if:` is required (the self-hosted labels are unreachable for forks).
+    write_workflow(tmp_path, "pr-gate", """
+        name: PR gate
+        on:
+          pull_request:
+            branches: [main]
+          workflow_dispatch:
+        jobs:
+          gate:
+            name: PR gate
+            runs-on: RUNSON
+            steps:
+              - run: echo aggregate
+        """)
+    (tmp_path / "pr-gate.yml").write_text(
+        (tmp_path / "pr-gate.yml").read_text(encoding="utf-8").replace(
+            "RUNSON", HYBRID_RUNS_ON
+        ),
+        encoding="utf-8",
+    )
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert result.violations == []
+    assert result.self_hosted_jobs == 1
+
+
+def test_hybrid_runs_on_wrong_labels_is_rejected(tmp_path):
+    write_workflow(tmp_path, "pr-gate", """
+        name: PR gate
+        on: workflow_dispatch
+        jobs:
+          gate:
+            runs-on: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","coursia-linux"]') || 'ubuntu-latest' }}
+            steps:
+              - run: echo aggregate
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert codes(result) == {"DYNAMIC_RUNS_ON"}
+    assert result.self_hosted_jobs == 0
+
+
+def test_hybrid_runs_on_wrong_fallback_is_rejected(tmp_path):
+    write_workflow(tmp_path, "pr-gate", """
+        name: PR gate
+        on: workflow_dispatch
+        jobs:
+          gate:
+            runs-on: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","coursia-waiter"]') || 'ubuntu-24.04' }}
+            steps:
+              - run: echo aggregate
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert codes(result) == {"DYNAMIC_RUNS_ON"}
+
+
+def test_hybrid_runs_on_universal_guard_is_rejected(tmp_path):
+    # The universal guard (|| null) inside the hybrid form would route
+    # workflow_dispatch runs to the waiter pool; only the strict same-repo
+    # equality is audited.
+    write_workflow(tmp_path, "pr-gate", """
+        name: PR gate
+        on: workflow_dispatch
+        jobs:
+          gate:
+            runs-on: ${{ (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","coursia-waiter"]') || 'ubuntu-latest' }}
+            steps:
+              - run: echo aggregate
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert codes(result) == {"DYNAMIC_RUNS_ON"}
+
+
+def test_hybrid_runs_on_in_non_allowlisted_workflow_is_rejected(tmp_path):
+    write_workflow(tmp_path, "other-aggregator", """
+        name: other
+        on: workflow_dispatch
+        jobs:
+          gate:
+            runs-on: RUNSON
+            steps:
+              - run: echo aggregate
+        """)
+    (tmp_path / "other-aggregator.yml").write_text(
+        (tmp_path / "other-aggregator.yml").read_text(encoding="utf-8").replace(
+            "RUNSON", HYBRID_RUNS_ON
+        ),
+        encoding="utf-8",
+    )
+    result = policy.scan_workflows(tmp_path)
+    assert codes(result) == {"WORKFLOW_NOT_ALLOWED"}
+
+
+def test_hybrid_runs_on_pull_request_target_is_rejected(tmp_path):
+    write_workflow(tmp_path, "pr-gate", """
+        name: PR gate
+        on: [pull_request_target]
+        jobs:
+          gate:
+            runs-on: RUNSON
+            steps:
+              - run: echo aggregate
+        """)
+    (tmp_path / "pr-gate.yml").write_text(
+        (tmp_path / "pr-gate.yml").read_text(encoding="utf-8").replace(
+            "RUNSON", HYBRID_RUNS_ON
+        ),
+        encoding="utf-8",
+    )
+    result = policy.scan_workflows(tmp_path)
+    assert "PULL_REQUEST_TARGET" in codes(result)
+
+
 def test_pull_request_job_without_guard_is_rejected(tmp_path):
     write_workflow(tmp_path, "unguarded", """
         name: unguarded


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #14582

# ci(#13363): PR gate jambe B — jambe pull_request vers le pool d'attente coursia-waiter

## Arbitrage exécuté (ai-01, 2026-09-02, commentaire [ai-01 ARBITRAGE] sur #13363)

La tension #11405 (famine : le gate tenait 11/14 runners) vs #11770 (FAIL faux : borne < durée Quarto p75) se dissout par un troisième terme : un pool d'attente dédié — attendre ne coûte pas de CPU. Découpe : **A** = label + slots waiters (po-2024) ; **B** = bascule runs-on (cette PR). **A avant B, sans exception** — respecté :

- **Jambe A — DÉPLOYÉE ce jour (2026-09-04 ~11:50Z), avant l'ouverture de cette PR** : `supervise.sh waiters 24` sous l'unité systemd dédiée `coursia-waiters.service` (même pattern que coursia-runner.service : token lu à chaque invocation depuis master.env, jamais d'EnvironmentFile). Preuve d'acceptation A : `gh api actions/runners` → **48 runners online dont 24 `coursia-waiter`** (zéro avant) ; consommation réelle mesurée ~37 MiB RAM / waiter (cap 1 GiB), CPU idle ~0.
- **Jambe B — cette PR** : la jambe pull_request quitte `ubuntu-latest` et attend sur les waiters ; forks ET workflow_dispatch retombent sur `ubuntu-latest` (garde same-repo dans l'expression même — #13874 : le code fork n'atteint jamais un runner du cluster).

## Sémantique inchangée (acceptance #13363)

- `unsettled = FAIL = BLOCKED` : aucun changement à pr_gate.py, aux bornes (`--timeout-min 45`), ni au nom du check `PR gate`.
- Le gate n'occupe plus un slot de TRAVAIL pendant qu'il attend : il attend sur un slot d'attente (1 vCPU / 1 GiB / 128 pids).

## Amendement fin du checker (fail-closed préservé)

`check_self_hosted_runner_policy.py` rejetait TOUT runs-on dynamique (DYNAMIC_RUNS_ON) et pr-gate.yml était exclu de l'allowlist (« l'agrégateur qui poll tiendrait le slot qu'il attend », tranche 3a #14283). L'exclusion est levée par la résolution du motif même de l'exclusion (le pool d'attente), et l'amendement est **fermé** :

- **UN SEUL motif hybride** audité : `(same-repo guard exacte) && fromJSON(["self-hosted","coursia-waiter"]) || 'ubuntu-latest'` — garde, labels et fallback sont des constantes énumérées dans le checker (`HYBRID_RUNS_ON_GUARD/LABELS/FALLBACK`).
- Toute variation (autre garde — y compris la forme universelle, qui routerait les dispatches sur les waiters —, autres labels, autre fallback, toute autre expression) reste **DYNAMIC_RUNS_ON** fail-closed.
- La jambe hybride passe TOUS les autres invariants : triggers (pull_request/workflow_dispatch dans SAFE_SELF_HOSTED_TRIGGERS ; pull_request_target/workflow_run refusés), allowlist, set de labels dédié (`WAITER_LABELS` ajouté à `DEDICATED_LABEL_SETS`), pas de runner group. La garde same-repo vit dans l'expression elle-même (les labels self-hosted sont inatteignables pour un payload fork), d'où l'exemption ciblée du check `if:` de job pour la seule jambe hybride.

## Tests (55 passés, 6 nouveaux)

- forme exacte acceptée (self_hosted_jobs == 1, 0 violation) · mauvais labels → DYNAMIC_RUNS_ON · mauvais fallback → DYNAMIC_RUNS_ON · garde universelle → DYNAMIC_RUNS_ON · workflow non allowlisté → WORKFLOW_NOT_ALLOWED · pull_request_target → PULL_REQUEST_TARGET.
- Baseline dépôt : `check_self_hosted_runner_policy.py --check` → OK (137 workflows, 167 jobs, 116 self-hosted, 0 violation).

## Contrôle positif attendu

Le PR gate de CETTE PR s'exécutera avec la nouvelle définition (PR same-repo) → il DOIT tourner sur un runner `myia-po-2024-linux-waiter-N` : preuve via `jobs[].runner_name` sur le run. La mesure de file (acceptance : sous file ≥200 queued, PR gate ≤1 in_progress + contrôle positif queued_runs imprimé) sera vérifiée à la prochaine période de charge ; état initial au déploiement : 18 queued / 4 in_progress (calme).

## Rollback

Revert de cette PR (retour ubuntu-latest intégral) ; jambe A : `systemctl stop coursia-waiters.service && systemctl disable coursia-waiters.service`.

See #13363
