### PR TITLE
feat(lean,#2159): Partie 71 -- sous-canonicite de opensTopology (theorie des sites)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesSubcanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesSubcanonical.lean
@@ -1,0 +1,81 @@
+/-
+Grothendieck hommage — Partie 71 : la sous-canonicité de la topologie des
+recouvrements ouverts.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+Une topologie de Grothendieck est *sous-canonique* lorsque tout préfaisceau
+représentable est un faisceau (Mathlib : `Subcanonical`). Pour le site des
+ouverts d'un espace topologique, c'est le fait fondateur qui permet de voir
+chaque ouvert `U` comme le faisceau qu'il représente : le plongement de
+Yoneda factorise par la catégorie des faisceaux (Mathlib :
+`GrothendieckTopology.yoneda`).
+
+La preuve est ponctuelle : le recollement d'une famille compatible de
+sections du représentable `yoneda.obj U` le long d'un crible couvrant `S` se
+construit point par point — chaque point de `X` vit dans le domaine d'une
+flèche de `S`, la famille fournit une section au-dessus de ce domaine (donc
+une flèche vers `U` contenant le point) — et l'unicité est celle des flèches
+entre ouverts (la catégorie `Opens T` est fine).
+
+Références :
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II §1 (sites sous-canoniques).
+  - Mathlib, `CategoryTheory.Sites.Canonical` (classe `Subcanonical`,
+    constructeur `Subcanonical.of_isSheaf_yoneda_obj`).
+  - Partie 68 (`Grothendieck.Spaces`) : la construction `opensTopology`.
+
+Convention i18n (EPIC #4980 ratifiée 2026-07-04) : ce module est jumelé avec
+`SpacesSubcanonical_en.lean`. Les énoncés, preuves et noms Lean restent
+identiques ; seules les docstrings et les commentaires diffèrent.
+
+Epic #1646, Phase 2 (#2159). Aucun `sorry` introduit.
+-/
+
+import Grothendieck.Spaces
+import Mathlib.CategoryTheory.Sites.Canonical
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+
+namespace Grothendieck
+
+open CategoryTheory TopologicalSpace
+
+universe u
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- Lemme central : pour tout ouvert `U`, le préfaisceau représentable
+`yoneda.obj U` est un faisceau pour la topologie `opensTopology`. Le
+recollement s'obtient point par point — chaque point de `X` est couvert par
+une flèche du crible, dont la section de la famille compatible donne
+l'appartenance à `U` — et l'unicité est l'unicité des flèches entre ouverts
+(catégorie fine). -/
+theorem isSheaf_yoneda_opensTopology (U : Opens T) :
+    Presieve.IsSheaf (opensTopology T) (yoneda.obj U) := by
+  intro X S hS xf _hcomp
+  have hXU : X ≤ U := by
+    intro p hp
+    obtain ⟨W, f, hf, hpW⟩ := hS p hp
+    have hsec : W ⟶ U := show W ⟶ U from xf f hf
+    exact hsec.le hpW
+  refine ⟨homOfLE hXU, ?amal, ?uniq⟩
+  · intro Y f hf
+    apply Subsingleton.elim (α := Y ⟶ U)
+  · intro t' _ht'
+    apply Subsingleton.elim (α := X ⟶ U)
+
+/-- **Résultat central** : la topologie `opensTopology` est sous-canonique.
+Tout préfaisceau représentable sur le site des ouverts d'un espace
+topologique est un faisceau — chaque ouvert se voit donc comme un faisceau,
+et le plongement de Yoneda factorise par la catégorie des faisceaux (voir
+`GrothendieckTopology.yoneda` dans Mathlib, disponible dès cette instance). -/
+theorem opensTopology_subcanonical : GrothendieckTopology.Subcanonical (opensTopology T) :=
+  GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj _ fun U => isSheaf_yoneda_opensTopology T U
+
+end Contenu
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesSubcanonical_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SpacesSubcanonical_en.lean
@@ -1,0 +1,78 @@
+/-
+Grothendieck tribute — Part 71: subcanonicity of the open-cover topology.
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 2 extension (#2159, Epic #1646).
+
+A Grothendieck topology is *subcanonical* when every representable presheaf
+is a sheaf (Mathlib: `Subcanonical`). For the site of open sets of a
+topological space, this is the founding fact that lets one view each open
+set `U` as the sheaf it represents: the Yoneda embedding factors through the
+category of sheaves (Mathlib: `GrothendieckTopology.yoneda`).
+
+The proof is pointwise: gluing a compatible family of sections of the
+representable `yoneda.obj U` along a covering sieve `S` is done point by
+point — each point of `X` lies in the domain of an arrow of `S`, the family
+supplies a section above that domain (hence an arrow to `U` containing the
+point) — and the uniqueness is the uniqueness of arrows between open sets
+(the category `Opens T` is thin).
+
+References:
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Ch. II §1 (subcanonical sites).
+  - Mathlib, `CategoryTheory.Sites.Canonical` (class `Subcanonical`,
+    constructor `Subcanonical.of_isSheaf_yoneda_obj`).
+  - Part 68 (`Grothendieck.Spaces`): the `opensTopology` construction.
+
+i18n convention (EPIC #4980 ratified 2026-07-04): this module is twinned
+with `SpacesSubcanonical.lean`. Statements, proofs and Lean names stay
+identical; only docstrings and comments differ.
+
+Epic #1646, Phase 2 (#2159). No `sorry` introduced.
+-/
+
+import Grothendieck.Spaces
+import Mathlib.CategoryTheory.Sites.Canonical
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+
+namespace Grothendieck.SpacesSubcanonical_en
+
+open CategoryTheory TopologicalSpace
+
+universe u
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- Central lemma: for any open set `U`, the representable presheaf
+`yoneda.obj U` is a sheaf for the topology `opensTopology`. The gluing is
+pointwise — each point of `X` is covered by an arrow of the sieve, whose
+section of the compatible family gives membership in `U` — and the
+uniqueness is the uniqueness of arrows between open sets (thin category). -/
+theorem isSheaf_yoneda_opensTopology (U : Opens T) :
+    Presieve.IsSheaf (opensTopology T) (yoneda.obj U) := by
+  intro X S hS xf _hcomp
+  have hXU : X ≤ U := by
+    intro p hp
+    obtain ⟨W, f, hf, hpW⟩ := hS p hp
+    have hsec : W ⟶ U := show W ⟶ U from xf f hf
+    exact hsec.le hpW
+  refine ⟨homOfLE hXU, ?amal, ?uniq⟩
+  · intro Y f hf
+    apply Subsingleton.elim (α := Y ⟶ U)
+  · intro t' _ht'
+    apply Subsingleton.elim (α := X ⟶ U)
+
+/-- **Central result**: the topology `opensTopology` is subcanonical. Every
+representable presheaf on the site of open sets of a topological space is a
+sheaf — each open set is therefore seen as a sheaf, and the Yoneda embedding
+factors through the category of sheaves (see `GrothendieckTopology.yoneda`
+in Mathlib, available from this instance). -/
+theorem opensTopology_subcanonical : GrothendieckTopology.Subcanonical (opensTopology T) :=
+  GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj _ fun U => isSheaf_yoneda_opensTopology T U
+
+end Contenu
+
+end Grothendieck.SpacesSubcanonical_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: MED/lean #14764

See #2159 (Partie 71 — Epic #1646 Phase 2). Troisième grain lean consécutif de la lane en séquence mergée (#14680 → #14764 → celui-ci) : justification G-VAR-3 explicite ci-dessous — les alternatives CONTENU de la lane sont toutes gated, et la substance est genuinement distincte (preuve effective de la condition de faisceau, pas un pont `rfl` comme P70).

## Résumé

La Partie 68 (`Spaces.lean`) a construit la topologie de Grothendieck `opensTopology` des recouvrements ouverts de `Opens T` ; la Partie 70 (`SpacesMathlib.lean`) a prouvé son égalité avec `Opens.grothendieckTopology` et le transport de la condition de faisceau vers `TopCat.Presheaf.IsSheaf`. Cette Partie 71 montre que le site `(Opens T, opensTopology T)` est **sous-canonique** : tout préfaisceau représentable `yoneda.obj U` est un faisceau. C'est ce qui fait de chaque ouvert un faisceau, et ce qui donne le plongement de Yoneda à valeurs dans la catégorie des faisceaux (`GrothendieckTopology.yoneda` dans Mathlib, disponible dès l'instance `Subcanonical`).

La preuve est ponctuelle : le recollement d'une famille compatible de sections du représentable le long d'un crible couvrant se construit point par point — chaque point de `X` est couvert par une flèche du crible, dont la section de la famille donne l'appartenance à `U` — et l'unicité est celle des flèches entre ouverts (la catégorie `Opens T` est fine). Aucun `sorry`.

## Validation

- build ciblé `lake build Grothendieck.SpacesSubcanonical Grothendieck.SpacesSubcanonical_en` : **Build completed successfully (1109 jobs)** ;
- build global du lake (`lake build`) : **Build completed successfully (3317 jobs)** ;
- `distinct_code_sorry` (lake grothendieck) : **0 → 0** ; total global 15 (inchangé — pré-existant dans 4 autres lakes, aucun touché par ce changement) ;
- checker i18n local (`check_i18n_siblings.py`) : **1/1 pairs byte-identical, 0 drift, 0 orphan, 0 unbuilt** ;
- `git diff --check` : vert.

## G-VAR-3 — troisième lean consécutif (justification)

Séquence mergée de la lane : #14680 (DEEP/lean, P68) → #14764 (MED/lean, L2) → ce grain. Trois consécutifs = zone grise G-VAR-3. Justification explicite :

- **Substance genuinement distincte** : P68 = construction à la main de la topologie ; P70 = pont d'égalité `rfl` vers Mathlib ; P71 = preuve effective de la condition de faisceau pour les représentables. Aucune instance `Subcanonical` n'existe dans Mathlib `Sites/Spaces.lean` (vérifié par grep d'olean : absence de la chaîne `Subcanonical`). Litmus LIGHT négatif (non générable-en-série en scannant l'instance suivante).
- **Alternatives CONTENU de la lane toutes gated** : `#13483` (jambe composition) bloquée par ma PR #14796 ouverte sur `HashlifeMarginFragment.lean` ; `#5635` (ICT-24) — le seul résiduel (Gate 24) exige un GPU ai-01 `CUDA_VISIBLE_DEVICES=2` sanctionné user 2026-07-07, machine-gated hors de cette lane ; `#14058` (ADK/Aspire) — emballement 6 notebooks/14 jours avec 2 consolidations déjà ouvertes (la contrepartie due est une consolidation, pas une instance de plus) ; slides — lane vision-gated.
- **Veine #2159** : #14812 = 1re PR citant l'épic aujourd'hui, celle-ci = 2e, sous le cap de 2/jour. Le `pick_idle_grain` n'a remonté aucune alternative CONTENU claimable pour cette lane (les autres candidats sont META ou déjà claimés).

## Périmètre

2 nouveaux fichiers : `Grothendieck/SpacesSubcanonical.lean` + `Grothendieck/SpacesSubcanonical_en.lean` (Pattern A consommateur : l'EN importe le FR `Grothendieck.Spaces` et référence `opensTopology` via le namespace parent, namespace `_en` anti-collision). Aucun README, agrégateur, manifeste, catalogue ou notebook modifié. Catalogue byte-identique à main.
