### PR TITLE
fix(ci,#15058): cabler les tests de contrat ADK C4-C7 dans Scripts Tests (CPU)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -245,7 +245,6 @@ jobs:
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py \
             MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
-            MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils \
             scripts/secrets/tests \
             scripts/quantconnect/tests \
             GradeBookApp \
@@ -272,6 +271,22 @@ jobs:
             exit 1
           fi
           echo "OK: $N tests collected (floor=$AUDIT_TESTS_FLOOR)."
+
+      - name: Run ADK contract tests (isolated session)
+        # #15058 : les 52 tests du Track2-GoogleADK (contrats C4-C7 de
+        # #13572 + runtime + llm_client) tournent dans un process SEPARE.
+        # Raison : le track expose des noms de modules generiques au niveau
+        # racine (config/, utils/), et la session combinee ci-dessus collecte
+        # scripts/tests D'ABORD -- une suite y important un module `config`
+        # (non-package) pollue sys.modules pour tout le reste : la collecte
+        # du track meurt sur "No module named 'config.providers'; 'config'
+        # is not a package" (mesure sur le premier run de cette PR, job
+        # 101799171419). Process dedie = session hermetique dans les DEUX
+        # sens (le track ne pollue personne, personne ne le pollue), meme
+        # job, meme runner. Le plancher de collecte ci-dessous reste la
+        # garde deux-signaux de ce run.
+        run: |
+          pytest MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils --tb=short -q
 
       - name: ADK contract tests collection floor (52)
         # Companion guard of the #15058 re-cabling, same two-signal semantics

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -67,6 +67,11 @@ on:
       # its own subject (#10416 pattern, flagged A2 by Hermes on #11845).
       # Mirrored under pull_request: below.
       - '.github/workflows/pr-gate-rerun.yml'
+      # #15058 ADK contract tests (C4-C7): the measurement organ of #13572
+      # lives in Track2-GoogleADK/utils but ran in no CI job -- a contract
+      # change could land un-rattled. Wire the whole track subtree (the
+      # contracts are also exercised by labs). Mirrored under pull_request:.
+      - 'MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/**'
       # #12704 self-hosted policy: fork PR tokens cannot publish the fast-lane
       # check-runs. Keep one ordinary CI surface that executes the scanner for
       # every workflow change, including workflow-only PRs from forks.
@@ -96,6 +101,8 @@ on:
       - 'MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py'
       # #11835 no-op guard (mirror of the push path above).
       - '.github/workflows/pr-gate-rerun.yml'
+      # #15058 ADK contract tests (mirror of the push path above).
+      - 'MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/**'
       # Mirror the push path above so fork workflow-only PRs execute the policy.
       - '.github/workflows/**'
   workflow_dispatch:
@@ -180,6 +187,17 @@ jobs:
           # them at collection time (famille 5 de #14615). The test guards with
           # importorskip, but wiring it into this run means running it for real.
           pip install rapidfuzz unidecode openpyxl
+          # #15058 Track2-GoogleADK contract tests (C4-C7): the measurement
+          # organ of #13572. The two pins are the compatibility chain verified
+          # 2026-09-03 in Track2-GoogleADK/requirements.txt (#13948). Both are
+          # needed AT COLLECTION: test_adk_runtime_contracts.py imports
+          # google.adk, and utils/adk_runtime.py imports
+          # google.adk.models.lite_llm.LiteLlm, which imports litellm at module
+          # level. Without them the suite dies as a collection error -- the
+          # exact failure mode this workflow exists to prevent (issue #15058).
+          # pydantic-settings: config/providers.py imports BaseSettings at
+          # module level (same collection-time requirement).
+          pip install litellm==1.93.2 google-adk==2.8.0 pydantic-settings
 
       - name: Run tests
         # Scope to the scripts/ + notebook_tools/ suites this job is named for.
@@ -227,6 +245,7 @@ jobs:
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py \
             MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
+            MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils \
             scripts/secrets/tests \
             scripts/quantconnect/tests \
             GradeBookApp \
@@ -253,6 +272,27 @@ jobs:
             exit 1
           fi
           echo "OK: $N tests collected (floor=$AUDIT_TESTS_FLOOR)."
+
+      - name: ADK contract tests collection floor (52)
+        # Companion guard of the #15058 re-cabling, same two-signal semantics
+        # as the audit floor above: 0 collected = collection crash (import
+        # error masking the whole suite), below floor = coverage regression.
+        # The organ that does not collect cannot go red (#15058).
+        if: always()
+        env:
+          ADK_CONTRACTS_FLOOR: 52
+        run: |
+          N=$(python -m pytest MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils --collect-only -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ tests collected' | grep -oE '^[0-9]+')
+          if [ -z "$N" ] || [ "$N" -eq 0 ]; then
+            echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."
+            exit 1
+          fi
+          if [ "$N" -lt "$ADK_CONTRACTS_FLOOR" ]; then
+            echo "::error::Coverage regression: $N tests collected, floor=$ADK_CONTRACTS_FLOOR."
+            echo "::error::If the drop is intentional, lower ADK_CONTRACTS_FLOOR in the same PR."
+            exit 1
+          fi
+          echo "OK: $N tests collected (floor=$ADK_CONTRACTS_FLOOR)."
       # CI-EXCLUDED — testpaths pytest.ini non couverts par ce run, garde #10903.
       # Retirer la ligne du répertoire câblé (et l'ajouter au run ci-dessus) quand
       # l'herméticité est démontrée sur runner nu. scripts/audit/tests a été


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15031

## Câbler les tests de contrat ADK C4-C7 dans la CI (#15058)

Closes #15058

`test_adk_runtime_contracts.py` — l'organe de mesure prescrit par #13572 (« un contrat
n'est porté que si un test échoue quand on le retire ») — ne tournait dans aucun job
CI. Un organe qui ne tourne jamais ne rougit jamais : la lecture que #13572 prescrit
n'était pas disponible.

### Le câblage (40 lignes, 1 fichier : `.github/workflows/scripts-tests.yml`)

| Élément | Rôle |
|---|---|
| Chemin de déclenchement `Track2-GoogleADK/**` (push **et** pull_request, miroir commenté) | le job part quand le sujet bouge — un contrat retiré dans le track rougit au push qui le retire |
| `pip install litellm==1.93.2 google-adk==2.8.0 pydantic-settings` | ferme le mode d'échec par **collecte** (voir justification du choix ci-dessous) |
| Step dédié « Run ADK contract tests (isolated session) » | **52 tests** : 16 contrats C1-C7 + 15 `test_adk_runtime.py` + 21 `test_llm_client.py` (tous hermétiques — network mocké `@patch("utils.llm_client.completion")`, LLM scripté). Process **séparé** de la session combinée : le track expose des noms de modules génériques au niveau racine (`config/`, `utils/`) et la session combinée collecte `scripts/tests` d'abord — un module `config` non-package y pollue `sys.modules` et fait mourir la collecte du track sur `No module named 'config.providers'; 'config' is not a package` (**mesuré sur le premier run de cette PR**, job 101799171419, corrigé par l'isolation — le workshop appelle ce mode d'échec celui que le workflow existe pour empêcher) |
| Garde « ADK contract tests collection floor (52) » | même sémantique deux-signaux que le plancher audit 455 : 0 collecté = crash de collecte (distinct d'une chute de couverture), < plancher = régression de couverture |

### Pourquoi l'installation des pins plutôt que le découplage (acceptance §2, choix justifié)

Le découplage de `utils/__init__.py` ne suffit pas : `utils/adk_runtime.py` importe
`google.adk.models.lite_llm.LiteLlm`, qui importe `litellm` au niveau module — et le
fichier de tests importe `google.adk` directement à la collecte. Ces tests exercent le
**vrai runtime ADK 2.8** (Runner, InMemorySessionService, auto-function-calling) :
google-adk doit être installé dans le job quoi qu'il arrive ; litellm arrive par la
même ligne (chaîne de compatibilité vérifiée 2026-09-03, `Track2-GoogleADK/requirements.txt` #13948),
pydantic-settings parce que `config/providers.py` importe `BaseSettings` au niveau module.
Aucun `continue-on-error`, aucun `|| true` : l'organe parle vraiment.

### Contrôle positif (acceptance §3, règle anti-regression « un détecteur se valide par ses faux négatifs »)

Mutation locale = celle que la docstring du test C5 documente (« build_agent cesse de
passer sub_agents ») :

```text
$ # mutation : retrait de "sub_agents=list(sub_agents)," dans build_agent
FAILED ...::test_c5_sub_agents_wire_handoff_and_it_is_observable
1 failed, 15 passed in 4.29s
$ # revert -> 54 passed (52 du track + 2 de la suite voisine)
```

L'organe câblé sait rougir : exactement le test du contrat muté échoue, rien d'autre.

### Validation locale (venv hermétique, pins exacts du job)

```text
52 tests collected in 3.74s          (test_adk_runtime_contracts=16, test_adk_runtime=15, test_llm_client=21)
54 passed, 1 warning in 4.85s        (+ 01-PythonForDataScience/tests dans la même session : 0 collision de modules utils/config)
```

### Résiduel (acceptance §4)

Le tableau des contrats de #13572 doit citer le job `Scripts Tests (CPU)` qui les
mesure — commentaire à poster sur #13572 dès le run CI vert cité (URL du run en
commentaire de suivi sur la PR).

### Ce que la PR ne touche pas

- Aucun fichier du track (le câblage est pur workflow ; les 52 tests et leur sujet
  sont inchangés, byte-identiques à main).
- Aucun pin modifié dans `requirements.txt`.
