### PR TITLE
test(ict,#14598): mocker evolve_alpha dans test_run_full_is_deterministic + reproductibilité réelle bornée

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy.py
@@ -17,6 +17,7 @@ Conventions :
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -182,12 +183,15 @@ def test_evolve_alpha_returns_value_in_unit_interval():
 def test_run_full_is_deterministic(monkeypatch):
     """Avec les mêmes seeds, run_full doit retourner le même résultat.
 
-    Tell c.931-L1 NEW : `evolve_alpha` est mocké pour ramener le runtime du test
-    sous 5 s (sous charge runner po-2024, n_seeds=5 × 2 runs = ~24 min en CI).
-    Le test ne valide pas la qualité de l'évolution (couverte par
-    `test_evolve_alpha_returns_value_in_unit_interval`), seulement que la
-    mécanique de déterminisme seed RNG tient : 2 invocations successives avec
-    les mêmes seeds doivent retourner des séries identiques.
+    Test de **plomberie** (réserve adjoint #14732, REPAIR HIGH
+    msg-20260905T112800-actho2) : `evolve_alpha` est mocké pour ramener le
+    runtime du test sous 5 s (sous charge runner po-2024, n_seeds=5 × 2 runs =
+    ~24 min en CI). Le test vérifie la mécanique — 2 invocations successives de
+    `run_full` avec les mêmes seeds retournent des séries identiques — sans
+    dépendre du contenu d'`evolve_alpha`. La reproductibilité réelle de la
+    fonction est couverte par `test_evolve_alpha_is_reproducible_for_same_seed`
+    (échelle bornée) et sa qualité par
+    `test_evolve_alpha_returns_value_in_unit_interval`.
 
     Issue #14598 : la CI ICT ict/tests/ (42 package) timeout 30 min sur
     `test_run_full_is_deterministic` (mesure 33944875818 du 2026-09-05,
@@ -197,8 +201,10 @@ def test_run_full_is_deterministic(monkeypatch):
     import ict.hoffman_interface_toy as hft
 
     def _fake_evolve_alpha(objective, landscape_name, seed, n_pop=200, n_gen=500, mutation_rate=0.05):
-        # Valeur déterministe seedée : reproductible byte-identique pour les mêmes args
-        rng = np.random.default_rng(hash((objective, landscape_name, seed)) & 0xFFFFFFFF)
+        # Valeur déterministe seedée, stable inter-processus : `hash()` est salé
+        # par PYTHONHASHSEED (réserve adjoint #14732), hashlib ne l'est pas.
+        digest = hashlib.sha256(f"{objective}:{landscape_name}:{seed}".encode()).digest()
+        rng = np.random.default_rng(int.from_bytes(digest[:8], "big"))
         return float(rng.uniform(0, 1))
 
     monkeypatch.setattr(hft, "evolve_alpha", _fake_evolve_alpha)
@@ -214,6 +220,22 @@ def test_run_full_is_deterministic(monkeypatch):
 
 
 # ── 7. Verdict scan ──
+
+
+def test_evolve_alpha_is_reproducible_for_same_seed():
+    """Même seed → même α : reproductibilité réelle de l'évolution (échelle bornée).
+
+    Réserve adjoint #14732 (REPAIR HIGH msg-20260905T112800-actho2) : le mock de
+    `test_run_full_is_deterministic` ne prouve pas la reproductibilité de la
+    fonction elle-même. Ce test la couvre à petite échelle (n_pop=50, n_gen=100,
+    ~2,5 s par run) : 2 invocations avec la même seed retournent le même α, en
+    tout paysage et toute objective.
+    """
+    for ln in LANDSCAPES:
+        for objective in ("truth", "fitness"):
+            a1 = evolve_alpha(objective, ln, seed=7, n_pop=50, n_gen=100)
+            a2 = evolve_alpha(objective, ln, seed=7, n_pop=50, n_gen=100)
+            assert a1 == a2, f"{objective}/{ln} seed=7 → {a1} != {a2}"
 
 
 def test_results_json_has_required_keys():

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy.py
@@ -179,8 +179,30 @@ def test_evolve_alpha_returns_value_in_unit_interval():
             assert 0.0 <= a <= 1.0, f"{objective}/{ln} → α={a}"
 
 
-def test_run_full_is_deterministic():
-    """Avec les mêmes seeds, run_full doit retourner le même résultat."""
+def test_run_full_is_deterministic(monkeypatch):
+    """Avec les mêmes seeds, run_full doit retourner le même résultat.
+
+    Tell c.931-L1 NEW : `evolve_alpha` est mocké pour ramener le runtime du test
+    sous 5 s (sous charge runner po-2024, n_seeds=5 × 2 runs = ~24 min en CI).
+    Le test ne valide pas la qualité de l'évolution (couverte par
+    `test_evolve_alpha_returns_value_in_unit_interval`), seulement que la
+    mécanique de déterminisme seed RNG tient : 2 invocations successives avec
+    les mêmes seeds doivent retourner des séries identiques.
+
+    Issue #14598 : la CI ICT ict/tests/ (42 package) timeout 30 min sur
+    `test_run_full_is_deterministic` (mesure 33944875818 du 2026-09-05,
+    ~24:48 pour 1 test, puis CANCELLED). Mocker `evolve_alpha` ramène ce test
+    à < 5 s sans rien perdre du déterminisme.
+    """
+    import ict.hoffman_interface_toy as hft
+
+    def _fake_evolve_alpha(objective, landscape_name, seed, n_pop=200, n_gen=500, mutation_rate=0.05):
+        # Valeur déterministe seedée : reproductible byte-identique pour les mêmes args
+        rng = np.random.default_rng(hash((objective, landscape_name, seed)) & 0xFFFFFFFF)
+        return float(rng.uniform(0, 1))
+
+    monkeypatch.setattr(hft, "evolve_alpha", _fake_evolve_alpha)
+
     r1 = run_full(n_seeds=5)
     r2 = run_full(n_seeds=5)
     # Compare les alpha finaux (série déterministe)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy_n8.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy_n8.py
@@ -16,6 +16,7 @@ Conventions :
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -233,13 +234,19 @@ def test_evolve_alpha_returns_value_in_unit_interval():
 def test_run_full_is_deterministic(monkeypatch):
     """Avec les mêmes seeds, run_full doit retourner le même résultat.
 
-    Tell c.931-L1 NEW : `evolve_alpha` est mocké (cf. test_hoffman_interface_toy.py
-    même méthode) pour ramener le runtime du test sous 5 s sur runner po-2024.
+    Test de **plomberie** (réserve adjoint #14732, REPAIR HIGH
+    msg-20260905T112800-actho2) : `evolve_alpha` est mocké (cf.
+    test_hoffman_interface_toy.py même méthode) pour ramener le runtime du test
+    sous 5 s sur runner po-2024. La reproductibilité réelle de la fonction est
+    couverte par `test_evolve_alpha_is_reproducible_for_same_seed`.
     """
     import ict.hoffman_interface_toy_n8 as hft
 
     def _fake_evolve_alpha(objective, landscape_name, seed, n_pop=200, n_gen=500, mutation_rate=0.05):
-        rng = np.random.default_rng(hash((objective, landscape_name, seed)) & 0xFFFFFFFF)
+        # Valeur déterministe seedée, stable inter-processus (hash() salé par
+        # PYTHONHASHSEED — réserve adjoint #14732 ; hashlib ne l'est pas).
+        digest = hashlib.sha256(f"{objective}:{landscape_name}:{seed}".encode()).digest()
+        rng = np.random.default_rng(int.from_bytes(digest[:8], "big"))
         return float(rng.uniform(0, 1))
 
     monkeypatch.setattr(hft, "evolve_alpha", _fake_evolve_alpha)
@@ -254,6 +261,22 @@ def test_run_full_is_deterministic(monkeypatch):
 
 
 # ── 7. Verdict scan ──
+
+
+def test_evolve_alpha_is_reproducible_for_same_seed():
+    """Même seed → même α : reproductibilité réelle de l'évolution (échelle bornée).
+
+    Réserve adjoint #14732 (REPAIR HIGH msg-20260905T112800-actho2) : le mock de
+    `test_run_full_is_deterministic` ne prouve pas la reproductibilité de la
+    fonction elle-même. Ce test la couvre à petite échelle (n_pop=50, n_gen=100,
+    ~2,5 s par run) : 2 invocations avec la même seed retournent le même α, en
+    tout paysage et toute objective.
+    """
+    for ln in LANDSCAPES:
+        for objective in ("truth", "fitness"):
+            a1 = evolve_alpha(objective, ln, seed=7, n_pop=50, n_gen=100)
+            a2 = evolve_alpha(objective, ln, seed=7, n_pop=50, n_gen=100)
+            assert a1 == a2, f"{objective}/{ln} seed=7 → {a1} != {a2}"
 
 
 def test_results_json_has_required_keys():

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy_n8.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy_n8.py
@@ -230,8 +230,20 @@ def test_evolve_alpha_returns_value_in_unit_interval():
             assert 0.0 <= a <= 1.0, f"{objective}/{ln} → α={a}"
 
 
-def test_run_full_is_deterministic():
-    """Avec les mêmes seeds, run_full doit retourner le même résultat."""
+def test_run_full_is_deterministic(monkeypatch):
+    """Avec les mêmes seeds, run_full doit retourner le même résultat.
+
+    Tell c.931-L1 NEW : `evolve_alpha` est mocké (cf. test_hoffman_interface_toy.py
+    même méthode) pour ramener le runtime du test sous 5 s sur runner po-2024.
+    """
+    import ict.hoffman_interface_toy_n8 as hft
+
+    def _fake_evolve_alpha(objective, landscape_name, seed, n_pop=200, n_gen=500, mutation_rate=0.05):
+        rng = np.random.default_rng(hash((objective, landscape_name, seed)) & 0xFFFFFFFF)
+        return float(rng.uniform(0, 1))
+
+    monkeypatch.setattr(hft, "evolve_alpha", _fake_evolve_alpha)
+
     r1 = run_full(n_seeds=3)
     r2 = run_full(n_seeds=3)
     for ln in LANDSCAPES:


### PR DESCRIPTION
Grain: DEEP/research-code -- lane myia-po-2024:CoursIA-2 -- prev: DEEP/research-code #14548

test(ict,#14598): mocker evolve_alpha dans test_run_full_is_deterministic — ramener le runtime sous 5s + tester la reproductibilité réelle bornée

## Résumé

**Cause première** (issue #14598, extension firsthand du commentaire `myia-ai-01` 07:04:00Z) : la CI ICT `ict/tests/ (42 package)` timeout 30 min sur **un seul test** : `test_run_full_is_deterministic` dans `ict/tests/test_hoffman_interface_toy.py` (case 11). Mesure verbatim run 33944875818 du 2026-09-05 : `test_run_full_is_deterministic` monopolise **24:48** (~24 min) avant que le job ne soit CANCELLED.

**Cause du bottleneck** : `test_run_full_is_deterministic` lance `run_full(n_seeds=5)` **deux fois** (r1 et r2). Chaque `run_full(5)` itère sur 5 seeds × `run_experiment(s)` qui itère sur 5 paysages × 2× `evolve_alpha` + transfer (~7 evolve_alpha par paysage). Total : `5 seeds × 5 paysages × ~7 evolve_alpha = 175 evolve_alpha calls par run_full`, **×2 runs = 350 calls dans le test**. Sous charge runner po-2024 (×4-5 vs local), `evolve_alpha` (n_pop=200, n_gen=500) prend ~4s par call → **~24 min en CI**.

**Profilage local c.931** (worktree `feature/14598-test-deterministic-mock`, branche rebasée origin/main 35657bc005) :

| `run_full(n_seeds=k)` | Local (Windows, Python 3.13) | CI runner po-2024 (charge ×4-5) |
|---|---|---|
| n_seeds=1 | 41s | ~3-4 min × 2 = 7-8 min |
| n_seeds=2 | 71s | ~5-6 min × 2 = 10-12 min |
| n_seeds=3 | 99s | ~7-8 min × 2 = 14-16 min |
| n_seeds=5 | 172s | ~12-14 min × 2 = **24-28 min** (mesuré) |

## Fix

**Mocker `evolve_alpha`** dans `test_run_full_is_deterministic` (case 11 + case 12) via pytest `monkeypatch.setattr(hft, "evolve_alpha", _fake_evolve_alpha)`. Le mock :

1. **Retourne une valeur déterministe seedée, stable inter-processus** : `_fake_evolve_alpha(objective, landscape, seed, ...) = np.random.default_rng(int.from_bytes(hashlib.sha256(f"{objective}:{landscape_name}:{seed}".encode()).digest()[:8], "big")).uniform(0, 1)`. `hash()` est salé par `PYTHONHASHSEED` donc instable inter-processus (réserve adjoint, traitée ci-dessous) ; `hashlib.sha256` est stable partout. La valeur n'est pas importante — ce qui compte est qu'elle soit **byte-identique** pour les mêmes arguments.
2. **Laisse `run_full` exécuter toute sa mécanique** : `run_experiment` calcule `alpha_truth`, `alpha_fit`, `transfer_truth`, `transfer_fit`, `self_truth`, `self_fit`. Le mock ne court-circuite que l'étape d'évolution, pas la structure.
3. **Préserve la validité du test** : le test vérifie **que la mécanique de déterminisme seed RNG tient** — 2 invocations successives avec mêmes seeds → séries identiques. Mocker `evolve_alpha` à une fonction seedée **prouve** ce déterminisme.

**Requalification plomberie (réserve adjoint, traitée)** : la docstring de `test_run_full_is_deterministic` déclare désormais que c'est un test de **plomberie** — il vérifie la mécanique d'ordre/agrégation de `run_full`, pas la reproductibilité réelle de la fonction.

**Pas de régression + nouveau test de reproductibilité réelle (réserve adjoint, traitée)** :
- `test_evolve_alpha_returns_value_in_unit_interval` teste `evolve_alpha` réelle avec `n_pop=50, n_gen=100` (2.46s).
- **`test_evolve_alpha_is_reproducible_for_same_seed` (NOUVEAU, case 11 + case 12)** : 2 invocations avec la même seed (`seed=7`, `n_pop=50, n_gen=100`) retournent le même α, en tout paysage et toute objective — la reproductibilité réelle de la fonction est à nouveau testée, à échelle bornée. Local : +5.0s (case 11) / +8.0s (case 12), mesuré.
- Le mock est proprement scopé au test déterminisme (monkeypatch restauré après le test) ; le nouveau test appelle `evolve_alpha` **réelle** (pas de mock).

## REPAIR adjoint #14732 — gestes traités (2026-09-05, head `906ad369ac`)

Réserve `PRR_kwDOH2Odns8AAAABMTvRGA` (myia-po-2025 adjoint, scellée au head précédent `644f2a9a32`) + REPAIR HIGH `msg-20260905T112800-actho2` — les 4 gestes sont livrés :

| # | Geste demandé | Livré |
|---|---|---|
| 1 | **Vrai test borné de reproductibilité `evolve_alpha`** (même seed, petits n_pop/n_gen) dans les deux modules | `test_evolve_alpha_is_reproducible_for_same_seed` (case 11 + case 12) — seed=7, n_pop=50, n_gen=100, tous paysages × objectives |
| 2 | **Requalifier le mock en test plomberie** | Docstrings `test_run_full_is_deterministic` requalifiées (« Test de **plomberie** … la reproductibilité réelle de la fonction est couverte par `test_evolve_alpha_is_reproducible_for_same_seed` ») |
| 3 | **Remplacer le `hash(...)` salé par une seed stable** | `hashlib.sha256(f"{objective}:{landscape_name}:{seed}")[:8]` → `int.from_bytes` → `default_rng` — stable inter-processus (PYTHONHASHSEED-indépendant) |
| 4 | **Retirer le close-keyword** frayant les issues deja resolues `#14595`/`#14571` | Les occurrences litterales du motif (mot-cleft + `#` + numero) sont remplacees par `See #...` (lien neutre) dans ce body — aucun litteral restant |

## Mesure avant/après

**Avant** (CI runner po-2024, charge ×4-5, n_seeds=5 × 2 runs) : **~24-28 min**, CANCELLED sur timeout 30 min.
**Après** (mock `evolve_alpha`) :

| Test | Avant (CI) | Après (local) | Gain |
|---|---|---|---|
| `test_hoffman_interface_toy.py::test_run_full_is_deterministic` | ~12-14 min × 2 = 24-28 min | **0.31s** (mesuré) | ~99.97% |
| `test_hoffman_interface_toy_n8.py::test_run_full_is_deterministic` | ~7-8 min × 2 = 14-16 min | **0.31s** (inclus) | ~99.97% |

**Suite Hoffman FBT complète (34 tests, 2 nouveaux inclus)** : **2:45 min** (165.56s mesuré) au lieu de CANCELLED. Tous les autres tests (canal, MAP, F(x), strategy, evolve_alpha, transfer, verdict scan, reproductibilité réelle) **toujours verts** — pas de régression.

## Vérifications

- C.1 (pas d'erreur volontaire) : grep `raise NotImplementedError\|assert False\|1/0` = 0
- C.2 (commit AVEC outputs) : N/A (test.py, pas de notebook)
- H.1 (validation exec réelle) : **34/34 tests pytest verts** (165.56s post-fix). Avant : CANCELLED sur timeout 30 min.
- H.3 (pre-commit notebook) : N/A (test.py)
- B.5 (regression check) : tous les autres tests Hoffman FBT **PASSED**. Mock proprement scopé au test déterminisme (monkeypatch) ; le nouveau test de reproductibilité appelle `evolve_alpha` réelle.
- G.6 (audit avant merge) : diff `--stat` vs origin/main = +69/-2 lignes sur 2 fichiers de tests. Pas de modification `hoffman_interface_toy.py` (le code prod reste intact — seul le test est mocké).
- Réserve adjoint : les 4 gestes ci-dessus sont tracés dans la section REPAIR (head `906ad369ac`, rebasé origin/main 35e4b874cf).
- Tell c.1356 ★★★ LIVRÉ-urn sustained : pas applicable (PR modifie test, pas LIVRÉ-urn).

## Limites assumées

- Le mock **ne valide pas la qualité de l'évolution**. La qualité est testée séparément par `test_evolve_alpha_returns_value_in_unit_interval` (n_pop=50, n_gen=100, 2.46s) + le verdict scan (`test_results_json_has_required_keys`) qui charge le JSON artifact et vérifie les clés.
- Le mock **réduit la confiance** sur les transferts cross-paysages testés dans `run_experiment` (car `evolve_alpha` est bypassé). Mais ces transferts sont testés **explicitement** dans `test_run_full_*_transfers_*` (cf. fichiers de test).
- La **reproductibilité réelle** d'`evolve_alpha` est testée à échelle bornée (seed=7, n_pop=50/n_gen=100) dans les deux modules — la mécanique de seed RNG tient sur la base de ce que le test démontre ; la reproductibilité exacte des runs de production (n_pop=200/n_gen=500) reste un invariant de `np.random.default_rng(seed)`, non re-testé par coût.
- Si un test **adjacent** requiert le **vrai** `evolve_alpha`, il doit le ré-importer directement (pas de mock global) — c'est l'état actuel (monkeypatch scoped).

## Modifications

| Fichier | Δ |
|---|---|
| `MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy.py` | +33/-2 lignes (mock hashlib-stable, test reproductibilité réelle, docstring plomberie) |
| `MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_hoffman_interface_toy_n8.py` | +36/-2 lignes (idem, case 12) |

## Voir aussi

- Issue #14598 (CI infra: la suite ICT tests/ timeout sur runner po-2024 — causes orthogonales à #14571)
- Issue #14571 (Errno 2 toolcache partagé — See #14595 MERGED)
- PR #14595 (venv per-job ICT — See #14571)
- PR #14655 (timeout-minutes 15→30 sur `.github/workflows/ict-tests.yml` — Option A LIVRÉE c.914, MERGED c.931)
- Tell c.931-L1 NEW (ci-dessous)
- Tell c.918-L1 ★★★ : `pr_gate.py` compte `CANCELLED` comme FAIL
- Tell c.1356 ★★★ : LIVRÉ-urn = mesure first-hand + balance honnête acceptance §N
- Tell c.898-L1 ★★★ : body = livrable audité
- Tell c.904-L1 ★★★ : verdict PR contre SCELLÉ
- Réserve adjoint #14732 : review `PRR_kwDOH2Odns8AAAABMTvRGA` + REPAIR HIGH `msg-20260905T112800-actho2`

See #14598

## Tell c.931-L1 NEW

**`test_run_full_is_deterministic` (et tout test de déterminisme structurel sur fonction coûteuse) doit mocker la fonction coûteuse pour ne valider que la mécanique de déterminisme seed RNG**, pas payer le coût de la fonction à chaque test. Pattern : `monkeypatch.setattr(module, "func_name", _fake_func)` avec `_fake_func(*args) = rng_seedé_déterministe(args).uniform(0, 1)`. Le test vérifie l'invariant (r1 == r2 pour mêmes seeds) sans dépendre du contenu de `func_name`. **Deux raffinements post-review adjoint** : (a) la seed du mock doit être **stable inter-processus** (`hashlib.sha256` — `hash()` est salé par `PYTHONHASHSEED`) ; (b) un test déterministe mocké est un test de **plomberie** et doit être doublé d'un vrai test de reproductibilité borné de la fonction (petits n_pop/n_gen).

**Tell** : quand un test passe de **runtime < 5 min à < 5 s** via mock (sans toucher au code de production, seulement au test), c'est une PR valide **DEEP/research-code** narrow-cassure Tell c.745-L2 ★★★ + Tell c.244-L2 ★★ monotonie META-light cassée. Applicable à **tout test structurel** (déterminisme, invariants, idempotence) sur fonction coûteuse.

`See #14598` — narrow-cassure 17ᵉ cycle Tell c.745-L2 ★★★ sustainée.