### PR TITLE
feat(lean,#13483): P4.4 L3 brique a — dilation encadrée du support, sorry-free

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -384,6 +384,38 @@ theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
       have hrq_cheb : chebDist r q ≤ 1 := chebDist_le_one_of_moore r q hrq
       exact (chebDist_triangle p q r).trans (add_le_add hpr hrq_cheb)
 
+/-! ## Dilation encadrée du support (forme boîte) — brique L3 de l'assemblage P4.4
+
+`evolve_reach_chebyshev` borne l'atteinte par la distance à une cellule
+initiale vivante ; l'assemblage P4.4 L3 (#13483) consomme la **forme boîte** :
+si le support initial tient dans une boîte, le support après `t` générations
+tient dans la dilation Chebyshev-`t` de cette boîte. C'est la brique vitesse
+de la lumière pour l'arithmétique de fenêtres de `hcap` (confinement de la
+trajectoire). Sans sorry.
+-/
+
+/-- **Dilation encadrée du support.** Toute cellule vivante après `t`
+    générations est dans la dilation `t` (par coordonnée) de toute boîte
+    contenant le support initial. Compose `evolve_reach_chebyshev`
+    (témoin initial à distance ≤ t) et `coord_bound_of_chebDist_le`
+    (borne par coordonnée) ; l'arithmétique finale est linéaire. -/
+theorem evolve_support_dilation_box (t : Nat) (g : Grid) (a b : Int × Int)
+    (h : ∀ p, isAlive g p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
+    a.1 - (t : Int) ≤ q.1 ∧ q.1 < b.1 + (t : Int) ∧
+    a.2 - (t : Int) ≤ q.2 ∧ q.2 < b.2 + (t : Int) := by
+  obtain ⟨p, hp, hcheb⟩ := evolve_reach_chebyshev t g q h_alive
+  have ⟨hb1, hb2⟩ := coord_bound_of_chebDist_le p q t hcheb
+  have ⟨ha1, ha2, ha3, ha4⟩ := h p hp
+  have e1 : |q.1 - p.1| ≤ (t : Int) := by
+    rw [Int.abs_eq_natAbs]; exact_mod_cast hb1
+  have e2 : |q.2 - p.2| ≤ (t : Int) := by
+    rw [Int.abs_eq_natAbs]; exact_mod_cast hb2
+  obtain ⟨hlo1, hhi1⟩ := Int.abs_le.mp e1
+  obtain ⟨hlo2, hhi2⟩ := Int.abs_le.mp e2
+  exact ⟨by omega, by omega, by omega, by omega⟩
+
 /-! ## Localité étroite (forme boîte Chebyshev) — dual d'accord de `evolve_reach_chebyshev`
 
 Le théorème d'atteinte étroit (`evolve_reach_chebyshev` ci-dessus) dit : si `q`

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -408,12 +408,9 @@ theorem evolve_support_dilation_box (t : Nat) (g : Grid) (a b : Int × Int)
   obtain ⟨p, hp, hcheb⟩ := evolve_reach_chebyshev t g q h_alive
   have ⟨hb1, hb2⟩ := coord_bound_of_chebDist_le p q t hcheb
   have ⟨ha1, ha2, ha3, ha4⟩ := h p hp
-  have e1 : |q.1 - p.1| ≤ (t : Int) := by
-    rw [Int.abs_eq_natAbs]; exact_mod_cast hb1
-  have e2 : |q.2 - p.2| ≤ (t : Int) := by
-    rw [Int.abs_eq_natAbs]; exact_mod_cast hb2
-  obtain ⟨hlo1, hhi1⟩ := Int.abs_le.mp e1
-  obtain ⟨hlo2, hhi2⟩ := Int.abs_le.mp e2
+  -- omega traite `Int.natAbs` nativement : les bornes par coordonnée sont
+  -- directement linéaires, sans conversion via `Int.abs` (dont l'API
+  -- `abs_le` n'est pas dans le périmètre core du toolchain, c.14701 CI).
   exact ⟨by omega, by omega, by omega, by omega⟩
 
 /-! ## Localité étroite (forme boîte Chebyshev) — dual d'accord de `evolve_reach_chebyshev`

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
@@ -260,12 +260,9 @@ theorem evolve_support_dilation_box (t : Nat) (g : Grid) (a b : Int × Int)
   obtain ⟨p, hp, hcheb⟩ := evolve_reach_chebyshev t g q h_alive
   have ⟨hb1, hb2⟩ := coord_bound_of_chebDist_le p q t hcheb
   have ⟨ha1, ha2, ha3, ha4⟩ := h p hp
-  have e1 : |q.1 - p.1| ≤ (t : Int) := by
-    rw [Int.abs_eq_natAbs]; exact_mod_cast hb1
-  have e2 : |q.2 - p.2| ≤ (t : Int) := by
-    rw [Int.abs_eq_natAbs]; exact_mod_cast hb2
-  obtain ⟨hlo1, hhi1⟩ := Int.abs_le.mp e1
-  obtain ⟨hlo2, hhi2⟩ := Int.abs_le.mp e2
+  -- omega handles `Int.natAbs` natively: the per-coordinate bounds are
+  -- directly linear, no `Int.abs` conversion (whose `abs_le` API is not in
+  -- the toolchain core scope, c.14701 CI).
   exact ⟨by omega, by omega, by omega, by omega⟩
 
 /-! ## Tight locality (Chebyshev-box form) — agreement dual of `evolve_reach_chebyshev`

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
@@ -237,6 +237,37 @@ theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
       have hrq_cheb : chebDist r q ≤ 1 := chebDist_le_one_of_moore r q hrq
       exact (chebDist_triangle p q r).trans (add_le_add hpr hrq_cheb)
 
+/-! ## Boxed support dilation — L3 brick of the P4.4 assembly
+
+`evolve_reach_chebyshev` bounds reachability by the distance to an initially
+live cell; the P4.4 L3 assembly (#13483) consumes the **box form**: if the
+initial support fits in a box, the support after `t` generations fits in the
+Chebyshev-`t` dilation of that box. This is the speed-of-light brick for the
+window arithmetic of `hcap` (trajectory confinement). Sorry-free.
+-/
+
+/-- **Boxed support dilation.** Any live cell after `t` generations lies in
+    the per-coordinate `t`-dilation of any box containing the initial
+    support. Composes `evolve_reach_chebyshev` (initial witness within
+    distance t) with `coord_bound_of_chebDist_le` (per-coordinate bound);
+    the final arithmetic is linear. -/
+theorem evolve_support_dilation_box (t : Nat) (g : Grid) (a b : Int × Int)
+    (h : ∀ p, isAlive g p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
+    a.1 - (t : Int) ≤ q.1 ∧ q.1 < b.1 + (t : Int) ∧
+    a.2 - (t : Int) ≤ q.2 ∧ q.2 < b.2 + (t : Int) := by
+  obtain ⟨p, hp, hcheb⟩ := evolve_reach_chebyshev t g q h_alive
+  have ⟨hb1, hb2⟩ := coord_bound_of_chebDist_le p q t hcheb
+  have ⟨ha1, ha2, ha3, ha4⟩ := h p hp
+  have e1 : |q.1 - p.1| ≤ (t : Int) := by
+    rw [Int.abs_eq_natAbs]; exact_mod_cast hb1
+  have e2 : |q.2 - p.2| ≤ (t : Int) := by
+    rw [Int.abs_eq_natAbs]; exact_mod_cast hb2
+  obtain ⟨hlo1, hhi1⟩ := Int.abs_le.mp e1
+  obtain ⟨hlo2, hhi2⟩ := Int.abs_le.mp e2
+  exact ⟨by omega, by omega, by omega, by omega⟩
+
 /-! ## Tight locality (Chebyshev-box form) — agreement dual of `evolve_reach_chebyshev`
 
 The tight reach theorem (`evolve_reach_chebyshev` above) says: if `q` is alive


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/notebook-python #14690

## Summary

Tranche 3 de l'assemblage P4.4 (#13483, la dette `hashlife_correct_margin`) — **brique (a) : dilation encadrée du support, sorry-free**.

Nouveau théorème `evolve_support_dilation_box` (LightCone.lean, + jumeau `_en` byte-identical sur signatures/preuve, i18n #4980) :

> Toute cellule vivante après `t` générations est dans la dilation `t` (par coordonnée) de toute boîte contenant le support initial.

Composition : `evolve_reach_chebyshev` (vitesse de la lumière GoL, forme atteinte, LightCone L357 — **déjà prouvé sorry-free dans le lake**) + `coord_bound_of_chebDist_le` (ConeGeometry) + arithmétique linéaire finale (`Int.abs_le`, `omega`).

**Corrections de diagnostic portées sur l'issue ce cycle** (c.5548562272 + ce tick) :
- Le tick de scoping précédent avait conclu « aucun lemme de dilation n'existe dans le lake » sur un grep à identifiants anglais — **faux** : `evolve_reach_chebyshev` / `evolve_reach_within_padCenter2_margin` / les lemmes de localité existent (`LightCone.lean`, vocabulaire `lightCone`/`chebDist`). La brique manquante était la **forme boîte** — c'est elle qui est livrée ici.
- L4 est absorbé par L2 (rappel du scoping) : l'unique maillon restant est L3 = `h_central → hcap`, dont l'arithmétique de fenêtres consommera cette brique.

## Validation (§B)

1. **Sorry count** — instrument canonique `count_code_sorry.py --json`, champ `distinct_code_sorry` : conway_lean **1 avant → 1 après** (le sorry du fragment, inchangé ; la brique livrée est sorry-free). Naive grep = 180 (prose des docstrings — sur-compte documenté).
2. **Lake build** : build local **froid** au worktree (Batteries depuis zéro — des heures) et service WSL tombé ce cycle (Wsl/Service/0x8007274c) : validation **portée par la CI hosted 32G** de cette PR (précédent tranche 2, #14661 MERGED avec ce mode). Deux identifiants Lean core (`Int.abs_eq_natAbs`, `Int.abs_le`) non vérifiables localement ce cycle : si `lean-axiom` rougit, la lane répare en P0 au tick suivant.
3. **Proof integrity** : job CI `lean-axiom` (`fail_on_sorry`, axiomes forbidden `native_decide.*`/`sorryAx`/`Classical.choice`) — aucun `sorry` ajouté, aucune tactique `native_decide`.
4. Refactor prover Python : **N/A** (aucun script touché).

## Périmètre

2 fichiers (les jumeaux i18n), +63 lignes, un seul sujet. Pas de catalogue touché.

See #13483 (tranche 3, brique a) · See #14058 (rien — hors registre EPITA). Jamais une restauration SK.
