### PR TITLE
feat(lean,#2159): Partie 70 - pont d'egalite opensTopology = Opens.grothendieckTopology

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesMathlib.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesMathlib.lean
@@ -1,0 +1,115 @@
+/-
+Grothendieck hommage — Partie 70 : le pont vers Mathlib.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+La Partie 68 (`Spaces.lean`) a construit à la main, dans la langue du lake,
+la topologie de Grothendieck des recouvrements ouverts d'un espace
+topologique. Mathlib pose la même construction dans
+`Mathlib.CategoryTheory.Sites.Spaces` (`Opens.grothendieckTopology`). Ce
+module ferme la boucle : les deux définitions sont ÉGALES — pas isomorphes,
+pas équivalentes : égales, car la Partie 68 a transcrit fidèlement la même
+spécification de cribles.
+
+L'égalité n'est pas une curiosité : `TopCat.Presheaf.IsSheaf`, la condition
+de faisceau de Mathlib pour un espace topologique, est DÉFINIE comme la
+condition de faisceau pour `Opens.grothendieckTopology ↑X`
+(`Mathlib.Topology.Sheaves.Sheaf`). Le corollaire
+`isSheaf_opensTopology_iff` dit donc exactement : un préfaisceau est un
+faisceau sur le site own `(Opens T, opensTopology T)` si et seulement si
+c'est un faisceau au sens usuel de la topologie — le cas fondateur de
+Mac Lane – Moerdijk, et l'accès de tout le corpus Mathlib
+(`Topology.Sheaves` : faisceification, germes, espaces étalés, foncteur
+points) au site du lake, sans traduction.
+
+  - `opensTopology_eq` : `opensTopology T = Opens.grothendieckTopology T` ;
+  - `opensPretopology_eq` : la même coïncidence côté prétopologies ;
+  - `isSheaf_opensTopology_iff_types` : transport de la condition de
+    faisceau (faisceaux de types) ;
+  - `isSheaf_opensTopology_iff` : le résultat central, à valeurs dans une
+    catégorie arbitraire ;
+  - `coversTop_opensTopology_iff` : transport de la notion de famille
+    couvrante.
+
+Références :
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II.
+  - Mathlib, `CategoryTheory.Sites.Spaces`, `Topology.Sheaves.Sheaf`.
+
+Convention i18n (EPIC #4980 ratifiée 2026-07-04) : ce module est jumelé avec
+`SpacesMathlib_en.lean`. Les énoncés, preuves et noms Lean restent identiques ;
+seules les docstrings et les commentaires diffèrent.
+
+Epic #1646, Phase 2 (#2159). Aucun `sorry` introduit.
+-/
+
+import Grothendieck.Spaces
+import Mathlib.CategoryTheory.Sites.Spaces
+import Mathlib.Topology.Sheaves.Sheaf
+
+namespace Grothendieck
+
+open CategoryTheory TopologicalSpace CategoryTheory.Limits
+
+universe u w w'
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- **Égalité des topologies** : la topologie définie à la main en Partie 68
+est exactement la topologie `Opens.grothendieckTopology` de Mathlib. La
+Partie 68 a transcrit la même spécification de cribles (« tout point de
+l'ouvert cible appartient au domaine d'une flèche du crible ») ; le champ de
+données `sieves` coïncide définitionnellement et les champs de preuve tombent
+par irrélevance des preuves. -/
+theorem opensTopology_eq :
+    opensTopology T = Opens.grothendieckTopology T :=
+  rfl
+
+/-- **Égalité des prétopologies** : la prétopologie own des recouvrements
+ouverts (`opensPretopology`, Partie 68) est exactement la prétopologie
+`Opens.pretopology` de Mathlib — le champ de données `coverings` porte la
+même spécification. -/
+theorem opensPretopology_eq :
+    opensPretopology T = Opens.pretopology T :=
+  rfl
+
+variable {T}
+
+/-- Transport de la condition de faisceau pour les faisceaux de types :
+être un faisceau pour la topologie own ou pour celle de Mathlib est la même
+chose. -/
+theorem isSheaf_opensTopology_iff_types (P : (Opens T)ᵒᵖ ⥤ Type*) :
+    Presheaf.IsSheaf (opensTopology T) P ↔
+      Presheaf.IsSheaf (Opens.grothendieckTopology T) P := by
+  rw [opensTopology_eq]
+
+/-- **Résultat central** : la condition de faisceau sur le site
+`(Opens T, opensTopology T)` est exactement la condition de faisceau usuelle
+de Mathlib pour un espace topologique. `TopCat.Presheaf.IsSheaf` est
+définie comme `Presheaf.IsSheaf (Opens.grothendieckTopology ↑X)`
+(`Mathlib.Topology.Sheaves.Sheaf`), et le pont `opensTopology_eq` transporte
+l'une dans l'autre : tout le corpus `Topology.Sheaves` (faisceification,
+germes, espaces étalés, foncteur points) s'applique au site own sans
+traduction. -/
+theorem isSheaf_opensTopology_iff {C : Type w} [Category.{w'} C]
+    (F : TopCat.Presheaf C (TopCat.of T)) :
+    Presheaf.IsSheaf (opensTopology T) F ↔ TopCat.Presheaf.IsSheaf F := by
+  rw [opensTopology_eq]
+  rfl
+
+/-- Transport de la notion de famille couvrante : `CoversTop` pour la
+topologie own est `CoversTop` pour celle de Mathlib. Combiné aux deux
+caractérisations par `IsOpenCover` (celle de la Partie 68
+`coversTop_isOpenCover_iff`, celle de Mathlib `Opens.coversTop_iff`), les
+deux mondes énoncent la même notion de recouvrement. -/
+theorem coversTop_opensTopology_iff {ι : Type*} (U : ι → Opens T) :
+    (opensTopology T).CoversTop U ↔ (Opens.grothendieckTopology T).CoversTop U := by
+  rw [opensTopology_eq]
+
+end Contenu
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesMathlib_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesMathlib_en.lean
@@ -1,0 +1,109 @@
+/-
+Grothendieck tribute — Part 70: the bridge to Mathlib.
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 2 extension (#2159, Epic #1646).
+
+Part 68 (`Spaces.lean`) built by hand, in the lake's own language, the
+Grothendieck topology of open covers of a topological space. Mathlib states
+the very same construction in `Mathlib.CategoryTheory.Sites.Spaces`
+(`Opens.grothendieckTopology`). This module closes the loop: the two
+definitions are EQUAL — not isomorphic, not equivalent: equal, because
+Part 68 faithfully transcribed the same sieve specification.
+
+The equality is no curiosity: `TopCat.Presheaf.IsSheaf`, Mathlib's sheaf
+condition for a topological space, is DEFINED as the sheaf condition for
+`Opens.grothendieckTopology ↑X` (`Mathlib.Topology.Sheaves.Sheaf`). The
+corollary `isSheaf_opensTopology_iff` therefore says exactly this: a
+presheaf is a sheaf on the own site `(Opens T, opensTopology T)` if and
+only if it is a sheaf in the usual topological sense — the founding case of
+Mac Lane – Moerdijk, and the gateway from the whole Mathlib corpus
+(`Topology.Sheaves`: sheafification, stalks, étale spaces, points functor)
+to the lake's site, with no translation.
+
+  - `opensTopology_eq` : `opensTopology T = Opens.grothendieckTopology T` ;
+  - `opensPretopology_eq` : the same coincidence on the pretopology side ;
+  - `isSheaf_opensTopology_iff_types` : transport of the sheaf condition
+    (sheaves of types) ;
+  - `isSheaf_opensTopology_iff` : the central result, valued in an
+    arbitrary category ;
+  - `coversTop_opensTopology_iff` : transport of the notion of covering
+    family.
+
+References:
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Ch. II.
+  - Mathlib, `CategoryTheory.Sites.Spaces`, `Topology.Sheaves.Sheaf`.
+
+i18n convention (EPIC #4980 ratified 2026-07-04): this module is twinned
+with `SpacesMathlib.lean`. Statements, proofs and Lean names stay
+identical; only docstrings and comments differ.
+
+Epic #1646, Phase 2 (#2159). No `sorry` introduced.
+-/
+
+import Grothendieck.Spaces
+import Mathlib.CategoryTheory.Sites.Spaces
+import Mathlib.Topology.Sheaves.Sheaf
+
+namespace Grothendieck.SpacesMathlib_en
+
+open CategoryTheory TopologicalSpace CategoryTheory.Limits
+
+universe u w w'
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- **Equality of the topologies**: the hand-defined topology of Part 68 is
+exactly Mathlib's `Opens.grothendieckTopology` topology. Part 68
+transcribed the same sieve specification ("every point of the target open
+belongs to the domain of an arrow of the sieve"); the data field `sieves`
+coincides definitionally and the proof fields fall by proof irrelevance. -/
+theorem opensTopology_eq :
+    opensTopology T = Opens.grothendieckTopology T :=
+  rfl
+
+/-- **Equality of the pretopologies**: the own pretopology of open covers
+(`opensPretopology`, Part 68) is exactly Mathlib's `Opens.pretopology`
+pretopology — the data field `coverings` carries the same specification. -/
+theorem opensPretopology_eq :
+    opensPretopology T = Opens.pretopology T :=
+  rfl
+
+variable {T}
+
+/-- Transport of the sheaf condition for sheaves of types: being a sheaf
+for the own topology or for Mathlib's is the same thing. -/
+theorem isSheaf_opensTopology_iff_types (P : (Opens T)ᵒᵖ ⥤ Type*) :
+    Presheaf.IsSheaf (opensTopology T) P ↔
+      Presheaf.IsSheaf (Opens.grothendieckTopology T) P := by
+  rw [opensTopology_eq]
+
+/-- **Central result**: the sheaf condition on the site
+`(Opens T, opensTopology T)` is exactly Mathlib's usual sheaf condition for
+a topological space. `TopCat.Presheaf.IsSheaf` is defined as
+`Presheaf.IsSheaf (Opens.grothendieckTopology ↑X)`
+(`Mathlib.Topology.Sheaves.Sheaf`), and the bridge `opensTopology_eq`
+transports one into the other: the whole `Topology.Sheaves` corpus
+(sheafification, stalks, étale spaces, points functor) applies to the own
+site with no translation. -/
+theorem isSheaf_opensTopology_iff {C : Type w} [Category.{w'} C]
+    (F : TopCat.Presheaf C (TopCat.of T)) :
+    Presheaf.IsSheaf (opensTopology T) F ↔ TopCat.Presheaf.IsSheaf F := by
+  rw [opensTopology_eq]
+  rfl
+
+/-- Transport of the notion of covering family: `CoversTop` for the own
+topology is `CoversTop` for Mathlib's. Combined with the two `IsOpenCover`
+characterizations (Part 68's `coversTop_isOpenCover_iff` and Mathlib's
+`Opens.coversTop_iff`), both worlds state the same notion of cover. -/
+theorem coversTop_opensTopology_iff {ι : Type*} (U : ι → Opens T) :
+    (opensTopology T).CoversTop U ↔ (Opens.grothendieckTopology T).CoversTop U := by
+  rw [opensTopology_eq]
+
+end Contenu
+
+end Grothendieck.SpacesMathlib_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: DEEP/lean #14680

See #2159 (Partie 70 — Epic #1646 Phase 2). Deuxième grain DEEP/lean consécutif de la lane, substance genuinement distincte de #14680 (P68 = construction own de la topologie ; P70 = le pont d'égalité vers Mathlib, qui ouvre l'accès au corpus `Topology.Sheaves`).

## Résumé

La Partie 68 (`Spaces.lean`) a construit à la main la topologie de Grothendieck des recouvrements ouverts de `Opens T`. Mathlib pose la même construction dans `Mathlib.CategoryTheory.Sites.Spaces` (`Opens.grothendieckTopology`, vérifié firsthand à la révision épinglée `520045ab`). Ce module prouve que les deux définitions sont **égales** (pas isomorphes) :

- `opensTopology_eq` : `opensTopology T = Opens.grothendieckTopology T` — les champs `sieves` portent la même spécification, `rfl` ferme par irrélevance des preuves ;
- `opensPretopology_eq` : la même coïncidence côté prétopologies ;
- `isSheaf_opensTopology_iff_types` : transport de la condition de faisceau (faisceaux de types) ;
- `isSheaf_opensTopology_iff` : **résultat central** — `Presheaf.IsSheaf (opensTopology T) F ↔ TopCat.Presheaf.IsSheaf F`. `TopCat.Presheaf.IsSheaf` est DÉFINIE comme `Presheaf.IsSheaf (Opens.grothendieckTopology X)` (Mathlib `Topology/Sheaves/Sheaf.lean` l.84, vérifié) : le cas fondateur Mac Lane–Moerdijk est fermé, et tout le corpus Mathlib `Topology.Sheaves` (faisceification, germes, espaces étalés, foncteur points) s'applique au site own sans traduction ;
- `coversTop_opensTopology_iff` : transport de la notion de famille couvrante.

## Validation

- build ciblé `lake build Grothendieck.SpacesMathlib Grothendieck.SpacesMathlib_en` : **Build completed successfully (1134 jobs)** ;
- build global du lake (`lake build`) : **Build completed successfully (3317 jobs)** (3315 post-Partie 69 + les 2 nouveaux modules) ;
- `distinct_code_sorry: 0 → 0` (136 → 138 fichiers, `count_code_sorry.py --json`) ;
- checker i18n local (`check_i18n_siblings.py SpacesMathlib_en.lean`) : **1/1 pairs byte-identical, 0 drift, 0 orphan, 0 unbuilt** ;
- CI : Lean CI / Proof integrity / i18n sibling drift / PR gate (rapport de run à suivre).

## Périmètre

2 nouveaux fichiers : `Grothendieck/SpacesMathlib.lean`, `Grothendieck/SpacesMathlib_en.lean` (Pattern A consommateur : l'EN importe le FR `Grothendieck.Spaces` et le référencent verbatim, namespace `_en` anti-collision). Aucun README, agrégateur, manifeste, catalogue ou notebook modifié. Catalogue byte-identique à main.
