### PR TITLE
enrich(qc,#11601): QC-Py-41-PaperTrading-IBKR — densité 1417 → 1598 c/cell (markdown-only, round 2)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
@@ -539,7 +539,7 @@
     "\n",
     "### Lecture de l'algorithme LEAN\n",
     "\n",
-    "Le listing (3 529 caracteres) suit la structure canonique LEAN : `initialize()` definit l'univers (top 50 SP500, classe par rendement 12 mois), le calendrier de rebalancement mensuel equal-weight et le warm-up ; le handler de donnees ne fait que mettre a jour les scores — toute la decision vit dans le rebalancement programme. Pour le paper IBKR, **rien ne change dans le code** : c'est la configuration de deploiement (section 4) qui bascule le meme algorithme du node backtest vers le compte paper TWS. Un seul implementation, trois modes d'execution — c'est le point structurel du workflow QC."
+    "Le listing (4 209 caracteres) suit la structure canonique LEAN : `initialize()` definit l'univers (top 50 SP500, classe par rendement 12 mois), le calendrier de rebalancement mensuel equal-weight et le warm-up ; le handler de donnees ne fait que mettre a jour les scores — toute la decision vit dans le rebalancement programme. Pour le paper IBKR, **rien ne change dans le code** : c'est la configuration de deploiement (section 4) qui bascule le meme algorithme du node backtest vers le compte paper TWS. Un seul implementation, trois modes d'execution — c'est le point structurel du workflow QC."
    ]
   },
   {
@@ -1257,6 +1257,12 @@
     "print(\"Indice: volatilite annualisee = std(daily_returns) * sqrt(252)\")\n",
     "print(f\"Config actuelle: {vol_config}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68afdd0e",
+   "source": "### Lecture du guide : le filtre de volatilite en pratique\n\nLe coeur de l'exercice tient dans la signature `apply_vol_filter(momentum_scores, spy_vol, config)`. C'est une fonction **pure** : elle recoit les scores momentum (`{symbol: return}`), une volatilite realisee du SP500 et le config, et retourne un dict filtre — pas de broker, pas d'etat, pas de side-effect. Cette forme n'est pas anodine : elle rend le filtre testable sans deployement (on peut appeler `apply_vol_filter({...}, 0.42, {...})` et verifier que le portefeuille se reduit), et c'est elle qui rend possible la comparaison honnete qu'annonce l'introduction de la section — meme signal, meme periode, avec et sans filtre.\n\nDeux parametres sont laisses a l'exercice (`vol_threshold`, `reduction_factor`) parce que ce sont les deux degres de liberte du filtre. `vol_period=20` fige la fenetre de volatilite realisee ; `vol_threshold` fixe le declencheur (0.30 = 30% annualisee, l'ordre de grandeur d'un marche en tension) ; `reduction_factor` dimensionne le retrait (0.5 = moitie des positions, en gardant les meilleurs scores). L'indice `vol = std(returns daily) * sqrt(252)` est la convention d'annualisation : 0.015 de volatilite quotidienne ≈ 23.8% annualisee — le passage de l'echelle journaliere a l'echelle annuelle se fait par une multiplication par la racine du nombre de jours de trading.\n\nLe point pedagogique : un filtre de volatilite **ne change pas le signal momentum, il redimensionne l'exposition**. Quand `spy_vol > vol_threshold`, on ne corrige pas la selection, on reduit le nombre de positions ; quand `spy_vol <= vol_threshold`, on ne touche a rien. C'est exactement ce qui permet de repondre a la question 3 des questions de reflexion ci-dessous : le filtre ameliore le ratio de Sharpe **si et seulement si** le gain sur la queue (moins de pertes extremes) depasse la perte de participation (moins de hausse quand la vol est haute sans que le marche s'ecroule). C'est une question **empirique** que les trois parametres optimises trancheront sur la periode mesuree — rappelons le MaxDD mesure de la section 3 (28.1%, la pire queue de la fenetre 2018-2024), point exact que le filtre vise a amputer — pas une garantie a priori : l'equity curve avec et sans filtre, sur la meme fenetre, est le juge, et l'artefact JSON cote du notebook contient les series pour le refaire.",
+   "metadata": {}
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2026:CoursIA-2 — prev: MED/training #14948

# enrich(notebooks,#11601): QC-Py-41-PaperTrading-IBKR — densité 1417 → 1598 c/cell (markdown-only, round 2)

## Objet

Complète le round-2 de densité (#11601, seuil ≥1500 c/cell) sur le notebook `QC-Py-41-PaperTrading-IBKR`, resté à **1417 c/cell** après le round-1 (#11228, 608→1415). Enrichissement **markdown-only** (exception C.2 — aucune re-exécution nécessaire) : les **13 cellules code sont byte-identiques à `main`** (vérifié), aucun output ni `execution_count` modifié.

## Ce qui a été ajouté

1. **Une cellule `### Lecture du guide : le filtre de volatilite en pratique`** (id `68afdd0e`), insérée entre l'exemple guide `apply_vol_filter` (section 7) et les questions de réflexion. Elle interprète :
   - la **fonction pure** — sa forme rend le filtre testable sans déploiement (`apply_vol_filter({...}, 0.42, {...})`) et permet la comparaison honnête avec/sans filtre sur la même fenêtre ;
   - le **paramétrage** `vol_period`/`vol_threshold`/`reduction_factor`, avec la convention d'annualisation `std(daily) * sqrt(252)` (0.015 → ≈23.8 %) ;
   - le point pédagogique : le filtre **redimensionne l'exposition, ne change pas le signal** — et se juge empiriquement contre le **MaxDD mesuré 28.1 %** (section 3), pas par garantie a priori.
2. **Correction doc-honesté (C.4)** : le compteur de caractères du listing LEAN passait de « 3 529 » (obsolète, antérieur à #14616) à **« 4 209 »** (valeur réellement affichée par la cellule code) — un drift de prose laissé par la reprise du backtest réel QC Cloud.

## Résolution d'un run `consecutive-code-cells`

Ce notebook portait **un** run de cellules code consécutives (l'exemple guide `apply_vol_filter` suivi de `# Question de reflexion`, aucune cellule markdown entre elles). La cellule `### Lecture du guide` insérée est la résolution prévue par #12797. `detect_consecutive_code_cells` passe de **1 run ≥ 2 à 0**.

## Validation (mesurée après le dernier commit)

| Check | Résultat |
|---|---|
| Densité `pedagogy_density --json` | **1598 c/cell** (seuil round-2 ≥1500 atteint), md_pct 60.7 % |
| Cellules code byte-identiques vs `origin/main` | **13/13 identiques** |
| `detect_consecutive_code_cells` | **0 run ≥ 2** (était 1) |
| `check_interp_positioning` | **0 finding** |
| `check_notebook_navlinks` | **0 lien cassé** |
| `detect_markdown_rendering` | **0 violation** |
| Pre-commit H.3 / gitleaks / #13326 | **Passed** (sortie du commit `b72e9033b0`) |

## Référence

`See #11601` (Epic densité — contribution partielle, l'Epic reste ouverte). Ne clôt pas l'issue.

## Note (pré-existante, hors scope de cette PR)

La valeur « 4 209 » est celle affichée par la cellule code ; elle pourrait dériver si l'algorithme LEAN était modifié à nouveau. Signalée ici pour traçabilité, pas corrigée plus avant.
