### PR TITLE
enrich(notebook,#13934): parler-au-chatbot-en-visiteur 1052 -> 1349 c/cell (queue drainee)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/parler-au-chatbot-en-visiteur-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/parler-au-chatbot-en-visiteur-par-l-api.ipynb
@@ -198,6 +198,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-vis-01",
+   "metadata": {},
+   "source": [
+    "### Trois faces, lues dans le catalogue\n",
+    "\n",
+    "Le catalogue de `/wp-json/` rend sept namespaces, et trois nous\n",
+    "concernent directement : `mwai/v1` (l'API d'administration des notebooks\n",
+    "precedents), `mwai-ui/v1` (la face visiteur, notre sujet) et `mcp/v1`\n",
+    "(le serveur MCP du quatrieme notebook). Les autres sont la plateforme\n",
+    "WordPress elle-meme. Une face = un namespace = un **contrat different** :\n",
+    "meme instance, memes donnees, mais des routes, des authentifications et\n",
+    "des garanties distinctes.\n",
+    "\n",
+    "La liste des six routes de `mwai-ui/v1` se lit comme un cahier des\n",
+    "charges du visiteur : soumettre un chat (`chats/submit`), un editeur\n",
+    "(`editor/submit`), gerer des fichiers (`upload`, `list`, `delete`). Aucune\n",
+    "route d'administration ici — ce namespace ne sait PAS configurer le\n",
+    "moteur, seulement l'utiliser. C'est la separation que la suite du\n",
+    "notebook va mesurer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f9170916",
    "metadata": {},
    "source": [
@@ -351,6 +374,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-vis-02",
+   "metadata": {},
+   "source": [
+    "### Ce que le visiteur porte apres le bootstrap\n",
+    "\n",
+    "Le handshake `mwai-ui/v1` rend quatre choses, et chacune a son role dans\n",
+    "la conversation a venir. Le `sessionId` (`5024de59...`) est un jeton de\n",
+    "**courte duree** : il identifie la conversation cote serveur. Le `nonce`\n",
+    "(`dd9b3f...`) est la credence anti-CSRF que WordPress exigera sur chaque\n",
+    "POST — sans elle, pas d'ecriture. Le cookie `mwai_session_id` pose par la\n",
+    "session requests joue le meme role que le cookie du navigateur : il\n",
+    "**suit** le visiteur d'un appel a l'autre. Et `success : True` dit juste\n",
+    "que le serveur a accepte de les distribuer.\n",
+    "\n",
+    "Aucune de ces trois credences n'est une authentification d'utilisateur :\n",
+    "un visiteur anonyme les obtient toutes, c'est prevu ainsi. Ce sont des\n",
+    "**jetons de parole**, pas des droits. La frontiere veritable se mesure\n",
+    "au palier suivant — et le contraste entre les deux POST (`401` sans\n",
+    "nonce, `200` avec) montrera exactement ou elle est posee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "58a73259",
    "metadata": {},
    "source": [
@@ -492,6 +538,27 @@
     "api(\"/wp/v2/pages/%d\" % PAGE_ID, method=\"DELETE\", payload={\"force\": True})\n",
     "statut, _ = http_get(\"/\" + SLUG + \"/\")\n",
     "print(\"apres suppression : GET /\" + SLUG + \"/ ->\", statut)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-vis-03",
+   "metadata": {},
+   "source": [
+    "### Instance rendue propre — et le parcours complet\n",
+    "\n",
+    "`GET /discussion-valmont/ -> 404` : la page de demonstration a disparu,\n",
+    "l'instance redevient celle que son etat initial decrit. Reste a relire ce\n",
+    "que le parcours a etabli, car les cinq sections forment une chaine : le\n",
+    "catalogue (1) annoncait une face visiteur sans droits d'administration ;\n",
+    "la page publique (2) embarquait le bot mais **aucun secret** (nonce et\n",
+    "session a `None` dans le HTML) ; le bootstrap (3) distribuait ses jetons\n",
+    "de parole a quiconque les demande ; la frontiere (4) refusait le POST\n",
+    "sans nonce puis acceptait la conversation -- `reply` reelle, `usage`\n",
+    "compte (`prompt 77 | completion 1388`), neuf champs de reponse dont\n",
+    "`actions`, `blocks`, `images`. Le visiteur peut parler au chatbot ; il ne\n",
+    "peut pas le configurer. La face navigateur de l'API tient sa promesse de\n",
+    "separation, et c'est mesurable."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #14601

## Enrichissement parler-au-chatbot-en-visiteur : 1052 -> 1349 c/cell (tranche 4/4 — la queue residuelle est drainee)

Quatrieme et dernier notebook sous la norme de la zone AI-Engine-WordPress (dispatch ai-01 msg-20260904T235209). Mesure pre-claim reverifiee firsthand : 9475/9 = 1052.

### Ce qui est ajoute

Trois cellules markdown (aucune cellule code touchee, aucune sortie modifiee), chacune apres la cellule dont l'output porte la valeur citee :

- **le catalogue relu** (apres `/wp-json/`) : sept namespaces dont trois faces du plugin (`mwai/v1` administration, `mwai-ui/v1` visiteur, `mcp/v1` serveur MCP) ; une face = un namespace = un contrat distinct ; les six routes visiteur lues comme un cahier des charges sans aucune route d'administration.
- **le bootstrap visiteur interprete** (apres le handshake) : `sessionId` courte duree, `nonce` credence anti-CSRF, cookie `mwai_session_id` de suivi — trois credences qu'un anonyme obtient toutes par conception : des **jetons de parole, pas des droits** ; annonce le contraste 401/200 du palier suivant.
- **la chaine des cinq sections recapitulee** (apres le 404 de nettoyage) : catalogue -> page publique sans secret (nonce/session a None dans le HTML) -> jetons distribuables -> frontiere mesuree (reply reelle, usage compte, neuf champs) ; le visiteur peut parler au chatbot, il ne peut pas le configurer — la promesse de separation, tenue et mesurable.

### Mesure canonique

Avant : 9475 prose / 9 code = **1052**. Apres : 12144 prose / 9 code = **1349**, statut `ok`. 22 -> 25 cellules.

### Validation

- Markdown-only : pas de re-execution requise (C.2).
- `check_notebook_navlinks.py` : 0 lien casse.
- Style : francais non accentue, conforme au style de ce notebook.

### Fermeture de la zone

Avec les tranches 1-3 (#14688 : 643 -> 1282, #14689 : 935 -> 1425, #14691 : 991 -> 1317), les quatre notebooks residuels passent au-dessus de la norme 1200 : la mesure plein perimetre `pedagogy_density.py --json AI-Engine-WordPress/` ne doit plus rien compter sous le seuil une fois les quatre mergees.

See #13934 (queue non terminee : 14/20 notebooks encore sous la norme au 2026-09-05, mesure sur main d8368756f)

