### PR TITLE
Add: slow-lane tranche 2 — CodeQL hebdomadaire x4 vers la voie lente (#12856)

### DIFF
--- a/.github/workflows/slow-lane.yml
+++ b/.github/workflows/slow-lane.yml
@@ -1,4 +1,4 @@
-name: Slow lane (voie asynchrone, tranche 1 #12856)
+name: Slow lane (voie asynchrone, tranches 1-2 #12856)
 
 # VOIE LENTE — execution asynchrone sur main, hebdomadaire.
 #
@@ -43,6 +43,39 @@ name: Slow lane (voie asynchrone, tranche 1 #12856)
 # REVERSIBILITE : `git revert` d'un seul commit retire `slow-lane.yml` et
 # restaure le regime actuel. Aucun fichier d'origine n'est modifie dans
 # cette PR, donc la reversibilite est triviale.
+#
+# TRANCHE 2 (cette PR) : PREMIER MOUVEMENT REEL — CodeQL vers la voie lente.
+#
+#   Sortie de tranche 1 constatee : run schedule 33463688662 (2026-09-01
+#   02:44 UTC) conclusion success, step "Publish verdict" success ; workflow
+#   en production depuis ~1 semaine sans faux vert ni faux rouge.
+#
+#   Mesure 24h (niveau ETAPE, instrument du commentaire ai-01 2026-08-24 —
+#   jamais run- ou job-level, contamines par l'attente en file) : le default
+#   setup CodeQL a tire **78 runs `pull_request` en 24 h** (matrice x4 =
+#   ~312 jobs Analyze, ~14 min/run github-hosted), y compris sur des PR
+#   100 % docs/markdown qui ne touchent ni C#, ni JS, ni workflows — ~18 h
+#   de runner par jour pour une detection qui n'est pas un check requis
+#   (seul `PR gate` l'est, cf. #12856). Tout le reste du top step-level est
+#   soit paths-filtre sur la surface touchee (Scripts Tests 9,2 min/run,
+#   Notebook Validation 5,4, ML Tests 5,2, Quarto 3,7 post-scoping #14429,
+#   golden-set 3,1 = regime H.7), soit hors scope (PR gate), soit deja
+#   mutualise (Always-on guards). Deplacer ces derniers serait une
+#   regression de couverture, pas une economie (#12856 : "a instruire, pas
+#   a bouger a l'aveugle").
+#
+#   COT ADMIN — POINT DE COORDINATION AU MERGE (le trigger a retirer ne vit
+#   pas dans un fichier) : CodeQL per-PR vient du DEFAULT SETUP
+#   (`dynamic/github-code-scanning/codeql`, settings repo), inatteignable
+#   par commit. La bascule COMPLETE = desactiver le default setup AU MERGE
+#   de cette PR : Settings > Code security and analysis > Code scanning >
+#   Default setup > Disable (ou `gh api -X PATCH
+#   repos/jsboige/CoursIA/code-scanning/default-setup -f state=not-configured`).
+#   Sans ce toggle, le default setup continue de tirer sur chaque PR EN PLUS
+#   du schedule = double cout. Ne merger cette jambe qu'avec le toggle.
+#
+#   Reversibilite tranche 2 : `git revert` du commit + reactiver le default
+#   setup restaurent le regime per-PR.
 
 on:
   # Schedule hebdo (mardi 02:30 UTC, apres le pic push europeen) — une seule
@@ -114,4 +147,57 @@ jobs:
             echo "::error title=Slow-lane ICT-Series pilot (rouge delibere)::La suite ICT-Series a echoue en mode slow-lane (exit=${PYTEST_EXIT}). Verdict : a investiguer. tail : ${TAIL}"
           else
             echo "::notice title=Slow-lane ICT-Series pilot (PASS)::La suite ICT-Series a reussi en mode slow-lane (tranche 1 #12856). Ce job sera re-run chaque mardi 02:30 UTC."
+          fi
+
+  # TRANCHE 2 (#12856) — CodeQL hebdomadaire contre main, meme matrice x4 que
+  # le default setup (actions, csharp, javascript-typescript, python). La
+  # suppression du per-PR vit cote settings (voir en-tete TRANCHE 2).
+  codeql-scheduled:
+    name: Slow-lane CodeQL (${{ matrix.language }})
+    # GitHub-hosted : CodeQL est gratuit sur repo public et ne concurrence pas
+    # le pool self-hosted (check_self_hosted_runner_policy : ubuntu-latest =
+    # baseline autorisee, hors allowlist). Declencheurs schedule/dispatch
+    # uniquement = refs possedees par le repo, aucune garde same-repo requise
+    # (cf en-tete du scanner).
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Job-level : le workflow reste contents: read ; seul ce job uploade du
+    # SARIF vers code scanning.
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, csharp, javascript-typescript, python]
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Init CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      # Autobuild est un no-op documente pour les langues interpretees ;
+      # pour csharp il construit la solution (meme chemin que le default
+      # setup, dont les runs csharp passent deja, ex. 6m34s sur #14746).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        id: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+      - name: Publish verdict
+        if: always()
+        env:
+          ANALYZE_OUTCOME: "${{ steps.analyze.outcome }}"
+        run: |
+          if [ "${ANALYZE_OUTCOME}" = "success" ]; then
+            echo "::notice title=Slow-lane CodeQL (${{ matrix.language }}) (PASS)::Analyse CodeQL ${{ matrix.language }} terminee en voie lente (tranche 2 #12856). Fournnee hebdo, mardi 02:30 UTC."
+          else
+            echo "::error title=Slow-lane CodeQL (${{ matrix.language }}) (rouge)::Analyse CodeQL ${{ matrix.language }} a echoue en voie lente (outcome=${ANALYZE_OUTCOME}). Verdict : a investiguer."
           fi

--- a/.github/workflows/slow-lane.yml
+++ b/.github/workflows/slow-lane.yml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Init CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
@@ -183,11 +183,11 @@ jobs:
       # pour csharp il construit la solution (meme chemin que le default
       # setup, dont les runs csharp passent deja, ex. 6m34s sur #14746).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Analyze
         id: analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/docs/ci/slow-lane.md
+++ b/docs/ci/slow-lane.md
@@ -1,4 +1,4 @@
-# Slow lane (voie asynchrone) — tranche 1 #12856
+# Slow lane (voie asynchrone) — tranches 1-2 #12856
 
 ## Strategie
 
@@ -46,15 +46,20 @@ Conditions a remplir AVANT de deplacer un workflow dans la voie lente :
 
 1. La tranche 1 a ete observee en production **>= 1 semaine**, sans faux
    vert ni faux rouge, avec verdict publie.
-2. Le workflow candidat a ete instrumente au niveau JOB
-   (`scripts/ci/measure_runner_demand.py` avec fenetre 24 h, mesure
-   `started_at → completed_at`, **pas** `run_started_at → updated_at` qui
-   inclut l'attente en file — cf. piege consigne dans le body de #12856).
+2. Le workflow candidat a ete instrumente au niveau **ETAPE**
+   (`steps[].started_at → steps[].completed_at`, fenetre 24 h). **Trois**
+   instruments ont ete essayes le 2026-08-24 (commentaire ai-01 #12856) :
+   run-level (`run_started_at → updated_at`) et job-level
+   (`started_at → completed_at`) sont **tous deux contamines par l'attente
+   en file** (des detecteurs aux travaux differents y convergent a six
+   secondes pres — signature d'attente partagee, pas de cout) ; seul le
+   niveau etape ne court que pendant le travail. Ne citer aucun chiffre
+   run- ou job-level.
 3. Le mouvement retire le trigger `pull_request` **dans le meme commit** que
    l'ajout a la voie lente (cf. acceptance #12856-2).
 4. La mesure apres-mouvement compare la meme PR temoin avant/apres.
 
-### Candidats a instruire (liste de depart, a confirmer par mesure job-level)
+### Candidats a instruire (liste de depart, a confirmer par mesure etape-level)
 
 - **`ict-tests.yml`** : ~3-5 min runner, 746 + 42 items, dejà instrumente.
 - **CodeQL `Analyze` x4** : 4 jobs lourds sur PR notebook sans ligne C#/JS.
@@ -63,6 +68,50 @@ Conditions a remplir AVANT de deplacer un workflow dans la voie lente :
 - **Quarto** (`quarto-pages-deploy.yml`) : ~3-8 min, dejà instrumente.
 - **`lean-build.yml`** et les ~30 lakes Lean : tres lourds quand ils tirent,
   filtres par `paths:`. A instruire sans regresser la couverture.
+
+## Tranche 2 — premier mouvement reel : CodeQL (PR livrante)
+
+Sortie de tranche 1 constatee : run schedule 33463688662 (2026-09-01 02:44
+UTC) `success`, step « Publish verdict » `success`, ~1 semaine en production
+sans faux vert ni faux rouge.
+
+**Tri etape-level 24 h (2026-09-05)** : le default setup CodeQL a tire
+**78 runs `pull_request` en 24 h** (matrice x4 = ~312 jobs, ~14 min/run
+github-hosted), y compris sur des PR 100 % docs — ~18 h runner/jour pour
+une detection qui n'est pas un check requis (seul `PR gate` l'est). Tout le
+reste du top etape-level est paths-filtre sur la surface touchee (Scripts
+Tests 9,2 min/run, Notebook Validation 5,4, ML Tests 5,2), scoped
+(Quarto 3,7 min/run post-#14429), protege par regime (golden-set H.7,
+3,1), mutualise (Always-on guards) ou hors scope (PR gate 8,0). Les
+deplacer serait une regression de couverture, pas une economie.
+
+**Mouvement** : job `codeql-scheduled` dans `slow-lane.yml` (matrice x4,
+`ubuntu-latest`, verdict publie par job). Le trigger per-PR vit dans le
+**default setup** (settings repo, `dynamic/github-code-scanning/codeql`),
+pas dans un fichier : la suppression = **toggle admin au merge** (Settings →
+Code scanning → Default setup → Disable). Ne merger la jambe schedule qu'avec
+le toggle — sans lui, double cout (per-PR + hebdo).
+
+**Controle positif (acceptance #12856-4)** : dispatch slow-lane sur une
+branche temoin portant un defaut deliber (C# non compilable dans un projet
+du sln) — [run 33970230585](https://github.com/jsboige/CoursIA/actions/runs/33970230585)
+(2026-09-05) :
+
+- `Slow-lane CodeQL (csharp)` : **ROUGE pour la bonne raison** — Autobuild
+  failure sur le code casse, Analyze skipped, verdict `::error` publie ;
+- `Slow-lane ICT-Series pilot` : **success** (pas de faux rouge sur la jambe
+  saine) ;
+- langues interpretees : **ROUGE SARIF** — « Code Scanning could not process
+  the submitted SARIF file: CodeQL analyses from advanced configurations
+  cannot be processed when the default setup is enabled ». Découverte
+  structurante : **la jambe schedule ne peut pas verdir tant que le default
+  setup est actif** — le rejet SARIF est le verrou fail-closed qui force la
+  coordination. Merger la jambe et basculer le toggle **le meme jour** ;
+  d'ici là chaque run hebdo publie ces rouges nommés (honnête, visible,
+  auto-résorbant au toggle).
+
+**Reversibilite** : `git revert` du commit tranche 2 + reactivation du
+default setup restaurent le regime per-PR.
 
 ## Mesure baseline (fenetre 24 h, mesuree 2026-08-27)
 
@@ -87,5 +136,7 @@ est le gain attendu de la voie lente.
 ## Voir aussi
 
 - #11835 — voie rapide (pilote ombre)
-- #12856 — slow-lane (cette PR, tranche 1)
-- `scripts/ci/measure_runner_demand.py` — instrument de mesure
+- #12856 — slow-lane (tranche 1 : pilote ; tranche 2 : CodeQL)
+- `scripts/ci/measure_runner_demand.py` — instrument de mesure (run/job-level ;
+  pour le tri des candidats, lui préférer l'instrument etape-level du
+  commentaire ai-01 2026-08-24 sur #12856)


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA -- prev: LIGHT/tooling #14744

## Tranche 2 de #12856 : premier mouvement réel vers la voie lente — CodeQL

**Mesure (instrument niveau ETAPE, dernier commentaire ai-01 #12856 — jamais run/job-level, contaminés par la file)** : le default setup CodeQL a tiré **78 runs `pull_request` en 24 h** (matrice x4 = ~312 jobs Analyze), **~14 min github-hosted par run** (1m27 + 6m34 + 1m39 + 4m23 mesurés sur #14746, PR 100 % docs), soit **~18 h de runner/jour** pour une détection qui n'est pas un check requis (seul `PR gate` l'est). Échantillon complémentaire step-level 24 h (300 runs PR, 0 erreur API, dénominateurs dans les chiffres) : tout le reste du top est **paths-filtré sur la surface touchée** ou protégé — les déplacer serait une régression de couverture, pas une économie (le corps de #12856 l'interdit à l'aveugle).

| Candidat (step-level 24 h) | Coût | Verdict triage |
|---|---|---|
| **CodeQL x4 (default setup)** | 78 runs/24 h, ~14 min/run, toutes PR même 100 % docs | **DÉPLACÉ (cette PR)** |
| PR gate | 8,0 min/run | Hors scope (#12856 explicite) |
| Scripts & Notebook-Tools Tests | 9,2 min/run × 5 | Vérifie la surface touchée (`scripts/**` paths-filtré) — laisser |
| Notebook Validation | 5,4 min/run × 9 | `**.ipynb` paths-filtré — laisser |
| Always-on guards | 2,2 min/run × 19 | Déjà mutualisé (12 organes, 1 checkout) — laisser |
| Quarto validate (PR) | 3,7 min/run × 9 | Déjà scoped #14429 (1192→1-2 docs) ; gate réel du rendu modifié — laisser |
| Golden-set (Notebook Exec Required) | 3,1 min/run × 9 | Régime H.7 P3 anti-complaisance — laisser |
| ML & Prover Tests | 5,2 min/run × 2 | Vérifie la surface touchée — laisser |
| Lakes Lean | paths-filtrés | Vérifient la PR qui les modifie — laisser |

## Le changement

`slow-lane.yml` : nouveau job `codeql-scheduled` — matrice x4 identique au default setup (`actions`, `csharp`, `javascript-typescript`, `python`), `ubuntu-latest` (CodeQL gratuit sur repo public, ne concurrence pas le pool self-hosted ; `check_self_hosted_runner_policy` : baseline autorisée hors allowlist), **codeql-action v4** (v3 déprécié 12/2026, annotation du témoin), step **Publish verdict** `if: always()` sur le pattern du pilote tranche 1. Rejoint la fournée hebdo mardi 02:30 UTC. `docs/ci/slow-lane.md` mis à jour (précondition instrument corrigée JOB→ETAPE, section tranche 2 réalisée, triage).

## ⚠️ Point de coordination AU MERGE (découvert par le témoin, fail-closed)

Le per-PR CodeQL vit dans le **default setup** (`dynamic/github-code-scanning/codeql`, settings repo) — inatteignable par commit. Et le témoin a découvert le verrou : **« CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled »** — le SARIF de la jambe schedule est rejeté tant que le default setup est actif. Donc :

1. La jambe schedule **ne peut pas verdir avant le toggle** — chaque run hebdo publierait des rouges SARIF nommés (honnête, visible, auto-résorbant).
2. La bascule complète = **merger cette PR ET désactiver le default setup le même jour** : Settings → Code security → Code scanning → Default setup → Disable (ou `gh api -X PATCH repos/jsboige/CoursIA/code-scanning/default-setup -f state=not-configured`).
3. C'est la lecture honnête du critère #12856-2 : aucun état « tire des deux côtés » ne doit survivre au merge — côté fichier il n'y a rien à retirer (le trigger n'y a jamais vécu), côté settings le toggle lève le per-PR et déverrouille le SARIF de la jambe en un seul geste.

## Acceptance #12856

1. **Verdict consultable** : step Publish verdict (annotation `::notice`/`::error`) par job — observé en production (run schedule 33463688662, 2026-09-01, success) et sur le témoin.
2. **Perte du trigger dans le même commit** : structural pour CodeQL — le trigger per-PR vit dans les settings ; le gate merge+toggle-same-day garantit qu'aucune phase à double tir ne survit (ci-dessus).
3. **Avant/après checks** : cette PR (touchée : `.github/workflows/slow-lane.yml` + `docs/ci/slow-lane.md`, zéro C#/JS/actions) tire **17 checks dont Analyze x4 + CodeQL** — le retrait du per-PR enlève 5 checks à **chaque** PR, toutes surfaces ; 78 runs/24 h → ~5 runs/semaine. Mesure après = première PR étroite post-merge+toggle (le point de départ écrit reste 60 checks sur #12840).
4. **Contrôle positif — témoin exécuté** ([run 33970230585](https://github.com/jsboige/CoursIA/actions/runs/33970230585), branche `witness/slow-lane-red-12856`, C# non compilable dans un projet du sln) :
   - `Slow-lane CodeQL (csharp)` : **ROUGE pour la bonne raison** — Autobuild failure sur le code cassé, Analyze skipped, verdict `::error` publié ;
   - `Slow-lane ICT-Series pilot` : **success** (pas de faux rouge sur la jambe saine) ;
   - langues interprétées : rouge SARIF = le verrou default setup (ci-dessus), pas un faux verdict du moteur.
   - Témoin bis (post-bump v4, [run 33970512948](https://github.com/jsboige/CoursIA/actions/runs/33970512948), branche `witness/slow-lane-red-12856-bis`) : **profil identique** — csharp Autobuild failure (rouge pour la bonne raison sous v4), langues interprétées rouges SARIF (verrou), pilote ICT success. La mécanique v4 (init/autobuild/analyze/verdict) est validée en conditions réelles.
5. **Réversibilité** : `git revert` + réactivation du default setup restaurent le régime per-PR.

## Validation

- `yaml.safe_load` OK (jobs : `ict-tests-pilot`, `codeql-scheduled`)
- `check_self_hosted_runner_policy.py` OK (142 workflows, 177 jobs) ; `check_unique_check_run_names.py` OK ; `check_concurrency_conj.py` OK (offenders=0)
- Groupe `slow-lane-${{ github.ref }}` inchangé : les témoins dispatchés sur branches dédiées ont leur propre clé (pas de cancel croisé, piège #11616)
- Sortie de tranche 1 constatée : run 33463688662 (2026-09-01 02:44 UTC) `success`, step « Publish verdict » `success`, ~1 semaine en prod sans faux vert/rouge

See #12856
