### PR TITLE
feat(ci-runner,#14612): persistance systemd de la jambe waiters (coursia-waiters.service)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,7 @@ MyIA.AI.Notebooks/**/*.md text eol=lf
 # no explicit eol rule is set. Found 5x (i18n *.en.md c.268, *.sh + .env c.281).
 *.lean text eol=lf
 *.sh text eol=lf
+*.service text eol=lf
 .env text eol=lf
 .env.example text eol=lf
 *.en.md text eol=lf

--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -271,6 +271,34 @@ Routage (décision coordinateur) — **tranche 1 portée par #14148, MERGED le 2
 
 Si l'empreinte mesurée pendant un job gêne la workstation (training GPU, sessions interactives), on **réduit les caps ou on arrête**, et on le signale à ai-01.
 
+### Persistance du POOL D'ATTENTE — `coursia-waiters.service`, déployée sur ai-01 (#14612, #14846)
+
+La section ci-dessous décrit la persistance de la jambe d'**exécution** (`start N`, label `coursia-linux`). La jambe **d'attente** (`waiters N`, label `coursia-waiter`) n'en avait aucune, **sur aucune machine** : ni unité installée, ni même copie de référence dans `persist/`. Elle était lancée à la main dans une session et mourait avec elle — la panne que la section suivante existe pour supprimer, restée entière sur l'autre jambe.
+
+**Ce que ça a coûté, mesuré le 2026-09-07.** Les 12 waiters d'ai-01 étaient morts depuis 15:40Z la veille (dernier `Listening for Jobs`, zéro conteneur sur l'hôte, 12 inscriptions `offline` fantômes côté GitHub). po-2024 était donc **fournisseur unique** du label. Quand ses conteneurs se sont mis à être fauchés à ~10 min, le `PR gate` — check **requis** — a échoué **6 fois sur 6** entre 00:06Z et 00:40Z : gel de tous les merges de la flotte. C'est très exactement le point unique de défaillance que **#14612** nomme, et la deuxième occurrence du gel décrit par **#14846**.
+
+**L'unité.** `coursia-waiters.service` est la jumelle de `coursia-runner.service` (mêmes `Wants=docker.service`, `Restart=always`, `Nice=10`), avec trois écarts délibérés :
+
+| | Jambe d'exécution | Jambe d'attente |
+|---|---|---|
+| Commande | `supervise.sh start N` | `supervise.sh waiters N` |
+| Label servi | `coursia-linux` | `coursia-waiter` |
+| `STATE_DIR` | `/var/lib/coursia-runner` | **`/var/lib/coursia-waiters`** |
+| `TimeoutStopSec` | 900 s (un `lake build` en vol) | 120 s (un slot d'attente ne porte pas de build long) |
+
+**Le `STATE_DIR` dédié n'est pas cosmétique — c'est la seule subtilité du montage.** `supervise.sh` pose sa sentinelle d'arrêt gracieux en `"$STATE_DIR/stop"`, et `cmd_waiters` **refuse de démarrer** tant qu'elle est présente (`sentinel STOP pose -- arreter d'abord`). Partager le state dir aurait donc fait qu'un `systemctl stop coursia-runner` empêche le pool d'attente de redémarrer : deux jambes conçues comme indépendantes, couplées en silence par un fichier, et un couplage qui ne se serait manifesté qu'au pire moment — pendant un arrêt de maintenance de l'autre jambe.
+
+**Acceptance — elle se mesure au registre, jamais au service.** `systemctl is-active` rend `active` dès que la boucle tourne, y compris si aucun conteneur ne s'enregistre (token illisible, mauvais `DOCKER_HOST`, plafond de runners du plan atteint). Le seul contrôle qui répond est le compte de runners **en ligne** :
+
+```bash
+GH_TOKEN=$(gh auth token --user jsboige --hostname github.com)   gh api "repos/jsboige/CoursIA/actions/runners?per_page=100"   --jq '[.runners[] | select(.name|startswith("myia-ai-01-linux-waiter"))]
+        | "online=\([.[]|select(.status=="online")]|length)"'
+```
+
+Mesure au déploiement (2026-09-07T00:39Z) : **`online=12`**, 12 conteneurs `Up` sur l'hôte, et deux slots `busy` dans la minute suivante.
+
+**Déploiement sur une autre machine** : copier les deux fichiers de `persist/` vers `/usr/local/bin/` et `/etc/systemd/system/`, ajuster `COURSIA_RUNNER_WAITER_NAME_PREFIX` (défaut `myia-ai-01-linux-waiter`) et le `N` de l'`ExecStart`, puis `systemctl enable --now`. Ne **pas** relancer `supervise.sh waiters` à la main en session : c'est précisément ce que cette unité remplace.
+
 ### Persistance du superviseur — déployée sur po-2024 (systemd dans Ubuntu + holder WSL)
 
 `supervise.sh` vit dans une session : si elle meurt, les slots en ligne consomment leur inscription au prochain job et rien ne les relance. Le déploiement durable est **posé et mesuré sur po-2024** (2026-09-02, mandat user « Il faut du persistant !!! ») : les slots ont quitté Docker Desktop pour la distro **Ubuntu sous systemd**, et le réveil de la distro est **tenu** par un processus holder Windows. Copies de référence committées dans `scripts/ci/docker/linux-runner/persist/`.

--- a/scripts/ci/docker/linux-runner/persist/coursia-waiters-start.sh
+++ b/scripts/ci/docker/linux-runner/persist/coursia-waiters-start.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Lanceur PERSISTANT du pool d'attente PR-gate (label coursia-waiter).
+#
+# POURQUOI CE FICHIER EXISTE (#14612, #14846)
+# -------------------------------------------
+# La jambe `waiters` n'avait de persistance sur AUCUNE machine : elle etait
+# lancee a la main dans une session, et mourait avec elle. Consequence mesuree
+# le 2026-09-07 : les 12 waiters d'ai-01 morts depuis la veille, po-2024 seul
+# fournisseur du label, et quand ses conteneurs se sont mis a etre fauches a
+# 10 min, le `PR gate` -- check REQUIS -- a echoue 5 fois sur 5 (00:06Z ->
+# 00:30Z) : gel de tous les merges de la flotte. #14612 nommait le defaut
+# structurel (aucune redondance) ; ce fichier le ferme cote ai-01.
+#
+# STATE_DIR DEDIE, ET C'EST LE POINT DELICAT. supervise.sh place sa sentinelle
+# d'arret gracieux en "$STATE_DIR/stop", et cmd_waiters REFUSE de demarrer si
+# elle est posee. Partager le state dir avec coursia-runner.service ferait donc
+# qu'un `systemctl stop coursia-runner` empeche le pool d'attente de redemarrer
+# -- deux jambes independantes couplees par un fichier. D'ou /var/lib/coursia-waiters.
+#
+# LE SECRET NE SE DUPLIQUE PAS : GH_RUNNERS_ADMIN_TOKEN est relu dans master.env
+# a chaque demarrage (jamais recopie dans un EnvironmentFile, jamais en argv).
+set -uo pipefail
+
+MASTER_ENV="${COURSIA_MASTER_ENV:-/mnt/d/CoursIA/.secrets/master.env}"
+REPO_DIR="${COURSIA_REPO_DIR:-/mnt/d/CoursIA}"
+ARG="${1:-12}"
+
+[ -r "$MASTER_ENV" ] || { echo "master.env illisible : $MASTER_ENV" >&2; exit 1; }
+
+GH_TOKEN="$(sed -n 's/^GH_RUNNERS_ADMIN_TOKEN=//p' "$MASTER_ENV" | head -1 | tr -d '"'"'"'\r')"
+[ -n "$GH_TOKEN" ] || { echo "GH_RUNNERS_ADMIN_TOKEN absent de master.env -- abandon" >&2; exit 1; }
+export GH_TOKEN
+
+# Daemon EPINGLE (meme raison que coursia-runner-start.sh) : sans cela
+# l'integration WSL de Docker Desktop rattacherait les conteneurs a la session.
+export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker-ce.sock}"
+
+export COURSIA_RUNNER_WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-myia-ai-01-linux-waiter}"
+export COURSIA_RUNNER_STATE_DIR="${COURSIA_RUNNER_STATE_DIR:-/var/lib/coursia-waiters}"
+mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+
+cd "$REPO_DIR" || exit 1
+
+if [ "$ARG" = "stop" ]; then
+  exec ./scripts/ci/docker/linux-runner/supervise.sh stop
+fi
+exec ./scripts/ci/docker/linux-runner/supervise.sh waiters "$ARG"

--- a/scripts/ci/docker/linux-runner/persist/coursia-waiters.service
+++ b/scripts/ci/docker/linux-runner/persist/coursia-waiters.service
@@ -1,0 +1,30 @@
+# Unite systemd de persistance du POOL D'ATTENTE PR-gate (label coursia-waiter).
+# Jumelle de coursia-runner.service, qui ne porte que la jambe d'EXECUTION
+# (`start N`, label coursia-linux). Les deux jambes sont independantes : state
+# dirs distincts, sentinelles d'arret distinctes, prefixes de nom distincts.
+#
+# Deploiement ai-01 (2026-09-07, #14612/#14846) : copie de reference -- l'original
+# vit dans la distro Ubuntu de l'hote, sous /etc/systemd/system/.
+#
+# N slots porte par l'argument ExecStart (ai-01 -> 12, l'effectif d'avant la chute).
+[Unit]
+Description=CoursIA PR-gate waiter pool (coursia-waiter slots)
+# Wants= et non Requires= (meme raison que coursia-runner.service, #14347) :
+# un docker.service en echec au boot doit retarder le service et le laisser
+# retenter, pas le sortir de la liste des unites.
+Wants=docker.service
+After=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/coursia-waiters-start.sh 12
+ExecStop=/usr/local/bin/coursia-waiters-start.sh stop
+Restart=always
+RestartSec=30
+Nice=10
+# Un slot d'attente ne porte jamais de build long : 120 s suffisent la ou la
+# jambe d'execution demande 900 s pour laisser finir un lake build.
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #14560

See #14612 (partiel : ai-01 seulement) · See #14846

## Ce que cette PR livre

La jambe **`waiters`** du superviseur de runners (`supervise.sh waiters N`, label `coursia-waiter`) n'avait de persistance **sur aucune machine** — pas même une copie de référence dans `persist/`. Elle était lancée à la main dans une session et mourait avec elle. Cette PR touche 4 fichiers : les deux unités de persistance manquantes, jumelles exactes de celles qui existent déjà pour la jambe `start` —

| Fichier | Jumeau existant |
|---|---|
| `scripts/ci/docker/linux-runner/persist/coursia-waiters-start.sh` | `coursia-runner-start.sh` |
| `scripts/ci/docker/linux-runner/persist/coursia-waiters.service` | `coursia-runner.service` |

Plus la doc de déploiement (`docs/ci/self-hosted-runners.md`) et une règle `.gitattributes` (voir plus bas).

**Déployé et vérifié sur ai-01** (`systemctl enable --now coursia-waiters`) ; les fichiers du dépôt sont les copies de référence de ce qui tourne.

## Pourquoi maintenant — la mesure

Le check **`PR gate`** est le **seul check requis** sur `main`, et il tourne sur `runs-on: [self-hosted, coursia-waiter]` pour les PRs same-repo (#14586). Entre 00:06Z et 00:40Z le 2026-09-07, il a échoué **6 fois sur 6**, chaque fois par perte du runner :

| tête | runner | fenêtre | durée |
|---|---|---|---|
| ed58c1bc | po-2024-waiter-10 | 00:06:14 → 00:17:21 | ~11 min |
| 3d143bba | po-2024-waiter-8 | 00:07:13 → 00:17:14 | 10 min 01 s |
| c71df9c7 | po-2024-waiter-24 | 00:11:55 → 00:21:56 | 10 min 01 s |
| b5f0daf7 | po-2024-waiter-18 | 00:20:18 → 00:30:19 | 10 min 01 s |
| 89cfad22 | po-2024-waiter-19 | 00:20:07 → 00:30:08 | 10 min 01 s |
| d485a287 | po-2024-waiter-19 | 00:30:22 → 00:40:22 | 10 min 00 s |

Dernier vert avant la série : 23:37:52Z, **sur le même `waiter-19`, en 14 min 45 s** — ce qui exclut un plafond préexistant. `timeout-minutes: 52` dans `pr-gate.yml` exclut le timeout du workflow. Quatre conteneurs *distincts* mourant à la seconde près à la même durée est un événement d'hôte, pas une série de flakes réseau.

**Ce que cette PR corrige** : les six morts sont sur po-2024, et po-2024 était le **seul fournisseur du label** — les 12 waiters d'ai-01 étaient morts depuis 15:40Z la veille (zéro conteneur, 12 enregistrements `offline` fantômes), parce que rien ne les redémarrait. Un point unique de défaillance sur le seul check requis du dépôt : c'est exactement ce que #14612 nomme. La cause des morts elles-mêmes reste ouverte côté po-2024 (mesure transmise en DM ; discriminant timer-vs-OOM, les waiters étant plafonnés à 1 g).

## Acceptance — mesurée, pas déclarée

`systemctl is-active` rend `active` même si zéro conteneur s'enregistre. La seule réponse est le compte de runners `online` au registre GitHub :

```
GH_TOKEN=$(gh auth token --user jsboige --hostname github.com) \
  gh api "repos/jsboige/CoursIA/actions/runners?per_page=100" \
  --jq '[.runners[] | select((.name|startswith("myia-ai-01-linux-waiter")) and .status=="online")] | length'
```

Rendu **`12`** au moment de la rédaction (12 conteneurs `Up`, `busy=2` dans la minute). Deux pièges que cette commande évite et qui ont chacun produit une conclusion fausse pendant le diagnostic :

- **`per_page=100`** — le défaut de 30 cachait 29 des 59 runners du parc et faisait conclure que le pool de waiters était mort *sur toute la flotte*.
- **le jeton épinglé** — l'endpoint `actions/runners` rend `403` sous le jeton par défaut. Un 403 est une question, pas une mesure : le lire comme « 0 runner » inverse la vérité.

## STATE_DIR — pourquoi les deux jambes ne peuvent pas la partager

`supervise.sh` pose `STOP_FILE="$STATE_DIR/stop"` (l.41) et `cmd_waiters` refuse de démarrer tant que la sentinelle existe (l.432). Avec un `STATE_DIR` commun, un `systemctl stop coursia-runner` bloquerait silencieusement la jambe `waiters`. D'où `COURSIA_RUNNER_STATE_DIR=/var/lib/coursia-waiters`, distinct de celui de la jambe d'exécution.

## `.gitattributes` — `*.service text eol=lf`

`core.autocrlf=true` + aucune règle sur `*.service` : le fichier arrive en CRLF dans un arbre de travail Windows, et une unité systemd copiée telle quelle depuis là est cassée. Les deux blobs (`coursia-runner.service` déjà sur `main` et le nouveau) sont **déjà en LF** — la règle ne produit donc **aucun churn** (`git diff origin/main` sur l'existant : vide) ; elle rend l'invariant structurel au lieu de dépendre de l'heuristique d'autocrlf, exactement comme `*.sh text eol=lf` juste au-dessus.

## Ce que cette PR ne fait PAS

- Elle ne déploie rien sur po-2024, po-2023, po-2025, po-2026 — seuls les **fichiers de référence** partent ici, l'installation reste un geste par machine (documenté).
- Elle ne diagnostique pas la mort à 10 min sur po-2024. Cette cause-là est ouverte et suivie sur #14846.

