### PR TITLE
enrich(ae,#11601): memoire-ephemere — densite 1201->1687, 4 lectures ancrees (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb
@@ -345,6 +345,38 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Le refId est le nom du fichier.** Regardez la paire rendue par\n",
+    "l'upload : l'URL se termine par `<refId>.txt` — le plugin ne fabrique\n",
+    "pas un second identifiant de stockage, il pose le fichier dans la\n",
+    "mediatheque sous SON identifiant public. Deux consequences de lecture :\n",
+    "\n",
+    "- **Le chemin est deterministe.** `wp-content/uploads/` + annee + mois\n",
+    "  + refId + extension d'origine. Qui connait le refId connait l'URL ;\n",
+    "  qui connait l'URL connait le refId — il y est litteralement ecrit.\n",
+    "  La protection de cette exposition (discutee juste apres) se reduit\n",
+    "  donc exactement au secret du refId : 32 caracteres hexadecimaux,\n",
+    "  imprevisibles en pratique, mais dont la *place* dans l'URL est connue\n",
+    "  de quiconque a deja vu un seul lien de ce plugin. Ce n'est pas un\n",
+    "  secret de conception, c'est un secret de tirage.\n",
+    "- **L'extension voyage avec le contenu.** Le fichier pose etait un\n",
+    "  `.txt`, l'URL sert un `.txt`. La mediatheque WordPress applique par\n",
+    "  ailleurs ses propres regles d'extension ; ce parcours n'a teste que\n",
+    "  du texte, et ce qu'un upload `.html` ou `.svg` deviendrait (servi\n",
+    "  tel quel ? refuse en amont ?) reste une question ouverte — non\n",
+    "  mesuree ici.\n",
+    "\n",
+    "Un dernier point, deduit du role du refId et non mesure dans ce run :\n",
+    "deux uploads du meme contenu recevront deux refIds differents, car\n",
+    "l'identifiant est tire au depot, pas calcule comme une empreinte du\n",
+    "contenu. Distinguer ce qui est prouve par les sorties de ce qui s'enonce\n",
+    "par raisonnement fait partie de la discipline de la serie."
+   ],
+   "id": "n3-refid-basename"
+  },
+  {
+   "cell_type": "markdown",
    "id": "a54bab65",
    "metadata": {},
    "source": [
@@ -426,6 +458,73 @@
     "maintenant_utc = datetime.now(timezone.utc).replace(tzinfo=None)\n",
     "print(\"expire a :\", (expire - maintenant_utc), \"de maintenant (UTC)\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Un id interne qui ne repart pas a zero.** La carte etait vide\n",
+    "(total 0, section 1), et la fiche rend `id : 4` — le compteur interne\n",
+    "de la table n'a jamais ete remis. Les ids 1 a 3 ont vecu : uploads de\n",
+    "runs anterieurs, effaces depuis. La memoire visible est vide, mais la\n",
+    "table, elle, compte encore. Trois lectures de cet ecart :\n",
+    "\n",
+    "- **La carte ment par omission.** Un `files/list` vide ne dit rien de\n",
+    "  l'activite passee de l'instance. Sur une instance que vous recevez,\n",
+    "  un premier fichier qui arrive a `id : 412` vous apprend qu'il y a eu\n",
+    "  de la vie avant vous — une information qu'aucune autre reponse de\n",
+    "  cette surface ne rend.\n",
+    "- **Le delete efface une fiche, pas une histoire.** Supprimer le\n",
+    "  fichier (section 6) rendra le total a zero, mais le prochain upload\n",
+    "  prendra l'id suivant — l'etat observable est restaurable, l'etat\n",
+    "  interne ne redescend jamais. Le mecanisme est constate ici par\n",
+    "  l'ecart 0/4 ; le prochain id, lui, est une deduction, pas une\n",
+    "  mesure de ce run.\n",
+    "- **Deux identites, une seule exposee.** La fiche porte `id` (interne,\n",
+    "  base de donnees) et `refId` (public, rendu a l'appelant — et, on l'a\n",
+    "  vu, nom du fichier servi). Les reponses d'upload ne rendent jamais\n",
+    "  l'id interne ; il faut la fiche complete pour croiser les deux.\n",
+    "\n",
+    "Deux champs de la fiche restent des constats isoles dans ce run :\n",
+    "`type : file` (une valeur unique observee — le champ suggere une\n",
+    "famille de ressources, la surface n'en montre pas d'autres) et\n",
+    "`status : uploaded` (l'etat a la creation ; le cycle de vie complet\n",
+    "n'est pas balaye par ce parcours). Les citer comme non mesures fait\n",
+    "partie du contrat d'honnetete de la serie."
+   ],
+   "id": "n1-compteur-ids"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Trois precautions de lecture du TTL.** La duree d'une heure est\n",
+    "verifiee par soustraction — mais la sortie elle-meme porte trois\n",
+    "details que cette verification ne couvre pas :\n",
+    "\n",
+    "1. **La fiche declare, elle n'execute pas.** `expires` est un champ\n",
+    "   ecrit a la creation. Rien dans ce run ne dit qui applique\n",
+    "   l'expiration ni quand : disparition a la seconde dite ? passage\n",
+    "   d'un nettoyage programme ? ou simple eviction de la liste, le\n",
+    "   fichier restant servi par son URL ? Ce notebook mesure\n",
+    "   l'intention declaree ; l'effectivite post-expiration serait une\n",
+    "   experience a part — attendre l'heure passee, puis re-tester\n",
+    "   `files/list` ET l'URL, deux sondes distinctes, car la liste et le\n",
+    "   service peuvent diverger.\n",
+    "2. **La fiche est une photographie, pas un chronometre.** « expire a :\n",
+    "   0:59:59.686609 de maintenant » : 0,31 seconde s'est deja ecoulee\n",
+    "   entre l'upload et la lecture de la fiche. Chaque relecture doit\n",
+    "   re-soustraire `expires - maintenant` ; copier ce temps restant dans\n",
+    "   un rapport le figera faux a la minute suivante.\n",
+    "3. **Les horodatages sont naifs.** `created` et `expires` sont des\n",
+    "   datetimes sans fuseau — compares a une heure locale, la\n",
+    "   soustraction rend des valeurs absurdes (un client UTC+2 qui\n",
+    "   soustrait son maintenant peut voir « -1 day, 22:59:59 »). Le\n",
+    "   « (UTC) » affiche par le helper est une convention du notebook,\n",
+    "   pas une information portee par la fiche : le consommateur de l'API\n",
+    "   doit savoir lui-meme dans quel fuseau il calcule."
+   ],
+   "id": "n2-bornes-ttl"
   },
   {
    "cell_type": "markdown",
@@ -587,6 +686,24 @@
     "statut, liste = api_files(session_editor, NONCE, \"list\")\n",
     "print(\"total final :\", liste.get(\"data\", {}).get(\"total\"))\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**L'etat initial retrouve — sauf le compteur.** La boucle est\n",
+    "fermee : `deleted : 1`, `total : 0` — et pourtant, par le mecanisme\n",
+    "constate plus haut, le prochain upload de cette instance prendra un id\n",
+    "superieur, pas l'id du fichier supprime. « Nettoyer » a donc deux\n",
+    "profondeurs : la carte visible, restauree (c'est ce que verifie la\n",
+    "discipline de cleanup de la serie), et la numerotation interne,\n",
+    "avancee d'un cran a chaque passage. Sur une instance de demonstration,\n",
+    "l'ecart est innocent ; pour auditer une instance partagee, il est\n",
+    "precisement le signal a savoir lire — le numero du prochain id dit\n",
+    "combien de fichiers ont vecu avant vous, meme quand la liste est vide\n",
+    "et que chaque reponse a dit success."
+   ],
+   "id": "n4-etat-vs-compteur"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #14551

Quoi: Enrichissement markdown-only du notebook `donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb` — round-2 densite (See #11601) : **1201 -> 1687 c/code-cell** a l'instrument canonique. 4 cellules markdown nouvelles, ancrees aux sorties commitees du run existant ; zero re-execution ; 11 cellules code byte-identiques. HEAD teste : `e04d7cdd6`.

Preuve:
```
pedagogy_density.py --json (worktree detache origin/main cd98e8a68) :
  density 1687 | prose 13211 -> 18562 | code_cells 11 | below_threshold 0
validate_pr_notebooks.py main <nb>     : 1/1 PASS (11 cells)
detect_md_content_loss --check         : findings=0 (md 12->16, chars 11025->15361)
check_notebook_navlinks                : 0 lien casse
detect_markdown_rendering --check      : 0 violation sur ce notebook
check_prose_quantitative_claims --diff : [OK] aucun compteur quantitatif en prose
pre-commit hooks au commit             : 9/9 Passed (gitleaks, H.3, #13326...)
```

Perimetre: **1 fichier** : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb` (117 insertions, 0 deletion).

Anti-Padding — les 4 angles ne paraphrasent aucune prose existante (verifies contre les 12 cellules md d'origine lues en entier) :
1. **refId = basename du fichier servi** : chemin `uploads/aaaa/mm/<refId>.<ext>` deterministe — le secret de l'URL se reduit exactement au refId. La prose existante parlait d'« obscurite de l'URL » sans la decomposer.
2. **`id : 4` sur une carte vide** : compteur monotone — la carte ment par omission, le delete efface une fiche pas une histoire, deux identites (id/refId) une seule exposee.
3. **Bornes du TTL** : la fiche declare sans executer (effectivite non mesuree), photographie a 0,31 s (`0:59:59.686609`), horodatages naifs sans fuseau (piege « -1 day, 22:59:59 » pour un client local).
4. **Etat observable restaure vs numerotation interne avancee** apres `deleted:1, total:0` — crantage du « etat initial retrouve exactement » de la prose existante.

Les deductions non mesurees sont etiquetees comme telles dans la prose (contrat d'honnetete de la serie : distinguer prouve par les sorties vs deduit par raisonnement).

Claim: paths-scoped pose AVANT edition — issuecomment-5563651240. Convention sans accents de la serie tenue (filet d'assert 0 accent dans le script d'enrichissement). Base : origin/main `cd98e8a68`, unique push.
