### PR TITLE
feat(lean,#2159): Partie 72 -- germes et tiges (stalks) du representable

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Stalks.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Stalks.lean
@@ -1,0 +1,110 @@
+/-
+Grothendieck hommage — Partie 72 : germes et tiges (stalks) sur le site des
+ouverts.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+La tige d'un préfaisceau `F` en un point `x` est la colimite des sections
+au-dessus des voisinages ouverts de `x` : deux sections ont même germe
+lorsqu'elles coïncident sur un voisinage assez petit. La Partie 70 a établi
+que la topologie `opensTopology` est exactement celle de Mathlib — les
+préfaisceaux sous-jacents sont définitionnellement les mêmes, et toute
+l'API `TopCat.Presheaf` (tiges, germes, `germ_res`, `stalk_hom_ext`)
+s'applique telle quelle aux préfaisceaux du site own.
+
+Le résultat nouveau de cette partie est le calcul complet de la tige du
+représentable. Pour un ouvert `U`, le préfaisceau `yoneda.obj U` (un
+faisceau, par la sous-canonicité de la Partie 71) a une tige en `x` qui
+est un singleton exactement lorsque `x ∈ U`, et vide sinon : la tige du
+représentable détecte l'appartenance du point. C'est le premier maillon du
+dictionnaire faisceaux ↔ espaces étalés — la fibre en `x` de l'espace étalé
+du faisceau représenté par `U` est `U` lui-même.
+
+La preuve va chercher chaque élément de la tige comme germe d'une section
+(`exists_germ_eq` : les flèches `germ` atteignent conjointement la
+colimite), puis identifie ce germe au germe de l'identité de `U` par
+restriction (`germ_res`) : une section du représentable au-dessus d'un
+voisinage `W` est une flèche `W ⟶ U`, l'inclusion d'un voisinage contenu
+dans `U`.
+
+Références :
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II §3 (germes et faisceaux sur un espace).
+  - Mathlib, `Mathlib.Topology.Sheaves.Stalks` (tiges et germes :
+    `exists_germ_eq`, `germ_res`).
+  - Partie 70 (`Grothendieck.SpacesMathlib`) : le pont d'égalité des
+    topologies, qui rend l'API de Mathlib applicable au site own.
+  - Partie 71 (`Grothendieck.SpacesSubcanonical`) : la sous-canonicité —
+    `yoneda.obj U` est un faisceau.
+
+Convention i18n (EPIC #4980 ratifiée 2026-07-04) : ce module est jumelé avec
+`Stalks_en.lean`. Les énoncés, preuves et noms Lean restent identiques ;
+seules les docstrings et les commentaires diffèrent.
+
+Epic #1646, Phase 2 (#2159). Aucun `sorry` introduit.
+-/
+
+import Grothendieck.Spaces
+import Mathlib.Topology.Sheaves.Stalks
+
+namespace Grothendieck
+
+open CategoryTheory TopologicalSpace
+
+universe u
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- **Tige du représentable, cas intérieur** : en un point `x ∈ U`, la tige
+du préfaisceau `yoneda.obj U` — vu comme préfaisceau sur l'espace `T` via le
+pont de la Partie 70 — est un singleton, dont l'unique élément est le germe
+de l'identité de `U`. Tout élément de la tige est le germe d'une section
+(`exists_germ_eq`) ; une telle section au-dessus d'un voisinage `W ∋ x` est
+une flèche `W ⟶ U`, et son germe s'identifie au germe de `𝟙 U` par
+restriction (`germ_res`). -/
+@[reducible]
+noncomputable def unique_stalk_yoneda (U : Opens T) {x : T} (hx : x ∈ U) :
+    Unique (TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x) := by
+  have key : ∀ z : TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x,
+      z = TopCat.Presheaf.germ (X := TopCat.of T) (yoneda.obj U) U x hx (𝟙 U) := by
+    intro z
+    obtain ⟨W, hW, w, rfl⟩ :=
+      TopCat.Presheaf.exists_germ_eq (X := TopCat.of T) (yoneda.obj U) z
+    have w' : W ⟶ U := w
+    have h := TopCat.Presheaf.germ_res_apply (X := TopCat.of T) (yoneda.obj U) w' x hW (𝟙 U)
+    simp only [CategoryTheory.yoneda_obj_map] at h
+    exact h
+  exact ⟨⟨TopCat.Presheaf.germ (X := TopCat.of T) (yoneda.obj U) U x hx (𝟙 U)⟩, key⟩
+
+/-- **Tige du représentable, cas extérieur** : si `x ∉ U`, la tige de
+`yoneda.obj U` est vide — tout germe provient d'une section `W ⟶ U`
+au-dessus d'un voisinage `W ∋ x`, qui forcerait `x ∈ U`. -/
+theorem isEmpty_stalk_yoneda (U : Opens T) {x : T} (hx : x ∉ U) :
+    IsEmpty (TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x) := by
+  refine ⟨fun z => ?_⟩
+  obtain ⟨W, hW, w, -⟩ :=
+    TopCat.Presheaf.exists_germ_eq (X := TopCat.of T) (yoneda.obj U) z
+  have w' : W ⟶ U := w
+  exact hx (w'.le hW)
+
+/-- **La tige du représentable détecte l'appartenance** — jonction avec la
+Partie 71 : `yoneda.obj U` est un faisceau (sous-canonicité de
+`opensTopology`), et sa tige en `x` est habitée exactement aux points de
+`U`. C'est l'ombre ponctuelle du fait que le faisceau représenté par `U`
+« vit sur `U` » : la fibre en `x` de l'espace étalé associé est habitée
+dans `U`, vide au-dehors. -/
+theorem nonempty_stalk_yoneda_iff (U : Opens T) (x : T) :
+    Nonempty (TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x) ↔ x ∈ U := by
+  constructor
+  · rintro ⟨z⟩
+    by_contra hx
+    exact (isEmpty_stalk_yoneda T U hx).elim z
+  · exact fun hx => ⟨(unique_stalk_yoneda T U hx).default⟩
+
+end Contenu
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Stalks_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Stalks_en.lean
@@ -1,0 +1,109 @@
+/-
+Grothendieck tribute — Part 72: germs and stalks on the site of open sets.
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 2 extension (#2159, Epic #1646).
+
+The stalk of a presheaf `F` at a point `x` is the colimit of the sections
+over the open neighbourhoods of `x`: two sections have the same germ when
+they agree on a small enough neighbourhood. Part 70 established that the
+topology `opensTopology` is exactly Mathlib's — the underlying presheaves
+are definitionally the same, and the whole `TopCat.Presheaf` API (stalks,
+germs, `germ_res`, `stalk_hom_ext`) applies verbatim to presheaves on the
+own site.
+
+The new result of this part is the complete computation of the stalk of a
+representable. For an open set `U`, the presheaf `yoneda.obj U` (a sheaf,
+by the subcanonicity of Part 71) has a stalk at `x` which is a singleton
+exactly when `x ∈ U`, and empty otherwise: the stalk of a representable
+detects membership of the point. This is the first link of the sheaves ↔
+étale spaces dictionary — the fibre at `x` of the étale space of the sheaf
+represented by `U` is `U` itself.
+
+The proof fetches every element of the stalk as the germ of a section
+(`exists_germ_eq`: the `germ` arrows are jointly surjective onto the
+colimit), then identifies that germ with the germ of the identity of `U`
+by restriction (`germ_res`): a section of the representable above a
+neighbourhood `W` is an arrow `W ⟶ U`, the inclusion of a neighbourhood
+contained in `U`.
+
+References:
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Ch. II §3 (germs and sheaves on a space).
+  - Mathlib, `Mathlib.Topology.Sheaves.Stalks` (stalks and germs:
+    `exists_germ_eq`, `germ_res`).
+  - Part 70 (`Grothendieck.SpacesMathlib`): the equality bridge between
+    the topologies, which makes Mathlib's API applicable to the own site.
+  - Part 71 (`Grothendieck.SpacesSubcanonical`): subcanonicity —
+    `yoneda.obj U` is a sheaf.
+
+i18n convention (EPIC #4980 ratified 2026-07-04): this module is twinned
+with `Stalks.lean`. Statements, proofs and Lean names stay identical; only
+docstrings and comments differ.
+
+Epic #1646, Phase 2 (#2159). No `sorry` introduced.
+-/
+
+import Grothendieck.Spaces
+import Mathlib.Topology.Sheaves.Stalks
+
+namespace Grothendieck.Stalks_en
+
+open CategoryTheory TopologicalSpace
+
+universe u
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- **Stalk of a representable, interior case**: at a point `x ∈ U`, the
+stalk of the presheaf `yoneda.obj U` — viewed as a presheaf on the space
+`T` through the Part 70 bridge — is a singleton, whose unique element is
+the germ of the identity of `U`. Every element of the stalk is the germ of
+a section (`exists_germ_eq`); such a section above a neighbourhood `W ∋ x`
+is an arrow `W ⟶ U`, and its germ identifies with the germ of `𝟙 U` by
+restriction (`germ_res`). -/
+@[reducible]
+noncomputable def unique_stalk_yoneda (U : Opens T) {x : T} (hx : x ∈ U) :
+    Unique (TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x) := by
+  have key : ∀ z : TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x,
+      z = TopCat.Presheaf.germ (X := TopCat.of T) (yoneda.obj U) U x hx (𝟙 U) := by
+    intro z
+    obtain ⟨W, hW, w, rfl⟩ :=
+      TopCat.Presheaf.exists_germ_eq (X := TopCat.of T) (yoneda.obj U) z
+    have w' : W ⟶ U := w
+    have h := TopCat.Presheaf.germ_res_apply (X := TopCat.of T) (yoneda.obj U) w' x hW (𝟙 U)
+    simp only [CategoryTheory.yoneda_obj_map] at h
+    exact h
+  exact ⟨⟨TopCat.Presheaf.germ (X := TopCat.of T) (yoneda.obj U) U x hx (𝟙 U)⟩, key⟩
+
+/-- **Stalk of a representable, exterior case**: if `x ∉ U`, the stalk of
+`yoneda.obj U` is empty — every germ comes from a section `W ⟶ U` above a
+neighbourhood `W ∋ x`, which would force `x ∈ U`. -/
+theorem isEmpty_stalk_yoneda (U : Opens T) {x : T} (hx : x ∉ U) :
+    IsEmpty (TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x) := by
+  refine ⟨fun z => ?_⟩
+  obtain ⟨W, hW, w, -⟩ :=
+    TopCat.Presheaf.exists_germ_eq (X := TopCat.of T) (yoneda.obj U) z
+  have w' : W ⟶ U := w
+  exact hx (w'.le hW)
+
+/-- **The stalk of a representable detects membership** — junction with
+Part 71: `yoneda.obj U` is a sheaf (subcanonicity of `opensTopology`), and
+its stalk at `x` is inhabited exactly at the points of `U`. This is the
+pointwise shadow of the fact that the sheaf represented by `U` "lives on
+`U`": the fibre at `x` of the associated étale space is inhabited inside
+`U`, empty outside. -/
+theorem nonempty_stalk_yoneda_iff (U : Opens T) (x : T) :
+    Nonempty (TopCat.Presheaf.stalk (X := TopCat.of T) (yoneda.obj U) x) ↔ x ∈ U := by
+  constructor
+  · rintro ⟨z⟩
+    by_contra hx
+    exact (isEmpty_stalk_yoneda T U hx).elim z
+  · exact fun hx => ⟨(unique_stalk_yoneda T U hx).default⟩
+
+end Contenu
+
+end Grothendieck.Stalks_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: DEEP/lean #14822

## Summary

Partie 72 de l'Epic #2159 (Grothendieck hommage, Phase 2) : **germes et tiges (stalks) sur le site des ouverts** — nouveau module `Grothendieck/Stalks.lean` (+ jumeau i18n `Stalks_en.lean`, convention #4980).

- **Pont (Partie 70)** : `opensTopology T = Opens.grothendieckTopology T` par `rfl` — les préfaisceaux sous-jacents sont définitionnellement identiques, donc l'API `TopCat.Presheaf` de Mathlib (tiges, germes, `germ_res`, `stalk_hom_ext`) s'applique telle quelle aux préfaisceaux du site own ; c'est ce que matérialisent les énoncés (`yoneda.obj U` vu comme `TopCat.Presheaf (Type u) (TopCat.of T)`).
- **Résultat nouveau — la tige du représentable détecte l'appartenance du point** (absent de Mathlib, vérifié : 0 hit `yoneda` dans `Topology/Sheaves/Stalks.lean`) :
  - `unique_stalk_yoneda` : `x ∈ U → Unique (stalk (yoneda.obj U) x)` — l'unique élément est le germe de `𝟙 U` ;
  - `isEmpty_stalk_yoneda` : `x ∉ U → IsEmpty (stalk (yoneda.obj U) x)` ;
  - `nonempty_stalk_yoneda_iff` : `Nonempty (stalk (yoneda.obj U) x) ↔ x ∈ U`.
- **Jonction Partie 71** : `yoneda.obj U` est un faisceau (sous-canonicité de `opensTopology`), et sa tige est habitée exactement aux points de `U` — le faisceau représenté par `U` « vit sur `U` », premier maillon du dictionnaire faisceaux ↔ espaces étalés.
- Preuves tactiques réelles : chaque élément de la tige est extrait comme germe d'une section (`exists_germ_eq` : les flèches `germ` atteignent conjointement la colimite), puis identifié au germe de l'identité par restriction (`germ_res_apply` + `yoneda_obj_map`). Aucun re-export, aucun pont ad hoc.

## Anti-régression (§B)

- `sorry` : `count_code_sorry.py --json` — **0 avant / 0 après** (nouveaux fichiers uniquement, aucune preuve existante touchée ; sortie dans les checks).
- `lake build Grothendieck.Stalks Grothendieck.Stalks_en` : **SUCCESS** (commit local prouvable, log dans la review).
- Proof integrity : à lire au passage de la CI (job câblé sur ce lake).
- i18n : `check_i18n_siblings.py` — paire FR/EN byte-identique hors docstrings/commentaires.

See #2159
