### PR TITLE
ci(cabling,#14615): recable scripts/secrets/tests into scripts-tests.yml (family 4/6)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -214,6 +214,7 @@ jobs:
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py \
             MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
+            scripts/secrets/tests \
             --tb=short -q
       # CI-EXCLUDED — testpaths pytest.ini non couverts par ce run, garde #10903.
       # Retirer la ligne du répertoire câblé (et l'ajouter au run ci-dessus) quand
@@ -221,5 +222,19 @@ jobs:
       # firsthand (2026-08-14, po-2024) :
       # CI-EXCLUDED: scripts/audit/tests — 4 échecs env-dépendants (test_regen_img1_dalle3.py, clé DALLE-3/OpenAI requise), 405 passent
       # CI-EXCLUDED: scripts/quantconnect/tests — deps yfinance + fichiers de données externes, non hermétique sur runner nu
-      # CI-EXCLUDED: scripts/secrets/tests — 4/6 fichiers non couverts par secret-scan.yml (render_envs/render_settings_json) ; scan gitleaks = 2 fichiers dédiés
+      # scripts/secrets/tests re-câblé (famille 4 de #14615, 2026-09-04) :
+      # dir entier dans le run ci-dessus. Les 2 modules gitleaks
+      # (test_gitleaks_qwen_rule.py, test_gitleaks_10143_classes.py) y sont
+      # collectés mais SKIP sans binaire gitleaks (docstring : skip si absent,
+      # gate autoritaire = secret-scan.yml qui les exécute avec le binaire).
       # CI-EXCLUDED: GradeBookApp — deps openpyxl/rapidfuzz/unidecode non installées dans ce job ; PII grading hors CI publique
+
+      - name: Secrets tests collection floor (148)
+        if: always()
+        env:
+          SECRETS_TESTS_FLOOR: 148
+        run: |
+          N=$(python -m pytest scripts/secrets/tests --collect-only -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ tests collected' | grep -oE '^[0-9]+')
+          if [ -z "$N" ] || [ "$N" -eq 0 ]; then echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."; exit 1; fi
+          if [ "$N" -lt "$SECRETS_TESTS_FLOOR" ]; then echo "::error::Coverage regression: $N tests collected, floor=$SECRETS_TESTS_FLOOR."; exit 1; fi
+          echo "OK: $N tests collected (floor=$SECRETS_TESTS_FLOOR)."

--- a/scripts/check_testpaths_coverage.py
+++ b/scripts/check_testpaths_coverage.py
@@ -40,6 +40,10 @@ PYTEST_INI = REPO_ROOT / "pytest.ini"
 WORKFLOW_COVERAGE: dict[str, list[str]] = {
     ".github/workflows/scripts-tests.yml": [
         "scripts/tests",
+        # scripts/secrets/tests : dir entier (famille 4 de #14615) — les 2
+        # modules gitleaks y skip sans binaire (gate binaire = secret-scan.yml,
+        # cibles fichier ci-dessous).
+        "scripts/secrets/tests",
         "scripts/notebook_tools/tests",
         "scripts/lean/tests",
         "scripts/translation/tests",

--- a/scripts/secrets/tests/test_render_envs.py
+++ b/scripts/secrets/tests/test_render_envs.py
@@ -347,6 +347,10 @@ class TestConstants:
             "GITHUB_ACCESS_TOKEN": "GITHUB_TOKEN",
             # #10265: Qwen legacy alias (kept by auth_manager.py:233).
             "QWEN_API_USER_TOKEN": "QWEN_API_TOKEN",
+            # #14382: ComfyUI-Login bearer, notebook-client canonical name
+            # (COMFYUI_AUTH_TOKEN shadows COMFYUI_API_TOKEN in the ``or``
+            # fallback chain -> 401 when stale).
+            "COMFYUI_AUTH_TOKEN": "COMFYUI_API_TOKEN",
         }
 
 

--- a/scripts/secrets/tests/test_verify_running_containers.py
+++ b/scripts/secrets/tests/test_verify_running_containers.py
@@ -202,6 +202,12 @@ def test_main_drift_returns_1(tmp_path, monkeypatch, capsys):
     _make_service_tree(tmp_path, "drifty", _DRIFT_COMPOSE)
     monkeypatch.setattr(mod, "SERVICES_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_container_env", lambda c: {"API_KEY": "stale"})
+    # Patch master read like test_main_ok_returns_0: without it the empty
+    # master gate (no .secrets/ on a runner or fresh worktree) exits 2
+    # before any drift is audited.
+    monkeypatch.setattr(
+        mod, "_read_master_env", lambda: {"WHISPER_API_KEY": "fixture-whisper-XXXX-1234"}
+    )
     monkeypatch.setattr(sys, "argv", ["verify"])
     rc = mod.main()
     assert rc == 1


### PR DESCRIPTION
Grain: MED/test -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Quoi

Famille 4/6 de #14615 (tranche 2-7 de #13746) : re-câblage de `scripts/secrets/tests` — le testpath **entier** (5 modules, 148 tests) — dans le job **Scripts Tests (CPU)** de `scripts-tests.yml`, dont il était exclu alors que secret-scan.yml n'en couvrait que les 2 modules gitleaks (cibles FICHIER, qui ne couvrent aucun testpath au sens du garde #10903).

## La preuve que l'exclusion masquait du rot réel (mesuré sur origin/main frais)

La suite n'avait **jamais été exécutée en CI** (secret-scan = 2 modules seulement). Baseline locale sur worktree frais origin/main : **2 failed / 131 passed / 15 skipped** :

1. `test_render_envs.py::TestConstants::test_aliases_mapping` — attend un dict `ALIASES` sans l'entrée `COMFYUI_AUTH_TOKEN: COMFYUI_API_TOKEN` ajoutée par #14382 (merge postérieur à la dernière exécution vérifiée de ce test). Mis à jour avec la référence #14382 en commentaire.
2. `test_verify_running_containers.py::test_main_drift_returns_1` — exit 2 au lieu de 1 : le test ne monkeypatch pas `_read_master_env`, contrairement à son sibling `test_main_ok_returns_0` (l.221) ; la gate « master.env vide » (l.238-240 de `verify_running_containers.py`) sort rc=2 sur tout runner/fresh worktree sans `.secrets/master.env`. Monkeypatch ajouté, miroir du sibling, valeur fixture factice (pas de littéral secret).

Après correctifs : **133 passed / 15 skipped** (les 15 skips = les 2 modules gitleaks sans binaire — comportement documenté dans leur docstring : « if it is missing, the test is skipped (CI is the authoritative gate…) » ; leur gate avec binaire reste secret-scan.yml, inchangé).

## Les 3 registres du garde #10903 (leçon famille 2)

- run list du workflow : `scripts/secrets/tests \` ajouté (fin de liste) ;
- `WORKFLOW_COVERAGE` (dict codé dur, source de vérité) : entrée dir après `scripts/tests` ;
- marqueur `# CI-EXCLUDED: scripts/secrets/tests` retiré (remplacé par un commentaire SANS préfixe marqueur — le garde : couverture prime sur exclusion, un marqueur mort serait trompeur).

Garde vérifié localement : `check_testpaths_coverage.py --verbose` → `[ok] couvert: scripts/secrets/tests`, et sa suite pytest **5/5 verts** (dont `test_guard_green_on_current_main` sur fichiers live).

## Floor (148)

Step compagnon `Secrets tests collection floor (148)` (`if: always()`), mêmes sémantiques deux-signaux que les floors des familles 1-2 : `N==0` = panne de collecte, `N < 148` = régression de couverture, exit 1 distincts. Pipeline d'extraction prouvé localement (N=148).

## Mesures firsthand (origin/main 3881b766a)

- suite secrets : 133 passed / 15 skipped en 0.64 s (stddev négligeable) ;
- invocation CI combinée complète (run list exact du workflow + secrets) : **11 553 tests collectés, 0 erreur** (11 405 + 148) ;
- zéro nouvelle dépendance : les 3 modules non-gitleaks sont stdlib-only (dotenv parse maison, parse compose), les 2 gitleaks skip sans binaire.

## Interleave G-VAR-3 (3e MED/test de la lane en vol)

Chaîne same-genre à merger dans l'ordre : **#14668 → #14670 → celle-ci** (toutes MED/test, lane po-2026 ; `prev` pointe au dernier MERGÉ #14601, invariant #13475). Conflit textuel possible avec #14670 sur `scripts-tests.yml`/`check_testpaths_coverage.py` (mêmes fichiers, ancres différentes choisies ici exprès — insertion en fin de liste vs leur position) : résolution triviale, rebase à la demande.

## Périmètre

4 fichiers modifiés (+30/−1) : `.github/workflows/scripts-tests.yml`, `scripts/check_testpaths_coverage.py`, `scripts/secrets/tests/test_render_envs.py`, `scripts/secrets/tests/test_verify_running_containers.py`. `pytest.ini` inchangé (testpath déjà déclaré l.12). Familles 3, 5, 6 hors PR (G.4 strict, une PR par famille).

Tranche partielle (3/6 familles livrées) — le tracker reste ouvert :

See #14615
See #13746
