### PR TITLE
fix(slides,#13237): grid 3-cols sur image-row Intelligences (suite) S2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,6 +279,9 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
+# Slidev QA render artefacts (Playwright captures — diagnostic only, never committed)
+slides/slide-renders*/
+
 # Visual Studio 6 build log
 *.plg
 

--- a/slides/S2-ia-exploratoire-symbolique/slides.md
+++ b/slides/S2-ia-exploratoire-symbolique/slides.md
@@ -217,7 +217,7 @@ layout: cover
 
 # Intelligences (suite)
 
-<div class="image-row">
+<div class="image-row grid grid-cols-3 gap-6 items-start justify-center max-w-3xl mx-auto">
 <img src="./images/img_010.jpg" height="180" alt="Intelligence exploratoire">
 <img src="./images/img_011.png" height="180" alt="Intelligence symbolique">
 <img src="./images/img_012.jpg" height="180" alt="Intelligence probabiliste">

--- a/slides/_tools/render_deck.py
+++ b/slides/_tools/render_deck.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+render_deck.py — instrument de capture Playwright pour decks Slidev.
+
+Navigation slide-par-slide, captures 1440x900 avec networkidle + 800ms
+(compile Tailwind). Utilise pour verifier visuellement les PRs slides
+(issue #13237 et suivantes).
+
+Usage :
+    # Terminal 1 : demarrer slidev sur le deck vise
+    cd <worktree>
+    npx slidev slides/S1-argumentation/slides.md --port 3031
+
+    # Terminal 2 : lancer le rendu
+    python slides/_tools/render_deck.py S1 --base http://localhost:3031
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+
+def render(deck: str, base: str, outdir: Path, viewport=(1440, 900), cap: int = 60) -> int:
+    outdir.mkdir(parents=True, exist_ok=True)
+    rendered = 0
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(viewport={"width": viewport[0], "height": viewport[1]})
+        page = context.new_page()
+        for n in range(1, cap + 1):
+            url = f"{base.rstrip('/')}/{n}?clicks=99"
+            try:
+                page.goto(url, wait_until="networkidle", timeout=30000)
+                page.wait_for_timeout(800)  # Tailwind compile
+                h1 = page.locator("h1").first.text_content(timeout=2000) or ""
+                fname = outdir / f"slide-{n:03d}.png"
+                page.screenshot(path=str(fname), full_page=False)
+                rendered += 1
+                title_short = (h1[:50].strip() if h1 else "(no h1)")
+                print(f"[{deck}] slide {n} : {title_short!r}")
+            except Exception as e:
+                print(f"[{deck}] slide {n} : ERROR {e}", file=sys.stderr)
+                break
+        browser.close()
+    return rendered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("deck", help="Identifiant deck (S1, S2, S3, ...)")
+    parser.add_argument("--base", default="http://localhost:3031", help="URL Slidev")
+    parser.add_argument(
+        "--outdir",
+        default=None,
+        help="Dossier de sortie (defaut: a cote du script dans slide-renders/<deck>)",
+    )
+    parser.add_argument("--cap", type=int, default=60, help="Nombre max de slides a scanner")
+    args = parser.parse_args()
+
+    here = Path(__file__).resolve().parent
+    outdir = Path(args.outdir) if args.outdir else here / "slide-renders" / args.deck
+    t0 = time.time()
+    n = render(args.deck, args.base, outdir, cap=args.cap)
+    elapsed = time.time() - t0
+    print(f"[{args.deck}] {n} slides rendues dans {outdir} en {elapsed:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2026:CoursIA-2 — prev: MED/lean #14953

## tranche 2 #13237 — calage image-row « Intelligences (suite) » (S2) — REPAIR 3 points ai-01

#13237 ouvre un chantier de calage visuel Slidev ; cette tranche ne traite **qu'un** défaut précis sur le deck `slides/S2-ia-exploratoire-symbolique/slides.md`, celui que le user a nommé en exemple lors de la session c.988 (et que la MEMORY dit reporté c.989+ « ne pas sur-investir »). Le fix est volontairement ultra-local — leçon c.692-L1 sustained (anti-composite).

### REPAIR (révision ai-01, 3 points verbatim)

Suite à la revue ai-01 (comment #5569699270), trois corrections ont été appliquées sur cette PR :

**1. Périmètre — 3 fichiers, pas 2.** Le body initial disait « deux fichiers modifiés », alors que la PR en porte trois (le `render_tranche2.py` ajouté a été omis du compte). Énumération corrigée :

- `slides/S2-ia-exploratoire-symbolique/slides.md` — fix du calage de la grille 3-cols (1 ligne, l.220)
- `.gitignore` — exclusion des artefacts `slides/slide-renders*/` (captures Playwright = diagnostic, jamais commitées)
- `slides/_tools/render_deck.py` — instrument Playwright réutilisable pour tranches futures (déplacé depuis `slides/render_tranche2.py`, renommé, voir point 2)

**2. Script déplacé et renommé.** `slides/render_tranche2.py` → `slides/_tools/render_deck.py` :
- Emplacement : tout l'outillage slides du dépôt vit dans `slides/_tools/` (`marp_to_slidev.py`, `compare_marp_pptx.py`, `slide_inventory.py`, `slide_tools.py`, `extract_animations.py`…). Un script à la racine de `slides/` était le seul de son espèce — règle CLAUDE.md générale.
- Nom : `render_deck.py` dit ce que ça fait. `render_tranche2.py` nommait une campagne, pas une fonction.
- Docstring : « tranche 2 #13237 » enlevé du titre (le lien vers l'issue est conservé en note d'usage). Commande d'invocation exemple mise à jour : `python slides/_tools/render_deck.py S1 --base http://localhost:3031`.
- `git mv` préserve l'identité du fichier (un seul commit amend).

**3. Vérification d'intêret transverse.** ai-01 note que deux lanes (po-2024 sur `08-ia-generative`, po-2027 sur `05-theorie-des-jeux`) vont vouloir vérifier leur rendu via cet instrument dans la semaine. Sous `slides/_tools/render_deck.py` elles le trouveront ; sous `slides/render_tranche2.py`, non. Périmètre de mon claim `slides/S2-ia-exploratoire-symbolique/**` + `slides/S3-acculturation/**` (amend ai-01 c.990) — pas de chevauchement avec leurs chemins.

### Périmètre initial (c.989) — inchangé fonctionnellement

Le défaut et le fix :

Le bloc `Intelligences (suite)` à la ligne 220 du deck S2 présente 3 images :

```html
<div class="image-row">
<img src="./images/img_010.jpg" height="180" alt="Intelligence exploratoire">
<img src="./images/img_011.png" height="180" alt="Intelligence symbolique">
<img src="./images/img_012.jpg" height="180" alt="Intelligence probabiliste">
</div>
```

**Défaut observé sur slide 11** (`?clicks=99`, viewport 1440×900, networkidle + 800 ms Tailwind compile) :

1. Images top-left alignées (au lieu d'être centrées horizontalement).
2. Clipping vertical visible : la 3ᵉ image (`img_012.jpg`, Intelligence probabiliste) sort de la zone visible en bas de la slide et chevauche la zone footer « Intelligence(s) ».
3. La lecture qui en résulte : l'étudiant voit « exploratoire / symbolique / (trou) », pas les trois familles d'intelligences annoncées.

Cause = la classe `.image-row` du thème ne porte pas de CSS grid ; le navigateur empile les 3 `<img>` par défaut (`display:inline` ligne à ligne), le `height=180` se combine avec les largeurs natives pour donner un rendu vertical tronqué.

**Fix** (ligne 220 uniquement) :

```diff
-<div class="image-row">
+<div class="image-row grid grid-cols-3 gap-6 items-start justify-center max-w-3xl mx-auto">
 <img src="./images/img_010.jpg" height="180" alt="Intelligence exploratoire">
 <img src="./images/img_011.png" height="180" alt="Intelligence symbolique">
 <img src="./images/img_012.jpg" height="180" alt="Intelligence probabiliste">
 </div>
```

Ajout d'une grille Tailwind 3-cols explicite (utility-first, scoped à ce conteneur), sans toucher aux autres `image-row` du deck (slides 5 et 7, qui portent 2 images et un layout différent — modifier ces dernières étendrait le périmètre au-delà du défaut nommé).

### Vérification visuelle

- **Instrument** : `slides/_tools/render_deck.py` (Python Playwright 1.60.0, slidev `?clicks=99`, viewport 1440×900, networkidle + 800 ms = compile Tailwind).
- **Pré-fix** (rendu `slide-011.png` avant le diff) : 2 images visibles, 3ᵉ hors-cadre.
- **Post-fix** (rendu `slides/slide-renders-s2-after/slide-011.png`, gitignored) : 3 images en grille, centrées horizontalement, footer safe.
- **Non-régression** : slides 1-10 et 12-13 re-rendues après le fix, layout inchangé sur les autres (la ligne 220 ne déplace qu'elle-même ; les autres `image-row` à hauteur différente — 100 px, 150 px — ne sont pas affectées par ce diff).

### Pourquoi cette tranche est modeste (mandat user c.988)

Le user a explicitement demandé « ne pas sur-investir maintenant, pourra attendre quelques jours » sur le calage images #13237 (verbatim session c.988, consigné en MEMORY). Livrer une tranche mono-fichier mono-slide tient le plancher sans engager le solde du chantier (les autres défauts de calage du même deck — slide 7 image-row à 2 images, slide 10 image-row procédurale 3 images verticales, slide 13 cover avec image isolée — existent mais sont **hors scope** de cette PR). L'EPIC #13237 reste ouverte pour les tranches suivantes.

### Note de généricité (sans engagement de scope)

La classe `.image-row` du thème Slidev n'a pas de définition CSS dans le dépôt. Soit elle est définie dans une dépendance node_modules non auditée (la grille est alors obtenue par `display:inline` natif, comme constaté), soit le thème ne la définit pas et chaque `<div class="image-row">` retombe sur le défaut navigateur. Un fix transverse (définir `.image-row { @apply grid ... }` dans un layout partagé) traiterait les 3 occurrences en une fois mais étendrait le diff à un fichier de thème et à d'autres decks — refus du périmètre large ici. À considérer en tranche ultérieure de #13237 si l'audit confirme la cause racine.

### Path-collision advisory (organ #13359/#13615)

GitHub Actions a posté un advisory « PR-PATH-COLLISION » signalant que `.gitignore` est aussi modifié par **#15029**. Vérification :
- **#15029** (po-2024, audio GenAI tranche 2) modifie `.gitignore` ligne ~1043 (zone `MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/_tranche2_15002/`).
- **#15017** (cette PR) modifie `.gitignore` zone `node_modules/` (l.281-282) avec `slides/slide-renders*/`.

Pas de chevauchement de lignes — les deux PRs ajoutent du contenu dans des zones distinctes. Le merge de l'une n'écrasera pas l'apport de l'autre.

See #13237 (contribution partielle — EPIC reste ouverte pour tranches suivantes : autres `image-row` du même deck, autres decks S3+, audit thème).
