### PR TITLE
fix(picker,#14738): zone_umbrellas source (2) ne nomme que les trackers racines

### DIFF
--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -669,7 +669,11 @@ def zone_umbrellas(issue_to_family: dict, pool: list, families=()) -> dict:
 
     L'attestation est la porte d'entree de la source (2) : une issue qui ne
     fait que MENTIONNER la zone (body de diagnostic, renvoi de contexte) n'est
-    pas un comptable, meme si son texte porte les marqueurs de tracker.
+    pas un comptable, meme si son texte porte les marqueurs de tracker. La
+    source (2) ne nomme que des trackers RACINES (`parent is None`) : une
+    fille d'EPIC dont le titre porte "tranches" est deja comptee sous son
+    parent par la source (1), la nommer aussi en propre la compterait en
+    double a la fois comme elle-meme et comme sa racine.
     """
     out: dict[str, dict[int, int]] = {}
     for it in pool:
@@ -681,6 +685,8 @@ def zone_umbrellas(issue_to_family: dict, pool: list, families=()) -> dict:
         out[fam][parent] = out[fam].get(parent, 0) + 1
     for it in pool:
         if not is_area_umbrella(it):
+            continue
+        if it.get("parent") is not None:
             continue
         fam = (issue_to_family or {}).get(it.get("number"))
         if not fam:

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -342,6 +342,23 @@ def test_zone_umbrellas_ignores_unattested_tracker_mention():
     assert ss.zone_umbrellas({}, pool) == {}
 
 
+def test_zone_umbrellas_rejects_parented_tranche_child():
+    """Fille d'EPIC titree "tranches" : pas un comptable en propre.
+
+    Le predicat de tracker (titre "tranches") s'applique aussi a une fille
+    d'EPIC : un sous-grain qui dit "tranche" dans son titre ne devient pas
+    racine pour autant. Sans le gate `parent is None` de la source (2), cette
+    fille attestee est comptee a la fois comme elle-meme (3) ET sous son
+    parent (9) -- la zone rend alors {9:1, 3:1} au lieu de {9:1}.
+    """
+    pool = [
+        {"number": 3, "parent": 9, "title": "tranches de l'EPIC #9",
+         "body": "", "labels": []},
+    ]
+    out = ss.zone_umbrellas({3: "Z"}, pool)
+    assert out["Z"] == {9: 1}, out
+
+
 # --- Attribution : ce qui empechait de NOMMER l'EPIC -----------------------
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #14745

## Summary

REPAIR de #14739 (merge 2026-09-05T12:29Z, `fix(picker,#14738)`). La **seconde source** de `zone_umbrellas` (docs `scripts/series_saturation.py`) comptait en double une issue-**fille** d'EPIC dont le titre porte « tranches » : sa racine (parent) est comptée par la source (1), et la source (2) la comptait **aussi** comme un standalone (ses propres numéros). Résultat : la zone rend `{9:1, 3:1}` au lieu de `{9:1}`.

Fix borné : la source (2) n'accepte que les **trackers racines** (`parent is None`). Les sous-grains parentés sont déjà comptés sous leur racine par la source (1) ; les nommer aussi en propre les compte en double. Le cas #13934 (racine, `parent None`) est inchangé.

## Diagnostic dérive (C.4)

- **(a) env/kernel** : n/a.
- **(b) claim antérieure fabriquée** : n/a.
- **(c) moteur upstream** : le défaut vient de la #14739 elle-même — la source (2) que j'ai ajoutée pour nommer les trackers **racines** attestés n'a pas porté le garde `parent is None`, laissant passer les **racines ET leurs filles** dès que la fille porte le marqueur de tracker (« tranches »). Verdict : `CAUSE_FIXED` — le gate restreint le prédicat aux racines, le double-comptage ne peut pas resurgir sans réintroduire une fille parentée dans la source (2).
- **(d) régression dépendance** : n/a.
- **(e) stochasticité non-seedée** : n/a — fonction déterministe.

## Verification

- **pytest `scripts/tests/test_series_saturation.py`** : **47 passed** (46 base + 1 nouveau).
- **Contrôle de mutation** (règle gate-anti-derive) : re-jeu du scénario avec la source (2) SANS le gate → `{'Z': {9:1, 3:1}}` (double comptage) ; avec le gate → `{'Z': {9:1}}`. Le nouveau test `test_zone_umbrellas_rejects_parented_tranche_child` attrape le défaut et le fix le supprime.
- Diff : 2 fichiers, 24 insertions / 1 suppression, 0 churn CRLF (vérifié `grep -c $'\r'` = 0).
- Pre-commit : gitleaks / encoding **Passed**, hooks notebook "no files to check" (fichiers `.py`).

## Périmètre

Aucun changement de comportement sur les racines légitimes (#13934, EPIC-label, « queue de tranches » racine) : le gate ne retire que le comptage des **filles parentées** qui étaient comptées en double. `is_area_umbrella` (classification) et la source (1) (parents déclarés) sont intouchés.

See #14738
