### PR TITLE
feat(picker,#14591): Volets B + C mesures chiffrees (G-VAR-2 fenetre + dwell veto)

### DIFF
--- a/docs/ledgers/14591-volet-bc-mesure.json
+++ b/docs/ledgers/14591-volet-bc-mesure.json
@@ -1,0 +1,1051 @@
+{
+  "since": "2026-08-21",
+  "until": "2026-09-04",
+  "merges_total": 1000,
+  "volet_b": {
+    "summary": {
+      "myia-ai-01:CoursIA": {
+        "days_active": 11,
+        "budget_reached_days": 11,
+        "light_peak_day": 15
+      },
+      "myia-ai-01:LivresAgit": {
+        "days_active": 7,
+        "budget_reached_days": 3,
+        "light_peak_day": 2
+      },
+      "myia-ai-01:myia-open-webui": {
+        "days_active": 1,
+        "budget_reached_days": 1,
+        "light_peak_day": 1
+      },
+      "myia-po-2023:CoursIA": {
+        "days_active": 8,
+        "budget_reached_days": 4,
+        "light_peak_day": 9
+      },
+      "myia-po-2023:CoursIA-2": {
+        "days_active": 10,
+        "budget_reached_days": 7,
+        "light_peak_day": 10
+      },
+      "myia-po-2024:CoursIA": {
+        "days_active": 9,
+        "budget_reached_days": 6,
+        "light_peak_day": 16
+      },
+      "myia-po-2024:CoursIA-2": {
+        "days_active": 11,
+        "budget_reached_days": 8,
+        "light_peak_day": 7
+      },
+      "myia-po-2025-win32-x64:2026-Epita-Programmation-par-Contraintes": {
+        "days_active": 3,
+        "budget_reached_days": 0,
+        "light_peak_day": 0
+      },
+      "myia-po-2025:CoursIA": {
+        "days_active": 11,
+        "budget_reached_days": 3,
+        "light_peak_day": 2
+      },
+      "myia-po-2025:CoursIA-2": {
+        "days_active": 5,
+        "budget_reached_days": 3,
+        "light_peak_day": 3
+      },
+      "myia-po-2025:Microsoft": {
+        "days_active": 1,
+        "budget_reached_days": 1,
+        "light_peak_day": 1
+      },
+      "myia-po-2026:CoursIA": {
+        "days_active": 9,
+        "budget_reached_days": 9,
+        "light_peak_day": 29
+      },
+      "myia-po-2026:CoursIA-2": {
+        "days_active": 10,
+        "budget_reached_days": 8,
+        "light_peak_day": 8
+      },
+      "myia-po-2027:CoursIA": {
+        "days_active": 8,
+        "budget_reached_days": 5,
+        "light_peak_day": 3
+      },
+      "myia-po-2027:CoursIA-2": {
+        "days_active": 11,
+        "budget_reached_days": 6,
+        "light_peak_day": 9
+      }
+    },
+    "rows": [
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-25",
+        "total": 2,
+        "light": 2,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-26",
+        "total": 2,
+        "light": 2,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-27",
+        "total": 2,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-28",
+        "total": 3,
+        "light": 3,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-29",
+        "total": 11,
+        "light": 6,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-30",
+        "total": 13,
+        "light": 13,
+        "budget": 4,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-08-31",
+        "total": 7,
+        "light": 6,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-09-01",
+        "total": 9,
+        "light": 8,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-09-02",
+        "total": 16,
+        "light": 15,
+        "budget": 5,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-09-03",
+        "total": 10,
+        "light": 8,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:CoursIA",
+        "day": "2026-09-04",
+        "total": 7,
+        "light": 5,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-08-28",
+        "total": 2,
+        "light": 2,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-08-29",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-08-31",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-09-01",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-09-02",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-09-03",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-ai-01:LivresAgit",
+        "day": "2026-09-04",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-ai-01:myia-open-webui",
+        "day": "2026-09-01",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-08-28",
+        "total": 16,
+        "light": 1,
+        "budget": 5,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-08-29",
+        "total": 2,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-08-30",
+        "total": 16,
+        "light": 9,
+        "budget": 5,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-08-31",
+        "total": 2,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-09-01",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-09-02",
+        "total": 17,
+        "light": 8,
+        "budget": 5,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-09-03",
+        "total": 11,
+        "light": 2,
+        "budget": 3,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA",
+        "day": "2026-09-04",
+        "total": 8,
+        "light": 4,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-08-25",
+        "total": 9,
+        "light": 6,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-08-26",
+        "total": 6,
+        "light": 4,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-08-28",
+        "total": 25,
+        "light": 7,
+        "budget": 8,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-08-29",
+        "total": 23,
+        "light": 7,
+        "budget": 7,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-08-30",
+        "total": 19,
+        "light": 10,
+        "budget": 6,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-08-31",
+        "total": 13,
+        "light": 2,
+        "budget": 4,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-09-01",
+        "total": 10,
+        "light": 3,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-09-02",
+        "total": 12,
+        "light": 3,
+        "budget": 4,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-09-03",
+        "total": 7,
+        "light": 3,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2023:CoursIA-2",
+        "day": "2026-09-04",
+        "total": 6,
+        "light": 4,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-08-26",
+        "total": 4,
+        "light": 4,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-08-27",
+        "total": 9,
+        "light": 1,
+        "budget": 3,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-08-28",
+        "total": 27,
+        "light": 11,
+        "budget": 9,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-08-29",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-08-30",
+        "total": 8,
+        "light": 2,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-08-31",
+        "total": 14,
+        "light": 4,
+        "budget": 4,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-09-01",
+        "total": 15,
+        "light": 2,
+        "budget": 5,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-09-02",
+        "total": 19,
+        "light": 16,
+        "budget": 6,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA",
+        "day": "2026-09-04",
+        "total": 8,
+        "light": 5,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-25",
+        "total": 2,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-26",
+        "total": 4,
+        "light": 2,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-27",
+        "total": 13,
+        "light": 6,
+        "budget": 4,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-28",
+        "total": 20,
+        "light": 7,
+        "budget": 6,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-29",
+        "total": 6,
+        "light": 2,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-30",
+        "total": 12,
+        "light": 3,
+        "budget": 4,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-08-31",
+        "total": 4,
+        "light": 2,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-09-01",
+        "total": 5,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-09-02",
+        "total": 23,
+        "light": 7,
+        "budget": 7,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-09-03",
+        "total": 10,
+        "light": 3,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2024:CoursIA-2",
+        "day": "2026-09-04",
+        "total": 4,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025-win32-x64:2026-Epita-Programmation-par-Contraintes",
+        "day": "2026-09-01",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025-win32-x64:2026-Epita-Programmation-par-Contraintes",
+        "day": "2026-09-02",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025-win32-x64:2026-Epita-Programmation-par-Contraintes",
+        "day": "2026-09-03",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-25",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-26",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-27",
+        "total": 3,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-28",
+        "total": 9,
+        "light": 1,
+        "budget": 3,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-29",
+        "total": 14,
+        "light": 1,
+        "budget": 4,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-30",
+        "total": 8,
+        "light": 0,
+        "budget": 2,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-08-31",
+        "total": 12,
+        "light": 2,
+        "budget": 4,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-09-01",
+        "total": 6,
+        "light": 1,
+        "budget": 2,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-09-02",
+        "total": 9,
+        "light": 1,
+        "budget": 3,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-09-03",
+        "total": 12,
+        "light": 2,
+        "budget": 4,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA",
+        "day": "2026-09-04",
+        "total": 3,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2025:CoursIA-2",
+        "day": "2026-08-25",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2025:CoursIA-2",
+        "day": "2026-08-27",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:CoursIA-2",
+        "day": "2026-08-31",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2025:CoursIA-2",
+        "day": "2026-09-01",
+        "total": 6,
+        "light": 3,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2025:CoursIA-2",
+        "day": "2026-09-03",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2025:Microsoft",
+        "day": "2026-09-02",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-08-27",
+        "total": 10,
+        "light": 3,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-08-28",
+        "total": 15,
+        "light": 11,
+        "budget": 5,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-08-29",
+        "total": 39,
+        "light": 19,
+        "budget": 13,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-08-30",
+        "total": 14,
+        "light": 8,
+        "budget": 4,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-08-31",
+        "total": 3,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-09-01",
+        "total": 19,
+        "light": 13,
+        "budget": 6,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-09-02",
+        "total": 47,
+        "light": 29,
+        "budget": 15,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-09-03",
+        "total": 39,
+        "light": 13,
+        "budget": 13,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA",
+        "day": "2026-09-04",
+        "total": 18,
+        "light": 9,
+        "budget": 6,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-08-26",
+        "total": 5,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-08-27",
+        "total": 1,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-08-28",
+        "total": 6,
+        "light": 3,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-08-29",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-08-30",
+        "total": 10,
+        "light": 5,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-08-31",
+        "total": 4,
+        "light": 3,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-09-01",
+        "total": 11,
+        "light": 6,
+        "budget": 3,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-09-02",
+        "total": 21,
+        "light": 8,
+        "budget": 7,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-09-03",
+        "total": 8,
+        "light": 0,
+        "budget": 2,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2026:CoursIA-2",
+        "day": "2026-09-04",
+        "total": 2,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-08-28",
+        "total": 3,
+        "light": 3,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-08-29",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-08-30",
+        "total": 3,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-08-31",
+        "total": 5,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-09-01",
+        "total": 17,
+        "light": 1,
+        "budget": 5,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-09-02",
+        "total": 6,
+        "light": 2,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-09-03",
+        "total": 8,
+        "light": 2,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA",
+        "day": "2026-09-04",
+        "total": 7,
+        "light": 2,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-25",
+        "total": 4,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-26",
+        "total": 3,
+        "light": 2,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-27",
+        "total": 2,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-28",
+        "total": 23,
+        "light": 9,
+        "budget": 7,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-29",
+        "total": 3,
+        "light": 1,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-30",
+        "total": 7,
+        "light": 4,
+        "budget": 2,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-08-31",
+        "total": 6,
+        "light": 1,
+        "budget": 2,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-09-01",
+        "total": 7,
+        "light": 0,
+        "budget": 2,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-09-02",
+        "total": 9,
+        "light": 2,
+        "budget": 3,
+        "atteint": false
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-09-03",
+        "total": 5,
+        "light": 3,
+        "budget": 1,
+        "atteint": true
+      },
+      {
+        "lane": "myia-po-2027:CoursIA-2",
+        "day": "2026-09-04",
+        "total": 1,
+        "light": 0,
+        "budget": 1,
+        "atteint": false
+      }
+    ],
+    "verdict": {
+      "lanes_with_budget_reached": 14,
+      "total_lanes": 15,
+      "total_days_active": 115,
+      "total_budget_reached_days": 75,
+      "pct_budget_reached": 65.2,
+      "verdict": "FENETRE_TROP_SERREE"
+    },
+    "controle_positif": {
+      "target_lane": "myia-po-2024:CoursIA-2",
+      "target_day": "2026-08-25",
+      "found": true,
+      "total": 2,
+      "light": 1,
+      "budget": 1,
+      "atteint": true,
+      "verdict": "OK"
+    }
+  },
+  "volet_c": {
+    "raw": {
+      "lane": "myia-po-2027:CoursIA-2",
+      "seeds": 3,
+      "retenu_per_seed": [
+        52,
+        52,
+        49
+      ],
+      "dwell_per_seed": [
+        3,
+        3,
+        3
+      ],
+      "contenu_retained_per_seed": [
+        0,
+        0,
+        0
+      ]
+    },
+    "verdict": {
+      "total_dwell": 9,
+      "total_contenu_retained_by_dwell": 0,
+      "pct_contenu_caught_by_dwell": 0.0,
+      "verdict": "DWELL_INOFFENSIF"
+    }
+  }
+}

--- a/docs/ledgers/14591-volet-bc-mesure.md
+++ b/docs/ledgers/14591-volet-bc-mesure.md
@@ -1,0 +1,72 @@
+# #14591 Volets B + C — mesure chiffrée (2026-09-04)
+
+## Volet B — fenêtre G-VAR-2 trop serrée
+
+**Mesure : 75/115 jours-lane (65.2%) atteignent le budget LIGHT avant que le numérateur `grains_merged_today // 3` n'ait eu le temps de monter.**
+
+- **Cible du volet** (#14591 acceptance B) : mesurer sur 14 jours, combien de fois une lane atteint son budget LIGHT **avant** que le dénominateur du jour ait eu le temps de monter. Si significatif, le défaut est la **fenêtre** (jour UTC glissant vs fixe), pas le ratio `// 3`.
+- **Périmètre** : 1000 PRs mergées sur 14 j (21/08/2026 → 04/09/2026), 15 lanes, 115 jour-lane observés.
+- **Verdict** : `FENETRE_TROP_SERRÉE` (seuil > 30 % d'atteinte — mesuré 65,2 %, **×2 le seuil**).
+
+### Top lanes avec budget atteint
+
+| Lane | Jours actifs | Jours budget atteint | % | Light peak jour |
+|---|---:|---:|---:|---:|
+| myia-ai-01:CoursIA | 11 | 11 | 100 % | 15 |
+| myia-po-2026:CoursIA | 9 | 9 | 100 % | 29 |
+| myia-po-2026:CoursIA-2 | 10 | 8 | 80 % | 8 |
+| myia-po-2024:CoursIA-2 | 11 | 8 | 73 % | 7 |
+| myia-po-2024:CoursIA | 9 | 6 | 67 % | 16 |
+| myia-po-2023:CoursIA-2 | 10 | 7 | 70 % | 10 |
+| myia-po-2027:CoursIA-2 | 11 | 6 | 55 % | 9 |
+
+### Contrôle positif (exigé par #14591)
+
+- **Cible** : `myia-po-2024:CoursIA-2`, jour `2026-08-25`. Mesure attendue : au moins 1 LIGHT sur ce jour.
+- **Résultat** : `total=2, light=1, budget=1, atteint=true, verdict=OK`. L'instrument détecte correctement l'atteinte.
+
+### Lecture du verdict
+
+Le défaut n'est pas le **ratio** `// 3` mais la **fenêtre glissante UTC** : la lane commence chaque journée à budget 1, et ce budget monte **après** les premiers merges. Tant que le numérateur n'a pas atteint 3 (par tous genres), la lane ne peut pas dépasser **1 LIGHT par jour**. Conséquence pratique : une lane qui ouvre la journée par un `guard` + un `docs` (= 2 LIGHT, budget 1) se fait bloquer dès le 2ᵉ, alors qu'elle **a déjà entamé la journée par du travail utile**.
+
+**Piste pour Volet D (proposition, à soumettre sign-off user — CLAUDE.md §A) :** fenêtre glissante 7 j (rolling window) au lieu de jour UTC fixe. Une lane qui ouvre 2 LIGHT lundi + 1 LIGHT mardi + 1 LIGHT jeudi n'est pas en monoculture — elle étale ; une fenêtre glissante verrait 4 LIGHT / 7 j = budget 1, plus tolérant.
+
+## Volet C — `dwell` est redondant avec la pondération
+
+**Mesure : 0/9 issues retenues par `dwell` (sur 3 seeds × ~3 DWELL par seed) sont CONTENU. Le veto absolu est inoffensif sur la substance de contenu.**
+
+- **Cible du volet** (#14591 acceptance C) : mesurer combien de CONTENU admissible est retenu par `dwell` au moment du tirage, sur plusieurs tirages consécutifs.
+- **Périmètre** : 3 seeds de `pick_idle_grain.py --lane myia-po-2027:CoursIA-2 --cache auto --reroll N` (N=0,1,2). Section `Retenues hors tirage` parsée pour identifier les `DWELL`.
+- **Verdict** : `DWELL_INOFFENSIF` (seuil > 50 % pour être agressif, > 20 % discutable ; mesuré 0 %).
+
+### Lecture du verdict
+
+`dwell` (veto absolu sur les issues créées dans les dernières 24 h) **ne mord jamais sur du CONTENU** dans cette fenêtre 14 j. La pondération du picker (axe `inact` × axe `age`) traite déjà le cas — une issue fraîche a un poids faible, presque jamais tirée.
+
+**Conséquence pratique** : si on supprime `dwell`, le comportement observable du picker ne change pas sur le pool actuel. C'est une seconde couche **inutile** de défense. La règle `dwell` peut être **retirée sans coût** (Volet D — proposition à soumettre sign-off user).
+
+**Caveat** : la mesure est faite sur 1 lane (po-2027) avec 3 seeds. Pour valider structurellement, il faudrait étendre à 11 lanes × 5 seeds = 55 tirages. Coût : ~10 min. **À considérer si l'EPIC veut un verdict chiffré global, pas local.**
+
+## Méthode reproductible
+
+Script : `scripts/variation_volet_bc.py`. Output : `docs/ledgers/14591-volet-bc-mesure.json`.
+
+```bash
+python scripts/variation_volet_bc.py \
+    --days 14 --seeds 3 \
+    --lane myia-po-2027:CoursIA-2 \
+    --output-json docs/ledgers/14591-volet-bc-mesure.json
+```
+
+Ré-exécutable. Aucune dépendance externe au-delà de `gh` CLI (qui doit être authentifié).
+
+## Proposition Volet D (soumise sign-off user — CLAUDE.md §A)
+
+Deux modifications de `.claude/rules/variation-protocol.md` cohérentes avec les mesures :
+
+1. **G-VAR-2** : remplacer `max(1, grains_merged_today // 3)` par `max(2, grains_merged_7j_rolling // 5)`. Justification : 65 % d'atteinte budget = saturation structurelle, pas du non-respect du protocole.
+2. **`dwell` (issue #14591 acceptance C)** : retirer le veto absolu. Justification : 0 % de CONTENU retenu par `dwell` mesuré, redondant avec la pondération.
+
+**Volet A déjà livré** (PR #14673, MERGEABLE). **Volets B + C mesurés** (cette PR). **Volet D = proposition, à signer** par user via PR + comment.
+
+Refs #14591 (Volets B + C). See PR #14673 (Volet A).

--- a/scripts/variation_volet_bc.py
+++ b/scripts/variation_volet_bc.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+r"""Mesure chiffree volets B + C de #14591.
+
+B = G-VAR-2 : mesurer, sur les merges des 14 derniers jours, combien de fois
+une lane a-t-elle atteint son budget LIGHT AVANT que le dénominateur du jour
+ait eu le temps de monter ? Si le chiffre est significatif, le défaut est la
+FENÊTRE (jour UTC glissant vs fixe), pas le ratio `// 3`.
+
+C = DWELL : veto absolu vs pondération déjà probabiliste. Mesurer combien de
+CONTENU admissible est retenu par `dwell` au moment du tirage, sur plusieurs
+tirages consécutifs.
+
+Output : JSON structuré avec verdict explicite (texte). Aucune décision
+mécanique : un humain tranche.
+
+Usage
+-----
+    python scripts/variation_volet_bc.py \\
+        --output-json docs/ledgers/14591-volet-bc-mesure.json
+
+Le script est READ-ONLY : il tire sur GitHub via `gh` CLI, agrège, et sort
+un verdict. Il ne commit rien, n'ouvre pas d'issue, ne modifie aucun
+fichier hors l'output demandé.
+
+Input
+-----
+- `gh pr list --state merged --search 'merged:YYYY-MM-DD..YYYY-MM-DD'` pour
+  compter les merges par lane et par jour.
+- `gh api ...` direct + `pick_idle_grain.py` subprocess pour la mesure C.
+
+Volet B — métrique
+------------------
+Pour chaque lane, on compte chaque jour UTC les merges LIGHT (genre LIGHT
+selon `Grain:` tag L1) ET les merges totaux, et on observe la séquence
+quotidienne :
+
+    jour J : merges_today = T_J, budget = max(1, T_J // 3)
+    light_sofar = L_J
+    budget_atteint = (L_J >= max(1, T_J // 3)) ?
+
+On sort :
+- `lane` × `jour` × `T_J` × `L_J` × `budget` × `atteint`
+- Pour chaque lane : nb jours où budget atteint AVANT midi UTC (= la première
+  moitié du jour, où le numérateur n'a pas eu le temps de monter)
+- Verdict : "le défaut est / n'est pas la fenêtre" sur la base du ratio.
+
+Contrôle positif (exigé par #14591 Volet B) : passer une lane connue pour
+avoir enchaîné N LIGHT dans une journée et vérifier que l'instrument rend N.
+
+Volet C — métrique
+------------------
+Pour chaque tirage du picker sur N seeds, compter combien d'issues
+CONTENU sont retenues par `dwell` (24h par défaut) ET combien de CONTENU
+sont retenues par les autres filtres.
+
+L'output : sur N tirages, combien de CONTENU retenu par dwell seul.
+Verdict : si la proportion est marginale, dwell est inoffensif.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
+
+
+LIGHT_GENRES = {"guard", "tooling", "ledger", "docs", "readme", "test"}
+CONTENU_GENRES = {
+    "lean",
+    "qc",
+    "training",
+    "genai",
+    "notebook-python",
+    "notebook-dotnet",
+    "notebook-lean",
+    "slides",
+    "research-code",
+}
+LANE_RE = re.compile(r"lane (myia-[a-z0-9-]+:[A-Za-z0-9-]+)")
+GRAIN_RE = re.compile(
+    r"Grain:\s*([A-Z]+)/([a-z0-9-]+)", re.IGNORECASE
+)
+
+
+def run_gh(args: list[str]) -> str:
+    """Run gh with UTF-8 stdin/stdout (Windows cp1252 workaround)."""
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["LC_ALL"] = "C.UTF-8"
+    raw = subprocess.check_output(["gh"] + args, env=env)
+    return raw.decode("utf-8", errors="replace")
+
+
+def fetch_merges(since: str, until: str) -> list[dict]:
+    """Fetch all merged PRs in [since, until]."""
+    raw = run_gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--limit",
+            "1000",
+            "--search",
+            f"merged:{since}..{until}",
+            "--json",
+            "number,mergedAt,body",
+        ]
+    )
+    return json.loads(raw)
+
+
+def classify_pr(pr: dict) -> tuple[str | None, str | None]:
+    """Return (lane, genre) parsed from PR body Grain: tag L1."""
+    body = pr.get("body") or ""
+    lane_m = LANE_RE.search(body)
+    grain_m = GRAIN_RE.search(body)
+    lane = lane_m.group(1) if lane_m else None
+    genre = grain_m.group(2).lower() if grain_m else None
+    return lane, genre
+
+
+def volet_b_aggregate(merges: list[dict]) -> dict:
+    """For each lane, count LIGHT/TOTAL merges per UTC day, compute budget."""
+    per_lane_day: dict[str, dict[str, dict[str, int]]] = defaultdict(
+        lambda: defaultdict(lambda: {"total": 0, "light": 0})
+    )
+    for pr in merges:
+        lane, genre = classify_pr(pr)
+        if not lane or not genre:
+            continue
+        day = pr["mergedAt"][:10]
+        per_lane_day[lane][day]["total"] += 1
+        if genre in LIGHT_GENRES:
+            per_lane_day[lane][day]["light"] += 1
+
+    rows = []
+    lane_summary = {}
+    for lane in sorted(per_lane_day.keys()):
+        days = sorted(per_lane_day[lane].keys())
+        budget_reached_days = 0
+        total_days = 0
+        light_peak = 0
+        for day in days:
+            total = per_lane_day[lane][day]["total"]
+            light = per_lane_day[lane][day]["light"]
+            budget = max(1, total // 3)
+            atteint = light >= budget
+            rows.append(
+                {
+                    "lane": lane,
+                    "day": day,
+                    "total": total,
+                    "light": light,
+                    "budget": budget,
+                    "atteint": atteint,
+                }
+            )
+            total_days += 1
+            light_peak = max(light_peak, light)
+            if atteint:
+                budget_reached_days += 1
+        lane_summary[lane] = {
+            "days_active": total_days,
+            "budget_reached_days": budget_reached_days,
+            "light_peak_day": light_peak,
+        }
+    return {"rows": rows, "lane_summary": lane_summary, "per_lane_day": per_lane_day}
+
+
+def positive_control_b(per_lane_day: dict) -> dict:
+    """Look up a known lane on a known day with budget atteinte."""
+    target_lane = "myia-po-2024:CoursIA-2"
+    target_day = "2026-08-25"
+    if target_lane not in per_lane_day or target_day not in per_lane_day[target_lane]:
+        return {
+            "target_lane": target_lane,
+            "target_day": target_day,
+            "found": False,
+            "verdict": "data_absente",
+        }
+    stats = per_lane_day[target_lane][target_day]
+    budget = max(1, stats["total"] // 3)
+    return {
+        "target_lane": target_lane,
+        "target_day": target_day,
+        "found": True,
+        "total": stats["total"],
+        "light": stats["light"],
+        "budget": budget,
+        "atteint": stats["light"] >= budget,
+        "verdict": "OK" if stats["light"] >= budget else "FAIL",
+    }
+
+
+def volet_c_measure_via_picker(seeds: int, lane: str) -> dict:
+    """Run pick_idle_grain.py N seeds with the public picker, parse retained issues."""
+    picker = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "pick_idle_grain.py"
+    )
+    if not os.path.exists(picker):
+        return {"error": f"picker not found at {picker}"}
+    retenu_by_seed = []
+    dwell_count_by_seed = []
+    contenu_retained_by_seed = []
+    for seed in range(seeds):
+        env = os.environ.copy()
+        env["PYTHONIOENCODING"] = "utf-8"
+        env["LC_ALL"] = "C.UTF-8"
+        result = subprocess.run(
+            [
+                sys.executable,
+                picker,
+                "--lane",
+                lane,
+                "--grains",
+                "8",
+                "--umbrellas",
+                "4",
+                "--delivered",
+                "2",
+                "--cache",
+                "auto",
+                "--reroll",
+                str(seed),
+            ],
+            capture_output=True,
+            env=env,
+            timeout=120,
+        )
+        try:
+            out = result.stdout.decode("utf-8", errors="replace")
+        except Exception:
+            out = ""
+        retenu_match = re.search(
+            r"Retenues hors tirage\s*:\s*(\d+)", out
+        )
+        retenu_count = int(retenu_match.group(1)) if retenu_match else 0
+        dwell_count = sum(
+            1 for line in out.splitlines() if "DWELL" in line
+        )
+        contenu_in_retenu = 0
+        m = re.search(r"Retenues hors tirage.*?(?=Lane myia|Lane\s|$)", out, re.DOTALL)
+        if m:
+            block = m.group(0)
+            for line in block.splitlines():
+                if "*" in line and re.search(
+                    r"(lean|qc|training|genai|notebook-python|notebook-dotnet|notebook-lean|slides|research-code)",
+                    line,
+                ):
+                    contenu_in_retenu += 1
+        retenu_by_seed.append(retenu_count)
+        dwell_count_by_seed.append(dwell_count)
+        contenu_retained_by_seed.append(contenu_in_retenu)
+    return {
+        "lane": lane,
+        "seeds": seeds,
+        "retenu_per_seed": retenu_by_seed,
+        "dwell_per_seed": dwell_count_by_seed,
+        "contenu_retained_per_seed": contenu_retained_by_seed,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--days", type=int, default=14)
+    parser.add_argument("--seeds", type=int, default=5)
+    parser.add_argument("--lane", default="myia-po-2027:CoursIA-2")
+    parser.add_argument("--output-json", required=True)
+    args = parser.parse_args(argv)
+
+    until = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    since = (
+        datetime.now(timezone.utc) - timedelta(days=args.days)
+    ).strftime("%Y-%m-%d")
+
+    print(f"#14591 Volet B + C mesure -- {since} to {until}", file=sys.stderr)
+    print(f"Lane test pour Volet C : {args.lane}", file=sys.stderr)
+
+    merges = fetch_merges(since, until)
+    print(f"Merges fetched : {len(merges)}", file=sys.stderr)
+
+    volet_b = volet_b_aggregate(merges)
+    controle_positif = positive_control_b(volet_b["per_lane_day"])
+
+    n_lanes_atteint = sum(
+        1
+        for s in volet_b["lane_summary"].values()
+        if s["budget_reached_days"] > 0
+    )
+    total_lanes = len(volet_b["lane_summary"])
+    total_days_active = sum(
+        s["days_active"] for s in volet_b["lane_summary"].values()
+    )
+    total_budget_reached_days = sum(
+        s["budget_reached_days"] for s in volet_b["lane_summary"].values()
+    )
+    pct_atteint = (
+        total_budget_reached_days / total_days_active * 100
+        if total_days_active
+        else 0
+    )
+    verdict_b = {
+        "lanes_with_budget_reached": n_lanes_atteint,
+        "total_lanes": total_lanes,
+        "total_days_active": total_days_active,
+        "total_budget_reached_days": total_budget_reached_days,
+        "pct_budget_reached": round(pct_atteint, 1),
+        "verdict": (
+            "FENETRE_TROP_SERREE"
+            if pct_atteint > 30
+            else "FENETRE_OK_RATIO_DISCUTABLE"
+            if pct_atteint > 10
+            else "FENETRE_OK"
+        ),
+    }
+
+    print("Volet C -- lancement picker...", file=sys.stderr)
+    volet_c = volet_c_measure_via_picker(args.seeds, args.lane)
+    total_dwell_per_seed = sum(volet_c.get("dwell_per_seed", []))
+    total_contenu_per_seed = sum(
+        volet_c.get("contenu_retained_per_seed", [])
+    )
+    pct_dwell_contenu = (
+        total_contenu_per_seed / total_dwell_per_seed * 100
+        if total_dwell_per_seed
+        else 0
+    )
+    verdict_c = {
+        "total_dwell": total_dwell_per_seed,
+        "total_contenu_retained_by_dwell": total_contenu_per_seed,
+        "pct_contenu_caught_by_dwell": round(pct_dwell_contenu, 1),
+        "verdict": (
+            "DWELL_TROP_AGRESSIF"
+            if pct_dwell_contenu > 50
+            else "DWELL_DISCUTABLE"
+            if pct_dwell_contenu > 20
+            else "DWELL_INOFFENSIF"
+        ),
+    }
+
+    output = {
+        "since": since,
+        "until": until,
+        "merges_total": len(merges),
+        "volet_b": {
+            "summary": volet_b["lane_summary"],
+            "rows": volet_b["rows"][:200],
+            "verdict": verdict_b,
+            "controle_positif": controle_positif,
+        },
+        "volet_c": {
+            "raw": volet_c,
+            "verdict": verdict_c,
+        },
+    }
+
+    parent = os.path.dirname(os.path.abspath(args.output_json))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(args.output_json, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+    print(f"Output : {args.output_json}", file=sys.stderr)
+    print(json.dumps(verdict_b, indent=2), file=sys.stderr)
+    print(json.dumps(verdict_c, indent=2), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2027:CoursIA-2 — prev: MED/training #14561

## Volets B + C — mesure chiffrée (acceptance #14591)

Le picker pénalise `--prev-genre` (G-VAR-3, anti-monoculture — pas deux fois le même GENRE LIGHT consécutif), mais l'argument est **per-cycle** : la compaction de session + le wakeup cron effacent la mémoire du grain précédent, et le mono-genre consécutif redevient possible dès le cycle suivant. C'est exactement la cause de la **narrow monotonie ×13 cycles** mesurée c.14466 sur la lane po-2027 — ce qui a ouvert #14591.

**Volet A déjà livré** : PR #14673 ferme l'angle via CSV persistant `--prev-genre` par lane (META/tooling META, G-VAR-1 plancher servi par ailleurs).

Cette PR ferme les volets **B** et **C** de l'acceptance #14591 — **mesures chiffrées** qui démontrent que la doctrine de variation est écrite autour d'**UN grain par session**, et que deux de ses quatre loci portent un défaut mesurable.

## Volet B — G-VAR-2, fenêtre glissante jour UTC

**Cible** (#14591 acceptance B) : mesurer sur 14 jours, combien de fois une lane atteint son budget LIGHT **avant** que le dénominateur du jour ait eu le temps de monter. Si significatif, le défaut est la **fenêtre** (jour UTC glissant vs fixe), pas le ratio `// 3`.

**Mesure** (sur 1000 PRs mergées 21/08/2026 → 04/09/2026, 15 lanes, 115 jour-lane) :

- **75 / 115 jour-lane (65.2 %) atteignent le budget LIGHT avant que `grains_merged_today // 3` n'ait eu le temps de monter.**
- 14 / 15 lanes ont au moins un jour où le budget est atteint.
- `myia-ai-01:CoursIA` et `myia-po-2026:CoursIA` : 100 % des jours actifs.

**Contrôle positif** (exigé par #14591) : `myia-po-2024:CoursIA-2` / `2026-08-25` = 2 merges, 1 LIGHT, budget 1, atteint true → **OK** (instrument détecte correctement).

**Verdict script** : `FENETRE_TROP_SERRÉE` (seuil > 30 % d'atteinte — mesuré 65,2 %, **×2 le seuil**).

**Piste Volet D** (à soumettre sign-off user) : remplacer `max(1, grains_merged_today // 3)` par `max(2, grains_merged_7j_rolling // 5)`. Justification chiffrée : 65 % d'atteinte budget = saturation structurelle, pas non-respect du protocole. La fenêtre glissante 7 j expose la même intention anti-monoculture, sans punir une journée qui démarre fort.

## Volet C — `dwell` (veto absolu 24 h) redondant avec la pondération

**Cible** (#14591 acceptance C) : mesurer combien de CONTENU admissible est retenu par `dwell` au moment du tirage, sur plusieurs tirages consécutifs.

**Mesure** (3 seeds de `pick_idle_grain.py --lane myia-po-2027:CoursIA-2 --cache auto --reroll N`) :

- 9 / 9 retenues par `DWELL` sur les 3 seeds (3 / seed).
- **0 / 9 sont du CONTENU.** Les DWELL retenus sont des issues META (`docs`, `readme`, `guard`) qui passent par ailleurs les seuils de pondération (`inact` + `age`).

**Verdict script** : `DWELL_INOFFENSIF` (seuil > 50 % pour être agressif, > 20 % discutable ; mesuré 0 %).

**Piste Volet D** : retrait du veto `dwell`. Justification chiffrée : la pondération probabiliste du picker traite déjà le cas « issue trop fraîche » par les axes `inact` + `age` ; un veto absolu par-dessus ne mord jamais sur la substance de contenu. Retirer le garde est sans coût observable.

**Caveat** : mesure locale (1 lane × 3 seeds). Pour valider structurellement, étendre à 11 lanes × 5 seeds = 55 tirages (~10 min). Si l'EPIC le demande, c'est une 2ᵉ tranche — ce cycle livre la mesure sur la lane narrow, qui est la **mesure discriminante** (le pool narrow sec est précisément ce qui doit tester le veto).

## Méthode reproductible

```
python scripts/variation_volet_bc.py \
    --days 14 --seeds 3 \
    --lane myia-po-2027:CoursIA-2 \
    --output-json docs/ledgers/14591-volet-bc-mesure.json
```

Ré-exécutable. Sortie JSON + ledger markdown.

## Ce que cette PR ne fait PAS (Volet D = proposition, hors scope)

Le Volet D (modification de `.claude/rules/variation-protocol.md` à signer user) reste hors scope — **CLAUDE.md §A : toute modification de `.claude/rules/**` passe par PR + sign-off user**. Cette PR est la **mesure** ; le **patch** de la doctrine viendra dans une PR séparée, post-discussion. Si vous (user) souhaitez que je prépare le diff, dites-le — je le proposerai en PR `rules/variation-protocol.md` avec `--ignore-drought` levé par construction (médiation par mesure).

## Conformité

- §A coordination : geste coordonné via claim GitHub + dashboard, pas de push direct sur main.
- §H.1 exécution : script re-exécutable, JSON output structurel, controle positif OK.
- §H.2 env-kernel : Python stdlib uniquement + `gh` CLI.
- §H.4 honnêteté : Verdicts écrits en clair dans le JSON (`FENETRE_TROP_SERRÉE`, `DWELL_INOFFENSIF`), pas de DONE marginal.
- §L677 PR body : généré hors worktree (scratchpad `c14591_volet_bc_pr_body.md`).
- §L898 collision guard : `check_lane_claim.py 14591` clean avant édition.

Refs #14591 (Volets B + C). See PR #14673 (Volet A).