### PR TITLE
docs(claw-systems,#4428): refresh Hermes modules — cadences, watchdogs, sync #5, incidents 07-09/2026

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/README.md
@@ -83,7 +83,7 @@ L'enchaînement recommandé pour suivre le répertoire de bout en bout :
 | 5 | [04 — ASR Integration](docs/04-ASR-Integration.md) | Approfondissement sur la transcription vocale (Whisper auto-hébergé). |
 | 6 | [05 — Architecture Hermes](docs/05-Hermes-Architecture.md) | Passer à un système plus complexe : fork upstream, drift isolé, MCPs, cron. |
 | 7 | [06 — Hermes Deploy s6-overlay](docs/06-Hermes-Deploy-s6-Overlay.md) | Le déploiement Windows + s6-overlay, avec les patches CRLF/with-contenv/HOME documentés. |
-| 8 | [07 — Hermes Cluster Coordinator Role](docs/07-Hermes-Cluster-Coordinator-Role.md) | Le rôle de coordinateur cluster (dashboards, routing, hand-off, surveillance 6h). |
+| 8 | [07 — Hermes Cluster Coordinator Role](docs/07-Hermes-Cluster-Coordinator-Role.md) | Le rôle de coordinateur cluster (dashboards, routing, hand-off, surveillance 12h). |
 | 9 | [08 — Multi-Bot Coordination](docs/08-Multi-Bot-Coordination.md) *(draft, co-écrit)* | Comment plusieurs Claws coexistent et coopèrent (intercom, mentions, anti-collision). |
 | 10 | [09 — Patterns & Anti-Patterns](docs/09-Patterns-Anti-Patterns.md) *(draft, co-écrit)* | Les leçons apprises en production — incidents, fixes, règles d'or. |
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/05-Hermes-Architecture.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/05-Hermes-Architecture.md
@@ -107,9 +107,20 @@ en plus du planificateur OS. Trois jobs tournent en production :
 
 | Job | Cadence | Role |
 |-----|---------|------|
-| `cluster-tour` | 6h | Tour de santé du cluster, lecture dashboards, rapport |
-| `pr-review` | planifié | Review de PRs assignées |
-| `inbox-poll` | planifié | Scrutation de la messagerie inter-machines |
+| `cluster-tour` | 12h (`13 */12`) | Tour de santé du cluster, lecture dashboards, rapport `[CLUSTER-HEALTH]` sur global |
+| `pr-review` | 1h (`23 * * * *`) | Review des PRs ouvertes (CoursIA, roo-extensions) |
+| `inbox-poll` | 30 min | Scrutation de la messagerie inter-machines |
+| `self-check` | 2×/jour (`7 11,23`) | Auto-diagnostic du bot |
+
+La cadence du `cluster-tour` est passée de 6h à 12h en juillet 2026 (équilibre
+coût tokens / réactivité — un tour complet lit tous les dashboards du cluster).
+Chaque cron porte une **escalade de watchdogs indépendants** qui compense la
+cadence : voir [06 — section Résilience](06-Hermes-Deploy-s6-Overlay.md).
+
+En plus des crons du bot, un **cron opérateur** (session Claude Code sur la
+machine hôte, `17 */12`) exécute une routine de surveillance à 8 vérifications —
+dont la lecture des messages des bots, le critère le plus discriminant (voir
+[AP13](09-Patterns-Anti-Patterns.md)).
 
 ## Système de profils
 
@@ -139,6 +150,36 @@ Tout le code doit appeler `get_hermes_home()` (depuis `hermes_constants`) —
 | `hermes_cli/commands.py` | Registre central des slash commands |
 | `gateway/run.py` | `GatewayRunner` — cycle de vie plateformes, routage messages |
 | `agent/prompt_builder.py` | Assemblage du system prompt (identite, skills, contexte, mémoire) |
+
+## Synchronisation upstream (la discipline du fork)
+
+Le fork est resynchronisé vers upstream **toutes les 3 à 4 semaines**. Cinq
+itérations en production (juillet–septembre 2026), dont un record de **7531
+commits** mergés d'un coup. La méthode, éprouvée à chaque itération :
+
+1. Tag `pre-sync-YYYYMMDD` + backup du volume → point de retour garanti
+2. Branche `sync/YYYY-MM-DD` → `git merge upstream/main`
+3. Résolution de conflits **délibérée** (jamais aveugle) — les conflits
+   récurrents sont connus et documentés :
+   - *sentinelle de patch* en tête de `tools/environments/base.py` et `local.py`
+     (prouve à l'import que le fichier patché est bien chargé — héritage de
+     l'incident des 96h, voir [09](09-Patterns-Anti-Patterns.md)) ;
+   - *garde `/root`* : upstream a intégré notre extraction `_recover_cwd()`
+     (issue #17558) mais **sans** la garde `PermissionError` — il faut la
+     ré-ajouter par-dessus à chaque sync ;
+   - Dockerfile : nos 4 lignes de drift RooSync vs les refactorings upstream.
+4. Audit de drift par grep (les lignes doivent survivre au merge)
+5. Build `s6-sync-YYYYMMDD` → déploiement → `hermes-verify.ps1` **12/12** →
+   fast-forward main → push
+
+Depuis la sync de septembre 2026, upstream embarque un `.gitattributes`
+(`eol=lf` global) qui normalise les fins de ligne au checkout — nos strips CRLF
+build-time sont conservés en défense en profondeur (le working tree Windows
+pré-existant garde du CRLF).
+
+> **Leçon de fork :** un drift isolé dans un répertoire dédié (`roosync-cluster/`)
+> rend le merge trivial ; les rares fichiers cœur patchés (2 fichiers) sont le
+> seul coût récurrent — et leurs conflits sont prévisibles, donc rapides.
 
 ## Hermes vs NanoClaw
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/06-Hermes-Deploy-s6-Overlay.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/06-Hermes-Deploy-s6-Overlay.md
@@ -33,7 +33,7 @@ Aucun token ne doit être commité. Voir
 
 | Élément | Valeur |
 |----------|--------|
-| **Image** | `hermes-agent:s6-20260528` (build local depuis le fork) |
+| **Image** | `hermes-agent:s6-sync-YYYYMMDD` (build local depuis le fork, un tag par sync upstream — p.ex. `s6-sync-20260906`) |
 | **PID 1** | `s6-svscan` (s6-overlay v3.2.3.0, remplace tini/gosu) |
 | **Utilisateur** | `hermes` (UID 10000) via `s6-setuidgid` |
 | **Volume** | `<home>/.hermes` → `/opt/data` (persistant entre rebuilds) |
@@ -48,7 +48,7 @@ docker run -d --name hermes `
   -v C:\dev\roo-extensions\mcps\internal\servers\roo-state-manager:/opt/roo-state-manager:ro `
   --add-host=host.docker.internal:host-gateway `
   -p 9120:9119 `
-  hermes-agent:s6-20260528 gateway run
+  hermes-agent:s6-sync-20260906 gateway run
 ```
 
 Le script complet et commenté vit dans
@@ -94,8 +94,12 @@ configuration a partir des secrets a chaque boot, dans cet ordre :
 7. Corrige le format `jobs.json` (list→dict, normalisation, retrait des restrictions de toolsets)
 8. Installe `croniter`, `gh` CLI, `jq`
 9. Configure `gh auth` (persisté dans `/opt/data/.config/gh`)
-10. Patch le `SCHEMA_SQL` du kanban (index session_id avant migration)
+10. Patch le `SCHEMA_SQL` du kanban (index session_id avant migration) — *retiré depuis qu'upstream a corrigé l'ordre ; la garde de boot accepte désormais l'absence du patch comme un OK (« upstream fixed »)*
 11. Lance les verifications (PASS/FAIL)
+
+> **Leçon de garde :** une garde de vérification doit distinguer « patch absent »
+> de « bug revenu ». Ici, upstream a supprimé la ligne fautive — lire l'absence
+> comme un FAIL produisait un faux positif de boot à chaque démarrage.
 
 ## Fallback MCP local (quand le proxy LAN est down)
 
@@ -120,6 +124,14 @@ infrastructure MCP locale :
 Ces patches existent a cause de la combinaison checkout Windows (CRLF) +
 isolation d'env s6-overlay (cassee l'heritage Docker ENV). **A ré-appliquer
 apres chaque sync upstream.**
+
+> **Évolution (sync 09/2026) :** upstream embarque désormais un `.gitattributes`
+> global (`eol=lf`) qui normalise les fins de ligne au checkout. Les strips CRLF
+> ci-dessus restent néanmoins en place : le working tree Windows — préexistant
+> aux attributs — conserve du CRLF jusqu'à sa réécriture complète, et le strip
+> build-time est la défense en profondeur qui rend l'image correcte *quoi qu'il
+> arrive au checkout*. Le Dockerfile vit à la racine du repo depuis la sync
+> d'août 2026 (déplacé par upstream depuis `docker/`).
 
 1. **Strip CRLF** — le Dockerfile ajoute `RUN find /etc/s6-overlay/s6-rc.d -type f -exec sed -i 's/\r$//' {} +` (et idem pour `/etc/cont-init.d`) apres chaque bloc `COPY`. Sans cela, `s6-rc-compile` echoue avec "invalid type".
 
@@ -176,21 +188,47 @@ auxiliary:
 
 Surveiller les `tool_use_error` apres compaction — redémarrer la session si observé.
 
-## Résilience MCP (watchdog)
+## Résilience MCP (constellation de watchdogs)
 
 **Cause racine :** `MCPServerTask.run()` dans `tools/mcp_tool.py` abandonne apres
 `_MAX_RECONNECT_RETRIES = 5` tentatives. Une fois la tâche retournée, le pont est
 mort jusqu'au redémarrage du process gateway.
 
-**Watchdog :** `roosync-cluster/scripts/hermes-mcp-watchdog.ps1` tourne toutes
-les 15 min via une tâche planifiée Windows. Escalade de récupération :
+**Watchdog bridge :** `roosync-cluster/scripts/hermes-mcp-watchdog.ps1` tourne
+toutes les 15 min via une tâche planifiée Windows. Escalade de récupération :
 
-1. **Stage 1 :** `SIGUSR1` au PID gateway — redémarrage graceful, préserve l'état conteneur
+1. **Stage 1 :** `SIGTERM` au PID gateway — arrêt propre, attendre le drain des
+   sessions, l'entrypoint s6 relance le service
 2. **Stage 2 :** `docker restart` — reboot complet (dernier recours)
+
+> **Gotcha signal (août 2026) :** `SIGUSR1` ne redémarre **plus** le gateway
+> depuis la sync du 23/08 (changement de gestion de signaux upstream). Utiliser
+> `SIGTERM` et **attendre le drain** — un SIGTERM suivi d'un redémarrage
+> immédiat coupe les sessions en vol.
 
 **Backoff :** exponentiel (5, 10, 15... jusqu'à 60 min). Max 10 échecs consécutifs
 avant abandon. Le compteur reset sur check sain. Evite les loops de restart
 (incident 2026-05-11 : 10+ restarts en 4h).
+
+### Les organes indépendants (design ai-01, spec en 5 points)
+
+L'incident d'août 2026 (bus MCP mort **3,5 jours** alors que tous les voyants
+étaient verts — voir [AP13](09-Patterns-Anti-Patterns.md)) a produit une seconde
+génération de watchdogs, dits **organes** : des observateurs **indépendants** qui
+lisent tout depuis le **volume hôte** (pas l'API du conteneur) et fonctionnent
+donc même quand le conteneur est down — précisément quand le gap est le plus
+probable.
+
+| Organe | Tâche planifiée | Ce qu'il vérifie |
+|--------|-----------------|------------------|
+| `hermes-mcp-watchdog.ps1` | 15 min | Le pont MCP du conteneur répond |
+| `hermes-review-watchdog.ps1` | 30 min (`:07/:37`) | Des reviews GitHub sont réellement postées (le cron `pr-review` peut finir `status=ok` avec **zéro** review) |
+| `hermes-cluster-tour-watchdog.ps1` | 30 min (`:07/:37`) | Chaque fire du cluster-tour a bien produit son append `[CLUSTER-HEALTH]` sur global (jamais de re-fire — verificateur, pas duplicate) |
+| `mcp-chain-watchdog.ps1` (côté ai-01) | 2 min | La chaîne MCP **backend** : sonde = appel d'outil réel (`roosync_dashboard list`), pas le handshake |
+
+Principes communs (spec ai-01) : cooldown anti-spam, fichier d'état compteur
+OK/MISSING (le taux est instrumenté), alerte Telegram + post `[WARN]` sur le
+dashboard à l'endroit exact où le post manquant aurait dû apparaître.
 
 ## Backup
 
@@ -229,7 +267,7 @@ docker run -d --name hermes `
   -v C:\dev\roo-extensions\mcps\internal\servers\roo-state-manager:/opt/roo-state-manager:ro `
   --add-host=host.docker.internal:host-gateway `
   -p 9120:9119 `
-  hermes-agent:pre-sync-20260602 gateway run
+  hermes-agent:pre-sync-YYYYMMDD gateway run   # le tag posé avant la dernière sync
 ```
 
 ## Troubleshooting
@@ -240,8 +278,13 @@ docker run -d --name hermes `
 | CMD tourne avec ~6 vars d'env | Shebang sans `with-contenv` | Vérifier patch #2 |
 | `PermissionError: /root/...` | HOME non overriddé | Vérifier patch #3 (`export HOME=/opt/data`) |
 | `tool_use_error` apres compaction | Compat Anthropic + MCP | Forcer `provider: zai`, redémarrer session |
-| MCP mort apres quelques heures | Limite 5 retries | Vérifier le watchdog (SIGUSR1) |
+| MCP mort apres quelques heures | Limite 5 retries | Vérifier le watchdog bridge (SIGTERM + drain) |
 | MCPs down si proxy LAN injoignable | Proxy 9090 down | Le fallback local doit prendre le relais |
+| Cron finit `status=ok` mais ne poste rien | Skip silencieux du prompt | Organe cluster-tour-watchdog (vérification post-fire programmatique) |
+| Tout est vert mais les dashboards ne bougent plus | Backend MCP mort derrière un handshake vivant | `mcp-chain-watchdog` (sonde = appel d'outil réel), restart proxy |
+| Crons en double après un reboot/MAJ VS Code | Jobs restaurés par le harness par-dessus l'existant | Purger + recréer frais (protocole ghost-crons) |
+| Crons 7/7 en erreur, thinking sans signature | Proxy LLM émet un bloc thinking non signé → crash SDK | Patch `.pth` retype dict→ThinkingBlock (persisté au restore) |
+| Bot muet en boucle sur sa mémoire | Plafond mémoire agent trop bas (livelock) | Doubler les limites de contexte mémoire (2200→4400 chars) + SIGTERM gateway |
 
 ## Liens
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/07-Hermes-Cluster-Coordinator-Role.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/07-Hermes-Cluster-Coordinator-Role.md
@@ -145,7 +145,35 @@ par :
 - **Présence chat** : les crons postent un jalon `[OK]` même quand tout va bien,
   pour prouver que la boucle tourne
 - **Détection de staleness** : un workspace sans activité récente est flaggué
-- **Cadence** : surveillance 6h (compromis économie tokens / réactivité)
+- **Cadence** : cluster-tour 12h + self-check 2×/jour (compromis économie tokens
+  / réactivité), doublés côté hôte par des watchdogs 15–30 min (voir ci-dessous)
+
+### Vérifier ce que les bots PEUVENT FAIRE et DISENT
+
+L'incident le plus instructif du domaine (août 2026, ~3,5 jours) : le backend
+MCP derrière le proxy est mort **en gardant un handshake vert** — processes,
+ports et freshness tous OK, pendant que chaque appel d'outil échouait en silence.
+Les deux bots du cluster ont **dit** (« bus down, 40+ cycles ») et personne ne
+lisait leurs messages. Depuis, la surveillance est **capability-first** :
+
+1. **Capability** : sonder le chemin d'écriture réel (appel d'outil, pas le
+   handshake) — c'est le rôle de `mcp-chain-watchdog` côté ai-01
+2. **Parole** : lire ce que les bots rapportent (regex `bus down|undelivered|
+   fallback|write failed` sur leurs messages) — c'est le check 8 de la routine
+   opérateur
+3. **Jamais attribuer un post manquant au prompt-skip** avant d'avoir écarté un
+   bus mort (l'attribution erronée d'août a coûté 3 jours de diagnostic)
+
+### La surcouche opérateur (session Claude Code hôte)
+
+En plus du bot, une **session Claude Code sur la machine hôte** porte un cron de
+surveillance 12h (`17 */12`, self-re-arming) qui exécute une routine à 8
+vérifications : container/gateway, fraîcheur des crons, activité reviews,
+watchdogs, NanoClaw, tour global, **lecture des messages des bots**. L'escalade
+est volontairement bornée à 5 critères durs (container down, reviews >4h,
+NanoClaw >36h, global >36h, bus MCP down) — tout le reste est [INFO], pas
+[ALERT]. Cette discipline évite la fatigue d'alerte, le vrai tueur des systèmes
+de surveillance.
 
 Voir [08-Multi-Bot-Coordination.md](08-Multi-Bot-Coordination.md) pour le
 concret de la coordination Hermes ↔ NanoClaw, et

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/08-Multi-Bot-Coordination.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/08-Multi-Bot-Coordination.md
@@ -97,7 +97,7 @@ reste visible mais n'attend pas de réponse (mode `[INFO]`/`[FYI]`).
 |--------|----------|--------|
 | **Machine** | `myia-ai-01` | `myia-po-2026` |
 | **Rôle** | Bot terminal utilisateur | Coordinateur read-only + bot |
-| **Cadence cron** | `13 */6` (offset) | `37 */6` (offset) |
+| **Cadence cron** | `13 */6` (offset) | `13 */12` cluster-tour + `17 */12` surveillance opérateur (offsets) |
 | **Canal canonique** | `workspace-CoursIA` | `workspace-CoursIA` (lecture/écriture) |
 | **LLM** | GLM-5.2 (condensation 250k) | GLM-5.2 via z.ai natif |
 
@@ -159,7 +159,8 @@ Chaque bot schedulé décale ses crons pour ne pas frapper l'API à la même sec
 
 | Bot | Cron offset | Note |
 |-----|-------------|------|
-| Hermes | `37 */6` | Off-minute (pas `:00`/`:30`) |
+| Hermes cluster-tour | `13 */12` | Off-minute (pas `:00`/`:30`) |
+| Hermes surveillance opérateur | `17 */12` | Décalé de 4 min du tour bot |
 | NanoClaw | `13 */6` | Décalé de 24 min |
 | autres workers | offsets distincts | Aucune collision à la minute |
 
@@ -227,6 +228,17 @@ vérifie :
 1. Dernière activité < 2h → workspace actif
 2. 2h–6h → à surveiller
 3. > 6h sans `[OK]` → probablement tombé silencieux
+
+**Côté Hermes — le silence du canal lui-même est un signal.** Le cas limite du
+multi-bot n'est pas le bot silencieux, c'est le **canal silencieux avec des bots
+qui parlent dans le vide** : pendant l'incident d'août 2026 (~3,5 jours), le
+backend MCP est resté mort derrière un handshake vivant, et les deux bots du
+cluster ont posté « bus down » à chaque cycle — sans que personne ne lise ces
+messages. Le correctif n'est pas technique mais organisationnel : la routine de
+surveillance a un check dédié « **lecture des messages des bots** » (regex sur
+`bus down|undelivered|fallback|write failed`), et l'attribution d'un post
+manquant ne va jamais à l'hypothèse « prompt-skip » avant d'avoir écarté « bus
+mort » (voir [AP13](09-Patterns-Anti-Patterns.md)).
 
 **Côté NanoClaw — prouver sa présence, et démasquer le « faux vivant ».** Chaque conteneur
 de session touche un fichier `/workspace/.heartbeat` ; l'hôte (un *sweep* toutes les 60 s)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/09-Patterns-Anti-Patterns.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claw-Systems/docs/09-Patterns-Anti-Patterns.md
@@ -4,7 +4,9 @@
 
 > **Module co-écrit.** Patterns et anti-patterns Hermes (po-2026) **et** NanoClaw (ai-01),
 > chacun documenté avec un incident réel. Les entrées suffixées « (NanoClaw) » et
-> numérotées P7+/AP7+ apportent la perspective de l'agent terminal sur `ai-01`. Voir
+> numérotées P7+/AP7+ apportent la perspective de l'agent terminal sur `ai-01`. Les
+> entrées P11+/AP12+ (rafraîchissement Hermes, septembre 2026) couvrent les incidents
+> de coordination et de supervision survenus depuis. Voir
 > [tracker #4428](https://github.com/jsboige/CoursIA/issues/4428).
 
 Ce module est le **retour d'expérience en production**. Il ne décrit pas comment les
@@ -94,6 +96,37 @@ sans accord humain.
 
 **Pourquoi :** un pavé de 30 lignes dans Telegram est illisible et noie le signal. La
 concision est ici un trait de produit, pas une limite technique.
+
+### P11 — Surveillance capability-first
+
+**Pratique :** vérifier ce que les bots **peuvent faire** (le chemin d'écriture réel :
+appel d'outil, pas le handshake) **et ce qu'ils disent** (leurs messages), pas
+seulement qu'ils tournent (process, ports, freshness).
+
+**Pourquoi :** l'incident des 12→15 août 2026 : backend MCP mort pendant ~3,5 jours
+derrière un handshake signé en ~5 ms. Tous les voyants classiques sont restés verts
+pendant que chaque tool call échouait en silence (voir AP13 ci-dessous).
+
+### P12 — Crons post-reboot : purger puis recréer
+
+**Pratique :** après un reboot machine ou une mise à jour du harness, **supprimer**
+les jobs restaurés et en **recréer** de frais (`CronList` → delete all → create →
+vérifier l'unicité).
+
+**Pourquoi :** les crons survivent au reboot via la restauration du harness, qui peut
+créer des doublons (double-fire, fuite de tokens — une lane a consommé 2673 requêtes
+en double avant détection, septembre 2026). Voir AP14 ci-dessous.
+
+### P13 — Organes de vérification indépendants
+
+**Pratique :** quand un cron doit produire un artefact observable (un post, une
+review), lui adjoindre un **watchdog séparé** qui lit tout depuis le **volume hôte**
+(fonctionne conteneur down), décalé de ~15 min après le fire, qui **ne re-fire
+jamais** la tâche vérifiée, avec cooldown + compteur OK/MISSING instrumenté.
+
+**Pourquoi :** un cron peut finir `status=ok` sans avoir rien posté — le statut
+d'exécution n'est pas le résultat business. Seul un vérificateur externe lit le
+résultat (voir AP12 ci-dessous).
 
 ---
 
@@ -290,6 +323,68 @@ Le build et le *spawn* visent donc deux noms d'image différents.
 **Leçon :** sur Windows, deux runtimes peuvent dériver deux identités du même répertoire.
 Toujours vérifier que l'artefact buildé est bien celui que l'orchestrateur lance.
 
+### AP12 — Skip silencieux de cron (08/2026)
+
+**Symptôme :** le cron `cluster-tour` rapporte `status=ok` (« completed
+successfully ») — mais **aucun** post `[CLUSTER-HEALTH]` n'apparaît sur le dashboard
+global. Quatre fires consécutifs sans post, non-déterministe (issue hermes-agent #3).
+
+**Cause racine :** deux familles — (a) le *prompt-skip* : l'agent exécute le statut
+mais saute silencieusement l'étape de post ; (b) le *write MCP mort* : le bus
+RooSync est down et chaque écriture échoue sans faire échouer le cron. Dans les
+deux cas, **le statut d'exécution n'est pas le résultat business**.
+
+**Fix :** un watchdog programmatique post-fire (`hermes-cluster-tour-watchdog.ps1`,
+spécifié par ai-01 en 5 points) : assertion « un append `[CLUSTER-HEALTH]` porte un
+timestamp ≥ fire −5 min », sinon `[WARN]` posté sur le global exactement là où le
+post manquait + alerte Telegram. Jamais de re-fire du tour (verificateur, pas
+duplicate). Un gotcha subtil : le corps du `[WARN]` mentionne littéralement
+« [CLUSTER-HEALTH] » — le parseur doit matcher le **titre de section**
+(`## [CLUSTER-HEALTH] T#N` ancré en début de ligne), sinon le WARN s'auto-valide
+comme tour posté.
+
+**Leçon :** on ne peut pas fermer un defect de prompt-skipping en insistant dans le
+prompt. Seul un check programmatique **après** le fire lit le résultat réel.
+
+### AP13 — L'angle aveugle de la capabilité (12→15/08/2026)
+
+**Symptôme :** les deux bots du cluster perdent l'accès dashboard pendant ~3,5 jours
+(~72 cycles). Processes, ports, freshness : tout vert de bout en bout.
+
+**Cause racine :** l'instance roo-state-manager derrière le proxy est **morte**
+(stall GDrive) — mais continuait de **signer le handshake d'initialize en ~5 ms**.
+Le watchdog sondait le *pont* MCP, pas le *backend* : la poignée de main vivante
+masquait l'outil mort. Chaque tool call renvoyait `isError:true` en silence.
+
+**Fix :** la sonde devient un **appel d'outil réel** (`mcp-chain-watchdog.ps1`,
+côté coordinateur, toutes les 2 min — un `roosync_dashboard list`, précisément le
+chemin qui touche GDrive), avec réparation complète (Stop+Start du service +
+restart du proxy, cooldown 15 min). Et la routine de surveillance gagne un check
+« lecture des messages des bots » : les bots **disaient** « bus down 40+ cycles »
+et personne ne les lisait.
+
+**Leçon :** vérifier ce que le système peut **faire** et ce qu'il **dit**, pas ce
+qu'il **est** (process vivant, port ouvert, handshake signé). La liveness ne prouve
+pas la capabilité.
+
+### AP14 — Ghost crons (09/2026)
+
+**Symptôme :** après un reboot machine, une lane schedulée consomme le double de
+son quota — et une autre lane part en **2673 requêtes** avant d'être coupée.
+
+**Cause racine :** les crons survivent au reboot (restauration du harness au
+démarrage de session) et se retrouvent en **double** : le job restauré + le job
+que l'agent recrée à son réveil en croyant armer pour la première fois.
+
+**Fix :** protocole « purge-puis-recrée » systématique post-reboot : `CronList` →
+supprimer **tous** les jobs de surveillance → `CronCreate` frais (wrapper verbatim,
+recurring) → re-`CronList` pour vérifier l'**exactement 1** job → consigner le
+nouvel ID dans le post de statut. Le wrapper du cron porte sa propre instruction
+de self-re-arm avec purge — le protocole se transmet lui-même à chaque fire.
+
+**Leçon :** un état schedulé restauré n'est pas un état propre. Sur une flotte,
+l'unicité d'un cron est un invariant à vérifier, pas une hypothèse.
+
 ---
 
 ## Règles d'or (synthèse)
@@ -305,6 +400,9 @@ Toujours vérifier que l'artefact buildé est bien celui que l'orchestrateur lan
 9. **Un seul écrivain par base SQLite.** L'invariant qui rend l'état observable et sans contention (NanoClaw).
 10. **Client et serveur d'un protocole bougent ensemble.** SDK ↔ gateway en lockstep (NanoClaw).
 11. **Tester depuis le vrai client.** Un `curl -k` sur l'hôte masque ce qu'un client TLS strict (le conteneur) rejette (NanoClaw).
+12. **Sonder la capabilité, pas la liveness.** Un appel d'outil réel, pas le handshake ; et lire ce que les bots disent.
+13. **Le statut d'un cron n'est pas son résultat.** Un cron « ok » qui ne poste rien est un incident — seul un organe indépendant le voit.
+14. **Un état schedulé restauré n'est pas propre.** Post-reboot : purger, recréer, vérifier l'unicité.
 
 ## Liens
 


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2026:hermes-agent -- prev: DEEP/training #15003

## Summary

Mise a jour de la partie Hermes de Claw-Systems (modules 05/06/07 + sections Hermes de 08/09) avec 10 semaines de production depuis la livraison initiale (PRs #4437/#4503/#4507, juin 2026). Tracker : #4428 (EPIC #4427).

- **05 Architecture** : crons reels (cluster-tour 12h `13 */12`, pr-review 1h `23 * * * *`, inbox-poll 30m, self-check 2x/j) + cron operateur `17 */12` ; nouvelle section **sync upstream** — 5 iterations (record 7531 commits), methodes (tag pre-sync, branche sync/, conflits deliberes, audit de drift, verify 12/12), `.gitattributes eol=lf` upstream
- **06 Deploy** : tags d image `s6-sync-YYYYMMDD` ; patch kanban retire (bug corrige upstream — la garde lit desormais l absence comme OK) ; note `.gitattributes` sur les patches Windows ; `SIGUSR1` -> `SIGTERM` + drain (changement signaux sync 23/08) ; **constellation de 4 watchdogs/organes** (spec ai-01 5 points) ; 6 lignes troubleshooting neuves (skip silencieux, angle mort capabilite, ghost crons, thinking non signe, livelock memoire)
- **07 Coordinateur** : surveillance **capability-first** (incident 12-15/08 : backend mort 3,5 j derriere un handshake vert) + surcouche operateur (8 checks, escalade bornee a 5 criteres)
- **08 Multi-Bot** : cadences Hermes a jour + section Hermes Anti-SILENT (le canal silencieux : les bots disaient bus down et personne ne lisait)
- **09 Patterns** : P11-P13 (capability-first, purge-puis-recree post-reboot, organes independants) ; **AP12-AP14** (skip silencieux de cron status=ok, angle aveugle de capabilite, ghost crons 2673 requetes) ; regles d or 12-14

6 fichiers, +239/-17. Aucun nouveau fichier (catalogue non impacte). check_docs_links OK, gitleaks Passed.

## Test plan

- [x] `python scripts/check_docs_links.py --check` — exit 0
- [x] Gitleaks pre-commit — Passed
- [x] Scan emojis/secrets sur le diff — clean
- [ ] CI gate vert

