### PR TITLE
enrich(tweety,#11601): densite Tweety-2c-FOL-Csharp 574 -> 740 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
@@ -16,7 +16,7 @@
     "[Tweety-2b-Semantics-Csharp](Tweety-2b-Semantics-Csharp.ipynb) (mondes possibles, conséquence sémantique) ·\n",
     "**Tweety-2c-FOL (ce notebook)**.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs pédagogiques\n",
     "\n",
@@ -447,7 +447,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "m633793",
    "metadata": {},
    "source": [
     "## 4 — Raisonnement : le syllogisme\n",
@@ -459,9 +458,19 @@
     "l'univers de Herbrand (les constantes apparaissant dans la base) et teste les formules sur les\n",
     "interprétations possibles. C'est complet mais exponentiel — adapté à de petites bases pédagogiques.\n",
     "\n",
+    "**Pourquoi énumérer seulement Herbrand suffit-il ?** Le théorème de Herbrand garantit qu'une base\n",
+    "FOL est insatisfiable si et seulement si un ensemble **fini d'instances ground** (formules sans\n",
+    "variable, obtenues en substituant les constantes aux variables) l'est déjà. Le raisonneur peut donc\n",
+    "se limiter aux interprétations sur l'univers de Herbrand — ici `{Socrate, Platon}` — sans inventer\n",
+    "d'individus extérieurs. Le prix de cette généralité se chiffre immédiatement : avec 2 constantes et\n",
+    "2 prédicats unaires, il y a 4 atomes ground possibles (`Homme(Socrate)`, `Homme(Platon)`,\n",
+    "`Mortel(Socrate)`, `Mortel(Platon)`) et donc **2⁴ = 16 interprétations** à explorer. Chaque constante\n",
+    "ou prédicat ajouté double ou quadruple ce compte : sur une base réelle (centaines de constantes,\n",
+    "prédicats d'arité 2+), l'énumération explose exponentiellement — c'est la limite structurelle de\n",
+    "cette méthode, formalisée en section 5.\n",
+    "\n",
     "> **Syllogisme classique.** Des prémisses `∀X (Homme(X) ⇒ Mortel(X))` et `Homme(Socrate)`,\n",
-    "> on infère `Mortel(Socrate)`. En termes de conséquence logique : **KB ⊨ Mortal(Socrates)**.\n",
-    "\n"
+    "> on infère `Mortel(Socrate)`. En termes de conséquence logique : **KB ⊨ Mortal(Socrates)**."
    ]
   },
   {
@@ -627,6 +636,21 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lecture des deux réponses. L'**asymétrie** `∃X Mortel(X) → true` / `∀X Mortel(X) → false` est\n",
+    "instructive : la première est portée par un **témoin** (Socrate suffit — le fait `Homme(Socrate)`\n",
+    "plus l'axiome universel produit `Mortel(Socrate)`, et le lemme d'introduction existentielle fait\n",
+    "le reste), tandis que la seconde exigerait que **tous** les individus de l'univers de Herbrand\n",
+    "soient mortels — or la base ne dit rien de `Platon` (aucun `Homme(Platon)` dans `kb`), et une seule\n",
+    "interprétation de Herbrand où `Mortel(Platon)` est faux suffit à casser l'universel. Retenez la\n",
+    "règle de lecture : **l'existential est facile à prouver (un témoin), l'universel est facile à\n",
+    "réfuter (un contre-exemple)** — et symétriquement difficile dans l'autre sens. C'est exactement\n",
+    "cette asymétrie qui rend le FOL semi-décidable (section 5)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m359571",
    "metadata": {},
    "source": [
@@ -697,10 +721,72 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lecture des trois réponses. `Mortel(Socrate)` et `Mortel(Platon)` : le syllogisme se propage à\n",
+    "chaque fait `Homme(·)` ajouté — le raisonner **généralise** l'axiome universel à chaque constante\n",
+    "de l'univers, par unification. La troisième requête est la plus intéressante : `∃X (Grec(X) ∧\n",
+    "Mortel(X))` vaut `true` **parce que le témoin est Socrate**, cumulant `Grec(Socrate)` (fait) et\n",
+    "`Mortel(Socrate)` (inférence). Le test de contrôle mental : retirez `Grec(Socrate)` de la base —\n",
+    "l'existential retombe à `false`, alors même que tous les mortels sont toujours là. La conjonction\n",
+    "sous quantificateur est donc **plus exigeante** que la somme de ses parties : `KB ⊨ ∃X Grec(X)` et\n",
+    "`KB ⊨ ∃X Mortel(X)` peuvent être vrais ensemble sans que `KB ⊨ ∃X (Grec(X) ∧ Mortel(X))` le soit —\n",
+    "les deux témoins peuvent être des individus différents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 — Sémantique ouverte, complexité, et ce que FOL ne décide pas\n",
+    "\n",
+    "### 5.1 Monde ouvert : le `false` du raisonner n'est pas un « non »\n",
+    "\n",
+    "Le contrôle négatif de la section 4.1 mérite sa généralisation. En logique du premier ordre, une\n",
+    "base de croyances fonctionne en **monde ouvert** (*Open World Assumption*) : ce qui n'est pas\n",
+    "démontrable est **inconnu**, jamais faux. Ce choix s'oppose à l'hypothèse du monde fermé (*Closed\n",
+    "World Assumption*) des bases de données : si une ligne `Mortel(Platon)` est absente d'une table\n",
+    "SQL, le système conclut « Platon n'est pas mortel » ; face à la même lacune, `SimpleFolReasoner`\n",
+    "répond `false` à `KB ⊨ Mortel(Platon)` — c'est-à-dire « pas conséquence », et répond **aussi**\n",
+    "`false` à `KB ⊨ ¬Mortel(Platon)`. Aucun des deux n'est connu. Le FOL est conçu pour raisonner sur\n",
+    "des connaissances **incomplètes par nature** (il peut exister des mortels que la base ne nomme\n",
+    "pas) ; une base de données est conçue pour gérer des états **complets par convention**. Confondre\n",
+    "les deux sémantiques est l'erreur classique du débutant : importer un dump SQL dans un raisonner\n",
+    "FOL et s'attendre à des réponses par négation échoue systématiquement.\n",
+    "\n",
+    "### 5.2 Le prix de la généralité : exponentiel en pratique, indécidable en théorie\n",
+    "\n",
+    "Deux limites emboîtées. En **pratique**, l'énumération de Herbrand (section 4) coûte\n",
+    "`2^(nombre d'atomes ground)` — `SimpleFolReasoner` est borné aux petites bases pédagogiques ; les\n",
+    "raisonneurs industriels n'énumèrent pas, ils **dérivent** par résolution + unification (le\n",
+    "mécanisme entrevu en 2.2), ce qui évite d'explorer tout l'espace d'interprétations mais ne fait\n",
+    "qu'atténuer l'explosion. En **théorie**, le problème de fond est plus grave : la validité FOL est\n",
+    "**semi-décidable** (théorème de Church-Turing, 1936). Si une formule est valide, une procédure\n",
+    "correcte la prouvera en temps fini ; si elle ne l'est pas, la même procédure peut boucler\n",
+    "**indéfiniment** sans jamais répondre. L'asymétrie ∃/∀ de la section 4.2 en est la manifestation\n",
+    "concrète : prouver un existential demande un témoin (recherche finie), réfuter un universel\n",
+    "demande l'absence de contre-exemple sur un domaine potentiellement infini — aucune machine ne\n",
+    "peut certifier cette absence en général. C'est pourquoi la question « cette KB est-elle\n",
+    "consistante ? » n'a pas d'algorithme général qui termine toujours — et pourquoi l'exercice 3\n",
+    "(détection d'inconsistance) travaille sur un cas où le raisonner répond vite : la contradiction\n",
+    "y est posée en faits **ground**, sans quantificateur à instancier.\n",
+    "\n",
+    "### 5.3 Et ensuite\n",
+    "\n",
+    "Ce notebook couvre la syntaxe FOL et le raisonnement sémantique par énumération. Trois suites\n",
+    "naturelles dans la série : `Tweety-3-Advanced-Logics-Csharp` (logiques modales et conditionnelles,\n",
+    "qui restreignent la quantification pour regagner de la décidabilité), le notebook\n",
+    "`Tweety-5-Abstract-Argumentation-Csharp` (le FOL y devient le langage des arguments, la contradiction cesse d'être\n",
+    "une pathologie pour devenir l'objet d'étude), et l'exercice 3 ci-dessous qui montre pourquoi\n",
+    "l'inconsistance doit être traquée **avant** tout raisonnement sérieux."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m967528",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercices\n",
     "\n",
@@ -761,6 +847,27 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Correction guidée — Exercice 1\n",
+    "\n",
+    "La solution suit cinq gestes, tous déjà rencontrés : (1) `new Predicate(\"Chat\", 1)` et\n",
+    "`new Predicate(\"Mammifere\", 1)` ; (2) `new Constant(\"Felix\")` ; (3) l'implication\n",
+    "`Chat(X) ⇒ Mammifere(X)` par `new Implication` sur deux `FolAtom` partageant la **même** variable\n",
+    "`X` — c'est le partage de variable qui porte le sens de la règle ; (4) le quantificateur\n",
+    "`new ForallQuantifiedFormula(impl, X)` ; (5) `FolBeliefSet` + `SimpleFolReasoner.query`. L'erreur\n",
+    "type : omettre le geste (4) et ajouter l'implication **non quantifiée** à la base. Qu'observerait-on\n",
+    "alors ? L'implication nue contient une variable libre — l'énumération de Herbrand l'instancie sur\n",
+    "`Felix`, et la requête `Mammifere(Felix)` répond quand même `true`. La base\n",
+    "« fonctionne » sans l'universel parce que l'univers est réduit à un seul individu. Le bug est\n",
+    "invisible ici et mortel dès qu'une seconde constante entre en scène : ajoutez `Chat(Milou)` — sans\n",
+    "le `∀X`, rien ne pousse à conclure `Mammifere(Milou)`. C'est le cas d'école pour comprendre que\n",
+    "**le quantificateur n'est pas une décoration syntaxique** : c'est lui qui étend la règle à\n",
+    "l'univers entier."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m561725",
    "metadata": {},
    "source": [
@@ -806,6 +913,29 @@
     "object formuleGrandParent = null;  // TODO etudiant\n",
     "Console.WriteLine(\"GrandParent = \" + (formuleGrandParent?.ToString() ?? \"Exercice a completer\"));\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Correction guidée — Exercice 2\n",
+    "\n",
+    "L'emboîtement : la formule n'introduit **pas** de prédicat `GrandParent` dédié — elle définit la\n",
+    "relation transitive de grand-parenté par pure contrainte logique sur `Parent`. Trois\n",
+    "`ForallQuantifiedFormula` emboîtés, du plus interne (lie `X`) au plus\n",
+    "externe (lie `Z`) : `∀Z(∀Y(∀X(…)))`. Deux points de sémantique à ne pas rater. **(a) L'ordre\n",
+    "importe — sauf entre universels** : `∀X ∀Y φ` et `∀Y ∀X φ` sont équivalents (une succession de\n",
+    "universels commute), donc les trois emboîtements peuvent s'écrire dans n'importe quel ordre *entre\n",
+    "eux*. Ce privilège s'arrête aux quantificateurs homogènes : `∀X ∃Y Parent(X,Y)` (« chacun a un\n",
+    "parent ») et `∃Y ∀X Parent(X,Y)` (« quelqu'un est le parent de tous ») disent des choses\n",
+    "**radicalement différentes** — dans le second, le même témoin `Y` doit servir tous les `X`.\n",
+    "L'exercice n'utilise que des universels, mais dès que vous mélangerez (section 3), retenez :\n",
+    "**le quantificateur externe choisit le premier**, et l'interne choisit **en connaissant** le choix\n",
+    "de l'externe. **(b) La forme prénexe** : toute formule FOL est équivalente à une formule où tous\n",
+    "les quantificateurs sont en tête (`∀X ∀Y ∀Z (…)` — exactement la forme demandée ici) ; la\n",
+    "conversion (déplacer les quantificateurs à travers ¬, ∧, ∨ en utilisant les dualités de De Morgan\n",
+    "vues en 3.2) est standard mais **ne commute pas les quantificateurs entre eux**."
    ]
   },
   {
@@ -858,10 +988,30 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Correction guidée — Exercice 3\n",
+    "\n",
+    "La mécanique : KB = {`Mortel(Socrate)`, `¬Mortel(Socrate)`}, puis `query(kb, Homme(Socrate))` sur\n",
+    "un prédicat qu'aucun axiome ne mentionne — et la réponse est `true`. **Pourquoi l'énumération de\n",
+    "Herbrand confirme-t-elle l'explosion ?** `KB ⊨ φ` signifie « toute interprétation qui satisfait KB\n",
+    "satisfait φ ». Une base contradictoire n'a **aucune** interprétation qui la satisfait — l'ensemble\n",
+    "des modèles de KB est vide, et « tout élément de l'ensemble vide vérifie φ » est trivialement vrai\n",
+    "(c'est la vacuité de l'implication sur le vide). *Ex falso quodlibet* : du faux, tout suit. La\n",
+    "leçon opérationnelle dépasse l'exercice : une KB inconsistante **prouve tout**, y compris les\n",
+    "énoncés absurdes — un raisonner branché sur une base contradictoire est un générateur de\n",
+    "confiance fausse. C'est pourquoi tout système sérieux (moteur de règles métier, agent\n",
+    "dialoguant, base d'arguments) commence par un test de consistance, et pourquoi la série\n",
+    "`Tweety-5` (argumentation) retourne le problème : plutôt que d'éradiquer la contradiction, elle en\n",
+    "fait l'objet d'étude — deux arguments opposés ne font pas exploser le système, ils s'affrontent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m641676",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",


### PR DESCRIPTION
## enrich(tweety): densite Tweety-2c-FOL-Csharp 574 -> 740 c/cell

Grain: MED/notebook-dotnet -- lane myia-po-2027:CoursIA -- prev: LIGHT/ledger #14563

### Périmètre

Enrichissement pédagogique markdown-only du notebook .NET le plus sous-dense de la famille SymbolicAI/Tweety (574 c/cell). 30 → 36 cellules (+6 md), sans toucher aucune cellule code.

### Ajouts (6 cellules md)

| Cellule | Contenu |
|---|---|
| Interprétation 4.2 | L'asymétrie `∃ vrai / ∀ faux` : témoin unique vs contre-exemple sur tout l'univers de Herbrand — et pourquoi cette asymétrie rend le FOL semi-décidable. |
| Interprétation 4.3 | Lecture ancrée des 3 réponses de `kb2` + test de contrôle (retirer `Grec(Socrate)`) ; la conjonction sous quantificateur est plus exigeante que la somme des parties (témoins distincts). |
| **Section 5.1** | **Monde ouvert vs monde fermé** : le `false` du raisonner = « pas conséquence », jamais « faux » ; SQL (CWA) vs FOL (OWA) ; l'erreur classique du dump SQL dans un raisonner FOL. |
| **Section 5.2** | **Le prix de la généralité** : Herbrand en 2^(atomes ground) (décompte concret 2⁴=16 sur la KB du notebook), semi-décidabilité (Church-Turing 1936), résolution+unification vs énumération. |
| Section 5.3 | Renvois : Tweety-3 (décidabilité regagnée), Tweety-5 (la contradiction comme objet d'étude), Exercice 3 (pourquoi la consistance précède tout). |
| Corrections guidées ×3 | Exo 1 : l'implication non quantifiée qui « marche » sur un univers à 1 constante et casse à la 2e (le quantificateur n'est pas décoratif). Exo 2 : `∀X∀Y` commutent entre eux mais `∀X∃Y ≠ ∃Y∀X` (chacun a un parent vs quelqu'un est parent de tous), forme prénexe. Exo 3 : pourquoi l'énumération confirme l'explosion (vacuité de l'implication sur l'ensemble vide de modèles), portée opérationnelle. |

### Extension in place (1 cellule)

**§4 intro** : le théorème de Herbrand étoffé — pourquoi l'univers de Herbrand suffit (instances ground finies), dénombrement conduit sur la KB du notebook (4 atomes ground → 16 interprétations), et le lien vers la limite de la section 5.2.

### Validation

| Étape | Résultat |
|---|---|
| Cellules code | **Intactes** (markdown-only, règle C.3 : aucune re-exec requise) ; séquence exec [1..15] inchangée |
| C.1 | 0 hit `raise NotImplementedError`/`assert False`/`1/0`/`throw new` dans le diff |
| Stubs exercices | Inchangés (les corrections guidées suivent chaque stub, structure ≠ solution) |
| Interprétations | Placées APRÈS les cellules qu'elles interprètent (cell-interpretation-ordering) |
| Round-trip JSON | Vérifié avant édition (indent=1, ensure_ascii=False) |
| Exercices | 3 exercices conservés, pas de 4e |
| Consecutive code cells | Aucune paire ajoutée (md insérées entre code existants) |

See #11601
