### PR TITLE
fix(guard,#14793): override = affirmation — rejeter les negations FR/EN dans le motif

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -208,8 +208,15 @@ OVERRIDE_LANE = _OVERRIDE_LANE
 # tant que [OVERRIDE] lane n'est pas posé ») n'est PAS un arbitrage posé et doit
 # rester un blocage (cf test_13083_blocage_reel_conditionnel). Partagé par
 # `_block_emitted` (point A) et `_coordinator_emission_informal`.
+# #14461 tranche 2 (adjoint po-2025) : un override est une AFFIRMATION, jamais
+# une negation. `[NO OVERRIDE]` / `[PAS D'OVERRIDE]` / `[SANS OVERRIDE]` /
+# `[NOT AN OVERRIDE]` disent l'inverse d'un arbitrage ; les croire overrides
+# SUPPRIMERAIT une injonction reelle. Lookahead negatif : un mot de negation
+# (EN/FR) present avant OVERRIDE dans le crochet = pas un override. Formes
+# positives (`[OVERRIDE]`, `[G-VAR-3 OVERRIDE]`, `[G-VAR-2 OVERRIDE]`) intactes.
 _OVERRIDE_HEAD_RE = re.compile(
-    r"\[\s*[^\]]*\bOVERRIDE\b[^\]]*\]",
+    r"\[\s*(?![^\]]*\b(?:no|not|nor|none|never|sans|pas|aucun|aucune)\b[^\]]*\bOVERRIDE\b)"
+    r"[^\]]*\bOVERRIDE\b[^\]]*\]",
     re.IGNORECASE,
 )
 

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -5351,3 +5351,36 @@ def test_14461_t2_negation_d_override_ne_supprime_rien() -> None:
             f"#14461-T2 {marker!r}: le motif doit matcher une forme positive."
         )
 
+
+def test_14793_troncature_60_crochet_non_ferme_est_pin() -> None:
+    """#14793 acceptance 3 : la troncature de tete a 60 caracteres, quand le
+    crochet OVERRIDE s'ouvre mais ne se ferme pas avant la limite, ne desarme
+    pas le garde (pin, comportement hereditaire accepte par la review de #14788).
+
+    Un en-tete dont le crochet s'ouvre dans les 60 premiers chars mais ne se
+    ferme pas avant la limite n'est PAS un override pose : le motif regu une
+    tete sans `]` et ne matche pas, le BLOCAGE reste une emission (garde arme),
+    pas un arbitrage muet. Valeurs mesurees sur `_OVERRIDE_HEAD_RE` a pos 0
+    (`.match`), `_coordinator_emission_informal`, `_block_emitted` et `classify`.
+    """
+    body = (
+        "**BLOCAGE MERGE (ai-01)** — Au tour precedent, l'ordre [OVERRIDE lane "
+        "myia-po-2024:CoursIA-2 -- justifier longuement que le crochet ne se "
+        "referme pas avant la limite de soixante caracteres]\n\nNe pas merger "
+        "tant que le run GPU n'est pas rendu."
+    )
+    head60 = body[:60]
+    assert not mod._OVERRIDE_HEAD_RE.match(head60.upper()), (
+        "#14793-TRUNC: un crochet non ferme dans les 60 premiers chars ne doit "
+        "pas matcher le motif d'override (le garde n'est pas desarme)."
+    )
+    assert mod._coordinator_emission_informal(body) is True, (
+        "#14793-TRUNC: l'injonction doit rester une emission."
+    )
+    assert mod._block_emitted(body) is True, (
+        "#14793-TRUNC: le BLOCAGE (point A) reste emis sous un crochet non ferme."
+    )
+    assert mod.classify("myia-ai-01", body) == "BLOCK", (
+        "#14793-TRUNC: classify doit rendre BLOCK, pas None/arbitrage."
+    )
+

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -5304,3 +5304,50 @@ def test_14461_gvar3_override_est_reconnu_comme_arbitrage() -> None:
         "(point A de _block_emitted, garde-fou du jumeau)."
     )
 
+
+def test_14461_t2_negation_d_override_ne_supprime_rien() -> None:
+    """#14461 tranche 2 (adjoint po-2025, 2026-09-05) : un override est une
+    AFFIRMATION, jamais une negation.
+
+    `[NO OVERRIDE]` / `[PAS D'OVERRIDE]` / `[SANS OVERRIDE]` / `[NOT AN
+    OVERRIDE]` disent l'inverse d'un arbitrage. Le motif bracketé
+    `_OVERRIDE_HEAD_RE` (qui ne portait qu'OVERRIDE) les reconnaissait quand
+    meme et SUPPRIMAIT une injonction reelle posee juste apres : `_block_emitted`
+    (point A) et `_coordinator_emission_informal` retombaient a False
+    (arbitrage) et `classify` rendait None sur un corps portant un BLOCAGE.
+    Lookahead negatif : un mot de negation (EN/FR) avant OVERRIDE dans le
+    crochet = pas un override. Controles positifs : les formes canoniques
+    (`[G-VAR-3 OVERRIDE]`, `[G-VAR-2 OVERRIDE]`, `[OVERRIDE]`) restent des
+    arbitrages (non-regression).
+    """
+    injonction = "**BLOCAGE MERGE (ai-01)** — Ne pas merger tant que le run GPU n'est pas rendu."
+    negs = ["[NO OVERRIDE]", "[PAS D'OVERRIDE]", "[SANS OVERRIDE]", "[NOT AN OVERRIDE]"]
+    for marker in negs:
+        body = f"{marker} lane x\n\n{injonction}"
+        assert mod._block_emitted(body) is True, (
+            f"#14461-T2 {marker!r}: le BLOCAGE doit rester emis — la negation ne "
+            f"desarme pas le point A de _block_emitted, got "
+            f"{mod._block_emitted(body)!r}"
+        )
+        assert mod._coordinator_emission_informal(body) is True, (
+            f"#14461-T2 {marker!r}: l'injonction doit rester une emission — la "
+            f"negation ne la supprime pas, got "
+            f"{mod._coordinator_emission_informal(body)!r}"
+        )
+        assert mod.classify("myia-ai-01", body) == "BLOCK", (
+            f"#14461-T2 {marker!r}: classify doit rendre BLOCK, pas None (la "
+            f"negation n'est pas un arbitrage), got "
+            f"{mod.classify('myia-ai-01', body)!r}"
+        )
+        assert not mod._OVERRIDE_HEAD_RE.match(f"{marker} lane x".upper()), (
+            f"#14461-T2 {marker!r}: le motif ne doit pas matcher une negation."
+        )
+    for marker in ("[G-VAR-3 OVERRIDE]", "[G-VAR-2 OVERRIDE]", "[OVERRIDE]"):
+        body = f"{marker} lane x\n\n{injonction}"
+        assert mod._block_emitted(body) is False
+        assert mod._coordinator_emission_informal(body) is False
+        assert mod.classify("myia-ai-01", body) is None
+        assert mod._OVERRIDE_HEAD_RE.match(f"{marker} lane x".upper()), (
+            f"#14461-T2 {marker!r}: le motif doit matcher une forme positive."
+        )
+


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/guard #14788

## Objet

Résout **#14793** (garde B.0 `check_unaddressed_nits.py`, tranche 2 de **#14461**). Le motif bracketé `_OVERRIDE_HEAD_RE` livré par #14788 ne portait que `OVERRIDE` : il reconnaissait `[NO OVERRIDE]` / `[PAS D'OVERRIDE]` / `[SANS OVERRIDE]` / `[NOT AN OVERRIDE]` comme des arbitrages, alors que ces graphies disent l'**inverse** d'un override. Conséquence : une injonction réelle posée juste après était **supprimée** — point A de `_block_emitted` et `_coordinator_emission_informal` retombaient à `False` (arbitrage) et `classify` rendait `None` sur un corps portant `BLOCAGE`.

## Fix

Lookahead négatif dans `_OVERRIDE_HEAD_RE` : un mot de négation (EN/FR : `no` / `not` / `nor` / `none` / `never` / `sans` / `pas` / `aucun` / `aucune`) présent **avant** `OVERRIDE` dans le crochet = pas un override. Les formes canoniques de l'arbitrage (`[OVERRIDE]`, `[G-VAR-3 OVERRIDE]`, `[G-VAR-2 OVERRIDE]`) restent reconnues (ancrage pos 0 inchangé — la mention en milieu de tête de `test_13083` reste un blocage).

## Acceptance #14793

1. **Négations FR/EN exclues** devant le mot-clé — oui.
2. **Tests sur `_coordinator_emission_informal` et `_block_emitted`** — oui, symétriques.
3. **Forme canonique G-VAR-3 + mention mid-head préservées** — oui (contrôles positifs + `test_13083` non-régressé).
4. **Contrôle positif obligatoire** — vérifié contre le motif pré-fix (`origin/main` : `da13579cac`) sur **chacune des quatre négations** (trois requises) : `_OVERRIDE_HEAD_RE.match`→`True`, `_block_emitted`→`False`, `_coordinator_emission_informal`→`False`, `classify`→`None`. Chaque forme échoue AVANT le fix, passe APRÈS. Voir `test_14461_t2_negation_d_override_ne_supprime_rien`.
5. **Pin troncature 60 chars à crochet non fermé** — `test_14793_troncature_60_crochet_non_ferme_est_pin` : `_OVERRIDE_HEAD_RE.match(head60)`→`False` (le crochet non fermé avant la limite n'est pas un override), `_block_emitted`→`True`, `_coordinator_emission_informal`→`True`, `classify`→`BLOCK`.

## Tests

- `test_14461_t2_negation_d_override_ne_supprime_rien` : pour chaque négation, `BLOCAGE` reste émis (`_block_emitted=True`, `_coordinator_emission_informal=True`, `classify="BLOCK"`), négation non matchée ; pour chaque forme canonique, arbitrage muet (non-régression).
- `test_14793_troncature_60_crochet_non_ferme_est_pin` : ci-dessus (acceptance 5).
- Module complet : **375 passed, 1 skipped, 0 failed** (précédemment 374/1/0 — aucun test existant régressé).

## Note de genre

PR de repair/refonte de garde → genre `guard` (**META**), ne tient pas le plancher G-VAR-1. Le plancher du cycle est tenu par **#14795** (`MED/notebook-python`, CONTENU).

Closes #14793



---

*Correction coordinateur (ai-01, 2026-09-05T18:21Z)* — le champ `prev:` pointait #14795, **non mergee** : l'invariant du `prev_guard` exige une PR **mergee** de la meme lane. Repointe sur #14788 (`MED/guard`, lane `myia-po-2024:CoursIA-2`, mergee 2026-09-05T17:53:38Z), qui est par ailleurs le predecesseur **reel** lu sur la sequence mergee par le garde d'adjacence. L'adjacence `guard` apres `guard` qui en decoule est levee par arbitrage coordinateur : voir le commentaire de marqueur poste sur cette PR.
