### PR TITLE
Consolidation DSA #13504 : renumerotation Labs ADK Day5 (14/15/16 -> 12b/12c/12d, collision numerotation globale)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12b-Sequential-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12b-Sequential-Orchestration.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Lab 16 : Désignation séquentielle — le contrat C4, l'orchestrateur explicite au-dessus d'ADK\n",
+    "# Lab 12b : Désignation séquentielle — le contrat C4, l'orchestrateur explicite au-dessus d'ADK\n",
     "\n",
     "Le quatrième contrat EPITA du registre (#14058) : **le runtime désigne le prochain agent selon une stratégie explicite**. La mesure initiale : ADK 2.8 embarque bien un ordonnanceur dynamique, mais aucune surface du dépôt n'exposait de stratégie — l'ordre Planner→Coder→… de vos chaînes était codé à la main, étape par étape, chez l'appelant. Ce lab travaille sur le portage livré par #14685 : un `AdkOrchestrator` accepte N spécialistes et exécute la chaîne selon un **plan déclaratif** posé avant le premier appel LLM.\n",
     "\n",
@@ -330,7 +330,7 @@
    "source": [
     "## 4. Désignation C4 vs handoff C5 : l'ordre posé avant, pas décidé pendant\n",
     "\n",
-    "Le point de distinction avec le Lab 15 : là, le transfert était **décidé par l'agent** au milieu d'un tour (`transfer_to_agent`) ; ici, l'ordre est **une donnée**. La preuve par l'expérience : la même flotte d'agents, un plan réduit — le déroulé change sans qu'aucun agent ne soit modifié."
+    "Le point de distinction avec le Lab 12c : là, le transfert était **décidé par l'agent** au milieu d'un tour (`transfer_to_agent`) ; ici, l'ordre est **une donnée**. La preuve par l'expérience : la même flotte d'agents, un plan réduit — le déroulé change sans qu'aucun agent ne soit modifié."
    ]
   },
   {
@@ -361,7 +361,7 @@
       "Plan réduit : ('planner', 'verifier')\n",
       "Désignation exécutée : ('planner', 'verifier')\n",
       "Appels d'outils : aucun\n",
-      "Côté C4, changer l'ordre = changer UNE donnée ; côté C5 (Lab 15), le transfert était décidé par le modèle en cours de tour.\n"
+      "Côté C4, changer l'ordre = changer UNE donnée ; côté C5 (Lab 12c), le transfert était décidé par le modèle en cours de tour.\n"
      ]
     }
    ],
@@ -385,7 +385,7 @@
     "print(f\"Désignation exécutée : {resultat_reduit.agent_hands}\")\n",
     "print(f\"Appels d'outils : {resultat_reduit.tool_calls or 'aucun'}\")\n",
     "print(\"Côté C4, changer l'ordre = changer UNE donnée ; côté C5 \"\n",
-    "      \"(Lab 15), le transfert était décidé par le modèle en cours de tour.\")\n"
+    "      \"(Lab 12c), le transfert était décidé par le modèle en cours de tour.\")\n"
    ]
   },
   {
@@ -707,8 +707,8 @@
    "end_time": "2026-09-05T04:05:40.069475+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Lab16-Sequential-Orchestration.ipynb",
-   "output_path": "Lab16-Sequential-Orchestration.ipynb",
+   "input_path": "Lab12b-Sequential-Orchestration.ipynb",
+   "output_path": "Lab12b-Sequential-Orchestration.ipynb",
    "parameters": {},
    "start_time": "2026-09-05T04:05:11.951822+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12c-Agent-Handoff.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12c-Agent-Handoff.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Lab 15 : Handoff entre agents — le contrat C5, le transfert natif câblé et observable\n",
+    "# Lab 12c : Handoff entre agents — le contrat C5, le transfert natif câblé et observable\n",
     "\n",
     "Le cinquième contrat EPITA du registre (#14058) : **un agent peut transférer la main à un autre agent, et le transfert est observable**. La mesure initiale de la tranche 3 disait : ADK 2.8 porte le transfert natif (`TransferToAgentTool`), mais rien ne l'exerçait — aucun agent du dépôt ne déclarait de hiérarchie. Ce lab travaille sur le câblage livré par #14686 : `build_agent` accepte `sub_agents`, et chaque tour rend **qui a parlé** (`agent_hands`) et **quels transferts ont eu lieu** (`handoffs`).\n",
     "\n",
@@ -694,8 +694,8 @@
    "end_time": "2026-09-05T03:37:00.163186+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Lab15-Agent-Handoff.ipynb",
-   "output_path": "Lab15-Agent-Handoff.ipynb",
+   "input_path": "Lab12c-Agent-Handoff.ipynb",
+   "output_path": "Lab12c-Agent-Handoff.ipynb",
    "parameters": {},
    "start_time": "2026-09-05T03:36:40.150032+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12d-Token-Usage.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12d-Token-Usage.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Lab 14 : Tracabilite de la consommation — le contrat C6 rend l'usage LLM observable\n",
+    "# Lab 12d : Tracabilite de la consommation — le contrat C6 rend l'usage LLM observable\n",
     "\n",
     "**Grain #14687 (registre EPITA #14058, contrat C6)**. La consommation d'une conversation\n",
     "multi-agents n'est pas un detail d'exploitation : c'est une **propriete observable du\n",
@@ -774,8 +774,8 @@
    "end_time": "2026-09-05T01:29:09.334499+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Day5-DS-Star/Lab14-Token-Usage.ipynb",
-   "output_path": "Day5-DS-Star/Lab14-Token-Usage.ipynb",
+   "input_path": "Day5-DS-Star/Lab12d-Token-Usage.ipynb",
+   "output_path": "Day5-DS-Star/Lab12d-Token-Usage.ipynb",
    "parameters": {},
    "start_time": "2026-09-05T01:28:48.830997+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/README.md
@@ -69,6 +69,9 @@ Track2-GoogleADK/
 │   ├── Lab10-File-Analyzer.ipynb
 │   ├── Lab11-Planner-Coder-Loop.ipynb
 │   ├── Lab12-DS-Star-Workshop.ipynb
+│   ├── Lab12b-Sequential-Orchestration.ipynb
+│   ├── Lab12c-Agent-Handoff.ipynb
+│   ├── Lab12d-Token-Usage.ipynb
 │   └── Lab18-Session-Persistence.ipynb
 │
 ├── Day6-MLE-Star/             # MLE-STAR (ML Engineering)
@@ -92,7 +95,7 @@ Introduction au framework ADK et configuration multi-provider.
 | 8 | [ADK-Introduction](Day4-Foundations/Lab8-ADK-Introduction.ipynb) | Architecture ADK, configuration providers |
 | 9 | [First-ADK-Agent](Day4-Foundations/Lab9-First-ADK-Agent.ipynb) | Premier agent pour Data Science |
 
-### Day 5 - DS-STAR (Labs 10-12, 18)
+### Day 5 - DS-STAR (Labs 10-12, 12b-12d, 18)
 
 Data Science autonome avec l'architecture Planner-Coder-Verifier.
 
@@ -101,6 +104,9 @@ Data Science autonome avec l'architecture Planner-Coder-Verifier.
 | 10 | [File-Analyzer](Day5-DS-Star/Lab10-File-Analyzer.ipynb) | Analyse de fichiers hétérogènes |
 | 11 | [Planner-Coder-Loop](Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb) | Boucle itérative multi-agents |
 | 12 | [DS-Star-Workshop](Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb) | Application complète |
+| 12b | [Sequential-Orchestration](Day5-DS-Star/Lab12b-Sequential-Orchestration.ipynb) | Contrat C4 : désignation séquentielle, orchestrateur explicite (#14058) |
+| 12c | [Agent-Handoff](Day5-DS-Star/Lab12c-Agent-Handoff.ipynb) | Contrat C5 : handoff entre agents câblé et observable (#14058) |
+| 12d | [Token-Usage](Day5-DS-Star/Lab12d-Token-Usage.ipynb) | Contrat C6 : traçabilité de la consommation LLM (#14058) |
 | 18 | [Session-Persistence](Day5-DS-Star/Lab18-Session-Persistence.ipynb) | Contrat C1b : conversation multi-tours persistante (#14058) |
 
 ### Day 6 - MLE-STAR (Labs 13-15)


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #14735

## Consolidation DSA #13504 — renumerotation des Labs ADK de Day5 (collision de numerotation globale)

**Constat mesure (7j)** : 9 notebooks DSA ajoutes sur 7 jours, 2 consolidations livrees vs 1 tranche d'expansion — l'EPIC #13504 mandate un grain de consolidation par tranche d'expansion.

**Defaut concret** : les Labs ADK de Day5 livrés par #14690/#14686/#14709 portaient les numeros **Lab14 / Lab15 / Lab16**, qui COLLIDENT avec la numerotation GLOBALE du track Track2-GoogleADK documentee au README (les numeros Lab sont uniques sur toute la semaine) :

| Numero | Day5 (nouveau, disque) | Day6/Day7 (README, existant) |
|--------|------------------------|------------------------------|
| Lab14 | Token-Usage | Lab14-Ablation-Refinement (Day6) |
| Lab15 | Agent-Handoff | Lab15-Kaggle-Challenge (Day6) |
| Lab16 | Sequential-Orchestration | Lab16-Data-Science-Agent (Day7) |

Les 3 nouveaux etaient de plus ABSENTS de l'arbre et de la table du README Track2 (le Day5 y sautait de Lab12 a Lab18).

## Livrable

Renum en **lettres du Lab12 existant** (pattern maison 2.8b/2.8c/3.6b), ordre des contrats #14058 croissant :

- `Lab16-Sequential-Orchestration.ipynb` → `Lab12b-Sequential-Orchestration.ipynb` (contrat C4)
- `Lab15-Agent-Handoff.ipynb` → `Lab12c-Agent-Handoff.ipynb` (contrat C5)
- `Lab14-Token-Usage.ipynb` → `Lab12d-Token-Usage.ipynb` (contrat C6)

Interne : titres H1, 3 refs de prose "Lab 15" → "Lab 12c" (dans 12b), metadata papermill input/output_path (normalisation au nouveau nom — metadata, pas une sortie). README : arbre + table + 3 lignes objectif completees.

## Verifications (firsthand)

- **#14058 ne prescrit aucun numero de Lab** (body lu : contrats C4/C5/C6, runtime de reference Lab11/12 — pas de numerotation imposee) : le renum ne deroge a aucun contrat.
- **Zero reference externe** aux 3 anciens chemins dans tout le depot (grep md/ipynb/py/yml ; controle positif : le grep matche les fichiers eux-memes avant renommage).
- **Navlinks** : `check_notebook_navlinks.py` → 0 lien casse sur les 4 notebooks Day5 scannes (12b/12c/12d/18).
- **Ledgers cles-par-chemin intacts** : pas de `_en` (pas de CSV translations), absents de `pedagogy_density_baseline.json`, catalogue = CI (jamais regenerate a la main).
- **C.2** : edits markdown + metadata uniquement → `execution_count` et `outputs` precedents conserves (8/8 cellules code avec exec/outputs par notebook). Pre-commit H.3 Passed.
- **Zero residu** des anciens numeros dans les fichiers renommes (comptage programme avant/apres avec assertions).

## Perimetre

Contribution partielle a l'EPIC : See #13504. Lab18-Session-Persistence NON touche (pas de collision — numero 18 unique, deja documente README).

Claim : [CLAIMED] #13504 c.5551823773.
