### PR TITLE
docs(genai,#14549): c.272 ComfyUI parity measurement — exact parity blocked by ComfyUI-GGUF NaN (#14808)

### DIFF
--- a/docs/ledgers/14549-tensorsharp-multimodal.md
+++ b/docs/ledgers/14549-tensorsharp-multimodal.md
@@ -340,3 +340,41 @@ d'appareils sur un livrable sain des deux côtés.
 - HF Lightning LoRA : https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning
 - Topic parent c.257 : [[topic-c257-investigation-14549-tensorsharp-multimodal]]
 - Topic parent c.258 : [[topic-c258-forge-run-INTRINSIC-14593-14617]]
+
+## c.272 — Parité ComfyUI même-machine/même-prompt (dernière jambe du critère 4) : mesure livrée, parité exacte BLOQUÉE par un défaut de stack (NaN ComfyUI-GGUF)
+
+**Setup** : conteneur `comfyui-qwen` (ComfyUI 0.25.0, port 8188, auth Bearer), GPU runtime-rapporté par le serveur = `cuda:0 NVIDIA GeForce RTX 3090` 24,0 GB (22,8 libres). Docker `DeviceIDs:["0"]`. Pic VRAM mesuré côté hôte pendant les runs : **20 755 MiB sur la 3090** (index 1 nvidia-smi), 3080 Ti 0 MiB — la comparaison avec le pic TensorSharp A2 (22 169 MiB, même 3090) est donc same-machine ET same-GPU. Entrée `test_input.png` (768×512) et prompt "Add a small red heart in the upper-right corner" STRICTEMENT identiques aux probes TensorSharp c.266/c.270 ; latents 1248×832 (= résolution de sortie des probes TensorSharp).
+
+### Constat principal : le DiT GGUF 2511 produit NaN via ComfyUI-GGUF, dans TOUTES les configurations
+
+8 runs via `UnetLoaderGGUF(qwen-image-edit-2511-Q4_K_M.gguf)` — balayage LoRA ON/OFF, steps 4/8/20, cfg 1.0/2.5, shift 2.5/3.1, conditionnement image avec/sans (EditPlus+VAE+ref_latents vs text-only) :
+
+| Run | Config | Wall (client) | Sortie |
+|---|---|---|---|
+| r1 | LoRA Lightning, 4 steps, cfg 1, shift 3.1 (froid) | 288,5 s (server 285,72 s) | NaN uniforme (std=0) |
+| r2 | idem (chaud) | 28,3 s (server 28,00 s) | NaN uniforme |
+| r3 | idem (chaud) | 30,1 s (server 29,38 s) | NaN uniforme |
+| A | sans LoRA, 4 steps, cfg 1 | 45,2 s | NaN uniforme |
+| B | LoRA, 4 steps, shift 2,5 | 84,2 s | NaN uniforme |
+| C | LoRA, 8 steps, shift 3.1 | 56,2 s | NaN uniforme |
+| D | sans LoRA, 20 steps, cfg 2.5 (recette officielle base) | 248,4 s | NaN uniforme |
+| E | text-only (sans image ni VAE au encode) | 125,8 s | noir pur (mean [0,0,0], std=0) |
+
+Chaque run porte `RuntimeWarning: invalid value encountered in cast` (`nodes.py:1653`, SaveImage) = latents NaN décodés en image unie. Le défaut est indépendant de la LoRA, du cfg, du shift, du nombre de steps ET du chemin ref_latents (E l élimine).
+
+### Isolement — ce qui n est PAS en cause
+
+- **Pipeline sain prouvé par contraste** : `qwen_image_edit_2509_fp8_e4m3fn.safetensors` (UNETLoader natif) + MÊME text encoder fp8 (`qwen_2.5_vl_7b_fp8_scaled`) + MÊME VAE + MÊME KSampler → **édition réelle** (cœur rouge ajouté : 2 391-2 523 px rouges, scène préservée diff 3,1/255, std 44,6-44,7 ; position imprécise UR 0-19 % — modèle 2509, hors objet de la mesure). F2 chaud 20 steps cfg 2.5 = **314,77 s server**. Text encoder, VAE, sampler, SaveImage : exonorés.
+- **Le fichier GGUF n est pas corrompu** : le même `qwen-image-edit-2511-Q4_K_M.gguf` + même LoRA Lightning fonctionnent sous TensorSharp.Cli (éditions réelles, hashes reproductibles — §c.266/c.270). Le défaut vit dans le chemin ComfyUI-GGUF de ce build pour ce fichier. **Issue de suivi #14808** (acceptance : cause + fix + re-run probe + parité livrée).
+- **Incident ops** : `svdq-int4_r128-qwen-image-edit-lightningv1.0-4steps.safetensors` (format nunchaku) chargé via `UNETLoader` nu → **crash du serveur** (model_type détecté FLUX), conteneur auto-restarté 2026-09-05T19:35:26Z (exit 0, pas OOM). Ce modèle exige `NunchakuQwenImageDiTLoader`.
+
+### Verdict parité (clôture de la question §7)
+
+1. La ligne comparative §5 "ComfyUI ~25-30 s (à reconfirmer)" est **confirmée numériquement mais invalidée sémantiquement** : 28,0-29,4 s chaud (4 steps) caractérisent un chemin **à sortie dégénérée** — ce n est pas une latence d édition valide, et l écart "40,44 s constructeur vs 25-30 s" ne soutenait aucune conclusion.
+2. **Parité exacte (même GGUF + même LoRA des deux côtés) : BLOQUÉE** par #14808 — non mesurable en l état sur le côté ComfyUI.
+3. **Datapoint de remplacement** (modèle DIFFÉRENT : 2509 fp8 natif, recette 20 steps cfg 2.5) : 314,77 s server chaud vs TensorSharp 2511 Q4_K_M Lightning 4-step ≈ 81 s wall par invocation (rechargement inclus, denoise 38,8-46,7 s). Ce n est PAS une parité (version, quant, recette différentes) — un encadrement qui établit que l avantage de latence TensorSharp sur cette stack ne tient ni au hasard ni à une mesure constructeur optimiste.
+4. VRAM comparable : pic 20 755 MiB (ComfyUI) vs 22 169 MiB (TensorSharp A2), même 3090.
+
+**Effet acceptance #14549 critère 4** : la jambe ComfyUI passe de "non mesuré" à "mesuré + bloqué par défaut de stack documenté" (#14808). La clôture définitive du critère attend le fix #14808 (parité même-modèle) — geste séparé, lane genai-stack.
+
+**Méthodo** : scripts scratchpad (workflow ComfyUI API-format, matrix NaN, discriminants E/F) ; artefacts `c272_*.png` conservés dans `C:/Users/jsboi/tensorsharp-investigation/` (hors repo) ; pics VRAM échantillonnés 3 s côté hôte pendant les runs ; timings server extraits de `/history` (execution_start→execution_success) et conciliés avec le wall client (écart < 1 s).


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #14759

## Summary

Dernière jambe du critère 4 de #14549 : mesure ComfyUI **même-machine/même-prompt** (entrée `test_input.png` 768×512 + prompt "Add a small red heart in the upper-right corner" strictement identiques aux probes TensorSharp c.266/c.270 ; latents 1248×832 ; GPU runtime-rapporté = RTX 3090 dans le conteneur, pic VRAM hôte 20 755 MiB sur la 3090 vs 22 169 MiB pour TensorSharp A2).

Ledger `docs/ledgers/14549-tensorsharp-multimodal.md` §c.272 (+38 lignes, append-only) :

1. **Constat principal** : le DiT `qwen-image-edit-2511-Q4_K_M.gguf` via `UnetLoaderGGUF` produit des **latents NaN → sortie uniforme** dans les **8 configurations** balayées (LoRA ON/OFF × steps 4/8/20 × cfg 1.0/2.5 × shift 2.5/3.1 × conditionnement image avec/sans). `RuntimeWarning: invalid value encountered in cast` à chaque SaveImage. Timings mesurés au passage : froid 285,7 s ; chaud 4-step 28,0-29,4 s ; 20-step 248,4 s.
2. **Isolement** : pipeline prouvé sain par contraste — DiT natif fp8 2509 + même text encoder + même VAE + même sampler → **édition réelle** (2 391-2 523 px rouges, scène préservée diff 3,1/255), 20 steps cfg 2.5 chaud = 314,77 s server. Le même fichier GGUF fonctionne sous TensorSharp (§c.266/c.270) → le défaut vit dans le chemin ComfyUI-GGUF de ce build. **Issue de suivi #14808** (cause + fix + re-run + parité même-modèle).
3. **Verdict §7** : le "~25-30 s (à reconfirmer)" est confirmé numériquement mais invalidé sémantiquement (il caractérise un chemin à sortie dégénérée) ; la parité exacte même-GGUF est **bloquée** par #14808 ; datapoint de remplacement (2509 fp8 natif, recette différente — pas une parité) : 314,77 s vs TensorSharp ~81 s wall/invocation (denoise 38,8-46,7 s).
4. Incident ops consigné : chargement du svdq-int4 (format nunchaku) via `UNETLoader` nu → crash serveur (model_type détecté FLUX), auto-restart 19:35:26Z — exige `NunchakuQwenImageDiTLoader`.

## Validation

- 13 runs firsthand sur le conteneur `comfyui-qwen` (API Bearer), timings server extraits de `/history` (execution_start → execution_success) et conciliés avec le wall client (écart < 1 s).
- QA pixel : masque rouge lâche (r>150, r-g>60, r-b>60) + contrôle std — NaN = std 0 mesuré sur les 8 sorties GGUF ; éditions réelles fp8 détectées (px rouges + std 44,6).
- GPU : runtime-rapporté par `/system_stats` (cuda:0 RTX 3090) + pics VRAM échantillonnés côté hôte (3 s) — 3080 Ti à 0 MiB pendant les runs.
- Artefacts `c272_*.png` conservés hors repo (`C:/Users/jsboi/tensorsharp-investigation/`).
- Append-only : §5 et §7 du ledger non retouchés (WIP non-commité d'une session parallèle sur ce fichier dans l'arbre partagé — re-flaggé sur le dashboard, séquencé après ce merge).

See #14549 (critère 4 : jambe ComfyUI mesurée + bloquée, clôture définitive gated par #14808). See #14808 (suivi stack).
