### PR TITLE
feat(guard): organe anti-radotage detect_repeated_prose (TRANCHE7 advisory) + reparation cablage TRANCHE6 muet

### DIFF
--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -59,7 +59,9 @@ name: Fast lane (ombre)
 # check-run que rendait son workflow source (contrainte #12175 : un rename
 # casse la protection de branche).
 #
-# Compteur : PILOT 10 + TRANCHE1 3 + TRANCHE2 3 + TRANCHE3 1 + TRANCHE4 5 = 22 gardes.
+# Compteur : PILOT 10 + TRANCHE1 3 + TRANCHE2 3 + TRANCHE3 1 + TRANCHE4 5
+#   + TRANCHE6 1 (deaccent, cablage complete ici : oubli d'import #14469
+#   corrige) + TRANCHE7 1 (repeated-prose) = 24 gardes.
 # NB collision #13203 : ce depot en parallele ouvre TRANCHE3 (1 garde) sur
 # les memes fichiers -- le merge des deux ajuste le compteur a 22.
 

--- a/.github/workflows/repeated-prose-advisory.yml
+++ b/.github/workflows/repeated-prose-advisory.yml
@@ -1,0 +1,65 @@
+name: Repeated-prose advisory
+
+# Source d'identite pour la garde absorbee par fast-lane-shadow (registre
+# TRANCHE7, demande user 2026-09-05 « un organe qui repèrera les notebooks
+# qui radotent, sans exploser le temps de CI »). Ce workflow garde seulement
+# workflow_dispatch : cible d'identite pour check_absorbed_check_run_identity
+# (job.name == Guard.name) et re-run manuel sur main.
+#
+# Detecteur : scripts/notebook_tools/detect_repeated_prose.py — texte pur
+# (stdlib), deux signaux INTRA-notebook :
+#   A. bloc verbatim duplique (normalise, >= 120 caracteres, 2+ occurrences)
+#   B. bloc paraphrase (>= 200 caracteres) dont les mots pleins RARES
+#      (df <= 4 dans le notebook) sont contenus a >= 30 % dans une autre
+#      cellule markdown, avec >= 10 mots rares partages.
+# Temoin fondateur epingle en fixture (tests/fixtures/search09c_ponts_pair.
+# json) : les puces « ponts » de la section 5 de Search-09c paraphrasaient la
+# table de la section 7 (fix PR #14794). Le self-test REFUSE de passer si le
+# temoin ne tire pas ou si le post-fix n'est pas muet.
+#
+# Cout CI : 1228 notebooks en 4,5 s en --scan-all (mesure 2026-09-05) ; le
+# garde per-PR ne scanne que les notebooks TOUCHES par la PR.
+#
+# Advisory, jamais bloquant : la dette corpus mesuree est de 999 findings /
+# 1228 notebooks (dominante : miroir intro-plan / conclusion-recap), et un
+# garde bloquant rougirait chaque PR qui touche un notebook porteuse de dette
+# heritee. Le passage eventuel en blocking sera tranche par le coordinateur
+# apres traitement de la dette par serie (precedent : deaccent TRANCHE6,
+# #14325).
+#
+# Wiring : scripts/ci/fast_lane_registry.py :: TRANCHE7.
+# Identite : Guard.name == job.name (cf check_absorbed_check_run_identity.py).
+# Tests : scripts/notebook_tools/tests/test_detect_repeated_prose.py.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repeated-prose-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repeated-prose-advisory:
+    name: "Repeated-prose advisory (per-notebook, non-blocking)"
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Pas de diff a calculer en dispatch : le verdict per-PR est rendu par
+      # la voie rapide (fast-lane-shadow). Ce job sert d'identite et de re-run
+      # manuel self-test + notebook ad-hoc.
+      - name: Detector self-test (positive + negative control)
+        run: python scripts/notebook_tools/detect_repeated_prose.py --self-test

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -220,6 +220,14 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "pr-gate-rerun.yml",
     "regression-guard.yml",
     "render-volume-delta-advisory.yml",
+    # registre TRANCHE7 (demande user 2026-09-05, owner myia-po-2023:CoursIA)
+    #   : vehicule workflow_dispatch-ONLY servant de cible d'identite au
+    #   check-run absorbe par fast-lane (registre TRANCHE7) et de re-run
+    #   manuel self-test sur main. Detecteur de prose repetee
+    #   intra-notebook (detect_repeated_prose.py), advisory pur-Python
+    #   stdlib-only, label signe, jamais exit != 0, aucun secret.
+    #   Rollback = revert de la PR (l'entree disparait de l'allowlist).
+    "repeated-prose-advisory.yml",
     "scripts-tests.yml",
     "series-naming-gate.yml",
     "stale-base-warning.yml",

--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -40,7 +40,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from fast_lane_registry import (  # noqa: E402
-    PILOT, TRANCHE1, TRANCHE2, TRANCHE3, TRANCHE4, TRANCHE5, Guard,
+    PILOT, TRANCHE1, TRANCHE2, TRANCHE3, TRANCHE4, TRANCHE5, TRANCHE6,
+    TRANCHE7, Guard,
 )
 
 SHADOW_PREFIX = "fast-lane (ombre): "
@@ -314,7 +315,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[fast-lane] {len(changed)} fichier(s) modifie(s) "
           f"contre {args.base_ref}")
 
-    guards = [g for g in PILOT + TRANCHE1 + TRANCHE2 + TRANCHE3 + TRANCHE4 + TRANCHE5
+    guards = [g for g in PILOT + TRANCHE1 + TRANCHE2 + TRANCHE3 + TRANCHE4
+              + TRANCHE5 + TRANCHE6 + TRANCHE7
               if not args.only or g.name == args.only]
     selected = [g for g in guards if guard_applies(g, changed)]
     for guard in guards:

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -757,3 +757,58 @@ TRANCHE6: list[Guard] = [
         warn_rc=(1, 2),  # rc=2 = findings (signale sans bloquer) ; rc=1 = vacuous
     ),
 ]
+
+
+# ---------------------------------------------------------------------------
+# TRANCHE 7 -- detecteur de prose repetee intra-notebook (« radotage »).
+# Origine : demande user 2026-09-05 (« est-ce qu'on est en mesure de se doter
+# d'un organe qui repèrera les notebooks qui radotent, sans exploser le temps
+# de CI ? »), incident fondateur = les puces « ponts » de la section 5 de
+# Search-09c paraphrasaient la table « ponts » de la section 7 (fix PR #14794).
+#
+# Forme moteur : iterate_paths per-notebook, MEME CABINE que TRANCHE6 (le
+# detecteur rend rc=2 sur --fail-on-findings, rc=1 sur illisible/vacuue).
+# Le pre-controle --self-test epingle le temoin fondateur en fixture : un
+# detecteur qu'on ne peut pas montrer en train de tirer est indiscernable
+# d'un detecteur debranche (lecon #11685/#12817, cf pre_argv TRANCHE2).
+#
+# Pourquoi advisory, pas bloquant : la dette corpus mesuree au cablage est
+# de 999 findings / 1228 notebooks (sweep 4,5 s), dominée par le miroir
+# intro-plan / conclusion-recap -- du radotage structurel réel mais a
+# trancher par l'humain notebook par notebook. Bloquer rougirait toute PR
+# touchant un notebook porteur de dette heritee. Cout CI negligeable :
+# quelques millisecondes par notebook touche (scan texte pur, jamais un
+# sweep repo-wide dans le slot per-PR).
+#
+# INCIDENT DE CABLAGE corrige dans la meme PR : TRANCHE6 (#14469) avait ete
+# enregistre ici SANS etre importe/agrege par fast_lane.py -- le garde
+# deaccent etait donc muet sur toutes les PRs malgre son `absorbed=True`.
+# Cette tranche ajoute le test de parite registre->moteur
+# (test_every_tranche_in_the_registry_is_run_by_the_engine) qui rend
+# l'oubli impossible pour les tranches futures.
+# ---------------------------------------------------------------------------
+TRANCHE7: list[Guard] = [
+    Guard(
+        name="Repeated-prose advisory (per-notebook, non-blocking)",
+        source="repeated-prose-advisory.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_repeated_prose.py",
+            "scripts/notebook_tools/tests/test_detect_repeated_prose.py",
+            ".github/workflows/repeated-prose-advisory.yml",
+        ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
+        pre_argv=[
+            "python", "scripts/notebook_tools/detect_repeated_prose.py",
+            "--self-test",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/detect_repeated_prose.py",
+            "--json", "--fail-on-findings", "{changed_paths}",
+        ],
+        blocking=False,  # advisory : signale le radotage, ne rougit jamais
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(1, 2),  # rc=2 = findings ; rc=1 = illisible/vacuue
+    ),
+]

--- a/scripts/notebook_tools/detect_repeated_prose.py
+++ b/scripts/notebook_tools/detect_repeated_prose.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Detecteur de prose repetee intra-notebook (« radotage »).
+
+Incident fondateur (demande user 2026-09-05, fix PR #14794) : dans
+Search-09c-CombinatorialDiscrepancy.ipynb, la section 5 portait trois puces
+« ponts vers le reste du parcours » (funnel PyMC, double-Q MGS, anti-fantome
+ICT) qui paraphrasait les trois lignes correspondantes de la table
+« 7. Ponts avec le reste de la serie » -- meme contenu, deux habits, deux
+cellules d'ecart. Aucune surface de garde existente n'a vu le doublon : ce
+n'etait ni un lien casse, ni une erreur d'execution, ni une desaccentuation --
+c'est la MEME IDEE dite deux fois, et l'oeil ne la voit plus a la relecture.
+
+Deux signaux, tous deux INTRA-notebook (jamais cross-fichier) :
+
+  A. Bloc verbatim duplique -- un bloc markdown normalise (espacements
+     reduits) d'au moins 120 caracteres qui apparait 2+ fois dans le
+     notebook. Attrape le copier-coller reflowe.
+
+  B. Bloc paraphrase -- un bloc d'au moins 200 caracteres dont les mots
+     pleins RARES (df <= 4 a travers les cellules markdown du notebook)
+     sont majoritairement contenus dans une AUTRE cellule markdown
+     (containment >= 0.30, au moins 10 mots rares partages). C'est le
+     signal qui attrape le cas fondateur : la paraphrase ne partage aucune
+     sequence de 4 mots, mais partage son vocabulaire discriminant
+     (funnel, pymc, conspiration, fantome, antidote...). Mesure sur le cas
+     fondateur : 26 mots rares partages, containment 0.48 ; temoin negatif
+     (paragraphe distinct de la meme section) : 3 mots, 0.09.
+
+Pourquoi la rarete (df intra-notebook) : les mots de sujet ('discrepance',
+'solution') reviennent partout dans un notebook pedagogique et ne prouvent
+rien ; un mot qui n'apparait que dans DEUX endroits du notebook, dont un
+bloc-suspicieux, est une empreinte de duplication. Le seuil df <= 4 garde
+les vocabulaires de section (3-4 occurrences legitimes) hors du signal.
+
+Portee et cout : scan texte pur (stdlib), O(blocs x cellules) intersections
+d'ensembles de <= ~100 mots -- quelques millisecondes par notebook, quelques
+secondes pour le corpus entier (mesure en corpus dans le body de la PR de
+cablage). Le cablage CI est un garde advisory per-notebook (registre
+TRANCHE7) : il signale sur les notebooks TOUCHES par la PR, jamais un scan
+repo-wide bloquant.
+
+Codes de retour : 0 = clean ; 1 = fichier illisible/introuvable ou scan
+vacuue (aucune cellule markdown) ; 2 = findings (avec --fail-on-findings).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Mots outils FR + EN. Liste FERMEE, volontairement courte : un mot outil
+# oublie ne crée pas de faux positif (il ne compte pas comme rare
+# partage s'il revient partout, donc df > 4 le filtre deja).
+STOPWORDS = frozenset("""
+le la les de des du un une et en dans pour par sur avec ou ou_ au aux ce cette
+ces que qui quoi dont est sont sera etre plus moins ne pas non tout tous toute
+toutes comme meme aussi alors donc si car mais or ni son sa ses leur leurs il
+ils elle elles on nous vous y a c d j l m n s t qu
+the of to and in for with or is are was were be been this that these those it
+its as an on at by from we you they he she not but can will would should may
+might must into over under between each other more most such no only own same
+so than too very
+""".split())
+
+WORD_RE = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿœŒæÆ0-9]{2,}")
+STRIP_RE = re.compile(
+    r"https?://\S+"          # URLs
+    r"|\$[^$]*\$"            # maths inline
+    r"|\$\$[^$]*\$\$"        # maths display
+    r"|`[^`]*`"              # code spans
+)
+
+MIN_VERBATIM_CHARS = 120     # signal A
+MIN_PARAPHRASE_CHARS = 200   # signal B
+MAX_DF = 4                   # rarete intra-notebook
+MIN_SHARED_RARE = 10         # signal B : plancher absolu de mots rares partages
+MIN_CONTAINMENT = 0.30       # signal B : |shared| / |rare(block)|
+
+
+def strip_markup(text: str) -> str:
+    return STRIP_RE.sub(" ", text)
+
+
+def content_words(text: str) -> set[str]:
+    words = WORD_RE.findall(strip_markup(text).lower())
+    return {w for w in words
+            if w not in STOPWORDS and not w.isdigit()}
+
+
+def markdown_cells(nb: dict) -> list[tuple[int, str]]:
+    out = []
+    for i, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") == "markdown":
+            src = cell.get("source", "")
+            if isinstance(src, list):
+                src = "".join(src)
+            out.append((i, src))
+    return out
+
+
+def blocks(text: str) -> list[str]:
+    """Decoupe en blocs sur les lignes vides (paragraphe / liste / table)."""
+    return [b.strip() for b in re.split(r"\n\s*\n", text) if b.strip()]
+
+
+def normalize_verbatim(text: str) -> str:
+    return " ".join(text.split())
+
+
+def detect(nb: dict) -> list[dict]:
+    """Renvoie les findings d'un notebook (liste, vide = clean)."""
+    cells = markdown_cells(nb)
+    findings: list[dict] = []
+
+    # --- Signal A : bloc verbatim duplique --------------------------------
+    seen: dict[str, list[tuple[int, int]]] = {}
+    for ci, text in cells:
+        for bi, block in enumerate(blocks(text)):
+            if len(block) < MIN_VERBATIM_CHARS:
+                continue
+            key = normalize_verbatim(block)
+            seen.setdefault(key, []).append((ci, bi))
+    for key, locs in seen.items():
+        if len(locs) >= 2:
+            findings.append({
+                "type": "verbatim_block",
+                "occurrences": [{"cell": ci, "block": bi} for ci, bi in locs],
+                "excerpt": key[:80],
+                "chars": len(key),
+            })
+
+    # --- Signal B : bloc paraphrase ---------------------------------------
+    cell_words = {ci: content_words(text) for ci, text in cells}
+    df: Counter[str] = Counter()
+    for ws in cell_words.values():
+        df.update(ws)
+
+    for ci, text in cells:
+        for bi, block in enumerate(blocks(text)):
+            if len(block) < MIN_PARAPHRASE_CHARS:
+                continue
+            rare = {w for w in content_words(block) if df[w] <= MAX_DF}
+            if len(rare) < MIN_SHARED_RARE:
+                continue
+            best = None
+            for cj, ws_j in cell_words.items():
+                if cj == ci:
+                    continue
+                shared = rare & ws_j
+                if len(shared) < MIN_SHARED_RARE:
+                    continue
+                containment = len(shared) / len(rare)
+                if containment < MIN_CONTAINMENT:
+                    continue
+                if best is None or containment > best["containment"]:
+                    best = {
+                        "target_cell": cj,
+                        "shared_rare": sorted(shared),
+                        "containment": round(containment, 2),
+                    }
+            if best:
+                findings.append({
+                    "type": "paraphrased_block",
+                    "cell": ci,
+                    "block": bi,
+                    "chars": len(block),
+                    **best,
+                })
+    findings.sort(key=lambda f: (f.get("cell", -1), f["type"]))
+    return findings
+
+
+def load_notebook(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def scan_one(path: Path, as_json: bool) -> tuple[int, str]:
+    try:
+        nb = load_notebook(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return 1, f"illisible : {exc}"
+    if not markdown_cells(nb):
+        return 1, "aucune cellule markdown (scan vacuue)"
+    findings = detect(nb)
+    if as_json:
+        out = json.dumps(
+            {"file": path.as_posix(), "findings": findings,
+             "counts": {"total": len(findings),
+                        "verbatim": sum(1 for f in findings
+                                        if f["type"] == "verbatim_block"),
+                        "paraphrased": sum(1 for f in findings
+                                           if f["type"] == "paraphrased_block")}},
+            ensure_ascii=False, indent=1)
+    else:
+        if not findings:
+            out = f"{path.as_posix()}: clean"
+        else:
+            lines = [f"{path.as_posix()}: {len(findings)} finding(s)"]
+            for f in findings:
+                if f["type"] == "verbatim_block":
+                    lines.append(
+                        f"  [verbatim] x{len(f['occurrences'])} "
+                        + ", ".join(f"cell[{o['cell']}].b{o['block']}"
+                                    for o in f["occurrences"])
+                        + f" ({f['chars']} c) « {f['excerpt'][:60]}… »")
+                else:
+                    lines.append(
+                        f"  [paraphrase] cell[{f['cell']}].b{f['block']} "
+                        f"-> cell[{f['target_cell']}] "
+                        f"containment={f['containment']} "
+                        f"{len(f['shared_rare'])} mots rares : "
+                        f"{' '.join(f['shared_rare'][:8])}")
+            out = "\n".join(lines)
+    print(out)
+    return (2 if findings else 0), out
+
+
+def scan_all(as_json: bool, fail: bool) -> int:
+    t0 = time.perf_counter()
+    results = []
+    for path in sorted(REPO_ROOT.glob("MyIA.AI.Notebooks/**/*.ipynb")):
+        rc, _ = scan_one(path, as_json=False)
+        results.append((path, rc))
+    elapsed = time.perf_counter() - t0
+    flagged = [p for p, rc in results if rc == 2]
+    unreadable = [p for p, rc in results if rc == 1]
+    print(f"\n[scan-all] {len(results)} notebooks en {elapsed:.1f}s "
+          f"({len(flagged)} findings, {len(unreadable)} illisibles/vacuues)")
+    for p in flagged:
+        print(f"  RADOTE : {p.relative_to(REPO_ROOT).as_posix()}")
+    if as_json:
+        print(json.dumps({"scanned": len(results), "seconds": round(elapsed, 1),
+                          "flagged": len(flagged),
+                          "files": [p.relative_to(REPO_ROOT).as_posix()
+                                    for p in flagged]},
+                         ensure_ascii=False, indent=1))
+    return 2 if (fail and flagged) else 0
+
+
+# --- Self-test : le temoin fondateur DOIT tirer, le fix DOIT etre muet ----
+# (lecon #11685 : un detecteur qu'on ne peut pas montrer en train de tirer
+# est indistinguishable d'un detecteur debranche).
+FIXTURE = Path(__file__).parent / "tests" / "fixtures" / "search09c_ponts_pair.json"
+
+
+def _nb_from_cells(cells: list[dict]) -> dict:
+    return {"cells": cells, "metadata": {}, "nbformat": 4,
+            "nbformat_minor": 5}
+
+
+def self_test() -> int:
+    fx = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert fx["provenance"]["founding_pr"] == 14794, "fixture corrompue"
+    failures = []
+
+    # 1. TEMOIN POSITIF — pre-fix Search-09c : signal B DOIT tirer.
+    pre = detect(_nb_from_cells(fx["pre_cells"]))
+    para = [f for f in pre if f["type"] == "paraphrased_block"]
+    if not para:
+        failures.append("NEGATIF CRITIQUE : le temoin fondateur (puces "
+                        "section 5 vs table section 7) NE TIRE PAS -- "
+                        "detecteur debranche ou seuils casses")
+    else:
+        f0 = para[0]
+        if f0["cell"] != 0 or f0["target_cell"] != 1:
+            failures.append(f"temoin tire sur les mauvaises cellules : {f0}")
+        if len(f0["shared_rare"]) < MIN_SHARED_RARE:
+            failures.append(f"temoin sous le plancher : {len(f0['shared_rare'])}")
+
+    # 2. TEMOIN NEGATIF — post-fix (renvoi d'une phrase) : silence attendu.
+    post = detect(_nb_from_cells(fx["post_cells"]))
+    if [f for f in post if f["type"] == "paraphrased_block"]:
+        failures.append("post-fix NON muet : le renvoi d'une phrase vers la "
+                        "section 7 declenche encore le signal")
+
+    # 3. Signal A — bloc verbatim duplique (synthetique).
+    dup = ("Ce paragraphe pedagogique de cent quarante caracteres explique "
+           "en detail pourquoi la recherche a ecart borne echoue sans "
+           "heuristique adaptee, avec des exemples concrets et mesures.")
+    nb_dup = _nb_from_cells([
+        {"cell_type": "markdown", "source": f"# Titre\n\n{dup}\n", "outputs": []},
+        {"cell_type": "markdown", "source": f"## Autre\n\n  {dup}  \n", "outputs": []},
+    ])
+    got_a = [f for f in detect(nb_dup) if f["type"] == "verbatim_block"]
+    if not got_a:
+        failures.append("signal A muet sur un bloc verbatim duplique")
+
+    # 4. Controle negatif — memes mots de sujet, propos distincts.
+    p1 = ("Le funnel de la variance apparait quand des parametres derivent "
+          "ensemble ; la geometrie contrainte restaure l'independance et le "
+          "sampling redevient efficace sur les modeles hierarchiques profonds.")
+    p2 = ("En TP, on observera le funnel sur un modele a huit parametres : "
+          "tracer la variance conditionnelle par niveau, puis comparer les "
+          "chaines avant et apres reparametrisation non centree du predicteur.")
+    nb_ok = _nb_from_cells([
+        {"cell_type": "markdown", "source": f"# A\n\n{p1}", "outputs": []},
+        {"cell_type": "markdown", "source": f"# B\n\n{p2}", "outputs": []},
+    ])
+    if detect(nb_ok):
+        failures.append("faux positif : deux paragraphes distincts partagent "
+                        "un vocabulaire de sujet et declenchent un finding")
+
+    if failures:
+        print("SELF-TEST FAILED")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(f"self-test OK : temoin fondateur tire ({len(para[0]['shared_rare'])} "
+          f"mots rares, containment {para[0]['containment']}), post-fix muet, "
+          f"A/B positifs, negatif silencieux.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("notebooks", nargs="*",
+                        help="notebook(s) .ipynb a scanner")
+    parser.add_argument("--json", action="store_true",
+                        help="sortie machine (JSON) par notebook")
+    parser.add_argument("--fail-on-findings", action="store_true",
+                        help="exit 2 si au moins un finding")
+    parser.add_argument("--scan-all", action="store_true",
+                        help="scanner tout MyIA.AI.Notebooks (sweep + timing)")
+    parser.add_argument("--self-test", action="store_true",
+                        help="controles positif/negatif sur le temoin "
+                             "fondateur (refuse de passer a vide)")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if args.scan_all:
+        return scan_all(args.json, args.fail_on_findings)
+
+    if not args.notebooks:
+        parser.error("fournir un notebook, --scan-all ou --self-test")
+    rc_max = 0
+    for raw in args.notebooks:
+        rc, _ = scan_one(Path(raw), args.json)
+        rc_max = max(rc_max, rc)
+    return rc_max if args.fail_on_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/fixtures/search09c_ponts_pair.json
+++ b/scripts/notebook_tools/tests/fixtures/search09c_ponts_pair.json
@@ -1,0 +1,166 @@
+{
+ "provenance": {
+  "founding_pr": 14794,
+  "pre_fix_commit": "4587dc7d26",
+  "notebook": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-09c-CombinatorialDiscrepancy.ipynb",
+  "user_request_2026_09_05": "les ponts avec d'autres series sont mentionnes deux fois ; doter le repo d'un organe qui repere les notebooks qui radotent",
+  "cells": {
+   "pre": [
+    9,
+    13
+   ],
+   "post": [
+    9,
+    13
+   ]
+  },
+  "note": "PRE = blob pre-fix (duplication live sur main jusqu'au merge de #14794 ; cell[9] porte 3 puces ponts paraphrasant la table de la cell[13]). POST = blob post-fix (renvoi d'une phrase vers la section 7). Le temoin DOIT tirer sur PRE et rester muet sur POST."
+ },
+ "pre_cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f744b07c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004814,
+     "end_time": "2026-08-25T04:31:06.392650+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T04:31:06.387836+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. La ligne de front 2025 : prouvé, conjecturé, et le geste du « découplage »\n",
+    "\n",
+    "| Résultat | Discrépance garantie | Statut | Où le voir dans ce notebook |\n",
+    "|---|---|---|---|\n",
+    "| Borne inférieure (Erdős–Spencer, méthode probabiliste) | $\\ge \\Omega(\\sqrt{k})$ sur certains systèmes | **PROUVÉ** | Section 3 (le hasard mesure le plancher) |\n",
+    "| Beck–Fiala (1981) | $\\le 2k - 1$ | **PROUVÉ** (arrondi flottant) | Section 4 (implémenté et mesuré) |\n",
+    "| Conjecture de Beck–Fiala | $O(\\sqrt{k})$ | **OUVERT** en général | — |\n",
+    "| Banaszczyk (1998) | $O(\\sqrt{k \\log n})$ | **PROUVÉ** (mesure gaussienne de corps convexes) | — |\n",
+    "| Spencer, « six deviations suffice » (1986) | $O(\\sqrt{n})$ pour $m = n$ | **PROUVÉ** (entropie partielle) | Exercice 2 |\n",
+    "| **Bansal–Jiang 2025** ([arXiv:2508.03961](https://arxiv.org/abs/2508.03961)) | $O(\\sqrt{k})$ dès $k \\ge \\log^2 n$ ; $\\tilde O(\\sqrt{k} + \\sqrt{\\log n})$ en dessous | **PROUVÉ** — **résout la conjecture pour $k \\ge \\log^2 n$** | — |\n",
+    "| Komlós (colonnes unitaires) | conjecture $O(1)$ ; Banaszczyk $O(\\sqrt{\\log n})$ ; **2025 : $\\tilde O(\\log^{1/4} n)$** | **OUVERT** à $O(1)$ | Exercice 3 |\n",
+    "\n",
+    "**Ce qu'apporte 2025.** Tout dans Bansal–Jiang est **algorithmique** (polynomial) : une\n",
+    "relaxation **SDP** suivie d'un **arrondi par mouvement brownien discret guidé**. La nouveauté\n",
+    "est le **découplage par indépendance spectrale affine** : des contraintes de spectre ajoutées à\n",
+    "la SDP font que les évolutions de discrépance des différentes lignes **cessent de conspirer** —\n",
+    "la concentration redevient applicable à un processus qui, sans cela, corrèle ses dérives.\n",
+    "C'est le pont vers le reste du parcours :\n",
+    "\n",
+    "- **[PyMC-12 / funnel](../../Probas/)** : le funnel de la variance est exactement une\n",
+    "  *conspiration* de paramètres qui dérive ensemble ; le découplage spectrale est le geste\n",
+    "  antidote — contraindre la géométrie pour que les dérives s'indépendent.\n",
+    "- **[MGS / double-Q](../Part4-Metaheuristics/)** : le double-Q de double exploitation apprend\n",
+    "  deux estimations *découplées* pour que l'optimisme de l'une corrige le biais de l'autre —\n",
+    "  même principe : la structure qui empêche la conspiration des erreurs.\n",
+    "- **[ICT / anti-fantôme](../../IIT/)** : la thèse anti-fantôme d'ICT exige qu'une mesure\n",
+    "  intégrée crédite un système **au-dessus de ce que ses parties découplées expliquent** —\n",
+    "  la discrépance est le versant combinatoire du même critère : ce qui *reste* quand les\n",
+    "  contributions indépendantes sont éliminées.\n",
+    "\n",
+    "La frontière est honnête : en dessous de $k \\ge \\log^2 n$ et pour la conjecture Komlós\n",
+    "$O(1)$, le problème reste ouvert ; l'étage amont (mesure gaussienne, dualité SDP, concentration\n",
+    "matricielle) n'est pas formalisé dans Mathlib — c'est la raison d'être du jumeau formel\n",
+    "[`discrepancy_lean/`](discrepancy_lean/) (livrable B de l'issue #12823)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d00148d2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001518,
+     "end_time": "2026-08-25T04:31:07.175550+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T04:31:07.174032+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Ponts avec le reste de la série\n",
+    "\n",
+    "| Direction | Lien | Relation |\n",
+    "|---|---|---|\n",
+    "| Recherche à écart borné (LDS) | [Search-03c — Limited Discrepancy Search](../Part1-Foundations/Search-03c-LimitedDiscrepancySearch.ipynb) | **Désambiguïsation** : écart à l'heuristique dans un arbre ≠ déséquilibre de sommes ; même intuition de « mesurer l'écart à l’équilibre » |\n",
+    "| Optimisation par contraintes | [Partie 2 — CSP](../Part2-CSP/README.md) | CP-SAT sert d'**oracle exact** ici, de solveur primaire là — le même moteur, deux rôles |\n",
+    "| Métaheuristiques composables | [Partie 4 — MGS](../Part4-Metaheuristics/README.md) | Le **double-Q** découple deux estimations pour empêcher la conspiration des biais — même geste que le découplage spectral de 2025 |\n",
+    "| Programmation probabiliste | [PyMC (funnel)](../../Probas/) | Le funnel de variance est une dérive *correlée* de paramètres ; contraindre la géométrie pour l'indépendance est l'antidote commun |\n",
+    "| Conscience intégrée | [ICT — anti-fantôme](../../IIT/) | Créditer ce qui dépasse les parties découplées : la discrépance est ce qui *reste* quand l'indépendant est éliminé |\n",
+    "| Jumeau formel | [`discrepancy_lean/`](discrepancy_lean/) | Livrable B de #12823 : les conjectures comme `Prop` nommées, la noix $2k-1$ grignotée par boutes |"
+   ]
+  }
+ ],
+ "post_cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f744b07c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004814,
+     "end_time": "2026-08-25T04:31:06.392650+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T04:31:06.387836+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. La ligne de front 2025 : prouvé, conjecturé, et le geste du « découplage »\n",
+    "\n",
+    "| Résultat | Discrépance garantie | Statut | Où le voir dans ce notebook |\n",
+    "|---|---|---|---|\n",
+    "| Borne inférieure (Erdős–Spencer, méthode probabiliste) | $\\ge \\Omega(\\sqrt{k})$ sur certains systèmes | **PROUVÉ** | Section 3 (le hasard mesure le plancher) |\n",
+    "| Beck–Fiala (1981) | $\\le 2k - 1$ | **PROUVÉ** (arrondi flottant) | Section 4 (implémenté et mesuré) |\n",
+    "| Conjecture de Beck–Fiala | $O(\\sqrt{k})$ | **OUVERT** en général | — |\n",
+    "| Banaszczyk (1998) | $O(\\sqrt{k \\log n})$ | **PROUVÉ** (mesure gaussienne de corps convexes) | — |\n",
+    "| Spencer, « six deviations suffice » (1986) | $O(\\sqrt{n})$ pour $m = n$ | **PROUVÉ** (entropie partielle) | Exercice 2 |\n",
+    "| **Bansal–Jiang 2025** ([arXiv:2508.03961](https://arxiv.org/abs/2508.03961)) | $O(\\sqrt{k})$ dès $k \\ge \\log^2 n$ ; $\\tilde O(\\sqrt{k} + \\sqrt{\\log n})$ en dessous | **PROUVÉ** — **résout la conjecture pour $k \\ge \\log^2 n$** | — |\n",
+    "| Komlós (colonnes unitaires) | conjecture $O(1)$ ; Banaszczyk $O(\\sqrt{\\log n})$ ; **2025 : $\\tilde O(\\log^{1/4} n)$** | **OUVERT** à $O(1)$ | Exercice 3 |\n",
+    "\n",
+    "**Ce qu'apporte 2025.** Tout dans Bansal–Jiang est **algorithmique** (polynomial) : une\n",
+    "relaxation **SDP** suivie d'un **arrondi par mouvement brownien discret guidé**. La nouveauté\n",
+    "est le **découplage par indépendance spectrale affine** : des contraintes de spectre ajoutées à\n",
+    "la SDP font que les évolutions de discrépance des différentes lignes **cessent de conspirer** —\n",
+    "la concentration redevient applicable à un processus qui, sans cela, corrèle ses dérives.\n",
+    "Ce geste — contraindre la structure pour que les dérives cessent de conspirer — est le fil\n",
+    "qui relie ce notebook au reste du parcours ; les ponts (funnel PyMC, double-Q des\n",
+    "métaheuristiques, anti-fantôme ICT) sont rassemblés en section 7.\n",
+    "\n",
+    "La frontière est honnête : en dessous de $k \\ge \\log^2 n$ et pour la conjecture Komlós\n",
+    "$O(1)$, le problème reste ouvert ; l'étage amont (mesure gaussienne, dualité SDP, concentration\n",
+    "matricielle) n'est pas formalisé dans Mathlib — c'est la raison d'être du jumeau formel\n",
+    "[`discrepancy_lean/`](discrepancy_lean/) (livrable B de l'issue #12823)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d00148d2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001518,
+     "end_time": "2026-08-25T04:31:07.175550+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T04:31:07.174032+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Ponts avec le reste de la série\n",
+    "\n",
+    "| Direction | Lien | Relation |\n",
+    "|---|---|---|\n",
+    "| Recherche à écart borné (LDS) | [Search-03c — Limited Discrepancy Search](../Part1-Foundations/Search-03c-LimitedDiscrepancySearch.ipynb) | **Désambiguïsation** : écart à l'heuristique dans un arbre ≠ déséquilibre de sommes ; même intuition de « mesurer l'écart à l’équilibre » |\n",
+    "| Optimisation par contraintes | [Partie 2 — CSP](../Part2-CSP/README.md) | CP-SAT sert d'**oracle exact** ici, de solveur primaire là — le même moteur, deux rôles |\n",
+    "| Métaheuristiques composables | [Partie 4 — MGS](../Part4-Metaheuristics/README.md) | Le **double-Q** découple deux estimations pour empêcher la conspiration des biais — même geste que le découplage spectral de 2025 |\n",
+    "| Programmation probabiliste | [PyMC (funnel)](../../Probas/) | Le funnel de variance est une dérive *correlée* de paramètres ; contraindre la géométrie pour l'indépendance est l'antidote commun |\n",
+    "| Conscience intégrée | [ICT — anti-fantôme](../../IIT/) | Créditer ce qui dépasse les parties découplées : la discrépance est ce qui *reste* quand l'indépendant est éliminé |\n",
+    "| Jumeau formel | [`discrepancy_lean/`](discrepancy_lean/) | Livrable B de #12823 : les conjectures comme `Prop` nommées, la noix $2k-1$ grignotée par boutes |"
+   ]
+  }
+ ]
+}

--- a/scripts/notebook_tools/tests/test_detect_repeated_prose.py
+++ b/scripts/notebook_tools/tests/test_detect_repeated_prose.py
@@ -1,0 +1,138 @@
+"""Tests for detect_repeated_prose.py — radotage intra-notebook.
+
+Le contrat epingle : (1) le temoin fondateur Search-09c (puces section 5 vs
+table section 7, pre-fix de la PR #14794) DOIT tirer sur le signal
+paraphrase ; (2) le post-fix (renvoi d'une phrase) DOIT rester muet ; (3) le
+signal verbatim tire sur le copier-colle reflowe ; (4) deux paragraphes
+distincts partageant un vocabulaire de sujet restent muets. Pas de reseau,
+pas de kernel.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from detect_repeated_prose import (MIN_CONTAINMENT, MIN_PARAPHRASE_CHARS,
+                                   MIN_SHARED_RARE, detect)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search09c_ponts_pair.json"
+
+
+def nb(*md_sources):
+    return {"cells": [{"cell_type": "markdown", "source": s, "outputs": []}
+                      for s in md_sources],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def para_types(findings):
+    return {f["type"] for f in findings}
+
+
+def test_founding_fixture_fires_paraphrase():
+    """La paire fondateur epinglee comme fixture (blob pre-fix = branche de
+    la PR #14794, jamais mergee sur main : le replay doit vivre en fixture,
+    pas en cat-file). Le signal B est le seul capable de la voir -- la
+    paraphrase ne partage AUCUNE sequence verbatim."""
+    fx = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert fx["provenance"]["founding_pr"] == 14794
+    got = detect({"cells": fx["pre_cells"]})
+    para = [f for f in got if f["type"] == "paraphrased_block"]
+    assert para, "temoin fondateur muet : detecteur debranche"
+    fwd = [f for f in para if f["cell"] == 0 and f["target_cell"] == 1]
+    assert fwd, f"le finding ne pointe pas cell[9] -> cell[13] : {para}"
+    f0 = fwd[0]
+    assert len(f0["shared_rare"]) >= MIN_SHARED_RARE
+    assert f0["containment"] >= MIN_CONTAINMENT
+    # Le vocabulaire discriminant du cas fondateur est bien dans le temoin.
+    for w in ("funnel", "pymc", "conspiration", "fantôme"):
+        assert w in f0["shared_rare"], f"{w} absent du temoin"
+
+
+def test_postfix_fixture_is_silent():
+    """Le renvoi d'une phrase vers la section 7 (le fix lui-meme) ne doit
+    plus declencher le signal paraphrase : l'organe ENDOSSE le fix."""
+    fx = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    got = detect({"cells": fx["post_cells"]})
+    assert not [f for f in got if f["type"] == "paraphrased_block"]
+
+
+def test_verbatim_block_duplication_fires():
+    dup = ("Ce paragraphe pedagogique de plus de cent vingt caracteres "
+           "explique en detail pourquoi la recherche a ecart borne echoue "
+           "sans heuristique adaptee, avec des exemples concrets mesures.")
+    got = detect(nb(f"# Titre\n\n{dup}\n", f"## Autre section\n\n  {dup}  \n"))
+    verb = [f for f in got if f["type"] == "verbatim_block"]
+    assert len(verb) == 1
+    assert len(verb[0]["occurrences"]) == 2
+    cells = {o["cell"] for o in verb[0]["occurrences"]}
+    assert cells == {0, 1}
+
+
+def test_verbatim_below_threshold_silent():
+    short = "Phrase courte repetee, sous le seuil."
+    assert detect(nb(f"# A\n\n{short}", f"# B\n\n{short}")) == []
+
+
+def test_distinct_topic_paragraphs_silent():
+    """Deux paragraphes qui partagent le vocabulaire de sujet d'un notebook
+    (funnel, variance, parametres -- typiques de l'intro et du TP) mais
+    disent des choses differentes ne doivent PAS tirer."""
+    p1 = ("Le funnel de la variance apparait quand des parametres derivent "
+          "ensemble ; la geometrie contrainte restaure l'independance et le "
+          "sampling redevient efficace sur les modeles hierarchiques "
+          "profonds a nombreux niveaux.")
+    p2 = ("En TP, on observera le funnel sur un modele a huit parametres : "
+          "tracer la variance conditionnelle par niveau, puis comparer les "
+          "chaines avant et apres reparametrisation non centree du "
+          "predicteur hierarchique etudié en cours.")
+    assert detect(nb(f"# A\n\n{p1}", f"# B\n\n{p2}")) == []
+
+
+def test_intro_recap_mirror_fires():
+    """Le miroir intro-plan / conclusion-recap est le premier pattern du
+    corpus (containment 0.9+) : le signal doit le voir -- c'est du radotage
+    structurel, juge par l'humain en advisory."""
+    chapters = ("Tweety-2 basic logics, Tweety-3 advanced, Tweety-4 aspic+, "
+                "Tweety-5 abstract argumentation, Tweety-7a extended "
+                "frameworks, Tweety-8 agent dialogues, Tweety-9 preferences "
+                "et Tweety-10 MLN structurent la serie autour des logiques "
+                "d'argumentation graduees et de leurs semantiques.")
+    intro = ("Dans ce notebook d'introduction nous installerons le socle "
+             "Java et decouvrirons la serie : " + chapters)
+    recap = ("Pour conclure ce notebook d'introduction, retenez le parcours "
+             "de la serie pose ici : " + chapters)
+    got = detect(nb(intro, recap))
+    assert "paraphrased_block" in para_types(got)
+
+
+def test_code_cells_ignored():
+    dup = ("Ce paragraphe de plus de cent vingt caracteres, place dans des "
+           "cellules CODE identiques, ne doit rien declencher : l'organe ne "
+           "regarde que les cellules markdown du notebook pedagogique.")
+    cells = [{"cell_type": "code", "source": f"# {dup}", "outputs": []},
+             {"cell_type": "code", "source": f"# {dup}", "outputs": []}]
+    assert detect({"cells": cells}) == []
+
+
+def test_block_length_floor_respected():
+    """Un bloc sous MIN_PARAPHRASE_CHARS ne peut pas tirer le signal B,
+    meme pleinement contenu dans une autre cellule."""
+    tiny = ("le funnel de pymc et le double-q de mgs avec l'anti fantome ict "
+            "sont les trois ponts")
+    assert len(tiny) < MIN_PARAPHRASE_CHARS
+    big = ("Section ponts : " + tiny + " — detaille chacune des trois "
+           "directions avec leurs liens et leurs relations profondes au "
+           "trace de ce notebook de recherche sur la discrepance.")
+    got = detect(nb(tiny, big))
+    assert not [f for f in got if f["type"] == "paraphrased_block"
+                and f["cell"] == 0]
+
+
+def test_self_test_fixture_provenance_pinned():
+    """La fixture doit citer son origine : sans preuve de provenance, un
+    temoin mute silencieusement devient invérifiable (lecon fixture #14603)."""
+    fx = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    prov = fx["provenance"]
+    assert prov["pre_fix_commit"].startswith("4587dc7d")
+    assert "Search-09c" in prov["notebook"]

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -757,6 +757,34 @@ def test_absorbed_workflows_of_tranche2_no_longer_trigger_on_pull_request():
             f"{guard.name} est absorbe : double execution + zero run sauve")
 
 
+def test_every_tranche_in_the_registry_is_run_by_the_engine():
+    """Incident de cablage #14469 (constate 2026-09-05, corrige avec
+    TRANCHE7) : TRANCHE6 etait definie dans fast_lane_registry.py mais
+    JAMAIS importee ni agregree par fast_lane.py -- le garde deaccent
+    etait enregistre, `absorbed=True`, workflow dispatch-only... et muet
+    sur toutes les PRs. Un organe enregistre mais non branche est
+    indiscernable d'un organe absent (lecon #11685). Ce test epingle la
+    parite registre -> moteur sur les DEUX moities du cablage : l'import
+    (hasattr) ET l'agregat de selection dans main()."""
+    import re as _re
+    import fast_lane_registry as registry
+    engine_src = Path(fast_lane.__file__).read_text(encoding="utf-8")
+    names = sorted(k for k in vars(registry)
+                   if _re.fullmatch(r"TRANCHE\d+", k))
+    assert names, "aucune TRANCHE trouvee : introspection cassee"
+    m = _re.search(r"guards = \[g for g in ([^\]]+)\]", engine_src, _re.S)
+    assert m, "agregat `guards = [g for g in ...]` introuvable dans main()"
+    aggregate = m.group(1)
+    for name in names:
+        assert hasattr(fast_lane, name), (
+            f"{name} est definie dans fast_lane_registry.py mais pas "
+            f"importee par fast_lane.py : garde enregistre et muet "
+            f"(incident #14469)")
+        assert _re.search(rf"\b{name}\b", aggregate), (
+            f"{name} est importee mais absente de l'agregat de main() : "
+            f"ses gardes ne tournent jamais")
+
+
 def test_warn_rc_is_success_everywhere(monkeypatch):
     """Un rc=2 declare en warn_rc doit etre un SUCCES coherant sur les TROIS
     surfaces : conclusion du check-run, titre, et rouge du job -- sinon le


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2027:CoursIA-2 -- prev: MED/notebook-python #14777

## Summary

Répond à la demande user 2026-09-05 : « est-ce qu'on est en mesure de se doter d'un organe qui repèrera les notebooks qui radotent, sans exploser le temps de CI ? » (incident fondateur : les « ponts » de Search-09c mentionnés deux fois, See #14794).

### Le détecteur — `scripts/notebook_tools/detect_repeated_prose.py`

Deux signaux **intra-notebook** (jamais cross-fichier), texte pur stdlib :

| Signal | Attrape | Seuils |
|---|---|---|
| **A. verbatim** | bloc copié-collé (reflowé) | normalisé ≥120 caractères, 2+ occurrences |
| **B. paraphrase** | même idée réécrite (le cas fondateur) | bloc ≥200 chars, mots pleins **rares** (df ≤4 dans le notebook) contenus à ≥30 % dans une autre cellule markdown, ≥10 mots partagés |

Pourquoi la rareté : les mots de sujet (« discrépance », « solution ») reviennent partout et ne prouvent rien ; un mot qui n'existe que dans deux endroits dont un bloc suspect est une empreinte de duplication. **Le cas fondateur ne partage AUCUNE séquence verbatim** — seule l'intersection du vocabulaire discriminant la trahit.

**Témoin fondateur épinglé en fixture** (`tests/fixtures/search09c_ponts_pair.json`, pre-fix + post-fix de #14794) : le `--self-test` **REFUSE de passer** si le témoin ne tire pas (30 mots rares, containment 0.53) ou si le post-fix n'est pas muet. 9 tests pytest.

### La réponse au « sans exploser le temps de CI » — mesuré

- **Sweep corpus entier : 1228 notebooks en 4,5 s** (scan texte pur, O(blocs×cellules) intersections d'ensembles ≤100 mots)
- Le garde per-PR ne scanne que les notebooks **touchés** par la PR (quelques ms/notebook), jamais de sweep repo-wide dans le slot CI
- Câblé via la voie rapide (un checkout déjà payé, check-run dédié), pas de workflow clonant le repo

### Mesures corpus (2026-09-05)

999 findings / 1228 notebooks. Répartition par série : GameTheory 71, ICT 66, QC-Python 50, Lean 45, Search-P1 38… Dominante : **miroir intro-plan / conclusion-recap** (containment 0.9+). Le cas fondateur est bien attrapé live sur main (`Search-09c cell[9].b3 → cell[13]`, 0.52) — et l'organe y voit 2 échos supplémentaires que l'œil n'avait pas signalés (intro cell[0] 0.34, conclusion cell[20] 0.88).

**Pourquoi advisory, pas bloquant** (précédent deaccent #14325) : la dette est corpus-wide ; un garde bloquant rougirait toute PR touchant un notebook porteur de dette héritée. Le passage éventuel en blocking sera tranché par le coordinateur après traitement de la dette par série.

### Réparation au passage : TRANCHE6 était muette (G.1, constaté firsthand)

`fast_lane_registry.py` définit TRANCHE6 (deaccent, #14469, merge 2026-09-04) mais `fast_lane.py` n'importait ni n'agrégeait que TRANCHE1-5 (dernière modif moteur : #13677, 2026-08-30, antérieure au merge). **Le garde deaccent n'a donc jamais tourné sur aucune PR** malgré son `absorbed=True` et son stub dispatch-only — exactement « un détecteur enregistré mais non branché ».

Corrigé ici : import + agrégat `TRANCHE6 + TRANCHE7` dans le moteur, et **test de parité registre→moteur** (`test_every_tranche_in_the_registry_is_run_by_the_engine`) qui vérifie l'import ET l'agrégat de `main()` pour CHAQUE `TRANCHE*` définie — l'oubli devient structurellement impossible pour les tranches futures. Ce test échoue sur main tel quel (preuve qu'il épingle bien l'incident).

## Validation

- `detect_repeated_prose.py --self-test` : OK (témoin tire, post-fix muet, A/B positifs, négatif silencieux)
- `pytest scripts/notebook_tools/tests/test_detect_repeated_prose.py scripts/tests/test_fast_lane.py` : **80 passed**
- `check_self_hosted_runner_policy.py` : OK (143 workflows, 119 self-hosted, allowlist à jour)
- End-to-end moteur : `fast_lane.py --dry-run --only "Repeated-prose advisory (per-notebook, non-blocking)" --base-ref <parent du dernier commit Search-09c>` → phase 1 self-test exit 0, **iter sur 185 notebooks**, check-run advisory `success` (les rc=2 findings agrégés OK via `warn_rc=(1,2)`, comportement épinglé par `test_warn_rc_is_success_everywhere`)
- Format : 9 fichiers, +819/−3, aucun notebook touché

## SOTA verdict

N/A — garde texte pur, pas de sortie d'outil.

Voir #14794 (le fix du notebook fondateur) — les deux PR sont indépendantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
