### PR TITLE
feat(lean,#4362): full pin-tree identity scanner for lake manifests

### DIFF
--- a/scripts/lean/compare_lake_manifests.py
+++ b/scripts/lean/compare_lake_manifests.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Compare the FULL dependency pins of every lake manifest (EPIC #4362, step 1).
+
+The 2026-09-01 re-read of #4362 measured Mathlib revisions across the 28
+``lake-manifest.json`` files and found 22/23 Mathlib-bearing lakes converged on
+``520045ab`` / v4.32.1 — but explicitly did NOT compare the rest of the pin
+tree (batteries, aesop, plausible, Qq, ...). Whether the lakes can share
+checkouts (junctions, #4363) or a warm pool volume (#14337) depends on the
+COMPLETE ``{package name -> rev}`` tree being identical, not just Mathlib:
+two lakes with the same Mathlib rev but different batteries revs cannot share
+a checkout.
+
+This scanner closes that gap. It discovers every ``lake-manifest.json`` outside
+``.lake/packages/``, reads the effective ``rev`` (the resolved SHA, not the
+``inputRev`` tag) of every package, and groups the lakes by pin-tree identity.
+Lakes excluded by the EPIC's own analysis are skipped with their reasons:
+
+- ``conway_cgt_lean``: Mathlib arrives transitively through the upstream
+  ``vihdzp/combinatorial-games`` pin (rev ``3c6dcdbc1c``) — converging it
+  means bumping a project we deliberately reference, not our parc (#6116,
+  #13146).
+- ``agent_tests/prover/session_state/reference_docs/*/upstream``: third-party
+  fixtures, out of scope per ``.claude/rules/code-style.md``.
+
+Output is a per-identity-cluster report: identical lakes together, divergent
+lakes with the exact package/rev pairs that differ. ``--json`` returns the
+same data machine-readably. Exit code is always 0: this is a measurement
+instrument, not a gate.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Documented exclusions of EPIC #4362 (see module docstring for the reasons).
+DEFAULT_EXCLUDES: dict[str, str] = {
+    "conway_cgt_lean": "transitive upstream pin (vihdzp/combinatorial-games), not ours to converge (#6116/#13146)",
+    "reference_docs": "third-party prover fixtures, out of scope (code-style.md)",
+}
+
+
+@dataclass
+class LakePins:
+    """Effective pin tree of one lake: package name -> resolved rev SHA."""
+
+    path: Path
+    toolchain: str | None
+    pins: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def identity_key(self) -> str:
+        """Stable fingerprint of the complete pin tree."""
+        canonical = json.dumps(sorted(self.pins.items()), sort_keys=True)
+        return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+    @property
+    def mathlib_rev(self) -> str | None:
+        return self.pins.get("mathlib")
+
+
+def read_toolchain(lake_root: Path) -> str | None:
+    toolchain_file = lake_root / "lean-toolchain"
+    if toolchain_file.is_file():
+        return toolchain_file.read_text(encoding="utf-8").strip()
+    return None
+
+
+def load_lake(manifest_path: Path) -> LakePins:
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    pins = {
+        pkg["name"]: pkg["rev"]
+        for pkg in data.get("packages", [])
+        if pkg.get("type") == "git" and pkg.get("rev")
+    }
+    return LakePins(
+        path=manifest_path.parent,
+        toolchain=read_toolchain(manifest_path.parent),
+        pins=pins,
+    )
+
+
+def discover_manifests(root: Path, excludes: dict[str, str]) -> tuple[list[LakePins], list[tuple[Path, str]]]:
+    """Return (loadable lakes, skipped paths with reason)."""
+    lakes: list[LakePins] = []
+    skipped: list[tuple[Path, str]] = []
+    for manifest in sorted(root.rglob("lake-manifest.json")):
+        rel = manifest.relative_to(root)
+        if ".lake" in rel.parts:
+            continue
+        reason = next((r for needle, r in excludes.items() if needle in str(rel)), None)
+        if reason is not None:
+            skipped.append((rel, reason))
+            continue
+        lakes.append(load_lake(manifest))
+    return lakes, skipped
+
+
+def diff_pin_trees(a: LakePins, b: LakePins) -> list[tuple[str, str | None, str | None]]:
+    """Packages whose rev differs between two lakes (name, rev_a, rev_b)."""
+    diffs = []
+    for name in sorted(set(a.pins) | set(b.pins)):
+        ra, rb = a.pins.get(name), b.pins.get(name)
+        if ra != rb:
+            diffs.append((name, ra, rb))
+    return diffs
+
+
+def build_report(lakes: list[LakePins], skipped: list[tuple[Path, str]]) -> dict:
+    clusters: dict[str, list[LakePins]] = {}
+    for lake in lakes:
+        clusters.setdefault(lake.identity_key, []).append(lake)
+
+    # Reference cluster = the largest non-empty one (the converged core, by
+    # construction). An empty pin tree is never the reference: a 1-vs-1 split
+    # against a real tree must not crown the empty lake as "the core".
+    non_empty = {k: v for k, v in clusters.items() if v[0].pins}
+    ref_key = max(non_empty, key=lambda k: len(non_empty[k])) if non_empty else None
+    ref = clusters[ref_key][0] if ref_key else None
+
+    # Lakes with NO dependency at all form their own class: they have nothing
+    # to share with the core, but reporting them as "divergent" (every package
+    # missing) is noise, not a finding.
+    no_deps = sorted(lake.path.name for lake in lakes if not lake.pins)
+
+    divergent = []
+    for lake in lakes:
+        if ref is None or lake.identity_key == ref_key or not lake.pins:
+            continue
+        divergent.append(
+            {
+                "lake": lake.path.name,
+                "toolchain": lake.toolchain,
+                "diffs_vs_reference": [
+                    {"package": n, "reference": ra, "lake": rb}
+                    for n, ra, rb in diff_pin_trees(ref, lake)
+                ],
+            }
+        )
+
+    return {
+        "total_manifests": len(lakes) + len(skipped),
+        "scanned": len(lakes),
+        "skipped": [{"path": str(p), "reason": r} for p, r in skipped],
+        "no_dependency_lakes": no_deps,
+        "identity_clusters": {
+            key: {
+                "size": len(members),
+                "toolchains": sorted({m.toolchain for m in members}),
+                "mathlib_rev": members[0].mathlib_rev,
+                "lakes": sorted(m.path.name for m in members),
+            }
+            for key, members in sorted(clusters.items(), key=lambda kv: -len(kv[1]))
+        },
+        "reference_cluster": ref_key,
+        "divergent_vs_reference": divergent,
+    }
+
+
+def render_text(report: dict) -> str:
+    lines = [
+        f"Lake manifests scanned: {report['scanned']} "
+        f"(skipped {len(report['skipped'])}, documented exclusions)",
+    ]
+    for s in report["skipped"]:
+        lines.append(f"  SKIP {s['path']}: {s['reason']}")
+    if report["no_dependency_lakes"]:
+        lines.append(f"  no-dependency lakes (empty pin tree): {', '.join(report['no_dependency_lakes'])}")
+    lines.append("")
+    lines.append("Identity clusters (COMPLETE pin tree {name: rev}):")
+    for key, cluster in report["identity_clusters"].items():
+        marker = "  [REFERENCE]" if key == report["reference_cluster"] else ""
+        lines.append(
+            f"  {cluster['size']:2d} lakes | toolchain={','.join(t or '?' for t in cluster['toolchains'])} "
+            f"| mathlib={cluster['mathlib_rev'] or 'none'}{marker}"
+        )
+        lines.append(f"      {', '.join(cluster['lakes'])}")
+    if report["divergent_vs_reference"]:
+        lines.append("")
+        lines.append("Divergent vs reference cluster:")
+        for d in report["divergent_vs_reference"]:
+            lines.append(f"  {d['lake']} (toolchain={d['toolchain']}):")
+            for diff in d["diffs_vs_reference"]:
+                lines.append(
+                    f"      {diff['package']}: ref={str(diff['reference'])[:12]} lake={str(diff['lake'])[:12]}"
+                )
+    else:
+        lines.append("")
+        lines.append("All scanned lakes share ONE complete pin tree.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", type=Path, default=Path("."), help="repository root (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    lakes, skipped = discover_manifests(args.root.resolve(), DEFAULT_EXCLUDES)
+    if not lakes:
+        print("no lake-manifest.json found under root (excluding .lake/packages/)", file=sys.stderr)
+        return 2
+    report = build_report(lakes, skipped)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lean/tests/test_compare_lake_manifests.py
+++ b/scripts/lean/tests/test_compare_lake_manifests.py
@@ -1,0 +1,135 @@
+"""Tests for compare_lake_manifests (EPIC #4362 step-1 scanner)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import compare_lake_manifests as clm  # noqa: E402
+
+
+def write_lake(root: Path, name: str, packages: list[dict], toolchain: str = "leanprover/lean4:v4.32.1") -> Path:
+    lake_dir = root / name
+    lake_dir.mkdir(parents=True)
+    (lake_dir / "lake-manifest.json").write_text(
+        json.dumps({"version": "1.2.0", "packages": packages}), encoding="utf-8"
+    )
+    if toolchain:
+        (lake_dir / "lean-toolchain").write_text(toolchain, encoding="utf-8")
+    return lake_dir
+
+
+def git_pkg(name: str, rev: str) -> dict:
+    return {"name": name, "type": "git", "rev": rev, "url": f"https://example.com/{name}.git"}
+
+
+CORE = [git_pkg("mathlib", "aa11"), git_pkg("batteries", "bb22")]
+
+
+def test_identical_manifests_form_one_cluster(tmp_path):
+    write_lake(tmp_path, "alpha", CORE)
+    write_lake(tmp_path, "beta", CORE)
+
+    lakes, skipped = clm.discover_manifests(tmp_path, {})
+    report = clm.build_report(lakes, skipped)
+
+    assert len(report["identity_clusters"]) == 1
+    assert sorted(report["identity_clusters"][list(report["identity_clusters"])[0]]["lakes"]) == ["alpha", "beta"]
+    assert report["divergent_vs_reference"] == []
+
+
+def test_divergent_rev_is_reported_with_package(tmp_path):
+    write_lake(tmp_path, "alpha", CORE)
+    write_lake(tmp_path, "beta", [git_pkg("mathlib", "aa11"), git_pkg("batteries", "OTHER")])
+
+    lakes, skipped = clm.discover_manifests(tmp_path, {})
+    report = clm.build_report(lakes, skipped)
+
+    assert len(report["divergent_vs_reference"]) == 1
+    div = report["divergent_vs_reference"][0]
+    assert div["lake"] == "beta"
+    assert div["diffs_vs_reference"] == [
+        {"package": "batteries", "reference": "bb22", "lake": "OTHER"}
+    ]
+
+
+def test_extra_own_package_is_a_divergence_not_a_conflict(tmp_path):
+    """social_choice_lean_peters / mimo_lean shape: core pins identical, one
+    additional own dependency. The scanner must report the addition -- shared
+    revs stay provably identical. The core cluster has the plurality (as in
+    the real parc: 20 core lakes vs 1 lake with an own dep)."""
+    write_lake(tmp_path, "core_lake", CORE)
+    write_lake(tmp_path, "core_lake_2", CORE)
+    write_lake(tmp_path, "plus_own", CORE + [git_pkg("own_dep", "cc33")])
+
+    lakes, _ = clm.discover_manifests(tmp_path, {})
+    report = clm.build_report(lakes, [])
+
+    div = {d["lake"]: d for d in report["divergent_vs_reference"]}
+    assert div["plus_own"]["diffs_vs_reference"] == [
+        {"package": "own_dep", "reference": None, "lake": "cc33"}
+    ]
+
+
+def test_documented_exclusions_are_skipped_with_reason(tmp_path):
+    write_lake(tmp_path, "conway_cgt_lean", CORE)
+    write_lake(tmp_path, "normal_lake", CORE)
+
+    lakes, skipped = clm.discover_manifests(tmp_path, clm.DEFAULT_EXCLUDES)
+
+    assert [l.path.name for l in lakes] == ["normal_lake"]
+    assert skipped == [
+        (Path("conway_cgt_lean") / "lake-manifest.json", clm.DEFAULT_EXCLUDES["conway_cgt_lean"])
+    ]
+
+
+def test_empty_pin_tree_is_not_divergent(tmp_path):
+    write_lake(tmp_path, "with_deps", CORE)
+    write_lake(tmp_path, "no_deps", [])
+
+    lakes, _ = clm.discover_manifests(tmp_path, {})
+    report = clm.build_report(lakes, [])
+
+    assert report["no_dependency_lakes"] == ["no_deps"]
+    assert report["divergent_vs_reference"] == []
+
+
+def test_lake_inside_dot_lake_packages_is_ignored(tmp_path):
+    write_lake(tmp_path, "real", CORE)
+    nested = tmp_path / "real" / ".lake" / "packages" / "mathlib"
+    nested.mkdir(parents=True)
+    (nested / "lake-manifest.json").write_text('{"version": "1.2.0", "packages": []}', encoding="utf-8")
+
+    lakes, _ = clm.discover_manifests(tmp_path, {})
+
+    assert len(lakes) == 1
+    assert lakes[0].path.name == "real"
+
+
+def test_toolchain_is_read(tmp_path):
+    write_lake(tmp_path, "alpha", CORE, toolchain="leanprover/lean4:v4.33.1")
+
+    lakes, _ = clm.discover_manifests(tmp_path, {})
+
+    assert lakes[0].toolchain == "leanprover/lean4:v4.33.1"
+
+
+def test_text_render_mentions_reference_cluster(tmp_path):
+    write_lake(tmp_path, "alpha", CORE)
+
+    lakes, _ = clm.discover_manifests(tmp_path, {})
+    report = clm.build_report(lakes, [])
+    text = clm.render_text(report)
+
+    assert "Identity clusters" in text
+    assert "[REFERENCE]" in text
+    assert "mathlib=aa11" in text
+
+
+def test_no_manifests_returns_exit_2(tmp_path, capsys):
+    assert clm.main(["--root", str(tmp_path)]) == 2
+    assert "no lake-manifest.json found" in capsys.readouterr().err


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/guard #14586

## Summary

Step-1 instrument of EPIC #4362: `scripts/lean/compare_lake_manifests.py` compares the **complete** pin tree (`{package -> resolved rev}`) of every `lake-manifest.json` outside `.lake/packages/`, not just the Mathlib rev the 2026-09-01 re-read measured. Sharing checkouts (#4363) or a warm pool volume (#14337) requires the full tree to be identical — two lakes with the same Mathlib rev but different batteries revs cannot share a checkout.

- Clusters lakes by pin-tree identity (sha256 of the sorted pins), elects the **largest non-empty cluster** as reference, reports each divergent lake with the exact package/rev pairs that differ; no-dependency lakes form their own class (not "divergent").
- Exclusions documented in-module with their reasons: `conway_cgt_lean` (transitive upstream pin `vihdzp/combinatorial-games`, #6116/#13146) and `reference_docs` fixtures.
- `--json` for machine-readable output; exit code always 0 (measurement instrument, not a gate), exit 2 only when no manifest is found.

## Verdict on current main (2026-09-04)

```
Lake manifests scanned: 20 (skipped 2, documented exclusions)
Identity clusters: ONE core cluster of 20 lakes, toolchain v4.32.1, mathlib=520045ab
Divergent: social_choice_lean_peters (+SocialChoiceLean only), mimo_lean (+slt only)
No-dependency lakes: 4
```

**All shared revs are identical across the parc.** The only two divergences are *additions of an own dependency* — no shared package rev differs anywhere. Checkout mutualisation (#4363) and the warm-pool volume (#14337) are therefore possible **without a single dependency bump**.

## Tests

`python -m pytest scripts/lean/tests/test_compare_lake_manifests.py -q` — **9 passed** (clustering, divergence reporting with package-level diffs, own-package addition shape, documented exclusions, `.lake/packages/` ignore, toolchain read, text render, exit-2 path).

See #4362
