### PR TITLE
ci(cabling,#14615): recable scripts/audit/tests into scripts-tests.yml (family 2/6)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -203,23 +203,54 @@ jobs:
         # would abort the whole pytest session with a collection error (masking
         # every other result) — the exact failure mode this workflow exists to
         # prevent. agent_tests owner: po-2026 (Lean lane).
+        #
+        # scripts/audit/tests re-cabled here (family 2 of #14615): the
+        # 2026-08-14 CI-EXCLUDED reason (4 env-dependent failures, DALLE-3
+        # key) was fixed by #12837 (hermetic rewrite, urlopen monkeypatched).
+        # Measured firsthand 2026-09-04 on origin/main: 455/455 green with the
+        # OpenAI key unset (env -u re-run), zero network/gh subprocess, zero
+        # dep delta vs this job (pillow arrives transitively with matplotlib).
         run: |
           pytest \
             scripts/tests \
             scripts/notebook_tools/tests \
             scripts/lean/tests \
             scripts/translation/tests \
+            scripts/audit/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py \
             MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
             --tb=short -q
+
+      - name: Audit tests collection floor (455)
+        # Companion guard of the audit re-cabling (family 2 of #14615), same
+        # two-signal semantics as the GameTheory floor (#14614) and the dotnet
+        # Shared.Tests floor (#14668): a green run must not silently shrink.
+        # 0 collected = collection crash (import error), below floor = coverage
+        # regression — distinct exit-1 signals either way.
+        if: always()
+        env:
+          AUDIT_TESTS_FLOOR: 455
+        run: |
+          N=$(python -m pytest scripts/audit/tests --collect-only -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ tests collected' | grep -oE '^[0-9]+')
+          if [ -z "$N" ] || [ "$N" -eq 0 ]; then
+            echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."
+            exit 1
+          fi
+          if [ "$N" -lt "$AUDIT_TESTS_FLOOR" ]; then
+            echo "::error::Coverage regression: $N tests collected, floor=$AUDIT_TESTS_FLOOR."
+            echo "::error::If the drop is intentional, raise AUDIT_TESTS_FLOOR in the same PR."
+            exit 1
+          fi
+          echo "OK: $N tests collected (floor=$AUDIT_TESTS_FLOOR)."
       # CI-EXCLUDED — testpaths pytest.ini non couverts par ce run, garde #10903.
       # Retirer la ligne du répertoire câblé (et l'ajouter au run ci-dessus) quand
-      # l'herméticité est démontrée sur runner nu. Chaque raison est vérifiée
-      # firsthand (2026-08-14, po-2024) :
-      # CI-EXCLUDED: scripts/audit/tests — 4 échecs env-dépendants (test_regen_img1_dalle3.py, clé DALLE-3/OpenAI requise), 405 passent
+      # l'herméticité est démontrée sur runner nu. scripts/audit/tests a été
+      # retiré de cette liste le 2026-09-04 (famille 2 de #14615) :
+      # l'herméticité est démontrée (455/455 sans clé, #12837). Les raisons
+      # restantes sont vérifiées firsthand (2026-08-14, po-2024) :
       # CI-EXCLUDED: scripts/quantconnect/tests — deps yfinance + fichiers de données externes, non hermétique sur runner nu
       # CI-EXCLUDED: scripts/secrets/tests — 4/6 fichiers non couverts par secret-scan.yml (render_envs/render_settings_json) ; scan gitleaks = 2 fichiers dédiés
       # CI-EXCLUDED: GradeBookApp — deps openpyxl/rapidfuzz/unidecode non installées dans ce job ; PII grading hors CI publique

--- a/scripts/audit/tests/test_check_orphan_merged_pr.py
+++ b/scripts/audit/tests/test_check_orphan_merged_pr.py
@@ -31,6 +31,33 @@ from pathlib import Path
 import pytest
 
 HERE = Path(__file__).resolve().parent
+
+
+def _gh_auth_available() -> bool:
+    """Les tests `_main` ci-dessous passent par mod.main(), dont la
+    découverte de slug en fallback interroge `gh repo view` même avec
+    --repo "" (check_orphan_merged_pr.py main(), `args.repo or ...`), puis
+    analyse_pr requête les PRs ouvertes sur la base quand un slug existe.
+    Sur un runner sans gh authentifié, le RuntimeError est avalé en exit 2
+    et le test échoue sans faute du code. Skip propre, pas FAILED — même
+    politique que test_check_unaddressed_nits.py (review NanoClaw #14322,
+    concern 2) ; constaté au câblage CI de cette suite (#14615 famille 2).
+    """
+    import shutil
+    if shutil.which("gh") is None:
+        return False
+    return subprocess.run(
+        ["gh", "auth", "status"], capture_output=True
+    ).returncode == 0
+
+
+requires_gh_auth = pytest.mark.skipif(
+    not _gh_auth_available(),
+    reason="gh absent/unauthed -- main() (découverte slug + requête PRs "
+           "ouvertes sur la base) exige gh authentifié (#14615 famille 2)",
+)
+
+
 CHECK_PATH = HERE.parent / "check_orphan_merged_pr.py"
 
 
@@ -54,7 +81,8 @@ def _g(repo: Path, *args: str, date: str | None = None) -> str:
         env["GIT_AUTHOR_DATE"] = date
         env["GIT_COMMITTER_DATE"] = date
     cmd = ["git", "-C", str(repo), *_BASE_CFG, *args]
-    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env,
+                          encoding="utf-8", errors="replace")
     assert proc.returncode == 0, f"git {args} failed: {proc.stderr.strip()}"
     return proc.stdout.strip()
 
@@ -162,6 +190,7 @@ def test_orphan_after_base_squash_merge(tmp_path):
     assert "recovery" in res
 
 
+@requires_gh_auth
 def test_orphan_strict_exits_1_main(tmp_path):
     """main() with --strict returns 1 on a genuine orphan (criterion 1: red)."""
     mod = _load()
@@ -585,6 +614,7 @@ def test_main_clean_exits_0(tmp_path):
     assert rc == 0
 
 
+@requires_gh_auth
 def test_main_orphan_advisory_exits_0(tmp_path):
     mod = _load()
     repo = _git_repo(tmp_path)
@@ -711,6 +741,7 @@ def test_format_report_lists_adjudges_separately_and_counts():
     assert "adjuges: 1" in out
 
 
+@requires_gh_auth
 def test_main_adjudged_does_not_fail_strict(tmp_path):
     """main() avec registre qui adjuge le seul orphelin -> --strict exit 0 :
     le compte orphelins retombe a 0, l'adjudication n'est pas un finding."""

--- a/scripts/check_testpaths_coverage.py
+++ b/scripts/check_testpaths_coverage.py
@@ -43,6 +43,7 @@ WORKFLOW_COVERAGE: dict[str, list[str]] = {
         "scripts/notebook_tools/tests",
         "scripts/lean/tests",
         "scripts/translation/tests",
+        "scripts/audit/tests",
         "MyIA.AI.Notebooks/GameTheory/tests",
         "MyIA.AI.Notebooks/QuantConnect/scripts/tests",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py",


### PR DESCRIPTION
Grain: MED/test -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Quoi

Famille 2/6 de #14615 (tranche 2-7 de #13746) : re-câblage de `scripts/audit/tests` — 16 fichiers de tests pytest, ~455 tests — dans le job **Scripts Tests (CPU)** de `scripts-tests.yml`, dont ils étaient exclus par une ligne `CI-EXCLUDED` périmée.

**Prémisse renversée (mesuré firsthand, séquence datée)** : la ligne CI-EXCLUDED invoquait « 4 échecs env-dépendants (test_regen_img1_dalle3.py, clé DALLE-3/OpenAI requise), 405 passent » — mesure po-2024 du **2026-08-14**, exacte alors. Mais **#12837 (merge 2026-08-28) a hermétisé ces tests** (urlopen monkeypatché, redirection des chemins d'assets vers tmp_path, plus aucune clé requise) et la ligne d'exclusion n'a jamais été retirée. La famille dormait non-câblée depuis une semaine pour une raison disparue.

Le marqueur `@pytest.mark.env` proposé par le dispatch est donc **moot** : il n'y a plus rien à séparer — c'est le verdict le plus simple et le plus honnête.

## Mesures firsthand (G.2, origin/main 3881b766a)

- `pytest scripts/audit/tests -q` local : **455/455 verts, 36-43 s**.
- **Clé OpenAI absente** (`env -u OPENAI_API_KEY -u OPENAI_BASE_URL`, re-passé) : **455/455 identiques** — l'env-var n'entre pas en jeu (docstring du fichier : « all hermetically, no network, no real OpenAI key » ; constaté, pas seulement lu).
- **Zéro appel réseau réel / zéro subprocess gh** : les seuls matches grep sont des littéraux dans des fixtures-notebooks (tests des analyseurs) et le monkeypatch explicite de `urllib.request.urlopen` (test_regen_img1_dalle3.py:208-227).
- **Delta deps vs le job = zéro** : les scripts audit importent en top-level `nbformat`, `yaml`, `matplotlib` (et pillow via import paresseux — pillow est une dépendance requise de matplotlib, donc déjà transitivement installée). Tout est dans le pip install du job.
- Invocation CI modifiée complète : **11 860 tests collectés, zéro erreur de collecte** (les 455 audit s'ajoutent proprement aux autres suites).

## Floor-guard (455)

Step compagnon `Audit tests collection floor (455)` (`if: always()`), mêmes sémantiques deux-signaux que les floors des tranches sœurs (#14614 GameTheory, #14668 Shared.Tests) : liste vide = panne de collecte, compte < 455 = régression de couverture — exit 1 distincts. Extraction ancrée sur `N tests collected` (pytest ne localise pas sa sortie — contrairement à l'en-tête `dotnet --list-tests` du grain précédent), vérifiée N=455 localement.

## Réparation après premier run CI (settlement fails=4 → commit 0fe365289)

Le premier run de la suite en CI a révélé **deux manques réels** (le workflow tourne sur sa propre PR — validation native) :

1. **`test_check_testpaths_coverage::test_guard_green_on_current_main` ROUGE** : `WORKFLOW_COVERAGE` dans [scripts/check_testpaths_coverage.py](scripts/check_testpaths_coverage.py) est le **registre déclaré du garde**, pas le seul fichier workflow — la cible devait y être enregistrée aussi (« testpaths non couverts : scripts/audit/tests »). Fait.
2. **`test_check_orphan_merged_pr` — 3 tests `_main` exit 2 sur le runner** : la découverte de slug en fallback de `main()` exécute `gh repo view` même avec `--repo ""`, puis `analyse_pr` requête les PRs ouvertes sur la base ; le RuntimeError avalé rend exit 2 sans faute du code. Décorés `@requires_gh_auth` skipif (même politique que test_check_unaddressed_nits.py, review NanoClaw #14322 concern 2 : skip, pas FAILED) — **452 exécutés + 3 skips sur runner nu, 455 localement** (gh authentifié). Ce sont les seuls tests réellement env-dépendants de la suite — la lignée du marqueur `@pytest.mark.env` du dispatch, resserrée à 3 tests nommés.

Bonus : durcissement `encoding="utf-8"` du helper `_g` requis par le hook check-subprocess-encoding (#12811).

Vérifié localement : garde coverage 5/5, fichier orphan 37/37, suite audit 455/455.

## Périmètre

3 fichiers modifiés : `.github/workflows/scripts-tests.yml` (+34/−3), `scripts/check_testpaths_coverage.py` (+1 registre), `scripts/audit/tests/test_check_orphan_merged_pr.py` (skipif ×3 + helper + encoding). `pytest.ini` racine inchangé (la suite y est déjà listée ligne 9 — seule l'exclusion workflow la bloquait). Familles 3-6 de #14615 hors PR (G.4 strict, PR séparée par famille).

## Interleave G-VAR-3 (même genre que #14668)

Cette PR est `MED/test` comme #14668 (famille 1, ouverte) : séquence same-genre de la lane. Le `prev:` pointe au dernier PR MERGÉ de la lane (#14601, MED/guard — invariant #13475 : jamais une PR ouverte) ; l'interfoliage same-genre avec #14668 est documenté ici et par DM ai-01 : merger #14668 avant celle-ci (ou un PR d'autre genre entre les deux).

Tranche partielle (2/6 familles livrées) — le tracker reste ouvert :

See #14615
See #13746
