### PR TITLE
feat(lean,#13483): interface corridor -> jumpCapturedF -- unfolding + dilation closure (tranche 3c etapes 1-2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -74,6 +74,7 @@ kernel) sur le bestiaire ci-dessous. EPIC #3846 / #6724 / #9568.
 
 import Conway.Life.AdversarialBattery
 import Conway.Life.HashlifeCorrectness
+import Conway.Life.LightCone
 
 namespace Conway
 namespace Life
@@ -204,6 +205,72 @@ private def jumpCapturedF (c : MacroCell) : Bool :=
     decide (p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) &&
     decide ((2 ^ c.level : Int) ≤ p.2) &&
     decide (p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+
+/-- **Interface (c) tranche 3, étape 1 — dépliage propositionnel de `jumpCapturedF`.**
+    Même preuve que `jumpCaptured_iff` (JumpCapture L264), répliquée localement :
+    ce module ne peut pas importer `JumpCapture` (cycle d'import, cf docstring de
+    `jumpCapturedF` ci-dessus). C'est la porte d'entrée du corridor (LightCone,
+    langage `isAlive`) dans le prédicat Bool que `hcap` exige. -/
+theorem jumpCapturedF_iff (c : MacroCell) :
+    jumpCapturedF c = true ↔
+      ∀ p ∈ evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0)),
+        (2 ^ c.level : Int) ≤ p.1 ∧
+          p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int) ∧
+          (2 ^ c.level : Int) ≤ p.2 ∧
+          p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int) := by
+  unfold jumpCapturedF
+  rw [List.all_eq_true]
+  constructor
+  · intro h p hp
+    have hb := h p hp
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at hb
+    tauto
+  · intro h p hp
+    have hb := h p hp
+    simp only [Bool.and_eq_true, decide_eq_true_eq]
+    tauto
+
+/-- **Interface (c) tranche 3, étape 2 — le corridor forward ferme le saut dès
+    que la fenêtre absorbe la dérive.** Pont entre le langage du corridor
+    (`evolve_support_dilation_from`, brique (a-b) de la tranche 3, LightCone :
+    confinement `isAlive` de la trajectoire) et le prédicat Bool `jumpCapturedF` :
+    si le support de la grille paddée tient dans la boîte `[a, b)` (`h₀`) et que
+    la boîte dilatée de `2^c.level` — la dérive forward maximale du saut — reste
+    dans la fenêtre du test `[2^lvl, 2^lvl + 2^(lvl+1))²` (`hwin1..4`), alors le
+    saut est capturé. La preuve ne fait aucune hypothèse de réversibilité (le GoL
+    n'est pas réversible) : le relais forward borne la dérive depuis `t₀ = 0`,
+    l'inclusion de fenêtres est linéaire. Les hypothèses `h₀`/`hwin` sont ce que
+    la partie géométrique de L3 (caractériser le niveau de la reconstruction le
+    long de la trajectoire) doit établir — ce lemme en est la cloison nette :
+    confinement forward [prouvé par le corridor] séparé de géométrie de fenêtre
+    [ouverte]. Les bornes de `hwin` portent le cast nat explicite
+    `((2 ^ c.level : Nat) : Int)` — même atome que celle du corridor (sinon la
+    puissance est forcée dans Int et omega la voit déconnectée). -/
+theorem jumpCapturedF_of_dilation (c : MacroCell) (a b : Int × Int)
+    (h₀ : ∀ p, isAlive ((padCenter2 c).toGrid (0, 0)) p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (hwin1 : ((2 ^ c.level : Nat) : Int) ≤ a.1 - ((2 ^ c.level : Nat) : Int))
+    (hwin2 : b.1 + ((2 ^ c.level : Nat) : Int) ≤
+      ((2 ^ c.level : Nat) : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+    (hwin3 : ((2 ^ c.level : Nat) : Int) ≤ a.2 - ((2 ^ c.level : Nat) : Int))
+    (hwin4 : b.2 + ((2 ^ c.level : Nat) : Int) ≤
+      ((2 ^ c.level : Nat) : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) :
+    jumpCapturedF c = true := by
+  rw [jumpCapturedF_iff]
+  intro p hp
+  have hq : isAlive (evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))) p = true := by
+    rw [isAlive]
+    exact List.elem_iff.mpr hp
+  obtain ⟨c1, c2, c3, c4⟩ :=
+    evolve_support_dilation_from 0 (2 ^ c.level) ((padCenter2 c).toGrid (0, 0)) a b
+      (Nat.zero_le _) h₀ p hq
+  simp only [Nat.sub_zero] at c1 c2 c3 c4
+  -- le but (issu de la définition) parle en `(2 ^ lvl : Int)` (pow dans Int) :
+  -- la relation avec le cast nat du corridor est fournie explicitement, puis
+  -- tout est linéaire.
+  have hpow : (2 ^ c.level : Int) = ((2 ^ c.level : Nat) : Int) := by
+    exact (Nat.cast_pow 2 c.level).symm
+  omega
 
 /-- **P4.4 L2 (réduction sorry-stable).** L'égalité globale du cadre se réduit à
     l'hypothèse de capture de trajectoire de la machine N : `hashlife_correctN` (prouvé)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -73,6 +73,7 @@ bestiary below. EPIC #3846 / #6724 / #9568.
 
 import Conway.Life.AdversarialBattery_en
 import Conway.Life.HashlifeCorrectness
+import Conway.Life.LightCone_en
 
 namespace Conway_en
 open Conway
@@ -205,6 +206,72 @@ private def jumpCapturedF (c : MacroCell) : Bool :=
     decide (p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) &&
     decide ((2 ^ c.level : Int) ≤ p.2) &&
     decide (p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+
+/-- **Interface (c) tranche 3, step 1 — propositional unfolding of `jumpCapturedF`.**
+    Same proof as `jumpCaptured_iff` (JumpCapture L264), replicated locally:
+    this module cannot import `JumpCapture` (import cycle, cf docstring of
+    `jumpCapturedF` above). This is the corridor's entry gate (LightCone,
+    `isAlive` language) into the Bool predicate that `hcap` requires. -/
+theorem jumpCapturedF_iff (c : MacroCell) :
+    jumpCapturedF c = true ↔
+      ∀ p ∈ evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0)),
+        (2 ^ c.level : Int) ≤ p.1 ∧
+          p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int) ∧
+          (2 ^ c.level : Int) ≤ p.2 ∧
+          p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int) := by
+  unfold jumpCapturedF
+  rw [List.all_eq_true]
+  constructor
+  · intro h p hp
+    have hb := h p hp
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at hb
+    tauto
+  · intro h p hp
+    have hb := h p hp
+    simp only [Bool.and_eq_true, decide_eq_true_eq]
+    tauto
+
+/-- **Interface (c) tranche 3, step 2 — the forward corridor closes the jump as
+    soon as the window absorbs the drift.** Bridge between the corridor's
+    language (`evolve_support_dilation_from`, brick (a-b) of tranche 3,
+    LightCone: `isAlive` confinement of the trajectory) and the Bool predicate
+    `jumpCapturedF`: if the padded grid's support fits in the box `[a, b)`
+    (`h₀`) and the box dilated by `2^c.level` — the jump's maximal forward
+    drift — stays inside the test window `[2^lvl, 2^lvl + 2^(lvl+1))²`
+    (`hwin1..4`), then the jump is captured. The proof makes no reversibility
+    assumption (GoL is not reversible): the forward relay bounds the drift from
+    `t₀ = 0`, the window inclusion is linear. The `h₀`/`hwin` hypotheses are
+    what the geometric half of L3 (characterizing the reconstruction's level
+    along the trajectory) must establish — this lemma is the clean partition:
+    forward confinement [proved by the corridor] separated from window
+    geometry [open]. The `hwin` bounds carry the explicit nat cast
+    `((2 ^ c.level : Nat) : Int)` — the same atom as the corridor's (otherwise
+    the power is forced into Int and omega sees it disconnected). -/
+theorem jumpCapturedF_of_dilation (c : MacroCell) (a b : Int × Int)
+    (h₀ : ∀ p, isAlive ((padCenter2 c).toGrid (0, 0)) p = true →
+      a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2)
+    (hwin1 : ((2 ^ c.level : Nat) : Int) ≤ a.1 - ((2 ^ c.level : Nat) : Int))
+    (hwin2 : b.1 + ((2 ^ c.level : Nat) : Int) ≤
+      ((2 ^ c.level : Nat) : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+    (hwin3 : ((2 ^ c.level : Nat) : Int) ≤ a.2 - ((2 ^ c.level : Nat) : Int))
+    (hwin4 : b.2 + ((2 ^ c.level : Nat) : Int) ≤
+      ((2 ^ c.level : Nat) : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) :
+    jumpCapturedF c = true := by
+  rw [jumpCapturedF_iff]
+  intro p hp
+  have hq : isAlive (evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))) p = true := by
+    rw [isAlive]
+    exact List.elem_iff.mpr hp
+  obtain ⟨c1, c2, c3, c4⟩ :=
+    evolve_support_dilation_from 0 (2 ^ c.level) ((padCenter2 c).toGrid (0, 0)) a b
+      (Nat.zero_le _) h₀ p hq
+  simp only [Nat.sub_zero] at c1 c2 c3 c4
+  -- the goal (from the definition) speaks in `(2 ^ lvl : Int)` (power in Int):
+  -- its relation with the corridor's nat cast is provided explicitly, then
+  -- everything is linear.
+  have hpow : (2 ^ c.level : Int) = ((2 ^ c.level : Nat) : Int) := by
+    exact (Nat.cast_pow 2 c.level).symm
+  omega
 
 /-- **P4.4 L2 (sorry-stable reduction).** The frame's global equality reduces to
     the N-machine's trajectory-capture hypothesis: `hashlife_correctN` (proved)


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: LIGHT/docs #14729

## Summary

#13483 tranche 3, interface (c), **étapes 1-2 : la porte d'entrée du corridor dans le prédicat Bool `jumpCapturedF`**.

Le pont L3 (`centralCorrect → hcap`, scoping c.5551298160) exigeait nommément la liaison « support dans boîte ⟹ `jumpCapturedF` au niveau de la reconstruction = true ». Cette PR pose la cloison nette entre les deux moitiés de L3 :

- **`jumpCapturedF_iff`** (étape 1) — dépliage propositionnel du prédicat Bool en implication de support `∀ p ∈ evolve (2^lvl) (padded)`. Même preuve que `jumpCaptured_iff` (JumpCapture L264), répliquée localement car ce module ne peut pas importer `JumpCapture` (cycle d'import, cf docstring de `jumpCapturedF`).
- **`jumpCapturedF_of_dilation`** (étape 2) — **consomme le corridor livré par #14712** : si le support de la grille paddée tient dans la boîte `[a, b)` et que la boîte dilatée de `2^lvl` (la dérive forward maximale du saut) reste dans la fenêtre du test `[2^lvl, 2^lvl + 2^(lvl+1))²`, alors `jumpCapturedF c = true`. La preuve applique `evolve_support_dilation_from` (relais forward, brique a-b) depuis `t₀ = 0` — **aucune hypothèse de réversibilité** (le GoL n'est pas réversible ; le cône rétrograde ne contraint pas les états intermédiaires).

**Ce que ce lemme sépare** : confinement forward [prouvé, par le corridor] ↔ géométrie de fenêtre/padding [la partie encore ouverte de L3 — caractériser le niveau de la reconstruction le long de la trajectoire]. Les hypothèses `h₀`/`hwin1..4` sont exactement ce que la partie géométrique doit établir : L3 se réduit désormais à produire ces bornes, sans plus toucher au Bool.

Les bornes `hwin` portent le cast nat explicite `((2 ^ c.level : Nat) : Int)` — même atome que celle du corridor (leçon #14712 : l'ascription `(2^lvl : Int)` force la pow dans Int et déconnecte omega) ; le pont `hpow : (2^lvl : Int) = ((2^lvl : Nat) : Int)` est fourni dans la preuve (`Nat.cast_pow`), l'inclusion de fenêtres est linéaire.

Jumeau `HashlifeMarginFragment_en.lean` : docstrings EN, preuves byte-identical (convention i18n #4980), import `LightCone_en` ajouté (FR : `LightCone`).

## Validation

- **`lake build Conway.Life.HashlifeMarginFragment Conway.Life.HashlifeMarginFragment_en` : SUCCESS local** (PIPESTATUS 0, vérifié) — nouveau départ vert au premier passage.
- Sorry count : `python scripts/lean/count_code_sorry.py --json` — `conway_lean : distinct_code_sorry = 1` AVANT/APRÈS inchangé (2 nouveaux théorèmes sorry-free ; le sorry résiduel reste `hashlife_correct_margin`, cible de l'interface).
- Claim : `check_lane_claim.py --lane myia-po-2024:CoursIA 13483` → CLEAR (claim actif de la lane).

See #13483 (tranche 3, interface (c) étapes 1-2, scoping c.5551298160)
See #14712 (briques corridor consommées)

---

### B.3 — proof-integrity : portée mesurée (ajouté par `myia-ai-01` au merge)

Le body ne portait pas la 3ᵉ preuve exigée par `pr-review-discipline.md` §B. Je l'ai
mesurée plutôt que de la sauter en silence, et je l'écris ici parce que c'est le
body qui doit la porter :

| Job de `lean-conway.yml` | `target-modules` | `fail-on-sorry` | Atteint `Conway.Life.HashlifeMarginFragment` ? | Verdict sur `744213ef` |
|---|---|---|---|---|
| `proof-integrity` (**bloquant**) | `Conway.KochenSpecker,Conway.FreeWillTheorem` | `true` | **NON** | success — mais **hors cible** |
| `proof-integrity-audit` (advisory) | `*` | `false` | **OUI** (wildcard) | success |

**Lecture honnête.** Le vert du job **bloquant** ne peut pas être cité comme preuve
pour cette PR : ses `target-modules` n'atteignent le module ni directement ni par
clôture d'imports — c'est exactement le vert-hors-cible que #8782 rend
indiscernable d'un vert sur cible dans le rollup. Ce qui couvre réellement le
module est l'audit **advisory** à `"*"`, vert lui aussi, mais en `fail-on-sorry:
false` : il atteste que les axiomes énumérés restent dans l'allow-list, **pas** la
sorry-freeness. `conway target-coverage` (l'organe qui rend précisément cet écart
lisible) est vert.

**Ce qui reste donc établi, et par quoi** : `lake build` SUCCESS — corroboré en CI
par `ci / Lean CI (conway_lean)` vert, pas seulement par le run local du body ; et
`distinct_code_sorry = 1` sur `conway_lean`, **inchangé**, que j'ai re-mesuré
moi-même avec `python scripts/lean/count_code_sorry.py --json` (le compte naïf du
même lake est 181 — un `grep -c sorry` aurait sur-compté d'un facteur 181, ce que
§B proscrit nommément).
