### PR TITLE
fix(organs,#14947): un acquit de persona n'eteint plus le nit user -- meme login n'est pas meme voix

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -3121,8 +3121,32 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         return False
 
     def _lift_eligible(lift_author: str, nit_author: str,
-                       lift_body: str = "") -> bool:
+                       lift_body: str = "", nit_body: str = "") -> bool:
         if lift_author == nit_author:
+            # #14947 -- meme login n'est pas meme voix. `jsboige` est A LA FOIS
+            # le compte du user et l'identite de poussee des personas (#13316).
+            # Une levee marquee `[Hermes]` / `[NanoClaw]` signe la revue de la
+            # persona sur SON propre travail ; elle ne repond pas a une remarque
+            # ecrite en voix nue par le user sous le meme login. B.0 : « se lever
+            # soi-meme une reserve d'autrui n'est pas y repondre, c'est la
+            # declarer repondue ».
+            #
+            # Le discriminant n'est pas neuf : #13609 tient deja le marqueur de
+            # persona pour une identite CROSS-login (la persona leve sa propre
+            # reserve sous l'autre login). Il vaut a fortiori SAME-login, ou la
+            # borne d'auteur #11145 ne discrimine plus rien.
+            #
+            # Incident fondateur #14937 : nit user 19:20:05Z (« Concern: le
+            # notebook ne devrait-il pas etre une accretion... »), review
+            # `[Hermes]` a 19:26:40Z terminee par un « RAS » nu -- six minutes
+            # plus tard, sur un tout autre objet (re-execution des cellules).
+            # Le RAS eteignait le nit : rc=0, PR mergeable, remarque user perdue.
+            # La levee etant PAR PR et non par reserve, un acquit de routine de
+            # la persona suffisait a solder la voix du user.
+            if (_PERSONA_MARKERS_RE.search(_strip_quoted(lift_body or ""))
+                    and not _PERSONA_MARKERS_RE.search(
+                        _strip_quoted(nit_body or ""))):
+                return False
             return True
         # #13609 -- alias de persona Hermes/NanoClaw cross-login. La persona
         # parle sous clusterManager-Myia ET jsboige. Quand elle leve SA
@@ -3392,7 +3416,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
             # NLP documentee dans can_lift.
             lifted = (_approved_lifts_reserve(login, when, pr_author)
                       or any(when < t < cutoff
-                             and _lift_eligible(lifter, login, lift_body)
+                             and _lift_eligible(lifter, login, lift_body, body)
                              for (t, lifter, lift_body) in explicit_lifts)
                       # #14218 conditions 5+6 — voir commentaire `followup_lifts`
                       or any(when < t < cutoff and namer in (login, pr_author)
@@ -3413,7 +3437,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         elif kind == "BLOCK":
             if (any(
                     when < t < cutoff
-                    and _lift_eligible(lift_author, login, lift_body)
+                    and _lift_eligible(lift_author, login, lift_body, body)
                     and (lift_author != pr_author
                          or bool(OVERRIDE_LANE.search(lift_body)))
                     for (t, lift_author, lift_body) in explicit_lifts)
@@ -3440,7 +3464,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         # OU une re-review APPROVED de l'auteur de la reserve (etat natif
         # GitHub, phrase de levee au sens fort).
         elif (any(
-                  when < t < cutoff and _lift_eligible(lift_author, login, lift_body)
+                  when < t < cutoff and _lift_eligible(lift_author, login, lift_body, body)
                   for (t, lift_author, lift_body) in explicit_lifts
               ) or _approved_lifts_reserve(login, when, pr_author)
               or any(when < t < cutoff and namer in (login, pr_author)


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA -- prev: LIGHT/tooling #14776

See #14947

## Le défaut

L'organe de B.0 rendait `rc=0` sur une PR portant un **nit user non traité**.

Mesuré sur **#14937** :

| Heure | Auteur | Contenu |
|---|---|---|
| 19:20:05Z | `jsboige` (**le user**) | `Concern: Le notebook ne devrait-il pas être une accrétion de l'induction arrière? […] mériteraient une renumérotation` |
| 19:26:40Z | `jsboige` (**persona Hermes**) | review `COMMENTED` sur la re-exécution des 8 cellules, terminée par un **`RAS`** nu |

Six minutes. Le `RAS` ne dit rien de l'accrétion ni de la renumérotation — il éteint pourtant le nit, et la PR devient mergeable avec la remarque du user perdue.

**Le nit était détecté.** `classify` rend `HUMAN`, `_CONCERN_LABEL` matche bien `Concern:`. Ce n'est pas un trou de vocabulaire : il est détecté **puis éteint**. Durcir le dictionnaire n'y aurait rien fait.

## La cause : la conjonction de deux propriétés connues

1. **Une levée est par PR, pas par réserve** — `explicit_lifts` est global.
2. **`jsboige` est à la fois le compte du user et l'identité de poussée des personas** (#13316) — donc la borne d'auteur #11145 s'ouvre sur `lift_author == nit_author` et **ne discrimine rien**.

Conséquence : tout acquit de routine d'une persona solde la voix du user. C'est mot pour mot ce que B.0 interdit — *« se lever soi-même une réserve d'autrui n'est pas y répondre, c'est la déclarer répondue »*.

## Le correctif — soustraire, pas ajouter

Aucun prédicat neuf. `_PERSONA_MARKERS_RE` est **déjà** tenu par #13609 pour une identité **cross-login** (la persona lève sa propre réserve sous l'autre login). Il vaut *a fortiori* **same-login**, là où la borne d'auteur est vacue.

Règle ajoutée dans `_lift_eligible` : **une levée marquée persona ne lève pas une réserve rédigée en voix nue.** Même login n'est pas même voix. `+28/−4`.

## Contrôles — sur l'organe réel, pas sur une réimplémentation

| Contrôle | Attendu | Obtenu |
|---|---|---|
| #14937 en l'état | bloque **en nommant** le nit | `rc=1`, nit cité intégralement |
| + levée en **voix nue** | lève | `blocked = False` |
| + levée de **persona** | ne lève pas | `blocked = True` |

Le deuxième est celui qui compte : il prouve que le garde reste **extinguible** et n'est pas devenu un mur. Un garde qu'on ne peut plus éteindre est un garde qu'on contourne.

## Régression

**60 PR mergées les plus récentes** : 5 bloquantes avant, 5 après, **0 verdict changé**.

**Portée honnête de ce zéro** — un zéro-régression est aussi ce que rend un correctif mort, donc la mesure de contrôle : le corpus porte **49 levées vivantes dont 23 marquées persona (47 %)**, mais seulement **3 nits en voix nue**, et la paire (nit voix nue → levée persona, même login) y apparaît **0 fois**. Le zéro est donc réel mais **peu informatif** : dans cette fenêtre, la branche ne tire que sur #14937. Magnitude sur fenêtre élargie postée en commentaire.

## Ce que cette PR ne corrige pas

La propriété (1) — *une levée est par PR, pas par réserve* — **reste entière** : deux réserves de personas distinctes sont toujours soldées par un seul acquit. Cette PR ne protège que la **voix nue du user**, la surface où la perte est irréparable parce que le user ne relance pas. L'appariement levée↔réserve est un chantier distinct, non ouvert ici.

## Note de protocole

Genre `guard` = classe **META** : cette PR **ne tient pas** le plancher G-VAR-1 du cycle, et je ne le prétends pas. Elle répond à un mandat user explicite (« continue à améliorer les organes »). Le grain de contenu du cycle est la tranche A de **#14944** (renumérotation GameTheory), dispatchée séparément.
