### PR TITLE
fix(lean): noeud en huit corrige — le cablage precedent etait un entrelacs a deux composantes

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
@@ -159,14 +159,18 @@ def trefoil : Knot where
 
 /- Le noeud en huit (4_1), le noeud le plus simple avec un nombre de croisements de 4.
 
-Code PD issu de KnotInfo : [[1,5,2,4],[3,8,4,2],[5,1,6,7],[7,3,8,6]]
+Code PD dérivé du code DT [4, 6, 8, 2] de KnotInfo : [[8,3,1,4],[2,5,3,6],[4,7,5,8],[6,1,7,2]].
+Chaque arête {1,..,8} apparaît exactement une fois en dessous et une fois en
+dessus, et le tracé des arêtes forme une boucle unique. Le câblage précédent
+([[1,5,2,4],[3,8,4,2],[5,1,6,7],[7,3,8,6]]) était en fait un entrelacs à
+deux composantes, pas un noeud.
 -/
 def figureEightDiagram : KnotDiagram where
   crossings := [
-    ⟨1, 5, 2, 4⟩,
-    ⟨3, 8, 4, 2⟩,
-    ⟨5, 1, 6, 7⟩,
-    ⟨7, 3, 8, 6⟩
+    ⟨8, 3, 1, 4⟩,
+    ⟨2, 5, 3, 6⟩,
+    ⟨4, 7, 5, 8⟩,
+    ⟨6, 1, 7, 2⟩
   ]
   numEdges := 8
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
@@ -155,14 +155,18 @@ def trefoil : Knot where
 
 /- The figure-eight knot (4_1), the simplest knot with crossing number 4.
 
-PD-code from KnotInfo: [[1,5,2,4],[3,8,4,2],[5,1,6,7],[7,3,8,6]]
+PD-code derived from KnotInfo DT-code [4, 6, 8, 2]: [[8,3,1,4],[2,5,3,6],[4,7,5,8],[6,1,7,2]].
+Each edge {1,..,8} appears exactly once as an under-strand and once as an
+over-strand, and the edge trace forms a single loop. The previous wiring
+([[1,5,2,4],[3,8,4,2],[5,1,6,7],[7,3,8,6]]) was in fact a two-component
+link, not a knot.
 -/
 def figureEightDiagram : KnotDiagram where
   crossings := [
-    ⟨1, 5, 2, 4⟩,
-    ⟨3, 8, 4, 2⟩,
-    ⟨5, 1, 6, 7⟩,
-    ⟨7, 3, 8, 6⟩
+    ⟨8, 3, 1, 4⟩,
+    ⟨2, 5, 3, 6⟩,
+    ⟨4, 7, 5, 8⟩,
+    ⟨6, 1, 7, 2⟩
   ]
   numEdges := 8
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
@@ -452,6 +452,18 @@ theorem det_two_aux (M : Matrix (Fin 2) (Fin 2) (Polynomial ℤ)) :
   simp [Matrix.det_unique, Fin.sum_univ_two]
   ring
 
+/-- Déterminant 3×3 générique (même esprit que `det_two_aux` : expansion de
+Laplace le long de la première colonne, les mineurs 2×2 étant traités par
+`det_two_aux`). -/
+theorem det_three_aux (A : Matrix (Fin 3) (Fin 3) (Polynomial ℤ)) :
+    A.det = A 0 0 * (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+          - A 1 0 * (A 0 1 * A 2 2 - A 0 2 * A 2 1)
+          + A 2 0 * (A 0 1 * A 1 2 - A 0 2 * A 1 1) := by
+  rw [Matrix.det_succ_column_zero]
+  simp (config := { decide := true }) [Fin.sum_univ_succ]
+  simp (config := { decide := true }) [det_two_aux, Matrix.submatrix_apply, Fin.succAbove]
+  ring
+
 /-- Contrôle positif : le trèfle retrouve la valeur classique t² − t + 1
 sous la normalisation désignée (mineur sans première ligne ni dernière
 colonne). -/
@@ -490,6 +502,33 @@ theorem alexander_trefoilMutant :
   dsimp [trefoilMutantDiagram, mutateWindow, KleinRot.apply, trefoilDiagram]
   simp (config := { decide := true })
   rw [det_two_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntry]
+  ring
+
+/-- Contrôle de discrimination sur le nœud en huit (4_1) : sous la
+normalisation désignée (mineur sans première ligne ni dernière colonne), la
+fonction rend −2·t² + 2·t − 1 sur le câblage brut corrigé.
+
+Remarque d'honnêteté : cette valeur n'est PAS le polynôme d'Alexander
+classique de 4_1 (qui vaut ±t² ∓ 3·t ± 1, soit t² − 3·t + 1 à un facteur
+unité près) ; le théorème mesure la valeur réellement produite par la
+fonction désignée sur un câblage à 4 croisements qui forme une boucle
+unique. Le trèfle (t² − t + 1) et le déterminant |P(−1)| = 5 = det(4_1)
+sont bien reproduits, mais la forme du polynôme diverge du classique sur la
+classe à 4 croisements — anomalie documentée exhaustivement (2736 câblages
+orientés testés, dont le câblage DT [4,6,8,2]) dans l'issue de suivi ouverte
+avec ce PR.
+-/
+theorem alexander_figureEight :
+    alexanderPolynomial figureEight =
+      - (2 : Polynomial ℤ) * Polynomial.X ^ 2 + 2 * Polynomial.X - 1 := by
+  have hp : arcPartition figureEightDiagram = [[3, 4], [5, 6], [7, 8], [1, 2]] := by
+    decide
+  simp only [alexanderPolynomial, alexanderPolynomialAux, figureEight, hp]
+  simp only [figureEightDiagram]
+  simp (config := { decide := true })
+  rw [det_three_aux]
   simp only [Matrix.of_apply]
   simp (config := { decide := true }) [alexanderEntry]
   ring

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -457,6 +457,17 @@ theorem det_two_aux (M : Matrix (Fin 2) (Fin 2) (Polynomial ℤ)) :
   simp [Matrix.det_unique, Fin.sum_univ_two]
   ring
 
+/-- Generic 3×3 determinant (same spirit as `det_two_aux`: Laplace expansion
+along the first column, the 2×2 minors being handled by `det_two_aux`). -/
+theorem det_three_aux (A : Matrix (Fin 3) (Fin 3) (Polynomial ℤ)) :
+    A.det = A 0 0 * (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+          - A 1 0 * (A 0 1 * A 2 2 - A 0 2 * A 2 1)
+          + A 2 0 * (A 0 1 * A 1 2 - A 0 2 * A 1 1) := by
+  rw [Matrix.det_succ_column_zero]
+  simp (config := { decide := true }) [Fin.sum_univ_succ]
+  simp (config := { decide := true }) [det_two_aux, Matrix.submatrix_apply, Fin.succAbove]
+  ring
+
 /-- Positive control: the trefoil recovers the classical value t² − t + 1
 under the designated normalization (minor without first row nor last
 column). -/
@@ -495,6 +506,32 @@ theorem alexander_trefoilMutant :
   dsimp [trefoilMutantDiagram, mutateWindow, KleinRot.apply, trefoilDiagram]
   simp (config := { decide := true })
   rw [det_two_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntry]
+  ring
+
+/-- Discrimination control on the figure-eight knot (4_1): under the
+designated normalization (minor omitting the first row and the last column),
+the function returns −2·t² + 2·t − 1 on the corrected raw wiring.
+
+Honesty note: this value is NOT the classical Alexander polynomial of 4_1
+(which is ±t² ∓ 3·t ± 1, i.e. t² − 3·t + 1 up to a unit factor); the
+theorem measures the value actually produced by the designated function on
+a 4-crossing wiring that forms a single loop. The trefoil (t² − t + 1) and
+the determinant |P(−1)| = 5 = det(4_1) are reproduced, but the polynomial
+shape diverges from the classical value on the 4-crossing class — anomaly
+exhaustively documented (2736 orientation-valid wirings tested, including
+the DT [4,6,8,2] wiring) in the follow-up issue opened with this PR.
+-/
+theorem alexander_figureEight :
+    alexanderPolynomial figureEight =
+      - (2 : Polynomial ℤ) * Polynomial.X ^ 2 + 2 * Polynomial.X - 1 := by
+  have hp : arcPartition figureEightDiagram = [[3, 4], [5, 6], [7, 8], [1, 2]] := by
+    decide
+  simp only [alexanderPolynomial, alexanderPolynomialAux, figureEight, hp]
+  simp only [figureEightDiagram]
+  simp (config := { decide := true })
+  rw [det_three_aux]
   simp only [Matrix.of_apply]
   simp (config := { decide := true }) [alexanderEntry]
   ring


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: LIGHT/readme #14906

## Objet

Correction du câblage du noeud en huit (`figureEightDiagram`) de `knot_lean` :
le câblage précédent `[[1,5,2,4],[3,8,4,2],[5,1,6,7],[7,3,8,6]]` était un
**entrelacs à deux composantes** (les boucles {1,2,8,7} et {3,4,5,6}), pas un
noeud. Il passait tous les gardes du projet (`figureEight_wf`,
`mirror_figureEight_wf`, `figureEight_not_tricolorable`) parce que
`KnotDiagram.wf` ne vérifie que la cohérence locale (chaque arête une fois en
dessous, une fois en dessus), pas la connectivité du tracé : le défaut était
donc structurellement invisible aux decide-proofs existants.

## Fix

Remplacement par le câblage PD dérivé du code DT `[4, 6, 8, 2]` de KnotInfo :

`[[8,3,1,4],[2,5,3,6],[4,7,5,8],[6,1,7,2]]` — chaque arête {1,..,8} apparaît
exactement une fois en dessous et une fois en dessus, et le tracé des arêtes
forme une **boucle unique** (vérifié par un traceur de composantes indépendant,
indépendant de la convention de numérotation).

## Contrôle

Nouveau théorème prouvé `alexander_figureEight` : sous la normalisation
désignée (mineur sans première ligne ni dernière colonne), la fonction rend

    −2·t² + 2·t − 1    (soit −(2·t² − 2·t + 1))

sur le câblage corrigé. Valeur vérifiée de deux façons indépendantes : réplique
fidèle du foldl `mergePair`/`arcPartition` (arcs `[[3,4],[5,6],[7,8],[1,2]]`)
et déterminant 3×3 calculé à la main. Contrôle de cohérence : |P(−1)| = 5 =
det(4_1).

**Remarque d'honnêteté — anomalie signalée** : cette valeur n'est PAS le
polynôme d'Alexander classique de 4_1 (`t² − 3t + 1` à un facteur unité près).
Le trèfle (`t² − t + 1`) et le déterminant |P(−1)| = 5 sont reproduits, mais la
forme du polynôme diverge du classique sur la **classe à 4 croisements**. Cette
anomalie (la fonction désignée ne rend jamais `unit × (t² − 3t + 1)` sur un
câblage orienté à 4 croisements formant un noeud — **2736 câblages énumérés**)
est ouverte en **issue de suivi** (lien ci-dessous). Le théorème mesure la
**valeur réelle** de la fonction ; il ne revendique pas la conformité au
classique. Il remplit son rôle de contrôle : il fige le comportement mesuré et
rend visible la divergence sur 4_1.

## Fichiers modifiés

- `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean` — câblage + docstring
- `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean` — sibling EN (i18n)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean` — contrôle + docstring
- `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean` — sibling EN (i18n)

## Validation

- `lake build` SUCCESS — 3010 jobs, `Knots.Conway`/`Conway_en`/`Basic`/
  `Invariant`/`Knots_en` compilés (les `⚠` sont les sorries pré-existants).
- Compte `sorry` **inchangé** : `python scripts/lean/count_code_sorry.py --json`
  rend pour `knot_lean` `distinct_code_sorry = 11` (et `code_sorry = 22` = 11×2
  langues), identique à l'état antérieur — le contrôle ajouté est **prouvé**
  (aucun `sorry` ajouté ni retiré).
- `Proof integrity` SUCCESS attendu sur le CI : le contrôle `alexander_figureEight`
  est un théorème prouvé (`decide` kernel + `ring`), aucun `native_decide.*`
  introduit ; sur ce lake `lean-axiom.yml` est câblé sur `Knots.Basic`/`Conway`
  (grep des workflows déclencheurs) — B.3 à confirmer sur la CI.

See #2874 (contribution à l'EPIC — corrige le câblage 4_1 et ajoute un contrôle
Alexander prouvé). L'EPIC reste ouvert ; l'anomalie de la fonction Alexander sur
la classe 4 croisements est trackée dans l'issue de suivi dédiée.
