### PR TITLE
feat(ml,#14768): M18 TimesFM 2.5 zero-shot benchmark — 5/6 BEATS vs Log-HAR (§C strict)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -19,8 +19,43 @@ Updated: 2026-09-04 — M17 HAR-LJ-Asym BTC revalidé contre HAR débiaisé trai
 Updated: 2026-09-04 — M17 HAR-LJ-Asym BTC REPAIR P0 c.953 (PR #14592, preflight po-2025 adjoint `msg-20260904T105224-z6f9d7` head 8167044f) : **calibration symétrique** sur LJ/HAR/M12 + `var(ddof=0)` + sanity `mse = bias²+var` à 1e-9 + `panel_hash` SHA256 sur fenêtre canonique 360 bars (BTC 4 seeds → 1 hash `86f36cb46f539c6d`) + naming `mse_har_raw`/`mse_har_debiased` (NaN si non-débiaisé). **Verdict révisé** : h=1 BEATS 4/4 (inchangé, var_ratio=0,778) ; h=5 INCONCLUSIVE 0/4 contre HAR **et** M12 (était 4/4 BEATS vs M12) ; h=10 BEATEN BY 0/4 contre HAR (MSE 0,464 > 0,366 HAR-débiaisé ; était INCONCLUSIVE 0/4). Le claim c.951 « 4/4 BEATS vs M12 aux trois horizons » ne tient plus sous calibration symétrique : la tête précédente de M17 sur M12 aux h=5/h=10 était portée par le gap de calibration, pas par un gain de précision. Detail dans `docs/M17_HAR_LJ_ASYM.md` section c.953. `panel_hashes_consistent=True`, OLS bit-identique par seed (DM-MSE p-values identiques 6 décimales).
 Updated: 2026-09-05 — M17 HAR-LJ-Asym round-3 calibration (PR #14592, preflight po-2025 adjoint re-review head `b974f2721`, DM `msg-20260904T141944`) : **nombres c.953 ci-dessus SUPERSEDES** (signe du biais inversé `yhat - bias` → corrigé `yhat + bias`, application per-fold, M12 calibré `calibrate_bias=debias`, deux jambes HAR `mse_har_raw` != `mse_har_debiased`, `panel_hash` sur index+valeurs avec manifeste per (coin,horizon)). Détail dans `docs/M17_HAR_LJ_ASYM.md` section « Round-3 calibration (this PR) ». [M17 HAR-LJ-Asym BTC run] — pending live run post-merge; round-3 calibration implemented, code PR #14592.
 Updated: 2026-09-05 — M17 HAR-LJ-Asym round-4 (PR #14592, adjoint re-review DM `msg-20260905T001520`, 3/6 PASS / 3/6 PARTIAL) : test OOS multi-fold discriminant `test_walk_forward_lj_asym_oos_target_invariance_multi_fold` (n_splits=3, biais per-fold **distincts**, invariance per-fold bit-identique rtol 1e-12, folds antérieurs inchangés, folds postérieurs = expanding-window retrain légitime asserté comme sensibilité, train-tail > 1.0 par fold) + provenance `bounds_train_test` (`{train_end_idx = n_splits·(n//(n_splits+1)), oos_start_idx = train_end+horizon, oos_end_idx}`) relayée par `_eval_one_coin` / `aggregate_verdicts` / manifeste (`bounds_per_coin_horizon`, `fc_lj_hash_per_fold` alignés sur `per_fold_bias`) ; placeholder `if False else None` supprimé. Tests 22 → 24 verts, suite 1194 passed / 0 failed. **[M17 HAR-LJ-Asym BTC run] LIVRÉ (round-4 code) — `python har_lj_asym.py --coins BTC-USD --skip-remote --debias --horizons 1 5 10 --seeds 0 7 42 99` en 467.9 s** : h=1 **BEATS 4/4** vs HAR et M12 (p<1e-6, mean_loss_diff<0, `_coherent_beats()` strict ✓) ; h=5/h=10 INCONCLUSIVE 0/4 (p>0.05, mean_loss_diff>0 ⇒ cohérent INCONCLUSIVE). Bornes effectives BTC : `train_end=1890` (5 folds × 378 jours), `n_oos=378-382`, `n_total=2272` jours. Bit-identity cross-seed OK (`per_fold_bias` et `fc_lj_hash_per_fold` identiques sur les 4 seeds, `bounds_consistent_across_seeds=True`). Précédent c.953 `h=1 BEATS p=0.839708` réfuté — sous round-3+4 calibration le verdict reste BEATS mais devient réellement significatif. Détail dans `docs/M17_HAR_LJ_ASYM.md` section « Live BTC run (concern b — this PR) ». Manifest `scripts/results/m17_har_lj_asym.json` régénéré ; meta `manifest_m17_har_lj_asym.json` mis à jour avec `concern_addressing` round-3 + round-4.
+Updated: 2026-09-05 — M18 TimesFM 2.5 zero-shot première entrée §C (issue #14768, lane myia-po-2026) : **vs Log-HAR 5/6 BEATS, 1/6 INCONCLUSIVE (BTC h=22, log-HAR numériquement meilleur mais p=0,23), 0/6 NO BEATS** — réserves : ETH h=22 p=0,0445 limite. Horizons 1/5/22 j, walk-forward 5 folds, seeds bit-identiques (GPU déterministe), débiais symétrique, DM conjonction MSE (#11010). Vrai checkpoint attesté (SHA 1d952420fba8, 43 720 séries, fail-explicit). Calibration quantile native : couverture 80 % à ±0,026 du nominal. HAR en niveaux dégénère en quasi-persistence (MSE identiques à 6 décimales, hashs distincts). Détail section M18 + `docs/M18_TimesFM.md`.
 
 Total checkpoints: 70 (20 legacy ARCHIVED + 50 panier baselines)
+
+## M18 TimesFM 2.5 zero-shot — première entrée §C (2026-09-05) — issue #14768
+
+Benchmark TimesFM 2.5-200M (`google/timesfm-2.5-200m-pytorch` SHA
+`1d952420fba8`, 43 720 séries servies, contrat fail-explicit sans fallback)
+contre persistence / EWMA / Log-HAR / HAR-RV sur RV crypto quotidienne,
+horizons **1/5/22 j** (protocole #14768), walk-forward 5 folds, seeds
+{0,7,42,99} **bit-identiques** (inférence GPU déterministe — jambe σ
+dégénérée, précédent M17 OLS), débiais symétrique per-fold (queue
+d'entraînement 60 j, `yhat + bias`), DM deux jambes (#11010) : conjonction
+sur MSE, `linear` = diagnostic biais. Script `scripts/m18_tsfm_benchmark.py`
+(+31 tests), manifeste `scripts/results/m18_tsfm_benchmark.json`, doc
+`docs/M18_TimesFM.md`.
+
+| Coin | h | vs persistence | vs ewma | vs log_har | vs har_rv |
+|---|---:|---|---|---|---|
+| BTC | 1 | **BEATS** +40,7 % | **BEATS** +20,1 % | **BEATS** +19,7 % | **BEATS** +40,7 % |
+| BTC | 5 | **BEATS** +56,2 % | INCONCLUSIVE +5,4 % (p=0,116) | **BEATS** +8,5 % (p=0,0015) | **BEATS** +56,2 % |
+| BTC | 22 | **BEATS** +46,5 % | **BEATS** +10,7 % | INCONCLUSIVE −4,8 % (p=0,232) | **BEATS** +46,5 % |
+| ETH | 1 | **BEATS** +30,6 % | **BEATS** +10,5 % | **BEATS** +7,6 % | **BEATS** +30,6 % |
+| ETH | 5 | **BEATS** +49,7 % | INCONCLUSIVE +4,1 % | **BEATS** +10,7 % | **BEATS** +49,7 % |
+| ETH | 22 | **BEATS** +47,2 % | **BEATS** +11,9 % | **BEATS** +12,5 % (p=0,0445 ⚠ limite) | **BEATS** +47,2 % |
+
+**Verdict contre la baseline de référence (Log-HAR) : 5/6 BEATS, 1/6
+INCONCLUSIVE, 0/6 NO BEATS** — solide sur 4 cellules (p ≤ 0,0015), deux
+réserves honnêtes : BTC h=22 INCONCLUSIVE (log-HAR numériquement meilleur
+−4,8 % mais non significatif), ETH h=22 BEATS au bord du seuil (p=0,0445).
+Calibration quantile native remarquable : couverture 80 % mesurée
+0,774-0,814 pour nominal 0,80, zero-shot sans ajustement. Trou empirique :
+HAR en niveaux dégénère en quasi-persistence sur ce panel (MSE égales à
+6 décimales, hashs distincts — artefact connu, pas un bug). Coûts :
+non applicables au forecast pur, aucun claim Sharpe/P&L. Aucun claim
+d'alpha : TimesFM entre comme forecasteur de volatilité, l'étape
+économique est hors scope #14768.
 
 ## M16 HAR asymétrique — re-test débiaisé BTC (2026-09-02) — Epic #1454
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M18_TimesFM.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M18_TimesFM.md
@@ -1,0 +1,183 @@
+# M18 : TimesFM 2.5 zero-shot contre HAR / Log-HAR / persistence / EWMA
+
+**Modèle :** TimesFM 2.5-200M (Google Research, code et poids Apache-2.0),
+zero-shot, sans fine-tuning ni calibration sur le panel.
+**Date :** 2026-09-05
+**Script :** `scripts/m18_tsfm_benchmark.py` · **Tests :** `scripts/tests/test_m18_tsfm_benchmark.py`
+**Issue :** #14768 · **Registre :** entrée M18 dans `REGISTRY.md`
+
+## Positionnement
+
+Le curriculum couvre déjà PatchTST et iTransformer (`QC-Py-23b`, entrées §C
+du registre : PatchTST `NO BEATS` revalidé #14081). TimesFM 2.5 entre comme
+**challenger falsifiable**, pas comme keeper présumé : la littérature primaire
+(Goel et al. 2025, https://arxiv.org/abs/2505.11163 sur TimesFM 2.0 ;
+comparaison zero-shot 50 actifs 1/5/22 j, https://arxiv.org/abs/2607.05291)
+donne un signal borné — Log-HAR reste très compétitif, le gain TSFM n'est pas
+uniforme. D'où un protocole §C strict, sans avantage de structure donné au
+challenger.
+
+## Protocole (§C, aligné M17 round-3/4)
+
+| Élément | Choix |
+|---|---|
+| Cible | moyenne glissante h-jour du log-RV (`rolling(h).mean().shift(-h)`) |
+| Horizons | 1, 5, 22 jours (protocole #14768, pas le 1/5/10 des M4/M17) |
+| Folds | walk-forward expanding 5 folds, `fold_size = n // 6` (arithmétique `har_model._make_split_indices`) |
+| Seeds | {0, 7, 42, 99} — timesfm servi avec `torch.manual_seed(seed)` |
+| Débiais | biais constant par fold estimé sur la queue d'entraînement (60 j) SEULE, appliqué symétriquement : `yhat_deb = yhat + bias` (leçon M17 round-3 : signe `+`, jamais `-`) |
+| DM | deux jambes (#11010) : conjonction sur `loss_fn="mse"` (perte de précision), jambe `linear` (erreurs signées) = diagnostic de biais, ne jambe jamais le verdict |
+| Verdict | `BEATS` ⇔ dm_p_median(mse) < 0,05 ET DM cohérent gagnant sur tous les seeds ET (edge ≥ 2σ cross-seed OU seeds bit-identiques — précédent M17 OLS : déterminisme ⇒ jambe σ dégénérée, pas artificiellement infinie) |
+| Métriques | MSE/MAE (log), QLIKE (Patton 2011, échelle RV), biais signé ; TimesFM seul : pinball natif, couverture/largeur 80 % |
+| Provenance | repo id + SHA du checkpoint (HfApi), compteur de séries réellement servies, `panel_hash` (fenêtre canonique 360 bars), `bounds_train_test` par fold, hash SHA256 des prévisions par fold (audit bit-identité cross-seed) |
+
+## Modèles
+
+Tous prédisent **la même cible** sur **les mêmes indices de test** :
+
+- **persistence** — dernier log-RV observé (naïf / marche aléatoire).
+- **ewma** — moyenne exponentiellement pondérée du log-RV, span choisi sur
+  la queue d'entraînement uniquement parmi {5, 10, 20, 60}.
+- **log_har** — OLS HAR(1d, 5d, 22d) sur lags log-RV (`har_model.HARModel`,
+  spécification log de Corsi 2009), chemin h-étapes itéré, prédiction =
+  moyenne du chemin log. Refit tous les 22 jours (fenêtre expanding).
+- **har_rv** — même structure OLS sur les **niveaux** de RV (HAR-RV brut),
+  chemin h-étapes itéré en RV, projection sur la cible commune =
+  `log(mean(chemin RV))`. Les deux spécifications HAR répondent à
+  l'exigence « HAR et Log-HAR » de l'issue.
+- **tsfm** — TimesFM 2.5-200M, contexte = `context_len` (512) derniers
+  log-RV, chemin direct multi-horizon (pas de récursion), prédiction =
+  moyenne des h premières étapes du chemin médian ; quantiles natifs à
+  l'étape h pour l'évaluation pinball/couverture.
+
+### Disposition du tenseur TimesFM (vérifiée empiriquement)
+
+Le dernier axe de la sortie quantiles est **`[mean, q0.1, q0.2, …, q0.9]`**
+(10 canaux) — le canal 0 est la tête mean, le quantile i vit en colonne
+`1 + i`, et la sortie point == canal 5 == médiane. Le wrapper asserte cette
+largeur d'axe à chaque appel (garde anti-dérivation d'API).
+
+### Évaluation quantile vs ponctuelle — deux fonctionnels distincts
+
+Les prévisions ponctuelles ciblent la **moyenne h-jour** du log-RV ; les
+quantiles natifs sont évalués sur le log-RV **réalisé à l'étape h** (cible
+directe). Les deux sont enregistrés séparément dans le manifeste, jamais
+mélangés — comparer le quantile d'une cible moyenne à la cible directe
+serait une erreur de fonctionnel.
+
+## Contrat fail-explicit (#14768)
+
+Aucun fallback : si le checkpoint ne charge pas, si la provenance HF échoue,
+ou si l'axe quantiles dévie, le script **abort** (exit non nul). Rien ne
+peut être rapporté sous l'étiquette TimesFM sans le vrai modèle. Le compteur
+`n_tsfm_series_served` atteste le volume réellement servi.
+
+## Données et périmètre
+
+- Panel M-série existant (`har_asymmetric._load_panel`) : BTC (Bitstamp 1h,
+  ~2 272 j de RV) et ETH (Binance 1h) en cache local (`--skip-remote`) ;
+  les 5 autres coins du panel (yfinance 1h, ~725 j) ne supportent pas
+  h=22 avec 5 folds + calibration — exclus du barème §C, même verdict de
+  profondeur que M4/M17.
+- « Panier diversifié, aucune FAANG/Mag7 » : satisfait structurellement —
+  le panel est crypto (BTC + ETH = les deux majeures), aucun titre
+  équity n'entre dans l'échantillon.
+
+## Choix de périmètre assumés
+
+- **Chronos-Bolt** : non inclus — l'issue le conditionne à « chargement
+  réel attesté » ; il a son propre script d'éval (`eval_chronos_bolt.py`)
+  et son cadre (direction-accuracy) diffère du protocole RV/§C. Un grain
+  séparé peut l'ajouter en baseline §C si souhaité.
+- **PatchTST / iTransformer** : modèles **entraînés** avec leurs propres
+  entrées §C (PatchTST `NO BEATS` #14081 sur BTC log-RV débiaisé) ;
+  les ré-entraîner dans ce benchmark dupliquerait ces entrées. Le doc les
+  cite comme contexte ; la comparaison fraîche ici est TSFM vs baselines
+  classiques zero-cost.
+- **TimesFM 3.0** : hors périmètre de ce benchmark public — poids sous
+  TimesFM Non-Commercial License v1.0 ; pilote privé suivi par #14769
+  (qui dépend du présent benchmark).
+
+## Résultats
+
+Run live 2026-09-05 : `google/timesfm-2.5-200m-pytorch` SHA `1d952420fba8`,
+43 720 séries servies, 867,5 s GPU (RTX 3090). Manifeste :
+`scripts/results/m18_tsfm_benchmark.json`. Les 4 seeds sont
+**bit-identiques** (`ident=True` partout — inférence GPU déterministe,
+précédent M17 OLS : la jambe σ cross-seed dégénère, elle ne gonfle rien).
+
+### Verdicts §C (conjonction : jambe MSE du DM)
+
+| Coin | h | vs persistence | vs ewma | vs log_har | vs har_rv |
+|---|---:|---|---|---|---|
+| BTC | 1 | **BEATS** +40,7 % (p<1e-4) | **BEATS** +20,1 % (p<1e-4) | **BEATS** +19,7 % (p<1e-4) | **BEATS** +40,7 % (p<1e-4) |
+| BTC | 5 | **BEATS** +56,2 % | INCONCLUSIVE +5,4 % (p=0,116) | **BEATS** +8,5 % (p=0,0015) | **BEATS** +56,2 % |
+| BTC | 22 | **BEATS** +46,5 % | **BEATS** +10,7 % (p=0,016) | INCONCLUSIVE −4,8 % (p=0,232) | **BEATS** +46,5 % |
+| ETH | 1 | **BEATS** +30,6 % | **BEATS** +10,5 % | **BEATS** +7,6 % | **BEATS** +30,6 % |
+| ETH | 5 | **BEATS** +49,7 % | INCONCLUSIVE +4,1 % (p=0,381) | **BEATS** +10,7 % (p=2e-4) | **BEATS** +49,7 % |
+| ETH | 22 | **BEATS** +47,2 % | **BEATS** +11,9 % (p=0,029) | **BEATS** +12,5 % (p=0,0445) | **BEATS** +47,2 % |
+
+**Lecture honnête.** Contre la baseline qui compte (Log-HAR) :
+**5/6 BEATS, 1/6 INCONCLUSIVE, 0/6 NO BEATS**. Deux réserves explicites :
+(i) BTC h=22 : le log-HAR est numériquement meilleur (edge −4,8 %) mais pas
+significativement (p=0,23) — INCONCLUSIVE, pas NO BEATS ; (ii) ETH h=22 :
+BEATS au bord du seuil (p=0,0445, à peine < 0,05) — fragile, à ne pas
+sur-vendre. Le verdict global « TimesFM 2.5 zero-shot bat Log-HAR sur RV
+crypto quotidienne aux horizons 1-22 j » tient sur 4 cellules solides
+(p ≤ 0,0015), pas sur les deux bordelines.
+
+La littérature citée en tête (TSFM non uniformément supérieur, Log-HAR très
+compétitif) est **partiellement confirmée** : Log-HAR résiste au plus long
+horizon BTC, l'avantage TSFM est net aux horizons courts/moyens.
+
+### Dégénérescence empirique de har_rv ≈ persistence
+
+Sur ce panel, le HAR en **niveaux** dégénère en quasi-persistence : les
+prévisions des deux modèles coïncident au point que leurs MSE sont égales à
+6 décimales et leurs edges identiques (ex. BTC h=1 : +40,7 % contre les
+deux). Les hashs SHA256 des prévisions **diffèrent** (écarts au niveau
+flottant, pas un bug de dispatch) : c'est l'artefact connu du HAR en
+niveaux sur séries très persistantes (poids OLS quasi tout sur le lag
+journalier ≈ reproduction de la dernière valeur). La spécification
+informativ­e est le log — d'où log_har comme baseline de référence.
+
+### Calibration quantile native (évaluée à l'étape h)
+
+| Config | couverture 80 % (nominal 0,80) | largeur | pinball q=0,5 |
+|---|---|---|---|
+| BTC h=1 | 0,814 | 2,053 | 0,313 |
+| BTC h=5 | 0,801 | 2,313 | 0,356 |
+| BTC h=22 | 0,794 | 2,672 | 0,418 |
+| ETH h=1 | 0,806 | 1,971 | 0,307 |
+| ETH h=5 | 0,795 | 2,225 | 0,350 |
+| ETH h=22 | 0,774 | 2,541 | 0,406 |
+
+Couverture 80 % mesurée entre 0,774 et 0,814 pour un nominal de 0,80 :
+**calibration quantile remarquablement honnête zero-shot**, sans aucun
+ajustement. La largeur croît avec l'horizon comme attendu (2,0 → 2,7 en
+log-RV). Pinball complet par niveau dans le manifeste.
+
+### Biais par fold (extraits, BTC h=1)
+
+`per_fold_bias` (queue d'entraînement, 60 j, signe +) : log_har
+[+0,59, +0,21, …], tsfm [+0,34, −0,01, …], persistence [+0,005, −0,020, …].
+Le débiais symétrique est appliqué à TOUS les modèles — aucun ne reçoit de
+calibration que les autres n'ont pas (leçon M17 round-3).
+
+## Coûts
+
+Non applicables au verdict de forecast pur (aucun claim Sharpe/P&L, aucune
+étape économique — hors scope #14768 jusqu'à une étape séparée).
+
+## Reproduction
+
+```bash
+python scripts/m18_tsfm_benchmark.py --coins BTC-USD ETH-USD \
+    --horizons 1 5 22 --seeds 0 7 42 99 --skip-remote \
+    --out-json scripts/results/m18_tsfm_benchmark.json
+```
+
+Environnement : `mcp-jupyter-py310` (torch 2.6.0+cu124, timesfm 3.0.1,
+checkpoint `google/timesfm-2.5-200m-pytorch` SHA consigné dans le manifeste).
+Inférence GPU déterministe (vérifiée : appels répétés bit-identiques) — les
+4 seeds servent d'audit de bit-identité, précédent M17 OLS.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m18_tsfm_benchmark.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m18_tsfm_benchmark.py
@@ -1,0 +1,719 @@
+"""M18 — TimesFM 2.5 zero-shot vs classical baselines on realized variance.
+
+Issue #14768: benchmark TimesFM 2.5 (Apache-2.0) against HAR / Log-HAR /
+persistence / EWMA on daily realized variance, under the §C barème of
+`pr-review-discipline.md` (walk-forward 5 folds, >=4 seeds, Diebold-Mariano
+HAC+HLN, honest verdict BEATS / NO BEATS / INCONCLUSIVE).
+
+Design mirrors `har_lj_asym.py` round-3/4 (M17):
+- target = h-day mean of log-RV (`rolling(h).mean().shift(-h)`),
+- expanding-window 5-fold walk-forward, fold_size = n // (n_splits + 1),
+- per-fold bias calibration from the TRAIN TAIL ONLY, applied SYMMETRICALLY
+  to every model as ``yhat_debiased = yhat + bias`` (round-3 sign fix),
+- `bounds_train_test` provenance per (coin, horizon),
+- panel hash on the canonical 360-bar window, forecast hashes per fold for
+  cross-seed bit-identity audit.
+
+Models (all predict the SAME target on the SAME test indices):
+- persistence : last observed log-RV (naive random-walk baseline)
+- ewma        : exponentially-weighted mean of log-RV, span selected on the
+                train tail ONLY among {5, 10, 20, 60}
+- log_har     : OLS HAR(1d,5d,22d) on log-RV lags (`har_model.HARModel`),
+                iterated h-step path, prediction = mean of the log path
+- har_rv      : same HAR structure fit on RV LEVELS (native RV-scale HAR),
+                iterated h-step path in RV, prediction = log(mean RV path)
+- tsfm        : TimesFM 2.5-200M zero-shot, batched per fold, direct
+                multi-horizon path from the last `context_len` log-RV
+                points, prediction = mean of the first h steps of the
+                point path (point = median channel).
+
+TimesFM tensor layout (verified empirically, see tests): the last axis of
+the quantile output is ``[mean, q0.1, q0.2, ..., q0.9]`` — 10 channels —
+and the point output equals channel 5 (the median). Quantile columns are
+therefore addressed as ``1 + i`` over ``TSFM_QUANTILES``.
+
+Fail-explicit contract (#14768 "gardes anti-faux modèle"): if the real
+TimesFM checkpoint cannot be loaded or a forecast call raises, the script
+aborts with a non-zero exit — there is NO fallback and nothing else may be
+reported under the TimesFM label.
+
+Usage:
+    python m18_tsfm_benchmark.py --coins BTC-USD --skip-remote --debias \
+        --horizons 1 5 22 --seeds 0 7 42 99 \
+        --out-json scripts/results/m18_tsfm_benchmark.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+from realized_variance import daily_realized_variance, realized_variance_to_log
+from dm_test import dm_verdict
+from har_model import HARModel
+from har_asymmetric import _load_panel
+from har_lj_asym import _panel_hash
+
+HORIZONS_DEFAULT = [1, 5, 22]  # issue #14768 protocol (not the M4/M17 1/5/10)
+SEEDS_DEFAULT = [0, 7, 42, 99]
+N_SPLITS = 5
+CALIBRATION_SIZE = 60  # train-tail size for per-fold bias estimation
+REFIT_EVERY = 22
+CONTEXT_LEN_DEFAULT = 512  # log-RV days fed to TimesFM (<= model 2048)
+EWMA_SPAN_GRID = [5, 10, 20, 60]
+TSFM_REPO_ID = "google/timesfm-2.5-200m-pytorch"
+# TimesFM 2.5 native quantile head (model config, verified: [0.1..0.9]).
+TSFM_QUANTILES = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+# Quantile tensor last axis = [mean, q0.1, ..., q0.9]: channel 0 is the mean
+# head, quantile i lives at column 1 + i. Channel 5 == median == point output.
+TSFM_QUANT_COL_OFFSET = 1
+MODELS = ["persistence", "ewma", "log_har", "har_rv", "tsfm"]
+BASELINES = [m for m in MODELS if m != "tsfm"]
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def qlike_loss(rv_true: np.ndarray, rv_pred: np.ndarray) -> float:
+    """Patton (2011) QLIKE robust loss on the RV scale.
+
+    Both inputs must be strictly positive. Log-scale forecasts are converted
+    with exp() upstream, which is always positive, so the guard is an
+    assertion on the contract rather than a clipping workaround.
+    """
+    rv_true = np.asarray(rv_true, dtype=float)
+    rv_pred = np.asarray(rv_pred, dtype=float)
+    if np.any(rv_pred <= 0) or np.any(rv_true <= 0):
+        raise ValueError("QLIKE requires strictly positive forecasts/targets")
+    ratio = rv_true / rv_pred
+    return float(np.mean(ratio - np.log(ratio) - 1.0))
+
+
+def pinball_loss(y: np.ndarray, yhat_q: np.ndarray, q: float) -> float:
+    """Mean pinball (quantile) loss at level q."""
+    y = np.asarray(y, dtype=float)
+    yhat_q = np.asarray(yhat_q, dtype=float)
+    diff = y - yhat_q
+    return float(np.mean(np.maximum(q * diff, (q - 1.0) * diff)))
+
+
+def interval_coverage(
+    y: np.ndarray, lower: np.ndarray, upper: np.ndarray
+) -> tuple[float, float]:
+    """Empirical coverage and mean width of a prediction interval."""
+    y = np.asarray(y, dtype=float)
+    lower = np.asarray(lower, dtype=float)
+    upper = np.asarray(upper, dtype=float)
+    if np.any(upper < lower):
+        raise ValueError("upper band below lower band (quantile crossing)")
+    coverage = float(np.mean((y >= lower) & (y <= upper)))
+    width = float(np.mean(upper - lower))
+    return coverage, width
+
+
+# ---------------------------------------------------------------------------
+# Baseline forecasters (deterministic, refit on expanding window)
+# ---------------------------------------------------------------------------
+
+def _har_rv_features(rv: pd.Series) -> pd.DataFrame:
+    """Daily / weekly / monthly means of RV LEVELS (Corsi 2009 plain spec)."""
+    rv = rv.astype(float)
+    return pd.DataFrame({
+        "rv_d": rv,
+        "rv_w": rv.rolling(5).mean(),
+        "rv_m": rv.rolling(22).mean(),
+    })
+
+
+class HarRvModel:
+    """OLS HAR(1d,5d,22d) on RV levels with iterated h-step RV path."""
+
+    def __init__(self) -> None:
+        self.coef: np.ndarray | None = None
+
+    def fit(self, rv_train: pd.Series) -> "HarRvModel":
+        feats = _har_rv_features(rv_train)
+        target = rv_train.rename("y")
+        df = pd.concat([feats, target], axis=1).dropna()
+        if len(df) < 30:
+            raise ValueError(f"HAR-RV fit needs >=30 obs after lags, got {len(df)}")
+        x = df[["rv_d", "rv_w", "rv_m"]].to_numpy()
+        y = df["y"].to_numpy()
+        x_aug = np.column_stack([np.ones(len(x)), x])
+        self.coef, *_ = np.linalg.lstsq(x_aug, y, rcond=None)
+        return self
+
+    def _step_features(self, history: list[float]) -> np.ndarray:
+        tail = pd.Series(history[-22:])
+        return np.array([
+            1.0,
+            float(tail.iloc[-1]),
+            float(tail.iloc[-5:].mean()),
+            float(tail.iloc[-22:].mean()),
+        ])
+
+    def predict_h_step_mean_log(self, rv_history: pd.Series, horizon: int) -> float:
+        """Iterated h-step RV path; returns log(mean of the RV path).
+
+        The model forecasts natively in RV levels and is projected onto the
+        common log-scale evaluation target as log(mean RV path) — the same
+        functional of the future the other models predict in log space.
+        """
+        if self.coef is None:
+            raise RuntimeError("HarRvModel.predict before fit()")
+        history = list(rv_history.astype(float).values)
+        path: list[float] = []
+        for _ in range(horizon):
+            rv_pred = float(self._step_features(history) @ self.coef)
+            path.append(max(rv_pred, 1e-12))
+            history.append(rv_pred)
+        return float(np.log(np.mean(path)))
+
+
+class TimesFMWrapper:
+    """TimesFM 2.5-200M zero-shot forecaster with fail-explicit contract.
+
+    ``loader`` is injected so tests can pass a deterministic fake; production
+    code uses :meth:`production_loader`, which imports timesfm lazily and
+    aborts on ANY failure — no silent fallback may ever serve forecasts
+    under the TimesFM label (#14768 garde anti-faux modèle).
+    """
+
+    def __init__(self, repo_id: str, context_len: int,
+                 loader=None, revision: str | None = None) -> None:
+        self.repo_id = repo_id
+        self.context_len = context_len
+        self.n_calls = 0  # individual series actually served by the model
+        self.revision = revision
+        if loader is not None:
+            self._model = loader(repo_id)
+        else:
+            self._model = None
+        self._loader = loader
+
+    @classmethod
+    def production_loader(cls, repo_id: str, context_len: int) -> "TimesFMWrapper":
+        import timesfm  # lazy: keeps torch off the test-import path
+        from huggingface_hub import HfApi
+
+        try:
+            info = HfApi().model_info(repo_id)
+            revision = getattr(info, "sha", None)
+        except Exception as exc:  # provenance must not silently degrade
+            raise RuntimeError(f"TimesFM provenance lookup failed for {repo_id}: {exc}")
+        try:
+            model = timesfm.TimesFM_2p5_200M_torch.from_pretrained(
+                repo_id, torch_compile=False,
+            )
+            model.compile(timesfm.ForecastConfig(
+                max_context=context_len, max_horizon=128,
+                per_core_batch_size=32,
+            ))
+        except Exception as exc:
+            raise RuntimeError(
+                f"TimesFM checkpoint {repo_id} failed to load/compile — "
+                f"aborting, no fallback allowed (#14768): {exc}"
+            )
+        wrapper = cls(repo_id=repo_id, context_len=context_len, revision=revision)
+        wrapper._model = model
+        return wrapper
+
+    def forecast_paths(
+        self, contexts: list[np.ndarray], horizon: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Batched forecast. Returns (point (B, h), quantiles (B, h, 1+9))."""
+        if self._model is None:
+            raise RuntimeError("TimesFM model not loaded — aborting (#14768)")
+        point, quant = self._model.forecast(horizon=horizon, inputs=list(contexts))
+        self.n_calls += len(contexts)
+        point = np.asarray(point, dtype=float)[:, :horizon]
+        quant = np.asarray(quant, dtype=float)[:, :horizon, :]
+        if point.shape[1] < horizon or quant.shape[1] < horizon:
+            raise RuntimeError(
+                f"TimesFM returned shorter horizon than requested "
+                f"({point.shape} < {horizon})"
+            )
+        if quant.shape[2] != TSFM_QUANT_COL_OFFSET + len(TSFM_QUANTILES):
+            raise RuntimeError(
+                f"TimesFM quantile axis has {quant.shape[2]} channels, expected "
+                f"{TSFM_QUANT_COL_OFFSET + len(TSFM_QUANTILES)} ([mean, q0.1..q0.9])"
+            )
+        return point, quant
+
+
+def _tsfm_batch_predictions(
+    log_rv: np.ndarray, indices: list[int], horizon: int, tsfm: TimesFMWrapper,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Batched zero-shot predictions at ``indices``.
+
+    Returns (pred_mean_path (len,), quantiles_last_step (len, 1+9)). The
+    point prediction is the mean of the first h steps of the median path;
+    the quantiles are the native bands at step h. One forecast call per
+    batch — the calibration pass and the OOS pass never re-forecast the
+    same context twice.
+    """
+    contexts = [log_rv[max(0, i - tsfm.context_len):i].astype(np.float32)
+                for i in indices]
+    point, quant = tsfm.forecast_paths(contexts, horizon)
+    preds = point[:, :horizon].mean(axis=1)
+    return preds, quant[:, horizon - 1, :]
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward harness — one protocol for ALL models (M17 round-3 symmetry)
+# ---------------------------------------------------------------------------
+
+def _rolling_predictions(
+    model_name: str,
+    log_rv: np.ndarray,
+    rv: pd.Series,
+    indices: list[int],
+    horizon: int,
+    refit_every: int = REFIT_EVERY,
+    ewma_span: int | None = None,
+) -> np.ndarray:
+    """Rolling h-step predictions of the h-day mean log-RV at ``indices``.
+
+    Deterministic models only (tsfm is batched separately). Strictly causal:
+    the prediction for index i uses log_rv[:i] only — the target
+    mean(log_rv[i:i+h]) is never touched.
+    """
+    preds = np.empty(len(indices), dtype=float)
+    log_har: HARModel | None = None
+    har_rv: HarRvModel | None = None
+    last_fit = -10**9
+
+    for out_i, i in enumerate(indices):
+        if model_name in ("log_har", "har_rv") and i - last_fit >= refit_every:
+            train = rv.iloc[:i]
+            if model_name == "log_har":
+                log_har = HARModel().fit(train)
+            else:
+                har_rv = HarRvModel().fit(train)
+            last_fit = i
+
+        if model_name == "persistence":
+            preds[out_i] = log_rv[i - 1]
+        elif model_name == "ewma":
+            if ewma_span is None:
+                raise ValueError("ewma model requires ewma_span")
+            s = pd.Series(log_rv[:i])
+            preds[out_i] = float(s.ewm(span=ewma_span).mean().iloc[-1])
+        elif model_name == "log_har":
+            assert log_har is not None
+            preds[out_i] = log_har.predict_h_step(rv.iloc[:i], horizon=horizon)
+        elif model_name == "har_rv":
+            assert har_rv is not None
+            preds[out_i] = har_rv.predict_h_step_mean_log(rv.iloc[:i], horizon=horizon)
+        else:
+            raise ValueError(f"unknown/non-deterministic model {model_name!r}")
+    return preds
+
+
+def _select_ewma_span(
+    log_rv: np.ndarray, train_end: int, horizon: int,
+    calibration_size: int = CALIBRATION_SIZE,
+) -> int:
+    """Pick the EWMA span minimizing train-tail MSE (train info only)."""
+    cal_start = max(22 + horizon, train_end - calibration_size)
+    idx = [i for i in range(cal_start, train_end) if i + horizon <= train_end]
+    if not idx:
+        return EWMA_SPAN_GRID[2]
+    targets = np.array([log_rv[i:i + horizon].mean() for i in idx])
+    series = pd.Series(log_rv[:train_end])
+    ewm_all = {span: series.ewm(span=span).mean().values
+               for span in EWMA_SPAN_GRID}
+    best_span, best_mse = EWMA_SPAN_GRID[2], np.inf
+    for span in EWMA_SPAN_GRID:
+        preds = np.array([ewm_all[span][i - 1] for i in idx])
+        mse = float(np.mean((preds - targets) ** 2))
+        if mse < best_mse:
+            best_span, best_mse = span, mse
+    return best_span
+
+
+def _fold_bounds(n: int, n_splits: int) -> list[dict[str, int]]:
+    """Expanding-window folds, same arithmetic as har_model._make_split_indices.
+
+    Target validity (``i + horizon <= n``) is enforced per index downstream;
+    bounds themselves stay horizon-agnostic so the provenance always reports
+    the full fold plan of the canonical splitter.
+    """
+    fold_size = n // (n_splits + 1)
+    bounds = []
+    for fold in range(n_splits):
+        split = (fold + 1) * fold_size
+        test_end = min(split + fold_size, n)
+        if split >= test_end:
+            break
+        bounds.append({
+            "fold_idx": int(fold),
+            "train_end_idx": int(split),
+            "oos_start_idx": int(split),
+            "oos_end_idx": int(test_end),
+            "n_train": int(split),
+            "n_oos": int(test_end - split),
+        })
+    return bounds
+
+
+def _sha256_array(arr: np.ndarray) -> str:
+    return hashlib.sha256(
+        np.ascontiguousarray(arr, dtype=np.float64).tobytes()
+    ).hexdigest()
+
+
+def run_config(
+    coin: str,
+    hourly_rets: pd.Series,
+    horizon: int,
+    seed: int,
+    n_splits: int,
+    calibration_size: int,
+    refit_every: int,
+    tsfm: TimesFMWrapper | None,
+    debias: bool = True,
+) -> dict:
+    """One (coin, horizon, seed) evaluation of all models under one protocol."""
+    rv = daily_realized_variance(hourly_rets).dropna()
+    if len(rv) < 300:
+        return {"coin": coin, "horizon": horizon, "seed": seed,
+                "skipped": f"rv<300 ({len(rv)})"}
+
+    log_rv_series = realized_variance_to_log(rv)
+    log_rv = log_rv_series.to_numpy(dtype=float)
+    n = len(log_rv)
+    folds = _fold_bounds(n, n_splits)
+    if not folds:
+        return {"coin": coin, "horizon": horizon, "seed": seed,
+                "skipped": f"no fold fits (n={n})"}
+    # HAR monthly lag (22) + minimum fit size (30 post-lag) + margin: the
+    # first fold's training window must clear the HAR lags or every refit
+    # inside the walk-forward would raise.
+    if folds[0]["train_end_idx"] < 100:
+        return {"coin": coin, "horizon": horizon, "seed": seed,
+                "skipped": f"first fold too short for HAR lags "
+                           f"({folds[0]['train_end_idx']} days)"}
+
+    rows: dict[str, dict] = {}
+    fc_hashes: dict[str, list[str]] = {}
+    per_fold_bias_out: dict[str, list[float]] = {}
+    # tsfm-only: last-step native quantiles on the OOS points (per fold)
+    tsfm_quant_folds: list[np.ndarray] = []
+    tsfm_y_folds: list[np.ndarray] = []
+    # per-model debiased OOS forecasts + common target, for in-situ DM
+    deb_arrays: dict[str, np.ndarray] = {}
+    tgt_concat: np.ndarray | None = None
+
+    for model in MODELS:
+        raw_all, deb_all, tgt_all = [], [], []
+        biases: list[float] = []
+        hashes: list[str] = []
+        quant_folds: list[np.ndarray] = []
+        y_folds: list[np.ndarray] = []
+
+        for fold in folds:
+            train_end = fold["train_end_idx"]
+            oos = [i for i in range(fold["oos_start_idx"], fold["oos_end_idx"])
+                   if i + horizon <= n]
+            if not oos:
+                continue
+
+            # Per-fold train-tail bias (M17 round-3: debiased = yhat + bias,
+            # estimated on the TRAIN TAIL only, never on OOS targets).
+            cal_start = max(22 + horizon, train_end - calibration_size)
+            cal_idx = [i for i in range(cal_start, train_end)
+                       if i + horizon <= train_end]
+            if cal_idx and debias:
+                if model == "tsfm":
+                    assert tsfm is not None
+                    cal_pred, _ = _tsfm_batch_predictions(
+                        log_rv, cal_idx, horizon, tsfm)
+                else:
+                    ewma_span = (_select_ewma_span(log_rv, train_end, horizon,
+                                                   calibration_size)
+                                 if model == "ewma" else None)
+                    cal_pred = _rolling_predictions(
+                        model, log_rv, rv.iloc[:train_end], cal_idx, horizon,
+                        refit_every, ewma_span)
+                cal_tgt = np.array([log_rv[i:i + horizon].mean() for i in cal_idx])
+                bias = float(np.mean(cal_tgt - cal_pred))
+            else:
+                bias = 0.0
+            biases.append(bias)
+
+            if model == "tsfm":
+                assert tsfm is not None
+                oos_pred, quant_last = _tsfm_batch_predictions(
+                    log_rv, oos, horizon, tsfm)
+                quant_folds.append(quant_last)
+                y_folds.append(log_rv[[i + horizon - 1 for i in oos]])
+            else:
+                ewma_span = (_select_ewma_span(log_rv, train_end, horizon,
+                                               calibration_size)
+                             if model == "ewma" else None)
+                oos_pred = _rolling_predictions(
+                    model, log_rv, rv, oos, horizon, refit_every, ewma_span)
+            oos_tgt = np.array([log_rv[i:i + horizon].mean() for i in oos])
+
+            raw_all.extend(oos_pred.tolist())
+            deb_all.extend((oos_pred + bias).tolist())
+            tgt_all.extend(oos_tgt.tolist())
+            hashes.append(_sha256_array(oos_pred))
+
+        raw = np.array(raw_all)
+        deb = np.array(deb_all)
+        tgt = np.array(tgt_all)
+        rv_tgt = np.exp(tgt)  # RV-scale realized proxy for QLIKE
+        rows[model] = {
+            "mse_raw": float(np.mean((raw - tgt) ** 2)),
+            "mse_debiased": float(np.mean((deb - tgt) ** 2)),
+            "mae_debiased": float(np.mean(np.abs(deb - tgt))),
+            "qlike_debiased": qlike_loss(rv_tgt, np.exp(deb)),
+            "signed_bias_debiased": float(np.mean(deb - tgt)),
+            "n_oos": int(len(tgt)),
+        }
+        fc_hashes[model] = hashes
+        per_fold_bias_out[model] = biases
+        deb_arrays[model] = deb
+        tgt_concat = tgt
+        if model == "tsfm":
+            tsfm_quant_folds = quant_folds
+            tsfm_y_folds = y_folds
+
+    # In-situ DM, two legs per amended §C (#11010): the CONJUNCTION verdict
+    # uses a PRECISION loss ("mse"); the "linear" leg (raw signed errors) is
+    # the bias-control diagnostic and is never the conjunction jambe. Both
+    # run where the arrays live — never reconstructed from summaries.
+    dm_out: dict[str, dict] = {}
+    dm_linear_out: dict[str, dict] = {}
+    for baseline in BASELINES:
+        err_t = deb_arrays["tsfm"] - tgt_concat
+        err_b = deb_arrays[baseline] - tgt_concat
+        dm_out[baseline] = dm_verdict(err_t, err_b, horizon=horizon,
+                                      loss_fn="mse")
+        dm_linear_out[baseline] = dm_verdict(err_t, err_b, horizon=horizon,
+                                             loss_fn="linear")
+
+    out = {
+        "coin": coin,
+        "horizon": horizon,
+        "seed": seed,
+        "models": rows,
+        "dm_vs_baselines_mse": dm_out,
+        "dm_vs_baselines_linear": dm_linear_out,
+        "per_fold_bias": per_fold_bias_out,
+        "fc_hash_per_fold": fc_hashes,
+        "n_oos": rows[MODELS[0]]["n_oos"],
+        "bounds_train_test": folds[0] | {
+            "n_total": int(n),
+            "fold_size": int(folds[0]["n_oos"]),
+            "n_folds": int(len(folds)),
+        },
+        "panel_hash": _panel_hash(rv),
+    }
+
+    # TimesFM native quantile evaluation at step h. The quantiles target
+    # realized log_rv at step h — a different functional than the h-day
+    # mean used for point forecasts; both are recorded, never mixed.
+    if tsfm_quant_folds:
+        quant = np.vstack(tsfm_quant_folds)
+        y = np.concatenate(tsfm_y_folds)
+        qs = np.array(TSFM_QUANTILES)
+        col = {q: TSFM_QUANT_COL_OFFSET + int(np.argmin(np.abs(qs - q)))
+               for q in (0.1, 0.5, 0.9)}
+        pinball = {}
+        for j, q in enumerate(TSFM_QUANTILES):
+            pinball[str(q)] = pinball_loss(y, quant[:, TSFM_QUANT_COL_OFFSET + j], q)
+        cov80, width80 = interval_coverage(
+            y, quant[:, col[0.1]], quant[:, col[0.9]])
+        out["tsfm_quantiles"] = {
+            "pinball_loss": pinball,
+            "coverage_80": cov80,
+            "width_80": width80,
+            "nominal_80": 0.8,
+            "n_obs": int(len(y)),
+            "note": "quantiles evaluated on realized log_rv at step h (direct); "
+                    "point forecasts on the h-day mean target — separate "
+                    "functionals, never mixed",
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Aggregate verdict (§C strict)
+# ---------------------------------------------------------------------------
+
+def _coherent(dm: dict, direction: str) -> bool:
+    if dm.get("verdict") != f"{direction} baseline":
+        return False
+    if dm.get("p_value", 1.0) >= 0.05:
+        return False
+    diff = dm.get("mean_loss_diff", 0.0)
+    return diff < 0.0 if direction == "BEATS" else diff > 0.0
+
+
+def aggregate_verdicts(configs: list[dict]) -> list[dict]:
+    """Group per-(coin, horizon) DM verdicts of tsfm vs each baseline.
+
+    §C conjunction (amended #11010): BEATS requires dm_p_median < 0.05 on
+    the MSE leg AND coherent DM wins on every seed AND (edge >= 2 sigma
+    cross-seed, or the seeds are bit-identical in which case the sigma
+    jambe is degenerate — M17 OLS precedent: determinism makes edge/sigma
+    non-applicable, not artificially infinite). The linear leg is reported
+    as a bias diagnostic and never gates the verdict.
+    """
+    groups: dict[tuple, list[dict]] = {}
+    for c in configs:
+        if "skipped" in c:
+            continue
+        groups.setdefault((c["coin"], c["horizon"]), []).append(c)
+
+    out = []
+    for (coin, horizon), rows in sorted(groups.items()):
+        for baseline in BASELINES:
+            dm_rows, dm_lin, edges = [], [], []
+            for r in rows:
+                dm = r.get("dm_vs_baselines_mse", {}).get(baseline)
+                if dm is None:
+                    continue
+                dm_rows.append(dm)
+                dm_lin.append(r.get("dm_vs_baselines_linear", {})
+                              .get(baseline, {}).get("p_value"))
+                ts = r["models"]["tsfm"]["mse_debiased"]
+                base = r["models"][baseline]["mse_debiased"]
+                edges.append((base - ts) / base * 100.0)
+            if not dm_rows:
+                continue
+            edge = float(np.mean(edges))
+            sigma = float(np.std(edges, ddof=1)) if len(edges) > 1 else 0.0
+            p_med = float(np.median([d["p_value"] for d in dm_rows]))
+            n_beats = sum(1 for d in dm_rows if _coherent(d, "BEATS"))
+            n_been = sum(1 for d in dm_rows if _coherent(d, "BEATEN BY"))
+            identical = len({
+                tuple(r["fc_hash_per_fold"]["tsfm"]) for r in rows
+            }) == 1
+            if n_beats == len(dm_rows) and p_med < 0.05 and (
+                identical or edge >= 2.0 * sigma
+            ):
+                verdict = "BEATS"
+            elif n_been == len(dm_rows) and p_med < 0.05:
+                verdict = "NO BEATS"
+            else:
+                verdict = "INCONCLUSIVE"
+            out.append({
+                "coin": coin, "horizon": horizon, "baseline": baseline,
+                "edge_pct_mean": edge, "edge_sigma_cross_seed": sigma,
+                "dm_p_median": p_med,
+                "dm_p_median_linear_leg": float(np.median(
+                    [p for p in dm_lin if p is not None])) if any(
+                    p is not None for p in dm_lin) else None,
+                "n_seeds": len(dm_rows),
+                "n_coherent_beats": n_beats, "n_coherent_beaten_by": n_been,
+                "seeds_bit_identical": identical,
+                "verdict": verdict,
+            })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="M18 TimesFM 2.5 zero-shot vs classical baselines (#14768)")
+    parser.add_argument("--coins", nargs="+", default=["BTC-USD"])
+    parser.add_argument("--horizons", nargs="+", type=int, default=HORIZONS_DEFAULT)
+    parser.add_argument("--seeds", nargs="+", type=int, default=SEEDS_DEFAULT)
+    parser.add_argument("--n-splits", type=int, default=N_SPLITS)
+    parser.add_argument("--calibration-size", type=int, default=CALIBRATION_SIZE)
+    parser.add_argument("--refit-every", type=int, default=REFIT_EVERY)
+    parser.add_argument("--context-len", type=int, default=CONTEXT_LEN_DEFAULT)
+    parser.add_argument("--skip-remote", action="store_true",
+                        help="use cached BTC+ETH hourly data only")
+    parser.add_argument("--debias", action="store_true", default=True)
+    parser.add_argument("--no-debias", dest="debias", action="store_false")
+    parser.add_argument("--out-json", type=Path,
+                        default=RESULTS_DIR / "m18_tsfm_benchmark.json")
+    args = parser.parse_args()
+
+    t0 = time.time()
+    tsfm = TimesFMWrapper.production_loader(TSFM_REPO_ID, args.context_len)
+    print(f"[tsfm] loaded {TSFM_REPO_ID} @ {tsfm.revision} "
+          f"in {time.time()-t0:.1f}s", flush=True)
+
+    print("[load] panel ...", flush=True)
+    panel = _load_panel(args.skip_remote)
+
+    configs: list[dict] = []
+    for coin in args.coins:
+        if coin not in panel:
+            print(f"[WARN] {coin} not in panel — skipped")
+            continue
+        for horizon in args.horizons:
+            for seed in args.seeds:
+                try:
+                    import torch
+                    torch.manual_seed(seed)
+                except ImportError as exc:
+                    raise SystemExit(
+                        f"torch unavailable — TimesFM cannot run (#14768): {exc}")
+                np.random.seed(seed)
+                t1 = time.time()
+                cfg = run_config(
+                    coin, panel[coin], horizon, seed, args.n_splits,
+                    args.calibration_size, args.refit_every, tsfm,
+                    debias=args.debias,
+                )
+                configs.append(cfg)
+                if "skipped" in cfg:
+                    print(f"  [{coin} h={horizon} s={seed}] SKIPPED: "
+                          f"{cfg['skipped']}", flush=True)
+                    continue
+                ts = cfg["models"]["tsfm"]["mse_debiased"]
+                print(f"  [{coin} h={horizon} s={seed}] tsfm mse_deb={ts:.4f} "
+                      f"({time.time()-t1:.1f}s)", flush=True)
+
+    summary = aggregate_verdicts(configs)
+    manifest = {
+        "module": "M18",
+        "issue": 14768,
+        "repo_id": TSFM_REPO_ID,
+        "checkpoint_revision": tsfm.revision,
+        "n_tsfm_series_served": tsfm.n_calls,
+        "context_len": args.context_len,
+        "n_splits": args.n_splits,
+        "calibration_size": args.calibration_size,
+        "refit_every": args.refit_every,
+        "quantile_levels": TSFM_QUANTILES,
+        "quantile_layout": "[mean, q0.1..q0.9] on the last axis; point = median",
+        "debias": args.debias,
+        "configs": configs,
+        "summary": summary,
+        "elapsed_s": round(time.time() - t0, 1),
+    }
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(manifest, indent=1), encoding="utf-8")
+    print(f"[done] wrote {args.out_json} "
+          f"({tsfm.n_calls} TimesFM series served)", flush=True)
+    for s in summary:
+        print(f"  {s['coin']} h={s['horizon']} vs {s['baseline']}: "
+              f"{s['verdict']} (edge {s['edge_pct_mean']:+.1f}%, "
+              f"p_med {s['dm_p_median']:.4f})", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m18_tsfm_benchmark.json
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m18_tsfm_benchmark.json
@@ -1,0 +1,6029 @@
+{
+ "module": "M18",
+ "issue": 14768,
+ "repo_id": "google/timesfm-2.5-200m-pytorch",
+ "checkpoint_revision": "1d952420fba87f3c6dee4f240de0f1a0fbc790e3",
+ "n_tsfm_series_served": 43720,
+ "context_len": 512,
+ "n_splits": 5,
+ "calibration_size": 60,
+ "refit_every": 22,
+ "quantile_levels": [
+  0.1,
+  0.2,
+  0.3,
+  0.4,
+  0.5,
+  0.6,
+  0.7,
+  0.8,
+  0.9
+ ],
+ "quantile_layout": "[mean, q0.1..q0.9] on the last axis; point = median",
+ "debias": true,
+ "configs": [
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "seed": 0,
+   "models": {
+    "persistence": {
+     "mse_raw": 1.171342450201853,
+     "mse_debiased": 1.1718269715401985,
+     "mae_debiased": 0.842743522015501,
+     "qlike_debiased": 0.8679026031197545,
+     "signed_bias_debiased": -0.012943125137100624,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.8616357222426929,
+     "mse_debiased": 0.8703353461752139,
+     "mae_debiased": 0.7181762811710045,
+     "qlike_debiased": 0.6518098090293598,
+     "signed_bias_debiased": -0.025170849757695644,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.8878202518689382,
+     "mse_debiased": 0.8652249324265595,
+     "mae_debiased": 0.7135491389464308,
+     "qlike_debiased": 0.5776163801037217,
+     "signed_bias_debiased": 0.0747362398699257,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 1.1713424502017917,
+     "mse_debiased": 1.1718269715401384,
+     "mae_debiased": 0.8427435220154789,
+     "qlike_debiased": 0.8679026031196735,
+     "signed_bias_debiased": -0.012943125137092832,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.670800307690165,
+     "mse_debiased": 0.6951461480162621,
+     "mae_debiased": 0.6458851535816242,
+     "qlike_debiased": 0.5224361813996501,
+     "signed_bias_debiased": 0.04025327121233176,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.335197205209651,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352393676,
+     "hac_variance": 2.828415070081371,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -7.277264218649959,
+     "p_value": 4.96713781217295e-13,
+     "mean_loss_diff": -0.17518919815895198,
+     "hac_variance": 1.0976359880732378,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -7.431275768060575,
+     "p_value": 1.6187051699034782e-13,
+     "mean_loss_diff": -0.17007878441029742,
+     "hac_variance": 0.9920955583381676,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.335197205209173,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352387625,
+     "hac_variance": 2.8284150700808715,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.3830541849327327,
+     "p_value": 0.01726774944068099,
+     "mean_loss_diff": 0.05319639634943238,
+     "hac_variance": 0.9437925969022312,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.712790485926041,
+     "p_value": 2.6215417354702453e-06,
+     "mean_loss_diff": 0.0654241209700274,
+     "hac_variance": 0.36500557780994697,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.18791790618666,
+     "p_value": 2.944457729880945e-05,
+     "mean_loss_diff": -0.03448296865759395,
+     "hac_variance": 0.12840825667753453,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.3830541849327185,
+     "p_value": 0.017267749440681657,
+     "mean_loss_diff": 0.05319639634942459,
+     "hac_variance": 0.943792596901966,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.004572154259880623,
+     -0.019876300268056927,
+     -0.002489150303865051,
+     -0.009833948609789974,
+     -0.03320066030340752
+    ],
+    "ewma": [
+     0.08869614097001603,
+     -0.10864563519274209,
+     0.012639780308211128,
+     0.002330311514152535,
+     -0.08563797701300802
+    ],
+    "log_har": [
+     0.5947739708325326,
+     0.2109151186093029,
+     0.392740652427628,
+     0.27951172829090115,
+     0.023221895192889086
+    ],
+    "har_rv": [
+     0.004572154259878284,
+     -0.01987630026818521,
+     -0.0024891503038815487,
+     -0.009833948609811424,
+     -0.03320066030346869
+    ],
+    "tsfm": [
+     0.33997103185378413,
+     -0.01376971102597809,
+     0.18165316770775775,
+     0.1269608012787347,
+     -0.09922172525697394
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a3878706681329b0ec038fdca55ca426e8c4600f40bb22c246293c02cb5ad1fb",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "99671078d4817a33c6ef976338304c244daf3ac0a0587354fd5dc4c393b77c19",
+     "25eff9f9083e57678c38e7f45631792a4029f8ea20e279b763cbbbb6735014c0",
+     "48bf7ed2ac1b33dccb4cf9b296a7b11c97540355576d51c2aeb3fc018631129d",
+     "6a2cae4fa8d70f57c0be9252dc0698bbf5a141af92873f9a43454eabd99362eb",
+     "025b343746bbc82415c647f27ba593e983e9c19b987fbf0666db6ee2fb1a5164"
+    ],
+    "har_rv": [
+     "632c2516810d03681bc7bd914707fe9ab27e9458c93a1ffada9933393b3ff897",
+     "0e90482ff5dade1298baa75900962648adc429efdfcd3634fdf83b2a84cb3d56",
+     "232611c8034c925da3b864950e61bb86b91195356c190f65f416baf0f36fe690",
+     "00f468d7361ce5149f2bf5797ffc3cfe19af6ba6701058d9d20632b654f731ec",
+     "84ba0f79d116ed72afab7188faa5f0cd8d4828d3db0cd8ab3c3dd7e8fc075138"
+    ],
+    "tsfm": [
+     "bcce091865a7032e6f71f5a2b87dde2dd7bab1316ecf828b030668e4236d69ee",
+     "535bd6714bbdb28d1210266d633255d4b0f15c9079e9c49bf250968d583df918",
+     "14ea37182edf185e1362297ace3b8dc92a09410159bf3d09eec3a1394a471bbe",
+     "46b33a40be15569403809823353d10846701b8242f6f5a86558713e2a8af29bf",
+     "52108ebfa68d0378a7af9b454e98ef8bfdb1f37669a1d3b19bbdd932fd2c88c5"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.12878020999293707,
+     "0.2": 0.20824239950675738,
+     "0.3": 0.2629615611650728,
+     "0.4": 0.29684484019049745,
+     "0.5": 0.3127241038684024,
+     "0.6": 0.30821138693798106,
+     "0.7": 0.284052340775624,
+     "0.8": 0.2382564618584388,
+     "0.9": 0.1601058791221442
+    },
+    "coverage_80": 0.8137203166226913,
+    "width_80": 2.0528447726156593,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "seed": 7,
+   "models": {
+    "persistence": {
+     "mse_raw": 1.171342450201853,
+     "mse_debiased": 1.1718269715401985,
+     "mae_debiased": 0.842743522015501,
+     "qlike_debiased": 0.8679026031197545,
+     "signed_bias_debiased": -0.012943125137100624,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.8616357222426929,
+     "mse_debiased": 0.8703353461752139,
+     "mae_debiased": 0.7181762811710045,
+     "qlike_debiased": 0.6518098090293598,
+     "signed_bias_debiased": -0.025170849757695644,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.8878202518689382,
+     "mse_debiased": 0.8652249324265595,
+     "mae_debiased": 0.7135491389464308,
+     "qlike_debiased": 0.5776163801037217,
+     "signed_bias_debiased": 0.0747362398699257,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 1.1713424502017917,
+     "mse_debiased": 1.1718269715401384,
+     "mae_debiased": 0.8427435220154789,
+     "qlike_debiased": 0.8679026031196735,
+     "signed_bias_debiased": -0.012943125137092832,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.670800307690165,
+     "mse_debiased": 0.6951461480162621,
+     "mae_debiased": 0.6458851535816242,
+     "qlike_debiased": 0.5224361813996501,
+     "signed_bias_debiased": 0.04025327121233176,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.335197205209651,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352393676,
+     "hac_variance": 2.828415070081371,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -7.277264218649959,
+     "p_value": 4.96713781217295e-13,
+     "mean_loss_diff": -0.17518919815895198,
+     "hac_variance": 1.0976359880732378,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -7.431275768060575,
+     "p_value": 1.6187051699034782e-13,
+     "mean_loss_diff": -0.17007878441029742,
+     "hac_variance": 0.9920955583381676,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.335197205209173,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352387625,
+     "hac_variance": 2.8284150700808715,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.3830541849327327,
+     "p_value": 0.01726774944068099,
+     "mean_loss_diff": 0.05319639634943238,
+     "hac_variance": 0.9437925969022312,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.712790485926041,
+     "p_value": 2.6215417354702453e-06,
+     "mean_loss_diff": 0.0654241209700274,
+     "hac_variance": 0.36500557780994697,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.18791790618666,
+     "p_value": 2.944457729880945e-05,
+     "mean_loss_diff": -0.03448296865759395,
+     "hac_variance": 0.12840825667753453,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.3830541849327185,
+     "p_value": 0.017267749440681657,
+     "mean_loss_diff": 0.05319639634942459,
+     "hac_variance": 0.943792596901966,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.004572154259880623,
+     -0.019876300268056927,
+     -0.002489150303865051,
+     -0.009833948609789974,
+     -0.03320066030340752
+    ],
+    "ewma": [
+     0.08869614097001603,
+     -0.10864563519274209,
+     0.012639780308211128,
+     0.002330311514152535,
+     -0.08563797701300802
+    ],
+    "log_har": [
+     0.5947739708325326,
+     0.2109151186093029,
+     0.392740652427628,
+     0.27951172829090115,
+     0.023221895192889086
+    ],
+    "har_rv": [
+     0.004572154259878284,
+     -0.01987630026818521,
+     -0.0024891503038815487,
+     -0.009833948609811424,
+     -0.03320066030346869
+    ],
+    "tsfm": [
+     0.33997103185378413,
+     -0.01376971102597809,
+     0.18165316770775775,
+     0.1269608012787347,
+     -0.09922172525697394
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a3878706681329b0ec038fdca55ca426e8c4600f40bb22c246293c02cb5ad1fb",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "99671078d4817a33c6ef976338304c244daf3ac0a0587354fd5dc4c393b77c19",
+     "25eff9f9083e57678c38e7f45631792a4029f8ea20e279b763cbbbb6735014c0",
+     "48bf7ed2ac1b33dccb4cf9b296a7b11c97540355576d51c2aeb3fc018631129d",
+     "6a2cae4fa8d70f57c0be9252dc0698bbf5a141af92873f9a43454eabd99362eb",
+     "025b343746bbc82415c647f27ba593e983e9c19b987fbf0666db6ee2fb1a5164"
+    ],
+    "har_rv": [
+     "632c2516810d03681bc7bd914707fe9ab27e9458c93a1ffada9933393b3ff897",
+     "0e90482ff5dade1298baa75900962648adc429efdfcd3634fdf83b2a84cb3d56",
+     "232611c8034c925da3b864950e61bb86b91195356c190f65f416baf0f36fe690",
+     "00f468d7361ce5149f2bf5797ffc3cfe19af6ba6701058d9d20632b654f731ec",
+     "84ba0f79d116ed72afab7188faa5f0cd8d4828d3db0cd8ab3c3dd7e8fc075138"
+    ],
+    "tsfm": [
+     "bcce091865a7032e6f71f5a2b87dde2dd7bab1316ecf828b030668e4236d69ee",
+     "535bd6714bbdb28d1210266d633255d4b0f15c9079e9c49bf250968d583df918",
+     "14ea37182edf185e1362297ace3b8dc92a09410159bf3d09eec3a1394a471bbe",
+     "46b33a40be15569403809823353d10846701b8242f6f5a86558713e2a8af29bf",
+     "52108ebfa68d0378a7af9b454e98ef8bfdb1f37669a1d3b19bbdd932fd2c88c5"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.12878020999293707,
+     "0.2": 0.20824239950675738,
+     "0.3": 0.2629615611650728,
+     "0.4": 0.29684484019049745,
+     "0.5": 0.3127241038684024,
+     "0.6": 0.30821138693798106,
+     "0.7": 0.284052340775624,
+     "0.8": 0.2382564618584388,
+     "0.9": 0.1601058791221442
+    },
+    "coverage_80": 0.8137203166226913,
+    "width_80": 2.0528447726156593,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "seed": 42,
+   "models": {
+    "persistence": {
+     "mse_raw": 1.171342450201853,
+     "mse_debiased": 1.1718269715401985,
+     "mae_debiased": 0.842743522015501,
+     "qlike_debiased": 0.8679026031197545,
+     "signed_bias_debiased": -0.012943125137100624,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.8616357222426929,
+     "mse_debiased": 0.8703353461752139,
+     "mae_debiased": 0.7181762811710045,
+     "qlike_debiased": 0.6518098090293598,
+     "signed_bias_debiased": -0.025170849757695644,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.8878202518689382,
+     "mse_debiased": 0.8652249324265595,
+     "mae_debiased": 0.7135491389464308,
+     "qlike_debiased": 0.5776163801037217,
+     "signed_bias_debiased": 0.0747362398699257,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 1.1713424502017917,
+     "mse_debiased": 1.1718269715401384,
+     "mae_debiased": 0.8427435220154789,
+     "qlike_debiased": 0.8679026031196735,
+     "signed_bias_debiased": -0.012943125137092832,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.670800307690165,
+     "mse_debiased": 0.6951461480162621,
+     "mae_debiased": 0.6458851535816242,
+     "qlike_debiased": 0.5224361813996501,
+     "signed_bias_debiased": 0.04025327121233176,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.335197205209651,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352393676,
+     "hac_variance": 2.828415070081371,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -7.277264218649959,
+     "p_value": 4.96713781217295e-13,
+     "mean_loss_diff": -0.17518919815895198,
+     "hac_variance": 1.0976359880732378,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -7.431275768060575,
+     "p_value": 1.6187051699034782e-13,
+     "mean_loss_diff": -0.17007878441029742,
+     "hac_variance": 0.9920955583381676,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.335197205209173,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352387625,
+     "hac_variance": 2.8284150700808715,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.3830541849327327,
+     "p_value": 0.01726774944068099,
+     "mean_loss_diff": 0.05319639634943238,
+     "hac_variance": 0.9437925969022312,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.712790485926041,
+     "p_value": 2.6215417354702453e-06,
+     "mean_loss_diff": 0.0654241209700274,
+     "hac_variance": 0.36500557780994697,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.18791790618666,
+     "p_value": 2.944457729880945e-05,
+     "mean_loss_diff": -0.03448296865759395,
+     "hac_variance": 0.12840825667753453,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.3830541849327185,
+     "p_value": 0.017267749440681657,
+     "mean_loss_diff": 0.05319639634942459,
+     "hac_variance": 0.943792596901966,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.004572154259880623,
+     -0.019876300268056927,
+     -0.002489150303865051,
+     -0.009833948609789974,
+     -0.03320066030340752
+    ],
+    "ewma": [
+     0.08869614097001603,
+     -0.10864563519274209,
+     0.012639780308211128,
+     0.002330311514152535,
+     -0.08563797701300802
+    ],
+    "log_har": [
+     0.5947739708325326,
+     0.2109151186093029,
+     0.392740652427628,
+     0.27951172829090115,
+     0.023221895192889086
+    ],
+    "har_rv": [
+     0.004572154259878284,
+     -0.01987630026818521,
+     -0.0024891503038815487,
+     -0.009833948609811424,
+     -0.03320066030346869
+    ],
+    "tsfm": [
+     0.33997103185378413,
+     -0.01376971102597809,
+     0.18165316770775775,
+     0.1269608012787347,
+     -0.09922172525697394
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a3878706681329b0ec038fdca55ca426e8c4600f40bb22c246293c02cb5ad1fb",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "99671078d4817a33c6ef976338304c244daf3ac0a0587354fd5dc4c393b77c19",
+     "25eff9f9083e57678c38e7f45631792a4029f8ea20e279b763cbbbb6735014c0",
+     "48bf7ed2ac1b33dccb4cf9b296a7b11c97540355576d51c2aeb3fc018631129d",
+     "6a2cae4fa8d70f57c0be9252dc0698bbf5a141af92873f9a43454eabd99362eb",
+     "025b343746bbc82415c647f27ba593e983e9c19b987fbf0666db6ee2fb1a5164"
+    ],
+    "har_rv": [
+     "632c2516810d03681bc7bd914707fe9ab27e9458c93a1ffada9933393b3ff897",
+     "0e90482ff5dade1298baa75900962648adc429efdfcd3634fdf83b2a84cb3d56",
+     "232611c8034c925da3b864950e61bb86b91195356c190f65f416baf0f36fe690",
+     "00f468d7361ce5149f2bf5797ffc3cfe19af6ba6701058d9d20632b654f731ec",
+     "84ba0f79d116ed72afab7188faa5f0cd8d4828d3db0cd8ab3c3dd7e8fc075138"
+    ],
+    "tsfm": [
+     "bcce091865a7032e6f71f5a2b87dde2dd7bab1316ecf828b030668e4236d69ee",
+     "535bd6714bbdb28d1210266d633255d4b0f15c9079e9c49bf250968d583df918",
+     "14ea37182edf185e1362297ace3b8dc92a09410159bf3d09eec3a1394a471bbe",
+     "46b33a40be15569403809823353d10846701b8242f6f5a86558713e2a8af29bf",
+     "52108ebfa68d0378a7af9b454e98ef8bfdb1f37669a1d3b19bbdd932fd2c88c5"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.12878020999293707,
+     "0.2": 0.20824239950675738,
+     "0.3": 0.2629615611650728,
+     "0.4": 0.29684484019049745,
+     "0.5": 0.3127241038684024,
+     "0.6": 0.30821138693798106,
+     "0.7": 0.284052340775624,
+     "0.8": 0.2382564618584388,
+     "0.9": 0.1601058791221442
+    },
+    "coverage_80": 0.8137203166226913,
+    "width_80": 2.0528447726156593,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "seed": 99,
+   "models": {
+    "persistence": {
+     "mse_raw": 1.171342450201853,
+     "mse_debiased": 1.1718269715401985,
+     "mae_debiased": 0.842743522015501,
+     "qlike_debiased": 0.8679026031197545,
+     "signed_bias_debiased": -0.012943125137100624,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.8616357222426929,
+     "mse_debiased": 0.8703353461752139,
+     "mae_debiased": 0.7181762811710045,
+     "qlike_debiased": 0.6518098090293598,
+     "signed_bias_debiased": -0.025170849757695644,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.8878202518689382,
+     "mse_debiased": 0.8652249324265595,
+     "mae_debiased": 0.7135491389464308,
+     "qlike_debiased": 0.5776163801037217,
+     "signed_bias_debiased": 0.0747362398699257,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 1.1713424502017917,
+     "mse_debiased": 1.1718269715401384,
+     "mae_debiased": 0.8427435220154789,
+     "qlike_debiased": 0.8679026031196735,
+     "signed_bias_debiased": -0.012943125137092832,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.670800307690165,
+     "mse_debiased": 0.6951461480162621,
+     "mae_debiased": 0.6458851535816242,
+     "qlike_debiased": 0.5224361813996501,
+     "signed_bias_debiased": 0.04025327121233176,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.335197205209651,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352393676,
+     "hac_variance": 2.828415070081371,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -7.277264218649959,
+     "p_value": 4.96713781217295e-13,
+     "mean_loss_diff": -0.17518919815895198,
+     "hac_variance": 1.0976359880732378,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -7.431275768060575,
+     "p_value": 1.6187051699034782e-13,
+     "mean_loss_diff": -0.17007878441029742,
+     "hac_variance": 0.9920955583381676,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.335197205209173,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.47668082352387625,
+     "hac_variance": 2.8284150700808715,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.3830541849327327,
+     "p_value": 0.01726774944068099,
+     "mean_loss_diff": 0.05319639634943238,
+     "hac_variance": 0.9437925969022312,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.712790485926041,
+     "p_value": 2.6215417354702453e-06,
+     "mean_loss_diff": 0.0654241209700274,
+     "hac_variance": 0.36500557780994697,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.18791790618666,
+     "p_value": 2.944457729880945e-05,
+     "mean_loss_diff": -0.03448296865759395,
+     "hac_variance": 0.12840825667753453,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.3830541849327185,
+     "p_value": 0.017267749440681657,
+     "mean_loss_diff": 0.05319639634942459,
+     "hac_variance": 0.943792596901966,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.004572154259880623,
+     -0.019876300268056927,
+     -0.002489150303865051,
+     -0.009833948609789974,
+     -0.03320066030340752
+    ],
+    "ewma": [
+     0.08869614097001603,
+     -0.10864563519274209,
+     0.012639780308211128,
+     0.002330311514152535,
+     -0.08563797701300802
+    ],
+    "log_har": [
+     0.5947739708325326,
+     0.2109151186093029,
+     0.392740652427628,
+     0.27951172829090115,
+     0.023221895192889086
+    ],
+    "har_rv": [
+     0.004572154259878284,
+     -0.01987630026818521,
+     -0.0024891503038815487,
+     -0.009833948609811424,
+     -0.03320066030346869
+    ],
+    "tsfm": [
+     0.33997103185378413,
+     -0.01376971102597809,
+     0.18165316770775775,
+     0.1269608012787347,
+     -0.09922172525697394
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a3878706681329b0ec038fdca55ca426e8c4600f40bb22c246293c02cb5ad1fb",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "99671078d4817a33c6ef976338304c244daf3ac0a0587354fd5dc4c393b77c19",
+     "25eff9f9083e57678c38e7f45631792a4029f8ea20e279b763cbbbb6735014c0",
+     "48bf7ed2ac1b33dccb4cf9b296a7b11c97540355576d51c2aeb3fc018631129d",
+     "6a2cae4fa8d70f57c0be9252dc0698bbf5a141af92873f9a43454eabd99362eb",
+     "025b343746bbc82415c647f27ba593e983e9c19b987fbf0666db6ee2fb1a5164"
+    ],
+    "har_rv": [
+     "632c2516810d03681bc7bd914707fe9ab27e9458c93a1ffada9933393b3ff897",
+     "0e90482ff5dade1298baa75900962648adc429efdfcd3634fdf83b2a84cb3d56",
+     "232611c8034c925da3b864950e61bb86b91195356c190f65f416baf0f36fe690",
+     "00f468d7361ce5149f2bf5797ffc3cfe19af6ba6701058d9d20632b654f731ec",
+     "84ba0f79d116ed72afab7188faa5f0cd8d4828d3db0cd8ab3c3dd7e8fc075138"
+    ],
+    "tsfm": [
+     "bcce091865a7032e6f71f5a2b87dde2dd7bab1316ecf828b030668e4236d69ee",
+     "535bd6714bbdb28d1210266d633255d4b0f15c9079e9c49bf250968d583df918",
+     "14ea37182edf185e1362297ace3b8dc92a09410159bf3d09eec3a1394a471bbe",
+     "46b33a40be15569403809823353d10846701b8242f6f5a86558713e2a8af29bf",
+     "52108ebfa68d0378a7af9b454e98ef8bfdb1f37669a1d3b19bbdd932fd2c88c5"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.12878020999293707,
+     "0.2": 0.20824239950675738,
+     "0.3": 0.2629615611650728,
+     "0.4": 0.29684484019049745,
+     "0.5": 0.3127241038684024,
+     "0.6": 0.30821138693798106,
+     "0.7": 0.284052340775624,
+     "0.8": 0.2382564618584388,
+     "0.9": 0.1601058791221442
+    },
+    "coverage_80": 0.8137203166226913,
+    "width_80": 2.0528447726156593,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "seed": 0,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.962914522619175,
+     "mse_debiased": 0.9668914235994632,
+     "mae_debiased": 0.7739069777234143,
+     "qlike_debiased": 0.6872154408576108,
+     "signed_bias_debiased": -0.005539481860520482,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.42047191265002015,
+     "mse_debiased": 0.44746683852318364,
+     "mae_debiased": 0.5220474649775007,
+     "qlike_debiased": 0.30122503718879595,
+     "signed_bias_debiased": 0.005002720950150699,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.5235595722265941,
+     "mse_debiased": 0.46277066189554145,
+     "mae_debiased": 0.5442991779959752,
+     "qlike_debiased": 0.26607938075661114,
+     "signed_bias_debiased": 0.1173693039490073,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 0.9629145226189213,
+     "mse_debiased": 0.9668914235992124,
+     "mae_debiased": 0.7739069777233291,
+     "qlike_debiased": 0.6872154408572302,
+     "signed_bias_debiased": -0.00553948186049137,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.36508532361846857,
+     "mse_debiased": 0.4233878978897371,
+     "mae_debiased": 0.5154709214161424,
+     "qlike_debiased": 0.26547800145185735,
+     "signed_bias_debiased": 0.068830579020728,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.395990131544602,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.543503525709726,
+     "hac_variance": 3.6256544166858746,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -1.5736832879561544,
+     "p_value": 0.11572770459443094,
+     "mean_loss_diff": -0.02407894063344653,
+     "hac_variance": 0.44155438815730946,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.1819866780442965,
+     "p_value": 0.0014863928451875896,
+     "mean_loss_diff": -0.03938276400580436,
+     "hac_variance": 0.28890814821173094,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.395990131543382,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.5435035257094755,
+     "hac_variance": 3.6256544166832456,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.539052718419972,
+     "p_value": 0.011194712698186837,
+     "mean_loss_diff": 0.07437006088124852,
+     "hac_variance": 1.6180686974467995,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 3.307465457320114,
+     "p_value": 0.0009590610224607943,
+     "mean_loss_diff": 0.06382785807057735,
+     "hac_variance": 0.7023830550282042,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.731023442040712,
+     "p_value": 2.3992121893634533e-06,
+     "mean_loss_diff": -0.04853872492827928,
+     "hac_variance": 0.19852291612281375,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.5390527184197915,
+     "p_value": 0.011194712698192388,
+     "mean_loss_diff": 0.07437006088121942,
+     "hac_variance": 1.6180686974457628,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.08524706159380054,
+     -0.04963568300845188,
+     0.045465394357227504,
+     -0.08459292313837219,
+     -0.01356408076442815
+    ],
+    "ewma": [
+     0.29442104703522815,
+     -0.10644042538348078,
+     0.028892756597705134,
+     -0.08548271962668176,
+     -0.07104924062580284
+    ],
+    "log_har": [
+     0.9249021111353407,
+     0.3595053177401188,
+     0.6039878956091403,
+     0.3493173552530352,
+     0.07210290859645753
+    ],
+    "har_rv": [
+     0.08524706159379224,
+     -0.04963568300880482,
+     0.04546539435717662,
+     -0.08459292313843791,
+     -0.013564080764613526
+    ],
+    "tsfm": [
+     0.5098790505103199,
+     -0.01503405203305354,
+     0.2882319908485225,
+     0.1564555829902061,
+     -0.14443112589744053
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a040666fadd2dcbd427a406aa130fcfd90e285ad61a216a8c11e8e979d3f5d46",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "a6037a71176d02bb6552fc0bc2e63408e8e4f0dc9d97f4fa35522f798414f197",
+     "c9f78c1fb9fb4de4405ab06f2843417f2e0fbfd23b05be7b11a05c534c462eb5",
+     "d5227e754a75e7aff6c2fafd11fd87f4a1b85df2a31b0e59fe5181046cb5da62",
+     "28444c5d343c5518baddf40cf6c5ab0c9acfadd847f4070f9a4ba5913305b7f7",
+     "45c31b8425ba6569059d79637e94e68b6e17b1123e6747b8e88c728e6384a3cc"
+    ],
+    "har_rv": [
+     "f3dca38b256d8b171a2d4832742cc9b240984b1af754bd4a110b23a5716e7072",
+     "6eb33ad9dd3f37c5855752f0979b4e38129d46b4bb1261977db3fd17399317a8",
+     "89dba725a394c5dc39b336c982f0a202413d96616edec3b6248ff8ef621381f0",
+     "58af73bd6c6d1cc7e70e72b380d19a151f94d80777546c914f29dae59b462f98",
+     "18edf9e958ab8cb57a97e57473404c1ffad7bcbfa02e9920122bfb818f786c02"
+    ],
+    "tsfm": [
+     "738ac670c987eb34c7c76f53910f0b01729ab98245f9de2207b22c9a47d8b34f",
+     "93727b0c31d526eacc4e6d194a929d9c625f73d0c5593eea94f106192ae004bb",
+     "bd4cb499b5f8f5f94ab733e9bade5ecd43105b1115e13b7a2e874dbe6ee5e9b4",
+     "ed77ec3e9425356f403f2a455fe1594952004f38fc581eb767b5f0f9aa8391b0",
+     "0e7730a859382fce884f0f4e0c3620984b7dc3b192dbfae103e7a7a7ad289103"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14665318769730298,
+     "0.2": 0.2397647874528763,
+     "0.3": 0.3028866455342151,
+     "0.4": 0.34057671979028664,
+     "0.5": 0.3556240346425143,
+     "0.6": 0.35127273451762636,
+     "0.7": 0.3259916788192313,
+     "0.8": 0.2751670365457178,
+     "0.9": 0.18650452960815758
+    },
+    "coverage_80": 0.8010554089709763,
+    "width_80": 2.3128677836194202,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "seed": 7,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.962914522619175,
+     "mse_debiased": 0.9668914235994632,
+     "mae_debiased": 0.7739069777234143,
+     "qlike_debiased": 0.6872154408576108,
+     "signed_bias_debiased": -0.005539481860520482,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.42047191265002015,
+     "mse_debiased": 0.44746683852318364,
+     "mae_debiased": 0.5220474649775007,
+     "qlike_debiased": 0.30122503718879595,
+     "signed_bias_debiased": 0.005002720950150699,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.5235595722265941,
+     "mse_debiased": 0.46277066189554145,
+     "mae_debiased": 0.5442991779959752,
+     "qlike_debiased": 0.26607938075661114,
+     "signed_bias_debiased": 0.1173693039490073,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 0.9629145226189213,
+     "mse_debiased": 0.9668914235992124,
+     "mae_debiased": 0.7739069777233291,
+     "qlike_debiased": 0.6872154408572302,
+     "signed_bias_debiased": -0.00553948186049137,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.36508532361846857,
+     "mse_debiased": 0.4233878978897371,
+     "mae_debiased": 0.5154709214161424,
+     "qlike_debiased": 0.26547800145185735,
+     "signed_bias_debiased": 0.068830579020728,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.395990131544602,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.543503525709726,
+     "hac_variance": 3.6256544166858746,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -1.5736832879561544,
+     "p_value": 0.11572770459443094,
+     "mean_loss_diff": -0.02407894063344653,
+     "hac_variance": 0.44155438815730946,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.1819866780442965,
+     "p_value": 0.0014863928451875896,
+     "mean_loss_diff": -0.03938276400580436,
+     "hac_variance": 0.28890814821173094,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.395990131543382,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.5435035257094755,
+     "hac_variance": 3.6256544166832456,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.539052718419972,
+     "p_value": 0.011194712698186837,
+     "mean_loss_diff": 0.07437006088124852,
+     "hac_variance": 1.6180686974467995,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 3.307465457320114,
+     "p_value": 0.0009590610224607943,
+     "mean_loss_diff": 0.06382785807057735,
+     "hac_variance": 0.7023830550282042,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.731023442040712,
+     "p_value": 2.3992121893634533e-06,
+     "mean_loss_diff": -0.04853872492827928,
+     "hac_variance": 0.19852291612281375,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.5390527184197915,
+     "p_value": 0.011194712698192388,
+     "mean_loss_diff": 0.07437006088121942,
+     "hac_variance": 1.6180686974457628,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.08524706159380054,
+     -0.04963568300845188,
+     0.045465394357227504,
+     -0.08459292313837219,
+     -0.01356408076442815
+    ],
+    "ewma": [
+     0.29442104703522815,
+     -0.10644042538348078,
+     0.028892756597705134,
+     -0.08548271962668176,
+     -0.07104924062580284
+    ],
+    "log_har": [
+     0.9249021111353407,
+     0.3595053177401188,
+     0.6039878956091403,
+     0.3493173552530352,
+     0.07210290859645753
+    ],
+    "har_rv": [
+     0.08524706159379224,
+     -0.04963568300880482,
+     0.04546539435717662,
+     -0.08459292313843791,
+     -0.013564080764613526
+    ],
+    "tsfm": [
+     0.5098790505103199,
+     -0.01503405203305354,
+     0.2882319908485225,
+     0.1564555829902061,
+     -0.14443112589744053
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a040666fadd2dcbd427a406aa130fcfd90e285ad61a216a8c11e8e979d3f5d46",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "a6037a71176d02bb6552fc0bc2e63408e8e4f0dc9d97f4fa35522f798414f197",
+     "c9f78c1fb9fb4de4405ab06f2843417f2e0fbfd23b05be7b11a05c534c462eb5",
+     "d5227e754a75e7aff6c2fafd11fd87f4a1b85df2a31b0e59fe5181046cb5da62",
+     "28444c5d343c5518baddf40cf6c5ab0c9acfadd847f4070f9a4ba5913305b7f7",
+     "45c31b8425ba6569059d79637e94e68b6e17b1123e6747b8e88c728e6384a3cc"
+    ],
+    "har_rv": [
+     "f3dca38b256d8b171a2d4832742cc9b240984b1af754bd4a110b23a5716e7072",
+     "6eb33ad9dd3f37c5855752f0979b4e38129d46b4bb1261977db3fd17399317a8",
+     "89dba725a394c5dc39b336c982f0a202413d96616edec3b6248ff8ef621381f0",
+     "58af73bd6c6d1cc7e70e72b380d19a151f94d80777546c914f29dae59b462f98",
+     "18edf9e958ab8cb57a97e57473404c1ffad7bcbfa02e9920122bfb818f786c02"
+    ],
+    "tsfm": [
+     "738ac670c987eb34c7c76f53910f0b01729ab98245f9de2207b22c9a47d8b34f",
+     "93727b0c31d526eacc4e6d194a929d9c625f73d0c5593eea94f106192ae004bb",
+     "bd4cb499b5f8f5f94ab733e9bade5ecd43105b1115e13b7a2e874dbe6ee5e9b4",
+     "ed77ec3e9425356f403f2a455fe1594952004f38fc581eb767b5f0f9aa8391b0",
+     "0e7730a859382fce884f0f4e0c3620984b7dc3b192dbfae103e7a7a7ad289103"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14665318769730298,
+     "0.2": 0.2397647874528763,
+     "0.3": 0.3028866455342151,
+     "0.4": 0.34057671979028664,
+     "0.5": 0.3556240346425143,
+     "0.6": 0.35127273451762636,
+     "0.7": 0.3259916788192313,
+     "0.8": 0.2751670365457178,
+     "0.9": 0.18650452960815758
+    },
+    "coverage_80": 0.8010554089709763,
+    "width_80": 2.3128677836194202,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "seed": 42,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.962914522619175,
+     "mse_debiased": 0.9668914235994632,
+     "mae_debiased": 0.7739069777234143,
+     "qlike_debiased": 0.6872154408576108,
+     "signed_bias_debiased": -0.005539481860520482,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.42047191265002015,
+     "mse_debiased": 0.44746683852318364,
+     "mae_debiased": 0.5220474649775007,
+     "qlike_debiased": 0.30122503718879595,
+     "signed_bias_debiased": 0.005002720950150699,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.5235595722265941,
+     "mse_debiased": 0.46277066189554145,
+     "mae_debiased": 0.5442991779959752,
+     "qlike_debiased": 0.26607938075661114,
+     "signed_bias_debiased": 0.1173693039490073,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 0.9629145226189213,
+     "mse_debiased": 0.9668914235992124,
+     "mae_debiased": 0.7739069777233291,
+     "qlike_debiased": 0.6872154408572302,
+     "signed_bias_debiased": -0.00553948186049137,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.36508532361846857,
+     "mse_debiased": 0.4233878978897371,
+     "mae_debiased": 0.5154709214161424,
+     "qlike_debiased": 0.26547800145185735,
+     "signed_bias_debiased": 0.068830579020728,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.395990131544602,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.543503525709726,
+     "hac_variance": 3.6256544166858746,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -1.5736832879561544,
+     "p_value": 0.11572770459443094,
+     "mean_loss_diff": -0.02407894063344653,
+     "hac_variance": 0.44155438815730946,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.1819866780442965,
+     "p_value": 0.0014863928451875896,
+     "mean_loss_diff": -0.03938276400580436,
+     "hac_variance": 0.28890814821173094,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.395990131543382,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.5435035257094755,
+     "hac_variance": 3.6256544166832456,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.539052718419972,
+     "p_value": 0.011194712698186837,
+     "mean_loss_diff": 0.07437006088124852,
+     "hac_variance": 1.6180686974467995,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 3.307465457320114,
+     "p_value": 0.0009590610224607943,
+     "mean_loss_diff": 0.06382785807057735,
+     "hac_variance": 0.7023830550282042,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.731023442040712,
+     "p_value": 2.3992121893634533e-06,
+     "mean_loss_diff": -0.04853872492827928,
+     "hac_variance": 0.19852291612281375,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.5390527184197915,
+     "p_value": 0.011194712698192388,
+     "mean_loss_diff": 0.07437006088121942,
+     "hac_variance": 1.6180686974457628,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.08524706159380054,
+     -0.04963568300845188,
+     0.045465394357227504,
+     -0.08459292313837219,
+     -0.01356408076442815
+    ],
+    "ewma": [
+     0.29442104703522815,
+     -0.10644042538348078,
+     0.028892756597705134,
+     -0.08548271962668176,
+     -0.07104924062580284
+    ],
+    "log_har": [
+     0.9249021111353407,
+     0.3595053177401188,
+     0.6039878956091403,
+     0.3493173552530352,
+     0.07210290859645753
+    ],
+    "har_rv": [
+     0.08524706159379224,
+     -0.04963568300880482,
+     0.04546539435717662,
+     -0.08459292313843791,
+     -0.013564080764613526
+    ],
+    "tsfm": [
+     0.5098790505103199,
+     -0.01503405203305354,
+     0.2882319908485225,
+     0.1564555829902061,
+     -0.14443112589744053
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a040666fadd2dcbd427a406aa130fcfd90e285ad61a216a8c11e8e979d3f5d46",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "a6037a71176d02bb6552fc0bc2e63408e8e4f0dc9d97f4fa35522f798414f197",
+     "c9f78c1fb9fb4de4405ab06f2843417f2e0fbfd23b05be7b11a05c534c462eb5",
+     "d5227e754a75e7aff6c2fafd11fd87f4a1b85df2a31b0e59fe5181046cb5da62",
+     "28444c5d343c5518baddf40cf6c5ab0c9acfadd847f4070f9a4ba5913305b7f7",
+     "45c31b8425ba6569059d79637e94e68b6e17b1123e6747b8e88c728e6384a3cc"
+    ],
+    "har_rv": [
+     "f3dca38b256d8b171a2d4832742cc9b240984b1af754bd4a110b23a5716e7072",
+     "6eb33ad9dd3f37c5855752f0979b4e38129d46b4bb1261977db3fd17399317a8",
+     "89dba725a394c5dc39b336c982f0a202413d96616edec3b6248ff8ef621381f0",
+     "58af73bd6c6d1cc7e70e72b380d19a151f94d80777546c914f29dae59b462f98",
+     "18edf9e958ab8cb57a97e57473404c1ffad7bcbfa02e9920122bfb818f786c02"
+    ],
+    "tsfm": [
+     "738ac670c987eb34c7c76f53910f0b01729ab98245f9de2207b22c9a47d8b34f",
+     "93727b0c31d526eacc4e6d194a929d9c625f73d0c5593eea94f106192ae004bb",
+     "bd4cb499b5f8f5f94ab733e9bade5ecd43105b1115e13b7a2e874dbe6ee5e9b4",
+     "ed77ec3e9425356f403f2a455fe1594952004f38fc581eb767b5f0f9aa8391b0",
+     "0e7730a859382fce884f0f4e0c3620984b7dc3b192dbfae103e7a7a7ad289103"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14665318769730298,
+     "0.2": 0.2397647874528763,
+     "0.3": 0.3028866455342151,
+     "0.4": 0.34057671979028664,
+     "0.5": 0.3556240346425143,
+     "0.6": 0.35127273451762636,
+     "0.7": 0.3259916788192313,
+     "0.8": 0.2751670365457178,
+     "0.9": 0.18650452960815758
+    },
+    "coverage_80": 0.8010554089709763,
+    "width_80": 2.3128677836194202,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "seed": 99,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.962914522619175,
+     "mse_debiased": 0.9668914235994632,
+     "mae_debiased": 0.7739069777234143,
+     "qlike_debiased": 0.6872154408576108,
+     "signed_bias_debiased": -0.005539481860520482,
+     "n_oos": 1895
+    },
+    "ewma": {
+     "mse_raw": 0.42047191265002015,
+     "mse_debiased": 0.44746683852318364,
+     "mae_debiased": 0.5220474649775007,
+     "qlike_debiased": 0.30122503718879595,
+     "signed_bias_debiased": 0.005002720950150699,
+     "n_oos": 1895
+    },
+    "log_har": {
+     "mse_raw": 0.5235595722265941,
+     "mse_debiased": 0.46277066189554145,
+     "mae_debiased": 0.5442991779959752,
+     "qlike_debiased": 0.26607938075661114,
+     "signed_bias_debiased": 0.1173693039490073,
+     "n_oos": 1895
+    },
+    "har_rv": {
+     "mse_raw": 0.9629145226189213,
+     "mse_debiased": 0.9668914235992124,
+     "mae_debiased": 0.7739069777233291,
+     "qlike_debiased": 0.6872154408572302,
+     "signed_bias_debiased": -0.00553948186049137,
+     "n_oos": 1895
+    },
+    "tsfm": {
+     "mse_raw": 0.36508532361846857,
+     "mse_debiased": 0.4233878978897371,
+     "mae_debiased": 0.5154709214161424,
+     "qlike_debiased": 0.26547800145185735,
+     "signed_bias_debiased": 0.068830579020728,
+     "n_oos": 1895
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -12.395990131544602,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.543503525709726,
+     "hac_variance": 3.6256544166858746,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -1.5736832879561544,
+     "p_value": 0.11572770459443094,
+     "mean_loss_diff": -0.02407894063344653,
+     "hac_variance": 0.44155438815730946,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.1819866780442965,
+     "p_value": 0.0014863928451875896,
+     "mean_loss_diff": -0.03938276400580436,
+     "hac_variance": 0.28890814821173094,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -12.395990131543382,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.5435035257094755,
+     "hac_variance": 3.6256544166832456,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 2.539052718419972,
+     "p_value": 0.011194712698186837,
+     "mean_loss_diff": 0.07437006088124852,
+     "hac_variance": 1.6180686974467995,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 3.307465457320114,
+     "p_value": 0.0009590610224607943,
+     "mean_loss_diff": 0.06382785807057735,
+     "hac_variance": 0.7023830550282042,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.731023442040712,
+     "p_value": 2.3992121893634533e-06,
+     "mean_loss_diff": -0.04853872492827928,
+     "hac_variance": 0.19852291612281375,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 2.5390527184197915,
+     "p_value": 0.011194712698192388,
+     "mean_loss_diff": 0.07437006088121942,
+     "hac_variance": 1.6180686974457628,
+     "n_obs": 1895,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.08524706159380054,
+     -0.04963568300845188,
+     0.045465394357227504,
+     -0.08459292313837219,
+     -0.01356408076442815
+    ],
+    "ewma": [
+     0.29442104703522815,
+     -0.10644042538348078,
+     0.028892756597705134,
+     -0.08548271962668176,
+     -0.07104924062580284
+    ],
+    "log_har": [
+     0.9249021111353407,
+     0.3595053177401188,
+     0.6039878956091403,
+     0.3493173552530352,
+     0.07210290859645753
+    ],
+    "har_rv": [
+     0.08524706159379224,
+     -0.04963568300880482,
+     0.04546539435717662,
+     -0.08459292313843791,
+     -0.013564080764613526
+    ],
+    "tsfm": [
+     0.5098790505103199,
+     -0.01503405203305354,
+     0.2882319908485225,
+     0.1564555829902061,
+     -0.14443112589744053
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "2031e7ec1021f077617c25b1fadd76183db1ee1225bd09b7e90bd319965df0d9"
+    ],
+    "ewma": [
+     "a040666fadd2dcbd427a406aa130fcfd90e285ad61a216a8c11e8e979d3f5d46",
+     "6d9fdb1912daebe5bb54bef220702aa4f2d7bcb32f908f7db46e1ac2e24f8c0f",
+     "7fc9ad719deb4be16e6ed21e584740eb70362e0b1e7d76b1b71861163cb54697",
+     "2edef1093ce4cc00e12e3562b57c9166bea8e4a8088e3052154f87bfa26a9816",
+     "8c9fae2361ce613aa1260b8ce557ccab5944f8dda6be5dc75dcf775b30823e7f"
+    ],
+    "log_har": [
+     "a6037a71176d02bb6552fc0bc2e63408e8e4f0dc9d97f4fa35522f798414f197",
+     "c9f78c1fb9fb4de4405ab06f2843417f2e0fbfd23b05be7b11a05c534c462eb5",
+     "d5227e754a75e7aff6c2fafd11fd87f4a1b85df2a31b0e59fe5181046cb5da62",
+     "28444c5d343c5518baddf40cf6c5ab0c9acfadd847f4070f9a4ba5913305b7f7",
+     "45c31b8425ba6569059d79637e94e68b6e17b1123e6747b8e88c728e6384a3cc"
+    ],
+    "har_rv": [
+     "f3dca38b256d8b171a2d4832742cc9b240984b1af754bd4a110b23a5716e7072",
+     "6eb33ad9dd3f37c5855752f0979b4e38129d46b4bb1261977db3fd17399317a8",
+     "89dba725a394c5dc39b336c982f0a202413d96616edec3b6248ff8ef621381f0",
+     "58af73bd6c6d1cc7e70e72b380d19a151f94d80777546c914f29dae59b462f98",
+     "18edf9e958ab8cb57a97e57473404c1ffad7bcbfa02e9920122bfb818f786c02"
+    ],
+    "tsfm": [
+     "738ac670c987eb34c7c76f53910f0b01729ab98245f9de2207b22c9a47d8b34f",
+     "93727b0c31d526eacc4e6d194a929d9c625f73d0c5593eea94f106192ae004bb",
+     "bd4cb499b5f8f5f94ab733e9bade5ecd43105b1115e13b7a2e874dbe6ee5e9b4",
+     "ed77ec3e9425356f403f2a455fe1594952004f38fc581eb767b5f0f9aa8391b0",
+     "0e7730a859382fce884f0f4e0c3620984b7dc3b192dbfae103e7a7a7ad289103"
+    ]
+   },
+   "n_oos": 1895,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14665318769730298,
+     "0.2": 0.2397647874528763,
+     "0.3": 0.3028866455342151,
+     "0.4": 0.34057671979028664,
+     "0.5": 0.3556240346425143,
+     "0.6": 0.35127273451762636,
+     "0.7": 0.3259916788192313,
+     "0.8": 0.2751670365457178,
+     "0.9": 0.18650452960815758
+    },
+    "coverage_80": 0.8010554089709763,
+    "width_80": 2.3128677836194202,
+    "nominal_80": 0.8,
+    "n_obs": 1895,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "seed": 0,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9997253820228909,
+     "mse_debiased": 1.0404818240245484,
+     "mae_debiased": 0.7939433211991935,
+     "qlike_debiased": 0.6692151330730421,
+     "signed_bias_debiased": 0.06905780278894587,
+     "n_oos": 1878
+    },
+    "ewma": {
+     "mse_raw": 0.36278330539127795,
+     "mse_debiased": 0.6225642354616653,
+     "mae_debiased": 0.662262326318261,
+     "qlike_debiased": 0.2777610083820804,
+     "signed_bias_debiased": 0.2699682665621156,
+     "n_oos": 1878
+    },
+    "log_har": {
+     "mse_raw": 0.7421476021323955,
+     "mse_debiased": 0.5308705613882957,
+     "mae_debiased": 0.6025252114997679,
+     "qlike_debiased": 0.22565417340034735,
+     "signed_bias_debiased": 0.30320294589019026,
+     "n_oos": 1878
+    },
+    "har_rv": {
+     "mse_raw": 0.9997253820217451,
+     "mse_debiased": 1.0404818240234535,
+     "mae_debiased": 0.7939433211988308,
+     "qlike_debiased": 0.6692151330711505,
+     "signed_bias_debiased": 0.06905780278913334,
+     "n_oos": 1878
+    },
+    "tsfm": {
+     "mse_raw": 0.34608356655162587,
+     "mse_debiased": 0.5562360932803637,
+     "mae_debiased": 0.6290131444588901,
+     "qlike_debiased": 0.258840623998409,
+     "signed_bias_debiased": 0.23040402840308247,
+     "n_oos": 1878
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.56046675307905,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.4842457307441845,
+     "hac_variance": 5.872607818179549,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.4073298514690364,
+     "p_value": 0.01616562930945098,
+     "mean_loss_diff": -0.0663281421813016,
+     "hac_variance": 1.3932169562395647,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": 1.1948538414135352,
+     "p_value": 0.23229509340328014,
+     "mean_loss_diff": 0.025365531892068072,
+     "hac_variance": 0.8270898027289438,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.560466753072832,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.48424573074308985,
+     "hac_variance": 5.872607818161532,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 4.14935921470596,
+     "p_value": 3.483063599407643e-05,
+     "mean_loss_diff": 0.1613462256141366,
+     "hac_variance": 2.7749159983885257,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.1245028894885585,
+     "p_value": 0.03375848918381541,
+     "mean_loss_diff": -0.03956423815903311,
+     "hac_variance": 0.6364807165994021,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.244507292315243,
+     "p_value": 2.2976356352177874e-05,
+     "mean_loss_diff": -0.07279891748710783,
+     "hac_variance": 0.5398704569565823,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 4.149359214704498,
+     "p_value": 3.483063599452052e-05,
+     "mean_loss_diff": 0.16134622561394912,
+     "hac_variance": 2.7749159983840315,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.35715072712861684,
+     0.02704289137342571,
+     0.12200171948049601,
+     -0.03164532039828792,
+     -0.15419382639125173
+    ],
+    "ewma": [
+     0.6637724166663259,
+     -0.16364087894254128,
+     0.5675803969719201,
+     0.3370308649637212,
+     -0.16170361643645817
+    ],
+    "log_har": [
+     1.5256281626129988,
+     0.8859523091449066,
+     1.2356669826192528,
+     0.7715535102795608,
+     0.18598373788137623
+    ],
+    "har_rv": [
+     0.35715072712856977,
+     0.02704289137213901,
+     0.1220017194803123,
+     -0.03164532039856567,
+     -0.15419382639164403
+    ],
+    "tsfm": [
+     0.8441662598376334,
+     0.12552418652987468,
+     0.6895721484026915,
+     0.3728806934072881,
+     -0.1879092176686515
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "13844224170ed0131f801b1e0a6ca61095b336cf1a3f4cd3a036e062857432c6"
+    ],
+    "ewma": [
+     "65bb53ed9bf10c54600f04cc75bf084cc1e803c50246d99621ca2c7553d036a7",
+     "f4d7c1629d08ff6ac0233af53214f507b3be503a05f9255d08a5ac19727fa693",
+     "1fc67d55cdac35a79aefbcfa8122b64d42356fe350712e417aff511dc1b66611",
+     "6803048cad4cdb669a372aea64c2e4e7727c0a17e07f8ed65c8a0d224df4e630",
+     "ecdc497dccf82d77abcd0f363f8849a6b70e34524ccb65ef5224a39e35c8ddea"
+    ],
+    "log_har": [
+     "620211f8796fb22307fb2d30e46abb783f8f948f9adc4533aeb2612daaa7063c",
+     "ad56dcb7ae40852fd97245181c23df3bae7bb6898fb749088e364ef404e01199",
+     "10614439951ddd4010233629e2cf6b7a94d2398851e7e3881b14ac1c8bf579f4",
+     "76aff5f57288b191c9172ed78f34d105551815a03fe9ec46f8ee3ef8beaa2699",
+     "3b05961e0c2ca3d339159503c16a464ebd720b05225f4d0776bb0c2f7b17ac4e"
+    ],
+    "har_rv": [
+     "fafdaf9eb376fbdfd56f52e287373fb1824288dd5430163f57da2b735636962e",
+     "3c6ad3dd35d6ac5d6f77a4e6b1cd3279892e5ed759486374d56d12e874d77bc0",
+     "98d409e1dc5cb4a65b4aae8fc320be3da5ebbe47f04464ab4a8dab41818be121",
+     "8971f413505edc89520a943c19f9dcbafa70ec80af7160dcec13bb3f0c0b1886",
+     "1eab450dee1491fe8ca9c19d9022214a0dbfb57395d8ad38dfb99b33ba88d43f"
+    ],
+    "tsfm": [
+     "dc06ead3102c65bfe81f761e4a151078ac26c40260a7513d804f631f9a93ed92",
+     "c792539f989445c726ce054ac913b5ad17011a038ab806646d53ea10dccb260e",
+     "6be9c816b432fd50eec46855ce520eb850d594da34fe4ce2742774161a80af06",
+     "ae2f9e45e1b308399d52cc40f0151894ae320fce62539681ed1a4025fc66282c",
+     "e0b6e78519929bcc1ed920cbecccd34cb1ee7b1709f61a515eea2f95fa97de4d"
+    ]
+   },
+   "n_oos": 1878,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.1797909590923861,
+     "0.2": 0.2878215393164275,
+     "0.3": 0.3591938791405095,
+     "0.4": 0.4006810273769151,
+     "0.5": 0.41775667500127867,
+     "0.6": 0.4093529368873825,
+     "0.7": 0.37469177530891706,
+     "0.8": 0.31021629973410186,
+     "0.9": 0.20181893760869493
+    },
+    "coverage_80": 0.7939297124600639,
+    "width_80": 2.6718472609250816,
+    "nominal_80": 0.8,
+    "n_obs": 1878,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "seed": 7,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9997253820228909,
+     "mse_debiased": 1.0404818240245484,
+     "mae_debiased": 0.7939433211991935,
+     "qlike_debiased": 0.6692151330730421,
+     "signed_bias_debiased": 0.06905780278894587,
+     "n_oos": 1878
+    },
+    "ewma": {
+     "mse_raw": 0.36278330539127795,
+     "mse_debiased": 0.6225642354616653,
+     "mae_debiased": 0.662262326318261,
+     "qlike_debiased": 0.2777610083820804,
+     "signed_bias_debiased": 0.2699682665621156,
+     "n_oos": 1878
+    },
+    "log_har": {
+     "mse_raw": 0.7421476021323955,
+     "mse_debiased": 0.5308705613882957,
+     "mae_debiased": 0.6025252114997679,
+     "qlike_debiased": 0.22565417340034735,
+     "signed_bias_debiased": 0.30320294589019026,
+     "n_oos": 1878
+    },
+    "har_rv": {
+     "mse_raw": 0.9997253820217451,
+     "mse_debiased": 1.0404818240234535,
+     "mae_debiased": 0.7939433211988308,
+     "qlike_debiased": 0.6692151330711505,
+     "signed_bias_debiased": 0.06905780278913334,
+     "n_oos": 1878
+    },
+    "tsfm": {
+     "mse_raw": 0.34608356655162587,
+     "mse_debiased": 0.5562360932803637,
+     "mae_debiased": 0.6290131444588901,
+     "qlike_debiased": 0.258840623998409,
+     "signed_bias_debiased": 0.23040402840308247,
+     "n_oos": 1878
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.56046675307905,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.4842457307441845,
+     "hac_variance": 5.872607818179549,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.4073298514690364,
+     "p_value": 0.01616562930945098,
+     "mean_loss_diff": -0.0663281421813016,
+     "hac_variance": 1.3932169562395647,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": 1.1948538414135352,
+     "p_value": 0.23229509340328014,
+     "mean_loss_diff": 0.025365531892068072,
+     "hac_variance": 0.8270898027289438,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.560466753072832,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.48424573074308985,
+     "hac_variance": 5.872607818161532,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 4.14935921470596,
+     "p_value": 3.483063599407643e-05,
+     "mean_loss_diff": 0.1613462256141366,
+     "hac_variance": 2.7749159983885257,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.1245028894885585,
+     "p_value": 0.03375848918381541,
+     "mean_loss_diff": -0.03956423815903311,
+     "hac_variance": 0.6364807165994021,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.244507292315243,
+     "p_value": 2.2976356352177874e-05,
+     "mean_loss_diff": -0.07279891748710783,
+     "hac_variance": 0.5398704569565823,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 4.149359214704498,
+     "p_value": 3.483063599452052e-05,
+     "mean_loss_diff": 0.16134622561394912,
+     "hac_variance": 2.7749159983840315,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.35715072712861684,
+     0.02704289137342571,
+     0.12200171948049601,
+     -0.03164532039828792,
+     -0.15419382639125173
+    ],
+    "ewma": [
+     0.6637724166663259,
+     -0.16364087894254128,
+     0.5675803969719201,
+     0.3370308649637212,
+     -0.16170361643645817
+    ],
+    "log_har": [
+     1.5256281626129988,
+     0.8859523091449066,
+     1.2356669826192528,
+     0.7715535102795608,
+     0.18598373788137623
+    ],
+    "har_rv": [
+     0.35715072712856977,
+     0.02704289137213901,
+     0.1220017194803123,
+     -0.03164532039856567,
+     -0.15419382639164403
+    ],
+    "tsfm": [
+     0.8441662598376334,
+     0.12552418652987468,
+     0.6895721484026915,
+     0.3728806934072881,
+     -0.1879092176686515
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "13844224170ed0131f801b1e0a6ca61095b336cf1a3f4cd3a036e062857432c6"
+    ],
+    "ewma": [
+     "65bb53ed9bf10c54600f04cc75bf084cc1e803c50246d99621ca2c7553d036a7",
+     "f4d7c1629d08ff6ac0233af53214f507b3be503a05f9255d08a5ac19727fa693",
+     "1fc67d55cdac35a79aefbcfa8122b64d42356fe350712e417aff511dc1b66611",
+     "6803048cad4cdb669a372aea64c2e4e7727c0a17e07f8ed65c8a0d224df4e630",
+     "ecdc497dccf82d77abcd0f363f8849a6b70e34524ccb65ef5224a39e35c8ddea"
+    ],
+    "log_har": [
+     "620211f8796fb22307fb2d30e46abb783f8f948f9adc4533aeb2612daaa7063c",
+     "ad56dcb7ae40852fd97245181c23df3bae7bb6898fb749088e364ef404e01199",
+     "10614439951ddd4010233629e2cf6b7a94d2398851e7e3881b14ac1c8bf579f4",
+     "76aff5f57288b191c9172ed78f34d105551815a03fe9ec46f8ee3ef8beaa2699",
+     "3b05961e0c2ca3d339159503c16a464ebd720b05225f4d0776bb0c2f7b17ac4e"
+    ],
+    "har_rv": [
+     "fafdaf9eb376fbdfd56f52e287373fb1824288dd5430163f57da2b735636962e",
+     "3c6ad3dd35d6ac5d6f77a4e6b1cd3279892e5ed759486374d56d12e874d77bc0",
+     "98d409e1dc5cb4a65b4aae8fc320be3da5ebbe47f04464ab4a8dab41818be121",
+     "8971f413505edc89520a943c19f9dcbafa70ec80af7160dcec13bb3f0c0b1886",
+     "1eab450dee1491fe8ca9c19d9022214a0dbfb57395d8ad38dfb99b33ba88d43f"
+    ],
+    "tsfm": [
+     "dc06ead3102c65bfe81f761e4a151078ac26c40260a7513d804f631f9a93ed92",
+     "c792539f989445c726ce054ac913b5ad17011a038ab806646d53ea10dccb260e",
+     "6be9c816b432fd50eec46855ce520eb850d594da34fe4ce2742774161a80af06",
+     "ae2f9e45e1b308399d52cc40f0151894ae320fce62539681ed1a4025fc66282c",
+     "e0b6e78519929bcc1ed920cbecccd34cb1ee7b1709f61a515eea2f95fa97de4d"
+    ]
+   },
+   "n_oos": 1878,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.1797909590923861,
+     "0.2": 0.2878215393164275,
+     "0.3": 0.3591938791405095,
+     "0.4": 0.4006810273769151,
+     "0.5": 0.41775667500127867,
+     "0.6": 0.4093529368873825,
+     "0.7": 0.37469177530891706,
+     "0.8": 0.31021629973410186,
+     "0.9": 0.20181893760869493
+    },
+    "coverage_80": 0.7939297124600639,
+    "width_80": 2.6718472609250816,
+    "nominal_80": 0.8,
+    "n_obs": 1878,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "seed": 42,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9997253820228909,
+     "mse_debiased": 1.0404818240245484,
+     "mae_debiased": 0.7939433211991935,
+     "qlike_debiased": 0.6692151330730421,
+     "signed_bias_debiased": 0.06905780278894587,
+     "n_oos": 1878
+    },
+    "ewma": {
+     "mse_raw": 0.36278330539127795,
+     "mse_debiased": 0.6225642354616653,
+     "mae_debiased": 0.662262326318261,
+     "qlike_debiased": 0.2777610083820804,
+     "signed_bias_debiased": 0.2699682665621156,
+     "n_oos": 1878
+    },
+    "log_har": {
+     "mse_raw": 0.7421476021323955,
+     "mse_debiased": 0.5308705613882957,
+     "mae_debiased": 0.6025252114997679,
+     "qlike_debiased": 0.22565417340034735,
+     "signed_bias_debiased": 0.30320294589019026,
+     "n_oos": 1878
+    },
+    "har_rv": {
+     "mse_raw": 0.9997253820217451,
+     "mse_debiased": 1.0404818240234535,
+     "mae_debiased": 0.7939433211988308,
+     "qlike_debiased": 0.6692151330711505,
+     "signed_bias_debiased": 0.06905780278913334,
+     "n_oos": 1878
+    },
+    "tsfm": {
+     "mse_raw": 0.34608356655162587,
+     "mse_debiased": 0.5562360932803637,
+     "mae_debiased": 0.6290131444588901,
+     "qlike_debiased": 0.258840623998409,
+     "signed_bias_debiased": 0.23040402840308247,
+     "n_oos": 1878
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.56046675307905,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.4842457307441845,
+     "hac_variance": 5.872607818179549,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.4073298514690364,
+     "p_value": 0.01616562930945098,
+     "mean_loss_diff": -0.0663281421813016,
+     "hac_variance": 1.3932169562395647,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": 1.1948538414135352,
+     "p_value": 0.23229509340328014,
+     "mean_loss_diff": 0.025365531892068072,
+     "hac_variance": 0.8270898027289438,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.560466753072832,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.48424573074308985,
+     "hac_variance": 5.872607818161532,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 4.14935921470596,
+     "p_value": 3.483063599407643e-05,
+     "mean_loss_diff": 0.1613462256141366,
+     "hac_variance": 2.7749159983885257,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.1245028894885585,
+     "p_value": 0.03375848918381541,
+     "mean_loss_diff": -0.03956423815903311,
+     "hac_variance": 0.6364807165994021,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.244507292315243,
+     "p_value": 2.2976356352177874e-05,
+     "mean_loss_diff": -0.07279891748710783,
+     "hac_variance": 0.5398704569565823,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 4.149359214704498,
+     "p_value": 3.483063599452052e-05,
+     "mean_loss_diff": 0.16134622561394912,
+     "hac_variance": 2.7749159983840315,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.35715072712861684,
+     0.02704289137342571,
+     0.12200171948049601,
+     -0.03164532039828792,
+     -0.15419382639125173
+    ],
+    "ewma": [
+     0.6637724166663259,
+     -0.16364087894254128,
+     0.5675803969719201,
+     0.3370308649637212,
+     -0.16170361643645817
+    ],
+    "log_har": [
+     1.5256281626129988,
+     0.8859523091449066,
+     1.2356669826192528,
+     0.7715535102795608,
+     0.18598373788137623
+    ],
+    "har_rv": [
+     0.35715072712856977,
+     0.02704289137213901,
+     0.1220017194803123,
+     -0.03164532039856567,
+     -0.15419382639164403
+    ],
+    "tsfm": [
+     0.8441662598376334,
+     0.12552418652987468,
+     0.6895721484026915,
+     0.3728806934072881,
+     -0.1879092176686515
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "13844224170ed0131f801b1e0a6ca61095b336cf1a3f4cd3a036e062857432c6"
+    ],
+    "ewma": [
+     "65bb53ed9bf10c54600f04cc75bf084cc1e803c50246d99621ca2c7553d036a7",
+     "f4d7c1629d08ff6ac0233af53214f507b3be503a05f9255d08a5ac19727fa693",
+     "1fc67d55cdac35a79aefbcfa8122b64d42356fe350712e417aff511dc1b66611",
+     "6803048cad4cdb669a372aea64c2e4e7727c0a17e07f8ed65c8a0d224df4e630",
+     "ecdc497dccf82d77abcd0f363f8849a6b70e34524ccb65ef5224a39e35c8ddea"
+    ],
+    "log_har": [
+     "620211f8796fb22307fb2d30e46abb783f8f948f9adc4533aeb2612daaa7063c",
+     "ad56dcb7ae40852fd97245181c23df3bae7bb6898fb749088e364ef404e01199",
+     "10614439951ddd4010233629e2cf6b7a94d2398851e7e3881b14ac1c8bf579f4",
+     "76aff5f57288b191c9172ed78f34d105551815a03fe9ec46f8ee3ef8beaa2699",
+     "3b05961e0c2ca3d339159503c16a464ebd720b05225f4d0776bb0c2f7b17ac4e"
+    ],
+    "har_rv": [
+     "fafdaf9eb376fbdfd56f52e287373fb1824288dd5430163f57da2b735636962e",
+     "3c6ad3dd35d6ac5d6f77a4e6b1cd3279892e5ed759486374d56d12e874d77bc0",
+     "98d409e1dc5cb4a65b4aae8fc320be3da5ebbe47f04464ab4a8dab41818be121",
+     "8971f413505edc89520a943c19f9dcbafa70ec80af7160dcec13bb3f0c0b1886",
+     "1eab450dee1491fe8ca9c19d9022214a0dbfb57395d8ad38dfb99b33ba88d43f"
+    ],
+    "tsfm": [
+     "dc06ead3102c65bfe81f761e4a151078ac26c40260a7513d804f631f9a93ed92",
+     "c792539f989445c726ce054ac913b5ad17011a038ab806646d53ea10dccb260e",
+     "6be9c816b432fd50eec46855ce520eb850d594da34fe4ce2742774161a80af06",
+     "ae2f9e45e1b308399d52cc40f0151894ae320fce62539681ed1a4025fc66282c",
+     "e0b6e78519929bcc1ed920cbecccd34cb1ee7b1709f61a515eea2f95fa97de4d"
+    ]
+   },
+   "n_oos": 1878,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.1797909590923861,
+     "0.2": 0.2878215393164275,
+     "0.3": 0.3591938791405095,
+     "0.4": 0.4006810273769151,
+     "0.5": 0.41775667500127867,
+     "0.6": 0.4093529368873825,
+     "0.7": 0.37469177530891706,
+     "0.8": 0.31021629973410186,
+     "0.9": 0.20181893760869493
+    },
+    "coverage_80": 0.7939297124600639,
+    "width_80": 2.6718472609250816,
+    "nominal_80": 0.8,
+    "n_obs": 1878,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "seed": 99,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9997253820228909,
+     "mse_debiased": 1.0404818240245484,
+     "mae_debiased": 0.7939433211991935,
+     "qlike_debiased": 0.6692151330730421,
+     "signed_bias_debiased": 0.06905780278894587,
+     "n_oos": 1878
+    },
+    "ewma": {
+     "mse_raw": 0.36278330539127795,
+     "mse_debiased": 0.6225642354616653,
+     "mae_debiased": 0.662262326318261,
+     "qlike_debiased": 0.2777610083820804,
+     "signed_bias_debiased": 0.2699682665621156,
+     "n_oos": 1878
+    },
+    "log_har": {
+     "mse_raw": 0.7421476021323955,
+     "mse_debiased": 0.5308705613882957,
+     "mae_debiased": 0.6025252114997679,
+     "qlike_debiased": 0.22565417340034735,
+     "signed_bias_debiased": 0.30320294589019026,
+     "n_oos": 1878
+    },
+    "har_rv": {
+     "mse_raw": 0.9997253820217451,
+     "mse_debiased": 1.0404818240234535,
+     "mae_debiased": 0.7939433211988308,
+     "qlike_debiased": 0.6692151330711505,
+     "signed_bias_debiased": 0.06905780278913334,
+     "n_oos": 1878
+    },
+    "tsfm": {
+     "mse_raw": 0.34608356655162587,
+     "mse_debiased": 0.5562360932803637,
+     "mae_debiased": 0.6290131444588901,
+     "qlike_debiased": 0.258840623998409,
+     "signed_bias_debiased": 0.23040402840308247,
+     "n_oos": 1878
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.56046675307905,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.4842457307441845,
+     "hac_variance": 5.872607818179549,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.4073298514690364,
+     "p_value": 0.01616562930945098,
+     "mean_loss_diff": -0.0663281421813016,
+     "hac_variance": 1.3932169562395647,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": 1.1948538414135352,
+     "p_value": 0.23229509340328014,
+     "mean_loss_diff": 0.025365531892068072,
+     "hac_variance": 0.8270898027289438,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.560466753072832,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.48424573074308985,
+     "hac_variance": 5.872607818161532,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 4.14935921470596,
+     "p_value": 3.483063599407643e-05,
+     "mean_loss_diff": 0.1613462256141366,
+     "hac_variance": 2.7749159983885257,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.1245028894885585,
+     "p_value": 0.03375848918381541,
+     "mean_loss_diff": -0.03956423815903311,
+     "hac_variance": 0.6364807165994021,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -4.244507292315243,
+     "p_value": 2.2976356352177874e-05,
+     "mean_loss_diff": -0.07279891748710783,
+     "hac_variance": 0.5398704569565823,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 4.149359214704498,
+     "p_value": 3.483063599452052e-05,
+     "mean_loss_diff": 0.16134622561394912,
+     "hac_variance": 2.7749159983840315,
+     "n_obs": 1878,
+     "lag": 12,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.35715072712861684,
+     0.02704289137342571,
+     0.12200171948049601,
+     -0.03164532039828792,
+     -0.15419382639125173
+    ],
+    "ewma": [
+     0.6637724166663259,
+     -0.16364087894254128,
+     0.5675803969719201,
+     0.3370308649637212,
+     -0.16170361643645817
+    ],
+    "log_har": [
+     1.5256281626129988,
+     0.8859523091449066,
+     1.2356669826192528,
+     0.7715535102795608,
+     0.18598373788137623
+    ],
+    "har_rv": [
+     0.35715072712856977,
+     0.02704289137213901,
+     0.1220017194803123,
+     -0.03164532039856567,
+     -0.15419382639164403
+    ],
+    "tsfm": [
+     0.8441662598376334,
+     0.12552418652987468,
+     0.6895721484026915,
+     0.3728806934072881,
+     -0.1879092176686515
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "816a57d7671eddff8f6dbf02741358069901e1d8985c58e7c960d9a186b014d3",
+     "fe8d77c1342a4e9bc8e9bbcab7a866970a88ef9cbfc8a2b3c6d12d4395471620",
+     "951f18f82e670bb51128e2e6b876aa561f43876b03cde18df6362acc1ad3bd5d",
+     "cfea9f3350146659c0017d66ec21fd50d86d8a3717cd888ada759d5175056a70",
+     "13844224170ed0131f801b1e0a6ca61095b336cf1a3f4cd3a036e062857432c6"
+    ],
+    "ewma": [
+     "65bb53ed9bf10c54600f04cc75bf084cc1e803c50246d99621ca2c7553d036a7",
+     "f4d7c1629d08ff6ac0233af53214f507b3be503a05f9255d08a5ac19727fa693",
+     "1fc67d55cdac35a79aefbcfa8122b64d42356fe350712e417aff511dc1b66611",
+     "6803048cad4cdb669a372aea64c2e4e7727c0a17e07f8ed65c8a0d224df4e630",
+     "ecdc497dccf82d77abcd0f363f8849a6b70e34524ccb65ef5224a39e35c8ddea"
+    ],
+    "log_har": [
+     "620211f8796fb22307fb2d30e46abb783f8f948f9adc4533aeb2612daaa7063c",
+     "ad56dcb7ae40852fd97245181c23df3bae7bb6898fb749088e364ef404e01199",
+     "10614439951ddd4010233629e2cf6b7a94d2398851e7e3881b14ac1c8bf579f4",
+     "76aff5f57288b191c9172ed78f34d105551815a03fe9ec46f8ee3ef8beaa2699",
+     "3b05961e0c2ca3d339159503c16a464ebd720b05225f4d0776bb0c2f7b17ac4e"
+    ],
+    "har_rv": [
+     "fafdaf9eb376fbdfd56f52e287373fb1824288dd5430163f57da2b735636962e",
+     "3c6ad3dd35d6ac5d6f77a4e6b1cd3279892e5ed759486374d56d12e874d77bc0",
+     "98d409e1dc5cb4a65b4aae8fc320be3da5ebbe47f04464ab4a8dab41818be121",
+     "8971f413505edc89520a943c19f9dcbafa70ec80af7160dcec13bb3f0c0b1886",
+     "1eab450dee1491fe8ca9c19d9022214a0dbfb57395d8ad38dfb99b33ba88d43f"
+    ],
+    "tsfm": [
+     "dc06ead3102c65bfe81f761e4a151078ac26c40260a7513d804f631f9a93ed92",
+     "c792539f989445c726ce054ac913b5ad17011a038ab806646d53ea10dccb260e",
+     "6be9c816b432fd50eec46855ce520eb850d594da34fe4ce2742774161a80af06",
+     "ae2f9e45e1b308399d52cc40f0151894ae320fce62539681ed1a4025fc66282c",
+     "e0b6e78519929bcc1ed920cbecccd34cb1ee7b1709f61a515eea2f95fa97de4d"
+    ]
+   },
+   "n_oos": 1878,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 379,
+    "oos_start_idx": 379,
+    "oos_end_idx": 758,
+    "n_train": 379,
+    "n_oos": 379,
+    "n_total": 2278,
+    "fold_size": 379,
+    "n_folds": 5
+   },
+   "panel_hash": "687ddd0768e37558",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.1797909590923861,
+     "0.2": 0.2878215393164275,
+     "0.3": 0.3591938791405095,
+     "0.4": 0.4006810273769151,
+     "0.5": 0.41775667500127867,
+     "0.6": 0.4093529368873825,
+     "0.7": 0.37469177530891706,
+     "0.8": 0.31021629973410186,
+     "0.9": 0.20181893760869493
+    },
+    "coverage_80": 0.7939297124600639,
+    "width_80": 2.6718472609250816,
+    "nominal_80": 0.8,
+    "n_obs": 1878,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "seed": 0,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9374063560261437,
+     "mse_debiased": 0.9375639535540303,
+     "mae_debiased": 0.7583345379838922,
+     "qlike_debiased": 0.6940352200302606,
+     "signed_bias_debiased": -0.008848496888981792,
+     "n_oos": 1245
+    },
+    "ewma": {
+     "mse_raw": 0.7109224262105045,
+     "mse_debiased": 0.7263490609016273,
+     "mae_debiased": 0.6530037729882157,
+     "qlike_debiased": 0.5831365243119568,
+     "signed_bias_debiased": -0.058574118435136,
+     "n_oos": 1245
+    },
+    "log_har": {
+     "mse_raw": 0.6838439947061115,
+     "mse_debiased": 0.7041050744763055,
+     "mae_debiased": 0.6436303801840619,
+     "qlike_debiased": 0.504359562911004,
+     "signed_bias_debiased": 0.02535106755093993,
+     "n_oos": 1245
+    },
+    "har_rv": {
+     "mse_raw": 0.9374063560256233,
+     "mse_debiased": 0.9375639535535036,
+     "mae_debiased": 0.7583345379836101,
+     "qlike_debiased": 0.6940352200301019,
+     "signed_bias_debiased": -0.008848496889916527,
+     "n_oos": 1245
+    },
+    "tsfm": {
+     "mse_raw": 0.6343646979800096,
+     "mse_debiased": 0.650350840140536,
+     "mae_debiased": 0.624268340540059,
+     "qlike_debiased": 0.471879899039107,
+     "signed_bias_debiased": 0.011808390326027549,
+     "n_oos": 1245
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.830841137008512,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134134944,
+     "hac_variance": 1.315905692981301,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -3.9238080383983593,
+     "p_value": 9.192891572773476e-05,
+     "mean_loss_diff": -0.07599822076109124,
+     "hac_variance": 0.4666719792642899,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -5.082170735962637,
+     "p_value": 4.3023400930763955e-07,
+     "mean_loss_diff": -0.05375423433576945,
+     "hac_variance": 0.13917051636040043,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.830841136999402,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134129675,
+     "hac_variance": 1.3159056929791877,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 0.8545791611531485,
+     "p_value": 0.3929487088898065,
+     "mean_loss_diff": 0.020656887215009336,
+     "hac_variance": 0.7268512476087728,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.514960754365918,
+     "p_value": 6.933341824666428e-06,
+     "mean_loss_diff": 0.07038250876116355,
+     "hac_variance": 0.30230261726982205,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -1.5142344679676802,
+     "p_value": 0.13022040212585462,
+     "mean_loss_diff": -0.013542677224912389,
+     "hac_variance": 0.09950460507231254,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 0.8545791611956696,
+     "p_value": 0.3929487088662673,
+     "mean_loss_diff": 0.020656887215944067,
+     "hac_variance": 0.7268512476022216,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.005554075541608805,
+     -0.018427748981054502,
+     -0.011493993749644386,
+     -0.004595357203536677,
+     -0.01781975140250364
+    ],
+    "ewma": [
+     -0.1880733157687444,
+     0.001033163402923365,
+     -0.0802912027738497,
+     0.028043679914234367,
+     0.006972238376790522
+    ],
+    "log_har": [
+     -0.06781894044507868,
+     0.35864125362250837,
+     0.03765916819494002,
+     0.19987813927852874,
+     -0.0004624755687501943
+    ],
+    "har_rv": [
+     0.005554075534825668,
+     -0.018427748981204355,
+     -0.011493993750034045,
+     -0.004595357203653575,
+     -0.01781975140271692
+    ],
+    "tsfm": [
+     -0.09256933449929984,
+     0.14285380108044163,
+     -0.04223836211760282,
+     0.14172015289369308,
+     0.03265419426795888
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "cb3c8ae1999b0547974eb9a6b7b385e6bc5589e68e245a3875ea83dd120006b2"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "a5a51184fdfa92829bd82e3681c285331fab1559c87a8d8a47e530b4bd5faaa2"
+    ],
+    "log_har": [
+     "081062086be9c0aa9fc064c1bf9af7ed689af01968e35b57f0a6fd37532a6d7c",
+     "6cbc2f87d031f2f63660c08969bde2c23d6aa10cd5542a662b07658d3bd01976",
+     "1687c34f928b1ee895093552757adf9f5cad62d213745315a1f158f879d33f37",
+     "33c63ebe58175f519c105bf5295c35367d751619e7e694cdfa0e59526121adb2",
+     "8302656aa6897dcd1a1192e6317283b3928532f9c714616238027d9ab36509e1"
+    ],
+    "har_rv": [
+     "f42aa00b705d50f94fbf4e53bcab91cc265b0a39a6b4bcc5670a5e3e231f997b",
+     "834b3f791dd59fff5268d6659032f6ccfdf89850199bd44ed3ed564d05216125",
+     "49321deda4a95e3f3f678919fd31cb8602af98cc9fdbaeb0e7783cfb6ec9b946",
+     "b79c2034980fd0b0ce285813309ae69f4f923eb7158aabf8eae61c9740e13c67",
+     "ae7bd895887115baa2e37dfc7b41fd2389f76daae6afabbae2ec43b462d39928"
+    ],
+    "tsfm": [
+     "b91fef97e68fcab02d1069fc39d7639584a5357d620b3b15a0ec3a6e29a4f1cb",
+     "75ab61f7832a93c442f87bc90644eed797a8a77f6f7c2e414bed051d5992ef40",
+     "2dd130c662a7ff7e3d2271ef1d023021d693f259f01bffc62e83ae303e6431f8",
+     "5269119f16ebe0a06e765b3951645507df583c2e7a636c42baa473815abd14db",
+     "f83a44d1e8c945a883c8ad3652f10cace8988155c71e30f4802dc5b0f45cee79"
+    ]
+   },
+   "n_oos": 1245,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.13073164905714255,
+     "0.2": 0.2095016855131374,
+     "0.3": 0.2620714181347537,
+     "0.4": 0.29443029796379155,
+     "0.5": 0.3065591144988673,
+     "0.6": 0.3009003936136734,
+     "0.7": 0.2759817322557216,
+     "0.8": 0.22926289942266562,
+     "0.9": 0.15297304287925392
+    },
+    "coverage_80": 0.8064257028112449,
+    "width_80": 1.9705003859048866,
+    "nominal_80": 0.8,
+    "n_obs": 1245,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "seed": 7,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9374063560261437,
+     "mse_debiased": 0.9375639535540303,
+     "mae_debiased": 0.7583345379838922,
+     "qlike_debiased": 0.6940352200302606,
+     "signed_bias_debiased": -0.008848496888981792,
+     "n_oos": 1245
+    },
+    "ewma": {
+     "mse_raw": 0.7109224262105045,
+     "mse_debiased": 0.7263490609016273,
+     "mae_debiased": 0.6530037729882157,
+     "qlike_debiased": 0.5831365243119568,
+     "signed_bias_debiased": -0.058574118435136,
+     "n_oos": 1245
+    },
+    "log_har": {
+     "mse_raw": 0.6838439947061115,
+     "mse_debiased": 0.7041050744763055,
+     "mae_debiased": 0.6436303801840619,
+     "qlike_debiased": 0.504359562911004,
+     "signed_bias_debiased": 0.02535106755093993,
+     "n_oos": 1245
+    },
+    "har_rv": {
+     "mse_raw": 0.9374063560256233,
+     "mse_debiased": 0.9375639535535036,
+     "mae_debiased": 0.7583345379836101,
+     "qlike_debiased": 0.6940352200301019,
+     "signed_bias_debiased": -0.008848496889916527,
+     "n_oos": 1245
+    },
+    "tsfm": {
+     "mse_raw": 0.6343646979800096,
+     "mse_debiased": 0.650350840140536,
+     "mae_debiased": 0.624268340540059,
+     "qlike_debiased": 0.471879899039107,
+     "signed_bias_debiased": 0.011808390326027549,
+     "n_oos": 1245
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.830841137008512,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134134944,
+     "hac_variance": 1.315905692981301,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -3.9238080383983593,
+     "p_value": 9.192891572773476e-05,
+     "mean_loss_diff": -0.07599822076109124,
+     "hac_variance": 0.4666719792642899,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -5.082170735962637,
+     "p_value": 4.3023400930763955e-07,
+     "mean_loss_diff": -0.05375423433576945,
+     "hac_variance": 0.13917051636040043,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.830841136999402,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134129675,
+     "hac_variance": 1.3159056929791877,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 0.8545791611531485,
+     "p_value": 0.3929487088898065,
+     "mean_loss_diff": 0.020656887215009336,
+     "hac_variance": 0.7268512476087728,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.514960754365918,
+     "p_value": 6.933341824666428e-06,
+     "mean_loss_diff": 0.07038250876116355,
+     "hac_variance": 0.30230261726982205,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -1.5142344679676802,
+     "p_value": 0.13022040212585462,
+     "mean_loss_diff": -0.013542677224912389,
+     "hac_variance": 0.09950460507231254,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 0.8545791611956696,
+     "p_value": 0.3929487088662673,
+     "mean_loss_diff": 0.020656887215944067,
+     "hac_variance": 0.7268512476022216,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.005554075541608805,
+     -0.018427748981054502,
+     -0.011493993749644386,
+     -0.004595357203536677,
+     -0.01781975140250364
+    ],
+    "ewma": [
+     -0.1880733157687444,
+     0.001033163402923365,
+     -0.0802912027738497,
+     0.028043679914234367,
+     0.006972238376790522
+    ],
+    "log_har": [
+     -0.06781894044507868,
+     0.35864125362250837,
+     0.03765916819494002,
+     0.19987813927852874,
+     -0.0004624755687501943
+    ],
+    "har_rv": [
+     0.005554075534825668,
+     -0.018427748981204355,
+     -0.011493993750034045,
+     -0.004595357203653575,
+     -0.01781975140271692
+    ],
+    "tsfm": [
+     -0.09256933449929984,
+     0.14285380108044163,
+     -0.04223836211760282,
+     0.14172015289369308,
+     0.03265419426795888
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "cb3c8ae1999b0547974eb9a6b7b385e6bc5589e68e245a3875ea83dd120006b2"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "a5a51184fdfa92829bd82e3681c285331fab1559c87a8d8a47e530b4bd5faaa2"
+    ],
+    "log_har": [
+     "081062086be9c0aa9fc064c1bf9af7ed689af01968e35b57f0a6fd37532a6d7c",
+     "6cbc2f87d031f2f63660c08969bde2c23d6aa10cd5542a662b07658d3bd01976",
+     "1687c34f928b1ee895093552757adf9f5cad62d213745315a1f158f879d33f37",
+     "33c63ebe58175f519c105bf5295c35367d751619e7e694cdfa0e59526121adb2",
+     "8302656aa6897dcd1a1192e6317283b3928532f9c714616238027d9ab36509e1"
+    ],
+    "har_rv": [
+     "f42aa00b705d50f94fbf4e53bcab91cc265b0a39a6b4bcc5670a5e3e231f997b",
+     "834b3f791dd59fff5268d6659032f6ccfdf89850199bd44ed3ed564d05216125",
+     "49321deda4a95e3f3f678919fd31cb8602af98cc9fdbaeb0e7783cfb6ec9b946",
+     "b79c2034980fd0b0ce285813309ae69f4f923eb7158aabf8eae61c9740e13c67",
+     "ae7bd895887115baa2e37dfc7b41fd2389f76daae6afabbae2ec43b462d39928"
+    ],
+    "tsfm": [
+     "b91fef97e68fcab02d1069fc39d7639584a5357d620b3b15a0ec3a6e29a4f1cb",
+     "75ab61f7832a93c442f87bc90644eed797a8a77f6f7c2e414bed051d5992ef40",
+     "2dd130c662a7ff7e3d2271ef1d023021d693f259f01bffc62e83ae303e6431f8",
+     "5269119f16ebe0a06e765b3951645507df583c2e7a636c42baa473815abd14db",
+     "f83a44d1e8c945a883c8ad3652f10cace8988155c71e30f4802dc5b0f45cee79"
+    ]
+   },
+   "n_oos": 1245,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.13073164905714255,
+     "0.2": 0.2095016855131374,
+     "0.3": 0.2620714181347537,
+     "0.4": 0.29443029796379155,
+     "0.5": 0.3065591144988673,
+     "0.6": 0.3009003936136734,
+     "0.7": 0.2759817322557216,
+     "0.8": 0.22926289942266562,
+     "0.9": 0.15297304287925392
+    },
+    "coverage_80": 0.8064257028112449,
+    "width_80": 1.9705003859048866,
+    "nominal_80": 0.8,
+    "n_obs": 1245,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "seed": 42,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9374063560261437,
+     "mse_debiased": 0.9375639535540303,
+     "mae_debiased": 0.7583345379838922,
+     "qlike_debiased": 0.6940352200302606,
+     "signed_bias_debiased": -0.008848496888981792,
+     "n_oos": 1245
+    },
+    "ewma": {
+     "mse_raw": 0.7109224262105045,
+     "mse_debiased": 0.7263490609016273,
+     "mae_debiased": 0.6530037729882157,
+     "qlike_debiased": 0.5831365243119568,
+     "signed_bias_debiased": -0.058574118435136,
+     "n_oos": 1245
+    },
+    "log_har": {
+     "mse_raw": 0.6838439947061115,
+     "mse_debiased": 0.7041050744763055,
+     "mae_debiased": 0.6436303801840619,
+     "qlike_debiased": 0.504359562911004,
+     "signed_bias_debiased": 0.02535106755093993,
+     "n_oos": 1245
+    },
+    "har_rv": {
+     "mse_raw": 0.9374063560256233,
+     "mse_debiased": 0.9375639535535036,
+     "mae_debiased": 0.7583345379836101,
+     "qlike_debiased": 0.6940352200301019,
+     "signed_bias_debiased": -0.008848496889916527,
+     "n_oos": 1245
+    },
+    "tsfm": {
+     "mse_raw": 0.6343646979800096,
+     "mse_debiased": 0.650350840140536,
+     "mae_debiased": 0.624268340540059,
+     "qlike_debiased": 0.471879899039107,
+     "signed_bias_debiased": 0.011808390326027549,
+     "n_oos": 1245
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.830841137008512,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134134944,
+     "hac_variance": 1.315905692981301,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -3.9238080383983593,
+     "p_value": 9.192891572773476e-05,
+     "mean_loss_diff": -0.07599822076109124,
+     "hac_variance": 0.4666719792642899,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -5.082170735962637,
+     "p_value": 4.3023400930763955e-07,
+     "mean_loss_diff": -0.05375423433576945,
+     "hac_variance": 0.13917051636040043,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.830841136999402,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134129675,
+     "hac_variance": 1.3159056929791877,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 0.8545791611531485,
+     "p_value": 0.3929487088898065,
+     "mean_loss_diff": 0.020656887215009336,
+     "hac_variance": 0.7268512476087728,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.514960754365918,
+     "p_value": 6.933341824666428e-06,
+     "mean_loss_diff": 0.07038250876116355,
+     "hac_variance": 0.30230261726982205,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -1.5142344679676802,
+     "p_value": 0.13022040212585462,
+     "mean_loss_diff": -0.013542677224912389,
+     "hac_variance": 0.09950460507231254,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 0.8545791611956696,
+     "p_value": 0.3929487088662673,
+     "mean_loss_diff": 0.020656887215944067,
+     "hac_variance": 0.7268512476022216,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.005554075541608805,
+     -0.018427748981054502,
+     -0.011493993749644386,
+     -0.004595357203536677,
+     -0.01781975140250364
+    ],
+    "ewma": [
+     -0.1880733157687444,
+     0.001033163402923365,
+     -0.0802912027738497,
+     0.028043679914234367,
+     0.006972238376790522
+    ],
+    "log_har": [
+     -0.06781894044507868,
+     0.35864125362250837,
+     0.03765916819494002,
+     0.19987813927852874,
+     -0.0004624755687501943
+    ],
+    "har_rv": [
+     0.005554075534825668,
+     -0.018427748981204355,
+     -0.011493993750034045,
+     -0.004595357203653575,
+     -0.01781975140271692
+    ],
+    "tsfm": [
+     -0.09256933449929984,
+     0.14285380108044163,
+     -0.04223836211760282,
+     0.14172015289369308,
+     0.03265419426795888
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "cb3c8ae1999b0547974eb9a6b7b385e6bc5589e68e245a3875ea83dd120006b2"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "a5a51184fdfa92829bd82e3681c285331fab1559c87a8d8a47e530b4bd5faaa2"
+    ],
+    "log_har": [
+     "081062086be9c0aa9fc064c1bf9af7ed689af01968e35b57f0a6fd37532a6d7c",
+     "6cbc2f87d031f2f63660c08969bde2c23d6aa10cd5542a662b07658d3bd01976",
+     "1687c34f928b1ee895093552757adf9f5cad62d213745315a1f158f879d33f37",
+     "33c63ebe58175f519c105bf5295c35367d751619e7e694cdfa0e59526121adb2",
+     "8302656aa6897dcd1a1192e6317283b3928532f9c714616238027d9ab36509e1"
+    ],
+    "har_rv": [
+     "f42aa00b705d50f94fbf4e53bcab91cc265b0a39a6b4bcc5670a5e3e231f997b",
+     "834b3f791dd59fff5268d6659032f6ccfdf89850199bd44ed3ed564d05216125",
+     "49321deda4a95e3f3f678919fd31cb8602af98cc9fdbaeb0e7783cfb6ec9b946",
+     "b79c2034980fd0b0ce285813309ae69f4f923eb7158aabf8eae61c9740e13c67",
+     "ae7bd895887115baa2e37dfc7b41fd2389f76daae6afabbae2ec43b462d39928"
+    ],
+    "tsfm": [
+     "b91fef97e68fcab02d1069fc39d7639584a5357d620b3b15a0ec3a6e29a4f1cb",
+     "75ab61f7832a93c442f87bc90644eed797a8a77f6f7c2e414bed051d5992ef40",
+     "2dd130c662a7ff7e3d2271ef1d023021d693f259f01bffc62e83ae303e6431f8",
+     "5269119f16ebe0a06e765b3951645507df583c2e7a636c42baa473815abd14db",
+     "f83a44d1e8c945a883c8ad3652f10cace8988155c71e30f4802dc5b0f45cee79"
+    ]
+   },
+   "n_oos": 1245,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.13073164905714255,
+     "0.2": 0.2095016855131374,
+     "0.3": 0.2620714181347537,
+     "0.4": 0.29443029796379155,
+     "0.5": 0.3065591144988673,
+     "0.6": 0.3009003936136734,
+     "0.7": 0.2759817322557216,
+     "0.8": 0.22926289942266562,
+     "0.9": 0.15297304287925392
+    },
+    "coverage_80": 0.8064257028112449,
+    "width_80": 1.9705003859048866,
+    "nominal_80": 0.8,
+    "n_obs": 1245,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "seed": 99,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.9374063560261437,
+     "mse_debiased": 0.9375639535540303,
+     "mae_debiased": 0.7583345379838922,
+     "qlike_debiased": 0.6940352200302606,
+     "signed_bias_debiased": -0.008848496888981792,
+     "n_oos": 1245
+    },
+    "ewma": {
+     "mse_raw": 0.7109224262105045,
+     "mse_debiased": 0.7263490609016273,
+     "mae_debiased": 0.6530037729882157,
+     "qlike_debiased": 0.5831365243119568,
+     "signed_bias_debiased": -0.058574118435136,
+     "n_oos": 1245
+    },
+    "log_har": {
+     "mse_raw": 0.6838439947061115,
+     "mse_debiased": 0.7041050744763055,
+     "mae_debiased": 0.6436303801840619,
+     "qlike_debiased": 0.504359562911004,
+     "signed_bias_debiased": 0.02535106755093993,
+     "n_oos": 1245
+    },
+    "har_rv": {
+     "mse_raw": 0.9374063560256233,
+     "mse_debiased": 0.9375639535535036,
+     "mae_debiased": 0.7583345379836101,
+     "qlike_debiased": 0.6940352200301019,
+     "signed_bias_debiased": -0.008848496889916527,
+     "n_oos": 1245
+    },
+    "tsfm": {
+     "mse_raw": 0.6343646979800096,
+     "mse_debiased": 0.650350840140536,
+     "mae_debiased": 0.624268340540059,
+     "qlike_debiased": 0.471879899039107,
+     "signed_bias_debiased": 0.011808390326027549,
+     "n_oos": 1245
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.830841137008512,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134134944,
+     "hac_variance": 1.315905692981301,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -3.9238080383983593,
+     "p_value": 9.192891572773476e-05,
+     "mean_loss_diff": -0.07599822076109124,
+     "hac_variance": 0.4666719792642899,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -5.082170735962637,
+     "p_value": 4.3023400930763955e-07,
+     "mean_loss_diff": -0.05375423433576945,
+     "hac_variance": 0.13917051636040043,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.830841136999402,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.2872131134129675,
+     "hac_variance": 1.3159056929791877,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 0.8545791611531485,
+     "p_value": 0.3929487088898065,
+     "mean_loss_diff": 0.020656887215009336,
+     "hac_variance": 0.7268512476087728,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.514960754365918,
+     "p_value": 6.933341824666428e-06,
+     "mean_loss_diff": 0.07038250876116355,
+     "hac_variance": 0.30230261726982205,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -1.5142344679676802,
+     "p_value": 0.13022040212585462,
+     "mean_loss_diff": -0.013542677224912389,
+     "hac_variance": 0.09950460507231254,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 0.8545791611956696,
+     "p_value": 0.3929487088662673,
+     "mean_loss_diff": 0.020656887215944067,
+     "hac_variance": 0.7268512476022216,
+     "n_obs": 1245,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     0.005554075541608805,
+     -0.018427748981054502,
+     -0.011493993749644386,
+     -0.004595357203536677,
+     -0.01781975140250364
+    ],
+    "ewma": [
+     -0.1880733157687444,
+     0.001033163402923365,
+     -0.0802912027738497,
+     0.028043679914234367,
+     0.006972238376790522
+    ],
+    "log_har": [
+     -0.06781894044507868,
+     0.35864125362250837,
+     0.03765916819494002,
+     0.19987813927852874,
+     -0.0004624755687501943
+    ],
+    "har_rv": [
+     0.005554075534825668,
+     -0.018427748981204355,
+     -0.011493993750034045,
+     -0.004595357203653575,
+     -0.01781975140271692
+    ],
+    "tsfm": [
+     -0.09256933449929984,
+     0.14285380108044163,
+     -0.04223836211760282,
+     0.14172015289369308,
+     0.03265419426795888
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "cb3c8ae1999b0547974eb9a6b7b385e6bc5589e68e245a3875ea83dd120006b2"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "a5a51184fdfa92829bd82e3681c285331fab1559c87a8d8a47e530b4bd5faaa2"
+    ],
+    "log_har": [
+     "081062086be9c0aa9fc064c1bf9af7ed689af01968e35b57f0a6fd37532a6d7c",
+     "6cbc2f87d031f2f63660c08969bde2c23d6aa10cd5542a662b07658d3bd01976",
+     "1687c34f928b1ee895093552757adf9f5cad62d213745315a1f158f879d33f37",
+     "33c63ebe58175f519c105bf5295c35367d751619e7e694cdfa0e59526121adb2",
+     "8302656aa6897dcd1a1192e6317283b3928532f9c714616238027d9ab36509e1"
+    ],
+    "har_rv": [
+     "f42aa00b705d50f94fbf4e53bcab91cc265b0a39a6b4bcc5670a5e3e231f997b",
+     "834b3f791dd59fff5268d6659032f6ccfdf89850199bd44ed3ed564d05216125",
+     "49321deda4a95e3f3f678919fd31cb8602af98cc9fdbaeb0e7783cfb6ec9b946",
+     "b79c2034980fd0b0ce285813309ae69f4f923eb7158aabf8eae61c9740e13c67",
+     "ae7bd895887115baa2e37dfc7b41fd2389f76daae6afabbae2ec43b462d39928"
+    ],
+    "tsfm": [
+     "b91fef97e68fcab02d1069fc39d7639584a5357d620b3b15a0ec3a6e29a4f1cb",
+     "75ab61f7832a93c442f87bc90644eed797a8a77f6f7c2e414bed051d5992ef40",
+     "2dd130c662a7ff7e3d2271ef1d023021d693f259f01bffc62e83ae303e6431f8",
+     "5269119f16ebe0a06e765b3951645507df583c2e7a636c42baa473815abd14db",
+     "f83a44d1e8c945a883c8ad3652f10cace8988155c71e30f4802dc5b0f45cee79"
+    ]
+   },
+   "n_oos": 1245,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.13073164905714255,
+     "0.2": 0.2095016855131374,
+     "0.3": 0.2620714181347537,
+     "0.4": 0.29443029796379155,
+     "0.5": 0.3065591144988673,
+     "0.6": 0.3009003936136734,
+     "0.7": 0.2759817322557216,
+     "0.8": 0.22926289942266562,
+     "0.9": 0.15297304287925392
+    },
+    "coverage_80": 0.8064257028112449,
+    "width_80": 1.9705003859048866,
+    "nominal_80": 0.8,
+    "n_obs": 1245,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "seed": 0,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.7568980409120822,
+     "mse_debiased": 0.7588700622206963,
+     "mae_debiased": 0.681586300684371,
+     "qlike_debiased": 0.5154669239514529,
+     "signed_bias_debiased": -0.03049772270975305,
+     "n_oos": 1242
+    },
+    "ewma": {
+     "mse_raw": 0.3707454406711131,
+     "mse_debiased": 0.3977221670848516,
+     "mae_debiased": 0.4753450545539377,
+     "qlike_debiased": 0.283274127801082,
+     "signed_bias_debiased": -0.07698294367262286,
+     "n_oos": 1242
+    },
+    "log_har": {
+     "mse_raw": 0.37203629093511775,
+     "mse_debiased": 0.4271530205576863,
+     "mae_debiased": 0.5171068987361491,
+     "qlike_debiased": 0.2620215887771005,
+     "signed_bias_debiased": 0.03460721812237744,
+     "n_oos": 1242
+    },
+    "har_rv": {
+     "mse_raw": 0.756898040909704,
+     "mse_debiased": 0.7588700622186395,
+     "mae_debiased": 0.6815863006837287,
+     "qlike_debiased": 0.5154669239495797,
+     "signed_bias_debiased": -0.030497722712575913,
+     "n_oos": 1242
+    },
+    "tsfm": {
+     "mse_raw": 0.33956844973349043,
+     "mse_debiased": 0.38151722454214787,
+     "mae_debiased": 0.4793137340620895,
+     "qlike_debiased": 0.24387998087954788,
+     "signed_bias_debiased": 0.004482813379115504,
+     "n_oos": 1242
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.889053611583417,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376785485,
+     "hac_variance": 2.2220454502829856,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -0.8753756097027213,
+     "p_value": 0.3815389562129372,
+     "mean_loss_diff": -0.01620494254270372,
+     "hac_variance": 0.42254683766661116,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.7370123433571227,
+     "p_value": 0.0001946869813498342,
+     "mean_loss_diff": -0.045635796015538396,
+     "hac_variance": 0.18387849660729816,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.889053611567274,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376764917,
+     "hac_variance": 2.222045450266834,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 1.0717575003836914,
+     "p_value": 0.284037345147206,
+     "mean_loss_diff": 0.034980536088868544,
+     "hac_variance": 1.3134955547114833,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.345460496229117,
+     "p_value": 1.5033678565146147e-05,
+     "mean_loss_diff": 0.08146575705173835,
+     "hac_variance": 0.4333585121595135,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.194972231573671,
+     "p_value": 0.02835029281773238,
+     "mean_loss_diff": -0.030124404743261956,
+     "hac_variance": 0.23224567536233387,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 1.0717575004817912,
+     "p_value": 0.28403734510314993,
+     "mean_loss_diff": 0.0349805360916914,
+     "hac_variance": 1.3134955546830231,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.028762012395295522,
+     -0.07068416522339546,
+     -0.022020576689171994,
+     0.012557871864366505,
+     -0.04246564372084032
+    ],
+    "ewma": [
+     -0.24903330708600377,
+     -0.038883745941850685,
+     -0.10658881522851042,
+     0.05535356344947669,
+     0.014287897181277194
+    ],
+    "log_har": [
+     -0.1342016108359201,
+     0.5453843855163018,
+     0.07075577114585686,
+     0.337943334957265,
+     0.0019632599810427737
+    ],
+    "har_rv": [
+     -0.028762012415760294,
+     -0.07068416522384631,
+     -0.02202057669031984,
+     0.01255787186400646,
+     -0.042465643721435846
+    ],
+    "tsfm": [
+     -0.1774835855512458,
+     0.16143854280975864,
+     -0.07621770909809551,
+     0.25258247881777596,
+     0.06885649388000627
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "9e537656d34396682b5823f01dd06944313f9d4cabb2d1c504da3b7b07002356"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "efa79f3a676562c3ecec23750a6589a11077a6a8ffc714d415c10e622235e6ad"
+    ],
+    "log_har": [
+     "1728e42bbacd7748d94926bd9092da888ca85c2e9362c2f9fed8c26b7903c3ad",
+     "547395d7d16f7ca0d8b0a7c02a15a3dafe0991d1a3f8432279e6c6775c841f40",
+     "f5a0cf9dda30a098cc09104ae137d4c06c4afcfd8934637276d59f07c43447f9",
+     "d65dddb82f7aa6c8509effc3fd2d9f477f4ad5ddcb1d3b69e687b71da945ac97",
+     "651f0f2d8be7d0cd47bf7d842ff33c61692aa4507821f11737f822f03e117f03"
+    ],
+    "har_rv": [
+     "cf7470c12245b7b73decdd43bcc196ff3620f88206b6aeea7e775f7fa0487475",
+     "de3e4cb984661d4c4113c22f521d4ed2cd17d63892f91fc17c516153d3012b83",
+     "8cbf2b7c23931aca27b1be151fbcfa02e9fa1ff070a1dcd8e53b5438cbc8ec57",
+     "024af203cd2a00c84caa52e7396f3023f48f325dc22dfe932b28c1a149bd5cef",
+     "04cc6d7bf3a05aa953e962b1fd21b8793d48104d4785864f9450d9165bfb175f"
+    ],
+    "tsfm": [
+     "b9ae47d3bc7cf369c94473dd5260bb357e5efa76e9cd4eaba735bbbf97581799",
+     "476148a6fb7e37661e2e495827adebb940f32e35798d8c72196cdd25e0c2182a",
+     "e00cdfec280d94aaab5825dc39b15a7e1e024c211aa4dc8aac29421d289a491d",
+     "155ba5c82d75d2469b33ac84067e0a196f2760c270df7c69d87044cc27d69cbb",
+     "63d6c7c2cfff32341f2ee5bfd61e83917f02ebe8d8fe1604a85eb7376d6b040e"
+    ]
+   },
+   "n_oos": 1242,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14867858563419586,
+     "0.2": 0.23919855330299014,
+     "0.3": 0.29868620723313893,
+     "0.4": 0.33529812038514656,
+     "0.5": 0.3503786725842651,
+     "0.6": 0.3475199667749395,
+     "0.7": 0.322724870755453,
+     "0.8": 0.27083979431532773,
+     "0.9": 0.18174876848655197
+    },
+    "coverage_80": 0.7946859903381642,
+    "width_80": 2.2251922176272014,
+    "nominal_80": 0.8,
+    "n_obs": 1242,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "seed": 7,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.7568980409120822,
+     "mse_debiased": 0.7588700622206963,
+     "mae_debiased": 0.681586300684371,
+     "qlike_debiased": 0.5154669239514529,
+     "signed_bias_debiased": -0.03049772270975305,
+     "n_oos": 1242
+    },
+    "ewma": {
+     "mse_raw": 0.3707454406711131,
+     "mse_debiased": 0.3977221670848516,
+     "mae_debiased": 0.4753450545539377,
+     "qlike_debiased": 0.283274127801082,
+     "signed_bias_debiased": -0.07698294367262286,
+     "n_oos": 1242
+    },
+    "log_har": {
+     "mse_raw": 0.37203629093511775,
+     "mse_debiased": 0.4271530205576863,
+     "mae_debiased": 0.5171068987361491,
+     "qlike_debiased": 0.2620215887771005,
+     "signed_bias_debiased": 0.03460721812237744,
+     "n_oos": 1242
+    },
+    "har_rv": {
+     "mse_raw": 0.756898040909704,
+     "mse_debiased": 0.7588700622186395,
+     "mae_debiased": 0.6815863006837287,
+     "qlike_debiased": 0.5154669239495797,
+     "signed_bias_debiased": -0.030497722712575913,
+     "n_oos": 1242
+    },
+    "tsfm": {
+     "mse_raw": 0.33956844973349043,
+     "mse_debiased": 0.38151722454214787,
+     "mae_debiased": 0.4793137340620895,
+     "qlike_debiased": 0.24387998087954788,
+     "signed_bias_debiased": 0.004482813379115504,
+     "n_oos": 1242
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.889053611583417,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376785485,
+     "hac_variance": 2.2220454502829856,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -0.8753756097027213,
+     "p_value": 0.3815389562129372,
+     "mean_loss_diff": -0.01620494254270372,
+     "hac_variance": 0.42254683766661116,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.7370123433571227,
+     "p_value": 0.0001946869813498342,
+     "mean_loss_diff": -0.045635796015538396,
+     "hac_variance": 0.18387849660729816,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.889053611567274,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376764917,
+     "hac_variance": 2.222045450266834,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 1.0717575003836914,
+     "p_value": 0.284037345147206,
+     "mean_loss_diff": 0.034980536088868544,
+     "hac_variance": 1.3134955547114833,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.345460496229117,
+     "p_value": 1.5033678565146147e-05,
+     "mean_loss_diff": 0.08146575705173835,
+     "hac_variance": 0.4333585121595135,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.194972231573671,
+     "p_value": 0.02835029281773238,
+     "mean_loss_diff": -0.030124404743261956,
+     "hac_variance": 0.23224567536233387,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 1.0717575004817912,
+     "p_value": 0.28403734510314993,
+     "mean_loss_diff": 0.0349805360916914,
+     "hac_variance": 1.3134955546830231,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.028762012395295522,
+     -0.07068416522339546,
+     -0.022020576689171994,
+     0.012557871864366505,
+     -0.04246564372084032
+    ],
+    "ewma": [
+     -0.24903330708600377,
+     -0.038883745941850685,
+     -0.10658881522851042,
+     0.05535356344947669,
+     0.014287897181277194
+    ],
+    "log_har": [
+     -0.1342016108359201,
+     0.5453843855163018,
+     0.07075577114585686,
+     0.337943334957265,
+     0.0019632599810427737
+    ],
+    "har_rv": [
+     -0.028762012415760294,
+     -0.07068416522384631,
+     -0.02202057669031984,
+     0.01255787186400646,
+     -0.042465643721435846
+    ],
+    "tsfm": [
+     -0.1774835855512458,
+     0.16143854280975864,
+     -0.07621770909809551,
+     0.25258247881777596,
+     0.06885649388000627
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "9e537656d34396682b5823f01dd06944313f9d4cabb2d1c504da3b7b07002356"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "efa79f3a676562c3ecec23750a6589a11077a6a8ffc714d415c10e622235e6ad"
+    ],
+    "log_har": [
+     "1728e42bbacd7748d94926bd9092da888ca85c2e9362c2f9fed8c26b7903c3ad",
+     "547395d7d16f7ca0d8b0a7c02a15a3dafe0991d1a3f8432279e6c6775c841f40",
+     "f5a0cf9dda30a098cc09104ae137d4c06c4afcfd8934637276d59f07c43447f9",
+     "d65dddb82f7aa6c8509effc3fd2d9f477f4ad5ddcb1d3b69e687b71da945ac97",
+     "651f0f2d8be7d0cd47bf7d842ff33c61692aa4507821f11737f822f03e117f03"
+    ],
+    "har_rv": [
+     "cf7470c12245b7b73decdd43bcc196ff3620f88206b6aeea7e775f7fa0487475",
+     "de3e4cb984661d4c4113c22f521d4ed2cd17d63892f91fc17c516153d3012b83",
+     "8cbf2b7c23931aca27b1be151fbcfa02e9fa1ff070a1dcd8e53b5438cbc8ec57",
+     "024af203cd2a00c84caa52e7396f3023f48f325dc22dfe932b28c1a149bd5cef",
+     "04cc6d7bf3a05aa953e962b1fd21b8793d48104d4785864f9450d9165bfb175f"
+    ],
+    "tsfm": [
+     "b9ae47d3bc7cf369c94473dd5260bb357e5efa76e9cd4eaba735bbbf97581799",
+     "476148a6fb7e37661e2e495827adebb940f32e35798d8c72196cdd25e0c2182a",
+     "e00cdfec280d94aaab5825dc39b15a7e1e024c211aa4dc8aac29421d289a491d",
+     "155ba5c82d75d2469b33ac84067e0a196f2760c270df7c69d87044cc27d69cbb",
+     "63d6c7c2cfff32341f2ee5bfd61e83917f02ebe8d8fe1604a85eb7376d6b040e"
+    ]
+   },
+   "n_oos": 1242,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14867858563419586,
+     "0.2": 0.23919855330299014,
+     "0.3": 0.29868620723313893,
+     "0.4": 0.33529812038514656,
+     "0.5": 0.3503786725842651,
+     "0.6": 0.3475199667749395,
+     "0.7": 0.322724870755453,
+     "0.8": 0.27083979431532773,
+     "0.9": 0.18174876848655197
+    },
+    "coverage_80": 0.7946859903381642,
+    "width_80": 2.2251922176272014,
+    "nominal_80": 0.8,
+    "n_obs": 1242,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "seed": 42,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.7568980409120822,
+     "mse_debiased": 0.7588700622206963,
+     "mae_debiased": 0.681586300684371,
+     "qlike_debiased": 0.5154669239514529,
+     "signed_bias_debiased": -0.03049772270975305,
+     "n_oos": 1242
+    },
+    "ewma": {
+     "mse_raw": 0.3707454406711131,
+     "mse_debiased": 0.3977221670848516,
+     "mae_debiased": 0.4753450545539377,
+     "qlike_debiased": 0.283274127801082,
+     "signed_bias_debiased": -0.07698294367262286,
+     "n_oos": 1242
+    },
+    "log_har": {
+     "mse_raw": 0.37203629093511775,
+     "mse_debiased": 0.4271530205576863,
+     "mae_debiased": 0.5171068987361491,
+     "qlike_debiased": 0.2620215887771005,
+     "signed_bias_debiased": 0.03460721812237744,
+     "n_oos": 1242
+    },
+    "har_rv": {
+     "mse_raw": 0.756898040909704,
+     "mse_debiased": 0.7588700622186395,
+     "mae_debiased": 0.6815863006837287,
+     "qlike_debiased": 0.5154669239495797,
+     "signed_bias_debiased": -0.030497722712575913,
+     "n_oos": 1242
+    },
+    "tsfm": {
+     "mse_raw": 0.33956844973349043,
+     "mse_debiased": 0.38151722454214787,
+     "mae_debiased": 0.4793137340620895,
+     "qlike_debiased": 0.24387998087954788,
+     "signed_bias_debiased": 0.004482813379115504,
+     "n_oos": 1242
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.889053611583417,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376785485,
+     "hac_variance": 2.2220454502829856,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -0.8753756097027213,
+     "p_value": 0.3815389562129372,
+     "mean_loss_diff": -0.01620494254270372,
+     "hac_variance": 0.42254683766661116,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.7370123433571227,
+     "p_value": 0.0001946869813498342,
+     "mean_loss_diff": -0.045635796015538396,
+     "hac_variance": 0.18387849660729816,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.889053611567274,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376764917,
+     "hac_variance": 2.222045450266834,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 1.0717575003836914,
+     "p_value": 0.284037345147206,
+     "mean_loss_diff": 0.034980536088868544,
+     "hac_variance": 1.3134955547114833,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.345460496229117,
+     "p_value": 1.5033678565146147e-05,
+     "mean_loss_diff": 0.08146575705173835,
+     "hac_variance": 0.4333585121595135,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.194972231573671,
+     "p_value": 0.02835029281773238,
+     "mean_loss_diff": -0.030124404743261956,
+     "hac_variance": 0.23224567536233387,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 1.0717575004817912,
+     "p_value": 0.28403734510314993,
+     "mean_loss_diff": 0.0349805360916914,
+     "hac_variance": 1.3134955546830231,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.028762012395295522,
+     -0.07068416522339546,
+     -0.022020576689171994,
+     0.012557871864366505,
+     -0.04246564372084032
+    ],
+    "ewma": [
+     -0.24903330708600377,
+     -0.038883745941850685,
+     -0.10658881522851042,
+     0.05535356344947669,
+     0.014287897181277194
+    ],
+    "log_har": [
+     -0.1342016108359201,
+     0.5453843855163018,
+     0.07075577114585686,
+     0.337943334957265,
+     0.0019632599810427737
+    ],
+    "har_rv": [
+     -0.028762012415760294,
+     -0.07068416522384631,
+     -0.02202057669031984,
+     0.01255787186400646,
+     -0.042465643721435846
+    ],
+    "tsfm": [
+     -0.1774835855512458,
+     0.16143854280975864,
+     -0.07621770909809551,
+     0.25258247881777596,
+     0.06885649388000627
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "9e537656d34396682b5823f01dd06944313f9d4cabb2d1c504da3b7b07002356"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "efa79f3a676562c3ecec23750a6589a11077a6a8ffc714d415c10e622235e6ad"
+    ],
+    "log_har": [
+     "1728e42bbacd7748d94926bd9092da888ca85c2e9362c2f9fed8c26b7903c3ad",
+     "547395d7d16f7ca0d8b0a7c02a15a3dafe0991d1a3f8432279e6c6775c841f40",
+     "f5a0cf9dda30a098cc09104ae137d4c06c4afcfd8934637276d59f07c43447f9",
+     "d65dddb82f7aa6c8509effc3fd2d9f477f4ad5ddcb1d3b69e687b71da945ac97",
+     "651f0f2d8be7d0cd47bf7d842ff33c61692aa4507821f11737f822f03e117f03"
+    ],
+    "har_rv": [
+     "cf7470c12245b7b73decdd43bcc196ff3620f88206b6aeea7e775f7fa0487475",
+     "de3e4cb984661d4c4113c22f521d4ed2cd17d63892f91fc17c516153d3012b83",
+     "8cbf2b7c23931aca27b1be151fbcfa02e9fa1ff070a1dcd8e53b5438cbc8ec57",
+     "024af203cd2a00c84caa52e7396f3023f48f325dc22dfe932b28c1a149bd5cef",
+     "04cc6d7bf3a05aa953e962b1fd21b8793d48104d4785864f9450d9165bfb175f"
+    ],
+    "tsfm": [
+     "b9ae47d3bc7cf369c94473dd5260bb357e5efa76e9cd4eaba735bbbf97581799",
+     "476148a6fb7e37661e2e495827adebb940f32e35798d8c72196cdd25e0c2182a",
+     "e00cdfec280d94aaab5825dc39b15a7e1e024c211aa4dc8aac29421d289a491d",
+     "155ba5c82d75d2469b33ac84067e0a196f2760c270df7c69d87044cc27d69cbb",
+     "63d6c7c2cfff32341f2ee5bfd61e83917f02ebe8d8fe1604a85eb7376d6b040e"
+    ]
+   },
+   "n_oos": 1242,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14867858563419586,
+     "0.2": 0.23919855330299014,
+     "0.3": 0.29868620723313893,
+     "0.4": 0.33529812038514656,
+     "0.5": 0.3503786725842651,
+     "0.6": 0.3475199667749395,
+     "0.7": 0.322724870755453,
+     "0.8": 0.27083979431532773,
+     "0.9": 0.18174876848655197
+    },
+    "coverage_80": 0.7946859903381642,
+    "width_80": 2.2251922176272014,
+    "nominal_80": 0.8,
+    "n_obs": 1242,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "seed": 99,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.7568980409120822,
+     "mse_debiased": 0.7588700622206963,
+     "mae_debiased": 0.681586300684371,
+     "qlike_debiased": 0.5154669239514529,
+     "signed_bias_debiased": -0.03049772270975305,
+     "n_oos": 1242
+    },
+    "ewma": {
+     "mse_raw": 0.3707454406711131,
+     "mse_debiased": 0.3977221670848516,
+     "mae_debiased": 0.4753450545539377,
+     "qlike_debiased": 0.283274127801082,
+     "signed_bias_debiased": -0.07698294367262286,
+     "n_oos": 1242
+    },
+    "log_har": {
+     "mse_raw": 0.37203629093511775,
+     "mse_debiased": 0.4271530205576863,
+     "mae_debiased": 0.5171068987361491,
+     "qlike_debiased": 0.2620215887771005,
+     "signed_bias_debiased": 0.03460721812237744,
+     "n_oos": 1242
+    },
+    "har_rv": {
+     "mse_raw": 0.756898040909704,
+     "mse_debiased": 0.7588700622186395,
+     "mae_debiased": 0.6815863006837287,
+     "qlike_debiased": 0.5154669239495797,
+     "signed_bias_debiased": -0.030497722712575913,
+     "n_oos": 1242
+    },
+    "tsfm": {
+     "mse_raw": 0.33956844973349043,
+     "mse_debiased": 0.38151722454214787,
+     "mae_debiased": 0.4793137340620895,
+     "qlike_debiased": 0.24387998087954788,
+     "signed_bias_debiased": 0.004482813379115504,
+     "n_oos": 1242
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -8.889053611583417,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376785485,
+     "hac_variance": 2.2220454502829856,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -0.8753756097027213,
+     "p_value": 0.3815389562129372,
+     "mean_loss_diff": -0.01620494254270372,
+     "hac_variance": 0.42254683766661116,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -3.7370123433571227,
+     "p_value": 0.0001946869813498342,
+     "mean_loss_diff": -0.045635796015538396,
+     "hac_variance": 0.18387849660729816,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -8.889053611567274,
+     "p_value": 0.0,
+     "mean_loss_diff": -0.3773528376764917,
+     "hac_variance": 2.222045450266834,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 1.0717575003836914,
+     "p_value": 0.284037345147206,
+     "mean_loss_diff": 0.034980536088868544,
+     "hac_variance": 1.3134955547114833,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 4.345460496229117,
+     "p_value": 1.5033678565146147e-05,
+     "mean_loss_diff": 0.08146575705173835,
+     "hac_variance": 0.4333585121595135,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.194972231573671,
+     "p_value": 0.02835029281773238,
+     "mean_loss_diff": -0.030124404743261956,
+     "hac_variance": 0.23224567536233387,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 1.0717575004817912,
+     "p_value": 0.28403734510314993,
+     "mean_loss_diff": 0.0349805360916914,
+     "hac_variance": 1.3134955546830231,
+     "n_obs": 1242,
+     "lag": 10,
+     "verdict": "INCONCLUSIVE",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.028762012395295522,
+     -0.07068416522339546,
+     -0.022020576689171994,
+     0.012557871864366505,
+     -0.04246564372084032
+    ],
+    "ewma": [
+     -0.24903330708600377,
+     -0.038883745941850685,
+     -0.10658881522851042,
+     0.05535356344947669,
+     0.014287897181277194
+    ],
+    "log_har": [
+     -0.1342016108359201,
+     0.5453843855163018,
+     0.07075577114585686,
+     0.337943334957265,
+     0.0019632599810427737
+    ],
+    "har_rv": [
+     -0.028762012415760294,
+     -0.07068416522384631,
+     -0.02202057669031984,
+     0.01255787186400646,
+     -0.042465643721435846
+    ],
+    "tsfm": [
+     -0.1774835855512458,
+     0.16143854280975864,
+     -0.07621770909809551,
+     0.25258247881777596,
+     0.06885649388000627
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "9e537656d34396682b5823f01dd06944313f9d4cabb2d1c504da3b7b07002356"
+    ],
+    "ewma": [
+     "5eb4cd9184d5e6578d529f3928e9a5a96273e291296d0f31e5c0be7a497757c1",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "80e91bbb0a7935b12d34b40524a33dd9205bec49c8f1473e5fa433611f6832fb",
+     "6b41779ca7c352084a94c464d62cf960295cc7b203a82c672664567b7b135816",
+     "efa79f3a676562c3ecec23750a6589a11077a6a8ffc714d415c10e622235e6ad"
+    ],
+    "log_har": [
+     "1728e42bbacd7748d94926bd9092da888ca85c2e9362c2f9fed8c26b7903c3ad",
+     "547395d7d16f7ca0d8b0a7c02a15a3dafe0991d1a3f8432279e6c6775c841f40",
+     "f5a0cf9dda30a098cc09104ae137d4c06c4afcfd8934637276d59f07c43447f9",
+     "d65dddb82f7aa6c8509effc3fd2d9f477f4ad5ddcb1d3b69e687b71da945ac97",
+     "651f0f2d8be7d0cd47bf7d842ff33c61692aa4507821f11737f822f03e117f03"
+    ],
+    "har_rv": [
+     "cf7470c12245b7b73decdd43bcc196ff3620f88206b6aeea7e775f7fa0487475",
+     "de3e4cb984661d4c4113c22f521d4ed2cd17d63892f91fc17c516153d3012b83",
+     "8cbf2b7c23931aca27b1be151fbcfa02e9fa1ff070a1dcd8e53b5438cbc8ec57",
+     "024af203cd2a00c84caa52e7396f3023f48f325dc22dfe932b28c1a149bd5cef",
+     "04cc6d7bf3a05aa953e962b1fd21b8793d48104d4785864f9450d9165bfb175f"
+    ],
+    "tsfm": [
+     "b9ae47d3bc7cf369c94473dd5260bb357e5efa76e9cd4eaba735bbbf97581799",
+     "476148a6fb7e37661e2e495827adebb940f32e35798d8c72196cdd25e0c2182a",
+     "e00cdfec280d94aaab5825dc39b15a7e1e024c211aa4dc8aac29421d289a491d",
+     "155ba5c82d75d2469b33ac84067e0a196f2760c270df7c69d87044cc27d69cbb",
+     "63d6c7c2cfff32341f2ee5bfd61e83917f02ebe8d8fe1604a85eb7376d6b040e"
+    ]
+   },
+   "n_oos": 1242,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.14867858563419586,
+     "0.2": 0.23919855330299014,
+     "0.3": 0.29868620723313893,
+     "0.4": 0.33529812038514656,
+     "0.5": 0.3503786725842651,
+     "0.6": 0.3475199667749395,
+     "0.7": 0.322724870755453,
+     "0.8": 0.27083979431532773,
+     "0.9": 0.18174876848655197
+    },
+    "coverage_80": 0.7946859903381642,
+    "width_80": 2.2251922176272014,
+    "nominal_80": 0.8,
+    "n_obs": 1242,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "seed": 0,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.8534417338424453,
+     "mse_debiased": 0.9295980818702669,
+     "mae_debiased": 0.7489658666052187,
+     "qlike_debiased": 0.6937119148824531,
+     "signed_bias_debiased": -0.14711493514705298,
+     "n_oos": 1225
+    },
+    "ewma": {
+     "mse_raw": 0.35635952736284915,
+     "mse_debiased": 0.5566983245556639,
+     "mae_debiased": 0.5866718284319071,
+     "qlike_debiased": 0.33686661363287645,
+     "signed_bias_debiased": -0.0625257112813957,
+     "n_oos": 1225
+    },
+    "log_har": {
+     "mse_raw": 0.396348345620637,
+     "mse_debiased": 0.5603787927430063,
+     "mae_debiased": 0.6088145451149602,
+     "qlike_debiased": 0.3147213744114635,
+     "signed_bias_debiased": 0.06744232594655668,
+     "n_oos": 1225
+    },
+    "har_rv": {
+     "mse_raw": 0.8534417338291221,
+     "mse_debiased": 0.9295980818639688,
+     "mae_debiased": 0.7489658666041834,
+     "qlike_debiased": 0.6937119148635806,
+     "signed_bias_debiased": -0.14711493515413265,
+     "n_oos": 1225
+    },
+    "tsfm": {
+     "mse_raw": 0.3284956413446431,
+     "mse_debiased": 0.4904712884028434,
+     "mae_debiased": 0.5560790823946081,
+     "qlike_debiased": 0.287322800698733,
+     "signed_bias_debiased": -0.008314361329939787,
+     "n_oos": 1225
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -7.126289278688061,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.43912679346742356,
+     "hac_variance": 4.489613994727299,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.185853125457631,
+     "p_value": 0.029015296442367777,
+     "mean_loss_diff": -0.06622703615282058,
+     "hac_variance": 1.085387237984486,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.011253626851238,
+     "p_value": 0.04451756362705139,
+     "mean_loss_diff": -0.06990750434016293,
+     "hac_variance": 1.428466111257925,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -7.126289278799675,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.4391267934611253,
+     "hac_variance": 4.489613994457879,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 3.1997907116206155,
+     "p_value": 0.0014105784010645106,
+     "mean_loss_diff": 0.1388005738171132,
+     "hac_variance": 2.224822673614323,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 1.9859458274306576,
+     "p_value": 0.04726211858000573,
+     "mean_loss_diff": 0.054211349951455934,
+     "hac_variance": 0.881052269815522,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.95658986615561,
+     "p_value": 0.003170248925905561,
+     "mean_loss_diff": -0.07575668727649645,
+     "hac_variance": 0.7762753725221041,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 3.1997907118561315,
+     "p_value": 0.001410578399921647,
+     "mean_loss_diff": 0.1388005738241929,
+     "hac_variance": 2.224822673513773,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.3244035148651606,
+     -0.38113486375234373,
+     -0.2251366808274129,
+     0.08372486909764812,
+     0.13151560470442417
+    ],
+    "ewma": [
+     -0.3827566465288271,
+     -0.3658907497196716,
+     -0.2963076231980935,
+     0.5013677632145388,
+     0.2082938762247561
+    ],
+    "log_har": [
+     -0.2459246220966368,
+     0.8157259092887365,
+     0.09194804513376223,
+     0.6661629016547302,
+     0.16386998288214247
+    ],
+    "har_rv": [
+     -0.32440351492517866,
+     -0.3811348637535923,
+     -0.22513668083116756,
+     0.08372486909622145,
+     0.13151560470173282
+    ],
+    "tsfm": [
+     -0.3589715503525329,
+     0.04786245231131396,
+     -0.16001282666480188,
+     0.5542448868399108,
+     0.30310410294165396
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "4d63fd8e0582e7035913f2ee893bce80815391812e84cefb945da9604ed15d44"
+    ],
+    "ewma": [
+     "a781646c93a1dd60a8b40bae4e76fede4900b642a988230afaeac6122cca63ee",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "2b691b16905dc75955e9cf03dc9a8a2f4082948cddbc39164fa85243cbb739ee",
+     "caf67214d31583d7917fe8c98db8dca4cb8677d295f48ceb91ec0df1561876d4",
+     "5baef3234c9166d71167a24a302772d7061512a4450eaac7010a7d07b63772bf"
+    ],
+    "log_har": [
+     "981bf9f03f847aea5b204bc631007eb198e77766b8bb0aaf5574d455635abfe3",
+     "3f3038195445c27084e0285b049c9c8116b6bc82666c6fa314a3db9f7ccccd39",
+     "80f0e42e48c1bb335bea09fe40b842d8e27f0a64ebf2eebb24c2c477d33f1337",
+     "e25db7ab93757797198599a3e979c6075e0c508368724bb040035a56b512aec8",
+     "fd6dad22121aae2fbc234b78d4501658e3c26d8909f38a2242ba31be95f782ee"
+    ],
+    "har_rv": [
+     "bfd0f855303d84e2b3b9eea6c46e52f4fa59dbf7fb37a1497663f443c9422621",
+     "2661d5b4c66e84fed0eabe134947e20229ae10fbca07494e84c971f4d6ff8dbe",
+     "b57a1c9c93cbeef58f295393cc4f01c665c6770c41d71a0e39a473b774ffdb79",
+     "1eefcc362a436c83bca0024e4aed4659d482bc2890ecec9c7c3c73048b9d090a",
+     "9824f3cef8c25649f6cb67c661114d112eb2e34a9aae16cceb86cf53b24805df"
+    ],
+    "tsfm": [
+     "cf94c0d757628c1b9b825e52b442d299cda8d14a4036857e7626501dd0e4de57",
+     "c0e2bfba70bbb06b4abc1d5d4404ae169f35e1b8a83ae08191da8cc4f2283753",
+     "0212153a671b951894b71fb8e6aa7b0211124f00c51756153f8c94f4d6623ece",
+     "2716b36195a39b46f26574b04930e12e1b697f7adb335bc96bf5ff314043f23e",
+     "98df41d730ce3d2feecc793f221e7219e9ab634d2c99279ce95b70d75c4d774e"
+    ]
+   },
+   "n_oos": 1225,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.18276099313787506,
+     "0.2": 0.28902467997076126,
+     "0.3": 0.3561457376144696,
+     "0.4": 0.39327725688839626,
+     "0.5": 0.40642357894060227,
+     "0.6": 0.3968003653155512,
+     "0.7": 0.36337824202904917,
+     "0.8": 0.29866283421157047,
+     "0.9": 0.1924683617644314
+    },
+    "coverage_80": 0.7738775510204081,
+    "width_80": 2.5405068693355637,
+    "nominal_80": 0.8,
+    "n_obs": 1225,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "seed": 7,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.8534417338424453,
+     "mse_debiased": 0.9295980818702669,
+     "mae_debiased": 0.7489658666052187,
+     "qlike_debiased": 0.6937119148824531,
+     "signed_bias_debiased": -0.14711493514705298,
+     "n_oos": 1225
+    },
+    "ewma": {
+     "mse_raw": 0.35635952736284915,
+     "mse_debiased": 0.5566983245556639,
+     "mae_debiased": 0.5866718284319071,
+     "qlike_debiased": 0.33686661363287645,
+     "signed_bias_debiased": -0.0625257112813957,
+     "n_oos": 1225
+    },
+    "log_har": {
+     "mse_raw": 0.396348345620637,
+     "mse_debiased": 0.5603787927430063,
+     "mae_debiased": 0.6088145451149602,
+     "qlike_debiased": 0.3147213744114635,
+     "signed_bias_debiased": 0.06744232594655668,
+     "n_oos": 1225
+    },
+    "har_rv": {
+     "mse_raw": 0.8534417338291221,
+     "mse_debiased": 0.9295980818639688,
+     "mae_debiased": 0.7489658666041834,
+     "qlike_debiased": 0.6937119148635806,
+     "signed_bias_debiased": -0.14711493515413265,
+     "n_oos": 1225
+    },
+    "tsfm": {
+     "mse_raw": 0.3284956413446431,
+     "mse_debiased": 0.4904712884028434,
+     "mae_debiased": 0.5560790823946081,
+     "qlike_debiased": 0.287322800698733,
+     "signed_bias_debiased": -0.008314361329939787,
+     "n_oos": 1225
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -7.126289278688061,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.43912679346742356,
+     "hac_variance": 4.489613994727299,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.185853125457631,
+     "p_value": 0.029015296442367777,
+     "mean_loss_diff": -0.06622703615282058,
+     "hac_variance": 1.085387237984486,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.011253626851238,
+     "p_value": 0.04451756362705139,
+     "mean_loss_diff": -0.06990750434016293,
+     "hac_variance": 1.428466111257925,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -7.126289278799675,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.4391267934611253,
+     "hac_variance": 4.489613994457879,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 3.1997907116206155,
+     "p_value": 0.0014105784010645106,
+     "mean_loss_diff": 0.1388005738171132,
+     "hac_variance": 2.224822673614323,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 1.9859458274306576,
+     "p_value": 0.04726211858000573,
+     "mean_loss_diff": 0.054211349951455934,
+     "hac_variance": 0.881052269815522,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.95658986615561,
+     "p_value": 0.003170248925905561,
+     "mean_loss_diff": -0.07575668727649645,
+     "hac_variance": 0.7762753725221041,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 3.1997907118561315,
+     "p_value": 0.001410578399921647,
+     "mean_loss_diff": 0.1388005738241929,
+     "hac_variance": 2.224822673513773,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.3244035148651606,
+     -0.38113486375234373,
+     -0.2251366808274129,
+     0.08372486909764812,
+     0.13151560470442417
+    ],
+    "ewma": [
+     -0.3827566465288271,
+     -0.3658907497196716,
+     -0.2963076231980935,
+     0.5013677632145388,
+     0.2082938762247561
+    ],
+    "log_har": [
+     -0.2459246220966368,
+     0.8157259092887365,
+     0.09194804513376223,
+     0.6661629016547302,
+     0.16386998288214247
+    ],
+    "har_rv": [
+     -0.32440351492517866,
+     -0.3811348637535923,
+     -0.22513668083116756,
+     0.08372486909622145,
+     0.13151560470173282
+    ],
+    "tsfm": [
+     -0.3589715503525329,
+     0.04786245231131396,
+     -0.16001282666480188,
+     0.5542448868399108,
+     0.30310410294165396
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "4d63fd8e0582e7035913f2ee893bce80815391812e84cefb945da9604ed15d44"
+    ],
+    "ewma": [
+     "a781646c93a1dd60a8b40bae4e76fede4900b642a988230afaeac6122cca63ee",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "2b691b16905dc75955e9cf03dc9a8a2f4082948cddbc39164fa85243cbb739ee",
+     "caf67214d31583d7917fe8c98db8dca4cb8677d295f48ceb91ec0df1561876d4",
+     "5baef3234c9166d71167a24a302772d7061512a4450eaac7010a7d07b63772bf"
+    ],
+    "log_har": [
+     "981bf9f03f847aea5b204bc631007eb198e77766b8bb0aaf5574d455635abfe3",
+     "3f3038195445c27084e0285b049c9c8116b6bc82666c6fa314a3db9f7ccccd39",
+     "80f0e42e48c1bb335bea09fe40b842d8e27f0a64ebf2eebb24c2c477d33f1337",
+     "e25db7ab93757797198599a3e979c6075e0c508368724bb040035a56b512aec8",
+     "fd6dad22121aae2fbc234b78d4501658e3c26d8909f38a2242ba31be95f782ee"
+    ],
+    "har_rv": [
+     "bfd0f855303d84e2b3b9eea6c46e52f4fa59dbf7fb37a1497663f443c9422621",
+     "2661d5b4c66e84fed0eabe134947e20229ae10fbca07494e84c971f4d6ff8dbe",
+     "b57a1c9c93cbeef58f295393cc4f01c665c6770c41d71a0e39a473b774ffdb79",
+     "1eefcc362a436c83bca0024e4aed4659d482bc2890ecec9c7c3c73048b9d090a",
+     "9824f3cef8c25649f6cb67c661114d112eb2e34a9aae16cceb86cf53b24805df"
+    ],
+    "tsfm": [
+     "cf94c0d757628c1b9b825e52b442d299cda8d14a4036857e7626501dd0e4de57",
+     "c0e2bfba70bbb06b4abc1d5d4404ae169f35e1b8a83ae08191da8cc4f2283753",
+     "0212153a671b951894b71fb8e6aa7b0211124f00c51756153f8c94f4d6623ece",
+     "2716b36195a39b46f26574b04930e12e1b697f7adb335bc96bf5ff314043f23e",
+     "98df41d730ce3d2feecc793f221e7219e9ab634d2c99279ce95b70d75c4d774e"
+    ]
+   },
+   "n_oos": 1225,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.18276099313787506,
+     "0.2": 0.28902467997076126,
+     "0.3": 0.3561457376144696,
+     "0.4": 0.39327725688839626,
+     "0.5": 0.40642357894060227,
+     "0.6": 0.3968003653155512,
+     "0.7": 0.36337824202904917,
+     "0.8": 0.29866283421157047,
+     "0.9": 0.1924683617644314
+    },
+    "coverage_80": 0.7738775510204081,
+    "width_80": 2.5405068693355637,
+    "nominal_80": 0.8,
+    "n_obs": 1225,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "seed": 42,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.8534417338424453,
+     "mse_debiased": 0.9295980818702669,
+     "mae_debiased": 0.7489658666052187,
+     "qlike_debiased": 0.6937119148824531,
+     "signed_bias_debiased": -0.14711493514705298,
+     "n_oos": 1225
+    },
+    "ewma": {
+     "mse_raw": 0.35635952736284915,
+     "mse_debiased": 0.5566983245556639,
+     "mae_debiased": 0.5866718284319071,
+     "qlike_debiased": 0.33686661363287645,
+     "signed_bias_debiased": -0.0625257112813957,
+     "n_oos": 1225
+    },
+    "log_har": {
+     "mse_raw": 0.396348345620637,
+     "mse_debiased": 0.5603787927430063,
+     "mae_debiased": 0.6088145451149602,
+     "qlike_debiased": 0.3147213744114635,
+     "signed_bias_debiased": 0.06744232594655668,
+     "n_oos": 1225
+    },
+    "har_rv": {
+     "mse_raw": 0.8534417338291221,
+     "mse_debiased": 0.9295980818639688,
+     "mae_debiased": 0.7489658666041834,
+     "qlike_debiased": 0.6937119148635806,
+     "signed_bias_debiased": -0.14711493515413265,
+     "n_oos": 1225
+    },
+    "tsfm": {
+     "mse_raw": 0.3284956413446431,
+     "mse_debiased": 0.4904712884028434,
+     "mae_debiased": 0.5560790823946081,
+     "qlike_debiased": 0.287322800698733,
+     "signed_bias_debiased": -0.008314361329939787,
+     "n_oos": 1225
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -7.126289278688061,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.43912679346742356,
+     "hac_variance": 4.489613994727299,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.185853125457631,
+     "p_value": 0.029015296442367777,
+     "mean_loss_diff": -0.06622703615282058,
+     "hac_variance": 1.085387237984486,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.011253626851238,
+     "p_value": 0.04451756362705139,
+     "mean_loss_diff": -0.06990750434016293,
+     "hac_variance": 1.428466111257925,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -7.126289278799675,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.4391267934611253,
+     "hac_variance": 4.489613994457879,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 3.1997907116206155,
+     "p_value": 0.0014105784010645106,
+     "mean_loss_diff": 0.1388005738171132,
+     "hac_variance": 2.224822673614323,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 1.9859458274306576,
+     "p_value": 0.04726211858000573,
+     "mean_loss_diff": 0.054211349951455934,
+     "hac_variance": 0.881052269815522,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.95658986615561,
+     "p_value": 0.003170248925905561,
+     "mean_loss_diff": -0.07575668727649645,
+     "hac_variance": 0.7762753725221041,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 3.1997907118561315,
+     "p_value": 0.001410578399921647,
+     "mean_loss_diff": 0.1388005738241929,
+     "hac_variance": 2.224822673513773,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.3244035148651606,
+     -0.38113486375234373,
+     -0.2251366808274129,
+     0.08372486909764812,
+     0.13151560470442417
+    ],
+    "ewma": [
+     -0.3827566465288271,
+     -0.3658907497196716,
+     -0.2963076231980935,
+     0.5013677632145388,
+     0.2082938762247561
+    ],
+    "log_har": [
+     -0.2459246220966368,
+     0.8157259092887365,
+     0.09194804513376223,
+     0.6661629016547302,
+     0.16386998288214247
+    ],
+    "har_rv": [
+     -0.32440351492517866,
+     -0.3811348637535923,
+     -0.22513668083116756,
+     0.08372486909622145,
+     0.13151560470173282
+    ],
+    "tsfm": [
+     -0.3589715503525329,
+     0.04786245231131396,
+     -0.16001282666480188,
+     0.5542448868399108,
+     0.30310410294165396
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "4d63fd8e0582e7035913f2ee893bce80815391812e84cefb945da9604ed15d44"
+    ],
+    "ewma": [
+     "a781646c93a1dd60a8b40bae4e76fede4900b642a988230afaeac6122cca63ee",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "2b691b16905dc75955e9cf03dc9a8a2f4082948cddbc39164fa85243cbb739ee",
+     "caf67214d31583d7917fe8c98db8dca4cb8677d295f48ceb91ec0df1561876d4",
+     "5baef3234c9166d71167a24a302772d7061512a4450eaac7010a7d07b63772bf"
+    ],
+    "log_har": [
+     "981bf9f03f847aea5b204bc631007eb198e77766b8bb0aaf5574d455635abfe3",
+     "3f3038195445c27084e0285b049c9c8116b6bc82666c6fa314a3db9f7ccccd39",
+     "80f0e42e48c1bb335bea09fe40b842d8e27f0a64ebf2eebb24c2c477d33f1337",
+     "e25db7ab93757797198599a3e979c6075e0c508368724bb040035a56b512aec8",
+     "fd6dad22121aae2fbc234b78d4501658e3c26d8909f38a2242ba31be95f782ee"
+    ],
+    "har_rv": [
+     "bfd0f855303d84e2b3b9eea6c46e52f4fa59dbf7fb37a1497663f443c9422621",
+     "2661d5b4c66e84fed0eabe134947e20229ae10fbca07494e84c971f4d6ff8dbe",
+     "b57a1c9c93cbeef58f295393cc4f01c665c6770c41d71a0e39a473b774ffdb79",
+     "1eefcc362a436c83bca0024e4aed4659d482bc2890ecec9c7c3c73048b9d090a",
+     "9824f3cef8c25649f6cb67c661114d112eb2e34a9aae16cceb86cf53b24805df"
+    ],
+    "tsfm": [
+     "cf94c0d757628c1b9b825e52b442d299cda8d14a4036857e7626501dd0e4de57",
+     "c0e2bfba70bbb06b4abc1d5d4404ae169f35e1b8a83ae08191da8cc4f2283753",
+     "0212153a671b951894b71fb8e6aa7b0211124f00c51756153f8c94f4d6623ece",
+     "2716b36195a39b46f26574b04930e12e1b697f7adb335bc96bf5ff314043f23e",
+     "98df41d730ce3d2feecc793f221e7219e9ab634d2c99279ce95b70d75c4d774e"
+    ]
+   },
+   "n_oos": 1225,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.18276099313787506,
+     "0.2": 0.28902467997076126,
+     "0.3": 0.3561457376144696,
+     "0.4": 0.39327725688839626,
+     "0.5": 0.40642357894060227,
+     "0.6": 0.3968003653155512,
+     "0.7": 0.36337824202904917,
+     "0.8": 0.29866283421157047,
+     "0.9": 0.1924683617644314
+    },
+    "coverage_80": 0.7738775510204081,
+    "width_80": 2.5405068693355637,
+    "nominal_80": 0.8,
+    "n_obs": 1225,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "seed": 99,
+   "models": {
+    "persistence": {
+     "mse_raw": 0.8534417338424453,
+     "mse_debiased": 0.9295980818702669,
+     "mae_debiased": 0.7489658666052187,
+     "qlike_debiased": 0.6937119148824531,
+     "signed_bias_debiased": -0.14711493514705298,
+     "n_oos": 1225
+    },
+    "ewma": {
+     "mse_raw": 0.35635952736284915,
+     "mse_debiased": 0.5566983245556639,
+     "mae_debiased": 0.5866718284319071,
+     "qlike_debiased": 0.33686661363287645,
+     "signed_bias_debiased": -0.0625257112813957,
+     "n_oos": 1225
+    },
+    "log_har": {
+     "mse_raw": 0.396348345620637,
+     "mse_debiased": 0.5603787927430063,
+     "mae_debiased": 0.6088145451149602,
+     "qlike_debiased": 0.3147213744114635,
+     "signed_bias_debiased": 0.06744232594655668,
+     "n_oos": 1225
+    },
+    "har_rv": {
+     "mse_raw": 0.8534417338291221,
+     "mse_debiased": 0.9295980818639688,
+     "mae_debiased": 0.7489658666041834,
+     "qlike_debiased": 0.6937119148635806,
+     "signed_bias_debiased": -0.14711493515413265,
+     "n_oos": 1225
+    },
+    "tsfm": {
+     "mse_raw": 0.3284956413446431,
+     "mse_debiased": 0.4904712884028434,
+     "mae_debiased": 0.5560790823946081,
+     "qlike_debiased": 0.287322800698733,
+     "signed_bias_debiased": -0.008314361329939787,
+     "n_oos": 1225
+    }
+   },
+   "dm_vs_baselines_mse": {
+    "persistence": {
+     "dm_statistic": -7.126289278688061,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.43912679346742356,
+     "hac_variance": 4.489613994727299,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": -2.185853125457631,
+     "p_value": 0.029015296442367777,
+     "mean_loss_diff": -0.06622703615282058,
+     "hac_variance": 1.085387237984486,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.011253626851238,
+     "p_value": 0.04451756362705139,
+     "mean_loss_diff": -0.06990750434016293,
+     "hac_variance": 1.428466111257925,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": -7.126289278799675,
+     "p_value": 1.7565948695619227e-12,
+     "mean_loss_diff": -0.4391267934611253,
+     "hac_variance": 4.489613994457879,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    }
+   },
+   "dm_vs_baselines_linear": {
+    "persistence": {
+     "dm_statistic": 3.1997907116206155,
+     "p_value": 0.0014105784010645106,
+     "mean_loss_diff": 0.1388005738171132,
+     "hac_variance": 2.224822673614323,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "ewma": {
+     "dm_statistic": 1.9859458274306576,
+     "p_value": 0.04726211858000573,
+     "mean_loss_diff": 0.054211349951455934,
+     "hac_variance": 0.881052269815522,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    },
+    "log_har": {
+     "dm_statistic": -2.95658986615561,
+     "p_value": 0.003170248925905561,
+     "mean_loss_diff": -0.07575668727649645,
+     "hac_variance": 0.7762753725221041,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATS baseline",
+     "significant_at": 0.05
+    },
+    "har_rv": {
+     "dm_statistic": 3.1997907118561315,
+     "p_value": 0.001410578399921647,
+     "mean_loss_diff": 0.1388005738241929,
+     "hac_variance": 2.224822673513773,
+     "n_obs": 1225,
+     "lag": 10,
+     "verdict": "BEATEN BY baseline",
+     "significant_at": 0.05
+    }
+   },
+   "per_fold_bias": {
+    "persistence": [
+     -0.3244035148651606,
+     -0.38113486375234373,
+     -0.2251366808274129,
+     0.08372486909764812,
+     0.13151560470442417
+    ],
+    "ewma": [
+     -0.3827566465288271,
+     -0.3658907497196716,
+     -0.2963076231980935,
+     0.5013677632145388,
+     0.2082938762247561
+    ],
+    "log_har": [
+     -0.2459246220966368,
+     0.8157259092887365,
+     0.09194804513376223,
+     0.6661629016547302,
+     0.16386998288214247
+    ],
+    "har_rv": [
+     -0.32440351492517866,
+     -0.3811348637535923,
+     -0.22513668083116756,
+     0.08372486909622145,
+     0.13151560470173282
+    ],
+    "tsfm": [
+     -0.3589715503525329,
+     0.04786245231131396,
+     -0.16001282666480188,
+     0.5542448868399108,
+     0.30310410294165396
+    ]
+   },
+   "fc_hash_per_fold": {
+    "persistence": [
+     "624c17fd8eebd4b4e8eb291a5b1a3c887d0e13da68c1bc0a714b1ce08dc32834",
+     "519a8b4223cc4e69fa49be65c16000da78d1a145fd773c461f4d21b5953a3e4c",
+     "6d4dc4731bec433017ffeadd053848e641403af3f9c98ca5039bafd1b2b51d7a",
+     "96780a4e46a00c04d8ae99ff18f0da34bfda30343975bca36ad38e1575c8aa29",
+     "4d63fd8e0582e7035913f2ee893bce80815391812e84cefb945da9604ed15d44"
+    ],
+    "ewma": [
+     "a781646c93a1dd60a8b40bae4e76fede4900b642a988230afaeac6122cca63ee",
+     "89740a455e9182b13af979a2bde29026790bf263afd66fce65bd420e5374b6ce",
+     "2b691b16905dc75955e9cf03dc9a8a2f4082948cddbc39164fa85243cbb739ee",
+     "caf67214d31583d7917fe8c98db8dca4cb8677d295f48ceb91ec0df1561876d4",
+     "5baef3234c9166d71167a24a302772d7061512a4450eaac7010a7d07b63772bf"
+    ],
+    "log_har": [
+     "981bf9f03f847aea5b204bc631007eb198e77766b8bb0aaf5574d455635abfe3",
+     "3f3038195445c27084e0285b049c9c8116b6bc82666c6fa314a3db9f7ccccd39",
+     "80f0e42e48c1bb335bea09fe40b842d8e27f0a64ebf2eebb24c2c477d33f1337",
+     "e25db7ab93757797198599a3e979c6075e0c508368724bb040035a56b512aec8",
+     "fd6dad22121aae2fbc234b78d4501658e3c26d8909f38a2242ba31be95f782ee"
+    ],
+    "har_rv": [
+     "bfd0f855303d84e2b3b9eea6c46e52f4fa59dbf7fb37a1497663f443c9422621",
+     "2661d5b4c66e84fed0eabe134947e20229ae10fbca07494e84c971f4d6ff8dbe",
+     "b57a1c9c93cbeef58f295393cc4f01c665c6770c41d71a0e39a473b774ffdb79",
+     "1eefcc362a436c83bca0024e4aed4659d482bc2890ecec9c7c3c73048b9d090a",
+     "9824f3cef8c25649f6cb67c661114d112eb2e34a9aae16cceb86cf53b24805df"
+    ],
+    "tsfm": [
+     "cf94c0d757628c1b9b825e52b442d299cda8d14a4036857e7626501dd0e4de57",
+     "c0e2bfba70bbb06b4abc1d5d4404ae169f35e1b8a83ae08191da8cc4f2283753",
+     "0212153a671b951894b71fb8e6aa7b0211124f00c51756153f8c94f4d6623ece",
+     "2716b36195a39b46f26574b04930e12e1b697f7adb335bc96bf5ff314043f23e",
+     "98df41d730ce3d2feecc793f221e7219e9ab634d2c99279ce95b70d75c4d774e"
+    ]
+   },
+   "n_oos": 1225,
+   "bounds_train_test": {
+    "fold_idx": 0,
+    "train_end_idx": 249,
+    "oos_start_idx": 249,
+    "oos_end_idx": 498,
+    "n_train": 249,
+    "n_oos": 249,
+    "n_total": 1495,
+    "fold_size": 249,
+    "n_folds": 5
+   },
+   "panel_hash": "0e2609d6130fd608",
+   "tsfm_quantiles": {
+    "pinball_loss": {
+     "0.1": 0.18276099313787506,
+     "0.2": 0.28902467997076126,
+     "0.3": 0.3561457376144696,
+     "0.4": 0.39327725688839626,
+     "0.5": 0.40642357894060227,
+     "0.6": 0.3968003653155512,
+     "0.7": 0.36337824202904917,
+     "0.8": 0.29866283421157047,
+     "0.9": 0.1924683617644314
+    },
+    "coverage_80": 0.7738775510204081,
+    "width_80": 2.5405068693355637,
+    "nominal_80": 0.8,
+    "n_obs": 1225,
+    "note": "quantiles evaluated on realized log_rv at step h (direct); point forecasts on the h-day mean target \u2014 separate functionals, never mixed"
+   }
+  }
+ ],
+ "summary": [
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "baseline": "persistence",
+   "edge_pct_mean": 40.67843078380487,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.01726774944068099,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "baseline": "ewma",
+   "edge_pct_mean": 20.128930639073822,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 4.96713781217295e-13,
+   "dm_p_median_linear_leg": 2.6215417354702453e-06,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "baseline": "log_har",
+   "edge_pct_mean": 19.657175612508574,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 1.6187051699034782e-13,
+   "dm_p_median_linear_leg": 2.944457729880945e-05,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 1,
+   "baseline": "har_rv",
+   "edge_pct_mean": 40.67843078380183,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.017267749440681657,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "baseline": "persistence",
+   "edge_pct_mean": 56.21143309829104,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.011194712698186837,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "baseline": "ewma",
+   "edge_pct_mean": 5.3811676219217786,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.11572770459443094,
+   "dm_p_median_linear_leg": 0.0009590610224607943,
+   "n_seeds": 4,
+   "n_coherent_beats": 0,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "INCONCLUSIVE"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "baseline": "log_har",
+   "edge_pct_mean": 8.510211914577683,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0014863928451875896,
+   "dm_p_median_linear_leg": 2.3992121893634533e-06,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 5,
+   "baseline": "har_rv",
+   "edge_pct_mean": 56.211433098279684,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.011194712698192388,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "baseline": "persistence",
+   "edge_pct_mean": 46.540527625089936,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 3.483063599407643e-05,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "baseline": "ewma",
+   "edge_pct_mean": 10.654023858616876,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.01616562930945098,
+   "dm_p_median_linear_leg": 0.03375848918381541,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "baseline": "log_har",
+   "edge_pct_mean": -4.778101054564762,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.23229509340328014,
+   "dm_p_median_linear_leg": 2.2976356352177874e-05,
+   "n_seeds": 4,
+   "n_coherent_beats": 0,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "INCONCLUSIVE"
+  },
+  {
+   "coin": "BTC-USD",
+   "horizon": 22,
+   "baseline": "har_rv",
+   "edge_pct_mean": 46.54052762503368,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 3.483063599452052e-05,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "baseline": "persistence",
+   "edge_pct_mean": 30.633975669046738,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.3929487088898065,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "baseline": "ewma",
+   "edge_pct_mean": 10.463043852050093,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 9.192891572773476e-05,
+   "dm_p_median_linear_leg": 6.933341824666428e-06,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "baseline": "log_har",
+   "edge_pct_mean": 7.634405188139071,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 4.3023400930763955e-07,
+   "dm_p_median_linear_leg": 0.13022040212585462,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 1,
+   "baseline": "har_rv",
+   "edge_pct_mean": 30.633975669007775,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.3929487088662673,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "baseline": "persistence",
+   "edge_pct_mean": 49.725619241625296,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.284037345147206,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "baseline": "ewma",
+   "edge_pct_mean": 4.0744378573313185,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.3815389562129372,
+   "dm_p_median_linear_leg": 1.5033678565146147e-05,
+   "n_seeds": 4,
+   "n_coherent_beats": 0,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "INCONCLUSIVE"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "baseline": "log_har",
+   "edge_pct_mean": 10.683711414695562,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0001946869813498342,
+   "dm_p_median_linear_leg": 0.02835029281773238,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 5,
+   "baseline": "har_rv",
+   "edge_pct_mean": 49.72561924148904,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.0,
+   "dm_p_median_linear_leg": 0.28403734510314993,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "baseline": "persistence",
+   "edge_pct_mean": 47.238349780578325,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 1.7565948695619227e-12,
+   "dm_p_median_linear_leg": 0.0014105784010645106,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "baseline": "ewma",
+   "edge_pct_mean": 11.896395809288725,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.029015296442367777,
+   "dm_p_median_linear_leg": 0.04726211858000573,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "baseline": "log_har",
+   "edge_pct_mean": 12.475044602950023,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 0.04451756362705139,
+   "dm_p_median_linear_leg": 0.003170248925905561,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  },
+  {
+   "coin": "ETH-USD",
+   "horizon": 22,
+   "baseline": "har_rv",
+   "edge_pct_mean": 47.23834978022086,
+   "edge_sigma_cross_seed": 0.0,
+   "dm_p_median": 1.7565948695619227e-12,
+   "dm_p_median_linear_leg": 0.001410578399921647,
+   "n_seeds": 4,
+   "n_coherent_beats": 4,
+   "n_coherent_beaten_by": 0,
+   "seeds_bit_identical": true,
+   "verdict": "BEATS"
+  }
+ ],
+ "elapsed_s": 867.5
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_m18_tsfm_benchmark.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_m18_tsfm_benchmark.py
@@ -1,0 +1,354 @@
+"""Tests for m18_tsfm_benchmark.py — TimesFM 2.5 zero-shot benchmark (#14768).
+
+No torch / timesfm dependency: the TimesFM model is faked (deterministic
+constant-path forecaster) so the harness, metrics, calibration symmetry and
+verdict logic are all exercised on synthetic data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import m18_tsfm_benchmark as m18
+
+
+# ---------------------------------------------------------------------------
+# Metrics — closed forms
+# ---------------------------------------------------------------------------
+
+class TestMetrics:
+    def test_qlike_zero_at_perfect_forecast(self):
+        rv = np.array([1.0, 2.0, 3.0])
+        assert m18.qlike_loss(rv, rv) == pytest.approx(0.0, abs=1e-12)
+
+    def test_qlike_known_value(self):
+        # ratio = 2 -> 2 - log(2) - 1 = 1 - log(2)
+        assert m18.qlike_loss(np.array([2.0]), np.array([1.0])) == pytest.approx(
+            1.0 - np.log(2.0), abs=1e-12
+        )
+
+    def test_qlike_rejects_nonpositive(self):
+        with pytest.raises(ValueError):
+            m18.qlike_loss(np.array([1.0]), np.array([0.0]))
+        with pytest.raises(ValueError):
+            m18.qlike_loss(np.array([0.0]), np.array([1.0]))
+
+    def test_pinball_median_is_half_mae(self):
+        y = np.array([1.0, 2.0, 5.0])
+        yhat = np.array([2.0, 2.0, 2.0])
+        half_mae = 0.5 * np.mean(np.abs(y - yhat))
+        assert m18.pinball_loss(y, yhat, 0.5) == pytest.approx(half_mae)
+
+    def test_pinball_asymmetry(self):
+        # over-prediction at high q costs (1-q), under-prediction costs q
+        assert m18.pinball_loss(np.array([1.0]), np.array([0.0]), 0.9) == pytest.approx(0.9)
+        assert m18.pinball_loss(np.array([0.0]), np.array([1.0]), 0.9) == pytest.approx(0.1)
+
+    def test_coverage_and_width_closed_form(self):
+        y = np.array([0.0, 1.0, 2.0])
+        lower = np.array([0.0, 0.0, 3.0])
+        upper = np.array([1.0, 2.0, 3.0])
+        cov, width = m18.interval_coverage(y, lower, upper)
+        assert cov == pytest.approx(2.0 / 3.0)
+        assert width == pytest.approx(np.mean(upper - lower))
+
+    def test_coverage_rejects_crossed_bands(self):
+        with pytest.raises(ValueError):
+            m18.interval_coverage(np.array([1.0]), np.array([2.0]), np.array([1.0]))
+
+
+# ---------------------------------------------------------------------------
+# Fold arithmetic — must match har_model._make_split_indices
+# ---------------------------------------------------------------------------
+
+class TestFoldBounds:
+    @pytest.mark.parametrize("n,n_splits", [(1000, 5), (2272, 5), (600, 4)])
+    def test_matches_make_split_indices(self, n, n_splits):
+        from har_model import _make_split_indices
+        expected = _make_split_indices(n, n_splits)
+        got = m18._fold_bounds(n, n_splits)
+        assert len(got) == len(expected)
+        for g, (train_end, test_start, test_end) in zip(got, expected):
+            assert g["train_end_idx"] == train_end
+            assert g["oos_start_idx"] == test_start
+            assert g["oos_end_idx"] == test_end
+
+
+# ---------------------------------------------------------------------------
+# Deterministic baselines — causality and alignment
+# ---------------------------------------------------------------------------
+
+class TestBaselines:
+    def _series(self, n=400, seed=3):
+        rng = np.random.default_rng(seed)
+        log_rv = np.cumsum(rng.normal(0, 0.05, n)) - 10.0
+        idx = pd.date_range("2020-01-01", periods=n, freq="D")
+        rv = pd.Series(np.exp(log_rv), index=idx)
+        return log_rv, rv
+
+    def test_persistence_uses_last_observation_only(self):
+        log_rv, rv = self._series()
+        idx = [50, 100, 150]
+        preds = m18._rolling_predictions("persistence", log_rv, rv, idx, horizon=5)
+        assert preds[0] == log_rv[49]
+        assert preds[1] == log_rv[99]
+        assert preds[2] == log_rv[149]
+
+    def test_ewma_matches_pandas_reference(self):
+        log_rv, rv = self._series()
+        i = 200
+        ref = pd.Series(log_rv[:i]).ewm(span=20).mean().iloc[-1]
+        preds = m18._rolling_predictions("ewma", log_rv, rv, [i], horizon=1, ewma_span=20)
+        assert preds[0] == pytest.approx(float(ref))
+
+    def test_ewma_requires_span(self):
+        log_rv, rv = self._series()
+        with pytest.raises(ValueError):
+            m18._rolling_predictions("ewma", log_rv, rv, [100], horizon=1)
+
+    def test_har_rv_constant_series_forecasts_its_level(self):
+        # constant RV -> OLS recovers the level; iterated path stays flat
+        idx = pd.date_range("2020-01-01", periods=200, freq="D")
+        rv = pd.Series(np.exp(2.0), index=idx)
+        model = m18.HarRvModel().fit(rv)
+        assert model.predict_h_step_mean_log(rv, horizon=5) == pytest.approx(2.0, abs=1e-6)
+
+    def test_select_ewma_span_is_train_only(self):
+        rng = np.random.default_rng(0)
+        log_rv = np.cumsum(rng.normal(0, 0.1, 600))
+        train_end = 500
+        span_a = m18._select_ewma_span(log_rv, train_end, horizon=1)
+        log_rv_mutated = log_rv.copy()
+        log_rv_mutated[train_end:] = 999.0  # future garbled
+        span_b = m18._select_ewma_span(log_rv_mutated, train_end, horizon=1)
+        assert span_a == span_b
+        assert span_a in m18.EWMA_SPAN_GRID
+
+
+# ---------------------------------------------------------------------------
+# TimesFM wrapper — faked model, layout and fail-explicit contract
+# ---------------------------------------------------------------------------
+
+class FakeTimesFM:
+    """Deterministic fake: point = last context value (flat path), quantile
+    tensor laid out as [mean, q0.1..q0.9] with the median at channel 5."""
+
+    def forecast(self, horizon, inputs):
+        point = np.stack([np.full(horizon, float(x[-1]), dtype=np.float32)
+                          for x in inputs])
+        n_q = 1 + len(m18.TSFM_QUANTILES)
+        base = point[:, :1]  # (B, 1)
+        quant = np.zeros((len(inputs), horizon, n_q), dtype=np.float32)
+        for j, q in enumerate(m18.TSFM_QUANTILES):
+            # monotone bands around the flat forecast, width grows with |q-0.5|
+            quant[:, :, 1 + j] = (base + (q - 0.5) * 2.0)[:, :, None].repeat(horizon, 1)[:, :, 0]
+        quant[:, :, 0] = base[:, :1][:, 0][:, None].repeat(horizon, 1)
+        return point, quant
+
+
+class FakeTimesFMBadAxis:
+    def forecast(self, horizon, inputs):
+        point = np.zeros((len(inputs), horizon), dtype=np.float32)
+        return point, np.zeros((len(inputs), horizon, 9), dtype=np.float32)
+
+
+def _fake_wrapper(context_len=64, model=None):
+    return m18.TimesFMWrapper(
+        repo_id="fake/timesfm", context_len=context_len,
+        loader=(lambda repo: model if model is not None else FakeTimesFM()),
+    )
+
+
+class TestTimesFMWrapper:
+    def test_fail_explicit_when_never_loaded(self):
+        w = m18.TimesFMWrapper(repo_id="fake", context_len=64)
+        with pytest.raises(RuntimeError, match="aborting"):
+            w.forecast_paths([np.zeros(8, dtype=np.float32)], horizon=2)
+
+    def test_fail_explicit_when_loader_raises(self):
+        def boom(repo):
+            raise OSError("checkpoint unavailable")
+        with pytest.raises(OSError):
+            m18.TimesFMWrapper(repo_id="fake", context_len=64, loader=boom)
+
+    def test_counts_every_series_served(self):
+        w = _fake_wrapper()
+        ctxs = [np.arange(10, dtype=np.float32)] * 7
+        w.forecast_paths(ctxs, horizon=3)
+        assert w.n_calls == 7
+
+    def test_rejects_wrong_quantile_axis(self):
+        w = _fake_wrapper(model=FakeTimesFMBadAxis())
+        with pytest.raises(RuntimeError, match="channels"):
+            w.forecast_paths([np.arange(10, dtype=np.float32)], horizon=3)
+
+    def test_median_channel_is_the_point_output(self):
+        # layout contract: quant[..., 5] == point == median
+        w = _fake_wrapper()
+        ctx = np.linspace(-5, -4, 30).astype(np.float32)
+        point, quant = w.forecast_paths([ctx], horizon=4)
+        assert np.allclose(quant[0, :, 5], point[0])
+
+    def test_batch_predictions_mean_path_and_last_step_quantiles(self):
+        w = _fake_wrapper(context_len=16)
+        log_rv = np.linspace(-10, -8, 40)
+        idx = [20, 30]
+        preds, q_last = m18._tsfm_batch_predictions(log_rv, idx, horizon=5, tsfm=w)
+        # flat path at last context value -> mean of path == last value
+        assert preds[0] == pytest.approx(log_rv[19])
+        assert preds[1] == pytest.approx(log_rv[29])
+        assert q_last.shape == (2, 1 + len(m18.TSFM_QUANTILES))
+        # q0.1 column is 1 (channel 0 is the mean head)
+        assert q_last[0, 1] == pytest.approx(log_rv[19] - 0.8)
+        assert q_last[0, 9] == pytest.approx(log_rv[19] + 0.8)
+
+
+# ---------------------------------------------------------------------------
+# run_config end-to-end on synthetic data with the fake model
+# ---------------------------------------------------------------------------
+
+def _synthetic_hourly(n_hours=13000, seed=11):
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2015-01-01", periods=n_hours, freq="h")
+    # two volatility regimes so RV carries real signal for the HAR models
+    regime = np.sin(np.arange(n_hours) / 700.0) > 0
+    sigma = np.where(regime, 0.01, 0.03)
+    rets = pd.Series(rng.normal(0, 1, n_hours) * sigma, index=idx)
+    return rets
+
+
+class TestRunConfig:
+    def test_structure_and_symmetry(self):
+        hourly = _synthetic_hourly()
+        tsfm = _fake_wrapper()
+        cfg = m18.run_config(
+            "SYN-USD", hourly, horizon=1, seed=0, n_splits=3,
+            calibration_size=30, refit_every=22, tsfm=tsfm,
+        )
+        assert "skipped" not in cfg
+        for model in m18.MODELS:
+            row = cfg["models"][model]
+            assert row["n_oos"] == cfg["n_oos"] > 0
+            assert np.isfinite(row["mse_debiased"])
+            assert row["qlike_debiased"] >= 0.0
+        # one bias entry per executed fold, for EVERY model (symmetry)
+        n_folds = cfg["bounds_train_test"]["n_folds"]
+        for model in m18.MODELS:
+            assert len(cfg["per_fold_bias"][model]) == n_folds
+            assert len(cfg["fc_hash_per_fold"][model]) == n_folds
+        # both DM legs present for every baseline
+        for leg in ("dm_vs_baselines_mse", "dm_vs_baselines_linear"):
+            assert set(cfg[leg].keys()) == set(m18.BASELINES)
+            for v in cfg[leg].values():
+                assert v["verdict"] in ("BEATS baseline", "BEATEN BY baseline",
+                                        "INCONCLUSIVE")
+        # quantile evaluation recorded with the layout note
+        q = cfg["tsfm_quantiles"]
+        assert q["n_obs"] == cfg["n_oos"]
+        assert set(q["pinball_loss"].keys()) == {str(x) for x in m18.TSFM_QUANTILES}
+        assert 0.0 <= q["coverage_80"] <= 1.0
+
+    def test_calibration_moves_constant_forecast_to_target_level(self):
+        # fake model predicts a flat path at the LAST log-RV value: on a
+        # trending series its raw bias is negative; the debiased leg must
+        # sit closer to the target level than the raw leg.
+        hourly = _synthetic_hourly(n_hours=13000, seed=5)
+        tsfm = _fake_wrapper()
+        cfg = m18.run_config(
+            "SYN-USD", hourly, horizon=1, seed=0, n_splits=3,
+            calibration_size=30, refit_every=22, tsfm=tsfm,
+        )
+        row = cfg["models"]["tsfm"]
+        assert row["mse_debiased"] < row["mse_raw"]
+
+    def test_debias_false_leaves_raw_predictions(self):
+        hourly = _synthetic_hourly(n_hours=13000, seed=5)
+        tsfm = _fake_wrapper()
+        cfg = m18.run_config(
+            "SYN-USD", hourly, horizon=1, seed=0, n_splits=3,
+            calibration_size=30, refit_every=22, tsfm=tsfm, debias=False,
+        )
+        assert all(b == 0.0 for b in cfg["per_fold_bias"]["tsfm"])
+        row = cfg["models"]["tsfm"]
+        assert row["mse_debiased"] == pytest.approx(row["mse_raw"])
+
+    def test_shallow_series_is_skipped(self):
+        idx = pd.date_range("2020-01-01", periods=500, freq="h")
+        hourly = pd.Series(0.01, index=idx)  # ~21 RV days
+        cfg = m18.run_config(
+            "SYN-USD", hourly, horizon=1, seed=0, n_splits=3,
+            calibration_size=30, refit_every=22, tsfm=_fake_wrapper(),
+        )
+        assert "skipped" in cfg
+
+
+# ---------------------------------------------------------------------------
+# Aggregate verdict — §C conjunction logic on synthetic config dicts
+# ---------------------------------------------------------------------------
+
+def _cfg(coin, horizon, seed, p_mse, mld_mse, tsfm_hash="aaa", tsfm_mse=1.0,
+         base_mse=2.0):
+    def dm(p, mld):
+        verdict = ("BEATS baseline" if (p < 0.05 and mld < 0)
+                   else "BEATEN BY baseline" if (p < 0.05 and mld > 0)
+                   else "INCONCLUSIVE")
+        return {"p_value": p, "mean_loss_diff": mld, "verdict": verdict}
+    return {
+        "coin": coin, "horizon": horizon, "seed": seed,
+        "models": {"tsfm": {"mse_debiased": tsfm_mse},
+                   "log_har": {"mse_debiased": base_mse}},
+        "dm_vs_baselines_mse": {"log_har": dm(p_mse, mld_mse)},
+        "dm_vs_baselines_linear": {"log_har": dm(0.3, 0.0)},
+        "fc_hash_per_fold": {"tsfm": [tsfm_hash], "log_har": ["x"]},
+    }
+
+
+class TestAggregateVerdicts:
+    def test_all_beats_and_identical_seeds_gives_beats(self):
+        cfgs = [_cfg("X", 1, s, p_mse=1e-4, mld_mse=-0.5) for s in (0, 7, 42, 99)]
+        out = m18.aggregate_verdicts(cfgs)
+        assert len(out) == 1
+        assert out[0]["baseline"] == "log_har"
+        assert out[0]["verdict"] == "BEATS"
+        assert out[0]["seeds_bit_identical"] is True
+
+    def test_all_beaten_gives_no_beats(self):
+        cfgs = [_cfg("X", 5, s, p_mse=1e-4, mld_mse=+0.5) for s in (0, 7)]
+        out = m18.aggregate_verdicts(cfgs)
+        assert out[0]["verdict"] == "NO BEATS"
+
+    def test_mixed_seeds_inconclusive(self):
+        cfgs = [
+            _cfg("X", 22, 0, p_mse=1e-4, mld_mse=-0.5),
+            _cfg("X", 22, 7, p_mse=0.4, mld_mse=-0.1),
+        ]
+        out = m18.aggregate_verdicts(cfgs)
+        assert out[0]["verdict"] == "INCONCLUSIVE"
+
+    def test_insignificant_p_is_inconclusive(self):
+        cfgs = [_cfg("X", 1, s, p_mse=0.4, mld_mse=-0.5) for s in (0, 7)]
+        out = m18.aggregate_verdicts(cfgs)
+        assert out[0]["verdict"] == "INCONCLUSIVE"
+
+    def test_non_identical_seeds_need_two_sigma_edge(self):
+        # all seeds beat with p<0.05, but hashes differ and edge spread is
+        # wide relative to the mean -> sigma jambe blocks the BEATS
+        cfgs = [
+            _cfg("X", 1, 0, p_mse=1e-4, mld_mse=-0.5, tsfm_mse=1.0, base_mse=1.1,
+                 tsfm_hash="a"),
+            _cfg("X", 1, 7, p_mse=1e-4, mld_mse=-0.5, tsfm_mse=1.0, base_mse=5.0,
+                 tsfm_hash="b"),
+        ]
+        out = m18.aggregate_verdicts(cfgs)
+        # edges: +9% and +80% -> mean 44.7, sigma 35.6 -> 2*sigma > edge
+        assert out[0]["verdict"] == "INCONCLUSIVE"
+        assert out[0]["seeds_bit_identical"] is False
+
+    def test_skipped_configs_are_ignored(self):
+        cfgs = [_cfg("X", 1, 0, 1e-4, -0.5),
+                {"coin": "X", "horizon": 1, "seed": 7, "skipped": "rv<300"}]
+        out = m18.aggregate_verdicts(cfgs)
+        assert len(out) == 1
+        assert out[0]["n_seeds"] == 1


### PR DESCRIPTION
Grain: MED/training -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14742

## Summary

Benchmark TimesFM 2.5-200M zero-shot contre persistence / EWMA / Log-HAR / HAR-RV sur RV crypto quotidienne, horizons 1/5/22 j, protocole §C strict aligne M17 round-3/4. Verdict SOTA: **SOTA-OK** — vrai checkpoint `google/timesfm-2.5-200m-pytorch` (SHA `1d952420fba8`) charge sur GPU, 43 720 séries réellement servies (compteur), contrat fail-explicit : 0 fallback, abort sur tout échec de chargement/provenance (#14768 gardes anti-faux modèle).

**Verdict contre Log-HAR (baseline de référence) : 5/6 BEATS, 1/6 INCONCLUSIVE, 0/6 NO BEATS.**

| Coin | h | vs persistence | vs ewma | vs log_har | vs har_rv |
|---|---:|---|---|---|---|
| BTC | 1 | BEATS +40,7 % | BEATS +20,1 % | **BEATS +19,7 %** (p<1e-4) | BEATS +40,7 % |
| BTC | 5 | BEATS +56,2 % | INCONCL. +5,4 % | **BEATS +8,5 %** (p=0,0015) | BEATS +56,2 % |
| BTC | 22 | BEATS +46,5 % | BEATS +10,7 % | **INCONCLUSIVE** −4,8 % (p=0,232) | BEATS +46,5 % |
| ETH | 1 | BEATS +30,6 % | BEATS +10,5 % | **BEATS +7,6 %** | BEATS +30,6 % |
| ETH | 5 | BEATS +49,7 % | INCONCL. +4,1 % | **BEATS +10,7 %** (p=2e-4) | BEATS +49,7 % |
| ETH | 22 | BEATS +47,2 % | BEATS +11,9 % | **BEATS +12,5 %** (p=0,0445 ⚠ limite) | BEATS +47,2 % |

Lecture honnête : solide sur 4 cellules (p ≤ 0,0015) ; BTC h=22 le log-HAR est numériquement meilleur mais non significativement ; ETH h=22 BEATS au bord du seuil (fragile, flaggé). La littérature (Log-HAR très compétitif, gain TSFM non uniforme) est partiellement confirmée.

## Protocole

- Cible = moyenne glissante h-jour du log-RV ; folds expanding 5 (arithmétique `har_model._make_split_indices`, test de parité inclus)
- Débiais symétrique per-fold : queue d'entraînement 60 j SEULE, `yhat + bias` (leçon M17 round-3 signe)
- DM deux jambes #11010 : conjonction sur MSE, `linear` = diagnostic biais
- Seeds {0,7,42,99} **bit-identiques** (GPU déterministe vérifié à l'échelle — précédent M17 OLS, jambe σ dégénérée)
- Provenance : SHA checkpoint (HfApi), compteur de séries, `panel_hash` 360 bars, `bounds_train_test` par fold, SHA256 des prévisions par fold
- TimesFM layout quantiles vérifié empiriquement : dernier axe `[mean, q0.1..q0.9]`, point = canal 5 = médiane — assert à chaque appel

## Découvertes

1. **Calibration quantile native remarquable** : couverture 80 % mesurée 0,774-0,814 pour nominal 0,80, zero-shot sans ajustement (pinball complet par niveau dans le manifeste).
2. **HAR en niveaux dégénère en quasi-persistence** sur ce panel : MSE égales à 6 décimales aux trois horizons × 2 coins, hashs de prévisions distincts (artefact connu des séries très persistantes, pas un bug de dispatch — investigué et écarté).

## Acceptance #14768 (7/7)

| # | Exigence | Preuve |
|---|---|---|
| 1 | Script + tests intégrés pipeline | `scripts/m18_tsfm_benchmark.py` + `scripts/tests/test_m18_tsfm_benchmark.py` (31 passed) |
| 2 | TimesFM 2.5 réel attesté | SHA `1d952420fba8` + 43 720 séries servies + fail-explicit (tests du contrat) |
| 3 | HAR/Log-HAR et persistence inclus | + EWMA, + HAR-RV (les deux spécifications HAR) |
| 4 | Walk-forward 5-fold, ≥4 seeds, biais documentés | manifeste `per_fold_bias` par modèle/fold ; coûts N/A forecast pur documenté |
| 5 | Quantiles évalués par calibration | pinball 9 niveaux + couverture/largeur 80 % par config |
| 6 | Verdict honnête au registre | REGISTRY.md entrée M18 + doc `docs/M18_TimesFM.md` |
| 7 | Aucun claim de trading | explicite (étape économique hors scope) |

Exécution : 867,5 s GPU (RTX 3090), timesfm 3.0.1 + torch 2.6.0+cu124, manifeste 192 Ko committé (précédents m4_dlinear ×4, m15 ×6).

Closes #14768