### PR TITLE
refactor(probas,#14883): Infer-101 -> Infer-1b accretion in Infer corpus

### DIFF
--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -95,7 +95,7 @@ Commit UNIQUEMENT les notebooks dont la source a change (`git diff <nb> | grep -
 |--------|---------|----------|
 | **Structurel** | `2^225` combinaisons → speedup `~2.8e24x` ; nombre de contraintes ; complexité | **GARDER** — stable d'une machine à l'autre, c'est du contenu pédagogique réel |
 | **Machine-dépendant** | temps absolus (`~21 s`, `24-127 ms`) | **RETIRER** — renvoi à la cellule de mesure ; si le coût relatif porte le propos, l'écrire en **rapport** (cf ci-dessous) |
-| **Donnée en unité de temps (data-unit)** | moyenne de trajet `15.33 min` (Infer-101) ; durée de contenu `30 sec` ; estimation pédagogique `Durée : ~2 h` | **GARDER** — c'est une *donnée* déterministe (statistique, longueur de contenu, estimation humaine), pas un runtime ; ne dérive pas à la re-exécution |
+| **Donnée en unité de temps (data-unit)** | moyenne de trajet `15.33 min` (Infer-1b) ; durée de contenu `30 sec` ; estimation pédagogique `Durée : ~2 h` | **GARDER** — c'est une *donnée* déterministe (statistique, longueur de contenu, estimation humaine), pas un runtime ; ne dérive pas à la re-exécution |
 | **Env-dépendant (observé)** | table de versions `NumPy 2.4.2` écrite à la main | **RETIRER** quand une cellule imprime déjà la version (source unique = l'output) |
 | **Env-dépendant (exigé)** | `Python 3.10+`, `.NET 9.0` | **GARDER** — c'est une **décision de projet**, pas une observation ; ne dérive pas |
 | **Stochastique seedé** | fitness d'un GA à `seed=42` | **GARDER** — reproductible, donc stable |

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-1b-Premiers-Modeles.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-1b-Premiers-Modeles.ipynb
@@ -14,13 +14,13 @@
     "tags": []
    },
    "source": [
-    "# Infer-101 : Introduction a Infer.NET\n",
+    "# Infer-1b : Introduction a Infer.NET\n",
     "\n",
     "**Serie** : Programmation Probabiliste avec Infer.NET  \n",
     "**Duree estimee** : 2h30  \n",
     "**Prerequis** : C# et .NET Interactive, notions de probabilites, loi normale, inference bayesienne\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -31,15 +31,15 @@
     "- Implementer l'apprentissage en ligne par mise a jour des a priori\n",
     "- Comparer des modèles (simple vs melange) avec la preuve bayesienne (log evidence)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Navigation\n",
     "\n",
     "| Précédent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [Catalogue Probas](README.md) | [Infer-1 : Setup](Infer/Infer-1-Setup.ipynb) |\n",
+    "| [Catalogue Probas](README.md) | [Infer-1 : Setup](Infer-1-Setup.ipynb) |\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -57,8 +57,6 @@
    },
    "source": [
     "## Introduction à la programmation probabiliste avec Infer.Net\n",
-    "\n",
-    "## Introduction à la Programmation Probabiliste\n",
     "\n",
     "### Avant-propos\n",
     "\n",
@@ -6058,7 +6056,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Variables aléatoires et Inférence probabiliste\n",
     "\n",
@@ -6074,7 +6072,7 @@
     "2. Comment le modèle mixte capture-t-il les événements extraordinaires ?\n",
     "3. Que se passerait-il avec un mélange de 3 gaussiennes ?\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<< Retour au README](README.md)"
    ]
@@ -6168,13 +6166,13 @@
     "- La preuve logarithmique (log evidence) permet de comparer des modèles objectivement\n",
     "- Un log evidence plus eleve (moins negatif) indique un meilleur equilibre fit/complexite\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Navigation\n",
     "\n",
     "| Précédent | Suivant |\n",
     "|-----------|--------|\n",
-    "| [Catalogue Probas](README.md) | [Infer-1 : Setup](Infer/Infer-1-Setup.ipynb) |"
+    "| [Catalogue Probas](README.md) | [Infer-1 : Setup](Infer-1-Setup.ipynb) |"
    ]
   }
  ],
@@ -6197,8 +6195,8 @@
    "end_time": "2026-06-04T06:34:40.743697",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer-101.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer-101.ipynb",
+   "input_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-1b-Premiers-Modeles.ipynb",
+   "output_path": "MyIA.AI.Notebooks\\Probas\\Infer\\Infer-1b-Premiers-Modeles.ipynb",
    "parameters": {},
    "start_time": "2026-06-04T06:33:58.629954",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -13,7 +13,7 @@ maturity: BETA=67
 
 Le monde réel est incertain. Un diagnostic médical n'est jamais sûr à 100%, un classement sportif dépend de performances intrinsèquement variables, et les données que nous collectons sont toujours bruitées ou incomplètes. La programmation probabiliste offre un cadre rigoureux pour modéliser cette incertitude : plutôt que de calculer une seule réponse, on obtient une **distribution de probabilités** qui quantifie notre confiance dans chaque résultat possible.
 
-Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence par **message passing déterministe** (EP/VMP, plus un échantillonneur de Gibbs disponible), **PyMC** (Python) pour l'**échantillonnage stochastique MCMC** (NUTS), et des **applications standalone** (RSA, identification causale avec DoWhy). Elle totalise **67 notebooks** — **28 en C#/.NET Interactive**, **37 en Python**, **2 en Lean 4** (voir le marqueur `CATALOG-STATUS` ci-dessus pour le décompte autoritatif). Le versant Infer.NET se scinde en **19 notebooks bayésiens** ([`Infer/`](Infer/README.md)) — fondements (distributions, graphes de facteurs), modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM) et frontières (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture, analyse de survie) — plus **8 notebooks C# de l'arc décision** ([`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) : utilité espérée, EVPI, MDPs, bandits, jusqu'au Thompson Sampling DecInfer-10) et le standalone **Infer-101**. Le versant PyMC porte ces modèles en Python avec l'échantillonnage NUTS : **19 notebooks corpus** ([`PyMC/`](PyMC/README.md), en parité 1:1 avec Infer — fondations, modèles classiques, inférence causale, puis frontières : séquences, reco, processus gaussien épars, filtre de Kalman, change-point, survie) et **12 miroirs de l'arc décision** ([`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md), renumérotés 1-12, dont la **jambe actuarielle** 8-12). L'arc décision est en outre certifié par un lake compagnon **Lean 4** ([`decision_theory_lean`](decision_theory_lean/)) et ses **2 notebooks à kernel Lean** (DecInfer-02, utilité espérée vNM ; DecInfer-09, indice de Gittins) : les identités d'escompte y sont démontrées (`0 sorry`), le théorème d'optimalité restant énoncé — sa preuve complète attend une formalisation des MDP absente de Mathlib. Enfin, un **pont causal** ([`DecisionTheory/Causal-Bridges/`](DecisionTheory/Causal-Bridges/README.md), 4 notebooks Python via kernel `coursia-ml-training`) fédère les quatre traitements de la causalité disséminés dans le dépôt — Tweety (logique), Infer.NET, PyMC et l'émergence causale (PyPhi) — autour de l'échelle de Pearl et du do-calculus, exécutés sur l'outil de référence [`dowhy`](https://www.pywhy.org/dowhy/).
+Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence par **message passing déterministe** (EP/VMP, plus un échantillonneur de Gibbs disponible), **PyMC** (Python) pour l'**échantillonnage stochastique MCMC** (NUTS), et des **applications standalone** (RSA, identification causale avec DoWhy). Elle totalise **67 notebooks** — **28 en C#/.NET Interactive**, **37 en Python**, **2 en Lean 4** (voir le marqueur `CATALOG-STATUS` ci-dessus pour le décompte autoritatif). Le versant Infer.NET se scinde en **19 notebooks bayésiens** ([`Infer/`](Infer/README.md)) — fondements (distributions, graphes de facteurs), modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM) et frontières (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture, analyse de survie) — plus **8 notebooks C# de l'arc décision** ([`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) : utilité espérée, EVPI, MDPs, bandits, jusqu'au Thompson Sampling DecInfer-10) et l'accretion de premier modèle **Infer-1b** ([`Infer/`](Infer/README.md)). Le versant PyMC porte ces modèles en Python avec l'échantillonnage NUTS : **19 notebooks corpus** ([`PyMC/`](PyMC/README.md), en parité 1:1 avec Infer — fondations, modèles classiques, inférence causale, puis frontières : séquences, reco, processus gaussien épars, filtre de Kalman, change-point, survie) et **12 miroirs de l'arc décision** ([`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md), renumérotés 1-12, dont la **jambe actuarielle** 8-12). L'arc décision est en outre certifié par un lake compagnon **Lean 4** ([`decision_theory_lean`](decision_theory_lean/)) et ses **2 notebooks à kernel Lean** (DecInfer-02, utilité espérée vNM ; DecInfer-09, indice de Gittins) : les identités d'escompte y sont démontrées (`0 sorry`), le théorème d'optimalité restant énoncé — sa preuve complète attend une formalisation des MDP absente de Mathlib. Enfin, un **pont causal** ([`DecisionTheory/Causal-Bridges/`](DecisionTheory/Causal-Bridges/README.md), 4 notebooks Python via kernel `coursia-ml-training`) fédère les quatre traitements de la causalité disséminés dans le dépôt — Tweety (logique), Infer.NET, PyMC et l'émergence causale (PyPhi) — autour de l'échelle de Pearl et du do-calculus, exécutés sur l'outil de référence [`dowhy`](https://www.pywhy.org/dowhy/).
 
 ## Pourquoi cette série
 
@@ -155,7 +155,7 @@ Pour les étudiants en recherche opérationnelle ou finance :
 
 #### Parcours rapide Python (standalone, ~2h)
 
-Si vous préférez Python au C#, commencez par **PyMC-01-Setup** (introduction standalone en Python, premier modèle Two Coins) puis Pyro_RSA_Hyperbole.ipynb (application à la linguistique pragmatique avec le framework RSA). Infer-101.ipynb est également une introduction standalone, mais en **C#/.NET** (voir la table « Notebooks racine » ci-dessous).
+Si vous préférez Python au C#, commencez par **PyMC-01-Setup** (introduction standalone en Python, premier modèle Two Coins) puis Pyro_RSA_Hyperbole.ipynb (application à la linguistique pragmatique avec le framework RSA). En **C#/.NET**, l'introduction est `Infer-1b` (`Infer/Infer-1b-Premiers-Modeles.ipynb`), le premier modèle avec les fondations de [`Infer/`](Infer/README.md).
 
 #### Parcours PyMC complet (31 notebooks, ~21h)
 
@@ -171,7 +171,7 @@ flowchart TD
     START --> Q3{"Indécis ?<br/>Découverte rapide"}
     Q1 -->|"oui"| INFER["<b>Infer.NET</b><br/>API C# native · Roslyn ·<br/>factor graphs · message passing<br/>déterministe (EP/VMP/Gibbs)"]
     Q2 -->|"oui"| PYMC["<b>PyMC</b><br/>with pm.Model() · NUTS ·<br/>écosystème pandas/arviz"]
-    Q3 --> IN101["<b>Infer-101</b><br/>(standalone, 45 min)"]
+    Q3 --> IN101["<b>Infer-1b</b><br/>(premier modèle, 1h)"]
     INFER --> PIVOT1{"Modèle trop complexe<br/>ou pipeline Python ?"}
     PYMC --> PIVOT2{"Besoin de message passing<br/>déterministe (VMP/EP) ou .NET ?"}
     PIVOT1 -->|"oui"| PYMC
@@ -202,9 +202,9 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 
 | Critère | Recommandation |
 |---------|---------------|
-| Juste découvrir la programmation probabiliste | **Infer-101.ipynb** (standalone, 45 min) |
+| Juste découvrir la programmation probabiliste | **Infer-1b** (`Infer/Infer-1b-Premiers-Modeles.ipynb`) |
 | Comprendre les graphes de facteurs | **Infer-3** (Monty Hall, Murder Mystery) |
-| Un premier modèle qui marche | **Infer-101** ou **PyMC-01-Setup** |
+| Un premier modèle qui marche | **Infer-1b** ou **PyMC-01-Setup** |
 | Application concrète rapide | **Infer-8 TrueSkill** ou **Infer-11 LDA** |
 | Comparer les deux approches | Suivre la table "inférence comparée" ci-dessus |
 | Production data science | **PyMC** (écosystème Python, NUTS, arviz) |
@@ -214,15 +214,15 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 
 ```
 Probas/
-├── Infer-101.ipynb              # Introduction C#/.NET (standalone)
 ├── Pyro_RSA_Hyperbole.ipynb     # Pragmatique linguistique (Python)
 ├── GeneratedSource/             # Sources Infer.NET compilées (Model0_EP.cs ... Model10_VMP.cs)
 ├── PyMC/                # Port PyMC : bayésien + causal (1-13, dont PyMC-5 causal) + séquences/reco/GP (14-16) + frontières (17-19)
 │   ├── PyMC-01-Setup.ipynb ... PyMC-19-Survival-Analysis.ipynb
 │   └── README.md                # Documentation détaillée de la série PyMC
 ├── decision_theory_lean/        # Projet Lake (racine série) : escompte géométrique + théorème de Gittins ; héberge les preuves VNM et Coherence/Dutch Book
-├── Infer/                       # Corpus bayésien Infer.NET (19 notebooks)
+├── Infer/                       # Corpus bayésien Infer.NET (19 notebooks + accretion Infer-1b)
 │   ├── Infer-1-Setup.ipynb ... Infer-19-Survival-Analysis.ipynb
+│   ├── Infer-1b-Premiers-Modeles.ipynb  # Accretion du premier modèle (ex-Infer-101)
 │   ├── README.md                # Documentation détaillée de la série bayésienne
 │   ├── Infer-Glossary.md        # Glossaire des termes Infer.NET
 │   ├── FactorGraphHelper.cs     # Helper visualisation graphes de facteurs
@@ -294,10 +294,10 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 
 | Notebook | Kernel | Contenu | Durée |
 |----------|--------|---------|-------|
-| [Infer-101](Infer-101.ipynb) | .NET (C#) | Introduction Infer.NET, Two Coins, Cyclist | 1h |
+| [Infer-1b](Infer/Infer-1b-Premiers-Modeles.ipynb) | .NET (C#) | Premier modèle Infer.NET, Two Coins, Cyclist | 1h |
 | [Pyro_RSA_Hyperbole](Pyro_RSA_Hyperbole.ipynb) | Python | Rational Speech Acts, hyperboles | 30 min |
 
-### Infer-101.ipynb
+### Infer-1b-Premiers-Modeles.ipynb
 
 Point d'entrée accessible pour la programmation probabiliste :
 - Concepts de base (variables aléatoires, modèles probabilistes)
@@ -409,7 +409,7 @@ Ce que le pont ajoute par rapport aux quatre notebooks pris isolément : la thé
 
 | Notebook | Kernel | Contenu | Durée |
 | -------- | ------- | ------- | ----- |
-| [Infer-101](Infer-101.ipynb) | .NET (C#) | Introduction Infer.NET, Two Coins, Cyclist | 1h |
+| [Infer-1b](Infer/Infer-1b-Premiers-Modeles.ipynb) | .NET (C#) | Premier modèle Infer.NET, Two Coins, Cyclist | 1h |
 | [Pyro_RSA_Hyperbole](Pyro_RSA_Hyperbole.ipynb) | Python 3 | Rational Speech Acts, hyperboles | 30 min |
 
 ## Prerequisites
@@ -556,7 +556,7 @@ La visualisation des factor graphs nécessite **Graphviz installé**. Si `dot` n
 
 ### Kernels : un par sous-série, jamais mélangés
 
-Chaque notebook de la série Probas utilise un **unique kernel** : `.NET (C#)` pour `Infer/` et `Infer-101`, `Python 3` pour `PyMC/` et `Pyro_RSA`. Aucun notebook ne mélange les deux kernels. (Historiquement, `Infer-101` avait été rédigé en mode polyglot .NET Interactive avec des cellules `#kernel` par langage ; ce n'est plus le cas — il est aujourd'hui un notebook C#/.NET autonome.)
+Chaque notebook de la série Probas utilise un **unique kernel** : `.NET (C#)` pour `Infer/` (dont `Infer-1b`), `Python 3` pour `PyMC/` et `Pyro_RSA`. Aucun notebook ne mélange les deux kernels. (Historiquement, `Infer-1b` avait été rédigé en mode polyglot .NET Interactive avec des cellules `#kernel` par langage ; ce n'est plus le cas — il est aujourd'hui un notebook C#/.NET.)
 
 ### PyMC : échantillonnage très lent ou divergence NUTS
 

--- a/MyIA.AI.Notebooks/Probas/index.qmd
+++ b/MyIA.AI.Notebooks/Probas/index.qmd
@@ -55,7 +55,6 @@ listing:
     page-size: 24
   - id: standalone-root
     contents:
-      - "Infer-101.ipynb"
       - "Pyro_RSA_Hyperbole.ipynb"
     type: grid
     sort: "filename"
@@ -74,12 +73,12 @@ La série Probas comporte **4 sous-séries principales + 1 racine standalone**, 
 
 | Sous-série | Notebooks | Stack | Focus |
 |------------|-----------|-------|-------|
-| **[Infer](Infer/README.md) (C#/.NET Interactive)** | 19 (+ Setup + _output.ipynb) | Infer.NET, EP/VMP | Corpus bayésien : fondations, modèles classiques (IRT, TrueSkill, LDA, HMM), frontières (causalité, GP, hiérarchiques, Kalman, change-point, survie) |
+| **[Infer](Infer/README.md) (C#/.NET Interactive)** | 19 (+ Setup + accretion Infer-1b + _output.ipynb) | Infer.NET, EP/VMP | Corpus bayésien : fondations, modèles classiques (IRT, TrueSkill, LDA, HMM), frontières (causalité, GP, hiérarchiques, Kalman, change-point, survie) |
 | **[PyMC](PyMC/README.md) (Python)** | 14 (+ Setup) | PyMC, NUTS | Mêmes modèles qu'Infer, en MCMC : NUTS, diagnostics (R-hat, ESS), posterior predictive checks |
 | **[DecisionTheory/Infer](DecisionTheory/DecInfer/README.md) (C#/.NET)** | 10 (Lean : 2, 9) | Infer.NET + Lean 4 | Utility espérée, EVPI, MDPs, bandits, **preuves formelles Lean** de vNM et Gittins (lake `decision_theory_lean/`) |
 | **[DecisionTheory/PyMC](DecisionTheory/PyMC/README.md) (Python)** | 7 | PyMC | Mêmes modèles de décision, en sampling |
 | **[DecisionTheory/Causal-Bridges](DecisionTheory/Causal-Bridges/)** | 1 | Python/Z3 | Do-Calculus, jumeaux causaux inter-domaines |
-| **Racine (standalone)** | 2 | Python | Infer-101 (intro complète Infer.NET), Pyro_RSA_Hyperbole (Pyro RSA) |
+| **Racine (standalone)** | 1 | Python | Pyro_RSA_Hyperbole (Pyro RSA) |
 
 **Kernels** : `dotnet-csharp` · `python3` · `lean4` (side tracks Lean via WSL, cf [`decision_theory_lean/install_wsl_kernel.md`](decision_theory_lean/README.md)) · **GPU** : non (Infer.NET/PyMC CPU-only) · **Prérequis** : algèbre linéaire, probabilités de base (variables aléatoires, Bayes), Python intermédiaire.
 
@@ -148,10 +147,11 @@ Notebook passerelle entre Probas, Search (CSP/SMT) et SymbolicAI : encode le Do-
 
 ## Racine — Notebooks standalone
 
-Deux notebooks applicatifs à la racine de la série, indépendants des deux arcs :
+Un notebook applicatif à la racine de la série, indépendant des deux arcs :
 
-- **Infer-101** : tutoriel Infer.NET "from scratch" (hors-numérotation 1-19).
 - **Pyro_RSA_Hyperbole** : Rational Speech Acts bayésien en Pyro (sémantique pragmatique).
+
+L'entrée Infer.NET du corpus bayésien est **Infer-1b** (accretion du premier modèle, ex-Infer-101), dans [`Infer/`](Infer/README.md).
 
 ::: {#standalone-root}
 :::
@@ -190,7 +190,7 @@ jupyter notebook MyIA.AI.Notebooks/Probas/PyMC/
 
 ## Note sur le rendu Quarto (.NET + Lean + Python)
 
-Cette page Quarto rend les **notebooks Python natifs** (PyMC + Causal-Bridges + Infer-101 + Pyro_RSA) ainsi que leurs **`*_output.ipynb`** committés (règle C.2). Les **notebooks .NET C#** (Infer/* principaux + DecisionTheory/DecInfer/*) et les **companions Lean 4** (`*-Lean-*`) ne sont **pas exécutés par Quarto** : leur rendu s'appuie sur les `*_output.ipynb` committés via le mode `freeze: auto` de `_quarto.yml`. Pour une exécution locale : kernel `dotnet-csharp` pour Infer.NET ; kernel Lean4 (WSL + elan) pour les companions. Ce point est la **matière de la tranche 4 #4211 (GH Actions deploy)** — un workflow dédié pourra automatiser exécution et publication, mais le **MVP actuel** se contente de freeze auto sans ré-exécution.
+Cette page Quarto rend les **notebooks Python natifs** (PyMC + Causal-Bridges + Pyro_RSA) ainsi que leurs **`*_output.ipynb`** committés (règle C.2). Les **notebooks .NET C#** (Infer/* principaux + DecisionTheory/DecInfer/*) et les **companions Lean 4** (`*-Lean-*`) ne sont **pas exécutés par Quarto** : leur rendu s'appuie sur les `*_output.ipynb` committés via le mode `freeze: auto` de `_quarto.yml`. Pour une exécution locale : kernel `dotnet-csharp` pour Infer.NET ; kernel Lean4 (WSL + elan) pour les companions. Ce point est la **matière de la tranche 4 #4211 (GH Actions deploy)** — un workflow dédié pourra automatiser exécution et publication, mais le **MVP actuel** se contente de freeze auto sans ré-exécution.
 
 ## Pour aller plus loin
 
@@ -215,7 +215,7 @@ pymc_advanced: 5 (10-14)
 dt_infer: 10 (Lean: 2, 9)
 dt_pymc: 7
 dt_causal_bridges: 1
-standalone_root: 2 (Infer-101 + Pyro_RSA)
+standalone_root: 1 (Pyro_RSA)
 listing_pattern: 4-sous-series + setup + standalone (sub-range-split pour corpus long)
 render_local: success
 -->

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
@@ -7452,7 +7452,7 @@
     "| Notebook | Ce qu'il apporte au pont |\n",
     "|----------|--------------------------|\n",
     "| [`Probas/Infer/Infer-14-Sequences`](../../Probas/Infer/Infer-14-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |\n",
-    "| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |\n",
+    "| [`Probas/Infer-1b`](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |\n",
     "| [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |\n",
     "| [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le même HMM gaussien, cote Python (hmmlearn) |\n",
     "\n",
@@ -7559,7 +7559,7 @@
     "| Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |\n",
     "| Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |\n",
     "| Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |\n",
-    "| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |\n",
+    "| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |\n",
     "| Automates & verification | Model checking | Serie SymbolicAI |\n"
    ]
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
@@ -2269,7 +2269,7 @@
     "| Notebook | Ce qu'il apporte au pont |\n",
     "|----------|--------------------------|\n",
     "| [`Probas/Infer/Infer-14-Sequences`](../../Probas/Infer/Infer-14-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |\n",
-    "| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |\n",
+    "| [`Probas/Infer-1b`](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |\n",
     "| [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |\n",
     "| [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le même HMM gaussien, cote Python (hmmlearn) |\n",
     "\n",
@@ -2380,7 +2380,7 @@
     "| Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |\n",
     "| Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |\n",
     "| Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |\n",
-    "| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |\n",
+    "| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |\n",
     "| Automates & verification | Model checking | Serie SymbolicAI |\n"
    ]
   },

--- a/docs/archive/01-cartographie-initiale.md
+++ b/docs/archive/01-cartographie-initiale.md
@@ -29,7 +29,7 @@ Voici une liste des principaux thèmes couverts, avec des liens vers les contenu
 
 ### 🔍 Autres thèmes
 - **Algorithmes de recherche :** Résolution de problèmes (Sudoku) et optimisation ([génétique](../../MyIA.AI.Notebooks/Search/GeneticSharp-EdgeDetection.ipynb)).
-- **Probabilités :** Introduction à l'inférence probabiliste ([Infer-101.ipynb](../../MyIA.AI.Notebooks/Probas/Infer-101.ipynb)).
+- **Probabilités :** Introduction à l'inférence probabiliste ([Infer-1b-Premiers-Modeles.ipynb](../../MyIA.AI.Notebooks/Probas/Infer/Infer-1b-Premiers-Modeles.ipynb)).
 
 ## 3. Évaluation et analyse
 

--- a/docs/curriculum/recherche.md
+++ b/docs/curriculum/recherche.md
@@ -204,7 +204,7 @@ Inférence probabiliste (Infer.NET, Pyro, PyMC), théorie de l'information inté
 
 | # | Notebook | Maturité | Exécutable |
 |---|----------|----------|------------|
-| 1 | Infer-101 : Introduction a Infer.NET | BETA | Oui |
+| 1 | Infer-1b : Introduction a Infer.NET | BETA | Oui |
 | 2 | Le Framework Rational Speech Act (RSA) | BETA | Oui |
 
 ## Probas/DecisionTheory (26 notebooks)

--- a/docs/curriculum/trading.md
+++ b/docs/curriculum/trading.md
@@ -116,7 +116,7 @@ Stratégies de trading algorithmique avec QuantConnect, pipeline ML (Transformer
 
 | # | Notebook | Maturité | Exécutable |
 |---|----------|----------|------------|
-| 1 | Infer-101 : Introduction a Infer.NET | BETA | Oui |
+| 1 | Infer-1b : Introduction a Infer.NET | BETA | Oui |
 | 2 | Le Framework Rational Speech Act (RSA) | BETA | Oui |
 
 ## Probas/DecisionTheory (26 notebooks)

--- a/docs/research/quant-prose-residual-machine-dep.md
+++ b/docs/research/quant-prose-residual-machine-dep.md
@@ -39,7 +39,7 @@
 | `04-6-Audiobook-Pipeline.ipynb` | 6 | 0 | 0 | 2 |
 | `Sudoku-18-Comparison-Csharp.ipynb` | 2 | 0 | 3 | 0 |
 | `Sudoku-18-Comparison-Python.ipynb` | 1 | 2 | 2 | 0 |
-| `Infer-101.ipynb` | 0 | 0 | 4 | 10 |
+| `Infer-1b-Premiers-Modeles.ipynb` | 0 | 0 | 4 | 10 |
 | `QC-Py-26-LLM-Trading-Signals.ipynb` | 0 | 0 | 4 | 0 |
 | `Sudoku-10-ORTools-Csharp.ipynb` | 0 | 0 | 4 | 0 |
 | `App-2b-GraphColoring-CSharp.ipynb` | 0 | 0 | 3 | 0 |

--- a/scripts/notebook_tools/pedagogy_density_baseline.json
+++ b/scripts/notebook_tools/pedagogy_density_baseline.json
@@ -335,7 +335,7 @@
     "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb": 1458.828,
     "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-6-Expert-Systems.ipynb": 1382.864,
     "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb": 1755.609,
-    "MyIA.AI.Notebooks/Probas/Infer-101.ipynb": 807.286,
+    "MyIA.AI.Notebooks/Probas/Infer/Infer-1b-Premiers-Modeles.ipynb": 807.286,
     "MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb": 1500.5,
     "MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb": 2024.588,
     "MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb": 1715.875,

--- a/scripts/notebook_tools/twin_pairs.d/sl-10-activeautomatalearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-10-activeautomatalearning.yaml
@@ -14,6 +14,12 @@
       csharp_sha: a0a7d245769c8540631d823f1152e693f9c131d9
       content_python_sha: 9f3452ddb6fb345b8935830c21d93c66c48d2f8f6c66a94e6d6e11fd7d5b09cf
       content_csharp_sha: 77769b3d1997dac2af83385df0be2ca22d80a00d07fb47164e4a73bfc9362a11
+    - date: "2026-09-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 735d0ed0f34df96c605d80f10cfaf8ebb571f8e8
+      csharp_sha: 6a4df7fb7710b3cf322f97acadee8432f23539f8
+      content_python_sha: 6ad5777489f3f4eb777fc0f27a592c7ed474081fdf44766ca92a0370225577b5
+      content_csharp_sha: 5d0e64003682524023c10e1869b9346805921d790890befd6be3675fbf863a4b
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = BCL Python from-scratch (dataclasses + frozenset pour les ensembles d'etats hashables) pour L* (Angluin 1987) + MAT (Minimally Adequate Teacher) + table d'observation + oracle d'equivalence + pont Infer.NET (DFA exact a reconnaissance probabiliste). C# = BCL .NET from-scratch (`HashSet<T>` + `Dictionary<TKey,TValue>` + `List<T>`) pour L* + MAT + table d'observation + oracle d'equivalence + meme pont Infer.NET. Verdict SOTA-OK (native-both) : substance from-scratch quasi-identique des deux cotes (45 cellules, 17 code, 28 markdown, memes 9 sections, meme ordre -- c'est le twin le plus proche cellule-a-cellule de la famille SL). Idiomes framework different (dataclasses/frozenset vs HashSet/Dictionary) mais la logique algorithmique est equivalente. z Aucun SOTA externe : L* from-scratch + Infer.NET sont les outils SOTA canoniques (pas de remplacement SOTA installable). Aucune asymetrie de couverture. `parity_level: native-both` preserve."
   known_differences:

--- a/slides/04-probabilites/analysis/improvement_plan.md
+++ b/slides/04-probabilites/analysis/improvement_plan.md
@@ -49,7 +49,7 @@
 **Améliorer** :
 - Ajouter slide sur l'incertitude dans les LLMs modernes (hallucinations, confidence scores)
 - Intégrer exemple avec calcul bayésien dans un contexte GenAI (prompt engineering avec probabilités)
-- Ajouter références vers `Probas/Infer-101.ipynb` pour exercices interactifs
+- Ajouter références vers `Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` pour exercices interactifs
 
 **Moderniser** :
 - Remplacer exemples abstraits par cas d'usage 2024-2026 (véhicules autonomes, diagnostics médicaux IA)
@@ -69,7 +69,7 @@
 
 | Slide | Concept | Notebook |
 |-------|---------|----------|
-| 36-45 | Inférence bayésienne | `Probas/Infer-101.ipynb` |
+| 36-45 | Inférence bayésienne | `Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` |
 | 46-60 | HMM | `Probas/Infer/Infer-6-HMM.ipynb` |
 | 61-70 | Factor Graphs | `Probas/Infer/Infer-3-Factor-Graphs.ipynb` |
 
@@ -99,7 +99,7 @@
 
 | Slide(s) | Concept | Notebooks |
 |-----------|---------|-----------|
-| 1-20 | Probabilités fondamentales | `Probas/Infer-101.ipynb` |
+| 1-20 | Probabilités fondamentales | `Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` |
 | 15-30 | Réseaux bayésiens | `Probas/Infer/Infer-3-Factor-Graphs.ipynb`, `Infer-4-Bayes-Nets.ipynb` |
 | 36-50 | Inférence probabiliste | `Probas/Infer/Infer-5-Inference.ipynb`, `Infer-7-Variable-Elimination.ipynb` |
 | 51-70 | HMM et chaînes de Markov | `Probas/Infer/Infer-6-HMM.ipynb`, `Infer-8-Temporal.ipynb` |

--- a/translations/symboliclearning/symboliclearning.csv
+++ b/translations/symboliclearning/symboliclearning.csv
@@ -1214,7 +1214,7 @@ Trois faits reunis ferment la boucle :
 | Notebook | Ce qu'il apporte au pont |
 |----------|--------------------------|
 | [`Probas/Infer/Infer-14-Sequences`](../../Probas/Infer/Infer-14-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |
-| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
+| [`Probas/Infer-1b`](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
 | [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |
 | [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le même HMM gaussien, cote Python (hmmlearn) |
 
@@ -1293,7 +1293,7 @@ MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
 | Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |
 | Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |
 | Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |
-| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
+| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
 | Automates & verification | Model checking | Serie SymbolicAI |
 ",,,,,,,,4e0a409a5f26b9bd,,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb,sl8-28,markdown,fr,0bf9f16d3532f0cc,"---
@@ -2469,7 +2469,7 @@ Trois faits reunis ferment la boucle :
 | Notebook | Ce qu'il apporte au pont |
 |----------|--------------------------|
 | [`Probas/Infer/Infer-14-Sequences`](../../Probas/Infer/Infer-14-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |
-| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
+| [`Probas/Infer-1b`](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
 | [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |
 | [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le même HMM gaussien, cote Python (hmmlearn) |
 
@@ -2546,7 +2546,7 @@ MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Cshar
 | Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |
 | Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |
 | Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |
-| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
+| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
 | Automates & verification | Model checking | Serie SymbolicAI |
 ",,,,,,,,379f6dc50932e175,,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb,617c6c79,markdown,fr,0bf9f16d3532f0cc,"---

--- a/translations/symboliclearning/symboliclearning.csv
+++ b/translations/symboliclearning/symboliclearning.csv
@@ -1214,7 +1214,7 @@ Trois faits reunis ferment la boucle :
 | Notebook | Ce qu'il apporte au pont |
 |----------|--------------------------|
 | [`Probas/Infer/Infer-14-Sequences`](../../Probas/Infer/Infer-14-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |
-| [`Probas/Infer-1b`](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
+| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
 | [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |
 | [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le même HMM gaussien, cote Python (hmmlearn) |
 
@@ -1293,7 +1293,7 @@ MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
 | Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |
 | Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |
 | Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |
-| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
+| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
 | Automates & verification | Model checking | Serie SymbolicAI |
 ",,,,,,,,4e0a409a5f26b9bd,,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb,sl8-28,markdown,fr,0bf9f16d3532f0cc,"---
@@ -2469,7 +2469,7 @@ Trois faits reunis ferment la boucle :
 | Notebook | Ce qu'il apporte au pont |
 |----------|--------------------------|
 | [`Probas/Infer/Infer-14-Sequences`](../../Probas/Infer/Infer-14-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |
-| [`Probas/Infer-1b`](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
+| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |
 | [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |
 | [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le même HMM gaussien, cote Python (hmmlearn) |
 
@@ -2546,7 +2546,7 @@ MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Cshar
 | Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |
 | Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |
 | Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |
-| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer/Infer-1b-Premiers-Modeles.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
+| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-14-Sequences](../../Probas/Infer/Infer-14-Sequences.ipynb) |
 | Automates & verification | Model checking | Serie SymbolicAI |
 ",,,,,,,,379f6dc50932e175,,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb,617c6c79,markdown,fr,0bf9f16d3532f0cc,"---


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #14874

> **Périmètre : 13 fichiers** (net PR vs `main`) — `.claude/rules/notebook-conventions.md` · `MyIA.AI.Notebooks/Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` · `MyIA.AI.Notebooks/Probas/README.md` · `MyIA.AI.Notebooks/Probas/index.qmd` · `MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb` · `MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb` · `docs/curriculum/recherche.md` · `docs/curriculum/trading.md` · `scripts/notebook_tools/pedagogy_density_baseline.json` · `scripts/notebook_tools/twin_pairs.d/sl-10-activeautomatalearning.yaml` · `docs/archive/01-cartographie-initiale.md` · `slides/04-probabilites/analysis/improvement_plan.md` · `docs/research/quant-prose-residual-machine-dep.md`

## Sujet

La seconde leçon d'ouverture concurrente à la racine de la série Probas — `Probas/Infer-101.ipynb` — devient l'**accrétion `Infer-1b`** du corpus [`Infer/`](MyIA.AI.Notebooks/Probas/Infer/README.md). C'est l'option 2 proposée dans #14883. Le « deuxième leçon 1 » visible comme premier fichier de `Probas/` disparaît ; l'entrée Infer.NET du corpus est désormais la compagne d'`Infer-1-Setup`.

## Mapping (avant PR, cf commentaire d'issue)

| Avant | Après |
|---|---|
| `MyIA.AI.Notebooks/Probas/Infer-101.ipynb` | `MyIA.AI.Notebooks/Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` |

`git mv` (identité préservée, similarité 99 %). **Aucun changement de contenu** (§6 du protocole, acceptation #5) : seuls écarts = (a) suppression du `## Introduction à la Programmation Probabiliste` dupliqué (cellule [1], acceptation #4) et (b) `metadata.papermill` au basename. Aucune re-exécution (markdown + métadonnées seulement, exception C.2). Le pré-commit `fix-hr-separator` a en outre normalisé 6 séparateurs `---` → `***` (hygiène d'ouverture de bloc YAML — markdown seulement, densité inchangée).

**Argument d'accrétion (exigence §3)** : Infer-101 est la version longue et pratique de l'introduction à Infer.NET — elle ouvre sur la même programmation probabiliste que `Infer-1-Setup` puis **approfondit** le palier 1 avec le tutoriel MBML cycliste (60 cellules uniques, [11]-[70]). Ni une application (pas `Applications/`), ni un doublon (pas de fusion — le contenu avancé est distinct et précieux) : c'est la marche d'approfondissement du repère `Infer-1`. Comme `Infer-1b`, elle sort du chemin canonique du speed-run, et le nom se trie avant `Infer-10` (fini le fichier-d'intro trié après `Infer-20`).

## Sweep des référents (acceptation #6)

| Surface | Fichier | Action |
|---|---|---|
| README série | `MyIA.AI.Notebooks/Probas/README.md` | 9 références `Infer-101` → `Infer-1b` (intro, arbre mermaid, tables, arbre de structure, section kernels) |
| index Quarto | `MyIA.AI.Notebooks/Probas/index.qmd` | retrait du listing `standalone-root`, comptes (Racine 2→1, Infer « + accrétion Infer-1b »), prose |
| navlinks SL-10 ×2 | `SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning{,-Csharp}.ipynb` | `../../Probas/Infer-101` → `../../Probas/Infer/Infer-1b-Premiers-Modeles` |
| twin registry | `scripts/notebook_tools/twin_pairs.d/sl-10-activeautomatalearning.yaml` | attestation `check_twin_parity.py --update` post-édition navlink (drift SL-10 résorbé, OK=157 DRIFT=0) |
| baseline | `scripts/notebook_tools/pedagogy_density_baseline.json` | clé orpheline renommée vers le nouveau chemin (valeur 807.286 préservée) |
| curriculum | `docs/curriculum/{trading,recherche}.md` | nom `Infer-101` → `Infer-1b` |
| règle | `.claude/rules/notebook-conventions.md` | exemple data-unit `(Infer-101)` → `(Infer-1b)` |
| trace (lien) | `docs/archive/01-cartographie-initiale.md` | lien markdown `Probas/Infer-101.ipynb` → `Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` (post-déplacement) |
| trace (nom) | `slides/04-probabilites/analysis/improvement_plan.md` | 3 mentions `Probas/Infer-101.ipynb` → `Probas/Infer/Infer-1b-Premiers-Modeles.ipynb` |
| trace (nom) | `docs/research/quant-prose-residual-machine-dep.md` | mention `Infer-101.ipynb` → `Infer-1b-Premiers-Modeles.ipynb` |

Note translation CSV : `translations/symboliclearning/symboliclearning.csv` est **intentionnellement non touché** — artefact généré par l'automatisation (#10042/#10038). La source FR est le twin SL-10 (navlink `Infer-1b` porté ci-dessus) ; le bot re-dérive le CSV à la prochaine exécution de `translation-sync.yml` (sur hold user depuis 2026-08-12, `workflow_dispatch` seul). Le catalogue (`COURSE_CATALOG.generated.*`) reste byte-identique à `main` — régénéré par le cron `catalog-cron.yml`, jamais à la main.

## Validation (organes — mêmes instruments que les merge-gates)

- `scripts/check_docs_links.py` : **0 broken** (sur 683 fichiers balayés, 5561 liens).
- `scripts/notebook_tools/check_notebook_navlinks.py` : **0 broken** (notebook déplacé + SL-10 ×2).
- `scripts/notebook_tools/pedagogy_density.py --check-orphans` : **0 orpheline** (811 clés).
- `scripts/notebook_tools/validate_pr_notebooks.py` : **3/3 notebooks PASS** — Infer-1b = 28 cellules code `.net-csharp`, `execution_count` présents, C.1/C.2/H.3 OK.
- `scripts/notebook_tools/check_twin_parity.py --pair "SL-10 ActiveAutomataLearning"` : **OK=157 DRIFT=0** (attestation `--update` post navlink).
- `scripts/check_docs_links.py` : le lien `docs/archive/01-cartographie-initiale.md` (référent `Infer-101`) corrigé vers le nouveau chemin.

Base fraîche : rebase sur `origin/main` `a716bc029` (aucun conflit). L1356 preflight : aucune PR ouverte sur le chemin `Probas/Infer-101` ni pour #14883.

## Liens

Closes #14883 · See #14873 · See #12208
