### PR TITLE
fix(rules,#15042): la digestion remplace le stub comme remede du cas 1 d'etiquetage

### DIFF
--- a/.claude/rules/exercise-example-labeling.md
+++ b/.claude/rules/exercise-example-labeling.md
@@ -8,6 +8,8 @@ S'applique a **tous les agents de-leak** (po-2023, po-2024, po-2025, po-2026, ai
 
 **Source** : mandat user 2026-05-20 (cours EPITA-IS live). Apres une frenesie de relabels contradictoires entre agents (le "pendule"), le user a impose une regle unique pour arreter le chaos. Broadcast dashboard workspace CoursIA 2026-05-20T09:25Z.
 
+**Amendement user 2026-09-07** (arbitrage #15042, signale par l'audit Astra #3) : le remede du cas 1 devient la **digestion**, pas le stub. Verbatim : « La regle devrait demander la digestion en exemple guide et la proposition d'un nouvel exercice en cas de leak (ou de soumission legitime). »
+
 ## Principe (HARD)
 
 Un notebook pedagogique DOIT contenir des **Exemples** (resolus) ET des **Exercices** (non resolus). Les deux **COHABITENT**. Quand un exercice est resolu/soumis il devient un exemple, et de nouveaux exercices sont ajoutes a la suite. Ne jamais "purger" l'un au profit de l'autre.
@@ -17,18 +19,36 @@ Un notebook pedagogique DOIT contenir des **Exemples** (resolus) ET des **Exerci
 - Cellule code = **solution complete fonctionnelle** => c'est un **EXEMPLE**. Label "Exemple" / "Exemple guide". **NE JAMAIS stubber, NE JAMAIS relabeler en Exercice.**
 - Cellule code = **stub** (squelette / `# TODO` / "a completer" / `print("...a completer")` / `pass` / `return None`) => c'est un **EXERCICE**. Garder en stub. **NE JAMAIS remplir la solution.**
 
-## Seul vrai leak a corriger (les 2 seuls cas)
+## Les 2 seuls cas a corriger
 
-1. Titre "**Exercice**" + cellule code = solution complete => **stubber le code** (garder le titre Exercice, conserver `# TODO`/`# Indice`/`# Etape N`).
+1. Titre "**Exercice**" + cellule code = solution complete => **digerer** (procedure ci-dessous). **Ne PAS stubber le code.**
 2. Titre "**Exemple**" + cellule code = stub vide => **relabeler le titre en Exercice**.
 
 Tout le reste est deja dans l'etat cible : ne pas toucher.
+
+## Digestion (remede du cas 1, HARD)
+
+Trois gestes, dans cet ordre, et **le premier est une conservation** :
+
+1. **Retitrer** la section en "Exemple guide" — le contenu decide du label (section precedente), donc c'est le titre qui est faux, jamais le code.
+2. **Conserver le code tel quel, avec son attribution s'il en porte une** (nom de groupe, d'etudiant, numero de PR de rendu). Une resolution attribuee est un livrable pedagogique, pas une fuite.
+3. **Ajouter a la suite un nouvel exercice non resolu** qui mesure quelque chose de neuf — pas une reformulation du meme enonce. Sans ce troisieme geste, le notebook perd une activite et la digestion appauvrit le catalogue.
+
+**La cause d'origine ne change pas le geste.** Une solution d'instructeur laissee en place (leak) et un rendu d'etudiant merge (soumission legitime) se digerent **de la meme facon** : le notebook ne garde aucune trace de la difference, et un agent qui rencontre le resultat ne peut pas la reconstituer.
+
+**Un "Exemple guide" est TERMINAL.** Il ne redeclenche ni le cas 1 (son titre n'est plus "Exercice") ni le cas 2 (son code n'est pas un stub). Ne pas inventer un cas 3 pour le re-traiter : c'est l'etat cible, pas une etape.
+
+**Precedent dans le depot** : `Texte/4_Function_Calling.ipynb` c45/c52, "EXEMPLE CORRIGE — Assistant de Planification Multi-Outils" — resolution conservee et titree, exercices maintenus a cote.
+
+**Pourquoi ce remede et pas le stub** : le protocole de TP (correction user 2026-09-07, EPIC #15035) veut que **chaque groupe rende au moins un exercice corrige, different d'une session a l'autre**. La digestion est le mecanisme qui rend ce cycle soutenable — le catalogue s'enrichit d'un exemple attribue et d'un exercice neuf a chaque rendu. Stubber la resolution effacerait le travail etudiant que ce cycle produit, et [anti-regression.md](anti-regression.md) le classe deja en regression de contenu.
 
 ## Interdits (= la source du chaos)
 
 - **find-replace aveugle** de titres "Exercice" <-> "Exemple" (= gaming du leak-scanner, incidents #1214 / #1336).
 - **resoudre un stub d'exercice** (remplir la solution).
 - **transformer un exemple resolu en exercice** (stubber un worked-example).
+- **stubber une resolution attribuee** a un groupe ou a un etudiant — c'est le cas 1 mal traite, et ce que l'amendement 2026-09-07 ferme.
+- **digerer a moitie** : retitrer sans ajouter le nouvel exercice laisse le notebook avec une activite de moins.
 - **reverter des relabels deja valides** (cf #1343 ferme comme redondant).
 
 ## Reference validee user (etat CIBLE)
@@ -45,9 +65,11 @@ Le stub d'exercice n'utilise **jamais** `raise NotImplementedError` / `assert Fa
 - **#1336** : rootcause de #1214 documente.
 - **#1343** : revert redondant ferme (ne pas re-reverter des relabels deja valides).
 - **EPIC #1344** : Planners de-leak (convention appliquee : stub = objectif + squelette, PAS verbatim/solution).
+- **#15042** : la regle prescrivait deux gestes opposes sur le meme objet — "NE JAMAIS stubber" (classification par contenu) contre "stubber le code" (cas 1). Signale par l'audit Astra #3 sur `RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb` c30/c32/c34. Tranche par le user le 2026-09-07 en faveur de la digestion.
 
 ## Voir aussi
 
 - [.claude/rules/anti-regression.md](anti-regression.md) — ne pas stripper une cellule `# Solution` / `# Exemple resolu` demonstrative.
 - [.claude/rules/notebook-conventions.md](notebook-conventions.md) — C.1 stubs sans erreur volontaire, C.2 outputs.
+- [.claude/rules/three-exercises-per-notebook.md](three-exercises-per-notebook.md) — le nouvel exercice ajoute par la digestion compte dans ce plancher.
 - CLAUDE.md section C — regles notebooks 2026-04-26.


### PR DESCRIPTION
Grain: MED/docs -- lane myia-ai-01:CoursIA -- prev: MED/guard #15034

See #15042 · fille de #15035 (audit Astra #3)

## La contradiction

`.claude/rules/exercise-example-labeling.md` prescrivait **deux gestes opposés sur exactement le même objet** — une solution complète sous un titre « Exercice » :

| Ligne | Section | Prescription |
|---:|---|---|
| **17** | Classification PAR CONTENU | *« Cellule code = solution complète fonctionnelle ⇒ c'est un EXEMPLE. **NE JAMAIS stubber**, NE JAMAIS relabeler en Exercice. »* |
| **22** | Cas 1 | *« Titre "Exercice" + cellule code = solution complète ⇒ **stubber le code** (garder le titre Exercice). »* |

C'est la forme de `RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb` c30/c32/c34, relevée par l'audit Astra #3 : trois cellules qui implémentent réellement le benchmark de dimension, le prix du rappel et le filtre combiné, sous des titres d'exercice.

## L'arbitrage

Tranché par le user le 2026-09-07, verbatim :

> « La règle devrait demander la digestion en exemple guidé et la proposition d'un nouvel exercice en cas de leak (ou de soumission légitime) »

Le remède du cas 1 devient la **digestion**. Sa **détection** est inchangée.

| | Avant | Après |
|---|---|---|
| Cas 1 détecté | titre « Exercice » + code = solution complète | *(inchangé)* |
| Geste | **stubber le code**, garder le titre | **retitrer en « Exemple guidé »**, conserver le code **et son attribution**, **et ajouter à la suite un nouvel exercice non résolu** |

Cela aligne le cas 1 sur la ligne 17 et sur le principe que la règle portait déjà en ligne 13 : *« Quand un exercice est résolu/soumis il devient un exemple, et de nouveaux exercices sont ajoutés à la suite. »* **La bonne doctrine était dans le principe ; c'est le remède opérationnel qui la contredisait.**

Le cas 2 (« Exemple » + stub vide ⇒ relabeler en Exercice) est inchangé : il ne détruit rien.

## Deux points que l'arbitrage user élargit au-delà de ce qui était proposé

1. **La cause d'origine ne change pas le geste.** Une solution d'instructeur laissée en place (*leak*) et un rendu d'étudiant mergé (*soumission légitime*) se digèrent identiquement. C'est le point important : le notebook résultant ne garde **aucune trace** de la différence, donc un agent qui rencontre le résultat ne peut pas la reconstituer — une règle qui distinguerait les deux serait inapplicable par construction.
2. **La digestion à moitié devient un interdit nommé.** Retitrer sans ajouter le nouvel exercice laisse le notebook avec une activité de moins ; sur un catalogue où chaque groupe pioche, c'est un appauvrissement silencieux.

## Pourquoi ça n'attendait pas

Le protocole de TP corrigé par le user (#15035) veut que **chaque groupe rende au moins un exercice corrigé, différent d'une session à l'autre**. Ce cycle produit donc, à chaque session, exactement la forme que le cas 1 détectait — et un agent de-leak l'appliquant à la lettre **aurait effacé les résolutions attribuées** à des étudiants nommés, que §8 de l'audit demande explicitement de préserver et que [anti-regression.md](../blob/main/.claude/rules/anti-regression.md) classe déjà en régression de contenu.

## Ce que la règle gagne

- **« Exemple guidé » est déclaré TERMINAL** — il ne redéclenche ni le cas 1 (titre changé) ni le cas 2 (code non-stub). Sans cette phrase, rien n'empêchait un agent d'inventer un cas 3 pour re-traiter l'état cible ; c'est le mécanisme exact du « pendule » que cette règle existe pour arrêter.
- **Un précédent citable** plutôt qu'une prescription abstraite : `Texte/4_Function_Calling.ipynb` c45/c52, « EXEMPLE CORRIGÉ — Assistant de Planification Multi-Outils ».
- **Un interdit de plus** dans la liste : *stubber une résolution attribuée*.

## Vérifications firsthand

Chaque référence introduite a été vérifiée sur l'arbre, pas citée de mémoire :

| Référence | Vérification |
|---|---|
| `anti-regression.md`, `notebook-conventions.md`, `three-exercises-per-notebook.md` | les trois fichiers existent dans `.claude/rules/` |
| `Texte/4_Function_Calling.ipynb` | existe, et `grep -c "EXEMPLE CORRIG"` rend **2** (c45 et c52) |
| `RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb` | existe |

Le lien vers `three-exercises-per-notebook.md` est ajouté à dessein : le nouvel exercice produit par la digestion compte dans ce plancher, et sans le lien la digestion se lit comme une obligation isolée.

## Périmètre

Un fichier, +24/−2. Aucun notebook touché — **cette PR ne digère rien**, elle rend la digestion prescriptible. Le premier chantier qui l'applique est #15041 (G06 cas A, R05 c30/c32/c34), qui était bloqué sur cet arbitrage.
