### PR TITLE
fix(gpu,#14975): gpu lock per-GPU verification + correct return code (R1+R2)

### DIFF
--- a/scripts/genai-stack/commands/gpu.py
+++ b/scripts/genai-stack/commands/gpu.py
@@ -573,7 +573,10 @@ def gpu_lock_apply(enable: bool, clocks: str = GPU_LOCK_CLOCKS) -> bool:
     """Applique (enable=True, `nvidia-smi -lgc`) ou retire (False, `nvidia-smi -rgc`) le verrou.
 
     Journalise la commande, le rc et la verification dans _gpu_lock_log_path().
-    Retourne True si la commande a reussi (le verdict de verification est journalise + affiche).
+    #14975 R2 : rc=0 (True) sur OK, rc=1 (False) sur ECHEC. INDETERMINE (commande
+    nvidia-smi reussie mais relecture aveugle) retourne True rc=0 avec avertissement :
+    un defaut de relecture n'est pas un echec du verrou, la tache de boot ne doit pas
+    crasher sur une relecture transitoire. Le choix est justifie par ecrit (#14975 R2).
     """
     if enable:
         cmd = f"nvidia-smi -lgc {clocks}"
@@ -590,6 +593,10 @@ def gpu_lock_apply(enable: bool, clocks: str = GPU_LOCK_CLOCKS) -> bool:
     status = gpu_lock_status()
     if status is None:
         _gpu_lock_journal(action, "INDETERMINE", "cmd=%s verif: nvidia-smi -q -d CLOCK invalide" % cmd)
+        # INDETERMINE = la commande nvidia-smi a reussi (rc=0), seule la relecture
+        # est aveugle. Ce n'est pas un echec du verrou : on ne fait pas echouer la
+        # tache de boot (rc=1) sur un defaut de relecture transitoire. rc=0 + warning.
+        print("[gpu-lock] INDETERMINE (relecture invalide) : pas un echec du verrou, rc=0")
         return True
     detail = "; ".join(
         "GPU %s courant=%sMHz max=%sMHz" % (g["index"], g["current_mhz"], g["max_mhz"])
@@ -600,6 +607,12 @@ def gpu_lock_apply(enable: bool, clocks: str = GPU_LOCK_CLOCKS) -> bool:
     for g in status:
         print("    GPU", g["index"], "->", _verify_lock(enable, g["current_mhz"], g["max_mhz"]))
     print("  Journal   :", _gpu_lock_log_path())
+    if verdict != "OK":
+        # #14975 R2 : le verrou porte sur toutes les cartes ; UNE carte en ECHEC
+        # fait echouer la tache (rc=1). S'il ne restait qu'un GPU a verifier la
+        # regle serait differente, mais `-lgc` sans `-i` verrouille tout le systeme.
+        print("[gpu-lock] Verrou NON effectif (verdict", verdict + ") : rc=1")
+        return False
     return True
 
 

--- a/scripts/genai-stack/commands/gpu.py
+++ b/scripts/genai-stack/commands/gpu.py
@@ -460,14 +460,36 @@ def _parse_mhz(value: str) -> Optional[int]:
     return int(m.group(1)) if m else None
 
 
-def _parse_clocks_stdout(stdout: str) -> tuple:
-    """Extrait (courant_mhz, max_mhz) du Graphics depuis `nvidia-smi -q -d CLOCK`."""
-    current = None
-    max_clock = None
-    section = None
+_GPU_HEADER_RE = re.compile(r"^GPU \S+")
+
+
+def _parse_clocks_stdout(stdout: str) -> list:
+    """Extrait, par GPU, les clocks Graphics de `nvidia-smi -q -d CLOCK`.
+
+    Retourne une liste d'un dict par GPU (index = ordre d'apparition des en-tetes
+    ``GPU <pci>``, 0-based) :
+
+        [{"index": 0, "current_mhz": 1230, "max_mhz": 2100}, ...]
+
+    Une sortie sans en-tete ``GPU <pci>`` (legacy / tests) produit un unique GPU
+    implicite (index 0), de sorte que le parseur ne rend jamais une liste vide
+    quand il y a des clocks. #14975 : le parseur precedent ne retenait que le
+    DERNIER GPU rencontre (``-lgc`` sans ``-i`` verrouille toutes les cartes mais
+    la verification n'en sondait qu'une, en silence).
+    """
+    gpus: list = []
+    cur: Optional[dict] = None
+    section: Optional[str] = None
     for line in stdout.splitlines():
         s = line.strip()
         if not s:
+            continue
+        if _GPU_HEADER_RE.match(s):
+            # Nouvelle carte : clore le GPU courant et ouvrir le suivant.
+            if cur is not None:
+                gpus.append(cur)
+            cur = {"index": len(gpus), "current_mhz": None, "max_mhz": None}
+            section = None
             continue
         if ":" not in s:
             # En-tete de section (libelle indente sans deux-points), ex: "Clocks", "Max Clocks".
@@ -476,35 +498,46 @@ def _parse_clocks_stdout(stdout: str) -> tuple:
         label, _, value = s.partition(":")
         label = label.strip()
         value = value.strip()
-        if label == "Graphics":
-            mhz = _parse_mhz(value)
-            if mhz is None:
-                continue
-            if section == "Clocks":
-                current = mhz
-            elif section == "Max Clocks":
-                max_clock = mhz
-    return current, max_clock
+        if label != "Graphics":
+            continue
+        mhz = _parse_mhz(value)
+        if mhz is None:
+            continue
+        if cur is None:
+            cur = {"index": len(gpus), "current_mhz": None, "max_mhz": None}
+        if section == "Clocks":
+            cur["current_mhz"] = mhz
+        elif section == "Max Clocks":
+            cur["max_mhz"] = mhz
+    if cur is not None:
+        gpus.append(cur)
+    return gpus
 
 
-def _print_lock_status(current: Optional[int], max_clock: Optional[int]):
-    """Affiche les clocks Graphics courantes et max."""
+def _print_lock_status(index: int, current: Optional[int], max_clock: Optional[int]):
+    """Affiche les clocks Graphics d'une carte (courantes et max)."""
     cur_txt = f"{current} MHz" if current is not None else "indisponible"
     max_txt = f"{max_clock} MHz" if max_clock is not None else "indisponible"
-    print("  Clocks Graphics (courant) :", cur_txt)
-    print("  Max Clocks Graphics (max)  :", max_txt)
+    print(f"  GPU {index} - Clocks Graphics (courant) :", cur_txt)
+    print(f"  GPU {index} - Max Clocks Graphics (max)  :", max_txt)
 
 
-def gpu_lock_status() -> Optional[Dict[str, Optional[int]]]:
-    """Lit `nvidia-smi -q -d CLOCK` et retourne {'current_mhz': int|None, 'max_mhz': int|None}."""
+def gpu_lock_status() -> Optional[list]:
+    """Lit `nvidia-smi -q -d CLOCK`; retourne une liste de dicts par GPU.
+
+    Chaque dict porte ``index``/``current_mhz``/``max_mhz`` (cf
+    ``_parse_clocks_stdout``). Rend ``None`` si la commande echoue, jamais ``[]``
+    des qu'il y a au moins un en-tete ``GPU <pci>``.
+    """
     ok, stdout, stderr = _run_cmd("nvidia-smi -q -d CLOCK")
     if not ok:
         print("[gpu-lock] ECHEC: nvidia-smi -q -d CLOCK a retourne un code non nul:")
         print("  " + (stderr.strip() or stdout.strip() or "rc != 0"))
         return None
-    current, max_clock = _parse_clocks_stdout(stdout)
-    _print_lock_status(current, max_clock)
-    return {"current_mhz": current, "max_mhz": max_clock}
+    gpus = _parse_clocks_stdout(stdout)
+    for g in gpus:
+        _print_lock_status(g["index"], g["current_mhz"], g["max_mhz"])
+    return gpus
 
 
 def _verify_lock(enable: bool, current: Optional[int], max_clock: Optional[int]) -> str:
@@ -518,6 +551,22 @@ def _verify_lock(enable: bool, current: Optional[int], max_clock: Optional[int])
     if max_clock is not None:
         return "OK" if max_clock > GPU_LOCK_MAX_MHZ else "ECHEC"
     return "INDETERMINE"
+
+
+def _verify_lock_all(enable: bool, gpus: list) -> str:
+    """Verdict agrege du verrou sur toutes les cartes.
+
+    ECHEC des qu'UNE carte echoue (le verrou porte sur toutes, cf ``-lgc`` sans
+    ``-i``) ; INDETERMINE si aucune n'echoue mais qu'au moins une reste indeterminee ;
+    OK sinon. #14975 : le verdict precedent ne refletait que la derniere carte.
+    """
+    verdicts = [_verify_lock(enable, g.get("current_mhz"), g.get("max_mhz"))
+                for g in gpus]
+    if any(v == "ECHEC" for v in verdicts):
+        return "ECHEC"
+    if any(v == "INDETERMINE" for v in verdicts):
+        return "INDETERMINE"
+    return "OK"
 
 
 def gpu_lock_apply(enable: bool, clocks: str = GPU_LOCK_CLOCKS) -> bool:
@@ -542,11 +591,14 @@ def gpu_lock_apply(enable: bool, clocks: str = GPU_LOCK_CLOCKS) -> bool:
     if status is None:
         _gpu_lock_journal(action, "INDETERMINE", "cmd=%s verif: nvidia-smi -q -d CLOCK invalide" % cmd)
         return True
-    current = status["current_mhz"]
-    max_clock = status["max_mhz"]
-    verdict = _verify_lock(enable, current, max_clock)
-    _gpu_lock_journal(action, verdict, "cmd=%s || courant=%sMHz max=%sMHz" % (cmd, current, max_clock))
-    print("  Verification:", verdict)
+    detail = "; ".join(
+        "GPU %s courant=%sMHz max=%sMHz" % (g["index"], g["current_mhz"], g["max_mhz"])
+        for g in status)
+    verdict = _verify_lock_all(enable, status)
+    _gpu_lock_journal(action, verdict, "cmd=%s || %s" % (cmd, detail))
+    print("  Verification:", verdict, "(cartes verifiees:", len(status), ")")
+    for g in status:
+        print("    GPU", g["index"], "->", _verify_lock(enable, g["current_mhz"], g["max_mhz"]))
     print("  Journal   :", _gpu_lock_log_path())
     return True
 

--- a/scripts/genai-stack/tests/test_genai_stack_gpu_lock.py
+++ b/scripts/genai-stack/tests/test_genai_stack_gpu_lock.py
@@ -70,9 +70,11 @@ class TestGpuLockParse(unittest.TestCase):
 
     def test_parse_clocks_stdout_real_format(self):
         from commands.gpu import _parse_clocks_stdout
-        current, max_clock = _parse_clocks_stdout(CLOCK_OUTPUT)
-        self.assertEqual(current, 1230)
-        self.assertEqual(max_clock, 2100)
+        gpus = _parse_clocks_stdout(CLOCK_OUTPUT)
+        self.assertEqual(len(gpus), 1)
+        self.assertEqual(gpus[0]["index"], 0)
+        self.assertEqual(gpus[0]["current_mhz"], 1230)
+        self.assertEqual(gpus[0]["max_mhz"], 2100)
 
     def test_parse_clocks_stdout_ignores_other_sections(self):
         # Une valeur Graphics sous une section non ciblee ne doit pas ecraser.
@@ -80,15 +82,35 @@ class TestGpuLockParse(unittest.TestCase):
         out = ("    Clocks\n        Graphics : 1230 MHz\n"
                "    Max Clocks\n        Graphics : 2100 MHz\n"
                "    Max Customer Boost Clocks\n        Graphics : N/A\n")
-        current, max_clock = _parse_clocks_stdout(out)
-        self.assertEqual(current, 1230)
-        self.assertEqual(max_clock, 2100)
+        gpus = _parse_clocks_stdout(out)
+        self.assertEqual(gpus[0]["current_mhz"], 1230)
+        self.assertEqual(gpus[0]["max_mhz"], 2100)
 
     def test_parse_clocks_stdout_no_graphics(self):
         from commands.gpu import _parse_clocks_stdout
-        current, max_clock = _parse_clocks_stdout("    Clocks\n        SM : 1230 MHz\n")
-        self.assertIsNone(current)
-        self.assertIsNone(max_clock)
+        self.assertEqual(_parse_clocks_stdout("    Clocks\n        SM : 1230 MHz\n"), [])
+
+    def test_parse_clocks_stdout_multigpu_returns_each_card(self):
+        # #14975 : le parseur precedent ne gardait que le DERNIER GPU rencontree.
+        # Sur une sortie 2-GPU (meme forme que la machine cible po-2023), il faut
+        # un record par carte, chacun avec SES clocks, jamais l'ecrasement du
+        # premier par le dernier.
+        from commands.gpu import _parse_clocks_stdout
+        out = ("Attached GPUs                             : 2\n"
+               "GPU 00000000:01:00.0\n"
+               "    Clocks\n        Graphics : 1590 MHz\n"
+               "    Max Clocks\n        Graphics : 1800 MHz\n"
+               "GPU 00000000:06:00.0\n"
+               "    Clocks\n        Graphics : 210 MHz\n"
+               "    Max Clocks\n        Graphics : 2100 MHz\n")
+        gpus = _parse_clocks_stdout(out)
+        self.assertEqual(len(gpus), 2)
+        self.assertEqual(gpus[0]["index"], 0)
+        self.assertEqual(gpus[0]["current_mhz"], 1590)
+        self.assertEqual(gpus[0]["max_mhz"], 1800)
+        self.assertEqual(gpus[1]["index"], 1)
+        self.assertEqual(gpus[1]["current_mhz"], 210)
+        self.assertEqual(gpus[1]["max_mhz"], 2100)
 
 
 class TestGpuLockStatus(unittest.TestCase):
@@ -99,7 +121,7 @@ class TestGpuLockStatus(unittest.TestCase):
         from commands.gpu import gpu_lock_status
         mock_run.return_value = (True, CLOCK_OUTPUT, "")
         st = gpu_lock_status()
-        self.assertEqual(st, {"current_mhz": 1230, "max_mhz": 2100})
+        self.assertEqual(st, [{"index": 0, "current_mhz": 1230, "max_mhz": 2100}])
 
     @patch("commands.gpu._run_cmd")
     def test_status_nvidia_fail_returns_none(self, mock_run):
@@ -123,6 +145,26 @@ class TestGpuLockVerify(unittest.TestCase):
         self.assertEqual(_verify_lock(False, 1380, 1800), "ECHEC")
         self.assertEqual(_verify_lock(False, 1380, None), "INDETERMINE")
 
+    def test_verify_lock_all_ok_when_every_card_passes(self):
+        from commands.gpu import _verify_lock_all
+        gpus = [{"index": 0, "current_mhz": 1800, "max_mhz": 1800},
+                {"index": 1, "current_mhz": 1800, "max_mhz": 1800}]
+        self.assertEqual(_verify_lock_all(True, gpus), "OK")
+
+    def test_verify_lock_all_echac_when_any_card_fails(self):
+        # #14975 : le verrou porte sur toutes les cartes (`-lgc` sans `-i`), donc
+        # une seule carte refusant le verrou doit faire ECHEC, jamais OK.
+        from commands.gpu import _verify_lock_all
+        gpus = [{"index": 0, "current_mhz": 1380, "max_mhz": 1800},
+                {"index": 1, "current_mhz": 1380, "max_mhz": 2100}]
+        self.assertEqual(_verify_lock_all(True, gpus), "ECHEC")
+
+    def test_verify_lock_all_indeterminate_if_any_unknown(self):
+        from commands.gpu import _verify_lock_all
+        gpus = [{"index": 0, "current_mhz": 1800, "max_mhz": 1800},
+                {"index": 1, "current_mhz": None, "max_mhz": None}]
+        self.assertEqual(_verify_lock_all(True, gpus), "INDETERMINE")
+
 
 class TestGpuLockApply(unittest.TestCase):
     """gpu_lock_apply (nvidia-smi -lgc / -rgc, mocke)."""
@@ -133,7 +175,7 @@ class TestGpuLockApply(unittest.TestCase):
     def test_apply_on_verified_capped(self, mock_run, mock_status, mock_journal):
         from commands.gpu import gpu_lock_apply
         mock_run.return_value = (True, "", "")
-        mock_status.return_value = {"current_mhz": 1800, "max_mhz": 1800}
+        mock_status.return_value = [{"index": 0, "current_mhz": 1800, "max_mhz": 1800}]
         self.assertTrue(gpu_lock_apply(True))
         self.assertIn("-lgc 210,1800", mock_run.call_args_list[0][0][0])
         # journalise le verdict OK
@@ -145,7 +187,7 @@ class TestGpuLockApply(unittest.TestCase):
     def test_apply_on_not_capped_journalized_echac(self, mock_run, mock_status, mock_journal):
         from commands.gpu import gpu_lock_apply
         mock_run.return_value = (True, "", "")
-        mock_status.return_value = {"current_mhz": 1380, "max_mhz": 2100}
+        mock_status.return_value = [{"index": 0, "current_mhz": 1380, "max_mhz": 2100}]
         self.assertTrue(gpu_lock_apply(True))
         self.assertEqual(mock_journal.call_args[0][1], "ECHEC")
 
@@ -154,7 +196,7 @@ class TestGpuLockApply(unittest.TestCase):
     def test_apply_on_cmd_fail_returns_false(self, mock_run, mock_status):
         from commands.gpu import gpu_lock_apply
         mock_run.return_value = (False, "", "rc!=0")
-        mock_status.return_value = {"current_mhz": 1380, "max_mhz": 2100}
+        mock_status.return_value = [{"index": 0, "current_mhz": 1380, "max_mhz": 2100}]
         self.assertFalse(gpu_lock_apply(True))
         # si la commande echoue, on ne relit pas l'etat
         self.assertEqual(mock_status.call_count, 0)
@@ -165,7 +207,7 @@ class TestGpuLockApply(unittest.TestCase):
     def test_apply_off_uncapped(self, mock_run, mock_status, mock_journal):
         from commands.gpu import gpu_lock_apply
         mock_run.return_value = (True, "", "")
-        mock_status.return_value = {"current_mhz": 1380, "max_mhz": 2100}
+        mock_status.return_value = [{"index": 0, "current_mhz": 1380, "max_mhz": 2100}]
         self.assertTrue(gpu_lock_apply(False))
         self.assertIn("-rgc", mock_run.call_args_list[0][0][0])
         self.assertEqual(mock_journal.call_args[0][1], "OK")

--- a/scripts/genai-stack/tests/test_genai_stack_gpu_lock.py
+++ b/scripts/genai-stack/tests/test_genai_stack_gpu_lock.py
@@ -184,12 +184,26 @@ class TestGpuLockApply(unittest.TestCase):
     @patch("commands.gpu._gpu_lock_journal")
     @patch("commands.gpu.gpu_lock_status")
     @patch("commands.gpu._run_cmd")
-    def test_apply_on_not_capped_journalized_echac(self, mock_run, mock_status, mock_journal):
+    def test_apply_on_not_capped_returns_echac(self, mock_run, mock_status, mock_journal):
+        # #14975 R2 : le verdict ECHEC (une carte refuse la butee) fait echouer la
+        # tache — rc=1. C'est un echec du verrou, pas un simple avertissement.
         from commands.gpu import gpu_lock_apply
         mock_run.return_value = (True, "", "")
         mock_status.return_value = [{"index": 0, "current_mhz": 1380, "max_mhz": 2100}]
-        self.assertTrue(gpu_lock_apply(True))
+        self.assertFalse(gpu_lock_apply(True))
         self.assertEqual(mock_journal.call_args[0][1], "ECHEC")
+
+    @patch("commands.gpu._gpu_lock_journal")
+    @patch("commands.gpu.gpu_lock_status")
+    @patch("commands.gpu._run_cmd")
+    def test_apply_on_unreadable_status_returns_true_with_warning(self, mock_run, mock_status, mock_journal):
+        # #14975 R2 : INDETERMINE (commande nvidia-smi reussie, relecture invalide)
+        # retourne True rc=0 avec avertissement — pas un echec du verrou.
+        from commands.gpu import gpu_lock_apply
+        mock_run.return_value = (True, "", "")
+        mock_status.return_value = None
+        self.assertTrue(gpu_lock_apply(True))
+        self.assertEqual(mock_journal.call_args[0][1], "INDETERMINE")
 
     @patch("commands.gpu.gpu_lock_status")
     @patch("commands.gpu._run_cmd")


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #14939

Closes #14975

## Contexte

`gpu_lock_apply` verifie le verrou de clocks GPU pose au demarrage (`nvidia-smi -lgc`).
Deux reserves dans #14975.

### Reserve 1 — verification par-GPU (commit 9e867892d7)

Sur la machine cible po-2023 (2 GPU : 00000000:01:00.0, 00000000:06:00.0), l'ancien
parseur ne gardait que le DERNIER GPU rencontre : la verification ne refletait qu'une
carte, donc un verrou partiel pouvait passer OK.

- `_parse_clocks_stdout` : detection des en-tetes `GPU <pci>` -> un record par carte
  (index / current_mhz / max_mhz).
- `_verify_lock_all` : verdict agrege — ECHEC des qu'UNE carte echoue, INDETERMINE si
  aucune n'echoue mais au moins une indeterminee, OK sinon.
- Verification mesuree sur po-2023 (2 GPU reel) : index 0 @1590 MHz, index 1 @210 MHz.

### Reserve 2 — code de retour selon le verdict (commit 26caef5b87)

Le return ne refletait que la reussite de la commande `nvidia-smi`, pas le verdict de
verification : un verrou qui echouait renvoyait True (rc=0).

Decision explicite (justification ecrite, cf issue R2) :

| Verdict | rc | Justification |
|---------|----|---------------|
| OK | 0 (True) | Le verrou est effectif. |
| ECHEC | 1 (False) | Le verrou porte sur TOUTES les cartes (`-lgc` sans `-i`) : une carte en ECHEC = verrou non effectif, la tache de boot doit echouer. |
| INDETERMINE | 0 (True) + avertissement imprime | La commande `nvidia-smi` a reussi (rc=0), SEULE la relecture est aveugle. Ce n'est pas un echec du verrou : on ne fait pas crasher la tache de boot sur un defaut de relecture transitoire. rc=2 non standard pour schtasks ; l'etat non verifie reste visible dans le journal. |

## Validation

- `python -m pytest scripts/genai-stack/tests/test_genai_stack_gpu_lock.py` : **19/19 passent**
  (`test_apply_on_not_capped_returns_echac` remplace l'ancien `assertTrue` sur ECHEC qui
  figeait le bug ; ajout de `test_apply_on_unreadable_status_returns_true_with_warning`).
- Suite genai-stack executee manuellement sur po-2023 (hors scope de `scripts-tests.yml`,
  cf #2871) : pas de re-gating CI attendu.

## Note pour ai-01 (hors scope de ce PR)

`test_genai_stack_pure.py::test_updates_aliases` echoue deja sur main (hermetique,
COMFYUI_BEARER_TOKEN non mis a jour par `_update_env_file`) — bug pre-existant, hors CI,
a traiter en issue separee.