### PR TITLE
feat(mgs): rebenchmark corrective PSO and DE mechanisms

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-vs-mealpy/MGS-22-MGS-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-vs-mealpy/MGS-22-MGS-vs-Mealpy.ipynb
@@ -62,9 +62,9 @@
    "source": [
     "// === MGS-22 : socle commun — DLLs MGS, grille de référence, fonction de coût ===\n",
     "// Même socle que MGS-21 : la représentation R1 (continu + arrondi) est le substrat du bench.\n",
-    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"../../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"../../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"../../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
     "using System.Diagnostics;\n",
@@ -620,7 +620,7 @@
     "\n",
     "Le plan est maintenant entièrement câblé : même grille, même coût (prouvé sur données), même représentation. Reste à exécuter le plan de la section 1 — population 50, 160 générations/epochs, graines {0, 1, 7, 42} — et à rapporter **les quatre colonnes** : conflits finaux, évaluations réellement consommées, temps, et le ratio ms/éval. Les courses mealpy tournent en une seule entrée dans le scope Python (la boucle vit côté Python, les résultats reviennent en JSON) ; les courses MGS tournent côté C#. Médianes et min-max se calculent sur les 4 graines de chaque moteur.\n",
     "\n",
-    "**Amendement de protocole, motivé par le run pilote.** La première exécution complète a montré le défaut du timing single-run : les temps MGS varient de ±30 % d'une exécution à l'autre (paliers de garbage collection .NET — un run a mesuré 1 132 ms là où un autre donne 660 ms pour la même course seedée), soit *plus que l'écart entre moteurs*. Un protocole vitesse qui bouge plus que la grandeur mesurée ne mesure rien. Amendement, appliqué symétriquement : **3 répétitions par graine et par moteur, la colonne ms rapporte la médiane** des 3 ; les conflits seedés doivent être identiques sur les 3 répétitions (et le notebook l'affiche — preuve de déterminisme en direct, 12 courses par moteur). La fitness isolée (section 3) suit la même règle à 5 répétitions. La qualité, elle, ne bouge pas : elle est seedée, le pilote l'a montré chiffre par chiffre.\n",
+    "**Amendement de protocole, motivé par le run pilote.** La première exécution complète a montré le défaut du timing single-run : les temps MGS varient de ±30 % d'une exécution à l'autre (paliers de garbage collection .NET — un run a mesuré 1 132 ms là où un autre donne 660 ms pour la même course seedée), soit *plus que l'écart entre moteurs*. Un protocole vitesse qui bouge plus que la grandeur mesurée ne mesure rien. Amendement, appliqué symétriquement : **3 répétitions par graine et par moteur, la colonne ms rapporte la médiane** des 3 ; les conflits seedés doivent être identiques sur les 3 répétitions (et le notebook l'affiche — preuve de déterminisme en direct, 12 courses par moteur). La fitness isolée (ci-dessous) suit la même règle à 5 répétitions. La qualité, elle, ne bouge pas : elle est seedée, le pilote l'a montré chiffre par chiffre.\n",
     "\n",
     "Rappel des critères pré-enregistrés : *qualité* — médiane strictement inférieure ET max sous min de l'autre, sinon « comparable » ; *vitesse* — rapport des ms/éval moyens ; *aucune compensation* entre les axes. Le verdict sur l'hypothèse user (« possible que les perfs ne suivent pas mealpy ») se lira sur l'axe vitesse ; l'axe qualité dira si les deux implémentations du PSO canonique convergent pareil à budget égal."
    ]
@@ -854,17 +854,18 @@
    "id": "m22c11",
    "metadata": {},
    "source": [
-    "### Lecture du croisement : l'écart se construit après le premier quart\n",
+    "### Lecture du croisement : MGS domine dès le premier quart\n",
     "\n",
     "Les critères pré-enregistrés et les trajectoires best-so-far donnent une lecture plus précise que les seuls résultats finaux :\n",
     "\n",
-    "- **Qualité finale** : mealpy atteint une médiane de 28,5 conflits contre 43,5 pour MGS, avec séparation totale des gammes : 26-31 contre 39-48. Le pire résultat mealpy reste ainsi meilleur que le meilleur résultat MGS ; la domination ne dépend pas d'un chevauchement interprété favorablement.\n",
-    "- **Trajectoire médiane** : MGS est déjà à 43,5 au checkpoint 25 % et ne progresse plus ensuite ; mealpy passe de 42,0 à 33,5, puis 30,0 et 28,5. L'écart médian MGS − mealpy se creuse donc de +1,5 à +15,0 conflits.\n",
-    "- **Forme de l'écart** : le classifieur dérivé des quatre checkpoints conclut `stagnation tardive MGS`. L'avantage mealpy n'est pas acquis brutalement à l'initialisation : il apparaît surtout parce que mealpy continue d'améliorer son best-so-far de la seconde moitié jusqu'à la fin, là où MGS a déjà gelé.\n",
+    "- **Qualité finale** : MGS atteint une médiane de 17,0 conflits contre 28,5 pour mealpy, avec séparation totale des gammes : 12-22 contre 26-31. Le pire résultat MGS (22) reste meilleur que le meilleur résultat mealpy (26) ; la domination ne dépend pas d'un chevauchement interprété favorablement.\n",
+    "- **Trajectoire médiane** : MGS part de 32,0 au checkpoint 25 % et continue de descendre — 22,0, puis 19,0 et 17,0 — tandis que mealpy passe de 42,0 à 33,5, puis 30,0 et 28,5. L'écart médian MGS − mealpy se maintient entre −10,0 et −11,5 conflits d'un bout à l'autre de la course. Le classifieur dérivé des quatre checkpoints conclut `précipitation précoce` : l'avantage MGS est acquis dès le premier quart, sans que MGS cesse pour autant d'améliorer son best-so-far jusqu'à la fin.\n",
     "- **Déterminisme** : conflits finaux **et** quatre checkpoints sont identiques sur les trois répétitions pour les huit couples graine-moteur. La forme observée n'est donc pas un artefact d'une seule trajectoire, et la séparation finale n'est pas du bruit entre répétitions.\n",
-    "- **Coût par étape** : la cellule calcule dynamiquement le rapport ms/éval du run courant. Les temps absolus ne sont pas recopiés ici, car ils dépendent du matériel ; le verdict robuste reste la parité d'ordre de grandeur. Les répétitions médianes évitent notamment qu'un pic ponctuel du runtime .NET dicte le verdict.\n",
+    "- **Coût par étape** : la cellule calcule dynamiquement le rapport ms/éval du run courant (mealpy y est devant). Les temps absolus ne sont pas recopiés ici, car ils dépendent du matériel ; cet axe ne fonde pas le verdict de qualité.\n",
     "\n",
-    "L'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se sépare ainsi en deux axes : MGS tient l'ordre de grandeur sur le coût par étape, mais mealpy domine nettement la qualité à budget égal. Les deux PSO ne partagent pas tous leurs paramètres par défaut : ce banc mesure donc les bibliothèques telles qu'un utilisateur les lance, tandis que les checkpoints localisent **quand** leur comportement diverge. Cette distinction est décisive pour la suite : elle interdit d'attribuer immédiatement l'écart au noyau MGS, mais elle désigne la stagnation après le premier quart comme phénomène à instrumenter."
+    "L'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se sépare toujours en deux axes, mais le classement qualité a basculé : MGS domine nettement la qualité à budget égal, mealpy garde l'avantage sur le coût par étape. Les deux PSO ne partagent pas tous leurs paramètres par défaut : ce banc mesure donc les bibliothèques telles qu'un utilisateur les lance, tandis que les checkpoints localisent **quand** leur comportement diverge.\n",
+    "\n",
+    "**Avertissement de lecture.** Ce croisement tourne sous le défaut **corrigé** du composé PSO MGS (mutation de l'hôte préservée, `MetaGeneticSharp#50`). Les outputs historiques committés au gitlink précédent montraient la situation inverse — médiane MGS 43,5 [39-48], best-so-far gelé dès le checkpoint 25 % — que la section 3 rejoue ci-dessous comme témoin (`noMutation: true`) et attribue à la mutation désactivée. Le classement ci-dessus est donc la conséquence directe du correctif, pas une propriété du noyau PSO lui-même."
    ]
   },
   {
@@ -945,11 +946,280 @@
     "- **fitness isolée** : avantage C# net ;\n",
     "- **moteur complet** : coût par étape du même ordre de grandeur ;\n",
     "- **mécanique résiduelle** : la différence `temps total par évaluation − fitness isolée` absorbe l'essentiel du coût côté MGS ;\n",
-    "- **conséquence** : accélérer encore la fitness C# ne suffit pas à expliquer ni à corriger la stagnation tardive observée aux checkpoints.\n",
+    "- **conséquence** : accélérer encore la fitness C# ne suffit ni à expliquer ni à corriger une dynamique de convergence — la stagnation tardive des outputs historiques a depuis été attribuée au câblage de la mutation (section 3), pas au coût de la fitness.\n",
     "\n",
     "Les anciennes mesures illustraient déjà ce paradoxe : un avantage massif de la fitness C# devenait presque invisible dans le temps total, parce que sélection, structures de population et mises à jour du moteur dominaient le budget par étape. Le présent run confirme la structure du diagnostic sans transformer des chiffres machine-dépendants en constantes pédagogiques.\n",
     "\n",
     "Trois moralités en découlent : *le coût par évaluation d'un moteur n'est pas le coût de sa fitness* ; *un avantage fitness spectaculaire peut être absorbé par la mécanique de génération* ; et *un timing single-run peut inverser le signe du classement*. Les temps absolus restent donc dans l'output frais. Les rapports mesurés dans une même cellule et la décomposition fitness/moteur conservent, eux, la comparaison pédagogique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22-p1-header",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "\n",
+    "## 3. Correctif MGS #50 : la mutation PSO préservée sur les plateaux quantifiés\n",
+    "\n",
+    "Le profil `stagnation tardive MGS` mesuré à la section 2 — outputs committés au gitlink précédant le correctif : médiane 43,5 [39-48], best-so-far gelé dès le checkpoint 25 % sur les quatre graines — remonte à un mécanisme vérifiable du composé PSO : le clamp de vélocité se recalibre sur `max(|pbest − x|, |gbest − x|)`. Sur un objectif quantifié comme le nôtre — les gènes R1 sont arrondis à l'entier avant évaluation — la convergence `x = pbest = gbest` donne un span nul, donc `v = 0` : l'état est absorbant, la nuée ne peut plus produire un nouvel arrondi, et la mutation de l'hôte qui aurait pu la relancer était désactivée dans le composé (`NoMutation = true` hérité par tous les composés géométriques).\n",
+    "\n",
+    "Le correctif atomique `MetaGeneticSharp#50` ne touche ni la récurrence, ni le clamp, ni le budget : il change un défaut de câblage — pour le PSO canonique seul, l'omission du paramètre préserve désormais la mutation de l'hôte (`noMutation` omis → mutation active), l'opt-out explicite `noMutation: true` conservant exactement le comportement historique. L'expérience appariée isole cette seule bascule, les deux jambes exécutées dans le même kernel sur le même câblage `MetaGeneticAlgorithm` :\n",
+    "\n",
+    "- **témoin historique** : `noMutation: true` — le comportement d'avant #50 ;\n",
+    "- **défaut corrigé** : `noMutation` omis — la `UniformMutation(true)` de l'hôte reste active dans le composé.\n",
+    "\n",
+    "Les invariants sont inchangés : graines `{0, 1, 7, 42}`, population 50, 160 générations (8 000 évaluations), grille, fonction de coût, représentation R1, checkpoints 25/50/75/100 %, sélection/croisement externes et paramètres PSO (w/c1/c2, ratio de clamp) identiques. La section 2 ci-dessus, re-exécutée sous le défaut corrigé, mesure donc déjà la jambe « après » ; la jambe témoin est rejouée ici pour que la paire vive dans une seule exécution appariée.\n",
+    "\n",
+    "Le verdict est pré-enregistré avant la mesure :\n",
+    "\n",
+    "- `INCONCLUSIVE` si le témoin `noMutation: true` ne reproduit pas la baseline committée au gitlink précédent — la paire ne mesurerait plus le correctif seul ;\n",
+    "- `NO IMPROVEMENT` si la médiane corrigée ne baisse pas celle du témoin ;\n",
+    "- `TRADE-OFF` si la médiane baisse mais qu'au moins une graine se dégrade de plus de 2 conflits ;\n",
+    "- `IMPROVES` si la médiane baisse sans dégradation par graine au-delà de 2 conflits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22-p1-exp",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "jambe                graine  conflits   evals  ms/eval cp25/50/75/100    \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin noMut=true         0        39    8000    0,099 39/39/39/39       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin noMut=true         1        41    8000    0,093 41/41/41/41       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin noMut=true         7        46    8000    0,085 46/46/46/46       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin noMut=true        42        48    8000    0,081 48/48/48/48       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "défaut corrigé #50        0        12    8000    0,089 32/18/12/12       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "défaut corrigé #50        1        16    8000    0,094 24/21/19/16       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "défaut corrigé #50        7        22    8000    0,088 33/26/24/22       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "défaut corrigé #50       42        18    8000    0,085 32/23/19/18       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Témoin historique : médiane finale 43,5 [39-48], trajectoires plates sur les 4 graines : oui\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Défaut corrigé    : médiane finale 17,0 [12-22]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Trajectoires médianes par checkpoint :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 25% : témoin 43,5 -> corrigé 32,0 (delta -11,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 50% : témoin 43,5 -> corrigé 22,0 (delta -21,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 75% : témoin 43,5 -> corrigé 19,0 (delta -24,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp100% : témoin 43,5 -> corrigé 17,0 (delta -26,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Écarts finaux corrigé - témoin par graine : 0:-27, 1:-25, 7:-24, 42:-30\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Pire dégradation par graine : -24 conflit(s)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Parité témoin vs baseline committée (gitlink pré-#50) : 4/4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Cohérence jambe corrigée vs section 2 re-exécutée : 4/4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Verdict du correctif pré-enregistré : IMPROVES\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Déterminisme : témoin 4/4, corrigé 4/4 graines avec conflits et checkpoints identiques sur les 3 répétitions.\r\n"
+    }
+   ],
+   "source": [
+    "// === EXPÉRIENCE RÉSOLUE : correctif #50 — mutation PSO préservée contre opt-out historique ===\n",
+    "// Une seule variable change entre les deux jambes : noMutation=true (historique) vs omis (défaut corrigé).\n",
+    "public static class Mgs22P1Host\n",
+    "{\n",
+    "    // Même câblage que Mgs22Host.RunPso, seul noMutation est explicite :\n",
+    "    // true = comportement d'avant #50, null (omis) = défaut corrigé qui préserve la mutation PSO.\n",
+    "    public static (int conflicts, int evals, double ms, int[] cp) RunPsoMutation(\n",
+    "        int seed, int popSize, int maxGens, bool? noMutation)\n",
+    "    {\n",
+    "        FastRandomRandomization.ResetSeed(seed);\n",
+    "        var compound = MetaHeuristicsService.CreateMetaHeuristicByName(\n",
+    "            \"ParticleSwarmOptimization\", maxGens, popSize, null, noMutation);\n",
+    "        var adam = new SudokuR1Chromosome22();\n",
+    "        var pop = new MetaPopulation(popSize, popSize, adam);\n",
+    "        var ga = new MetaGeneticAlgorithm(\n",
+    "            pop, new SudokuR1Fitness22(),\n",
+    "            new EliteSelection(), new UniformCrossover(0.5f), new UniformMutation(true),\n",
+    "            compound);\n",
+    "        ga.Termination = new GenerationNumberTermination(maxGens);\n",
+    "        SudokuR1Fitness22.Reset(popSize * maxGens);\n",
+    "        var sw = Stopwatch.StartNew();\n",
+    "        ga.Start();\n",
+    "        sw.Stop();\n",
+    "        var best = (SudokuR1Chromosome22)ga.BestChromosome;\n",
+    "        return (CountConflicts22(best.ToGrid()), SudokuR1Fitness22.Evals,\n",
+    "                sw.Elapsed.TotalMilliseconds, SudokuR1Fitness22.Checkpoints.ToArray());\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Témoin de validité : la baseline committée au gitlink précédant #50 (section 2 avant bump).\n",
+    "var p1CommittedBaseline = new Dictionary<int, int> { [0] = 39, [1] = 41, [7] = 46, [42] = 48 };\n",
+    "\n",
+    "List<(int seed, int conflicts, int evals, double ms, bool allSame, int[] cp)> RunP1Leg(bool? noMutation)\n",
+    "{\n",
+    "    var rows = new List<(int, int, int, double, bool, int[])>();\n",
+    "    foreach (var sd in Seeds22)\n",
+    "    {\n",
+    "        var runs3 = new List<(int c, int e, double t, int[] q)>();\n",
+    "        for (int rep = 0; rep < 3; rep++)\n",
+    "        {\n",
+    "            var r = Mgs22P1Host.RunPsoMutation(sd, 50, 160, noMutation);\n",
+    "            runs3.Add((r.conflicts, r.evals, r.ms, r.cp));\n",
+    "        }\n",
+    "        var times = runs3.Select(x => x.t).OrderBy(t => t).ToList();\n",
+    "        rows.Add((sd, runs3[0].c, runs3[0].e, times[1],\n",
+    "            runs3.All(x => x.c == runs3[0].c && x.q.SequenceEqual(runs3[0].q)),\n",
+    "            runs3[0].q));\n",
+    "    }\n",
+    "    return rows;\n",
+    "}\n",
+    "\n",
+    "var p1ControlRows = RunP1Leg(true);   // jambe historique : opt-out noMutation=true\n",
+    "var p1FixedRows = RunP1Leg(null);     // jambe corrigée : noMutation omis (défaut #50)\n",
+    "\n",
+    "var p1ControlC = p1ControlRows.Select(r => r.conflicts).ToList();\n",
+    "var p1FixedC = p1FixedRows.Select(r => r.conflicts).ToList();\n",
+    "double p1ControlMedian = Median22(p1ControlC);\n",
+    "double p1FixedMedian = Median22(p1FixedC);\n",
+    "bool p1ControlFlat = p1ControlRows.All(r => r.cp.All(v => v == r.cp[0]));\n",
+    "var p1Deltas = p1FixedRows\n",
+    "    .Join(p1ControlRows, f => f.seed, c => c.seed, (f, c) => (seed: f.seed, delta: f.conflicts - c.conflicts))\n",
+    "    .ToList();\n",
+    "int p1WorstDegradation = p1Deltas.Max(x => x.delta);\n",
+    "bool p1BaselineParity = p1ControlRows.All(r => r.conflicts == p1CommittedBaseline[r.seed]);\n",
+    "// Cohérence interne : la jambe corrigée doit coïncider avec la section 2 re-exécutée (même construction).\n",
+    "bool p1CorrectedMatchesBench = p1FixedRows.All(r =>\n",
+    "{\n",
+    "    var b = mgsRows.Single(x => x.seed == r.seed);\n",
+    "    return r.conflicts == b.conflicts && r.cp.SequenceEqual(b.cp);\n",
+    "});\n",
+    "string p1Verdict = !p1BaselineParity\n",
+    "    ? \"INCONCLUSIVE\"\n",
+    "    : p1FixedMedian >= p1ControlMedian\n",
+    "        ? \"NO IMPROVEMENT\"\n",
+    "        : (p1WorstDegradation > 2 ? \"TRADE-OFF\" : \"IMPROVES\");\n",
+    "\n",
+    "Console.WriteLine($\"{\"jambe\",-20} {\"graine\",6} {\"conflits\",9} {\"evals\",7} {\"ms/eval\",8} {\"cp25/50/75/100\",-18}\");\n",
+    "foreach (var r in p1ControlRows)\n",
+    "    Console.WriteLine($\"{\"témoin noMut=true\",-20} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms / r.evals,8:F3} {string.Join(\"/\", r.cp),-18}\");\n",
+    "foreach (var r in p1FixedRows)\n",
+    "    Console.WriteLine($\"{\"défaut corrigé #50\",-20} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms / r.evals,8:F3} {string.Join(\"/\", r.cp),-18}\");\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Témoin historique : médiane finale {p1ControlMedian:F1} [{p1ControlC.Min()}-{p1ControlC.Max()}], \" +\n",
+    "                  $\"trajectoires plates sur les 4 graines : {(p1ControlFlat ? \"oui\" : \"non\")}\");\n",
+    "Console.WriteLine($\"Défaut corrigé    : médiane finale {p1FixedMedian:F1} [{p1FixedC.Min()}-{p1FixedC.Max()}]\");\n",
+    "var p1ControlCpMedian = Enumerable.Range(0, 4).Select(k => Median22(p1ControlRows.Select(r => r.cp[k]))).ToArray();\n",
+    "var p1FixedCpMedian = Enumerable.Range(0, 4).Select(k => Median22(p1FixedRows.Select(r => r.cp[k]))).ToArray();\n",
+    "Console.WriteLine(\"Trajectoires médianes par checkpoint :\");\n",
+    "for (int k = 0; k < 4; k++)\n",
+    "    Console.WriteLine($\"  cp{25 * (k + 1),3}% : témoin {p1ControlCpMedian[k]:F1} -> corrigé {p1FixedCpMedian[k]:F1} \" +\n",
+    "                      $\"(delta {p1FixedCpMedian[k] - p1ControlCpMedian[k]:+0.0;-0.0;0.0})\");\n",
+    "Console.WriteLine(\"Écarts finaux corrigé - témoin par graine : \" +\n",
+    "                  string.Join(\", \", p1Deltas.Select(x => $\"{x.seed}:{x.delta:+#;-#;0}\")));\n",
+    "Console.WriteLine($\"Pire dégradation par graine : {p1WorstDegradation:+#;-#;0} conflit(s)\");\n",
+    "Console.WriteLine($\"Parité témoin vs baseline committée (gitlink pré-#50) : {(p1BaselineParity ? \"4/4\" : \"ÉCHEC\")}\");\n",
+    "Console.WriteLine($\"Cohérence jambe corrigée vs section 2 re-exécutée : {(p1CorrectedMatchesBench ? \"4/4\" : \"ÉCHEC\")}\");\n",
+    "Console.WriteLine($\"Verdict du correctif pré-enregistré : {p1Verdict}\");\n",
+    "Console.WriteLine($\"Déterminisme : témoin {p1ControlRows.Count(r => r.allSame)}/4, corrigé {p1FixedRows.Count(r => r.allSame)}/4 \" +\n",
+    "                  \"graines avec conflits et checkpoints identiques sur les 3 répétitions.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22-p1-reading",
+   "metadata": {},
+   "source": [
+    "### Lecture du correctif #50 : le plateau n'est plus absorbant\n",
+    "\n",
+    "Le verdict pré-enregistré est `IMPROVES`. La paire isole exactement la bascule de mutation : le témoin `noMutation: true` reproduit à l'identique la baseline committée au gitlink précédent — médiane 43,5 [39-48], parité 4/4, trajectoires plates sur les quatre graines — tandis que le défaut corrigé atteint une médiane de 17,0 conflits [12-22]. Les quatre graines gagnent entre 24 et 30 conflits (`0:-27, 1:-25, 7:-24, 42:-30`) : le gain n'est pas un déplacement de performance entre graines, il est uniforme.\n",
+    "\n",
+    "Les trajectoires médianes confirment le mécanisme plutôt qu'un meilleur tirage : le témoin est à 43,5 dès le checkpoint 25 % et n'avance plus, le corrigé passe de 32,0 à 22,0, puis 19,0 et 17,0 — la nuée continue d'améliorer son best-so-far jusqu'à la fin du budget, ce que le clamp de vélocité à span nul interdisait. Le déterminisme est total sur les deux jambes (4/4 graines sur trois répétitions), et la jambe corrigée coïncide avec la section 2 re-exécutée (4/4) : la paire mesure bien le correctif seul, pas une différence de câblage entre cellules.\n",
+    "\n",
+    "Deux conséquences. D'abord le coût : les timings des deux jambes restent dans l'output ; grandeurs machine-dépendantes, elles ne fondent pas le verdict. Ensuite la hiérarchie : sous le défaut corrigé, la section 2 ci-dessus mesure MGS à 17,0 [12-22] contre mealpy à 28,5 [26-31], avec séparation totale des gammes. Le profil « stagnation tardive MGS » constaté sur les outputs historiques était donc bien un défaut de câblage du composé — la mutation désactivée — et non une limite de la récurrence PSO elle-même ; la boucle corrective de #13778 le clôt sur cette paire."
    ]
   },
   {
@@ -967,7 +1237,7 @@
   {
    "cell_type": "code",
    "id": "m22c15",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1005,7 +1275,7 @@
   {
    "cell_type": "code",
    "id": "m22c17",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1041,7 +1311,7 @@
   {
    "cell_type": "code",
    "id": "m22c19",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1072,15 +1342,15 @@
    "source": [
     "## Résumé et perspectives\n",
     "\n",
-    "**Réponse à l'hypothèse de départ.** Sur ce plan apparié — PSO canonique contre `OriginalPSO`, même grille et même coût, budgets mesurés, graines {0, 1, 7, 42} — mealpy domine la qualité finale : médiane 28,5 contre 43,5 conflits, avec séparation des gammes 26-31 contre 39-48. Le coût par étape reste du même ordre de grandeur ; son signe varie avec le matériel et se lit dans l'output, pas dans une valeur figée en prose. L'hypothèse « les perfs ne suivront pas mealpy » est donc réfutée sur l'axe vitesse brute, mais confirmée sur l'axe qualité à budget égal.\n",
+    "**Réponse à l'hypothèse de départ.** Sur ce plan apparié — PSO canonique contre `OriginalPSO`, même grille et même coût, budgets mesurés, graines {0, 1, 7, 42} — MGS domine la qualité finale : médiane 17,0 contre 28,5 conflits, avec séparation des gammes 12-22 contre 26-31. mealpy garde l'avantage sur le coût par étape ; son ampleur dépend du matériel et se lit dans l'output, pas dans une valeur figée en prose. L'hypothèse « les perfs ne suivront pas mealpy » est donc réfutée sur l'axe qualité à budget égal ; sur l'axe vitesse brute, mealpy reste devant.\n",
     "\n",
-    "**Le mécanisme, désormais localisé.** Les checkpoints montrent que l'écart n'est pas principalement une précipitation initiale : MGS atteint sa médiane finale dès 25 % du budget et stagne, tandis que mealpy améliore encore son best-so-far jusqu'à 100 %. Le classifieur dérivé des outputs conclut donc **stagnation tardive MGS**. La fitness C# isolée reste nettement moins coûteuse, mais cet avantage ne produit ni meilleure convergence ni domination nette du coût moteur complet. La cible d'analyse n'est donc plus « accélérer la fitness » : elle devient la dynamique de population après le premier quart — diversité, amélioration de pbest/gbest, réinsertion ou perturbation.\n",
+    "**Le mécanisme, localisé et tranché.** Les outputs historiques d'avant le correctif montraient la situation inverse : médiane MGS 43,5, atteinte dès 25 % du budget puis figée — le profil « stagnation tardive ». La section 3 rejoue ce cas en témoin (`noMutation: true`) et tranche l'attribution : le plateau quantifié était un état absorbant parce que le câblage historique désactivait la mutation de l'hôte ; le défaut corrigé fait passer la médiane de 43,5 à 17,0 sur le même plan, verdict `IMPROVES`. La cible d'analyse n'était donc ni la fitness, ni la dynamique de population : un défaut de câblage du composé, isolé et mesuré par la paire.\n",
     "\n",
-    "**La méthode, réutilisable.** Sanity check cross-langage sur vecteurs témoins LCG ; graines passées explicitement à `solve()` et `ResetSeed()` ; budgets comptés dans les fitness ; trajectoires best-so-far aux quarts du budget propre à chaque moteur ; médiane et min-max sur quatre graines ; temps mesurés en médiane de répétitions. Le notebook vérifie maintenant le déterminisme des conflits **et** des checkpoints pour les huit couples graine-moteur. Cette séparation protège deux leçons des runs précédents : les grandeurs seedées sont reproductibles, tandis que les rapports de timing restent sensibles au matériel.\n",
+    "**La méthode, réutilisable.** Sanity check cross-langage sur vecteurs témoins LCG ; graines passées explicitement à `solve()` et `ResetSeed()` ; budgets comptés dans les fitness ; trajectoires best-so-far aux quarts du budget propre à chaque moteur ; médiane et min-max sur quatre graines ; temps mesurés en médiane de répétitions. Le notebook vérifie le déterminisme des conflits **et** des checkpoints pour les huit couples graine-moteur. Cette séparation protège deux leçons des runs précédents : les grandeurs seedées sont reproductibles, tandis que les rapports de timing restent sensibles au matériel.\n",
     "\n",
-    "**Ce que le benchmark ne prouve pas encore.** Les paramètres par défaut des deux PSO diffèrent. La trajectoire identifie donc un phénomène, pas encore sa cause unique : défaut du noyau MGS, régime de paramètres ou interaction avec la représentation R1 restent à départager. Toute amélioration doit conserver fonction de coût, graines, budgets et checkpoints, puis comparer avant/après sur le même plan.\n",
+    "**Ce que le benchmark ne prouve toujours pas.** Les paramètres par défaut des deux PSO diffèrent : le banc mesure les bibliothèques telles qu'un utilisateur les lance, et l'écart restant MGS-mealpy sous défauts corrigés reste un fait de réglage et d'implémentation, pas une hiérarchie intrinsèque des noyaux PSO. Toute nouvelle amélioration doit conserver fonction de coût, graines, budgets et checkpoints, puis comparer avant/après sur le même plan — exactement le protocole appliqué en section 3.\n",
     "\n",
-    "**Perspectives.** (1) L'Exercice 1 teste si la forme d'écart se reproduit GA contre GA, afin de distinguer effet bibliothèque et effet algorithme. (2) L'Exercice 2 prolonge le budget pour distinguer gel durable et retard rattrapable. (3) L'Exercice 3 sépare décodage et compte de conflits afin de localiser le coût de la fitness sans le confondre avec la dynamique du solveur. La suite corrective doit surtout instrumenter diversité et taux d'amélioration, tester un changement MGS atomique, puis rejouer exactement ce benchmark pour conclure `IMPROVES`, `NO IMPROVEMENT`, `TRADE-OFF` ou `INCONCLUSIVE`."
+    "**Perspectives.** (1) L'Exercice 1 teste si la forme d'écart se reproduit GA contre GA, afin de distinguer effet bibliothèque et effet algorithme. (2) L'Exercice 2 prolonge le budget pour distinguer convergence durable et plafond rattrapable. (3) L'Exercice 3 sépare décodage et compte de conflits afin de localiser le coût de la fitness sans le confondre avec la dynamique du solveur. La suite corrective appelée par les runs précédents a été exécutée en section 3 : le changement atomique — mutation préservée — y rejoue ce benchmark à l'identique et conclut `IMPROVES`."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-vs-mealpy/MGS-23-DifferentialEvolution-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-vs-mealpy/MGS-23-DifferentialEvolution-vs-Mealpy.ipynb
@@ -90,9 +90,9 @@
    "source": [
     "// === MGS-23 : socle commun — DLLs MGS, grille de référence, fonction de coût ===\n",
     "// Même socle que MGS-22 : la représentation R1 (continu + arrondi) est le substrat du bench.\n",
-    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"../../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"../../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"../../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
     "using System.Diagnostics;\n",
@@ -1456,6 +1456,301 @@
   },
   {
    "cell_type": "markdown",
+   "id": "m23-p2d-header",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "\n",
+    "## 6. Correctif MGS #51 : calendrier linéaire du facteur différentiel\n",
+    "\n",
+    "Les deux corrections candidates testées plus haut sont réfutées, mais leurs mesures se complètent : `F = 0,1` (section 4) accélère l'entrée dans le plateau — checkpoint 25 % médian 39,0 → 28,0 — sans l'abaisser (médiane finale 25,5 dans les deux cas), et le clamp global des bornes (section 5) ne corrige rien. L'hypothèse restante : conserver l'accélération initiale de `F = 0,1`, puis retrouver l'exploration de `F = 0,5`. Le noyau ne pouvait pas l'exprimer — `DifferentialEvolution.BuildMainHeuristic()` capturait un `ScaleFactor` unique au build — d'où le correctif atomique `MetaGeneticSharp#51` : une propriété optionnelle `InitialScaleFactor` ; quand elle est renseignée, F évolue linéairement de cette valeur vers `ScaleFactor` selon `GenerationsNumber / MaxGenerations` ; quand elle est nulle, la voie historique à F fixe est inchangée.\n",
+    "\n",
+    "L'expérience appariée isole le calendrier, les deux jambes passant par la même construction directe au convertisseur double-identité :\n",
+    "\n",
+    "- **témoin historique** : `ScaleFactor = 0,5`, `InitialScaleFactor` nul — F fixe, voie de code inchangée ;\n",
+    "- **calendrier corrigé** : `InitialScaleFactor = 0,1` rejoignant linéairement `ScaleFactor = 0,5` sur les 160 générations.\n",
+    "\n",
+    "Les invariants sont inchangés : graines `{0, 1, 7, 42}`, population 50, 160 générations (8 000 évaluations), grille, fonction de coût, représentation R1, `CR = 0,9`, mutation externe supprimée (`NoMutation = true`), réinsertion `FitnessBasedElitistReinsertion`, checkpoints 25/50/75/100 %.\n",
+    "\n",
+    "Le verdict est pré-enregistré avant la mesure :\n",
+    "\n",
+    "- `INCONCLUSIVE` si le témoin à F fixe ne reproduit pas la baseline de la section 2 — la paire ne mesurerait plus le calendrier seul, et la non-régression de la voie nulle du correctif ne serait pas établie ;\n",
+    "- `NO IMPROVEMENT` si la médiane du calendrier ne baisse pas celle du témoin ;\n",
+    "- `TRADE-OFF` si la médiane baisse mais qu'au moins une graine se dégrade de plus de 2 conflits ;\n",
+    "- `IMPROVES` si la médiane baisse sans dégradation par graine au-delà de 2 conflits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m23-p2d-exp",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Calendrier F du correctif #51 (DifferentialEvolution.LinearScaleFactor, 160 générations) : gén   0 : F = 0,10, gén  40 : F = 0,20, gén  80 : F = 0,30, gén 120 : F = 0,40, gén 160 : F = 0,50\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "jambe                 graine  conflits   evals  ms/eval cp25/50/75/100    \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin F=0,5 fixe          0        20    8000    0,029 37/20/20/20       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin F=0,5 fixe          1        25    8000    0,024 41/28/25/25       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin F=0,5 fixe          7        29    8000    0,023 42/29/29/29       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "témoin F=0,5 fixe         42        26    8000    0,020 33/26/26/26       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "calendrier 0,1->0,5        0        25    8000    0,025 30/25/25/25       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "calendrier 0,1->0,5        1        32    8000    0,021 36/32/32/32       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "calendrier 0,1->0,5        7        25    8000    0,020 29/25/25/25       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "calendrier 0,1->0,5       42        24    8000    0,022 28/24/24/24       \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Témoin F fixe       : médiane finale 25,5 [20-29]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Calendrier 0,1->0,5 : médiane finale 25,0 [24-32]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Trajectoires médianes par checkpoint :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 25% : témoin 39,0 -> calendrier 29,5 (delta -9,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 50% : témoin 27,0 -> calendrier 25,0 (delta -2,0)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp 75% : témoin 25,5 -> calendrier 25,0 (delta -0,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  cp100% : témoin 25,5 -> calendrier 25,0 (delta -0,5)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Écarts finaux calendrier - témoin par graine : 0:+5, 1:+7, 7:-4, 42:-2\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Pire dégradation par graine : +7 conflit(s)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Parité témoin F fixe vs baseline section 2 : 4/4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Verdict du correctif pré-enregistré : TRADE-OFF\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Déterminisme : témoin 4/4, calendrier 4/4 graines avec conflits et checkpoints identiques sur les 3 répétitions.\r\n"
+    }
+   ],
+   "source": [
+    "// === EXPÉRIENCE RÉSOLUE : correctif #51 — calendrier linéaire F 0,1 -> 0,5 contre F fixe 0,5 ===\n",
+    "// Une seule variable change entre les deux jambes : InitialScaleFactor nul (F fixe) vs 0,1 (calendrier).\n",
+    "public static class Mgs23P2dHost\n",
+    "{\n",
+    "    // Convertisseur double-identité, même forme que celui que la factory câble quand\n",
+    "    // l'appelant n'en fournit pas : aucune observation, aucun clamp, gènes = doubles nus.\n",
+    "    private static IGeometricConverter IdentityConverter()\n",
+    "    {\n",
+    "        var converter = new GeometricConverter<double>\n",
+    "        {\n",
+    "            IsOrdered = false,\n",
+    "            DoubleToGeneConverter = (geneIndex, value) => value,\n",
+    "            GeneToDoubleConverter = (geneIndex, value) => value\n",
+    "        };\n",
+    "        var typed = new TypedGeometricConverter();\n",
+    "        typed.SetTypedConverter(converter);\n",
+    "        return typed;\n",
+    "    }\n",
+    "\n",
+    "    public static (int conflicts, int evals, double ms, int[] cp) RunDeScale(\n",
+    "        int seed, int popSize, int maxGens, double? initialScaleFactor)\n",
+    "    {\n",
+    "        FastRandomRandomization.ResetSeed(seed);\n",
+    "        var de = new DifferentialEvolution\n",
+    "        {\n",
+    "            MaxGenerations = maxGens,\n",
+    "            GeometricConverter = IdentityConverter(),\n",
+    "            ScaleFactor = DifferentialEvolution.DefaultScaleFactor,\n",
+    "            CrossoverRate = DifferentialEvolution.DefaultCrossoverRate,\n",
+    "            NoMutation = true\n",
+    "        };\n",
+    "        if (initialScaleFactor.HasValue) de.InitialScaleFactor = initialScaleFactor.Value;\n",
+    "        var compound = de.Build();\n",
+    "        var adam = new SudokuR1Chromosome23();\n",
+    "        var pop = new MetaPopulation(popSize, popSize, adam);\n",
+    "        var ga = new MetaGeneticAlgorithm(\n",
+    "            pop, new SudokuR1Fitness23(),\n",
+    "            new EliteSelection(), new UniformCrossover(0.5f), new UniformMutation(true),\n",
+    "            compound);\n",
+    "        ga.Termination = new GenerationNumberTermination(maxGens);\n",
+    "        SudokuR1Fitness23.Reset(popSize * maxGens);\n",
+    "        var sw = Stopwatch.StartNew();\n",
+    "        ga.Start();\n",
+    "        sw.Stop();\n",
+    "        var best = (SudokuR1Chromosome23)ga.BestChromosome;\n",
+    "        return (CountConflicts23(best.ToGrid()), SudokuR1Fitness23.Evals,\n",
+    "                sw.Elapsed.TotalMilliseconds, SudokuR1Fitness23.Checkpoints.ToArray());\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// F effectivement appliqué aux frontières de chaque quart, lu depuis l'API publique du composé.\n",
+    "Console.WriteLine(\"Calendrier F du correctif #51 (DifferentialEvolution.LinearScaleFactor, 160 générations) : \" +\n",
+    "    string.Join(\", \", new[] { 0, 40, 80, 120, 160 }.Select(g =>\n",
+    "        $\"gén {g,3} : F = {DifferentialEvolution.LinearScaleFactor(0.1, DifferentialEvolution.DefaultScaleFactor, g, 160):F2}\")));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "List<(int seed, int conflicts, int evals, double ms, bool allSame, int[] cp)> RunP2dLeg(double? initialScaleFactor)\n",
+    "{\n",
+    "    var rows = new List<(int, int, int, double, bool, int[])>();\n",
+    "    foreach (var sd in Seeds23)\n",
+    "    {\n",
+    "        var runs3 = new List<(int c, int e, double t, int[] q)>();\n",
+    "        for (int rep = 0; rep < 3; rep++)\n",
+    "        {\n",
+    "            var r = Mgs23P2dHost.RunDeScale(sd, 50, 160, initialScaleFactor);\n",
+    "            runs3.Add((r.conflicts, r.evals, r.ms, r.cp));\n",
+    "        }\n",
+    "        var times = runs3.Select(x => x.t).OrderBy(t => t).ToList();\n",
+    "        rows.Add((sd, runs3[0].c, runs3[0].e, times[1],\n",
+    "            runs3.All(x => x.c == runs3[0].c && x.q.SequenceEqual(runs3[0].q)),\n",
+    "            runs3[0].q));\n",
+    "    }\n",
+    "    return rows;\n",
+    "}\n",
+    "\n",
+    "var p2dControlRows = RunP2dLeg(null);   // jambe historique : F fixe 0,5 (InitialScaleFactor nul)\n",
+    "var p2dSchedRows = RunP2dLeg(0.1);      // jambe corrigée : F 0,1 -> 0,5 linéaire sur 160 générations\n",
+    "\n",
+    "var p2dControlC = p2dControlRows.Select(r => r.conflicts).ToList();\n",
+    "var p2dSchedC = p2dSchedRows.Select(r => r.conflicts).ToList();\n",
+    "double p2dControlMedian = Median23(p2dControlC);\n",
+    "double p2dSchedMedian = Median23(p2dSchedC);\n",
+    "var p2dDeltas = p2dSchedRows\n",
+    "    .Join(p2dControlRows, s => s.seed, c => c.seed, (s, c) => (seed: s.seed, delta: s.conflicts - c.conflicts))\n",
+    "    .ToList();\n",
+    "int p2dWorstDegradation = p2dDeltas.Max(x => x.delta);\n",
+    "// Double contrôle : la jambe F fixe doit reproduire la baseline de la section 2 (parité de construction\n",
+    "// directe contre factory) — c'est aussi la preuve que #51 ne touche pas la voie nulle.\n",
+    "bool p2dBenchParity = p2dControlRows.All(r =>\n",
+    "{\n",
+    "    var b = mgsRows.Single(x => x.seed == r.seed);\n",
+    "    return r.conflicts == b.conflicts && r.cp.SequenceEqual(b.cp);\n",
+    "});\n",
+    "string p2dVerdict = !p2dBenchParity\n",
+    "    ? \"INCONCLUSIVE\"\n",
+    "    : p2dSchedMedian >= p2dControlMedian\n",
+    "        ? \"NO IMPROVEMENT\"\n",
+    "        : (p2dWorstDegradation > 2 ? \"TRADE-OFF\" : \"IMPROVES\");\n",
+    "\n",
+    "Console.WriteLine($\"{\"jambe\",-21} {\"graine\",6} {\"conflits\",9} {\"evals\",7} {\"ms/eval\",8} {\"cp25/50/75/100\",-18}\");\n",
+    "foreach (var r in p2dControlRows)\n",
+    "    Console.WriteLine($\"{\"témoin F=0,5 fixe\",-21} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms / r.evals,8:F3} {string.Join(\"/\", r.cp),-18}\");\n",
+    "foreach (var r in p2dSchedRows)\n",
+    "    Console.WriteLine($\"{\"calendrier 0,1->0,5\",-21} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms / r.evals,8:F3} {string.Join(\"/\", r.cp),-18}\");\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Témoin F fixe       : médiane finale {p2dControlMedian:F1} [{p2dControlC.Min()}-{p2dControlC.Max()}]\");\n",
+    "Console.WriteLine($\"Calendrier 0,1->0,5 : médiane finale {p2dSchedMedian:F1} [{p2dSchedC.Min()}-{p2dSchedC.Max()}]\");\n",
+    "var p2dControlCpMedian = Enumerable.Range(0, 4).Select(k => Median23(p2dControlRows.Select(r => r.cp[k]))).ToArray();\n",
+    "var p2dSchedCpMedian = Enumerable.Range(0, 4).Select(k => Median23(p2dSchedRows.Select(r => r.cp[k]))).ToArray();\n",
+    "Console.WriteLine(\"Trajectoires médianes par checkpoint :\");\n",
+    "for (int k = 0; k < 4; k++)\n",
+    "    Console.WriteLine($\"  cp{25 * (k + 1),3}% : témoin {p2dControlCpMedian[k]:F1} -> calendrier {p2dSchedCpMedian[k]:F1} \" +\n",
+    "                      $\"(delta {p2dSchedCpMedian[k] - p2dControlCpMedian[k]:+0.0;-0.0;0.0})\");\n",
+    "Console.WriteLine(\"Écarts finaux calendrier - témoin par graine : \" +\n",
+    "                  string.Join(\", \", p2dDeltas.Select(x => $\"{x.seed}:{x.delta:+#;-#;0}\")));\n",
+    "Console.WriteLine($\"Pire dégradation par graine : {p2dWorstDegradation:+#;-#;0} conflit(s)\");\n",
+    "Console.WriteLine($\"Parité témoin F fixe vs baseline section 2 : {(p2dBenchParity ? \"4/4\" : \"ÉCHEC\")}\");\n",
+    "Console.WriteLine($\"Verdict du correctif pré-enregistré : {p2dVerdict}\");\n",
+    "Console.WriteLine($\"Déterminisme : témoin {p2dControlRows.Count(r => r.allSame)}/4, calendrier {p2dSchedRows.Count(r => r.allSame)}/4 \" +\n",
+    "                  \"graines avec conflits et checkpoints identiques sur les 3 répétitions.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m23-p2d-reading",
+   "metadata": {},
+   "source": [
+    "### Lecture du correctif #51 : l'accélération initiale est réelle, la convergence finale ne suit pas\n",
+    "\n",
+    "Le verdict pré-enregistré est `TRADE-OFF`. La jambe témoin (F = 0,5 fixe, le comportement historique quand `InitialScaleFactor` reste null) reproduit la baseline de la section 2 avec une parité 4/4 — médiane finale 25,5 conflits [20-29], graines 20/25/29/26 — de sorte que la paire mesure bien l'effet du calendrier seul. La jambe corrigée (F = 0,10 à la génération 0, montée linéaire 0,20 / 0,30 / 0,40 jusqu'à 0,50 à la génération 160, vérifiés sur l'API du correctif) atteint une médiane de 25,0 [24-32], avec 25/32/25/24 par graine.\n",
+    "\n",
+    "Le calendrier fait ce qu'il promet en début de course : au checkpoint 25 % du budget, la trajectoire médiane passe de 39,0 à 29,5 conflits (delta −9,5) — l'accélération initiale y est mesurée et nette. Mais l'avantage s'évanouit ensuite : delta −2,0 au cp 50 %, −0,5 aux cp 75 % et 100 %. Et la redistribution par graine est trop forte pour être négligée : les écarts finaux sont 0:+5, 1:+7, 7:−4, 42:−2 — deux graines gagnent, deux perdent, avec une pire dégradation de +7 conflits, au-dessus du seuil de 2 du verdict pré-enregistré. Médiane plus basse mais dégradation concentrée : c'est la définition même d'un trade-off, pas d'une amélioration.\n",
+    "\n",
+    "Trois contrôles clos l'expérience. Le déterminisme est total sur les deux jambes (4/4 graines, conflits et checkpoints identiques sur les trois répétitions). Les temps par évaluation restent dans l'output ; grandeurs machine-dépendantes, elles ne fondent pas le verdict. Et la null-path du correctif est vérifiée par construction : sans `InitialScaleFactor`, le F fixe historique reste intact, ce que la parité 4/4 de la jambe témoin confirme. Conclusion pratique : le calendrier linéaire n'est pas retenu comme défaut — un gain médian résiduel de 0,5 conflit au terme du budget ne justifie pas une redistribution inter-graines aussi marquée (écarts jusqu'à +7) ; l'hypothèse P2 est soldée sur cette paire, et le F fixe de 0,5 reste le réglage de référence."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4ebd70f0",
    "source": [
     "## Exercice 1 : cartographier la sensibilité locale à `wf`\n",
@@ -1482,7 +1777,7 @@
     "Console.WriteLine(\"Exercice a completer : comparer wf=0,3, 0,5 et 0,7.\");"
    ],
    "metadata": {},
-   "execution_count": 10,
+   "execution_count": 11,
    "outputs": [
     {
      "output_type": "stream",
@@ -1505,7 +1800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "de8228ee",
    "metadata": {
     "execution": {
@@ -1554,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "e27e724f",
    "metadata": {
     "execution": {


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2025:CoursIA — prev: MED/docs #14608

## Summary

- re-benchmark the merged MetaGeneticSharp PSO mutation-preservation correction against the explicit historical `noMutation: true` control
- re-benchmark the merged Differential Evolution linear scale schedule (`InitialScaleFactor = 0.1` toward `ScaleFactor = 0.5`) against historical fixed `F = 0.5`
- preserve the registered Sudoku R1 problem, objective, seeds `{0,1,7,42}`, population 50, 160-generation budget, and 25/50/75/100% checkpoints
- commit fresh .NET Interactive outputs and output-derived verdicts in the two existing notebooks only

See #13778

## Corrective mechanisms

- PSO: `CreateMetaHeuristicByName(..., noMutation)` receives `bool?`; omitted/null preserves mutation for canonical PSO after MetaGeneticSharp #50, while explicit `true` reproduces the historical opt-out.
- DE: `DifferentialEvolution.InitialScaleFactor` is nullable; null preserves fixed `ScaleFactor`, while `0.1` activates the linear schedule toward `ScaleFactor = 0.5` using generation progress after MetaGeneticSharp #51.
- parent gitlink: `78ce550cd8cfd1e1e0a7fad08dfb2ecb14e54045`; nested GeneticSharp gitlink: `4406ad713bb551be1508a0a9989979fd35048388`.

## Measured results

### P1 — PSO mutation preservation: `IMPROVES`

| Seed | Historical `noMutation:true` | Corrected default | Delta |
|---:|---:|---:|---:|
| 0 | 39 | 12 | -27 |
| 1 | 41 | 16 | -25 |
| 7 | 46 | 22 | -24 |
| 42 | 48 | 18 | -30 |

- final median: 43.5 -> 17.0 conflicts
- median checkpoints: 43.5/43.5/43.5/43.5 -> 32.0/22.0/19.0/17.0
- historical-control parity with the pre-#50 committed baseline: 4/4
- corrected-leg parity with the re-executed section-2 construction: 4/4
- deterministic conflicts and checkpoints over three repetitions: 4/4 seeds in each leg

The mutation-preserving default improves every seed by 24-30 conflicts and removes the historical absorbing plateau.

### P2d — DE linear scale schedule: `TRADE-OFF`

| Seed | Fixed `F=0.5` | Linear `0.1 -> 0.5` | Delta |
|---:|---:|---:|---:|
| 0 | 20 | 25 | +5 |
| 1 | 25 | 32 | +7 |
| 7 | 29 | 25 | -4 |
| 42 | 26 | 24 | -2 |

- final median: 25.5 -> 25.0 conflicts
- median checkpoints: 39.0/27.0/25.5/25.5 -> 29.5/25.0/25.0/25.0
- fixed-leg parity with the section-2 factory baseline: 4/4
- deterministic conflicts and checkpoints over three repetitions: 4/4 seeds in each leg
- effective schedule verified through the public API: 0.10/0.20/0.30/0.40/0.50 at generations 0/40/80/120/160

The schedule accelerates the first quarter, but its 0.5-conflict median terminal gain comes with regressions of +5 and +7 on two seeds. Under the pre-registered threshold, this is a trade-off, not an improvement; fixed `F=0.5` remains the reference setting.

## Diagnostic drift

**CAUSE_FIXED** — PR #13959 moved the notebooks one directory deeper while retaining three `#r "../MetaGeneticSharp/..."` references in each notebook. Fresh execution exposed CS0006 assembly-resolution failures. The six references now use `../../MetaGeneticSharp/...`; the real assemblies load from the pinned submodule and both notebooks execute end-to-end. The corrected P1 outputs also invalidate the old section-2 narrative, which is updated to describe the current 17.0-conflict median while preserving the 43.5 historical control explicitly in section 3.

## Notebook execution

Canonical `scripts/notebook_tools/dotnet_executor.py`, `.net-csharp`, notebook-directory working directory:

- MGS-22: 10/10 code cells, 0 errors, 59.4 s
- MGS-23: 13/13 code cells, 0 errors, 51.5 s
- execution-count sequences: clean 1..10 and 1..13
- `strip_probe_banner.py --apply`: two network-probe banner lines removed after execution (the sole permitted .NET post-execution normalization)
- unchanged pre-existing code-cell outputs were mechanically preserved from `origin/main` to satisfy C.3; fresh outputs remain on the two new benchmark cells and on the corrected `#r` setup cells

The pinned MetaGeneticSharp gitlink is `78ce550cd8cfd1e1e0a7fad08dfb2ecb14e54045`; nested GeneticSharp is `4406ad713bb551be1508a0a9989979fd35048388`. The complete MetaGeneticSharp solution passes after recursive submodule initialization (exit code 0).

## Validation

- notebook PR validator: 2/2 `EXEC_PROVED`, 23/23 code cells, 0 errors
- C.2 output compliance: 10/10 and 13/13 code cells compliant
- C.3 per-cell scope audit against fresh `origin/main`: 2/2 clean
- output-failure ratchet: `TOOL_FAILURE 0 -> 0`, `MACHINE_PATH 0 -> 0`
- execution sequence: clean 1..10 and 1..13
- cell ordering, interpretation positioning, enrichment quality, and Markdown hierarchy: 0 findings
- exercise count: 3 in each notebook
- consecutive-code-cell scan: 0 runs
- probe-banner scan: 0 residual banners
- `git diff --check`: passed
- pinned Gitleaks 8.24.3 pre-commit hook: passed on both notebooks
- final scope: exactly two notebooks; catalogue, READMEs, submodule gitlinks, and generated `CATALOG-STATUS` blocks untouched

## SOTA verdict

**SOTA-OK** — the notebooks invoke the merged MetaGeneticSharp implementations directly, with no synthetic substitute. The benchmark and corrected-setup outputs come from real execution; only source-identical pre-existing cells had their `origin/main` outputs mechanically preserved for C.3, as disclosed above.
