### PR TITLE
fix(prover,#14996): distinguish calibration result populations

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/RUNBOOK.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/RUNBOOK.md
@@ -77,7 +77,7 @@ bg_id = Bash(
 
 ## Honest reporting
 
-- `DELTA > 0 AND ok=True` → real progress. Open PR with `lake build` log.
+- `DELTA > 0 AND ok=True` → real progress. Open PR with `lake build` log, sauf si `RESULT_CALIBRATION True` : le lanceur restaure alors la preuve approuvée byte-exactement, donc un `sorry_decreased` de calibration n'a volontairement aucun diff disque.
 - `DELTA == 0 AND ok=False` → no progress (typical for very_hard targets).
   This is **expected**, not a failure of the infrastructure. Report as
   `iter N: 0/M sorrys eliminated` in dashboard, do not claim "DONE".

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/baselines/analyze_traces.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/baselines/analyze_traces.py
@@ -36,6 +36,9 @@ _parser = argparse.ArgumentParser(
 _parser.add_argument(
     "--since", default=None, metavar="YYYY-MM-DD",
     help="Only include traces whose companion *_result.json timestamp is >= this date.")
+_parser.add_argument(
+    "--result-dir", default=None, metavar="PATH",
+    help="Read *_result.json wrappers from PATH (defaults to the detected traces directory).")
 _args = _parser.parse_args()
 
 jsonl_files_all = sorted(glob.glob(os.path.join(TRACE_DIR, "*.spans.jsonl")))
@@ -565,8 +568,14 @@ print("="*80)
 # the macro signal a coordinator dispatches on carries a real termination
 # taxonomy (sorry_decreased / structural_only / provider_outage / crashed /
 # no_progress / ...) instead of a 53%-delta-0 blob.
-result_files = sorted(glob.glob(os.path.join(RESULT_DIR, "*_result.json")))
-_verdicts = defaultdict(lambda: {"count": 0, "elapsed": [], "preset": 0, "rederived": 0})
+_result_dir = _args.result_dir or RESULT_DIR
+result_files = sorted(glob.glob(os.path.join(_result_dir, "*_result.json")))
+_by_population = {
+    population: defaultdict(
+        lambda: {"count": 0, "elapsed": [], "preset": 0, "rederived": 0}
+    )
+    for population in ("calibration", "real", "legacy_unknown")
+}
 _by_mode = defaultdict(lambda: defaultdict(int))
 _total = 0
 for _rf in result_files:
@@ -580,7 +589,21 @@ for _rf in result_files:
         if _ts and _ts < _args.since:
             continue
     _mode = str(_d.get("mode", ""))
-    _mode = "auto" if _mode.startswith("auto") else "multi" if _mode.startswith("multi") else "custom"
+    _mode = (
+        "auto"
+        if _mode.startswith("auto")
+        else "multi"
+        if _mode.startswith("multi")
+        else "custom"
+    )
+    _calibration = _d.get("calibration")
+    if _calibration is True:
+        _population = "calibration"
+    elif _calibration is False:
+        _population = "real"
+    else:
+        _population = "legacy_unknown"
+    _verdicts = _by_population[_population]
     _preset = _d.get("result_kind")
     if _preset:
         _kind = _preset
@@ -595,8 +618,14 @@ for _rf in result_files:
     _by_mode[_mode][_kind] += 1
     _total += 1
 
-_preset_n = sum(v["preset"] for v in _verdicts.values())
-_rederived_n = sum(v["rederived"] for v in _verdicts.values())
+_preset_n = sum(
+    v["preset"] for population in _by_population.values() for v in population.values()
+)
+_rederived_n = sum(
+    v["rederived"]
+    for population in _by_population.values()
+    for v in population.values()
+)
 print(f"\n{_total} result files classified ({_preset_n} preset result_kind, "
       f"{_rederived_n} re-derived from legacy wrappers lacking the field).")
 _VERDICT_ORDER = [
@@ -604,19 +633,26 @@ _VERDICT_ORDER = [
     "heartbeat_budget_exceeded", "decomposition_regression",
     "reasoning_budget_exceeded", "provider_outage", "crashed", "no_progress",
 ]
-print(f"\n{'Verdict':<28} {'Count':>6} {'MeanEl':>9} {'Preset':>7} {'Rederived':>10}")
-print("-" * 70)
-for _kind in _VERDICT_ORDER + [k for k in _verdicts if k not in _VERDICT_ORDER]:
-    _v = _verdicts.get(_kind)
-    if not _v or _v["count"] == 0:
-        continue
-    _mean = sum(_v["elapsed"]) / len(_v["elapsed"]) if _v["elapsed"] else 0
-    print(f"{_kind:<28} {_v['count']:>6} {_mean:>8.0f}s {_v['preset']:>7} {_v['rederived']:>10}")
-if _total:
-    _delta0_share = _verdicts.get("no_progress", {}).get("count", 0) / _total * 100
-    print(f"\nno_progress share: {_delta0_share:.0f}% of {_total} — previously the "
-          f"undifferentiated 'sorry_delta==0' bucket; structural_only / "
-          f"provider_outage / heartbeat_budget_exceeded above now sub-classify it.")
+for _population in ("calibration", "real", "legacy_unknown"):
+    _verdicts = _by_population[_population]
+    print(f"\n{_population.upper()} VERDICTS")
+    print(f"{'Verdict':<28} {'Count':>6} {'MeanEl':>9} {'Preset':>7} {'Rederived':>10}")
+    print("-" * 70)
+    for _kind in _VERDICT_ORDER + [k for k in _verdicts if k not in _VERDICT_ORDER]:
+        _v = _verdicts.get(_kind)
+        if not _v or _v["count"] == 0:
+            continue
+        _mean = sum(_v["elapsed"]) / len(_v["elapsed"]) if _v["elapsed"] else 0
+        print(f"{_kind:<28} {_v['count']:>6} {_mean:>8.0f}s {_v['preset']:>7} {_v['rederived']:>10}")
+    _population_total = sum(v["count"] for v in _verdicts.values())
+    _no_progress = _verdicts.get("no_progress", {}).get("count", 0)
+    if _population_total:
+        print(f"  no_progress share: {_no_progress / _population_total * 100:.0f}% "
+              f"of {_population_total}")
+    else:
+        print("  no results")
 if _by_mode:
-    print("By mode: " + " | ".join(
-        f"{_m}={sum(_by_mode[_m].values())}" for _m in sorted(_by_mode)))
+    print("\nBy mode: " + " | ".join(
+        f"{_mode}={sum(_by_mode[_mode].values())}"
+        for _mode in sorted(_by_mode)
+    ))

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -334,11 +334,13 @@ def _run_with_calibration_stub(demo, name, filepath, line, mode, iterations,
             f"original restored on exit"
         )
 
+    calibration = calibration_target is not None
     try:
         return _run_prover_locked(
             demo, name, filepath, line, mode, iterations, provider,
             local_provider, director_provider, coordinator_provider,
             tactic_provider, use_diagnosis_agent, concurrent_search_count,
+            calibration=calibration,
         )
     finally:
         if calibration_target is not None:
@@ -349,7 +351,7 @@ def _run_with_calibration_stub(demo, name, filepath, line, mode, iterations,
 def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
                        local_provider, director_provider, coordinator_provider,
                        tactic_provider, use_diagnosis_agent,
-                       concurrent_search_count):
+                       concurrent_search_count, calibration=False):
     """The original run body, executed while holding the tree lock."""
     original = Path(filepath).read_text(encoding="utf-8")
     original_sorry = count_real_sorries(original)
@@ -383,6 +385,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
             "final_sorry": 0,
             "sorry_delta": 0,
             "result_kind": "already_solved",
+            "calibration": calibration,
             "elapsed_s": 0.0,
             "result": {"status": "already_solved",
                        "reason": "0 sorry in target file (pre-check, no prover spawn)"},
@@ -474,6 +477,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
         # structural_only | provider_outage | no_progress | crashed |
         # already_solved | heartbeat_budget_exceeded | decomposition_regression.
         "result_kind": result_kind,
+        "calibration": calibration,
         "elapsed_s": round(elapsed, 1),
         "result": result,
         "trace_file": trace_path,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -205,8 +205,11 @@ async def _run_locked(
             f"original restored on exit"
         )
 
+    calibration = calibration_target is not None
     try:
-        return await _run_calibration_ready(args, demo, file_target)
+        return await _run_calibration_ready(
+            args, demo, file_target, calibration=calibration
+        )
     finally:
         if calibration_target is not None:
             calibration_target[0].write_bytes(calibration_target[1])
@@ -214,7 +217,10 @@ async def _run_locked(
 
 
 async def _run_calibration_ready(
-    args: argparse.Namespace, demo: dict, file_target: str
+    args: argparse.Namespace,
+    demo: dict,
+    file_target: str,
+    calibration: bool = False,
 ) -> int:
     """The original run body, executed while holding the tree lock."""
     pre_sorry = _peek_sorry_count(file_target) if demo.get("file") else None
@@ -258,6 +264,7 @@ async def _run_calibration_ready(
             _bg(f"DELTA {pre_sorry - post_sorry}")
 
     _bg(f"RESULT_KEYS {sorted(result.keys())}")
+    _bg(f"RESULT_CALIBRATION {calibration}")
     _bg(f"RESULT_SUCCESS {result.get('success')}")
     # #1453: success=True with already_solved=True and 0 iterations is a NO-OP
     # exit, not a proof — make the distinction parseable for harvest scripts

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_calibration_stub.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_calibration_stub.py
@@ -14,6 +14,13 @@ prover run stubs that file in place, and a test reading it races the run
 state and failed on a sorry count of 2 vs 1).
 """
 
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from prover.lean_utils import count_real_sorries, stub_theorem_proof
@@ -112,3 +119,118 @@ def test_stub_statement_without_assign_raises():
     source = "theorem broken : Nat\n\ntheorem next : True := trivial\n"
     with pytest.raises(ValueError, match="no ':='"):
         stub_theorem_proof(source, "broken")
+
+
+def test_root_launcher_marks_applied_calibration(tmp_path, monkeypatch):
+    """The root launcher's parseable result carries the applied-stub flag."""
+    import run_prover_bg as launcher
+
+    target = tmp_path / "Nim.lean"
+    target.write_text(NIM_FIXTURE, encoding="utf-8", newline="\n")
+    original_bytes = target.read_bytes()
+    demo = {
+        "file": str(target),
+        "theorem_name": "isWinningNim_345",
+        "sorry_type": "sorry_replacement",
+        "line": 22,
+    }
+    seen = []
+
+    async def _record(_args, _demo, _file_target, calibration=False):
+        seen.append(calibration)
+        return 0
+
+    monkeypatch.setattr(launcher, "_run_calibration_ready", _record)
+    args = SimpleNamespace()
+    assert asyncio.run(launcher._run_locked(args, demo, str(target))) == 0
+    assert seen == [True]
+    assert target.read_bytes() == original_bytes
+
+
+@pytest.mark.parametrize("calibration", [True, False])
+def test_root_launcher_emits_calibration_result(
+    tmp_path, monkeypatch, capsys, calibration
+):
+    """The root launcher's result protocol exposes the population flag."""
+    import run_prover_bg as launcher
+
+    target = tmp_path / "Nim.lean"
+    source = (
+        stub_theorem_proof(NIM_FIXTURE, "isWinningNim_345")
+        if calibration
+        else NIM_FIXTURE
+    )
+    target.write_text(source, encoding="utf-8", newline="\n")
+
+    class _FakeProver:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def prove_sorry(self, _demo, **_kwargs):
+            return {"success": True, "iterations": 1}
+
+    monkeypatch.setattr(launcher, "MultiAgentSorryProver", _FakeProver)
+    monkeypatch.setattr(launcher, "TraceLogger", lambda **_kwargs: object())
+    args = SimpleNamespace(
+        provider="local",
+        local_provider="local",
+        director_provider=None,
+        coordinator_provider=None,
+        tactic_provider=None,
+        search_provider=None,
+        critic_provider=None,
+        max_iter=1,
+        workflow_timeout=1,
+    )
+
+    assert asyncio.run(
+        launcher._run_calibration_ready(
+            args,
+            {"file": str(target)},
+            str(target),
+            calibration=calibration,
+        )
+    ) == 0
+    assert f"[BG] RESULT_CALIBRATION {calibration}" in capsys.readouterr().out
+
+
+def test_analyzer_separates_calibration_and_real_successes(tmp_path):
+    """Positive control: equal verdicts land in separate populations."""
+    for name, calibration in (
+        ("calibration", True),
+        ("real", False),
+        ("legacy", None),
+    ):
+        (tmp_path / f"{name}_result.json").write_text(
+            json.dumps({
+                "mode": "multi",
+                "result_kind": "sorry_decreased",
+                "calibration": calibration,
+                "original_sorry": 1,
+                "final_sorry": 0,
+                "elapsed_s": 1.0,
+                "result": {"success": True},
+                "timestamp": "2026-09-07T00:00:00Z",
+            }),
+            encoding="utf-8",
+        )
+
+    analyzer = (
+        Path(__file__).resolve().parent.parent
+        / "prover" / "baselines" / "analyze_traces.py"
+    )
+    completed = subprocess.run(
+        [sys.executable, str(analyzer), "--result-dir", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    calibration_section, remainder = completed.stdout.split(
+        "CALIBRATION VERDICTS", 1
+    )[1].split("REAL VERDICTS", 1)
+    real_section, legacy_section = remainder.split("LEGACY_UNKNOWN VERDICTS", 1)
+    assert "sorry_decreased" in calibration_section
+    assert "sorry_decreased" in real_section
+    assert "sorry_decreased" in legacy_section

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_subdir_launcher_calibration.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_subdir_launcher_calibration.py
@@ -170,6 +170,7 @@ def test_calibration_stub_runs_prover_and_restores(tmp_path, monkeypatch, capsys
     # Not the false already_solved: the preflight saw the STUBBED state.
     assert summary["result_kind"] != "already_solved"
     assert summary["result_kind"] == "sorry_decreased"
+    assert summary["calibration"] is True
     assert summary["original_sorry"] == 1  # 0 -> 1 before the preflight
     assert summary["final_sorry"] == 0
     # The spawn itself saw exactly one sorry on disk (and the stubbed file,
@@ -223,6 +224,7 @@ def test_clean_target_outside_calibration_keeps_skip(tmp_path, monkeypatch, caps
     summary = _run(monkeypatch, tmp_path, demo)
 
     assert summary["result_kind"] == "already_solved"
+    assert summary["calibration"] is False
     assert calls["constructed"] == 0  # skip: no prover spawned
     out = capsys.readouterr().out
     assert "CALIBRATION_STUB" not in out


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2025:CoursIA-2 — prev: MED/research-code #14995

Closes #14996
See #1453

## Problème

Les deux lanceurs restaurent byte-exactement la preuve approuvée après une calibration `sorry_replacement`. Un succès de calibration peut donc produire `result_kind == "sorry_decreased"` avec un diff disque volontairement vide. Sans population explicite, un futur harvest pourrait confondre ce résultat avec un succès sur cible réelle, et l'analyse agrégée gonflerait le taux réel avec les calibrations du harnais.

## Solution

- pose `calibration = true` exactement là où le stub de calibration est réellement appliqué, sans inférence depuis le nom du fichier ou de la DEMO ;
- propage cette distinction dans le summary JSON du lanceur sous-répertoire et dans la sortie parseable `RESULT_CALIBRATION` du lanceur racine ;
- conserve `calibration = false` pour les runs réels/non stubbés ;
- classe les anciens wrappers sans champ dans une population honnête `LEGACY_UNKNOWN` plutôt que de les requalifier rétroactivement ;
- sépare les verdicts `CALIBRATION`, `REAL` et `LEGACY_UNKNOWN` dans `analyze_traces.py` ;
- ajoute un contrôle positif hermétique où les trois populations portent le même verdict `sorry_decreased` mais apparaissent dans trois sections distinctes ;
- documente dans le RUNBOOK pourquoi une calibration réussie ne laisse aucun diff disque.

## Acceptance #14996

1. Champ explicite au point d'application du stub : couvert dans les deux lanceurs.
2. Agrégation séparée : couverte par trois populations, avec compatibilité historique explicite.
3. Tests des deux lanceurs : couverts pour calibration appliquée et cible réelle/non stubbée.
4. Phrase RUNBOOK : couverte.
5. Contrôle positif mixte : couvert par calibration + réel + legacy dans une même passe de l'analyseur.

## Validation fraîche post-synchronisation

```text
python -m pytest tests/test_calibration_stub.py tests/test_subdir_launcher_calibration.py -q
16 passed in 1.11s

python -m pytest tests/ -q
755 collected / 755 passed / 0 failed / 0 skipped in 3.40s

python -m py_compile prover/baselines/analyze_traces.py prover/run_prover_bg.py run_prover_bg.py tests/test_calibration_stub.py tests/test_subdir_launcher_calibration.py
PASS

git diff --check
PASS
```

Le contrôle positif vérifie que `CALIBRATION VERDICTS`, `REAL VERDICTS` et `LEGACY_UNKNOWN VERDICTS` contiennent chacun leur propre `sorry_decreased`.

## Discipline Lean / anti-régression

- Fichiers `.lean` modifiés : **0**.
- `distinct_code_sorry` avant/après : **inchangé par construction** (aucun source Lean dans le diff).
- `lake build` : **non applicable** — aucun module Lean modifié ; le patch concerne exclusivement le protocole de résultats et son analyse Python.
- Proof integrity : **non applicable** — aucun module Lean ni preuve modifié.
- Justification du refactor Python : nécessaire au claim de #14996, car la distinction doit être produite par les deux lanceurs au point exact où ils appliquent le stub, puis consommée par l'analyseur qui calcule les taux du prover.

## Périmètre

Six fichiers sous `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/` : deux lanceurs, l'analyseur, deux fichiers de tests et le RUNBOOK. Aucun notebook, catalogue, résultat de trace ni fichier Lean n'est modifié.
