### PR TITLE
feat(ci,#14597): instrument Quarto render phase timings (post-render gap visibility)

### DIFF
--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -145,9 +145,23 @@ jobs:
         # .ipynb (execute.enabled: false) : ils sont RENDUS en HTML statique avec
         # echo:true (EPIC #10921, #10923) — code affiché + outputs déjà validés et
         # commités par les workers (règle C.2), sans kernel.
-        run: quarto render --to html
+        # #14597 : le pipeline horodate chaque ligne (builtin bash, zéro fork) et
+        # garde une copie pour le step "Report render phase timings" -- la phase
+        # post-rendu (assemblage du site : index de recherche sur 3122 pages,
+        # manifests) est muette dans le log, mesurable 2:56-15:09 selon le pool.
+        run: |
+          set -o pipefail
+          quarto render --to html 2>&1 \
+            | while IFS= read -r line; do printf '%(%H:%M:%S)T %s\n' -1 "$line"; done \
+            | tee render-timed.log
         # Pas de --execute : sinon ça tente de ré-exécuter les notebooks = impossible
         # sans kernels .NET Interactive / Lean 4 / conda Python spécialisés.
+
+      - name: Report render phase timings
+        # Mesure (#14597), pas une gate : exit 0 toujours, "not found" si un
+        # marqueur manque (changement de format de log Quarto = rapport dégradé,
+        # pas un build rouge). Ajoute le tableau de phases au job summary.
+        run: python scripts/quarto_render_timing.py render-timed.log
 
       - name: Restore kernel language (hygiene)
         # Le checkout CI est ephemere : le restore n'est pas indispensable, mais il
@@ -286,8 +300,21 @@ jobs:
         # `quarto render` SANS argument de fichier rend tout ce que la liste
         # porte : c'est pourquoi le mode `empty` saute le step au lieu de lancer
         # un rendu sur une liste vide, qui rendrait le site entier.
+        # Horodatage + tee comme le job `build` (#14597).
         if: steps.scope.outputs.mode != 'empty'
-        run: quarto render --to html
+        run: |
+          set -o pipefail
+          quarto render --to html 2>&1 \
+            | while IFS= read -r line; do printf '%(%H:%M:%S)T %s\n' -1 "$line"; done \
+            | tee render-timed.log
+
+      - name: Report render phase timings
+        # #14597 : en jambe PR, le rapport n'a de sens que sur un rendu COMPLET
+        # (mode full = config/theme/scripts touches) -- le cas exact qui tuait
+        # des runs a 53 min (#14225). Sur un rendu scope (1-2 documents), la
+        # phase post-rendu n'est pas representative et le rapport resterait muet.
+        if: steps.scope.outputs.mode == 'full'
+        run: python scripts/quarto_render_timing.py render-timed.log
 
       - name: Restore kernel language (hygiene)
         if: steps.scope.outputs.mode != 'empty'

--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -217,7 +217,7 @@ Pipeline d'audit qualité et de **matrice de coût** (EPIC #8056) + audit séman
 | **smartcontracts/** | 2 | validate_sc_notebooks.py |
 | **extract-titles (top-level)** | 4 | extract_pptx_titles.py, extract_slidev_titles.py, extract_titles.py, extract_readme_figures.py |
 | **ml/** | 1 | garch_baseline |
-| **autres (top-level + misc)** | 26 | check_docs_links, convert_print_to_deploy, regen_quarto_render, render_envs (secrets), scan_student_forks, series_progress_manager, update_navigation, validate_qc_projects, execute_sudoku_python, execute_qcpy_docker, translation_sync, translate_csv, detect_{ascii_workaround,blank_figures,svg_decimal_commas}, verify_{prosody,transcript}, audit_exposed_services, auth_manager, configure_max_quantization, container_startup, download_yfinance, manage_crypto_archive, notebook_tools_pure, repair_genai_notebooks, validation_dispatch |
+| **autres (top-level + misc)** | 27 | check_docs_links, convert_print_to_deploy, regen_quarto_render, quarto_render_timing (mesure phases #14597), render_envs (secrets), scan_student_forks, series_progress_manager, update_navigation, validate_qc_projects, execute_sudoku_python, execute_qcpy_docker, translation_sync, translate_csv, detect_{ascii_workaround,blank_figures,svg_decimal_commas}, verify_{prosody,transcript}, audit_exposed_services, auth_manager, configure_max_quantization, container_startup, download_yfinance, manage_crypto_archive, notebook_tools_pure, repair_genai_notebooks, validation_dispatch |
 
 Lancer la suite : `python -m pytest scripts/tests/ -v` (depuis la racine du repo).
 

--- a/scripts/quarto_render_timing.py
+++ b/scripts/quarto_render_timing.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Measure the phases of a ``quarto render`` run from a timestamped log.
+
+Why this exists
+---------------
+Forensics on issue #14597 (2026-09-07) found that a Quarto site build has a
+long SILENT phase between the last ``[N/M]`` document line and the
+``Output created: _site/index.html`` line -- measured 2:56-5:50 on po-2024
+docker runners and 11:27-15:09 on ai-01 docker runners, proportional to the
+corpus (1252+ documents). That gap is invisible in the job log unless someone
+manually diffs the raw-log timestamps of those two lines, which nobody does
+until a run has already starved its ``PR gate`` (#13510) or hit the 60-min
+ceiling (#14283).
+
+``quarto-pages-deploy.yml`` therefore pipes ``quarto render`` through a bash
+timestamping loop (``printf '%(%H:%M:%S)T'``) into ``render-timed.log``, and
+this script turns that log into a phase table appended to the job summary:
+
+- doc phase    : first timestamped line -> last ``[N/M]`` line
+- post-render  : last ``[N/M]`` line    -> ``Output created`` line
+                 (site assembly: search index over every page, manifests,
+                 copied resources -- no per-document progress is printed)
+- total        : first line -> ``Output created`` line
+
+This is a measurement, not a gate: the script always exits 0 and reports
+``not found`` for any marker absent from the log, so a Quarto log-format
+change degrades the report rather than breaking the build.
+
+Local usage
+-----------
+The same format is produced outside CI by::
+
+    quarto render --to html 2>&1 \
+      | awk '{ print strftime("%H:%M:%S"), $0; fflush() }' | tee render-timed.log
+    python scripts/quarto_render_timing.py render-timed.log
+
+(mawk lacks ``strftime``; gawk or the CI bash builtin loop are the portable
+options).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime
+
+TS_RE = re.compile(r"^(\d{2}:\d{2}:\d{2})\s?(.*)$")
+DOC_RE = re.compile(r"\[(\d+)/(\d+)\]")
+OUTPUT_RE = re.compile(r"Output created:\s*(\S+)")
+
+
+def _parse(ts: str) -> datetime:
+    return datetime.strptime(ts, "%H:%M:%S")
+
+
+def _fmt(delta: float) -> str:
+    if delta < 0:  # %H:%M:%S wraps at midnight; renders crossing it are sub-hour
+        delta += 86400
+    seconds = int(round(delta))
+    return f"{seconds // 60}:{seconds % 60:02d}"
+
+
+def analyse(lines: list[str]) -> dict[str, object]:
+    """Extract phase timestamps from timestamped render-log lines."""
+    events: list[tuple[datetime, str]] = []
+    for line in lines:
+        m = TS_RE.match(line.rstrip("\n"))
+        if m:
+            try:
+                events.append((_parse(m.group(1)), m.group(2)))
+            except ValueError:
+                continue
+    first_ts = events[0][0] if events else None
+    last_doc = None
+    doc_count = None
+    output_created = None
+    site_path = None
+    for ts, text in events:
+        m = DOC_RE.search(text)
+        if m:
+            last_doc = (ts, text.strip())
+            doc_count = int(m.group(2))
+        m = OUTPUT_RE.search(text)
+        if m and output_created is None:
+            output_created = (ts, text.strip())
+            site_path = m.group(1)
+    return {
+        "first": first_ts,
+        "last_doc": last_doc,
+        "doc_count": doc_count,
+        "output_created": output_created,
+        "site_path": site_path,
+        "n_lines": len(events),
+    }
+
+
+def render_report(r: dict[str, object]) -> str:
+    first = r["first"]
+    last_doc = r["last_doc"]
+    output_created = r["output_created"]
+    doc_count = r["doc_count"]
+
+    def phase(a, b):
+        if a is None or b is None:
+            return "not found"
+        return _fmt((b - a).total_seconds())
+
+    suffix = f" ({doc_count})" if doc_count else ""
+    lines = [
+        "### Quarto render phases (#14597)",
+        "",
+        "| phase | duration |",
+        "|-------|----------|",
+        f"| documents{suffix} | {phase(first, last_doc[0] if last_doc else None)} |",
+        f"| post-render (silent) | {phase(last_doc[0] if last_doc else None, output_created[0] if output_created else None)} |",
+        f"| total to `Output created` | {phase(first, output_created[0] if output_created else None)} |",
+    ]
+    if last_doc:
+        lines.append("")
+        lines.append(f"last document line: `{last_doc[1]}`")
+    if output_created:
+        lines.append(f"output: `{output_created[1]}`")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Report doc-phase vs post-render timings from a "
+                    "timestamped `quarto render` log (measurement, never a gate).")
+    ap.add_argument("log", help="path to the timestamped render log")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.log, encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError as exc:
+        print(f"quarto_render_timing: cannot read {args.log}: {exc}", file=sys.stderr)
+        return 0
+
+    report = render_report(analyse(lines))
+    print(report)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quarto_render_timing.py
+++ b/scripts/quarto_render_timing.py
@@ -46,8 +46,8 @@ import re
 import sys
 from datetime import datetime
 
-TS_RE = re.compile(r"^(\d{2}:\d{2}:\d{2})\s?(.*)$")
-DOC_RE = re.compile(r"\[(\d+)/(\d+)\]")
+TS_RE = re.compile(r"^(\d{2}:\d{2}:\d{2})\s?")
+DOC_RE = re.compile(r"\[\s*(\d+)\s*/\s*(\d+)\s*\]")
 OUTPUT_RE = re.compile(r"Output created:\s*(\S+)")
 
 
@@ -62,37 +62,58 @@ def _fmt(delta: float) -> str:
     return f"{seconds // 60}:{seconds % 60:02d}"
 
 
-def analyse(lines: list[str]) -> dict[str, object]:
-    """Extract phase timestamps from timestamped render-log lines."""
-    events: list[tuple[datetime, str]] = []
-    for line in lines:
-        m = TS_RE.match(line.rstrip("\n"))
-        if m:
-            try:
-                events.append((_parse(m.group(1)), m.group(2)))
-            except ValueError:
-                continue
-    first_ts = events[0][0] if events else None
+def _physical_lines(raw: str) -> list[list[str]]:
+    """Split raw log bytes into \\n-lines, each further split on \\r.
+
+    Quarto's document-progress lines are \\r-separated segments riding inside
+    one \\n-terminated line (ANSI color prefix, then ``\\r`` + one
+    ``[  N/M]`` per document). Python text mode would translate those ``\\r``
+    into newlines and divorce each progress segment from the line's timestamp
+    prefix, so the file is decoded manually and segments stay grouped with
+    their timestamp.
+    """
+    return [line.split("\r") for line in raw.split("\n")]
+
+
+def analyse(raw: str) -> dict[str, object]:
+    """Extract phase timestamps from a timestamped render log."""
+    first_ts = None
     last_doc = None
     doc_count = None
     output_created = None
     site_path = None
-    for ts, text in events:
-        m = DOC_RE.search(text)
-        if m:
-            last_doc = (ts, text.strip())
-            doc_count = int(m.group(2))
-        m = OUTPUT_RE.search(text)
-        if m and output_created is None:
-            output_created = (ts, text.strip())
-            site_path = m.group(1)
+    n_lines = 0
+    for segments in _physical_lines(raw):
+        ts = None
+        for seg in segments:
+            m = TS_RE.match(seg)
+            if m:
+                try:
+                    ts = _parse(m.group(1))
+                except ValueError:
+                    continue
+                break
+        if ts is None:
+            continue
+        if first_ts is None:
+            first_ts = ts
+        n_lines += 1
+        for seg in segments:
+            m = DOC_RE.search(seg)
+            if m:
+                last_doc = (ts, seg.strip())
+                doc_count = int(m.group(2))
+            m = OUTPUT_RE.search(seg)
+            if m and output_created is None:
+                output_created = (ts, seg.strip())
+                site_path = m.group(1)
     return {
         "first": first_ts,
         "last_doc": last_doc,
         "doc_count": doc_count,
         "output_created": output_created,
         "site_path": site_path,
-        "n_lines": len(events),
+        "n_lines": n_lines,
     }
 
 
@@ -133,13 +154,13 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     try:
-        with open(args.log, encoding="utf-8", errors="replace") as fh:
-            lines = fh.readlines()
+        with open(args.log, "rb") as fh:
+            raw = fh.read().decode("utf-8", errors="replace")
     except OSError as exc:
         print(f"quarto_render_timing: cannot read {args.log}: {exc}", file=sys.stderr)
         return 0
 
-    report = render_report(analyse(lines))
+    report = render_report(analyse(raw))
     print(report)
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary:

--- a/scripts/tests/test_quarto_render_timing.py
+++ b/scripts/tests/test_quarto_render_timing.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Tests for scripts/quarto_render_timing.py.
+
+The script is a measurement, not a gate (it always exits 0 -- a Quarto
+log-format change must degrade the report, never break a build). What must
+NOT drift is the parsing contract: the doc phase ends at the LAST ``[N/M]``
+line, the post-render gap ends at the FIRST ``Output created`` line, and a
+render crossing midnight must not produce a negative duration.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import quarto_render_timing as qrt  # noqa: E402
+
+
+LOG = [
+    "03:10:01 Preparing to render\n",
+    "03:11:00 [1/1252] MyIA.AI.Notebooks/a.ipynb\n",
+    "03:25:30 [1252/1252] README.md\n",
+    "03:38:17 Output created: _site/index.html\n",
+]
+
+
+def test_phases_split_at_last_doc_and_first_output():
+    r = qrt.analyse(LOG)
+    assert r["doc_count"] == 1252
+    assert r["site_path"] == "_site/index.html"
+    assert qrt._fmt((r["last_doc"][0] - r["first"]).total_seconds()) == "15:29"
+    assert qrt._fmt((r["output_created"][0] - r["last_doc"][0]).total_seconds()) == "12:47"
+    assert qrt._fmt((r["output_created"][0] - r["first"]).total_seconds()) == "28:16"
+
+
+def test_report_renders_table_and_not_found():
+    report = qrt.render_report(qrt.analyse(LOG))
+    assert "| documents (1252) | 15:29 |" in report
+    assert "| post-render (silent) | 12:47 |" in report
+    empty = qrt.render_report(qrt.analyse(["03:10:01 only one line\n"]))
+    assert "not found" in empty
+    assert "[1252/1252]" not in empty
+
+
+def test_midnight_rollover_is_positive():
+    r = qrt.analyse([
+        "23:58:00 [1/10] a.ipynb\n",
+        "00:04:30 Output created: _site/index.html\n",
+    ])
+    assert qrt._fmt((r["output_created"][0] - r["first"]).total_seconds()) == "6:30"
+
+
+def test_untimestamped_lines_are_ignored():
+    r = qrt.analyse(["no ts here\n", "03:00:00 [1/1] a.ipynb\n",
+                     "03:01:00 Output created: _site/index.html\n"])
+    assert r["n_lines"] == 2
+    assert r["doc_count"] == 1

--- a/scripts/tests/test_quarto_render_timing.py
+++ b/scripts/tests/test_quarto_render_timing.py
@@ -3,9 +3,18 @@
 
 The script is a measurement, not a gate (it always exits 0 -- a Quarto
 log-format change must degrade the report, never break a build). What must
-NOT drift is the parsing contract: the doc phase ends at the LAST ``[N/M]``
-line, the post-render gap ends at the FIRST ``Output created`` line, and a
-render crossing midnight must not produce a negative duration.
+NOT drift is the parsing contract, pinned against the REAL CI log format
+observed on run 34074565982 (2026-09-07):
+
+- document progress counters are SPACE-PADDED (``[   1/1265]``, width of M);
+- progress segments ride \\r-separated inside one \\n-terminated line, after
+  an ANSI color prefix (``\\x1b[1m\\x1b[34m\\r[ 586/1261] file\\x1b[39m``),
+  so the first CI render of the tool reported ``documents: not found`` --
+  text-mode ``readlines()`` split on those ``\\r`` and divorced every
+  progress segment from the line's timestamp prefix;
+- the doc phase ends at the LAST ``[N/M]`` segment, the post-render gap ends
+  at the FIRST ``Output created`` line;
+- a render crossing midnight must not produce a negative duration.
 """
 from __future__ import annotations
 
@@ -19,12 +28,20 @@ if str(SCRIPTS_DIR) not in sys.path:
 import quarto_render_timing as qrt  # noqa: E402
 
 
-LOG = [
-    "03:10:01 Preparing to render\n",
-    "03:11:00 [1/1252] MyIA.AI.Notebooks/a.ipynb\n",
-    "03:25:30 [1252/1252] README.md\n",
-    "03:38:17 Output created: _site/index.html\n",
-]
+LOG = (
+    "03:10:01 Preparing to render\n"
+    "03:11:00 [1/1252] MyIA.AI.Notebooks/a.ipynb\n"
+    "03:25:30 [1252/1252] README.md\n"
+    "03:38:17 Output created: _site/index.html\n"
+)
+
+# Format as observed on CI run 34074565982: ANSI prefix, \r, padded counters.
+CI_LOG = (
+    "02:01:10 \x1b[1m\x1b[34m\r[   1/1265] MyIA.AI.Notebooks/GameTheory/index.qmd\x1b[39m\x1b[22m\n"
+    "02:22:20 \x1b[1m\x1b[34m\r[1000/1265] Search/CSP-7.ipynb\x1b[39m\x1b[22m\n"
+    "02:28:37 \x1b[1m\x1b[34m\r[1265/1265] Tweety-7a.ipynb\x1b[39m\x1b[22m\n"
+    "02:32:54 Output created: _site/index.html\n"
+)
 
 
 def test_phases_split_at_last_doc_and_first_output():
@@ -36,25 +53,47 @@ def test_phases_split_at_last_doc_and_first_output():
     assert qrt._fmt((r["output_created"][0] - r["first"]).total_seconds()) == "28:16"
 
 
+def test_ci_format_padded_counters_and_cr_segments():
+    r = qrt.analyse(CI_LOG)
+    assert r["doc_count"] == 1265
+    assert "1265/1265" in r["last_doc"][1]
+    # 02:01:10 -> 02:28:37 docs, -> 02:32:54 output created
+    assert qrt._fmt((r["last_doc"][0] - r["first"]).total_seconds()) == "27:27"
+    assert qrt._fmt((r["output_created"][0] - r["last_doc"][0]).total_seconds()) == "4:17"
+    assert qrt._fmt((r["output_created"][0] - r["first"]).total_seconds()) == "31:44"
+
+
 def test_report_renders_table_and_not_found():
     report = qrt.render_report(qrt.analyse(LOG))
     assert "| documents (1252) | 15:29 |" in report
     assert "| post-render (silent) | 12:47 |" in report
-    empty = qrt.render_report(qrt.analyse(["03:10:01 only one line\n"]))
+    empty = qrt.render_report(qrt.analyse("03:10:01 only one line\n"))
     assert "not found" in empty
     assert "[1252/1252]" not in empty
 
 
 def test_midnight_rollover_is_positive():
-    r = qrt.analyse([
-        "23:58:00 [1/10] a.ipynb\n",
-        "00:04:30 Output created: _site/index.html\n",
-    ])
+    r = qrt.analyse(
+        "23:58:00 [1/10] a.ipynb\n"
+        "00:04:30 Output created: _site/index.html\n"
+    )
     assert qrt._fmt((r["output_created"][0] - r["first"]).total_seconds()) == "6:30"
 
 
 def test_untimestamped_lines_are_ignored():
-    r = qrt.analyse(["no ts here\n", "03:00:00 [1/1] a.ipynb\n",
-                     "03:01:00 Output created: _site/index.html\n"])
+    r = qrt.analyse(
+        "no ts here\n"
+        "03:00:00 [1/1] a.ipynb\n"
+        "03:01:00 Output created: _site/index.html\n"
+    )
     assert r["n_lines"] == 2
     assert r["doc_count"] == 1
+
+
+def test_cr_segment_without_timestamp_is_not_its_own_event():
+    # A \r-segment carrying content but no timestamp anywhere in its physical
+    # line must not create an event (the v1 bug: text mode made these lines
+    # timestamp-less events, losing every progress marker).
+    r = qrt.analyse("03:00:00 \x1b[1m\x1b[34m\r[  1/900] a.ipynb\x1b[39m\n03:09:00 Output created: _site/index.html\n")
+    assert r["doc_count"] == 900
+    assert qrt._fmt((r["output_created"][0] - r["last_doc"][0]).total_seconds()) == "9:00"


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #14967

See #14597 (tranche instrumentation — la cause est nommée séparément dans un commentaire d'issue avec l'A/B search off/on).

## Problème

La phase post-rendu d'un build Quarto (fenêtre muette entre la dernière ligne `[N/M]` et `Output created: _site/index.html`) a été mesurée à 2:56–5:50 sur les runners docker po-2024 et 11:27–15:09 sur ai-01 (5 runs, corpus ~1252 documents). Rien dans le log du job ne l'expose : la mesurer exige un diff manuel des timestamps du log brut — personne ne le fait avant qu'un run ait déjà affamé son `PR gate` (#13510) ou touché le plafond de 60 min (#14283).

## Ce que fait cette PR

Perimètre: 4 fichiers : .github/workflows/quarto-pages-deploy.yml, scripts/quarto_render_timing.py, scripts/tests/test_quarto_render_timing.py, docs/reference/scripts-reference.md

- **Workflow (les deux jambes)** : le rendu passe par un pipeline d'horodatage (`printf '%(%H:%M:%S)T'`, builtin bash, zéro fork) + `tee render-timed.log`. `set -o pipefail` préserve la propagation d'échec de `quarto render` à travers le pipeline.
- **Nouveau step "Report render phase timings"** : `scripts/quarto_render_timing.py` parse le log horodaté et ajoute au job summary un tableau documents / post-render (muette) / total. En jambe PR, il ne s'active qu'en scope mode `full` — le cas exact (config/theme/scripts touchés) qui tuait des runs à 53 min (#14225) ; en rendu scope le rapport serait non-représentatif.
- **Mesure, pas une gate** : le script sort toujours 0 et rend « not found » si un marqueur manque — un changement de format de log Quarto dégrade le rapport, jamais le build.
- **Tests** (4, verts) : split au dernier `[N/M]` et premier `Output created`, rollover minuit positif, lignes non-horodatées ignorées, rapport dégradé sans marqueur.

## Validation

- `python -m pytest scripts/tests/test_quarto_render_timing.py -q` → 4 passed.
- Log synthétique : documents 15:29 / post-render 12:47 / total 28:16 — conformes aux timestamps injectés.
- `yaml.safe_load` OK sur le workflow ; snippet bash testé (printf `%(..)T` : bash ≥ 4.2, runners Ubuntu = bash 5.x).
- Le snippet awk équivalent est documenté dans le docstring pour usage local hors CI (mawk manque de `strftime`).

La table des 5 runs mesurés + l'A/B (search off/on) et la cause nommée suivent en commentaire sur #14597 — cette PR ne fait que rendre la mesure durable sur chaque futur run.
