### PR TITLE
enrich(notebooks,#11601): QC-Py-28-Market-Regime — densité 1445 → 1629 c/code-cell (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -56,7 +56,9 @@
     "> **[REFERENCE QC Cloud]**\n",
     "> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n",
     "> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n",
-    "> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
+    "> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n",
+    "",
+    "> **Ce que QuantBook apporte ici** : la partie locale de ce notebook tourne sur des donnees synthetiques (sans frais ni slippage) — parfaite pour comprendre la mecanique, insuffisante pour valider une strategie. Le passage en QC Cloud donne acces a l'historique reel (SPY, QQQ, GLD, IEF) avec frais et slippage simules ; le backtest `RegimeSwitching` rappele en tete de notebook en est le resultat. La double approche — local pour la pedagogie, Cloud pour la validation — est le motif de ce notebook a deux parties."
    ],
    "id": "cell-5d52f80a"
   },
@@ -420,7 +422,9 @@
     "\n",
     "### Code de reference pour QC Lab\n",
     "\n",
-    "Voici le code complet a copier dans `main.py` de votre projet QuantConnect. Ce code implemente la stratégie RegimeSwitching avec toutes les fonctionnalites decrites dans ce notebook."
+    "Voici le code complet a copier dans `main.py` de votre projet QuantConnect. Ce code implemente la stratégie RegimeSwitching avec toutes les fonctionnalites decrites dans ce notebook.",
+    "",
+    "**Pourquoi porter en QC Lab ?** Les parties precedentes valident la strategie sur donnees synthetiques : aucun frais, aucun slippage, aucune contrainte de liquidite. Le code de reference ci-dessous transpose le detecteur SMA50/SMA200 et l'allocation par regime dans l'API QuantConnect : donnees reellement historiques, resolution quotidienne, rebalancement conditionne aux transitions de regime. C'est la que la strategie rencontre la realite — le backtest `RegimeSwitching` (2015-2024, 100 000 $ initial) rappele en tete de notebook en est le resultat, pas une extrapolation des donnees synthetiques."
    ],
    "id": "cell-41ddcfa6"
   },
@@ -988,7 +992,9 @@
     "- **Distribution des regimes** : Pourcentage du temps passe dans chaque regime\n",
     "- **Return moyen par regime** : Performance annualisee par regime\n",
     "- **Drawdown par regime** : Risque maximal par regime\n",
-    "- **Stabilite** : Variance de la performance dans le temps"
+    "- **Stabilite** : Variance de la performance dans le temps",
+    "",
+    "**Ce que l'attribution revele** : la question n'est pas seulement « la strategie gagne-t-elle ? » mais « ou gagne-t-elle, et ou perd-elle ? ». Une strategie peut afficher un Sharpe honnete tout en concentrant ses pertes sur un seul regime — une fragilite invisible dans la courbe de capitaux globale. L'analyse ci-dessous ventile les jours utiles par regime detecte et expose cette structure : c'est ce diagnostic qui decide si un parametre doit etre ajuste par regime, ou si le detecteur lui-meme doit etre ameliore."
    ],
    "id": "cell-64a2cb0d"
   },
@@ -1239,7 +1245,12 @@
     "- Tester chaque combinaison sur la periode complete\n",
     "- Calculer Sharpe, CAGR, Max Drawdown\n",
     "- Sélectionner la combinaison avec le meilleur Sharpe\n",
-    "- Verifier la robustesse (pas d'overfitting)"
+    "- Verifier la robustesse (pas d'overfitting)",
+    "",
+    "**Les trois pieges de la grid search** :",
+    "1. **Le pic isole** : un optimum net sur un seul seuil, entoure de voisins mediocres, signale l'overfitting — la vraie robustesse est un plateau.",
+    "2. **Le plateau plat** : des metriques strictement identiques d'un bout a l'autre de la grille (ce que la sortie ci-dessous illustre) ne prouvent pas la robustesse mais la non-sensibilite : le parametre ne joue aucun role sur la periode testee.",
+    "3. **L'in-sample cache** : optimiser et evaluer sur la meme periode sur-estime systematiquement la performance ; seul le out-of-sample ou le walk-forward compte pour une decision de deploiement."
    ],
    "id": "cell-99088f11"
   },
@@ -1799,7 +1810,9 @@
     "Cette approche contre-trend est **risquee** mais peut etre rentable si :\n",
     "1. On est en regime defensif (bear/sideways)\n",
     "2. On utilise des positions reduites (30% max)\n",
-    "3. On a un stop-loss strict"
+    "3. On a un stop-loss strict",
+    "",
+    "**Dependence au regime** : un RSI < 30 en bull market signale souvent un point d'entree favorable (le trend reprend apres le creux) ; le meme signal en bear market est un « couteau qui tombe » — le rebond attendu peut ne jamais venir et l'achat contre-trend aggraver la perte. C'est precisement pourquoi la strategie de ce notebook ne declenche le mean-reversion qu'en regime defensif, avec position reduite et stop-loss : l'indicateur fournit le signal, le regime fournit le droit de l'utiliser."
    ],
    "id": "cell-3ab41c06"
   },
@@ -2019,7 +2032,9 @@
     "    # Les signaux sont contradictoires\n",
     "```\n",
     "\n",
-    "Cette logique est **simple, robuste et eprouvee**. Elle evite les whipsaws (faux signaux) en exigeant que TANT le prix que SMA50 soient du même cote de SMA200."
+    "Cette logique est **simple, robuste et eprouvee**. Elle evite les whipsaws (faux signaux) en exigeant que TANT le prix que SMA50 soient du même cote de SMA200.",
+    "",
+    "**Le cout de la simplicite** : cette regle binaire ne reagit qu'apres le croisement effectif des moyennes — le regime est confirme avec retard, car SMA200 integre 200 jours d'historique. Le haut et le bas d'un retournement sont donc toujours detectes trop tard, et la serie comptera des jours non classes pendant les transitions de croisement. Ce compromis retard/whipsaw est assume : exiger DEUX conditions (prix ET SMA50 du meme cote de SMA200) echange de la reactivite contre de la fiabilite du signal."
    ],
    "id": "cell-61efddaa"
   },
@@ -2225,7 +2240,9 @@
     "| **Performance** | Une strategy peut gagner +20% en bull et perdre -30% en bear |\n",
     "| **Risque** | Le drawdown maximal depend du regime |\n",
     "| **Allocation** | L'optimale differe selon le regime (100% equity en bull vs 0% en bear) |\n",
-    "| **Psychologie** | Les investisseurs se comportent differemment selon le regime |"
+    "| **Psychologie** | Les investisseurs se comportent differemment selon le regime |",
+    "",
+    "**Non-stationnarite** : derriere cette classification se cache le probleme fondamental du trading quantitatif : les series de prix ne sont pas stationnaires — leur esperance, leur volatilite et leur autocorrelation changent de regime. Un modele calibre sur une periode bull (un momentum, par exemple) transporte mal ses coefficients en bear. Detecter le regime, c'est segmenter la serie en sous-populations ou les statistiques restent stables, et adapter l'outil statistique a chaque sous-population — la difference entre un backtest qui suppose un marche unique et une strategie qui reconnait que le marche a des etats."
    ],
    "id": "cell-9d00c42a"
   },

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -57,7 +57,7 @@
     "> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n",
     "> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n",
     "> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n",
-    "",
+    "\n",
     "> **Ce que QuantBook apporte ici** : la partie locale de ce notebook tourne sur des donnees synthetiques (sans frais ni slippage) — parfaite pour comprendre la mecanique, insuffisante pour valider une strategie. Le passage en QC Cloud donne acces a l'historique reel (SPY, QQQ, GLD, IEF) avec frais et slippage simules ; le backtest `RegimeSwitching` rappele en tete de notebook en est le resultat. La double approche — local pour la pedagogie, Cloud pour la validation — est le motif de ce notebook a deux parties."
    ],
    "id": "cell-5d52f80a"
@@ -422,8 +422,8 @@
     "\n",
     "### Code de reference pour QC Lab\n",
     "\n",
-    "Voici le code complet a copier dans `main.py` de votre projet QuantConnect. Ce code implemente la stratégie RegimeSwitching avec toutes les fonctionnalites decrites dans ce notebook.",
-    "",
+    "Voici le code complet a copier dans `main.py` de votre projet QuantConnect. Ce code implemente la stratégie RegimeSwitching avec toutes les fonctionnalites decrites dans ce notebook.\n",
+    "\n",
     "**Pourquoi porter en QC Lab ?** Les parties precedentes valident la strategie sur donnees synthetiques : aucun frais, aucun slippage, aucune contrainte de liquidite. Le code de reference ci-dessous transpose le detecteur SMA50/SMA200 et l'allocation par regime dans l'API QuantConnect : donnees reellement historiques, resolution quotidienne, rebalancement conditionne aux transitions de regime. C'est la que la strategie rencontre la realite — le backtest `RegimeSwitching` (2015-2024, 100 000 $ initial) rappele en tete de notebook en est le resultat, pas une extrapolation des donnees synthetiques."
    ],
    "id": "cell-41ddcfa6"
@@ -992,8 +992,8 @@
     "- **Distribution des regimes** : Pourcentage du temps passe dans chaque regime\n",
     "- **Return moyen par regime** : Performance annualisee par regime\n",
     "- **Drawdown par regime** : Risque maximal par regime\n",
-    "- **Stabilite** : Variance de la performance dans le temps",
-    "",
+    "- **Stabilite** : Variance de la performance dans le temps\n",
+    "\n",
     "**Ce que l'attribution revele** : la question n'est pas seulement « la strategie gagne-t-elle ? » mais « ou gagne-t-elle, et ou perd-elle ? ». Une strategie peut afficher un Sharpe honnete tout en concentrant ses pertes sur un seul regime — une fragilite invisible dans la courbe de capitaux globale. L'analyse ci-dessous ventile les jours utiles par regime detecte et expose cette structure : c'est ce diagnostic qui decide si un parametre doit etre ajuste par regime, ou si le detecteur lui-meme doit etre ameliore."
    ],
    "id": "cell-64a2cb0d"
@@ -1245,11 +1245,12 @@
     "- Tester chaque combinaison sur la periode complete\n",
     "- Calculer Sharpe, CAGR, Max Drawdown\n",
     "- Sélectionner la combinaison avec le meilleur Sharpe\n",
-    "- Verifier la robustesse (pas d'overfitting)",
-    "",
-    "**Les trois pieges de la grid search** :",
-    "1. **Le pic isole** : un optimum net sur un seul seuil, entoure de voisins mediocres, signale l'overfitting — la vraie robustesse est un plateau.",
-    "2. **Le plateau plat** : des metriques strictement identiques d'un bout a l'autre de la grille (ce que la sortie ci-dessous illustre) ne prouvent pas la robustesse mais la non-sensibilite : le parametre ne joue aucun role sur la periode testee.",
+    "- Verifier la robustesse (pas d'overfitting)\n",
+    "\n",
+    "**Les trois pieges de la grid search** :\n",
+    "\n",
+    "1. **Le pic isole** : un optimum net sur un seul seuil, entoure de voisins mediocres, signale l'overfitting — la vraie robustesse est un plateau.\n",
+    "2. **Le plateau plat** : des metriques strictement identiques d'un bout a l'autre de la grille (ce que la sortie ci-dessous illustre) ne prouvent pas la robustesse mais la non-sensibilite : le parametre ne joue aucun role sur la periode testee.\n",
     "3. **L'in-sample cache** : optimiser et evaluer sur la meme periode sur-estime systematiquement la performance ; seul le out-of-sample ou le walk-forward compte pour une decision de deploiement."
    ],
    "id": "cell-99088f11"
@@ -1810,8 +1811,8 @@
     "Cette approche contre-trend est **risquee** mais peut etre rentable si :\n",
     "1. On est en regime defensif (bear/sideways)\n",
     "2. On utilise des positions reduites (30% max)\n",
-    "3. On a un stop-loss strict",
-    "",
+    "3. On a un stop-loss strict\n",
+    "\n",
     "**Dependence au regime** : un RSI < 30 en bull market signale souvent un point d'entree favorable (le trend reprend apres le creux) ; le meme signal en bear market est un « couteau qui tombe » — le rebond attendu peut ne jamais venir et l'achat contre-trend aggraver la perte. C'est precisement pourquoi la strategie de ce notebook ne declenche le mean-reversion qu'en regime defensif, avec position reduite et stop-loss : l'indicateur fournit le signal, le regime fournit le droit de l'utiliser."
    ],
    "id": "cell-3ab41c06"
@@ -2032,8 +2033,8 @@
     "    # Les signaux sont contradictoires\n",
     "```\n",
     "\n",
-    "Cette logique est **simple, robuste et eprouvee**. Elle evite les whipsaws (faux signaux) en exigeant que TANT le prix que SMA50 soient du même cote de SMA200.",
-    "",
+    "Cette logique est **simple, robuste et eprouvee**. Elle evite les whipsaws (faux signaux) en exigeant que TANT le prix que SMA50 soient du même cote de SMA200.\n",
+    "\n",
     "**Le cout de la simplicite** : cette regle binaire ne reagit qu'apres le croisement effectif des moyennes — le regime est confirme avec retard, car SMA200 integre 200 jours d'historique. Le haut et le bas d'un retournement sont donc toujours detectes trop tard, et la serie comptera des jours non classes pendant les transitions de croisement. Ce compromis retard/whipsaw est assume : exiger DEUX conditions (prix ET SMA50 du meme cote de SMA200) echange de la reactivite contre de la fiabilite du signal."
    ],
    "id": "cell-61efddaa"
@@ -2240,8 +2241,8 @@
     "| **Performance** | Une strategy peut gagner +20% en bull et perdre -30% en bear |\n",
     "| **Risque** | Le drawdown maximal depend du regime |\n",
     "| **Allocation** | L'optimale differe selon le regime (100% equity en bull vs 0% en bear) |\n",
-    "| **Psychologie** | Les investisseurs se comportent differemment selon le regime |",
-    "",
+    "| **Psychologie** | Les investisseurs se comportent differemment selon le regime |\n",
+    "\n",
     "**Non-stationnarite** : derriere cette classification se cache le probleme fondamental du trading quantitatif : les series de prix ne sont pas stationnaires — leur esperance, leur volatilite et leur autocorrelation changent de regime. Un modele calibre sur une periode bull (un momentum, par exemple) transporte mal ses coefficients en bear. Detecter le regime, c'est segmenter la serie en sous-populations ou les statistiques restent stables, et adapter l'outil statistique a chaque sous-population — la difference entre un backtest qui suppose un marche unique et une strategie qui reconnait que le marche a des etats."
    ],
    "id": "cell-9d00c42a"


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2023:CoursIA -- prev: MED/docs #14587

## Tranche densite umbrella #11601 (round 3, veine QC-Py)

Suite de #14599 (round 2, QC-Py-Cloud-02 1385 → 1944). Cible choisie sur scan du pool QC-Py : QC-Py-28-Market-Regime-Detection etait le plus bas non-collisionne (1445 c/code-cell) — QC-Py-41 evite (PR #14616 OPEN sur le meme notebook), QC-Py-Cloud-02 deja traite.

## Livrable

Enrichissement markdown-only de 7 cellules (intros de parties 1/2/3/5/6/7 + bloc REFERENCE QC Cloud), chaque ajout ancre sur les sorties reelles du notebook :

- Non-stationnarite et segmentation par sous-populations statistiques (Partie 1)
- Cout de la regle binaire SMA : retard de detection vs fiabilite (Partie 2)
- Dependence au regime du signal RSI : le regime donne le droit d'utiliser l'indicateur (Partie 3)
- Les trois pieges de la grid search : pic isole / plateau plat / in-sample cache — illustres par la sortie ou les seuils RSI 20-40 donnent un Sharpe identique de 1.146 (Partie 5)
- Ce que l'attribution par regime revele vs la courbe de capitaux globale (Partie 6)
- Pourquoi porter en QC Lab : frais/slippage/donnees reelles vs synthetiques (Partie 7 + bloc QC Cloud)

## Densite

- Avant : 1445 chars markdown / code-cell (30350 md / 21 code)
- Apres : **1629** chars markdown / code-cell (34227 md / 21 code) — cible 1500-2000

## Validations

- **Code byte-identique** : les 21 sources de cellules code comparees pre/post edition (script, assertion d'egalite) — aucune cellule code modifiee
- `nbformat.validate` : OK
- `detect_markdown_rendering.py` : **0 violations**
- Regle C.1 : inchangee (code non modifie ; les 2 matches grep `1/0` sont des fragments base64 dans les PNG de sortie, preexistants sur main)
- Execution : modifs uniquement markdown -> outputs precedents valides (exception C.2 md-only) ; notebook de reference QC Cloud (cellule [REFERENCE QC], non executable localement)

See #11601 (tranche d'une umbrella, closing global au coordonnateur)