### PR TITLE
fix(ci,#14473): prune-guard markers aligned with the actually-merged #14481 fix (guard was unsatisfiable)

### DIFF
--- a/scripts/ci/install_prune_task.py
+++ b/scripts/ci/install_prune_task.py
@@ -16,9 +16,10 @@ Modes :
                                               journal horodate, jamais de couleur/TTY
 
 Garde de securite (#14476) : --install REFUSE de cabler --apply si le script
-cible ne contient pas encore la resolution par numero (def _normalize_subject,
-PR #14481) -- installer le cron avec l'ancien predicat d'intersection de
-jetons deploierait l'attribution fausse (et destructive) TOUS LES JOURS.
+cible ne contient pas encore les deux voies du fix PR #14481 (resolution
+par numero + _normalize) -- installer le cron avec l'ancien predicat
+d'intersection de jetons deploierait l'attribution fausse (et destructive)
+TOUS LES JOURS.
 
 Journal : %LOCALAPPDATA%\CoursIA\prune_task\logs\prune_YYYYMMDD.log
 """
@@ -35,8 +36,13 @@ TASK_NAME = r"CoursIA\prune_merged_worktrees"
 THIS_FILE = Path(__file__).resolve()
 LOG_DIR = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))) / "CoursIA" / "prune_task" / "logs"
 
-# Marqueur du fix #14476/#14481 dans le script cible -- voir garde ci-dessus.
-REQUIRED_FIX_MARKER = "def _normalize_subject"
+# Marqueurs du fix #14476/#14481 dans le script cible -- voir garde ci-dessus.
+# Alignes sur le contenu REEL merge par #14481 (voie 1 : resolution par
+# numero ; voie 2 : egalite normalisee du sujet via _normalize). Le marqueur
+# historique 'def _normalize_subject' ne correspondait a AUCUN symbole du
+# fichier merge -- la garde etait insatisfaisable et refusait tout --install,
+# y compris sur un main frais contenant le fix (mesure 2026-09-04).
+REQUIRED_FIX_MARKERS = ("Resolution directe par numero", "def _normalize")
 
 
 def _run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
@@ -59,12 +65,13 @@ def check_prune_fix_present(repo: Path) -> tuple[bool, str]:
     if not target.is_file():
         return False, f"introuvable : {target}"
     text = target.read_text(encoding="utf-8", errors="replace")
-    if REQUIRED_FIX_MARKER not in text:
+    missing = [m for m in REQUIRED_FIX_MARKERS if m not in text]
+    if missing:
         return False, (
             f"{target.name} ne contient pas le fix #14476 "
-            f"('{REQUIRED_FIX_MARKER}'). Installer le cron --apply avec "
-            "l'heuristique d'intersection de jetons deploierait "
-            "l'attribution fausse quotidiennement (cf #14481). "
+            f"(marqueurs absents : {', '.join(missing)}). Installer le "
+            "cron --apply avec l'heuristique d'intersection de jetons "
+            "deploierait l'attribution fausse quotidiennement (cf #14481). "
             "Rebase/merge d'abord, puis relancer --install."
         )
     return True, "fix #14476 present"

--- a/scripts/tests/test_install_prune_task.py
+++ b/scripts/tests/test_install_prune_task.py
@@ -3,8 +3,9 @@ r"""Tests de l'installateur de tache planifiee prune (#14473).
 
 Pinent :
 1. la garde de securite : --install REFUSE si le script cible ne contient
-   pas le fix #14476 (_normalize_subject) -- un cron --apply quotidien ne
-   doit JAMAIS deployer l'attribution fausse par intersection de jetons ;
+   pas le fix #14476 (resolution par numero + _normalize, cf #14481) --
+   un cron --apply quotidien ne doit JAMAIS deployer l'attribution
+   fausse par intersection de jetons ;
 2. l'idempotence : schtasks /Create /F (relançable sans doublon) ;
 3. la commande de tache appelle bien --run (le mode journalisant) avec le
    --repo explicit, et l'organe en --apply vient de cmd_run seulement ;
@@ -42,11 +43,42 @@ class TestPruneFixGuard:
     def test_accepte_quand_le_fix_est_present(self, tmp_path):
         repo = tmp_path / "CoursIA"
         (repo / "scripts" / "ci").mkdir(parents=True)
+        # extrait fidele des DEUX voies du fix #14481 telles que mergees
+        # (le marqueur historique _normalize_subject etait une fixture
+        # circulaire : le test ecrivait lui-meme le symbole attendu)
         (repo / "scripts" / "ci" / "prune_merged_worktrees.py").write_text(
-            "def _normalize_subject(s):\n    return s.lower()\n",
+            "# 1. Resolution directe par numero extractible du sujet\n"
+            "def lookup_pr_for_detached_head():\n"
+            "    def _normalize(s: str) -> str:\n"
+            "        return s.strip().lower()\n"
+            "    return None\n",
             encoding="utf-8")
         ok, _ = ipt.check_prune_fix_present(repo)
         assert ok
+
+    def test_refuse_si_une_seule_voie_du_fix_est_presente(self, tmp_path):
+        """Un seul des deux marqueurs (ex : _normalize sans la resolution
+        par numero) ne doit pas suffire -- la voie 1 est la protection
+        principale contre l'attribution fausse."""
+        repo = tmp_path / "CoursIA"
+        (repo / "scripts" / "ci").mkdir(parents=True)
+        (repo / "scripts" / "ci" / "prune_merged_worktrees.py").write_text(
+            "def _normalize(s: str) -> str:\n    return s.strip().lower()\n",
+            encoding="utf-8")
+        ok, msg = ipt.check_prune_fix_present(repo)
+        assert not ok
+        assert "Resolution directe par numero" in msg
+
+    def test_garde_accepte_le_vrai_fichier_du_depot(self):
+        """Anti-dérive : la garde doit rester satisfaisable par le VRAI
+        scripts/ci/prune_merged_worktrees.py du depot (incident 2026-09-04 :
+        le marqueur '_normalize_subject' ne correspondait a aucun symbole
+        merge -- refus perpetual, meme sur main frais). Si ce test echoue,
+        un refactor a renomme les voies du fix : resynchroniser
+        REQUIRED_FIX_MARKERS."""
+        repo = Path(__file__).resolve().parents[2]
+        ok, msg = ipt.check_prune_fix_present(repo)
+        assert ok, f"la garde refuse le fichier reel du depot : {msg}"
 
     def test_refuse_si_le_script_est_absent(self, tmp_path):
         ok, msg = ipt.check_prune_fix_present(tmp_path)


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14594

## Summary

La garde de securite de l'installateur #14473 etait **insatisfaisable** : `REQUIRED_FIX_MARKER = "def _normalize_subject"` ne correspond a AUCUN symbole du `prune_merged_worktrees.py` reellement merge par #14481. Le fix reel a livre deux voies :

- voie 1 : `Resolution directe par numero` (docstring/code du chemin nominal) ;
- voie 2 : `def _normalize(s: str)` (egalite normalisee du sujet).

Mesure du defaut (2026-09-04, main frais a0577d135, #14481 mergee depuis le 03/09 18:25) :

```
$ python scripts/ci/install_prune_task.py --install --repo <main frais>
REFUSE : prune_merged_worktrees.py ne contient pas le fix #14476 ('def _normalize_subject'). ...
```

L'acceptance differee de #14473 (« controles machine post-merge #14481 ») etait donc bloquee a jamais -- personne ne pouvait installer la tache, sur aucune machine, aucun checkout.

## Pourquoi les tests n'avaient rien vu

Le test d'acceptation ecrivait lui-meme la fixture contenant le marqueur attendu (`def _normalize_subject(s):`) -- **fixture circulaire** : il prouvait que la garde lit le marqueur, jamais que le marqueur correspond au livrable reel.

## Fix

1. `REQUIRED_FIX_MARKERS` (tuple) : les DEUX voies doivent etre presentes dans le script cible.
2. Fixture d'acceptation reecrite depuis le contenu merge (extrait fidele des deux voies).
3. Nouveau cas de refus : une seule voie presente ne suffit pas (la voie 1 est la protection principale).
4. **Test anti-derive** : la garde doit accepter le VRAI `scripts/ci/prune_merged_worktrees.py` du depot (`test_garde_accepte_le_vrai_fichier_du_depot`). Tout refactor renommant les voies du fix fera echouer ce test et forcera la resynchronisation des marqueurs -- le refus perpetual ne peut plus revenir en silence.
5. Docstring de l'installeur aligne sur les deux voies.

## Verification

```
python -m pytest scripts/tests/test_install_prune_task.py -q
11 passed in 0.15s          (7 avant + 1 reecrit + 2 nouveaux cas + anti-derive)

Roundtrip machine (po-2026, --repo pointant sur un checkout de main + ce fix) :
  --install  -> tache installee, garde PASSEE (rc=0)
  --status   -> tache presente (schtasks /Query OK)
  --uninstall-> tache supprimee
  --status   -> ABSENTE
```

L'installation DURABLE sur le chemin par defaut (`C:\dev\CoursIA`) attend : merge de cette PR + rafraichissement du checkout partage (actuellement bloque par le WIP d'une autre session -- pull --ff-only refuse sur Nash.lean/lake-manifest.json, non touche).

## Perimetre

2 fichiers changes : `scripts/ci/install_prune_task.py` et `scripts/tests/test_install_prune_task.py`.

See #14473 (deblocke l'acceptance differee ; les controles machine restent a executer post-merge). Correctif connexe : #14476/#14481 (le fix que la garde verifie).

