### PR TITLE
fix(13755): production-scope checklist Cloud-06-VolTargeting -> Cloud-13 (residu sweep tranche 6)

### DIFF
--- a/docs/notebook-metadata/production-scope.md
+++ b/docs/notebook-metadata/production-scope.md
@@ -105,7 +105,7 @@ Le détail par notebook suit en strate A ci-dessous : consultation, plus décisi
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-11-RegimeSwitching.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-PCA-StatArb.ipynb`
-- [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-VolTargeting.ipynb`
+- [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-13-VolTargeting.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-07-TemporalCNN.ipynb`
 - [ ] `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb`


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: MED/lean #14701

## Summary

Résidu de sweep de #13755 (tranche 6, Cloud-06 → Cloud-13, PR #14093) : la checklist `docs/notebook-metadata/production-scope.md` portait encore l'ancien chemin `QC-Py-Cloud-06-VolTargeting.ipynb` (ligne 108) — ligne morte depuis le `git mv`, et `Cloud-13-VolTargeting` était absent de la checklist.

Corps de la série vérifié firsthand sur `origin/main` (`git ls-tree`) : les entrées des autres tranches (Cloud-10 l.102, Cloud-11 l.105, Cloud-12 l.96, Cloud-14 l.98) sont propres — seule la ligne VolTargeting avait été loupée.

Fix : 1 ligne, l'ancien chemin remplacé par `QC-Py-Cloud-13-VolTargeting.ipynb` (remplacement, pas doublon).

## Validation

- `git grep -c "Cloud-06-VolTargeting" origin/main` avant fix : 1 (production-scope.md:108, la seule référence **courante** morte — les autres hits résiduels sont des artefacts d'automatisation : `COURSE_CATALOG.generated.json` resynchronisé par le cron catalogue, CSV `translations/` sous hold user #10038, et références historiques légitimes dans `docs/archive/` et `docs/ledgers/`).
- Diff : 1 fichier, +1/-1, markdown checklist uniquement — aucun code, aucun notebook, catalogue byte-identique à main.

See #13755 (complément de sweep, tranche 6 — ne clôt pas l'issue : l'arbitrage de fermeture revient à ai-01, cf. commentaire candidate-delivered)
