### PR TITLE
fix(sudoku,#14938): stale "Sudoku-7b" identifier in Sudoku-19 heading after renumbering

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-19-Lean-Propagation.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-19-Lean-Propagation.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Sudoku-7b — Soundness de la propagation de contraintes (companion formel natif)\n",
+    "# Sudoku-19 — Soundness de la propagation de contraintes (companion formel natif)\n",
     "\n",
     "Ce notebook est le **companion formel** du lake [`sudoku_lean`](sudoku_lean/),\n",
     "dont la lib `Sudoku` prouve la **soundness des règles de propagation** d'un Sudoku\n",
@@ -1061,8 +1061,8 @@
    "duration": 652.939738,
    "end_time": "2026-07-03T11:06:02.767594",
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-7b-Lean-Propagation.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-19-Lean-Propagation.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-19-Lean-Propagation.ipynb",
    "start_time": "2026-07-03T10:55:09.827856"
   }
  },


### PR DESCRIPTION
Grain: LIGHT/notebook-lean — lane myia-po-2023:CoursIA — prev: MED/notebook-python #14916

## What

Closes #14938 — l'identifiant périmé « Sudoku-7b » (antérieur au renumbering vers Sudoku-19) persistait dans le notebook `Sudoku-19-Lean-Propagation.ipynb` : c'est la source du désaccord libellé/cible surfacé par `check_link_label_agreement.py` sur les pages parcours lors du cycle #14832.

3 occurrences corrigées dans le fichier :

| Ligne | Avant | Après |
|---|---|---|
| heading (cell markdown 0) | `# Sudoku-7b — Soundness de la propagation…` | `# Sudoku-19 — Soundness de la propagation…` |
| `metadata.papermill.input_path` | `…/Sudoku-7b-Lean-Propagation.ipynb` | `…/Sudoku-19-Lean-Propagation.ipynb` |
| `metadata.papermill.output_path` | idem | idem |

## Why le heading est la clé

Le titre du catalogue dérive du premier heading du notebook : les pages parcours (`docs/curriculum/ia-classique.md`) affichent « Sudoku-7b » comme libellé vers la cible `Sudoku-19-…ipynb` — exactement la classe de défaut #13645 que l'organe de #14832 a signalée. Corriger le heading corrige la SOURCE ; le cron catalogue (`catalog-cron.yml`, quotidien sur main) rattrape le titre et régénère catalogue + parcours ≤24h.

## Non-touché (délibéré)

- **Catalogue + parcours byte-identiques à main** ([catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md) HARD 1 : jamais de régénération sur branche — le diff massif empoisonnerait la PR).
- **`translations/sudoku/sudoku.csv`** : la ligne seedée sur l'ancien contenu devient orpheline ; le mécanisme de sync bot-owned re-seedera la nouvelle clé — pas d'édition manuelle.
- **`scripts/notebook_tools/tests/test_validate_pr_notebooks.py:594`** : « Sudoku-7b.ipynb » y est un simple nom de fixture dans un tmp_path, sans lien avec ce notebook.

## Validation

- Markdown + metadata uniquement — outputs et `execution_count` intacts (exception C.2 : modifs markdown → outputs précédents valides ; Lean non ré-exécuté sur po-2023, ⛔ user stop 30/08).
- `nbformat.validate` OK après édition.
- `git diff` : 3 lignes, 1 fichier, +3/−3.
- Grep repo-wide `Sudoku-7b` : il ne reste que les artefacts générés (cron) + la fixture de test sans rapport.
