### PR TITLE
feat(ci,#14696): cabler la paire AgentSafetyAnalyzer en CI dediee (floor 26) + entrees .sln

### DIFF
--- a/.github/workflows/dotnet-AgentSafetyAnalyzer.yml
+++ b/.github/workflows/dotnet-AgentSafetyAnalyzer.yml
@@ -1,0 +1,115 @@
+name: dotnet-AgentSafetyAnalyzer
+
+# Tranche 2 de #14696 (orphelins .sln) : la paire Vibe-Coding/analyzers —
+# CoursIA.AgentSafetyAnalyzer (netstandard2.0, analyzer Roslyn) + son projet
+# de tests xunit (net8.0) — exclue du glob parent par #14695, absente de
+# MyIA.CoursIA.sln, donc sans CI avant cette PR.
+#
+# Bornes mesurees firsthand (worktree origin/main c04ec58df, 2026-09-05,
+# DOTNET_ROLL_FORWARD=Major faute de runtime 8 local — le comptage
+# --list-tests est independant du runtime d'execution) :
+#   - dotnet test AgentSafetyAnalyzer.Tests = 26 tests, 0 echec
+#   - Dependances : xunit + Microsoft.CodeAnalysis + ProjectReference vers
+#     l'analyzer — zero service externe, zero secret, runner ephemere OK.
+#
+# Deux jobs STATIQUES (pas de matrix runs-on dynamique — garde #13363,
+# meme forme que dotnet-ArgumentAnalysis.yml / dotnet-Shared.Tests.yml).
+# setup-dotnet 8.0.x : les tests ciblent net8.0 (distinct du trio
+# Argument_Analysis en 9.0.x).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/**'
+      - '.github/workflows/dotnet-AgentSafetyAnalyzer.yml'
+      - 'MyIA.CoursIA.sln'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/**'
+      - '.github/workflows/dotnet-AgentSafetyAnalyzer.yml'
+      - 'MyIA.CoursIA.sln'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dotnet-agentsafetyanalyzer-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  ASA_TESTS: MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/AgentSafetyAnalyzer.Tests/AgentSafetyAnalyzer.Tests.csproj
+
+jobs:
+  dotnet-agentsafetyanalyzer-linux:
+    name: AgentSafetyAnalyzer dotnet (ubuntu-latest, floor 26)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run the test project
+        run: dotnet test "$ASA_TESTS" --nologo
+
+      # Floor-guard de collecte (semantique dotnet-Shared.Tests.yml : un run
+      # vert alors que la collecte a silencieusement perdu des tests doit
+      # rougir). Pattern d'extraction locale-proof `^    [A-Za-z_]` (sans
+      # ancre d'en-tete localise), liste vide = panne de collecte = exit 1.
+      - name: Collection floor-guard (26)
+        if: always()
+        shell: bash
+        env:
+          DOTNET_CLI_UI_LANGUAGE: en
+        run: |
+          NAME=$(basename "$ASA_TESTS" .csproj)
+          LISTED=$(dotnet test "$ASA_TESTS" --list-tests --nologo 2>/dev/null | grep -cE '^    [A-Za-z_]')
+          if [ -z "$LISTED" ] || [ "$LISTED" -eq 0 ]; then
+            echo "::error::$NAME : --list-tests n'a renvoye aucun test — panne de collecte (a distinguer d'une baisse de couverture)."
+            exit 1
+          fi
+          if [ "$LISTED" -lt 26 ]; then
+            echo "::error::$NAME : regression de couverture — $LISTED tests listes, plancher=26. Si la baisse est intentionnelle, ajuster le plancher dans cette PR."
+            exit 1
+          fi
+          echo "OK : $NAME — $LISTED tests listes (plancher=26)."
+
+  dotnet-agentsafetyanalyzer-windows:
+    name: AgentSafetyAnalyzer dotnet (windows-latest, floor 26)
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run the test project
+        shell: bash
+        run: dotnet test "$ASA_TESTS" --nologo
+
+      - name: Collection floor-guard (26)
+        if: always()
+        shell: bash
+        env:
+          DOTNET_CLI_UI_LANGUAGE: en
+        run: |
+          NAME=$(basename "$ASA_TESTS" .csproj)
+          LISTED=$(dotnet test "$ASA_TESTS" --list-tests --nologo 2>/dev/null | grep -cE '^    [A-Za-z_]')
+          if [ -z "$LISTED" ] || [ "$LISTED" -eq 0 ]; then
+            echo "::error::$NAME : --list-tests n'a renvoye aucun test — panne de collecte (a distinguer d'une baisse de couverture)."
+            exit 1
+          fi
+          if [ "$LISTED" -lt 26 ]; then
+            echo "::error::$NAME : regression de couverture — $LISTED tests listes, plancher=26. Si la baisse est intentionnelle, ajuster le plancher dans cette PR."
+            exit 1
+          fi
+          echo "OK : $NAME — $LISTED tests listes (plancher=26)."

--- a/MyIA.CoursIA.sln
+++ b/MyIA.CoursIA.sln
@@ -28,6 +28,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.DatasetUpdater.Prom
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.DatasetUpdater.Prompts.Tests", "MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\CoursIA-DatasetUpdater-Prompts\src\CoursIA.DatasetUpdater.Prompts.Tests\CoursIA.DatasetUpdater.Prompts.Tests.csproj", "{26D274FA-3CB0-48EB-9561-DCA41FA405AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.AgentSafetyAnalyzer", "MyIA.AI.Notebooks\GenAI\Vibe-Coding\analyzers\AgentSafetyAnalyzer\AgentSafetyAnalyzer.csproj", "{BF3B5EC4-0E62-4928-AD3B-DEC9C4D7566F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.AgentSafetyAnalyzer.Tests", "MyIA.AI.Notebooks\GenAI\Vibe-Coding\analyzers\AgentSafetyAnalyzer.Tests\AgentSafetyAnalyzer.Tests.csproj", "{42AA7A16-ADB1-4330-9FDC-DCC90D2B4066}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +86,14 @@ Global
 {26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {26D274FA-3CB0-48EB-9561-DCA41FA405AA}.Release|Any CPU.Build.0 = Release|Any CPU
+{BF3B5EC4-0E62-4928-AD3B-DEC9C4D7566F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{BF3B5EC4-0E62-4928-AD3B-DEC9C4D7566F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{BF3B5EC4-0E62-4928-AD3B-DEC9C4D7566F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{BF3B5EC4-0E62-4928-AD3B-DEC9C4D7566F}.Release|Any CPU.Build.0 = Release|Any CPU
+{42AA7A16-ADB1-4330-9FDC-DCC90D2B4066}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{42AA7A16-ADB1-4330-9FDC-DCC90D2B4066}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{42AA7A16-ADB1-4330-9FDC-DCC90D2B4066}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{42AA7A16-ADB1-4330-9FDC-DCC90D2B4066}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14692

## Tranche 2 de #14696 : la paire Vibe-Coding/analyzers cablee en CI

CoursIA.AgentSafetyAnalyzer (analyzer Roslyn, netstandard2.0) + CoursIA.AgentSafetyAnalyzer.Tests (xunit, net8.0) — exclus du glob parent par #14695, absents de MyIA.CoursIA.sln, donc sans CI avant cette PR.

### Ce qui est fait

- **Entrees .sln minimales** : 2 Project + 8 lignes de configuration (+12 lignes, 0 deletion, format d'octets original preserve). Meme ancre d'insertion que #14698 : si #14698 merge en premier, un rebase trivial en union suffit (les deux ajouts sont disjoints).
- **Workflow dedie** `.github/workflows/dotnet-AgentSafetyAnalyzer.yml` : deux jobs STATIQUES ubuntu-latest + windows-latest (garde #13363), **setup-dotnet 8.0.x** — les tests ciblent net8.0, distinct du trio Argument_Analysis en 9.0.x — floor-guard de collecte a 26.

### Mesures (worktree origin/main c04ec58df, firsthand)

- `dotnet test` : **26 tests, 0 echec** (runtime 8 absent localement, execution via DOTNET_ROLL_FORWARD=Major ; le comptage --list-tests est independant du runtime, dry-run du pattern exact du floor-guard = 26).
- Garde isolation self-hosted : OK (workflows=139), 57/57 pytest verts.
- `dotnet sln list` : 8 projets resolus (6 + la paire).

### Validation

- 2 fichiers modifies : `MyIA.CoursIA.sln`, `.github/workflows/dotnet-AgentSafetyAnalyzer.yml` — enumeration verifiee.
- Unite suivantes de #14696 (tranches 3+) : cluster Aspire Integrations-DotNet (AgentGuard x3 + IntegrationTests + StreamingAgent.App — Aspire hosting, design distinct), CopilotAgent.App, LiveOrderApp (csharprepl demo), InferNetVoi, Tweety (19 shade builds, dependances Java a qualifier), 5 file-based apphost.cs (services live, hors scope CI).

See #14696 (tranche 2 — paires standard d'abord, clusters a design au cycle suivant)
