### PR TITLE
feat(sudoku,#14957): accrétion 12b — Linq2Z3, l'histoire du binding en 4 barreaux

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -443,6 +443,7 @@ Les notebooks suivants sont disponibles dans les deux langages pour comparaison 
 | 10 | OR-Tools | [Sudoku-10-ORTools-Csharp](Sudoku-10-ORTools-Csharp.ipynb) | [Sudoku-10-ORTools-Python](Sudoku-10-ORTools-Python.ipynb) | CP-SAT solveur |
 | 11 | Choco | [Sudoku-11-Choco-Csharp](Sudoku-11-Choco-Csharp.ipynb) | [Sudoku-11-Choco-Python](Sudoku-11-Choco-Python.ipynb) | CP industrielle |
 | 12 | Z3 | [Sudoku-12-Z3-Csharp](Sudoku-12-Z3-Csharp.ipynb) | [Sudoku-12-Z3-Python](Sudoku-12-Z3-Python.ipynb) | SMT solveur |
+| 12b | Linq2Z3 (accrétion de 12) | [Sudoku-12b-Z3-Linq2Z3-Csharp](Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb) | — | Le binding Z3.Linq en 4 barreaux (propriétés → collections → `int[][]` → rung `int[,]` attesté) |
 | 13 | Symbolic Automata | [Sudoku-13-SymbolicAutomata-Csharp](Sudoku-13-SymbolicAutomata-Csharp.ipynb) | [Sudoku-13-SymbolicAutomata-Python](Sudoku-13-SymbolicAutomata-Python.ipynb) | Automates symboliques : .NET vs regex récursive + Z3 |
 | 14 | BDD/MDD | [Sudoku-14-BDD-Csharp](Sudoku-14-BDD-Csharp.ipynb) | [Sudoku-14-BDD-Python](Sudoku-14-BDD-Python.ipynb) | Diagrammes de décision hand-rolled (parité) |
 | 15 | Infer (Probabiliste) | [Sudoku-15-Infer-Csharp](Sudoku-15-Infer-Csharp.ipynb) | [Sudoku-15-Infer-Python](Sudoku-15-Infer-Python.ipynb) | Inférence bayésienne |
@@ -656,6 +657,7 @@ Sudoku/
 ├── Sudoku-11-Choco-Python.ipynb           # Choco Solver Python
 ├── Sudoku-12-Z3-Csharp.ipynb              # Z3 SMT C#
 ├── Sudoku-12-Z3-Python.ipynb              # Z3 SMT Python
+├── Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb     # Accrétion de 12 : le binding Z3.Linq (C#-only)
 ├── Sudoku-13-SymbolicAutomata-Csharp.ipynb # Automates symboliques C#
 ├── Sudoku-13-SymbolicAutomata-Python.ipynb # Twin Python (regex, Z3, récursion (?&rec))
 ├── Sudoku-14-BDD-Csharp.ipynb             # BDD/MDD C#

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb
@@ -1,0 +1,1786 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "11fea2ec",
+   "metadata": {},
+   "source": [
+    "# Sudoku 12b : Linq2Z3 — l'histoire d'un binding, de 81 propriétés aux tableaux imbriqués\n",
+    "\n",
+    "[<< Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb) | [Index](README.md) | [Sudoku-13 Automates symboliques >>](Sudoku-13-SymbolicAutomata-Csharp.ipynb)\n",
+    "\n",
+    "**Série :** Sudoku (accrétion du notebook 12) · **Kernel :** .NET (C#) · **Prérequis :** [Sudoku-12-Z3-Csharp](Sudoku-12-Z3-Csharp.ipynb) (Z3 brut)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6c8eb6f",
+   "metadata": {},
+   "source": [
+    "## Vue d'ensemble : le même moteur, une couche d'expression fluente\n",
+    "\n",
+    "[Sudoku-12](Sudoku-12-Z3-Csharp.ipynb) résout le Sudoku avec l'API **Z3 brute** : on fabrique soi-même les `IntExpr`, les `BoolExpr`, on appelle `solver.Check()` puis on relit le modèle cellule par cellule. C'est la voie directe — et la plus verbeuse.\n",
+    "\n",
+    "Il existe une autre voie : **Linq2Z3** (bibliothèque `Z3.Linq`), un *binding* qui enveloppe le même moteur Z3 dans un DSL LINQ déclaratif. On décrit une **classe C# ordinaire** dont les propriétés sont les inconnues, puis on écrit les contraintes comme des prédicats `.Where(...)` :\n",
+    "\n",
+    "```csharp\n",
+    "var theorem = ctx.NewTheorem<SudokuGrid>();\n",
+    "theorem = theorem.Where(g => g.Cells[row][col] >= 1 && g.Cells[row][col] <= 9);\n",
+    "var solution = theorem.Solve();   // solution est une SudokuGrid remplie\n",
+    "```\n",
+    "\n",
+    "Ce binding a une **histoire** : né en 2009 dans une série de trois articles de Bart De Smet, porté par nos soins dans le fork `MyIntelligenceAgency/Z3.Linq`, il a évolué en **quatre rungs** — quatre marches d'une échelle dont chaque barreau est porté par un artefact ou un commit tracé. Le Sudoku est l'application canonique de cette évolution : chaque rung se mesure sur lui.\n",
+    "\n",
+    "**Pourquoi une accrétion de Sudoku-12 et pas un nouveau numéro ?** Le Linq2Z3 approfondit le palier Z3 (même solveur, couche d'expression plus riche) au lieu de l'étendre en un survol de plus — c'est la convention d'accrétion de la série (la base compte comme `a`, la première accrétion est `b`, réf. #5081).\n",
+    "\n",
+    "**Positionnement vis-à-vis de la série SMT.** La série [`SymbolicAI/SMT/Z3-Linq2Z3/`](../SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb) enseigne le binding en profondeur (modélisation, modes, cas d'usage). Ce notebook est le pont côté série Sudoku : il raconte **l'évolution du binding** telle qu'elle se lit dans son code, ancrée à chaque marche. Pour la pratique de modélisation, voir [02 — Théorème vs Arrays](../SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb) et [05 — Tableaux imbriqués](../SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7d3b185",
+   "metadata": {},
+   "source": [
+    "## L'échelle des quatre barreaux\n",
+    "\n",
+    "| Barreau | Forme du modèle | Ancrage tracé | Ce qu'il apporte |\n",
+    "|---|---|---|---|\n",
+    "| 1 | une propriété `int` par cellule (81 pour un 9x9) | `SudokuTable.cs`, série d'articles 2009 | le DSL existe : `NewTheorem<T>` / `Where` / `Z3Methods.Distinct` |\n",
+    "| 2 | collections indicées (`List<int>`, mode *Constants*) | branche `feature/list-collection-constants-mode` (notre port) | boucles et closures remplacent la réflexion |\n",
+    "| 3 | tableaux imbriqués `int[][]` | commit `096a638` — `SudokuGrid.cs` / `SudokuGridTheorem.cs` | le modèle ressemble enfin à la grille |\n",
+    "| 4 | tableaux rectangulaires `int[,]` | **l'intention, confrontée au code réel** | le rung manquant — attesté tel quel en section 4 |\n",
+    "\n",
+    "Chaque barreau est démontré **exécuté** dans ce notebook, sur le même moteur Z3 que Sudoku-12."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f9c10d4",
+   "metadata": {},
+   "source": [
+    "### Configuration de l'environnement\n",
+    "\n",
+    "Le binding vit dans le sous-module `SymbolicAI/SMT/Z3.Linq` (fork de `endjin/Z3.Linq`), qui embarque un dossier `.deploy/` préassemblé : les DLL `Microsoft.Z3` (le moteur), `Z3.Linq` (le binding) et `ExpressionUtils` (dépendance de réécriture d'expressions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1dbe8bc8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:30.712149Z",
+     "iopub.status.busy": "2026-09-06T22:20:30.707301Z",
+     "iopub.status.idle": "2026-09-06T22:20:32.885734Z",
+     "shell.execute_reply": "2026-09-06T22:20:32.881563Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '39164.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3.Linq   v1.0.0.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Microsoft.Z3 v4.12.2.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"../SymbolicAI/SMT/Z3.Linq/.deploy/Microsoft.Z3.dll\"\n",
+    "#r \"../SymbolicAI/SMT/Z3.Linq/.deploy/ExpressionUtils.dll\"\n",
+    "#r \"../SymbolicAI/SMT/Z3.Linq/.deploy/Z3.Linq.dll\"\n",
+    "\n",
+    "using Z3.Linq;\n",
+    "using Microsoft.Z3;\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "using System.Linq.Expressions;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "Console.WriteLine($\"Z3.Linq   v{typeof(Z3Context).Assembly.GetName().Version}\");\n",
+    "Console.WriteLine($\"Microsoft.Z3 v{typeof(Context).Assembly.GetName().Version}\");\n",
+    "Console.WriteLine(\"Imports OK\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc114b12",
+   "metadata": {},
+   "source": [
+    "### Outils d'affichage\n",
+    "\n",
+    "Une grille 1D aplatie (81 cellules, index `i * 9 + j`) et une grille imbriquée `int[][]` — les deux formes que les barreaux vont croiser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "79dd571c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:32.887072Z",
+     "iopub.status.busy": "2026-09-06T22:20:32.886902Z",
+     "iopub.status.idle": "2026-09-06T22:20:33.288320Z",
+     "shell.execute_reply": "2026-09-06T22:20:33.287983Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle temoin charge : 30 indices non nuls\n"
+     ]
+    }
+   ],
+   "source": [
+    "void DisplayFlat(int[] cells, string title)\n",
+    "{\n",
+    "    Console.WriteLine($\"--- {title} ---\");\n",
+    "    var sep = new string('-', 25);\n",
+    "    Console.WriteLine(sep);\n",
+    "    for (int i = 0; i < 9; i++)\n",
+    "    {\n",
+    "        var sb = new StringBuilder(\"| \");\n",
+    "        for (int j = 0; j < 9; j++)\n",
+    "        {\n",
+    "            sb.Append(cells[i * 9 + j]);\n",
+    "            sb.Append((j + 1) % 3 == 0 ? \" | \" : \" \");\n",
+    "        }\n",
+    "        Console.WriteLine(sb);\n",
+    "        if ((i + 1) % 3 == 0) Console.WriteLine(sep);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "void DisplayNested(int[][] cells, string title)\n",
+    "{\n",
+    "    Console.WriteLine($\"--- {title} ---\");\n",
+    "    var sep = new string('-', 25);\n",
+    "    Console.WriteLine(sep);\n",
+    "    for (int i = 0; i < 9; i++)\n",
+    "    {\n",
+    "        var sb = new StringBuilder(\"| \");\n",
+    "        for (int j = 0; j < 9; j++)\n",
+    "        {\n",
+    "            sb.Append(cells[i][j]);\n",
+    "            sb.Append((j + 1) % 3 == 0 ? \" | \" : \" \");\n",
+    "        }\n",
+    "        Console.WriteLine(sb);\n",
+    "        if ((i + 1) % 3 == 0) Console.WriteLine(sep);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Le puzzle témoin de Wikipedia, utilisé par tous les barreaux.\n",
+    "int[] WIKI_PUZZLE = {\n",
+    "    5,3,0, 0,7,0, 0,0,0,\n",
+    "    6,0,0, 1,9,5, 0,0,0,\n",
+    "    0,9,8, 0,0,0, 0,6,0,\n",
+    "    8,0,0, 0,6,0, 0,0,3,\n",
+    "    4,0,0, 8,0,3, 0,0,1,\n",
+    "    7,0,0, 0,2,0, 0,0,6,\n",
+    "    0,6,0, 0,0,0, 2,8,0,\n",
+    "    0,0,0, 4,1,9, 0,0,5,\n",
+    "    0,0,0, 0,8,0, 0,7,9,\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine($\"Puzzle temoin charge : {WIKI_PUZZLE.Count(v => v != 0)} indices non nuls\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a571402",
+   "metadata": {},
+   "source": [
+    "## 1. Barreau 1 — 2009 : le binding et son premier Sudoku, une propriété par cellule\n",
+    "\n",
+    "L'origine est une série de trois articles de **Bart De Smet** (avril et septembre 2009, conservés sur archive.org et re-déposés dans le fork sous `docs/blogs/`) :\n",
+    "\n",
+    "1. *Exploring the Z3 Theorem Prover* — le moteur ;\n",
+    "2. *LINQ to the Unexpected* — l'idée du binding : un « esoteric LINQ binding » où `Where` ne filtre pas une collection mais **contraint un théorème** ;\n",
+    "3. *Theorem Solving on Steroids* — le type `Theorem<T>` et le pattern de requête.\n",
+    "\n",
+    "Le Sudoku d'origine du binding est [`SudokuTable.cs`](../SymbolicAI/SMT/Z3.Linq/solutions/Z3.Linq.Examples/Sudoku/SudokuTable.cs) : **une classe où chaque cellule est une propriété typée distincte** — `Cell11`, `Cell12`, … `Cell99`, soit 81 propriétés `int`. Le théorème se construit avec une contrainte `.Where(...)` par propriété, et `Z3Methods.Distinct(...)` porte l'unicité.\n",
+    "\n",
+    "Pour toucher ce rung du doigt sans recopier 220 lignes, voici sa déclinaison fidèle sur un **Sudoku 4x4** (16 propriétés, valeurs 1 à 4, blocs 2x2) :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "acdcbb7f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:33.289497Z",
+     "iopub.status.busy": "2026-09-06T22:20:33.289313Z",
+     "iopub.status.idle": "2026-09-06T22:20:33.410127Z",
+     "shell.execute_reply": "2026-09-06T22:20:33.409718Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SudokuTable4 : 16 proprietes, un nom par cellule — la forme du rung 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 1 : la classe-modele, une propriete par cellule (forme de SudokuTable.cs)\n",
+    "public class SudokuTable4\n",
+    "{\n",
+    "    public int Cell11 { get; private set; }\n",
+    "    public int Cell12 { get; private set; }\n",
+    "    public int Cell13 { get; private set; }\n",
+    "    public int Cell14 { get; private set; }\n",
+    "    public int Cell21 { get; private set; }\n",
+    "    public int Cell22 { get; private set; }\n",
+    "    public int Cell23 { get; private set; }\n",
+    "    public int Cell24 { get; private set; }\n",
+    "    public int Cell31 { get; private set; }\n",
+    "    public int Cell32 { get; private set; }\n",
+    "    public int Cell33 { get; private set; }\n",
+    "    public int Cell34 { get; private set; }\n",
+    "    public int Cell41 { get; private set; }\n",
+    "    public int Cell42 { get; private set; }\n",
+    "    public int Cell43 { get; private set; }\n",
+    "    public int Cell44 { get; private set; }\n",
+    "\n",
+    "    public override string ToString()\n",
+    "    {\n",
+    "        var names = new[] { \"Cell11\",\"Cell12\",\"Cell13\",\"Cell14\",\"Cell21\",\"Cell22\",\"Cell23\",\"Cell24\",\n",
+    "                            \"Cell31\",\"Cell32\",\"Cell33\",\"Cell34\",\"Cell41\",\"Cell42\",\"Cell43\",\"Cell44\" };\n",
+    "        var props = GetType().GetProperties();\n",
+    "        var sb = new StringBuilder();\n",
+    "        for (int i = 0; i < 4; i++)\n",
+    "        {\n",
+    "            for (int j = 0; j < 4; j++)\n",
+    "                sb.Append(props.Single(p => p.Name == names[i * 4 + j]).GetValue(this)).Append(' ');\n",
+    "            sb.AppendLine();\n",
+    "        }\n",
+    "        return sb.ToString();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// L'astuce de SudokuTheorem.cs : les bornes 1..4 sont construites par reflexion,\n",
+    "// par nom de propriete — parce qu'une lambda ne peut PAS indexer t.Cell{i}{j}.\n",
+    "Expression<Func<SudokuTable4, bool>> Between1And4(string cellName)\n",
+    "{\n",
+    "    var t = Expression.Parameter(typeof(SudokuTable4), \"t\");\n",
+    "    var cell = Expression.Property(t, cellName);\n",
+    "    var one = Expression.Constant(1);\n",
+    "    var four = Expression.Constant(4);\n",
+    "    return Expression.Lambda<Func<SudokuTable4, bool>>(\n",
+    "        Expression.AndAlso(\n",
+    "            Expression.GreaterThanOrEqual(cell, one),\n",
+    "            Expression.LessThanOrEqual(cell, four)), t);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"SudokuTable4 : 16 proprietes, un nom par cellule — la forme du rung 1\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "59b8e098",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:33.411372Z",
+     "iopub.status.busy": "2026-09-06T22:20:33.411181Z",
+     "iopub.status.idle": "2026-09-06T22:20:33.674629Z",
+     "shell.execute_reply": "2026-09-06T22:20:33.674716Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resolution 4x4 en 145 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 3 2 4 \n",
+      "4 2 3 1 \n",
+      "3 4 1 2 \n",
+      "2 1 4 3 \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 1 : le theoreme en 4x4 — domaines par reflexion, unites explicites, indices poses\n",
+    "var sw1 = Stopwatch.StartNew();\n",
+    "var ctx1 = new Z3Context();\n",
+    "var th1 = ctx1.NewTheorem<SudokuTable4>();\n",
+    "\n",
+    "// (a) Domaines 1..4 : une contrainte par propriete, construite par reflexion\n",
+    "foreach (var name in new[] { \"Cell11\",\"Cell12\",\"Cell13\",\"Cell14\",\"Cell21\",\"Cell22\",\"Cell23\",\"Cell24\",\n",
+    "                             \"Cell31\",\"Cell32\",\"Cell33\",\"Cell34\",\"Cell41\",\"Cell42\",\"Cell43\",\"Cell44\" })\n",
+    "{\n",
+    "    th1 = th1.Where(Between1And4(name));\n",
+    "}\n",
+    "\n",
+    "// (b) Unites : rangees, colonnes, blocs 2x2 — ecritures explicites, aucune boucle possible\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell11, t.Cell12, t.Cell13, t.Cell14));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell21, t.Cell22, t.Cell23, t.Cell24));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell31, t.Cell32, t.Cell33, t.Cell34));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell41, t.Cell42, t.Cell43, t.Cell44));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell11, t.Cell21, t.Cell31, t.Cell41));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell12, t.Cell22, t.Cell32, t.Cell42));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell13, t.Cell23, t.Cell33, t.Cell43));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell14, t.Cell24, t.Cell34, t.Cell44));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell11, t.Cell12, t.Cell21, t.Cell22));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell13, t.Cell14, t.Cell23, t.Cell24));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell31, t.Cell32, t.Cell41, t.Cell42));\n",
+    "th1 = th1.Where(t => Z3Methods.Distinct(t.Cell33, t.Cell34, t.Cell43, t.Cell44));\n",
+    "\n",
+    "// (c) Indices du puzzle 4x4 : les coins\n",
+    "th1 = th1.Where(t => t.Cell11 == 1);\n",
+    "th1 = th1.Where(t => t.Cell14 == 4);\n",
+    "th1 = th1.Where(t => t.Cell41 == 2);\n",
+    "th1 = th1.Where(t => t.Cell44 == 3);\n",
+    "\n",
+    "var sol1 = th1.Solve();\n",
+    "sw1.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Resolution 4x4 en {sw1.ElapsedMilliseconds} ms\");\n",
+    "Console.WriteLine();\n",
+    "Console.Write(sol1.ToString());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e6b5286",
+   "metadata": {},
+   "source": [
+    "### Interprétation 1 — le rung propriétés : le DSL existe, l'échelle n'existe pas encore\n",
+    "\n",
+    "Le binding fonctionne dès 2009 : `NewTheorem<SudokuTable4>()` fabrique les 16 inconnues Z3 à partir des propriétés, chaque `Where` compile une expression C# en contrainte SMT, et `Solve()` rend **une instance remplie** de la classe — pas un modèle à relire index par index. C'est déjà un saut ergonomique énorme sur le Z3 brut de Sudoku-12.\n",
+    "\n",
+    "Mais regardez **ce que le code a dû faire pour tenir sur ce rung** :\n",
+    "\n",
+    "- la classe `SudokuTable` réelle compte **81 propriétés** et 220 lignes (l'artefact la génère telle quelle) ;\n",
+    "- les bornes 1..9 de l'artefact sont construites **par réflexion sur des noms en chaîne** (`\"Cell{0}{1}\"`, cf. `SudokuTheorem.cs`) — parce qu'une expression lambda ne peut pas écrire `t.Cell{i}{j}` ;\n",
+    "- les neuf contraintes `Distinct` de blocs du 9x9 sont **écrites une à une**, chacune avec neuf arguments nommés.\n",
+    "\n",
+    "Sur notre 4x4, douze contraintes d'unité explicites ont suffi. Sur un 9x9 il en faut 27 ; sur un 16x16, 48 — et la classe doit d'abord exister, propriété par propriété. **Le rung propriétés ne passe pas à l'échelle : c'est exactement le problème que le rung suivant vient résoudre.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56c6760b",
+   "metadata": {},
+   "source": [
+    "## 2. Barreau 2 — notre port : les collections indicées (mode *Constants*)\n",
+    "\n",
+    "Le deuxième rung est **notre port du binding**, porté par la branche `feature/list-collection-constants-mode` du fork : le théorème accepte désormais une **collection indicée** comme inconnue — `List<int>`, `IList<int>`, `int[]` — et le DSL gagne un réglage :\n",
+    "\n",
+    "```csharp\n",
+    "var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Constants };\n",
+    "```\n",
+    "\n",
+    "Deux modes existent (enum `CollectionHandling` dans `Environment.cs`) :\n",
+    "\n",
+    "- **`Array`** (le défaut) : la collection devient un **tableau SMT** (`Store`/`Select`) — l'unicité de l'objet est native côté Z3 ;\n",
+    "- **`Constants`** : la collection est **éclatée en constantes individuelles**, une par élément — le solveur voit 81 inconnues plates.\n",
+    "\n",
+    "Le point technique qui explique la marche : un indexeur `List<int>` compile vers un appel de méthode `get_Item`, pas vers un nœud `ArrayIndex` comme `int[]` — le *visitor* du binding a dû apprendre à router les deux front-ends (c'est documenté dans `ListCollectionTests.cs` du fork, qui épingle les deux modes ensemble).\n",
+    "\n",
+    "Le modèle 9x9 complet devient **une classe de quatre lignes** :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "18a4103c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:33.676047Z",
+     "iopub.status.busy": "2026-09-06T22:20:33.675881Z",
+     "iopub.status.idle": "2026-09-06T22:20:33.770473Z",
+     "shell.execute_reply": "2026-09-06T22:20:33.770352Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BuildArrayTheorem pret : 81 domaines + 27 unites, tout en boucles\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 2 : le modele 9x9 complet en une propriete collection\n",
+    "public class SudokuArray\n",
+    "{\n",
+    "    public List<int> Cells { get; set; } = Enumerable.Repeat(0, 81).ToList();\n",
+    "}\n",
+    "\n",
+    "// Le theoreme en mode Constants : boucles + closures, plus de reflexion\n",
+    "Theorem<SudokuArray> BuildArrayTheorem(Z3Context ctx)\n",
+    "{\n",
+    "    var th = ctx.NewTheorem<SudokuArray>();\n",
+    "    var idx = Enumerable.Range(0, 9).ToArray();\n",
+    "\n",
+    "    // Domaines 1..9 : la boucle que le rung 1 ne pouvait pas ecrire\n",
+    "    for (int i = 0; i < 9; i++)\n",
+    "        for (int j = 0; j < 9; j++)\n",
+    "        {\n",
+    "            var i1 = i; var j1 = j;   // capture de closure : copie locale obligatoire\n",
+    "            th = th.Where(s => s.Cells[i1 * 9 + j1] > 0 && s.Cells[i1 * 9 + j1] < 10);\n",
+    "        }\n",
+    "\n",
+    "    // Unites : rangees, colonnes, blocs — args explicites, la forme que le\n",
+    "    // rewriter Distinct epingle pour les deux modes (CollectionHandlingTests)\n",
+    "    for (int r = 0; r < 9; r++)\n",
+    "    {\n",
+    "        var r1 = r;\n",
+    "        th = th.Where(t => Z3Methods.Distinct(\n",
+    "            t.Cells[r1 * 9 + 0], t.Cells[r1 * 9 + 1], t.Cells[r1 * 9 + 2],\n",
+    "            t.Cells[r1 * 9 + 3], t.Cells[r1 * 9 + 4], t.Cells[r1 * 9 + 5],\n",
+    "            t.Cells[r1 * 9 + 6], t.Cells[r1 * 9 + 7], t.Cells[r1 * 9 + 8]));\n",
+    "    }\n",
+    "    for (int c = 0; c < 9; c++)\n",
+    "    {\n",
+    "        var c1 = c;\n",
+    "        th = th.Where(t => Z3Methods.Distinct(\n",
+    "            t.Cells[0 * 9 + c1], t.Cells[1 * 9 + c1], t.Cells[2 * 9 + c1],\n",
+    "            t.Cells[3 * 9 + c1], t.Cells[4 * 9 + c1], t.Cells[5 * 9 + c1],\n",
+    "            t.Cells[6 * 9 + c1], t.Cells[7 * 9 + c1], t.Cells[8 * 9 + c1]));\n",
+    "    }\n",
+    "    for (int b = 0; b < 9; b++)\n",
+    "    {\n",
+    "        var b1 = b;\n",
+    "        var start = (b1 / 3) * 27 + (b1 % 3) * 3;\n",
+    "        th = th.Where(t => Z3Methods.Distinct(\n",
+    "            t.Cells[start],      t.Cells[start + 1],  t.Cells[start + 2],\n",
+    "            t.Cells[start + 9],  t.Cells[start + 10], t.Cells[start + 11],\n",
+    "            t.Cells[start + 18], t.Cells[start + 19], t.Cells[start + 20]));\n",
+    "    }\n",
+    "    return th;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"BuildArrayTheorem pret : 81 domaines + 27 unites, tout en boucles\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e6fddd64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:33.771695Z",
+     "iopub.status.busy": "2026-09-06T22:20:33.771526Z",
+     "iopub.status.idle": "2026-09-06T22:20:33.894882Z",
+     "shell.execute_reply": "2026-09-06T22:20:33.894748Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode Constants : resolution en 72 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Solution (mode Constants) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 5 3 4 | 6 7 8 | 9 1 2 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 6 7 2 | 1 9 5 | 3 4 8 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 1 9 8 | 3 4 2 | 5 6 7 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 8 5 9 | 7 6 1 | 4 2 3 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 4 2 6 | 8 5 3 | 7 9 1 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 7 1 3 | 9 2 4 | 8 5 6 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 9 6 1 | 5 3 7 | 2 8 4 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 2 8 7 | 4 1 9 | 6 3 5 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 3 4 5 | 2 8 6 | 1 7 9 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 2 : resolution du puzzle temoin en mode Constants\n",
+    "var sw2 = Stopwatch.StartNew();\n",
+    "var ctx2 = new Z3Context { DefaultCollectionHandling = CollectionHandling.Constants };\n",
+    "var th2 = BuildArrayTheorem(ctx2);\n",
+    "for (int k = 0; k < 81; k++)\n",
+    "{\n",
+    "    if (WIKI_PUZZLE[k] != 0)\n",
+    "    {\n",
+    "        var k1 = k; var v1 = WIKI_PUZZLE[k];\n",
+    "        th2 = th2.Where(t => t.Cells[k1] == v1);\n",
+    "    }\n",
+    "}\n",
+    "var sol2 = th2.Solve();\n",
+    "sw2.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Mode Constants : resolution en {sw2.ElapsedMilliseconds} ms\");\n",
+    "DisplayFlat(sol2.Cells.ToArray(), \"Solution (mode Constants)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4978fcca",
+   "metadata": {},
+   "source": [
+    "### Interprétation 2 — boucles et closures remplacent la réflexion\n",
+    "\n",
+    "Comparez les deux barreaux sur le même geste « chaque cellule entre 1 et 9 » :\n",
+    "\n",
+    "- **rung 1** : `Expression.Property(t, \"Cell\" + i + j)` — réflexion sur des noms, hors du DSL ;\n",
+    "- **rung 2** : `th.Where(s => s.Cells[i1 * 9 + j1] > 0 && ...)` — **une expression C# ordinaire**, dans le DSL, dans une boucle.\n",
+    "\n",
+    "L'indice reste aplati (`i * 9 + j`) — la grille est un `List<int>` de 81 éléments, la géométrie est arithmétique modulaire dans les contraintes de blocs (`start`, `+9`, `+18`). Notez la `capture de closure` (`var i1 = i`) : sans cette copie locale, toutes les lambdas referenceraient la même variable de boucle et le théorème résolu serait faux — c'est le piège classique du rung, celui que la sortie du notebook 02 de la série SMT documente aussi.\n",
+    "\n",
+    "La classe modèle est passée de 220 lignes (81 propriétés) à **4 lignes** (1 collection)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ccf7a0cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:33.895960Z",
+     "iopub.status.busy": "2026-09-06T22:20:33.895782Z",
+     "iopub.status.idle": "2026-09-06T22:20:33.999123Z",
+     "shell.execute_reply": "2026-09-06T22:20:33.998833Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mode Array : resolution en 43 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Solution (mode Array) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 5 3 4 | 6 7 8 | 9 1 2 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 6 7 2 | 1 9 5 | 3 4 8 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 1 9 8 | 3 4 2 | 5 6 7 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 8 5 9 | 7 6 1 | 4 2 3 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 4 2 6 | 8 5 3 | 7 9 1 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 7 1 3 | 9 2 4 | 8 5 6 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 9 6 1 | 5 3 7 | 2 8 4 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 2 8 7 | 4 1 9 | 6 3 5 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 3 4 5 | 2 8 6 | 1 7 9 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identique a la solution Constants : True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 2 (bis) : le meme theoreme, le meme puzzle, en mode Array\n",
+    "var sw2b = Stopwatch.StartNew();\n",
+    "var ctx2b = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };\n",
+    "var th2b = BuildArrayTheorem(ctx2b);\n",
+    "for (int k = 0; k < 81; k++)\n",
+    "{\n",
+    "    if (WIKI_PUZZLE[k] != 0)\n",
+    "    {\n",
+    "        var k1 = k; var v1 = WIKI_PUZZLE[k];\n",
+    "        th2b = th2b.Where(t => t.Cells[k1] == v1);\n",
+    "    }\n",
+    "}\n",
+    "var sol2b = th2b.Solve();\n",
+    "sw2b.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Mode Array : resolution en {sw2b.ElapsedMilliseconds} ms\");\n",
+    "DisplayFlat(sol2b.Cells.ToArray(), \"Solution (mode Array)\");\n",
+    "Console.WriteLine($\"Identique a la solution Constants : {sol2.Cells.SequenceEqual(sol2b.Cells)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f18a5086",
+   "metadata": {},
+   "source": [
+    "### Interprétation 3 — Constants vs Array : deux front-ends, un même théorème\n",
+    "\n",
+    "La même fonction `BuildArrayTheorem` a produit les deux solutions — le code utilisateur ne change **pas d'une ligne** entre les deux modes ; seul le réglage du contexte diffère. C'est la propriété que les tests du fork épingle : *les deux front-ends d'indexation (nœud `ArrayIndex` pour `int[]`, appel `get_Item` pour `List<T>`) doivent rester alignés en comportement*.\n",
+    "\n",
+    "La différence est **sémantique côté Z3** : en mode `Array` la collection est un objet unique que le solveur contraint via la théorie des tableaux (`Store`/`Select` imbriqués) ; en mode `Constants` elle est éclatée en constantes plates. Pour un Sudoku, les deux convergent — sur des problèmes où la cardinalité ou les quantificateurs bornés comptent, le choix du mode devient un vrai levier de modélisation (la série SMT, notebook 05, creuse cet écart)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e181f2e",
+   "metadata": {},
+   "source": [
+    "## 3. Barreau 3 — les tableaux imbriqués `int[][]` (commit `096a638`)\n",
+    "\n",
+    "Troisième marche, portée par le commit **`096a638`** (« feat: add nested int[][] array support », branche `feature/list-collection-constants-mode`) : le modèle peut désormais être un **tableau de tableaux**. Les artefacts sont [`SudokuGrid.cs`](../SymbolicAI/SMT/Z3.Linq/solutions/Z3.Linq.Examples/Sudoku/SudokuGrid.cs) et [`SudokuGridTheorem.cs`](../SymbolicAI/SMT/Z3.Linq/solutions/Z3.Linq.Examples/Sudoku/SudokuGridTheorem.cs) :\n",
+    "\n",
+    "```csharp\n",
+    "public class SudokuGrid\n",
+    "{\n",
+    "    public int[][] Cells { get; set; } = new int[9][];\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "La cellule s'écrit `g.Cells[row][col]` — plus d'arithmétique `i * 9 + j`, plus de tableau à une dimension : **le modèle a la forme de la grille**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5b1da5ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.000381Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.000223Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.092446Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.092571Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BuildGridTheorem pret : Cells[row][col], la forme de la grille\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 3 : le modele jagged, forme de SudokuGrid.cs\n",
+    "public class SudokuGrid\n",
+    "{\n",
+    "    public int[][] Cells { get; set; } = new int[9][];\n",
+    "    public SudokuGrid()\n",
+    "    {\n",
+    "        for (int i = 0; i < 9; i++) Cells[i] = new int[9];\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Le theoreme, forme de SudokuGridTheorem.cs\n",
+    "Theorem<SudokuGrid> BuildGridTheorem(Z3Context ctx)\n",
+    "{\n",
+    "    var th = ctx.NewTheorem<SudokuGrid>();\n",
+    "\n",
+    "    // Domaines : g.Cells[row][col] entre 1 et 9\n",
+    "    for (int i = 0; i < 9; i++)\n",
+    "        for (int j = 0; j < 9; j++)\n",
+    "        {\n",
+    "            var (r, c) = (i, j);\n",
+    "            th = th.Where(g => g.Cells[r][c] >= 1 && g.Cells[r][c] <= 9);\n",
+    "        }\n",
+    "\n",
+    "    // Unites : rangee, colonne, bloc — l'indice a deux dimensions, comme la grille\n",
+    "    for (int i = 0; i < 9; i++)\n",
+    "    {\n",
+    "        var row = i;\n",
+    "        th = th.Where(g => Z3Methods.Distinct(\n",
+    "            g.Cells[row][0], g.Cells[row][1], g.Cells[row][2],\n",
+    "            g.Cells[row][3], g.Cells[row][4], g.Cells[row][5],\n",
+    "            g.Cells[row][6], g.Cells[row][7], g.Cells[row][8]));\n",
+    "    }\n",
+    "    for (int j = 0; j < 9; j++)\n",
+    "    {\n",
+    "        var col = j;\n",
+    "        th = th.Where(g => Z3Methods.Distinct(\n",
+    "            g.Cells[0][col], g.Cells[1][col], g.Cells[2][col],\n",
+    "            g.Cells[3][col], g.Cells[4][col], g.Cells[5][col],\n",
+    "            g.Cells[6][col], g.Cells[7][col], g.Cells[8][col]));\n",
+    "    }\n",
+    "    for (int br = 0; br < 3; br++)\n",
+    "        for (int bc = 0; bc < 3; bc++)\n",
+    "        {\n",
+    "            var (R, C) = (br, bc);\n",
+    "            th = th.Where(g => Z3Methods.Distinct(\n",
+    "                g.Cells[R * 3][C * 3],     g.Cells[R * 3][C * 3 + 1],     g.Cells[R * 3][C * 3 + 2],\n",
+    "                g.Cells[R * 3 + 1][C * 3], g.Cells[R * 3 + 1][C * 3 + 1], g.Cells[R * 3 + 1][C * 3 + 2],\n",
+    "                g.Cells[R * 3 + 2][C * 3], g.Cells[R * 3 + 2][C * 3 + 1], g.Cells[R * 3 + 2][C * 3 + 2]));\n",
+    "        }\n",
+    "    return th;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"BuildGridTheorem pret : Cells[row][col], la forme de la grille\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b9878b66",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.093826Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.093502Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.202026Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.202129Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele jagged : resolution en 47 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Solution (int[][]) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 5 3 4 | 6 7 8 | 9 1 2 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 6 7 2 | 1 9 5 | 3 4 8 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 1 9 8 | 3 4 2 | 5 6 7 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 8 5 9 | 7 6 1 | 4 2 3 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 4 2 6 | 8 5 3 | 7 9 1 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 7 1 3 | 9 2 4 | 8 5 6 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 9 6 1 | 5 3 7 | 2 8 4 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 2 8 7 | 4 1 9 | 6 3 5 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 3 4 5 | 2 8 6 | 1 7 9 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identique a la solution du barreau 2 : True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 3 : resolution du puzzle temoin sur le modele jagged\n",
+    "var sw3 = Stopwatch.StartNew();\n",
+    "var ctx3 = new Z3Context();\n",
+    "var th3 = BuildGridTheorem(ctx3);\n",
+    "for (int i = 0; i < 9; i++)\n",
+    "    for (int j = 0; j < 9; j++)\n",
+    "    {\n",
+    "        if (WIKI_PUZZLE[i * 9 + j] != 0)\n",
+    "        {\n",
+    "            var (r, c) = (i, j); var v = WIKI_PUZZLE[i * 9 + j];\n",
+    "            th3 = th3.Where(g => g.Cells[r][c] == v);\n",
+    "        }\n",
+    "    }\n",
+    "var sol3 = th3.Solve();\n",
+    "sw3.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Modele jagged : resolution en {sw3.ElapsedMilliseconds} ms\");\n",
+    "DisplayNested(sol3.Cells, \"Solution (int[][])\");\n",
+    "\n",
+    "var flat3 = new int[81];\n",
+    "for (int i = 0; i < 9; i++) for (int j = 0; j < 9; j++) flat3[i * 9 + j] = sol3.Cells[i][j];\n",
+    "Console.WriteLine($\"Identique a la solution du barreau 2 : {sol2.Cells.SequenceEqual(flat3)}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f51ca93c",
+   "metadata": {},
+   "source": [
+    "### Interprétation 4 — le modèle ressemble enfin à la grille\n",
+    "\n",
+    "Le commit `096a638` fait passer l'expression de `s.Cells[i1 * 9 + j1]` à `g.Cells[r][c]`. Techniquement, le *visitor* du binding apprend à **descendre dans les nœuds `ArrayIndex` imbriqués** : `g.Cells[r]` est un premier tableau, `[c]` indexes le second — l'expression C# arbore deux niveaux que le binding compile en `Select(Select(cells, r), c)` côté SMT.\n",
+    "\n",
+    "Le gain n'est pas cosmétique :\n",
+    "\n",
+    "- les contraintes de blocs se lisent `g.Cells[R*3][C*3]` au lieu de `start + 18` — **la géométrie est dans les indices, plus dans l'arithmétique** ;\n",
+    "- la sortie **se parcourt comme une grille** (`sol3.Cells[i][j]`) sans dé-aplatissement ;\n",
+    "- la classe modèle reflète la donnée réelle d'un Sudoku (une grille 9x9), pas son encodage linéarisé.\n",
+    "\n",
+    "Les trois rungs démontrés résolvent le même puzzle — vérifié en sortie : les trois solutions coïncident. L'échelle ne change pas le moteur (c'est toujours le Z3 de Sudoku-12) ; elle change **le coût d'expression du modèle**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ec8950e",
+   "metadata": {},
+   "source": [
+    "## 4. Barreau 4 — `int[,]` : l'intention confrontée au code réel\n",
+    "\n",
+    "La quatrième marche — les **tableaux rectangulaires** `int[,]` — est signalée comme la dernière évolution **voulue** du binding. Ce notebook l'atteste honnêtement plutôt qu'il ne la démontre : **au 2026-09-06, `int[,]` comme type de modèle de théorème est absent du code du fork** (scan exhaustif des 30 refs distantes : le motif `int[,]` n'apparaît dans aucun `.cs` du binding ; les seules occurrences de `int[,]` dans les notebooks de la série SMT sont des **données** de puzzle, pas des modèles — cf. notebook 05, indices déclarés `int[,]` puis convertis).\n",
+    "\n",
+    "Ce qui existe déjà, on peut le **voir tourner** : la forme du nœud d'expression que le *visitor* devrait apprendre à router. Comparons les trois accès que C# compile différemment :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5df7b957",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.203320Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.203139Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.331261Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.331055Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jagged  a[1][2]  : ArrayIndex  |  a[1][2]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "list    l[1]     : Call  |  l.get_Item(1)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rect    g[1,2]   : Call  |  g.Get(1, 2)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "detail rect : InstanceMethodCallExpression2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "methode appelee : Get\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 4 : confrontation en direct — trois acces, trois formes d'arbre d'expression\n",
+    "Expression<Func<int[][], int>> jaggedAccess = a => a[1][2];\n",
+    "Expression<Func<List<int>, int>> listAccess  = l => l[1];\n",
+    "Expression<Func<int[,],   int>> rectAccess   = g => g[1, 2];\n",
+    "\n",
+    "Console.WriteLine(\"jagged  a[1][2]  : \" + jaggedAccess.Body.NodeType + \"  |  \" + jaggedAccess.Body);\n",
+    "Console.WriteLine(\"list    l[1]     : \" + listAccess.Body.NodeType + \"  |  \" + listAccess.Body);\n",
+    "Console.WriteLine(\"rect    g[1,2]   : \" + rectAccess.Body.NodeType + \"  |  \" + rectAccess.Body);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"detail rect : \" + rectAccess.Body.GetType().Name);\n",
+    "if (rectAccess.Body is MethodCallExpression call)\n",
+    "    Console.WriteLine(\"methode appelee : \" + call.Method.Name);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9430f82f",
+   "metadata": {},
+   "source": [
+    "### Interprétation 5 — chaque rung est un nœud d'expression routé\n",
+    "\n",
+    "La sortie ci-dessus est l'explication du barreau manquant, lue dans le compilateur : les trois accès **ne compilent pas vers la même forme**. L'accès imbriqué `a[1][2]` et l'indexeur `l[1]` produisent des nœuds que le *visitor* du binding sait déjà traduire (c'est le barreau 2 — `get_Item` — et le barreau 3 — `ArrayIndex` imbriqué) ; l'accès rectangulaire `g[1,2]` produit **une autre forme**, celle que le *visitor* ne route pas encore.\n",
+    "\n",
+    "Relue depuis la sortie, toute l'échelle prend son sens générique : **un binding LINQ évolue en apprenant des nœuds d'expression**. Chaque rung de l'histoire — propriétés (`Member`), collections indicées (`Call get_Item`), tableaux imbriqués (`ArrayIndex` imbriqué) — est un type de nœud que `ExpressionVisitor` a appris à compiler vers Z3. Le rung 4 attend son routage.\n",
+    "\n",
+    "C'est la frontière honnête de ce notebook : il **atteste** le rung manquant (code scanné, nœud exhibé) sans le combler — l'implémenter serait une PR du fork `Z3.Linq`, pas un livrable pédagogique Sudoku."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f2cc6205",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.332647Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.332384Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.435323Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.435017Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Donnee int[,] -> modele jagged : resolution en 51 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Solution (indices 2D, modele jagged) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 5 3 4 | 6 7 8 | 9 1 2 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 6 7 2 | 1 9 5 | 3 4 8 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 1 9 8 | 3 4 2 | 5 6 7 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 8 5 9 | 7 6 1 | 4 2 3 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 4 2 6 | 8 5 3 | 7 9 1 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 7 1 3 | 9 2 4 | 8 5 6 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 9 6 1 | 5 3 7 | 2 8 4 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 2 8 7 | 4 1 9 | 6 3 5 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| 3 4 5 | 2 8 6 | 1 7 9 | \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Barreau 4 : ce que la branche porte deja — la donnee 2D convertie vers le modele jagged\n",
+    "int[,] clues2D = new int[9, 9];\n",
+    "for (int i = 0; i < 9; i++)\n",
+    "    for (int j = 0; j < 9; j++)\n",
+    "        clues2D[i, j] = WIKI_PUZZLE[i * 9 + j];\n",
+    "\n",
+    "var sw4 = Stopwatch.StartNew();\n",
+    "var ctx4 = new Z3Context();\n",
+    "var th4 = BuildGridTheorem(ctx4);\n",
+    "for (int i = 0; i < 9; i++)\n",
+    "    for (int j = 0; j < 9; j++)\n",
+    "    {\n",
+    "        if (clues2D[i, j] != 0)\n",
+    "        {\n",
+    "            var (r, c) = (i, j); var v = clues2D[i, j];\n",
+    "            th4 = th4.Where(g => g.Cells[r][c] == v);\n",
+    "        }\n",
+    "    }\n",
+    "var sol4 = th4.Solve();\n",
+    "sw4.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Donnee int[,] -> modele jagged : resolution en {sw4.ElapsedMilliseconds} ms\");\n",
+    "DisplayNested(sol4.Cells, \"Solution (indices 2D, modele jagged)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08f36936",
+   "metadata": {},
+   "source": [
+    "### Interprétation 6 — la donnée 2D existe déjà, c'est le modèle qui attend son rung\n",
+    "\n",
+    "Le pont pratiqué aujourd'hui : déclarer les indices en `int[,]` (la forme naturelle d'une grille de données — celle du notebook 05 de la série SMT, celle de l'exercice Z3 de Sudoku-13), puis les verser dans le modèle jagged. La conversion coûte une double boucle de lecture ; le théorème, lui, reste du barreau 3.\n",
+    "\n",
+    "Quand le rung 4 existera dans le fork, cette cellule perdra sa boucle de conversion et la classe `SudokuGrid` déclarera `int[,] Cells` — même moteur, même solveur, un nœud d'expression de plus routé. L'échelle est ouverte vers le haut."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41b5889d",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a96e3b5e",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — 16x16 : mesurer la marche du rung 1\n",
+    "\n",
+    "**Objectif :** un Sudoku 16x16 (valeurs 1 à 16, blocs 4x4) sur le rung de votre choix. Estimez d'abord **sur papier** ce que coûterait le rung 1 : combien de propriétés, combien de contraintes d'unité explicites ? Puis implémentez-le sur un rung indicé (barreau 2 ou 3) et comparez votre estimation au code réellement écrit.\n",
+    "\n",
+    "**Indice :** réutilisez `BuildGridTheorem` en paramétrant la taille (9 -> 16, blocs 3 -> 4)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "30ec6112",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.436676Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.436506Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.461391Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.461070Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Sudoku 16x16 — le rung 1 exigerait 256 proprietes ; combien de lignes avec le votre ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : Sudoku 16x16 sur un rung indicie\n",
+    "// TODO etudiant : generaliser BuildGridTheorem a une taille N (N=16, blocs de 4)\n",
+    "// puis construire le theoreme et poser quelques indices avant de resoudre.\n",
+    "// Etape 1 : ecrire Theorem<TGrid> BuildGridTheoremN<TGrid>(Z3Context ctx, int n) ou equivalent\n",
+    "// Etape 2 : poser 4 a 6 indices valides d'un 16x16\n",
+    "// Etape 3 : resoudre et afficher\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : Sudoku 16x16 — le rung 1 exigerait 256 proprietes ; combien de lignes avec le votre ?\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08a62322",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Constants vs Array : mesurer l'écart sur trois puzzles\n",
+    "\n",
+    "**Objectif :** chronométrer les deux modes (`CollectionHandling.Constants` et `.Array`) sur trois puzzles de difficultés différentes (le témoin ci-dessus, une grille presque vide, une grille presque pleine), et rapporter les temps dans un tableau. Formulez une hypothèse : lequel des deux régimes favorise quel mode ?\n",
+    "\n",
+    "**Indice :** pour générer les grilles, retirez aléatoirement des indices du puzzle témoin (grille presque vide) ou partez de la solution et retirez-en peu (grille presque pleine)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c75deb57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.462879Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.462628Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.486150Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.485836Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : 6 mesures a rapporter (3 grilles x 2 modes).\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : Constants vs Array sur trois puzzles\n",
+    "// TODO etudiant : construire les trois grilles, resoudre chacune dans les deux modes, chronometrer.\n",
+    "// Etape 1 : grille presque vide (<= 10 indices) et grille presque pleine (>= 50 indices)\n",
+    "// Etape 2 : pour chaque grille : BuildArrayTheorem + indices, dans un contexte Constants puis dans un contexte Array\n",
+    "// Etape 3 : rapporter les 6 temps dans un tableau + une phrase d'interpretation\n",
+    "\n",
+    "var mesuresExercice2 = new List<string>();  // TODO etudiant : remplir (\"grille x mode : y ms\")\n",
+    "Console.WriteLine(\"Exercice a completer : 6 mesures a rapporter (3 grilles x 2 modes).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03d5538b",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — prédire la forme du nœud, puis vérifier\n",
+    "\n",
+    "**Objectif :** sans l'exécuter, prédire ce qu'affiche `Expression<Func<int[,,], int>> c = a => a[1, 2, 3];` (tableau tridimensionnel) : quel `NodeType`, quelle forme de corps ? Notez votre prédiction, puis vérifiez.\n",
+    "\n",
+    "**Indice :** généralisez la lecture de la section 4 — que fait le compilateur quand il y a plus de deux indices ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "416ab323",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.487409Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.487247Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.508331Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.508188Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : ecrire la prediction, puis decommenter les deux lignes pour verifier.\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : le nœud du tableau 3D\n",
+    "// TODO etudiant : noter la prediction ici (en commentaire), puis decommenter et executer.\n",
+    "// Prediction : ...\n",
+    "// Expression<Func<int[,,], int>> cubeAccess = a => a[1, 2, 3];\n",
+    "// Console.WriteLine(cubeAccess.Body.NodeType + \"  |  \" + cubeAccess.Body);\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : ecrire la prediction, puis decommenter les deux lignes pour verifier.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77a21abc",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 — Sudoku-X : étendre le théorème jagged\n",
+    "\n",
+    "**Objectif :** le Sudoku-X ajoute deux contraintes d'unité : les deux diagonales principales doivent aussi contenir 1 à 9. Étendez `BuildGridTheorem` en `BuildGridTheoremX` (une dizaine de lignes) et résolvez le puzzle témoin — le Sudoku-X a-t-il encore une solution avec ces indices ?\n",
+    "\n",
+    "**Indice :** diagonale principale `g.Cells[k][k]`, anti-diagonale `g.Cells[k][8 - k]` — deux `Z3Methods.Distinct` de plus. La réponse à la question finale n'est pas « oui » ; vérifiez ce que renvoie `Solve()` quand le problème devient insatisfiable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "248073bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:20:34.509598Z",
+     "iopub.status.busy": "2026-09-06T22:20:34.509439Z",
+     "iopub.status.idle": "2026-09-06T22:20:34.533250Z",
+     "shell.execute_reply": "2026-09-06T22:20:34.533088Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : etendre le theoreme aux diagonales et tester la satisfiabilite.\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE : Sudoku-X sur le modele jagged\n",
+    "// TODO etudiant : reprendre BuildGridTheorem et ajouter les deux unites diagonales.\n",
+    "// Etape 1 : BuildGridTheoremX (copie + deux Distinct)\n",
+    "// Etape 2 : poser les indices du puzzle temoin et resoudre\n",
+    "// Etape 3 : si Solve() renvoie null, expliquer pourquoi dans un Console.WriteLine\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : etendre le theoreme aux diagonales et tester la satisfiabilite.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e726bb29",
+   "metadata": {},
+   "source": [
+    "## Conclusion — ce que raconte l'échelle\n",
+    "\n",
+    "Les quatre barreaux ne changent **ni le solveur, ni le problème** : c'est le Z3 de Sudoku-12 à chaque marche, sur le même puzzle témoin, avec trois solutions identiques vérifiées en sortie. Ce qui change de rung en rung, c'est le **coût d'expression du modèle** :\n",
+    "\n",
+    "| Rung | Classe modèle (9x9) | Contraintes écrites | Forme compilée |\n",
+    "|---|---|---|---|\n",
+    "| 1 — propriétés | 220 lignes, 81 propriétés | réflexion + 27 `Distinct` explicites | nœuds `Member` |\n",
+    "| 2 — collections | 4 lignes, `List<int>` | boucles + closures | `Call get_Item` / constantes plates ou `Store`/`Select` |\n",
+    "| 3 — jagged | 4 lignes, `int[][]` | boucles, indices à deux dimensions | `ArrayIndex` imbriqués |\n",
+    "| 4 — `int[,]` | — | — | appel `Get(i, j)` exhibé en section 4, non routé à ce jour |\n",
+    "\n",
+    "La leçon transférable dépasse le binding : **une API déclarative gagne ses marches une forme d'expression à la fois**. Chaque rung de `Z3.Linq` est un type de nœud que le *visitor* a appris à compiler vers SMT — et le rung manquant se diagnostique exactement ainsi : exhiber le nœud, montrer qu'aucun routage ne le prend.\n",
+    "\n",
+    "**Pour aller plus loin :** la série [`SymbolicAI/SMT/Z3-Linq2Z3/`](../SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb) — en particulier [02 : Théorème vs Arrays](../SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb) (les deux stratégies de modélisation), [03 : comparaison des modes](../SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb) et [05 : tableaux imbriqués et grilles 2D](../SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb) (l'encodage `Store`/`Select` imbriqué côté Z3 brut)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "064a1f5e",
+   "metadata": {},
+   "source": [
+    "### Provenance et ancrages\n",
+    "\n",
+    "- **Articles fondateurs** (Bart De Smet, 2009, conservés sur archive.org, re-déposés dans le fork sous `docs/blogs/`) : *Exploring the Z3 Theorem Prover* (15 avril 2009) · *LINQ to the Unexpected* (19 avril 2009) · *Theorem Solving on Steroids* (27 septembre 2009).\n",
+    "- **Binding** : fork [`MyIntelligenceAgency/Z3.Linq`](https://github.com/MyIntelligenceAgency/Z3.Linq) (fork de `endjin/Z3.Linq`), sous-module `SymbolicAI/SMT/Z3.Linq`, pointeur `20984bf` — les exécutions de ce notebook utilisent son dossier `.deploy/` préassemblé.\n",
+    "- **Artefacts cités** : `solutions/Z3.Linq.Examples/Sudoku/SudokuTable.cs` (rung 1, 81 propriétés) · `SudokuTheorem.cs` (contraintes par réflexion `\"Cell{0}{1}\"`) · `SudokuGrid.cs` + `SudokuGridTheorem.cs` (rung 3) · `ListCollectionTests.cs` (alignement des deux front-ends d'indexation).\n",
+    "- **Commits et branches** : `096a638` « feat: add nested int[][] array support » (rung 3) · branche `feature/list-collection-constants-mode` (rung 2).\n",
+    "- **Références** : épic #1206 (piste Z3.Linq) · #14169 (posture de fork amont) · #6300 (nomenclature Z3-Linq-primary) · #5081 (convention d'accrétion Sudoku : la lettre colle au numéro).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "[Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb) | [Index](README.md) | [Sudoku-13 Automates symboliques >>](Sudoku-13-SymbolicAutomata-Csharp.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb
@@ -85,7 +85,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -95,10 +94,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -113,7 +109,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -125,8 +120,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -175,13 +168,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -329,7 +320,7 @@
     "2. *LINQ to the Unexpected* — l'idée du binding : un « esoteric LINQ binding » où `Where` ne filtre pas une collection mais **contraint un théorème** ;\n",
     "3. *Theorem Solving on Steroids* — le type `Theorem<T>` et le pattern de requête.\n",
     "\n",
-    "Le Sudoku d'origine du binding est [`SudokuTable.cs`](../SymbolicAI/SMT/Z3.Linq/solutions/Z3.Linq.Examples/Sudoku/SudokuTable.cs) : **une classe où chaque cellule est une propriété typée distincte** — `Cell11`, `Cell12`, … `Cell99`, soit 81 propriétés `int`. Le théorème se construit avec une contrainte `.Where(...)` par propriété, et `Z3Methods.Distinct(...)` porte l'unicité.\n",
+    "Le Sudoku d'origine du binding est [`SudokuTable.cs`](https://github.com/MyIntelligenceAgency/Z3.Linq/blob/20984bf/solutions/Z3.Linq.Examples/Sudoku/SudokuTable.cs) : **une classe où chaque cellule est une propriété typée distincte** — `Cell11`, `Cell12`, … `Cell99`, soit 81 propriétés `int`. Le théorème se construit avec une contrainte `.Where(...)` par propriété, et `Z3Methods.Distinct(...)` porte l'unicité.\n",
     "\n",
     "Pour toucher ce rung du doigt sans recopier 220 lignes, voici sa déclinaison fidèle sur un **Sudoku 4x4** (16 propriétés, valeurs 1 à 4, blocs 2x2) :"
    ]
@@ -1000,7 +991,7 @@
    "source": [
     "## 3. Barreau 3 — les tableaux imbriqués `int[][]` (commit `096a638`)\n",
     "\n",
-    "Troisième marche, portée par le commit **`096a638`** (« feat: add nested int[][] array support », branche `feature/list-collection-constants-mode`) : le modèle peut désormais être un **tableau de tableaux**. Les artefacts sont [`SudokuGrid.cs`](../SymbolicAI/SMT/Z3.Linq/solutions/Z3.Linq.Examples/Sudoku/SudokuGrid.cs) et [`SudokuGridTheorem.cs`](../SymbolicAI/SMT/Z3.Linq/solutions/Z3.Linq.Examples/Sudoku/SudokuGridTheorem.cs) :\n",
+    "Troisième marche, portée par le commit **`096a638`** (« feat: add nested int[][] array support », branche `feature/list-collection-constants-mode`) : le modèle peut désormais être un **tableau de tableaux**. Les artefacts sont [`SudokuGrid.cs`](https://github.com/MyIntelligenceAgency/Z3.Linq/blob/20984bf/solutions/Z3.Linq.Examples/Sudoku/SudokuGrid.cs) et [`SudokuGridTheorem.cs`](https://github.com/MyIntelligenceAgency/Z3.Linq/blob/20984bf/solutions/Z3.Linq.Examples/Sudoku/SudokuGridTheorem.cs) :\n",
     "\n",
     "```csharp\n",
     "public class SudokuGrid\n",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA — prev: MED/tooling #14954

Closes #14957

## Summary

Notebook d'accrétion `Sudoku-12b-Z3-Linq2Z3-Csharp.ipynb` (37 cellules, 15 code, kernel `.net-csharp`) : le pont côté série Sudoku pour le binding **Linq2Z3 / Z3.Linq**, en échelle historique à la Sudoku-13 (barreaux + cellules `### Interprétation` **après** chaque cellule dont la sortie porte la valeur citée). Le parent pédagogique est nommé dans la vue d'ensemble : le binding approfondit le palier Z3 de Sudoku-12 (même moteur, couche d'expression plus riche), convention d'accrétion #5081 (base = `a`, première accrétion = `b`).

## Les 4 barreaux (acceptance 1 du corps de l'issue)

| Barreau | Contenu exécuté | Ancrage |
|---|---|---|
| 1 — propriétés | `SudokuTable4` 4x4 fidèle (16 propriétés `{ get; private set; }`), contraintes de bornes **par réflexion sur noms** (`Between1And4`, la technique de `SudokuTheorem.cs`), 12 `Distinct` explicites, indices aux coins, résolution | `SudokuTable.cs` + série 3 articles Bart De Smet 2009 (`docs/blogs/` du fork) |
| 2 — collections indicées | `List<int>` 81 + boucles/closures, **args explicites** pour `Z3Methods.Distinct` (la forme que `CollectionHandlingTests` épingle pour les deux modes), résolu en mode `Constants` **puis** mode `Array`, solutions identiques | branche `feature/list-collection-constants-mode` (notre port) |
| 3 — jagged `int[][]` | `SudokuGrid` + théorème forme `SudokuGridTheorem.cs` (`g.Cells[r][c]`), même puzzle, même solution | commit `096a638` |
| 4 — `int[,]` attesté | **confrontation en direct** : `a[1][2]` → `ArrayIndex`, `l[1]` → `Call get_Item`, `g[1,2]` → **`Call g.Get(1, 2)`** — la forme que le visitor ne route pas. Puis le pont que la branche porte : indices déclarés `int[,]`, convertis vers le modèle jagged, résolus | scan exhaustif des 30 refs distantes du fork (motif `int[,]` absent de tout `.cs` du binding au 2026-09-06) — le rung est livré en « ce qui manque / ce que la branche porte », comme le gate le prévoit |

Les 3 solutions (rungs 1-4 confondus) sont vérifiées **identiques en sortie** (`SequenceEqual` ×2 imprimé).

## Exécution réelle (H.1)

`jupyter nbconvert --execute --inplace` kernel `.net-csharp`, timeout 900 s :

- **15/15 cellules code : `execution_count` 1..15, 0 erreur, 0 output d'erreur**
- Temps mesurés : 4x4 propriétés 145 ms · Constants 72 ms · Array 43 ms · jagged 47 ms · pont 2D 51 ms
- `nbformat.validate` : VALID
- Scan path-leak (`C:\Users`, `AppData`, `D:\Dev`, `D:/Dev`) : **clean** ; bannière probe kernel .NET (9 lignes) strippée via `strip_probe_banner.py --apply` (exception documentée) ; sorties normalisées LF (0 CR, convention de la série — Sudoku-13 : 0 CR)
- `validate_pr_notebooks.py origin/main` : **1/1 PASS**
- `check_notebook_navlinks.py` : **0 lien cassé**
- `Z3.Linq v1.0.0.0` / `Microsoft.Z3 v4.12.2.0` imprimés en tête (assemblées chargées du `.deploy/` **committé** du sous-module au pointeur enregistré `20984bf` — aucun build local requis)

## C.1 / exercices (acceptance 2)

4 exercices stubs, aucun `raise NotImplementedError` / `assert False` / `1/0` (grep = 0) : 16x16 (mesure de la marche du rung 1), Constants vs Array sur 3 puzzles, prédiction du nœud `int[,,]`, Sudoku-X diagonal. Le notebook s'exécute de bout en bout exercices non complétés.

## Périmètre honnête (acceptance 5)

- **C#-only** : aucune jumelle Python créée, **aucune entrée `twin_pairs.d`** (le binding est .NET — pas d'attente de paire).
- Sudoku-12 **intact** (aucun retrait) ; Sudoku-13 non touché.
- **Catalogue intouché** : `git show --stat` = 2 fichiers (notebook + README série).
- Rung 2D : l'intention est documentée comme intention — le notebook **atteste** (scan + nœud exhibé) sans combler ; l'implémentation serait une PR du fork Z3.Linq.

## Provenance (acceptance 4)

3 articles Bart De Smet (15/04/2009, 19/04/2009, 27/09/2009 — archive.org, re-déposés `docs/blogs/` du fork) · fork `MyIntelligenceAgency/Z3.Linq` (fork de `endjin/Z3.Linq`) · artefacts `SudokuTable.cs` / `SudokuTheorem.cs` / `SudokuGrid.cs` / `SudokuGridTheorem.cs` / `ListCollectionTests.cs` · commit `096a638` · épic #1206 · #14169 · #6300 · #5081 · liens croisés vers la série SMT (01/02/03/05).

## Test plan

- [x] Exécution end-to-end 15/15, 0 erreur (sorties committées)
- [x] Solutions identiques entre rungs vérifiées en sortie
- [x] nbformat VALID, path-leak clean, navlinks 0 cassé
- [x] C.1 grep = 0 ; 4 exercices stubs
- [x] README série : ligne tableau 12b + entrée arbre
