### PR TITLE
docs(training,#14579): protocole OOT cite les 3 conjoncts BEATS, dans l'ordre du code

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L4_decision_transformer.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/L4_decision_transformer.md
@@ -105,7 +105,7 @@ d'hyperparamètres**. Instrument mis en place le 04/09 :
 | **Gel de borne** `--train-end` | `scripts/train_dt_multiseed.py` | Tronque le CSV à la borne inclusive AVANT le walk-forward ; le hash est recalculé sur la tranche gelée (l'absence de contamination devient vérifiable). |
 | **Jambe de précision §C** | `scripts/validate_xrp_dt_holdout.py` | Erreur directionnelle `e_t = position_t − sign(r_{t+1})` — une politique alignée au marché fait `e = 0`, une politique opposée `e = ±2` : le DM mse/mae sur `e` est sign-aware pour des positions ±1 (le mse direct sur les retours positionnés reste sign-blind, `(−r)² = r²`, cf #10228). |
 | **Contrôle de biais** | idem | DM `linear` sur les retours positionnés (différentiel de performance moyenne), **jamais la jambe de conjonction** (§C amendé #11010) ; biais signés par modèle (`mean(return)` DT / momentum / BH) rapportés dans le JSON. |
-| **Conjonction** | idem | `edge ≥ 2σ` cross-seed **et** `dm_p_mse_median < 0.05` (mae rapportée en variante), sinon `NO-BEATS` / `INCONCLUSIVE` explicites. |
+| **Conjonction** | idem | `seeds_beat ≥ min(4, len(seeds))` **et** `edge ≥ 2σ` cross-seed **et** `dm_p_mse_median < 0.05` (mae rapportée en variante) — dans cet ordre, celui du code (`validate_xrp_dt_holdout.py`, verdict `BEATS`). La médiane des p DM exige la significativité sur une majorité de seeds : un seed chanceux sur cinq ne fait pas passer le 3e conjonct. Sinon `NO-BEATS` / `INCONCLUSIVE` explicites. |
 
 Dataset de référence (04/09, yfinance, gitignored) : `XRP-USD.csv` — bornes
 `2018-01-01 → 2026-09-04` (3169 rows), sha256 `71d8aee9d0bda18b`.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_holdout.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_holdout.py
@@ -21,8 +21,9 @@ Deux modes de holdout (a lancer separement, --label distinct) :
 Contrairement au walk-forward (5 modeles/seed), on entraine UN modele par
 seed sur la fenetre train, puis on evalue DT / momentum_naked / buy_and_hold
 sur le holdout. Memes garde-fous que validate_xrp_dt : normalisation
-train-only, gap anti-leakage, net Sharpe post-TC, DM HAC Newey-West,
->=4 seeds, edge >= 2 sigma cross-seed sinon INCONCLUSIVE. Pas de "promising".
+train-only, gap anti-leakage, net Sharpe post-TC, DM HAC Newey-West
+(p mse median < 0.05), >=4 seeds, edge >= 2 sigma cross-seed sinon
+INCONCLUSIVE. Pas de "promising".
 
 Usage
 -----


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: LIGHT/tooling #14744

# Fix #14681 : la prose du protocole OOT sous-citait le code

Le verdict `BEATS` de `validate_xrp_dt_holdout.py` (l.326-328) exige **trois** conjoncts :
1. `seeds_beat >= min(4, len(seeds))`
2. `edge_sigma >= 2.0`
3. `dm_p_median is not None and dm_p_median < 0.05`

La ligne « Conjonction » de la section Protocole OOT (`docs/L4_decision_transformer.md`) n'en citait que deux (`edge ≥ 2σ`, `dm_p_mse_median < 0.05`) — une prose qui enseigne un protocole plus permissif que celui qui tourne.

## Changements (2 fichiers, +4/−3, zéro changement de comportement)

- `docs/L4_decision_transformer.md` (l.108) : les 3 conjoncts cités **dans l'ordre du code**, avec la raison du 3e — la médiane des p DM exige la significativité sur une majorité de seeds, un seed chanceux isolé ne fait pas passer le conjonct.
- `scripts/validate_xrp_dt_holdout.py` : docstring du header précise le seuil du DM (`p mse median < 0.05`) — doc et header ne divergent plus. Docstring uniquement.

## Preuves

```
$ python -m py_compile scripts/validate_xrp_dt_holdout.py
OK (aucun changement d'exécutable — docstring seule)
$ git diff --stat
 2 files changed, 4 insertions(+), 3 deletions(-)
```

## Acceptance #14681

- [x] La section « Protocole OOT » cite les trois conjoncts, dans l'ordre du code, avec la raison du 3e (protection contre le seed chanceux)
- [x] Header de `validate_xrp_dt_holdout.py` et doc ne divergent plus (seuil DM explicite des deux côtés)
- [x] Aucun changement de comportement : alignement de prose sur du code déjà correct (le point cosmétique `train_dt_multiseed.py` l.111-113, marqué « à prendre ou à laisser », n'est PAS pris — hors scope d'un PR prose pure)

Closes #14681 — acceptance 100% couverte. See #14579 (epic parent).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
