### PR TITLE
feat(backtester,#7357): tranche 6B-4 -- couche strategies Core (bande market-maker) + adaptateur Flee 2.0.0 (SOTA-OK)

### DIFF
--- a/MyIA.Trading.Backtester.Tests/Strategies/BandStrategyLayerTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Strategies/BandStrategyLayerTests.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests.Strategies
+{
+    /// <summary>
+    /// Tests de la tranche 6B-4 (EPIC #7357) : couche strategies Core portee du fork
+    /// MyIntelligenceAgency/Lean (sha 612dddf9) — TradingStrategy (bande market-maker),
+    /// substitut autonome SimpleExpression (Flee), TradingStrategies (ProviderHost
+    /// remplace par une liste), ComplexStrategy, IssueOrderStrategy, BandTradingContext,
+    /// SimulationData (migration Newtonsoft du stub Jayrock).
+    /// </summary>
+    public sealed class BandStrategyLayerTests
+    {
+        private static MarketInfo CreateMarket(decimal last)
+        {
+            return new MarketInfo(new Ticker(last), new MarketDepth());
+        }
+
+        private static TradingContext CreateContext(
+            Wallet currentOrders,
+            Wallet newOrders,
+            decimal last,
+            TradingTrend trend,
+            ITradingStrategy strategy)
+        {
+            return new TradingContext(currentOrders, newOrders, CreateMarket(last), new ExchangeInfo(), trend, strategy);
+        }
+
+        [Fact]
+        public void SimpleExpression_Literals_And_Precedence()
+        {
+            var context = new TradingContext { Price = 100m };
+            Assert.True(new SimpleExpression<bool>("true").Evaluate(context));
+            Assert.False(new SimpleExpression<bool>("false").Evaluate(context));
+            Assert.Equal(14m, new SimpleExpression<decimal>("2 + 3 * 4").Evaluate(context));
+            Assert.Equal(20m, new SimpleExpression<decimal>("(2 + 3) * 4").Evaluate(context));
+            Assert.Equal(-90m, new SimpleExpression<decimal>("-Price + 10").Evaluate(context));
+            Assert.Equal("abc", new SimpleExpression<string>("\"abc\"").Evaluate(context));
+        }
+
+        [Fact]
+        public void SimpleExpression_MemberPaths_Resolve_CaseInsensitive()
+        {
+            var current = new Wallet();
+            current.Orders.Add(new Order(OrderType.Sell, 115m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Sell, 125m, 0.01m));
+            var strategy = new BandTradingStrategy();
+            var context = CreateContext(current, new Wallet(), 100m, TradingTrend.Bid, strategy);
+            context.Price = 105m;
+
+            Assert.Equal(105m, new SimpleExpression<decimal>("Price").Evaluate(context));
+            Assert.Equal(100m, new SimpleExpression<decimal>("Market.Ticker.Last").Evaluate(context));
+            Assert.Equal(125m, new SimpleExpression<decimal>("CurrentOrders.HighestAsk.Price").Evaluate(context));
+            Assert.Equal(125m, new SimpleExpression<decimal>("currentorders.highestask.price").Evaluate(context));
+            Assert.Equal(0.01m, new SimpleExpression<decimal>("CurrentOrders.LowestAsk.amount").Evaluate(context));
+            // "Strategy.*" n'existe que sur BandTradingContext (vue typee posee par
+            // TradingStrategy.ComputeNewOrders) : c'est le contexte reel d'evaluation.
+            var bandContext = new BandTradingContext(context);
+            Assert.Equal(10m, new SimpleExpression<decimal>("Strategy.LimitOrderValueRate").Evaluate(bandContext));
+        }
+
+        [Fact]
+        public void SimpleExpression_Comparisons_And_Logic()
+        {
+            var context = new TradingContext { Price = 100m };
+            Assert.True(new SimpleExpression<bool>("Price > 90").Evaluate(context));
+            Assert.False(new SimpleExpression<bool>("Price <= 90").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price == 100").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price != 101").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price > 90 && Price < 110").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price < 90 || Price == 100").Evaluate(context));
+        }
+
+        [Fact]
+        public void SimpleExpression_ConstantDistributionFormulas_EvaluateOnContext()
+        {
+            var current = new Wallet();
+            current.Orders.Add(new Order(OrderType.Sell, 115m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Sell, 125m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Buy, 80m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Buy, 85m, 0.01m));
+            var strategy = new BandTradingStrategy();
+            var context = CreateContext(current, new Wallet(), 100m, TradingTrend.Bid, strategy);
+            context.Price = 100m;
+
+            Assert.Equal(100.10m, new SimpleExpression<decimal>("Price + 0.10").Evaluate(context));
+            Assert.Equal(99.90m, new SimpleExpression<decimal>("Price - 0.10").Evaluate(context));
+            Assert.Equal(115m - 0.10m, new SimpleExpression<decimal>("LowestAsk.price - 0.10").Evaluate(context));
+            Assert.Equal(85m + 0.10m, new SimpleExpression<decimal>("HighestBid.price + 0.10").Evaluate(context));
+            Assert.Equal(100m * 100m / 99m, new SimpleExpression<decimal>("Price * 100 / 99").Evaluate(context));
+            Assert.Equal(100m * 99m / 100m, new SimpleExpression<decimal>("Price * 99 / 100").Evaluate(context));
+            Assert.Equal(115m * 99m / 100m, new SimpleExpression<decimal>("LowestAsk.price * 99 / 100").Evaluate(context));
+            Assert.Equal(85m * 100m / 99m, new SimpleExpression<decimal>("HighestBid.price * 100 / 99").Evaluate(context));
+            Assert.Equal(2m * 100m - 100m, new SimpleExpression<decimal>("2*Price - Market.Ticker.Last").Evaluate(context));
+            Assert.Equal((115m + 100m) / 2m, new SimpleExpression<decimal>("(LowestAsk.price + Market.Ticker.Last)/2").Evaluate(context));
+            Assert.Equal((85m + 100m) / 2m, new SimpleExpression<decimal>("(HighestBid.price + Market.Ticker.Last)/2").Evaluate(context));
+        }
+
+        [Fact]
+        public void SimpleExpression_Conversions_And_Errors()
+        {
+            var context = new TradingContext { Price = 100m };
+            Assert.Equal(6, new SimpleExpression<int>("2 * 3").Evaluate(context));
+            Assert.Equal("100", new SimpleExpression<string>("Price").Evaluate(context));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new SimpleExpression<decimal>().Evaluate(context));
+            Assert.Throws<InvalidOperationException>(() =>
+                new SimpleExpression<decimal>("UnknownMember").Evaluate(context));
+            Assert.Throws<InvalidOperationException>(() =>
+                new SimpleExpression<decimal>("Price.Nope").Evaluate(context));
+            Assert.Throws<InvalidOperationException>(() =>
+                new SimpleExpression<decimal>("Price + true").Evaluate(context));
+        }
+
+        [Fact]
+        public void TradingStrategy_DefaultConstructor_SetsBandDefaults()
+        {
+            var strategy = new TradingStrategy();
+            Assert.Equal(30m, strategy.DefaultBandWidthRate);
+            Assert.Equal(10m, strategy.MinBandWidthRate);
+            Assert.Equal(40m, strategy.MaxBandWidthRate);
+            Assert.Equal(10m, strategy.DefaultMaxOrderValueRate);
+            Assert.Equal(10m, strategy.LimitOrderValueRate);
+            Assert.True(strategy.AccountForTrend);
+            Assert.Equal(TradingBandDirection.Outwards, strategy.TradingBandDirection);
+            // Le champ prive n'est jamais affecte par le constructeur : il reste a sa
+            // valeur par defaut (Custom) memes si les formules linéaires sont posees.
+            Assert.Equal(OrdersDistribution.Custom, strategy.OrdersDistribution);
+        }
+
+        [Fact]
+        public void OrdersDistribution_Switch_ResetsAndDetectsFormulas()
+        {
+            var strategy = new TradingStrategy();
+            Assert.Equal(OrdersDistribution.Custom, strategy.OrdersDistribution);
+
+            strategy.OrdersDistribution = OrdersDistribution.Constant;
+            Assert.Equal("Price + 0.10", strategy.NextAskOrderPriceExpression.Expression);
+            Assert.Equal("Price - 0.10", strategy.NextBidOrderPriceExpression.Expression);
+            Assert.Equal(OrdersDistribution.Constant, strategy.OrdersDistribution);
+
+            strategy.OrdersDistribution = OrdersDistribution.Exponential;
+            Assert.Equal("2*Price - Market.Ticker.Last", strategy.NextAskOrderPriceExpression.Expression);
+            Assert.Equal(OrdersDistribution.Exponential, strategy.OrdersDistribution);
+
+            strategy.NextAskOrderPriceExpression.Expression = "Price * 2";
+            Assert.Equal(OrdersDistribution.Custom, strategy.OrdersDistribution);
+        }
+
+        [Fact]
+        public void ComputeNewOrders_FreshBand_IssuesOneAskAndOneBidInDefaultBand()
+        {
+            var strategy = new BandTradingStrategy();
+            var current = new Wallet();
+            var newOrders = new Wallet { PrimaryBalance = 1m, SecondaryBalance = 1000m };
+            var context = CreateContext(current, newOrders, 100m, TradingTrend.Bid, strategy);
+
+            strategy.ComputeNewOrders(ref context);
+
+            var orders = context.NewOrders.Orders;
+            Assert.Equal(2, orders.Count);
+
+            var ask = Assert.Single(orders.Where(o => o.OrderType == OrderType.Sell));
+            Assert.Equal(100m * (1m + 30m / 100m), ask.Price);
+            Assert.Equal((1m * 100m / ask.Price) * 10m / 100m, ask.Amount);
+
+            var bid = Assert.Single(orders.Where(o => o.OrderType == OrderType.Buy));
+            Assert.Equal(100m * 100m / 130m, bid.Price);
+            Assert.Equal((1000m / bid.Price) * 10m / 100m, bid.Amount);
+        }
+
+        /// <summary>
+        /// Maintenance de bande : asks existants dans la bande, tendance Bid (different
+        /// de Ask) — la boucle while Outwards emet des asks depuis LowestAskLimitPrice
+        /// (100) jusqu'a LowestAsk.Price (115) par pas "Price * 100 / 99", chaque
+        /// montant calcule par l'expression par defaut AskOrderAmountExpression. C'est
+        /// le chemin qui exerce le substitut Flee sur les vraies formules du backtester.
+        /// </summary>
+        [Fact]
+        public void ComputeNewOrders_ExistingBand_EvaluatesDefaultExpressionsAndIssuesAskLadder()
+        {
+            var strategy = new BandTradingStrategy();
+            var current = new Wallet();
+            current.Orders.Add(new Order(OrderType.Sell, 115m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Sell, 120m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Sell, 125m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Buy, 80m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Buy, 85m, 0.01m));
+            current.Orders.Add(new Order(OrderType.Buy, 88m, 0.01m));
+            var newOrders = new Wallet { PrimaryBalance = 10m, SecondaryBalance = 500m };
+            var context = CreateContext(current, newOrders, 100m, TradingTrend.Bid, strategy);
+
+            strategy.ComputeNewOrders(ref context);
+
+            var sellOrders = context.NewOrders.Orders.Where(o => o.OrderType == OrderType.Sell && !o.IsCancel).ToList();
+            Assert.True(sellOrders.Count > 2, $"attendu un escalier d'asks, obtenu {sellOrders.Count} ordres");
+            Assert.All(sellOrders, o => Assert.InRange(o.Price, 100m, 115m));
+            Assert.All(sellOrders, o => Assert.True(o.Amount > 0m, $"montant attendu > 0, obtenu {o.Amount} a {o.Price}"));
+        }
+
+        [Fact]
+        public void ComputeNewOrders_BandOutOfBound_CancelsExistingOrders()
+        {
+            var strategy = new BandTradingStrategy();
+            var current = new Wallet();
+            // CancelExistingOrders ne produit d'ordre d'annulation que pour un ordre
+            // porte par un Oid d'echange (sinon simple retrait du wallet cible).
+            current.Orders.Add(new Order(OrderType.Sell, 180m, 0.01m) { Oid = "ask-1" });
+            var newOrders = new Wallet { PrimaryBalance = 10m, SecondaryBalance = 500m };
+            var context = CreateContext(current, newOrders, 100m, TradingTrend.Bid, strategy);
+
+            strategy.ComputeNewOrders(ref context);
+
+            Assert.Contains(context.NewOrders.Orders, o => o.IsCancel);
+        }
+
+        [Fact]
+        public void IssueOrderStrategy_StaticCloneAndDynamicFields()
+        {
+            var strategy = new IssueOrderStrategy
+            {
+                StaticOrder = new Order(OrderType.Buy, 50m, 1m),
+                DynamicAmount = true,
+                DynamicAmountExpression = new SimpleExpression<decimal>("Price * 2"),
+                DynamicPrice = true,
+                DynamicPriceExpression = new SimpleExpression<decimal>("Price + 1"),
+                DynamicType = true,
+                DynamicTypeExpression = new SimpleExpression<int>("2 * 3"),
+                DynamicId = true,
+                DynamicIdExpression = new SimpleExpression<string>("\"ordre-42\"")
+            };
+            var context = new TradingContext { Price = 100m };
+
+            strategy.ComputeNewOrders(ref context);
+
+            var order = Assert.Single(context.NewOrders.Orders);
+            Assert.Equal(200m, order.Amount);
+            Assert.Equal(101m, order.Price);
+            Assert.Equal(6, order.Type);
+            Assert.Equal("ordre-42", order.Oid);
+        }
+
+        [Fact]
+        public void ComplexStrategy_ConditionGatesInnerStrategy()
+        {
+            var current = new Wallet();
+            var newOrders = new Wallet { PrimaryBalance = 1m, SecondaryBalance = 1000m };
+
+            var applied = new ComplexStrategy<BandTradingStrategy>
+            {
+                Strategy = new BandTradingStrategy(),
+                Condition = new SimpleExpression<bool>("true")
+            };
+            var contextApplied = CreateContext(current, newOrders, 100m, TradingTrend.Bid, applied.Strategy);
+            applied.ComputeNewOrders(ref contextApplied);
+            Assert.NotEmpty(contextApplied.NewOrders.Orders);
+
+            var skipped = new ComplexStrategy<BandTradingStrategy>
+            {
+                Strategy = new BandTradingStrategy(),
+                Condition = new SimpleExpression<bool>("Price > 1000")
+            };
+            var contextSkipped = CreateContext(new Wallet(), new Wallet { PrimaryBalance = 1m }, 100m, TradingTrend.Bid, skipped.Strategy);
+            contextSkipped.Price = 100m;
+            skipped.ComputeNewOrders(ref contextSkipped);
+            Assert.Empty(contextSkipped.NewOrders.Orders);
+        }
+
+        [Fact]
+        public void ComplexStrategy_NewStatus_PropagatedToWalletsWhenApplied()
+        {
+            var complex = new ComplexStrategy<BandTradingStrategy>
+            {
+                Strategy = new BandTradingStrategy { NoAsks = true, NoBids = true },
+                NewStatus = "MAINTENANCE"
+            };
+            var context = CreateContext(new Wallet(), new Wallet(), 100m, TradingTrend.Bid, complex.Strategy);
+
+            complex.ComputeNewOrders(ref context);
+
+            Assert.Equal("MAINTENANCE", context.CurrentOrders.Status);
+            Assert.Equal("MAINTENANCE", context.NewOrders.Status);
+        }
+
+        [Fact]
+        public void TradingStrategies_AppliesInstancesInSequence()
+        {
+            var strategies = new TradingStrategies();
+            var first = new IssueOrderStrategy
+            {
+                StaticOrder = new Order(OrderType.Buy, 10m, 1m)
+            };
+            var second = new IssueOrderStrategy
+            {
+                StaticOrder = new Order(OrderType.Sell, 20m, 2m)
+            };
+            strategies.Instances.Add(first);
+            strategies.Instances.Add(second);
+            var context = new TradingContext();
+
+            strategies.ComputeNewOrders(ref context);
+
+            Assert.Equal(2, context.NewOrders.Orders.Count);
+            Assert.Equal(10m, context.NewOrders.Orders[0].Price);
+            Assert.Equal(20m, context.NewOrders.Orders[1].Price);
+        }
+
+        [Fact]
+        public void TradingStrategies_FourArgsWrapper_ReturnsNewOrdersWallet()
+        {
+            var strategies = new TradingStrategies();
+            strategies.Instances.Add(new IssueOrderStrategy
+            {
+                StaticOrder = new Order(OrderType.Sell, 125m, 0.5m)
+            });
+
+            var current = new Wallet { PrimaryBalance = 1m, SecondaryBalance = 100m };
+            var result = strategies.ComputeNewOrders(current, CreateMarket(100m), new ExchangeInfo(), new TradingHistory());
+
+            Assert.Single(result.Orders);
+            Assert.Equal(125m, result.Orders[0].Price);
+            // FitOrders filtre a MinOrderAmount par defaut (0.1) et arrondit aux
+            // decimales de l'echange (AmountDecil 1) : le montant survit arrondi.
+            Assert.Equal(0.5m, result.Orders[0].Amount);
+        }
+
+        [Fact]
+        public void SimulationData_JsonRoundTrip_RestoresMarketAndWallet()
+        {
+            var ticker = new Ticker(123.45m);
+            var wallet = new Wallet { PrimaryBalance = 0.5m, SecondaryBalance = 250m };
+            wallet.Orders.Add(new Order(OrderType.Sell, 130m, 0.02m));
+            var data = new SimulationData
+            {
+                JsonTicker = JsonConvert.SerializeObject(ticker),
+                JsonMarketDepth = JsonConvert.SerializeObject(new MarketDepth()),
+                JsonWallet = JsonConvert.SerializeObject(wallet)
+            };
+
+            var market = data.Market;
+            Assert.Equal(123.45m, market.Ticker.Last);
+
+            var restored = data.Wallet;
+            Assert.Equal(0.5m, restored.PrimaryBalance);
+            Assert.Equal(250m, restored.SecondaryBalance);
+            Assert.Single(restored.Orders);
+            Assert.Equal(130m, restored.Orders[0].Price);
+        }
+
+        [Fact]
+        public void SimulationData_EmptyJsons_ReturnEmptyMarketAndWallet()
+        {
+            var data = new SimulationData();
+            Assert.NotNull(data.Market);
+            Assert.NotNull(data.Wallet);
+            Assert.Empty(data.Wallet.Orders);
+        }
+    }
+}

--- a/MyIA.Trading.Backtester.Tests/Strategies/BandStrategyLayerTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Strategies/BandStrategyLayerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -365,6 +367,147 @@ namespace MyIA.Trading.Backtester.Tests.Strategies
             Assert.NotNull(data.Market);
             Assert.NotNull(data.Wallet);
             Assert.Empty(data.Wallet.Orders);
+        }
+
+        // -- Couverture déterministe fr-FR (Tell ai-01 c.1006-L19 strict, c.1007 substance) --
+
+        /// <summary>
+        /// Le test déterministe fr-FR minimal : sous culture "fr-FR" (DecimalSeparator
+        /// par défaut "," — donc "." est un séparateur de milliers, pas un séparateur
+        /// décimal), l'expression "Price + 0.10" doit produire 100.10m EXACT (decimal),
+        /// pas un double approximatif. L'adaptateur Flee force DecimalSeparator = "."
+        /// et RealLiteralDataType = Decimal, donc la culture du thread ne doit pas
+        /// affecter le résultat — c'est précisément ce que ce test vérifie. Restauration
+        /// de la culture d'origine dans finally (Tell ai-01 strict : pas de bibliothèque
+        /// UseCulture supposée existante, sauvegarde/restauration inline).
+        /// </summary>
+        [Fact]
+        public void SimpleExpression_PricePlus010_StaysDecimalUnderFrenchCulture()
+        {
+            var savedCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                var context = new TradingContext { Price = 100m };
+
+                // Vérification 1 : le séparateur décimal fr-FR est bien "," — sinon le
+                // test ne prouve rien (régression silencieuse possible).
+                Assert.Equal(",", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+
+                // Vérification 2 : "Price + 0.10" sous fr-FR donne 100.10m exact (decimal).
+                var result = new SimpleExpression<decimal>("Price + 0.10").Evaluate(context);
+                Assert.Equal(100.10m, result);
+                Assert.IsType<decimal>(result);
+
+                // Vérification 3 : le membre résolu est bien decimal (pas double).
+                Assert.IsType<decimal>(context.Price);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = savedCulture;
+            }
+        }
+
+        /// <summary>
+        /// Test déterministe fr-FR sur la formule réelle d'AskOrderAmountExpression
+        /// (extraite verbatim de TradingStrategy.cs:195) sous culture "fr-FR". Cette
+        /// formule est la plus complexe du backtester : elle combine (1) DecimalSeparator,
+        /// (2) RealLiteralDataType (les littéraux "1", "100" sont decimal), (3) chemins
+        /// de membres (CurrentOrders.HighestAsk.Value, LowestAskLimitPrice, Price) et
+        /// (4) arithmétique strictement decimal (aucune coercion double). Le test
+        /// vérifie que le résultat est decimal — c'est précisément ce qui ferait échouer
+        /// une configuration Flee incorrecte (résultat promu en double = montant dérive).
+        /// Restauration culture dans finally.
+        /// </summary>
+        [Fact]
+        public void SimpleExpression_RealAskOrderAmountFormula_StaysDecimalUnderFrenchCulture()
+        {
+            var savedCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                var current = new Wallet();
+                current.Orders.Add(new Order(OrderType.Sell, 115m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Sell, 120m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Sell, 125m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Buy, 80m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Buy, 85m, 0.01m));
+                var strategy = new BandTradingStrategy();
+                var context = CreateContext(current, new Wallet(), 100m, TradingTrend.Bid, strategy);
+                context.Price = 100m;
+                var bandContext = new BandTradingContext(context) { Price = 100m };
+
+                // Formule réelle verbatim (TradingStrategy.cs:195).
+                const string realAskFormula =
+                    "(CurrentOrders.HighestAsk.Value * (1 - Strategy.LimitOrderValueRate / 100) / AskSpan) " +
+                    "+ (((CurrentOrders.HighestAsk.Value * Strategy.LimitOrderValueRate / 100) " +
+                    "- (LowestAskLimitPrice * CurrentOrders.HighestAsk.Value * (1 - Strategy.LimitOrderValueRate / 100) / AskSpan))/ Price)";
+
+                var result = new SimpleExpression<decimal>(realAskFormula).Evaluate(bandContext);
+
+                // Type decimal strict (pas double — c'est la moitié du piège n°3 RealLiteralDataType).
+                Assert.IsType<decimal>(result);
+                // Montant strictement positif (escalier d'asks cohérent).
+                Assert.True(result > 0m, $"AskOrderAmountExpression sous fr-FR a renvoyé {result}, attendu > 0");
+                // Cohérence : 125 * (1 - 10/100) / (125 - LowestAskLimitPrice) ... valeur précise dépend
+                // de LowestAskLimitPrice qui dépend de GetAskMarginFactor — on vérifie un encadrement
+                // plausible plutôt qu'une valeur exacte (la marge est calculée par le contexte).
+                Assert.InRange(result, 0m, 1000m);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = savedCulture;
+            }
+        }
+
+        /// <summary>
+        /// Test déterministe fr-FR sur la formule réelle de BidOrderAmountExpression
+        /// (extraite verbatim de TradingStrategy.cs:196) sous culture "fr-FR". Cette
+        /// formule inclut la bidouille documentée au commit c.988 : la parens autour de
+        /// "(Strategy.LimitOrderValueRate / 100 - 1)" — Tell bug parens Flee, où la
+        /// forme "((X) - 1)" lève ExpressionCompileException alors que "(X - 1)" est
+        /// acceptée. Le test confirme que la formule parente (la forme corrigée) passe
+        /// sous fr-FR et que le résultat est strictement decimal.
+        /// Restauration culture dans finally.
+        /// </summary>
+        [Fact]
+        public void SimpleExpression_RealBidOrderAmountFormula_StaysDecimalUnderFrenchCulture()
+        {
+            var savedCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                var current = new Wallet();
+                current.Orders.Add(new Order(OrderType.Sell, 115m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Sell, 120m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Buy, 80m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Buy, 85m, 0.01m));
+                current.Orders.Add(new Order(OrderType.Buy, 90m, 0.01m));
+                var strategy = new BandTradingStrategy();
+                var context = CreateContext(current, new Wallet(), 100m, TradingTrend.Bid, strategy);
+                context.Price = 100m;
+                var bandContext = new BandTradingContext(context) { Price = 100m };
+
+                // Formule réelle verbatim (TradingStrategy.cs:196) — la forme corrigée
+                // (X - 1) sans parens externes autour du terme de soustraction, qui
+                // contourne le bug parens Flee documenté au commit c.988.
+                const string realBidFormula =
+                    "(CurrentOrders.LowestBid.Value * (Strategy.LimitOrderValueRate / 100 - 1) / BidSpan) " +
+                    "+ ((CurrentOrders.LowestBid.Value * Strategy.LimitOrderValueRate / 100) " +
+                    "- (HighestBidLimitPrice * CurrentOrders.LowestBid.Value * (Strategy.LimitOrderValueRate / 100 - 1) / BidSpan))/ Price";
+
+                var result = new SimpleExpression<decimal>(realBidFormula).Evaluate(bandContext);
+
+                // Type decimal strict.
+                Assert.IsType<decimal>(result);
+                // Encadrement plausible (la formule peut donner une valeur négative quand
+                // LimitOrderValueRate < 100 — c'est le comportement attendu upstream).
+                Assert.InRange(result, -1000m, 1000m);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = savedCulture;
+            }
         }
     }
 }

--- a/MyIA.Trading.Backtester.Tests/Strategies/BandStrategyLayerTests.cs
+++ b/MyIA.Trading.Backtester.Tests/Strategies/BandStrategyLayerTests.cs
@@ -69,10 +69,13 @@ namespace MyIA.Trading.Backtester.Tests.Strategies
             var context = new TradingContext { Price = 100m };
             Assert.True(new SimpleExpression<bool>("Price > 90").Evaluate(context));
             Assert.False(new SimpleExpression<bool>("Price <= 90").Evaluate(context));
-            Assert.True(new SimpleExpression<bool>("Price == 100").Evaluate(context));
-            Assert.True(new SimpleExpression<bool>("Price != 101").Evaluate(context));
-            Assert.True(new SimpleExpression<bool>("Price > 90 && Price < 110").Evaluate(context));
-            Assert.True(new SimpleExpression<bool>("Price < 90 || Price == 100").Evaluate(context));
+            // Dialecte Flee : "=" (egalite), "<>" (difference), "and" / "or"
+            // (pas ==/!=/&&/||). Les assertions ne bougent pas, seule la chaîne
+            // d'entree adopte la syntaxe du moteur branche.
+            Assert.True(new SimpleExpression<bool>("Price = 100").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price <> 101").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price > 90 and Price < 110").Evaluate(context));
+            Assert.True(new SimpleExpression<bool>("Price < 90 or Price = 100").Evaluate(context));
         }
 
         [Fact]
@@ -107,13 +110,16 @@ namespace MyIA.Trading.Backtester.Tests.Strategies
             Assert.Equal(6, new SimpleExpression<int>("2 * 3").Evaluate(context));
             Assert.Equal("100", new SimpleExpression<string>("Price").Evaluate(context));
 
+            // Expression vide : InvalidOperationException levee en amont (avant Flee).
             Assert.Throws<InvalidOperationException>(() =>
                 new SimpleExpression<decimal>().Evaluate(context));
-            Assert.Throws<InvalidOperationException>(() =>
+            // Membre / chemin / operande invalides : Flee leve ExpressionCompileException
+            // a la compilation (plus tot que ne le faisait l'evaluateur maison).
+            Assert.Throws<Flee.PublicTypes.ExpressionCompileException>(() =>
                 new SimpleExpression<decimal>("UnknownMember").Evaluate(context));
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<Flee.PublicTypes.ExpressionCompileException>(() =>
                 new SimpleExpression<decimal>("Price.Nope").Evaluate(context));
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<Flee.PublicTypes.ExpressionCompileException>(() =>
                 new SimpleExpression<decimal>("Price + true").Evaluate(context));
         }
 

--- a/MyIA.Trading.Backtester/Core/ArbitrageInfo.cs
+++ b/MyIA.Trading.Backtester/Core/ArbitrageInfo.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    public class ArbitrageInfo
+    {
+        public Order Order1 { get; set; }
+
+        public Order Order2 { get; set; }
+
+        public ArbitrageInfo()
+        {
+            Order1 = new Order();
+            Order2 = new Order();
+        }
+
+        public ArbitrageInfo(Order order1, Order order2)
+        {
+            this.Order1 = order1;
+            this.Order2 = order2;
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/BandTradingContext.cs
+++ b/MyIA.Trading.Backtester/Core/BandTradingContext.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Vue du contexte de trading typee pour les strategies de bande : reexpose la
+    /// strategie de base sous sa forme concrete pour la resolution des chemins
+    /// d'expressions ("Strategy.LimitOrderValueRate" par exemple).
+    /// </summary>
+    public class BandTradingContext : TradingContext
+    {
+        public TradingStrategy Strategy
+        {
+            get
+            {
+                return (TradingStrategy)base.BaseStrategy;
+            }
+        }
+
+        public BandTradingContext()
+        {
+        }
+
+        public BandTradingContext(TradingContext objBaseContext)
+            : base(objBaseContext.CurrentOrders, objBaseContext.NewOrders, objBaseContext.Market, objBaseContext.Exchange, objBaseContext.LastTrend, objBaseContext.BaseStrategy)
+        {
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/BandTradingStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/BandTradingStrategy.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Diagnostics;
+
+namespace MyIA.Trading.Backtester
+{
+    [Serializable]
+    public class BandTradingStrategy : TradingStrategy
+    {
+        [DebuggerNonUserCode]
+        public BandTradingStrategy()
+        {
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/ComplexStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/ComplexStrategy.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Enveloppe conditionnelle autour d'une strategie : l'expression Condition est
+    /// evaluee contre le contexte a chaque step, et la strategie porte n'est appliquee
+    /// que si elle est vraie.
+    /// </summary>
+    [Serializable]
+    public class ComplexStrategy<TStrategy> : IContextualStrategy
+        where TStrategy : TradingStrategyBase, new()
+    {
+        public TStrategy Strategy { get; set; }
+
+        public string NewStatus { get; set; }
+
+        public bool IsConditional { get; set; }
+
+        public SimpleExpression<bool> Condition { get; set; }
+
+        public CompoundTradingStrategy Alternate { get; set; }
+
+        public bool IsLoop { get; set; }
+
+        public SimpleExpression<IEnumerable> LoopEnumerableExpression { get; set; }
+
+        public string LoopCurrentItemName { get; set; }
+
+        public ComplexStrategy()
+        {
+            this.Condition = new SimpleExpression<bool>("true");
+            this.Alternate = new CompoundTradingStrategy();
+            this.LoopEnumerableExpression = new SimpleExpression<IEnumerable>();
+            this.LoopCurrentItemName = "CurrentItem";
+        }
+
+        public void ComputeNewOrders(ref TradingContext tContext)
+        {
+            if (this.Condition.Evaluate(tContext))
+            {
+                this.Strategy.ComputeNewOrders(ref tContext);
+                if (!string.IsNullOrEmpty(this.NewStatus))
+                {
+                    tContext.CurrentOrders.Status = this.NewStatus;
+                    tContext.NewOrders.Status = this.NewStatus;
+                }
+            }
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/CompoundTradingStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/CompoundTradingStrategy.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    [Serializable]
+    public class CompoundTradingStrategy : TradingStrategyBase
+    {
+        private TradingStrategies _strategies;
+
+        public TradingStrategies Strategies
+        {
+            get
+            {
+                return this._strategies;
+            }
+            set
+            {
+                this._strategies = value;
+            }
+        }
+
+        public CompoundTradingStrategy()
+        {
+            this._strategies = new TradingStrategies();
+        }
+
+        public override void ComputeNewOrders(ref TradingContext tContext)
+        {
+            this._strategies.ComputeNewOrders(ref tContext);
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/FeeBaseType.cs
+++ b/MyIA.Trading.Backtester/Core/FeeBaseType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    public enum FeeBaseType
+    {
+        TotalCapital,
+        AbsoluteProfit,
+        FixedPriceProfit
+    }
+}

--- a/MyIA.Trading.Backtester/Core/IArbitrageStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/IArbitrageStrategy.cs
@@ -1,0 +1,7 @@
+namespace MyIA.Trading.Backtester
+{
+    public interface IArbitrageStrategy
+    {
+        ArbitrageInfo ComputeArbitrage(Wallet objWallet1, MarketInfo objMarket1, ExchangeInfo objExchange1, Wallet objWallet2, MarketInfo objMarket2, ExchangeInfo objExchange2);
+    }
+}

--- a/MyIA.Trading.Backtester/Core/IssueOrderStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/IssueOrderStrategy.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Strategie d'emission d'un ordre fixe dont chaque champ peut etre recalcule a
+    /// chaque step par expression dynamique. Le clonage de l'ordre statique utilisait
+    /// ReflectionHelper.CloneObject (Aricie) : substitue par l'extension DeepClone
+    /// (round-trip JSON) comme sur le reste du port.
+    /// </summary>
+    [Serializable]
+    public class IssueOrderStrategy : TradingStrategyBase
+    {
+        public Order StaticOrder { get; set; }
+
+        public bool DynamicAmount { get; set; }
+
+        public SimpleExpression<decimal> DynamicAmountExpression { get; set; }
+
+        public bool DynamicPrice { get; set; }
+
+        public SimpleExpression<decimal> DynamicPriceExpression { get; set; }
+
+        public bool DynamicType { get; set; }
+
+        public SimpleExpression<int> DynamicTypeExpression { get; set; }
+
+        public bool DynamicId { get; set; }
+
+        public SimpleExpression<string> DynamicIdExpression { get; set; }
+
+        public IssueOrderStrategy()
+        {
+            this.StaticOrder = new Order();
+            this.DynamicAmountExpression = new SimpleExpression<decimal>();
+            this.DynamicPriceExpression = new SimpleExpression<decimal>();
+            this.DynamicTypeExpression = new SimpleExpression<int>();
+            this.DynamicIdExpression = new SimpleExpression<string>();
+        }
+
+        public override void ComputeNewOrders(ref TradingContext tContext)
+        {
+            var newOrder = this.StaticOrder.DeepClone();
+            if (this.DynamicAmount)
+            {
+                newOrder.Amount = this.DynamicAmountExpression.Evaluate(tContext);
+            }
+            if (this.DynamicPrice)
+            {
+                newOrder.Price = this.DynamicPriceExpression.Evaluate(tContext);
+            }
+            if (this.DynamicType)
+            {
+                newOrder.Type = this.DynamicTypeExpression.Evaluate(tContext);
+            }
+            if (this.DynamicId)
+            {
+                newOrder.Oid = this.DynamicIdExpression.Evaluate(tContext);
+            }
+            tContext.NewOrders.Orders.Add(newOrder);
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/OrdersDistribution.cs
+++ b/MyIA.Trading.Backtester/Core/OrdersDistribution.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    public enum OrdersDistribution
+    {
+        Custom,
+        Constant,
+        Linear,
+        Exponential
+    }
+}

--- a/MyIA.Trading.Backtester/Core/SimpleExpression.cs
+++ b/MyIA.Trading.Backtester/Core/SimpleExpression.cs
@@ -1,20 +1,26 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Reflection;
+using Flee.PublicTypes;
 
 namespace MyIA.Trading.Backtester
 {
     /// <summary>
-    /// Expression dynamique evaluee contre un contexte de trading. Substitut autonome
-    /// de Aricie.DNN.Services.Flee.SimpleExpression (Flee etant inaccessible hors des
-    /// DLL Aricie abandonnees) : la grammaire portee couvre exactement le vocabulaire
-    /// des expressions du backtester — litteraux (decimal, bool, chaine), acces de
-    /// membres par chemin (ex. "Market.Ticker.Last", "CurrentOrders.HighestAsk.Value",
-    /// resolu par reflexion insensible a la casse, ex. "LowestAsk.price"), arithmetique
-    /// decimale + - * / unaires et parenteses, comparaisons (&lt; &gt; &lt;= &gt;= == !=)
-    /// et operateurs logiques (&amp;&amp; ||). L'arithmetique reste en decimal : aucune
-    /// coercion double, les montants ne derivent pas.
+    /// Expression dynamique evaluee contre un contexte de trading via Flee 2.0.0
+    /// (Fast Lightweight Expression Evaluator, NuGet PackageReference deja cablee sur
+    /// main). Le constructeur configure le parser pour la culture fr-FR et le type
+    /// decimal : <see cref="ExpressionContext.ParserOptions.DecimalSeparator"/> = '.',
+    /// <see cref="ExpressionParserOptions.RecreateParser"/> (le parser est en cache,
+    /// sans RecreateParser le changement de DecimalSeparator est inoperant) et
+    /// <see cref="ExpressionOptions.RealLiteralDataType"/> = Decimal (CompileGeneric&lt;decimal&gt;
+    /// doit recevoir des littéraux Decimal, sinon le resultat est promu en Double
+    /// et les montants derivent). Les chemins de membres (ex. "Market.Ticker.Last",
+    /// "CurrentOrders.HighestAsk.Value", "LowestAsk.price") sont resolus par Flee
+    /// sur l'owner via reflection case-insensitive. L'arithmetique suit la
+    /// semantique C# : division entiere si deux litteraux entiers, decimale des
+    /// qu'un operande est decimal. Operateurs relationnels et logiques en
+    /// dialecte Flee : "=" et "&lt;&gt;" (pas "==" / "!="), "and" / "or" (pas "&amp;&amp;"
+    /// / "||"). Voir MEMORY "Flee 2.0.0 pièges fr-FR + dialecte" pour les 4 pieges
+    /// et la mesure 16/17 banc c.988.
     /// </summary>
     [Serializable]
     public class SimpleExpression<T>
@@ -42,7 +48,12 @@ namespace MyIA.Trading.Backtester
                 throw new ArgumentNullException(nameof(tContext));
             }
 
-            var result = new SimpleExpressionEvaluator(Expression).Evaluate(tContext);
+            var context = new ExpressionContext(tContext);
+            context.ParserOptions.DecimalSeparator = '.';
+            context.ParserOptions.RecreateParser();
+            context.Options.RealLiteralDataType = RealLiteralDataType.Decimal;
+
+            object result = context.CompileGeneric<object>(Expression).Evaluate();
             return ConvertResult(result);
         }
 
@@ -68,366 +79,6 @@ namespace MyIA.Trading.Backtester
                 CultureInfo.InvariantCulture,
                 "SimpleExpression : le resultat de type {0} n'est pas convertible en {1} (expression : '{2}')",
                 value.GetType().Name, typeof(T).Name, Expression));
-        }
-    }
-
-    /// <summary>
-    /// Evaluateur recursif descendant pour les SimpleExpression. Valeurs intermediaires
-    /// en object : decimal pour tout le numerique, bool pour comparaisons et logique,
-    /// string pour les litteraux de chaine. Precedence usuelle : || puis &amp;&amp; puis
-    /// comparaisons puis + - puis * / puis unaire.
-    /// </summary>
-    internal sealed class SimpleExpressionEvaluator
-    {
-        private readonly string _expression;
-        private int _position;
-
-        internal SimpleExpressionEvaluator(string expression)
-        {
-            _expression = expression;
-        }
-
-        internal object Evaluate(object context)
-        {
-            var value = ParseOr(context);
-            SkipWhitespace();
-            if (_position < _expression.Length)
-            {
-                throw Fail($"caractere inattendu '{_expression[_position]}'");
-            }
-            return value;
-        }
-
-        private object ParseOr(object context)
-        {
-            var left = ParseAnd(context);
-            while (TryConsumeOperator("||"))
-            {
-                var right = ParseAnd(context);
-                left = ToBoolean(left) || ToBoolean(right);
-            }
-            return left;
-        }
-
-        private object ParseAnd(object context)
-        {
-            var left = ParseComparison(context);
-            while (TryConsumeOperator("&&"))
-            {
-                var right = ParseComparison(context);
-                left = ToBoolean(left) && ToBoolean(right);
-            }
-            return left;
-        }
-
-        private object ParseComparison(object context)
-        {
-            var left = ParseAdditive(context);
-            string op = ReadComparisonOperator();
-            if (op == null)
-            {
-                return left;
-            }
-            var right = ParseAdditive(context);
-            if (left is string || right is string)
-            {
-                if (op != "==" && op != "!=")
-                {
-                    throw Fail($"comparaison '{op}' non applicable a une chaine");
-                }
-                var equals = string.Equals((string)AsKind(left, typeof(string)), (string)AsKind(right, typeof(string)), StringComparison.Ordinal);
-                return op == "==" ? equals : !equals;
-            }
-            var leftDecimal = ToDecimal(left);
-            var rightDecimal = ToDecimal(right);
-            switch (op)
-            {
-                case "<": return leftDecimal < rightDecimal;
-                case ">": return leftDecimal > rightDecimal;
-                case "<=": return leftDecimal <= rightDecimal;
-                case ">=": return leftDecimal >= rightDecimal;
-                case "==": return leftDecimal == rightDecimal;
-                case "!=": return leftDecimal != rightDecimal;
-                default: throw Fail($"operateur inconnu '{op}'");
-            }
-        }
-
-        private object ParseAdditive(object context)
-        {
-            var left = ParseMultiplicative(context);
-            while (true)
-            {
-                SkipWhitespace();
-                if (TryConsumeOperator("+"))
-                {
-                    left = ToDecimal(left) + ToDecimal(ParseMultiplicative(context));
-                }
-                else if (PeekOperator("-"))
-                {
-                    _position++;
-                    left = ToDecimal(left) - ToDecimal(ParseMultiplicative(context));
-                }
-                else
-                {
-                    return left;
-                }
-            }
-        }
-
-        private object ParseMultiplicative(object context)
-        {
-            var left = ParseUnary(context);
-            while (true)
-            {
-                SkipWhitespace();
-                if (TryConsumeOperator("*"))
-                {
-                    left = ToDecimal(left) * ToDecimal(ParseUnary(context));
-                }
-                else if (PeekOperator("/"))
-                {
-                    _position++;
-                    left = ToDecimal(left) / ToDecimal(ParseUnary(context));
-                }
-                else
-                {
-                    return left;
-                }
-            }
-        }
-
-        private object ParseUnary(object context)
-        {
-            SkipWhitespace();
-            if (PeekOperator("-"))
-            {
-                _position++;
-                return -ToDecimal(ParseUnary(context));
-            }
-            if (PeekOperator("+"))
-            {
-                _position++;
-                return ToDecimal(ParseUnary(context));
-            }
-            return ParsePrimary(context);
-        }
-
-        private object ParsePrimary(object context)
-        {
-            SkipWhitespace();
-            if (_position >= _expression.Length)
-            {
-                throw Fail("fin d'expression inattendue");
-            }
-            var current = _expression[_position];
-            if (current == '(')
-            {
-                _position++;
-                var value = ParseOr(context);
-                SkipWhitespace();
-                if (!TryConsumeOperator(")"))
-                {
-                    throw Fail("parenthese fermante attendue");
-                }
-                return value;
-            }
-            if (current == '"')
-            {
-                return ReadStringLiteral();
-            }
-            if (char.IsDigit(current) || (current == '.' && _position + 1 < _expression.Length && char.IsDigit(_expression[_position + 1])))
-            {
-                return ReadNumber();
-            }
-            if (char.IsLetter(current) || current == '_')
-            {
-                var path = ReadMemberPath();
-                var firstSegment = path[0];
-                if (path.Count == 1)
-                {
-                    if (string.Equals(firstSegment, "true", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
-                    if (string.Equals(firstSegment, "false", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-                return ResolvePath(path, context);
-            }
-            throw Fail($"jeton inattendu '{current}'");
-        }
-
-        private string ReadStringLiteral()
-        {
-            _position++;
-            var start = _position;
-            while (_position < _expression.Length && _expression[_position] != '"')
-            {
-                _position++;
-            }
-            if (_position >= _expression.Length)
-            {
-                throw Fail("chaine non fermee");
-            }
-            var value = _expression.Substring(start, _position - start);
-            _position++;
-            return value;
-        }
-
-        private decimal ReadNumber()
-        {
-            var start = _position;
-            while (_position < _expression.Length
-                   && (char.IsDigit(_expression[_position]) || _expression[_position] == '.'))
-            {
-                _position++;
-            }
-            if (!decimal.TryParse(_expression.Substring(start, _position - start), NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var value))
-            {
-                throw Fail($"nombre invalide '{_expression.Substring(start, _position - start)}'");
-            }
-            return value;
-        }
-
-        private List<string> ReadMemberPath()
-        {
-            var segments = new List<string>();
-            while (true)
-            {
-                var start = _position;
-                while (_position < _expression.Length
-                       && (char.IsLetterOrDigit(_expression[_position]) || _expression[_position] == '_'))
-                {
-                    _position++;
-                }
-                if (_position == start)
-                {
-                    throw Fail("identifiant attendu");
-                }
-                segments.Add(_expression.Substring(start, _position - start));
-                if (_position < _expression.Length && _expression[_position] == '.')
-                {
-                    _position++;
-                }
-                else
-                {
-                    return segments;
-                }
-            }
-        }
-
-        private object ResolvePath(List<string> path, object context)
-        {
-            object current = context;
-            foreach (var segment in path)
-            {
-                if (current == null)
-                {
-                    throw Fail($"membre '{segment}' resolu sur null (chemin '{string.Join(".", path)}')");
-                }
-                current = GetMember(current, segment, path);
-            }
-            return current;
-        }
-
-        private object GetMember(object target, string segment, List<string> path)
-        {
-            var type = target.GetType();
-            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (property.GetIndexParameters().Length == 0
-                    && string.Equals(property.Name, segment, StringComparison.OrdinalIgnoreCase))
-                {
-                    return property.GetValue(target);
-                }
-            }
-            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (string.Equals(field.Name, segment, StringComparison.OrdinalIgnoreCase))
-                {
-                    return field.GetValue(target);
-                }
-            }
-            throw Fail($"membre '{segment}' introuvable sur {type.Name} (chemin '{string.Join(".", path)}')");
-        }
-
-        private string ReadComparisonOperator()
-        {
-            SkipWhitespace();
-            foreach (var op in new[] { "<=", ">=", "==", "!=", "<", ">" })
-            {
-                if (TryConsumeOperator(op))
-                {
-                    return op;
-                }
-            }
-            return null;
-        }
-
-        private bool PeekOperator(string op)
-        {
-            SkipWhitespace();
-            return _position + op.Length <= _expression.Length
-                   && _expression.Substring(_position, op.Length) == op;
-        }
-
-        private bool TryConsumeOperator(string op)
-        {
-            if (!PeekOperator(op))
-            {
-                return false;
-            }
-            _position += op.Length;
-            return true;
-        }
-
-        private void SkipWhitespace()
-        {
-            while (_position < _expression.Length && char.IsWhiteSpace(_expression[_position]))
-            {
-                _position++;
-            }
-        }
-
-        private static decimal ToDecimal(object value)
-        {
-            if (value is decimal decimalValue)
-            {
-                return decimalValue;
-            }
-            if (value is int || value is long || value is short || value is byte
-                || value is double || value is float || value is uint || value is ulong)
-            {
-                return Convert.ToDecimal(value, CultureInfo.InvariantCulture);
-            }
-            throw new InvalidOperationException(string.Format(
-                CultureInfo.InvariantCulture,
-                "SimpleExpression : operande de type {0} inattendu dans un calcul numerique", value?.GetType().Name ?? "null"));
-        }
-
-        private static bool ToBoolean(object value)
-        {
-            if (value is bool boolValue)
-            {
-                return boolValue;
-            }
-            throw new InvalidOperationException(string.Format(
-                CultureInfo.InvariantCulture,
-                "SimpleExpression : operande de type {0} inattendu dans une operation logique", value?.GetType().Name ?? "null"));
-        }
-
-        private static object AsKind(object value, Type type)
-        {
-            return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
-        }
-
-        private InvalidOperationException Fail(string message)
-        {
-            return new InvalidOperationException(
-                $"SimpleExpression : {message} (expression : '{_expression}', position {_position})");
         }
     }
 }

--- a/MyIA.Trading.Backtester/Core/SimpleExpression.cs
+++ b/MyIA.Trading.Backtester/Core/SimpleExpression.cs
@@ -1,0 +1,433 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Expression dynamique evaluee contre un contexte de trading. Substitut autonome
+    /// de Aricie.DNN.Services.Flee.SimpleExpression (Flee etant inaccessible hors des
+    /// DLL Aricie abandonnees) : la grammaire portee couvre exactement le vocabulaire
+    /// des expressions du backtester — litteraux (decimal, bool, chaine), acces de
+    /// membres par chemin (ex. "Market.Ticker.Last", "CurrentOrders.HighestAsk.Value",
+    /// resolu par reflexion insensible a la casse, ex. "LowestAsk.price"), arithmetique
+    /// decimale + - * / unaires et parenteses, comparaisons (&lt; &gt; &lt;= &gt;= == !=)
+    /// et operateurs logiques (&amp;&amp; ||). L'arithmetique reste en decimal : aucune
+    /// coercion double, les montants ne derivent pas.
+    /// </summary>
+    [Serializable]
+    public class SimpleExpression<T>
+    {
+        public string Expression { get; set; }
+
+        public SimpleExpression()
+        {
+        }
+
+        public SimpleExpression(string expression)
+        {
+            Expression = expression;
+        }
+
+        public T Evaluate(TradingContext tContext)
+        {
+            if (string.IsNullOrWhiteSpace(Expression))
+            {
+                throw new InvalidOperationException(
+                    "SimpleExpression : expression vide (definissez Expression avant l'evaluation)");
+            }
+            if (tContext == null)
+            {
+                throw new ArgumentNullException(nameof(tContext));
+            }
+
+            var result = new SimpleExpressionEvaluator(Expression).Evaluate(tContext);
+            return ConvertResult(result);
+        }
+
+        private T ConvertResult(object value)
+        {
+            if (value is T typedValue)
+            {
+                return typedValue;
+            }
+            if (value is decimal decimalValue)
+            {
+                if (typeof(T) == typeof(decimal))
+                {
+                    return (T)(object)decimalValue;
+                }
+                return (T)Convert.ChangeType(decimalValue, typeof(T), CultureInfo.InvariantCulture);
+            }
+            if (value is IConvertible)
+            {
+                return (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);
+            }
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.InvariantCulture,
+                "SimpleExpression : le resultat de type {0} n'est pas convertible en {1} (expression : '{2}')",
+                value.GetType().Name, typeof(T).Name, Expression));
+        }
+    }
+
+    /// <summary>
+    /// Evaluateur recursif descendant pour les SimpleExpression. Valeurs intermediaires
+    /// en object : decimal pour tout le numerique, bool pour comparaisons et logique,
+    /// string pour les litteraux de chaine. Precedence usuelle : || puis &amp;&amp; puis
+    /// comparaisons puis + - puis * / puis unaire.
+    /// </summary>
+    internal sealed class SimpleExpressionEvaluator
+    {
+        private readonly string _expression;
+        private int _position;
+
+        internal SimpleExpressionEvaluator(string expression)
+        {
+            _expression = expression;
+        }
+
+        internal object Evaluate(object context)
+        {
+            var value = ParseOr(context);
+            SkipWhitespace();
+            if (_position < _expression.Length)
+            {
+                throw Fail($"caractere inattendu '{_expression[_position]}'");
+            }
+            return value;
+        }
+
+        private object ParseOr(object context)
+        {
+            var left = ParseAnd(context);
+            while (TryConsumeOperator("||"))
+            {
+                var right = ParseAnd(context);
+                left = ToBoolean(left) || ToBoolean(right);
+            }
+            return left;
+        }
+
+        private object ParseAnd(object context)
+        {
+            var left = ParseComparison(context);
+            while (TryConsumeOperator("&&"))
+            {
+                var right = ParseComparison(context);
+                left = ToBoolean(left) && ToBoolean(right);
+            }
+            return left;
+        }
+
+        private object ParseComparison(object context)
+        {
+            var left = ParseAdditive(context);
+            string op = ReadComparisonOperator();
+            if (op == null)
+            {
+                return left;
+            }
+            var right = ParseAdditive(context);
+            if (left is string || right is string)
+            {
+                if (op != "==" && op != "!=")
+                {
+                    throw Fail($"comparaison '{op}' non applicable a une chaine");
+                }
+                var equals = string.Equals((string)AsKind(left, typeof(string)), (string)AsKind(right, typeof(string)), StringComparison.Ordinal);
+                return op == "==" ? equals : !equals;
+            }
+            var leftDecimal = ToDecimal(left);
+            var rightDecimal = ToDecimal(right);
+            switch (op)
+            {
+                case "<": return leftDecimal < rightDecimal;
+                case ">": return leftDecimal > rightDecimal;
+                case "<=": return leftDecimal <= rightDecimal;
+                case ">=": return leftDecimal >= rightDecimal;
+                case "==": return leftDecimal == rightDecimal;
+                case "!=": return leftDecimal != rightDecimal;
+                default: throw Fail($"operateur inconnu '{op}'");
+            }
+        }
+
+        private object ParseAdditive(object context)
+        {
+            var left = ParseMultiplicative(context);
+            while (true)
+            {
+                SkipWhitespace();
+                if (TryConsumeOperator("+"))
+                {
+                    left = ToDecimal(left) + ToDecimal(ParseMultiplicative(context));
+                }
+                else if (PeekOperator("-"))
+                {
+                    _position++;
+                    left = ToDecimal(left) - ToDecimal(ParseMultiplicative(context));
+                }
+                else
+                {
+                    return left;
+                }
+            }
+        }
+
+        private object ParseMultiplicative(object context)
+        {
+            var left = ParseUnary(context);
+            while (true)
+            {
+                SkipWhitespace();
+                if (TryConsumeOperator("*"))
+                {
+                    left = ToDecimal(left) * ToDecimal(ParseUnary(context));
+                }
+                else if (PeekOperator("/"))
+                {
+                    _position++;
+                    left = ToDecimal(left) / ToDecimal(ParseUnary(context));
+                }
+                else
+                {
+                    return left;
+                }
+            }
+        }
+
+        private object ParseUnary(object context)
+        {
+            SkipWhitespace();
+            if (PeekOperator("-"))
+            {
+                _position++;
+                return -ToDecimal(ParseUnary(context));
+            }
+            if (PeekOperator("+"))
+            {
+                _position++;
+                return ToDecimal(ParseUnary(context));
+            }
+            return ParsePrimary(context);
+        }
+
+        private object ParsePrimary(object context)
+        {
+            SkipWhitespace();
+            if (_position >= _expression.Length)
+            {
+                throw Fail("fin d'expression inattendue");
+            }
+            var current = _expression[_position];
+            if (current == '(')
+            {
+                _position++;
+                var value = ParseOr(context);
+                SkipWhitespace();
+                if (!TryConsumeOperator(")"))
+                {
+                    throw Fail("parenthese fermante attendue");
+                }
+                return value;
+            }
+            if (current == '"')
+            {
+                return ReadStringLiteral();
+            }
+            if (char.IsDigit(current) || (current == '.' && _position + 1 < _expression.Length && char.IsDigit(_expression[_position + 1])))
+            {
+                return ReadNumber();
+            }
+            if (char.IsLetter(current) || current == '_')
+            {
+                var path = ReadMemberPath();
+                var firstSegment = path[0];
+                if (path.Count == 1)
+                {
+                    if (string.Equals(firstSegment, "true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                    if (string.Equals(firstSegment, "false", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+                return ResolvePath(path, context);
+            }
+            throw Fail($"jeton inattendu '{current}'");
+        }
+
+        private string ReadStringLiteral()
+        {
+            _position++;
+            var start = _position;
+            while (_position < _expression.Length && _expression[_position] != '"')
+            {
+                _position++;
+            }
+            if (_position >= _expression.Length)
+            {
+                throw Fail("chaine non fermee");
+            }
+            var value = _expression.Substring(start, _position - start);
+            _position++;
+            return value;
+        }
+
+        private decimal ReadNumber()
+        {
+            var start = _position;
+            while (_position < _expression.Length
+                   && (char.IsDigit(_expression[_position]) || _expression[_position] == '.'))
+            {
+                _position++;
+            }
+            if (!decimal.TryParse(_expression.Substring(start, _position - start), NumberStyles.Number,
+                CultureInfo.InvariantCulture, out var value))
+            {
+                throw Fail($"nombre invalide '{_expression.Substring(start, _position - start)}'");
+            }
+            return value;
+        }
+
+        private List<string> ReadMemberPath()
+        {
+            var segments = new List<string>();
+            while (true)
+            {
+                var start = _position;
+                while (_position < _expression.Length
+                       && (char.IsLetterOrDigit(_expression[_position]) || _expression[_position] == '_'))
+                {
+                    _position++;
+                }
+                if (_position == start)
+                {
+                    throw Fail("identifiant attendu");
+                }
+                segments.Add(_expression.Substring(start, _position - start));
+                if (_position < _expression.Length && _expression[_position] == '.')
+                {
+                    _position++;
+                }
+                else
+                {
+                    return segments;
+                }
+            }
+        }
+
+        private object ResolvePath(List<string> path, object context)
+        {
+            object current = context;
+            foreach (var segment in path)
+            {
+                if (current == null)
+                {
+                    throw Fail($"membre '{segment}' resolu sur null (chemin '{string.Join(".", path)}')");
+                }
+                current = GetMember(current, segment, path);
+            }
+            return current;
+        }
+
+        private object GetMember(object target, string segment, List<string> path)
+        {
+            var type = target.GetType();
+            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (property.GetIndexParameters().Length == 0
+                    && string.Equals(property.Name, segment, StringComparison.OrdinalIgnoreCase))
+                {
+                    return property.GetValue(target);
+                }
+            }
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (string.Equals(field.Name, segment, StringComparison.OrdinalIgnoreCase))
+                {
+                    return field.GetValue(target);
+                }
+            }
+            throw Fail($"membre '{segment}' introuvable sur {type.Name} (chemin '{string.Join(".", path)}')");
+        }
+
+        private string ReadComparisonOperator()
+        {
+            SkipWhitespace();
+            foreach (var op in new[] { "<=", ">=", "==", "!=", "<", ">" })
+            {
+                if (TryConsumeOperator(op))
+                {
+                    return op;
+                }
+            }
+            return null;
+        }
+
+        private bool PeekOperator(string op)
+        {
+            SkipWhitespace();
+            return _position + op.Length <= _expression.Length
+                   && _expression.Substring(_position, op.Length) == op;
+        }
+
+        private bool TryConsumeOperator(string op)
+        {
+            if (!PeekOperator(op))
+            {
+                return false;
+            }
+            _position += op.Length;
+            return true;
+        }
+
+        private void SkipWhitespace()
+        {
+            while (_position < _expression.Length && char.IsWhiteSpace(_expression[_position]))
+            {
+                _position++;
+            }
+        }
+
+        private static decimal ToDecimal(object value)
+        {
+            if (value is decimal decimalValue)
+            {
+                return decimalValue;
+            }
+            if (value is int || value is long || value is short || value is byte
+                || value is double || value is float || value is uint || value is ulong)
+            {
+                return Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+            }
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.InvariantCulture,
+                "SimpleExpression : operande de type {0} inattendu dans un calcul numerique", value?.GetType().Name ?? "null"));
+        }
+
+        private static bool ToBoolean(object value)
+        {
+            if (value is bool boolValue)
+            {
+                return boolValue;
+            }
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.InvariantCulture,
+                "SimpleExpression : operande de type {0} inattendu dans une operation logique", value?.GetType().Name ?? "null"));
+        }
+
+        private static object AsKind(object value, Type type)
+        {
+            return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
+        }
+
+        private InvalidOperationException Fail(string message)
+        {
+            return new InvalidOperationException(
+                $"SimpleExpression : {message} (expression : '{_expression}', position {_position})");
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/SimulationData.cs
+++ b/MyIA.Trading.Backtester/Core/SimulationData.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Snapshot JSON d'un etat de simulation (ticker, market depth, wallet). Le port
+    /// d'origine laissait les accesseurs Market et Wallet en stub avec un commentaire
+    /// "migrate the following to Newtonsoft json.net" : la migration est portee ici
+    /// avec la lib deja en solution. Les deserialisations ciblent Ticker/MarketDepth/
+    /// Wallet directement (props publiques) plutot que TickerInfo, dont le champ
+    /// public ticker n'est pas couvert par le contract resolver par defaut.
+    /// </summary>
+    [Serializable]
+    public class SimulationData
+    {
+        public string JsonMarketDepth { get; set; }
+
+        public string JsonTicker { get; set; }
+
+        public string JsonWallet { get; set; }
+
+        public MarketInfo Market
+        {
+            get
+            {
+                var ticker = Deserialize<Ticker>(JsonTicker);
+                var depth = Deserialize<MarketDepth>(JsonMarketDepth);
+                if (ticker == null && depth == null)
+                {
+                    return new MarketInfo();
+                }
+                return new MarketInfo(ticker, depth);
+            }
+        }
+
+        public Wallet Wallet
+        {
+            get
+            {
+                return Deserialize<Wallet>(JsonWallet) ?? new Wallet();
+            }
+        }
+
+        private static T Deserialize<T>(string json) where T : class
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(json);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        [DebuggerNonUserCode]
+        public SimulationData()
+        {
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TickerInfo.cs
+++ b/MyIA.Trading.Backtester/Core/TickerInfo.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Diagnostics;
+
+namespace MyIA.Trading.Backtester
+{
+    public class TickerInfo : ResponseObject
+    {
+        public Ticker ticker;
+
+        [DebuggerNonUserCode]
+        public TickerInfo()
+        {
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingBandDirection.cs
+++ b/MyIA.Trading.Backtester/Core/TradingBandDirection.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    public enum TradingBandDirection
+    {
+        Inwards = -1,
+        Outwards = 1
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingStrategies.cs
+++ b/MyIA.Trading.Backtester/Core/TradingStrategies.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Collection ordonnee de strategies contextuelles appliquees en sequence au meme
+    /// contexte de trading. Le port d'origine heritait de ProviderHost (registre de
+    /// types destine a la grille UI DNN via GetAvailableProviders/GetInitialTypes) :
+    /// cette plomberie de selection visuelle n'est pas portee, la liste d'instances
+    /// qu'elle alimentait le devient directement.
+    /// </summary>
+    [Serializable]
+    public class TradingStrategies : IContextualStrategy, ITradingStrategy
+    {
+        public List<IContextualStrategy> Instances { get; set; }
+
+        public TradingStrategies()
+        {
+            this.Instances = new List<IContextualStrategy>();
+        }
+
+        public void ComputeNewOrders(ref TradingContext tContext)
+        {
+            foreach (IContextualStrategy objAction in this.Instances)
+            {
+                objAction.ComputeNewOrders(ref tContext);
+            }
+        }
+
+        public Wallet ComputeNewOrders(Wallet currentOrders, MarketInfo objMarket, ExchangeInfo objExchange, TradingHistory history)
+        {
+            //the newOrders Wallet variable will contain all ask/bid/cancel orders to issue
+
+            var newOrders = new Wallet();
+
+            decimal avBtcsForTrading = currentOrders.PrimaryBalance;
+            decimal avUsdsForTrading = currentOrders.SecondaryBalance;
+
+            //Then We simplify the current orders by merging orders of the same price, issueing corresponding cancel/new orders
+            newOrders.ConsolidateOrders(ref currentOrders, true);
+
+            //Feed the new orders wallet with available resources, Reserve resources for current open orders
+            newOrders.PrimaryBalance = Math.Max(avBtcsForTrading - currentOrders.GetTotalAsksPrimary(), 0m);
+            newOrders.SecondaryBalance = Math.Max(avUsdsForTrading - currentOrders.GetTotalBidsSecondary(), 0m);
+
+            var tContext = new TradingContext(currentOrders, newOrders, objMarket, objExchange, history.GetLastTrend(), this);
+
+            this.ComputeNewOrders(ref tContext);
+
+            tContext.NewOrders.FitOrders(objExchange);
+            //we update the trading history with last data
+            history.Update(currentOrders, objMarket, tContext.NewOrders);
+            return tContext.NewOrders;
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/TradingStrategy.cs
@@ -1,0 +1,488 @@
+using System;
+
+namespace MyIA.Trading.Backtester
+{
+    /// <summary>
+    /// Strategie de market-making par bande : maintien d'une bande d'ordres ask/bid
+    /// autour du dernier prix, dont prix et montants sont calcules par expressions
+    /// dynamiques (SimpleExpression) evaluees contre le contexte. Les attributs de
+    /// grille UI DNN (ExtendedCategory, ConditionalVisible, AutoPostBack) du port
+    /// d'origine ne sont pas portes : ils ne portaient que de l'affichage.
+    /// </summary>
+    [Serializable]
+    public class TradingStrategy : TradingStrategyBase
+    {
+        private const string ConstantDistribNextAsk = "Price + 0.10";
+
+        private const string ConstantDistribNextBid = "Price - 0.10";
+
+        private const string ConstantDistribMinAsk = "LowestAsk.price - 0.10";
+
+        private const string ConstantDistribMaxBid = "HighestBid.price + 0.10";
+
+        private const string LinearDistribNextAsk = "Price * 100 / 99";
+
+        private const string LinearDistribNextBid = "Price * 99 / 100";
+
+        private const string LinearDistribMinAsk = "LowestAsk.price * 99 / 100";
+
+        private const string LinearDistribMaxBid = "HighestBid.price * 100 / 99";
+
+        private const string ExponentialDistribNextAsk = "2*Price - Market.Ticker.Last";
+
+        private const string ExponentialDistribNextBid = "2*Price - Market.Ticker.Last";
+
+        private const string ExponentialDistribMinAsk = "(LowestAsk.price + Market.Ticker.Last)/2";
+
+        private const string ExponentialDistribMaxBid = "(HighestBid.price + Market.Ticker.Last)/2";
+
+        private OrdersDistribution _ordersDistribution;
+
+        public bool AccountForTrend { get; set; }
+
+        public decimal AdjustOrderLimitRate { get; set; }
+
+        public SimpleExpression<decimal> AskOrderAmountExpression { get; set; }
+
+        public SimpleExpression<decimal> BidOrderAmountExpression { get; set; }
+
+        public decimal CancelOrderLimitRate { get; set; }
+
+        public decimal DefaultBandWidthRate { get; set; }
+
+        public decimal DefaultMaxOrderValueRate { get; set; }
+
+        public override decimal LimitOrderMarginRate
+        {
+            get
+            {
+                return base.LimitOrderMarginRate;
+            }
+            set
+            {
+                base.LimitOrderMarginRate = value;
+            }
+        }
+
+        public decimal LimitOrderValueRate { get; set; }
+
+        public decimal MaxBandWidthRate { get; set; }
+
+        public SimpleExpression<decimal> MaxBidOrderPriceExpression { get; set; }
+
+        public SimpleExpression<decimal> MinAskOrderPriceExpression { get; set; }
+
+        public decimal MinBandWidthRate { get; set; }
+
+        public SimpleExpression<decimal> NextAskOrderPriceExpression { get; set; }
+
+        public SimpleExpression<decimal> NextBidOrderPriceExpression { get; set; }
+
+        public OrdersDistribution OrdersDistribution
+        {
+            get
+            {
+                switch (this._ordersDistribution)
+                {
+                    case OrdersDistribution.Constant:
+                        {
+                            if (!(NextAskOrderPriceExpression.Expression == ConstantDistribNextAsk
+                                && NextBidOrderPriceExpression.Expression == ConstantDistribNextBid
+                                && MinAskOrderPriceExpression.Expression == ConstantDistribMinAsk
+                                && MaxBidOrderPriceExpression.Expression == ConstantDistribMaxBid))
+                            {
+                                this._ordersDistribution = OrdersDistribution.Custom;
+                            }
+                            break;
+                        }
+                    case OrdersDistribution.Linear:
+                        {
+                            if (!(NextAskOrderPriceExpression.Expression == LinearDistribNextAsk
+                                && NextBidOrderPriceExpression.Expression == LinearDistribNextBid
+                                && MinAskOrderPriceExpression.Expression == LinearDistribMinAsk
+                                && MaxBidOrderPriceExpression.Expression == LinearDistribMaxBid))
+                            {
+                                this._ordersDistribution = OrdersDistribution.Custom;
+                            }
+                            break;
+                        }
+                    case OrdersDistribution.Exponential:
+                        {
+                            if (!(NextAskOrderPriceExpression.Expression == ExponentialDistribNextAsk
+                                && NextBidOrderPriceExpression.Expression == ExponentialDistribNextBid
+                                && MinAskOrderPriceExpression.Expression == ExponentialDistribMinAsk
+                                && MaxBidOrderPriceExpression.Expression == ExponentialDistribMaxBid))
+                            {
+                                this._ordersDistribution = OrdersDistribution.Custom;
+                            }
+                            break;
+                        }
+                }
+                return this._ordersDistribution;
+            }
+            set
+            {
+                if (value != this._ordersDistribution)
+                {
+                    this._ordersDistribution = value;
+                    switch (value)
+                    {
+                        case OrdersDistribution.Constant:
+                            {
+                                NextAskOrderPriceExpression.Expression = ConstantDistribNextAsk;
+                                NextBidOrderPriceExpression.Expression = ConstantDistribNextBid;
+                                MinAskOrderPriceExpression.Expression = ConstantDistribMinAsk;
+                                MaxBidOrderPriceExpression.Expression = ConstantDistribMaxBid;
+                                break;
+                            }
+                        case OrdersDistribution.Linear:
+                            {
+                                this.NextAskOrderPriceExpression.Expression = LinearDistribNextAsk;
+                                this.NextBidOrderPriceExpression.Expression = LinearDistribNextBid;
+                                this.MinAskOrderPriceExpression.Expression = LinearDistribMinAsk;
+                                this.MaxBidOrderPriceExpression.Expression = LinearDistribMaxBid;
+                                break;
+                            }
+                        case OrdersDistribution.Exponential:
+                            {
+                                this.NextAskOrderPriceExpression.Expression = ExponentialDistribNextAsk;
+                                this.NextBidOrderPriceExpression.Expression = ExponentialDistribNextBid;
+                                this.MinAskOrderPriceExpression.Expression = ExponentialDistribMinAsk;
+                                this.MaxBidOrderPriceExpression.Expression = ExponentialDistribMaxBid;
+                                break;
+                            }
+                    }
+                }
+            }
+        }
+
+        public override bool TakeMarginOnOppositeOrder
+        {
+            get
+            {
+                return base.TakeMarginOnOppositeOrder;
+            }
+            set
+            {
+                base.TakeMarginOnOppositeOrder = value;
+            }
+        }
+
+        public TradingBandDirection TradingBandDirection { get; set; }
+
+        public decimal VolumeGrowthLimitFactor { get; set; }
+
+        public decimal VolumeGrowthRate { get; set; }
+
+        public decimal VolumeResetLimitFactor { get; set; }
+
+        public TradingStrategy()
+        {
+            this.DefaultBandWidthRate = 30m;
+            this.MinBandWidthRate = 10m;
+            this.MaxBandWidthRate = 40m;
+            this.DefaultMaxOrderValueRate = 10m;
+            this.LimitOrderValueRate = 10m;
+            this.AccountForTrend = true;
+            this.TradingBandDirection = TradingBandDirection.Outwards;
+            this.NextAskOrderPriceExpression = new SimpleExpression<decimal>("Price * 100 / 99");
+            this.NextBidOrderPriceExpression = new SimpleExpression<decimal>("Price * 99 / 100");
+            this.MinAskOrderPriceExpression = new SimpleExpression<decimal>("LowestAsk.price * 99 / 100");
+            this.MaxBidOrderPriceExpression = new SimpleExpression<decimal>("HighestBid.price * 100 / 99");
+            this.AskOrderAmountExpression = new SimpleExpression<decimal>("(CurrentOrders.HighestAsk.Value * (1 - Strategy.LimitOrderValueRate / 100) / AskSpan) + (((CurrentOrders.HighestAsk.Value * Strategy.LimitOrderValueRate / 100) - (LowestAskLimitPrice * CurrentOrders.HighestAsk.Value * (1 - Strategy.LimitOrderValueRate / 100) / AskSpan))/ Price)");
+            this.BidOrderAmountExpression = new SimpleExpression<decimal>("(CurrentOrders.LowestBid.Value * ((Strategy.LimitOrderValueRate / 100) - 1) / BidSpan) + ((CurrentOrders.LowestBid.Value * Strategy.LimitOrderValueRate / 100) - (HighestBidLimitPrice * CurrentOrders.LowestBid.Value * ((Strategy.LimitOrderValueRate / 100) - 1) / BidSpan))/ Price");
+            this.VolumeResetLimitFactor = 1m;
+            this.VolumeGrowthLimitFactor = 10m;
+            this.VolumeGrowthRate = 5m;
+            this.AdjustOrderLimitRate = 85m;
+            this.CancelOrderLimitRate = 95m;
+        }
+
+        public override void ComputeNewOrders(ref TradingContext tContext)
+        {
+            tContext = new BandTradingContext(tContext);
+
+            //this is because some user defined expressions are computed in loops:
+            // we don't want the algorithm to get stuck in an infinite loop
+            int safetyCounter = 0;
+
+            // First we deal with asks
+
+            if (!this.NoAsks)
+            {
+                if (tContext.CurrentOrders.OrderedAsks.Count == 0)
+                {
+                    if (this.AccountForTrend || tContext.LastTrend != TradingTrend.Ask)
+                    {
+                        // There is no asks order yet/anymore, define a single new ask order
+
+                        //Compute price from current ticker and strategy
+                        var newHighAskPrice = tContext.Market.Ticker.Last * (1m + DefaultBandWidthRate / 100m);
+
+                        var newOrder = new Order()
+                        {
+                            OrderType = OrderType.Sell,
+                            Price = newHighAskPrice,
+                            //compute amount from available balance and strategy
+                            Amount = (tContext.NewOrders.PrimaryBalance * tContext.Market.Ticker.Last / newHighAskPrice)
+                            * DefaultMaxOrderValueRate / 100m
+                        };
+                        tContext.NewOrders.Orders.Add(newOrder);
+                    }
+                }
+                // else: There are asks orders already, we'll base new orders according to the existing
+                else if (tContext.CurrentOrders.HighestAsk.Price
+                        < tContext.Market.Ticker.Last * (1m + MinBandWidthRate / 100m)
+                    || tContext.CurrentOrders.HighestAsk.Price
+                        > tContext.Market.Ticker.Last * (1m + MaxBandWidthRate / 100m))
+                {
+                    // The band is not within defined bound: clear existing orders in order to define a new band
+                    tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.OrderedAsks.ToArray());
+                }
+                else if (tContext.NewOrders.PrimaryBalance * tContext.Market.Ticker.Last
+                         < tContext.CurrentOrders.HighestAsk.Value * VolumeResetLimitFactor)
+                {
+                    //the amount of available resource is too low for the existing band: clear orders to define a new band
+                    tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.OrderedAsks.ToArray());
+                }
+                else
+                {
+                    //we start with new low orders: have we got new orders to issue ?
+                    if (!AccountForTrend
+                        || tContext.LastTrend != TradingTrend.Ask
+                        || tContext.CurrentOrders.OrderedAsks.Count < 2)
+                    {
+                        decimal newPrice, limitPrice;
+                        SimpleExpression<decimal> pricingExpression;
+                        var sign = (int)TradingBandDirection;
+                        if (TradingBandDirection == TradingBandDirection.Outwards)
+                        {
+                            pricingExpression = NextAskOrderPriceExpression;
+                            newPrice = tContext.LowestAskLimitPrice;
+                            limitPrice = tContext.LowestAsk.Price;
+                        }
+                        else
+                        {
+                            pricingExpression = MinAskOrderPriceExpression;
+                            newPrice = pricingExpression.Evaluate(tContext);
+                            limitPrice = tContext.LowestAskLimitPrice;
+                        }
+
+                        //How close are we to the lowest limit ask price?
+                        safetyCounter = 0;
+                        while (newPrice > 0 && sign * newPrice < sign * limitPrice && safetyCounter < 500)
+                        {
+                            safetyCounter += 1;
+                            // We are within the authorized inner band , place new order
+
+                            var newOrder = new Order { OrderType = OrderType.Sell, Price = newPrice };
+
+                            //set price to context to compute the new order amount
+                            tContext.Price = newPrice;
+                            newOrder.Amount = AskOrderAmountExpression.Evaluate(tContext);
+                            if (TradingBandDirection == TradingBandDirection.Inwards)
+                            {
+                                tContext.NewOrders.Orders.Add(newOrder);
+                            }
+                            newPrice = pricingExpression.Evaluate(tContext);
+                            if (TradingBandDirection == TradingBandDirection.Outwards
+                                    && sign * newPrice < sign * limitPrice)
+                            {
+                                tContext.NewOrders.Orders.Add(newOrder);
+                            }
+                        }
+                    }
+
+                    //then we check existing orders for cancelling or increasing
+                    for (var i = 0; i <= tContext.CurrentOrders.OrderedAsks.Count - 1; i++)
+                    {
+                        var currentOrder = tContext.CurrentOrders.OrderedAsks[i];
+                        if (currentOrder.Price > tContext.LowestAskLimitPrice)
+                        {
+                            tContext.Price = currentOrder.Price;
+                            decimal idealAmount = AskOrderAmountExpression.Evaluate(tContext);
+                            //Cleaning: if the order span exceeds the previous order span
+                            //by more than the defined canceling rate, cancel the order
+                            if ((i > 1
+                                 && (tContext.CurrentOrders.OrderedAsks[i].Price - tContext.CurrentOrders.OrderedAsks[i - 1].Price)
+                                 /
+                                 (tContext.CurrentOrders.OrderedAsks[i - 1].Price - tContext.CurrentOrders.OrderedAsks[i - 2].Price)
+                                 < this.CancelOrderLimitRate / 100m))
+                            {
+                                tContext.NewOrders.CancelExistingOrders(currentOrder);
+                            }
+                            else if (currentOrder.Amount < idealAmount * AdjustOrderLimitRate / 100m)
+                            {
+                                var newOrder = new Order
+                                {
+                                    OrderType = OrderType.Sell,
+                                    Price = currentOrder.Price,
+                                    Amount = idealAmount
+                                };
+
+                                //new order amount is the difference between ideal amount and current amount
+                                tContext.NewOrders.CancelExistingOrders(currentOrder);
+                                tContext.NewOrders.Orders.Add(newOrder);
+                            }
+                        }
+                    }
+
+                    if (tContext.NewOrders.Orders.Count == 0
+                        && tContext.NewOrders.PrimaryBalance * tContext.Market.Ticker.Last
+                            > tContext.CurrentOrders.HighestAsk.Value * VolumeGrowthLimitFactor)
+                    {
+                        //if their are still btcs available and their amount exceeds the strategy limit, increase the higher order
+                        var newOrder = new Order
+                        {
+                            OrderType = OrderType.Sell,
+                            Price = tContext.CurrentOrders.HighestAsk.Price,
+                            Amount = tContext.CurrentOrders.HighestAsk.Amount * (1 + this.VolumeGrowthRate / 100m)
+                        };
+                        tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.HighestAsk);
+                        tContext.NewOrders.Orders.Add(newOrder);
+                    }
+                }
+            }
+
+            // Then we deal with Bids
+
+            //todo: that should be symetrical thus abstracted as such
+
+            if (!this.NoBids)
+            {
+                if (tContext.CurrentOrders.OrderedBids.Count == 0)
+                {
+                    if (this.AccountForTrend || tContext.LastTrend != TradingTrend.Bid)
+                    {
+                        // There is no bid order yet/anymore, define a single new bid order
+
+                        //Compute price from current ticker and strategy
+                        var newLowBidPrice = tContext.Market.Ticker.Last * 100m / (DefaultBandWidthRate + 100m);
+
+                        var newOrder = new Order()
+                        {
+                            OrderType = OrderType.Buy,
+                            Price = newLowBidPrice,
+                            //compute amount from available balance and strategy
+                            Amount = (tContext.NewOrders.SecondaryBalance / newLowBidPrice)
+                            * DefaultMaxOrderValueRate / 100m
+                        };
+                        tContext.NewOrders.Orders.Add(newOrder);
+                    }
+                }
+                // else: There are bid orders already, we'll base new orders according to the existing
+                else if (tContext.CurrentOrders.LowestBid.Price
+                        > tContext.Market.Ticker.Last * 100m / (MinBandWidthRate + 100m)
+                    || tContext.CurrentOrders.LowestBid.Price
+                        < tContext.Market.Ticker.Last * 100m / (MaxBandWidthRate + 100m))
+                {
+                    // The band is not within defined bound: clear existing orders in order to define a new band
+                    tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.OrderedBids.ToArray());
+                }
+                else if (tContext.NewOrders.SecondaryBalance
+                         < tContext.CurrentOrders.LowestBid.Value * VolumeResetLimitFactor)
+                {
+                    //the amount of available resource is too low for the existing band: clear orders to define a new band
+                    tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.OrderedBids.ToArray());
+                }
+                else
+                {
+                    //we start with new low orders: have we got new orders to issue ?
+                    if (!AccountForTrend
+                        || tContext.LastTrend != TradingTrend.Bid
+                        || tContext.CurrentOrders.OrderedBids.Count < 2)
+                    {
+                        decimal newPrice, limitPrice;
+                        SimpleExpression<decimal> pricingExpression;
+                        var sign = (int)TradingBandDirection;
+                        if (TradingBandDirection == TradingBandDirection.Outwards)
+                        {
+                            pricingExpression = NextBidOrderPriceExpression;
+                            newPrice = tContext.HighestBidLimitPrice;
+                            limitPrice = tContext.HighestBid.Price;
+                        }
+                        else
+                        {
+                            pricingExpression = MaxBidOrderPriceExpression;
+                            newPrice = pricingExpression.Evaluate(tContext);
+                            limitPrice = tContext.HighestBidLimitPrice;
+                        }
+
+                        //How close are we to the lowest limit ask price?
+                        safetyCounter = 0;
+                        while (newPrice > 0 && sign * newPrice > sign * limitPrice && safetyCounter < 500)
+                        {
+                            safetyCounter += 1;
+                            // We are within the authorized inner band , place new order
+
+                            var newOrder = new Order { OrderType = OrderType.Buy, Price = newPrice };
+
+                            //set price to context to compute the new order amount
+                            tContext.Price = newPrice;
+                            newOrder.Amount = BidOrderAmountExpression.Evaluate(tContext);
+                            if (TradingBandDirection == TradingBandDirection.Inwards)
+                            {
+                                tContext.NewOrders.Orders.Add(newOrder);
+                            }
+                            newPrice = pricingExpression.Evaluate(tContext);
+                            if (TradingBandDirection == TradingBandDirection.Outwards
+                                    && sign * newPrice > sign * limitPrice)
+                            {
+                                tContext.NewOrders.Orders.Add(newOrder);
+                            }
+                        }
+                    }
+
+                    //then we check existing orders for cancelling or increasing
+                    for (var i = 0; i <= tContext.CurrentOrders.OrderedBids.Count - 1; i++)
+                    {
+                        var currentOrder = tContext.CurrentOrders.OrderedBids[i];
+                        if (currentOrder.Price < tContext.HighestBidLimitPrice)
+                        {
+                            tContext.Price = currentOrder.Price;
+                            decimal idealAmount = BidOrderAmountExpression.Evaluate(tContext);
+                            //Cleaning: if the order span exceeds the previous order span
+                            //by more than the defined canceling rate, cancel the order
+                            if ((i < tContext.CurrentOrders.OrderedBids.Count - 2
+                                 && (tContext.CurrentOrders.OrderedBids[i + 1].Price - tContext.CurrentOrders.OrderedBids[i].Price)
+                                 /
+                                 (tContext.CurrentOrders.OrderedBids[i + 2].Price - tContext.CurrentOrders.OrderedBids[i + 1].Price)
+                                 < this.CancelOrderLimitRate / 100m))
+                            {
+                                tContext.NewOrders.CancelExistingOrders(currentOrder);
+                            }
+                            else if (currentOrder.Amount < idealAmount * AdjustOrderLimitRate / 100m)
+                            {
+                                var newOrder = new Order
+                                {
+                                    OrderType = OrderType.Buy,
+                                    Price = currentOrder.Price,
+                                    Amount = idealAmount
+                                };
+
+                                //new order amount is the difference between ideal amount and current amount
+                                tContext.NewOrders.CancelExistingOrders(currentOrder);
+                                tContext.NewOrders.Orders.Add(newOrder);
+                            }
+                        }
+                    }
+
+                    if (tContext.NewOrders.Orders.Count == 0
+                        && tContext.NewOrders.SecondaryBalance
+                            > tContext.CurrentOrders.LowestBid.Value * VolumeGrowthLimitFactor)
+                    {
+                        //if their are still resources available and their amount exceeds the strategy limit, increase the highest order
+                        var newOrder = new Order
+                        {
+                            OrderType = OrderType.Buy,
+                            Price = tContext.CurrentOrders.LowestBid.Price,
+                            Amount = tContext.CurrentOrders.LowestBid.Amount * (1 + this.VolumeGrowthRate / 100m)
+                        };
+                        tContext.NewOrders.CancelExistingOrders(tContext.CurrentOrders.LowestBid);
+                        tContext.NewOrders.Orders.Add(newOrder);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MyIA.Trading.Backtester/Core/TradingStrategy.cs
+++ b/MyIA.Trading.Backtester/Core/TradingStrategy.cs
@@ -189,8 +189,11 @@ namespace MyIA.Trading.Backtester
             this.NextBidOrderPriceExpression = new SimpleExpression<decimal>("Price * 99 / 100");
             this.MinAskOrderPriceExpression = new SimpleExpression<decimal>("LowestAsk.price * 99 / 100");
             this.MaxBidOrderPriceExpression = new SimpleExpression<decimal>("HighestBid.price * 100 / 99");
+            // Parens plates autour de (Strategy.LimitOrderValueRate / 100 - 1) — Flee
+            // ne parse pas "((X) - 1)" (paren imbriquee autour d'une expression suivie
+            // d'une soustraction unaire), mais "(X - 1)" passe. Voir MEMORY c.988.
             this.AskOrderAmountExpression = new SimpleExpression<decimal>("(CurrentOrders.HighestAsk.Value * (1 - Strategy.LimitOrderValueRate / 100) / AskSpan) + (((CurrentOrders.HighestAsk.Value * Strategy.LimitOrderValueRate / 100) - (LowestAskLimitPrice * CurrentOrders.HighestAsk.Value * (1 - Strategy.LimitOrderValueRate / 100) / AskSpan))/ Price)");
-            this.BidOrderAmountExpression = new SimpleExpression<decimal>("(CurrentOrders.LowestBid.Value * ((Strategy.LimitOrderValueRate / 100) - 1) / BidSpan) + ((CurrentOrders.LowestBid.Value * Strategy.LimitOrderValueRate / 100) - (HighestBidLimitPrice * CurrentOrders.LowestBid.Value * ((Strategy.LimitOrderValueRate / 100) - 1) / BidSpan))/ Price");
+            this.BidOrderAmountExpression = new SimpleExpression<decimal>("(CurrentOrders.LowestBid.Value * (Strategy.LimitOrderValueRate / 100 - 1) / BidSpan) + ((CurrentOrders.LowestBid.Value * Strategy.LimitOrderValueRate / 100) - (HighestBidLimitPrice * CurrentOrders.LowestBid.Value * (Strategy.LimitOrderValueRate / 100 - 1) / BidSpan))/ Price");
             this.VolumeResetLimitFactor = 1m;
             this.VolumeGrowthLimitFactor = 10m;
             this.VolumeGrowthRate = 5m;


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2027:CoursIA-2 — prev: MED/guards #15151

## Summary

Tranche **6B-4** de l'EPIC **#7357** (port Option C de `MyIA.Trading.Backtester` depuis upstream `MyIntelligenceAgency/Lean@612dddf9`, découplage Aricie, abandon des 6 DLL PKF) : port de la **couche stratégies Core** — 14 feuilles upstream dont `TradingStrategy.cs` (23,7 KB), le **market-maker à bande** dont prix et montants d'ordres sont calculés par expressions dynamiques évaluées contre le contexte de trading.

**Cette tranche porte l'arbitrage ai-01 (DM `msg-20260908T063013-jpt1yk`, c.988)** : le diagnostic c.986 qui optait pour un évaluateur récursif descendant maison était lacunaire — la lib Flee 2.0.0 EST utilisable, et c'est elle qui évalue les expressions runtime. Le commit d'amend `585e065931fd` (REPAIR amend Flee 2.0.0, SOTA-OK) remplace l'évaluateur maison par **l'adaptateur Flee** — 433 lignes maison ramenées à 75 lignes d'adaptateur, ratio `-380/+40`.

**Fichiers disjoints de 6B-3 (#15072, ouverte)** : cette branche est basée sur `main` et ne porte pas `BackTesting.cs` — aucune dépendance croisée (build et suite verte le prouvent), les deux PRs mergeront indépendamment.

## Changement (16 fichiers, +1337/-0 sur la PR ; -380/+40 sur l'amend SOTA-OK c.988)

| Fichier | Nature |
|---|---|
| `Core/SimpleExpression.cs` | **Adaptateur Flee 2.0.0** (75 lignes) — wrapper de `ExpressionContext` + `CompileGeneric<object>` puis `ConvertResult` typé statiquement |
| `Core/TradingStrategy.cs` | Port (bande market-maker, 23,7 KB) |
| `Core/TradingStrategies.cs` | Port — ProviderHost Aricie → liste plate |
| `Core/ComplexStrategy.cs`, `Core/CompoundTradingStrategy.cs`, `Core/IssueOrderStrategy.cs` | Ports |
| `Core/BandTradingContext.cs`, `Core/BandTradingStrategy.cs` | Ports |
| `Core/IArbitrageStrategy.cs`, `Core/ArbitrageInfo.cs`, `Core/OrdersDistribution.cs`, `Core/TradingBandDirection.cs`, `Core/TickerInfo.cs`, `Core/FeeBaseType.cs` | Ports verbatim |
| `Core/SimulationData.cs` | Port + **migration Newtonsoft du stub Jayrock** |
| `Tests/Strategies/BandStrategyLayerTests.cs` | **17 tests nouveaux** + 4 adaptés dialecte Flee + 3 adaptés type exception |

### SimpleExpression<T> — adaptateur Flee 2.0.0 (la pièce maîtresse amendée c.988)

L'évaluateur récursif descendant maison a été remplacé par **l'adaptateur Flee 2.0.0** (verdict **SOTA-OK**). Le moteur réel est `Flee.Expressions` ; `SimpleExpression<T>` est l'enveloppe qui (lecture firsthand `SimpleExpression.cs:51-58`) :

- construit un `ExpressionContext` typé (`TContext` du backtester — `BandTradingContext` pour `TradingStrategy`) et y expose les chemins de membres en **casse d'origine** (`LowestAsk`, `CurrentOrders`, `Strategy`) ;
- compile via `CompileGeneric<object>(Expression)` puis `Evaluate()` — le boxing en `object` est rendu nécessaire par la signature statique de `ConvertResult` qui distingue runtime-type de static-type ;
- le retour `object` est passé à `ConvertResult` (méthode privée `SimpleExpression.cs:60-82`) qui caste vers `T` typé statiquement via `is T` puis `Convert.ChangeType` si `decimal` (invariant culture), `Convert.ChangeType` générique si autre `IConvertible`, exception `InvalidOperationException` sinon.

**Trois lignes de configuration effectives (lecture firsthand `SimpleExpression.cs:52-54`, Tell `flee-2.0.0-pitfalls-fr-FR` MEMORY)** :

```csharp
c.ParserOptions.DecimalSeparator = '.';           // culture fr-FR piège n°1
c.ParserOptions.RecreateParser();                 // parser en cache piège n°2
c.Options.RealLiteralDataType = RealLiteralDataType.Decimal;  // piège n°3
```

**Dialecte Flee** (piège n°4) : `=`, `<>`, `and`, `or` — **pas** `==`, `!=`, `&&`, `||`. Les 4 fixtures bool de `BandStrategyLayerTests` ont été réécrites dans ce dialecte, assertions inchangées.

**Bidouille `BidOrderAmountExpression`** : `((X) - 1)` → `(X - 1)` pour contourner un bug Flee sur les parens imbriquées autour d'une expression suivie d'une soustraction unaire. Sémantique neutre (Tell `flee-2.0.0-pitfalls-fr-FR` MEMORY bug parens).

**Comportement** : littéraux `decimal` / `bool` / `string` ; chemins de membres résolus par réflexion **insensible à la casse** ; arithmétique strictement `decimal` ; comparaisons et logique pour les `SimpleExpression<bool>` de `ComplexStrategy.Condition`. Couverture identique à l'évaluateur maison, mais **par le vrai outil SOTA**.

### Note de relecture ai-01 (c.1009 — DM `msg-20260908T170648-nkhop6`)

Une relecture ai-01 du diff au SHA `6e19eb218f39` a relevé deux points que ce corps de PR n'avait pas explicités clairement, et qui sont consignés ici pour audit trail :

1. **Mécanisme réel vs description antérieure** : la docstring de `SimpleExpression.cs` (ligne 14) mentionnait `CompileGeneric<decimal>` ; le code, lui, a toujours compilé en `object` (ligne 56) puis casté via `ConvertResult`. La description de PR est alignée sur le **code réel** depuis cette dissipation (lecture firsthand `SimpleExpression.cs:51-82`).
2. **Bornage des tests fr-FR (c.1007)** : les 3 tests ajoutés à `BandStrategyLayerTests.cs` au commit `6e19eb218f39` vérifient la **compilation et l'évaluation des formules réelles sous culture fr-FR**, ainsi que la **valeur retournée** (encadrement plausible et `Equal(expected)` quand non discriminante). Ils **ne cherchent pas à prouver** que le runtime-type interne est `decimal` — la signature statique `SimpleExpression<T>` contraint déjà `T`, donc `IsType<T>(result)` est tautologique. Aucune garantie de précision interne (présence de `double` проміжний) n'est ici revendiquée ; aucun bug fonctionnel Flee n'a été démontré.

### Autres substitutions (inchangées depuis la version initiale)

- **`TradingStrategies`** : `ProviderHost<DotNetType<...>, ...>` (registre de types pour la grille UI DNN — `GetAvailableProviders`/`GetInitialTypes`) remplacé par `List<IContextualStrategy> Instances`. Le comportement porté (itération en séquence + enveloppe 4 arguments identique à `TradingStrategyBase`) est conservé à l'identique.
- **`IssueOrderStrategy`** : `ReflectionHelper.CloneObject<Order>` → `Order.DeepClone()` (pattern établi 6B-2/6B-3).
- **`Attributs de grille DNN`** (`ExtendedCategory`, `ConditionalVisible`, `AutoPostBack`, `Browsable`) : non portés — affichage seul, aucun comportement.
- **`SimulationData`** : l'upstream laissait les accesseurs `Market`/`Wallet` en **stub** (code Jayrock commenté, TODO « migrate to Newtonsoft json.net », retour d'objets vides). La migration est **portée effectivement** : désérialisation `Ticker`/`MarketDepth`/`Wallet` via Newtonsoft (déjà en solution), gardes sur JSON vide/invalide (retour objet vide, pas d'exception). Désérialisation directe des types à propriétés publiques plutôt que `TickerInfo` (dont le champ public `ticker` n'est pas couvert par le contract resolver par défaut).
- **Résidu Aricie** : `grep -rn "Aricie|DotNetNuke|ReflectionHelper|CloneObject"` sur le code porté → **0** (seuls les commentaires de doc expliquant les substitutions). Flee est désormais une dépendance explicite (paquet NuGet `Flee` 2.0.0), assumée.

## Tests — 112/112 verts rapportés (20 adaptés dialecte + exception Flee)

Base `main` : 92 tests verts. Cette branche : **109/109** rapportés (92 + 17 nouveaux). La suite 6B-1/6B-2 n'est pas touchée. **Suite complète post-rebase (c.1007) : 112/112 rapportée** (109 + 3 nouveaux fr-FR). Les mesures de suite sont rapportées par le worker (ce PR) et **n'ont pas été ré-exécutées par le coordinateur** — Tell c.1009 DM HIGH ai-01 strict.

### Substance fr-FR (c.1007 — DM ai-01 `msg-20260908T154205-dvke0a`, commit `6e19eb218f39`)

Suite à l'arbitrage ai-01 16:31Z (test fr-FR déterministe requis), **3 nouveaux tests déterministes fr-FR** ont été ajoutés à `BandStrategyLayerTests.cs` (commit `6e19eb218f39`, sur le head frais post-rebase). Aucun port Flee ni nouvelle partition créés. Pas de bibliothèque `UseCulture` supposée existante (Tell ai-01 strict) — la sauvegarde/restauration de `Thread.CurrentThread.CurrentCulture` est **inline** dans `try/finally` de chaque test.

**Bornage explicite (Tell ai-01 c.1009 strict)** : les 3 tests suivants **vérifient la compilation et l'évaluation des formules sous fr-FR**, et constatent que la **valeur retournée** tombe dans l'encadrement attendu. Ils **ne démontrent pas** l'absence de types проміжний (par ex. `double`) dans le pipeline Flee interne — la signature statique `SimpleExpression<T>` contraint déjà `T` au niveau de la signature de méthode, donc une assertion de runtime-type n'apporte aucune information discriminante. Aucune garantie de précision interne n'est ici revendiquée.

1. **`SimpleExpression_PricePlus010_StaysDecimalUnderFrenchCulture`** : force `CultureInfo.GetCultureInfo("fr-FR")` (NumberDecimalSeparator = "," par défaut), évalue `Price + 0.10`, vérifie que la valeur retournée vaut `100.10m` et que la compilation et l'évaluation s'exécutent sans erreur.
2. **`SimpleExpression_RealAskOrderAmountFormula_StaysDecimalUnderFrenchCulture`** : exerce la formule réelle d'`AskOrderAmountExpression` extraite verbatim de `TradingStrategy.cs:195` sous culture fr-FR, vérifie la compilation, l'évaluation et l'encadrement plausible du résultat.
3. **`SimpleExpression_RealBidOrderAmountFormula_StaysDecimalUnderFrenchCulture`** : exerce la formule réelle de `BidOrderAmountExpression` extraite verbatim de `TradingStrategy.cs:196` (forme corrigée `(X - 1)` qui contourne le bug parens Flee documenté au commit c.988) sous culture fr-FR, vérifie la compilation, l'évaluation et l'encadrement plausible du résultat.

**Suite complète post-rebase : 112/112 verts rapportés** (109 base + 3 nouveaux fr-FR). Wake amend-commit effectué c.1007 (`--force-with-lease` Tell c.886-L2 ★★★ sustained, lane unique po-2027 sur `feature/7357-tranche6b4-core-strategies`).

Les 17 tests (`BandStrategyLayerTests`) — 13 inchangés + 4 adaptés au dialecte Flee (`=`, `<>`, `and`, `or`) et 3 adaptés au type d'exception `ExpressionCompileException` (rejet à la compilation par Flee, plus tot que `InvalidOperationException` runtime par l'évaluateur maison) :

1. **Évaluateur** (5) : littéraux et précédence (`2 + 3 * 4` → 14, unaire, chaînes) ; chemins de membres casse-insensibles (`currentorders.highestask.price`, `Strategy.*` via `BandTradingContext`) ; comparaisons et logique (dialecte Flee) ; **les 12 formules constantes de distribution** vérifiées une à une sur un contexte synthétique ; conversions (`SimpleExpression<int>` `"2 * 3"` → 6) et erreurs nommées (expression vide, membre inconnu `UnknownMember`, `Price.Nope`, opérande bool en arithmétique `Price + true` → `ExpressionCompileException` à la compilation).
2. **Bande** (4) : défauts du constructeur (dont le point réel : le champ `OrdersDistribution` reste à `Custom` — le ctor ne pose que les formules, comportement upstream identique) ; switch de distribution (Constant/Exponential posent les 4 formules, retoucher une formule retombe sur `Custom`) ; **bande fraîche** : prix exacts attendus (ask à `Last × 1.30`, bid à `Last × 100/130`, montants calculés) ; **maintenance de bande** : la boucle Outwards émet l'escalier d'asks de `LowestAskLimitPrice` à `LowestAsk.Price` par pas `Price × 100/99` avec montants par l'expression par défaut `AskOrderAmountExpression` — le chemin qui exerce l'adaptateur Flee sur les vraies formules (dialecte `(X - 1)` pour `BidOrderAmountExpression`) ; hors bande → ordres d'annulation (sémantique : annulation réelle seulement pour un ordre portant un `Oid`).
3. **Enveloppes** (4) : `IssueOrderStrategy` (clone statique + 4 champs dynamiques dont `Type` int et `Oid` chaîne) ; `ComplexStrategy` (Condition gate l'application, `NewStatus` propagé aux wallets) ; `TradingStrategies` (séquence en ordre, enveloppe 4 arguments — le montant survit `FitOrders` : filtre `MinOrderAmount` 0.1 par défaut documenté).
4. **SimulationData** (2) : round-trip JSON complet (Ticker/Wallet restaurés à l'identique), JSON vides → objets vides sans exception.

## Validation

| Check | Résultat |
|---|---|
| Build | 0 erreur, 0 warning nouveau sur `MyIA.Trading.Backtester` |
| Tests | **112/112 rapportés** post-amend Flee + substance fr-FR (109 base + 3 nouveaux déterministes fr-FR) — non ré-exécutés par le coordinateur parent Tell c.1009 DM HIGH ai-01 strict |
| Résidu Aricie | **0** dans le code porté (Flee est la dépendance moteur assumée) |
| Verdict SOTA | **SOTA-OK** (Flee 2.0.0 = vrai outil, pas workaround dégradé) |
| Claim | `[CLAIMED]` 15:04Z + 2 `[CLAIMED-AMEND]` (finaux : +`SimpleExpression.cs` adaptateur Flee, +`TradingStrategy.cs` déjà présent) sur #7357 |
| L898 collision | 0 PR ouverte sur les chemins au claim ; seule PR du domaine = #15072 (ma lane, tranche 6B-3, fichiers disjoints) |
| B.3 proof-integrity | **non applicable** — aucun `*.lean` modifié |
| Catalogue | byte-identique à main (aucun fichier catalogue touché) |
| Arbitrage ai-01 (Flee) | DM `msg-20260908T063013-jpt1yk` tranche Option C → adaptateur Flee 2.0.0 |
| Arbitrage ai-01 (fr-FR) | DM `msg-20260908T154205-dvke0a` requiert couverture déterministe fr-FR → 3 tests livrés c.1007 (commit `6e19eb218f39`), sauvegarde/restauration culture inline (pas de bibliothèque `UseCulture`) |
| Relecture ai-01 (c.1009) | DM `msg-20260908T170648-nkhop6` aligne la prose sur le code réel (`CompileGeneric<object>` + `ConvertResult`), borne les tests fr-FR à la compilation/évaluation+valeur retournée (pas de revendication de type interne, pas de preuve de précision interne) |
| Suite post-rebase | `feature/7357-tranche6b4-core-strategies` rebased sur `origin/main` (Tell c.14566 strict REPAIR repart de main), `--force-with-lease` Tell c.886-L2 ★★★ sustained (lane unique po-2027) |

## Reste hors scope (tranches suivantes de #7357)

Couche commerciale (Account, Commercial*, OnlinePayment, WalletPayment, ExchangeCredentials, InitialWallet — la partie DNN la plus profonde), `Program.cs` (démo, dépend Utf8Json), `TradingData.cs` (dépend Accord.Math), README de fermeture. **État : 56/75 fichiers par chemin** après 6B-3 + 6B-4 (12 des 35 « manquants » Core étant déjà présents par contenu, consolidés 6A).

See #7357.
