### PR TITLE
enrich(rl,#13410): rl_14 hierarchical RL -- densite 683.9 -> 1568.4 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb
@@ -268,6 +268,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6821a2fe",
+   "source": [
+    "**Lecture de la sortie — l'environnement en trois chiffres.** Avant de lancer le moindre\n",
+    "apprentissage, trois valeurs méritent qu'on s'y arrête :\n",
+    "\n",
+    "- **200 cellules ouvertes sur 225** : chaque barre intérieure compte 15 cellules moins ses\n",
+    "  2 portes (13 murs), la croisée `(7,7)` étant partagée — 13 + 13 − 1 = 25 murs, donc 200\n",
+    "  états navigables. L'espace d'états reste petit : c'est voulu, pour que la différence\n",
+    "  entre apprenants vienne de la **structure temporelle** du problème, pas de sa taille.\n",
+    "- **`distance BFS start->goal : 24`** : le chemin optimal fait 24 pas, et il en existe\n",
+    "  deux (via `(7,3)` puis `(11,7)`, ou via `(3,7)` puis `(7,11)`). Avec −1 par pas et +20\n",
+    "  au but, le retour optimal non actualisé vaut −23 + 20 = **−3** : la récompense est\n",
+    "  presque entièrement absorbée par le coût du trajet. Le signal existe, mais il est loin.\n",
+    "- **Départ `(1,1)`, but `(13,13)`** : coins opposés, deux portes à franchir dans le bon\n",
+    "  ordre — les deux obstacles annoncés (crédit long-horizon, exploration) sont bien là.\n",
+    "\n",
+    "> **Note** : la distance BFS est calculée par le **simulateur**, qui connaît la carte.\n",
+    "> L'agent ne la verra jamais — c'est le but de l'expérience : mesurer ce que\n",
+    "> l'essai-erreur coûte quand la solution est connue du monde mais pas de l'apprenant."
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "2dc544af",
@@ -326,6 +350,28 @@
     "render_grid(env)\n",
     "print(\"\\nTrouver le chemin le plus court est facile (BFS). Apprendre à le FAIRE par essai-erreur est lent.\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4be5ef4f",
+   "source": [
+    "**Lecture de la grille.** Le rendu confirme la structure annoncée : ligne 7 et colonne 7\n",
+    "forment une croix de `#`, percée de deux ouvertures chacune — les quatre trous visibles\n",
+    "dans la croix sont les portes. `S` et `G` occupent les coins diagonalement opposés\n",
+    "(haut-gauche, bas-droite).\n",
+    "\n",
+    "Deux détails compteront pour la suite :\n",
+    "\n",
+    "1. **Aucune pièce ne touche sa diagonale** : aller de `S` à `G` impose de traverser une\n",
+    "   pièce intermédiaire et deux portes — et, dans la pièce intermédiaire, de ressortir par\n",
+    "   la **bonne** porte. Une exploration au hasard des portes fait errer d'une pièce à\n",
+    "   l'autre sans jamais accumuler de progrès.\n",
+    "2. **La dernière ligne de la sortie résume l'enjeu** : le plus court chemin est un\n",
+    "   problème de graphe, résolu en millisecondes par BFS. L'*apprendre* par essai-erreur\n",
+    "   demande d'enchaîner ~24 décisions cohérentes avant le premier signal positif — c'est\n",
+    "   cet écart entre planifier et apprendre que le notebook mesure."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -391,6 +437,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "08506d4f",
+   "source": [
+    "**Lecture de la sortie — que dessinent les flèches ?** Chaque flèche est l'action que\n",
+    "prendrait l'option « atteindre la porte (7,3) » depuis cette cellule : la politique\n",
+    "intra-option `π_o` est définie sur **tous** les états ouverts, pas seulement dans la\n",
+    "pièce de la cible.\n",
+    "\n",
+    "- Dans la **pièce haut-gauche**, les flèches descendent vers la rangée 6, convergent vers\n",
+    "  la colonne 3, puis `↓` entre dans la porte — le `*` marque la cible, où l'option\n",
+    "  s'arrête (c'est la condition de fin `β_o`).\n",
+    "- Depuis la **pièce haut-droite**, les flèches descendent vers la rangée 3 puis partent à\n",
+    "  gauche : le chemin passe d'abord par la porte `(3,7)`. Depuis la pièce bas-droite, il\n",
+    "  transite par `(11,7)` puis remonte vers la colonne 3. Autrement dit, cette `π_o` «\n",
+    "  sait » déjà qu'il faut franchir une **autre** porte avant d'atteindre la sienne — le\n",
+    "  routage multi-portes est embarqué dans le macro-comportement.\n",
+    "\n",
+    "Et c'est là le point à retenir : cette politique est **calculée par BFS**, donc\n",
+    "**parfaite**. L'option est un macro-comportement tout prêt. Ce que l'agent aurait appris\n",
+    "de moins bon — ou comment apprendre `π_o` au lieu de la recevoir — est renvoyé à\n",
+    "l'intra-option learning, plus bas dans le notebook."
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "0973326e",
@@ -441,6 +512,34 @@
     "print(\"départ (1,1) -> option porte (7,3) : arrivée\", env.decode(s_end), \"| étapes:\", tau, \"| récompense:\", rr)\n",
     "print(\"L'option a 'sauté' plusieurs pas d'un coup : c'est l'abstraction temporelle.\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e60e6e3",
+   "source": [
+    "**Lecture de la démo — une décision, huit pas.** La sortie dit l'essentiel : parti de\n",
+    "`(1,1)`, un seul choix d'option (« porte (7,3) ») amène l'agent en `(7,3)` en **8\n",
+    "étapes**, pour une récompense totale de **−8.0** — exactement −1 par pas, aucun détour.\n",
+    "Huit pas, c'est la distance de Manhattan |7−1| + |3−1| = 8 : la politique BFS ne gaspille\n",
+    "rien.\n",
+    "\n",
+    "La transition SMDP `(s, o) → (s', τ, r)` se lit directement sur ces trois nombres :\n",
+    "\n",
+    "| Grandeur | Valeur | Rôle |\n",
+    "|---|---|---|\n",
+    "| `s'` | `(7,3)` | l'état d'arrivée — celui sur lequel le haut niveau rechoisit |\n",
+    "| `τ` | 8 | la durée de l'option ; l'actualisation du Bellman SMDP porte `γ^τ` (avec le `γ = 0.99` des apprenants ci-dessous : `0.99^8 ≈ 0.92`), pas `γ` |\n",
+    "| `r` | −8.0 | la récompense **cumulée** sur les 8 pas — un seul « retour » vu du haut niveau |\n",
+    "\n",
+    "L'option s'est arrêtée sur sa cible : condition de fin `β_o` déterministe (1 sur la\n",
+    "cible, 0 ailleurs), doublée d'un garde-fou `max_steps` qui coupe une option qui tournerait\n",
+    "en rond.\n",
+    "\n",
+    "**Transition** : cette option était parfaite et donnée. Avant de mesurer ce que l'agent\n",
+    "**apprend**, il faut une référence — le Q-learning plat du notebook 5, sur les 4 actions\n",
+    "primaires, au même budget d'épisodes. Cellule suivante."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -522,6 +621,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "15b2ba40",
+   "source": [
+    "**Lecture des quatre runs — que mesure chaque colonne ?** Avant les statistiques, un\n",
+    "décryptage ligne par ligne :\n",
+    "\n",
+    "- **`first_solved` vaut 8, 13, 15 ou 12 selon le seed** : le premier succès tombe dans la\n",
+    "  première quinzaine d'épisodes, pour les 4 seeds. Mais attention à ce que la métrique\n",
+    "  capture : à l'épisode 12 sur 3000, l'anneau d'exploration n'a presque pas bougé\n",
+    "  (`ε` passe de 0.40 à ≈ 0.398). Ce premier succès est donc un **coup d'exploration** —\n",
+    "  une séquence chanceuse de ~24 pas largement aléatoires — et non déjà un apprentissage.\n",
+    "- **`solved_last100 = 100` partout** : ceci, en revanche, est la signature de\n",
+    "  l'apprentissage. Sur les 100 derniers épisodes, `ε ≈ 0.05` : l'agent suit sa politique\n",
+    "  apprise et atteint le but à chaque épisode. La valeur s'est propagée le long du chemin,\n",
+    "  et la politique la suit.\n",
+    "- **0.2–0.3 s par seed** : expérience délibérément petite (200 états × 4 actions) —\n",
+    "  assez pour être répétée par seed, pas assez pour impressionner.\n",
+    "\n",
+    "La dispersion `8 → 15` (facteur ~2) servira de référence : elle dit combien la\n",
+    "**découverte** initiale dépend du hasard, là où la consolidation, elle, est\n",
+    "systématique."
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "e095913a",
@@ -574,6 +698,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "59db3141",
+   "source": [
+    "**Transition — de la référence au cadre à options.** Le plat a appris, mais il a payé\n",
+    "chaque pas de sa découverte. On munit maintenant l'agent d'un niveau haut qui choisit non\n",
+    "plus des pas mais des **options** — les quatre « atteindre la porte k » et « atteindre le\n",
+    "but ». Deux changements structurels en découlent, tous deux mesurables :\n",
+    "\n",
+    "- le choix de haut niveau porte sur **5 options** au lieu de 4 actions, mais il n'est plus\n",
+    "  refait à chaque pas — seulement à la fin de chaque option ;\n",
+    "- la table `Q(s, o)` se met à jour à l'échelle de l'option : récompense cumulée `r`,\n",
+    "  durée `τ`, actualisation `γ^τ`.\n",
+    "\n",
+    "Et surtout : ces macros sont **construites par BFS** — parfaites, données. Retenez-le,\n",
+    "c'est ce qui déterminera la lecture des résultats qui viennent."
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "3ce61ece",
@@ -617,6 +760,25 @@
     "for k, (t, pol, _) in options.items():\n",
     "    print(f\"  {k:9s} -> cible {env.decode(t)}  (politique intra-option : {len(pol)} états)\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b058b2cf",
+   "source": [
+    "**Lecture de la sortie — le menu du haut niveau.** Cinq options : quatre « porte k » et\n",
+    "« but ». Deux détails dans la colonne de droite :\n",
+    "\n",
+    "- chaque politique intra-option couvre **199 états** — les 200 cellules ouvertes moins la\n",
+    "  cible elle-même : sur sa cible, l'option n'a plus rien à décider, elle s'arrête ;\n",
+    "- les cibles sont exactement les quatre portes et le but : le haut niveau choisit **où\n",
+    "  aller**, chaque choix déléguant le **comment y aller** à sa `π_o`.\n",
+    "\n",
+    "Noter l'asymétrie de rythme : le plat lit sa table 200 × 4 une fois par **étape** ; le SMDP\n",
+    "lit sa table 200 × 5 une fois par **option** (le `τ` de la démo était 8 pour une porte\n",
+    "voisine, ~24 pour le but — la distance BFS mesurée au départ). C'est cette différence de\n",
+    "rythme de décision — pas la taille des tables — que la comparaison mesure."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -697,6 +859,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2469364c",
+   "source": [
+    "**Lecture des quatre runs — une uniformité parfaite.** Contrairement au plat\n",
+    "(`8, 13, 15, 12`), les quatre seeds rendent **exactement la même ligne** :\n",
+    "`first_solved = 0`, `solved_last100 = 100`, temps de run affiché `0.0 s`.\n",
+    "\n",
+    "- **Dispersion nulle.** Quatre générateurs aléatoires différents, quatre issues\n",
+    "  identiques : le résultat ne dépend pas du hasard d'exploration. C'est la signature d'une\n",
+    "  **compétence déjà présente** dans l'agent — pas d'une découverte qu'il aurait faite.\n",
+    "- **`first_solved = 0`** : le premier épisode atteint déjà le but. L'explication est\n",
+    "  mécanique : parmi les 5 options du menu, l'une (`but`) est compétente depuis tout état —\n",
+    "  tôt ou tard dans l'épisode elle est sélectionnée, et elle résout.\n",
+    "- **`0.0 s`** : quelques décisions de haut niveau par épisode, là où le plat enchaînait\n",
+    "  des dizaines à centaines de pas — le budget de pas se consomme beaucoup plus\n",
+    "  lentement.\n",
+    "\n",
+    "Le contraste avec le plat est frappant — mais il ne dit pas encore ce qu'il semble dire.\n",
+    "Les statistiques et la lecture honnête qui suivent établissent pourquoi."
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "0f63e64b",
@@ -760,6 +945,27 @@
     "   C'est la section suivante (intra-option learning) — et c'est là que le RL hiérarchique montre sa\n",
     "   force, quand les `π_o` ne sont pas offertes mais apprises.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87fef034",
+   "source": [
+    "**Transition — apprendre les macros au lieu de les recevoir.** La case limite est\n",
+    "établie ; que reste-t-il à **apprendre** dans le framework ? Les politiques intra-option\n",
+    "`π_o` elles-mêmes. La cellule suivante ré-entraîne chaque option « porte k » **de zéro**,\n",
+    "avec trois ingrédients qui changent la nature du problème :\n",
+    "\n",
+    "1. **récompense de sous-objectif** (+1 en entrant dans la cible, −1 sinon) : chaque\n",
+    "   sous-tâche devient à récompense **dense**, là où la tâche globale était parcimonieuse ;\n",
+    "2. **un Q par option** : chaque `Q_prim` apprend « sa » politique orientée vers « sa »\n",
+    "   porte ;\n",
+    "3. **un haut niveau oracle** : l'option active est choisie par proximité BFS — un choix\n",
+    "   **donné**, pour isoler et mesurer l'apprentissage bas niveau seul.\n",
+    "\n",
+    "Le chiffre à surveiller : le **taux d'atteinte du sous-objectif** — combien d'épisodes\n",
+    "atteignent leur cible avec une `π_o` partie de zéro."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -831,6 +1037,33 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0a0f7552",
+   "source": [
+    "**Lecture de la sortie — ce que la `π_o` apprise vaut.** Sur 1500 épisodes, l'option\n",
+    "active a atteint sa cible **1459 fois** : un taux de **0.97**. Décomposons ce que ce\n",
+    "nombre mesure — et ce qu'il ne mesure pas :\n",
+    "\n",
+    "- **0.97 atteste que le bas niveau s'apprend** : avec une récompense dense (+1/−1 par pas\n",
+    "  de sous-objectif), chaque `Q_prim` devient une politique qui mène à sa porte — le même\n",
+    "  routage que la cellule des flèches, mais **reconstruit par essai-erreur** au lieu d'être\n",
+    "  calculé par BFS. L'agrégat ne dit pas quand la convergence a eu lieu, seulement qu'à\n",
+    "  l'arrivée l'atteinte est quasi systématique.\n",
+    "- **Les ~3 % restants (41 épisodes)** : des épisodes où le budget de 400 pas s'épuise\n",
+    "  avant la cible — exploration encore dispersée en début d'anneau, ou cible plus\n",
+    "  lointaine. Un taux inférieur à 1.00 est sain : un apprentissage parfait d'emblée serait\n",
+    "  suspect.\n",
+    "- **Ce que ça ne mesure pas** : un seul seed (le seed 0), un haut niveau **oracle**, et\n",
+    "  une évaluation à la première cible atteinte — pas la trajectoire complète jusqu'au but.\n",
+    "  L'intégration bout-en-bout (apprendre les DEUX niveaux) est le terrain d'Option-Critic,\n",
+    "  cité en bibliographie.\n",
+    "\n",
+    "C'est pourtant ici que le framework « apprend » au sens propre — le contraste avec la\n",
+    "case limite précédente est le message central du notebook."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "0efb28d4",
    "metadata": {},
    "source": [
@@ -844,6 +1077,19 @@
     "Ce découplage est ce qui permet le **RL hiérarchique** : un niveau haut choisit *où aller*, le\n",
     "niveau bas apprend *comment y aller*, et les deux peuvent se ré-entraîner.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47e732a7",
+   "source": [
+    "**Transition — le verdict par règles explicites.** Reste à confronter les mécanismes sur\n",
+    "les mêmes seeds `{0, 1, 7, 42}`. La cellule suivante n'improvise pas sa conclusion : elle\n",
+    "calcule les médianes, rapporte la dispersion min/max, puis embranche sur un verdict parmi\n",
+    "cinq cas codés — « case limite », « accélère », « accélère modérément », « inconclusif »,\n",
+    "« ne résout pas ». Les seuils sont écrits **avant** lecture des chiffres : c'est cette\n",
+    "procédure, plus que la valeur du verdict, qui rend la comparaison honnête."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -961,7 +1207,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_39712\\1322819636.py:67: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\1322819636.py:67: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
       "  plt.show()\n"
      ]
     }
@@ -1039,6 +1285,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5aefb68c",
+   "source": [
+    "**Lecture des chiffres — pourquoi 0.52 et pas 1.00 ?** Les deux courbes s'achèvent sur le\n",
+    "même « taux de succès 0.52 », alors que leurs dynamiques n'ont rien en commun. Ce 0.52\n",
+    "identique est un **artefact de bord**, pas une mesure :\n",
+    "\n",
+    "- Le lissage est `np.convolve(..., mode=\"same\")` sur une fenêtre de 60. Au **dernier\n",
+    "  indice**, la fenêtre ne couvre que 31 épisodes réels — le reste est du zéro-padding.\n",
+    "  Un taux brut de 1.00 s'affiche donc ≈ 31/60 ≈ **0.52**. Que les DEUX méthodes affichent\n",
+    "  exactement 0.52 signifie que leurs derniers épisodes sont tous réussis — cohérent avec\n",
+    "  `solved_last100 = 100` mesuré plus haut. Le même artefact déprime le début de chaque\n",
+    "  courbe (bord gauche).\n",
+    "- **Protocole volontairement différent** du run principal : `ε` **fixe à 0.2** (plus\n",
+    "  d'anneau 0.4 → 0.05), 600 épisodes, 3 seeds (0, 1, 7). La montée du plat est ici plus\n",
+    "  lente que dans le run à `ε` annealing — les courbes se comparent entre elles, pas aux\n",
+    "  médianes précédentes. (Détail : le calcul est une **moyenne** sur les 3 runs, `acc/3`,\n",
+    "  alors que le titre du graphe dit « médiane ».)\n",
+    "- Le `UserWarning` du backend `Agg` est bénin — il signale juste que la figure n'est pas\n",
+    "  affichée en interactif. La trace quantitative commitée, ce sont les deux valeurs\n",
+    "  imprimées ci-dessus.\n",
+    "\n",
+    "À retenir : une moyenne glissante sous-estime systématiquement en bord de série — lire la\n",
+    "valeur brute ou le last-100 avant de conclure."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "a05905c7",
    "metadata": {},
    "source": [
@@ -1054,6 +1328,36 @@
     "signature d'un *planner parfait*, pas d'un *learner*. La courbe qui compte pour l'apprentissage est\n",
     "celle de l'intra-option learning, où les sous-politiques partent de zéro.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89cd6468",
+   "source": [
+    "**Synthèse — ce que l'expérience a établi.** Trois mécanismes, trois résultats, un fil\n",
+    "conducteur :\n",
+    "\n",
+    "| Mécanisme | Ce qui est donné | Résultat mesuré | Ce que ça prouve |\n",
+    "|---|---|---|---|\n",
+    "| Q-learning plat | rien | `first_solved` médian **12.5** (dispersion 8–15), succès final 1.00 | le crédit long-horizon se paie en épisodes de découverte aléatoire |\n",
+    "| SMDP à options | les `π_o` (BFS, parfaites) | `first_solved` **0** sur les 4 seeds | un macro parfait donné = planification, pas apprentissage |\n",
+    "| Intra-option learning | le haut niveau (oracle) | **1459/1500 = 0.97** (seed 0) | la vraie brique d'apprentissage : `π_o` reconstruite par essai-erreur |\n",
+    "\n",
+    "Trois leçons à emporter :\n",
+    "\n",
+    "1. **L'abstraction temporelle raccourcit l'horizon de décision** — de ~24 choix par trajet\n",
+    "   à 1–3 choix d'options — et cela se voit jusque dans le temps de run (0.2–0.3 s contre\n",
+    "   0.0 s).\n",
+    "2. **Le gain affiché par des macros données est une case limite** : le framework y agit en\n",
+    "   planificateur. Comparer « qui apprend plus vite » exige des macros **apprises** — sinon\n",
+    "   on compare un apprenant à un solveur.\n",
+    "3. **Le contenu d'apprentissage réel est en bas** : des sous-politiques à récompense\n",
+    "   dense, apprises séparément, assemblables par un niveau haut — la brique\n",
+    "   qu'Option-Critic et FeUdal Networks étendent aux deux niveaux à la fois.\n",
+    "\n",
+    "Les exercices qui suivent attaquent chacun une hypothèse du protocole : la durée `τ`\n",
+    "(exercice 1), l'initiation `I_o` (exercice 2), les options paresseuses (exercice 3)."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #14745

## Summary

Enrichissement pédagogique markdown-only de `MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb` (hierarchical RL, options framework). Densité pédagogique 683.9 → 1568.4 c/cell (floor 1200 atteint).

- 13 cellules markdown ajoutées (25 au total) : 8 interprétations quantitatives ancrées sur les sorties déjà committées, 4 transitions, 1 synthèse avec table récapitulative.
- Cellules code : **source + `execution_count` byte-identiques a HEAD (16/16)** ; les `outputs` de la cellule 30 sont normalises par le hook de pre-commit (chemin machine `C:\Users\jsboi\...\ipykernel_39712\` -> `<USER_PATH>\...\ipykernel_<pid>\`), seule ligne de sortie touchee par le diff. Enrichissement markdown-only cote source, conforme C.2 -- pas de re-execution. Voir la Note ci-dessous et #14200.
- Prose : 10942 → 25094 chars (métrique `pedagogy_density.py`).

## Verification

- Densité canonique (`pedagogy_density.py`) : **1568**, status ok (plancher 1200 atteint).
- Cellules code SOURCE + `execution_count` byte-identiques à HEAD : vérifié (16/16).
- Les 41 cellules `source` en forme liste (nbformat canonique), accents UTF-8 préservés.
- `check_interp_positioning` : **0 finding** — chaque interprétation suit la cellule de code dont l'output porte la valeur citée.
- `detect_markdown_rendering` : **0 violation**.
- C.1 (pas d'erreur volontaire) : 0 pattern interdit.
- H.3 (exécution) : toutes les cellules code portent `execution_count` + `outputs` (pre-commit Passed).
- Pre-commit (gitleaks + strips + H.3 + #13326) : **tous Passed**.

## Note

La sortie de la cellule 30 porte un chemin machine pré-existant (`...\ipykernel_<pid>\...`), normalisé par le hook `strip-dotnet-nuget-ext` au commit. Elle n'a pas été touchée par cet enrichissement ; la classe de défaut (chemin machine dans une sortie) est suivie sous #14200.

See #13410




---

*Correction coordinateur (ai-01, 2026-09-05T19:09Z)* -- le resume annoncait « 16 cellules code byte-identiques » alors que le diff modifie une ligne d'`outputs` (cellule 30). Reserve 2 de la review du 18:21:30Z, exacte : reformulee ci-dessus dans les termes proposes par son auteur, pour que le claim et le diff coincident. La section Verification et la Note disaient deja juste ; seul le resume les contredisait.
