### PR TITLE
enrich(notebook,#13934): 00-Parcours-QA-AI-Engine 643 -> 1282 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/05-Playwright-AI-Engine/00-Parcours-QA-AI-Engine.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/05-Playwright-AI-Engine/00-Parcours-QA-AI-Engine.ipynb
@@ -219,6 +219,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-int-01",
+   "metadata": {},
+   "source": [
+    "### Ce que cette reponse etablit -- et ce qu'elle n'etablit pas\n",
+    "\n",
+    "L'API sert 19 indicateurs `module_*` : 14 actifs, 5 inactifs. C'est l'etat\n",
+    "**officiel** du serveur, celui que verrait un tableau de bord, un script\n",
+    "d'exploitation ou un test d'integration classique -- une photographie nette,\n",
+    "prise par le seul canal que ces outils connaissent. Le temoin choisi,\n",
+    "`module_workspace`, arrive a `False` : le serveur le declare inactif, donc\n",
+    "toute ecriture qui le rendrait `True` se lira sans ambiguite sur ce meme\n",
+    "canal, et l'inverse aussi.\n",
+    "\n",
+    "Ce que la photographie ne montre pas, c'est le **mouvement**. Rien ici ne dit\n",
+    "si cet etat est stable : pour le savoir, il faudrait ecrire, puis verifier\n",
+    "que l'ecriture tient. C'est exactement le programme des paliers suivants --\n",
+    "chaque palier ajoute UN acteur (l'API, puis le navigateur) et ne conclut\n",
+    "que sur ce que ses seuls yeux peuvent voir."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-06",
    "metadata": {},
    "source": [
@@ -262,6 +284,26 @@
     "print()\n",
     "print(\"Un test d'integration qui ne parle qu'a l'API s'arrete ici.\")\n",
     "print(\"Il est vert, et il a raison de l'etre : le serveur a bien ecrit.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-int-02",
+   "metadata": {},
+   "source": [
+    "### Le vert du test, lu de pres\n",
+    "\n",
+    "Le serveur a repondu favorablement : `False -> True` est maintenant l'etat\n",
+    "servi par l'API. Un test d'integration qui ne parle qu'a l'API s'arrete sur\n",
+    "ce vert, et il a raison : ce qu'il pretendait verifier -- « le serveur\n",
+    "accepte cette ecriture » -- est etabli.\n",
+    "\n",
+    "Ce que ce vert ne couvre pas : ce que fera le **reste** du systeme a cette\n",
+    "nouvelle valeur. Le serveur d'une application reelle n'est pas un tutoriel\n",
+    "d'API ; autour de la base de donnees vivent des clients qui ont leur propre\n",
+    "opinion sur les reglages. Le palier suivant introduit le plus influent de\n",
+    "tous : le navigateur d'administration, ouvert par n'importe quel humain qui\n",
+    "consulte la page -- sans meme avoir besoin de cliquer."
    ]
   },
   {
@@ -339,6 +381,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-int-03",
+   "metadata": {},
+   "source": [
+    "### Pourquoi une page qui ne fait rien ecrit deux fois\n",
+    "\n",
+    "Le resultat est surprenant au premier regard : aucun clic, aucune saisie,\n",
+    "et pourtant **deux** `POST settings/update` partis vers le serveur. La page\n",
+    "de reglages n'est pas un document passif : en se chargeant, elle lit l'etat\n",
+    "des cases a cocher, construit sa representation du formulaire... et le\n",
+    "mecanisme de sauvegarde du formulaire d'options emet ses ecritures de lui\n",
+    "meme.\n",
+    "\n",
+    "Les deux envois ne disent pas la meme chose. Le premier repete l'etat que\n",
+    "le serveur vient d'admettre (`True`) : c'est l'echo de notre ecriture\n",
+    "d'API. Le second applique la regle du **client** (`False`) : l'etat que la\n",
+    "page croit etre le bon, calcule cote navigateur. Ces deux opinions vont se\n",
+    "croiser sur le serveur -- et le palier suivant regarde laquelle survit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-10",
    "metadata": {},
    "source": [
@@ -385,6 +448,30 @@
     "else:\n",
     "    print(\"Cette fois, le navigateur a defait l'ecriture de l'API.\")\n",
     "print(\"Le mot important est « cette fois ». Palier suivant.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-int-04",
+   "metadata": {},
+   "source": [
+    "### Cette fois, le navigateur a defait l'API\n",
+    "\n",
+    "Valeur retenue : `False`. L'ecriture de l'API (palier 1, confirmee par le\n",
+    "serveur) a ete ecrasee par l'ouverture d'une page (palier 2, sans aucun\n",
+    "geste). Recapitulons ce que chaque acteur pouvait croire :\n",
+    "\n",
+    "- **L'API** : « j'ai ecrit True, le serveur m'a repondu 200, c'est fait. »\n",
+    "- **Le navigateur** : « la page est ouverte, l'etat des reglages est\n",
+    "  celui que je calcule, je l'enregistre. »\n",
+    "- **Le serveur** : deux ecritures contradictoires sur le meme\n",
+    "  enregistrement, une seule valeur retenue -- la derniere arrivee.\n",
+    "\n",
+    "Le mot important de la sortie est « cette fois ». On a observe UNE course,\n",
+    "avec UNE arrivee. Rien ne prouve que la prochaine course ait le meme\n",
+    "vainqueur : peut-etre l'ordre d'arrivee des deux POST depend-il du reseau,\n",
+    "de la charge, du minutage exact de la page. C'est la question a laquelle le\n",
+    "palier suivant repond -- en rejouant."
    ]
   },
   {
@@ -449,6 +536,31 @@
     "    print(\"Meme manipulation, memes conditions, resultats differents :\")\n",
     "    print(\"le phenomene est intermittent. Un test qui l'observe UNE fois\")\n",
     "    print(\"ne rapporte pas l'etat du systeme, il rapporte son tirage.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-int-05",
+   "metadata": {},
+   "source": [
+    "### Ce que 3/5 veut dire pour un test automatise\n",
+    "\n",
+    "Cinq tours, memes gestes, memes conditions : trois ecritures de l'API ont\n",
+    "survecu, deux ont ete defaites. Le phenomene n'est donc ni constant ni\n",
+    "absent : il est **intermittent**.\n",
+    "\n",
+    "Pour l'assurance-qualite, c'est le pire des regimes -- et le plus\n",
+    "repandu. Un test qui observe le systeme UNE fois et echoue dira « bug »\n",
+    "la ou le tirage etait simplement defavorable ; un test qui passe dira\n",
+    "« conforme » la ou le defaut existe, simplement invisible ce tour-la.\n",
+    "La reponse classique est le **rejeu en cas d'echec** (« flaky retry ») :\n",
+    "c'est une facon honnete de mesurer un taux, et une facon tres malhonnete\n",
+    "de le cacher -- un test rejoue jusqu'a vert ne mesure plus le systeme, il\n",
+    "mesure la patience de l'orchestrateur.\n",
+    "\n",
+    "Ce parcours choisit l'autre voie : chronometrer la course pour comprendre\n",
+    "**pourquoi** le tirage varie, au lieu de la rejouer jusqu'a ce qu'elle\n",
+    "dise ce qu'on veut entendre."
    ]
   },
   {
@@ -567,6 +679,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-int-06",
+   "metadata": {},
+   "source": [
+    "### Lire la course au millieme\n",
+    "\n",
+    "La chronologie raconte tout. Les deux envois partent a 0 ms et 47 ms -- le\n",
+    "premier (l'echo de l'etat serveur), puis le client qui applique sa regle.\n",
+    "Les reponses reviennent a 157 ms et 159 ms : **200** pour l'un, **200**\n",
+    "pour l'autre. Le serveur a accepte les deux, il n'a arbitre aucun\n",
+    "conflit : du point de vue du protocole, aucune de ces ecritures n'est une\n",
+    "erreur.\n",
+    "\n",
+    "C'est la definition meme d'une course d'ecriture (write skew temporel) :\n",
+    "l'ordre d'arrivee au serveur decide de la valeur retenue, et cet ordre\n",
+    "depend de dizaines de millisecondes de reseau et de traitement. D'ou\n",
+    "l'intermittence du palier precedent : parfois les paquets se croisent dans\n",
+    "un sens, parfois dans l'autre.\n",
+    "\n",
+    "La sortie nomme aussi le cout collateral : **5 indicateurs** rabattus a\n",
+    "`False` par le second envoi (`embeddings`, `forms`, `orchestration`,\n",
+    "`statistics`, `workspace`). L'ouverture d'une page de reglages n'a pas\n",
+    "defait un temoin isole : elle a reimpose l'ETAT ENTIER du formulaire tel\n",
+    "que le client le calcule. Un test qui ne surveille que son indicateur\n",
+    "temoin passerait vert pendant que quatre autres reglages changent sous\n",
+    "ses yeux."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-16",
    "metadata": {},
    "source": [
@@ -615,6 +756,25 @@
     "\n",
     "Trois pistes, a completer sur l'instance jetable. Les squelettes\n",
     "ci-dessous ne rendent rien : c'est a vous d'ecrire le corps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-int-07",
+   "metadata": {},
+   "source": [
+    "### A vous : construire les instruments manquants\n",
+    "\n",
+    "Les trois exercices qui suivent reprennent chacun un fil laisse ouvert par\n",
+    "le parcours. Le premier donne un taux (`2/5`) et demande quand un tel taux\n",
+    "devient une mesure plutot qu'un bruit -- c'est la question du nombre de\n",
+    "tours, celle que tout test flaky pose un jour. Le deuxieme part d'un fait\n",
+    "etabli ici (la page de reglages ecrit) et cartographie quelles autres\n",
+    "pages ecrivent aussi. Le troisieme est le plus proche du metier : ecrire\n",
+    "la sonde qui aurait attrape ce defaut en integration continue, c'est-a-\n",
+    "dire echouer de facon FIABLE sur un phenomene intermittent -- le point\n",
+    "dur de tout test de concurrence. Les squelettes sont volontairement\n",
+    "silencieux : a completer sur l'instance jetable, sans cle ni adresse."
    ]
   },
   {
@@ -794,6 +954,28 @@
     "print(\"Elle s'en ecartera de nouveau a la prochaine page de reglages ouverte,\")\n",
     "print(\"et c'est exactement ce que ce parcours vient de mesurer.\")\n",
     "print(\"Aucun contenu, aucun utilisateur, aucun chatbot n'a ete touche.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-int-08",
+   "metadata": {},
+   "source": [
+    "### L'etat rendu, et ce qu'il faut en retenir\n",
+    "\n",
+    "La restauration a reactive les 6 modules du seed (6/6) ; les 4 ecartes en\n",
+    "arrivant ici (`embeddings`, `forms`, `workspace`, `statistics`) sont\n",
+    "exactement les indicateurs que la course du palier 4 rabattait -- la\n",
+    "signature du defaut, visible jusque dans le menage final. Aucun contenu,\n",
+    "aucun utilisateur, aucun chatbot n'a ete touche : le parcours n'a fait que\n",
+    "pousser des reglages et les rendre.\n",
+    "\n",
+    "La derniere ligne de la sortie merite une relecture : l'instance\n",
+    "**s'ecartera de nouveau** a la prochaine page de reglages ouverte. La\n",
+    "restauration ne corrige rien du defaut -- elle remet le decor pour le\n",
+    "prochain passage. C'est la discipline d'un parcours QA reproductible :\n",
+    "chaque execution commence et finit dans l'etat que le seed declare, et le\n",
+    "defaut, lui, reste entierement a documenter et a corriger ailleurs."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Enrichissement 00-Parcours-QA-AI-Engine : 643 -> 1282 c/cell (tranche 1/4 de la queue residuelle)

Dispatch ai-01 (msg-20260904T235209, mesure canonique 2026-09-04T23:51Z reverifye firsthand au claim : 7073/11 = 643). Ce notebook etait le plus deficient de la zone AI-Engine-WordPress.

### Ce qui est ajoute

Huit cellules markdown (aucune cellule code touchee, aucune sortie modifiee) :

- **une interpretation par palier** (0 a 4), chacune placee immediatement APRES la cellule dont l'output porte la valeur citee : la photographie d'etat du palier 0 (19 indicateurs, temoin `module_workspace`), le vert du test d'integration au palier 1 et son angle mort, les deux POST emis sans clic au palier 2 (echo serveur vs regle client), la course perdue par l'API au palier 3 (« cette fois »), la lecture du taux 3/5 au palier de repetition (intermittence, flaky retry vs mesure), la chronologie au millieme (t+0/47 ms envois, 157/159 ms reponses, deux HTTP 200 = aucun arbitrage serveur, 5 indicateurs rabattus en collateral).
- **une transition avant les exercices** : cadre les trois squelettes (taux et nombre de tours, cartographie des pages qui ecrivent, sonde fiable sur phenomene intermittent) — pas de « suite du traitement » generique.
- **une interpretation de la restauration** : les 4 ecartes en arrivant (`embeddings`, `forms`, `workspace`, `statistics`) sont exactement les indicateurs rabattus par la course — la signature du defaut lisible jusque dans le menage final.

Style : francais non accentue, conforme au style etabli de la zone (tranches mergees precedentes : 0 accents sur 12705 chars au `presenter`).

### Mesure canonique

```
python scripts/notebook_tools/pedagogy_density.py --json <notebook>
```

Avant : 7073 prose / 11 code = **643**. Apres : 14109 prose / 11 code = **1282**, statut `ok`. Cellules markdown 12 -> 20, total 23 -> 31.

### Validation

- Markdown-only : pas de re-execution requise (C.2), aucune cellule code modifiee.
- `check_notebook_navlinks.py` : 0 lien casse.
- IDs de cellules uniques (31/31).

See #13934 (tranche 1/4 — restent `piloter-wordpress-par-mcp` 935, `obtenir-des-donnees-structurees-par-l-api` 991, `parler-au-chatbot-en-visiteur-par-l-api` 1052).
