### PR TITLE
docs(ml,#13504): resync READMEs DataScienceWithAgents (52->57) + parent ML (32->57, socle 9->21)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -24,7 +24,7 @@ La formation couvre deux stacks complémentaires :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 52 (7 LangChain + 10 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 2 vision) |
+| Notebooks | 57 (7 LangChain + 14 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 3 vision) |
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 
@@ -116,16 +116,17 @@ DataScienceWithAgents/
 │   └── 3.8-Representations-Contrastives.ipynb
 │
 │
-├── 04-Vision/                # Vision par ordinateur : du neurone convolutif au transfer learning (2 notebooks)
+├── 04-Vision/                # Vision par ordinateur : du neurone convolutif au transfer learning (3 notebooks)
 │   ├── 4.1-Conv-NumPy-Torch-Allclose.ipynb
-│   └── 4.2-ConvNet-Profonde-Residuelles.ipynb
+│   ├── 4.2-ConvNet-Profonde-Residuelles.ipynb
+│   └── 4.3-TransferLearning-ResNet.ipynb
 │
 ├── Track1-LangChain/ # Track LangChain (7 labs)
 │   ├── Day1-Foundations/Labs/              # Revision
 │   ├── Day2-Document-Agents/Labs/              # Agents RFP et CV
 │   └── Day3-Data-Agents/Labs/              # Data + Agents
 │
-└── Track2-GoogleADK/         # Track Google ADK (10 labs)
+└── Track2-GoogleADK/         # Track Google ADK (14 labs)
     ├── Day4-Foundations/       # Introduction ADK
     ├── Day5-DS-Star/           # Data Science autonome
     ├── Day6-MLE-Star/          # ML Engineering
@@ -197,6 +198,7 @@ Documentation complète : [03-DeepLearning/README.md](03-DeepLearning/README.md)
 |----------|-------|---------------|
 | [4.1-Conv-NumPy-Torch-Allclose](04-Vision/4.1-Conv-NumPy-Torch-Allclose.ipynb) | Conv2d NumPy pur (single + multi-canal), gradient vérifié par différence finie, parité epsilon machine avec `torch.nn.Conv2d`, pooling et invariance par translation | **La convolution n'est pas magique** : un produit scalaire local, partagé spatialement, parité NumPy/torch à epsilon machine |
 | [4.2-ConvNet-Profonde-Residuelles](04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb) | 20 conv2d empilées nues (effondrement du gradient), skip naïf (gradient réparé mais passe avant qui dérive), bloc pré-norme (les deux réparés), même protocole transposé à 20 blocs d'attention, puis accuracy CIFAR-10 sur 3 graines | **Le skip-connection n'est pas un détail architectural** : c'est le mécanisme qui rend les réseaux profonds entraînables |
+| [4.3-TransferLearning-ResNet](04-Vision/4.3-TransferLearning-ResNet.ipynb) | ResNet18 pré-entraîné ImageNet, tête greffée (5 130 params entraînables sur 11,18 M), gelé vs fine-tuné sur EuroSAT (Sentinel-2, 10 classes, 3 graines appariées + test de permutation des signes) | **Le feature extractor pré-entraîné est réutilisable — et le prix de ne pas l'adapter se mesure** : gelé ~89 % ; fine-tuné +6,2 pts appariés, mais seulement à taux différencié décroissant (à taux constants, l'optimiseur finit sous le gelé) |
 
 Documentation complète : [04-Vision/README.md](04-Vision/README.md)
 
@@ -235,13 +237,17 @@ Track avancé intégrant les frameworks Google ADK (DS-STAR, MLE-STAR) avec supp
 | 8 | [ADK-Introduction](Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb) | Architecture ADK, configuration providers |
 | 9 | [First-ADK-Agent](Track2-GoogleADK/Day4-Foundations/Lab9-First-ADK-Agent.ipynb) | Premier agent pour Data Science |
 
-### Day 5 - DS-STAR (Labs 10-12)
+### Day 5 - DS-STAR (Labs 10-12 + extensions 12b-12d, 18)
 
 | Lab | Notebook | Objectif |
 |-----|----------|----------|
 | 10 | [File-Analyzer](Track2-GoogleADK/Day5-DS-Star/Lab10-File-Analyzer.ipynb) | Analyse de fichiers hétérogènes |
 | 11 | [Planner-Coder-Loop](Track2-GoogleADK/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb) | Boucle itérative multi-agents |
 | 12 | [DS-Star-Workshop](Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb) | Application complète |
+| 12b | [Sequential-Orchestration](Track2-GoogleADK/Day5-DS-Star/Lab12b-Sequential-Orchestration.ipynb) | Contrat C4 : désignation séquentielle, l'orchestrateur explicite au-dessus d'ADK |
+| 12c | [Agent-Handoff](Track2-GoogleADK/Day5-DS-Star/Lab12c-Agent-Handoff.ipynb) | Contrat C5 : handoff inter-agents natif câblé et observable |
+| 12d | [Token-Usage](Track2-GoogleADK/Day5-DS-Star/Lab12d-Token-Usage.ipynb) | Contrat C6 : traçabilité de la consommation LLM |
+| 18 | [Session-Persistence](Track2-GoogleADK/Day5-DS-Star/Lab18-Session-Persistence.ipynb) | Persistance d'état de session : une conversation qui se souvient |
 
 ### Day 6 - MLE-STAR (Labs 13-15)
 
@@ -413,7 +419,7 @@ La thèse est honnête : les agents LLM ne remplacent pas le data scientist, ils
 ### Prochaines étapes
 
 - **Approfondir le ML sous-jacent** : la série [ML](../README.md) (et son pendant C# [ML.Net](../ML.Net/README.md)) reprend les algorithmes (LightGBM, SSA, évaluation PFI/ROC) sous l'angle de l'implémentation — utile pour comprendre ce que l'agent exécute quand il génère du code scikit-learn.
-- **Démarrer par les fondations visuelles** : la sous-série [`04-Vision`](04-Vision/README.md) prolonge [03-DeepLearning](03-DeepLearning/README.md) sur les images (Conv2d from scratch + ConvNet profonde + résiduelles, parité NumPy/torch à epsilon machine). Prérequis utile avant d'orchestrer un agent sur des données image.
+- **Démarrer par les fondations visuelles** : la sous-série [`04-Vision`](04-Vision/README.md) prolonge [03-DeepLearning](03-DeepLearning/README.md) sur les images (Conv2d from scratch + ConvNet profonde + résiduelles, parité NumPy/torch à epsilon machine, puis transfer learning ResNet gelé vs fine-tuné). Prérequis utile avant d'orchestrer un agent sur des données image.
 - **Aller vers l'évaluation et la robustesse** : les Labs 13-15 (Web-Search-SOTA, Ablation-Refinement, Kaggle-Challenge) introduisent l'évaluation rigoureuse des agents ML (MLE-bench, métriques cross-compétition) ; le prolongement naturel est la **robustesse multi-seed** et la **walk-forward validation**, traitées dans le pipeline [QuantConnect](../../QuantConnect/README.md).
 - **Franchir le cap production** : le Day 7 (BigQuery, BQML, Vertex AI) ouvre sur le déploiement réel. Le pont vers [GenAI](../../GenAI/README.md) relie ces agents data aux pipelines de génération (image, audio, texte) et aux architectures Qwen/Lumina auto-hébergées.
 - Pour la pratique : reprenez le Lab 7 (agent DataFrame) et posez-lui une question qu'il *ne peut pas* répondre avec les seules colonnes présentes — comment réagit-il ? Confrontez cette limite au Lab 11 (boucle planner-coder) : qu'apporte vraiment le multi-agent ? C'est la tension vivante de la série : la puissance de l'agent *vs* la nécessité de l'encadrer.

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -59,9 +59,9 @@ Six figures illustrent les trois fils de la série : les fondations Python (Pand
 
 Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML) — son **leaderboard AutoML** (cell 12-13) rend visible la discrimination entre entraîneurs : sur données quadratiques, `LightGbmRegression` gagne avec un RMSE de 90 262 contre 30,5 millions pour `FastTreeRegression`, soit un écart de **plus de 300×** qu'aucun tableau `Console.WriteLine` ne fait ressortir. Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 
-### Track B : Data Science with Agents (Python, 32 notebooks, ~21h)
+### Track B : Data Science with Agents (Python, 57 notebooks, ~21h)
 
-Le parcours Python s'articule en trois temps. Les **fondations** (NumPy/Pandas) installent la manipulation de données. Le **socle ML canonique** ([02-ML-Cours](DataScienceWithAgents/02-ML-Cours/), 9 notebooks scikit-learn) pose ensuite les concepts fondamentaux — workflow et surapprentissage, descente de gradient, régressions, ensembles, biais-variance, non supervisé, modèles non-paramétriques, théorie PAC, grokking — chacun rendant *visible* un concept-phare et ancrant un article fondateur. Viennent enfin les **labs agentic**, en deux sous-tracks : le sous-track **LangChain** (Labs 1-7) couvre le data wrangling, la visualisation, le ML classique et le NLP de base ; le sous-track **Google ADK** (Labs 8-17) monte en complexité avec le deep learning (PyTorch), le dashboarding et les pipelines multi-agents (agents LLM pour automatiser le workflow data science). Ce track présuppose Python 3.10+ avec PyTorch, scikit-learn et pandas.
+Le parcours Python s'articule en trois temps. Les **fondations** (NumPy/Pandas) installent la manipulation de données. Le **socle ML canonique** ([02-ML-Cours](DataScienceWithAgents/02-ML-Cours/), 21 notebooks scikit-learn) pose ensuite les concepts fondamentaux — workflow et surapprentissage, descente de gradient, régressions et pont génératif, ensembles, biais-variance/calibration/équité, non supervisé, théorie PAC et ses compagnons formels, grokking, puis optimisation d'hyperparamètres, régularisation sparse et classes déséquilibrées — chacun rendant *visible* un concept-phare et ancrant un article fondateur. Viennent enfin les **labs agentic**, en deux sous-tracks : le sous-track **LangChain** (Labs 1-7) couvre le data wrangling, la visualisation, le ML classique et le NLP de base ; le sous-track **Google ADK** (Labs 8-18, extensions 12b-12d) monte en complexité avec le deep learning (PyTorch), le dashboarding et les pipelines multi-agents (agents LLM pour automatiser le workflow data science). Deux volets spécialisés complètent le parcours : [03-DeepLearning](DataScienceWithAgents/03-DeepLearning/) (10 notebooks PyTorch) et [04-Vision](DataScienceWithAgents/04-Vision/) (3 notebooks, dont transfer learning ResNet). Ce track présuppose Python 3.10+ avec PyTorch, scikit-learn et pandas.
 
 ## Progression recommandée
 
@@ -76,7 +76,7 @@ Le parcours Python s'articule en trois temps. Les **fondations** (NumPy/Pandas) 
 ### Parcours AI Agent Builder (~15h)
 
 1. Days 1-3 (Labs 1-7) : Data Science + LangChain
-1. Days 4-7 (Labs 8-17) : Google ADK + multi-agents
+1. Days 4-7 (Labs 8-18) : Google ADK + multi-agents
 1. Projets finaux : Kaggle + BigQuery
 
 ### Parcours Enterprise .NET (~6h)
@@ -126,8 +126,10 @@ ML/
 │   ├── 02-ML-Cours/                  # Socle ML canonique (scikit-learn)
 │   │   ├── 2.8b-Theorie-PAC-Lean.ipynb   # compagnon Lean (lean4-wsl) du lake learning_theory_lean (moitie PAC)
 │   │   └── 2.8d-Lean-Novikoff-Convergence.ipynb   # compagnon Lean (lean4-wsl) du lake learning_theory_lean (moitie Perceptron)
+│   ├── 03-DeepLearning/              # Deep learning PyTorch (10 notebooks)
+│   ├── 04-Vision/                    # Vision par ordinateur (3 notebooks)
 │   ├── Track1-LangChain/   # Track LangChain (Labs 1-7)
-│   └── Track2-GoogleADK/           # Track Google ADK (Labs 8-17)
+│   └── Track2-GoogleADK/           # Track Google ADK (Labs 8-18, extensions 12b-12d)
 │
 └── learning_theory_lean/                  # Lake Lean 4 — convergence du perceptron (Novikoff)
 ```
@@ -242,19 +244,31 @@ Formation complète en Data Science Python enrichie d'agents IA. Vous commencere
 
 ### Socle ML canonique (02-ML-Cours)
 
-Entre les fondations NumPy/Pandas et les labs agentic, le socle machine learning **canonique avec scikit-learn** : le workflow (train/test split, surapprentissage rendu visible), la descente de gradient (ouvrir la boîte noire de `fit()`), les régressions linéaire et logistique (OLS vs MLE), les arbres et ensembles (réduction de variance), l'évaluation rigoureuse (biais-variance, validation croisée, courbe ROC/AUC), et le non supervisé (KMeans, ACP). Chaque notebook rend visible un concept-phare et ancre les articles fondateurs — le référent manuel qui rend *jugeable* ce qu'un agent produira ensuite.
+Entre les fondations NumPy/Pandas et les labs agentic, le socle machine learning **canonique avec scikit-learn** : le workflow (train/test split, surapprentissage rendu visible), la descente de gradient (ouvrir la boîte noire de `fit()`), les régressions linéaire et logistique complétées par le pont génératif Naive Bayes et la grande dimension, les arbres et ensembles, l'évaluation rigoureuse (biais-variance, calibration, équité), le non supervisé, la théorie PAC et ses trois compagnons formel/concentration/Perceptron, puis trois chapitres de praticien (hyperparamètres, régularisation sparse, classes déséquilibrées) et l'analyse d'erreurs. Chaque notebook rend visible un concept-phare et ancre les articles fondateurs — le référent manuel qui rend *jugeable* ce qu'un agent produira ensuite.
 
 | # | Notebook | Concept rendu visible | Focus |
 |---|----------|----------------------|-------|
 | 2.1 | [Workflow ML](DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb) | Train/test split, surapprentissage rendu visible | Méthodologie |
 | 2.2 | [Descente de gradient](DataScienceWithAgents/02-ML-Cours/2.2-Descente-de-gradient.ipynb) | Ouvrir la boîte noire de `fit()` | Optimisation |
 | 2.3 | [Régression linéaire & logistique](DataScienceWithAgents/02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb) | OLS vs maximum de vraisemblance | Modèles linéaires |
+| 2.3b | [Naive Bayes génératif](DataScienceWithAgents/02-ML-Cours/2.3b-Naive-Bayes-Generatif.ipynb) | L'indépendance conditionnelle qui décide la frontière (Bernoulli, multinomial, Gaussien) | Modèles génératifs |
+| 2.3c | [Régression grande dimension](DataScienceWithAgents/02-ML-Cours/2.3c-Regression-Grande-Dimension.ipynb) | p >> n : Ridge, PCR, PLS — var ≠ valeur prédictive | Modèles linéaires |
+| 2.3d | [Modèle gaussien LDA/QDA](DataScienceWithAgents/02-ML-Cours/2.3d-Modele-Gaussien-LDA-QDA.ipynb) | L'hypothèse de covariance décide la frontière : droite (LDA) vs conique (QDA) | Modèles génératifs |
 | 2.4 | [Arbres, forêts & ensembles](DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb) | Réduction de variance (bagging, boosting) | Ensembles |
 | 2.5 | [Biais, variance, CV & ROC](DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb) | Compromis biais-variance, validation croisée, ROC/AUC | Évaluation |
+| 2.5b | [Calibration des probabilités](DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb) | Reliability diagram, ECE — pourquoi 0.87 n'est pas 87 % de chances | Évaluation |
+| 2.5c | [Équité par sous-groupes](DataScienceWithAgents/02-ML-Cours/2.5c-Equite-Sous-Groupes.ipynb) | Parité démographique, equalized odds, post-traitement par seuils | Évaluation |
 | 2.6 | [Clustering & PCA](DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb) | KMeans, réduction de dimension | Non supervisé |
 | 2.7 | [Modèles non paramétriques](DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb) | SVM, k plus proches voisins | Non paramétrique |
 | 2.8 | [Théorie PAC & VC](DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb) | Cadre PAC, dimension de Vapnik-Chervonenkis | Théorie de l'apprentissage |
+| 2.8b | [Théorie PAC — compagnon Lean](DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb) | La même borne PAC démontrée et interrogée depuis le lake (kernel `lean4-wsl`) | Théorie formelle |
+| 2.8c | [Borne témoin concentration](DataScienceWithAgents/02-ML-Cours/2.8c-Borne-Temoin-Concentration.ipynb) | Carte transversale + mesure numérique : Novikoff, témoin extrémal, Hoeffding | Théorie de l'apprentissage |
+| 2.8d | [Lean Novikoff convergence](DataScienceWithAgents/02-ML-Cours/2.8d-Lean-Novikoff-Convergence.ipynb) | Novikoff `n·γ² ≤ R²` interrogé en direct : `#check` + `#print axioms` | Théorie formelle |
 | 2.9 | [Grokking — généralisation tardive](DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb) | Généralisation qui émerge après que le surapprentissage soit maximal (PyTorch + ACP) | Épilogue avancé |
+| 2.10 | [Optimisation hyperparamètres](DataScienceWithAgents/02-ML-Cours/2.10-Optimisation-Hyperparametres.ipynb) | Grille, hasard, bayésien (TPE) — et quand s'arrêter | Praticien |
+| 2.11 | [Régularisation sparse LASSO](DataScienceWithAgents/02-ML-Cours/2.11-Regularisation-Sparse-LASSO.ipynb) | La géométrie décide : polyèdre L1 → sparsité, boule L2 → shrink | Praticien |
+| 2.12 | [Données déséquilibrées](DataScienceWithAgents/02-ML-Cours/2.12-Donnees-Desequilibrees.ipynb) | La courbe PR dit la vérité quand la ROC flatte | Praticien |
+| 2.13 | [Analyse d'erreurs](DataScienceWithAgents/02-ML-Cours/2.13-Analyse-Erreurs.ipynb) | Tranches, worst-k : la poche invisible sous un score global correct | Praticien |
 
 Dossier : [`02-ML-Cours/`](DataScienceWithAgents/02-ML-Cours/). Le notebook 2.8 (borne PAC/VC) est le **pendant empirique** du lake [`learning_theory_lean/`](learning_theory_lean/) qui *prouve* la convergence du perceptron — voir la section [Théorie formelle (Lean)](#théorie-formelle-lean) ci-dessous. Le notebook 2.9 (grokking) est un **épilogue avancé** qui rend visible un phénomène empirique (la généralisation *après* surapprentissage complet) souvent cité dans la littérature récente (Power et al., 2022), positionné hors du parcours fundamentals par PR #7280.
 
@@ -281,6 +295,10 @@ Track avancé intégrant les frameworks Google ADK (DS-STAR, MLE-STAR) avec supp
 | **Day 5** | 10 | File Analyzer | Analyse de fichiers hétérogènes |
 | **Day 5** | 11 | Planner-Coder Loop | Boucle itérative multi-agents |
 | **Day 5** | 12 | DS-Star Workshop | Application complète DS-STAR |
+| **Day 5** | 12b | Sequential-Orchestration | Orchestration séquentielle (contrat C4 : désignation séquentielle) |
+| **Day 5** | 12c | Agent-Handoff | Handoff natif câblé (contrat C5) |
+| **Day 5** | 12d | Token-Usage | Traçabilité de la consommation LLM (contrat C6) |
+| **Day 5** | 18 | Session-Persistence | Persistance d'état de session |
 | **Day 6** | 13 | Web Search SOTA | Recherche de modèles SOTA |
 | **Day 6** | 14 | Ablation Refinement | Optimisation ciblée par ablation |
 | **Day 6** | 15 | Kaggle Challenge | Compétition Kaggle avec MLE-STAR |


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2027:CoursIA — prev: LIGHT/ledger #14563

## Summary

Re-synchronisation des README `DataScienceWithAgents/README.md` et du parent `ML/README.md` contre le disque (point 2/4 de l'EPIC #13504 — README racine en dérive). Audit **fichier-entier** des deux fichiers, pas un slim +5/−5.

## Mesures disque (audit fichier-entier)

```
DataScienceWithAgents/  57 notebooks au total :
  01-PythonForDataScience/   2   (fondations NumPy/Pandas)
  02-ML-Cours/              21   (socle ML canonique)
  03-DeepLearning/          10
  04-Vision/                 3   (dont 4.3-TransferLearning-ResNet)
  Track1-LangChain/          7   (Labs 1-7)
  Track2-GoogleADK/         14   (Labs 8-18, extensions 12b/12c/12d)
```

Réconciliation : prose DSA disait **52**, prose parent ML disait **32** (encore plus stale) et « 9 notebooks scikit-learn » pour 02-ML-Cours (21 réels). Les marqueurs `CATALOG-STATUS` (breakdown `DataScienceWithAgents=55`) sont **byte-identiques à main** — automation-owned (catalog-cron), non régénérés ici ; la prose est ré-alignée sur le disque, pas sur le marqueur.

## Changements

**`DataScienceWithAgents/README.md`** (audit du cycle précédent, repris ici) :
- ventilation 52 → 57 (7 LangChain + 14 ADK + 2 + 21 + 10 + 3)
- tree : 04-Vision 2→3 (+ ligne 4.3), Track2 10→14 labs
- table Vision : + ligne 4.3 TransferLearning-ResNet
- table Track2 Day 5 : + Labs 12b/12c/12d (contrats C4/C5/C6) et 18 Session-Persistence
- prose « Prochaines étapes » : énumère 4.3

**`ML/README.md`** (parent — même réconciliation parent/enfant) :
- Track B : 32 → 57 notebooks ; socle canonique 9 → 21 + énumération actualisée (pont génératif, calibration/équité, compagnons formels, praticien)
- ADK « Labs 8-17 » → « Labs 8-18, extensions 12b-12d » (prose, progression, tree)
- tree : + dossiers `03-DeepLearning/` et `04-Vision/` (absents)
- section « Socle ML canonique » : prose élargie + table 9 → 21 lignes (2.3b/c/d, 2.5b/c, 2.8b/c/d, 2.10-2.13)
- table Track2 : + 4 lignes (12b/12c/12d/18, mêmes intitulés que le sous-README)

## Validation

- Liens internes : 60 (DSA) + 58 (parent) uniques, **0 manquant** (check existence par script).
- Noms des labs 12b/12c/12d/18 vérifiés contre le disque (`Day5-DS-Star/`).
- Aucun marqueur CATALOG-STATUS dans le diff (grep du diff : 0 hit).

## Signal — anomalie de numérotation Lab18

`Lab18-Session-Persistence.ipynb` vit dans `Day5-DS-Star/` alors que Day7 porte Labs 16-17 : numéro d'opportunité au-delà de la plage de son jour. **Non corrigé ici** — une renum exige table de mapping dans l'issue + `git mv` + sweep des référents (règle notebook-accretion-numbering). Signalé en commentaire sur #13504.

## Note protocole

Grain META (`readme`) : ne tient pas G-VAR-1 seul. Le grain CONTENU de la lane au cycle suivant est nommé sur le dashboard (consolidation DataScienceWithAgents / grounder les ajouts Track2).

See #13504 (contribution partielle à l'EPIC — points 2/4)
