### PR TITLE
Add: hcap of still lifes closed (T=1) -- first entirely-proved L3 link (13483 tranche 3c step 4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -410,6 +410,110 @@ theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
   hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap
 
+/-! ## L3 classe `T = 1` — hcap des natures mortes (tranche 3, étape 4)
+
+Premier maillon L3 **entièrement clos** : pour la classe des natures mortes
+(`evolve 1 g = g`, point fixe de `step`), l'hypothèse `hcap` de la réduction L2
+est établie de bout en bout — la trajectoire est constante, la reconstruction
+est constante, et le saut est capturé par `jumpCapturedF_of_still_life`. Le
+chaînage : round-trip ÉGALITÉ de la reconstruction pour grilles canoniques
+(`Canonical.ext`, rigidité des listes triées-dédupliquées) → transport du point
+fixe à l'origine via `toGrid_shift_grid`/`evolve_shift` → capture. -/
+
+/-- **Round-trip ÉGALITÉ de la reconstruction (grilles canoniques).**
+    La forme générale du docstring de `gridToMacroCellWithOffset` — jusqu'ici
+    établie seulement au niveau des membres
+    (`mem_toGrid_gridToMacroCellWithOffset`, MacroCell L857) — se renforce en
+    **égalité de listes** dès que `g` est canonique : les deux grilles sont
+    canoniques (`toGrid` est une image `sortDedup`, `g` l'est par hypothèse)
+    et ont les mêmes membres, donc sont égales par rigidité
+    (`Canonical.ext`). C'est le pont members→égalité qui manquait pour
+    transporter des équivalences de point fixe (des `Prop` d'égalité) à
+    travers la reconstruction. -/
+theorem toGrid_gridToMacroCellWithOffset_eq (g : Grid) (hg : Canonical g) :
+    (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1 = g :=
+  Canonical.ext (canonical_sortDedup _) hg (fun p => mem_toGrid_gridToMacroCellWithOffset g p)
+
+/-- **Transport du point fixe à la reconstruction (rendue à l'origine).**
+    Si `g` est une nature morte canonique, alors la MacroCell reconstruite
+    rendue à l'origine `(gridToMacroCellWithOffset g).2.toGrid (0, 0)` est
+    elle-même un point fixe de `evolve 1` : la navette `toGrid_shift_grid`
+    ramène l'origine à un shift de la grille cadrée, `evolve_shift` fait
+    commuter le shift avec `evolve`, `evolve_congr` transporte l'évolution au
+    cadre de `g` (même membres), et le round-trip ÉGALITÉ referme la boucle.
+    C'est l'hypothèse `hfix` exacte qu'exige `jumpCapturedF_of_still_life`
+    sur la reconstruction — désormais disponible pour la classe `T = 1`. -/
+theorem still_life_fix_toGrid_zero (g : Grid) (hg : Canonical g)
+    (hfix : evolve 1 g = g) :
+    evolve 1 ((gridToMacroCellWithOffset g).2.toGrid (0, 0))
+      = (gridToMacroCellWithOffset g).2.toGrid (0, 0) := by
+  have hrt : (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1
+      = g := toGrid_gridToMacroCellWithOffset_eq g hg
+  have hshift : (gridToMacroCellWithOffset g).2.toGrid (0, 0)
+      = shift (0 - (gridToMacroCellWithOffset g).1.1,
+               0 - (gridToMacroCellWithOffset g).1.2)
+          ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
+    toGrid_shift_grid _ 0 0 _ _
+  rw [hshift, ← evolve_shift, hrt, hfix]
+
+/-- **hcap de la classe `T = 1` (natures mortes) — la capture de la
+    reconstruction.** Pour toute nature morte `g` (canonique ou vide), la
+    MacroCell reconstruite satisfait le prédicat de saut : c'est l'hypothèse
+    de capture que la réduction L2 consomme, établie pour la classe entière.
+    Cas non vide : `jumpCapturedF_of_still_life` consomme les trois hypothèses
+    désormais disponibles — wf (`buildFromGrid_wf`), niveau (la borne
+    n-aware : `2 < 2^lvl` dès `g ≠ []`, donc `1 ≤ lvl`) et point fixe
+    (`still_life_fix_toGrid_zero`). Cas vide : la reconstruction est une
+    feuille morte de niveau 0, la grille paddée est vide, et `List.all` sur
+    `[]` est trivialement vrai — décidé par le noyau. -/
+theorem jumpCapturedF_reconstruction_of_still_life (g : Grid) (hg : Canonical g)
+    (hfix : evolve 1 g = g) :
+    jumpCapturedF (gridToMacroCellWithOffset g).2 = true := by
+  by_cases hne : g = []
+  · subst hne
+    decide
+  · apply jumpCapturedF_of_still_life _ ?_ ?_ ?_
+    · unfold gridToMacroCellWithOffset
+      exact buildFromGrid_wf g _ _ _
+    · have hN := gridToMacroCellWithOffsetN_level_gt_n 2 g hne
+      rw [gridToMacroCellWithOffsetN_le_two_eq 2 g (by omega)] at hN
+      cases hL : (gridToMacroCellWithOffset g).2.level with
+      | zero => rw [hL] at hN; exact absurd hN (by decide)
+      | succ m => omega
+    · exact still_life_fix_toGrid_zero g hg hfix
+
+/-- **hcap des natures mortes, trajectoire complète.** Pour toute nature
+    morte `g`, **tout** instant `t` (a fortiori tout `t ≤ 2^k`) : la
+    trajectoire est constante (`evolve t g = g`, période 1 répétée via
+    `evolve_mulF_of_period`), donc la reconstruction le long de la trajectoire
+    est l'objet constant `gridToMacroCellWithOffset g`, dont le saut est
+    capturé. Avec le corollaire d'assemblage ci-dessous, c'est le **premier
+    maillon L3 entièrement prouvé** de la décomposition P4.4 : relever une
+    classe de motifs en l'hypothèse `hcap` de la machine N, sans aucun sorry. -/
+theorem hcap_of_still_life (g : Grid) (hg : Canonical g)
+    (hfix : evolve 1 g = g) (t : Nat) :
+    jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
+  have hself : evolve t g = g := by
+    have hmul := evolve_mulF_of_period g hfix t
+    rwa [Nat.mul_one] at hmul
+  rw [hself]
+  exact jumpCapturedF_reconstruction_of_still_life g hg hfix
+
+/-- **L3 clos pour la classe `T = 1` : correction Hashlife des natures
+    mortes.** Corollaire d'assemblage — le premier cas de la décomposition
+    P4.4 où le maillon L3 (relever une classe de motifs en `hcap`) est
+    **entièrement prouvé** : pour toute MacroCell dont la grille rendue à
+    l'origine est une nature morte, l'égalité globale `hashlife_correctN`
+    s'applique à tout horizon `2^k` sous `centralCorrect`. Il ne reste que
+    L4 (l'égalité restreinte `centralCorrect` elle-même), qui vit dans
+    l'hypothèse — exactement la cloison annoncée par la réduction L2. -/
+theorem hashlife_correct_margin_of_still_life (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k)
+    (hfix : evolve 1 (c.toGrid (0, 0)) = c.toGrid (0, 0)) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correct_margin_of_hcap c k h_central
+    (fun t _ => hcap_of_still_life _ (canonical_sortDedup _) hfix t)
+
 /-! ## Sanity-checks sur le bestiaire
 
 Le fragment `supportInMargin` est **décidable** (instance `Decidable (BoxAssezGrandN)`,
@@ -458,7 +562,11 @@ l'assemblage borné P4/P5 encore ouvert (`p4_nw_overlap_wall`, ai-01 c.94).
 Stratégie pour la suite de #6724 : les murs NE/SW/SE bornés sont FERMÉS et `p5_large_n_jumpN`
 est prouvé (b3') — la réduction L2 ci-dessus est en place, restent les maillons L3 (le pont
 `centralCorrect → hcap`, l'assemblage borné proprement dit) et L4 (égalité restreinte →
-globale), qui déchargeront le `sorry` de `hashlife_correct_margin`.
+globale), qui déchargeront le `sorry` de `hashlife_correct_margin`. **Premier maillon L3
+clos** (tranche 3, étape 4) : la classe `T = 1` des natures mortes est intégralement
+relevée en `hcap` (`hcap_of_still_life` → `hashlife_correct_margin_of_still_life`),
+sans sorry — la généralisation aux autres classes périodiques `T ∣ 2^k` suivra le même
+schéma (round-trip canonique → point fixe transporté → capture).
 -/
 
 end Life

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -410,6 +410,111 @@ theorem hashlife_correct_margin_of_hcap (c : MacroCell) (k : Nat)
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
   hashlife_correctN (2^k) (c.toGrid (0, 0)) hcap
 
+/-! ## L3 class `T = 1` — hcap of still lifes (step 3, slice 4)
+
+First **entirely closed** L3 link: for the class of still lifes
+(`evolve 1 g = g`, a fixpoint of `step`), the L2 reduction's `hcap`
+hypothesis is established end to end — the trajectory is constant, the
+reconstruction is constant, and the jump is captured by
+`jumpCapturedF_of_still_life`. The chain: EQUALITY round-trip of the
+reconstruction for canonical grids (`Canonical.ext`, rigidity of
+sorted-deduplicated lists) → transport of the fixpoint to the origin via
+`toGrid_shift_grid`/`evolve_shift` → capture. -/
+
+/-- **EQUALITY round-trip of the reconstruction (canonical grids).**
+    The general form of `gridToMacroCellWithOffset`'s docstring — so far
+    established only at the membership level
+    (`mem_toGrid_gridToMacroCellWithOffset`, MacroCell L857) — strengthens
+    to a **list equality** as soon as `g` is canonical: both grids are
+    canonical (`toGrid` is a `sortDedup` image, `g` by hypothesis) and have
+    the same members, hence are equal by rigidity (`Canonical.ext`). This
+    is the members→equality bridge that was missing to transport fixpoint
+    equivalences (`Prop` equalities) across the reconstruction. -/
+theorem toGrid_gridToMacroCellWithOffset_eq (g : Grid) (hg : Canonical g) :
+    (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1 = g :=
+  Canonical.ext (canonical_sortDedup _) hg (fun p => mem_toGrid_gridToMacroCellWithOffset g p)
+
+/-- **Transport of the fixpoint to the origin-rendered reconstruction.**
+    If `g` is a canonical still life, then the reconstructed MacroCell
+    rendered at the origin, `(gridToMacroCellWithOffset g).2.toGrid (0, 0)`,
+    is itself a fixpoint of `evolve 1`: the `toGrid_shift_grid` shuttle
+    brings the origin back to a shift of the framed grid, `evolve_shift`
+    commutes the shift with `evolve`, `evolve_congr` transports the
+    evolution to `g`'s frame (same members), and the EQUALITY round-trip
+    closes the loop. This is the exact `hfix` hypothesis that
+    `jumpCapturedF_of_still_life` requires on the reconstruction — now
+    available for the `T = 1` class. -/
+theorem still_life_fix_toGrid_zero (g : Grid) (hg : Canonical g)
+    (hfix : evolve 1 g = g) :
+    evolve 1 ((gridToMacroCellWithOffset g).2.toGrid (0, 0))
+      = (gridToMacroCellWithOffset g).2.toGrid (0, 0) := by
+  have hrt : (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1
+      = g := toGrid_gridToMacroCellWithOffset_eq g hg
+  have hshift : (gridToMacroCellWithOffset g).2.toGrid (0, 0)
+      = shift (0 - (gridToMacroCellWithOffset g).1.1,
+               0 - (gridToMacroCellWithOffset g).1.2)
+          ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
+    toGrid_shift_grid _ 0 0 _ _
+  rw [hshift, ← evolve_shift, hrt, hfix]
+
+/-- **hcap of the `T = 1` class (still lifes) — the reconstruction's
+    capture.** For any still life `g` (canonical or empty), the
+    reconstructed MacroCell satisfies the jump predicate: this is the
+    capture hypothesis that the L2 reduction consumes, established for the
+    whole class. Nonempty case: `jumpCapturedF_of_still_life` consumes the
+    three now-available hypotheses — wf (`buildFromGrid_wf`), level (the
+    n-aware bound: `2 < 2^lvl` as soon as `g ≠ []`, hence `1 ≤ lvl`) and
+    fixpoint (`still_life_fix_toGrid_zero`). Empty case: the
+    reconstruction is a dead level-0 leaf, the padded grid is empty, and
+    `List.all` on `[]` is vacuously true — decided by the kernel. -/
+theorem jumpCapturedF_reconstruction_of_still_life (g : Grid) (hg : Canonical g)
+    (hfix : evolve 1 g = g) :
+    jumpCapturedF (gridToMacroCellWithOffset g).2 = true := by
+  by_cases hne : g = []
+  · subst hne
+    decide
+  · apply jumpCapturedF_of_still_life _ ?_ ?_ ?_
+    · unfold gridToMacroCellWithOffset
+      exact buildFromGrid_wf g _ _ _
+    · have hN := gridToMacroCellWithOffsetN_level_gt_n 2 g hne
+      rw [gridToMacroCellWithOffsetN_le_two_eq 2 g (by omega)] at hN
+      cases hL : (gridToMacroCellWithOffset g).2.level with
+      | zero => rw [hL] at hN; exact absurd hN (by decide)
+      | succ m => omega
+    · exact still_life_fix_toGrid_zero g hg hfix
+
+/-- **hcap of still lifes, full trajectory.** For any still life `g`, at
+    **every** instant `t` (a fortiori every `t ≤ 2^k`): the trajectory is
+    constant (`evolve t g = g`, period 1 repeated via
+    `evolve_mulF_of_period`), so the reconstruction along the trajectory
+    is the constant object `gridToMacroCellWithOffset g`, whose jump is
+    captured. With the assembly corollary below, this is the **first
+    entirely proved L3 link** of the P4.4 decomposition: lifting a whole
+    class of patterns to the N-machine's `hcap` hypothesis, with no sorry. -/
+theorem hcap_of_still_life (g : Grid) (hg : Canonical g)
+    (hfix : evolve 1 g = g) (t : Nat) :
+    jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
+  have hself : evolve t g = g := by
+    have hmul := evolve_mulF_of_period g hfix t
+    rwa [Nat.mul_one] at hmul
+  rw [hself]
+  exact jumpCapturedF_reconstruction_of_still_life g hg hfix
+
+/-- **L3 closed for the `T = 1` class: Hashlife correctness of still
+    lifes.** Assembly corollary — the first case of the P4.4 decomposition
+    where the L3 link (lifting a class of patterns to `hcap`) is **entirely
+    proved**: for any MacroCell whose origin-rendered grid is a still life,
+    the global equality `hashlife_correctN` applies at any horizon `2^k`
+    under `centralCorrect`. Only L4 remains (the restricted equality
+    `centralCorrect` itself), which lives in the hypothesis — exactly the
+    clean seam announced by the L2 reduction. -/
+theorem hashlife_correct_margin_of_still_life (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k)
+    (hfix : evolve 1 (c.toGrid (0, 0)) = c.toGrid (0, 0)) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correct_margin_of_hcap c k h_central
+    (fun t _ => hcap_of_still_life _ (canonical_sortDedup _) hfix t)
+
 /-! ## Sanity checks on the bestiary
 
 The fragment `supportInMargin` is **decidable** (instance `Decidable (BoxAssezGrandN)`,
@@ -459,6 +564,11 @@ Strategy for the rest of #6724: the bounded NE/SW/SE walls are CLOSED and
 `p5_large_n_jumpN` is proved (b3') — the L2 reduction above is in place, leaving the L3
 link (the `centralCorrect → hcap` bridge, the bounded assembly proper) and L4 (restricted
 → global equality), which will discharge the `sorry` of `hashlife_correct_margin`.
+**First closed L3 link** (step 3, slice 4): the `T = 1` class of still lifes is
+entirely lifted to `hcap` (`hcap_of_still_life` →
+`hashlife_correct_margin_of_still_life`), with no sorry — generalizing to the
+other periodic classes `T ∣ 2^k` will follow the same pattern (canonical
+round-trip → transported fixpoint → capture).
 -/
 
 end Life_en


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/lean #14743

## Summary

#13483 tranche 3, interface (c), **étape 4 : le maillon L3 est CLOS pour la classe `T = 1` (natures mortes) — `hcap` des still lifes établi de bout en bout, sans aucun `sorry`.**

La décomposition P4.4 (§ du module, L170) laissait deux maillons ouverts : L3 (relever `centralCorrect c k` en `hcap`, la capture de la trajectoire entière) et L4 (égalité restreinte → globale). Cette PR clôt **L3 pour la première classe entière** : les natures mortes (`evolve 1 g = g`, point fixe de `step`). Le chaînage rendu possible par le round-trip **ÉGALITÉ** de la reconstruction, qu'on ne connaissait qu'au niveau des membres.

- **`toGrid_gridToMacroCellWithOffset_eq`** — le round-trip `Grid → MacroCell → Grid` se renforce en **égalité de listes** dès que `g` est canonique : les deux grilles sont canoniques (`toGrid` est une image `sortDedup`, rigide par `Canonical.ext`) et ont les mêmes membres (`mem_toGrid_gridToMacroCellWithOffset`). C'est le pont members→égalité qui manquait pour transporter des `Prop` d'égalité à travers la reconstruction.
- **`still_life_fix_toGrid_zero`** — le point fixe est transporté à la reconstruction rendue à l'origine : navette `toGrid_shift_grid` + `evolve_shift` (sens inverse) + `evolve_congr` + round-trip ÉGALITÉ ⟹ `evolve 1 (mc.toGrid (0,0)) = mc.toGrid (0,0)`.
- **`jumpCapturedF_reconstruction_of_still_life`** — `jumpCapturedF` de la reconstruction : cas non vide via `jumpCapturedF_of_still_life` (wf `buildFromGrid_wf`, niveau via la borne n-aware `2 < 2^lvl`, point fixe transporté) ; cas vide par décision noyau (grille paddée vide → `List.all []` vacuous).
- **`hcap_of_still_life`** — la trajectoire entière est constante (`evolve t g = g`, période 1 via `evolve_mulF_of_period`) ⟹ `∀ t ≤ 2^k`, la reconstruction est l'objet constant et capturé.
- **`hashlife_correct_margin_of_still_life`** — corollaire d'assemblage : pour toute MacroCell de grille still-life, l'égalité globale `hashlife_correctN` s'applique à tout horizon `2^k` sous `centralCorrect`. Premier cas où L3 est entièrement prouvé ; ne reste que L4 (l'égalité restreinte, qui vit dans l'hypothèse `centralCorrect`).

La généralisation aux classes périodiques `T ∣ 2^k` (déjà capturées au « saut » par `jumpCapturedF_of_period_divides`, #14743) suivra le même schéma : équivalence de trajectoire → reconstruction constante → capture.

## Validation

- **double `lake build` SUCCESS** (`PIPESTATUS=0`) sur `Conway.Life.HashlifeMarginFragment` ET `HashlifeMarginFragment_en` — chaque `lake build` relancé rend `EXIT=0` (recompile les 2 modules à partir des oleans, zéro erreur Lean).
- **sorry count inchangé** : `distinct_code_sorry` = 1 (résiduel = `hashlife_correct_margin`, la cible connue de #6724) — avant comme après, aucun `sorry` ajouté.
- **i18n 33/33 pairs byte-identical** (`scripts/lean/check_i18n_siblings.py --all`), sibling `_en` porté (docstrings EN, preuves byte-identiques).
- **Périmètre** : 2 fichiers, 219 insertions / 1 suppression (paire FR + `_en`). Aucun notebook, catalogue, script, dataset touché.

See #13483 · See #6724
