### PR TITLE
fix(notebook-tools,#14613): align accents curer with detector (RL family, fence/inline/URL protection, hors-table report)

### DIFF
--- a/scripts/notebook_tools/detect_accent_stripping.py
+++ b/scripts/notebook_tools/detect_accent_stripping.py
@@ -269,6 +269,35 @@ ACCENT_PAIRS = {
     # regle (not FR regle, not EN rule)
     "regle": "règle",
     "regles": "règles",
+    # Famille RL (#14139 / #14613) : formes context-free mesurees sur
+    # rl_1_intro_cartpole a la tete b4bdcf95f (167 occurrences). Les formes
+    # AMBIGUES relevees dans le meme passage (entraine, enregistre,
+    # recommande, cumule -- present/participe homographes une fois
+    # desaccentues) sont EXCLUES a dessein : une table globale en
+    # choisirait forcement une resolution de travers (#14613 point 3).
+    "recompense": "récompense",
+    "recompenses": "récompenses",
+    "entrainement": "entraînement",
+    "episode": "épisode",
+    "episodes": "épisodes",
+    "aleatoire": "aléatoire",
+    "aleatoires": "aléatoires",
+    # NB « evaluation » : demandé par #14613 point 2 mais EXCLU — exclusion
+    # délibérée antérieure (test_excludes_en_valid_words, incident po-2025
+    # c.591 : -tion/-ence anglicisms = mots anglais valides, FP en prose EN /
+    # identifiants code). Le désalignement devient BRUYANT au lieu de muet :
+    # le rapport « formes hors table » du cureur le montre.
+    "hyperparametres": "hyperparamètres",
+    "metrique": "métrique",
+    "creation": "création",
+    "cles": "clés",
+    "reseau": "réseau",
+    "reseaux": "réseaux",
+    "equivalent": "équivalent",
+    "complementaire": "complémentaire",
+    "complementaires": "complémentaires",
+    "reperer": "repérer",
+    "entrainer": "entraîner",
 }
 
 

--- a/scripts/notebook_tools/restore_accents_canonical.py
+++ b/scripts/notebook_tools/restore_accents_canonical.py
@@ -89,6 +89,15 @@ _CURE_RE = das._build_regex()
 # On matche depuis le `](` jusqu'a la parenthese fermante (greedy minimal sur la
 # meme ligne ; les liens markdown ne contiennent pas de ")" nu dans la cible).
 _LINK_TARGET_RE = re.compile(r"\]\([^)]*\)")
+# #14613 point 4 (porte de la cure #14139 dans l'organe canonique) : les spans
+# de code inline `...` et les URLs NUES (hors cible de lien) sont masques au
+# meme titre que les cibles de lien. Un mot du dictionnaire dans un span de code
+# (nom de variable, argument CLI) ou dans le chemin d'une URL n'est pas de la
+# prose -- l'accentuer casse le code ou le lien. Ces masques vivent dans le
+# COEUR `_cure_line` (pas seulement l'adaptateur decks) : le chemin notebook en
+# beneficie aussi, uniformement.
+_INLINE_SPAN_RE = re.compile(r"`[^`\n]*`")
+_BARE_URL_RE = re.compile(r"\bhttps?://\S+")
 
 
 def _preserve_case(match_str: str, suggestion: str) -> str:
@@ -107,23 +116,26 @@ def _preserve_case(match_str: str, suggestion: str) -> str:
 
 def _cure_line(line: str) -> tuple[str, int]:
     """Cure une ligne de markdown : accentue les formes stripped dans la PROSE,
-    en protegeant les cibles de liens ]( ... ).
+    en protegeant les cibles de liens ]( ... ), les spans de code inline et les
+    URLs nues (#14613 point 4).
 
     Retourne (ligne_curee, n_cures).
     """
-    # 1. extraire + masquer les cibles de liens. On remplace chaque span ]( ... )
-    # par un placeholder unique (base64 de l'index) qui ne peut matcher aucun mot
-    # du dictionnaire (lettres uniquement). Le contenu original est preserve tel
-    # quel dans la liste link_targets, restaure byte-identique a l'etape 3.
-    link_targets = []
+    # 1. extraire + masquer les zones non-prose. Chaque span protege est remplace
+    # par un placeholder indexe qui ne peut matcher aucun mot du dictionnaire
+    # (lettres uniquement). Le contenu original est preserve tel quel dans la
+    # liste masked_spans, restaure byte-identique a l'etape 3.
+    masked_spans: list[str] = []
 
     def _mask(m):
-        link_targets.append(m.group(0))
-        return "\x00LT{}\x00".format(len(link_targets) - 1)
+        masked_spans.append(m.group(0))
+        return "\x00MS{}\x00".format(len(masked_spans) - 1)
 
     masked = _LINK_TARGET_RE.sub(_mask, line)
+    masked = _INLINE_SPAN_RE.sub(_mask, masked)
+    masked = _BARE_URL_RE.sub(_mask, masked)
 
-    # 2. curer la prose (hors cibles masquees)
+    # 2. curer la prose (hors spans masques)
     n = [0]
 
     def _repl(m):
@@ -136,9 +148,9 @@ def _cure_line(line: str) -> tuple[str, int]:
 
     cured = _CURE_RE.sub(_repl, masked)
 
-    # 3. restaurer les cibles de liens (byte-identiques a l'original)
-    for i, original in enumerate(link_targets):
-        cured = cured.replace("\x00LT{}\x00".format(i), original, 1)
+    # 3. restaurer les spans proteges (byte-identiques a l'original)
+    for i, original in enumerate(masked_spans):
+        cured = cured.replace("\x00MS{}\x00".format(i), original, 1)
     return cured, n[0]
 
 
@@ -153,7 +165,20 @@ def _cure_source(source) -> tuple[object, int]:
         lines = source.split("\n")
         cured_lines = []
         total = 0
+        in_fence = False
         for ln in lines:
+            # #14613 point 4 : une fence reproduit souvent une sortie LITTERALE
+            # de programme (« Entrainement PPO ... : eval deterministe finale =
+            # 418.9 », fences 22/24 de #14139). Accentuer une transcription
+            # d'execution la falsifie (Stop & Repair, secrets-hygiene regle 6) :
+            # les lignes de fence (delimiteurs inclus) ne sont JAMAIS curees.
+            if _FENCE_RE.match(ln):
+                cured_lines.append(ln)
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                cured_lines.append(ln)
+                continue
             cl, n = _cure_line(ln)
             cured_lines.append(cl)
             total += n
@@ -170,10 +195,18 @@ def _cure_source(source) -> tuple[object, int]:
     original = list(source)
     new_chunks = []
     total = 0
+    in_fence = False  # l'etat persiste d'un chunk a l'autre de la MEME cellule
     for chunk in original:
         lines = chunk.split("\n")
         cured_lines = []
         for ln in lines:
+            if _FENCE_RE.match(ln):
+                cured_lines.append(ln)
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                cured_lines.append(ln)
+                continue
             cl, n = _cure_line(ln)
             cured_lines.append(cl)
             total += n
@@ -260,6 +293,11 @@ _EN_COLLIDING_FORMS = {
     "operations", "operation", "categories", "categorie",
     "theme", "themes", "different", "generation", "generations",
     "scenario", "resultat", "resultats",
+    # Famille RL #14613 : mots anglais valides ajoutes a ACCENT_PAIRS -- la
+    # garde a preuve positive de contexte FR s'applique a eux aussi. NB
+    # « evaluation » reste hors table (exclusion EN-valide délibérée,
+    # cf das.ACCENT_PAIRS).
+    "equivalent", "creation", "episode", "episodes",
 }
 _EN_COLLIDING = {k for k in ACCENT_PAIRS if k in _EN_COLLIDING_FORMS}
 _FR_MARKER_RE = re.compile(
@@ -445,6 +483,7 @@ def cure_notebook(path: Path, write: bool, check_scope: bool = False):
     cells_touched = 0
     md_cells = 0
     code_hits = 0
+    shadow_cells: list[dict] = []
 
     for cell in nb.get("cells", []):
         ctype = cell.get("cell_type", "")
@@ -452,13 +491,18 @@ def cure_notebook(path: Path, write: bool, check_scope: bool = False):
         if ctype == "markdown":
             md_cells += 1
             new_source, n = _cure_source(source)
+            # copie ombre avec la source CUREE (ecrite ou simulee) pour le
+            # rapport hors-table ci-dessous -- jamais ecrite sur disque
+            shadow_cells.append({**cell, "source": new_source})
             if n > 0:
                 total_cures += n
                 cells_touched += 1
                 if write:
                     cell["source"] = new_source
                     # outputs/execution_count/metadata intacts (jamais touches)
-        elif ctype == "code" and check_scope:
+        else:
+            shadow_cells.append(cell)
+        if ctype == "code" and check_scope:
             # mode scope : detecter les formes accentuables residuelles en code
             code_text = "".join(source) if isinstance(source, list) else (source or "")
             code_hits += sum(1 for _ in _CURE_RE.finditer(code_text))
@@ -467,12 +511,31 @@ def cure_notebook(path: Path, write: bool, check_scope: bool = False):
         with open(path, "w", encoding="utf-8", newline="\n") as f:
             json.dump(nb, f, ensure_ascii=False, indent=1)
             f.write("\n")
-    return {
+    result = {
         "cures": total_cures,
         "cells_touched": cells_touched,
         "md_cells": md_cells,
         "code_hits": code_hits,
     }
+    # #14613 point 1 : un cureur qui ne peut pas atteindre le critere du
+    # detecteur doit le DIRE. Apres la passe (ecrite ou simulee), on rejoue
+    # l'heuristique OUVERTE du detecteur sur le notebook cure et on rapporte
+    # les formes qu'elle voit encore et que la table fermee ne sait pas curer
+    # -- l'ecart qui coutait un aller-retour complet sur #14139 : « CURED (written)
+    # N accents » en succes muet alors que le compte detecteur restait au-dessus
+    # du seuil. Import paresseux (le module n'est utile que pour ce rapport).
+    try:
+        import detect_markdown_deaccent as dmd
+        shadow = {"cells": shadow_cells}
+        auto = dmd.find_candidates(shadow).get("auto") or {}
+        hors_table = {w: c for w, c in auto.items()
+                      if w.lower() not in ACCENT_PAIRS}
+        if hors_table:
+            result["hors_table"] = hors_table
+            result["hors_table_total"] = sum(hors_table.values())
+    except Exception:
+        pass  # le rapport est un service, jamais un bloqueur de cure
+    return result
 
 
 def main(argv=None) -> int:
@@ -535,6 +598,13 @@ def main(argv=None) -> int:
         if args.scope and res.get("code_hits"):
             print(f"  WARNING: {res['code_hits']} accentable form(s) found in CODE cells "
                   f"(HORS scope #2876 — possible ad-hoc script residue)")
+        if res.get("hors_table"):
+            detail = ", ".join(f"{w} (x{c})" for w, c
+                               in sorted(res["hors_table"].items(),
+                                         key=lambda kv: -kv[1]))
+            print(f"  ATTENTION: {res['hors_table_total']} forme(s) hors table — "
+                  f"le detecteur les voit encore, la table ne les cure pas "
+                  f"(cures incompletes, pas un succes) : {detail}")
 
     if args.check:
         if res["cures"] > 0 or (args.scope and res.get("code_hits", 0) > 0):

--- a/scripts/notebook_tools/tests/test_restore_accents_canonical.py
+++ b/scripts/notebook_tools/tests/test_restore_accents_canonical.py
@@ -533,3 +533,137 @@ class TestEnglishGrayZone:
         rac.cure_markdown(p, write=True)
         out = p.read_text(encoding="utf-8")
         assert "paramètre" in out and "problème" in out
+
+
+# ---------------------------------------------------------------------------
+# #14613 : protections portees de la cure ad-hoc #14139 dans l'organe canonique
+# (fences, inline-code, URLs nues) + cureur BRUYANT (rapport formes hors table)
+# + extension ACCENT_PAIRS famille RL (formes context-free, ambigues exclues).
+# ---------------------------------------------------------------------------
+class Test14613FenceProtection:
+    def test_fence_content_never_cured(self, tmp_path):
+        # fences 22/24 de #14139 : sortie LITTERALE de programme. Accentuer une
+        # transcription d'execution la falsifie (Stop & Repair) -- mesure
+        # firsthand : l'organe canonique d'avant ce fix corrompait 7 fences.
+        literal = ("```\nEntrainement PPO (graine 42, 10 000 pas) : "
+                   "287 episodes explores, eval deterministe finale = 418.9\n```")
+        nb = _nb([("markdown", "La recompense par episode est aleatoire.\n\n"
+                               + literal + "\n\nLe reseau est cree.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        rac.cure_notebook(p, write=True)
+        cured = json.loads(p.read_text(encoding="utf-8"))
+        src = cured["cells"][0]["source"]
+        # la fence reste byte-identique
+        assert literal in src
+        # la prose autour est curee
+        assert "récompense" in src and "épisode" in src and "aléatoire" in src
+        assert "réseau" in src and "créé" in src
+
+    def test_fence_state_crosses_list_chunks(self, tmp_path):
+        # source list : la fence s'ouvre dans un chunk et se ferme dans un
+        # autre -- l'etat doit persister d'un chunk a l'autre de la meme cellule.
+        nb = {"cells": [{"cell_type": "markdown",
+                         "source": ["Prose avec recompense.\n", "```\n",
+                                    "entrainement deterministe\n", "```\n",
+                                    "Suite aleatoire.\n"],
+                         "metadata": {}}],
+              "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        rac.cure_notebook(p, write=True)
+        cured = json.loads(p.read_text(encoding="utf-8"))
+        src = "".join(cured["cells"][0]["source"])
+        assert "entrainement deterministe" in src  # inter-fence intact
+        assert "récompense" in src and "aléatoire" in src  # prose curee
+
+
+class Test14613InlineAndUrlProtection:
+    def test_inline_code_span_not_accented(self, tmp_path):
+        nb = _nb([("markdown", "La variable `recompense` accumule, la recompense "
+                               "affichee est aleatoire.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        rac.cure_notebook(p, write=True)
+        cured = json.loads(p.read_text(encoding="utf-8"))
+        src = cured["cells"][0]["source"]
+        assert "`recompense`" in src      # span de code intact
+        assert "récompense" in src        # occurrence en prose curee
+        assert "aléatoire" in src
+
+    def test_bare_url_not_accented(self, tmp_path):
+        # sur-accusation mesuree #14139 : le segment de chemin d'une URL n'est
+        # pas de la prose francaise (guide x3 dans un chemin readthedocs).
+        # NB : « episodes » dans le chemin est une forme EN table -- si l'URL
+        # n'etait pas masquee, elle serait corrompue en « épisodes ».
+        nb = _nb([("markdown", "Voir https://example.com/docs/evaluation/episodes.html "
+                               "pour l episode complet et la metrique.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        rac.cure_notebook(p, write=True)
+        cured = json.loads(p.read_text(encoding="utf-8"))
+        src = cured["cells"][0]["source"]
+        assert "https://example.com/docs/evaluation/episodes.html" in src  # URL intacte
+        assert "épisode" in src and "métrique" in src  # la prose, elle, est curee
+
+
+class Test14613RlFamilyAndReport:
+    def test_rl_forms_cured(self, tmp_path):
+        nb = _nb([("markdown", "L entrainement dure 287 episodes ; la metrique "
+                               "d evaluation et les hyperparametres sont aleatoires, "
+                               "les reseaux sont complementaires, reseau equivalent "
+                               "a reperer, les cles de creation des recompenses.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        rac.cure_notebook(p, write=True)
+        cured = json.loads(p.read_text(encoding="utf-8"))
+        src = cured["cells"][0]["source"]
+        for form in ["entraînement", "épisodes", "métrique",
+                     "hyperparamètres", "aléatoires", "réseaux", "complémentaires",
+                     "réseau", "équivalent", "repérer", "clés", "création",
+                     "récompenses"]:
+            assert form in src, form
+        # « evaluation » EXCLU de la table (test_excludes_en_valid_words,
+        # exclusion EN-valide délibérée) : il reste stripped ET remonte dans
+        # le rapport hors-table -- désalignement bruyant, pas muet (#14613).
+        assert "evaluation" in src
+
+    def test_ambiguous_rl_forms_still_not_cured(self, tmp_path):
+        # #14613 point 3 : entraine/enregistre/recommande/cumule (present vs
+        # participe homographes une fois desaccentues) EXCLUS de la table.
+        nb = _nb([("markdown", "Il entraine le modele, l agent enregistre la video, "
+                               "on recommande la methode, le gain cumule.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        res = rac.cure_notebook(p, write=True)
+        cured = json.loads(p.read_text(encoding="utf-8"))
+        src = cured["cells"][0]["source"]
+        for form in ["entraine", "enregistre", "recommande", "cumule"]:
+            assert form in src, form
+        # modele/methode/agent/video (deja en table, non ambigus) sont cures
+        assert "modèle" in src and "méthode" in src
+        assert res["cures"] == 2
+
+    def test_hors_table_reported_when_cure_incomplete(self, tmp_path):
+        # #14613 point 1 : un cureur qui ne peut pas atteindre le critere du
+        # detecteur doit le DIRE -- « N formes hors table », pas un succes muet.
+        # NB : le detecteur exige une forme accentuee jumelle dans le notebook
+        # (controle positif interne) -- « enregistré » active le comptage de
+        # « enregistre », qui reste hors table (ambigu, point 3).
+        nb = _nb([("markdown", "La video s enregistre automatiquement. "
+                               "Le trace a bien été enregistré. "
+                               "La recompense est aleatoire.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        res = rac.cure_notebook(p, write=True)
+        src = json.loads(p.read_text(encoding="utf-8"))["cells"][0]["source"]
+        assert "récompense" in src  # les formes EN table sont bien cures
+        assert "enregistre" in res.get("hors_table", {})
+        assert res["hors_table_total"] >= 1
+
+    def test_no_hors_table_when_clean(self, tmp_path):
+        nb = _nb([("markdown", "Tout est deja correctement accentué ici.")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        res = rac.cure_notebook(p, write=True)
+        assert "hors_table" not in res


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Alignement cureur/detecteur d'accents — #14613

**Interleave MED/tooling (G-VAR-3)** : #14672 (open) est un autre MED/tooling de cette lane — ordre de merge documente : #14672 d'abord, celle-ci ensuite.

### Mesures (rl_1_intro_cartpole @ b4bdcf95f)

- Avant : detecteur 276 hits / 248 auto ; cureur 140 cures -> residuel detecteur 210 hits / 182 auto.
- Apres : **296 cures** ; detecteur auto = **33 <= 37** (critere d'acceptance de l'issue).
- Residuel 33 = `evaluation` (x18) + formes ambigues (`entraine` x5, `enregistre` x4, `recommande` x2, `cumule` x1 — point 3 : homographes present/participe, exclus a dessein) + `guide` (x3 — sur-accusation URL #14139, traitement separe assume).

### Les 4 points de l'issue

1. **Rapport formes hors table** : `cure_notebook` emet `hors_table` + `hors_table_total` ; `main` imprime `ATTENTION: N forme(s) hors table ... (cures incompletes, pas un succes)`. Une cure incomplete n'est jamais un succes muet.
2. **Extension de table** : ACCENT_PAIRS 161 -> 179 (+18 formes RL : recompense(s), entrainement, episode(s), aleatoire(s), hyperparametres, metrique, creation, cles, reseau(x), equivalent, complementaire(s), reperer, entrainer).
   - **Arbitrage « evaluation »** : la liste demandee incluait `evaluation`, mais l'exclusion -tion/-ence (en_valid_risky, `test_excludes_en_valid_words`, incident po-2025 c.591 : anglicismes = mots EN valides, FP en prose EN / identifiants code) est deliberée et gardee par un test existant. **Le garde l'emporte sur la prescription de liste** — `evaluation` reste hors table (NB comment au point d'entree du dict), et le desalignement devient BRUYANT : le rapport hors-table le liste (x18) au lieu de le laisser muet. Le critere auto <= 37 tient malgre tout (33).
3. **Formes ambigues** : `entraine`/`enregistre`/`recommande`/`cumule` EXCLUES de la table (homographes une fois desaccentues) — commente dans le dict + test de non-cure dedie.
4. **Protection fences / inline / URL** : machine d'etat de fence dans `_cure_source` (l'etat persiste a travers les chunks de liste nbformat d'une meme cellule), masquage des spans `` `code` `` et des URLs nues dans `_cure_line` (placeholders byte-identiques). Replay : 62 openers de fence intacts, 144 spans inline intacts, URL `/docs/evaluation/` intacte.

### Tests

8 nouveaux dans `test_restore_accents_canonical.py` (fence contenu, etat fence cross-chunk, span inline, URL nue, famille RL curee, ambigues non curees, rapport hors-table, propre = sans rapport).
- Suites cibles : 110 passed (3 modules accents).
- Full `scripts/notebook_tools/tests` : **5381 passed, 1 skipped, 1 xfailed** (post-commit).

### Verdict SOTA

SOTA-OK — le cureur existant etendu ; pas de sortie degradee.

Closes #14613
