### PR TITLE
fix(guard): scan_diacritics compte les lignes survivantes, pas le total -- contenu retire exonere (FP #14795)

### DIFF
--- a/scripts/notebook_tools/scan_enrich_quality.py
+++ b/scripts/notebook_tools/scan_enrich_quality.py
@@ -22,8 +22,13 @@ Defect classes and their mechanical checks:
                                signature of the wave (#14161 measured 30%,
                                #14166 20%, #14164 31%)
   Class (c) accents must survive enrichment
-    HIGH  DIACRITICS_LOSS      accented characters drop en masse (head < 40%
-                               of base; #14166 measured 99 -> 1, i.e. -99%)
+    HIGH  DIACRITICS_LOSS      a markdown line survives enrichment only as
+                               its de-accented skeleton (#14166 measured
+                               99 -> 1 chars, i.e. -99%); content REMOVED by
+                               the PR is exempt (#14795: splitting 15
+                               accented cells out of GT-04 collapsed the
+                               file total while every surviving line kept
+                               its accents)
   Class (d) inline arithmetic must be true
     HIGH  ARITH_WRONG          "A x B = C" stated in markdown is false
   Class (e) hrefs must resolve at head
@@ -79,6 +84,7 @@ import argparse
 import json
 import re
 import sys
+import unicodedata
 from pathlib import Path
 from urllib.parse import unquote
 
@@ -269,29 +275,55 @@ def scan_anchors(cells: list[dict]) -> list[dict]:
     return findings
 
 
+def _deaccent(text: str) -> str:
+    return "".join(ch for ch in unicodedata.normalize("NFD", text.lower())
+                   if not unicodedata.combining(ch))
+
+
 def scan_diacritics(head_cells: list[dict], base_cells: list[dict] | None) -> list[dict]:
-    """Class (c): accented characters must not vanish during enrichment."""
+    """Class (c): surviving markdown lines must keep their accents.
+
+    A line REMOVED by the PR is content removal, not de-accentation (#14795:
+    splitting 15 accented cells out of GT-04 collapsed the total 375 -> 96
+    while every surviving line kept its accents). The loss signature is a
+    line that survives -- same de-accented skeleton -- with all its accents
+    gone, the #14166 enrich-wave defect.
+    """
     if base_cells is None:
         return []
-    base = sum(len(_ACCENT_RE.findall(_src(c))) for _, c in _md_cells(base_cells))
-    head = sum(len(_ACCENT_RE.findall(_src(c))) for _, c in _md_cells(head_cells))
-    if base < 10:  # too few to speak of a loss
+    skeleton_accents: dict[str, list[int]] = {}
+    for _, c in _md_cells(head_cells):
+        for ln in _src(c).splitlines():
+            s = _deaccent(ln.strip())
+            if len(s) >= 15:
+                skeleton_accents.setdefault(s, []).append(
+                    len(_ACCENT_RE.findall(ln)))
+    lost_lines = 0
+    lost_chars = 0
+    for _, c in _md_cells(base_cells):
+        for ln in _src(c).splitlines():
+            accents = len(_ACCENT_RE.findall(ln))
+            if accents < 3:  # too few for one line to speak of a loss
+                continue
+            s = _deaccent(ln.strip())
+            if len(s) < 15:
+                continue
+            counts = skeleton_accents.get(s)
+            if counts and max(counts) == 0:
+                lost_lines += 1
+                lost_chars += accents
+    if not lost_lines:
         return []
-    ratio = head / base
-    if ratio < 0.4:
-        return [{
-            "cell_index": 0, "category": "DIACRITICS_LOSS", "severity": "HIGH",
-            "evidence": f"{base} -> {head} accented chars",
-            "message": f"accented characters collapse from {base} to {head} "
-                       f"({ratio:.0%}) -- generated text left the pipeline de-accented",
-        }]
-    if ratio < 0.7:
-        return [{
-            "cell_index": 0, "category": "DIACRITICS_LOSS", "severity": "MED",
-            "evidence": f"{base} -> {head} accented chars",
-            "message": f"accented characters drop from {base} to {head} ({ratio:.0%})",
-        }]
-    return []
+    # HIGH from 10 lost chars (2-3 typical md lines) or 3 lines; the wave
+    # incident #14166 measured 99 lost chars.
+    severity = "HIGH" if (lost_lines >= 3 or lost_chars >= 10) else "MED"
+    return [{
+        "cell_index": 0, "category": "DIACRITICS_LOSS", "severity": severity,
+        "evidence": f"{lost_lines} surviving line(s) lost {lost_chars} accented char(s)",
+        "message": f"{lost_lines} markdown line(s) survive only as de-accented "
+                   f"rewrites ({lost_chars} accented chars lost) -- content "
+                   f"removed by the PR is exempt, only surviving lines count",
+    }]
 
 
 def scan_survival(head_cells: list[dict], base_cells: list[dict] | None) -> list[dict]:

--- a/scripts/notebook_tools/tests/test_scan_enrich_quality.py
+++ b/scripts/notebook_tools/tests/test_scan_enrich_quality.py
@@ -96,6 +96,27 @@ class TestDiacritics:
         head = [_md("theorie")]
         assert scan_diacritics(head, base) == []
 
+    def test_removed_content_is_silent(self):
+        # #14795: a PR that splits accented cells out of a notebook collapses
+        # the file total (375 -> 96 chars) while every SURVIVING line keeps
+        # its accents -- removal is not de-accentation, must stay silent.
+        kept = ["La théorie de l'apprentissage était mesurée.",
+                "L'équilibre décrit un comportement décentralisé."]
+        base = [_md(kept[0]), _md("Le point de désaccord dérive, mesuré sur γ."),
+                _md(kept[1]), _md("Sensibilité κ paramétrée par défaut.")]
+        head = [_md(kept[0]), _md(kept[1])]
+        assert scan_diacritics(head, base) == []
+
+    def test_surviving_deaccented_line_fires(self):
+        # Same split, but one surviving line came back de-accented: the
+        # skeleton matches, the accents are gone -- the real class (c) defect.
+        base = [_md("La théorie de l'apprentissage était mesurée."),
+                _md("Le point de désaccord dérive, mesuré sur γ.")]
+        head = [_md("La theorie de l'apprentissage etait mesuree."),
+                _md("Le point de désaccord dérive, mesuré sur γ.")]
+        f = scan_diacritics(head, base)
+        assert _cats(f) == {"DIACRITICS_LOSS"} and f[0]["severity"] == "MED"
+
 
 # ---------------------------------------------------------------------------
 # Class (b): survival


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: LIGHT/readme #14906

## Objet

`DIACRITICS_LOSS` (classe c du scanner enrich-quality, #13410) compare le **total** des caractères accentués markdown base vs head. Toute PR qui retire légitimement du contenu français fait chuter ce total et déclenche un HIGH de faux positif — mesuré sur #14795, qui découpe le §8 de GT-04 en notebook dédié :

| Mesure (GT-04-NashEquilibrium.ipynb) | Valeur |
|---|---|
| Accents markdown sur `main` | 375 |
| Accents sur le head de #14795 | 96 |
| Accents des cellules 29-43 retirées (§8) | **292** |
| Cellules conservées [0:29] modifiées | 1 (idx 27 : stub C.1, sans rapport accents) |

375 − 292 = 83, le reste étant la cellule de navigation ajoutée. **Aucune ligne conservée n'a perdu ses accents** — le rouge était un faux positif structurel.

## Fix

Le prédicat compare désormais **ligne par ligne via squelette désaccentué** (NFD + suppression des combining + lower) :

- une ligne base (≥ 3 accents, ≥ 15 chars) dont le squelette survit en head avec **0 accent sur toutes ses occurrences** = vraie perte (le défaut de la vague #14166) ;
- une ligne dont le squelette **disparaît** = contenu retiré → neutre.

Sévérité : HIGH dès 3 lignes perdues ou 10 caractères perdus ; MED en dessous (l'incident #14166 mesurait 99 caractères perdus).

## Validation

- **Contrôle positif** (FP levé) : `enrich_quality_ci.py --base <GT-04 main> --head <GT-04 branche 14442>` → **rc=0** (rouge avant fix).
- **Contrôle négatif** (sensibilité conservée) : désaccentuation sabotée d'UNE ligne conservée de 13 accents dans le même contexte de retrait → `DIACRITICS_LOSS` HIGH se déclenche.
- **Tests** : `pytest scripts/notebook_tools/tests/test_scan_enrich_quality.py` → **30/30** (3 existants inchangés et verts, +2 nouveaux : `test_removed_content_is_silent`, `test_surviving_deaccented_line_fires`).

## Déblocage attendu

Après merge : `gh pr update-branch 14795` (la gate exécute le script du head de la PR) → la gate enrich-quality repasse verte sur #14795, qui redevient mergeable pour ai-01.

Voir #14795 (le FP mesuré), #13410 (l'organe d'origine).
