### PR TITLE
fix(genai,#15040): DER — nommer la projection normalisee, ne plus deriver de pourcentages de contenu perdu

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/mesurer-la-derive-dun-copilot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/mesurer-la-derive-dun-copilot.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "d4c8d56c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003508,
+     "end_time": "2026-09-07T13:02:30.228345",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.224837",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Mesurer la dérive d'un copilot — le gate par étape ne protège pas la chaîne\n",
     "\n",
@@ -37,7 +46,16 @@
   {
    "cell_type": "markdown",
    "id": "204d5d87",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-09-07T13:02:30.236353",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.233352",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Le Copilot Gutenberg en une phrase\n",
     "\n",
@@ -65,7 +83,16 @@
   {
    "cell_type": "markdown",
    "id": "1bb93a3f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004695,
+     "end_time": "2026-09-07T13:02:30.244047",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.239352",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Quatre natures informationnelles — pas six\n",
     "\n",
@@ -92,7 +119,16 @@
   {
    "cell_type": "markdown",
    "id": "aae38fbb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004515,
+     "end_time": "2026-09-07T13:02:30.252697",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.248182",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Le fixture — un document et son vecteur\n",
     "\n",
@@ -111,11 +147,19 @@
    "id": "b12a8721",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.654155Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.653629Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.742696Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.742173Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.261728Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.261728Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.353907Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.353395Z"
+    },
+    "papermill": {
+     "duration": 0.098217,
+     "end_time": "2026-09-07T13:02:30.354914",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.256697",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -159,27 +203,52 @@
   {
    "cell_type": "markdown",
    "id": "c282e62f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-09-07T13:02:30.361425",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.358424",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### La métrique : le rappel de l'original\n",
+    "### La métrique : une projection normalisée — pas une fraction conservée\n",
     "\n",
-    "Pour mesurer la dérive, on calcule le **rappel** — la fraction de l'original\n",
-    "qui survit dans le vecteur courant. Concrètement : la projection du vecteur\n",
-    "courant sur le vecteur original, normalisée.\n",
+    "Pour mesurer la dérive, on calcule la **projection normalisée** du vecteur\n",
+    "courant sur le vecteur original, plafonnée à 1 :\n",
     "\n",
-    "$$\\text{rappel}(v) = \\frac{v \\cdot v_0}{v_0 \\cdot v_0}$$\n",
+    "$$\\text{projection}(v) = \\min\\!\\left(1,\\ \\frac{v \\cdot v_0}{v_0 \\cdot v_0}\\right)$$\n",
     "\n",
-    "- Si $v = v_0$ : rappel = 1,0 (rien n'a bougé).\n",
+    "Ce que cette quantité mesure — et ce qu'elle ne mesure pas :\n",
+    "\n",
+    "- Si $v = v_0$ : projection = 1,0 (identité, rien n'a bougé).\n",
     "- Si $v$ ajoute du contenu **orthogonal** (une image sur un axe nouveau) :\n",
-    "  rappel = 1,0 (l'original est intact, juste dilué — le rappel *ne pénalise\n",
-    "  pas l'ajout*).\n",
-    "- Si $v$ atténue ou supprime des composantes de $v_0$ : rappel < 1,0 (perte).\n",
+    "  projection = 1,0 (la projection ne voit pas l'ajout — l'original est intact,\n",
+    "  juste dilué).\n",
+    "- Si $v$ **atténue** des composantes de $v_0$ sans en amplifier d'autres :\n",
+    "  projection < 1,0.\n",
+    "- **Contre-exemple** : supprimer une composante et en amplifier une autre peut\n",
+    "  ramener la projection à 1,0. Sur $v_0 = (1, 1)$, le vecteur $(2, 0)$ donne\n",
+    "  une projection de 1,0 — la deuxième composante a entièrement disparu, mais\n",
+    "  le doublement de la première compense exactement la perte dans le produit\n",
+    "  scalaire. **La projection n'est donc pas une fraction d'information\n",
+    "  conservée** : c'est un chevauchement directionnel, trompable par\n",
+    "  compensation (les quatre cas-limites sont testés ci-dessous).\n",
     "\n",
-    "C'est cette propriété qui rend le rappel supérieur au cosinus pour notre\n",
-    "propos : le cosinus confond *perte* et *dilution* (les deux le font baisser) ;\n",
-    "le rappel isole la perte. Une synthèse additive (image) et une réduction\n",
-    "(résumé) baissent toutes deux le cosinus, mais pour des raisons opposées —\n",
-    "seul le rappel les distingue.\n"
+    "Pourquoi l'utiliser quand même ? Parce qu'elle sépare l'**ajout** de la\n",
+    "**perte**, là où le cosinus confond *perte* et *dilution* (les deux le font\n",
+    "baisser). Une synthèse additive (image) et une réduction (résumé) baissent\n",
+    "toutes deux le cosinus, mais pour des raisons opposées — seule la projection\n",
+    "les distingue.\n",
+    "\n",
+    "Pour une lecture en « fraction conservée », il faut un indicateur\n",
+    "**composante par composante** — le `recouvrement` défini ci-dessous, valable\n",
+    "pour des fréquences non négatives. Les deux indicateurs ne sont pas\n",
+    "interchangeables, et ni l'un ni l'autre ne mesure la **fidélité factuelle**\n",
+    "d'une réécriture textuelle réelle : pour cela, il faudrait des faits de\n",
+    "référence et une vérification dédiée."
    ]
   },
   {
@@ -188,11 +257,19 @@
    "id": "7a24d72e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.744324Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.743802Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.750064Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.749548Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.370938Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.370938Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.379268Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.378262Z"
+    },
+    "papermill": {
+     "duration": 0.014346,
+     "end_time": "2026-09-07T13:02:30.379773",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.365427",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -207,16 +284,21 @@
    ],
    "source": [
     "def rappel(v_courant, v_original):\n",
-    "    \"\"\"Fraction de l'original qui survit dans v_courant.\n",
+    "    \"\"\"Projection normalisee du vecteur courant sur l'original, plafonnee a 1.\n",
     "\n",
-    "    Projection normalisee : (v_courant . v_original) / (v_original . v_original).\n",
-    "    Vaut 1.0 si l'original est intact (memes composantes), < 1.0 si de l'information\n",
-    "    de l'original a ete perdue, = 1.0 si on a seulement ajoute du contenu orthogonal.\n",
+    "    (v_courant . v_original) / (v_original . v_original), bornee par min(1, .).\n",
+    "    ATTENTION : ce n'est PAS une fraction d'information conservee -- une\n",
+    "    suppression compensee par une amplification (ex. (1,1) -> (2,0)) vaut 1.0\n",
+    "    bien qu'une composante ait entierement disparu. Vaut 1.0 si l'original est\n",
+    "    intact ou si seul un contenu orthogonal a ete ajoute ; < 1.0 si des\n",
+    "    composantes de l'original sont attenuees sans compensation. Le nom\n",
+    "    `rappel` est historique : pour une lecture \"fraction conservee\", voir\n",
+    "    `recouvrement` ci-dessous.\n",
     "    \"\"\"\n",
     "    denom = float(v_original @ v_original)\n",
     "    if denom == 0.0:\n",
     "        return 0.0\n",
-    "    # Plafonne a 1.0 : une fraction de l'original ne peut pas depasser 100 %.\n",
+    "    # Plafonne a 1.0 : la projection normalisee ne depasse pas son support.\n",
     "    # Le bruit additif (enhancement, rewriting) pousse legerement au-dessus ;\n",
     "    # c'est un artefact, pas une retention superieure a l'original.\n",
     "    return min(1.0, float(v_courant @ v_original) / denom)\n",
@@ -235,13 +317,121 @@
     "v_ajout = v0.copy()\n",
     "v_ajout[9] += 4.0   # ajout orthogonal sur l'axe 'image'\n",
     "print(\"rappel(v0 + ajout_image, v0) = \" + str(round(rappel(v_ajout, v0), 3)) + \"  (doit valoir 1.0 : ajout non penalise)\")\n",
-    "print(\"cosinus(v0 + ajout_image, v0) = \" + str(round(cosinus(v_ajout, v0), 3)) + \"  (baisse : dilution)\")\n"
+    "print(\"cosinus(v0 + ajout_image, v0) = \" + str(round(cosinus(v_ajout, v0), 3)) + \"  (baisse : dilution)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cecdbc8c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004,
+     "end_time": "2026-09-07T13:02:30.387786",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.383786",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Les quatre cas-limites — projection contre recouvrement\n",
+    "\n",
+    "La projection normalisée peut valoir 1,0 alors que de l'information a\n",
+    "disparu. Pour le voir : quatre cas sur un jouet à deux axes occupés et un\n",
+    "axe libre, comparés sur **deux indicateurs** — la projection, et le\n",
+    "**recouvrement composante par composante**, valable pour des fréquences non\n",
+    "négatives : la masse commune à chaque axe (le minimum des deux), rapportée à\n",
+    "la masse totale de l'original. C'est lui — et seulement lui — qui se lit\n",
+    "comme « fraction de la masse fréquencielle conservée »."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "88bd46b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T13:02:30.397317Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.397317Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.403294Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.403294Z"
+    },
+    "papermill": {
+     "duration": 0.012497,
+     "end_time": "2026-09-07T13:02:30.404299",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.391802",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "original = (1, 1, 0)     |  projection  recouvrement\n",
+      "  ----------------------------------------------------------\n",
+      "  identite                (1, 1, 0)  |  1.0       1.0\n",
+      "  suppression             (1, 0, 0)  |  0.5       0.5\n",
+      "  ajout orthogonal        (1, 1, 2)  |  1.0       1.0\n",
+      "  amplification compensee (2, 0, 0)  |  1.0       0.5\n",
+      "\n",
+      "Derniere ligne : la projection vaut 1.0 -- le doublement de l'axe 1\n",
+      "compense exactement la disparition de l'axe 2 dans le produit scalaire\n",
+      "-- alors que la moitie de la masse frequentielle a disparu. Seul le\n",
+      "recouvrement (0.5) revele la perte. Les deux indicateurs ne sont pas\n",
+      "interchangeables.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def recouvrement(v_courant, v_original):\n",
+    "    \"\"\"Recouvrement composante par composante (frequences non negatives) :\n",
+    "    sum(min(v_courant, v_original)) / sum(v_original). Se lit comme la\n",
+    "    fraction de la masse frequentielle conservee axe par axe -- ce que la\n",
+    "    projection normalisee n'est PAS (voir la metrique plus haut).\n",
+    "    \"\"\"\n",
+    "    return float(np.minimum(v_courant, v_original).sum() / v_original.sum())\n",
+    "\n",
+    "\n",
+    "# Jouet : deux axes occupes (1, 1) + un axe libre (0).\n",
+    "original_limites = np.array([1.0, 1.0, 0.0])\n",
+    "cas_limites = {\n",
+    "    \"identite                (1, 1, 0)\": np.array([1.0, 1.0, 0.0]),\n",
+    "    \"suppression             (1, 0, 0)\": np.array([1.0, 0.0, 0.0]),\n",
+    "    \"ajout orthogonal        (1, 1, 2)\": np.array([1.0, 1.0, 2.0]),\n",
+    "    \"amplification compensee (2, 0, 0)\": np.array([2.0, 0.0, 0.0]),\n",
+    "}\n",
+    "\n",
+    "print(\"original = (1, 1, 0)     |  projection  recouvrement\")\n",
+    "print(\"  \" + \"-\" * 58)\n",
+    "for nom, v in cas_limites.items():\n",
+    "    p = rappel(v, original_limites)\n",
+    "    r = recouvrement(v, original_limites)\n",
+    "    print(\"  \" + nom + \"  |  \" + str(round(p, 2)).ljust(10) + str(round(r, 2)))\n",
+    "\n",
+    "print()\n",
+    "print(\"Derniere ligne : la projection vaut 1.0 -- le doublement de l'axe 1\")\n",
+    "print(\"compense exactement la disparition de l'axe 2 dans le produit scalaire\")\n",
+    "print(\"-- alors que la moitie de la masse frequentielle a disparu. Seul le\")\n",
+    "print(\"recouvrement (0.5) revele la perte. Les deux indicateurs ne sont pas\")\n",
+    "print(\"interchangeables.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "38d7223c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00451,
+     "end_time": "2026-09-07T13:02:30.412810",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.408300",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Les six transformations, en vecteurs\n",
     "\n",
@@ -255,15 +445,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "2d2af733",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.751650Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.751650Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.756275Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.756275Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.421375Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.421375Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.428394Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.427890Z"
+    },
+    "papermill": {
+     "duration": 0.014084,
+     "end_time": "2026-09-07T13:02:30.429400",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.415316",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -325,15 +523,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "1186da05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.758279Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.758279Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.765189Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.764671Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.437241Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.437241Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.856020Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.855515Z"
+    },
+    "papermill": {
+     "duration": 0.424626,
+     "end_time": "2026-09-07T13:02:30.857026",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.432400",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -344,7 +550,13 @@
       "\n",
       "  transformationrappel   cosinus   nature (rappel + norme)\n",
       "  ----------------------------------------------------------------\n",
-      "  resume        0.776    0.881     perte (rappel < 0.85)\n",
+      "  resume        0.776    0.881     perte (rappel < 0.85)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  enhancement   1.0      0.994     reecriture reversible (norme stable)\n",
       "  rewriting     1.0      0.996     reecriture reversible (norme stable)\n",
       "  traduction    0.732    0.941     perte (rappel < 0.85)\n",
@@ -385,7 +597,16 @@
   {
    "cell_type": "markdown",
    "id": "1185191f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-09-07T13:02:30.864026",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.860027",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture\n",
     "\n",
@@ -409,7 +630,16 @@
   {
    "cell_type": "markdown",
    "id": "182d533a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003007,
+     "end_time": "2026-09-07T13:02:30.871059",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.868052",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. La chaîne — la dérive est cumulative\n",
     "\n",
@@ -420,33 +650,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "d8463e36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.766744Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.766744Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.772936Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.772417Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.879083Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.879083Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.886660Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.886660Z"
+    },
+    "papermill": {
+     "duration": 0.012607,
+     "end_time": "2026-09-07T13:02:30.887668",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.875061",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rappel final apres chaque chaine :\n",
+      "Verdict final de chaque chaine (les deux indicateurs, cf. la metrique) :\n",
       "\n",
-      "  A (destructrice)       -> rappel 0.548    (45 % de l'original perdu)\n",
-      "  B (benigne)            -> rappel 1.0      (0 % de l'original perdu)\n",
-      "  C (collapse)           -> rappel 0.776    (22 % de l'original perdu)\n"
+      "  A (destructrice)       -> projection 0.544   | recouvrement 0.424\n",
+      "  B (benigne)            -> projection 1.0     | recouvrement 0.988\n",
+      "  C (collapse)           -> projection 0.776   | recouvrement 0.632\n"
      ]
     }
    ],
    "source": [
     "def rappel_apres_chaine(v_original, chaine):\n",
     "    \"\"\"Applique une chaine de transformations (par nom) a l'original,\n",
-    "    renvoie le rappel final.\n",
+    "    renvoie la projection normalisee finale.\n",
     "    \"\"\"\n",
     "    v = v_original.copy()\n",
     "    for nom in chaine:\n",
@@ -461,18 +699,30 @@
     "    \"C (collapse)\":          [\"resume\", \"resume\"],\n",
     "}\n",
     "\n",
-    "print(\"Rappel final apres chaque chaine :\")\n",
+    "print(\"Verdict final de chaque chaine (les deux indicateurs, cf. la metrique) :\")\n",
     "print()\n",
     "for nom, chaine in chaines.items():\n",
-    "    r = rappel_apres_chaine(v0, chaine)\n",
-    "    pertes = round((1.0 - r) * 100)\n",
-    "    print(\"  \" + nom.ljust(22) + \" -> rappel \" + str(round(r, 3)).ljust(7) + \"  (\" + str(pertes) + \" % de l'original perdu)\")\n"
+    "    v_final = v0.copy()\n",
+    "    for t in chaine:\n",
+    "        v_final = TRANSFORMATIONS[t](v_final)\n",
+    "    p = rappel_apres_chaine(v0, chaine)\n",
+    "    r = recouvrement(v_final, v0)\n",
+    "    print(\"  \" + nom.ljust(22) + \" -> projection \" + str(round(p, 3)).ljust(7) + \" | recouvrement \" + str(round(r, 3)))"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "2adeada2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003592,
+     "end_time": "2026-09-07T13:02:30.895794",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.892202",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture\n",
     "\n",
@@ -480,33 +730,49 @@
     "étape individuelle passait le gate humain** — aucune n'aurait été rejetée à\n",
     "la lecture, car chaque transformation prise seule est légitime. Et pourtant :\n",
     "\n",
-    "- **Chaîne A** (résumé → traduction → enhancement) perd environ la moitié de\n",
-    "  l'original. Le résumé a retiré les nuances ; la traduction a écrasé le\n",
+    "- **Chaîne A** (résumé → traduction → enhancement) : projection 0,54,\n",
+    "  recouvrement 0,42 — **plus de la moitié de la masse fréquentielle a\n",
+    "  disparu** (lecture sur le recouvrement, seul indicateur qui se lit en\n",
+    "  fraction conservée ; la projection ne mesure qu'un chevauchement\n",
+    "  directionnel). Le résumé a retiré les nuances ; la traduction a écrasé le\n",
     "  registre qu'il restait ; l'enhancement a bruité le tout. Le rédacteur a\n",
-    "  validé trois fois, et la moitié du document est partie.\n",
-    "- **Chaîne B** (enhancement → rewriting → alt text) préserve l'original à\n",
-    "  100 %. Trois transformations, mais toutes réversibles ou additives : le\n",
-    "  fond tient, le rappel reste au plafond.\n",
-    "- **Chaîne C** (résumé → résumé) ne perd **rien de plus** qu'un seul\n",
-    "  résumé. Ce n'est pas que la chaîne soit sûre — c'est qu'il n'y a plus\n",
-    "  rien à perdre : le premier résumé a déjà tué les nuances, et le second\n",
-    "  bute sur le même plancher. La destruction a un **point bas**, et le\n",
-    "  résumé d'un résumé le confirme.\n",
+    "  validé trois fois, et plus de la moitié du document est partie.\n",
+    "- **Chaîne B** (enhancement → rewriting → alt text) : projection au plafond\n",
+    "  (1,0) et recouvrement 0,99 — les fréquences de l'original sont quasi\n",
+    "  intactes. Trois transformations, mais toutes réversibles ou additives :\n",
+    "  le fond tient.\n",
+    "- **Chaîne C** (résumé → résumé) : projection 0,78, recouvrement 0,63 — et\n",
+    "  **les mêmes valeurs qu'un seul résumé**, sur les deux indicateurs à la\n",
+    "  fois. Ce n'est pas que la chaîne soit sûre — c'est qu'il n'y a plus rien\n",
+    "  à perdre : le premier résumé a déjà tué les nuances, et le second bute sur\n",
+    "  le même plancher (`resume` est idempotente dans ce modèle top-k : résumer\n",
+    "  le résumé redonne le même vecteur). La destruction a un **point bas**, et\n",
+    "  le résumé d'un résumé le confirme.\n",
     "\n",
     "C'est l'enseignement central : **le gate humain est local, la dérive est\n",
     "globale**. La chaîne A perd deux fois (deux destructrices *complémentaires*\n",
-    "tuent des informations différentes), la chaîne C ne perd qu'une fois (la\n",
-    "deuxième destructive est *redondante* avec la première). Dans les deux cas,\n",
-    "aucune des étapes n'aurait été rejetée isolément — et dans les deux cas, le\n",
-    "résultat global n'est pas la somme des résultats locaux. Un Copilot sans\n",
-    "vision de la chaîne — sans afficher « il reste X % de l'original » — laisse\n",
-    "le rédacteur approuver une perte qu'il n'aurait pas acceptée d'un coup.\n"
+    "détruisent des informations différentes), la chaîne C ne perd qu'une fois\n",
+    "(la deuxième destructive est *redondante* avec la première). Dans les deux\n",
+    "cas, aucune des étapes n'aurait été rejetée isolément — et dans les deux\n",
+    "cas, le résultat global n'est pas la somme des résultats locaux. Un Copilot\n",
+    "sans vision de la chaîne — sans afficher un indicateur de conservation\n",
+    "**muni de sa définition** — laisse le rédacteur approuver une perte qu'il\n",
+    "n'aurait pas acceptée d'un coup."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "81d2c30f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003512,
+     "end_time": "2026-09-07T13:02:30.902821",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.899309",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Où la dérive se produit — le profil étape par étape\n",
     "\n",
@@ -517,22 +783,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "de3a6fd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.775040Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.775040Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.780203Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.779689Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.911921Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.911921Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.917507Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.917507Z"
+    },
+    "papermill": {
+     "duration": 0.012183,
+     "end_time": "2026-09-07T13:02:30.918514",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.906331",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  A (destructrice)       initial=1.0  resume=0.78  traduction=0.53  enhancement=0.55  \n",
+      "  A (destructrice)       initial=1.0  resume=0.78  traduction=0.53  enhancement=0.54  \n",
       "  B (benigne)            initial=1.0  enhancement=1.0  rewriting=1.0  alt_text=1.0  \n",
       "  C (collapse)           initial=1.0  resume=0.78  resume=0.78  \n"
      ]
@@ -563,7 +837,16 @@
   {
    "cell_type": "markdown",
    "id": "7ce3cca6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004036,
+     "end_time": "2026-09-07T13:02:30.926550",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.922514",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture\n",
     "\n",
@@ -586,18 +869,28 @@
     "  à extraire.\n",
     "\n",
     "C'est la contre-mesure pédagogique : si le Copilot affichait le profil —\n",
-    "« après cette validation, il reste X % du document original » — le rédacteur\n",
-    "verrait le point de rupture (chaîne A), la préservation (chaîne B) ou le\n",
-    "plancher (chaîne C), et pourrait décider en connaissance de cause. Le gate\n",
+    "« après cette validation, la conservation mesurée du document est de X,\n",
+    "selon l'indicateur affiché et sa définition » — le rédacteur verrait le\n",
+    "point de rupture (chaîne A), la préservation (chaîne B) ou le plancher\n",
+    "(chaîne C), et pourrait décider en connaissance de cause. Le gate\n",
     "humain *pourrait* protéger la chaîne, à la condition expresse de l'instrumenter\n",
     "avec une mémoire de la chaîne. Sans cette mémoire, le gate est une suite\n",
-    "d'approbations locales qui ne voient pas la dérive globale.\n"
+    "d'approbations locales qui ne voient pas la dérive globale."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "5271dc84",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004535,
+     "end_time": "2026-09-07T13:02:30.934104",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.929569",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Provenance et limites\n",
     "\n",
@@ -632,7 +925,16 @@
   {
    "cell_type": "markdown",
    "id": "c3501a50",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004157,
+     "end_time": "2026-09-07T13:02:30.942516",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.938359",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Exercices\n",
     "\n",
@@ -644,7 +946,16 @@
   {
    "cell_type": "markdown",
    "id": "8f05c8f4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00486,
+     "end_time": "2026-09-07T13:02:30.951833",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.946973",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 — rappel après une chaîne\n",
     "\n",
@@ -656,15 +967,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a972dbde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.782236Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.781231Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.784219Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.784219Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.962761Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.962055Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.966099Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.965523Z"
+    },
+    "papermill": {
+     "duration": 0.010893,
+     "end_time": "2026-09-07T13:02:30.967689",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.956796",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -679,7 +998,16 @@
   {
    "cell_type": "markdown",
    "id": "c0a68b2e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.0053,
+     "end_time": "2026-09-07T13:02:30.980455",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.975155",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 — la chaîne la plus destructrice\n",
     "\n",
@@ -691,15 +1019,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9d3449bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.786276Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.785223Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.789804Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.789220Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:30.992883Z",
+     "iopub.status.busy": "2026-09-07T13:02:30.992883Z",
+     "iopub.status.idle": "2026-09-07T13:02:30.995955Z",
+     "shell.execute_reply": "2026-09-07T13:02:30.995955Z"
+    },
+    "papermill": {
+     "duration": 0.01302,
+     "end_time": "2026-09-07T13:02:30.997465",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:30.984445",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -714,7 +1050,16 @@
   {
    "cell_type": "markdown",
    "id": "1b98f8bd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004,
+     "end_time": "2026-09-07T13:02:31.005476",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:31.001476",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 — le profil étape par étape\n",
     "\n",
@@ -725,15 +1070,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d581e6cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T01:20:57.791343Z",
-     "iopub.status.busy": "2026-08-13T01:20:57.791343Z",
-     "iopub.status.idle": "2026-08-13T01:20:57.794964Z",
-     "shell.execute_reply": "2026-08-13T01:20:57.794443Z"
-    }
+     "iopub.execute_input": "2026-09-07T13:02:31.016615Z",
+     "iopub.status.busy": "2026-09-07T13:02:31.016087Z",
+     "iopub.status.idle": "2026-09-07T13:02:31.019882Z",
+     "shell.execute_reply": "2026-09-07T13:02:31.019311Z"
+    },
+    "papermill": {
+     "duration": 0.011537,
+     "end_time": "2026-09-07T13:02:31.021523",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:31.009986",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -749,7 +1102,16 @@
   {
    "cell_type": "markdown",
    "id": "3fceb250",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006002,
+     "end_time": "2026-09-07T13:02:31.033846",
+     "exception": false,
+     "start_time": "2026-09-07T13:02:31.027844",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Ce que ce notebook enseigne, en une ligne\n",
     "\n",
@@ -777,7 +1139,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.141122,
+   "end_time": "2026-09-07T13:02:31.270447",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "mesurer-la-derive-dun-copilot.ipynb",
+   "output_path": "mesurer-la-derive-dun-copilot.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-07T13:02:28.129325",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #15040

Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15008

## Contexte

G05 (P1), fille de l'audit Astra #3 (#15035). Notebook :
`MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/mesurer-la-derive-dun-copilot.ipynb`
(100 % numpy, aucune dependance reseau — re-executable localement, hors du blocage 401).

## Le defaut corrige

La fonction `rappel` calcule une **projection normalisee plafonnee a 1** ;
la prose la lisait comme « la fraction de l'original qui survit » et en
derivait des « X % de l'original perdu ». Contre-exemple de l'issue, reproduit
dans le notebook : sur `(1,1) -> (2,0)`, la projection vaut 1.0 alors que la
deuxieme composante a entierement disparu (le doublement de la premiere
compense exactement dans le produit scalaire).

## Corrections (4 cellules defectueuses + 2 nouvelles)

1. **Metrique** (`[DER:c5]`) : la quantite est nommee « projection normalisee »,
   contre-exemple explicite, separation ajout/perte vs cosinus conservee,
   limites enoncees (ni la projection ni le recouvrement ne mesurent la
   fidelite factuelle).
2. **Docstring de `rappel`** (`[DER:c6]`) : « ce n'est PAS une fraction
   d'information conservee » ; nom `rappel` declare historique.
3. **NOUVEL indicateur `recouvrement`** (composante par composante, frequences
   non negatives) + cellule des **4 cas-limites** exigee par l'acceptation :
   identite, suppression, ajout orthogonal, **amplification compensee**.
   Sortie executee : la ligne `(2,0,0)` affiche projection 1.0 / recouvrement 0.5.
4. **Verdicts de chaines** (`[DER:c12]`) : plus aucun « X % de l'original
   perdu » ; les deux indicateurs sont affiches.
5. **Lecture** (`[DER:c13]`) : re-ancree sur les valeurs reellement executees
   — A 0.544/0.424 (« plus de la moitie de la masse frequentielle a disparu »,
   lecture sur le recouvrement), B 1.0/0.988 (« quasi intactes », pas
   « 100 % »), C 0.776/0.632.
6. **Ce qui tient — PRESERVE** : le plateau de la chaine C (idempotence top-k
   de `resume`) est intact et desormais verifie sur les DEUX indicateurs
   (0.776/0.632 = valeurs d'un seul resume). Une phrase de `[DER:c16]`
   (« il reste X % du document original ») est reloe a la definition de la
   mesure, sans toucher aux explications verifiees.

## Acceptance (verbatim #15040)

> Le cas `[1,1] -> [2,0]` n'est plus decrit comme une conservation integrale.
> Tester egalement identite, suppression, ajout sur un axe orthogonal et
> amplification. Tous les pourcentages du commentaire sont relies a la
> definition exacte de la mesure.

Les 4 cas sont executes dans le notebook ; chaque nombre de la prose est
lie a son indicateur (projection ou recouvrement).

## Preuves

- **Reassessed by myia-po-2026: CONFIRMED** — contre-exemple reproduit puis
  corrige ; source relue cellule par cellule.
- **Re-execution complete reelle** : `notebook_tools.py execute` kernel
  python3, numpy 2.2.6, SUCCESS (8.3 s), exec_count 1-10, 0 erreur,
  0 NotImplementedError (C.1), outputs coherents (C.2, H.3 pre-commit PASSED).
- `0 raise NotImplementedError` (grep C.1 OK).

## Note de re-execution (transparence)

Le tie-break `argsort` du top-4 de `resume` (trois composantes a 2.0 dans
`v0`) resout differemment sous numpy 2.2.6 que sous le build du precedent
commit : la chaine A passe de 0.548 a 0.544 (et `enhancement=0.55 -> 0.54`
dans le profil). Les verdicts single-transform sont inchanges. Deterministe
par build numpy (graines fixes). Observation signalee pour un eventuel grain
separe (tri stable dans `resume`) — hors scope ici.

## Diff

```
.../03-1-Chatbots/mesurer-la-derive-dun-copilot.ipynb | 498 insertions(+), 124 deletions(-)
```
(Largeur = re-execution complete : compteurs d'execution decales par les 2
nouvelles cellules + sorties regenerees ; changements de fond limites aux
cellules citees.)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>