### PR TITLE
enrich(qc,#11601): QC-Py-23c TimesFM lectures et transitions -- densite 1161 -> 2475 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23c-TimesFM-Foundation-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23c-TimesFM-Foundation-Models.ipynb
@@ -13,45 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# QC-Py-23c — Modèles de fondation pour séries temporelles (TimesFM)\n",
-    "\n",
-    "La série `QC-Py` a déjà vu des modèles **entraînés localement** : LSTM (`QC-Py-22`),\n",
-    "les State-Space Models (`QC-Py-23`) et les transformers spécialisés PatchTST /\n",
-    "iTransformer (`QC-Py-23b`). Ce notebook introduit le **changement de paradigme**\n",
-    "qui a suivi : les **modèles de fondation** (`foundation models`).\n",
-    "\n",
-    "> Un modèle de fondation pour séries temporelles est pré-entraîné sur un très\n",
-    "> grand corpus de séries réelles, puis utilisé **zéro-shot** : on lui donne un\n",
-    "> historique et il prévoit l'avenir **sans être ré-entraîné sur cette série**.\n",
-    "\n",
-    "## Table des matières\n",
-    "\n",
-    "1. Modèle entraîné localement vs modèle de fondation zéro-shot\n",
-    "2. Prévision univariée vs multivariée, et covariables\n",
-    "3. Prévision ponctuelle vs quantiles, et calibration\n",
-    "4. Comparaison conceptuelle PatchTST / iTransformer / TimesFM\n",
-    "5. Licence : code, poids, droit de production\n",
-    "6. Exercices\n",
-    "\n",
-    "## Licence — à lire avant toute chose\n",
-    "\n",
-    "TimesFM est le modèle de fondation de Google Research. Il faut **séparer trois\n",
-    "objets aux licences différentes** :\n",
-    "\n",
-    "| Objet | Licence | Utilisable ici ? |\n",
-    "|---|---|---|\n",
-    "| **Code** (`google-research/timesfm`) | Apache-2.0 | Oui |\n",
-    "| **Poids ≤ 2.5** (`google/timesfm-2.5-200m-pytorch`) | Apache-2.0 | Oui |\n",
-    "| **Poids 3.0** (`google/timesfm-3.0-pytorch`) | **TimesFM Non-Commercial License v1.0** | Non — présenté en comparaison seulement |\n",
-    "\n",
-    "Le notebook exécute donc **TimesFM 2.5** (Apache-2.0), et aborde TimesFM 3.0\n",
-    "uniquement sur le plan **architectural et juridique**, sans distribuer ses poids\n",
-    "ni produire de sortie issue des poids 3.0. Sources : le dépôt GitHub\n",
-    "`google-research/timesfm`, le hub HF `google/timesfm-3.0-pytorch` et le billet\n",
-    "de recherche *TimesFM 3: A Zero-shot Foundation Model for Multivariate\n",
-    "Forecasting*."
-   ]
+   "source": "[<< Sommaire QC](../README.md) | [Précédent : QC-Py-23b-PatchTST-iTransformer <<](./QC-Py-23b-PatchTST-iTransformer.ipynb) | [Suivant : QC-Py-24-Autoencoders-Anomaly >>](./QC-Py-24-Autoencoders-Anomaly.ipynb)\n\n# QC-Py-23c — Modèles de fondation pour séries temporelles (TimesFM)\n\nLa série `QC-Py` a déjà vu des modèles **entraînés localement** : LSTM (`QC-Py-22`),\nles State-Space Models (`QC-Py-23`) et les transformers spécialisés PatchTST /\niTransformer (`QC-Py-23b`). Ce notebook introduit le **changement de paradigme**\nqui a suivi : les **modèles de fondation** (`foundation models`).\n\n> Un modèle de fondation pour séries temporelles est pré-entraîné sur un très\n> grand corpus de séries réelles, puis utilisé **zéro-shot** : on lui donne un\n> historique et il prévoit l'avenir **sans être ré-entraîné sur cette série**.\n\n**Objectifs d'apprentissage** : (1) exécuter le vrai TimesFM 2.5 en zéro-shot et\nle comparer honnêtement à une baseline naïve ; (2) distinguer prévision univariée\net multivariée, et savoir quand une covariable mérite l'effort de l'API dédiée ;\n(3) lire une prévision par quantiles et mesurer sa calibration (couverture\nempirique) ; (4) situer le modèle de fondation face aux architectures entraînées\nlocalement ; (5) séparer licence du code et licence des poids.\n\n**Prerequis** : QC-Py-23b (PatchTST / iTransformer — la Partie 4 s'y appuie),\nbases de numpy/matplotlib ; aucun entraînement n'est requis dans ce notebook.\n\n**Duree estimee** : ~40 min (parties guidées ; les exercices reprennent le\nprotocole et demandent du temps supplémentaire).\n\n## Table des matières\n\n1. Modèle entraîné localement vs modèle de fondation zéro-shot\n2. Prévision univariée vs multivariée, et covariables\n3. Prévision ponctuelle vs quantiles, et calibration\n4. Comparaison conceptuelle PatchTST / iTransformer / TimesFM\n5. Licence : code, poids, droit de production\n6. Exercices\n\n## Licence — à lire avant toute chose\n\nTimesFM est le modèle de fondation de Google Research. Il faut **séparer trois\nobjets aux licences différentes** :\n\n| Objet | Licence | Utilisable ici ? |\n|---|---|---|\n| **Code** (`google-research/timesfm`) | Apache-2.0 | Oui |\n| **Poids ≤ 2.5** (`google/timesfm-2.5-200m-pytorch`) | Apache-2.0 | Oui |\n| **Poids 3.0** (`google/timesfm-3.0-pytorch`) | **TimesFM Non-Commercial License v1.0** | Non — présenté en comparaison seulement |\n\nLe notebook exécute donc **TimesFM 2.5** (Apache-2.0), et aborde TimesFM 3.0\nuniquement sur le plan **architectural et juridique**, sans distribuer ses poids\nni produire de sortie issue des poids 3.0. Sources : le dépôt GitHub\n`google-research/timesfm`, le hub HF `google/timesfm-3.0-pytorch` et le billet\nde recherche *TimesFM 3: A Zero-shot Foundation Model for Multivariate\nForecasting*."
   },
   {
    "cell_type": "markdown",
@@ -152,6 +114,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9caaef11",
+   "source": "### Lecture du résultat — le protocole expérimental\n\nLe graphique montre les 300 pas de la série (noir), la fenêtre verte du\n**contexte** (les 96 derniers pas donnés au modèle) et la fenêtre orange du\n**test** (les 24 pas suivants, cachés au modèle). Trois choix méritent d'être\nlus avant d'aller plus loin :\n\n1. **Deux périodicités superposées** (24 et 96 pas) : le contexte de 96 pas\n   couvre exactement **un cycle long**, ou quatre cycles courts — le modèle\n   dispose de l'information nécessaire pour reconstituer la structure.\n2. **Horizon égal à la période courte** : les 24 pas à prévoir forment un cycle\n   complet. Une prévision constante ne peut pas suivre ce cycle : la baseline\n   naïve va échouer **structurellement**, et c'est précisément ce qu'on veut\n   mesurer.\n3. **Bruits et tendance contrôlés** : bruit gaussien d'écart-type `0.6` devant\n   une composante dominante d'amplitude `20`, tendance de `0.02` par pas ; le\n   tout reproductible (`RandomState(7)`).\n\nLa valeur imprimée en fin de cellule — la dernière observation du contexte —\nest celle que la baseline naïve va répéter sur tout l'horizon : le contraste de\nla Partie 1 se joue déjà entre ce nombre unique et le cycle qu'il prétend\nrésumer.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "9bbe0725",
    "metadata": {
     "papermill": {
@@ -163,13 +131,7 @@
     },
     "tags": []
    },
-   "source": [
-    "La cellule suivante charge le **vrai checkpoint TimesFM 2.5** depuis le hub\n",
-    "Hugging Face. Le modèle est un réseau de fondation : on invoque\n",
-    "`from_pretrained(...)`, on le compile avec un `ForecastConfig`, puis on prévoit.\n",
-    "Aucun `forward` de notre cru, aucun réseau réentraîné — c'est le **modèle\n",
-    "publié** qui produit la prévision (`SOTA-OK`)."
-   ]
+   "source": "La cellule suivante charge le **vrai checkpoint TimesFM 2.5** depuis le hub\nHugging Face. Le modèle est un réseau de fondation : on invoque\n`from_pretrained(...)`, on le compile avec un `ForecastConfig`, puis on prévoit.\nAucun `forward` de notre cru, aucun réseau réentraîné — c'est le **modèle\npublié** qui produit la prévision (`SOTA-OK`).\n\nTrois gestes s'enchaînent et aucun n'est un entraînement : `from_pretrained`\nrapatrie les poids publiés une fois pour toutes ; `compile` fixe la\nconfiguration d'inférence — `max_context=512` (l'historique sera tronqué\nau-delà) et `max_horizon=128` (le plafond d'horizon demandable) — ; la prévision\nelle-même viendra ensuite par un unique appel à `forecast`. Notre protocole\n(96 pas de contexte, 24 d'horizon) tient dans ces plafonds avec plus de 5× de\nmarge : de la place pour allonger l'un ou l'autre sans recharger le modèle."
   },
   {
    "cell_type": "code",
@@ -219,6 +181,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "39a2a2e8",
+   "source": "### Lecture du résultat — ce que le chargement dit\n\nLa sortie confirme les deux temps : les poids sont téléchargés **depuis le hub**\n(l'identifiant affiché est bien `google/timesfm-2.5-200m-pytorch`) puis compilés\ndans la configuration demandée. Le **200M** de l'identifiant est l'ordre de\ngrandeur des paramètres du réseau — un objet modeste côté LLM, énorme côté\nséries temporelles, et qui tient ici en mémoire sans précaution particulière.\nLe **warning HF_TOKEN** n'est pas une erreur : sans jeton, le hub applique des\nlimites de débit aux requêtes anonymes ; un téléchargement répété en peu de\ntemps peut être ralenti, pas empêché. Le point essentiel pour la suite : il n'y\na eu **aucun entraînement** — ni boucle d'optimisation, ni jeu de données local\n— là où QC-Py-22, 23 et 23b construisaient puis entraînaient leur réseau de\nzéro.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "7bd2afd9",
    "metadata": {
     "papermill": {
@@ -230,12 +198,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Le modèle est prêt. On définit maintenant deux aides de mesure — une **baseline\n",
-    "naïve** (persistance : répéter la dernière observation) et deux métriques (MAE,\n",
-    "RMSE) — puis on lance la prévision zéro-shot sur la fenêtre de test. La baseline\n",
-    "sert de **référence** : elle dit ce qu'on obtient sans aucun modèle."
-   ]
+   "source": "Le modèle est prêt. On définit maintenant deux aides de mesure — une **baseline\nnaïve** (persistance : répéter la dernière observation) et deux métriques (MAE,\nRMSE) — puis on lance la prévision zéro-shot sur la fenêtre de test. La baseline\nsert de **référence** : elle dit ce qu'on obtient sans aucun modèle.\n\nPourquoi deux métriques plutôt qu'une : la **MAE** s'exprime dans l'unité de la\nsérie et traite toutes les erreurs à égalité ; la **RMSE** élève au carré avant\nde moyenner, donc quelques grandes erreurs pèsent plus que beaucoup de petites.\nEn finance l'écart entre les deux est une information : une RMSE nettement plus\nhaute que la MAE signale des erreurs concentrées — exactement ce qu'un stop ou\nun appel de marge sanctionne. La cellule affichera les deux, pour la baseline et\npour TimesFM, sur la même fenêtre de test."
   },
   {
    "cell_type": "code",
@@ -301,15 +264,7 @@
     },
     "tags": []
    },
-   "source": [
-    "#### Lecture du résultat\n",
-    "\n",
-    "Le score est **honnête** : il compare le naive (une ligne plate) à TimesFM\n",
-    "zéro-shot sur la fenêtre de test, *sans entraînement sur cette série*. La\n",
-    "prévision du modèle de fondation est produite en une passe, là où un modèle\n",
-    "local devrait : collecter ses données, choisir une architecture, s'entraîner\n",
-    "(souvent des dizaines de minutes) et valider. **Ici il n'y a eu qu'un appel.**"
-   ]
+   "source": "#### Lecture du résultat\n\nLe score est **honnête** : il compare le naive (une ligne plate) à TimesFM\nzéro-shot sur la fenêtre de test, *sans entraînement sur cette série*. La\nprévision du modèle de fondation est produite en une passe, là où un modèle\nlocal devrait : collecter ses données, choisir une architecture, s'entraîner\n(souvent des dizaines de minutes) et valider. **Ici il n'y a eu qu'un appel.**\n\n| Métrique | Baseline naïve | TimesFM 2.5 zéro-shot | Écart |\n|---|---|---|---|\n| MAE | 16.0573 | 0.8782 | ~18× meilleur |\n| RMSE | 17.4018 | 1.1231 | ~15× meilleur |\n\nDeux lectures derrière les chiffres. D'abord l'**ordre de grandeur de l'écart** :\nsur une série dont la composante dominante a une amplitude de 20, une MAE de\n16 signifie que la persistance rate le cycle en entier, tandis que 0.88 le\nreconstitue presque pas à pas. Ensuite le fait que **RMSE dépasse MAE** pour les\ndeux prévisionneurs (1.1231 contre 0.8782 pour TimesFM) : la distribution des\nerreurs a une queue — quelques horizons sont plus difficiles que les autres,\ntypiquement les zones de retournement du cycle, où le carré de l'erreur grossit\nvite."
   },
   {
    "cell_type": "code",
@@ -360,6 +315,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ecebf8d",
+   "source": "### Lecture du graphique\n\nLa courbe noire (réalité) décrit **exactement un cycle complet** de la\ncomposante dominante : l'horizon de 24 pas a été choisi égal à la période 24 du\nsignal. La ligne rouge, elle, est **plate par construction** — `np.repeat`\nrépète une seule valeur sur tout l'horizon — et son écart à la réalité traverse\ntout le cycle : c'est la traduction visuelle de la MAE `16.0573` mesurée plus\nhaut (Partie 1). La trajectoire bleue suit la périodicité **sans l'avoir jamais\napprise sur cette série** : le modèle a reconnu la structure dans les 96 pas de\ncontexte. La bande bleutée est l'intervalle `q0.1..q0.9` — la même dont la\nPartie 3 mesurera la couverture (`19/24`) et la largeur moyenne (`4.27`). Ce\ngraphique montre d'un coup d'œil les trois objets du notebook : baseline,\nprévision, incertitude.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "a4800535",
    "metadata": {
     "papermill": {
@@ -371,29 +332,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Partie 2 — Prévision univariée vs multivariée, et covariables\n",
-    "<a id=\"Partie-2\"></a>\n",
-    "\n",
-    "Une **série univariée** n'a qu'une seule série de valeurs. Un prévisionneur\n",
-    "« univarié » (TimesFM sur un canal) traite chaque canal indépendamment : c'est ce\n",
-    "qu'on a fait en Partie 1. Une **prévision multivariée** a plusieurs canaux qui\n",
-    "évoluent ensemble, et — surtout — des **covariables** : des variables exogènes\n",
-    "qui ne sont pas la cible mais qui aident à la prévoir.\n",
-    "\n",
-    "Il faut distinguer deux familles de covariables :\n",
-    "\n",
-    "| Famille | Exemple | Disponibilité au moment de prévoir |\n",
-    "|---|---|---|\n",
-    "| **Passées** | prix d'hier, volume, autre actif | connues pour l'historique |\n",
-    "| **Connues dans le futur** | jour de la semaine, jours fériés | connues à l'avance pour tout l'horizon |\n",
-    "\n",
-    "Un modèle de fondation ne « devine » pas les covariables : il faut les lui\n",
-    "**fournir**. TimesFM 2.5 expose `forecast_with_covariates(...)` pour les\n",
-    "covariables **dynamiques** (qui varient dans le temps) et des covariables\n",
-    "**statiques**. Ici on prévoit plusieurs canaux et on compare (a) l'approche\n",
-    "purement univariée et (b) une approche avec une covariable connue dans le futur."
-   ]
+   "source": "## Partie 2 — Prévision univariée vs multivariée, et covariables\n<a id=\"Partie-2\"></a>\n\nUne **série univariée** n'a qu'une seule série de valeurs. Un prévisionneur\n« univarié » (TimesFM sur un canal) traite chaque canal indépendamment : c'est ce\nqu'on a fait en Partie 1. Une **prévision multivariée** a plusieurs canaux qui\névoluent ensemble, et — surtout — des **covariables** : des variables exogènes\nqui ne sont pas la cible mais qui aident à la prévoir.\n\nIl faut distinguer deux familles de covariables :\n\n| Famille | Exemple | Disponibilité au moment de prévoir |\n|---|---|---|\n| **Passées** | prix d'hier, volume, autre actif | connues pour l'historique |\n| **Connues dans le futur** | jour de la semaine, jours fériés | connues à l'avance pour tout l'horizon |\n\nUn modèle de fondation ne « devine » pas les covariables : il faut les lui\n**fournir**. TimesFM 2.5 expose `forecast_with_covariates(...)` pour les\ncovariables **dynamiques** (qui varient dans le temps) et des covariables\n**statiques**. Ici on prévoit plusieurs canaux et on compare (a) l'approche\npurement univariée et (b) une approche avec une covariable connue dans le futur.\n\nConcrètement, l'expérience portera sur **quatre canaux** de structures\ndifférentes : un sinus de période 24 (amplitude 20, avec tendance), un sinus de\npériode 48 (amplitude 15), un cosinus de période 24 (amplitude 10) et une\ntendance pure sans périodicité. Deux questions guident la partie : (a) le\ntransfert zéro-shot observé en Partie 1 **tient-il** quand la périodicité,\nl'amplitude, ou la présence même d'une périodicité, changent ? (b) fournir au\nmodèle une covariable **connue dans le futur** déplace-t-il la prévision — et\ndans quel sens ?"
   },
   {
    "cell_type": "code",
@@ -460,17 +399,7 @@
     },
     "tags": []
    },
-   "source": [
-    "#### Lecture du résultat\n",
-    "\n",
-    "Chaque canal est prévu **indépendamment** : c'est la façon la plus simple de\n",
-    "traiter un problème multivarié avec un modèle univarié. Le point faible est\n",
-    "qu'aucun canal **n'apprend des autres**. Lorsqu'on veut modéliser un autre actif,\n",
-    "une nouvelle série, ou une covariable **connue dans le futur** (un jour de la\n",
-    "semaine, un jour férié, un calendrier), on doit passer par l'API covariables —\n",
-    "généralement au prix d'un surcoût et de contraintes de forme qu'on vérifie\n",
-    "soi-même. C'est le **compromis** à connaître avant de choisir une API."
-   ]
+   "source": "#### Lecture du résultat\n\nChaque canal est prévu **indépendamment** : c'est la façon la plus simple de\ntraiter un problème multivarié avec un modèle univarié. Le point faible est\nqu'aucun canal **n'apprend des autres**. Lorsqu'on veut modéliser un autre actif,\nune nouvelle série, ou une covariable **connue dans le futur** (un jour de la\nsemaine, un jour férié, un calendrier), on doit passer par l'API covariables —\ngénéralement au prix d'un surcoût et de contraintes de forme qu'on vérifie\nsoi-même. C'est le **compromis** à connaître avant de choisir une API.\n\n| Canal | Structure | MAE zéro-shot |\n|---|---|---|\n| 0 | sinus période 24, amplitude 20, tendance | 0.4480 |\n| 1 | sinus période 48, amplitude 15, tendance | 0.4136 |\n| 2 | cosinus période 24, amplitude 10 | 0.6405 |\n| 3 | tendance pure, sans périodicité | 0.5352 |\n\nLa lecture du tableau : les quatre MAE restent **sous 0.65** — le transfert\nzéro-shot ne tient pas qu'au signal de la Partie 1, il suit des périodicités,\ndes amplitudes et même une absence totale de périodicité. Le canal 2 est le\nmoins bon (`0.6405`) pour une raison lisible dans sa construction : des trois\ncanaux périodiques, c'est celui dont l'amplitude (10) est la plus faible face au\nbruit — donc le **rapport signal/bruit le plus bas** des trois. Et le canal 3\n(`0.5352`) apporte une limite instructive : une tendance est prévisible par\nextrapolation triviale, mais le modèle ne « régresse » pas une droite — il traite\nla série comme une parmi celles vues pendant son pré-entraînement."
   },
   {
    "cell_type": "code",
@@ -559,21 +488,13 @@
     },
     "tags": []
    },
-   "source": [
-    "#### Lecture du résultat\n",
-    "\n",
-    "Résultat **honnête et en soi instructif** : ici, ajouter la covariable connue\n",
-    "dans le futur **ne réduit pas** la MAE (`0.5285` contre `0.4480` sans covariable).\n",
-    "Ce n'est ni un échec du modèle ni une erreur de manipulation — c'est le point\n",
-    "pédagogique de la partie. La série synthétique est **déjà** dominée par une\n",
-    "périodicité `sin(2πt/24)` que le **contexte seul** (96 pas) suffit à reconstituer :\n",
-    "le modèle de fondation n'a pas besoin qu'on lui donne la composante, il l'a\n",
-    "« vue » dans l'historique. Une covariable apporte quelque chose quand elle porte\n",
-    "une information **que l'historique ne contient pas déjà** — un jour de la semaine,\n",
-    "un jour férié, un effet de calendrier, une variable exogène. C'est le critère à\n",
-    "garder avant de dépenser l'effort d'une API covariables : elle n'aide que si elle\n",
-    "**étend** l'information du contexte, pas si elle la redouble."
-   ]
+   "source": "#### Lecture du résultat\n\nRésultat **honnête et en soi instructif** : ici, ajouter la covariable connue\ndans le futur **ne réduit pas** la MAE (`0.5285` contre `0.4480` sans covariable).\nCe n'est ni un échec du modèle ni une erreur de manipulation — c'est le point\npédagogique de la partie. La série synthétique est **déjà** dominée par une\npériodicité `sin(2πt/24)` que le **contexte seul** (96 pas) suffit à reconstituer :\nle modèle de fondation n'a pas besoin qu'on lui donne la composante, il l'a\n« vue » dans l'historique. Une covariable apporte quelque chose quand elle porte\nune information **que l'historique ne contient pas déjà** — un jour de la semaine,\nun jour férié, un effet de calendrier, une variable exogène. C'est le critère à\ngarder avant de dépenser l'effort d'une API covariables : elle n'aide que si elle\n**étend** l'information du contexte, pas si elle la redouble.\n\nUn détail de mécanique API mérite d'être retenu avant de réutiliser\n`forecast_with_covariates` : la fonction exige une instance compilée avec\n`return_backcast=True` — d'où la **seconde instance** `model_cov` (mêmes poids,\nconfiguration différente) pendant que le modèle principal reste compilé sans\nbackcast. Et la covariable doit couvrir **contexte plus horizon** : ici\n`96 + 24 = 120` pas, alignés sur la fenêtre exacte utilisée pour prévoir. Ces\ncontraintes de forme, visibles dans le code de la cellule, sont le « surcoût »\ndont parlait la lecture précédente."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85694b5c",
+   "source": "### Transition — de la précision à l'incertitude\n\nCe que la Partie 2 a établi : le zéro-shot tient canal par canal (quatre MAE\nsous `0.65`), et une covariable n'aide que si elle **étend** l'information du\ncontexte. Ce qui manque encore à tout cela : aucune mesure n'a dit **dans quelle\nbande** la vérité va tomber. Une prévision à MAE `0.4480` est un point ; un\nsystème de trading a besoin d'un intervalle pour dimensionner son risque. La\nPartie 3 ouvre les quantiles que TimesFM renvoie déjà — et les met à l'épreuve\nde la calibration.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -588,23 +509,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Partie 3 — Prévision ponctuelle vs quantiles, et calibration\n",
-    "<a id=\"Partie-3\"></a>\n",
-    "\n",
-    "Une **prévision ponctuelle** (`point forecast`) est un nombre : `mean`. Une\n",
-    "**prévision probabiliste** ajoute une **distribution** : ici une série de\n",
-    "**quantiles** par horizon. TimesFM 2.5 renvoie, pour chaque horizon,\n",
-    "`10 colonnes` — la première est l'estimation ponctuelle, les neuf suivantes sont\n",
-    "les quantiles `0.1, 0.2, …, 0.9` (croissants). C'est ce qui permet de répondre\n",
-    "« quel est l'intervalle dans lequel la vraie valeur va tomber avec 80% de\n",
-    "probabilité ? ».\n",
-    "\n",
-    "**Calibrer** un modèle probabiliste, c'est vérifier que son intervalle couvre\n",
-    "réellement la bonne proportion du temps. Un modèle sur-confiant annonce des\n",
-    "intervalles trop étroits ; un modèle sous-confiant, trop larges. On mesure ici la\n",
-    "**couverture empirique** de l'intervalle central à 80% (`q0.1`..`q0.9`)."
-   ]
+   "source": "## Partie 3 — Prévision ponctuelle vs quantiles, et calibration\n<a id=\"Partie-3\"></a>\n\nUne **prévision ponctuelle** (`point forecast`) est un nombre : `mean`. Une\n**prévision probabiliste** ajoute une **distribution** : ici une série de\n**quantiles** par horizon. TimesFM 2.5 renvoie, pour chaque horizon,\n`10 colonnes` — la première est l'estimation ponctuelle, les neuf suivantes sont\nles quantiles `0.1, 0.2, …, 0.9` (croissants). C'est ce qui permet de répondre\n« quel est l'intervalle dans lequel la vraie valeur va tomber avec 80% de\nprobabilité ? ».\n\n**Calibrer** un modèle probabiliste, c'est vérifier que son intervalle couvre\nréellement la bonne proportion du temps. Un modèle sur-confiant annonce des\nintervalles trop étroits ; un modèle sous-confiant, trop larges. On mesure ici la\n**couverture empirique** de l'intervalle central à 80% (`q0.1`..`q0.9`).\n\nEn finance, l'enjeu dépasse la curiosité statistique : une espérance de\nrendement sans intervalle ne dimensionne ni un stop, ni une taille de position,\nni une exigence de capital. La couverture empirique jouera ici le rôle qu'un\nbacktest joue pour une espérance : **vérifier la promesse** contre la réalité\nobservée."
   },
   {
    "cell_type": "code",
@@ -668,19 +573,13 @@
     },
     "tags": []
    },
-   "source": [
-    "#### Lecture du résultat\n",
-    "\n",
-    "- Si la couverture empirique est proche de **0.80**, le modèle est **bien calibré**.\n",
-    "- Si elle est **plus petite**, le modèle est **sur-confiant** : il promet un\n",
-    "  intervalle trop serré.\n",
-    "- Si elle est **plus grande**, il est **sous-confiant**.\n",
-    "\n",
-    "Peur de la dispersion ? Non : c'est la **vertu** de la prévision probabiliste.\n",
-    "Une prévision ponctuelle ne dit rien du risque ; un intervalle calibré dit\n",
-    "« dans 80 % des cas la vraie valeur tombera ici ». C'est indispensable en\n",
-    "finance, où l'on gère le risque, pas seulement l'espérance."
-   ]
+   "source": "#### Lecture du résultat\n\n- Si la couverture empirique est proche de **0.80**, le modèle est **bien calibré**.\n- Si elle est **plus petite**, le modèle est **sur-confiant** : il promet un\n  intervalle trop serré.\n- Si elle est **plus grande**, il est **sous-confiant**.\n\nPeur de la dispersion ? Non : c'est la **vertu** de la prévision probabiliste.\nUne prévision ponctuelle ne dit rien du risque ; un intervalle calibré dit\n« dans 80 % des cas la vraie valeur tombera ici ». C'est indispensable en\nfinance, où l'on gère le risque, pas seulement l'espérance.\n\n**Application aux valeurs mesurées.** La couverture empirique vaut **0.792**\n(`19` points couverts sur `24`) contre une cible de `0.80` : à 24 points, la\ncible exacte serait `19.2` — l'écart constaté tient en deux dixièmes de point.\nSur cet exemple, l'intervalle de TimesFM est donc **quasi calibré**, avec une\nlargeur moyenne de `4.27` (demi-largeur d'environ `2.1`, à rapporter à la RMSE\nde `1.1231` mesurée en Partie 1 : la bande paie ~1.9× l'erreur typique pour\ntenir ses 80 %). Le contraste avec la dernière ligne de la sortie est le vrai\nenseignement : l'intervalle **gaussien naïf** atteint `1.000` de couverture non\npas parce qu'il est meilleur, mais parce que son `sigma` est estimé sur la\n**dispersion de la fenêtre de test** — la sinusoïde entière — et non sur\nl'**erreur de prévision**. Une bande quasi certaine ne contient aucune\ninformation décisionnelle : c'est exactement la différence entre **large** et\n**calibré**."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44e599af",
+   "source": "### Transition — de la mesure au choix d'outil\n\nLes trois parties précédentes ont produit des **mesures** : zéro-shot compétitif\n(Partie 1), limites des covariables (Partie 2), calibration des quantiles\n(Partie 3). La question qui reste ouverte est un choix d'**outil** : quand\nconvient-il de payer le coût d'un modèle entraîné localement, et quand un modèle\nde fondation suffit-il ? La Partie 4 replace PatchTST, iTransformer et TimesFM\ndans le même cadre de décision — en s'appuyant sur les chiffres mesurés ici.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -695,27 +594,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Partie 4 — Comparaison conceptuelle PatchTST / iTransformer / TimesFM\n",
-    "<a id=\"Partie-4\"></a>\n",
-    "\n",
-    "Les trois familles répondent au même problème (prévoir une série temporelle)\n",
-    "mais par des voies très différentes.\n",
-    "\n",
-    "| Aptitude | PatchTST | iTransformer | TimesFM (fondation) |\n",
-    "|---|---|---|---|\n",
-    "| Vue | **par patchs** (morceaux de temps) | **par variables** (attention sur les canaux) | **série entière** (zéro-shot) |\n",
-    "| Entraînement | local, sur TA série | local, sur TA série | **pré-entraîné** sur de très nombreuses séries |\n",
-    "| Prévoir | après entraînement | après entraînement | **immédiatement** (zéro-shot) |\n",
-    "| Probabiliste | à ajouter | à ajouter | **quantiles natifs** |\n",
-    "| Covariables | à bricoler | à bricoler | API covariables dédiée |\n",
-    "| Cas d'usage | beaucoup de données target | beaucoup de **variables** | peu de données, besoin d'un démarrage rapide |\n",
-    "\n",
-    "**En une phrase** : PatchTST et iTransformer sont des **architectures** qu'on\n",
-    "entraîne ; TimesFM est un **produit pré-entraîné** qu'on utilise. Les deux mondes\n",
-    "sont complémentaires — un modèle local reste le bon choix quand on a beaucoup de\n",
-    "données siennes et un régime très spécifique."
-   ]
+   "source": "## Partie 4 — Comparaison conceptuelle PatchTST / iTransformer / TimesFM\n<a id=\"Partie-4\"></a>\n\nLes trois familles répondent au même problème (prévoir une série temporelle)\nmais par des voies très différentes.\n\n| Aptitude | PatchTST | iTransformer | TimesFM (fondation) |\n|---|---|---|---|\n| Vue | **par patchs** (morceaux de temps) | **par variables** (attention sur les canaux) | **série entière** (zéro-shot) |\n| Entraînement | local, sur TA série | local, sur TA série | **pré-entraîné** sur de très nombreuses séries |\n| Prévoir | après entraînement | après entraînement | **immédiatement** (zéro-shot) |\n| Probabiliste | à ajouter | à ajouter | **quantiles natifs** |\n| Covariables | à bricoler | à bricoler | API covariables dédiée |\n| Cas d'usage | beaucoup de données target | beaucoup de **variables** | peu de données, besoin d'un démarrage rapide |\n\n**En une phrase** : PatchTST et iTransformer sont des **architectures** qu'on\nentraîne ; TimesFM est un **produit pré-entraîné** qu'on utilise. Les deux mondes\nsont complémentaires — un modèle local reste le bon choix quand on a beaucoup de\ndonnées siennes et un régime très spécifique.\n\n**Relu à la lumière des mesures de ce notebook**, chaque ligne du tableau a déjà\nété vécue : « Prévoir immédiatement », c'est la Partie 1 — MAE `0.8782` obtenue\nsans une seule passe d'entraînement, là où il fallait le cycle complet\ndonnées / architecture / optimisation dans QC-Py-22 à 23b ; « quantiles\nnatifs », c'est la Partie 3 — couverture `0.792` mesurée sans rien ajouter au\nmodèle ; « API covariables dédiée », c'est la Partie 2 — au prix d'une seconde\ninstance et de contraintes de forme, pour un gain nul (`0.5285` contre\n`0.4480`) quand la covariable redouble le contexte. La dernière ligne (« beaucoup\nde données siennes ») est la contrepartie honnête : un régime très spécifique et\nbeaucoup d'historique restent le terrain des modèles entraînés localement."
   },
   {
    "cell_type": "markdown",
@@ -730,29 +609,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Partie 5 — Licence : code, poids, droit de production\n",
-    "<a id=\"Partie-5\"></a>\n",
-    "\n",
-    "C'est le point que le notebook tient à séparer **explicitement** :\n",
-    "\n",
-    "1. **Licence du code** : `google-research/timesfm` est sous **Apache-2.0**. Le\n",
-    "   code peut être utilisé, modifié et redistribué librement (avec mention de la\n",
-    "   licence).\n",
-    "2. **Licence des poids ≤ 2.5** : `google/timesfm-2.5-200m-pytorch` est **aussi\n",
-    "   Apache-2.0** — c'est pourquoi on l'exécute ici, reproduisible et committable\n",
-    "   avec ses sorties.\n",
-    "3. **Licence des poids 3.0** : `google/timesfm-3.0-pytorch` est sous **TimesFM\n",
-    "   Non-Commercial License v1.0**. On ne distribue **ni** ses poids **ni** des\n",
-    "   sorties produites par ces poids dans un notebook public. TimesFM 3.0 est donc\n",
-    "   abordé **uniquement** aux plans conceptuel et juridique (sources : dépôt\n",
-    "   GitHub, hub HF, billet de recherche).\n",
-    "\n",
-    "Séparer « licence du code » et « licence des poids » n'est pas un détail : un\n",
-    "modèle est un **code** (la recette) plus des **poids** (le savoir-faire appris).\n",
-    "Les deux peuvent vivre sous des licences différentes. Avant d'utiliser un modèle\n",
-    "de fondation en production, relire **les deux** licences."
-   ]
+   "source": "## Partie 5 — Licence : code, poids, droit de production\n<a id=\"Partie-5\"></a>\n\nC'est le point que le notebook tient à séparer **explicitement** :\n\n1. **Licence du code** : `google-research/timesfm` est sous **Apache-2.0**. Le\n   code peut être utilisé, modifié et redistribué librement (avec mention de la\n   licence).\n2. **Licence des poids ≤ 2.5** : `google/timesfm-2.5-200m-pytorch` est **aussi\n   Apache-2.0** — c'est pourquoi on l'exécute ici, reproduisible et committable\n   avec ses sorties.\n3. **Licence des poids 3.0** : `google/timesfm-3.0-pytorch` est sous **TimesFM\n   Non-Commercial License v1.0**. On ne distribue **ni** ses poids **ni** des\n   sorties produites par ces poids dans un notebook public. TimesFM 3.0 est donc\n   abordé **uniquement** aux plans conceptuel et juridique (sources : dépôt\n   GitHub, hub HF, billet de recherche).\n\nSéparer « licence du code » et « licence des poids » n'est pas un détail : un\nmodèle est un **code** (la recette) plus des **poids** (le savoir-faire appris).\nLes deux peuvent vivre sous des licences différentes. Avant d'utiliser un modèle\nde fondation en production, relire **les deux** licences.\n\nLa conséquence pratique pour un projet QuantConnect est directe : une stratégie\ndestinée à tourner en production — a fortiori si elle porte de l'argent réel ou\nun objectif commercial — ne peut s'appuyer que sur des poids dont la licence\nl'autorise. C'est ce qui départage ici 2.5 (exécutable, committable, déployable)\nde 3.0 (comparaison architecturale seulement) : la question « ai-je le droit de\nfaire tourner ces poids en production ? » se pose **avant** d'écrire la première\nligne de la stratégie, pas après."
   },
   {
    "cell_type": "markdown",
@@ -767,14 +624,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Exercices\n",
-    "<a id=\"Exercices\"></a>\n",
-    "\n",
-    "Les exercices sont volontairement **non résolus**. Complétez les `# TODO\n",
-    "etudiant` — les notebooks de la série s'exécutent de bout en bout même non\n",
-    "complétés (aucune exception volontaire)."
-   ]
+   "source": "## Exercices\n<a id=\"Exercices\"></a>\n\nLes exercices sont volontairement **non résolus**. Complétez les `# TODO\netudiant` — les notebooks de la série s'exécutent de bout en bout même non\ncomplétés (aucune exception volontaire).\n\nChaque exercice reprend une partie du notebook et pousse là où elle s'arrête :\nl'exercice 1 attaque la **limite du zéro-shot** (Partie 1), l'exercice 2 la\n**calibration** des quantiles (Partie 3), l'exercice 3 les **covariables**\n(Partie 2). Les cellules stub s'exécutent telles quelles ; c'est en les\ncomplétant que les mesures redeviennent les vôtres."
   },
   {
    "cell_type": "code",
@@ -935,6 +785,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4fe38952",
+   "source": "**Objectif** : départager covariable **passée** et covariable **connue dans le\nfutur** sur un cas où l'information est réellement nouvelle. La Partie 2 a montré\nqu'une covariable qui redouble le contexte ne sert à rien (`0.5285` contre\n`0.4480` sans) ; celle qui aide porte une information absente de l'historique —\nun calendrier, un jour férié, un événement programmé. L'exercice consiste à en\nconstruire une et à mesurer si elle déplace la MAE.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "c4b343a5",
    "metadata": {
     "papermill": {
@@ -946,29 +802,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Bilan\n",
-    "\n",
-    "Ce notebook a fait exactement trois choses de plus qu'un notebook « architecture » :\n",
-    "\n",
-    "1. Il a **exécuté le vrai TimesFM 2.5** (Apache-2.0) en zéro-shot, sans le\n",
-    "   ré-entraîner, et l'a comparé à une base naïve.\n",
-    "2. Il a montré la différence entre **univarié / multivarié** et le rôle des\n",
-    "   **covariables** passées vs connues dans le futur.\n",
-    "3. Il a utilisé la **prévision probabiliste** (quantiles) et mesuré sa\n",
-    "   **calibration** — pas seulement une espérance.\n",
-    "\n",
-    "Et il a séparé **licence du code, licence des poids, droit de production** :\n",
-    "les modèles de fondation se prêtent magnifiquement à la démonstration, mais ils\n",
-    "arrivent avec un **contrat juridique** qu'on lit avant de les utiliser.\n",
-    "\n",
-    "## Pour aller plus loin\n",
-    "\n",
-    "- Dépot : https://github.com/google-research/timesfm\n",
-    "- Hub HF (2.5) : https://huggingface.co/google/timesfm-2.5-200m-pytorch\n",
-    "- Hub HF (3.0) : https://huggingface.co/google/timesfm-3.0-pytorch\n",
-    "- Billet de recherche : https://research.google/blog/timesfm-3-a-zero-shot-foundation-model-for-multivariate-forecasting/"
-   ]
+   "source": "## Bilan\n\nCe notebook a fait exactement trois choses de plus qu'un notebook « architecture » :\n\n1. Il a **exécuté le vrai TimesFM 2.5** (Apache-2.0) en zéro-shot, sans le\n   ré-entraîner, et l'a comparé à une base naïve.\n2. Il a montré la différence entre **univarié / multivarié** et le rôle des\n   **covariables** passées vs connues dans le futur.\n3. Il a utilisé la **prévision probabiliste** (quantiles) et mesuré sa\n   **calibration** — pas seulement une espérance.\n\nEt il a séparé **licence du code, licence des poids, droit de production** :\nles modèles de fondation se prêtent magnifiquement à la démonstration, mais ils\narrivent avec un **contrat juridique** qu'on lit avant de les utiliser.\n\n### Récapitulatif des mesures\n\n| Question posée | Réponse mesurée | Où |\n|---|---|---|\n| Le zéro-shot bat-il la persistance ? | MAE `0.8782` contre `16.0573` (~18×), RMSE `1.1231` contre `17.4018` | Partie 1 |\n| Le transfert tient-il sur d'autres structures ? | Quatre canaux, MAE de `0.4136` à `0.6405` | Partie 2 |\n| Une covariable future aide-t-elle toujours ? | Non : `0.5285` avec contre `0.4480` sans — redondante avec le contexte | Partie 2 |\n| L'intervalle à 80 % couvre-t-il 80 % ? | `0.792` (`19/24`) : quasi calibré ; l'alternative gaussienne naïve couvre `1.000` en étant vide d'information | Partie 3 |\n\n**Les limites de l'expérience, à garder en tête en lisant ces chiffres** : la\nsérie est synthétique et favorable — des périodicités franches sont le terrain\nnaturel d'un modèle pré-entraîné sur des millions de séries réelles, et\nl'exercice 1 montre le contre-exemple du bruit pur ; un seul couple\ncontexte/horizon a été testé (`96/24`) ; et la calibration est mesurée sur 24\npoints, un seul tirage — un indicateur, pas une preuve statistique.\n\n## Pour aller plus loin\n\n- Dépot : https://github.com/google-research/timesfm\n- Hub HF (2.5) : https://huggingface.co/google/timesfm-2.5-200m-pytorch\n- Hub HF (3.0) : https://huggingface.co/google/timesfm-3.0-pytorch\n- Billet de recherche : https://research.google/blog/timesfm-3-a-zero-shot-foundation-model-for-multivariate-forecasting/"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #14984

## Summary

Enrichissement markdown-only de `QC-Py-23c-TimesFM-Foundation-Models.ipynb` — tranche QC-Py-23c du pool densité QC (See #11601). 19 éditions pédagogiques : 6 insertions de cellules (lectures de résultats, transitions P1→P2→P3→P4, objectif exercice 3) et 13 extensions de cellules existantes **par ajout pur** (navigation header, objectifs d'apprentissage, prérequis, lecture chiffrée de la calibration 0.792 vs cible 0.80, tableau récapitulatif + limites au bilan). 26 → 32 cellules (16 → 22 md).

- Densité prose : **1161 → 2475 c/cell** (floor 1200, cible standard 1500-2000)
- **0 cellule code modifiée** : les 10 cellules code (sources, outputs, `execution_count`) sont sémantiquement byte-identiques HEAD vs branche — comparaison mécanique cell-by-cell, ordre du code préservé. C.3 markdown-only : aucune re-exécution requise, outputs réels de #14772 intacts.

## Validation

| Organe | Résultat |
|---|---|
| `pedagogy_density.py` | 0 below floor (2475 mesuré) |
| `scan_enrich_quality.py` | 1 clean, 0 finding |
| `detect_markdown_rendering.py` | 0 violations (critère #11600/#11601) |
| `check_interp_positioning.py` | 0 finding (anchor check strict) |
| Pre-commit H.3 / gitleaks / #13326 | Passed |

**Ancrage des interprétations (audit valeur par valeur)** : 8/8 lectures tombent immédiatement après la cellule de code dont l'output porte chaque valeur citée — vérifié contre les outputs réels : MAE 16.0573/0.8782, RMSE 17.4018/1.1231, canaux 0.4136/0.5352/0.6405, covariable 0.5285 vs 0.4480, calibration 0.792 (19/24), largeur 4.27, gaussien naïf 1.000, identifiant checkpoint HF. Les dérivées arithmétiques (~18×, ~15×, 19.2 cible, demi-largeur ~2.1 ≈ 1.9× RMSE) recalculées exactes. Les valeurs non visibles en output (cellules image) ne sont citées que comme constantes structurelles du code, jamais comme mesures.

See #11601 (contribution partielle à l'umbrella — tranche QC-Py-23c, à ajouter à la liste des tranches livrées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
