### PR TITLE
feat(lean,#14990): prove feasible_convex — convexity of the feasible payoff set (Folk, FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
@@ -71,6 +71,35 @@ def Feasible (g : PrisonersDilemma) (u_row u_col : ℝ) : Prop :=
     u_row = pCC * g.R + pCD * g.S + pDC * g.T + pDD * g.P ∧
     u_col = pCC * g.R + pCD * g.T + pDC * g.S + pDD * g.P
 
+/-- Convexité de l'ensemble faisable (#14990) : toute combinaison convexe de
+    deux vecteurs de paiements faisables est faisable. Première brique du
+    théorème de Folk — la construction Fudenberg–Maskin interpole entre
+    l'action jointe cible et une phase de punition, elle exige donc que
+    l'ensemble des paiements réalisables soit stable par barycentre. Preuve
+    directe sur l'existentiel `Feasible` (pas de `convexHull` de Mathlib) :
+    les poids témoins se combinent en `lam * p + (1 - lam) * q`, qui reste
+    non négatif (produits de non négatifs) et somme à un (combinaison affine
+    des deux sommes unité). -/
+theorem feasible_convex (g : PrisonersDilemma) (lam : ℝ)
+    (u1_row u1_col u2_row u2_col : ℝ)
+    (h1 : Feasible g u1_row u1_col) (h2 : Feasible g u2_row u2_col)
+    (hlam : 0 ≤ lam) (hlam1 : lam ≤ 1) :
+    Feasible g (lam * u1_row + (1 - lam) * u2_row)
+                (lam * u1_col + (1 - lam) * u2_col) := by
+  obtain ⟨pCC1, pCD1, pDC1, pDD1, hs1, ha1, ha2, ha3, ha4, hr1, hc1⟩ := h1
+  obtain ⟨pCC2, pCD2, pDC2, pDD2, hs2, hb1, hb2, hb3, hb4, hr2, hc2⟩ := h2
+  have h1l : 0 ≤ 1 - lam := by nlinarith
+  refine ⟨lam * pCC1 + (1 - lam) * pCC2, lam * pCD1 + (1 - lam) * pCD2,
+    lam * pDC1 + (1 - lam) * pDC2, lam * pDD1 + (1 - lam) * pDD2,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination lam * hs1 + (1 - lam) * hs2
+  · exact add_nonneg (mul_nonneg hlam ha1) (mul_nonneg h1l hb1)
+  · exact add_nonneg (mul_nonneg hlam ha2) (mul_nonneg h1l hb2)
+  · exact add_nonneg (mul_nonneg hlam ha3) (mul_nonneg h1l hb3)
+  · exact add_nonneg (mul_nonneg hlam ha4) (mul_nonneg h1l hb4)
+  · linear_combination lam * hr1 + (1 - lam) * hr2
+  · linear_combination lam * hc1 + (1 - lam) * hc2
+
 /-- Paiement actualisé du joueur de référence (ligne) sous une trajectoire
     d'actions conjointes `a` et facteur d'escompte `δ`. Généralise
     `coopValue` / `deviateValue` (cas particuliers stationnaires) à une

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
@@ -91,6 +91,35 @@ def Feasible (g : PrisonersDilemma) (u_row u_col : ℝ) : Prop :=
     u_row = pCC * g.R + pCD * g.S + pDC * g.T + pDD * g.P ∧
     u_col = pCC * g.R + pCD * g.T + pDC * g.S + pDD * g.P
 
+/-- Convexity of the feasible set (#14990): any convex combination of two
+    feasible payoff vectors is feasible. First brick of the Folk theorem —
+    the Fudenberg–Maskin construction interpolates between the target joint
+    action and a punishment phase, so it requires the set of realizable
+    payoffs to be stable under barycentres. Direct proof on the `Feasible`
+    existential (no Mathlib `convexHull`): the witness weights combine as
+    `lam * p + (1 - lam) * q`, which stays non-negative (product of
+    non-negatives) and sums to one (affine combination of the two unit
+    sums). -/
+theorem feasible_convex (g : PrisonersDilemma) (lam : ℝ)
+    (u1_row u1_col u2_row u2_col : ℝ)
+    (h1 : Feasible g u1_row u1_col) (h2 : Feasible g u2_row u2_col)
+    (hlam : 0 ≤ lam) (hlam1 : lam ≤ 1) :
+    Feasible g (lam * u1_row + (1 - lam) * u2_row)
+                (lam * u1_col + (1 - lam) * u2_col) := by
+  obtain ⟨pCC1, pCD1, pDC1, pDD1, hs1, ha1, ha2, ha3, ha4, hr1, hc1⟩ := h1
+  obtain ⟨pCC2, pCD2, pDC2, pDD2, hs2, hb1, hb2, hb3, hb4, hr2, hc2⟩ := h2
+  have h1l : 0 ≤ 1 - lam := by nlinarith
+  refine ⟨lam * pCC1 + (1 - lam) * pCC2, lam * pCD1 + (1 - lam) * pCD2,
+    lam * pDC1 + (1 - lam) * pDC2, lam * pDD1 + (1 - lam) * pDD2,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · linear_combination lam * hs1 + (1 - lam) * hs2
+  · exact add_nonneg (mul_nonneg hlam ha1) (mul_nonneg h1l hb1)
+  · exact add_nonneg (mul_nonneg hlam ha2) (mul_nonneg h1l hb2)
+  · exact add_nonneg (mul_nonneg hlam ha3) (mul_nonneg h1l hb3)
+  · exact add_nonneg (mul_nonneg hlam ha4) (mul_nonneg h1l hb4)
+  · linear_combination lam * hr1 + (1 - lam) * hr2
+  · linear_combination lam * hc1 + (1 - lam) * hc2
+
 /-- Discounted payoff of the reference (row) player under a trajectory of
     joint actions `a` and discount factor `δ`. Generalizes `coopValue` /
     `deviateValue` (stationary special cases) to an arbitrary trajectory:


### PR DESCRIPTION
Grain: DEEP/lean -- lane myia-po-2026:CoursIA -- prev: MED/tooling #14940

## feasible_convex : convexité de l'ensemble des paiements faisables (Folk, 1re brique)

Closes #14990

`Folk.lean` scaffolde le théorème de Folk (STRETCH #4880) mais n'avait que les
définitions `IndividuallyRational` / `Feasible` et le grand `sorry`
`folk_theorem_discounted`. L'issue #14990 (acceptée par le picker) demande la
première brique élémentaire utilisée par la construction Fudenberg–Maskin :
l'ensemble des paiements faisables est **stable par combinaison convexe**.

### Livrable

`theorem feasible_convex` dans `RepeatedGames/Folk.lean` (FR canonique) +
sibling `Folk_en.lean` (EPIC #4980 Pattern A : namespace `RepeatedGames_en`,
imports `_en`, énoncé/preuve byte-identical, seules docstrings/commentaires
diffèrent) :

```lean
theorem feasible_convex (g : PrisonersDilemma) (lam : ℝ)
    (u1_row u1_col u2_row u2_col : ℝ)
    (h1 : Feasible g u1_row u1_col) (h2 : Feasible g u2_row u2_col)
    (hlam : 0 ≤ lam) (hlam1 : lam ≤ 1) :
    Feasible g (lam * u1_row + (1 - lam) * u2_row)
                (lam * u1_col + (1 - lam) * u2_col)
```

Preuve directe sur l'existentiel `Feasible` (pas de `convexHull` Mathlib) :
les poids témoins se combinent en `lam * p + (1 - lam) * q` — non-négativité
par `mul_nonneg` ×2, sommes unité et équations de paiement par
`linear_combination (lam * h₁) + (1 - lam) * h₂`. Insertion après la définition
`Feasible`, avant `discountedPayoff` (ordre du dossier : la convexité est le
fait géométrique qui précède la construction).

### Preuves de validation (règle B pr-review-discipline)

1. **sorry count avant/après** (`scripts/lean/count_code_sorry.py --json`) :
   - `game_theory_lean` `distinct_code_sorry` : **1 avant → 1 après** (inchangé).
   - Flotte entière : **15 avant → 15 après**.
   - Le lemme ajouté ne contient aucun `sorry` ; le `sorry` restant du fichier
     est celui, authentique, de `folk_theorem_discounted` (STRETCH Fudenberg–Maskin,
     ne doit PAS être fermé — cf #10188). `grep -c sorry` Folk.lean: 6→6, Folk_en.lean: 6→6
     (occurrences = 1 code + 5 mentions en prose/docstrings, inchangées).
2. **`lake build` SUCCESS** : build local WSL complet du lake (toolchain v4.32.1
   épinglée, Mathlib 520045ab via `lake exe cache get`) — log (commit 984795043) :
   ```
   warning: RepeatedGames/Folk.lean:134:8: declaration uses `sorry`      ← folk_theorem_discounted (STRETCH préexistant, inchangé)
   warning: RepeatedGames/Folk_en.lean:152:8: declaration uses `sorry`   ← idem sibling EN
   ✔ [8710/8711] Built CooperativeGames (207s)
   Build completed successfully (8711 jobs).
   ```
   `feasible_convex` compile sans erreur NI warning (aucune ligne Folk hors les 2 `sorry` STRETCH ci-dessus).
3. **Proof integrity** :
   ```
   'RepeatedGames.feasible_convex' depends on axioms: [propext, Classical.choice, Quot.sound]
   'RepeatedGames_en.feasible_convex' depends on axioms: [propext, Classical.choice, Quot.sound]
   ```
   Les trois axiomes standard de Mathlib — **pas de `sorryAx`**.
4. Pas de refactor du prover Python (N/A).

### i18n siblings (#4980)

`python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/GameTheory/game_theory_lean` :
**20/21 pairs byte-identical | 1 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt**
— `Folk_en.lean` OK (nouveau lemme couvert par la byte-identity).

### Périmètre

Perimètre: 2 fichiers : MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean, MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean

Aucun autre fichier touché ; catalogue byte-identical à main (non-régénéré, cf catalog-pr-hygiene).

See #4880 (STRETCH Folk), #4208 (axe E), #4980 (i18n).
