### PR TITLE
test(guard,#14703): test de régression guard-level — citation prev backtiquée multi-lignes

### DIFF
--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -680,6 +680,66 @@ def test_fenced_block_with_internal_backticks_still_masked():
     assert vpg.find_prev_target_pr_numbers(body) == [14501]
 
 
+def test_multiline_backticked_citation_in_commit_passes_full_guard():
+    # #14703 -- the issue's isolated control replayed at FULL GUARD level.
+    # ai-01 measured the defect through the complete verdict path (the
+    # organ's `prev_invalid` named ``commits[0]`` / prev-not-merged / 14592);
+    # the mask-level tests above pin the mechanism, this one pins the
+    # end-to-end verdict the CI actually computes. The cited #14592 is held
+    # OPEN in ``prev_targets`` so a mask leak would turn into a block --
+    # the pass is earned by the mask, not by an accidentally-unresolvable
+    # target.
+    targets = {
+        "13826": {"kind": "pr", "merged": True},   # the body's own prev
+        "14592": {"kind": "pr", "merged": False},  # the cited-in-prose PR
+    }
+    commit_two_line = (
+        "fix(guard): document citation defect\n"
+        "\n"
+        "1. defect. The commit body documents the bug in prose, citing "
+        "`prev: MED/training\n"
+        "#14592` in backticks inside a numbered list, with NO Grain: "
+        "line of its own.\n"
+    )
+    v = vpg.check(CLEAN_PREV_BODY, [commit_two_line],
+                  current_pr=14703, prev_targets=targets)
+    assert v["guard_pass"] is True
+    assert v["hits"]["prev_invalid"] == []
+
+    # NON-REGRESSION CONTROL: the same citation on a single line -- the
+    # pre-fix working case, unchanged by the multi-line extension.
+    commit_one_line = (
+        "fix(guard): document citation defect\n"
+        "\n"
+        "1. defect. Citing `prev: MED/training #14592` in backticks.\n"
+    )
+    v = vpg.check(CLEAN_PREV_BODY, [commit_one_line],
+                  current_pr=14703, prev_targets=targets)
+    assert v["guard_pass"] is True
+    assert v["hits"]["prev_invalid"] == []
+
+    # TEETH CONTROL: the SAME wrapped clause WITHOUT backticks is a bare
+    # `prev:` declaration in a commit -- it must still block (the regex
+    # matches across the soft line break via ``\\s*``). This is what makes
+    # the two tests above fail on the pre-#14700 regex (`` `[^`\\n]*` ``):
+    # back then the L5 half ``#14592`` escaped the mask and this exact
+    # block fired. If the mask ever regresses, the pair above goes red
+    # while this one stays red-but-expected -- remove it and the suite
+    # loses its proof that the pass was earned.
+    commit_bare_wrapped = (
+        "fix(guard): stray declaration\n"
+        "\n"
+        "1. text with prev: MED/training\n"
+        "#14592 outside any backticks.\n"
+    )
+    v = vpg.check(CLEAN_PREV_BODY, [commit_bare_wrapped],
+                  current_pr=14703, prev_targets=targets)
+    assert v["guard_pass"] is False
+    assert any(h["kind"] == "prev-not-merged" and h["prev_pr"] == 14592
+               and h["location"] == "commits[0]"
+               for h in v["hits"]["prev_invalid"])
+
+
 # --- #14550, second defect: a silent fail-open is an unearned attestation ----
 # ai-01 measured it on #14515: CLEAN, PR gate green, mergeable -- with a
 # `prev:` at an OPEN PR, because the `gh` resolution happened to fail during


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14763

## Résumé

Le défaut de #14703 (masquage des spans backtickés ne survivant pas au repli de ligne) est **déjà résolu sur main** par le merge de #14700 (regex `_CODE_SPAN_RE` étendue à `re.DOTALL` + tests mask/finder niveau) — vérifié firsthand sur worktree frais da13579ca : les deux formes du contrôle isolé de l'issue passent (`guard_pass=True`, aucun `prev_invalid`).

Cette PR livre les deux éléments d'acceptance restants :

1. **Test guard-level** (acceptance item 2, au niveau où l'issue a mesuré) : le contrôle isolé complet — citation `prev: MED/training\n#14592` backtiquée sur deux lignes dans `commits[0]`, avec #14592 tenu OPEN dans `prev_targets` (une fuite du masque = blocage, le pass est gagné par le masque, pas par une cible non résoluble) ; contrôle mono-ligne inchangé ; **contrôle de mordant** : la même clause repliée SANS backticks bloque toujours (`prev-not-merged → commits[0] → 14592`), vérifié échouer sur la regex pré-#14700 (`` ` [^`\n] * ` `` simulée → verdict exact de l'issue reproduit).
2. **Vérification item 4** : `pr_close_keyword_guard.py` ne partage AUCUNE logique de spans (prémisse de l'issue fausse) — il scanne via `grain_tag.find_close_keyword_pr_refs` sur texte brut sans masquage. Le repli ne peut pas casser ce qui n'existe pas. Découverte adjacente au passage : les citations backtiquées `fixes #N` (mono-ligne ET repliées) déclenchent ce garde — signalée par issue dédiée #14780 (famille #14550, hors scope ici).

## Non-régression (acceptance item 3)

`pytest tests/test_variation_prev_guard.py` : **44 passed** (43 existants + 1 nouveau), 0.35 s.

## Traçabilité

- Contrôle isolé reproduit sur main frais : les DEUX formes vertes.
- Mordant vérifié : regex pré-#14700 simulée par monkeypatch → `guard_pass=False`, `prev_invalid=[{location: commits[0], kind: prev-not-merged, prev_pr: 14592}]` = verdict exact de l'issue.
- Issue adjacente #14780 (close-keyword guard sans masquage) avec mesures reproduites.

Closes #14703