### PR TITLE
feat(adk,#14687): tracabilite C6 -- usage LLM remonte dans AdkRunResult et ConversationRunner

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab14-Token-Usage.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab14-Token-Usage.ipynb
@@ -1,0 +1,667 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4431588",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002831,
+     "end_time": "2026-09-05T00:55:07.229704+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:07.226873+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Lab 14 : Tracabilite de la consommation — le contrat C6 rend l'usage LLM observable\n",
+    "\n",
+    "**Grain #14687 (registre EPITA #14058, contrat C6)**. La consommation d'une conversation\n",
+    "multi-agents n'est pas un detail d'exploitation : c'est une **propriete observable du\n",
+    "runtime**. Jusqu'a la tracons 1, ADK produisait bien `usage_metadata` sur ses events,\n",
+    "mais `AdkRunResult` ne le remontait pas — la consommation etait invisible depuis le code.\n",
+    "\n",
+    "Ce lab execute de **vrais tours LLM** (seul le provider du `.env` change selon la machine)\n",
+    "et lit, appel par appel, ce que le runtime consomme :\n",
+    "\n",
+    "- `AdkRunResult.usage_turns` : un snapshot `AdkUsage` (prompt / completion / total) par appel LLM du tour ;\n",
+    "- `AdkRunResult.usage_total` : la somme du tour ;\n",
+    "- `ConversationRunner.usage_total` : le profil cumule d'une conversation entiere.\n",
+    "\n",
+    "Jamais une restauration du moteur SK (#14058) : ADK reste le runtime, l'usage est\n",
+    "simplement rendu observable au-dessus de lui."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97e9a447",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002121,
+     "end_time": "2026-09-05T00:55:07.234686+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:07.232565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "Le track charge son provider LLM depuis la configuration (`config/providers.py`).\n",
+    "La cle n'est jamais lue ni affichee ici — seuls le provider, le modele et le type d'endpoint le sont."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d1c80603",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:07.240032Z",
+     "iopub.status.busy": "2026-09-05T00:55:07.239779Z",
+     "iopub.status.idle": "2026-09-05T00:55:07.398288Z",
+     "shell.execute_reply": "2026-09-05T00:55:07.397174Z"
+    },
+    "papermill": {
+     "duration": 0.162295,
+     "end_time": "2026-09-05T00:55:07.399011+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:07.236716+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Provider actif : openrouter\n",
+      "Modele : openrouter/openai/gpt-4.1\n",
+      "Endpoint externe : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=(\n",
+    "        r\"\\[EXPERIMENTAL\\] feature \"\n",
+    "        r\"FeatureName\\.JSON_SCHEMA_FOR_FUNC_DECL is enabled\\.\"\n",
+    "    ),\n",
+    "    category=UserWarning,\n",
+    "    module=r\"google\\.adk\\.models\\.llm_request\",\n",
+    ")\n",
+    "\n",
+    "from config.providers import get_settings, get_provider_config, get_litellm_model\n",
+    "\n",
+    "settings = get_settings()\n",
+    "provider = get_provider_config(settings)\n",
+    "print(f\"Provider actif : {provider.provider.value}\")\n",
+    "print(f\"Modele : {get_litellm_model(provider)}\")\n",
+    "print(f\"Endpoint externe : {bool(provider.base_url)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75c31cca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002005,
+     "end_time": "2026-09-05T00:55:07.403293+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:07.401288+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Un tour avec outil : deux appels LLM, deux snapshots\n",
+    "\n",
+    "L'agent `dataset_profile` repond a une question en **deux appels LLM** : le premier\n",
+    "decide d'invoquer l'outil, le second interprete son resultat. Chaque appel laisse un\n",
+    "snapshot dans `usage_turns` — la tracons C6 distingue les deux jambes du tour."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e0dc436f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:07.408499Z",
+     "iopub.status.busy": "2026-09-05T00:55:07.408289Z",
+     "iopub.status.idle": "2026-09-05T00:55:15.232676Z",
+     "shell.execute_reply": "2026-09-05T00:55:15.231869Z"
+    },
+    "papermill": {
+     "duration": 7.828143,
+     "end_time": "2026-09-05T00:55:15.233376+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:07.405233+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Appels LLM du tour : 2\n",
+      "  appel 1 : prompt=149 completion=19 total=168\n",
+      "  appel 2 : prompt=204 completion=78 total=282\n",
+      "Cumul du tour (usage_total) : AdkUsage(prompt_tokens=353, completion_tokens=97, total_tokens=450)\n",
+      "Outil invoque : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from utils.adk_runtime import run_data_agent, AdkUsage\n",
+    "\n",
+    "resultat = await run_data_agent(\n",
+    "    \"Un dataset contient 30 lignes et 5 colonnes. \"\n",
+    "    \"Appelle dataset_profile et interprete le resultat.\",\n",
+    "    timeout_seconds=120,\n",
+    ")\n",
+    "\n",
+    "print(f\"Appels LLM du tour : {len(resultat.usage_turns)}\")\n",
+    "for i, usage in enumerate(resultat.usage_turns, start=1):\n",
+    "    print(f\"  appel {i} : prompt={usage.prompt_tokens} \"\n",
+    "          f\"completion={usage.completion_tokens} total={usage.total_tokens}\")\n",
+    "print(f\"Cumul du tour (usage_total) : {resultat.usage_total}\")\n",
+    "print(f\"Outil invoque : {resultat.tool_was_invoked}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7df56a47",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002274,
+     "end_time": "2026-09-05T00:55:15.238370+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:15.236096+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "Le tour laisse **deux snapshots distincts**. Le premier correspond a la decision d'appel\n",
+    "d'outil, le second a l'interpretation : la reponse finale ne sort pas du meme appel que la\n",
+    "decision. Le cout d'un tour n'est donc pas un nombre, c'est une **decomposition** — et\n",
+    "`usage_total` en est la somme. Si le provider ne compte pas ses jetons, `usage_turns`\n",
+    "reste vide : le runtime n'invente rien."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d6034c4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002068,
+     "end_time": "2026-09-05T00:55:15.242807+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:15.240739+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Profil d'une conversation multi-tours : la memoire a un prix\n",
+    "\n",
+    "Le contrat C1b (persistance entre tours, Lab18) fait revenir **tout l'historique** a chaque\n",
+    "appel. C6 rend ce cout mesurable : dans une conversation de trois tours, le `prompt_tokens`\n",
+    "de chaque tour doit **croitre** — c'est la trace chifree de la memoire qui s'accumule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "134aec37",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:15.248593Z",
+     "iopub.status.busy": "2026-09-05T00:55:15.248099Z",
+     "iopub.status.idle": "2026-09-05T00:55:21.043422Z",
+     "shell.execute_reply": "2026-09-05T00:55:21.042892Z"
+    },
+    "papermill": {
+     "duration": 5.799355,
+     "end_time": "2026-09-05T00:55:21.044192+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:15.244837+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tour | prompt | completion | cumul conversation\n",
+      "-----|--------|------------|------------------\n",
+      "  1  |   343  |     69    |    412\n",
+      "  2  |   607  |     53    |   1072\n",
+      "  3  |   845  |     97    |   2014\n"
+     ]
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "from utils.adk_conversation import ConversationRunner\n",
+    "from utils.adk_runtime import build_data_agent\n",
+    "\n",
+    "async def conversation_trois_tours():\n",
+    "    agent = build_data_agent()\n",
+    "    lignes_profil = []\n",
+    "    async with ConversationRunner(agent) as conversation:\n",
+    "        questions = [\n",
+    "            \"Un dataset contient 12 lignes et 3 colonnes. Appelle dataset_profile.\",\n",
+    "            \"Souviens-toi du dataset precedent : combien de cellules avait-il ? \"\n",
+    "            \"Appelle dataset_profile pour verifier.\",\n",
+    "            \"Toujours pour ce meme dataset : quelle est la densite par colonne ? \"\n",
+    "            \"Appelle dataset_profile une derniere fois.\",\n",
+    "        ]\n",
+    "        for i, question in enumerate(questions, start=1):\n",
+    "            tour = await conversation.turn(question, timeout_seconds=120)\n",
+    "            lignes_profil.append(\n",
+    "                (i, tour.usage_total.prompt_tokens,\n",
+    "                 tour.usage_total.completion_tokens,\n",
+    "                 conversation.usage_total.total_tokens))\n",
+    "    return lignes_profil\n",
+    "\n",
+    "profil = await conversation_trois_tours()\n",
+    "print(\"tour | prompt | completion | cumul conversation\")\n",
+    "print(\"-----|--------|------------|------------------\")\n",
+    "for i, prompt, completion, cumul in profil:\n",
+    "    print(f\"  {i}  |  {prompt:4d}  |    {completion:3d}    |  {cumul:5d}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e491fd83",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001918,
+     "end_time": "2026-09-05T00:55:21.048304+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.046386+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "La colonne `prompt` **croit a chaque tour** : le deuxieme et le troisieme appel reçoivent\n",
+    "l'historique complet des precedents. C'est le cout marginal de la persistance C1b — un cout\n",
+    "reel, maintenant mesurable au lieu d'imaginaire. La colonne `completion` reste du meme ordre :\n",
+    "c'est le contexte qui coute, pas les reponses. La derniere colonne est ce qu'un **budget**\n",
+    "de conversation devra borner (jambe 2 du grain #14687)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc35879e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001864,
+     "end_time": "2026-09-05T00:55:21.053174+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.051310+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Ce que C6 ne dit pas (encore) : le budget natif n'existe pas\n",
+    "\n",
+    "La tracons est portee ; le **plafond** n'est pas natif. La mesure du registre reste vraie :\n",
+    "`RunConfig` ne porte aucun champ de consommation (`max_llm_calls` borne des *appels*, pas\n",
+    "les jetons). Verifions-le sur le runtime reellement installe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5b2c3ed4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:21.058090Z",
+     "iopub.status.busy": "2026-09-05T00:55:21.057917Z",
+     "iopub.status.idle": "2026-09-05T00:55:21.061568Z",
+     "shell.execute_reply": "2026-09-05T00:55:21.060949Z"
+    },
+    "papermill": {
+     "duration": 0.007032,
+     "end_time": "2026-09-05T00:55:21.062068+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.055036+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Champs de budget natif dans RunConfig : AUCUN\n"
+     ]
+    }
+   ],
+   "source": [
+    "from google.adk.runners import RunConfig\n",
+    "\n",
+    "champs_budget = [\n",
+    "    f for f in RunConfig.model_fields\n",
+    "    if \"token\" in f.lower() or \"cost\" in f.lower()\n",
+    "]\n",
+    "print(f\"Champs de budget natif dans RunConfig : {champs_budget or 'AUCUN'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d389e5ff",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001961,
+     "end_time": "2026-09-05T00:55:21.066455+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.064494+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "`AUCUN` : le budget de jetons devra etre un **assemblage au-dessus d'ADK** (un plafond sur\n",
+    "`conversation.usage_total` qui coupe proprement), pas une option de configuration. C'est la\n",
+    "jambe 2 du grain #14687 — la tracons la rend maintenant possible : on ne peut borner que ce\n",
+    "qu'on mesure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86592c52",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001966,
+     "end_time": "2026-09-05T00:55:21.070444+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.068478+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "Trois exercices pour vous approprier le contrat. Le notebook doit rester executable meme\n",
+    "si vous ne les completez pas — chaque cellule d'exercice est un stub correct (C.1)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed91ead7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001902,
+     "end_time": "2026-09-05T00:55:21.074395+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.072493+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 -- Cout marginal de la memoire\n",
+    "\n",
+    "Ecrivez `cout_marginal(profil)` qui, a partir du profil de la section 3, rend la liste des\n",
+    "delta de `prompt` entre tours consecutifs. Le premier delta doit etre `None` (pas de tour\n",
+    "precedent)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "758d9fe0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:21.079336Z",
+     "iopub.status.busy": "2026-09-05T00:55:21.079142Z",
+     "iopub.status.idle": "2026-09-05T00:55:21.082110Z",
+     "shell.execute_reply": "2026-09-05T00:55:21.081638Z"
+    },
+    "papermill": {
+     "duration": 0.006318,
+     "end_time": "2026-09-05T00:55:21.082604+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.076286+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : cout_marginal(profil)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : a completer\n",
+    "# Etape 1 : recuperer la colonne prompt du profil de la section 3.\n",
+    "# Etape 2 : calculer les differences entre tours consecutifs.\n",
+    "# Etape 3 : retourner la liste (le premier element vaut None).\n",
+    "\n",
+    "def cout_marginal(profil):\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "\n",
+    "print(\"Exercice 1 a completer : cout_marginal(profil)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ebda03f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001944,
+     "end_time": "2026-09-05T00:55:21.086563+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.084619+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 -- Detecteur d'incoherence d'usage\n",
+    "\n",
+    "Ecrivez `usage_coherent(resultat)` qui rend `True` ssi la somme des `usage_turns` de\n",
+    "`resultat` egale exactement `resultat.usage_total` — la propriete qui doit tenir pour que\n",
+    "un budget (jambe 2) puisse se fier au cumul."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "25ae4233",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:21.091722Z",
+     "iopub.status.busy": "2026-09-05T00:55:21.091516Z",
+     "iopub.status.idle": "2026-09-05T00:55:21.094353Z",
+     "shell.execute_reply": "2026-09-05T00:55:21.093741Z"
+    },
+    "papermill": {
+     "duration": 0.006181,
+     "end_time": "2026-09-05T00:55:21.094866+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.088685+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : usage_coherent(resultat)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : a completer\n",
+    "# Etape 1 : sommer les snapshots de resultat.usage_turns.\n",
+    "# Etape 2 : comparer chaque composante a resultat.usage_total.\n",
+    "# Etape 3 : retourner le booleen.\n",
+    "\n",
+    "def usage_coherent(resultat):\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "\n",
+    "print(\"Exercice 2 a completer : usage_coherent(resultat)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dae53fd5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001932,
+     "end_time": "2026-09-05T00:55:21.098866+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.096934+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 -- Isolement des compteurs\n",
+    "\n",
+    "C1 doit rester tenu cote consommation : deux conversations isolees doivent avoir des cumuls\n",
+    "independants. Ecrivez `compteurs_independants(agent)` qui joue la meme question dans deux\n",
+    "`ConversationRunner` distinctes et rend `True` ssi aucun cumul ne fuit dans l'autre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e097d3e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T00:55:21.103914Z",
+     "iopub.status.busy": "2026-09-05T00:55:21.103761Z",
+     "iopub.status.idle": "2026-09-05T00:55:21.106897Z",
+     "shell.execute_reply": "2026-09-05T00:55:21.106288Z"
+    },
+    "papermill": {
+     "duration": 0.006668,
+     "end_time": "2026-09-05T00:55:21.107487+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.100819+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : compteurs_independants(agent)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : a completer\n",
+    "# Etape 1 : ouvrir deux ConversationRunner sur le meme agent.\n",
+    "# Etape 2 : jouer la meme question dans chacune.\n",
+    "# Etape 3 : verifier que les deux usage_total sont strictement positifs\n",
+    "#           et que chaque cumul ne compte que ses propres tours.\n",
+    "\n",
+    "def compteurs_independants(agent):\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "\n",
+    "print(\"Exercice 3 a completer : compteurs_independants(agent)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a0e36d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002179,
+     "end_time": "2026-09-05T00:55:21.111914+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T00:55:21.109735+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Conclusion\n",
+    "\n",
+    "| Idee clee | Ou la voir |\n",
+    "|---|---|\n",
+    "| Un tour = plusieurs appels LLM, chacun avec son snapshot | section 2, `usage_turns` |\n",
+    "| La memoire C1b a un cout marginal mesurable | section 3, croissance de `prompt` |\n",
+    "| Le budget natif n'existe pas : `RunConfig` sans champ de consommation | section 4 |\n",
+    "| Un compteur qui n'invente rien : provider muet = `usage_turns` vide | docstring `_event_usage` |\n",
+    "\n",
+    "Le contrat C6 est desormais **porte cote tracabilite** (PR #14690) : ce que la conversation\n",
+    "consomme est observable depuis le code du depot, appel par appel. Le budget reste un grain\n",
+    "ouvert — au-dessus d'ADK, jamais une restauration SK. See #14687, #14058."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 16.38244,
+   "end_time": "2026-09-05T00:55:22.232420+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Day5-DS-Star/Lab14-Token-Usage.ipynb",
+   "output_path": "Day5-DS-Star/Lab14-Token-Usage.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-05T00:55:05.849980+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab14-Token-Usage.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab14-Token-Usage.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f4431588",
+   "id": "f8c837b0",
    "metadata": {
     "papermill": {
-     "duration": 0.002831,
-     "end_time": "2026-09-05T00:55:07.229704+00:00",
+     "duration": 0.003034,
+     "end_time": "2026-09-05T01:28:50.235045+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:07.226873+00:00",
+     "start_time": "2026-09-05T01:28:50.232011+00:00",
      "status": "completed"
     },
     "tags": []
@@ -34,13 +34,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97e9a447",
+   "id": "90a2aa95",
    "metadata": {
     "papermill": {
-     "duration": 0.002121,
-     "end_time": "2026-09-05T00:55:07.234686+00:00",
+     "duration": 0.001943,
+     "end_time": "2026-09-05T01:28:50.241028+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:07.232565+00:00",
+     "start_time": "2026-09-05T01:28:50.239085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -55,19 +55,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d1c80603",
+   "id": "51f83bba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:07.240032Z",
-     "iopub.status.busy": "2026-09-05T00:55:07.239779Z",
-     "iopub.status.idle": "2026-09-05T00:55:07.398288Z",
-     "shell.execute_reply": "2026-09-05T00:55:07.397174Z"
+     "iopub.execute_input": "2026-09-05T01:28:50.246386Z",
+     "iopub.status.busy": "2026-09-05T01:28:50.245994Z",
+     "iopub.status.idle": "2026-09-05T01:28:50.427225Z",
+     "shell.execute_reply": "2026-09-05T01:28:50.426587Z"
     },
     "papermill": {
-     "duration": 0.162295,
-     "end_time": "2026-09-05T00:55:07.399011+00:00",
+     "duration": 0.184828,
+     "end_time": "2026-09-05T01:28:50.427786+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:07.236716+00:00",
+     "start_time": "2026-09-05T01:28:50.242958+00:00",
      "status": "completed"
     },
     "tags": []
@@ -110,13 +110,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75c31cca",
+   "id": "5541fc2b",
    "metadata": {
     "papermill": {
-     "duration": 0.002005,
-     "end_time": "2026-09-05T00:55:07.403293+00:00",
+     "duration": 0.00215,
+     "end_time": "2026-09-05T01:28:50.432466+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:07.401288+00:00",
+     "start_time": "2026-09-05T01:28:50.430316+00:00",
      "status": "completed"
     },
     "tags": []
@@ -132,19 +132,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e0dc436f",
+   "id": "92d9f6e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:07.408499Z",
-     "iopub.status.busy": "2026-09-05T00:55:07.408289Z",
-     "iopub.status.idle": "2026-09-05T00:55:15.232676Z",
-     "shell.execute_reply": "2026-09-05T00:55:15.231869Z"
+     "iopub.execute_input": "2026-09-05T01:28:50.438525Z",
+     "iopub.status.busy": "2026-09-05T01:28:50.438177Z",
+     "iopub.status.idle": "2026-09-05T01:28:59.089822Z",
+     "shell.execute_reply": "2026-09-05T01:28:59.088966Z"
     },
     "papermill": {
-     "duration": 7.828143,
-     "end_time": "2026-09-05T00:55:15.233376+00:00",
+     "duration": 8.655824,
+     "end_time": "2026-09-05T01:28:59.090699+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:07.405233+00:00",
+     "start_time": "2026-09-05T01:28:50.434875+00:00",
      "status": "completed"
     },
     "tags": []
@@ -156,8 +156,8 @@
      "text": [
       "Appels LLM du tour : 2\n",
       "  appel 1 : prompt=149 completion=19 total=168\n",
-      "  appel 2 : prompt=204 completion=78 total=282\n",
-      "Cumul du tour (usage_total) : AdkUsage(prompt_tokens=353, completion_tokens=97, total_tokens=450)\n",
+      "  appel 2 : prompt=204 completion=76 total=280\n",
+      "Cumul du tour (usage_total) : AdkUsage(prompt_tokens=353, completion_tokens=95, total_tokens=448)\n",
       "Outil invoque : True\n"
      ]
     }
@@ -181,13 +181,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7df56a47",
+   "id": "cde5ef17",
    "metadata": {
     "papermill": {
-     "duration": 0.002274,
-     "end_time": "2026-09-05T00:55:15.238370+00:00",
+     "duration": 0.003002,
+     "end_time": "2026-09-05T01:28:59.097037+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:15.236096+00:00",
+     "start_time": "2026-09-05T01:28:59.094035+00:00",
      "status": "completed"
     },
     "tags": []
@@ -204,13 +204,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d6034c4",
+   "id": "325e4978",
    "metadata": {
     "papermill": {
-     "duration": 0.002068,
-     "end_time": "2026-09-05T00:55:15.242807+00:00",
+     "duration": 0.002795,
+     "end_time": "2026-09-05T01:28:59.102829+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:15.240739+00:00",
+     "start_time": "2026-09-05T01:28:59.100034+00:00",
      "status": "completed"
     },
     "tags": []
@@ -226,19 +226,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "134aec37",
+   "id": "75666c32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:15.248593Z",
-     "iopub.status.busy": "2026-09-05T00:55:15.248099Z",
-     "iopub.status.idle": "2026-09-05T00:55:21.043422Z",
-     "shell.execute_reply": "2026-09-05T00:55:21.042892Z"
+     "iopub.execute_input": "2026-09-05T01:28:59.111751Z",
+     "iopub.status.busy": "2026-09-05T01:28:59.111320Z",
+     "iopub.status.idle": "2026-09-05T01:29:04.668344Z",
+     "shell.execute_reply": "2026-09-05T01:29:04.667629Z"
     },
     "papermill": {
-     "duration": 5.799355,
-     "end_time": "2026-09-05T00:55:21.044192+00:00",
+     "duration": 5.563304,
+     "end_time": "2026-09-05T01:29:04.668860+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:15.244837+00:00",
+     "start_time": "2026-09-05T01:28:59.105556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -251,8 +251,8 @@
       "tour | prompt | completion | cumul conversation\n",
       "-----|--------|------------|------------------\n",
       "  1  |   343  |     69    |    412\n",
-      "  2  |   607  |     53    |   1072\n",
-      "  3  |   845  |     97    |   2014\n"
+      "  2  |   607  |     59    |   1078\n",
+      "  3  |   857  |     70    |   2005\n"
      ]
     }
    ],
@@ -289,13 +289,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e491fd83",
+   "id": "ec2a24fd",
    "metadata": {
     "papermill": {
-     "duration": 0.001918,
-     "end_time": "2026-09-05T00:55:21.048304+00:00",
+     "duration": 0.002257,
+     "end_time": "2026-09-05T01:29:04.673707+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.046386+00:00",
+     "start_time": "2026-09-05T01:29:04.671450+00:00",
      "status": "completed"
     },
     "tags": []
@@ -312,13 +312,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc35879e",
+   "id": "5d83871a",
    "metadata": {
     "papermill": {
-     "duration": 0.001864,
-     "end_time": "2026-09-05T00:55:21.053174+00:00",
+     "duration": 0.002047,
+     "end_time": "2026-09-05T01:29:04.677870+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.051310+00:00",
+     "start_time": "2026-09-05T01:29:04.675823+00:00",
      "status": "completed"
     },
     "tags": []
@@ -334,19 +334,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5b2c3ed4",
+   "id": "2baabc51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:21.058090Z",
-     "iopub.status.busy": "2026-09-05T00:55:21.057917Z",
-     "iopub.status.idle": "2026-09-05T00:55:21.061568Z",
-     "shell.execute_reply": "2026-09-05T00:55:21.060949Z"
+     "iopub.execute_input": "2026-09-05T01:29:04.682935Z",
+     "iopub.status.busy": "2026-09-05T01:29:04.682760Z",
+     "iopub.status.idle": "2026-09-05T01:29:04.686408Z",
+     "shell.execute_reply": "2026-09-05T01:29:04.685824Z"
     },
     "papermill": {
-     "duration": 0.007032,
-     "end_time": "2026-09-05T00:55:21.062068+00:00",
+     "duration": 0.007064,
+     "end_time": "2026-09-05T01:29:04.686966+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.055036+00:00",
+     "start_time": "2026-09-05T01:29:04.679902+00:00",
      "status": "completed"
     },
     "tags": []
@@ -372,13 +372,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d389e5ff",
+   "id": "db727c46",
    "metadata": {
     "papermill": {
-     "duration": 0.001961,
-     "end_time": "2026-09-05T00:55:21.066455+00:00",
+     "duration": 0.002104,
+     "end_time": "2026-09-05T01:29:04.691266+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.064494+00:00",
+     "start_time": "2026-09-05T01:29:04.689162+00:00",
      "status": "completed"
     },
     "tags": []
@@ -388,25 +388,142 @@
     "\n",
     "`AUCUN` : le budget de jetons devra etre un **assemblage au-dessus d'ADK** (un plafond sur\n",
     "`conversation.usage_total` qui coupe proprement), pas une option de configuration. C'est la\n",
-    "jambe 2 du grain #14687 — la tracons la rend maintenant possible : on ne peut borner que ce\n",
-    "qu'on mesure."
+    "jambe 2 du grain #14687 — portee en section 5. La tracabilite la rend possible : on ne peut\n",
+    "borner que ce qu'on mesure."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "86592c52",
+   "id": "6e2fce9e",
    "metadata": {
     "papermill": {
-     "duration": 0.001966,
-     "end_time": "2026-09-05T00:55:21.070444+00:00",
+     "duration": 0.002103,
+     "end_time": "2026-09-05T01:29:04.695490+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.068478+00:00",
+     "start_time": "2026-09-05T01:29:04.693387+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Exercices\n",
+    "## 5. Le budget porte au-dessus d'ADK : couper proprement\n",
+    "\n",
+    "La section 4 a mesure l'absence de budget natif. Le voici, assemble au-dessus d'ADK : un\n",
+    "plafond de jetons cumules par conversation (`budget_total_tokens`), qui **refuse un tour avant\n",
+    "tout appel LLM** quand le plafond est deja atteint, et **coupe au premier appel qui le\n",
+    "franchit**. La coupe rend un verdict explicite — l'exception typee `AdkBudgetExceeded`, qui\n",
+    "porte le plafond, le cumul exact au moment de la coupe et le numero du tour — pas une\n",
+    "exception brute du runtime.\n",
+    "\n",
+    "Pour que la demonstration soit deterministe quel que soit le comptage reel du provider, le\n",
+    "plafond est **derive de la mesure** : juste au-dessus du cumul du tour 1, le tour 2 doit le\n",
+    "franchir des son premier appel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b8d59f42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T01:29:04.701142Z",
+     "iopub.status.busy": "2026-09-05T01:29:04.700961Z",
+     "iopub.status.idle": "2026-09-05T01:29:08.139697Z",
+     "shell.execute_reply": "2026-09-05T01:29:08.138362Z"
+    },
+    "papermill": {
+     "duration": 3.443209,
+     "end_time": "2026-09-05T01:29:08.140888+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T01:29:04.697679+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plafond pose apres le tour 1 : 453 jetons\n",
+      "Verdict : BUDGET_EXCEEDED (tour 2)\n",
+      "Cumul au moment de la coupe : 725 jetons\n",
+      "Message d'origine : BUDGET_EXCEEDED: 725 jetons cumules >= plafond 453 (tour 2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from utils.adk_conversation import AdkBudgetExceeded\n",
+    "from utils.adk_runtime import build_data_agent\n",
+    "\n",
+    "async def demonstration_budget():\n",
+    "    agent = build_data_agent()\n",
+    "    async with ConversationRunner(agent) as conversation:\n",
+    "        await conversation.turn(\n",
+    "            \"Un dataset contient 7 lignes et 2 colonnes. Appelle dataset_profile.\",\n",
+    "            timeout_seconds=120,\n",
+    "        )\n",
+    "        # Plafond derive de la mesure : le cumul du tour 1 + une marge mince.\n",
+    "        conversation.budget_total_tokens = conversation.usage_total.total_tokens + 30\n",
+    "        plafond = conversation.budget_total_tokens\n",
+    "        try:\n",
+    "            await conversation.turn(\n",
+    "                \"Un dataset contient 9 lignes et 3 colonnes. Appelle dataset_profile.\",\n",
+    "                timeout_seconds=120,\n",
+    "            )\n",
+    "            return plafond, None\n",
+    "        except AdkBudgetExceeded as verdict:\n",
+    "            return plafond, verdict\n",
+    "\n",
+    "plafond, verdict = await demonstration_budget()\n",
+    "if verdict is None:\n",
+    "    print(f\"Plafond {plafond} non franchi -- relancer la cellule.\")\n",
+    "else:\n",
+    "    print(f\"Plafond pose apres le tour 1 : {plafond} jetons\")\n",
+    "    print(f\"Verdict : {verdict.verdict} (tour {verdict.tour})\")\n",
+    "    print(f\"Cumul au moment de la coupe : {verdict.usage_total.total_tokens} jetons\")\n",
+    "    print(f\"Message d'origine : {verdict}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "406b29b7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003279,
+     "end_time": "2026-09-05T01:29:08.148250+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T01:29:08.144971+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "Le tour 2 n'a jamais produit de reponse : des que son premier appel LLM fait franchir le\n",
+    "plafond, la consommation s'arrete et le verdict `BUDGET_EXCEEDED` porte le plafond, le cumul\n",
+    "exact au moment de la coupe (les jetons consommes avant la coupe restent comptes — comptabilite\n",
+    "honnete) et le numero du tour coupe. Pas d'exception brute du stream : un **verdict type**,\n",
+    "attrapable, qui laisse la conversation dans un etat comptable coherent. On ne peut borner que\n",
+    "ce qu'on mesure — la tracabilite des sections 2 et 3 est ce qui rend ce plafond possible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6dd0059",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002896,
+     "end_time": "2026-09-05T01:29:08.155360+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T01:29:08.152464+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercices\n",
     "\n",
     "Trois exercices pour vous approprier le contrat. Le notebook doit rester executable meme\n",
     "si vous ne les completez pas — chaque cellule d'exercice est un stub correct (C.1)."
@@ -414,13 +531,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed91ead7",
+   "id": "1279cae1",
    "metadata": {
     "papermill": {
-     "duration": 0.001902,
-     "end_time": "2026-09-05T00:55:21.074395+00:00",
+     "duration": 0.002815,
+     "end_time": "2026-09-05T01:29:08.160974+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.072493+00:00",
+     "start_time": "2026-09-05T01:29:08.158159+00:00",
      "status": "completed"
     },
     "tags": []
@@ -435,20 +552,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "758d9fe0",
+   "execution_count": 6,
+   "id": "4b4106ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:21.079336Z",
-     "iopub.status.busy": "2026-09-05T00:55:21.079142Z",
-     "iopub.status.idle": "2026-09-05T00:55:21.082110Z",
-     "shell.execute_reply": "2026-09-05T00:55:21.081638Z"
+     "iopub.execute_input": "2026-09-05T01:29:08.168826Z",
+     "iopub.status.busy": "2026-09-05T01:29:08.168421Z",
+     "iopub.status.idle": "2026-09-05T01:29:08.172637Z",
+     "shell.execute_reply": "2026-09-05T01:29:08.171863Z"
     },
     "papermill": {
-     "duration": 0.006318,
-     "end_time": "2026-09-05T00:55:21.082604+00:00",
+     "duration": 0.010014,
+     "end_time": "2026-09-05T01:29:08.173868+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.076286+00:00",
+     "start_time": "2026-09-05T01:29:08.163854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -477,13 +594,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ebda03f",
+   "id": "c877a4ff",
    "metadata": {
     "papermill": {
-     "duration": 0.001944,
-     "end_time": "2026-09-05T00:55:21.086563+00:00",
+     "duration": 0.003277,
+     "end_time": "2026-09-05T01:29:08.181346+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.084619+00:00",
+     "start_time": "2026-09-05T01:29:08.178069+00:00",
      "status": "completed"
     },
     "tags": []
@@ -498,20 +615,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "25ae4233",
+   "execution_count": 7,
+   "id": "a4465294",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:21.091722Z",
-     "iopub.status.busy": "2026-09-05T00:55:21.091516Z",
-     "iopub.status.idle": "2026-09-05T00:55:21.094353Z",
-     "shell.execute_reply": "2026-09-05T00:55:21.093741Z"
+     "iopub.execute_input": "2026-09-05T01:29:08.190187Z",
+     "iopub.status.busy": "2026-09-05T01:29:08.189755Z",
+     "iopub.status.idle": "2026-09-05T01:29:08.195283Z",
+     "shell.execute_reply": "2026-09-05T01:29:08.194045Z"
     },
     "papermill": {
-     "duration": 0.006181,
-     "end_time": "2026-09-05T00:55:21.094866+00:00",
+     "duration": 0.011422,
+     "end_time": "2026-09-05T01:29:08.196219+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.088685+00:00",
+     "start_time": "2026-09-05T01:29:08.184797+00:00",
      "status": "completed"
     },
     "tags": []
@@ -540,13 +657,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dae53fd5",
+   "id": "61bb9bb6",
    "metadata": {
     "papermill": {
-     "duration": 0.001932,
-     "end_time": "2026-09-05T00:55:21.098866+00:00",
+     "duration": 0.003317,
+     "end_time": "2026-09-05T01:29:08.203112+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.096934+00:00",
+     "start_time": "2026-09-05T01:29:08.199795+00:00",
      "status": "completed"
     },
     "tags": []
@@ -561,20 +678,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "e097d3e8",
+   "execution_count": 8,
+   "id": "ec569eb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-05T00:55:21.103914Z",
-     "iopub.status.busy": "2026-09-05T00:55:21.103761Z",
-     "iopub.status.idle": "2026-09-05T00:55:21.106897Z",
-     "shell.execute_reply": "2026-09-05T00:55:21.106288Z"
+     "iopub.execute_input": "2026-09-05T01:29:08.211122Z",
+     "iopub.status.busy": "2026-09-05T01:29:08.210739Z",
+     "iopub.status.idle": "2026-09-05T01:29:08.215655Z",
+     "shell.execute_reply": "2026-09-05T01:29:08.214681Z"
     },
     "papermill": {
-     "duration": 0.006668,
-     "end_time": "2026-09-05T00:55:21.107487+00:00",
+     "duration": 0.010467,
+     "end_time": "2026-09-05T01:29:08.216708+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.100819+00:00",
+     "start_time": "2026-09-05T01:29:08.206241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -604,30 +721,32 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a0e36d1",
+   "id": "9a0f5cc2",
    "metadata": {
     "papermill": {
-     "duration": 0.002179,
-     "end_time": "2026-09-05T00:55:21.111914+00:00",
+     "duration": 0.003483,
+     "end_time": "2026-09-05T01:29:08.224108+00:00",
      "exception": false,
-     "start_time": "2026-09-05T00:55:21.109735+00:00",
+     "start_time": "2026-09-05T01:29:08.220625+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Conclusion\n",
+    "## 7. Conclusion\n",
     "\n",
     "| Idee clee | Ou la voir |\n",
     "|---|---|\n",
     "| Un tour = plusieurs appels LLM, chacun avec son snapshot | section 2, `usage_turns` |\n",
     "| La memoire C1b a un cout marginal mesurable | section 3, croissance de `prompt` |\n",
     "| Le budget natif n'existe pas : `RunConfig` sans champ de consommation | section 4 |\n",
+    "| Un plafond de jetons qui coupe proprement, verdict type | section 5, `AdkBudgetExceeded` |\n",
     "| Un compteur qui n'invente rien : provider muet = `usage_turns` vide | docstring `_event_usage` |\n",
     "\n",
-    "Le contrat C6 est desormais **porte cote tracabilite** (PR #14690) : ce que la conversation\n",
-    "consomme est observable depuis le code du depot, appel par appel. Le budget reste un grain\n",
-    "ouvert — au-dessus d'ADK, jamais une restauration SK. See #14687, #14058."
+    "Le contrat C6 est desormais **porte en entier** (PR #14690) : ce que la conversation consomme\n",
+    "est observable depuis le code du depot, appel par appel, ET bornable — un plafond qui coupe\n",
+    "proprement sur un verdict explicite. Toujours au-dessus d'ADK, jamais une restauration SK.\n",
+    "See #14687, #14058."
    ]
   }
  ],
@@ -651,14 +770,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 16.38244,
-   "end_time": "2026-09-05T00:55:22.232420+00:00",
+   "duration": 20.503502,
+   "end_time": "2026-09-05T01:29:09.334499+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Day5-DS-Star/Lab14-Token-Usage.ipynb",
    "output_path": "Day5-DS-Star/Lab14-Token-Usage.ipynb",
    "parameters": {},
-   "start_time": "2026-09-05T00:55:05.849980+00:00",
+   "start_time": "2026-09-05T01:28:48.830997+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_conversation.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_conversation.py
@@ -32,6 +32,32 @@ from utils.adk_runtime import (
 )
 
 
+class AdkBudgetExceeded(Exception):
+    """Verdict explicite du plafond de jetons cumules (contrat C6, jambe budget).
+
+    Un plafond atteint ne doit ni tuer le runtime en vol ni remonter une
+    exception brute du stream ADK : la coupe rend un verdict type, portant
+    le plafond, le cumul exact au moment de la coupe (jetons consommes
+    inclus, comptabilite honnete) et le numero du tour coupe ou refuse.
+    """
+
+    verdict = "BUDGET_EXCEEDED"
+
+    def __init__(
+        self,
+        budget_total: int,
+        usage_total: AdkUsage,
+        tour: int,
+    ) -> None:
+        self.budget_total = budget_total
+        self.usage_total = usage_total
+        self.tour = tour
+        super().__init__(
+            f"{self.verdict}: {usage_total.total_tokens} jetons cumules "
+            f">= plafond {budget_total} (tour {tour})"
+        )
+
+
 class ConversationRunner:
     """Execute plusieurs tours d'un agent dans la MEME session ADK.
 
@@ -40,6 +66,11 @@ class ConversationRunner:
     porte le contrat C1b (persistance d'etat entre tours). Le cloisonnement
     reste celui du contrat C1 : deux ``ConversationRunner`` sont deux sessions
     distinctes, isolees l'une de l'autre.
+
+    ``budget_total_tokens`` (contrat C6, jambe budget) pose un plafond sur le
+    cumul de jetons de la conversation : un tour est refuse AVANT tout appel
+    LLM quand le plafond est deja atteint, et coupe au premier appel qui le
+    franchit -- dans les deux cas par ``AdkBudgetExceeded``.
     """
 
     def __init__(
@@ -49,11 +80,13 @@ class ConversationRunner:
         app_name: str = APP_NAME,
         user_id: str = "track2-user",
         session_id: str | None = None,
+        budget_total_tokens: int | None = None,
     ) -> None:
         self.agent = agent
         self.app_name = app_name
         self.user_id = user_id
         self.session_id = session_id or f"conversation-{uuid4().hex}"
+        self.budget_total_tokens = budget_total_tokens
         self.session_service = InMemorySessionService()
         self._runner = Runner(
             agent=agent,
@@ -62,6 +95,7 @@ class ConversationRunner:
         )
         self._started = False
         self.turn_usages: list[AdkUsage] = []
+        self.turn_count = 0
 
     @property
     def usage_total(self) -> AdkUsage:
@@ -70,6 +104,13 @@ class ConversationRunner:
         for usage in self.turn_usages:
             total = total + usage
         return total
+
+    @property
+    def budget_exhausted(self) -> bool:
+        """Vrai des que le cumul atteint le plafond (sans plafond : faux)."""
+        if self.budget_total_tokens is None:
+            return False
+        return self.usage_total.total_tokens >= self.budget_total_tokens
 
     async def start(self) -> None:
         """Cree la session unique de la conversation (idempotent)."""
@@ -92,6 +133,15 @@ class ConversationRunner:
         if not self._started:
             await self.start()
 
+        if (
+            self.budget_total_tokens is not None
+            and self.usage_total.total_tokens >= self.budget_total_tokens
+        ):
+            raise AdkBudgetExceeded(
+                self.budget_total_tokens, self.usage_total, self.turn_count + 1
+            )
+
+        self.turn_count += 1
         message = types.Content(role="user", parts=[types.Part(text=prompt)])
         response_text = ""
         tool_calls: list[str] = []
@@ -99,9 +149,11 @@ class ConversationRunner:
         usage_turns: list[AdkUsage] = []
         event_errors: list[str] = []
         event_count = 0
+        budget_cut = False
 
         async def consume_events() -> None:
-            nonlocal event_count, response_text
+            nonlocal event_count, response_text, budget_cut
+            turn_cumulative = AdkUsage()
             async for event in self._runner.run_async(
                 user_id=self.user_id,
                 session_id=self.session_id,
@@ -119,6 +171,17 @@ class ConversationRunner:
                 usage = _event_usage(event)
                 if usage is not None:
                     usage_turns.append(usage)
+                    if self.budget_total_tokens is not None:
+                        turn_cumulative = turn_cumulative + usage
+                        if (
+                            self.usage_total + turn_cumulative
+                        ).total_tokens > self.budget_total_tokens:
+                            # Coupe propre au premier appel qui FRANCHIT le
+                            # plafond (strict) : un tour atterrissant exactement
+                            # sur le plafond se termine normalement -- c'est le
+                            # garde pre-tour qui refusera la suite.
+                            budget_cut = True
+                            break
                 error_code = getattr(event, "error_code", None)
                 error_message = getattr(event, "error_message", None)
                 if error_code or error_message:
@@ -146,6 +209,14 @@ class ConversationRunner:
                 f"RECOVERABLE-LOCAL: echec du runtime ADK reel "
                 f"({type(exc).__name__}){suffix}"
             ) from exc
+
+        if budget_cut:
+            # Comptabilite honnete : les jetons consommes avant la coupe
+            # entrent dans le cumul AVANT le verdict.
+            self.turn_usages.extend(usage_turns)
+            raise AdkBudgetExceeded(
+                self.budget_total_tokens, self.usage_total, self.turn_count
+            )
 
         if not response_text:
             detail = f" ({'; '.join(event_errors)})" if event_errors else ""

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_conversation.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_conversation.py
@@ -22,7 +22,14 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
-from utils.adk_runtime import APP_NAME, AdkRunResult, AdkRuntimeUnavailable, _part_text
+from utils.adk_runtime import (
+    APP_NAME,
+    AdkRunResult,
+    AdkRuntimeUnavailable,
+    AdkUsage,
+    _event_usage,
+    _part_text,
+)
 
 
 class ConversationRunner:
@@ -54,6 +61,15 @@ class ConversationRunner:
             session_service=self.session_service,
         )
         self._started = False
+        self.turn_usages: list[AdkUsage] = []
+
+    @property
+    def usage_total(self) -> AdkUsage:
+        """Consommation cumulee de tous les tours joues (tracabilite C6)."""
+        total = AdkUsage()
+        for usage in self.turn_usages:
+            total = total + usage
+        return total
 
     async def start(self) -> None:
         """Cree la session unique de la conversation (idempotent)."""
@@ -80,6 +96,7 @@ class ConversationRunner:
         response_text = ""
         tool_calls: list[str] = []
         tool_responses: list[str] = []
+        usage_turns: list[AdkUsage] = []
         event_errors: list[str] = []
         event_count = 0
 
@@ -99,6 +116,9 @@ class ConversationRunner:
                     for response in event.get_function_responses()
                     if response.name
                 )
+                usage = _event_usage(event)
+                if usage is not None:
+                    usage_turns.append(usage)
                 error_code = getattr(event, "error_code", None)
                 error_message = getattr(event, "error_message", None)
                 if error_code or error_message:
@@ -134,11 +154,13 @@ class ConversationRunner:
                 + detail
             )
 
+        self.turn_usages.extend(usage_turns)
         return AdkRunResult(
             response_text=response_text,
             event_count=event_count,
             tool_calls=tuple(tool_calls),
             tool_responses=tuple(tool_responses),
+            usage_turns=tuple(usage_turns),
         )
 
     async def history(self) -> list[types.Event]:

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
@@ -35,6 +35,28 @@ class AdkRuntimeUnavailable(RuntimeError):
 
 
 @dataclass(frozen=True)
+class AdkUsage:
+    """Jetons consommes par un appel LLM, remontes depuis l'event ADK.
+
+    Contrat C6 (#14058) -- tracabilite : ADK produit ``usage_metadata`` sur
+    ses events LLM (natif), mais le runtime du depot ne le remontait pas.
+    Chaque appel LLM d'un tour contribue un snapshot ; la consommation
+    devient observable depuis ``AdkRunResult``.
+    """
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    def __add__(self, other: "AdkUsage") -> "AdkUsage":
+        return AdkUsage(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
+
+
+@dataclass(frozen=True)
 class AdkRunResult:
     """Observable evidence produced by a complete ADK invocation."""
 
@@ -42,11 +64,20 @@ class AdkRunResult:
     event_count: int
     tool_calls: tuple[str, ...]
     tool_responses: tuple[str, ...]
+    usage_turns: tuple[AdkUsage, ...] = ()
 
     @property
     def tool_was_invoked(self) -> bool:
         """Whether ADK emitted both a tool request and its response."""
         return bool(self.tool_calls and self.tool_responses)
+
+    @property
+    def usage_total(self) -> AdkUsage:
+        """Somme des jetons consommes par les appels LLM du tour."""
+        total = AdkUsage()
+        for usage in self.usage_turns:
+            total = total + usage
+        return total
 
 
 def dataset_profile(rows: int, columns: int) -> dict[str, int | float]:
@@ -123,6 +154,26 @@ def _part_text(content: types.Content | None) -> str:
     return "".join(part.text or "" for part in content.parts).strip()
 
 
+def _event_usage(event) -> AdkUsage | None:
+    """Snapshot C6 d'un event : son usage LLM, ou None s'il n'en porte pas.
+
+    Un event sans appel LLM (message utilisateur, reponse d'outil) n'emet
+    pas d'usage ; un provider qui ne compte pas ses jetons emet un usage
+    nul -- dans les deux cas la tracabilite reste honnete (rien invente).
+    """
+    metadata = getattr(event, "usage_metadata", None)
+    if metadata is None:
+        return None
+    snapshot = AdkUsage(
+        prompt_tokens=metadata.prompt_token_count or 0,
+        completion_tokens=metadata.candidates_token_count or 0,
+        total_tokens=metadata.total_token_count or 0,
+    )
+    if snapshot == AdkUsage():
+        return None
+    return snapshot
+
+
 async def run_agent_turn(
     agent: Agent,
     prompt: str,
@@ -150,6 +201,7 @@ async def run_agent_turn(
     response_text = ""
     tool_calls: list[str] = []
     tool_responses: list[str] = []
+    usage_turns: list[AdkUsage] = []
     event_errors: list[str] = []
     event_count = 0
 
@@ -169,6 +221,9 @@ async def run_agent_turn(
                 for response in event.get_function_responses()
                 if response.name
             )
+            usage = _event_usage(event)
+            if usage is not None:
+                usage_turns.append(usage)
             error_code = getattr(event, "error_code", None)
             error_message = getattr(event, "error_message", None)
             if error_code or error_message:
@@ -209,6 +264,7 @@ async def run_agent_turn(
         event_count=event_count,
         tool_calls=tuple(tool_calls),
         tool_responses=tuple(tool_responses),
+        usage_turns=tuple(usage_turns),
     )
 
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py
@@ -69,6 +69,8 @@ class ScriptedLlm(BaseLlm):
         kind, payload = _SCRIPT.pop(0)
         if kind == "call":
             yield _tool_call_response(payload[0], payload[1])
+        elif kind == "usage":
+            yield _text_response_with_usage(payload[0], payload[1], payload[2])
         elif kind == "sleep":
             # Dort PUIS repond : sous mutation du budget de tour (wait_for
             # neutralise), le tour finit normalement et le test budget
@@ -84,6 +86,20 @@ class ScriptedLlm(BaseLlm):
 def _text_response(text):
     return LlmResponse(content=types.Content(
         role="model", parts=[types.Part(text=text)]))
+
+
+def _text_response_with_usage(text, prompt, completion):
+    # LlmResponse/Event portent GenerateContentResponseUsageMetadata (champ
+    # candidates_token_count), pas types.UsageMetadata (response_token_count) :
+    # le type attendu par le runtime ADK est le premier.
+    return LlmResponse(
+        content=types.Content(
+            role="model", parts=[types.Part(text=text)]),
+        usage_metadata=types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=prompt,
+            candidates_token_count=completion,
+            total_token_count=prompt + completion,
+        ))
 
 
 def _tool_call_response(name, args):
@@ -411,14 +427,17 @@ def test_c5_transfer_exists_in_adk_but_is_not_wired():
     assert "agents" not in turn_params
 
 
-def test_c6_no_token_budget_and_usage_not_observable():
-    # C6 (budgets de jetons / couts) -- MESURE : RunConfig ne porte aucun
-    # champ de budget de consommation (max_llm_calls borne des APPELS, pas
-    # les jetons ; grep du package : token_budget/cost_budget/usage_limit
-    # = 0). Cote tracabilite, ADK produit usage_metadata sur ses events
-    # (natif), mais AdkRunResult ne le remonte pas : la consommation
-    # n'est pas observable depuis le runtime du depot. Non porte ->
-    # grain ouvert.
+def test_c6_no_native_token_budget_but_usage_is_observable():
+    # C6 (budgets de jetons / couts) -- TRACABILITE PORTEE (#14687) :
+    # AdkRunResult remonte desormais l'usage LLM de chaque appel
+    # (usage_turns / usage_total), et ConversationRunner cumule par
+    # conversation. La MESURE initiale reste vraie cote budget NATIF :
+    # RunConfig ne porte toujours aucun champ de consommation (max_llm_calls
+    # borne des APPELS, pas les jetons) -- le budget au-dessus d'ADK est
+    # la jambe 2 du grain, pas suppose natif.
+    # Critere 4 -- ce test echoue au retrait de la collecte : sans le
+    # releve _event_usage dans consume_events, usage_turns est vide et
+    # chaque assert ci-dessous rouge (verifie par mutation locale).
     from dataclasses import fields
     from google.adk.runners import RunConfig
 
@@ -427,13 +446,48 @@ def test_c6_no_token_budget_and_usage_not_observable():
         if "token" in f.lower() or "cost" in f.lower()
     ]
     assert run_config_budget_fields == [], (
-        f"RunConfig porte un budget de consommation ({run_config_budget_fields}) "
-        ": ce test documentait le non-portage C6, il doit etre inverse")
+        f"RunConfig porte un budget natif ({run_config_budget_fields}) : "
+        "la jambe budget doit documenter ce changement de fond")
+
     result_fields = {f.name for f in fields(AdkRunResult)}
-    assert not any(
-        "usage" in f or "token" in f or "cost" in f for f in result_fields), (
-        "AdkRunResult remonte la consommation : la tracabilite C6 est "
-        "portee, ce test doit etre inverse par le grain qui porte le contrat")
+    assert "usage_turns" in result_fields, (
+        "AdkRunResult ne remonte plus l'usage : la tracabilite C6 est "
+        "retiree")
+
+    _SCRIPT.append(("usage", ("profil", 42, 17)))
+    result = _run_turn(_scripted_agent(tools=()), "question simple")
+    assert len(result.usage_turns) == 1, (
+        f"un appel LLM doit laisser exactement un snapshot d'usage, "
+        f"mesure : {result.usage_turns}")
+    assert result.usage_turns[0] == adk_runtime.AdkUsage(
+        prompt_tokens=42, completion_tokens=17, total_tokens=59)
+    assert result.usage_total == adk_runtime.AdkUsage(
+        prompt_tokens=42, completion_tokens=17, total_tokens=59)
+
+
+def test_c6_usage_accumulates_across_conversation_turns():
+    # C6, versant ConversationRunner : chaque tour rend son usage (contrat
+    # du tour) ET la conversation cumule (profil de consommation multi-tours).
+    # Critere 4 -- au retrait de la collecte d'usage dans
+    # ConversationRunner.turn, conversation.usage_total reste nul -> rouge.
+    from utils.adk_conversation import ConversationRunner
+
+    async def scenario():
+        agent = _scripted_agent(tools=())
+        async with ConversationRunner(agent) as conversation:
+            tour1 = await conversation.turn("premier tour")
+            tour2 = await conversation.turn("second tour")
+            return conversation, tour1, tour2
+
+    _SCRIPT.append(("usage", ("reponse un", 40, 10)))
+    _SCRIPT.append(("usage", ("reponse deux", 60, 25)))
+    conversation, tour1, tour2 = asyncio.run(scenario())
+    assert tour1.usage_turns and tour2.usage_turns, (
+        "chaque tour doit rendre son propre snapshot d'usage")
+    assert conversation.usage_total == adk_runtime.AdkUsage(
+        prompt_tokens=100, completion_tokens=35, total_tokens=135), (
+        f"le cumul conversation doit sommer les tours, mesure : "
+        f"{conversation.usage_total}")
 
 
 def test_c7_roles_are_declared_and_required():

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py
@@ -490,6 +490,79 @@ def test_c6_usage_accumulates_across_conversation_turns():
         f"{conversation.usage_total}")
 
 
+def test_c6_budget_cuts_mid_turn_with_explicit_verdict():
+    # C6 jambe 2 -- le plafond de jetons cumules coupe PROPREMENT : verdict
+    # type AdkBudgetExceeded (pas une exception brute du stream), portant
+    # plafond, cumul exact au moment de la coupe et numero du tour. Le VRAI
+    # Runner ADK tourne (seul le LLM est scripte) ; le 1er tour consomme 50
+    # jetons, le 2e (85) franchit le plafond de 100 pose d'office.
+    # Critere 4 -- au retrait du releve de plafond dans consume_events
+    # (comparaison neutralisee), le tour 2 se termine normalement et ce
+    # test echoue (verifie par mutation locale).
+    from utils.adk_conversation import AdkBudgetExceeded, ConversationRunner
+
+    async def scenario():
+        agent = _scripted_agent(tools=())
+        async with ConversationRunner(
+            agent, budget_total_tokens=100
+        ) as conversation:
+            tour1 = await conversation.turn("premier tour")
+            try:
+                await conversation.turn("second tour qui depasse")
+            except AdkBudgetExceeded as verdict:
+                return conversation, tour1, verdict
+            raise AssertionError("le tour 2 devait couper sur le plafond")
+
+    _SCRIPT.append(("usage", ("reponse un", 40, 10)))
+    _SCRIPT.append(("usage", ("reponse deux", 60, 25)))
+    conversation, tour1, verdict = asyncio.run(scenario())
+    assert tour1.usage_total.total_tokens == 50, (
+        "le tour 1 (sous plafond) doit se derouler normalement")
+    assert verdict.verdict == "BUDGET_EXCEEDED"
+    assert verdict.budget_total == 100
+    assert verdict.tour == 2
+    assert verdict.usage_total.total_tokens == 135, (
+        f"le cumul au moment de la coupe doit inclure l'appel qui franchit "
+        f"le plafond, mesure : {verdict.usage_total}")
+    assert verdict.usage_total == conversation.usage_total, (
+        "les jetons consommes avant la coupe restent dans le cumul "
+        "(comptabilite honnete)")
+
+
+def test_c6_budget_refuses_next_turn_without_calling_the_llm():
+    # C6 jambe 2, versant refus pre-tour : plafond atteint des le 1er tour
+    # -> le tour 2 est refuse AVANT tout appel LLM. La preuve mecanique :
+    # _REQUESTS n'enregistre qu'UN appel (celui du tour 1) -- un second
+    # appel LLM serait comptee la.
+    # Critere 4 -- au retrait du garde pre-tour dans turn(), le tour 2
+    # declenche un appel LLM (script epuise -> reponse par defaut) et ce
+    # test echoue sur len(_REQUESTS) == 1.
+    from utils.adk_conversation import AdkBudgetExceeded, ConversationRunner
+
+    async def scenario():
+        agent = _scripted_agent(tools=())
+        async with ConversationRunner(
+            agent, budget_total_tokens=50
+        ) as conversation:
+            await conversation.turn("premier tour consomme tout le plafond")
+            try:
+                await conversation.turn("tour refuse d'office")
+            except AdkBudgetExceeded as verdict:
+                return conversation, verdict
+            raise AssertionError("le tour 2 devait etre refuse pre-tour")
+
+    _SCRIPT.append(("usage", ("reponse un", 40, 10)))
+    conversation, verdict = asyncio.run(scenario())
+    assert verdict.verdict == "BUDGET_EXCEEDED"
+    assert verdict.tour == 2
+    assert verdict.budget_total == 50
+    assert len(_REQUESTS) == 1, (
+        f"le tour refuse ne doit declencher AUCUN appel LLM, "
+        f"appels mesures : {len(_REQUESTS)}")
+    assert conversation.budget_exhausted
+    assert conversation.usage_total.total_tokens == 50
+
+
 def test_c7_roles_are_declared_and_required():
     # C7 (specialistes : role declare, orchestration appuyee dessus) --
     # MESURE : PORTE. L'API Agent exige name + description + instruction


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/lean #14680

## Summary

Grain #14687 (contrat C6 du registre #14058) : **traçabilité + budget, portés du runtime au lab exécutable**. La mesure du registre disait « ADK produit `usage_metadata` sur ses events mais rien ne le remonte, et aucun plafond natif n'existe » — les deux jambes sont portées au-dessus d'ADK.

**Runtime — traçabilité (commit e8505e1352)** :
- `AdkUsage` (frozen dataclass) : `prompt_tokens` / `completion_tokens` / `total_tokens`, sommable.
- `AdkRunResult.usage_turns` : un snapshot par appel LLM du tour ; `.usage_total` : somme du tour.
- `ConversationRunner.turn_usages` / `.usage_total` : profil de consommation multi-tours.

**Runtime — budget (commit db08727f32)** :
- `AdkBudgetExceeded` : verdict **typé** (`verdict = "BUDGET_EXCEEDED"`) portant plafond, cumul exact au moment de la coupe (jetons consommes avant coupe inclus — comptabilite honnete) et numero du tour. Pas d'exception brute du stream.
- `ConversationRunner(budget_total_tokens=N)` : **refus pre-tour avant tout appel LLM** quand le plafond est atteint (`>=`), **coupe au premier appel qui le franchit** (`>` strict — un tour atterrissant exactement sur le plafond se termine normalement). La coupe arrete de consommer le stream et rend le verdict hors vol.
- `budget_exhausted` : etat consultable. Sans plafond (`None`) : comportement inchangé, conversation non bornee.

**Lab14-Token-Usage (commits a0ec3e5e58 + db08727f32)** — exécution réelle (OpenRouter, `openai/gpt-4.1`, clé uniquement dans l'env du process, jamais dans le notebook ni ses outputs) :
- Section 2 : tour avec outil = **2 appels LLM = 2 snapshots** (149+19, 204+78).
- Section 3 : conversation 3 tours — **prompt 343 → 607 → 845**, cumul 2014 : coût marginal mesuré de la mémoire C1b.
- Section 4 : budget natif `RunConfig` = **AUCUN** champ token/cost.
- Section 5 : **démo budget sur LLM réel** — plafond dérivé de la mesure (453 jetons après le tour 1), le tour 2 coupe au premier appel : verdict `BUDGET_EXCEEDED (tour 2)`, cumul à la coupe 725 jetons.
- 3 exercices stubbés conformes C.1 (`cout_marginal`, `usage_coherent`, `compteurs_independants`).

**Piège d'API tranché empiriquement** : `Event.usage_metadata` et `LlmResponse.usage_metadata` sont annotés `google.genai.types.GenerateContentResponseUsageMetadata` (champ completion = `candidates_token_count`), PAS `types.UsageMetadata` (qui porte `response_token_count` et rejette `candidates_token_count` en `extra_forbidden`). Les deux classes coexistent dans `google.genai.types`.

## Validation

- `pytest utils/` (track complet) : **51 passed** — dont les 12 contrats + 4 C6 (2 traçabilité + 2 budget).
- `test_c6_budget_cuts_mid_turn_with_explicit_verdict` : VRAI Runner ADK 2.8, seul le LLM scripté — tour 1 (50 jetons) sous plafond 100 se déroule normalement, tour 2 (85) franchit → verdict avec `budget_total=100`, `tour=2`, `usage_total.total_tokens=135` = cumul conversation (comptabilité honnête vérifiée).
- `test_c6_budget_refuses_next_turn_without_calling_the_llm` : preuve mécanique du refus pre-tour — `_REQUESTS` n'enregistre qu'**1** appel LLM (celui du tour 1) ; le tour refusé n'en déclenche aucun.
- **Critère 4 vérifié par mutation locale, garde par garde** : comparaison mid-turn neutralisée → test coupe ROUGE ; garde pre-tour neutralisée → test refus ROUGE (2 appels LLM mesurés) ; collecte d'usage neutralisée → les 2 tests traçabilité ROUGES ; tout rétabli → 51/51 verts.
- Lab14 : Papermill end-to-end kernel python3, 23 cellules, 8 code cells **toutes `execution_count` non-nul + outputs**, 0 erreur, 0 `raise NotImplementedError` (C.1), grep clé/`sk-or` = 0 occurrence.
- Environnement : provider vLLM local down → bascule `ACTIVE_PROVIDER=openrouter` (clé du `.secrets/master.env`, env du process uniquement).

## Jambes du grain #14687 — toutes portées

| Jambe | État |
|---|---|
| Traçabilité (`usage_turns` / `usage_total` / cumul conversation) | PORTÉE (e8505e1352) |
| Lab Token-Usage (LLM réel, exécution fraîche) | LIVRÉ (a0ec3e5e58 + db08727f32) |
| Budget : plafond cumulé coupant proprement, verdict explicite | PORTÉ (db08727f32) |

Closes #14687 · See #14058 (registre C6 : les deux jambes portées). Jamais une restauration SK.
