### PR TITLE
fix(readme,#14058): residu post-renum Lab18 -> Lab12e (lien mort DataScienceWithAgents)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -246,7 +246,7 @@ Track avancé intégrant les frameworks Google ADK (DS-STAR, MLE-STAR) avec supp
 | 12b | [Sequential-Orchestration](Track2-GoogleADK/Day5-DS-Star/Lab12b-Sequential-Orchestration.ipynb) | Contrat C4 : désignation séquentielle, l'orchestrateur explicite au-dessus d'ADK |
 | 12c | [Agent-Handoff](Track2-GoogleADK/Day5-DS-Star/Lab12c-Agent-Handoff.ipynb) | Contrat C5 : handoff inter-agents natif câblé et observable |
 | 12d | [Token-Usage](Track2-GoogleADK/Day5-DS-Star/Lab12d-Token-Usage.ipynb) | Contrat C6 : traçabilité de la consommation LLM |
-| 18 | [Session-Persistence](Track2-GoogleADK/Day5-DS-Star/Lab18-Session-Persistence.ipynb) | Persistance d'état de session : une conversation qui se souvient |
+| 12e | [Session-Persistence](Track2-GoogleADK/Day5-DS-Star/Lab12e-Session-Persistence.ipynb) | Persistance d'état de session : une conversation qui se souvient |
 
 ### Day 6 - MLE-STAR (Labs 13-15)
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: MED/notebook-python #14869

## Summary

Résidu post-renum du commit `8c70dd66d5` (#14869, renum Lab18 → Lab12e de la consolidation zone agentique #14058) : la ligne du README `DataScienceWithAgents` est restée sur l'ancien chemin `Lab18-Session-Persistence.ipynb`, qui n'existe plus sur `main`.

- `check_docs_links.py --check` rend **1 broken link sur `main`** (reproduit firsthand sur checkout frais : `README.md:249 -> Track2-GoogleADK/Day5-DS-Star/Lab18-Session-Persistence.ipynb`), ce qui fait rougir `check-links` sur toute PR qui merge `main` depuis (constaté sur #14854 au push du re-baseline twin-parity).
- Correction : 1 ligne — numéro de lab `18` → `12e` (la ligne suit déjà 12d dans la série agentique) + chemin vers `Lab12e-Session-Persistence.ipynb`.
- Vérification post-fix : `check_docs_links.py --check` → **OK, 0 broken link (5559 total)**.
- Le catalogue généré (`COURSE_CATALOG.generated.json`, 1 occurrence restante) n'est pas touché : il appartient à l'automatisation (catalog-pr-hygiene HARD 1), rattrapé par le cron quotidien.

Anti-régression §E (audit fichier-entier) : la table Day 5 (lignes 245-249) relue en entier — la série 12/12b/12c/12d/12e est désormais continue et chaque cible existe sur le disque.

See #14058
