### PR TITLE
fix(ci,#14259): pin runner account + surface gh errors + name status contradiction

### DIFF
--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -116,7 +116,20 @@ fetch_token() {
   # conteneur. C'est la raison pour laquelle la boucle vit sur l'HOTE et non
   # dans l'image -- `gh` et ses credentials ne descendent jamais dans le
   # conteneur.
-  gh api --method POST "repos/$REPO/actions/runners/registration-token" --jq .token 2>/dev/null
+  #
+  # #14259 epinglage : GH_TOKEN ambiant est honore tel quel par gh ;
+  # COURSIA_RUNNER_GH_ACCOUNT (plus specifique) le surpasse en resolvant
+  # le token du compte nomme. Sans epinglage, le fetch depend du compte
+  # gh ACTIF -- un `gh auth switch` dans une autre session changeait
+  # l'identite des registration tokens en silence (incident 2026-09-02).
+  if [ -n "${COURSIA_RUNNER_GH_ACCOUNT:-}" ]; then
+    GH_TOKEN="$(gh auth token --user "$COURSIA_RUNNER_GH_ACCOUNT")" || return 1
+    export GH_TOKEN
+  fi
+  # Pas de 2>/dev/null (#14259) : l'erreur REELLE de gh (403, token expire,
+  # compte sans droit admin) doit atteindre l'operateur. Le message de la
+  # boucle resume le symptome ; il ne remplace pas la cause.
+  gh api --method POST "repos/$REPO/actions/runners/registration-token" --jq .token
 }
 
 slot_loop() {
@@ -251,9 +264,29 @@ cmd_status() {
   echo "== conteneurs runner en cours =="
   docker ps --filter "name=$NAME_PREFIX" --format '  {{.Names}}  {{.Status}}  {{.RunningFor}}' 2>/dev/null || true
   echo "== runners enregistres cote GitHub =="
-  gh api "repos/$REPO/actions/runners" \
-    --jq '.runners[]|"  \(.name) [\(.status)] busy=\(.busy) labels=\([.labels[].name]|join(","))"' 2>/dev/null \
-    || echo "  (droit admin requis pour lire l'inventaire)"
+  # #14259 : nommer la contradiction docker-vs-inventaire au lieu
+  # d'afficher les deux blocs cote a cote. « N conteneurs / 0 runner
+  # enregistre » est l'etat exact de l'incident 2026-09-02 (jetons crees
+  # sous un compte, inventaire lu sous un autre). Une fenetre transitoire
+  # existe au re-enregistrement entre deux jobs (--ephemeral), d'ou le
+  # « si persistant » du message.
+  local runners_ok=0 runners_out=""
+  if runners_out="$(gh api "repos/$REPO/actions/runners" \
+      --jq '.runners[]|"  \(.name) [\(.status)] busy=\(.busy) labels=\([.labels[].name]|join(","))"' 2>/dev/null)"; then
+    runners_ok=1
+    printf '%s\n' "$runners_out"
+  else
+    echo "  (droit admin requis pour lire l'inventaire)"
+  fi
+  if [ "$runners_ok" -eq 1 ]; then
+    local n_cont n_run
+    n_cont="$(docker ps --filter "name=$NAME_PREFIX" -q 2>/dev/null | wc -l | tr -d ' ')"
+    n_run="$(printf '%s\n' "$runners_out" | grep -c '^  ' || true)"
+    if [ "$n_cont" -gt 0 ] && [ "$n_run" -eq 0 ]; then
+      echo "  -- CONTRADICTION : $n_cont conteneur(s) $NAME_PREFIX actif(s) mais 0 runner enregistre cote GitHub."
+      echo "     Si persistant : fetch_token sous un mauvais compte -- cf epinglage COURSIA_RUNNER_GH_ACCOUNT (#14259)."
+    fi
+  fi
   [ -f "$STOP_FILE" ] && echo "== sentinel STOP pose : les boucles ne relancent plus =="
 }
 

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -5,6 +5,10 @@
 
 set -o pipefail
 
+# Portabilite (#14259) : le test vit a cote du script sous test -- plus de
+# chemin de worktree hardcode (l original cassait hors de sa session d origine).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 TEST_DIR="/tmp/supervise-test-$$"
 mkdir -p "$TEST_DIR/bin" "$TEST_DIR/state-A" "$TEST_DIR/state-B" "$TEST_DIR/state-C"
 LOG="$TEST_DIR/test.log"
@@ -47,7 +51,7 @@ run_supervise() {
   export PATH="$TEST_DIR/bin:$PATH"
   export COURSIA_RUNNER_NAME_PREFIX="$prefix"
   export COURSIA_RUNNER_STATE_DIR="$state"
-  timeout --kill-after=1 1 bash "scripts/ci/docker/linux-runner/supervise.sh" $args >/dev/null 2>"$TEST_DIR/last.err"
+  timeout --kill-after=1 1 bash "$SCRIPT_DIR/supervise.sh" $args >/dev/null 2>"$TEST_DIR/last.err"
   echo "rc=$?"
   cat "$TEST_DIR/last.err"
 }
@@ -55,7 +59,7 @@ run_supervise() {
 # --- Test 1 : start quand un superviseur est deja actif refuse -----
 echo "Test 1 : start quand un superviseur est deja actif (Defaut 1)"
 (
-  cd /c/dev/CoursIA-c182-14259
+  cd "$SCRIPT_DIR"
   export PS_OUTPUT="jsboige  12345    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
   rc="$(run_supervise 'start 1' 'test-prefix-A' "$TEST_DIR/state-A" 2>&1 | head -1 | sed 's/rc=//')"
   err="$(cat "$TEST_DIR/last.err")"
@@ -70,7 +74,7 @@ echo ""
 # --- Test 2 : start apres stop sans --force refuse -----
 echo "Test 2 : start apres stop refuse, sentinel preserve (Defaut 2 sans --force)"
 (
-  cd /c/dev/CoursIA-c182-14259
+  cd "$SCRIPT_DIR"
   unset PS_OUTPUT
   touch "$TEST_DIR/state-B/stop"
   rc="$(run_supervise 'start 1' 'test-prefix-B' "$TEST_DIR/state-B" 2>&1 | head -1 | sed 's/rc=//')"
@@ -91,13 +95,13 @@ echo ""
 # --- Test 3 : start --force leve le sentinel et demarre -----
 echo "Test 3 : start --force leve sentinel (Defaut 2 avec --force)"
 (
-  cd /c/dev/CoursIA-c182-14259
+  cd "$SCRIPT_DIR"
   unset PS_OUTPUT
   export PATH="$TEST_DIR/bin:$PATH"
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-C"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-C"
   touch "$TEST_DIR/state-C/stop"
-  timeout --kill-after=1 2 bash "scripts/ci/docker/linux-runner/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
+  timeout --kill-after=1 2 bash "$SCRIPT_DIR/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
   TPID=$!
   sleep 0.5
   if [ ! -f "$TEST_DIR/state-C/stop" ]; then
@@ -114,13 +118,13 @@ echo ""
 # --- Test 4 : status compte les superviseurs par PPID==1 -----
 echo "Test 4 : status affiche le compte par PPID==1"
 (
-  cd /c/dev/CoursIA-c182-14259
+  cd "$SCRIPT_DIR"
   export PS_OUTPUT="jsboige  100    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
   export PATH="$TEST_DIR/bin:$PATH"
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-status-1"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-status"
   mkdir -p "$COURSIA_RUNNER_STATE_DIR"
-  out="$(bash "scripts/ci/docker/linux-runner/supervise.sh" status 2>&1)"
+  out="$(bash "$SCRIPT_DIR/supervise.sh" status 2>&1)"
   if echo "$out" | grep -q "superviseurs actifs : 1 (PID 100)"; then
     ok "status compte 1 superviseur (PPID==1)"
   else
@@ -133,14 +137,14 @@ echo ""
 # --- Test 5 : status ANOMALIE si >1 superviseurs -----
 echo "Test 5 : status detecte >1 superviseur (ANOMALIE)"
 (
-  cd /c/dev/CoursIA-c182-14259
+  cd "$SCRIPT_DIR"
   export PS_OUTPUT="jsboige  100    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
 jsboige  101    1   10:28:12  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
   export PATH="$TEST_DIR/bin:$PATH"
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-status-2"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-status-2"
   mkdir -p "$COURSIA_RUNNER_STATE_DIR"
-  out="$(bash "scripts/ci/docker/linux-runner/supervise.sh" status 2>&1)"
+  out="$(bash "$SCRIPT_DIR/supervise.sh" status 2>&1)"
   if echo "$out" | grep -q "superviseurs actifs : 2" && echo "$out" | grep -q "ANOMALIE"; then
     ok "status detecte anomalie >1 superviseur"
   else
@@ -153,7 +157,7 @@ echo ""
 # --- Test 6 : status ignore les forks (PPID != 1) -----
 echo "Test 6 : status ignore les slot_loop forks (PPID != 1)"
 (
-  cd /c/dev/CoursIA-c182-14259
+  cd "$SCRIPT_DIR"
   export PS_OUTPUT="jsboige  100    1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
 jsboige  101  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
 jsboige  102  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4
@@ -163,12 +167,94 @@ jsboige  104  100   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh s
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-status-3"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-status-3"
   mkdir -p "$COURSIA_RUNNER_STATE_DIR"
-  out="$(bash "scripts/ci/docker/linux-runner/supervise.sh" status 2>&1)"
+  out="$(bash "$SCRIPT_DIR/supervise.sh" status 2>&1)"
   if echo "$out" | grep -q "superviseurs actifs : 1 (PID 100)" && ! echo "$out" | grep -q "ANOMALIE"; then
     ok "status compte 1 superviseur + ignore les forks PPID!=1"
   else
     ko "status aurait du compter 1 et ignorer forks, output: $out"
   fi
   unset PS_OUTPUT
+)
+echo ""
+
+# --- Test 7 : COURSIA_RUNNER_GH_ACCOUNT epingle le compte du fetch -----
+echo "Test 7 : COURSIA_RUNNER_GH_ACCOUNT epingle le compte (epinglage #14259)"
+(
+  cd "$SCRIPT_DIR"
+  mkdir -p "$TEST_DIR/bin7" "$TEST_DIR/state-7"
+  cat > "$TEST_DIR/bin7/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$GH_CALLS_LOG"
+if echo "$@" | grep -q 'auth token'; then echo "FAKE_ACCOUNT_TOKEN"; exit 0; fi
+if echo "$@" | grep -q 'registration-token'; then echo "FAKE_TOKEN"; exit 0; fi
+if echo "$@" | grep -q 'actions/runners'; then echo '{"runners":[]}'; exit 0; fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin7/gh"
+  cat > "$TEST_DIR/bin7/docker" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin7/docker"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin7/ps"
+  export PATH="$TEST_DIR/bin7:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-7"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-7"
+  export COURSIA_RUNNER_GH_ACCOUNT="fake-account"
+  export GH_CALLS_LOG="$TEST_DIR/gh7.calls"
+  : > "$GH_CALLS_LOG"
+  timeout --kill-after=1 2 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  sleep 1
+  pkill -P $TPID 2>/dev/null
+  pkill -f 'supervise.sh start' 2>/dev/null
+  wait 2>/dev/null
+  if grep -q 'auth token --user fake-account' "$GH_CALLS_LOG"; then
+    ok "fetch_token resout le token via gh auth token --user fake-account"
+  else
+    ko "gh auth token --user attendu, appels: $(cat "$GH_CALLS_LOG")"
+  fi
+  if grep -q 'registration-token' "$GH_CALLS_LOG"; then
+    ok "le registration fetch a bien eu lieu apres epinglage"
+  else
+    ko "registration-token absent des appels gh"
+  fi
+)
+echo ""
+
+# --- Test 8 : status nomme la contradiction conteneurs/runners -----
+echo "Test 8 : status nomme la contradiction conteneurs vs inventaire (Defaut #14259 residuel)"
+(
+  cd "$SCRIPT_DIR"
+  mkdir -p "$TEST_DIR/bin8" "$TEST_DIR/state-8"
+  cat > "$TEST_DIR/bin8/gh" <<'STUB'
+#!/usr/bin/env bash
+if echo "$@" | grep -q 'registration-token'; then echo "FAKE_TOKEN"; exit 0; fi
+if echo "$@" | grep -q 'actions/runners'; then echo '{"runners":[]}'; exit 0; fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin8/gh"
+  cat > "$TEST_DIR/bin8/docker" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "ps" ]; then printf 'fakeid1\nfakeid2\n'; exit 0; fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin8/docker"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin8/ps"
+  export PATH="$TEST_DIR/bin8:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-8"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-8"
+  unset PS_OUTPUT || true
+  out="$(bash "$SCRIPT_DIR/supervise.sh" status 2>&1)"
+  if echo "$out" | grep -q "CONTRADICTION : 2 conteneur(s)"; then
+    ok "status nomme la contradiction 2 conteneurs / 0 runner"
+  else
+    ko "ligne CONTRADICTION attendue, output: $out"
+  fi
+  if echo "$out" | grep -q "COURSIA_RUNNER_GH_ACCOUNT"; then
+    ok "le message pointe vers l'epinglage"
+  else
+    ko "renvoi vers epinglage attendu"
+  fi
 )
 echo ""


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14594

## Summary

Complete les 3 sous-items residuels de #14259 apres le merge de #14293 (qui avait livre les 3 defauts du titre : idempotence du start, sentinel collant, compte de superviseurs dans status).

1. **Epinglage du compte** (`COURSIA_RUNNER_GH_ACCOUNT`) : `fetch_token` resout une fois le token du compte nomme via `gh auth token --user <compte>` et l'exporte en `GH_TOKEN` ; le fetch ne depend plus du compte gh ACTIF (un `gh auth switch` d'une autre session changeait l'identite des registration tokens en silence -- incident 2026-09-02). Un `GH_TOKEN` deja present dans l'env est honore tel quel par gh.
2. **Retrait du `2>/dev/null`** sur l'appel registration-token : l'erreur REELLE de gh (403, token expire, droit admin manquant) atteint l'operateur ; le message de boucle resume le symptome, il ne remplace pas la cause.
3. **`status` nomme la contradiction** « N conteneurs / 0 runner enregistre » au lieu d'afficher les deux blocs cote a cote sans commentaire -- c'est l'etat exact de l'incident (jetons crees sous un compte, inventaire lu sous un autre). Le message renvoie vers l'epinglage. Une fenetre transitoire existe au re-enregistrement entre deux jobs (--ephemeral), d'ou le « si persistant ».

## Deplacement du fichier de test (defaut de portabilite corrige au passage)

#14293 avait committé `test_supervise_guards.sh` a la RACINE du depot avec `cd /c/dev/CoursIA-c182-14259` en dur dans chaque sous-shell -- un worktree qui n'existe plus : le test etait inexecutable en dehors de sa session d'origine (verifie : `git worktree list` ne contient pas c182). Le fichier vit desormais a cote du script sous test (`scripts/ci/docker/linux-runner/`), portable via `SCRIPT_DIR` derive de `BASH_SOURCE`.

## Verification

Suite complete depuis le nouvel emplacement, 11 PASS / 0 FAIL :

```
Test 1 : start refuse, message nomme PID (rc=1)                        PASS
Test 2 : start apres stop refuse + sentinel preserve                   PASS x2
Test 3 : start --force leve sentinel                                   PASS
Test 4 : status compte 1 superviseur (PPID==1)                          PASS
Test 5 : status detecte anomalie >1 superviseur                        PASS
Test 6 : status compte 1 + ignore les forks PPID!=1                    PASS
Test 7 : gh auth token --user fake-account appele + registration apres  PASS x2  (NOUVEAU)
Test 8 : status nomme "CONTRADICTION : 2 conteneur(s)" + renvoi epinglage PASS x2 (NOUVEAU)
```

Stubs : PATH detourne (`docker`, `gh`, `ps` par test), gh du test 7 journalise ses appels (`$GH_CALLS_LOG`), docker du test 8 rend 2 IDs sur `ps`.

## Perimetre

2 fichiers changes : `scripts/ci/docker/linux-runner/supervise.sh` (modifie) et `test_supervise_guards.sh` (deplace de la racine vers `scripts/ci/docker/linux-runner/`, puis etendu -- rename 61 % + edits).

## Claim

[CLAIMED] par le coordinateur pour cette lane sur #14259 (paths : supervise.sh + test), PR precedente #14293 mergee.

Closes #14259

