### PR TITLE
fix(guard,#14513): le ratchet MACHINE_PATH voit aussi les metadonnees

### DIFF
--- a/scripts/notebook_tools/check_output_failure_text.py
+++ b/scripts/notebook_tools/check_output_failure_text.py
@@ -34,6 +34,15 @@ occurrences whose count GREW are reported. A notebook that already carried
 such text keeps it: this is a ratchet, not a repo-wide scold. Pre-existing
 debt is surfaced by ``--all`` (advisory sweep), never by the gate.
 
+MACHINE_PATH is also matched on document and cell METADATA string values
+(``metadata.path``, or any metadata key whose value is a string), not only on
+cell outputs (#14513): a re-execution can leak an absolute path into
+``metadata.path`` without touching a single output, which the output-only gate
+read as ``0 regressed`` while the branch carried the path. The extension is
+kept to MACHINE_PATH -- metadata never carries a tool-failure banner, and the
+convention permits normalizing a metadata key by hand (secrets-hygiene rule 6)
+only because the gate has to be able to SEE it first.
+
 The sweep also ventilates a third class, ``DEGRADED_HINT`` (#11692): the two
 soft "non disponible / not available" motifs, which on an absolute sweep are
 the large majority of hits and are mostly DELIBERATE fallback banners. They
@@ -406,8 +415,44 @@ def output_texts(nb):
                 yield i, "\n".join(str(x) for x in tb)
 
 
+def metadata_texts(nb):
+    """Yield (location_label, text) for every string-valued metadata key.
+
+    Document-level and cell-level surfaces the output-only scan cannot see.
+    A key is scanned because its VALUE is a string -- no name whitelist -- so
+    the next metadata key a re-execution leaks is caught the first time it is
+    introduced, not after somebody names it.
+
+    ``metadata.papermill.input_path`` / ``output_path`` are repo-relative or
+    basename (a pre-commit hook + secrets-hygiene rule 6) and so never match
+    the machine-path patterns (verified on the 1234 notebooks, issue #14513
+    precaution 1).
+
+    location_label: ``doc:<key>`` for document metadata, ``cell[<i>]:<key>``
+    for cell metadata.
+    """
+    md = nb.get("metadata", {}) or {}
+    if isinstance(md, dict):
+        for k, v in md.items():
+            if isinstance(v, str) and v:
+                yield "doc:" + str(k), v
+    for i, cell in enumerate(nb.get("cells", []) or []):
+        cmd = cell.get("metadata", {}) or {}
+        if isinstance(cmd, dict):
+            for k, v in cmd.items():
+                if isinstance(v, str) and v:
+                    yield "cell[%d]:%s" % (i, str(k)), v
+
+
 def scan(nb):
-    """{class: [(cell_index, matched_text), ...]} for one notebook."""
+    """{class: [(location, matched_text), ...]} for one notebook.
+
+    ``location`` is a cell index for output hits, or a metadata descriptor
+    (``doc:<key>`` / ``cell[<i>]:<key>``) for metadata hits. Only
+    MACHINE_PATH is extended to metadata (issue #14513): metadata does not
+    carry tool-failure banners, and the machine-path metadata class is what a
+    re-execution leaks.
+    """
     found = {"TOOL_FAILURE": [], "MACHINE_PATH": []}
     if not nb:
         return found
@@ -425,6 +470,15 @@ def scan(nb):
         for pat in MACHINE_PATH_PATTERNS:
             for m in pat.finditer(text):
                 found["MACHINE_PATH"].append((idx, m.group(0)[:120]))
+    # #14513: a machine path can also sit in document/cell metadata, invisible
+    # to the output-only loop above -- the exact hole that let PT_11c's
+    # metadata.path pass the gate green while the branch still carried the
+    # path (#14272 / #13891). Scan string-valued metadata too, so the gate
+    # sees the surface the convention (secrets-hygiene rule 6) allows fixing.
+    for loc, text in metadata_texts(nb):
+        for pat in MACHINE_PATH_PATTERNS:
+            for m in pat.finditer(text):
+                found["MACHINE_PATH"].append((loc, m.group(0)[:120]))
     return found
 
 
@@ -606,6 +660,38 @@ def self_test(cwd=None):
         if n_path < SELF_TEST_MIN_PATH:
             failures.append("replay MACHINE_PATH +" + str(n_path) + " < "
                             + str(SELF_TEST_MIN_PATH) + " expected")
+
+    # #14513 replay: the metadata-only leak of #14272 / #13891, the defect
+    # this extension exists to close. c4b99a3ec4 is the PT_11c head whose
+    # metadata.path still carried the machine path (one document-level
+    # MACHINE_PATH hit); 109cf4eb2 removed it (zero). The original output-only
+    # scan reported 0 regressed on BOTH -- it cannot see metadata -- so a
+    # predicate that fires on the base and stays silent on the head is the
+    # proof of the fix, not a synthetic witness. Both commits are branch-side
+    # history of a squash-merged PR and are absent from a fresh clone
+    # (fetch-depth 0), so guard with cat-file exactly like the founding replay.
+    c4b99a3ec4 = "c4b99a3ec49cda31057630ffb67802c026e75cbf"
+    c109cf4eb = "109cf4eb219a7b5d0f566aaa47fda9540bba9926"
+    if (git("cat-file", "-e", c4b99a3ec4, cwd=cwd) is None
+            or git("cat-file", "-e", c109cf4eb, cwd=cwd) is None):
+        print("SKIP #14513 replay: c4b99a3ec4/c109cf4eb not in this clone")
+    else:
+        nb_path = ("MyIA.AI.Notebooks/GenAI/PostTraining/"
+                   "PT_11c_grpo_qwen17_rlvr.ipynb")
+        base_nb = read_notebook_at(c4b99a3ec4, nb_path, cwd=cwd)
+        head_nb = read_notebook_at(c109cf4eb, nb_path, cwd=cwd)
+        b_meta = [loc for loc, _ in scan(base_nb)["MACHINE_PATH"]
+                  if isinstance(loc, str)]
+        h_meta = [loc for loc, _ in scan(head_nb)["MACHINE_PATH"]
+                  if isinstance(loc, str)]
+        print("replay #14513: metadata-path hits "
+              + str(len(b_meta)) + " -> " + str(len(h_meta)))
+        if "doc:path" not in b_meta:
+            failures.append("#14513 replay: metadata.path not seen in base ("
+                            + repr(b_meta) + ")")
+        if h_meta:
+            failures.append("#14513 replay: metadata machine path still in "
+                            "head (" + repr(h_meta) + ")")
 
     # Second replay (#14603): the GPU -> CPU re-exec of #14262, pinned as a
     # fixture (see DOWNGRADE_REPLAY_FIXTURE). The two gating classes read

--- a/scripts/notebook_tools/check_output_failure_text.py
+++ b/scripts/notebook_tools/check_output_failure_text.py
@@ -491,6 +491,20 @@ def _is_degraded_hint(match_text):
     return any(p.search(match_text) for p in DEGRADED_HINT_PATTERNS)
 
 
+def _sample_location(loc):
+    """Rend la localisation d'un echantillon telle qu'elle a ete produite.
+
+    Un hit d'output porte un index de cellule entier -> ``cell[7]``. Un hit de
+    metadata porte deja son propre label (``doc:<cle>`` ou ``cell[<i>]:<cle>``,
+    cf. ``metadata_texts()``) -> l'imprimer verbatim. Sans ce tri, un hit
+    metadata de document sortait ``cell[doc:path]`` et un hit metadata de
+    cellule ``cell[cell[3]:papermill]`` : lisible, mais mal etiquete.
+    """
+    if isinstance(loc, str):
+        return loc
+    return "cell[" + str(loc) + "]"
+
+
 def compare(base_ref, head_ref, paths, cwd=None):
     """Per-notebook growth of each class between base_ref and head_ref."""
     rows = []
@@ -831,7 +845,8 @@ def main(argv=None):
                     print("  " + cls + ": " + str(e["base"]) + " -> "
                           + str(e["head"]) + " (+" + str(e["delta"]) + ")")
                     for s in e.get("samples", []):
-                        print("     cell[" + str(s["cell"]) + "] " + s["match"])
+                        print("     " + _sample_location(s["cell"]) + " "
+                              + s["match"])
         if bad:
             print("\nCause is on the executing machine, not in the notebook: "
                   "install the missing tool and RE-EXECUTE. Never hand-edit a "

--- a/scripts/notebook_tools/tests/test_check_output_failure_text.py
+++ b/scripts/notebook_tools/tests/test_check_output_failure_text.py
@@ -12,6 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_output_failure_text import (CAPABILITY_VALUE_RE,
+                                       _sample_location,
                                        CAPABILITY_WITNESS_PATTERNS,
                                        capability_downgrades,
                                        metadata_texts,
@@ -200,3 +201,27 @@ def test_output_paths_still_scanned_alongside_metadata():
     assert "doc:path" in locs
     assert "cell[0]:path" in locs
     assert 0 in locs  # output hit keeps its cell index
+
+
+def test_sample_location_renders_each_shape_once():
+    # Les trois formes que scan() produit cote a cote (cf. le test ci-dessus)
+    # doivent s'imprimer telles quelles. Sans le tri, l'imprimeur FAIL
+    # enveloppait tout dans cell[...] : un hit metadata de document sortait
+    # "cell[doc:path]" et un hit metadata de cellule "cell[cell[0]:path]".
+    assert _sample_location(0) == "cell[0]"        # hit d'output : index entier
+    assert _sample_location("doc:path") == "doc:path"
+    assert _sample_location("cell[0]:path") == "cell[0]:path"
+
+
+def test_sample_location_no_double_wrapping_on_real_scan_output():
+    # Controle positif sur les localisations REELLES de scan(), pas sur des
+    # litteraux : aucune sortie ne doit contenir "cell[cell[" ni "cell[doc:".
+    cell_ = {"cell_type": "code", "source": "print(1)",
+             "metadata": {"path": DUP_PATH},
+             "outputs": [{"output_type": "stream", "text": DUP_PATH}]}
+    nb_ = {"cells": [cell_], "metadata": {"path": DUP_PATH}}
+    rendered = [_sample_location(loc) for loc, _ in scan(nb_)["MACHINE_PATH"]]
+    assert rendered, "le controle positif doit produire des hits"
+    for r in rendered:
+        assert "cell[cell[" not in r
+        assert "cell[doc:" not in r

--- a/scripts/notebook_tools/tests/test_check_output_failure_text.py
+++ b/scripts/notebook_tools/tests/test_check_output_failure_text.py
@@ -13,7 +13,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_output_failure_text import (CAPABILITY_VALUE_RE,
                                        CAPABILITY_WITNESS_PATTERNS,
-                                       capability_downgrades)
+                                       capability_downgrades,
+                                       metadata_texts,
+                                       scan)
 
 
 def cell(source, out_text):
@@ -120,3 +122,81 @@ def test_founding_fixture_fires():
     assert len(got) == 2
     assert all(g["base"] == "cuda" and g["head"] == "cpu"
                and g["witness_lost"] >= 1 for g in got)
+
+
+# --- #14513: MACHINE_PATH extended to document/cell metadata ---------------
+# The output-only predicate was blind to metadata; a machine path in
+# metadata.path passed the gate green (#14272 / #13891). The REAL leaked
+# value is the positive control.
+
+DUP_PATH = ("C:\\dev\\CoursIA-cycle-32\\MyIA.AI.Notebooks\\"
+            "GenAI\\PostTraining")
+
+
+def test_metadata_texts_yields_string_values():
+    cells = {"cells": [
+        {"cell_type": "code", "metadata": {"path": DUP_PATH}, "outputs": []},
+        {"cell_type": "markdown", "metadata": {"tags": ["x"]}, "outputs": []}],
+        "metadata": {"path": DUP_PATH, "kernelspec": {"name": "python3"}}}
+    locs = list(metadata_texts(cells))
+    assert ("doc:path", DUP_PATH) in locs
+    assert ("cell[0]:path", DUP_PATH) in locs
+    # dicts are not scanned; tags is a list.
+    assert not any(l.startswith("doc:kernelspec") for l, _ in locs)
+
+
+def test_metadata_path_machine_fires():
+    nb_ = {"cells": [], "metadata": {"path": DUP_PATH}}
+    hits = [loc for loc, _ in scan(nb_)["MACHINE_PATH"]]
+    assert "doc:path" in hits
+
+
+def test_cell_metadata_machine_fires():
+    cell = {"cell_type": "code", "source": "print(1)",
+            "metadata": {"path": DUP_PATH}, "outputs": []}
+    hits = [loc for loc, _ in scan({"cells": [cell], "metadata": {}})
+            ["MACHINE_PATH"]]
+    assert "cell[0]:path" in hits
+
+
+def test_metadata_path_clean_silent():
+    # No metadata, and a repo-relative value (the shape the pre-commit hook
+    # and convention leave in place) must stay silent.
+    assert scan({"cells": [], "metadata": {}})["MACHINE_PATH"] == []
+    rel = {"cells": [], "metadata": {"path": (
+        "MyIA.AI.Notebooks/GenAI/PostTraining/"
+        "PT_11c_grpo_qwen17_rlvr.ipynb")}}
+    assert scan(rel)["MACHINE_PATH"] == []
+
+
+def test_metadata_papermill_paths_silent():
+    # Precaution 1 of #14513: input_path/output_path normalized to a
+    # repo-relative path or basename must never fire retroactively.
+    pm = {"input_path": ("MyIA.AI.Notebooks/GenAI/PostTraining/"
+                         "PT_11c_grpo_qwen17_rlvr.ipynb"),
+          "output_path": "PT_11c_grpo_qwen17_rlvr.ipynb"}
+    assert scan({"cells": [], "metadata": {"papermill": pm}})["MACHINE_PATH"] == []
+
+
+def test_metadata_non_string_silent():
+    # Document metadata is scanned for STRING values only -- dicts (kernelspec,
+    # language_info) and ints are not machine paths by construction.
+    nb_ = {"cells": [], "metadata": {
+        "kernelspec": {"name": "python3", "display_name": "Python 3"},
+        "language_info": {"name": "python"},
+        "toc": 3}}
+    assert scan(nb_)["MACHINE_PATH"] == []
+
+
+def test_output_paths_still_scanned_alongside_metadata():
+    # The extension must not regress the original output surface: an output
+    # path AND a metadata path both fire, with distinct locations.
+    cell = {"cell_type": "code", "source": "print(1)",
+            "metadata": {"path": DUP_PATH},
+            "outputs": [{"output_type": "stream", "text": DUP_PATH}]}
+    nb_ = {"cells": [cell], "metadata": {"path": DUP_PATH}}
+    hits = scan(nb_)["MACHINE_PATH"]
+    locs = [loc for loc, _ in hits]
+    assert "doc:path" in locs
+    assert "cell[0]:path" in locs
+    assert 0 in locs  # output hit keeps its cell index


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA -- prev: MED/refactor #14695
<!-- orpheline adoptee par ai-01 : aucune lane ne l'avait revendiquee (issue #14513 sans [CLAIMED]) -->

Closes #14513

## Defaut

Le garde derriere le check bloquant **`Output-failure ratchet (base vs PR)`** (`scripts/notebook_tools/check_output_failure_text.py`) ne scannait que les **sorties de cellules** (`cell["outputs"]`). Un chemin machine logeant dans `metadata.path` (ou toute cle de metadata, niveau document/cellule, dont la valeur est une chaine) lui etait invisible → le garde rendait `success` (vert) en le laissant passer.

Manifestation (#14272 / #13891) : le ratchet est passe a `0 regressed` sur `PT_11c_grpo_qwen17_rlvr.ipynb` **avec** `metadata.path = C:\dev\CoursIA-cycle-32\MyIA.AI.Notebooks\GenAI\PostTraining` encore present (retire a la main en `109cf4eb2` avant merge).

## Changement

- **`metadata_texts()`** : releve toute valeur de metadata `str` (document + cellule), sans liste blanche de noms de cles — la prochaine cle qu'une re-execution leake est vue des sa premiere apparition.
- **`scan()`** : applique `MACHINE_PATH_PATTERNS` a ces surfaces. **MACHINE_PATH seulement** — une metadata ne porte pas de banniere de tool-failure, et la convention permet de normaliser une cle metadata a la main uniquement parce que le garde doit d'abord pouvoir la VOIR.
- Location des hits : `doc:<cle>` / `cell[<i>]:<cle>` a cote de l'index de cellule des hits de sortie. `samples`/gate inchanges par ailleurs.

## Acceptance (les 2 precautions de l'issue)

| Item | Resultat |
|---|---|
| Predicat etendu a `metadata.path` et aux cles de metadata document/cellule (value str, pas de whitelist) | Fait — `metadata_texts()` + boucle MACHINE_PATH dans `scan()` |
| **Precaution 1** : 0 nouvelle accusation sur `main` avant de rendre bloquant | **Verifie** — sweep des 1234 notebooks : 0 notebook porte un hit MACHINE_PATH metadata (`papermill.input/output_path` sont repo-relative/basename → silencieux par construction) |
| **Precaution 2** : controle positif reel | Replay `c4b99a3ec4` → `109cf4eb2` dans `--self-test` : `metadata-path hits 1 -> 0` — `doc:path` vu a la base, absent au head. Garde par `cat-file` comme le replay fondateur (blobs hors branche squash-merged, absents d'un clone `fetch-depth 0`) |

## Validation

- `python scripts/notebook_tools/check_output_failure_text.py --self-test` → **SELF-TEST OK** (replay fondateur `9881553...` TOOL_FAILURE +18 / MACHINE_PATH +12 inchanges, replay downgrade #14603 2 cells, replay #14513 `1 -> 0`).
- `python -m pytest scripts/notebook_tools/tests/test_check_output_failure_text.py -q` → **17 passed** (10 existants + 7 nouveaux sur le predicat etendu).

## Fichiers

- `scripts/notebook_tools/check_output_failure_text.py` (+88/−2) — docstring, `metadata_texts()`, `scan()`, replay self-test
- `scripts/notebook_tools/tests/test_check_output_failure_text.py` (+82) — 7 tests

## Note de scope

Le retrait manuel d'une cle de `metadata` reste conforme a `secrets-hygiene` regle 6 (classe explicitement toleree, au meme titre que `metadata.papermill.*`) — cette PR ne le remet pas en cause ; elle fait que le garde **voit** ce que la convention autorise a corriger.

Refs #13891, #14272.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
