### PR TITLE
feat(qc): consolidate aggregate sales growth sizing

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
@@ -50,12 +50,12 @@ Fenetre, couts et capital strictement identiques pour les deux bras :
   pour fournir a la variance les 10 annees de l'article plus une marge
   avant le premier echange.
 - **Entrainement/warmup** : 2007-01 -> 2017-12. Le bras ASG accumule ses
-  series mensuelles - 131 valeurs d'ASG (2007-02 -> 2017-12) et 130
-  rendements excedentaires (2007-03 -> 2017-12 ; le warm-up de 35 jours
-  avale les evenements de janvier et fevrier 2007) - de sorte que la
-  variance 120 mois de l'article est PLEINE des le premier echange de
-  janvier 2018 (fenetre pleine + ~10 mois de marge). Le bras baseline
-  n'echange pas : aucun des deux bras n'echange.
+  series mensuelles : au premier echange de janvier 2018, au moins 130
+  valeurs d'ASG et au moins 129 rendements excedentaires sont disponibles
+  (bornes conservatives, valables meme si le warm-up de 35 jours ignorait
+  les evenements de janvier et fevrier 2007) - la variance 120 mois de
+  l'article est donc PLEINE des le premier echange, avec de la marge. Le
+  bras baseline n'echange pas : aucun des deux bras n'echange.
 - **OOS** : 2018-01 -> 2025-01 (84 evenements mensuels ou les deux bras
   tradent). Les metriques pleine periode partagent le meme prefixe plat
   2007-2017 (100 % cash) : la comparaison directe reste valide.
@@ -65,11 +65,12 @@ Fenetre, couts et capital strictement identiques pour les deux bras :
 - **Garde-fou variance (amendement audit pre-PR)** : la premiere version
   de l'experimentation (v1, fenetre 2012-2025) tolerait une variance
   estimee sur seulement 60 mois (`MIN_VARIANCE_OBSERVATIONS = 60`), ce qui
-  laissait le bras ASG echanger des 71 rendements - un relachement de la
-  mecanique de l'article, corrige : la variance exige desormais la fenetre
-  PLEINE de 120 mois (`MIN_VARIANCE_OBSERVATIONS = VARIANCE_WINDOW`), et
-  les deux bras ont ete relances (v2) sur la fenetre 2007-2025. Les
-  metriques v1 ci-dessous sont conservees uniquement pour tracabilite.
+  laissait le bras ASG echanger avant que la fenetre pleine ne soit
+  remplie - un relachement de la mecanique de l'article, corrige : la
+  variance exige desormais la fenetre PLEINE de 120 mois
+  (`MIN_VARIANCE_OBSERVATIONS = VARIANCE_WINDOW`), et les deux bras ont
+  ete relances (v2) sur la fenetre 2007-2025. Les metriques v1 ci-dessous
+  sont conservees uniquement pour tracabilite.
 - **Bug latent corrige** : le clone local portait
   `set_brokerage_model(INTERACTIVE_BROKERS...)`, qui rejette les cibles
   Crypto ("Unsupported security type: Crypto", erreur runtime constatee au

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
@@ -45,16 +45,31 @@ OLS retarde, variance 120 mois, bornes de poids) sont extraites dans
 
 Fenetre, couts et capital strictement identiques pour les deux bras :
 
-- **Fenetre fixe** : 2012-01-01 -> 2025-01-01 (capital 100 000 USD, benchmark SPY).
-- **Entrainement/warmup** : 2012-01 -> 2017-12. Le bras ASG accumule ses
-  series mensuelles (72 mois d'ASG, 71 rendements excedentaires) ; le bras
-  baseline n'echange pas. Aucun des deux bras n'echange.
+- **Fenetre fixe** : 2007-01-01 -> 2025-01-01 (capital 100 000 USD,
+  benchmark SPY). Amendement audit pre-PR : la fenetre demarre en 2007
+  pour fournir a la variance les 10 annees de l'article plus une marge
+  avant le premier echange.
+- **Entrainement/warmup** : 2007-01 -> 2017-12. Le bras ASG accumule ses
+  series mensuelles - 131 valeurs d'ASG (2007-02 -> 2017-12) et 130
+  rendements excedentaires (2007-03 -> 2017-12 ; le warm-up de 35 jours
+  avale les evenements de janvier et fevrier 2007) - de sorte que la
+  variance 120 mois de l'article est PLEINE des le premier echange de
+  janvier 2018 (fenetre pleine + ~10 mois de marge). Le bras baseline
+  n'echange pas : aucun des deux bras n'echange.
 - **OOS** : 2018-01 -> 2025-01 (84 evenements mensuels ou les deux bras
   tradent). Les metriques pleine periode partagent le meme prefixe plat
-  2012-2017 (100 % cash) : la comparaison directe reste valide.
+  2007-2017 (100 % cash) : la comparaison directe reste valide.
 - **Couts** : brokerage par defaut QC pour les deux bras (modeles de frais
   QC identiques, fills par defaut, aucun modele de slippage explicite -
   l'article #21132 n'en annonce pas non plus).
+- **Garde-fou variance (amendement audit pre-PR)** : la premiere version
+  de l'experimentation (v1, fenetre 2012-2025) tolerait une variance
+  estimee sur seulement 60 mois (`MIN_VARIANCE_OBSERVATIONS = 60`), ce qui
+  laissait le bras ASG echanger des 71 rendements - un relachement de la
+  mecanique de l'article, corrige : la variance exige desormais la fenetre
+  PLEINE de 120 mois (`MIN_VARIANCE_OBSERVATIONS = VARIANCE_WINDOW`), et
+  les deux bras ont ete relances (v2) sur la fenetre 2007-2025. Les
+  metriques v1 ci-dessous sont conservees uniquement pour tracabilite.
 - **Bug latent corrige** : le clone local portait
   `set_brokerage_model(INTERACTIVE_BROKERS...)`, qui rejette les cibles
   Crypto ("Unsupported security type: Crypto", erreur runtime constatee au
@@ -63,20 +78,33 @@ Fenetre, couts et capital strictement identiques pour les deux bras :
   la ligne est retiree pour les deux bras, conformement au commentaire
   d'origine de la strategie (multi-actifs : aucun broker reel unique).
 
-## Metriques backtest (QC Cloud, 2026-09-05)
+## Metriques backtest v2 (QC Cloud, 2026-09-05)
 
 Projet `MacroFactorRotation-ASG-14722` (ID 36141780), compile
-`b9fc7f7c5a6e18d802c921396df1de6e`, une execution par bras, statut
-Completed (progress 1).
+`3f91dbe0544942bce2c7a47ea73cbb97-1748601bd97343c8210c636f8add2b34`
+(code amendement 120 mois), une execution par bras, statut Completed
+(progress 1), parametres `mode=baseline|asg`, `start_date=20070101`,
+`end_date=20250101`, `trading_start=20180101`.
 
-| Metrique | Bras baseline (7877e24091314e0b65ffe7a3f8b4d1da) | Bras ASG (5500f1749e4f16776759ab7433558a0d) |
+| Metrique | Bras baseline (53f10a127e160966176247f2018e68bc) | Bras ASG (149b8c44c0eaf887395e697e50da38e1) |
 |----------|------------|-----------|
-| Sharpe Ratio | 0.325 | 0.404 |
-| CAGR | 8.047 % | 10.214 % |
+| Sharpe Ratio | 0.227 | 0.234 |
+| CAGR | 5.750 % | 5.643 % |
 | Max Drawdown | 41.900 % | 47.800 % |
-| Profit net total | 173.809 % | 254.446 % |
-| Ordres | 261 | 150 |
-| PSR | 0.157 % | 0.413 % |
+| Profit net total | 173.809 % | 168.841 % |
+| Ordres | 261 | 139 |
+| PSR | 0.004 % | 0.005 % |
+
+Controle de validite : le bras baseline v2 produit exactement les memes
+trades que v1 (261 ordres, profit net 173.809 % identiques) - l'extension
+2007-2012 ne fait qu'allonger le prefixe plat en cash, comme prevu.
+
+Metriques v1 supersedees (fenetre 2012-2025, variance tolerait 60 mois ;
+backtests 7877e240 / 5500f174, compile b9fc7f7c) : baseline Sharpe 0.325,
+CAGR 8.047 %, MaxDD 41.900 % ; ASG Sharpe 0.404, CAGR 10.214 %, MaxDD
+47.800 %. L'apparent avantage de Sharpe du bras ASG en v1 etait un artefact
+du relachement de la fenetre de variance : avec la mecanique exacte de
+l'article (variance 120 mois pleine), il disparait.
 
 Reference : baseline deployee non contrainte (projet 32730301, backtest
 `a99c2b6ad7c4a0ffe94bc70484170b56`, fenetre propre 10 ans) : Sharpe 0.731,
@@ -85,23 +113,26 @@ CAGR 22.626 %, MaxDD 42.000 % - chiffres non comparables aux bras alignes
 
 ## Verdict : INCONCLUSIVE
 
-Lecture descriptive : sur la meme fenetre alignee, le bras ASG affiche un
-Sharpe (0.404 vs 0.325) et un CAGR (10.2 % vs 8.0 %) superieurs, mais un
-drawdown plus profond (47.8 % vs 41.9 %), coherent avec son exposition SPY
-pouvant atteindre 150 %. Aucune amelioration statistiquement etablie n'est
-revendiquee : comparaison sur une seule fenetre, PSR des deux bras tres
-loin de tout seuil de confiance (0.16 % et 0.41 %), et pas de protocole
-multi-seed / Diebold-Mariano. Les deux bras sont deterministes (pas de
-graine a varier), le protocole BEATS strict ne s'applique donc pas ; le
-verdict honnete reste INCONCLUSIVE, avec un cout en drawdown a documenter
-pour toute suite donnee au sizing ASG.
+Lecture descriptive : sur la fenetre alignee 2007-2025 avec la mecanique
+exacte de l'article (variance 120 mois pleine), les deux bras sont
+statistiquement indiscernables - Sharpe 0.234 vs 0.227, CAGR 5.6 % vs
+5.8 % - et le bras ASG conserve un drawdown plus profond (47.8 % vs
+41.9 %), coherent avec son exposition SPY pouvant atteindre 150 %. Aucune
+amelioration statistiquement etablie n'est revendiquee : comparaison sur
+une seule fenetre, PSR des deux bras tres loin de tout seuil de confiance
+(0.004 % et 0.005 %), et pas de protocole multi-seed / Diebold-Mariano.
+Les deux bras sont deterministes (pas de graine a varier), le protocole
+BEATS strict ne s'applique donc pas ; le verdict honnete reste
+INCONCLUSIVE. Le resultat v1 (Sharpe ASG 0.404 vs 0.325) illustre au
+passage la sensibilite du sizing a la fenetre de variance - motivation
+supplementaire pour ne pas revendiquer d'edge sur cet echantillon.
 
 ## How to Run
 
 **Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC"`
 **QC Cloud :** copier `main.py` + `asg_helpers.py` dans un projet Py, puis
 lancer deux backtests avec les parametres `mode=baseline|asg`,
-`start_date=20120101`, `end_date=20250101`, `trading_start=20180101`.
+`start_date=20070101`, `end_date=20250101`, `trading_start=20180101`.
 **Tests locaux :** `python -m pytest tests/test_asg_helpers.py` depuis le
 dossier du projet.
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
@@ -1,31 +1,119 @@
 # MacroFactorRotation-QC
 
-**Asset class:** Multi-Asset (factor rotation)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Multi-actifs (rotation macro et sizing d'exposition)
+**Projets cloud QC :** `MacroFactorRotation-QC` (ID 32730301, original) ; `MacroFactorRotation-ASG-14722` (ID 36141780, experimentation alignee de l'issue #14722)
 
 ## Description
 
-QC Strategy Library clone. Macro factor rotation rotating between asset classes based on macroeconomic indicators.
+Consolidation experimentale (issue #14722) du projet de rotation macro : la
+baseline DecisionTree est preservee a l'identique, et une variante de
+controle ASG (Aggregate Sales Growth) ajoutee comme bras de comparaison sur
+une fenetre alignee. Un seul fichier `main.py`, une seule classe
+`MacroFactorRotationAlgorithm` pilotee par le parametre `mode`.
+
+## Architecture
+
+| Bras | Parametre | Mecanique |
+|------|-----------|-----------|
+| Baseline (defaut) | `mode=baseline` | Rotation macro multi-actifs SPY/GLD/BND/BTCUSD selon VIX, courbe 10Y-3M et fed funds, `DecisionTreeRegressor` reentraine mensuellement, 150 % d'exposition brute, BTC plafonne a 10 % (QC Strategy Library #72, logique d'origine inchangee) |
+| ASG | `mode=asg` | Sizing d'exposition SPY/BIL de l'article QC research #21132 : ASG mensuelle (croissance annuelle du CA winsorisee 1/99, ponderee par capitalisation, univers USA primaires hors Financial Services / Real Estate), regression OLS a fenetre croissante du rendement excedentaire mensuel de SPY sur l'ASG retardée d'un mois, prevision `alpha + beta*ASG`, exposition `clip(forecast/(3*variance_120m), 0, 1.5)`, reliquat en BIL |
+
+Parametres optionnels communs (alignement de l'experimentation) :
+`start_date`, `end_date`, `trading_start` (format YYYYMMDD). Sans ces
+parametres, le bras baseline reproduit le comportement d'origine.
+
+Les fonctions pures du bras ASG (winsorisation, agregation cap-ponderee,
+OLS retarde, variance 120 mois, bornes de poids) sont extraites dans
+`asg_helpers.py` (aucune dependance LEAN) et couvertes par
+`tests/test_asg_helpers.py` (9 tests pytest, executions locales vertes).
+
+## Provenance
+
+- **Baseline** : QC Strategy Library #72, "Monthly Macro Factor Cross-Asset
+  Rotation" de Derek Melchin, clone 2026-04-05. Metriques annoncees par la
+  bibliotheque : Sharpe OOS 1Y 1.23, CAGR 5Y 33.45 %, MaxDD 27.60 %.
+- **Bras ASG** : QC research #21132, "Sizing Market Exposure With Aggregate
+  Sales Growth" de Derek Melchin (juillet 2026). L'article rapporte Sharpe
+  0.753 contre 0.412 pour SPY sur juillet 2021 - juillet 2026, sans modele
+  explicite de frais/slippage, et qualifie lui-meme sa robustesse
+  parametrique d'instable sur cet echantillon court (moyenne de grille
+  0.670, fenetre 11 ans a 0.55). Source primaire : Garfinkel, Hribar &
+  Hsiao (2025), "Aggregate Sales Growth and Stock Market Returns"
+  (SSRN 5066654), archivee hors Git dans `G:\Mon Drive\MyIA\IA\Bibliographie IA\Trading\`.
+
+## Experimentation alignee #14722
+
+Fenetre, couts et capital strictement identiques pour les deux bras :
+
+- **Fenetre fixe** : 2012-01-01 -> 2025-01-01 (capital 100 000 USD, benchmark SPY).
+- **Entrainement/warmup** : 2012-01 -> 2017-12. Le bras ASG accumule ses
+  series mensuelles (72 mois d'ASG, 71 rendements excedentaires) ; le bras
+  baseline n'echange pas. Aucun des deux bras n'echange.
+- **OOS** : 2018-01 -> 2025-01 (84 evenements mensuels ou les deux bras
+  tradent). Les metriques pleine periode partagent le meme prefixe plat
+  2012-2017 (100 % cash) : la comparaison directe reste valide.
+- **Couts** : brokerage par defaut QC pour les deux bras (modeles de frais
+  QC identiques, fills par defaut, aucun modele de slippage explicite -
+  l'article #21132 n'en annonce pas non plus).
+- **Bug latent corrige** : le clone local portait
+  `set_brokerage_model(INTERACTIVE_BROKERS...)`, qui rejette les cibles
+  Crypto ("Unsupported security type: Crypto", erreur runtime constatee au
+  premier backtest v1). Le projet cloud d'origine (32730301) tourne sans
+  brokerage model depuis le precedent "brokerage-fix-v2" (2026-06-10) ;
+  la ligne est retiree pour les deux bras, conformement au commentaire
+  d'origine de la strategie (multi-actifs : aucun broker reel unique).
+
+## Metriques backtest (QC Cloud, 2026-09-05)
+
+Projet `MacroFactorRotation-ASG-14722` (ID 36141780), compile
+`b9fc7f7c5a6e18d802c921396df1de6e`, une execution par bras, statut
+Completed (progress 1).
+
+| Metrique | Bras baseline (7877e24091314e0b65ffe7a3f8b4d1da) | Bras ASG (5500f1749e4f16776759ab7433558a0d) |
+|----------|------------|-----------|
+| Sharpe Ratio | 0.325 | 0.404 |
+| CAGR | 8.047 % | 10.214 % |
+| Max Drawdown | 41.900 % | 47.800 % |
+| Profit net total | 173.809 % | 254.446 % |
+| Ordres | 261 | 150 |
+| PSR | 0.157 % | 0.413 % |
+
+Reference : baseline deployee non contrainte (projet 32730301, backtest
+`a99c2b6ad7c4a0ffe94bc70484170b56`, fenetre propre 10 ans) : Sharpe 0.731,
+CAGR 22.626 %, MaxDD 42.000 % - chiffres non comparables aux bras alignes
+(fenetre et prefixe plat differents), cites pour la tracabilite.
+
+## Verdict : INCONCLUSIVE
+
+Lecture descriptive : sur la meme fenetre alignee, le bras ASG affiche un
+Sharpe (0.404 vs 0.325) et un CAGR (10.2 % vs 8.0 %) superieurs, mais un
+drawdown plus profond (47.8 % vs 41.9 %), coherent avec son exposition SPY
+pouvant atteindre 150 %. Aucune amelioration statistiquement etablie n'est
+revendiquee : comparaison sur une seule fenetre, PSR des deux bras tres
+loin de tout seuil de confiance (0.16 % et 0.41 %), et pas de protocole
+multi-seed / Diebold-Mariano. Les deux bras sont deterministes (pas de
+graine a varier), le protocole BEATS strict ne s'applique donc pas ; le
+verdict honnete reste INCONCLUSIVE, avec un cout en drawdown a documenter
+pour toute suite donnee au sizing ASG.
 
 ## How to Run
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
-
-## Backtest Metrics
-
-| Metric | Value |
-|--------|-------|
-| Sharpe Ratio | 1.23 |
-| CAGR | 33.45% |
-| Max Drawdown | 27.60% |
-| Source | QC Strategy Library clone |
-| Note | Metrics from original library, not locally reproduced |
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC"`
+**QC Cloud :** copier `main.py` + `asg_helpers.py` dans un projet Py, puis
+lancer deux backtests avec les parametres `mode=baseline|asg`,
+`start_date=20120101`, `end_date=20250101`, `trading_start=20180101`.
+**Tests locaux :** `python -m pytest tests/test_asg_helpers.py` depuis le
+dossier du projet.
 
 ## Files
 
-- main.py - Strategy (QC Library clone)
+- `main.py` - strategie deux bras (baseline preservee + variante ASG)
+- `asg_helpers.py` - fonctions pures ASG (winsorisation, agregation, OLS, variance, bornes)
+- `tests/test_asg_helpers.py` - tests pytest locaux (9 tests)
 
 ## References
 
-- QuantConnect Strategy Library
+- [QC research #21132 - Sizing Market Exposure With Aggregate Sales Growth](https://www.quantconnect.com/research/21132/sizing-market-exposure-with-aggregate-sales-growth/)
+- Garfinkel, Hribar & Hsiao (2025), Aggregate Sales Growth and Stock Market Returns, SSRN 5066654
+- [QC Strategy Library #72 - Monthly Macro Factor Cross-Asset Rotation](https://www.quantconnect.com/strategies/72)
+- Issue #14722 (verdict CONSOLIDATION, label quantconnect-research)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/asg_helpers.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/asg_helpers.py
@@ -27,11 +27,14 @@ VARIANCE_WINDOW = 120  # mois (10 ans)
 MIN_WEIGHT = 0.0
 MAX_WEIGHT = 1.5
 
-# Garde-fous robustesse (choix #14722, l'article n'en fixe pas) :
-# nombre minimal d'observations appariees / de mois de variance avant
-# qu'un poids autre que 100 % BIL puisse etre emis.
+# Garde-fous robustesse (#14722, amendement audit pre-PR) :
+# - la variance exige la fenetre PLEINE de 120 mois de l'article
+#   (Variance(10*12)) : aucun echange avant qu'elle ne soit remplie ;
+# - plancher d'observations appariees pour l'OLS expanding (l'article
+#   n'en fixe pas ; ne lie pas dans l'experimentation, 130 paires au
+#   premier echange).
 MIN_FIT_OBSERVATIONS = 60
-MIN_VARIANCE_OBSERVATIONS = 60
+MIN_VARIANCE_OBSERVATIONS = VARIANCE_WINDOW
 
 
 def winsorize(
@@ -111,9 +114,11 @@ def trailing_variance(
 ) -> Optional[float]:
     """Variance echantillon (ddof=1) des derniers `window` mois.
 
-    Equivalent pandas de l'indicateur Variance(10*12) de l'article une
-    fois la fenetre remplie. Renvoie None sous le seuil minimal
-    d'observations ou si la variance est non finie / nulle.
+    Equivalent pandas de l'indicateur Variance(10*12) de l'article.
+    Par defaut, exige la fenetre PLEINE (min_observations = window,
+    amendement audit #14722) : une variance estimee sur moins de 120
+    mois ne correspond pas a la mecanique de l'article et renvoie None.
+    Renvoie egalement None si la variance est non finie / nulle.
     """
     if excess_returns.empty:
         return None

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/asg_helpers.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/asg_helpers.py
@@ -1,0 +1,162 @@
+"""Fonctions pures du bras ASG (Aggregate Sales Growth) - MacroFactorRotation-QC.
+
+Extraites de main.py pour etre testees localement sans aucune dependance
+LEAN/QuantConnect. Mecaniques conformes a l'article QC research #21132
+"Sizing Market Exposure With Aggregate Sales Growth" (Derek Melchin,
+juillet 2026), lui-meme fonde sur Garfinkel, Hribar & Hsiao (2025),
+"Aggregate Sales Growth and Stock Market Returns" (SSRN 5066654) :
+
+- croissance annuelle du chiffre d'affaires, winsorisee 1 % / 99 % en
+  coupe transversale, agregee par pondération de capitalisation ;
+- regression OLS a fenetre croissante du rendement excédentaire mensuel
+  de SPY sur l'ASG retardée d'un mois (convention shift(1, freq="M") ;
+- exposition clip(forecast / (gamma * variance), 0, 1.5) avec gamma = 3
+  et variance des 120 derniers rendements excédentaires mensuels.
+"""
+
+from typing import Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+# Constantes de l'article #21132 (garde-fous decrits dans l'issue #14722).
+WINSOR_LOWER_Q = 0.01
+WINSOR_UPPER_Q = 0.99
+GAMMA = 3.0
+VARIANCE_WINDOW = 120  # mois (10 ans)
+MIN_WEIGHT = 0.0
+MAX_WEIGHT = 1.5
+
+# Garde-fous robustesse (choix #14722, l'article n'en fixe pas) :
+# nombre minimal d'observations appariees / de mois de variance avant
+# qu'un poids autre que 100 % BIL puisse etre emis.
+MIN_FIT_OBSERVATIONS = 60
+MIN_VARIANCE_OBSERVATIONS = 60
+
+
+def winsorize(
+    values: pd.Series,
+    lower_q: float = WINSOR_LOWER_Q,
+    upper_q: float = WINSOR_UPPER_Q,
+) -> pd.Series:
+    """Ecrete la coupe transversale aux quantiles lower_q / upper_q."""
+    if values.empty:
+        return values
+    lower, upper = values.quantile([lower_q, upper_q])
+    return values.clip(lower, upper)
+
+
+def aggregate_sales_growth(
+    growth: pd.Series, market_cap: pd.Series
+) -> Optional[float]:
+    """ASG mensuelle : moyenne des croissances winsorisees, ponderee par cap.
+
+    Ne contribuent que les firmes avec capitalisation positive non nulle
+    et croissance observee (mecanique de l'article #21132). Renvoie None
+    si aucune observation exploitable.
+    """
+    firms = pd.concat(
+        [growth.rename("growth"), market_cap.rename("market_cap")], axis=1
+    ).dropna(subset=["growth"])
+    if firms.empty:
+        return None
+    firms["growth"] = winsorize(firms["growth"])
+    usable = firms["market_cap"].notna() & (firms["market_cap"] > 0)
+    firms = firms[usable]
+    if firms.empty:
+        return None
+    total_cap = firms["market_cap"].sum()
+    if not np.isfinite(total_cap) or total_cap <= 0:
+        return None
+    return float(np.average(firms["growth"], weights=firms["market_cap"]))
+
+
+def fit_expanding_ols(
+    asg: pd.Series,
+    excess_returns: pd.Series,
+    min_observations: int = 2,
+) -> Optional[Tuple[float, float]]:
+    """OLS fenetre croissante du rendement excédentaire sur l'ASG retardée.
+
+    Reproduit la construction de l'article : X = asg.shift(1, freq="M")
+    aligne (jointure interne) sur la serie des rendements excédentaires
+    mensuels realises, puis ajustement polynomial de degre 1 via
+    np.polynomial.polynomial.polyfit (coefficient en degre croissant :
+    renvoie (alpha, beta)).
+
+    Renvoie None si moins de min_observations paires exploitables ou si
+    l'ajustement echoue / diverge.
+    """
+    if asg.empty or excess_returns.empty:
+        return None
+    x, y = asg.shift(1, freq="M").align(excess_returns, join="inner")
+    paired = pd.concat([x.rename("x"), y.rename("y")], axis=1).dropna()
+    if len(paired) < max(2, min_observations):
+        return None
+    try:
+        alpha, beta = np.polynomial.polynomial.polyfit(
+            paired["x"], paired["y"], 1
+        )
+    except Exception:
+        return None
+    if not (np.isfinite(alpha) and np.isfinite(beta)):
+        return None
+    return float(alpha), float(beta)
+
+
+def trailing_variance(
+    excess_returns: pd.Series,
+    window: int = VARIANCE_WINDOW,
+    min_observations: int = MIN_VARIANCE_OBSERVATIONS,
+) -> Optional[float]:
+    """Variance echantillon (ddof=1) des derniers `window` mois.
+
+    Equivalent pandas de l'indicateur Variance(10*12) de l'article une
+    fois la fenetre remplie. Renvoie None sous le seuil minimal
+    d'observations ou si la variance est non finie / nulle.
+    """
+    if excess_returns.empty:
+        return None
+    tail = excess_returns.dropna().tail(window)
+    if len(tail) < min_observations:
+        return None
+    variance = float(tail.var())
+    if not np.isfinite(variance) or variance <= 0:
+        return None
+    return variance
+
+
+def forecast_excess_return(
+    fit: Optional[Tuple[float, float]], current_asg: Optional[float]
+) -> Optional[float]:
+    """Prevision alpha + beta * ASG courante (entree de l'article #21132)."""
+    if fit is None or current_asg is None:
+        return None
+    if not np.isfinite(current_asg):
+        return None
+    alpha, beta = fit
+    value = alpha + beta * float(current_asg)
+    return float(value) if np.isfinite(value) else None
+
+
+def solve_exposure(
+    forecast: Optional[float],
+    variance: Optional[float],
+    gamma: float = GAMMA,
+    min_weight: float = MIN_WEIGHT,
+    max_weight: float = MAX_WEIGHT,
+) -> float:
+    """Poids SPY w = clip(forecast / (gamma * variance), min, max).
+
+    Entrees invalides (None, variance <= 0, NaN) -> min_weight (100 % BIL),
+    garde-fou #14722 : l'article diviserait par une variance d'indicateur
+    non prete (division par zero), on reste ici entierement en T-bills.
+    """
+    if forecast is None or variance is None:
+        return min_weight
+    if not (np.isfinite(forecast) and np.isfinite(variance)):
+        return min_weight
+    if variance <= 0:
+        return min_weight
+    w_star = forecast / (gamma * variance)
+    return float(np.clip(w_star, min_weight, max_weight))

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/asg_helpers.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/asg_helpers.py
@@ -9,7 +9,7 @@ juillet 2026), lui-meme fonde sur Garfinkel, Hribar & Hsiao (2025),
 - croissance annuelle du chiffre d'affaires, winsorisee 1 % / 99 % en
   coupe transversale, agregee par pondération de capitalisation ;
 - regression OLS a fenetre croissante du rendement excédentaire mensuel
-  de SPY sur l'ASG retardée d'un mois (convention shift(1, freq="M") ;
+  de SPY sur l'ASG retardée d'un mois (convention shift(1, freq="M")) ;
 - exposition clip(forecast / (gamma * variance), 0, 1.5) avec gamma = 3
   et variance des 120 derniers rendements excédentaires mensuels.
 """
@@ -31,8 +31,9 @@ MAX_WEIGHT = 1.5
 # - la variance exige la fenetre PLEINE de 120 mois de l'article
 #   (Variance(10*12)) : aucun echange avant qu'elle ne soit remplie ;
 # - plancher d'observations appariees pour l'OLS expanding (l'article
-#   n'en fixe pas ; ne lie pas dans l'experimentation, 130 paires au
-#   premier echange).
+#   n'en fixe pas ; ne lie pas dans l'experimentation, au moins 129
+#   paires appariees au premier echange - borne conservative, review
+#   finale #14722).
 MIN_FIT_OBSERVATIONS = 60
 MIN_VARIANCE_OBSERVATIONS = VARIANCE_WINDOW
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/main.py
@@ -40,11 +40,15 @@ import asg_helpers
 # localement dans tests/test_asg_helpers.py.
 #
 # Experimentation alignee #14722 (les deux bras, parametres passes au
-# backtest) : start_date=20120101, end_date=20250101, trading_start=20180101,
+# backtest) : start_date=20070101, end_date=20250101, trading_start=20180101,
 # capital 100 000 USD, brokerage par defaut QC (frais/fills identiques),
 # benchmark SPY. Periode
-# d'entrainement/warmup 2012-01 -> 2017-12 (le bras ASG accumule ses series
-# mensuelles, le bras baseline n'echange pas), periode OOS 2018-01 -> 2025-01
+# d'entrainement/warmup 2007-01 -> 2017-12 : le bras ASG accumule ses series
+# mensuelles (131 valeurs d'ASG, 130 rendements excedentaires au premier
+# echange ; le warm-up de 35 jours avale les evenements de janv/ferv 2007)
+# et sa variance 120 mois est PLEINE des le premier echange de janvier 2018
+# (fenetre de l'article + ~10 mois de marge, amendement audit pre-PR), le
+# bras baseline n'echange pas. Periode OOS 2018-01 -> 2025-01
 # ou les deux bras echangent. Sans ces parametres, le comportement par
 # defaut reproduit la baseline d'origine.
 # ============================================================================

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/main.py
@@ -44,10 +44,11 @@ import asg_helpers
 # capital 100 000 USD, brokerage par defaut QC (frais/fills identiques),
 # benchmark SPY. Periode
 # d'entrainement/warmup 2007-01 -> 2017-12 : le bras ASG accumule ses series
-# mensuelles (131 valeurs d'ASG, 130 rendements excedentaires au premier
-# echange ; le warm-up de 35 jours avale les evenements de janv/ferv 2007)
+# mensuelles (au moins 130 valeurs d'ASG et au moins 129 rendements
+# excedentaires au premier echange, borne conservative valable meme si le
+# warm-up de 35 jours ignorait les evenements de janvier et fevrier 2007)
 # et sa variance 120 mois est PLEINE des le premier echange de janvier 2018
-# (fenetre de l'article + ~10 mois de marge, amendement audit pre-PR), le
+# (fenetre de l'article + marge, amendement audit pre-PR), le
 # bras baseline n'echange pas. Periode OOS 2018-01 -> 2025-01
 # ou les deux bras echangent. Sans ces parametres, le comportement par
 # defaut reproduit la baseline d'origine.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/main.py
@@ -3,24 +3,107 @@ from AlgorithmImports import *
 
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.preprocessing import StandardScaler
+
+import asg_helpers
 # endregion
+# ============================================================================
+# Bras "baseline" (mode="baseline", defaut) - QC Strategy Library #72 clone :
 # https://www.quantconnect.com/strategies/72
 # Monthly Macro Factor Cross-Asset Rotation by Derek Melchin
-# 1Y OOS Sharpe 1.23, 5Y CAGR 33.45%, 5Y Drawdown 27.60%, 71% Win Rate, 163 Followers
-# Macro factor driven cross-asset rotation: SPY, GLD, BND, BTCUSD
-# Uses VIX, 10Y-3M yield curve, fed funds rate as ML features
-# DecisionTreeRegressor with monthly retraining, 150% gross exposure, BTC capped 10%
-# Source: QC Strategy Library #72, cloned 2026-04-05, QC Project ID: 29687828
+# 1Y OOS Sharpe 1.23, 5Y CAGR 33.45%, 5Y Drawdown 27.60%, 71% Win Rate
+# Rotation multi-actifs SPY/GLD/BND/BTCUSD pilotee par VIX, courbe 10Y-3M et
+# fed funds ; DecisionTreeRegressor avec reentrainement mensuel, 150 %
+# d'exposition brute, BTC plafonne a 10 %. Source: QC Strategy Library #72,
+# clone 2026-04-05. La logique de decision d'origine est preservee a
+# l'identique (seul un parametre optionnel trading_start permet d'aligner
+# la fenetre d'experimentation, voir issue #14722).
+#
+# Bras "asg" (mode="asg") - QC research #21132, issue #14722 :
+# https://www.quantconnect.com/research/21132/sizing-market-exposure-with-aggregate-sales-growth/
+# "Sizing Market Exposure With Aggregate Sales Growth" (Derek Melchin,
+# juillet 2026), d'apres Garfinkel, Hribar & Hsiao (2025), "Aggregate Sales
+# Growth and Stock Market Returns" (SSRN 5066654).
+# Mecanique mensuelle exacte de l'article :
+#   - actions ordinaires americaines primaires (ST00000001, country USA),
+#     secteurs Financial Services et Real Estate exclus ;
+#   - ASG = moyenne, ponderee par capitalisation, de la croissance annuelle
+#     du chiffre d'affaires winsorisee 1 % / 99 % en coupe ;
+#   - regression OLS a fenetre croissante du rendement excédentaire mensuel
+#     de SPY sur l'ASG retardée d'un mois (convention d'indexation
+#     pd.Period(now)-1 + shift(1, freq="M"), np.polynomial.polynomial.polyfit) ;
+#   - prevision forecast = alpha + beta * ASG courante ;
+#   - exposition SPY w = clip(forecast / (gamma * variance), 0, 1.5) avec
+#     gamma = 3 et variance des 120 derniers rendements excédentaires
+#     mensuels ; reliquat 1 - w place en BIL (T-bills 13 semaines).
+# Les fonctions pures correspondantes (winsorisation, agregation, OLS,
+# variance, bornes) sont extraites dans asg_helpers.py et testees
+# localement dans tests/test_asg_helpers.py.
+#
+# Experimentation alignee #14722 (les deux bras, parametres passes au
+# backtest) : start_date=20120101, end_date=20250101, trading_start=20180101,
+# capital 100 000 USD, brokerage par defaut QC (frais/fills identiques),
+# benchmark SPY. Periode
+# d'entrainement/warmup 2012-01 -> 2017-12 (le bras ASG accumule ses series
+# mensuelles, le bras baseline n'echange pas), periode OOS 2018-01 -> 2025-01
+# ou les deux bras echangent. Sans ces parametres, le comportement par
+# defaut reproduit la baseline d'origine.
+# ============================================================================
 
 
-class AIStocksBondsRotationAlgorithm(QCAlgorithm):
+class MacroFactorRotationAlgorithm(QCAlgorithm):
 
     def initialize(self):
-        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
-        self.set_start_date(self.end_date - timedelta(10*365))
-        self.set_end_date(2025, 1, 1)  # Fixed end date for reproducibility
+        self._mode = self.get_parameter("mode", "baseline").lower()
+        if self._mode not in ("baseline", "asg"):
+            raise ValueError(
+                f"parametre mode inconnu : {self._mode} (baseline | asg)"
+            )
+        self._trading_start = self._parse_date_param("trading_start")
+
+        # Brokerage par defaut (les deux bras) : la strategy multi-actifs
+        # equities + crypto ne passe sous aucun broker reel unique (IBKR
+        # rejette les targets Crypto - "Unsupported security type: Crypto",
+        # bug latent du clone local #14722 - , Binance rejette les equities).
+        # Le projet cloud d'origine (32730301, metriques de l'issue) tourne
+        # lui-meme sans set_brokerage_model : mode par defaut, frais QC
+        # identiques pour les deux bras de l'experimentation alignee.
+        start_date_param = self._parse_date_param("start_date")
+        end_date_param = self._parse_date_param("end_date")
+        # Ordre d'origine preserve : sans parametre, start = end_date par
+        # defaut - 10 ans, puis end fixe au 2025-01-01 (baseline #72).
+        self.set_start_date(
+            start_date_param
+            if start_date_param is not None
+            else self.end_date - timedelta(10 * 365)
+        )
+        if end_date_param is not None:
+            self.set_end_date(end_date_param)
+        else:
+            self.set_end_date(2025, 1, 1)  # Fixed end date for reproducibility
+        self.set_cash(100_000)
         self.settings.daily_precise_end_time = False
         self.settings.seed_initial_prices = True
+        self.set_benchmark("SPY")
+
+        if self._mode == "asg":
+            self._initialize_asg()
+        else:
+            self._initialize_baseline()
+
+    def _parse_date_param(self, name):
+        raw = self.get_parameter(name)
+        if raw is None or str(raw).strip() == "":
+            return None
+        return datetime.strptime(str(raw).strip(), "%Y%m%d")
+
+    def _may_trade(self):
+        """Porte d'alignement #14722 : avant trading_start, on n'echange pas."""
+        return self._trading_start is None or self.time >= self._trading_start
+
+    # ------------------------------------------------------------------
+    # Bras baseline : rotation macro DecisionTree (logique d'origine #72)
+    # ------------------------------------------------------------------
+    def _initialize_baseline(self):
         # Multi-asset strategy (equities + crypto): no single brokerage supports both.
         # IBKR rejects crypto, Binance rejects equities. Default brokerage allows both
         # with realistic fills per asset type. For production, split into sub-strategies.
@@ -44,12 +127,14 @@ class AIStocksBondsRotationAlgorithm(QCAlgorithm):
         self.schedule.on(
             self.date_rules.month_start(self._equities[0]),
             self.time_rules.after_market_open(self._equities[0], 1),
-            self._rebalance
+            self._rebalance_baseline
         )
         self.set_warm_up(timedelta(35))
 
-    def _rebalance(self):
+    def _rebalance_baseline(self):
         if self.is_warming_up:
+            return
+        if not self._may_trade():
             return
         # Get historical factor data
         factors = self.history(
@@ -112,4 +197,101 @@ class AIStocksBondsRotationAlgorithm(QCAlgorithm):
         self.set_holdings(targets, True)
 
     def on_warmup_finished(self):
-        self._rebalance()
+        if self._mode == "baseline":
+            self._rebalance_baseline()
+
+    # ------------------------------------------------------------------
+    # Bras ASG : sizing d'exposition par Aggregate Sales Growth (#21132)
+    # ------------------------------------------------------------------
+    def _initialize_asg(self):
+        self._spy = self.add_equity("SPY", Resolution.DAILY, leverage=3).symbol
+        self._bil = self.add_equity("BIL", Resolution.DAILY, leverage=3).symbol
+        # Etat accumule mois par mois (fenetre croissante de l'article).
+        self._firm_data = {}
+        self._asg = pd.Series(dtype=float)
+        self._excess_returns = pd.Series(dtype=float)
+        self._prev_event_price = None
+        self._gamma = asg_helpers.GAMMA
+        # Selection d'univers programmee au debut de chaque mois (00:00),
+        # rebalance programme le meme jour a 08:00 : la coupe fondamentale
+        # est donc toujours fraiche et connue avant la decision.
+        date_rule = self.date_rules.month_start("SPY")
+        self.universe_settings.schedule.on(date_rule)
+        self._universe = self.add_universe(self._select_assets)
+        self.schedule.on(date_rule, self.time_rules.at(8, 0), self._rebalance_asg)
+        self.set_warm_up(timedelta(35))
+
+    def _select_assets(self, fundamentals: List[Fundamental]) -> List[Symbol]:
+        # Univers #21132 : actions ordinaires americaines primaires,
+        # Financial Services et Real Estate exclus. L'univers ne selectionne
+        # aucun titre (retour vide) : il sert uniquement a collecter la coupe
+        # fondamentale point-in-time du mois.
+        self._firm_data = {
+            f.symbol: (f.operation_ratios.revenue_growth.one_year, f.market_cap)
+            for f in fundamentals
+            if (f.company_reference.country_id == "USA"
+                and f.security_reference.is_primary_share
+                and f.security_reference.security_type == "ST00000001"
+                and f.asset_classification.morningstar_sector_code
+                    not in (MorningstarSectorCode.FINANCIAL_SERVICES,
+                            MorningstarSectorCode.REAL_ESTATE))
+        }
+        return []
+
+    def _rebalance_asg(self):
+        if self.is_warming_up:
+            return
+        # Convention d'indexation de l'article : a l'evenement de debut du
+        # mois M, les donnees du mois complete M-1 sont enregistrees sous
+        # l'index Period(M-1).
+        month = pd.Period(self.time, freq="M") - 1
+        # 1) Rendement excédentaire mensuel de SPY du mois complete :
+        #    close de fin de mois -> close de fin de mois (prix a 08:00 =
+        #    dernier close du mois precedent), moins taux sans risque
+        #    mensuel courant (mecanique de l'article).
+        price = self.securities[self._spy].price
+        if self._prev_event_price:
+            rf_monthly = (
+                self.risk_free_interest_rate_model.get_interest_rate(self.time)
+                / 12
+            )
+            self._excess_returns[month] = (
+                price / self._prev_event_price - 1 - rf_monthly
+            )
+        self._prev_event_price = price
+        # 2) ASG du mois : coupe fondamentale fraiche (point-in-time),
+        #    winsorisation 1/99 et ponderation par capitalisation.
+        if self._firm_data:
+            firms = pd.DataFrame.from_dict(
+                self._firm_data, orient="index", columns=["growth", "market_cap"]
+            )
+            asg_value = asg_helpers.aggregate_sales_growth(
+                firms["growth"], firms["market_cap"]
+            )
+            if asg_value is not None:
+                self._asg[month] = asg_value
+        # 3) Avant trading_start (periode d'entrainement/warmup #14722) :
+        #    accumuler sans echanger.
+        if not self._may_trade():
+            return
+        # 4) OLS a fenetre croissante (lag d'un mois via shift), prevision,
+        #    variance 120 mois, exposition bornee clip(., 0, 1.5).
+        fit = asg_helpers.fit_expanding_ols(
+            self._asg,
+            self._excess_returns,
+            min_observations=asg_helpers.MIN_FIT_OBSERVATIONS,
+        )
+        variance = asg_helpers.trailing_variance(
+            self._excess_returns,
+            window=asg_helpers.VARIANCE_WINDOW,
+            min_observations=asg_helpers.MIN_VARIANCE_OBSERVATIONS,
+        )
+        forecast = asg_helpers.forecast_excess_return(fit, self._asg.get(month))
+        w_star = asg_helpers.solve_exposure(
+            forecast, variance, gamma=self._gamma
+        )
+        # 5) SPY a w_star, reliquat en BIL (negatif = financement du levier).
+        self.set_holdings([
+            PortfolioTarget(self._spy, w_star),
+            PortfolioTarget(self._bil, 1 - w_star),
+        ])

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/tests/test_asg_helpers.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/tests/test_asg_helpers.py
@@ -103,21 +103,25 @@ def test_fit_expanding_ols_requires_min_observations():
     assert asg_helpers.fit_expanding_ols(asg, excess, min_observations=2) is not None
 
 
-def test_trailing_variance_uses_last_window_months():
+def test_trailing_variance_requires_full_window():
     rng = np.random.default_rng(7)
     months = pd.period_range("2005-01", "2020-12", freq="M")
     excess = pd.Series(rng.normal(0.005, 0.04, len(months)), index=months)
-    value = asg_helpers.trailing_variance(excess, window=120, min_observations=60)
+    value = asg_helpers.trailing_variance(excess, window=120, min_observations=120)
     assert value is not None
     assert abs(value - excess.tail(120).var()) < 1e-15
-    # 59 mois < seuil minimal de 60 -> None ; 100 mois disponibles ->
-    # variance portee par les 100 mois (fenetre 120 non remplie).
-    assert asg_helpers.trailing_variance(excess.tail(59), window=120, min_observations=60) is None
+    # Amendement audit #14722 : 119 mois < fenetre pleine de 120 -> None
+    # (aucune variance partielle ne peut produire un poids).
+    assert asg_helpers.trailing_variance(excess.tail(119), window=120, min_observations=120) is None
+    # 120 mois exactement -> valeur sur la fenetre pleine.
+    exact = excess.tail(120)
+    value_exact = asg_helpers.trailing_variance(exact, window=120, min_observations=120)
+    assert value_exact is not None
+    assert abs(value_exact - exact.var()) < 1e-15
+    # Valeur par defaut de la constante = fenetre pleine de l'article.
+    assert asg_helpers.MIN_VARIANCE_OBSERVATIONS == asg_helpers.VARIANCE_WINDOW == 120
+    # Fenetre plus courte respectee quand elle est demandee explicitement.
     short = excess.tail(100)
-    value_100 = asg_helpers.trailing_variance(short, window=120, min_observations=60)
-    assert value_100 is not None
-    assert abs(value_100 - short.var()) < 1e-15
-    # Fenetre plus courte respectee.
     value_50 = asg_helpers.trailing_variance(short, window=50, min_observations=50)
     assert value_50 is not None
     assert abs(value_50 - short.tail(50).var()) < 1e-15

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/tests/test_asg_helpers.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/tests/test_asg_helpers.py
@@ -1,0 +1,145 @@
+"""Tests locaux des helpers purs du bras ASG (issue #14722).
+
+Couvre : winsorisation 1/99, ponderation par capitalisation, lag d'un
+mois de la regression OLS a fenetre croissante, variance 120 mois et
+bornes du poids clip(., 0, 1.5).
+
+Execute avec : python -m pytest tests/test_asg_helpers.py
+(depuis MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC)
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asg_helpers  # noqa: E402
+
+
+def _cross_section(n_half: int = 50) -> pd.Series:
+    """Coupe a 2*n_half valeurs dupliquees (quantiles 1/99 exacts)."""
+    return pd.Series([0.10] * n_half + [0.20] * n_half)
+
+
+def test_winsorize_clips_at_quantiles():
+    values = pd.Series(np.arange(1, 101, dtype=float))
+    clipped = asg_helpers.winsorize(values)
+    lo, hi = values.quantile([0.01, 0.99])
+    assert clipped.min() == lo
+    assert clipped.max() == hi
+    # Les valeurs interieures ne bougent pas.
+    assert clipped.iloc[50] == values.iloc[50]
+
+
+def test_aggregate_sales_growth_cap_weighting_exact():
+    growth = _cross_section()
+    caps = pd.Series(1.0, index=growth.index)
+    # Quantiles exactement 0.10/0.20 (valeurs dupliquees) -> winsorisation
+    # identite, moyenne ponderee attendue = 0.15.
+    assert abs(asg_helpers.aggregate_sales_growth(growth, caps) - 0.15) < 1e-12
+    # La ponderation par cap respecte les proportions.
+    caps = pd.Series([3.0] + [1.0] * (len(growth) - 1), index=growth.index)
+    growth_all_010 = pd.Series(0.10, index=growth.index)
+    value = asg_helpers.aggregate_sales_growth(growth_all_010, caps)
+    assert abs(value - 0.10) < 1e-12
+
+
+def test_aggregate_sales_growth_winsorizes_outliers():
+    # Une firme extreme (croissance 100) avec cap ecrasante : sans
+    # winsorisation l'ASG serait proche de 100 ; winsorisee au quantile
+    # 99 % elle est contenue juste au-dessus de la masse des valeurs.
+    growth = pd.Series([0.10] * 50 + [0.20] * 49 + [100.0])
+    caps = pd.Series([1.0] * 99 + [1e12])
+    value = asg_helpers.aggregate_sales_growth(growth, caps)
+    assert value is not None
+    assert 1.0 < value < 2.0
+
+
+def test_aggregate_sales_growth_excludes_nonpositive_caps():
+    # 101 valeurs : 50 x 0.10, 50 x 0.20, 1 extreme a 100.0. Les quantiles
+    # 1/99 tombent exactement sur 0.10/0.20 (positions 1 et 99), donc la
+    # winsorisation ne touche pas les 100 valeurs retenues.
+    growth = pd.Series([0.10] * 50 + [0.20] * 50 + [100.0])
+    caps = pd.Series([1.0] * 100 + [0.0])  # firme extreme sans cap
+    value = asg_helpers.aggregate_sales_growth(growth, caps)
+    assert abs(value - 0.15) < 1e-12
+    # Cap NaN : meme exclusion.
+    caps_nan = pd.Series([1.0] * 100 + [np.nan])
+    value = asg_helpers.aggregate_sales_growth(growth, caps_nan)
+    assert abs(value - 0.15) < 1e-12
+    # Aucune observation exploitable -> None.
+    assert asg_helpers.aggregate_sales_growth(pd.Series(dtype=float), pd.Series(dtype=float)) is None
+    assert asg_helpers.aggregate_sales_growth(growth, pd.Series(0.0, index=growth.index)) is None
+
+
+def test_fit_expanding_ols_recovers_relationship_with_one_month_lag():
+    # Serie ASG aleatoire (autocorrelation nulle) : seul l'appariement
+    # retarde d'un mois peut retrouver exactement (alpha, beta).
+    rng = np.random.default_rng(42)
+    months = pd.period_range("2015-01", "2019-12", freq="M")
+    asg = pd.Series(rng.normal(0.05, 0.02, len(months)), index=months)
+    alpha_true, beta_true = 0.001, 0.75
+    excess = (alpha_true + beta_true * asg.shift(1)).dropna()
+    fit = asg_helpers.fit_expanding_ols(asg, excess)
+    assert fit is not None
+    alpha_hat, beta_hat = fit
+    assert abs(alpha_hat - alpha_true) < 1e-8
+    assert abs(beta_hat - beta_true) < 1e-8
+    # Un appariement concurrent (sans lag) ne retrouverait pas beta :
+    # l'ASG n'est pas autocorrelee, la regression serait degénérée en pente 0.
+    concurrent = asg.align(excess, join="inner")[0]
+    a2, b2 = np.polynomial.polynomial.polyfit(concurrent, excess, 1)
+    assert abs(b2 - beta_true) > 0.1
+
+
+def test_fit_expanding_ols_requires_min_observations():
+    months = pd.period_range("2015-01", "2016-06", freq="M")
+    asg = pd.Series(np.linspace(0.01, 0.09, len(months)), index=months)
+    excess = pd.Series(np.linspace(0.0, 0.02, len(months)), index=months)
+    assert asg_helpers.fit_expanding_ols(asg, excess, min_observations=60) is None
+    assert asg_helpers.fit_expanding_ols(asg, excess, min_observations=2) is not None
+
+
+def test_trailing_variance_uses_last_window_months():
+    rng = np.random.default_rng(7)
+    months = pd.period_range("2005-01", "2020-12", freq="M")
+    excess = pd.Series(rng.normal(0.005, 0.04, len(months)), index=months)
+    value = asg_helpers.trailing_variance(excess, window=120, min_observations=60)
+    assert value is not None
+    assert abs(value - excess.tail(120).var()) < 1e-15
+    # 59 mois < seuil minimal de 60 -> None ; 100 mois disponibles ->
+    # variance portee par les 100 mois (fenetre 120 non remplie).
+    assert asg_helpers.trailing_variance(excess.tail(59), window=120, min_observations=60) is None
+    short = excess.tail(100)
+    value_100 = asg_helpers.trailing_variance(short, window=120, min_observations=60)
+    assert value_100 is not None
+    assert abs(value_100 - short.var()) < 1e-15
+    # Fenetre plus courte respectee.
+    value_50 = asg_helpers.trailing_variance(short, window=50, min_observations=50)
+    assert value_50 is not None
+    assert abs(value_50 - short.tail(50).var()) < 1e-15
+
+
+def test_solve_exposure_formula_and_clips():
+    # w = forecast / (gamma * variance) : 0.10 / (3 * 0.04) = 0.8333...
+    assert abs(asg_helpers.solve_exposure(0.10, 0.04) - 0.10 / 0.12) < 1e-12
+    # Prevision negative -> jamais short -> 0.
+    assert asg_helpers.solve_exposure(-0.10, 0.04) == 0.0
+    # Prevision extreme -> plafond 1.5.
+    assert asg_helpers.solve_exposure(10.0, 0.001) == 1.5
+    # Entrees invalides -> 100 % BIL (garde-fou #14722).
+    assert asg_helpers.solve_exposure(None, 0.04) == 0.0
+    assert asg_helpers.solve_exposure(0.10, None) == 0.0
+    assert asg_helpers.solve_exposure(0.10, 0.0) == 0.0
+    assert asg_helpers.solve_exposure(float("nan"), 0.04) == 0.0
+    assert asg_helpers.solve_exposure(0.10, float("nan")) == 0.0
+
+
+def test_forecast_excess_return():
+    assert asg_helpers.forecast_excess_return(None, 0.05) is None
+    assert asg_helpers.forecast_excess_return((0.001, 0.75), None) is None
+    value = asg_helpers.forecast_excess_return((0.001, 0.75), 0.05)
+    assert abs(value - (0.001 + 0.75 * 0.05)) < 1e-15

--- a/docs/qc/qc-research-seeded.json
+++ b/docs/qc/qc-research-seeded.json
@@ -9,8 +9,8 @@
   "21132": {
    "url": "https://www.quantconnect.com/research/21132/sizing-market-exposure-with-aggregate-sales-growth/",
    "lastmod": "2026-08-01T06:47:10+00:00",
-   "seeded_at": null,
-   "issue": null
+   "seeded_at": "2026-09-05",
+   "issue": 14722
   },
   "21066": {
    "url": "https://www.quantconnect.com/research/21066/intraday-volume-periodicity/",


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2025:CoursIA — prev: MED/notebook-python #14651

## Summary

- preserve the existing DecisionTree macro-factor allocation logic as the default `baseline` arm while removing its invalid IBKR/crypto brokerage combination
- add a parameterized aggregate-sales-growth control arm matching QuantConnect Research #21132: point-in-time monthly fundamentals, 1/99 winsorization, market-cap aggregation, one-month lagged expanding OLS, full 120-month variance, and bounded SPY/BIL exposure
- compare both deterministic arms in QC Cloud over the same accumulation and OOS periods, capital, benchmark, fees, and fill assumptions; the result is **INCONCLUSIVE**, not a `BEATS` claim

See #11698
Closes #14722

## Research provenance

- QuantConnect Research: https://www.quantconnect.com/research/21132/sizing-market-exposure-with-aggregate-sales-growth/
- Primary source: Garfinkel, Hribar & Hsiao (2025), *Aggregate Sales Growth and Stock Market Returns*
- Shared bibliography (outside Git): `G:\Mon Drive\MyIA\IA\Bibliographie IA\Trading\Garfinkel-Hribar-Hsiao-2025-Aggregate-Sales-Growth-and-Stock-Market-Returns.pdf`

## Experimental design

- Fixed aligned backtest: 2007-01-01 through 2025-01-01
- Accumulation/no-trade period: 2007-01 through 2017-12; conservative lower bounds are at least 130 ASG observations and at least 129 excess returns before the first trade, so the full 120-month variance is ready with margin
- OOS trading period: 2018-01 through 2025-01
- Starting capital: USD 100,000
- Costs: the same default QC brokerage fee/fill models for both arms; no explicit slippage model, matching the article's undisclosed slippage assumption
- Benchmark: SPY
- Parameters: `mode=baseline|asg`, `start_date=20070101`, `end_date=20250101`, `trading_start=20180101`

The pre-PR audit rejected an initial 2012 start because it allowed variance estimation after 60 rather than 120 months. Commit `d10c5b10b` requires the full `Variance(10*12)` window, extends accumulation to 2007, strengthens the test at 119/120 observations, and reruns both arms. The v1 metrics remain in the README only as explicitly superseded evidence of why the correction matters.

## QC Cloud evidence

Fresh project `MacroFactorRotation-ASG-14722` (ID `36141780`); the original project was read but not modified.

Compile `3f91dbe0544942bce2c7a47ea73cbb97-1748601bd97343c8210c636f8add2b34`: **BuildSuccess**, zero errors.

| Arm | Backtest | Status | Orders | Sharpe | CAGR | MaxDD | Net profit | PSR |
|---|---|---|---:|---:|---:|---:|---:|---:|
| Existing macro rotation | `53f10a127e160966176247f2018e68bc` | Completed, progress 1 | 261 | 0.227 | 5.750% | 41.900% | 173.809% | 0.004% |
| ASG SPY/BIL sizing | `149b8c44c0eaf887395e697e50da38e1` | Completed, progress 1 | 139 | 0.234 | 5.643% | 47.800% | 168.841% | 0.005% |

Both result reads were performed only after `status == "Completed."` and `progress == 1`. As a sanity check, extending the flat pre-trade prefix left baseline trades unchanged from v1: 261 orders and 173.809% net profit in both runs.

## Verdict

**INCONCLUSIVE.** The exact 120-month arm has a nearly identical Sharpe (0.234 versus 0.227), slightly lower CAGR (5.643% versus 5.750%), and a materially deeper drawdown (47.8% versus 41.9%). Both PSRs are approximately zero. This is one deterministic window, so no multi-seed or Diebold-Mariano superiority claim is applicable and no statistically established improvement is claimed.

## Validation

- QC Cloud compile: BuildSuccess, zero errors
- QC Cloud baseline and ASG backtests: Completed, progress 1
- `python -m pytest tests/test_asg_helpers.py -q`: **9 passed**
- `python -m py_compile main.py asg_helpers.py`: success
- `git -c core.whitespace=cr-at-eol diff --check origin/main...HEAD`: success; the registry retains its repository-wide CRLF convention rather than normalizing 868 unrelated lines
- content-based secret scan over changed project files: zero hits
- scope: five files, all under `MacroFactorRotation-QC/**` except the two-field update for research registry key `21132`
- catalogue/generated artifacts: byte-identical to `origin/main`
