### PR TITLE
fix(genai,#15043): T01 prose — client non valide sans appel API; haiku = historique fourni

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -115,7 +115,7 @@
     "   - Récapitulatif des points abordés\n",
     "   - Proposition d’activité (rédaction d’une synthèse ou d’une extension)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Introduction à l'IA Générative\n",
     "\n",
@@ -337,7 +337,7 @@
     "**Vérifications effectuées** :\n",
     "1. **Packages installés** : `openai`, `tiktoken`, `python-dotenv`\n",
     "2. **Configuration chargée** : Le fichier `.env` a été lu avec succès\n",
-    "3. **Client initialisé** : Le message \"Client OpenAI initialisé avec succès\" confirme que `OPENAI_API_KEY` est valide\n",
+    "3. **Client configuré** : `client = OpenAI()` s'est construit sans erreur — la clé a été chargée depuis `.env`, mais sa **validité n'est confirmée que par un premier appel API** (cellule suivante). Construire le client **ne prouve pas** que la clé fonctionne.\n",
     "\n",
     "**Fichiers de configuration** :\n",
     "\n",
@@ -346,11 +346,11 @@
     "| `.env` | Stocke `OPENAI_API_KEY` (secret) | `MyIA.AI.Notebooks/GenAI/.env` |\n",
     "| `.env.example` | Template sans secrets | Même répertoire (versionné Git) |\n",
     "\n",
-    "**Important** : \n",
+    "**Important** :\n",
     "- Le fichier `.env` ne doit **jamais** être commité dans Git (vérifié via `.gitignore`)\n",
     "- La clé API est chargée automatiquement par `OpenAI()` via la variable d'environnement\n",
     "\n",
-    "**Prochaine étape** : Tester un premier appel API pour valider la connexion au service OpenAI."
+    "**Prochaine étape** : Tester un premier appel API pour **valider la connexion au service** — c'est cet appel, et non la construction du client, qui confirme la clé."
    ]
   },
   {
@@ -386,7 +386,7 @@
     "Dans ce notebook, nous utilisons principalement la **Chat Completions API** via `client.chat.completions.create()` (syntaxe moderne). \n",
     "[En savoir plus dans la documentation officielle](https://platform.openai.com/docs/api-reference/chat).\n",
     "\n",
-    "---\n"
+    "***\n"
    ]
   },
   {
@@ -631,13 +631,15 @@
     "\n",
     "**Analyse de la conversation** :\n",
     "1. **Message system** : \"Tu es un assistant poétique qui répond toujours en haiku\"\n",
-    "2. **Première réponse** : Le modèle a produit un haiku sur la tour Eiffel (3 vers, structure 5-7-5 syllabes)\n",
-    "3. **Deuxième réponse** : Le modèle maintient la contrainte haiku même pour l'auto-critique de son poème\n",
+    "2. **Haiku fourni** : Le poème sur la tour Eiffel (\"Fleur de fer dressee…\") **n'est pas une sortie de cet appel** : il a été injecté comme message `assistant` dans l'historique fourni. C'est un **exemple d'historique** (comment on fabrique un contexte), pas une production du modèle interrogé.\n",
+    "3. **Réponse du modèle** : À la dernière question (\"Que penses-tu de ton poème ?\"), le modèle **maintient la contrainte haiku** et produit son propre poème (voir la sortie réelle de la cellule ci-dessus).\n",
     "\n",
-    "**Capacités observées** :\n",
+    "**Capacités observées** (sur la sortie réellement obtenue) :\n",
     "- **Mémoire de rôle** : Le modèle conserve le rôle \"poétique\" sur plusieurs tours\n",
-    "- **Contrainte formelle** : Respect de la structure haiku (syllabique et thématique)\n",
-    "- **Cohérence conversationnelle** : Le modèle inclut les messages `assistant` précédents pour maintenir le contexte\n",
+    "- **Contrainte de forme** : La réponse réellement obtenue poursuit en vers courts, en cohérence avec la consigne \"répond toujours en haiku\" (aucun comptage syllabique n'est effectué ici)\n",
+    "- **Cohérence conversationnelle** : Le modèle répond à la dernière question utilisateur en tenant compte du contexte fourni (messages `system` et `assistant` injectés)\n",
+    "\n",
+    "**Leçon** : Un texte placé en `role: assistant` est un **exemple d'historique**, pas une production du modèle interrogé — distinguer les deux est essentiel pour lire une conversation API.\n",
     "\n",
     "**Applications pratiques** :\n",
     "\n",
@@ -1532,7 +1534,7 @@
     "   - Conseils avancés pour concevoir des prompts clairs et informatifs.\n",
     "\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "Merci d'avoir suivi cette introduction au monde de l'IA générative !"
    ]


### PR DESCRIPTION
Closes #15043

Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15008

## Contexte

Fille de l'audit Astra #3 (#15035). P1 — notebook de la demonstration de
mercredi (`MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb`). Deux defauts
de prose.

## Defaut 1 — « client initialisé » présente comme preuve de clé valide

La cellule code `[T01:c4]` **construit** le client ; le premier appel réel
arrive plus loin (`[T01:c10]`). La cellule markdown `[T01:c7]` (id
`b2ae1675`) affirmait que le message "Client OpenAI initialisé avec succès"
confirme que `OPENAI_API_KEY` est valide.

**Correction** : le client est **configuré** (construit sans erreur) ; sa
**validité n'est confirmée que par le premier appel API**. Construire le
client ne prouve pas que la clé fonctionne. La transition vers la cellule
suivante explicite : « c'est cet appel, et non la construction du client, qui
confirme la clé ».

## Defaut 2 — un haiku attribué au modèle qui ne l'a pas écrit

La cellule code `[T01:c13]` (id `f7369f94`) injecte un haiku sur la tour
Eiffel ("Fleur de fer dressee...") comme message `assistant` dans
l'historique. La cellule markdown `[T01:c14]` (id `a45c3a56`) affirmait que
le modèle l'a produit (« Le modèle a produit un haiku... 3 vers, structure
5-7-5 syllabes ») — ce poème n'est **pas une sortie de cet appel**, et aucun
comptage syllabique n'est effectué.

**Correction** : présenté comme un **exemple d'historique fourni** (comment on
fabrique un contexte), pas une production du modèle interrogé. La lecture ne
commente plus que la **réponse réellement obtenue** ("Écho de mon cœur /
Courbe, fier, caresse le ciel / Silence d'acier"), sans affirmation
syllabique non vérifiée.

**Leçon pédagogique ajoutée** : distinguer le rôle `assistant` dans les
données de la provenance d'un texte.

## Acceptation (verbatim #15043)

> Chaque observation est rattachée à une sortie de la cellule correspondante ;
> le texte injecté n'est pas attribué au modèle interrogé. Une clé non
> fonctionnelle n'est jamais annoncée comme validée sur la seule construction
> du client.

Les deux observations corrigées s'y conforment.

## Preuves

- **Reassessed by myia-po-2026**: CONFIRMED — source relue cellule par cellule
  (`gh issue view 15043` puis lecture directe des cellules c4/c7/c10/c13/c14).
- **Prose uniquement** (markdown) → exception C.2 (outputs précédents valides).
- Aucune cellule code ni sortie touchée ; `execution_count`/`outputs` inchangés.
- JSON valide (`json.load`), pre-commit H.3 `check-null-exec` PASSED.

## Note sur 3 normalisations de séparateur

Le hook pre-commit `fix-hr-separator` (convention `***`, cf #11451/#12075) a
converti 3 séparateurs décoratifs `---` → `***` dans des cellules markdown non
concernées par le fix (cell[3] `902813b9`, cell[8] `fc9e74bf`, cell[33]
`03d41848`). Normalisation auto-imposée par le hook (rendu `<hr>` identique) ;
aucun `--no-verify` utilisé.

## Diff

```
MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb | 13 insertions(+), 11 deletions(-)
```

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>