### PR TITLE
enrich(qc): densite QC-Py-Cloud-08-ValueFactor-ZScore 785 -> 1192 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-08-ValueFactor-ZScore.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-08-ValueFactor-ZScore.ipynb
@@ -11,7 +11,7 @@
     "**Source** : Projet etudiant ESGF 2026 (QC `31932810`), anonymise et adapte.\n",
     "**Type** : `doc cloud` — résultats obtenus sur [QuantConnect Cloud](https://www.quantconnect.com/lab).\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d’apprentissage\n",
     "\n",
@@ -47,6 +47,15 @@
     "| Earning Yield | `valuation_ratios.earning_yield` | Bénéfices / prix | Supérieur = mieux |\n",
     "| FCF Yield | `valuation_ratios.fcf_yield` | Flux de trésorerie libres / prix | Supérieur = mieux |\n",
     "\n",
+    "### Pourquoi normaliser avant de combiner ?\n",
+    "\n",
+    "Les 8 facteurs ne vivent **pas sur la même échelle** : une marge brute est un ratio entre 0 et 1, un P/E se compte en dizaines, une croissance peut être négative. Additionner ces valeurs brutes donnerait un score dominé par le facteur aux plus grands nombres (le P/E écraserait tout). Le Z-Score ramène chaque colonne à une moyenne 0 et un écart-type 1 : chaque facteur **pèse exactement le même poids statistique** dans le composite, quels que soient ses ordres de grandeur d’origine.\n",
+    "\n",
+    "Deux pièges classiques de la cross-section :\n",
+    "\n",
+    "- **Les extrêmes écrasent la moyenne** : un actif au P/E aberrant (proche de zéro, ou négatif sur un trimestre de perte) produit un z monstrueux. Les stratégies sérieuses **winsorisent** (bornent les z à ±3) ou excluent les fondamentaux non exploitables avant de calculer.\n",
+    "- **La normalisation est relative à l’univers** : un z-score de +1.5 signifie « au-dessus de la moyenne du top 50 liquide », pas « bon en absolu ». Changer l’univers (top 50 → top 500) change tous les z-scores.\n",
+    "\n",
     "### Méthode\n",
     "\n",
     "1. **Sélection** : prendre les N actions les plus liquides (top 50 par dollar volume).\n",
@@ -68,7 +77,9 @@
     "\n",
     "$$z_i = \\frac{x_i - \\mu}{\\sigma}$$\n",
     "\n",
-    "Implémentez la fonction `zscore_composite` qui prend une matrice de facteurs (lignes = actifs, colonnes = facteurs) et retourne le score composite pour chaque actif."
+    "Implémentez la fonction `zscore_composite` qui prend une matrice de facteurs (lignes = actifs, colonnes = facteurs) et retourne le score composite pour chaque actif.\n",
+    "\n",
+    "**Indices méthodologiques** : utilisez `np.nanmean` / `np.nanstd` sur `axis=0` — dans un univers réel, certains actifs n’ont pas tous leurs fondamentaux publiés, et une seule valeur manquante suffirait sinon à contaminer toute la colonne avec `NaN`. Bornez ensuite les z à ±3 avant la moyenne (winsorisation) : un P/E aberrant sur un actif ne doit pas dicter le classement. Enfin, l’argument `invert_cols` reçoit les indices des colonnes à inverser — dans le notebook QC, il vaut l’indice du P/E."
    ],
    "id": "cell-cf5588cd"
   },
@@ -91,15 +102,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Exemple résolu : le composite en action sur un mini-univers\n",
+    "\n",
+    "La fonction `zscore_composite` étant à compléter, voici la **même mécanique appliquée pas à pas** sur un univers simulé de 8 actifs et 4 facteurs (les ordres de grandeur hétérogènes sont volontaires : une croissance s’exprime en dixièmes, un P/E en dizaines). Observez comment la normalisation rend les colonnes comparables, comment l’inversion du P/E réorienté le facteur value, et surtout **qui gagne** à l’arrivée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "actif     | croissance_CA |   marge_brute |           ROE |      PE_ratio | composite\nHotel     |         0.134 |         0.290 |         0.162 |        16.361 |    +0.876\nBravo     |        -0.000 |         0.316 |         0.226 |        14.991 |    +0.719\nFoxtrot   |         0.069 |         0.187 |         0.155 |        23.925 |    -0.001\nAlpha     |        -0.024 |         0.148 |         0.137 |         9.554 |    -0.045\nDelta     |         0.059 |         0.216 |         0.122 |        21.979 |    -0.059\nGolf      |         0.023 |         0.466 |         0.042 |        29.042 |    -0.233\nCharlie   |        -0.002 |         0.209 |         0.090 |        22.024 |    -0.502\nEcho      |        -0.059 |         0.183 |         0.162 |        29.352 |    -0.754\n\nTop 2 retenu par le Z-Score composite : ['Hotel', 'Bravo']\nActif au P/E le plus bas (Alpha, PE 9.6) : composite -0.045\nActif a la meilleure croissance (Hotel, +13.4%) : composite +0.876\n"
+    }
+   ],
+   "source": [
+    "# Demonstration executee : Z-Score composite sur un mini-univers simule seedee\n",
+    "# (complement de l'Exercice 1 -- meme mecanique, appliquee pas a pas)\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "rng = np.random.default_rng(8)\n",
+    "noms = [\"Alpha\", \"Bravo\", \"Charlie\", \"Delta\", \"Echo\", \"Foxtrot\", \"Golf\", \"Hotel\"]\n",
+    "facteurs = [\"croissance_CA\", \"marge_brute\", \"ROE\", \"PE_ratio\"]\n",
+    "croissance = rng.normal(0.08, 0.06, 8)          # ordres de grandeur heterogenes\n",
+    "marge = rng.uniform(0.10, 0.55, 8)              # volontaires : dixiemes vs dizaines\n",
+    "roe = rng.normal(0.14, 0.06, 8)\n",
+    "pe = rng.uniform(9.0, 42.0, 8)\n",
+    "\n",
+    "M = np.column_stack([croissance, marge, roe, pe])\n",
+    "z = (M - np.nanmean(M, axis=0)) / np.nanstd(M, axis=0)   # normalisation par colonne\n",
+    "z[:, 3] = -z[:, 3]                                       # inversion du P/E (bas = value)\n",
+    "\n",
+    "composite = z.mean(axis=1)\n",
+    "ordre = np.argsort(-composite)\n",
+    "print(\"actif     | \" + \" | \".join(f\"{f:>13s}\" for f in facteurs) + \" | composite\")\n",
+    "for i in ordre:\n",
+    "    print(f\"{noms[i]:9s} | \" + \" | \".join(f\"{M[i, j]:13.3f}\" for j in range(4)) + f\" | {composite[i]:+9.3f}\")\n",
+    "print()\n",
+    "print(f\"Top 2 retenu par le Z-Score composite : {[noms[i] for i in ordre[:2]]}\")\n",
+    "print(f\"Actif au P/E le plus bas ({noms[np.argmin(pe)]}, PE {pe.min():.1f}) : composite {composite[np.argmin(pe)]:+.3f}\")\n",
+    "print(f\"Actif a la meilleure croissance ({noms[np.argmax(croissance)]}, {croissance.max():+.1%}) : composite {composite[np.argmax(croissance)]:+.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lecture de la sortie. **Hotel** domine le classement (composite **+0.876**) : croissance de +13.4 %, P/E contenu à 16.4 — il est bien noté sur les quatre facteurs à la fois, et le composite récompense cette régularité. La leçon la plus instructive est ailleurs : **Alpha, l’actif au P/E le plus bas (9.6), ne finit qu’à −0.045**. Vu au travers du seul critère value, Alpha serait le champion ; le composite le rétrograde parce que ses autres fondamentaux (croissance −2.4 %, ROE 13.7 %) sont dans la moyenne basse de l’univers. C’est exactement la fonction d’un score multi-facteurs : **éviter les value traps** — ces titres bon marché sur un seul ratio mais médiocres sur le reste. À l’inverse Bravo (croissance nulle, P/E 15.0, ROE 22.6 %) monte à +0.719 : la « qualité value » sans croissance reste un profil recherché. Enfin, comparez les colonnes brutes du tableau : sans normalisation, le P/E (9 à 42) écraserait numériquement la marge brute (0.10 à 0.55) dans toute somme — le Z-Score est ce qui rend les quatre colonnes comparables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2. Le piège du value investing (2015-2024)\n",
     "\n",
     "La période 2015-2024 a été dominée par les **growth stocks** (FAANG/Mag7, tech, IA). Les facteurs value (P/E bas, book yield élevé) ont systématiquement sous-performé.\n",
     "\n",
     "### Pourquoi ?\n",
     "\n",
-    "- **Taux bas** : l’argent gratuit favorise les entreprises en croissance rapide.\n",
+    "- **Taux bas** : l’argent gratuit favorise les entreprises en croissance rapide. Le mécanisme est celui de la **duration** : une action value est un flux de dividendes proches et tangibles (duration courte), une action growth capitalise des flux lointains et espérés (duration longue). Quand les taux baissent, la valeur actualisée des flux lointains monte **plus vite** que celle des flux proches — le growth sur-performe mécaniquement.\n",
     "- **Concentration** : les Mag7 (Apple, Microsoft, Amazon, Google, Meta, Nvidia, Tesla) ont accaparé les rendements.\n",
-    "- **Intangibles** : les fondamentaux comptables traditionnels sous-évaluent les actifs incorporels (R&D, marques, réseaux).\n",
+    "- **Intangibles** : les fondamentaux comptables traditionnels sous-évaluent les actifs incorporels (R&D, marques, réseaux). Le book yield d’une plateforme logicielle ne dit rien de son avantage concurrentiel.\n",
     "- **Momentum croissance** : les actions growth ont bénéficié d’un cercle vertueux (appréciation → inflow → appréciation).\n",
     "\n",
     "### Résultat : la stratégie value Z-Score sur 2015-2024\n",
@@ -111,7 +178,7 @@
     "| MaxDD | -36.5% | ~-25% (COVID) | Drawdown plus sévère |\n",
     "| PSR | 0.8% | > 50% | **Non significatif** statistiquement |\n",
     "\n",
-    "> **Leçon** : une stratégie value à fondamentaux solides (8 facteurs diversifiés) peut tout de même sous-performer pendant une décennie entière. Le value n’est pas un signal universel — il est **régime-dépendant**."
+    "> **Leçon** : une stratégie value à fondamentaux solides (8 facteurs diversifiés) peut tout de même sous-performer pendant une décennie entière. Le value n’est pas un signal universel — il est **régime-dépendant**. La remontée des taux de 2022 (fin de l’argent gratuit) a d’ailleurs commencé à replier ce régime : le value a repris du terrain relatif précisément quand la duration longue du growth est redevenue un risque."
    ],
    "id": "cell-acd29344"
   },
@@ -121,7 +188,9 @@
    "source": [
     "### Exercice 2 : Identifier les facteurs défavorisés dans un contexte growth\n",
     "\n",
-    "Certains de nos 8 facteurs sont particulièrement pénalisés en période growth. Identifiez lesquels et pourquoi."
+    "Certains de nos 8 facteurs sont particulièrement pénalisés en période growth. Identifiez lesquels et pourquoi.\n",
+    "\n",
+    "**Piste de structuration** : classez d’abord les 8 facteurs en trois familles — valorisation (P/E, book yield, earning yield, FCF yield), qualité (marges, ROE), croissance (revenue growth) — et demandez-vous, pour chaque famille, si le régime 2015-2024 la payait ou la pénalisait. Attention à une subtilité : les quatre facteurs de valorisation ne sont **pas quatre signaux indépendants** — P/E bas et earning yield élevé sont deux écritures de la même information de prix. Un composite qui les additionne sur-pondère donc implicitement le « value » ; c’est un choix de design (ici assumé), pas un accident."
    ],
    "id": "cell-47014291"
   },
@@ -161,6 +230,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Correction guidée : les facteurs sous pression en régime growth\n",
+    "\n",
+    "En cascade dans le contexte 2015-2024 :\n",
+    "\n",
+    "- **Pénalisés** — `pe_ratio`, `book_yield`, `earning_yield`, `fcf_yield` : les quatre facteurs de valorisation adorent les flux actuels et tangibles ; or la décennie a payé les flux futurs espérés. Sélectionner sur ces critères a systématiquement écarté les Mag7 du portefeuille — le coût d’opportunité EST la sous-performance.\n",
+    "- **Neutres à favorisés** — `gross_margin`, `op_margin`, `roe` : les mesures de qualité ne discriminent pas growth vs value ; plusieurs géants tech ont d’excellentes marges, ce qui les aurait fait remonter dans un composite orienté qualité.\n",
+    "- **Favorisé** — `revenue_growth` : le seul facteur dont le signe jouait à plein pour le régime de la décennie.\n",
+    "\n",
+    "Le point à retenir : sur nos 8 facteurs, **la moitié jouait contre le régime** et une seule jouait pour. Un composite également pondéré hérite donc de ce biais de régime — ce que la section suivante mesure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2b. Le piège look-ahead des données fondamentales\n",
+    "\n",
+    "Avant de lire le code, une mise en garde qui concerne **toute stratégie à fondamentaux** : les ratios ne sont pas disponibles le jour où la période comptable se clôt. Une entreprise publie son trimestre avec 4 à 10 semaines de délai ; les `operation_ratios` et `valuation_ratios` de QuantConnect matérialisent ce délai (données **laguées et polarisées** : le ratio du T4 2021 n’entre dans l’univers que lorsqu’il est effectivement publié, début 2022).\n",
+    "\n",
+    "Le piège du look-ahead se glisse quand on reconstruit soi-même les z-scores **hors de l’engine** : calculer le composite du 31 décembre avec les ratios « de l’exercice 2021 », c’est utiliser en décembre une information que le marché n’a connue qu’en février. Le backtest devient magique — et faux. Trois réflexes :\n",
+    "\n",
+    "1. **Dater l’information, pas la période** : chaque facteur doit être horodaté par sa **date de publication**, jamais par sa période de référence.\n",
+    "2. **Vérifier la source** : l’API `fundamentals` de LEAN gère ce lag pour vous quand on la consomme depuis l’algorithm (`self.fundamentals` au rebalancement) ; un export CSV reconstruit à la main, non.\n",
+    "3. **Le test de survie** : si votre backtest à fondamentaux affiche un Sharpe > 1.5 là où la littérature académique mesure 0.3-0.5, suspectez d’abord le look-ahead avant de vous féliciter.\n",
+    "\n",
+    "C’est aussi ce qui explique en partie la modestie du Sharpe final (0.227) : la version **honnête** d’un composite value — sans information d’avance, avec les délais de publication réels — est structurellement moins brillante qu’un prototype qui triche sans le savoir."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 3. Le code QC Cloud\n",
     "\n",
     "La stratégie `FundamentalZScoreAlgorithm` (projet QC `31932810`) :\n",
@@ -171,11 +272,11 @@
     "        self.set_start_date(2015, 1, 1)\n",
     "        self.set_end_date(2024, 12, 31)\n",
     "        self.set_cash(100_000)\n",
-    "        \n",
+    "\n",
     "        # 8 facteurs fondamentaux\n",
     "        self._factor_names = [\n",
     "            \"revenue_growth\", \"gross_margin\", \"roe\", \"op_margin\",\n",
-    "            \"pe_ratio\", \"book_yield\", \"earning_yield\", \"fcf_yield\",\n",
+    "            \"pe_ratio\", \"book_value_yield\", \"earning_yield\", \"fcf_yield\",\n",
     "        ]\n",
     "        # Sélection : top 50 par liquidité, puis top 10 par Z-Score composite\n",
     "        self._liquid_universe_size = 50\n",
@@ -187,7 +288,12 @@
     "2. Extraction des 8 fondamentaux → matrice $50 \\times 8$.\n",
     "3. Z-Score par colonne (inversion du P/E).\n",
     "4. Composite = moyenne des Z-Scores.\n",
-    "5. Top 10 → équipondérée, rééquilibrage mensuel."
+    "5. Top 10 → équipondérée, rééquilibrage mensuel.\n",
+    "\n",
+    "Deux détails d’implémentation qui comptent dans les résultats :\n",
+    "\n",
+    "- **Le filtrage des données manquantes** : un actif dont un facteur est indisponible au rebalancement est **exclu du mois** plutôt que comblé — un `fillna(0)` silencieux fabriquerait un z-artefact (un zéro n’est jamais neutre une fois normalisé : c’est une note de « moyenne » mensongère).\n",
+    "- **L’univers liquide recalculé chaque mois** : le top 50 par dollar volume n’est pas figé ; les entrées/sorties créent du turnover, et donc des frais, que le net de la performance intègre."
    ],
    "id": "cell-353b31af"
   },
@@ -218,6 +324,10 @@
     "\n",
     "**PSR 0.8%** : le Probabilistic Sharpe Ratio est proche de zéro. Cela signifie que le Sharpe observé (0.227) n’est **statistiquement pas distinguishable de zéro**. Le signal est du bruit, pas de l’alpha.\n",
     "\n",
+    "#### Le PSR en une phrase\n",
+    "\n",
+    "Le PSR (Bailey & López de Prado) estime la **probabilité que le Sharpe vrai soit positif**, compte tenu du Sharpe observé, de la longueur de l’échantillon (2516 jours) et de la forme de la distribution des rendements (skew et kurtosis — les deux pénalisent). Ici 0.8 % : même en faveur du doute statistique, il y a moins d’une chance sur cent que cette stratégie ait un véritable edge positif sur la période. C’est le genre de chiffre qui doit **arrêter** un déploiement, pas le faire attendre : à l’inverse d’un Sharpe élevé mais mesuré sur 60 jours (échantillon trop court), ici l’échantillon est long — c’est le signal lui-même qui est absent.\n",
+    "\n",
     "> **Conclusion** : la stratégie fonctionne en théorie (value factor académiquement valide), mais **échoue en pratique** sur cette décennie spécifique. C’est un cas d’école du risque de **régime dependency**."
    ],
    "id": "cell-2674a6e6"
@@ -228,7 +338,9 @@
    "source": [
     "### Exercice 3 : Proposer une amélioration régime-aware\n",
     "\n",
-    "Une stratégie value ne fonctionne pas dans tous les régimes de marché. Proposez un mécanisme simple pour désactiver le signal value quand le régime est défavorable."
+    "Une stratégie value ne fonctionne pas dans tous les régimes de marché. Proposez un mécanisme simple pour désactiver le signal value quand le régime est défavorable.\n",
+    "\n",
+    "**Structure attendue** : (1) un **indicateur de régime** mesurable (le squelette suggère le rendement relatif SPY vs VTV sur 252 jours) ; (2) une **règle de décision** avec seuil — pensez à l’hystérésis pour éviter les allers-retours au voisinage du seuil ; (3) l’**action** sur le portefeuille : désactivation brutale, ou gradation de l’exposition ? La correction guidée après la cellule détaille chacun de ces trois choix et leurs limites."
    ],
    "id": "cell-dad1694a"
   },
@@ -261,13 +373,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Correction guidée : un filtre de régime minimal\n",
+    "\n",
+    "Le mécanisme attendu tient en trois ingrédients :\n",
+    "\n",
+    "1. **Un spread relatif** : rendement de SPY sur `lookback` jours moins rendement d’un proxy value (VTV). Le niveau absolu du marché ne dit rien du régime — c’est l’**écart** growth−value qui le mesure.\n",
+    "2. **Un seuil avec hystérésis** : désactiver le signal value quand le spread dépasse un seuil haut (régime growth confirmé), le réactiver quand il repasse sous un seuil bas plus faible. Sans hystérésis, un régime frontalier ferait entrer/sortir la stratégie chaque semaine — coûts de transaction et whipsaw.\n",
+    "3. **Une action de gradation** : plutôt qu’un on/off binaire, réduire la pondération du composite value et la basculer sur le benchmark — le filtre devient une exposition modulée, pas un interrupteur.\n",
+    "\n",
+    "Deux limites à garder en tête (elles sont celles de tout filtre de régime) : le lookback 252 jours **retarde** le basculement d’environ un trimestre (le régime de mars 2020 serait détecté en été) ; et le filtre optimisé a posteriori sur 2015-2024 surfit par construction — il faut le valider sur une période hors échantillon, ou l’accepter comme garde-fou conservateur plutôt que comme source d’alpha."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 5. Leçon principale : Le value n’est pas un signal universel\n",
     "\n",
     "### Points clés\n",
     "\n",
     "1. **Le value factor est régime-dépendant** : il fonctionne sur de longues périodes (Fama-French, 1992-2020) mais peut sous-performer pendant une décennie entière.\n",
     "\n",
-    "2. **Le Z-Score composite ne corrige pas le problème** : normaliser des fondamentaux ne change pas le fait que le marché préfère la croissance à la valeur comptable.\n",
+    "2. **Le Z-Score composite ne corrige pas le problème** : normaliser des fondamentaux ne change pas le fait que le marché préfère la croissance à la valeur comptable. Le composite protège des value traps (cf. l’exemple résolu : le P/E le plus bas ne gagne pas), pas des régimes hostiles à toute la famille value.\n",
     "\n",
     "3. **Le PSR est un filtre essentiel** : un Sharpe de 0.227 avec PSR < 1% = signal non significatif. Toujours vérifier la **significativité statistique** avant de déployer.\n",
     "\n",
@@ -275,13 +402,19 @@
     "\n",
     "5. **Les fondamentaux traditionnels** (P/E, book value) sous-évaluent les entreprises à actifs incorporels dominants (tech, plateforme, IA).\n",
     "\n",
+    "6. **Les données fondamentales sont laguées** : la date de publication prime sur la période de référence (section 2b) — un backtest value qui brille trop a probablement un look-ahead.\n",
+    "\n",
+    "### Positionnement dans la série\n",
+    "\n",
+    "Ce notebook est le pendant **fondamental** des Cloud-01 à Cloud-07 orientés prix/sentiment : il montre la même discipline de mesure (Sharpe/PSR/MaxDD face au benchmark) appliquée à une famille de signaux différente — et le verdict négatif honnête fait partie de l’enseignement. Les filtres de régime esquissés à l’Exercice 3 sont approfondis dans `QC-Py-28-Market-Regime-Detection`.\n",
+    "\n",
     "### Pour aller plus loin\n",
     "\n",
     "- **Fama-French 5-factor model** : ajouter size, profitability, investment aux facteurs value et marché.\n",
     "- **Regime detection** : utiliser le momentum relatif (growth vs value ETFs) comme filtre.\n",
     "- **Dynamic weighting** : adapter l’allocation aux régimes détectés (value en régime value, growth en régime growth).\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "[<< Sommaire QC](../README.md) | [Précédent : QC-Py-Cloud-07-TemporalCNN <<](./QC-Py-Cloud-07-TemporalCNN.ipynb)"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-08-ValueFactor-ZScore.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-08-ValueFactor-ZScore.ipynb
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -346,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
## enrich(qc): densite QC-Py-Cloud-08-ValueFactor-ZScore 785 -> 1192 c/cell

Grain: MED/notebook-python -- lane myia-po-2027:CoursIA -- prev: LIGHT/ledger #14563

### Périmètre

Enrichissement pédagogique du notebook le plus sous-dense de la série Cloud (785 c/cell, loin sous le seuil 1200 du pool #11601) : +6 cellules, 3 cellules existantes étendues. 12 → 18 cellules, 9 428 → 21 456 chars.

### Ajouts (6 cellules nouvelles)

| Cellule | Contenu |
|---|---|
| md intro démo (après Exo 1) | Transition « Exemple résolu » vers la démonstration numérique. |
| **code démo exécuté** (exec 4) | Mini-univers seedé 8 actifs × 4 facteurs (ordres de grandeur hétérogènes volontaires) : Z-Score par colonne, inversion P/E, composite, classement complet rendu. |
| md interprétation | Ancrée aux valeurs réelles de la sortie : Hotel +0.876 domine ; **Alpha, le P/E le plus bas (9.6), ne finit qu'à −0.045** — le composite corrige le value trap mono-critère ; rôle de la normalisation. |
| md section 2b | **Le piège look-ahead des données fondamentales** : lag/polarisation des ratios QC, dater l'information par publication (pas par période), le test de survie « Sharpe > 1.5 à fondamentaux = suspectez le look-ahead ». |
| md correction Exo 2 | Classement des 8 facteurs par famille en régime growth (4 pénalisés / 3 neutres / 1 favorisé), colinéarité P/E ↔ earning yield. |
| md correction Exo 3 | Filtre de régime en 3 ingrédients (spread SPY−VTV, hystérésis, gradation) + limites (retard 252 j, surfit a posteriori). |

### Extensions in place (markdown-only, sources code intactes)

- **§1 Concept** : pourquoi normaliser (échelles hétérogènes, P/E en dizaines vs marge en dixièmes), winsorisation ±3, normalisation relative à l'univers.
- **§2 Piège value** : mécanisme de **duration** (value = flux proches, growth = flux lointains — les taux bas paient la duration longue), repli 2022.
- **§4 Résultats** : le PSR en une phrase (Bailey & López de Prado — probabilité que le Sharpe vrai soit > 0 ; ici 0.8 % sur 2516 jours = le signal est absent, pas jeune).
- **Énoncés Exo 1/2/3** : indices méthodologiques (nanmean/nanstd, structure de réponse attendue).
- **§3 Code QC** : filtrage des données manquantes (exclusion du mois vs fillna(0) mensonger), univers liquide recalculé.
- **§5 Leçon** : point 6 ajouté (données laguées), positionnement dans la série (pendant fondamental des Cloud-01-07, verdict négatif honnête, renvoi QC-Py-28).

### Validation

| Étape | Résultat |
|---|---|
| Cellule démo | Exécutée réellement (exec_count 4, stdout 961 chars, subprocess venv) — valeurs de l'interprétation = valeurs de la sortie, vérifiées |
| Cellules code existantes | **Intactes** (markdown-only ailleurs, règle C.3 : aucune re-exec requise) ; stubs exercices inchangés |
| C.1 | 0 hit `raise NotImplementedError`/`assert False`/`1/0` dans le diff |
| Hygiène | 0 bannière TOOL_FAILURE / chemin machine dans le diff |
| Exercices | 3 exercices conservés (pas de 4e) ; corrections guidées APRÈS chaque cellule stub (conforme cell-interpretation-ordering) |
| Consecutive code cells | Aucune paire de code consécutives ajoutée (md entre l'Exo 1 et la démo) |
| Round-trip JSON | OK (indent=1, ensure_ascii=False), vérifié avant chaque passe |
| Pre-commit hooks | (exécutés au commit) |

See #11601
