### PR TITLE
feat(lean,#13483): P4.4 assembly L2 — sorry-stable reduction to the N-machine hcap

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -190,13 +190,28 @@ Diagnostic du 2026-09-04 (c.5539811910) : toutes les briques préliminaires sont
 `hashlife_correct_margin_of_hcap c k h_central (L3 c k h_central)` : L3/L4 sont les seuls
 maillons ouverts. -/
 
+/-- **P4.4 L2 — copie locale byte-identical de `jumpCaptured`** (pattern
+    d'inlining du lake, cf HashlifeCorrectness L6436 : le `jumpCaptured` que
+    consomme `hashlife_correctN` y est `private` — inline de
+    `Conway.Life.JumpCapture.jumpCaptured` pour casser le cycle d'import
+    A↔B, `JumpCapture.lean` important CE module). Ce module ne peut donc ni
+    voir le private ni importer `JumpCapture` (cycle) : même remède, copie
+    byte-identical. La defeq des corps identiques (delta-unfolding des deux
+    `def` semi-reducibles) fait passer l'appel à `hashlife_correctN` ci-dessous. -/
+private def jumpCapturedF (c : MacroCell) : Bool :=
+  (evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))).all fun p =>
+    decide ((2 ^ c.level : Int) ≤ p.1) &&
+    decide (p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) &&
+    decide ((2 ^ c.level : Int) ≤ p.2) &&
+    decide (p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+
 /-- **P4.4 L2 (réduction sorry-stable).** L'égalité globale du cadre se réduit à
     l'hypothèse de capture de trajectoire de la machine N : `hashlife_correctN` (prouvé)
     clôt le but dès `hcap`. Les maillons ouverts sont L3 (relever `centralCorrect c k`
     en `hcap`) et L4 (égalité restreinte → globale). -/
 theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
     (h_central : centralCorrect c k)
-    (hcap : ∀ t ≤ 2^k, jumpCaptured
+    (hcap : ∀ t ≤ 2^k, jumpCapturedF
       (gridToMacroCellWithOffset (evolve t (c.toGrid (0, 0)))).2 = true) :
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
   hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -166,6 +166,41 @@ theorem hashlife_correct_margin (c : MacroCell) (k : Nat)
   -- open P4/P5 heart — sorry documenté (acceptance B).
   sorry
 
+/-! ## Assemblage P4.4 — réduction sorry-stable (tranche 2, #13483)
+
+Diagnostic du 2026-09-04 (c.5539811910) : toutes les briques préliminaires sont prouvées
+(`p5_large_n_jumpN` b3', P4 complet, les 4 murs bornés sans sorry) — le sorry de
+`hashlife_correct_margin` est l'assemblage lui-même. Décomposition :
+
+- **L1** — l'hypothèse `h_margin` est gratuite : `supportInMargin` est tautologique
+  (`supportInMargin_trivial`), l'énoncé effectif est l'inconditionnel sous `centralCorrect`.
+- **L2** — le but se réduit à l'hypothèse de la machine N : `hashlife_correctN` (prouvé,
+  HashlifeCorrectness) donne l'égalité globale dès `hcap : ∀ t ≤ 2^k, jumpCaptured …`.
+  C'est le lemme ci-dessous, sorry-free.
+- **L3 (cœur ouvert)** — relever `centralCorrect c k` (égalité de grille RESTREINTE à la
+  fenêtre finale) en `hcap` (confinement de la TRAJECTOIRE entière). C'est l'assemblage
+  borné P4/P5 proprement dit : un argument de structure de la récursion Hashlife (la marge
+  contient le cône de lumière à chaque saut), PAS un argument de réversibilité — le GoL
+  n'est pas réversible, le cône rétrograde ne contraint pas les états intermédiaires.
+- **L4** — la jambe d'égalité : `centralCorrect` est une égalité restreinte, le but est
+  global ; la fermeture exige que les deux grilles portent leur support dans la fenêtre
+  (`jumpCaptured` du final + borne forward du support de `evolve`).
+
+`hashlife_correct_margin c k h_margin h_central` se déchargerait par
+`hashlife_correct_margin_of_hcap c k h_central (L3 c k h_central)` : L3/L4 sont les seuls
+maillons ouverts. -/
+
+/-- **P4.4 L2 (réduction sorry-stable).** L'égalité globale du cadre se réduit à
+    l'hypothèse de capture de trajectoire de la machine N : `hashlife_correctN` (prouvé)
+    clôt le but dès `hcap`. Les maillons ouverts sont L3 (relever `centralCorrect c k`
+    en `hcap`) et L4 (égalité restreinte → globale). -/
+theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k)
+    (hcap : ∀ t ≤ 2^k, jumpCaptured
+      (gridToMacroCellWithOffset (evolve t (c.toGrid (0, 0)))).2 = true) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap
+
 /-! ## Sanity-checks sur le bestiaire
 
 Le fragment `supportInMargin` est **décidable** (instance `Decidable (BoxAssezGrandN)`,
@@ -211,8 +246,10 @@ theorem cexEmpty1_supportInMargin_k0 : supportInMargin cexEmpty1 0 :=
 note *inconditionnel-en-attente* dans sa docstring : le prédicat est tautologique, le
 cœur de recherche reste l'assemblage borné P4/P5) ; son `sorry` documente ouvertement
 l'assemblage borné P4/P5 encore ouvert (`p4_nw_overlap_wall`, ai-01 c.94).
-Stratégie confirmée pour la suite de #6724 : fermer les murs NE/SW/SE bornés, puis câbler
-l'assemblage P4.4 qui déchargera le `sorry` de `hashlife_correct_margin`.
+Stratégie pour la suite de #6724 : les murs NE/SW/SE bornés sont FERMÉS et `p5_large_n_jumpN`
+est prouvé (b3') — la réduction L2 ci-dessus est en place, restent les maillons L3 (le pont
+`centralCorrect → hcap`, l'assemblage borné proprement dit) et L4 (égalité restreinte →
+globale), qui déchargeront le `sorry` de `hashlife_correct_margin`.
 -/
 
 end Life

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -166,6 +166,42 @@ theorem hashlife_correct_margin (c : MacroCell) (k : Nat)
   -- open P4/P5 heart — documented sorry (acceptance B).
   sorry
 
+/-! ## P4.4 assembly — sorry-stable reduction (tranche 2, #13483)
+
+Diagnosis of 2026-09-04 (c.5539811910): every preliminary brick is proved
+(`p5_large_n_jumpN` b3', full P4, the four bounded walls sorry-free) — the sorry of
+`hashlife_correct_margin` is the assembly itself. Decomposition:
+
+- **L1** — the `h_margin` hypothesis is free: `supportInMargin` is tautological
+  (`supportInMargin_trivial`), the effective statement is the unconditional one under
+  `centralCorrect`.
+- **L2** — the goal reduces to the N-machine's hypothesis: `hashlife_correctN` (proved,
+  in HashlifeCorrectness) yields the global equality as soon as
+  `hcap : ∀ t ≤ 2^k, jumpCaptured …` holds. That is the lemma below, sorry-free.
+- **L3 (open heart)** — lift `centralCorrect c k` (grid equality RESTRICTED to the final
+  window) to `hcap` (confinement of the WHOLE trajectory). This is the bounded P4/P5
+  assembly proper: a structural argument about the Hashlife recursion (the margin contains
+  the light cone at every jump), NOT a reversibility argument — GoL is not reversible, the
+  retrograde cone does not constrain intermediate states.
+- **L4** — the equality leg: `centralCorrect` is a restricted equality, the goal is
+  global; closing requires both grids to carry their support inside the window
+  (`jumpCaptured` of the final state + forward bound on the support of `evolve`).
+
+`hashlife_correct_margin c k h_margin h_central` would discharge as
+`hashlife_correct_margin_of_hcap c k h_central (L3 c k h_central)`: L3/L4 are the only
+open links. -/
+
+/-- **P4.4 L2 (sorry-stable reduction).** The frame's global equality reduces to
+    the N-machine's trajectory-capture hypothesis: `hashlife_correctN` (proved)
+    closes the goal as soon as `hcap` holds. The open links are L3 (lifting
+    `centralCorrect c k` to `hcap`) and L4 (restricted → global equality). -/
+theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k)
+    (hcap : ∀ t ≤ 2^k, jumpCaptured
+      (gridToMacroCellWithOffset (evolve t (c.toGrid (0, 0)))).2 = true) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap
+
 /-! ## Sanity checks on the bestiary
 
 The fragment `supportInMargin` is **decidable** (instance `Decidable (BoxAssezGrandN)`,
@@ -211,8 +247,10 @@ statement `hashlife_correct_margin` carries the fragment-relative correctness (i
 — see *unconditional-in-waiting* note in its docstring: the predicate is tautological, the
 research heart remains the bounded P4/P5 assembly); its `sorry` openly documents the
 still-open bounded P4/P5 assembly (`p4_nw_overlap_wall`, ai-01 c.94).
-Strategy confirmed for the rest of #6724: close the bounded NE/SW/SE walls, then wire the
-P4.4 assembly that will discharge the `sorry` of `hashlife_correct_margin`.
+Strategy for the rest of #6724: the bounded NE/SW/SE walls are CLOSED and
+`p5_large_n_jumpN` is proved (b3') — the L2 reduction above is in place, leaving the L3
+link (the `centralCorrect → hcap` bridge, the bounded assembly proper) and L4 (restricted
+→ global equality), which will discharge the `sorry` of `hashlife_correct_margin`.
 -/
 
 end Life_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -191,13 +191,28 @@ Diagnosis of 2026-09-04 (c.5539811910): every preliminary brick is proved
 `hashlife_correct_margin_of_hcap c k h_central (L3 c k h_central)`: L3/L4 are the only
 open links. -/
 
+/-- **P4.4 L2 — local byte-identical copy of `jumpCaptured`** (the lake's
+    inlining pattern, cf HashlifeCorrectness L6436: the `jumpCaptured` consumed
+    by `hashlife_correctN` is `private` there — an inline of
+    `Conway.Life.JumpCapture.jumpCaptured` breaking the A↔B import cycle,
+    `JumpCapture.lean` importing THIS module). This module can therefore neither
+    see the private nor import `JumpCapture` (cycle): same remedy, byte-identical
+    copy. Defeq of the identical bodies (delta-unfolding of both semi-reducible
+    `def`s) makes the call to `hashlife_correctN` below typecheck. -/
+private def jumpCapturedF (c : MacroCell) : Bool :=
+  (evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))).all fun p =>
+    decide ((2 ^ c.level : Int) ≤ p.1) &&
+    decide (p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) &&
+    decide ((2 ^ c.level : Int) ≤ p.2) &&
+    decide (p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+
 /-- **P4.4 L2 (sorry-stable reduction).** The frame's global equality reduces to
     the N-machine's trajectory-capture hypothesis: `hashlife_correctN` (proved)
     closes the goal as soon as `hcap` holds. The open links are L3 (lifting
     `centralCorrect c k` to `hcap`) and L4 (restricted → global equality). -/
 theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
     (h_central : centralCorrect c k)
-    (hcap : ∀ t ≤ 2^k, jumpCaptured
+    (hcap : ∀ t ≤ 2^k, jumpCapturedF
       (gridToMacroCellWithOffset (evolve t (c.toGrid (0, 0)))).2 = true) :
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
   hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/guard #14586

See #13483 (tranche 2, suite du diagnostic c.5539811910) — l'issue reste ouverte : L3/L4 sont les maillons ouverts restants.

## Ce que fait cette PR

Tranche 2 de l'assemblage P4.4 : le théorème **`hashlife_correct_margin_of_hcap`** (sorry-free, FR + jumeau `_en` byte-identique hors docstrings), qui réduit l'égalité globale du cadre à l'hypothèse de capture de trajectoire de la machine N :

```lean
theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
    (h_central : centralCorrect c k)
    (hcap : ∀ t ≤ 2^k, jumpCapturedF
      (gridToMacroCellWithOffset (evolve t (c.toGrid (0, 0)))).2 = true) :
    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
  hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap
```

C'est le pattern sorry-stable du lake (c.139/c.142/c.153 `centralCorrect_mem`) : l'infrastructure qui transforme le sorry monolithique en deux maillons précis.

**Réparation f1f9142204 (cycle d'import)** : la première compilation réelle (CI du commit initial) a échoué sur `Unknown identifier jumpCaptured` — le `jumpCaptured` que consomme `hashlife_correctN` est `private` dans HashlifeCorrectness (L6436 : inline byte-identical de `Conway.Life.JumpCapture.jumpCaptured` posé là pour casser le cycle A↔B, `JumpCapture.lean` important CE module). Remède : copie locale `private def jumpCapturedF` byte-identical (le pattern d'inlining canonique du lake, documenté deux fois dans HashlifeCorrectness) ; la defeq des corps identiques fait passer l'appel. i18n re-vérifié 33/33 après coup.

## Décomposition P4.4 posée en docstring de section (L1-L4)

| Maillon | État |
|---|---|
| **L1** — `h_margin` gratuite (`supportInMargin` tautologique, `supportInMargin_trivial`) | trivial |
| **L2** — but → `hcap` via `hashlife_correctN` (prouvé, HashlifeCorrectness) | **PROUVÉ dans cette PR** |
| **L3** — relever `centralCorrect c k` (égalité restreinte fenêtre finale) en `hcap` (confinement de la trajectoire entière) | **cœur ouvert** — argument de structure de la récursion Hashlife, PAS de réversibilité (GoL non réversible, le cône rétrograde ne contraint pas les intermédiaires) |
| **L4** — égalité restreinte → globale (support des deux grilles dans la fenêtre) | ouvert |

`hashlife_correct_margin c k h_margin h_central` se déchargerait par `hashlife_correct_margin_of_hcap c k h_central (L3 c k h_central)`.

## Validation

- **Jumeau `_en`** : `check_i18n_siblings.py` 33/33 paires byte-identical (énoncés/preuves identiques, docstrings EN).
- **Sorry count inchangé** : `python scripts/lean/count_code_sorry.py --json` → conway_lean = 1 déclaration distincte / 2 tokens (`hashlife_correct_margin` FR + `_en`), avant comme après — aucun sorry ajouté ni retiré (l'infrastructure sorry-stable, pas une régression ni un retrait prématuré).
- **`lake build`** : la compilation locale des cibles est **wall-blockée par le dimensionnement mémoire** (finding mesuré, voir ci-dessous) — les modules `Walls/SE.lean` / `Walls/NE.lean` exit 137 sous `-m 8g --memory-swap 24g` (SW passe à ~16g). La validation du build est portée par **la CI hosted 32G de cette PR** (le même lake est vert sur `main` en CI) — le check de build de la PR fait foi ; il sera cité au vert avant tout merge.

## Finding infra associé (rapporté, pas corrigé ici)

`-m 8g --memory-swap 24g` (config slots #14337, commit 496079da74) est **insuffisant pour `Walls/SE` et `Walls/NE`** : mesuré exit 137 sous cette limite ce jour, alors que le hosted 32G passe. La VM hôte des slots n'offre par ailleurs que ~6 Go de swap réel — le plafond cgroup 24g n'est pas honorable. Rapporté sur #14337.

## Signal périmètre voisin (hors scope, non corrigé ici)

`README.en.md` L8/L22/L47 est **stale** : il annonce « Sorry count: 2 / P5 large-n: 2 sorry (`p5_large_n_jumpN` …) » alors que `p5_large_n_jumpN` est prouvé depuis b3' (2026-08-15) et que le `README.md` FR est à jour. Tracker ouvert : #14606 (audit fichier-entier exigé pour README, règle E).
