### PR TITLE
fix(genai,#15046): ING -- decrire le decoupage reel ( caracteres, frontieres de mots ), separer tracabilite et qualite de retrieval

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/ingestion-corpus-long-rag.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/ingestion-corpus-long-rag.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "f2d2db73",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002482,
+     "end_time": "2026-09-07T14:28:34.019719",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:34.017237",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Ingestion RAG d'un corpus long structure\n",
     "\n",
@@ -38,7 +47,16 @@
   {
    "cell_type": "markdown",
    "id": "dbd9b5d8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003519,
+     "end_time": "2026-09-07T14:28:34.027247",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:34.023728",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Configuration\n",
     "\n",
@@ -55,11 +73,19 @@
    "id": "f525fac0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:23.974091Z",
-     "iopub.status.busy": "2026-08-10T01:15:23.974091Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.147362Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.146358Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:34.037018Z",
+     "iopub.status.busy": "2026-09-07T14:28:34.036018Z",
+     "iopub.status.idle": "2026-09-07T14:28:35.850617Z",
+     "shell.execute_reply": "2026-09-07T14:28:35.848436Z"
+    },
+    "papermill": {
+     "duration": 1.821668,
+     "end_time": "2026-09-07T14:28:35.852914",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:34.031246",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -85,7 +111,16 @@
   {
    "cell_type": "markdown",
    "id": "be4eadee",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008058,
+     "end_time": "2026-09-07T14:28:35.869184",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.861126",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Le corpus : trois ouvrages structures en chapitres\n",
     "\n",
@@ -105,11 +140,19 @@
    "id": "282c7287",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.148809Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.148809Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.162911Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.161632Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:35.889982Z",
+     "iopub.status.busy": "2026-09-07T14:28:35.889463Z",
+     "iopub.status.idle": "2026-09-07T14:28:35.902840Z",
+     "shell.execute_reply": "2026-09-07T14:28:35.901237Z"
+    },
+    "papermill": {
+     "duration": 0.025673,
+     "end_time": "2026-09-07T14:28:35.904432",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.878759",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -204,32 +247,51 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "50adf0af",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00851,
+     "end_time": "2026-09-07T14:28:35.920904",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.912394",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du corpus brut (ancre sur code[1])\n",
     "\n",
-    "La cellule code[1] charge le corpus synthetique sous la forme `dict[str, list[str]]` : cle = titre du livre, valeur = liste de chapitres (chaines longues). La sortie observee est `Corpus : 3 ouvrages, 9 chapitres au total.` -- trois ouvrages = Horlogerie Pratique, Sauvages et Cultivees, Peche en mer ; neuf chapitres repartis a raison de 3 par ouvrage.\n",
+    "La cellule code[1] construit le corpus synthetique sous la forme d'un dict de dicts : cle = titre du livre, valeur = `{\"auteur\": ..., \"chapitres\": {numero: (titre_du_chapitre, texte)}}`. La sortie observee est `Corpus : 3 ouvrages, 9 chapitres au total.` -- trois ouvrages = Horlogerie Pratique, Sauvages et Cultivees, Peche en mer ; neuf chapitres repartis a raison de 3 par ouvrage.\n",
     "\n",
     "**Pourquoi ce corpus synthetique** : la mediatheque de Valmont est une **domaine public fictionnel**, evitant toute oeuvre reelle sous droits. Chaque ouvrage choisit un theme tres distinct (mecanique / horticulture / maritime) -- cela rend les confusions chunking tres visibles a l'oeil, alors qu'elles seraient ambigues sur un corpus realiste variete encyclopedique.\n",
     "\n",
     "**Trois proprietes pedagogiques** du corpus :\n",
     "1. **Themes disjoints** : un lecteur humain peut labelliser chaque phrase a 100 % de confiance sur l'ouvrage d'origine. Un LLM pourrait faire de meme -- le test RAG mesure donc l'identite du chunk, pas la discrimination semantique.\n",
-    "2. **Chapitres assez longs** : les chapitres font 200-400 mots, ce qui produit des chunks naifs de taille 1-3 par chapitre. Granularite compatible avec l'experience pedagogique desiree.\n",
+    "2. **Chapitres courts et calibres** : chaque chapitre fait 292-343 caracteres (46-63 mots), soit ~2 830 caracteres au total une fois concatene. Avec la grille naive (tranches de 180 caracteres), cela produit 20 chunks ; avec la grille structuree (morceaux d'au plus 220 caracteres par chapitre), 18 chunks. Granularite compatible avec l'experience pedagogique desiree.\n",
     "3. **Vocabulaire marque** : chaque theme a un lexique distinct ('engrenage', 'echappement' vs 'rosier', 'bouture' vs 'phare', 'sauvetage'). Discriminant TF-IDF facile, donc le defaut de chunking peut apparaitre sans etre masque par la qualite de l'embedding."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "c1ca0a11",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008078,
+     "end_time": "2026-09-07T14:28:35.937607",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.929529",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Deux strategies de chunking\n",
     "\n",
-    "On definit les deux strategies avant de les comparer. La strategie **naive** decoupe le texte par nombre de mots fixes (taille 180, recouvrement 40) sans regarder la structure ; la strategie **structuree** decoupe a la frontiere des chapitres du livre source.\n",
+    "On definit les deux strategies avant de les comparer. La strategie **naive** concatene tout le corpus puis le tranche par **taille fixe en caracteres** (tranche de 180, recouvrement de 40) sans regarder la structure -- la coupe peut tomber au milieu d'un mot comme au milieu d'une phrase. La strategie **structuree** decoupe chaque chapitre a la **frontiere des mots** (`textwrap.wrap`) en morceaux d'au plus 220 caracteres, et preserve livre + chapitre comme etiquettes.\n",
     "\n",
     "**Pourquoi cette dichotomie est pedagogiquement centrale** : un pipeline RAG peut-etre elegant en surface (embedding + cosine top-k) mais desastreux en pratique si les chunks sont mal formes. Le notebook isole ce determinant cache en faisant varier une seule variable a la fois : la granularite et la preservation des metadonnees.\n",
     "\n",
-    "**Sortie attendue du code[2]** : deux fonctions Python `chunk_naif(corpus, taille=180, recouvrement=40)` et `chunk_structure(corpus)`, qui prennent toutes deux un corpus (dict livre -> liste de chapitres) et renvoient une liste de chunks. Les valeurs exactes choisies (180 mots / 40 mots de recouvrement) calibrent l'experience : 180 mots ~= 2 paragraphes de la mediatheque de Valmont ; 40 mots de recouvrement preservent les transitions."
+    "**Sortie attendue du code[2]** : deux fonctions Python `chunk_naif(corpus, taille=180, recouvrement=40)` et `chunk_structure(corpus, taille_max=220)`, qui prennent toutes deux un corpus (dict livre -> chapitres) et renvoient une liste de chunks. Les valeurs exactes choisies (180 caracteres / 40 caracteres de recouvrement) calibrent l'experience : 180 caracteres ~= 2-3 lignes de texte ; le recouvrement de 40 caracteres preserve les transitions. Cote structure, 220 caracteres est le plafond par morceau : chaque chapitre de ~300 caracteres est sous-decoupe en 2 morceaux."
    ]
   },
   {
@@ -238,24 +300,33 @@
    "id": "567350c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.165006Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.165006Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.178212Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.176997Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:35.958497Z",
+     "iopub.status.busy": "2026-09-07T14:28:35.957392Z",
+     "iopub.status.idle": "2026-09-07T14:28:35.971944Z",
+     "shell.execute_reply": "2026-09-07T14:28:35.969816Z"
+    },
+    "papermill": {
+     "duration": 0.026789,
+     "end_time": "2026-09-07T14:28:35.973553",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.946764",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deux strategies definies : chunk_naif (taille fixe, sans etiquette) et chunk_structure (par chapitre, etiquette livre+chapitre).\n"
+      "Deux strategies definies : chunk_naif (taille fixe en caracteres, sans etiquette) et chunk_structure (par chapitre, sous-decoupe aux frontieres de mots, etiquette livre+chapitre).\n"
      ]
     }
    ],
    "source": [
     "def chunk_naif(corpus, taille=180, recouvrement=40):\n",
-    "    # Chunking par taille fixe avec recouvrement. Ignore la structure.\n",
+    "    # Chunking par taille fixe EN CARACTERES avec recouvrement. Ignore la structure.\n",
+    "    # La frontiere peut tomber au milieu d'un mot ou d'une phrase.\n",
     "    # Renvoie des chunks plats sans metadonnee de source ni de chapitre.\n",
     "    texte_complet = \"\\n\\n\".join(\n",
     "        para\n",
@@ -277,12 +348,14 @@
     "\n",
     "def chunk_structure(corpus, taille_max=220):\n",
     "    # Chunking par chapitre. Preserve livre + chapitre comme metadonnee.\n",
-    "    # Sous-decoupe un chapitre trop long, mais chaque chunk reste etiquete.\n",
+    "    # Si le chapitre depasse taille_max (en caracteres), textwrap.wrap le\n",
+    "    # sous-decoupe AUX FRONTIERES DE MOTS : jamais au milieu d'un mot, mais\n",
+    "    # une frontiere peut tomber au milieu d'une phrase (la coupe suit la\n",
+    "    # largeur, pas la ponctuation). Chaque morceau reste etiquete.\n",
     "    chunks = []\n",
     "    for titre, livre in corpus.items():\n",
     "        auteur = livre[\"auteur\"]\n",
     "        for n_ch, (titre_ch, texte_ch) in livre[\"chapitres\"].items():\n",
-    "            # si le chapitre depasse taille_max, on le decoupe par phrase\n",
     "            morceaux = textwrap.wrap(texte_ch, width=taille_max, break_long_words=False)\n",
     "            for morceau in morceaux:\n",
     "                chunks.append({\n",
@@ -294,20 +367,30 @@
     "                })\n",
     "    return chunks\n",
     "\n",
-    "print(\"Deux strategies definies : chunk_naif (taille fixe, sans etiquette) \"\n",
-    "      \"et chunk_structure (par chapitre, etiquette livre+chapitre).\")"
+    "print(\"Deux strategies definies : chunk_naif (taille fixe en caracteres, sans etiquette) \"\n",
+    "      \"et chunk_structure (par chapitre, sous-decoupe aux frontieres de mots, \"\n",
+    "      \"etiquette livre+chapitre).\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "10b70cfe",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008076,
+     "end_time": "2026-09-07T14:28:35.989709",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.981633",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Application -- et le defaut apparait\n",
     "\n",
-    "**Sortie observee de code[3]** : 20 chunks naifs (decoupage par taille fixe) vs 18 chunks structures (un par chapitre de livre en moyenne). Les 20 chunks naifs portent **AUCUNE metadonnee** de source (ni livre, ni chapitre, ni position) ; les 18 chunks structures preservent livre + chapitre. La difference de cardinal (20 vs 18) reflete le fait que certains chapitres sont grands et produisent plusieurs chunks naifs, alors qu'en structure un chapitre fait un seul chunk.\n",
+    "**Sortie observee de code[3]** : 20 chunks naifs (tranches de 180 caracteres sur ~2 830 caracteres concatnes) vs 18 chunks structures (9 chapitres, chacun sous-decoupe en 2 morceaux d'au plus 220 caracteres). Les 20 chunks naifs portent **AUCUNE metadonnee** de source (ni livre, ni chapitre, ni position) ; les 18 chunks structures preservent livre + chapitre. La difference de cardinal (20 vs 18) est un artefact des deux grilles de decoupe differentes -- ce qui compte n'est pas le nombre de chunks, mais l'etiquette qu'ils portent (ou non).\n",
     "\n",
-    "L'exemple de chunk naif affiche en sortie, tire au hasard au milieu du corpus, melange les themes du phare (chapter maritime) et de la roseraie (chapter horticole) -- c'est precisement le defaut que la section 8 explicitera comme demonstration.\n",
+    "L'exemple de chunk naif affiche en sortie est pris au milieu du corpus (indice median, deterministe -- aucun hasard). Sur cette execution il tombe sur un fragment coherent (irrigation du jardin) : le chunkage naif ne produit pas *systematiquement* des fragments incoherents, il les produit *invérifiables*. Les fragments qui melangent deux themes sont comptes par la sonde de cette meme cellule (2 sur 20) et exhibes en section 8.\n",
     "\n",
     "**Implication pedagogique** : le defaut n'est pas un bug ; il est la consequence directe d'avoir ignore la structure du corpus. C'est la preuve que `decouper` sans `comprendre` est insuffisant pour un RAG de qualite."
    ]
@@ -318,11 +401,19 @@
    "id": "ffa8c24e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.180306Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.179783Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.192367Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.191775Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.008936Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.008398Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.022897Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.020667Z"
+    },
+    "papermill": {
+     "duration": 0.027304,
+     "end_time": "2026-09-07T14:28:36.024500",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:35.997196",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -332,7 +423,7 @@
       "Chunking naif      : 20 chunks, AUCUNE metadonnee de source.\n",
       "Chunking structure : 18 chunks, livre + chapitre preserves.\n",
       "\n",
-      "=== Un chunk naif au hasard (milieu du corpus) ===\n",
+      "=== Un chunk naif au milieu du corpus (indice median, deterministe) ===\n",
       "\"on : trois cycles d'eau par jour en ete, un seul en hiver. Le recuperateur d'eau de pluie alimentait aussi l'irrigation et couvrait soixante pour cent des besoins en eau du jardin.\"\n",
       "\n",
       "=== Le chunk naif chevauche-t-il deux themes ? ===\n",
@@ -348,7 +439,7 @@
     "print(f\"Chunking naif      : {len(naif)} chunks, AUCUNE metadonnee de source.\")\n",
     "print(f\"Chunking structure : {len(structure)} chunks, livre + chapitre preserves.\")\n",
     "print()\n",
-    "print(\"=== Un chunk naif au hasard (milieu du corpus) ===\")\n",
+    "print(\"=== Un chunk naif au milieu du corpus (indice median, deterministe) ===\")\n",
     "print(repr(naif[len(naif)//2]))\n",
     "print()\n",
     "print(\"=== Le chunk naif chevauche-t-il deux themes ? ===\")\n",
@@ -374,7 +465,16 @@
   {
    "cell_type": "markdown",
    "id": "c4016442",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009084,
+     "end_time": "2026-09-07T14:28:36.042177",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.033093",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Vectorisation TF-IDF deterministe\n",
     "\n",
@@ -391,11 +491,19 @@
    "id": "77812c46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.194471Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.194471Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.208147Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.207009Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.059766Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.058718Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.070918Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.069849Z"
+    },
+    "papermill": {
+     "duration": 0.024022,
+     "end_time": "2026-09-07T14:28:36.072579",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.048557",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -424,7 +532,16 @@
   {
    "cell_type": "markdown",
    "id": "29fd089c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007272,
+     "end_time": "2026-09-07T14:28:36.087294",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.080022",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Recherche -- meme requete, deux strategies\n",
     "\n",
@@ -439,10 +556,11 @@
     "\n",
     "**Lecture de la sortie** :\n",
     "\n",
-    "- La requete horlogerie est bien resolue par les deux strategies mais avec des scores tres differents. La strategie structuree remonte directement le chapitre 1 de l'Horlogerie Pratique ; la strategie naive prend un fragment textuel qui contient \"orloge\" mais pas la demonstration complete.\n",
-    "- Les 4 autres requetes du tableau (jardin/phare/horlogerie/sombrero) montrent des ecarts analogues : la structure preserve la **completude du contexte**, le naive preserve la **rapidite du match lexical**.\n",
+    "- La requete horlogerie illustre le defaut de la grille naive : le fragment top-1 **commence au milieu du mot** \"horloge\" (`'orloge. Un pendule...'`) -- preuve directe de la tranche en caracteres. Cote structure, le top-1 est le debut complet du chapitre 1, etiquete `[Horlogerie Pratique > ch.1]`, avec l'etiquette attendue (ok=True).\n",
+    "- **Le score cosinus ne dit pas lequel des deux retrievals est \"meilleur\"** : sur la requete du gardien, le fragment naive score plus haut (0.262) que le chunk structure (0.236) ; sur la requete de l'eau au jardin, idem (0.382 vs 0.252). Un fragment court et lexicallement proche bat souvent un passage complet -- un score eleve n'est pas une preuve de qualite.\n",
+    "- Le **constant** sur les cinq requetes : le top-1 structure porte toujours l'etiquette livre+chapitre attendue (5/5), le top-1 naive n'est jamais verifiable (aucune etiquette), et parfois un fragment coupe au milieu d'un mot.\n",
     "\n",
-    "**Implication** : un pipeline RAG qui sert un LLM en aval prefere la structure (passages complets = moins d'hallucination), un pipeline qui sert un humain en recherche libre prefere parfois le naif (fragments courts + rapide a scanner). Le choix depend du contrat de service."
+    "**Implication** : ce tableau demontre la **tracabilite** (verifier d'ou vient chaque reponse), pas la superiorite du retrieval structure. Un pipeline RAG qui sert un LLM en aval prefere des passages complets et etiquetes ; un pipeline qui sert un humain en recherche libre peut preferer des fragments courts. Le choix depend du contrat de service."
    ]
   },
   {
@@ -451,11 +569,19 @@
    "id": "1a7fe687",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.209714Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.209194Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.222874Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.222286Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.102764Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.102229Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.126116Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.125584Z"
+    },
+    "papermill": {
+     "duration": 0.03333,
+     "end_time": "2026-09-07T14:28:36.127629",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.094299",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -479,7 +605,7 @@
       "comment economiser l'eau au jardin ?           | Jardins Suspendus    ch.2           | s=0.382 ' pour cent des besoins en eau du jardin.'\n",
       "                                               |                                    |              | [Jardins Suspendus > ch.2] ok=True s=0.252\n",
       "\n",
-      "Precision chapitre exact (top-1) : structure = 5/5, naif = N/A (pas d etiquette).\n"
+      "Origine verifiee (top-1) : structure = 5/5 etiquettes livre+chapitre conformes ; naif = non verifiable (aucune etiquette).\n"
      ]
     }
    ],
@@ -504,56 +630,74 @@
     "\n",
     "print(f\"{'Requete':<46} | {'Attendu':<34} | Naif (top-1) | Structure (top-1)\")\n",
     "print(\"-\" * 130)\n",
-    "exact_naif = 0\n",
-    "exact_struct = 0\n",
+    "origines_conformes = 0\n",
     "for req, livre_attendu, ch_attendu in REQUETES:\n",
     "    rv = vec.transform([req])\n",
-    "    # naif : on ne peut verifier le livre/chapitre (pas d'etiquette) -> on verifie la presence des mots-cles\n",
+    "    # naif : aucune etiquette a verifier -- on affiche le fragment brut\n",
     "    i_n, s_n = top_k(mat_naif, naif, rv)[0]\n",
     "    bout_naif = naif[i_n][:40].replace(\"\\n\", \" \")\n",
-    "    # structure : on a l'etiquette exacte\n",
+    "    # structure : on a l'etiquette exacte, donc l'origine est VERIFIABLE\n",
     "    i_s, s_s = top_k(mat_struct, structure, rv)[0]\n",
     "    c_s = structure[i_s]\n",
     "    ok_struct = (c_s[\"livre\"] == livre_attendu and c_s[\"chapitre\"] == ch_attendu)\n",
-    "    exact_struct += int(ok_struct)\n",
+    "    origines_conformes += int(ok_struct)\n",
     "    print(f\"{req:<46} | {livre_attendu:<20} ch.{ch_attendu:<11} | s={s_n:.3f} {bout_naif!r}\")\n",
     "    print(f\"{'':<46} | {'':<34} |              | {etiquetter_struct(c_s)} ok={ok_struct} s={s_s:.3f}\")\n",
     "    print()\n",
     "\n",
-    "print(f\"Precision chapitre exact (top-1) : structure = {exact_struct}/{len(REQUETES)}, naif = N/A (pas d etiquette).\")"
+    "# Ce compte mesure la TRACABILITE (l'origine du top-1 est verifiable et conforme),\n",
+    "# pas une precision de retrieval comparee : le naif n'a aucune etiquette a verifier,\n",
+    "# il n'y a donc pas de bras de comparaison ici (voir Exercice 2 pour en construire un).\n",
+    "print(f\"Origine verifiee (top-1) : structure = {origines_conformes}/{len(REQUETES)} etiquettes \"\n",
+    "      f\"livre+chapitre conformes ; naif = non verifiable (aucune etiquette).\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "3bd19332",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006509,
+     "end_time": "2026-09-07T14:28:36.139551",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.133042",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## 7. Lecture du resultat\n",
+    "## 7. Lecture du resultat : ce qui est demontre, ce qui ne l'est pas\n",
     "\n",
-    "La strategie structuree permet de **mesurer** la precision (on a l'etiquette\n",
-    "exacte livre + chapitre) : c'est l'avantage decisive. La strategie naivee, meme\n",
-    "quand elle remonte un fragment correct, est **invérifiable** -- l'utilisateur ne\n",
-    "sait pas de quel ouvrage ni de quel chapitre il vient, et un chunk a cheval sur\n",
-    "deux sujets est indiscernable d'un chunk coherent.\n",
+    "**Ce que le tableau demontre : la tracabilite.** Chaque chunk structure porte une etiquette livre + chapitre, donc l'origine de chaque reponse est **verifiable** -- et sur les cinq requetes de ce notebook, elle est conforme (5/5). La strategie naive, meme quand elle remonte un fragment correct, est **invérifiable** : l'utilisateur ne sait pas de quel ouvrage ni de quel chapitre il vient, et un chunk a cheval sur deux sujets est indiscernable d'un chunk coherent.\n",
+    "\n",
+    "**Ce que le tableau ne mesure pas : la qualite de retrieval comparee.** Les scores cosinus des deux index ne se comparent pas comme a comme (fragments courts d'un cote, passages complets de l'autre) -- sur deux des cinq requetes, le fragment naive score meme plus haut. Une vraie comparaison de precision exigerait **le meme type de verite terrain pour les deux methodes** : c'est exactement ce que l'exercice 2 (etiquetage a posteriori des chunks naifs) permet de construire.\n",
     "\n",
     "Ce qui est perdu avec le chunking naif :\n",
     "\n",
     "- **l'etiquette de source** (quel ouvrage ?) -- impossible de filtrer par livre ;\n",
     "- **l'etiquette de chapitre** (quelle partie ?) -- impossible de filtrer par section ;\n",
-    "- **la coherence thematique** -- un chunk qui chevauche deux chapitres peut\n",
-    "  contenir des affirmations contradictoires ou hors-contexte.\n",
+    "- **la coherence thematique** -- un chunk qui chevauche deux chapitres peut contenir des affirmations contradictoires ou hors-contexte.\n",
     "\n",
     "Ce qui est preserve avec le chunking structure :\n",
     "\n",
     "- la **granularite** (chunk de taille raisonnable) -- on sous-decoupe si besoin ;\n",
     "- la **traceabilite** (chaque chunk porte son origine) -- filtrable en payload ;\n",
-    "- la **coherence** (un chunk = un theme) -- le retrieval reste pertinent."
+    "- la **coherence** (un chunk reste dans un seul chapitre) -- le retrieval reste pertinent."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "fd6551fd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007525,
+     "end_time": "2026-09-07T14:28:36.154076",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.146551",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. La pire chute : un chunk qui melange deux sujets\n",
     "\n",
@@ -570,11 +714,19 @@
    "id": "85ce3018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.224956Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.224437Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.238639Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.237503Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.169132Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.168612Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.178129Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.177050Z"
+    },
+    "papermill": {
+     "duration": 0.018164,
+     "end_time": "2026-09-07T14:28:36.179227",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.161063",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -598,7 +750,7 @@
    ],
    "source": [
     "#Deterministe : on exhibe directement l'un des chunks naifs qui melangent 2 themes\n",
-    "# (la section 4 en a compte 2 sur 13). Aucune requete, aucun hasard : on montre\n",
+    "# (la section 4 en a compte 2 sur 20). Aucune requete, aucun hasard : on montre\n",
     "# un fragment hybride reellement produit par la decoupe a taille fixe.\n",
     "hybrides = []\n",
     "for chunk in naif:\n",
@@ -628,22 +780,41 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2255be4e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004301,
+     "end_time": "2026-09-07T14:28:36.188833",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.184532",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture des chunks hybrides (ancre sur code[6])\n",
     "\n",
     "La sortie observee de code[6] detient deux informations complementaires :\n",
     "\n",
     "1. **Compte** : `Chunks naifs melangeant >= 2 themes : 2 sur 20.` -- 10 % du corpus est hybride. C'est une mesure *directe* du defaut de decoupe.\n",
-    "2. **Liste des themes** : `['tempete/phare', 'rosiers/jardin']` -- les 2 chunks sont des collisions de chapitres adjacents dans le pipeline textuel, et non des collisions semantiques aleatoires. Le defaut est donc **structurel**, pas stochastique : un chapitre qui finit sur 'tempete' suivi d'un autre qui commence sur 'rosiers' va presque certainement etre coupe par une frontiere de mots fixes si la frontiere tombe a l'interieur de la zone de recouvrement.\n",
+    "2. **Liste des themes** : `['tempete/phare', 'rosiers/jardin']` -- les 2 chunks sont des collisions de chapitres adjacents dans le pipeline textuel, et non des collisions semantiques aleatoires. Le defaut est donc **structurel**, pas stochastique : un chapitre qui finit sur 'tempete' suivi d'un autre qui commence sur 'rosiers' va quasi certainement etre colle si la frontiere fixe tombe entre les deux.\n",
     "\n",
-    "**Implication pour la regle de chunking** : utiliser une frontiere fixe en mots (taille=180) est sous-optimal pour un corpus avec des chapitres courts. Une regle pragmatique est : `taille >= plus court chapitre` ET `recouvrement >= 2 phrases`. Pour ce corpus avec chapitres >= 200 mots, taille=180 est sous-optimale -- la calibration pedagogique a ete faite au plus juste pour rendre le defaut visible."
+    "**Implication pour la regle de chunking** : une frontiere fixe **en caracteres** (taille=180) coupe sans regarder ni les mots ni les phrases -- le fragment top-1 `'orloge. Un pendule...'` de la section 6 en est la preuve (la coupe est tombee au milieu du mot \"horloge\"). Une regle pragmatique est : `taille >= plus court chapitre` ET decoupage aux frontieres de mots. Pour ce corpus aux chapitres de ~300 caracteres, taille=180 garantie que certaines frontieres tombent entre deux chapitres -- la calibration pedagogique a ete faite au plus juste pour rendre le defaut visible."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "92b90d04",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007651,
+     "end_time": "2026-09-07T14:28:36.200925",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.193274",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Ce qu'il faut retenir\n",
     "\n",
@@ -651,9 +822,9 @@
     "\n",
     "**Trois idees cles** que ce notebook demontre sur la mediatheque de Valmont :\n",
     "\n",
-    "1. **Granularite fixe ignore la structure** : 20 chunks naifs pour 9 chapitres, dont 2 melangeant 2 themes par malchance de la frontiere. La strategie structuree produit 18 chunks (un par chapitre ou demi-chapitre) et **zero** melange de themes.\n",
+    "1. **Granularite fixe ignore la structure** : 20 tranches naives de 180 caracteres pour 9 chapitres, dont 2 melangeant 2 themes par malchance de la frontiere. La strategie structuree produit 18 chunks (chaque chapitre sous-decoupe aux frontieres de mots en morceaux d'au plus 220 caracteres) et **zero** melange de themes.\n",
     "2. **Les metadonnees permettent le filtrage a posteriori** : sans `livre` / `chapitre` / `position` dans chaque chunk, on ne peut pas repondre a \"donne-moi les passages du chapitre 3 du livre 1\". Le chunking naif rend cette fonctionnalite impossible.\n",
-    "3. **Le top-k peut paraitre bon en moyenne etrater en pratique** : un chunk hybride qui melange 2 themes se comporte comme un point barycentre en TF-IDF ; selon la requete, il sort dans le top-1 alors qu'il n'est pertinent pour aucun des deux themes en propre.\n",
+    "3. **Le top-k peut paraitre bon en moyenne et rater en pratique** : un chunk hybride qui melange 2 themes se comporte comme un point barycentre en TF-IDF ; selon la requete, il sort dans le top-1 alors qu'il n'est pertinent pour aucun des deux themes en propre.\n",
     "\n",
     "**Transition vers la serie `5_RAG_Modern.ipynb`** : la ou ce notebook utilise TF-IDF (vocabulaire partage), `5_RAG_Modern` utilise des embeddings denses (cosinus semantique). Le determinant cache reste le chunking -- c'est pourquoi le notebook pedagogique fondateur doit rester en TF-IDF : la modularite du pipeline est plus visible avec un vectoriseur reversible a la main.\n",
     "\n",
@@ -666,7 +837,16 @@
   {
    "cell_type": "markdown",
    "id": "3b157ca9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003526,
+     "end_time": "2026-09-07T14:28:36.211912",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.208386",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 10. Exercices\n",
     "\n",
@@ -684,11 +864,19 @@
    "id": "b32584c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.240199Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.239678Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.253933Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.252679Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.221983Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.221454Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.227506Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.226326Z"
+    },
+    "papermill": {
+     "duration": 0.01313,
+     "end_time": "2026-09-07T14:28:36.228039",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.214909",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -716,7 +904,16 @@
   {
    "cell_type": "markdown",
    "id": "e534c2a1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004517,
+     "end_time": "2026-09-07T14:28:36.236600",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.232083",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 -- Etiqueter les chunks naifs a posteriori\n",
     "\n",
@@ -738,11 +935,19 @@
    "id": "3db8ee47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.256530Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.256530Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.269054Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.267924Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.246773Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.245774Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.251309Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.250776Z"
+    },
+    "papermill": {
+     "duration": 0.012599,
+     "end_time": "2026-09-07T14:28:36.252815",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.240216",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -769,7 +974,16 @@
   {
    "cell_type": "markdown",
    "id": "1746ed71",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004649,
+     "end_time": "2026-09-07T14:28:36.263074",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.258425",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 -- Le filtrage par metadonnee, que le chunking naif ne permet pas\n",
     "\n",
@@ -798,11 +1012,19 @@
    "id": "693798b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.270623Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.270098Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.284297Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.283155Z"
-    }
+     "iopub.execute_input": "2026-09-07T14:28:36.272308Z",
+     "iopub.status.busy": "2026-09-07T14:28:36.272308Z",
+     "iopub.status.idle": "2026-09-07T14:28:36.276540Z",
+     "shell.execute_reply": "2026-09-07T14:28:36.276540Z"
+    },
+    "papermill": {
+     "duration": 0.010288,
+     "end_time": "2026-09-07T14:28:36.277560",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.267272",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -837,7 +1059,16 @@
   {
    "cell_type": "markdown",
    "id": "dddaee56",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004005,
+     "end_time": "2026-09-07T14:28:36.286071",
+     "exception": false,
+     "start_time": "2026-09-07T14:28:36.282066",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 11. Pour aller plus loin\n",
     "\n",
@@ -874,7 +1105,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.989471,
+   "end_time": "2026-09-07T14:28:36.629262",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "ingestion-corpus-long-rag.ipynb",
+   "output_path": "ingestion-corpus-long-rag.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-07T14:28:32.639791",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15008

Closes #15046 (G10 P2, fille #15035 — geste privilegie par l'issue : « rester explicitement une demonstration de provenance ... corriger la prose »).

## Defaut 1 — le commentaire decrit un decoupage que le code ne fait pas [ING:c7]

Le commentaire de `chunk_structure` disait « si le chapitre depasse taille_max, on le decoupe **par phrase** » ; le code appelle `textwrap.wrap(texte_ch, width=taille_max, break_long_words=False)`, qui coupe par **largeur en caracteres** aux **frontieres de mots** — jamais au milieu d'un mot, mais la frontiere peut tomber au milieu d'une phrase. Corrige :

- **c7 (code)** : commentaire reecrit — « sous-decoupe AUX FRONTIERES DE MOTS : jamais au milieu d'un mot, mais une frontiere peut tomber au milieu d'une phrase (la coupe suit la largeur, pas la ponctuation) ».
- **Unites corrigees partout ou la prose mentait** : `chunk_naif` fait des tranches de **180 caracteres** par slices purs (`texte[debut:fin]`), pas « taille fixe en **mots** » (c6) ; les chapitres font **292-343 caracteres (46-63 mots)**, pas « 200-400 mots » (c5, c17) ; la « frontiere fixe en mots » devient « en caracteres » (c17) avec la preuve visible dans la sortie : le fragment top-1 `'orloge. Un pendule...'` commence **au milieu du mot** « horloge ».

**Acceptance verbatim** : « Une phrase plus longue que la largeur est traitee conformement a la description » — la description dit maintenant exactement ce que textwrap fait.

## Defaut 2 — le 5/5 ne demontre aucune amelioration [ING:c13]

`exact_naif = 0` etait initialise sans jamais etre alimente (code mort simulant un bras de comparaison). Le tableau etait lu comme une precision comparee. Corrige :

- **c13 (code)** : variable morte supprimee ; compteur renomme `origines_conformes` ; print final recadre : « **Origine verifiee (top-1)** : structure = 5/5 etiquettes livre+chapitre conformes ; naif = non verifiable (aucune etiquette) ».
- **c12 (lecture, ancree sur les scores reels)** : la prose « les 4 autres requetes ... montrent des ecarts analogues » etait fausse — sur **2 des 5 requetes le fragment naif score PLUS HAUT** que le chunk structure (gardien 0.262 vs 0.236 ; eau au jardin 0.382 vs 0.252). La requete « sombrero » citee dans l'ancienne lecture **n'existe pas** dans REQUETES ni dans le corpus (phantom). Lecture reecrite sur les sorties reelles : le constant est l'**etiquette verifiable 5/5**, pas le score.
- **c14 (section 7)** : separation explicite « ce qui est demontre » (tracabilite : origine verifiable, conforme 5/5, filtrable) vs « ce qui n'est pas mesure » (qualite de retrieval comparee — comparer les scores de deux index differents n'est pas un like-for-like ; l'exercice 2, etiquetage a posteriori, en est le point de depart, exactement comme le suggere l'issue).

**Acceptance verbatim** : « la comparaison ... reste explicitement une demonstration de provenance » — voie choisie (celle que l'issue designe comme « le geste a privileger »).

## Tailles recalculees a partir des variables (acceptance)

- c5 : structure reelle du CORPUS decrite (`dict livre -> {"auteur", "chapitres": {num: (titre, texte)}}` — l'ancienne prose disait `dict[str, list[str]]`, faux) ; chapitres 292-343 caracteres.
- c8 : « 18 chunks structures = un par chapitre en moyenne » etait faux — chaque chapitre de ~300 caracteres depasse le plafond 220 et est sous-decoupe en 2 morceaux (9 x 2 = 18). L'exemple « tire au hasard » est en fait l'indice median deterministe (print c9 aligne aussi) ; sur cette execution il tombe sur un fragment coherent — la prose le dit honnetement au lieu d'affirmer un melange absent.
- c16 : commentaire interne « 2 sur 13 » -> « 2 sur 20 » (compte reel de la section 4).
- c18 : « un par chapitre ou demi-chapitre » -> sous-decoupe aux frontieres de mots ; typo « etrater » -> « et rater ».

Valeurs toutes reproduites par l'execution committee : 20 naifs / 18 structures / matrice 38 x 246 / 2 hybrides sur 20 / 5-5 origines conformes.

## Re-execution (C.2)

`python scripts/notebook_tools/notebook_tools.py execute ... --kernel python3` -> **SUCCESS** (7.8 s), 0 erreur, 0 NotImplementedError, `execution_count` 1-10 non-null sur toutes les cells code. Notebook 100 % local (sklearn TF-IDF + numpy, « Aucun reseau ») — deterministe, valeurs reproduites a l'identique entre les deux executions de ce grain.

## Diff

1 fichier, 348 insertions / 105 deletions (cellules 5-9, 12-14, 16-18 ; les cells code modifiees : 7, 9, 13, 16). Aucune cellule supprimee, aucun exemple resolu stubbe, exercices 1-3 intacts. Catalogue byte-identique a main (aucun fichier catalogue touche).