### PR TITLE
docs(claim,#14323): document the one-agent lane invariant

### DIFF
--- a/.claude/rules/lane-claim-protocol.md
+++ b/.claude/rules/lane-claim-protocol.md
@@ -10,6 +10,16 @@ S'applique à tous les agents du cluster CoursIA (workers `po-*` + coordinateur 
 3. **Tout timestamp rédigé est en UTC explicite.** Le suffixe `Z` sur une heure locale est proscrit. En cas de conflit, l'ordering par `createdAt` serveur **l'emporte toujours** sur un stamp de corps.
 4. Le dashboard **garde le récit de cycle** (`[CLAIMED]` informatif y reste bienvenu) ; il **cesse d'être le registre de verrous** — seul le commentaire d'issue fait foi cross-lane.
 
+## Prémisse d'identité — une lane = un agent actif (HARD, #14323)
+
+Le protocole suppose **un seul agent actif par couple `machine:workspace`**. Un second processus (cron chevauché, session interactive parallèle) sous la même lane est indiscernable du premier : `check_lane_claim.py` traite leur claim commun comme une reprise légitime.
+
+- `CLEAR` signifie uniquement **« aucune autre lane ne bloque ce grain ou ces chemins »**. Il ne prouve ni « aucun autre processus travaille », ni « aucun travail de ma propre lane n'est en cours ».
+- La voie retenue est de **restaurer cette prémisse opérationnelle** : un cron/session actif par lane, sans ajouter d'identité de processus au format de claim.
+- Avant de démarrer une seconde session sous la même lane, arrêter ou laisser finir la première. Si un chevauchement est découvert, ne pas éditer : coordonner les deux sessions et conserver un seul propriétaire actif.
+
+Le détail et les alternatives écartées sont consignés dans [lane-claim-detail.md](../../docs/reference/lane-claim-detail.md#identité-de-lane-et-collisions-intra-lane-14323).
+
 ## Règle HARD — côté coordinateur (ai-01)
 
 5. **Poser le `[CLAIMED]` au dispatch** (commentaire d'issue au nom de la lane servie), sans attendre que le worker le pose au démarrage : la fenêtre décision → claim est celle du coordinateur à couvrir.

--- a/docs/reference/lane-claim-detail.md
+++ b/docs/reference/lane-claim-detail.md
@@ -41,6 +41,30 @@ La garantie fail-CLOSED de la ligne 28 (rule) tient pour les déviations **synta
 
 Politique choisie (option **b**, signaler sans re-bloquer) : on NE rouvre PAS le fail-open #10958 — un claim actif dont tout le scope est mort reste porté epic-wide (un claim cassé n'est pas permissif) — mais `check_lane_claim.py` ajoute un champ JSON `dead_scope_globs` (lane-keyed, agrégé sur TOUS les événements de claim, y compris relâchés) pour que le typo soit visible à un sweep JSON, et non seulement sur le stderr que le gate/le picker ne consomment pas. Le cas légitime du fichier pas encore créé (grain Lean, nouveau notebook) reste couvert sans geler la lane : la cible s'écrit avec un métacaractère de répertoire (`scripts/notebook_tools/*markdown*`).
 
+## Identité de lane et collisions intra-lane (#14323)
+
+Le protocole indexe l'exclusion mutuelle sur la **lane** (`machine:workspace`), pas sur le processus Claude Code. C'est intentionnel : un claim de sa propre lane doit permettre une reprise après compaction ou réveil. Cette propriété repose toutefois sur une prémisse opérationnelle désormais explicite : **une seule session active par lane**.
+
+Deux processus simultanés sous la même lane — par exemple un cron qui se déclenche pendant une session interactive, ou deux réveils qui se chevauchent — présentent la même identité à `check_lane_claim.py`. Le garde ne peut pas les distinguer : chacun interprète le claim existant comme sa propre reprise. Le mode `--paths` a la même limite, puisqu'il signale les intersections portées par une lane différente.
+
+### Portée exacte de `CLEAR`
+
+`CLEAR` garantit seulement qu'**aucune autre lane** ne détient un claim actif intersectant le grain ou les chemins demandés. Il ne garantit pas :
+
+- qu'aucun autre processus ne travaille sous la même lane ;
+- qu'une PR ou un worktree de la même lane n'est pas déjà en cours ;
+- que la session appelante est l'auteur du claim observé.
+
+Les gardes L898 (`git worktree list`, PRs ouvertes par branche/sujet/chemin) restent donc complémentaires, mais ils ne remplacent pas la prémisse : un travail intra-lane non poussé peut être invisible aux deux.
+
+### Décision : restaurer la prémisse, ne pas étendre le marqueur
+
+La voie retenue est **un agent actif par lane**, appliquée au niveau des schedulers et des sessions : laisser finir ou arrêter la session existante avant d'en démarrer une autre sous le même couple `machine:workspace`. En cas de chevauchement constaté, les deux processus cessent d'éditer, comparent leur périmètre, puis conservent un seul propriétaire actif.
+
+L'alternative `[CLAIMED] lane <L> agent <session-id>` n'est pas retenue. Elle alourdirait un format déjà partagé par les issues, le picker et le merge-gate, tout en transformant chaque reprise après compaction en problème d'identité et chaque `RELEASED` manquant en blocage intra-lane. La règle d'exploitation rétablit l'invariant avec moins d'état et sans migration du parseur.
+
+**Référence** : issue #14323 — diagnostic de l'angle mort intra-lane et lien avec les crons chevauchés.
+
 ## Tie-break — l'issue l'emporte, l'override s'écrit (#10223)
 
 Les deux collisions du 2026-08-09 (#10169 puis #10161) ont révélé deux non-écrits qu'on écrit ici noir sur blanc. Un organe débloquant les enforce désormais : `.github/workflows/lane-claim-guard.yml` (`check-lane-claim-required`).


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python #14487

Closes #14323

## Décision

La voie 1 est retenue : le protocole conserve `machine:workspace` comme identité de claim et rend explicite sa prémisse opérationnelle — un seul agent actif par lane. Le format n'est pas étendu avec un identifiant de processus/session.

## Changements

- la règle auto-chargée précise qu'un résultat `CLEAR` signifie seulement qu'aucune **autre lane** ne bloque le grain ou les chemins ;
- elle interdit de prendre `CLEAR` pour une preuve d'absence de processus concurrent sous la même lane ;
- la documentation détaillée explique l'angle mort intra-lane, les gardes complémentaires et pourquoi l'alternative `agent <session-id>` n'est pas retenue ;
- la conduite en cas de chevauchement est explicite : cesser d'éditer, comparer les périmètres et conserver un seul propriétaire actif.

## Validation

- `python scripts/check_docs_links.py --check` → `OK: No new broken links. (0 pre-existing, 5446 total)`
- `python scripts/check_lane_claim.py --lane myia-po-2025:CoursIA 14323` → `CLEAR` avec reprise du claim propre, 0 chemin bloqué / 2 libres
- `git diff --check` → aucune erreur
- périmètre : 2 fichiers, +34/−0 ; aucun changement du parseur ou des marqueurs

## Note de worktree

Le validateur de liens a révélé que `slides/S3-acculturation/slides.md` porte un blob CRLF historique alors que `.gitattributes` exige LF. Ce fichier est hors scope et n'est pas inclus dans le commit/PR ; seuls les deux chemins claimés sont livrés.

