### PR TITLE
docs(rules,#14627): protocole renum()/reclass() — le canonique est ce qui n'a pas de lettre

### DIFF
--- a/.claude/rules/notebook-accretion-numbering.md
+++ b/.claude/rules/notebook-accretion-numbering.md
@@ -1,6 +1,6 @@
 # Renumerotation et reclassement de notebooks — `renum()` / `reclass()`
 
-S'applique a **tout agent** qui envisage de renommer, renumeroter ou requalifier un notebook pedagogique, **et a tout reviewer** d'une PR `renum(...)` / `reclass(...)`. Source : convention d'accretion posee par le user, sign-off du 2026-09-04. Le geste avait ete re-derive a la main sur ~15 issues sans jamais etre ecrit ; c'est ce cout repete que cette regle ferme.
+S'applique a **tout agent** qui envisage de renommer, renumeroter ou requalifier un notebook pedagogique, **et a tout reviewer** d'une PR `renum(...)` / `reclass(...)`. Source : convention d'accretion posee par le user, sign-off du 2026-09-04. Le geste avait ete re-derive a la main sur les **19** issues du corpus (seize tranchees, trois encore ouvertes) sans jamais etre ecrit ; c'est ce cout repete que cette regle ferme.
 
 **Detail** (corpus des precedents, verdicts par famille, tables de mapping, residus) : [notebook-renumbering-detail.md](../../docs/reference/notebook-renumbering-detail.md).
 

--- a/.claude/rules/notebook-accretion-numbering.md
+++ b/.claude/rules/notebook-accretion-numbering.md
@@ -1,0 +1,108 @@
+# Renumerotation et reclassement de notebooks — `renum()` / `reclass()`
+
+S'applique a **tout agent** qui envisage de renommer, renumeroter ou requalifier un notebook pedagogique, **et a tout reviewer** d'une PR `renum(...)` / `reclass(...)`. Source : convention d'accretion posee par le user, sign-off du 2026-09-04. Le geste avait ete re-derive a la main sur ~15 issues sans jamais etre ecrit ; c'est ce cout repete que cette regle ferme.
+
+**Detail** (corpus des precedents, verdicts par famille, tables de mapping, residus) : [notebook-renumbering-detail.md](../../docs/reference/notebook-renumbering-detail.md).
+
+## 1. Le fait qui gouverne : le canonique est ce qui n'a PAS de lettre
+
+Convention de nommage : `<Prefixe>-<num><lettre?>-<Titre>.ipynb` — **la lettre est collee au numero**, sans separateur.
+
+```python
+ID_IN_NAME_RE = re.compile(r"^(?P<pre>.+?)[-_](?P<num>\d{1,3})(?P<let>[a-z])?[-_]", re.I)
+```
+
+**Lire les numeros nus dans l'ordre EST le parcours canonique** — le speed-run du programme par les grands principes. Une lettre dit « ceci approfondit », jamais « ceci prolonge le survol ». Poser une lettre est donc un acte **pedagogique**, pas un acte de rangement : c'est declarer qu'un contenu sort du chemin principal.
+
+Mesure du 2026-09-04 (`MyIA.AI.Notebooks/**/*.ipynb`, hors `_archive`/checkpoints/`.lake`) :
+
+| | N |
+|---|---:|
+| Notebooks portant un identifiant | 814 |
+| Familles | 34 |
+| Branches numerotees | 494 |
+| … **sans accretion = le speed-run canonique** | **411** |
+| … accretees | 83 |
+
+## 2. La convention se constate, elle ne se decrete pas : la base compte comme `a`
+
+Sur les 83 branches accretees, **80 commencent a `b`**. La base sans lettre occupe donc la place de `a`, et la premiere accretion est `b`. Trois branches s'en ecartent — ce sont des **defauts**, pas des variantes :
+
+| Branche | Ecart | Etat |
+|---|---|---|
+| `GameTheory-03` | base presente **et** premiere accretion `a` (`a`..`h`) | a normaliser en `b`..`i`, ou fusionner (cf §4) |
+| `Lean-16` | **aucune base** — la branche Conway commence a `16a` (`a`..`j`) | pas d'entree canonique du tout : la branche entiere est hors speed-run |
+| `Tweety-7` | **aucune base** (`a`, `b`) | idem, blast-radius reduit |
+
+Un `renum()` ne cree jamais une quatrieme convention. Si la branche visee est l'une de ces trois, la traiter **dans la meme tranche** ou dire explicitement pourquoi on ne le fait pas.
+
+## 3. Le verdict par defaut est « aucune renum » (HARD)
+
+Quatre analyses de famille sous #5081 ont conclu **aucune renumerotation** : #5656 (GameTheory, arc 1..17 canonique + suffixes intentionnels), #5662 (Sudoku, arc 0..19 + twin C#/Python intentionnel), #5667 (Search, prefixe par famille intentionnel), #5669 (SemanticWeb, `SW-` + suffixe `b` canoniques). **Une numerotation qui *parait* opportuniste est le plus souvent un arc.**
+
+Des trous dans la suite des numeros ne justifient **rien**. Le geste ne se declenche que sur l'un de ces quatre tells, **nomme dans l'issue** :
+
+| Tell | Ce qui le prouve | Precedent |
+|---|---|---|
+| **Collision d'identifiant** | deux fichiers portent le meme `<prefixe>-<num><lettre>` | #13771 (deux `Search-17`, merges a 8 h 23 d'intervalle) |
+| **Faux prerequis sequentiel** | la position implique un prerequis que le contenu dement | #13770 (`Part3` declare Search-3 en prerequis, donc ne suit pas CSP) |
+| **Numero d'opportunite** | l'historique montre un numero choisi sur la disponibilite du slot | #13771 (concu 15, puis 17, puis 18) |
+| **Transversal en position canonique** | outillage/debug/diagnostic occupant un slot du survol | #13753 (`Infer-6-Debugging`) |
+
+Le tell se lit **dans le contenu et l'historique**, jamais dans le titre seul.
+
+## 4. Norme de profondeur : `e`-`f` au maximum par branche
+
+Une branche s'epaissit legitimement — c'est ainsi que les series grandissent. Ce qui ne va pas, c'est qu'elle **s'etende** : au-dela de `f`, les accretions doivent **fusionner en notebooks plus lourds** plutot que se multiplier en lettres.
+
+Mesure du 2026-09-04 : **80 des 83 branches accretees tiennent la norme** (≤ 4 accretions). Exactement trois la depassent — c'est la surface entiere du chantier, pas une campagne :
+
+| Branche | Lettres | Notebooks |
+|---|---|---:|
+| `ICT-15` | `b`..`l` | 12 |
+| `Lean-16` | `a`..`j` | 10 |
+| `GameTheory-03` | `a`..`h` | 9 |
+
+Fusionner **n'est pas supprimer** : « Consolider != Archiver » s'applique integralement — chaque contenu absorbe est preserve et cite, ligne a ligne, dans le notebook cible.
+
+## 5. Protocole (HARD, l'ordre compte)
+
+1. **Lire le contenu**, pas les titres. Un mapping derive de titres et de volumes est une hypothese : l'annoncer comme telle.
+2. **Nommer le parent pedagogique et l'argument** : pourquoi ce notebook approfondit *ce* palier. Sans cet argument ecrit, pas de lettre.
+3. **Garde de collision** — L898 (`git worktree list`, `gh pr list --search head:`, PRs ouvertes sur le **chemin**) **et** L1356 (`--state all` : une PR **mergee** en rider rend le grain deja livre).
+4. **Gate de sequencement** : ne pas renommer un fichier pendant qu'une PR ouverte le touche. Le nommer dans l'issue (precedent #13771, gate sur #13576 et #12703).
+5. **Table de mapping dans l'issue, avant la PR** — `actuel -> cible`, une ligne par fichier.
+6. **`git mv`** : l'identite du fichier est preservee. **Aucun changement de contenu dans la meme PR** — un renommage et un enrichissement ne se relisent pas ensemble.
+7. **Sweep des referents** — §6 ci-dessous.
+8. **Catalogue non touche a la main** ([catalog-pr-hygiene.md](catalog-pr-hygiene.md)) : il appartient a l'automatisation.
+
+## 6. Ce qu'une renum casse — et l'organe qui le rattrape
+
+Le sweep n'est pas « chercher l'ancien nom ». Cinq surfaces cassent, et elles ont chacune leur organe :
+
+| Surface | Organe |
+|---|---|
+| Liens 404 dans les notebooks | `scripts/notebook_tools/check_notebook_navlinks.py` |
+| Liens 404 dans la doc | `scripts/check_docs_links.py` |
+| Accents perdus dans les cibles | `scripts/notebook_tools/detect_link_target_regression.py` |
+| Rendu des liens de README de serie | `scripts/notebook_tools/check_notebook_link_render.py` |
+| **Libelle qui ment sur sa cible** | `scripts/notebook_tools/check_link_label_agreement.py` — **livre par la PR #14625, pas encore sur `main`** (#14624) |
+
+**La cinquieme est celle que le sweep rate**, et c'est la sequelle propre a la renumerotation : les quatre premiers organes verifient que la cible **existe**, aucun ne verifie que le **libelle dit la verite**. Un `[Search-12](.../Search-03b-....ipynb)` passe les quatre. Mesure du 2026-09-04 : **32 desaccords sur 2194 fichiers**, dont la sequelle directe de #13770.
+
+Deux residus supplementaires se traitent dans la meme tranche : les cles orphelines de `pedagogy_density_baseline.json` (#13815) et la liste de rendu Quarto (#13931).
+
+## 7. Ce que la regle ne couvre pas
+
+- **Le padding zero** (`Search-3` vs `GameTheory-03`, ordre lexicographique casse) — chantier propre, **#14545**.
+- **Le suffixe de langage** des twins C#/Python — **#12933**.
+- **La numerotation des en-tetes markdown *dans* un notebook** (`## 3.`) — [notebook-conventions.md](notebook-conventions.md).
+
+## Voir aussi
+
+- [notebook-renumbering-detail.md](../../docs/reference/notebook-renumbering-detail.md) — corpus des precedents, verdicts par famille, residus
+- [notebook-conventions.md](notebook-conventions.md) — C.1/C.2/C.3, numerotation des en-tetes
+- [catalog-pr-hygiene.md](catalog-pr-hygiene.md) — le catalogue appartient a l'automatisation
+- [proactive-coordination.md](proactive-coordination.md) — L898 (garde de collision), L1356 (`--state all`)
+- [verify-before-claiming.md](verify-before-claiming.md) — lire l'artefact et l'historique, pas le body date
+- **#5081** — EPIC fondateur de l'analyse par famille · **#12375** — doctrine d'application · **#13769**, **#13755**, **#14545** — chantiers ouverts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Cadre de travail (adapté de Karpathy + ajout user) : ces principes gouvernent *
 | [reference/architecture_mcp_roo.md](docs/reference/architecture_mcp_roo.md) | Cycle de vie, logs et diagnostic des serveurs MCP (inventaire des 15 outils roo-state-manager : [HARNESS-OVERVIEW.md](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) §2) |
 | [reference/regles-vigilance-detail.md](docs/reference/regles-vigilance-detail.md) · [regles-validation-detail.md](docs/reference/regles-validation-detail.md) | Détail G.1-G.9 et H.1-H.7 + incidents |
 | [reference/_archive-convention.md](docs/reference/_archive-convention.md) | Convention `_archive/` (11 emplacements) — modèle ML-Training-Pipeline généralisé, 4 critères d'éligibilité, header per-function |
+| [reference/notebook-renumbering-detail.md](docs/reference/notebook-renumbering-detail.md) | Corpus des precedents de renumerotation — le geste `renum()`/`reclass()` est porte par `.claude/rules/notebook-accretion-numbering.md` |
 | [reference/env-python-reparation.md](docs/reference/env-python-reparation.md) | Réparation env Python (règle F) |
 | [reference/stale-tree-drift-scan.md](docs/reference/stale-tree-drift-scan.md) · [orphan-branch-scan-l576.md](docs/reference/orphan-branch-scan-l576.md) | Scans anti-phantom (drift, branche orpheline) |
 | [lean/](docs/lean/) | Prover iteration history, intractable diagnosis, LLM endpoints, pièges tactiques (propagation d'instance `Decidable`) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Documentation vivante, active et liée depuis CLAUDE.md / `.claude/rules/`.
 | [reference/regles-vigilance-detail.md](reference/regles-vigilance-detail.md) | Détails G.1-G.9 + incidents |
 | [reference/regles-validation-detail.md](reference/regles-validation-detail.md) | Détails H.1-H.7 + incident Sudoku-13 |
 | [reference/anti-regression-detail.md](reference/anti-regression-detail.md) | Patterns red-flag, protocole avant suppression |
+| [reference/notebook-renumbering-detail.md](reference/notebook-renumbering-detail.md) | Corpus des precedents `renum()`/`reclass()` (19 issues, 4 verdicts « aucune renum »), blast-radius mesure de la grappe Probas, etat de l'arbre. Detail de `.claude/rules/notebook-accretion-numbering.md` |
 | [reference/lean-axiom-coverage.md](reference/lean-axiom-coverage.md) | Couverture axiomes du gate proof-integrity par lake (22 lakes inventoriés, 2 câblés en CI : `lean-knot.yml` + `lean-conway.yml`) — classes dangereuses `native_decide.*`/`sorryAx`/`Classical.choice`. Détail de référence pour §B.3 de `.claude/rules/pr-review-discipline.md`. Établi cycle c.950 (worker po-2023, lane `myia-po-2023:CoursIA-2`), 167 lignes. See #8738 (step 3), #8752 (livraison) |
 | [reference/secrets-and-coord-detail.md](reference/secrets-and-coord-detail.md) | Secrets + coordination cross-machine |
 | [reference/student-pr-reviews-detail.md](reference/student-pr-reviews-detail.md) | Incident, format public, workflow |

--- a/docs/reference/notebook-renumbering-detail.md
+++ b/docs/reference/notebook-renumbering-detail.md
@@ -2,9 +2,9 @@
 
 Detail de [`.claude/rules/notebook-accretion-numbering.md`](../../.claude/rules/notebook-accretion-numbering.md). La regle porte le geste ; ce fichier porte les precedents qui l'ont produite, mesures le 2026-09-04.
 
-## 1. Pourquoi une regle : le geste a ete re-derive quinze fois
+## 1. Pourquoi une regle : le geste a ete re-derive dix-neuf fois
 
-Le geste `renum()` / `reclass()` a une histoire dense et aucune trace de protocole. Chaque issue a re-decouvert, seule, les memes questions : quel est le parent pedagogique, quels referents cassent, dans quel ordre renommer.
+Le geste `renum()` / `reclass()` a une histoire dense et aucune trace de protocole. Chaque issue a re-decouvert, seule, les memes questions : quel est le parent pedagogique, quels referents cassent, dans quel ordre renommer. Le tableau ci-dessous en porte **dix-neuf** : seize verdicts rendus, trois issues encore ouvertes (#13755, #13769, #14545) ou la question est posee sans etre tranchee.
 
 | Issue | Famille | Verdict |
 |---|---|---|

--- a/docs/reference/notebook-renumbering-detail.md
+++ b/docs/reference/notebook-renumbering-detail.md
@@ -1,0 +1,109 @@
+# Renumerotation de notebooks — corpus des precedents
+
+Detail de [`.claude/rules/notebook-accretion-numbering.md`](../../.claude/rules/notebook-accretion-numbering.md). La regle porte le geste ; ce fichier porte les precedents qui l'ont produite, mesures le 2026-09-04.
+
+## 1. Pourquoi une regle : le geste a ete re-derive quinze fois
+
+Le geste `renum()` / `reclass()` a une histoire dense et aucune trace de protocole. Chaque issue a re-decouvert, seule, les memes questions : quel est le parent pedagogique, quels referents cassent, dans quel ordre renommer.
+
+| Issue | Famille | Verdict |
+|---|---|---|
+| #5637 | Probas/Infer | renum narrative — arc pedagogique, blast-radius borne |
+| #5666 | Search | arc global canonique **mais** `Search-11` = collision reelle (6 nb, 2 traitements C#, split EN/FR) |
+| #5656 | GameTheory | **aucune renum** — arc 1..17 canonique, suffixes `b`/`c` intentionnels |
+| #5662 | Sudoku | **aucune renum** — arc 0..19 canonique, twin C#/Python intentionnel |
+| #5667 | Search | **aucune renum** — prefixe par famille intentionnel (4 familles algorithmiques) |
+| #5669 | SemanticWeb | **aucune renum** — prefixe `SW-` + suffixe `b` canoniques |
+| #13753 | Probas/Infer | `Infer-6-Debugging` → accretion transversale (`Infer-2b` candidat) |
+| #13754 | Search/Apps | `App-12` Connect Four → rattache au traitement canonique `App-14` |
+| #13757 | GenAI/Video | `04-6` → `04-5b` |
+| #13758 | GenAI/Image | Qwen Image Edit 2509 → rattache au palier `01-5` |
+| #13761 | Lean | TorchLean Python → companion `Lean-11b` |
+| #13762 | Planners | `Planners-14` LLM Space Reducer → side de 10 ou 12 |
+| #13765 | Z3 | `Z3-Python-07` style declaratif LINQ → side |
+| #13770 | Search | `Part3-Advanced` → accretions `Search-03b/03c/03d` |
+| #13771 | Search | deux `Search-17` + `Search-18` → `09b`/`09c`/`11c` |
+| #13822 | ICT | SAE-Calibration / SAE-Catastrophes → `ICT-21b` / `ICT-21c` |
+| #13755 | QC-Py Cloud | **ouverte** — six collisions de concepts `Cloud-01`..`Cloud-06` |
+| #13769 | Search | **ouverte** — fusionner la recherche avancee, rendre CSP autonome |
+| #14545 | Search | **ouverte** — padding zero, ordre lexicographique casse |
+
+## 2. Le verdict par defaut, et sa nuance
+
+Quatre familles sur les six analysees sous #5081 ont conclu **aucune renumerotation**. C'est le fait le plus important du corpus : la numerotation du depot est majoritairement **saine**, et un agent qui aborde une famille en supposant le contraire fabrique du travail.
+
+**La nuance est dans le grain.** #5667 (Search) conclut « aucune renum » pour la famille — et #5666, sur la **meme** famille, etablit que `Search-11` porte une collision reelle qui, elle, justifie le geste. Les deux verdicts sont justes : **le verdict se pose par branche, pas par famille.** Un « la famille est saine » ne dispense pas d'examiner une branche nommement suspecte, et un defaut sur une branche ne condamne pas la famille.
+
+## 3. Le blast-radius reel : la grappe Probas
+
+Le cas le plus instructif du depot. Une renumerotation narrative de la lane Infer.NET (#5637) a produit **cinq PRs**, dont quatre en aval du renommage lui-meme :
+
+| PR | Ce qu'elle repare |
+|---|---|
+| #5807 | la renum elle-meme — cycle 5, 7, 9, 11, 14 |
+| #5856 | le **miroir PyMC** : 12 deplacements pour restaurer la parite avec Infer (#4956) |
+| #5849 | resync du **README** Probas apres la renum |
+| #6471 | **derive de prose** : « Debugging is Infer-6 not 13 » — un libelle survivant dans le texte |
+| #5846 | re-seed du **CSV de traduction** (#4957 Phase 2) |
+
+Deux lecons s'en degagent, toutes deux ecrites dans la regle :
+
+1. **La serie jumelle bouge aussi.** Renumeroter Infer sans PyMC casse une parite qui etait le produit d'un travail anterieur. Toute famille a twin (C#/Python, FR/EN, Infer/PyMC) double le mapping.
+2. **La prose survit au renommage.** #6471 est exactement la classe de defaut que les quatre gardes de liens historiques ne voient pas : la cible existe, le lien fonctionne, et le texte nomme le mauvais numero. C'est ce qui a motive `check_link_label_agreement.py` (#14624).
+
+## 4. Les residus, et l'ordre dans lequel ils apparaissent
+
+Un renommage propage dans cinq surfaces de liens (table dans la regle) plus deux artefacts derives :
+
+- **`pedagogy_density_baseline.json`** — les cles sont des chemins. La campagne de renum y a laisse **48 cles orphelines**, et aucun refresh automatique n'existait (#13815, ferme par l'organe `--check-orphans` de #13826).
+- **Liste de rendu Quarto** — #13931 a du regenerer la liste apres le rename #13823, avec « residu ICT-21b/21c + drift accumule ». Le residu s'accumule silencieusement : il ne casse rien de visible tant qu'on ne regenere pas.
+
+L'ordre observe est stable : le rename passe, puis les liens 404 sautent (visibles), puis les libelles mentent (invisibles), puis les artefacts derives divergent (invisibles jusqu'a la prochaine regeneration).
+
+## 5. Etat mesure de l'arbre (2026-09-04)
+
+Commande de mesure (a re-executer plutot qu'a recopier) :
+
+```bash
+python - <<'PY'
+import re, collections
+from pathlib import Path
+ID = re.compile(r"^(?P<pre>.+?)[-_](?P<num>\d{1,3})(?P<let>[a-z])?[-_]", re.I)
+fam = collections.defaultdict(lambda: collections.defaultdict(set))
+for p in Path("MyIA.AI.Notebooks").rglob("*.ipynb"):
+    s = str(p).replace("\\", "/")
+    if "_archive" in s or ".ipynb_checkpoints" in s or "/.lake/" in s:
+        continue
+    m = ID.match(p.name)
+    if m:
+        fam[m.group("pre").lower()][int(m.group("num"))].add((m.group("let") or "").lower())
+for f, nums in sorted(fam.items()):
+    for n, lets in sorted(nums.items()):
+        real = sorted(x for x in lets if x)
+        if real and max(real) >= "g":
+            print(f"{f}-{n}: {''.join(real)} ({len(lets)} slots)")
+PY
+```
+
+| Mesure | Valeur |
+|---|---:|
+| Notebooks portant un identifiant | 814 |
+| Familles | 34 |
+| Branches numerotees | 494 |
+| Branches **sans accretion** (speed-run canonique) | 411 |
+| Branches accretees | 83 |
+| … dont premiere accretion = `b` (convention) | 80 |
+| … dont deviantes | 3 |
+| Branches depassant la norme `e`-`f` | 3 |
+
+Les trois deviations de convention et les trois depassements de norme **ne sont pas les memes ensembles** : `Tweety-7` devie (pas de base) sans depasser la norme, `ICT-15` depasse la norme sans devier de la convention. Deux mesures, deux chantiers.
+
+## 6. Ce que la mesure dit du speed-run
+
+411 branches canoniques. La cible enoncee par le user pour le parcours canonique est « plutot autour des 500 notebooks max, peut-etre moins » — le **nombre de slots canoniques y est deja**, ce qui deplace la question. Ce qui reste a faire n'est pas d'elaguer massivement mais :
+
+1. de rendre le speed-run **lisible** (une branche sans base — `Lean-16`, `Tweety-7` — n'a aucune entree canonique, donc trouee dans le parcours) ;
+2. de ramener les trois branches sur-etendues sous la norme par **fusion**, pas par suppression ;
+3. de verifier que les numeros nus, lus dans l'ordre, forment bien un arc — c'est le travail que #5081 a fait par famille et que le compilateur de parcours de #14620 consomme.
+
+Le compte de **notebooks** reste superieur au compte de **slots** (twins C#/Python, siblings FR/EN partagent un slot) : les deux ne se comparent pas directement.


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/research-code #14605

Closes #14627.

**Sign-off user du 2026-09-04** — un ajout a `.claude/rules/` exige PR + sign-off (CLAUDE.md §A), il a ete donne explicitement.

## Le defaut

Le geste `renum()` / `reclass()` a ete re-derive a la main sur **dix-neuf issues** sans jamais etre ecrit. Chacune a re-decouvert seule : quel est le parent pedagogique, quels referents cassent, dans quel ordre renommer — et, le plus souvent oublie, **s'il faut renommer tout court**.

## Ce que la regle porte, et sur quelle mesure

Tout ce qui suit est mesure firsthand le 2026-09-04, pas repris d'un document.

**Le canonique est ce qui n'a pas de lettre.** 814 notebooks a identifiant, 34 familles, 494 branches numerotees, dont **411 sans accretion** — lire les numeros nus dans l'ordre *est* le speed-run.

**La convention se constate, elle ne se decrete pas.** Sur les 83 branches accretees, **80 commencent a `b`** : la base sans lettre occupe la place de `a`. La regle enregistre donc une pratique etablie a 96 %, elle n'en invente pas une. Les trois ecarts deviennent des defauts nommes :

| Branche | Ecart |
|---|---|
| `GameTheory-03` | base presente **et** premiere accretion `a` |
| `Lean-16` | **aucune base** — la branche Conway commence a `16a`, donc n'a aucune entree dans le speed-run |
| `Tweety-7` | **aucune base** (blast-radius reduit) |

**La norme `e`-`f` est deja tenue presque partout** : 80 des 83 branches accretees sont a 4 accretions ou moins. Exactement trois la depassent — `ICT-15` (`b`..`l`, 12 nb), `Lean-16` (`a`..`j`, 10), `GameTheory-03` (`a`..`h`, 9). C'est la surface entiere du chantier de fusion, et cette PR le dit pour eviter qu'il soit lu comme une campagne repo-wide.

**Le verdict par defaut est « aucune renum ».** Quatre des six familles analysees sous #5081 ont conclu qu'il n'y avait rien a faire (#5656, #5662, #5667, #5669). C'est la moitie du geste qui manquait : une regle qui n'expliquerait que *comment* renumeroter pousserait a renumeroter partout. **Et le verdict se pose par branche, pas par famille** — #5667 conclut « rien a faire » sur Search pendant que #5666, meme famille, etablit une collision reelle sur `Search-11`.

## Le blast-radius, documente par le cas mesure

La grappe Probas : une renum narrative (#5637) a produit **cinq PRs** — la renum (#5807), le miroir PyMC pour restaurer la parite (#5856), le resync README (#5849), la derive de prose « Debugging is Infer-6 not 13 » (#6471), le re-seed du CSV de traduction (#5846).

La quatrieme est la classe que les quatre gardes de liens historiques ne voient pas : **la cible existe, le lien marche, et le texte nomme le mauvais numero**. La regle liste les cinq surfaces et leur organe, et signale explicitement que le cinquieme (`check_link_label_agreement.py`, #14624) **est livre par la PR #14625 et n'est pas encore sur `main`** — pointer un organe absent sans le dire serait le meme defaut a un cran de meta.

## Fichiers

| Fichier | Role |
|---|---|
| `.claude/rules/notebook-accretion-numbering.md` | la regle — **auto-chargee** |
| `docs/reference/notebook-renumbering-detail.md` | corpus des 19 precedents, verdicts par famille, blast-radius Probas, commande de mesure re-executable |
| `docs/README.md`, `CLAUDE.md` | une ligne d'index chacun |

**Pourquoi auto-chargee et non `paths:`-gatee** : la decision de renumeroter se prend **avant** de toucher un fichier notebook — en lisant une issue. Un `paths: MyIA.AI.Notebooks/**` la rendrait invisible exactement au moment ou elle sert. Le cout est assume et la regle est tenue courte, le volume vivant dans `docs/` (harness-hygiene, 3 tiers).

## Verification

- `python scripts/check_docs_links.py` → **677 fichiers, 5482 liens, aucun casse**
- Diff : **4 fichiers, +219, −0** — aucune suppression, aucun fichier hors sujet. Un `slides/S3-acculturation/slides.md` happe par `git add -A` (2869/2869, pur flip CRLF) a ete retire du commit avant push.
- Aucune modification du catalogue genere.

## Hors perimetre — nomme, pas absorbe

- **Padding zero** (`Search-3` vs `GameTheory-03`) → #14545
- **Suffixe de langage** des twins C#/Python → #12933
- **Fusion effective** des trois branches sur-etendues → #11690 (ICT-15) ; a ouvrir pour `Lean-16` et `GameTheory-03`
- **Normalisation des trois deviations de convention** → suit la fusion, meme tranche

