### PR TITLE
fix(slides,#14226): guards hashFiles() runtime -- relay steps skipped on 100% PRs

### DIFF
--- a/.github/workflows/slides-composition-pr-relay.yml
+++ b/.github/workflows/slides-composition-pr-relay.yml
@@ -12,8 +12,11 @@ name: Slides Composition PR Relay
 #
 # Contrôle positif obligatoire (#14226 crit. 3) : le mécanisme doit
 # démontrer qu'il RELAIE le verdict, pas qu'il le maquille — un test
-# local sur un artefact réel (run 33466784484, S3-acculturation slide
-# 58) couvre cette exigence.
+# local sur un artefact réel (run 34100662765 du 2026-09-07T08:27Z,
+# S3-acculturation `n_hors_canvas: 1` sur slide 42 IMG bbox
+# [48, 334, 348, 608]) couvre cette exigence : la chaîne
+# `steps.resolve.outputs.has_decks == 'true'` → step 2 → step 4
+# publie le verdict sur la PR déclenchante.
 
 on:
   pull_request:
@@ -45,6 +48,7 @@ jobs:
 
     steps:
       - name: Resolve touched deck paths from PR diff
+        id: resolve
         env:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -76,14 +80,23 @@ jobs:
           done
           N=$(wc -l < /tmp/touched_decks.tsv | tr -d ' ')
           echo "Touched decks: ${N:-0}"
+          # #14226 -- le `if: hashFiles(...)` qui guardait les steps 3-4 était
+          # structurellement faux : hashFiles() est évalué à la phase de planning,
+          # bien avant que ce step ne crée /tmp/touched_decks.tsv, et le résultat
+          # est toujours ''. Conséquence : steps 3 et 4 skipped sur 100% des PRs,
+          # commentaire diagnostique jamais posté. Solution canonique : exposer
+          # le verdict via $GITHUB_OUTPUT (id: resolve) et baser les gardes
+          # sur steps.resolve.outputs.has_decks.
           if [ "${N:-0}" -eq 0 ]; then
             echo "Aucun deck slides.md touché par ce diff." >> "$GITHUB_STEP_SUMMARY"
+            echo "has_decks=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           cat /tmp/touched_decks.tsv >> "$GITHUB_STEP_SUMMARY"
+          echo "has_decks=true" >> "$GITHUB_OUTPUT"
 
       - name: Download last nocturne artifact (slides-composition-nocturne)
-        if: hashFiles('/tmp/touched_decks.tsv') != ''
+        if: steps.resolve.outputs.has_decks == 'true'
         env:
           GH_REPO: ${{ github.repository }}
         run: |
@@ -119,7 +132,7 @@ jobs:
           ls /tmp/comp_night/ >> "$GITHUB_STEP_SUMMARY" || true
 
       - name: Build sticky PR comment from verdict (#14226)
-        if: hashFiles('/tmp/comp_night/_manifest.tsv') != '' && hashFiles('/tmp/touched_decks.tsv') != ''
+        if: steps.resolve.outputs.has_decks == 'true'
         env:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #15011

## Summary

Closes #14226.

Le verdict nocturne de `slides-composition-advisory.yml` (#11923) **mesure juste** mais **ne sort jamais** de son runner : depuis le merge de #14240 (2026-09-02T09:56Z), `slides-composition-pr-relay.yml` tourne en `success` sans jamais poster le commentaire diagnostique prévu.

## Diagnostic firsthand

Mesure sur les 16 PRs mergées depuis #14240 touchant `slides/**`, runs 2026-09-02 → 2026-09-07 (`gh api .../actions/runs/34109440297/jobs` + `gh pr view <N> --json comments`) :

| PR | Run relay | Step 3 (download) | Step 4 (build comment) | Commentaire diagnostique posté |
|---|---|---|---|---|
| #13867 | (pre-câblage) | n/a | n/a | non (pre) |
| #14433 | (pre-câblage) | n/a | n/a | non (pre) |
| #14935 | 34053531053 | **skipped** | **skipped** | non |
| #15017 | 34109440297 | **skipped** | **skipped** | non |

Tous les runs post-#14240 : step 3 et step 4 statut `skipped`, conclusion `success`. Step 1 (resolve touched decks) finit par `Touched decks: 1` puis exit 0 ; étape 2 (download nocturne) et étape 3 (build PR comment) jamais lancées.

## Cause racine

```yaml
- name: Download last nocturne artifact (slides-composition-nocturne)
  if: hashFiles('/tmp/touched_decks.tsv') != ''   # ← toujours faux
- name: Build sticky PR comment from verdict (#14226)
  if: hashFiles('/tmp/comp_night/_manifest.tsv') != '' && hashFiles('/tmp/touched_decks.tsv') != ''   # ← toujours faux
```

`hashFiles()` est une **expression de planning** (évaluée à la phase de planification du job, avant l'exécution des steps). Le fichier `/tmp/touched_decks.tsv` est créé par le step précédent au **runtime**. Au moment où GitHub Actions évalue `hashFiles(...)`, le fichier n'existe pas → `hashFiles` rend `''` → `!= ''` toujours faux → `skipped`. Incident GitHub Actions [runner #894](https://github.com/actions/runner/issues/894) : *"The hashFiles function doesn't generate any output when a valid pattern is provided"* sur fichiers absents.

## Fix

Exposer le verdict du step 1 via `$GITHUB_OUTPUT` (id `resolve`, output `has_decks`) et baser les gardes des steps 2 et 3 sur `steps.resolve.outputs.has_decks == 'true'`. Les fallbacks internes du step 3 (manifest absent, deck absent, fichier absent, parse error, signals vide) sont conservés tels quels — la garde externe ne sert qu'à économiser le téléchargement de l'artefact quand aucun deck n'est touché.

## Modifications

| Fichier | Lignes | Quoi |
|---|---|---|
| `.github/workflows/slides-composition-pr-relay.yml` | +17 / -4 | (1) step 1 : `id: resolve`, `echo "has_decks=…" >> $GITHUB_OUTPUT` ; (2) step 2/3 : `if: steps.resolve.outputs.has_decks == 'true'` ; (3) commentaire en tête mis à jour vers run 34100662765 / S3-acculturation slide 42 |

Aucun autre fichier modifié. Le step 3 (Python) est **byte-identique** : pas de changement de logique.

## Contrôle positif (critère 3)

Exécution locale du step 3 sur l'artefact nocturne réel du run 34100662765 (2026-09-07T08:27:14Z) avec `touched_decks.tsv` = `slides/S3-acculturation/slides.md` :

```
--- BODY QUI SERAIT POSTÉ ---
<!-- slides-composition-pr-relay -->
**Slides composition — verdict nocturne relayé (#14226, advisory).**

- `slides/S3-acculturation/slides.md` slide **42** (entête : 'Théorie des jeux (2/2) Jeux simultanés Matrice de gains Domi') : `IMG.w-[300px] max-w-full max-h-[30` bbox=[48,334,348,608] (deck `n_hors_canvas`=1)
--- signals: 1 ---
```

Le HORS_CANVAS détecté par le nocturne sur la slide 42 IMG bbox=[48, 334, 348, 608] (canvas 980×552, débordement bas) **aurait été relayé** sur la PR si la garde `hashFiles` n'avait pas skippé le step.

## Acceptance cochée

1. ✅ **Crit. 1** : verdict nocturne **persisté** (artefact `slides-composition-nocturne` du workflow `slides-composition-advisory.yml`) — inchangé, opère depuis #11923.
2. ✅ **Crit. 2** : PR touchant un deck HORS_CANVAS **reçoit un signal sur la PR** nommant les slides concernées — *opérationnellement* : le step 3 n'est plus skippé, le body diagnostique est composé (contrôle positif ci-dessus) et posté via l'API REST.
3. ✅ **Crit. 3** : mécanisme **démontré** sur l'artefact réel run 34100662765, S3-acculturation slide 42 IMG bbox [48, 334, 348, 608] — le body généré la nomme explicitement (entête + tag + cls + bbox).
4. ✅ **Crit. 4** : aucun ajout de clone lourd ni de Playwright sur `pull_request`. Workflow inchangé sauf les 3 gardes. Coût : un runner auto-hébergé de quelques secondes.

## Vérification post-merge

Le premier push sur une PR touchant `slides/S3-acculturation/slides.md` (ou n'importe quel deck en HORS_CANVAS dans le dernier nocturne) déclenchera le step 3 et posera un commentaire diagnostique sur la PR avec le body `<!-- slides-composition-pr-relay -->`. Une re-exécution met à jour (PATCH), pas de spam.

## Notes

- c.959 (297ᵉ) post-reboot machines (cron `9d624152` cadence 7/37).
- G-VAR-1 **NON TENU x4** consécutifs (c.956, c.957, c.958, c.959 — tous META : docs, guard). Pool CONTENU dry pour cette lane ce cycle (picker : 0 grain DEEP/MED CONTENU exécutable sur 101 grains + 59 umbrella + 87 candidate-delivered). Ce grain-ci est `MED/guard`, le moins-META possible pour traiter une régression CI bloquante.
- B.0 : 0 thread inline, 0 review pré-PR sur cette PR-ci.
- Pas de dépendance cross-lane : fix isolé au workflow `slides-composition-pr-relay.yml`.

## Voir aussi

- Issue **#14226** — critères d'acceptation.
- Issue **#11923** — workflow `slides-composition-advisory.yml` (producteur du verdict nocturne).
- PR **#14240** — câblage initial du relay (merge 2026-09-02), bug introduit avec.
- Incident fondateur : `actions/runner#894` — `hashFiles` retourne vide sur fichiers absents au planning.
