### PR TITLE
enrich(notebook,#13934): obtenir-donnees-structurees 991 -> 1317 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/obtenir-des-donnees-structurees-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/obtenir-des-donnees-structurees-par-l-api.ipynb
@@ -159,6 +159,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-api-01",
+   "metadata": {},
+   "source": [
+    "### Le parcours en cinq temps\n",
+    "\n",
+    "Les helpers sont prêts — voici l'itinéraire. Ce notebook suit une veine\n",
+    "unique (obtenir du JSON fiable d'un moteur conversationnel) à travers\n",
+    "cinq moments qui se répondent : l'**erreur à froid** qui avait bloqué le\n",
+    "premier sondage (section 1), la **matrice d'usages** où la case `json`\n",
+    "reste vide (section 2), le **read-modify-write** qui la remplit sans\n",
+    "dégât collatéral (section 3), la **requête réelle** sur le catalogue\n",
+    "Valmont (section 4), puis les **mesures d'honnêteté** — le null\n",
+    "silencieux et la comparaison wire-level (section 5) — avant de rendre\n",
+    "l'instance à son état (section 6).\n",
+    "\n",
+    "Chaque section ne conclut que sur ce que sa mesure établit : le fil\n",
+    "directeur est la différence entre « la réponse est verte » et « la\n",
+    "donnée est là »."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6c14b841",
    "metadata": {
     "papermill": {
@@ -442,6 +464,22 @@
     "m = matrice()\n",
     "print(\"Case chat :\", m.get(\"chat\"))\n",
     "print(\"Case json :\", m.get(\"json\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-api-02",
+   "metadata": {},
+   "source": [
+    "#### Où en est l'exercice 1 ?\n",
+    "\n",
+    "Les deux `None` affichés sont ceux du **squelette** : la fonction\n",
+    "`matrice()` rend pour l'instant les valeurs brutes des deux cases, sans\n",
+    "structure. Complétée, elle doit rendre le dictionnaire `{usage: {\"env\":\n",
+    "..., \"model\": ...}}` décrit dans sa docstring — la même information que\n",
+    "la boucle d'affichage de la section 2, mais dans une forme qu'un test\n",
+    "peut parcourir sans relire du texte formaté. C'est le premier geste du\n",
+    "métier ici : transformer une lecture humaine en structure consommable."
    ]
   },
   {
@@ -769,6 +807,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-api-03",
+   "metadata": {},
+   "source": [
+    "#### Ce premier bord de la mesure\n",
+    "\n",
+    "`success: True`, `data` est un dictionnaire, et il est **sérialisable** :\n",
+    "côté syntaxe, tout est en ordre — la réponse est du JSON valide qui\n",
+    "contient une vraie donnée. Ce bord-là établit donc que la route PEUT\n",
+    "rendre du JSON habité. Mais ce n'est qu'un bord : la section 5b force\n",
+    "volontairement une réponse non-JSON avec le même moteur et la même case\n",
+    "`json`, pour voir ce que la route rend quand le contenu dégénère. La\n",
+    "question de l'honnêteté n'est pas « un exemple marche-t-il ? » mais\n",
+    "« que se passe-t-il quand ça ne marche pas ? » — et c'est la suite\n",
+    "immédiate."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "ae681f17",
@@ -962,6 +1018,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-api-04",
+   "metadata": {},
+   "source": [
+    "### Bilan des mesures d'honnêteté\n",
+    "\n",
+    "Avant les exercices, le tri des preuves accumulées. Cinq mesures ont\n",
+    "encadré la même promesse : le plugin déclare une case `json` (section 2),\n",
+    "la remplir ne casse rien (section 3), la route rend un JSON valide et\n",
+    "habité quand le moteur coopère (5a), un **null silencieux** quand il ne\n",
+    "coopère pas (5b), et la transformation est wire-level — confirmée des\n",
+    "deux côtés du plugin (5c). Aucune de ces mesures seule ne suffit : c'est\n",
+    "l'ensemble qui transforme « la case json existe » en « voici ce qu'elle\n",
+    "garantit, et voici son mode de défaillance ».\n",
+    "\n",
+    "Les deux exercices qui suivent prolongent exactement ce programme :\n",
+    "l'un sonde la robustesse (un taux, pas un exemple), l'autre audite la\n",
+    "restauration (un diff complet, pas deux cases affichées)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f2e48af3",
    "metadata": {
     "papermill": {
@@ -1030,6 +1107,25 @@
     "\n",
     "taux, details = taux_json([\"Réponds juste le mot: bonjour\"])\n",
     "print(\"taux :\", taux, \"| details :\", details)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-api-05",
+   "metadata": {},
+   "source": [
+    "#### Lire le rendu du squelette\n",
+    "\n",
+    "`taux : 0.0 | details : []` est le rendu du **squelette**, pas une\n",
+    "mesure : sans complétion, aucun message n'a été sondé, et le zéro ne\n",
+    "veut rien dire. Une fois complétée, la fonction rendra la proportion de\n",
+    "réponses au JSON valide sur une liste de messages — et la lecture\n",
+    "deviendrait intéressante dans les deux sens : un taux de 1.0 sur trois\n",
+    "messages ne prouve pas la robustesse (c'est la mise en garde de\n",
+    "l'exercice), un taux proche de zéro avec des détails remplis cartographie\n",
+    "les cas de défaillance. La bonne question pour dimensionner la liste :\n",
+    "combien de messages faut-il pour qu'un taux soit une mesure et non un\n",
+    "tirage ?"
    ]
   },
   {
@@ -1171,6 +1267,23 @@
     "print(\"ecarts :\", len(ecarts))\n",
     "for k, va, vp in ecarts[:10]:\n",
     "    print(f\"  {k}: {str(va)[:50]} -> {str(vp)[:50]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-api-06",
+   "metadata": {},
+   "source": [
+    "#### Le zéro qui ne prouve rien — pour l'instant\n",
+    "\n",
+    "`ecarts : 0` sort du squelette : l'audit n'a encore rien comparé. La\n",
+    "différence avec la preuve visée est entièrement dans le **spectre de la\n",
+    "comparaison** : « les deux cases affichées sont revenues » (ce que\n",
+    "l'œil vérifie) compare deux valeurs ; l'audit complété compare\n",
+    "l'instantané ENTIER d'avant avec l'état d'après, clé par clé. Un zéro\n",
+    "rendu par ce diff complet serait une vraie preuve de restauration — le\n",
+    "genre de différence entre « ça a l'air revenu » et « rien n'a changé »\n",
+    "qui sépare une relecture d'un test."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Enrichissement obtenir-des-donnees-structurees-par-l-api : 991 -> 1317 c/cell (tranche 3/4)

Troisieme notebook de la queue residuelle #13934. Mesure pre-claim reverifiee firsthand : 11902/12 = 991. Ce notebook etait deja bien interprete par paliers — le deficit etait structurel (12 cellules code) ; l'apport porte sur les angles non couverts.

### Ce qui est ajoute

Six cellules markdown (aucune cellule code touchee, aucune sortie modifiee) :

- **itineraire en cinq temps** (apres la config, output « Helpers prets ») : annonce l'arc narratif des six sections et le fil directeur (« la reponse est verte » vs « la donnee est la »).
- **interpretation du bord 5a** (apres la mesure JSON valide/habite) : ce que ce bord etablit (la route PEUT rendre du JSON habite) et pourquoi ce n'est qu'un bord — la 5b force la degenerescence.
- **bilan des mesures d'honnetete** (apres le verdict wire-level 5c) : le tri des cinq preuves accumulees, aucune suffisante seule, et le lien vers les deux exercices qui prolongent le programme.
- **coaching sur les trois squelettes d'exercices** (apres chacun) : les rendus `None`/`taux : 0.0 | details : []`/`ecarts : 0` sont explicitement nommes comme rendus de squelette, distincts d'une mesure — la cellule dit ce que la fonction completee rendra et pourquoi la difference compte (structure consommable, taux dimensionne, diff complet vs deux cases affichees).

Le point de vigilance respecte : aucune interpretation ne presente un rendu de squelette comme une mesure reelle.

### Mesure canonique

Avant : 11902 prose / 12 code = **991**. Apres : 15814 prose / 12 code = **1317**, statut `ok`. 30 -> 36 cellules.

### Validation

- Markdown-only : pas de re-execution requise (C.2).
- `check_notebook_navlinks.py` : 0 lien casse.
- Style : francais accentue, conforme au style de CE notebook (la zone n'est pas homogene — les deux tranches precedentes #14688/#14689 sont en non-accente, celle-ci en accentue).

See #13934 (tranche 3/4 — reste `parler-au-chatbot-en-visiteur-par-l-api` 1052 ; tranches 1-2 = PR #14688/#14689).
