### PR TITLE
fix(rag,#15046): G10 ING — decoupage reel decrit + comparaison recadree en demonstration de provenance

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/ingestion-corpus-long-rag.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings/ingestion-corpus-long-rag.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "f2d2db73",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002887,
+     "end_time": "2026-09-07T18:03:33.837719",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:33.834832",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Ingestion RAG d'un corpus long structure\n",
     "\n",
@@ -38,7 +47,16 @@
   {
    "cell_type": "markdown",
    "id": "dbd9b5d8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002076,
+     "end_time": "2026-09-07T18:03:33.842218",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:33.840142",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Configuration\n",
     "\n",
@@ -55,11 +73,19 @@
    "id": "f525fac0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:23.974091Z",
-     "iopub.status.busy": "2026-08-10T01:15:23.974091Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.147362Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.146358Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:33.847246Z",
+     "iopub.status.busy": "2026-09-07T18:03:33.847037Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.739099Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.738578Z"
+    },
+    "papermill": {
+     "duration": 0.89645,
+     "end_time": "2026-09-07T18:03:34.740724",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:33.844274",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -85,7 +111,16 @@
   {
    "cell_type": "markdown",
    "id": "be4eadee",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002281,
+     "end_time": "2026-09-07T18:03:34.745845",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.743564",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Le corpus : trois ouvrages structures en chapitres\n",
     "\n",
@@ -105,11 +140,19 @@
    "id": "282c7287",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.148809Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.148809Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.162911Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.161632Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.751282Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.750948Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.755976Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.755585Z"
+    },
+    "papermill": {
+     "duration": 0.008969,
+     "end_time": "2026-09-07T18:03:34.756729",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.747760",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -204,7 +247,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c14eaa8e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002517,
+     "end_time": "2026-09-07T18:03:34.761722",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.759205",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du corpus brut (ancre sur code[1])\n",
     "\n",
@@ -221,7 +274,16 @@
   {
    "cell_type": "markdown",
    "id": "c1ca0a11",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002395,
+     "end_time": "2026-09-07T18:03:34.766380",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.763985",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Deux strategies de chunking\n",
     "\n",
@@ -238,18 +300,30 @@
    "id": "567350c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.165006Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.165006Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.178212Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.176997Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.773157Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.772786Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.777790Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.777384Z"
+    },
+    "papermill": {
+     "duration": 0.010535,
+     "end_time": "2026-09-07T18:03:34.779074",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.768539",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deux strategies definies : chunk_naif (taille fixe, sans etiquette) et chunk_structure (par chapitre, etiquette livre+chapitre).\n"
+      "Deux strategies definies : chunk_naif (taille fixe, sans etiquette) et chunk_structure (par chapitre, etiquette livre+chapitre).\n",
+      "=== Sous-decoupage d'un chapitre trop long (taille_max=22) ===\n",
+      "  'Cette phrase contient'  origine : [Ouvrage de test > ch.1]\n",
+      "  'plusieurs mots et se'  origine : [Ouvrage de test > ch.1]\n",
+      "  'termine ici.'  origine : [Ouvrage de test > ch.1]\n"
      ]
     }
    ],
@@ -282,7 +356,9 @@
     "    for titre, livre in corpus.items():\n",
     "        auteur = livre[\"auteur\"]\n",
     "        for n_ch, (titre_ch, texte_ch) in livre[\"chapitres\"].items():\n",
-    "            # si le chapitre depasse taille_max, on le decoupe par phrase\n",
+    "            # si le chapitre depasse taille_max, on le sous-decoupe par textwrap.wrap :\n",
+    "            # largeur en CARACTERES, en respectant les frontieres de MOTS -- pas les\n",
+    "            # frontieres de phrases. Chaque morceau garde livre + chapitre.\n",
     "            morceaux = textwrap.wrap(texte_ch, width=taille_max, break_long_words=False)\n",
     "            for morceau in morceaux:\n",
     "                chunks.append({\n",
@@ -295,13 +371,30 @@
     "    return chunks\n",
     "\n",
     "print(\"Deux strategies definies : chunk_naif (taille fixe, sans etiquette) \"\n",
-    "      \"et chunk_structure (par chapitre, etiquette livre+chapitre).\")"
+    "      \"et chunk_structure (par chapitre, etiquette livre+chapitre).\")\n",
+    "# Demonstration : une phrase plus longue que taille_max est decoupee par\n",
+    "# frontieres de mots (pas de phrases), et chaque morceau garde son etiquette.\n",
+    "mini_corpus = {\"Ouvrage de test\": {\"auteur\": \"A. Test\",\n",
+    "    \"chapitres\": {1: (\"Un chapitre\",\n",
+    "        \"Cette phrase contient plusieurs mots et se termine ici.\")}}}\n",
+    "print(\"=== Sous-decoupage d'un chapitre trop long (taille_max=22) ===\")\n",
+    "for m in chunk_structure(mini_corpus, taille_max=22):\n",
+    "    print(f\"  {m['texte']!r}  origine : [{m['livre']} > ch.{m['chapitre']}]\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "10b70cfe",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002847,
+     "end_time": "2026-09-07T18:03:34.784556",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.781709",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Application -- et le defaut apparait\n",
     "\n",
@@ -318,11 +411,19 @@
    "id": "ffa8c24e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.180306Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.179783Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.192367Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.191775Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.791109Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.790921Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.796028Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.795652Z"
+    },
+    "papermill": {
+     "duration": 0.009073,
+     "end_time": "2026-09-07T18:03:34.796907",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.787834",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -374,7 +475,16 @@
   {
    "cell_type": "markdown",
    "id": "c4016442",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005007,
+     "end_time": "2026-09-07T18:03:34.803897",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.798890",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Vectorisation TF-IDF deterministe\n",
     "\n",
@@ -391,11 +501,19 @@
    "id": "77812c46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.194471Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.194471Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.208147Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.207009Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.809308Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.808979Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.819439Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.819116Z"
+    },
+    "papermill": {
+     "duration": 0.013996,
+     "end_time": "2026-09-07T18:03:34.820177",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.806181",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -424,7 +542,16 @@
   {
    "cell_type": "markdown",
    "id": "29fd089c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002068,
+     "end_time": "2026-09-07T18:03:34.824743",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.822675",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Recherche -- meme requete, deux strategies\n",
     "\n",
@@ -451,11 +578,19 @@
    "id": "1a7fe687",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.209714Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.209194Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.222874Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.222286Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.830497Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.830128Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.842380Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.841807Z"
+    },
+    "papermill": {
+     "duration": 0.016375,
+     "end_time": "2026-09-07T18:03:34.843223",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.826848",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -479,7 +614,12 @@
       "comment economiser l'eau au jardin ?           | Jardins Suspendus    ch.2           | s=0.382 ' pour cent des besoins en eau du jardin.'\n",
       "                                               |                                    |              | [Jardins Suspendus > ch.2] ok=True s=0.252\n",
       "\n",
-      "Precision chapitre exact (top-1) : structure = 5/5, naif = N/A (pas d etiquette).\n"
+      "Provenance (chapitre) au top-1, structure = 5/5.\n",
+      "La strategie NAIVE n'a pas d'etiquette -> sa provenance n'est PAS verifiable.\n",
+      "Le score ci-dessus est donc une demonstration de PROVENANCE du structure\n",
+      "(ses metadonnees sont retrouvees au top-1), PAS une victoire de precision\n",
+      "du structure sur le naif : on compare une provenance lisible a une absence\n",
+      "d'etiquette, non deux precisions de retrieval.\n"
      ]
     }
    ],
@@ -504,7 +644,6 @@
     "\n",
     "print(f\"{'Requete':<46} | {'Attendu':<34} | Naif (top-1) | Structure (top-1)\")\n",
     "print(\"-\" * 130)\n",
-    "exact_naif = 0\n",
     "exact_struct = 0\n",
     "for req, livre_attendu, ch_attendu in REQUETES:\n",
     "    rv = vec.transform([req])\n",
@@ -520,13 +659,27 @@
     "    print(f\"{'':<46} | {'':<34} |              | {etiquetter_struct(c_s)} ok={ok_struct} s={s_s:.3f}\")\n",
     "    print()\n",
     "\n",
-    "print(f\"Precision chapitre exact (top-1) : structure = {exact_struct}/{len(REQUETES)}, naif = N/A (pas d etiquette).\")"
+    "print(f\"Provenance (chapitre) au top-1, structure = {exact_struct}/{len(REQUETES)}.\")\n",
+    "print(\"La strategie NAIVE n'a pas d'etiquette -> sa provenance n'est PAS verifiable.\")\n",
+    "print(\"Le score ci-dessus est donc une demonstration de PROVENANCE du structure\")\n",
+    "print(\"(ses metadonnees sont retrouvees au top-1), PAS une victoire de precision\")\n",
+    "print(\"du structure sur le naif : on compare une provenance lisible a une absence\")\n",
+    "print(\"d'etiquette, non deux precisions de retrieval.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "3bd19332",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00225,
+     "end_time": "2026-09-07T18:03:34.848552",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.846302",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Lecture du resultat\n",
     "\n",
@@ -553,7 +706,16 @@
   {
    "cell_type": "markdown",
    "id": "fd6551fd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002325,
+     "end_time": "2026-09-07T18:03:34.853075",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.850750",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. La pire chute : un chunk qui melange deux sujets\n",
     "\n",
@@ -570,11 +732,19 @@
    "id": "85ce3018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.224956Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.224437Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.238639Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.237503Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.858662Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.858275Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.863797Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.862895Z"
+    },
+    "papermill": {
+     "duration": 0.009513,
+     "end_time": "2026-09-07T18:03:34.864868",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.855355",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -628,7 +798,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "aa029fa1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002265,
+     "end_time": "2026-09-07T18:03:34.869695",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.867430",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture des chunks hybrides (ancre sur code[6])\n",
     "\n",
@@ -643,7 +823,16 @@
   {
    "cell_type": "markdown",
    "id": "92b90d04",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002353,
+     "end_time": "2026-09-07T18:03:34.874321",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.871968",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Ce qu'il faut retenir\n",
     "\n",
@@ -666,7 +855,16 @@
   {
    "cell_type": "markdown",
    "id": "3b157ca9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002554,
+     "end_time": "2026-09-07T18:03:34.879265",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.876711",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 10. Exercices\n",
     "\n",
@@ -684,11 +882,19 @@
    "id": "b32584c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.240199Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.239678Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.253933Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.252679Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.884850Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.884642Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.887687Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.887308Z"
+    },
+    "papermill": {
+     "duration": 0.006864,
+     "end_time": "2026-09-07T18:03:34.888508",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.881644",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -716,7 +922,16 @@
   {
    "cell_type": "markdown",
    "id": "e534c2a1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002424,
+     "end_time": "2026-09-07T18:03:34.893378",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.890954",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 -- Etiqueter les chunks naifs a posteriori\n",
     "\n",
@@ -738,11 +953,19 @@
    "id": "3db8ee47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.256530Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.256530Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.269054Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.267924Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.899099Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.898836Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.901976Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.901512Z"
+    },
+    "papermill": {
+     "duration": 0.00702,
+     "end_time": "2026-09-07T18:03:34.902637",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.895617",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -769,7 +992,16 @@
   {
    "cell_type": "markdown",
    "id": "1746ed71",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002261,
+     "end_time": "2026-09-07T18:03:34.907419",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.905158",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 -- Le filtrage par metadonnee, que le chunking naif ne permet pas\n",
     "\n",
@@ -798,11 +1030,19 @@
    "id": "693798b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T01:15:30.270623Z",
-     "iopub.status.busy": "2026-08-10T01:15:30.270098Z",
-     "iopub.status.idle": "2026-08-10T01:15:30.284297Z",
-     "shell.execute_reply": "2026-08-10T01:15:30.283155Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:03:34.912868Z",
+     "iopub.status.busy": "2026-09-07T18:03:34.912674Z",
+     "iopub.status.idle": "2026-09-07T18:03:34.915669Z",
+     "shell.execute_reply": "2026-09-07T18:03:34.915284Z"
+    },
+    "papermill": {
+     "duration": 0.006602,
+     "end_time": "2026-09-07T18:03:34.916337",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.909735",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -837,7 +1077,16 @@
   {
    "cell_type": "markdown",
    "id": "dddaee56",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00228,
+     "end_time": "2026-09-07T18:03:34.920943",
+     "exception": false,
+     "start_time": "2026-09-07T18:03:34.918663",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 11. Pour aller plus loin\n",
     "\n",
@@ -874,7 +1123,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.546846,
+   "end_time": "2026-09-07T18:03:37.620940",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "D:\\Dev\\CoursIA-15046\\MyIA.AI.Notebooks\\GenAI\\Plateformes-Conversationnelles\\AI-Engine-WordPress\\03-Functional\\03-3-RAG-et-Embeddings\\ingestion-corpus-long-rag.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-15046\\MyIA.AI.Notebooks\\GenAI\\Plateformes-Conversationnelles\\AI-Engine-WordPress\\03-Functional\\03-3-RAG-et-Embeddings\\ingestion-corpus-long-rag_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-07T18:03:32.074094",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15056

## G10 — ING : decoupage reel decrit, comparaison recadree en demonstration de provenance

Closes #15046

Fichier : `ingestion-corpus-long-rag.ipynb` (AI-Engine-WordPress/03-Functional/03-3-RAG-et-Embeddings).

### Defaut 1 — le commentaire decrivait un decoupage que le code ne fait pas (ING:c7)

`chunk_structure` commentait « si le chapitre depasse taille_max, on le decoupe par phrase »,
mais le code appelle `textwrap.wrap(texte_ch, width=taille_max, break_long_words=False)` :
decoupage par **largeur en caracteres en respectant les frontieres de mots**, pas les
frontieres de phrases.

**Correctif** : le commentaire decrit desormais le decoupage reel, et conserve la propriete
vraiment tenue que l'issue demande de conserver (« chaque fragment garde son livre et son
chapitre »). La demonstration de l'acceptance (« une phrase plus longue que la largeur est
traitee conformement a la description ») est ajoutee en fin de cellule — sortie reelle du run :

```text
=== Sous-decoupage d'un chapitre trop long (taille_max=22) ===
  'Cette phrase contient'  origine : [Ouvrage de test > ch.1]
  'plusieurs mots et se'  origine : [Ouvrage de test > ch.1]
  'termine ici.'  origine : [Ouvrage de test > ch.1]
```

Exactement le comportement documente par le finding (`['Cette phrase contient', 'plusieurs
mots et se', 'termine ici.']`), avec l'etiquette livre+chapitre preservee sur chaque morceau.

### Defaut 2 — le 5/5 ne demontrait aucune amelioration (ING:c13)

`exact_naif` etait initialise sans jamais etre alimente : la precision naive restait `N/A`
pendant que la sortie finale se lisait comme une comparaison gagnante. L'issue offre deux
routes (« le meme type de verite terrain pour les deux methodes, **ou** reste explicitement
une demonstration de provenance ») et privilegie explicitement la seconde (« acceptable et
peu couteuse... C'est le geste a privilegier avant mercredi »).

**Correctif** : variable morte retiree ; le score est reframe en sortie reelle :

```text
Provenance (chapitre) au top-1, structure = 5/5.
La strategie NAIVE n'a pas d'etiquette -> sa provenance n'est PAS verifiable.
Le score ci-dessus est donc une demonstration de PROVENANCE du structure
(ses metadonnees sont retrouvees au top-1), PAS une victoire de precision
du structure sur le naif : on compare une provenance lisible a une absence
d'etiquette, non deux precisions de retrieval.
```

Tracabilite et qualite de retrieval sont presentes separement, comme le demande la
correction minimale d'Astra. Aucune verite terrain construite pour le naif — c'est la route
assumee, pas un contournement.

### Tailles du commentaire (acceptance, 3e point)

Les chiffres cites en prose (20 chunks naifs / 18 structures, matrice 38 x 246) sont
**restes conformes au run re-execute** — verifie cellule par cellule contre les sorties
reelles : aucun nombre n'a derive, la prose etait deja ancree sur les vraies variables
(sorties des cellules 9 et 11 reproduites a l'identique par le run).

### Re-execution reelle (C.2)

Notebook entier re-execute (`notebook_tools.py execute --kernel python3`) : **10 cellules
code, 0 `execution_count` null, 0 erreur**, 7.1 s. TF-IDF deterministe local
(scikit-learn 1.6.1), aucun reseau.

### Verifications

- Diff source strictement confine aux cellules 7 et 13 (comparaison per-cellule contre
  `b646b2fca0` = origin/main) : 26 cellules avant/apres, aucune suppression, aucun
  reordonnancement.
- Ratchets rejoues (base `origin/main` = merge-base `b646b2fca0`) :
  `check_output_failure_text.py` **0 regressed**, `check_output_flood.py` **0 regressed**,
  `check_cell_source_parses.py` **0 finding**.
- 0 chemin machine dans les sorties ; AST parse 10/10 ; 0 `raise NotImplementedError` /
  `assert False` / `1/0` (C.1) ; les 3 cellules d'exercice stub sont conservees
  byte-identiques (anti-regression).
- Catalogue byte-identique a main ; 1 fichier, 335 insertions / 74 deletions (churn de
  re-execution compris).
- Claim poste en commentaire de l'issue avant le debut ([CLAIMED] myia-po-2023:CoursIA,
  2026-09-07 18:04Z) conformement au protocole de routage du commentaire de 13:29Z.
