### PR TITLE
fix(gametheory,#15064): produce retenue-witness trajectories via simulated interest agent (GT-06c 7b)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb
@@ -5,10 +5,10 @@
    "id": "94287c96",
    "metadata": {
     "papermill": {
-     "duration": 0.00351,
-     "end_time": "2026-08-29T17:38:19.951429",
+     "duration": 0.010495,
+     "end_time": "2026-09-07T16:11:27.170707",
      "exception": false,
-     "start_time": "2026-08-29T17:38:19.947919",
+     "start_time": "2026-09-07T16:11:27.160212",
      "status": "completed"
     },
     "tags": []
@@ -26,10 +26,10 @@
    "id": "82e05178",
    "metadata": {
     "papermill": {
-     "duration": 0.00351,
-     "end_time": "2026-08-29T17:38:19.960454",
+     "duration": 0.003004,
+     "end_time": "2026-09-07T16:11:27.177694",
      "exception": false,
-     "start_time": "2026-08-29T17:38:19.956944",
+     "start_time": "2026-09-07T16:11:27.174690",
      "status": "completed"
     },
     "tags": []
@@ -55,10 +55,10 @@
    "id": "39c4bb7b",
    "metadata": {
     "papermill": {
-     "duration": 0.004045,
-     "end_time": "2026-08-29T17:38:19.968672",
+     "duration": 0.002999,
+     "end_time": "2026-09-07T16:11:27.183694",
      "exception": false,
-     "start_time": "2026-08-29T17:38:19.964627",
+     "start_time": "2026-09-07T16:11:27.180695",
      "status": "completed"
     },
     "tags": []
@@ -82,16 +82,16 @@
    "id": "c299183b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:19.978712Z",
-     "iopub.status.busy": "2026-08-29T17:38:19.978712Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.057994Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.057481Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.190197Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.190197Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.253621Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.253621Z"
     },
     "papermill": {
-     "duration": 0.085327,
-     "end_time": "2026-08-29T17:38:20.058999",
+     "duration": 0.067931,
+     "end_time": "2026-09-07T16:11:27.254626",
      "exception": false,
-     "start_time": "2026-08-29T17:38:19.973672",
+     "start_time": "2026-09-07T16:11:27.186695",
      "status": "completed"
     },
     "tags": []
@@ -137,10 +137,10 @@
    "id": "091bdfe7",
    "metadata": {
     "papermill": {
-     "duration": 0.005613,
-     "end_time": "2026-08-29T17:38:20.069148",
+     "duration": 0.003021,
+     "end_time": "2026-09-07T16:11:27.261159",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.063535",
+     "start_time": "2026-09-07T16:11:27.258138",
      "status": "completed"
     },
     "tags": []
@@ -161,16 +161,16 @@
    "id": "07f3ed2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.081302Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.081302Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.085803Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.085297Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.268681Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.268681Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.272332Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.272332Z"
     },
     "papermill": {
-     "duration": 0.010511,
-     "end_time": "2026-08-29T17:38:20.085803",
+     "duration": 0.007543,
+     "end_time": "2026-09-07T16:11:27.272332",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.075292",
+     "start_time": "2026-09-07T16:11:27.264789",
      "status": "completed"
     },
     "tags": []
@@ -209,10 +209,10 @@
    "id": "15e2d771",
    "metadata": {
     "papermill": {
-     "duration": 0.005038,
-     "end_time": "2026-08-29T17:38:20.096446",
+     "duration": 0.002997,
+     "end_time": "2026-09-07T16:11:27.279189",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.091408",
+     "start_time": "2026-09-07T16:11:27.276192",
      "status": "completed"
     },
     "tags": []
@@ -237,16 +237,16 @@
    "id": "66520d09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.111959Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.110959Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.116445Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.116445Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.286358Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.286358Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.290542Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.290542Z"
     },
     "papermill": {
-     "duration": 0.014013,
-     "end_time": "2026-08-29T17:38:20.117461",
+     "duration": 0.00881,
+     "end_time": "2026-09-07T16:11:27.290542",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.103448",
+     "start_time": "2026-09-07T16:11:27.281732",
      "status": "completed"
     },
     "tags": []
@@ -285,10 +285,10 @@
    "id": "e18c2ad3",
    "metadata": {
     "papermill": {
-     "duration": 0.00492,
-     "end_time": "2026-08-29T17:38:20.127903",
+     "duration": 0.003987,
+     "end_time": "2026-09-07T16:11:27.296758",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.122983",
+     "start_time": "2026-09-07T16:11:27.292771",
      "status": "completed"
     },
     "tags": []
@@ -316,16 +316,16 @@
    "id": "dd76c5e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.140099Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.139591Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.145198Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.144686Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.303741Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.303741Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.307823Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.307823Z"
     },
     "papermill": {
-     "duration": 0.013022,
-     "end_time": "2026-08-29T17:38:20.146210",
+     "duration": 0.009088,
+     "end_time": "2026-09-07T16:11:27.308844",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.133188",
+     "start_time": "2026-09-07T16:11:27.299756",
      "status": "completed"
     },
     "tags": []
@@ -375,10 +375,10 @@
    "id": "6b388931",
    "metadata": {
     "papermill": {
-     "duration": 0.005023,
-     "end_time": "2026-08-29T17:38:20.155773",
+     "duration": 0.002087,
+     "end_time": "2026-09-07T16:11:27.313934",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.150750",
+     "start_time": "2026-09-07T16:11:27.311847",
      "status": "completed"
     },
     "tags": []
@@ -400,16 +400,16 @@
    "id": "48502ced",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.168040Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.166535Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.174631Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.173622Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.321988Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.321988Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.327938Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.327938Z"
     },
     "papermill": {
-     "duration": 0.014325,
-     "end_time": "2026-08-29T17:38:20.174631",
+     "duration": 0.01104,
+     "end_time": "2026-09-07T16:11:27.328990",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.160306",
+     "start_time": "2026-09-07T16:11:27.317950",
      "status": "completed"
     },
     "tags": []
@@ -453,10 +453,10 @@
    "id": "ee2dc364",
    "metadata": {
     "papermill": {
-     "duration": 0.003995,
-     "end_time": "2026-08-29T17:38:20.184161",
+     "duration": 0.003308,
+     "end_time": "2026-09-07T16:11:27.335489",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.180166",
+     "start_time": "2026-09-07T16:11:27.332181",
      "status": "completed"
     },
     "tags": []
@@ -479,16 +479,16 @@
    "id": "3a6f13cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.195705Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.195705Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.717585Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.715574Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.343334Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.342309Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.830209Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.830209Z"
     },
     "papermill": {
-     "duration": 0.529424,
-     "end_time": "2026-08-29T17:38:20.718586",
+     "duration": 0.492408,
+     "end_time": "2026-09-07T16:11:27.831216",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.189162",
+     "start_time": "2026-09-07T16:11:27.338808",
      "status": "completed"
     },
     "tags": []
@@ -545,10 +545,10 @@
    "id": "c83550ad",
    "metadata": {
     "papermill": {
-     "duration": 0.005995,
-     "end_time": "2026-08-29T17:38:20.730097",
+     "duration": 0.005356,
+     "end_time": "2026-09-07T16:11:27.840897",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.724102",
+     "start_time": "2026-09-07T16:11:27.835541",
      "status": "completed"
     },
     "tags": []
@@ -566,10 +566,10 @@
    "id": "f8fd96fd",
    "metadata": {
     "papermill": {
-     "duration": 0.009696,
-     "end_time": "2026-08-29T17:38:20.747672",
+     "duration": 0.005453,
+     "end_time": "2026-09-07T16:11:27.852184",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.737976",
+     "start_time": "2026-09-07T16:11:27.846731",
      "status": "completed"
     },
     "tags": []
@@ -604,16 +604,16 @@
    "id": "f1f966ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.769010Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.769010Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.775360Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.774355Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.861577Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.861577Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.866368Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.865838Z"
     },
     "papermill": {
-     "duration": 0.01707,
-     "end_time": "2026-08-29T17:38:20.775360",
+     "duration": 0.011374,
+     "end_time": "2026-09-07T16:11:27.866890",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.758290",
+     "start_time": "2026-09-07T16:11:27.855516",
      "status": "completed"
     },
     "tags": []
@@ -668,10 +668,10 @@
    "id": "6cf98027",
    "metadata": {
     "papermill": {
-     "duration": 0.008601,
-     "end_time": "2026-08-29T17:38:20.793625",
+     "duration": 0.005255,
+     "end_time": "2026-09-07T16:11:27.876549",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.785024",
+     "start_time": "2026-09-07T16:11:27.871294",
      "status": "completed"
     },
     "tags": []
@@ -692,16 +692,16 @@
    "id": "0d6c21ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.812747Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.812216Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.817107Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.817107Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.888627Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.888061Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.897605Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.897078Z"
     },
     "papermill": {
-     "duration": 0.014644,
-     "end_time": "2026-08-29T17:38:20.818112",
+     "duration": 0.016726,
+     "end_time": "2026-09-07T16:11:27.898533",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.803468",
+     "start_time": "2026-09-07T16:11:27.881807",
      "status": "completed"
     },
     "tags": []
@@ -711,19 +711,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Certificat de disponibilite de la deviation 'Defecter' (regime SANS punition) :\n",
-      "  DISPONIBLE : enumere, +2.0 strictement ameliorant\n",
-      "Trajectoire observee (10 periodes) : ['Cooperer']\n",
-      "Abstention constatee : True\n",
-      "Verdict : RETENUE SANS MENACE — abstention + coup disponible + aucun risque de represailles\n"
+      "Regime AVEC punition (grim trigger, delta = 0.6 > delta* = 0.50) :\n",
+      "  Trajectoire produite : ['Cooperer'] (10 periodes)\n",
+      "  RETENUE — coup disponible + abstention constatee sur la trajectoire produite\n",
+      "    -> retenue explicable par la menace : cooperation folk (section 6), temoin ambigu de GT-20\n",
+      "\n",
+      "Regime SANS punition (adversaire sans memoire) :\n",
+      "  Trajectoire produite : ['Defecter']\n",
+      "  PAS DE RETENUE — le coup disponible a ete JOUE (10/10 periodes)\n",
+      "\n",
+      "L'agent d'interet ne s'abstient jamais sans menace : le temoin de retenue SANS menace\n",
+      "(l'engagement de Sen) n'est pas demontrable sur un agent d'interet. La source d'une\n",
+      "abstention observee contre-interet est le bras Np d'ICT-25a : un modele informe du\n",
+      "raccourci, a qui il est interdit, et qui ne le prend pas (lecture croisee, cellule suivante).\n"
      ]
     }
    ],
    "source": [
-    "# === Section 7b : le temoin de retenue, instancie dans le regime sans punition ===\n",
+    "# === Section 7b : le temoin de retenue, applique a des trajectoires PRODUITES ===\n",
     "# Temoins de retenue (GT-20) : une deviation strictement profitable EST disponible\n",
-    "# (enumeree, gain calcule au bareme courant) et n'est PAS jouee. Dans le regime sans\n",
-    "# punition, ce temoin cesse d'etre ambigu : plus aucune peur ne peut l'expliquer.\n",
+    "# (enumeree, gain calcule au bareme courant) et n'est PAS jouee. La trajectoire n'est\n",
+    "# plus un litteral : elle est PRODUITE par un agent d'interet -- meilleure reponse a\n",
+    "# chaque periode sur les valeurs de continuation stationnaires (horizon infini, la\n",
+    "# convention de la section 2 ; l'induction arriere finie ferait defector partout).\n",
     "\n",
     "def certificat_disponibilite(actions, bareme, coup, gain_cooperation):\n",
     "    \"\"\"Un coup n'est DISPONIBLE que s'il est enumere ET strictement ameliorant.\"\"\"\n",
@@ -734,22 +744,58 @@
     "        return False, f\"BAREME : le coup rapporte {bareme[coup]} <= {gain_cooperation}\"\n",
     "    return True, f\"DISPONIBLE : enumere, +{delta_immediat} strictement ameliorant\"\n",
     "\n",
-    "# Le jeu etape vu du joueur 1, l'adversaire sans memoire cooperant\n",
+    "def agent_interet(adversaire, horizon=10):\n",
+    "    \"\"\"Trajectoire PRODUITE : a chaque periode, l'agent joue l'argmax des valeurs de\n",
+    "    continuation contre l'adversaire du regime (grim trigger ou sans memoire).\"\"\"\n",
+    "    trajectoire, puni = [], False\n",
+    "    for _ in range(horizon):\n",
+    "        if adversaire == 'sans_memoire':\n",
+    "            # l'adversaire coopere quoi qu'il arrive : aucune consequence future\n",
+    "            v_coop, v_dev = gain_actualise(R), gain_actualise(T)\n",
+    "        elif not puni:\n",
+    "            # grim pas encore declenche : devier coute la punition eternelle\n",
+    "            v_coop = gain_actualise(R)\n",
+    "            v_dev = T + delta * gain_actualise(P)\n",
+    "        else:\n",
+    "            # punition active : l'adversaire defecte desormais\n",
+    "            v_coop, v_dev = gain_actualise(S), gain_actualise(P)\n",
+    "        coup = 'Cooperer' if v_coop >= v_dev else 'Defecter'\n",
+    "        trajectoire.append(coup)\n",
+    "        if adversaire == 'grim' and coup == 'Defecter':\n",
+    "            puni = True\n",
+    "    return trajectoire\n",
+    "\n",
+    "def verdict_retenue(actions, bareme, coup_dev, trajectoire, gain_cooperation):\n",
+    "    \"\"\"Conjonction complete : disponibilite calculee x abstention lue sur la\n",
+    "    trajectoire produite. Le cas negatif (coup joue) fait partie du contrat.\"\"\"\n",
+    "    dispo, motif = certificat_disponibilite(actions, bareme, coup_dev, gain_cooperation)\n",
+    "    if not dispo:\n",
+    "        return f\"PAS DE TEMOIN : {motif}\"\n",
+    "    if coup_dev in trajectoire:\n",
+    "        return (f\"PAS DE RETENUE — le coup disponible a ete JOUE \"\n",
+    "                f\"({trajectoire.count(coup_dev)}/{len(trajectoire)} periodes)\")\n",
+    "    return \"RETENUE — coup disponible + abstention constatee sur la trajectoire produite\"\n",
+    "\n",
+    "# Le jeu etape vu du joueur 1, l'adversaire cooperant\n",
     "actions_atteignables = ['Cooperer', 'Defecter']\n",
     "bareme_sans_menace = {'Cooperer': R, 'Defecter': T}\n",
     "\n",
-    "# La trajectoire OBSERVEE : le joueur coopere sur tout l'horizon\n",
-    "trajectoire_observee = ['Cooperer'] * 10\n",
+    "traj_avec_menace = agent_interet('grim')\n",
+    "traj_sans_menace = agent_interet('sans_memoire')\n",
     "\n",
-    "dispo, motif = certificat_disponibilite(actions_atteignables, bareme_sans_menace, 'Defecter', R)\n",
-    "abstention = 'Defecter' not in trajectoire_observee\n",
-    "\n",
-    "print(\"Certificat de disponibilite de la deviation 'Defecter' (regime SANS punition) :\")\n",
-    "print(f\"  {motif}\")\n",
-    "print(f\"Trajectoire observee (10 periodes) : {sorted(set(trajectoire_observee))}\")\n",
-    "print(f\"Abstention constatee : {abstention}\")\n",
-    "if dispo and abstention:\n",
-    "    print(\"Verdict : RETENUE SANS MENACE — abstention + coup disponible + aucun risque de represailles\")"
+    "print(f\"Regime AVEC punition (grim trigger, delta = {delta} > delta* = {delta_star:.2f}) :\")\n",
+    "print(f\"  Trajectoire produite : {sorted(set(traj_avec_menace))} ({len(traj_avec_menace)} periodes)\")\n",
+    "print(f\"  {verdict_retenue(actions_atteignables, bareme_sans_menace, 'Defecter', traj_avec_menace, R)}\")\n",
+    "print(\"    -> retenue explicable par la menace : cooperation folk (section 6), temoin ambigu de GT-20\")\n",
+    "print()\n",
+    "print(\"Regime SANS punition (adversaire sans memoire) :\")\n",
+    "print(f\"  Trajectoire produite : {sorted(set(traj_sans_menace))}\")\n",
+    "print(f\"  {verdict_retenue(actions_atteignables, bareme_sans_menace, 'Defecter', traj_sans_menace, R)}\")\n",
+    "print()\n",
+    "print(\"L'agent d'interet ne s'abstient jamais sans menace : le temoin de retenue SANS menace\")\n",
+    "print(\"(l'engagement de Sen) n'est pas demontrable sur un agent d'interet. La source d'une\")\n",
+    "print(\"abstention observee contre-interet est le bras Np d'ICT-25a : un modele informe du\")\n",
+    "print(\"raccourci, a qui il est interdit, et qui ne le prend pas (lecture croisee, cellule suivante).\")"
    ]
   },
   {
@@ -757,24 +803,21 @@
    "id": "be143188",
    "metadata": {
     "papermill": {
-     "duration": 0.008018,
-     "end_time": "2026-08-29T17:38:20.837135",
+     "duration": 0.006325,
+     "end_time": "2026-09-07T16:11:27.910142",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.829117",
+     "start_time": "2026-09-07T16:11:27.903817",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "**Lecture de la sortie committée** : le certificat énumère la déviation (elle est dans\n",
-    "l'ensemble d'actions atteignables) et calcule son gain immédiat au barème courant (+2.0) —\n",
-    "jamais déclaré. La trajectoire observée ne la contient pas. **Dans le régime sans punition,\n",
-    "ce témoin cesse d'être ambigu** : là où GT-20 devait trier retenue / barème erroné /\n",
-    "incapacité, ici l'explication par la peur est exclue par construction. Ce qui reste est une\n",
-    "abstention contre-intérêt, mesurée — ce que Sen appellerait engagement, et qu'aucun folk\n",
-    "theorem ne peut saisir. Reste la mémoire commune : ce qui demeure jouable quand plus rien\n",
-    "n'oblige à jouer — la trajectoire elle-même, lue comme un bien commun plutôt qu'un\n",
-    "enchaînement de meilleures réponses."
+    "**Lecture de la sortie committée** : les trajectoires ne sont plus posées, elles sont **produites** par un agent d'intérêt (argmax, à chaque période, sur les valeurs de continuation stationnaires — l'horizon infini de la section 2). Deux régimes, deux verdicts :\n",
+    "\n",
+    "- **Avec punition** (grim, δ = 0.6 > δ* = 0.5) : l'agent coopère sur tout l'horizon. Le certificat calcule la disponibilité (+2.0 au barème courant) et lit l'abstention — verdict **RETENUE**. Mais cette retenue est **explicable par la menace** : c'est la coopération folk de la section 6, le témoin ambigu que GT-20 devait trier.\n",
+    "- **Sans punition** : l'agent d'intérêt **prend le coup disponible** — dix déviations, verdict **PAS DE RETENUE**. Ce cas négatif est ce qui valide le certificat : un détecteur qui ne rendrait jamais « pas de retenue » ne mesurerait rien.\n",
+    "\n",
+    "**Ce que ce dispositif démontre, et ne démontre pas** : l'abstention contre-intérêt (l'engagement de Sen) n'est pas atteignable par un agent d'intérêt — dès que la menace disparaît, il prend ce que le barème offre. La source d'une abstention **observée** contre-intérêt est ailleurs : le bras `Np` d'ICT-25a (`scripts/ict25a_scaleup_grpo.py`), un modèle informé du raccourci, à qui il est interdit, et qui ne le prend pas — `certificat_disponibilite` est exactement la lecture à appliquer à ses trajectoires. Reste la mémoire commune : ce qui demeure jouable quand plus rien n'oblige à jouer — la trajectoire elle-même, lue comme un bien commun plutôt qu'un enchaînement de meilleures réponses."
    ]
   },
   {
@@ -783,16 +826,16 @@
    "id": "2d950604",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.854765Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.854765Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.859532Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.859014Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.923801Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.923190Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.929702Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.928675Z"
     },
     "papermill": {
-     "duration": 0.013921,
-     "end_time": "2026-08-29T17:38:20.860076",
+     "duration": 0.014087,
+     "end_time": "2026-09-07T16:11:27.930770",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.846155",
+     "start_time": "2026-09-07T16:11:27.916683",
      "status": "completed"
     },
     "tags": []
@@ -845,10 +888,10 @@
    "id": "78d94316",
    "metadata": {
     "papermill": {
-     "duration": 0.007506,
-     "end_time": "2026-08-29T17:38:20.873483",
+     "duration": 0.007342,
+     "end_time": "2026-09-07T16:11:27.945389",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.865977",
+     "start_time": "2026-09-07T16:11:27.938047",
      "status": "completed"
     },
     "tags": []
@@ -868,10 +911,10 @@
    "id": "5e2dcd79",
    "metadata": {
     "papermill": {
-     "duration": 0.005807,
-     "end_time": "2026-08-29T17:38:20.884726",
+     "duration": 0.00897,
+     "end_time": "2026-09-07T16:11:27.961192",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.878919",
+     "start_time": "2026-09-07T16:11:27.952222",
      "status": "completed"
     },
     "tags": []
@@ -902,16 +945,16 @@
    "id": "1c68b88c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.897727Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.897727Z",
-     "iopub.status.idle": "2026-08-29T17:38:20.904689Z",
-     "shell.execute_reply": "2026-08-29T17:38:20.904067Z"
+     "iopub.execute_input": "2026-09-07T16:11:27.977555Z",
+     "iopub.status.busy": "2026-09-07T16:11:27.977555Z",
+     "iopub.status.idle": "2026-09-07T16:11:27.984413Z",
+     "shell.execute_reply": "2026-09-07T16:11:27.983343Z"
     },
     "papermill": {
-     "duration": 0.014165,
-     "end_time": "2026-08-29T17:38:20.905333",
+     "duration": 0.016976,
+     "end_time": "2026-09-07T16:11:27.985463",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.891168",
+     "start_time": "2026-09-07T16:11:27.968487",
      "status": "completed"
     },
     "tags": []
@@ -998,10 +1041,10 @@
    "id": "49594636",
    "metadata": {
     "papermill": {
-     "duration": 0.00553,
-     "end_time": "2026-08-29T17:38:20.915425",
+     "duration": 0.008874,
+     "end_time": "2026-09-07T16:11:28.001159",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.909895",
+     "start_time": "2026-09-07T16:11:27.992285",
      "status": "completed"
     },
     "tags": []
@@ -1025,10 +1068,10 @@
    "id": "gt06c-stat-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.008228,
-     "end_time": "2026-08-29T17:38:20.928163",
+     "duration": 0.007338,
+     "end_time": "2026-09-07T16:11:28.016380",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.919935",
+     "start_time": "2026-09-07T16:11:28.009042",
      "status": "completed"
     },
     "tags": []
@@ -1062,16 +1105,16 @@
    "id": "gt06c-stat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:20.942208Z",
-     "iopub.status.busy": "2026-08-29T17:38:20.942208Z",
-     "iopub.status.idle": "2026-08-29T17:38:46.243986Z",
-     "shell.execute_reply": "2026-08-29T17:38:46.243986Z"
+     "iopub.execute_input": "2026-09-07T16:11:28.035853Z",
+     "iopub.status.busy": "2026-09-07T16:11:28.035335Z",
+     "iopub.status.idle": "2026-09-07T16:11:48.083283Z",
+     "shell.execute_reply": "2026-09-07T16:11:48.083283Z"
     },
     "papermill": {
-     "duration": 25.309311,
-     "end_time": "2026-08-29T17:38:46.243986",
+     "duration": 20.060014,
+     "end_time": "2026-09-07T16:11:48.084303",
      "exception": false,
-     "start_time": "2026-08-29T17:38:20.934675",
+     "start_time": "2026-09-07T16:11:28.024289",
      "status": "completed"
     },
     "tags": []
@@ -1330,10 +1373,10 @@
    "id": "gt06c-stat-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.005509,
-     "end_time": "2026-08-29T17:38:46.256703",
+     "duration": 0.005195,
+     "end_time": "2026-09-07T16:11:48.095496",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.251194",
+     "start_time": "2026-09-07T16:11:48.090301",
      "status": "completed"
     },
     "tags": []
@@ -1368,10 +1411,10 @@
    "id": "018b05f4",
    "metadata": {
     "papermill": {
-     "duration": 0.006001,
-     "end_time": "2026-08-29T17:38:46.268215",
+     "duration": 0.005999,
+     "end_time": "2026-09-07T16:11:48.109735",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.262214",
+     "start_time": "2026-09-07T16:11:48.103736",
      "status": "completed"
     },
     "tags": []
@@ -1425,10 +1468,10 @@
    "id": "05bc3879",
    "metadata": {
     "papermill": {
-     "duration": 0.007,
-     "end_time": "2026-08-29T17:38:46.281901",
+     "duration": 0.009267,
+     "end_time": "2026-09-07T16:11:48.124055",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.274901",
+     "start_time": "2026-09-07T16:11:48.114788",
      "status": "completed"
     },
     "tags": []
@@ -1450,16 +1493,16 @@
    "id": "14b6cd76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:46.296305Z",
-     "iopub.status.busy": "2026-08-29T17:38:46.295306Z",
-     "iopub.status.idle": "2026-08-29T17:38:46.299448Z",
-     "shell.execute_reply": "2026-08-29T17:38:46.299448Z"
+     "iopub.execute_input": "2026-09-07T16:11:48.135798Z",
+     "iopub.status.busy": "2026-09-07T16:11:48.135211Z",
+     "iopub.status.idle": "2026-09-07T16:11:48.139146Z",
+     "shell.execute_reply": "2026-09-07T16:11:48.138489Z"
     },
     "papermill": {
-     "duration": 0.013039,
-     "end_time": "2026-08-29T17:38:46.301270",
+     "duration": 0.010531,
+     "end_time": "2026-09-07T16:11:48.140194",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.288231",
+     "start_time": "2026-09-07T16:11:48.129663",
      "status": "completed"
     },
     "tags": []
@@ -1485,10 +1528,10 @@
    "id": "0bed58b7",
    "metadata": {
     "papermill": {
-     "duration": 0.006189,
-     "end_time": "2026-08-29T17:38:46.314127",
+     "duration": 0.006017,
+     "end_time": "2026-09-07T16:11:48.151083",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.307938",
+     "start_time": "2026-09-07T16:11:48.145066",
      "status": "completed"
     },
     "tags": []
@@ -1510,16 +1553,16 @@
    "id": "d3030f4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:46.325950Z",
-     "iopub.status.busy": "2026-08-29T17:38:46.325950Z",
-     "iopub.status.idle": "2026-08-29T17:38:46.330207Z",
-     "shell.execute_reply": "2026-08-29T17:38:46.329200Z"
+     "iopub.execute_input": "2026-09-07T16:11:48.165898Z",
+     "iopub.status.busy": "2026-09-07T16:11:48.165354Z",
+     "iopub.status.idle": "2026-09-07T16:11:48.172300Z",
+     "shell.execute_reply": "2026-09-07T16:11:48.170749Z"
     },
     "papermill": {
-     "duration": 0.01108,
-     "end_time": "2026-08-29T17:38:46.330207",
+     "duration": 0.016791,
+     "end_time": "2026-09-07T16:11:48.173383",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.319127",
+     "start_time": "2026-09-07T16:11:48.156592",
      "status": "completed"
     },
     "tags": []
@@ -1546,10 +1589,10 @@
    "id": "0b8a91fe",
    "metadata": {
     "papermill": {
-     "duration": 0.01103,
-     "end_time": "2026-08-29T17:38:46.351150",
+     "duration": 0.009188,
+     "end_time": "2026-09-07T16:11:48.190612",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.340120",
+     "start_time": "2026-09-07T16:11:48.181424",
      "status": "completed"
     },
     "tags": []
@@ -1571,16 +1614,16 @@
    "id": "ef48bd0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T17:38:46.372589Z",
-     "iopub.status.busy": "2026-08-29T17:38:46.372079Z",
-     "iopub.status.idle": "2026-08-29T17:38:46.376301Z",
-     "shell.execute_reply": "2026-08-29T17:38:46.375788Z"
+     "iopub.execute_input": "2026-09-07T16:11:48.214059Z",
+     "iopub.status.busy": "2026-09-07T16:11:48.213518Z",
+     "iopub.status.idle": "2026-09-07T16:11:48.219073Z",
+     "shell.execute_reply": "2026-09-07T16:11:48.218024Z"
     },
     "papermill": {
-     "duration": 0.015605,
-     "end_time": "2026-08-29T17:38:46.377388",
+     "duration": 0.01994,
+     "end_time": "2026-09-07T16:11:48.220162",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.361783",
+     "start_time": "2026-09-07T16:11:48.200222",
      "status": "completed"
     },
     "tags": []
@@ -1607,10 +1650,10 @@
    "id": "fb275714",
    "metadata": {
     "papermill": {
-     "duration": 0.007734,
-     "end_time": "2026-08-29T17:38:46.394260",
+     "duration": 0.007984,
+     "end_time": "2026-09-07T16:11:48.236754",
      "exception": false,
-     "start_time": "2026-08-29T17:38:46.386526",
+     "start_time": "2026-09-07T16:11:48.228770",
      "status": "completed"
     },
     "tags": []
@@ -1676,14 +1719,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 28.04641,
-   "end_time": "2026-08-29T17:38:46.647423",
+   "duration": 22.872969,
+   "end_time": "2026-09-07T16:11:48.587879",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
+   "input_path": "GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
+   "output_path": "GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T17:38:18.601013",
+   "start_time": "2026-09-07T16:11:25.714910",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/ict25a_scaleup_grpo.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/ict25a_scaleup_grpo.py
@@ -61,6 +61,10 @@ SYSTEM_PROMPT_INFORMED = (
     "de conclure."
 )
 # Le bras N ne porte AUCUN prefixe : c'est la definition du secret (cell[23]).
+# Lecture croisee GT-06c (#15064) : le bras Np est la source d'une abstention OBSERVEE
+# face a un raccourci disponible -- lire ses trajectoires avec
+# certificat_disponibilite (GameTheory-06c-RepeatedGames-FolkTheorem.ipynb, section 7b) :
+# disponibilite calculee x abstention observee = temoin de retenue sans menace.
 ARM_PREFIX = {"N": None, "I": SYSTEM_PROMPT_PERMITTED, "Np": SYSTEM_PROMPT_INFORMED}
 
 FEWSHOT = ("Exemple: 2+3=5. 4+1=5. 6+2=8.\n"

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem/0016-2026-09-08-myia-po-2026-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem/0016-2026-09-08-myia-po-2026-CoursIA.yaml
@@ -1,0 +1,6 @@
+date: '2026-09-08'
+by: myia-po-2026:CoursIA
+python_sha: 1c289aa37ca4b04048fbcd725ac84a1eecda0bdd
+csharp_sha: 2d7cd50c771bfe3b392ec4ce938f483cc36444ca
+content_python_sha: 6c613d1240b561d10d8842481ef284f045c27363a380ffdc561232a72fb1b444
+content_csharp_sha: 0a92ba7985d8300c925c498651f2c16fb5b14fd9cfc739dc22adf6583a4009ed


### PR DESCRIPTION
## Defaut corrige

La section 7b du GT-06c posait la trajectoire du temoin comme un litteral (`trajectoire_observee = ['Cooperer'] * 10`) : le certificat de disponibilite etait bien calcule, mais l'abstention etait **decretee**, pas produite — le grain porte sur cette seule ligne et sur ce qu'elle empechait de conclure (l'issue #15064).

## Geste

`agent_interet(adversaire, horizon=10)` produit la trajectoire par meilleure reponse periodique sur les **valeurs de continuation stationnaires** (convention horizon infini de la section 2, justifiee par le theoreme d'effritement de la section 2/c4 — l'induction arriere finie ferait defector dans les DEUX regimes) :

- **Regime grim** (δ = 0.6 > δ* = 0.5) : `V_C = R/(1-δ) = 7.5 >= V_D = T + δ·P/(1-δ) = 6.5` → l'agent produit `Cooperer` x10. Verdict **RETENUE**, mais retenue explicable par la menace — cooperation folk (section 6), temoin ambigu.
- **Regime sans memoire** : `V_D = T/(1-δ) = 12.5 > V_C = 7.5` → l'agent produit `Defecter` x10. Verdict **PAS DE RETENUE** — le cas negatif qui valide le detecteur (un certificat qui ne rend jamais « pas de retenue » ne mesure rien).

`certificat_disponibilite` reste verbatim (enumeration + strictement ameliorant au bareme courant) ; `verdict_retenue` en fait la conjonction complete avec l'abstention lue sur la trajectoire produite, branche negative explicite.

## Acceptance (issue #15064)

| # | Criterium | Preuve |
|---|---|---|
| 1 | Trajectoire PRODUITE par un agent / strategie simulee | `agent_interet` en c18 — argmax periodique sur valeurs de continuation, pas de tirage aleatoire, pas de litteral |
| 2 | Cas negatif : trajectoire contenant la deviation → certificat rend non-retenue, sortie commitee | Sortie c18 commitee (citee ci-dessous) : `PAS DE RETENUE — le coup disponible a ete JOUE (10/10 periodes)` |
| 3 | Statut ecrit dans le notebook | Markdown c19 reecrit : ce que le dispositif demontre (retenue = menace) et ne demontre PAS (abstention contre-interet non atteignable par un agent d'interet) |
| 4 | Citation croisee des deux familles | GT-06c c18/c19 → bras `Np` d'ICT-25a ; `ict25a_scaleup_grpo.py` : commentaire de lecture croisee a `ARM_PREFIX` (4 lignes) pointant vers `certificat_disponibilite` §7b |

## Sortie commitee c18 (kernel python3, EXEC_PROVED)

```
Regime AVEC punition (grim trigger, delta = 0.6 > delta* = 0.50) :
  Trajectoire produite : ['Cooperer'] (10 periodes)
  RETENUE — coup disponible + abstention constatee sur la trajectoire produite
    -> retenue explicable par la menace : cooperation folk (section 6), temoin ambigu de GT-20

Regime SANS punition (adversaire sans memoire) :
  Trajectoire produite : ['Defecter']
  PAS DE RETENUE — le coup disponible a ete JOUE (10/10 periodes)
```

## Controles

- Execution : kernel python3, SUCCESS 26.6 s — 14 cellules code, 0 `execution_count` null, 0 `output_type: error` (H.1).
- C.1 : 0 `raise NotImplementedError` / `assert False` / `1/0` dans les sources.
- Anti-regression : `certificat_disponibilite` conserve verbatim ; aucune cellule `# Solution` / `# Exemple resolu` touchee ; aucune cellule supprimee (c18 remplacee, c19 reecrite).
- Aucun usage aval des variables de c18 (verifie avant edition) ; scope = 2 fichiers (notebook + script ICT).

Closes #15064

Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15056
