### PR TITLE
feat(gametheory,#12598): GT-27 echo Munkres — renvoi croise vers Sudoku-15

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-27-Munkres-Assignment.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-27-Munkres-Assignment.ipynb
@@ -20,7 +20,13 @@
     "> Si son nom est familier des générations d'étudiants par son manuel de topologie (*Topology*,\n",
     "> 1975 — le « Munkres » des cours 18.901), il est pour nous le co-éponyme de l'**algorithme de\n",
     "> Kuhn-Munkres** — la méthode hongroise pour le problème d'affectation, dont il a établi en 1957\n",
-    "> la première analyse de complexité *fortement polynomiale*. Ce notebook travaille son théorème."
+    "> la première analyse de complexité *fortement polynomiale*. Ce notebook travaille son théorème.\n",
+    "\n",
+    "> **Écho dans le dépôt.** La méthode tourne en production pédagogique dans\n",
+    "> [Sudoku-15 — Solveurs probabilistes (C#)](../Sudoku/Sudoku-15-Infer-Csharp.ipynb) :\n",
+    "> le solveur v4 (max-product sur facteurs AllDiff d'arité 9) appelle Kuhn-Munkres (`Hungarian`)\n",
+    "> pour extraire son affectation à chaque message.\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2027:CoursIA — prev: MED/guard #14901

## Summary

Renvoi croise Munkres, sens GT-27 -> Sudoku-15 : dans la cellule hommage de
GameTheory-27, un bloc « Echo dans le depot » pointe vers Sudoku-15 (C#) ou
la methode tourne en production pedagogique — le solveur v4 max-product sur
facteurs AllDiff d'arite 9 appelle Kuhn-Munkres (`Hungarian`) pour extraire
son affectation a chaque message (livre par #12769, sur main).

Le sens reciproque (Sudoku-15 -> GT-27, cellule hommage Munkres) est porte
par la PR Sudoku-15 de cette meme lane. See #12598 (contribution partielle a
l'epic hommage, pas une cloture).

## Validation

- Markdown uniquement (C.2 : exception prose, pas de re-exec requise) ;
  diff strictement additif (+7/-1), contenu main preserve tel quel.
- Lien relatif `../Sudoku/Sudoku-15-Infer-Csharp.ipynb` resolu sur la base
  fraiche (fichier present, base = origin/main 26f6bc44eec8).
- Base fraiche re-appliquee (le worktree source etait sur une base stale
  pre-#13606) : aucun churn parasite.
