### PR TITLE
feat(lean,#2159): Partie 73 -- point du site des ouverts, iso presheafFiber = stalk (TODO Mathlib)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkPoints.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkPoints.lean
@@ -1,0 +1,219 @@
+/-
+Grothendieck hommage — Partie 73 : points du site des ouverts et tiges.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+Un point d'un site au sens de SGA 4 (IV 6.3) est un foncteur fibre : un
+foncteur vers `Type` dont la catégorie des éléments est cofiltrée et qui
+rencontre tous les cribles couvrants. La Partie 15 (`SitePoints`) avait
+établi la théorie abstraite ; la Partie 72 (`Stalks`) le calcul concret des
+tiges sur le site des ouverts. Cette partie soude les deux : à tout point
+`x : T` on associe un point du site `(Opens T, opensTopology T)` — la fibre
+en `U` est l'ensemble (au plus unimodal) des éléments de `U` égaux à `x` —
+et l'on montre que **le foncteur fibre de ce point est exactement la tige
+en `x`** :
+
+  `stalkFiberIso : (opensPoint T x).presheafFiber.obj F ≅ F.stalk x`
+
+C'est le TODO explicite de Mathlib (`Topology/Sheaves/Points.lean` :
+« Redefine the stalks functors in Stalks.lean using
+`GrothendieckTopology.Point.presheafFiber` ») — l'iso est ici établi côté
+lake. La preuve est un double passage à la colimite : les germes forment un
+cône sur le diagramme des éléments de la fibre (via `germ_res`), les
+`toPresheafFiber` forment un cône sur le diagramme des voisinages (via
+`toPresheafFiber_w`), et les deux universalités se répondent via les deux
+lemmes d'extension (`stalk_hom_ext`, `presheafFiber_hom_ext`). L'iso est
+naturel en le préfaisceau.
+
+Références :
+  - SGA 4, IV 6.3 (points d'un site, foncteurs fibres).
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II §3, exercice (les points de l'espace redonnent les tiges).
+  - Mathlib, `Mathlib.Topology.Sheaves.Points` (le point canonique
+    `Opens.pointGrothendieckTopology`, dont la construction de
+    `opensPoint` est la transcription sur le site own).
+  - Partie 15 (`Grothendieck.SitePoints`) : foncteurs fibres abstraits.
+  - Partie 70 (`Grothendieck.SpacesMathlib`) : l'égalité des topologies.
+  - Partie 72 (`Grothendieck.Stalks`) : germes et tiges concrets.
+
+Convention i18n (EPIC #4980 ratifiée 2026-07-04) : ce module est jumelé avec
+`StalkPoints_en.lean`. Les énoncés, preuves et noms Lean restent identiques ;
+seules les docstrings et les commentaires diffèrent.
+
+Epic #1646, Phase 2 (#2159). Aucun `sorry` introduit.
+-/
+
+import Grothendieck.Spaces
+import Grothendieck.SpacesMathlib
+import Mathlib.Topology.Sheaves.Points
+import Mathlib.Topology.Sheaves.Stalks
+
+universe u
+
+namespace Grothendieck
+
+open CategoryTheory CategoryTheory.Limits Opposite TopCat TopologicalSpace
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T] (x : T)
+
+/-- **Le point du site des ouverts associé à `x`** : la fibre d'un ouvert
+`U` est l'ensemble des éléments de `U` égaux à `x` (un type au plus
+singleton, habité exactement lorsque `x ∈ U`). La catégorie des éléments —
+les voisinages ouverts de `x` et leurs inclusions — est cofiltrée ; tout
+crible couvrant d'un ouvert contenant `x` contient un voisinage de `x`
+(`mem_opensTopology_iff`). C'est la transcription sur le site own du point
+canonique `Opens.pointGrothendieckTopology` de Mathlib, l'égalité des
+topologies (Partie 70) garantissant qu'il s'agit du même point. -/
+def opensPoint : GrothendieckTopology.Point (opensTopology T) where
+  fiber.obj U := ULift.{u} (PLift (x ∈ U))
+  fiber.map f := ↾fun h ↦ ⟨⟨leOfHom f h.down.down⟩⟩
+  isCofiltered :=
+    { nonempty := ⟨⊤, ⟨⟨by simp⟩⟩⟩
+      cone_objs := by
+        rintro ⟨U, ⟨⟨hU⟩⟩⟩ ⟨V, ⟨⟨hV⟩⟩⟩
+        exact ⟨⟨U ⊓ V, ⟨⟨⟨hU, hV⟩⟩⟩⟩, ⟨homOfLE (by simp), rfl⟩,
+          ⟨homOfLE (by simp), rfl⟩, ⟨⟩⟩
+      cone_maps _ _ _ _ := ⟨_, 𝟙 _, rfl⟩ }
+  initiallySmall := initiallySmall_of_essentiallySmall _
+  jointly_surjective := by
+    rintro U R hR ⟨⟨hU⟩⟩
+    rw [mem_opensTopology_iff] at hR
+    obtain ⟨V, f, hf, hV⟩ := hR x hU
+    exact ⟨_, _, hf, ⟨⟨hV⟩⟩, rfl⟩
+
+/-- Tout élément de la fibre de `U` provient d'une appartenance `x ∈ U`
+(réciproque tautologique de la construction). -/
+theorem mem_of_fiber {U : Opens T} (p : (opensPoint T x).fiber.obj U) : x ∈ U :=
+  p.down.down
+
+/-- L'élément de la fibre codant une appartenance `x ∈ U`. -/
+def fiberElem {U : Opens T} (hx : x ∈ U) : (opensPoint T x).fiber.obj U :=
+  ⟨⟨hx⟩⟩
+
+variable (F : TopCat.Presheaf (Type u) (TopCat.of T))
+
+/-- Le cône des germes sur le diagramme des éléments de la fibre : un
+élément `(U, p)` vit au-dessus d'un ouvert `U` qui contient `x`, et le germe
+s'y restreint (`germ_res`). -/
+noncomputable def fiberToStalkCocone :
+    Cocone ((CategoryOfElements.π (opensPoint T x).fiber).op ⋙ F) where
+  pt := TopCat.Presheaf.stalk (X := TopCat.of T) F x
+  ι.app e := TopCat.Presheaf.germ (X := TopCat.of T) F e.unop.1 x e.unop.2.down.down
+  ι.naturality _ j' f := by
+    obtain ⟨V, ⟨⟨hV⟩⟩⟩ := j'
+    exact TopCat.Presheaf.germ_res (X := TopCat.of T) F f.unop.1 x hV
+
+/-- **De la fibre vers la tige** : descente universelle du cône des germes,
+morphisme de la fibre colimite vers la tige. -/
+noncomputable def fiberToStalk :
+    (opensPoint T x).presheafFiber.obj F ⟶ TopCat.Presheaf.stalk (X := TopCat.of T) F x :=
+  colimit.desc _ (fiberToStalkCocone T x F)
+
+/-- Le cône des `toPresheafFiber` sur le diagramme des voisinages : chaque
+voisinage `U ∋ x` fournit une section au-dessus de `U`, donc un élément de
+la fibre colimite (`toPresheafFiber_w`). -/
+noncomputable def stalkToFiberCocone :
+    Cocone ((OpenNhds.inclusion (X := TopCat.of T) x).op ⋙ F) where
+  pt := (opensPoint T x).presheafFiber.obj F
+  ι.app j := (opensPoint T x).toPresheafFiber j.unop.1 ⟨⟨j.unop.2⟩⟩ F
+  ι.naturality _ j' f := by
+    obtain ⟨V, hV⟩ := j'
+    exact (opensPoint T x).toPresheafFiber_w f.unop ⟨⟨hV⟩⟩ F
+
+/-- **De la tige vers la fibre** : descente universelle du cône des
+`toPresheafFiber`, morphisme de la tige vers la fibre. -/
+noncomputable def stalkToFiber :
+    TopCat.Presheaf.stalk (X := TopCat.of T) F x ⟶ (opensPoint T x).presheafFiber.obj F :=
+  colimit.desc _ (stalkToFiberCocone T x F)
+
+/-- Le morphisme `fiberToStalk` envoie le `toPresheafFiber` d'une section
+au-dessus de `U` sur son germe : les deux côtés sont des composantes de
+colimite (`colimit.ι_desc`). -/
+theorem toPresheafFiber_fiberToStalk (U : Opens T) (p : (opensPoint T x).fiber.obj U) :
+    (opensPoint T x).toPresheafFiber U p F ≫ fiberToStalk T x F =
+      TopCat.Presheaf.germ (X := TopCat.of T) F U x p.down.down :=
+  colimit.ι_desc _ _
+
+/-- Le morphisme `stalkToFiber` envoie chaque germe sur le `toPresheafFiber`
+de la section : les deux côtés sont des composantes de colimite
+(`colimit.ι_desc`). -/
+theorem germ_stalkToFiber (U : Opens T) (hx : x ∈ U) :
+    TopCat.Presheaf.germ (X := TopCat.of T) F U x hx ≫ stalkToFiber T x F =
+      (opensPoint T x).toPresheafFiber U ⟨⟨hx⟩⟩ F :=
+  colimit.ι_desc _ _
+
+/-- La section tige → fibre → tige est l'identité : deux morphismes sortant
+de la tige coïncident dès qu'ils coïncident après tout germe
+(`stalk_hom_ext`), et le triangle se ferme par les deux caractérisations
+ci-dessus. -/
+@[simp]
+theorem stalkToFiber_comp_fiberToStalk :
+    stalkToFiber T x F ≫ fiberToStalk T x F = 𝟙 _ := by
+  apply TopCat.Presheaf.stalk_hom_ext (X := TopCat.of T)
+  intro U hx
+  rw [← Category.assoc, germ_stalkToFiber, toPresheafFiber_fiberToStalk,
+    Category.comp_id]
+
+/-- La section fibre → tige → fibre est l'identité : deux morphismes sortant
+de la fibre colimite coïncident dès qu'ils coïncident après tout
+`toPresheafFiber` (`presheafFiber_hom_ext`), et le triangle se ferme de
+façon symétrique. -/
+@[simp]
+theorem fiberToStalk_comp_stalkToFiber :
+    fiberToStalk T x F ≫ stalkToFiber T x F = 𝟙 _ := by
+  apply (opensPoint T x).presheafFiber_hom_ext
+  intro U p
+  obtain ⟨⟨h⟩⟩ := p
+  rw [← Category.assoc, toPresheafFiber_fiberToStalk, germ_stalkToFiber,
+    Category.comp_id]
+
+/-- **La tige est le foncteur fibre du point associé** : iso canonique entre
+la fibre de tout préfaisceau `F` au point du site `opensPoint T x` et la tige
+topologique de `F` en `x`. Cet iso est le TODO explicite de
+`Mathlib.Topology.Sheaves.Points` ; il soude la théorie abstraite de la
+Partie 15 au calcul concret de la Partie 72. -/
+noncomputable def stalkFiberIso :
+    (opensPoint T x).presheafFiber.obj F ≅ TopCat.Presheaf.stalk (X := TopCat.of T) F x where
+  hom := fiberToStalk T x F
+  inv := stalkToFiber T x F
+  hom_inv_id := fiberToStalk_comp_stalkToFiber T x F
+  inv_hom_id := stalkToFiber_comp_fiberToStalk T x F
+
+/-- L'iso `stalkFiberIso` est naturel en le préfaisceau : il entrelace
+`presheafFiber.map` et `stalkFunctor.map`. -/
+theorem stalkFiberIso_naturality {G : TopCat.Presheaf (Type u) (TopCat.of T)} (f : F ⟶ G) :
+    (opensPoint T x).presheafFiber.map f ≫ fiberToStalk T x G =
+      fiberToStalk T x F ≫
+        (TopCat.Presheaf.stalkFunctor (Type u) (X := TopCat.of T) x).map f := by
+  apply (opensPoint T x).presheafFiber_hom_ext
+  intro U p
+  obtain ⟨⟨h⟩⟩ := p
+  calc (opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫
+          ((opensPoint T x).presheafFiber.map f ≫ fiberToStalk T x G)
+      = ((opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫ (opensPoint T x).presheafFiber.map f) ≫
+          fiberToStalk T x G := (Category.assoc _ _ _).symm
+    _ = (f.app (op U) ≫ (opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ G) ≫ fiberToStalk T x G :=
+        congrArg (· ≫ fiberToStalk T x G) ((opensPoint T x).toPresheafFiber_naturality f U ⟨⟨h⟩⟩)
+    _ = f.app (op U) ≫
+          ((opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ G ≫ fiberToStalk T x G) :=
+        Category.assoc _ _ _
+    _ = f.app (op U) ≫ TopCat.Presheaf.germ (X := TopCat.of T) G U x h :=
+        congrArg (f.app (op U) ≫ ·) (toPresheafFiber_fiberToStalk T x G U ⟨⟨h⟩⟩)
+    _ = TopCat.Presheaf.germ (X := TopCat.of T) F U x h ≫
+          (TopCat.Presheaf.stalkFunctor (Type u) x).map f :=
+        (TopCat.Presheaf.stalkFunctor_map_germ (X := TopCat.of T) U x h f).symm
+    _ = ((opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫ fiberToStalk T x F) ≫
+          (TopCat.Presheaf.stalkFunctor (Type u) x).map f :=
+        congrArg (· ≫ (TopCat.Presheaf.stalkFunctor (Type u) x).map f)
+          (toPresheafFiber_fiberToStalk T x F U ⟨⟨h⟩⟩).symm
+    _ = (opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫
+          (fiberToStalk T x F ≫ (TopCat.Presheaf.stalkFunctor (Type u) x).map f) :=
+        Category.assoc _ _ _
+
+end Contenu
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkPoints_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkPoints_en.lean
@@ -1,0 +1,217 @@
+/-
+Grothendieck tribute — Part 73: points of the site of opens and stalks.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+A point of a site in the sense of SGA 4 (IV 6.3) is a fiber functor: a
+functor to `Type` whose category of elements is cofiltered and which meets
+every covering sieve. Part 15 (`SitePoints`) established the abstract
+theory; Part 72 (`Stalks`) the concrete computation of stalks on the site
+of opens. This part solders the two together: to every point `x : T` we
+attach a point of the site `(Opens T, opensTopology T)` — the fiber at `U`
+is the (at most singleton) set of elements of `U` equal to `x` — and we
+show that **the fiber functor of this point is exactly the stalk at `x`**:
+
+  `stalkFiberIso : (opensPoint T x).presheafFiber.obj F ≅ F.stalk x`
+
+This is Mathlib's explicit TODO (`Topology/Sheaves/Points.lean`: "Redefine
+the stalks functors in Stalks.lean using
+`GrothendieckTopology.Point.presheafFiber`") — the iso is established here
+on the lake side. The proof is a double passage to colimits: germs form a
+cone on the diagram of elements of the fiber (via `germ_res`), the
+`toPresheafFiber` maps form a cone on the diagram of neighborhoods (via
+`toPresheafFiber_w`), and the two universal properties answer each other
+through the two extension lemmas (`stalk_hom_ext`,
+`presheafFiber_hom_ext`). The iso is natural in the presheaf.
+
+References:
+  - SGA 4, IV 6.3 (points of a site, fiber functors).
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II §3, exercise (points of the space recover the stalks).
+  - Mathlib, `Mathlib.Topology.Sheaves.Points` (the canonical point
+    `Opens.pointGrothendieckTopology`, whose construction `opensPoint`
+    transcribes on the own site).
+  - Part 15 (`Grothendieck.SitePoints`): abstract fiber functors.
+  - Part 70 (`Grothendieck.SpacesMathlib`): the equality of topologies.
+  - Part 72 (`Grothendieck.Stalks`): concrete germs and stalks.
+
+i18n convention (EPIC #4980 ratified 2026-07-04): this module is twinned
+with `StalkPoints.lean`. Statements, proofs and Lean names remain
+identical; only docstrings and comments differ.
+
+Epic #1646, Phase 2 (#2159). No `sorry` introduced.
+-/
+
+import Grothendieck.Spaces
+import Grothendieck.SpacesMathlib
+import Mathlib.Topology.Sheaves.Points
+import Mathlib.Topology.Sheaves.Stalks
+
+universe u
+
+namespace Grothendieck.StalkPoints_en
+
+open CategoryTheory CategoryTheory.Limits Opposite TopCat TopologicalSpace
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T] (x : T)
+
+/-- **The point of the site of opens attached to `x`**: the fiber of an
+open `U` is the set of elements of `U` equal to `x` (an at most singleton
+type, inhabited exactly when `x ∈ U`). The category of elements — the open
+neighborhoods of `x` and their inclusions — is cofiltered; every covering
+sieve of an open containing `x` contains a neighborhood of `x`
+(`mem_opensTopology_iff`). This is the transcription on the own site of
+Mathlib's canonical point `Opens.pointGrothendieckTopology`, the equality
+of topologies (Part 70) guaranteeing it is the same point. -/
+def opensPoint : GrothendieckTopology.Point (opensTopology T) where
+  fiber.obj U := ULift.{u} (PLift (x ∈ U))
+  fiber.map f := ↾fun h ↦ ⟨⟨leOfHom f h.down.down⟩⟩
+  isCofiltered :=
+    { nonempty := ⟨⊤, ⟨⟨by simp⟩⟩⟩
+      cone_objs := by
+        rintro ⟨U, ⟨⟨hU⟩⟩⟩ ⟨V, ⟨⟨hV⟩⟩⟩
+        exact ⟨⟨U ⊓ V, ⟨⟨⟨hU, hV⟩⟩⟩⟩, ⟨homOfLE (by simp), rfl⟩,
+          ⟨homOfLE (by simp), rfl⟩, ⟨⟩⟩
+      cone_maps _ _ _ _ := ⟨_, 𝟙 _, rfl⟩ }
+  initiallySmall := initiallySmall_of_essentiallySmall _
+  jointly_surjective := by
+    rintro U R hR ⟨⟨hU⟩⟩
+    rw [mem_opensTopology_iff] at hR
+    obtain ⟨V, f, hf, hV⟩ := hR x hU
+    exact ⟨_, _, hf, ⟨⟨hV⟩⟩, rfl⟩
+
+/-- Every element of the fiber of `U` arises from a membership `x ∈ U`
+(tautological converse of the construction). -/
+theorem mem_of_fiber {U : Opens T} (p : (opensPoint T x).fiber.obj U) : x ∈ U :=
+  p.down.down
+
+/-- The element of the fiber encoding a membership `x ∈ U`. -/
+def fiberElem {U : Opens T} (hx : x ∈ U) : (opensPoint T x).fiber.obj U :=
+  ⟨⟨hx⟩⟩
+
+variable (F : TopCat.Presheaf (Type u) (TopCat.of T))
+
+/-- The cone of germs on the diagram of elements of the fiber: an element
+`(U, p)` lives over an open `U` which contains `x`, and the germ restricts
+along the inclusion (`germ_res`). -/
+noncomputable def fiberToStalkCocone :
+    Cocone ((CategoryOfElements.π (opensPoint T x).fiber).op ⋙ F) where
+  pt := TopCat.Presheaf.stalk (X := TopCat.of T) F x
+  ι.app e := TopCat.Presheaf.germ (X := TopCat.of T) F e.unop.1 x e.unop.2.down.down
+  ι.naturality _ j' f := by
+    obtain ⟨V, ⟨⟨hV⟩⟩⟩ := j'
+    exact TopCat.Presheaf.germ_res (X := TopCat.of T) F f.unop.1 x hV
+
+/-- **From the fiber to the stalk**: universal descent of the cone of
+germs, a morphism from the fiber colimit to the stalk. -/
+noncomputable def fiberToStalk :
+    (opensPoint T x).presheafFiber.obj F ⟶ TopCat.Presheaf.stalk (X := TopCat.of T) F x :=
+  colimit.desc _ (fiberToStalkCocone T x F)
+
+/-- The cone of `toPresheafFiber` maps on the diagram of neighborhoods:
+every neighborhood `U ∋ x` provides a section over `U`, hence an element of
+the fiber colimit (`toPresheafFiber_w`). -/
+noncomputable def stalkToFiberCocone :
+    Cocone ((OpenNhds.inclusion (X := TopCat.of T) x).op ⋙ F) where
+  pt := (opensPoint T x).presheafFiber.obj F
+  ι.app j := (opensPoint T x).toPresheafFiber j.unop.1 ⟨⟨j.unop.2⟩⟩ F
+  ι.naturality _ j' f := by
+    obtain ⟨V, hV⟩ := j'
+    exact (opensPoint T x).toPresheafFiber_w f.unop ⟨⟨hV⟩⟩ F
+
+/-- **From the stalk to the fiber**: universal descent of the cone of
+`toPresheafFiber` maps, a morphism from the stalk to the fiber. -/
+noncomputable def stalkToFiber :
+    TopCat.Presheaf.stalk (X := TopCat.of T) F x ⟶ (opensPoint T x).presheafFiber.obj F :=
+  colimit.desc _ (stalkToFiberCocone T x F)
+
+/-- The morphism `fiberToStalk` sends the `toPresheafFiber` of a section
+over `U` to its germ: both sides are colimit components
+(`colimit.ι_desc`). -/
+theorem toPresheafFiber_fiberToStalk (U : Opens T) (p : (opensPoint T x).fiber.obj U) :
+    (opensPoint T x).toPresheafFiber U p F ≫ fiberToStalk T x F =
+      TopCat.Presheaf.germ (X := TopCat.of T) F U x p.down.down :=
+  colimit.ι_desc _ _
+
+/-- The morphism `stalkToFiber` sends every germ to the `toPresheafFiber`
+of the section: both sides are colimit components (`colimit.ι_desc`). -/
+theorem germ_stalkToFiber (U : Opens T) (hx : x ∈ U) :
+    TopCat.Presheaf.germ (X := TopCat.of T) F U x hx ≫ stalkToFiber T x F =
+      (opensPoint T x).toPresheafFiber U ⟨⟨hx⟩⟩ F :=
+  colimit.ι_desc _ _
+
+/-- The round trip stalk → fiber → stalk is the identity: two morphisms
+out of the stalk coincide as soon as they coincide after every germ
+(`stalk_hom_ext`), and the triangle closes via the two characterizations
+above. -/
+@[simp]
+theorem stalkToFiber_comp_fiberToStalk :
+    stalkToFiber T x F ≫ fiberToStalk T x F = 𝟙 _ := by
+  apply TopCat.Presheaf.stalk_hom_ext (X := TopCat.of T)
+  intro U hx
+  rw [← Category.assoc, germ_stalkToFiber, toPresheafFiber_fiberToStalk,
+    Category.comp_id]
+
+/-- The round trip fiber → stalk → fiber is the identity: two morphisms
+out of the fiber colimit coincide as soon as they coincide after every
+`toPresheafFiber` (`presheafFiber_hom_ext`), and the triangle closes
+symmetrically. -/
+@[simp]
+theorem fiberToStalk_comp_stalkToFiber :
+    fiberToStalk T x F ≫ stalkToFiber T x F = 𝟙 _ := by
+  apply (opensPoint T x).presheafFiber_hom_ext
+  intro U p
+  obtain ⟨⟨h⟩⟩ := p
+  rw [← Category.assoc, toPresheafFiber_fiberToStalk, germ_stalkToFiber,
+    Category.comp_id]
+
+/-- **The stalk is the fiber functor of the attached point**: canonical iso
+between the fiber of any presheaf `F` at the site point `opensPoint T x`
+and the topological stalk of `F` at `x`. This iso is the explicit TODO of
+`Mathlib.Topology.Sheaves.Points`; it solders the abstract theory of Part
+15 to the concrete computation of Part 72. -/
+noncomputable def stalkFiberIso :
+    (opensPoint T x).presheafFiber.obj F ≅ TopCat.Presheaf.stalk (X := TopCat.of T) F x where
+  hom := fiberToStalk T x F
+  inv := stalkToFiber T x F
+  hom_inv_id := fiberToStalk_comp_stalkToFiber T x F
+  inv_hom_id := stalkToFiber_comp_fiberToStalk T x F
+
+/-- The iso `stalkFiberIso` is natural in the presheaf: it intertwines
+`presheafFiber.map` and `stalkFunctor.map`. -/
+theorem stalkFiberIso_naturality {G : TopCat.Presheaf (Type u) (TopCat.of T)} (f : F ⟶ G) :
+    (opensPoint T x).presheafFiber.map f ≫ fiberToStalk T x G =
+      fiberToStalk T x F ≫
+        (TopCat.Presheaf.stalkFunctor (Type u) (X := TopCat.of T) x).map f := by
+  apply (opensPoint T x).presheafFiber_hom_ext
+  intro U p
+  obtain ⟨⟨h⟩⟩ := p
+  calc (opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫
+          ((opensPoint T x).presheafFiber.map f ≫ fiberToStalk T x G)
+      = ((opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫ (opensPoint T x).presheafFiber.map f) ≫
+          fiberToStalk T x G := (Category.assoc _ _ _).symm
+    _ = (f.app (op U) ≫ (opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ G) ≫ fiberToStalk T x G :=
+        congrArg (· ≫ fiberToStalk T x G) ((opensPoint T x).toPresheafFiber_naturality f U ⟨⟨h⟩⟩)
+    _ = f.app (op U) ≫
+          ((opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ G ≫ fiberToStalk T x G) :=
+        Category.assoc _ _ _
+    _ = f.app (op U) ≫ TopCat.Presheaf.germ (X := TopCat.of T) G U x h :=
+        congrArg (f.app (op U) ≫ ·) (toPresheafFiber_fiberToStalk T x G U ⟨⟨h⟩⟩)
+    _ = TopCat.Presheaf.germ (X := TopCat.of T) F U x h ≫
+          (TopCat.Presheaf.stalkFunctor (Type u) x).map f :=
+        (TopCat.Presheaf.stalkFunctor_map_germ (X := TopCat.of T) U x h f).symm
+    _ = ((opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫ fiberToStalk T x F) ≫
+          (TopCat.Presheaf.stalkFunctor (Type u) x).map f :=
+        congrArg (· ≫ (TopCat.Presheaf.stalkFunctor (Type u) x).map f)
+          (toPresheafFiber_fiberToStalk T x F U ⟨⟨h⟩⟩).symm
+    _ = (opensPoint T x).toPresheafFiber U ⟨⟨h⟩⟩ F ≫
+          (fiberToStalk T x F ≫ (TopCat.Presheaf.stalkFunctor (Type u) x).map f) :=
+        Category.assoc _ _ _
+
+end Contenu
+
+end Grothendieck.StalkPoints_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: LIGHT/docs #14906

## Summary

Partie 73 de l'Epic #2159 (Grothendieck hommage, Phase 2) : **point du site des ouverts associé à un point x, et identification du foncteur fibre avec la tige** — nouveau module `Grothendieck/StalkPoints.lean` (+ jumeau i18n `StalkPoints_en.lean`, convention #4980).

- **Le point du site** `opensPoint T x : GrothendieckTopology.Point (opensTopology T)` : transcription sur le site own du point canonique `Opens.pointGrothendieckTopology` de Mathlib (la fibre en `U` est l'ensemble au plus singleton des éléments de `U` égaux à `x`), avec `jointly_surjective` prouvé via notre propre `mem_opensTopology_iff` (Partie 70) — l'égalité des topologies garantit qu'il s'agit du même point.
- **Résultat principal — `stalkFiberIso`** : `(opensPoint T x).presheafFiber.obj F ≅ stalk F x` pour tout préfaisceau `F` sur `Opens T`. C'est le **TODO explicite de Mathlib** (`Topology/Sheaves/Points.lean` : « Redefine the stalks functors in Stalks.lean using `GrothendieckTopology.Point.presheafFiber` ») — l'iso n'existe pas dans Mathlib (vérifié : 0 occurrence de `presheafFiber` dans `Topology/Sheaves/Stalks.lean`), il est ici établi côté lake.
- **Stratégie — double passage à la colimite** : les germes forment un cône sur le diagramme des éléments de la fibre (`germ_res`), les `toPresheafFiber` forment un cône sur le diagramme des voisinages (`toPresheafFiber_w`) ; les deux descentes universelles (`fiberToStalk`, `stalkToFiber`) se répondent via `colimit.ι_desc` et les deux lemmes d'extension (`stalk_hom_ext`, `presheafFiber_hom_ext`) donnent les deux sections identité.
- **Naturalité** : `stalkFiberIso_naturality` — l'iso entrelace `presheafFiber.map` et `stalkFunctor.map` ; la tige EST le foncteur fibre du point, en tant que foncteurs et pas seulement objet par objet.
- **Jonction** : soude la théorie abstraite des points d'un site (Partie 15, SGA 4 IV 6.3) au calcul concret des tiges (Partie 72) — le premier maillon du dictionnaire points de l'espace ↔ fibres, au cœur de la théorie des topos (MM92 Chap. II §3).

## Anti-régression (§B)

- `sorry` : `count_code_sorry.py --json` — **0 avant / 0 après** (nouveaux fichiers uniquement, aucune preuve existante touchée ; grothendieck_lean : 143 fichiers, `distinct_code_sorry: 0`).
- `lake build Grothendieck.StalkPoints Grothendieck.StalkPoints_en` : **SUCCESS** — `Build completed successfully (1417 jobs)` (commit local prouvable, worktree `feature/2159-p73-stalk-points`).
- Proof integrity : job câblé sur ce lake (`lean-grothendieck.yml` → `lean-axiom.yml`), à lire au passage de la CI.
- i18n : `check_i18n_siblings.py` — paire FR/EN byte-identique hors docstrings/commentaires.

See #2159
