### PR TITLE
docs(env,#14926): 4 gabarits .env.example vers claudish models.myia.io/v1 (#14952)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/.env.example
@@ -133,10 +133,12 @@ OPENAI_CHAT_MODEL_ID=gpt-5-mini
 # Nom du endpoint OpenAI (pour Semantic Kernel)
 OPENAI_ENDPOINT_NAME=OpenAI
 
-# Endpoint vLLM partagé utilisé par le notebook Texte/10b (optionnel)
+# Endpoint LLM partagé utilisé par le notebook Texte/10b (optionnel)
+# Via claudish (proxy myia.io) — la clé de service vLLM a été rotatée, les
+# consommateurs passent par claudish avec CLAUDISH_PROXY_KEY.
 # VLLM_ENDPOINT_NAME=vllm-qwen3.6
-# VLLM_BASE_URL=http://192.168.0.47:5002/v1
-# VLLM_API_KEY=your_vllm_api_key_here
+# VLLM_BASE_URL=https://models.myia.io/v1
+# CLAUDISH_PROXY_KEY=your_claudish_proxy_key_here
 # VLLM_MODEL_ID=qwen3.6-35b-a3b
 #
 # Endpoints locaux supplementaires (optionnel)
@@ -294,12 +296,12 @@ GITHUB_ACCESS_TOKEN=your_github_token_here
 # Mini: ZwZ-8B AWQ-4bit (vision specialisee, 135 tok/s, GPU 2)
 TGWUI_MINI_API_URL=https://api.mini.text-generation-webui.myia.io/v1
 # Medium: Qwen3.5-35B-A3B GPTQ-Int4 (vision+thinking, 86 tok/s, GPUs 0,1)
-TGWUI_MEDIUM_API_URL=https://api.medium.text-generation-webui.myia.io/v1
+TGWUI_MEDIUM_API_URL=https://models.myia.io/v1
 #
-# Pour utiliser un LLM local au lieu d'OpenAI, configurez comme endpoint 2 ou 3
+# Pour utiliser un LLM hébergé au lieu d'OpenAI, configurez comme endpoint 2 ou 3
 # dans la section 2 ci-dessus, ou directement :
-# OPENAI_BASE_URL=https://api.medium.text-generation-webui.myia.io/v1
-# OPENAI_API_KEY=your_vllm_api_key_here
+# OPENAI_BASE_URL=https://models.myia.io/v1
+# CLAUDISH_PROXY_KEY=your_claudish_proxy_key_here
 # OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b
 
 # ============================================================================

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/.env.example
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/.env.example
@@ -34,15 +34,15 @@ ZAI_BASE_URL="https://open.bigmodel.cn/api/paas/v4"
 ZAI_CHAT_MODEL_ID="glm-5.1"
 
 # ============================================================
-# Qwen 3.6 35B-A3B local (vLLM sur ai-01, port 5002)
+# Qwen 3.6 35B-A3B via claudish (proxy myia.io)
 # Utiliser en mode "thinking" pour les agents Search/Tactic peu gourmands
 # ============================================================
 
-# Endpoint vLLM local (compatible OpenAI Chat Completions)
-QWEN_LOCAL_BASE_URL="http://localhost:5002/v1"
+# Endpoint OpenAI-compatible via claudish
+QWEN_LOCAL_BASE_URL="https://models.myia.io/v1"
 
-# Bearer token (defini dans la config vLLM ai-01, voir GenAI/.env OPENAI_API_KEY_3)
-# QWEN_LOCAL_API_KEY=...
+# Cle du proxy claudish (voir GenAI/.env CLAUDISH_PROXY_KEY)
+# CLAUDISH_PROXY_KEY=your_claudish_proxy_key_here
 
 # Modele expose par vLLM
 QWEN_LOCAL_CHAT_MODEL_ID="qwen3.6-35b-a3b"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/.env.example
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/.env.example
@@ -28,9 +28,9 @@ DEPLOYER_PRIVATE_KEY=0x<FILL_YOUR_TESTNET_PRIVATE_KEY>
 # LLM APIs (for SC-11 LLM-Assisted notebook)
 # ============================================================
 
-# Option 1: Local LLM (OpenAI-compatible endpoint)
-LLM_API_URL=http://localhost:5002/v1
-LLM_API_KEY=your_local_key
+# Option 1: LLM via claudish (OpenAI-compatible endpoint)
+LLM_API_URL=https://models.myia.io/v1
+CLAUDISH_PROXY_KEY=your_claudish_proxy_key_here
 LLM_MODEL=default
 
 # Option 2: OpenRouter (all frontier models)
@@ -39,7 +39,7 @@ OPENROUTER_API_KEY=sk-or-v1-your_key_here
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
 # OpenAI-compatible alias (used by SC-11)
-OPENAI_API_KEY=${LLM_API_KEY}
+OPENAI_API_KEY=${CLAUDISH_PROXY_KEY}
 OPENAI_BASE_URL=${LLM_API_URL}
 
 # ============================================================

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example
@@ -15,7 +15,7 @@ OPENAI_CHAT_MODEL_ID=google/gemini-3.5-flash
 # OPENAI_BASE_URL=https://api.openai.com/v1
 # OPENAI_CHAT_MODEL_ID=gpt-4o-mini
 
-# --- Option C : modele auto-heberge (vLLM / Ollama, API OpenAI-compatible) ---
-# OPENAI_API_KEY=<token-local>
-# OPENAI_BASE_URL=http://localhost:5002/v1
+# --- Option C : modele via claudish (proxy myia.io, API OpenAI-compatible) ---
+# CLAUDISH_PROXY_KEY=your_claudish_proxy_key_here
+# OPENAI_BASE_URL=https://models.myia.io/v1
 # OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: MED/notebook-dotnet #14969

See #14926

## Ce qui est livre

Les 4 gabarits `.env.example` enseignant l'ancienne cible vLLM morte (`192.168.0.47:5002` / `localhost:5002`, cle de service rotee → 401) pointent desormais la cible OpenAI de claudish et nomment `CLAUDISH_PROXY_KEY` :

1. `MyIA.AI.Notebooks/GenAI/.env.example` — bloc `VLLM_BASE_URL` (plus l.297/l.301 `OPENAI_BASE_URL`).
2. `MyIA.AI.Notebooks/SymbolicAI/Lean/.env.example` — `QWEN_LOCAL_BASE_URL`.
3. `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/.env.example` — `LLM_API_URL` (consomme par `OPENAI_BASE_URL=${LLM_API_URL}` l.43).
4. `MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/.env.example` — `OPENAI_BASE_URL` (Option C, commente).

`CLAUDISH_PROXY_KEY` remplace la variable de cle de service ; le placeholder reste explicite (`your_claudish_proxy_key_here`), **aucune valeur de secret ni empreinte** dans le diff.

## Verifications

- Diff = **exactement 4 fichiers** (`git diff --stat` : 4 files changed, +21/-19).
- `grep "192.168.0.47:5002|localhost:5002"` sur les 4 fichiers → **NONE** (aucune cible morte restante).
- `grep "CLAUDISH_PROXY_KEY"` → present dans les 4 gabarits.
- **Controle positif do** : la cible `https://models.myia.io/v1` est celle verifiee firsthand dans #14952 (rend 200 avec completion reelle sur `qwen3.6-35b-a3b`, en-tete `Authorization: Bearer ${CLAUDISH_PROXY_KEY}` ou `x-proxy-key`).

## Hors scope (non touche)

- Aucun `.ipynb`, `.cs`, `.py` (les consommateurs runtime exigent une re-execution reelle, regle C.2 — traites ailleurs).
- `docs/reference/cluster-agents.md` (decrit la topologie, ne configure personne).
- `translations/**` (derive).
- `TGWUI_MINI_API_URL` (GenAI l.295) et les endpoints `_2`/`_3` (l.148-154) referencent encore l'ancien facade `*.text-generation-webui.myia.io` : **non enonces par l'issue** (elle valide seulement le medium `qwen3.6-35b-a3b` via claudish). Laisses en l'etat conformement a l'enumeration exacte de #14952.

## Definition of done

- [x] Les 4 gabarits pointent la cible OpenAI de claudish (`https://models.myia.io/v1`).
- [x] Les 4 gabarits nomment `CLAUDISH_PROXY_KEY`.
- [x] Diff = uniquement ces 4 fichiers.
- [x] Aucune valeur de secret n'y figure.