### PR TITLE
feat(lean,#13483): hcap des oscillateurs périodiques T|2^k — L3 clos phase par phase (tranche 3c, étape 6)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -514,6 +514,133 @@ theorem hashlife_correct_margin_of_still_life (c : MacroCell) (k : Nat)
   hashlife_correct_margin_of_hcap c k h_central
     (fun t _ => hcap_of_still_life _ (canonical_sortDedup _) hfix t)
 
+/-! ## L3 classe périodique `T ∣ 2^k` — hcap des oscillateurs (tranche 3, étape 6)
+
+Deuxième maillon L3 **entièrement clos** : la généralisation de la chaîne
+`T = 1` aux oscillateurs de période `T > 1` à période dyadique. L'orbite
+n'est plus constante — `evolve t g` parcourt les `T` phases — donc la
+capture se prouve **phase par phase** : chaque phase `evolve r g` (`r < T`)
+est elle-même un point fixe de `evolve T` (`evolve_phase_fix`), la
+trajectoire se réduit au résidu modulo `T` (`evolve_mod_period`), et le
+schéma round-trip → point fixe transporté s'applique à chaque phase
+canonique. La prémisse géométrique `T ∣ 2^level` de
+`jumpCapturedF_of_period_divides` est portée **explicitement** : c'est une
+contrainte réelle sur le niveau de la reconstruction de chaque phase (le
+niveau doit atteindre `log₂ T`), pas une conséquence — la borne de niveau
+supérieure du côté `gridFrame` (étape 5) est ce qui la rend calculable. -/
+
+/-- **Chaque phase est un point fixe de `evolve T`.** Si `g` est
+    `T`-périodique, toute phase `evolve r g` l'est aussi : l'évolution
+    commute à elle-même (`evolve_add`), donc `evolve T (evolve r g)
+    = evolve r (evolve T g) = evolve r g`. C'est l'hypothèse `hper` exacte
+    qu'exige la capture au niveau de chaque phase. -/
+theorem evolve_phase_fix {T : Nat} (g : Grid)
+    (hper : evolve T g = g) (r : Nat) :
+    evolve T (evolve r g) = evolve r g := by
+  rw [← evolve_add, Nat.add_comm T r, evolve_add, hper]
+
+/-- **Réduction de la trajectoire au résidu modulo `T`.** Pour un motif
+    `T`-périodique, la trajectoire entière se replie sur ses `T` phases :
+    `evolve t g = evolve (t % T) g` — le quotient `t / T` de périodes
+    complètes disparaît par point fixe. C'est ce qui borne le travail de la
+    capture de « tout `t ≤ 2^k` » à « chacune des `T` phases ». -/
+theorem evolve_mod_period {T : Nat} (g : Grid)
+    (hper : evolve T g = g) (t : Nat) :
+    evolve t g = evolve (t % T) g := by
+  have hsplit : t = T * (t / T) + t % T := (Nat.div_add_mod t T).symm
+  conv_lhs => rw [hsplit, evolve_add, Nat.mul_comm]
+  exact evolve_mulF_of_period _ (evolve_phase_fix g hper _) _
+
+/-- **Transport du point fixe de période `T` à la reconstruction (rendue à
+    l'origine).** L'analogue exact de `still_life_fix_toGrid_zero` pour la
+    période `T` : si `g` est canonique et `T`-périodique, la MacroCell
+    reconstruite rendue à l'origine est elle-même un point fixe de
+    `evolve T` — navette `toGrid_shift_grid`, commutation `evolve_shift`,
+    round-trip ÉGALITÉ, point fixe. -/
+theorem periodic_fix_toGrid_zero (g : Grid) (hg : Canonical g) {T : Nat}
+    (hper : evolve T g = g) :
+    evolve T ((gridToMacroCellWithOffset g).2.toGrid (0, 0))
+      = (gridToMacroCellWithOffset g).2.toGrid (0, 0) := by
+  have hrt : (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1
+      = g := toGrid_gridToMacroCellWithOffset_eq g hg
+  have hshift : (gridToMacroCellWithOffset g).2.toGrid (0, 0)
+      = shift (0 - (gridToMacroCellWithOffset g).1.1,
+               0 - (gridToMacroCellWithOffset g).1.2)
+          ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
+    toGrid_shift_grid _ 0 0 _ _
+  rw [hshift, ← evolve_shift, hrt, hper]
+
+/-- **Capture de la reconstruction d'une phase périodique.** Pour toute
+    phase canonique `g` d'un oscillateur `T`-périodique (`T > 1` a fortiori
+    `0 < T`), dont le niveau de reconstruction divise l'horizon du saut
+    (`T ∣ 2^level`), la reconstruction satisfait le prédicat de saut —
+    c'est `jumpCapturedF_of_period_divides` consommé au niveau de la
+    reconstruction, avec les trois hypothèses désormais disponibles : wf
+    (`buildFromGrid_wf`), niveau (`1 ≤ lvl` dès `g ≠ []`, borne n-aware) et
+    point fixe de période `T` (`periodic_fix_toGrid_zero`). Cas vide : la
+    reconstruction est une feuille morte de niveau 0, décidée par le noyau. -/
+theorem jumpCapturedF_reconstruction_of_period (g : Grid) (hg : Canonical g)
+    {T : Nat} (hT0 : 0 < T) (hper : evolve T g = g)
+    (hdiv : T ∣ 2 ^ (gridToMacroCellWithOffset g).2.level) :
+    jumpCapturedF (gridToMacroCellWithOffset g).2 = true := by
+  by_cases hne : g = []
+  · subst hne
+    decide
+  · have hwf : ((gridToMacroCellWithOffset g).2).wf = true := by
+      unfold gridToMacroCellWithOffset
+      exact buildFromGrid_wf g _ _ _
+    have hlvl : 1 ≤ (gridToMacroCellWithOffset g).2.level := by
+      have hN := gridToMacroCellWithOffsetN_level_gt_n 2 g hne
+      rw [gridToMacroCellWithOffsetN_le_two_eq 2 g (by omega)] at hN
+      cases hL : (gridToMacroCellWithOffset g).2.level with
+      | zero => rw [hL] at hN; exact absurd hN (by decide)
+      | succ m => omega
+    exact jumpCapturedF_of_period_divides _ hwf hlvl hT0
+      (periodic_fix_toGrid_zero g hg hper) hdiv
+
+/-- **hcap de la classe périodique, trajectoire complète.** Pour un
+    oscillateur canonique de période `T > 1` dont **chaque phase** a un
+    niveau de reconstruction divisible par `T` (au sens `T ∣ 2^level`), tout
+    instant `t` (a fortiori tout `t ≤ 2^k`) est capturé : la trajectoire se
+    réduit à la phase `t % T` (`evolve_mod_period`), la phase est canonique
+    (`canonical_evolve_of_pos`, ou `g` lui-même pour la phase nulle),
+    point fixe de `evolve T` (`evolve_phase_fix`), et sa reconstruction est
+    capturée. La prémisse de divisibilité est finie : elle porte sur les `T`
+    phases seulement, pas sur la trajectoire infinie. -/
+theorem hcap_of_period (g : Grid) (hg : Canonical g) {T : Nat} (hT0 : 0 < T)
+    (hper : evolve T g = g)
+    (hdiv : ∀ i, i < T →
+      T ∣ 2 ^ (gridToMacroCellWithOffset (evolve i g)).2.level) :
+    ∀ t, jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
+  intro t
+  rw [evolve_mod_period g hper t]
+  have hr : t % T < T := Nat.mod_lt _ hT0
+  have hcan : Canonical (evolve (t % T) g) := by
+    rcases Nat.eq_zero_or_pos (t % T) with h0 | hpos
+    · rw [h0]
+      simpa using hg
+    · exact canonical_evolve_of_pos hpos _
+  have hfix : evolve T (evolve (t % T) g) = evolve (t % T) g :=
+    evolve_phase_fix g hper _
+  exact jumpCapturedF_reconstruction_of_period _ hcan hT0 hfix (hdiv _ hr)
+
+/-- **L3 clos pour la classe périodique `T ∣ 2^k` : correction Hashlife des
+    oscillateurs.** Corollaire d'assemblage — le deuxième cas de la
+    décomposition P4.4 où le maillon L3 est **entièrement prouvé** : pour
+    toute MacroCell dont la grille rendue à l'origine est un oscillateur de
+    période `T > 1` (chaque phase de niveau divisible), l'égalité globale
+    `hashlife_correctN` s'applique à tout horizon `2^k` sous `centralCorrect`.
+    La classe couvre les témoins multi-cycles du bestiaire (clignotant
+    `T = 2`, crapaud `T = 2`, phare `T = 3` dès que `T ∣ 2^level`). -/
+theorem hashlife_correct_margin_of_period (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k) {T : Nat} (hT0 : 0 < T)
+    (hper : evolve T (c.toGrid (0, 0)) = c.toGrid (0, 0))
+    (hdiv : ∀ i, i < T →
+      T ∣ 2 ^ (gridToMacroCellWithOffset (evolve i (c.toGrid (0, 0)))).2.level) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correct_margin_of_hcap c k h_central
+    (fun t _ => hcap_of_period _ (canonical_sortDedup _) hT0 hper hdiv t)
+
 /-! ## Sanity-checks sur le bestiaire
 
 Le fragment `supportInMargin` est **décidable** (instance `Decidable (BoxAssezGrandN)`,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -515,6 +515,133 @@ theorem hashlife_correct_margin_of_still_life (c : MacroCell) (k : Nat)
   hashlife_correct_margin_of_hcap c k h_central
     (fun t _ => hcap_of_still_life _ (canonical_sortDedup _) hfix t)
 
+/-! ## L3 periodic class `T ∣ 2^k` — hcap of oscillators (tranche 3, step 6)
+
+Second L3 link **entirely closed**: the generalization of the `T = 1` chain
+to oscillators of period `T > 1` with dyadic period. The orbit is no longer
+constant — `evolve t g` cycles through the `T` phases — so the capture is
+proved **phase by phase**: each phase `evolve r g` (`r < T`) is itself a
+fixed point of `evolve T` (`evolve_phase_fix`), the trajectory reduces to
+the residue modulo `T` (`evolve_mod_period`), and the round-trip →
+transported fixed point scheme applies to each canonical phase. The
+geometric premise `T ∣ 2^level` of `jumpCapturedF_of_period_divides` is
+carried **explicitly**: it is a real constraint on the reconstruction level
+of each phase (the level must reach `log₂ T`), not a consequence — the
+upper level bound on the `gridFrame` side (step 5) is what makes it
+computable. -/
+
+/-- **Each phase is a fixed point of `evolve T`.** If `g` is `T`-periodic,
+    so is every phase `evolve r g`: evolution commutes with itself
+    (`evolve_add`), hence `evolve T (evolve r g) = evolve r (evolve T g)
+    = evolve r g`. This is the exact `hper` hypothesis the capture requires
+    at the level of each phase. -/
+theorem evolve_phase_fix {T : Nat} (g : Grid)
+    (hper : evolve T g = g) (r : Nat) :
+    evolve T (evolve r g) = evolve r g := by
+  rw [← evolve_add, Nat.add_comm T r, evolve_add, hper]
+
+/-- **Reduction of the trajectory to the residue modulo `T`.** For a
+    `T`-periodic pattern, the whole trajectory folds onto its `T` phases:
+    `evolve t g = evolve (t % T) g` — the quotient `t / T` of complete
+    periods vanishes by fixed point. This bounds the capture work from
+    "every `t ≤ 2^k`" to "each of the `T` phases". -/
+theorem evolve_mod_period {T : Nat} (g : Grid)
+    (hper : evolve T g = g) (t : Nat) :
+    evolve t g = evolve (t % T) g := by
+  have hsplit : t = T * (t / T) + t % T := (Nat.div_add_mod t T).symm
+  conv_lhs => rw [hsplit, evolve_add, Nat.mul_comm]
+  exact evolve_mulF_of_period _ (evolve_phase_fix g hper _) _
+
+/-- **Transport of the period-`T` fixed point to the reconstruction
+    (returned to the origin).** The exact analogue of
+    `still_life_fix_toGrid_zero` for period `T`: if `g` is canonical and
+    `T`-periodic, the reconstructed MacroCell returned to the origin is
+    itself a fixed point of `evolve T` — `toGrid_shift_grid` shuttle,
+    `evolve_shift` commutation, EQUALITY round-trip, fixed point. -/
+theorem periodic_fix_toGrid_zero (g : Grid) (hg : Canonical g) {T : Nat}
+    (hper : evolve T g = g) :
+    evolve T ((gridToMacroCellWithOffset g).2.toGrid (0, 0))
+      = (gridToMacroCellWithOffset g).2.toGrid (0, 0) := by
+  have hrt : (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1
+      = g := toGrid_gridToMacroCellWithOffset_eq g hg
+  have hshift : (gridToMacroCellWithOffset g).2.toGrid (0, 0)
+      = shift (0 - (gridToMacroCellWithOffset g).1.1,
+               0 - (gridToMacroCellWithOffset g).1.2)
+          ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
+    toGrid_shift_grid _ 0 0 _ _
+  rw [hshift, ← evolve_shift, hrt, hper]
+
+/-- **Capture of the reconstruction of a periodic phase.** For any
+    canonical phase `g` of a `T`-periodic oscillator (`T > 1` a fortiori
+    `0 < T`), whose reconstruction level divides the jump horizon
+    (`T ∣ 2^level`), the reconstruction satisfies the jump predicate —
+    this is `jumpCapturedF_of_period_divides` consumed at the
+    reconstruction level, with the three hypotheses now available: wf
+    (`buildFromGrid_wf`), level (`1 ≤ lvl` as soon as `g ≠ []`, n-aware
+    bound) and period-`T` fixed point (`periodic_fix_toGrid_zero`). Empty
+    case: the reconstruction is a dead level-0 leaf, decided by the kernel. -/
+theorem jumpCapturedF_reconstruction_of_period (g : Grid) (hg : Canonical g)
+    {T : Nat} (hT0 : 0 < T) (hper : evolve T g = g)
+    (hdiv : T ∣ 2 ^ (gridToMacroCellWithOffset g).2.level) :
+    jumpCapturedF (gridToMacroCellWithOffset g).2 = true := by
+  by_cases hne : g = []
+  · subst hne
+    decide
+  · have hwf : ((gridToMacroCellWithOffset g).2).wf = true := by
+      unfold gridToMacroCellWithOffset
+      exact buildFromGrid_wf g _ _ _
+    have hlvl : 1 ≤ (gridToMacroCellWithOffset g).2.level := by
+      have hN := gridToMacroCellWithOffsetN_level_gt_n 2 g hne
+      rw [gridToMacroCellWithOffsetN_le_two_eq 2 g (by omega)] at hN
+      cases hL : (gridToMacroCellWithOffset g).2.level with
+      | zero => rw [hL] at hN; exact absurd hN (by decide)
+      | succ m => omega
+    exact jumpCapturedF_of_period_divides _ hwf hlvl hT0
+      (periodic_fix_toGrid_zero g hg hper) hdiv
+
+/-- **hcap of the periodic class, whole trajectory.** For a canonical
+    oscillator of period `T > 1` whose **every phase** has a reconstruction
+    level divisible by `T` (in the sense `T ∣ 2^level`), every instant `t`
+    (a fortiori every `t ≤ 2^k`) is captured: the trajectory reduces to the
+    phase `t % T` (`evolve_mod_period`), the phase is canonical
+    (`canonical_evolve_of_pos`, or `g` itself for the zero phase), a fixed
+    point of `evolve T` (`evolve_phase_fix`), and its reconstruction is
+    captured. The divisibility premise is finite: it bears on the `T`
+    phases only, not on the infinite trajectory. -/
+theorem hcap_of_period (g : Grid) (hg : Canonical g) {T : Nat} (hT0 : 0 < T)
+    (hper : evolve T g = g)
+    (hdiv : ∀ i, i < T →
+      T ∣ 2 ^ (gridToMacroCellWithOffset (evolve i g)).2.level) :
+    ∀ t, jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
+  intro t
+  rw [evolve_mod_period g hper t]
+  have hr : t % T < T := Nat.mod_lt _ hT0
+  have hcan : Canonical (evolve (t % T) g) := by
+    rcases Nat.eq_zero_or_pos (t % T) with h0 | hpos
+    · rw [h0]
+      simpa using hg
+    · exact canonical_evolve_of_pos hpos _
+  have hfix : evolve T (evolve (t % T) g) = evolve (t % T) g :=
+    evolve_phase_fix g hper _
+  exact jumpCapturedF_reconstruction_of_period _ hcan hT0 hfix (hdiv _ hr)
+
+/-- **L3 closed for the periodic class `T ∣ 2^k`: Hashlife correctness of
+    oscillators.** Assembly corollary — the second case of the P4.4
+    decomposition where the L3 link is **entirely proved**: for any
+    MacroCell whose grid returned to the origin is an oscillator of period
+    `T > 1` (every phase of divisible level), the global equality
+    `hashlife_correctN` applies at any horizon `2^k` under `centralCorrect`.
+    The class covers the multi-cycle witnesses of the bestiary (blinker
+    `T = 2`, toad `T = 2`, lighthouse `T = 3` as soon as `T ∣ 2^level`). -/
+theorem hashlife_correct_margin_of_period (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k) {T : Nat} (hT0 : 0 < T)
+    (hper : evolve T (c.toGrid (0, 0)) = c.toGrid (0, 0))
+    (hdiv : ∀ i, i < T →
+      T ∣ 2 ^ (gridToMacroCellWithOffset (evolve i (c.toGrid (0, 0)))).2.level) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correct_margin_of_hcap c k h_central
+    (fun t _ => hcap_of_period _ (canonical_sortDedup _) hT0 hper hdiv t)
+
 /-! ## Sanity checks on the bestiary
 
 The fragment `supportInMargin` is **decidable** (instance `Decidable (BoxAssezGrandN)`,


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/lean #14743

## Summary

#13483 tranche 3, interface (c), **étape 6 : L3 clos pour la classe périodique `T ∣ 2^k`, `T > 1` — hcap des oscillateurs, phase par phase, sans aucun `sorry`.**

Empilée sur #14756 (la chaîne `T = 1` des natures mortes), cette PR généralise le maillon L3 aux oscillateurs de période dyadique — l'orbite n'est plus constante, la capture se prouve **phase par phase** :

- **`evolve_phase_fix`** — chaque phase `evolve r g` d'un motif `T`-périodique est elle-même un point fixe de `evolve T` (commutation `evolve_add`, `evolve T (evolve r g) = evolve r (evolve T g)`).
- **`evolve_mod_period`** — la trajectoire entière se réduit au résidu : `evolve t g = evolve (t % T) g` (`Nat.div_add_mod` + point fixe) — le travail de capture passe de « tout `t ≤ 2^k` » à « chacune des `T` phases ».
- **`periodic_fix_toGrid_zero`** — l'analogue exact de `still_life_fix_toGrid_zero` pour la période `T` : le point fixe transporté à la reconstruction rendue à l'origine (navette `toGrid_shift_grid`, commutation `evolve_shift`, round-trip ÉGALITÉ).
- **`jumpCapturedF_reconstruction_of_period`** — capture de la reconstruction d'une phase canonique via `jumpCapturedF_of_period_divides` (#14743) : wf (`buildFromGrid_wf`), niveau (`1 ≤ lvl` dès `g ≠ []`, borne n-aware), point fixe (`periodic_fix_toGrid_zero`) et divisibilité `T ∣ 2^level` **portée explicitement** — c'est une contrainte réelle sur le niveau de chaque phase (le niveau doit atteindre `log₂ T`), pas une conséquence ; la borne de niveau supérieure de l'étape 5 (#14764) est ce qui la rend calculable.
- **`hcap_of_period`** — trajectoire complète : réduction au résidu, canonicité de phase (`canonical_evolve_of_pos`, ou `g` lui-même pour la phase nulle), capture par phase. La prémisse de divisibilité est **finie** : elle porte sur les `T` phases seulement, pas sur la trajectoire infinie.
- **`hashlife_correct_margin_of_period`** — corollaire d'assemblage : deuxième cas de la décomposition P4.4 où le maillon L3 est **entièrement prouvé** (clignotant `T = 2`, crapaud `T = 2`, phare `T = 3` dès que `T ∣ 2^level`). Ne reste que L4 (`centralCorrect`), dans l'hypothèse — la cloison annoncée par la réduction L2.

## Validation

- **double `lake build` SUCCESS** sur `Conway.Life.HashlifeMarginFragment` ET `Conway.Life.HashlifeMarginFragment_en` — chaque relance rend EXIT=0.
- **sorry count inchangé** : `distinct_code_sorry` = 1 (résiduel = `hashlife_correct_margin`, cible connue de #6724) — avant comme après, aucun `sorry` ajouté.
- **i18n** : sibling `_en` porté (docstrings EN, preuves byte-identiques) ; le check CI `i18n sibling drift` tranche sur la PR.
- **Périmètre** : 2 fichiers (paire FR + `_en`), insertion pure après la section still-life. Aucun notebook, catalogue, script, dataset touché.
- **Stack** : base = `feature/13483-t3c3` (tête de #14756) — le diff de la PR est l'incrément périodique seul. Retarget `main` + rebase après merge de #14756.

See #13483 · See #6724
