### PR TITLE
fix(prover,#1453): refresh drifted line fields on calibration DEMOS 39-52

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1390,7 +1390,7 @@ DEMOS = {
     39: {
         "name": "CALIBRATION_CONWAY_NIM_WINNING_345",
         "file": str(CONWAY_NIM_FILE) if CONWAY_NIM_FILE else "",
-        "line": 42,
+        "line": 57,
         "sorry_type": "sorry_replacement",
         "theorem_name": "isWinningNim_345",
         "theorem": "isWinningNim_345",
@@ -1407,7 +1407,7 @@ DEMOS = {
     40: {
         "name": "CALIBRATION_CONWAY_NIM_SUM_SINGLE",
         "file": str(CONWAY_NIM_FILE) if CONWAY_NIM_FILE else "",
-        "line": 46,
+        "line": 61,
         "sorry_type": "sorry_replacement",
         "theorem_name": "nimSum_single",
         "theorem": "nimSum_single",
@@ -1424,7 +1424,7 @@ DEMOS = {
     41: {
         "name": "CALIBRATION_CONWAY_NIM_SUM_SELF",
         "file": str(CONWAY_NIM_FILE) if CONWAY_NIM_FILE else "",
-        "line": 50,
+        "line": 65,
         "sorry_type": "sorry_replacement",
         "theorem_name": "nimSum_self",
         "theorem": "nimSum_self",
@@ -1442,7 +1442,7 @@ DEMOS = {
     42: {
         "name": "CALIBRATION_CONWAY_ANGEL_KING_MOVES",
         "file": str(CONWAY_ANGEL_FILE) if CONWAY_ANGEL_FILE else "",
-        "line": 47,
+        "line": 59,
         "sorry_type": "sorry_replacement",
         "theorem_name": "kingMoves_card",
         "theorem": "kingMoves_card",
@@ -1457,7 +1457,7 @@ DEMOS = {
     43: {
         "name": "CALIBRATION_CONWAY_ANGEL_POWER2",
         "file": str(CONWAY_ANGEL_FILE) if CONWAY_ANGEL_FILE else "",
-        "line": 51,
+        "line": 63,
         "sorry_type": "sorry_replacement",
         "theorem_name": "angelMoves2_card",
         "theorem": "angelMoves2_card",
@@ -1472,7 +1472,7 @@ DEMOS = {
     44: {
         "name": "CALIBRATION_CONWAY_ANGEL_CARD_FORMULA",
         "file": str(CONWAY_ANGEL_FILE) if CONWAY_ANGEL_FILE else "",
-        "line": 58,
+        "line": 69,
         "sorry_type": "sorry_replacement",
         "theorem_name": "angelMoves_card",
         "theorem": "angelMoves_card",
@@ -1488,7 +1488,7 @@ DEMOS = {
     45: {
         "name": "CALIBRATION_CONWAY_DOOMSDAY_LEAP_2000",
         "file": str(CONWAY_DOOMSDAY_FILE) if CONWAY_DOOMSDAY_FILE else "",
-        "line": 25,
+        "line": 31,
         "sorry_type": "sorry_replacement",
         "theorem_name": "isLeapYear_2000",
         "theorem": "isLeapYear_2000",
@@ -1503,7 +1503,7 @@ DEMOS = {
     46: {
         "name": "CALIBRATION_CONWAY_DOOMSDAY_LEAP_1900",
         "file": str(CONWAY_DOOMSDAY_FILE) if CONWAY_DOOMSDAY_FILE else "",
-        "line": 29,
+        "line": 35,
         "sorry_type": "sorry_replacement",
         "theorem_name": "isLeapYear_1900",
         "theorem": "isLeapYear_1900",
@@ -1518,7 +1518,7 @@ DEMOS = {
     47: {
         "name": "CALIBRATION_CONWAY_DOOMSDAY_LEAP_2024",
         "file": str(CONWAY_DOOMSDAY_FILE) if CONWAY_DOOMSDAY_FILE else "",
-        "line": 33,
+        "line": 39,
         "sorry_type": "sorry_replacement",
         "theorem_name": "isLeapYear_2024",
         "theorem": "isLeapYear_2024",
@@ -1533,7 +1533,7 @@ DEMOS = {
     48: {
         "name": "CALIBRATION_CONWAY_DOOMSDAY_CONWAY_DEATH",
         "file": str(CONWAY_DOOMSDAY_FILE) if CONWAY_DOOMSDAY_FILE else "",
-        "line": 38,
+        "line": 44,
         "sorry_type": "sorry_replacement",
         "theorem_name": "dayOfWeek_conway_death",
         "theorem": "dayOfWeek_conway_death",
@@ -1549,7 +1549,7 @@ DEMOS = {
     49: {
         "name": "CALIBRATION_CONWAY_DOOMSDAY_ADD_SEVEN",
         "file": str(CONWAY_DOOMSDAY_FILE) if CONWAY_DOOMSDAY_FILE else "",
-        "line": 43,
+        "line": 49,
         "sorry_type": "sorry_replacement",
         "theorem_name": "dayOfWeek_add_seven",
         "theorem": "dayOfWeek_add_seven",
@@ -1566,7 +1566,7 @@ DEMOS = {
     50: {
         "name": "CALIBRATION_CONWAY_LAS_DIGITS_EXAMPLE",
         "file": str(CONWAY_LOOKANDSAY_FILE) if CONWAY_LOOKANDSAY_FILE else "",
-        "line": 25,
+        "line": 32,
         "sorry_type": "sorry_replacement",
         "theorem_name": "digitsToNat_example",
         "theorem": "digitsToNat_example",
@@ -1581,7 +1581,7 @@ DEMOS = {
     51: {
         "name": "CALIBRATION_CONWAY_LAS_LOOKANDSAY_4",
         "file": str(CONWAY_LOOKANDSAY_FILE) if CONWAY_LOOKANDSAY_FILE else "",
-        "line": 29,
+        "line": 36,
         "sorry_type": "sorry_replacement",
         "theorem_name": "lookAndSay_4",
         "theorem": "lookAndSay_4",
@@ -1597,7 +1597,7 @@ DEMOS = {
     52: {
         "name": "CALIBRATION_CONWAY_LAS_ROUND_TRIP",
         "file": str(CONWAY_LOOKANDSAY_FILE) if CONWAY_LOOKANDSAY_FILE else "",
-        "line": 34,
+        "line": 41,
         "sorry_type": "sorry_replacement",
         "theorem_name": "digitsToNat_natToDigits",
         "theorem": "digitsToNat_natToDigits",


### PR DESCRIPTION
Grain: LIGHT/lean -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Quoi

Refresh des 14 champs `line` des cibles de calibration Conway (DEMOS 39-52, `prover/config.py`) : **14/14 étaient dérivées** par rapport à `origin/main` (3881b766a), mesuré par résolution du nom de déclaration (`theorem|lemma|def|abbrev` + `theorem_name`) dans chaque fichier.

| DEMO | théorème | déclaré | réel | Δ |
|---|---|---:|---:|---:|
| 39 | isWinningNim_345 | 42 | 57 | +15 |
| 40 | nimSum_single | 46 | 61 | +15 |
| 41 | nimSum_self | 50 | 65 | +15 |
| 42 | kingMoves_card | 47 | 59 | +12 |
| 43 | angelMoves2_card | 51 | 63 | +12 |
| 44 | angelMoves_card | 58 | 69 | +11 |
| 45 | isLeapYear_2000 | 25 | 31 | +6 |
| 46 | isLeapYear_1900 | 29 | 35 | +6 |
| 47 | isLeapYear_2024 | 33 | 39 | +6 |
| 48 | dayOfWeek_conway_death | 38 | 44 | +6 |
| 49 | dayOfWeek_add_seven | 43 | 49 | +6 |
| 50 | digitsToNat_example | 25 | 32 | +7 |
| 51 | lookAndSay_4 | 29 | 36 | +7 |
| 52 | digitsToNat_natToDigits | 34 | 41 | +7 |

Cause : les fichiers scaffolding (Nim/Angel/DoomsdayLemmas/LookAndSay) ont reçu docstrings/commentaires après l'écriture des DEMOS (les 4 fichiers diffèrent entre les snapshots où les lignes ont été mesurées et `origin/main`).

## Pourquoi ce n'est pas cosmétique

- `sorry_line` est **fonctionnel en aval** : `_match_intractable_kb` (provers.py:75-95) et le registre honest-sorry matchent par **égalité exacte de ligne** — une dérive sur un fichier ayant des entrées KB ferait silencieusement rater un `DOCUMENTED INTRACTABLE` (ou refuser à faux).
- Le garde P2b #7477 (`_resolve_target_line`, run_prover_bg.py) réconcilie `line` avec la description **seulement si elle porte un marqueur `CURRENT TARGET`** — les descriptions de calibration n'en portent pas : le garde est structurellement no-op sur DEMOS 39-52.
- Le stubber `stub_theorem_proof` (#13907) est épargné (résolution par nom), donc le pré-vol réparé fonctionne — mais les traces et la visée runtime portent les mauvaises coordonnées.

## Preuve

- Re-vérification post-fix : les 14 déclarations résolvent à la ligne rafraîchie (`14/14 OK`, script de mesure par nom).
- `pytest tests/` (harnais) : **746 passed** sur le checkout avec le correctif — zéro régression.
- Smoke run DEMO 39 (post-fix, lanceur racine) : `[BG] LINE 57` puis `[BG] CALIBRATION_STUB theorem=isWinningNim_345 line=57` — **la ligne rafraîchie est consommée par le pré-vol #13907** (`PRE_FILE_SORRY_COUNT 1`, restore byte-exact vérifié `git status` propre, exit 0). Nuance honnête : le workflow a terminé en `provider_outage` (mistral 402, cf commentaire issue) — la validation porte sur la chaîne stub→visée→restore, pas sur des itérations de preuve.

## Suivi suggéré (non inclus — zone claimée po-2027)

La dérive est une **classe** de bug (elle reviendra au prochain edit des fichiers) : une résolution name-first de la ligne cible dans `run_prover_bg.py` (le stubber le fait déjà) l'éliminerait structurellement. `run_prover_bg.py` n'est pas dans les paths claimés, mais le geste touche le comportement du lanceur : suggestion routée vers po-2027 (claim actif `prover/tools.py` + `tests/*`) plutôt qu'implémentée ici.

## Périmètre

1 fichier : `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py` (+14/−14, zéro changement de format).

Tranche du sous-grain « replay du gradient calibration post-#13907 » (claim c.5544510564) — l'EPIC reste ouvert :

See #1453
