### PR TITLE
feat(lean,#13483): corridor dyadique -- relais de dilation entre checkpoints (tranche 3b)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -467,8 +467,10 @@ theorem evolve_support_dyadic_corridor (j t : Nat) (g : Grid) (a b : Int × Int)
     (h : ∀ p, isAlive (evolve (2 ^ j) g) p = true →
       a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
     (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
-    a.1 - (2 ^ j : Int) ≤ q.1 ∧ q.1 < b.1 + (2 ^ j : Int) ∧
-      a.2 - (2 ^ j : Int) ≤ q.2 ∧ q.2 < b.2 + (2 ^ j : Int) := by
+    a.1 - ((2 ^ j : Nat) : Int) ≤ q.1 ∧
+      q.1 < b.1 + ((2 ^ j : Nat) : Int) ∧
+      a.2 - ((2 ^ j : Nat) : Int) ≤ q.2 ∧
+      q.2 < b.2 + ((2 ^ j : Nat) : Int) := by
   obtain ⟨c1, c2, c3, c4⟩ :=
     evolve_support_dilation_from (2 ^ j) t g a b hlo h q h_alive
   -- omega ne fait pas l'exponentiation : la relation dyadique du segment

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -413,6 +413,70 @@ theorem evolve_support_dilation_box (t : Nat) (g : Grid) (a b : Int × Int)
   -- `abs_le` n'est pas dans le périmètre core du toolchain, c.14701 CI).
   exact ⟨by omega, by omega, by omega, by omega⟩
 
+/-! ## Corridor dyadique — brique (b) de l'assemblage P4.4 L3 (#13483, tranche 3)
+
+La brique vitesse de la lumière (forme boîte) dilate depuis `t = 0`. L'assemblage
+L3 consomme sa **composition le long des segments dyadiques** : couper la
+trajectoire à un instant `t₀` intermédiaire (`evolve_add`), appliquer la dilation
+au seul segment restant. Deux conséquences :
+
+- le **relais générique** `evolve_support_dilation_from` : le support à tout
+  `t ≥ t₀` tient dans la dilation `(t - t₀)` de la boîte du support à `t₀` ;
+- le **corridor dyadique** `evolve_support_dyadic_corridor` : sur le segment
+  `[2^j, 2^(j+1)]`, la dérive est bornée par la longueur du segment — tout
+  instant du segment est confiné dans la dilation `2^j` de la boîte du
+  checkpoint `2^j`.
+
+C'est la réduction des points de contrôle au réseau dyadique dans le **seul
+sens que les lemmes d'impossibilité laissent ouvert** : FORWARD depuis le
+checkpoint inférieur. La direction inverse (les extrémités contraindraient le
+milieu) est fermée structurellement — le GoL n'est pas réversible, le cône
+rétrograde ne contraint pas les états intermédiaires — et la route « la marge
+absorbe la dérive » est fermée par `no_padding_depth_suffices`
+(JumpCapture.lean §3). L'interface `(c)` (`centralCorrect`) consommera ce
+corridor en récurrence sur `j` pour fermer les checkpoints. Sans sorry.
+-/
+
+/-- **Relais de dilation depuis un instant intermédiaire.** Si le support à
+    l'instant `t₀` tient dans la boîte `[a, b)`, le support à tout instant
+    `t ≥ t₀` tient dans la dilation `(t - t₀)` de cette boîte : coupe de la
+    trajectoire en `t₀` (`evolve_add`), puis brique `evolve_support_dilation_box`
+    sur le seul segment restant, appliquée à la grille intermédiaire. -/
+theorem evolve_support_dilation_from (t₀ t : Nat) (g : Grid) (a b : Int × Int)
+    (hle : t₀ ≤ t)
+    (h : ∀ p, isAlive (evolve t₀ g) p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
+    a.1 - ((t - t₀ : Nat) : Int) ≤ q.1 ∧
+      q.1 < b.1 + ((t - t₀ : Nat) : Int) ∧
+      a.2 - ((t - t₀ : Nat) : Int) ≤ q.2 ∧
+      q.2 < b.2 + ((t - t₀ : Nat) : Int) := by
+  have hsplit : evolve t g = evolve (t - t₀) (evolve t₀ g) := by
+    rw [← evolve_add, Nat.sub_add_cancel hle]
+  rw [hsplit] at h_alive
+  exact evolve_support_dilation_box (t - t₀) (evolve t₀ g) a b h q h_alive
+
+/-- **Corridor dyadique (brique b, #13483 tranche 3).** Pour tout instant `t`
+    du segment `[2^j, 2^(j+1)]`, le support de `evolve t g` tient dans la
+    dilation `2^j` de la boîte du support au checkpoint `2^j` : la dérive sur
+    le segment est bornée par sa longueur `t - 2^j ≤ 2^j`. Réduction des
+    points de contrôle au réseau dyadique, sens forward uniquement (les sens
+    rétrograde et marge-absorbante sont fermés, voir la section ci-dessus). -/
+theorem evolve_support_dyadic_corridor (j t : Nat) (g : Grid) (a b : Int × Int)
+    (hlo : 2 ^ j ≤ t) (hhi : t ≤ 2 ^ (j + 1))
+    (h : ∀ p, isAlive (evolve (2 ^ j) g) p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
+    a.1 - (2 ^ j : Int) ≤ q.1 ∧ q.1 < b.1 + (2 ^ j : Int) ∧
+      a.2 - (2 ^ j : Int) ≤ q.2 ∧ q.2 < b.2 + (2 ^ j : Int) := by
+  obtain ⟨c1, c2, c3, c4⟩ :=
+    evolve_support_dilation_from (2 ^ j) t g a b hlo h q h_alive
+  -- omega ne fait pas l'exponentiation : la relation dyadique du segment
+  -- lui est fournie explicitement (`Nat.two_pow_succ`, core), puis
+  -- l'affaiblissement des bornes est linéaire (cast Nat→Int natif).
+  have hpow : 2 ^ (j + 1) = 2 ^ j + 2 ^ j := Nat.two_pow_succ j
+  exact ⟨by omega, by omega, by omega, by omega⟩
+
 /-! ## Localité étroite (forme boîte Chebyshev) — dual d'accord de `evolve_reach_chebyshev`
 
 Le théorème d'atteinte étroit (`evolve_reach_chebyshev` ci-dessus) dit : si `q`

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
@@ -320,8 +320,10 @@ theorem evolve_support_dyadic_corridor (j t : Nat) (g : Grid) (a b : Int × Int)
     (h : ∀ p, isAlive (evolve (2 ^ j) g) p = true →
       a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
     (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
-    a.1 - (2 ^ j : Int) ≤ q.1 ∧ q.1 < b.1 + (2 ^ j : Int) ∧
-      a.2 - (2 ^ j : Int) ≤ q.2 ∧ q.2 < b.2 + (2 ^ j : Int) := by
+    a.1 - ((2 ^ j : Nat) : Int) ≤ q.1 ∧
+      q.1 < b.1 + ((2 ^ j : Nat) : Int) ∧
+      a.2 - ((2 ^ j : Nat) : Int) ≤ q.2 ∧
+      q.2 < b.2 + ((2 ^ j : Nat) : Int) := by
   obtain ⟨c1, c2, c3, c4⟩ :=
     evolve_support_dilation_from (2 ^ j) t g a b hlo h q h_alive
   -- omega does not do exponentiation: the dyadic relation of the segment is

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
@@ -265,6 +265,71 @@ theorem evolve_support_dilation_box (t : Nat) (g : Grid) (a b : Int × Int)
   -- the toolchain core scope, c.14701 CI).
   exact ⟨by omega, by omega, by omega, by omega⟩
 
+/-! ## Dyadic corridor — brick (b) of the P4.4 L3 assembly (#13483, slice 3)
+
+The speed-of-light brick (box form) dilates from `t = 0`. The L3 assembly
+consumes its **composition along dyadic segments**: split the trajectory at an
+intermediate time `t0` (`evolve_add`), apply the dilation to the remaining
+segment only. Two consequences:
+
+- the **generic relay** `evolve_support_dilation_from`: the support at any
+  `t ≥ t0` lies in the `(t - t0)`-dilation of the box of the support at `t0`;
+- the **dyadic corridor** `evolve_support_dyadic_corridor`: on the segment
+  `[2^j, 2^(j+1)]`, the drift is bounded by the segment length — every time
+  on the segment is confined in the `2^j`-dilation of the box of the
+  checkpoint `2^j`.
+
+This is the reduction of the control points to the dyadic grid in the **only
+direction the impossibility lemmas leave open**: FORWARD from the lower
+checkpoint. The reverse direction (endpoints constraining the middle) is
+structurally closed — the GoL is not reversible, the retrograde cone does not
+constrain intermediate states — and the "margin absorbs the drift" route is
+closed by `no_padding_depth_suffices` (JumpCapture.lean §3). The `(c)`
+interface (`centralCorrect`) will consume this corridor by induction on `j`
+to close the checkpoints. Sorry-free.
+-/
+
+/-- **Dilation relay from an intermediate time.** If the support at time
+    `t0` lies in the box `[a, b)`, then the support at any time `t ≥ t0`
+    lies in the `(t - t0)`-dilation of that box: split the trajectory at
+    `t0` (`evolve_add`), then apply the `evolve_support_dilation_box` brick
+    to the remaining segment only, on the intermediate grid. -/
+theorem evolve_support_dilation_from (t₀ t : Nat) (g : Grid) (a b : Int × Int)
+    (hle : t₀ ≤ t)
+    (h : ∀ p, isAlive (evolve t₀ g) p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
+    a.1 - ((t - t₀ : Nat) : Int) ≤ q.1 ∧
+      q.1 < b.1 + ((t - t₀ : Nat) : Int) ∧
+      a.2 - ((t - t₀ : Nat) : Int) ≤ q.2 ∧
+      q.2 < b.2 + ((t - t₀ : Nat) : Int) := by
+  have hsplit : evolve t g = evolve (t - t₀) (evolve t₀ g) := by
+    rw [← evolve_add, Nat.sub_add_cancel hle]
+  rw [hsplit] at h_alive
+  exact evolve_support_dilation_box (t - t₀) (evolve t₀ g) a b h q h_alive
+
+/-- **Dyadic corridor (brick b, #13483 slice 3).** For any time `t` on the
+    segment `[2^j, 2^(j+1)]`, the support of `evolve t g` lies in the
+    `2^j`-dilation of the box of the support at the checkpoint `2^j`: the
+    drift over the segment is bounded by its length `t - 2^j ≤ 2^j`.
+    Reduction of the control points to the dyadic grid, forward direction
+    only (the retrograde and margin-absorbing directions are closed, see the
+    section above). -/
+theorem evolve_support_dyadic_corridor (j t : Nat) (g : Grid) (a b : Int × Int)
+    (hlo : 2 ^ j ≤ t) (hhi : t ≤ 2 ^ (j + 1))
+    (h : ∀ p, isAlive (evolve (2 ^ j) g) p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (q : Int × Int) (h_alive : isAlive (evolve t g) q = true) :
+    a.1 - (2 ^ j : Int) ≤ q.1 ∧ q.1 < b.1 + (2 ^ j : Int) ∧
+      a.2 - (2 ^ j : Int) ≤ q.2 ∧ q.2 < b.2 + (2 ^ j : Int) := by
+  obtain ⟨c1, c2, c3, c4⟩ :=
+    evolve_support_dilation_from (2 ^ j) t g a b hlo h q h_alive
+  -- omega does not do exponentiation: the dyadic relation of the segment is
+  -- provided explicitly (`Nat.two_pow_succ`, core), then weakening the
+  -- bounds is linear (Nat-to-Int cast native for omega).
+  have hpow : 2 ^ (j + 1) = 2 ^ j + 2 ^ j := Nat.two_pow_succ j
+  exact ⟨by omega, by omega, by omega, by omega⟩
+
 /-! ## Tight locality (Chebyshev-box form) — agreement dual of `evolve_reach_chebyshev`
 
 The tight reach theorem (`evolve_reach_chebyshev` above) says: if `q` is alive


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/lean #14701

## Summary

#13483 tranche 3, brique (b) : la **réduction des points de contrôle au réseau dyadique**, dans le seul sens que les lemmes d'impossibilité du lake laissent ouvert.

Après la brique (a) `evolve_support_dilation_box` (#14701, dilation depuis `t = 0`), cette PR livre la **composition le long des segments dyadiques** :

- **`evolve_support_dilation_from`** (relais générique) : si le support à l'instant `t₀` tient dans la boîte `[a, b)`, le support à tout `t ≥ t₀` tient dans la dilation `(t - t₀)` de cette boîte — coupe de trajectoire par `evolve_add`, puis la brique (a) appliquée au seul segment restant, sur la grille intermédiaire.
- **`evolve_support_dyadic_corridor`** (corridor dyadique, consommé par l'interface (c)) : pour tout `t ∈ [2^j, 2^(j+1)]`, le support de `evolve t g` tient dans la dilation `2^j` de la boîte du checkpoint `2^j` — la dérive sur le segment est bornée par sa longueur `t - 2^j ≤ 2^j`.

**Pourquoi « sens forward uniquement » est le verdict honnête** (documenté dans la section du module) : la direction inverse — les extrémités contraindraient le milieu — est fermée structurellement (le GoL n'est pas réversible, le cône rétrograde ne contraint pas les états intermédiaires, cf. docstring L3 de `HashlifeMarginFragment`), et la route « la marge absorbe la dérive » est fermée par `no_padding_depth_suffices` (JumpCapture.lean §3, prouvé). Le corridor forward est donc la forme maximale de la réduction dyadique. L'interface (c) (`centralCorrect`) consommera ce corridor en récurrence sur `j` pour fermer les checkpoints — maillon suivant de la tranche.

Jumeau `LightCone_en.lean` : docstrings EN, preuve byte-identical (convention i18n #4980).

## Validation

- **`lake build Conway.Life.LightCone Conway.Life.LightCone_en` : SUCCESS en local** (commit a4c45fdea7, PIPESTATUS 0, warnings préexistants seuls). Premier passage rouge attrapé par ce build : `(2 ^ j : Int)` force la puissance **dans Int** (`(↑2)^j`, atome déconnectée du nat `2^j` des hypothèses) — 4 × « omega could not prove the goal » sur les bornes du corridor. Fix : caster le nat explicitement `((2 ^ j : Nat) : Int)`, omega relie alors segment et checkpoints. Le relais n'était pas touché (il castait déjà `(t - t₀ : Nat)`).
- **APIs vérifiées par probe core local** (lean 4.33.1 Windows) : `Nat.two_pow_succ : 2^(n+1) = 2^n + 2^n` ✓, `Nat.sub_add_cancel (h : m ≤ n) : n - m + m = n` ✓ — les deux exemples compilent. Le relais ne compose que `evolve_add` (Foundation L2839, prouvé) et la brique (a) (#14701, prouvée) ; l'affaiblissement final est linéaire (`omega`, relation dyadique fournie explicitement).
- Sorry count : `python scripts/lean/count_code_sorry.py --json` depuis le worktree — `conway_lean : distinct_code_sorry = 1` AVANT/APRÈS inchangé (2 nouveaux théorèmes sorry-free ; naive 169→181 = prose seule, l'écart documenté du piège naive-vs-distinct).

See #13483 (tranche 3, brique (b) du plan c.5548562272)
See #14701 (brique (a), la dilation boîte)
