### PR TITLE
fix(notebook-tools,#14356): troisieme axe de la garde de vraisemblance -- volume par type MIME

### DIFF
--- a/scripts/notebook_tools/batch_reexecute.py
+++ b/scripts/notebook_tools/batch_reexecute.py
@@ -108,6 +108,20 @@ def read_kernelspec_name(nb_path: Path) -> str:
     return spec.get("name") or "python3"
 
 
+def _payload_chars(value) -> int:
+    """Character volume of one MIME payload as nbformat stores it.
+
+    Rich outputs carry either a single string (``image/png`` base64) or a list
+    of lines (``text/html``); both conventions occur, sometimes mixed across
+    keys of the same ``data`` dict.
+    """
+    if isinstance(value, str):
+        return len(value)
+    if isinstance(value, list):
+        return sum(len(s) for s in value if isinstance(s, str))
+    return 0
+
+
 def _output_census(nb_path: Path) -> dict:
     """Count the outputs and embedded images a notebook currently carries.
 
@@ -120,21 +134,42 @@ def _output_census(nb_path: Path) -> dict:
     does not need to know *why* the run degraded, which is what makes it worth
     having over a detector tied to one mechanism.
 
+    The census also totals the character volume per MIME type (``mime_chars``):
+    counting alone is blind to a payload replaced by a stub -- a missing
+    ``dot`` turns six factor graphs into six ``<strong>Graphviz non
+    disponible.</strong>`` lines, which reads as output count *rising* (#14356
+    gap, measured 2026-09-03: ``text/html`` 194 409 -> 6 856 chars).
+
     An unreadable notebook yields ``readable: False`` so the comparison
     abstains rather than accuses.
     """
+    empty = {"readable": False, "outputs": 0, "images": 0, "mime_chars": {}}
     try:
         data = json.loads(nb_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return {"readable": False, "outputs": 0, "images": 0}
+        return empty
     outputs = 0
     images = 0
+    mime_chars: dict = {}
     for cell in data.get("cells", []):
         for out in cell.get("outputs") or []:
             outputs += 1
-            if "image/png" in (out.get("data") or {}):
-                images += 1
-    return {"readable": True, "outputs": outputs, "images": images}
+            for mime, value in (out.get("data") or {}).items():
+                if mime == "image/png":
+                    images += 1
+                mime_chars[mime] = mime_chars.get(mime, 0) + _payload_chars(value)
+    return {"readable": True, "outputs": outputs, "images": images,
+            "mime_chars": mime_chars}
+
+
+# A payload below this baseline is too small to distinguish a stub from
+# legitimate variation (a shorter table, a terser repr) -- flagging it would
+# be noise. The measured stub collapse starts from six-figure baselines.
+_MIME_VOLUME_FLOOR = 2000
+
+# A division shallower than this is normal re-render variation; the measured
+# stub case divides by 28, far past any reasonable threshold.
+_MIME_VOLUME_FACTOR = 10
 
 
 def _degradation(before: dict, after: dict) -> str:
@@ -145,6 +180,12 @@ def _degradation(before: dict, after: dict) -> str:
     carried no images to begin with gives no baseline -- the guard stays silent
     there instead of inventing one, which is why it catches regressions and not
     absences.
+
+    The same abstention applies to MIME volume: only a dramatic collapse of an
+    established payload (at least ``_MIME_VOLUME_FLOOR`` chars divided by more
+    than ``_MIME_VOLUME_FACTOR``) is named. A stub replacing rich ``text/html``
+    collapses volume while *raising* the output count, so the volume axis sees
+    what the count axis cannot.
     """
     if not (before["readable"] and after["readable"]):
         return ""
@@ -152,6 +193,12 @@ def _degradation(before: dict, after: dict) -> str:
         return "images %d -> 0" % before["images"]
     if before["outputs"] > 0 and after["outputs"] * 2 < before["outputs"]:
         return "outputs %d -> %d" % (before["outputs"], after["outputs"])
+    before_mimes = before.get("mime_chars") or {}
+    after_mimes = after.get("mime_chars") or {}
+    for mime in sorted(before_mimes):
+        b, a = before_mimes[mime], after_mimes.get(mime, 0)
+        if b >= _MIME_VOLUME_FLOOR and a * _MIME_VOLUME_FACTOR < b:
+            return "%s %d -> %d" % (mime, b, a)
     return ""
 
 

--- a/tests/test_batch_reexecute.py
+++ b/tests/test_batch_reexecute.py
@@ -3,16 +3,22 @@
 test_batch_reexecute.py — garde de vraisemblance et cwd explicite (#14356).
 
 Couvre :
-  - _output_census : recensement outputs / image/png, abstention si illisible
+  - _output_census : recensement outputs / image/png / volume par type MIME,
+    abstention si illisible
   - _degradation : ne signale qu'une CHUTE, et seulement avec une reference
+    (comptes images/outputs, volume MIME -- l'axe qui voit les talons que le
+    comptage glorifie en hausse)
   - execute_notebook : un papermill sortant 0 en ayant perdu les images rend
-    DEGRADED et restaure la sauvegarde
+    DEGRADED et restaure la sauvegarde ; idem quand un talon HTML remplace la
+    charge utile alors que le compte d'outputs MONTE
   - execute_notebook : --cwd transmis a papermill, valeur selon cwd_mode
 
-Le troisieme test est la reproduction du defaut mesure le 2026-09-02 sur
-``01-5-Qwen-Image-Edit.ipynb`` : 9 s, 0 image, ``SUCCESS`` affiche, tous les
-gardes CI verts. C'est le seul cas ou le code de sortie ment sans qu'aucun
-autre signal ne bronche.
+Les reproductions sont les deux defauts mesures : 2026-09-02 sur
+``01-5-Qwen-Image-Edit.ipynb`` (9 s, 0 image, ``SUCCESS`` affiche) et
+2026-09-03 sur ``Infer-7-Skills-IRT.ipynb`` (``dot`` absent : six graphes de
+facteurs remplaces par des talons ``Graphviz non disponible``, outputs en
+HAUSSE, ``text/html`` 194 409 -> 6 856). Ce sont les deux seuls cas ou le
+code de sortie ment sans qu'aucun autre signal ne bronche.
 
 Usage :
     pytest tests/test_batch_reexecute.py -v
@@ -33,12 +39,21 @@ import batch_reexecute  # noqa: E402
 from batch_reexecute import _degradation, _output_census  # noqa: E402
 
 
-def _nb(n_images: int = 0, n_text: int = 0) -> dict:
-    """Minimal notebook carrying the requested output census."""
+def _nb(n_images: int = 0, n_text: int = 0, html_chars: int = 0,
+        n_html: int = 1) -> dict:
+    """Minimal notebook carrying the requested output census.
+
+    ``html_chars`` spreads ``n_html`` ``text/html`` payloads of that many
+    characters each (list-of-lines form, as nbformat stores it), so volume
+    collapses can be reproduced without six-figure literals in the source.
+    """
     outputs = [{"output_type": "display_data", "data": {"image/png": "iVBORw0KGgo="}}
                for _ in range(n_images)]
     outputs += [{"output_type": "stream", "name": "stdout", "text": ["ok\n"]}
                 for _ in range(n_text)]
+    for _ in range(n_html if html_chars > 0 else 0):
+        outputs.append({"output_type": "display_data",
+                        "data": {"text/html": ["g" * html_chars]}})
     return {
         "cells": [{"cell_type": "code", "source": ["pass"],
                    "execution_count": 1, "outputs": outputs, "metadata": {}}],
@@ -56,7 +71,19 @@ def _write(path: Path, nb: dict) -> Path:
 
 def test_census_counts_images_and_outputs(tmp_path: Path) -> None:
     nb = _write(tmp_path / "a.ipynb", _nb(n_images=2, n_text=3))
-    assert _output_census(nb) == {"readable": True, "outputs": 5, "images": 2}
+    assert _output_census(nb) == {
+        "readable": True, "outputs": 5, "images": 2,
+        "mime_chars": {"image/png": 2 * len("iVBORw0KGgo=")},
+    }
+
+
+def test_census_totals_mime_volume_across_outputs(tmp_path: Path) -> None:
+    """The volume axis: three ``text/html`` payloads sum into one per-MIME
+    total, whatever their number of lines."""
+    nb = _write(tmp_path / "a2.ipynb", _nb(n_text=1, html_chars=3000, n_html=3))
+    census = _output_census(nb)
+    assert census["outputs"] == 4
+    assert census["mime_chars"]["text/html"] == 3 * 3000
 
 
 def test_census_handles_null_outputs(tmp_path: Path) -> None:
@@ -116,6 +143,49 @@ def test_degradation_abstains_when_either_side_unreadable() -> None:
     assert _degradation(populated, unreadable) == ""
 
 
+# --- _degradation, axe volume MIME (#14356, gap mesure sur Infer-7) ---
+
+def test_degradation_flags_mime_volume_collapse_despite_output_rise() -> None:
+    """The measured Graphviz incident: six factor graphs replaced by as many
+    ``<strong>Graphviz non disponible.</strong>`` stubs -- the output count
+    RISES (290 -> 314), the image count never moved, only the ``text/html``
+    volume (194 409 -> 6 856) tells the story."""
+    before = {"readable": True, "outputs": 290, "images": 0,
+              "mime_chars": {"text/html": 194409}}
+    after = {"readable": True, "outputs": 314, "images": 0,
+             "mime_chars": {"text/html": 6856}}
+    assert _degradation(before, after) == "text/html 194409 -> 6856"
+
+
+def test_degradation_silent_on_minor_mime_shrink() -> None:
+    """A re-render 10 % shorter (a shorter table, a terser repr) is variation,
+    not a stub."""
+    before = {"readable": True, "outputs": 5, "images": 0,
+              "mime_chars": {"text/html": 100000}}
+    after = {"readable": True, "outputs": 5, "images": 0,
+             "mime_chars": {"text/html": 90000}}
+    assert _degradation(before, after) == ""
+
+
+def test_degradation_mime_silent_below_volume_floor() -> None:
+    """Small payloads vary legitimately; without a floor a 1.5k -> 100 stub
+    would cry wolf on every terse notebook."""
+    before = {"readable": True, "outputs": 5, "images": 0,
+              "mime_chars": {"text/html": 1500}}
+    after = {"readable": True, "outputs": 5, "images": 0,
+             "mime_chars": {"text/html": 100}}
+    assert _degradation(before, after) == ""
+
+
+def test_degradation_handles_censuses_without_mime_axis() -> None:
+    """Censuses shaped before the volume axis (and handcrafted ones) must keep
+    working: absence of the key is absence of a reference, not a collapse."""
+    before = {"readable": True, "outputs": 4, "images": 0}
+    after = {"readable": True, "outputs": 4, "images": 0,
+             "mime_chars": {"text/html": 7000}}
+    assert _degradation(before, after) == ""
+
+
 # --- execute_notebook ---
 
 @pytest.fixture
@@ -149,6 +219,22 @@ def test_zero_exit_with_lost_images_is_degraded(tmp_path: Path, fake_papermill) 
     assert "images 2 -> 0" in result["error"]
     # The backup is restored: a green-looking empty notebook is worse than none.
     assert _output_census(nb)["images"] == 2
+    assert not nb.with_suffix(".ipynb.bak").exists()
+
+
+def test_zero_exit_with_stubbed_html_is_degraded(tmp_path: Path, fake_papermill) -> None:
+    """The 2026-09-03 reproduction: papermill exits 0, the output count RISES
+    (a stub is one more output, not one fewer), images never existed -- only
+    the per-MIME volume names the collapse. The backup must be restored."""
+    nb = _write(tmp_path / "d2.ipynb", _nb(n_text=2, html_chars=65000, n_html=3))
+    # 3 riches payloads deviennent 6 talons : outputs 5 -> 8, volume /28.
+    fake_papermill(_nb(n_text=2, html_chars=65000 // 28, n_html=6))
+
+    result = batch_reexecute.execute_notebook(nb, "python3", 60)
+
+    assert result["status"] == "DEGRADED"
+    assert "text/html" in result["error"]
+    assert _output_census(nb)["mime_chars"]["text/html"] == 3 * 65000
     assert not nb.with_suffix(".ipynb.bak").exists()
 
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/lean #14787

See #14356 (troisième axe de la garde de vraisemblance, versé en attente par le commentaire de clôture de #14394).

## Résumé

La garde de vraisemblance de `batch_reexecute.py` (#14361) ne mesurait que des **comptes** (`outputs`, `image/png`). Le cas mesuré sur `Infer-7-Skills-IRT.ipynb` la traversait silencieusement : `dot` absent → six graphes de facteurs remplacés par six talons `<strong>Graphviz non disponible.</strong>` — le compte d'outputs **monte** (290 → 314, un talon est une sortie de plus, pas de moins), `image/png` reste à 0, et seule la **charge utile** s'effondre (`text/html` 194 409 → 6 856 caractères, division par 28).

Cette PR ajoute l'axe manquant nommé par le commentaire fondateur : **le volume total de charge utile par type MIME**.

- **`_payload_chars`** : volume en caractères d'un payload tel que nbformat le stocke (les deux formes coexistent — `str` pour `image/png` base64, liste de lignes pour `text/html`).
- **`_output_census`** totalise désormais `mime_chars: {mime: total}` en plus des comptes. `image/png` devient un cas particulier de l'axe général (son **compte** reste mesuré, l'effondrement d'un **volume** est une information différente).
- **`_degradation`** nomme l'effondrement d'un volume établi : **chute seule, référence requise** — mêmes formes d'abstention que les deux axes existants, pour ne pas crier au loup sur les variations légitimes de re-rendu :
  - *floor* 2 000 caractères : un payload trop petit ne distingue pas un talon d'une variation (1 500 → 100 = silence, mesuré par test) ;
  - *facteur* 10 : un re-rendu 10 % plus court (table plus concise) est du bruit (100 000 → 90 000 = silence, mesuré par test) ; la reproduction réelle divise par 28.
- **`execute_notebook` inchangé** : le chemin DEGRADED (backup restauré) et `--allow-degraded` consomment `_degradation` de façon générique — l'axe s'active sans autre câblage.

## Validation

- `pytest tests/test_batch_reexecute.py` : **20/20 verts** (12 préexistants adaptés ou intacts + 8 nouveaux).
- `pytest scripts/notebook_tools/tests/test_batch_reexecute.py` : 29/29 verts (fichier sibling, non touché — preuve de non-régression des imports).
- Reproductions en fixture, les deux défauts mesurés :
  - `test_zero_exit_with_lost_images_is_degraded` (Qwen-Image-Edit 2026-09-02 : images 2 → 0) — préexistant, intouché ;
  - `test_zero_exit_with_stubbed_html_is_degraded` (Infer-7 2026-09-03 : 3 payloads de 65 000 chars → 6 talons, outputs **en hausse**, `text/html` 195 000 → 13 926) — nouveau : DEGRADED + backup restauré.
- Abstentions testées : hausse nominale, shrink mineur, sous-floor, census sans axe MIME (rétrocompatible avec les censuses façonnés à la main).

## Périmètre

2 fichiers modifiés : `scripts/notebook_tools/batch_reexecute.py` (+111/−12), `tests/test_batch_reexecute.py` (+69/−4 approximatif au commit). Aucun notebook touché, catalogue byte-identique à main.
