### PR TITLE
[Probas/Lean] Noyau percolation — évènement de connexité croissant (tranche 2)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation.lean
@@ -1,7 +1,9 @@
 import Percolation.Basic
+import Percolation.Connectivity
 
 /-! # Percolation — lake racine (FR)
 
-Aggregateur racine de la sous-série `Percolation` : importe le module de base.
-Le contenu réel vit dans `Percolation/Basic.lean`.
+Aggregateur racine de la sous-série `Percolation` : importe le module de base
+(`Basic`) et le module de connexité (`Connectivity`).
+Le contenu réel vit dans `Percolation/Basic.lean` et `Percolation/Connectivity.lean`.
 -/

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Connectivity.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Connectivity.lean
@@ -1,0 +1,92 @@
+import Mathlib.Combinatorics.SetFamily.HarrisKleitman
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Logic.Relation
+
+/-! # Noyau fini de la percolation — connexité (tranche 2)
+
+Suite du noyau fini (voir `Percolation/Basic.lean`). Ce module établit que
+l'événement « deux sommets sont reliés » est un événement **croissant**
+(monotone pour l'inclusion des arêtes ouvertes) : plus d'arêtes ouvertes ne
+peut que le conserver. C'est précisément la propriété qui rend les événements
+de connexité éligibles à l'inégalité de **Harris–Kleitman** (FKG fini) prouvée
+au jalon 1.
+
+Sur un graphe simple fini `G` et un ensemble `ω` d'arêtes **ouvertes** (une
+configuration), deux sommets `u` et `v` sont *reliés* s'il existe un chemin
+d'arêtes ouvertes les joignant — la fermeture réflexive-transitive de la
+relation « `u` et `v` sont adjacents par une arête ouverte ».
+
+Convention i18n EPIC #4980 : docstrings en français ici, le miroir anglais vit
+dans `Percolation/Connectivity_en.lean` (byte-identiques hors docstrings/comments).
+-/
+
+-- Les lemmes de monotonie `openAdj_mono`/`connected_mono` raisonnent sur
+-- l'inclusion de `Finset (Edge G)` sans avoir besoin des instances de finitude
+-- (utiles aux événements `connectedEvent`) : on désactive l'avertissement.
+set_option linter.unusedSectionVars false
+
+namespace Percolation
+
+open Finset
+open Classical
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- Le type des arêtes d'un graphe simple fini `G` : une paire non ordonnée
+`{u, v}` (`Sym2 V`) qui appartient à l'ensemble d'arêtes `G.edgeSet`. -/
+abbrev Edge (G : SimpleGraph V) := {e : Sym2 V // e ∈ G.edgeSet}
+
+variable (G : SimpleGraph V) [Fintype (Edge G)] [DecidableEq (Edge G)]
+
+/-- **Adjacence ouverte** : dans la configuration `ω` (ensemble d'arêtes
+ouvertes), `u` et `v` sont adjacents s'ils le sont dans `G` et si l'arête
+`s(u, v)` est ouverte (appartient à `ω`). -/
+abbrev openAdj (ω : Finset (Edge G)) (u v : V) : Prop :=
+  ∃ (huv : G.Adj u v), (⟨s(u, v), (show s(u, v) ∈ G.edgeSet from huv)⟩ : Edge G) ∈ ω
+
+/-- **Connexité par arêtes ouvertes** : `u` et `v` sont reliés dans la
+configuration `ω` s'il existe un chemin d'arêtes ouvertes les joignant
+(fermeture réflexive-transitive de `openAdj`). -/
+abbrev ConnectedIn (ω : Finset (Edge G)) (u v : V) : Prop :=
+  Relation.ReflTransGen (openAdj G ω) u v
+
+/-- **Monotonie de l'adjacence ouverte** : si `ω₁ ⊆ ω₂` (plus d'arêtes
+ouvertes), alors toute adjacence ouverte dans `ω₁` l'est dans `ω₂`. -/
+lemma openAdj_mono {ω₁ ω₂ : Finset (Edge G)} (h : ω₁ ⊆ ω₂) :
+    openAdj G ω₁ ≤ openAdj G ω₂ := by
+  intro u v huv
+  rcases huv with ⟨huv_adj, hmem⟩
+  exact ⟨huv_adj, h hmem⟩
+
+/-- **Monotonie de la connexité** : si `ω₁ ⊆ ω₂`, alors tout couple relié dans
+`ω₁` reste relié dans `ω₂`. L'événement de connexité est donc **croissant**. -/
+lemma connected_mono {ω₁ ω₂ : Finset (Edge G)} (h : ω₁ ⊆ ω₂) :
+    ConnectedIn G ω₁ ≤ ConnectedIn G ω₂ := by
+  intro u v h_conn
+  exact Relation.ReflTransGen.mono (openAdj_mono G h) u v h_conn
+
+/-- **Événement de connexité** : la famille des configurations `ω` dans
+lesquelles `u` et `v` sont reliés, vue comme un `Finset` de configurations. -/
+noncomputable def connectedEvent (u v : V) : Finset (Finset (Edge G)) :=
+  Finset.univ.filter (fun ω : Finset (Edge G) => ConnectedIn G ω u v)
+
+/-- **L'événement de connexité est croissant** : c'est un `IsUpperSet` pour
+l'ordre d'inclusion des configurations — plus d'arêtes ouvertes conserve la
+connexité. -/
+theorem connectedEvent_isUpperSet {u v : V} :
+    IsUpperSet (connectedEvent G u v : Set (Finset (Edge G))) := by
+  intro ω₁ ω₂ hsub hm
+  exact Finset.mem_filter.mpr ⟨Finset.mem_univ _,
+    connected_mono G hsub u v (Finset.mem_filter.mp hm).2⟩
+
+/-- **Harris–Kleitman (FKG fini) pour la connexité** : deux événements croissants
+de connexité corrèlent positivement sous la mesure uniforme du cube booléen des
+arêtes. C'est le pont du jalon 1 vers la percolation : la connexité étant un
+événement croissant, elle est éligible à l'inégalité d'association. -/
+theorem harris_kleitman_connected {u v x y : V} :
+    #(connectedEvent G u v) * #(connectedEvent G x y) ≤
+      2 ^ Fintype.card (Edge G) * #((connectedEvent G u v) ∩ (connectedEvent G x y)) :=
+  (connectedEvent_isUpperSet G (u := u) (v := v)).le_card_inter_finset
+    (connectedEvent_isUpperSet G (u := x) (v := y))
+
+end Percolation

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Connectivity_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Connectivity_en.lean
@@ -1,0 +1,93 @@
+import Mathlib.Combinatorics.SetFamily.HarrisKleitman
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Logic.Relation
+
+/-! # Finite kernel of percolation — connectivity (tranche 2)
+
+Continuation of the finite kernel (see `Percolation/Basic_en.lean`). This module
+establishes that the event « two vertices are connected » is an **increasing**
+event (monotone with respect to the inclusion of open edges): more open edges
+can only preserve it. It is precisely the property that makes connectivity
+events eligible for the **Harris–Kleitman** inequality (finite FKG) proved in
+milestone 1.
+
+On a finite simple graph `G` and a set `ω` of **open** edges (a
+configuration), two vertices `u` and `v` are *connected* if there is a path of
+open edges joining them — the reflexive-transitive closure of the relation
+« `u` and `v` are adjacent by an open edge ».
+
+i18n convention EPIC #4980: docstrings in English here; the French mirror lives
+in `Percolation/Connectivity.lean` (byte-identical apart from docstrings/comments).
+-/
+
+-- The monotonicity lemmas `openAdj_mono`/`connected_mono` reason about the
+-- inclusion of `Finset (Edge G)` without needing the finiteness instances
+-- (used by the events `connectedEvent`): we turn the linter warning off.
+set_option linter.unusedSectionVars false
+
+namespace Percolation_en
+
+open Finset
+open Classical
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The type of the edges of a finite simple graph `G`: an unordered pair
+`{u, v}` (`Sym2 V`) belonging to the edge set `G.edgeSet`. -/
+abbrev Edge (G : SimpleGraph V) := {e : Sym2 V // e ∈ G.edgeSet}
+
+variable (G : SimpleGraph V) [Fintype (Edge G)] [DecidableEq (Edge G)]
+
+/-- **Open adjacency**: in the configuration `ω` (set of open edges), `u` and
+`v` are adjacent if they are in `G` and if the edge `s(u, v)` is open (belongs
+to `ω`). -/
+abbrev openAdj (ω : Finset (Edge G)) (u v : V) : Prop :=
+  ∃ (huv : G.Adj u v), (⟨s(u, v), (show s(u, v) ∈ G.edgeSet from huv)⟩ : Edge G) ∈ ω
+
+/-- **Connectivity by open edges**: `u` and `v` are connected in the
+configuration `ω` if there is a path of open edges joining them
+(reflexive-transitive closure of `openAdj`). -/
+abbrev ConnectedIn (ω : Finset (Edge G)) (u v : V) : Prop :=
+  Relation.ReflTransGen (openAdj G ω) u v
+
+/-- **Monotonicity of open adjacency**: if `ω₁ ⊆ ω₂` (more open edges), then
+every open adjacency in `ω₁` also holds in `ω₂`. -/
+lemma openAdj_mono {ω₁ ω₂ : Finset (Edge G)} (h : ω₁ ⊆ ω₂) :
+    openAdj G ω₁ ≤ openAdj G ω₂ := by
+  intro u v huv
+  rcases huv with ⟨huv_adj, hmem⟩
+  exact ⟨huv_adj, h hmem⟩
+
+/-- **Monotonicity of connectivity**: if `ω₁ ⊆ ω₂`, then every pair connected
+in `ω₁` remains connected in `ω₂`. The connectivity event is therefore
+**increasing**. -/
+lemma connected_mono {ω₁ ω₂ : Finset (Edge G)} (h : ω₁ ⊆ ω₂) :
+    ConnectedIn G ω₁ ≤ ConnectedIn G ω₂ := by
+  intro u v h_conn
+  exact Relation.ReflTransGen.mono (openAdj_mono G h) u v h_conn
+
+/-- **Connectivity event**: the family of configurations `ω` in which `u` and
+`v` are connected, viewed as a `Finset` of configurations. -/
+noncomputable def connectedEvent (u v : V) : Finset (Finset (Edge G)) :=
+  Finset.univ.filter (fun ω : Finset (Edge G) => ConnectedIn G ω u v)
+
+/-- **The connectivity event is increasing**: it is an `IsUpperSet` for the
+inclusion order on configurations — more open edges preserves connectivity. -/
+theorem connectedEvent_isUpperSet {u v : V} :
+    IsUpperSet (connectedEvent G u v : Set (Finset (Edge G))) := by
+  intro ω₁ ω₂ hsub hm
+  exact Finset.mem_filter.mpr ⟨Finset.mem_univ _,
+    connected_mono G hsub u v (Finset.mem_filter.mp hm).2⟩
+
+/-- **Harris–Kleitman (finite FKG) for connectivity**: two increasing
+connectivity events correlate positively under the uniform measure on the
+Boolean cube of edges. This is the milestone-1 bridge toward percolation: since
+connectivity is an increasing event, it is eligible for the association
+inequality. -/
+theorem harris_kleitman_connected {u v x y : V} :
+    #(connectedEvent G u v) * #(connectedEvent G x y) ≤
+      2 ^ Fintype.card (Edge G) * #((connectedEvent G u v) ∩ (connectedEvent G x y)) :=
+  (connectedEvent_isUpperSet G (u := u) (v := v)).le_card_inter_finset
+    (connectedEvent_isUpperSet G (u := x) (v := y))
+
+end Percolation_en

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation_en.lean
@@ -1,7 +1,9 @@
 import Percolation.Basic_en
+import Percolation.Connectivity_en
 
 /-! # Percolation — root lake (EN)
 
-Root aggregator of the `Percolation` subseries: imports the base module.
-Real content lives in `Percolation/Basic_en.lean`.
+Root aggregator of the `Percolation` subseries: imports the base module
+(`Basic`) and the connectivity module (`Connectivity`).
+Real content lives in `Percolation/Basic_en.lean` and `Percolation/Connectivity_en.lean`.
 -/


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2027:CoursIA-2 — prev: DEEP/lean #14892

## Objet

Tranche 2 de #14871 (jambe Lean de la distillation percolation #14847) : le **pont connexité-croissante**. Le jalon 1 (#14892, **mergé** sur `main`) a prouvé le **Harris–Kleitman (FKG fini)** au cas uniforme `p = 1/2` ; ce module fournit la propriété qui **rend la connexité éligible** à cette inégalité : l'évènement « deux sommets sont reliés » est **croissant** (monotone pour l'inclusion des arêtes ouvertes). Sur un graphe simple fini `G` et une configuration `ω` d'arêtes ouvertes, `u` et `v` sont reliés s'il existe un chemin d'arêtes ouvertes — la fermeture réflexive-transitive de la relation d'adjacence ouverte.

Théorème central : `harris_kleitman_connected` — deux évènements croissants de connexité corrèlent positivement sous la mesure uniforme du cube d'arêtes.

**Séquençage** : jalon 1 mergé → tranche 2 en PR normale sur `main` (pas de stack nécessaire). `Percolation.Connectivity` n'importe que Mathlib (indépendant de `Percolation.Basic`).

## Livrable

- **Paire i18n (#4980)** `Percolation/Connectivity.lean` ↔ `Percolation/Connectivity_en.lean` (namespaces `Percolation`/`Percolation_en`).
- **Aggrégateurs racine** `Percolation.lean` / `Percolation_en.lean` mis à jour pour importer les modules de connexité (série cohérente).
- **Théorèmes no-sorry** :
  - `openAdj_mono` : `openAdj G ω₁ ≤ openAdj G ω₂` si `ω₁ ⊆ ω₂` (monotonie de l'adjacence ouverte).
  - `connected_mono` : `ConnectedIn G ω₁ ≤ ConnectedIn G ω₂` si `ω₁ ⊆ ω₂` (monotonie de la connexité).
  - `connectedEvent_isUpperSet` : l'évènement de connexité est un `IsUpperSet` (croissant).
  - `harris_kleitman_connected` : `#(conn u v) * #(conn x y) ≤ 2 ^ |Edge G| * #(conn u v ∩ conn x y)`.
- Preuves = application directe de `Relation.ReflTransGen.mono` (monotonie du chemin) + `IsUpperSet.le_card_inter_finset` (Harris–Kleitman).

## Grounding Mathlib (acceptance 1)

Vérifié firsthand dans `Mathlib v4.32.1` :
- `Relation.ReflTransGen` + `Relation.ReflTransGen.mono` (`Mathlib.Logic.Relation`) — monotonie de la fermeture réflexive-transitive.
- `SimpleGraph.mem_edgeSet : s(v,w) ∈ G.edgeSet ↔ G.Adj v w` (`Mathlib.Combinatorics.SimpleGraph.Basic`) — l'appartenance à `edgeSet` est **définitionnelle** (`Iff.rfl`), ce qui évitera tout `mpr` non résolvable.
- `IsUpperSet.le_card_inter_finset` / `IsLowerSet.le_card_inter_finset` (Harris–Kleitman, jalon 1) — l'inégalité d'association finie.

## Vérifications (acceptance 6)

- **`lake build` SUCCESS** (exit 0, 846 jobs) — module + aggrégateurs recompilés contre la warm Mathlib v4.32.1 :
  ```
  ✔ [844/846] Built Percolation_en (6.9s)
  ✔ [845/846] Built Percolation (6.9s)
  Build completed successfully (846 jobs).
  ```
- **`count_code_sorry.py --json`** : `name`/`distinct_code_sorry = 0`, `naive_sorry = 0` (7 fichiers `.lean` du lake, options `linter.unusedSectionVars` désactivé, pas de `sorry`).
- **`#print axioms`** (local, équivalent proche de proof-integrity) : `[propext, Classical.choice, Quot.sound]` pour `harris_kleitman_connected`, `connectedEvent_isUpperSet`, `connected_mono`, `openAdj_mono` — **ni `sorryAx` ni `native_decide.*`**.
- **i18n (#4980)** : `Connectivity.lean` / `Connectivity_en.lean` byte-identiques hors docstrings/commentaires et hors suffixe `_en` du namespace (vérifié par normalisation + diff, 36 lignes de code identiques).
- **proof-integrity : `n/a (B.3)`** — aucun workflow `lean-axiom.yml` / `proof-integrity` n'est câblé sur `percolation_lean` (câblage CI recommandé en issue de suivi, comme au jalon 1).

## Distinction prouvé / importé / hors portée (acceptance 5)

- **Prouvé ici** : la monotonie de l'adjacence ouverte et de la connexité, le fait que l'évènement de connexité soit croissant (`connectedEvent_isUpperSet`), et le **Harris–Kleitman fini pour la connexité** (`harris_kleitman_connected`), au cas uniforme `p = 1/2`.
- **Importé de Mathlib** : `Relation.ReflTransGen.mono`, `IsUpperSet.le_card_inter_finset` (preuves Mathlib v4.32.1).
- **Hors portée / horizon de recherche** : le théorème de l'article (sharpness supercritique), le **FKG mesure-théorique / passage à la mesure produit Bernoulli de paramètre général `p`**, et la **suite du noyau** — composantes connexes, frontière isopérimétrique, lemme connexion↔composante↔frontière, et le **notebook Lean** exécuté end-to-end — sont la **tranche suivante** de #14871, non livrée ici. Aucun `sorry` introduit pour pallier l'absence.

## Scope / hygiène

- Aucun artefact catalogue généré modifié : catalogue byte-identique à `main`.
- Aucune modification de `MyIA.AI.Notebooks/Probas/README.md` ni de la nav Probas (acceptance 7 ; collision #14825 évitée).
- Aucun `sorry`, `native_decide` ni axiome non déclaré.
- Aucun overlap avec la jambe Python de #14847.

See #14847. See #14871.
