### PR TITLE
fix(notebook-tools,#14814): REFERENCE never promoted to REPRODUCED — honest axe-2 counts

### DIFF
--- a/docs/PARCOURS.md
+++ b/docs/PARCOURS.md
@@ -41,9 +41,11 @@ Mélanger ces axes en une seule étiquette (PRODUCTION, BETA…) a trois défaut
 | `UNTESTED` | Aucune cellule code exécutée | `C_NEVER_EXECUTED` OU `NO_CODE` |
 | `STATIC_OK` | Notebook *valide statiquement* (parse OK, structure OK) mais non exécuté | `STATIC_OK` (parse réussi, `n_code > 0`, `n_exec == 0`, pas d'erreur statique) |
 | `EXECUTED` | Toutes les cellules code exécutées avec succès | `A_ALL_EXEC_OK` — `execution_count != null` partout + 0 erreur |
-| `REPRODUCED` | Ré-exécution *horodatée* de bout en bout, SHA engagé | `EXECUTED` + `last_commit_sha` cohérent avec `executed_at` (±7 jours) ET `metadata.last_success_sha == last_commit_sha` |
+| `REPRODUCED` | Ré-exécution *horodatée* de bout en bout, attestation d'exécution | `EXECUTED` + `executed_at` présent ET `last_success_sha == head_sha` |
 
 **Différence EXECUTED vs REPRODUCED** : `EXECUTED` est un état *intrinsèque* du fichier (au moment du commit) ; `REPRODUCED` est un état *daté* (on peut affirmer « ce notebook a tourné le JJ/MM avec succès sur le SHA X »). REPRODUCED est ce qui permet de répondre « oui, ce notebook marche *aujourd'hui* » ; EXECUTED peut dater de 2 ans et avoir régressé depuis.
+
+**Provenance des champs (`executed_at`, `last_success_sha`)** : ils doivent venir d'une **attestation d'exécution** (exécuteur, date, SHA des sources, environnement, résultat) — pas d'une date de dernière modification `git log` (#14814). Une référence jamais exécutée (`metadata.qc_reference == true`) est un **type de document** (`forensic_category == REFERENCE`), pas un claim de reproductibilité : son axe 2 vaut `UNTESTED`, jamais `REPRODUCED`. Tant qu'aucune attestation n'existe, `REPRODUCED` n'est pas émis — un champ vide est honnête, un champ dérivé d'une date de modification ne l'est pas.
 
 ### Axe 3 — `scientific_review` (revue scientifique)
 

--- a/scripts/notebook_tools/forensic_scan.py
+++ b/scripts/notebook_tools/forensic_scan.py
@@ -45,7 +45,23 @@ def categorize_notebook(path: Path) -> dict:
         return {"path": str(path), "category": "PARSE_ERROR", "error": str(e)}
 
     if nb.get("metadata", {}).get("qc_reference") is True:
-        return {"path": str(path), "category": "REFERENCE", "n_code": 0}
+        # qc_reference = QC Cloud / full-QCAlgorithm reference notebook, not
+        # locally executable (#3776). The flag changes the CATEGORY (document
+        # type), never the counting (#14814): the code-cell counts are measured.
+        cells = nb.get("cells", [])
+        code_cells = [c for c in cells if c.get("cell_type") == "code"]
+        return {
+            "path": str(path),
+            "category": "REFERENCE",
+            "n_code": len(code_cells),
+            "n_exec": sum(1 for c in code_cells if c.get("execution_count") is not None),
+            "n_err": sum(
+                1
+                for c in code_cells
+                if any(o.get("output_type") == "error" for o in c.get("outputs", []))
+            ),
+            "n_outputs": sum(1 for c in code_cells if c.get("outputs")),
+        }
 
     cells = nb.get("cells", [])
     code_cells = [c for c in cells if c.get("cell_type") == "code"]

--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -728,7 +728,14 @@ _FORENSIC_CATEGORY_REPRO = {
     "D_HAS_ERRORS": "UNTESTED",
     "NO_CODE": "STATIC_OK",
     "PARSE_ERROR": "UNTESTED",
-    "REFERENCE": "REPRODUCED",  # notebook de reference, jamais execute par design
+    # REFERENCE (`metadata.qc_reference == true`) = QC Cloud / full-QCAlgorithm
+    # reference notebook, never executed locally by design (#3776). It is a
+    # DOCUMENT TYPE carried by `forensic_category`, NOT a reproducibility claim.
+    # The execution axis (axe 2) values what the real forensic says: a reference
+    # notebook with no output / no execution_count is UNTESTED, never REPRODUCED
+    # (#14814). REPRODUCED requires the attestation proof (executed_at +
+    # last_success_sha == head_sha), which a never-executed reference lacks.
+    "REFERENCE": "UNTESTED",
 }
 
 
@@ -742,7 +749,9 @@ def classify_reproducibility(
     """Axe 2 — reproductibilite (UNTESTED/STATIC_OK/EXECUTED/REPRODUCED).
 
     Cf docs/PARCOURS.md. La categorie de base vient du forensic scan ; REPRODUCED
-    n'est emis que si `last_success_sha` correspond au SHA HEAD (coherence).
+    n'est emis que si `last_success_sha` correspond au SHA HEAD (coherence),
+    c'est-a-dire une attestation d'execution (`executed_at` + SHA coherent),
+    jamais le seul type de document (#14814).
     """
     if not forensic_category:
         return "UNTESTED"

--- a/scripts/notebook_tools/tests/test_forensic_scan.py
+++ b/scripts/notebook_tools/tests/test_forensic_scan.py
@@ -109,6 +109,27 @@ class TestCategorizeNotebook:
                              metadata={"qc_reference": True})
         result = categorize_notebook(nb_path)
         assert result["category"] == "REFERENCE"
+        # qc_reference changes the category (document type), never the counting (#14814)
+        assert result["n_code"] == 1
+        assert result["n_exec"] == 0
+        assert result["n_outputs"] == 0
+
+    def test_reference_notebook_counts_code_cells(self, tmp_path):
+        # Real-world reference notebook (cf #14814): several code cells, none
+        # executed (no output, no exec_count). Category stays REFERENCE; the
+        # code-cell count is measured, not fabricated as 0.
+        nb_path = _write_nb(tmp_path / "a.ipynb", [
+            _code("x = 1"),
+            _code("y = 2"),
+            _code("z = 3"),
+            _md("# note"),
+        ], metadata={"qc_reference": True})
+        result = categorize_notebook(nb_path)
+        assert result["category"] == "REFERENCE"
+        assert result["n_code"] == 3
+        assert result["n_exec"] == 0
+        assert result["n_err"] == 0
+        assert result["n_outputs"] == 0
 
     def test_parse_error(self, tmp_path):
         bad = tmp_path / "bad.ipynb"

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -28,6 +28,7 @@ from generate_catalog import (
     analyze_notebook,
     check_errors,
     classify_maturity,
+    classify_reproducibility,
     classify_scientific_review,
     count_todos,
     detect_kernel,
@@ -1615,6 +1616,64 @@ class TestEditorialReviewPromotion:
             json.dumps({"d": rd})
         finally:
             tmp.unlink()
+
+
+class TestClassifyReproducibility:
+    """Axe 2 (reproductibilite) — le label REPRODUCED exige une attestation.
+
+    #14814 : une reference jamais executee ne doit JAMAIS sortir REPRODUCED ;
+    le chemin nominal (EXECUTED + attestation) doit rester atteignable.
+    """
+
+    def test_reference_never_reproduced(self):
+        # REFERENCE (qc_reference==true) est un type de document, pas une
+        # reproductibilite. Meme avec des champs d'attestation fournis, un
+        # notebook jamais execute ne sort pas REPRODUCED.
+        assert classify_reproducibility("REFERENCE") == "UNTESTED"
+        assert classify_reproducibility(
+            "REFERENCE",
+            last_success_sha="abc1234",
+            executed_at="2026-09-01T00:00:00Z",
+            head_sha="abc1234",
+        ) == "UNTESTED"
+
+    def test_never_executed_is_untested(self):
+        assert classify_reproducibility("C_NEVER_EXECUTED") == "UNTESTED"
+        assert classify_reproducibility("D_HAS_ERRORS") == "UNTESTED"
+        assert classify_reproducibility(None) == "UNTESTED"
+
+    def test_executed_without_attestation_stays_executed(self):
+        # EXECUTE sans SHA/date coherent -> EXECUTED (pas REPRODUCED)
+        assert classify_reproducibility("A_ALL_EXEC_OK") == "EXECUTED"
+        assert classify_reproducibility(
+            "A_ALL_EXEC_OK", last_success_sha="abc1234",
+        ) == "EXECUTED"
+        assert classify_reproducibility(
+            "A_ALL_EXEC_OK", executed_at="2026-09-01T00:00:00Z",
+        ) == "EXECUTED"
+
+    def test_executed_mismatched_sha_not_reproduced(self):
+        # SHA differents -> pas de coherence -> EXECUTED
+        assert classify_reproducibility(
+            "A_ALL_EXEC_OK",
+            last_success_sha="abc1234",
+            executed_at="2026-09-01T00:00:00Z",
+            head_sha="zzz9999",
+        ) == "EXECUTED"
+
+    def test_positive_control_reproduced_with_attestation(self):
+        # CONTROLE POSITIF (le chemin nominal, qui n'a jamais tourne) :
+        # EXECUTE + attestation (SHA coherent + executed_at) -> REPRODUCED.
+        assert classify_reproducibility(
+            "A_ALL_EXEC_OK",
+            last_success_sha="abc1234",
+            executed_at="2026-09-01T00:00:00Z",
+            head_sha="abc1234",
+        ) == "REPRODUCED"
+
+    def test_partial_exec_is_static_ok(self):
+        assert classify_reproducibility("B_PARTIAL_EXEC") == "STATIC_OK"
+        assert classify_reproducibility("NO_CODE") == "STATIC_OK"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA-2 — prev: MED/guard #14775

# Axe 2 : une reference jamais executee ne sort plus `REPRODUCED` (#14814)

## Problème

Le générateur de catalogue classifiait **tout** notebook portant `metadata.qc_reference == true` en `reproducibility = REPRODUCED` via la table `_FORENSIC_CATEGORY_REPRO["REFERENCE"] = "REPRODUCED"`. Or ces notebooks sont des **références QC Cloud / full-QCAlgorithm** (`qc_reference`, #3776) qui ne sont **jamais exécutées localement** : elles n'ont ni `execution_count`, ni `outputs`. Les qualifier de « reproduites » est un **faux claim de reproductibilité** — le défaut que l'issue demande de corriger.

En parallèle, `forensic_scan.categorize_notebook` court-circuitait ces notebooks avec `return {"category": "REFERENCE", "n_code": 0}` — le compte `n_code` était **falsifié à 0** (un notebook de référence à 3 cellules code paraissait n'en avoir aucune).

## Changement

**1. `scripts/notebook_tools/forensic_scan.py`** — le flag `qc_reference` change la **catégorie** (type de document), jamais le **comptage** : `n_code` / `n_exec` / `n_err` / `n_outputs` sont désormais **mesurés** comme pour tout notebook. Les cellules code d'une référence sont comptées honnêtement.

**2. `scripts/notebook_tools/generate_catalog.py`** — `_FORENSIC_CATEGORY_REPRO["REFERENCE"]` passe de `"REPRODUCED"` à `"UNTESTED"` : `REFERENCE` est un **type de document** porté par `forensic_category`, pas un claim de reproductibilité. La valeur de l'axe 2 vient de ce que le forensic dit réellement — une référence sans exec ni output est `UNTESTED`, jamais `REPRODUCED`. `REPRODUCED` exige l'**attestation** (`executed_at` + `last_success_sha == head_sha`), qu'une référence jamais exécutée n'a pas.

**3. `docs/PARCOURS.md`** — reconciliation du **critère de promotion documenté** avec le **critère implémenté** (point d'acceptance 3 de #14814 : « l'un des deux se corrige, explicitement ») : la ligne `REPRODUCED` ne mentionne plus la fenêtre `git log` ±7 j sur `last_commit_sha` (que le code n'implémentait pas) mais l'attestation (`executed_at` présent ET `last_success_sha == head_sha`). Note de provenance ajoutée : les champs doivent venir d'une **attestation d'exécution**, pas d'une date de modification `git log`.

**4. Tests — non-régression à deux sens** (point d'acceptance 4) :
- `test_reference_never_reproduced` — une entrée `REFERENCE` ne sort jamais `REPRODUCED`, **même avec des champs d'attestation fournis** (négatif).
- `test_positive_control_reproduced_with_attestation` — une entrée `EXECUTED` réellement ré-exécutée avec attestation (SHA cohérent + `executed_at`) sort `REPRODUCED` (le **contrôle positif**, le chemin nominal qui n'avait jamais tourné).
- + `test_executed_without_attestation_stays_executed`, `test_executed_mismatched_sha_not_reproduced`, `test_reference_notebook_counts_code_cells`, `test_never_executed_is_untested`, `test_partial_exec_is_static_ok`.

## Résultat

Le catalogue ne qualifie plus une référence QC jamais exécutée de « reproduite » ; le compte de cellules code d'une référence est exact. `REPRODUCED` reste atteignable, mais **uniquement** pour un notebook `EXECUTED` dont l'attestation d'exécution est cohérente.

## Périmètre & résiduel

- **Vérifié** : `Catalogue` byte-identique à `origin/main` (catalog-pr-hygiene) ; 207 tests passent ; `test_forensic_scan.py` renforcé.
- **Résiduel (issu #14814, à traiter séparément)** : les champs `executed_at` / `last_success_sha` sont **encore dérivés de `git log`** dans `forensic_scan.py` (point 2 de l'issue — l'architecture d'**attestation d'exécution** elle-même). Ce PR corrige le **critère** (3) + le **comptage** (1) + le **type de document** (5) + le **test de non-régression** (4) ; l'attestation de provenance est le résiduel profond, car `generate_release_notes.py` consomme `executed_at` comme proxy d'exécution — retirer la dérivation `git log` casserait les notes de release tant que l'attestation n'existe pas. Contribution partielle → `See #14814`.

See #14814
