### PR TITLE
fix(genai,#12194): restaurer les 8 accolades de classe supprimees par le denamespace file-scoped

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/AutoInvokeSKAgentsNotebookUpdater.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/AutoInvokeSKAgentsNotebookUpdater.cs
@@ -105,3 +105,4 @@ public class AutoInvokeSKAgentsNotebookUpdater(string notebookPath, ILogger logg
 			}
 		}
 	}
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/DisplayLogger.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/DisplayLogger.cs
@@ -39,3 +39,4 @@ public class DisplayLogger : ILogger, ILoggerFactory
 	public ILogger CreateLogger(string categoryName) => this;
 
 	public void AddProvider(ILoggerProvider provider) => throw new NotSupportedException();
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/DisplayLoggerProvider.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/DisplayLoggerProvider.cs
@@ -15,3 +15,4 @@ public class DisplayLoggerProvider : ILoggerProvider
 	}
 
 	public void Dispose() { }
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/NotebookExecutor.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/NotebookExecutor.cs
@@ -216,3 +216,4 @@ public class NotebookExecutor
 				break;
 		}
 	}
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/NotebookUpdaterBase.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/NotebookUpdaterBase.cs
@@ -233,3 +233,4 @@ Tool usage instructions apply to any function calls you make.";
 	}
 
 	protected abstract Task PerformNotebookUpdateAsync();
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/WorkbookInteractionBase.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/WorkbookInteractionBase.cs
@@ -303,3 +303,4 @@ public class WorkbookInteractionBase
 	{
 		return !string.IsNullOrEmpty(cell.KernelName); // Les cellules de code ont un KernelName défini.
 	}
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/WorkbookUpdateInteraction.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/WorkbookUpdateInteraction.cs
@@ -110,3 +110,4 @@ public class WorkbookUpdateInteraction(string notebookPath, ILogger logger)
 		_logger.LogInformation(message);
 		return Task.FromResult(message);
 	}
+}

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/WorkbookValidation.cs
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/WorkbookValidation.cs
@@ -20,3 +20,4 @@ public class WorkbookValidation(string notebookPath, ILogger logger) : WorkbookI
 		_logger.LogInformation(message);
 		return Task.FromResult(message);
 	}
+}


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-ai-01:CoursIA — prev: MED/guard #14625

## Quoi

`MyIA.CoursIA.sln` ne compile pas. Huit helpers `.cs` de `GenAI/SemanticKernel/` sont **tronqués** : il leur manque à chacun l'accolade fermante de leur classe. Cette PR les restaure — 8 fichiers, **+8 lignes, 0 suppression**, une accolade par fichier.

## Cause, vérifiée sur les 8 diffs

PR #12198 (`e71b19d4f`, mergée) retirait un namespace **file-scoped** de ces 8 fichiers :

```csharp
namespace MyNotebookLib;    // point-virgule — PAS de bloc, donc pas d'accolade à fermer
```

La suppression a emporté, dans chaque fichier, **et** la ligne `namespace` **et** la dernière ligne `}` — qui ne fermait pas le namespace mais la **classe**. Mesuré sur les 8 diffs, sans exception :

```
$ for F in $(git show --name-only --format='' e71b19d4f | grep '\.cs$'); do
    echo "$(basename $F) derniere-suppr=[$(git show e71b19d4f -- "$F" | grep '^-' | grep -v '^---' | tail -1)]"
  done
AutoInvokeSKAgentsNotebookUpdater.cs  derniere-suppr=[-}]
DisplayLogger.cs                      derniere-suppr=[-}]
DisplayLoggerProvider.cs              derniere-suppr=[-}]
NotebookExecutor.cs                   derniere-suppr=[-}]
NotebookUpdaterBase.cs                derniere-suppr=[-}]
WorkbookInteractionBase.cs            derniere-suppr=[-}]
WorkbookUpdateInteraction.cs          derniere-suppr=[-}]
WorkbookValidation.cs                 derniere-suppr=[-}]
```

**Contrôle positif** — le déséquilibre suit exactement la liste des fichiers touchés, il n'est pas une propriété du répertoire :

| Fichier | `{` / `}` | Touché par `e71b19d4f` |
|---|---|---|
| AutoInvokeSKAgentsNotebookUpdater.cs | 32 / **31** | oui |
| DisplayLogger.cs | 9 / **8** | oui |
| DisplayLoggerProvider.cs | 4 / **3** | oui |
| NotebookExecutor.cs | 34 / **33** | oui |
| NotebookUpdaterBase.cs | 29 / **28** | oui |
| WorkbookInteractionBase.cs | 53 / **52** | oui |
| WorkbookUpdateInteraction.cs | 20 / **19** | oui |
| WorkbookValidation.cs | 2 / **1** | oui |
| AutoGenNotebookUpdater.cs | 17 / 17 | non |
| GuessingGame.cs | 19 / 19 | non |
| NotebookPlannerUpdater.cs | 8 / 8 | non |
| apphost.cs | 0 / 0 | non |

**8/8 touchés déséquilibrés, 4/4 non touchés équilibrés.**

## Mesure firsthand — build avant / après

`dotnet build MyIA.CoursIA.sln -c Release --nologo -v minimal`, SDK **10.0.111**, dans un worktree **sans sous-modules initialisés** (voir la note ci-dessous sur pourquoi ce détail compte) :

| | rc | Erreurs | Classes |
|---|---:|---:|---|
| **avant** | 1 | 13 | `CS1513` « } attendue » ×13 |
| **après** | 1 | **5** | `CS9298` ×5 — **sans rapport**, voir résiduel |

Le `restore` passe proprement dans les deux cas. La classe `CS1513` est **entièrement** éteinte.

## Ce que cette PR ne corrige PAS (résiduel nommé, non revendiqué)

Le build reste **rouge** après ce correctif, pour une cause distincte et indépendante :

```
GenAI/Aspire/GenAiStack.AppHost/apphost.cs(1,2): error CS9298:
  Les directives « #: » ne peuvent être utilisées que dans des programmes basés
  sur des fichiers (« -features:FileBasedProgram ») [MyIA.AI.Notebooks.csproj]
```

5 `apphost.cs` Aspire — des **programmes mono-fichier** (`dotnet run app.cs`, directives `#:sdk`) — sont avalés par le glob implicite `**/*.cs` de `MyIA.AI.Notebooks.csproj`, qui n'a aucune clause `Compile Remove`. Sujet différent (hygiène de glob du csproj, pas régression de source) → **PR séparée**, G.4 strict. Je la porte sur ma lane dans la foulée.

Je le dis explicitement plutôt que d'annoncer un build vert : **13 → 5 n'est pas 13 → 0.**

## Pourquoi personne ne l'a vu pendant ~2 semaines

Le dépôt **n'a aucune CI .NET** — c'est le constat de #13378, et c'est ce grain-là qui a fait apparaître celui-ci. Le notebook `Semantic-kernel-AutoInteractive.ipynb`, lui, **s'exécutait** : .NET Interactive compile les cellules une par une via `#!import`, là où `dotnet build` compile l'assembly entier. Le verdict `EXEC_PROVED` de #12198 était donc **vrai pour le notebook et faux pour la solution**, et rien dans le dépôt n'était en position de le contredire.

Note de méthode, qui a failli me faire écrire un rapport faux : le même build lancé depuis le **checkout principal** rend 12 `MSB3822` (« ressources non-chaînes ») au lieu de ces erreurs. Ce n'est pas le même défaut — ce sont les **513 `.resx`** du sous-module Argumentum (DotNetNuke), avalés eux aussi par le glob implicite. `git ls-files | grep '\.resx$'` rend **0** dans le dépôt parent : un runner CI qui checkout sans `submodules:` n'en voit aucun. Mesurer dans un worktree sans sous-modules est ce qui reproduit la condition CI — et c'est seulement là que les vraies `CS1513` deviennent visibles.

## Scope

8 fichiers, +8/−0, une accolade chacun. Aucune logique touchée, aucun renommage, aucun fichier ajouté ou supprimé. BOM et fins de ligne préservés **par fichier** (4 des 8 portent un BOM, les 8 sont en CRLF) — vérifié après coup, `git diff --stat` rend bien `8 files changed, 8 insertions(+)` sans une seule suppression.

See #13378
See #12194
