### PR TITLE
fix(lean,#14886): authentifier les clones lake via jeton de job (insteadOf) — stop code 128 anonyme sous rafale

### DIFF
--- a/.github/actions/lean-axiom/action.yml
+++ b/.github/actions/lean-axiom/action.yml
@@ -68,6 +68,17 @@ runs:
         sudo swapon /mnt/lean-swap
         free -h
 
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        # Anonymous clones of lake deps die under a rafale of concurrent Lean jobs:
+        # GitHub demands credentials and git (no TTY) exits code 128, and the package
+        # that drops is whoever crosses the window (See #14886). Route every
+        # github.com clone through the job token so no clone goes anonymous.
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        # Confirm the rewrite is in effect without ever printing the job token.
+        git config --global --get-regexp 'url\..*\.insteadof' | sed -E 's#x-access-token:[^@]+@#x-access-token:***@#g'
+
     - name: Lake build
       shell: bash
       working-directory: ${{ inputs.project-path }}

--- a/.github/actions/lean-build/action.yml
+++ b/.github/actions/lean-build/action.yml
@@ -154,6 +154,17 @@ runs:
         sudo swapon /mnt/lean-swap
         free -h
 
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        # Anonymous clones of lake deps die under a rafale of concurrent Lean jobs:
+        # GitHub demands credentials and git (no TTY) exits code 128, and the package
+        # that drops is whoever crosses the window (See #14886). Route every
+        # github.com clone through the job token so no clone goes anonymous.
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        # Confirm the rewrite is in effect without ever printing the job token.
+        git config --global --get-regexp 'url\..*\.insteadof' | sed -E 's#x-access-token:[^@]+@#x-access-token:***@#g'
+
     - name: Lake build
       shell: bash
       working-directory: ${{ inputs.project-path }}

--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -113,6 +113,17 @@ jobs:
         sudo swapon /mnt/lean-swap
         free -h
 
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        # Anonymous clones of lake deps die under a rafale of concurrent Lean jobs:
+        # GitHub demands credentials and git (no TTY) exits code 128, and the package
+        # that drops is whoever crosses the window (See #14886). Route every
+        # github.com clone through the job token so no clone goes anonymous.
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        # Confirm the rewrite is in effect without ever printing the job token.
+        git config --global --get-regexp 'url\..*\.insteadof' | sed -E 's#x-access-token:[^@]+@#x-access-token:***@#g'
+
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -218,6 +218,17 @@ jobs:
         sudo swapon /mnt/lean-swap
         free -h
 
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        # Anonymous clones of lake deps die under a rafale of concurrent Lean jobs:
+        # GitHub demands credentials and git (no TTY) exits code 128, and the package
+        # that drops is whoever crosses the window (See #14886). Route every
+        # github.com clone through the job token so no clone goes anonymous.
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        # Confirm the rewrite is in effect without ever printing the job token.
+        git config --global --get-regexp 'url\..*\.insteadof' | sed -E 's#x-access-token:[^@]+@#x-access-token:***@#g'
+
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA-2 — prev: MED/lean #15020 (assignment_lean, MERGED)

## Summary

Fix **#14886** — les clones `lake` des dépendances partent **sans authentification** et meurent en `code 128` sous la rafale de jobs Lean concurrents : GitHub exige une identité, `git` (sans TTY) ne peut pas la fournir, et le paquet qui tombe est celui qui passe dans la fenêtre. Mesuré sur le run `34027638170` (PR #14821, `knot_lean`) : fenêtre de ~24 s (10:35:54 → 10:36:18) où `Qq`/`batteries`/`LeanSearchClient` tombent en alternance, quel que soit le dépôt. Cause racine + correctif sont posés dans l'issue.

### Fix

Un step `Authenticate lake's git clones` posé **avant** `lake` (donc avant `lake exe cache get` + `lake -R build`, les deux points de clone) dans les **quatre** chemins de CI qui clonent :

- `.github/actions/lean-build/action.yml` (composite — pool Lean spécialisé)
- `.github/actions/lean-axiom/action.yml` (composite — pool Lean spécialisé)
- `.github/workflows/lean-build.yml` (reusable — 25 lakes non routés)
- `.github/workflows/lean-axiom.yml` (reusable — 25 lakes non routés)

Le step pose `git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"` : **tout** clone `github.com` passe par le jeton du job au lieu de partir anonyme. Aucun changement de source Lean, aucune preuve modifiée.

## Validation (relancée après le commit)

| Check | Résultat |
|---|---|
| YAML (`yaml.safe_load`) | OK sur les 4 fichiers |
| Mécanisme `insteadOf` | `git ls-remote` **à travers la réécriture** rend `HEAD` (un sous-processus `git`, comme lake, la respecte — testé dans un `GIT_CONFIG_GLOBAL` isolé) |
| Masquage jeton | la ligne de confirmation rend `url...insteadof` avec `x-access-token:***` (`sed`), et GitHub masque `github.token` dans les logs — **aucun jeton en clair** |
| Contrôle positif (acceptance #2) | **à exécuter en CI** : un run `knot_lean` **cache vidé sur les 2 jobs** → 18 clones aboutissent, 0 `code 128`. Non reproductible en worker (impossible de vider le cache Actions) |

**B.3 (proof-integrity) : non applicable** — cette PR ne touche aucun `*.lean` ; c'est un fix d'infrastructure CI. Le gate d'intégrité des preuves (axiomes/sorries) ne porte pas sur du contenu modifié ici — seul le **clone** des dépendances change de régime (anonyme → authentifié).

## Résiduel

L'acceptance #2 (contrôle positif à cache froid, 18 clones en parallèle) reste un **run CI à produire** : elle sera couverte au prochain cold-cache du lake après merge. Le fix de mécanisme est prouvé localement ; le contrôle complet appartient à l'exécution CI (un worker ne peut pas vider le cache GitHub Actions).

## Note genre

Grain **META** (`guard`) : ce n'est pas du contenu Lean (aucune preuve/capacité nouvelle) — c'est le garde d'infrastructure qui rend les builds Lean fiables. Livré parce qu'il est **en-dehors de la veine saturée #14773** (vein_cap=2 atteint) et qu'il débloque la CI commune des lakes. Voir le rapport dashboard pour la demande de grain CONTENU du prochain cycle.

See #14886.
