### PR TITLE
fix(docker,#14941): redact le credential des logs de boot des services ai-dock (2 vecteurs)

### DIFF
--- a/docker-configurations/services/forge-turbo/Dockerfile
+++ b/docker-configurations/services/forge-turbo/Dockerfile
@@ -20,6 +20,14 @@ RUN source /opt/environments/python/forge/bin/activate && \
 # The base image uses user 1000 (often named 'user' or 'webui')
 RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webui-forge
 
+# #14941: ai-dock's env-store.sh echoes every stored env var's VALUE to stdout
+# (-> docker logs): at boot, init.sh calls it for ALL env vars, leaking
+# FORGE_ARGS (contains --gradio-auth admin:<password>) and WEB_PASSWORD.
+# Drop the value from the log line; the persistence append to
+# /opt/ai-dock/etc/environment.sh (required by the app) is kept intact.
+# Before USER appuser (file is root-owned); after the cached pip layers.
+RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
+
 RUN groupadd -g 1000 appuser && \
     useradd -u 1000 -g appuser -m -s /bin/bash appuser
 

--- a/docker-configurations/services/forge-turbo/Dockerfile
+++ b/docker-configurations/services/forge-turbo/Dockerfile
@@ -28,6 +28,30 @@ RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webu
 # Before USER appuser (file is root-owned); after the cached pip layers.
 RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
 
+# #14941 (vecteur 2/2) : modules/launch_utils.py (app Forge) imprime argv au
+# boot ("Launching Web UI with arguments: ...") -> gradio-auth admin:<pw> dans
+# les logs. Redaction de la paire credential dans CE print seulement ; le flag
+# atteint l'app inchangé. NB : fichier app — une mise à jour git au runtime
+# peut le restaurer (même précarité que le sed requirements ci-dessus).
+RUN python3 - <<'PYEOF'
+BS = chr(92)
+p = "/opt/stable-diffusion-webui-forge/modules/launch_utils.py"
+src = open(p, encoding="utf-8").read()
+anchor = '    print(f"Launching '
+pattern = "r'(--gradio-auth[ =])[^ ]*'"
+repl = "r'" + BS + "1***'"
+helper = (
+    "    _redacted_args = re.sub(" + pattern + ", " + repl
+    + ", shlex.join(sys.argv[1:]))\n"
+)
+assert src.count(anchor) == 1, "anchor not unique: print(f Launching"
+assert src.count("{shlex.join(sys.argv[1:])}") == 1, "fragment not unique"
+src = src.replace(anchor, helper + anchor)
+src = src.replace("{shlex.join(sys.argv[1:])}", "{_redacted_args}")
+open(p, "w", encoding="utf-8").write(src)
+print("launch_utils.py patched: gradio-auth redacted in startup print")
+PYEOF
+
 RUN groupadd -g 1000 appuser && \
     useradd -u 1000 -g appuser -m -s /bin/bash appuser
 

--- a/docker-configurations/services/sd-forge-main/Dockerfile
+++ b/docker-configurations/services/sd-forge-main/Dockerfile
@@ -16,3 +16,11 @@ RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webu
 
 RUN source /opt/environments/python/forge/bin/activate && \
     python -c "import numpy; import cv2; import skimage; print('Imports successful')"
+
+# #14941: ai-dock's env-store.sh echoes every stored env var's VALUE to stdout
+# (-> docker logs): at boot, init.sh calls it for ALL env vars, leaking
+# FORGE_ARGS (contains --gradio-auth admin:<password>) and WEB_PASSWORD.
+# Drop the value from the log line; the persistence append to
+# /opt/ai-dock/etc/environment.sh (required by the app) is kept intact.
+# Last layer, after the cached pip layers, to keep rebuilds cheap.
+RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh

--- a/docker-configurations/services/sd-forge-main/Dockerfile
+++ b/docker-configurations/services/sd-forge-main/Dockerfile
@@ -24,3 +24,27 @@ RUN source /opt/environments/python/forge/bin/activate && \
 # /opt/ai-dock/etc/environment.sh (required by the app) is kept intact.
 # Last layer, after the cached pip layers, to keep rebuilds cheap.
 RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
+
+# #14941 (vecteur 2/2) : modules/launch_utils.py (app Forge) imprime argv au
+# boot ("Launching Web UI with arguments: ...") -> gradio-auth admin:<pw> dans
+# les logs. Redaction de la paire credential dans CE print seulement ; le flag
+# atteint l'app inchangé. NB : fichier app — une mise à jour git au runtime
+# peut le restaurer (même précarité que le sed requirements ci-dessus).
+RUN python3 - <<'PYEOF'
+BS = chr(92)
+p = "/opt/stable-diffusion-webui-forge/modules/launch_utils.py"
+src = open(p, encoding="utf-8").read()
+anchor = '    print(f"Launching '
+pattern = "r'(--gradio-auth[ =])[^ ]*'"
+repl = "r'" + BS + "1***'"
+helper = (
+    "    _redacted_args = re.sub(" + pattern + ", " + repl
+    + ", shlex.join(sys.argv[1:]))\n"
+)
+assert src.count(anchor) == 1, "anchor not unique: print(f Launching"
+assert src.count("{shlex.join(sys.argv[1:])}") == 1, "fragment not unique"
+src = src.replace(anchor, helper + anchor)
+src = src.replace("{shlex.join(sys.argv[1:])}", "{_redacted_args}")
+open(p, "w", encoding="utf-8").write(src)
+print("launch_utils.py patched: gradio-auth redacted in startup print")
+PYEOF

--- a/docker-configurations/services/sdnext/Dockerfile
+++ b/docker-configurations/services/sdnext/Dockerfile
@@ -20,4 +20,12 @@ RUN source /opt/environments/python/forge/bin/activate && \
 RUN groupadd -g 1000 appuser && \
     useradd -u 1000 -g appuser -m -s /bin/bash appuser
 
+# #14941: ai-dock's env-store.sh echoes every stored env var's VALUE to stdout
+# (-> docker logs): at boot, init.sh calls it for ALL env vars, leaking
+# FORGE_ARGS (contains --gradio-auth admin:<password>) and WEB_PASSWORD.
+# Drop the value from the log line; the persistence append to
+# /opt/ai-dock/etc/environment.sh (required by the app) is kept intact.
+# Before USER appuser (file is root-owned); after the cached pip layers.
+RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
+
 USER appuser

--- a/docker-configurations/services/sdnext/Dockerfile
+++ b/docker-configurations/services/sdnext/Dockerfile
@@ -28,4 +28,28 @@ RUN groupadd -g 1000 appuser && \
 # Before USER appuser (file is root-owned); after the cached pip layers.
 RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
 
+# #14941 (vecteur 2/2) : modules/launch_utils.py (app Forge) imprime argv au
+# boot ("Launching Web UI with arguments: ...") -> gradio-auth admin:<pw> dans
+# les logs. Redaction de la paire credential dans CE print seulement ; le flag
+# atteint l'app inchangé. NB : fichier app — une mise à jour git au runtime
+# peut le restaurer (même précarité que le sed requirements ci-dessus).
+RUN python3 - <<'PYEOF'
+BS = chr(92)
+p = "/opt/stable-diffusion-webui-forge/modules/launch_utils.py"
+src = open(p, encoding="utf-8").read()
+anchor = '    print(f"Launching '
+pattern = "r'(--gradio-auth[ =])[^ ]*'"
+repl = "r'" + BS + "1***'"
+helper = (
+    "    _redacted_args = re.sub(" + pattern + ", " + repl
+    + ", shlex.join(sys.argv[1:]))\n"
+)
+assert src.count(anchor) == 1, "anchor not unique: print(f Launching"
+assert src.count("{shlex.join(sys.argv[1:])}") == 1, "fragment not unique"
+src = src.replace(anchor, helper + anchor)
+src = src.replace("{shlex.join(sys.argv[1:])}", "{_redacted_args}")
+open(p, "w", encoding="utf-8").write(src)
+print("launch_utils.py patched: gradio-auth redacted in startup print")
+PYEOF
+
 USER appuser


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-python #14916

## What

See #14941 — à chaque boot, `docker logs sd-forge-main` exposait le mot de passe **par deux vecteurs distincts**, tous deux corrigés :

**Vecteur 1 — env-store.sh (image amont ai-dock).** `/opt/ai-dock/bin/env-store.sh` termine par `printf "Stored environment variable '%s': %s\n" "$key" "$value"` — et `init.sh` (Cmd par défaut, non surchargé) appelle `init_write_environment()` (init.sh:396) qui boucle sur **toutes** les variables d'environnement du conteneur via `env -0` → chaque valeur d'env se retrouve dans les logs de boot (`FORGE_ARGS` avec `--gradio-auth admin:<pw>`, `WEB_PASSWORD`, `WEB_PASSWORD_B64`…). Rien de tout cela n'est dans notre repo (`git grep "Stored environment variable"` = 0) : la chaîne appartient à l'image de base.

**Vecteur 2 — le print de l'app Forge.** `modules/launch_utils.py:545` imprime son argv complet au démarrage : `Launching Web UI with arguments: --api … --gradio-auth admin:<pw> …` (acheminé dans docker logs via le logtail supervisor `forge.log`).

## Fix (3 services × 2 layers RUN)

| Service | FROM | env-store sed | launch_utils redaction |
|---|---|---|---|
| `sd-forge-main` | `ghcr.io/ai-dock/stable-diffusion-webui-forge:latest-cuda` | oui | oui |
| `forge-turbo` | idem | oui | oui |
| `sdnext` | idem | oui | oui |

1. **env-store** : l'echo perd la valeur (`Stored environment variable '%s'\n`), l'append de persistance vers `/opt/ai-dock/etc/environment.sh` — requis par l'app — reste **intact, bit à bit**. Protection générique : toute variable future portant un secret est couverte.
2. **launch_utils.py** : le print calcule `_redacted_args = re.sub(r'(--gradio-auth[ =])[^ ]*', r'\1***', shlex.join(sys.argv[1:]))` — seule la **paire credential** est masquée dans CE print ; le flag réel atteint l'app inchangé.

Placement : après les layers pip cachés (rebuild pas cher), avant `USER appuser` là où il existe (`env-store.sh` est `root:ai-dock`, non inscriptible par appuser ; `launch_utils.py` root-owned). Rebuild `sd-forge-main` mesuré : env-store layer caché, seul le layer nouveau s'exécute.

Survey (acceptance c) : les 9 autres services partent de `python:3.11-slim` / `nvidia/cuda…` / `fishaudio` — pas d'env-store.sh ni de webui Forge, non concernés.

## Mesures (acceptance révisée du commentaire coordinator)

| Mesure | Avant | Après |
|---|---|---|
| `docker logs … \| grep -c "gradio-auth admin:."` | ≥ 2 (ligne env-store FORGE_ARGS attestée par le body de l'issue + ligne Launching mesurée = 1 au premier boot post-vecteur-1) | **0** |
| `grep -c "Stored environment variable 'WEB_PASSWORD':"` (avec valeur) | 1 (forme à valeur — attestée par le script non patché lu dans l'image d'origine ; les logs du conteneur d'origine ont été perdus à la recréation) | **0** (la ligne `Stored environment variable 'WEB_PASSWORD'` subsiste, sans valeur) |
| Ligne `Launching Web UI with arguments:` | `--gradio-auth admin:<pw>` | `--gradio-auth ***` (mesuré, autres args intacts) |
| `/opt/ai-dock/etc/environment.sh` | `export FORGE_ARGS=…` / `export WEB_PASSWORD=…` présents | **identiques** (1/1) — le mécanisme de persistance requis n'est pas cassé |
| Boot | healthy | **healthy** (compose healthcheck) |
| Auth app | — | **active** : `curl /config` → `{"detail":"Not authenticated"}` (le flag redacté à l'affichage est bien passé réel) |

Mesure §2 demandée par le coordinator (compte seul) : `grep -c "Stored environment variable 'WEB_PASSWORD'"` = 1 en key-only post-fix ; la forme « avec valeur » (deux-points) = 0. La surface était bien **double** (FORGE_ARGS + WEB_PASSWORD portent la même valeur) — le patch env-store étant générique, les deux sont couvertes, ainsi que `WEB_PASSWORD_B64`.

## Écart assumé vs bullet « mécanisme sans variable d'environnement »

Le commentaire coordinator propose un mécanisme de remplacement ne reposant pas sur une env var (fichier lu par l'app, `secrets:` compose). **Non retenu ici** : l'app Forge ne sait pas lire un auth-file (`--gradio-auth` ne prend que `user:pass` en CLI), et `secrets:` compose exige que l'app lise le fichier — elle ne le fait pas. Le geste livré attaque l'autre bout constaté au §1 du commentaire : **l'image journalise → on silencie la journalisation**, aux deux sources, pour toute variable (présente et future). Le secret reste transporté par env var en interne (jamais loggé). Si la direction reste « zéro secret en env var », cela demande un wrapper entrypoint qui lit le `.env`/un fichier secret et construit le CLI — changement plus profond, à trancher en issue dédiée si souhaité.

**Rotation (§4)** : suivie par ai-01 dès le merge, conformément au commentaire — pas dans cette PR.

## Signalement hors scope

Le premier boot post-fix a confirmé un défaut préexistant indépendant : `FORGE_ARGS` passe `--api` **sans** `--api-auth` — l'extension API A1111 (`/sdapi/v1/…`) répond 200 sans credential (l'auth Gradio, elle, est bien active). Configuration d'origine, non touchée ici ; à traiter en sujet séparé si jugé utile (le service écoute sur le réseau docker/local).

## Non-touché

- Aucune valeur de mot de passe dans ce repo/PR : les citations sont tronquées (`<pw>`).
- Compose / entrypoints / genai-stack inchangés.
- Caveat honnête : `launch_utils.py` est un fichier app — un `git pull` de mise à jour au runtime peut restaurer le print non redacté (précarité identique au sed `requirements…txt` opencv déjà en place dans ces Dockerfiles ; env-store.sh, lui, est hors du checkout app).

## Validation

- Sed testé sur le script extrait de l'image (git-bash et GNU sed conteneur) : echo patché, append intact.
- Patch launch_utils testé sur copie dans le conteneur : `py_compile` OK (Python 3.10 — le `\1` vit hors f-string, l'expression f-string sans backslash) + rendu vérifié : `--api --gradio-auth *** --port 7860`.
- Les asserts du heredoc (`count == 1`) échouent le build si l'amont bouge les lignes — pas de patch silencieux dérivé.
- Image rebuildée, conteneur recréé depuis la branche, tableau de mesures ci-dessus.
- Diff : 3 fichiers, Dockerfiles only.
