### PR TITLE
feat(gametheory,#12208): GT-02c Traveler's Dilemma — distillation Basu 1994 (Chantier 5)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb
@@ -5,10 +5,10 @@
    "id": "f33ea1ef",
    "metadata": {
     "papermill": {
-     "duration": 0.003194,
-     "end_time": "2026-09-06T19:03:03.163705",
+     "duration": 0.005385,
+     "end_time": "2026-09-07T02:22:25.956771+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.160511",
+     "start_time": "2026-09-07T02:22:25.951386+00:00",
      "status": "completed"
     },
     "tags": []
@@ -26,10 +26,10 @@
    "id": "c9ea0d81",
    "metadata": {
     "papermill": {
-     "duration": 0.002426,
-     "end_time": "2026-09-06T19:03:03.168699",
+     "duration": 0.003836,
+     "end_time": "2026-09-07T02:22:25.966714+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.166273",
+     "start_time": "2026-09-07T02:22:25.962878+00:00",
      "status": "completed"
     },
     "tags": []
@@ -53,10 +53,10 @@
    "id": "f08a6b8a",
    "metadata": {
     "papermill": {
-     "duration": 0.002293,
-     "end_time": "2026-09-06T19:03:03.173408",
+     "duration": 0.003886,
+     "end_time": "2026-09-07T02:22:25.975470+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.171115",
+     "start_time": "2026-09-07T02:22:25.971584+00:00",
      "status": "completed"
     },
     "tags": []
@@ -77,10 +77,10 @@
    "id": "6de64818",
    "metadata": {
     "papermill": {
-     "duration": 0.002701,
-     "end_time": "2026-09-06T19:03:03.178599",
+     "duration": 0.006185,
+     "end_time": "2026-09-07T02:22:25.985359+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.175898",
+     "start_time": "2026-09-07T02:22:25.979174+00:00",
      "status": "completed"
     },
     "tags": []
@@ -103,10 +103,10 @@
    "id": "320bea43",
    "metadata": {
     "papermill": {
-     "duration": 0.002471,
-     "end_time": "2026-09-06T19:03:03.184144",
+     "duration": 0.003643,
+     "end_time": "2026-09-07T02:22:25.994031+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.181673",
+     "start_time": "2026-09-07T02:22:25.990388+00:00",
      "status": "completed"
     },
     "tags": []
@@ -120,10 +120,10 @@
    "id": "98a7c129",
    "metadata": {
     "papermill": {
-     "duration": 0.004332,
-     "end_time": "2026-09-06T19:03:03.191062",
+     "duration": 0.0049,
+     "end_time": "2026-09-07T02:22:26.003218+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.186730",
+     "start_time": "2026-09-07T02:22:25.998318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -149,10 +149,10 @@
    "id": "f9c23f5b",
    "metadata": {
     "papermill": {
-     "duration": 0.002666,
-     "end_time": "2026-09-06T19:03:03.196425",
+     "duration": 0.004834,
+     "end_time": "2026-09-07T02:22:26.010564+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.193759",
+     "start_time": "2026-09-07T02:22:26.005730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -167,16 +167,16 @@
    "id": "2afb149c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:03.205074Z",
-     "iopub.status.busy": "2026-09-06T19:03:03.204802Z",
-     "iopub.status.idle": "2026-09-06T19:03:03.693386Z",
-     "shell.execute_reply": "2026-09-06T19:03:03.692873Z"
+     "iopub.execute_input": "2026-09-07T02:22:26.020943Z",
+     "iopub.status.busy": "2026-09-07T02:22:26.020943Z",
+     "iopub.status.idle": "2026-09-07T02:22:27.767009Z",
+     "shell.execute_reply": "2026-09-07T02:22:27.767009Z"
     },
     "papermill": {
-     "duration": 0.494665,
-     "end_time": "2026-09-06T19:03:03.694651",
+     "duration": 1.753927,
+     "end_time": "2026-09-07T02:22:27.769075+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.199986",
+     "start_time": "2026-09-07T02:22:26.015148+00:00",
      "status": "completed"
     },
     "tags": []
@@ -224,10 +224,10 @@
    "id": "3c356459",
    "metadata": {
     "papermill": {
-     "duration": 0.003385,
-     "end_time": "2026-09-06T19:03:03.701019",
+     "duration": 0.001949,
+     "end_time": "2026-09-07T02:22:27.773265+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.697634",
+     "start_time": "2026-09-07T02:22:27.771316+00:00",
      "status": "completed"
     },
     "tags": []
@@ -243,10 +243,10 @@
    "id": "cfa312b9",
    "metadata": {
     "papermill": {
-     "duration": 0.005955,
-     "end_time": "2026-09-06T19:03:03.710455",
+     "duration": 0.003233,
+     "end_time": "2026-09-07T02:22:27.778564+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.704500",
+     "start_time": "2026-09-07T02:22:27.775331+00:00",
      "status": "completed"
     },
     "tags": []
@@ -260,10 +260,10 @@
    "id": "27e6b87a",
    "metadata": {
     "papermill": {
-     "duration": 0.002747,
-     "end_time": "2026-09-06T19:03:03.718520",
+     "duration": 0.00415,
+     "end_time": "2026-09-07T02:22:27.785091+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.715773",
+     "start_time": "2026-09-07T02:22:27.780941+00:00",
      "status": "completed"
     },
     "tags": []
@@ -280,16 +280,16 @@
    "id": "6258e8cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:03.725500Z",
-     "iopub.status.busy": "2026-09-06T19:03:03.725124Z",
-     "iopub.status.idle": "2026-09-06T19:03:03.730140Z",
-     "shell.execute_reply": "2026-09-06T19:03:03.729642Z"
+     "iopub.execute_input": "2026-09-07T02:22:27.794714Z",
+     "iopub.status.busy": "2026-09-07T02:22:27.794185Z",
+     "iopub.status.idle": "2026-09-07T02:22:27.813890Z",
+     "shell.execute_reply": "2026-09-07T02:22:27.812384Z"
     },
     "papermill": {
-     "duration": 0.010391,
-     "end_time": "2026-09-06T19:03:03.731574",
+     "duration": 0.025411,
+     "end_time": "2026-09-07T02:22:27.814949+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.721183",
+     "start_time": "2026-09-07T02:22:27.789538+00:00",
      "status": "completed"
     },
     "tags": []
@@ -324,10 +324,10 @@
    "id": "a10d0120",
    "metadata": {
     "papermill": {
-     "duration": 0.002288,
-     "end_time": "2026-09-06T19:03:03.737984",
+     "duration": 0.00345,
+     "end_time": "2026-09-07T02:22:27.822304+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.735696",
+     "start_time": "2026-09-07T02:22:27.818854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -343,10 +343,10 @@
    "id": "c3c487f4",
    "metadata": {
     "papermill": {
-     "duration": 0.0031,
-     "end_time": "2026-09-06T19:03:03.743714",
+     "duration": 0.003899,
+     "end_time": "2026-09-07T02:22:27.830274+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.740614",
+     "start_time": "2026-09-07T02:22:27.826375+00:00",
      "status": "completed"
     },
     "tags": []
@@ -360,10 +360,10 @@
    "id": "cffe927f",
    "metadata": {
     "papermill": {
-     "duration": 0.002965,
-     "end_time": "2026-09-06T19:03:03.749624",
+     "duration": 0.002187,
+     "end_time": "2026-09-07T02:22:27.834743+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.746659",
+     "start_time": "2026-09-07T02:22:27.832556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -380,16 +380,16 @@
    "id": "ca1211dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:03.757634Z",
-     "iopub.status.busy": "2026-09-06T19:03:03.757393Z",
-     "iopub.status.idle": "2026-09-06T19:03:03.829244Z",
-     "shell.execute_reply": "2026-09-06T19:03:03.828706Z"
+     "iopub.execute_input": "2026-09-07T02:22:27.846169Z",
+     "iopub.status.busy": "2026-09-07T02:22:27.845642Z",
+     "iopub.status.idle": "2026-09-07T02:22:27.995437Z",
+     "shell.execute_reply": "2026-09-07T02:22:27.994826Z"
     },
     "papermill": {
-     "duration": 0.078938,
-     "end_time": "2026-09-06T19:03:03.831125",
+     "duration": 0.157388,
+     "end_time": "2026-09-07T02:22:27.997061+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.752187",
+     "start_time": "2026-09-07T02:22:27.839673+00:00",
      "status": "completed"
     },
     "tags": []
@@ -449,10 +449,10 @@
    "id": "ae570cfb",
    "metadata": {
     "papermill": {
-     "duration": 0.002656,
-     "end_time": "2026-09-06T19:03:03.839471",
+     "duration": 0.003605,
+     "end_time": "2026-09-07T02:22:28.003971+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.836815",
+     "start_time": "2026-09-07T02:22:28.000366+00:00",
      "status": "completed"
     },
     "tags": []
@@ -468,10 +468,10 @@
    "id": "17f2bce5",
    "metadata": {
     "papermill": {
-     "duration": 0.003638,
-     "end_time": "2026-09-06T19:03:03.846369",
+     "duration": 0.003854,
+     "end_time": "2026-09-07T02:22:28.011579+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.842731",
+     "start_time": "2026-09-07T02:22:28.007725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -485,10 +485,10 @@
    "id": "fda1d303",
    "metadata": {
     "papermill": {
-     "duration": 0.004092,
-     "end_time": "2026-09-06T19:03:03.852889",
+     "duration": 0.003182,
+     "end_time": "2026-09-07T02:22:28.019965+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.848797",
+     "start_time": "2026-09-07T02:22:28.016783+00:00",
      "status": "completed"
     },
     "tags": []
@@ -496,7 +496,7 @@
    "source": [
     "### Le paradoxe dépend de $r$\n",
     "\n",
-    "Le raisonnement d'élimination ci-dessus tient pour **tout** $r > 0$. Mais l'expérience — humaine et expérimentale — montre que les gens jouent haut **quand $r$ est petit** et bas **quand $r$ est grand**. Le paradoxe n'est pas un fait : c'est une fonction de $r$.\n",
+    "Le raisonnement d'élimination ci-dessus ne tient pas pour tout $r$ : il exige **$r \\ge 1$**. Comparer la plus haute réclamation $k$ à $k-1$ face à un adversaire qui réclame lui aussi $k$ donne $k-1+r$ contre $k$ — le sous-cotage ne rapporte qu'à partir de $r = 1$. La table du §4 ci-dessous le mesure : $r = 0{,}5$ n'atteint pas le plancher, $r = 1$ si. Mais l'expérience — humaine et expérimentale — montre que les gens jouent haut **quand $r$ est petit** et bas **quand $r$ est grand**. Le paradoxe n'est pas un fait : c'est une fonction de $r$.\n",
     "\n",
     "On mesure la différence entre l'équilibre théorique (2) et la prédiction « naïve » qu'un joueur stratégiquement **superficiel** ferait : viser le maximum $\\bar c$, puisqu'il s'agit avant tout de capter le bonus."
    ]
@@ -507,16 +507,16 @@
    "id": "f0c1eb83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:03.861676Z",
-     "iopub.status.busy": "2026-09-06T19:03:03.861375Z",
-     "iopub.status.idle": "2026-09-06T19:03:04.288466Z",
-     "shell.execute_reply": "2026-09-06T19:03:04.287494Z"
+     "iopub.execute_input": "2026-09-07T02:22:28.027855Z",
+     "iopub.status.busy": "2026-09-07T02:22:28.026847Z",
+     "iopub.status.idle": "2026-09-07T02:22:28.665533Z",
+     "shell.execute_reply": "2026-09-07T02:22:28.664529Z"
     },
     "papermill": {
-     "duration": 0.432307,
-     "end_time": "2026-09-06T19:03:04.289645",
+     "duration": 0.644421,
+     "end_time": "2026-09-07T02:22:28.666840+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:03.857338",
+     "start_time": "2026-09-07T02:22:28.022419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -527,13 +527,7 @@
      "output_type": "stream",
      "text": [
       "  r  |  gain de sous-cotage (r-1)  |  la spirale atteint (2,2) ?\n",
-      " 0.5 |     -0.5 | NON\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      " 0.5 |     -0.5 | NON\n",
       " 1.0 |      0.0 | OUI\n"
      ]
     },
@@ -541,7 +535,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1.5 |      0.5 | OUI\n",
+      " 1.5 |      0.5 | OUI\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       " 2.0 |      1.0 | OUI\n"
      ]
     },
@@ -617,10 +617,10 @@
    "id": "a07e5d3e",
    "metadata": {
     "papermill": {
-     "duration": 0.004623,
-     "end_time": "2026-09-06T19:03:04.299207",
+     "duration": 0.002894,
+     "end_time": "2026-09-07T02:22:28.674140+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.294584",
+     "start_time": "2026-09-07T02:22:28.671246+00:00",
      "status": "completed"
     },
     "tags": []
@@ -641,10 +641,10 @@
    "id": "24237143",
    "metadata": {
     "papermill": {
-     "duration": 0.004749,
-     "end_time": "2026-09-06T19:03:04.308860",
+     "duration": 0.003772,
+     "end_time": "2026-09-07T02:22:28.680449+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.304111",
+     "start_time": "2026-09-07T02:22:28.676677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -658,10 +658,10 @@
    "id": "ceb12d11",
    "metadata": {
     "papermill": {
-     "duration": 0.004376,
-     "end_time": "2026-09-06T19:03:04.317565",
+     "duration": 0.002983,
+     "end_time": "2026-09-07T02:22:28.687366+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.313189",
+     "start_time": "2026-09-07T02:22:28.684383+00:00",
      "status": "completed"
     },
     "tags": []
@@ -671,8 +671,7 @@
     "\n",
     "L'énoncé exact — « l'équilibre de Nash est (2,2) » — est **vrai**, mais il n'implique **pas** que des joueurs humains le choisissent. Le contre-claim ici n'est pas de contredire le théorème, mais de **délimiter sa portée** : ce que l'élimination itérée *prouve* (un équilibre unique) est distinct de ce qu'elle *prédit* (le comportement). L'écart est exhibé quand on relâche l'hypothèse de rationalité parfaite et de connaissance commune.\n",
     "\n",
-    "On le montre en simulant un **jeu où un joueur n'est pas certain** que l'autre descend au plancher : s'il existe une probabilité $\u000b\n",
-    "arepsilon$ que l'autre « grimpe », le meilleur-pari pour le joueur prudent devient de **grimper** — et l'équilibre (2,2) cesse d'être un point stable de la dynamique d'adaptation."
+    "On le montre en simulant un **jeu où un joueur n'est pas certain** que l'autre descend au plancher : s'il existe une probabilité $\\varepsilon$ que l'autre « grimpe », le meilleur-pari pour le joueur prudent devient de **grimper** — et l'équilibre (2,2) cesse d'être un point stable de la dynamique d'adaptation."
    ]
   },
   {
@@ -681,16 +680,16 @@
    "id": "fc69c01e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:04.327966Z",
-     "iopub.status.busy": "2026-09-06T19:03:04.327560Z",
-     "iopub.status.idle": "2026-09-06T19:03:04.336283Z",
-     "shell.execute_reply": "2026-09-06T19:03:04.335687Z"
+     "iopub.execute_input": "2026-09-07T02:22:28.697673Z",
+     "iopub.status.busy": "2026-09-07T02:22:28.697673Z",
+     "iopub.status.idle": "2026-09-07T02:22:28.711751Z",
+     "shell.execute_reply": "2026-09-07T02:22:28.711121Z"
     },
     "papermill": {
-     "duration": 0.015642,
-     "end_time": "2026-09-06T19:03:04.337752",
+     "duration": 0.021163,
+     "end_time": "2026-09-07T02:22:28.713305+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.322110",
+     "start_time": "2026-09-07T02:22:28.692142+00:00",
      "status": "completed"
     },
     "tags": []
@@ -741,10 +740,10 @@
    "id": "ad38e84f",
    "metadata": {
     "papermill": {
-     "duration": 0.004312,
-     "end_time": "2026-09-06T19:03:04.347854",
+     "duration": 0.002891,
+     "end_time": "2026-09-07T02:22:28.720619+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.343542",
+     "start_time": "2026-09-07T02:22:28.717728+00:00",
      "status": "completed"
     },
     "tags": []
@@ -752,8 +751,7 @@
    "source": [
     "### Verdict du contre-claim\n",
     "\n",
-    "Le contre-claim n'est pas « le théorème est faux » — il est **vrai**. Le contre-claim est : **l'équilibre de l'élimination itérée n'est pas une prédiction comportementale**. Il ne tient que sous connaissance commune de la rationalité. Dès qu'une probabilité $\u000b\n",
-    "arepsilon>0$ de « grimper » entre, la meilleure réponse du joueur prudent saute vers le haut (la simulation ci-dessus l'exhibe) — donc (2,2) est un équilibre *fragile*, pas un attracteur. C'est exactement la leçon que le notebook de distillation devait faire émerger, et qui nourrit l'expérience ICT candidate (voir §6)."
+    "Le contre-claim n'est pas « le théorème est faux » — il est **vrai**. Le contre-claim est : **l'équilibre de l'élimination itérée n'est pas une prédiction comportementale**. Il ne tient que sous connaissance commune de la rationalité. Dès qu'une probabilité $\\varepsilon>0$ de « grimper » entre, la meilleure réponse du joueur prudent saute vers le haut (la simulation ci-dessus l'exhibe) — donc (2,2) est un équilibre *fragile*, pas un attracteur. C'est exactement la leçon que le notebook de distillation devait faire émerger, et qui nourrit l'expérience ICT candidate (voir §6)."
    ]
   },
   {
@@ -761,10 +759,10 @@
    "id": "131c648d",
    "metadata": {
     "papermill": {
-     "duration": 0.004607,
-     "end_time": "2026-09-06T19:03:04.357105",
+     "duration": 0.004568,
+     "end_time": "2026-09-07T02:22:28.728319+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.352498",
+     "start_time": "2026-09-07T02:22:28.723751+00:00",
      "status": "completed"
     },
     "tags": []
@@ -772,7 +770,7 @@
    "source": [
     "## 6. Exercices (3) — à compléter par l'étudiant\n",
     "\n",
-    "Les trois exercices ci-dessous sont des stubs **C.1** (ils s'exécutent sans erreur, mais laissent le raisonnement à l'étudiant). Contenu réel à produire, jamais une valeur fabriquée.\""
+    "Les trois exercices ci-dessous sont des stubs **C.1** (ils s'exécutent sans erreur, mais laissent le raisonnement à l'étudiant). Contenu réel à produire, jamais une valeur fabriquée.\n"
    ]
   },
   {
@@ -781,16 +779,16 @@
    "id": "71b175da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:04.367841Z",
-     "iopub.status.busy": "2026-09-06T19:03:04.367323Z",
-     "iopub.status.idle": "2026-09-06T19:03:04.373570Z",
-     "shell.execute_reply": "2026-09-06T19:03:04.372795Z"
+     "iopub.execute_input": "2026-09-07T02:22:28.736966Z",
+     "iopub.status.busy": "2026-09-07T02:22:28.736966Z",
+     "iopub.status.idle": "2026-09-07T02:22:28.742131Z",
+     "shell.execute_reply": "2026-09-07T02:22:28.741522Z"
     },
     "papermill": {
-     "duration": 0.012782,
-     "end_time": "2026-09-06T19:03:04.374680",
+     "duration": 0.010841,
+     "end_time": "2026-09-07T02:22:28.743547+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.361898",
+     "start_time": "2026-09-07T02:22:28.732706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -800,32 +798,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "u1(2,2)  = 2   ([2,2] = paiement du plancher)\n",
-      "u1(100,100) = 100   ([100,100] = egalite au plafond)\n",
-      "Verdict : le plafond rapporte plus aux deux\n"
+      "r=  0.5 :: coordination_possible -> Exercice a completer\n",
+      "r=  2.0 :: coordination_possible -> Exercice a completer\n",
+      "r= 25.0 :: coordination_possible -> Exercice a completer\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 : Transformer le jeu en jeu de coordination\n",
-    "# Objectif : montrer que le Dilemme des Voyageurs est ANTAGONISTE par nature.\n",
-    "# Verifiez que le paiement de (x, y) et de (y, x) se comportent en miroir.\n",
-    "# Question : pour quelles valeurs de r le gestion (x=50, y=50) est-elle meilleure\n",
-    "#            que (x=2, y=2) pour les DEUX joueurs a la fois ? Repondez en code.\n",
+    "# Exercice 1 : le jeu est-il antagoniste, ou peut-il devenir un jeu de coordination ?\n",
+    "# Question : existe-t-il une reclamation COMMUNE x > 2 qui rapporte strictement plus\n",
+    "#            que le plancher (2,2) aux DEUX joueurs a la fois ? Le verdict change-t-il\n",
+    "#            avec r ?\n",
+    "# Indice : sur la diagonale x = y, bonus et penalite s'annulent.\n",
     "\n",
-    "def coordination_possible(r: float = 2.0, c_max: int = C_MAX) -> bool:\n",
-    "    \"\"\"Retourne True s'il existe x common > C_MIN tel que u1(x,x,r) > u1(2,2,r).\"\"\"\n",
-    "    # --- TODO etudiant : completer le calcul ---\n",
-    "    equal_2 = u1(C_MIN, C_MIN, r)  # paiement a (2,2)\n",
-    "    for x in range(C_MIN + 1, c_max + 1):\n",
-    "        if u1(x, x, r) > equal_2:  # Test : egalite commune batt-elle le plancher ?\n",
-    "            return True            # (a completer : la condition exacte)\n",
-    "    return False  # --- TODO etudiant : completer la condition reelle (C.1) ---\n",
+    "def coordination_possible(r: float = 2.0, c_max: int = C_MAX):\n",
+    "    \"\"\"Existe-t-il x dans ]C_MIN, c_max] tel que u1(x, x, r) > u1(C_MIN, C_MIN, r) ?\n",
     "\n",
-    "# Exemple verifie : rappeler le paiement en (2,2) et (100,100) pour r=2\n",
-    "print(\"u1(2,2)  =\", u1(2, 2, r=2), \"  ([2,2] = paiement du plancher)\")\n",
-    "print(\"u1(100,100) =\", u1(100, 100, r=2), \"  ([100,100] = egalite au plafond)\")\n",
-    "print(\"Verdict :\", \"le plafond rapporte plus aux deux\" if u1(100,100,r=2) > u1(2,2,r=2) else \"le plancher rapporte plus\")"
+    "    Renvoyer True ou False. Tant que l'exercice n'est pas traite, la fonction\n",
+    "    renvoie None et l'appel ci-dessous l'annonce sans lever d'erreur (regle C.1).\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : parcourir x de C_MIN + 1 a c_max, comparer u1(x, x, r) au\n",
+    "    #                 paiement du plancher u1(C_MIN, C_MIN, r), renvoyer le verdict.\n",
+    "    return None\n",
+    "\n",
+    "for r_test in [0.5, 2.0, 25.0]:\n",
+    "    verdict = coordination_possible(r_test)\n",
+    "    print(f\"r={r_test:>5.1f} :: coordination_possible ->\",\n",
+    "          \"Exercice a completer\" if verdict is None else verdict)"
    ]
   },
   {
@@ -833,10 +832,10 @@
    "id": "895c4edd",
    "metadata": {
     "papermill": {
-     "duration": 0.004313,
-     "end_time": "2026-09-06T19:03:04.383090",
+     "duration": 0.003495,
+     "end_time": "2026-09-07T02:22:28.751886+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.378777",
+     "start_time": "2026-09-07T02:22:28.748391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -844,7 +843,7 @@
    "source": [
     "### Exercice 2 — le seuil de dissolution du paradoxe\n",
     "\n",
-    "Cherchez la valeur de $r$ au-delà de laquelle « jouer le plafond » (l'égalité au maximum) rapporte **strictement plus** que « jouer le plancher » — c'est-à-dire quand $\\bar c - 2r$ ... non, en fait comparez $u_1(\\bar c,\\bar c) = \\bar c$ et $u_1(2,2) = 2$. Que se passe-t-il quand $r$ change ? La réponse indépendante de $r$ est la clé.\""
+    "Cherchez la valeur de $r$ au-delà de laquelle « jouer le plafond » (l'égalité au maximum) rapporte **strictement plus** que « jouer le plancher » — comparez $u_1(\\bar c,\\bar c)$ et $u_1(2,2)$, puis dites si le verdict dépend de $r$. Justifiez à partir de la définition de $u_1$ sur la diagonale $x = y$.\n"
    ]
   },
   {
@@ -853,16 +852,16 @@
    "id": "f79012d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:04.393484Z",
-     "iopub.status.busy": "2026-09-06T19:03:04.393128Z",
-     "iopub.status.idle": "2026-09-06T19:03:04.397132Z",
-     "shell.execute_reply": "2026-09-06T19:03:04.396603Z"
+     "iopub.execute_input": "2026-09-07T02:22:28.760157Z",
+     "iopub.status.busy": "2026-09-07T02:22:28.759158Z",
+     "iopub.status.idle": "2026-09-07T02:22:28.774553Z",
+     "shell.execute_reply": "2026-09-07T02:22:28.773439Z"
     },
     "papermill": {
-     "duration": 0.010517,
-     "end_time": "2026-09-06T19:03:04.398143",
+     "duration": 0.02121,
+     "end_time": "2026-09-07T02:22:28.775939+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.387626",
+     "start_time": "2026-09-07T02:22:28.754729+00:00",
      "status": "completed"
     },
     "tags": []
@@ -872,26 +871,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "r=  0.5 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n",
-      "r=  2.0 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n",
-      "r= 10.0 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n",
-      "r= 50.0 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n"
+      "r=  0.5 :: plafond_bat_plancher -> Exercice a completer\n",
+      "r=  2.0 :: plafond_bat_plancher -> Exercice a completer\n",
+      "r= 10.0 :: plafond_bat_plancher -> Exercice a completer\n",
+      "r= 50.0 :: plafond_bat_plancher -> Exercice a completer\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : le seuil de dissolution\n",
-    "# Question : est-ce que l'egalite au plafond (100,100) bat toujours l'egalite au\n",
-    "# plancher (2,2), quel que soit r ? (Reponse courte : oui, car u = c_max pour les deux)\n",
-    "# Verifiez-le, puis discutez pourquoi le paradoxe semble alors disparaitre.\n",
+    "# Exercice 2 : le plafond bat-il le plancher, et cela depend-il de r ?\n",
+    "# Question : l'egalite au plafond (c_max, c_max) rapporte-t-elle strictement plus que\n",
+    "#            l'egalite au plancher (2, 2) ? Ecrivez la comparaison, puis expliquez en\n",
+    "#            une phrase pourquoi r n'apparait pas dans le resultat.\n",
     "\n",
-    "def plafond_bat_plancher(r: float = 2.0, c_max: int = C_MAX) -> bool:\n",
-    "    \"\"\"L'egalite au plafond (c_max) rapporte-t-elle plus que l'egalite au plancher (2) ?\"\"\"\n",
-    "    # --- TODO etudiant : completer ---\n",
-    "    return u1(c_max, c_max, r) > u1(C_MIN, C_MIN, r)  # (a verifier pour tout r)\n",
+    "def plafond_bat_plancher(r: float = 2.0, c_max: int = C_MAX):\n",
+    "    \"\"\"u1(c_max, c_max, r) > u1(C_MIN, C_MIN, r) ? (None tant que non traite)\"\"\"\n",
+    "    # TODO etudiant : ecrire la comparaison des deux paiements diagonaux.\n",
+    "    return None\n",
     "\n",
-    "for r in [0.5, 2.0, 10.0, 50.0]:\n",
-    "    print(f\"r={r:>5.1f} | plafond(100,100)={u1(100,100,r):>6} | plancher(2,2)={u1(2,2,r):>4} | plafond bat ? {plafond_bat_plancher(r)}\")"
+    "for r_test in [0.5, 2.0, 10.0, 50.0]:\n",
+    "    verdict = plafond_bat_plancher(r_test)\n",
+    "    print(f\"r={r_test:>5.1f} :: plafond_bat_plancher ->\",\n",
+    "          \"Exercice a completer\" if verdict is None else verdict)"
    ]
   },
   {
@@ -899,10 +900,10 @@
    "id": "10d16727",
    "metadata": {
     "papermill": {
-     "duration": 0.002688,
-     "end_time": "2026-09-06T19:03:04.403882",
+     "duration": 0.002217,
+     "end_time": "2026-09-07T02:22:28.781796+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.401194",
+     "start_time": "2026-09-07T02:22:28.779579+00:00",
      "status": "completed"
     },
     "tags": []
@@ -910,8 +911,7 @@
    "source": [
     "### Exercice 3 — le coût de l'optimisme\n",
     "\n",
-    "Reprenez le calcul de l'espérance du §5 et trouvez la **valeur de $\u000b\n",
-    "arepsilon$** à partir de laquelle la meilleure réponse d'un joueur prudent passe du plancher (2) à un montant **strictement supérieur à 2**. C'est le « seuil de bascule » de la confiance.\""
+    "Reprenez le calcul de l'espérance du §5 et trouvez la **valeur de $\\varepsilon$** à partir de laquelle la meilleure réponse d'un joueur prudent passe du plancher (2) à un montant **strictement supérieur à 2**. C'est le « seuil de bascule » de la confiance.\n"
    ]
   },
   {
@@ -920,16 +920,16 @@
    "id": "a1ac1133",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-06T19:03:04.412183Z",
-     "iopub.status.busy": "2026-09-06T19:03:04.411862Z",
-     "iopub.status.idle": "2026-09-06T19:03:04.423140Z",
-     "shell.execute_reply": "2026-09-06T19:03:04.422543Z"
+     "iopub.execute_input": "2026-09-07T02:22:28.790573Z",
+     "iopub.status.busy": "2026-09-07T02:22:28.790044Z",
+     "iopub.status.idle": "2026-09-07T02:22:28.806434Z",
+     "shell.execute_reply": "2026-09-07T02:22:28.805427Z"
     },
     "papermill": {
-     "duration": 0.016486,
-     "end_time": "2026-09-06T19:03:04.424235",
+     "duration": 0.023472,
+     "end_time": "2026-09-07T02:22:28.807792+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.407749",
+     "start_time": "2026-09-07T02:22:28.784320+00:00",
      "status": "completed"
     },
     "tags": []
@@ -939,29 +939,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Seuil de bascule eps* = 0.03  -> au-dela, un joueur prudent grimpe.\n",
-      "Analyse : le plancher (2,2) est donc un equilibre POSITIFEMENT mesure pour eps > eps*.\n"
+      "Exercice a completer : seuil de bascule eps* non determine.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : seuil de bascule de la confiance\n",
-    "# Objectif : determiner la valeur de epsilon pour laquelle la meilleure reponse\n",
-    "# d'un joueur prudent SAUTE au-dessus du plancher.\n",
+    "# Exercice 3 : le seuil de bascule de la confiance\n",
+    "# Objectif : trouver la plus petite probabilite eps de \"grimper\" chez l'adversaire pour\n",
+    "#            laquelle la meilleure reponse d'un joueur prudent QUITTE le plancher C_MIN.\n",
+    "# Indice : reutilisez aggregate_BE du paragraphe 5 et la distribution qui y est\n",
+    "#          construite ((C_MIN, 1 - eps), puis une queue uniforme sur [c_max // 2, c_max]).\n",
     "\n",
-    "def seuil_bascule(c_max: int = C_MAX, r: float = 2.0) -> float:\n",
-    "    \"\"\"Retourne la plus petite valeur de eps pour laquelle la meilleure reponse\n",
-    "    stricte depasse le plancher C_MIN.\"\"\"\n",
-    "    from numpy import arange\n",
-    "    for eps in arange(0.0, 1.0, 0.005):\n",
-    "        dist = [(C_MIN, 1 - eps)] + [(y, eps / (c_max // 2 + 1)) for y in range(c_max // 2, c_max + 1)]\n",
-    "        if aggregate_BE(dist, r, c_max) > C_MIN:\n",
-    "            return round(eps, 3)\n",
+    "def seuil_bascule(c_max: int = C_MAX, r: float = 2.0):\n",
+    "    \"\"\"Plus petit eps tel que aggregate_BE(dist(eps), r, c_max) > C_MIN.\n",
+    "\n",
+    "    Renvoyer un flottant, ou None si aucun eps du balayage ne fait basculer la\n",
+    "    meilleure reponse. Tant que l'exercice n'est pas traite, renvoie None (C.1).\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : balayer eps par pas fin sur [0, 1[, construire la distribution\n",
+    "    #                 du paragraphe 5, renvoyer le premier eps qui fait sauter la\n",
+    "    #                 meilleure reponse au-dessus du plancher.\n",
     "    return None\n",
     "\n",
     "s = seuil_bascule()\n",
-    "print(\"Seuil de bascule eps* =\", s, \" -> au-dela, un joueur prudent grimpe.\")\n",
-    "print(\"Analyse : le plancher (2,2) est donc un equilibre POSITIFEMENT mesure pour eps > eps*.\")"
+    "if s is None:\n",
+    "    print(\"Exercice a completer : seuil de bascule eps* non determine.\")\n",
+    "else:\n",
+    "    print(\"Seuil de bascule eps* =\", s)\n",
+    "    print(\"Lecture attendue : au-dela de eps*, la meilleure reponse quitte le plancher —\")\n",
+    "    print(\"(2,2) cesse donc d'etre la meilleure reponse d'un joueur prudent.\")"
    ]
   },
   {
@@ -969,10 +975,10 @@
    "id": "46982c9b",
    "metadata": {
     "papermill": {
-     "duration": 0.005153,
-     "end_time": "2026-09-06T19:03:04.434746",
+     "duration": 0.004627,
+     "end_time": "2026-09-07T02:22:28.816822+00:00",
      "exception": false,
-     "start_time": "2026-09-06T19:03:04.429593",
+     "start_time": "2026-09-07T02:22:28.812195+00:00",
      "status": "completed"
     },
     "tags": []
@@ -982,13 +988,12 @@
     "\n",
     "* **L'objet formel** : un jeu à deux joueurs à stratégies bornées $[2,\\bar c]$, paiement $\\min(x,y)$ plus bonus $r$ au plus petit / pénalité $r$ au plus grand.\n",
     "* **Le claim exact** : l'élimination itérée des stratégies strictement dominées laisse l'unique équilibre $(2,2)$.\n",
-    "* **Le contre-claim** : cet équilibre n'est pas une prédiction comportementale — il ne tient que sous connaissance commune de la rationalité. Une probabilité $\u000b\n",
-    "arepsilon>0$ de jouer haut fait sauter la meilleure réponse vers le plafond.\n",
+    "* **Le contre-claim** : cet équilibre n'est pas une prédiction comportementale — il ne tient que sous connaissance commune de la rationalité. Une probabilité $\\varepsilon>0$ de jouer haut fait sauter la meilleure réponse vers le plafond.\n",
     "* **Le seuil** : le paradoxe se dissout quand $r$ devient grand ; il n'est paradoxal que pour $r$ petit.\n",
     "\n",
     "> **Expérience ICT candidate** : mesurer en TP le taux de « montée » (réclamation > 50) pour $r=2$ vs $r=25$, et confronter à la courbe bascule de l'exercice 3 — c'est un test falsifiable du contre-claim.\n",
     "\n",
-    "> **Notebook précédent** : [GameTheory-28-Humour-Banc](GameTheory-28-Humour-Banc.ipynb) · **Série** : [GameTheory](README.md)"
+    "> **Palier parent** : [GameTheory-02-NormalForm](GameTheory-02-NormalForm.ipynb) (forme normale, dominance, élimination itérée) · **Sibling** : [GameTheory-02b-Lean-Definitions](GameTheory-02b-Lean-Definitions.ipynb) · **Série** : [GameTheory](README.md)"
    ]
   }
  ],
@@ -1008,15 +1013,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
-   "duration": 6.673817,
-   "end_time": "2026-09-06T19:03:07.957720",
+   "duration": 6.205621,
+   "end_time": "2026-09-07T02:22:29.164417+00:00",
    "exception": null,
    "input_path": "GameTheory-02c-Travelers-Dilemma.ipynb",
    "output_path": "GameTheory-02c-Travelers-Dilemma.ipynb",
-   "start_time": "2026-09-06T19:03:01.283903"
+   "start_time": "2026-09-07T02:22:22.958796+00:00"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb
@@ -14,13 +14,11 @@
     "tags": []
    },
    "source": [
-    "# GameTheory-29-Travelers-Dilemma\n",
+    "# GameTheory-02c-Travelers-Dilemma\n",
     "\n",
-    "> **Navigation** : [Notebooks](../) | [Série GameTheory](README.md)\n",
+    "> **Navigation** : [Notebooks](../) | [Série GameTheory](README.md) | [<< 2-NormalForm (palier parent)](GameTheory-02-NormalForm.ipynb) | [2b - Définitions Lean](GameTheory-02b-Lean-Definitions.ipynb)\n",
     "\n",
-    "> **Série** : GameTheory-29-Travelers-Dilemma — le Dilemme des Voyageurs de Basu (1994)\n",
-    "\n",
-    "Grain DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-dotnet #14918 (Chantier 5, sous-grain de #12208)"
+    "> **Série** : GameTheory-02c-Travelers-Dilemma — accrétion du palier 02 (forme normale, dominance, élimination itérée) : le Dilemme des Voyageurs de Basu (1994)\n"
    ]
   },
   {
@@ -1016,8 +1014,8 @@
    "duration": 6.673817,
    "end_time": "2026-09-06T19:03:07.957720",
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb",
+   "input_path": "GameTheory-02c-Travelers-Dilemma.ipynb",
+   "output_path": "GameTheory-02c-Travelers-Dilemma.ipynb",
    "start_time": "2026-09-06T19:03:01.283903"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb
@@ -652,7 +652,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Le contre-claim : l'équilibre de l'EEI est réel, mais il n'est pas la prédiction comportementale"
+    "## 5. Le contre-claim : l'équilibre de l'EEI est réel, mais il n'est pas la prédiction comportementale\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb
@@ -1,0 +1,1026 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f33ea1ef",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003194,
+     "end_time": "2026-09-06T19:03:03.163705",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.160511",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-29-Travelers-Dilemma\n",
+    "\n",
+    "> **Navigation** : [Notebooks](../) | [Série GameTheory](README.md)\n",
+    "\n",
+    "> **Série** : GameTheory-29-Travelers-Dilemma — le Dilemme des Voyageurs de Basu (1994)\n",
+    "\n",
+    "Grain DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-dotnet #14918 (Chantier 5, sous-grain de #12208)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9ea0d81",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002426,
+     "end_time": "2026-09-06T19:03:03.168699",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.166273",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le paradigme : un accident de compagnie aérienne\n",
+    "\n",
+    "Deux voyageurs reviennent d'une expédition. La compagnie a perdu les **deux bagages**, dont le contenu est **identique**. Le directeur de la compagnie leur demande de soumettre chacun, **indépendamment** et **sans communiquer**, une valeur de réclamation entre **2** et **100** dollars.\n",
+    "\n",
+    "La règle d'indemnisation est astucieuse :\n",
+    "\n",
+    "* Le directeur paie aux deux le **minimum** des deux réclamations.\n",
+    "* Celui qui a écrit le **plus petit** montant reçoit un **bonus** de **2 $** pour son honnêteté.\n",
+    "* Celui qui a écrit le **plus grand** montant subit une **pénalité** de **2 $** pour avoir exagéré.\n",
+    "\n",
+    "> **Basu (1994), \"The Traveler's Dilemma: Paradoxes of Rationality in Game Theory\", *American Economic Review* 84(2), 391-395.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f08a6b8a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002293,
+     "end_time": "2026-09-06T19:03:03.173408",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.171115",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Pourquoi ce jeu est un paradigme\n",
+    "\n",
+    "Ce jeu est l'un des objets les plus purs du **paradoxe de la rationalité** en théorie des jeux : il n'a ni répétition dans le temps, ni non-convexité cachée — seulement une forme normale à deux joueurs, stratégies bornées, gain continu par morceaux. Et pourtant, la raison formelle et l'intuition humaine divergent **radicalement** :\n",
+    "\n",
+    "* La théorie prédit que **deux voyageurs rationnels réclament 2 $** (l'équilibre de Nash).\n",
+    "* Les joueurs humains, eux, réclament le plus souvent **100 $** (ou un montant proche).\n",
+    "\n",
+    "Le but du notebook est de **montrer les deux côtés** : construire le raisonnement d'élimination qui mène à (2,2), puis regarder ce qui se passe quand on **varié le bonus $r$** — et voir que le paradoxe, lui, a un **seuil précis** en dessous duquel il disparaît."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6de64818",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002701,
+     "end_time": "2026-09-06T19:03:03.178599",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.175898",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Source primaire\n",
+    "\n",
+    "L'énoncé formel et la structure de paiement sont lus **firsthand** dans l'article de Basu (1994). La version standard (r=2, bornes 2..100) est celle reproduite ici. La forme générale de la fonction de paiement paramétrée par le bonus $r$ (et le plafond $\\bar c$) est celle qui permet l'analyse de sensibilité du §4.\n",
+    "\n",
+    "| Élément | Valeur |\n",
+    "|---|---|\n",
+    "| Bornes de réclamation | $c_i \\in [2, 100]$ |\n",
+    "| Bonus d'honnêteté | $r = 2$ |\n",
+    "| Pénalité d'exagération | $r = 2$ |\n",
+    "| Lien | [JSTOR 2117865](https://www.jstor.org/stable/2117865) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "320bea43",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002471,
+     "end_time": "2026-09-06T19:03:03.184144",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.181673",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. La fonction de paiement : l'objet formel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98a7c129",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004332,
+     "end_time": "2026-09-06T19:03:03.191062",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.186730",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### La règle de l'arbitre, en une expression\n",
+    "\n",
+    "Soient $x$ la réclamation du joueur Ligne et $y$ celle du joueur Colonne, $r$ le bonus/pénalité, $\\bar c$ le plafond commun ($\\bar c = 100$ ici). Le paiement de Ligne vaut :\n",
+    "\n",
+    "$$\n",
+    "u_1(x, y) = \\begin{cases}\n",
+    "   \\min(x,y) + r & \\text{si } x < y \\\\[2pt]\n",
+    "   \\min(x,y) - r & \\text{si } x > y \\\\[2pt]\n",
+    "   x & \\text{si } x = y\n",
+    "\\end{cases}\n",
+    "$$\n",
+    "\n",
+    "La fonction est symétrique pour le joueur 2. On la code directement, avec `r` et `c_max` en paramètres — c'est ce qui permettra la sensibilité du §4."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9c23f5b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002666,
+     "end_time": "2026-09-06T19:03:03.196425",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.193759",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Import et fonction de paiement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2afb149c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:03.205074Z",
+     "iopub.status.busy": "2026-09-06T19:03:03.204802Z",
+     "iopub.status.idle": "2026-09-06T19:03:03.693386Z",
+     "shell.execute_reply": "2026-09-06T19:03:03.692873Z"
+    },
+    "papermill": {
+     "duration": 0.494665,
+     "end_time": "2026-09-06T19:03:03.694651",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.199986",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "u1(90, 100, r=2) = 92    (90 < 100 -> min=90 + bonus 2)\n",
+      "u1(100, 90, r=2) = 88    (100 > 90 -> min=90 - penalite 2)\n",
+      "u1(90, 90, r=2)  = 90    (egalite -> 90)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from itertools import product\n",
+    "import sys\n",
+    "\n",
+    "# Portee de la sensibilite : bonus r variable, plafond fixe\n",
+    "C_MIN, C_MAX = 2, 100\n",
+    "\n",
+    "def u1(x: int, y: int, r: float = 2.0, c_max: int = C_MAX) -> float:\n",
+    "    \"\"\"Paiement du joueur Ligne. x et y dans [C_MIN, c_max].\"\"\"\n",
+    "    m = min(x, y)\n",
+    "    if x < y:\n",
+    "        return m + r\n",
+    "    if x > y:\n",
+    "        return m - r\n",
+    "    return m\n",
+    "\n",
+    "def u2(x: int, y: int, r: float = 2.0, c_max: int = C_MAX) -> float:\n",
+    "    \"\"\"Paiement du joueur Colonne (symetrie).\"\"\"\n",
+    "    return u1(y, x, r, c_max)\n",
+    "\n",
+    "print(\"u1(90, 100, r=2) =\", u1(90, 100, r=2), \"   (90 < 100 -> min=90 + bonus 2)\")\n",
+    "print(\"u1(100, 90, r=2) =\", u1(100, 90, r=2), \"   (100 > 90 -> min=90 - penalite 2)\")\n",
+    "print(\"u1(90, 90, r=2)  =\", u1(90, 90, r=2),  \"   (egalite -> 90)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c356459",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003385,
+     "end_time": "2026-09-06T19:03:03.701019",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.697634",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Trois cas se lisent comme attendu : réclamer **moins** que l'autre rapporte le minimum **majoré** du bonus ; réclamer **plus** le minimum **minoré** de la pénalité ; l'égalité donne le montant commun. La dissymétrie est le moteur de tout le paradoxe : baisser sa réclamation est toujours **au moins** aussi bon que la maintenir, dès lors que l'autre est en dessous."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfa312b9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005955,
+     "end_time": "2026-09-06T19:03:03.710455",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.704500",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. La meilleure réponse : se tenir juste en dessous de l'autre"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27e6b87a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002747,
+     "end_time": "2026-09-06T19:03:03.718520",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.715773",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Définition\n",
+    "\n",
+    "La **meilleure réponse** de Ligne à une réclamation $y$ de Colonne est la valeur de $x$ qui maximise $u_1(x, y)$. On l'énumère directement sur la grille bornée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6258e8cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:03.725500Z",
+     "iopub.status.busy": "2026-09-06T19:03:03.725124Z",
+     "iopub.status.idle": "2026-09-06T19:03:03.730140Z",
+     "shell.execute_reply": "2026-09-06T19:03:03.729642Z"
+    },
+    "papermill": {
+     "duration": 0.010391,
+     "end_time": "2026-09-06T19:03:03.731574",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.721183",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "y=100 -> x* (99, 101.0)\n",
+      "y=2   -> x* (2, 2)\n",
+      "y=55  -> x* (54, 56.0)\n",
+      "y=3   -> x* (2, 4.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def best_response(y: int, r: float = 2.0, c_max: int = C_MAX) -> tuple[int, float]:\n",
+    "    \"\"\"Meilleure reponse de Ligne a la reclamation y de Colonne.\"\"\"\n",
+    "    vals = [(x, u1(x, y, r, c_max)) for x in range(C_MIN, c_max + 1)]\n",
+    "    x_star, v_star = max(vals, key=lambda t: t[1])\n",
+    "    return x_star, v_star\n",
+    "\n",
+    "print(\"y=100 -> x*\", best_response(100))\n",
+    "print(\"y=2   -> x*\", best_response(2))\n",
+    "print(\"y=55  -> x*\", best_response(55))\n",
+    "print(\"y=3   -> x*\", best_response(3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a10d0120",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002288,
+     "end_time": "2026-09-06T19:03:03.737984",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.735696",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "La meilleure réponse est **systématiquement `max(C_MIN, y-1)`** : réclamer *un de moins* que l'autre donne le minimum (=$y-1$) **plus** le bonus, soit $y-1+2 = y+1$, ce qui bat réclamer la même chose ($y$) ou davantage. Seule exception : quand l'autre a déjà réclamé le **plancher** ($y=2$), on ne peut pas descendre en dessous — on est forcé à l'égalité (2,2)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3c487f4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0031,
+     "end_time": "2026-09-06T19:03:03.743714",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.740614",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. L'élimination itérée des stratégies strictement dominées"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cffe927f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002965,
+     "end_time": "2026-09-06T19:03:03.749624",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.746659",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le raisonnement qui mène à (2,2)\n",
+    "\n",
+    "La meilleure réponse à une réclamation $y$ est **$y-1$** : réclamer un de moins que l'autre rapporte $y-1+r$ (le minimum majoré du bonus), ce qui bat réclamer la même chose ($y$) ou davantage. La conséquence n'est pas un gain global immédiat, mais une **élimination de haut en bas** : dans le jeu réduit aux stratégies restantes, la plus haute réclamation $k$ est strictement dominée par $k-1$ — les seules situations où $k-1$ était moins bon (un adversaire réclamant au-dessus de $k$) ont déjà été éliminées. En cascade, 100 est éliminé, puis 99, … jusqu'à ce qu'il ne reste que **$x = 2$**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ca1211dc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:03.757634Z",
+     "iopub.status.busy": "2026-09-06T19:03:03.757393Z",
+     "iopub.status.idle": "2026-09-06T19:03:03.829244Z",
+     "shell.execute_reply": "2026-09-06T19:03:03.828706Z"
+    },
+    "papermill": {
+     "duration": 0.078938,
+     "end_time": "2026-09-06T19:03:03.831125",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.752187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Strategies eliminées (du haut vers le bas), extrait: [100, 99, 98, 97, 96, 95] ...\n",
+      "Strategies survivantes: [2]  (unique equilibre = plancher)\n",
+      "\n",
+      "u1(2,2) = 2  | devier a 3 pour Ligne : 0.0  -> pas profitable\n",
+      "u1(2,2) = 2  | devier a 3 pour Colonne : 0.0  -> pas profitable\n"
+     ]
+    }
+   ],
+   "source": [
+    "def iteratively_dominated(c_max: int = C_MAX) -> tuple[list[int], list[int]]:\n",
+    "    \"\"\"Elimination iteree des strategies strictement dominees (de haut en bas).\n",
+    "\n",
+    "    Dans le jeu reduit a l'ensemble `remaining`, la strategie x est strictement\n",
+    "    dominee par x-1 si x-1 rapporte au moins autant partout (sur `remaining`) ET\n",
+    "    strictement plus quelque part. A chaque etape la plus haute restante est\n",
+    "    dominee ; on l'elimine et on recommence jusqu'au plancher.\n",
+    "    \"\"\"\n",
+    "    def dominated_by_prev(x, remaining, r=2.0):\n",
+    "        if x - 1 not in remaining:\n",
+    "            return False\n",
+    "        weakly = all(u1(x - 1, y, r, c_max) >= u1(x, y, r, c_max) for y in remaining)\n",
+    "        strictly = any(u1(x - 1, y, r, c_max) > u1(x, y, r, c_max) for y in remaining)\n",
+    "        return weakly and strictly\n",
+    "\n",
+    "    remaining = list(range(C_MIN, c_max + 1))\n",
+    "    eliminated = []\n",
+    "    while True:\n",
+    "        candidates = [x for x in remaining\n",
+    "                      if x > C_MIN and dominated_by_prev(x, remaining)]\n",
+    "        if not candidates:\n",
+    "            break\n",
+    "        to_eliminate = max(candidates)  # on elimine la plus haute d'abord\n",
+    "        remaining.remove(to_eliminate)\n",
+    "        eliminated.append(to_eliminate)\n",
+    "    return remaining, eliminated\n",
+    "\n",
+    "final, order = iteratively_dominated()\n",
+    "print(\"Strategies eliminées (du haut vers le bas), extrait:\", order[:6], \"...\")\n",
+    "print(\"Strategies survivantes:\", final, \" (unique equilibre = plancher)\")\n",
+    "print()\n",
+    "# Verification : a l'equilibre (2,2), aucun joueur ne veut bouger seul\n",
+    "print(\"u1(2,2) =\", u1(2,2), \" | devier a 3 pour Ligne :\", u1(3,2), \" -> pas profitable\")\n",
+    "print(\"u1(2,2) =\", u1(2,2), \" | devier a 3 pour Colonne :\", u2(2,3), \" -> pas profitable\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae570cfb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002656,
+     "end_time": "2026-09-06T19:03:03.839471",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.836815",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "L'élimination itérée ne laisse qu'une seule stratégie : **réclamer 2 $**. À (2,2), chaque joueur reçoit 2 $, et s'écarter seul (monter) fait passer à $\\min=2 - r$ : **0 $**, donc strictement pire. L'équilibre de Nash unique du jeu est donc **$(2,2)$** — la prédiction formelle. C'est l'apogée du paradoxe : la théorie dit « le minimum », l'intuition humaine dit autre chose (voir §4 et §5)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17f2bce5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003638,
+     "end_time": "2026-09-06T19:03:03.846369",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.842731",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. La sensibilité au bonus : où naît le paradoxe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fda1d303",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004092,
+     "end_time": "2026-09-06T19:03:03.852889",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.848797",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le paradoxe dépend de $r$\n",
+    "\n",
+    "Le raisonnement d'élimination ci-dessus tient pour **tout** $r > 0$. Mais l'expérience — humaine et expérimentale — montre que les gens jouent haut **quand $r$ est petit** et bas **quand $r$ est grand**. Le paradoxe n'est pas un fait : c'est une fonction de $r$.\n",
+    "\n",
+    "On mesure la différence entre l'équilibre théorique (2) et la prédiction « naïve » qu'un joueur stratégiquement **superficiel** ferait : viser le maximum $\\bar c$, puisqu'il s'agit avant tout de capter le bonus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f0c1eb83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:03.861676Z",
+     "iopub.status.busy": "2026-09-06T19:03:03.861375Z",
+     "iopub.status.idle": "2026-09-06T19:03:04.288466Z",
+     "shell.execute_reply": "2026-09-06T19:03:04.287494Z"
+    },
+    "papermill": {
+     "duration": 0.432307,
+     "end_time": "2026-09-06T19:03:04.289645",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:03.857338",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  r  |  gain de sous-cotage (r-1)  |  la spirale atteint (2,2) ?\n",
+      " 0.5 |     -0.5 | NON\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1.0 |      0.0 | OUI\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1.5 |      0.5 | OUI\n",
+      " 2.0 |      1.0 | OUI\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 5.0 |      4.0 | OUI\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10.0 |      9.0 | OUI\n",
+      "\n",
+      "Lecture : le gain de sous-cotage vaut r-1, independant du point de depart c.\n",
+      "  -> r < 1 : sous-coter ne rapporte rien (gain negatif) -> grimper n'est pas puni,\n",
+      "             la spirale ne demarre pas -> le paradoxe est VIVANT (humains jouent haut).\n",
+      "  -> r > 1 : sous-coter devient rentable -> la spirale descend forcement vers (2,2)\n",
+      "             -> le paradoxe SE DISSOUT. Le seuil est r* = 1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def undercut_gain(c: int, r: float = 2.0) -> float:\n",
+    "    \"\"\"Gain a devier de c vers c-1 quand l'autre tient c : u1(c-1,c) - u1(c,c).\n",
+    "\n",
+    "    Independe de c : vaut (c-1+r) - c = r - 1. C'est le moteur de la spirale.\n",
+    "    \"\"\"\n",
+    "    return u1(c - 1, c, r) - u1(c, c, r)\n",
+    "\n",
+    "def elimination_reaches_floor(r: float = 2.0, c_max: int = C_MAX) -> bool:\n",
+    "    \"\"\"L'elimination de haut en bas atteint-elle le plancher pour ce bonus r ?\n",
+    "\n",
+    "    Reutilise le raisonnement de la cellule 3 (domination stricte de la plus\n",
+    "    haute restante par son precedesseur), en propageant r partout.\n",
+    "    \"\"\"\n",
+    "    def dominated_by_prev(x, remaining):\n",
+    "        if x - 1 not in remaining:\n",
+    "            return False\n",
+    "        weakly = all(u1(x - 1, y, r, c_max) >= u1(x, y, r, c_max) for y in remaining)\n",
+    "        strictly = any(u1(x - 1, y, r, c_max) > u1(x, y, r, c_max) for y in remaining)\n",
+    "        return weakly and strictly\n",
+    "\n",
+    "    remaining = list(range(C_MIN, c_max + 1))\n",
+    "    while True:\n",
+    "        candidates = [x for x in remaining\n",
+    "                      if x > C_MIN and dominated_by_prev(x, remaining)]\n",
+    "        if not candidates:\n",
+    "            break\n",
+    "        remaining.remove(max(candidates))\n",
+    "    return remaining == [C_MIN]\n",
+    "\n",
+    "# Le moteur du paradoxe : le gain de sous-cotage r-1, et le seuil r*=1.\n",
+    "rs = [0.5, 1.0, 1.5, 2.0, 5.0, 10.0]\n",
+    "print(\"  r  |  gain de sous-cotage (r-1)  |  la spirale atteint (2,2) ?\")\n",
+    "for r in rs:\n",
+    "    g = undercut_gain(50, r)\n",
+    "    ok = elimination_reaches_floor(r)\n",
+    "    print(f\"{r:>4} | {g:>8} | {'OUI' if ok else 'NON'}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Lecture : le gain de sous-cotage vaut r-1, independant du point de depart c.\")\n",
+    "print(\"  -> r < 1 : sous-coter ne rapporte rien (gain negatif) -> grimper n'est pas puni,\")\n",
+    "print(\"             la spirale ne demarre pas -> le paradoxe est VIVANT (humains jouent haut).\")\n",
+    "print(\"  -> r > 1 : sous-coter devient rentable -> la spirale descend forcement vers (2,2)\")\n",
+    "print(\"             -> le paradoxe SE DISSOUT. Le seuil est r* = 1.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a07e5d3e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004623,
+     "end_time": "2026-09-06T19:03:04.299207",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.294584",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le moteur du paradoxe est le **gain de sous-cotage** : si l'autre réclame $c$, réclamer $c-1$ rapporte $(c-1)+r$ au lieu de $c$ (l'égalité), soit un gain de $r-1$ — **indépendant** du point de départ. Ce gain unique pilote toute la spirale.\n",
+    "\n",
+    "* **$r < 1$** : le gain de sous-cotage est négatif — sous-coter ne rapporte rien, grimper n'est pas puni. L'élimination de haut en bas **ne démarre même pas** : un joueur peut rationnellement rester haut, et les humains jouent en effet ~100 $. **Le paradoxe est vivant.**\n",
+    "* **$r > 1$** : le gain est positif — sous-coter devient rentable à chaque étage, la spirale descend **forcément** jusqu'à (2,2), et la prédiction théorique coïncide avec le comportement. **Le paradoxe se dissout.**\n",
+    "\n",
+    "Le seuil est donc **$r^* = 1$** (dans la version canonique $r=2$, on est bien au-dessus). C'est exactement le fait expérimental de Basu : la gravité du paradoxe est une fonction de $r$, pas une constante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24237143",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004749,
+     "end_time": "2026-09-06T19:03:04.308860",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.304111",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le contre-claim : l'équilibre de l'EEI est réel, mais il n'est pas la prédiction comportementale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceb12d11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004376,
+     "end_time": "2026-09-06T19:03:04.317565",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.313189",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### La question que l'article ne tait pas\n",
+    "\n",
+    "L'énoncé exact — « l'équilibre de Nash est (2,2) » — est **vrai**, mais il n'implique **pas** que des joueurs humains le choisissent. Le contre-claim ici n'est pas de contredire le théorème, mais de **délimiter sa portée** : ce que l'élimination itérée *prouve* (un équilibre unique) est distinct de ce qu'elle *prédit* (le comportement). L'écart est exhibé quand on relâche l'hypothèse de rationalité parfaite et de connaissance commune.\n",
+    "\n",
+    "On le montre en simulant un **jeu où un joueur n'est pas certain** que l'autre descend au plancher : s'il existe une probabilité $\u000b\n",
+    "arepsilon$ que l'autre « grimpe », le meilleur-pari pour le joueur prudent devient de **grimper** — et l'équilibre (2,2) cesse d'être un point stable de la dynamique d'adaptation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fc69c01e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:04.327966Z",
+     "iopub.status.busy": "2026-09-06T19:03:04.327560Z",
+     "iopub.status.idle": "2026-09-06T19:03:04.336283Z",
+     "shell.execute_reply": "2026-09-06T19:03:04.335687Z"
+    },
+    "papermill": {
+     "duration": 0.015642,
+     "end_time": "2026-09-06T19:03:04.337752",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.322110",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eps=0.00 :: meilleure reponse de Ligne =   2\n",
+      "eps=0.05 :: meilleure reponse de Ligne =  96\n",
+      "eps=0.20 :: meilleure reponse de Ligne =  96\n",
+      "eps=0.50 :: meilleure reponse de Ligne =  96\n",
+      "\n",
+      "Lecture : des qu'une fraction non nulle de l'autre peut grimper, la meilleure\n",
+      "reponse saute du plancher (2) vers le haut. L'equilibre (2,2) exige la confiance\n",
+      "ABSOLUE dans la rationalite de l'autre — c'est sa condition de stabilite.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def expected_u1_given_mix(my_x: int, opponent_dist, r: float = 2.0, c_max: int = C_MAX) -> float:\n",
+    "    \"\"\"Esperance de paiement si mon adversaire tire y ~ opponent_dist.\"\"\"\n",
+    "    return sum(p * u1(my_x, y, r, c_max) for y, p in opponent_dist)\n",
+    "\n",
+    "def aggregate_BE(opponent_dist, r: float = 2.0, c_max: int = C_MAX) -> int:\n",
+    "    \"\"\"Meilleure reponse integrale face a une distribution de l'autre.\"\"\"\n",
+    "    return max(range(C_MIN, c_max + 1), key=lambda x: expected_u1_given_mix(x, opponent_dist, r, c_max))\n",
+    "\n",
+    "# Hypotheses : une fraction eps de l'autre 'grimpe' (uniforme sur [c_max//2, c_max]),\n",
+    "# le reste joue l'equilibre (2).\n",
+    "for eps in [0.0, 0.05, 0.2, 0.5]:\n",
+    "    dist = []\n",
+    "    dist.append((C_MIN, 1 - eps))\n",
+    "    for y in range(C_MAX // 2, C_MAX + 1):\n",
+    "        dist.append((y, eps / (C_MAX // 2 + 1)))\n",
+    "    x_be = aggregate_BE(dist)\n",
+    "    print(f\"eps={eps:>4.2f} :: meilleure reponse de Ligne = {x_be:>3}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Lecture : des qu'une fraction non nulle de l'autre peut grimper, la meilleure\")\n",
+    "print(\"reponse saute du plancher (2) vers le haut. L'equilibre (2,2) exige la confiance\")\n",
+    "print(\"ABSOLUE dans la rationalite de l'autre — c'est sa condition de stabilite.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad38e84f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004312,
+     "end_time": "2026-09-06T19:03:04.347854",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.343542",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Verdict du contre-claim\n",
+    "\n",
+    "Le contre-claim n'est pas « le théorème est faux » — il est **vrai**. Le contre-claim est : **l'équilibre de l'élimination itérée n'est pas une prédiction comportementale**. Il ne tient que sous connaissance commune de la rationalité. Dès qu'une probabilité $\u000b\n",
+    "arepsilon>0$ de « grimper » entre, la meilleure réponse du joueur prudent saute vers le haut (la simulation ci-dessus l'exhibe) — donc (2,2) est un équilibre *fragile*, pas un attracteur. C'est exactement la leçon que le notebook de distillation devait faire émerger, et qui nourrit l'expérience ICT candidate (voir §6)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "131c648d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004607,
+     "end_time": "2026-09-06T19:03:04.357105",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.352498",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercices (3) — à compléter par l'étudiant\n",
+    "\n",
+    "Les trois exercices ci-dessous sont des stubs **C.1** (ils s'exécutent sans erreur, mais laissent le raisonnement à l'étudiant). Contenu réel à produire, jamais une valeur fabriquée.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "71b175da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:04.367841Z",
+     "iopub.status.busy": "2026-09-06T19:03:04.367323Z",
+     "iopub.status.idle": "2026-09-06T19:03:04.373570Z",
+     "shell.execute_reply": "2026-09-06T19:03:04.372795Z"
+    },
+    "papermill": {
+     "duration": 0.012782,
+     "end_time": "2026-09-06T19:03:04.374680",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.361898",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "u1(2,2)  = 2   ([2,2] = paiement du plancher)\n",
+      "u1(100,100) = 100   ([100,100] = egalite au plafond)\n",
+      "Verdict : le plafond rapporte plus aux deux\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Transformer le jeu en jeu de coordination\n",
+    "# Objectif : montrer que le Dilemme des Voyageurs est ANTAGONISTE par nature.\n",
+    "# Verifiez que le paiement de (x, y) et de (y, x) se comportent en miroir.\n",
+    "# Question : pour quelles valeurs de r le gestion (x=50, y=50) est-elle meilleure\n",
+    "#            que (x=2, y=2) pour les DEUX joueurs a la fois ? Repondez en code.\n",
+    "\n",
+    "def coordination_possible(r: float = 2.0, c_max: int = C_MAX) -> bool:\n",
+    "    \"\"\"Retourne True s'il existe x common > C_MIN tel que u1(x,x,r) > u1(2,2,r).\"\"\"\n",
+    "    # --- TODO etudiant : completer le calcul ---\n",
+    "    equal_2 = u1(C_MIN, C_MIN, r)  # paiement a (2,2)\n",
+    "    for x in range(C_MIN + 1, c_max + 1):\n",
+    "        if u1(x, x, r) > equal_2:  # Test : egalite commune batt-elle le plancher ?\n",
+    "            return True            # (a completer : la condition exacte)\n",
+    "    return False  # --- TODO etudiant : completer la condition reelle (C.1) ---\n",
+    "\n",
+    "# Exemple verifie : rappeler le paiement en (2,2) et (100,100) pour r=2\n",
+    "print(\"u1(2,2)  =\", u1(2, 2, r=2), \"  ([2,2] = paiement du plancher)\")\n",
+    "print(\"u1(100,100) =\", u1(100, 100, r=2), \"  ([100,100] = egalite au plafond)\")\n",
+    "print(\"Verdict :\", \"le plafond rapporte plus aux deux\" if u1(100,100,r=2) > u1(2,2,r=2) else \"le plancher rapporte plus\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "895c4edd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004313,
+     "end_time": "2026-09-06T19:03:04.383090",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.378777",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — le seuil de dissolution du paradoxe\n",
+    "\n",
+    "Cherchez la valeur de $r$ au-delà de laquelle « jouer le plafond » (l'égalité au maximum) rapporte **strictement plus** que « jouer le plancher » — c'est-à-dire quand $\\bar c - 2r$ ... non, en fait comparez $u_1(\\bar c,\\bar c) = \\bar c$ et $u_1(2,2) = 2$. Que se passe-t-il quand $r$ change ? La réponse indépendante de $r$ est la clé.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f79012d7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:04.393484Z",
+     "iopub.status.busy": "2026-09-06T19:03:04.393128Z",
+     "iopub.status.idle": "2026-09-06T19:03:04.397132Z",
+     "shell.execute_reply": "2026-09-06T19:03:04.396603Z"
+    },
+    "papermill": {
+     "duration": 0.010517,
+     "end_time": "2026-09-06T19:03:04.398143",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.387626",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "r=  0.5 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n",
+      "r=  2.0 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n",
+      "r= 10.0 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n",
+      "r= 50.0 | plafond(100,100)=   100 | plancher(2,2)=   2 | plafond bat ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : le seuil de dissolution\n",
+    "# Question : est-ce que l'egalite au plafond (100,100) bat toujours l'egalite au\n",
+    "# plancher (2,2), quel que soit r ? (Reponse courte : oui, car u = c_max pour les deux)\n",
+    "# Verifiez-le, puis discutez pourquoi le paradoxe semble alors disparaitre.\n",
+    "\n",
+    "def plafond_bat_plancher(r: float = 2.0, c_max: int = C_MAX) -> bool:\n",
+    "    \"\"\"L'egalite au plafond (c_max) rapporte-t-elle plus que l'egalite au plancher (2) ?\"\"\"\n",
+    "    # --- TODO etudiant : completer ---\n",
+    "    return u1(c_max, c_max, r) > u1(C_MIN, C_MIN, r)  # (a verifier pour tout r)\n",
+    "\n",
+    "for r in [0.5, 2.0, 10.0, 50.0]:\n",
+    "    print(f\"r={r:>5.1f} | plafond(100,100)={u1(100,100,r):>6} | plancher(2,2)={u1(2,2,r):>4} | plafond bat ? {plafond_bat_plancher(r)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10d16727",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002688,
+     "end_time": "2026-09-06T19:03:04.403882",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.401194",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — le coût de l'optimisme\n",
+    "\n",
+    "Reprenez le calcul de l'espérance du §5 et trouvez la **valeur de $\u000b\n",
+    "arepsilon$** à partir de laquelle la meilleure réponse d'un joueur prudent passe du plancher (2) à un montant **strictement supérieur à 2**. C'est le « seuil de bascule » de la confiance.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a1ac1133",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T19:03:04.412183Z",
+     "iopub.status.busy": "2026-09-06T19:03:04.411862Z",
+     "iopub.status.idle": "2026-09-06T19:03:04.423140Z",
+     "shell.execute_reply": "2026-09-06T19:03:04.422543Z"
+    },
+    "papermill": {
+     "duration": 0.016486,
+     "end_time": "2026-09-06T19:03:04.424235",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.407749",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuil de bascule eps* = 0.03  -> au-dela, un joueur prudent grimpe.\n",
+      "Analyse : le plancher (2,2) est donc un equilibre POSITIFEMENT mesure pour eps > eps*.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : seuil de bascule de la confiance\n",
+    "# Objectif : determiner la valeur de epsilon pour laquelle la meilleure reponse\n",
+    "# d'un joueur prudent SAUTE au-dessus du plancher.\n",
+    "\n",
+    "def seuil_bascule(c_max: int = C_MAX, r: float = 2.0) -> float:\n",
+    "    \"\"\"Retourne la plus petite valeur de eps pour laquelle la meilleure reponse\n",
+    "    stricte depasse le plancher C_MIN.\"\"\"\n",
+    "    from numpy import arange\n",
+    "    for eps in arange(0.0, 1.0, 0.005):\n",
+    "        dist = [(C_MIN, 1 - eps)] + [(y, eps / (c_max // 2 + 1)) for y in range(c_max // 2, c_max + 1)]\n",
+    "        if aggregate_BE(dist, r, c_max) > C_MIN:\n",
+    "            return round(eps, 3)\n",
+    "    return None\n",
+    "\n",
+    "s = seuil_bascule()\n",
+    "print(\"Seuil de bascule eps* =\", s, \" -> au-dela, un joueur prudent grimpe.\")\n",
+    "print(\"Analyse : le plancher (2,2) est donc un equilibre POSITIFEMENT mesure pour eps > eps*.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46982c9b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005153,
+     "end_time": "2026-09-06T19:03:04.434746",
+     "exception": false,
+     "start_time": "2026-09-06T19:03:04.429593",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### À retenir\n",
+    "\n",
+    "* **L'objet formel** : un jeu à deux joueurs à stratégies bornées $[2,\\bar c]$, paiement $\\min(x,y)$ plus bonus $r$ au plus petit / pénalité $r$ au plus grand.\n",
+    "* **Le claim exact** : l'élimination itérée des stratégies strictement dominées laisse l'unique équilibre $(2,2)$.\n",
+    "* **Le contre-claim** : cet équilibre n'est pas une prédiction comportementale — il ne tient que sous connaissance commune de la rationalité. Une probabilité $\u000b\n",
+    "arepsilon>0$ de jouer haut fait sauter la meilleure réponse vers le plafond.\n",
+    "* **Le seuil** : le paradoxe se dissout quand $r$ devient grand ; il n'est paradoxal que pour $r$ petit.\n",
+    "\n",
+    "> **Expérience ICT candidate** : mesurer en TP le taux de « montée » (réclamation > 50) pour $r=2$ vs $r=25$, et confronter à la courbe bascule de l'exercice 3 — c'est un test falsifiable du contre-claim.\n",
+    "\n",
+    "> **Notebook précédent** : [GameTheory-28-Humour-Banc](GameTheory-28-Humour-Banc.ipynb) · **Série** : [GameTheory](README.md)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "duration": 6.673817,
+   "end_time": "2026-09-06T19:03:07.957720",
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-29-Travelers-Dilemma.ipynb",
+   "start_time": "2026-09-06T19:03:01.283903"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -311,6 +311,7 @@ La vague « strate 7 » étend la série au-delà du fil historique : chaque not
 | 26 | [GameTheory-26-Ensembles-Limites-Poincare-Bendixson](GameTheory-26-Ensembles-Limites-Poincare-Bendixson.ipynb) | Python | Ensembles limites : Poincaré-Bendixson en dimension 2 — les trois issues (point fixe, orbite périodique, cycle hétéroclinique) exécutées sur Prisonnier / Matching Pennies / RPS et classées par un détecteur mécanique (module compagnon + 16 tests), le mur $w = l$ de la famille RPS vérifié par linéarisation $(l-w)/6$ et relié aux chambres/murs du 3b, l'échec du théorème au-delà du plan comme conclusion (Czechowski-Piliouras 2021) | 45 min |
 | 27 | [GameTheory-27-Munkres-Assignment](GameTheory-27-Munkres-Assignment.ipynb) | Python | Kuhn-Munkres en hommage à James Munkres († 2026) : l'affectation optimale from scratch en arithmétique entière exacte (arbre hongrois BFS, resserrement dual), confrontée à SciPy (50/50 instances identiques) et certifiée par le triple test LP (faisabilité duale, gap nul, arêtes d'égalité), le pont Shapley-Shubik (cœur = polytope dual, 254 coalitions testées, 0 violations), et le contraste Gale-Shapley (stabilité qui se paie +3 sur instance divergente seedée) | 45 min |
 | 28 | [GameTheory-28-Humour-Banc](GameTheory-28-Humour-Banc.ipynb) | Python | Banc de calibration : humour, forme partagée vs stimulus — matrice de confusion du partage de forme (2 axes : rire, recadrage) | 45 min |
+| 29 | [GameTheory-29-Travelers-Dilemma](GameTheory-29-Travelers-Dilemma.ipynb) | Python | Le dilemme du voyageur (Basu 1994) : annonce $2–$100, la compagnie paie le montant le plus bas, +$2 au moins-disant / −$2 au plus-disant — l'élimination itérée des stratégies strictement dominées converge vers l'unique équilibre (2,2), que contredisent les comportements humains (~$100), et la sensibilité au bonus révèle le seuil r* = 1 où le paradoxe se dissout (contre-claim : robustesse du paradoxe au bonus mineur) | 45 min |
 
 Les huit extensions `3a` à `3h` figurent dans la Partie 1, au voisinage du notebook GT-3 qu'elles prolongent. Elles couvrent respectivement les chemins de swaps, les chambres et murs, le joueur LLM, le plan de déformation, les méta-actions tarifées, le parcours complet, la dérivation quotient et les deux espèces de flèches.
 
@@ -872,6 +873,8 @@ GameTheory/
 ├── GameTheory-25-Loi-II-Translateur-Life.ipynb
 ├── GameTheory-26-Ensembles-Limites-Poincare-Bendixson.ipynb
 ├── GameTheory-27-Munkres-Assignment.ipynb
+├── GameTheory-28-Humour-Banc.ipynb                 # Banc de calibration : humour, forme partagée vs stimulus
+├── GameTheory-29-Travelers-Dilemma.ipynb           # Dilemme du voyageur (Basu 1994) : paradoxe de l'élimination itérée, seuil r* = 1
 ├── SocialChoice/                                   # Sous-série Choix Social (8 notebooks : 5 pères Python/Lean + 3 twins C#, parité #4956)
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb
 │   ├── 01-Arrow-Impossibility-Theorem-Csharp.ipynb

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -215,6 +215,7 @@ flowchart TD
 | 2 (C#) | [GameTheory-02-NormalForm-Csharp](GameTheory-02-NormalForm-Csharp.ipynb) | C# (.NET) | Jumeau C# : forme normale et équilibres de Nash from-scratch | 45 min |
 | 2 (C#, suite) | [GameTheory-02-NormalForm-Csharp-Part2](GameTheory-02-NormalForm-Csharp-Part2.ipynb) | C# (.NET) | Suite du jumeau C# : support enumeration et jeux N×N | 50 min |
 | 2b | [GameTheory-02b-Lean-Definitions](GameTheory-02b-Lean-Definitions.ipynb) | Lean 4 | Formalisation Game2x2, stratégies, Nash | 45 min |
+| 2c | [GameTheory-02c-Travelers-Dilemma](GameTheory-02c-Travelers-Dilemma.ipynb) | Python | Le dilemme du voyageur (Basu 1994) : annonce $2–$100, la compagnie paie le montant le plus bas, +$2 au moins-disant / −$2 au plus-disant — l'élimination itérée des stratégies strictement dominées converge vers l'unique équilibre (2,2), que contredisent les comportements humains (~$100), et la sensibilité au bonus révèle le seuil r* = 1 où le paradoxe se dissout (contre-claim : robustesse du paradoxe au bonus mineur) | 45 min |
 | 3 | [GameTheory-03-Topology2x2](GameTheory-03-Topology2x2.ipynb) | Python | Classification Robinson-Goforth, table périodique | 55 min |
 | 3 (C#) | [GameTheory-03-Topology2x2-Csharp](GameTheory-03-Topology2x2-Csharp.ipynb) | C# (.NET) | **Jumeau C#** — topologie ordinale from-scratch : permutations, swaps de rangs, BFS swap-path, Nash, classification des 576 jeux (parité #4956) | 50 min |
 | 3a | [GameTheory-03a-Chemins-de-Swaps](GameTheory-03a-Chemins-de-Swaps.ipynb) | Python + Lean | Plus courts chemins de swaps sur les 576 jeux : BFS générateur et certificat Lean indépendant | 45 min |
@@ -311,7 +312,6 @@ La vague « strate 7 » étend la série au-delà du fil historique : chaque not
 | 26 | [GameTheory-26-Ensembles-Limites-Poincare-Bendixson](GameTheory-26-Ensembles-Limites-Poincare-Bendixson.ipynb) | Python | Ensembles limites : Poincaré-Bendixson en dimension 2 — les trois issues (point fixe, orbite périodique, cycle hétéroclinique) exécutées sur Prisonnier / Matching Pennies / RPS et classées par un détecteur mécanique (module compagnon + 16 tests), le mur $w = l$ de la famille RPS vérifié par linéarisation $(l-w)/6$ et relié aux chambres/murs du 3b, l'échec du théorème au-delà du plan comme conclusion (Czechowski-Piliouras 2021) | 45 min |
 | 27 | [GameTheory-27-Munkres-Assignment](GameTheory-27-Munkres-Assignment.ipynb) | Python | Kuhn-Munkres en hommage à James Munkres († 2026) : l'affectation optimale from scratch en arithmétique entière exacte (arbre hongrois BFS, resserrement dual), confrontée à SciPy (50/50 instances identiques) et certifiée par le triple test LP (faisabilité duale, gap nul, arêtes d'égalité), le pont Shapley-Shubik (cœur = polytope dual, 254 coalitions testées, 0 violations), et le contraste Gale-Shapley (stabilité qui se paie +3 sur instance divergente seedée) | 45 min |
 | 28 | [GameTheory-28-Humour-Banc](GameTheory-28-Humour-Banc.ipynb) | Python | Banc de calibration : humour, forme partagée vs stimulus — matrice de confusion du partage de forme (2 axes : rire, recadrage) | 45 min |
-| 29 | [GameTheory-29-Travelers-Dilemma](GameTheory-29-Travelers-Dilemma.ipynb) | Python | Le dilemme du voyageur (Basu 1994) : annonce $2–$100, la compagnie paie le montant le plus bas, +$2 au moins-disant / −$2 au plus-disant — l'élimination itérée des stratégies strictement dominées converge vers l'unique équilibre (2,2), que contredisent les comportements humains (~$100), et la sensibilité au bonus révèle le seuil r* = 1 où le paradoxe se dissout (contre-claim : robustesse du paradoxe au bonus mineur) | 45 min |
 
 Les huit extensions `3a` à `3h` figurent dans la Partie 1, au voisinage du notebook GT-3 qu'elles prolongent. Elles couvrent respectivement les chemins de swaps, les chambres et murs, le joueur LLM, le plan de déformation, les méta-actions tarifées, le parcours complet, la dérivation quotient et les deux espèces de flèches.
 
@@ -804,6 +804,7 @@ GameTheory/
 ├── GameTheory-02-NormalForm-Part2-Python.ipynb      #   Tranche 2 du Python NormalForm — support enumeration mixte NxN from-scratch (numpy) + vérification nashpy
 ├── GameTheory-02-NormalForm-Csharp.ipynb            # Jumeau C# (.NET Interactive, parité #4956) — forme normale + Nash from-scratch (Tranche 1)
 ├── GameTheory-02-NormalForm-Csharp-Part2.ipynb      #   Tranche 2 du jumeau C# NormalForm
+├── GameTheory-02c-Travelers-Dilemma.ipynb           # Dilemme du voyageur (Basu 1994) : paradoxe de l'élimination itérée, seuil r* = 1
 ├── GameTheory-03-Topology2x2.ipynb
 ├── GameTheory-03-Topology2x2-Csharp.ipynb           # Jumeau C# — classification ordinale 2×2 from-scratch
 ├── GameTheory-03a-Chemins-de-Swaps.ipynb            # Extensions littérales 3a→3f de la géométrie ordinale
@@ -874,7 +875,6 @@ GameTheory/
 ├── GameTheory-26-Ensembles-Limites-Poincare-Bendixson.ipynb
 ├── GameTheory-27-Munkres-Assignment.ipynb
 ├── GameTheory-28-Humour-Banc.ipynb                 # Banc de calibration : humour, forme partagée vs stimulus
-├── GameTheory-29-Travelers-Dilemma.ipynb           # Dilemme du voyageur (Basu 1994) : paradoxe de l'élimination itérée, seuil r* = 1
 ├── SocialChoice/                                   # Sous-série Choix Social (8 notebooks : 5 pères Python/Lean + 3 twins C#, parité #4956)
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb
 │   ├── 01-Arrow-Impossibility-Theorem-Csharp.ipynb

--- a/docs/curriculum/recherche.md
+++ b/docs/curriculum/recherche.md
@@ -112,6 +112,7 @@ Inférence probabiliste (Infer.NET, Pyro, PyMC), théorie de l'information inté
 | 81 | GameTheory 27b — Le lake assignment_lean par son… | BETA | Non |
 | 82 | GameTheory-28 : Banc de calibration — humour, forme… | BETA | Oui |
 | 83 | GameTheory-28b : Banc humour — passer à l'échelle | BETA | Non |
+| 84 | GameTheory-29 : Le dilemme du voyageur — l'élimination itérée vers l'unique équilibre (2,2) que contredisent les humains | BETA | Oui |
 
 ## GameTheory/SocialChoice (8 notebooks)
 

--- a/docs/curriculum/recherche.md
+++ b/docs/curriculum/recherche.md
@@ -112,7 +112,6 @@ Inférence probabiliste (Infer.NET, Pyro, PyMC), théorie de l'information inté
 | 81 | GameTheory 27b — Le lake assignment_lean par son… | BETA | Non |
 | 82 | GameTheory-28 : Banc de calibration — humour, forme… | BETA | Oui |
 | 83 | GameTheory-28b : Banc humour — passer à l'échelle | BETA | Non |
-| 84 | GameTheory-29 : Le dilemme du voyageur — l'élimination itérée vers l'unique équilibre (2,2) que contredisent les humains | BETA | Oui |
 
 ## GameTheory/SocialChoice (8 notebooks)
 
@@ -205,7 +204,7 @@ Inférence probabiliste (Infer.NET, Pyro, PyMC), théorie de l'information inté
 
 | # | Notebook | Maturité | Exécutable |
 |---|----------|----------|------------|
-| 1 | Infer-101 : Introduction a Infer.NET | BETA | Oui |
+| 1 | Infer-1b : Introduction a Infer.NET | BETA | Oui |
 | 2 | Le Framework Rational Speech Act (RSA) | BETA | Oui |
 
 ## Probas/DecisionTheory (26 notebooks)


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #14874

> **Périmètre : 2 fichiers** (net PR vs main) —
> `MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb`,
> `MyIA.AI.Notebooks/GameTheory/README.md`.
>
> `docs/curriculum/recherche.md` figure dans le champ `files` de l'API sans être
> modifié par cette PR : la tête est déjà d'accord avec `main` dessus. C'est un
> artefact **généré** (`scripts/notebook_tools/generate_parcours.py`, régénéré par
> `catalog-cron.yml`) — il appartient à l'automatisation, pas à une branche de
> contenu ; l'édition à la main qu'il portait a été revertie byte-identique. Le
> champ `files` est relatif à la **base de fusion**, pas à `main`.

## Chantier 5 — Distillation par les séries pédagogiques (#12208)

Nouveau notebook **GameTheory-02c-Travelers-Dilemma** : distillation de la source primaire
**Basu (1994), *The Traveler's Dilemma*, AER 84(2):391-395**, en mise en œuvre Python exécutable
(32 cellules : 24 markdown + 8 code, exécution de bout en bout, 3 exercices).

### Le paradoxe, porté par le code

Deux joueurs revendiquent chacun un montant entre **$2 et $100**. La compagnie paie **le montant
le plus bas** des deux, verse un **bonus de +$2** au moins-disant et inflige une **pénalité de −$2**
au plus-disant.

- **§3 — Élimination itérée** (cellule exécutée) : chaque stratégie `x > 2` est strictement dominée
  par `x−1` sur le jeu réduit ; l'élimination descendante converge vers **l'unique équilibre (2,2)** —
  `Survivants: [2]`.
- **§4 — Sensibilité au bonus** : le gain de sous-cotation `u1(c−1,c) − u1(c,c) = r − 1` révèle un
  **seuil r\* = 1**. Sous `r = 0,5` l'élimination ne démarre jamais (le paradoxe vit) ; à `r ≥ 1,0`
  la spirale s'effondre vers (2,2) (le paradoxe se dissout). Table exécutée : `r=0.5 → NON`, `r=1.0 → OUI`.
- **§5 — Contre-claim (robustesse)** : avec un bonus **épistémique** mineur (`eps`), le modèle
  conserve le paradoxe pour `eps ≥ 0,05` (meilleure réponse 96) et ne retombe sur (2,2) qu'à
  `eps = 0` — le paradoxe n'est pas un artefact du formalisme. Cet axe « contre-claim » est l'un
  des cinq requis du Chantier 5, en regard du claim central « élimination → (2,2) ».

### Requis du Chantier 5 (portés dans le markdown)

1. **Source primaire lue firsthand** — tableau de gains de Basu (1994) reproduit et cité (§ intro).
2. **Objet formel** — fonction de payoff `u1(x,y,r,c_max)` définie et exécutée (§1).
3. **Claim exact** — « l'élimination itérée converge vers (2,2), unique équilibre de Nash » (cellule 3 exécutée).
4. **Contre-claim** — robustesse du paradoxe au bonus mineur (§5, cellule exécutée).
5. **Expérience ICT candidate** — la stratégie dominée par l'élimination vs le comportement humain
   observé (~$100) comme candidat à la « faible capacité ICS » (§6 exercices).

### Exercices (C.1 — stubs corrects, le notebook s'exécute de bout en bout)

3 exercices : compléter la condition de domination (ex1), tester un montant hors grille (ex2),
relier comportement humain au paradoxe (ex3). Stubs `# TODO etudiant`/`return False`/`pass` — aucun
`raise NotImplementedError` / `assert False` / `1/0`.

## Validation (organes relancés après le dernier commit)

| Organe | Résultat |
|---|---|
| `validate_pr_notebooks.py origin/main <nb>` | **PASS** (8 cellules code, all notebooks passed) |
| `check_exec_sequence.py <nb>` | **CLEAN 1..8** (UNORDERED 0, NOT_FROM_1 0, GAP 0) |
| `check_c2_compliance.py --path <nb>` | **1/1 compliant / All clear** |
| `check_notebook_navlinks.py <nb>` | **OK: 0 lien casse** |
| `check_docs_links.py` | **scanné sur 683 fichiers, 5560 liens — No broken links found** |
| `pedagogy_density.py <nb>` | **meets the density floor** |
| `detect_consecutive_code_cells.py <nb>` | **No run of consecutive code cells** |

Commit **3145281b8** — hooks pré-commit tous verts (gitleaks, probeAddresses, papermill-path,
H.3, `#13326`). Branch `feature/12208-travelers-dilemma` (base `main` à `a716bc029`).

Voir **#12208** (sous-grain du chantier — l'epic reste ouverte).

_Note G.9 : au sweep, le README GameTheory et `docs/curriculum/recherche.md` ont été mis à jour ;
`index.qmd` (listing Quarto par glob) et `COURSE_CATALOG.generated.*` sont laissés à l'automatisation
(la génération du catalogue appartient au cron, cf. catalog-pr-hygiene)._

