### PR TITLE
fix(smartcontracts,#14839): SC-13 contrat Stack compilable -- pop() lit la valeur avant de depiler

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.026366,
-     "end_time": "2026-06-03T09:31:34.519003+00:00",
+     "duration": 0.003111,
+     "end_time": "2026-09-06T16:57:40.870581",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.492637+00:00",
+     "start_time": "2026-09-06T16:57:40.867470",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.009873,
-     "end_time": "2026-06-03T09:31:34.548518+00:00",
+     "duration": 0.002435,
+     "end_time": "2026-09-06T16:57:40.875657",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.538645+00:00",
+     "start_time": "2026-09-06T16:57:40.873222",
      "status": "completed"
     },
     "tags": []
@@ -63,16 +63,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.561335Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.561105Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.570378Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.568775Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.881742Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.881396Z",
+     "iopub.status.idle": "2026-09-06T16:57:40.887378Z",
+     "shell.execute_reply": "2026-09-06T16:57:40.886836Z"
     },
     "papermill": {
-     "duration": 0.01647,
-     "end_time": "2026-06-03T09:31:34.571573+00:00",
+     "duration": 0.00992,
+     "end_time": "2026-09-06T16:57:40.888149",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.555103+00:00",
+     "start_time": "2026-09-06T16:57:40.878229",
      "status": "completed"
     },
     "tags": []
@@ -134,10 +134,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.003644,
-     "end_time": "2026-06-03T09:31:34.580214+00:00",
+     "duration": 0.002663,
+     "end_time": "2026-09-06T16:57:40.893351",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.576570+00:00",
+     "start_time": "2026-09-06T16:57:40.890688",
      "status": "completed"
     },
     "tags": []
@@ -154,26 +154,27 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.586340Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.586169Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.589795Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.589340Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.899483Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.899276Z",
+     "iopub.status.idle": "2026-09-06T16:57:40.903144Z",
+     "shell.execute_reply": "2026-09-06T16:57:40.902627Z"
     },
     "papermill": {
-     "duration": 0.00742,
-     "end_time": "2026-06-03T09:31:34.590386+00:00",
+     "duration": 0.008118,
+     "end_time": "2026-09-06T16:57:40.903971",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.582966+00:00",
+     "start_time": "2026-09-06T16:57:40.895853",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Contrat SafeMath:\n",
+      "\n",
       "// SPDX-License-Identifier: MIT\n",
       "pragma solidity ^0.8.28;\n",
       "\n",
@@ -201,9 +202,11 @@
       "    }\n",
       "}\n",
       "\n",
+      "\n",
       "==================================================\n",
       "\n",
       "Test Fuzz:\n",
+      "\n",
       "// SPDX-License-Identifier: MIT\n",
       "pragma solidity ^0.8.28;\n",
       "\n",
@@ -253,7 +256,8 @@
       "    function testFuzz_SafeAdd_Bounds(uint128 a, uint128 b) public {\n",
       "        assertEq(sm.safeAdd(uint256(a), uint256(b)), uint256(a) + uint256(b));\n",
       "    }\n",
-      "}\n"
+      "}\n",
+      "\n"
      ]
     }
    ],
@@ -345,8 +349,7 @@
     "print(FUZZ_BASIC)\n",
     "print(\"\\n\" + \"=\"*50 + \"\\n\")\n",
     "print(\"Test Fuzz:\")\n",
-    "print(FUZZ_TEST_BASIC)\n",
-    ""
+    "print(FUZZ_TEST_BASIC)\n"
    ]
   },
   {
@@ -354,10 +357,10 @@
    "id": "0e47c508",
    "metadata": {
     "papermill": {
-     "duration": 0.002138,
-     "end_time": "2026-06-03T09:31:34.594649+00:00",
+     "duration": 0.002508,
+     "end_time": "2026-09-06T16:57:40.908921",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.592511+00:00",
+     "start_time": "2026-09-06T16:57:40.906413",
      "status": "completed"
     },
     "tags": []
@@ -393,10 +396,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.002013,
-     "end_time": "2026-06-03T09:31:34.598692+00:00",
+     "duration": 0.002567,
+     "end_time": "2026-09-06T16:57:40.914236",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.596679+00:00",
+     "start_time": "2026-09-06T16:57:40.911669",
      "status": "completed"
     },
     "tags": []
@@ -415,16 +418,16 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.603808Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.603635Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.607158Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.606540Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.920875Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.920661Z",
+     "iopub.status.idle": "2026-09-06T16:57:40.924055Z",
+     "shell.execute_reply": "2026-09-06T16:57:40.923580Z"
     },
     "papermill": {
-     "duration": 0.006934,
-     "end_time": "2026-06-03T09:31:34.607622+00:00",
+     "duration": 0.007622,
+     "end_time": "2026-09-06T16:57:40.924767",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.600688+00:00",
+     "start_time": "2026-09-06T16:57:40.917145",
      "status": "completed"
     },
     "tags": []
@@ -450,7 +453,7 @@
       "    function setUp() public {\n",
       "        token = new SimpleToken(1_000_000 * 10**18);\n",
       "        initialSupply = token.totalSupply();  // capture UNE fois, pas a chaque invariant\n",
-      "        \n",
+      "\n",
       "        // Creer des utilisateurs\n",
       "        for (uint i = 0; i < 5; i++) {\n",
       "            users.push(address(uint160(i + 1)));\n",
@@ -536,10 +539,10 @@
    "id": "04d191ae",
    "metadata": {
     "papermill": {
-     "duration": 0.002121,
-     "end_time": "2026-06-03T09:31:34.612170+00:00",
+     "duration": 0.005108,
+     "end_time": "2026-09-06T16:57:40.932406",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.610049+00:00",
+     "start_time": "2026-09-06T16:57:40.927298",
      "status": "completed"
     },
     "tags": []
@@ -571,10 +574,10 @@
    "id": "3f5443cd",
    "metadata": {
     "papermill": {
-     "duration": 0.001919,
-     "end_time": "2026-06-03T09:31:34.616093+00:00",
+     "duration": 0.002635,
+     "end_time": "2026-09-06T16:57:40.937787",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.614174+00:00",
+     "start_time": "2026-09-06T16:57:40.935152",
      "status": "completed"
     },
     "tags": []
@@ -601,16 +604,16 @@
    "id": "d51c891e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.621380Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.621215Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.624518Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.623887Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.943986Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.943765Z",
+     "iopub.status.idle": "2026-09-06T16:57:40.947385Z",
+     "shell.execute_reply": "2026-09-06T16:57:40.946935Z"
     },
     "papermill": {
-     "duration": 0.006763,
-     "end_time": "2026-06-03T09:31:34.624968+00:00",
+     "duration": 0.007701,
+     "end_time": "2026-09-06T16:57:40.948090",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.618205+00:00",
+     "start_time": "2026-09-06T16:57:40.940389",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +680,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.001967,
-     "end_time": "2026-06-03T09:31:34.629168+00:00",
+     "duration": 0.002697,
+     "end_time": "2026-09-06T16:57:40.953371",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.627201+00:00",
+     "start_time": "2026-09-06T16:57:40.950674",
      "status": "completed"
     },
     "tags": []
@@ -702,16 +705,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.634247Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.634080Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.637386Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.636777Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.959532Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.959234Z",
+     "iopub.status.idle": "2026-09-06T16:57:40.963041Z",
+     "shell.execute_reply": "2026-09-06T16:57:40.962317Z"
     },
     "papermill": {
-     "duration": 0.006704,
-     "end_time": "2026-06-03T09:31:34.637867+00:00",
+     "duration": 0.008097,
+     "end_time": "2026-09-06T16:57:40.964028",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.631163+00:00",
+     "start_time": "2026-09-06T16:57:40.955931",
      "status": "completed"
     },
     "tags": []
@@ -805,10 +808,10 @@
    "id": "7bb68bfd",
    "metadata": {
     "papermill": {
-     "duration": 0.002093,
-     "end_time": "2026-06-03T09:31:34.642456+00:00",
+     "duration": 0.002691,
+     "end_time": "2026-09-06T16:57:40.969601",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.640363+00:00",
+     "start_time": "2026-09-06T16:57:40.966910",
      "status": "completed"
     },
     "tags": []
@@ -839,10 +842,10 @@
    "id": "a9f4e96f",
    "metadata": {
     "papermill": {
-     "duration": 0.002006,
-     "end_time": "2026-06-03T09:31:34.646502+00:00",
+     "duration": 0.002804,
+     "end_time": "2026-09-06T16:57:40.974914",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.644496+00:00",
+     "start_time": "2026-09-06T16:57:40.972110",
      "status": "completed"
     },
     "tags": []
@@ -870,16 +873,16 @@
    "id": "25064242",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.651535Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.651369Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.656081Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.655391Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.981554Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.981269Z",
+     "iopub.status.idle": "2026-09-06T16:57:40.985859Z",
+     "shell.execute_reply": "2026-09-06T16:57:40.985266Z"
     },
     "papermill": {
-     "duration": 0.0081,
-     "end_time": "2026-06-03T09:31:34.656596+00:00",
+     "duration": 0.009048,
+     "end_time": "2026-09-06T16:57:40.986724",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.648496+00:00",
+     "start_time": "2026-09-06T16:57:40.977676",
      "status": "completed"
     },
     "tags": []
@@ -951,10 +954,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.002552,
-     "end_time": "2026-06-03T09:31:34.661631+00:00",
+     "duration": 0.002748,
+     "end_time": "2026-09-06T16:57:40.992216",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.659079+00:00",
+     "start_time": "2026-09-06T16:57:40.989468",
      "status": "completed"
     },
     "tags": []
@@ -973,16 +976,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.667979Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.667670Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.671819Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.671107Z"
+     "iopub.execute_input": "2026-09-06T16:57:40.999136Z",
+     "iopub.status.busy": "2026-09-06T16:57:40.998773Z",
+     "iopub.status.idle": "2026-09-06T16:57:41.002210Z",
+     "shell.execute_reply": "2026-09-06T16:57:41.001778Z"
     },
     "papermill": {
-     "duration": 0.00817,
-     "end_time": "2026-06-03T09:31:34.672377+00:00",
+     "duration": 0.007827,
+     "end_time": "2026-09-06T16:57:41.002907",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.664207+00:00",
+     "start_time": "2026-09-06T16:57:40.995080",
      "status": "completed"
     },
     "tags": []
@@ -1067,10 +1070,10 @@
    "id": "6b11f2d1",
    "metadata": {
     "papermill": {
-     "duration": 0.001996,
-     "end_time": "2026-06-03T09:31:34.739490+00:00",
+     "duration": 0.002942,
+     "end_time": "2026-09-06T16:57:41.008744",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.737494+00:00",
+     "start_time": "2026-09-06T16:57:41.005802",
      "status": "completed"
     },
     "tags": []
@@ -1102,10 +1105,10 @@
    "id": "0e5f4e57",
    "metadata": {
     "papermill": {
-     "duration": 0.002398,
-     "end_time": "2026-06-03T09:31:34.683341+00:00",
+     "duration": 0.00274,
+     "end_time": "2026-09-06T16:57:41.014594",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.680943+00:00",
+     "start_time": "2026-09-06T16:57:41.011854",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1139,10 @@
    "id": "4350ffac",
    "metadata": {
     "papermill": {
-     "duration": 0.002292,
-     "end_time": "2026-06-03T09:31:34.687992+00:00",
+     "duration": 0.002932,
+     "end_time": "2026-09-06T16:57:41.020488",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.685700+00:00",
+     "start_time": "2026-09-06T16:57:41.017556",
      "status": "completed"
     },
     "tags": []
@@ -1167,10 +1170,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.002322,
-     "end_time": "2026-06-03T09:31:34.692649+00:00",
+     "duration": 0.003094,
+     "end_time": "2026-09-06T16:57:41.026658",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.690327+00:00",
+     "start_time": "2026-09-06T16:57:41.023564",
      "status": "completed"
     },
     "tags": []
@@ -1189,16 +1192,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.700303Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.700113Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.703528Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.702967Z"
+     "iopub.execute_input": "2026-09-06T16:57:41.035516Z",
+     "iopub.status.busy": "2026-09-06T16:57:41.035296Z",
+     "iopub.status.idle": "2026-09-06T16:57:41.038703Z",
+     "shell.execute_reply": "2026-09-06T16:57:41.038249Z"
     },
     "papermill": {
-     "duration": 0.007263,
-     "end_time": "2026-06-03T09:31:34.704076+00:00",
+     "duration": 0.009576,
+     "end_time": "2026-09-06T16:57:41.039802",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.696813+00:00",
+     "start_time": "2026-09-06T16:57:41.030226",
      "status": "completed"
     },
     "tags": []
@@ -1228,7 +1231,9 @@
     "    \n",
     "    function pop() public returns (uint256) {\n",
     "        require(items.length > 0, \"Empty stack\");\n",
-    "        return items.pop();\n",
+    "        uint256 value = items[items.length - 1];\n",
+    "        items.pop();\n",
+    "        return value;\n",
     "    }\n",
     "    \n",
     "    function peek() public view returns (uint256) {\n",
@@ -1284,10 +1289,10 @@
    "id": "7b3cbeb5",
    "metadata": {
     "papermill": {
-     "duration": 0.002295,
-     "end_time": "2026-06-03T09:31:34.708644+00:00",
+     "duration": 0.002748,
+     "end_time": "2026-09-06T16:57:41.046026",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.706349+00:00",
+     "start_time": "2026-09-06T16:57:41.043278",
      "status": "completed"
     },
     "tags": []
@@ -1314,10 +1319,10 @@
    "id": "2d3734f9",
    "metadata": {
     "papermill": {
-     "duration": 0.002185,
-     "end_time": "2026-06-03T09:31:34.713009+00:00",
+     "duration": 0.003094,
+     "end_time": "2026-09-06T16:57:41.053049",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.710824+00:00",
+     "start_time": "2026-09-06T16:57:41.049955",
      "status": "completed"
     },
     "tags": []
@@ -1334,16 +1339,16 @@
    "id": "58201809",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T09:31:34.718584Z",
-     "iopub.status.busy": "2026-06-03T09:31:34.718352Z",
-     "iopub.status.idle": "2026-06-03T09:31:34.722143Z",
-     "shell.execute_reply": "2026-06-03T09:31:34.721622Z"
+     "iopub.execute_input": "2026-09-06T16:57:41.061846Z",
+     "iopub.status.busy": "2026-09-06T16:57:41.061632Z",
+     "iopub.status.idle": "2026-09-06T16:57:41.065300Z",
+     "shell.execute_reply": "2026-09-06T16:57:41.064765Z"
     },
     "papermill": {
-     "duration": 0.007456,
-     "end_time": "2026-06-03T09:31:34.722713+00:00",
+     "duration": 0.009881,
+     "end_time": "2026-09-06T16:57:41.066407",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.715257+00:00",
+     "start_time": "2026-09-06T16:57:41.056526",
      "status": "completed"
     },
     "tags": []
@@ -1420,10 +1425,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.002219,
-     "end_time": "2026-06-03T09:31:34.727351+00:00",
+     "duration": 0.002706,
+     "end_time": "2026-09-06T16:57:41.071919",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.725132+00:00",
+     "start_time": "2026-09-06T16:57:41.069213",
      "status": "completed"
     },
     "tags": []
@@ -1454,7 +1459,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-sc13-fuzzdemo-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002778,
+     "end_time": "2026-09-06T16:57:41.077291",
+     "exception": false,
+     "start_time": "2026-09-06T16:57:41.074513",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Demonstration reelle : forge trouve un contre-exemple par fuzzing\n",
     "\n",
@@ -1470,24 +1484,40 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-sc13-fuzzdemo-code",
    "execution_count": 10,
-   "metadata": {},
+   "id": "cell-sc13-fuzzdemo-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T16:57:41.083928Z",
+     "iopub.status.busy": "2026-09-06T16:57:41.083632Z",
+     "iopub.status.idle": "2026-09-06T16:57:42.640189Z",
+     "shell.execute_reply": "2026-09-06T16:57:42.639167Z"
+    },
+    "papermill": {
+     "duration": 1.561088,
+     "end_time": "2026-09-06T16:57:42.641186",
+     "exception": false,
+     "start_time": "2026-09-06T16:57:41.080098",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Ran 3 tests for test/Average.t.sol:AverageTest\n",
-      "[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa32657ac17e5343275785eb49f75102b683287e59bb22f65e6a5cf3ef3659367c14ed3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc args=[10808163746427798858815147971665063963230100358334369314465970687383935308799 [1.08e76], 115792089237316195423570985008687907853269984665640564039457584007913129639932 [1.157e77]]] testFuzz_naive_inRange(uint256,uint256) (runs: 4, μ: 1255, ~: 1238)\n",
-      "[PASS] testFuzz_safe_inRange(uint256,uint256) (runs: 512, μ: 1275, ~: 1251)\n",
+      "[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa32657acfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd args=[115792089237316195423570985008687907853269984665640564039457584007913129639933 [1.157e77], 115792089237316195423570985008687907853269984665640564039457584007913129639933 [1.157e77]]] testFuzz_naive_inRange(uint256,uint256) (runs: 15, μ: 1248, ~: 1238)\n",
+      "[PASS] testFuzz_safe_inRange(uint256,uint256) (runs: 512, μ: 1273, ~: 1251)\n",
       "[PASS] test_avg_small() (gas: 633)\n",
-      "Suite result: FAILED. 2 passed; 1 failed; 0 skipped; finished in 5.64ms (7.47ms CPU time)\n",
-      "Ran 1 test suite in 7.40ms (5.64ms CPU time): 2 tests passed, 1 failed, 0 skipped (3 total tests)\n",
+      "Suite result: FAILED. 2 passed; 1 failed; 0 skipped; finished in 8.24ms (13.73ms CPU time)\n",
+      "Ran 1 test suite in 9.01ms (8.24ms CPU time): 2 tests passed, 1 failed, 0 skipped (3 total tests)\n",
       "Failing tests:\n",
       "Encountered 1 failing test in test/Average.t.sol:AverageTest\n",
-      "[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa32657ac17e5343275785eb49f75102b683287e59bb22f65e6a5cf3ef3659367c14ed3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc args=[10808163746427798858815147971665063963230100358334369314465970687383935308799 [1.08e76], 115792089237316195423570985008687907853269984665640564039457584007913129639932 [1.157e77]]] testFuzz_naive_inRange(uint256,uint256) (runs: 4, μ: 1255, ~: 1238)\n",
-      "Encountered a total of 1 failing tests, 2 tests succeeded\n"
+      "[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa32657acfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd args=[115792089237316195423570985008687907853269984665640564039457584007913129639933 [1.157e77], 115792089237316195423570985008687907853269984665640564039457584007913129639933 [1.157e77]]] testFuzz_naive_inRange(uint256,uint256) (runs: 15, μ: 1248, ~: 1238)\n",
+      "Encountered a total of 1 failing tests, 2 tests succeeded\n",
+      "Fuzz seed: 0x53432d3133 (use `--fuzz-seed` to reproduce)\n"
      ]
     }
    ],
@@ -1585,7 +1615,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-sc13-fuzzdemo-interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002679,
+     "end_time": "2026-09-06T16:57:42.646846",
+     "exception": false,
+     "start_time": "2026-09-06T16:57:42.644167",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : ce que le fuzzer a trouve\n",
     "\n",
@@ -1603,10 +1642,10 @@
    "id": "71eb986a",
    "metadata": {
     "papermill": {
-     "duration": 0.001994,
-     "end_time": "2026-06-03T09:31:34.731523+00:00",
+     "duration": 0.002636,
+     "end_time": "2026-09-06T16:57:42.652123",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.729529+00:00",
+     "start_time": "2026-09-06T16:57:42.649487",
      "status": "completed"
     },
     "tags": []
@@ -1626,10 +1665,10 @@
    "id": "edcb0a4d",
    "metadata": {
     "papermill": {
-     "duration": 0.001974,
-     "end_time": "2026-06-03T09:31:34.735502+00:00",
+     "duration": 0.002945,
+     "end_time": "2026-09-06T16:57:42.657886",
      "exception": false,
-     "start_time": "2026-06-03T09:31:34.733528+00:00",
+     "start_time": "2026-09-06T16:57:42.654941",
      "status": "completed"
     },
     "tags": []
@@ -1657,18 +1696,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.459422,
-   "end_time": "2026-06-03T09:31:38.309644+00:00",
+   "duration": 3.764182,
+   "end_time": "2026-09-06T16:57:42.895552",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb",
+   "input_path": "s.ipynb",
+   "output_path": "s.ipynb",
    "parameters": {},
-   "start_time": "2026-06-03T09:31:32.850222+00:00",
+   "start_time": "2026-09-06T16:57:39.131370",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

- SC-13 `cell-12` (chaine `EXERCISE_STACK`) : le contrat `Stack` declarait `pop() ... returns (uint256)` mais rendait `return items.pop()` — `array.pop()` en Solidity ne retourne rien => erreur de compilation solc avant meme d'aborder l'invariant, sujet de la cellule.
- Correctif : capturer `items[items.length - 1]` dans une locale, depiler, rendre la locale. Message `"Empty stack"` conserve. La cellule est un **Exemple guide** (solution etudiante TP 2026) — pas de stubbing ; la prose d'analyse qui suit decrivait deja le comportement corrigé, aucune prose a changer.

## Verifications (criteres de cloture #14839)

1. **solc 0.8.28 compile la chaine et EMET un binaire** (string extrait du notebook corrige, compile direct `~/.solcx/solc-v0.8.28`) :
   `======= Stack.sol:Stack ======= Binary: 6080604052348015600e575f5ffd5b506104028061001c5f395ff3fe...` (rc=0)
2. **forge test sur le contrat corrige** (projet temporaire foundry, forge-std du scaffold, `--fuzz-runs 256 --fuzz-seed 0x53432d3133`) :
   `[PASS] testFuzz_PushPop(uint256) (runs: 256)` / `[PASS] testFuzz_LIFO(uint256[]) (runs: 256)` — `Suite result: ok. 2 passed; 0 failed`.
3. **Controle negatif** : l'ancien pattern isole sous le meme solc => `Error: Different number of arguments in return statement than in returns declaration.` (rc=1) — la verification mord.
4. **Papermill end-to-end** : 32/32 cellules, `execution_count` non-null partout (cell-12 exec=8), 0 erreur, grep `raise NotImplementedError|assert False|1/0` = 0. La cellule demo `forge` montre un VRAI run forge (contre-exemple overflow sur `AverageNaive` = echec pedagogique intentionnel ; `AverageSafe` PASS 512 runs).

Verdict execution : **EXEC_PROVED**.

## Scope

- 1 fichier (`SC-13-Fuzz-Invariants.ipynb`). Pattern `return items.pop()` greppe : 1 occurrence repo-wide (celle-ci, SmartContracts).
- Worktree frais depuis `origin/main` (36c2c130f9) ; catalogue byte-identique a main ; metadata papermill normalisee au basename (cas tolere).
- Observation hors scope : le fallback `find_forge()` de la cellule demo teste `~/.foundry/bin/forge` sans `.exe` — inoperant sous Windows (os.path.exists n'appende pas PATHEXT) ; fonctionne des que forge est sur le PATH. Signale sans toucher (scope discipline).

Closes #14839

Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #14759