### PR TITLE
fix(picker,#14738): zone_umbrellas nomme les EPICs racines attestes dans une zone

### DIFF
--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -659,6 +659,17 @@ def zone_umbrellas(issue_to_family: dict, pool: list, families=()) -> dict:
     -- un verdict qui ne nomme pas l'EPIC responsable laisse le lecteur le
     chercher. Une zone chaude SANS parent declare est le cas le plus grave et
     non le plus propre : personne n'y est comptable de la contrepartie.
+
+    Deux sources : (1) les parents DECLARES par les grains du pool ; (2) les
+    EPICs racines (label/titre EPIC, file de tranches) ATTESTES dans une zone
+    par les PRs mergees qui les citent (`issue_to_family`). Sans la seconde,
+    un tracker racine sans fille ouverte -- #13934, dont les tranches vivent
+    dans des PRs mergees, pas dans des issues -- rendait la zone qu'il
+    alimente "SANS REMEDE (aucun EPIC declare)".
+
+    L'attestation est la porte d'entree de la source (2) : une issue qui ne
+    fait que MENTIONNER la zone (body de diagnostic, renvoi de contexte) n'est
+    pas un comptable, meme si son texte porte les marqueurs de tracker.
     """
     out: dict[str, dict[int, int]] = {}
     for it in pool:
@@ -668,7 +679,41 @@ def zone_umbrellas(issue_to_family: dict, pool: list, families=()) -> dict:
             continue
         out.setdefault(fam, {})
         out[fam][parent] = out[fam].get(parent, 0) + 1
+    for it in pool:
+        if not is_area_umbrella(it):
+            continue
+        fam = (issue_to_family or {}).get(it.get("number"))
+        if not fam:
+            continue
+        out.setdefault(fam, {})
+        out[fam][it["number"]] = out[fam].get(it["number"], 0) + 1
     return out
+
+
+# Une issue qui TRACK une zone est nommable comme "alimente par" d'une zone
+# chaude : EPIC par label/titre (meme logique que le pool du picker), ou file
+# de tranches (#13934, "queue de tranches"). Les tranches vivent dans des PRs
+# mergees, pas dans des issues ouvertes -- un tel tracker racine n'a donc
+# jamais de parent declare dans le pool, et seule l'attestation par les PRs
+# citees (`issue_to_family`) le rend visible.
+_TRACKER_TRANCHES_RE = re.compile(r"tranches?", re.I)
+
+
+def is_area_umbrella(item: dict) -> bool:
+    """L'issue PEUT-ELLE etre nommee comme comptable d'une zone chaude ?
+
+    Distingue de la classification du pool (`klass` = umbrella) : celle-la
+    decide du triage du tirage (un grain utilisable), celle-ci ne nomme qu'un
+    comptable pour l'affichage de la parite. Les deux predicats peuvent
+    diverger sans creer de double lecteur de source.
+    """
+    title = item.get("title") or ""
+    labels = {str(x).lower() for x in item.get("labels", []) or []}
+    if "epic" in labels or title.upper().lstrip("[").startswith("EPIC"):
+        return True
+    head = "\n".join((item.get("body") or "").splitlines()[:_EPIC_PARENT_HEAD_LINES])
+    return bool(_TRACKER_TRANCHES_RE.search(title)) or bool(
+        _TRACKER_TRANCHES_RE.search(head))
 
 
 def main() -> int:

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -289,6 +289,59 @@ def test_zone_umbrellas_empty_when_no_parent_declared():
     assert ss.zone_umbrellas({1: "Z"}, pool) == {}
 
 
+def test_zone_umbrellas_names_root_tracker_attested_in_zone():
+    """Tracker racine sans fille ouverte (#13934) : nomme pour sa zone.
+
+    Ses tranches vivent dans des PRs mergees qui le citent -- `issue_to_family`
+    l'atteste dans la zone, `parent` reste None, et sans la source (2) la zone
+    chaude rendait "(aucun EPIC declare)" alors que son remede est ouvert.
+    """
+    pool = [
+        {"number": 100, "parent": None, "title": "Enrichissement AI-Engine-WordPress : ",
+         "body": "queue de tranches -- la zone reste vivante", "labels": []},
+        {"number": 101, "parent": None, "title": "d", "body": "", "labels": []},
+    ]
+    i2f = {100: "GenAI/Plateformes-Conversationnelles", 101: "Z"}
+    out = ss.zone_umbrellas(i2f, pool)
+    assert out["GenAI/Plateformes-Conversationnelles"] == {100: 1}, out
+
+
+def test_zone_umbrellas_names_epic_label_root_attested():
+    """EPIC racine par label, attestee dans une zone : nommee comme comptable."""
+    pool = [
+        {"number": 50, "parent": None, "title": "g", "labels": ["EPIC"], "body": ""},
+        {"number": 51, "parent": None, "title": "h", "body": ""},
+    ]
+    out = ss.zone_umbrellas({50: "Z"}, pool)
+    assert out["Z"] == {50: 1}, out
+
+
+def test_zone_umbrellas_ignores_plain_attested_issue():
+    """Une issue ordinaire attestee n'est pas nommee comptable.
+
+    Le controle negatif du garde d'attribution : le predicat repare qui rend
+    "tout le monde alimente tout" est un predicat casse dans l'autre sens.
+    """
+    pool = [{"number": 7, "parent": None, "title": "upgrade", "body": ""}]
+    assert ss.zone_umbrellas({7: "Z"}, pool) == {}
+
+
+def test_zone_umbrellas_ignores_unattested_tracker_mention():
+    """Tracker mentionne mais NON atteste : pas de comptable.
+
+    L'attestation (`issue_to_family`, PRs mergees qui citent l'issue) est la
+    porte d'entree : une issue qui ne fait que citer la zone dans son texte
+    (body de diagnostic, renvoi de contexte) ne nomme pas la zone -- le cas
+    d'un corps qui paraphrasait "queue de tranches" en se citant lui-meme.
+    """
+    pool = [
+        {"number": 200, "parent": None, "title": "x",
+         "body": "queue de tranches -- zone Z mentionnee au fil du texte",
+         "labels": []},
+    ]
+    assert ss.zone_umbrellas({}, pool) == {}
+
+
 # --- Attribution : ce qui empechait de NOMMER l'EPIC -----------------------
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA-2 — prev: MED/docs #14558

## Summary

Le picker rendait `SANS REMEDE` / « (aucun EPIC declare) » sur une zone chaude dont l'EPIC alimentant est pourtant ouvert. Cas mesuré : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles` (3 notebooks neufs) alimentée par #13934 (enrichissement AI-Engine-WordPress, queue de tranches active — 8+ PRs mergées qui la consomment, dont #14688-#14692 le 2026-09-05).

DISPATCH ai-01 (msg-20260904T235231-35u615) : départager deux hypothèses avant d'écrire quoi que ce soit.

## Diagnostic firsthand

Reproduction via le pipeline exact du picker (fetch_pool + fetch_series_visits + resolve_family + zone_umbrellas), lancé le 2026-09-05 :

- **#13934** : dans le pool ouvert, `parent=None` (tracker racine, pas de fille ouverte), attestée dans la zone par `issue_to_family` (les PRs mergées de la fenêtre qui la citent touchent `GenAI/Plateformes-Conversationnelles`).
- **#13581** (réorganisation GenAI) : `resolve_family` = `GenAI/FallacyDetection`.
- **Aucune issue du pool ne déclare `parent` = 13934/13581** : les tranches vivent dans des PRs mergées, pas dans des issues ouvertes.
- `zone_umbrellas(...)[zone]` = `None` → « (aucun EPIC declare) ».

**Hypothèse (a) table statique écartée** : l'attribution est dérivée. **Hypothèse (b) confirmée** : `zone_umbrellas` ne compte que les parents *déclarés* par les issues du pool ; un tracker racine attesté dans une zone n'apparaît jamais comme « EPIC de la zone ». Aucun patch au cas : le fix est générique.

## Fix

`zone_umbrellas` (scripts/series_saturation.py) lit désormais **deux sources** :

1. les parents déclarés par les grains du pool (comportement existant) ;
2. les **EPICs racines attestés** dans une zone : label/titre EPIC ou file de tranches (« tranches » — cas #13934), et **attestés** dans la zone par `issue_to_family` (PRs mergées de la fenêtre qui les citent).

L'attestation est la porte d'entrée : une issue qui ne fait que *mentionner* la zone dans son texte (body de diagnostic, renvoi de contexte) n'est pas nommée comptable — le prédicat ne nomme que des travailleurs attestés, jamais des citeurs.

Verdicts et tirages inchangés : `zone_umbrellas` est un affichage (« alimentee par ») ; `zone_verdict` / `SANS REMEDE` / `admissibility` ne sont pas touchés.

## Validation (post-fix, relancée)

- **Tests unitaires** : `pytest scripts/tests/test_series_saturation.py` → **46 passed** (42 existants + 4 nouveaux : tracker racine attesté nommé ; EPIC label racine attesté nommé ; issue ordinaire attestée non nommée ; tracker *mentionné mais non attesté* non nommé).
- **Contrôle end-to-end** (garde ai-01) — bloc « Zones chaudes » recalculé sur le pipeline réel :

```
   6 neufs |  1 exp /  2 con  EMBALLEMENT  MyIA.AI.Notebooks/ML/DataScienceWithAgents
       alimentee par #14058 #3801
   3 neufs |  0 exp /  0 con  SANS REMEDE  MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles
       alimentee par #13934
```

Contrôle **positif** : une zone connue pour avoir un EPIC de remède → le picker le trouve (`#13934` nommé). Contrôle **négatif** : une zone sans EPIC déclaré ni attesté → « (aucun EPIC declare) » reste (ML/DataScienceWithAgents inchangé ; aucune zone n'a gagné de comptable fantôme). Le prédicat échoue symétriquement : l'issue de diagnostic elle-même (#14738, corps citant la zone) a été rejetée par l'attestation pendant la revue du contrôle.

## Preuves

- Pre-commit : hooks H.3 / gitleaks / encoding **Passed** sur le commit `5656616db571`.
- Diff : 2 fichiers, +98 lignes, 0 suppression (EOL LF vérifié, 0 CR introduit).

Closes #14738