### PR TITLE
fix(dotnet,#5167): etendre le garde de glob -- 10 sous-projets autonomes + 5 apphost Aspire avales par MyIA.AI.Notebooks.csproj

### DIFF
--- a/MyIA.AI.Notebooks/MyIA.AI.Notebooks.csproj
+++ b/MyIA.AI.Notebooks/MyIA.AI.Notebooks.csproj
@@ -53,6 +53,25 @@
          QuantConnect exclusion above). OwlAdapter/GSheetSync/DatasetUpdater
          were added in #5167 without this guard. -->
     <Compile Remove="SymbolicAI\Argument_Analysis\CoursIA-*\**\*.cs" />
+    <!-- Same class, never extended since #5167: each directory below holds its
+         own .csproj, so its sources belong to that build unit, not to
+         MyIA.AI.Notebooks.dll. Swept in by the implicit glob they fail the
+         parent build on references the parent does not carry (xunit, Roslyn
+         analyzer SDK, Aspire hosting). -->
+    <Compile Remove="GenAI\Aspire\AgentGuard.Analyzers\**\*.cs" />
+    <Compile Remove="GenAI\Aspire\AgentGuard.Demo\**\*.cs" />
+    <Compile Remove="GenAI\Aspire\AgentGuard.Verifier\**\*.cs" />
+    <Compile Remove="GenAI\Aspire\IntegrationTests\**\*.cs" />
+    <Compile Remove="GenAI\Aspire\StreamingAgent.App\**\*.cs" />
+    <Compile Remove="GenAI\CopilotSDK\**\*.cs" />
+    <Compile Remove="GenAI\Vibe-Coding\analyzers\**\*.cs" />
+    <Compile Remove="GenAI\Vibe-Coding\docs\**\*.cs" />
+    <Compile Remove="Probas\DecisionTheory\voi\**\*.cs" />
+    <Compile Remove="SymbolicAI\Tweety\**\*.cs" />
+    <!-- Aspire file-based programs (`#:sdk` directives, run via
+         `dotnet run apphost.cs`, no .csproj of their own): the `#:` directive
+         is only legal under -features:FileBasedProgram, hence CS9298. -->
+    <Compile Remove="**\apphost.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Grain: MED/refactor — lane myia-ai-01:CoursIA — prev: MED/notebook-dotnet #14694

> **Empilée sur #14694** (base = `fix/12198-restore-class-braces`). À merger **après** lui. Le `0 erreur` mesuré plus bas est celui de la pile complète.

## Quoi

`MyIA.AI.Notebooks.csproj` ne pose pas `EnableDefaultCompileItems=false` : le glob implicite `**/*.cs` ramasse **tout** ce qui vit sous `MyIA.AI.Notebooks/`, y compris les répertoires qui portent **leur propre `.csproj`**. Leurs sources sont alors compilées dans l'assembly parent — qui ne référence ni xunit, ni le SDK d'analyseurs Roslyn, ni `Aspire.Hosting`. D'où 117 erreurs de référence.

**Le garde existe déjà** dans ce fichier, l.51-55, avec son commentaire d'intention :

> `Nested standalone sub-projects (own .csproj): excluded from the parent glob so they do not break MyIA.AI.Notebooks.dll (precedent: QuantConnect exclusion above). OwlAdapter/GSheetSync/DatasetUpdater were added in #5167 without this guard.`

Il n'a simplement **jamais été étendu**. AgentGuard (×3), IntegrationTests, StreamingAgent.App, CopilotSDK, Vibe-Coding (×2), InferNetVoi et Tweety/dotnet-build ont été ajoutés depuis #5167, chacun sans sa clause. Cette PR ajoute les 10 manquantes, dans le style du fichier, plus un cas voisin (ci-dessous).

## Recensement — comment les 10 préfixes ont été choisis

Énumération de tous les `.cs` sous `MyIA.AI.Notebooks/`, classés selon qu'un répertoire ancêtre porte ou non un `.csproj` :

| | `.cs` |
|---|---:|
| dans un sous-projet autonome (→ à exclure) | **59** |
| appartenant réellement au csproj parent | 34 |

Les 10 préfixes retenus couvrent exactement ces 59, et **aucun ne recouvre un `.cs` du parent** — le contrôle est mécanique : pour chaque préfixe retenu, le compte de `.cs` situés sous lui *mais hors* d'un sous-projet vaut **0**. C'est ce qui autorise à remonter d'un cran (`GenAI\CopilotSDK` plutôt que `GenAI\CopilotSDK\CopilotAgent.App`) sans emporter de source légitime.

## Le cas voisin : 5 `apphost.cs` Aspire

```
GenAI/Aspire/GenAiStack.AppHost/apphost.cs          GenAI/Aspire/GenAiStackReel.AppHost/apphost.cs
GenAI/Aspire/GenAiStack.AppHost-wt2/apphost.cs      GenAI/Aspire/GenAiStackReel.AppHost-wt2/apphost.cs
GenAI/SemanticKernel/aspire-otel/SkOtel.AppHost/apphost.cs
```

Pas de `.csproj` — ce sont des **programmes mono-fichier** (`#:sdk Aspire.AppHost.Sdk@13.4.6` en première ligne, lancés par `dotnet run apphost.cs`). La directive `#:` n'est légale que sous `-features:FileBasedProgram`, d'où `CS9298` quand le glob parent les avale. Même sujet — *un fichier qui appartient à une autre unité de build* — donc même PR.

## Aucune régression possible, et c'est vérifiable

Question légitime sur une PR qui **retire** 59 fichiers d'un build : perd-on de la couverture ?

**Non, et pour deux raisons mesurées :**

1. **Aucun de ces sous-projets n'est dans `MyIA.CoursIA.sln`.** La solution en déclare six : `MyIA.AI.Shared`, `MyIA.AI.Shared.Tests`, `MyIA.AI.Notebooks`, `MyIA.Trading.Converter`, `MyIA.Trading.Backtester`, `MyIA.Trading.Backtester.Tests`. `grep -c` rend **0** pour `IntegrationTests`, `AgentGuard.Analyzers`, `CopilotAgent.App`, `AgentSafetyAnalyzer`, `InferNetVoi`, `StreamingAgent.App`. Ils se construisent par leur propre `.csproj`, hors de cette solution — cette PR ne change rien pour eux.
2. **L'assembly parent n'a jamais été produit.** Le build échouait ; rien n'a jamais été compilé depuis ces fichiers dans `MyIA.AI.Notebooks.dll`. On ne retire pas une capacité existante, on cesse de tenter une compilation qui n'a jamais abouti.

Le fait qu'ils soient hors solution est en soi un défaut — mais c'en est un **autre** (couverture CI des sous-projets .NET, territoire de #14615), et il ne se traite pas ici.

## Mesure firsthand — `dotnet build MyIA.CoursIA.sln -c Release`

SDK **10.0.111**, worktree **sans sous-modules initialisés** (condition CI : `git ls-files | grep '\.resx$'` rend 0 dans le dépôt parent ; les 513 `.resx` visibles depuis un checkout complet appartiennent au sous-module Argumentum et masquent le vrai diagnostic derrière des `MSB3822`).

| État | rc | Erreurs | Classe |
|---|---:|---:|---|
| `origin/main` | 1 | 13 | `CS1513` — 8 classes tronquées |
| \+ #14694 (accolades) | 1 | 5 | `CS9298` — apphost Aspire |
| \+ **cette PR** | **0** | **0** | — (32 avertissements) |

Chaque couche en démasquait une autre : c'est pourquoi le compte monte à 117 si l'on n'exclut que les `apphost.cs`. Le chiffre honnête n'est pas « 13 → 5 → 0 » par soustraction, mais « chaque exclusion révèle la suivante jusqu'à épuisement ».

## Scope

**1 fichier, +19/−0**, uniquement des clauses `<Compile Remove>` et leurs commentaires. Aucune source touchée, aucun package ajouté, aucun `.sln` modifié.

See #13378
See #5167
