### PR TITLE
fix(smartcontracts,#9434): remove SC-1 host-path output

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
@@ -5,10 +5,10 @@
    "id": "d5df895f",
    "metadata": {
     "papermill": {
-     "duration": 0.00298,
-     "end_time": "2026-05-26T19:15:49.930643",
+     "duration": 0.002606,
+     "end_time": "2026-09-05T07:13:17.061062+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:49.927663",
+     "start_time": "2026-09-05T07:13:17.058456+00:00",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "8ae34784",
    "metadata": {
     "papermill": {
-     "duration": 0.002306,
-     "end_time": "2026-05-26T19:15:49.935727",
+     "duration": 0.00172,
+     "end_time": "2026-09-05T07:13:17.065208+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:49.933421",
+     "start_time": "2026-09-05T07:13:17.063488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -62,16 +62,16 @@
    "id": "9e4fc3fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:49.940987Z",
-     "iopub.status.busy": "2026-05-26T19:15:49.940760Z",
-     "iopub.status.idle": "2026-05-26T19:15:49.947082Z",
-     "shell.execute_reply": "2026-05-26T19:15:49.946594Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.070153Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.069982Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.077920Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.077299Z"
     },
     "papermill": {
-     "duration": 0.010131,
-     "end_time": "2026-05-26T19:15:49.948012",
+     "duration": 0.011596,
+     "end_time": "2026-09-05T07:13:17.078573+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:49.937881",
+     "start_time": "2026-09-05T07:13:17.066977+00:00",
      "status": "completed"
     },
     "tags": []
@@ -82,24 +82,24 @@
      "output_type": "stream",
      "text": [
       "Systeme: Windows\n",
-      "Python: 3.13.3\n",
-      "Repertoire: D:\\Dev\\CoursIA\n"
+      "Python: 3.13.12\n",
+      "Repertoire de travail: 00-Foundations\n"
      ]
     }
    ],
    "source": [
     "# Detection de l'environnement\n",
     "import sys\n",
-    "import os\n",
     "import platform\n",
     "import subprocess\n",
+    "from pathlib import Path\n",
     "\n",
     "OS_NAME = platform.system()\n",
     "PYTHON_VERSION = sys.version_info\n",
     "\n",
     "print(f\"Systeme: {OS_NAME}\")\n",
     "print(f\"Python: {PYTHON_VERSION.major}.{PYTHON_VERSION.minor}.{PYTHON_VERSION.micro}\")\n",
-    "print(f\"Repertoire: {os.getcwd()}\")"
+    "print(f\"Repertoire de travail: {Path.cwd().name}\")"
    ]
   },
   {
@@ -107,10 +107,10 @@
    "id": "fad19034",
    "metadata": {
     "papermill": {
-     "duration": 0.002201,
-     "end_time": "2026-05-26T19:15:49.952590",
+     "duration": 0.001957,
+     "end_time": "2026-09-05T07:13:17.082687+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:49.950389",
+     "start_time": "2026-09-05T07:13:17.080730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -124,17 +124,19 @@
     "|-----------|--------|---------------|\n",
     "| Système | Windows | OS hôte |\n",
     "| Python | *imprimée par la cellule* — pré-requis : **3.10+** | Version Python installée |\n",
-    "| Répertoire | *imprimé par la cellule* | Chemin de la machine hôte |\n",
+    "| Répertoire | *imprimé par la cellule* | Nom du répertoire de travail (basename), identique sur toutes les machines |\n",
     "\n",
-    "Ni la version ni le chemin absolu ne sont recopiés ici : la cellule les\n",
-    "imprime tous deux, et sa sortie committée en est la source unique. Ce qui a\n",
-    "une valeur pédagogique est le **pré-requis** `3.10+` — il tient sur toutes les\n",
-    "machines, là où la version installée et le chemin du dépôt changent d'une\n",
-    "machine à l'autre (#9434).\n",
+    "Ni la version ni le nom du répertoire ne sont recopiés ici : la cellule les\n",
+    "imprime, et sa sortie committée en est la source unique. Ce qui a une valeur\n",
+    "pédagogique est le **pré-requis** `3.10+` — il tient sur toutes les machines,\n",
+    "là où la version installée change d'une machine à l'autre. Pour le répertoire,\n",
+    "la cellule n'imprime que son **basename** (`pathlib.Path.cwd().name`) : le\n",
+    "chemin absolu complet est un artefact de la machine hôte, sans valeur\n",
+    "pédagogique, qui ne doit pas figurer dans les sorties committées (#9434).\n",
     "\n",
     "**Points clés** :\n",
     "1. Le pré-requis `3.10+` est satisfait : tous les outils de la série SmartContracts sont compatibles\n",
-    "2. Le chemin absolu permet de localiser les fichiers de configuration (.env)\n",
+    "2. Le basename du répertoire de travail suffit à situer le notebook dans la série ; aucun chemin absolu de la machine hôte n'est imprimé\n",
     "3. La détection préalable évite les erreurs de compatibilité\n",
     "\n",
     "> **Note technique** : Si la version Python était < 3.10, certains packages (web3.py v7+) ne fonctionneraient pas.\n"
@@ -145,10 +147,10 @@
    "id": "6f1f3434",
    "metadata": {
     "papermill": {
-     "duration": 0.002159,
-     "end_time": "2026-05-26T19:15:49.956886",
+     "duration": 0.001958,
+     "end_time": "2026-09-05T07:13:17.086573+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:49.954727",
+     "start_time": "2026-09-05T07:13:17.084615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,16 +185,16 @@
    "id": "3e2cb95d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:49.962627Z",
-     "iopub.status.busy": "2026-05-26T19:15:49.962178Z",
-     "iopub.status.idle": "2026-05-26T19:15:50.029778Z",
-     "shell.execute_reply": "2026-05-26T19:15:50.029195Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.092015Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.091753Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.145952Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.145308Z"
     },
     "papermill": {
-     "duration": 0.071595,
-     "end_time": "2026-05-26T19:15:50.030674",
+     "duration": 0.058041,
+     "end_time": "2026-09-05T07:13:17.146573+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:49.959079",
+     "start_time": "2026-09-05T07:13:17.088532+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,20 +207,20 @@
       "Verification des outils Foundry...\n",
       "==================================================\n",
       "forge: OK\n",
-      "  forge Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n",
+      "  forge Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n",
       "cast: OK\n",
-      "  cast Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n",
+      "  cast Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n",
       "anvil: OK\n",
-      "  anvil Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n"
+      "  anvil Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n"
      ]
     }
    ],
@@ -251,10 +253,10 @@
    "id": "232e0866",
    "metadata": {
     "papermill": {
-     "duration": 0.002364,
-     "end_time": "2026-05-26T19:15:50.036144",
+     "duration": 0.002158,
+     "end_time": "2026-09-05T07:13:17.150892+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.033780",
+     "start_time": "2026-09-05T07:13:17.148734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -266,9 +268,12 @@
     "\n",
     "| Outil | Version | Statut |\n",
     "|-------|---------|--------|\n",
-    "| **forge** | 1.7.1 | OK |\n",
-    "| **cast** | 1.7.1 | OK |\n",
-    "| **anvil** | 1.7.1 | OK |\n",
+    "| **forge** | *imprimée par la cellule* | OK |\n",
+    "| **cast** | *imprimée par la cellule* | OK |\n",
+    "| **anvil** | *imprimée par la cellule* | OK |\n",
+    "\n",
+    "Les versions ne sont pas recopiées ici : la sortie de la cellule en est la\n",
+    "source unique, et elles changent d'une machine à l'autre (#9434).\n",
     "\n",
     "**Analyse des composants** :\n",
     "\n",
@@ -279,9 +284,9 @@
     "| **anvil** | Nœud Ethereum local pour développement et tests |\n",
     "\n",
     "**Points clés** :\n",
-    "1. Les trois outils partagent la même version (1.7.1) - cohérence garantie\n",
-    "2. Le build profile \"dist\" correspond à la version de distribution (release) de Foundry\n",
-    "3. Le commit SHA permet de reproduire exactement cette version si nécessaire\n",
+    "1. Les trois outils partagent la même version (visible dans la sortie) — cohérence garantie\n",
+    "2. Le build profile imprimé par la cellule indique le mode de compilation : `dist` = version de distribution (release), `maxperf` = build optimisé\n",
+    "3. Le commit SHA (visible dans la sortie) permet de reproduire exactement cette version si nécessaire\n",
     "\n",
     "> **Note technique** : Foundry est écrit en Rust, ce qui le rend beaucoup plus rapide que les outils basés sur JavaScript (comme Truffle ou Hardhat).\n"
    ]
@@ -291,10 +296,10 @@
    "id": "7bc5f7dc",
    "metadata": {
     "papermill": {
-     "duration": 0.002423,
-     "end_time": "2026-05-26T19:15:50.043169",
+     "duration": 0.002232,
+     "end_time": "2026-09-05T07:13:17.155247+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.040746",
+     "start_time": "2026-09-05T07:13:17.153015+00:00",
      "status": "completed"
     },
     "tags": []
@@ -313,16 +318,16 @@
    "id": "3a40ca73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:50.049785Z",
-     "iopub.status.busy": "2026-05-26T19:15:50.049418Z",
-     "iopub.status.idle": "2026-05-26T19:15:50.075578Z",
-     "shell.execute_reply": "2026-05-26T19:15:50.074946Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.160438Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.160245Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.181937Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.180937Z"
     },
     "papermill": {
-     "duration": 0.030896,
-     "end_time": "2026-05-26T19:15:50.076781",
+     "duration": 0.025232,
+     "end_time": "2026-09-05T07:13:17.182536+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.045885",
+     "start_time": "2026-09-05T07:13:17.157304+00:00",
      "status": "completed"
     },
     "tags": []
@@ -333,10 +338,10 @@
      "output_type": "stream",
      "text": [
       "Solidity est compile via forge build\n",
-      "Version Foundry: forge Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n"
+      "Version Foundry: forge Version: 1.5.1-stable\n",
+      "Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\n",
+      "Build Timestamp: 2025-12-22T11:40:33.870895500Z (1766403633)\n",
+      "Build Profile: maxperf\n"
      ]
     }
    ],
@@ -355,10 +360,10 @@
    "id": "a323cb3e",
    "metadata": {
     "papermill": {
-     "duration": 0.002668,
-     "end_time": "2026-05-26T19:15:50.082156",
+     "duration": 0.002005,
+     "end_time": "2026-09-05T07:13:17.186835+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.079488",
+     "start_time": "2026-09-05T07:13:17.184830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -371,7 +376,7 @@
     "| Composant | Valeur | Signification |\n",
     "|-----------|--------|---------------|\n",
     "| Foundry | OK | La suite d'outils est disponible |\n",
-    "| Version | 1.7.1 | Version stable et récente |\n",
+    "| Version | *imprimée par la cellule* | Version Foundry installée sur la machine |\n",
     "\n",
     "**Points clés** :\n",
     "1. Foundry inclut son propre compilateur `solc` (pas besoin d'installation séparée)\n",
@@ -386,10 +391,10 @@
    "id": "954c4b2f",
    "metadata": {
     "papermill": {
-     "duration": 0.00305,
-     "end_time": "2026-05-26T19:15:50.088048",
+     "duration": 0.002,
+     "end_time": "2026-09-05T07:13:17.190885+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.084998",
+     "start_time": "2026-09-05T07:13:17.188885+00:00",
      "status": "completed"
     },
     "tags": []
@@ -408,16 +413,16 @@
    "id": "a462793d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:50.096517Z",
-     "iopub.status.busy": "2026-05-26T19:15:50.095782Z",
-     "iopub.status.idle": "2026-05-26T19:15:50.101250Z",
-     "shell.execute_reply": "2026-05-26T19:15:50.100771Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.195851Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.195666Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.199652Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.199098Z"
     },
     "papermill": {
-     "duration": 0.011236,
-     "end_time": "2026-05-26T19:15:50.102525",
+     "duration": 0.007283,
+     "end_time": "2026-09-05T07:13:17.200167+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.091289",
+     "start_time": "2026-09-05T07:13:17.192884+00:00",
      "status": "completed"
     },
     "tags": []
@@ -468,10 +473,10 @@
    "id": "e7ea8e98",
    "metadata": {
     "papermill": {
-     "duration": 0.003276,
-     "end_time": "2026-05-26T19:15:50.109297",
+     "duration": 0.001977,
+     "end_time": "2026-09-05T07:13:17.204219+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.106021",
+     "start_time": "2026-09-05T07:13:17.202242+00:00",
      "status": "completed"
     },
     "tags": []
@@ -490,16 +495,16 @@
    "id": "6eb9a2f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:50.118572Z",
-     "iopub.status.busy": "2026-05-26T19:15:50.118290Z",
-     "iopub.status.idle": "2026-05-26T19:15:50.122549Z",
-     "shell.execute_reply": "2026-05-26T19:15:50.121884Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.209231Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.209067Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.212272Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.211733Z"
     },
     "papermill": {
-     "duration": 0.010886,
-     "end_time": "2026-05-26T19:15:50.123917",
+     "duration": 0.006635,
+     "end_time": "2026-09-05T07:13:17.212903+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.113031",
+     "start_time": "2026-09-05T07:13:17.206268+00:00",
      "status": "completed"
     },
     "tags": []
@@ -559,10 +564,10 @@
    "id": "0c5fc5cb",
    "metadata": {
     "papermill": {
-     "duration": 0.003571,
-     "end_time": "2026-05-26T19:15:50.130661",
+     "duration": 0.002031,
+     "end_time": "2026-09-05T07:13:17.217206+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.127090",
+     "start_time": "2026-09-05T07:13:17.215175+00:00",
      "status": "completed"
     },
     "tags": []
@@ -599,10 +604,10 @@
    "id": "ac8f8ec5",
    "metadata": {
     "papermill": {
-     "duration": 0.003568,
-     "end_time": "2026-05-26T19:15:50.138026",
+     "duration": 0.001969,
+     "end_time": "2026-09-05T07:13:17.221307+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.134458",
+     "start_time": "2026-09-05T07:13:17.219338+00:00",
      "status": "completed"
     },
     "tags": []
@@ -624,10 +629,10 @@
    "id": "a7500d9c",
    "metadata": {
     "papermill": {
-     "duration": 0.00302,
-     "end_time": "2026-05-26T19:15:50.144038",
+     "duration": 0.002021,
+     "end_time": "2026-09-05T07:13:17.225350+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.141018",
+     "start_time": "2026-09-05T07:13:17.223329+00:00",
      "status": "completed"
     },
     "tags": []
@@ -646,16 +651,16 @@
    "id": "4a1204c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:50.152119Z",
-     "iopub.status.busy": "2026-05-26T19:15:50.151581Z",
-     "iopub.status.idle": "2026-05-26T19:15:50.155889Z",
-     "shell.execute_reply": "2026-05-26T19:15:50.155199Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.230493Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.230328Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.233850Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.233179Z"
     },
     "papermill": {
-     "duration": 0.009583,
-     "end_time": "2026-05-26T19:15:50.156937",
+     "duration": 0.00677,
+     "end_time": "2026-09-05T07:13:17.234245+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.147354",
+     "start_time": "2026-09-05T07:13:17.227475+00:00",
      "status": "completed"
     },
     "tags": []
@@ -731,10 +736,10 @@
    "id": "026b3cda",
    "metadata": {
     "papermill": {
-     "duration": 0.003027,
-     "end_time": "2026-05-26T19:15:50.163211",
+     "duration": 0.002016,
+     "end_time": "2026-09-05T07:13:17.238349+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.160184",
+     "start_time": "2026-09-05T07:13:17.236333+00:00",
      "status": "completed"
     },
     "tags": []
@@ -774,10 +779,10 @@
    "id": "012c072d",
    "metadata": {
     "papermill": {
-     "duration": 0.003165,
-     "end_time": "2026-05-26T19:15:50.170034",
+     "duration": 0.002024,
+     "end_time": "2026-09-05T07:13:17.242365+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.166869",
+     "start_time": "2026-09-05T07:13:17.240341+00:00",
      "status": "completed"
     },
     "tags": []
@@ -794,16 +799,16 @@
    "id": "2c9230ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:15:50.178397Z",
-     "iopub.status.busy": "2026-05-26T19:15:50.177955Z",
-     "iopub.status.idle": "2026-05-26T19:15:50.207442Z",
-     "shell.execute_reply": "2026-05-26T19:15:50.206686Z"
+     "iopub.execute_input": "2026-09-05T07:13:17.247340Z",
+     "iopub.status.busy": "2026-09-05T07:13:17.247102Z",
+     "iopub.status.idle": "2026-09-05T07:13:17.269105Z",
+     "shell.execute_reply": "2026-09-05T07:13:17.268520Z"
     },
     "papermill": {
-     "duration": 0.034933,
-     "end_time": "2026-05-26T19:15:50.208479",
+     "duration": 0.02535,
+     "end_time": "2026-09-05T07:13:17.269654+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.173546",
+     "start_time": "2026-09-05T07:13:17.244304+00:00",
      "status": "completed"
     },
     "tags": []
@@ -817,7 +822,7 @@
       "RESUME DE L'ENVIRONNEMENT SMART CONTRACTS\n",
       "============================================================\n",
       "Systeme: Windows\n",
-      "Python: 3.13.3\n",
+      "Python: 3.13.12\n",
       "------------------------------------------------------------\n",
       "Foundry: OK\n",
       "============================================================\n",
@@ -850,10 +855,10 @@
    "id": "d12cec3c",
    "metadata": {
     "papermill": {
-     "duration": 0.002724,
-     "end_time": "2026-05-26T19:15:50.213990",
+     "duration": 0.002285,
+     "end_time": "2026-09-05T07:13:17.274261+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.211266",
+     "start_time": "2026-09-05T07:13:17.271976+00:00",
      "status": "completed"
     },
     "tags": []
@@ -866,7 +871,7 @@
     "| Composant | Statut | Détails |\n",
     "|-----------|--------|---------|\n",
     "| **Système** | Windows | OS compatible avec Foundry |\n",
-    "| **Python** | 3.13.3 | Version récente, compatible |\n",
+    "| **Python** | *imprimé par la cellule* | Pré-requis **3.10+** satisfait |\n",
     "| **Foundry** | OK | Suite d'outils installée et fonctionnelle |\n",
     "\n",
     "**État de préparation** :\n",
@@ -887,10 +892,10 @@
    "id": "6ffe3c70",
    "metadata": {
     "papermill": {
-     "duration": 0.002623,
-     "end_time": "2026-05-26T19:15:50.219285",
+     "duration": 0.001988,
+     "end_time": "2026-09-05T07:13:17.278527+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.216662",
+     "start_time": "2026-09-05T07:13:17.276539+00:00",
      "status": "completed"
     },
     "tags": []
@@ -927,10 +932,10 @@
    "id": "lm53dbk8xf",
    "metadata": {
     "papermill": {
-     "duration": 0.003144,
-     "end_time": "2026-05-26T19:15:50.225278",
+     "duration": 0.001965,
+     "end_time": "2026-09-05T07:13:17.282508+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.222134",
+     "start_time": "2026-09-05T07:13:17.280543+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1010,18 +1015,35 @@
   {
    "cell_type": "markdown",
    "id": "f406fb62",
-   "source": "## Resume et perspectives\n\nCe notebook a guide l'installation et la verification de la suite Foundry (forge, cast, anvil), l'environnement de développement moderne pour les smart contracts Ethereum. Les trois composants couvrent l'ensemble du cycle de vie : `forge` pour la compilation, les tests et le deploiement des contrats Solidity ; `cast` pour les interactions avec la blockchain depuis la ligne de commande ; et `anvil` comme noeud Ethereum local fournissant 10 comptes pre-finances pour le développement et les tests. L'ecriture de tests en Solidity natif (plutot qu'en JavaScript) est l'un des avantages majeurs de Foundry par rapport aux alternatives comme Hardhat ou Truffle.\n\nLe contrat `Hello.sol` et son test `Hello.t.sol` ont illustre les conventions fondamentales de Foundry : le pattern `setUp()` + `testXxx()` pour les tests unitaires, les assertions `assertEq()` pour la verification, et la structure de projet `src/` / `test/` / `lib/`. Le mot-cle `public` generant automatiquement un getter est un premier apercu de la magie Solidity qui sera detaillee dans les notebooks suivants. L'exercice du contrat Counter avec `increment()`, `decrement()` et `vm.expectRevert()` prepare aux patterns de test avance.\n\nL'environnement etant operationnel, le notebook suivant [SC-2-Setup-Web3py](SC-2-Setup-Web3py.ipynb) complete la chaîne d'outils en ajoutant l'interaction Python avec Ethereum via web3.py, permettant de compiler, deployer et appeler des contrats Solidity entierement depuis un notebook Jupyter.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002018,
+     "end_time": "2026-09-05T07:13:17.286461+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T07:13:17.284443+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a guide l'installation et la verification de la suite Foundry (forge, cast, anvil), l'environnement de développement moderne pour les smart contracts Ethereum. Les trois composants couvrent l'ensemble du cycle de vie : `forge` pour la compilation, les tests et le deploiement des contrats Solidity ; `cast` pour les interactions avec la blockchain depuis la ligne de commande ; et `anvil` comme noeud Ethereum local fournissant 10 comptes pre-finances pour le développement et les tests. L'ecriture de tests en Solidity natif (plutot qu'en JavaScript) est l'un des avantages majeurs de Foundry par rapport aux alternatives comme Hardhat ou Truffle.\n",
+    "\n",
+    "Le contrat `Hello.sol` et son test `Hello.t.sol` ont illustre les conventions fondamentales de Foundry : le pattern `setUp()` + `testXxx()` pour les tests unitaires, les assertions `assertEq()` pour la verification, et la structure de projet `src/` / `test/` / `lib/`. Le mot-cle `public` generant automatiquement un getter est un premier apercu de la magie Solidity qui sera detaillee dans les notebooks suivants. L'exercice du contrat Counter avec `increment()`, `decrement()` et `vm.expectRevert()` prepare aux patterns de test avance.\n",
+    "\n",
+    "L'environnement etant operationnel, le notebook suivant [SC-2-Setup-Web3py](SC-2-Setup-Web3py.ipynb) complete la chaîne d'outils en ajoutant l'interaction Python avec Ethereum via web3.py, permettant de compiler, deployer et appeler des contrats Solidity entierement depuis un notebook Jupyter."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e169ec75",
    "metadata": {
     "papermill": {
-     "duration": 0.003418,
-     "end_time": "2026-05-26T19:15:50.231979",
+     "duration": 0.001989,
+     "end_time": "2026-09-05T07:13:17.290698+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:15:50.228561",
+     "start_time": "2026-09-05T07:13:17.288709+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1035,9 +1057,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "name": "python3",
    "display_name": "Python 3",
-   "language": "python"
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1049,18 +1071,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.305612,
-   "end_time": "2026-05-26T19:15:50.473330",
+   "duration": 2.202395,
+   "end_time": "2026-09-05T07:13:17.520836+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb",
    "output_path": "SC-1-Setup-Foundry.ipynb",
    "parameters": {},
-   "start_time": "2026-05-26T19:15:48.167718",
+   "start_time": "2026-09-05T07:13:15.318441+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: DEEP/research-code #14608

## Summary

- replace the absolute `os.getcwd()` output in SC-1 with the stable notebook-directory basename from `Path.cwd().name`
- remove stale environment observations from the three interpretation cells that fresh execution proved divergent; structural requirements such as Python `3.10+` and Solidity `^0.8.28` remain
- re-execute all seven Python cells through the real `smartcontracts` kernel with Foundry available, committing the genuine outputs

See #9434

## Diagnostic drift

**CAUSE_FIXED** — the environment-detection source printed the host's full current working directory, so every execution committed a machine-specific path. Fresh execution also demonstrated why observed versions must not be copied into markdown: this machine reports Python 3.13.12 and Foundry 1.5.1-stable, while the old prose pinned Python 3.13.3 and Foundry 1.7.1. The source now emits only the basename `00-Foundations`; interpretation prose uses the executed output as its single source of truth rather than re-pinning either environment.

## Real execution

Canonical command:

```text
python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb --kernel smartcontracts --cwd MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations --verbose
```

Result: `SUCCESS`, 1/1 notebook, 3.3 s. The `smartcontracts` kernelspec exposed the installed real Foundry binaries; `forge`, `cast`, and `anvil` were all detected as `OK`. No mock, fallback, or hand-edited output was used.

## Validation

- `validate_pr_notebooks.py`: 1/1 passed, 7/7 code cells
- execution counts: clean 1..7; every code cell has one output; zero error outputs
- output-failure ratchet: regressions 0; `MACHINE_PATH 1 -> 0`
- `scan_cell_ordering.py`: 0 findings
- `check_interp_positioning.py`: 0 misplaced interpretation cells
- `scan_enrich_quality.py --base origin/main`: 0 findings
- quantitative classifier: ENV-DEP 12 -> 6; six residuals are structural keepers (`3.10+` and `0.8.28`); MACHINE-DEP 0, STOCH 0
- banned deliberate-error patterns: 0
- `git diff --check`: passed
- scope: exactly one notebook; catalogue, READMEs, submodules, and generated markers untouched

## SOTA verdict

**SOTA-OK** — the notebook executes against the installed Foundry toolchain through its canonical kernel. The committed output is the real execution result; the repair removes the source of the host-path disclosure rather than scrubbing the output afterward.