### PR TITLE
chore(9535): remove orphaned one-shot run_build_v7.sh from repo root

### DIFF
--- a/run_build_v7.sh
+++ b/run_build_v7.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-export PATH=/home/jesse/.elan/bin:$PATH
-cd /mnt/c/dev/CoursIA-c6724-c31-p4nw/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
-lake env lean Conway/Life/HashlifeCorrectness.lean > /tmp/build_p4ne_v7.log 2>&1
-echo "EXIT=$?"
-wc -l /tmp/build_p4ne_v7.log
-grep -c "error:" /tmp/build_p4ne_v7.log
-tail -50 /tmp/build_p4ne_v7.log


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14724

## Livrable

Suppression de `run_build_v7.sh` (8 lignes, racine du depot) — script one-shot de build Lean ciblant le worktree de session `CoursIA-c6724-c31-p4nw` (n'existe plus), chemins machine en dur (`/home/jesse/.elan/bin`), sortie vers `/tmp`.

## Preuve de non-referencement (preflight firsthand 2026-09-05, origin/main 35657bc00)

- `git grep -c "run_build_v7.sh" origin/main` : **0 hit** (nom de fichier, tout le depot)
- `git grep -c "run_build_v7" origin/main` : **0 hit** (forme module, tout le depot)
- 0 PR ouverte en collision (`gh pr list --search run_build_v7` vide)

## Contexte

Lot 1 (« racine + orphelins ») du bandeau de curation 2026-09-02 de #9535, annonce comme grain LIGHT de 4 suppressions. Re-mesure firsthand : les 3 orphelins `scripts/` (`add_p3_bandeaus.py`, `enrich_lean18.py`, `verify_lean18.py`) sont deja absents d'origin/main — livres par #14155. Ce grain reduit donc au seul residu racine, qui porte le critere d'acceptance « racine sans fichier de travail tracke » (NON TENU -> TENU par cette PR).

Une suppression de fichier, zero modification ailleurs.

See #9535
