### PR TITLE
fix(guard,#14900): la table CTRL couvre le septieme echappement Python (BEL/a) -- 2 \approx repares

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
@@ -748,7 +748,7 @@
     "\n",
     "### Complexite exacte vs approximation\n",
     "\n",
-    "**Exact $O(2^n \\cdot n)$** : on enumere tous les sous-ensembles $S \\subseteq N \\setminus \\{i\\}$ (il y en a $2^{n-1}$), pour chaque $S$ on evalue $v(S \\cup \\{i\\})$ et $v(S)$ (2 evaluations), puis on moyenne. Pour $n=10$, ca fait $10 \\cdot 2^9 = 5120$ evaluations -- encore faisable. Pour $n=20$, ca fait $20 \\cdot 2^{19} \u0007pprox 10^7$ -- long mais faisable. Pour $n=30$, ca fait $20 \\cdot 2^{29} \u0007pprox 10^{10}$ -- impraticable.\n",
+    "**Exact $O(2^n \\cdot n)$** : on enumere tous les sous-ensembles $S \\subseteq N \\setminus \\{i\\}$ (il y en a $2^{n-1}$), pour chaque $S$ on evalue $v(S \\cup \\{i\\})$ et $v(S)$ (2 evaluations), puis on moyenne. Pour $n=10$, ca fait $10 \\cdot 2^9 = 5120$ evaluations -- encore faisable. Pour $n=20$, ca fait $20 \\cdot 2^{19} \\approx 10^7$ -- long mais faisable. Pour $n=30$, ca fait $20 \\cdot 2^{29} \\approx 10^{10}$ -- impraticable.\n",
     "\n",
     "**Monte Carlo $O(\\text{samples} \\cdot n)$** : on tire `samples` permutations aleatoires uniformement, pour chaque permutation on calcule les contributions marginales, on moyenne. La convergence est en $O(1/\\sqrt{\\text{samples}})$ par le TCL. Pour `samples = 10^4` et $n = 100$, on obtient une erreur typique de l'ordre de $10^{-2}$ -- acceptable pour la visualisation politique, insuffisant pour une application legale ou financiere.\n",
     "\n",

--- a/scripts/notebook_tools/check_latex_control_chars.py
+++ b/scripts/notebook_tools/check_latex_control_chars.py
@@ -196,7 +196,12 @@ def pr_diff_files(base: str, head: str) -> list[Path]:
         cwd=REPO_ROOT, capture_output=True, text=True, check=True,
         encoding="utf-8", errors="replace",
     )
-    return [REPO_ROOT / f for f in proc.stdout.splitlines() if f.endswith(".ipynb")]
+    # A path the diff names but the working tree lacks (renamed or deleted
+    # since base -- e.g. a rename landed on main after the branch point)
+    # has nothing to scan at HEAD; scanning it crashed the workflow with
+    # UNREADABLE (#14901).
+    return [REPO_ROOT / f for f in proc.stdout.splitlines()
+            if f.endswith(".ipynb") and (REPO_ROOT / f).exists()]
 
 
 def main(argv=None) -> int:

--- a/scripts/notebook_tools/check_latex_control_chars.py
+++ b/scripts/notebook_tools/check_latex_control_chars.py
@@ -56,10 +56,14 @@ CTRL = {
     "\f": ("FF", "f"),
     "\v": ("VT", "v"),
     "\x08": ("BS", "b"),
+    "\x07": ("BEL", "a"),
 }
 # queues = command name minus its first letter (the escape ate both).
 # Superset of the issue's table: `eq` (\neq) and `arnothing` (\varnothing)
-# are measured defects the issue's own list omitted.
+# are measured defects the issue's own list omitted. The `a` row covers the
+# seventh Python escape (#14900): a hand-copied table had omitted BEL and
+# two measured `\approx` went undetected -- the coverage test compares
+# against the seven escapes, never against this table.
 QUEUES = {
     "t": {"heta", "imes", "ext", "op", "au", "ilde", "o"},
     "n": {"eg", "abla", "otin", "ewline", "eq", "e", "u"},
@@ -67,6 +71,8 @@ QUEUES = {
     "f": {"orall", "rac", "rown", "lat"},
     "v": {"ee", "dash", "arphi", "ec", "ert", "arnothing"},
     "b": {"eta", "egin", "igcup", "ot", "ar", "inom"},
+    "a": {"pprox", "lpha", "ngle", "leph", "st", "top",
+          "rccos", "rcsin", "rctan", "rray", "malg"},
 }
 MAXQ = 10
 EXCLUDED_DIRS = ("/_archive/", "/.ipynb_checkpoints/", "/.lake/")

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
@@ -69,6 +69,12 @@
       csharp_sha: 3f2db3ce96f3711878be04f0eede760e2ead53ac
       content_python_sha: 68264fddff413639300a0e785befddc3b3c1779c2bb9151b0d285ce1624d3d9c
       content_csharp_sha: ae6e685e922ec0ebb2c4719b7c3f64138c946122e172420693053b5072e0fb22
+    - date: "2026-09-06"
+      by: myia-po-2027:CoursIA
+      python_sha: 4f795d52b28c6704651d6ab072480265f20fdc77
+      csharp_sha: 3f2db3ce96f3711878be04f0eede760e2ead53ac
+      content_python_sha: a75f50b8b56033dd423e18180a947e9d10127824c8e10b4f7b505d05b4209543
+      content_csharp_sha: ae6e685e922ec0ebb2c4719b7c3f64138c946122e172420693053b5072e0fb22
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = numpy + matplotlib + module local `cooperative_games` + itertools (54 cellules dont 25 code). C# = BCL .NET 9 pur (System.Linq, System.Collections.Generic, 0 NuGet, convention marathon #4956). Tranche 2026-08-22 (PR #12312, c.1301+334, myia-po-2025:CoursIA-2, issue #10382) : les sections legislatives 2024 (Python cellules 33-45 : donnees officielles NFP Ministere de l'Interieur, fonction de valeur sieges avec synergies calibrees, Shapley NFP, contributions marginales par coalition d'accueil, scenarios contrefactuels, comparaison sieges/pouvoir de vote/negociation) ET la comparaison exact vs Monte Carlo (Python cellules 12-13 : jeu de vote pondere 8 actionnaires [51; 25,20,15,12,10,8,6,4], exact 8! = 40320 permutations en 111 ms vs MC 10 000 echantillons graine 42, erreur max 0.0030) sont desormais portees cote C# (section 7, 7 cellules code ajoutees executees, 24/24 notebook complet, 0 erreur, nbconvert .net-csharp). Resultats cles : LFI 37.0% du Shapley vs 46.1% du poids electoral NFP (-9.1 pts, sur-estime dans le debat public), PS +7.5 pts (capte les reports du centre), perdre LFI ou PS coute symetriquement 95 sieges, somme Shapley = 180 = v(N) (efficacite). Residuel : visualisations matplotlib remplacees par tableaux numeriques (convention BCL 0-NuGet, documentee, precedent sweeps numeriques). Verdict SOTA-OK : pas de moteur tiers applicable par convention from-scratch assumee des deux cotes (marathon #4956), couverture legislative + Monte Carlo paritaire, asymetrie uniquement visuelle et documentee."
   known_differences:

--- a/scripts/tests/test_check_latex_control_chars.py
+++ b/scripts/tests/test_check_latex_control_chars.py
@@ -43,9 +43,28 @@ def md(source: str) -> dict:
 # NOTE ON THE LITERALS BELOW: a SINGLE backslash in these Python strings is
 # the defect's ghost -- `\t` is a real TAB (what Python left of `\theta`),
 # `\r` a real CR, `\f` a real FF, `\v` a real VT, `\b` a real BS, `\n` a
-# real LF. The cell therefore carries exactly the bytes found in the
-# measured corpus. Double backslashes (`\\text`) are real LaTeX, kept to
-# prove the detector is not just matching any backslash.
+# real LF, `\a` a real BEL. The cell therefore carries exactly the bytes
+# found in the measured corpus. Double backslashes (`\\text`) are real
+# LaTeX, kept to prove the detector is not just matching any backslash.
+
+
+class TestTableCoversAllSevenPythonEscapes(unittest.TestCase):
+    """#14900 acceptance 1: the CTRL table is checked against THE SEVEN
+    Python escape sequences (`\\a \\b \\f \\n \\r \\t \\v`), not against a
+    hand-copied enumeration of itself. The original table was written by
+    hand and omitted BEL -- a table re-copied from it would re-omit it the
+    same way."""
+
+    def test_ctrl_is_exactly_the_seven_escapes(self):
+        seven = {"\a", "\b", "\f", "\n", "\r", "\t", "\v"}
+        self.assertEqual(set(clc.CTRL), seven,
+                         "CTRL must cover exactly the seven Python escapes")
+
+    def test_every_ctrl_entry_has_a_queue_row(self):
+        for _, (_, first) in clc.CTRL.items():
+            self.assertIn(first, clc.QUEUES,
+                          f"CTRL entry '{first}' has no QUEUES row")
+
 
 class TestPositiveControls(unittest.TestCase):
 
@@ -88,6 +107,23 @@ class TestPositiveControls(unittest.TestCase):
         hits = clc.find_defects("donne $\binom{n-1}{k-1}$ et $\beta_i(v)$")
         self.assertEqual([h["command"] for h in hits], ["\\binom", "\\beta"])
 
+    def test_bel_pprox_inline(self):
+        # #14900: GameTheory-15 cell 13 -- `$20 \cdot 2^{19} <BEL>pprox 10^7$`
+        # (`\a` is the seventh Python escape; the CTRL table omitted it and
+        # this exact measured defect went undetected -- the false negative
+        # the original table's hand-enumeration was guaranteed to repeat)
+        h = self.hit("ca fait $20 \\cdot 2^{19} \x07pprox 10^7$ -- long mais")
+        self.assertEqual(h["command"], "\\approx")
+
+    def test_bel_pprox_second_measured_line(self):
+        h = self.hit("ca fait $20 \\cdot 2^{29} \x07pprox 10^{10}$ -- impraticable")
+        self.assertEqual(h["command"], "\\approx")
+
+    def test_bel_queue_word_boundary(self):
+        # BEL + "pproximation" is NOT \approx (queue must end the word)
+        hits = clc.find_defects("$n \x07pproximation directe$")
+        self.assertEqual(hits, [])
+
     def test_tab_o_to_with_word_boundary(self):
         # Planners-4 tranche2-fd-intro: `$<TAB>o$ SAS+` = \to
         h = self.hit("translation domaine $\to$ SAS+")
@@ -97,7 +133,6 @@ class TestPositiveControls(unittest.TestCase):
 # --- Negative controls: shapes a looser detector gets wrong ----------------
 
 class TestNegativeControls(unittest.TestCase):
-
     def test_code_cell_newline_else_never_scanned(self):
         # discriminant 1: code cells are out of scope (`\nelse:` was the
         # first version's false-positive flood)

--- a/scripts/tests/test_check_latex_control_chars.py
+++ b/scripts/tests/test_check_latex_control_chars.py
@@ -181,6 +181,38 @@ class TestNegativeControls(unittest.TestCase):
         self.assertEqual(clc.find_defects(text), [])
 
 
+# --- PR-diff scope: renamed/deleted files are ghosts, not targets -----------
+
+class TestPrDiffSkipsRenamedAwayFiles(unittest.TestCase):
+    """#14901: a notebook renamed on main AFTER the branch point shows up in
+    the three-dot diff as deleted-at-base; the scanner tried to open it and
+    the run died UNREADABLE. A file absent from the PR's tree has nothing
+    to scan."""
+
+    def test_pr_diff_skips_files_absent_from_the_working_tree(self):
+        import subprocess as sp
+        with tempfile.TemporaryDirectory() as d:
+            old_root = clc.REPO_ROOT
+            clc.REPO_ROOT = Path(d)
+            try:
+                def git(*a):
+                    sp.run(["git", *a], cwd=d, check=True, capture_output=True)
+                git("init", "-q", "-b", "main")
+                git("config", "user.email", "t@t")
+                git("config", "user.name", "t")
+                (Path(d) / "ghost.ipynb").write_text("{}", encoding="utf-8")
+                git("add", "-A")
+                git("commit", "-qm", "base has ghost")
+                git("rm", "-q", "ghost.ipynb")
+                git("commit", "-qm", "pr removes ghost")
+                # diff HEAD~1..HEAD names ghost.ipynb; the working tree
+                # (HEAD) does not have it
+                files = clc.pr_diff_files("HEAD~1", "HEAD")
+                self.assertEqual(files, [])
+            finally:
+                clc.REPO_ROOT = old_root
+
+
 # --- Exit codes -------------------------------------------------------------
 
 class TestMainExitCodes(unittest.TestCase):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA — prev: MED/readme #14887

## Summary

La table `CTRL` de `check_latex_control_chars.py` couvrait six des **sept** échappements Python — `\a` (BEL, `0x07`) manquait, et `QUEUES` n'avait pas de ligne `"a"`. Conséquence mesurée : les deux `\approx` mangés de `GameTheory-15-CooperativeGames.ipynb` (cellule 13) passaient l'organe en silence — c'est ce zéro qui avait soutenu l'attestation « 0 occurrence » du body de #14885, plus large que son instrument.

## Correctif

- `CTRL["\x07"] = ("BEL", "a")` + ligne `QUEUES["a"]` (`\approx \alpha \angle \aleph \ast \atop \arccos \arcsin \arctan \array \amalg`).
- `GameTheory-15` cellule `5d63b0e9` (markdown) : `2^19 pprox 10^7` et `2^29 pprox 10^{10}` → `\approx` — **diff d'une seule ligne**, cellule markdown (exception C.2 md-only, aucune cellule code touchée, pas de re-exec due).

## Acceptance #14900, critère par critère

1. **CTRL couvre les sept échappements, testé contre LA liste des sept** — `TestTableCoversAllSevenPythonEscapes.test_ctrl_is_exactly_the_seven_escapes` compare `set(CTRL)` à `{"\a","\b","\f","\n","\r","\t","\v"}`, jamais à une recopie de la table ; plus `test_every_ctrl_entry_has_a_queue_row` (aucune entrée CTRL orpheline de QUEUES).
2. **Contrôle positif + preuve du faux négatif** — `test_bel_pprox_inline` et `test_bel_pprox_second_measured_line` portent les deux lignes mesurées de GameTheory-15. Mesuré **avant** le correctif : `3 failed, 21 passed` (les 2 lignes BEL → `0 != 1 : expected 1 hit, got []`, + le test de couverture des sept). **Après** : `24 passed`. Un contrôle négatif de frontière de mot (`\a`+`pproximation` n'est pas `\approx`) accompagne.
3. **2 occurrences réparées + scan corpus 0** — diff notebook : 1 ligne (les deux `pprox` → `\approx`) ; `python scripts/notebook_tools/check_latex_control_chars.py` sur tout le repo avec la table complétée : `=== 0 occurrence(s) in 0 notebook(s), 0 unreadable ===`, exit 0.

## Note de mesure

La chaîne de remplacement de la première tentative (`'\approx'` en Python) valait `BEL + "pprox"` — le remplacement était un no-op **parce que le défaut réparé l'a recréé sur place**. Le remplacement final passe par `chr(92) + 'approx'`. C'est la démonstration la plus directe de pourquoi `\a` devait être dans la table.

See #14900 · See #14859 (organe d'origine, livré par #14885)
