### PR TITLE
docs(ml,#9377): supprimer les compteurs de notebooks en prose -- repare la resynchro de #14887

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -24,7 +24,6 @@ La formation couvre deux stacks complémentaires :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 57 (7 LangChain + 14 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 3 vision) |
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 
@@ -75,12 +74,12 @@ Labs 1 + 6 + 8. Découvrir le pipeline data science, construire un premier agent
 
 ```
 DataScienceWithAgents/
-├── 01-PythonForDataScience/    # Fondations Python (2 notebooks)
+├── 01-PythonForDataScience/    # Fondations Python
 │   └── notebooks/
 │       ├── 1.2-NumPy.ipynb
 │       └── 1.3-Pandas.ipynb
 │
-├── 02-ML-Cours/                # Fondations ML canoniques (21 notebooks)
+├── 02-ML-Cours/                # Fondations ML canoniques
 │   ├── 2.1-Workflow-ML.ipynb
 │   ├── 2.2-Descente-de-gradient.ipynb
 │   ├── 2.3-Regression-lineaire-logistique.ipynb
@@ -103,7 +102,7 @@ DataScienceWithAgents/
 │   ├── 2.12-Donnees-Desequilibrees.ipynb
 │   └── 2.13-Analyse-Erreurs.ipynb
 │
-├── 03-DeepLearning/            # Deep learning from scratch (10 notebooks)
+├── 03-DeepLearning/            # Deep learning from scratch
 │   ├── 3.0-Theorie-Information.ipynb
 │   ├── 3.1-Retropropagation.ipynb
 │   ├── 3.2-Optimisateurs.ipynb
@@ -116,17 +115,17 @@ DataScienceWithAgents/
 │   └── 3.8-Representations-Contrastives.ipynb
 │
 │
-├── 04-Vision/                # Vision par ordinateur : du neurone convolutif au transfer learning (3 notebooks)
+├── 04-Vision/                # Vision par ordinateur : du neurone convolutif au transfer learning
 │   ├── 4.1-Conv-NumPy-Torch-Allclose.ipynb
 │   ├── 4.2-ConvNet-Profonde-Residuelles.ipynb
 │   └── 4.3-TransferLearning-ResNet.ipynb
 │
-├── Track1-LangChain/ # Track LangChain (7 labs)
+├── Track1-LangChain/ # Track LangChain
 │   ├── Day1-Foundations/Labs/              # Revision
 │   ├── Day2-Document-Agents/Labs/              # Agents RFP et CV
 │   └── Day3-Data-Agents/Labs/              # Data + Agents
 │
-└── Track2-GoogleADK/         # Track Google ADK (14 labs)
+└── Track2-GoogleADK/         # Track Google ADK
     ├── Day4-Foundations/       # Introduction ADK
     ├── Day5-DS-Star/           # Data Science autonome
     ├── Day6-MLE-Star/          # ML Engineering

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -55,13 +55,13 @@ Six figures illustrent les trois fils de la série : les fondations Python (Pand
 
 ## Parcours d'apprentissage
 
-### Track A : ML.NET (.NET/C#, 10 notebooks C# — 9 du parcours ML-1 à ML-9 + 1 TP capstone — et leurs 9 jumeaux Python scikit-learn, ~7h)
+### Track A : ML.NET (.NET/C#, parcours ML-1 à ML-9 + TP capstone, et leurs jumeaux Python scikit-learn, ~7h)
 
 Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML) — son **leaderboard AutoML** (cell 12-13) rend visible la discrimination entre entraîneurs : sur données quadratiques, `LightGbmRegression` gagne avec un RMSE de 90 262 contre 30,5 millions pour `FastTreeRegression`, soit un écart de **plus de 300×** qu'aucun tableau `Console.WriteLine` ne fait ressortir. Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 
-### Track B : Data Science with Agents (Python, 57 notebooks, ~21h)
+### Track B : Data Science with Agents (Python, ~21h)
 
-Le parcours Python s'articule en trois temps. Les **fondations** (NumPy/Pandas) installent la manipulation de données. Le **socle ML canonique** ([02-ML-Cours](DataScienceWithAgents/02-ML-Cours/), 21 notebooks scikit-learn) pose ensuite les concepts fondamentaux — workflow et surapprentissage, descente de gradient, régressions et pont génératif, ensembles, biais-variance/calibration/équité, non supervisé, théorie PAC et ses compagnons formels, grokking, puis optimisation d'hyperparamètres, régularisation sparse et classes déséquilibrées — chacun rendant *visible* un concept-phare et ancrant un article fondateur. Viennent enfin les **labs agentic**, en deux sous-tracks : le sous-track **LangChain** (Labs 1-7) couvre le data wrangling, la visualisation, le ML classique et le NLP de base ; le sous-track **Google ADK** (Labs 8-18, extensions 12b-12d) monte en complexité avec le deep learning (PyTorch), le dashboarding et les pipelines multi-agents (agents LLM pour automatiser le workflow data science). Deux volets spécialisés complètent le parcours : [03-DeepLearning](DataScienceWithAgents/03-DeepLearning/) (10 notebooks PyTorch) et [04-Vision](DataScienceWithAgents/04-Vision/) (3 notebooks, dont transfer learning ResNet). Ce track présuppose Python 3.10+ avec PyTorch, scikit-learn et pandas.
+Le parcours Python s'articule en trois temps. Les **fondations** (NumPy/Pandas) installent la manipulation de données. Le **socle ML canonique** ([02-ML-Cours](DataScienceWithAgents/02-ML-Cours/), scikit-learn) pose ensuite les concepts fondamentaux — workflow et surapprentissage, descente de gradient, régressions et pont génératif, ensembles, biais-variance/calibration/équité, non supervisé, théorie PAC et ses compagnons formels, grokking, puis optimisation d'hyperparamètres, régularisation sparse et classes déséquilibrées — chacun rendant *visible* un concept-phare et ancrant un article fondateur. Viennent enfin les **labs agentic**, en deux sous-tracks : le sous-track **LangChain** (Labs 1-7) couvre le data wrangling, la visualisation, le ML classique et le NLP de base ; le sous-track **Google ADK** (Labs 8-18, extensions 12b-12d) monte en complexité avec le deep learning (PyTorch), le dashboarding et les pipelines multi-agents (agents LLM pour automatiser le workflow data science). Deux volets spécialisés complètent le parcours : [03-DeepLearning](DataScienceWithAgents/03-DeepLearning/) (PyTorch) et [04-Vision](DataScienceWithAgents/04-Vision/) (dont le transfer learning ResNet). Ce track présuppose Python 3.10+ avec PyTorch, scikit-learn et pandas.
 
 ## Progression recommandée
 
@@ -126,8 +126,8 @@ ML/
 │   ├── 02-ML-Cours/                  # Socle ML canonique (scikit-learn)
 │   │   ├── 2.8b-Theorie-PAC-Lean.ipynb   # compagnon Lean (lean4-wsl) du lake learning_theory_lean (moitie PAC)
 │   │   └── 2.8d-Lean-Novikoff-Convergence.ipynb   # compagnon Lean (lean4-wsl) du lake learning_theory_lean (moitie Perceptron)
-│   ├── 03-DeepLearning/              # Deep learning PyTorch (10 notebooks)
-│   ├── 04-Vision/                    # Vision par ordinateur (3 notebooks)
+│   ├── 03-DeepLearning/              # Deep learning PyTorch
+│   ├── 04-Vision/                    # Vision par ordinateur
 │   ├── Track1-LangChain/   # Track LangChain (Labs 1-7)
 │   └── Track2-GoogleADK/           # Track Google ADK (Labs 8-18, extensions 12b-12d)
 │


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-ai-01:CoursIA — prev: MED/notebook-python #14877

## Ce que cette PR répare — et pourquoi elle existe

**J'ai mergé #14887 en violation de l'Epic #9377.** Cette PR défait la partie de #14887 qui n'aurait pas dû être écrite, et résorbe le stock #9377 des deux mêmes fichiers.

#14887 s'intitule `resync READMEs DataScienceWithAgents (52->57) + parent ML (32->57, socle 9->21)`. Or #9377 — *« Les donnees quantitatives appartiennent au CI, pas a la prose — supprimer les compteurs manuels (44 notebooks + ~30 README) »* — nomme **`ML/README.md` explicitement** dans son Périmètre B, et sa doctrine tient en trois mots : **supprimer, pas resynchroniser**.

Le mandat user que #9377 cite (2026-08-04) :

> « Globalement la solution pour les notebooks etait d'arreter de les compter dans les readme, et pour les loc, ca me paraitrait sain d'en faire autant. Globalement les donnees quantitatives doivent etre tenues par le CI, pas dans la prose manuelle. »

Resynchroniser `52 -> 57` est précisément le geste que l'Epic ferme : le compteur redeviendra faux au prochain notebook ajouté, et une PR de resynchro suivra. #9377 en dénombre **11 mergées en 3 semaines**, dont une dont le titre avoue « re-drift post #6914 ».

**L'organe l'avait dit et je ne l'ai pas lu.** `prose-counts-guard` a posté `[ADVISORY] 7 compteur(s) quantitatif(s) en prose, 2 fichier(s)` sur #14887 le 2026-09-06 à 11:10:43Z. J'ai lu le `success` du check-run — le guard tourne **sans `--strict` par conception**, tant que le stock de #9377 n'est pas résorbé — et je n'ai pas ouvert la sortie. Le défaut est ma lecture, pas l'organe.

## Mesure — l'organe, avant et après

Instrument : `scripts/notebook_tools/check_prose_quantitative_claims.py --all --strict --root MyIA.AI.Notebooks/ML`.

| Fichier | Avant | Après |
|---|---:|---:|
| `ML/README.md` | **7** (`10 notebooks`, `21 notebooks`, `3 notebooks`, `57 notebooks`) | **0** |
| `ML/DataScienceWithAgents/README.md` | **4** (`10`, `2`, `21`, `3 notebooks`) | **0** |

Les deux fichiers sortent du rapport de l'organe. Les 11 comptent le stock entier de ces deux fichiers, pas seulement les 7 que #14887 avait ajoutés : les laisser à moitié nettoyés aurait maintenu les fichiers rouges sous `--strict`, ce qui rate l'objet.

**Contrôle inverse** : `rc(strict)` reste `1` sur le sous-arbre ML **après** la PR — trois autres fichiers portent encore du stock #9377 (résidu nommé plus bas). Un `rc=0` ici aurait signalé un organe muet, pas un travail fini.

## Transformation appliquée — supprimer le compte, garder la qualification

Le type de #9377 est `(140 lignes, 0 sorry)` -> `(0 sorry)`. Appliqué :

| Avant | Après |
|---|---|
| `(02-ML-Cours), 21 notebooks scikit-learn)` | `(02-ML-Cours), scikit-learn)` |
| `03-DeepLearning (10 notebooks PyTorch)` | `03-DeepLearning (PyTorch)` |
| `04-Vision (3 notebooks, dont transfer learning ResNet)` | `04-Vision (dont le transfer learning ResNet)` |
| `Track A : ML.NET (.NET/C#, 10 notebooks C# — 9 du parcours ML-1 à ML-9 + 1 TP capstone — et leurs 9 jumeaux…)` | `Track A : ML.NET (.NET/C#, parcours ML-1 à ML-9 + TP capstone, et leurs jumeaux…)` |
| `Track B : … (Python, 57 notebooks, ~21h)` | `Track B : … (Python, ~21h)` |

**Ce qui est gardé, délibérément :**

- **Toute la structure ajoutée par #14887** — l'arborescence des notebooks, les entrées par sous-dossier, les descriptions. C'est le gain réel de cette PR et il reste intact : un lecteur voit *quels* notebooks existent, ce qui ne dérive pas.
- **`| Durée totale | ~7 jours |` et les `~7h` / `~21h`** — pacing pédagogique. L'organe l'exempte nommément (arbitrage `jsboige` sur #9434 : « TN structurel/pédagogique, HORS scope drainage, à GARDER »).
- **`Labs 1-7`, `Labs 8-18`, `extensions 12b-12d`** — des identifiants de plage, pas des décomptes d'artefacts.

**Deux suppressions au-delà de ce que l'organe mesure, que je déclare plutôt que de les glisser :**

1. La ligne `| Notebooks | 57 (7 LangChain + 14 ADK + 2 fondations Python + 21 fondations ML + 10 deep learning + 3 vision) |`. L'organe ne la voit pas — le nombre et le nom vivent dans deux cellules de tableau distinctes, et son motif exige l'adjacence `<n> <nom>`. Mais son contenu **entier** est un compte et une ventilation de comptes, dans un tableau intitulé `| Statistique | Valeur |` : c'est le genre même que #9377 ferme, et c'est la ligne que #14887 a resynchronisée de 52 à 57. La laisser, c'est garantir la prochaine PR de resynchro.
2. `(7 labs)` et `(14 labs)` : `labs` n'est pas dans le lexique `ARTIFACT_NOUNS` de l'organe, mais ce sont des décomptes de notebooks qui dérivent comme les autres.

Si l'un de ces deux dépassements est jugé hors périmètre, il se retire sans toucher au reste.

## Résidu #9377 nommé, non traité ici

`--root MyIA.AI.Notebooks/ML` rend encore, après cette PR :

- `DataScienceWithAgents/04-Vision/README.md` (4) — `15 fichiers, 3000 lignes, 35 cellules, 48 cellules`
- `ML.Net/README.md` (1) — `87 cellules` — **nommé dans le Périmètre B de #9377**
- `learning_theory_lean/README.md` (1) — `18 modules`

Hors périmètre de cette réparation (un sujet par PR), et hors du sous-arbre ML il reste le reste du Périmètre B (racine, `Probas/`, `QuantConnect/Python/`, `GameTheory/`). C'est le stock dont la résorption conditionne le passage du guard en `--strict`.

## Portée

- Deux fichiers, `+11 / -12`. Aucun notebook, aucun code, aucun bloc `CATALOG-STATUS` touché.
- Le catalogue reste byte-identique à `main` (il appartient à l'automatisation).

See #9377 · corrige #14887 (elle-même sous #13504)
