### PR TITLE
feat(ci,#14696): cabler le trio Argument_Analysis en CI dediee (12+23+19 tests) + entrees .sln

### DIFF
--- a/.github/workflows/dotnet-ArgumentAnalysis.yml
+++ b/.github/workflows/dotnet-ArgumentAnalysis.yml
@@ -1,0 +1,155 @@
+name: dotnet-ArgumentAnalysis
+
+# Tranche 1 de #14696 (orphelins .sln signales par ai-01 msg-20260905T014247) :
+# le trio Argument_Analysis — CoursIA.GSheetSync, CoursIA.OwlAdapter,
+# CoursIA.DatasetUpdater.Prompts + leurs 3 projets de tests xunit — est
+# exclu du glob parent depuis #5167, absent de MyIA.CoursIA.sln, et n'a
+# donc JAMAIS eu de CI. Cette PR les ajoute a la solution (entrees
+# minimales, +36 lignes) et les cable en workflow dedie.
+#
+# Bornes mesurees firsthand (worktree origin/main 0f157615e, 2026-09-05,
+# SDK 10.0.111 local, DOTNET_ROLL_FORWARD=Major faute de runtime 9 local —
+# le comptage --list-tests est independant du runtime d'execution) :
+#   - dotnet test GSheetSync.Tests       = 12 tests, 0 echec
+#   - dotnet test OwlAdapter.Tests       = 23 tests, 0 echec
+#   - dotnet test DatasetUpdater.Tests   = 19 tests, 0 echec
+#   - Dependances : xunit + ProjectReference vers la lib de chaque paire —
+#     zero service externe, zero secret, runner ephemere OK.
+#
+# Le build sln complet reste rouge sur main AVANT #14695 (apphost.cs
+# CS9298, glob parent — sujet d'#14695, pas de cette PR) : le workflow ne
+# construit donc PAS la solution, il cible les 3 csproj de tests
+# directement, qui build-ent leur lib transitive proprement.
+#
+# Deux jobs STATIQUES (pas de matrix runs-on dynamique — garde #13363,
+# meme forme que dotnet-Shared.Tests.yml famille 1/#14615).
+# Floors distincts par projet : une baisse de collecte est attribuee au
+# bon projet, pas a un agregat.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/**'
+      - '.github/workflows/dotnet-ArgumentAnalysis.yml'
+      - 'MyIA.CoursIA.sln'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/**'
+      - '.github/workflows/dotnet-ArgumentAnalysis.yml'
+      - 'MyIA.CoursIA.sln'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dotnet-argumentanalysis-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  AA_TESTS: >-
+    MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-GSheetSync/src/CoursIA.GSheetSync.Tests/CoursIA.GSheetSync.Tests.csproj
+    MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-OwlAdapter/src/CoursIA.OwlAdapter.Tests/CoursIA.OwlAdapter.Tests.csproj
+    MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/CoursIA-DatasetUpdater-Prompts/src/CoursIA.DatasetUpdater.Prompts.Tests/CoursIA.DatasetUpdater.Prompts.Tests.csproj
+
+jobs:
+  dotnet-argumentanalysis-linux:
+    name: ArgumentAnalysis dotnet (ubuntu-latest, floors 12/23/19)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Run the three test projects
+        run: |
+          for csproj in $AA_TESTS; do
+            dotnet test "$csproj" --nologo
+          done
+
+      # Floor-guard par projet (semantique dotnet-Shared.Tests.yml : un run
+      # vert alors que la collecte a silencieusement perdu des tests doit
+      # rougir). Pattern d'extraction locale-proof `^    [A-Za-z_]` (sans
+      # ancre d'en-tete localise), liste vide = panne de collecte = exit 1.
+      - name: Collection floor-guard (12/23/19)
+        if: always()
+        shell: bash
+        env:
+          DOTNET_CLI_UI_LANGUAGE: en
+        run: |
+          declare -A FLOOR=(
+            ["CoursIA.GSheetSync.Tests"]=12
+            ["CoursIA.OwlAdapter.Tests"]=23
+            ["CoursIA.DatasetUpdater.Prompts.Tests"]=19
+          )
+          STATUS=0
+          for csproj in $AA_TESTS; do
+            NAME=$(basename "$csproj" .csproj)
+            LISTED=$(dotnet test "$csproj" --list-tests --nologo 2>/dev/null | grep -cE '^    [A-Za-z_]')
+            if [ -z "$LISTED" ] || [ "$LISTED" -eq 0 ]; then
+              echo "::error::$NAME : --list-tests n'a renvoye aucun test — panne de collecte (a distinguer d'une baisse de couverture)."
+              STATUS=1; continue
+            fi
+            FLOOR=${FLOOR[$NAME]}
+            if [ "$LISTED" -lt "$FLOOR" ]; then
+              echo "::error::$NAME : regression de couverture — $LISTED tests listes, plancher=$FLOOR. Si la baisse est intentionnelle, ajuster FLOOR[$NAME] dans cette PR."
+              STATUS=1
+            else
+              echo "OK : $NAME — $LISTED tests listes (plancher=$FLOOR)."
+            fi
+          done
+          exit $STATUS
+
+  dotnet-argumentanalysis-windows:
+    name: ArgumentAnalysis dotnet (windows-latest, floors 12/23/19)
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Run the three test projects
+        shell: bash
+        run: |
+          for csproj in $AA_TESTS; do
+            dotnet test "$csproj" --nologo
+          done
+
+      - name: Collection floor-guard (12/23/19)
+        if: always()
+        shell: bash
+        env:
+          DOTNET_CLI_UI_LANGUAGE: en
+        run: |
+          declare -A FLOOR=(
+            ["CoursIA.GSheetSync.Tests"]=12
+            ["CoursIA.OwlAdapter.Tests"]=23
+            ["CoursIA.DatasetUpdater.Prompts.Tests"]=19
+          )
+          STATUS=0
+          for csproj in $AA_TESTS; do
+            NAME=$(basename "$csproj" .csproj)
+            LISTED=$(dotnet test "$csproj" --list-tests --nologo 2>/dev/null | grep -cE '^    [A-Za-z_]')
+            if [ -z "$LISTED" ] || [ "$LISTED" -eq 0 ]; then
+              echo "::error::$NAME : --list-tests n'a renvoye aucun test — panne de collecte (a distinguer d'une baisse de couverture)."
+              STATUS=1; continue
+            fi
+            FLOOR=${FLOOR[$NAME]}
+            if [ "$LISTED" -lt "$FLOOR" ]; then
+              echo "::error::$NAME : regression de couverture — $LISTED tests listes, plancher=$FLOOR. Si la baisse est intentionnelle, ajuster FLOOR[$NAME] dans cette PR."
+              STATUS=1
+            else
+              echo "OK : $NAME — $LISTED tests listes (plancher=$FLOOR)."
+            fi
+          done
+          exit $STATUS

--- a/MyIA.CoursIA.sln
+++ b/MyIA.CoursIA.sln
@@ -16,6 +16,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.Trading.Backtester", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.Trading.Backtester.Tests", "MyIA.Trading.Backtester.Tests\MyIA.Trading.Backtester.Tests.csproj", "{DF112603-A4EE-4651-B9DD-19E9BA338320}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.GSheetSync", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-GSheetSync\src\CoursIA.GSheetSync\CoursIA.GSheetSync.csproj", "{2E4B17E5-B54D-4B33-8A91-302149728C83}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.GSheetSync.Tests", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-GSheetSync\src\CoursIA.GSheetSync.Tests\CoursIA.GSheetSync.Tests.csproj", "{BD773DD6-F650-4D0B-9D22-20C13EADF239}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.OwlAdapter", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-OwlAdapter\src\CoursIA.OwlAdapter\CoursIA.OwlAdapter.csproj", "{3889BEA2-28C1-4BAA-833B-AB7E304D2E01}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.OwlAdapter.Tests", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-OwlAdapter\src\CoursIA.OwlAdapter.Tests\CoursIA.OwlAdapter.Tests.csproj", "{C76509BE-5013-4771-9058-0647765285CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.DatasetUpdater.Prompts", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-DatasetUpdater-Prompts\src\CoursIA.DatasetUpdater.Prompts\CoursIA.DatasetUpdater.Prompts.csproj", "{9DB079FF-016E-4102-979F-2851DDBFA099}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.DatasetUpdater.Prompts.Tests", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-DatasetUpdater-Prompts\src\CoursIA.DatasetUpdater.Prompts.Tests\CoursIA.DatasetUpdater.Prompts.Tests.csproj", "{26D274FA-3CB0-48EB-9561-DCA41FA405AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +58,30 @@ Global
 {DF112603-A4EE-4651-B9DD-19E9BA338320}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {DF112603-A4EE-4651-B9DD-19E9BA338320}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {DF112603-A4EE-4651-B9DD-19E9BA338320}.Release|Any CPU.Build.0 = Release|Any CPU
+{2E4B17E5-B54D-4B33-8A91-302149728C83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2E4B17E5-B54D-4B33-8A91-302149728C83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2E4B17E5-B54D-4B33-8A91-302149728C83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2E4B17E5-B54D-4B33-8A91-302149728C83}.Release|Any CPU.Build.0 = Release|Any CPU
+{BD773DD6-F650-4D0B-9D22-20C13EADF239}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{BD773DD6-F650-4D0B-9D22-20C13EADF239}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{BD773DD6-F650-4D0B-9D22-20C13EADF239}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{BD773DD6-F650-4D0B-9D22-20C13EADF239}.Release|Any CPU.Build.0 = Release|Any CPU
+{3889BEA2-28C1-4BAA-833B-AB7E304D2E01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{3889BEA2-28C1-4BAA-833B-AB7E304D2E01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{3889BEA2-28C1-4BAA-833B-AB7E304D2E01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{3889BEA2-28C1-4BAA-833B-AB7E304D2E01}.Release|Any CPU.Build.0 = Release|Any CPU
+{C76509BE-5013-4771-9058-0647765285CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{C76509BE-5013-4771-9058-0647765285CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{C76509BE-5013-4771-9058-0647765285CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{C76509BE-5013-4771-9058-0647765285CA}.Release|Any CPU.Build.0 = Release|Any CPU
+{9DB079FF-016E-4102-979F-2851DDBFA099}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{9DB079FF-016E-4102-979F-2851DDBFA099}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{9DB079FF-016E-4102-979F-2851DDBFA099}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{9DB079FF-016E-4102-979F-2851DDBFA099}.Release|Any CPU.Build.0 = Release|Any CPU
+{26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14691

## Tranche 1 de #14696 : le trio Argument_Analysis cable en CI

Les 6 projets Argument_Analysis (CoursIA.GSheetSync, CoursIA.OwlAdapter, CoursIA.DatasetUpdater.Prompts + leurs 3 projets de tests xunit) sont exclus du glob parent depuis #5167, absents de MyIA.CoursIA.sln, et n'ont jamais eu de CI — un des ilots du constat #14696 (mesure ai-01 : .sln = 6 projets, sous-projets orphelins).

### Ce qui est fait

- **Entrees .sln minimales** : 6 Project + 24 lignes de configuration, splice dans les octets originaux (+36 lignes, 0 deletion — le BOM et les LF du fichier sont preserves ; `dotnet sln list` confirme les 12 projets).
- **Workflow dedie** `.github/workflows/dotnet-ArgumentAnalysis.yml` : deux jobs STATIQUES ubuntu-latest + windows-latest (pas de matrix runs-on dynamique, garde #13363), setup-dotnet 9.0.x, `dotnet test` sur les 3 csproj de tests directement, floor-guard de collecte PAR projet (12 / 23 / 19).

### Mesures (worktree origin/main 0f157615e, firsthand)

- `dotnet build` x3 : 0 erreur.
- `dotnet test` x3 : **12 + 23 + 19 = 54 tests, 0 echec** (runtime local absent pour 9.0 — execution via DOTNET_ROLL_FORWARD=Major ; les compteurs --list-tests sont independants du runtime et confirmes a 12/23/19 par le pattern exact du floor-guard).
- Garde isolation self-hosted : `check_self_hosted_runner_policy.py` OK (workflows=138), 57/57 pytest verts.

### Interaction avec #14695 (pas de cette PR)

Le build **sln complet** reste rouge sur main tant que #14695 (apphost.cs CS9298, glob parent) n'est pas merge : les 5 erreurs sont pre-existantes dans MyIA.AI.Notebooks.csproj, aucune dans les 6 entrees nouvelles. Le workflow ne construit donc pas la solution — il cible les 3 csproj de tests, qui amenent leur lib par ProjectReference.

### Validation

- 2 fichiers modifies : `MyIA.CoursIA.sln`, `.github/workflows/dotnet-ArgumentAnalysis.yml` — enumeration verifiee.
- Re-run local du garde #13363 et des tests du garde avant push.
- Tranches suivantes (#14696 reste ouvert) : les 10 unites exclues par #14695 (AgentGuard.*, IntegrationTests, StreamingAgent.App, CopilotAgent.App, AgentSafetyAnalyzer, InferNetVoi, LiveOrderApp) une fois #14695 merge — Aspire hosting et file-based programs demandent un design distinct.

See #14696 (tranche 1 — la decision de couverture des 10 unites #14695 reste ouverte)
