### PR TITLE
feat(aspire,#10473): le harness GitHub.Copilot.SDK exécuté pour de vrai (notebook 09)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/09-Aspire-Harness-CopilotSdk.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/09-Aspire-Harness-CopilotSdk.ipynb
@@ -1,0 +1,1071 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5a97eefb",
+   "metadata": {},
+   "source": [
+    "# Aspire : le harness Copilot SDK \u2014 CopilotClient, session, SessionEvent en C#\n",
+    "\n",
+    "La s\u00e9rie *The Unexpected AI Stack* a d\u00e9j\u00e0 livr\u00e9 ses couches : orchestration Aspire (01, 02), observabilit\u00e9 Serilog/OTEL (03), transport agent Channels/SSE (04), tests d'int\u00e9gration Testcontainers (05), garde-fous Roslyn (06). Il manquait le maillon de **t\u00eate** : le harness lui-m\u00eame. [`GitHub.Copilot.SDK`](https://www.nuget.org/packages/GitHub.Copilot.SDK) 1.0.13 \u2014 publi\u00e9 par GitHub, le m\u00eame moteur que les Copilot coding agents \u2014 met **l'agent complet** (runtime, session, outils, permissions, cycle de vie \u00e9v\u00e9nementiel) derri\u00e8re une API .NET.\n",
+    "\n",
+    "Source de l'axe : [Part 3 de la s\u00e9rie chrlschn.dev](https://chrlschn.dev/blog/2026/08/the-unexpected-ai-stack-csharp-dotnet-part-3/) (2026-08-14), distill\u00e9e dans la veille #10475. Notre apport propre : le harness ex\u00e9cut\u00e9 **pour de vrai** depuis .NET 10 \u2014 auth r\u00e9elle, catalogue r\u00e9el, tour de conversation r\u00e9el, cycle de vie `SessionEvent` observ\u00e9 \u2014 pas une narration.\n",
+    "\n",
+    "La Part 3 de la source branche ce harness sur Channels + SSE ; ce transport est d\u00e9j\u00e0 couvert par le notebook 04 \u2014 ici on montre la **source** du flux. Voir #10473, #10475."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "903cc6e9",
+   "metadata": {},
+   "source": [
+    "## A1 \u2014 Le package et son runtime embarqu\u00e9\n",
+    "\n",
+    "Le package NuGet p\u00e8se ~58 Mo : il **embarque son runtime** (biblioth\u00e8que native FFI). Aucune CLI externe \u00e0 installer, aucun service \u00e0 d\u00e9marrer \u2014 `CopilotClient.StartAsync()` suffit. Les d\u00e9pendances d\u00e9clar\u00e9es sont l\u00e9g\u00e8res (`Microsoft.Extensions.AI.Abstractions`, `System.Text.Json`) : tout le poids est le runtime agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a46e8b48",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:28:58.269588Z",
+     "iopub.status.busy": "2026-09-05T18:28:58.265061Z",
+     "iopub.status.idle": "2026-09-05T18:28:59.863065Z",
+     "shell.execute_reply": "2026-09-05T18:28:59.860618Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-1150924.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1150924.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "amorcage OK -- projet compagnon : MyIA.AI.Notebooks\\GenAI\\Integrations-DotNet\\Aspire\\CopilotHarness.App\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Cellule d'amorcage : helper d'execution du notebook (chemins RELATIFS uniquement).\n",
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "using System.Text;\n",
+    "\n",
+    "public static class Harness\n",
+    "{\n",
+    "    public static readonly string RepoRoot = FindRepoRoot(Directory.GetCurrentDirectory());\n",
+    "\n",
+    "    static string FindRepoRoot(string dir) =>\n",
+    "        File.Exists(Path.Combine(dir, \"COURSE_CATALOG.generated.json\")) ? dir\n",
+    "        : dir.Length > 3 ? FindRepoRoot(Path.GetDirectoryName(dir)!)\n",
+    "        : throw new InvalidOperationException(\"racine du depot introuvable\");\n",
+    "\n",
+    "    public static string Rel(string path) => Path.GetRelativePath(RepoRoot, path);\n",
+    "\n",
+    "    public static void ShowFile(string relPath, int startLine = 1, int? endLine = null)\n",
+    "    {\n",
+    "        var abs = Path.Combine(RepoRoot, relPath);\n",
+    "        Console.WriteLine($\"--- {relPath} ---\");\n",
+    "        var lines = File.ReadAllLines(abs);\n",
+    "        var end = Math.Min(endLine ?? lines.Length, lines.Length);\n",
+    "        for (var i = startLine - 1; i < end; i++)\n",
+    "            Console.WriteLine($\"{i + 1,4} | {lines[i]}\");\n",
+    "    }\n",
+    "\n",
+    "    public static int Dotnet(string args, string workdir)\n",
+    "    {\n",
+    "        var psi = new ProcessStartInfo(\"dotnet\", args)\n",
+    "        {\n",
+    "            WorkingDirectory = Path.Combine(RepoRoot, workdir),\n",
+    "            RedirectStandardOutput = true,\n",
+    "            RedirectStandardError = true,\n",
+    "            UseShellExecute = false,\n",
+    "        };\n",
+    "        var sb = new StringBuilder();\n",
+    "        var p = Process.Start(psi)!;\n",
+    "        p.OutputDataReceived += (_, e) => { if (e.Data is not null) lock (sb) sb.AppendLine(e.Data); };\n",
+    "        p.ErrorDataReceived += (_, e) => { if (e.Data is not null) lock (sb) sb.AppendLine(e.Data); };\n",
+    "        p.BeginOutputReadLine();\n",
+    "        p.BeginErrorReadLine();\n",
+    "        p.WaitForExit();\n",
+    "        // Projection d'affichage : les resumes de build embarquent le chemin absolu\n",
+    "        // de la DLL -- on retire les lignes qui le portent (meme hygiene que le notebook 05).\n",
+    "        var cleaned = string.Join(Environment.NewLine,\n",
+    "            sb.ToString().Split(Environment.NewLine).Where(l => !l.Contains(RepoRoot)));\n",
+    "        Console.WriteLine(cleaned);\n",
+    "        return p.ExitCode;\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine($\"amorcage OK -- projet compagnon : {Harness.Rel(Path.Combine(Harness.RepoRoot, \"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App\"))}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Voici la feuille de d\u00e9pendances du projet compagnon \u2014 elle tient en un fichier :"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "72f58dda",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:28:59.864467Z",
+     "iopub.status.busy": "2026-09-05T18:28:59.864277Z",
+     "iopub.status.idle": "2026-09-05T18:28:59.899237Z",
+     "shell.execute_reply": "2026-09-05T18:28:59.897350Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/CopilotHarness.App.csproj ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 | <Project Sdk=\"Microsoft.NET.Sdk\">\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   3 |   <PropertyGroup>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   4 |     <OutputType>Exe</OutputType>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   5 |     <TargetFramework>net10.0</TargetFramework>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   6 |     <ImplicitUsings>enable</ImplicitUsings>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   7 |     <Nullable>enable</Nullable>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   8 |   </PropertyGroup>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   9 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 |   <ItemGroup>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  11 |     <PackageReference Include=\"GitHub.Copilot.SDK\" Version=\"1.0.13\" />\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  12 |   </ItemGroup>\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  13 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  14 | </Project>\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Harness.ShowFile(\"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/CopilotHarness.App.csproj\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76d90fe2",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation\n",
+    "\n",
+    "Le `.csproj` ne d\u00e9clare qu'une d\u00e9pendance inhabituelle : `GitHub.Copilot.SDK` 1.0.13. C'est la seule ligne qui change tout \u2014 le runtime agent, ses outils et sa couche de permissions arrivent avec le package. Le reste est un `net10.0` ordinaire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "80f16f0a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:28:59.900822Z",
+     "iopub.status.busy": "2026-09-05T18:28:59.900627Z",
+     "iopub.status.idle": "2026-09-05T18:29:01.712748Z",
+     "shell.execute_reply": "2026-09-05T18:29:01.712529Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Identification des projets \u00e0 restaurer...\r\n",
+      "  Tous les projets sont \u00e0 jour pour la restauration.\r\n",
+      "\r\n",
+      "La g\u00e9n\u00e9ration a r\u00e9ussi.\r\n",
+      "    0 Avertissement(s)\r\n",
+      "    0 Erreur(s)\r\n",
+      "\r\n",
+      "Temps \u00e9coul\u00e9 00:00:01.37\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Compilation du projet compagnon (les cellules suivantes lancent avec --no-build).\n",
+    "Harness.Dotnet(\"build\", \"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ee88732",
+   "metadata": {},
+   "source": [
+    "## A2 \u2014 CopilotClient : d\u00e9marrer le harness, l'auth qui se propage\n",
+    "\n",
+    "`Program.cs` construit un `CopilotClientOptions` (le r\u00e9pertoire de travail d\u00e9limite le terrain d'action de l'agent), d\u00e9marre le client, puis propose quatre modes : `auth`, `models`, `ask`, `events`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6891313c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:01.714378Z",
+     "iopub.status.busy": "2026-09-05T18:29:01.714144Z",
+     "iopub.status.idle": "2026-09-05T18:29:01.769252Z",
+     "shell.execute_reply": "2026-09-05T18:29:01.761956Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/Program.cs ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 | // CopilotHarness.App : le harness GitHub.Copilot.SDK ex\u00e9cute pour de vrai.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 | // Le package embarque son runtime (FFI native) : aucune CLI externe \u00e0 installer.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   3 | // Modes :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   4 | //   auth            -- \u00e9tat d'authentification du harness (aucun appel mod\u00e8le)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   5 | //   models          -- catalogue des mod\u00e8les servis par Copilot (aucun appel mod\u00e8le)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   6 | //   ask \"<prompt>\"  -- un tour complet : session + envoi + attente de la r\u00e9ponse\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   7 | //   events \"<prompt>\" -- m\u00eame tour, mais en consommant le flux SessionEvent au fil de l'eau\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   8 | using System.Text;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   9 | using System.Text.Json;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 | using GitHub.Copilot;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  11 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  12 | var mode = args.Length > 0 ? args[0] : \"auth\";\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  13 | if (mode is \"ask\" or \"events\" && args.Length < 2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  14 | {\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  15 |     Console.WriteLine($\"usage : CopilotHarness.App {mode} \\\"<prompt>\\\"\");\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  16 |     return 1;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  17 | }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  18 | var jsonOpts = new JsonSerializerOptions { WriteIndented = true };\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  19 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  20 | var options = new CopilotClientOptions\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  21 | {\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  22 |     // Le harness est un agent : son r\u00e9pertoire de travail d\u00e9limite son terrain d'action.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  23 |     WorkingDirectory = Environment.CurrentDirectory,\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  24 | };\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  25 | using var client = new CopilotClient(options);\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  26 | await client.StartAsync();\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  27 | \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  28 | switch (mode)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  29 | {\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  30 |     case \"auth\":\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  31 |     {\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  32 |         var auth = await client.GetAuthStatusAsync();\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  33 |         Console.WriteLine(JsonSerializer.Serialize(auth, jsonOpts));\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  34 |         break;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  35 |     }\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  36 |     case \"models\":\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  37 |     {\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  38 |         var models = await client.ListModelsAsync();\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  39 |         Console.WriteLine($\"{\"id\",-24} {\"nom\",-22} vision\");\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  40 |         foreach (var m in models.OrderBy(m => m.Id, StringComparer.Ordinal))\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Harness.ShowFile(\"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/Program.cs\", 1, 40);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Premi\u00e8re ex\u00e9cution r\u00e9elle : l'\u00e9tat d'authentification du harness sur cette machine."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "494e86f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:01.771027Z",
+     "iopub.status.busy": "2026-09-05T18:29:01.770817Z",
+     "iopub.status.idle": "2026-09-05T18:29:04.683409Z",
+     "shell.execute_reply": "2026-09-05T18:29:04.683195Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\r\n",
+      "  \"isAuthenticated\": true,\r\n",
+      "  \"authType\": \"gh-cli\",\r\n",
+      "  \"host\": \"https://github.com\",\r\n",
+      "  \"login\": \"jsboige\",\r\n",
+      "  \"statusMessage\": \"jsboige (via gh)\"\r\n",
+      "}\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Le mode auth : aucun appel modele, juste l'etat du harness sur cette machine.\n",
+    "Harness.Dotnet(\"run --no-build -- auth\", \"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "583bbaa7",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation\n",
+    "\n",
+    "`isAuthenticated: true`, `authType: \"gh-cli\"` : le harness **h\u00e9rite l'authentification de la machine** \u2014 ici la session `gh` locale \u2014 sans qu'aucune cl\u00e9 ne figure dans le code ou dans l'environnement du projet. Le SDK propose aussi la voie BYOK (`LlmInferenceAdapter`, \u00e9change `LlmInferenceExchange`) pour d\u00e9porter l'inf\u00e9rence vers votre propre endpoint ; elle n'est pas exerc\u00e9e ici et reste document\u00e9e par sa signature publique.\n",
+    "\n",
+    "Aucun secret ne transite dans les sorties : l'objet d'auth expose un \u00e9tat, pas un jeton."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53eb5c98",
+   "metadata": {},
+   "source": [
+    "## A3 \u2014 Le catalogue : quinze mod\u00e8les derri\u00e8re une API .NET\n",
+    "\n",
+    "`ListModelsAsync` rend le catalogue servi par Copilot \u2014 capacit\u00e9s (vision, effort de raisonnement), fen\u00eatres de contexte et facturation inclus. C'est la surface qui permet de **choisir** un mod\u00e8le programmatiquement plut\u00f4t que de le figer en configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dbec3418",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:04.684795Z",
+     "iopub.status.busy": "2026-09-05T18:29:04.684586Z",
+     "iopub.status.idle": "2026-09-05T18:29:07.381000Z",
+     "shell.execute_reply": "2026-09-05T18:29:07.380449Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id                       nom                    vision\r\n",
+      "auto                     Auto                   non\r\n",
+      "claude-haiku-4.5         Claude Haiku 4.5       oui\r\n",
+      "claude-sonnet-5          Claude Sonnet 5        oui\r\n",
+      "gpt-5-mini               GPT-5 mini             oui\r\n",
+      "gpt-5.3-codex            GPT-5.3-Codex          oui\r\n",
+      "gpt-5.4                  GPT-5.4                oui\r\n",
+      "gpt-5.4-mini             GPT-5.4 mini           oui\r\n",
+      "gpt-5.6-luna             GPT-5.6 Luna           oui\r\n",
+      "gpt-5.6-terra            GPT-5.6 Terra          oui\r\n",
+      "grok-4.5                 Grok 4.5               oui\r\n",
+      "grok-4.6                 Grok 4.6               oui\r\n",
+      "kimi-k2.7-code           Kimi K2.7 Code         oui\r\n",
+      "kimi-k3                  Kimi K3                oui\r\n",
+      "mai-code-1-flash-picker  MAI-Code-1-Flash       non\r\n",
+      "mai-code-1.1-flash       MAI-Code-1.1-Flash     oui\r\n",
+      "TOTAL 15 modeles\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Harness.Dotnet(\"run --no-build -- models\", \"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "217b44d8",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation\n",
+    "\n",
+    "Quinze mod\u00e8les \u2014 Claude Sonnet 5, Haiku 4.5, la famille GPT-5.x, Grok, Kimi, MAI \u2014 derri\u00e8re une seule API locale. L'entr\u00e9e `auto` est le s\u00e9lecteur par d\u00e9faut : le harness choisit. Pour un notebook p\u00e9dagogique, ce catalogue est aussi l'occasion d'un exercice LINQ (voir Exercice 3)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9b1e996",
+   "metadata": {},
+   "source": [
+    "## A4 \u2014 Un tour complet : session, envoi, r\u00e9ponse\n",
+    "\n",
+    "`CreateSessionAsync` ouvre une conversation d'agent ; `SendAndWaitAsync` envoie un message en texte brut et attend que la session redevienne inactive. Comptez **une requ\u00eate premium Copilot** par ex\u00e9cution des cellules `ask`/`events` de ce notebook \u2014 le prompt est volontairement minuscule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8b07ee86",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:07.383207Z",
+     "iopub.status.busy": "2026-09-05T18:29:07.382956Z",
+     "iopub.status.idle": "2026-09-05T18:29:12.571108Z",
+     "shell.execute_reply": "2026-09-05T18:29:12.570897Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "session c339d194-6798-4fef-b022-ca67cfc4f1d7\r\n",
+      "{\r\n",
+      "  \"data\": {\r\n",
+      "    \"apiCallId\": \"msg_011CekmS83YokuKFAsxzqFDr\",\r\n",
+      "    \"content\": \"Le SDK officiel .NET pour int\\u00E9grer GitHub Copilot dans ses applications.\",\r\n",
+      "    \"interactionId\": \"4787e1cc-5747-4632-ba41-a739c3307857\",\r\n",
+      "    \"messageId\": \"9e27008d-aec5-4c0e-a66f-f026aa342b7a\",\r\n",
+      "    \"model\": \"claude-sonnet-5\",\r\n",
+      "    \"rte\": true,\r\n",
+      "    \"toolRequests\": [],\r\n",
+      "    \"turnId\": \"0\"\r\n",
+      "  },\r\n",
+      "  \"id\": \"6b9bb3a4-f56b-4741-96dd-92eeefd16424\",\r\n",
+      "  \"parentId\": \"1bba9bea-cd39-4abb-bcff-0af8598b638e\",\r\n",
+      "  \"timestamp\": \"2026-09-05T18:29:12.135+00:00\"\r\n",
+      "}\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Harness.Dotnet(\"run --no-build -- ask \\\"En une seule phrase de 12 mots maximum : que represente le package GitHub.Copilot.SDK pour un developpeur .NET ?\\\"\", \"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0bee5d9",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation\n",
+    "\n",
+    "La r\u00e9ponse arrive enrichie : `model` (ici `claude-sonnet-5` \u2014 le s\u00e9lecteur `auto` a tranch\u00e9), `toolRequests` (vide : ce tour n'a d\u00e9clench\u00e9 aucun outil), `apiCallId`/`turnId` pour la tra\u00e7abilit\u00e9. Ce n'est **pas** un client LLM brut : c'est un tour d'agent complet, avec sa politique d'outils et ses identifiants de tour."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3092b1ee",
+   "metadata": {},
+   "source": [
+    "## A5 \u2014 Le cycle de vie observable : les `SessionEvent`\n",
+    "\n",
+    "Le mode `events` joue le m\u00eame tour, puis relit `GetEventsAsync()` \u2014 qui rend la **liste** des \u00e9v\u00e9nements de la session (un instantan\u00e9 `IReadOnlyList<SessionEvent>`, pas un flux `IAsyncEnumerable`). C'est la source que le notebook 04 transportait ensuite par Channels et SSE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "add607b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:12.572761Z",
+     "iopub.status.busy": "2026-09-05T18:29:12.572531Z",
+     "iopub.status.idle": "2026-09-05T18:29:17.779413Z",
+     "shell.execute_reply": "2026-09-05T18:29:17.779220Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "session 2f44ca21-89f0-41c0-9921-26a20675fb35\r\n",
+      "histogramme des SessionEvent du tour :\r\n",
+      "  assistant.message                        1\r\n",
+      "  assistant.turn_end                       1\r\n",
+      "  assistant.turn_start                     1\r\n",
+      "  session.model_change                     1\r\n",
+      "  session.start                            1\r\n",
+      "  session.usage_checkpoint                 1\r\n",
+      "  system.message                           1\r\n",
+      "  user.message                             1\r\n",
+      "texte assemble depuis les deltas (15 car.) :\r\n",
+      "BONJOUR HARNESS\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Harness.Dotnet(\"run --no-build -- events \\\"Reponds exactement : BONJOUR HARNESS\\\"\", \"MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "049e52d0",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation\n",
+    "\n",
+    "L'histogramme raconte le tour dans l'ordre : `session.start` \u2192 `session.model_change` (r\u00e9solution de `auto`) \u2192 `system.message` \u2192 `user.message` \u2192 `assistant.turn_start` \u2192 `assistant.message` \u2192 `assistant.turn_end` \u2192 `session.usage_checkpoint`. Le texte `BONJOUR HARNESS` a \u00e9t\u00e9 r\u00e9-assembl\u00e9 depuis le champ `content` des \u00e9v\u00e9nements d'assistant \u2014 la preuve que le contenu transite bien par le canal \u00e9v\u00e9nementiel, pas seulement par la valeur de retour."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4637a799",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices \u00e9tendent `Program.cs`. \u00c0 chaque fois : modifier le fichier, reconstruire (`dotnet build`), ex\u00e9cuter le mode nouveau \u2014 et **compter** les requ\u00eates premium que votre test consomme."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 1 \u2014 le point de contr\u00f4le d'usage\n\nLe mode `usage` : apr\u00e8s un tour, extraire du `session.usage_checkpoint` le nombre de tokens consomm\u00e9s et l'afficher."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3aeb4d0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:17.780846Z",
+     "iopub.status.busy": "2026-09-05T18:29:17.780660Z",
+     "iopub.status.idle": "2026-09-05T18:29:17.802993Z",
+     "shell.execute_reply": "2026-09-05T18:29:17.802817Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mode usage (voir TODO dans Program.cs)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : le mode \"usage\".\n",
+    "// Objectif : ajouter un mode qui, apres un tour, extrait du session.usage_checkpoint\n",
+    "// le nombre de tokens du tour et l'affiche. Indice : serialiser l'evenement\n",
+    "// checkpoint en JSON et lire ses champs.\n",
+    "// TODO etudiant : implementer le mode puis l'appeler ici.\n",
+    "Console.WriteLine(\"Exercice a completer : mode usage (voir TODO dans Program.cs)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 2 \u2014 la m\u00e9moire de conversation\n\nLe mode `memoire` : deux tours dans la m\u00eame session, dont le second prouve que le premier est retenu."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "81bcc6b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:17.804376Z",
+     "iopub.status.busy": "2026-09-05T18:29:17.804164Z",
+     "iopub.status.idle": "2026-09-05T18:29:17.847545Z",
+     "shell.execute_reply": "2026-09-05T18:29:17.847270Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mode memoire (voir TODO dans Program.cs)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : la memoire de conversation.\n",
+    "// Objectif : dans une MEME session, envoyer \"Retiens le mot XYLOPHONE\" puis\n",
+    "// \"Quel mot te devais-je ?\" et montrer que la seconde reponse cite le mot.\n",
+    "// Indice : SendAndWaitAsync deux fois sur la meme instance de session.\n",
+    "// TODO etudiant : implementer le mode \"memoire\" puis l'appeler ici.\n",
+    "Console.WriteLine(\"Exercice a completer : mode memoire (voir TODO dans Program.cs)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Exercice 3 \u2014 le catalogue tri\u00e9\n\nLe mode `catalogue` : table markdown des mod\u00e8les \u00e0 vision, tri\u00e9s par fen\u00eatre de contexte d\u00e9croissante."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "54f84e29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T18:29:17.848824Z",
+     "iopub.status.busy": "2026-09-05T18:29:17.848607Z",
+     "iopub.status.idle": "2026-09-05T18:29:17.869858Z",
+     "shell.execute_reply": "2026-09-05T18:29:17.869471Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mode catalogue (voir TODO dans Program.cs)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : le catalogue en table triee.\n",
+    "// Objectif : mode \"catalogue\" qui produit une table markdown des modeles\n",
+    "// capables de vision, triee par fenetre de contexte decroissante.\n",
+    "// Indice : ListModelsAsync puis OrderByDescending sur Capabilities.Limits.\n",
+    "// TODO etudiant : implementer le mode puis l'appeler ici.\n",
+    "Console.WriteLine(\"Exercice a completer : mode catalogue (voir TODO dans Program.cs)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "364cc192",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le maillon de t\u00eate de la pile est en place : un harness d'agent **complet, local et scriptable** \u2014 auth h\u00e9rit\u00e9e de la machine, catalogue interrogeable, tours r\u00e9els, cycle de vie observable. La s\u00e9rie du d\u00e9p\u00f4t couvre d\u00e9sormais la cha\u00eene enti\u00e8re de l'article source : runtime encapsul\u00e9 (01-02), t\u00e9l\u00e9m\u00e9trie (03), transport de flux (04), tests \u00e9clat\u00e9s (05), garde-fous statiques (06), et maintenant le harness agent lui-m\u00eame.\n",
+    "\n",
+    "Limites honn\u00eates : l'adaptateur BYOK (`LlmInferenceAdapter`) n'est pas exerc\u00e9 \u2014 il d\u00e9pend d'un endpoint d'inf\u00e9rence d\u00e9di\u00e9 et reste \u00e0 l'\u00e9tat de signature ; les ex\u00e9cutions consomment le quota premium de l'abonnement Copilot de la machine (deux requ\u00eates par passage complet du notebook).\n",
+    "\n",
+    "Voir #10473 (Epic), #10475 (veille)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/CopilotHarness.App.csproj
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/CopilotHarness.App.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.13" />
+  </ItemGroup>
+
+</Project>

--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/CopilotHarness.App/Program.cs
@@ -1,0 +1,89 @@
+// CopilotHarness.App : le harness GitHub.Copilot.SDK exécute pour de vrai.
+// Le package embarque son runtime (FFI native) : aucune CLI externe à installer.
+// Modes :
+//   auth            -- état d'authentification du harness (aucun appel modèle)
+//   models          -- catalogue des modèles servis par Copilot (aucun appel modèle)
+//   ask "<prompt>"  -- un tour complet : session + envoi + attente de la réponse
+//   events "<prompt>" -- même tour, mais en consommant le flux SessionEvent au fil de l'eau
+using System.Text;
+using System.Text.Json;
+using GitHub.Copilot;
+
+var mode = args.Length > 0 ? args[0] : "auth";
+if (mode is "ask" or "events" && args.Length < 2)
+{
+    Console.WriteLine($"usage : CopilotHarness.App {mode} \"<prompt>\"");
+    return 1;
+}
+var jsonOpts = new JsonSerializerOptions { WriteIndented = true };
+
+var options = new CopilotClientOptions
+{
+    // Le harness est un agent : son répertoire de travail délimite son terrain d'action.
+    WorkingDirectory = Environment.CurrentDirectory,
+};
+using var client = new CopilotClient(options);
+await client.StartAsync();
+
+switch (mode)
+{
+    case "auth":
+    {
+        var auth = await client.GetAuthStatusAsync();
+        Console.WriteLine(JsonSerializer.Serialize(auth, jsonOpts));
+        break;
+    }
+    case "models":
+    {
+        var models = await client.ListModelsAsync();
+        Console.WriteLine($"{"id",-24} {"nom",-22} vision");
+        foreach (var m in models.OrderBy(m => m.Id, StringComparer.Ordinal))
+        {
+            var vision = m.Capabilities?.Supports?.Vision is true ? "oui" : "non";
+            Console.WriteLine($"{m.Id,-24} {m.Name,-22} {vision}");
+        }
+        Console.WriteLine($"TOTAL {models.Count} modeles");
+        break;
+    }
+    case "ask":
+    {
+        var session = await client.CreateSessionAsync(new SessionConfig());
+        Console.WriteLine($"session {session.SessionId}");
+        var reply = await session.SendAndWaitAsync(args[1], TimeSpan.FromMinutes(2));
+        Console.WriteLine(JsonSerializer.Serialize(reply, reply.GetType(), jsonOpts));
+        break;
+    }
+    case "events":
+    {
+        var session = await client.CreateSessionAsync(new SessionConfig());
+        Console.WriteLine($"session {session.SessionId}");
+        var reply = await session.SendAndWaitAsync(args[1], TimeSpan.FromMinutes(2));
+        var events = await session.GetEventsAsync();
+        var histogram = new SortedDictionary<string, int>();
+        var streamed = new StringBuilder();
+        foreach (var ev in events)
+        {
+            var typeName = ev.Type?.ToString() ?? "?";
+            histogram[typeName] = histogram.GetValueOrDefault(typeName) + 1;
+            if ((typeName.Contains("AssistantMessageDelta") || typeName.Contains("assistant.message"))
+                && streamed.Length < 400)
+            {
+                var je = JsonSerializer.SerializeToElement(ev, ev.GetType());
+                if (je.TryGetProperty("data", out var d)
+                    && d.TryGetProperty("content", out var c)
+                    && c.ValueKind == JsonValueKind.String)
+                    streamed.Append(c.GetString());
+            }
+        }
+        Console.WriteLine("histogramme des SessionEvent du tour :");
+        foreach (var (typeName, count) in histogram)
+            Console.WriteLine($"  {typeName,-40} {count}");
+        Console.WriteLine($"texte assemble depuis les deltas ({streamed.Length} car.) :");
+        Console.WriteLine(streamed.ToString());
+        break;
+    }
+    default:
+        Console.WriteLine($"mode inconnu : {mode}");
+        return 1;
+}
+return 0;

--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/README.md
@@ -25,6 +25,8 @@ paradigme de test absent du dépôt, démontré réel ».
 | [`IntegrationTests/`](IntegrationTests/) | Projet de tests auto-contenu (TUnit 1.65 + Testcontainers.PostgreSql 4.14 + EF Core 10 sur `net10.0`) : `dotnet test` démarre un vrai Postgres 18, 5/5 tests verts, conteneur auto-purgé |
 | [`06-Aspire-GardeFous-Roslyn.ipynb`](06-Aspire-GardeFous-Roslyn.ipynb) | Notebook #10473 (axe Roslyn) : **analyseurs Roslyn comme garde-fous du code d'agent** — `DiagnosticAnalyzer` AGENTGUARD001 (blocage synchrone `.Result`/`.Wait()` d'une Task), verdict rendu par `dotnet build` lui-même + canal API (Verifier par compilation Roslyn en mémoire), contraste Python (ruff hors compilation), 3 exercices |
 | [`AgentGuard.Analyzers/`](AgentGuard.Analyzers/) · [`AgentGuard.Demo/`](AgentGuard.Demo/) · [`AgentGuard.Verifier/`](AgentGuard.Verifier/) | Projets du notebook 06 : l'analyseur (netstandard2.0, chargé par `OutputItemType="Analyzer"`), le terrain fautif (copie de démo du motif notebook 04 avec `.Result` injecté — 2 avertissements au build), et le vérificateur de verdicts (compilation `CSharpCompilation` + `WithAnalyzers` sur les ref packs du SDK) |
+| [`09-Aspire-Harness-CopilotSdk.ipynb`](09-Aspire-Harness-CopilotSdk.ipynb) | Notebook #10473 (axe Copilot SDK, veille #10475) : **le harness des Copilot coding agents en C#** — `GitHub.Copilot.SDK` 1.0.13 (runtime agent embarqué, aucune CLI externe), `CopilotClient` avec auth héritée de `gh` (aucune clé dans le code), catalogue des 15 modèles servis (`ListModelsAsync`), tour complet `SendAndWaitAsync` (réponse réelle), cycle de vie `SessionEvent` observé (histogramme du tour + contenu ré-assemblé), 3 exercices |
+| [`CopilotHarness.App/`](CopilotHarness.App/) | Projet .NET 10 du notebook 09 : console à quatre modes (`auth`/`models`/`ask`/`events`) pilotant le harness réel — dépendance unique `GitHub.Copilot.SDK` 1.0.13 |
 | [`assets/echantillon-test-fr.wav`](assets/echantillon-test-fr.wav) | Échantillon audio FR de test (synthèse SAPI Windows) envoyé au service orchestré |
 
 ## Prérequis
@@ -36,6 +38,7 @@ paradigme de test absent du dépôt, démontré réel ».
 - Pour le notebook 02 (#10857) : la **pile réelle** joignable — conteneur `comfyui-qwen` démarré (8188) et `VLLM_API_KEY` rendu dans `GenAI/.env` (modèle : [`.env.example`](../../.env.example)) via `scripts/secrets/render_envs.py` depuis `master.env`
 - Pour le notebook 04 (#11516) : **aucun Docker requis** — `StreamingAgent.App` compile avec le SDK .NET 10 seul (`dotnet build`), puis le notebook le lance et l'interroge (port local 5128)
 - Pour le notebook 05 / `IntegrationTests/` (#11516 Grain 2) : Docker suffit — l'image `postgres:18` est tirée au premier `dotnet test` (~30 s), les conteneurs de test s'auto-purgent
+- Pour le notebook 09 / `CopilotHarness.App/` (#10473) : **aucune installation** — le package embarque son runtime ; l'authentification passe par la session `gh` locale (abonnement Copilot requis) ; compter ~2 requêtes premium par passage complet du notebook
 
 ## Démarrage rapide
 


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/lean #14756

## Summary

#10473 (axe de tête de la série, veille #10475) : **le harness `GitHub.Copilot.SDK` exécuté pour de vrai** — le maillon qui manquait aux notebooks 01-08 de la série *The Unexpected AI Stack*. Le package 1.0.13 (publié par GitHub, 1,2 M downloads) embarque le runtime agent complet (FFI native, ~58 Mo, aucune CLI externe) derrière une API .NET : c'est le moteur des Copilot coding agents.

- **`CopilotHarness.App/`** — projet compagnon net10.0, dépendance unique `GitHub.Copilot.SDK` 1.0.13, quatre modes : `auth` (état d'authentification, aucun appel modèle), `models` (catalogue, aucun appel modèle), `ask` (tour complet `CreateSessionAsync` + `SendAndWaitAsync`), `events` (même tour + lecture `GetEventsAsync` : histogramme des types + contenu assistant ré-assemblé).
- **`09-Aspire-Harness-CopilotSdk.ipynb`** — notebook .NET Interactive exécuté : auth réelle héritée de `gh` (`isAuthenticated: true, authType: gh-cli` — aucune clé dans le code), catalogue des **15 modèles** servis (Claude Sonnet 5, GPT-5.x, Grok, Kimi, MAI), réponse réelle d'un tour (`model: claude-sonnet-5`, `toolRequests: []`, `turnId`), cycle de vie `SessionEvent` du tour observé (`session.start → model_change → user.message → turn_start → assistant.message → turn_end → usage_checkpoint`) avec le texte « BONJOUR HARNESS » ré-assemblé depuis les événements. 3 exercices C.1 (stub sans erreur volontaire).
- **README de série** — ligne tableau 09 + projet + prérequis (aucune installation ; abonnement Copilot via session gh ; ~2 requêtes premium par passage).

Positionnement : la source (Part 3 chrlschn.dev, 2026-08-14) branche ce harness sur Channels+SSE — déjà couverts par le notebook 04 ; ce grain livre la **source** du flux, la partie jamais livrée. L'adaptateur BYOK (`LlmInferenceAdapter`/`LlmInferenceExchange`) est documenté par sa signature publique mais **non exercé** — il exige un endpoint d'inférence dédié ; la voie auth gh a été démontrée réelle, c'est celle du verdict.

## Validation

- **Exécution réelle** : notebook exécuté via kernel `.net-csharp` (jupyter nbconvert) — 11/11 cellules code `execution_count != null`, **0 erreur**, sorties réelles commitées (C.2). Spikes préalables du harness en console : `ask` → réponse réelle, `events` → histogramme 8 types + contenu assemblé.
- **SOTA-OK** : le vrai harness, les vrais modèles servis, les vraies réponses — pas de substitution. Compteur de dépense : 4 requêtes premium au total pendant le développement + 2 par re-exécution complète du notebook (prompts minuscules, par design).
- **Hygiène sorties** : `strip_probe_banner.py --apply` (9 bandeaux probeAddresses retirés), 0 chemin machine (lignes portant le RepoRoot filtrées, même hygiène que le notebook 05), ratchet `check_output_failure_text.py origin/main` rc=0.
- **Conformité** : C.1 (stubs `Console.WriteLine` + `// TODO etudiant`, aucune erreur volontaire), max run de cellules code consécutives = 1, interprétations placées après chaque cellule mesurée. Catalogue non touché (l'entrée 09 sera créée par le cron/CI).
- **Périmètre** : 4 fichiers — notebook, csproj, Program.cs, README de série. Insertions pures (+1177), aucun autre fichier touché.

See #10473 · See #10475
