### PR TITLE
fix(qc-py-cloud,#13755): sweep final renum -- purge anciens chemins CSV translations + repoint 3 refs docs

### DIFF
--- a/STABLE_SNAPSHOT.md
+++ b/STABLE_SNAPSHOT.md
@@ -52,7 +52,7 @@
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb` | QuantConnect | 2026-07-12 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-11-RegimeSwitching.ipynb` | QuantConnect | 2026-07-12 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-PCA-StatArb.ipynb` | QuantConnect | 2026-07-12 |
-| `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-VolTargeting.ipynb` | QuantConnect | 2026-07-12 |
+| `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-13-VolTargeting.ipynb` | QuantConnect | 2026-07-12 |
 | `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-07-TemporalCNN.ipynb` | QuantConnect | 2026-07-12 |
 | `MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/runner.ipynb` | QuantConnect | 2026-06-01 |
 | `MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j_minute.ipynb` | QuantConnect | 2026-06-28 |

--- a/docs/archive/handson-book-mapping.md
+++ b/docs/archive/handson-book-mapping.md
@@ -72,7 +72,7 @@
 
 | Book Section | Pages | Topic | CoursIA Mapping | Notes |
 |---|---|---|---|---|
-| RL for hedging | 281-303 | Policy network, simulation, refinement on market data, QC implementation | [QC-Py-25-Reinforcement-Learning.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb), [QC-Py-32-RL-DQN-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb), [QC-Py-Cloud-04-RL-DQN-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | Book applies RL to hedging specifically; our notebooks focus on trading signals |
+| RL for hedging | 281-303 | Policy network, simulation, refinement on market data, QC implementation | [QC-Py-25-Reinforcement-Learning.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb), [QC-Py-32-RL-DQN-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb), [QC-Py-Cloud-10-RL-DQN-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-10-RL-DQN-Trading.ipynb) | Book applies RL to hedging specifically; our notebooks focus on trading signals |
 
 ### Chapter 8: AI for Risk Management and Optimization
 

--- a/docs/ledgers/3801-sota-axe2.md
+++ b/docs/ledgers/3801-sota-axe2.md
@@ -1716,7 +1716,7 @@ La famille QC-Py présente une **architecture d'exécution à deux couches**, v�
 | **QC-Py-25-Reinforcement-Learning** | 39 | 15 | 12/15 | 1 | python3 | **torch Q-learning** | **SOTA-OK** |
 | **QC-Py-33-RL-PPO-Trading** | 38 | 16 | 16/16 | 0 | **conda-torch** | **torch PPO** (GPU-kernel) | **SOTA-OK** |
 | **QC-Py-34-RL-SAC-A2C-Trading** | 40 | 17 | 17/17 | 0 | **conda-torch** | **torch SAC + A2C** (GPU-kernel) | **SOTA-OK** |
-| **QC-Py-Cloud-03-DualMomentum** | 15 | 3 | 3/3 | 0 | python3 | seed stratégie QC Cloud | **RECOVERABLE-MACHINE** |
+| **QC-Py-Cloud-14-DualMomentum** | 15 | 3 | 3/3 | 0 | python3 | seed stratégie QC Cloud | **RECOVERABLE-MACHINE** |
 
 **Total famille (53 nb)** : 491 cellules EXEC_PROVED (couche analytics, SOTA-OK) · 164 cellules `[REFERENCE QC]` (couche plateforme, RECOVERABLE-MACHINE by design) · ~112 cellules Cloud-* seeds (RECOVERABLE-MACHINE) · 0 erreur · 0 violation C.1 · 11 CJK cosmétique.
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA-2 — prev: MED/genai #14751

## Summary

Sweep final des résidus **doc** du renum Cloud (#13755) laissés par les 6 tranches (#13804, #14082, #14084, #14083, #14093, #14443) : 3 références docs pointaient encore des chemins morts. La partie **CSV translations** du sweep est séparée en PR #14758 (translation-sync.yml en HOLD #10038) — cette PR ne porte que la doc.

**Fichiers touchés (3, 1 ligne chacun)** :
- `STABLE_SNAPSHOT.md:55` : `QC-Py-Cloud-06-VolTargeting` → `QC-Py-Cloud-13-VolTargeting` (les autres tranches avaient mis à jour le snapshot, la ligne de la tranche 6 avait été ratée).
- `docs/archive/handson-book-mapping.md:75` : lien `QC-Py-Cloud-04-RL-DQN-Trading` → `QC-Py-Cloud-10-RL-DQN-Trading`.
- `docs/ledgers/3801-sota-axe2.md:1719` : entrée du registre `QC-Py-Cloud-03-DualMomentum` → `QC-Py-Cloud-14-DualMomentum` (l'identifiant de l'entrée reste trouvable).

**Vérifications d'acceptance #13755 (firsthand, pour le close)** :
- 15 notebooks Cloud sur disque : 01..14 + 03b, un concept par numéro, lane des numéros simples complète et ordonnée.
- `git grep` des 6 anciens chemins sur l'arbre committé : **0 hit** (hors `COURSE_CATALOG*` générés, byte-identiques à main).
- `scripts/notebook_tools/twin_pairs.d` : 0 entrée Cloud (les paires renumérées ne sont pas des twins — l'issue le posait).
- Checklist `production-scope.md` : déjà corrigée par #14729 (tranche 6).
- Catalogue non touché (byte-identique), renommages/code inchangés (les tranches ont fait les `git mv`).

## Validation

- Éditions markdown au niveau binaire (`read_bytes`/`write_bytes`) pour préserver les line endings — churn CRLF vérifié nul (2 lignes par fichier dans le diff).
- Aucune cellule de notebook modifiée, aucun fichier hors les 3 ci-dessus — pas de re-exécution due.

Closes #13755
See #5081
See #14758
