### PR TITLE
feat(lean,#13106): module GradientFlow — évanouissement c^n vs survie (1-c)^n (digestion, forme formalisation)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow.lean
@@ -1,0 +1,79 @@
+import Mathlib
+import GradientFlow.Plain
+import GradientFlow.Residual
+
+/-!
+# GradientFlow — digestion formelle : pourquoi le gradient survit aux blocs résiduels
+
+Tranche de l'EPIC digestion **#13106** (forme *formalisation*, comme le pilote
+CHSH #14858 de po-2025 et la grille PFR #14566 de ai-01). Le protocole de
+digestion (Tao, ICM 2026 — opération *digérer*) exige, par grain enfant, une
+grille à 10 points ; elle est déroulée ici.
+
+1. **Énoncé exact.** Pour une pile « plain » de `n` blocs dérivables dont
+   chacun contracte la dérivée (`|f'_k| ≤ c`), la dérivée de la composition
+   vérifie `|(f_{n-1} ∘ … ∘ f_0)'| ≤ c ^ n` (`abs_deriv_plainStack_le`), et
+   pour `c < 1` la borne tend vers `0` (`plainStack_gradient_vanishes`).
+   Pour une pile de blocs résiduels `h ↦ h + f h` avec `c ≤ 1`,
+   `(1 - c) ^ n ≤ |(g_{n-1} ∘ … ∘ g_0)'|`
+   (`abs_deriv_residualStack_ge`) : le gradient survit géométriquement.
+2. **Provenance.** Le raccourci identité : He, Zhang, Ren & Sun, *Deep
+   Residual Learning for Image Recognition*, arXiv:1512.03385 (2015) ; la
+   lecture ensembliste : Veit, Wilber & Belongie, *Residual Networks Behave
+   Like Ensembles of Relatively Shallow Networks*, arXiv:1605.06431 (2016).
+   Le contenu digéré est **notre propre notebook**
+   `DataScienceWithAgents/04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb`
+   (§3 : mesure du facteur ≈ 0,4/bloc ; §6 : plain 43,1 % vs prenorm 58,4 %
+   d'accuracy pairwise sur 3 graines).
+3. **Nouveauté réelle.** Premier module du lake (et du dépôt, grep vain) à
+   formaliser la mécanique du gradient profond : la paire
+   majoration/minoration ci-dessus n'existait sous aucune forme ; les frères
+   `Perceptron` (Novikoff) et `PacLearning` (Valiant) couvrent la convergence
+   algorithmique et la généralisation, pas l'optimisation.
+4. **Carte de dépendances.** Mathlib uniquement (`HasDerivAt.comp`,
+   `HasDerivAt.add`, `abs_mul`, `abs_sub_abs_le_abs_add`,
+   `Real.tendsto_pow_atTop_nhds_0_nat`, `norm_num`) ; aucune dépendance aux
+   modules frères du lake — le module s'ajoute sans coupler.
+5. **Trivial condensé vs nouveau développé.** Les briques sont des
+   condensés honnêtes (règle de chaîne + induction + monotonie du produit) ;
+   ce qui est **neuf** est la paire d'énoncés et le couplage aux ancres
+   numériques du cours (`0,4 ^ 20 < 1e-7` côté plain, `3e-5 < 0,6 ^ 20` côté
+   résiduel).
+6. **Friction naturelle.** Naviguer l'API `Deriv`/`HasDerivAt` (l'ordre des
+   arguments de `.comp`, la forme exacte des lemmes d'absolue) ; maintenir
+   0-sorry sur des récurrences syntaxiques (la valeur dérivée portée par
+   `HasDerivAt` plutôt que ré-exprimée via `deriv`).
+7. **Chemin de découverte.** Le notebook 4.2-ConvNet mesure d'abord (pente
+   droite en semilog : facteur ~0,4/bloc, `0,4 ^ 20 ≈ 1e-8`), le lake démontre
+   ensuite : la mesure précède la preuve, exactement l'ordre que le protocole
+   de digestion veut institutionaliser.
+8. **Limites.** Modèle jouet 1-D sur `ℝ` : pas de Jacobiennes, pas de valeurs
+   propres, pas de pré-norme/LayerNorm. La formalisation capture la survie
+   par raccourci identité, **pas** la réparation par normalisation (le
+   notebook distingue les deux ; le lake ne couvre que la première).
+9. **Raccord corpus.** Notebook `4.2-ConvNet-Profonde-Residuelles` (§3, §6) ;
+   lake `learning_theory_lean` (frères `Perceptron`, `PacLearning`) ; README
+   du lake mis à jour (section module + références).
+10. **Transmission.** Docstrings FR (canoniques) + siblings EN
+    (`GradientFlow_en`, convention #4980) ; grille résumée dans le README ;
+    ancres numériques vérifiées par `norm_num`.
+
+## Statut
+
+Tranche 1 **livrée** : `Plain.lean` (majoration `c ^ n` + évanouissement +
+ancre `0,4 ^ 20`), `Residual.lean` (minoration `(1-c) ^ n` + ancre `0,6 ^ 20`),
+tous deux 0-sorry. Extension naturelle (hors périmètre de cette tranche) :
+le modèle matriciel (jacobiennes, rayon spectral) et la pré-norme.
+-/
+
+namespace GradientFlow
+
+/-- Statut : tranche 1 livrée (digestion #13106) — pile plain majorée par
+`c ^ n` (`abs_deriv_plainStack_le`, évanouissement
+`plainStack_gradient_vanishes`), pile résiduelle minorée par `(1-c) ^ n`
+(`abs_deriv_residualStack_ge`), ancres numériques du notebook 4.2-ConvNet
+(`two_fifths_pow_twenty_lt`, `three_fifths_pow_twenty_gt`). Extensions ouvertes
+hors périmètre : modèle matriciel (jacobiennes/spectral), pré-norme. -/
+abbrev Status : Prop := True
+
+end GradientFlow

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Plain.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Plain.lean
@@ -1,0 +1,85 @@
+import Mathlib
+
+/-!
+# GradientFlow.Plain — évanouissement du gradient dans une pile « plain »
+
+Sous-module de `GradientFlow` (digestion #13106, forme formalisation — cf pilote
+CHSH #14858) : une pile de `n` blocs **sans raccourci** (« plain », l'empilement
+d'études du notebook `4.2-ConvNet-Profonde-Residuelles`) est la composition
+`f_{n-1} ∘ … ∘ f_0`. Si chaque bloc contracte la dérivée (`|f'_k| ≤ c`), la
+règle de chaîne et une induction sur la profondeur donnent
+
+    |(f_{n-1} ∘ … ∘ f_0)'| ≤ c ^ n,
+
+et pour une contraction stricte `c < 1`, la borne `c ^ n` tend vers `0` : **le
+gradient meurt exponentiellement vite avec la profondeur**. C'est exactement le
+phénomène mesuré dans le notebook (§3) : facteur ≈ 0,4 par bloc, donc
+`0,4 ^ 20 ≈ 1e-8` au bout de 20 blocs — un gradient cent million de fois plus
+petit qu'en entrée. L'ancre numérique `two_fifths_pow_twenty_lt` verrouille cette
+valeur du cours (`0,4 ^ 20 < 1e-7`).
+
+Toutes les preuves sont **0-sorry** et élémentaires (règle de chaîne via
+`HasDerivAt.comp`, puis monotonie du produit) : le contenu du module est le
+théorème, pas les tactiques.
+-/
+
+namespace GradientFlow
+
+variable (fs : ℕ → ℝ → ℝ) (c : ℝ)
+
+/-- Pile « plain » de profondeur `n` : composition des blocs `0, …, n-1`, le bloc
+`k` étant la fonction `fs k`. `plainStack fs 0 = id` et
+`plainStack fs (n + 1) = fs n ∘ plainStack fs n`. -/
+def plainStack (fs : ℕ → ℝ → ℝ) : ℕ → ℝ → ℝ
+  | 0 => id
+  | n + 1 => fs n ∘ plainStack fs n
+
+/-- **Lemme central** : par induction sur la profondeur, la pile plain dérive en
+un produit de dérivées de blocs, de valeur absolue bornée par `c ^ n` dès que
+chaque bloc dérive et contracte (`|f'_k| ≤ c`). La valeur dérivée est portée par
+`HasDerivAt` pour que la récurrence reste syntaxique. -/
+theorem plainStack_deriv_bound (hc : 0 ≤ c)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) :
+    ∀ n, ∃ d : ℝ, HasDerivAt (plainStack fs n) d x ∧ |d| ≤ c ^ n := by
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨1, ?_, ?_⟩
+    · simpa [plainStack] using hasDerivAt_id x
+    · simp
+  | succ n ih =>
+    obtain ⟨dA, hA, hB⟩ := ih
+    have hfd := (hf n (plainStack fs n x)).1
+    have hcomp := HasDerivAt.comp x hfd.hasDerivAt hA
+    show ∃ d : ℝ, HasDerivAt (fs n ∘ plainStack fs n) d x ∧ |d| ≤ c ^ (n + 1)
+    refine ⟨deriv (fs n) (plainStack fs n x) * dA, hcomp, ?_⟩
+    have hFs : |deriv (fs n) (plainStack fs n x)| ≤ c := (hf n _).2
+    rw [abs_mul, pow_succ, ← mul_comm c (c ^ n)]
+    exact (mul_le_mul_of_nonneg_right hFs (abs_nonneg _)).trans
+      (mul_le_mul_of_nonneg_left hB hc)
+
+/-- **Évanouissement du gradient (pile plain)** : si chaque bloc contracte la
+dérivée (`|f'_k| ≤ c`), la dérivée de la pile de `n` blocs est majorée par
+`c ^ n`. Pour `c < 1`, `plainStack_gradient_vanishes` en tire la mort
+exponentielle. -/
+theorem abs_deriv_plainStack_le (hc : 0 ≤ c)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) (n : ℕ) :
+    |deriv (plainStack fs n) x| ≤ c ^ n := by
+  obtain ⟨d, hA, hB⟩ := plainStack_deriv_bound fs c hc hf x n
+  rw [hA.deriv]
+  exact hB
+
+/-- **Évanouissement exponentiel** : pour une contraction stricte `c < 1`, la
+borne `c ^ n` tend vers `0` — la profondeur tue le gradient à vitesse
+géométrique, ce que le notebook 4.2-ConvNet mesure à `c ≈ 0,4` (pente droite en
+échelle semilog). -/
+theorem plainStack_gradient_vanishes (hc : 0 ≤ c) (h1 : c < 1) :
+    Filter.Tendsto (fun n => c ^ n) Filter.atTop (nhds 0) :=
+  tendsto_pow_atTop_nhds_zero_of_abs_lt_one (by rwa [abs_of_nonneg hc])
+
+/-- **Ancre numérique du cours** (notebook `4.2-ConvNet-Profonde-Residuelles`,
+§3) : à facteur `0,4` par bloc, 20 blocs laissent passer moins d'un
+dix-millionième du gradient — `0,4 ^ 20 ≈ 1,1e-8 < 1e-7`. -/
+theorem two_fifths_pow_twenty_lt : (2 / 5 : ℝ) ^ 20 < 1 / 10 ^ 7 := by norm_num
+
+end GradientFlow

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Plain_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Plain_en.lean
@@ -1,0 +1,89 @@
+import Mathlib
+
+/-!
+# GradientFlow.Plain — gradient vanishing in a "plain" stack
+
+English mirror of `GradientFlow/Plain.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): namespace
+`GradientFlow_en` (anti-collision with the FR `GradientFlow` namespace);
+non-docstring proof code unchanged.
+
+Submodule of `GradientFlow` (digestion #13106, formalization form — cf CHSH
+pilot #14858): a stack of `n` blocks **without shortcut** (the plain
+architecture of the notebook `4.2-ConvNet-Profonde-Residuelles`) is the
+composition `f_{n-1} ∘ … ∘ f_0`. If every block contracts the derivative
+(`|f'_k| ≤ c`), the chain rule and an induction on depth give
+
+    |(f_{n-1} ∘ … ∘ f_0)'| ≤ c ^ n,
+
+and for a strict contraction `c < 1` the bound `c ^ n` tends to `0`: **the
+gradient dies exponentially fast with depth**. This is exactly the phenomenon
+measured in the notebook (§3): factor ≈ 0.4 per block, hence
+`0.4 ^ 20 ≈ 1e-8` after 20 blocks. The numeric anchor
+`two_fifths_pow_twenty_lt` locks this course value (`0.4 ^ 20 < 1e-7`).
+
+All proofs are **0-sorry** and elementary (chain rule via `HasDerivAt.comp`,
+then product monotonicity): the content of the module is the theorem, not the
+tactics.
+-/
+
+namespace GradientFlow_en
+
+variable (fs : ℕ → ℝ → ℝ) (c : ℝ)
+
+/-- "Plain" stack of depth `n`: composition of blocks `0, …, n-1`, block `k`
+being the function `fs k`. `plainStack fs 0 = id` and
+`plainStack fs (n + 1) = fs n ∘ plainStack fs n`. -/
+def plainStack (fs : ℕ → ℝ → ℝ) : ℕ → ℝ → ℝ
+  | 0 => id
+  | n + 1 => fs n ∘ plainStack fs n
+
+/-- **Central lemma**: by induction on depth, the plain stack derives to a
+product of block derivatives, with absolute value bounded by `c ^ n` as soon as
+every block derives and contracts (`|f'_k| ≤ c`). The derivative value is
+carried by `HasDerivAt` so the recursion stays syntactic. -/
+theorem plainStack_deriv_bound (hc : 0 ≤ c)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) :
+    ∀ n, ∃ d : ℝ, HasDerivAt (plainStack fs n) d x ∧ |d| ≤ c ^ n := by
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨1, ?_, ?_⟩
+    · simpa [plainStack] using hasDerivAt_id x
+    · simp
+  | succ n ih =>
+    obtain ⟨dA, hA, hB⟩ := ih
+    have hfd := (hf n (plainStack fs n x)).1
+    have hcomp := HasDerivAt.comp x hfd.hasDerivAt hA
+    show ∃ d : ℝ, HasDerivAt (fs n ∘ plainStack fs n) d x ∧ |d| ≤ c ^ (n + 1)
+    refine ⟨deriv (fs n) (plainStack fs n x) * dA, hcomp, ?_⟩
+    have hFs : |deriv (fs n) (plainStack fs n x)| ≤ c := (hf n _).2
+    rw [abs_mul, pow_succ, ← mul_comm c (c ^ n)]
+    exact (mul_le_mul_of_nonneg_right hFs (abs_nonneg _)).trans
+      (mul_le_mul_of_nonneg_left hB hc)
+
+/-- **Gradient vanishing (plain stack)**: if every block contracts the
+derivative (`|f'_k| ≤ c`), the derivative of the `n`-block stack is bounded by
+`c ^ n`. For `c < 1`, `plainStack_gradient_vanishes` draws the exponential
+death. -/
+theorem abs_deriv_plainStack_le (hc : 0 ≤ c)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) (n : ℕ) :
+    |deriv (plainStack fs n) x| ≤ c ^ n := by
+  obtain ⟨d, hA, hB⟩ := plainStack_deriv_bound fs c hc hf x n
+  rw [hA.deriv]
+  exact hB
+
+/-- **Exponential vanishing**: for a strict contraction `c < 1`, the bound
+`c ^ n` tends to `0` — depth kills the gradient geometrically, which the
+4.2-ConvNet notebook measures at `c ≈ 0.4` (straight line on a semilog scale). -/
+theorem plainStack_gradient_vanishes (hc : 0 ≤ c) (h1 : c < 1) :
+    Filter.Tendsto (fun n => c ^ n) Filter.atTop (nhds 0) :=
+  tendsto_pow_atTop_nhds_zero_of_abs_lt_one (by rwa [abs_of_nonneg hc])
+
+/-- **Numeric anchor of the course** (notebook
+`4.2-ConvNet-Profonde-Residuelles`, §3): at a factor of `0.4` per block, 20
+blocks let through less than one ten-millionth of the gradient —
+`0.4 ^ 20 ≈ 1.1e-8 < 1e-7`. -/
+theorem two_fifths_pow_twenty_lt : (2 / 5 : ℝ) ^ 20 < 1 / 10 ^ 7 := by norm_num
+
+end GradientFlow_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Residual.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Residual.lean
@@ -1,0 +1,99 @@
+import Mathlib
+
+/-!
+# GradientFlow.Residual — survie du gradient dans une pile résiduelle
+
+Sous-module de `GradientFlow` (digestion #13106, forme formalisation) : chaque
+bloc de la pile est maintenant un **bloc résiduel** `h ↦ h + f h` — le raccourci
+identité de He, Zhang, Ren & Sun (*Deep Residual Learning for Image
+Recognition*, arXiv:1512.03385, 2015). Si chaque branche contracte la dérivée
+(`|f'_k| ≤ c` avec `c ≤ 1`), le terme `+1` du raccourci change la marche : la
+dérivée de chaque bloc est `1 + f'_k`, de module au moins `1 - c > 0`, et
+l'induction sur la profondeur donne
+
+    (1 - c) ^ n ≤ |(g_{n-1} ∘ … ∘ g_0)'|,
+
+le gradient **survit** géométriquement au lieu de mourir. À contraction de
+branche égale `c = 0,4`, l'écart avec la pile plain est de trois ordres de
+grandeur à profondeur 20 : `0,6 ^ 20 ≈ 3,7e-5` contre `0,4 ^ 20 ≈ 1,1e-8` —
+ancres numériques `three_fifths_pow_twenty_gt` et
+`GradientFlow.two_fifths_pow_twenty_lt`.
+
+La borne inférieure repose sur l'anti-inégalité triangulaire tirée de
+`abs_add_le` (`1 - |t| ≤ |1 + t|`). Toutes les preuves sont **0-sorry**.
+-/
+
+namespace GradientFlow
+
+variable (fs : ℕ → ℝ → ℝ) (c : ℝ)
+
+/-- Bloc résiduel (raccourci identité, He et al. 2016) : `h ↦ h + f h`. La
+dérivée en un point est `1 + f'`, de module au moins `1 - |f'|`. -/
+def residualBlock (f : ℝ → ℝ) : ℝ → ℝ := fun h => h + f h
+
+/-- **Anti-inégalité triangulaire (forme du bloc résiduel)** : le terme `+1` du
+raccourci garantit `1 - |t| ≤ |1 + t|` — la dérivée d'un bloc résiduel ne peut
+pas descendre sous `1 - c` quand la branche contracte à `|f'| ≤ c`. -/
+theorem one_sub_le_abs_add (t : ℝ) : 1 - |t| ≤ |1 + t| := by
+  have h : (1 : ℝ) ≤ |1 + t| + |t| := by
+    simpa using abs_add_le (1 + t) (-t)
+  linarith
+
+/-- Pile résiduelle de profondeur `n` : composition des blocs résiduels
+construits sur `fs 0, …, fs (n-1)`. `residualStack fs 0 = id` et
+`residualStack fs (n + 1) = residualBlock (fs n) ∘ residualStack fs n`. -/
+def residualStack (fs : ℕ → ℝ → ℝ) : ℕ → ℝ → ℝ
+  | 0 => id
+  | n + 1 => residualBlock (fs n) ∘ residualStack fs n
+
+/-- **Lemme central** : par induction sur la profondeur, la pile résiduelle
+dérive en un produit dont le module est **minoré** par `(1 - c) ^ n` dès que
+chaque branche dérive et contracte (`|f'_k| ≤ c`, `c ≤ 1`). -/
+theorem residualStack_deriv_bound (hc1 : c ≤ 1)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) :
+    ∀ n, ∃ d : ℝ, HasDerivAt (residualStack fs n) d x ∧ (1 - c) ^ n ≤ |d| := by
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨1, ?_, ?_⟩
+    · simpa [residualStack] using hasDerivAt_id x
+    · simp
+  | succ n ih =>
+    obtain ⟨dA, hA, hB⟩ := ih
+    have hfd := (hf n (residualStack fs n x)).1
+    have hBlock : HasDerivAt (residualBlock (fs n))
+        (1 + deriv (fs n) (residualStack fs n x)) (residualStack fs n x) :=
+      (hasDerivAt_id _).add hfd.hasDerivAt
+    have hcomp := HasDerivAt.comp x hBlock hA
+    show ∃ d : ℝ, HasDerivAt (residualBlock (fs n) ∘ residualStack fs n) d x ∧
+      (1 - c) ^ (n + 1) ≤ |d|
+    refine ⟨(1 + deriv (fs n) (residualStack fs n x)) * dA, hcomp, ?_⟩
+    have hFs : |deriv (fs n) (residualStack fs n x)| ≤ c := (hf n _).2
+    have hLow : 1 - c ≤ |1 + deriv (fs n) (residualStack fs n x)| :=
+      (sub_le_sub_left hFs 1).trans (one_sub_le_abs_add _)
+    have hc0 : 0 ≤ 1 - c := sub_nonneg.mpr hc1
+    rw [abs_mul, pow_succ, ← mul_comm (1 - c) ((1 - c) ^ n)]
+    calc (1 - c) * (1 - c) ^ n
+        ≤ |1 + deriv (fs n) (residualStack fs n x)| * (1 - c) ^ n :=
+          mul_le_mul_of_nonneg_right hLow (pow_nonneg hc0 n)
+      _ ≤ |1 + deriv (fs n) (residualStack fs n x)| * |dA| :=
+          mul_le_mul_of_nonneg_left hB (abs_nonneg _)
+
+/-- **Survie du gradient (pile résiduelle)** : si chaque branche contracte la
+dérivée (`|f'_k| ≤ c`, `c ≤ 1`), la dérivée de la pile de `n` blocs est
+**minorée** par `(1 - c) ^ n` — le raccourci identité empêche l'évanouissement
+exponentiel de la pile plain (`abs_deriv_plainStack_le`). -/
+theorem abs_deriv_residualStack_ge (hc1 : c ≤ 1)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) (n : ℕ) :
+    (1 - c) ^ n ≤ |deriv (residualStack fs n) x| := by
+  obtain ⟨d, hA, hB⟩ := residualStack_deriv_bound fs c hc1 hf x n
+  rw [hA.deriv]
+  exact hB
+
+/-- **Ancre numérique jumelle** (notebook `4.2-ConvNet-Profonde-Residuelles`,
+§6) : à contraction de branche égale `c = 0,4`, la pile résiduelle laisse
+passer au moins `0,6 ^ 20 ≈ 3,7e-5` — trois ordres de grandeur au-dessus de la
+pile plain (`0,4 ^ 20 ≈ 1,1e-8`, voir `GradientFlow.two_fifths_pow_twenty_lt`). -/
+theorem three_fifths_pow_twenty_gt : 3 / 10 ^ 5 < (3 / 5 : ℝ) ^ 20 := by norm_num
+
+end GradientFlow

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Residual_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow/Residual_en.lean
@@ -1,0 +1,103 @@
+import Mathlib
+
+/-!
+# GradientFlow.Residual — gradient survival in a residual stack
+
+English mirror of `GradientFlow/Residual.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): namespace
+`GradientFlow_en`; non-docstring proof code unchanged.
+
+Submodule of `GradientFlow` (digestion #13106, formalization form): every
+block of the stack is now a **residual block** `h ↦ h + f h` — the identity
+shortcut of He, Zhang, Ren & Sun (*Deep Residual Learning for Image
+Recognition*, arXiv:1512.03385, 2015). If every branch contracts the derivative
+(`|f'_k| ≤ c` with `c ≤ 1`), the `+1` of the shortcut changes the game: each
+block's derivative is `1 + f'_k`, of modulus at least `1 - c > 0`, and the
+induction on depth gives
+
+    (1 - c) ^ n ≤ |(g_{n-1} ∘ … ∘ g_0)'|,
+
+the gradient **survives** geometrically instead of dying. At equal branch
+contraction `c = 0.4`, the gap with the plain stack is three orders of
+magnitude at depth 20: `0.6 ^ 20 ≈ 3.7e-5` versus `0.4 ^ 20 ≈ 1.1e-8` —
+numeric anchors `three_fifths_pow_twenty_gt` and
+`GradientFlow.two_fifths_pow_twenty_lt`.
+
+The lower bound rests on the reverse triangle inequality derived from
+`abs_add_le` (`1 - |t| ≤ |1 + t|`). All proofs are **0-sorry**.
+-/
+
+namespace GradientFlow_en
+
+variable (fs : ℕ → ℝ → ℝ) (c : ℝ)
+
+/-- Residual block (identity shortcut, He et al. 2016): `h ↦ h + f h`. Its
+derivative at a point is `1 + f'`, of modulus at least `1 - |f'|`. -/
+def residualBlock (f : ℝ → ℝ) : ℝ → ℝ := fun h => h + f h
+
+/-- **Reverse triangle inequality (residual-block form)**: the `+1` of the
+shortcut guarantees `1 - |t| ≤ |1 + t|` — a residual block's derivative cannot
+drop below `1 - c` when the branch contracts at `|f'| ≤ c`. -/
+theorem one_sub_le_abs_add (t : ℝ) : 1 - |t| ≤ |1 + t| := by
+  have h : (1 : ℝ) ≤ |1 + t| + |t| := by
+    simpa using abs_add_le (1 + t) (-t)
+  linarith
+
+/-- Residual stack of depth `n`: composition of residual blocks built on
+`fs 0, …, fs (n-1)`. `residualStack fs 0 = id` and
+`residualStack fs (n + 1) = residualBlock (fs n) ∘ residualStack fs n`. -/
+def residualStack (fs : ℕ → ℝ → ℝ) : ℕ → ℝ → ℝ
+  | 0 => id
+  | n + 1 => residualBlock (fs n) ∘ residualStack fs n
+
+/-- **Central lemma**: by induction on depth, the residual stack derives to a
+product whose modulus is **bounded below** by `(1 - c) ^ n` as soon as every
+branch derives and contracts (`|f'_k| ≤ c`, `c ≤ 1`). -/
+theorem residualStack_deriv_bound (hc1 : c ≤ 1)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) :
+    ∀ n, ∃ d : ℝ, HasDerivAt (residualStack fs n) d x ∧ (1 - c) ^ n ≤ |d| := by
+  intro n
+  induction n with
+  | zero =>
+    refine ⟨1, ?_, ?_⟩
+    · simpa [residualStack] using hasDerivAt_id x
+    · simp
+  | succ n ih =>
+    obtain ⟨dA, hA, hB⟩ := ih
+    have hfd := (hf n (residualStack fs n x)).1
+    have hBlock : HasDerivAt (residualBlock (fs n))
+        (1 + deriv (fs n) (residualStack fs n x)) (residualStack fs n x) :=
+      (hasDerivAt_id _).add hfd.hasDerivAt
+    have hcomp := HasDerivAt.comp x hBlock hA
+    show ∃ d : ℝ, HasDerivAt (residualBlock (fs n) ∘ residualStack fs n) d x ∧
+      (1 - c) ^ (n + 1) ≤ |d|
+    refine ⟨(1 + deriv (fs n) (residualStack fs n x)) * dA, hcomp, ?_⟩
+    have hFs : |deriv (fs n) (residualStack fs n x)| ≤ c := (hf n _).2
+    have hLow : 1 - c ≤ |1 + deriv (fs n) (residualStack fs n x)| :=
+      (sub_le_sub_left hFs 1).trans (one_sub_le_abs_add _)
+    have hc0 : 0 ≤ 1 - c := sub_nonneg.mpr hc1
+    rw [abs_mul, pow_succ, ← mul_comm (1 - c) ((1 - c) ^ n)]
+    calc (1 - c) * (1 - c) ^ n
+        ≤ |1 + deriv (fs n) (residualStack fs n x)| * (1 - c) ^ n :=
+          mul_le_mul_of_nonneg_right hLow (pow_nonneg hc0 n)
+      _ ≤ |1 + deriv (fs n) (residualStack fs n x)| * |dA| :=
+          mul_le_mul_of_nonneg_left hB (abs_nonneg _)
+
+/-- **Gradient survival (residual stack)**: if every branch contracts the
+derivative (`|f'_k| ≤ c`, `c ≤ 1`), the derivative of the `n`-block stack is
+**bounded below** by `(1 - c) ^ n` — the identity shortcut prevents the plain
+stack's exponential vanishing (`abs_deriv_plainStack_le`). -/
+theorem abs_deriv_residualStack_ge (hc1 : c ≤ 1)
+    (hf : ∀ k x, DifferentiableAt ℝ (fs k) x ∧ |deriv (fs k) x| ≤ c) (x : ℝ) (n : ℕ) :
+    (1 - c) ^ n ≤ |deriv (residualStack fs n) x| := by
+  obtain ⟨d, hA, hB⟩ := residualStack_deriv_bound fs c hc1 hf x n
+  rw [hA.deriv]
+  exact hB
+
+/-- **Twin numeric anchor** (notebook `4.2-ConvNet-Profonde-Residuelles`, §6):
+at equal branch contraction `c = 0.4`, the residual stack lets through at
+least `0.6 ^ 20 ≈ 3.7e-5` — three orders of magnitude above the plain stack
+(`0.4 ^ 20 ≈ 1.1e-8`, see `GradientFlow.two_fifths_pow_twenty_lt`). -/
+theorem three_fifths_pow_twenty_gt : 3 / 10 ^ 5 < (3 / 5 : ℝ) ^ 20 := by norm_num
+
+end GradientFlow_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/GradientFlow_en.lean
@@ -1,0 +1,80 @@
+import Mathlib
+import GradientFlow.Plain_en
+import GradientFlow.Residual_en
+
+/-!
+# GradientFlow — formal digestion: why the gradient survives residual blocks
+
+English mirror of `GradientFlow.lean` (FR-first canonical), EPIC #4980 (i18n
+Lean). Convention ratified 2026-07-04 (issue #4980): namespace
+`GradientFlow_en`; cross-module `_en` imports `_en`.
+
+A tranche of the digestion EPIC **#13106** (formalization form, like the CHSH
+pilot #14858 by po-2025 and the PFR grid #14566 by ai-01). The digestion
+protocol (Tao, ICM 2026 — the *digest* operation) requires a 10-point grid per
+child grain; it is rolled out in the FR canonical header. Summary:
+
+1. **Exact statement.** Plain stack of `n` blocks each contracting the
+   derivative (`|f'_k| ≤ c`): `|(f_{n-1} ∘ … ∘ f_0)'| ≤ c ^ n`
+   (`abs_deriv_plainStack_le`), and for `c < 1` the bound tends to `0`
+   (`plainStack_gradient_vanishes`). Stack of residual blocks `h ↦ h + f h`
+   with `c ≤ 1`: `(1 - c) ^ n ≤ |(g_{n-1} ∘ … ∘ g_0)'|`
+   (`abs_deriv_residualStack_ge`) — the gradient survives geometrically.
+2. **Provenance.** The identity shortcut: He, Zhang, Ren & Sun, *Deep
+   Residual Learning for Image Recognition*, arXiv:1512.03385 (2015); the
+   ensemble view: Veit, Wilber & Belongie, arXiv:1605.06431 (2016). The
+   digested content is **our own notebook**
+   `DataScienceWithAgents/04-Vision/4.2-ConvNet-Profonde-Residuelles.ipynb`
+   (§3: measured factor ≈ 0.4/block; §6: plain 43.1% vs prenorm 58.4%
+   pairwise accuracy over 3 seeds).
+3. **Real novelty.** First module of the lake (and of the repo, empty grep)
+   formalizing deep-gradient mechanics: the upper/lower bound pair above
+   existed in no form; the siblings `Perceptron` (Novikoff) and `PacLearning`
+   (Valiant) cover algorithmic convergence and generalization, not
+   optimization.
+4. **Dependency map.** Mathlib only (`HasDerivAt.comp`, `HasDerivAt.add`,
+   `abs_mul`, `abs_sub_abs_le_abs_add`,
+   `Real.tendsto_pow_atTop_nhds_0_nat`, `norm_num`); no dependency on the
+   lake's sibling modules.
+5. **Condensed trivial vs newly developed.** The bricks are honest
+   condensates (chain rule + induction + product monotonicity); what is
+   **new** is the pair of statements and the coupling to the course's
+   numeric anchors (`0.4 ^ 20 < 1e-7` plain-side, `3e-5 < 0.6 ^ 20`
+   residual-side).
+6. **Natural friction.** Navigating the `Deriv`/`HasDerivAt` API (argument
+   order of `.comp`, exact shape of the abs lemmas); keeping 0-sorry on
+   syntactic recursions (the derivative value carried by `HasDerivAt`).
+7. **Discovery path.** The 4.2-ConvNet notebook measures first (straight
+   line on a semilog scale: factor ~0.4/block, `0.4 ^ 20 ≈ 1e-8`), the lake
+   proves second: measurement precedes proof — exactly the order the
+   digestion protocol wants to institutionalize.
+8. **Limits.** 1-D toy model over `ℝ`: no Jacobians, no eigenvalues, no
+   pre-norm/LayerNorm. The formalization captures survival by identity
+   shortcut, **not** repair by normalization (the notebook distinguishes
+   both; the lake covers only the first).
+9. **Corpus connection.** Notebook `4.2-ConvNet-Profonde-Residuelles`
+   (§3, §6); lake `learning_theory_lean` (siblings `Perceptron`,
+   `PacLearning`); lake README updated.
+10. **Transmission.** FR docstrings (canonical) + EN siblings
+    (`GradientFlow_en`, convention #4980); grid summarized in the README;
+    numeric anchors checked by `norm_num`.
+
+## Status
+
+Tranche 1 **delivered**: `Plain.lean` (upper bound `c ^ n` + vanishing +
+anchor `0.4 ^ 20`), `Residual.lean` (lower bound `(1-c) ^ n` + anchor
+`0.6 ^ 20`), both 0-sorry. Natural extensions (out of scope for this
+tranche): the matrix model (Jacobians, spectral radius) and the pre-norm.
+-/
+
+namespace GradientFlow_en
+
+/-- Status: tranche 1 delivered (digestion #13106) — plain stack bounded above
+by `c ^ n` (`abs_deriv_plainStack_le`, vanishing
+`plainStack_gradient_vanishes`), residual stack bounded below by `(1-c) ^ n`
+(`abs_deriv_residualStack_ge`), numeric anchors of the 4.2-ConvNet notebook
+(`two_fifths_pow_twenty_lt`, `three_fifths_pow_twenty_gt`). Open extensions
+out of scope: matrix model (Jacobians/spectral), pre-norm. -/
+abbrev Status : Prop := True
+
+end GradientFlow_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/README.md
@@ -1,6 +1,6 @@
-# learning_theory_lean — Learning theory (Perceptron / Novikoff + PAC / Valiant), Lean 4
+# learning_theory_lean — Learning theory (Perceptron / Novikoff + PAC / Valiant + GradientFlow), Lean 4
 
-Lake Lean 4 (Mathlib) à la racine de la série **ML**, mutualisant deux résultats
+Lake Lean 4 (Mathlib) à la racine de la série **ML**, mutualisant des résultats
 fondamentaux de **théorie de l'apprentissage** sous un même umbrella généraliste
 (cf `decision_theory_lean` qui co-localise Gittins + Utility + Coherence) :
 
@@ -17,6 +17,14 @@ fondamentaux de **théorie de l'apprentissage** sous un même umbrella général
    `m ≥ (1/ε)(ln|H| + ln(1/δ))` (concentration de Hoeffding pour Bernoulli + union
    bound, `PacFiniteBound.lean`) ainsi que la **borne de généralisation
    agnostic** (`Agnostic.lean`, itération 2) — toutes deux **0-sorry**.
+3. **Module `GradientFlow`** — digestion #13106 (forme formalisation) :
+   mécanique du **gradient profond** du notebook
+   `4.2-ConvNet-Profonde-Residuelles`. Si chaque bloc contracte la dérivée
+   (`|f'_k| ≤ c`), une pile *plain* voit sa dérivée bornée par `c ^ n`
+   (évanouissement exponentiel, ancre `0,4 ^ 20 < 1e-7`) tandis qu'une pile de
+   blocs *résiduels* `h ↦ h + f h` la voit **minorée** par `(1-c) ^ n` (survie,
+   ancre `3e-5 < 0,6 ^ 20`) — le raccourci identité (He et al. 2015) rend
+   géométriquement improbable ce que la pile plain tue géométriquement.
 
 C'est le **premier lake Lean de la série ML** (aucun lake Lean en ML auparavant,
 roadmap #4038 Tier 2). La preuve de Novikoff est **géométrique élémentaire** :
@@ -33,14 +41,15 @@ argument ERM dans `ERM`).
 
 ## Statut
 
-- **Toolchain** : `leanprover/lean4:v4.31.0-rc1` + Mathlib4 (`v4.31.0-rc1`)
+- **Toolchain** : `leanprover/lean4:v4.32.1` + Mathlib4 (`v4.32.1`)
 - **Sorry** : **0** sur tout le module (comptage code-only, voir § Modules).
   Côté Perceptron, la borne `novikoff_mistake_bound` (`n · γ² ≤ R²`), le Lemme A
   d'alignement (`⟪wₖ, u⟫ ≥ kγ`) et le Lemme B de norme (`‖wₖ‖² ≤ kR²`) sont
   entièrement prouvés, ainsi que le **serrage** `novikoff_bound_is_sharp` (témoin
   sur `ℂ` atteignant l'égalité `n·γ² = R²`). Côté PacLearning, les deux bornes
   phares `PacFiniteBound` (Valiant) et `Agnostic` sont 0-sorry.
-- **Build** : `lake build Perceptron` / `lake build PacLearning` (dépend de Mathlib4)
+- **Build** : `lake build Perceptron` / `lake build PacLearning` /
+  `lake build GradientFlow` (dépend de Mathlib4)
 
 ## Ce qui est formalisé
 
@@ -144,6 +153,14 @@ des docstrings « 0-sorry »). Chaque fichier FR possède un **sibling anglais**
 | `PacLearning/ERM.lean` | 0 | Argument ERM (Empirical Risk Minimization) — brique agnostic 6/6. |
 | `PacLearning.lean` | 0 | Imports parapluie + doc de statut. |
 
+### Module `GradientFlow` (digestion #13106 — gradient profond plain vs résiduel)
+
+| Fichier | sorry | Contenu |
+|---------|-------|---------|
+| `GradientFlow/Plain.lean` | 0 | Pile « plain » `plainStack` (composition sans raccourci) : lemme central par induction (`plainStack_deriv_bound`), **majoration** `abs_deriv_plainStack_le` (`\|f'_{n-1} ∘ … \| ≤ c ^ n`), évanouissement exponentiel `plainStack_gradient_vanishes` (`c ^ n → 0`), ancre numérique du cours `two_fifths_pow_twenty_lt` (`0,4 ^ 20 < 1e-7`). |
+| `GradientFlow/Residual.lean` | 0 | Bloc résiduel `residualBlock` (`h ↦ h + f h`, He et al. 2015) + pile `residualStack` : lemme central (`residualStack_deriv_bound` via l'anti-inégalité triangulaire), **minoration** `abs_deriv_residualStack_ge` (`(1-c) ^ n ≤ \|g'\|`), ancre jumelle `three_fifths_pow_twenty_gt` (`3e-5 < 0,6 ^ 20`). |
+| `GradientFlow.lean` | 0 | Imports parapluie + **grille de digestion 10 points** (énoncé, provenance He/Veit, nouveauté, dépendances, trivial/neuf, friction, chemin de découverte, limites, raccord corpus, transmission). |
+
 ### i18n FR/EN
 
 Chaque module est doublé d'un **sibling anglais** `Foo_en.lean` (namespace
@@ -155,7 +172,8 @@ fichiers `_en` couvrent l'intégralité des 18 modules feuilles + agrégateurs :
 `PacLearning_en.lean`, `PacLearning/{Agnostic,BernoulliMGF,Concentration,Data,
 ERM,Hoeffding,MGF,PacFiniteBound,Sample,SampleExpect,UniformConcentration,
 UnionBound}_en.lean`, `Perceptron_en.lean`,
-`Perceptron/{Convergence,Data,Perceptron,Tightness}_en.lean`.
+`Perceptron/{Convergence,Data,Perceptron,Tightness}_en.lean`,
+`GradientFlow_en.lean`, `GradientFlow/{Plain,Residual}_en.lean`.
 
 **Conséquence** : les futurs raffinements doivent conserver la symétrie FR/EN
 (les deux fichiers évoluent ensemble ou pas du tout). La CI `check_i18n_siblings`
@@ -200,10 +218,15 @@ déclaration dans un notebook :
   (1984).
 - S. Shalev-Shwartz & S. Ben-David, *Understanding Machine Learning*, Cambridge
   University Press (2014), §2 (classes finies) et §6 (VC dimension).
+- K. He, X. Zhang, S. Ren & J. Sun, *Deep Residual Learning for Image
+  Recognition*, arXiv:1512.03385 (2015) — le raccourci identité.
+- A. Veit, M. Wilber & S. Belongie, *Residual Networks Behave Like Ensembles of
+  Relatively Shallow Networks*, arXiv:1605.06431 (2016) — la lecture ensembliste.
 
 ## Voir aussi
 
 - **Issue #4051** — création du lake + module Perceptron (roadmap Lean #4038, Tier 2 « first ML theorem »)
 - **Issue #4293** — renommage `perceptron_lean → learning_theory_lean` + module PacLearning (mutualisation, cf `decision_theory_lean`)
+- **EPIC #13106** — digestion : le module `GradientFlow` en est la tranche « forme formalisation » (grille 10 points dans `GradientFlow.lean`)
 - **`ML/`** — série Machine Learning (ML.NET C#, Data Science with Agents Python)
 - **Epic #2651** — prose pédagogique README

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/lakefile.lean
@@ -46,3 +46,12 @@ Frère de `Perceptron` dans le lake ML généraliste `learning_theory_lean` (cf
 @[default_target]
 lean_lib «PacLearning» where
   globs := #[.submodules `PacLearning, `PacLearning_en]
+
+/-- Module `GradientFlow` — digestion #13106 (forme formalisation) :
+évanouissement du gradient `c ^ n` dans une pile plain vs survie `(1-c) ^ n`
+dans une pile résiduelle (raccourci identité, He et al. 2016), ancres
+numériques du notebook 4.2-ConvNet-Profonde-Residuelles (facteur 0,4/bloc).
+Frère de `Perceptron` et `PacLearning`. -/
+@[default_target]
+lean_lib «GradientFlow» where
+  globs := #[.submodules `GradientFlow, `GradientFlow_en]


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #14971

## Summary

Tranche « forme formalisation » de l'EPIC digestion #13106 (cf pilote CHSH #14858) : nouveau module `GradientFlow` dans le lake `learning_theory_lean` (série ML), troisième frère après `Perceptron` (Novikoff) et `PacLearning` (Valiant).

Le contenu digéré est **notre propre corpus** : le notebook `4.2-ConvNet-Profonde-Residuelles.ipynb` (série DataScienceWithAgents) mesure au §3 le facteur ≈ 0,4/bloc de contraction du gradient (`0,4^20 ≈ 1e-8`) et au §6 la réparation par blocs pré-normés. La tranche formalise la moitié **raccourci-identité** de cette mécanique :

- **Pile plain** (`GradientFlow/Plain.lean`) : `plainStack fs n` = composition des n blocs. Si `|f'_k| ≤ c` en chaque point → `|deriv (plainStack fs n) x| ≤ c ^ n` (`abs_deriv_plainStack_le`, lemme central `plainStack_deriv_bound` par induction), et pour `c < 1` la borne tend vers 0 (`plainStack_gradient_vanishes`). Ancre numérique du cours : `two_fifths_pow_twenty_lt` (`(2/5)^20 < 1/10^7`, par `norm_num`).
- **Pile résiduelle** (`GradientFlow/Residual.lean`) : bloc `h ↦ h + f h` (He et al. 2015). Pour `c ≤ 1` → `(1-c)^n ≤ |deriv (residualStack fs n) x|` (`abs_deriv_residualStack_ge`), via l'anti-inégalité triangulaire `1 - |t| ≤ |1+t|`. Ancre jumelle : `three_fifths_pow_twenty_gt` (`3/10^5 < (3/5)^20`) — à contraction de branche égale `c = 0,4`, trois ordres de grandeur d'écart à profondeur 20.

La **grille de digestion 10 points** (énoncé exact, provenance, nouveauté réelle, carte de dépendances, trivial condensé vs nouveau développé, friction, chemin de découverte, limites, raccord corpus, transmission) est déroulée dans l'en-tête de `GradientFlow.lean` (FR) et `GradientFlow_en.lean` (EN).

**Limites assumées** (grille point 8) : modèle jouet 1-D sur ℝ — pas de Jacobiennes, pas de rayon spectral, pas de pré-norme/LayerNorm. La formalisation capture la survie par raccourci identité, pas la réparation par normalisation.

## Validation

- `lake build GradientFlow` : **SUCCESS** (local, WSL natif, Mathlib v4.32.1 via cache — 8660 jobs, 0 erreur) ; la CI `Lean CI (learning_theory_lean)` re-vérifie. Le root aggregator FR (`GradientFlow.lean`, hors globs `.submodules` comme `Perceptron`/`PacLearning`) vérifié séparément : `lake env lean GradientFlow.lean` exit 0.
- `#print axioms` sur les 8 théorèmes FR + 2 miroirs EN : tous `[propext, Classical.choice, Quot.sound]` uniquement — aucun `sorryAx`, aucun `native_decide`.
- Sorry : `python scripts/lean/count_code_sorry.py --json` — `learning_theory_lean` `distinct_code_sorry` **0 avant (main) / 0 après** (43 fichiers = 37 + 6 nouveaux, tous 0-sorry ; le naive 26 est de la prose seule, dont les mentions « 0-sorry » des en-têtes nouveaux — le comptage code-only est inchangé).
- B.3 (proof-integrity) : **non applicable, câblage ne l'expose pas** — `lean-build.yml` (réutilisé par `lean-learning-theory.yml`) ne porte pas de job `proof-integrity`/`LeanVerifier` ; le gate réel de ce lake est `sorry-baseline: 0, sorry-filter-mode: real`. Substitut local : `#print axioms` ci-dessus.
- i18n : FR canonique + siblings EN (namespace `GradientFlow_en`, imports croisés `_en`, convention #4980) ; `check_i18n_siblings.py --all` : 3 nouvelles paires OK byte-identical, 0 drift, 0 orphan cluster-wide.
- README du lake : section module + ancre #13106 + références He (1512.03385) / Veit (1605.06431) + liste i18n + ligne build ; correction au passage d'un drift de statut (le README disait toolchain v4.31.0-rc1, le lake est à v4.32.1 depuis #11334).
- Périmètre : 8 fichiers (6 `.lean` + lakefile + README), un seul sujet (module GradientFlow).

See #13106
