### PR TITLE
docs(ai-engine): enrich joindre-un-fichier notebook density round 2 (#11601)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/joindre-un-fichier-au-chatbot-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/joindre-un-fichier-au-chatbot-par-l-api.ipynb
@@ -369,6 +369,36 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Le refus n'est pas un signal stable.** Comparez les deux reponses :\n",
+    "meme question, meme fichier, meme compteur de tokens — et pourtant deux\n",
+    "formulations differentes. La premiere suggere de copier-coller le texte\n",
+    "du fichier dans le message ; la seconde enonce ne pas avoir acces aux\n",
+    "pieces jointes. Aucune des deux n'est un message d'erreur systeme : ce\n",
+    "sont des generations du modele, et la generation varie. Deux\n",
+    "consequences de methode :\n",
+    "\n",
+    "- **Ne sondez pas le wording.** Un client qui teste son integration en\n",
+    "  cherchant une phrase precise dans la reponse cassera sans raison\n",
+    "  apparente au tour suivant. Les champs machine (purpose,\n",
+    "  prompt_tokens, fiche) sont les seules sondes reproductibles ; le\n",
+    "  texte, lui, navigue.\n",
+    "- **Un meme refus masque deux etats systeme differents.** Avant et\n",
+    "  apres la correction du nom de parametre, le modele dit a peu pres la\n",
+    "  meme chose — alors que le systeme a change d'etat entre les deux (la\n",
+    "  fiche du second tour porte les traces du traitement). Un audit qui ne\n",
+    "  lirait que les reponses conclurait « rien ne fonctionne » deux fois,\n",
+    "  et passerait a cote du fait que la seconde tentative a bien ete\n",
+    "  traitee, puis jetee au routeur de formats.\n",
+    "\n",
+    "La variation elle-meme est une observation a deux echantillons : ce run\n",
+    "ne mesure pas la variance, il constate qu'elle existe."
+   ],
+   "id": "n27-refus-instable"
+  },
+  {
+   "cell_type": "markdown",
    "id": "041058b9",
    "metadata": {},
    "source": [
@@ -399,6 +429,56 @@
     "compte de tokens — la seule mesure qui ne peut pas mentir sur ce qui est\n",
     "entre dans le prompt.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**La fiche parle dans le namespace du moteur.** La fiche rendue apres\n",
+    "traitement porte `query_session : 862bcbf0...` — or le notebook avait\n",
+    "soumis `sessionId : 2aa021cc...`. Deux identifiants differents pour ce\n",
+    "qui semble etre « la » conversation : celui que le client pose dans le\n",
+    "payload, et celui que le moteur enregistre dans la fiche. La jointure\n",
+    "n'est donc pas tracee dans l'identite que vous manipulez :\n",
+    "`chats/submit` opere la traduction vers sa session interne, et c'est\n",
+    "cette derniere qui figure dans les metadonnees. Pour croiser un fichier\n",
+    "avec une conversation dans un audit, il faut les deux namespaces — et\n",
+    "aucun champ de cette surface ne les relie explicitement : la reponse\n",
+    "d'upload rend le refId, la fiche rend la session interne.\n",
+    "\n",
+    "Un second champ merite l'attention : `query_envId` est **vide**. Le\n",
+    "schema prevoit le multi-environnement (les environnements du cinquieme\n",
+    "grain), mais cette instance n'en enregistre aucun au moment de la\n",
+    "jointure. Slot prevu, valeur absente — un vide informatif : la\n",
+    "structure des metadonnees decrit une capacite de routage que ce\n",
+    "parcours, instance de demonstration a environnement par defaut,\n",
+    "n'exerce pas."
+   ],
+   "id": "n27-query-session-namespace"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**`purpose` : requis, libre, puis ecrase.** Le contrat de ce champ se\n",
+    "lit en trois temps dans les sorties. A l'upload, il est obligatoire\n",
+    "(le grain precedent a croise le 400 « Purpose is required. »). Mais il\n",
+    "n'est pas valide : la valeur posee ici, `jointure-sondage`, est un tag\n",
+    "fabrique pour l'occasion — aucune enumeration ne l'attendait, l'API\n",
+    "l'a accepte tel quel. Et au traitement, il est ecrase : le passage a\n",
+    "`analysis` ne garde aucune trace de la valeur client.\n",
+    "\n",
+    "Autrement dit : le client nomme, le serveur renomme. La valeur\n",
+    "choisie n'a d'effet observable nulle part dans ce parcours — ni dans\n",
+    "la reponse, ni dans les metadonnees de jointure. Des usages\n",
+    "specialises attendent peut-etre des valeurs precises (les surfaces de\n",
+    "consommation evoquees au dernier acte), mais rien dans ce run ne le\n",
+    "mesure ; ce qui est prouve est la structure du contrat — champ present,\n",
+    "contenu libre, semantique serveur. Conclusion pratique en une ligne :\n",
+    "n'encodez pas d'information dans `purpose`, elle ne survit pas au\n",
+    "premier tour qui consomme le fichier."
+   ],
+   "id": "n27-purpose-contrat"
   },
   {
    "cell_type": "code",
@@ -560,6 +640,33 @@
     "f = fiche_de(REFID_PNG)\n",
     "print(\"purpose png apres :\", f.get(\"purpose\"))\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**105, 105, 170 : l'arithmetique de l'admission.** Les trois tours\n",
+    "texte mesurent le meme plancher — 105 tokens, quel que soit le destin\n",
+    "du fichier (ignore, puis annote-jete). Le tour a l'image monte a 170 :\n",
+    "**+65 tokens pour 128 pixels**. Cette difference se lit comme le prix\n",
+    "du format de fil : l'image voyage encodee dans une partie `image_url`,\n",
+    "et ce codage coute ce qu'il coute quelle que soit la scene representee.\n",
+    "Deux deductions, etiquetees comme telles :\n",
+    "\n",
+    "- **Le delta, pas le total, est la mesure.** 105 est le plancher de\n",
+    "  tout tour (instructions du bot, message, habillage) ; il masque ce\n",
+    "  que vous voulez savoir. En soustrayant deux tours qui ne different\n",
+    "  que d'un element, vous isolez le prix de cet element — technique de\n",
+    "  differenciation reutilisable sur toute surface qui rend un compteur.\n",
+    "- **Etre vu coute plus cher que lire.** Le canary texte fait 74\n",
+    "  caracteres ; entre dans le prompt comme message, il couterait de\n",
+    "  l'ordre de sa propre longueur — une quinzaine de tokens, estimation\n",
+    "  non mesuree ici. transmis comme image, ces 128 pixels en ont coute\n",
+    "  65 : le codage du format pese plus que le contenu literal.\n",
+    "  l'economie du multimodal n'est pas celle du texte, et la grille de\n",
+    "  facturation est visible dans `usage` a chaque tour."
+   ],
+   "id": "n27-arithmetique-tokens"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #14985

Quoi: Enrichissement markdown-only du notebook `joindre-un-fichier-au-chatbot-par-l-api.ipynb` — round-2 densite (See #11601) : **1242 -> 1721 c/code-cell** a l'instrument canonique. 4 cellules markdown nouvelles, ancrees aux sorties commitees du run existant ; zero re-execution ; 10 cellules code byte-identiques. HEAD teste : `f5f510e3b`.

Preuve:
```
pedagogy_density.py --json (worktree origin/main 777a7a378) :
  density 1721 | prose 12420 -> 17210 | code_cells 10 | below_threshold 0
validate_pr_notebooks.py main <nb>     : 1/1 PASS (10 cells)
detect_md_content_loss --check         : findings=0 (md 12->16, chars 10281->14233)
check_notebook_navlinks                : 0 lien casse
detect_markdown_rendering --check      : 0 violation sur ce notebook
check_prose_quantitative_claims --diff : [OK] aucun compteur quantitatif en prose
pre-commit hooks au commit             : 9/9 Passed (gitleaks, H.3, #13326...)
```

Perimetre: **1 fichier** : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-1-Chatbots/joindre-un-fichier-au-chatbot-par-l-api.ipynb` (107 insertions, 0 deletion).

Anti-Padding — les 4 angles ne paraphrasent aucune prose existante (verifies contre les 12 cellules md d'origine lues en entier) :
1. **Le refus n'est pas un signal stable** : les deux tours texte rendent deux formulations differentes pour la meme situation — le wording est une generation, pas un message systeme ; un meme refus honnete masque deux etats systeme distincts. La prose existante citait la reponse comme indice n.1 ; cet angle en montre la fragilite (observation a deux echantillons, etiquetee).
2. **La fiche parle dans le namespace du moteur** : `query_session : 862bcbf0...` differe du `sessionId : 2aa021cc...` soumis dans le payload — la jointure est tracee dans la session interne du moteur, aucun champ ne relie les deux namespaces. Plus `query_envId` vide : slot multi-environnement prevu, non exerce. La prose existante disait « query_session lie le fichier a la conversation » sans remarquer l'ecart d'identifiant.
3. **`purpose` : requis, libre, puis ecrase** : obligatoire a l'upload (400 croise au grain precedent), valeur libre acceptee (`jointure-sondage` est un tag fabrique), ecrasee a `analysis` au traitement — le client nomme, le serveur renomme. La prose existante notait la bascule comme preuve de traitement, sans analyser le contrat du champ.
4. **105, 105, 170 : l'arithmetique de l'admission** : +65 tokens pour 128 pixels ; le delta (pas le total) isole le prix d'un element — technique de differenciation generalisable ; etre vu comme image coute plus cher que lire comme texte (estimation etiquetee non mesuree). La prose existante disait « coute davantage », sans l'arithmetique ni la methode.

Les deductions non mesurees sont etiquetees comme telles dans la prose (contrat d'honnetete de la serie).

Claim: paths-scoped pose AVANT edition — issuecomment-5568168130. Convention sans accents de la serie tenue (filet d'assert 0 accent dans le script d'enrichissement). Base : origin/main `777a7a378`, unique push.
