### PR TITLE
feat(backtester,#7357): port strategy and results layer

### DIFF
--- a/MyIA.Trading.Backtester.Tests/Strategies/StrategyLayerTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Strategies/StrategyLayerTests.cs
@@ -1,0 +1,603 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Accord;
+using Accord.MachineLearning;
+using Accord.MachineLearning.VectorMachines;
+using Accord.MachineLearning.VectorMachines.Learning;
+using Accord.Statistics.Kernels;
+using FileHelpers;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Strategies
+{
+    /// <summary>
+    /// Tests de la tranche 6B-1 (EPIC #7357) : couche strategies et resultats
+    /// portee du fork MyIntelligenceAgency/Lean (sha 612dddf9) — MultiClassBoost,
+    /// ModelStrategy, BoostedStrategy, HodlStrategy, SimpleStopStrategy,
+    /// BackTestingSettings, CompareBackTestings, BacktestResult.
+    /// </summary>
+    public sealed class StrategyLayerTests
+    {
+        private sealed class FixedClassifier : IClassifier<double[], int>
+        {
+            private readonly int _label;
+
+            public FixedClassifier(int label)
+            {
+                _label = label;
+            }
+
+            public int Decide(double[] input)
+            {
+                return _label;
+            }
+
+            public int[] Decide(double[][] input)
+            {
+                return input.Select(_ => _label).ToArray();
+            }
+
+            public int[] Decide(double[][] input, int[] result)
+            {
+                for (int i = 0; i < input.Length; i++)
+                {
+                    result[i] = _label;
+                }
+
+                return result;
+            }
+
+            public int Transform(double[] input)
+            {
+                return _label;
+            }
+
+            public int[] Transform(double[][] input)
+            {
+                return input.Select(_ => _label).ToArray();
+            }
+
+            public int[] Transform(double[][] input, int[] result)
+            {
+                for (int i = 0; i < input.Length; i++)
+                {
+                    result[i] = _label;
+                }
+
+                return result;
+            }
+
+            public int NumberOfClasses { get; set; }
+
+            public int NumberOfInputs { get; set; }
+
+            public int NumberOfOutputs { get; set; }
+        }
+
+        private sealed class FixedTradingModel : ITradingModel
+        {
+            private readonly double _output;
+
+            public FixedTradingModel(double output)
+            {
+                _output = output;
+            }
+
+            public IList<TradingTrainingSample> Predict(IList<TradingTrainingSample> inputs)
+            {
+                var toReturn = new List<TradingTrainingSample>();
+                foreach (var input in inputs)
+                {
+                    toReturn.Add(new TradingTrainingSample
+                    {
+                        Inputs = input.Inputs,
+                        Sample = input.Sample,
+                        Output = _output
+                    });
+                }
+
+                return toReturn;
+            }
+        }
+
+        /// <summary>
+        /// Config SVM de test : l'entrainement est remplace par un mini-SVM reel
+        /// (6 points, 3 classes separees, SMO — quelques millisecondes), sans
+        /// aucun acces disque ni reseau — sert les tests de BackTestingSettings
+        /// et BoostedStrategy. Un MSVM non entraine ne peut pas Decide (etat
+        /// interne null chez Accord), d'ou l'entrainement minimal.
+        /// </summary>
+        private sealed class StubSvmModelConfig : TradingSvmModelConfig
+        {
+            public const double TrainedTestError = 0.42D;
+
+            public override ITradingModel TrainModel(
+                Action<string> logger, TradingTrainingDataConfig dataConfig, ref double testError)
+            {
+                testError = TrainedTestError;
+                var inputs = new[]
+                {
+                    new[] { 0.0D, 0.0D }, new[] { 0.1D, 0.1D },
+                    new[] { 5.0D, 5.0D }, new[] { 5.1D, 5.1D },
+                    new[] { -5.0D, 5.0D }, new[] { -5.1D, 5.1D }
+                };
+                var outputs = new[] { 0, 0, 1, 1, 2, 2 };
+                var teacher = new MulticlassSupportVectorLearning<IKernel>
+                {
+                    Learner = p => new SequentialMinimalOptimization<IKernel>
+                    {
+                        Complexity = 1D,
+                        Kernel = new Linear()
+                    }
+                };
+                return new SvmTradingModel { Svm = teacher.Learn(inputs, outputs) };
+            }
+        }
+
+        private static BackTestingSettings BuildStubSettings()
+        {
+            var modelsConfig = new TradingModelsConfig { SvmModelConfig = new StubSvmModelConfig() };
+            return new BackTestingSettings
+            {
+                TrainingConfig = new TradingTrainingConfig { ModelsConfig = modelsConfig }
+            };
+        }
+
+        private static MultiClassBoost BuildBoost(params int[] labels)
+        {
+            var weights = new List<double>();
+            var models = new List<IClassifier<double[], int>>();
+            foreach (var label in labels)
+            {
+                weights.Add(1D);
+                models.Add(new FixedClassifier(label));
+            }
+
+            return new MultiClassBoost(weights, models);
+        }
+
+        // --- MultiClassBoost -------------------------------------------------
+
+        [Fact]
+        public void MultiClassBoost_Decide_ResolvesClassByWeightedScoreThresholds()
+        {
+            // Difference 2 > 1 : classe 1.
+            Assert.Equal(1, BuildBoost(1, 1, 2, 1).Decide(new[] { 0.1D }));
+            // Difference 2 > 1 dans l'autre sens : classe 2.
+            Assert.Equal(2, BuildBoost(2, 2, 1, 2).Decide(new[] { 0.1D }));
+            // Egalite parfaite : neutre.
+            Assert.Equal(0, BuildBoost(1, 2).Decide(new[] { 0.1D }));
+            // Difference exactement 1 : le seuil upstream est strictement superieur a 1.
+            Assert.Equal(0, BuildBoost(1, 1, 2).Decide(new[] { 0.1D }));
+        }
+
+        [Fact]
+        public void MultiClassBoost_DecideDetail_ListsEachWeakModelDecisionInOrder()
+        {
+            var boost = BuildBoost(1, 0, 2);
+
+            var details = boost.DecideDetail(new[] { 0.1D });
+
+            Assert.Equal(new List<int> { 1, 0, 2 }, details);
+        }
+
+        [Fact]
+        public void MultiClassBoost_Constructor_ThrowsWhenWeightsAndModelsDifferInCount()
+        {
+            var models = new List<IClassifier<double[], int>> { new FixedClassifier(1) };
+
+            Assert.Throws<DimensionMismatchException>(
+                () => new MultiClassBoost(new List<double> { 1D, 1D }, models));
+        }
+
+        [Fact]
+        public void MultiClassBoost_Add_AppendsWeightedModelUsedByDecide()
+        {
+            var boost = BuildBoost(2);
+            boost.Add(3D, new FixedClassifier(1));
+
+            // score1 = 3, score2 = 1 : difference 2 > 1 -> classe 1.
+            Assert.Equal(1, boost.Decide(new[] { 0.1D }));
+            Assert.Equal(2, boost.Models.Count);
+            Assert.Equal(3D, boost[1].Weight);
+        }
+
+        // --- BoostedStrategy --------------------------------------------------
+
+        [Fact]
+        public void BoostedStrategy_Constructor_BuildsNonNullBoostedEnsembleFromSvmModels()
+        {
+            // Preuve de la reparation du cast invariant : le corps upstream
+            // (`models as IList<IClassifier<double[], int>>` rend null, IList<T>
+            // etant invariant) levait NullReferenceException au premier
+            // constructeur. La conversion explicite doit produire un ensemble
+            // utilisable, non vide.
+            var strategy = new BoostedStrategy(new List<BackTestingSettings> { BuildStubSettings() });
+
+            // L'ensemble est verifie via Model.Classifier (le wrapper
+            // ClassifierTradingModel). Le getter upstream `MultiClassBoost`
+            // castait Model lui-meme en MultiClassBoost et leverait toujours
+            // InvalidCastException — defaut repare, la propriete doit rendre
+            // le meme ensemble.
+            var wrapper = Assert.IsType<ClassifierTradingModel>(strategy.Model);
+            var ensemble = Assert.IsType<MultiClassBoost>(wrapper.Classifier);
+            Assert.Single(ensemble.Models);
+            Assert.Equal(1D, ensemble.Models[0].Weight);
+            Assert.NotNull(ensemble.Models[0].Model);
+
+            // Propriete reparee : meme instance d'ensemble.
+            Assert.Same(ensemble, strategy.MultiClassBoost);
+
+            // DecideDetail traversable au travers de la propriete (une decision
+            // par modele faible, ici le mini-SVM entraine du stub). Assertion de
+            // cardinalite seulement, pas de label exact — non brittle.
+            var details = strategy.MultiClassBoost.DecideDetail(new[] { 0.1D, 0.2D });
+            Assert.Single(details);
+
+            // GetResult desormais atteignable : les retours conditionnels sur
+            // les scores etant commentes en upstream, il renvoie toujours 0.
+            var sample = new TradingTrainingSample { Inputs = new List<double> { 0.1D, 0.2D } };
+            Assert.Equal(0, strategy.GetResult(sample,
+                new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc)));
+        }
+
+        // --- HodlStrategy -----------------------------------------------------
+
+        [Fact]
+        public void HodlStrategy_ComputeNewOrders_NeverIssuesOrders()
+        {
+            var strategy = new HodlStrategy();
+            var currentOrders = new Wallet();
+            var newOrders = new Wallet { PrimaryBalance = 2m, SecondaryBalance = 500m };
+            var market = new MarketInfo(new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc))
+            {
+                Ticker = new Ticker(100m)
+            };
+            var context = new TradingContext(currentOrders, newOrders, market, new ExchangeInfo(),
+                TradingTrend.Neutral, strategy);
+
+            strategy.ComputeNewOrders(ref context);
+
+            Assert.Empty(newOrders.Orders);
+            Assert.Empty(currentOrders.Orders);
+        }
+
+        // --- SimpleStopStrategy -------------------------------------------------
+
+        private static TradingContext BuildStopContext(
+            Wallet newOrders, decimal price, DateTime time, SimpleStopStrategy strategy)
+        {
+            var market = new MarketInfo(time, new Ticker(price), null, null);
+            return new TradingContext(new Wallet(), newOrders, market, new ExchangeInfo(),
+                TradingTrend.Neutral, strategy);
+        }
+
+        private static void RunStop(SimpleStopStrategy strategy, ref TradingContext context)
+        {
+            strategy.ComputeNewOrders(ref context);
+        }
+
+        [Fact]
+        public void SimpleStopStrategy_ComputeNewOrders_ThrowsWhenOpenOrdersRemain()
+        {
+            var strategy = new SimpleStopStrategy();
+            var currentOrders = new Wallet
+            {
+                Orders = new List<Order> { new Order(OrderType.Buy, 100m, 1m) }
+            };
+            var market = new MarketInfo(new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc))
+            {
+                Ticker = new Ticker(100m)
+            };
+            var context = new TradingContext(currentOrders, new Wallet { PrimaryBalance = 1m },
+                market, new ExchangeInfo(), TradingTrend.Neutral, strategy);
+
+            Assert.Throws<InvalidOperationException>(() => RunStop(strategy, ref context));
+        }
+
+        [Fact]
+        public void SimpleStopStrategy_NoOrderUntilStopIsHitThenSellsAtDiscount()
+        {
+            var strategy = new SimpleStopStrategy();
+            var startTime = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            // Portefeuille charge en actif primaire : suivi d'un stop de vente.
+            var newOrders = new Wallet { PrimaryBalance = 10m, SecondaryBalance = 100m };
+
+            var context = BuildStopContext(newOrders, 100m, startTime, strategy);
+            strategy.ComputeNewOrders(ref context);
+            // Prix 100 > stop 80 : pas d'ordre.
+            Assert.Empty(newOrders.Orders);
+
+            // Chute sous le stop (80) : vente a 0.99 x prix du solde primaire.
+            context = BuildStopContext(newOrders, 79m, startTime.AddHours(1), strategy);
+            strategy.ComputeNewOrders(ref context);
+
+            var sell = Assert.Single(newOrders.Orders);
+            Assert.Equal(OrderType.Sell, sell.OrderType);
+            Assert.Equal(79m * 0.99m, sell.Price);
+            Assert.Equal(10m, sell.Amount);
+        }
+
+        [Fact]
+        public void SimpleStopStrategy_RefactoryPeriodBlocksThenAllowsReEngagement()
+        {
+            var strategy = new SimpleStopStrategy { RefactoryPeriod = TimeSpan.FromDays(5) };
+            var startTime = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            var newOrders = new Wallet { PrimaryBalance = 10m, SecondaryBalance = 100m };
+
+            var context = BuildStopContext(newOrders, 100m, startTime, strategy);
+            strategy.ComputeNewOrders(ref context);
+            context = BuildStopContext(newOrders, 79m, startTime.AddHours(1), strategy);
+            strategy.ComputeNewOrders(ref context);
+            Assert.Single(newOrders.Orders);
+
+            // Apres l'engagement, suivi Buy avec stop a 79 x 1.2 = 94.8. Prix 95
+            // > 94.8 mais garde strictement superieure a +5 j non passee : rien.
+            context = BuildStopContext(newOrders, 95m, startTime.AddHours(2), strategy);
+            strategy.ComputeNewOrders(ref context);
+            Assert.Single(newOrders.Orders);
+
+            // Hors refraction (garde strictement >), fonds secondaires suffisants :
+            // achat a 1.01 x prix d'un montant SecondaryBalance / prix.
+            newOrders.SecondaryBalance = 5_000m;
+            context = BuildStopContext(newOrders, 95m, startTime.AddHours(1).Add(TimeSpan.FromDays(5)).AddSeconds(1), strategy);
+            strategy.ComputeNewOrders(ref context);
+
+            Assert.Equal(2, newOrders.Orders.Count);
+            var buy = newOrders.Orders[1];
+            Assert.Equal(OrderType.Buy, buy.OrderType);
+            Assert.Equal(95m * 1.01m, buy.Price);
+            Assert.Equal(5_000m / (95m * 1.01m), buy.Amount);
+        }
+
+        [Fact]
+        public void SimpleStopStrategy_SellStopRatchetsUpWithRisingPrices()
+        {
+            var strategy = new SimpleStopStrategy();
+            var startTime = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            var newOrders = new Wallet { PrimaryBalance = 10m, SecondaryBalance = 100m };
+
+            // Initialisation du suivi : stop de vente a 100 x 0.8 = 80.
+            var context = BuildStopContext(newOrders, 100m, startTime, strategy);
+            strategy.ComputeNewOrders(ref context);
+
+            // Hausse a 150 : le stop de vente suit a la hausse (150 x 0.8 = 120),
+            // toujours pas d'engagement tant que le prix reste au-dessus.
+            context = BuildStopContext(newOrders, 150m, startTime.AddHours(1), strategy);
+            strategy.ComputeNewOrders(ref context);
+            Assert.Empty(newOrders.Orders);
+
+            // Retombee a 119, sous le stop remonte : engagement de la vente.
+            context = BuildStopContext(newOrders, 119m, startTime.AddHours(2), strategy);
+            strategy.ComputeNewOrders(ref context);
+
+            var sell = Assert.Single(newOrders.Orders);
+            Assert.Equal(OrderType.Sell, sell.OrderType);
+            Assert.Equal(119m * 0.99m, sell.Price);
+        }
+
+        // --- ModelStrategy -----------------------------------------------------
+
+        private static TradingTrainingConfig BuildTrainingConfig()
+        {
+            return new TradingTrainingConfig
+            {
+                DataConfig = new TradingTrainingDataConfig
+                {
+                    SampleConfig = new TradingSampleConfig
+                    {
+                        LeftWindow = TimeSpan.FromDays(4),
+                        ConstantSliceSpan = TimeSpan.FromDays(1),
+                        SamplingMode = SamplingMode.Constant
+                    }
+                }
+            };
+        }
+
+        private static List<OrderTrade> BuildDailyTrades(DateTime targetTime, decimal price)
+        {
+            var trades = new List<OrderTrade>();
+            for (int offset = 4; offset >= 0; offset--)
+            {
+                trades.Add(new OrderTrade
+                {
+                    Time = targetTime.Subtract(TimeSpan.FromDays(offset)),
+                    Price = price,
+                    Amount = 1m
+                });
+            }
+
+            return trades;
+        }
+
+        private static TradingContext BuildModelContext(
+            ModelStrategy strategy, DateTime time, decimal price, Wallet newOrders,
+            List<OrderTrade> recentTrades)
+        {
+            var market = new MarketInfo(time, new Ticker(price), null, null);
+            market.RecentTrades = recentTrades;
+            return new TradingContext(new Wallet(), newOrders, market, new ExchangeInfo(),
+                TradingTrend.Neutral, strategy);
+        }
+
+        private static ModelStrategy BuildStrategy(double output)
+        {
+            return new ModelStrategy
+            {
+                Model = new FixedTradingModel(output),
+                TrainingConfig = BuildTrainingConfig(),
+                Logger = _ => { }
+            };
+        }
+
+        [Fact]
+        public void ModelStrategy_GetResult_ReturnsModelPredictionAsClassLabel()
+        {
+            var strategy = new ModelStrategy { Model = new FixedTradingModel(2) };
+            var sample = new TradingTrainingSample { Inputs = new List<double> { 0.5D } };
+
+            Assert.Equal(2, strategy.GetResult(sample, DateTime.UtcNow));
+        }
+
+        [Fact]
+        public void ModelStrategy_BuySignalPlacesBuyLimitOrderAtOnePercentMargin()
+        {
+            var time = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            var newOrders = new Wallet { PrimaryBalance = 1m, SecondaryBalance = 1_000m };
+            var strategy = BuildStrategy(1);
+
+            var context = BuildModelContext(strategy, time, 100m, newOrders, BuildDailyTrades(time, 100m));
+            strategy.ComputeNewOrders(ref context);
+
+            var order = Assert.Single(newOrders.Orders);
+            Assert.Equal(OrderType.Buy, order.OrderType);
+            Assert.Equal(100m * 1.01m, order.Price);
+            Assert.Equal(newOrders.SecondaryBalance / (100m * 1.01m), order.Amount);
+        }
+
+        [Fact]
+        public void ModelStrategy_SellSignalPlacesSellLimitOrderAtOnePercentDiscount()
+        {
+            var time = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            var newOrders = new Wallet { PrimaryBalance = 10m, SecondaryBalance = 100m };
+            var strategy = BuildStrategy(2);
+
+            var context = BuildModelContext(strategy, time, 100m, newOrders, BuildDailyTrades(time, 100m));
+            strategy.ComputeNewOrders(ref context);
+
+            var order = Assert.Single(newOrders.Orders);
+            Assert.Equal(OrderType.Sell, order.OrderType);
+            Assert.Equal(100m * 0.99m, order.Price);
+            Assert.Equal(10m, order.Amount);
+        }
+
+        [Fact]
+        public void ModelStrategy_NeutralSignalPlacesNothingAndWindowBlocksRepeatSignals()
+        {
+            var time = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            var newOrders = new Wallet { PrimaryBalance = 1m, SecondaryBalance = 1_000m };
+
+            var neutral = BuildStrategy(0);
+            var context = BuildModelContext(neutral, time, 100m, newOrders, BuildDailyTrades(time, 100m));
+            neutral.ComputeNewOrders(ref context);
+            Assert.Empty(newOrders.Orders);
+
+            // Fenetre OutputPrediction (5 h par defaut) non ecoulee apres un
+            // achat : le signal suivant est ignore, aucun second ordre.
+            var buyer = BuildStrategy(1);
+            context = BuildModelContext(buyer, time, 100m, newOrders, BuildDailyTrades(time, 100m));
+            buyer.ComputeNewOrders(ref context);
+            Assert.Single(newOrders.Orders);
+
+            var later = time.AddHours(1);
+            context = BuildModelContext(buyer, later, 101m, newOrders, BuildDailyTrades(later, 101m));
+            buyer.ComputeNewOrders(ref context);
+            Assert.Single(newOrders.Orders);
+        }
+
+        // --- BackTestingSettings ------------------------------------------------
+
+        [Fact]
+        public void BackTestingSettings_GetResult_ReturnsLastWalletTotalAtLastTickerPrice()
+        {
+            var settings = new BackTestingSettings
+            {
+                Results = new TradingHistory
+                {
+                    LastWallet = new Wallet { PrimaryBalance = 2m, SecondaryBalance = 500m },
+                    LastTicker = new Ticker(250m)
+                }
+            };
+
+            // Total = secondaire + primaire x dernier prix = 500 + 2 x 250.
+            Assert.Equal(1_000m, settings.GetResult());
+        }
+
+        [Fact]
+        public void BackTestingSettings_GetModelStrategy_TrainsOnceCachesAppliesZeroReservesAndResets()
+        {
+            var settings = BuildStubSettings();
+
+            var first = settings.GetModelStrategy(_ => { });
+            var second = settings.GetModelStrategy(_ => { });
+
+            Assert.NotNull(first);
+            Assert.Same(first, second);
+            Assert.Equal(StubSvmModelConfig.TrainedTestError, settings.TestError);
+            Assert.Equal(0m, first.AskReserveRate);
+            Assert.Equal(0m, first.BidReserveRate);
+
+            // Reaffecter TrainingConfig invalide la strategie cachee.
+            settings.TrainingConfig = new TradingTrainingConfig
+            {
+                ModelsConfig = new TradingModelsConfig { SvmModelConfig = new StubSvmModelConfig() }
+            };
+            var third = settings.GetModelStrategy(_ => { });
+            Assert.NotSame(first, third);
+        }
+
+        // --- CompareBackTestings --------------------------------------------------
+
+        [Fact]
+        public void CompareBackTestings_EqualsMatchesModelNameAndHandlesNulls()
+        {
+            var comparer = new CompareBackTestings();
+            var settings = new BackTestingSettings();
+
+            Assert.True(comparer.Equals(null, null));
+            Assert.False(comparer.Equals(settings, null));
+            Assert.False(comparer.Equals(null, settings));
+
+            // Noms de modeles identiques (config par defaut) : egalite + hash cohérent.
+            Assert.True(comparer.Equals(settings, new BackTestingSettings()));
+            Assert.Equal(comparer.GetHashCode(settings), comparer.GetHashCode(new BackTestingSettings()));
+
+            // Taille d'ensemble d'entrainement differente -> nom different -> inegalite.
+            var other = new BackTestingSettings
+            {
+                TrainingConfig = new TradingTrainingConfig
+                {
+                    DataConfig = new TradingTrainingDataConfig { TrainNb = 3_000 }
+                }
+            };
+            Assert.False(comparer.Equals(settings, other));
+        }
+
+        // --- BacktestResult --------------------------------------------------
+
+        [Fact]
+        public void BacktestResult_DelimitedRecord_SerializesAndRoundTripsWithSemicolons()
+        {
+            var engine = new FileHelperEngine<BacktestResult>();
+            var record = new BacktestResult
+            {
+                BackTestPeriod = "2018-2019",
+                ModelName = "svm-kernel-test",
+                TestError = 0.25D,
+                Result = 1_500m,
+                TradeNb = 12,
+                Trade1 = "Buy@100",
+                Trade2 = "Sell@120"
+            };
+
+            var csv = engine.WriteString(new[] { record });
+            var lines = csv.Replace("\r\n", "\n").Split('\n');
+
+            // WriteString n'emet pas d'en-tete par defaut : la premiere ligne est
+            // l'enregistrement, delimite par des points-virgules.
+            Assert.StartsWith("2018-2019;svm-kernel-test;", lines[0]);
+            Assert.Contains("Buy@100", lines[0]);
+            Assert.Contains("Sell@120", lines[0]);
+
+            var parsed = engine.ReadString(csv);
+            Assert.Single(parsed);
+            Assert.Equal("2018-2019", parsed[0].BackTestPeriod);
+            Assert.Equal("svm-kernel-test", parsed[0].ModelName);
+            Assert.Equal(0.25D, parsed[0].TestError);
+            Assert.Equal(1_500m, parsed[0].Result);
+            Assert.Equal(12, parsed[0].TradeNb);
+            Assert.Equal("Buy@100", parsed[0].Trade1);
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/BackTestingSettings.cs
+++ b/MyIA.Trading.Backtester/BackTestingSettings.cs
@@ -1,0 +1,60 @@
+using System;
+using Accord.MachineLearning;
+using Accord.MachineLearning.VectorMachines;
+using Accord.Statistics.Kernels;
+using MyIA.Trading.Backtester;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+    public class BackTestingSettings
+    {
+        public TradingTrainingConfig TrainingConfig
+        {
+            get => _trainingConfig;
+            set
+            {
+                _Strategy = null;
+                _trainingConfig = value;
+            }
+        }
+
+        public double TestError { get; set; }
+
+        public TradingHistory Results { get; set; }
+
+        private ModelStrategy _Strategy;
+        private TradingTrainingConfig _trainingConfig = new TradingTrainingConfig();
+
+        public ModelStrategy GetModelStrategy(Action<string> logger)
+        {
+            if (_Strategy == null)
+            {
+                double testError = double.MinValue;
+                ITradingModel model = TrainingConfig.TrainModel(logger,ref testError);
+                TestError = testError;
+                if (model != null)
+                {
+                    _Strategy= new ModelStrategy()
+                    {
+                        Model = model,
+                        TrainingConfig = TrainingConfig,
+                        Logger = logger,
+                        AskReserveRate = 0,
+                        BidReserveRate = 0
+                    };
+                }
+            }
+
+
+            return _Strategy;
+        }
+
+        public decimal GetResult()
+        {
+            return Results.LastWallet.GetBalance(Results.LastTicker).Total;
+        }
+
+
+    }
+}

--- a/MyIA.Trading.Backtester/BacktestResult.cs
+++ b/MyIA.Trading.Backtester/BacktestResult.cs
@@ -1,0 +1,93 @@
+using System;
+using FileHelpers;
+
+namespace MyIA.Trading.Backtester
+{
+    [DelimitedRecord(";")]
+    public class BacktestResult
+    {
+
+        public string BackTestPeriod { get; set; }
+        public string ModelName { get; set; }
+
+        public  double TestError { get; set; }
+        public decimal Result { get; set; }
+        public int TradeNb { get; set; }
+
+        public string Trade1 { get; set; }
+        public string Trade2 { get; set; }
+        public string Trade3 { get; set; }
+        public string Trade4 { get; set; }
+        public string Trade5 { get; set; }
+        public string Trade6 { get; set; }
+        public string Trade7 { get; set; }
+        public string Trade8 { get; set; }
+        public string Trade9 { get; set; }
+        public string Trade10 { get; set; }
+        public string Trade11 { get; set; }
+        public string Trade12 { get; set; }
+        public string Trade13 { get; set; }
+        public string Trade14 { get; set; }
+
+        public string Trade15 { get; set; }
+
+        public string Trade16 { get; set; }
+        public string Trade17 { get; set; }
+        public string Trade18 { get; set; }
+        public string Trade19 { get; set; }
+        public string Trade20 { get; set; }
+        public string Trade21 { get; set; }
+        public string Trade22 { get; set; }
+        public string Trade23 { get; set; }
+        public string Trade24 { get; set; }
+        public string Trade25 { get; set; }
+        public string Trade26 { get; set; }
+        public string Trade27 { get; set; }
+        public string Trade28 { get; set; }
+        public string Trade29 { get; set; }
+        public string Trade30 { get; set; }
+        public string Trade31 { get; set; }
+        public string Trade32 { get; set; }
+        public string Trade33 { get; set; }
+        public string Trade34 { get; set; }
+        public string Trade35 { get; set; }
+        public string Trade36 { get; set; }
+        public string Trade37 { get; set; }
+        public string Trade38 { get; set; }
+        public string Trade39 { get; set; }
+        public string Trade40 { get; set; }
+        public string Trade41 { get; set; }
+        public string Trade42 { get; set; }
+        public string Trade43 { get; set; }
+        public string Trade44 { get; set; }
+        public string Trade45 { get; set; }
+        public string Trade46 { get; set; }
+        public string Trade47 { get; set; }
+        public string Trade48 { get; set; }
+        public string Trade49 { get; set; }
+        public string Trade50 { get; set; }
+        public string Trade51 { get; set; }
+        public string Trade52 { get; set; }
+        public string Trade53 { get; set; }
+        public string Trade54 { get; set; }
+        public string Trade55 { get; set; }
+        public string Trade56 { get; set; }
+        public string Trade57 { get; set; }
+        public string Trade58 { get; set; }
+        public string Trade59 { get; set; }
+        public string Trade60 { get; set; }
+        public string Trade61 { get; set; }
+        public string Trade62 { get; set; }
+        public string Trade63 { get; set; }
+        public string Trade64 { get; set; }
+        public string Trade65 { get; set; }
+        public string Trade66 { get; set; }
+        public string Trade67 { get; set; }
+        public string Trade68 { get; set; }
+        public string Trade69 { get; set; }
+
+
+
+
+    }
+}

--- a/MyIA.Trading.Backtester/BoostedStrategy.cs
+++ b/MyIA.Trading.Backtester/BoostedStrategy.cs
@@ -1,0 +1,116 @@
+﻿// Port tranche 6B-1 (EPIC #7357) : corps du fork MyIntelligenceAgency/Lean
+// (branche MyIABacktesting_integration, sha 612dddf9). Trois ecarts documentes :
+//   1. `Program.Log` (classe du binaire console upstream, hors perimetre du
+//      port de bibliotheque) remplacee par une methode statique equivalente —
+//      meme canal console, meme portee statique.
+//   2. REPARATION d'un defaut upstream confirme (cf precedent CalibrateComplexity,
+//      tranche 4) : le corps original construisait l'ensemble via
+//      `models as IList<IClassifier<double[], int>>`. IList<T> etant invariant,
+//      ce `as` rend TOUJOURS null sur un List<MulticlassSupportVectorMachine<IKernel>>,
+//      et MultiClassBoost(weights, null) levait NullReferenceException sur son
+//      controle de dimensions au premier constructeur. Remplace par une
+//      conversion explicite `models.Cast<IClassifier<double[], int>>().ToList()`,
+//      qui retablit le comportement evidemment voulu (construire l'ensemble).
+//   3. REPARATION d'un second defaut upstream confirme, meme famille : le getter
+//      original `MultiClassBoost => (MultiClassBoost) Model` castait Model
+//      lui-meme, alors que le constructeur y range un wrapper ClassifierTradingModel
+//      dont la propriete Classifier porte l'ensemble — InvalidCastException
+//      systematique, rendant GetResult inatteignable. Le getter lit desormais
+//      `((ClassifierTradingModel)Model).Classifier` et caste ce classifieur.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Accord.MachineLearning;
+using Accord.MachineLearning.Boosting;
+using Accord.Statistics;
+using MyIA.Trading.Backtester;
+
+namespace MyIA.Trading.Backtester
+{
+    public class BoostedStrategy : ModelStrategy
+    {
+
+        private static void Log(string message)
+        {
+            Console.WriteLine(message);
+        }
+
+        public BoostedStrategy(List<BackTestingSettings> configs)
+        {
+            _Configs = configs;
+            var models = _Configs.Select(objBack => objBack.GetModelStrategy(Log).Model).Cast<SvmTradingModel>().Select(objTradingModel=> objTradingModel.Svm).ToList();
+            var weights = _Configs.Select(objBack => 1D).ToList();
+            Model = new ClassifierTradingModel()
+                {Classifier = new MultiClassBoost(weights, models.Cast<IClassifier<double[], int>>().ToList())};
+        }
+
+        private List<BackTestingSettings> _Configs;
+
+        private Dictionary<int, Tuple<int,DateTime>> TargetDates = new  Dictionary<int, Tuple<int, DateTime>>();
+
+        public MultiClassBoost MultiClassBoost => (MultiClassBoost)((ClassifierTradingModel)Model).Classifier;
+
+        public override int GetResult(TradingTrainingSample objInputs, DateTime time)
+        {
+
+            var details = MultiClassBoost.DecideDetail(objInputs.Inputs.ToArray());
+            for (var index = 0; index < details.Count; index++)
+            {
+                Tuple<int, DateTime> target;
+                if (!TargetDates.TryGetValue(index, out target) || target.Item2 < time)
+                {
+                    var classified = details[index];
+                    var config = _Configs[index];
+                    if (classified != 0)
+                    {
+                        //target = new Tuple<int, DateTime>(classified, time.Add(config.TrainingConfig.OutputPrediction));
+                        target = new Tuple<int, DateTime>(classified, time);//.Add(TimeSpan.FromHours(2)));
+                        TargetDates[index] = target;
+                    }
+                }
+            }
+
+            var score1 = TargetDates.Count(objPair => objPair.Value.Item1 == 1 && objPair.Value.Item2 >= time);
+            var score2 = TargetDates.Count(objPair => objPair.Value.Item1 == 2 && objPair.Value.Item2 >= time);
+            //if ((TargetOrder == null || TargetOrder.OrderType == OrderType.Sell) &&  score2 > 4)
+            //{
+            //    Program.Log($"Date: {time.ToString(CultureInfo.InvariantCulture)} Engaging 2 with score diff: score1 = {score1}, score2 ={score2} ");
+            //    return 2;
+            //}
+            //if ((TargetOrder == null || TargetOrder.OrderType == OrderType.Buy) && score1 > 15 && score2 < 2)
+            //{
+            //    Program.Log($"Date: {time.ToString(CultureInfo.InvariantCulture)} Engaging 1 with score diff: score1 = {score1}, score2 ={score2} ");
+            //    return 1;
+            //}
+
+            //if ((TargetOrder == null || TargetOrder.OrderType == OrderType.Sell) && 4*score2 - score1 > 2 )
+            //{
+            //    Program.Log($"Date: {time.ToString(CultureInfo.InvariantCulture)} Engaging 2 with score diff: score1 = {score1}, score2 ={score2} ");
+            //    return 2;
+            //}
+            //if ((TargetOrder == null || TargetOrder.OrderType == OrderType.Buy) && score1 - 4 * score2 > 2)
+            //{
+            //    Program.Log($"Date: {time.ToString(CultureInfo.InvariantCulture)} Engaging 1 with score diff: score1 = {score1}, score2 ={score2} ");
+            //    return 1;
+            //}
+
+
+            if (time > _TargetReportTime)
+            {
+                Log($"Date: {time.ToString(CultureInfo.InvariantCulture)} score1 = {score1}, score2 ={score2} ");
+                _TargetReportTime.Add(TimeSpan.FromHours(2));
+            }
+
+
+            return 0;
+
+
+        }
+
+        private DateTime _TargetReportTime = DateTime.MinValue;
+
+    }
+
+
+}

--- a/MyIA.Trading.Backtester/CompareBackTestings.cs
+++ b/MyIA.Trading.Backtester/CompareBackTestings.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MyIA.Trading.Backtester
+{
+    public class CompareBackTestings : IEqualityComparer<BackTestingSettings>
+    {
+        public bool Equals(BackTestingSettings item1, BackTestingSettings item2)
+        {
+            if (item1 == null && item2 == null)
+                return true;
+            else if ((item1 != null && item2 == null) ||
+                     (item1 == null && item2 != null))
+                return false;
+
+            return String.Equals(item1.TrainingConfig.GetModelName(), item2.TrainingConfig.GetModelName(), StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(BackTestingSettings item)
+        {
+            return item.TrainingConfig.GetModelName().GetHashCode();
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/HodlStrategy.cs
+++ b/MyIA.Trading.Backtester/HodlStrategy.cs
@@ -1,0 +1,19 @@
+﻿using MyIA.Trading.Backtester;
+
+namespace MyIA.Trading.Backtester
+{
+    public class HodlStrategy : TradingStrategyBase
+    {
+
+
+
+        public override void ComputeNewOrders(ref TradingContext tContext)
+        {
+
+
+
+        }
+    }
+
+
+}

--- a/MyIA.Trading.Backtester/ModelStrategy.cs
+++ b/MyIA.Trading.Backtester/ModelStrategy.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Accord.MachineLearning;
+using MyIA.Trading.Backtester;
+
+namespace MyIA.Trading.Backtester
+{
+    public class ModelStrategy : TradingStrategyBase
+    {
+
+        public string FriendlyId => $"{TrainingConfig.GetModelName()}";
+
+        public Action<string> Logger { get; set; }
+
+        public TradingTrainingConfig TrainingConfig { get; set; }
+        public ITradingModel Model { get; set; }
+
+        private DateTime _TargetTime = DateTime.MinValue;
+
+        protected Order TargetOrder;
+
+        private DateTime _WeeklyTargetMarket = DateTime.MinValue;
+        public override void ComputeNewOrders(ref TradingContext tContext)
+        {
+            if (tContext.Market.Time> _WeeklyTargetMarket)
+            {
+                _WeeklyTargetMarket = tContext.Market.Time.Add(TimeSpan.FromDays(7));
+                Logger($"Date: {tContext.Market.Time}, Price: {tContext.Market.Ticker.Last}");
+            }
+            Order newOrder = null;
+            var objBalance = tContext.NewOrders.GetBalance(tContext.Market.Ticker);
+            if (tContext.CurrentOrders.Orders.Count > 0)
+            {
+                foreach (Order order in tContext.CurrentOrders.Orders)
+                {
+                    tContext.NewOrders.CancelExistingOrders(order);
+
+                    if (order.OrderType == OrderType.Sell)
+                    {
+                        var objPrice = tContext.Market.Ticker.Last * 0.995M;
+                        newOrder = new Order() { OrderType = OrderType.Sell, Price = objPrice, Amount = tContext.NewOrders.PrimaryBalance };
+                    }
+                    else
+                    {
+
+                        var objPrice = tContext.Market.Ticker.Last * 1.005M;
+                        newOrder = new Order() { OrderType = OrderType.Buy, Price = objPrice, Amount = tContext.NewOrders.SecondaryBalance / objPrice };
+
+                    }
+
+                }
+                //_TargetTime = DateTime.MinValue;
+            }
+            else
+            {
+                if (tContext.Market.Time > _TargetTime)
+                {
+                    if (TargetOrder != null)
+                    {
+                        if (
+                            //    (_TargetOrder.OrderType == OrderType.Sell && tContext.Market.Ticker.Last / _TargetOrder.Price < (1 - TrainingConfig.OutputThresold)/100)
+                            //|| (_TargetOrder.OrderType == OrderType.Buy && tContext.Market.Ticker.Last / _TargetOrder.Price > (1 + TrainingConfig.OutputThresold) / 100)
+                            (TargetOrder.OrderType == OrderType.Sell && tContext.Market.Ticker.Last < TargetOrder.Price * (100 - TrainingConfig.StopLossRate) / 100)
+                            || (TargetOrder.OrderType == OrderType.Buy && tContext.Market.Ticker.Last > TargetOrder.Price * (100 + TrainingConfig.StopLossRate) / 100)
+                            )
+                        {
+                            Logger($" Date: {tContext.Market.Time.ToString(CultureInfo.InvariantCulture)}, Cancellation {tContext.Market.Ticker.Last} vs {TargetOrder.Price}, Wallet: {objBalance.Primary}BTC {objBalance.Secondary}USD, Total {objBalance.Total}USD   ");
+                            newOrder = Engage(ref tContext, TargetOrder.OrderType);
+                            TargetOrder = null;
+                        }
+                    }
+                    if (newOrder == null)
+                    {
+                        var objSample = TrainingConfig.DataConfig.SampleConfig.CreateInput(tContext.Market.RecentTrades, tContext.Market.RecentTrades.Count - 1);
+                        if (objSample != null)
+                        {
+                            var objInputs = TrainingConfig.DataConfig.GetTrainingData(objSample);
+
+                            var result = GetResult(objInputs, tContext.Market.Time);
+                            switch (result)
+                            {
+                                case 1:
+                                    newOrder = Engage(ref tContext, OrderType.Buy);
+                                    break;
+                                case 2:
+                                    newOrder = Engage(ref tContext, OrderType.Sell);
+                                    break;
+                            }
+
+                        }
+                    }
+
+                }
+
+            }
+            if (newOrder != null)
+            {
+                Logger($"{FriendlyId}");
+                Logger($" Date: {tContext.Market.Time.ToString(CultureInfo.InvariantCulture)}, {newOrder.FriendlyId}, Wallet: {objBalance.Primary}BTC {objBalance.Secondary}USD, Total {objBalance.Total}USD   ");
+                tContext.NewOrders.Orders.Add(newOrder);
+            }
+
+
+        }
+
+        public virtual int GetResult(TradingTrainingSample objInputs, DateTime time)
+        {
+            var objData = new List<TradingTrainingSample>();
+            objData.Add(objInputs);
+            var result = Model.Predict(objData);
+            return (int)result[0].Output;
+        }
+
+        private Order Engage(ref TradingContext tContext, OrderType orderType)
+        {
+            var objBalance = tContext.NewOrders.GetBalance(tContext.Market.Ticker);
+            Order newOrder = null;
+            if (orderType == OrderType.Sell)
+            {
+                if (objBalance.Value > (objBalance.Secondary * 2))
+                {
+                    var objPrice = tContext.Market.Ticker.Last * 0.99M;
+                    newOrder = new Order() { OrderType = orderType, Price = objPrice, Amount = tContext.NewOrders.PrimaryBalance };
+                }
+            }
+            else
+            {
+                if (objBalance.Secondary > (objBalance.Value * 2))
+                {
+                    var objPrice = tContext.Market.Ticker.Last * 1.01M;
+                    newOrder = new Order() { OrderType = orderType, Price = objPrice, Amount = tContext.NewOrders.SecondaryBalance / objPrice };
+                }
+            }
+            if (newOrder != null)
+            {
+                _TargetTime = tContext.Market.Time.Add(TrainingConfig.DataConfig.OutputPrediction);
+                decimal targetPrice;
+                if (newOrder.OrderType == OrderType.Buy)
+                {
+                    targetPrice = newOrder.Price; /*objBalance.Ticker.Last * (1 + TrainingConfig.OutputThresold / 100);*/
+                    TargetOrder = new Order() { OrderType = OrderType.Sell, Price = targetPrice, Amount = tContext.NewOrders.PrimaryBalance };
+                }
+                else
+                {
+                    targetPrice = newOrder.Price;// objBalance.Ticker.Last * (1 - TrainingConfig.OutputThresold / 100);
+                    TargetOrder = new Order() { OrderType = OrderType.Buy, Price = targetPrice, Amount = tContext.NewOrders.SecondaryBalance / targetPrice };
+                }
+
+            }
+            return newOrder;
+
+        }
+
+    }
+
+
+}

--- a/MyIA.Trading.Backtester/MultiClassBoost.cs
+++ b/MyIA.Trading.Backtester/MultiClassBoost.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Accord;
+using Accord.MachineLearning;
+using Accord.MachineLearning.Boosting;
+
+namespace MyIA.Trading.Backtester
+
+{
+
+
+    [Serializable]
+    public class MultiClassBoost : MultiClassBoost<IClassifier<double[], int>, Weighted<IClassifier<double[], int>>,
+        double[]>
+    {
+        public MultiClassBoost(IList<double> weights, IList<IClassifier<double[], int>> models) : base(weights, models)
+        {
+
+        }
+    }
+
+
+    /// <summary>Boosted classification model.</summary>
+    /// <typeparam name="TModel">The type of the weak classifier.</typeparam>
+    /// <typeparam name="TWeighted">The type of the weighted classifier.</typeparam>
+    /// <typeparam name="TInput">The type of the input vectors accepted by the classifier.</typeparam>
+    [Serializable]
+    public class MultiClassBoost<TModel, TWeighted, TInput> : MulticlassClassifierBase<TInput>, IEnumerable<TWeighted>, IEnumerable where TModel : IClassifier<TInput, int> where TWeighted : Weighted<TModel, TInput>, new()
+    {
+        /// <summary>
+        ///   Gets the list of weighted weak models
+        ///   contained in this boosted classifier.
+        /// </summary>
+        public List<TWeighted> Models { get; private set; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="T:Accord.MachineLearning.Boosting.Boost`1" /> class.
+        /// </summary>
+        public MultiClassBoost()
+        {
+            this.Models = new List<TWeighted>();
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="T:Accord.MachineLearning.Boosting.Boost`1" /> class.
+        /// </summary>
+        /// <param name="weights">The initial boosting weights.</param>
+        /// <param name="models">The initial weak classifiers.</param>
+        public MultiClassBoost(IList<double> weights, IList<TModel> models)
+        {
+            this.Models = new List<TWeighted>();
+            if (weights.Count != models.Count)
+                throw new DimensionMismatchException(nameof(models), "The number of models and weights must match.");
+            for (int index = 0; index < weights.Count; ++index)
+            {
+                List<TWeighted> models1 = this.Models;
+                TWeighted instance = Activator.CreateInstance<TWeighted>();
+                instance.Weight = weights[index];
+                instance.Model = models[index];
+                models1.Add(instance);
+            }
+        }
+
+        /// <summary>
+        /// Computes a class-label decision for a given <paramref name="input" />.
+        /// </summary>
+        /// <param name="input">The input vector that should be classified into
+        /// one of the <see cref="P:Accord.MachineLearning.ITransform.NumberOfOutputs" /> possible classes.</param>
+        /// <returns>A class-label that best described <paramref name="input" /> according
+        /// to this classifier.</returns>
+        public override int Decide(TInput input)
+        {
+            var scores = new Dictionary<int, double>();
+            foreach (TWeighted model in this.Models)
+            {
+                var classified = model.Model.Decide(input);
+                if (!scores.ContainsKey(classified))
+                {
+                    scores[classified] = 0;
+                }
+                scores[classified] += model.Weight;
+
+            }
+
+
+            double score1, score0, score2;
+            scores.TryGetValue(0, out score0);
+            scores.TryGetValue(1, out score1);
+            scores.TryGetValue(2, out score2);
+            if (score1-score2>1)
+            {
+                return 1;
+            }
+            if (score2 - score1 > 1)
+            {
+                return 2;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Computes a class-label decision for a given <paramref name="input" />.
+        /// </summary>
+        /// <param name="input">The input vector that should be classified into
+        /// one of the <see cref="P:Accord.MachineLearning.ITransform.NumberOfOutputs" /> possible classes.</param>
+        /// <returns>A class-label that best described <paramref name="input" /> according
+        /// to this classifier.</returns>
+        public List<int> DecideDetail(TInput input)
+        {
+            var scores = new List<int>(Models.Count);
+            for (var index = 0; index < this.Models.Count; index++)
+            {
+                TWeighted model = this.Models[index];
+                var classified = model.Model.Decide(input);
+                scores.Add(classified) ;
+            }
+
+
+            return scores;
+        }
+
+
+
+
+
+        /// <summary>
+        ///   Adds a new weak classifier and its corresponding
+        ///   weight to the end of this boosted classifier.
+        /// </summary>
+        /// <param name="weight">The weight of the weak classifier.</param>
+        /// <param name="model">The weak classifier</param>
+        public void Add(double weight, TModel model)
+        {
+            List<TWeighted> models = this.Models;
+            TWeighted instance = Activator.CreateInstance<TWeighted>();
+            instance.Weight = weight;
+            instance.Model = model;
+            models.Add(instance);
+        }
+
+        /// <summary>
+        ///   Gets or sets the <see cref="T:Accord.MachineLearning.Boosting.Weighted`1" /> at the specified index.
+        /// </summary>
+        public TWeighted this[int index]
+        {
+            get
+            {
+                return this.Models[index];
+            }
+            set
+            {
+                this.Models[index] = value;
+            }
+        }
+
+        /// <summary>
+        ///   Returns an enumerator that iterates through this collection.
+        /// </summary>
+        /// <returns>
+        ///   An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.
+        /// </returns>
+        public IEnumerator<TWeighted> GetEnumerator()
+        {
+            return (IEnumerator<TWeighted>)this.Models.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return (IEnumerator)this.Models.GetEnumerator();
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/SimpleStopStrategy.cs
+++ b/MyIA.Trading.Backtester/SimpleStopStrategy.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using MyIA.Trading.Backtester;
+
+namespace MyIA.Trading.Backtester
+{
+    public class SimpleStopStrategy : TradingStrategyBase
+    {
+
+        public Action<string> Logger { get; set; }
+        private DateTime _WeeklyTargetMarket = DateTime.MinValue;
+
+        public decimal StopRate { get; set; } = 0.2m;
+
+        public TimeSpan RefactoryPeriod { get; set; } = TimeSpan.FromDays(5);
+
+        private OrderType nextOrderType;
+        private decimal currentStop;
+        private Order lastOrder;
+        private bool raiseRate;
+
+        public override void ComputeNewOrders(ref TradingContext tContext)
+        {
+
+            //if (tContext.Market.Time > _WeeklyTargetMarket)
+            //{
+            //    _WeeklyTargetMarket = tContext.Market.Time.Add(TimeSpan.FromDays(7));
+            //    Logger($"Date: {tContext.Market.Time}, Price: {tContext.Market.Ticker.Last}");
+            //}
+            Order newOrder = null;
+            var currentPrice = tContext.Market.Ticker.Last;
+            var objBalance = tContext.NewOrders.GetBalance(tContext.Market.Ticker);
+            if (tContext.CurrentOrders.Orders.Count > 0)
+            {
+                throw new InvalidOperationException("strategy should not keep open orders");
+            }
+
+            if (currentStop == 0)
+            {
+                if (objBalance.Value > (objBalance.Secondary * 2))
+                {
+                    nextOrderType = OrderType.Sell;
+                }
+                else
+                {
+                    nextOrderType = OrderType.Buy;
+                }
+                currentStop = nextOrderType == OrderType.Buy ? currentPrice * (1 + StopRate) : currentPrice * (1 - StopRate);
+            }
+
+            if (lastOrder == null || tContext.Market.Time > lastOrder.Time + RefactoryPeriod)
+            {
+                if ((nextOrderType == OrderType.Buy && currentPrice > currentStop) || (nextOrderType == OrderType.Sell && currentPrice < currentStop))
+                {
+
+                    // stop hit, engage
+
+                    //if ((nextOrderType == OrderType.Buy && lastOrder.Price<currentPrice) || (nextOrderType == OrderType.Sell && lastOrder.Price > currentPrice))
+                    //{
+                    //    // losing stop, change rate
+                    //    //StopRate = raiseRate ? StopRate * 1.3m : StopRate / 1.3m;
+                    //    //raiseRate = ((StopRate < 0.1m) || (StopRate > 0.4m)) ? !raiseRate : raiseRate;
+                    //}
+                    newOrder = Engage(ref tContext, nextOrderType);
+                    nextOrderType = nextOrderType == OrderType.Buy ? OrderType.Sell : OrderType.Buy;
+                    currentStop = nextOrderType == OrderType.Buy ? currentPrice * (1 + StopRate) : currentPrice * (1 - StopRate);
+                }
+                else
+                {
+
+                    //no stop, adjust if necessary
+
+                    if (nextOrderType == OrderType.Buy)
+                    {
+                        var newStop = currentPrice * (1 + StopRate);
+                        if (newStop < currentStop)
+                        {
+                            currentStop = newStop;
+                        }
+                    }
+                    else
+                    {
+                        var newStop = currentPrice * (1 - StopRate);
+                        if (newStop > currentStop)
+                        {
+                            currentStop = newStop;
+                        }
+                    }
+                }
+
+            }
+
+            if (newOrder != null)
+            {
+                //Logger($"{this.GetType().Name}");
+                //Logger($" Date: {tContext.Market.Time.ToString(CultureInfo.InvariantCulture)}, {newOrder.FriendlyId}, Wallet: {objBalance.Primary}BTC {objBalance.Secondary}USD, Total {objBalance.Total}USD   ");
+                tContext.NewOrders.Orders.Add(newOrder);
+                lastOrder = newOrder;
+            }
+        }
+
+
+        private Order Engage(ref TradingContext tContext, OrderType orderType)
+        {
+            var objBalance = tContext.NewOrders.GetBalance(tContext.Market.Ticker);
+            Order newOrder = null;
+            if (orderType == OrderType.Sell)
+            {
+                if (objBalance.Value > (objBalance.Secondary * 2))
+                {
+                    var objPrice = tContext.Market.Ticker.Last * 0.99M;
+                    newOrder = new Order() { OrderType = orderType, Price = objPrice, Amount = tContext.NewOrders.PrimaryBalance, Time = tContext.Market.Time};
+                }
+            }
+            else
+            {
+                if (objBalance.Secondary > (objBalance.Value * 2))
+                {
+                    var objPrice = tContext.Market.Ticker.Last * 1.01M;
+                    newOrder = new Order() { OrderType = orderType, Price = objPrice, Amount = tContext.NewOrders.SecondaryBalance / objPrice , Time = tContext.Market.Time };
+                }
+            }
+
+            return newOrder;
+
+        }
+    }
+}


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2025:CoursIA — prev: DEEP/lean #14770

## Résumé

- porte les huit feuilles stratégies/résultats nécessaires au futur orchestrateur `BackTesting.cs` depuis `MyIntelligenceAgency/Lean@612dddf9` ;
- ajoute `MultiClassBoost`, `ModelStrategy`, `BoostedStrategy`, `HodlStrategy`, `SimpleStopStrategy`, `BacktestResult`, `BackTestingSettings` et `CompareBackTestings` ;
- ajoute 18 tests xUnit ciblés dans un seul fichier, sans nouvelle dépendance de test ;
- laisse `BackTestingConfig.cs`, `BackTesting.cs`, les README et les catalogues générés hors scope.

## Fidélité et adaptations

- `BacktestResult.cs` et `CompareBackTestings.cs` sont byte-identiques à l'upstream ;
- cinq autres feuilles préservent le comportement upstream avec seulement les espaces finaux normalisés ;
- `BoostedStrategy.cs` porte trois adaptations documentées :
  1. remplacement de `Program.Log`, dépendance au binaire console non porté, par un logger console local équivalent ;
  2. remplacement du cast invariant `models as IList<IClassifier<double[], int>>`, qui produisait toujours `null`, par une conversion explicite ;
  3. accès à `ClassifierTradingModel.Classifier` avant le cast vers `MultiClassBoost`, au lieu de caster le wrapper lui-même.

Les adaptations 2 et 3 sont couvertes par un mini-SVM Accord réellement entraîné en mémoire : construction de `BoostedStrategy`, accès à l'ensemble, `DecideDetail` et `GetResult` sont tous exercés.

Aucune référence Aricie/DNN/Flee n'est introduite dans les huit fichiers. `FileHelpers` est déjà fourni transitivement par `MyIA.Trading.Converter`; aucun `.csproj` n'est modifié.

## Validation

- `dotnet restore MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj` : succès ;
- `dotnet build MyIA.Trading.Backtester/MyIA.Trading.Backtester.csproj --configuration Release --no-restore` : succès, 0 avertissement, 0 erreur ;
- `dotnet test MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj --configuration Release --no-restore` : 85/85 tests verts (67 baseline + 18 nouveaux) ;
- `git diff --check origin/main...HEAD` : succès ;
- sweep erreurs volontaires et secrets sur le scope : aucun finding ;
- neuf fichiers, un seul domaine, aucun catalogue généré modifié.

## Résiduel

Cette tranche rend la couche stratégies/résultats disponible et testée. L'EPIC reste ouverte : `BackTestingConfig.cs`, puis `BackTesting.cs` et le README de fermeture restent à porter dans des tranches séquentielles distinctes.

See #7357