### PR TITLE
fix(guard,#14461): reconnaitre tout override en tete (motif, pas startswith)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -195,6 +195,24 @@ _OVERRIDE_LANE = re.compile(
 )
 OVERRIDE_LANE = _OVERRIDE_LANE
 
+# #14461 -- un marqueur d'override EN TÊTE est TOUT token bracketé dont
+# l'étiquette porte OVERRIDE, quel que soit le garde émetteur : `[OVERRIDE]`,
+# `[G-VAR-3 OVERRIDE]`, et les futurs overrides de gardes adjacents. Le
+# `startswith("[OVERRIDE]")` (une seule graphie) ne reconnaissait pas la forme
+# canonique `[G-VAR-3 OVERRIDE]` de variation_adjacency_guard.py : un override
+# correctement posé devenait une émission de hold (BOT-CONCERN) et bloquait la
+# PR qu'il venait de débloquer — les deux instruments de déblocage se bloquaient
+# l'un l'autre. Reconnaissance par MOTIF (bracketé portant OVERRIDE), pas par
+# graphie. GARDE-FOU d'EN-TÊTE : les appelants ne font que `.match` (ancrage
+# position 0) — un `[OVERRIDE]` MENTIONNÉ en milieu de tête (ex. « pas de merge
+# tant que [OVERRIDE] lane n'est pas posé ») n'est PAS un arbitrage posé et doit
+# rester un blocage (cf test_13083_blocage_reel_conditionnel). Partagé par
+# `_block_emitted` (point A) et `_coordinator_emission_informal`.
+_OVERRIDE_HEAD_RE = re.compile(
+    r"\[\s*[^\]]*\bOVERRIDE\b[^\]]*\]",
+    re.IGNORECASE,
+)
+
 # #13083 — le symetrique de #11639 : un coordinateur BLOQUE aussi, et l'organe
 # ne le modelisait pas. Même contrainte de pose stricte que le durcissement de
 # la citation (#13030) : le marqueur est POSE — ancre debut de ligne (seule
@@ -2107,7 +2125,7 @@ def _block_emitted(body: str) -> bool:
         return True
     head = normalised[:60]
     uhead = head.upper()
-    if head.lstrip(" \t*_").upper().startswith("[OVERRIDE]"):
+    if _OVERRIDE_HEAD_RE.match(head.lstrip(" \t*_").upper()):
         return False
     m_hold = HOLD_HEAD.match(head)
     if m_hold and _hold_head_is_emission(head, m_hold.end()):
@@ -2274,11 +2292,14 @@ def _coordinator_emission_informal(body: str) -> bool:
     # injonctions sont suivies d'un participe de levee, c'est une levee.
     if _every_injunction_followed_by_lift(normalised):
         return False
-    # Un [OVERRIDE] pose en tete (arbretage tiers de B.0) EMET une levee,
-    # jamais une reserve — garde-fou de l'override, deja documente en
-    # `_block_emitted` point A.
+    # Un override pose en tete (arbitrage tiers de B.0, quelle que soit sa
+    # graphie — `[OVERRIDE]`, `[G-VAR-3 OVERRIDE]`, et les futurs overrides de
+    # gardes) EMET une levee, jamais une reserve — garde-fou de l'override,
+    # deja documente en `_block_emitted` point A. #14461 : le
+    # `startswith("[OVERRIDE]")` ne reconnaissait pas la forme canonique
+    # d'adjacence, un override correctement pose redevenait une emission.
     head = normalised[:60].lstrip(" \t*_").upper()
-    if head.startswith("[OVERRIDE]"):
+    if _OVERRIDE_HEAD_RE.match(head):
         return False
     return True
 

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -5248,3 +5248,59 @@ def test_13083_instance3_tete_h1_neutralise_toujours():
         f"fondateur), got {mod.classify('myia-ai-01', body)!r}"
     )
 
+
+def test_14461_gvar3_override_est_reconnu_comme_arbitrage() -> None:
+    """#14461 : un [G-VAR-3 OVERRIDE] pose en tete EMET une levee, pas un hold.
+
+    Cas fondateur (PR #14345) : le coordinateur pose l'override d'adjacence
+    canonique `[G-VAR-3 OVERRIDE] lane <m:w> -- next: <genre>` pour debloquer
+    le garde d'adjacence, mais la phrase qui suit (« tant que ... n'est pas
+    sur main ») est lue comme une injonction -> classify = BOT-CONCERN ->
+    la PR que l'override venait de debloquer reste bloquee. Les deux
+    instruments de deblocage du depot se bloquaient l'un l'autre.
+
+    Controle a variable unique (tableau de l'issue) : meme corps, meme auteur,
+    seul le marqueur d'en-tete change. B vs C isole la cause a une seule
+    variable (l'orthographe du marqueur). D (vraie injonction) et E (anodin)
+    rendent le controle non vacuous : la correction ne desarme PAS la
+    detection de hold reelle — un predicat qui ne porte que B serait permissif
+    et passerait inapercu.
+    """
+    phrase = "Tant que #14345 n'est pas sur `main`, chaque levee de la flotte porte ce risque."
+    cases = [
+        ("A phrase seule", phrase, True),
+        (
+            "B sous [G-VAR-3 OVERRIDE]",
+            f"[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: notebook-python\n\n{phrase}",
+            False,
+        ),
+        (
+            "C sous [OVERRIDE]",
+            f"[OVERRIDE] lane myia-po-2026:CoursIA -- next: notebook-python\n\n{phrase}",
+            False,
+        ),
+        ("D vraie injonction", "Ne pas merger tant que le run GPU n'est pas rendu.", True),
+        ("E commentaire anodin", "Vu, merci.", False),
+    ]
+    for label, body, expected in cases:
+        got = mod._coordinator_emission_informal(body)
+        assert got is expected, (
+            f"#14461 {label}: _coordinator_emission_informal attendu "
+            f"{expected}, got {got!r}"
+        )
+    # Integration (symptome mesure sur #14345) : un override d'adjacence pose
+    # par un LIFT_OVERRIDE_LOGINS ne doit plus classifier BOT-CONCERN (la PR que
+    # l'override debloque reste bloquee). Il doit rendre None (pas de reserve).
+    body_b = (
+        f"[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: notebook-python\n\n{phrase}"
+    )
+    assert mod.classify("myia-ai-01", body_b) is None, (
+        f"#14461: classify(myia-ai-01, [G-VAR-3 OVERRIDE] + phrase) attendu "
+        f"None (pas de BOT-CONCERN vivant), got "
+        f"{mod.classify('myia-ai-01', body_b)!r}"
+    )
+    assert mod._block_emitted(body_b) is False, (
+        "#14461: l'override d'adjacence n'emet pas non plus un BLOCAGE "
+        "(point A de _block_emitted, garde-fou du jumeau)."
+    )
+


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #14772

## Summary

Le garde B.0 `scripts/check_unaddressed_nits.py` supprime l'émission-coordinateur quand un commentaire s'ouvre sur `[OVERRIDE]`, **mais pas** quand il s'ouvre sur `[G-VAR-3 OVERRIDE]` — la forme canonique et documentée de l'override d'adjacence, celle que `variation_adjacency_guard.py` exige. Conséquence : **poser correctement l'override qui débloque le garde d'adjacence crée mécaniquement un nit B.0 vivant** (BOT-CONCERN) et la PR reste bloquée par un autre organe. Les deux instruments de déblocage du dépôt se bloquent l'un l'autre.

Reproduit **firsthand sur `origin/main`** (da13579cac) avec le **corps réel** du commentaire d'arbitrage de ai-01 (2002 o, sur #14345, 2026-09-03T10:33:28Z) :

```
[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: notebook-python
...
_coordinator_emission_informal : True
classify(myia-ai-01)           : BOT-CONCERN
_block_emitted                 : False
```

(Nota : un verdict antérieur de po-2026 déclarait le défaut « non reproductible » en citant un corps de **4 262 o** — le commentaire réel fait **2 002 o** ; le corps testé n'était pas celui qui produit le défaut. La reproduction ci-dessus le réfute.)

## Cause

Deux `head.startswith("[OVERRIDE]")` — queue de `_coordinator_emission_informal` et point A de `_block_emitted` — n'ancrent que la **graphie unique** `[OVERRIDE]`. `[G-VAR-3 OVERRIDE]` ne commence pas par `[OVERRIDE]`, la suppression ne s'arme pas, le commentaire d'arbitrage retombe dans la branche « émission de hold » → `BOT-CONCERN`.

## Fix

Remplacement par un **motif** bracketé portant `OVERRIDE` (`_OVERRIDE_HEAD_RE`), posé avec **`.match` (ancrage position 0)** :

- `[G-VAR-3 OVERRIDE]` **en tête** → reconnu comme arbitrage → `False` (plus de nit vivant).
- Un `[OVERRIDE]` **mentionné en milieu de tête** (ex. « pas de merge tant que [OVERRIDE] lane n'est pas posé ») → **pas** un arbitrage posé → reste un blocage. C'est la non-régression gardée par `test_13083_blocage_reel_conditionnel_a_un_override_reste_block` : `.search` (n'importe où) aurait désarmé cette mention ; `.match` (début) la préserve.

Le motif reconnaît aussi les futurs overrides de gardes adjacents (ex. `[G-VAR-2 OVERRIDE]`), conformément à l'acceptance 1 : « reconnaissance par motif, pas par startswith sur une graphie ».

## Validation

`python -m pytest scripts/tests/test_check_unaddressed_nits.py` → **373 passed, 1 skipped, 0 failed** (sur HEAD après le fix, base `da13579cac`).

Nouveau test `test_14461_gvar3_override_est_reconnu_comme_arbitrage` porte **les cinq lignes du tableau** de l'issue avec la phrase déclenchante réelle (« Tant que #14345 n'est pas sur `main`, chaque levée de la flotte porte ce risque. ») :

| # | Corps | `_coordinator_emission_informal` attendu |
|---|---|---|
| A | phrase seule | `True` |
| B | sous `[G-VAR-3 OVERRIDE]` | `False` (le fix) |
| C | sous `[OVERRIDE]` | `False` |
| D | vraie injonction | `True` (contrôle positif) |
| E | commentaire anodin | `False` (contrôle négatif) |

D et E rendent le contrôle non vacuous : la correction ne désarme pas la détection de hold réelle (seul un prédicat ne portant que B serait permissif). Intégration : `classify(myia-ai-01, bodyB) is None` (plus de BOT-CONCERN) et `_block_emitted(bodyB) is False`.

## Files

- `scripts/check_unaddressed_nits.py` — ajout `_OVERRIDE_HEAD_RE` + les deux gardes en `.match`.
- `scripts/tests/test_check_unaddressed_nits.py` — test 5 lignes + intégration.

Closes #14461
