### PR TITLE
fix(docker,#14956): --api-auth sur les 3 services Forge + redaction etendue (api-auth)

### DIFF
--- a/docker-configurations/services/forge-turbo/Dockerfile
+++ b/docker-configurations/services/forge-turbo/Dockerfile
@@ -28,17 +28,18 @@ RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webu
 # Before USER appuser (file is root-owned); after the cached pip layers.
 RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
 
-# #14941 (vecteur 2/2) : modules/launch_utils.py (app Forge) imprime argv au
-# boot ("Launching Web UI with arguments: ...") -> gradio-auth admin:<pw> dans
-# les logs. Redaction de la paire credential dans CE print seulement ; le flag
-# atteint l'app inchangé. NB : fichier app — une mise à jour git au runtime
-# peut le restaurer (même précarité que le sed requirements ci-dessus).
+# #14941 (vecteur 2/2) + #14956 : modules/launch_utils.py (app Forge) imprime
+# argv au boot ("Launching Web UI with arguments: ...") -> gradio-auth ET
+# api-auth admin:<pw> dans les logs. Redaction de la paire credential dans CE
+# print seulement ; les flags atteignent l'app inchangés. NB : fichier app —
+# une mise à jour git au runtime peut le restaurer (même précarité que le sed
+# requirements ci-dessus).
 RUN python3 - <<'PYEOF'
 BS = chr(92)
 p = "/opt/stable-diffusion-webui-forge/modules/launch_utils.py"
 src = open(p, encoding="utf-8").read()
 anchor = '    print(f"Launching '
-pattern = "r'(--gradio-auth[ =])[^ ]*'"
+pattern = "r'(--(?:gradio|api)-auth[ =])[^ ]*'"
 repl = "r'" + BS + "1***'"
 helper = (
     "    _redacted_args = re.sub(" + pattern + ", " + repl

--- a/docker-configurations/services/forge-turbo/docker-compose.yml
+++ b/docker-configurations/services/forge-turbo/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - CUDA_VISIBLE_DEVICES=0
       - WEB_USER=${FORGE_USER:-admin}
       - WEB_PASSWORD=${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)}
-      - FORGE_ARGS=--ui-settings-file config-turbo.json --api --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --gpu-device-id 0 --xformers --skip-install
+      - FORGE_ARGS=--ui-settings-file config-turbo.json --api --api-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --gpu-device-id 0 --xformers --skip-install
     volumes:
       # Checkpoint models (SDXL Lightning, etc.)
       - ../../shared/models/checkpoints:/opt/stable-diffusion-webui-forge/models/Stable-diffusion

--- a/docker-configurations/services/sd-forge-main/Dockerfile
+++ b/docker-configurations/services/sd-forge-main/Dockerfile
@@ -25,17 +25,18 @@ RUN source /opt/environments/python/forge/bin/activate && \
 # Last layer, after the cached pip layers, to keep rebuilds cheap.
 RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
 
-# #14941 (vecteur 2/2) : modules/launch_utils.py (app Forge) imprime argv au
-# boot ("Launching Web UI with arguments: ...") -> gradio-auth admin:<pw> dans
-# les logs. Redaction de la paire credential dans CE print seulement ; le flag
-# atteint l'app inchangé. NB : fichier app — une mise à jour git au runtime
-# peut le restaurer (même précarité que le sed requirements ci-dessus).
+# #14941 (vecteur 2/2) + #14956 : modules/launch_utils.py (app Forge) imprime
+# argv au boot ("Launching Web UI with arguments: ...") -> gradio-auth ET
+# api-auth admin:<pw> dans les logs. Redaction de la paire credential dans CE
+# print seulement ; les flags atteignent l'app inchangés. NB : fichier app —
+# une mise à jour git au runtime peut le restaurer (même précarité que le sed
+# requirements ci-dessus).
 RUN python3 - <<'PYEOF'
 BS = chr(92)
 p = "/opt/stable-diffusion-webui-forge/modules/launch_utils.py"
 src = open(p, encoding="utf-8").read()
 anchor = '    print(f"Launching '
-pattern = "r'(--gradio-auth[ =])[^ ]*'"
+pattern = "r'(--(?:gradio|api)-auth[ =])[^ ]*'"
 repl = "r'" + BS + "1***'"
 helper = (
     "    _redacted_args = re.sub(" + pattern + ", " + repl

--- a/docker-configurations/services/sd-forge-main/docker-compose.yml
+++ b/docker-configurations/services/sd-forge-main/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
       - WEB_USER=${FORGE_USER:-admin}
       - WEB_PASSWORD=${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)}
-      - FORGE_ARGS=--api --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --gpu-device-id 0 --xformers --skip-install
+      - FORGE_ARGS=--api --api-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --gpu-device-id 0 --xformers --skip-install
     volumes:
       - ../../shared/models:/opt/storage/stable_diffusion/models
       - ../../shared/outputs:/opt/storage/stable_diffusion/outputs

--- a/docker-configurations/services/sdnext/Dockerfile
+++ b/docker-configurations/services/sdnext/Dockerfile
@@ -28,17 +28,18 @@ RUN groupadd -g 1000 appuser && \
 # Before USER appuser (file is root-owned); after the cached pip layers.
 RUN sed -i "/Stored environment variable/ s|': %s|'|; /Stored environment variable/ s|\" \"[$]value\"|\"|" /opt/ai-dock/bin/env-store.sh
 
-# #14941 (vecteur 2/2) : modules/launch_utils.py (app Forge) imprime argv au
-# boot ("Launching Web UI with arguments: ...") -> gradio-auth admin:<pw> dans
-# les logs. Redaction de la paire credential dans CE print seulement ; le flag
-# atteint l'app inchangé. NB : fichier app — une mise à jour git au runtime
-# peut le restaurer (même précarité que le sed requirements ci-dessus).
+# #14941 (vecteur 2/2) + #14956 : modules/launch_utils.py (app Forge) imprime
+# argv au boot ("Launching Web UI with arguments: ...") -> gradio-auth ET
+# api-auth admin:<pw> dans les logs. Redaction de la paire credential dans CE
+# print seulement ; les flags atteignent l'app inchangés. NB : fichier app —
+# une mise à jour git au runtime peut le restaurer (même précarité que le sed
+# requirements ci-dessus).
 RUN python3 - <<'PYEOF'
 BS = chr(92)
 p = "/opt/stable-diffusion-webui-forge/modules/launch_utils.py"
 src = open(p, encoding="utf-8").read()
 anchor = '    print(f"Launching '
-pattern = "r'(--gradio-auth[ =])[^ ]*'"
+pattern = "r'(--(?:gradio|api)-auth[ =])[^ ]*'"
 repl = "r'" + BS + "1***'"
 helper = (
     "    _redacted_args = re.sub(" + pattern + ", " + repl

--- a/docker-configurations/services/sdnext/docker-compose.yml
+++ b/docker-configurations/services/sdnext/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
       - WEB_USER=${FORGE_USER:-admin}
       - WEB_PASSWORD=${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)}
-      - FORGE_ARGS=--api --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --gpu-device-id 0 --xformers --skip-install
+      - FORGE_ARGS=--api --api-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)} --gpu-device-id 0 --xformers --skip-install
     volumes:
       - ../../shared/models:/opt/storage/stable_diffusion/models
       - ../../shared/outputs:/opt/storage/stable_diffusion/outputs


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #14954

## What

See #14956 — les trois services Forge/SDNext passaient `--api` **sans** `--api-auth` : l'extension API A1111 (`/sdapi/v1/…`) répondait **sans credential**, tandis que `--gradio-auth` protège seulement l'UI. Le geste : ajouter `--api-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?…}` aux côtés de `--api` et **étendre le motif de redaction de #14954** pour couvrir `--api-auth` (couplage demandé par l'issue).

## Portée mesurée (acceptance 1) — avant de qualifier

| Service | `ports:` du compose | Binding host mesuré |
|---|---|---|
| `sd-forge-main` | `127.0.0.1:7862:7860` | `127.0.0.1:7862` LISTENING (loopback seul) |
| `forge-turbo` | `127.0.0.1:${FORGE_PORT:-17861}:17860` + `127.0.0.1:1111:1111` | — (pas de conteneur live) |
| `sdnext` | `127.0.0.1:7861:7860` | — (pas de conteneur live) |

**Surface réelle** : publiée sur **127.0.0.1 uniquement** → non joignable depuis le LAN (une machine du LAN ne peut pas atteindre le loopback de l'hôte ; le binding est mesuré, pas supposé). La porte « réelle » à fermer est le **réseau conteneur** : `/sdapi/v1/options` **sans credential = 200** (mesuré par accès direct dans le conteneur) — c'est le contrôle positif. Le front hôte (caddy, port 7862) ajoute déjà une couche 302, mais l'extension A1111 reste ouverte en direct.

*Note d'honnêteté* : l'appel /sdapi/v1 depuis **une autre** machine du LAN n'a pas pu être exécuté depuis po-2023 (pas de SSH vers les pairs, machine executor). Le binding `127.0.0.1` est l'évidence autoritative d'absence d'exposition LAN — la jambe « appel cross-machine » est RAPPORTÉE (dérivée du binding), pas VERIFIÉE par un appel réel.

## Geste (6 fichiers, 3 composes + 3 Dockerfiles)

1. **`--api-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:?…}`** inséré après `--api` dans `FORGE_ARGS` des trois composes — même forme fail-closed `:?` déjà en place (#14726), **aucune valeur en clair** dans le dépôt.
2. **Redaction étendue** (#14954) : `modules/launch_utils.py` passe de `re.sub(r'(--gradio-auth[ =])[^ ]*', …)` à `re.sub(r'(--(?:gradio|api)-auth[ =])[^ ]*', …)` — couvre les deux flags. Le heredoc conserve ses `assert count == 1` (casse le build si l'amont bouge).

## Validation (acceptance 3 + 4) — boot réel reconstruit

Image rebuildée, conteneur `sd-forge-main` recréé (compose à jour), healthy :

- **Faux négatifs (a3)** : ligne `Launching Web UI with arguments:` = `--api --api-auth *** --api-log --listen --gradio-auth *** --gpu-device-id 0 --xformers --skip-install --port 17860` — **ni** api-auth **ni** gradio-auth avec valeur. `grep -c "gradio-auth admin:."` = 0 ; `grep -c "api-auth admin:."` = 0.
- **Contrôle positif (a4)** : `/sdapi/v1/options` sans credential (direct conteneur) : **401** après le geste (mesuré **200 avant**, sur la même instance à l'instant — la mesure mesure donc bien quelque chose).
  - avec credential faux : 401 ;
  - avec le credential présent (lu depuis le var, jamais affiché) : **200** — l'auth API réelle fonctionne.
- **Auth UI toujours OK** : `POST /login` avec le credential → 200 (Gradio inchangé).
- **Health** : `State.Health.Status` = healthy.

## Non-touché

- Aucune valeur/empreinte de secret dans le repo ; les `:?...` fail-closed conservés.
- `forge-turbo`/`sdnext` : images non rebuildées localement (même layer que sd-forge-main + RUN vérifié sur l'image de base fraîche ; rebuild au prochain déploiement). Compose édités dans le repo (source) uniquement — les copies de déploiement locales (CoursIA-2, arbre partagé) sont des arbres de déploiement, pas commitées par cette PR.
- Le front caddy (port hôte 7862) reste tel quel — il est hors sujet (#14956 porte sur l'extension A1111).
