### PR TITLE
ci(exec-ratchet,#11112): prove the gate fires — detector self-test + organ pytest in CI

### DIFF
--- a/.github/workflows/notebook-exec-sequence-ratchet.yml
+++ b/.github/workflows/notebook-exec-sequence-ratchet.yml
@@ -25,6 +25,7 @@ on:
       - '**.ipynb'
       - 'scripts/notebook_tools/check_exec_sequence.py'
       - 'scripts/notebook_tools/check_exec_ratchet.py'
+      - 'scripts/notebook_tools/tests/**'
       - '.github/workflows/notebook-exec-sequence-ratchet.yml'
   workflow_dispatch:
     inputs:
@@ -60,6 +61,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      # The self-test runs FIRST and gates the gate: it asserts a clean
+      # sequence stays CLEAN (negative control), every dirty class fires
+      # (positive control), and the #14676 option-(c) outcome (a markdown
+      # cell drops out of the sequence, leaving 1..N CLEAN). This makes the
+      # gate's blocking nature machine-provable: without it, the check was
+      # misread as advisory and its CLEAN -> non-CLEAN regressions passed for
+      # several cycles (#14676 saga). A detector that cannot be shown to fire
+      # is indistinguishable from one that is unplugged.
+      - name: Detector self-test (positive + negative control)
+        run: python scripts/notebook_tools/check_exec_sequence.py --self-test
+
+      - name: Organ unit tests
+        run: python -m pytest scripts/notebook_tools/tests/test_check_exec_sequence.py scripts/notebook_tools/tests/test_check_exec_ratchet.py -q
 
       # Refs reach the script via env, never inline in the run script
       # (script-injection guard).

--- a/scripts/notebook_tools/check_exec_sequence.py
+++ b/scripts/notebook_tools/check_exec_sequence.py
@@ -104,6 +104,42 @@ def buckets_of(exec_counts):
     return buckets
 
 
+def self_test():
+    """Prove the detector gates the gate (issue #14676 lesson).
+
+    A gate that cannot be shown to fire is indistinguishable from one that is
+    unplugged -- which is exactly how the Exec-sequence ratchet was misread as
+    advisory and its CLEAN -> non-CLEAN regressions let through for several
+    cycles. Assert a clean sequence stays CLEAN (negative control), every
+    dirty class fires (positive control), and the #14676 option-(c) scenario
+    -- a DUPLICATE-producing code cell converted to markdown leaves the
+    sequence 1..N CLEAN. Exit 0 iff every control holds."""
+    controls = [
+        ("negative: clean 1..N stays CLEAN", [1, 2, 3], "CLEAN"),
+        ("negative: single clean cell stays CLEAN", [1], "CLEAN"),
+        ("positive: not-from-1 fires", [2, 3, 4], "NOT_FROM_1"),
+        ("positive: duplicate fires", [1, 2, 2, 3], "DUPLICATE"),
+        ("positive: unordered fires", [1, 2, 4, 3], "UNORDERED"),
+        ("positive: gap fires (cell deleted after run)", [1, 2, 3, 5], "GAP"),
+        ("#14676 option-(c): markdown cell drops, clean 1..12 stays CLEAN",
+         list(range(1, 13)), "CLEAN"),
+    ]
+    failures = []
+    for label, seq, expected in controls:
+        got = sequence_verdict(seq)
+        status = "ok" if got == expected else "FAIL"
+        if got != expected:
+            failures.append((label, expected, got))
+        print(f"  [{status}] {label}: {got}")
+    if failures:
+        print("SELF-TEST FAIL:")
+        for label, expected, got in failures:
+            print(f"  - {label}: expected {expected}, got {got}")
+        return 1
+    print("all detector self-test controls passed")
+    return 0
+
+
 def family_of(path, root):
     try:
         rel = path.resolve().relative_to(root.resolve())
@@ -190,7 +226,13 @@ def main():
                          "(DIRTY = DUPLICATE|UNORDERED|NOT_FROM_1|GAP)")
     ap.add_argument("--verbose", action="store_true",
                     help="Also list CLEAN notebooks")
+    ap.add_argument("--self-test", action="store_true",
+                    help="Run the detector self-test (positive + negative "
+                         "control) and exit")
     args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
 
     target = Path(args.path)
     if not target.exists():


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #14676

## Résumé

Durcir le gate `Exec-sequence ratchet` (#11112 tier 2) pour que sa nature **bloquante** soit machine-prouvée. Ajout d'un mode `--self-test` au détecteur `check_exec_sequence.py` (contrôles négatif/positif + témoin #14676 option-(c)) et câblage du self-test + pytest de l'organe dans `notebook-exec-sequence-ratchet.yml`. **Genre `guard` (META)** : le plancher G-VAR-1 de cette lane a été tenu par #14676 (c.975, `MED/notebook-python`) ; ce grain est un durcissement d'outillage autour du contenu.

## Ce que le grounding (G.1) a établi — et l'honnêteté du constat

Le steer partait de l'écart « nommé advisory » vs « traité comme advisory » dans `pr_gate.py::is_advisory()` (classification par sous-chaîne "advisory" dans le nom du check). Vérifié firsthand :

- **Aucune misclassification n'existe.** `Exec-sequence ratchet (base vs PR)` est correctement un **gate dur** (requis, bloquant) ; `Source-output ratchet (advisory)` est correctement advisory. La saga #14676 (c.973→c.975) était une mauvaise lecture — le gate bloquait à juste titre l'option (b), et l'option (c) (cellule basculée en markdown) était le bon fix.
- Le **vrai** écart est un trou de **CI**, pas de classification : `notebook-exec-sequence-ratchet.yml` n'exécutait **ni self-test ni pytest de l'organe**, contrairement à `notebook-output-failure-ratchet.yml` qui exécute les deux. Un gate qu'on ne peut pas montrer en train de mordre est indistinguable d'un gate débranché — c'est exactement ce flou qui a permis la mauvaise lecture.

Ce grain ne fabrique donc **pas** un correctif de misclassification (il n'y en a pas) : il ferme l'asymétrie réelle.

## Ce qui a été fait

- **`check_exec_sequence.py`** : ajout de `self_test()` + flag `--self-test` (miroir du `check_output_failure_text.py --self-test`). Contrôles :
  - négatif : `[1,2,3]` et `[1]` restent `CLEAN` ;
  - positifs : `[2,3,4]`→`NOT_FROM_1`, `[1,2,2,3]`→`DUPLICATE`, `[1,2,4,3]`→`UNORDERED`, `[1,2,3,5]`→`GAP` ;
  - témoin #14676 option-(c) : une cellule de code source de DUPLICATE **basculée en markdown** sort de la séquence → `[1..12]` redevient `CLEAN`.
- **`notebook-exec-sequence-ratchet.yml`** : étapes `Detector self-test (positive + negative control)` (avant le ratchet, « gates the gate ») et `Organ unit tests` (pytest `test_check_exec_sequence.py` + `test_check_exec_ratchet.py`) ; ajout de `scripts/notebook_tools/tests/**` aux `paths:` de déclenchement.

## Validation (post-édition, dans le worktree)

- `python scripts/notebook_tools/check_exec_sequence.py --self-test` → **7/7 contrôles ok, exit 0**.
- `python -m pytest .../test_check_exec_sequence.py .../test_check_exec_ratchet.py -q` → **39 passed** (aucune régression organe).
- YAML du workflow : parse OK, steps = checkout / Set up Python / Detector self-test / Organ unit tests / Ratchet check.
- Pre-commit : gitleaks + « Refuse NEW text=True without encoding= » **passent** (le reste skipped, aucun notebook dans le diff).
- Diff : **+57 / −0** sur 2 fichiers (workflow +15, script +42). Aucun notebook touché → pas de ré-exécution requise (C.2).

## Notes

`See #14676` — le gate durci est ce qui rend la sémantique bloquante du ratchet vérifiable, pour que la saga c.973-c.975 ne se reproduise pas. Aucune issue dédiée n'existait sur ce sujet ; le plus proche adjacent est #13326 (autre trou de garde, hors périmètre).
