### PR TITLE
fix(rules,#14872): boucle derive gitlink — ref déclarée + INJOIGNABLE

### DIFF
--- a/.claude/rules/submodule-maintenance.md
+++ b/.claude/rules/submodule-maintenance.md
@@ -30,11 +30,16 @@ Un gitlink en retard rend **invisible depuis CoursIA** du travail déjà mergé 
 cd <racine CoursIA>
 for P in $(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}'); do
   U=$(git config -f .gitmodules --get "submodule.$P.url")
+  B=$(git config -f .gitmodules --get "submodule.$P.branch" 2>/dev/null)
+  REF=${B:+refs/heads/$B}; REF=${REF:-HEAD}
   L=$(git ls-tree origin/main "$P" | awk '{print substr($3,1,12)}')
-  R=$(git ls-remote "$U" HEAD 2>/dev/null | awk '{print substr($1,1,12)}')
-  [ "$L" != "$R" ] && printf "DERIVE %-56s %s -> %s\n" "$P" "$L" "$R"
+  R=$(git ls-remote "$U" "$REF" 2>/dev/null | awk '{print substr($1,1,12)}')
+  [ -z "$R" ] && { printf "INJOIGNABLE %-56s (ref %s)\n" "$P" "$REF"; continue; }
+  [ "$L" != "$R" ] && printf "DERIVE %-56s %s -> %s (ref %s)\n" "$P" "$L" "$R" "$REF"
 done
 ```
+
+La référence de comparaison est la **branche déclarée** quand `.gitmodules` porte un `branch =` (`refs/heads/` explicite, pour ne jamais résoudre un tag homonyme), `HEAD` sinon — `HEAD` résout la branche par défaut et déclare « DERIVE » un gitlink qui est exactement sur sa branche déclarée (#14872 : faux positif permanent sur `semantic-fleet`). Et un `ls-remote` muet (ref injoignable, 403 d'org, réseau) s'affiche `INJOIGNABLE`, jamais comme une égalité — la même leçon que celle du `403` de la mesure de gate ci-dessous.
 
 **Ordre obligatoire** (déjà porté par le `CLAUDE.md` global) : commiter **dedans** d'abord, pousser, **puis** bumper le pointeur parent. Jamais l'inverse.
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/guard #14945

## Constat (#14872)

La boucle de mesure de dérive de gitlink (Règle HARD 2 de `.claude/rules/submodule-maintenance.md`) comparait chaque gitlink à `git ls-remote "$U" HEAD` — la **branche par défaut** — alors que la même règle nomme le piège deux paragraphes plus bas : `semantic-fleet` déclare `branch = stable-from-v0343`, son gitlink `9df360374e1c` est **exactement sur cette branche**, et la boucle le déclarait `DERIVE` à chaque cycle. Rouge permanent = organe éteint.

## Fix

- `REF = refs/heads/$B` quand `.gitmodules` porte un `branch =` (qualifié `refs/heads/` explicite : ne jamais résoudre un tag homonyme), `HEAD` sinon.
- `ls-remote` muet (ref injoignable, 403 d'org, réseau) → ligne `INJOIGNABLE <path> (ref <ref>)`, jamais confondu avec l'égalité — la même leçon que le `403` de la mesure de gate (R3), que la règle portait déjà pour cette boucle-ci manquait.
- Le paragraphe d'avertissement « trois références divergentes » reste inchangé (visible en contexte du diff).

## Acceptance (3 critères de l'issue, tous mesurés firsthand)

**1. Contrôle positif** — boucle actuelle (origin/main) vs boucle corrigée, exécutées côte à côte sur un worktree frais `origin/main` = `a716bc029e` :

```
AVANT (ls-remote HEAD)                                APRES (ref déclarée)
DERIVE Argumentum ceb572c8a3b9 -> 1ab6d861ace4        DERIVE Argumentum ceb572c8a3b9 -> 1ab6d861ace4 (ref HEAD)
DERIVE semantic-fleet 9df360374e1c -> 168fd5d8bef5    (semantic-fleet : aucune ligne = à jour)
```

`semantic-fleet` passe à jour (gitlink `9df360374e1c` = `refs/heads/stable-from-v0343` = `9df360374e1c`), `Argumentum` reste DERIVE — **la dérive réelle n'est pas masquée** : corriger n'a pas remplacé un faux positif par un faux négatif. Les trois autres submod (MetaGeneticSharp, Z3.Linq, Automata) restent à jour des deux côtés.

NB : le SHA droit d'Argumentum (`1ab6d861ace4`) a bougé depuis la mesure de l'issue (`2a2e7b32c139`) — l'amont avance, le gitlink `ceb572c8a3b9` est inchangé, la dérive est bien réelle et croissante.

**2. `ls-remote` muet != à jour** — chemin testé avec une ref inexistante (`refs/heads/branche-inexistante-xyz` sur l'URL semantic-fleet) : rend `INJOIGNABLE semantic-fleet (ref refs/heads/branche-inexistante-xyz)`, jamais une égalité.

**3. Paragraphe d'avertissement conservé** — inchangé dans le diff (l.41+ de la règle).

## Validation post-fix sur le livrable

La boucle a été ré-exécutée **verbatim extraite du fichier règle édité** (pas d'une copie parallèle) : rend exactement `DERIVE Argumentum ceb572c8a3b9 -> 1ab6d861ace4 (ref HEAD)` et rien d'autre. L'exit code 1 de la boucle est préexistant (idiome `[ ... ] && printf` : le dernier submod testé-faux rend non-zéro) — non introduit ici.

## Résidu nommé, hors scope (déjà porté par l'issue)

La dérive **réelle** d'`Argumentum` demande un bump de pointeur : PR dédiée soumise au gate R3, dépendante du lien montant dégradé (#14868). Non traité ici.

Closes #14872

