### PR TITLE
enrich(claude-code,#13410): 01-Claude-CLI-Bases densite 956 -> 1202 + enonces manquants + corrections guidees

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -1209,7 +1209,7 @@
     "\n",
     "Maintenant c'est a vous ! Completez les cellules suivantes.\n",
     "\n",
-    "Les quatre exercices qui suivent mesurent votre maîtrise des trois compétences introduites plus haut — composer un prompt, choisir le modèle adapté, et exploiter la sortie (texte ou JSON). Ils montent en autonomie : les exercices 1 et 2 consistent à appeler `run_claude()` avec les bons paramètres, tandis que les exercices 3 et 4 vous demandent d'écrire des fonctions réutilisables (`compare_models`, `extract_json_field`, `ask_about_topic`) qui combinent plusieurs concepts. Chaque stub est conçu pour s'exécuter sans erreur (`return None`) tant que la solution n'est pas écrite — vous pouvez exécuter le notebook de bout en bout puis revenir remplir les stubs un par un."
+    "Les six exercices qui suivent mesurent votre maîtrise des trois compétences introduites plus haut — composer un prompt, choisir le modèle adapté, et exploiter la sortie (texte ou JSON). Ils montent en autonomie : les exercices 1 et 2 consistent à appeler `run_claude()` avec les bons paramètres, tandis que les exercices 3 et 4 vous demandent d'écrire des fonctions réutilisables (`compare_models`, `extract_json_field`, `ask_about_topic`) qui combinent plusieurs concepts. Chaque stub est conçu pour s'exécuter sans erreur (`return None`) tant que la solution n'est pas écrite — vous pouvez exécuter le notebook de bout en bout puis revenir remplir les stubs un par un."
    ]
   },
   {
@@ -1278,7 +1278,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Comparer les modèles sur une même question\n",
+    "### Exercice 2 : Comparer les modèles sur une même question\n",
     "\n",
     "Le choix du modèle (haiku, sonnet, opus) a un impact direct sur la qualite et le cout de la reponse. **Objectif** : Completez la fonction `compare_models` qui pose la même question a deux modèles et retourne les deux reponses pour comparaison. Cet exercice vous fera pratiquer le paramètre `model` de `run_claude()`."
    ]
@@ -1342,9 +1342,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 2 : Une question simple avec Haiku\n",
+    "### Exercice 3 : Une question simple avec Haiku\n",
     "\n",
-    "Avant de comparer les modèles sur des questions riches (exercice suivant), testons le cas le plus\n",
+    "Après avoir comparé les modèles sur des questions riches (exercice précédent), testons le cas le plus\n",
     "dégradé : une question **fermée et courte**. Dans la cellule `# EXERCICE 2` ci-dessous, demandez\n",
     "au modèle `haiku` un fait simple (« Quelle est la capitale de l'Australie ? » par exemple), puis\n",
     "variez : une question ouverte courte, puis une consigne de format (« réponds en exactement 5 mots »).\n",
@@ -1398,7 +1398,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Interpreter une reponse JSON\n",
+    "### Exercice 4 : Interpreter une reponse JSON\n",
     "\n",
     "Le format JSON est essentiel pour integrer Claude dans des pipelines automatisees. **Objectif** : Completez la fonction `extract_json_field` qui parse la reponse JSON de Claude et extrait les champs pertinents. Cette competence est indispensable pour tout script qui traite les sorties de Claude programmatiquement."
    ]
@@ -1482,7 +1482,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Reponse structuree en JSON\n",
+    "### Exercice 5 : Reponse structuree en JSON\n",
     "\n",
     "Dans les exercices précédents, vous avez utilise le format texte et le modèle haiku. Maintenant, combinez les deux concepts : demandez une reponse structuree en JSON. Le format JSON est essentiel pour integrer Claude dans des pipelines automatisees."
    ]
@@ -1538,7 +1538,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Composer un prompt avec paramètres\n",
+    "### Exercice 6 : Composer un prompt avec paramètres\n",
     "\n",
     "Dans les sections précédentes, vous avez utilise `run_claude()` avec des prompts simples. Un usage avance consiste a composer dynamiquement le prompt en fonction du contexte (langage, niveau de detail, format souhaite). **Objectif** : Completez la fonction `ask_about_topic` qui genere un prompt structure pour poser une question technique a Claude."
    ]
@@ -1608,33 +1608,33 @@
     "une **trace d'exécution sur un petit exemple** : ces deux exigences forcent le modèle à vraiment\n",
     "suivre la logique plutôt qu'à paraphraser la syntaxe.\n",
     "\n",
-    "**Exercice 2 (question simple avec Haiku).** Sur une question fermée, tous les modèles convergent\n",
+    "**Exercice 2 (comparer les modèles).** La structure attendue boucle sur les modèles avec le MÊME\n",
+    "prompt, et collecte réponse + métriques (longueur, temps). Le piège classique : comparer des\n",
+    "réponses à des prompts différents — la comparaison ne mesure alors plus le modèle mais la question.\n",
+    "La fonction gagne à retourner un dictionnaire structuré plutôt que d'imprimer, pour pouvoir\n",
+    "réutiliser les résultats.\n",
+    "\n",
+    "**Exercice 3 (question simple avec Haiku).** Sur une question fermée, tous les modèles convergent\n",
     "vers la même réponse : le différentiateur devient le **coût** (tokens consommés) et la **latence**.\n",
     "C'est le cas d'usage canonique du petit modèle — réserver les questions riches à un modèle plus\n",
-    "capable, comme la section 5 le montrait sur la comparaison liste/tuple.\n",
+    "capable, comme l'exercice précédent le montrait sur la comparaison de modèles.\n",
     "\n",
-    "**Exercice 3 / comparaison de modèles (l'exercice à fonction `compare_models`).** La structure\n",
-    "attendue boucle sur les modèles avec le MÊME prompt, et collecte réponse + métriques (longueur,\n",
-    "temps). Le piège classique : comparer des réponses à des prompts différents — la comparaison ne\n",
-    "mesure alors plus le modèle mais la question. La fonction gagne à retourner un dictionnaire\n",
-    "structuré plutôt que d'imprimer, pour pouvoir réutiliser les résultats.\n",
+    "**Exercice 4 (interpreter une réponse JSON).** La clé : demander un JSON **dès le prompt**\n",
+    "(« réponds UNIQUEMENT avec un tableau JSON d'objets {nom, description} »), puis `json.loads` sur\n",
+    "la sortie. Le format `run_claude_json` de la section 4 fait exactement ça côté helper. Une\n",
+    "extraction par expressions régulières sur une réponse libre est l'anti-pattern : fragile face au\n",
+    "moindre changement de formulation du modèle.\n",
     "\n",
-    "**Exercice 4 (prompt paramétré).** L'intérêt pédagogique est la **séparation prompt / paramètres** :\n",
-    "`ask_about_topic(topic, language, detail_level)` fabrique le prompt final par template. C'est le\n",
-    "pont direct vers les scripts reproductibles du notebook 02 : un prompt paramétré se met au propre\n",
-    "dans une fonction, se teste, et se versionne — un prompt copié-collé dans le shell ne l'est jamais.\n",
-    "\n",
-    "**Exercice 5 (extraction JSON).** La clé : demander un JSON **dès le prompt** (« réponds UNIQUEMENT\n",
-    "avec un tableau JSON d'objets {nom, description} »), puis `json.loads` sur la sortie. Le format\n",
-    "`run_claude_json` de la section 4 fait exactement ça côté helper. Une extraction par expressions\n",
-    "régulières sur une réponse libre est l'anti-pattern : fragile face au moindre changement de\n",
-    "formulation du modèle.\n",
-    "\n",
-    "**Exercice 6 (réponse structurée).** La progression attendue : contrainte de format dans le prompt,\n",
+    "**Exercice 5 (réponse structurée).** La progression attendue : contrainte de format dans le prompt,\n",
     "validation par `json.loads`, puis exploitation programmatique (filtrer, trier, compter). Une fois\n",
     "la sortie structurée, la réponse du modèle cesse d'être du texte à lire : c'est une **donnée** que\n",
     "votre code peut consommer — c'est toute la différence entre « discuter avec un assistant » et\n",
-    "« construire un pipeline »."
+    "« construire un pipeline ».\n",
+    "\n",
+    "**Exercice 6 (prompt paramétré).** L'intérêt pédagogique est la **séparation prompt / paramètres** :\n",
+    "`ask_about_topic(topic, language, detail_level)` fabrique le prompt final par template. C'est le\n",
+    "pont direct vers les scripts reproductibles du notebook 02 : un prompt paramétré se met au propre\n",
+    "dans une fonction, se teste, et se versionne — un prompt copié-collé dans le shell ne l'est jamais."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -306,9 +306,13 @@
     "tags": []
    },
    "source": [
-    "**Interpretation :** La version detectee confirme que Claude Code est operationnel. Le numéro de version (ici 2.x) indique la generation de l'outil -- les mises a jour apportent regululierement de nouvelles capacites (modèles, commandes, formats de sortie).\n",
-    "\n",
-    "Verifions maintenant que la connexion reseau fonctionne correctement pour atteindre les serveurs de l'API :"
+    "**Interpretation :** La version detectee confirme que Claude Code est operationnel\n",
+    "localement. Deux remarques de methode. D'abord, la version n'est pas un detail cosmétique : les\n",
+    "capacites du CLI (formats de sortie, gestion des sessions, models disponibles) evoluent d'une\n",
+    "version a l'autre — un notebook qui documente un comportement devrait citer la version avec\n",
+    "laquelle il a ete valide. Ensuite, notez que le helper isole l'appel : si la commande echoue\n",
+    "(CLI absent du PATH), c'est le helper qui formate l'erreur, pas la cellule qui plante — c'est le\n",
+    "pattern qui rend ce notebook re-executable meme sur une machine sans installation."
    ]
   },
   {
@@ -366,9 +370,13 @@
     "tags": []
    },
    "source": [
-    "**Lecture.** Sortie **non-nominale** : `Erreur de connexion: inconnue`. Le helper `check_claude_status()` a pu trouver le binaire (cellule précédente OK) mais n'a pas pu interroger son endpoint -- typiquement parce que la session n'est pas authentifiée (`claude login` à refaire) ou que le proxy d'entreprise intercepte `api.anthropic.com`. **Le notebook ne s'arrête pas** : les cellules suivantes (`run_claude(…)`) могут quand même aboutir si une session auth existe ailleurs, mais le risque d'une erreur `401 Unauthorized` plus loin est élevé.\n",
-    "\n",
-    "**Action recommandée :** un `claude login` depuis le terminal avant de relancer ce notebook. Si l'erreur persiste, consulter `/tmp/claude-cli.log`."
+    "**Lecture.** Sortie **non-nominale** : `Erreur de connexion: inconnue`. Le helper rend\n",
+    "un statut structure au lieu de lever une exception — et c'est la decision de conception importante :\n",
+    "un **statut** se teste (`if status.get(...)`), s'affiche et se journalise, alors qu'une exception\n",
+    "interrompt le notebook. Pour un outil en ligne de commande appele depuis du code, distinguer\n",
+    "« l'outil a repondu » de « l'outil a repondu OK » est la frontiere entre un script qui casse et un\n",
+    "script qui **rapporte**. Retenez le triplet retourne (sortie, erreur, code de retour) : il revient\n",
+    "dans toutes les cellules suivantes."
    ]
   },
   {
@@ -1205,6 +1213,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Expliquer un code mystère\n",
+    "\n",
+    "La cellule `# EXERCICE 1` ci-dessous contient un fragment de code volontairement peu lisible\n",
+    "(variables à une lettre, logique tassée). À vous de jouer :\n",
+    "\n",
+    "1. Lisez le code et formulez une **hypothèse** sur ce qu'il calcule, AVANT de consulter le modèle.\n",
+    "2. Demandez ensuite à Claude de l'expliquer, avec un prompt du type « Explique ce que fait ce code,\n",
+    "   ligne par ligne, puis donne un nom explicite à chaque variable ».\n",
+    "3. Comparez : quels détails votre hypothèse avait-elle manqués ? C'est exactement le réflexe\n",
+    "   « relecture par un second lecteur » qui fait la valeur du modèle en relecture de code."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "id": "9949c8ac",
@@ -1312,6 +1336,19 @@
     "# Test (sans appel API - la fonction retourne None tant que le stub n'est pas complete)\n",
     "comparaison = compare_models(\"Quelle est la difference entre == et is en Python ?\")\n",
     "print(f\"Comparaison : {comparaison}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Une question simple avec Haiku\n",
+    "\n",
+    "Avant de comparer les modèles sur des questions riches (exercice suivant), testons le cas le plus\n",
+    "dégradé : une question **fermée et courte**. Dans la cellule `# EXERCICE 2` ci-dessous, demandez\n",
+    "au modèle `haiku` un fait simple (« Quelle est la capitale de l'Australie ? » par exemple), puis\n",
+    "variez : une question ouverte courte, puis une consigne de format (« réponds en exactement 5 mots »).\n",
+    "Observerez-vous la même économie de tokens ? Le même respect de la consigne ?"
    ]
   },
   {
@@ -1561,6 +1598,47 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Corrections guidées — les six exercices\n",
+    "\n",
+    "**Exercice 1 (code mystère).** Le réflexe attendu : formuler SA hypothèse d'abord. La valeur du\n",
+    "modèle n'est pas de penser à votre place, mais de **contredire ou confirmer** votre lecture — un\n",
+    "dispositif anti-aveuglement. Un bon prompt d'explication demande un **renommage des variables** et\n",
+    "une **trace d'exécution sur un petit exemple** : ces deux exigences forcent le modèle à vraiment\n",
+    "suivre la logique plutôt qu'à paraphraser la syntaxe.\n",
+    "\n",
+    "**Exercice 2 (question simple avec Haiku).** Sur une question fermée, tous les modèles convergent\n",
+    "vers la même réponse : le différentiateur devient le **coût** (tokens consommés) et la **latence**.\n",
+    "C'est le cas d'usage canonique du petit modèle — réserver les questions riches à un modèle plus\n",
+    "capable, comme la section 5 le montrait sur la comparaison liste/tuple.\n",
+    "\n",
+    "**Exercice 3 / comparaison de modèles (l'exercice à fonction `compare_models`).** La structure\n",
+    "attendue boucle sur les modèles avec le MÊME prompt, et collecte réponse + métriques (longueur,\n",
+    "temps). Le piège classique : comparer des réponses à des prompts différents — la comparaison ne\n",
+    "mesure alors plus le modèle mais la question. La fonction gagne à retourner un dictionnaire\n",
+    "structuré plutôt que d'imprimer, pour pouvoir réutiliser les résultats.\n",
+    "\n",
+    "**Exercice 4 (prompt paramétré).** L'intérêt pédagogique est la **séparation prompt / paramètres** :\n",
+    "`ask_about_topic(topic, language, detail_level)` fabrique le prompt final par template. C'est le\n",
+    "pont direct vers les scripts reproductibles du notebook 02 : un prompt paramétré se met au propre\n",
+    "dans une fonction, se teste, et se versionne — un prompt copié-collé dans le shell ne l'est jamais.\n",
+    "\n",
+    "**Exercice 5 (extraction JSON).** La clé : demander un JSON **dès le prompt** (« réponds UNIQUEMENT\n",
+    "avec un tableau JSON d'objets {nom, description} »), puis `json.loads` sur la sortie. Le format\n",
+    "`run_claude_json` de la section 4 fait exactement ça côté helper. Une extraction par expressions\n",
+    "régulières sur une réponse libre est l'anti-pattern : fragile face au moindre changement de\n",
+    "formulation du modèle.\n",
+    "\n",
+    "**Exercice 6 (réponse structurée).** La progression attendue : contrainte de format dans le prompt,\n",
+    "validation par `json.loads`, puis exploitation programmatique (filtrer, trier, compter). Une fois\n",
+    "la sortie structurée, la réponse du modèle cesse d'être du texte à lire : c'est une **donnée** que\n",
+    "votre code peut consommer — c'est toute la différence entre « discuter avec un assistant » et\n",
+    "« construire un pipeline »."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6a1213fa",
    "metadata": {
     "papermill": {
@@ -1612,7 +1690,14 @@
     "\n",
     "Dans le notebook suivant, nous verrons comment gerer les **sessions et conversations** pour maintenir un contexte entre plusieurs echanges.\n",
     "\n",
-    "-> [02-Claude-CLI-Sessions.ipynb](02-Claude-CLI-Sessions.ipynb)\n"
+    "-> [02-Claude-CLI-Sessions.ipynb](02-Claude-CLI-Sessions.ipynb)\n",
+    "\n",
+    "**Choisir son modele en pratique** : question fermee ou tache repetitive -> petit modele\n",
+    "(haiku), le differentiateur y est le cout et la latence, pas la qualite. Analyse de code,\n",
+    "redaction structuree, comparaison argumentee -> modele equilibre (sonnet) : la section 6 a montre\n",
+    "le gain qualitatif sur le diagnostic de complexite. Le reflexe a garder de ce notebook : mesurer\n",
+    "sur VOTRE cas d usage (l exercice compare_models en est le gabarit) plutot que de croire les\n",
+    "classements generaux — un benchmark ne connait pas vos prompts."
    ]
   }
  ],
@@ -1658,7 +1743,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "01-Claude-CLI-Bases.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/2b36da1d-b3d6-48d7-97f2-37a6d5c34555/scratchpad/exec_01-Claude-CLI-Bases.ipynb",
+   "output_path": "01-Claude-CLI-Bases.ipynb",
    "parameters": {},
    "start_time": "2026-08-23T19:31:59.709968",
    "version": "2.6.0"

--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -669,6 +669,51 @@ def exercise_with_exercice_indice_skeleton(source: str) -> bool:
     return not has_substantive_call
 
 
+def exercise_with_code_subject_string(source: str) -> bool:
+    """Return True if the cell is a "code-as-subject" exercise: the only
+    executable code is the assignment of a multi-line string literal holding
+    the code the student must ANALYZE (``mystery_code = \'\'\'...\'\'\'``),
+    everything else being guidance comments (``# EXERCICE N : ...``,
+    ``# Indice : ...``, a commented-out solution skeleton).
+
+    The ``def`` / ``return`` lines INSIDE the string literal make
+    ``exercise_with_exercice_indice_skeleton`` return False (its substantive-
+    call regex sees the string body as executable code) and
+    ``commented_template_stub`` early-exits on the in-string ``def`` — so this
+    FP class needs its own recognition. Pattern: 01-Claude-CLI-Bases cell 34
+    (exercise "Expliquer un code mystere" — the mystery code IS the subject,
+    not the solution).
+
+    Recall-safe: a real solution NEVER reduces to a bare string assignment —
+    solving "explain this code" means CALLING the model (``run_claude(...)``,
+    a solver, a print of the result). Any executable line beyond
+    ``<name> = <STR>`` (call, return, loop, subscript) makes this return
+    False. A solution also never carries 2+ ``# Exercice`` / ``# Indice``
+    guidance markers alongside a ``# Votre code ici`` placeholder block.
+    """
+    # Strip multi-line string literals before analyzing executable lines —
+    # the def/return lines inside the string are DATA, not code.
+    stripped = re.sub(
+        r"'''[\s\S]*?'''|\"\"\"[\s\S]*?\"\"\"", "<STR>", source,
+    )
+    exec_lines = [
+        l.strip() for l in stripped.split('\n')
+        if l.strip() and not l.strip().startswith(('#', '//', '--'))
+    ]
+    if not exec_lines:
+        return False
+    # Every executable line must be a pure assignment of the stripped string.
+    for s in exec_lines:
+        if not re.match(r'^[A-Za-z_][\w\[\]."\']*\s*(?::\s*str)?\s*=\s*<STR>$', s):
+            return False
+    # Guidance markers (same marker set as exercise_with_exercice_indice_skeleton).
+    pattern = re.compile(
+        r'(?:^|\n)[ \t]*#[ \t]*(?:Exercice|Indice|Etape)\b',
+        re.IGNORECASE | re.MULTILINE,
+    )
+    return len(pattern.findall(source)) >= 2
+
+
 def exercise_with_run_lean_snippet(source: str) -> bool:
     """Return True if the cell is a Lean exercise that wraps a ``snippet_exN``
     string literal passed to ``run_lean(...)`` for isolated execution, with
@@ -911,6 +956,13 @@ def scan_notebook(path: str) -> list[dict]:
             # guidance headers, no substantive call/return body. Arrow-33
             # pattern. The student follows the indicesteps.
             if exercise_with_exercice_indice_skeleton(next_code_source):
+                continue
+            # "Code-as-subject" exercise: the only executable code is the
+            # assignment of a multi-line string holding the code the student
+            # must ANALYZE (mystery_code = '''...'''), the rest is guidance
+            # comments. The in-string def/return defeats the helpers above.
+            # 01-Claude-CLI-Bases cell 34 pattern.
+            if exercise_with_code_subject_string(next_code_source):
                 continue
             # Lean exercise wrapping a `snippet_exN = """..."""` literal
             # passed to `run_lean(snippet_exN, timeout_s=...)` with a


### PR DESCRIPTION
## enrich(claude-code): 01-Claude-CLI-Bases densite 956 -> 1200 c/cell + 2 enonces manquants + corrections guidees

Grain: MED/notebook-python -- lane myia-po-2027:CoursIA -- prev: MED/guard #14478

Genre CONTENU, famille nouvelle pour la lane aujourd'hui (apres 2 notebook-dotnet) : la variete G-VAR-3 est tenue par changement de famille ET de langage.

### Audit-test d'abord (lecon #13410)

La baseline rendait 596 c/cell — **stale**. Re-mesure du pool a la main : App-13 (1537 reel), medical_chatbot (1307), FT-01 (2212), 01-3-Basic-Image-Operations (1287), App-14c (1501) = NON-gaps ; seul **01-Claude-CLI-Bases mesure reellement 956** (18 cellules code, 26 md). Gap confirme.

### Defaut structurel decouvert : 2 stubs d'exercices orphelins d'enonce

La section 7 comptait 6 stubs code mais seulement 4 enonces markdown — les stubs `# EXERCICE 1` (code mystere `mystery_code`) et `# EXERCICE 2` (question simple haiku) n'avaient **aucun enonce** : l'etudiant tombait sur une cellule a completer sans consigne. Deux enonces ajoutes devant chacun.

### Ajouts (3 cellules md nouvelles + 2 md enrichies + Resume complete + renumerotation)

| Cellule | Contenu |
|---|---|
| Enonce code mystere (avant stub) | Demarche 3 etapes : hypothese personnelle AVANT le modele, prompt avec renommage de variables + trace d'execution, comparaison |
| Enonce question simple (avant stub) | Question fermee/ouverte/contrainte de format avec haiku — economies de tokens et respect de consigne |
| Corrections guidees (6 exercices, avant le Resume) | Une correction par exercice dans l'ordre du notebook |
| Interpretations version/statut enrichies | Pourquoi citer la version validee ; statut structure vs exception (rapporter plutot que casser), le triplet (sortie, erreur, code retour) |
| Resume + synthese choix de modele | Petit modele sur question fermee (cout/latence), equilibre sur analyse/redaction ; mesurer sur SON cas d'usage |

### Renumerotation des enonces (commit f841a927, fix du garde #8053)

Le notebook preexistant melangeait deux numerations incoherentes : enonces md « Exercice 1..4 » (sujets distincts) vs stubs code commentes « # EXERCICE 1..6 » (autre ordre). L'ajout des 2 enonces manquants creait une collision (guard #8053 : `Duplicate Exercice 1/2`). Les **6 enonces md** sont renumerotes dans l'ordre physique 1..6 (mystere, comparaison modeles, question simple haiku, interpretation JSON, reponse structuree, prompt parametre), corrections guidees realignees dessus, « Les quatre exercices » -> six. Les commentaires internes des stubs code ne sont PAS touches (md-only).

### Fix garde #8053 : nouvelle FP class « code-as-subject » (commit f841a927)

L'enonce ajoute au-dessus du stub orphelin `# EXERCICE 1` creait l'attribution header->code, et le garde lisait le `def f(s): return s == s[::-1]` **a l'interieur de la triple-quoted string** comme une solution (HIGH `412 chars not stub`). Nouvel helper `exercise_with_code_subject_string` dans `detect_solution_leaks.py` : le seul executable de la cellule est l'assignation de la string a ANALYSER (`mystery_code = '''...'''`), tout le reste est commentaire de guidance. Recall-safe : une vraie solution appelle le modele (`run_claude(...)`), elle ne se reduit jamais a une assignation de litteral — toute ligne executable non triviale fait echouer l'helper.

**Mesure** (scan-all, diff integral verifie) : corpus 26 HIGH/26 MEDIUM -> **25/24**, seuls les 3 findings vises disparaissent. Notebook main (jambe BASE du delta) : 0 finding.

### Validation

| Etape | Resultat |
|---|---|
| Cellules code | **Intactes** (markdown-only strict, C.3) ; sequence exec [1..18] inverifiee intacte ; stubs inchanges |
| Densite | 956 -> **1200** c/cell (prose/code-cell) |
| C.1 | 0 hit `raise NotImplementedError`/`assert False`/`1/0` dans le diff |
| Round-trip JSON | Verifie avant chaque passe ET recharge apres ecriture finale (indent=1, ensure_ascii=False) |
| Garde #8053 | scan head : 0 finding sur le notebook ; delta base/head = 0 HIGH, 0 MEDIUM |
| Pre-commit | Hooks Passed (2 commits) |

See #13410, See #8053
