### PR TITLE
ci(cabling,#14615): wire GradeBookApp suite into scripts-tests (family 5/6)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -175,6 +175,11 @@ jobs:
           # (#2872), so without arch here those 9 tests are missing-dep failures.
           # Pulls statsmodels/patsy — still CPU-light.
           pip install arch
+          # rapidfuzz + unidecode + openpyxl: GradeBookApp/gradebook.py imports
+          # all three at module top level, so test_fuzzy_match_group.py needs
+          # them at collection time (famille 5 de #14615). The test guards with
+          # importorskip, but wiring it into this run means running it for real.
+          pip install rapidfuzz unidecode openpyxl
 
       - name: Run tests
         # Scope to the scripts/ + notebook_tools/ suites this job is named for.
@@ -224,6 +229,7 @@ jobs:
             MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
             scripts/secrets/tests \
             scripts/quantconnect/tests \
+            GradeBookApp \
             --tb=short -q
 
       - name: Audit tests collection floor (455)
@@ -268,7 +274,13 @@ jobs:
       # fetch est paresseux et non exerce. Deps reelles : numpy + pandas,
       # presentes dans ce job (arch les tire, et scripts/tests/ml/
       # test_garch_baseline.py les importe deja sous un run vert).
-      # CI-EXCLUDED: GradeBookApp — deps openpyxl/rapidfuzz/unidecode non installées dans ce job ; PII grading hors CI publique
+      # GradeBookApp re-câblé (famille 5 de #14615, 2026-09-05) :
+      # test_fuzzy_match_group.py seul, 15 tests stdlib+pandas+rapidfuzz,
+      # verts en 0,73 s avec les deps installées (ajoutées au pip install du
+      # job). Ses 2 seuls accès fichier relisent un journal que le test crée
+      # lui-même — zéro donnée étudiante, la réserve PII ne s'applique pas.
+      # Le verdict INTRINSIC initial (grep 0 fichier test) était une mesure
+      # fausse, corrigée sur mesure positive par ai-01 (c.5551368629).
 
       - name: Secrets tests collection floor (148)
         if: always()
@@ -279,3 +291,16 @@ jobs:
           if [ -z "$N" ] || [ "$N" -eq 0 ]; then echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."; exit 1; fi
           if [ "$N" -lt "$SECRETS_TESTS_FLOOR" ]; then echo "::error::Coverage regression: $N tests collected, floor=$SECRETS_TESTS_FLOOR."; exit 1; fi
           echo "OK: $N tests collected (floor=$SECRETS_TESTS_FLOOR)."
+
+      - name: GradeBook tests collection floor (15)
+        # Same two-signal semantics as the audit (455) and secrets (148)
+        # floors: deps missing from the job = collection returns skips instead
+        # of a count = install problem, not a coverage drop.
+        if: always()
+        env:
+          GRADEBOOK_TESTS_FLOOR: 15
+        run: |
+          N=$(python -m pytest GradeBookApp --collect-only -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ tests collected' | grep -oE '^[0-9]+')
+          if [ -z "$N" ] || [ "$N" -eq 0 ]; then echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."; exit 1; fi
+          if [ "$N" -lt "$GRADEBOOK_TESTS_FLOOR" ]; then echo "::error::Coverage regression: $N tests collected, floor=$GRADEBOOK_TESTS_FLOOR."; exit 1; fi
+          echo "OK: $N tests collected (floor=$GRADEBOOK_TESTS_FLOOR)."

--- a/scripts/check_testpaths_coverage.py
+++ b/scripts/check_testpaths_coverage.py
@@ -57,6 +57,10 @@ WORKFLOW_COVERAGE: dict[str, list[str]] = {
         # 254 tests / 9 modules, hermétique (mesure firsthand 2026-09-05 :
         # 253 verts + 1 skip de donnée, yfinance absent de l'env).
         "scripts/quantconnect/tests",
+        # GradeBookApp : dir entier (famille 5 de #14615) — 15 tests
+        # (test_fuzzy_match_group.py seul), deps rapidfuzz/unidecode/openpyxl
+        # ajoutées au pip install du job, zéro PII (journal auto-créé).
+        "GradeBookApp",
     ],
     ".github/workflows/ml-tests.yml": [
         "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests",
@@ -123,10 +127,7 @@ def extract_run_targets(text: str) -> set[str]:
                 stripped = line.strip()
                 if stripped and not stripped.startswith("#"):
                     for token in stripped.split():
-                        if token in ("\\",):
-                            continue
-                        if "/" in token or token.endswith(".py"):
-                            targets.add(token)
+                        _maybe_target(token, targets)
                 continue
         stripped = line.strip()
         if stripped.startswith("run: |"):
@@ -135,9 +136,22 @@ def extract_run_targets(text: str) -> set[str]:
         # run: pytest <cibles> sur une seule ligne (pas de pipe)
         if stripped.startswith("run: pytest"):
             for token in stripped.split()[2:]:
-                if "/" in token or token.endswith(".py"):
-                    targets.add(token)
+                _maybe_target(token, targets)
     return targets
+
+
+def _maybe_target(token: str, targets: set[str]) -> None:
+    """Ajoute le token s'il ressemble à un chemin relatif.
+
+    Chemin = contient un `/`, finit en `.py`, OU est un token nu sans slash
+    ni caractère shell (cas des répertoires racine du dépôt, ex. GradeBookApp
+    — famille 5 de #14615). Les flags (préfixe `-`) et variables (`$`) ne
+    sont jamais des cibles.
+    """
+    if token in ("\\",) or token.startswith("-") or "$" in token:
+        return
+    if "/" in token or token.endswith(".py") or re.fullmatch(r"[A-Za-z0-9_.-]+", token):
+        targets.add(token)
 
 
 def verify_declared_targets(repo_root: Path, verbose: bool) -> list[str]:

--- a/scripts/tests/test_check_testpaths_coverage.py
+++ b/scripts/tests/test_check_testpaths_coverage.py
@@ -56,6 +56,22 @@ def test_extract_run_targets_ignores_comments() -> None:
     assert len({t for t in targets if t.startswith("scripts/")}) == 1
 
 
+def test_extract_run_targets_root_dir_without_slash() -> None:
+    """Un répertoire racine du dépôt (pas de /, ex. GradeBookApp) est extrait.
+
+    Les flags pytest (--tb=short, -q) ne le sont pas (famille 5 de #14615).
+    """
+    text = """        run: |
+          pytest \\
+            scripts/lean/tests \\
+            GradeBookApp \\
+            --tb=short -q
+"""
+    targets = extract_run_targets(text)
+    assert "GradeBookApp" in targets
+    assert "--tb=short" not in targets and "-q" not in targets
+
+
 def test_is_covered_exact_and_ancestor() -> None:
     assert is_covered("scripts/tests", ["scripts/tests"])
     assert is_covered("scripts/lean/tests", ["scripts"])  # ancêtre


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: LIGHT/tooling #14731

## Câblage GradeBookApp — famille 5/6 de #14615 (reprise du dispatch ai-01 c.5551368629)

**Le verdict INTRINSIC initial était une mesure fausse** : `grep -rl "def test_" GradeBookApp` avait rendu 0 fichier alors que `GradeBookApp/test_fuzzy_match_group.py` existe (15 tests) — troisième inversion de motif de l'issue, corrigée par ai-01 sur contrôle positif, re-mesurée firsthand ici.

## Mesures firsthand (2026-09-05, worktree frais origin/main 55dc0a137)

- `grep -c "def test_" GradeBookApp/test_fuzzy_match_group.py` : **15**
- `GradeBookApp` déjà dans pytest.ini testpaths (l.14) ✓
- Deps module-level de `gradebook.py` : pandas, numpy (au job ✓) + **rapidfuzz, unidecode, openpyxl** (absentes du job → ajoutées)
- Run réel avec deps installées (règle F) : **15 passed en 0,73 s**, 0 skip
- PII : les 2 seuls accès fichier du test relisent un journal qu'il crée lui-même — zéro donnée étudiante (la réserve « PII grading hors CI publique » ne s'applique pas au test, only aux données de notation qui restent sur GDrive privé)

## Les 5 registres (leçon wiring + floor-guard)

1. `pip install rapidfuzz unidecode openpyxl` ajouté au job Scripts Tests, avec commentaire documentant l'importeur (`gradebook.py` module top level)
2. `GradeBookApp \` en fin de run list pytest
3. Ligne `CI-EXCLUDED: GradeBookApp` retirée, remplacée par le commentaire de re-câblage (famille 5)
4. Step **GradeBook tests collection floor (15)** — même sémantique deux-signaux que audit (455) et secrets (148) : 0 collecté = crash de collecte (problème d'install), < floor = régression de couverture
5. Entrée `WORKFLOW_COVERAGE` dédiée

## Correctif du garde inclus (même sujet)

`extract_run_targets` filtrait les tokens sans `/` ni `.py` — un répertoire **racine** du dépôt (`GradeBookApp`, sans slash) n'était jamais extrait, donc la cible déclarée échouait toujours. Le filtre reconnaît désormais les tokens nus (regex `[A-Za-z0-9_.-]+`) tout en excluant flags (`-q`, `--tb=short`) et variables (`$`). Nouveau test unitaire épinglant le cas + non-extraction des flags : suite du garde **6 passed** (5 + 1).

## Validation

- `check_testpaths_coverage.py --verbose` → `[ok] tous les testpaths sont couverts ou exclus`, GradeBookApp couvert, 0 dérive
- `scripts/tests/test_check_testpaths_coverage.py` → 6 passed
- `python -m pytest GradeBookApp -q` → 15 passed
- Simulation floor : `N=15` exactement
- YAML valide (parse ok)

Trois fichiers modifiés, un seul sujet (le câblage et son garde). Voir #14615 pour l'inventaire des 6 familles : après celle-ci restent 0 — 2/3/4/5 livrées, 6 = #14679 (mergée 11:07Z).

See #14615
