### PR TITLE
feat(ci,#14696): cabler les 8 apps orphelines .NET en CI build-only (Aspire cluster, Copilot, LiveOrderApp, InferNetVoi) + entrees .sln

### DIFF
--- a/.github/workflows/dotnet-OrphanApps.yml
+++ b/.github/workflows/dotnet-OrphanApps.yml
@@ -1,0 +1,104 @@
+name: dotnet-OrphanApps
+
+# Tranche 3 de #14696 (orphelins .sln) : les 8 apps .NET sans projet de
+# tests, exclues du glob parent par #14695 — cluster Aspire Integrations-DotNet
+# (AgentGuard x3, IntegrationTests, StreamingAgent.App), CopilotAgent.App,
+# LiveOrderApp (csharprepl demo), InferNetVoi (Probas).
+#
+# Aucune ne porte de projet xunit : le garde est BUILD-ONLY (dotnet build par
+# csproj, echec au premier code d'erreur) — pas de floor-guard de collecte
+# (il n'y a rien a collecter).
+#
+# TFM melange : netstandard2.0 (AgentGuard.Analyzers), net9.0 (CopilotAgent,
+# InferNetVoi), net10.0 (AgentGuard.Demo/Verifier, IntegrationTests,
+# StreamingAgent.App, LiveOrderApp) — setup-dotnet multi-versions.
+#
+# Hors scope de cette tranche (documente sur #14696) : les 19 builds Tweety
+# shade (IKVM jar->dll, arbitrage #13831 debout) et les 5 file-based
+# apphost.cs (services live Aspire, non deterministes en runner ephemere).
+#
+# Deux jobs STATIQUES (garde #13363, meme forme que dotnet-ArgumentAnalysis.yml
+# et dotnet-AgentSafetyAnalyzer.yml).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GenAI/Integrations-DotNet/**'
+      - 'MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/**'
+      - 'MyIA.AI.Notebooks/Probas/DecisionTheory/voi/**'
+      - '.github/workflows/dotnet-OrphanApps.yml'
+      - 'MyIA.CoursIA.sln'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/GenAI/Integrations-DotNet/**'
+      - 'MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/**'
+      - 'MyIA.AI.Notebooks/Probas/DecisionTheory/voi/**'
+      - '.github/workflows/dotnet-OrphanApps.yml'
+      - 'MyIA.CoursIA.sln'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dotnet-orphanapps-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  ORPHAN_APPS: >-
+    MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/AgentGuard.Analyzers/AgentGuard.Analyzers.csproj
+    MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/AgentGuard.Demo/AgentGuard.Demo.csproj
+    MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/AgentGuard.Verifier/AgentGuard.Verifier.csproj
+    MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/IntegrationTests/IntegrationTests.csproj
+    MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/StreamingAgent.App/StreamingAgent.App.csproj
+    MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/CopilotAgent.App/CopilotAgent.App.csproj
+    MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/LiveOrderApp.csproj
+    MyIA.AI.Notebooks/Probas/DecisionTheory/voi/InferNetVoi/InferNetVoi.csproj
+
+jobs:
+  dotnet-orphanapps-linux:
+    name: OrphanApps build (ubuntu-latest, 8 csproj)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Build the eight orphan apps
+        run: |
+          for csproj in $ORPHAN_APPS; do
+            echo "--- $csproj"
+            dotnet build "$csproj" --nologo
+          done
+
+  dotnet-orphanapps-windows:
+    name: OrphanApps build (windows-latest, 8 csproj)
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Build the eight orphan apps
+        shell: bash
+        run: |
+          for csproj in $ORPHAN_APPS; do
+            echo "--- $csproj"
+            dotnet build "$csproj" --nologo
+          done

--- a/MyIA.CoursIA.sln
+++ b/MyIA.CoursIA.sln
@@ -32,6 +32,22 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.AgentSafetyAnalyzer
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoursIA.AgentSafetyAnalyzer.Tests", "MyIA.AI.Notebooks\GenAI\Vibe-Coding\analyzers\AgentSafetyAnalyzer.Tests\AgentSafetyAnalyzer.Tests.csproj", "{42AA7A16-ADB1-4330-9FDC-DCC90D2B4066}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentGuard.Analyzers", "MyIA.AI.Notebooks\GenAI\Integrations-DotNet\Aspire\AgentGuard.Analyzers\AgentGuard.Analyzers.csproj", "{6EE20460-D2F6-46E7-A049-B18D8944BDB1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentGuard.Demo", "MyIA.AI.Notebooks\GenAI\Integrations-DotNet\Aspire\AgentGuard.Demo\AgentGuard.Demo.csproj", "{C6225A3F-7301-4492-8CB3-8ECC4F872E19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentGuard.Verifier", "MyIA.AI.Notebooks\GenAI\Integrations-DotNet\Aspire\AgentGuard.Verifier\AgentGuard.Verifier.csproj", "{ACFE1B69-B694-4F12-9EA8-46F796DA3370}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.IntegrationTests", "MyIA.AI.Notebooks\GenAI\Integrations-DotNet\Aspire\IntegrationTests\IntegrationTests.csproj", "{71FEF29D-499D-45DB-B7E7-DCD413110340}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StreamingAgent.App", "MyIA.AI.Notebooks\GenAI\Integrations-DotNet\Aspire\StreamingAgent.App\StreamingAgent.App.csproj", "{97DE39E8-612F-4C88-9C49-EDC30AA99CE7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CopilotAgent.App", "MyIA.AI.Notebooks\GenAI\Integrations-DotNet\CopilotSDK\CopilotAgent.App\CopilotAgent.App.csproj", "{95977523-7989-4D04-AB79-F9A92D819403}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveOrderApp", "MyIA.AI.Notebooks\GenAI\Vibe-Coding\docs\csharprepl-demo\LiveOrderApp.csproj", "{69E49604-6C37-4B48-9739-B22CD0D9B33F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InferNetVoi", "MyIA.AI.Notebooks\Probas\DecisionTheory\voi\InferNetVoi\InferNetVoi.csproj", "{7021DC28-88F5-4E7D-8BF2-830B1F31CA85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +78,38 @@ Global
 {DF112603-A4EE-4651-B9DD-19E9BA338320}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {DF112603-A4EE-4651-B9DD-19E9BA338320}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {DF112603-A4EE-4651-B9DD-19E9BA338320}.Release|Any CPU.Build.0 = Release|Any CPU
+{6EE20460-D2F6-46E7-A049-B18D8944BDB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6EE20460-D2F6-46E7-A049-B18D8944BDB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6EE20460-D2F6-46E7-A049-B18D8944BDB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6EE20460-D2F6-46E7-A049-B18D8944BDB1}.Release|Any CPU.Build.0 = Release|Any CPU
+{C6225A3F-7301-4492-8CB3-8ECC4F872E19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{C6225A3F-7301-4492-8CB3-8ECC4F872E19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{C6225A3F-7301-4492-8CB3-8ECC4F872E19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{C6225A3F-7301-4492-8CB3-8ECC4F872E19}.Release|Any CPU.Build.0 = Release|Any CPU
+{ACFE1B69-B694-4F12-9EA8-46F796DA3370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{ACFE1B69-B694-4F12-9EA8-46F796DA3370}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{ACFE1B69-B694-4F12-9EA8-46F796DA3370}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{ACFE1B69-B694-4F12-9EA8-46F796DA3370}.Release|Any CPU.Build.0 = Release|Any CPU
+{71FEF29D-499D-45DB-B7E7-DCD413110340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{71FEF29D-499D-45DB-B7E7-DCD413110340}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{71FEF29D-499D-45DB-B7E7-DCD413110340}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{71FEF29D-499D-45DB-B7E7-DCD413110340}.Release|Any CPU.Build.0 = Release|Any CPU
+{97DE39E8-612F-4C88-9C49-EDC30AA99CE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{97DE39E8-612F-4C88-9C49-EDC30AA99CE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{97DE39E8-612F-4C88-9C49-EDC30AA99CE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{97DE39E8-612F-4C88-9C49-EDC30AA99CE7}.Release|Any CPU.Build.0 = Release|Any CPU
+{95977523-7989-4D04-AB79-F9A92D819403}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{95977523-7989-4D04-AB79-F9A92D819403}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{95977523-7989-4D04-AB79-F9A92D819403}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{95977523-7989-4D04-AB79-F9A92D819403}.Release|Any CPU.Build.0 = Release|Any CPU
+{69E49604-6C37-4B48-9739-B22CD0D9B33F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{69E49604-6C37-4B48-9739-B22CD0D9B33F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{69E49604-6C37-4B48-9739-B22CD0D9B33F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{69E49604-6C37-4B48-9739-B22CD0D9B33F}.Release|Any CPU.Build.0 = Release|Any CPU
+{7021DC28-88F5-4E7D-8BF2-830B1F31CA85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{7021DC28-88F5-4E7D-8BF2-830B1F31CA85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{7021DC28-88F5-4E7D-8BF2-830B1F31CA85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{7021DC28-88F5-4E7D-8BF2-830B1F31CA85}.Release|Any CPU.Build.0 = Release|Any CPU
 {2E4B17E5-B54D-4B33-8A91-302149728C83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {2E4B17E5-B54D-4B33-8A91-302149728C83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {2E4B17E5-B54D-4B33-8A91-302149728C83}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14702

## Tranche 3 de #14696 : les 8 apps orphelines .NET cablees en build-only

Les 8 csproj sans projet de tests, exclus du glob parent par #14695 et absents de MyIA.CoursIA.sln : cluster Aspire Integrations-DotNet (AgentGuard.Analyzers, AgentGuard.Demo, AgentGuard.Verifier, IntegrationTests, StreamingAgent.App), CopilotAgent.App, LiveOrderApp (csharprepl demo), InferNetVoi (Probas). Aucun ne porte de projet xunit ("IntegrationTests" est un Exe net10.0 de demo) : le garde est BUILD-ONLY — un floor-guard de collecte n'a rien a compter.

### Ce qui est fait

- **Entrees .sln minimales** : 8 Project + 32 lignes de configuration (+48 lignes, 0 deletion, format d'octets original, GUIDs entre accolades).
- **Workflow dedie** `.github/workflows/dotnet-OrphanApps.yml` : deux jobs STATIQUES ubuntu-latest + windows-latest (garde #13363), setup-dotnet multi-versions 8.0.x / 9.0.x / 10.0.x (TFM melange : netstandard2.0 + net9.0 x2 + net10.0 x5), `dotnet build` par csproj.

### Mesures (worktree origin/main 87a3dacf8, firsthand)

- Les 8 csproj compilent : 0 erreur chacun (SDK 10 local, `dotnet build -v q`, grep error = 0).
- Garde isolation self-hosted : OK, 57/57 pytest verts.
- `dotnet sln list` : 22 projets resolus.

### Hors scope documente sur #14696

- **Tweety (19 builds shade)** : csproj IKVM (jar tweety -> dll a la build) — builds lourds, et l'arbitrage #13831 (Tweety dotnet-build, REQUEST_CHANGES debout) doit trancher d'abord. A requalifier en tranche dediee apres arbitrage.
- **5 file-based apphost.cs** (GenAiStack x2-wt2, GenAiStackReel x2, SkOtel) : programmes `#:sdk` qui orchestrent des services live (Docker/vLLM) — non deterministes sur runner ephemere, hors scope CI.

### Validation

- 2 fichiers modifies : `MyIA.CoursIA.sln`, `.github/workflows/dotnet-OrphanApps.yml` — enumeration verifiee.

See #14696 (tranche 3 — le residuel est Tweety-post-arbitrage et apphost.cs hors scope)
