### PR TITLE
feat(adk,#14686): C5 handoff câblé et observable — sub_agents natif ADK + Lab15 réel

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab15-Agent-Handoff.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab15-Agent-Handoff.ipynb
@@ -1,0 +1,706 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4b320a3e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003852,
+     "end_time": "2026-09-05T03:36:41.868048+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:41.864196+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Lab 15 : Handoff entre agents — le contrat C5, le transfert natif câblé et observable\n",
+    "\n",
+    "Le cinquième contrat EPITA du registre (#14058) : **un agent peut transférer la main à un autre agent, et le transfert est observable**. La mesure initiale de la tranche 3 disait : ADK 2.8 porte le transfert natif (`TransferToAgentTool`), mais rien ne l'exerçait — aucun agent du dépôt ne déclarait de hiérarchie. Ce lab travaille sur le câblage livré par #14686 : `build_agent` accepte `sub_agents`, et chaque tour rend **qui a parlé** (`agent_hands`) et **quels transferts ont eu lieu** (`handoffs`).\n",
+    "\n",
+    "LLM réel (OpenRouter) : les décisions de transfert ci-dessous sont prises par le modèle, jamais scriptées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "239d7848",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002746,
+     "end_time": "2026-09-05T03:36:41.876407+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:41.873661+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cb82e36f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:41.883909Z",
+     "iopub.status.busy": "2026-09-05T03:36:41.883632Z",
+     "iopub.status.idle": "2026-09-05T03:36:42.118864Z",
+     "shell.execute_reply": "2026-09-05T03:36:42.117899Z"
+    },
+    "papermill": {
+     "duration": 0.240422,
+     "end_time": "2026-09-05T03:36:42.119680+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:41.879258+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Provider actif : openrouter\n",
+      "Modele : openrouter/openai/gpt-4.1\n",
+      "Endpoint externe : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=(\n",
+    "        r\"\\[EXPERIMENTAL\\] feature \"\n",
+    "        r\"FeatureName\\.JSON_SCHEMA_FOR_FUNC_DECL is enabled\\.\"\n",
+    "    ),\n",
+    "    category=UserWarning,\n",
+    "    module=r\"google\\.adk\\.models\\.llm_request\",\n",
+    ")\n",
+    "\n",
+    "from config.providers import get_settings, get_provider_config, get_litellm_model\n",
+    "\n",
+    "settings = get_settings()\n",
+    "provider = get_provider_config(settings)\n",
+    "print(f\"Provider actif : {provider.provider.value}\")\n",
+    "print(f\"Modele : {get_litellm_model(provider)}\")\n",
+    "print(f\"Endpoint externe : {bool(provider.base_url)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0572b2e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002732,
+     "end_time": "2026-09-05T03:36:42.125345+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:42.122613+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. L'arbre d'agents : un codeur assisté par un vérificateur\n",
+    "\n",
+    "La hiérarchie se **déclare** : `build_agent(..., sub_agents=(...))`. Dès qu'un agent porte des sous-agents, ADK injecte nativement l'outil `transfer_to_agent` (avec une contrainte d'enum sur les noms valides — le modèle ne peut pas inventer une cible). Rien n'est à écrire côté outillage : câbler la hiérarchie suffit à rendre le handoff *exerçable*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "20e064a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:42.132505Z",
+     "iopub.status.busy": "2026-09-05T03:36:42.132095Z",
+     "iopub.status.idle": "2026-09-05T03:36:47.905270Z",
+     "shell.execute_reply": "2026-09-05T03:36:47.904242Z"
+    },
+    "papermill": {
+     "duration": 5.778178,
+     "end_time": "2026-09-05T03:36:47.906173+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:42.127995+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Racine de l'arbre : coder\n",
+      "Sous-agents declares : ['verificateur']\n",
+      "L'outil natif transfer_to_agent est injecte par ADK des que la hierarchie existe.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from utils.adk_runtime import build_agent\n",
+    "\n",
+    "verificateur = build_agent(\n",
+    "    name=\"verificateur\",\n",
+    "    description=\"Verificateur de l'atelier : relit du code Python et rend un verdict.\",\n",
+    "    instruction=(\n",
+    "        \"Tu es le verificateur de l'atelier. On te transfere du code Python \"\n",
+    "        \"a relire. Reponds en trois lignes : VERDICT (OK ou ECART), la regle \"\n",
+    "        \"de code verifiee, puis une suggestion d'amelioration concrete.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "coder = build_agent(\n",
+    "    name=\"coder\",\n",
+    "    description=\"Codeur Python de l'atelier, assiste par un verificateur.\",\n",
+    "    instruction=(\n",
+    "        \"Tu es le codeur de l'atelier. Quand on te demande d'ecrire du code, \"\n",
+    "        \"produis une fonction Python courte et commentee. DES QUE la demande \"\n",
+    "        \"mentionne une verification, un controle ou le verificateur, tu \"\n",
+    "        \"dois OBLIGATOIREMENT transferer la main au verificateur avec l'outil \"\n",
+    "        \"transfer_to_agent, puis laisser la reponse finale au verificateur.\"\n",
+    "    ),\n",
+    "    sub_agents=(verificateur,),\n",
+    ")\n",
+    "\n",
+    "print(f\"Racine de l'arbre : {coder.name}\")\n",
+    "print(f\"Sous-agents declares : {[s.name for s in coder.sub_agents]}\")\n",
+    "print(\"L'outil natif transfer_to_agent est injecte par ADK des que la \"\n",
+    "      \"hierarchie existe.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98d9afea",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003197,
+     "end_time": "2026-09-05T03:36:47.912732+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:47.909535+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "La racine `coder` déclare exactement un sous-agent, `verificateur`. L'arbre est de vrais `Agent` ADK — jamais une restauration du moteur SK (#14058) : la décision actée reste ADK comme runtime."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9fb1c9e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004001,
+     "end_time": "2026-09-05T03:36:47.920220+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:47.916219+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le handoff en action : la main passe au vérificateur\n",
+    "\n",
+    "Un seul tour de conversation : la demande couvre deux rôles (écrire, puis faire vérifier). Observez `tool_calls` — le transfert y apparaît comme un appel d'outil — puis `agent_hands`, la trace mécanique de qui a tenu la main."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "361c4731",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:47.930550Z",
+     "iopub.status.busy": "2026-09-05T03:36:47.929954Z",
+     "iopub.status.idle": "2026-09-05T03:36:52.437185Z",
+     "shell.execute_reply": "2026-09-05T03:36:52.436114Z"
+    },
+    "papermill": {
+     "duration": 4.514929,
+     "end_time": "2026-09-05T03:36:52.438083+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:47.923154+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "App \"track2_google_adk\" can transfer between agents but has no context_cache_config. Every transfer swaps the system instruction and the tool set, so the request prefix changes and the whole prompt is re-sent uncached after each transfer. Set context_cache_config on the app to give each agent its own cache.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\google\\adk\\tools\\transfer_to_agent_tool.py:72: UserWarning: [EXPERIMENTAL] feature FeatureName.JSON_SCHEMA_FOR_FUNC_DECL is enabled.\n",
+      "  function_decl = super()._get_declaration()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Appels d'outils du tour : ('transfer_to_agent',)\n",
+      "Mains du tour (ordre de passage) : ('coder', 'verificateur')\n",
+      "Handoffs observes : (('coder', 'verificateur'),)\n",
+      "Agent final : verificateur\n"
+     ]
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "from utils.adk_conversation import ConversationRunner\n",
+    "\n",
+    "async def demonstration_handoff():\n",
+    "    async with ConversationRunner(coder) as conversation:\n",
+    "        return await conversation.turn(\n",
+    "            \"Ecris une fonction mediane(liste) qui rend la mediane d'une \"\n",
+    "            \"liste de nombres, puis fais verifier ton code par le \"\n",
+    "            \"verificateur.\",\n",
+    "            timeout_seconds=180,\n",
+    "        )\n",
+    "\n",
+    "resultat = await demonstration_handoff()\n",
+    "print(f\"Appels d'outils du tour : {resultat.tool_calls}\")\n",
+    "print(f\"Mains du tour (ordre de passage) : {resultat.agent_hands}\")\n",
+    "print(f\"Handoffs observes : {resultat.handoffs}\")\n",
+    "print(f\"Agent final : {resultat.final_agent}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ae24fe5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003721,
+     "end_time": "2026-09-05T03:36:52.446952+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:52.443231+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le couple clé : `tool_calls` contient `transfer_to_agent`, et `agent_hands` montre la main passant de `coder` à `verificateur`. C'est le **LLM** qui a décidé du transfert, au milieu du tour — le handoff n'est ni ordonnancé ni simulé par l'appelant. La réponse finale vient du vérificateur (`final_agent`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22433fa6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003853,
+     "end_time": "2026-09-05T03:36:52.454278+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:52.450425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Handoff C5 vs désignation C4 : deux contrats distincts\n",
+    "\n",
+    "Le registre distingue deux mécaniques souvent confondues :\n",
+    "\n",
+    "- **C5 — handoff** (ce lab) : décision **de l'agent**, *en cours de tour*. Le LLM choisit de transférer ; l'observateur ne fait que constater.\n",
+    "- **C4 — désignation** (grain ouvert #14685) : stratégie **explicite de l'orchestrateur**, décidée *avant* le tour — qui parle ensuite est une règle, pas un choix du modèle.\n",
+    "\n",
+    "La cellule suivante rejoue « coder puis vérifier » en mode C4 : l'ordre vit dans **notre** code Python, le runtime n'a rien choisi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4deb3816",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:52.463672Z",
+     "iopub.status.busy": "2026-09-05T03:36:52.462992Z",
+     "iopub.status.idle": "2026-09-05T03:36:54.742672Z",
+     "shell.execute_reply": "2026-09-05T03:36:54.741623Z"
+    },
+    "papermill": {
+     "duration": 2.285852,
+     "end_time": "2026-09-05T03:36:54.743515+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:52.457663+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "etape 1 (code, decidee par l'appelant) -> mains : ('coder',)\n",
+      "etape 2 (verif, decidee par l'appelant) -> mains : ('verificateur_autonome',)\n",
+      "Cote C4, la sequence est dans NOTRE liste Python ; cote C5, elle etait apparue DANS un seul tour, decidee par le LLM.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from utils.adk_runtime import build_agent\n",
+    "\n",
+    "verificateur_autonome = build_agent(\n",
+    "    name=\"verificateur_autonome\",\n",
+    "    description=\"Verificateur autonome, appele directement par l'appelant.\",\n",
+    "    instruction=(\n",
+    "        \"Tu es un verificateur autonome. On te soumet du code Python : \"\n",
+    "        \"reponds en une ligne par VERDICT (OK ou ECART) et la regle verifiee.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "async def designation_explicite():\n",
+    "    # Contrat C4 (designation) : l'ORDRE vit dans le code de l'appelant.\n",
+    "    # Le runtime ne choisit rien -- nous enchainons nous-memes deux\n",
+    "    # conversations mono-agent, dans un ordre ecrit ici, en Python.\n",
+    "    traces = []\n",
+    "    async with ConversationRunner(coder) as conversation:\n",
+    "        tour = await conversation.turn(\n",
+    "            \"Ecris une fonction est_pair(n). Ne demande aucune verification.\",\n",
+    "            timeout_seconds=180,\n",
+    "        )\n",
+    "        traces.append((\"etape 1 (code, decidee par l'appelant)\", tour.agent_hands))\n",
+    "    async with ConversationRunner(verificateur_autonome) as conversation:\n",
+    "        tour = await conversation.turn(\n",
+    "            \"Verifie cette fonction : def est_pair(n): return n % 2 == 0\",\n",
+    "            timeout_seconds=180,\n",
+    "        )\n",
+    "        traces.append((\"etape 2 (verif, decidee par l'appelant)\", tour.agent_hands))\n",
+    "    return traces\n",
+    "\n",
+    "for etiquette, mains in await designation_explicite():\n",
+    "    print(f\"{etiquette} -> mains : {mains}\")\n",
+    "print(\"Cote C4, la sequence est dans NOTRE liste Python ; cote C5, elle \"\n",
+    "      \"etait apparue DANS un seul tour, decidee par le LLM.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05373620",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003077,
+     "end_time": "2026-09-05T03:36:54.750072+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:54.746995+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Deux conversations mono-agent enchaînées par l'appelant : chaque tour reste mono-main, la séquence existe seulement dans la liste `traces` de notre code. Au §3, la même intention (« écris puis fais vérifier ») s'était réalisée **dans un seul tour**, par décision du modèle — c'est toute la différence entre les deux contrats."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4c681f4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002964,
+     "end_time": "2026-09-05T03:36:54.756128+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:54.753164+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le transfert, tour à tour\n",
+    "\n",
+    "Une même conversation, trois tours : coder seul, puis handoff demandé, puis retour au résumé. Chaque tour rend ses propres mains."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a9d36fc6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:54.763876Z",
+     "iopub.status.busy": "2026-09-05T03:36:54.763589Z",
+     "iopub.status.idle": "2026-09-05T03:36:58.873736Z",
+     "shell.execute_reply": "2026-09-05T03:36:58.872935Z"
+    },
+    "papermill": {
+     "duration": 4.115081,
+     "end_time": "2026-09-05T03:36:58.874313+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:54.759232+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tour 1 : mains = ('coder',) | handoffs = ()\n",
+      "tour 2 : mains = ('coder', 'verificateur') | handoffs = (('coder', 'verificateur'),)\n",
+      "tour 3 : mains = ('verificateur',) | handoffs = ()\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def mains_tour_par_tour():\n",
+    "    async with ConversationRunner(coder) as conversation:\n",
+    "        empreintes = []\n",
+    "        questions = (\n",
+    "            \"Ecris une fonction moyenne(liste). Ne verifie rien pour l'instant.\",\n",
+    "            \"Fais maintenant verifier moyenne par le verificateur.\",\n",
+    "            \"Merci. Resume en une ligne ce que l'atelier a produit.\",\n",
+    "        )\n",
+    "        for numero, question in enumerate(questions, start=1):\n",
+    "            tour = await conversation.turn(question, timeout_seconds=180)\n",
+    "            empreintes.append((numero, tour.agent_hands, tour.handoffs))\n",
+    "        return empreintes\n",
+    "\n",
+    "for numero, mains, handoffs in await mains_tour_par_tour():\n",
+    "    print(f\"tour {numero} : mains = {mains} | handoffs = {handoffs}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33ca4d98",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002504,
+     "end_time": "2026-09-05T03:36:58.879542+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.877038+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le tour 1 reste mono-main (`coder`), le tour 2 porte le handoff observable (`(('coder', 'verificateur'),)` dans `handoffs`). Le tour 3 révèle un comportement précieux : la conversation ne repart **pas** de la racine — la main est restée au vérificateur (`mains = ('verificateur',)`, aucun handoff). ADK mémorise l'agent courant au-delà du tour : le handoff est un transfert **durable** du point d'entrée, pas un écart d'un seul tour. L'historique persiste (contrat C1b) : le résumé du tour 3 s'appuie sur tout ce qui précède."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cccb811",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002584,
+     "end_time": "2026-09-05T03:36:58.885170+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.882586+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15b731d4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002537,
+     "end_time": "2026-09-05T03:36:58.890235+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.887698+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Détecteur de handoff manquant\n",
+    "\n",
+    "Écris une fonction `handoff_attendu(resultat)` qui rend `True` si un handoff est observable dans un `AdkRunResult`, `False` sinon. Puis sers-t'en pour vérifier que le tour 2 du §5 a bien transféré (et que le tour 1, non)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d9f6bda3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:58.896923Z",
+     "iopub.status.busy": "2026-09-05T03:36:58.896698Z",
+     "iopub.status.idle": "2026-09-05T03:36:58.900251Z",
+     "shell.execute_reply": "2026-09-05T03:36:58.899557Z"
+    },
+    "papermill": {
+     "duration": 0.008101,
+     "end_time": "2026-09-05T03:36:58.900928+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.892827+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : a completer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47d4b06a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002594,
+     "end_time": "2026-09-05T03:36:58.906257+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.903663+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Chaîne à trois agents\n",
+    "\n",
+    "Déclare un troisième agent `documenteur` en sous-agent du **vérificateur** (pas du coder), demande « écris, fais vérifier, puis fais documenter » et observe : combien de handoffs dans le tour ? La chaîne descend-elle jusqu'au documenteur ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6ecbfb00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:58.912140Z",
+     "iopub.status.busy": "2026-09-05T03:36:58.911954Z",
+     "iopub.status.idle": "2026-09-05T03:36:58.915175Z",
+     "shell.execute_reply": "2026-09-05T03:36:58.914467Z"
+    },
+    "papermill": {
+     "duration": 0.007265,
+     "end_time": "2026-09-05T03:36:58.916005+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.908740+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 : a completer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25e100ae",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002485,
+     "end_time": "2026-09-05T03:36:58.921118+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.918633+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Isolement des hiérarchies\n",
+    "\n",
+    "Construis **deux** `ConversationRunner` sur le même arbre. Déclenche un handoff dans le premier. Vérifie ensuite dans l'historique du second (`await conversation.history()`) que le transfert du premier n'y apparaît pas — la contre-garde C1 : les sessions s'isolent, hiérarchies ou pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e3d2c430",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:58.927727Z",
+     "iopub.status.busy": "2026-09-05T03:36:58.927302Z",
+     "iopub.status.idle": "2026-09-05T03:36:58.930574Z",
+     "shell.execute_reply": "2026-09-05T03:36:58.929815Z"
+    },
+    "papermill": {
+     "duration": 0.007723,
+     "end_time": "2026-09-05T03:36:58.931276+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.923553+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 : a completer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8383d45",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002595,
+     "end_time": "2026-09-05T03:36:58.936558+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:58.933963+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Conclusion\n",
+    "\n",
+    "- **C5 est câblé au-dessus d'ADK, pas réécrit** : `build_agent` transmet la hiérarchie, ADK injecte `transfer_to_agent`, le Runner exécute le transfert natif.\n",
+    "- **Le handoff est observable** : `agent_hands` (qui a parlé), `handoffs` (les passages de main), `final_agent` (qui conclut) — la preuve mécanique vit dans l'`AdkRunResult`, testée au retrait (critère 4 du registre).\n",
+    "- **C4 reste distinct et ouvert** (#14685) : la désignation est une stratégie d'orchestrateur, le handoff une décision d'agent — les deux contrats cohabiteront sans se recouvrir.\n",
+    "- Registre vivant : #14058 — jamais une restauration SK : ADK reste le runtime."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 20.013154,
+   "end_time": "2026-09-05T03:37:00.163186+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lab15-Agent-Handoff.ipynb",
+   "output_path": "Lab15-Agent-Handoff.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-05T03:36:40.150032+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_conversation.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_conversation.py
@@ -148,6 +148,7 @@ class ConversationRunner:
         tool_responses: list[str] = []
         usage_turns: list[AdkUsage] = []
         event_errors: list[str] = []
+        agent_hands: list[str] = []
         event_count = 0
         budget_cut = False
 
@@ -160,6 +161,9 @@ class ConversationRunner:
                 new_message=message,
             ):
                 event_count += 1
+                author = getattr(event, "author", None)
+                if author and (not agent_hands or agent_hands[-1] != author):
+                    agent_hands.append(author)
                 tool_calls.extend(
                     call.name for call in event.get_function_calls() if call.name
                 )
@@ -232,6 +236,7 @@ class ConversationRunner:
             tool_calls=tuple(tool_calls),
             tool_responses=tuple(tool_responses),
             usage_turns=tuple(usage_turns),
+            agent_hands=tuple(agent_hands),
         )
 
     async def history(self) -> list[types.Event]:

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py
@@ -65,11 +65,27 @@ class AdkRunResult:
     tool_calls: tuple[str, ...]
     tool_responses: tuple[str, ...]
     usage_turns: tuple[AdkUsage, ...] = ()
+    agent_hands: tuple[str, ...] = ()
 
     @property
     def tool_was_invoked(self) -> bool:
         """Whether ADK emitted both a tool request and its response."""
         return bool(self.tool_calls and self.tool_responses)
+
+    @property
+    def handoffs(self) -> tuple[tuple[str, str], ...]:
+        """Transferts de main observes au sein de l'invocation (contrat C5).
+
+        Chaque couple ``(depuis, vers)`` est un changement d'auteur entre deux
+        events consecutifs -- la trace mecanique d'un handoff natif
+        (``transfer_to_agent``), pas une decision de l'appelant.
+        """
+        return tuple(zip(self.agent_hands, self.agent_hands[1:]))
+
+    @property
+    def final_agent(self) -> str:
+        """Le dernier agent qui a parle (celui qui tient la main en fin de tour)."""
+        return self.agent_hands[-1] if self.agent_hands else ""
 
     @property
     def usage_total(self) -> AdkUsage:
@@ -120,9 +136,17 @@ def build_agent(
     instruction: str,
     *,
     tools: tuple = (),
+    sub_agents: tuple = (),
     config: ProviderConfig | None = None,
 ) -> Agent:
-    """Construct a real Google ADK agent for one pedagogical role."""
+    """Construct a real Google ADK agent for one pedagogical role.
+
+    ``sub_agents`` (contrat C5, #14058) declare une hierarchie : ADK injecte
+    alors nativement l'outil ``transfer_to_agent`` (ciblees par enum sur les
+    noms des sous-agents), et le transfert de main devient exercable par le
+    LLM lui-meme -- decision D'AGENT en cours de tour, distincte de la
+    designation C4 (strategie explicite de l'orchestrateur).
+    """
     provider = config or get_provider_config()
     return Agent(
         name=name,
@@ -130,6 +154,7 @@ def build_agent(
         instruction=instruction,
         model=build_adk_model(provider),
         tools=list(tools),
+        sub_agents=list(sub_agents),
     )
 
 
@@ -203,6 +228,7 @@ async def run_agent_turn(
     tool_responses: list[str] = []
     usage_turns: list[AdkUsage] = []
     event_errors: list[str] = []
+    agent_hands: list[str] = []
     event_count = 0
 
     async def consume_events() -> None:
@@ -213,6 +239,9 @@ async def run_agent_turn(
             new_message=message,
         ):
             event_count += 1
+            author = getattr(event, "author", None)
+            if author and (not agent_hands or agent_hands[-1] != author):
+                agent_hands.append(author)
             tool_calls.extend(
                 call.name for call in event.get_function_calls() if call.name
             )
@@ -265,6 +294,7 @@ async def run_agent_turn(
         tool_calls=tuple(tool_calls),
         tool_responses=tuple(tool_responses),
         usage_turns=tuple(usage_turns),
+        agent_hands=tuple(agent_hands),
     )
 
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py
@@ -407,24 +407,82 @@ def test_c4_designation_exists_in_adk_but_runtime_is_single_agent():
         "le grain qui porte le contrat")
 
 
-def test_c5_transfer_exists_in_adk_but_is_not_wired():
-    # C5 (handoff : transfert observable entre agents) -- MESURE : ADK 2.8
-    # porte le transfer natif (TransferToAgentTool, importe ici comme
-    # preuve), mais aucun agent du depot ne declare de sub_agents et
-    # build_agent ne les accepte pas : le transfer n'est pas exercable
-    # depuis le runtime du depot. Non porte -> grain ouvert.
+def test_c5_sub_agents_wire_handoff_and_it_is_observable():
+    # C5 (handoff : transfert observable entre agents) -- PORTE (#14686),
+    # inverse du test de non-portage. build_agent accepte desormais
+    # sub_agents : ADK 2.8 injecte alors nativement l'outil
+    # transfer_to_agent (enum sur les noms des sous-agents), et le VRAI
+    # Runner execute le transfert -- le LLM scripte decide du handoff,
+    # comme un LLM reel le deciderait en cours de tour.
+    #
+    # Complementarite C4/C5 (documentee par ce test) : la designation C4
+    # est une strategie EXPLICITE de l'orchestrateur -- QUI PARLE ENSUITE
+    # est decide AVANT le tour, hors LLM ; le handoff C5 est une decision
+    # DE L'AGENT en cours de tour -- c'est le LLM qui appelle
+    # transfer_to_agent au milieu de son tour. Les deux contrats restent
+    # distincts : ce test n'exerce QUE le transfert natif cable, aucune
+    # strategie d'ordonnancement n'est lue ici.
+    #
+    # Critere 4 -- au retrait du cablage (build_agent cesse de passer
+    # sub_agents a Agent), la hierarchie n'est plus declaree : l'outil
+    # transfer_to_agent n'est pas injecte, l'appel scripte devient une
+    # fonction inconnue, aucun transfert n'a lieu et agent_hands reste
+    # ("contract_root",) -> rouge (verifie par mutation locale, journal
+    # au body de la PR).
     from google.adk.tools import TransferToAgentTool  # noqa: F401 (preuve)
 
     import inspect
+    from config.providers import ProviderConfig, ProviderType
     from utils import adk_runtime
 
+    # Jamais une restauration SK : l'arbre est de vrais Agent ADK.
     build_params = inspect.signature(adk_runtime.build_agent).parameters
-    assert "sub_agents" not in build_params, (
-        "build_agent accepte desormais sub_agents : le transfer C5 est "
-        "cable, ce test documentait le non-portage, il doit etre inverse "
-        "par le grain qui porte le contrat")
-    turn_params = inspect.signature(adk_runtime.run_agent_turn).parameters
-    assert "agents" not in turn_params
+    assert "sub_agents" in build_params, (
+        "build_agent n'accepte plus sub_agents : le cablage C5 est retire")
+
+    verifier = _scripted_agent(name="verifier_agent", tools=())
+    offline_config = ProviderConfig(
+        provider=ProviderType.LMSTUDIO, model="m", base_url="http://localhost:1")
+    root_via_build_agent = adk_runtime.build_agent(
+        name="contract_root",
+        description="porte-contrat de test",
+        instruction="scripte",
+        sub_agents=(verifier,),
+        config=offline_config,
+    )
+    assert [
+        sub.name for sub in root_via_build_agent.sub_agents
+    ] == ["verifier_agent"], (
+        "build_agent ne transmet plus la hierarchie sub_agents : le "
+        "cablage C5 est retire")
+
+    # Scenario comportemental sur le VRAI Runner : le LLM racine demande
+    # le transfert, le sous-agent herite de la main et repond. Instance
+    # fraiche : un Agent ADK parente ne peut pas etre re-parente.
+    behavioral_verifier = _scripted_agent(name="verifier_agent", tools=())
+    root = Agent(
+        name="contract_root",
+        description="porte-contrat de test",
+        instruction="scripte",
+        model=ScriptedLlm(model="scripted"),
+        sub_agents=[behavioral_verifier],
+    )
+    _SCRIPT.append(("call", ("transfer_to_agent", {"agent_name": "verifier_agent"})))
+    _SCRIPT.append(("text", "verifie : le code est correct"))
+    result = _run_turn(root, "verifie ce code", app_name="contracts-c5")
+
+    assert "transfer_to_agent" in result.tool_calls, (
+        f"le handoff natif n'a pas ete appele, tool_calls : "
+        f"{result.tool_calls}")
+    assert result.agent_hands == ("contract_root", "verifier_agent"), (
+        f"la main doit passer au sous-agent, mesure : {result.agent_hands}")
+    assert result.handoffs == (("contract_root", "verifier_agent"),), (
+        f"le handoff doit etre un couple observable, mesure : "
+        f"{result.handoffs}")
+    assert result.final_agent == "verifier_agent"
+    assert "verifie" in result.response_text.lower(), (
+        f"la reponse finale doit venir du sous-agent, mesure : "
+        f"{result.response_text!r}")
 
 
 def test_c6_no_native_token_budget_but_usage_is_observable():


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/lean #14701

## Summary

C5 (#14686) : le handoff inter-agents passe de « natif mais non câblé » à « câblé et observable », au-dessus d'ADK — jamais une restauration SK (#14058, décision actée).

- `build_agent(..., sub_agents=(...))` transmet la hiérarchie : ADK 2.8 injecte alors nativement `transfer_to_agent` (enum sur les noms des sous-agents — le LLM ne peut pas inventer une cible), et le VRAI Runner exécute le transfert.
- `AdkRunResult` rend la main observable : `agent_hands` (qui a parlé, ordre de passage), `handoffs` (les passages de main en couples `(depuis, vers)`), `final_agent` (qui conclut le tour). Relevé dans `run_agent_turn` ET `ConversationRunner.turn`.
- Test de non-portage C5 **inversé** : `test_c5_sub_agents_wire_handoff_and_it_is_observable` — seul le LLM est scripté, le Runner ADK 2.8 tourne ; le LLM racine demande le transfert (`transfer_to_agent`), le sous-agent hérite de la main et produit la réponse finale.
- Complémentarité C4/C5 **documentée dans le test** : désignation = stratégie EXPLICITE de l'orchestrateur, décidée AVANT le tour ; handoff = décision DE L'AGENT en cours de tour. Les deux contrats restent distincts (C4 ouvert : #14685).
- Lab15-Agent-Handoff.ipynb (Day5-DS-Star, 23 cellules, LLM réel OpenRouter) : arbre coder→vérificateur, handoff en action, contraste C4 (l'ordre vit chez l'appelant) vs C5 (le modèle décide), mains tour à tour, 3 exercices stubés conformes C.1.

## Validation

- `python -m pytest` (Track2-GoogleADK complet) : **81 passed** (remplacement 1:1 du test de non-portage par le test inversé).
- **Critère 4 vérifié par mutation locale** : `build_agent` cesse de passer `sub_agents` à `Agent` → hiérarchie non déclarée → outil non injecté → l'appel scripté `transfer_to_agent` devient une fonction inconnue → aucun transfert → `agent_hands == ("contract_root",)` → test ROUGE. Rétabli → vert. (Mutation appliquée puis revertée dans le worktree ce cycle.)
- Papermill end-to-end (kernel python3, `--cwd .`, OpenRouter réel) : EXEC_PROVED — trace réelle ci-dessous.
- C.1 : `grep -cE "raise NotImplementedError|assert False|1/0"` = **0** (stubs `# Exercice N : à compléter`).
- C.2 : les 8 cellules code committées avec `execution_count` + outputs réels (re-exec papermill complète).
- B.3 / sorry avant-après : non applicable (aucun fichier `.lean`).

## Trace C5 réelle du lab (OpenRouter)

Cellule handoff (§3), sortie exacte :

```
Appels d'outils du tour : ('transfer_to_agent',)
Mains du tour (ordre de passage) : ('coder', 'verificateur')
Handoffs observes : (('coder', 'verificateur'),)
Agent final : verificateur
```

Conversation trois tours (§5) — la main **persiste** au-delà du handoff (mesure réelle, prose du lab alignée dessus) :

```
tour 1 : mains = ('coder',) | handoffs = ()
tour 2 : mains = ('coder', 'verificateur') | handoffs = (('coder', 'verificateur'),)
tour 3 : mains = ('verificateur',) | handoffs = ()
```

Le tour 3 ne repart pas de la racine : ADK mémorise l'agent courant entre tours — comportement découvert par l'exécution réelle et documenté tel quel dans le lab (§5, Lecture du résultat).

See #14686 (les 5 critères d'acceptance couverts par cette PR)
See #14058 (registre vivant — ligne C5 cochée au merge)
See #13572 (expérience history de la mesure initiale)
