### PR TITLE
feat(claims-guard): detect relations against output metrics

### DIFF
--- a/.github/workflows/markdown-claims-output-advisory.yml
+++ b/.github/workflows/markdown-claims-output-advisory.yml
@@ -55,7 +55,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # The detector requires merge-base(origin/main, HEAD). A depth-1
+          # checkout made the advisory abstain on ordinary pull requests.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/markdown-claims-output-advisory.yml
+++ b/.github/workflows/markdown-claims-output-advisory.yml
@@ -1,8 +1,9 @@
 name: Markdown claims anchored to previous output (advisory)
 
-# Durable anti-regression advisory for the c.290 / c.331 pathologie:
-# "markdown prose cites quantitative values that contradict the output
-# of the previous code cell". Two open PRs in the same week exhibited
+# Durable anti-regression advisory for two prose/output hazards:
+# - markdown cites numeric values absent from nearby code outputs;
+# - an explicit named relation is contradicted or left unproved by those outputs.
+# Two open PRs in the same week exhibited the first class:
 # this:
 #   - PR #11435 (FT-02-QLoRA-Quantization.ipynb c10/c20)
 #   - c.290 LSTM-vol notebook (M15)
@@ -89,17 +90,19 @@ jobs:
             echo "::warning::markdown-claims-output: merge-base origin/main HEAD introuvable -- detector abstains (shallow fetch or unanchored branch)." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          CHANGED=$(git diff --name-only --diff-filter=MR -M50% "$BASE" HEAD -- '*.ipynb' | head -50)
-          if [ -z "$CHANGED" ]; then
+          mapfile -t CHANGED < <(git diff --name-only --diff-filter=MR -M50% "$BASE" HEAD -- '*.ipynb' | head -50)
+          if [ ${#CHANGED[@]} -eq 0 ]; then
             echo "exit=0" >> "$GITHUB_OUTPUT"
             echo "::notice::markdown-claims-output: aucun notebook modifie entre $BASE et HEAD -- rien a scanner." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          # xargs chunk to dodge ARG_MAX on large diffs (> ~100 notebooks)
-          printf '%s\n' "$CHANGED" | xargs -n 30 python scripts/check_markdown_claims_output.py \
-            --json > /tmp/claims-output.json 2> /tmp/claims-output.err
+          # One bounded invocation preserves checker exit codes and emits one
+          # valid JSON document; the array also preserves spaces in paths.
+          python scripts/check_markdown_claims_output.py --json "${CHANGED[@]}" \
+            > /tmp/claims-output.json 2> /tmp/claims-output.err
           rc=$?
           echo "exit=$rc" >> "$GITHUB_OUTPUT"
+          echo "report=present" >> "$GITHUB_OUTPUT"
           if [ $rc -ne 0 ] && [ $rc -ne 1 ]; then
             echo "::warning::markdown-claims-output: detector exit code $rc (not 0/1) -- voir /tmp/claims-output.err." >> "$GITHUB_STEP_SUMMARY"
             cat /tmp/claims-output.err >> "$GITHUB_STEP_SUMMARY"
@@ -107,14 +110,22 @@ jobs:
           fi
           set -e
 
+      - name: Upload structured advisory report
+        if: steps.run.outputs.report == 'present'
+        uses: actions/upload-artifact@v4
+        with:
+          name: markdown-claims-output-report
+          path: /tmp/claims-output.json
+          retention-days: 7
+
       - name: Post advisory comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: markdown-claims-output-advisory
           message: |
-            ${{ steps.run.outputs.exit == '0' && '✅ No fabricated prose detected (in the notebooks this PR changed).' || steps.run.outputs.exit == 'abstain' && '⚠️ Detector abstained (merge-base introuvable, shallow fetch or unanchored branch).' || '⚠️ Potential fabricated prose in the notebooks this PR changed (markdown cites numbers absent from previous code output). Review against source — these are advisory, NOT a merge gate.' }}
+            ${{ steps.run.outputs.exit == '0' && '✅ No prose/output mismatch detected in the notebooks this PR changed.' || steps.run.outputs.exit == 'abstain' && '⚠️ Detector abstained (merge-base introuvable, shallow fetch or unanchored branch).' || '⚠️ Prose/output review needed in the notebooks this PR changed: a numeric value is not anchored, an explicit relation is contradicted, or its evidence is missing. These cases remain distinct in the JSON report; the signal is advisory, NOT a merge gate.' }}
 
-            c.415 (#11873): scope = notebooks CHANGED in this PR, not the whole corpus.
-            See `python scripts/check_markdown_claims_output.py --help` for re-running locally.
-            Detector rationale: c.290 / c.331 / PR #11435 pathologie.
+            Scope = notebooks CHANGED in this PR, not the whole corpus. Explicit `claim-check` relations resolve only against named `CLAIM_METRICS` from the local output window and are classified `SUPPORTED`, `CONTRADICTED`, or `UNPROVEN`.
+            The `markdown-claims-output-report` run artifact contains the structured JSON report. See `python scripts/check_markdown_claims_output.py --help` for re-running locally.
+            Detector rationale: c.290 / c.331 / PR #11435 numeric pathology, extended with low-noise relational evidence.

--- a/scripts/check_markdown_claims_output.py
+++ b/scripts/check_markdown_claims_output.py
@@ -154,7 +154,11 @@ def _output_text(outputs: list) -> str:
             continue
         ot = out.get("output_type") or out.get("type")
         if ot == "stream":
-            chunks.append(str(out.get("text", "")))
+            value = out.get("text", "")
+            if isinstance(value, list):
+                chunks.append("".join(str(item) for item in value))
+            else:
+                chunks.append(str(value))
         elif ot in ("execute_result", "display_data"):
             data = out.get("data", {}) or {}
             for k in ("text/plain", "text/html", "application/vnd.jupyter.widget-view+json"):

--- a/scripts/check_markdown_claims_output.py
+++ b/scripts/check_markdown_claims_output.py
@@ -41,14 +41,18 @@ The script does NOT touch:
     output format is opaque to a regex)
 
 The script is read-only on the notebook: it does NOT edit, only classifies.
-Verdicts: CLEAN / FABRICATION_DETECTED / SKIPPED-LITERATURE / ERROR.
+Notebook verdicts: CLEAN / FABRICATION_DETECTED / CONTRADICTION_DETECTED /
+CLAIM_UNPROVEN / ERROR. Individual relational claims are classified as
+SUPPORTED / CONTRADICTED / UNPROVEN.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
+from decimal import Decimal
 import sys
 from pathlib import Path
 
@@ -73,6 +77,17 @@ NUMERIC_RE = re.compile(
     """,
     re.VERBOSE | re.IGNORECASE,
 )
+
+# Optional machine-readable contract for claims that cannot be checked by
+# numeric presence alone. Code outputs expose named scalar metrics and the
+# adjacent markdown states an explicit relation. JSON is parsed as data only;
+# no expression is evaluated.
+METRICS_RE = re.compile(r"(?m)^\s*CLAIM_METRICS\s+(\{[^\r\n]*\})\s*$")
+CLAIM_CHECK_RE = re.compile(
+    r"<!--\s*claim-check\s*:\s*(.*?)\s*-->",
+    re.IGNORECASE | re.DOTALL,
+)
+RELATIONAL_OPERATORS = {"<", "<=", ">", ">=", "==", "!="}
 
 
 def _normalize_num(token: str) -> str:
@@ -188,23 +203,26 @@ def _is_md_heading_line(line: str) -> bool:
     return line.lstrip().startswith("#")
 
 
-def _strip_md_structure(src: str) -> str:
-    """Drop heading lines + code fences + table-headers so we only scan prose
-    sentences. Code fences are STATEFUL (a ``` line opens and closes a block)."""
+def _strip_fenced_blocks(src: str) -> str:
+    """Drop fenced examples while preserving ordinary markdown prose."""
     kept: list[str] = []
     in_fence = False
     for line in src.splitlines():
         if line.strip().startswith("```"):
             in_fence = not in_fence
             continue
-        if in_fence:
-            continue
-        if _is_md_heading_line(line):
-            continue
-        if line.lstrip().startswith("|"):
-            continue
-        kept.append(line)
+        if not in_fence:
+            kept.append(line)
     return "\n".join(kept)
+
+
+def _strip_md_structure(src: str) -> str:
+    """Drop headings, fenced examples, and table rows before scanning prose."""
+    return "\n".join(
+        line
+        for line in _strip_fenced_blocks(src).splitlines()
+        if not _is_md_heading_line(line) and not line.lstrip().startswith("|")
+    )
 
 
 # Tokens that, when appearing immediately before a number, mark the
@@ -532,6 +550,197 @@ def _is_threshold_expression(src: str, match_pos: int, match_end: int) -> bool:
     return bool(_THRESHOLD_OP_RE.search(span))
 
 
+def _is_scalar(value: object) -> bool:
+    """Return whether value is a finite JSON scalar supported by claims."""
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, int):
+        return True
+    return isinstance(value, float) and math.isfinite(value)
+
+
+def _extract_claim_metrics(
+    output_texts: list[tuple[int, str]],
+) -> tuple[dict[str, object], dict[str, int]]:
+    """Extract nearest named metrics and their code-cell provenance."""
+    metrics: dict[str, object] = {}
+    sources: dict[str, int] = {}
+    for code_idx, text in output_texts:
+        for match in METRICS_RE.finditer(text):
+            try:
+                payload = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            for name, value in payload.items():
+                if (
+                    isinstance(name, str)
+                    and name
+                    and _is_scalar(value)
+                    and name not in metrics
+                ):
+                    metrics[name] = value
+                    sources[name] = code_idx
+    return metrics, sources
+
+
+def _resolve_operand(
+    operand: object,
+    metrics: dict[str, object],
+) -> tuple[object | None, str | None]:
+    """Resolve a metric-name operand or accept a scalar constant."""
+    if isinstance(operand, str):
+        if operand not in metrics:
+            return None, f"metric {operand!r} is absent from the local output window"
+        return metrics[operand], None
+    if _is_scalar(operand):
+        return operand, None
+    return None, "operand must be a metric name or a finite numeric/boolean constant"
+
+
+def _compare_relation(
+    left: object,
+    op: str,
+    right: object,
+    tolerance: int | float,
+) -> bool:
+    """Evaluate one closed relation without evaluating arbitrary code."""
+    if op in {"<", "<=", ">", ">="}:
+        if (
+            isinstance(left, bool)
+            or isinstance(right, bool)
+            or not isinstance(left, (int, float))
+            or not isinstance(right, (int, float))
+        ):
+            raise TypeError("ordered comparisons require numeric operands")
+        return {
+            "<": left < right,
+            "<=": left <= right,
+            ">": left > right,
+            ">=": left >= right,
+        }[op]
+
+    left_numeric = isinstance(left, (int, float)) and not isinstance(left, bool)
+    right_numeric = isinstance(right, (int, float)) and not isinstance(right, bool)
+    if left_numeric and right_numeric:
+        equal = abs(Decimal(str(left)) - Decimal(str(right))) <= Decimal(str(tolerance))
+    elif left_numeric != right_numeric:
+        raise TypeError("equality requires operands of compatible types")
+    else:
+        equal = type(left) is type(right) and left == right
+    return equal if op == "==" else not equal
+
+
+def _check_relational_claims(
+    source: str,
+    markdown_cell: int,
+    metrics: dict[str, object],
+    metric_sources: dict[str, int],
+    window: list[int],
+) -> list[dict]:
+    """Classify explicit claim-check contracts as supported/contradicted/unproven."""
+    results: list[dict] = []
+    for ordinal, match in enumerate(CLAIM_CHECK_RE.finditer(source), start=1):
+        raw_contract = match.group(1)
+        claim: object
+        try:
+            claim = json.loads(raw_contract)
+        except json.JSONDecodeError as exc:
+            results.append({
+                "id": f"markdown-{markdown_cell}-{ordinal}",
+                "status": "UNPROVEN",
+                "reason": f"invalid claim-check JSON: {exc.msg}",
+                "markdown_cell": markdown_cell,
+                "window": window,
+            })
+            continue
+
+        generated_id = f"markdown-{markdown_cell}-{ordinal}"
+        supplied_id = claim.get("id") if isinstance(claim, dict) else None
+        claim_id = supplied_id if isinstance(supplied_id, str) and supplied_id else generated_id
+        if not isinstance(claim, dict):
+            results.append({
+                "id": claim_id,
+                "status": "UNPROVEN",
+                "reason": "claim-check must be a JSON object",
+                "markdown_cell": markdown_cell,
+                "window": window,
+            })
+            continue
+
+        allowed = {"id", "left", "op", "right", "tolerance"}
+        unknown = sorted(set(claim) - allowed)
+        op = claim.get("op")
+        tolerance = claim.get("tolerance", 0.0)
+        reason = None
+        if unknown:
+            reason = f"unknown claim-check fields: {', '.join(unknown)}"
+        elif not isinstance(supplied_id, str) or not supplied_id:
+            reason = "claim-check id must be a non-empty string"
+        elif "left" not in claim or "right" not in claim:
+            reason = "claim-check requires left and right operands"
+        elif op not in RELATIONAL_OPERATORS:
+            reason = f"unsupported operator: {op!r}"
+        elif (
+            isinstance(tolerance, bool)
+            or not isinstance(tolerance, (int, float))
+            or (isinstance(tolerance, float) and not math.isfinite(tolerance))
+            or tolerance < 0
+        ):
+            reason = "tolerance must be a finite non-negative number"
+        elif op in {"<", "<=", ">", ">="} and tolerance != 0:
+            reason = "tolerance is supported only for equality comparisons"
+
+        left = right = None
+        if reason is None:
+            left, reason = _resolve_operand(claim["left"], metrics)
+        if reason is None:
+            right, reason = _resolve_operand(claim["right"], metrics)
+
+        if reason is not None:
+            results.append({
+                "id": claim_id,
+                "status": "UNPROVEN",
+                "reason": reason,
+                "markdown_cell": markdown_cell,
+                "window": window,
+            })
+            continue
+
+        try:
+            supported = _compare_relation(left, op, right, tolerance)
+        except TypeError as exc:
+            results.append({
+                "id": claim_id,
+                "status": "UNPROVEN",
+                "reason": str(exc),
+                "markdown_cell": markdown_cell,
+                "window": window,
+            })
+            continue
+
+        metric_names = [
+            operand
+            for operand in (claim["left"], claim["right"])
+            if isinstance(operand, str)
+        ]
+        results.append({
+            "id": claim_id,
+            "status": "SUPPORTED" if supported else "CONTRADICTED",
+            "left": claim["left"],
+            "left_value": left,
+            "op": op,
+            "right": claim["right"],
+            "right_value": right,
+            "tolerance": tolerance,
+            "markdown_cell": markdown_cell,
+            "code_cells": sorted({metric_sources[name] for name in metric_names}),
+            "window": window,
+        })
+    return results
+
+
 def check_notebook(path: Path) -> dict:
     """Scan a single notebook. Returns a structured dict compatible with
     JSON serialization (so the script can be consumed by CI gates)."""
@@ -543,10 +752,12 @@ def check_notebook(path: Path) -> dict:
             "verdict": "ERROR",
             "errors": [f"json.loads failed: {e}"],
             "findings": [],
+            "relational_claims": [],
         }
 
     cells = nb.get("cells", []) or []
     findings: list[dict] = []
+    relational_claims: list[dict] = []
     skipped_lit = 0
     skipped_no_prev = 0
     skipped_no_output = 0
@@ -555,34 +766,48 @@ def check_notebook(path: Path) -> dict:
         if cell.get("cell_type") != "markdown":
             continue
         src = "".join(cell.get("source", []) if isinstance(cell.get("source"), list) else [str(cell.get("source", ""))])
-        if not src or _lit_skip(src):
+        if not src:
             skipped_lit += 1
             continue
-        # Drop heading lines + table-headers + code fences from the prose
-        # we scan (structurals are not quantitative claims).
-        prose = _strip_md_structure(src)
-        # Find the previous code cells (within window) with output
+        # Find the previous code cells (within window) with output.
         prev_code_idxs: list[int] = []
         for j in range(idx - 1, -1, -1):
             if cells[j].get("cell_type") == "code":
                 prev_code_idxs.append(j)
                 if len(prev_code_idxs) >= WINDOW:
                     break
+
+        output_texts: list[tuple[int, str]] = []
+        for j in prev_code_idxs:
+            outputs = cells[j].get("outputs") or []
+            output_texts.append((j, _output_text(outputs)))
+
+        metrics, metric_sources = _extract_claim_metrics(output_texts)
+        relational_claims.extend(
+            _check_relational_claims(
+                _strip_fenced_blocks(src),
+                idx,
+                metrics,
+                metric_sources,
+                prev_code_idxs,
+            )
+        )
+
+        # The literature heuristic suppresses only noisy numeric extraction.
+        # Explicit claim-check contracts remain checkable in long prose cells.
+        if _lit_skip(src):
+            skipped_lit += 1
+            continue
+        # Drop heading lines + table-headers + code fences from the prose
+        # we scan (structurals are not quantitative claims).
+        prose = CLAIM_CHECK_RE.sub("", _strip_md_structure(src))
         if not prev_code_idxs:
             skipped_no_prev += 1
             continue
-        # Concat outputs of the previous code cells (within window)
-        out_chunks: list[str] = []
-        any_output = False
-        for j in prev_code_idxs:
-            outs = cells[j].get("outputs") or []
-            if outs:
-                any_output = True
-            out_chunks.append(_output_text(outs))
-        if not any_output:
+        if not any(text for _, text in output_texts):
             skipped_no_output += 1
             continue
-        raw_out_text = "\n".join(out_chunks)
+        raw_out_text = "\n".join(text for _, text in output_texts)
         # #12076: the direct search compares normalized claim vs normalized
         # output; the fuzzy fallback keeps the RAW text (its comma-gate, clause
         # (c), reads large-number signals from the commas themselves).
@@ -636,16 +861,28 @@ def check_notebook(path: Path) -> dict:
                     "context": _excerpt(src, raw),
                 })
 
-    n_findings = len(findings)
-    verdict = "CLEAN" if n_findings == 0 else "FABRICATION_DETECTED"
+    relational_counts = {
+        status: sum(1 for claim in relational_claims if claim["status"] == status)
+        for status in ("SUPPORTED", "CONTRADICTED", "UNPROVEN")
+    }
+    if findings:
+        verdict = "FABRICATION_DETECTED"
+    elif relational_counts["CONTRADICTED"]:
+        verdict = "CONTRADICTION_DETECTED"
+    elif relational_counts["UNPROVEN"]:
+        verdict = "CLAIM_UNPROVEN"
+    else:
+        verdict = "CLEAN"
     return {
         "path": str(path),
         "verdict": verdict,
         "findings": findings,
+        "relational_claims": relational_claims,
         "stats": {
             "skipped_literature": skipped_lit,
             "skipped_no_prev_code": skipped_no_prev,
             "skipped_no_output": skipped_no_output,
+            "relational_claims": relational_counts,
         },
     }
 
@@ -742,6 +979,19 @@ def render(result: dict) -> str:
                 f"raw={f['raw']!r} normalized={f['normalized']!r}"
             )
             lines.append(f"      context: ...{f['context']}...")
+    for claim in result.get("relational_claims", []):
+        relation = ""
+        if "op" in claim:
+            relation = (
+                f" {claim['left']!r}={claim['left_value']!r} "
+                f"{claim['op']} {claim['right']!r}={claim['right_value']!r}"
+            )
+        lines.append(
+            f"  claim {claim['id']!r}: {claim['status']} at "
+            f"md[{claim['markdown_cell']}]{relation}"
+        )
+        if claim.get("reason"):
+            lines.append(f"    reason: {claim['reason']}")
     return "\n".join(lines)
 
 
@@ -752,8 +1002,8 @@ def main() -> int:
             "previous code cell's output (c.290 pathologie, C.5 violation)."
         ),
         epilog=(
-            "Exit: 0 CLEAN, 1 FABRICATION_DETECTED, 2 ERROR. "
-            "Use --json for CI gate consumption."
+            "Exit: 0 CLEAN, 1 advisory finding (numeric, contradicted, or "
+            "unproven), 2 ERROR. Use --json for CI consumption."
         ),
     )
     ap.add_argument("notebooks", nargs="+", help="paths to .ipynb files")
@@ -772,6 +1022,7 @@ def main() -> int:
                 "verdict": "ERROR",
                 "errors": [f"file not found: {p}"],
                 "findings": [],
+                "relational_claims": [],
             })
             continue
         results.append(check_notebook(p))
@@ -783,11 +1034,19 @@ def main() -> int:
             print(render(r))
             print()
 
-    fabricated = sum(1 for r in results if r["verdict"] == "FABRICATION_DETECTED")
-    errored = sum(1 for r in results if r["verdict"] == "ERROR")
+    advisory = sum(
+        1
+        for result in results
+        if result["verdict"] in {
+            "FABRICATION_DETECTED",
+            "CONTRADICTION_DETECTED",
+            "CLAIM_UNPROVEN",
+        }
+    )
+    errored = sum(1 for result in results if result["verdict"] == "ERROR")
     if errored:
         return 2
-    return 1 if fabricated else 0
+    return 1 if advisory else 0
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_markdown_claims_output.py
+++ b/scripts/tests/test_check_markdown_claims_output.py
@@ -1077,3 +1077,282 @@ class TestRealFabricationStillDetected:
         assert any("0,09" in r or "0.09" in r for r in raws), (
             f"Expected '0,09' / '0.09' substring in findings, got {raws}"
         )
+
+
+class TestRelationalClaims:
+    """Explicit named relations distinguish evidence from contradiction."""
+
+    @staticmethod
+    def _claim(**payload) -> str:
+        return (
+            "Conclusion calculée.\n"
+            f"<!-- claim-check: {json.dumps(payload)} -->"
+        )
+
+    @staticmethod
+    def _scan(tmp_path: Path, cells: list[dict]):
+        path = tmp_path / "relational.ipynb"
+        path.write_text(json.dumps(_mk_nb(cells)), encoding="utf-8")
+        return check_notebook(path)
+
+    def test_contradicted_acceleration_14_vs_16(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("compare()", [
+                _stream_output(
+                    'CLAIM_METRICS {"plain_iterations": 14, '
+                    '"shaped_iterations": 16}\n'
+                ),
+            ]),
+            _md_cell(self._claim(
+                id="shaping-accelerates",
+                left="shaped_iterations",
+                op="<",
+                right="plain_iterations",
+            )),
+        ])
+
+        assert result["verdict"] == "CONTRADICTION_DETECTED"
+        claim = result["relational_claims"][0]
+        assert claim["status"] == "CONTRADICTED"
+        assert claim["left_value"] == 16
+        assert claim["right_value"] == 14
+        assert claim["code_cells"] == [0]
+
+    def test_supported_relation_and_boolean(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("compare()", [
+                _exec_output(
+                    'CLAIM_METRICS {"plain_sweep": 8, "shaped_sweep": 3, '
+                    '"final_policy_equal": true}'
+                ),
+            ]),
+            _md_cell(
+                self._claim(
+                    id="earlier-policy",
+                    left="shaped_sweep",
+                    op="<",
+                    right="plain_sweep",
+                )
+                + "\n"
+                + self._claim(
+                    id="policy-preserved",
+                    left="final_policy_equal",
+                    op="==",
+                    right=True,
+                )
+            ),
+        ])
+
+        assert result["verdict"] == "CLEAN"
+        assert [c["status"] for c in result["relational_claims"]] == [
+            "SUPPORTED",
+            "SUPPORTED",
+        ]
+        assert result["stats"]["relational_claims"]["SUPPORTED"] == 2
+
+    def test_missing_metric_is_unproven(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("compare()", [
+                _stream_output('CLAIM_METRICS {"plain_iterations": 14}\n'),
+            ]),
+            _md_cell(self._claim(
+                id="missing-shaped",
+                left="shaped_iterations",
+                op="<",
+                right="plain_iterations",
+            )),
+        ])
+
+        assert result["verdict"] == "CLAIM_UNPROVEN"
+        claim = result["relational_claims"][0]
+        assert claim["status"] == "UNPROVEN"
+        assert "shaped_iterations" in claim["reason"]
+
+    @pytest.mark.parametrize(
+        ("actual", "tolerance", "status"),
+        [(0.301, 0.01, "SUPPORTED"), (0.32, 0.01, "CONTRADICTED")],
+    )
+    def test_numeric_equality_tolerance(
+        self,
+        tmp_path: Path,
+        actual: float,
+        tolerance: float,
+        status: str,
+    ):
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output(
+                    f'CLAIM_METRICS {{"measured_regret": {actual}}}\n'
+                ),
+            ]),
+            _md_cell(self._claim(
+                id="regret-target",
+                left="measured_regret",
+                op="==",
+                right=0.3,
+                tolerance=tolerance,
+            )),
+        ])
+
+        assert result["relational_claims"][0]["status"] == status
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"id": "bad-op", "left": "x", "op": "approximately", "right": 1},
+            {"id": "unknown-field", "left": "x", "op": "==", "right": 1,
+             "expression": "x == 1"},
+            {"left": "x", "op": "==", "right": 1},
+            {"id": "", "left": "x", "op": "==", "right": 1},
+            {"id": 7, "left": "x", "op": "==", "right": 1},
+            {"id": "ordered-tolerance", "left": "x", "op": "<", "right": 2,
+             "tolerance": 0.1},
+        ],
+    )
+    def test_invalid_contract_is_unproven_without_crash(
+        self,
+        tmp_path: Path,
+        payload: dict,
+    ):
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output('CLAIM_METRICS {"x": 1}\n'),
+            ]),
+            _md_cell(self._claim(**payload)),
+        ])
+
+        assert result["verdict"] == "CLAIM_UNPROVEN"
+        assert result["relational_claims"][0]["status"] == "UNPROVEN"
+
+    def test_huge_integer_metric_and_tolerance_do_not_crash(self, tmp_path: Path):
+        huge = 10**400
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output(f'CLAIM_METRICS {{"huge": {huge}}}\n'),
+            ]),
+            _md_cell(self._claim(
+                id="huge-int",
+                left="huge",
+                op="==",
+                right=huge,
+                tolerance=huge,
+            )),
+        ])
+
+        assert result["verdict"] == "CLEAN"
+        assert result["relational_claims"][0]["status"] == "SUPPORTED"
+
+    def test_boolean_numeric_equality_is_unproven(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output('CLAIM_METRICS {"flag": true}\n'),
+            ]),
+            _md_cell(self._claim(
+                id="typed-equality",
+                left="flag",
+                op="==",
+                right=1,
+            )),
+        ])
+
+        assert result["verdict"] == "CLAIM_UNPROVEN"
+        assert result["relational_claims"][0]["status"] == "UNPROVEN"
+
+    def test_fenced_claim_example_is_not_evaluated(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output('CLAIM_METRICS {"x": 1}\n'),
+            ]),
+            _md_cell(
+                "Exemple de syntaxe :\n```html\n"
+                + self._claim(id="example", left="x", op="==", right=2)
+                + "\n```"
+            ),
+        ])
+
+        assert result["verdict"] == "CLEAN"
+        assert result["relational_claims"] == []
+
+    def test_malformed_json_is_unproven(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output('CLAIM_METRICS {"x": 1}\n'),
+            ]),
+            _md_cell(
+                "Conclusion calculée.\n"
+                '<!-- claim-check: {"id":"broken","left":"x" -->'
+            ),
+        ])
+
+        assert result["verdict"] == "CLAIM_UNPROVEN"
+        claim = result["relational_claims"][0]
+        assert claim["status"] == "UNPROVEN"
+        assert "invalid claim-check JSON" in claim["reason"]
+
+    def test_explicit_claim_in_long_prose_is_still_checked(self, tmp_path: Path):
+        long_prose = "## Bibliographie\n" + "Contexte pédagogique détaillé. " * 50
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output('CLAIM_METRICS {"x": 1}\n'),
+            ]),
+            _md_cell(
+                long_prose
+                + "\n"
+                + self._claim(id="long-cell", left="x", op="==", right=1)
+            ),
+        ])
+
+        assert result["relational_claims"][0]["status"] == "SUPPORTED"
+        assert result["stats"]["skipped_literature"] == 1
+
+    def test_distant_metric_outside_window_does_not_prove_claim(self, tmp_path: Path):
+        cells = [
+            _code_cell("old_measure()", [
+                _stream_output('CLAIM_METRICS {"score": 0.9}\n'),
+            ]),
+            _code_cell("step_1()", [_stream_output("step one\n")]),
+            _code_cell("step_2()", [_stream_output("step two\n")]),
+            _code_cell("step_3()", [_stream_output("step three\n")]),
+            _md_cell(self._claim(
+                id="local-only",
+                left="score",
+                op=">",
+                right=0.5,
+            )),
+        ]
+        result = self._scan(tmp_path, cells)
+
+        claim = result["relational_claims"][0]
+        assert claim["status"] == "UNPROVEN"
+        assert claim["window"] == [3, 2, 1]
+
+    def test_numeric_finding_and_relation_coexist(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("measure()", [
+                _stream_output(
+                    'observed=0.24\nCLAIM_METRICS {"final_policy_equal": true}\n'
+                ),
+            ]),
+            _md_cell(
+                "La valeur observée est 0,09.\n"
+                + self._claim(
+                    id="policy-preserved",
+                    left="final_policy_equal",
+                    op="==",
+                    right=True,
+                )
+            ),
+        ])
+
+        assert result["verdict"] == "FABRICATION_DETECTED"
+        assert result["findings"]
+        assert result["relational_claims"][0]["status"] == "SUPPORTED"
+
+    def test_plain_unannotated_prose_keeps_legacy_behavior(self, tmp_path: Path):
+        result = self._scan(tmp_path, [
+            _code_cell("print_domain()", [_stream_output("three actions\n")]),
+            _md_cell("Le domaine comprend trois actions possibles."),
+        ])
+
+        assert result["verdict"] == "CLEAN"
+        assert result["relational_claims"] == []

--- a/scripts/tests/test_check_markdown_claims_output.py
+++ b/scripts/tests/test_check_markdown_claims_output.py
@@ -206,6 +206,15 @@ class TestOutputExtraction:
         text = _output_output = _output_text([_stream_output("hello 0.24")])
         assert "hello 0.24" in text
 
+    def test_stream_output_nbformat_line_list(self):
+        output = _stream_output("unused")
+        output["text"] = [
+            "progress complete\n",
+            'CLAIM_METRICS {"first_optimal_sweep": 1}\n',
+        ]
+        text = _output_text([output])
+        assert "progress complete\nCLAIM_METRICS" in text
+
     def test_execute_result_output(self):
         text = _output_text([_exec_output("Params: 3,145,728")])
         assert "3,145,728" in text


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: DEEP/qc #14857

## Résumé

- étend l’advisory prose-sorties avec un contrat relationnel explicite pour les conclusions que la présence d’un nombre ne peut pas valider ;
- lit des métriques scalaires nommées émises par une sortie locale `CLAIM_METRICS {...}` puis classe chaque annotation markdown `claim-check` en `SUPPORTED`, `CONTRADICTED` ou `UNPROVEN` ;
- conserve le détecteur numérique historique et maintient le workflow en advisory non bloquant.

## Contrat fermé

Le parseur n’évalue aucune expression. Il accepte uniquement :

- un objet JSON `claim-check` avec `id`, `left`, `op`, `right` et une tolérance optionnelle ;
- les opérateurs `<`, `<=`, `>`, `>=`, `==`, `!=` ;
- des noms de métriques locales ou des constantes JSON numériques finies et booléennes ;
- des métriques trouvées dans la même fenêtre de trois cellules code précédentes que le garde existant, la plus proche ayant priorité.

Une métrique absente, un JSON mal formé, un identifiant invalide, un champ inconnu, un opérateur non autorisé ou des types incompatibles produit `UNPROVEN`, jamais un succès implicite. Les comparaisons ordonnées excluent les booléens ; l’égalité numérique utilise une tolérance absolue explicite.

## Cas fondateur

Le test de non-régression encode les sorties observées de DecPyMC-7 :

- `plain_iterations = 14` ;
- `shaped_iterations = 16` ;
- claim `shaped_iterations < plain_iterations`.

Le verdict attendu et obtenu est `CONTRADICTED`. Ce garde ne modifie pas encore le notebook : la correction mathématique active est déjà portée par la PR #14866, afin d’éviter un diff concurrent sur le même fichier. L’expérience de profondeur finie restera une livraison notebook séparée, fondée sur cette correction.

## Compatibilité et rendu CI

- la prose non annotée suit exactement le chemin historique ;
- un finding numérique historique garde la priorité de verdict et peut coexister avec des claims relationnels ;
- le JSON et le rendu texte exposent l’identifiant, les opérandes résolues, l’opérateur, la provenance cellulaire et le motif d’un `UNPROVEN` ;
- le commentaire sticky distingue désormais nombre non ancré, relation contredite et preuve absente ;
- le workflow appelle le checker une seule fois avec un tableau Bash borné : il conserve les espaces dans les chemins, le code advisory `1` et un document JSON unique ;
- le scan reste limité aux notebooks modifiés dans la PR et s’abstient explicitement si le merge-base est introuvable.

## Validation

- `python -m pytest scripts/tests/test_check_markdown_claims_output.py -q` : **106 tests réussis**, dont un output `stream.text` nbformat sous forme liste ;
- `python -m py_compile scripts/check_markdown_claims_output.py` : succès ;
- `python scripts/ci/check_self_hosted_runner_policy.py` : **OK**, 144 workflows / 180 jobs / 119 jobs self-hosted conformes ;
- `git diff --check` : succès ;
- collision sur les trois chemins modifiés : aucune PR ouverte trouvée avant livraison.

Le signal reste volontairement advisory : une contradiction ou une preuve absente déclenche une revue, pas un merge-gate automatique.
