### PR TITLE
fix(rules): semantic-fleet a deux references, pas trois — la regle contredisait son propre paragraphe

### DIFF
--- a/.claude/rules/submodule-maintenance.md
+++ b/.claude/rules/submodule-maintenance.md
@@ -43,7 +43,17 @@ La référence de comparaison est la **branche déclarée** quand `.gitmodules` 
 
 **Ordre obligatoire** (déjà porté par le `CLAUDE.md` global) : commiter **dedans** d'abord, pousser, **puis** bumper le pointeur parent. Jamais l'inverse.
 
-**Un `branch =` dans `.gitmodules` n'est pas le gitlink.** `semantic-fleet` déclare `branch = stable-from-v0343` alors que son gitlink pointe ailleurs et que son `main` est ailleurs encore : **trois références divergentes** qui se lisent comme un seul état. Réconcilier explicitement avant de conclure quoi que ce soit sur le retard d'un sous-module.
+**Un `branch =` dans `.gitmodules` n'est pas la branche par défaut du dépôt distant.** `semantic-fleet` déclare `branch = stable-from-v0343`, et sa branche par défaut est `main` : **deux** références, pas trois. Mesure du 2026-09-07 :
+
+| Référence | SHA |
+|---|---|
+| gitlink sur `origin/main` | `9df360374e1c` |
+| tip de la branche déclarée `stable-from-v0343` | `9df360374e1c` — **identique** |
+| `HEAD` distant (branche par défaut `main`) | `168fd5d8bef5` |
+
+Le gitlink est **exactement sur sa branche déclarée**. C'est l'état *nominal* d'un sous-module épinglé, pas une dérive à réconcilier — et c'est précisément ce que le paragraphe ci-dessus établit depuis #14872 en nommant le faux positif permanent. La phrase que ces lignes remplacent disait l'inverse (« son gitlink pointe ailleurs », « trois références divergentes ») : elle envoyait le lecteur chercher une troisième divergence qui n'existe pas, et lui faisait lire comme un retard ce qui est le fonctionnement attendu.
+
+Ce qui reste vrai, et qui est le seul point à retenir : **`HEAD` distant n'est pas la référence de comparaison** quand un `branch =` est déclaré. Comparer le gitlink à `HEAD` fabrique une dérive. Comparer à `refs/heads/<branch déclarée>` mesure la vraie.
 
 ## Règle HARD 3 — l'absence de gate est le défaut, pas les PRs qui dorment
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/tooling #14981

## Le défaut

`.claude/rules/submodule-maintenance.md` R2 affirmait, sous un titre en gras :

> **Un `branch =` dans `.gitmodules` n'est pas le gitlink.** `semantic-fleet` déclare `branch = stable-from-v0343` alors que **son gitlink pointe ailleurs** et que son `main` est ailleurs encore : **trois références divergentes** qui se lisent comme un seul état.

Les deux affirmations en gras sont fausses. Mesure du **2026-09-07** :

| Référence | commande | SHA |
|---|---|---|
| gitlink sur `origin/main` | `git ls-tree origin/main <path>` | `9df360374e1c` |
| tip de la branche déclarée `stable-from-v0343` | `git ls-remote <url> refs/heads/stable-from-v0343` | `9df360374e1c` — **identique** |
| `HEAD` distant (branche par défaut `main`) | `git ls-remote <url> HEAD` | `168fd5d8bef5` |

Deux références, pas trois. Et le gitlink est **exactement sur sa branche déclarée** — l'état *nominal* d'un sous-module épinglé, pas une dérive à réconcilier.

## Ce qui rend le défaut sérieux : la règle se contredisait à deux paragraphes d'écart

Le paragraphe **immédiatement au-dessus** de la phrase corrigée établit déjà la bonne lecture, et depuis #14872 :

> `HEAD` résout la branche par défaut et déclare « DERIVE » un gitlink qui est exactement sur sa branche déclarée (**#14872 : faux positif permanent sur `semantic-fleet`**).

Un même fichier disait donc, en deux endroits, qu'il s'agit d'un faux positif permanent *et* de trois divergences réelles. La moitié fausse est celle qu'un lecteur pressé rencontre en premier : elle porte le titre en gras, elle nomme un sous-module, elle donne un chiffre. La phrase était un fossile de la compréhension d'avant #14872, restée après que le correctif ait été écrit juste au-dessus.

Le coût concret : un lecteur part chercher une **troisième** divergence qui n'existe pas, puis lit comme un retard ce qui est le fonctionnement attendu d'un pin.

## Le correctif

La phrase est remplacée par la table des trois SHA mesurés, la lecture correcte (état nominal), et le **seul point qui restait vrai** dans la phrase d'origine :

> `HEAD` distant n'est pas la référence de comparaison quand un `branch =` est déclaré. Comparer le gitlink à `HEAD` fabrique une dérive. Comparer à `refs/heads/<branche déclarée>` mesure la vraie.

Le titre en gras est reformulé en conséquence : « Un `branch =` dans `.gitmodules` n'est pas **la branche par défaut du dépôt distant** » — ce qui est l'énoncé exact, là où « n'est pas le gitlink » suggérait une divergence entre les deux.

Conforme au principe *No Pendulum* du `CLAUDE.md` global : la ligne fautive est **retirée**, et n'est remplacée que là où le retrait laissait un trou réel (le point sur la référence de comparaison, qui n'est redit nulle part ailleurs sous cette forme).

## Note de méthode, et elle s'applique à ce commit même

J'avais annoncé ce résidu comme étant à la **ligne 41** (DM `msg-20260907T033858-hjwg6n` à po-2023). Il est à la **ligne 46** : le fichier a grossi entre l'annonce et la correction. C'est exactement le mécanisme que #2874 documente en tête de son propre corps — « une ligne citée ne se vérifie que le jour où on la lit ». Le numéro de ligne n'apparaît donc pas dans le texte corrigé ; l'ancre est la phrase.

Ce résidu était le mien : je l'avais d'abord annoncé comme un dispatch po-2023, puis retiré de leur budget LIGHT pour le porter moi-même. C'est fait.

## Vérification

- Ancre unique avant remplacement (`assert s.count(old) == 1`), échec sinon.
- Les trois SHA sont re-mesurés au moment du commit, pas recopiés du diagnostic initial.
- Aucun autre fichier touché.

See #2874
