### PR TITLE
docs(notebooks,#13410): enrichir Planners-10b-LLM-Space-Reducer densite 934->1250

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10b-LLM-Space-Reducer.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10b-LLM-Space-Reducer.ipynb
@@ -332,6 +332,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "La definition est compacte mais elle porte un engagement fort : huit primitives, et un espace de programmes qui croit vite. Le sanity de la cellule suivante ne teste pas des cas d'usage — il verifie des **invariants structurels** : les symetries (`flipud`, `fliplr`, `rot90`, `transpose`) doivent composer vers l'identite, et les filtres (`recolor`, `mask_keep`) doivent etre *sans effet* hors de leur domaine. C'est le genre de propriete qu'un solveur exploitera comme heuristique de coupe, et qu'un test unitaire capture mieux qu'un exemple."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "cell-07",
@@ -378,6 +385,13 @@
     "}\n",
     "for k, v in checks.items():\n",
     "    print((\"OK  \" if v else \"FAIL\"), k)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Les six lignes `OK` ne sont pas triviales : elles prouvent que le DSL est *ferme* — chaque primitive est une fonction totale `Grid -> Grid`, et les involutions (`x2 = id`, `x4 = id`) sont vraies pour toute grille, pas seulement les exemples. Une primitive qui violerait ces invariants ferait degenerer la recherche en espace infini. Cette fermeture est la condition de possibilite du comptage d'espace qui suit : sans elle, le nombre de programmes serait un mensonge, car des programmes divergents échapperaient au recensement."
    ]
   },
   {
@@ -484,6 +498,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Les trois taches sont des transformations de grille a solution *courte* : deux ou trois primitives suffisent. Ce choix n'est pas gratuit — une tache dont la solution exigerait huit primitives rendrait la comparaison des trois bras moins lisible, car chaque bras aurait un espace de recherche different. La cellule suivante verifie que la solution attendue est bien *correcte* : elle sert d'oracle pour les trois bras, car un solveur qui annonce `TROUVE` ne peut etre cru que si sa solution *passe* cette verification."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "cell-10",
@@ -528,6 +549,13 @@
     "    ok = all(np.array_equal(compose(t[\"solution\"], gin), gout)\n",
     "             for gin, gout in t[\"train\"])\n",
     "    print((\"OK  \" if ok else \"FAIL\"), name, \"->\", \" >> \".join(t[\"solution\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Le verdict `OK` confirme l'oracle : pour chaque tache, la solution attendue produit bien la grille cible. C'est le point de reference qui rend les trois bras comparables. Sans cet oracle, `TROUVE` serait un verdict non falsifiable — n'importe quel programme serait un succes et la these du reducteur s'effondrerait. La verification est donc le socle methodologique du reste du notebook, pas une formalite."
    ]
   },
   {
@@ -626,6 +654,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Le bras 1 est le *mur*. T1 et T2 sont resolus en quelques milliers de noeuds, mais T3 depasse le budget de `15,000` noeuds sans solution. Ce n'est pas un echec du solveur — c'est la geometrie de l'espace : apres `15,001` noeuds, la recherche exhaustive a couvert une fraction negligeable des 176 millions de programmes, et toute solution situee plus loin est structurellement hors d'atteinte. Le temps de `0.080s` pour `15,001` noeuds montre que le solveur n'est pas lent : c'est l'espace qui est immense."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "cell-13",
@@ -671,6 +706,13 @@
     "print()\n",
     "print(f\"Le budget de {BUDGET_NODES:,} noeuds couvre ~{100 * BUDGET_NODES / total_space:.1f} % de l'espace.\")\n",
     "print(\"Une solution situee apres le budget est INACCESSIBLE au bras 1 : c'est le mur a reduire.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "L'extrapolation est le chiffre qui porte la these. A `169,038` noeuds/seconde, explorer l'espace complet prendrait `1,044` secondes — soit environ `0.3` heures de calcul continu. Mais le budget de la cellule precedente ne couvre que `~0.0 %` de cet espace. La consequence est brute : une solution qui vit dans la zone non exploree est *inaccessible* au bras 1, non par lenteur mais par budget. C'est exactement le mur que les bras 2 et 3 vont tenter de reduire — et c'est pour cela que la *reduction* est la vraie question, pas la vitesse."
    ]
   },
   {
@@ -796,6 +838,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ce bras change de contrat : au lieu d'explorer l'espace, on demande au LLM de produire directement le programme. Il n'y a pas de comptage de noeuds ici — la question est celle du *verdict immediat* : le programme rendu est-il correct selon l'oracle ? La cellule suivante applique ce verdict a chaque tache, et c'est ce qui distingue un vrai solver d'une illusion de solver."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "cell-16",
@@ -858,6 +907,13 @@
     "        print(f\"{name:26s} {verdict:14s} essais={essais} prog={kept}\")\n",
     "else:\n",
     "    print(\"Client LLM absent : bras 2 non execute (constat affiche, pas de substitution).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Le verdict est honnete : le LLM *trouve* les trois solutions en un seul essai. Mais ce n'est pas une preuve de capacite generale — c'est un resultat sur trois taches a solution courte, dans un DSL de huit primitives. Le bras 2 repond vite, mais il ne garantit rien sur le reste de l'espace : il peut se tromper hors de ces trois cas, et il ne produit aucun comptage de noeuds ni certificat de correction. C'est la faiblesse que le bras 3 adresse : garder la vitesse du LLM, mais lui faire *reduire* au lieu de trancher."
    ]
   },
   {
@@ -958,6 +1014,13 @@
     "            print(f\"{name:26s} ERREUR_API ({type(e).__name__})\")\n",
     "else:\n",
     "    print(\"Client LLM absent : bras 3 non execute (constat affiche, pas de substitution).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "La mesure de reduction est le coeur de la these. Pour T2, le sous-espace propose par le LLM ne contient que `132` programmes contre `176,434,840` au depart : une reduction d'un facteur `1,336,628`. Le solveur deterministe ne parcourt alors que `67` noeuds — contre `2,071` a l'exhaustif. T3, inaccessible au bras 1, est trouve en `373` noeuds dans un sous-espace de `1,884`. Le LLM ne *resout* pas ici : il *digine* l'espace, et le solveur fait le reste. La reduction, pas la magie, est le mecanisme."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #14740

## Résumé

Enrichissement markdown-only de `Planners-10b-LLM-Space-Reducer.ipynb` (épic densité #13410). Densité **934 → 1250** char/cellule code, statut `below_threshold` → `ok`.

## Ce qui a été fait

9 cellules markdown d'interprétation insérées entre les cellules de code, chacune ancrée à une sortie réelle committée :

- **Fermeture du DSL** (après `Grid = np.ndarray`) : 8 primitives, invariants structurels qu'un solveur exploite en heuristique de coupe.
- **Sanity de fermeture** (après `# Sanity du DSL`) : involutions `x2=id`/`x4=id` vraies pour toute grille — condition de possibilité du comptage d'espace qui suit.
- **Tâches à solution courte** (après `def grid(*rows)`) : oracle des trois bras.
- **Verdict de l'oracle** (après la vérification) : rend les trois bras comparables — sans lui `TROUVE` serait non falsifiable.
- **Le mur du budget** (après `BUDGET_NODES = 15_000`) : T3 dépasse 15 000 noeuds, l'espace est immense, pas le solveur lent.
- **L'extrapolation** (après `# Débit mesure`) : 169 038 noeuds/s → 1 044 s pour l'espace complet, ~0.0 % couvert.
- **Bras 2 : contrat LLM** (après `SYSTEM_PROMPT = (`) : verdict immédiat, pas de comptage de noeuds.
- **Bras 2 honnête** (après `# Bras 2 : le LLM rend`) : trouve 3 solutions en 1 essai, mais aucune garantie sur le reste de l'espace.
- **Bras 3 : réduction** (après `# Bras 3 : reduction LLM`) : T2 ×1 336 628 de réduction, T3 trouvé en 373 noeuds — la réduction, pas la magie.

## Validation

- `pedagogy_density.py --json` : **1250** (ok, seuil 1200) ; `code_cells: 14` inchangé.
- `detect_consecutive_code_cells.py` : **0 run** (les 4 runs résolus).
- `validate_pr_notebooks.py` : **EXEC_PROVED**, 14 code cells, `passed: true`.
- `check_notebook_navlinks.py` : **0 broken**.
- `detect_md_content_loss.py` : **0 finding** (md_cells 16 → 25).
- Diff : **+63 / −0**, uniquement `"source"` de cellules markdown ; aucun `execution_count`/`outputs`/`cell_type: code` touché → code byte-identique, modif markdown-only (exception C.2, pas de re-exécution).

Pre-commit : gitleaks, H.3, probeAddresses, yaml_block, #13326 → tout passé.

## Notes

`See #13410` — contribution partielle à l'épic densité (Planners-10b), l'épic reste ouvert.
