### PR TITLE
enrich(notebook,#13934): piloter-wordpress-par-mcp 935 -> 1425 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-4-MCP-Server/piloter-wordpress-par-mcp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-4-MCP-Server/piloter-wordpress-par-mcp.ipynb
@@ -298,6 +298,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-mcp-01",
+   "metadata": {},
+   "source": [
+    "### Ce que le catalogue revele de la surface\n",
+    "\n",
+    "Quarante-trois outils, chacun avec ses parametres declares : le catalogue\n",
+    "est un **contrat**, pas une documentation au kilometre. Les prefixes\n",
+    "racontent la taxonomie avant meme qu'on lise les noms -- `wp_get_*` pour\n",
+    "lire, `wp_create_*` et `wp_update_*` pour ecrire, et des utilitaires de\n",
+    "protocole comme `mcp_ping` qui ne touchent WordPress que de loin. Un\n",
+    "auditeur de surface d'attaque lirait cette liste autrement : chaque outil\n",
+    "d'ecriture (`wp_create_user`, `wp_update_user`, ...) est une action que le\n",
+    "porteur du header d'autorisation pourra demander telle quelle, sans\n",
+    "interface, sans rate-limit visible, sans journal d'interface.\n",
+    "\n",
+    "Pour la suite du notebook, ce contrat a une vertu pratique : les\n",
+    "parametres annonces ici sont exactement ceux que `tools/call` acceptera --\n",
+    "inutile de deviner la forme des arguments, le serveur l'a declaree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3b70dceb",
    "metadata": {},
    "source": [
@@ -358,6 +380,29 @@
     "print(\"wp_get_posts ->\", statut)\n",
     "for post in json.loads(texte_outil(reponse)):\n",
     "    print(f\"  [{post['post_status']:8s}] #{post['ID']} {post['post_title']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-mcp-02",
+   "metadata": {},
+   "source": [
+    "### Lire par MCP : la meme base, servie autrement\n",
+    "\n",
+    "Les deux lectures reviennent en `200`, et leurs contenus meritent un arret.\n",
+    "`wp_count_posts` ne rend pas un nombre mais un **dictionnaire d'etats** :\n",
+    "un article `publish`, zero partout ailleurs. C'est la photographie d'une\n",
+    "instance fraiche -- les zeros de `draft`, `pending`, `trash` disent qu'aucun\n",
+    "brouillon n'a survecu a un precedent passage, et le compte final du palier\n",
+    "d'ecriture ci-dessous devra retomber exactement sur ces zeros pour prouver\n",
+    "le menage.\n",
+    "\n",
+    "`wp_get_posts` confirme avec le detail : le seul article publie est\n",
+    "`#1 Hello world!` -- l'article d'installation de WordPress, signature d'une\n",
+    "instance jetable qui n'a encore servi a rien d'autre. La valeur de ces\n",
+    "lectures n'est pas dans leur contenu (minimal) mais dans leur **forme** :\n",
+    "le meme JSON structure que l'API d'administration, obtenu par un autre\n",
+    "transport."
    ]
   },
   {
@@ -439,6 +484,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-mcp-03",
+   "metadata": {},
+   "source": [
+    "### Le cycle de vie complet, dans un seul transport\n",
+    "\n",
+    "Create, read, delete : trois appels, trois `200`, et le compteur de\n",
+    "brouillons retombe a zero -- le cycle se referme proprement. Trois details\n",
+    "font la valeur de la demonstration.\n",
+    "\n",
+    "D'abord **l'identifiant parse** : le serveur repond par un texte (`Post\n",
+    "created ID 14`), et c'est au client d'en extraire le `14` pour l'etape\n",
+    "suivante. Le protocole ne rend pas de cle structuree ici : piloter par\n",
+    "MCP, c'est aussi accepter de decouper des reponses en prose. Ensuite\n",
+    "**l'article nait en `draft`** : le statut lu apres creation n'est pas\n",
+    "« publie » mais brouillon -- la creation par outil n'importe pas\n",
+    "d'hypothese de publication, c'est au client de decider. Enfin **la\n",
+    "suppression verifyee par le comptage** : le `200` du delete ne suffit\n",
+    "pas, le retour a zero du compteur de brouillons en est la preuve\n",
+    "reellement mesuree. Un test qui s'arrete au code de reponse sait ce que\n",
+    "le serveur a dit ; un test qui recompte sait ce qui est arrive."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3ca889e8",
    "metadata": {},
    "source": [
@@ -494,6 +563,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-mcp-04",
+   "metadata": {},
+   "source": [
+    "### La frontiere, lue dans les trois refus\n",
+    "\n",
+    "Sans le header d'autorisation, les trois niveaux du protocole disent\n",
+    "exactement la meme chose : non. `tools/list` et `tools/call` recoivent un\n",
+    "`401 rest_forbidden` -- le refus standard de la REST API de WordPress,\n",
+    "donc la frontiere est posee **avant** la couche MCP, au niveau du\n",
+    "transport. Et `initialize` lui-meme echoue : reponse `None` du serveur,\n",
+    "pas meme un handshake. C'est le detail le plus instructif de la mesure :\n",
+    "l'authentification ne protege pas seulement les outils, elle protege le\n",
+    "**protocole entier**. Un serveur qui accepterait le handshake sans\n",
+    "autorisation exposerait deja son identite, sa version et son protocole a\n",
+    "n'importe quel curieux du reseau.\n",
+    "\n",
+    "La mesure vaut ce que vaut son instance : sur `localhost:8093`, derriere\n",
+    "un tunnel reserve, le risque est nul. Transposee a une instance publique,\n",
+    "la meme sortie serait la verification minimale que le serveur MCP n'est\n",
+    "pas un canal d'administration ouvert."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7f8d4031",
    "metadata": {},
    "source": [
@@ -516,6 +609,24 @@
     "(classer CRUD generique vs verbes metier d'un catalogue) et\n",
     "[`consommer-vs-exposer-le-mcp.ipynb`](consommer-vs-exposer-le-mcp.ipynb)\n",
     "(les deux sens du fil MCP et le risque de double-ecrit).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-mcp-05",
+   "metadata": {},
+   "source": [
+    "### A vous : trois instruments autour du contrat\n",
+    "\n",
+    "Les exercices qui suivent reprennent le contrat declare au catalogue.\n",
+    "Le premier ecrit le **wrapper generique** qui manquait au notebook : une\n",
+    "seule fonction pour n'importe quel `tools/call`, avec le decoupage de\n",
+    "reponse en prose que le cycle de vie a revele. Le deuxieme relit le\n",
+    "catalogue d'un oeil d'auditeur -- l'histogramme des niveaux d'acces, c'est\n",
+    "la question « combien d'outils peuvent ecrire ? » posee directement aux\n",
+    "donnees. Le troisieme rejoue le cycle create-read-delete en autonomie\n",
+    "completement deleguee a vos fonctions. Les squelettes sont silencieux, les\n",
+    "meme instances que le parcours restent disponibles."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Enrichissement piloter-wordpress-par-mcp : 935 -> 1425 c/cell (tranche 2/4)

Deuxieme notebook de la queue residuelle #13934 (dispatch ai-01, deficit decroissant). Mesure pre-claim reverifiee firsthand : 8420/9 = 935.

### Ce qui est ajoute

Cinq cellules markdown (aucune cellule code touchee, aucune sortie modifiee), chacune placee apres la cellule dont l'output porte la valeur citee :

- **le catalogue comme contrat** (apres `tools/list` : 43 outils) : taxonomie des prefixes get/create/update, lecture d'auditeur de surface d'attaque, parametres declares = forme exacte des `tools/call` futurs.
- **les lectures structurees** (apres `wp_count_posts`/`wp_get_posts`) : le dictionnaire d'etats comme photographie d'instance fraiche, `#1 Hello world!` comme signature, la forme (JSON structure) plus importante que le contenu minimal.
- **le cycle de vie relu en trois details** (apres create/read/delete ID 14) : l'identifiant a parser depuis une reponse en prose, l'article qui nait en `draft` sans hypothese de publication, la suppression prouvee par recomptage a zero plutot que par le seul `200`.
- **les trois refus** (apres les `401 rest_forbidden`) : la frontiere posee au niveau transport avant la couche MCP, `initialize` refuse aussi = le protocole entier protege, la transposition a une instance publique.
- **transition vers les exercices** : les trois squelettes cadre comme instruments autour du contrat declare (wrapper generique, histogramme d'auditeur, cycle autonome).

### Mesure canonique

Avant : 8420 prose / 9 code = **935**. Apres : 12827 prose / 9 code = **1425**, statut `ok`. 22 -> 27 cellules.

### Validation

- Markdown-only : pas de re-execution requise (C.2).
- `check_notebook_navlinks.py` : 0 lien casse.
- Style francais non accentue conforme a la zone.

See #13934 (tranche 2/4 — restent `obtenir-des-donnees-structurees-par-l-api` 991 et `parler-au-chatbot-en-visiteur-par-l-api` 1052 ; tranche 1/4 = PR #14688).
