### PR TITLE
fix(docker,#14974): name fail-closed FORGE_PASSWORD in sd-forge-main/sdnext .env.example

### DIFF
--- a/docker-configurations/services/sd-forge-main/.env.example
+++ b/docker-configurations/services/sd-forge-main/.env.example
@@ -1,2 +1,5 @@
 # SD Forge Main Service Configuration
 SD_FORGE_MAIN_API_KEY=your_sd_forge_main_api_key_here
+
+# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente.
+FORGE_PASSWORD=changeme

--- a/docker-configurations/services/sdnext/.env.example
+++ b/docker-configurations/services/sdnext/.env.example
@@ -1,2 +1,5 @@
 # SD.Next Service Configuration
 SDNEXT_API_KEY=your_sdnext_api_key_here
+
+# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente.
+FORGE_PASSWORD=changeme


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #14939

Closes #14974

## Defaut

#14726 a rendu les services fail-closed sur leur mot de passe (`${VAR:?}`). Mais
`sd-forge-main` et `sdnext` utilisent `${FORGE_PASSWORD:?}` dans leur
`docker-compose.yml` SANS nommer la variable dans leur `.env.example` : un
operateur qui copie le template obtient un `.env` incapable de demarrer le service,
sans explication. `sd-forge-main` est reste down **39 h** sur po-2023 — la lane a
relance 4 fois la demande de secret en visant `WEB_PASSWORD` (nom cote conteneur)
au lieu de `FORGE_PASSWORD` (nom cote `.env`) : le compose ne lit pas le premier.

## Correctif

Ajout dans les DEUX templates (sur le modele de `forge-turbo`, nommer la variable,
pas inventer de convention) :

```
# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente.
FORGE_PASSWORD=changeme
```

- **Aucune valeur reelle** : `changeme` est un placeholder (fichier committe).
- Commentaire d'une ligne conforme a l'acceptance 1 (par instance / locale / jamais centralisee / jamais publiee).
- `FORGE_PASSWORD` reste intentionnellement **hors de `master.env`** (exclusion deliberee, cf issue — hors scope).

## Controle positif (docker compose config)

**sd-forge-main** — absent → rc=1, posee → rc=0 :
```
$ env -u FORGE_PASSWORD docker compose -f docker-configurations/services/sd-forge-main/docker-compose.yml config
rc=1
error while interpolating services.sd-forge-main.environment.[]: required variable FORGE_PASSWORD is missing a value: FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)

$ FORGE_PASSWORD=test docker compose -f docker-configurations/services/sd-forge-main/docker-compose.yml config
rc=0
```

**sdnext** — absent → rc=1, posee → rc=0 :
```
$ env -u FORGE_PASSWORD docker compose -f docker-configurations/services/sdnext/docker-compose.yml config
rc=1
error while interpolating services.sdnext.environment.[]: required variable FORGE_PASSWORD is missing a value: FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)

$ FORGE_PASSWORD=test docker compose -f docker-configurations/services/sdnext/docker-compose.yml config
rc=0
```

## Acceptance 4 — GAP scan (aucune autre service en defaut)

La commande reconductible de l'issue, executee sur l'arbre de la branche :
```
GAP scan (services with ${VAR:?} but no template entry): --- end scan ---
```
**0 variable manquante** sur l'ensemble de `docker-configurations/services/*/`.

## Diff

Atomique : 2 fichiers, +6 lignes (1 commentaire + 1 entree par template).