### PR TITLE
ci(lean,#14904): cabler proof-integrity (lean-axiom.yml) sur percolation_lean

### DIFF
--- a/.github/workflows/lean-percolation.yml
+++ b/.github/workflows/lean-percolation.yml
@@ -1,0 +1,73 @@
+name: Lean CI (percolation_lean)
+
+# CI for percolation_lean (MyIA.AI.Notebooks/Probas/Applications/Percolation).
+# Finite percolation kernel: connectivity/increasing events (Harris-Kleitman
+# finite FKG), isoperimetric profile. 0 sorry (raw=0, verified), fully proven.
+# Wired per ai-01 dispatch / #14904: B.3 "non applicable" was an absence of
+# measurement, not a green -- this file closes the gap. Template: lean-sensitivity.yml
+# (small lake, sorry-filter-mode: real).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/lean-toolchain'
+      # The gate's own implementation: a change to it must re-run the gate
+      # (same rationale as lean-galois.yml / lean-conway.yml, cf #8951).
+      - '.github/workflows/lean-percolation.yml'
+      - '.github/workflows/lean-axiom.yml'
+      # The axiom step is a Python program (`from lean_server import LeanVerifier`);
+      # lean_server.py + lean_utils.py ARE gate inputs (cf #8722).
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/**.lean'
+      - 'MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean/lean-toolchain'
+      # The gate must run on the PR that introduces or changes it (cf #8712).
+      - '.github/workflows/lean-percolation.yml'
+      - '.github/workflows/lean-axiom.yml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lean-percolation-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean
+      display-name: percolation_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: real
+
+  # Level 3 proof-integrity gate (criterion B.3 of pr-review-discipline).
+  # Wired per ai-01 dispatch / #14904: the lake had NO dedicated workflow, so
+  # B.3 read "non applicable" -- which is the absence of a measurement, not a
+  # green. The `#print axioms` footprint measured on the percolation lake
+  # (#14897 / #14907 bodies: [propext, Classical.choice, Quot.sound]) is a
+  # subset of the reusable-workflow defaults, so allow-axioms stays "". A NEW
+  # axiom (native_decide, sorryAx) = a red, which is exactly the point.
+  # fail-on-sorry: true -- sorry-baseline is 0, the lake is fully proven.
+  # target-modules: "*" (issue #10889) -- the module list is derived at runtime
+  # from the lake walk, so it cannot drift out of view. The `_en` i18n siblings
+  # are EXCLUDED by default (FR-only measurement; the byte-parity of the i18n
+  # pair is covered structurally by `lean-i18n-drift.yml`, #10007).
+  proof-integrity:
+    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean
+      display-name: percolation_lean
+      target-modules: "*"
+      allow-axioms: ""
+      fail-on-sorry: true

--- a/docs/reference/lean-axiom-coverage.md
+++ b/docs/reference/lean-axiom-coverage.md
@@ -57,6 +57,7 @@ Tous les verdicts de la table ci-dessous sont **GREEN-par-grep** / **RED-par-gre
 | `MyIA.AI.Notebooks/GameTheory/game_theory_lean` | 25 | 0 | 0 | 0 | 0 | GREEN |
 | `MyIA.AI.Notebooks/GameTheory/conway_cgt_lean` | 2 | 0 | 0 | 0 | 0 | GREEN |
 | `MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean` | 6 | 0 | 0 | 0 | 0 | **GREEN mesuré** (hors périmètre de la mesure initiale du 2026-07-29 — lake ajouté après coup ; mesuré firsthand 2026-08-26 au câblage CI #13139 : `real sorry` = 0 sur les 6 modules non-`_en`, clôture `#print axioms` = `propext`+`Quot.sound` sur les 51 déclarations) |
+| `MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean` | 6 | 0 | 0 | 0 | 0 | **GREEN** (mesuré 2026-09-06 au câblage CI #14904 : `distinct_code_sorry = 0` sur 13 fichiers, 0 `native_decide`, clôture `#print axioms` = `[propext, Classical.choice, Quot.sound]` — cf. #14896/#14897/#14907) |
 
 ## 3. Lecture par verdict
 
@@ -201,6 +202,7 @@ forbidden union : []
 | `grothendieck_lean` | `lean-grothendieck.yml` | OUI (post-#8941) | GREEN avec `Classical.choice` whitelisté explicitement (théorie intrinsèquement non-constructive, §3.5) |
 | `sensitivity_lean` | `lean-sensitivity.yml` | OUI (c.101) | GREEN (0 `native_decide`, `Classical.choice` whitelist par défaut) |
 | `asymmetric_information_lean` | `lean-asymmetric-information.yml` | OUI (#13139, 2026-08-26) | **GREEN mesuré** (exécution locale du step exact du gate, 2026-08-26 : 51 déclarations sur 6 modules, clôture axiomatique = `propext` + `Quot.sound` seulement, 0 `sorryAx`, 0 `native_decide`, 0 `Classical.choice`) ; `target-modules: "*"` + `fail-on-sorry: true` cohérent avec baseline 0. **Premier lake du dépôt avec un `[[require]]` cross-lake par chemin** (`../lean_game_defs_ext`) : le caller déclenche aussi sur les sources de la dépendance — un gate aveugle à la moitié de ses entrées n'est pas un gate. `lake build` local WSL SUCCESS (28 jobs, toolchain v4.32.1) |
+| `percolation_lean` | `lean-percolation.yml` | OUI (#14904, 2026-09-06) | **GREEN mesuré** — `distinct_code_sorry = 0` (`count_code_sorry.py --json`, 13 fichiers), 0 `native_decide` / 0 `sorryAx` (grep FR + `#print axioms` des tranches #14896/#14897/#14907 = `[propext, Classical.choice, Quot.sound]`, sous-ensemble des défauts du workflow réutilisable). `target-modules: "*"` (dérivation runtime #10889, `_en` exclus par défaut) + `fail-on-sorry: true` cohérent avec baseline 0. **Contrôle positif HARD exécuté** : mutation `sorry` temporaire sur `probe/*` → `proof-integrity` ROUGE, retirée → vert sur la tête propre |
 | 15 autres lacs | workflows existants | **NON** | GREEN si câblés (sauf 3 borderline sur `Classical.choice` : `sudoku_lean`, `learning_theory_lean`, `decision_theory_lean`) |
 
 Le câblage du gate sur les lacs non-pilotes est un travail séparé qui sort du scope #8738 (chaque workflow lake est un livrable à part avec son `target-modules` adapté). Voir #11699 pour la roadmap tranche-par-tranche des 15 restants (mimo_lean = tranche 1 livrée par PR de cette PR).


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/genai #14593

## Quoi

Câble le gate `proof-integrity` (`lean-axiom.yml`) sur `percolation_lean`. Le lake n'avait **aucun** workflow dédié : B.3 de [pr-review-discipline](.claude/rules/pr-review-discipline.md) s'y lisait « non applicable », ce qui est **l'absence d'une mesure**, pas un vert. Cette PR ferme le trou.

## Scope (borné)

- `.github/workflows/lean-percolation.yml` — nouveau, gabarit `lean-sensitivity.yml` (petit lake, `sorry-filter-mode: real`)
- `docs/reference/lean-axiom-coverage.md` — tables triage (§2) et câblage (§4) : ajout percolation

**Aucune modification des preuves Lean.** Aucune touchée au catalogue.

## Paramètres mesurés (pas recopiés, 2026-09-06)

- `project-path: MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean`
- `display-name: percolation_lean`
- `sorry-baseline: "0"` — `count_code_sorry.py --json` rend `distinct_code_sorry: 0` sur **13** fichiers (0 naïf, 0 code)
- `sorry-filter-mode: real` — le lake est intégralement prouvé, la prose ne mentionne pas "sorry"
- `fail-on-sorry: true`
- `target-modules: "*"` — dérivation runtime (#10889), insensible à la dérive de la liste ; `_en` exclus par défaut (parité FR/EN couverte structuralement par `lean-i18n-drift.yml`, #10007)
- `allow-axioms: ""` — clôture mesurée `#print axioms` sur les tranches #14896/#14897/#14907 = `[propext, Classical.choice, Quot.sound]`, sous-ensemble des défauts du workflow réutilisable => **tout axiome nouveau (native_decide, sorryAx) doit rougir**

## Triggers `paths:` (acceptance 3)

`.lean` / `lakefile.lean` / `lean-toolchain` du lake + **le workflow lui-même** + `lean-axiom.yml` + les deux entrées Python du gate (`lean_server.py`, `lean_utils.py`) — cf #8712/#8722/#8951.

## Contrôle positif (acceptance 4)

- **ROUGE** — run 34047876576 (`workflow_dispatch` sur `probe/14904-red`, mutation `sorry` temporaire) : `ci` **failure** + `proof-integrity` **failure**. https://github.com/jsboige/CoursIA/actions/runs/34047876576
- **VERT** — run 34047841716 (`pull_request` PR #14917, tête propre) : `ci` **success** + `proof-integrity` **success**. https://github.com/jsboige/CoursIA/actions/runs/34047841716

La mutation `sorry` (commit `bd74b8f2b`, `theorem positive_control_probe : False := by sorry` ajouté à `Percolation/Basic.lean`) a été posée sur une branche **jetable** `probe/14904-red`, puis **supprimée** (locale + distante) une fois le rouge observé. Elle n'apparaît dans **aucun commit** du PR (`git log` de `feature/14904-lean-percolation` = 1 commit de câblage). Le **rouge** prouve que le gate mord (`sorryAx` + baseline dépassée) ; le **vert** sur la tête propre prouve que le câblage ne casse rien.

## Note, délibérément hors scope

Le **placement** du lake (`MyIA.AI.Notebooks/Probas/Applications/Percolation/` vs le `Probas/percolation_lean/` prescrit par #14871) est une divergence antérieure à #14896, nommée ici pour ne pas se perdre, traitée séparément (cf #14904 §Hors scope). Le cablage des autres lakes non couverts ne relève pas de cette PR.

See #14871. See #14896. See #14897. See #14907.
Closes #14904.
