### PR TITLE
feat(gate,#14603): advisory CAPABILITY_DOWNGRADE axis (cuda->cpu + witness loss, couple-verified)

### DIFF
--- a/.github/workflows/notebook-output-failure-ratchet.yml
+++ b/.github/workflows/notebook-output-failure-ratchet.yml
@@ -64,8 +64,14 @@ jobs:
       # that replaying the founding commit still fires. A detector that cannot
       # be shown to fire is indistinguishable from one that is unplugged --
       # which is exactly how the three surfaces above passed this through.
+      # Since #14603 it also replays the GPU -> CPU re-exec of #14262 for the
+      # advisory CAPABILITY_DOWNGRADE axis (never gates; the lift -- a
+      # documented RECOVERABLE-MACHINE CPU run -- is written in the report).
       - name: Detector self-test (positive + negative control)
         run: python scripts/notebook_tools/check_output_failure_text.py --self-test
+
+      - name: Capability-downgrade axis unit tests (#14603)
+        run: python -m pytest scripts/notebook_tools/tests/test_check_output_failure_text.py -q
 
       # Refs reach the script via env, never inline in the run script
       # (script-injection guard, same as notebook-papermill-ratchet.yml).

--- a/scripts/notebook_tools/check_output_failure_text.py
+++ b/scripts/notebook_tools/check_output_failure_text.py
@@ -42,6 +42,24 @@ still signal) but are reported in their own count by ``--all`` and never
 summed into the TOOL_FAILURE total -- so an advisory sweep no longer reads
 as a cleanup backlog that is mostly noise.
 
+A third axis, ``CAPABILITY_DOWNGRADE`` (#14603), is ADVISORY and never gates:
+a re-execution on a machine without the capability the notebook was written
+for (GPU -> CPU) produces well-formed output -- "Device : cpu" is a correct
+execution report, not a failure banner, so the two gating classes are blind
+to it BY DESIGN. What makes the downgrade invisible rather than merely
+unclassified is the second half-turn: the witness line printed under
+``if gpu_available:`` disappears at the same time, so the output diff looks
+exactly like a legitimate re-execution. The finding is the COUPLE on one
+cell with byte-identical source: capability value regression AND
+witness-line disappearance. Founding replay: #14262 (be6a8c7f3b9e ->
+0ea56ae0f, GenAI/Audio 02-4-Demucs cells 10/31, cuda + "VRAM utilisee" ->
+cpu, VRAM gone) -- a state that existed TRANSIENTLY on the #14262 branch
+while the gate read 0 regressed; the branch's own final GPU re-exec (merged
+as 15c205323) restored cuda, which main still carries. The replay pair
+documents what this axis would have flagged had the branch merged mid-leg.
+A deliberate documented CPU run (RECOVERABLE-MACHINE verdict in the PR
+body) passes: the lift is written in the report line itself.
+
 Usage:
     python check_output_failure_text.py <base-ref> [--json]
     python check_output_failure_text.py --all [--json]
@@ -192,6 +210,115 @@ _PATH_WITNESSES = (
     "/Users/jsboige/CoursIA/scripts",
 )
 
+# --- class 3 (ADVISORY, never gates): capability downgrade -------------------
+# #14603. Each half of the couple alone is legitimate: a value can move on a
+# same-tier machine swap, a witness line can vanish in an honest output
+# change reviewed as code. Only the couple on an UNCHANGED-SOURCE cell says
+# "same code, executed elsewhere, with less capability".
+#
+# Closed, witnessed order table. cuda > cpu is the measured instance
+# (#14262); fp16 -> fp32 and device-count -> 0 are the same FORM but have no
+# witnessed pair in the repo yet -- extend only with a witness + its replay
+# (the pattern-set philosophy above: a class that cannot be shown to fire is
+# indistinguishable from one that is unplugged).
+CAPABILITY_VALUE_RE = re.compile(
+    r"\bdevice\s*[:=]\s*['\"]?(cuda(?:\s*:\s*\d+)?|cpu)\b", re.IGNORECASE)
+CAPABILITY_ORDER = {"cuda": 2, "cpu": 1}
+
+# Witness lines: measured on origin/main 2026-09-04 ("VRAM utilisee" x53,
+# "GB VRAM" x144 inside GPU-name lines, "GPU : <Cap>" x36). The issue also
+# names "CUDA device" / "Using device": zero committed occurrences -- not
+# shipped without a witness.
+CAPABILITY_WITNESS_PATTERNS = (
+    re.compile(r"VRAM\s+utilis.e", re.IGNORECASE),
+    re.compile(r"\d+(?:\.\d+)?\s*GB\s+VRAM", re.IGNORECASE),
+    re.compile(r"GPU\s*[:=]\s*[A-Z]"),
+)
+
+# Founding downgrade replay (#14603): the CPU re-exec of #14262. Expected
+# floor measured firsthand: 02-4-Demucs cells 10 and 31 regress
+# (cuda + VRAM -> cpu, VRAM gone) while cell 4 was restored mid-range
+# (net cuda -> cuda, must NOT fire -- the upgrade guard below is what keeps
+# the restoration from being re-flagged in the 39f96fb82..0ea56ae0f
+# direction). The degraded head is branch-side history of the squash-merged
+# PR -- absent from any fresh clone (fetch-depth: 0 carries refs/heads
+# only) -- so the replay pair is pinned as a fixture carrying the real
+# cells verbatim, never read from git objects that may not be there.
+DOWNGRADE_REPLAY_FIXTURE = "demucs_downgrade_pair_14603.json"
+SELF_TEST_MIN_DOWNGRADE = 2
+
+
+def _cell_output_text(cell):
+    """Concatenated textual output of one code cell (stream, text/plain,
+    traceback) -- the per-cell view of what output_texts yields per output."""
+    parts = []
+    for out in cell.get("outputs", []) or []:
+        kind = out.get("output_type")
+        if kind == "stream":
+            text = out.get("text", "")
+            parts.append("".join(text) if isinstance(text, list) else str(text))
+        elif kind in ("execute_result", "display_data"):
+            plain = (out.get("data", {}) or {}).get("text/plain")
+            if plain is not None:
+                parts.append("".join(plain) if isinstance(plain, list)
+                             else str(plain))
+        elif kind == "error":
+            parts.append("\n".join(str(x) for x in (out.get("traceback", [])
+                                                    or [])))
+    return "\n".join(parts)
+
+
+def _cell_source(cell):
+    src = cell.get("source", "")
+    return "".join(src) if isinstance(src, list) else str(src)
+
+
+def _capability_values(text):
+    """Set of normalised capability values named in an output text
+    (subset of CAPABILITY_ORDER keys)."""
+    values = set()
+    for m in CAPABILITY_VALUE_RE.finditer(text):
+        values.add(m.group(1).lower().split(":")[0].strip())
+    return {v for v in values if v in CAPABILITY_ORDER}
+
+
+def _witness_count(text):
+    return sum(len(p.findall(text)) for p in CAPABILITY_WITNESS_PATTERNS)
+
+
+def capability_downgrades(base_nb, head_nb):
+    """Advisory findings (#14603): one per cell whose source is byte-identical
+    between base and head, whose best capability class strictly DROPPED, and
+    from which every witness line vanished. See the class-3 block above for
+    why the couple -- not either half -- is the finding."""
+    findings = []
+    if not base_nb or not head_nb:
+        return findings
+    base_cells = base_nb.get("cells", []) or []
+    head_cells = head_nb.get("cells", []) or []
+    for i in range(min(len(base_cells), len(head_cells))):
+        b_cell, h_cell = base_cells[i], head_cells[i]
+        if b_cell.get("cell_type") != "code" or h_cell.get("cell_type") != "code":
+            continue
+        if _cell_source(b_cell) != _cell_source(h_cell):
+            continue
+        b_text, h_text = _cell_output_text(b_cell), _cell_output_text(h_cell)
+        b_best = max((CAPABILITY_ORDER[v]
+                      for v in _capability_values(b_text)), default=0)
+        h_best = max((CAPABILITY_ORDER[v]
+                      for v in _capability_values(h_text)), default=0)
+        if not b_best > h_best:
+            continue
+        b_wit, h_wit = _witness_count(b_text), _witness_count(h_text)
+        if b_wit > 0 and h_wit == 0:
+            findings.append({
+                "cell": i,
+                "base": "/".join(sorted(_capability_values(b_text))) or "(absent)",
+                "head": "/".join(sorted(_capability_values(h_text))) or "(absent)",
+                "witness_lost": b_wit,
+            })
+    return findings
+
 
 def git(*args, cwd=None):
     """Run a git command, returning stdout (utf-8) or None on failure."""
@@ -336,6 +463,9 @@ def compare(base_ref, head_ref, paths, cwd=None):
                 entry["samples"] = [{"cell": c, "match": t}
                                     for c, t in h[cls][:6]]
             row["classes"][cls] = entry
+        # Advisory axis (#14603): needs a base blob, never gates.
+        row["capability_downgrades"] = (capability_downgrades(base_nb, head_nb)
+                                        if base_nb is not None else [])
         row["regressed"] = regressed
         rows.append(row)
     return rows
@@ -400,6 +530,64 @@ def self_test(cwd=None):
         failures.append("sandbox banner masked a real failure in the same "
                         "stream")
 
+    # Capability axis (#14603): witnesses first, then the couple controls.
+    # A witness line the patterns do not match is a hole by construction.
+    for witness_line in ("VRAM utilisee : 0.64 GB",
+                         "GPU : NVIDIA GeForce RTX 3090 (24.0 GB VRAM)"):
+        if not any(p.search(witness_line)
+                   for p in CAPABILITY_WITNESS_PATTERNS):
+            failures.append("capability witness line unmatched: "
+                            + repr(witness_line))
+    for probe, expected in (("Mode : batch, Device : cuda", {"cuda"}),
+                            ("Device = cpu", {"cpu"}),
+                            ("torch.device('cuda:0')", set())):
+        got = _capability_values(probe)
+        if got != expected:
+            failures.append("capability values " + repr(got) + " != "
+                            + repr(expected) + " on " + repr(probe))
+
+    def _nb_cell(source, out_text):
+        return {"cells": [{"cell_type": "code", "source": source,
+                           "outputs": [{"output_type": "stream",
+                                        "text": out_text}]}]}
+
+    _gpu_src = "print(info)\nprint(f'VRAM utilisee : {v:.2f} GB')"
+    _couple = capability_downgrades(
+        _nb_cell(_gpu_src, "Device : cuda\nVRAM utilisee : 0.64 GB"),
+        _nb_cell(_gpu_src, "Device : cpu"))
+    if len(_couple) != 1 or _couple[0]["base"] != "cuda":
+        failures.append("couple (value regressed + witness gone + same "
+                        "source) not flagged: " + repr(_couple))
+    # Legit re-exec: same tier, values wiggle -- the everyday case.
+    if capability_downgrades(
+            _nb_cell(_gpu_src, "Device : cuda\nVRAM utilisee : 0.64 GB"),
+            _nb_cell(_gpu_src, "Device : cuda\nVRAM utilisee : 0.63 GB")):
+        failures.append("legit GPU re-exec flagged as capability downgrade")
+    # Source changed: the move is a CODE change, reviewed as code.
+    if capability_downgrades(
+            _nb_cell(_gpu_src, "Device : cuda\nVRAM utilisee : 0.64 GB"),
+            _nb_cell(_gpu_src + "\nprint('cpu fallback')",
+                     "Device : cpu")):
+        failures.append("changed-source downgrade flagged (must be reviewed "
+                        "as code, not by this axis)")
+    # Value alone: witness line still printed -- not the couple.
+    if capability_downgrades(
+            _nb_cell(_gpu_src, "Device : cuda\nVRAM utilisee : 0.64 GB"),
+            _nb_cell(_gpu_src, "Device : cpu\nVRAM utilisee : 0.00 GB")):
+        failures.append("value-only regression flagged (couple incomplete)")
+    # Witness alone: value did not regress -- not the couple.
+    if capability_downgrades(
+            _nb_cell(_gpu_src, "Device : cuda\nVRAM utilisee : 0.64 GB"),
+            _nb_cell(_gpu_src, "Device : cuda")):
+        failures.append("witness-only disappearance flagged (couple "
+                        "incomplete)")
+    # Upgrade (restoration direction of #14262): must stay silent.
+    if capability_downgrades(
+            _nb_cell(_gpu_src, "Device : cpu"),
+            _nb_cell(_gpu_src,
+                     "Device : cuda\nVRAM utilisee : 0.64 GB")):
+        failures.append("capability UPGRADE flagged (restoration must pass)")
+
     # Replay the founding commit against its parent.
     if git("cat-file", "-e", SELF_TEST_COMMIT, cwd=cwd) is None:
         print("SKIP replay: " + SELF_TEST_COMMIT[:12] + " not in this clone")
@@ -419,11 +607,37 @@ def self_test(cwd=None):
             failures.append("replay MACHINE_PATH +" + str(n_path) + " < "
                             + str(SELF_TEST_MIN_PATH) + " expected")
 
+    # Second replay (#14603): the GPU -> CPU re-exec of #14262, pinned as a
+    # fixture (see DOWNGRADE_REPLAY_FIXTURE). The two gating classes read
+    # 0 regressed on this exact pair while the diff carried cuda -> cpu +
+    # VRAM-line disappearance on unchanged-source cells -- the hole this
+    # axis exists to close. Refuses to pass if the replay comes back
+    # empty, same contract as the founding replay above -- and unlike a
+    # git-object replay it cannot silently skip in a fresh clone.
+    fixture_path = (Path(__file__).resolve().parent / "tests" / "fixtures"
+                    / DOWNGRADE_REPLAY_FIXTURE)
+    try:
+        blob = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        blob = None
+        failures.append("downgrade replay fixture unreadable ("
+                        + str(fixture_path) + "): " + str(exc))
+    if blob is not None:
+        n_down = len(capability_downgrades({"cells": blob["base_cells"]},
+                                           {"cells": blob["head_cells"]}))
+        print("replay fixture " + DOWNGRADE_REPLAY_FIXTURE + ": "
+              + str(len(blob["base_cells"])) + " cells, "
+              + "CAPABILITY_DOWNGRADE " + str(n_down))
+        if n_down < SELF_TEST_MIN_DOWNGRADE:
+            failures.append("downgrade replay CAPABILITY_DOWNGRADE "
+                            + str(n_down) + " < "
+                            + str(SELF_TEST_MIN_DOWNGRADE) + " expected")
+
     for f in failures:
         print("SELF-TEST FAIL: " + f)
     if failures:
         return 1
-    print("SELF-TEST OK: witnesses matched, benign text silent, replay fires")
+    print("SELF-TEST OK: witnesses matched, benign text silent, replays fire")
     return 0
 
 
@@ -536,6 +750,22 @@ def main(argv=None):
             print("\nCause is on the executing machine, not in the notebook: "
                   "install the missing tool and RE-EXECUTE. Never hand-edit a "
                   "committed output (Stop & Repair, secrets-hygiene rule 6).")
+        downgrades = [(r["notebook"], r["capability_downgrades"])
+                      for r in rows if r.get("capability_downgrades")]
+        if downgrades:
+            n_cells = sum(len(d) for _, d in downgrades)
+            print("\nADVISORY CAPABILITY_DOWNGRADE (" + str(n_cells)
+                  + " cell(s)) -- byte-identical source, executed with less "
+                  "capability, witness line gone. Not gating (#14603):")
+            for path, ds in downgrades:
+                for d in ds:
+                    print("  " + path + " cell[" + str(d["cell"]) + "] "
+                          + d["base"] + " -> " + d["head"])
+            print("  Lift: a deliberate, documented CPU run (RECOVERABLE-"
+                  "MACHINE verdict in the PR body) passes -- state it there "
+                  "and the reviewer acknowledges this line. Otherwise "
+                  "re-execute on the capable machine; never hand-edit the "
+                  "output (Stop & Repair).")
     return 1 if bad else 0
 
 

--- a/scripts/notebook_tools/tests/fixtures/demucs_downgrade_pair_14603.json
+++ b/scripts/notebook_tools/tests/fixtures/demucs_downgrade_pair_14603.json
@@ -1,0 +1,381 @@
+{
+ "provenance": {
+  "issue": 14603,
+  "founding_pr": 14262,
+  "base_commit": "be6a8c7f3b9ea3ac82e6232813c2eccda1b87800",
+  "head_commit": "0ea56ae0f712327b6fc7fb3b8bc834c8983f39dc",
+  "notebook": "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-4-Demucs-Source-Separation.ipynb",
+  "original_cell_indices": [
+   10,
+   31
+  ],
+  "extracted": "2026-09-04",
+  "note": "Real cells (source + outputs) extracted verbatim. The head commit is branch-side history of the squash-merged PR #14262 -- absent from fresh clones (fetch-depth: 0 carries refs/heads only) -- so the replay is pinned here instead of read from git objects. The PR's own final GPU re-exec (main merge 15c205323) restored cuda; this pair is the mid-leg state the advisory axis exists to flag."
+ },
+ "base_cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-load-model",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T17:20:24.177633Z",
+     "iopub.status.busy": "2026-08-20T17:20:24.177229Z",
+     "iopub.status.idle": "2026-08-20T17:20:26.071255Z",
+     "shell.execute_reply": "2026-08-20T17:20:26.070629Z"
+    },
+    "papermill": {
+     "duration": 1.898407,
+     "end_time": "2026-08-20T17:20:26.072122",
+     "exception": false,
+     "start_time": "2026-08-20T17:20:24.173715",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CHARGEMENT DU MODELE DEMUCS\n",
+      "=============================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chargement htdemucs_ft...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele charge en 1.7s\n",
+      "Device : cuda\n",
+      "Sources : ['drums', 'bass', 'other', 'vocals']\n",
+      "Sample rate : 44100 Hz\n",
+      "Nombre de sources : 4\n",
+      "VRAM utilisee : 0.64 GB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Chargement du modele Demucs\n",
+    "print(\"CHARGEMENT DU MODELE DEMUCS\")\n",
+    "print(\"=\" * 45)\n",
+    "\n",
+    "demucs_loaded = False\n",
+    "\n",
+    "try:\n",
+    "    from demucs.pretrained import get_model\n",
+    "    from demucs.apply import apply_model\n",
+    "\n",
+    "    print(f\"Chargement {model_name}...\")\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    separator = get_model(model_name)\n",
+    "    separator.to(device)\n",
+    "    separator.eval()\n",
+    "    load_time = time.time() - start_time\n",
+    "    demucs_loaded = True\n",
+    "\n",
+    "    print(f\"Modele charge en {load_time:.1f}s\")\n",
+    "    print(f\"Device : {device}\")\n",
+    "    print(f\"Sources : {separator.sources}\")\n",
+    "    print(f\"Sample rate : {separator.samplerate} Hz\")\n",
+    "    print(f\"Nombre de sources : {len(separator.sources)}\")\n",
+    "\n",
+    "    if gpu_available:\n",
+    "        vram_used = torch.cuda.memory_allocated(0) / (1024**3)\n",
+    "        print(f\"VRAM utilisee : {vram_used:.2f} GB\")\n",
+    "\n",
+    "except ImportError:\n",
+    "    print(\"demucs non installe\")\n",
+    "    print(\"Installation : pip install demucs\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Erreur lors du chargement : {type(e).__name__} - {str(e)[:200]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-stats",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T17:20:32.812178Z",
+     "iopub.status.busy": "2026-08-20T17:20:32.811963Z",
+     "iopub.status.idle": "2026-08-20T17:20:32.913958Z",
+     "shell.execute_reply": "2026-08-20T17:20:32.913359Z"
+    },
+    "papermill": {
+     "duration": 0.188283,
+     "end_time": "2026-08-20T17:20:32.914884",
+     "exception": false,
+     "start_time": "2026-08-20T17:20:32.726601",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "STATISTIQUES DE SESSION\n",
+      "=============================================\n",
+      "Date : 2026-08-20 19:20:32\n",
+      "Modele : htdemucs_ft\n",
+      "Device : cuda\n",
+      "Modele charge : Oui\n",
+      "VRAM utilisee : 0.66 GB\n",
+      "Fichiers sauvegardes : 14 (22.1 MB) dans outputs\\audio\\demucs\n",
+      "\n",
+      "Resume des stems separes :\n",
+      "  drums      : RMS=0.0260, Peak=0.5033\n",
+      "  bass       : RMS=0.1490, Peak=0.4070\n",
+      "  other      : RMS=0.1403, Peak=0.5368\n",
+      "  vocals     : RMS=0.0081, Peak=0.1623\n",
+      "\n",
+      "Liberation du modele...\n",
+      "Memoire liberee\n",
+      "\n",
+      "PROCHAINES ETAPES\n",
+      "1. Comparer tous les modeles audio (03-1)\n",
+      "2. Construire un pipeline vocal complet (03-2)\n",
+      "3. Explorer l'API Realtime d'OpenAI (03-3)\n",
+      "4. Creer des compositions multi-etapes (04-3)\n",
+      "\n",
+      "Notebook Demucs Source Separation termine - 19:20:32\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Statistiques de session et prochaines etapes\n",
+    "print(\"STATISTIQUES DE SESSION\")\n",
+    "print(\"=\" * 45)\n",
+    "\n",
+    "print(f\"Date : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "print(f\"Modele : {model_name}\")\n",
+    "print(f\"Device : {device}\")\n",
+    "print(f\"Modele charge : {'Oui' if demucs_loaded else 'Non'}\")\n",
+    "\n",
+    "if gpu_available:\n",
+    "    vram_current = torch.cuda.memory_allocated(0) / (1024**3)\n",
+    "    print(f\"VRAM utilisee : {vram_current:.2f} GB\")\n",
+    "\n",
+    "if save_results:\n",
+    "    saved = list(OUTPUT_DIR.glob('*'))\n",
+    "    total_size = sum(f.stat().st_size for f in saved if f.is_file()) / (1024*1024)\n",
+    "    print(f\"Fichiers sauvegardes : {len(saved)} ({total_size:.1f} MB) dans {OUTPUT_DIR.relative_to(GENAI_ROOT)}\")\n",
+    "\n",
+    "if stem_results:\n",
+    "    print(f\"\\nResume des stems separes :\")\n",
+    "    for name, data in stem_results.items():\n",
+    "        print(f\"  {name:<10} : RMS={data['rms']:.4f}, Peak={data['peak']:.4f}\")\n",
+    "\n",
+    "# Liberation memoire\n",
+    "if demucs_loaded:\n",
+    "    print(f\"\\nLiberation du modele...\")\n",
+    "    del separator\n",
+    "    gc.collect()\n",
+    "    if gpu_available:\n",
+    "        torch.cuda.empty_cache()\n",
+    "    print(f\"Memoire liberee\")\n",
+    "\n",
+    "print(f\"\\nPROCHAINES ETAPES\")\n",
+    "print(f\"1. Comparer tous les modeles audio (03-1)\")\n",
+    "print(f\"2. Construire un pipeline vocal complet (03-2)\")\n",
+    "print(f\"3. Explorer l'API Realtime d'OpenAI (03-3)\")\n",
+    "print(f\"4. Creer des compositions multi-etapes (04-3)\")\n",
+    "\n",
+    "print(f\"\\nNotebook Demucs Source Separation termine - {datetime.now().strftime('%H:%M:%S')}\")\n"
+   ]
+  }
+ ],
+ "head_cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-load-model",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T13:29:27.499006Z",
+     "iopub.status.busy": "2026-09-03T13:29:27.499006Z",
+     "iopub.status.idle": "2026-09-03T13:29:28.918842Z",
+     "shell.execute_reply": "2026-09-03T13:29:28.917822Z"
+    },
+    "papermill": {
+     "duration": 1.424344,
+     "end_time": "2026-09-03T13:29:28.919844",
+     "exception": false,
+     "start_time": "2026-09-03T13:29:27.495500",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CHARGEMENT DU MODELE DEMUCS\n",
+      "=============================================\n",
+      "Chargement htdemucs_ft...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\miniconda3\\envs\\audiocraft-env\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele charge en 1.4s\n",
+      "Device : cpu\n",
+      "Sources : ['drums', 'bass', 'other', 'vocals']\n",
+      "Sample rate : 44100 Hz\n",
+      "Nombre de sources : 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Chargement du modele Demucs\n",
+    "print(\"CHARGEMENT DU MODELE DEMUCS\")\n",
+    "print(\"=\" * 45)\n",
+    "\n",
+    "demucs_loaded = False\n",
+    "\n",
+    "try:\n",
+    "    from demucs.pretrained import get_model\n",
+    "    from demucs.apply import apply_model\n",
+    "\n",
+    "    print(f\"Chargement {model_name}...\")\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    separator = get_model(model_name)\n",
+    "    separator.to(device)\n",
+    "    separator.eval()\n",
+    "    load_time = time.time() - start_time\n",
+    "    demucs_loaded = True\n",
+    "\n",
+    "    print(f\"Modele charge en {load_time:.1f}s\")\n",
+    "    print(f\"Device : {device}\")\n",
+    "    print(f\"Sources : {separator.sources}\")\n",
+    "    print(f\"Sample rate : {separator.samplerate} Hz\")\n",
+    "    print(f\"Nombre de sources : {len(separator.sources)}\")\n",
+    "\n",
+    "    if gpu_available:\n",
+    "        vram_used = torch.cuda.memory_allocated(0) / (1024**3)\n",
+    "        print(f\"VRAM utilisee : {vram_used:.2f} GB\")\n",
+    "\n",
+    "except ImportError:\n",
+    "    print(\"demucs non installe\")\n",
+    "    print(\"Installation : pip install demucs\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Erreur lors du chargement : {type(e).__name__} - {str(e)[:200]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-stats",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-03T13:29:50.819909Z",
+     "iopub.status.busy": "2026-09-03T13:29:50.818909Z",
+     "iopub.status.idle": "2026-09-03T13:29:50.908840Z",
+     "shell.execute_reply": "2026-09-03T13:29:50.907329Z"
+    },
+    "papermill": {
+     "duration": 0.212983,
+     "end_time": "2026-09-03T13:29:50.909862",
+     "exception": false,
+     "start_time": "2026-09-03T13:29:50.696879",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "STATISTIQUES DE SESSION\n",
+      "=============================================\n",
+      "Date : 2026-09-03 15:29:50\n",
+      "Modele : htdemucs_ft\n",
+      "Device : cpu\n",
+      "Modele charge : Oui\n",
+      "Fichiers sauvegardes : 14 (22.1 MB) dans outputs\\audio\\demucs\n",
+      "\n",
+      "Resume des stems separes :\n",
+      "  drums      : RMS=0.0258, Peak=0.5136\n",
+      "  bass       : RMS=0.1496, Peak=0.4500\n",
+      "  other      : RMS=0.1407, Peak=0.4829\n",
+      "  vocals     : RMS=0.0119, Peak=0.2324\n",
+      "\n",
+      "Liberation du modele...\n",
+      "Memoire liberee\n",
+      "\n",
+      "PROCHAINES ETAPES\n",
+      "1. Comparer tous les modeles audio (03-1)\n",
+      "2. Construire un pipeline vocal complet (03-2)\n",
+      "3. Explorer l'API Realtime d'OpenAI (03-3)\n",
+      "4. Creer des compositions multi-etapes (04-3)\n",
+      "\n",
+      "Notebook Demucs Source Separation termine - 15:29:50\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Statistiques de session et prochaines etapes\n",
+    "print(\"STATISTIQUES DE SESSION\")\n",
+    "print(\"=\" * 45)\n",
+    "\n",
+    "print(f\"Date : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "print(f\"Modele : {model_name}\")\n",
+    "print(f\"Device : {device}\")\n",
+    "print(f\"Modele charge : {'Oui' if demucs_loaded else 'Non'}\")\n",
+    "\n",
+    "if gpu_available:\n",
+    "    vram_current = torch.cuda.memory_allocated(0) / (1024**3)\n",
+    "    print(f\"VRAM utilisee : {vram_current:.2f} GB\")\n",
+    "\n",
+    "if save_results:\n",
+    "    saved = list(OUTPUT_DIR.glob('*'))\n",
+    "    total_size = sum(f.stat().st_size for f in saved if f.is_file()) / (1024*1024)\n",
+    "    print(f\"Fichiers sauvegardes : {len(saved)} ({total_size:.1f} MB) dans {OUTPUT_DIR.relative_to(GENAI_ROOT)}\")\n",
+    "\n",
+    "if stem_results:\n",
+    "    print(f\"\\nResume des stems separes :\")\n",
+    "    for name, data in stem_results.items():\n",
+    "        print(f\"  {name:<10} : RMS={data['rms']:.4f}, Peak={data['peak']:.4f}\")\n",
+    "\n",
+    "# Liberation memoire\n",
+    "if demucs_loaded:\n",
+    "    print(f\"\\nLiberation du modele...\")\n",
+    "    del separator\n",
+    "    gc.collect()\n",
+    "    if gpu_available:\n",
+    "        torch.cuda.empty_cache()\n",
+    "    print(f\"Memoire liberee\")\n",
+    "\n",
+    "print(f\"\\nPROCHAINES ETAPES\")\n",
+    "print(f\"1. Comparer tous les modeles audio (03-1)\")\n",
+    "print(f\"2. Construire un pipeline vocal complet (03-2)\")\n",
+    "print(f\"3. Explorer l'API Realtime d'OpenAI (03-3)\")\n",
+    "print(f\"4. Creer des compositions multi-etapes (04-3)\")\n",
+    "\n",
+    "print(f\"\\nNotebook Demucs Source Separation termine - {datetime.now().strftime('%H:%M:%S')}\")\n"
+   ]
+  }
+ ]
+}

--- a/scripts/notebook_tools/tests/test_check_output_failure_text.py
+++ b/scripts/notebook_tools/tests/test_check_output_failure_text.py
@@ -1,0 +1,122 @@
+"""Tests for check_output_failure_text.py — capability-downgrade axis (#14603).
+
+Pins the couple contract: a capability value regression AND a witness-line
+disappearance on a byte-identical-source cell is the finding; each half
+alone, a changed source, a same-tier value wiggle, and the restoration
+(upgrade) direction are all silent. No network, no kernel.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_output_failure_text import (CAPABILITY_VALUE_RE,
+                                       CAPABILITY_WITNESS_PATTERNS,
+                                       capability_downgrades)
+
+
+def cell(source, out_text):
+    return {"cell_type": "code", "source": source,
+            "outputs": [{"output_type": "stream", "name": "stdout",
+                         "text": out_text}]}
+
+
+def nb(*cells):
+    return {"cells": list(cells), "metadata": {}, "nbformat": 4,
+            "nbformat_minor": 5}
+
+
+GPU_SRC = "print(info)\nprint(f'VRAM utilisee : {v:.2f} GB')"
+GPU_OUT = "Device : cuda\nVRAM utilisee : 0.64 GB"
+CPU_OUT = "Device : cpu"
+
+
+def test_couple_fires():
+    got = capability_downgrades(nb(cell(GPU_SRC, GPU_OUT)),
+                                nb(cell(GPU_SRC, CPU_OUT)))
+    assert len(got) == 1
+    assert got[0]["cell"] == 0
+    assert got[0]["base"] == "cuda"
+    assert got[0]["head"] == "cpu"
+
+
+def test_legit_reexec_silent():
+    wiggle = "Device : cuda\nVRAM utilisee : 0.63 GB"
+    assert capability_downgrades(nb(cell(GPU_SRC, GPU_OUT)),
+                                 nb(cell(GPU_SRC, wiggle))) == []
+
+
+def test_changed_source_silent():
+    assert capability_downgrades(
+        nb(cell(GPU_SRC, GPU_OUT)),
+        nb(cell(GPU_SRC + "\nprint('cpu fallback')", CPU_OUT))) == []
+
+
+def test_value_regression_without_witness_loss_silent():
+    kept = "Device : cpu\nVRAM utilisee : 0.00 GB"
+    assert capability_downgrades(nb(cell(GPU_SRC, GPU_OUT)),
+                                 nb(cell(GPU_SRC, kept))) == []
+
+
+def test_witness_loss_without_value_regression_silent():
+    assert capability_downgrades(nb(cell(GPU_SRC, GPU_OUT)),
+                                 nb(cell(GPU_SRC, "Device : cuda"))) == []
+
+
+def test_upgrade_silent():
+    # Restoration direction of #14262: cpu -> cuda with the witness line
+    # APPEARING must never fire.
+    assert capability_downgrades(nb(cell(GPU_SRC, CPU_OUT)),
+                                 nb(cell(GPU_SRC, GPU_OUT))) == []
+
+
+def test_markdown_cells_ignored():
+    # Same index, but the base cell is markdown: index-matched comparison
+    # must skip non-code cells, not crash.
+    assert capability_downgrades(
+        nb({"cell_type": "markdown", "source": GPU_SRC,
+            "outputs": []}, cell(GPU_SRC, GPU_OUT)),
+        nb(cell(GPU_SRC, CPU_OUT))) == []
+
+
+def test_value_extraction_witnessed_forms():
+    for text, expected in (
+            ("Mode : batch, Device : cuda", {"cuda"}),
+            ("Device : cpu", {"cpu"}),
+            ("Device: CUDA", {"cuda"}),
+            ("device='cuda:0'", {"cuda"}),
+            ("torch.device('cuda:0')", set()),
+            ("VRAM utilisee : 0.64 GB", set())):
+        assert CAPABILITY_VALUE_RE.search(text) is not None or not expected
+        got = set()
+        for m in CAPABILITY_VALUE_RE.finditer(text):
+            v = m.group(1).lower().split(":")[0].strip()
+            got.add(v)
+        assert got == expected, text
+
+
+def test_witness_patterns_match_measured_lines():
+    # Closed, witnessed set -- measured on origin/main 2026-09-04.
+    for line in ("VRAM utilisee : 0.64 GB",
+                 "GPU : NVIDIA GeForce RTX 3090 (24.0 GB VRAM)",
+                 "24.0 GB VRAM)"):
+        assert any(p.search(line) for p in CAPABILITY_WITNESS_PATTERNS), line
+
+
+def test_founding_fixture_fires():
+    """The #14262 founding pair, pinned as a fixture because the degraded
+    head is branch-side history of a squash-merged PR (absent from fresh
+    clones). Both cells must fire; the sources must be byte-identical so
+    the finding cannot be an artifact of a source change."""
+    fx = (Path(__file__).parent / "fixtures"
+          / "demucs_downgrade_pair_14603.json")
+    blob = json.loads(fx.read_text(encoding="utf-8"))
+    assert blob["provenance"]["founding_pr"] == 14262
+    for b, h in zip(blob["base_cells"], blob["head_cells"]):
+        assert b["source"] == h["source"]
+    got = capability_downgrades({"cells": blob["base_cells"]},
+                                {"cells": blob["head_cells"]})
+    assert len(got) == 2
+    assert all(g["base"] == "cuda" and g["head"] == "cpu"
+               and g["witness_lost"] >= 1 for g in got)


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-python #14262

## Quoi

Axe `CAPABILITY_DOWNGRADE` advisory dans `scripts/notebook_tools/check_output_failure_text.py` (#14603) : détecte le couple **régression de valeur de capacité (cuda -> cpu) ET disparition de ligne témoin (VRAM / bannière GPU)** sur une cellule à **source byte-identique**. Jamais gating : la voie de levée (re-exec CPU délibérée documentée, verdict RECOVERABLE-MACHINE dans le body PR) est écrite dans la ligne advisory elle-même.

Chaque moitié seule est légitime et reste silencieuse ; c'est le couple qui est le finding :

| Contrôle | Résultat |
|---|---|
| Couple cuda+VRAM -> cpu (source identique) | **fire** |
| Re-exec légitime (VRAM 0.64 -> 0.63) | silent |
| Source changée | silent |
| Régression de valeur SANS perte de témoin (`Device : cpu` + `VRAM utilisee : 0.00 GB`) | silent |
| Perte de témoin SANS régression (cuda -> cuda) | silent |
| Upgrade / restauration cpu -> cuda (#14262 direction finale) | silent |

## Preuve (relancée après le dernier commit)

Self-test étendu (`--self-test`), rc=0 :

```
replay 988155353765: 2 notebooks, TOOL_FAILURE +18, MACHINE_PATH +12
replay fixture demucs_downgrade_pair_14603.json: 2 cells, CAPABILITY_DOWNGRADE 2
SELF-TEST OK: witnesses matched, benign text silent, replays fire
```

Tests unitaires : `python -m pytest scripts/notebook_tools/tests/test_check_output_failure_text.py tests/test_check_papermill_ratchet.py -q` = **25 passed** (10 nouveaux tests axe #14603 + fixture fondateur ; 15 papermill-ratchet non régressés).

Exercice end-to-end du chemin advisory en mode gate (commit scratch : outputs des cells 10/31 remplacées par celles du state dégradé, puis scratché) :

```
base origin/main -> merge-base 3881b766aaa6 | 1 changed notebooks | 0 regressed

ADVISORY CAPABILITY_DOWNGRADE (2 cell(s)) -- byte-identical source, executed
with less capability, witness line gone. Not gating (#14603):
  .../02-4-Demucs-Source-Separation.ipynb cell[10] cuda -> cpu
  .../02-4-Demucs-Source-Separation.ipynb cell[31] cuda -> cpu
  Lift: a deliberate, documented CPU run (RECOVERABLE-MACHINE verdict in the
  PR body) passes -- ... Otherwise re-execute on the capable machine; never
  hand-edit the output (Stop & Repair).
RC=0
```

Exit code inchangé (`1 if bad else 0`) : l'axe n'ajoute AUCUNE condition de fail.

## Décisions de design (G.1, vérifié firsthand)

1. **Tables fermées, witnesses mesurés.** `CAPABILITY_VALUE_RE` : forme `Device : cuda`/`device='cuda:0'` mesurée sur origin/main (2026-09-04). Witness lines : `VRAM utilis.e` (x53), `\d+ GB VRAM` (x144), `GPU : <Cap>` (x36). Les formes non witnessées de l'issue (`fp16 -> fp32`, `CUDA device`, `Using device` : 0 occurrence commitée) ne sont PAS embarquées — un pattern set se valide par ses faux négatifs.
2. **Ordre clos witnessé** `{cuda: 2, cpu: 1}` : uniquement des valeurs dont la régression est attestée par un témoin dans le corpus.
3. **Le replay fondateur est un FIXTURE, pas un objet git — et c'est le cœur de la correction de premise.** L'issue dit les cells dégradées « still on main ». Vérifié : **faux**. `0ea56ae0f` (cells 10/31 cpu) est un commit **de branche** du PR #14262, **pas un ancêtre de origin/main** (`git merge-base --is-ancestor` = NOT) ; le merge final `15c205323` a restauré cuda partout (mesuré sur origin/main actuel : cells 4/10/31 = `Device : cuda` + lignes VRAM). La dégradation n'a existé que **transitoirement sur la branche**. Conséquence CI : un clone frais (`fetch-depth: 0` = refs/heads seulement) ne porte PAS `0ea56ae0f` — un replay par objet git SKIPPERAIT silencieusement (exactement le « found nothing vs did not look » que ce module existe pour fermer). Le fixture `tests/fixtures/demucs_downgrade_pair_14603.json` embarque les cells réelles (sources + outputs verbatim, provenance : SHAs complets, indices originaux 10/31, date d'extraction) et le self-test **refuse le replay vide, toujours** — pas de branche SKIP.
4. **Numérotation des cells** : l'issue nomme les cells dégradées ; indices mesurés firsthand = 10 et 31 (chargement du modèle, statistiques de session), cohérent avec les previews (« CHARGEMENT DU MODELE DEMUCS », « STATISTIQUES DE SESSION »).

## Périmètre

4 fichiers : `check_output_failure_text.py` (axe + self-test + fixture replay), `tests/test_check_output_failure_text.py` (nouveau, 10 tests), `tests/fixtures/demucs_downgrade_pair_14603.json` (nouveau, cells réelles + provenance), `.github/workflows/notebook-output-failure-ratchet.yml` (étape pytest + commentaire).

Workflow en `workflow_dispatch` (absorbé par la voie rapide #12567 ; le fast-lane joue déjà `--self-test` en pré-contrôle sur chaque PR — l'axe s'y active automatiquement).

Closes #14603
