### PR TITLE
test(prune,#14693): hermetic E2E positive control -- dry-run/apply verdict parity

### DIFF
--- a/scripts/tests/test_prune_merged_worktrees.py
+++ b/scripts/tests/test_prune_merged_worktrees.py
@@ -984,3 +984,158 @@ class TestEndToEnd:
         assert proc.returncode != 2, f"stderr: {proc.stderr}"
         # Au moins 1 ligne REFUSE dans la sortie (le run reel)
         assert "REFUSE" in proc.stdout or "applied=0" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Controle positif hermetique E2E (#14693 point 4)
+# ---------------------------------------------------------------------------
+
+
+def _git_ok(cwd: str, *args: str) -> subprocess.CompletedProcess:
+    """git strict dans un depot temoin : toute erreur echoue le test.
+
+    L'identite de commit est forcee par -c (les runners CI n'ont pas de
+    user.email global), et le dossier est temporaire donc isole.
+    """
+    proc = subprocess.run(
+        ["git", "-C", cwd, "-c", "user.email=e2e@test", "-c",
+         "user.name=e2e", "-c", "protocol.file.allow=always", *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert proc.returncode == 0, (
+        f"git {' '.join(args)} failed in {cwd}: {proc.stderr.strip()}"
+    )
+    return proc
+
+
+def _make_repo_with_feature_worktree(
+    base: Path, with_submodule: bool = False,
+) -> tuple[Path, Path]:
+    """Depot temoin + worktree lie sur branche feature.
+
+    Retourne (super, wt). Si with_submodule, un vrai sous-module est
+    configure sur main AVANT la creation du worktree (pour que la branche
+    feature le porte) et initialise DANS le worktree -- le fixture exact
+    de #14693 point 4.
+
+    Pas d'upstream sur la branche feature : le predicat unpushed reste a
+    0 et le verdict est porte par l'ancre PR (monkeypatchee MERGED).
+    """
+    super = base / "super"
+    super.mkdir()
+    _git_ok(str(super), "init", "-b", "main")
+    (super / "README.md").write_text("tmp", encoding="utf-8")
+    _git_ok(str(super), "add", "README.md")
+    _git_ok(str(super), "commit", "-m", "init")
+
+    if with_submodule:
+        sub = base / "sublib"
+        sub.mkdir()
+        _git_ok(str(sub), "init", "-b", "main")
+        (sub / "lib.txt").write_text("s", encoding="utf-8")
+        _git_ok(str(sub), "add", "lib.txt")
+        _git_ok(str(sub), "commit", "-m", "sub init")
+        _git_ok(str(super), "submodule", "add",
+                str(sub).replace("\\", "/"), "vendor")
+        _git_ok(str(super), "commit", "-m", "add submodule")
+
+    wt = base / "wt-feature"
+    _git_ok(str(super), "worktree", "add", str(wt), "-b", "feature/e2e")
+    if with_submodule:
+        # Materialise vendor/ dans le worktree : `git submodule status`
+        # y rend une entree sans prefixe '-' (initialise).
+        _git_ok(str(wt), "submodule", "update", "--init")
+    (wt / "feature.txt").write_text("f", encoding="utf-8")
+    _git_ok(str(wt), "add", "feature.txt")
+    _git_ok(str(wt), "commit", "-m", "feature work")
+    return super, wt
+
+
+class TestEndToEndHermetic14693:
+    """#14693 point 4 : le controle positif qui manquait a #14476.
+
+    Les tests unitaires ci-dessus monkeypatchent les sorties git : ils
+    pincent la LOGIQUE de decision, pas le contrat avec le git reel. Ici
+    on construit un vrai depot, un vrai worktree lie, de vrais fichiers
+    untracked et un vrai sous-module initialise ; seule l'ancre PR
+    (reseau gh) est remplacee par un objet MERGED. Ce controle verifie
+    la propriete demande par #14693 point 1 : ce qui est annonce REMOVE
+    quitte VRAIMENT le disque, et ce que git ne retirera jamais est
+    REFUSE avec sa cause AVANT l'annonce -- dry-run et apply rendent le
+    meme verdict.
+    """
+
+    MERGED_PR = {
+        "number": 424242,
+        "state": "MERGED",
+        "url": "https://example/pr/424242",
+        "headRefName": "feature/e2e",
+    }
+
+    def _merged_anchor(self, monkeypatch):
+        monkeypatch.setattr(
+            pmw, "lookup_pr_for_branch",
+            lambda branch: dict(self.MERGED_PR, headRefName=branch),
+        )
+
+    def test_tolerated_artifacts_only_is_removed(self, tmp_path, monkeypatch):
+        """Classe 1 : residu exclusivement tolere -> REMOVE annonce,
+        nettoyage des toleres, retrait sans force QUI REUSSIT."""
+        super, wt = _make_repo_with_feature_worktree(tmp_path)
+        # Artefacts tolere a la RACINE (porcelain affiche le dossier
+        # collapse `?? bg_logs/` ; un parent tracked casserait le token).
+        (wt / "bg_logs").mkdir()
+        (wt / "bg_logs" / "run.jsonl").write_text("{}", encoding="utf-8")
+        (wt / "__pycache__").mkdir()
+        (wt / "__pycache__" / "x.pyc").write_bytes(b"pyc")
+        self._merged_anchor(monkeypatch)
+        monkeypatch.chdir(super)
+
+        s = pmw.diagnose_worktree(str(wt), str(super))
+        assert s.decision == "REMOVE", (
+            f"tolerated-only doit etre REMOVE, got {s.refusal_reason}"
+        )
+        # Sequence exacte du apply de main() : clean des toleres puis
+        # remove sans force.
+        cleaned = pmw.clean_tolerated_artifacts(s)
+        assert len(cleaned) == 2, f"2 artefacts toleres attendus: {cleaned}"
+        ok, stderr = pmw.apply_removal(s)
+        assert ok, f"REMOVE annonce mais retrait echoue: {stderr}"
+        assert not wt.exists(), "le worktree doit avoir quitte le disque"
+
+    def test_untolerated_residue_refuses_and_survives(self, tmp_path, monkeypatch):
+        """Complement fail-closed : un residu hors liste toleree ->
+        REFUSE nomme, le worktree reste sur disque."""
+        super, wt = _make_repo_with_feature_worktree(tmp_path)
+        (wt / "blob.bin").write_bytes(b"\x00\x01")
+        self._merged_anchor(monkeypatch)
+        monkeypatch.chdir(super)
+
+        s = pmw.diagnose_worktree(str(wt), str(super))
+        assert s.decision == "REFUSE"
+        assert s.refusal_reason == "untolerated_untracked:1", s.refusal_reason
+        assert wt.exists(), "un worktree REFUSE ne doit jamais bouger"
+
+    def test_initialised_submodule_with_pycache_refuses(self, tmp_path, monkeypatch):
+        """Classe 2 (fixture exacte de #14693 point 4) : un worktree
+        portant un __pycache__/ untracked ET un sous-module initialise ->
+        REFUSE contains_submodules (git ne le retirera jamais), et la
+        tentative reelle echoue structurellement."""
+        super, wt = _make_repo_with_feature_worktree(
+            tmp_path, with_submodule=True)
+        (wt / "__pycache__").mkdir()
+        (wt / "__pycache__" / "x.pyc").write_bytes(b"pyc")
+        self._merged_anchor(monkeypatch)
+        monkeypatch.chdir(super)
+
+        s = pmw.diagnose_worktree(str(wt), str(super))
+        assert s.decision == "REFUSE", (
+            f"sous-module initialise doit REFUSER, got {s.refusal_reason}"
+        )
+        assert s.refusal_reason == "contains_submodules"
+        # Meme en forcant la tentative : git refuse structurellement --
+        # c'est la demonstration live que REMOVE ici aurait ete un mensonge.
+        ok, stderr = pmw.apply_removal(s)
+        assert not ok, "git ne peut PAS retirer un worktree a sous-modules"
+        assert "submodule" in stderr.lower(), stderr
+        assert wt.exists(), "le worktree REFUSE reste sur disque"


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14742

## Summary

Verification firsthand : les classes 1-2 de #14693 sont **deja reprises sur main** par #14672 (issue #14619, merge 01:03Z) + #14585 (issue #14509) -- la mesure de #14693 (creee 01:14Z, 11 min apres le merge de #14672) date d'un checkout stale : les numeros de ligne cites (l.128-142, l.67-68) ne correspondent pas au fichier actuel, et les 3 worktrees cites sont exactement ceux du constat pre-fix de #14619.

Le residuel reel etait le **point 4 (controle positif)** : cette PR le livre. Le script lui-meme n'est PAS modifie (tests uniquement, aucune regression possible).

## Controle positif hermetique (point 4)

3 nouveaux tests `TestEndToEndHermetic14693` -- **vrai depot git, vrai worktree lie, vrais fichiers untracked, vrai sous-module initialise** ; seule l'ancre PR (reseau gh) est remplacee par un objet MERGED :

1. `test_tolerated_artifacts_only_is_removed` -- classe 1 : `bg_logs/` + `__pycache__/` untracked -> REMOVE annonce -> toleres nettoyes -> retrait sans force QUI REUSSIT -> worktree parti du disque
2. `test_untolerated_residue_refuses_and_survives` -- complement fail-closed : `blob.bin` hors liste -> REFUSE `untolerated_untracked:1`, worktree intact
3. `test_initialised_submodule_with_pycache_refuses` -- classe 2, fixture exacte du point 4 (`__pycache__/` ET sous-module initialise) -> REFUSE `contains_submodules` AVANT l'annonce + demonstration live que `git worktree remove` echoue structurellement

Pieges du fixture, corriges dans le test : `transport 'file' not allowed` (CVE-2022-39253 -> `-c protocol.file.allow=always`), collapse porcelain des dossiers untracked (artefats poses a la racine pour que le token matche), ordre de creation (sous-module committe sur main AVANT `worktree add` pour que la branche feature le porte).

## Preuves (acceptance 4/4 de #14693)

| # | Exigence | Preuve |
|---|---|---|
| 1 | dry-run == apply | **Live sur cette machine (40 worktrees reels)** : dry-run `removable=2 failed=0` ; `--apply` : `applied=2 errors=0` (REMOVED clean9535 #14731 + csp8 #14626) |
| 2 | toleres-seuls -> retrait aboutit | test hermetique 1 + run live #14672 (`removable=15 applied=15 errors=0`, c.14619) |
| 3 | sous-modules detectes en dry-run | **Live** : `CoursIA-c162-z3dt -> REFUSE reason=contains_submodules` (l'ancien script annoncait REMOVE puis FAILED) + test hermetique 3 |
| 4 | controle positif | les 3 tests hermetiques, suite completee : `70 passed, 1 skipped` (le skip = test destructif `--apply`, par design) |

Sortie pytest (fin) :
```
........................................s...                             [100%]
================== 70 passed, 1 skipped in 165.66s ==================
```

## Portee

1 fichier (`scripts/tests/test_prune_merged_worktrees.py`, +155 lignes), tests uniquement.

Closes #14693