### PR TITLE
ci(ict,#14571): venv per-job dans ict-tests.yml -- arrete pip-install destructif du toolcache partage

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -102,13 +102,37 @@ jobs:
           cache: pip
           cache-dependency-path: MyIA.AI.Notebooks/IIT/ICT-Series/pyproject.toml
 
-      - name: Install ict package + deps (pyphi 1.2.0, numpy<2, scipy, matplotlib)
+      - name: Install ict package + deps dans venv per-job (pyphi 1.2.0, numpy<2, scipy, matplotlib)
+        # Fix #14571a : le toolcache `/opt/hostedtoolcache/Python/3.9.x/x64` du runner
+        # self-heberge `coursia-ephemeral` est PERSISTANT entre conteneurs (etiquette
+        # declarative, pas mode --ephemeral). `pip install -e .` y ecrit des fichiers
+        # .pth qu'un job ulterieur tente de desinstaller sur un cache devenu incoherent
+        # -> Errno 2 en ~15 s sur des PRs sans rapport (#14559 a ete mal attribue
+        # d'abord a un probleme de la PR). Le venv `$RUNNER_TEMP` est detruit a la fin
+        # du job par GitHub Actions, donc zero contamination inter-jobs. Acceptance :
+        # 2 runs consecutifs du MEME workflow sur le MEME runner, le 2e doit reussir.
         id: install
         working-directory: MyIA.AI.Notebooks/IIT/ICT-Series
+        env:
+          ICT_VENV: ${{ runner.temp }}/ict-venv
         run: |
+          python -m venv "$ICT_VENV"
+          # shellcheck disable=SC1091
+          source "$ICT_VENV/bin/activate"
           python -m pip install --upgrade pip
           pip install -e .
           pip install pytest
+          # Garde-fou : verifier que `pip show` rapporte le site-packages du venv,
+          # pas celui du toolcache partage. Un editable install fait pointer
+          # `ict.__file__` vers le source-tree (par design), donc on interroge pip.
+          if ! pip show ict-series 2>/dev/null | grep -q "$ICT_VENV"; then
+            echo "::error title=ICT install hors venv::pip show ict-series ne pointe pas vers \$ICT_VENV -- l'install a ecrit dans le toolcache partage, ce qui reproduit le defaut #14571. Venv: $ICT_VENV"
+            pip show ict-series || true
+            exit 1
+          fi
+          echo "ICT install OK in venv (pip show ict-series -> $ICT_VENV)"
+          python -c "import ict; print('ict import OK, __file__=', ict.__file__)"
+          echo "$ICT_VENV/bin" >> "$GITHUB_PATH"
 
       - name: Run ${{ matrix.suite-name }}
         working-directory: ${{ matrix.test-cwd }}


### PR DESCRIPTION
Grain: MED/ci-infra -- lane myia-po-2024:CoursIA-2 -- prev: DEEP/research-code #14501 (c.890, MERGED 2026-09-03T18:39, distinct genre guard vs research-code ; voir commentaire issue ci-joint : Tell c.896-L2 sustained -- filter-branch tag vers PR MERGED de la même lane)

ci(ict,#14571): venv per-job dans ict-tests.yml -- arrete pip-install destructif du toolcache partage

## Resume

Le toolcache `/opt/hostedtoolcache/Python/3.9.x/x64` du runner self-heberge `coursia-ephemeral` de po-2024 **persiste entre conteneurs** : l'etiquette est declarative, le mode `--ephemeral` cote hote n'est pas impose. `pip install -e .` dans `ict-tests.yml` y ecrit des fichiers `.pth` qu'un job ulterieur tente de desinstaller sur un cache devenu incoherent -> `Errno 2: No such file or directory` en ~15 s sur des PRs **sans rapport** (le rouge a ete mal attribue a la PR #14559 par moi-meme avant lecture du log du job -- voir DM `msg-20260904T101310-mqai6j` d'ai-01).

Cette PR implemente le fix **(a)** de l'acceptance #14571 : creer un **venv per-job** dans `${{ runner.temp }}/ict-venv` et installer `ict-series` dedans, jamais dans le toolcache partage. Le venv est detruit a la fin du job par GitHub Actions (zero contamination inter-jobs).

## Cause instrumentale verifiee firsthand

| Run | Job | Runner | Horodatage |
|---|---|---|---|
| `33828593263` | `100886494483` | `myia-po-2024-linux-docker-5` | 2026-09-04 |
| `33841162044` | `100937271413` | `myia-po-2024-linux-docker-6` | 2026-09-04T06:47:05Z |

Les deux occurrences concernent le **meme parc** (`myia-po-2024-linux-docker-*`), aucune sur `ai-01` executant le meme workflow. C'est une **localisation apparente**, pas une mesure de taux definitive, mais elle est coherente avec l'hypothese d'un montage partage cote po-2024.

## Modifications

| Fichier | Delta |
|---|---|
| `.github/workflows/ict-tests.yml` | +25 lignes : step `install` recreate en venv per-job (`python -m venv "$ICT_VENV"`, source, `pip install -e .`), `$ICT_VENV/bin` ajoute a `$GITHUB_PATH` pour les steps suivants (`Run` + `Collection floor-guard`), garde-fou `pip show ict-series \| grep -q "$ICT_VENV"` pour detecter toute ecriture hors-venv. Note d'iteration : un 1er garde-fou testait `assert $RUNNER_TEMP in ict.__file__`, mais `pip install -e .` est un **editable install** : `ict.__file__` pointe vers le source-tree (par design), pas le site-packages. La verification correcte est `pip show ict-series` → `Location:` doit etre dans `$ICT_VENV`. Le garde-fou corrige echoue bruyamment avec un `::error title=ICT install hors venv` si pip re-ecrit dans le toolcache partage. |

Aucun autre fichier touche. Pas de notebook, pas de code ICT, pas de catalogue.

## Acceptance #14571 — point (a)

1. **Cause etablie** : le toolcache partage entre conteneurs self-heberge `coursia-ephemeral` (verifie par les 2 runs ci-dessus + verbatim de l'erreur `Could not install packages due to an OSError: [Errno 2] No such file or directory: '/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/__editable__.ict_series-0.1.0.pth'`).
2. **`ict-tests.yml` n'ecrit plus dans le toolcache** : le step `install` cree un venv `$RUNNER_TEMP/ict-venv` isole, et le garde-fou Python verifie `ict.__file__` reside dans `$RUNNER_TEMP`. Si pip re-ecrit dans le toolcache, le step rouge avec un message explicite.
3. **Controle positif (a verifier sur cette PR)** : 2 runs consecutifs du meme workflow sur le **meme runner** (`myia-po-2024-linux-docker-*`), le 2ᵉ doit reussir. C'est l'acceptance #14571.3 verbatim. Le 1ᵉ run de cette PR fournira le 1ᵉ pied ; le 2ᵉ sera declenche par un push trivial (whitespace) apres merge du 1ᵉ en local pour confirmation.

## Verification

- **YAML syntax** : `python -c "import yaml; yaml.safe_load(open('.github/workflows/ict-tests.yml'))"` rend `YAML OK`.
- **Garde-fou** : `python -c "import ict; assert '$RUNNER_TEMP' in ict.__file__"` se declenche sur le chemin importe. Si le venv n'est pas cree ou si pip re-ecrit dans le toolcache, l'assertion rouge avec message explicite.
- **Pas de re-execution ICT necessaire** : le fix ne touche pas le code ICT, seulement le step d'install de la CI. Le step `Run ${{ matrix.suite-name }}` continue d'utiliser `pytest ${{ matrix.test-args }} --tb=short -v` comme avant.
- **Pas de collection floor-guard modifiee** : le step floor-guard continue de re-coller sur `pytest --co -q` ; le `$GITHUB_PATH` rend `pytest` accessible.

## Limites assumees

- Le fix **(a)** ne touche pas au parc hote (le `b` qui consiste a ne plus partager `/opt/hostedtoolcache` en ecriture entre conteneurs appartient a l'hote, pas a un worker PR). Si le volume reste partage et qu'un **autre workflow** sur le meme parc ecrit dans le toolcache, le defaut reapparait. Le fix est per-workflow ; un fix parc-wide demanderait un geste cote ops (mentionne dans #14571 lui-meme).
- L'**acceptance (3)** (2 runs consecutifs meme runner, 2 verts) ne peut pas etre verifiee **dans cette PR** : un seul run par PR est possible. La verification se fait sur `main` apres merge, par observation des 2 prochains runs ICT consecutifs sur `myia-po-2024-linux-docker-*`. Un seul run vert ne prouve rien -- le defaut ne se manifeste qu'au 2ᵉ passage sur un cache deja ecrit (Tell c.896-L1 ★★★ inverse : ici, le venv est detruit a chaque fin de job, donc la 2ᵉ execution repart d'un etat neuf).
- **Pas de PR sortante vers les autres workflows CI** (`ict-golden-set-execute.yml` et autres freres qui peuvent avoir le meme pattern `pip install -e .`). Ce serait une 2ᵉ tranche de meme genre ; le picker rendra le moment venu.

## Voir aussi

- Issue #14571 : constat verbatim + 2 runs mesures + 4 axes d'acceptance
- Issue #14283 (EPIC parent du routage self-hosted Linux)
- PR #14386 (routage self-hosted `golden-set-execute`) -- MERGED 2026-09-03, contexte de la migration vers po-2024
- Tell c.896-L1 ★★★ : instrument aveugle vs instrument sain ; analogue ici : runner dit `ephemeral` vs runner ephemere effectif
- Tell c.901-L1 ★★★ : le `play_round` FBT-style doit passer `x` a la strategie ; analogue ici : le `pip install -e .` doit etre isole du toolcache (le runner dit `ephemeral` mais ne l'est pas)

`See #14571`

