### PR TITLE
fix(notebook-tools,#14908): wsl_papermill derive le venv d'execution du kernelspec + flag --venv

### DIFF
--- a/scripts/notebook_tools/tests/test_wsl_papermill.py
+++ b/scripts/notebook_tools/tests/test_wsl_papermill.py
@@ -10,8 +10,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from wsl_papermill import (
+    _declared_venv_from_kernel_json,
     _default_mode,
+    _normalize_venv,
     _validate_output,
+    _venv_from_interpreter,
+    _venv_mismatch_message,
     batch_execute,
     check_env,
     check_env_native,
@@ -203,6 +207,95 @@ class TestCheckEnvDispatch:
 
     def test_invalid_mode(self):
         assert check_env("invalid") is False
+
+
+# --- venv derivation from kernelspec (#14908) ---
+
+
+class TestVenvFromInterpreter:
+    def test_venv_python3(self):
+        assert _venv_from_interpreter("/home/jesse/.lean4-venv/bin/python3") == "/home/jesse/.lean4-venv"
+
+    def test_venv_python(self):
+        assert _venv_from_interpreter("/home/jesse/x/bin/python") == "/home/jesse/x"
+
+    def test_system_python_none(self):
+        assert _venv_from_interpreter("/usr/bin/python3") is None
+
+    def test_bin_python_none(self):
+        assert _venv_from_interpreter("/bin/python3") is None
+
+    def test_bare_python_none(self):
+        assert _venv_from_interpreter("python3") is None
+
+    def test_none(self):
+        assert _venv_from_interpreter(None) is None
+
+
+class TestDeclaredVenvFromKernelJson:
+    def test_extracts_argv_interpreter(self):
+        kj = {"argv": ["/home/jesse/x/bin/python3", "-m", "ipykernel_launcher"]}
+        assert _declared_venv_from_kernel_json(kj) == "/home/jesse/x"
+
+    def test_bare_python_returns_none(self):
+        assert _declared_venv_from_kernel_json({"argv": ["python", "-m", "x"]}) is None
+
+    def test_empty_returns_none(self):
+        assert _declared_venv_from_kernel_json({}) is None
+
+    def test_none_returns_none(self):
+        assert _declared_venv_from_kernel_json(None) is None
+
+
+class TestNormalizeVenv:
+    def test_expands_tilde(self):
+        assert _normalize_venv("~/coursia-wsl", "/home/jesse") == "/home/jesse/coursia-wsl"
+
+    def test_strips_trailing_slash(self):
+        assert _normalize_venv("/home/jesse/coursia-wsl/", "/home/jesse") == "/home/jesse/coursia-wsl"
+
+    def test_empty_none(self):
+        assert _normalize_venv(None) == ""
+
+
+class TestVenvMismatchMessage:
+    def test_mismatch_returns_message(self):
+        msg = _venv_mismatch_message("python3-wsl", "~/coursia-wsl", "/home/jesse/.lean4-venv", "/home/jesse")
+        assert msg is not None and ".lean4-venv" in msg and "--venv" in msg
+
+    def test_same_venv_no_message(self):
+        assert _venv_mismatch_message("k", "~/coursia-wsl", "/home/jesse/coursia-wsl", "/home/jesse") is None
+
+    def test_no_declared_no_message(self):
+        assert _venv_mismatch_message("k", "~/coursia-wsl", None, "/home/jesse") is None
+
+
+class TestExecuteNotebookWslVenv:
+    def _write_nb(self, tmp_path):
+        nb = {"cells": [], "nbformat": 4}
+        p = tmp_path / "t.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        return p
+
+    def test_warns_on_declared_mismatch(self, tmp_path, capsys):
+        p = self._write_nb(tmp_path)
+        kj = {"argv": ["/home/jesse/.lean4-venv/bin/python3", "-m", "ipykernel_launcher"]}
+        with patch("wsl_papermill._find_kernel_json_wsl", return_value=kj), \
+             patch("wsl_papermill._wsl_home", return_value="/home/jesse"), \
+             patch("wsl_papermill.run_wsl", return_value=(0, "", "")):
+            rc = execute_notebook_wsl(str(p), kernel="python3-wsl")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert ".lean4-venv" in out  # divergence is printed, not silent
+
+    def test_default_venv_unchanged(self, tmp_path, capsys):
+        p = self._write_nb(tmp_path)
+        with patch("wsl_papermill._find_kernel_json_wsl", return_value=None), \
+             patch("wsl_papermill.run_wsl", return_value=(0, "", "")):
+            rc = execute_notebook_wsl(str(p), kernel="python3-wsl")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "~/coursia-wsl" in out  # default venv in use, no silent divergence
 
 
 # --- batch_execute mode propagation ---

--- a/scripts/notebook_tools/wsl_papermill.py
+++ b/scripts/notebook_tools/wsl_papermill.py
@@ -9,6 +9,14 @@ Windows-side jupyter_client cannot connect to WSL kernels because
 WSL strips backslashes from connection file paths. WSL mode runs
 papermill natively inside WSL, avoiding the cross-OS boundary entirely.
 
+The WSL execution venv is ``~/coursia-wsl`` by default. Since the kernel
+identity of a WSL kernelspec is decided by the active venv (the ``argv`` of
+the WSL kernelspecs carries a bare ``python``), a notebook declaring a kernelspec
+whose interpreter lives in another venv would silently execute in the wrong
+environment. Use ``--venv <path>`` to run in a specific venv; without it the
+tool derives the venv the notebook's kernelspec declares (from its ``kernel.json``)
+and prints a divergence warning on stdout instead of diverging silently (#14908).
+
 Prerequisites (WSL, one-time setup):
     wsl -e bash -c "python3 -m venv ~/coursia-wsl"
     wsl -e bash -c "source ~/coursia-wsl/bin/activate && pip install nashpy matplotlib papermill ipykernel scipy numpy"
@@ -19,8 +27,8 @@ Prerequisites (native macOS/Linux):
     (plus any notebook-specific dependencies: nashpy, matplotlib, numpy, scipy, etc.)
 
 Usage:
-    python wsl_papermill.py execute <notebook.ipynb> [--output <path>] [--kernel python3] [--mode auto]
-    python wsl_papermill.py batch <dir> [--pattern "*.ipynb"] [--kernel python3] [--mode auto]
+    python wsl_papermill.py execute <notebook.ipynb> [--output <path>] [--kernel python3] [--mode auto] [--venv <path>]
+    python wsl_papermill.py batch <dir> [--pattern "*.ipynb"] [--kernel python3] [--mode auto] [--venv <path>]
     python wsl_papermill.py check-env [--mode auto]
 
 Examples:
@@ -36,10 +44,9 @@ import shutil
 import subprocess
 import sys
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 WSL_VENV = "~/coursia-wsl"
-WSL_PAPERMILL_CMD = f"source {WSL_VENV}/bin/activate && papermill"
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
@@ -86,6 +93,91 @@ def run_wsl(cmd: str, timeout: int = 300) -> tuple[int, str, str]:
     return result.returncode, result.stdout, result.stderr
 
 
+# =============================================================================
+# WSL venv resolution (#14908) — derive the execution venv from the kernel spec
+# =============================================================================
+
+_WSL_KERNEL_JSON_CANDIDATES = (
+    "~/.local/share/jupyter/kernels/{name}/kernel.json",
+    "/usr/local/share/jupyter/kernels/{name}/kernel.json",
+    "/usr/share/jupyter/kernels/{name}/kernel.json",
+    "/etc/jupyter/kernels/{name}/kernel.json",
+)
+
+
+def _venv_from_interpreter(interpreter: str | None) -> str | None:
+    """Derive a venv path from a kernel interpreter path ``<venv>/bin/python3``.
+
+    Returns ``None`` for system interpreters (``/usr/bin/python3``, ``/bin/python3``)
+    and bare names (``python3``), where no venv can be inferred.
+    """
+    if not interpreter:
+        return None
+    p = PurePosixPath(interpreter)
+    if not p.name.startswith("python"):
+        return None
+    if p.parent.name != "bin":
+        return None
+    venv = p.parent.parent
+    if str(venv) in ("/", "/usr", "/usr/local"):
+        return None
+    return str(venv)
+
+
+def _declared_venv_from_kernel_json(kernel_json: dict | None) -> str | None:
+    """Extract the venv a kernel declares from its parsed ``kernel.json``."""
+    if not kernel_json or not isinstance(kernel_json, dict):
+        return None
+    argv = kernel_json.get("argv")
+    if not isinstance(argv, list) or not argv:
+        return None
+    return _venv_from_interpreter(argv[0])
+
+
+def _find_kernel_json_wsl(kernel_name: str) -> dict | None:
+    """Read the ``kernel.json`` for a kernelspec registered in WSL."""
+    for tmpl in _WSL_KERNEL_JSON_CANDIDATES:
+        path = tmpl.format(name=kernel_name)
+        rc, out, _ = run_wsl(f"cat {path} 2>/dev/null")
+        if rc == 0 and out.strip():
+            try:
+                return json.loads(out)
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def _normalize_venv(path: str | None, home: str = "") -> str:
+    """Normalize a venv path for comparison (expand ``~/``, strip trailing ``/``)."""
+    if not path:
+        return ""
+    if path.startswith("~/") and home:
+        path = home + path[1:]
+    return str(PurePosixPath(path)).rstrip("/")
+
+
+def _venv_mismatch_message(kernel: str, use_venv: str, declared_venv: str | None,
+                           home: str = "") -> str | None:
+    """One-line warning when the venv in use differs from the one the kernel declares."""
+    if not declared_venv:
+        return None
+    if _normalize_venv(use_venv, home) == _normalize_venv(declared_venv, home):
+        return None
+    return (f"[!] kernel '{kernel}' declares venv {declared_venv}; executing in "
+            f"{use_venv} -- pass --venv {declared_venv} to match")
+
+
+def _wsl_home() -> str:
+    """Return the WSL home dir (for ``~``-normalization in the venv comparison)."""
+    _, out, _ = run_wsl("echo $HOME")
+    return out.strip()
+
+
+def _papermill_cmd(venv: str) -> str:
+    """Build the WSL papermill activation command for a venv."""
+    return f"source {venv}/bin/activate && papermill"
+
+
 def check_env_wsl() -> bool:
     """Verify WSL papermill environment is set up."""
     print("Checking WSL papermill environment...")
@@ -114,8 +206,13 @@ def check_env_wsl() -> bool:
 
 def execute_notebook_wsl(notebook: str, output: str | None = None,
                          kernel: str = "python3", timeout: int = 300,
-                         in_place: bool = False) -> int:
-    """Execute a single notebook via WSL papermill."""
+                         in_place: bool = False, venv: str | None = None) -> int:
+    """Execute a single notebook via WSL papermill.
+
+    ``venv`` overrides the execution venv (default ``~/coursia-wsl``, unchanged).
+    When the kernelspec the notebook declares points to a different venv, the
+    divergence is printed on stdout instead of diverging silently (#14908).
+    """
     nb_path = Path(notebook).resolve()
     if not nb_path.exists():
         print(f"ERROR: {nb_path} not found")
@@ -130,7 +227,18 @@ def execute_notebook_wsl(notebook: str, output: str | None = None,
     else:
         wsl_output = f"/tmp/{nb_path.stem}_wsl_output.ipynb"
 
-    cmd = f'{WSL_PAPERMILL_CMD} --kernel {kernel} "{wsl_input}" "{wsl_output}"'
+    use_venv = venv or WSL_VENV
+    if _WIN_DRIVE_RE.match(use_venv):
+        use_venv = win_to_wsl_path(use_venv)
+
+    declared = _declared_venv_from_kernel_json(_find_kernel_json_wsl(kernel))
+    if declared:
+        msg = _venv_mismatch_message(kernel, use_venv, declared, _wsl_home())
+        if msg:
+            print(msg)
+    print(f"[info] venv: {use_venv}")
+
+    cmd = f'{_papermill_cmd(use_venv)} --kernel {kernel} "{wsl_input}" "{wsl_output}"'
     print(f"Executing (WSL): {nb_path.name} ...")
 
     start = time.time()
@@ -212,8 +320,12 @@ def _find_papermill() -> str | None:
 
 def execute_notebook_native(notebook: str, output: str | None = None,
                             kernel: str = "python3", timeout: int = 300,
-                            in_place: bool = False) -> int:
-    """Execute a single notebook via native papermill (macOS/Linux)."""
+                            in_place: bool = False, venv: str | None = None) -> int:
+    """Execute a single notebook via native papermill (macOS/Linux).
+
+    ``venv`` is accepted for API symmetry with the WSL path but ignored: in
+    native mode the interpreter is ``sys.executable`` (the current venv).
+    """
     nb_path = Path(notebook).resolve()
     if not nb_path.exists():
         print(f"ERROR: {nb_path} not found")
@@ -285,15 +397,16 @@ def _validate_output(nb_path: Path, elapsed: float) -> int:
 
 def execute_notebook(notebook: str, output: str | None = None,
                      kernel: str = "python3", timeout: int = 300,
-                     in_place: bool = False, mode: str = "auto") -> int:
+                     in_place: bool = False, mode: str = "auto",
+                     venv: str | None = None) -> int:
     """Execute a single notebook, dispatching to native or WSL mode."""
     if mode == "auto":
         mode = _default_mode()
 
     if mode == "wsl":
-        return execute_notebook_wsl(notebook, output, kernel, timeout, in_place)
+        return execute_notebook_wsl(notebook, output, kernel, timeout, in_place, venv)
     elif mode == "native":
-        return execute_notebook_native(notebook, output, kernel, timeout, in_place)
+        return execute_notebook_native(notebook, output, kernel, timeout, in_place, venv)
     else:
         print(f"ERROR: unknown mode '{mode}' (use 'wsl', 'native', or 'auto')")
         return 1
@@ -301,7 +414,7 @@ def execute_notebook(notebook: str, output: str | None = None,
 
 def batch_execute(directory: str, pattern: str = "*.ipynb",
                   kernel: str = "python3", timeout: int = 300,
-                  mode: str = "auto") -> int:
+                  mode: str = "auto", venv: str | None = None) -> int:
     """Execute all matching notebooks in a directory."""
     nb_dir = Path(directory).resolve()
     if not nb_dir.exists():
@@ -319,7 +432,7 @@ def batch_execute(directory: str, pattern: str = "*.ipynb",
     for i, nb in enumerate(notebooks, 1):
         print(f"\n[{i}/{len(notebooks)}] {nb.name}")
         rc = execute_notebook(str(nb), kernel=kernel, timeout=timeout,
-                              in_place=True, mode=mode)
+                              in_place=True, mode=mode, venv=venv)
         if rc == 0:
             results["ok"] += 1
         elif rc == 2:
@@ -362,6 +475,10 @@ def main():
     p_exec.add_argument("--mode", default="auto",
                         choices=["auto", "wsl", "native"],
                         help="Execution mode (default: auto-detected)")
+    p_exec.add_argument("--venv", default=None,
+                        help="WSL venv to execute in (default: ~/coursia-wsl). "
+                             "If omitted, the venv derived from the notebook's "
+                             "kernelspec is compared and a divergence is printed.")
 
     # batch
     p_batch = sub.add_parser("batch", help="Execute all notebooks in directory")
@@ -372,6 +489,10 @@ def main():
     p_batch.add_argument("--mode", default="auto",
                          choices=["auto", "wsl", "native"],
                          help="Execution mode (default: auto-detected)")
+    p_batch.add_argument("--venv", default=None,
+                        help="WSL venv to execute in (default: ~/coursia-wsl). "
+                             "If omitted, the venv derived from each notebook's "
+                             "kernelspec is compared and a divergence is printed.")
 
     # check-env
     p_check = sub.add_parser("check-env", help="Check papermill environment")
@@ -382,10 +503,10 @@ def main():
     args = parser.parse_args()
     if args.command == "execute":
         sys.exit(execute_notebook(args.notebook, args.output, args.kernel,
-                                  args.timeout, mode=args.mode))
+                                  args.timeout, mode=args.mode, venv=args.venv))
     elif args.command == "batch":
         sys.exit(batch_execute(args.directory, args.pattern, args.kernel,
-                               args.timeout, mode=args.mode))
+                               args.timeout, mode=args.mode, venv=args.venv))
     elif args.command == "check-env":
         sys.exit(0 if check_env(args.mode) else 1)
     else:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA-2 — prev: DEEP/lean #14907

## Quoi

`scripts/notebook_tools/wsl_papermill.py` figurait le venv d'execution a
`~/coursia-wsl` et ignorait le kernelspec declare par le notebook. Comme
l'identite d'un kernel WSL est decidee par le venv actif (l'`argv` des
kernelspecs WSL porte un `python` nu), un notebook declarant un kernelspec dont
l'interpreteur vit dans un autre venv (ex. `/home/jesse/.lean4-venv`) s'executait
**en silence** dans le mauvais environnement -- l'ecart evident dans #14855.

Cette PR ferme le trou (acceptations 1-3 de #14908) :

1. **`--venv <path>`** explicite (defaut inchange `~/coursia-wsl`, rien casse).
2. **Derivation** du venv depuis `metadata.kernelspec.name` : lit le `kernel.json`
   et extrait l'interpreteur de l'`argv` (`_venv_from_interpreter` /
   `_declared_venv_from_kernel_json`).
3. **Divergence imprimee** sur stdout quand le venv utilise != venv declare
   (`_venv_mismatch_message`), au lieu de diverger en silence.
4. Le venv effectif est toujours imprime (`[info] venv: ...`).

Aucune valeur de secret manipulee. Aucune preuve Lean touchee. Catalogue non touche.

## Validation (post-fix, relancee)

- **`python -m pytest scripts/notebook_tools/tests/test_wsl_papermill.py -q`** :
  **43 passed** (25 existants + **18 nouveaux** couvrant la derivation, le
  message de divergence et le chemin `execute_notebook_wsl` verse divergent).
- **Lookup `kernel.json` + derivation contre WSL reel** : kernelspec jetable
  `po2027-test` (argv -> `/home/jesse/.lean4-venv/bin/python3`) enregistre dans
  WSL, `_find_kernel_json_wsl` + `_declared_venv_from_kernel_json` rendent
  `/home/jesse/.lean4-venv`, message correct -- puis kernelspec retire.
- **CLI** : `execute --help` montre `--venv` ; `py_compile` OK ; pre-commit hook
  passe (gitleaks + garde `encoding=` subprocess, `run_wsl` deja utf-8).
- **Regressions** : changement additif uniquement (`venv` en dernier parametre
  optionnel) ; aucun appelant existant de `execute_notebook` / `batch_execute` /
  `execute_notebook_wsl` repositionne.

## Residual / verdict SOTA

Le **controle acceptance 4** (executer un notebook `python3-wsl` et verifier
`sys.executable`) exige un venv WSL provisionne pour papermill + le kernelspec
`python3-wsl`, presents sur la machine ai-01 (cf. #14908) **mais pas sur cette
machine** (WSL sans `~/coursia-wsl`, ni papermill dans les venvs existants).
Verdict : **RECOVERABLE-MACHINE** pour ce controle -- code verifie par 43 tests
unitaire + lookup WSL reel, le controle end-to-end a lancer sur ai-01.

See #14908
