### PR TITLE
fix(runner,#14801): garde de fraicheur d'image au demarrage des pools supervise.sh

### DIFF
--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -120,6 +120,34 @@ export MSYS2_ARG_CONV_EXCL='*'
 
 die() { echo "ERREUR: $*" >&2; exit 1; }
 
+# Contexte de build du runner : le dossier qui porte ce script porte aussi
+# Dockerfile et entrypoint.sh -- le garde de fraicheur compare le sibling du
+# checkout d'ou l'operateur lance le superviseur a ce que porte l'image.
+RUNNER_CTX="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# #14801 Garde de fraicheur d'image. Un correctif d'entrypoint.sh merge mais
+# dont l'image n'a pas ete reconstruite est INERTE : #14385 (purge sparse au
+# demarrage du slot) est reste inerte 3 jours sur la moitie du parc (image du
+# daemon docker-ce WSL construite 5 h AVANT le merge, jamais rebatie), et ce
+# silence a produit les rouges fantomes du sparse-checkout empoisonne. Le
+# demarrage d'un pool est le seul point qui s'execute inconditionnellement
+# (un job annule ne joue aucun step post) : on y compare le sha256 du
+# entrypoint.sh de CE checkout a celui embarque dans l'image. La lecture
+# cote image passe par `docker run --entrypoint sha256sum` -- le Dockerfile
+# place le script a /opt/runner/entrypoint.sh et MSYS_NO_PATHCONV (exporte
+# plus haut) protege l'argument POSIX sous Git Bash.
+assert_image_fresh() {
+  local image="$1" build_cmd="$2"
+  local repo_sha img_sha
+  repo_sha="$(sha256sum "$RUNNER_CTX/entrypoint.sh" 2>/dev/null | awk '{print $1}')"
+  [ -n "$repo_sha" ] || die "entrypoint.sh introuvable a cote de supervise.sh ($RUNNER_CTX) -- lancer depuis un checkout du depot"
+  img_sha="$(docker run --rm --entrypoint sha256sum "$image" /opt/runner/entrypoint.sh 2>/dev/null | awk '{print $1}')"
+  [ -n "$img_sha" ] || die "lecture de /opt/runner/entrypoint.sh dans $image impossible (docker run --entrypoint sha256sum)"
+  [ "$repo_sha" = "$img_sha" ] || die "image $image PERIMEE : entrypoint.sh du checkout ($repo_sha) != entrypoint embarque ($img_sha).
+Un correctif merge mais non deploye est indiscernable d'un correctif absent (#14801, #14385). Reconstruire :
+    $build_cmd"
+}
+
 # #14259 Defaut 1+3 : compte et liste les PIDs des superviseurs actifs du
 # meme `NAME_PREFIX`. La cle est `PPID==1` : un superviseur est le parent
 # direct d'un slot_loop fork (mesure : PPID 72469 = LE superviseur ;
@@ -220,6 +248,7 @@ cmd_start() {
   docker image inspect "$IMAGE" >/dev/null 2>&1 \
     || die "image $IMAGE absente -- construire d'abord :
     docker build -t $IMAGE scripts/ci/docker/linux-runner/"
+  assert_image_fresh "$IMAGE" "docker build -t $IMAGE scripts/ci/docker/linux-runner/"
   docker volume create "$TOOLCACHE_VOLUME" >/dev/null \
     || die "volume $TOOLCACHE_VOLUME impossible a creer -- docker volume create"
   # #14259 Defaut 1 : garde d'idempotence. `pgrep` n'existe PAS sous Git
@@ -368,6 +397,7 @@ cmd_waiters() {
   docker image inspect "$IMAGE" >/dev/null 2>&1 \
     || die "image $IMAGE absente -- construire d'abord :
     docker build -t $IMAGE scripts/ci/docker/linux-runner/"
+  assert_image_fresh "$IMAGE" "docker build -t $IMAGE scripts/ci/docker/linux-runner/"
   [ -f "$STOP_FILE" ] && die "sentinel STOP pose -- arreter d'abord ($0 stop)"
   # Idempotence propre a la famille waiters : le garde de `start` filtre
   # `supervise.sh start` et ne voit pas `waiters`. Verrou porte par le pid
@@ -396,6 +426,9 @@ cmd_lean() {
   docker image inspect "$LEAN_IMAGE" >/dev/null 2>&1 \
     || die "image $LEAN_IMAGE absente -- construire d'abord :
     docker build -t $LEAN_IMAGE -f scripts/ci/docker/linux-runner/Dockerfile.lean scripts/ci/docker/linux-runner/"
+  # Dockerfile.lean FROM coursia-linux-runner : l'entrypoint est herite de la
+  # base -- un ecart pointe soit vers l'image lean, soit vers sa base.
+  assert_image_fresh "$LEAN_IMAGE" "docker build -t $LEAN_IMAGE -f scripts/ci/docker/linux-runner/Dockerfile.lean scripts/ci/docker/linux-runner/"
   [ -f "$STOP_FILE" ] && die "sentinel STOP pose -- arreter d'abord ($0 stop)"
   # Idempotence calquee sur cmd_waiters : le garde PPID de `start` filtre
   # `supervise.sh start` et ne verrait pas `lean`. Verrou par pid file.

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -17,9 +17,17 @@ LOG="$TEST_DIR/test.log"
 ok() { echo "  PASS: $1"; }
 ko() { echo "  FAIL: $1"; }
 
-# Stubs docker + gh + ps.
-cat > "$TEST_DIR/bin/docker" <<'STUB'
+# Stubs docker + gh + ps. Le stub docker simule une image A JOUR pour le
+# garde de fraicheur #14801 : au probe `run --entrypoint sha256sum`, il rend
+# le sha256 du VRAI entrypoint.sh sibling (bake a la generation du stub).
+# STUB_IMG_ENTRYPOINT_SHA force un ecart pour tester le refus (test 9).
+REPO_ENTRYPOINT_SHA="$(sha256sum "$SCRIPT_DIR/entrypoint.sh" 2>/dev/null | awk '{print $1}')"
+cat > "$TEST_DIR/bin/docker" <<STUB
 #!/usr/bin/env bash
+if [ "\$1" = "run" ]; then
+  echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+  exit 0
+fi
 exit 0
 STUB
 chmod +x "$TEST_DIR/bin/docker"
@@ -191,10 +199,7 @@ if echo "$@" | grep -q 'actions/runners'; then echo '{"runners":[]}'; exit 0; fi
 exit 0
 STUB
   chmod +x "$TEST_DIR/bin7/gh"
-  cat > "$TEST_DIR/bin7/docker" <<'STUB'
-#!/usr/bin/env bash
-exit 0
-STUB
+  cp "$TEST_DIR/bin/docker" "$TEST_DIR/bin7/docker"
   chmod +x "$TEST_DIR/bin7/docker"
   cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin7/ps"
   export PATH="$TEST_DIR/bin7:$PATH"
@@ -256,5 +261,47 @@ STUB
   else
     ko "renvoi vers epinglage attendu"
   fi
+)
+echo ""
+
+# --- Test 9 : garde de fraicheur -- image perimee refuse (#14801) -----
+echo "Test 9 : start refuse si entrypoint de l'image != checkout (#14801)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-9"
+  STUB_IMG_ENTRYPOINT_SHA=f0000000000000000000000000000000000000000000000000000000000000f00
+  export STUB_IMG_ENTRYPOINT_SHA
+  rc="$(run_supervise 'start 1' 'test-prefix-9' "$TEST_DIR/state-9" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "PERIMEE" && echo "$err" | grep -q "docker build -t"; then
+    ok "image perimee refusee avec la commande de rebuild (rc=$rc)"
+  else
+    ko "refus attendu sur image perimee, rc=$rc err=$err"
+  fi
+  unset STUB_IMG_ENTRYPOINT_SHA
+)
+echo ""
+
+# --- Test 10 : garde de fraicheur -- image a jour ne bloque pas -----
+echo "Test 10 : start passe le garde quand l'image est a jour (#14801)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-10"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-10"
+  mkdir -p "$TEST_DIR/state-10"
+  timeout --kill-after=1 2 bash "$SCRIPT_DIR/supervise.sh" start 1 >"$TEST_DIR/out-10.log" 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  sleep 0.7
+  if grep -q "slots lances" "$TEST_DIR/out-10.log" && ! grep -q "PERIMEE" "$TEST_DIR/last.err"; then
+    ok "image a jour : garde passe, slots lances"
+  else
+    ko "le garde a tort ou le start a echoue, out=$(cat "$TEST_DIR/out-10.log") err=$(cat "$TEST_DIR/last.err")"
+  fi
+  pkill -P $TPID 2>/dev/null
+  pkill -f 'supervise.sh start' 2>/dev/null
+  wait 2>/dev/null
 )
 echo ""


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #14781

See #14801

## Summary

Piste (a) du commentaire ai-01 : **un correctif d'entrypoint merge mais non deploye est indiscernable d'un correctif absent** — #14385 est reste inerte 3 jours sur la moitie du parc (image du daemon docker-ce WSL construite 5 h AVANT le merge). Le demarrage d'un pool etant le seul point qui s'execute inconditionnellement (un job annule ne joue aucun step post), `assert_image_fresh()` y compare le sha256 du `entrypoint.sh` du checkout (sibling de supervise.sh) a celui embarque dans l'image (`docker run --rm --entrypoint sha256sum … /opt/runner/entrypoint.sh`) et **refuse de demarrer** — avec la commande de rebuild exacte — en cas d'ecart.

- Cable dans les **3 pools** : `start`, `waiters`, `lean` (Dockerfile.lean herite l'entrypoint de l'image base, la meme sonde le couvre).
- Meme place et meme forme que le `die "image absente"` existant (proposition verbatim du commentaire ai-01).
- Fail loud sur les 3 modes d'echec : sibling introuvable (lance hors checkout), sonde illisible (docker), ecart hash (PERIMEE + rebuild).
- Cout : un conteneur trivial (~1 s) par commande de pool, jamais par job.
- Le probe `/opt/runner/entrypoint.sh` est protege de la reecriture MSYS par le `MSYS_NO_PATHCONV=1` deja exporte en tete de script.

## Tests

`test_supervise_guards.sh` etendu : le stub docker repond au probe avec le sha du VRAI sibling (image a jour par defaut ; `STUB_IMG_ENTRYPOINT_SHA` force l'ecart).

- **Test 9** : hash image force different → `start` refuse, message `PERIMEE` + commande `docker build -t` presente.
- **Test 10** : hash image = checkout → garde passe, slots lances.
- Les 8 gardes #14259 existantes restent vertes — **13 PASS / 0 FAIL** au harnais complet.

## Hors scope (declares)

- Piste (b) (tag d'image derive du contenu) : la garde (a) suffit selon ai-01 ; (b) peut suivre si le besoin de visibilite `docker ps` se confirme.
- Le deploiement lui-meme (rebuild des images sur les 2 daemons) reste une operation operateur — ai-01 l'a faite manuellement 2026-09-05 21:00 UTC pour wsl-* ; cette garde empeche desormais que le prochain ecart passe inapercu.
- Contexte amont de la meme famille : PR #14815 (fail loud notebook-validation) rend visibles les workspaces incomplets cote CI pendant que cette garde les empeche cote runner.