### PR TITLE
fix(prover,#1453): calibration stub sorry_replacement au lanceur sous-répertoire

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -6,6 +6,12 @@ Usage:
     python run_prover_bg.py --file path/to.lean --line 563 --mode autonomous --iterations 8
 
 Supports both demo-based (from prover/__init__.py DEMOS) and direct file/line targeting.
+
+Signal lines (same tokens as the root agent_tests/run_prover_bg.py launcher):
+    [CALIBRATION_STUB] theorem=<name> line=<n>   (#1453 sorry_replacement
+                     target: approved proof stubbed in place, original
+                     restored on exit — paired with [CALIBRATION_RESTORE])
+    [CALIBRATION_RESTORE] approved proof restored
 """
 import argparse
 import asyncio
@@ -24,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from prover import DEMOS, PROVED_DEMOS, TraceLogger
 from prover.provers import MultiAgentSorryProver, AutonomousProver
 from prover.config import create_client
-from prover.lean_utils import count_real_sorries
+from prover.lean_utils import count_real_sorries, stub_theorem_proof
 from prover.tree_lock import (
     acquire_tree_lock,
     find_lean_project_root,
@@ -33,6 +39,16 @@ from prover.tree_lock import (
 
 TRACES_DIR = Path(__file__).parent / "traces"
 TRACES_DIR.mkdir(exist_ok=True)
+
+
+def _peek_sorry_count(filepath: str) -> int:
+    # Same contract as the root launcher: count REAL sorry tokens
+    # (comment-stripped, word-bounded, #9402) from the file on disk; -1 on
+    # read failure so callers comparing `== 0` never stub an unreadable file.
+    try:
+        return count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
+    except OSError:
+        return -1
 
 
 def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
@@ -266,13 +282,68 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         return {"name": name, "result_kind": "locked", "reason": lock_msg}
     print(f"[TREE_LOCK] {lock_path}")
     try:
-        return _run_prover_locked(
+        return _run_with_calibration_stub(
             demo, name, filepath, line, mode, iterations, provider,
             local_provider, director_provider, coordinator_provider,
             tactic_provider, use_diagnosis_agent, concurrent_search_count,
         )
     finally:
         release_tree_lock(lock_path)
+
+
+def _run_with_calibration_stub(demo, name, filepath, line, mode, iterations,
+                               provider, local_provider, director_provider,
+                               coordinator_provider, tactic_provider,
+                               use_diagnosis_agent, concurrent_search_count):
+    """Run body under the tree lock, with #1453 calibration preparation.
+
+    Port of the root launcher mechanism (#13907, agent_tests/run_prover_bg.py
+    ``_run_locked``): a DEMO declaring ``sorry_type: sorry_replacement``
+    targets scaffolding committed WITH its approved proof — that proof is the
+    ground truth the prover must reproduce, not a state to keep. Without this
+    step, ``_run_prover_locked``'s pre-flight counts 0 real sorry and returns
+    a false ``already_solved`` in seconds: the Conway calibration gradient
+    (DEMOS 39-52) was dead-on-arrival through THIS launcher on demo 39
+    (#1453).
+
+    The stub is written in place BEFORE the pre-flight/spawn (0 -> 1 sorry)
+    and the original bytes are restored in ``finally`` — bytes I/O, no
+    newline translation — so the restore survives any exception path. The
+    tree lock held by the caller already serialises in-place mutation
+    (#6790). A ``stub_theorem_proof`` failure (unknown declaration, no ``:=``)
+    raises BEFORE any write: a calibration run must fail loud rather than
+    stub the wrong region.
+    """
+    calibration_target = None
+    if (
+        demo.get("sorry_type") == "sorry_replacement"
+        and demo.get("file")
+        and demo.get("theorem_name")
+        and _peek_sorry_count(demo["file"]) == 0
+    ):
+        target_path = Path(demo["file"])
+        original = target_path.read_bytes()
+        stubbed = stub_theorem_proof(
+            original.decode("utf-8"), demo["theorem_name"]
+        )
+        target_path.write_bytes(stubbed.encode("utf-8"))
+        calibration_target = (target_path, original)
+        print(
+            f"[CALIBRATION_STUB] theorem={demo['theorem_name']} "
+            f"line={demo.get('line')} - approved proof stubbed to sorry, "
+            f"original restored on exit"
+        )
+
+    try:
+        return _run_prover_locked(
+            demo, name, filepath, line, mode, iterations, provider,
+            local_provider, director_provider, coordinator_provider,
+            tactic_provider, use_diagnosis_agent, concurrent_search_count,
+        )
+    finally:
+        if calibration_target is not None:
+            calibration_target[0].write_bytes(calibration_target[1])
+            print("[CALIBRATION_RESTORE] approved proof restored")
 
 
 def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_subdir_launcher_calibration.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_subdir_launcher_calibration.py
@@ -1,0 +1,270 @@
+"""Tests for the #1453 calibration stub in the INNER launcher
+(prover/run_prover_bg.py).
+
+Forensic (#1453, measured on demo 39): a ``sorry_type: sorry_replacement``
+DEMO targets scaffolding committed WITH its approved proof, so the inner
+launcher's dynamic pre-check counted 0 real sorry and returned a FALSE
+``already_solved`` — the Conway calibration gradient (DEMOS 39-52) was
+dead-on-arrival through this launcher. The fix ports the root-launcher
+mechanism (#13907, agent_tests/run_prover_bg.py ``_run_locked``): stub the
+approved proof to ``sorry`` in place (0 -> 1 before preflight/spawn), run
+under the tree lock, restore the original BYTES in ``finally``.
+
+All tests are offline — MultiAgentSorryProver is replaced by a recording
+fake (the LLM boundary), so no provider key is needed. The fixture is
+EMBEDDED for the same reason as tests/test_calibration_stub.py: a live
+prover run stubs the real Nim.lean in place and a test reading it races
+the run.
+
+Run from `agent_tests/`:
+    python -m pytest tests/test_subdir_launcher_calibration.py -q
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# The launcher import chain pulls the prover LLM stack
+# (agent_framework / agent_framework_openai) — skip cleanly off-stack, same
+# pattern as tests/test_bg_tree_lock.py.
+_LLM_STACK = "agent_framework"
+
+# Make `prover/` importable regardless of how pytest was invoked.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+DEMO_ID = 39  # the false-already_solved forensic demo
+
+# DEMO39-like shape (conway_lean/Conway/Nim.lean): approved proofs, ZERO real
+# sorry token — the committed state the calibration targets start from.
+NIM_LIKE = """\
+/-
+  Fixture DEMO39-like : cible de calibration committed avec sa preuve approuvee.
+-/
+import Mathlib.Data.List.Basic
+
+namespace Conway
+/-- Le nim-sum d'une position : XOR-fold des tailles de tas. -/
+def nimSum (heaps : List Nat) : Nat :=
+  heaps.foldl (· ^^^ ·) 0
+
+/-- Une position de Nim est gagnante pour le premier joueur ssi son nim-sum est non nul. -/
+def isWinningNim (heaps : List Nat) : Bool :=
+  nimSum heaps != 0
+
+/-- Ancre prouvee : la position vide a un nim-sum nul. -/
+theorem nimSum_nil : nimSum [] = 0 := rfl
+
+/-- CALIBRATION (decide) : la position [3,4,5] est gagnante pour le premier joueur. -/
+theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by
+  decide
+
+/-- CALIBRATION (unfold + zero_xor) : un tas unique a un nim-sum egal a sa taille. -/
+theorem nimSum_single (n : Nat) : nimSum [n] = n := by
+  simp [nimSum, Nat.xor_zero]
+
+end Conway
+"""
+
+
+def _load():
+    """Import the launcher behind the LLM-stack guard."""
+    pytest.importorskip(_LLM_STACK, reason="prover LLM stack absent (bare CI)")
+    import prover.run_prover_bg as launcher
+    from prover.lean_utils import count_real_sorries, stub_theorem_proof
+
+    return launcher, count_real_sorries, stub_theorem_proof
+
+
+def _make_setup(tmp_path, source):
+    """Write a DEMO39-like target + lakefile in tmp_path, return (demo, path)."""
+    target = tmp_path / "Nim.lean"
+    # newline="\n": stub_theorem_proof hardcodes an LF stub line — keep the
+    # whole fixture LF so byte comparisons stay deterministic.
+    target.write_text(source, encoding="utf-8", newline="\n")
+    (tmp_path / "lakefile.lean").write_text("-- lake", encoding="utf-8")
+    demo = {
+        "name": "CALIBRATION_CONWAY_NIM_WINNING_345",
+        "file": str(target),
+        "line": 22,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "isWinningNim_345",
+        "description": "Calibration: position [3,4,5] is a first-player win.",
+        "difficulty": "easy",
+    }
+    return demo, target
+
+
+def _patch_fake_prover(monkeypatch, prove_behavior=None, init_raises=None):
+    """Replace launcher MultiAgentSorryProver with an offline recording fake.
+
+    The prover class is the LLM boundary: patching it keeps every test
+    key-free while the launcher's stub -> preflight -> spawn -> restore
+    lifecycle runs for real.
+    """
+    launcher, count_real_sorries, _ = _load()
+    calls = {"constructed": 0, "spawn_sorry_counts": [], "spawn_bytes": []}
+
+    class _FakeProver:
+        def __init__(self, **kwargs):
+            calls["constructed"] += 1
+            if init_raises is not None:
+                raise init_raises
+
+        async def prove_sorry(self, demo=None, max_iterations=8, **kwargs):
+            raw = Path(demo["file"]).read_bytes()
+            calls["spawn_bytes"].append(raw)
+            calls["spawn_sorry_counts"].append(
+                count_real_sorries(raw.decode("utf-8"))
+            )
+            if prove_behavior is not None:
+                return prove_behavior(demo)
+            return {"success": True, "iterations": 1}
+
+    monkeypatch.setattr(launcher, "MultiAgentSorryProver", _FakeProver)
+    return calls
+
+
+def _run(monkeypatch, tmp_path, demo):
+    """Run the inner launcher on the fake DEMO_ID, hermetically."""
+    launcher, _, _ = _load()
+    monkeypatch.setattr(launcher, "DEMOS", {DEMO_ID: demo})
+    monkeypatch.setattr(launcher, "PROVED_DEMOS", set())
+    traces = tmp_path / "traces"
+    traces.mkdir(exist_ok=True)
+    monkeypatch.setattr(launcher, "TRACES_DIR", traces)
+    return launcher.run_prover(demo_num=DEMO_ID, mode="multi", iterations=1)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The fix: sorry_replacement + clean target -> stub, run, restore
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_calibration_stub_runs_prover_and_restores(tmp_path, monkeypatch, capsys):
+    """DEMO39-like with approved proof: stub 0->1 BEFORE preflight/spawn,
+    no false already_solved, original bytes restored exactly after."""
+    demo, target = _make_setup(tmp_path, NIM_LIKE)
+    original_bytes = target.read_bytes()
+    original_sha = hashlib.sha256(original_bytes).hexdigest()
+
+    def _reprove(demo):
+        # The "prover" reproduces the approved proof: replaces the stub with
+        # a decide proof (bytes-level, no newline translation).
+        p = Path(demo["file"])
+        p.write_bytes(
+            p.read_bytes().replace(
+                b"= true := by sorry", b"= true := by\n  decide", 1
+            )
+        )
+        return {"success": True, "iterations": 1}
+
+    calls = _patch_fake_prover(monkeypatch, prove_behavior=_reprove)
+    summary = _run(monkeypatch, tmp_path, demo)
+
+    # Not the false already_solved: the preflight saw the STUBBED state.
+    assert summary["result_kind"] != "already_solved"
+    assert summary["result_kind"] == "sorry_decreased"
+    assert summary["original_sorry"] == 1  # 0 -> 1 before the preflight
+    assert summary["final_sorry"] == 0
+    # The spawn itself saw exactly one sorry on disk (and the stubbed file,
+    # not the approved original).
+    assert calls["constructed"] == 1
+    assert calls["spawn_sorry_counts"] == [1]
+    assert b":= by sorry" in calls["spawn_bytes"][0]
+    assert calls["spawn_bytes"][0] != original_bytes
+    # Same signal tokens as the root launcher (#13907).
+    out = capsys.readouterr().out
+    assert "[CALIBRATION_STUB] theorem=isWinningNim_345" in out
+    assert "[CALIBRATION_RESTORE] approved proof restored" in out
+    # Original approved proof restored byte-exact (sha included).
+    assert target.read_bytes() == original_bytes
+    assert hashlib.sha256(target.read_bytes()).hexdigest() == original_sha
+
+
+def test_calibration_restore_survives_exception(tmp_path, monkeypatch, capsys):
+    """An exception anywhere in the locked run body still restores the
+    original bytes — the restore lives in a finally, not on the happy path."""
+    demo, target = _make_setup(tmp_path, NIM_LIKE)
+    original_bytes = target.read_bytes()
+
+    # Constructor raise escapes _run_prover_locked's internal try (which only
+    # wraps prove_sorry), exercising the wrapper's finally directly.
+    _patch_fake_prover(
+        monkeypatch, init_raises=RuntimeError("provider stack blew up")
+    )
+    with pytest.raises(RuntimeError, match="provider stack blew up"):
+        _run(monkeypatch, tmp_path, demo)
+
+    assert target.read_bytes() == original_bytes
+    out = capsys.readouterr().out
+    assert "[CALIBRATION_STUB] theorem=isWinningNim_345" in out
+    assert "[CALIBRATION_RESTORE] approved proof restored" in out
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The guards: no stub outside the sorry_replacement + 0-sorry condition
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_clean_target_outside_calibration_keeps_skip(tmp_path, monkeypatch, capsys):
+    """A full_proof DEMO on a clean file keeps the honest already_solved
+    skip — only sorry_replacement stubs."""
+    demo, target = _make_setup(tmp_path, NIM_LIKE)
+    demo["sorry_type"] = "full_proof"
+    original_bytes = target.read_bytes()
+
+    calls = _patch_fake_prover(monkeypatch)
+    summary = _run(monkeypatch, tmp_path, demo)
+
+    assert summary["result_kind"] == "already_solved"
+    assert calls["constructed"] == 0  # skip: no prover spawned
+    out = capsys.readouterr().out
+    assert "CALIBRATION_STUB" not in out
+    assert "CALIBRATION_RESTORE" not in out
+    assert target.read_bytes() == original_bytes
+
+
+def test_demo_without_sorry_type_never_stubs(tmp_path, monkeypatch, capsys):
+    """A DEMO dict with NO sorry_type key (the direct --file/--line shape)
+    never stubs — the calibration only applies to declared targets."""
+    demo, target = _make_setup(tmp_path, NIM_LIKE)
+    demo.pop("sorry_type", None)
+    original_bytes = target.read_bytes()
+
+    calls = _patch_fake_prover(monkeypatch)
+    summary = _run(monkeypatch, tmp_path, demo)
+
+    assert summary["result_kind"] == "already_solved"
+    assert calls["constructed"] == 0
+    out = capsys.readouterr().out
+    assert "CALIBRATION_STUB" not in out
+    assert "CALIBRATION_RESTORE" not in out
+    assert target.read_bytes() == original_bytes
+
+
+def test_sorry_replacement_with_live_sorry_no_stub(tmp_path, monkeypatch, capsys):
+    """sorry_replacement target whose file ALREADY carries a real sorry: the
+    stub condition (count == 0) is False — run proceeds on the real locus,
+    the launcher never rewrites the file."""
+    _, _, stub_theorem_proof = _load()
+    pre_stubbed = stub_theorem_proof(NIM_LIKE, "isWinningNim_345")
+    demo, target = _make_setup(tmp_path, pre_stubbed)
+    original_bytes = target.read_bytes()
+
+    calls = _patch_fake_prover(monkeypatch)  # no-op prover
+    summary = _run(monkeypatch, tmp_path, demo)
+
+    assert summary["result_kind"] != "already_solved"
+    assert calls["spawn_sorry_counts"] == [1]
+    # The spawn saw the file untouched (no stub write, no restore).
+    assert calls["spawn_bytes"] == [original_bytes]
+    out = capsys.readouterr().out
+    assert "CALIBRATION_STUB" not in out
+    assert "CALIBRATION_RESTORE" not in out
+    assert target.read_bytes() == original_bytes


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #14937

See #1453 — claim: https://github.com/jsboige/CoursIA/issues/1453#issuecomment-5565054352

## Défaut

`agent_tests/prover/run_prover_bg.py` accepte la DEMO 39 mais ignore `demo['sorry_type']` : son pre-check dynamique `original_sorry == 0` (P3) retourne un **faux `already_solved`** sur les cibles de calibration committées AVEC leur preuve approuvée — le gradient Conway (DEMOS 39-52) était dead-on-arrival via ce lanceur.

## Fix — port du mécanisme éprouvé #13907 (lanceur racine)

`_run_with_calibration_stub` (nouveau wrapper, appelé sous le tree lock existant) :

- pour `sorry_type: sorry_replacement` avec `file` + `theorem_name` et **0 sorry réel** (`_peek_sorry_count`, mêmes sémantiques que le lanceur racine) :
  - sauvegarde des bytes originaux, application de `stub_theorem_proof` (**0 -> 1 avant preflight/spawn**), signal `[CALIBRATION_STUB]` ;
  - exécution du corps original (`_run_prover_locked`) sous le lock existant (#6790) ;
  - **restauration des bytes dans `finally`** + signal `[CALIBRATION_RESTORE]` — survit à toute exception (le test le prouve via un constructeur prover qui raise).
- Bytes I/O partout (pas de translation de newline) ; `stub_theorem_proof` raise AVANT toute écriture si la déclaration est introuvable (échec bruyant, jamais un stub de la mauvaise région).

Gardes conservées :
- cible propre **hors calibration** (`full_proof` ou sans clé `sorry_type`, y compris le mode `--file/--line`) : le skip honnête `already_solved` est conservé, pas de stub ;
- `sorry_replacement` sur un fichier portant **déjà** un sorry : pas de stub (la condition `== 0` est fausse), le run attaque le vrai locus.

## Scope

1. `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py` (+73/−2)
2. `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_subdir_launcher_calibration.py` (nouveau, 5 tests)

`agent_tests/multi_agent_proof.py` inspecté : **hors défaut** (aucun bloc `original_sorry == 0 -> already_solved` ; sa seule sortie 0-sorry est le « No sorry found » honnête du mode `--lean` opérateur) — non modifié.

## Tests (offline, aucune clé/provider — `MultiAgentSorryProver` patché au boundary LLM)

Fixture DEMO39-like embarquée (preuve approuvée `decide`, 0 sorry réel committé).

| Test | Ce qu'il verrouille |
|---|---|
| `test_calibration_stub_runs_prover_and_restores` | 0->1 avant preflight/spawn (`original_sorry == 1`, spawn voit exactement 1 sorry + `:= by sorry` sur disque), `result_kind == "sorry_decreased"` (≠ `already_solved`), signaux STUB/RESTORE, restore **bytes + SHA exacts** |
| `test_calibration_restore_survives_exception` | exception dans le corps locké -> restore bytes exact quand même |
| `test_clean_target_outside_calibration_keeps_skip` | `full_proof` sur fichier propre -> skip `already_solved` conservé, 0 spawn |
| `test_demo_without_sorry_type_never_stubs` | DEMO sans `sorry_type` -> pas de stub |
| `test_sorry_replacement_with_live_sorry_no_stub` | sorry déjà présent -> pas de stub, spawn voit le fichier intact |

## Validation

```
python -m pytest tests/test_subdir_launcher_calibration.py -q
-> 5 passed in 0.99s

python -m pytest tests/ -q        (suite complète agent_tests)
-> 751 passed in 4.63s
```

Aucun fichier `.lean` modifié (fixture embarquée en tmp_path ; `TRACES_DIR` monkeypatché) — pas de `lake build` dû.
