### PR TITLE
fix(ci,#14799): notebook-validation fail loud on scanner crash / empty workspace (advisory preserved)

### DIFF
--- a/.github/workflows/notebook-validation.yml
+++ b/.github/workflows/notebook-validation.yml
@@ -48,7 +48,9 @@ jobs:
       run: |
         echo "Validating notebook JSON structure and nbformat..."
         ERRORS=0
+        NB_COUNT=0
         while IFS= read -r nb; do
+          NB_COUNT=$((NB_COUNT + 1))
           python -c "
         import json, sys
         import nbformat
@@ -69,23 +71,51 @@ jobs:
         " || ERRORS=$((ERRORS + 1))
         done < <(find . -name "*.ipynb" -not -path "*/\.*" -not -path "*/.ipynb_checkpoints/*")
 
+        # The workflow only triggers on PRs/pushes touching *.ipynb, so the tree
+        # always holds 1200+ notebooks. A zero here means the workspace itself
+        # is broken (incomplete checkout on the self-hosted ephemeral runner —
+        # observed 2026-09-05, run 33979473831: only 7366/9060 files written,
+        # every .ipynb missing, both downstream steps validating empty air)
+        # and this loop would otherwise report a false "all validated" green.
+        if [ $NB_COUNT -eq 0 ]; then
+          echo "::error::find located ZERO notebooks in the workspace — checkout incomplete? (expected 1200+ .ipynb) (#14799)"
+          exit 1
+        fi
+
         if [ $ERRORS -gt 0 ]; then
           echo "FAILED: $ERRORS notebook(s) with errors"
           exit 1
         fi
-        echo "All notebooks validated successfully"
+        echo "All $NB_COUNT notebooks validated successfully"
 
     - name: Check C.2 compliance (execution outputs)
       run: |
-        python scripts/notebook_tools/check_c2_compliance.py --json > /tmp/c2_results.json || true
-        VIOLATIONS=$(python -c "
+        # The scanner's exit code is ambiguous by design: 1 = "violations
+        # found" (advisory, must NOT fail the PR) but ALSO what an uncaught
+        # crash yields (MemoryError on a large notebook is NOT caught by
+        # check_notebook's except clause — #14799). The disambiguator is the
+        # JSON stream: a completing run always prints its report, a crashing
+        # run prints nothing. The old `|| true` preserved the advisory
+        # contract but also swallowed crashes, leaving an empty file for the
+        # parser below to die on with "Expecting value: line 1 column 1".
+        C2_EXIT=0
+        python scripts/notebook_tools/check_c2_compliance.py --json > /tmp/c2_results.json || C2_EXIT=$?
+        if [ $C2_EXIT -ne 0 ] && [ ! -s /tmp/c2_results.json ]; then
+          echo "::error::check_c2_compliance.py exited $C2_EXIT without producing JSON (crashed — see traceback above) (#14799)"
+          exit 1
+        fi
+        if ! VIOLATIONS=$(python -c "
         import json
         data = json.load(open('/tmp/c2_results.json'))
         nb_violations = [r for r in data if r['violations']]
         total_cells = sum(len(r['violations']) for r in nb_violations)
         print(f'{len(nb_violations)} notebooks, {total_cells} cells')
-        ")
-        echo "C.2 compliance: $VIOLATIONS with violations"
+        " 2>/tmp/c2_parse.err); then
+          FIRST=$(head -c 120 /tmp/c2_results.json | tr '\n' ' ')
+          echo "::error::C.2 results not parseable as JSON — scanner wrote non-JSON or truncated output (file starts with: '$FIRST') (#14799)"
+          exit 1
+        fi
+        echo "C.2 compliance: $VIOLATIONS with violations (scanner exit $C2_EXIT)"
         # Report but don't block — C.2 is advisory on PRs, enforced on merge
         if echo "$VIOLATIONS" | grep -q "0 notebooks"; then
           echo "All notebooks C.2 compliant."


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #14781

Closes #14799

## Summary

Le step « Check C.2 compliance » de `notebook-validation.yml` masquait toute erreur du scanner (`|| true`) et le parseur inline crasait ensuite sur un JSON vide avec `Expecting value: line 1 column 1`. Le step « Validate notebook structure » avait le masquage symétrique : une boucle `find` vide validait « successfully » un workspace sans carnets (faux vert observé firsthand).

- **C2_EXIT capturé** : fail loud (`::error::` + exit 1) si le scanner exit ≠ 0 SANS produire de JSON (crash réel, traceback visible au-dessus).
- **Garde non-JSON/tronqué** : si le fichier n'est pas parsable, fail loud en montrant les 120 premiers octets du fichier — couvre le cas observé où le scanner écrit `No notebooks to check.` (exit 0) sur un workspace sans carnets.
- **Advisory préservé** : exit 1 AVEC JSON valide (violations C.2) reste un `::warning::`, conforme au contrat « advisory on PRs, enforced on merge ».
- **Garde faux-vert structure** : le step nbformat compte les carnets trouvés et fail si `NB_COUNT == 0` (« checkout incomplete? »), avec le compte affiché dans le message de succès.

## Diagnostic de la question ouverte (forensique, run 33979473831 attempt 1)

**Pourquoi le scanner échouait-il ? Réponse : il n'échouait pas — le workspace du runner était incomplet.**

1. Logs du job fautif (job 101341975582, runner self-hosted `myia-ai-01-wsl-4`) : le checkout rapporte `Updating files: 100% (7366/7366)` alors que le merge ref `f12fc8bb8` contient **9060 paths dont 1225 .ipynb** (vérifié `git ls-tree -r`) — ~1700 paths non écrits, dont tous les carnets.
2. Conséquence en cascade : step nbformat « All notebooks validated successfully » en **0,13 s** (zéro itération de boucle — faux vert), puis le scanner C.2 sort instantanément (`No notebooks to check.`, catalogue sans chemins existants) et le parseur inline crashe sur ce texte non-JSON.
3. **Intermittence confirmée** : le re-run du même run (attempt 2, job 101358213390) est vert en 4m3s avec l'annotation advisory normale « 64 notebooks, 170 cells ». Idem #14790 (attempt 2 vert). Un workspace ephemeral empoisonné (kill pendant un checkout précédent — `cancel-in-progress` est actif sur ce workflow), pas un bug des PRs.
4. **Réfutation de la piste OOM/timeout de l'issue** : repro locale de la commande exacte de CI sur un checkout complet de #14790 (`pr-14790-repro`, head `c45eaf33c`) : **1092 carnets scannés en 29,2 s, RSS max 110 MB**, JSON complet produit (exit 1 = 63 carnets/169 cellules en violation, warning advisory normal). Le plus gros carnet du corpus (42,3 MB, GenAI Audio TTS) est dans le lot — le scanner n'a aucun problème de taille.
5. Le « 12m+ » cité dans l'issue ne correspond pas au job notebook-validation fautif (34 s) — ce sont les jobs Gitleaks/PR-gate du même push.

## Validation

Harnais de rejeu local (extraction PyYAML des run blocks + shim `python`) — 6/6 :

| Scénario | Attendu | Obtenu |
|---|---|---|
| exit 0, JSON sans violations | vert, « All notebooks C.2 compliant. » | ✓ exit 0 |
| exit 1, JSON avec violations | advisory `::warning::` | ✓ exit 0 |
| exit 1, stdout vide (crash) | `::error::` « without producing JSON » | ✓ exit 1 |
| exit 0, « No notebooks to check. » (cas du run réel) | `::error::` montrant la ligne | ✓ exit 1 |
| workspace 0 carnet | `::error::` « find located ZERO notebooks » | ✓ exit 1 |
| workspace 1 carnet sain | « All 1 notebooks validated successfully » | ✓ exit 0 |

## Residual

La cause racine côté runner (checkout incomplet sur ephemeral malgré `checkout --force` après kill) est un sujet infra runner, hors scope de cette PR — les deux gardes la rendent désormais visible au lieu de la masquer.
