### PR TITLE
fix(ci,#14921): sérialiser proof-integrity après ci dans lean-knot — rafale git anonyme ÷2 + mainmise sur le cache .lake

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -151,8 +151,17 @@ jobs:
   # twin (.github/actions/lean-axiom) -- job-level `uses:` on the local
   # reusable replaced by a LOCAL job (runs-on/if/steps) invoking the
   # composite. check_target_coverage.py unions BOTH wiring forms.
+  #
+  # Serialized after `ci` (#14921): both jobs used to start at the same
+  # second, doubling the anonymous git burst from this machine's IP (2x
+  # mathlib + 2x plausible) -- the burst trips GitHub's per-IP anonymous
+  # limit and lake dies at `plausible` with `could not read Username`
+  # (exit 128). Running second, this job also restores the cache entry
+  # `ci` just saved, making the axiom pass fetch-free. This also makes
+  # the job true to its own comment above ("Runs after the build").
   proof-integrity:
     name: "Proof integrity (knot_lean)"
+    needs: ci
     runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     steps:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/lean #14903

(Grain note: coordinator P1 mission — dispatch ai-01 msg-20260906T171046-fdzzvl, "traite-les directement — tu choisis la forme". Genre guard = câblage d'un check CI susceptible de rougir.)

## Summary

Réponse au dispatch sur les 2 défauts mesurés des runners lean de po-2024 : diagnostic complet livré dans #14921 (l'étape exacte, les exclusions mesurées, la chaîne causale cache), et ce fix court terme — **sérialiser `proof-integrity` après `ci`** dans `lean-knot.yml` (`needs: ci`).

**Pourquoi ça répare les deux défauts à la fois :**
- **Défaut 2 (clone plausible 401)** : les 2 jobs démarraient à la même seconde (mesuré run 34047026316 : les deux à 16:56:27), doublant la rafale git anonyme depuis l'IP (2× mathlib + 2× plausible). La rafale fait basculer GitHub en 401/auth-required sur le dépôt public (git tente un prompt, pas de TTY, exit 128 à ~93 s). Sérialisés, un seul job froid → la rafale est divisée par 2 (les sondages solo passent 100 %, rafale de 8 : 7/8 échecs — mesures dans #14921).
- **Défaut 1 (cache jamais restauré)** : le post-save de `actions/cache` ne s'exécute que sur `success()` → 20 h d'échecs = 0 save jamais fait (`total_count: 0` mesuré) ; et le quota 10 Go est saturé par les 4 caches lean (~10,01 Go mesurés — grothendieck ×2, percolation ×2), le dernier save knot ayant été évincé par LRU. Sérialisés, le job axiom **restaure le cache que `ci` vient de sauver dans le même run** → plus aucun fetch de dépendances côté axiom, et le premier vert resauvegarde l'entrée.
- **Cohérence documentaire** : le comment du job disait déjà « Runs after the build to reuse the cached lake artifacts » — le `needs:` manquait depuis l'origine du job (vérifié : absent aussi de l'ancienne forme reusable-workflow, commit b4fb8b96e9).

**Self-test intégré** : `lean-knot.yml` est dans le paths-filter du workflow → cette PR déclenche elle-même un run froid solo de Lean Knot CI ; s'il passe, il sauve le cache knot et débloque #14821 / #14913 sans rerun de ma part (conforme à la décision d'ai-01 de ne pas relancer le PR gate). Durée attendue du job froid : ~1 h 45 (build mathlib) — la vérification du vert se fera au cycle suivant.

Les options structurelles (harmoniser les clés de cache build/axiom = quota ÷ 2 + fin des rebuilds 1 h 45 ; amaigrir le chemin caché ; PAT fetch authentifié ; parité conway) restent à arbitrer dans #14921.

## Anti-régression (§B)

- Aucun code/preuve touché — 1 fichier workflow, +9/-0 (commentaire + `needs:`).
- `yaml.safe_load` OK ; `check_self_hosted_runner_policy.py` OK (145 workflows, 181 jobs audités).
- Aucune collision : #14821/#14913 touchent le même fichier uniquement sur la baseline sorry (zones textuelles disjointes, vérifié par diff).

See #14921

