### PR TITLE
Add: L3 geometry leg -- box bounds + reconstruction level bound (13483 t3c step 5)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -513,6 +513,146 @@ theorem hashlife_correct_margin_of_still_life (c : MacroCell) (k : Nat)
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
   hashlife_correct_margin_of_hcap c k h_central
     (fun t _ => hcap_of_still_life _ (canonical_sortDedup _) hfix t)
+/-! ## L3 géométrie — bornes de la boîte et niveau de la reconstruction (tranche 3, étape 5)
+
+Le scoping 3-(c) (c.5551298160) identifie la jambe « géométrie » de L3 : au niveau
+adaptatif, la fenêtre `[2^lvl, 3·2^lvl)` doit absorber la boîte du corridor. Deux
+briques se posent : (i) les **bornes de la boîte englobante** d'une grille dont le
+support est contraint — `gridRowMin` est minorée, `gridRowMax` est majorée (et
+colonnes) ; (ii) la **borne de niveau** de la reconstruction
+`gridToMacroCellWithOffset g` en fonction de la boîte. Ce sont les prémisses
+géométriques pour la capture au niveau adaptatif. -/
+
+/-- **Aide : un `foldl` de `max` (via `proj`) reste strictement sous `b`** si le
+    seed et chaque élément le sont. Induction directe sur la liste (invariant du
+    `max`). -/
+theorem foldl_proj_max_lt_of_mem_lt (ps : Grid) (proj : Int × Int → Int)
+    (acc : Int) (b : Int) (hb : acc < b)
+    (h₀ : ∀ q, q ∈ ps → proj q < b) :
+    ps.foldl (fun m q => max m (proj q)) acc < b := by
+  induction ps generalizing acc with
+  | nil => simpa using hb
+  | cons q qs ih =>
+    have hq : proj q < b := h₀ q (by simp)
+    have hb' : max acc (proj q) < b := max_lt_iff.mpr ⟨hb, hq⟩
+    exact ih _ hb' (fun r hr => h₀ r (List.mem_cons_of_mem q hr))
+
+/-- **Borne inférieure de `gridRowMin` par une boîte.** Si toute cellule de `g`
+    vérifie `a ≤ p.1`, alors `a ≤ gridRowMin g` : le minimum des lignes est une des
+    lignes de `g` (`foldl_proj_min_attained`), donc il hérite de la borne. La
+    grille doit être non vide : sur la grille vide, `gridRowMin` vaut `0` par
+    défaut et la borne serait fausse. -/
+theorem gridRowMin_lower_bound (g : Grid) (a : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → a ≤ p.1) :
+    a ≤ gridRowMin g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridRowMin]
+    rcases foldl_proj_min_attained ps (·.1) p₀.1 with hcase | ⟨p, hp, hval⟩
+    · rw [hcase]
+      exact h₀ p₀ (by simp)
+    · rw [hval]
+      exact h₀ p (List.mem_cons_of_mem p₀ hp)
+
+/-- **Borne supérieure de `gridRowMax` par une boîte.** Si toute cellule de `g`
+    vérifie `p.1 < b`, alors `gridRowMax g < b` : le maximum des lignes hérite de
+    la borne (invariant du `foldl` de `max`). -/
+theorem gridRowMax_upper_bound (g : Grid) (b : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → p.1 < b) :
+    gridRowMax g < b := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridRowMax]
+    exact foldl_proj_max_lt_of_mem_lt ps (·.1) p₀.1 b (h₀ p₀ (by simp))
+      (fun q hq => h₀ q (List.mem_cons_of_mem p₀ hq))
+
+/-- **Borne inférieure de `gridColMin` par une boîte** (miroir colonne de
+    `gridRowMin_lower_bound`). -/
+theorem gridColMin_lower_bound (g : Grid) (a : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → a ≤ p.2) :
+    a ≤ gridColMin g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMin]
+    rcases foldl_proj_min_attained ps (·.2) p₀.2 with hcase | ⟨p, hp, hval⟩
+    · rw [hcase]
+      exact h₀ p₀ (by simp)
+    · rw [hval]
+      exact h₀ p (List.mem_cons_of_mem p₀ hp)
+
+/-- **Borne supérieure de `gridColMax` par une boîte** (miroir colonne de
+    `gridRowMax_upper_bound`). -/
+theorem gridColMax_upper_bound (g : Grid) (b : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → p.2 < b) :
+    gridColMax g < b := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMax]
+    exact foldl_proj_max_lt_of_mem_lt ps (·.2) p₀.2 b (h₀ p₀ (by simp))
+      (fun q hq => h₀ q (List.mem_cons_of_mem p₀ hq))
+
+/-- **Monotonie de `ceilLog2`.** Le plafond log₂ est une fonction croissante :
+    `a ≤ b ⟹ ceilLog2 a ≤ ceilLog2 b`. Se déduit de `Nat.log_mono_right`
+    (monotonie de `log` en son argument), après le split du `if k ≤ 1`. -/
+theorem ceilLog2_mono {a b : Nat} (hab : a ≤ b) :
+    MacroCell.ceilLog2 a ≤ MacroCell.ceilLog2 b := by
+  by_cases hb1 : b ≤ 1
+  · have ha1 : a ≤ 1 := le_trans hab hb1
+    simp only [MacroCell.ceilLog2, hb1, ha1, reduceIte]
+    omega
+  · by_cases ha1 : a ≤ 1
+    · simp only [MacroCell.ceilLog2, ha1, reduceIte]
+      exact Nat.zero_le _
+    · simp only [MacroCell.ceilLog2, hb1, ha1, reduceIte]
+      have hlog : Nat.log 2 (a - 1) ≤ Nat.log 2 (b - 1) :=
+        Nat.log_mono_right (by omega)
+      omega
+
+/-- **Borne de niveau de la reconstruction (jambe « géométrie » de L3).** Si le
+    support de `g` tient dans la boîte `[a,b)` (au sens
+    `a.1 ≤ p.1 ∧ p.1 < b.1` et idem colonne), alors le niveau de la
+    reconstruction `gridToMacroCellWithOffset g` est borné par `ceilLog2` de la
+    dimension de la boîte plus le rembourrage fixe `5` de `gridFrame`. Preuve :
+    `gridRowMin`/`gridColMin` sont minorées et `gridRowMax`/`gridColMax` majorées
+    par la boîte, donc la hauteur/largeur du cadre (`+5`) reste sous la dimension
+    de la boîte `+5`, et `ceilLog2` est monotone. -/
+theorem gridToMacroCellWithOffset_level_le_of_box (g : Grid) (a b : Int × Int)
+    (h₀ : ∀ p, p ∈ g → a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2) :
+    (gridToMacroCellWithOffset g).2.level ≤
+      MacroCell.ceilLog2 (max (b.1 - a.1 + 5).toNat (b.2 - a.2 + 5).toNat) := by
+  by_cases hg : g = []
+  · subst hg
+    simp only [gridToMacroCellWithOffset, gridFrame]
+    rw [MacroCell.level_buildFromGrid]
+    exact Nat.zero_le _
+  · cases g with
+    | nil => exact absurd rfl hg
+    | cons p₀ ps =>
+      have hne : p₀ :: ps ≠ [] := List.cons_ne_nil p₀ ps
+      have hrowmin : a.1 ≤ gridRowMin (p₀ :: ps) :=
+        gridRowMin_lower_bound _ a.1 hne (fun p hp => (h₀ p hp).1)
+      have hrowmax : gridRowMax (p₀ :: ps) < b.1 :=
+        gridRowMax_upper_bound _ b.1 hne (fun p hp => (h₀ p hp).2.1)
+      have hcolmin : a.2 ≤ gridColMin (p₀ :: ps) :=
+        gridColMin_lower_bound _ a.2 hne (fun p hp => (h₀ p hp).2.2.1)
+      have hcolmax : gridColMax (p₀ :: ps) < b.2 :=
+        gridColMax_upper_bound _ b.2 hne (fun p hp => (h₀ p hp).2.2.2)
+      have hside_le : max ((gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat)
+          ((gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat) ≤
+          max (b.1 - a.1 + 5).toNat (b.2 - a.2 + 5).toNat := by
+        apply max_le_max
+        · exact Int.toNat_le_toNat (by omega)
+        · exact Int.toNat_le_toNat (by omega)
+      simp only [gridToMacroCellWithOffset]
+      rw [MacroCell.level_buildFromGrid]
+      show MacroCell.ceilLog2
+          (max ((gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat)
+               ((gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat)) ≤ _
+      exact ceilLog2_mono hside_le
 
 /-! ## Sanity-checks sur le bestiaire
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -514,6 +514,146 @@ theorem hashlife_correct_margin_of_still_life (c : MacroCell) (k : Nat)
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
   hashlife_correct_margin_of_hcap c k h_central
     (fun t _ => hcap_of_still_life _ (canonical_sortDedup _) hfix t)
+/-! ## L3 geometry — bounding-box bounds and reconstruction level (slice 3, step 5)
+
+Scoping 3-(c) (c.5551298160) identifies the "geometry" leg of L3: at the
+adaptive level, the window `[2^lvl, 3·2^lvl)` must absorb the corridor box.
+Two bricks are laid here: (i) the **bounding-box bounds** of a grid whose
+support is constrained — `gridRowMin` is bounded below, `gridRowMax` is
+bounded above (and likewise columns); (ii) the **level bound** of the
+reconstruction `gridToMacroCellWithOffset g` in terms of the box. These are
+the geometric premises for capture at the adaptive level. -/
+
+/-- **Helper: a `foldl` of `max` (via `proj`) stays strictly below `b`** if the
+    seed and every element are. Direct induction on the list (invariant of
+    `max`). -/
+theorem foldl_proj_max_lt_of_mem_lt (ps : Grid) (proj : Int × Int → Int)
+    (acc : Int) (b : Int) (hb : acc < b)
+    (h₀ : ∀ q, q ∈ ps → proj q < b) :
+    ps.foldl (fun m q => max m (proj q)) acc < b := by
+  induction ps generalizing acc with
+  | nil => simpa using hb
+  | cons q qs ih =>
+    have hq : proj q < b := h₀ q (by simp)
+    have hb' : max acc (proj q) < b := max_lt_iff.mpr ⟨hb, hq⟩
+    exact ih _ hb' (fun r hr => h₀ r (List.mem_cons_of_mem q hr))
+
+/-- **Lower bound of `gridRowMin` from a box.** If every cell of `g` satisfies
+    `a ≤ p.1`, then `a ≤ gridRowMin g`: the minimum of the rows is one of the
+    rows of `g` (`foldl_proj_min_attained`), so it inherits the bound. The grid
+    must be non-empty: on the empty grid, `gridRowMin` defaults to `0` and the
+    bound would fail. -/
+theorem gridRowMin_lower_bound (g : Grid) (a : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → a ≤ p.1) :
+    a ≤ gridRowMin g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridRowMin]
+    rcases foldl_proj_min_attained ps (·.1) p₀.1 with hcase | ⟨p, hp, hval⟩
+    · rw [hcase]
+      exact h₀ p₀ (by simp)
+    · rw [hval]
+      exact h₀ p (List.mem_cons_of_mem p₀ hp)
+
+/-- **Upper bound of `gridRowMax` from a box.** If every cell of `g` satisfies
+    `p.1 < b`, then `gridRowMax g < b`: the maximum of the rows inherits the
+    bound (invariant of the `foldl` of `max`). -/
+theorem gridRowMax_upper_bound (g : Grid) (b : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → p.1 < b) :
+    gridRowMax g < b := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridRowMax]
+    exact foldl_proj_max_lt_of_mem_lt ps (·.1) p₀.1 b (h₀ p₀ (by simp))
+      (fun q hq => h₀ q (List.mem_cons_of_mem p₀ hq))
+
+/-- **Lower bound of `gridColMin` from a box** (column mirror of
+    `gridRowMin_lower_bound`). -/
+theorem gridColMin_lower_bound (g : Grid) (a : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → a ≤ p.2) :
+    a ≤ gridColMin g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMin]
+    rcases foldl_proj_min_attained ps (·.2) p₀.2 with hcase | ⟨p, hp, hval⟩
+    · rw [hcase]
+      exact h₀ p₀ (by simp)
+    · rw [hval]
+      exact h₀ p (List.mem_cons_of_mem p₀ hp)
+
+/-- **Upper bound of `gridColMax` from a box** (column mirror of
+    `gridRowMax_upper_bound`). -/
+theorem gridColMax_upper_bound (g : Grid) (b : Int) (hg : g ≠ [])
+    (h₀ : ∀ p, p ∈ g → p.2 < b) :
+    gridColMax g < b := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMax]
+    exact foldl_proj_max_lt_of_mem_lt ps (·.2) p₀.2 b (h₀ p₀ (by simp))
+      (fun q hq => h₀ q (List.mem_cons_of_mem p₀ hq))
+
+/-- **Monotonicity of `ceilLog2`.** The log₂ ceiling is an increasing function:
+    `a ≤ b ⟹ ceilLog2 a ≤ ceilLog2 b`. Follows from `Nat.log_mono_right`
+    (monotonicity of `log` in its argument), after splitting on `if k ≤ 1`. -/
+theorem ceilLog2_mono {a b : Nat} (hab : a ≤ b) :
+    MacroCell.ceilLog2 a ≤ MacroCell.ceilLog2 b := by
+  by_cases hb1 : b ≤ 1
+  · have ha1 : a ≤ 1 := le_trans hab hb1
+    simp only [MacroCell.ceilLog2, hb1, ha1, reduceIte]
+    omega
+  · by_cases ha1 : a ≤ 1
+    · simp only [MacroCell.ceilLog2, ha1, reduceIte]
+      exact Nat.zero_le _
+    · simp only [MacroCell.ceilLog2, hb1, ha1, reduceIte]
+      have hlog : Nat.log 2 (a - 1) ≤ Nat.log 2 (b - 1) :=
+        Nat.log_mono_right (by omega)
+      omega
+
+/-- **Level bound of the reconstruction ("geometry" leg of L3).** If the
+    support of `g` fits in the box `[a,b)` (in the sense
+    `a.1 ≤ p.1 ∧ p.1 < b.1` and likewise columns), then the level of the
+    reconstruction `gridToMacroCellWithOffset g` is bounded by `ceilLog2` of
+    the box dimension plus the fixed padding `5` of `gridFrame`. Proof:
+    `gridRowMin`/`gridColMin` are bounded below and `gridRowMax`/`gridColMax`
+    bounded above by the box, so the frame height/width (`+5`) stays below the
+    box dimension `+5`, and `ceilLog2` is monotone. -/
+theorem gridToMacroCellWithOffset_level_le_of_box (g : Grid) (a b : Int × Int)
+    (h₀ : ∀ p, p ∈ g → a.1 ≤ p.1 ∧ p.1 < b.1 ∧ a.2 ≤ p.2 ∧ p.2 < b.2) :
+    (gridToMacroCellWithOffset g).2.level ≤
+      MacroCell.ceilLog2 (max (b.1 - a.1 + 5).toNat (b.2 - a.2 + 5).toNat) := by
+  by_cases hg : g = []
+  · subst hg
+    simp only [gridToMacroCellWithOffset, gridFrame]
+    rw [MacroCell.level_buildFromGrid]
+    exact Nat.zero_le _
+  · cases g with
+    | nil => exact absurd rfl hg
+    | cons p₀ ps =>
+      have hne : p₀ :: ps ≠ [] := List.cons_ne_nil p₀ ps
+      have hrowmin : a.1 ≤ gridRowMin (p₀ :: ps) :=
+        gridRowMin_lower_bound _ a.1 hne (fun p hp => (h₀ p hp).1)
+      have hrowmax : gridRowMax (p₀ :: ps) < b.1 :=
+        gridRowMax_upper_bound _ b.1 hne (fun p hp => (h₀ p hp).2.1)
+      have hcolmin : a.2 ≤ gridColMin (p₀ :: ps) :=
+        gridColMin_lower_bound _ a.2 hne (fun p hp => (h₀ p hp).2.2.1)
+      have hcolmax : gridColMax (p₀ :: ps) < b.2 :=
+        gridColMax_upper_bound _ b.2 hne (fun p hp => (h₀ p hp).2.2.2)
+      have hside_le : max ((gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat)
+          ((gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat) ≤
+          max (b.1 - a.1 + 5).toNat (b.2 - a.2 + 5).toNat := by
+        apply max_le_max
+        · exact Int.toNat_le_toNat (by omega)
+        · exact Int.toNat_le_toNat (by omega)
+      simp only [gridToMacroCellWithOffset]
+      rw [MacroCell.level_buildFromGrid]
+      show MacroCell.ceilLog2
+          (max ((gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat)
+               ((gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat)) ≤ _
+      exact ceilLog2_mono hside_le
 
 /-! ## Sanity checks on the bestiary
 


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/lean #14743

## Summary

#13483 tranche 3, interface (c), **étape 5 : la jambe « géométrie » de L3 — bornes de la boîte englobante et borne de niveau de la reconstruction, sans aucun `sorry`.**

Le scoping 3-(c) (c.5551298160) découpe L3 en deux jambes : géométrie (la fenêtre adaptative absorbe la boîte) et composition (corridor → h₀/hwin). Cette PR pose la jambe géométrie :

- **`foldl_proj_max_lt_of_mem_lt`** — aide d'invariant : un `foldl` de `max` reste strictement sous `b` si le seed et chaque élément y sont (induction directe, `max_lt_iff`).
- **`gridRowMin_lower_bound` / `gridRowMax_upper_bound` / `gridColMin_lower_bound` / `gridColMax_upper_bound`** — les quatre bornes de la boîte englobante : si le support de `g` est contraint dans une boîte, `gridRowMin`/`gridColMin` en héritent comme minorantes et `gridRowMax`/`gridColMax` comme majorantes. Le minimum est atteint par une cellule vivante (`foldl_proj_min_attained`), le maximum par l'invariant du `foldl`. **La non-vacuité `g ≠ []` est requise** : sur la grille vide les quatre valent `0` par défaut et les bornes seraient fausses.
- **`ceilLog2_mono`** — le plafond log₂ est croissant (`Nat.log_mono_right`, split du `if k ≤ 1`). La monotonie de `ceilLog2` n'était disponible nulle part localement.
- **`gridToMacroCellWithOffset_level_le_of_box`** — la brique principale : si le support de `g` tient dans la boîte `[a,b)` (au sens `a.1 ≤ p.1 ∧ p.1 < b.1` et idem colonne), le **niveau de la reconstruction** `gridToMacroCellWithOffset g` est ≤ `ceilLog2 (dim boîte + 5)` (le `+5` = rembourrage fixe de `gridFrame`). C'est la prémisse géométrique pour la capture au niveau adaptatif : la classe périodique `T ∣ 2^k` exige `T ∣ 2^level` via `jumpCapturedF_of_period_divides` (#14743), et cette borne de niveau est ce qui manque pour l'obtenir au niveau de la reconstruction.

## Validation

- **double `lake build` SUCCESS** sur `Conway.Life.HashlifeMarginFragment` ET `Conway.Life.HashlifeMarginFragment_en` — chaque relance rend EXIT=0.
- **sorry count inchangé** : `distinct_code_sorry` = 1 (résiduel = `hashlife_correct_margin`, la cible connue de #6724) — avant comme après, aucun `sorry` ajouté.
- **i18n siblings OK** (`scripts/lean/check_i18n_siblings.py --all`), sibling `_en` porté (docstrings EN, preuves byte-identiques).
- **Périmètre** : 2 fichiers (paire FR + `_en`), insertion pure avant la section Sanity-checks. Aucun notebook, catalogue, script, dataset touché.

See #13483 · See #6724
