### PR TITLE
enrich(tweety,#11601): densite Tweety-3-Dung 576 -> 728 c/cell + 2 fixes theoriques

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
@@ -957,7 +957,7 @@
     "`∅` est admissible partout mais **complète seulement sans argument inattaqué** (comparez les lignes\n",
     "`a → b` et `x ↔ y` — c'est la leçon de l'Exercice 3),\n",
     "`stable ⊆ préférée` *quand des stables existent* (les deux dernières lignes du tableau montrent ce\n",
-    "qui arrive sinon). Les trois garanties de Dung (1985) à retenir : la fondée existe et est unique ;\n",
+    "qui arrive sinon). Les trois garanties de Dung (1995) à retenir : la fondée existe et est unique ;\n",
     "la préférée existe toujours ; la stable n'est garantie nulle part.\n",
     "\n",
     "**Choisir en pratique** : position unique et incontestable → fondée ; énumérer les lectures\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
@@ -17,7 +17,7 @@
     "[Tweety-2c-FOL-Csharp](Tweety-2c-FOL-Csharp.ipynb) (premier ordre) ·\n",
     "**Tweety-3-Dung (ce notebook)**.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs pédagogiques\n",
     "\n",
@@ -561,9 +561,10 @@
     "| **Fondée** | `{}` | Aucun argument n'est inattaqué, donc rien n'entre. Prudence maximale. |\n",
     "| **Stable** | `{x}`, `{y}` | Accepter l'un exclut l'autre. `{}` n'est **pas** stable : un stable doit attaquer tout non-membre, or `{}` n'attaque personne. |\n",
     "| **Préférée** | `{x}`, `{y}` | Maximaux parmi les admissibles. Ici, coïncide avec le stable. |\n",
-    "| **Complète** | `{x}`, `{y}`, `{}` | Comme la préférée **plus `{}`** : l'extension vide est toujours complète (trivialement admissible, elle se défend contre tout… rien). |\n",
+    "| **Complète** | `{x}`, `{y}`, `{}` | Comme la préférée **plus `{}`** : l'extension vide est admissible, et elle est complète ici car aucun argument n'est inattaqué (sur d'autres AF, `{}` cesse d'être complète — l'Exercice 3 le montrera). |\n",
     "\n",
-    "**La cascade d'inclusions canonique** : `fondée ⊆ complète`, et la fondée est la *plus petite* extension complète (ici `{}`). `stable ⊆ complète` quand des stables existent ; `préférée = complète maximale`. C'est cette hiérarchie que les exercices ci-dessous vous demanderont d'explorer sur des AF plus subtils (cycle à trois, auto-attaque).\n"
+    "**La cascade d'inclusions canonique** : `fondée ⊆ complète`, et la fondée est la *plus petite* extension complète (ici `{}`). `stable ⊆ complète` quand des stables existent ; `préférée = complète maximale`. C'est cette hiérarchie que les exercices ci-dessous vous demanderont d'explorer sur des AF plus subtils (cycle à trois, auto-attaque).\n",
+    ""
    ]
   },
   {
@@ -688,7 +689,7 @@
    "id": "m90160",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercices\n",
     "\n",
@@ -698,7 +699,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "m219209",
    "metadata": {},
    "source": [
     "### Exercice 1 — Cycle à trois : stable vs fondée\n",
@@ -707,9 +707,10 @@
     "Affichez l'extension **fondée** et les extensions **stables**.\n",
     "\n",
     "**Question** : combien d'extensions stables obtient-on ? L'extension fondée est-elle vide ? (Indice :\n",
-    "dans un cycle impair sans argument inattaqué, le point fixe fondé ne décolle pas, mais chaque argument\n",
-    "isolé bat la chaîne restante → plusieurs stables.)\n",
-    "\n"
+    "dans un cycle impair sans argument inattaqué, le point fixe fondé ne décolle pas. Pour les stables,\n",
+    "testez chaque candidat un à un : un singleton est stable s'il bat **tous** les non-membres — la\n",
+    "situation est plus subtile que le 2-cycle `x ↔ y` de la section 3.2, où chaque singleton battait\n",
+    "l'unique non-membre.)"
    ]
   },
   {
@@ -742,6 +743,33 @@
     "object nbStables = null;  // TODO etudiant : nombre d'extensions stables (int)\n",
     "Console.WriteLine(\"extensions stables du cycle = \" + (nbStables ?? \"Exercice a completer\"));\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Correction guidée — Exercice 1 : le 3-cycle n'a AUCUNE extension stable\n",
+    "\n",
+    "**Fondée** : `∅`, sans surprise — aucun argument n'est inattaqué, le point fixe ne décolle pas.\n",
+    "\n",
+    "**Stables : zéro.** C'est le résultat qui surprend, alors démontrons-le sur les candidats :\n",
+    "\n",
+    "- **Singletons** : `{p}` est-il stable ? Il doit battre *tous* ses non-membres. `p` attaque `q`…\n",
+    "  mais pas `r` (c'est `r` qui attaque `p`). `r` est non-membre et non battu → `{p}` n'est **pas**\n",
+    "  stable. Symétriquement pour `{q}` et `{r}`.\n",
+    "- **Paires** : `{p,q}` porte l'attaque interne `p → q` → pas *sans conflit*. `{q,r}` et `{r,p}`\n",
+    "  pareil. Aucune paire n'est candidate.\n",
+    "- **L'ensemble plein** `{p,q,r}` n'est pas sans conflit non plus. **Aucun** ensemble sans conflit\n",
+    "  ne bat tout le reste : l'AF n'a **aucune extension stable**.\n",
+    "\n",
+    "L'intuition à retenir : le 2-cycle `x ↔ y` (section 3.2) offrait deux stables parce qu'un singleton\n",
+    "y battait l'*unique* non-membre. Dans un 3-cycle, chaque argument n'en bat qu'un sur deux — le\n",
+    "cycle **impair** est le cas d'école de la non-existence des stables (les cycles *pairs*, eux,\n",
+    "offrent les deux stables alternés : sur `p→q→r→s→p`, `{p,r}` et `{q,s}`). Et c'est exactement pour\n",
+    "ça que la théorie de Dung ne repose **pas** sur la sémantique stable : elle peut ne rien renvoyer\n",
+    "du tout. La **préférée**, elle, existe toujours (au pire `∅`), et la **fondée** existe toujours et\n",
+    "est unique — deux garanties d'existence que la stable n'offre pas."
    ]
   },
   {
@@ -793,18 +821,47 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Correction guidée — Exercice 2 : l'auto-attaque exclut partout\n",
+    "\n",
+    "Le verdict attendu tombe : fondée = `∅`, et `query(af, s)` = `false`. La raison tient en une\n",
+    "définition : une extension doit être **sans conflit**, et un ensemble contenant `s` porte\n",
+    "l'attaque `s → s` — le conflit est *interne à l'argument lui-même*. `s` ne peut donc figurer dans\n",
+    "**aucune** extension, pour **aucune** sémantique (fondée, complète, préférée, stable : toutes\n",
+    "exigent l'absence de conflit interne).\n",
+    "\n",
+    "Deux observations bonus, à vérifier avec `Dump` :\n",
+    "\n",
+    "1. **Aucune extension stable non plus** : le seul candidat, `∅`, devrait battre `s` pour être\n",
+    "   stable — or `∅` n'attaque personne. L'AF à auto-attaque est un deuxième exemple (avec le\n",
+    "   3-cycle de l'Exercice 1) d'inexistence des stables.\n",
+    "2. **Complète = préférée = `{∅}`** : l'extension vide est trivialement admissible (aucun conflit,\n",
+    "   rien à défendre) et complète. C'est le plancher commun de toutes les sémantiques.\n",
+    "\n",
+    "En pratique, l'auto-attaque est la manière la plus économique de rendre un argument inacceptable :\n",
+    "le moteur de raisonnement n'a même pas besoin d'examiner le reste du graphe. Dans les cadres\n",
+    "structurés (Tweety-4, Aspic+), une prémisse contradictoire ou une règle auto-réfutée se ramène\n",
+    "souvent à ce schéma abstrait."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m144582",
    "metadata": {},
    "source": [
-    "### Exercice 3 — Comparer complète et préférée\n",
+    "### Exercice 3 — Complète vs préférée… et le statut de l'extension vide\n",
     "\n",
-    "Sur l'AF `{a → b, a → c}` (où `a` attaque `b` et `c`, mais rien n'attaque `a`), la sémantique\n",
-    "**complète** admet une extension non-maximale en plus de la préférée. Affichez les extensions\n",
-    "**complètes** ET **préférées** et identifiez laquelle est commune.\n",
+    "Sur l'AF `{a → b, a → c}` (où `a` attaque `b` et `c`, mais rien n'attaque `a`), affichez les\n",
+    "extensions **complètes** et **préférées**, puis répondez aux deux questions :\n",
     "\n",
-    "**Indice** : `{a}` est complète ; est-elle aussi préférée ? Et `{a, b}` est-elle admissible\n",
-    "(si `b` et `c` ne s'attaquent pas mutuellement) ?\n",
-    "\n"
+    "1. Quelle est l'extension commune aux deux sémantiques — et sont-elles ici confondues ?\n",
+    "2. Sur le 2-cycle de la section 3.2, `{}` figurait parmi les complètes. Est-elle encore complète\n",
+    "   ici ? (Indice : une extension complète doit contenir **tout argument qu'elle défend** ; qui\n",
+    "   `{}` défend-elle quand `a` est inattaqué ?)\n",
+    "\n",
+    "**Seconde question-piège** : `{a, b}` est-elle admissible ? (`b` et `c` ne s'attaquent pas\n",
+    "mutuellement — mais est-ce la bonne question à se poser ?)"
    ]
   },
   {
@@ -841,10 +898,82 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Correction guidée — Exercice 3 : pourquoi `{}` n'est PAS complète ici\n",
+    "\n",
+    "Le décompte attendu :\n",
+    "\n",
+    "| Sémantique | Extensions |\n",
+    "|---|---|\n",
+    "| Fondée | `{a}` |\n",
+    "| Complète | `{a}` **seulement** |\n",
+    "| Préférée | `{a}` |\n",
+    "| Stable | `{a}` |\n",
+    "\n",
+    "**(1)** Complète et préférée sont **confondues** : `{a}` — l'extension commune. Sur cet AF, la\n",
+    "complète n'admet aucune extension non-maximale en plus de la préférée.\n",
+    "\n",
+    "**(2) Le résultat le plus instructif** : contrairement au 2-cycle de la section 3.2, `{}` n'est\n",
+    "**pas** complète. Rappel de la définition : `E` est complète si `E` est admissible **et** contient\n",
+    "tout argument qu'elle *défend*. Or « défendre » un argument sans attaquants est une condition\n",
+    "**vide** — `{}` défend donc `a` (inattaqué), et une extension complète devrait alors contenir\n",
+    "`a`. `{}` ne le contient pas : elle n'est pas complète. Retenez la règle exacte : `{}` est\n",
+    "admissible sur tout AF, mais **complète seulement si aucun argument n'est inattaqué** — c'était\n",
+    "le cas du 2-cycle (chaque argument y est attaqué), pas ici.\n",
+    "\n",
+    "**La question-piège** : `{a, b}` n'est **pas** admissible — et la raison n'est pas l'absence\n",
+    "d'attaque entre `b` et `c`, mais l'attaque `a → b` **interne** à l'ensemble : un ensemble sans\n",
+    "conflit ne peut pas contenir un argument et sa cible. Quant à `b` et `c`, ils sont battus par `a`\n",
+    "et **personne ne les défend** (défendre `b` exigerait d'attaquer `a` — rien ne l'attaque) : ils\n",
+    "restent hors de toute extension non vide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 — Synthèse : quatre sémantiques, cinq graphes, une grille de lecture\n",
+    "\n",
+    "Les AF rencontrés dans ce notebook se rangent en une grille unique — la garder sous les yeux vaut\n",
+    "toutes les définitions :\n",
+    "\n",
+    "| AF | Fondée | Complète | Préférée | Stable | Ce que l'AF enseigne |\n",
+    "|---|---|---|---|---|---|\n",
+    "| `a → b` | `{a}` | `{a}` | `{a}` | `{a}` | cas dégénéré : tout coïncide |\n",
+    "| `x ↔ y` (2-cycle) | `∅` | `{x}`,`{y}`,`∅` | `{x}`,`{y}` | `{x}`,`{y}` | la fondée se trompe par prudence |\n",
+    "| `A→B, A→C, D→A` (chaîne) | `{B,C,D}` | `{B,C,D}` | `{B,C,D}` | `{B,C,D}` | la défense réhabilite les battus |\n",
+    "| `p→q→r→p` (3-cycle) | `∅` | `∅` | `∅` | **aucune** | cycle impair : la stable disparaît |\n",
+    "| `s → s` (auto-attaque) | `∅` | `∅` | `∅` | **aucune** | l'inacceptable universel |\n",
+    "\n",
+    "**Une phrase par sémantique** : la **fondée** est le point fixe sceptique — unique, calculable en\n",
+    "polynomial, mais parfois trop prudente (`x ↔ y`). La **complète** ajoute à l'admissibilité la\n",
+    "règle « tout argument défendu est accepté » — c'est la plus fidèle à la notion de *position\n",
+    "rationnelle*. La **préférée** en prend les maximaux — le choix standard quand on veut TOUTES les\n",
+    "positions maximales défendables. La **stable** exige de battre activement chaque outsider — la\n",
+    "plus agressive, et la seule sans garantie d'existence.\n",
+    "\n",
+    "**Le rapport d'inclusion qui structure tout** : `fondée ⊆ chaque complète ⊆ quelque préférée`, et\n",
+    "`∅` est admissible partout mais **complète seulement sans argument inattaqué** (comparez les lignes\n",
+    "`a → b` et `x ↔ y` — c'est la leçon de l'Exercice 3),\n",
+    "`stable ⊆ préférée` *quand des stables existent* (les deux dernières lignes du tableau montrent ce\n",
+    "qui arrive sinon). Les trois garanties de Dung (1985) à retenir : la fondée existe et est unique ;\n",
+    "la préférée existe toujours ; la stable n'est garantie nulle part.\n",
+    "\n",
+    "**Choisir en pratique** : position unique et incontestable → fondée ; énumérer les lectures\n",
+    "maximales d'un débat → préférée ; modéliser un système où tout non-accepté doit être « réfuté »\n",
+    "(configurations, game theory) → stable, en vérifiant d'abord qu'elle existe. La suite naturelle\n",
+    "dans la série : `Tweety-4-Aspic-Csharp` (argumentation **structurée** : les arguments deviennent\n",
+    "des déductions, les attaques des rebuts/undercuts) et `Tweety-7a-Extended-Frameworks-Csharp`\n",
+    "(attaques sur attaques, bipolarité)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m372034",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",


### PR DESCRIPTION
## enrich(tweety): densite Tweety-3-Dung-Csharp 576 -> 728 c/cell + 2 fixes theoriques

Grain: MED/notebook-dotnet -- lane myia-po-2027:CoursIA -- prev: MED/guard #14478

Deuxieme grain notebook-dotnet consecutif, substance genuinement distincte : ou #14653 ajoutait interpetations + section 5 sur le FOL, celui-ci corrige **deux erreurs theoriques existantes** du notebook et livre les corrections guidees manquantes. G-VAR-3 : DEEP/MED consecutifs OK si substance distincte (cas d'espèce : meme famille, deux sujets differents — semantique FOL vs semantiques de Dung).

### Fixes theoriques (contenu existant errone)

| Endroit | Erreur | Correction |
|---|---|---|
| Indice Exercice 1 | « chaque argument isolé bat la chaîne restante → **plusieurs** stables » — faux : dans un 3-cycle `p→q→r→p`, un singleton `{p}` bat `q` mais **pas** `r` (non-membre non battu), et toute paire porte une attaque interne → **ZÉRO extension stable** (résultat classique des cycles impairs ; le comportement invoqué est celui du 2-cycle). | Indice réécrit (teste chaque candidat un à un), la correction guidée démontre le résultat réel et relie cycles pairs (2 stables alternés) vs impairs (aucun). |
| Cellule « hiérarchie des sémantiques » + Exercice 3 | « l'extension vide est **toujours** complète » et l'énoncé Exo 3 supposait une complète non-maximale sur `{a→b, a→c}` — faux : `∅` défend tout argument **inattaqué** (condition vide), donc `∅` n'est complète que si aucun argument n'est inattaqué. Sur `{a→b, a→c}`, `a` est inattaqué → complètes = `{a}` **seulement**, la complète non-maximale n'existe pas. | Cellule nuancée, énoncé Exo 3 reformulé (la question devient « pourquoi `∅` n'est PAS complète ici alors qu'elle l'était sur le 2-cycle »), correction guidée avec le décompte exact. |

### Ajouts (4 cellules md)

| Cellule | Contenu |
|---|---|
| Correction guidée Exo 1 | Démonstration exhaustive : singletons (ne battent pas tous les non-membres), paires (attaque interne) → 0 stable ; leçon cycles pairs/impairs ; les 2 garanties d'existence de Dung (fondée unique, préférée toujours) que la stable n'offre pas. |
| Correction guidée Exo 2 | L'auto-attaque = conflit interne à l'argument → exclu de toute extension, toute sémantique ; deuxième exemple d'inexistence des stables ; ramification Aspic+ (Tweety-4). |
| Correction guidée Exo 3 | Tableau des 4 sémantiques sur `{a→b, a→c}`, la règle exacte « ∅ complète ⟺ aucun inattaqué », la question-piège `{a,b}` (l'attaque `a→b` est interne). |
| **Section 5 — Synthèse** | Grille unique 5 AF × 4 sémantiques (tous les AF du notebook), une phrase par sémantique, le rapport d'inclusions, les 3 garanties de Dung (1995), guide de choix pratique, renvois Tweety-4 (Aspic+) et Tweety-7a (frameworks étendus). |

### Validation

| Étape | Résultat |
|---|---|
| Cellules code | **Intactes** (markdown-only, C.3) ; séquence exec [1..12] inchangée ; stubs inchangés |
| Contre-vérification théorique | Les 4 corrections guidées revérifiées contre les définitions (conflict-free, admissible, complète, stable) avant commit — le fix ∅-complète découle de la définition même (« contient tout argument qu'elle défend », condition vide sur les inattaqués) |
| C.1 | 0 hit `raise`/`assert False`/`1/0`/`throw new` dans le diff |
| Interprétations | Corrections APRÈS chaque stub (structure ≠ solution) |
| Round-trip JSON | Vérifié avant chaque passe (indent=1, ensure_ascii=False) |
| Exercices | 3 conservés, pas de 4e |

See #11601

