### PR TITLE
fix(markdown-claims,#14982): escape \gamma in Family D1 docstring (SyntaxWarning)

### DIFF
--- a/scripts/check_markdown_claims_output.py
+++ b/scripts/check_markdown_claims_output.py
@@ -628,7 +628,7 @@ def _is_math_parameter_definition(prose: str, match_pos: int, match_end: int) ->
       symbol LHS, stays checked;
     - a greek symbol holding an ESTIMATED value (`$\\mu = 20.8$` read off a
       plot) is a citation too -- no definition verb on the line, stays
-      checked. The verb gate separates 'Avec $\gamma = 0.9$' (founding
+      checked. The verb gate separates 'Avec $\\gamma = 0.9$' (founding
       instance, DecPyMC-7 md[15]/md[19]) from it.
     """
     span = _nearest_math_span(prose, match_pos)


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #14998

## check_markdown_claims_output : échappement de `\gamma` dans la docstring Family D1 (SyntaxWarning)

Closes #14982

Depuis #14934 (MERGED 01:05Z), `check_markdown_claims_output.py` émet un `SyntaxWarning: "\g" is an invalid escape sequence` à l'import sur Python 3.12+. La docstring de `_is_math_parameter_definition` échappait correctement `\\mu` (ligne 629) et `\\gamma` (ligne 623), sauf sur UNE ligne : `'Avec $\gamma = 0.9$'` (backslash simple → séquence `\g` invalide). L'incohérence était dans la même docstring.

Correctif : doubler le backslash de la ligne fautive (`$\\gamma`), symétrique du `\\mu` voisin. Le rendu LaTeX de la docstring reste identique ; le raw `r"""` a été écarté car il aurait affiché `\\gamma` (double) dans un texte qui cite du LaTeX simple.

## Acceptance (issue, point par point)

| # | Critère | Preuve |
|---|---------|--------|
| 1 | `python -W error::SyntaxWarning -c "<import>"` passe sans lever | ✅ **PASS sur py 3.14.4** (plus strict que 3.12 ; import propre `ACCEPTANCE-1 PASS`) — et comme 3.14 fait de toute séquence invalide une erreur, l'import propre prouve qu'aucune autre séquence invalide ne subsiste dans le module |
| 2 | `pytest scripts/tests/test_check_markdown_claims_output.py` reste à 123/123 | ✅ **123 passed** (collected 123) |
| 3 | La docstring reste lisible (le `r"""` ne doit pas transformer les exemples LaTeX cités) | ✅ échappement symétrique choisi — le rendu `\gamma` est inchangé, cohérent avec `\\gamma`/`\\mu` voisins |

## Périmètre

Perimètre: 1 fichier : scripts/check_markdown_claims_output.py (+1/−1)
