### PR TITLE
fix(ml,#9768): ucr_anomaly_fetch — manifeste illisible rapporte au basename, sans chemin machine

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/tests/test_ucr_anomaly_fetch.py
+++ b/MyIA.AI.Notebooks/ML/ML.Net/tests/test_ucr_anomaly_fetch.py
@@ -160,3 +160,20 @@ def test_load_manifest_rejects_malformed_entry(
 def test_fetch_raw_rejects_unmanifested_series() -> None:
     with pytest.raises(ucr.UcrFetchError, match="aucune empreinte"):
         ucr.fetch_raw("unknown.txt")
+
+
+def test_load_manifest_error_hides_machine_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    missing = tmp_path / "ucr_anomaly_manifest.json"
+    monkeypatch.setattr(ucr, "_MANIFEST_PATH", str(missing))
+
+    with pytest.raises(ucr.UcrFetchError) as excinfo:
+        ucr._load_manifest()
+
+    message = str(excinfo.value)
+    parent = str(missing.parent)
+    escaped = parent.replace("\\", "\\\\")
+    assert parent not in message and escaped not in message
+    assert "ucr_anomaly_manifest.json" in message
+    assert "FileNotFoundError" in message

--- a/MyIA.AI.Notebooks/ML/ML.Net/ucr_anomaly_fetch.py
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ucr_anomaly_fetch.py
@@ -134,7 +134,8 @@ def _load_manifest() -> dict[str, dict[str, int | str]]:
             manifest = json.load(fh)
     except (OSError, json.JSONDecodeError) as exc:
         raise UcrFetchError(
-            f"manifeste d'integrite UCR illisible ({type(exc).__name__}: {exc})."
+            f"manifeste d'integrite UCR illisible "
+            f"({type(exc).__name__} sur {os.path.basename(_MANIFEST_PATH)})."
         ) from exc
     if not isinstance(manifest, dict):
         raise UcrFetchError("manifeste d'integrite UCR invalide : objet JSON attendu.")


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: MED/genai #14697 (c.262)

# Fix #14736 : le message de manifeste illisible interpole un chemin machine absolu

`_MANIFEST_PATH` est absolu (derivé de `__file__`) et le `str()` d'une `OSError` porte le nom de fichier tel que passé à `open()` : le message rendait `manifeste d'integrite UCR illisible (FileNotFoundError: [Errno 2] No such file or directory: 'D:\...\ucr_anomaly_manifest.json')`. Cause (C) source-leak du triage `secrets-hygiene.md` règle 6 — corriger la source, jamais scrubber la sortie.

## Changements (2 fichiers, +19/−1, aucun notebook, catalogue byte-identique à main)

- `MyIA.AI.Notebooks/ML/ML.Net/ucr_anomaly_fetch.py` : le message interpole désormais `os.path.basename(_MANIFEST_PATH)` — `({type(exc).__name__} sur {basename})`. Le basename suffit au diagnostic : le fichier vit à côté du module.
- `MyIA.AI.Notebooks/ML/ML.Net/tests/test_ucr_anomaly_fetch.py` : test `test_load_manifest_error_hides_machine_path` (contrôle positif exigé par l'acceptance).

## Subtilité du contrôle positif

`str(OSError)` échappe les backslashes sous Windows (forme repr : `'C:\Users\...'`), donc `os.path.dirname(path) not in message` est TOUJOURS vrai sur Windows — contrôle creux (vérifié : PASSAIT sur l'ancien code). Le test compare donc le répertoire parent dans ses **deux formes** : simple (`C:\...`) et échappée (`C:\...`).

## Preuves d'exécution

```
$ python -m pytest tests/test_ucr_anomaly_fetch.py
10 passed in 0.14s   (9 existants + 1 nouveau)
```

Contrôle de non-régression du test lui-même (module restauré à l'ancien code via backup/restore, jamais `git checkout --`) :

```
$ pytest tests/test_ucr_anomaly_fetch.py::test_load_manifest_error_hides_machine_path
FAILED — assert 'C:\Users\jsboi\...\error_hides0' not in "manifeste d'integrite UCR illisible (FileNotFoundError: [Errno 2] No such file or directory: 'C:\Users\...')"
```

Le test échoue sur l'ancien code (Windows ET la forme échappée attrapée ; la forme simple couvre POSIX), passe après fix.

## Acceptance #14736

- [x] Le message d'erreur du manifeste illisible ne contient plus de chemin absolu
- [x] Un test le prouve : contrôle positif dirname absent + basename présent + type d'exception préservé
- [x] Les 9 tests existants restent verts (10/10)

Closes #14736 — acceptance 100% couverte. See #9768 (epic parent).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
