### PR TITLE
enrich(dswa,#11601): 4.2-ConvNet lectures intermediaires -- densite 1203 -> 1515 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb
@@ -417,6 +417,18 @@
     "plt.show()"
    ]
   },
+ {
+  "cell_type": "markdown",
+  "id": "e6a6-lecture-figure",
+  "metadata": {},
+  "source": [
+   "**Lecture de la figure — pourquoi une droite.** En échelle logarithmique, une droite ne signifie pas une décroissance en ligne droite : elle signifie que chaque bloc multiplie la norme du gradient par un **facteur à peu près constant** (ici ~0,4, lu comme la pente de la droite). Vingt blocs, vingt multiplications : 0,4²⁰ ≈ 1e-08 — c'est l'annotation posée sur la courbe, calculée depuis les données tracées elles-mêmes, pas depuis une formule séparée.\n",
+   "\n",
+   "La légère ondulation autour de la droite est réelle et attendue : le facteur par bloc n'est pas exactement constant, il fluctue d'un bloc à l'autre avec les poids initialisés. C'est la régularité *en moyenne* qui fait le dommage — aucun bloc individuel n'est pathologique, c'est leur composition qui l'est.\n",
+   "\n",
+   "Une précaution de lecture : cette figure porte une graine et un lot. Le balayage de profondeurs de la section 5 (même diagnostic, six profondeurs) est ce qui généralise le constat."
+  ]
+ },
   {
    "cell_type": "markdown",
    "id": "e348eb5e",
@@ -978,6 +990,16 @@
     "print(\"  - seule `Transformation` change : conv locale vs attention globale\")"
    ]
   },
+ {
+  "cell_type": "markdown",
+  "id": "e6a1-pont-mesure",
+  "metadata": {},
+  "source": [
+   "**Deux géométries, un diagnostic.** L'impression ci-dessus établit l'isomorphisme *structurel* — même squelette `h + Transformation(Normalisation(h))`, seule la transformation change (conv locale pour la vision, attention globale pour le texte). Ce qui reste à vérifier est que le diagnostic *mesuré* transfère : le gradient au premier pas meurt-il pareillement dans un empilement d'attention nue, et le bloc pré-norme le répare-t-il ?\n",
+   "\n",
+   "La cellule suivante rejoue exactement le protocole de la section 3 — une passe avant/arrière, aucun entraînement — sur deux piles de 20 blocs d'attention (sans et avec pré-norme). Deux quantités sont surveillées simultanément, parce que la section 4 a montré qu'elles peuvent se réparer séparément : `|g|` (le gradient qui atteint le bloc 0) et `|h|` (l'activation qui atteint le bloc 19 — la passe avant qui s'effondre ou explose). Si la pré-norme répare les deux dans le monde attention, l'affirmation « c'est le même bloc » ne relève plus de l'analogie : elle est mesurée des deux côtés."
+  ]
+ },
   {
    "cell_type": "code",
    "execution_count": 11,
@@ -1203,6 +1225,18 @@
     "print(f\"accuracy d'un classifieur au hasard : {1 / len(CLASSES):.1%}\")"
    ]
   },
+ {
+  "cell_type": "markdown",
+  "id": "e6a2-lecture-chargement",
+  "metadata": {},
+  "source": [
+   "**Lecture du chargement.** Chaque ligne de la sortie mérite un arrêt, parce qu'elle conditionne la lecture de tout ce qui suit.\n",
+   "\n",
+   "- **Les formes** — `train : (5000, 3, 32, 32)`, `test : (1000, 3, 32, 32)` — confirment mot pour mot le protocole de la section précédente : 1000 images par classe à l'entraînement, 200 au test. La normalisation par canal (moyenne/écart-type) a été appliquée ; `moyenne_std` la mémorise, et la cellule suivante s'en servira pour la *défaire* au moment d'afficher des images.\n",
+   "- **La répartition `[1000, 1000, 1000, 1000, 1000]`** n'est pas un détail cosmétique : elle fixe la ligne de hasard à exactement **20,0 %**. Avec des classes déséquilibrées, « prédire la classe majoritaire » battrait le hasard uniforme, et toute comparaison à 20 % serait faussée. Ici, 20,0 % est le plancher honnête.\n",
+   "- **La granularité de la mesure** : chaque image de test pèse 0,1 point d'accuracy (1 sur 1000). C'est le pas de quantification de *tous* les chiffres de cette section — raison de plus pour exiger un écart largement supérieur au bruit avant de conclure quoi que ce soit."
+  ]
+ },
   {
    "cell_type": "code",
    "execution_count": 13,
@@ -1248,6 +1282,18 @@
     "plt.show()"
    ]
   },
+ {
+  "cell_type": "markdown",
+  "id": "e6a3-lecture-vignettes",
+  "metadata": {},
+  "source": [
+   "**Lecture de la planche.** Les dix vignettes sont les dix premières images d'entraînement, restituées en couleurs réelles par l'inversion de la normalisation (`X * écart-type + moyenne`, par canal) — les titres sont les étiquettes de vérité, pas des prédictions.\n",
+   "\n",
+   "Ce que la planche montre : à 32×32 pixels, un cerf et un oiseau partagent souvent le même fond ciel, un chat et un cerf se réduisent à des taches brunes — l'information discriminante tient à quelques dizaines de pixels actifs. C'est ce qui rend le sous-ensemble non trivial malgré sa taille. Une honnêteté d'usage : dix images ne sont pas un échantillon statistique, juste un coup d'œil au terrain avant l'expérience.\n",
+   "\n",
+   "**Transition.** Le protocole entre maintenant dans sa phase de mesure : deux architectures (`plain`, `prenorm`) × trois graines, quinze époques chacune. La cellule suivante déroule les six entraînements et imprime l'accuracy finale de chacun — environ deux minutes au total sur CPU, timings détaillés à la clé."
+  ]
+ },
   {
    "cell_type": "code",
    "execution_count": 14,
@@ -1349,6 +1395,18 @@
     "print(f\"\\ntotal : {time.time() - t0:.0f} s\")"
    ]
   },
+ {
+  "cell_type": "markdown",
+  "id": "e6a4-lecture-graines",
+  "metadata": {},
+  "source": [
+   "**Lecture brute, graine par graine — avant tout moyennage.** Le tableau récapitulatif n'existe pas encore : lisons d'abord les six lignes telles qu'elles sont sorties.\n",
+   "\n",
+   "- **`prenorm` gagne chaque affrontement pairwise** : 58,4 > 43,1, 65,1 > 38,9, 62,4 > 20,0. L'effet n'est pas porté par une graine chanceuse — il tient sur les trois tirages indépendants.\n",
+   "- **La ligne `plain graine=2 : 20,0 %`** est celle qui mérite l'œil : exactement le taux du hasard sur cinq classes équilibrées. Cette graine n'est pas partie lentement — elle n'a jamais quitté la ligne de départ. (La lecture complète de cette bimodalité suit après le tableau.)\n",
+   "- **Les temps d'exécution confirment le budget annoncé** : ~1,3 s par époque pour `plain` (19 s / 15 époques), ~1,6–1,7 s pour `prenorm` (24–25 s) — la pré-norme coûte environ 30 % de temps en plus, le prix des normalisations dans chaque branche. Total mesuré : 128 s, cohérent avec l'ordre de grandeur annoncé en section précédente."
+  ]
+ },
   {
    "cell_type": "code",
    "execution_count": 15,
@@ -1403,6 +1461,20 @@
     "print(f\"rapport ecart / bruit : {ecart / bruit:.1f}\" if bruit > 0 else \"bruit nul\")"
    ]
   },
+ {
+  "cell_type": "markdown",
+  "id": "e6a5-pont-courbes",
+  "metadata": {},
+  "source": [
+   "**Du tableau aux trajectoires.** Le tableau condense chaque mode en deux nombres (moyenne ± écart-type sur les graines) plus la meilleure accuracy atteinte — 34,9 % pour `plain`, 63,4 % pour `prenorm`. C'est le format le plus compact pour répondre à la question posée, mais il ne peut pas montrer *comment* on y arrive :\n",
+   "\n",
+   "- à quelle époque la séparation entre les deux modes s'installe-t-elle — dès la première, ou après une phase d'indifférenciation ?\n",
+   "- les graines perdantes de `plain` décroissent-elles, ou stagnent-elles sur la ligne de hasard pendant quinze époques ?\n",
+   "- la bande de `prenorm` reste-t-elle serrée tout au long, ou s'élargit-elle en fin de course ?\n",
+   "\n",
+   "La figure suivante répond aux trois : accuracy de test par époque, moyenne en trait plein, enveloppe min–max des trois graines en aérographié, ligne de hasard à 20 % en repère. La lecture détaillée des chiffres suit la figure."
+  ]
+ },
   {
    "cell_type": "code",
    "execution_count": 16,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/lean #14965

## Summary

Enrichissement pédagogique **markdown-only** de `MyIA.AI.Notebooks/ML/DataScienceWithAgents/04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb` (tranche densité round 2 de l'umbrella #11601). Densité `1203 → 1515` chars/cellule de code (cible round 2 `≥1500`), md% `58.7 → 61.4`. **Aucune cellule code modifiée** (exception C.2 : markdown-only — les 19 cellules code et leurs outputs sont byte-identiques).

**Gap structurel réel avant enrichment** (mesuré, pas supposé) : `detect_consecutive_code_cells` rendait `max=5 runs=2` — un run de 5 cellules code consécutives (section 7 CIFAR-10 : chargement → planche → entraînement → tableau → courbes) et un run de 2 (section 6 : bloc pont → mesure transformer). Après : `Run >= 2: 0`.

**6 cellules markdown ajoutées**, chacune insérée immédiatement après la cellule dont la sortie est citée (D.4bis), valeurs ancrées sur les outputs committés :

1. **§6, avant la mesure transformer** — l'isomorphisme structurel établi (squelette commun `h + Transformation(Normalisation(h))`), ce qui reste à vérifier (le diagnostic *mesuré* transfère-t-il), et le double critère `|g|`/`|h|`.
2. **Lecture du chargement CIFAR-10** — formes vs protocole, répartition équilibrée `[1000×5]` → ligne de hasard honnête à 20,0 %, granularité 0,1 pt/image de test.
3. **Lecture de la planche** — inversion de normalisation pour l'affichage, difficulté 32×32 (cerf/oiseau même fond ciel), honnêteté : dix images ≠ échantillon.
4. **Lecture brute graine par graine** — `prenorm` gagne les trois affrontements pairwise (58,4>43,1 ; 65,1>38,9 ; 62,4>20,0), la graine `plain=20,0 %` jamais partie, timings ~1,3 vs ~1,6–1,7 s/époque (total 128 s).
5. **Pont tableau → trajectoires** — pourquoi des endpoints seuls cachent le *quand* et le *comment* (séparation précoce ?, stagnation vs décroissance, largeur de bande).
6. **Lecture de la figure semilog §3** — pourquoi une droite en log = facteur multiplicatif constant par bloc (0,4²⁰ ≈ 1e-08), l'ondulation réelle autour de la droite, précaution une-graine-un-lot avec renvoi au balayage §5.

## Validation

- **Densité** : `pedagogy_density.py` (instrument canonique #14096) — `1203 → 1515`, status `ok`.
- **Runs** : `detect_consecutive_code_cells.py` — `max=5 runs=2 → Run >= 2: 0`.
- **Interp positioning** : `check_interp_positioning.py` — `findings total : 0`.
- **Rendu markdown** : `detect_code_in_markdown_cells.py` — `0 violation (0 new vs baseline)`. Liens `check_notebook_link_render.py` : 8 BRUT identiques à la base (préexistants, aucune nouveau lien ajouté).
- **Chirurgical** : diff `+72/−0`, 1 fichier — splice textuel, 48 cellules originales byte-préservées (vérifié par re-parse + comparaison structurelle).
- **C.1/C.2** : aucune cellule code touchée ; markdown-only.

See #11601 (contribution partielle — umbrella round 2, pool 224-242 notebooks)
