### PR TITLE
enrich(mgs,#1203): MGS-18-CecBanc lectures intermediaires -- densite 955 -> 1504 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
@@ -383,6 +383,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mi-a",
+   "metadata": {},
+   "source": [
+    "**Lecture du cablage CEC.** Les quatre evaluations du point de controle x=(1,2,3,4,5) valident l'instrument avant l'experimente : plain 9,6973, shifted 12,1977, rotated 10,7205, combined 13,0514. Trois observations.\n",
+    "\n",
+    "- Le decalage seul ajoute +2,500 a la valeur du point, la rotation seule +1,023. Sur Ackley, proche de l'origine, la rotation change peu la valeur — la fonction est quasi invariante en direction a rayon fixe — alors que le decalage (-0,11 ; -1,82 ; -0,17 ; 1,62 ; -1,31) eloigne l'optimum d'environ 2,77 unites (norme euclidienne du vecteur) du point de depart des optimiseurs. C'est le canal par lequel chaque variante mord : geometrie pour l'une, distance pour l'autre.\n",
+    "- Le combine (+3,354) est deja legerement sous la somme des deux effets isoles (+3,524) : premier indice de la sous-additivite que le §2 va mesurer systematiquement sur tout le portefeuille.\n",
+    "- La verification d'orthogonalite ||M·M^T - I||_F = 0,0000 garantit que la rotation est une vraie isometrie : tout ecart observe ensuite sur les variantes combinees sera attribuable au protocole, pas a une deformation numerique du decorateur.\n",
+    "\n",
+    "Pourquoi ce point de controle x=(1,2,3,4,5) ? C'est un sondage hors-axe, a composantes toutes distinctes et loin de l'origine : si deux variantes y rendaient la meme valeur, les decorateurs s'aliaseraient (par exemple une rotation identite ou un decalage nul) et la suite du banc mesurerait du bruit. Les quatre valeurs distinctes, plus l'orthogonalite a zero exact, font de cette cellule la preuve que le banc mesure ce qu'il pretend mesurer."
+   ]
+  },  {
+   "cell_type": "markdown",
    "id": "m3",
    "metadata": {},
    "source": [
@@ -649,6 +662,17 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mi-b",
+   "metadata": {},
+   "source": [
+    "**Lecture de l'interaction.** La colonne interaction = d_comb - (d_shift + d_rot) se lit en deux histoires distinctes.\n",
+    "\n",
+    "- **Les solveurs au plancher rendent la question vacante.** EO, FBI, DE et SA affichent des deltas ~0,000 sur les quatre variantes : ils resolvent chaque instance, donc il n'existe plus de biais a decomposer. L'additivite affichee est un artefact de plancher sur 3 seeds, pas une propriete demontrée — meme prudence que la lecture du banc Ackley ci-dessus.\n",
+    "- **Les autres sont tous sous-additifs (interaction <= 0).** Le pire cas combine coute systematiquement MOINS que la somme des variantes isolees. WOA est l'extreme : -1,748 — son biais d'ancre rotation (+1,198) s'evanouit presque dans le combine (+2,421 contre une somme de 4,169). Consequence pratique : evaluer shift et rotation separement SURTESTIME le degat du combine ; le protocole CEC complet n'est pas deux fois plus dur, il est autrement dur. L'interaction de Random (-1,057) releve du bruit d'echantillonnage d'un objectif moyen sur 3 seeds, pas d'une structure.\n",
+    "- **GA (-0,182) et BBPSO (-0,265) frisent l'additivite** et balisent la zone frontiere du verdict : leurs quatre colonnes se recomposent presque exactement, ce qui autorise l'extrapolation du combine depuis les variantes isolees — un privilege que WOA n'a pas. Le profil de BBPSO est d'ailleurs remarquable en lui-meme : cout de rotation exactement nul (d_rot = -0,000) mais cout de decalage plein (1,740) — insensible a la geometrie, sensible a la distance, le profil inverse de GA qui paie la rotation au prix fort."
+   ]
+  },  {
+   "cell_type": "markdown",
    "id": "m6",
    "metadata": {},
    "source": [
@@ -754,6 +778,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "mi-c",
+   "metadata": {},
+   "source": [
+    "**Lecture du banc Rosenbrock.** La vallee banane retrie les cartes par rapport a Ackley.\n",
+    "\n",
+    "- **GA paie la rotation au prix fort** (1,680 en plain -> 3,705 en rotated, +2,025) : une vallee etroite alignee sur les axes est precisement ce que la rotation brouille, et un croisement composante-par-composante ne peut pas re-aligner ses directions de recherche.\n",
+    "- **DE est covariant sous rotation** : il reste plat (1,584 -> 1,706) et ameliore meme en shifted (0,920). Ses vecteurs differentiels vivent dans l'espace des solutions — tourner l'espace tourne ses deplacements, c'est l'invariance structurelle que la these du fil predit pour un operateur vectoriel.\n",
+    "- **WOA confirme son ancre** : pire-cas combine 6,910, le biais identifie en MGS-16/17 se cumule au lieu de s'annuler.\n",
+    "- **FBI en shifted (1,528) fait mieux qu'en plain (2,324)**, et SA en rotated (1,067) fait mieux que son propre plain (1,719) : dans les deux cas le biais deplace l'optimum vers une region ou la dynamique converge mieux par chance. Ce sont des lectures mono-cellule sur 3 seeds — a signaler, pas a generaliser. La colonne qui decide est le pire-cas, pas la cellule favorable.\n",
+    "\n",
+    "L'exception EO merite son ligne : rotated 1,470 < plain 1,681 — EO profite lui aussi de la rotation sur cette fonction, mais son pire-cas combine (2,500) reste au-dessus de DE (1,498) : l'avantage ponctuel ne survit pas au passage au pire-cas, qui est la seule colonne que le protocole retient pour le verdict final."
+   ]
+  },  {
    "cell_type": "markdown",
    "id": "m7",
    "metadata": {},
@@ -881,6 +919,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "mi-d",
+   "metadata": {},
+   "source": [
+    "**Lecture de la synthese.** La question du bandeau (la these DE/SA vectoriels > EO/BBPSO > WOA ancre > GA composante tient-elle sous le combine ?) recoit une reponse nuancee : oui, par la colonne pire-cas, presque trait pour trait — DE 1,706 < SA 1,751 < FBI 2,743 ~ EO 2,781 < BBPSO 3,327 < GA 3,705 < WOA 6,910 << Random 14,393 — avec une inversion : WOA chute SOUS GA, l'ancre fait pire que la composante sur ce banc consolide.\n",
+    "\n",
+    "La colonne Ackley seule ne discriminait rien (plancher 0,000 pour EO/FBI/DE/SA) : c'est le pire-cas croise fonctions x variantes qui trie le portefeuille. Les verdicts a eviter suivent : Random trivialement, WOA parce que son biais d'ancre se compose au lieu de s'annuler. Formule honnete : le combine confirme l'ordre structurel, il ne le cree pas — c'est exactement ce qu'on attend d'un banc de robustesse.\n",
+    "\n",
+    "Aucun optimiseur ne sort dominateur des deux cotes du tableau : EO affiche 0,000 en pire-cas Ackley et 2,781 en pire-cas Rosenbrock — parfait sur l'un, moyen sur l'autre. C'est la raison d'etre du croisement CEC : chaque fonction isole un canal de faiblesse different (plancher de convergence pour Ackley, geometrie de la vallee pour Rosenbrock), et seul le max sur l'ensemble approche une lecture robuste. L'exercice 1 (Griewank) ajoutera la troisieme fonction exactement dans cet esprit. La regle de lecture reste celle du §2 : un avantage qui ne survit pas au pire-cas n est pas un avantage."
+   ]
+  },  {
    "cell_type": "markdown",
    "id": "m8",
    "metadata": {},


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-python #14973

## Summary

Tranche densité sur l'EPIC MetaGeneticSharp #1203 (veine MGS, famille Search) : `MGS-18-CecBanc.ipynb` passe **955 → 1504 c/cell** (md% 49,6 → 60,8) par l'ajout de **4 cellules markdown de lecture interprétative**, chacune ancrée sur les outputs committés de la cellule de code qu'elle suit immédiatement (règle cell-interpretation-ordering) :

- **mi-a** (après le câblage CEC, cell 5) : lecture du point de contrôle x=(1,2,3,4,5) — plain 9,6973 / shifted 12,1977 / rotated 10,7205 / combined 13,0514 ; canaux distincts des deux biais (géométrie vs distance, norme du décalage ≈ 2,77) ; premier indice de sous-additivité (+3,354 vs +3,524) ; pourquoi un sondage hors-axe à valeurs toutes distinctes valide l'instrument.
- **mi-b** (après la table d'interaction, cell 10) : les deux histoires de la colonne interaction — solveurs au plancher (EO/FBI/DE/SA, question vacante, artefact 3 seeds) vs sous-additivité systématique des autres (WOA −1,748) ; GA/BBPSO en frontière d'additivité ; profil inverse GA (paie la rotation) vs BBPSO (aveugle rotation, sensible décalage).
- **mi-c** (après le banc Rosenbrock, cell 12) : GA paie la rotation au prix fort (+2,025), covariation de DE sous rotation, ancre WOA confirmée, lectures mono-cellule favorables (FBI shifted 1,528, SA rotated 1,067) signalées comme chance sur 3 seeds — la colonne qui décide est le pire-cas.
- **mi-d** (après la table de synthèse, cell 14) : réponse nuancée à la question du bandeau — la these structurelle tient par le pire-cas croisé (DE 1,706 < SA 1,751 < FBI 2,743 ≈ EO 2,781 < BBPSO 3,327 < GA 3,705 < WOA 6,910) avec l'inversion WOA/GA ; pourquoi seule la colonne pire-cas discrimine (plancher Ackley 0,000) ; aucun dominateur cross-fonctions, raison d'être du croisement CEC.

## Validation

- **Markdown-only** : 0 cellule code modifiée (25 → 29 cellules, les 4 nouvelles sont markdown) → pas de re-exécution due (exception C.2 modifs uniquement markdown).
- **Byte-preservation** : sha256 par cellule avant/après — 25/25 cellules originales présentes à l'identique, 4 ajoutées, 0 perdue, 0 modifiée.
- **Densité** (`scripts/notebook_tools/pedagogy_density.py`, instrument canonique) : 955 → **1504** c/cell (prose 10 505 → 16 441 chars / 11 code cells), md% 60,8. `below_threshold: 0`.
- **Gap réel mesuré avant** : 4 sections (après cellules 5/10/12/14) portaient des outputs committés (14/11/11/12 sorties) sans aucune lecture ; le run ≥2 restant (cells 2-3) est le binôme setup câblage+chromosome préexistant, hors scope markdown-only (sa fusion modifierait des cellules code → re-exéc .NET hors tranche).
- **Ancrage C.4** : chaque valeur citée provient de l'output committé de la cellule précédente (vérifié avant rédaction) ; aucune valeur recalculée ni inventée.
- Guards : `detect_consecutive_code_cells.py` — inchangé vs base (max=2 runs=1, setup) ; aucun lien ajouté (renvois § en texte) ; pas de move de fichier.

See #1203
