### PR TITLE
docs(archive,#13749): tranche 2B headers disposition sur 16 fichiers genai-stack/_archive/

### DIFF
--- a/scripts/genai-stack/_archive/core/cleanup_comfyui_auth.py
+++ b/scripts/genai-stack/_archive/core/cleanup_comfyui_auth.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py auth | Reason: Nettoyage one-shot
+#
 """
 cleanup-comfyui-auth.py - Script de nettoyage one-liner pour ComfyUI-Login
 
@@ -51,7 +54,7 @@ class CleanupManager:
             # Vérifier si le conteneur existe
             result = subprocess.run(
                 ["docker", "ps", "-a", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Names}}"],
-                capture_output=True, text=True
+                capture_output=True, text=True, encoding="utf-8", errors="replace"
             )
             
             if CONTAINER_NAME not in result.stdout.strip():

--- a/scripts/genai-stack/_archive/core/deploy_comfyui_auth.py
+++ b/scripts/genai-stack/_archive/core/deploy_comfyui_auth.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py docker start | Reason: Deploiement one-shot
+#
 """
 deploy-comfyui-auth.py - Script de déploiement one-liner robuste pour ComfyUI-Login
 
@@ -112,7 +115,7 @@ class DeploymentManager:
         try:
             result = subprocess.run(
                 ["docker", "ps", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Names}}"],
-                capture_output=True, text=True
+                capture_output=True, text=True, encoding="utf-8", errors="replace"
             )
             if CONTAINER_NAME in result.stdout.strip():
                 if self.args.force:
@@ -151,7 +154,7 @@ class DeploymentManager:
                 # On utilise docker exec pour vérifier l'état interne
                 result = subprocess.run(
                     ["docker", "exec", CONTAINER_NAME, "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8188"],
-                    capture_output=True, text=True
+                    capture_output=True, text=True, encoding="utf-8", errors="replace"
                 )
                 status_code = result.stdout.strip()
                 

--- a/scripts/genai-stack/_archive/core/diagnose_comfyui_auth.py
+++ b/scripts/genai-stack/_archive/core/diagnose_comfyui_auth.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py auth audit | Reason: Importe docker_qwen_manager inexistant (CASSE)
+#
 """
 Script de diagnostic complet pour l'authentification ComfyUI
 Utilise les utilitaires consolidés pour analyser et corriger les problèmes d'authentification

--- a/scripts/genai-stack/_archive/utils/benchmark.py
+++ b/scripts/genai-stack/_archive/utils/benchmark.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: abandoned | Successor: (none) | Reason: Hardcode login/password, auth par cookie obsolete
+#
 """
 Script de benchmark pour ComfyUI Qwen
 Mesure les temps de génération d'images et monitor l'utilisation du GPU
@@ -84,7 +87,7 @@ class ComfyUIBenchmark:
                 result = subprocess.run([
                     'nvidia-smi', '--query-gpu=memory.used,memory.total,utilization.gpu,temperature.gpu',
                     '--format=csv,noheader,nounits'
-                ], capture_output=True, text=True, timeout=2)
+                ], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2)
                 
                 if result.returncode == 0:
                     lines = result.stdout.strip().split('\n')

--- a/scripts/genai-stack/_archive/utils/comfyui_client_helper.py
+++ b/scripts/genai-stack/_archive/utils/comfyui_client_helper.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: core/comfyui_client.py | Reason: 1418 lignes, remplace par core/comfyui_client.py (269 lignes)
+#
 """
 ComfyUI Client Helper - Utilitaire complet pour investigations ComfyUI
 
@@ -546,7 +549,7 @@ class InvestigationUtils:
         """Exécute une commande dans le container Docker"""
         try:
             full_command = f"docker exec {self.container_name} bash -c '{command}'"
-            result = subprocess.run(full_command, shell=True, capture_output=True, text=True)
+            result = subprocess.run(full_command, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
             return result.stdout, result.stderr, result.returncode
         except Exception as e:
             return "", str(e), 1

--- a/scripts/genai-stack/_archive/utils/consolidated_tests.py
+++ b/scripts/genai-stack/_archive/utils/consolidated_tests.py
@@ -1,4 +1,7 @@
 # encoding: utf-8
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py validate | Reason: Importe token_manager + comfyui_client_helper (legacy)
+#
 """
 Fichier consolidé de tests pour le système Qwen ComfyUI.
 Ce fichier regroupe tous les tests pour faciliter la maintenance et la simplification.
@@ -209,7 +212,7 @@ def run_docker_command(command: str) -> Optional[str]:
     """Exécute une commande Docker via Windows CLI."""
     try:
         full_command = f"docker exec {CONTAINER_NAME} {command}"
-        result = subprocess.run(["pwsh", "-c", full_command], capture_output=True, text=True, check=True)
+        result = subprocess.run(["pwsh", "-c", full_command], capture_output=True, text=True, encoding="utf-8", errors="replace", check=True)
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
         print(f"   - Erreur Docker: {e.stderr.strip()}")
@@ -221,7 +224,7 @@ def copy_image_from_container(filename_prefix):
         # Lister les images dans le conteneur
         list_cmd = f"ls -t /workspace/ComfyUI/output/{filename_prefix}* 2>/dev/null | head -1"
         result = subprocess.run(["pwsh", "-c", f"docker exec {CONTAINER_NAME} bash -c '{list_cmd}'"],
-                           capture_output=True, text=True, check=False)
+                           capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
         
         if result.returncode == 0 and result.stdout.strip():
             image_name = result.stdout.strip()

--- a/scripts/genai-stack/_archive/utils/diagnostic_model_paths.py
+++ b/scripts/genai-stack/_archive/utils/diagnostic_model_paths.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: abandoned | Successor: (none) | Reason: Script one-shot Phase 29, probleme resolu
+#
 """
 Script de Diagnostic Complet : Chemins des Modèles Qwen + Corruption Potentielle
 ================================================================================
@@ -80,7 +83,7 @@ def run_docker_command(command: str) -> Optional[str]:
         result = subprocess.run(
             ["pwsh", "-c", full_command],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True
         )
         return result.stdout.strip()

--- a/scripts/genai-stack/_archive/utils/diagnostic_utils.py
+++ b/scripts/genai-stack/_archive/utils/diagnostic_utils.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: abandoned | Successor: (none) | Reason: Jamais appele depuis aucun script actif
+#
 """
 Utilitaire consolidé pour le diagnostic de l'environnement ComfyUI
 
@@ -138,7 +141,7 @@ class DiagnosticUtils:
             # Lister les conteneurs
             result = subprocess.run([
                 'docker', 'ps', '-a', '--filter', 'name=comfyui'
-            ], capture_output=True, text=True, timeout=10)
+            ], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
             
             if result.returncode == 0:
                 lines = result.stdout.strip().split('\n')
@@ -152,7 +155,7 @@ class DiagnosticUtils:
             # Lister les images
             result = subprocess.run([
                 'docker', 'images', '--filter', 'comfyui'
-            ], capture_output=True, text=True, timeout=10)
+            ], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
             
             if result.returncode == 0:
                 lines = result.stdout.strip().split('\n')

--- a/scripts/genai-stack/_archive/utils/reconstruct_env.py
+++ b/scripts/genai-stack/_archive/utils/reconstruct_env.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py auth reconstruct-env | Reason: Remplace par core/auth_manager.py reconstruct-env
+#
 """
 reconstruct_env.py - Script de reconstruction du fichier .env complet pour ComfyUI-Login
 

--- a/scripts/genai-stack/_archive/utils/token_manager.py
+++ b/scripts/genai-stack/_archive/utils/token_manager.py
@@ -1,3 +1,7 @@
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py auth | Reason: Remplace par core/auth_manager.py
+#
+
 # scripts/genai-auth/utils/token_manager.py
 """
 Gestionnaire centralisé des tokens d'authentification Qwen ComfyUI

--- a/scripts/genai-stack/_archive/utils/token_synchronizer.py
+++ b/scripts/genai-stack/_archive/utils/token_synchronizer.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py auth sync | Reason: Remplace par core/auth_manager.py sync
+#
 """
 token_synchronizer.py - Script d'unification définitive des tokens ComfyUI-Login
 

--- a/scripts/genai-stack/_archive/utils/validate_all_models.py
+++ b/scripts/genai-stack/_archive/utils/validate_all_models.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py validate --full | Reason: Remplace par validate_stack.py --full
+#
 """
 validate_all_models.py - Script de validation unifié pour les moteurs GenAI (Images)
 

--- a/scripts/genai-stack/_archive/utils/validate_genai_stack.py
+++ b/scripts/genai-stack/_archive/utils/validate_genai_stack.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py validate | Reason: Remplace par validate_stack.py puis commands/validate.py
+#
 """
 validate_genai_stack.py - Script de validation unifié pour les moteurs GenAI (Images)
 

--- a/scripts/genai-stack/_archive/utils/validate_gpu_cuda.py
+++ b/scripts/genai-stack/_archive/utils/validate_gpu_cuda.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py gpu --detailed | Reason: Absorbe dans commands/gpu.py
+#
 """
 Script de validation GPU et CUDA pour ComfyUI Docker
 Créé pour la validation du démarrage ComfyUI - 2025-11-06
@@ -11,7 +14,7 @@ import sys
 def run_command(cmd):
     """Exécute une commande et retourne le résultat"""
     try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
         return result.returncode == 0, result.stdout, result.stderr
     except Exception as e:
         return False, "", str(e)

--- a/scripts/genai-stack/_archive/utils/validate_tokens_simple.py
+++ b/scripts/genai-stack/_archive/utils/validate_tokens_simple.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: genai.py auth audit | Reason: Remplace par core/auth_manager.py audit
+#
 """
 validate_tokens_simple.py - Validation simple des tokens ComfyUI-Login
 """

--- a/scripts/genai-stack/_archive/utils/workflow_utils.py
+++ b/scripts/genai-stack/_archive/utils/workflow_utils.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# ARCHIVED: 2026-02 (consolidation genai-stack) -- see scripts/genai-stack/_archive/ARCHIVE_README.md
+# DISPOSITION: superseded | Successor: core/comfyui_client.py | Reason: Remplace par core/comfyui_client.py WorkflowManager
+#
 """
 Utilitaire consolidé pour la manipulation de workflows ComfyUI
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #14745

## Summary

Tranche 2B de la consolidation `_archive/` (#13749) : ajoute le header `ARCHIVED`/`DISPOSITION` aux **16 fichiers .py restants** de `scripts/genai-stack/_archive/` (core + utils). La tranche 2A (8 fichiers) a été livrée via **#14561** et est déjà dans `main`.

- Disposition per-file sourcée depuis `ARCHIVE_README.md` (colonne « Remplace par ») : `superseded` avec successeur (`genai.py ...`, `core/comfyui_client.py`, `genai.py docker ...`) ou `abandoned` (`Successor: (none)`) pour les dead-ends (import cassé / one-shot résolu / jamais appelé).
- Correction au passage de **11 appels subprocess pré-existants** `text=True` sans `encoding=` (#12811, crash cp1252 sur payload UTF-8), requis par le hook pré-commit sur ces fichiers.

## Verification

- 16 fichiers, **60 insertions / 11 délétions** (headers per-file + 11 lignes encoding).
- `python -m py_compile` sur les 8 fichiers modifiés : **SYNTAX OK** (warning `\U` pré-existant non lié).
- Pre-commit : gitleaks **Passed**, `text=True`-encoding **Passed**, notebooks "no files to check".
- Aucun changement de comportement au-delà du paramètre `encoding="utf-8", errors="replace"` (fix cause, règle F — pas de hand-edit de sortie).

## Note

Format per-file `DISPOSITION` (cohérent avec la 2A mergee #14561) ; la table canonique par-fichier (Raison / Remplace par) vit dans `scripts/genai-stack/_archive/ARCHIVE_README.md`.

See #13749
