### PR TITLE
feat(ci): plancher de 2 h entre le dernier commit de tete et le merge

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -200,4 +200,6 @@ jobs:
             --timeout-min 45 \
             --poll-sec 30 \
             --settle-polls 2 \
+            --pr "${{ github.event.pull_request.number }}" \
+            --dwell-min 120 \
             $IS_FORK_ARG

--- a/scripts/ci/merge_dwell.py
+++ b/scripts/ci/merge_dwell.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Plancher de temps entre le DERNIER commit de tete d'une PR et son merge.
+
+Mandat user 2026-09-07 : « Je veux bien un delai de 2h oui stp, si certains
+checks doivent durcir, n'hesite pas. »
+
+Pourquoi ce module existe, et pourquoi il vit DANS le `PR gate`
+--------------------------------------------------------------
+
+Mesure du 2026-09-07 sur la protection de `main` :
+
+    required_status_checks.contexts = ["PR gate"]
+    required_pull_request_reviews  = null
+    strict                          = false
+    enforce_admins                  = false
+
+Une seule surface peut refuser un merge sur ce depot : le check `PR gate`.
+Aucune fenetre horaire n'existe nulle part -- une recherche des motifs
+`datetime.now().hour`, `MERGE_HOURS`, `ALLOWED_HOURS` sur `scripts/` rend
+zero -- et les deux seuls mecanismes temporels du depot ne gatent PAS un
+merge :
+
+  * `DWELL_HOURS_DEFAULT = 24.0` (`scripts/pick_idle_grain.py`) refuse de
+    *proposer* une issue creee il y a moins de 24 h -- c'est un picker, pas
+    un gate ;
+  * l'attente bornee du `PR gate` (`--timeout-min 45`) attend que les
+    constituants concluent -- elle ne differe rien une fois qu'ils sont verts.
+
+D'ou l'attachement retenu : le plancher est evalue par le gate lui-meme,
+**apres** que les constituants ont conclu verts, et **hors** de la boucle
+d'attente. Aucun runner n'est tenu a dormir : un sommeil de 2 h tiendrait
+2 h le slot que l'agregateur occupe deja.
+
+Comment le rouge se leve tout seul
+----------------------------------
+
+Un check-run ne se re-evalue pas : rendu rouge a T+5 min parce que la tete est
+jeune, il resterait rouge pour toujours si personne ne le rejouait. Deux
+organes deja en place rejouent precisement ce cas de figure, sans qu'aucun ne
+soit a ecrire :
+
+  * `pr-gate-rerun.yml` -- `workflow_run` sur la fin d'un garde ;
+  * `pr-gate-stale-sweep.yml` -- balayage horaire (`cron: '7 * * * *'`) qui
+    selectionne exactement « une jambe `PR gate` rouge alors que tout le reste
+    est vert », c'est-a-dire l'etat qu'une PR en attente de plancher presente,
+    et **re-lance le run d'origine** (un POST d'un check-run homonyme atterrit
+    dans une suite etrangere et GitHub ANDe les deux -- mesure #11519).
+
+Consequence a assumer et a dire : le plancher est un PLANCHER, pas une
+horloge. Une PR devient mergeable au premier balayage horaire suivant
+l'ecoulement des 2 h -- donc entre 2 h 00 et 3 h 00 apres son dernier commit,
+pas a 2 h 00 pile.
+
+La date lue est celle du COMMITTER, pas de l'auteur
+---------------------------------------------------
+
+`--amend`, `rebase`, `gh pr update-branch` conservent la date d'auteur et
+rafraichissent celle du committer. Le mandat parle du « dernier commit de
+tete » : c'est la date de committer qui la porte. Une PR rebasee re-arme donc
+son plancher, ce qui est le comportement voulu -- la tete qui va etre mergee
+n'a jamais ete observee 2 h par la CI avant le rebase.
+
+Derogation
+----------
+
+Le label `merge-dwell-waived` leve le plancher pour la PR qui le porte. Il
+existe pour un cas nomme : `main` est rouge et le correctif ne doit pas
+attendre 2 h. Le module dit **dans le message** que la derogation a joue, pour
+qu'elle reste lisible dans le log du gate et pas seulement dans la liste des
+labels.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+
+#: Plancher par defaut, en minutes. 120 = le mandat user du 2026-09-07.
+DEFAULT_DWELL_MIN = 120.0
+
+#: Label qui leve le plancher sur une PR donnee.
+WAIVER_LABEL = "merge-dwell-waived"
+
+
+class DwellError(RuntimeError):
+    """Etat de plancher illisible. Rule 1 du gate : on refuse, on ne passe pas."""
+
+
+def parse_iso8601(value: str) -> datetime:
+    """Parse une date ISO-8601 GitHub (`2026-09-07T09:48:43Z`) en aware-UTC.
+
+    `datetime.fromisoformat` n'accepte le `Z` qu'a partir de Python 3.11 ; le
+    remplacement explicite garde le module lisible sur 3.10, la version
+    plancher annoncee par `CLAUDE.md` section E.
+    """
+    text = (value or "").strip()
+    if not text:
+        raise DwellError("date vide")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise DwellError("date illisible: {!r}".format(value)) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def evaluate(
+    committed_at: datetime,
+    now: datetime,
+    dwell_min: float,
+    waived: bool = False,
+) -> tuple[bool, float, str]:
+    """Decide si le plancher est ecoule. Fonction PURE (testable sans reseau).
+
+    Renvoie `(ok, minutes_restantes, message)`.
+
+    Une horloge qui recule -- tete datee dans le futur, par decalage de machine
+    ou date de committer forgee -- rend l'age negatif : le plancher n'est alors
+    PAS ecoule, et le message le dit. Traiter le futur comme « tres vieux »
+    serait la seule facon de transformer ce garde en passe-plat.
+    """
+    if dwell_min <= 0:
+        return True, 0.0, "dwell desactive (--dwell-min <= 0)"
+    if waived:
+        return True, 0.0, (
+            "dwell leve par le label `{}` "
+            "(plancher {:.0f} min non applique)".format(WAIVER_LABEL, dwell_min)
+        )
+
+    age_min = (now - committed_at).total_seconds() / 60.0
+    remaining = dwell_min - age_min
+    stamp = committed_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if remaining <= 0:
+        return True, 0.0, (
+            "dwell ecoule: tete du {}, {:.0f} min "
+            "(plancher {:.0f} min)".format(stamp, age_min, dwell_min)
+        )
+    return False, remaining, (
+        "tete du {}, {:.0f} min -- plancher {:.0f} min, reste {:.0f} min. "
+        "Le balayage horaire (pr-gate-stale-sweep.yml, cron '7 * * * *') "
+        "re-agrege cette jambe des que le plancher est ecoule ; aucun geste "
+        "manuel n'est requis. Urgence (main rouge) : poser le label `{}` sur "
+        "la PR.".format(stamp, age_min, dwell_min, remaining, WAIVER_LABEL)
+    )
+
+
+def _gh_json(path: str) -> object:
+    try:
+        completed = subprocess.run(
+            ["gh", "api", path],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environnement
+        raise DwellError("gh CLI absent: {}".format(exc)) from exc
+    if completed.returncode != 0:
+        raise DwellError(
+            "gh api {} a echoue (exit {}): {}".format(
+                path, completed.returncode, completed.stderr.strip()[:300]
+            )
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise DwellError("reponse non-JSON de gh api {}".format(path)) from exc
+
+
+def head_committed_at(repo: str, sha: str, fetch=_gh_json) -> datetime:
+    """Date de COMMITTER de `sha`. Leve `DwellError` si elle est illisible."""
+    payload = fetch("repos/{}/commits/{}".format(repo, sha))
+    if not isinstance(payload, dict):
+        raise DwellError("payload commit inattendu pour {}".format(sha[:12]))
+    committer = ((payload.get("commit") or {}).get("committer") or {})
+    date = committer.get("date")
+    if not date:
+        raise DwellError("pas de commit.committer.date sur {}".format(sha[:12]))
+    return parse_iso8601(date)
+
+
+def is_waived(repo: str, pr_number: int, fetch=_gh_json) -> bool:
+    """La PR porte-t-elle `merge-dwell-waived` ?
+
+    Un echec de lecture n'est PAS une derogation : il remonte en `DwellError`
+    et le gate refuse (rule 1). Lire « pas de label » d'une API muette est
+    exactement le zero propre que le harnais interdit de croire.
+    """
+    payload = fetch("repos/{}/pulls/{}".format(repo, pr_number))
+    if not isinstance(payload, dict):
+        raise DwellError("payload PR inattendu pour #{}".format(pr_number))
+    names = {
+        (label or {}).get("name", "")
+        for label in (payload.get("labels") or [])
+        if isinstance(label, dict)
+    }
+    return WAIVER_LABEL in names
+
+
+def check(
+    repo: str,
+    sha: str,
+    pr_number: "int | None",
+    dwell_min: float = DEFAULT_DWELL_MIN,
+    now: "datetime | None" = None,
+    fetch=_gh_json,
+) -> tuple[bool, str]:
+    """Verdict reseau complet. Renvoie `(ok, message)`.
+
+    `pr_number is None` desactive le plancher : le gate tourne alors hors
+    contexte de PR (`workflow_dispatch`), ou son check-run atterrit sur le
+    commit de la branche par defaut et ne peut de toute facon pas bouger le
+    `mergeState` d'une PR (documente en tete de `pr-gate.yml`). Y appliquer
+    un plancher rougirait la branche par defaut sans rien gater.
+    """
+    if dwell_min <= 0 or pr_number is None:
+        return True, "dwell non applicable (hors contexte de PR ou desactive)"
+    waived = is_waived(repo, pr_number, fetch=fetch)
+    committed = head_committed_at(repo, sha, fetch=fetch)
+    ok, _remaining, message = evaluate(
+        committed, now or datetime.now(timezone.utc), dwell_min, waived
+    )
+    return ok, message

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -184,6 +184,18 @@ def is_advisory(name: str, workflow_name: str = "") -> bool:
 # repository root that holds .github/workflows.
 DEFAULT_WORKFLOWS_DIR = str(Path(__file__).resolve().parent.parent / ".github" / "workflows")
 
+# Plancher de temps entre le dernier commit de tete et le merge (mandat user
+# 2026-09-07). Importe tard et de facon defensive : `pr_gate.py` est le seul
+# check requis de `main`, et une ImportError ici bloquerait 100 % des PRs.
+# Absent -> le plancher est simplement inapplicable, jamais un refus.
+try:  # pragma: no cover - chemin d'import
+    from ci import merge_dwell as _merge_dwell
+except ImportError:  # pragma: no cover
+    try:
+        from scripts.ci import merge_dwell as _merge_dwell  # type: ignore
+    except ImportError:
+        _merge_dwell = None  # type: ignore
+
 
 def _norm(name: str) -> str:
     """Normalise a check/job name for the delivery canary: lowercase, collapse
@@ -888,6 +900,21 @@ def wait_and_decide(
         sleep(poll_sec)
 
 
+def _optional_int(raw: str) -> "int | None":
+    """`--pr ""` vaut « pas de PR », pas une erreur d'argparse.
+
+    Le workflow passe `--pr "${{ github.event.pull_request.number }}"` sans
+    condition ; sur un `workflow_dispatch` cette expression rend la chaine
+    vide. Un `type=int` y leverait SystemExit et rendrait le gate rouge pour
+    une raison qui n'a rien a voir avec la PR -- exactement la classe de
+    defaut que l'ancien input `sha` de ce workflow avait deja produite.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    return int(text)
+
+
 def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--repo", required=True, help="owner/name")
@@ -935,6 +962,29 @@ def main(argv: Iterable[str] | None = None) -> int:
         help=(
             "Workflow run id used to self-cancel on starvation (#13510); "
             "defaults to $GITHUB_RUN_ID when the script runs inside Actions."
+        ),
+    )
+    parser.add_argument(
+        "--pr",
+        type=_optional_int,
+        default=None,
+        help=(
+            "Numero de la PR agregee. Requis pour appliquer le plancher de "
+            "merge (--dwell-min) : sans lui le gate ne tourne pas dans un "
+            "contexte de PR et son verdict ne peut pas bouger de mergeState."
+        ),
+    )
+    parser.add_argument(
+        "--dwell-min",
+        type=float,
+        default=0.0,
+        help=(
+            "Plancher, en minutes, entre le dernier commit de tete et le "
+            "merge (mandat user 2026-09-07 : 120). 0 = desactive. Evalue "
+            "APRES que les constituants ont conclu verts, hors de la boucle "
+            "d'attente : aucun runner n'est tenu a dormir. Le rouge se leve "
+            "seul au balayage horaire de pr-gate-stale-sweep.yml. Voir "
+            "scripts/ci/merge_dwell.py."
         ),
     )
     parser.add_argument(
@@ -1036,6 +1086,44 @@ def main(argv: Iterable[str] | None = None) -> int:
                 "FAIL per rule 1",
                 flush=True,
             )
+
+    # --- plancher de merge (mandat user 2026-09-07) ---------------------
+    #
+    # Evalue APRES l'agregation, et seulement si elle est verte : un rouge
+    # de CI est une information plus utile qu'un « attends 2 h », et la
+    # remplacer ferait disparaitre la cause reelle du log.
+    #
+    # Le plancher n'entre PAS dans la boucle d'attente. `wait_and_decide`
+    # tient un slot de runner tant qu'il poll ; l'y faire dormir 120 min
+    # tiendrait ce slot 120 min par PR. Le rouge rendu ici est rejoue par
+    # pr-gate-stale-sweep.yml (cron horaire) des que le plancher est ecoule.
+    if code == 0 and args.dwell_min > 0:
+        if _merge_dwell is None:
+            # Rule 1 ne s'applique pas a une capacite absente : le module
+            # manquant n'est pas un etat de PR inconnu, c'est un depot mal
+            # deploye. Le dire fort, et ne pas bloquer 100 % des PRs.
+            print(
+                "[pr-gate] plancher de merge demande mais "
+                "scripts/ci/merge_dwell.py est introuvable -- plancher NON "
+                "applique (ceci est un defaut de deploiement, pas un vert).",
+                flush=True,
+            )
+        else:
+            try:
+                dwell_ok, dwell_msg = _merge_dwell.check(
+                    args.repo, args.sha, args.pr, args.dwell_min
+                )
+            except _merge_dwell.DwellError as exc:
+                # Ici rule 1 s'applique : l'age de la tete est lisible en
+                # principe, donc ne pas l'avoir lu est un etat inconnu.
+                code, message = 1, (
+                    "FAIL -- plancher de merge illisible: {}".format(exc)
+                )
+            else:
+                if dwell_ok:
+                    print("[pr-gate] {}".format(dwell_msg), flush=True)
+                else:
+                    code, message = 1, "DWELL -- {}".format(dwell_msg)
 
     print(f"[pr-gate] {message}", flush=True)
     _maybe_post_check_run(args, code, message)

--- a/scripts/tests/test_merge_dwell.py
+++ b/scripts/tests/test_merge_dwell.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Tests du plancher de merge (`scripts/ci/merge_dwell.py`, mandat user 2026-09-07).
+
+Ce que ces tests epinglent, par ordre de degat s'ils cassent :
+
+1. **Le plancher refuse vraiment une tete jeune.** Un garde temporel qui rend
+   toujours vert est indiscernable d'un garde debranche -- c'est la premiere
+   chose a mesurer, avant meme la mise en forme du message.
+2. **Le futur n'est pas « tres vieux ».** Une date de committer dans le futur
+   (decalage d'horloge, date forgee) rend l'age negatif ; la seule facon de
+   transformer ce garde en passe-plat serait de la laisser passer.
+3. **Une lecture d'API muette n'est pas une derogation.** `is_waived` sur une
+   reponse illisible doit LEVER, jamais renvoyer False silencieusement -- le
+   zero propre que le harnais interdit de croire.
+4. **Hors contexte de PR, pas de plancher.** Le gate tourne aussi sur
+   `workflow_dispatch`, ou son check-run atterrit sur la branche par defaut :
+   y appliquer un plancher rougirait `main` sans rien gater.
+
+Run: python -m pytest scripts/tests/test_merge_dwell.py
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ci import merge_dwell  # noqa: E402
+
+NOW = datetime(2026, 9, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- 1. le plancher refuse une tete jeune -----------------------------------
+
+def test_tete_jeune_refusee():
+    ok, remaining, msg = merge_dwell.evaluate(NOW - timedelta(minutes=5), NOW, 120.0)
+    assert ok is False
+    assert 114 < remaining <= 115
+    assert "reste 115 min" in msg
+
+
+def test_tete_agee_acceptee():
+    ok, remaining, msg = merge_dwell.evaluate(NOW - timedelta(minutes=121), NOW, 120.0)
+    assert ok is True
+    assert remaining == 0.0
+    assert "dwell ecoule" in msg
+
+
+def test_bord_exact_accepte():
+    """A 120 min pile le plancher est ecoule -- un plancher, pas un plafond."""
+    ok, _, _ = merge_dwell.evaluate(NOW - timedelta(minutes=120), NOW, 120.0)
+    assert ok is True
+
+
+def test_message_de_refus_nomme_le_geste_de_levee():
+    """Le rouge doit dire comment il se leve, sinon il se lit comme un blocage."""
+    _, _, msg = merge_dwell.evaluate(NOW - timedelta(minutes=1), NOW, 120.0)
+    assert "pr-gate-stale-sweep.yml" in msg
+    assert merge_dwell.WAIVER_LABEL in msg
+
+
+# --- 2. le futur n'est pas « tres vieux » -----------------------------------
+
+def test_tete_dans_le_futur_refusee():
+    ok, remaining, _ = merge_dwell.evaluate(NOW + timedelta(minutes=30), NOW, 120.0)
+    assert ok is False
+    assert remaining > 120.0
+
+
+# --- derogation et desactivation --------------------------------------------
+
+def test_label_de_derogation_leve_le_plancher():
+    ok, _, msg = merge_dwell.evaluate(
+        NOW - timedelta(minutes=1), NOW, 120.0, waived=True
+    )
+    assert ok is True
+    assert merge_dwell.WAIVER_LABEL in msg
+    # Controle positif de la meme entree SANS derogation : sans lui, un test
+    # vert ne distingue pas « le label a leve » de « le plancher ne mord pas ».
+    assert merge_dwell.evaluate(NOW - timedelta(minutes=1), NOW, 120.0)[0] is False
+
+
+def test_dwell_nul_desactive():
+    ok, _, _ = merge_dwell.evaluate(NOW - timedelta(minutes=1), NOW, 0.0)
+    assert ok is True
+
+
+# --- 3. une API muette n'est pas une derogation -----------------------------
+
+def test_is_waived_leve_sur_payload_inattendu():
+    with pytest.raises(merge_dwell.DwellError):
+        merge_dwell.is_waived("o/r", 1, fetch=lambda path: [])
+
+
+def test_is_waived_lit_le_label():
+    payload = {"labels": [{"name": "docs"}, {"name": merge_dwell.WAIVER_LABEL}]}
+    assert merge_dwell.is_waived("o/r", 1, fetch=lambda path: payload) is True
+    assert merge_dwell.is_waived(
+        "o/r", 1, fetch=lambda path: {"labels": [{"name": "docs"}]}
+    ) is False
+
+
+def test_head_committed_at_leve_sans_date():
+    with pytest.raises(merge_dwell.DwellError):
+        merge_dwell.head_committed_at(
+            "o/r", "deadbeef", fetch=lambda path: {"commit": {"committer": {}}}
+        )
+
+
+def test_head_committed_at_lit_la_date_du_committer():
+    payload = {
+        "commit": {
+            "author": {"date": "2020-01-01T00:00:00Z"},
+            "committer": {"date": "2026-09-07T09:48:43Z"},
+        }
+    }
+    got = merge_dwell.head_committed_at("o/r", "abc", fetch=lambda path: payload)
+    assert got == datetime(2026, 9, 7, 9, 48, 43, tzinfo=timezone.utc)
+
+
+def test_parse_iso8601_refuse_une_date_vide():
+    with pytest.raises(merge_dwell.DwellError):
+        merge_dwell.parse_iso8601("")
+
+
+# --- 4. hors contexte de PR, pas de plancher --------------------------------
+
+def test_check_sans_numero_de_pr_ne_gate_rien():
+    def boom(path):  # le reseau ne doit meme pas etre touche
+        raise AssertionError("aucun appel gh attendu hors contexte de PR")
+
+    ok, msg = merge_dwell.check("o/r", "abc", None, 120.0, fetch=boom)
+    assert ok is True
+    assert "non applicable" in msg
+
+
+def test_check_bout_en_bout_refuse_une_tete_jeune():
+    def fetch(path):
+        if path.startswith("repos/o/r/pulls/"):
+            return {"labels": []}
+        return {"commit": {"committer": {"date": "2026-09-07T11:55:00Z"}}}
+
+    ok, msg = merge_dwell.check("o/r", "abc", 42, 120.0, now=NOW, fetch=fetch)
+    assert ok is False
+    assert msg.startswith("tete du 2026-09-07T11:55:00Z")
+
+
+def test_check_bout_en_bout_accepte_une_tete_agee():
+    def fetch(path):
+        if path.startswith("repos/o/r/pulls/"):
+            return {"labels": []}
+        return {"commit": {"committer": {"date": "2026-09-07T09:00:00Z"}}}
+
+    ok, msg = merge_dwell.check("o/r", "abc", 42, 120.0, now=NOW, fetch=fetch)
+    assert ok is True
+    assert "dwell ecoule" in msg

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -1191,3 +1191,163 @@ def test_fetch_checks_stops_on_empty_page(monkeypatch):
     checks = pr_gate.fetch_checks("o/r", "deadbeef")
     assert len(checks) == 1
     assert checks[0]["name"] == "a"
+
+
+# --- plancher de merge (--dwell-min, mandat user 2026-09-07) ------------------
+#
+# Le plancher lui-meme est teste dans test_merge_dwell.py (logique pure +
+# lecture d'API). Ce qui suit epingle son CABLAGE dans le gate, c'est-a-dire
+# les quatre facons dont il pourrait mal se brancher :
+#
+#   1. gater une PR etudiante de fork -- la politique bienveillante de
+#      student-pr-reviews.md l'interdit, et aujourd'hui c'est l'ORDRE des
+#      lignes qui l'empeche (le `return 0` du fork precede le bloc dwell).
+#      Un invariant qui ne tient que par un ordre de lignes se casse au
+#      premier refactor sans que rien ne rougisse ;
+#   2. masquer un rouge de CI derriere un rouge de plancher ;
+#   3. exploser sur `--pr ""` (un `workflow_dispatch` rend la chaine vide) ;
+#   4. rendre vert quand l'etat du plancher est ILLISIBLE.
+
+
+def _no_dwell_module(monkeypatch):
+    monkeypatch.setattr(pr_gate, "_merge_dwell", None, raising=False)
+
+
+class _FakeDwell:
+    """Double de `scripts/ci/merge_dwell` : compte ses appels et rend un verdict."""
+
+    DwellError = RuntimeError
+
+    def __init__(self, verdict=(True, "dwell ecoule"), raises=None):
+        self.verdict = verdict
+        self.raises = raises
+        self.calls = []
+
+    def check(self, repo, sha, pr, dwell_min):
+        self.calls.append((repo, sha, pr, dwell_min))
+        if self.raises is not None:
+            raise self.raises
+        return self.verdict
+
+
+def test_fork_pr_is_never_held_by_the_dwell_floor(monkeypatch):
+    """Une PR de fork sort avant le plancher, meme avec --dwell-min actif."""
+    fake = _FakeDwell(verdict=(False, "tete du ..., reste 119 min"))
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide", lambda *_a, **_kw: (0, "PASS")
+    )
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--is-fork",
+         "--pr", "42", "--dwell-min", "120"]
+    )
+    assert code == 0
+    assert fake.calls == [], "le plancher ne doit pas etre consulte sur un fork"
+
+    # Controle positif : le MEME plancher, la MEME PR jeune, sans --is-fork,
+    # rend bien 1. Sans cette moitie, le test ci-dessus serait aussi vert si
+    # le plancher etait globalement inerte.
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef",
+         "--pr", "42", "--dwell-min", "120"]
+    )
+    assert code == 1
+    assert fake.calls == [("o/r", "deadbeef", 42, 120.0)]
+
+
+def test_dwell_does_not_run_when_ci_is_red(monkeypatch):
+    """Un rouge de CI garde son message : le plancher ne le recouvre pas.
+
+    Deux axes partagent un seul rouge (sante CI, age de la tete) ; c'est le
+    compromis assume de loger le plancher dans le gate. Le minimum est que le
+    message dise LEQUEL des deux a parle -- sinon une lane repare un plancher
+    la ou sa CI est cassee.
+    """
+    fake = _FakeDwell(verdict=(False, "reste 119 min"))
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(
+        pr_gate,
+        "wait_and_decide",
+        lambda *_a, **_kw: (1, "FAIL -- failing checks: Lean CI"),
+    )
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef",
+         "--pr", "42", "--dwell-min", "120", "--no-self-cancel"]
+    )
+    assert code == 1
+    assert fake.calls == [], "plancher consulte alors que la CI est rouge"
+
+
+def test_dwell_red_is_prefixed_so_the_cause_is_readable(capsys, monkeypatch):
+    fake = _FakeDwell(verdict=(False, "tete du 2026-09-07T11:55:00Z, reste 115 min"))
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_kw: (0, "PASS"))
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--pr", "7", "--dwell-min", "120"]
+    )
+    assert code == 1
+    assert "DWELL -- tete du 2026-09-07T11:55:00Z" in capsys.readouterr().out
+
+
+def test_empty_pr_argument_means_no_pr(monkeypatch):
+    """`--pr ""` (workflow_dispatch) ne doit pas faire exploser argparse.
+
+    `${{ github.event.pull_request.number }}` rend la chaine vide hors
+    contexte de PR. Un `type=int` y leverait SystemExit et rendrait le gate
+    rouge pour une raison etrangere a la PR.
+    """
+    fake = _FakeDwell()
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_kw: (0, "PASS"))
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--pr", "", "--dwell-min", "120"]
+    )
+    assert code == 0
+    assert fake.calls == [("o/r", "deadbeef", None, 120.0)]
+
+
+def test_unreadable_dwell_state_fails_closed(monkeypatch):
+    """Rule 1 du gate : un etat illisible refuse, il ne passe pas."""
+    fake = _FakeDwell(raises=RuntimeError("gh api a echoue (exit 1)"))
+    fake.DwellError = RuntimeError
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_kw: (0, "PASS"))
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--pr", "7", "--dwell-min", "120"]
+    )
+    assert code == 1
+
+
+def test_missing_dwell_module_says_so_instead_of_passing_silently(capsys, monkeypatch):
+    """Module absent = defaut de deploiement, dit a voix haute, pas un vert muet.
+
+    L'import de `merge_dwell` est defensif a dessein : `pr_gate.py` est le seul
+    check requis de `main`, et une ImportError y bloquerait 100 % des PRs. Le
+    prix de ce choix est qu'un deploiement incomplet n'applique plus le
+    plancher -- ce test garantit que le log le DIT, pour qu'un vert ne se lise
+    jamais comme un plancher tenu.
+    """
+    _no_dwell_module(monkeypatch)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_kw: (0, "PASS"))
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--pr", "7", "--dwell-min", "120"]
+    )
+    assert code == 0
+    assert "plancher NON applique" in capsys.readouterr().out
+
+
+def test_dwell_disabled_by_default(monkeypatch):
+    """Sans --dwell-min, aucun plancher : le defaut reste le gate d'avant."""
+    fake = _FakeDwell(verdict=(False, "reste 119 min"))
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_kw: (0, "PASS"))
+
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef", "--pr", "7"])
+    assert code == 0
+    assert fake.calls == []


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA -- prev: MED/guard #13817

Mandat user 2026-09-07 : « Je veux bien un délai de 2h oui stp, si certains checks doivent durcir, n'hésite pas. »

## Où le plancher est posé, et pourquoi là

La mesure d'abord, la décision ensuite. Protection de `main`, lue le 2026-09-07 :

| Champ | Valeur |
|---|---|
| `required_status_checks.contexts` | `["PR gate"]` |
| `required_pull_request_reviews` | `null` |
| `strict` | `false` |
| `enforce_admins` | `false` |

**Une seule surface peut refuser un merge sur ce dépôt.** Et il n'existe aujourd'hui aucune temporisation de merge nulle part : les deux seuls mécanismes temporels du dépôt sont `DWELL_HOURS_DEFAULT = 24.0` dans `scripts/pick_idle_grain.py` (un *picker* qui refuse de **proposer** une issue trop jeune) et l'attente bornée du gate (`--timeout-min 45`), qui attend que les constituants concluent et ne diffère rien une fois qu'ils sont verts. Ni l'un ni l'autre ne gate un merge.

Le plancher est donc évalué par `PR gate` lui-même. Un check requis séparé aurait demandé une modification de la protection de branche **plus** son propre organe de re-lancement ; en se logeant dans le gate, le plancher hérite gratuitement de `pr-gate-rerun.yml` et de `pr-gate-stale-sweep.yml` — dont le prédicat de sélection est *exactement* « une jambe `PR gate` rouge alors que tout le reste est vert », c'est-à-dire l'état qu'une PR en attente de plancher présente.

**Aucun runner ne dort.** Le plancher est évalué **après** que la boucle d'attente a conclu, jamais dedans. Un sommeil de 2 h tiendrait 2 h le slot `coursia-waiter` que l'agrégateur occupe déjà (`waiting-gate-holds-the-slot-it-waits-for`).

## Le caveat honnête : 2 h 00 – 3 h 00, pas 2 h 00

Un check-run **ne se ré-évalue pas lui-même**. Rendu rouge à T+5 min parce que la tête est jeune, il resterait rouge indéfiniment si personne ne le rejouait. C'est `pr-gate-stale-sweep.yml` qui le relève — et son cron est **horaire** (`'7 * * * *'`).

Conséquence à assumer : **une PR devient mergeable au premier balayage suivant l'écoulement des 2 h, donc entre 2 h 00 et 3 h 00 après son dernier commit de tête.** C'est un plancher, pas une horloge. Descendre à 2 h 00 ± quelques minutes demanderait un cron plus fréquent — un réglage séparé, pas un ajout à cette PR.

## La date lue est celle du COMMITTER

`--amend`, `rebase` et `gh pr update-branch` conservent la date d'**auteur** et rafraîchissent celle du **committer**. Le mandat parle du « dernier commit de tête » : c'est la date de committer qui la porte. **Une PR rebasée ré-arme donc son plancher**, ce qui est le comportement voulu — la tête qui va être mergée n'a jamais été observée 2 h par la CI avant le rebase.

## Dérogation

Label **`merge-dwell-waived`**, créé sur le dépôt par cette tranche. Il existe pour un cas nommé : `main` est rouge et le correctif ne doit pas attendre 2 h. Le module dit **dans le message du gate** que la dérogation a joué, pour qu'elle reste lisible dans le log et pas seulement dans la liste des labels.

## Ce que les tests épinglent (au-delà de la logique)

`scripts/tests/test_merge_dwell.py` (15) couvre la logique pure et la lecture d'API. `scripts/tests/test_pr_gate.py` (+7) couvre le **câblage**, c'est-à-dire les cinq façons dont il pourrait mal se brancher :

1. **Une PR de fork n'est JAMAIS gatée.** La politique bienveillante de `student-pr-reviews.md` l'interdit, et jusqu'ici l'invariant ne tenait **que par l'ordre des lignes** (le `return 0` du court-circuit fork précède le bloc dwell). Un invariant qui tient par un ordre de lignes se casse au premier refactor sans que rien ne rougisse — il porte désormais son test, avec son contrôle positif (même plancher, même PR jeune, sans `--is-fork` → exit 1).
2. **Un rouge de CI n'est pas recouvert par un rouge de plancher.** Deux axes partagent un seul rouge ; le minimum est que le message dise lequel a parlé, d'où le préfixe explicite `DWELL --`.
3. **`--pr ""` vaut « pas de PR »**, pas un `SystemExit`. Sur `workflow_dispatch`, `${{ github.event.pull_request.number }}` rend la chaîne vide ; un `type=int` y aurait rougi le gate pour une raison étrangère à la PR — la classe de défaut exacte de l'ancien input `sha` mort de ce workflow.
4. **Un état de plancher ILLISIBLE refuse** (rule 1 du gate), il ne passe pas. Lire « pas de label » d'une API muette est le zéro propre qu'on ne croit pas.
5. **Module absent = défaut de déploiement DIT dans le log**, jamais un vert muet. L'import est défensif à dessein (`pr_gate.py` est le seul check requis : une `ImportError` y bloquerait 100 % des PRs) ; le prix de ce choix est qu'un déploiement incomplet n'applique plus le plancher, et le log doit le dire.

### Contrôle positif du test, pas seulement du code

Les deux mutations qui cassent réellement le câblage ont été passées **dans l'organe réel**, puis l'arbre restauré :

| Mutation | Résultat |
|---|---|
| retrait du garde `code == 0` (le plancher s'évalue même sur CI rouge) | `test_dwell_does_not_run_when_ci_is_red` **FAILED** |
| perte du court-circuit fork (`if args.is_fork:` → `if False:`) | `test_fork_pr_is_never_held_by_the_dwell_floor` **FAILED** (+ 4 tests fork préexistants) |

```
python -m pytest scripts/tests/test_pr_gate.py scripts/tests/test_merge_dwell.py -q
93 passed in 39.38s
```

## Durcissement proposé, NON appliqué ici : `strict: true`

Le mandat ouvrait la porte (« si certains checks doivent durcir »). La mesure ci-dessus en a fait apparaître un candidat que je n'avais pas cherché : **`strict: false` signifie qu'une PR peut merger sur une base en retard sur `main`** — sa CI est verte contre un `main` qui n'existe plus. C'est ce qui a laissé #15019 merger 26 min après sa création sans jamais voir la tête courante.

Passer `strict: true` obligerait chaque PR à être à jour avant merge. **Je ne le flippe pas unilatéralement** : c'est une modification de la protection de branche (owner-only), et le coût est réel — sur un dépôt à ~180 merges/jour, chaque merge périme toutes les autres PRs et déclenche une vague de `update-branch` + re-CI. Le compromis mérite un arbitrage explicite, pas un effet de bord de cette PR.

## Portée

`Grain: MED/guard` — genre **META**, donc cette PR ne tient **pas** le plancher de contenu G-VAR-1 de mon cycle ; elle répond à un mandat user direct. G-VAR-3 : même genre que `prev` (#13817, guard) — substance genuinement distincte (là un vocabulaire clos de tags d'agent pour les verdicts de titre, ici un plancher temporel dans le gate de merge), ce que la règle autorise pour un MED hors liste LIGHT.

See #9819 (le gate lui-même).
