### PR TITLE
fix(tooling,#15080): exercise counter reads body state; markdown-only notebooks are NO_CODE

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -400,6 +400,119 @@ EMPTY_RETURN_PATTERNS = [
     re.compile(r"\breturn\s+''(?!\w)"),
 ]
 
+# Indices of STUB_PATTERNS that are COMMENT markers (# TODO, # Indice, // TODO,
+# -- TODO). A leftover comment marker in an otherwise COMPLETE body is not itself
+# a stub signal: `# TODO etudiant` above a full implementation is an instructor's
+# residual comment, and counting the cell as an open exercise inverts the truth
+# (#15080 D01 -- R05 c30/c32/c34). The executable markers below (pass, return
+# None, result=None, empty-typed return, "Exercice a completer" print/display,
+# raise, assert) are NOT in this set: they are unambiguously stubs even when a
+# body happens to carry one. The `# a completer` LINE-COMMENT form (index 13) is
+# also excluded: it introduces a SEPARATE skeleton after a complete function in
+# a mixed cell (Search-11 cell 43 -- a complete `profit_function` plus a
+# truncated `# A COMPLETER` Problem skeleton), which must stay a stub.
+COMMENT_STUB_PATTERN_IDX = frozenset({3, 4, 5, 6, 7, 8})
+
+
+def _effective_code_lines(source: str) -> list[str]:
+    """Non-comment, non-import code lines of a cell (mirrors the filtering in
+    ``_is_stub_code``: `#` Python/F#, `//` C#, `--` Lean/Haskell)."""
+    lines = [
+        ln.strip()
+        for ln in source.strip().split("\n")
+        if ln.strip()
+        and not ln.strip().startswith("#")
+        and not ln.strip().startswith("//")
+        and not ln.strip().startswith("--")
+    ]
+    return [
+        ln for ln in lines
+        if not ln.startswith("import ") and not ln.startswith("from ")
+        and not ln.startswith("using ")
+    ]
+
+
+def _function_param_names(source: str) -> set[str]:
+    """Names bound by ``def`` signatures in the cell (for passthrough detection).
+
+    A ``return grid`` echoing an unchanged parameter is a placeholder stub, not a
+    computed result; a ``return rows`` where ``rows`` is assigned in the body is a
+    real solution. We need the parameter names to tell the two apart.
+    """
+    names: set[str] = set()
+    for m in re.finditer(
+        r"^\s*def\s+\w+\s*\((.*?)\)\s*(?:->[^:]+)?\s*:", source, re.MULTILINE
+    ):
+        for raw in m.group(1).split(","):
+            p = raw.strip()
+            if not p:
+                continue
+            # strip default (`x=1`) and annotation (`x: int`); accept *args/**kwargs
+            p = re.split(r"[:=]", p)[0].lstrip("*").strip()
+            if re.match(r"^[A-Za-z_]\w*$", p):
+                names.add(p)
+    return names
+
+
+def _return_is_derived(return_stmt: str, code_lines: list[str], params: set[str]) -> bool:
+    """True when a ``return`` statement yields a computed value, not a stub shape.
+
+    A derived return is an internal variable assigned in the body, a call, a
+    subscript, an attribute, a binary expression, or a non-empty literal. None,
+    an empty-typed literal (``[]``/``{}``/``()``/``0``/``""``/``set()``), or a
+    pass-through of an unchanged parameter are the stub shapes.
+    """
+    m = re.match(r"^return\b(.*)$", return_stmt.strip())
+    if not m:
+        return False
+    operand = m.group(1).strip()
+    if not operand or operand.lower().startswith("none"):
+        return False
+    if any(p.search(return_stmt) for p in EMPTY_RETURN_PATTERNS):
+        return False
+    if re.match(r"^[\[{]", operand):  # a list/dict literal -- computed when non-empty
+        return operand not in ("[]", "{}")
+    if re.match(r"""^["']""", operand):  # a returned string is a solved value
+        return True
+    if re.match(r"^[A-Za-z_]\w*\(", operand):  # call `f(...)`
+        return True
+    if re.match(r"^[A-Za-z_]\w*\.", operand):  # attribute `obj.attr`
+        return True
+    if re.match(r"^[A-Za-z_]\w*\[", operand):  # subscript `x[i]`
+        return True
+    if re.match(r"^[A-Za-z_]\w*$", operand):  # bare name
+        base = operand
+        if base in params:
+            return False  # unchanged parameter passthrough = placeholder stub
+        body = "\n".join(code_lines)
+        if re.search(rf"\b{re.escape(base)}\s*[+*/%]?=", body):
+            return True  # assigned in the body (loop-built local, etc.)
+        return False
+    if re.search(r"[+\-*/%]|\b(?:and|or|in)\b|\bis\s+not\b", operand):
+        return True  # binary expression
+    return False
+
+
+def _body_computes_result(source: str) -> bool:
+    """True when a cell's body computes a real result (a solution, not a stub).
+
+    Gates the comment-marker override in ``_is_stub_code``. A cell needs at
+    least three effective code lines AND a derived return to be a solution; a
+    one-line ``return grid`` (passthrough), a scaffolded skeleton with no
+    return, or an empty-typed return remains a stub. This keeps the scaffolded
+    C#/Lean exercises (which carry ``// TODO``/``-- TODO`` above a partial
+    skeleton with no computed return) counted as stubs.
+    """
+    code_lines = _effective_code_lines(source)
+    if len(code_lines) < 3:
+        return False
+    params = _function_param_names(source)
+    for ln in code_lines:
+        if re.match(r"^return\b", ln.strip()):
+            if _return_is_derived(ln, code_lines, params):
+                return True
+    return False
+
 
 @dataclass
 class ExerciseHit:
@@ -439,6 +552,12 @@ class NotebookCount:
 
     path: Path
     exercises: list[ExerciseHit] = field(default_factory=list)
+    #: Markdown exercise_instance lines that named a subject but found no paired
+    #: stub ("declared subject with no write-space"). Distinguishes a notebook
+    #: whose three exercise headers are all orphans (CSK: 01-GitHub-Copilot-SDK
+    #: -Binding) from one with genuinely no exercise at all (R05b demo): both
+    #: render `count == 0` but mean opposite things (#15080 D01, acceptance 3).
+    unpaired_markdown_instances: int = 0
     parse_error: str | None = None
 
     @property
@@ -459,8 +578,15 @@ def _is_stub_code(source: str) -> bool:
     """
     if not source.strip():
         return True
-    for pat in STUB_PATTERNS:
+    for idx, pat in enumerate(STUB_PATTERNS):
         if pat.search(source):
+            # A leftover COMMENT marker (# / // / -- TODO / Indice / "a completer")
+            # above a body that COMPUTES a result is a complete solution, not an
+            # open stub (#15080 D01: R05 c30/c32/c34). The executable markers
+            # (pass / return None / result=None / empty-typed return / "Exercice
+            # a completer" print / raise / assert) stay unconditional.
+            if idx in COMMENT_STUB_PATTERN_IDX and _body_computes_result(source):
+                continue
             return True
     lines = [
         ln.strip()
@@ -658,18 +784,17 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
         header_num = _exercise_number(header_source)
         # Forward (common): the stub just below the header, within 3 cells.
         forward_stub: int | None = None
+        forward_has_code_cell = False
         for j in range(idx + 1, min(idx + 4, len(cells))):
             jcell = cells[j]
             if jcell.get("cell_type") != "code":
                 continue
+            forward_has_code_cell = True
             j_source = "".join(jcell.get("source", []))
             if _is_stub_code(j_source):
                 forward_stub = j
                 paired_code_indices.add(j)
                 break
-            # First code cell in the window is NOT a stub -> stop the search;
-            # any later code cell is unlikely to be the paired exercise (#6051
-            # Bug 1's original pairing policy is preserved here).
             break
         # Backward (stub-then-header layout): the nearest preceding code cell,
         # absorbed only when it is itself a stub. NUMBERED headers additionally
@@ -716,7 +841,17 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
         # while still dropping the GT-20 numbered-header-with-solution case.
         if forward_stub is None and backward_stub is None:
             if header_num is not None:
-                # NUMBERED header without a paired stub: silently dropped.
+                # NUMBERED header without a paired stub: NOT an exercise (a title
+                # whose paired cell is a complete solution or missing is dropped,
+                # cf #12305). But a header with NO code cell at all in its window
+                # named a subject with notng to write in -- count it as an
+                # unpaired instance so "3 detached exercise headings" (CSK,
+                # `csharp` blocks inside markdown) is distinguishable from "no
+                # exercise at all" (R05b demo) and from "solved example" (R05,
+                # whose complete-solution cell follows the header) (#15080 D01,
+                # acceptance 3). The counter alone renders all three as 0.
+                if not forward_has_code_cell:
+                    result.unpaired_markdown_instances += instance_count
                 continue
             # NUMBERLESS header without a paired stub: counted (conservative).
         for _ in range(instance_count):
@@ -915,6 +1050,11 @@ def _run_text(
         for nb_path, cnt, kind, effective in sub_threshold:
             rel = _display_path(nb_path)
             print(f"\n[{cnt.count}/{effective}] ({kind}) {rel}")
+            if cnt.unpaired_markdown_instances:
+                print(
+                    f"    ! {cnt.unpaired_markdown_instances} exercise heading(s) "
+                    f"with no paired stub (subject declared, no cell to write in)"
+                )
             for hit in cnt.exercises:
                 print(f"    cell {hit.cell_index:>3} ({hit.cell_type:<8} {hit.detected_by}): {hit.preview}")
     else:
@@ -947,6 +1087,11 @@ def _run_json(
         entry = {
             "path": str(_display_path(nb_path)),
             "count": cnt.count,
+            #: Exercise-instance headers with no paired stub -- a subject declared
+            #: but no cell to write in. Distinguishes `count == 0` for a notebook
+            #: whose exercises are detached headings (CSK) from one with no
+            #: exercise at all (R05b demo) (#15080 D01, acceptance 3).
+            "declared_markdown_instances": cnt.unpaired_markdown_instances,
             "kind": kind,
             # None => outside the pedagogical corpus, so never sub-threshold.
             "effective_threshold": effective,

--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -331,6 +331,15 @@ def determine_status(
     if _is_research_path(nb_path):
         return "RESEARCH"
 
+    # No code cells at all → NO_CODE, not READY. `all([])` is True by vacuous
+    # truth, so without this guard a markdown-only notebook (01-1b-Video-Slideshow
+    # -Bonus: 2 markdown cells, `forensic_category: NO_CODE`) would be labeled
+    # READY -- "executed" with nothing to execute. Reuse the existing
+    # `forensic_category` vocabulary rather than inventing a new status
+    # (#15080 D01, acceptance 1).
+    if not code_cells:
+        return "NO_CODE"
+
     # Check for errors in outputs
     all_errors = []
     for cell in code_cells:

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -1452,3 +1452,116 @@ class TestPathFormInvariance:
         assert _classify(
             root / "GradeBook.ipynb", standard_threshold=3, root=root,
         ) == ("tooling", None)
+
+
+# ---------------------------------------------------------------------------
+# #15080 D01 -- a complete solution carrying a leftover `# TODO etudiant` is NOT
+# an open exercise; a header with no following code cell is a declared subject
+# with no write-space (distinguishable from "no exercise at all").
+# ---------------------------------------------------------------------------
+
+class TestD01CompletedSolutionWithTodo:
+    def test_complete_solution_with_todo_comment_is_not_a_stub(self, tmp_path):
+        """R05 c30/c32/c34 each render a full implementation below a surviving
+        `# TODO etudiant` comment (issue #15080 D01, acceptance 2). The counter
+        must NOT read them as open exercises -- this is the inversion the finding
+        names. Validated by its false negative: none of the three is counted.
+        """
+        c30 = (
+            "def mur_latence_exo(dims=64, sizes=(10**4, 10**5), seed=0):\n"
+            "    # TODO etudiant : completer la mesure -- reutiliser exact_knn, renvoyer [(n, ms)].\n"
+            "    rows = []\n"
+            "    rng = np.random.default_rng(seed)\n"
+            "    for n in sizes:\n"
+            "        db = rng.random((n, dims), dtype=np.float32)\n"
+            "        q = rng.random(dims).astype(np.float32)\n"
+            "        t0 = time.perf_counter()\n"
+            "        for _ in range(3):\n"
+            "            exact_knn(db, q)\n"
+            "        rows.append((n, (time.perf_counter() - t0) / 3 * 1000))\n"
+            "    return rows\n"
+            "\n"
+            'result = mur_latence_exo(dims=128)\n'
+            'print("Exercice 1 : latence dims=128 :", [(n, round(ms, 1)) for n, ms in result])\n'
+        )
+        # The header precedes the complete solution: it is a SOLVED example
+        # (corrige), not an orphan -- so count 0 AND unpaired 0.
+        nb = _write_nb(
+            tmp_path / "r05_solution.ipynb",
+            [
+                _md("## Exercice 1 : latence vs dimension"),
+                _code(c30),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 0, (
+            "A complete solution with a leftover '# TODO etudiant' must not count "
+            "as an open exercise (got %d)" % result.count
+        )
+        assert result.unpaired_markdown_instances == 0, (
+            "A header followed by a complete solution is a solved example, not an "
+            "orphaned subject"
+        )
+
+    def test_todo_with_passthrough_or_skeleton_remains_a_stub(self):
+        """The override must NOT swallow genuine stubs: a `# TODO` above a
+        passthrough return or a multi-line scaffold with no computed result stays
+        a stub (guard on the existing scaffolded C#/Lean tests)."""
+        passthrough = "def solve(grid):\n    # TODO etudiant : completer\n    return grid\n"
+        assert _is_stub_code(passthrough) is True, (
+            "A passthrough return (unchanged parameter) is a placeholder stub"
+        )
+        skeleton = (
+            "// Exercice 1 : Artificial Bee Colony (ABC).\n"
+            "// TODO etudiant : implementez ABC\n"
+            "public class ABC\n"
+            "{\n"
+            "    public double[] Best;\n"
+            "    public double BestFitness = double.MaxValue;\n"
+            "}\n"
+        )
+        assert _is_stub_code(skeleton) is True, (
+            "A scaffolded C# skeleton with // TODO is a student stub"
+        )
+
+
+class TestD01UnpairedHeaders:
+    def test_headers_with_no_code_cell_are_declared_instances(self, tmp_path):
+        """CSK (01-GitHub-Copilot-SDK-Binding) holds three exercise headings whose
+        `csharp` blocks live INSIDE markdown -- no code cell exists to write in.
+        The counter must report them as declared-but-empty, distinct from a
+        notebook with genuinely no exercise (R05b demo), which renders 0 with no
+        declared instances (#15080 D01, acceptance 3).
+        """
+        nb = _write_nb(
+            tmp_path / "csk_detached.ipynb",
+            [
+                _md("# Titre CSK"),
+                _md("## Exercice 1 : utiliser le binding\n```csharp\n// sk\n```"),
+                _md("## Exercice 2 : ...\n```csharp\n// ...\n```"),
+                _md("## Exercice 3 : ...\n```csharp\n// ...\n```"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 0
+        assert result.unpaired_markdown_instances == 3, (
+            "Three exercise headings with no code cell below them are declared "
+            "subjects with no write-space (got %d)" % result.unpaired_markdown_instances
+        )
+
+    def test_no_exercise_notebook_has_zero_declared_instances(self, tmp_path):
+        """R05b (05b-Stockage-Vectoriel-Serveur) has no exercise word at all --
+        a demonstration of method. It must render 0 count AND 0 declared
+        instances, so it is distinguishable from the CSK detached-headings case.
+        """
+        nb = _write_nb(
+            tmp_path / "demo.ipynb",
+            [
+                _md("# Demo de methode"),
+                _md("## Methode"),
+                _code("x = 1\nprint(x)"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 0
+        assert result.unpaired_markdown_instances == 0

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -240,11 +240,17 @@ class TestDetermineStatus:
         reqs = {"requires_api": False, "requires_gpu": True, "requires_cloud": False, "requires_wsl": False}
         assert determine_status(self._make_path(), nb, code_cells, reqs, pedagogical=True) == "READY"
 
-    def test_ready_empty_code_cells(self):
+    def test_empty_code_cells_is_no_code_not_ready(self):
+        # #15080 D01 acceptance 1: a markdown-only notebook (code_cells == [])
+        # must NOT be labeled READY -- `all([])` is True by vacuous truth, so the
+        # old code returned READY for a notebook that had nothing to execute
+        # (01-1b-Video-Slideshow-Bonus: `forensic_category: NO_CODE`). Reuse the
+        # existing NO_CODE vocabulary (the buggy-READY behavior is now asserted
+        # as the regression this fixes).
         nb = _nb([_md("# Title")])
         code_cells = []
         reqs = {"requires_api": False, "requires_gpu": False, "requires_cloud": False, "requires_wsl": False}
-        assert determine_status(self._make_path(), nb, code_cells, reqs, pedagogical=True) == "READY"
+        assert determine_status(self._make_path(), nb, code_cells, reqs, pedagogical=True) == "NO_CODE"
 
 
 # --- count_todos ---


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15056

## Resume

Repare les deux instruments du ticket D01 (#15080) sur les criteres 1-3 — la partie instrument-correction, propre, locale et testable. Le compteur ne lit plus la **presence d'un marqueur** (`# TODO`) mais l'**etat du corps** ; et un notebook sans cellule de code devient `NO_CODE`, plus `READY` par verite vacante.

**Le champ `role_pedagogique` du catalogue (criteres 4-6) est explicitement HORS scope de cette PR** : c'est un choix de schema qui appartient a la propriete de l'automatisation du catalogue (cf catalog-pr-hygiene), et a la decision ai-01 — je n'ouvre pas ce champ sur une branche feature.

## Criteres couverts

### C1 — `determine_status()` ne rend plus `READY` sur `code_cells == []`

`generate_catalog.py` : ajout d'une garde apres le chemin `_is_research_path` et avant le check-erreurs :

```python
if not code_cells:
    return "NO_CODE"
```

`all([])` est `True` par verite vacante — sans cette garde, un notebook markdown-seulement (`01-1b-Video-Slideshow-Bonus`: 2 cellules markdown, `forensic_category: NO_CODE`) serait etiquette `READY` alors qu'il n'y a rien a executer. On reutilise le vocabulaire `NO_CODE` existant plutot que d'inventer un statut.

**Test** — `test_ready_empty_code_cells` renomme `test_empty_code_cells_is_no_code_not_ready` (regression-guard du bug) et assert `== "NO_CODE"`. Le controle positif a 14 cellules toutes executees reste `READY` (test `test_ready_when_all_code_cells_have_outputs` conserve).

### C2 — le compteur ne lit plus la presence de `# TODO` mais l'etat du corps

`count_exercises.py` : le discriminant n'est plus « un motif matche » mais « le corps calcule-t-il un resultat ». Un corps dont le `return` est **derive** (variable assignee dans le corps, appel, subscript, attribute, expression binaire, ou litteral non-vide) est une **solution** meme s'il porte un `# TODO etudiant` / `# Indice`. Restent des **stubs** : `return <param>` passthrough inchange, `return None`, retours types-vides, scaffolds (pas de `return` calcule), et la forme `# A COMPLETER` (qui introduit un squelette separe apres une fonction complete dans une cellule mixte).

**Validation par faux negatifs** (`test_count_exercises.py`) — les trois fonctions de `05-Stockage-Vectoriel.ipynb` reecrites en fixture doivent etre NON comptees :
- `mur_latence_exo` (c30) — compte `0`
- `prix_du_rappel` (c32) — compte `0`
- `filtre_multiple` (c34) — compte `0`

Et le test inversé (sanity) : un stub avec `return <param>` passthrough ou squelette reste compte.

### C3 — distinguer « en-tete d'exercice sans cellule de code » de « aucun exercice »

`count_exercises.py` : nouveau champ `unpaired_markdown_instances` (renvoye comme `declared_markdown_instances`). Un en-tete numerote sans cellule de code dans sa fenetre avant est un **sujet declare sans espace d'ecriture** (compte comme ce que la lecture humaine voit : un sujet), pas silencieusement abandonne. Un notebook sans aucun mot d'exercice (demo de methode) a `declared_markdown_instances = 0`.

**Mesure avant/après** sur `main` `b646b2fca` :

| Notebook | avant | apres |
|---|---|---|
| `05-Stockage-Vectoriel.ipynb` | `3` completes comptees `conforming: true` | `count=0 declared=0` |
| `01-GitHub-Copilot-SDK-Binding.ipynb` (CSK) | `0` (contradictoire) | `count=0 declared=3` |
| `05b-Stockage-Vectoriel-Serveur.ipynb` | `0, conforming: false` | `count=0 declared=0` |

Les deux derniers ne rendent plus le meme couple `(0, false)` : `(0, 3)` vs `(0, 0)`.

## Criteres NON couverts (deferes)

- **C4** — champ `role_pedagogique` au schema du catalogue + population des 5 notebooks cites : choix de schema, propriete de l'automatisation du catalogue.
- **C5** — `01-1b-Video-Slideshow-Bonus` (cellule de code `OUTPUT_DIR` / tranche 5min vs 15min) : enonce vs support, depend du champ C4 pour etre honnete.
- **C6** — `10e_LLamaSharp_DotNet_BakeOff` (projet .NET / chemin modele non reproductibles) : reproduction du projet, hors instrument.

## Tests

```
test_count_exercises.py   + test_generate_catalog.py : 270 passed
test_catalog_scripts.py   (importe les deux modules)  :  93 passed
```

Aucun notebook touche, catalogue byte-identique a `main`, un seul sujet par PR.

See #15080
