### PR TITLE
feat(lean,#14871): composantes et frontiere du noyau percolation (tranche 3)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation.lean
@@ -1,12 +1,13 @@
 import Percolation.Basic
 import Percolation.Connectivity
 import Percolation.Components
+import Percolation.Examples
 
 /-! # Percolation — lake racine (FR)
 
 Aggregateur racine de la sous-série `Percolation` : importe le module de base
-(`Basic`), le module de connexité (`Connectivity`) et le module de composantes
-(`Components`).
-Le contenu réel vit dans `Percolation/Basic.lean`, `Percolation/Connectivity.lean`
-et `Percolation/Components.lean`.
+(`Basic`), le module de connexité (`Connectivity`), le module de composantes
+(`Components`) et le module d'exemple calculable (`Examples`).
+Le contenu réel vit dans `Percolation/Basic.lean`, `Percolation/Connectivity.lean`,
+`Percolation/Components.lean` et `Percolation/Examples.lean`.
 -/

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation.lean
@@ -1,9 +1,12 @@
 import Percolation.Basic
 import Percolation.Connectivity
+import Percolation.Components
 
 /-! # Percolation — lake racine (FR)
 
 Aggregateur racine de la sous-série `Percolation` : importe le module de base
-(`Basic`) et le module de connexité (`Connectivity`).
-Le contenu réel vit dans `Percolation/Basic.lean` et `Percolation/Connectivity.lean`.
+(`Basic`), le module de connexité (`Connectivity`) et le module de composantes
+(`Components`).
+Le contenu réel vit dans `Percolation/Basic.lean`, `Percolation/Connectivity.lean`
+et `Percolation/Components.lean`.
 -/

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Components.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Components.lean
@@ -1,0 +1,101 @@
+import Mathlib.Logic.Relation
+import Percolation.Connectivity
+
+/-! # Noyau fini de la percolation — composantes et frontière (tranche 3)
+
+Suite du noyau fini (voir `Percolation/Connectivity.lean`). Ce module relie trois
+notions : la **composante connexe ouverte** d'un sommet, la propriété d'être
+**fermé le long des arêtes ouvertes** (aucune arête ouverte n'en sort), et la
+**frontière** (le complémentaire). Le pont central est le lemme
+connexion↔composante↔frontière : un ensemble est ω-fermé si et seulement s'il
+est une union de composantes connexes (il contient la composante de chacun de
+ses éléments), si et seulement si aucune arête ouverte ne le relie à son
+complémentaire (frontière vide).
+
+Sur un graphe simple fini `G` et une configuration `ω` d'arêtes ouvertes, la
+composante `Component ω v` est l'ensemble des sommets reliés à `v` par un chemin
+d'arêtes ouvertes (la fermeture réflexive-transitive de l'adjacence ouverte).
+
+Convention i18n EPIC #4980 : docstrings en français ici ; le miroir anglais vit
+dans `Percolation/Components_en.lean` (byte-identique hors docstrings/commentaires).
+-/
+
+set_option linter.unusedSectionVars false
+
+namespace Percolation
+
+open Finset
+open Classical
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable (G : SimpleGraph V) [Fintype (Edge G)] [DecidableEq (Edge G)]
+
+/-- **Composante connexe ouverte** d'un sommet `v` : l'ensemble des sommets `w`
+reliés à `v` dans la configuration `ω` (chemin d'arêtes ouvertes). -/
+def Component (ω : Finset (Edge G)) (v : V) : Set V :=
+  {w : V | ConnectedIn G ω v w}
+
+/-- **Fermé le long des arêtes ouvertes** : `A` est ω-fermé si aucune arête
+ouverte n'en sort — tout `u ∈ A` adjoint ouvertement à `v` implique `v ∈ A`. -/
+def openEdgeClosed (ω : Finset (Edge G)) (A : Set V) : Prop :=
+  ∀ ⦃u v : V⦄, u ∈ A → openAdj G ω u v → v ∈ A
+
+/-- **Un sommet appartient à sa propre composante** (réflexivité). -/
+theorem component_self {ω : Finset (Edge G)} (v : V) : v ∈ Component G ω v := by
+  unfold Component
+  exact Relation.ReflTransGen.refl
+
+/-- **La composante est ω-fermée** : aucune arête ouverte n'en sort. C'est la
+première face du lien composante↔frontière. -/
+theorem component_closed {ω : Finset (Edge G)} (v : V) : openEdgeClosed G ω (Component G ω v) := by
+  intro u w hu huw
+  unfold Component at hu ⊢
+  exact Relation.ReflTransGen.trans hu (Relation.ReflTransGen.single huw)
+
+/-- **Pont connexité↔composante** : `w ∈ Component v` si et seulement si `v` et
+`w` sont reliés. Définitionnel (la composante EST l'ensemble des reliés). -/
+theorem component_iff_connected {ω : Finset (Edge G)} (v w : V) :
+    w ∈ Component G ω v ↔ ConnectedIn G ω v w := by
+  rfl
+
+/-- **Contiguïté implique appartenance à la composante** : une arête ouverte en
+partant de `u` place son extrémité dans la composante de `u`. -/
+theorem mem_component_of_adj {ω : Finset (Edge G)} {u v : V} (hAdj : openAdj G ω u v) :
+    v ∈ Component G ω u := by
+  unfold Component
+  exact Relation.ReflTransGen.single hAdj
+
+/-- **Un ensemble fermé contient la composante de chacun de ses éléments** : si
+`A` est ω-fermé et contient `u`, il contient tous les sommets reliés à `u`
+(récurrence le long du chemin d'arêtes ouvertes). -/
+theorem openEdgeClosed.mem_of_connected {ω : Finset (Edge G)} {A : Set V}
+    (h : openEdgeClosed G ω A) {u w : V} (hu : u ∈ A) (hconn : ConnectedIn G ω u w) : w ∈ A := by
+  induction hconn with
+  | refl => exact hu
+  | tail hconn2 hstep ih => exact h ih hstep
+
+/-- **Fermé ⟺ frontière vide** : `A` est ω-fermé si et seulement si aucune
+arête ouverte ne relie `A` à son complémentaire. C'est la face « frontière »
+(deuxième face du lien). -/
+theorem openEdgeClosed_iff_no_cross {ω : Finset (Edge G)} (A : Set V) :
+    openEdgeClosed G ω A ↔ ∀ ⦃u v : V⦄, u ∈ A → v ∉ A → ¬ openAdj G ω u v := by
+  constructor
+  · intro h u v hu hvnot hAdj
+    exact hvnot (h hu hAdj)
+  · intro h u v hu hAdj
+    by_contra hvnot
+    exact (h hu hvnot) hAdj
+
+/-- **Lemme connexion↔composante↔frontière** : `A` est ω-fermé si et seulement
+s'il est une union de composantes connexes (contient la composante de chacun de
+ses éléments). C'est le pont du noyau : la frontière vide (aucune arête ouverte
+ne sort de `A`) équivaut à « `A` est une réunion de composantes ». -/
+theorem openEdgeClosed_iff_contains_components {ω : Finset (Edge G)} (A : Set V) :
+    openEdgeClosed G ω A ↔ ∀ ⦃u : V⦄, u ∈ A → Component G ω u ⊆ A := by
+  constructor
+  · intro h u hu w hw
+    exact openEdgeClosed.mem_of_connected (G := G) h hu (by simpa [Component] using hw)
+  · intro h u v hu hAdj
+    exact h hu (mem_component_of_adj (G := G) hAdj)
+
+end Percolation

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Components_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Components_en.lean
@@ -1,0 +1,101 @@
+import Mathlib.Logic.Relation
+import Percolation.Connectivity_en
+
+/-! # Finite kernel of percolation — components and boundary (tranche 3)
+
+Continuation of the finite kernel (see `Percolation/Connectivity_en.lean`). This
+module ties together three notions: the **open connected component** of a vertex,
+the property of being **closed along open edges** (no open edge leaves it), and
+the **boundary** (the complement). The central bridge is the
+connection↔component↔boundary lemma: a set is ω-closed if and only if it is a
+union of connected components (it contains the component of each of its
+elements), if and only if no open edge links it to its complement (empty
+boundary).
+
+On a finite simple graph `G` and a configuration `ω` of **open** edges, the
+component `Component ω v` is the set of vertices reachable from `v` by a path of
+open edges (the reflexive-transitive closure of the open adjacency).
+
+i18n convention EPIC #4980: docstrings in English here; the French mirror lives
+in `Percolation/Components.lean` (byte-identical apart from docstrings/comments).
+-/
+
+set_option linter.unusedSectionVars false
+
+namespace Percolation_en
+
+open Finset
+open Classical
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable (G : SimpleGraph V) [Fintype (Edge G)] [DecidableEq (Edge G)]
+
+/-- **Open connected component** of a vertex `v`: the set of vertices `w`
+reachable from `v` in the configuration `ω` (path of open edges). -/
+def Component (ω : Finset (Edge G)) (v : V) : Set V :=
+  {w : V | ConnectedIn G ω v w}
+
+/-- **Closed along open edges**: `A` is ω-closed if no open edge leaves it — any
+`u ∈ A` openly adjacent to `v` forces `v ∈ A`. -/
+def openEdgeClosed (ω : Finset (Edge G)) (A : Set V) : Prop :=
+  ∀ ⦃u v : V⦄, u ∈ A → openAdj G ω u v → v ∈ A
+
+/-- **A vertex belongs to its own component** (reflexivity). -/
+theorem component_self {ω : Finset (Edge G)} (v : V) : v ∈ Component G ω v := by
+  unfold Component
+  exact Relation.ReflTransGen.refl
+
+/-- **The component is ω-closed**: no open edge leaves it. This is the first
+face of the component↔boundary link. -/
+theorem component_closed {ω : Finset (Edge G)} (v : V) : openEdgeClosed G ω (Component G ω v) := by
+  intro u w hu huw
+  unfold Component at hu ⊢
+  exact Relation.ReflTransGen.trans hu (Relation.ReflTransGen.single huw)
+
+/-- **Connectivity↔component bridge**: `w ∈ Component v` if and only if `v` and
+`w` are connected. Definitional (the component IS the set of the connected). -/
+theorem component_iff_connected {ω : Finset (Edge G)} (v w : V) :
+    w ∈ Component G ω v ↔ ConnectedIn G ω v w := by
+  rfl
+
+/-- **Adjacency implies membership in the component**: an open edge leaving `u`
+places its endpoint in the component of `u`. -/
+theorem mem_component_of_adj {ω : Finset (Edge G)} {u v : V} (hAdj : openAdj G ω u v) :
+    v ∈ Component G ω u := by
+  unfold Component
+  exact Relation.ReflTransGen.single hAdj
+
+/-- **A closed set contains the component of each of its elements**: if `A` is
+ω-closed and contains `u`, it contains every vertex reachable from `u`
+(induction along the path of open edges). -/
+theorem openEdgeClosed.mem_of_connected {ω : Finset (Edge G)} {A : Set V}
+    (h : openEdgeClosed G ω A) {u w : V} (hu : u ∈ A) (hconn : ConnectedIn G ω u w) : w ∈ A := by
+  induction hconn with
+  | refl => exact hu
+  | tail hconn2 hstep ih => exact h ih hstep
+
+/-- **Closed ⟺ empty boundary**: `A` is ω-closed if and only if no open edge
+links `A` to its complement. This is the « boundary » face (second face of the
+link). -/
+theorem openEdgeClosed_iff_no_cross {ω : Finset (Edge G)} (A : Set V) :
+    openEdgeClosed G ω A ↔ ∀ ⦃u v : V⦄, u ∈ A → v ∉ A → ¬ openAdj G ω u v := by
+  constructor
+  · intro h u v hu hvnot hAdj
+    exact hvnot (h hu hAdj)
+  · intro h u v hu hAdj
+    by_contra hvnot
+    exact (h hu hvnot) hAdj
+
+/-- **Connection↔component↔boundary lemma**: `A` is ω-closed if and only if it
+is a union of connected components (contains the component of each of its
+elements). It is the kernel bridge: the empty boundary (no open edge leaves `A`)
+is equivalent to « `A` is a union of components ». -/
+theorem openEdgeClosed_iff_contains_components {ω : Finset (Edge G)} (A : Set V) :
+    openEdgeClosed G ω A ↔ ∀ ⦃u : V⦄, u ∈ A → Component G ω u ⊆ A := by
+  constructor
+  · intro h u hu w hw
+    exact openEdgeClosed.mem_of_connected (G := G) h hu (by simpa [Component] using hw)
+  · intro h u v hu hAdj
+    exact h hu (mem_component_of_adj (G := G) hAdj)
+
+end Percolation_en

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples.lean
@@ -86,4 +86,48 @@ theorem exists_boundary_edge_C3 :
   · show openAdj C3 full3 (0 : Fin 3) 1
     use adj_C3_0_1; simp [full3]
 
+/-- **Carré** `C₄` — la 4-cycle. Contrairement au triangle, `0` n'est pas adjacent
+à `2` : y atteindre exige un chemin de deux arêtes, donc la composition
+`Relation.ReflTransGen.trans`. -/
+abbrev C4 : SimpleGraph (Fin 4) := SimpleGraph.cycleGraph 4
+
+/-- **Configuration complète** sur `C₄` : toutes les arêtes sont ouvertes. -/
+abbrev full4 : Finset (Edge C4) := Finset.univ
+
+/-- Dans le carré complet `full4`, la composante ouverte de `0` atteint `2` par la
+composition `0 — 1 — 2` (deux arêtes), ce qui **exerce** le `Relation.ReflTransGen.trans`
+au cœur du noyau de la tranche 3. Ainsi `component_C4_full` vaut l'ensemble des
+sommets. -/
+theorem component_C4_full :
+    Component C4 full4 (0 : Fin 4) = Set.univ := by
+  ext u
+  constructor
+  · intro _; trivial
+  · intro _; unfold Component
+    fin_cases u
+    · exact Relation.ReflTransGen.refl
+    · exact Relation.ReflTransGen.single
+        (show openAdj C4 full4 (0 : Fin 4) 1 from by
+          use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 1); simp [full4])
+    · exact Relation.ReflTransGen.trans
+        (Relation.ReflTransGen.single
+          (show openAdj C4 full4 (0 : Fin 4) 1 from by
+            use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 1); simp [full4]))
+        (Relation.ReflTransGen.single
+          (show openAdj C4 full4 (1 : Fin 4) 2 from by
+            use (by decide : (SimpleGraph.cycleGraph 4).Adj 1 2); simp [full4]))
+    · exact Relation.ReflTransGen.single
+        (show openAdj C4 full4 (0 : Fin 4) 3 from by
+          use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 3); simp [full4])
+
+/-- Le singleton `{0}` n'est **pas** ω-fermé dans `full4` : l'arête ouverte `0—1`
+le quitte. -/
+theorem not_openEdgeClosed_C4_singleton :
+    ¬ openEdgeClosed C4 full4 ({0} : Set (Fin 4)) := by
+  intro h
+  have h1 : (1 : Fin 4) ∈ ({0} : Set (Fin 4)) :=
+    h (by simp) (show openAdj C4 full4 (0 : Fin 4) 1 from by
+      use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 1); simp [full4])
+  simp at h1
+
 end Percolation

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples.lean
@@ -1,0 +1,89 @@
+import Percolation.Components
+import Mathlib.Combinatorics.SimpleGraph.CycleGraph
+
+/-! # Noyau fini de la percolation — un exemple calculable (tranche 3, acceptation 3)
+
+Instance concrète du noyau composantes/frontière sur le **triangle** `C₃`
+(`SimpleGraph.cycleGraph 3`). Dans `cycleGraph 3` toute paire de sommets est
+adjacente (soustraction modulaire), donc `C₃` est le graphe complet sur `Fin 3` :
+son ensemble d'arêtes a pour cardinal 3, et la configuration `full3` (toutes les
+arêtes ouvertes) rend le graphe entier connexe.
+
+Ce module ancre les lemmes abstraits de `Percolation/Components.lean` sur un
+petit graphe fini — l'« exemple calculable » de l'issue #14871, acceptation 3 —
+et est vérifiable par `lake build`.
+
+- `component_C3_full` : dans la configuration complète, la composante ouverte de
+  `0` est l'ensemble des sommets.
+- `not_openEdgeClosed_C3_singleton` : le singleton `{0}` n'est **pas** ω-fermé.
+- `exists_boundary_edge_C3` : l'arête ouverte `0—1` traverse de `{0}` à son
+  complémentaire — un témoin de frontière concret.
+-/
+
+set_option linter.unusedSectionVars false
+
+namespace Percolation
+
+open Finset
+
+/-- **Triangle** `C₃` — le 3-cycle, un graphe simple fini concret. Dans
+`SimpleGraph.cycleGraph 3` toute paire de sommets est adjacente, donc `C₃` est
+le graphe complet sur `Fin 3`. -/
+abbrev C3 : SimpleGraph (Fin 3) := SimpleGraph.cycleGraph 3
+
+/-- **Configuration complète** sur `C₃` : toutes les arêtes sont ouvertes. -/
+abbrev full3 : Finset (Edge C3) := Finset.univ
+
+/-- `C₃` a exactement trois arêtes (ouvrables). -/
+theorem card_edge_C3 : Fintype.card (Edge C3) = 3 := by
+  decide
+
+/-- Dans `C₃` les sommets `0` et `1` sont adjacents. -/
+theorem adj_C3_0_1 : (SimpleGraph.cycleGraph 3).Adj (0 : Fin 3) 1 := by
+  decide
+
+/-- Dans `C₃` les sommets `0` et `2` sont adjacents. -/
+theorem adj_C3_0_2 : (SimpleGraph.cycleGraph 3).Adj (0 : Fin 3) 2 := by
+  decide
+
+/-- Dans la configuration complète `full3`, la composante ouverte de `0` est
+l'ensemble des sommets : tout sommet est atteignable depuis `0` par un chemin
+d'arêtes ouvertes. -/
+theorem component_C3_full :
+    Component C3 full3 (0 : Fin 3) = Set.univ := by
+  ext u
+  constructor
+  · intro _; trivial
+  · intro _; unfold Component
+    fin_cases u
+    · exact Relation.ReflTransGen.refl
+    · exact Relation.ReflTransGen.single
+        (show openAdj C3 full3 (0 : Fin 3) 1 from by
+          use adj_C3_0_1; simp [full3])
+    · exact Relation.ReflTransGen.single
+        (show openAdj C3 full3 (0 : Fin 3) 2 from by
+          use adj_C3_0_2; simp [full3])
+
+/-- Le singleton `{0}` n'est **pas** ω-fermé dans `full3` : l'arête ouverte
+`0—1` en sort. Un ensemble ω-fermé dans la configuration complète doit être bien
+plus grand qu'un sommet unique. -/
+theorem not_openEdgeClosed_C3_singleton :
+    ¬ openEdgeClosed C3 full3 ({0} : Set (Fin 3)) := by
+  intro h
+  have h1 : (1 : Fin 3) ∈ ({0} : Set (Fin 3)) :=
+    h (by simp) (show openAdj C3 full3 (0 : Fin 3) 1 from by
+      use adj_C3_0_1; simp [full3])
+  simp at h1
+
+/-- L'**arête frontière** de `{0}` dans `full3` : l'arête ouverte `0—1` traverse
+de `{0}` à son complémentaire. C'est le témoin concret que le complémentaire de
+`{0}` a une frontière non vide — la face frontière du pont du noyau. -/
+theorem exists_boundary_edge_C3 :
+    ∃ u v : Fin 3, u ∈ ({0} : Set (Fin 3)) ∧ v ∉ ({0} : Set (Fin 3)) ∧ openAdj C3 full3 u v := by
+  refine ⟨(0 : Fin 3), (1 : Fin 3), ?_, ?_, ?_⟩
+  · simp
+  · simp
+  · show openAdj C3 full3 (0 : Fin 3) 1
+    use adj_C3_0_1; simp [full3]
+
+end Percolation

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples_en.lean
@@ -85,4 +85,48 @@ theorem exists_boundary_edge_C3 :
   · show openAdj C3 full3 (0 : Fin 3) 1
     use adj_C3_0_1; simp [full3]
 
+/-- **Square** `C₄` — the 4-cycle. Unlike the triangle, `0` is not adjacent to
+`2`: reaching it requires a two-edge path, hence the composition
+`Relation.ReflTransGen.trans`. -/
+abbrev C4 : SimpleGraph (Fin 4) := SimpleGraph.cycleGraph 4
+
+/-- **Full configuration** on `C₄`: every edge is open. -/
+abbrev full4 : Finset (Edge C4) := Finset.univ
+
+/-- In the square `full4`, the open component of `0` reaches `2` through the
+composition `0 — 1 — 2` (two edges), which **exercises** the `Relation.ReflTransGen.trans`
+at the core of the tranche-3 kernel. Thus `component_C4_full` is the whole
+vertex set. -/
+theorem component_C4_full :
+    Component C4 full4 (0 : Fin 4) = Set.univ := by
+  ext u
+  constructor
+  · intro _; trivial
+  · intro _; unfold Component
+    fin_cases u
+    · exact Relation.ReflTransGen.refl
+    · exact Relation.ReflTransGen.single
+        (show openAdj C4 full4 (0 : Fin 4) 1 from by
+          use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 1); simp [full4])
+    · exact Relation.ReflTransGen.trans
+        (Relation.ReflTransGen.single
+          (show openAdj C4 full4 (0 : Fin 4) 1 from by
+            use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 1); simp [full4]))
+        (Relation.ReflTransGen.single
+          (show openAdj C4 full4 (1 : Fin 4) 2 from by
+            use (by decide : (SimpleGraph.cycleGraph 4).Adj 1 2); simp [full4]))
+    · exact Relation.ReflTransGen.single
+        (show openAdj C4 full4 (0 : Fin 4) 3 from by
+          use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 3); simp [full4])
+
+/-- The singleton `{0}` is **not** ω-closed in `full4`: the open edge `0—1`
+leaves it. -/
+theorem not_openEdgeClosed_C4_singleton :
+    ¬ openEdgeClosed C4 full4 ({0} : Set (Fin 4)) := by
+  intro h
+  have h1 : (1 : Fin 4) ∈ ({0} : Set (Fin 4)) :=
+    h (by simp) (show openAdj C4 full4 (0 : Fin 4) 1 from by
+      use (by decide : (SimpleGraph.cycleGraph 4).Adj 0 1); simp [full4])
+  simp at h1
+
 end Percolation_en

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation/Examples_en.lean
@@ -1,0 +1,88 @@
+import Percolation.Components_en
+import Mathlib.Combinatorics.SimpleGraph.CycleGraph
+
+/-! # Finite kernel of percolation — a calculable example (tranche 3, acceptance 3)
+
+Concrete instance of the components/boundary kernel on the **triangle** `C₃`
+(`SimpleGraph.cycleGraph 3`). In `cycleGraph 3` every pair of vertices is
+adjacent (modular subtraction), so `C₃` is the complete graph on `Fin 3`: its
+edge set has cardinal 3, and the full configuration `full3` (all edges open)
+makes the whole graph connected.
+
+This module grounds the abstract lemmas of
+`Percolation/Components_en.lean` on a small finite graph — the « calculable
+example » of issue #14871, acceptance 3 — and is checkable by `lake build`.
+
+- `component_C3_full`: in the full configuration the open component of `0` is
+  the whole vertex set.
+- `not_openEdgeClosed_C3_singleton`: the singleton `{0}` is **not** ω-closed.
+- `exists_boundary_edge_C3`: the open edge `0—1` crosses from `{0}` to its
+  complement — a concrete boundary witness.
+-/
+
+set_option linter.unusedSectionVars false
+
+namespace Percolation_en
+
+open Finset
+
+/-- **Triangle** `C₃` — the 3-cycle, a concrete finite simple graph. In
+`SimpleGraph.cycleGraph 3` every pair of vertices is adjacent, so `C₃` is the
+complete graph on `Fin 3`. -/
+abbrev C3 : SimpleGraph (Fin 3) := SimpleGraph.cycleGraph 3
+
+/-- **Full configuration** on `C₃`: every edge is open. -/
+abbrev full3 : Finset (Edge C3) := Finset.univ
+
+/-- `C₃` has exactly three (openable) edges. -/
+theorem card_edge_C3 : Fintype.card (Edge C3) = 3 := by
+  decide
+
+/-- In `C₃` the vertices `0` and `1` are adjacent. -/
+theorem adj_C3_0_1 : (SimpleGraph.cycleGraph 3).Adj (0 : Fin 3) 1 := by
+  decide
+
+/-- In `C₃` the vertices `0` and `2` are adjacent. -/
+theorem adj_C3_0_2 : (SimpleGraph.cycleGraph 3).Adj (0 : Fin 3) 2 := by
+  decide
+
+/-- In the full configuration `full3`, the open component of `0` is the whole
+vertex set: every vertex is reachable from `0` by a path of open edges. -/
+theorem component_C3_full :
+    Component C3 full3 (0 : Fin 3) = Set.univ := by
+  ext u
+  constructor
+  · intro _; trivial
+  · intro _; unfold Component
+    fin_cases u
+    · exact Relation.ReflTransGen.refl
+    · exact Relation.ReflTransGen.single
+        (show openAdj C3 full3 (0 : Fin 3) 1 from by
+          use adj_C3_0_1; simp [full3])
+    · exact Relation.ReflTransGen.single
+        (show openAdj C3 full3 (0 : Fin 3) 2 from by
+          use adj_C3_0_2; simp [full3])
+
+/-- The singleton `{0}` is **not** ω-closed in `full3`: the open edge `0—1`
+leaves it. A component-closed set in the full configuration must be far larger
+than a single vertex. -/
+theorem not_openEdgeClosed_C3_singleton :
+    ¬ openEdgeClosed C3 full3 ({0} : Set (Fin 3)) := by
+  intro h
+  have h1 : (1 : Fin 3) ∈ ({0} : Set (Fin 3)) :=
+    h (by simp) (show openAdj C3 full3 (0 : Fin 3) 1 from by
+      use adj_C3_0_1; simp [full3])
+  simp at h1
+
+/-- The **boundary edge** of `{0}` in `full3`: the open edge `0—1` crosses from
+`{0}` to its complement. This is the concrete witness that the complement of
+`{0}` has a non-empty boundary — the boundary face of the kernel bridge. -/
+theorem exists_boundary_edge_C3 :
+    ∃ u v : Fin 3, u ∈ ({0} : Set (Fin 3)) ∧ v ∉ ({0} : Set (Fin 3)) ∧ openAdj C3 full3 u v := by
+  refine ⟨(0 : Fin 3), (1 : Fin 3), ?_, ?_, ?_⟩
+  · simp
+  · simp
+  · show openAdj C3 full3 (0 : Fin 3) 1
+    use adj_C3_0_1; simp [full3]
+
+end Percolation_en

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation_en.lean
@@ -1,9 +1,12 @@
 import Percolation.Basic_en
 import Percolation.Connectivity_en
+import Percolation.Components_en
 
 /-! # Percolation — root lake (EN)
 
 Root aggregator of the `Percolation` subseries: imports the base module
-(`Basic`) and the connectivity module (`Connectivity`).
-Real content lives in `Percolation/Basic_en.lean` and `Percolation/Connectivity_en.lean`.
+(`Basic`), the connectivity module (`Connectivity`) and the components module
+(`Components`).
+Real content lives in `Percolation/Basic_en.lean`, `Percolation/Connectivity_en.lean`
+and `Percolation/Components_en.lean`.
 -/

--- a/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation_en.lean
+++ b/MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/Percolation_en.lean
@@ -1,12 +1,13 @@
 import Percolation.Basic_en
 import Percolation.Connectivity_en
 import Percolation.Components_en
+import Percolation.Examples_en
 
 /-! # Percolation — root lake (EN)
 
 Root aggregator of the `Percolation` subseries: imports the base module
-(`Basic`), the connectivity module (`Connectivity`) and the components module
-(`Components`).
-Real content lives in `Percolation/Basic_en.lean`, `Percolation/Connectivity_en.lean`
-and `Percolation/Components_en.lean`.
+(`Basic`), the connectivity module (`Connectivity`), the components module
+(`Components`) and the calculable example module (`Examples`).
+Real content lives in `Percolation/Basic_en.lean`, `Percolation/Connectivity_en.lean`,
+`Percolation/Components_en.lean` and `Percolation/Examples_en.lean`.
 -/


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2027:CoursIA-2 — prev: DEEP/lean #14892

## Objet

Tranche 3 de #14871 (jambe Lean de la distillation percolation #14847) : le noyau
**composantes / frontière**. Le jalon 1 (#14892, **mergé**) a prouvé le
**Harris–Kleitman (FKG fini)** au cas uniforme `p = 1/2` ; la tranche 2
(Connectivity, **PR #14896**, ouverte — pas encore sur `main`) a établi que
l'évènement « deux sommets sont reliés » est **croissant**. Cette tranche 3 relie
trois notions du noyau : la **composante connexe ouverte** `Component ω v`
(l'ensemble des sommets reliés à `v` par un chemin d'arêtes ouvertes), la
propriété d'être **fermé le long des arêtes ouvertes** (`openEdgeClosed` : aucune
arête ouverte ne sort de l'ensemble), et la **frontière** (le complémentaire).

Le **lemme connexion↔composante↔frontière** est le cœur du noyau : un ensemble
`A` est ω-fermé si et seulement s'il est une union de composantes connexes (il
contient la composante de chacun de ses éléments), si et seulement si aucune
arête ouverte ne relie `A` à son complémentaire (frontière vide).

**Séquençage** : tranche 3 **pîlée** sur la tranche 2 — `Percolation.Components`
`import Percolation.Connectivity`, qui n'est pas encore sur `main`. La base de la
PR est donc `feature/percolation-lean-connectivity` (#14896) ; elle se re-base sur
`main` quand #14896 aura mergé. En attendant, la PR est attendue **BLOCKED**
(review/merge gated sur la base, comportement normal d'un stack).

## Livrable

- **Paire i18n (#4980)** `Percolation/Components.lean` ↔ `Percolation/Components_en.lean`
  (namespaces `Percolation`/`Percolation_en`). Le sibling EN est un miroir
  auto-contenu qui importe `Percolation.Connectivity_en` et re-déclare dans
  `Percolation_en` (pattern miroir, byte-identique hors docstrings/commentaires).
- **Aggrégateurs racine** `Percolation.lean` / `Percolation_en.lean` mis à jour pour
  importer le module de composantes (série cohérente `Basic` → `Connectivity` → `Components`).
- **Paire i18n** `Percolation/Examples.lean` ↔ `Percolation/Examples_en.lean` —
  l'**exemple calculable** de l'acceptation 3 de #14871 : sur le triangle `C₃`
  (`SimpleGraph.cycleGraph 3`, graphe complet) la composante ouverte de `0` vaut
  l'ensemble des sommets (un seul pas) ; sur le carré `C₄` (`cycleGraph 4`) la
  composante atteint `2` par la **composition `0—1—2`** (deux arêtes), ce qui
  **exerce** `Relation.ReflTransGen.trans`. Les deux singletons `{0}` ne sont pas
  ω-fermés, avec témoin de frontière `0—1`. Ancré dans `Percolation.Components`,
  vérifiable par `lake build`.
- **Théorèmes no-sorry** :
  - `component_self` : `v ∈ Component ω v` (réflexivité, `ReflTransGen.refl`).
  - `component_closed` : la composante est ω-fermée (`ReflTransGen.trans` + `.single`).
  - `component_iff_connected` : `w ∈ Component v ↔ Connected v w` (**pont connexité↔composante**, définitionnel).
  - `mem_component_of_adj` : une arête ouverte place son extrémité dans la composante.
  - `openEdgeClosed.mem_of_connected` : un ensemble fermé contient la composante de chacun de ses éléments (induction le long du chemin).
  - `openEdgeClosed_iff_no_cross` : fermé ⟺ frontière vide (aucune arête ouverte vers le complémentaire).
  - `openEdgeClosed_iff_contains_components` : fermé ⟺ union de composantes (**lemme connexion↔composante↔frontière**).

## Grounding Mathlib (acceptance 1)

Vérifié firsthand dans `Mathlib v4.32.1` :
- `Relation.ReflTransGen` (`Mathlib.Logic.Relation`) : `.refl`, `.single`, `.trans`
  et l'induction `ReflTransGen` (`| refl => … | tail hconn hstep ih => …`) —
  la récurrence le long du chemin d'arêtes ouvertes, utilisée par `mem_of_connected`.
- `Relation.ReflTransGen.single : r a b → ReflTransGen r a b` et `.trans` — la
  fermeture d'un pas d'adjacence ouverte et la composition des segments, utilisées
  par `component_closed`.

## Vérifications (acceptance 6)

- **`lake build` SUCCESS** (exit 0, 1022 jobs) — `Percolation.Components`,
  `Percolation.Components_en` **et** `Percolation.Examples`/`Percolation.Examples_en`
  compilés contre la warm Mathlib v4.32.1 (848 → 1022 jobs, +4 modules pour
  l'exemple calculable) :
  ```
  ✔ [1018/1022] Built Percolation.Examples_en (7.8s)
  ✔ [1019/1022] Built Percolation.Examples (7.8s)
  ✔ [1020/1022] Built Percolation (7.7s)
  ✔ [1021/1022] Built Percolation_en (7.9s)
  Build completed successfully (1022 jobs).
  ```
- **`count_code_sorry.py --repo … --json`** : `distinct_code_sorry = 0`, `code_sorry = 0`
  sur `percolation_lean` (11 fichiers ; ce cycle n'introduit aucun `sorry`).
- **`#print axioms`** (équivalent proche de proof-integrity) : **FR et EN** — tous les
  nouveaux théorèmes dépendent de `[propext, Classical.choice, Quot.sound]` :
  **ni `sorryAx` ni `native_decide.*`**.
- **i18n (#4980)** : `Components.lean` / `Components_en.lean` **et**
  `Examples.lean` / `Examples_en.lean` byte-identiques hors docstrings/commentaires
  et hors suffixe `_en` normalisé (checker `check_i18n_siblings.py` :
  `1/1 pairs byte-identical | 0 drift | 0 orphan | 0 half-done`).
- **proof-integrity : `n/a (B.3)`** — aucun workflow `lean-axiom.yml` / `proof-integrity`
  n'est câblé sur `percolation_lean` (câblage CI recommandé en issue de suivi, comme
  aux tranches 1 et 2).

## Distinction prouvé / importé / hors portée (acceptance 5)

- **Prouvé ici** : les 7 lemmes du noyau — appartenance réflexive à la composante,
  fermeture ω de la composante, le pont connexité↔composante, contiguïté ⇒
  appartenance, fermeture héritée par récurrence, fermé ⟺ frontière vide, et le
  **lemme connexion↔composante↔frontière** `openEdgeClosed_iff_contains_components`.
- **Importé de Mathlib** : `Relation.ReflTransGen` (`refl`/`single`/`trans`, induction).
- **Hors portée / horizon de recherche** : le **notebook Lean** exécuté end-to-end
  (jambe apprentissage), le **FKG mesure-théorique** (passage à la mesure produit
  Bernoulli de paramètre général `p`), et la **suite du noyau** (inégalités
  isopérimétriques fines, sharpness supercritique) — tranches suivantes de #14871,
  non livrées ici. Aucun `sorry` introduit pour pallier l'absence.

## Scope / hygiène

- Aucun artefact catalogue généré modifié : catalogue byte-identique à `main`.
- Aucune modification de `MyIA.AI.Notebooks/Probas/README.md` ni de la nav Probas
  (acceptance 7 ; collision #14825 évitée).
- Aucun `sorry`, `native_decide` ni axiome non déclaré.
- Aucun overlap avec la jambe Python de #14847.
- **Collision garde (L898)** : `git worktree list` + `gh pr list --state open --json files`
  sur le chemin `percolation_lean` — seule PR ouverte sur le chemin = #14896 (la mienne,
  la base de ce stack). `check_lane_claim.py 14871` → `blocking_lanes: []` (CLEAR).

See #14871. See #14896. Part of #14871.
