### PR TITLE
feat(backtester): port deterministic simulation core

### DIFF
--- a/MyIA.Trading.Backtester.Tests/Core/BacktestingCoreTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Core/BacktestingCoreTests.cs
@@ -23,11 +23,13 @@ namespace MyIA.Trading.Backtester.Tests.Core
             wallet.LastTransactions.Add(new Transaction { Amount = 25m });
 
             var clone = (Wallet)wallet.Clone();
+            clone.Orders[0].Amount = 10m;
             clone.Orders.Clear();
             clone.LastTrades.Clear();
             clone.LastTransactions.Clear();
 
             Assert.Single(wallet.Orders);
+            Assert.Equal(1m, wallet.Orders[0].Amount);
             Assert.Single(wallet.LastTrades);
             Assert.Single(wallet.LastTransactions);
             Assert.Equal(wallet.PrimaryBalance, clone.PrimaryBalance);
@@ -54,6 +56,27 @@ namespace MyIA.Trading.Backtester.Tests.Core
             Assert.Equal(2, matches.Count);
             Assert.Contains(matches, order => order.OrderType == OrderType.Buy && order.Price == 110m);
             Assert.Contains(matches, order => order.OrderType == OrderType.Sell && order.Price == 80m);
+        }
+
+        [Fact]
+        public void MatchOrders_DuplicatePricesDoNotMutateOrInflateOrders()
+        {
+            var wallet = new Wallet
+            {
+                Orders = new List<Order>
+                {
+                    new Order(OrderType.Buy, 110m, 1m),
+                    new Order(OrderType.Buy, 110m, 1m)
+                }
+            };
+            var exchange = new ExchangeInfo();
+
+            var firstMatches = exchange.MatchOrders(ref wallet, 100m);
+            var secondMatches = exchange.MatchOrders(ref wallet, 100m);
+
+            Assert.Equal(2, firstMatches.Count);
+            Assert.Equal(2, secondMatches.Count);
+            Assert.All(wallet.Orders, order => Assert.Equal(1m, order.Amount));
         }
 
         [Fact]
@@ -99,7 +122,7 @@ namespace MyIA.Trading.Backtester.Tests.Core
         {
             var depth = new MarketDepth
             {
-                Bids = new[] { new[] { 99m, 2m, 0m } }
+                Bids = new[] { new[] { 99m, 2m, 1_700_000_000m } }
             };
 
             Assert.Single(depth.BidOrders);
@@ -123,6 +146,21 @@ namespace MyIA.Trading.Backtester.Tests.Core
         }
 
         [Fact]
+        public void TradingHistory_PreservesTickerSnapshotPerEvent()
+        {
+            var ticker = new Ticker(100m);
+            var wallet = new Wallet { PrimaryBalance = 1m };
+            var history = new TradingHistory();
+
+            history.AddEvent(new TradingEvent(
+                new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                wallet.GetBalance(ticker)));
+            ticker.Last = 150m;
+
+            Assert.Equal(100m, history.LastEvents.Instances[0].Balance.TickerLast);
+        }
+
+        [Fact]
         public void ExchangeSimulator_DoesNotUseFutureTradePrice()
         {
             var start = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -139,6 +177,25 @@ namespace MyIA.Trading.Backtester.Tests.Core
 
             Assert.Equal(100m, market.Ticker.Last);
             Assert.Single(market.RecentTrades);
+        }
+
+        [Fact]
+        public void ExchangeSimulator_RecentTradesUsesRollingDayWindow()
+        {
+            var start = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var simulator = new ExchangeSimulator
+            {
+                Trades = new List<OrderTrade>
+                {
+                    new OrderTrade { Time = start, Price = 100m, Amount = 1m },
+                    new OrderTrade { Time = start.AddHours(25), Price = 110m, Amount = 1m }
+                }
+            };
+
+            var market = simulator.GetMarket(start.AddHours(25));
+
+            Assert.Single(market.RecentTrades);
+            Assert.Equal(110m, market.RecentTrades[0].Price);
         }
 
         [Fact]
@@ -164,6 +221,29 @@ namespace MyIA.Trading.Backtester.Tests.Core
             Assert.True(firstStrategy.CallCount > 0);
             Assert.Equal(1m, setups[0].Walllet.PrimaryBalance);
             Assert.Equal(2m, setups[1].Walllet.PrimaryBalance);
+        }
+
+        [Fact]
+        public void RunSimulations_FastSkipStateIsIndependentPerSetup()
+        {
+            var trades = CreateTrades();
+            var standaloneStrategy = new CountingStrategy();
+            var firstStrategy = new CountingStrategy();
+            var secondStrategy = new CountingStrategy();
+            var simulation = CreateFastSimulation(trades);
+
+            simulation.RunSimulation(new Wallet(), standaloneStrategy, new ExchangeInfo(), trades);
+            simulation.RunSimulations(
+                new List<SimulationSetup>
+                {
+                    new SimulationSetup { Walllet = new Wallet(), Strategy = firstStrategy },
+                    new SimulationSetup { Walllet = new Wallet(), Strategy = secondStrategy }
+                },
+                new ExchangeInfo(),
+                trades);
+
+            Assert.Equal(standaloneStrategy.CallCount, firstStrategy.CallCount);
+            Assert.Equal(standaloneStrategy.CallCount, secondStrategy.CallCount);
         }
 
         [Fact]
@@ -208,6 +288,20 @@ namespace MyIA.Trading.Backtester.Tests.Core
                 EndDate = trades[^1].Time.AddSeconds(-1),
                 BotPeriod = botPeriod,
                 FastSimulation = false
+            };
+        }
+
+        private static SimulationInfo CreateFastSimulation(IReadOnlyList<OrderTrade> trades)
+        {
+            return new SimulationInfo
+            {
+                StartDate = trades[0].Time.AddSeconds(-1),
+                EndDate = trades[^1].Time.AddSeconds(-1),
+                BotPeriod = TimeSpan.FromMinutes(5),
+                FastSimulation = true,
+                SkippedMinVoidRuns = 1m,
+                SkippedMaxRuns = 3m,
+                SkippedVariationRate = 100m
             };
         }
 

--- a/MyIA.Trading.Backtester.Tests/Core/BacktestingCoreTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Core/BacktestingCoreTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using MyIA.Trading.Backtester;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Core
+{
+    public sealed class BacktestingCoreTests
+    {
+        [Fact]
+        public void WalletClone_CopiesMutableCollections()
+        {
+            var wallet = new Wallet
+            {
+                PrimaryBalance = 2m,
+                SecondaryBalance = 500m,
+                Orders = new List<Order>
+                {
+                    new Order(OrderType.Buy, 100m, 1m)
+                }
+            };
+            wallet.LastTrades.Add(new OrderTrade { Price = 100m, Amount = 1m });
+            wallet.LastTransactions.Add(new Transaction { Amount = 25m });
+
+            var clone = (Wallet)wallet.Clone();
+            clone.Orders.Clear();
+            clone.LastTrades.Clear();
+            clone.LastTransactions.Clear();
+
+            Assert.Single(wallet.Orders);
+            Assert.Single(wallet.LastTrades);
+            Assert.Single(wallet.LastTransactions);
+            Assert.Equal(wallet.PrimaryBalance, clone.PrimaryBalance);
+            Assert.Equal(wallet.SecondaryBalance, clone.SecondaryBalance);
+        }
+
+        [Fact]
+        public void MatchOrders_ReturnsOnlyOrdersCrossingMarketPrice()
+        {
+            var wallet = new Wallet
+            {
+                Orders = new List<Order>
+                {
+                    new Order(OrderType.Buy, 110m, 1m),
+                    new Order(OrderType.Buy, 90m, 1m),
+                    new Order(OrderType.Sell, 80m, 1m),
+                    new Order(OrderType.Sell, 120m, 1m)
+                }
+            };
+            var exchange = new ExchangeInfo();
+
+            var matches = exchange.MatchOrders(ref wallet, 100m);
+
+            Assert.Equal(2, matches.Count);
+            Assert.Contains(matches, order => order.OrderType == OrderType.Buy && order.Price == 110m);
+            Assert.Contains(matches, order => order.OrderType == OrderType.Sell && order.Price == 80m);
+        }
+
+        [Fact]
+        public void ExecuteOrders_AppliesBalancesFeesAndHistory()
+        {
+            var executionTime = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var wallet = new Wallet
+            {
+                PrimaryBalance = 10m,
+                SecondaryBalance = 1_000m,
+                Orders = new List<Order>
+                {
+                    new Order(OrderType.Buy, 110m, 2m),
+                    new Order(OrderType.Sell, 90m, 1m)
+                }
+            };
+            var market = new MarketInfo(executionTime, new Ticker(100m), null, null)
+            {
+                PrimaryCode = "BTC",
+                SecondaryCode = "USD"
+            };
+            var exchange = new ExchangeInfo
+            {
+                BidCommission = 1m,
+                AskCommission = 2m
+            };
+            var history = new TradingHistory();
+
+            exchange.ExecuteOrders(market, ref wallet, ref history);
+
+            Assert.Equal(10.98m, wallet.PrimaryBalance);
+            Assert.Equal(868.20m, wallet.SecondaryBalance);
+            Assert.Empty(wallet.Orders);
+            Assert.Equal(executionTime, wallet.Time);
+            Assert.Equal(2, history.Trades.Count);
+            Assert.Equal(2, history.Fees.Count);
+            Assert.Equal(0.02m, history.Fees[0].Amount);
+            Assert.Equal(1.80m, history.Fees[1].Amount);
+        }
+
+        [Fact]
+        public void MarketDepth_BidsDeserializeAsBuyOrders()
+        {
+            var depth = new MarketDepth
+            {
+                Bids = new[] { new[] { 99m, 2m, 0m } }
+            };
+
+            Assert.Single(depth.BidOrders);
+            Assert.Equal(OrderType.Buy, depth.BidOrders[0].OrderType);
+        }
+
+        [Fact]
+        public void TradingSeries_RespectsPeriodAndMaximumSize()
+        {
+            var start = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var series = new TradingSeries(2, TimeSpan.FromMinutes(5));
+
+            series.AddEvent(CreateEvent(start, 100m));
+            series.AddEvent(CreateEvent(start.AddMinutes(3), 101m));
+            series.AddEvent(CreateEvent(start.AddMinutes(6), 102m));
+            series.AddEvent(CreateEvent(start.AddMinutes(12), 103m));
+
+            Assert.Equal(2, series.Instances.Count);
+            Assert.Equal(start.AddMinutes(12), series.Instances[0].Time);
+            Assert.Equal(start.AddMinutes(6), series.Instances[1].Time);
+        }
+
+        [Fact]
+        public void ExchangeSimulator_DoesNotUseFutureTradePrice()
+        {
+            var start = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var simulator = new ExchangeSimulator
+            {
+                Trades = new List<OrderTrade>
+                {
+                    new OrderTrade { Time = start, Price = 100m, Amount = 1m },
+                    new OrderTrade { Time = start.AddMinutes(10), Price = 150m, Amount = 1m }
+                }
+            };
+
+            var market = simulator.GetMarket(start.AddMinutes(5));
+
+            Assert.Equal(100m, market.Ticker.Last);
+            Assert.Single(market.RecentTrades);
+        }
+
+        [Fact]
+        public void RunSimulations_KeepsSetupsIndependent()
+        {
+            var trades = CreateTrades();
+            var firstStrategy = new CountingStrategy();
+            var secondStrategy = new CountingStrategy();
+            var firstWallet = new Wallet { PrimaryBalance = 1m, SecondaryBalance = 100m };
+            var secondWallet = new Wallet { PrimaryBalance = 2m, SecondaryBalance = 200m };
+            var setups = new List<SimulationSetup>
+            {
+                new SimulationSetup { Walllet = firstWallet, Strategy = firstStrategy },
+                new SimulationSetup { Walllet = secondWallet, Strategy = secondStrategy }
+            };
+            var simulation = CreateSimulation(trades, TimeSpan.FromMinutes(5));
+
+            var histories = simulation.RunSimulations(setups, new ExchangeInfo(), trades);
+
+            Assert.Equal(2, histories.Count);
+            Assert.NotSame(histories[0], histories[1]);
+            Assert.Equal(firstStrategy.CallCount, secondStrategy.CallCount);
+            Assert.True(firstStrategy.CallCount > 0);
+            Assert.Equal(1m, setups[0].Walllet.PrimaryBalance);
+            Assert.Equal(2m, setups[1].Walllet.PrimaryBalance);
+        }
+
+        [Fact]
+        public void RunSimulation_BotPeriodControlsStrategyFrequency()
+        {
+            var trades = CreateTrades();
+            var frequentStrategy = new CountingStrategy();
+            var sparseStrategy = new CountingStrategy();
+
+            CreateSimulation(trades, TimeSpan.FromMinutes(5)).RunSimulation(
+                new Wallet(), frequentStrategy, new ExchangeInfo(), trades);
+            CreateSimulation(trades, TimeSpan.FromMinutes(10)).RunSimulation(
+                new Wallet(), sparseStrategy, new ExchangeInfo(), trades);
+
+            Assert.Equal(4, frequentStrategy.CallCount);
+            Assert.Equal(2, sparseStrategy.CallCount);
+        }
+
+        private static TradingEvent CreateEvent(DateTime time, decimal total)
+        {
+            return new TradingEvent(time, new Balance(0m, new Ticker(1m), total));
+        }
+
+        private static List<OrderTrade> CreateTrades()
+        {
+            var start = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            return new List<OrderTrade>
+            {
+                new OrderTrade { Time = start, Price = 100m, Amount = 1m },
+                new OrderTrade { Time = start.AddMinutes(6), Price = 101m, Amount = 1m },
+                new OrderTrade { Time = start.AddMinutes(12), Price = 102m, Amount = 1m },
+                new OrderTrade { Time = start.AddMinutes(18), Price = 103m, Amount = 1m },
+                new OrderTrade { Time = start.AddMinutes(24), Price = 104m, Amount = 1m }
+            };
+        }
+
+        private static SimulationInfo CreateSimulation(IReadOnlyList<OrderTrade> trades, TimeSpan botPeriod)
+        {
+            return new SimulationInfo
+            {
+                StartDate = trades[0].Time.AddSeconds(-1),
+                EndDate = trades[^1].Time.AddSeconds(-1),
+                BotPeriod = botPeriod,
+                FastSimulation = false
+            };
+        }
+
+        private sealed class CountingStrategy : ITradingStrategy
+        {
+            public int CallCount { get; private set; }
+
+            public Wallet ComputeNewOrders(
+                Wallet currentOrders,
+                MarketInfo objMarket,
+                ExchangeInfo objExchange,
+                TradingHistory history)
+            {
+                CallCount++;
+                return new Wallet();
+            }
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/ExchangeInfo.cs
+++ b/MyIA.Trading.Backtester/Core/ExchangeInfo.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace MyIA.Trading.Backtester
+{
+    [Serializable]
+    public class ExchangeInfo
+    {
+        public int AmountDecil { get; set; }
+
+        public decimal AskCommission { get; set; }
+
+        public decimal BidCommission { get; set; }
+
+        public decimal MinOrderAmount { get; set; }
+
+        public decimal MinOrderValue { get; set; }
+
+        public int PriceDecil { get; set; }
+
+        public Dictionary<TradingAPIUrls, string> TradingUrls { get; set; }
+
+        public ExchangeInfo()
+        {
+            MinOrderAmount = new decimal(1, 0, 0, false, 1);
+            MinOrderValue = 0m;
+            AskCommission = new decimal(65, 0, 0, false, 2);
+            BidCommission = new decimal(65, 0, 0, false, 2);
+            AmountDecil = 1;
+            PriceDecil = 5;
+            TradingUrls = new Dictionary<TradingAPIUrls, string>();
+        }
+
+        public void ExecuteOrders(MarketInfo objMarket, ref Wallet targetWallet, ref TradingHistory history)
+        {
+            var trades = new List<OrderTrade>();
+            var fees = new List<Payment>();
+            var matchedOrders = MatchOrders(ref targetWallet, objMarket.Ticker.Last);
+            foreach (var matchedOrder in matchedOrders)
+            {
+                var trade = new OrderTrade
+                {
+                    Time = objMarket.Time,
+                    Price = matchedOrder.Price,
+                    Amount = matchedOrder.Amount
+                };
+                var fee = new Payment
+                {
+                    Time = objMarket.Time,
+                    Label = matchedOrder.FriendlyId
+                };
+
+                if (matchedOrder.OrderType == OrderType.Buy)
+                {
+                    trade.TradeType = TradeType.Buy;
+                    fee.Currency = objMarket.PrimaryCode;
+                    fee.Amount = matchedOrder.Amount * BidCommission / 100m;
+                    fee.Label = string.Format(
+                        "{0} - Bid Fee: {1} % = {2} {3}",
+                        fee.Label,
+                        BidCommission.ToString(CultureInfo.InvariantCulture),
+                        fee.Amount,
+                        fee.Currency);
+                    targetWallet.SecondaryBalance -= matchedOrder.Value;
+                    targetWallet.PrimaryBalance += matchedOrder.Amount - fee.Amount;
+                }
+                else if (matchedOrder.OrderType == OrderType.Sell)
+                {
+                    trade.TradeType = TradeType.Sell;
+                    fee.Currency = objMarket.SecondaryCode;
+                    fee.Amount = matchedOrder.Value * AskCommission / 100m;
+                    fee.Label = string.Format(
+                        "{0} - Ask Fee: {1} % = {2} {3}",
+                        fee.Label,
+                        AskCommission.ToString(CultureInfo.InvariantCulture),
+                        fee.Amount,
+                        fee.Currency);
+                    targetWallet.SecondaryBalance += matchedOrder.Value - fee.Amount;
+                    targetWallet.PrimaryBalance -= matchedOrder.Amount;
+                }
+
+                trades.Add(trade);
+                fees.Add(fee);
+                targetWallet.Orders.Remove(matchedOrder);
+            }
+
+            targetWallet.Time = objMarket.Time;
+            history.Update(targetWallet, objMarket, trades, fees);
+        }
+
+        public ExchangeInfo FromCustomFees(decimal newCommission)
+        {
+            return FromCustomFees(newCommission, newCommission);
+        }
+
+        public ExchangeInfo FromCustomFees(decimal askFee, decimal bidFee)
+        {
+            return new ExchangeInfo
+            {
+                MinOrderAmount = MinOrderAmount,
+                MinOrderValue = MinOrderValue,
+                AmountDecil = AmountDecil,
+                PriceDecil = PriceDecil,
+                TradingUrls = TradingUrls,
+                AskCommission = askFee,
+                BidCommission = bidFee
+            };
+        }
+
+        public List<Order> MatchOrders(ref Wallet objWallet, decimal price)
+        {
+            var matches = objWallet.OrderedBids.Where(order => order.Price > price).ToList();
+            matches.AddRange(objWallet.OrderedAsks.Where(order => order.Price < price));
+            return matches;
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/ExchangeSimulator.cs
+++ b/MyIA.Trading.Backtester/Core/ExchangeSimulator.cs
@@ -48,6 +48,8 @@ namespace MyIA.Trading.Backtester
                 _currentTradeIdx += 1;
             }
 
+            _currentMarket.RecentTrades.RemoveAll(trade => trade.Time < time.AddHours(-24d));
+
             if (currentTrade == null)
             {
                 if (_currentTradeIdx == 0)

--- a/MyIA.Trading.Backtester/Core/ExchangeSimulator.cs
+++ b/MyIA.Trading.Backtester/Core/ExchangeSimulator.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MyIA.Trading.Backtester
+{
+    public class ExchangeSimulator
+    {
+
+        public List<OrderTrade> Trades { get; set; }
+
+        public bool IncludeDepth { get; set; }
+        public bool FullTicker { get; set; }
+
+        private MarketInfo _currentMarket =  new MarketInfo();
+        private int _currentTradeIdx = 0;
+        private int _currentLast24HTradeIdx = 0;
+
+        /// <summary>
+        /// Emulates the Market data at a given time, given the historical trades
+        /// In order to optimise performances, it keeps previous emulated market and only performs updates
+        /// It implies that the method is called sequentially at increasing timings.
+        /// Note that the marketDepth is only broadly approximated from future trades found in history
+        /// </summary>
+        /// <param name="time">the time at which the market should be emulated</param>
+        /// <returns>a MarketInfo object with emulated ticker, RecentTrades, and Marketdepth</returns>
+        public MarketInfo GetMarket(DateTime time)
+        {
+            _currentMarket.Time = time;
+
+            // First we move the current trade cursor according to the new time and update the ticker and recent trades accordingly
+
+            OrderTrade currentTrade = null;
+            while (_currentTradeIdx < Trades.Count && Trades[_currentTradeIdx].Time <= time)
+            {
+                currentTrade = Trades[_currentTradeIdx];
+                _currentMarket.RecentTrades.Add(currentTrade);
+
+                if (FullTicker)
+                {
+                    _currentMarket.Ticker.Volume += currentTrade.Amount;
+                    if (currentTrade.Price > _currentMarket.Ticker.High)
+                        _currentMarket.Ticker.High = currentTrade.Price;
+                    if (_currentMarket.Ticker.Low == 0m || currentTrade.Price < _currentMarket.Ticker.Low)
+                        _currentMarket.Ticker.Low = currentTrade.Price;
+                }
+
+                _currentTradeIdx += 1;
+            }
+
+            if (currentTrade == null)
+            {
+                if (_currentTradeIdx == 0)
+                    throw new InvalidOperationException("No trade is available at or before the requested time.");
+                currentTrade = Trades[_currentTradeIdx - 1];
+            }
+            _currentMarket.Ticker.Last = currentTrade.Price;
+
+
+            if (FullTicker)
+            {
+                // Then we move the previous 24h trades cursor and update the Ticker accordingly
+                var last24hTime = time.AddHours(-24d);
+                while (_currentLast24HTradeIdx < _currentTradeIdx
+                       && Trades[_currentLast24HTradeIdx].Time < last24hTime)
+                {
+                    var last24HTrade = Trades[_currentLast24HTradeIdx];
+                    _currentMarket.Ticker.Volume -= last24HTrade.Amount;
+                    if (last24HTrade.Price == _currentMarket.Ticker.High)
+                    {
+                        _currentMarket.Ticker.High = 0m;
+                    }
+                    if (last24HTrade.Price == _currentMarket.Ticker.Low)
+                    {
+                        _currentMarket.Ticker.Low = 0m;
+                    }
+                    _currentLast24HTradeIdx += 1;
+                }
+                // if the ticker low or high were reset, recompute them
+
+                if (_currentMarket.Ticker.Low == 0m || _currentMarket.Ticker.High == 0m)
+                {
+                    for (int i = _currentLast24HTradeIdx; i < _currentTradeIdx; i++)
+                    {
+                        var tempTrade = Trades[i];
+                        if (_currentMarket.Ticker.Low == 0m || tempTrade.Price < _currentMarket.Ticker.Low)
+                            _currentMarket.Ticker.Low = tempTrade.Price;
+                        if (tempTrade.Price > _currentMarket.Ticker.High)
+                            _currentMarket.Ticker.High = tempTrade.Price;
+
+                    }
+                }
+            }
+
+            // Finally, compute MarketDepth
+            if (IncludeDepth)
+            {
+                //Identifying executed orders segments to be removed from existing MarketDepth
+                var newMinAskIdx = 0;
+                var existingMinAsk = decimal.MaxValue;
+                var newMaxBidIdx = 0;
+                var existingMaxBid = 0m;
+                if (_currentMarket.MarketDepth.AskOrders.Count > 0)
+                {
+                    while (newMinAskIdx < _currentMarket.MarketDepth.AskOrders.Count - 1 && _currentMarket.MarketDepth.AskOrders[newMinAskIdx].Time < time)
+                    {
+                        newMinAskIdx++;
+                    }
+                    existingMinAsk = _currentMarket.MarketDepth.AskOrders[newMinAskIdx].Price;
+                }
+
+                if (_currentMarket.MarketDepth.BidOrders.Count > 0)
+                {
+
+                    while (newMaxBidIdx < _currentMarket.MarketDepth.BidOrders.Count - 1 && _currentMarket.MarketDepth.BidOrders[newMaxBidIdx].Time < time)
+                    {
+                        newMaxBidIdx++;
+                    }
+                    existingMaxBid = _currentMarket.MarketDepth.BidOrders[newMaxBidIdx].Price;
+                }
+
+
+                //Computing new depth segments
+                var exitAskCondition = false;
+                var exitBidCondition = false;
+                var newDepth = new MarketDepth();
+                for (int depthIdx = _currentTradeIdx; depthIdx < Trades.Count && !(exitAskCondition && exitBidCondition); depthIdx++)
+                {
+                    var depthTrade = Trades[depthIdx];
+                    if (!exitAskCondition && (newDepth.AskOrders.Count > 0 &&
+                                              depthTrade.Price > newDepth.AskOrders.Last().Price)
+                        || (newDepth.AskOrders.Count == 0 && depthTrade.Price > currentTrade.Price))
+                    {
+                        if (depthTrade.Price < existingMinAsk)
+                        {
+                            newDepth.AskOrders.Add(depthTrade.ToOrder(OrderType.Sell));
+                        }
+                        else
+                        {
+                            exitAskCondition = true;
+                        }
+
+                    }
+                    else if (!exitBidCondition && (newDepth.BidOrders.Count > 0 &&
+                                                   depthTrade.Price < newDepth.BidOrders.Last().Price)
+                             ||
+                             (newDepth.BidOrders.Count == 0 && depthTrade.Price < currentTrade.Price))
+                    {
+                        if (depthTrade.Price > existingMaxBid)
+                        {
+                            newDepth.BidOrders.Add(depthTrade.ToOrder(OrderType.Buy));
+                        }
+                        else
+                        {
+                            exitBidCondition = true;
+                        }
+                    }
+                }
+                //joining former and new marketdepth segments
+                newDepth.AskOrders.AddRange(_currentMarket.MarketDepth.AskOrders.Skip(newMinAskIdx));
+                newDepth.BidOrders.AddRange(_currentMarket.MarketDepth.BidOrders.Skip(newMaxBidIdx));
+                _currentMarket.MarketDepth = newDepth;
+            }
+
+
+
+
+            return _currentMarket;
+        }
+
+
+
+
+    }
+}

--- a/MyIA.Trading.Backtester/Core/IContextualStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/IContextualStrategy.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+	public interface IContextualStrategy
+	{
+		void ComputeNewOrders(ref TradingContext tContext);
+	}
+}

--- a/MyIA.Trading.Backtester/Core/ITradingStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/ITradingStrategy.cs
@@ -1,0 +1,7 @@
+namespace MyIA.Trading.Backtester
+{
+	public interface ITradingStrategy
+	{
+		Wallet ComputeNewOrders(Wallet currentOrders, MarketInfo objMarket, ExchangeInfo objExchange, TradingHistory history);
+	}
+}

--- a/MyIA.Trading.Backtester/Core/MarketModels.cs
+++ b/MyIA.Trading.Backtester/Core/MarketModels.cs
@@ -351,7 +351,7 @@ namespace MyIA.Trading.Backtester
                     }
                     else
                     {
-                        BidOrders.Add(new Order(OrderType.Sell, triplet[0], triplet[1],
+                        BidOrders.Add(new Order(OrderType.Buy, triplet[0], triplet[1],
                             UnixTime.ConvertFromUnixTimestamp(Convert.ToInt64(triplet[2]))));
                     }
 

--- a/MyIA.Trading.Backtester/Core/MarketModels.cs
+++ b/MyIA.Trading.Backtester/Core/MarketModels.cs
@@ -1,0 +1,535 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Serialization;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+	[Serializable]
+	public class ResponseObject
+	{
+		public string Error;
+
+		public string ReturnCodes;
+
+		public ResponseObject()
+		{
+			this.Error = "";
+			this.ReturnCodes = "";
+		}
+
+		public ResponseObject(ResponseObject objResponseObject)
+		{
+			this.Error = objResponseObject.Error;
+			this.ReturnCodes = objResponseObject.ReturnCodes;
+		}
+	}
+
+    [Serializable]
+	public class Ticker : ResponseObject, ICloneable
+	{
+	    public decimal Buy { get; set; }
+
+	    public decimal High { get; set; }
+
+	    public decimal Last { get; set; }
+
+	    public decimal Low { get; set; }
+
+	    public decimal Sell { get; set; }
+
+	    public decimal Volume { get; set; }
+
+	    public Ticker()
+		{
+		}
+
+        public Ticker(decimal price): this(price, 0m)
+		{
+		}
+
+        public Ticker(decimal price, decimal volume)
+        {
+            this.Last = price;
+            this.Sell = price;
+            this.Buy = price;
+            this.Low = price;
+            this.High = price;
+            this.Volume = volume;
+        }
+
+	    public Ticker(Ticker cloneTicker)
+	    {
+	        if (cloneTicker != null)
+	        {
+                this.Last = cloneTicker.Last;
+                this.Sell = cloneTicker.Sell;
+                this.Buy = cloneTicker.Buy;
+                this.Low = cloneTicker.Low;
+                this.High = cloneTicker.High;
+                this.Volume = cloneTicker.Volume;
+	        }
+	    }
+
+
+	    public object Clone()
+	    {
+	        return new Ticker(this);
+	    }
+	}
+
+	[Serializable]
+	public class Balance : ResponseObject
+	{
+	    public decimal Primary { get; set; }
+
+        public decimal Secondary { get; set; }
+
+        [Browsable(false)]
+        public Ticker Ticker { get; set; }
+
+	    [XmlIgnore()][JsonIgnore()]
+		public decimal Value
+		{
+			get
+			{
+			    if (Ticker == null)
+			    {
+                    throw new InvalidOperationException("Balance Value cannot be computed without Ticker");
+			    }
+				return this.Primary * this.Ticker.Last;
+			}
+		}
+
+
+
+	    [XmlIgnore()][JsonIgnore()]
+		public decimal TickerLast
+		{
+			get
+			{
+				return this.Ticker.Last;
+			}
+		}
+
+		[XmlIgnore()][JsonIgnore()]
+		public decimal Total
+		{
+			get
+			{
+				return this.GetTotal();
+			}
+		}
+
+
+
+		public Balance()
+		{
+		}
+
+		public Balance(ResponseObject objresponseObject) : base(objresponseObject)
+		{
+		}
+
+        public Balance(decimal objPrimary,  decimal objSecondary)
+        {
+
+            this.Primary = objPrimary;
+            this.Secondary = objSecondary;
+        }
+
+		public Balance(decimal objPrimary, Ticker objTicker, decimal objSecondary): this(objPrimary, objSecondary)
+		{
+			this.Ticker = objTicker;
+		}
+
+		public decimal GetTotal()
+		{
+			return  Secondary + Value;
+		}
+	}
+
+
+
+
+//[Serializable]
+//public class Balance : ResponseObject
+//{
+//    private Ticker _Ticker;
+
+//    public decimal usds;
+
+//    public decimal btcs;
+
+//    public decimal BTC
+//    {
+//        get
+//        {
+//            return this.btcs;
+//        }
+//        set
+//        {
+//            this.btcs = value;
+//        }
+//    }
+
+//    [XmlIgnore()][JsonIgnore()]
+//    public decimal Value
+//    {
+//        get
+//        {
+//            decimal Value = decimal.Round(decimal.Multiply(this.btcs, this.Ticker.Last), 5);
+//            return Value;
+//        }
+//    }
+
+//    [Browsable(false)]
+//    public MyIA.Trading.Backtester.Ticker Ticker
+//    {
+//        get
+//        {
+//            return this._Ticker;
+//        }
+//        set
+//        {
+//            this._Ticker = value;
+//        }
+//    }
+
+//    [XmlIgnore()][JsonIgnore()]
+//    public decimal TickerLast
+//    {
+//        get
+//        {
+//            return this._Ticker.Last;
+//        }
+//    }
+
+//    [XmlIgnore()][JsonIgnore()]
+//    public decimal Total
+//    {
+//        get
+//        {
+//            return this.GetTotal();
+//        }
+//    }
+
+//    public decimal USD
+//    {
+//        get
+//        {
+//            return this.usds;
+//        }
+//        set
+//        {
+//            this.usds = value;
+//        }
+//    }
+
+//    public Balance()
+//    {
+//    }
+
+//    public Balance(ResponseObject objresponseObject)
+//        : base(objresponseObject)
+//    {
+//    }
+
+//    public Balance(decimal objUsds, decimal objBtcs, MyIA.Trading.Backtester.Ticker objTicker)
+//    {
+//        this.usds = objUsds;
+//        this.btcs = objBtcs;
+//        this._Ticker = objTicker;
+//    }
+
+//    public decimal GetTotal()
+//    {
+//        if (this.Ticker == null)
+//        {
+//            throw new InvalidOperationException("Ticker less balance can't compute total");
+//        }
+//        decimal GetTotal = decimal.Round(decimal.Add(this.usds, decimal.Multiply(this.btcs, this.Ticker.Last)), 5);
+//        return GetTotal;
+//    }
+//
+
+    [Serializable]
+	public class MarketDepth : ResponseObject, ICloneable
+	{
+
+        public MarketDepth()
+        {
+            Init();
+        }
+
+        public MarketDepth(ResponseObject objresponseObject)
+            : base(objresponseObject)
+        {
+            Init();
+        }
+
+        public MarketDepth(MarketDepth cloneDepth) : this(cloneDepth, false)
+        {
+
+        }
+
+        public MarketDepth(MarketDepth cloneDepth, bool deepCopy)
+        {
+            if (cloneDepth != null)
+            {
+                if (deepCopy)
+                {
+                    BidOrders = new List<Order>(cloneDepth.BidOrders);
+                    AskOrders = new List<Order>(cloneDepth.AskOrders);
+                }
+                else
+                {
+                    BidOrders = cloneDepth.BidOrders;
+                    AskOrders = cloneDepth.AskOrders;
+                }
+            }
+            else
+            {
+                Init();
+            }
+        }
+
+        private void Init()
+        {
+            BidOrders = new List<Order>();
+            AskOrders = new List<Order>();
+        }
+
+        public List<Order> AskOrders { get; set; }
+
+        public List<Order> BidOrders { get; set; }
+
+        [XmlIgnore()]
+	    public decimal[][] Asks
+	    {
+	        get
+	        {
+	            return AskOrders.Select(objOrder => new decimal[3] {objOrder.Price, objOrder.Amount, objOrder.Date}).ToArray();
+	        }
+	        set
+	        {
+	            foreach (var triplet in value)
+	            {
+                    if (triplet.Length <= 2 || triplet[2]<=0)
+	                {
+                        AskOrders.Add(new Order(OrderType.Sell, triplet[0], triplet[1]));
+	                }
+                    else
+                    {
+                        AskOrders.Add(new Order(OrderType.Sell, triplet[0], triplet[1],
+                            UnixTime.ConvertFromUnixTimestamp(Convert.ToInt64( triplet[2]))));
+                    }
+
+	            }
+
+	        }
+	    }
+
+        [XmlIgnore()]
+	    public decimal[][] Bids
+	    {
+            get
+            {
+                return BidOrders.Select(objOrder => new decimal[3] { objOrder.Price, objOrder.Amount, objOrder.Date }).ToArray();
+            }
+            set
+            {
+                foreach (var triplet in value)
+                {
+                    if (triplet.Length <= 2 || triplet[2] <= 0)
+                    {
+                        BidOrders.Add(new Order(OrderType.Buy, triplet[0], triplet[1]));
+                    }
+                    else
+                    {
+                        BidOrders.Add(new Order(OrderType.Sell, triplet[0], triplet[1],
+                            UnixTime.ConvertFromUnixTimestamp(Convert.ToInt64(triplet[2]))));
+                    }
+
+                }
+
+            }
+	    }
+
+        public object Clone()
+        {
+            return new MarketDepth(this, true);
+        }
+	}
+
+	[Serializable]
+	public class MarketInfo:ICloneable
+	{
+
+	    public string Id { get; set; }
+
+        public string Label { get; set; }
+
+        public string PrimaryName { get; set; }
+        public string PrimaryCode { get; set; }
+        public string SecondaryName { get; set; }
+        public string SecondaryCode { get; set; }
+
+        public DateTime Time { get; set; }
+
+        public Ticker Ticker { get; set; }
+
+	    public List<OrderTrade> RecentTrades { get; set; }
+
+	    public MarketDepth MarketDepth { get; set; }
+
+
+
+	    public MarketInfo() : this(DateTime.Now, null, null, null, false)
+	    {
+	    }
+
+
+        public MarketInfo(DateTime objTime)
+            : this(objTime, null, null, null, false)
+	    {
+	    }
+
+
+        public MarketInfo(Ticker ticker, MarketDepth depth)
+            : this(DateTime.Now, ticker, depth, null, false)
+		{
+		}
+
+
+	    public MarketInfo(DateTime objTime, Ticker ticker, MarketDepth depth, List<OrderTrade> trades)
+	        : this(objTime, ticker, depth, trades, false)
+	    {
+
+	    }
+
+        public MarketInfo(DateTime objTime, Ticker ticker, MarketDepth depth, List<OrderTrade> trades, bool deepCopy)
+		{
+            Id = "";
+            Label = "";
+            PrimaryName = "";
+            PrimaryCode = "";
+            SecondaryCode = "";
+            SecondaryName = "";
+
+		    Time = objTime;
+
+            if (ticker != null)
+            {
+                if (deepCopy)
+                {
+                    Ticker = new Ticker(ticker);
+                }
+                else
+                {
+                    Ticker = ticker;
+                }
+            }
+            else
+            {
+                Ticker = new Ticker();
+            }
+
+
+            MarketDepth = new MarketDepth(depth, deepCopy);
+
+            if (trades != null)
+            {
+                if (deepCopy)
+                {
+                    RecentTrades = new List<OrderTrade>(trades);
+                }
+                else
+                {
+                    RecentTrades = trades;
+                }
+            }
+            else
+            {
+                RecentTrades = new List<OrderTrade>();
+            }
+		}
+
+        public MarketInfo(MarketInfo sourceMarket): this(sourceMarket, false)
+        {
+
+        }
+
+        public MarketInfo(MarketInfo sourceMarket, bool deepCopy)
+            : this(sourceMarket, null, deepCopy)
+	    {
+
+	    }
+
+        public MarketInfo(MarketInfo sourceMarket, MarketInfo additionalData)
+            : this(sourceMarket, additionalData, false)
+        {
+
+        }
+
+
+        public MarketInfo(MarketInfo sourceMarket, MarketInfo additionalData, bool deepCopy)
+            : this(sourceMarket.Time, sourceMarket.Ticker, sourceMarket.MarketDepth, sourceMarket.RecentTrades, deepCopy)
+        {
+            Id = sourceMarket.Id;
+            Label = sourceMarket.Label;
+            PrimaryName = sourceMarket.PrimaryName;
+            PrimaryCode = sourceMarket.PrimaryCode;
+            SecondaryCode = sourceMarket.SecondaryCode;
+            SecondaryName = sourceMarket.SecondaryName;
+
+            if (additionalData!= null)
+            {
+                RecentTrades.AddRange(additionalData.RecentTrades);
+                MarketDepth.AskOrders.AddRange(additionalData.MarketDepth.AskOrders);
+                MarketDepth.BidOrders.AddRange(additionalData.MarketDepth.BidOrders);
+            }
+        }
+
+
+	    public object Clone()
+	    {
+	        return new MarketInfo(this, true);
+	    }
+	}
+
+	public class AsksAndBids : ResponseObject
+	{
+		public Order[] Asks;
+
+		public Order[] Bids;
+
+		public AsksAndBids()
+		{
+		}
+
+		public AsksAndBids(ResponseObject objresponseObject) : base(objresponseObject)
+		{
+		}
+
+		public MarketDepth ToMarketDepth()
+		{
+			var toReturn = new MarketDepth(this);
+		    toReturn.AskOrders.AddRange(this.Asks);
+		    toReturn.BidOrders.AddRange(this.Bids);
+			return toReturn;
+		}
+
+		public Wallet ToWallet()
+		{
+			var toReturn = new Wallet(this);
+			toReturn.Orders.AddRange(this.Asks);
+            toReturn.Orders.AddRange(this.Bids);
+			return toReturn;
+		}
+	}
+}

--- a/MyIA.Trading.Backtester/Core/SimulationInfo.cs
+++ b/MyIA.Trading.Backtester/Core/SimulationInfo.cs
@@ -103,16 +103,19 @@ namespace MyIA.Trading.Backtester
 
             var objExchangeSimulator = new ExchangeSimulator()
             {
-                Trades = exchangeHistory.ToList(),
+                Trades = exchangeHistory.OrderBy(trade => trade.Time).ToList(),
                 IncludeDepth = objSimulation.IncludeDepth,
                 FullTicker = objSimulation.FullTicker
             };
             //var currentWallet = (Wallet)initialWallet.Clone();
             //var lastBotMarket = new MarketInfo(DateTime.MinValue);
-            var lastBotTicker = 0m;
             var lastBotTime = DateTime.MinValue;
             MarketInfo objMarket = null;
-            int nbEmptyRuns = 0;
+            foreach (var setup in setups)
+            {
+                setup.LastBotTicker = 0m;
+                setup.EmptyRunCount = 0;
+            }
             foreach (var historicTrade in objExchangeSimulator.Trades
                     .Where(objTrade => objTrade.Time > objSimulation.StartDate
                     && objTrade.Time < objSimulation.EndDate))
@@ -125,7 +128,7 @@ namespace MyIA.Trading.Backtester
                         || (currentWallet.OrderedBids.Count > 0 &&
                             historicTrade.Price < currentWallet.HighestBid.Price))
                     {
-                        nbEmptyRuns = 0;
+                        simulationSetup.EmptyRunCount = 0;
                         objMarket = objExchangeSimulator.GetMarket(historicTrade.Time);
                         var currentHistory = simulationSetup.TradingHistory;
                         objExchange.ExecuteOrders(objMarket, ref currentWallet, ref currentHistory);
@@ -140,39 +143,39 @@ namespace MyIA.Trading.Backtester
                         var currentWallet = simulationSetup.Walllet;
 
                         currentWallet.Time = historicTrade.Time;
-                        bool isBigVariation =
-                            Math.Abs((historicTrade.Price - lastBotTicker) / historicTrade.Price)
+                        bool isBigVariation = historicTrade.Price != 0m
+                            && Math.Abs((historicTrade.Price - simulationSetup.LastBotTicker) / historicTrade.Price)
                             > objSimulation.SkippedVariationRate / 100;
 
                         if (!objSimulation.FastSimulation
-                            || nbEmptyRuns < objSimulation.SkippedMinVoidRuns
-                            || nbEmptyRuns >= objSimulation.SkippedMaxRuns
+                            || simulationSetup.EmptyRunCount < objSimulation.SkippedMinVoidRuns
+                            || simulationSetup.EmptyRunCount >= objSimulation.SkippedMaxRuns
                             || isBigVariation)
                         {
-                            if (objMarket == null || objMarket.Time<historicTrade.Time)
+                            if (objMarket == null || objMarket.Time < historicTrade.Time)
                             {
                                 objMarket = objExchangeSimulator.GetMarket(historicTrade.Time);
                             }
                             var newOrders = simulationSetup.Strategy.ComputeNewOrders(currentWallet, objMarket, objExchange, simulationSetup.TradingHistory);
                             currentWallet.IntegrateOrders(newOrders.Orders.ToArray());
-                            lastBotTicker = objMarket.Ticker.Last;
-                            if (newOrders.Orders.Count == 0 && !isBigVariation && nbEmptyRuns < objSimulation.SkippedMaxRuns)
+                            simulationSetup.LastBotTicker = objMarket.Ticker.Last;
+                            if (newOrders.Orders.Count == 0
+                                && !isBigVariation
+                                && simulationSetup.EmptyRunCount < objSimulation.SkippedMaxRuns)
                             {
-                                nbEmptyRuns++;
+                                simulationSetup.EmptyRunCount++;
                             }
                             else
                             {
-                                nbEmptyRuns = 0;
+                                simulationSetup.EmptyRunCount = 0;
                             }
                         }
                         else
                         {
-                            nbEmptyRuns++;
+                            simulationSetup.EmptyRunCount++;
                         }
-                        lastBotTime = historicTrade.Time;
                     }
-
-
+                    lastBotTime = historicTrade.Time;
                 }
             }
             return setups.Select(objSetup=>objSetup.TradingHistory).ToList();

--- a/MyIA.Trading.Backtester/Core/SimulationInfo.cs
+++ b/MyIA.Trading.Backtester/Core/SimulationInfo.cs
@@ -1,0 +1,183 @@
+using System.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// That class serves defining simulation parameter for tradegies back testing.
+    /// A couple parameters are available to the user and a method runs the simulation given historical data
+    /// </summary>
+    [Serializable]
+    public class SimulationInfo
+    {
+
+        public bool IncludeDepth { get; set; }
+
+        public bool FullTicker { get; set; }
+
+        /// <summary>
+        /// Duration between each bot run. It should match the platform configuration for accurate results
+        /// </summary>
+        public TimeSpan BotPeriod { get; set; }
+
+        /// <summary>
+        /// The date to start the simulation or the closest historical data if unavailable
+        /// </summary>
+        public DateTime StartDate { get; set; }
+
+        /// <summary>
+        /// The date to end the simulation or the closest historical data if unavailable
+        /// </summary>
+        public DateTime EndDate { get; set; }
+
+        /// <summary>
+        /// Allows for much faster simulations by skipping suposedly useless bot runs
+        /// when the market does not move. Other parameters define the corresponding behavior.
+        /// </summary>
+        public bool FastSimulation { get; set; }
+
+        /// <summary>
+        /// The minimum number of bot runs without any new order getting issued before skipping starts
+        /// </summary>
+        public decimal SkippedMinVoidRuns { get; set; }
+
+        /// <summary>
+        /// The maximum number of successive bot runs skipped
+        /// </summary>
+        public decimal SkippedMaxRuns { get; set; }
+
+        /// <summary>
+        /// The maximum variation of the market since the last unskipped bot run to keep skipping bot runs
+        /// </summary>
+        public decimal SkippedVariationRate { get; set; }
+
+
+
+
+
+        public SimulationInfo()
+        {
+            this.StartDate = DateTime.Now.Subtract(TimeSpan.FromDays(60)); ;
+            this.EndDate = DateTime.Now;
+            this.BotPeriod = TimeSpan.FromMinutes(5);
+            this.FastSimulation = true;
+            this.SkippedVariationRate = 1m;
+            this.SkippedMinVoidRuns = 2m;
+            this.SkippedMaxRuns = 20m;
+        }
+
+        public TradingHistory RunSimulation(Wallet initialWallet, ITradingStrategy obStrategy, ExchangeInfo objExchange, IEnumerable<OrderTrade> exchangeHistory)
+        {
+            return SimulationInfo.RunSimulation(this, initialWallet, obStrategy, objExchange, exchangeHistory);
+        }
+
+        /// <summary>
+        /// Static method that runs a simulation of a Market and bot runs for a given period,
+        /// with the parameters and historical data supplied as parameters
+        /// </summary>
+        /// <param name="objSimulation">An instance of the simulation info class with properties defining how to perform the simulation</param>
+        /// <param name="initialWallet">The Wallet to use at the start of the simulation</param>
+        /// <param name="obStrategy">The existing strategy to use if the simulation object does not specify a custom strategy</param>
+        /// <param name="objExchange">An instance of the Exchange parameters</param>
+        /// <param name="exchangeHistory">Historical data for the Exchange object</param>
+        /// <returns>the trading history computed from the simulation with resulting balance, issued and executed orders</returns>
+        public static TradingHistory RunSimulation(SimulationInfo objSimulation, Wallet initialWallet
+            , ITradingStrategy obStrategy, ExchangeInfo objExchange, IEnumerable<OrderTrade> exchangeHistory)
+        {
+            var objSetup = new SimulationSetup() {Strategy = obStrategy, Walllet = initialWallet};
+            var setups = new List<SimulationSetup>( new []{objSetup});
+            return objSimulation.RunSimulations(setups, objExchange, exchangeHistory)[0];
+        }
+
+        public List<TradingHistory> RunSimulations(List<SimulationSetup> setups
+            , ExchangeInfo objExchange, IEnumerable<OrderTrade> exchangeHistory)
+        {
+            return RunSimulations(this, setups, objExchange, exchangeHistory);
+        }
+
+
+        public static List<TradingHistory> RunSimulations(SimulationInfo objSimulation, List<SimulationSetup> setups
+         , ExchangeInfo objExchange, IEnumerable<OrderTrade> exchangeHistory)
+        {
+
+            var objExchangeSimulator = new ExchangeSimulator()
+            {
+                Trades = exchangeHistory.ToList(),
+                IncludeDepth = objSimulation.IncludeDepth,
+                FullTicker = objSimulation.FullTicker
+            };
+            //var currentWallet = (Wallet)initialWallet.Clone();
+            //var lastBotMarket = new MarketInfo(DateTime.MinValue);
+            var lastBotTicker = 0m;
+            var lastBotTime = DateTime.MinValue;
+            MarketInfo objMarket = null;
+            int nbEmptyRuns = 0;
+            foreach (var historicTrade in objExchangeSimulator.Trades
+                    .Where(objTrade => objTrade.Time > objSimulation.StartDate
+                    && objTrade.Time < objSimulation.EndDate))
+            {
+                for (var setupIndex = 0; setupIndex < setups.Count; setupIndex++)
+                {
+                    var simulationSetup = setups[setupIndex];
+                    var currentWallet = simulationSetup.Walllet;
+                    if ((currentWallet.OrderedAsks.Count > 0 && historicTrade.Price > currentWallet.LowestAsk.Price)
+                        || (currentWallet.OrderedBids.Count > 0 &&
+                            historicTrade.Price < currentWallet.HighestBid.Price))
+                    {
+                        nbEmptyRuns = 0;
+                        objMarket = objExchangeSimulator.GetMarket(historicTrade.Time);
+                        var currentHistory = simulationSetup.TradingHistory;
+                        objExchange.ExecuteOrders(objMarket, ref currentWallet, ref currentHistory);
+                    }
+                }
+
+
+                if (historicTrade.Time.Subtract(lastBotTime) > objSimulation.BotPeriod)
+                {
+                    foreach (var simulationSetup in setups)
+                    {
+                        var currentWallet = simulationSetup.Walllet;
+
+                        currentWallet.Time = historicTrade.Time;
+                        bool isBigVariation =
+                            Math.Abs((historicTrade.Price - lastBotTicker) / historicTrade.Price)
+                            > objSimulation.SkippedVariationRate / 100;
+
+                        if (!objSimulation.FastSimulation
+                            || nbEmptyRuns < objSimulation.SkippedMinVoidRuns
+                            || nbEmptyRuns >= objSimulation.SkippedMaxRuns
+                            || isBigVariation)
+                        {
+                            if (objMarket == null || objMarket.Time<historicTrade.Time)
+                            {
+                                objMarket = objExchangeSimulator.GetMarket(historicTrade.Time);
+                            }
+                            var newOrders = simulationSetup.Strategy.ComputeNewOrders(currentWallet, objMarket, objExchange, simulationSetup.TradingHistory);
+                            currentWallet.IntegrateOrders(newOrders.Orders.ToArray());
+                            lastBotTicker = objMarket.Ticker.Last;
+                            if (newOrders.Orders.Count == 0 && !isBigVariation && nbEmptyRuns < objSimulation.SkippedMaxRuns)
+                            {
+                                nbEmptyRuns++;
+                            }
+                            else
+                            {
+                                nbEmptyRuns = 0;
+                            }
+                        }
+                        else
+                        {
+                            nbEmptyRuns++;
+                        }
+                        lastBotTime = historicTrade.Time;
+                    }
+
+
+                }
+            }
+            return setups.Select(objSetup=>objSetup.TradingHistory).ToList();
+        }
+
+
+    }
+}

--- a/MyIA.Trading.Backtester/Core/SimulationSetup.cs
+++ b/MyIA.Trading.Backtester/Core/SimulationSetup.cs
@@ -1,0 +1,13 @@
+namespace MyIA.Trading.Backtester
+{
+    public class SimulationSetup
+    {
+        public Wallet Walllet { get; set; }
+
+
+        public ITradingStrategy Strategy { get; set; }
+
+        public TradingHistory TradingHistory { get; set; } = new TradingHistory();
+
+    }
+}

--- a/MyIA.Trading.Backtester/Core/SimulationSetup.cs
+++ b/MyIA.Trading.Backtester/Core/SimulationSetup.cs
@@ -9,5 +9,9 @@ namespace MyIA.Trading.Backtester
 
         public TradingHistory TradingHistory { get; set; } = new TradingHistory();
 
+        internal decimal LastBotTicker { get; set; }
+
+        internal int EmptyRunCount { get; set; }
+
     }
 }

--- a/MyIA.Trading.Backtester/Core/TradingContext.cs
+++ b/MyIA.Trading.Backtester/Core/TradingContext.cs
@@ -1,0 +1,159 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    public class TradingContext
+    {
+        public decimal AskSpan
+        {
+            get
+            {
+                return this.CurrentOrders.HighestAsk.Price - this.LowestAskLimitPrice;
+            }
+        }
+
+        public ITradingStrategy BaseStrategy { get; set; }
+
+        public decimal BidSpan
+        {
+            get
+            {
+                return this.HighestBidLimitPrice - this.CurrentOrders.LowestBid.Price;
+            }
+        }
+
+        public Wallet CurrentOrders { get; set; }
+
+        public ExchangeInfo Exchange { get; set; }
+
+        public TradingTrend LastTrend { get; private set; }
+
+        public Order HighestBid
+        {
+            get
+            {
+                Order toReturn = CurrentOrders.HighestBid;
+                if (toReturn == null)
+                {
+                    toReturn = this.NewOrders.HighestBid;
+                }
+                else if (this.NewOrders.HighestBid != null && this.NewOrders.HighestBid.Price > toReturn.Price)
+                {
+                    toReturn = this.NewOrders.HighestBid;
+                }
+                return toReturn;
+            }
+        }
+
+
+
+        public decimal HighestBidLimitPrice
+        {
+            get
+            {
+                var bidMargingFactor = GetBidMarginFactor();
+                var objBaseStrategy = this.BaseStrategy as TradingStrategyBase;
+                if (objBaseStrategy != null && objBaseStrategy.TakeMarginOnOppositeOrder)
+                {
+
+                    var objLowestAsk = LowestAsk;
+                    if (objLowestAsk != null)
+                    {
+                        return Math.Min(Market.Ticker.Last * bidMargingFactor,
+                            bidMargingFactor * objLowestAsk.Price / this.GetAskMarginFactor());
+                    }
+                }
+                return Market.Ticker.Last * bidMargingFactor;
+            }
+        }
+
+
+
+        public Order LowestAsk
+        {
+            get
+            {
+                Order toReturn = this.CurrentOrders.LowestAsk;
+                if (toReturn == null)
+                {
+                    toReturn = this.NewOrders.LowestAsk;
+                }
+                else if (this.NewOrders.LowestAsk != null && this.NewOrders.LowestAsk.Price < toReturn.Price)
+                {
+                    toReturn = this.NewOrders.LowestAsk;
+                }
+                return toReturn;
+            }
+        }
+
+        public decimal LowestAskLimitPrice
+        {
+            get
+            {
+                var askMargingFactor = GetAskMarginFactor();
+                var objBaseStrategy = this.BaseStrategy as TradingStrategyBase;
+                if (objBaseStrategy != null && objBaseStrategy.TakeMarginOnOppositeOrder)
+                {
+
+                    var objHighestBid = HighestBid;
+                    if (objHighestBid != null)
+                    {
+                        return Math.Max(Market.Ticker.Last * askMargingFactor,
+                            askMargingFactor * objHighestBid.Price / this.GetBidMarginFactor());
+                    }
+                }
+                return Market.Ticker.Last * askMargingFactor;
+            }
+        }
+
+        public MarketInfo Market { get; set; }
+
+        public Wallet NewOrders { get; set; }
+
+        public decimal Price { get; set; }
+
+        public TradingContext()
+        {
+            this.Exchange = new ExchangeInfo();
+            this.Market = new MarketInfo();
+            this.CurrentOrders = new Wallet();
+            this.NewOrders = new Wallet();
+        }
+
+        public TradingContext(Wallet currentOrders, Wallet newOrders, MarketInfo objMarket, ExchangeInfo objExchange, TradingTrend lastTrend, ITradingStrategy objStrategy)
+        {
+            this.Exchange = new ExchangeInfo();
+            this.Market = new MarketInfo();
+            this.CurrentOrders = new Wallet();
+            this.NewOrders = new Wallet();
+            this.CurrentOrders = currentOrders;
+            this.NewOrders = newOrders;
+            this.Market = objMarket;
+            this.Exchange = objExchange;
+            this.LastTrend = lastTrend;
+            this.BaseStrategy = objStrategy;
+        }
+
+        private decimal GetAskMarginFactor()
+        {
+            var objBaseStrategy = this.BaseStrategy as TradingStrategyBase;
+            if (objBaseStrategy != null)
+            {
+                return (1 + (Exchange.AskCommission / 100m) + (objBaseStrategy.LimitOrderMarginRate / 100m));
+            }
+            return 1 + (Exchange.AskCommission / 100m);
+
+        }
+
+        private decimal GetBidMarginFactor()
+        {
+            var objBaseStrategy = this.BaseStrategy as TradingStrategyBase;
+            if (objBaseStrategy != null)
+            {
+                return (1 - (Exchange.BidCommission / 100m) - (objBaseStrategy.LimitOrderMarginRate / 100m));
+            }
+            return 1 - (Exchange.BidCommission / 100m);
+        }
+
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingHistory.cs
+++ b/MyIA.Trading.Backtester/Core/TradingHistory.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+	[DefaultProperty("FriendlyId")]
+	[Serializable]
+	public class TradingHistory
+	{
+	    private TradingSeries _lastEvents;
+
+		private TradingSeries _fiveMinEvents;
+
+		private TradingSeries _hourlyEvents;
+
+		private TradingSeries _dailyEvents;
+
+		private TradingSeries _weeklyEvents;
+
+		private TradingSeries _monthlyEvents;
+
+	    [JsonIgnore()]
+        [Browsable(false)]
+        public string FriendlyId
+        {
+            get
+            {
+                return string.Format("History:  {0} {1},".PadRight(25)
+                    + "{2} {3}".PadRight(18)
+                    + "Hourly: {4}%".PadRight(18)
+                    + "Daily: {5}%".PadRight(18)
+                    + "Weekly: {6}%".PadRight(18)
+                    + "Monthly: {7}%".PadRight(18),
+                    LastWallet.PrimaryBalance.ToString(CultureInfo.InvariantCulture)
+                    , LastWallet.PrimarySymbol
+                    , LastWallet.SecondaryBalance.ToString(CultureInfo.InvariantCulture)
+                    , LastWallet.SecondarySymbol
+                    , _hourlyEvents.TotalEarningsRateFixedPrice.ToString(CultureInfo.InvariantCulture)
+                    , _dailyEvents.TotalEarningsRateFixedPrice.ToString(CultureInfo.InvariantCulture)
+                    , _weeklyEvents.TotalEarningsRateFixedPrice.ToString(CultureInfo.InvariantCulture)
+                    , _monthlyEvents.TotalEarningsRateFixedPrice.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        public Wallet LastWallet { get; set; }
+
+	    public Ticker LastTicker { get; set; }
+
+        public List<Wallet> LastOrdersSeries { get; set; }
+
+        public List<OrderTrade> Trades { get; set; }
+
+        public List<Payment> Fees { get; set; }
+
+        public TradingSeries LastEvents
+        {
+            get
+            {
+                return this._lastEvents;
+            }
+            set
+            {
+                this._lastEvents = value;
+                this._lastEvents.MaxNbItems = 15;
+            }
+        }
+
+        public TradingSeries FiveMinEvents
+        {
+            get
+            {
+                return this._fiveMinEvents;
+            }
+            set
+            {
+                this._fiveMinEvents = value;
+                this._fiveMinEvents.MaxNbItems = 13;
+            }
+        }
+
+        public TradingSeries HourlyEvents
+        {
+            get
+            {
+                return this._hourlyEvents;
+            }
+            set
+            {
+                this._hourlyEvents = value;
+                this._hourlyEvents.MaxNbItems = 25;
+            }
+        }
+
+		public TradingSeries DailyEvents
+		{
+			get
+			{
+				return this._dailyEvents;
+			}
+			set
+			{
+				this._dailyEvents = value;
+				this._dailyEvents.MaxNbItems = 8;
+			}
+		}
+
+        public TradingSeries WeeklyEvents
+        {
+            get
+            {
+                return this._weeklyEvents;
+            }
+            set
+            {
+                this._weeklyEvents = value;
+                this._weeklyEvents.MaxNbItems = 5;
+            }
+        }
+
+		public TradingSeries MonthlyEvents
+		{
+			get
+			{
+				return this._monthlyEvents;
+			}
+			set
+			{
+				this._monthlyEvents = value;
+				this._monthlyEvents.MaxNbItems = 13;
+			}
+		}
+
+		public TradingHistory()
+		{
+			this.LastWallet = new Wallet();
+			this.LastOrdersSeries = new List<Wallet>();
+			this._lastEvents = new TradingSeries(15, TimeSpan.FromMilliseconds(100));
+			this._fiveMinEvents = new TradingSeries(13, TimeSpan.FromMinutes(5));
+			this._hourlyEvents = new TradingSeries(25, TimeSpan.FromHours(1));
+			this._dailyEvents = new TradingSeries(8, TimeSpan.FromDays(1));
+			this._weeklyEvents = new TradingSeries(5, TimeSpan.FromDays(7));
+			this._monthlyEvents = new TradingSeries(13, TimeSpan.FromDays(30));
+			this.Trades = new List<OrderTrade>();
+			this.Fees = new List<Payment>();
+		}
+
+		public void AddEvent(TradingEvent objEvent)
+		{
+			this._lastEvents.AddEvent(objEvent);
+			this._fiveMinEvents.AddEvent(objEvent);
+			this._hourlyEvents.AddEvent(objEvent);
+			this._dailyEvents.AddEvent(objEvent);
+			this._weeklyEvents.AddEvent(objEvent);
+			this._monthlyEvents.AddEvent(objEvent);
+		}
+
+
+        public void Update(Wallet currentWallet, MarketInfo currentMarket, Wallet newOrders)
+        {
+            this.AddEvent(new TradingEvent(currentMarket.Time, currentWallet.GetBalance(currentMarket.Ticker)));
+            this.LastWallet = currentWallet;
+            this.LastTicker = currentMarket.Ticker;
+            if (newOrders.Orders.Count > 0)
+            {
+                this.LastOrdersSeries.Insert(0, newOrders);
+                if (this.LastOrdersSeries.Count > 10)
+                {
+                    this.LastOrdersSeries.RemoveRange(10, this.LastOrdersSeries.Count - 10);
+                }
+            }
+        }
+
+        public void Update(Wallet currentWallet, MarketInfo currentMarket, IList<OrderTrade> objTrades, IList<Payment> objfees)
+        {
+            this.AddEvent(new TradingEvent(currentMarket.Time, currentWallet.GetBalance(currentMarket.Ticker)));
+            this.LastWallet = currentWallet;
+            this.Trades.AddRange(objTrades);
+            this.Fees.AddRange(objfees);
+        }
+
+
+		public TradingTrend GetLastTrend()
+		{
+            var series = new List<TradingSeries>
+            {
+                this._fiveMinEvents,
+                this._hourlyEvents,
+                this._dailyEvents,
+                this._weeklyEvents,
+                this._monthlyEvents
+            };
+		    foreach (TradingSeries objSeries in series)
+            {
+
+                if (objSeries.Instances.Count > 1)
+                {
+                    decimal lastBalance = objSeries.Instances[0].Balance.Primary;
+                    int i = 1;
+                    while (i < objSeries.Instances.Count - 1 && objSeries.Instances[i].Balance.Primary == lastBalance)
+                    {
+                        i += 1;
+                    }
+                    if (lastBalance < objSeries.Instances[i].Balance.Primary)
+                    {
+                        return TradingTrend.Ask;
+                    }
+                    else if (lastBalance > objSeries.Instances[i].Balance.Primary)
+                    {
+                        return TradingTrend.Bid;
+                    }
+                }
+            }
+            return TradingTrend.Neutral;
+		}
+
+
+	}
+}

--- a/MyIA.Trading.Backtester/Core/TradingModels.cs
+++ b/MyIA.Trading.Backtester/Core/TradingModels.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Serialization;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+	[DefaultProperty("Label")]
+	[Serializable]
+	public class Payment
+	{
+		public decimal Amount
+		{
+			[DebuggerNonUserCode]
+			get;
+			[DebuggerNonUserCode]
+			set;
+		}
+
+		public string Currency
+		{
+			[DebuggerNonUserCode]
+			get;
+			[DebuggerNonUserCode]
+			set;
+		}
+
+		public string Label
+		{
+			[DebuggerNonUserCode]
+			get;
+			[DebuggerNonUserCode]
+			set;
+		}
+
+		public DateTime Time
+		{
+			[DebuggerNonUserCode]
+			get;
+			[DebuggerNonUserCode]
+			set;
+		}
+
+		public Payment()
+		{
+			this.Currency = "BTC";
+		}
+	}
+
+	[DefaultProperty("Time")]
+	[Serializable]
+	public class TradingEvent
+	{
+	    public Balance Balance { get; set; }
+
+	    public DateTime Time { get; set; }
+
+	    public TradingEvent()
+		{
+			Balance = new Balance();
+		}
+
+		public TradingEvent(DateTime time, Balance objBalance)
+		{
+			Balance = new Balance();
+			Time = time;
+			Balance = objBalance;
+		}
+	}
+
+	public enum TradingTrend
+	{
+		Bid = -1,
+		Neutral = 0,
+		Ask = 1
+	}
+
+    [DefaultProperty("DisplayName")]
+    [Serializable]
+    public class Transaction
+    {
+
+        public string Id { get; set; }
+
+        public string Symbol { get; set; }
+
+        public DateTime Time { get; set; }
+
+        public string TimeStamp { get; set; }
+
+        public string TimeZone { get; set; }
+
+        public TransactionType TransactionType { get; set; }
+
+        public string Address { get; set; }
+
+        public decimal Amount { get; set; }
+
+        public decimal Fee { get; set; }
+
+        [Browsable(false)]
+        [XmlIgnore()]
+        [JsonIgnore()]
+        public virtual string DisplayName
+        {
+            get
+            {
+                return string.Format("{0} {1} - {2} : {3} {4} {5},  Address: {6}, Fee: {7}",
+                    Time.ToShortDateString(), Time.ToShortTimeString(), TransactionType, Amount.ToString(CultureInfo.InvariantCulture), Symbol,
+                    Address, Fee.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+    }
+
+    public enum TransactionType
+    {
+        Deposit = 1,
+        Withdrawal = 2,
+    }
+
+    public enum TradingAPIUrls
+    {
+        Ticker,
+        MarketDepth,
+        RecentTrades,
+        GetBalance,
+        BuyBTC,
+        SellBTC,
+        GetOrders,
+        CancelOrder,
+        SendBTC,
+        GetDepositAddress,
+        GetMarkets
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingSeries.cs
+++ b/MyIA.Trading.Backtester/Core/TradingSeries.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace MyIA.Trading.Backtester
+{
+    [Serializable]
+    public class TradingSeries
+    {
+        public TradingSeries()
+        {
+            Instances = new List<TradingEvent>();
+        }
+
+        public TradingSeries(int maxNbItems, TimeSpan period)
+            : this()
+        {
+            MaxNbItems = maxNbItems;
+            Period = period;
+        }
+
+        public List<TradingEvent> Instances { get; }
+
+        [Browsable(false)]
+        public int MaxNbItems { get; set; }
+
+        [Browsable(false)]
+        public TimeSpan Period { get; set; }
+
+        public decimal EarningsPerPeriodRate
+        {
+            get { return decimal.Round(TotalEarningsRate * GetSpanRatio(), 3); }
+        }
+
+        public decimal TotalEarnings
+        {
+            get
+            {
+                if (Instances.Count > 1)
+                {
+                    return decimal.Round(
+                        Instances[0].Balance.Total - Instances[Instances.Count - 1].Balance.Total,
+                        5);
+                }
+                return 0m;
+            }
+        }
+
+        public decimal TotalEarningsRate
+        {
+            get
+            {
+                if (Instances.Count > 1 && Instances[Instances.Count - 1].Balance.Total > 0m)
+                {
+                    return decimal.Round(
+                        TotalEarnings / Instances[Instances.Count - 1].Balance.Total * 100m,
+                        3);
+                }
+                return 0m;
+            }
+        }
+
+        public decimal TotalEarningsFixedPrice
+        {
+            get
+            {
+                if (Instances.Count > 1)
+                {
+                    return decimal.Round(
+                        Instances[0].Balance.Total
+                        - (Instances[Instances.Count - 1].Balance.Secondary
+                           + Instances[Instances.Count - 1].Balance.Primary * Instances[0].Balance.TickerLast),
+                        5);
+                }
+                return 0m;
+            }
+        }
+
+        public decimal TotalEarningsRateFixedPrice
+        {
+            get
+            {
+                if (Instances.Count > 1 && Instances[Instances.Count - 1].Balance.Total > 0m)
+                {
+                    return decimal.Round(
+                        TotalEarningsFixedPrice
+                        / (Instances[Instances.Count - 1].Balance.Secondary
+                           + Instances[Instances.Count - 1].Balance.Primary * Instances[0].Balance.TickerLast)
+                        * 100m,
+                        3);
+                }
+                return 0m;
+            }
+        }
+
+        public void AddEvent(TradingEvent objEvent)
+        {
+            if (Instances.Count > 0)
+            {
+                if (Instances[0].Balance.Total == 0m)
+                {
+                    Instances.RemoveAt(0);
+                }
+                else if ((Period.TotalDays < 10 && TotalEarningsRateFixedPrice > 30m)
+                         || TotalEarningsRateFixedPrice > 100m)
+                {
+                    Instances.RemoveAt(Instances.Count - 1);
+                }
+            }
+
+            if (Instances.Count == 0 || objEvent.Time.Subtract(Instances[0].Time) > Period)
+            {
+                Instances.Insert(0, objEvent);
+                if (Instances.Count > MaxNbItems)
+                {
+                    Instances.RemoveRange(MaxNbItems, Instances.Count - MaxNbItems);
+                }
+            }
+        }
+
+        private decimal GetSpanRatio()
+        {
+            if (Period.Ticks > 0 && Instances.Count > 0)
+            {
+                decimal span = Instances[0].Time.Subtract(Instances[Instances.Count - 1].Time).Ticks;
+                if (span > 0m)
+                {
+                    return Period.Ticks / span;
+                }
+            }
+            return 1m;
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingStrategyBase.cs
+++ b/MyIA.Trading.Backtester/Core/TradingStrategyBase.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace MyIA.Trading.Backtester
+{
+	[Serializable]
+	public abstract class TradingStrategyBase : ITradingStrategy, IContextualStrategy
+	{
+	    public decimal AskReserveAmount { get; set; }
+
+	    public decimal AskReserveRate { get; set; }
+
+	    public decimal BidReserveRate { get; set; }
+
+	    public decimal BidReserveValue { get; set; }
+
+	    public bool ClearAsks { get; set; }
+
+	    public bool ClearBids { get; set; }
+
+	    [Browsable(false)]
+	    public virtual decimal LimitOrderMarginRate { get; set; }
+
+	    public bool NoAsks { get; set; }
+
+	    public bool NoBids { get; set; }
+
+	    [Browsable(false)]
+	    public virtual bool TakeMarginOnOppositeOrder { get; set; }
+
+	    protected TradingStrategyBase()
+		{
+			this.AskReserveRate = 30m;
+			this.AskReserveAmount = 0m;
+			this.BidReserveRate = 20m;
+			this.BidReserveValue = 0m;
+			this.LimitOrderMarginRate = 1m;
+		}
+
+		public Wallet ComputeNewOrders(Wallet currentOrders, MarketInfo objMarket, ExchangeInfo objExchange, TradingHistory history)
+		{
+			var newOrders = new Wallet();
+            var askReserve = Math.Max(this.AskReserveAmount, currentOrders.PrimaryBalance * AskReserveRate / 100m);
+            var bidReserve = Math.Max(this.BidReserveValue, currentOrders.SecondaryBalance * BidReserveRate / 100m);
+
+			decimal avBtcsForTrading = currentOrders.PrimaryBalance- askReserve;
+			decimal avUsdsForTrading = currentOrders.SecondaryBalance- bidReserve;
+
+            //todo: should we update the original wallet?
+			newOrders.ConsolidateOrders(ref currentOrders, true);
+
+			newOrders.PrimaryBalance = Math.Max(avBtcsForTrading- currentOrders.GetTotalAsksPrimary(), decimal.Zero);
+			newOrders.SecondaryBalance = Math.Max(decimal.Subtract(avUsdsForTrading, currentOrders.GetTotalBidsSecondary()), decimal.Zero);
+
+			var tContext = new TradingContext(currentOrders, newOrders, objMarket, objExchange, history.GetLastTrend(), this);
+			this.ComputeNewOrders(ref tContext);
+			if (this.NoAsks)
+			{
+				tContext.NewOrders.ClearAsks();
+				if (this.ClearAsks)
+				{
+					tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.OrderedAsks.ToArray());
+				}
+			}
+			if (this.NoBids)
+			{
+				tContext.NewOrders.ClearBids();
+				if (this.ClearBids)
+				{
+					tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.OrderedBids.ToArray());
+				}
+			}
+			tContext.NewOrders.FitOrders(objExchange);
+			history.Update(currentOrders, objMarket, tContext.NewOrders);
+			return tContext.NewOrders;
+		}
+
+		public abstract void ComputeNewOrders(ref TradingContext tContext);
+	}
+}

--- a/MyIA.Trading.Backtester/Core/Wallet.cs
+++ b/MyIA.Trading.Backtester/Core/Wallet.cs
@@ -1,0 +1,511 @@
+using System.Globalization;
+using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Xml.Serialization;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+    [DefaultProperty("DisplayName")]
+    [Serializable]
+    public class Wallet : ResponseObject, ICloneable
+    {
+        private List<Order> _orders;
+
+        private List<Order> _orderedAsks;
+        private List<Order> _orderedBids;
+
+        [Browsable(false)]
+        [XmlIgnore()][JsonIgnore()]
+        public virtual string DisplayName
+        {
+            get
+            {
+                return string.Format("{0} {1} - {2} {3}, {4} {5} - {6} Asks, {7} Bids, {8} Cancels",
+                    Time.ToShortDateString(), Time.ToShortTimeString(), PrimaryBalance, PrimarySymbol,
+                    SecondaryBalance.ToString(CultureInfo.InvariantCulture), SecondarySymbol.ToString(CultureInfo.InvariantCulture),
+                    OrderedAsks.Count.ToString(CultureInfo.InvariantCulture), OrderedBids.Count.ToString(CultureInfo.InvariantCulture),
+                    CancelOrders.Count.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        public string Status { get; set; }
+
+        public DateTime Time { get; set; }
+
+        public string MarketId { get; set; }
+
+        public string PrimarySymbol { get; set; } = "";
+
+        public string SecondarySymbol { get; set; } = "";
+
+        public decimal PrimaryBalance { get; set; }
+
+        public decimal SecondaryBalance { get; set; }
+
+        [Browsable(false)]
+        public virtual List<Order> Orders
+        {
+            get
+            {
+                Clean();
+                return _orders;
+            }
+            set
+            {
+                _orders = value;
+                Clean();
+            }
+        }
+
+
+
+        [XmlIgnore()][JsonIgnore()]
+        public List<Order> OrderedAsks
+        {
+            get
+            {
+                if (_orderedAsks == null)
+                {
+                    _orderedAsks = GetSortedOrders(1);
+                }
+                return _orderedAsks;
+            }
+        }
+
+        [XmlIgnore()][JsonIgnore()]
+        public List<Order> OrderedBids
+        {
+            get
+            {
+                if (_orderedBids == null)
+                {
+                    _orderedBids = GetSortedOrders(2);
+                }
+                return _orderedBids;
+            }
+        }
+
+        [XmlIgnore()][JsonIgnore()]
+        public List<Order> CancelOrders
+        {
+            get
+            {
+                return _orders.Where(objOrder => objOrder.OrderType == OrderType.Cancel || objOrder.IsCancel).ToList();
+            }
+        }
+
+        [XmlIgnore()][JsonIgnore()]
+        public Order HighestAsk
+        {
+            get
+            {
+                var asks = OrderedAsks;
+                if (asks.Count > 0)
+                {
+                    return asks[(asks.Count - 1)];
+                }
+                return null;
+            }
+        }
+
+        [XmlIgnore()][JsonIgnore()]
+        public Order HighestBid
+        {
+            get
+            {
+                var bids = OrderedBids;
+                if (bids.Count > 0)
+                {
+                     return bids[bids.Count - 1];
+                }
+                return null;
+            }
+        }
+
+        [XmlIgnore()][JsonIgnore()]
+        public Order LowestAsk
+        {
+            get
+            {
+                var asks = this.OrderedAsks;
+                if (asks.Count == 0)
+                {
+                    return null;
+                }
+                else
+                {
+                    return asks[0];
+                }
+            }
+        }
+
+        [XmlIgnore()][JsonIgnore()]
+        public Order LowestBid
+        {
+            get
+            {
+                var bids = OrderedBids;
+                if (bids.Count == 0)
+                {
+                    return null;
+                }
+                else
+                {
+                    return bids[0];
+                }
+            }
+        }
+
+        public virtual List<OrderTrade> LastTrades { get; set; }
+
+        public virtual List<Transaction> LastTransactions { get; set; }
+
+        #region cTors
+
+        public Wallet()
+        {
+            this.Status = "Default";
+            this.Time = DateTime.Now;
+            this._orders = new List<Order>();
+            this.LastTrades = new List<OrderTrade>();
+            this.LastTransactions = new List<Transaction>();
+
+        }
+
+        public Wallet(ResponseObject objresponseObject)
+            : base(objresponseObject)
+        {
+            this.Status = "Default";
+            this.Time = DateTime.Now;
+            this.Orders = new List<Order>();
+            this.LastTrades = new List<OrderTrade>();
+            this.LastTransactions = new List<Transaction>();
+        }
+
+        //public Wallet(Balance objBalance, Wallet balanceLessWallet)
+        //    : this(balanceLessWallet)
+        //{
+        //    this.SecondaryBalance = objBalance.usds;
+        //    this.PrimaryBalance = objBalance.btcs;
+        //    this.Orders = balanceLessWallet.Orders;
+        //}
+
+        #endregion
+
+
+
+        public void CancelExistingOrders(params Order[] objOrders)
+        {
+            foreach (var objOrder in objOrders)
+            {
+                if (!objOrder.IsCancel)
+                {
+                    string cancelOrderId = objOrder.Oid;
+                    if (string.IsNullOrEmpty(cancelOrderId))
+                    {
+                        this.Orders.Remove(objOrder);
+                    }
+                    else if (!this.CancelOrders.Exists(varOrder => varOrder.Oid == cancelOrderId))
+                    {
+                        var toReturn = new Order()
+                        {
+                            IsCancel = true,
+                            Type = objOrder.Type,
+                            Oid = objOrder.Oid,
+                            Price = objOrder.Price,
+                            Amount = objOrder.Amount
+                        };
+                        this.Orders.Add(toReturn);
+                        //todo: not sure where that came from, need to check balance vs avail balance handling
+                        switch (objOrder.OrderType)
+                        {
+                            case OrderType.Sell:
+                                this.PrimaryBalance += objOrder.Amount;
+                                break;
+                            case OrderType.Buy:
+                                this.SecondaryBalance += objOrder.Price * objOrder.Amount;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove all ask orders
+        /// </summary>
+        public void ClearAsks()
+        {
+            foreach (var order in OrderedAsks)
+            {
+                this.Orders.Remove(order);
+            }
+        }
+
+        /// <summary>
+        ///  Removes all bid orders
+        /// </summary>
+        public void ClearBids()
+        {
+            foreach (var order in OrderedBids)
+            {
+                this.Orders.Remove(order);
+            }
+        }
+
+        /// <summary>
+        ///  Performs a deep copy of the current wallet
+        /// </summary>
+        /// <returns>the clone wallet</returns>
+        public object Clone()
+        {
+            var toReturn = new Wallet
+            {
+                Time = this.Time,
+                PrimarySymbol = this.PrimarySymbol,
+                SecondarySymbol = this.SecondarySymbol,
+                PrimaryBalance = this.PrimaryBalance,
+                SecondaryBalance = this.SecondaryBalance,
+                Status = this.Status,
+                Orders = new List<Order>(this._orders),
+                LastTrades = new List<OrderTrade>(this.LastTrades),
+                LastTransactions = new List<Transaction>(this.LastTransactions),
+                ReturnCodes = this.ReturnCodes,
+                Error = this.Error
+            };
+            return toReturn;
+        }
+
+        /// <summary>
+        /// Consolidates the current wallet
+        /// </summary>
+        public void ConsolidateOrders()
+        {
+            Wallet objWallet = this;
+            this.ConsolidateOrders(ref objWallet, true);
+        }
+
+        /// <summary>
+        /// Merges orders of the same price from an given wallet, while creating the cancel and new orders in the current wallet
+        /// </summary>
+        /// <param name="originalWallet">the wallet to merge the same priced orders from</param>
+        /// <param name="updateOriginalWallet">defines if only the current wallet is updated with new orders, or also the original wallet</param>
+        public void ConsolidateOrders(ref Wallet originalWallet, bool updateOriginalWallet)
+        {
+
+            var priceWallets = new Dictionary<decimal, Wallet>();
+            foreach (var objOrder in _orders)
+            {
+                if (!objOrder.IsCancel)
+                {
+                    Wallet tempPriceWallet;
+                    if (!priceWallets.TryGetValue(objOrder.Price, out tempPriceWallet))
+                    {
+                        tempPriceWallet = new Wallet();
+                        priceWallets[objOrder.Price] = tempPriceWallet;
+                    }
+                    tempPriceWallet.Orders.Add(objOrder);
+                }
+            }
+            foreach (var priceWallet in priceWallets.Values)
+            {
+                if (priceWallet._orders.Count > 1)
+                {
+                    var mergedOrder = new Order()
+                    {
+                        Type = priceWallet._orders[0].Type,
+                        Price = priceWallet._orders[0].Price
+                    };
+                    foreach (var subOrder in priceWallet._orders)
+                    {
+                        mergedOrder.Amount = decimal.Add(mergedOrder.Amount, subOrder.Amount);
+                        if (updateOriginalWallet)
+                        {
+                            originalWallet.Orders.Remove(subOrder);
+                        }
+
+                    }
+                   // The current wallet serves collecting the consolidation orders to be issued (2 cancels + 1 new)
+                    this.CancelExistingOrders(priceWallet._orders.ToArray());
+                    this.Orders.Add(mergedOrder);
+                    // the new order replaces the consolidated orders in the original wallet too
+                    if (originalWallet != this & updateOriginalWallet)
+                    {
+                        originalWallet.Orders.Add(mergedOrder);
+                    }
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Shortcut function for selecting an order by id
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <returns></returns>
+        public Order FindOrderById(string orderId)
+        {
+            return _orders.Find(o => o.Oid == orderId);
+        }
+
+
+
+        /// <summary>
+        ///  Updates the orders according to the available balance (overflow orders are removed), and to the exchange min order settings.
+        /// </summary>
+        /// <param name="exchange">the exchange defining minimum order settings</param>
+        public void FitOrders(ExchangeInfo exchange)
+        {
+
+            this.ConsolidateOrders();
+
+
+            //first we fit orders according to the available resources
+            decimal totalBids = this.GetTotalBidsSecondary();
+            if (totalBids > 0)
+            {
+                var coefBids = Math.Max(this.SecondaryBalance, 0) / totalBids;
+                if (coefBids < 1)
+                {
+                    decimal cumulativeBids = 0;
+                    foreach (var bid in this.OrderedBids)
+                    {
+                        //bid.amount = Decimal.Round(bid.amount * coefBids, exchange.AmountDecil, MidpointRounding.ToEven)
+                        cumulativeBids += bid.Value;
+                        if (cumulativeBids > this.SecondaryBalance)
+                        {
+                            this.Orders.Remove(bid);
+                        }
+                    }
+                }
+            }
+            var totalAsks = this.GetTotalAsksPrimary();
+            if (totalAsks > 0)
+            {
+                var coefAsks = Math.Max(this.PrimaryBalance, 0) / totalAsks;
+                if (coefAsks < 1)
+                {
+                    decimal cumulativeAsks = 0;
+                   var decreasingAsks = this.OrderedAsks;
+                    decreasingAsks.Reverse();
+                    foreach (var ask in decreasingAsks)
+                    {
+                        //ask.amount = Decimal.Round(ask.amount * coefAsks, exchange.AmountDecil, MidpointRounding.ToEven)
+                        cumulativeAsks += ask.Amount;
+                        if (cumulativeAsks > this.PrimaryBalance)
+                        {
+                            _orders.Remove(ask);
+                        }
+                    }
+                }
+            }
+
+
+            var cleanOrders = new List<Order>();
+            foreach (var objOrder in _orders)
+            {
+                if (objOrder.IsCancel)
+                {
+                    cleanOrders.Add(objOrder);
+                }
+                else
+                {
+                    if (objOrder.Amount >= Math.Max(exchange.MinOrderAmount, exchange.MinOrderValue / objOrder.Price))
+                    {
+                        objOrder.Price = decimal.Round(objOrder.Price, exchange.PriceDecil);
+                        objOrder.Amount = decimal.Round(objOrder.Amount, exchange.AmountDecil);
+                        cleanOrders.Add(objOrder);
+                    }
+
+                }
+            }
+            Orders = cleanOrders;
+        }
+
+        public Balance GetBalance(decimal price)
+        {
+            return new Balance(this.PrimaryBalance, new Ticker(price), this.SecondaryBalance);
+        }
+
+        public Balance GetBalance(Ticker objTicker)
+        {
+            return new Balance(this.PrimaryBalance, objTicker, this.SecondaryBalance);
+        }
+
+        public decimal GetTotalAsksPrimary()
+        {
+            return _orders.Where(objOrder => (objOrder.Type == 1 && !objOrder.IsCancel))
+                .Aggregate(0m, (current, objOrder) => decimal.Add(current, objOrder.Amount));
+        }
+
+        public decimal GetTotalBidsSecondary()
+        {
+            return _orders.Where(objOrder => (objOrder.Type == 2 && !objOrder.IsCancel))
+                .Aggregate(0m, (current, objOrder) => decimal.Add(current, objOrder.Value));
+        }
+
+
+        /// <summary>
+        /// Updates a wallet with a list of orders, as expected from the exchange (used for simulation)
+        /// </summary>
+        /// <param name="newOrders"></param>
+        public void IntegrateOrders(Order[] newOrders)
+        {
+            Order[] orderArray = newOrders;
+            foreach (var newOrder in newOrders)
+            {
+                if (!newOrder.IsCancel)
+                {
+                    newOrder.Oid = Guid.NewGuid().ToString();
+                    this.Orders.Add(newOrder);
+                }
+                else
+                {
+                    Order targetOrder = this.FindOrderById(newOrder.Oid);
+                    if (targetOrder != null)
+                    {
+                        this.Orders.Remove(targetOrder);
+                    }
+                }
+            }
+        }
+
+
+
+        #region Private methods
+
+        private List<Order> GetSortedOrders(int objOrderType)
+        {
+            var objSortedList = new SortedList<decimal, Order>(this._orders.Count);
+            for (int i = 0; i < _orders.Count; i++)
+            {
+                Order objOrder = _orders[i];
+                if ((objOrder.Type == objOrderType && !objOrder.IsCancel))
+                {
+                    if (objSortedList.ContainsKey(objOrder.Price))
+                    {
+                        Order item = objSortedList[objOrder.Price];
+                        item.Amount = decimal.Add(item.Amount, objOrder.Amount);
+                    }
+                    else
+                    {
+                        objSortedList.Add(objOrder.Price, objOrder);
+                    }
+                }
+            }
+            return new List<Order>(objSortedList.Values);
+        }
+
+        private void Clean()
+        {
+            _orderedAsks = null;
+            _orderedBids = null;
+        }
+
+        #endregion
+
+    }
+}

--- a/MyIA.Trading.Backtester/Core/Wallet.cs
+++ b/MyIA.Trading.Backtester/Core/Wallet.cs
@@ -265,12 +265,23 @@ namespace MyIA.Trading.Backtester
             var toReturn = new Wallet
             {
                 Time = this.Time,
+                MarketId = this.MarketId,
                 PrimarySymbol = this.PrimarySymbol,
                 SecondarySymbol = this.SecondarySymbol,
                 PrimaryBalance = this.PrimaryBalance,
                 SecondaryBalance = this.SecondaryBalance,
                 Status = this.Status,
-                Orders = new List<Order>(this._orders),
+                Orders = this._orders.Select(order => new Order
+                {
+                    Oid = order.Oid,
+                    Status = order.Status,
+                    Date = order.Date,
+                    IsCancel = order.IsCancel,
+                    Type = order.Type,
+                    Price = order.Price,
+                    Amount = order.Amount,
+                    Dark = order.Dark
+                }).ToList(),
                 LastTrades = new List<OrderTrade>(this.LastTrades),
                 LastTransactions = new List<Transaction>(this.LastTransactions),
                 ReturnCodes = this.ReturnCodes,
@@ -432,7 +443,7 @@ namespace MyIA.Trading.Backtester
 
         public Balance GetBalance(Ticker objTicker)
         {
-            return new Balance(this.PrimaryBalance, objTicker, this.SecondaryBalance);
+            return new Balance(this.PrimaryBalance, new Ticker(objTicker), this.SecondaryBalance);
         }
 
         public decimal GetTotalAsksPrimary()
@@ -479,24 +490,10 @@ namespace MyIA.Trading.Backtester
 
         private List<Order> GetSortedOrders(int objOrderType)
         {
-            var objSortedList = new SortedList<decimal, Order>(this._orders.Count);
-            for (int i = 0; i < _orders.Count; i++)
-            {
-                Order objOrder = _orders[i];
-                if ((objOrder.Type == objOrderType && !objOrder.IsCancel))
-                {
-                    if (objSortedList.ContainsKey(objOrder.Price))
-                    {
-                        Order item = objSortedList[objOrder.Price];
-                        item.Amount = decimal.Add(item.Amount, objOrder.Amount);
-                    }
-                    else
-                    {
-                        objSortedList.Add(objOrder.Price, objOrder);
-                    }
-                }
-            }
-            return new List<Order>(objSortedList.Values);
+            return _orders
+                .Where(order => order.Type == objOrderType && !order.IsCancel)
+                .OrderBy(order => order.Price)
+                .ToList();
         }
 
         private void Clean()


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2025:CoursIA — prev: DEEP/research-code #14608

## Résumé

- porte la fermeture Core déterministe requise par la future couche `BackTesting.cs` : portefeuille, marché, exchange, matching, historique, séries temporelles, contexte de stratégie et orchestration de simulation ;
- remplace les dépendances décoratives Aricie/DNN par la BCL (`TimeSpan`, `Dictionary`, classes et listes C# simples), tout en conservant les attributs de sérialisation et BCL utiles ;
- corrige les défauts métier vérifiés du code historique : bids datés correctement désérialisés, absence d'anticipation, ordres au même prix sans inflation, snapshots de ticker immuables, fenêtre glissante des trades récents et état de skip indépendant par setup ;
- ajoute 12 tests déterministes couvrant clone et collections mutables, franchissement du marché, ordres dupliqués, commissions/soldes, désérialisation bid datée, séries temporelles, snapshots, non-anticipation, fenêtre glissante, indépendance multi-setup et cadence `BotPeriod`.

## Périmètre

- 14 fichiers nouveaux, 2 616 lignes ;
- `MyIA.Trading.Backtester/Core/**` et `MyIA.Trading.Backtester.Tests/Core/**` uniquement ;
- catalogue généré byte-identique à `main` ;
- aucune référence à Aricie, DotNetNuke ou Flee dans la fermeture ajoutée.

`BackTesting.cs` reste explicitement hors scope et formera la tranche 6B. Cette PR est donc liée par `See`, sans clôture de l'EPIC.

## Validation

```text
dotnet build MyIA.Trading.Backtester/MyIA.Trading.Backtester.csproj --configuration Release --no-restore
Build succeeded — 0 error (2 pre-existing warnings outside Core)

dotnet test MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj --configuration Release --no-restore
Passed: 67, Failed: 0, Skipped: 0 (.NET 9.0)
```

Baseline avant tranche : 55 tests. Après tranche : 67 tests, soit 12 nouveaux tests Core.

## SOTA / substitution

**SOTA-OK** : ce grain ne remplace aucun moteur numérique ou ML par un contournement. Il porte le moteur déterministe historique et substitue seulement des wrappers/UI propriétaires par des types BCL équivalents. Le chemin SVM/Accord.NET et la couche AutoML restent inchangés et hors de ce diff.

See #7357
