### PR TITLE
test(m18,#14823): document non-discriminating constant fixture, add median separation to the guard

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m18_tsfm_benchmark.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m18_tsfm_benchmark.py
@@ -384,7 +384,7 @@ def _sha256_array(arr: np.ndarray) -> str:
 
 def assert_baselines_distinct(
     deb_arrays: dict[str, np.ndarray], threshold: float = 1e-6,
-) -> float:
+) -> dict[str, float]:
     """Non-degeneracy control (#14791): baselines declared as distinct models
     must actually differ.
 
@@ -396,12 +396,25 @@ def assert_baselines_distinct(
     agreement below ``threshold`` everywhere means same effective model, and
     the run aborts instead of publishing an empty column.
 
-    Returns the weakest pairwise separation observed (the smallest, across
-    baseline pairs, of each pair's maximum relative difference) — recorded in
-    the manifest as provenance.
+    Floor of detection (#14823): the abort fires only on agreement EVERYWHERE.
+    Each pairwise separation is aggregated by MAX over the OOS points, so a
+    single divergent point keeps a partially-degenerate column green. This is
+    deliberate — the guard rejects "same effective model" (agree below
+    ``threshold`` on all points), not a model that merely reproduces
+    persistence on most points. The per-point MEDIAN is recorded alongside the
+    max as the monotone "how much do these baselines really differ" metric:
+    it stays near the floor when baselines agree almost everywhere but max is
+    buoyed by one outlier.
+
+    Returns ``{"max": ..., "median": ...}``: the weakest pairwise separation
+    across baseline pairs, each pair's separation aggregated over OOS points
+    by max (``max``, the abort signal) and by median (``median``, recorded in
+    the manifest as ``baseline_median_rel_sep``). With no baseline pair to
+    compare, both are ``inf``.
     """
     names = [m for m in BASELINES if m in deb_arrays]
-    weakest = np.inf
+    weakest_max = np.inf
+    weakest_median = np.inf
     for i in range(len(names)):
         for j in range(i + 1, len(names)):
             a, b = names[i], names[j]
@@ -409,14 +422,16 @@ def assert_baselines_distinct(
             denom = np.maximum(np.abs(pa), np.abs(pb))
             rel = np.abs(pa - pb) / np.maximum(denom, 1e-12)
             top = float(np.max(rel))
-            weakest = min(weakest, top)
+            med = float(np.median(rel))
+            weakest_max = min(weakest_max, top)
+            weakest_median = min(weakest_median, med)
             if top < threshold:
                 raise RuntimeError(
                     f"degenerate baselines (#14791): {a!r} and {b!r} agree to "
                     f"{top:.2e} (max relative over {len(pa)} OOS points) — "
                     f"below {threshold:g}: same effective model, the vs-{b} "
                     f"column carries no independent information")
-    return float(weakest)
+    return {"max": float(weakest_max), "median": float(weakest_median)}
 
 
 def run_config(
@@ -540,7 +555,9 @@ def run_config(
     # Non-degeneracy control (#14791): a run where two declared baselines
     # agree below 1e-6 everywhere aborts here instead of publishing an
     # empty "vs X" column; the weakest separation is kept as provenance.
-    baseline_weakest_rel_sep = assert_baselines_distinct(deb_arrays)
+    _baseline_sep = assert_baselines_distinct(deb_arrays)
+    baseline_weakest_rel_sep = _baseline_sep["max"]
+    baseline_median_rel_sep = _baseline_sep["median"]
 
     # In-situ DM, two legs per amended §C (#11010): the CONJUNCTION verdict
     # uses a PRECISION loss ("mse"); the "linear" leg (raw signed errors) is
@@ -566,6 +583,7 @@ def run_config(
         "per_fold_bias": per_fold_bias_out,
         "fc_hash_per_fold": fc_hashes,
         "baseline_weakest_rel_sep": baseline_weakest_rel_sep,
+        "baseline_median_rel_sep": baseline_median_rel_sep,
         "n_oos": rows[MODELS[0]]["n_oos"],
         "bounds_train_test": folds[0] | {
             "n_total": int(n),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_m18_tsfm_benchmark.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_m18_tsfm_benchmark.py
@@ -109,7 +109,13 @@ class TestBaselines:
             m18._rolling_predictions("ewma", log_rv, rv, [100], horizon=1)
 
     def test_har_rv_constant_series_forecasts_its_level(self):
-        # constant RV -> OLS recovers the level; iterated path stays flat
+        # NOT a discriminating test for the #14791 defect: on a CONSTANT RV the
+        # contemporaneous identity fit and a properly-lagged HAR both forecast
+        # the constant level (2.0), so this passes on either alignment. It
+        # guards a real invariant (level recovery on a flat series), but the
+        # tests that actually REJECT #14791 are in TestHarRvAlignment — their
+        # fixtures (a persistent series, not a constant) are the ones that go
+        # red under the contemporaneous alignment (see its docstring).
         idx = pd.date_range("2020-01-01", periods=200, freq="D")
         rv = pd.Series(np.exp(2.0), index=idx)
         model = m18.HarRvModel().fit(rv)
@@ -173,7 +179,7 @@ class TestHarRvAlignment:
         har = m18._rolling_predictions("har_rv", log_rv, rv, idx, horizon=5)
         sep = m18.assert_baselines_distinct(
             {"persistence": pers, "har_rv": har})
-        assert sep >= 1e-6
+        assert sep["max"] >= 1e-6
 
 
 class TestBaselineDistinctnessGuard:
@@ -190,14 +196,30 @@ class TestBaselineDistinctnessGuard:
         sep = m18.assert_baselines_distinct(
             {"persistence": a, "ewma": b, "log_har": c})
         # weakest pair is a-vs-b: max rel diff = 0.1/0.9... ~ 1e-1 scale
-        assert sep > 1e-2
+        assert sep["max"] > 1e-2
+        assert sep["median"] > 1e-2
 
     def test_tsfm_excluded_from_the_guard(self):
         a = np.array([-9.1, -9.0])
         same_as_a = a.copy()
         sep = m18.assert_baselines_distinct(
             {"persistence": a, "tsfm": same_as_a})
-        assert sep == np.inf  # no baseline pair -> nothing to compare
+        # no baseline pair -> nothing to compare -> both aggregations are inf
+        assert sep["max"] == np.inf
+        assert sep["median"] == np.inf
+
+    def test_median_surfaces_partial_degeneracy_the_max_hides(self):
+        # Two of three OOS points agree to ~1e-8 (below the 1e-6 floor) while a
+        # single divergent point keeps the max (the abort signal) at 0.625 — the
+        # guard correctly does NOT abort (it only detects agreement-everywhere),
+        # but the recorded median (~1.4e-8) exposes the near-total agreement
+        # that the max alone would obscure (#14823).
+        a = np.array([-8.0, -7.0, -8.0])
+        b = np.array([-8.0 + 1e-7, -7.0 + 1e-7, -3.0])
+        sep = m18.assert_baselines_distinct(
+            {"persistence": a, "har_rv": b})
+        assert sep["max"] > 1e-6
+        assert sep["median"] < sep["max"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/training -- lane myia-po-2026:CoursIA -- prev: MED/training #14809

Closes #14823 — resolution of the two instruments that guard `har_rv`, per the 4 acceptance items. Follow-up of #14809 (which fixed the defect itself); nothing here touches predictions or the verdict.

## What changes

- `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m18_tsfm_benchmark.py` — `assert_baselines_distinct` now aggregates each pairwise separation by BOTH max and per-point median, returns `{"max": ..., "median": ...}`, and its docstring states the detection floor explicitly: the abort fires only on agreement EVERYWHERE; a single divergent OOS point keeps a partially-degenerate column green (deliberate — the guard rejects "same effective model", not a model that merely reproduces persistence on most points). `run_config` records the median in the manifest as `baseline_median_rel_sep` alongside `baseline_weakest_rel_sep` (committed `m18_tsfm_benchmark.json` untouched per acceptance item 4 — no re-run, prediction/verdict paths unchanged).
- `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_m18_tsfm_benchmark.py` — the constant-fixture test is now explicitly labeled NON-discriminating for #14791 (it passes on both alignments) and points to `TestHarRvAlignment` as the discriminating set; a new test shows the median exposing partial degeneracy the max hides.

## Item 1 — the constant fixture, honestly labeled

`test_har_rv_constant_series_forecasts_its_level` keeps its invariant (level recovery on a flat series) but its comment now names what it does NOT test and why: on a CONSTANT RV the identity fit and the lagged HAR both forecast the constant level, so this passes on either alignment. Measured firsthand:

```
[constant LAGGED  (fixed)]  pred_log = 2.00000000  -> PASS
[constant CONTEMP (buggy)]  pred_log = 2.00000000  -> PASS   (non-discriminating, confirmed)
```

## Item 2 — proof of teeth for the discriminating set (measured, not cited)

Monkeypatching `_har_rv_features` back to the contemporaneous alignment (the #14791 defect) and re-running the `TestHarRvAlignment` assertions:

```
[LAGGED  (fixed)]  coef = [3.476e-07, 1.041e+00, -3.130e-02, -1.115e-02]  spread>1e-3 = True   guard sep max=5.243e-03 med=1.019e-03 -> GREEN
[CONTEMP (buggy)]  coef = [2.212e-20, 1.000e+00,  3.331e-16, -1.110e-16]  spread>1e-3 = False  guard RAISED (degenerate baselines)      -> RED
```

So `test_fit_is_not_the_identity` goes red under the bug (coefficient collapse) and `test_har_rv_rolling_predictions_pass_the_distinctness_guard` goes red under the bug (RuntimeError) — the suite now demonstrably rejects the contemporaneous alignment. This reproduces the issue's table with the shipped code.

## Item 3 — median separation alongside the max

New test `test_median_surfaces_partial_degeneracy_the_max_hides`: two of three OOS points agree to ~1e-8 while a single divergent point keeps max at 0.625 — the guard correctly does NOT abort (agreement-everywhere floor, documented), but the recorded median (~1.4e-8) exposes the near-total agreement the max alone would obscure.

## Item 4 — no benchmark re-run

`scripts/results/m18_tsfm_benchmark.json` is byte-identical to main; only the guard's provenance reporting and tests changed.

## Validation

- `test_m18_tsfm_benchmark.py`: **38 passed** (37 before + 1 new).
- Full `ML-Training-Pipeline/scripts/tests/` directory: **1243 passed, 1 skipped** (skip is destructive-by-design), 178s — no regression outside the touched module.
- Only consumer of `assert_baselines_distinct` / `run_config` outputs is the test file itself (grep-verified repo-wide) — the return-type change breaks nothing else.