### PR TITLE
fix(rl,#9434): de-pin des versions d'environnement du Bilan de rl_1_intro_cartpole

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
@@ -2627,7 +2627,6 @@
     "\n",
     "| Étape | Résultat | Signification |\n",
     "|-------|----------|---------------|\n",
-    "| Installation | SB3 2.9.0, gym 1.3.0 | versions a jour |\n",
     "| Évaluation aléatoire | 22 +/- 12 | baseline du problème |\n",
     "| Politique initiale | 95 +/- 23 | baseline du réseau |\n",
     "| Entraînement 10k pas | eval 88 -> 419 | saut classique PPO |\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/lean #15020 (assignment_lean, MERGED)

## Summary

Mandat **#9434** (« quantitatif tenu par le CI, pas par la prose », règle C.5) — tranche `RL/rl_1_intro_cartpole.ipynb` (claim path-scopée active de cette lane). Le census complet du notebook identifie **exactement un défaut** : la table **Bilan** de la conclusion épinglait à la main `SB3 2.9.0, gym 1.3.0` alors que les cellules 3 et 7 **impriment déjà ces versions dynamiquement** (`stable_baselines3.__version__='2.9.0'`, `gym.__version__='1.3.0'` — sorties committées). Classe C.5 **env-dépendant (observé)** : la décision prescrite est **RETIRER** — la sortie committée devient la source unique de vérité, la prose ne re-pinne pas ce qui dérive au prochain bump d'environnement.

## Changement

**1 ligne supprimée** (cellule markdown de Conclusion, id `60eb43d4`) :

```diff
-| Installation | SB3 2.9.0, gym 1.3.0 | versions a jour |
```

Les 5 autres lignes du Bilan (Évaluation aléatoire 22±12, Politique initiale 95±23, Entraînement 88→419, Eval finale 405±108, Plafond ≥475) correspondent toutes aux sorties committées et restent inchangées.

## Census du notebook (pourquoi 1 seul retrait)

| Catégorie | Occurrences | Verdict |
|---|---|---|
| Versions env observées (Bilan) | 1 (la ligne retirée) | **RETIRÉES** — cellules 3/7 les impriment déjà |
| Planchers de versions (« Versions minimales » SB3 2.0.0, gymnasium 0.28.0…) | tables cell[2]/cell[4] | **KEEP** — décision de projet (classe *exigé*), ne dérive pas au bump d'env |
| Stats stochastiques (~22, ~95±23, ~405±108, 88→419, ~287 épisodes) | prose + Bilan | **KEEP** — `SEED = 42` fixe modèle ET échantillonnage (cell[13]) ; chaque valeur matche la sortie committée adjacente (21.92±11.97, 95.08±23.08, 405.09±107.78, 418.9, 287) |
| Timings (« environ 10-30 s », « 30 secondes », table 1000→3 s/5000→15 s/10000→30 s) | cell[12]/[22]/[24]/[50] | **KEEP** — ordres de grandeur avec ~/« environ », forme prescrite pour le machine-dépendant |
| Bornes API (`gymnasium >= 0.26`) | cell[31] | **KEEP** — plage exigée, pas observation |
| Provenance GPU session (rl_15_grpo, RTX 3070/torch 2.6.0+cu124) | hors fichier | **hors scope** — note de provenance légitime, pas de la pathologie #8052 |

Le notebook est déjà largement mandate-aware : la cellule[21] encadre elle-même ses valeurs « en ordre de grandeur : ~22 / ~95 », et les cellules 3/7/16 portent des sections « Sortie attendue » qui disent que la valeur exacte dépend de l'installation.

## Validation

| Check | Résultat |
|---|---|
| Diff | **1 deletion, 0 insertion** (édition byte-level, pas de re-sérialisation JSON) |
| JSON | `json.load` OK, 54 cellules intactes |
| C.2 | Changement **markdown-only** → exception C.2 (pas de re-exécution requise) ; aucune sortie de cellule touchée |
| H.3 pre-commit | tous les hooks passés (commit `940c0cba026c`) |
| L898 collision | `gh pr list --search "rl_1_intro_cartpole"` → aucune PR ouverte sur le chemin |
| Claim | `check_lane_claim.py 9434 --lane myia-po-2027:CoursIA-2` → CLEAR (claim active de cette lane) |
| B.3 proof-integrity | **non applicable** — aucun `*.lean` modifié |

See #9434.
