### PR TITLE
feat(lean-galois,#14783): complétions adiques des anneaux locaux — port pédagogique FLT

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/Galois.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/Galois.lean
@@ -3,5 +3,11 @@ Root aggregator for the `galois_lean` lake (proof layer for Lean-19, inverse
 Galois problem / M23). Imports the vendored upstream M23 proof bundle so that
 `lake build` (the bare `lean_lib Galois` default target) builds the full proof
 without a glob — mirroring the conway_lean / cooperative_games_lean layout.
+
+The adic-completion layer (#14783) adds the FR/EN sibling pair
+`AdicCompletionLocalRing.lean` / `AdicCompletionLocalRing_en.lean` (i18n
+#4980): both are self-contained and imported here.
 -/
 import Galois.M23Lean4Web
+import Galois.AdicCompletionLocalRing
+import Galois.AdicCompletionLocalRing_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/Galois/AdicCompletionLocalRing.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/Galois/AdicCompletionLocalRing.lean
@@ -1,0 +1,322 @@
+import Mathlib.RingTheory.AdicCompletion.Completeness
+import Mathlib.RingTheory.AdicCompletion.LocalRing
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.Ideal.Quotient.Operations
+import Mathlib.RingTheory.Noetherian.Defs
+
+/-!
+# Complétions adiques des anneaux locaux : une première couche
+
+Ce module pose, dans le lake `galois_lean`, une couche d'**arithmétique
+locale** dédiée aux **complétions adiques** d'un anneau local `A` par rapport
+à son idéal maximal.
+
+Le contenu est un portage pédagogique de
+`Definitions/Def_AdicCompletionLocalRing.lean` du dépôt
+[`anthropics/fermats-last-theorem`](https://github.com/anthropics/fermats-last-theorem)
+(commit `aa2d8b34`, licence Apache-2.0 — attribution et `NOTICE` préservées,
+issue #14783). Les énoncés, preuves et noms de théorèmes sont conservés ; seules
+les docstrings ont été rédigées et les importations resserrées sur les modules
+Mathlib utilisés (pas de `import Mathlib` global).
+
+La couche s'articule en quatre sections :
+
+- **Kernel** — pour un idéal `I`, le noyau de l'évaluation `evalₐ I n` est
+  exactement l'image de `I ^ n` dans la complétion (`ker_evalₐ_eq_map_pow`) ;
+  un élément `1 + x` avec `x` dans l'image d'un idéal `I` finiment engendré est
+  une unité (`isUnit_one_add_of_mem_map`) ;
+- **Exemple** — la troncature `2`-adique de `ℤ` : évaluer en degré `n`, c'est
+  réduire modulo `2 ^ n`, et le noyau est l'image de `I ^ n` — le sens concret
+  des quotients `A ⧸ I ^ n` ;
+- **Local** — quand `A` est local et noethérien, l'idéal maximal de la
+  complétion est le noyau de l'évaluation en degré 1, et le quotient par ses
+  puissances s'identifie à celui de `A`
+  (`quotientMaximalIdealPowAlgEquiv`) ;
+- **Transport** — ces identités se transportent le long d'un isomorphisme
+  d'algèbres, en particulier une équivalence entre complétions.
+
+Ce socle est le prérequis des grains aval (Hensel, groupes de ramification,
+issue #14786) ; il ne modifie pas le bundle M22/M23 existant du lake.
+
+Les axiomes utilisés se réduisent à `propext`, `Classical.choice` et
+`Quot.sound` — vérifiés par le gate `proof-integrity` de la CI (aucun `sorry`,
+`sorryAx` ni `native_decide`).
+-/
+
+set_option autoImplicit false
+
+open IsLocalRing
+
+namespace AdicCompletion
+
+variable {A : Type*} [CommRing A]
+
+section Kernel
+
+variable (I : Ideal A)
+
+/-- L'image dans la complétion d'un élément `a`, ré-évaluée en degré `n`, est
+la classe de `a` dans `A ⧸ I ^ n` : la forme de l'algèbre `algebraMap` est
+préservée par `evalₐ`. -/
+theorem evalₐ_algebraMap (n : ℕ) (a : A) :
+    evalₐ I n (algebraMap A (AdicCompletion I A) a) = Ideal.Quotient.mk _ a := by
+  rw [algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply, evalₐ_of]
+
+/-- Équivalence des deux descriptions (homomorphisme de `RingHom` et de
+`LinearMap`) du noyau de l'évaluation `evalₐ I n`. -/
+theorem mem_ker_evalₐ_iff (n : ℕ) (x : AdicCompletion I A) :
+    x ∈ RingHom.ker (evalₐ I n) ↔ x ∈ LinearMap.ker (eval I A n) := by
+  have h : (I ^ n • ⊤ : Ideal A) = I ^ n := by rw [smul_eq_mul, Ideal.mul_top]
+  rw [RingHom.mem_ker, LinearMap.mem_ker]
+  constructor
+  · intro hx; rw [← factor_evalₐ_eq_eval I x h.ge, hx]; exact RingHom.map_zero _
+  · intro hx; rw [← factor_eval_eq_evalₐ I x h.le, hx]; exact LinearMap.map_zero _
+
+/-- Pour `I` finiment engendré, le noyau de `evalₐ I n` est exactement l'image
+de la puissance `I ^ n` dans la complétion : c'est la caractérisation
+« noyau d'évaluation = puissance de l'idéal » de la géométrie locale. -/
+theorem ker_evalₐ_eq_map_pow (hI : I.FG) (n : ℕ) :
+    RingHom.ker (evalₐ I n) = (I ^ n).map (algebraMap A (AdicCompletion I A)) := by
+  ext x
+  rw [mem_ker_evalₐ_iff, ← pow_smul_top_eq_ker_eval hI, Ideal.smul_top_eq_map,
+    Submodule.restrictScalars_mem]
+
+/-- Tout élément de la complétion s'écrit comme un élément de `A` plus un
+élément de l'image de `I ^ n` : la complétion est engendrée au-dessus de `A` par
+les petites puissances de l'idéal. -/
+theorem exists_eq_algebraMap_add (hI : I.FG) (n : ℕ) (x : AdicCompletion I A) :
+    ∃ a : A, ∃ y ∈ (I ^ n).map (algebraMap A (AdicCompletion I A)),
+      x = algebraMap A (AdicCompletion I A) a + y := by
+  obtain ⟨a, ha⟩ := Ideal.Quotient.mk_surjective (evalₐ I n x)
+  refine ⟨a, x - algebraMap A _ a, ?_, by ring⟩
+  rw [← ker_evalₐ_eq_map_pow I hI, RingHom.mem_ker, map_sub, evalₐ_algebraMap, ha, sub_self]
+
+/-- Dans la complétion, `1 + x` est une unité dès que `x` est dans l'image de
+l'idéal `I` (finiment engendré) : c'est le fait que l'image de l'idéal maximal
+reste dans le radical de Jacobson. -/
+theorem isUnit_one_add_of_mem_map (hI : I.FG) {x : AdicCompletion I A}
+    (hx : x ∈ I.map (algebraMap A (AdicCompletion I A))) : IsUnit (1 + x) := by
+  haveI : IsAdicComplete (I.map (algebraMap A (AdicCompletion I A))) (AdicCompletion I A) :=
+    (IsAdicComplete.map_algebraMap_iff I (AdicCompletion I A)).mpr (isAdicComplete hI)
+  have h := Ideal.mem_jacobson_bot.mp (IsAdicComplete.le_jacobson_bot _ hx) 1
+  rwa [mul_one, add_comm] at h
+
+/-- Version décalée du précédent : `u + x` est une unité dès que `u` en est une
+et que `x` est dans l'image de `I` (le facteur inverse ramène à `1 + …`). -/
+theorem isUnit_add_of_mem_map (hI : I.FG) {u x : AdicCompletion I A} (hu : IsUnit u)
+    (hx : x ∈ I.map (algebraMap A (AdicCompletion I A))) : IsUnit (u + x) := by
+  have e : u + x = u * (1 + ↑hu.unit⁻¹ * x) := by
+    rw [mul_add, mul_one, ← mul_assoc, IsUnit.mul_val_inv, one_mul]
+  rw [e]
+  exact hu.mul (isUnit_one_add_of_mem_map I hI (Ideal.mul_mem_left _ _ hx))
+
+end Kernel
+
+section Exemple
+
+/-- Exemple pédagogique borné — la troncature 2-adique. Dans la complétion
+`2`-adique de `ℤ`, évaluer en degré `3` revient à réduire modulo `2 ^ 3 = 8` :
+l'image de `20` s'évalue sur la classe de `4`. C'est le sens concret des
+quotients `A ⧸ I ^ n` : chaque niveau de la complétion est l'arithmétique
+modulo `2 ^ n`. -/
+example :
+    evalₐ (Ideal.span {2} : Ideal ℤ) 3 (algebraMap ℤ (AdicCompletion (Ideal.span {2} : Ideal ℤ) ℤ) 20)
+      = Ideal.Quotient.mk _ 4 := by
+  rw [evalₐ_algebraMap]
+  refine (Ideal.Quotient.eq (I := (Ideal.span {2} : Ideal ℤ) ^ 3)).mpr ?_
+  rw [Ideal.span_singleton_pow, show (2 : ℤ) ^ 3 = 8 by norm_num]
+  exact Ideal.mem_span_singleton'.mpr ⟨2, by norm_num⟩
+
+/-- Le complément : le noyau de la troncature en degré `3` est exactement
+l'image de `I ^ 3` (`ker_evalₐ_eq_map_pow`) — l'image de `8`, multiple de
+`2 ^ 3`, s'évanouit au niveau `3`. -/
+example :
+    algebraMap ℤ (AdicCompletion (Ideal.span {2} : Ideal ℤ) ℤ) 8
+      ∈ RingHom.ker (evalₐ (Ideal.span {2} : Ideal ℤ) 3) := by
+  rw [ker_evalₐ_eq_map_pow _ (Submodule.fg_span_singleton 2),
+    Ideal.span_singleton_pow, show (2 : ℤ) ^ 3 = 8 by norm_num]
+  exact Ideal.mem_map_of_mem _ (Ideal.mem_span_singleton_self 8)
+
+end Exemple
+
+section Local
+
+variable [IsLocalRing A]
+
+/-- Une unité de la complétion en l'idéal maximal se relève en une unité de
+`A` : la réduction modulo le maximal ne crée pas de nouvelles unités. -/
+theorem isUnit_of_isUnit_algebraMap {a : A}
+    (h : IsUnit (algebraMap A (AdicCompletion (maximalIdeal A) A) a)) : IsUnit a := by
+  by_contra ha
+  have hmem : a ∈ maximalIdeal A ^ 1 := by
+    rw [pow_one]; exact (mem_maximalIdeal a).mpr ha
+  have h1 := h.map (evalₐ (maximalIdeal A) 1)
+  rw [evalₐ_algebraMap, Ideal.Quotient.eq_zero_iff_mem.mpr hmem, isUnit_zero_iff] at h1
+  exact (maximalIdeal.isMaximal A).ne_top
+    ((pow_one (maximalIdeal A)).symm.trans (Ideal.Quotient.zero_eq_one_iff.mp h1))
+
+/-- Cas particulier de `isUnit_one_add_of_mem_map` pour l'idéal maximal : un
+élément de la forme `1 + x` avec `x` dans l'image du maximal est une unité. -/
+theorem isUnit_one_add_of_mem_map_maximalIdeal (h𝔪 : (maximalIdeal A).FG)
+    {x : AdicCompletion (maximalIdeal A) A}
+    (hx : x ∈ (maximalIdeal A).map (algebraMap A (AdicCompletion (maximalIdeal A) A))) :
+    IsUnit (1 + x) :=
+  isUnit_one_add_of_mem_map _ h𝔪 hx
+
+variable [IsNoetherianRing A]
+
+/-- En anneau noethérien, l'idéal maximal est finiment engendré. -/
+theorem maximalIdeal_fg : (maximalIdeal A).FG := IsNoetherian.noetherian _
+
+/-- La complétion d'un anneau local noethérien en son idéal maximal est encore
+un anneau local. -/
+instance instIsLocalRingMaximalIdeal : IsLocalRing (AdicCompletion (maximalIdeal A) A) :=
+  isLocalRing_of_fg maximalIdeal_fg
+
+/-- Dans la complétion, la puissance `n`-ième de l'idéal maximal est le noyau
+de l'évaluation en degré `n`. -/
+theorem maximalIdeal_pow_eq_ker_evalₐ (n : ℕ) :
+    maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n = RingHom.ker (evalₐ (maximalIdeal A) n) := by
+  rw [maximalIdeal_eq_map, ← Ideal.map_pow, ker_evalₐ_eq_map_pow _ maximalIdeal_fg]
+
+/-- Le degré 1 : l'idéal maximal de la complétion est le noyau de `evalₐ` en
+degré 1. -/
+theorem maximalIdeal_eq_ker_evalₐ_one :
+    maximalIdeal (AdicCompletion (maximalIdeal A) A) = RingHom.ker (evalₐ (maximalIdeal A) 1) := by
+  rw [← maximalIdeal_pow_eq_ker_evalₐ, pow_one]
+
+/-- Membrane de l'idéal maximal de la complétion en fonction de l'évaluation
+en degré 1. -/
+theorem mem_maximalIdeal_iff (x : AdicCompletion (maximalIdeal A) A) :
+    x ∈ maximalIdeal (AdicCompletion (maximalIdeal A) A) ↔ evalₐ (maximalIdeal A) 1 x = 0 := by
+  rw [maximalIdeal_eq_ker_evalₐ_one, RingHom.mem_ker]
+
+section Scalars
+
+variable (k : Type*) [CommRing k] [Algebra k A]
+
+/-- L'isomorphisme (en tant qu'algèbre sur `k`) entre le quotient de la
+complétion par la puissance `n` de son idéal maximal et le quotient de `A` par
+`maximalIdeal A ^ n`. -/
+noncomputable def quotientMaximalIdealPowAlgHom (n : ℕ) :
+    (AdicCompletion (maximalIdeal A) A ⧸ maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n)
+      →ₐ[k] A ⧸ maximalIdeal A ^ n :=
+  Ideal.Quotient.liftₐ _ ((evalₐ (maximalIdeal A) n).restrictScalars k) fun x hx => by
+    rwa [maximalIdeal_pow_eq_ker_evalₐ, RingHom.mem_ker] at hx
+
+/-- Action de `quotientMaximalIdealPowAlgHom` sur une classe, par l'évaluation
+en degré `n`. -/
+theorem quotientMaximalIdealPowAlgHom_mk (n : ℕ) (x : AdicCompletion (maximalIdeal A) A) :
+    quotientMaximalIdealPowAlgHom k n (Ideal.Quotient.mk _ x) = evalₐ (maximalIdeal A) n x :=
+  rfl
+
+/-- Le morphisme de quotient précédent est bijectif : les quotients par les
+puissances de l'idéal maximal sont algébriquement équivalents. -/
+theorem quotientMaximalIdealPowAlgHom_bijective (n : ℕ) :
+    Function.Bijective (quotientMaximalIdealPowAlgHom (A := A) k n) := by
+  constructor
+  · intro x y hxy
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+    obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective y
+    rw [quotientMaximalIdealPowAlgHom_mk, quotientMaximalIdealPowAlgHom_mk] at hxy
+    refine Ideal.Quotient.eq.mpr ?_
+    rw [maximalIdeal_pow_eq_ker_evalₐ, RingHom.mem_ker, map_sub, hxy, sub_self]
+  · intro z
+    obtain ⟨x, rfl⟩ := surjective_evalₐ (maximalIdeal A) n z
+    exact ⟨Ideal.Quotient.mk _ x, rfl⟩
+
+/-- L'équivalence d'algèbres entre le quotient de la complétion par `𝔪 ^ n` et
+le quotient de `A` par `𝔪 ^ n` (`𝔪 = maximalIdeal A`). -/
+noncomputable def quotientMaximalIdealPowAlgEquiv (n : ℕ) :
+    (AdicCompletion (maximalIdeal A) A ⧸ maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n)
+      ≃ₐ[k] A ⧸ maximalIdeal A ^ n :=
+  AlgEquiv.ofBijective _ (quotientMaximalIdealPowAlgHom_bijective k n)
+
+/-- Action de `quotientMaximalIdealPowAlgEquiv` sur une classe. -/
+theorem quotientMaximalIdealPowAlgEquiv_mk (n : ℕ) (x : AdicCompletion (maximalIdeal A) A) :
+    quotientMaximalIdealPowAlgEquiv k n (Ideal.Quotient.mk _ x) = evalₐ (maximalIdeal A) n x :=
+  rfl
+
+/-- Le diagramme avec `algebraMap` commute : passer l'image d'un élément de `A`
+par l'équivalence revient à prendre sa classe dans `A ⧸ 𝔪 ^ n`. -/
+theorem quotientMaximalIdealPowAlgEquiv_mk_algebraMap (n : ℕ) (a : A) :
+    quotientMaximalIdealPowAlgEquiv k n (Ideal.Quotient.mk _ (algebraMap A _ a))
+      = Ideal.Quotient.mk _ a := by
+  rw [quotientMaximalIdealPowAlgEquiv_mk, evalₐ_algebraMap]
+
+end Scalars
+
+end Local
+
+section Transport
+
+variable [IsLocalRing A] [IsNoetherianRing A]
+variable {k : Type*} [CommRing k] [Algebra k A] {B : Type*} [CommRing B] [IsLocalRing B] [Algebra k B]
+variable (Φ : AdicCompletion (maximalIdeal A) A ≃ₐ[k] B)
+
+omit [IsNoetherianRing A] [IsLocalRing B] in
+/-- Un isomorphisme d'algèbres préserve le caractère unité dans les deux sens. -/
+theorem isUnit_algEquiv_iff (x : AdicCompletion (maximalIdeal A) A) : IsUnit (Φ x) ↔ IsUnit x :=
+  ⟨fun h => by simpa using h.map Φ.symm, fun h => h.map Φ⟩
+
+/-- L'image réciproque du maximal de `B` par un isomorphisme est le maximal de
+la complétion. -/
+theorem comap_maximalIdeal_algEquiv :
+    (maximalIdeal B).comap (Φ : AdicCompletion (maximalIdeal A) A →+* B)
+      = maximalIdeal (AdicCompletion (maximalIdeal A) A) := by
+  ext x
+  show Φ x ∈ maximalIdeal B ↔ x ∈ maximalIdeal _
+  rw [mem_maximalIdeal, mem_maximalIdeal, mem_nonunits_iff, mem_nonunits_iff, isUnit_algEquiv_iff]
+
+/-- L'image du maximal de la complétion par un isomorphisme est le maximal de
+`B`. -/
+theorem map_maximalIdeal_algEquiv :
+    (maximalIdeal (AdicCompletion (maximalIdeal A) A)).map
+        (Φ : AdicCompletion (maximalIdeal A) A →+* B) = maximalIdeal B := by
+  rw [← comap_maximalIdeal_algEquiv Φ]
+  exact Ideal.map_comap_of_surjective _ Φ.surjective _
+
+/-- Le maximal de `B` s'obtient comme image du maximal de `A` via le composé
+`algebraMap` puis `Φ`. -/
+theorem maximalIdeal_eq_map_algEquiv :
+    maximalIdeal B = (maximalIdeal A).map
+      ((Φ : AdicCompletion (maximalIdeal A) A →+* B).comp
+        (algebraMap A (AdicCompletion (maximalIdeal A) A))) := by
+  rw [← Ideal.map_map, ← maximalIdeal_eq_map, map_maximalIdeal_algEquiv]
+
+/-- Version puissance du précédent : la puissance `n` du maximal de `B` est
+l'image de `𝔪 ^ n` via le composé. -/
+theorem maximalIdeal_pow_eq_map_algEquiv (n : ℕ) :
+    maximalIdeal B ^ n = (maximalIdeal A ^ n).map
+      ((Φ : AdicCompletion (maximalIdeal A) A →+* B).comp
+        (algebraMap A (AdicCompletion (maximalIdeal A) A))) := by
+  rw [Ideal.map_pow, ← maximalIdeal_eq_map_algEquiv]
+
+/-- L'image par `Φ` d'un élément du maximal de `A` reste dans le maximal de
+`B`. -/
+theorem algEquiv_algebraMap_mem_maximalIdeal {a : A} (ha : a ∈ maximalIdeal A) :
+    Φ (algebraMap A _ a) ∈ maximalIdeal B := by
+  rw [maximalIdeal_eq_map_algEquiv Φ]
+  exact Ideal.mem_map_of_mem _ ha
+
+/-- Transport le long d'un isomorphisme de l'équivalence
+`quotientMaximalIdealPowAlgEquiv` sur une complétion `B`. -/
+noncomputable def quotientMaximalIdealPowAlgEquivOfAlgEquiv (n : ℕ) :
+    (B ⧸ maximalIdeal B ^ n) ≃ₐ[k] A ⧸ maximalIdeal A ^ n :=
+  (Ideal.quotientEquivAlg (maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n) (maximalIdeal B ^ n)
+    Φ (by rw [Ideal.map_pow, map_maximalIdeal_algEquiv])).symm.trans
+    (quotientMaximalIdealPowAlgEquiv k n)
+
+/-- Le diagramme de transport commute : la classe d'`Φ (algebraMap … a)` s'envoie
+sur la classe de `a`. -/
+theorem quotientMaximalIdealPowAlgEquivOfAlgEquiv_mk (n : ℕ) (a : A) :
+    quotientMaximalIdealPowAlgEquivOfAlgEquiv Φ n (Ideal.Quotient.mk _ (Φ (algebraMap A _ a)))
+      = Ideal.Quotient.mk _ a := by
+  rw [quotientMaximalIdealPowAlgEquivOfAlgEquiv, AlgEquiv.trans_apply,
+    ← Ideal.quotientEquivAlg_mk (I := maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n)
+      (J := maximalIdeal B ^ n) (f := Φ) (hIJ := by rw [Ideal.map_pow, map_maximalIdeal_algEquiv]),
+    AlgEquiv.symm_apply_apply, quotientMaximalIdealPowAlgEquiv_mk_algebraMap]
+
+end Transport
+
+end AdicCompletion

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/Galois/AdicCompletionLocalRing_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/Galois/AdicCompletionLocalRing_en.lean
@@ -1,0 +1,326 @@
+import Mathlib.RingTheory.AdicCompletion.Completeness
+import Mathlib.RingTheory.AdicCompletion.LocalRing
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.Ideal.Quotient.Operations
+import Mathlib.RingTheory.Noetherian.Defs
+
+/-!
+# Adic completions of local rings : a first layer
+
+This module sets up, in the `galois_lean` lake, a layer of **local
+arithmetic** devoted to the **adic completions** of a local ring `A` with
+respect to its maximal ideal.
+
+The content is a pedagogical port of
+`Definitions/Def_AdicCompletionLocalRing.lean` from the
+[`anthropics/fermats-last-theorem`](https://github.com/anthropics/fermats-last-theorem)
+repository (commit `aa2d8b34`, Apache-2.0 licence — attribution and `NOTICE`
+preserved, issue #14783). Statements, proofs and theorem names are kept; only
+docstrings were written and imports tightened to the Mathlib modules actually
+used (no global `import Mathlib`).
+
+The layer is organised into four sections :
+
+- **Kernel** — for an ideal `I`, the kernel of the evaluation `evalₐ I n` is
+  exactly the image of `I ^ n` in the completion (`ker_evalₐ_eq_map_pow`); an
+  element `1 + x` with `x` in the image of a finitely generated ideal `I` is a
+  unit (`isUnit_one_add_of_mem_map`);
+- **Exemple** — the `2`-adic truncation of `ℤ`: evaluating at degree `n` is
+  reducing modulo `2 ^ n`, and the kernel is the image of `I ^ n` — the
+  concrete meaning of the quotients `A ⧸ I ^ n`;
+- **Local** — when `A` is local and Noetherian, the maximal ideal of the
+  completion is the kernel of the degree-1 evaluation, and its quotient by its
+  powers identifies with that of `A` (`quotientMaximalIdealPowAlgEquiv`);
+- **Transport** — these identities are transported along an algebra
+  isomorphism, in particular an equivalence between completions.
+
+This base is the prerequisite of the downstream grains (Hensel, ramification
+groups, issue #14786); it does not modify the existing M22/M23 bundle of the
+lake.
+
+The axioms used reduce to `propext`, `Classical.choice` and `Quot.sound` —
+checked by the `proof-integrity` gate of the CI (no `sorry`, `sorryAx` nor
+`native_decide`).
+-/
+
+set_option autoImplicit false
+
+open IsLocalRing
+
+open AdicCompletion
+
+namespace AdicCompletion_en
+
+variable {A : Type*} [CommRing A]
+
+section Kernel
+
+variable (I : Ideal A)
+
+/-- The image in the completion of an element `a`, re-evaluated at degree `n`,
+is the class of `a` in `A ⧸ I ^ n`: the algebraMap form is preserved by
+`evalₐ`. -/
+theorem evalₐ_algebraMap (n : ℕ) (a : A) :
+    evalₐ I n (algebraMap A (AdicCompletion I A) a) = Ideal.Quotient.mk _ a := by
+  rw [algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply, evalₐ_of]
+
+/-- Equivalence of the two descriptions (as a `RingHom` and as a `LinearMap`)
+of the kernel of the evaluation `evalₐ I n`. -/
+theorem mem_ker_evalₐ_iff (n : ℕ) (x : AdicCompletion I A) :
+    x ∈ RingHom.ker (evalₐ I n) ↔ x ∈ LinearMap.ker (eval I A n) := by
+  have h : (I ^ n • ⊤ : Ideal A) = I ^ n := by rw [smul_eq_mul, Ideal.mul_top]
+  rw [RingHom.mem_ker, LinearMap.mem_ker]
+  constructor
+  · intro hx; rw [← factor_evalₐ_eq_eval I x h.ge, hx]; exact RingHom.map_zero _
+  · intro hx; rw [← factor_eval_eq_evalₐ I x h.le, hx]; exact LinearMap.map_zero _
+
+/-- For a finitely generated `I`, the kernel of `evalₐ I n` is exactly the image
+of the power `I ^ n` in the completion: this is the « kernel of evaluation =
+power of the ideal » characterization of local geometry. -/
+theorem ker_evalₐ_eq_map_pow (hI : I.FG) (n : ℕ) :
+    RingHom.ker (evalₐ I n) = (I ^ n).map (algebraMap A (AdicCompletion I A)) := by
+  ext x
+  rw [mem_ker_evalₐ_iff, ← pow_smul_top_eq_ker_eval hI, Ideal.smul_top_eq_map,
+    Submodule.restrictScalars_mem]
+
+/-- Any element of the completion writes as an element of `A` plus an element of
+the image of `I ^ n`: the completion is generated over `A` by the small powers
+of the ideal. -/
+theorem exists_eq_algebraMap_add (hI : I.FG) (n : ℕ) (x : AdicCompletion I A) :
+    ∃ a : A, ∃ y ∈ (I ^ n).map (algebraMap A (AdicCompletion I A)),
+      x = algebraMap A (AdicCompletion I A) a + y := by
+  obtain ⟨a, ha⟩ := Ideal.Quotient.mk_surjective (evalₐ I n x)
+  refine ⟨a, x - algebraMap A _ a, ?_, by ring⟩
+  rw [← ker_evalₐ_eq_map_pow I hI, RingHom.mem_ker, map_sub, evalₐ_algebraMap, ha, sub_self]
+
+/-- In the completion, `1 + x` is a unit as soon as `x` is in the image of the
+ideal `I` (finitely generated): the image of the maximal ideal stays inside the
+Jacobson radical. -/
+theorem isUnit_one_add_of_mem_map (hI : I.FG) {x : AdicCompletion I A}
+    (hx : x ∈ I.map (algebraMap A (AdicCompletion I A))) : IsUnit (1 + x) := by
+  haveI : IsAdicComplete (I.map (algebraMap A (AdicCompletion I A))) (AdicCompletion I A) :=
+    (IsAdicComplete.map_algebraMap_iff I (AdicCompletion I A)).mpr (isAdicComplete hI)
+  have h := Ideal.mem_jacobson_bot.mp (IsAdicComplete.le_jacobson_bot _ hx) 1
+  rwa [mul_one, add_comm] at h
+
+/-- Shifted version of the previous one: `u + x` is a unit as soon as `u` is a
+unit and `x` is in the image of `I` (the inverse factor brings it back to
+`1 + …`). -/
+theorem isUnit_add_of_mem_map (hI : I.FG) {u x : AdicCompletion I A} (hu : IsUnit u)
+    (hx : x ∈ I.map (algebraMap A (AdicCompletion I A))) : IsUnit (u + x) := by
+  have e : u + x = u * (1 + ↑hu.unit⁻¹ * x) := by
+    rw [mul_add, mul_one, ← mul_assoc, IsUnit.mul_val_inv, one_mul]
+  rw [e]
+  exact hu.mul (isUnit_one_add_of_mem_map I hI (Ideal.mul_mem_left _ _ hx))
+
+end Kernel
+
+section Exemple
+
+/-- Bounded pedagogical example — the 2-adic truncation. In the `2`-adic
+completion of `ℤ`, evaluating at degree `3` is reducing modulo `2 ^ 3 = 8`:
+the image of `20` evaluates to the class of `4`. This is the concrete meaning
+of the quotients `A ⧸ I ^ n`: each level of the completion is arithmetic
+modulo `2 ^ n`. -/
+example :
+    evalₐ (Ideal.span {2} : Ideal ℤ) 3 (algebraMap ℤ (AdicCompletion (Ideal.span {2} : Ideal ℤ) ℤ) 20)
+      = Ideal.Quotient.mk _ 4 := by
+  rw [evalₐ_algebraMap]
+  refine (Ideal.Quotient.eq (I := (Ideal.span {2} : Ideal ℤ) ^ 3)).mpr ?_
+  rw [Ideal.span_singleton_pow, show (2 : ℤ) ^ 3 = 8 by norm_num]
+  exact Ideal.mem_span_singleton'.mpr ⟨2, by norm_num⟩
+
+/-- The complement: the kernel of the degree-`3` truncation is exactly the
+image of `I ^ 3` (`ker_evalₐ_eq_map_pow`) — the image of `8`, a multiple of
+`2 ^ 3`, vanishes at level `3`. -/
+example :
+    algebraMap ℤ (AdicCompletion (Ideal.span {2} : Ideal ℤ) ℤ) 8
+      ∈ RingHom.ker (evalₐ (Ideal.span {2} : Ideal ℤ) 3) := by
+  rw [ker_evalₐ_eq_map_pow _ (Submodule.fg_span_singleton 2),
+    Ideal.span_singleton_pow, show (2 : ℤ) ^ 3 = 8 by norm_num]
+  exact Ideal.mem_map_of_mem _ (Ideal.mem_span_singleton_self 8)
+
+end Exemple
+
+section Local
+
+variable [IsLocalRing A]
+
+/-- A unit of the completion at the maximal ideal lifts to a unit of `A`:
+reducing modulo the maximal ideal creates no new units. -/
+theorem isUnit_of_isUnit_algebraMap {a : A}
+    (h : IsUnit (algebraMap A (AdicCompletion (maximalIdeal A) A) a)) : IsUnit a := by
+  by_contra ha
+  have hmem : a ∈ maximalIdeal A ^ 1 := by
+    rw [pow_one]; exact (mem_maximalIdeal a).mpr ha
+  have h1 := h.map (evalₐ (maximalIdeal A) 1)
+  rw [evalₐ_algebraMap, Ideal.Quotient.eq_zero_iff_mem.mpr hmem, isUnit_zero_iff] at h1
+  exact (maximalIdeal.isMaximal A).ne_top
+    ((pow_one (maximalIdeal A)).symm.trans (Ideal.Quotient.zero_eq_one_iff.mp h1))
+
+/-- Particular case of `isUnit_one_add_of_mem_map` for the maximal ideal: an
+element of the form `1 + x` with `x` in the image of the maximal ideal is a
+unit. -/
+theorem isUnit_one_add_of_mem_map_maximalIdeal (h𝔪 : (maximalIdeal A).FG)
+    {x : AdicCompletion (maximalIdeal A) A}
+    (hx : x ∈ (maximalIdeal A).map (algebraMap A (AdicCompletion (maximalIdeal A) A))) :
+    IsUnit (1 + x) :=
+  isUnit_one_add_of_mem_map _ h𝔪 hx
+
+variable [IsNoetherianRing A]
+
+/-- In a Noetherian ring, the maximal ideal is finitely generated. -/
+theorem maximalIdeal_fg : (maximalIdeal A).FG := IsNoetherian.noetherian _
+
+/-- The completion of a Noetherian local ring at its maximal ideal is still a
+local ring. -/
+instance instIsLocalRingMaximalIdeal : IsLocalRing (AdicCompletion (maximalIdeal A) A) :=
+  isLocalRing_of_fg maximalIdeal_fg
+
+/-- In the completion, the `n`-th power of the maximal ideal is the kernel of
+the evaluation at degree `n`. -/
+theorem maximalIdeal_pow_eq_ker_evalₐ (n : ℕ) :
+    maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n = RingHom.ker (evalₐ (maximalIdeal A) n) := by
+  rw [maximalIdeal_eq_map, ← Ideal.map_pow, ker_evalₐ_eq_map_pow _ maximalIdeal_fg]
+
+/-- Degree 1: the maximal ideal of the completion is the kernel of `evalₐ` at
+degree 1. -/
+theorem maximalIdeal_eq_ker_evalₐ_one :
+    maximalIdeal (AdicCompletion (maximalIdeal A) A) = RingHom.ker (evalₐ (maximalIdeal A) 1) := by
+  rw [← maximalIdeal_pow_eq_ker_evalₐ, pow_one]
+
+/-- Membership of the maximal ideal of the completion in terms of the degree-1
+evaluation. -/
+theorem mem_maximalIdeal_iff (x : AdicCompletion (maximalIdeal A) A) :
+    x ∈ maximalIdeal (AdicCompletion (maximalIdeal A) A) ↔ evalₐ (maximalIdeal A) 1 x = 0 := by
+  rw [maximalIdeal_eq_ker_evalₐ_one, RingHom.mem_ker]
+
+section Scalars
+
+variable (k : Type*) [CommRing k] [Algebra k A]
+
+/-- The isomorphism (as an algebra over `k`) between the quotient of the
+completion by the `n`-th power of its maximal ideal and the quotient of `A` by
+`maximalIdeal A ^ n`. -/
+noncomputable def quotientMaximalIdealPowAlgHom (n : ℕ) :
+    (AdicCompletion (maximalIdeal A) A ⧸ maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n)
+      →ₐ[k] A ⧸ maximalIdeal A ^ n :=
+  Ideal.Quotient.liftₐ _ ((evalₐ (maximalIdeal A) n).restrictScalars k) fun x hx => by
+    rwa [maximalIdeal_pow_eq_ker_evalₐ, RingHom.mem_ker] at hx
+
+/-- Action of `quotientMaximalIdealPowAlgHom` on a class, via the evaluation at
+degree `n`. -/
+theorem quotientMaximalIdealPowAlgHom_mk (n : ℕ) (x : AdicCompletion (maximalIdeal A) A) :
+    quotientMaximalIdealPowAlgHom k n (Ideal.Quotient.mk _ x) = evalₐ (maximalIdeal A) n x :=
+  rfl
+
+/-- The previous quotient morphism is bijective: the quotients by the powers of
+the maximal ideal are algebraically equivalent. -/
+theorem quotientMaximalIdealPowAlgHom_bijective (n : ℕ) :
+    Function.Bijective (quotientMaximalIdealPowAlgHom (A := A) k n) := by
+  constructor
+  · intro x y hxy
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+    obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective y
+    rw [quotientMaximalIdealPowAlgHom_mk, quotientMaximalIdealPowAlgHom_mk] at hxy
+    refine Ideal.Quotient.eq.mpr ?_
+    rw [maximalIdeal_pow_eq_ker_evalₐ, RingHom.mem_ker, map_sub, hxy, sub_self]
+  · intro z
+    obtain ⟨x, rfl⟩ := surjective_evalₐ (maximalIdeal A) n z
+    exact ⟨Ideal.Quotient.mk _ x, rfl⟩
+
+/-- The algebra equivalence between the quotient of the completion by `𝔪 ^ n` and
+the quotient of `A` by `𝔪 ^ n` (`𝔪 = maximalIdeal A`). -/
+noncomputable def quotientMaximalIdealPowAlgEquiv (n : ℕ) :
+    (AdicCompletion (maximalIdeal A) A ⧸ maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n)
+      ≃ₐ[k] A ⧸ maximalIdeal A ^ n :=
+  AlgEquiv.ofBijective _ (quotientMaximalIdealPowAlgHom_bijective k n)
+
+/-- Action of `quotientMaximalIdealPowAlgEquiv` on a class. -/
+theorem quotientMaximalIdealPowAlgEquiv_mk (n : ℕ) (x : AdicCompletion (maximalIdeal A) A) :
+    quotientMaximalIdealPowAlgEquiv k n (Ideal.Quotient.mk _ x) = evalₐ (maximalIdeal A) n x :=
+  rfl
+
+/-- The diagram with `algebraMap` commutes: sending the image of an element of
+`A` through the equivalence is the same as taking its class in `A ⧸ 𝔪 ^ n`. -/
+theorem quotientMaximalIdealPowAlgEquiv_mk_algebraMap (n : ℕ) (a : A) :
+    quotientMaximalIdealPowAlgEquiv k n (Ideal.Quotient.mk _ (algebraMap A _ a))
+      = Ideal.Quotient.mk _ a := by
+  rw [quotientMaximalIdealPowAlgEquiv_mk, evalₐ_algebraMap]
+
+end Scalars
+
+end Local
+
+section Transport
+
+variable [IsLocalRing A] [IsNoetherianRing A]
+variable {k : Type*} [CommRing k] [Algebra k A] {B : Type*} [CommRing B] [IsLocalRing B] [Algebra k B]
+variable (Φ : AdicCompletion (maximalIdeal A) A ≃ₐ[k] B)
+
+omit [IsNoetherianRing A] [IsLocalRing B] in
+/-- An algebra isomorphism preserves the unit property in both directions. -/
+theorem isUnit_algEquiv_iff (x : AdicCompletion (maximalIdeal A) A) : IsUnit (Φ x) ↔ IsUnit x :=
+  ⟨fun h => by simpa using h.map Φ.symm, fun h => h.map Φ⟩
+
+/-- The pullback of the maximal ideal of `B` along an isomorphism is the maximal
+ideal of the completion. -/
+theorem comap_maximalIdeal_algEquiv :
+    (maximalIdeal B).comap (Φ : AdicCompletion (maximalIdeal A) A →+* B)
+      = maximalIdeal (AdicCompletion (maximalIdeal A) A) := by
+  ext x
+  show Φ x ∈ maximalIdeal B ↔ x ∈ maximalIdeal _
+  rw [mem_maximalIdeal, mem_maximalIdeal, mem_nonunits_iff, mem_nonunits_iff, isUnit_algEquiv_iff]
+
+/-- The image of the maximal ideal of the completion under an isomorphism is the
+maximal ideal of `B`. -/
+theorem map_maximalIdeal_algEquiv :
+    (maximalIdeal (AdicCompletion (maximalIdeal A) A)).map
+        (Φ : AdicCompletion (maximalIdeal A) A →+* B) = maximalIdeal B := by
+  rw [← comap_maximalIdeal_algEquiv Φ]
+  exact Ideal.map_comap_of_surjective _ Φ.surjective _
+
+/-- The maximal ideal of `B` is obtained as the image of the maximal ideal of
+`A` via the composite `algebraMap` then `Φ`. -/
+theorem maximalIdeal_eq_map_algEquiv :
+    maximalIdeal B = (maximalIdeal A).map
+      ((Φ : AdicCompletion (maximalIdeal A) A →+* B).comp
+        (algebraMap A (AdicCompletion (maximalIdeal A) A))) := by
+  rw [← Ideal.map_map, ← maximalIdeal_eq_map, map_maximalIdeal_algEquiv]
+
+/-- Power version of the previous one: the `n`-th power of the maximal ideal of
+`B` is the image of `𝔪 ^ n` via the composite. -/
+theorem maximalIdeal_pow_eq_map_algEquiv (n : ℕ) :
+    maximalIdeal B ^ n = (maximalIdeal A ^ n).map
+      ((Φ : AdicCompletion (maximalIdeal A) A →+* B).comp
+        (algebraMap A (AdicCompletion (maximalIdeal A) A))) := by
+  rw [Ideal.map_pow, ← maximalIdeal_eq_map_algEquiv]
+
+/-- The image under `Φ` of an element of the maximal ideal of `A` stays in the
+maximal ideal of `B`. -/
+theorem algEquiv_algebraMap_mem_maximalIdeal {a : A} (ha : a ∈ maximalIdeal A) :
+    Φ (algebraMap A _ a) ∈ maximalIdeal B := by
+  rw [maximalIdeal_eq_map_algEquiv Φ]
+  exact Ideal.mem_map_of_mem _ ha
+
+/-- Transport along an isomorphism of the equivalence
+`quotientMaximalIdealPowAlgEquiv` onto a completion `B`. -/
+noncomputable def quotientMaximalIdealPowAlgEquivOfAlgEquiv (n : ℕ) :
+    (B ⧸ maximalIdeal B ^ n) ≃ₐ[k] A ⧸ maximalIdeal A ^ n :=
+  (Ideal.quotientEquivAlg (maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n) (maximalIdeal B ^ n)
+    Φ (by rw [Ideal.map_pow, map_maximalIdeal_algEquiv])).symm.trans
+    (quotientMaximalIdealPowAlgEquiv k n)
+
+/-- The transport diagram commutes: the class of `Φ (algebraMap … a)` is sent to
+the class of `a`. -/
+theorem quotientMaximalIdealPowAlgEquivOfAlgEquiv_mk (n : ℕ) (a : A) :
+    quotientMaximalIdealPowAlgEquivOfAlgEquiv Φ n (Ideal.Quotient.mk _ (Φ (algebraMap A _ a)))
+      = Ideal.Quotient.mk _ a := by
+  rw [quotientMaximalIdealPowAlgEquivOfAlgEquiv, AlgEquiv.trans_apply,
+    ← Ideal.quotientEquivAlg_mk (I := maximalIdeal (AdicCompletion (maximalIdeal A) A) ^ n)
+      (J := maximalIdeal B ^ n) (f := Φ) (hIJ := by rw [Ideal.map_pow, map_maximalIdeal_algEquiv]),
+    AlgEquiv.symm_apply_apply, quotientMaximalIdealPowAlgEquiv_mk_algebraMap]
+
+end Transport
+
+end AdicCompletion_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/lakefile.lean
@@ -10,13 +10,16 @@ package «galois» where
 require mathlib from git
   "https://github.com/leanprover-community/mathlib4.git" @ "db584cd6d46c92f209a44c0f1c829460d327499d"
 
--- Bare `lean_lib` (no `globs`): the root aggregator `Galois.lean` imports the
--- vendored module(s), so `lake build` (default target) builds the full proof via
--- the root's import closure — mirroring conway_lean / cooperative_games_lean.
--- NB: the glob form `globs := #[`Galois.*]` triggers a lake v4.31.0-rc1 job-
--- computation trace quirk ("some modules have bad imports") on this single-
--- module lake, even though every module compiles cleanly; the bare-lib +
--- root-aggregator path sidesteps it. Sibling `_en` modules (i18n #4980) will be
--- imported here when added. Cf grothendieck_lean (#6154) for the glob form.
+-- `globs := #[`Galois.*]` auto-discovers every submodule under `Galois/`,
+-- including the `_en` i18n siblings (#4980, added with the adic-completion
+-- layer #14783) — same pattern as game_theory_lean / decision_theory_lean.
+-- History: the lake started bare-lib (root aggregator only) because the glob
+-- form tripped a lake v4.31.0-rc1 job-computation quirk ("some modules have
+-- bad imports"); at v4.33.0 the glob build is verified SUCCESS. The bare-lib
+-- escape is no longer viable anyway: `check_en_built` in
+-- scripts/lean/check_i18n_siblings.py reads roots/globs only, so a root-import
+-- `_en` mirror would be flagged UNBUILT by the lean-i18n-drift CI gate even
+-- though `lake build` compiles it.
 @[default_target]
 lean_lib «Galois» where
+  globs := #[`Galois.*]


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: DEEP/lean #14931

## Summary

Portage pédagogique de `Definitions/Def_AdicCompletionLocalRing.lean` du dépôt
`anthropics/fermats-last-theorem` (commit `aa2d8b34`, Apache-2.0) dans le lake
`galois_lean`, en paire FR/EN i18n (#4980) :

- `Galois/AdicCompletionLocalRing.lean` (FR, `namespace AdicCompletion`) — 27
  déclarations en trois sections : **Kernel** (noyau de `evalₐ` = image de
  `I ^ n`, unités `1 + x`), **Local** (`𝔪̂ ^ n = ker evalₐ`,
  `IsLocalRing` de la complétion, équivalence d'algèbres des quotients
  `quotientMaximalIdealPowAlgEquiv`), **Transport** (le long d'une équivalence
  d'algèbres). Corps de preuve byte-identique à l'amont.
- `Galois/AdicCompletionLocalRing_en.lean` (EN, `namespace AdicCompletion_en`,
  `open AdicCompletion`) — miroir EN, divergence de qualifieur intrinsèque
  (troisième forme légitime de paire i18n, cf `docs/lean/i18n-sibling-patterns.md`).
- **Section Exemple** (bornée, tranche #14783) : la troncuation `2`-adique de
  `ℤ` — `evalₐ` en degré `3` réduit modulo `2 ^ 3 = 8` (l'image de `20` donne
  la classe de `4`), et le noyau est exactement l'image de `I ^ 3` (l'image de
  `8` s'évanouit). Sens concret des quotients `A ⧸ I ^ n`.
- Imports Mathlib ciblés (5 modules, pas de `import Mathlib` global) ;
  `#print axioms` amont retirés (le gate `proof-integrity` les remplace).
- `Galois.lean` (agrégateur racine) importe la paire ; `lakefile.lean` passe
  de bare-lib à `globs := #[`Galois.*]` (voir ci-dessous).

## B.1 Lean — preuves vérifiables

1. **Compte `sorry` réel avant/après** — `python scripts/lean/count_code_sorry.py
   --json`, champ `distinct_code_sorry` pour galois_lean : **0 avant / 0 après**
   (baseline CI `sorry-baseline: "0"` inchangée). Le `naive_sorry` passe de 1 à 3 :
   les 2 ajouts sont la prose des docstrings FR/EN (« aucun `sorry`, `sorryAx`
   ni `native_decide` »), pas du code — mode `real` les exclut.
2. **`lake build` SUCCESS** — local, worktree `C:\dev\CoursIA-14783-adic`,
   cible par défaut `Galois` (globs) : **Build completed successfully (2371
   jobs)** — les 4 modules compilent (`Galois` 13 s, `Galois.M23Lean4Web`,
   `Galois.AdicCompletionLocalRing` 22 s, `Galois.AdicCompletionLocalRing_en`
   22 s). Seul warning : linter style `haveI` sur une ligne **verbatim amont**
   (`isUnit_one_add_of_mem_map`) — conservée pour la byte-identité du port, ne
   casse rien. La CI `lean-galois.yml` re-vérifie.
3. **Proof-integrity** — câblée sur ce lake (`lean-galois.yml` → `lean-axiom.yml`,
   `target-modules: "*"`, `allow-axioms: ""`, `fail-on-sorry: true`) : le job
   tourne sur cette PR. Axiomes attendus : `[propext, Classical.choice,
   Quot.sound]` (mesurés sur l'amont) — dans la whitelist §B par défaut.
4. **Parité FR/EN** — `check_i18n_siblings.py` : `check_pair` rend **OK**
   (byte-identity des corps après normalisation ; les lignes `open`/`namespace`
   sont structurellement exclues, la divergence de qualifieur est légitime) ;
   `check_en_built` voit le miroir `_en` **BUILT** via le glob `Galois.*`
   (le gate `lean-i18n-drift.yml` passe au vert).

## Pourquoi `globs` (et non plus bare-lib)

Le lake était bare-lib + agrégateur racine pour contourner un quirk
`v4.31.0-rc1` (« some modules have bad imports »). À `v4.33.0` le glob build
est vérifié SUCCESS. Le bare-lib n'était de toute façon plus viable avec des
siblings `_en` : `check_en_built` (gate CI `lean-i18n-drift.yml`) ne lit que
roots/globs — un miroir importé par le seul agrégateur racine serait flaggé
UNBUILT bien que compilé. Le glob `Galois.*` est le pattern canonique des
lakes à siblings (game_theory_lean, decision_theory_lean).

## Provenance

- Amont : `anthropics/fermats-last-theorem` @ `aa2d8b34692b16c70f699536de0d8e75b9a3e9ef`,
  `Definitions/Def_AdicCompletionLocalRing.lean` — Apache-2.0, attribution et
  `NOTICE` préservées (en-tête de module).
- Mathlib : `db584cd6d46c92f209a44c0f1c829460d327499d` (pin inchangé).
- Ne modifie pas le bundle M22/M23 (socle des grains aval Hensel /
  ramification #14786).

## Résiduel

- Un exemple sur anneau fini local (`ZMod p^n`, volet Local de la tranche)
  exigerait des instances `IsLocalRing`/`IsNoetherianRing` absentes de Mathlib
  à ce pin — grain de suivi possible, signalé sur #14783.

Closes #14783
