### PR TITLE
fix(guards,#14590): SIGPIPE-safe detect_markdown_rendering + --max-findings remplace | head || true

### DIFF
--- a/.github/workflows/markdown-rendering-guard.yml
+++ b/.github/workflows/markdown-rendering-guard.yml
@@ -130,4 +130,4 @@ jobs:
         if: always()
         run: |
           python scripts/notebook_tools/detect_markdown_rendering.py \
-                 --closure --quarto-yml _quarto.yml MyIA.AI.Notebooks | head -8 || true
+                 --closure --quarto-yml _quarto.yml MyIA.AI.Notebooks --max-findings 8

--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -107,6 +107,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -1402,6 +1403,8 @@ def main(argv=None) -> int:
                          "#11630 for the rationale.")
     ap.add_argument("--quarto-yml", type=Path, default=Path("_quarto.yml"),
                     help="path to the Quarto project YAML (default: ./_quarto.yml)")
+    ap.add_argument("--max-findings", type=int, default=200, metavar="N",
+                    help="cap the human-readable findings listing (default: 200)")
     ap.add_argument("--selfcheck", action="store_true",
                     help="run the embedded positive/negative controls of the "
                          "yaml_block_open_no_close rule (BOTH observed forms: "
@@ -1484,13 +1487,14 @@ def main(argv=None) -> int:
         for rule in sorted(by_rule):
             print(f"  {RULE_SEVERITY.get(rule, '?'):>5} {rule}: {by_rule[rule]}")
         shown = new_findings if baseline else findings
+        max_findings = max(0, args.max_findings)
         print()
-        for f in shown[:200]:
+        for f in shown[:max_findings]:
             flag = "NEW " if (baseline and f["hash"] not in baseline) else ""
             print(f"  {flag}{f['severity'].upper():>5} {f['file']} cell#{f['cell']} [{f['rule']}]")
             print(f"        {f['evidence']}")
-        if len(shown) > 200:
-            print(f"  ... {len(shown) - 200} more")
+        if len(shown) > max_findings:
+            print(f"  ... {len(shown) - max_findings} more")
 
     # ---- exit code --------------------------------------------------------------
     if args.check:
@@ -1507,4 +1511,15 @@ def main(argv=None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    # SIGPIPE-safe exit (#14590): when the consumer (head, less, |) closes the
+    # pipe mid-listing, that is not a scan error. Redirect stdout to devnull so
+    # the interpreter's final flush does not re-raise BrokenPipeError
+    # ("Exception ignored in: <_io.TextIOWrapper ...>"), then exit 141
+    # (128 + SIGPIPE), the shell convention.
+    try:
+        rc = main()
+    except BrokenPipeError:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        rc = 141
+    raise SystemExit(rc)

--- a/scripts/tests/test_detect_markdown_rendering_repair.py
+++ b/scripts/tests/test_detect_markdown_rendering_repair.py
@@ -75,3 +75,67 @@ def test_toute_entree_de_la_table_est_une_regle_connue(rule):
     regle du detecteur serait un conseil pour un defaut qui n'est jamais
     signale — invisible, donc jamais corrige."""
     assert rule in dmr.RULE_SEVERITY
+
+
+# --- #14590 : sortie SIGPIPE-safe + --max-findings ---------------------------
+
+def _run_driver(tmp_path):
+    """Execute un driver dans un processus isole : le wrapper __main__ fait un
+    dup2 de stdout vers devnull, on ne veut pas empoisonner le fd 1 de la
+    session pytest."""
+    import subprocess
+    driver = tmp_path / "driver_14590.py"
+    driver.write_text(
+        "import sys\n"
+        f"sys.path.insert(0, r'{pathlib.Path(dmr.__file__).parent}')\n"
+        "import detect_markdown_rendering as d\n"
+        "def boom(): raise BrokenPipeError()\n"
+        "d.main = boom\n"
+        "src = open(d.__file__, encoding='utf-8').read()\n"
+        "import textwrap\n"
+        "block = textwrap.dedent(src.split('if __name__ == \"__main__\":', 1)[1])\n"
+        "exec(block, d.__dict__)\n",
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        [sys.executable, str(driver)], capture_output=True, text=True, timeout=60
+    )
+
+
+def test_tube_ferme_rend_141_sans_traceback(tmp_path):
+    """Un appelant qui borne la sortie (| head) fermait le tube APRES le
+    verdict et tuait le script sur BrokenPipeError non gere (#14590, log CI
+    du 2026-09-04 : traceback dans la boucle d'affichage des findings).
+    Le wrapper doit rendre 141 (128 + SIGPIPE) -- pas une traceback, et pas
+    non plus le 'Exception ignored' du flush final."""
+    proc = _run_driver(tmp_path)
+    assert proc.returncode == 141, proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert "Exception ignored" not in proc.stderr
+
+
+def test_max_findings_remplace_le_cap_dur(tmp_path):
+    """--max-findings N doit exister et cappeer la liste des findings :
+    le workflow appelait | head -8, ce qui masquait tout (y compris les
+    plantages) derriere || true. Un cap interne rend le tube inutile."""
+    import json as _json
+    import subprocess
+    nb_dir = tmp_path / "nbs"
+    nb_dir.mkdir()
+    for i in range(3):
+        nb = {
+            "cells": [{"cell_type": "markdown", "metadata": {},
+                       "source": ["---\n", "title: unclosed block\n"]}],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+        }
+        (nb_dir / f"fixture_{i}.ipynb").write_text(
+            _json.dumps(nb), encoding="utf-8")
+    script = pathlib.Path(dmr.__file__)
+    proc = subprocess.run(
+        [sys.executable, str(script), "--report", "--max-findings", "2", str(nb_dir)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    finding_lines = [l for l in proc.stdout.splitlines() if "[yaml_block_open_no_close]" in l]
+    assert len(finding_lines) == 2, proc.stdout
+    assert "1 more" in proc.stdout


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: MED/ledger #14578

## Summary

The closure-scan workflow step called the detector through `| head -8 || true`: on a closed pipe the script died on an unhandled `BrokenPipeError` AFTER its verdict (CI log 2026-09-04, PR #14139 — traceback in the findings-listing loop), and the `|| true` masked the crash: the informational step was structurally unable to report anything but success (#14590).

## Changes (3 files, +84/-5)

1. **`detect_markdown_rendering.py`** — SIGPIPE-safe `__main__` wrapper (canonical CPython form from the issue): `BrokenPipeError` -> redirect stdout to devnull (so the interpreter's final flush does not re-raise as `Exception ignored in: <_io.TextIOWrapper ...>`), exit **141** (128 + SIGPIPE). Plus `--max-findings N` (default 200) replacing the hardcoded `[:200]` listing cap.
2. **`markdown-rendering-guard.yml`** — the closure-scan step now caps internally (`--max-findings 8`): no pipe, no `|| true`; the step can report a real failure again. The HARD gate `--check --baseline` call is untouched.
3. **Tests** (`test_detect_markdown_rendering_repair.py`, 2 new): subprocess driver proves the wrapper (rc 141, zero traceback, zero `Exception ignored` — the fd-juggling is isolated from the pytest session); 3-fixture run proves `--max-findings 2` lists exactly 2 findings + `... 1 more`.

## Verification (ubuntu container python:3.12-slim, per the issue's Linux-only reproduction note)

- **Gate parity**: `--check` on a fresh ERROR-level fixture (`yaml_block_open_no_close`) returns **1 on old (origin/main) AND on new** — the blocking gate is unchanged.
- **--max-findings (no pipe)**: 3 fixtures -> exactly 2 finding lines + `... 1 more`, rc 0.
- **EPIPE primitive on this container**: `python3 -c "10000 prints" | head -1` -> `BrokenPipeError: [Errno 32] Broken pipe` traceback, rc 1 (the exact CI signature) — proving the pipe semantics the wrapper handles.
- **Faithful CI-shape control** (full-repo `--closure --quarto-yml _quarto.yml MyIA.AI.Notebooks | head -8`, old vs new, in container): **done — [comment](https://github.com/jsboige/CoursIA/pull/14656#issuecomment-5544600175)**. OLD (origin/main) dies on the closed pipe **after** its verdict with rc 120 (CPython shutdown-on-broken-pipe, the CI signature); NEW renders the same verdict (430 violations, render-list=1191) then exits **141, zero traceback**.
- Local suite: 9 passed (7 preexisting + 2 new).

Closes #14590 (acceptance 1 verified via unit test + container primitive + full-scan CI-shape control; acceptance 2, 3, 4 verified above)

## Test plan

- [ ] CI: markdown-rendering-guard informational step no longer pipes through head; HARD gate still red on real violations
- [x] Full-scan container control comment (old: rc 120 crash after verdict / new: rc 141 clean)

