### PR TITLE
fix(genai,#15041): G06 Cas B — extraire les 3 stubs C# du CSK en vraies cellules de code

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "f5dd089c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004141,
+     "end_time": "2026-09-07T18:24:26.874090",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:26.869949",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GitHub Copilot SDK en C# : binding, streaming, Scrutor\n",
     "\n",
@@ -21,7 +30,16 @@
   {
    "cell_type": "markdown",
    "id": "49101ac9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-09-07T18:24:26.879062",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:26.877062",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Contexte : un SDK, deux protocoles, une philosophie\n",
     "\n",
@@ -44,11 +62,19 @@
    "id": "c8a30d20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T19:40:39.303682Z",
-     "iopub.status.busy": "2026-08-20T19:40:39.262311Z",
-     "iopub.status.idle": "2026-08-20T19:40:41.665358Z",
-     "shell.execute_reply": "2026-08-20T19:40:41.653438Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:24:26.890801Z",
+     "iopub.status.busy": "2026-09-07T18:24:26.886067Z",
+     "iopub.status.idle": "2026-09-07T18:24:28.347263Z",
+     "shell.execute_reply": "2026-09-07T18:24:28.343168Z"
+    },
+    "papermill": {
+     "duration": 1.466187,
+     "end_time": "2026-09-07T18:24:28.347263",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:26.881076",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -60,6 +86,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -69,7 +96,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -84,6 +114,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -95,11 +126,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '54220.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '42836.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -143,11 +176,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -193,7 +228,16 @@
   {
    "cell_type": "markdown",
    "id": "7928e83d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001985,
+     "end_time": "2026-09-07T18:24:28.352008",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:28.350023",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1 — Premier dialogue : `CopilotClient` + `SendAsync`\n",
     "\n",
@@ -212,32 +256,26 @@
    "id": "b8cac1c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T19:40:41.667884Z",
-     "iopub.status.busy": "2026-08-20T19:40:41.667322Z",
-     "iopub.status.idle": "2026-08-20T19:40:48.524554Z",
-     "shell.execute_reply": "2026-08-20T19:40:48.524841Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:24:28.358462Z",
+     "iopub.status.busy": "2026-09-07T18:24:28.358462Z",
+     "iopub.status.idle": "2026-09-07T18:24:31.775092Z",
+     "shell.execute_reply": "2026-09-07T18:24:31.775092Z"
+    },
+    "papermill": {
+     "duration": 3.420083,
+     "end_time": "2026-09-07T18:24:31.775092",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:28.355009",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Quota GitHub Copilot depasse ce mois-ci : l'appel au modele a ete refuse.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "La chaîne SDK -> CLI -> provider GitHub reste intacte ; seul l'appel LLM a echoue.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Re-executer ce notebook apres le renouvelllement mensuel du quota, OU configurer BYOK Azure OpenAI (cf. exercice 3).\r\n"
+      "Erreur SDK : IOException : Communication error with Copilot CLI: Request session.create failed with message: Model \"gpt-4.1\" is not available.\r\n"
      ]
     },
     {
@@ -364,7 +402,16 @@
   {
    "cell_type": "markdown",
    "id": "72f83d89",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003562,
+     "end_time": "2026-09-07T18:24:31.781746",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:31.778184",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -379,7 +426,16 @@
   {
    "cell_type": "markdown",
    "id": "b4749a9d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003622,
+     "end_time": "2026-09-07T18:24:31.786877",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:31.783255",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2 — Streaming via `Channel<string>` : `AssistantMessageDeltaEvent`\n",
     "\n",
@@ -399,25 +455,26 @@
    "id": "4a9c1e00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T19:40:48.527642Z",
-     "iopub.status.busy": "2026-08-20T19:40:48.527087Z",
-     "iopub.status.idle": "2026-08-20T19:40:54.400556Z",
-     "shell.execute_reply": "2026-08-20T19:40:54.401185Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:24:31.792602Z",
+     "iopub.status.busy": "2026-09-07T18:24:31.792602Z",
+     "iopub.status.idle": "2026-09-07T18:24:34.316782Z",
+     "shell.execute_reply": "2026-09-07T18:24:34.315764Z"
+    },
+    "papermill": {
+     "duration": 2.527887,
+     "end_time": "2026-09-07T18:24:34.316782",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:31.788895",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Texte assemble : \r\n"
+      "Erreur SDK : IOException : Communication error with Copilot CLI: Request session.create failed with message: Model \"gpt-4.1\" is not available.\r\n"
      ]
     },
     {
@@ -548,7 +605,16 @@
   {
    "cell_type": "markdown",
    "id": "ac7f2839",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002122,
+     "end_time": "2026-09-07T18:24:34.321884",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:34.319762",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -563,7 +629,16 @@
   {
    "cell_type": "markdown",
    "id": "518e937d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00248,
+     "end_time": "2026-09-07T18:24:34.327381",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:34.324901",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3 — Scrutor : découverte d'endpoints `IEndpoint`\n",
     "\n",
@@ -592,11 +667,19 @@
    "id": "1414a8e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T19:40:54.403595Z",
-     "iopub.status.busy": "2026-08-20T19:40:54.403091Z",
-     "iopub.status.idle": "2026-08-20T19:40:54.940618Z",
-     "shell.execute_reply": "2026-08-20T19:40:54.940922Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:24:34.335054Z",
+     "iopub.status.busy": "2026-09-07T18:24:34.335054Z",
+     "iopub.status.idle": "2026-09-07T18:24:34.584695Z",
+     "shell.execute_reply": "2026-09-07T18:24:34.584695Z"
+    },
+    "papermill": {
+     "duration": 0.254156,
+     "end_time": "2026-09-07T18:24:34.584695",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:34.330539",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -675,7 +758,16 @@
   {
    "cell_type": "markdown",
    "id": "92d163ab",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004012,
+     "end_time": "2026-09-07T18:24:34.592608",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:34.588596",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -690,7 +782,16 @@
   {
    "cell_type": "markdown",
    "id": "4b31fcf8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004153,
+     "end_time": "2026-09-07T18:24:34.599292",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:34.595139",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4 — Composition : CopilotAgent.App (Channels + Scrutor + Copilot SDK)\n",
     "\n",
@@ -703,11 +804,19 @@
    "id": "20cedb94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T19:40:54.943726Z",
-     "iopub.status.busy": "2026-08-20T19:40:54.942962Z",
-     "iopub.status.idle": "2026-08-20T19:40:57.132472Z",
-     "shell.execute_reply": "2026-08-20T19:40:57.131834Z"
-    }
+     "iopub.execute_input": "2026-09-07T18:24:34.607171Z",
+     "iopub.status.busy": "2026-09-07T18:24:34.606178Z",
+     "iopub.status.idle": "2026-09-07T18:24:35.893499Z",
+     "shell.execute_reply": "2026-09-07T18:24:35.893499Z"
+    },
+    "papermill": {
+     "duration": 1.291336,
+     "end_time": "2026-09-07T18:24:35.893499",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:34.602163",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -763,7 +872,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[srv]       Content root path: D:\\dev\\CoursIA-11926-copilot-sdk-binding\\MyIA.AI.Notebooks\\GenAI\\CopilotSDK\\CopilotAgent.App\r\n"
+      "[srv]       Content root path: C:\\dev\\CoursIA-15041b\\MyIA.AI.Notebooks\\GenAI\\Integrations-DotNet\\CopilotSDK\\CopilotAgent.App\r\n"
      ]
     },
     {
@@ -840,7 +949,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[client] Service pret en 1654 ms.\r\n"
+      "[client] Service pret en 1105 ms.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[srv] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[srv]       Request finished HTTP/1.1 GET http://127.0.0.1:5299/health - 200 - application/json;+charset=utf-8 56.3926ms\r\n"
      ]
     },
     {
@@ -924,28 +1047,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[srv]       Request finished HTTP/1.1 GET http://127.0.0.1:5299/health - 200 - application/json;+charset=utf-8 96.7589ms\r\n"
+      "[srv]       Request finished HTTP/1.1 GET http://127.0.0.1:5299/health - 200 - application/json;+charset=utf-8 0.9680ms\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[srv] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[srv]       Request finished HTTP/1.1 GET http://127.0.0.1:5299/health - 200 - application/json;+charset=utf-8 1.0709ms\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GET /health : 200 en 4 ms\r\n"
+      "GET /health : 200 en 2 ms\r\n"
      ]
     },
     {
@@ -1036,7 +1145,16 @@
   {
    "cell_type": "markdown",
    "id": "17d9ade7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005,
+     "end_time": "2026-09-07T18:24:35.903303",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.898303",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -1051,7 +1169,16 @@
   {
    "cell_type": "markdown",
    "id": "d80c59ed",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006001,
+     "end_time": "2026-09-07T18:24:35.914288",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.908287",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -1072,65 +1199,224 @@
   {
    "cell_type": "markdown",
    "id": "cf64d643",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004985,
+     "end_time": "2026-09-07T18:24:35.924288",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.919303",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 1 — invoquer `/prompt` et observer le flux SSE\n",
     "\n",
     "Complète la cellule suivante pour appeler le endpoint Scrutor `/prompt` avec une question courte (par exemple *« Quelle est la capitale du Japon ? »*) et observer le flux SSE chunk par chunk. Le format SSE rend chaque fragment précédé de `data: ` et terminé par `\\n\\n` — utilise `StreamReader.ReadLineAsync()` pour les séparer.\n",
     "\n",
-    "Indice : il faut invoquer `POST http://127.0.0.1:5299/prompt` avec un body JSON `{ \"prompt\": \"...\" }` (le record C# s'appelle `PromptRequest(string Prompt)` et `System.Text.Json` est configuré en mode web par défaut dans ASP.NET Core 9, donc la propriété est `prompt` en snake-case). Garde le timeout HTTP à 30 s.\n",
-    "\n",
-    "```csharp\n",
+    "Indice : il faut invoquer `POST http://127.0.0.1:5299/prompt` avec un body JSON `{ \"prompt\": \"...\" }` (le record C# s'appelle `PromptRequest(string Prompt)` et `System.Text.Json` est configuré en mode web par défaut dans ASP.NET Core 9, donc la propriété est `prompt` en snake-case). Garde le timeout HTTP à 30 s.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6b9fbe35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T18:24:35.932290Z",
+     "iopub.status.busy": "2026-09-07T18:24:35.932290Z",
+     "iopub.status.idle": "2026-09-07T18:24:35.957516Z",
+     "shell.execute_reply": "2026-09-07T18:24:35.957516Z"
+    },
+    "papermill": {
+     "duration": 0.029228,
+     "end_time": "2026-09-07T18:24:35.957516",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.928288",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter : invoquer /prompt et compter les chunks SSE.\r\n"
+     ]
+    }
+   ],
+   "source": [
     "// EXERCICE 1 : POST /prompt et lecture du flux SSE.\n",
     "// A compléter : envoyer la requête, lire le stream ligne par ligne, compter les chunks.\n",
     "\n",
-    "Console.WriteLine(\"Exercice 1 à compléter : invoquer /prompt et compter les chunks SSE.\");\n",
-    "```\n",
-    "\n",
-    "**Critère de validation** : la cellule affiche le nombre de chunks SSE reçus, le premier chunk commence par `data:` et la concaténation forme une réponse cohérente sur le sujet posé."
+    "Console.WriteLine(\"Exercice 1 à compléter : invoquer /prompt et compter les chunks SSE.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7752e50",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004027,
+     "end_time": "2026-09-07T18:24:35.965554",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.961527",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Critère de validation** : la cellule affiche le nombre de chunks SSE reçus, le premier chunk commence par `data:` et la concaténation forme une réponse cohérente sur le sujet posé.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "c32436b4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004004,
+     "end_time": "2026-09-07T18:24:35.972557",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.968553",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 2 — généraliser Scrutor avec `MapEndpoints`\n",
     "\n",
     "L'exercice 1 du notebook [`04-Aspire-Streaming-Agent.ipynb`](../Aspire/04-Aspire-Streaming-Agent.ipynb) t'a fait réécrire un endpoint typé. Ici, on te demande de **généraliser la glue Scrutor** : la méthode `MapEndpoints` doit itérer sur `IEnumerable<IEndpoint>` résolu par DI et appeler `Map(...)` sur chacun. Vérifie aussi que `HealthEndpoint` est bien dans la liste retournée par `provider.GetServices<IEndpoint>()`.\n",
     "\n",
-    "Indice : inspire-toi de la cellule 10. Le code complet est déjà dans `CopilotAgent.App/Program.cs` — compare avec ta version pour voir ce qui manque.\n",
-    "\n",
-    "```csharp\n",
+    "Indice : inspire-toi de la cellule 10. Le code complet est déjà dans `CopilotAgent.App/Program.cs` — compare avec ta version pour voir ce qui manque.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "22cb33ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T18:24:35.981580Z",
+     "iopub.status.busy": "2026-09-07T18:24:35.981580Z",
+     "iopub.status.idle": "2026-09-07T18:24:36.003252Z",
+     "shell.execute_reply": "2026-09-07T18:24:36.003252Z"
+    },
+    "papermill": {
+     "duration": 0.026532,
+     "end_time": "2026-09-07T18:24:36.003252",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:35.976720",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter : ScanEndpoints + MapEndpoints typés.\r\n"
+     ]
+    }
+   ],
+   "source": [
     "// EXERCICE 2 : généraliser la glue Scrutor.\n",
     "// A compléter : déclarer IServiceCollection ScanEndpoints(I), IEndpointRouteBuilder MapEndpoints(I).\n",
     "\n",
-    "Console.WriteLine(\"Exercice 2 à compléter : ScanEndpoints + MapEndpoints typés.\");\n",
-    "```\n",
-    "\n",
-    "**Critère de validation** : ta méthode `MapEndpoints` est appelée après `app.Build()` dans `CopilotAgent.App/Program.cs`, et `GET /health` retourne le JSON attendu."
+    "Console.WriteLine(\"Exercice 2 à compléter : ScanEndpoints + MapEndpoints typés.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed9ac6ae",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004004,
+     "end_time": "2026-09-07T18:24:36.010811",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:36.006807",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Critère de validation** : ta méthode `MapEndpoints` est appelée après `app.Build()` dans `CopilotAgent.App/Program.cs`, et `GET /health` retourne le JSON attendu.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "33bc0c0f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004001,
+     "end_time": "2026-09-07T18:24:36.018850",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:36.014849",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 3 — câbler BYOK Azure OpenAI via `Provider` config\n",
     "\n",
     "Le SDK supporte Azure OpenAI en configurant `SessionConfig.Provider` avec un objet qui porte l'endpoint Azure, le déploiement, et la clé API. Sans cette clé (variable d'environnement `AZURE_OPENAI_API_KEY`), le notebook doit **stubber** le client (cf. règle C.1 : pas de `raise NotImplementedError`).\n",
     "\n",
-    "Indice : en SDK 1.0.11, `Provider` est un objet `IDictionary<string, object>` (ou un type concret `CopilotProvider` — voir la doc NuGet 1.0.11). Les clés typiques sont `\"kind\"`, `\"base_url\"`, `\"api_key\"`, `\"wire_api\"`. Quand la clé Azure manque, le notebook doit afficher un message clair et un lien vers la doc, **pas** crasher.\n",
-    "\n",
-    "```csharp\n",
+    "Indice : en SDK 1.0.11, `Provider` est un objet `IDictionary<string, object>` (ou un type concret `CopilotProvider` — voir la doc NuGet 1.0.11). Les clés typiques sont `\"kind\"`, `\"base_url\"`, `\"api_key\"`, `\"wire_api\"`. Quand la clé Azure manque, le notebook doit afficher un message clair et un lien vers la doc, **pas** crasher.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "08bc9d55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T18:24:36.027849Z",
+     "iopub.status.busy": "2026-09-07T18:24:36.027849Z",
+     "iopub.status.idle": "2026-09-07T18:24:36.069329Z",
+     "shell.execute_reply": "2026-09-07T18:24:36.069329Z"
+    },
+    "papermill": {
+     "duration": 0.047494,
+     "end_time": "2026-09-07T18:24:36.069329",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:36.021835",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter : branchement BYOK Azure OpenAI.\r\n"
+     ]
+    }
+   ],
+   "source": [
     "// EXERCICE 3 : câbler BYOK Azure OpenAI via Provider (stubbé sans clé).\n",
     "// A compléter : si AZURE_OPENAI_API_KEY est défini, créer une session avec Provider azure.\n",
     "//                sinon, afficher un stub C.1-conform qui pointe vers la doc.\n",
     "\n",
-    "Console.WriteLine(\"Exercice 3 à compléter : branchement BYOK Azure OpenAI.\");\n",
-    "```\n",
-    "\n",
-    "**Critère de validation** : sans clé, la cellule rend un message stub propre et un lien vers la doc NuGet ; avec une clé factice (variable d'env), elle tente la session et affiche l'erreur venue du provider (pas une `NullReferenceException`)."
+    "Console.WriteLine(\"Exercice 3 à compléter : branchement BYOK Azure OpenAI.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "139cc2c1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004998,
+     "end_time": "2026-09-07T18:24:36.081354",
+     "exception": false,
+     "start_time": "2026-09-07T18:24:36.076356",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Critère de validation** : sans clé, la cellule rend un message stub propre et un lien vers la doc NuGet ; avec une clé factice (variable d'env), elle tente la session et affiche l'erreur venue du provider (pas une `NullReferenceException`).\n"
    ]
   }
  ],
@@ -1146,6 +1432,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 11.766019,
+   "end_time": "2026-09-07T18:24:36.210573",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "01-GitHub-Copilot-SDK-Binding.ipynb",
+   "output_path": "csk_out3.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-07T18:24:24.444554",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-dotnet -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15056

## Résumé

G06 (#15041), **Cas B** — extraire les trois blocs `csharp` enfermés dans les cellules markdown du notebook CSK `01-GitHub-Copilot-SDK-Binding.ipynb` en **vraies cellules de code** exécutables (correction minimale Astra : « Extraire les trois blocs C# de CSK en vraies cellules de code »).

Le défaut : les exercices 1-3 (c16-c18) étaient des énoncés markdown contenant le stub C# dans un bloc fenced — la cellule de code promise n'existait pas ; l'étudiant devait d'abord fabriquer son espace de travail. Un groupe qui pioche dans le catalogue ne peut pas piocher dans un notebook sans cellule à compléter.

## Livrable (1 notebook, 1 sujet)

Chaque exercice devient le triplet idiomatique du notebook (md énoncé → code → md lecture, comme c03/c04/c05) :

| Avant | Après |
|---|---|
| c16 md (énoncé + fence + critère) | c16 énoncé → **c17 code** → c18 critère |
| c17 md | c19 énoncé → **c20 code** → c21 critère |
| c18 md | c22 énoncé → **c23 code** → c24 critère |

Le contenu des stubs est **extrait verbatim des fences** (inchangé) : `// A compléter` + `Console.WriteLine("Exercice N à compléter : ...")` — pas d'erreur volontaire (C.1), exécutable bout en bout. 19 → 25 cellules.

## Validation

- **Re-exéc complète** papermill kernel `.net-csharp`, cwd = dossier CopilotSDK : 8 cellules code (5 existantes + 3 nouvelles), **0 erreur**, **0 `execution_count` null** (H.1/H.3). Le service `CopilotAgent.App` démarre **en direct** : `Now listening on :5299`, `/health` 200 en ~1,1 s, endpoints exécutés, arrêt propre — profil d'exécution identique à celui commis sur main.
- Compteur d'exercices : avant `count=0 sub-threshold` → après `count=3 conforming` — vérifié avec le compteur de main **et** le compteur corrigé D01 (PR #15092).
- `grep NotImplemented` : 1 occurrence, en **prose markdown** (l'énoncé 3 cite la règle C.1 « pas de `raise NotImplementedException` ») — verbatim de main, aucun code.

## Env (règle F — réparation, pas contournement)

- `dotnet build CopilotAgent.App` : OK, `copilot.exe` 1.0.79 téléchargé par la cible MSBuild au chemin exact attendu par c4/c7.
- Runtime **.NET 9 absent** de `C:\Program Files\dotnet` (3.1/6.0/10.x seulement) → le service net9.0 refusait de démarrer. Le runtime 9.0.15 existait déjà dans `%USERPROFILE%\.dotnet` (jamais sur le chemin de sonde). Ajoutés dans `%USERPROFILE%\.dotnet` : runtimes NETCore + ASP.NET **10.0.11** + `DOTNET_ROOT` persistant — le kernel `dotnet-interactive` (net10.0) et l'app net9.0 résolvent tous deux depuis ce répertoire.
- `dotnet run` écrase `DOTNET_ROOT*` pour son enfant : le lancement passe par `DOTNET_ROLL_FORWARD=Major` (env du process d'exécution, pas persistant) — l'app net9.0 roule sur le runtime 10.0.11, vérifié `health=200` avant l'exécution du notebook.

## Signal remonté (hors scope, à traiter séparément)

c4/c7 : le CLI Copilot est **authentifié** mais le serveur répond `Model "gpt-4.1" is not available` — main avait le même type d'échec propre (quota). Les cellules le gèrent via leur catch (chaîne SDK intacte, échec expliqué). Si le modèle `gpt-4.1` a été retiré côté GitHub, un changement de nom de modèle dans c4/c7 sera nécessaire — sujet séparé, pas dans cette PR.

## Résiduel (hors scope de cette PR)

- **Cas C** (absences : 05b, 10e_LLamaSharp, 01-1b) : lié au champ `role_pedagogique` du catalogue (D01 #15080 critère 4 — décision de schema ai-01).
- **Cas D** (EMB : paramètres de l'expérience pilotés par appel explicite) : notebook distinct.

See #15041 (Cas B livré ; C/D en résiduel)