### PR TITLE
fix(prune,#14619): clean tolerated artifacts before no-force removal -- removable forecasts applied

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -203,23 +203,54 @@ jobs:
         # would abort the whole pytest session with a collection error (masking
         # every other result) — the exact failure mode this workflow exists to
         # prevent. agent_tests owner: po-2026 (Lean lane).
+        #
+        # scripts/audit/tests re-cabled here (family 2 of #14615): the
+        # 2026-08-14 CI-EXCLUDED reason (4 env-dependent failures, DALLE-3
+        # key) was fixed by #12837 (hermetic rewrite, urlopen monkeypatched).
+        # Measured firsthand 2026-09-04 on origin/main: 455/455 green with the
+        # OpenAI key unset (env -u re-run), zero network/gh subprocess, zero
+        # dep delta vs this job (pillow arrives transitively with matplotlib).
         run: |
           pytest \
             scripts/tests \
             scripts/notebook_tools/tests \
             scripts/lean/tests \
             scripts/translation/tests \
+            scripts/audit/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py \
             MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
             --tb=short -q
+
+      - name: Audit tests collection floor (455)
+        # Companion guard of the audit re-cabling (family 2 of #14615), same
+        # two-signal semantics as the GameTheory floor (#14614) and the dotnet
+        # Shared.Tests floor (#14668): a green run must not silently shrink.
+        # 0 collected = collection crash (import error), below floor = coverage
+        # regression — distinct exit-1 signals either way.
+        if: always()
+        env:
+          AUDIT_TESTS_FLOOR: 455
+        run: |
+          N=$(python -m pytest scripts/audit/tests --collect-only -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ tests collected' | grep -oE '^[0-9]+')
+          if [ -z "$N" ] || [ "$N" -eq 0 ]; then
+            echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."
+            exit 1
+          fi
+          if [ "$N" -lt "$AUDIT_TESTS_FLOOR" ]; then
+            echo "::error::Coverage regression: $N tests collected, floor=$AUDIT_TESTS_FLOOR."
+            echo "::error::If the drop is intentional, raise AUDIT_TESTS_FLOOR in the same PR."
+            exit 1
+          fi
+          echo "OK: $N tests collected (floor=$AUDIT_TESTS_FLOOR)."
       # CI-EXCLUDED — testpaths pytest.ini non couverts par ce run, garde #10903.
       # Retirer la ligne du répertoire câblé (et l'ajouter au run ci-dessus) quand
-      # l'herméticité est démontrée sur runner nu. Chaque raison est vérifiée
-      # firsthand (2026-08-14, po-2024) :
-      # CI-EXCLUDED: scripts/audit/tests — 4 échecs env-dépendants (test_regen_img1_dalle3.py, clé DALLE-3/OpenAI requise), 405 passent
+      # l'herméticité est démontrée sur runner nu. scripts/audit/tests a été
+      # retiré de cette liste le 2026-09-04 (famille 2 de #14615) :
+      # l'herméticité est démontrée (455/455 sans clé, #12837). Les raisons
+      # restantes sont vérifiées firsthand (2026-08-14, po-2024) :
       # CI-EXCLUDED: scripts/quantconnect/tests — deps yfinance + fichiers de données externes, non hermétique sur runner nu
       # CI-EXCLUDED: scripts/secrets/tests — 4/6 fichiers non couverts par secret-scan.yml (render_envs/render_settings_json) ; scan gitleaks = 2 fichiers dédiés
       # CI-EXCLUDED: GradeBookApp — deps openpyxl/rapidfuzz/unidecode non installées dans ce job ; PII grading hors CI publique

--- a/scripts/audit/tests/test_check_orphan_merged_pr.py
+++ b/scripts/audit/tests/test_check_orphan_merged_pr.py
@@ -31,6 +31,33 @@ from pathlib import Path
 import pytest
 
 HERE = Path(__file__).resolve().parent
+
+
+def _gh_auth_available() -> bool:
+    """Les tests `_main` ci-dessous passent par mod.main(), dont la
+    découverte de slug en fallback interroge `gh repo view` même avec
+    --repo "" (check_orphan_merged_pr.py main(), `args.repo or ...`), puis
+    analyse_pr requête les PRs ouvertes sur la base quand un slug existe.
+    Sur un runner sans gh authentifié, le RuntimeError est avalé en exit 2
+    et le test échoue sans faute du code. Skip propre, pas FAILED — même
+    politique que test_check_unaddressed_nits.py (review NanoClaw #14322,
+    concern 2) ; constaté au câblage CI de cette suite (#14615 famille 2).
+    """
+    import shutil
+    if shutil.which("gh") is None:
+        return False
+    return subprocess.run(
+        ["gh", "auth", "status"], capture_output=True
+    ).returncode == 0
+
+
+requires_gh_auth = pytest.mark.skipif(
+    not _gh_auth_available(),
+    reason="gh absent/unauthed -- main() (découverte slug + requête PRs "
+           "ouvertes sur la base) exige gh authentifié (#14615 famille 2)",
+)
+
+
 CHECK_PATH = HERE.parent / "check_orphan_merged_pr.py"
 
 
@@ -54,7 +81,8 @@ def _g(repo: Path, *args: str, date: str | None = None) -> str:
         env["GIT_AUTHOR_DATE"] = date
         env["GIT_COMMITTER_DATE"] = date
     cmd = ["git", "-C", str(repo), *_BASE_CFG, *args]
-    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env,
+                          encoding="utf-8", errors="replace")
     assert proc.returncode == 0, f"git {args} failed: {proc.stderr.strip()}"
     return proc.stdout.strip()
 
@@ -162,6 +190,7 @@ def test_orphan_after_base_squash_merge(tmp_path):
     assert "recovery" in res
 
 
+@requires_gh_auth
 def test_orphan_strict_exits_1_main(tmp_path):
     """main() with --strict returns 1 on a genuine orphan (criterion 1: red)."""
     mod = _load()
@@ -585,6 +614,7 @@ def test_main_clean_exits_0(tmp_path):
     assert rc == 0
 
 
+@requires_gh_auth
 def test_main_orphan_advisory_exits_0(tmp_path):
     mod = _load()
     repo = _git_repo(tmp_path)
@@ -711,6 +741,7 @@ def test_format_report_lists_adjudges_separately_and_counts():
     assert "adjuges: 1" in out
 
 
+@requires_gh_auth
 def test_main_adjudged_does_not_fail_strict(tmp_path):
     """main() avec registre qui adjuge le seul orphelin -> --strict exit 0 :
     le compte orphelins retombe a 0, l'adjudication n'est pas un finding."""

--- a/scripts/check_testpaths_coverage.py
+++ b/scripts/check_testpaths_coverage.py
@@ -43,6 +43,7 @@ WORKFLOW_COVERAGE: dict[str, list[str]] = {
         "scripts/notebook_tools/tests",
         "scripts/lean/tests",
         "scripts/translation/tests",
+        "scripts/audit/tests",
         "MyIA.AI.Notebooks/GameTheory/tests",
         "MyIA.AI.Notebooks/QuantConnect/scripts/tests",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py",

--- a/scripts/ci/prune_merged_worktrees.py
+++ b/scripts/ci/prune_merged_worktrees.py
@@ -66,7 +66,12 @@ rate les squash-merges, le second a des faux negatifs mesures.
    qu'il épargne est indiscernable d'un outil qui ne regarde pas.
 3. **Aucun `git worktree remove --force`.** Le retrait est `git worktree
    remove` sans --force ; si git refuse (worktree sale), on log la cause et
-   on continue (ne JAMAIS forcer).
+   on continue (ne JAMAIS forcer). Depuis #14619 : avant le retrait, l'apply
+   supprime exactement les artefacts untracked toleres (et eux seuls --
+   clean_tolerated_artifacts), sinon git refuse sur tout non-suivi et un
+   worktree classe REMOVE pour artefacts seulement ne part jamais. Un residu
+   hors liste tolerree est classe REFUSE (untolerated_untracked), pas REMOVE,
+   et un worktree a sous-modules REFUSE (contains_submodules).
 4. **Mode `--json` parallele au mode texte.** Mêmes chiffres, même ordre ;
    le recipient downstream (dashboard sweep, DM ai-01) parse le JSON sans
    réinventer le rendu.
@@ -114,6 +119,7 @@ import argparse
 import dataclasses
 import json
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -147,6 +153,10 @@ UNTRACKED_ARTIFACT_TOKENS = (
     "/build/",
     ".eggs",
     ".tox",
+    # #14619 : residus BG-prover constates sur les machines (un fichier de
+    # log chacun bloquait le retrait de worktrees mergees).
+    "bg_logs",
+    ".log.relaunch",
 )
 
 # Extensions/editions source : si du contenu untracked touche un fichier
@@ -255,6 +265,25 @@ def same_worktree_path(a: str, b: str) -> bool:
                 == b.replace("\\", "/").rstrip("/").lower())
 
 
+def has_initialized_submodule(submodule_status_stdout: str) -> bool:
+    """True si au moins un sous-module est INITIALISÉ dans ce worktree.
+
+    `git submodule status` liste tous les sous-modules CONFIGURÉS du repo,
+    y compris non-initialisés (préfixe '-') — et ce dans chaque worktree.
+    Seuls les initialisés (matérialisés : un .git vit dans le chemin) font
+    refuser `git worktree remove`. Mesuré firsthand 2026-09-04 (#14619) :
+    ce repo porte des submodules configurés (MetaGeneticSharp…), tous en
+    '-' dans les worktrees de feature — git les retire sans protester ;
+    matcher sur la sortie brute aurait REFUSE les 55 worktrees d'un coup.
+    Préfixes : '-' = non initialisé ; '' = initialisé au sha enregistré ;
+    '+' = initialisé à un autre sha ; 'U' = conflit. Tout sauf '-' compte.
+    """
+    return any(
+        line.strip() and not line.strip().startswith("-")
+        for line in submodule_status_stdout.splitlines()
+    )
+
+
 def get_worktree_info(wt_path: str, current_path: str) -> dict:
     """Recupere branch + ahead count + dirty status d'un worktree."""
     # Branche (peut etre None si HEAD detaché)
@@ -309,11 +338,20 @@ def get_worktree_info(wt_path: str, current_path: str) -> dict:
             # Modification tracked non commitee = source sale
             has_source = True
 
+    # Sous-modules : `git worktree remove` les refuse categoriquement
+    # ("working trees containing submodules cannot be moved or removed"),
+    # meme avec --force sur certains etats. #14619 : l'organe ne doit pas
+    # annoncer REMOVE ce que git interdit par construction. Seuls les
+    # sous-modules INITIALISÉS comptent (cf has_initialized_submodule).
+    subm_proc = run_git(wt_path, "submodule", "status", check=False)
+    has_submodules = has_initialized_submodule(subm_proc.stdout)
+
     return {
         "branch": branch,
         "ahead_count": ahead_count,
         "untracked": untracked,
         "has_source_dirty": has_source,
+        "has_submodules": has_submodules,
         "is_current": same_worktree_path(wt_path, current_path),
     }
 
@@ -475,6 +513,23 @@ def diagnose_worktree(wt_path: str, current_path: str) -> WorktreeStatus:
             refusal_reason="protected_branch:main",
         )
 
+    # Sous-modules : git interdit le retrait par construction -> REFUSE sans
+    # meme annoncer REMOVE (#14619 point 4).
+    if info.get("has_submodules"):
+        return WorktreeStatus(
+            path=wt_path,
+            branch=info["branch"],
+            is_current=False,
+            pr_state=None,
+            pr_number=None,
+            pr_url=None,
+            ahead_count=info["ahead_count"],
+            has_source_dirty=info["has_source_dirty"],
+            untracked_paths=info["untracked"],
+            decision="REFUSE",
+            refusal_reason="contains_submodules",
+        )
+
     # Predicat 1 : commits non poussés -> REFUSE inconditionnel
     if info["branch"] and info["ahead_count"] > 0:
         return WorktreeStatus(
@@ -505,6 +560,31 @@ def diagnose_worktree(wt_path: str, current_path: str) -> WorktreeStatus:
             untracked_paths=info["untracked"],
             decision="REFUSE",
             refusal_reason="uncommitted_source_changes",
+        )
+
+    # Predicat 2b : residu untracked NON tolere -> REFUSE (#14619 point 2).
+    # `git worktree remove` sans --force refuse sur TOUT fichier non suivi,
+    # tolere ou non : un worktree qui porte un residu hors liste toleree ne
+    # pourra jamais etre retire, il ne doit donc pas etre compte removable.
+    # Le nettoyage a l'apply (clean_tolerated_artifacts) ne touche que la
+    # liste toleree -- ce REFUSE est le complement fail-closed du couple
+    # classification/execution.
+    untolerated = [
+        p for p in info["untracked"] if not is_untracked_artifact(p)
+    ]
+    if untolerated:
+        return WorktreeStatus(
+            path=wt_path,
+            branch=info["branch"],
+            is_current=False,
+            pr_state=None,
+            pr_number=None,
+            pr_url=None,
+            ahead_count=info["ahead_count"],
+            has_source_dirty=info["has_source_dirty"],
+            untracked_paths=info["untracked"],
+            decision="REFUSE",
+            refusal_reason=f"untolerated_untracked:{len(untolerated)}",
         )
 
     # Resolution PR
@@ -586,6 +666,59 @@ def list_worktrees() -> list[dict]:
     if cur:
         out.append(cur)
     return out
+
+
+def clean_tolerated_artifacts(wt: WorktreeStatus) -> list[str]:
+    """Supprime les SEULS artefacts tolérés du worktree, avant retrait.
+
+    #14619 : la liste tolérée encode déjà le jugement « ces fichiers ne
+    valent rien » (caches, logs BG, résultats). `git worktree remove` sans
+    --force refuse sur TOUT fichier non suivi, toléré ou non : sans ce
+    nettoyage, un worktree classé REMOVE pour artefacts seulement ne peut
+    jamais être retiré (removable n'est alors pas une prévision de applied).
+
+    Garde-fous :
+    - seuls les chemins untracked qui matchent la liste tolérée sont visés ;
+    - chaque cible doit résoudre DANS le worktree (défense en profondeur
+      contre une entrée porcelain inattendue) ;
+    - jamais de `--force` : le retrait reste `git worktree remove` nu. Si un
+      résidu hors liste survient entre le diagnostic et l'apply, git refuse
+      et le statut FAILED rend la cause (fail-closed).
+    """
+    removed: list[str] = []
+    root = Path(wt.path)
+    try:
+        root_resolved = root.resolve()
+    except OSError:
+        return removed
+    for rel in wt.untracked_paths:
+        if not is_untracked_artifact(rel):
+            continue
+        target = root / rel.rstrip("/\\")
+        try:
+            if not target.resolve().is_relative_to(root_resolved):
+                continue
+        except OSError:
+            continue
+        if target.is_symlink():
+            # rmtree sur un lien symbolique leve OSError ; unlink est le
+            # geste correct et ne touche pas la cible.
+            try:
+                target.unlink()
+                removed.append(rel)
+            except OSError:
+                continue
+        elif target.is_dir():
+            shutil.rmtree(target, ignore_errors=True)
+            if not target.exists():
+                removed.append(rel)
+        elif target.exists():
+            try:
+                target.unlink()
+                removed.append(rel)
+            except OSError:
+                continue
+    return removed
 
 
 def apply_removal(wt: WorktreeStatus) -> tuple[bool, str]:
@@ -717,6 +850,9 @@ def main() -> int:
                 if s.decision == "REFUSE":
                     refused_count += 1
                 continue
+            # #14619 : nettoyer exactement les artefacts tolérés AVANT le
+            # retrait sans force, sinon git refuse sur tout untracked.
+            cleaned = clean_tolerated_artifacts(s)
             ok, stderr = apply_removal(s)
             apply_results.append({
                 "path": s.path,
@@ -724,6 +860,7 @@ def main() -> int:
                 "pr_number": s.pr_number,
                 "applied": ok,
                 "stderr": stderr,
+                "cleaned_artifacts": cleaned,
             })
             if ok:
                 removal_count += 1

--- a/scripts/tests/test_prune_merged_worktrees.py
+++ b/scripts/tests/test_prune_merged_worktrees.py
@@ -478,6 +478,133 @@ class TestRenderText:
 
 
 # ---------------------------------------------------------------------------
+# #14619 -- removable doit etre une prevision de applied
+# ---------------------------------------------------------------------------
+
+
+_MERGED_PR = {
+    "number": 14670, "state": "MERGED",
+    "url": "https://github.com/jsboige/CoursIA/pull/14670",
+    "headRefName": "fix/merged-thing",
+}
+
+
+def _fake_info(**overrides):
+    defaults = dict(
+        branch="fix/merged-thing",
+        ahead_count=0,
+        untracked=[],
+        has_source_dirty=False,
+        has_submodules=False,
+        is_current=False,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+class TestToleratedCleanup14619:
+    """Correctif #14619 : nettoyage des seuls artefacts tolérés avant retrait
+    sans force, REFUSE sur résidu hors liste, REFUSE sur sous-modules."""
+
+    def test_bg_logs_dir_is_artifact(self):
+        assert pmw.is_untracked_artifact(
+            "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/bg_logs/") is True
+        assert pmw.is_untracked_artifact(
+            "agent_tests/bg_logs/run.jsonl") is True
+
+    def test_log_relaunch_is_artifact(self):
+        # Cas exact mesure sur D:/CoursIA-wt/c552-7012-build (#14619)
+        assert pmw.is_untracked_artifact("lake_7012.log.relaunch") is True
+
+    def test_clean_removes_only_tolerated(self, tmp_path):
+        (tmp_path / "bg_logs").mkdir()
+        (tmp_path / "bg_logs" / "run.jsonl").write_text(
+            "{}", encoding="utf-8")
+        (tmp_path / "lake_7012.log.relaunch").write_text(
+            "log", encoding="utf-8")
+        keep = tmp_path / "src" / "keep.py"
+        keep.parent.mkdir()
+        keep.write_text("x = 1", encoding="utf-8")
+        wt = _make_status(
+            path=str(tmp_path),
+            untracked_paths=[
+                "bg_logs/", "lake_7012.log.relaunch", "src/keep.py",
+            ],
+        )
+        removed = pmw.clean_tolerated_artifacts(wt)
+        assert sorted(removed) == ["bg_logs/", "lake_7012.log.relaunch"]
+        assert not (tmp_path / "bg_logs").exists()
+        assert not (tmp_path / "lake_7012.log.relaunch").exists()
+        assert keep.exists(), "untracked non toléré ne doit pas être touché"
+
+    def test_clean_never_escapes_worktree(self, tmp_path):
+        probe = tmp_path.parent / "prune_escape_probe_14619.txt"
+        wt = _make_status(
+            path=str(tmp_path),
+            untracked_paths=["slides/images/../../prune_escape_probe_14619.txt"],
+        )
+        removed = pmw.clean_tolerated_artifacts(wt)
+        assert removed == []
+        assert not probe.exists(), "la cible résolue doit rester dans le worktree"
+
+    def test_diagnose_remove_when_only_tolerated_artifacts(self, monkeypatch):
+        monkeypatch.setattr(
+            pmw, "get_worktree_info",
+            lambda *a, **k: _fake_info(
+                untracked=["bg_logs/", "lake_7012.log.relaunch"]),
+        )
+        monkeypatch.setattr(
+            pmw, "lookup_pr_for_branch", lambda b: dict(_MERGED_PR))
+        s = pmw.diagnose_worktree("C:/fake/wt", "C:/elsewhere")
+        assert s.decision == "REMOVE"
+
+    def test_diagnose_refuse_untolerated_untracked(self, monkeypatch):
+        monkeypatch.setattr(
+            pmw, "get_worktree_info",
+            lambda *a, **k: _fake_info(untracked=["residu.bin"]),
+        )
+        monkeypatch.setattr(
+            pmw, "lookup_pr_for_branch", lambda b: dict(_MERGED_PR))
+        s = pmw.diagnose_worktree("C:/fake/wt", "C:/elsewhere")
+        assert s.decision == "REFUSE"
+        assert s.refusal_reason == "untolerated_untracked:1"
+
+    def test_submodule_detection_ignores_uninitialized(self):
+        # `git submodule status` liste les submodules CONFIGURÉS dans tous
+        # les worktrees ; seuls les initialisés (sans préfixe '-') bloquent
+        # `git worktree remove`. Matcher la sortie brute refuserait tout.
+        assert pmw.has_initialized_submodule("") is False
+        assert pmw.has_initialized_submodule(
+            "-cac5abc MyIA.AI.Notebooks/GenAI/SemanticKernel/semantic-fleet"
+        ) is False
+        assert pmw.has_initialized_submodule(
+            "-abc path/one\n-def path/two\n"
+        ) is False
+        assert pmw.has_initialized_submodule(
+            " 30c3993 MyIA.AI.Notebooks/Search/MetaGeneticSharp (v0.1.0)"
+        ) is True
+        assert pmw.has_initialized_submodule("+abc path/one") is True
+        assert pmw.has_initialized_submodule(
+            "-abc path/one\n 30c3993 path/initialized\n"
+        ) is True
+
+    def test_diagnose_refuse_submodules(self, monkeypatch):
+        monkeypatch.setattr(
+            pmw, "get_worktree_info",
+            lambda *a, **k: _fake_info(has_submodules=True),
+        )
+        s = pmw.diagnose_worktree("C:/fake/wt", "C:/elsewhere")
+        assert s.decision == "REFUSE"
+        assert s.refusal_reason == "contains_submodules"
+
+    def test_no_force_in_source(self):
+        src = Path(pmw.__file__).read_text(encoding="utf-8")
+        assert '"--force"' not in src and "'--force'" not in src, (
+            "la propriété no-force (docstring règle 3) doit tenir"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Tests d'integration subprocess sur le repo reel
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Quoi

Correctif #14619 : `removable` redevient une **prévision de `applied`** dans `prune_merged_worktrees.py` — l'incohérence entre le prédicat de classement (tolère les artefacts) et la politique d'exécution (`git worktree remove` sans force refuse sur TOUT non-suivi, toléré ou non) est résolue dans les deux sens, en préservant les deux propriétés de sécurité (jamais `--force`, jamais de suppression hors liste tolérée).

Les 4 points du correctif de l'issue :
1. **Nettoyage exact des artefacts tolérés avant retrait** : `clean_tolerated_artifacts` (garde de confinement par `resolve().is_relative_to()`, symlink-first, append seulement si réellement parti) précède le retrait sans force.
2. **Résidu hors liste = REFUSE** (`untolerated_untracked:N`) au classement — un worktree qui ne peut pas être retiré n'est pas compté removable.
3. `bg_logs` + `.log.relaunch` ajoutés à `UNTRACKED_ARTIFACT_TOKENS` (les 2 résidus mesurés sur ai-01).
4. **Sous-modules = REFUSE** (`contains_submodules`) — détection sur les entrées **initialisées** seulement.

## Le piège attrapé avant tout apply (dry-run d'abord, toujours)

Première version de la détection sous-modules : `git submodule status` non vide. **Faux positif massif** — ce repo a des submodules *configurés* (MetaGeneticSharp, Argumentum…) listés dans CHAQUE worktree, préfixés `-` quand non-initialisés : le dry-run a REFUSÉ les 55 worktrees d'un coup. Corrigé sur l'entrée `has_initialized_submodule` (tout préfixe sauf `-`), vérifié contre le disque : checkout principal = 2 initialisés (REFUSE légitime), worktrees de feature = tous `-` (retirables). **Aucun apply n'a eu lieu avant ce diagnostic** — la discipline dry-run-first a tenu.

## Contrôle positif exigible (exécuté réellement)

Sonde : worktree HEAD détaché sur commit de PR mergée + `lake_7012.log.relaunch` + `scripts/bg_logs/` (les deux artefacts du cas ai-01) :

```
removable 15 applied 15 errors 0
PROBE True C:/dev/CoursIA-t14619 | cleaned: ['lake_7012.log.relaunch', 'scripts/bg_logs/']
```

`applied == removable` exactement (acceptance 1), la sonde passe deREMOVE→nettoyée→retirée, et `C:/dev/CoursIA-c162-z3dt` (submodule Z3 initialisé) est correctement REFUSE. Bonus opérationnel : 14 worktrees stalés de PRs mergées libérés sur la machine de dev (campagne disque #14612).

## Acceptance (4/4)

- [x] `applied == removable` du dry-run précédent (15/15 mesuré live)
- [x] Aucun `--force` (assertion grep `test_no_force_in_source` + propriété docstring l.67-69 tenue)
- [x] Worktree avec untracked **hors** liste reste REFUSE (`test_diagnose_refuse_untolerated_untracked` + garde d'échappement `test_clean_never_escapes_worktree`)
- [x] Worktree à sous-modules classé REFUSE pas REMOVE (`test_diagnose_refuse_submodules` + parsing `-` `test_submodule_detection_ignores_uninitialized` + cas réel c162-z3dt)

Tests : **43 passed, 1 skipped** (9 nouveaux), dont les EndToEnd subprocess sur le repo réel.

Closes #14619
