### PR TITLE
fix(gitattributes,#11698): qc-research-seeded.json en LF -- 874+/868- pour un seul ID ajoute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,14 @@
 # comparison is platform-independent (issue #1056). Limited to the exact files
 # the check reads, to avoid a wide renormalization of unrelated .md files.
 COURSE_CATALOG.generated.json text eol=lf
+# Meme motif pour l'etat de dedup du monitor qc-research (#11698) : le fichier est
+# reecrit par `qc-research-monitor.yml` (runner Linux, donc LF) alors que le blob sur
+# main est en CRLF. Mesure sur la PR #14994 : UNE entree ajoutee (`21195`, 144 -> 145,
+# zero retrait, zero valeur modifiee, ordre preserve) rend un diff de 874+/868- --
+# les 868 lignes different toutes par leur seule fin de ligne. Le body de la PR
+# demande au reviewer de refuser "si le diff touche autre chose" : sans cette regle,
+# ce critere est illisible a chaque run. Meme remede que le catalogue ci-dessus.
+docs/qc/qc-research-seeded.json text eol=lf
 # Notebooks Markdown : la regle precedente `MyIA.AI.Notebooks/*/README.md` ne
 # matchait qu'1 niveau de profondeur et ratait 296 READMEs profonds (cf #14570).
 # `**` matche profondeur arbitraire et remplace les 2 lignes en une seule, plus


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-ai-01:CoursIA — prev: LIGHT/docs #14993

See #11698, #10136.

## Le fait mesuré

La PR véhicule #14994 (`chore/qc-research-state-pending`, bot-owned) ajoute **une** entrée au dict `seeded` et rend un diff de **874+/868−**.

Diff sémantique, mesuré en chargeant les deux blobs :

| | valeur |
|---|---|
| entrées `seeded` | 144 -> **145** |
| ajouts | **1** (`21195`) |
| retraits | 0 |
| valeurs modifiées | 0 |
| ordre des clés | préservé |

Cause : `main` porte le blob en **CRLF** (868 lignes, 868 CR), le monitor l'écrit depuis un runner Linux en **LF**. Les 868 lignes diffèrent donc toutes, par leur seule fin de ligne.

## Pourquoi ça compte au-delà de l'esthétique

Le body du véhicule donne au reviewer un critère explicite :

> « uniquement des IDs d'articles ajoutés au dict `seeded` [...] Si le diff touche autre chose, ne pas merger »

Sans normalisation, **ce critère est inapplicable à l'œil** : chaque run présente un diff qui touche tout le fichier. Le reviewer doit soit charger les deux JSON et les comparer par clé (ce que j'ai dû faire ici), soit merger sur la foi du titre — c'est-à-dire renoncer au garde-fou que le body pose lui-même.

## Le correctif

Une ligne, **exactement le motif déjà appliqué au véhicule catalogue** trois lignes plus haut dans le même fichier :

```
COURSE_CATALOG.generated.json text eol=lf     <- deja la, meme rationale (#1056)
docs/qc/qc-research-seeded.json text eol=lf   <- ajoutee ici
```

Le commentaire qui l'accompagne cite la mesure, pour que la prochaine lane n'ait pas à la refaire.

## Contrôle positif

L'attribut ne résolvait rien avant, et résout après :

```
# avant
$ git check-attr -a docs/qc/qc-research-seeded.json
(aucune sortie)

# apres
$ git check-attr -a docs/qc/qc-research-seeded.json
docs/qc/qc-research-seeded.json: text: set
docs/qc/qc-research-seeded.json: eol: lf
```

## Ce que cette PR ne fait PAS

- Elle **ne touche pas** au véhicule #14994 (branche bot-owned, re-enracinée à chaque run — `catalog-pr-hygiene.md`).
- Elle **ne renormalise pas** le blob : c'est le prochain écrivain qui le fera, et le diff de renormalisation sera alors le sien, isolé et lisible.
- Elle ne traite pas les 8 autres fichiers CRLF de `docs/qc/` : ce sont des `.md` édités à la main, pas des artefacts générés lus par un check. La règle vise la classe « artefact généré comparé octet à octet », pas la normalisation large du répertoire.

## G-VAR-2 — cap atteint, PR volontairement tenue

`variation_light_cap.py` mesuré sur les 21 PRs mergées du 2026-09-07 :

```json
{"lane": "myia-ai-01:CoursIA", "tally": {"lane_grains": 2, "light_declared": 1, "cap": 1}}
```

Ma lane a **déjà dépensé son budget LIGHT du jour** (#14993, `LIGHT/docs`, mergée à 04:09Z). Ce grain est LIGHT au litmus — je pourrais en générer d'autres en scannant les artefacts générés voisins.

**Je ne la merge donc pas aujourd'hui.** Je détiens l'override de coordinateur ; m'en servir pour lever mon propre garde en ferait une décoration. Elle attend demain, ou une lane qui la reprend — et le merge-gate rappelle qu'une LIGHT ne se tient jamais plus d'une journée.

Le plancher G-VAR-1 de mon cycle n'est pas porté par cette PR : il l'est par la marche 7 B de la campagne GRPO (#5105), genre `training`, classe CONTENU.
