### PR TITLE
fix(guards,#14849): light-cap G-VAR-2 verdict 3 etats -- unknown visible, jamais False permissif

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -282,8 +282,13 @@ jobs:
           # est 30, silencieusement. Le set tronque attaque le
           # DENOMINATEUR du ratio G-VAR-2 (#10328 : 60 mergees pour 30
           # vues -> faux positif contre les lanes productives).
+          # #14849 : stderr du fetch CAPTURE (jamais /dev/null) -- un gh pr
+          # list qui echoue produisait un merged.json absent, et la chaine
+          # silencieuse crash -> || echo "False" -> "cap non atteint"
+          # re-autorisait une LIGHT over budget. L'unknown doit etre VISIBLE.
           gh pr list --state merged --search "merged:$TODAY" --limit 500 \
-            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || true
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/tmp/merged_fetch.err || true
+          [ -s /tmp/merged_fetch.err ] && { echo "--- gh pr list (merged) stderr ---"; cat /tmp/merged_fetch.err; } || true
 
           printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
 
@@ -306,7 +311,11 @@ jobs:
           cat /tmp/status.json 2>/dev/null || true
           [ -s /tmp/cap.err ] && { echo "--- detector stderr ---"; cat /tmp/cap.err; } || true
 
-          CAP=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('cap_reached'))" 2>/dev/null || echo "False")
+          # #14849 : verdict a 3 ETATS. Le fallback permissif || echo "False"
+          # transformait crash/status absent/cap_reached null en "cap non
+          # atteint" -- une decison prise sur une absence de donnee. Reader
+          # HS ou champ null -> "None" -> branche unknown ci-dessous.
+          CAP=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('cap_reached'))" 2>/dev/null || echo "None")
 
           gh label create variation-light-cap-reached \
             --description "Lane ayant deja merge une LIGHT aujourd'hui (cap G-VAR-2 atteint)" \
@@ -328,8 +337,14 @@ jobs:
               gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
             fi
             echo "::notice::G-VAR-2 cap reached pour la lane ${LANE} (consomme par ${CB})."
-          else
+          elif [ "$CAP" = "False" ]; then
             gh pr edit "$PR_NUMBER" --remove-label variation-light-cap-reached 2>/dev/null || true
+          else
+            # #14849 : UNKNOWN (replay absent/invalide, detector crash, ou PR
+            # inassessable sans tag Grain). On ne pose NI ne retire le label
+            # -- les deux branches lisent un cap qui n'a pas ete calcule. Le
+            # warning rend l'unknown visible dans le resume du job.
+            echo "::warning::G-VAR-2 light-cap verdict UNKNOWN (CAP='${CAP}') : merged.json absent/invalide ou detector non sorti -- voir detector stderr ci-dessus. Label variation-light-cap-reached laisse intact."
           fi
           exit 0
 
@@ -349,9 +364,13 @@ jobs:
 
           TODAY=$(date -u +%Y-%m-%d)
           # --limit 500 : cf light-cap ci-dessus (#10328).
+          # #14849 : PAS de fabrication || printf '[]' -- un fetch echoue
+          # devenait un "journee vide" legitime en apparence et tous les
+          # signaux lisaient False sur une absence de donnee. Le fichier
+          # absent va jusqu'au detecteur, qui emet verdict unknown.
           gh pr list --state merged --search "merged:$TODAY" --limit 500 \
-            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || \
-            printf '[]' > /tmp/merged.json
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/tmp/merged_fetch.err || true
+          [ -s /tmp/merged_fetch.err ] && { echo "--- gh pr list (merged) stderr ---"; cat /tmp/merged_fetch.err; } || true
 
           printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
 
@@ -396,6 +415,16 @@ jobs:
           echo "--- detector output ---"
           cat /tmp/signals.json 2>/dev/null || true
           [ -s /tmp/cap.err ] && { echo "--- detector stderr ---"; cat /tmp/cap.err; } || true
+
+          # #14849 : verdict UNKNOWN (replay absent/invalide, detector sans
+          # sortie) -> on n'applique NI ne retire les labels : chaque branche
+          # du label loop lirait des signaux non calcules. Warning visible,
+          # labels laisses dans l'etat du dernier run assessable.
+          B_VERDICT=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('verdict') or 'assessed')" 2>/dev/null || echo "unknown")
+          if [ "$B_VERDICT" = "unknown" ]; then
+            echo "::warning::G-VAR-2/3 genre-signals : verdict UNKNOWN (signals.json absent/invalide ou verdict unknown du detecteur) -- labels laisses intacts, voir detector stderr ci-dessus (#14849)."
+            exit 0
+          fi
 
           SIG_INFLATION=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('TIER-INFLATION'))" 2>/dev/null || echo "False")
           SIG_RUN=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-RUN'))" 2>/dev/null || echo "False")

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -2040,3 +2040,85 @@ def test_light_guard_on_spent_tier_budget_still_caps_13632():
     )
     assert out["tier_cap_reached"] is True
     assert out["cap_reached"] is True
+
+
+# --- #14849 : verrou 3 etats, never a permissive False -------------------
+#
+# Controles POSITIFS du detecteur : un detecteur se valide par ses faux
+# negatifs. Pre-fix, un replay absent/vide/garbage faisait crasher _load
+# (ou sys.exit) AVANT toute sortie JSON ; le reader workflow
+# `|| echo "False"` transformait le crash en "cap non atteint" et
+# re-autorisait silencieusement une LIGHT over budget. Chaque test
+# ci-dessous echoue sur le code pre-fix (crash au lieu d'un verdict).
+
+
+_LIGHT_CANDIDATE_BODY = "Grain: LIGHT/readme -- lane myia-po-2026:CoursIA"
+
+
+def test_replay_absent_yields_unknown_not_false(tmp_path, capsys):
+    # Le cas mesure par l'issue : gh pr list echoue, merged.json n'existe pas.
+    rc = vlc.main([
+        "--replay", str(tmp_path / "merged.json"), "--check-pr", "4242",
+        "--body", _LIGHT_CANDIDATE_BODY,
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cap_reached"] is None  # pas False : on ne sait PAS
+    assert out["verdict"] == "unknown"
+    assert "reason" in out
+
+
+def test_replay_empty_file_yields_unknown_not_false(tmp_path, capsys):
+    # Fichier present mais vide (ex: redirection > avant echec d'ecriture).
+    (tmp_path / "merged.json").write_text("", encoding="utf-8")
+    rc = vlc.main([
+        "--replay", str(tmp_path / "merged.json"), "--check-pr", "4243",
+        "--body", _LIGHT_CANDIDATE_BODY,
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cap_reached"] is None
+    assert out["verdict"] == "unknown"
+
+
+def test_replay_garbage_yields_unknown_not_false(tmp_path, capsys):
+    # JSON invalide (download tronque, page d'erreur HTML du hub, ...).
+    (tmp_path / "merged.json").write_text("{not json", encoding="utf-8")
+    rc = vlc.main([
+        "--replay", str(tmp_path / "merged.json"), "--check-pr", "4244",
+        "--body", _LIGHT_CANDIDATE_BODY,
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cap_reached"] is None
+    assert out["verdict"] == "unknown"
+
+
+def test_replay_non_array_yields_unknown_not_false(tmp_path, capsys):
+    # JSON valide mais pas un tableau : pre-fix c'etait sys.exit(1) sans
+    # sortie JSON -> meme fabrique permissive "False" cote workflow.
+    (tmp_path / "merged.json").write_text('{"items": []}', encoding="utf-8")
+    rc = vlc.main([
+        "--replay", str(tmp_path / "merged.json"), "--check-pr", "4245",
+        "--body", _LIGHT_CANDIDATE_BODY,
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cap_reached"] is None
+    assert out["verdict"] == "unknown"
+
+
+def test_replay_valid_empty_array_still_computes_legitimate_false(tmp_path, capsys):
+    # Controle du controle : un [] VALIDE n'est pas un unknown. C'est une
+    # vraie journee a zero mergees -> cap = max(1, 0//3) = 1, budget intact,
+    # premiere LIGHT de la lane legitime. Confondre ce cas avec unknown
+    # serait la regression inverse (paralysie du garde).
+    (tmp_path / "merged.json").write_text("[]", encoding="utf-8")
+    rc = vlc.main([
+        "--replay", str(tmp_path / "merged.json"), "--check-pr", "4246",
+        "--body", _LIGHT_CANDIDATE_BODY,
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cap_reached"] is False  # calcule, pas fabrique
+    assert out.get("verdict", "assessed") == "assessed"

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -1165,10 +1165,31 @@ def compute_signals(
 _GH_DEFAULT_PAGE = 30
 
 
+class CapInputError(Exception):
+    """The merged-PR replay file is absent, unreadable, or not a JSON array.
+
+    #14849: this is an UNKNOWN verdict, never a permissive False. Pre-fix,
+    _load crashed (or sys.exit'd) before any JSON hit stdout, the workflow's
+    `|| echo "False"` reader turned the crash into "cap not reached", and a
+    LIGHT over budget was silently re-authorized. Raising lets main() emit
+    {"cap_reached": null, "verdict": "unknown"} so the workflow can warn and
+    leave labels untouched instead of guessing.
+    """
+
+
 def _load(path: str) -> list[dict]:
-    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as e:
+        raise CapInputError(f"replay file absent/unreadable: {path} ({e})") from e
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise CapInputError(f"replay file is not valid JSON: {path} ({e})") from e
     if not isinstance(data, list):
-        sys.exit(f"--replay/--check-pr expects a JSON array, got {type(data).__name__}")
+        raise CapInputError(
+            f"--replay/--check-pr expects a JSON array, got {type(data).__name__}"
+        )
     if len(data) == _GH_DEFAULT_PAGE:
         print(
             f"AVERTISSEMENT: le jeu de comptage fait exactement {_GH_DEFAULT_PAGE} "
@@ -1223,7 +1244,18 @@ def main(argv: list[str] | None = None) -> int:
     if not args.replay:
         p.error("--replay FILE (the merged-PR set) is required")
 
-    merged = _load(args.replay)
+    try:
+        merged = _load(args.replay)
+    except CapInputError as e:
+        # #14849: unassessable input = UNKNOWN verdict (same family as the
+        # no-Grain-tag / no-lane paths: cap_reached null), never a permissive
+        # False. Advisory organ -> exit 0; the workflow surfaces ::warning::
+        # and leaves labels untouched. A valid empty array `[]` still computes
+        # a legitimate False (it goes through _load without raising).
+        print(f"ENTREE NON EXPLOITABLE : {e} -- verdict UNKNOWN, cap non calcule.",
+              file=sys.stderr)
+        print(json.dumps({"cap_reached": None, "verdict": "unknown", "reason": str(e)}))
+        return 0
 
     if args.check_pr is not None:
         # CI mode: the current PR is OPEN, so its body is NOT in the merged set.


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14818

## Defaut (cas mesure par l'issue)

La porte light-cap de `always-on-guards.yml` chainait trois silencements qui, combines, transformaient un crash en decision permissive :

1. `gh pr list ... > /tmp/merged.json 2>/dev/null || true` — fetch echoue => merged.json **absent**, stderr avale
2. `_load()` crashait (`FileNotFoundError`) avant toute sortie JSON => status.json vide
3. `CAP=$(python3 ... 2>/dev/null || echo "False")` — le fallback fabriquait **cap non atteint** sur une absence de donnee

Resultat : une LIGHT over budget etait re-autorisee en silence. En section B, `|| printf '[]' > /tmp/merged.json` fabriquait une "journee a zero mergees" en apparence legitime (signaux tous lus False).

## Fix (3 fichiers, +151/-8)

**`scripts/variation_light_cap.py`**
- `CapInputError` (exception dediee, docstring #14849)
- `_load()` raise sur : fichier absent/illisible (`OSError`), JSON invalide (`JSONDecodeError`), pas un tableau (l'ancien `sys.exit` sans sortie JSON avait la meme fabrique permissive cote workflow)
- `main()` catch => `{"cap_reached": null, "verdict": "unknown", "reason": ...}` sur stdout + diagnostic stderr, exit 0 (organe advisory, symetrique au chemin no-Grain-tag #9465). **Un `[]` valide traverse `_load` sans raise et calcule toujours un False legitime.**

**`.github/workflows/always-on-guards.yml` section A (light-cap)**
- stderr du fetch capture (`/tmp/merged_fetch.err`) et surface dans le log du job
- reader CAP : fallback `"None"` (jamais `"False"`) — reader HS ou champ null => branche unknown
- nouvelle branche `else` = `::warning::` nommant la cause + **label ni pose ni retire** (les deux branches lisent un cap non calcule)

**section B (genre-signals)**
- fabrication `printf '[]'` supprimee ; stderr capture et surfacee
- guard `B_VERDICT` avant le label loop : verdict unknown => `::warning::` + labels laisses intacts (ni pose ni retire) + exit 0

## Controles positifs (un detecteur se valide par ses faux negatifs)

5 nouveaux tests dans `scripts/tests/test_variation_light_cap.py`, chacun echoue sur le code pre-fix :

| replay | verdict pre-fix | verdict post-fix |
|---|---|---|
| fichier absent | crash (workflow lisait False) | `cap_reached: null, verdict: unknown` |
| fichier vide | crash | idem |
| JSON invalide | crash | idem |
| JSON non-tableau | sys.exit(1) sans sortie | idem |
| `[]` **valide** | False calcule | False calcule (controle du controle : pas de regression inverse) |

Suite complete : **118/118 passed** (113 existants intacts + 5 nouveaux).

## Simulation des branches workflow (post-fix)

```
cap_reached=true   -> CAP='True'  -> add-label
cap_reached=false  -> CAP='False' -> remove-label
cap_reached=null   -> CAP='None'  -> UNKNOWN-warning   (le fix)
status.json absent -> CAP='None'  -> UNKNOWN-warning   (le fix)
```

Idem section B : `signals.json` sans verdict => proceed ; verdict unknown ou fichier absent => guard + warning.

## Portee et suivi

- Cas mesure only. Le **sweep** du meme idiome ailleurs (readers `|| echo "False"`, `printf '[]'`) est un grain distinct : `variation-light-genre.yml` l.111/137/147 + 8 readers l.179-186 porte la copie integrale de la section B pre-fix.
- La branche unknown de la section A couvre aussi le cas no-Grain-tag (`cap_reached: null` existant) : le label n'est plus retire sur une PR inassessable — semantique voulue (variation-tag-guard signale deja le tag manquant).

Closes #14849