### PR TITLE
fix(ci,#15091): sparse-checkout cone sur pr-gate.yml + bornes restart/IO sur les unites du parc

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -158,7 +158,41 @@ jobs:
     # under the 60-min ceiling.
     timeout-minutes: 52
     steps:
+      # #15091 : sparse-checkout en mode cone. Ce job est le SEUL route sur le
+      # label coursia-waiter, et ce pool n a deliberement aucun volume (ni
+      # _work, ni toolcache, conteneurs --rm) sous la premisse "un slot qui
+      # attend ne coute rien" (#13363). La premisse tombe pendant les ~2
+      # premieres minutes : un checkout nu materialise 10 387 fichiers /
+      # 1,14 GiB, puis les detruit -- ~291 runs/jour, soit de l ordre de
+      # 330 GiB ecrits par jour, sans jamais rien amortir. Le cone rend
+      # 2 460 fichiers / 16,71 MiB (facteur 70).
+      #
+      # Pourquoi le sparse est sur CE pool, et sur lui seul. #14385 a etabli
+      # que le sparse-checkout empoisonne un _work PERSISTANT : une config
+      # sparse survivant entre deux jobs tronque l arbre du job suivant, et
+      # entrypoint.sh porte depuis une boucle de purge pour ca. Mot exact de
+      # #14385 : "Condition habilitante : le volume _work persistant par slot
+      # (#14285/#14288). Sans lui, chaque job repartait d un _work vide."
+      # Le pool d attente n a aucun volume persistant : le mode de defaillance
+      # y est structurellement impossible. Sur la branche de repli
+      # ubuntu-latest (PRs de forks), la VM est neuve a chaque job -- meme
+      # immunite, autre raison.
+      #
+      # Cone et non pas non-cone, malgre un facteur 15x moins bon (149
+      # fichiers / 1,09 MiB) : le mode non-cone est EXACTEMENT celui qui a
+      # empoisonne les slots dans #14385, et un cone sur scripts/ ne peut pas
+      # casser au premier import voisin ajoute a pr_gate.py. Le cone inclut
+      # aussi les fichiers de la racine, ce qui suffit au reste du job.
+      #
+      # Perimetre requis, mesure : pr_gate.py n importe que la stdlib plus
+      # yaml en import paresseux, et son seul chemin est
+      # DEFAULT_WORKFLOWS_DIR = <repo>/.github/workflows, que
+      # derive_always_on_jobs et derive_advisory_jobs globent (canari regle 8).
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts
+            .github/workflows
 
       - uses: actions/setup-python@v5
         with:

--- a/scripts/ci/docker/linux-runner/persist/coursia-runner.service
+++ b/scripts/ci/docker/linux-runner/persist/coursia-runner.service
@@ -16,6 +16,19 @@ Description=CoursIA Linux runners supervisor (docker slots)
 Wants=docker.service
 After=docker.service
 
+# #15091 : plafond de redemarrage. Les deux unites portaient Restart=always
+# + RestartSec=30 SANS aucune borne : un docker.service indisponible faisait
+# relancer indefiniment N boucles de slots, chacune retentant docker run
+# toutes les 15 s. Releve sur ai-01 avant l arret du 2026-09-07 :
+# "activating (auto-restart)", NRestarts=10. Au-dela de 5 demarrages en
+# 10 min, l unite passe desormais en "failed" et cesse -- un etat lisible,
+# qui se voit dans systemctl status, la ou une boucle muette ne se voyait
+# que dans le debit disque.
+# En [Unit] et non en [Service] : ces deux directives y ont ete deplacees en
+# systemd 229 (elles restent acceptees en [Service], avec un avertissement).
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/coursia-runner-start.sh start 8
@@ -26,6 +39,19 @@ Nice=10
 # ExecStop est gracieux (sentinel supervise.sh) : un job en vol va a son
 # terme, ce qui peut prendre des dizaines de minutes sur un build Lean.
 TimeoutStopSec=900
+
+# #15091 : Nice=10 ci-dessus gouverne le CPU, et RIEN d autre. L I/O du parc
+# n etait bornee par aucun plafond, ce qui a contribue aux gels par famine
+# disque de ai-01 le 2026-09-07 (le pool d attente reclonait 1,14 GiB par job,
+# 12 slots de front). IOWeight fait ceder le parc sous contention plutot que
+# de le laisser rivaliser a poids egal avec le reste de la machine.
+# Requiert cgroup v2 avec le controleur io delegue ; IOAccounting rend la
+# consommation lisible dans systemctl status meme la ou le poids ne mord pas.
+# Le plafond DUR de bande passante (IOWriteBandwidthMax) est volontairement
+# laisse ouvert : il exige de nommer le device, et sa valeur doit sortir d une
+# mesure sous charge, pas d une intuition -- question posee a roo-extensions.
+IOAccounting=yes
+IOWeight=50
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/ci/docker/linux-runner/persist/coursia-waiters.service
+++ b/scripts/ci/docker/linux-runner/persist/coursia-waiters.service
@@ -15,6 +15,19 @@ Description=CoursIA PR-gate waiter pool (coursia-waiter slots)
 Wants=docker.service
 After=docker.service
 
+# #15091 : plafond de redemarrage. Les deux unites portaient Restart=always
+# + RestartSec=30 SANS aucune borne : un docker.service indisponible faisait
+# relancer indefiniment N boucles de slots, chacune retentant docker run
+# toutes les 15 s. Releve sur ai-01 avant l arret du 2026-09-07 :
+# "activating (auto-restart)", NRestarts=10. Au-dela de 5 demarrages en
+# 10 min, l unite passe desormais en "failed" et cesse -- un etat lisible,
+# qui se voit dans systemctl status, la ou une boucle muette ne se voyait
+# que dans le debit disque.
+# En [Unit] et non en [Service] : ces deux directives y ont ete deplacees en
+# systemd 229 (elles restent acceptees en [Service], avec un avertissement).
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/coursia-waiters-start.sh 12
@@ -25,6 +38,19 @@ Nice=10
 # Un slot d'attente ne porte jamais de build long : 120 s suffisent la ou la
 # jambe d'execution demande 900 s pour laisser finir un lake build.
 TimeoutStopSec=120
+
+# #15091 : Nice=10 ci-dessus gouverne le CPU, et RIEN d autre. L I/O du parc
+# n etait bornee par aucun plafond, ce qui a contribue aux gels par famine
+# disque de ai-01 le 2026-09-07 (le pool d attente reclonait 1,14 GiB par job,
+# 12 slots de front). IOWeight fait ceder le parc sous contention plutot que
+# de le laisser rivaliser a poids egal avec le reste de la machine.
+# Requiert cgroup v2 avec le controleur io delegue ; IOAccounting rend la
+# consommation lisible dans systemctl status meme la ou le poids ne mord pas.
+# Le plafond DUR de bande passante (IOWriteBandwidthMax) est volontairement
+# laisse ouvert : il exige de nommer le device, et sa valeur doit sortir d une
+# mesure sous charge, pas d une intuition -- question posee a roo-extensions.
+IOAccounting=yes
+IOWeight=50
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/tooling #14981

Mandat user 2026-09-07 : « roo-extensions qui tente de diagnostiquer suggere que ton
superviseur de runners docker declanche un traffic disque fou et des git clones en serie.
Il l'a kille mais il faut absolument que tu revois ton design. »

Deux pieces sur les quatre de #15091 -- celles qui ferment la cause disque et bornent le
redemarrage. Les pieces (3) conteneurisation et (4) budget inter-familles restent ouvertes
dans l'issue.

## Ce que la mesure a montre

Le pool d'attente `coursia-waiter` a ete construit sous la premisse « un slot qui attend ne
coute rien » (#13363), donc **deliberement sans volume** -- ni `_work`, ni toolcache, et des
conteneurs `--rm`. La premisse tombe pendant les ~2 premieres minutes de chaque job : le seul
workflow route sur ce pool commence par un `checkout` complet.

| Fait | Mesure firsthand (2026-09-07) |
|---|---|
| Workflows routes sur `coursia-waiter` | **un seul** : `pr-gate.yml` |
| Part des runs `PR gate` qui y atterrissent | **100/100** des runs recents |
| Runs `PR gate` / jour | 295 / 300 / 255 / 341 / 291 / 321 / 219 (29-08 -> 04-09) |
| Ecriture par job | `checkout@v4` nu, `fetch-depth` 1 -> **10 387 fichiers, 1,14 GiB** |
| Amortissement | **aucun** : ecrit-puis-detruit a chaque job |

Soit de l'ordre de **330 GiB ecrits par jour**, en rafales de 12 slots simultanes. La lane
`roo-extensions` a mesure independamment, pendant le gel, **une boucle qui ecrivait 96 Mo/s**
(dashboard global, 2026-09-07T17:25Z) -- 12 slots a ~8 Mo/s. Je ne pretends pas l'avoir
demontre ; je constate que ce mecanisme le produit exactement.

**1,14 GiB est un plancher**, pas une mesure complete : c'est l'arbre materialise, le pack
transfere s'y ajoute et n'a **pas** ete chiffre -- le benchmark qui devait le faire a ete tue
avant terme pour ne pas concurrencer les sondages disque des lanes `Maintenance` et
`roo-extensions` sur une machine qui sortait de deux gels par famine I/O. Ma faute, corrigee.

**Correction d'une estimation a moi** : j'avais d'abord suppose un clone complet (3,70 GiB de
pack). `checkout@v4` clone en profondeur 1 : le chiffre juste est 1,14 GiB -- facteur 3,2 de
moins que ce que j'annoncais.

## Piece (1) -- sparse-checkout cone sur `pr-gate.yml`

`pr_gate.py` n'importe que la stdlib plus `yaml` en import paresseux, et son seul chemin est
`DEFAULT_WORKFLOWS_DIR = <repo>/.github/workflows`, que `derive_always_on_jobs` et
`derive_advisory_jobs` globent (canari regle 8).

| Mode | Fichiers | Taille |
|---|---|---|
| Aujourd'hui (`checkout` nu) | 10 387 | **1,14 GiB** |
| **Cone `scripts` + `.github/workflows`** (+ 28 fichiers de racine) | **2 488** | **18,23 MiB** |
| Non-cone `scripts/pr_gate.py` + `.github/workflows/` | 149 | 1,09 MiB |

**Le cone est retenu malgre son facteur ~15x moins bon** : le mode non-cone est *exactement*
celui qui a empoisonne les slots dans #14385, et un cone sur `scripts/` ne peut pas casser au
premier import voisin ajoute a `pr_gate.py`.

**Pourquoi le sparse est sur ce pool, et sur lui seul.** #14385 a etabli que le sparse-checkout
empoisonne un `_work` **persistant** : une configuration sparse survivant entre deux jobs
tronque l'arbre du job suivant, et `entrypoint.sh` porte depuis lors une boucle de purge pour
ca. Le mot exact de #14385 :

> Condition habilitante : le volume `_work` **persistant par slot** (#14285/#14288). Sans lui,
> chaque job repartait d'un `_work` vide.

Le pool d'attente **n'a aucun volume persistant** : le mode de defaillance y est
structurellement impossible. Sur la branche de repli `ubuntu-latest` (PRs de forks), la VM est
neuve a chaque job -- meme immunite, autre raison.

`runs-on` n'est **pas** touche : `check_self_hosted_runner_policy.py` audite exactement cette
expression, et le nom de check `PR gate` -- qui est le nom du check requis -- est inchange.

## Piece (2) -- borner le redemarrage et l'I/O sur les deux unites

Les deux unites portaient `Restart=always` + `RestartSec=30` **sans aucune borne**. Un
`docker.service` indisponible faisait relancer indefiniment N boucles de slots, chacune
retentant `docker run` toutes les 15 s. Releve sur ai-01 avant l'arret : `activating
(auto-restart)`, **`NRestarts=10`**.

`Nice=10` gouverne le **CPU seulement**. Aucun `IOAccounting`, aucun `IOWeight`, aucun plafond
de bande passante : **l'I/O n'etait bornee par rien**.

Ajoute aux deux unites : `StartLimitIntervalSec=600` / `StartLimitBurst=5` (au-dela, l'unite
passe en `failed` -- un etat lisible dans `systemctl status`, la ou une boucle muette ne se
voyait que dans le debit disque) et `IOAccounting=yes` / `IOWeight=50`.

Le plafond **dur** de bande passante (`IOWriteBandwidthMax`) est **volontairement laisse
ouvert** : il exige de nommer le device, et sa valeur doit sortir d'une mesure sous charge, pas
d'une intuition. Question posee a `roo-extensions` sur le dashboard global.

## Ce que j'ai verifie, et avec quel controle

**Piece (1) -- controle positif dans l'artefact reel.** J'ai materialise le cone dans un
worktree sparse et fait tourner le gate dedans :

```
git worktree add --no-checkout <tmp> HEAD
git sparse-checkout set --cone scripts .github/workflows && git checkout
-> 2 490 fichiers, 23 Mo sur disque   (contre 10 387 / 1,14 GiB)
python scripts/pr_gate.py --help     -> OK
derive_always_on_jobs()  -> 6 jobs
derive_advisory_jobs()   -> 33 jobs
```

**Controle differentiel** : les deux derivations rendent des ensembles **identiques** a ceux
obtenus sur un checkout complet de `main` -- meme liste nominative de 6, meme compte de 33. Le
verdict du gate est donc inchange, ce n'est pas une inference.

**Controle negatif** : `MyIA.AI.Notebooks`, `docs` et `GradeBookApp` sont bien **absents** du
cone -- le sparse fait ce qu'il annonce, il ne rend pas un arbre complet en silence.

```
python scripts/ci/check_self_hosted_runner_policy.py
  workflows=148 jobs=186 self_hosted=121 -- OK
python -m pytest scripts/tests/test_pr_gate.py -q
  71 passed in 10.30s
```

**Piece (2) -- controle de l'instrument avant de croire son vert.**

```
systemd 255 (255.4-1ubuntu8.17)
systemd-analyze verify coursia-waiters.service -> rc=0
systemd-analyze verify coursia-runner.service  -> rc=0
```

Un `rc=0` ne prouve rien tant qu'on n'a pas montre que l'outil sait rougir. Faute volontaire
`IOWeight` -> `IOWeightt` :

```
/tmp/ctl.service:53: Unknown key name 'IOWeightt' in section 'Service', ignoring.
```

L'instrument voit bien une directive inconnue : le `rc=0` des deux unites signifie donc que
les quatre directives ajoutees sont reellement **reconnues** par systemd 255, pas ignorees en
silence.

## Ce que cette PR ne fait PAS

- **Elle ne redemarre rien.** `coursia-waiters.service` et `coursia-runner.service` restent
  `inactive` + `disabled` sur ai-01. Consigne user du 2026-09-07 : *« je ne le ferai que quand
  plusieurs d'entre vous m'y inviteront apres concertation dans le dashboard global »*. Je
  n'invite pas ce redemarrage, et cette PR ne vaut pas invitation.
- **Elle ne deploie pas les unites.** Les fichiers du depot sont des **copies de reference** ;
  les originaux vivent sous `/etc/systemd/system/` dans la distro Ubuntu de l'hote. Le
  `daemon-reload` est un geste separe, a faire au moment du redemarrage invite.
- **Elle ne conteneurise pas le superviseur** (piece 3, demande explicite du user) ni ne pose
  de budget inter-familles (piece 4). Les deux restent ouvertes dans #15091, avec l'evaluation
  honnete de la piece 3 -- notamment sa reserve : monter `/var/run/docker-ce.sock` dans le
  superviseur est **root-equivalent sur l'hote**, donc l'isolation obtenue serait partielle.

## Cout de l'arret, nomme

`PR gate` est un check **requis**. Pool d'attente eteint, ses runs restent en file --
**14 runs `queued`, le plus ancien depuis 2026-09-07T12:08:24Z** -- et autant de PRs same-repo
restent `BLOCKED`. La machine est stable *parce que* la CI est eteinte : un troc temporaire,
pas un etat cible. C'est ce qui rend ces deux pieces urgentes plutot que confortables.

## Coexistence avec #15034

#15034 (plancher de dwell 2 h) touche le meme fichier, mais uniquement les arguments du
dernier step (`--pr`, `--dwell-min`). Cette PR touche le step de `checkout`. Aucun
chevauchement textuel ; l'ordre de merge est indifferent. `merge_dwell` vit sous `scripts/`,
donc dans le cone.

## G-VAR-1 -- dit franchement

Ce grain est **META** (`tooling`) : il ne met pas de contenu sur `main`. Le plancher de contenu
du cycle n'est pas tenu par cette PR, et je ne pretends pas le contraire. Il est pris sous
mandat user direct, sur un incident qui a gele la machine deux fois dans la journee.

See #15091, #13363, #14285, #14385, #14303

