### PR TITLE
fix(tooling,#14195): drainer les enregistrements de worktree morts + 3 chemins de travail hors gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -601,6 +601,21 @@ tmp/
 
 # Claude Code worktrees and temp artifacts
 .claude/worktrees/
+
+# Worktrees hors `.claude/` : `git worktree add` depose aussi des checkouts
+# sous `.worktrees/` a la racine du depot. Sans cette ligne, chaque worktree
+# ainsi cree expose son arbre entier comme untracked -- mesure 2026-09-05 :
+# 101 054 fichiers untracked pour 10 worktrees, qui noient le panneau Source
+# Control et masquent les modifications reelles (#14195).
+.worktrees/
+
+# Scratch local d'agent : patches, sondes, sorties de commande jetables.
+# Meme rationale que ci-dessus -- ces fichiers ne sont jamais des livrables.
+.local/
+
+# Logs de sessions prover en arriere-plan (Lean). Produits par les runs
+# `agent_tests`, jamais commites.
+MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/bg_logs/
 *.lscache
 $null
 

--- a/scripts/ci/prune_merged_worktrees.py
+++ b/scripts/ci/prune_merged_worktrees.py
@@ -77,14 +77,24 @@ rate les squash-merges, le second a des faux negatifs mesures.
 1. **Dry-run par defaut, --apply explicite.** Jamais de retrait silencieux.
 2. **Journal de refus obligatoire.** Un outil de purge qui ne dit pas ce
    qu'il épargne est indiscernable d'un outil qui ne regarde pas.
-3. **Aucun `git worktree remove --force`.** Le retrait est `git worktree
-   remove` sans --force ; si git refuse (worktree sale), on log la cause et
-   on continue (ne JAMAIS forcer). Depuis #14619 : avant le retrait, l'apply
-   supprime exactement les artefacts untracked toleres (et eux seuls --
+3. **`--force` reserve aux enregistrements morts, jamais general.** Le
+   retrait est `git worktree remove` sans --force ; si git refuse (worktree
+   sale), on log la cause et on continue. C'est ce refus qui reste le
+   dernier garde-fou quand la classification s'est trompee : le rendre
+   inoperant par un --force inconditionnel oterait au dispositif sa seule
+   verification externe. Depuis #14619 : avant le retrait, l'apply supprime
+   exactement les artefacts untracked toleres (et eux seuls --
    clean_tolerated_artifacts), sinon git refuse sur tout non-suivi et un
    worktree classe REMOVE pour artefacts seulement ne part jamais. Un residu
    hors liste tolerree est classe REFUSE (untolerated_untracked), pas REMOVE,
    et un worktree a sous-modules REFUSE (contains_submodules).
+   **Unique exception (#14195)** : un enregistrement dont le CHECKOUT a
+   disparu (`dead_registration`, predicat 1bis) est retire avec --force --
+   sans lui git refuse un arbre absent ("contains modified or untracked
+   files") et l'organe annoncerait un REMOVE qu'il ne peut pas executer. Le
+   drapeau est calcule par deux conditions conjonctives (toute modification
+   est une suppression ET >= DEAD_TREE_RATIO de l'index a disparu), et
+   `test_no_unconditional_force` pinne que le --force reste sous ce test.
 4. **Mode `--json` parallele au mode texte.** Mêmes chiffres, même ordre ;
    le recipient downstream (dashboard sweep, DM ai-01) parse le JSON sans
    réinventer le rendu.
@@ -220,6 +230,9 @@ class WorktreeStatus:
     has_submodules: bool = False          # submodule initialise present
     blocking_untracked: list = dataclasses.field(default_factory=list)
     ignored_extra: list = dataclasses.field(default_factory=list)
+    # Champ #14195 (additif) : checkout disparu, enregistrement orphelin.
+    # Porte la decision REMOVE *et* le passage a `--force` a l'apply.
+    dead_registration: bool = False
 
     def to_dict(self) -> dict:
         return dataclasses.asdict(self)
@@ -284,6 +297,7 @@ def parse_porcelain(stdout: str) -> dict:
     blocking: list[str] = []
     ignored_extra: list[str] = []
     tracked_modified: list[str] = []
+    tracked_deleted: list[str] = []
     for line in stdout.splitlines():
         # Format porcelain : XY path (XY = 2 chars index/worktree)
         if len(line) < 4:
@@ -305,11 +319,18 @@ def parse_porcelain(stdout: str) -> dict:
         elif any(c != " " for c in xy):
             # Modification tracked non commitee = source sale
             tracked_modified.append(path)
+            # Suppression cote arbre de travail (colonne worktree = 'D').
+            # Comptee a part : un arbre ENTIEREMENT supprime n'est pas du
+            # travail en cours, c'est un checkout disparu (cf #14195,
+            # predicat `dead_registration`).
+            if len(xy) > 1 and xy[1] == "D":
+                tracked_deleted.append(path)
     return {
         "untracked": untracked,
         "blocking_untracked": blocking,
         "ignored_extra": ignored_extra,
         "tracked_modified": tracked_modified,
+        "tracked_deleted": tracked_deleted,
     }
 
 
@@ -395,6 +416,36 @@ def has_initialized_submodule(submodule_status_stdout: str) -> bool:
     )
 
 
+# Fraction de l'index qui doit avoir disparu du disque pour qu'un
+# enregistrement soit declare mort. 0.9 laisse deliberement de la marge :
+# les cadavres mesures rendent 100 % (7355 a 8409 suppressions pour autant
+# de fichiers tracks), et aucune suppression volontaire plausible n'atteint
+# ce seuil SANS s'accompagner d'au moins une edition (condition (a)).
+DEAD_TREE_RATIO = 0.9
+
+
+def _is_dead_registration(wt_path: str, parsed: dict) -> bool:
+    """Le checkout a-t-il disparu, laissant l'enregistrement orphelin ?
+
+    Fail-CLOSED : au moindre doute (index illisible, index vide, une seule
+    edition non-suppression), rend False -- le worktree repart alors dans
+    les predicats de refus habituels.
+    """
+    deleted = parsed.get("tracked_deleted") or []
+    modified = parsed.get("tracked_modified") or []
+    if not deleted or len(deleted) != len(modified):
+        # (a) une edition reelle coexiste avec les suppressions : c'est du
+        # travail, pas un checkout disparu.
+        return False
+    ls_proc = run_git(wt_path, "ls-files", check=False)
+    if ls_proc.returncode != 0:
+        return False
+    tracked_total = len([x for x in ls_proc.stdout.splitlines() if x.strip()])
+    if tracked_total <= 0:
+        return False
+    return (len(deleted) / tracked_total) >= DEAD_TREE_RATIO
+
+
 def get_worktree_info(wt_path: str, current_path: str) -> dict:
     """Recupere branch + ahead count + dirty status d'un worktree."""
     # Branche (peut etre None si HEAD detaché)
@@ -454,6 +505,23 @@ def get_worktree_info(wt_path: str, current_path: str) -> dict:
     subm_proc = run_git(wt_path, "submodule", "status", check=False)
     has_submodules = has_initialized_submodule(subm_proc.stdout)
 
+    # Enregistrement mort (#14195) : le checkout a disparu du disque alors
+    # que `.git/worktrees/<nom>` subsiste. Cas mesure le 2026-09-05 : 26
+    # des 51 worktrees enregistres, TOUS sous `C:\...\Temp`, vides par le
+    # nettoyage disque de Windows. Git les voit comme des milliers de
+    # fichiers tracks supprimes -- donc `tracked_modified` non vide, donc
+    # `uncommitted_source_changes`, donc REFUSE a perpetuite : la preuve de
+    # leur mort est exactement ce qui les rendait irreclamables.
+    #
+    # Le predicat exige les DEUX conditions, pour ne jamais confondre un
+    # checkout disparu avec une lane qui supprime volontairement des
+    # fichiers : (a) toute modification tracked est une suppression -- une
+    # seule edition reelle disqualifie ; (b) la quasi-totalite de l'index
+    # a disparu du disque (>= DEAD_TREE_RATIO). Une PR qui supprime 200
+    # fichiers sur 9000 echoue (b) ; une PR qui en supprime 8900 et en
+    # edite un echoue (a).
+    dead_registration = _is_dead_registration(wt_path, parsed)
+
     return {
         "branch": branch,
         "ahead_count": ahead_count,
@@ -464,6 +532,7 @@ def get_worktree_info(wt_path: str, current_path: str) -> dict:
         "has_source_dirty": has_source,
         "has_submodules": has_submodules,
         "is_current": same_worktree_path(wt_path, current_path),
+        "dead_registration": dead_registration,
     }
 
 
@@ -666,6 +735,32 @@ def diagnose_worktree(wt_path: str, current_path: str) -> WorktreeStatus:
             ignored_extra=info.get("ignored_extra", []),
         )
 
+    # Predicat 1bis : enregistrement mort (#14195). DOIT preceder les
+    # predicats de salete : un checkout disparu se presente comme des
+    # milliers de fichiers tracks supprimes, donc `has_source_dirty`, donc
+    # REFUSE -- c'est ce masquage qui laissait 26 enregistrements morts au
+    # registre. L'etat PR n'est pas interroge : il n'y a plus d'arbre a
+    # proteger, quel que soit le sort de la branche (que `git worktree
+    # remove` ne supprime jamais).
+    if info.get("dead_registration"):
+        return WorktreeStatus(
+            path=wt_path,
+            branch=info["branch"],
+            is_current=False,
+            pr_state=None,
+            pr_number=None,
+            pr_url=None,
+            ahead_count=info["ahead_count"],
+            has_source_dirty=info["has_source_dirty"],
+            untracked_paths=info["untracked"],
+            decision="REMOVE",
+            refusal_reason=None,
+            has_submodules=info["has_submodules"],
+            blocking_untracked=info.get("blocking_untracked", []),
+            ignored_extra=info.get("ignored_extra", []),
+            dead_registration=True,
+        )
+
     # Predicat 2a : source sale (fichier source untracked non tolere, ou
     # tracked modifie) -> REFUSE (#14509 : pouvoir de refus git reel ;
     # #14619 : les toleres sont nettoyables a l'apply et ne comptent plus).
@@ -856,8 +951,20 @@ def clean_tolerated_artifacts(wt: WorktreeStatus) -> list[str]:
 
 
 def apply_removal(wt: WorktreeStatus) -> tuple[bool, str]:
-    """Tente `git worktree remove`. Retourne (success, stderr)."""
-    proc = run_git(".", "worktree", "remove", wt.path, check=False)
+    """Tente `git worktree remove`. Retourne (success, stderr).
+
+    `--force` est reserve aux enregistrements morts (#14195) : sans lui,
+    git refuse de retirer un worktree dont l'arbre a disparu ("contains
+    modified or untracked files"), et l'organe annoncerait un REMOVE qu'il
+    ne peut pas executer. Pour tout autre worktree, l'absence de `--force`
+    reste le garde-fou : c'est git qui refuse en dernier ressort si la
+    classification s'est trompee.
+    """
+    args = ["worktree", "remove"]
+    if wt.dead_registration:
+        args.append("--force")
+    args.append(wt.path)
+    proc = run_git(".", *args, check=False)
     if proc.returncode == 0:
         return True, ""
     return False, proc.stderr.strip()

--- a/scripts/tests/test_prune_merged_worktrees.py
+++ b/scripts/tests/test_prune_merged_worktrees.py
@@ -461,6 +461,153 @@ class TestGetWorktreeInfoPorcelain:
 
 
 # ---------------------------------------------------------------------------
+# Enregistrement mort -- le checkout a disparu du disque (#14195)
+# ---------------------------------------------------------------------------
+
+
+class TestDeadRegistration14195:
+    """Un enregistrement dont le CHECKOUT a disparu se lit comme du travail.
+
+    Mesure ai-01 du 2026-09-05 : 26 des 51 enregistrements du registre
+    pointaient un repertoire vide, tous sur le volume systeme, vides par
+    le nettoyage de Temp de Windows. `.git/worktrees/<nom>` survit, donc
+    `git status` rend des MILLIERS de fichiers tracks supprimes, donc
+    `has_source_dirty`, donc `uncommitted_source_changes` : le predicat 2a
+    refuse, et il refusera toujours. La preuve de la mort est exactement
+    ce qui rendait le cadavre irrecuperable.
+
+    Le predicat separe la mort du travail par DEUX conditions
+    CONJONCTIVES, et aucune ne suffit seule :
+      (a) toute modification tracked est une suppression d'arbre ;
+      (b) au moins DEAD_TREE_RATIO de l'index a disparu.
+    Les deux controles negatifs ci-dessous pinnent chacune des deux : une
+    lane qui supprime deliberement des fichiers reste REFUSE.
+    """
+
+    @staticmethod
+    def _deleted(n: int) -> str:
+        """Porcelain de `n` fichiers supprimes cote ARBRE DE TRAVAIL."""
+        return "".join(" D src/f%d.py\n" % i for i in range(n))
+
+    @staticmethod
+    def _stub_index(monkeypatch, total: int, rc: int = 0):
+        """Stub `git ls-files` : `total` chemins tracks dans l'index."""
+        listing = "".join("src/f%d.py\n" % i for i in range(total))
+        monkeypatch.setattr(
+            pmw, "run_git", lambda *a, **k: _fake_proc(rc, listing))
+
+    # -- parse_porcelain : la colonne ARBRE 'D' se collecte a part ------
+
+    def test_worktree_deletion_collected_apart_from_staged(self):
+        out = pmw.parse_porcelain(" D a.py\n M b.py\nD  c.py\n")
+        # ' D' = supprime cote arbre de travail : le cas du cadavre.
+        # 'D ' = suppression STAGEE : un geste delibere, jamais une
+        # disparition -- elle compte comme modification, pas comme
+        # deletion d'arbre. Le predicat (a) la lira donc comme du travail.
+        assert out["tracked_deleted"] == ["a.py"]
+        assert out["tracked_modified"] == ["a.py", "b.py", "c.py"]
+
+    # -- controle positif : l'arbre entier a disparu --------------------
+
+    def test_whole_tree_deleted_is_a_dead_registration(self, monkeypatch):
+        self._stub_index(monkeypatch, total=9000)
+        parsed = pmw.parse_porcelain(self._deleted(9000))
+        assert len(parsed["tracked_deleted"]) == 9000
+        assert pmw._is_dead_registration("C:/gone", parsed) is True
+
+    # -- controle negatif (b) : suppression deliberee, sous le seuil ----
+
+    def test_partial_deletion_is_work_not_death(self, monkeypatch):
+        # 200 suppressions sur 9000 tracks = 2,2 %. Une lane qui retire
+        # deliberement un repertoire doit rester REFUSE : sans le ratio,
+        # tout `git rm -r` d'un sous-arbre partirait au retrait.
+        self._stub_index(monkeypatch, total=9000)
+        parsed = pmw.parse_porcelain(self._deleted(200))
+        assert pmw._is_dead_registration("C:/wt", parsed) is False
+
+    # -- controle negatif (a) : une seule edition reelle suffit ---------
+
+    def test_one_real_edit_among_deletions_is_work(self, monkeypatch):
+        # 8900 suppressions sur 9000 = 98,9 %, AU-DESSUS du seuil : le
+        # ratio seul aurait rendu True. Une edition non-suppression
+        # coexiste, donc c'est du travail en cours -- et la condition (a)
+        # tranche SANS meme lire l'index (run_git leve si appele).
+        def _no_git(*a, **k):
+            raise AssertionError(
+                "condition (a) doit court-circuiter : une edition reelle "
+                "tranche sans que l'index soit lu"
+            )
+
+        monkeypatch.setattr(pmw, "run_git", _no_git)
+        parsed = pmw.parse_porcelain(self._deleted(8900) + " M src/keep.py\n")
+        assert len(parsed["tracked_deleted"]) == 8900
+        assert len(parsed["tracked_modified"]) == 8901
+        assert pmw._is_dead_registration("C:/wt", parsed) is False
+
+    # -- fail-closed : une mesure impossible n'est pas un cadavre -------
+
+    def test_unreadable_index_fails_closed(self, monkeypatch):
+        self._stub_index(monkeypatch, total=9000, rc=128)
+        parsed = pmw.parse_porcelain(self._deleted(9000))
+        assert pmw._is_dead_registration("C:/gone", parsed) is False
+
+    def test_empty_index_fails_closed(self, monkeypatch):
+        # Index vide : le ratio serait une division par zero. Un
+        # enregistrement dont l'index ne rend aucun chemin n'est pas un
+        # cadavre MESURE, c'est une mesure absente -- donc REFUSE.
+        self._stub_index(monkeypatch, total=0)
+        parsed = pmw.parse_porcelain(self._deleted(3))
+        assert pmw._is_dead_registration("C:/gone", parsed) is False
+
+    # -- aval : le verdict precede les predicats de salete --------------
+
+    def test_diagnose_removes_dead_registration_without_gh(self, monkeypatch):
+        info = dict(
+            branch="fix/X", ahead_count=0, untracked=[],
+            blocking_untracked=[], ignored_extra=[],
+            tracked_modified=["src/f0.py"], has_source_dirty=True,
+            has_submodules=False, is_current=False, dead_registration=True,
+        )
+        monkeypatch.setattr(pmw, "get_worktree_info", lambda *a: info)
+
+        def _no_gh(*a):
+            raise AssertionError(
+                "aucun appel gh : il n'y a plus d'arbre a proteger, quel "
+                "que soit l'etat de la PR"
+            )
+
+        monkeypatch.setattr(pmw, "lookup_pr_for_branch", _no_gh)
+        s = pmw.diagnose_worktree("C:/gone", "C:/other")
+        # has_source_dirty est VRAI (les suppressions) : sans le predicat
+        # 1bis place AVANT le 2a, ce worktree rendait
+        # `uncommitted_source_changes` -- le refus perpetuel mesure.
+        assert s.decision == "REMOVE"
+        assert s.refusal_reason is None
+        assert s.dead_registration is True
+
+    # -- aval : --force est CIBLE, jamais general -----------------------
+
+    def test_force_is_reserved_to_dead_registrations(self, monkeypatch):
+        seen: list[list[str]] = []
+
+        def fake_run_git(cwd, *args, **kwargs):
+            seen.append(list(args))
+            return _fake_proc(0, "")
+
+        monkeypatch.setattr(pmw, "run_git", fake_run_git)
+
+        ok, err = pmw.apply_removal(
+            _make_status(path="C:/gone", dead_registration=True))
+        assert ok is True and err == ""
+        assert seen[-1] == ["worktree", "remove", "--force", "C:/gone"]
+
+        pmw.apply_removal(_make_status(path="C:/live"))
+        # Worktree ordinaire : PAS de --force. Le refus de git reste le
+        # dernier garde-fou si la classification s'est trompee.
+        assert seen[-1] == ["worktree", "remove", "C:/live"]
+
+
+# ---------------------------------------------------------------------------
 # same_worktree_path -- le drapeau is_current se CALCULE
 # ---------------------------------------------------------------------------
 
@@ -864,10 +1011,50 @@ class TestToleratedCleanup14619:
         assert s.decision == "REFUSE"
         assert s.refusal_reason == "contains_submodules"
 
-    def test_no_force_in_source(self):
+    def test_no_unconditional_force(self):
+        """Regle 3 durcie (#14195) : `--force` existe, mais SOUS TEST.
+
+        La propriete d'origine etait l'absence du litteral dans la source.
+        Le predicat 1bis l'a rendue intenable : un enregistrement dont
+        l'arbre a disparu ne se retire pas sans --force, et l'organe
+        annoncerait alors un REMOVE qu'il ne peut pas executer.
+
+        Ce qui comptait n'a jamais ete l'absence du mot -- c'est que le
+        REFUS DE GIT reste opposable a un worktree vivant, seule
+        verification externe du dispositif. On pinne donc la structure :
+        chaque apparition de `--force` doit etre gardee par un test sur
+        `dead_registration`. Un `--force` inconditionnel (le raccourci qui
+        ferait passer n'importe quelle mauvaise classification) echoue.
+        """
+        import ast
         src = Path(pmw.__file__).read_text(encoding="utf-8")
-        assert '"--force"' not in src and "'--force'" not in src, (
-            "la propriété no-force (docstring règle 3) doit tenir"
+        tree = ast.parse(src)
+
+        def _force_ids(node):
+            return {
+                id(n) for n in ast.walk(node)
+                if isinstance(n, ast.Constant) and n.value == "--force"
+            }
+
+        guarded: set[int] = set()
+        for stmt in ast.walk(tree):
+            if not isinstance(stmt, ast.If):
+                continue
+            names = {
+                n.attr for n in ast.walk(stmt.test)
+                if isinstance(n, ast.Attribute)
+            } | {
+                n.id for n in ast.walk(stmt.test) if isinstance(n, ast.Name)
+            }
+            if "dead_registration" in names:
+                guarded |= _force_ids(stmt)
+
+        total = _force_ids(tree)
+        assert total, "le --force cible du predicat 1bis a disparu"
+        assert total == guarded, (
+            f"{len(total - guarded)} occurrence(s) de --force hors garde "
+            "`dead_registration` : la regle 3 exige que le refus de git "
+            "reste opposable a un worktree vivant"
         )
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: LIGHT/tooling #14776

## Ce que ce grain repare

Deux defauts distincts qui produisaient le meme symptome visible : le panneau Source Control de VS Code noye, et un main qui *parait* deriver alors qu'il ne derive pas.

### 1. Un registre de worktrees que l'organe de purge ne pouvait pas drainer

Mesure sur ai-01 le 2026-09-05 : `prune_merged_worktrees.py` rendait `total=51 removable=0 refused=50`. **26 de ces 50 refus etaient des cadavres** : leur repertoire de checkout avait ete vide par le nettoyage de Temp de Windows (tous sur le volume systeme -- cause racine deja routee vers Maintenance, roo-extensions #3462/#3463). `.git/worktrees/<nom>` survit a la disparition de l'arbre, donc `git status` rend des milliers de fichiers tracks supprimes, donc `has_source_dirty`, donc `uncommitted_source_changes`.

**La preuve de la mort etait exactement ce qui rendait le cadavre irrecuperable** : un enregistrement mort est indiscernable d'un travail en cours pour un predicat fail-closed. Le predicat n'avait pas tort -- il est fidele au pouvoir de refus reel de `git worktree remove` -- il lui manquait une **classe de decision**, pas un seuil relache.

Ce que la PR ajoute (`Predicat 1bis`, place **avant** les predicats de salete) :

- `parse_porcelain` collecte a part les suppressions **cote arbre de travail** (colonne worktree `D`) sous la cle `tracked_deleted` ; une suppression **stagee** (`D `) reste une modification ordinaire, jamais une disparition ;
- `_is_dead_registration` tranche par **deux conditions conjonctives** : (a) toute modification tracked est une suppression d'arbre, **et** (b) `>= DEAD_TREE_RATIO` (0.9) de l'index a disparu ;
- fail-CLOSED : index illisible, index vide, une seule edition non-suppression -> `False`, le worktree repart dans les predicats de refus habituels ;
- `apply_removal` ajoute `--force` **uniquement** pour cette classe : sans lui git refuse un arbre absent et l'organe annoncerait un REMOVE qu'il ne peut pas executer.

**Les deux conditions sont chacune pinnee par un controle negatif**, parce que ce sont elles qui empechent le predicat d'emporter du travail :

| Controle | Fixture | Verdict attendu | Condition qui l'obtient |
|---|---|---|---|
| Positif | 9000 suppressions / 9000 tracks | `REMOVE` | (a) et (b) |
| Negatif (b) | 200 suppressions / 9000 tracks (2,2 %) | `REFUSE` | ratio sous le seuil -- un `git rm -r` delibere reste protege |
| Negatif (a) | 8900 suppressions / 9000 (**98,9 %, au-dessus du seuil**) + 1 edition | `REFUSE` | une edition reelle coexiste : c'est du travail |

Le controle negatif (a) est le decisif : le ratio seul aurait rendu `True`. Il verifie aussi que la condition (a) **court-circuite sans lire l'index** (le stub de `run_git` leve si appele).

### 2. Trois repertoires de travail que `.gitignore` ne couvrait pas

`.claude/worktrees/` etait ignore ; `.worktrees/` (ou `git worktree add` depose aussi des checkouts), `.local/` (scratch d'agent) et les `bg_logs/` du prover Lean ne l'etaient pas. **Mesure : 47 fichiers untracked sur `main`, dont 47 sous ces trois chemins** -- et jusqu'a 101 054 quand des worktrees vivent sous `.worktrees/`.

**Controle positif de la remede, pas seulement du diagnostic** : la regle n'est pas validee par `git check-ignore` (qui prouve seulement qu'un motif matche) mais en la passant dans l'organe reel --
`git -c core.excludesFile=<simulation> status --porcelain -uall` : **untracked 47 -> 0**.

## Regle 3 de l'organe : amendee, pas contournee

La docstring du module portait « **Aucun** `git worktree remove --force` », et un test source-level (`test_no_force_in_source`, #14619) pinnait l'absence du litteral. Le predicat 1bis rend cette propriete intenable.

Ce qui comptait n'a jamais ete l'absence du mot : c'est que **le refus de git reste opposable a un worktree vivant** -- seule verification externe du dispositif, celle qui rattrape une mauvaise classification. La propriete est donc reecrite a la structure, pas retiree :

`test_no_unconditional_force` parse l'organe en AST et exige que **chaque** occurrence de `"--force"` soit gardee par un test sur `dead_registration`.

**Controle positif du garde lui-meme** : sur l'organe reel, `total=1, hors-garde=0` ; sur un mutant ou `--force` est rendu inconditionnel, `total=1, hors-garde=1` -> le garde rougit. Un garde qui ne rougit sur rien est un garde eteint.

## Ce que la PR ne fait pas

- **Elle ne supprime aucune branche.** `git worktree remove` ne touche jamais la branche -- verifie par un controle a posteriori sur les 26 retraits manuels de ce cycle (`pr9755`, `pr11217`, `pr12339`, `fix13081` resolvent toujours vers un SHA).
- **Elle ne traite pas la cause racine** de la disparition des checkouts (nettoyage de Temp sur le volume systeme) : c'est roo-extensions #3462/#3463, deja route vers Maintenance. Cette PR rend l'organe capable d'absorber le degat, pas de l'empecher.
- **Elle ne traite pas la classe CRLF-sous-`eol=lf`** (blob CRLF commite sous `text eol=lf` -> arbre sale a la naissance, jamais prunable) rencontree pendant l'investigation : issue de suivi ouverte a part.

## Validation

```
python -m pytest scripts/tests/test_prune_merged_worktrees.py -q
```

9 tests ajoutes (`TestDeadRegistration14195`), 1 test reecrit (`test_no_unconditional_force`).

See #14195
