### PR TITLE
feat(aspire,#10473): enrichissement call-site {Here} dans 03-Observabilite -- section 1bis

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/03-Aspire-Observabilite.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/Aspire/03-Aspire-Observabilite.ipynb
@@ -169,6 +169,97 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1bis. L'origine de l'appel : l'enrichissement call-site `{Here}`\n",
+    "\n",
+    "`Enrich.WithProperty` pose un champ **fixe**. L'étape suivante du log structuré\n",
+    "est de capturer **d'où** la ligne a été émise — méthode, fichier, numéro de\n",
+    "ligne — sans le passer à la main à chaque appel. C# le fait à la compilation\n",
+    "avec les *caller-info attributes* (`[CallerMemberName]`, `[CallerFilePath]`,\n",
+    "`[CallerLineNumber]`) : des paramètres optionnels laissés vides à l'appel,\n",
+    "remplis par le compilateur avec le site exact de l'invocation. La fonction\n",
+    "`Here()` ci-dessous les récupère et les attache par `ForContext` ; deux voies\n",
+    "de rendu suivent : le champ `Here` comme **champ structuré** du JSON compact\n",
+    "(indexable comme `Utilisateur`), et le placeholder `({Here})` dans un\n",
+    "`outputTemplate` de console. Source : *The Unexpected AI Stack* Part 5\n",
+    "(chrlschn.dev), qui la justifie pour les **agents** — un diagnostic lu par un\n",
+    "agent obtient la ligne de vue directe vers l'origine du problème dans la source.\n",
+    "\n",
+    "Deux constats honnêtes sur la sortie : `MemberName` et `LineNumber` sont\n",
+    "capturés (`:TraiterRequete@23` — le numéro est celui de la ligne dans la\n",
+    "cellule), mais `FilePath` est **vide** : une cellule de kernel n'a pas de\n",
+    "fichier source .cs sous-jacent ; en programme complet, le rendu serait\n",
+    "`Health.cs:HandleAsync@26` comme dans l'article. C'est aussi le pont vers la\n",
+    "section 3 : les *tags* call-site d'`Activity` y démontrent le même principe\n",
+    "côté traces.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-06T22:46:02.036409Z",
+     "iopub.status.busy": "2026-09-06T22:46:02.036132Z",
+     "iopub.status.idle": "2026-09-06T22:46:02.195919Z",
+     "shell.execute_reply": "2026-09-06T22:46:02.195761Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"@t\":\"2026-09-06T22:46:02.1854780Z\",\"@mt\":\"requete traitee {Utilisateur}\",\"@tr\":\"5f4f395eaad9e73195618bcf0d74209d\",\"@sp\":\"1b3fa0f71bb63026\",\"Utilisateur\":\"etudiant-42\",\"LineNumber\":23,\"FilePath\":\"\",\"MemberName\":\"TraiterRequete\",\"Here\":\":TraiterRequete@23\",\"app\":\"aspire03-demo\"}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[00:46:02.188 INF] verification sante demandee (:VerifierSante@32)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// L'enrichissement {Here} : caller-info attributes + ForContext (Part 5 chrlschn.dev).\n",
+    "// Contrainte kernel : une methode d'extension exige une classe statique de niveau\n",
+    "// top, qu'une cellule ne peut pas declarer (CS1109) -- en programme complet, Here()\n",
+    "// vivrait dans un LoggerExtensions.cs comme `public static ILogger Here(this ILogger ...)`.\n",
+    "// Ici : fonction locale ordinaire, meme signature moins le `this`.\n",
+    "using System.Runtime.CompilerServices;\n",
+    "\n",
+    "ILogger Here(ILogger logger,\n",
+    "    [CallerMemberName] string memberName = \"\",\n",
+    "    [CallerFilePath] string sourceFilePath = \"\",\n",
+    "    [CallerLineNumber] int sourceLineNumber = 0)\n",
+    "{\n",
+    "    var srcFile = Path.GetFileName(sourceFilePath);\n",
+    "    return logger\n",
+    "        .ForContext(\"Here\", $\"{srcFile}:{memberName}@{sourceLineNumber}\")\n",
+    "        .ForContext(\"MemberName\", memberName)\n",
+    "        .ForContext(\"FilePath\", sourceFilePath)\n",
+    "        .ForContext(\"LineNumber\", sourceLineNumber);\n",
+    "}\n",
+    "\n",
+    "// Voie 1 : le logger JSON compact de la cellule precedente -- {Here} devient un CHAMP.\n",
+    "void TraiterRequete(string utilisateur)\n",
+    "    => Here(log).Information(\"requete traitee {Utilisateur}\", utilisateur);\n",
+    "TraiterRequete(\"etudiant-42\");\n",
+    "\n",
+    "// Voie 2 : le rendu template -- {Here} dans l'outputTemplate, comme dans l'article.\n",
+    "var logTemplate = new LoggerConfiguration()\n",
+    "    .Enrich.WithProperty(\"app\", \"aspire03-demo\")\n",
+    "    .WriteTo.Console(outputTemplate:\n",
+    "        \"[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj} ({Here}){NewLine}{Exception}\")\n",
+    "    .CreateLogger();\n",
+    "void VerifierSante() => Here(logTemplate).Information(\"verification sante demandee\");\n",
+    "VerifierSante();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "asp03obs05",
    "metadata": {},
    "source": [
@@ -191,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "asp03obs06",
    "metadata": {
     "execution": {
@@ -471,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "asp03obs09",
    "metadata": {
     "execution": {
@@ -649,7 +740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "asp03obs12",
    "metadata": {
     "execution": {
@@ -1050,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "asp03obs22",
    "metadata": {
     "execution": {
@@ -1107,7 +1198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "asp03obs24",
    "metadata": {
     "execution": {
@@ -1157,7 +1248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "asp03obs26",
    "metadata": {
     "execution": {
@@ -1217,7 +1308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "asp03obs-t2-dashboard",
    "metadata": {},
    "outputs": [
@@ -1296,7 +1387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "asp03obs-t2-host",
    "metadata": {},
    "outputs": [
@@ -1423,7 +1514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "asp03obs-t2-relit",
    "metadata": {},
    "outputs": [
@@ -1639,7 +1730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "asp03obs-t2-stop",
    "metadata": {},
    "outputs": [
@@ -1695,7 +1786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "asp03obs16",
    "metadata": {
     "execution": {
@@ -1736,7 +1827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "asp03obs18",
    "metadata": {
     "execution": {
@@ -1777,7 +1868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "asp03obs20",
    "metadata": {
     "execution": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/lean #14965

## Summary

Enrichissement de `03-Aspire-Observabilite.ipynb` §1 : nouvelle section **1bis — L'origine de l'appel : l'enrichissement call-site `{Here}`**, dernier résidu non couvert de la distillation Part 5 (veille #10475, vérifié firsthand ce cycle : la relecture CLI `aspire otel spans --search` était déjà couverte en cellule 24 ; seul `{Here}` manquait).

Contenu ajouté (1 markdown + 1 cellule code exécutée) :

- la fonction `Here()` capture l'origine de l'appel via les *caller-info attributes* (`[CallerMemberName]`, `[CallerFilePath]`, `[CallerLineNumber]` — injectés par le compilateur au site d'invocation) et l'attache par `ForContext` ;
- deux voies de rendu démontrées : le champ `Here` comme **champ structuré** du JSON compact, et le placeholder `({Here})` dans un `outputTemplate` console — exactement la démonstration de *The Unexpected AI Stack* Part 5 (chrlschn.dev), justifiée par l'auteur pour les **agents** (« direct line of sight to the source origins at runtime ») ;
- contrainte kernel documentée dans le code : une méthode d'extension exige une classe statique de niveau top (CS1109 constaté en exécution) → fonction locale ordinaire, même signature moins le `this` ;
- honnêteté de la sortie : `MemberName` et `LineNumber` capturés (`:TraiterRequete@23`, `:VerifierSante@32` — numéro = ligne dans la cellule), `FilePath` **vide** car une cellule de kernel n'a pas de fichier .cs sous-jacent — documenté dans la prose (en programme complet : `Health.cs:HandleAsync@26`).

## Validation (D.4 — preuves d'exécution réelle)

1. **Exécution papermill** kernel `.net-csharp` (scratch : nuget pins §1 + logger + nouvelle cellule) — SUCCESS. Sorties réelles transplantées :
   - `{"@t":"2026-09-06T22:46:02.18Z","@mt":"requete traitee {Utilisateur}",...,"LineNumber":23,"FilePath":"","MemberName":"TraiterRequete","Here":":TraiterRequete@23","app":"aspire03-demo"}`
   - `[00:46:02.188 INF] verification sante demandee (:VerifierSante@32)`
2. **Séquence d'exécution** — `check_exec_sequence.py` : CLEAN (UNORDERED=0, GAP=0, NOT_FROM_1=0). L'insertion en §1 a nécessité le **renumbering transplant** (permutation pure des `execution_count` 1..16 en ordre fichier — sources et outputs byte-identiques, les −13 lignes du diff sont ces labels uniquement). Scratch exécuté SANS metadata papermill (strippée au transplant).
3. **C.1** — aucun `raise`/`assert False`/`1/0` ; C.2 — cellule committée avec `execution_count: 3` et ses 2 sorties réelles ; cellules non modifiées : outputs inchangés (C.3).
4. **Scan chemins machine** dans les outputs : aucun (`FilePath` vide par construction kernel).

## Provenance

- Source : *The Unexpected AI Stack: C# + .NET — Part 5* (chrlschn.dev, 2026-08-17), axe Serilog `{Here}` — la citation « direct line of sight… » et le pattern `ForContext` sont de l'article.
- Écart assumé et documenté : l'article utilise une méthode d'extension dans `LoggerExtensions.cs` ; la cellule utilise une fonction locale (contrainte CS1109 du kernel, commentée dans le code).

See #10473 (contribution partielle — l'EPIC vit tant que la série publie) · refs #10475 (résidu P5 soldé : CLI déjà couverte, `{Here}` livré ici)

