### PR TITLE
fix(ci,#15091): bornes I/O ai-01 -- unite corrigee, daemon.json, garde sur l'arret

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,6 +38,19 @@ MyIA.AI.Notebooks/**/*.md text eol=lf
 *.lean text eol=lf
 *.sh text eol=lf
 *.service text eol=lf
+# Meme motif, meme consommateur (#15091) : une slice systemd est parsee ligne a
+# ligne par le meme analyseur que les .service ci-dessus -- un `CPUQuota=800%`
+# suivi d'un CR devient une valeur invalide, et l'unite refuse de charger. Le
+# depot est checkout par git Windows sous /mnt/d, puis les fichiers sont
+# installes depuis CE working tree vers /etc/systemd/system : sans regle, la
+# borne agregee serait deployee illisible et le refus se lirait comme une
+# panne de cgroup.
+*.slice text eol=lf
+# daemon.json est lu par dockerd sous Linux. JSON tolere CRLF, donc le defaut
+# serait SILENCIEUX ici -- mais le fichier voisine avec la slice dans le meme
+# geste d'installation, et une regle qui couvre l'un sans l'autre invite a
+# croire que le repertoire entier est normalise.
+scripts/ci/docker/linux-runner/persist/**/*.json text eol=lf
 .env text eol=lf
 .env.example text eol=lf
 *.en.md text eol=lf

--- a/scripts/ci/docker/linux-runner/persist/README.md
+++ b/scripts/ci/docker/linux-runner/persist/README.md
@@ -1,0 +1,227 @@
+# `persist/` -- copies de reference des fichiers qui vivent HORS du depot
+
+Les fichiers de ce repertoire ne sont **executes par personne ici**. Chacun est la
+copie de reference d'un fichier deploye ailleurs : une unite systemd sous
+`/etc/systemd/system/`, un wrapper sous `/usr/local/bin/`, une configuration de
+daemon sous `/etc/docker/`. Le depot en garde une copie pour qu'ils soient
+relisibles, versionnes et discutables en PR -- pas pour qu'ils tournent.
+
+**Consequence directe, et c'est la premiere correction que ce fichier doit :**
+modifier un fichier ici ne change rien sur une machine tant que la copie vivante
+n'a pas ete remplacee. Un `git pull` ne deploie pas `persist/`.
+
+## Table de correspondance -- quel fichier appartient a quelle machine
+
+| Fichier | Machine | Chemin vivant | Etat |
+|---|---|---|---|
+| `coursia-runner.service` | **po-2024** | `/etc/systemd/system/coursia-runner.service` | reference |
+| `coursia-runner-start.sh` | **po-2024** | `/usr/local/bin/coursia-runner-start.sh` | reference |
+| `launch-runner.sh` | po-2024 | lancement manuel d'un slot | reference |
+| `hold-runner.ps1` | po-2024 (hote Windows) | tache planifiee | reference |
+| `coursia-waiters.service` | **ai-01** | `/etc/systemd/system/coursia-waiters.service` | reference |
+| `coursia-waiters-start.sh` | **ai-01** | `/usr/local/bin/coursia-waiters-start.sh` | reference |
+| `coursia-ci.slice` | **ai-01** | `/etc/systemd/system/coursia-ci.slice` | **a deployer** (une version ad-hoc de 283 octets, sans documentation, occupe la place) |
+| `daemon.json` | **ai-01** | `/etc/docker/daemon.json` | **a deployer** (le fichier n'existe pas encore) |
+| `ai-01/coursia-runner.service` | **ai-01** | `/etc/systemd/system/coursia-runner.service` | **a deployer** (corrige, cf. correction 3) |
+| `ai-01/coursia-runner-start.sh` | **ai-01** | `/usr/local/bin/coursia-runner-start.sh` | **a deployer** (corrige, cf. correction 3) |
+
+Le sous-repertoire `ai-01/` existe parce que les deux machines ont des fichiers
+**homonymes et incompatibles**. Les melanger a plat, comme c'etait le cas, revient
+a laisser croire qu'il n'y en a qu'un.
+
+## Les trois corrections dues sur #15091 / #15094
+
+Ces trois points ont ete etablis firsthand sur ai-01 le 2026-09-07 (lecture des
+fichiers vivants via `wsl.exe -d Ubuntu -u root --`). Ils corrigent des choses que
+j'avais annoncees ou laissees entendre, et qui etaient fausses.
+
+### 1. La PR #15094 patche une copie qui ne tourne pas sur ai-01
+
+`persist/coursia-runner.service` et `persist/coursia-runner-start.sh` sont ceux de
+**po-2024** : depot sous `/mnt/c/dev/CoursIA`, prefixe `myia-po-2024-linux-docker`,
+et un wrapper qui relaie n'importe quelle sous-commande (`exec "$SUPERVISE" "$@"`).
+
+Les fichiers vivants d'ai-01 sont differents sur les trois points qui comptent :
+depot sous `/mnt/d/CoursIA`, prefixe `myia-ai-01-wsl`, et un premier argument qui
+est le **nombre de slots**, pas une sous-commande. Un correctif porte sur la copie
+a plat ne touche donc pas la machine qui a gele. C'est ce que le sous-repertoire
+`ai-01/` rend desormais impossible a confondre.
+
+### 2. `systemctl start` ignore `disabled` -- une unite desactivee redemarre au boot
+
+J'ai ecrit que la machine etait au repos parce que les deux unites etaient
+`inactive` / `disabled`. C'etait incomplet. `disabled` ne dit qu'une chose : que
+l'unite n'a pas de lien dans `multi-user.target.wants`. Un `systemctl start`
+explicite la demarre quand meme.
+
+Or la tache planifiee Windows **`CoursIA-LinuxRunners-Boot`** fait exactement cela
+a chaque demarrage. Une unite desactivee y est donc re-armee sans que rien ne
+signale la contradiction. La desactivation seule n'est pas un arret : la tache
+planifiee fait partie de l'inventaire a traiter, et elle est le vrai item du lot
+UAC (le travail sur le superviseur, lui, n'en demande aucun -- tout se fait sous
+WSL root).
+
+### 3. L'arret gracieux d'ai-01 n'a jamais fonctionne, et rendait 0 en le faisant
+
+C'est le defaut le plus consequent des trois, parce qu'il est silencieux.
+
+`coursia-runner.service` sur ai-01 porte un `Environment=` **vide** et un
+`ExecStop=` qui appelle `supervise.sh stop` **directement**, sans passer par le
+wrapper. Sans `COURSIA_RUNNER_STATE_DIR`, `supervise.sh` retombe sur son defaut,
+`$HOME/.coursia-runner` -- soit `/root/.coursia-runner` pour un service systemd.
+Et comme `supervise.sh` fait lui-meme `mkdir -p "$STATE_DIR"`, l'arret **cree** ce
+repertoire, y pose son sentinel, et affiche son message de succes.
+
+Mesure : le repertoire n'existait pas avant la sonde, il existait apres. Le
+superviseur, lui, surveille `/var/lib/coursia-runner/stop`. Il n'a jamais rien vu.
+
+`cmd_stop` rend `0` quoi qu'il arrive -- le script tourne sous `set -uo pipefail`
+**sans `-e`**, donc l'echec eventuel du `touch` n'interromprait rien, et le code de
+retour de la fonction est celui de son dernier `echo`. Un arret inerte est donc
+indiscernable d'un arret reussi, pour systemd comme pour l'operateur.
+
+La suite est mecanique : `systemctl stop` attend, rien ne se passe, puis le
+`KillMode=mixed` envoie SIGTERM aux jobs en vol. C'est-a-dire precisement le
+« couper net » que le sentinel existe pour eviter, et que le commentaire de
+l'unite decrit comme produisant des rouges qui ne veulent rien dire.
+
+La jambe **waiters** ne souffre pas de ce defaut : son wrapper porte une branche
+`stop`, et son unite y route son `ExecStop`. `ai-01/coursia-runner-start.sh`
+reprend cette forme.
+
+## Ce qui rend l'ordre de grandeur concret
+
+Le diagnostic d'origine parlait de « traffic disque fou et git clones en serie ».
+Voici ce qu'un clone complet de ce depot coute, mesure sur ai-01 le 2026-09-07 par
+lecture de metadonnees git (aucun clone lance -- la machine sortait de deux gels
+d'I/O, et deux autres lanes sondaient le disque au meme moment) :
+
+| Grandeur | Valeur | Comment elle est obtenue |
+|---|---|---|
+| Objets dans le pack | 241 982 | `git count-objects -v` |
+| **Transfere par un clone complet** | **3,70 Gio** | `size-pack` |
+| **Ecrit par le checkout** | **1,14 Gio** (10 387 blobs) | somme des tailles de `git ls-tree -r -l HEAD` |
+| `.git` sur disque, arbre deja construit | 13 Go | `du -sh` |
+| Arbre de travail apres builds | 67 Go | `du -sh` |
+
+Les deux dernieres lignes ne sont **pas** ce qu'un clone ecrit : elles portent les
+artefacts de build (`.lake`, caches, sorties). Ce qu'un slot neuf ecrit reellement,
+c'est la somme des deux premieres, **environ 4,8 Gio par clone**. Douze slots qui
+repartent ensemble ecrivent une cinquantaine de gigaoctets avant d'avoir execute la
+premiere ligne de CI -- sans aucun plafond, sur le meme disque que l'interactif.
+
+C'est la raison d'etre des bornes ci-dessous, et la raison pour laquelle elles sont
+posees **avant** le redemarrage du parc, pas apres.
+
+## Les trois bornes, et laquelle borne quoi
+
+Elles ne sont pas redondantes : chacune couvre ce que les autres ne peuvent pas
+voir.
+
+| Borne | Ou elle vit | Ce qu'elle borne | Ce qu'elle ne peut pas borner |
+|---|---|---|---|
+| `coursia-ci.slice` | `/etc/systemd/system/` + `cgroup-parent` du daemon | la **somme** de tous les conteneurs : `CPUQuota=800%`, `IOWriteBandwidthMax` | rien en dessous : elle ne distingue pas un slot glouton d'une famille entiere |
+| `--device-write-bps` / `--device-read-bps` | drapeaux passes par `supervise.sh` a chaque `docker run` | **un** conteneur | la somme : 12 conteneurs conformes un a un saturent quand meme le disque |
+| `COURSIA_RUNNER_CPU_BUDGET` | verification dans `supervise.sh` au demarrage | la **somme des demandes** de vCPU entre familles, **avant** de lancer quoi que ce soit | l'usage reel : c'est un refus de demarrage, pas un plafond kernel |
+
+Le budget agrege est **applique par defaut du daemon** (`cgroup-parent` dans
+`daemon.json`), pas par un drapeau du superviseur -- et le superviseur le
+**verifie** plutot que de le re-imposer. La distinction n'est pas cosmetique :
+passer `--cgroup-parent` sur une machine ou la slice n'existe pas **cree** un
+cgroup vide, qui a l'apparence exacte d'un garde et ne borne rien.
+
+Mesure du 2026-09-07, trois conteneurs ecrivant en parallele sur `/dev/sde` :
+
+| | Debit cumule |
+|---|---|
+| sans la slice | 5,4 + 5,9 + 5,6 = **16,9 Go/s** |
+| sous la slice (`wbps=209715200`) | 77,6 + 72,0 + 71,5 = **221 Mo/s** |
+
+soit 5,4 % au-dessus des 209,7 Mo/s declares, et un facteur **76**. Le plafond par
+conteneur a ete verifie separement : 7,4 Go/s ramenes a 21,2 Mo/s sous un cap de
+20 Mio/s, a 1 % pres.
+
+## Ce que la conteneurisation du superviseur ne resoudra PAS
+
+Le superviseur lance ses conteneurs a travers le socket du daemon. Une fois
+conteneurise, il reste donc **oncle** de ses workers, jamais leur parent : les
+conteneurs naissent dans le cgroup du daemon, pas dans le sien. Mettre le
+superviseur dans un cgroup borne ne borne que ce que le superviseur ecrit
+lui-meme -- ses journaux.
+
+Ce que la conteneurisation apporte reellement : l'isolation de l'environnement du
+superviseur, un `--restart on-failure` qui ne depend pas de systemd, et un cgroup
+propre pour ses propres ressources. Ce qu'elle demande en echange : monter
+`/var/run/docker-ce.sock` dans le conteneur, ce qui est **equivalent a root sur
+l'hote**. Les deux moities de ce constat doivent figurer dans la PR qui la porte.
+
+## Deploiement sur ai-01
+
+**Aucun UAC.** WSL root ne passe pas par l'elevation Windows -- tout ce qui suit
+s'execute via `wsl.exe -d Ubuntu -u root --`. Les items qui demandent reellement
+une fenetre UAC sont les **taches planifiees Windows**, et elles sont annoncees
+separement.
+
+Ordre obligatoire -- les bornes d'abord, le parc ensuite. Redemarrer avant de les
+poser ferait repartir la file sous le regime non borne qui a gele la machine.
+
+```sh
+# 1. Le budget agrege, au daemon et au kernel.
+install -m 0644 persist/daemon.json          /etc/docker/daemon.json
+install -m 0644 persist/coursia-ci.slice     /etc/systemd/system/coursia-ci.slice
+
+# 2. L'unite corrigee et son wrapper.
+install -m 0644 persist/ai-01/coursia-runner.service   /etc/systemd/system/coursia-runner.service
+install -m 0755 persist/ai-01/coursia-runner-start.sh  /usr/local/bin/coursia-runner-start.sh
+
+# 3. Recharger, puis appliquer.
+systemctl daemon-reload
+systemctl restart docker.service          # docker-ce : 0 conteneur, redemarrage sans effet sur le parc
+systemctl start coursia-ci.slice
+
+# 4. Verifier que la borne est REELLE avant de rallumer quoi que ce soit.
+cat /sys/fs/cgroup/coursia.slice/coursia-ci.slice/io.max
+cat /sys/fs/cgroup/coursia.slice/coursia-ci.slice/cpu.max
+./scripts/ci/docker/linux-runner/supervise.sh status
+```
+
+Le chemin kernel porte **deux** niveaux (`coursia.slice/coursia-ci.slice`) parce
+que systemd imbrique automatiquement une slice sous le prefixe de son nom. Chercher
+`coursia-ci.slice` a la racine du cgroup ne rend rien, et se lit a tort comme une
+slice absente.
+
+Le `restart docker.service` ne vise que **docker-ce** (`unix:///var/run/docker-ce.sock`,
+pid 253, `Name=MyIA-AI-01`), qui portait **0 conteneur** a la mesure. Le socket par
+defaut est celui du proxy Docker Desktop (pid 10179), qui portait les 48 conteneurs
+du parc : il n'est pas touche.
+
+`supervise.sh status` est le controle qui compte : il enumere les familles actives,
+lit la slice, et **refuse** de rendre un vert si le budget est exige et absent
+(`COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET=1`, arme par le wrapper d'ai-01).
+
+## Rotation des journaux
+
+Les journaux du superviseur ne tournaient pas : `/var/lib/coursia-runner` pesait
+**14 Mo** et `/var/lib/coursia-waiters` 280 Ko, sans rotation d'aucune sorte.
+
+`supervise.sh` porte desormais `COURSIA_RUNNER_LOG_MAX_BYTES`, et c'est **la seule
+des nouvelles valeurs qui n'est pas inerte par defaut** : elle vaut **32 Mio**, donc
+la rotation s'active partout, po-2024 comprise, des le `git pull`. Les autres bornes
+sont vides ou a 0 tant qu'une machine ne les declare pas -- une machine ne se voit
+jamais imposer un plafond de ressources qu'elle n'a pas demande. La rotation est
+d'une autre nature : elle ne refuse rien, ne ralentit rien, et son absence est ce
+qui a laisse un journal grossir sans borne. La laisser inerte aurait demande a
+chaque machine de reclamer explicitement de ne pas remplir son disque.
+
+Les journaux des **conteneurs** sont bornes ailleurs, par `daemon.json`
+(`log-driver: local`, 10 Mo x 3). Deux mecanismes distincts, ecrits a deux endroits
+differents, qui remplissaient chacun le meme disque.
+
+## Voir aussi
+
+- [`../supervise.sh`](../supervise.sh) -- le superviseur, ses trois pools et ses bornes
+- [`../test_supervise_guards.sh`](../test_supervise_guards.sh) -- 18 tests, chaque garde avec son controle negatif
+- [`../../../../../docs/ci/self-hosted-runners.md`](../../../../../docs/ci/self-hosted-runners.md) -- vue d'ensemble du parc
+- **#15091** -- revision du design du superviseur (traffic disque, isolation)
+- **#14385** -- volumes `_work` par slot -- les waiters n'en montent pas, le test 17 le garde
+- **#14801** -- fraicheur de l'image, verifiee par empreinte de l'entrypoint

--- a/scripts/ci/docker/linux-runner/persist/ai-01/coursia-runner-start.sh
+++ b/scripts/ci/docker/linux-runner/persist/ai-01/coursia-runner-start.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Lanceur du superviseur de runners Linux -- version ai-01 (systemd/Ubuntu WSL2).
+# Copie de REFERENCE : l'original vit dans la distro Ubuntu de l'hote, sous
+# /usr/local/bin/coursia-runner-start.sh.
+#
+# CE QUI DISTINGUE CETTE COPIE DE persist/coursia-runner-start.sh
+# ---------------------------------------------------------------
+# La copie a la racine de persist/ est celle de po-2024 : depot sous
+# /mnt/c/dev/CoursIA, prefixe myia-po-2024-linux-docker, et surtout un
+# `exec "$SUPERVISE" "$@"` qui relaie n'importe quelle sous-commande. Celle-ci
+# vit sur ai-01 : depot sous /mnt/d/CoursIA, prefixe myia-ai-01-wsl, et le
+# premier argument est le NOMBRE DE SLOTS, pas une sous-commande.
+#
+# Les deux ne sont pas interchangeables, et c'est ce qui a fait qu'un correctif
+# porte sur la copie po-2024 (#15094) ne changeait rien a ce qui tourne ici.
+# persist/README.md dresse la table de correspondance ; ce commentaire existe
+# pour que la question se pose meme sans lire le README.
+#
+# LE DEFAUT QUE CETTE VERSION CORRIGE (#15091)
+# --------------------------------------------
+# La version deployee ne connaissait que le demarrage. L'unite routait donc son
+# ExecStop directement vers supervise.sh, SANS COURSIA_RUNNER_STATE_DIR --
+# lequel retombe alors sur $HOME/.coursia-runner. Or supervise.sh fait lui-meme
+# `mkdir -p "$STATE_DIR"` : l'arret CREAIT /root/.coursia-runner/, y posait le
+# sentinel, et rendait rc=0. Mesure ai-01 du 2026-09-07 : le repertoire
+# n'existait pas avant la sonde, il existait apres, et le superviseur -- qui
+# surveille /var/lib/coursia-runner/stop -- n'a jamais rien vu.
+#
+# L'arret gracieux etait donc inerte depuis son deploiement, en annoncant le
+# succes. `systemctl stop` retombait sur le SIGTERM de KillMode=mixed, c'est-a-dire
+# exactement ce que le sentinel existe pour eviter : un job en vol tue net, qui
+# rend un rouge ne voulant rien dire.
+#
+# La reparation est la branche `stop` ci-dessous : l'arret repasse par le
+# wrapper, donc par le meme STATE_DIR que le demarrage. C'est la forme qu'a
+# deja coursia-waiters-start.sh, et la raison pour laquelle la jambe waiters,
+# elle, s'arrete proprement.
+#
+# LE SECRET NE SE DUPLIQUE PAS. GH_RUNNERS_ADMIN_TOKEN est relu dans master.env
+# a chaque demarrage plutot que recopie dans un EnvironmentFile : une seconde
+# copie serait une seconde chose a rotater et a proteger. `gh auth token` est
+# inutilisable ici -- le trousseau gh est attache a la session utilisateur, que
+# precisement ce service n'a plus.
+set -uo pipefail
+
+MASTER_ENV="${COURSIA_MASTER_ENV:-/mnt/d/CoursIA/.secrets/master.env}"
+REPO_DIR="${COURSIA_REPO_DIR:-/mnt/d/CoursIA}"
+ARG="${1:-8}"
+
+[ -r "$MASTER_ENV" ] || { echo "master.env illisible : $MASTER_ENV" >&2; exit 1; }
+
+# Extraction ciblee : on ne source PAS le fichier entier (des dizaines de
+# secrets sans rapport n'ont rien a faire dans l'environnement d'un runner).
+GH_TOKEN="$(sed -n 's/^GH_RUNNERS_ADMIN_TOKEN=//p' "$MASTER_ENV" | head -1 | tr -d '"'"'"'\r')"
+[ -n "$GH_TOKEN" ] || { echo "GH_RUNNERS_ADMIN_TOKEN absent de master.env -- abandon" >&2; exit 1; }
+export GH_TOKEN
+
+# Daemon EPINGLE. Sans cela, si l'integration WSL de Docker Desktop est activee
+# sur Ubuntu, elle remplace /var/run/docker.sock par le socket de SON daemon :
+# les conteneurs runner repartiraient sur Docker Desktop -- donc a nouveau
+# attaches a la session utilisateur, ce que cette installation existe
+# precisement pour supprimer. L'echec serait muet.
+#
+# L'epinglage porte aussi la resolution du device d'I/O : les deux daemons de
+# la machine annoncent le MEME DockerRootDir, et c'est le socket qui decide
+# lequel repond a `docker info`.
+export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker-ce.sock}"
+
+export COURSIA_RUNNER_NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-myia-ai-01-wsl}"
+export COURSIA_RUNNER_STATE_DIR="${COURSIA_RUNNER_STATE_DIR:-/var/lib/coursia-runner}"
+
+# --- Bornes #15091 ---------------------------------------------------------
+# ai-01 ARME ce que supervise.sh laisse inerte par defaut. Le script ne suppose
+# rien : ses defauts sont vides, po-2024 garde donc son comportement en tirant
+# la meme version. C'est ici, sur la machine qui a gele deux fois, que les
+# bornes sont declarees.
+#
+# 1. Budget agrege EXIGE. La slice est appliquee par defaut du daemon
+#    (/etc/docker/daemon.json), pas par un drapeau ; le superviseur la VERIFIE
+#    et refuse de demarrer si elle manque ou ne porte pas d'io.max. Un pool non
+#    borne est exactement ce qui a gele la machine : un refus lisible vaut
+#    mieux qu'un demarrage silencieux.
+export COURSIA_RUNNER_CGROUP_PARENT="${COURSIA_RUNNER_CGROUP_PARENT:-coursia-ci.slice}"
+export COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET="${COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET:-1}"
+
+# 2. Plafond PAR CONTENEUR : 40 Mio/s en ecriture, 80 Mio/s en lecture. Il ne
+#    remplace pas le budget agrege (12 conteneurs conformes un a un saturent
+#    quand meme le disque) -- il empeche UN slot d'emporter a lui seul la part
+#    de toute la famille. Le device est resolu par `docker info` a travers le
+#    socket epingle ci-dessus ; le nommer en dur ici masquerait un mauvais
+#    epinglage.
+export COURSIA_RUNNER_DEVICE_WRITE_BPS="${COURSIA_RUNNER_DEVICE_WRITE_BPS:-41943040}"
+export COURSIA_RUNNER_DEVICE_READ_BPS="${COURSIA_RUNNER_DEVICE_READ_BPS:-83886080}"
+
+# 3. Budget CPU inter-familles : 8 vCPU sur les 16 de la machine, la meme
+#    moitie que CPUQuota=800% dans la slice. Les deux bornes disent la meme
+#    chose a deux endroits differents -- la slice l'impose au kernel, ce budget
+#    la fait REFUSER au demarrage, avec un message qui nomme les termes de la
+#    somme. Sans lui, `waiters 12` puis `lean 2` sont conformes chacun et
+#    demandent 24 coeurs ensemble.
+export COURSIA_RUNNER_CPU_BUDGET="${COURSIA_RUNNER_CPU_BUDGET:-8}"
+
+mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+
+cd "$REPO_DIR" || exit 1
+
+# La branche `stop` : c'est elle qui rend l'arret gracieux reel (cf. en-tete).
+if [ "$ARG" = "stop" ]; then
+  exec ./scripts/ci/docker/linux-runner/supervise.sh stop
+fi
+exec ./scripts/ci/docker/linux-runner/supervise.sh start "$ARG"

--- a/scripts/ci/docker/linux-runner/persist/ai-01/coursia-runner.service
+++ b/scripts/ci/docker/linux-runner/persist/ai-01/coursia-runner.service
@@ -12,6 +12,26 @@ After=docker.service
 # main, et personne ne va la chercher.
 Wants=docker.service
 
+# Garde anti-emballement au niveau de l'unite (#15091). Restart=always seul
+# fait boucler indefiniment un service qui echoue au demarrage -- master.env
+# illisible, token revoque, slice absente sous REQUIRE=1 : autant de causes qui
+# ne se reparent PAS toutes seules. Au-dela de 5 echecs en 10 min, systemd
+# passe l'unite en `failed` et arrete de marteler. Le backoff interne des
+# boucles de slot couvre l'autre echelle -- la panne transitoire pendant que le
+# superviseur, lui, tourne.
+#
+# CES DEUX CLES SONT EN [Unit] ET NON EN [Service] (mesure du 2026-09-07). Elles
+# y ont ete ecrites d'abord, et `systemd-analyze verify` a rendu :
+#   Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
+# Une clause ignoree ne refuse rien : le service aurait redemarre toutes les 30 s
+# indefiniment, en presentant l'apparence exacte d'un garde anti-emballement.
+# C'est la classe de defaut que cette PR ferme ailleurs, reproduite dans le
+# fichier qui la porte -- d'ou la mention explicite ici plutot qu'un
+# deplacement silencieux. Depuis systemd v229 ces cles appartiennent a [Unit]
+# (systemd.unit(5)) ; mesure sur systemd 255 (255.4-1ubuntu8.17).
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/coursia-runner-start.sh 8
@@ -30,15 +50,9 @@ TimeoutStopSec=900
 
 Restart=always
 RestartSec=30
-# Garde anti-emballement au niveau de l'unite (#15091). Restart=always seul
-# fait boucler indefiniment un service qui echoue au demarrage -- master.env
-# illisible, token revoque, slice absente sous REQUIRE=1 : autant de causes qui
-# ne se reparent PAS toutes seules. Au-dela de 5 echecs en 10 min, systemd
-# passe l'unite en `failed` et arrete de marteler. Le backoff interne des
-# boucles de slot couvre l'autre echelle -- la panne transitoire pendant que le
-# superviseur, lui, tourne.
-StartLimitIntervalSec=600
-StartLimitBurst=5
+# Le plafond de redemarrage qui borne ce Restart=always vit en [Unit], pas ici
+# -- voir le bloc StartLimit* plus haut, et la raison pour laquelle il a fallu
+# l'y deplacer.
 
 # L'hote prime (clause en tete de supervise.sh et de
 # docs/ci/self-hosted-runners.md) : le superviseur cede la main devant

--- a/scripts/ci/docker/linux-runner/persist/ai-01/coursia-runner.service
+++ b/scripts/ci/docker/linux-runner/persist/ai-01/coursia-runner.service
@@ -1,0 +1,57 @@
+# Unite systemd du superviseur de runners Linux CoursIA -- version ai-01.
+# Copie de REFERENCE : l'original vit sous /etc/systemd/system/ dans la distro
+# Ubuntu de l'hote. La copie a la racine de persist/ est celle de po-2024 --
+# voir persist/README.md pour la table de correspondance.
+[Unit]
+Description=Superviseur de runners GitHub Actions Linux (CoursIA, ephemeres conteneurises)
+Documentation=https://github.com/jsboige/CoursIA/blob/main/docs/ci/self-hosted-runners.md
+After=docker.service
+# Wants= et NON Requires= (#14347 item 2). Un docker.service en echec au boot
+# doit retarder ce service et le laisser retenter sous Restart=always, pas le
+# faire sortir de la liste des unites -- une unite sortie ne revient qu'a la
+# main, et personne ne va la chercher.
+Wants=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/coursia-runner-start.sh 8
+# ExecStop PASSE PAR LE WRAPPER (#15091). La version precedente appelait
+# supervise.sh directement, donc sans COURSIA_RUNNER_STATE_DIR : le sentinel
+# atterrissait dans $HOME/.coursia-runner/ -- que supervise.sh CREE lui-meme --
+# pendant que le superviseur surveillait /var/lib/coursia-runner/. L'arret
+# gracieux etait inerte et rendait rc=0 ; systemd retombait sur le SIGTERM de
+# KillMode=mixed, tuant net les jobs en vol que le sentinel existe pour laisser
+# finir.
+ExecStop=/usr/local/bin/coursia-runner-start.sh stop
+KillMode=mixed
+# Un lake build a froid tient des dizaines de minutes : l'arret gracieux doit
+# lui laisser le temps d'aboutir, sinon il rend un rouge qui ne veut rien dire.
+TimeoutStopSec=900
+
+Restart=always
+RestartSec=30
+# Garde anti-emballement au niveau de l'unite (#15091). Restart=always seul
+# fait boucler indefiniment un service qui echoue au demarrage -- master.env
+# illisible, token revoque, slice absente sous REQUIRE=1 : autant de causes qui
+# ne se reparent PAS toutes seules. Au-dela de 5 echecs en 10 min, systemd
+# passe l'unite en `failed` et arrete de marteler. Le backoff interne des
+# boucles de slot couvre l'autre echelle -- la panne transitoire pendant que le
+# superviseur, lui, tourne.
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+# L'hote prime (clause en tete de supervise.sh et de
+# docs/ci/self-hosted-runners.md) : le superviseur cede la main devant
+# l'interactif et les trainings GPU.
+Nice=10
+# Comptabilite d'I/O et poids relatif. PAS de IOWriteBandwidthMax ici : les
+# conteneurs sont des NEVEUX du superviseur, pas ses enfants -- ils naissent
+# dans le cgroup du daemon, pas dans celui de cette unite. Un plafond dur pose
+# ici ne bornerait que ce que le superviseur ecrit lui-meme, c'est-a-dire ses
+# journaux. Le plafond dur des conteneurs vit dans coursia-ci.slice ; ce qui
+# est honnete a cette place, ce sont ces deux lignes.
+IOAccounting=yes
+IOWeight=50
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ci/docker/linux-runner/persist/ai-01/coursia-waiters.service
+++ b/scripts/ci/docker/linux-runner/persist/ai-01/coursia-waiters.service
@@ -1,0 +1,71 @@
+# Unite systemd de persistance du POOL D'ATTENTE PR-gate (label coursia-waiter).
+# Jumelle de coursia-runner.service, qui ne porte que la jambe d'EXECUTION
+# (`start N`, label coursia-linux). Les deux jambes sont independantes : state
+# dirs distincts, sentinelles d'arret distinctes, prefixes de nom distincts.
+#
+# Deploiement ai-01 (2026-09-07, #14612/#14846) : copie de REFERENCE -- l'original
+# vit dans la distro Ubuntu de l'hote, sous /etc/systemd/system/. Modifier ce
+# fichier ne change rien sur la machine tant que la copie vivante n'a pas ete
+# remplacee ; un `git pull` ne deploie pas persist/. Voir persist/README.md.
+#
+# N slots porte par l'argument ExecStart (ai-01 -> 12, l'effectif d'avant la chute).
+#
+# CE QUI DISTINGUE CETTE COPIE DE LA VERSION VIVANTE (#15091, mesure du 2026-09-07)
+# ---------------------------------------------------------------------------------
+# Un seul ajout : le plafond de redemarrage en [Unit]. Le reste est byte-pour-byte
+# la version deployee -- deliberement, pour que le diff soit relisible d'un coup
+# d'oeil et que le garde ne se cache pas au milieu d'autre chose.
+[Unit]
+Description=CoursIA PR-gate waiter pool (coursia-waiter slots)
+Documentation=https://github.com/jsboige/CoursIA/blob/main/docs/ci/self-hosted-runners.md
+# Wants= et non Requires= (meme raison que coursia-runner.service, #14347) :
+# un docker.service en echec au boot doit retarder le service et le laisser
+# retenter, pas le sortir de la liste des unites.
+Wants=docker.service
+After=docker.service
+
+# GARDE ANTI-EMBALLEMENT (#15091) -- absent de la version vivante, et le defaut
+# n'etait pas theorique : mesure du 2026-09-07, la sentinelle
+# /var/lib/coursia-waiters/stop etait POSEE, laissee par le dernier arret
+# gracieux. Or cmd_waiters REFUSE de demarrer tant qu'elle est la (supervise.sh :
+# `[ -f "$STOP_FILE" ] && die "sentinel STOP pose"`). Sous Restart=always +
+# RestartSec=30 et SANS plafond, un `systemctl start` sur cet etat aurait relance
+# le wrapper toutes les 30 secondes indefiniment -- lecture de master.env, mkdir,
+# `cd`, echec, recommence -- sur une machine qui sortait de deux gels d'I/O.
+#
+# La cause (sentinelle residuelle) se repare a la main en un `rm`. Ce qui se
+# repare ici est la CONSEQUENCE : qu'une cause non auto-reparable devienne un
+# martelement sans fin plutot qu'un `failed` visible. Au-dela de 5 echecs en
+# 10 minutes, systemd passe l'unite en `failed` et arrete.
+#
+# CES DEUX CLES VONT EN [Unit], JAMAIS EN [Service]. Ecrites en [Service],
+# `systemd-analyze verify` rend :
+#   Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
+# -- une clause ignoree ne refuse rien, et presente l'apparence exacte d'un
+# garde. Le defaut a ete commis puis mesure sur coursia-runner.service dans
+# cette meme PR ; il est nomme ici pour qu'il ne se re-commette pas au prochain
+# fichier. Depuis systemd v229 elles appartiennent a [Unit] (systemd.unit(5)) ;
+# mesure sur systemd 255 (255.4-1ubuntu8.17).
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/coursia-waiters-start.sh 12
+ExecStop=/usr/local/bin/coursia-waiters-start.sh stop
+Restart=always
+RestartSec=30
+Nice=10
+# Un slot d'attente ne porte jamais de build long : 120 s suffisent la ou la
+# jambe d'execution demande 900 s pour laisser finir un lake build.
+TimeoutStopSec=120
+# Comptabilite d'I/O sur le superviseur lui-meme. PAS de IOWriteBandwidthMax ici :
+# les conteneurs waiters sont des NEVEUX de cette unite, pas des enfants -- ils
+# naissent dans le cgroup du daemon docker. Un plafond dur pose ici ne bornerait
+# que les journaux du superviseur. Ce qui borne les conteneurs est la slice
+# agregee, appliquee par defaut via "cgroup-parent" dans /etc/docker/daemon.json.
+IOAccounting=yes
+IOWeight=50
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ci/docker/linux-runner/persist/coursia-ci.slice
+++ b/scripts/ci/docker/linux-runner/persist/coursia-ci.slice
@@ -1,0 +1,82 @@
+# Budget AGREGE de toutes les familles de conteneurs runner (#15091 piece 4).
+#
+# CE QUE CETTE SLICE FERME
+# ------------------------
+# supervise.sh documente lui-meme le trou, dans cmd_lean :
+#
+#   « La somme des caps CPU des familles actives n'est gardee par RIEN --
+#     c'est l'operateur qui dimensionne. »
+#
+# Le garde `supervisor_pids()` ne matche que `supervise.sh start` : les
+# familles `start`, `waiters` et `lean` coexistent donc sans plafond commun.
+# Les caps `--cpus` / `--memory` de docker sont PAR CONTENEUR : 12 waiters a
+# 1 vCPU chacun sont conformes un par un et prennent 12 coeurs ensemble.
+#
+# Un plafond par conteneur ne peut pas borner une flotte. Un cgroup PARENT le
+# peut : les conteneurs y sont imbriques, et les limites du parent s'appliquent
+# a leur SOMME. C'est le seul endroit ou un budget inter-familles existe.
+#
+# COMMENT LES CONTENEURS Y ENTRENT
+# --------------------------------
+# Par le defaut du daemon, pas par un drapeau que chaque appelant devrait
+# penser a passer -- `/etc/docker/daemon.json` porte `"cgroup-parent":
+# "coursia-ci.slice"` (copie de reference dans persist/daemon.json). Tout
+# conteneur du daemon docker-ce y atterrit, y compris ceux lances a la main
+# pour un debug, y compris ceux d'une famille future que personne n'aura pense
+# a cabler. Un garde qui depend de la memoire de son appelant n'est pas un
+# garde.
+#
+# systemd imbrique une slice sur son nom : `coursia-ci.slice` vit sous
+# `coursia.slice`. Le chemin cgroup reel est donc
+# /sys/fs/cgroup/coursia.slice/coursia-ci.slice/ -- c'est la qu'on lit io.max.
+#
+# MESURE (ai-01, 2026-09-07, controle apparie a trois conteneurs simultanes
+# ecrivant 400 Mio chacun en oflag=direct sur leur volume _work) :
+#
+#   sans la slice : 5,4 + 5,9 + 5,6 GB/s  =  16,9 GB/s cumules
+#   sous la slice :  77,6 + 72,0 + 71,5 MB/s = 221 MB/s cumules
+#
+# soit un facteur 76, pour un plafond declare a 209,7 MB/s (ecart 5,4 %, la
+# tolerance attendue du throttling cgroup v2 sur des rafales en direct I/O).
+# io.max relu sur le cgroup pendant la mesure :
+#   8:64 rbps=419430400 wbps=209715200 riops=max wiops=max
+# 8:64 est /dev/sde, le device qui porte /var/lib/docker du daemon docker-ce.
+#
+# POURQUOI PAS IOWriteBandwidthMax SUR LES UNITES DU SUPERVISEUR
+# --------------------------------------------------------------
+# Parce que ce serait un garde de facade. Le superviseur parle au daemon par
+# le socket : les conteneurs sont ses NEVEUX, pas ses enfants -- ils ne sont
+# pas dans son cgroup. Un plafond d'I/O pose sur coursia-runner.service ne
+# borne que ce que le superviseur ecrit lui-meme, c'est-a-dire ses journaux.
+# Les unites gardent IOAccounting + IOWeight, qui eux sont honnetes a cette
+# place ; le plafond dur vit ici, ou vivent les conteneurs.
+[Unit]
+Description=CoursIA CI runner containers -- aggregate budget (all families)
+Documentation=https://github.com/jsboige/CoursIA/blob/main/docs/ci/self-hosted-runners.md
+Before=slices.target
+
+[Slice]
+CPUAccounting=yes
+# 8 coeurs sur les 16 de la machine. L'hote prime (clause en tete de
+# supervise.sh) : la workstation garde la moitie de ses coeurs quoi que fasse
+# la CI, meme si trois familles tournent ensemble.
+CPUQuota=800%
+
+IOAccounting=yes
+IOWeight=50
+# Plafond DUR, agrege, sur le device qui porte /var/lib/docker.
+#
+# 200 Mio/s en ecriture. Le point de comparaison est la mesure de la lane
+# roo-extensions pendant le gel du 2026-09-07 : une boucle a 96 Mo/s soutenus.
+# Ce plafond ne l'interdit pas -- il interdit qu'elle PASSE L'ECHELLE. Le
+# defaut qui a gele la machine deux fois n'etait pas un pic, c'etait un debit
+# soutenu sans borne superieure ; ici la borne existe, et l'hote garde de quoi
+# repondre a l'interactif et aux trainings GPU sur le meme disque.
+#
+# La valeur se re-mesure quand la charge change ; elle ne se devine pas. Le
+# controle est celui documente en tete : trois conteneurs, dd en direct I/O,
+# somme des debits comparee au plafond.
+IOWriteBandwidthMax=/var/lib/docker 209715200
+IOReadBandwidthMax=/var/lib/docker 419430400
+
+MemoryAccounting=yes

--- a/scripts/ci/docker/linux-runner/persist/daemon.json
+++ b/scripts/ci/docker/linux-runner/persist/daemon.json
@@ -1,0 +1,9 @@
+{
+  "cgroup-parent": "coursia-ci.slice",
+  "log-driver": "local",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  },
+  "live-restore": true
+}

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -26,7 +26,44 @@
 #   ./supervise.sh lean [N]      # N slots Lean specialises (label coursia-lean, image
 #                                  # dediee elan+toolchain, .lake chaud par slot, defaut 2)
 #   ./supervise.sh stop          # arret gracieux : pas de nouveau conteneur
-#   ./supervise.sh status
+#   ./supervise.sh status        # familles actives + etat des trois bornes
+#
+# BORNES (#15091) -- toutes declarees par ENVIRONNEMENT.
+#
+# Les bornes de RESSOURCES sont vides ou a 0 par defaut : une machine qui tire
+# cette version sans rien declarer ne se voit imposer aucun plafond qu'elle
+# n'a pas demande, et garde exactement son comportement anterieur. C'est le
+# wrapper de chaque machine qui arme ce qu'elle veut (voir persist/README.md).
+#
+# Les deux valeurs qui ne sont PAS inertes -- backoff et rotation -- ne sont
+# pas des plafonds : elles ne refusent rien et ne ralentissent aucun travail
+# qui aboutit. Elles ne mordent que sur ce qui echoue en boucle ou grossit
+# sans borne, c'est-a-dire exactement les deux comportements qui ont mis la
+# machine par terre. Les laisser inertes aurait demande a chaque machine de
+# reclamer explicitement de ne pas marteler l'API et de ne pas remplir son
+# disque.
+#
+#   COURSIA_RUNNER_CGROUP_PARENT        slice systemd attendue (ex.
+#                                       coursia-ci.slice). Le script la
+#                                       VERIFIE, il ne la re-impose pas.
+#   COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET  1 = REFUSER de demarrer si elle
+#                                       manque ou n'a pas d'io.max. 0 =
+#                                       avertir et continuer.
+#   COURSIA_RUNNER_DEVICE_WRITE_BPS     plafond d'ecriture PAR conteneur, en
+#   COURSIA_RUNNER_DEVICE_READ_BPS      octets/s (ex. 41943040 = 40 Mio/s).
+#   COURSIA_RUNNER_BLKIO_DEVICE         device porteur ; auto-detecte si vide.
+#   COURSIA_RUNNER_CPU_BUDGET           somme MAX de vCPU, toutes familles
+#                                       confondues. 0 = pas de garde.
+#   COURSIA_RUNNER_LOG_MAX_BYTES        rotation des journaux de slot.
+#                                       NON inerte : 32 Mio. 0 = desactive.
+#   COURSIA_RUNNER_BACKOFF_MIN_SEC      backoff exponentiel des boucles de
+#   COURSIA_RUNNER_BACKOFF_MAX_SEC      slot. NON inertes : 5 s -> 300 s.
+#   COURSIA_RUNNER_BACKOFF_JITTER_PCT   dispersion du backoff. NON inerte :
+#                                       25 %. 0 = rafale synchronisee.
+#
+# Le detail de chaque borne -- ce qu'elle couvre, ce qu'elle ne peut PAS
+# couvrir, et la mesure qui l'etablit -- est dans le bloc BORNES plus bas et
+# dans persist/README.md.
 #
 # PREREQUIS : docker, gh authentifie avec droit admin sur le depot (le fetch
 # du registration token l'exige). Le token n'est JAMAIS passe en argv --
@@ -81,6 +118,16 @@ WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-myia-po-2024-linux-wait
 WAITER_CPUS="${COURSIA_RUNNER_WAITER_CPUS:-1}"
 WAITER_MEMORY="${COURSIA_RUNNER_WAITER_MEMORY:-1g}"
 WAITER_PIDS="${COURSIA_RUNNER_WAITER_PIDS:-128}"
+# Toolcache partage sur les waiters (#15091). La premisse d'origine etait
+# « un slot qui attend ne coute rien », donc aucun volume. Elle tombe sur le
+# seul workflow route ici : le job `PR gate` commence par un checkout PUIS un
+# `setup-python@v5`, qui sans RUNNER_TOOL_CACHE re-telecharge et reinstalle
+# CPython a CHAQUE job -- ~300 jobs/jour sur ce pool. Le toolcache est le
+# MEME volume nomme que celui des slots d'execution : partage, en lecture
+# quasi exclusive, il ne croit pas avec le nombre de jobs. Ce n'est PAS le
+# volume _work, dont la persistance est le vecteur ferme par #14385 -- les
+# waiters n'en ont toujours aucun, et cette distinction est la garde.
+WAITER_TOOLCACHE="${COURSIA_RUNNER_WAITER_TOOLCACHE:-1}"
 
 # Pool Lean specialise (#14337 tranche 1) : le cout d'un job Lean n'est pas le
 # toolchain mais MATHLIB. Image dediee (Dockerfile.lean : elan + toolchain
@@ -107,6 +154,83 @@ LEAN_PIDS="${COURSIA_LEAN_RUNNER_PIDS:-512}"
 # memory-swap 24g = 8g RAM + 16g swap. Le swap n'est PAS de la RAM
 # reservee -- l'hote ne paie que si le pic survient.
 LEAN_MEMORY_SWAP="${COURSIA_LEAN_RUNNER_MEMORY_SWAP:-24g}"
+
+# ---------------------------------------------------------------------------
+# BORNES D'I/O ET BUDGET INTER-FAMILLES (#15091 pieces 2 et 4)
+# ---------------------------------------------------------------------------
+# Le mandat : « optimiser au mieux tout le traffic et les acces engendres par
+# le superviseur et ses workers avec de vrais gardes surtout en cas de panne ».
+# Les trois mots qui comptent sont VRAIS et EN CAS DE PANNE : un cap qui ne se
+# verifie pas et une boucle qui retente a cadence fixe ne sont pas des gardes,
+# ce sont des intentions.
+#
+# Trois bornes distinctes, qui ne se remplacent pas :
+#
+#   1. PAR CONTENEUR -- COURSIA_RUNNER_DEVICE_WRITE_BPS. Empeche UN slot de
+#      monopoliser le disque. Mesure ai-01 2026-09-07 : dd 256 Mio oflag=direct
+#      rend 7,4 GB/s sans cap et 21,2 MB/s sous --device-write-bps 20 Mio/s --
+#      facteur 350, a 1 % de la valeur demandee. Le cap est REEL.
+#   2. AGREGE -- la slice systemd coursia-ci.slice, appliquee par defaut du
+#      daemon (/etc/docker/daemon.json "cgroup-parent"). C'est la seule borne
+#      qui somme les familles ; voir persist/coursia-ci.slice.
+#   3. CPU INTER-FAMILLES -- assert_cpu_budget() ci-dessous, qui ferme le trou
+#      que cmd_lean documente depuis #14337 (« la somme des caps CPU des
+#      familles actives n'est gardee par RIEN »).
+#
+# La borne 2 est daemon-wide et donc independante de l'appelant ; ce script
+# n'a pas a la re-imposer, il a a VERIFIER qu'elle est en vigueur. La
+# difference n'est pas cosmetique : re-passer --cgroup-parent sur une machine
+# ou la slice n'existe pas cree un cgroup vide qui a l'air d'un garde et n'en
+# est pas -- exactement la classe de defaut ou un outil manquant rend un garde
+# vert.
+#
+# Vide = borne desactivee, explicitement. Aucun defaut n'est impose aux
+# machines qui n'ont pas deploye la slice (po-2024) : elles gardent le
+# comportement anterieur et recoivent un avertissement nomme.
+CGROUP_PARENT="${COURSIA_RUNNER_CGROUP_PARENT:-}"
+# 1 = refuser de demarrer si CGROUP_PARENT est declare mais introuvable /
+# sans io.max. La machine qui a deploye la slice veut un echec LISIBLE
+# (unite en `failed`, cf StartLimitBurst) plutot qu'un pool non borne qui
+# tourne comme si de rien n'etait -- c'est ce silence-la qui a gele ai-01.
+REQUIRE_CGROUP_BUDGET="${COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET:-0}"
+# Plafond d'ecriture PAR CONTENEUR, en octets/s. Vide = pas de cap.
+DEVICE_WRITE_BPS="${COURSIA_RUNNER_DEVICE_WRITE_BPS:-}"
+DEVICE_READ_BPS="${COURSIA_RUNNER_DEVICE_READ_BPS:-}"
+# Device porteur de /var/lib/docker. Auto-detecte si vide (df sur le
+# DockerRootDir REEL du daemon vise, pas un chemin suppose : ai-01 a deux
+# daemons et le socket epingle decide lequel repond).
+BLKIO_DEVICE="${COURSIA_RUNNER_BLKIO_DEVICE:-}"
+# Budget CPU total de la CI, toutes familles confondues. 0 = pas de garde.
+# 8 sur les 16 coeurs d'ai-01 : la workstation garde la moitie de sa machine
+# quoi que fasse la CI (clause « l'hote prime » en tete de ce fichier).
+CPU_BUDGET="${COURSIA_RUNNER_CPU_BUDGET:-0}"
+# Rotation des journaux de slot. Sans elle, $STATE_DIR/<nom>.log croit sans
+# borne : mesure ai-01 2026-09-07, /var/lib/coursia-runner = 14 Mo pour un
+# pool eteint la majeure partie de la journee. 32 Mio par fichier, une
+# generation conservee -- assez pour diagnostiquer le dernier incident, borne
+# pour ne jamais devenir la fuite disque qu'on pretend surveiller.
+LOG_MAX_BYTES="${COURSIA_RUNNER_LOG_MAX_BYTES:-33554432}"
+
+# Backoff exponentiel des boucles de slot (#15091 : « de vrais gardes surtout
+# en cas de panne »).
+#
+# Le defaut ferme ici : la boucle retentait a CADENCE FIXE -- `sleep 15` apres
+# un echec, `sleep 60` apres un token refuse. Sous panne (image absente, token
+# expire, daemon docker mort), 12 slots produisaient donc ~48 appels
+# `registration-token` par minute, indefiniment, pendant que rien ne pouvait
+# aboutir. Une panne se transformait en charge soutenue sur l'API GitHub et
+# sur le daemon -- l'inverse d'un garde.
+#
+# Le backoff double a chaque echec consecutif jusqu'a un plafond, et se
+# REINITIALISE des qu'un conteneur se termine proprement (rc=0) : une panne
+# franche se calme en quelques minutes, un job normal ne paie rien.
+BACKOFF_MIN_SEC="${COURSIA_RUNNER_BACKOFF_MIN_SEC:-5}"
+BACKOFF_MAX_SEC="${COURSIA_RUNNER_BACKOFF_MAX_SEC:-300}"
+# Jitter, en pourcentage du delai. NON cosmetique : les N slots sont lances
+# dans la meme seconde, echouent dans la meme seconde et repartiraient dans la
+# meme seconde -- le backoff seul deplace la rafale sans la disperser. Le
+# jitter la disperse.
+BACKOFF_JITTER_PCT="${COURSIA_RUNNER_BACKOFF_JITTER_PCT:-25}"
 
 mkdir -p "$STATE_DIR"
 
@@ -146,6 +270,218 @@ assert_image_fresh() {
   [ "$repo_sha" = "$img_sha" ] || die "image $image PERIMEE : entrypoint.sh du checkout ($repo_sha) != entrypoint embarque ($img_sha).
 Un correctif merge mais non deploye est indiscernable d'un correctif absent (#14801, #14385). Reconstruire :
     $build_cmd"
+}
+
+# --- Bornes d'I/O : resolution du device et des drapeaux docker -------------
+
+# Device bloc qui porte le repertoire de donnees du daemon VISE. La resolution
+# passe par `docker info` et non par un chemin suppose : ai-01 porte deux
+# daemons (docker-ce sur /var/run/docker-ce.sock, Docker Desktop sur le socket
+# par defaut) et c'est DOCKER_HOST qui decide lequel repond. Les deux
+# annoncent le meme DockerRootDir -- s'y fier sans passer par le socket epingle
+# est un leurre verifie firsthand.
+resolve_blkio_device() {
+  [ -n "$BLKIO_DEVICE" ] && { printf '%s\n' "$BLKIO_DEVICE"; return 0; }
+  local root dev
+  root="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null)"
+  [ -n "$root" ] || return 1
+  # df --output n'existe pas partout ; la forme POSIX (colonne 1 de la 2e
+  # ligne) marche sur coreutils comme sur busybox.
+  dev="$(df -P "$root" 2>/dev/null | awk 'NR==2 {print $1}')"
+  case "$dev" in
+    /dev/*) printf '%s\n' "$dev" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Drapeaux --device-{read,write}-bps a passer a docker run. Rend une liste
+# vide si aucun plafond n'est demande, ou si le device n'a pas pu etre resolu
+# -- et dans ce dernier cas le DIT : un plafond demande et silencieusement non
+# applique est pire que pas de plafond, parce qu'on se croit borne.
+BLKIO_ARGS=()
+compute_blkio_args() {
+  BLKIO_ARGS=()
+  [ -z "$DEVICE_WRITE_BPS$DEVICE_READ_BPS" ] && return 0
+  local dev
+  if ! dev="$(resolve_blkio_device)"; then
+    echo "AVERTISSEMENT: plafond d'I/O par conteneur demande (write=$DEVICE_WRITE_BPS read=$DEVICE_READ_BPS) mais le device de DockerRootDir n'a pas pu etre resolu -- AUCUN plafond ne sera applique. Nommer le device : COURSIA_RUNNER_BLKIO_DEVICE=/dev/sdX" >&2
+    return 0
+  fi
+  [ -n "$DEVICE_WRITE_BPS" ] && BLKIO_ARGS+=(--device-write-bps "$dev:$DEVICE_WRITE_BPS")
+  [ -n "$DEVICE_READ_BPS" ] && BLKIO_ARGS+=(--device-read-bps "$dev:$DEVICE_READ_BPS")
+  echo "plafond d'I/O par conteneur : $dev write=${DEVICE_WRITE_BPS:-illimite} read=${DEVICE_READ_BPS:-illimite} (octets/s)"
+  return 0
+}
+
+# --- Borne agregee : VERIFIER la slice, ne pas la re-imposer ----------------
+
+# La slice systemd est appliquee par defaut du daemon. Ce garde ne la pose pas,
+# il constate qu'elle est en vigueur ET qu'elle porte reellement un io.max --
+# une slice qui existe sans limite est un cgroup vide qui a l'exacte apparence
+# d'un garde. La verification lit le kernel, pas la configuration :
+# /sys/fs/cgroup/<parent imbrique>/io.max.
+#
+# systemd imbrique une slice sur son nom : `coursia-ci.slice` vit sous
+# `coursia.slice`. On essaie les formes plausibles plutot que de coder
+# l'imbrication en dur.
+assert_cgroup_budget() {
+  [ -z "$CGROUP_PARENT" ] && return 0
+  local base path found="" io=""
+  base="${CGROUP_PARENT%.slice}"
+  for path in \
+      "/sys/fs/cgroup/${base%%-*}.slice/${CGROUP_PARENT}" \
+      "/sys/fs/cgroup/${CGROUP_PARENT}" \
+      "/sys/fs/cgroup/system.slice/${CGROUP_PARENT}"; do
+    if [ -d "$path" ]; then found="$path"; break; fi
+  done
+  if [ -n "$found" ] && [ -r "$found/io.max" ]; then
+    io="$(cat "$found/io.max" 2>/dev/null)"
+  fi
+  if [ -n "$io" ]; then
+    echo "budget agrege en vigueur : $found"
+    echo "  io.max  = $io"
+    [ -r "$found/cpu.max" ] && echo "  cpu.max = $(cat "$found/cpu.max")"
+    return 0
+  fi
+  local msg="budget agrege $CGROUP_PARENT INTROUVABLE ou sans io.max"
+  local how="Deployer la slice et le defaut du daemon :
+    sudo cp scripts/ci/docker/linux-runner/persist/coursia-ci.slice /etc/systemd/system/
+    sudo cp scripts/ci/docker/linux-runner/persist/daemon.json /etc/docker/daemon.json
+    sudo systemctl daemon-reload && sudo systemctl restart docker.service
+  Puis relire : cat /sys/fs/cgroup/coursia.slice/coursia-ci.slice/io.max"
+  if [ "$REQUIRE_CGROUP_BUDGET" = "1" ]; then
+    die "$msg -- REFUS de demarrer (COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET=1).
+Un pool non borne est precisement ce qui a gele cette machine ; un echec
+lisible vaut mieux qu'un demarrage silencieux.
+$how"
+  fi
+  echo "AVERTISSEMENT: $msg -- les familles tourneront SANS plafond agrege." >&2
+  echo "$how" >&2
+  return 0
+}
+
+# --- Budget CPU inter-familles ---------------------------------------------
+
+# Enumere TOUTES les familles de superviseur actives, une par ligne :
+#   <pid> <famille> <n>
+#
+# Distinct de supervisor_pids() a dessein. supervisor_pids() est le garde
+# d'idempotence de `start` : il ne doit voir que `start`, sinon un pool de
+# waiters actif ferait refuser un `start` legitime (les familles coexistent
+# par design). Ce recensement-ci repond a l'autre question -- « que tourne-t-il
+# en tout sur cette machine ? » -- et c'est celle que le budget CPU pose.
+#
+# La table des processus est la source : elle porte deja la famille et le N
+# dans l'argv, elle traverse les state dirs (ai-01 en a deux, un par jambe) et
+# elle ne peut pas deriver d'un fichier d'etat oublie.
+supervisor_families() {
+  local me="$$"
+  ps -ef 2>/dev/null \
+    | grep -E '[s]upervise\.sh (start|waiters|lean)' \
+    | awk -v me="$me" '$2 != me && $3==1 {
+        for (i=1; i<=NF; i++) {
+          if ($i ~ /supervise\.sh$/) {
+            fam = $(i+1); n = $(i+2);
+            if (n !~ /^[0-9]+$/) n = "";
+            print $2, fam, n;
+            break;
+          }
+        }
+      }'
+}
+
+# Cap CPU par conteneur DECLARE par un superviseur donne, lu dans son propre
+# environnement (/proc/<pid>/environ) -- pas dans le mien. Deux superviseurs
+# lances par des wrappers differents portent des caps differents ; supposer les
+# miens rendrait un budget faux et confiant.
+family_cpus_of() {
+  local pid="$1" fam="$2" var fallback val=""
+  case "$fam" in
+    start)   var="COURSIA_RUNNER_CPUS";        fallback="$CPUS" ;;
+    waiters) var="COURSIA_RUNNER_WAITER_CPUS"; fallback="$WAITER_CPUS" ;;
+    lean)    var="COURSIA_LEAN_RUNNER_CPUS";   fallback="$LEAN_CPUS" ;;
+    *)       printf '0\n'; return 0 ;;
+  esac
+  if [ -r "/proc/$pid/environ" ]; then
+    val="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | sed -n "s/^${var}=//p" | head -1)"
+  fi
+  printf '%s\n' "${val:-$fallback}"
+}
+
+# Ferme le trou nomme dans cmd_lean depuis #14337 :
+#   « La somme des caps CPU des familles actives n'est gardee par RIEN --
+#     c'est l'operateur qui dimensionne. »
+# Un cap `--cpus` est PAR CONTENEUR : 12 waiters a 1 vCPU sont conformes un a
+# un et prennent 12 coeurs ensemble. Le seul endroit ou la somme existe est
+# ici, avant de lancer la famille suivante.
+#
+# Refus, jamais avertissement : depasser le budget est exactement l'etat qui a
+# gele la machine, et un demarrage refuse se repare en une commande.
+assert_cpu_budget() {
+  local new_fam="$1" new_n="$2" new_cpus="$3"
+  [ "${CPU_BUDGET:-0}" = "0" ] && return 0
+  local total detail pid fam n c sub
+  total=0; detail=""
+  while read -r pid fam n; do
+    [ -z "${n:-}" ] && continue
+    c="$(family_cpus_of "$pid" "$fam")"
+    sub="$(awk -v a="$n" -v b="$c" 'BEGIN{printf "%.2f", a*b}')"
+    total="$(awk -v a="$total" -v b="$sub" 'BEGIN{printf "%.2f", a+b}')"
+    detail="$detail
+  deja actif : $fam n=$n cpus=$c -> $sub"
+  done < <(supervisor_families)
+  sub="$(awk -v a="$new_n" -v b="$new_cpus" 'BEGIN{printf "%.2f", a*b}')"
+  total="$(awk -v a="$total" -v b="$sub" 'BEGIN{printf "%.2f", a+b}')"
+  detail="$detail
+  demande    : $new_fam n=$new_n cpus=$new_cpus -> $sub"
+  if awk -v t="$total" -v b="$CPU_BUDGET" 'BEGIN{exit !(t > b)}'; then
+    die "budget CPU inter-familles depasse : $total vCPU demandes pour un plafond de $CPU_BUDGET.$detail
+
+Le cap --cpus de docker est PAR CONTENEUR ; il ne borne pas une flotte (#14337).
+Baisser N, arreter une autre famille, ou relever COURSIA_RUNNER_CPU_BUDGET en
+connaissance de cause -- l'hote prime sur la CI (clause en tete de ce fichier)."
+  fi
+  echo "budget CPU inter-familles : $total / $CPU_BUDGET vCPU$detail"
+}
+
+# --- Rotation des journaux de slot ------------------------------------------
+
+# Appelee avant chaque `docker run`. Une generation conservee, pas de
+# dependance a logrotate : le superviseur tourne sous une unite systemd qui
+# n'a pas de hook de rotation, et un journal non borne dans le repertoire
+# d'etat est une fuite disque de plus dans un script qui existe pour les
+# fermer. Mesure ai-01 2026-09-07 : /var/lib/coursia-runner = 14 Mo alors que
+# le pool etait eteint la majeure partie de la journee.
+rotate_log() {
+  local f="$1" sz
+  [ "${LOG_MAX_BYTES:-0}" = "0" ] && return 0
+  [ -f "$f" ] || return 0
+  sz="$(wc -c < "$f" 2>/dev/null | tr -d ' ')"
+  [ -n "$sz" ] || return 0
+  if [ "$sz" -gt "$LOG_MAX_BYTES" ]; then
+    mv -f "$f" "$f.1" 2>/dev/null || true
+    : > "$f"
+  fi
+}
+
+# --- Backoff exponentiel avec jitter ----------------------------------------
+
+# Rend le delai a attendre apres `n` echecs consecutifs : min * 2^(n-1),
+# plafonne, puis disperse par un jitter de +/- BACKOFF_JITTER_PCT %.
+# $RANDOM suffit ici -- on disperse des rafales, on ne tire rien de sensible.
+backoff_delay() {
+  local fails="$1" d="$BACKOFF_MIN_SEC" i
+  for ((i=1; i<fails; i++)); do
+    d=$(( d * 2 ))
+    if [ "$d" -ge "$BACKOFF_MAX_SEC" ]; then d="$BACKOFF_MAX_SEC"; break; fi
+  done
+  [ "$d" -gt "$BACKOFF_MAX_SEC" ] && d="$BACKOFF_MAX_SEC"
+  local span=$(( d * BACKOFF_JITTER_PCT / 100 ))
+  if [ "$span" -gt 0 ]; then
+    d=$(( d - span + (RANDOM % (2 * span + 1)) ))
+  fi
+  [ "$d" -lt 1 ] && d=1
+  printf '%s\n' "$d"
 }
 
 # #14259 Defaut 1+3 : compte et liste les PIDs des superviseurs actifs du
@@ -200,15 +536,22 @@ slot_loop() {
   local mem_swap="${9:-}"
   local swap_args=()
   [ -n "$mem_swap" ] && swap_args=(--memory-swap "$mem_swap")
+  # Compteur d'echecs CONSECUTIFS : c'est lui qui porte le backoff, et il est
+  # remis a zero par le premier cycle propre. Une panne franche se calme ; un
+  # job qui echoue de temps en temps ne penalise pas le slot.
+  local fails=0 wait_s
   echo "[slot $slot] demarrage, nom runner=$name"
   while [ ! -f "$STOP_FILE" ]; do
     local token
     token="$(fetch_token)"
     if [ -z "$token" ]; then
-      echo "[slot $slot] token indisponible (droit admin gh ?) -- nouvelle tentative dans 60 s" >&2
-      sleep 60
+      fails=$(( fails + 1 ))
+      wait_s="$(backoff_delay "$fails")"
+      echo "[slot $slot] token indisponible (droit admin gh ?) -- echec consecutif #$fails, nouvelle tentative dans ${wait_s}s" >&2
+      sleep "$wait_s"
       continue
     fi
+    rotate_log "$STATE_DIR/$name.log"
     # --rm : le conteneur disparait avec le job. --ephemeral (dans l'entrypoint)
     # desenregistre le runner cote GitHub. Un cycle = un job, proprement --
     # mais le cache de depot (volume par slot) survit au conteneur (#14285).
@@ -216,6 +559,7 @@ slot_loop() {
       --name "$name" \
       --cpus="$cpus" --memory="$memory" --pids-limit="$pids" \
       "${swap_args[@]+"${swap_args[@]}"}" \
+      "${BLKIO_ARGS[@]+"${BLKIO_ARGS[@]}"}" \
       --security-opt=no-new-privileges \
       -v "$TOOLCACHE_VOLUME":"$TOOLCACHE_MOUNT" \
       -v "${vol_prefix}-${slot}":"$WORK_MOUNT" \
@@ -227,9 +571,22 @@ slot_loop() {
       "$image" >>"$STATE_DIR/$name.log" 2>&1
     local rc=$?
     echo "[slot $slot] conteneur termine (rc=$rc)"
-    # Anti-emballement : si le conteneur meurt immediatement et en boucle
-    # (image absente, token refuse), on ne martele ni docker ni l'API.
-    [ "$rc" -ne 0 ] && sleep 15 || sleep 2
+    # Anti-emballement (#15091). La forme precedente etait un delai FIXE de
+    # 15 s : sous panne durable, N slots produisaient N/15 e appels
+    # registration-token par seconde -- ~48/min a 12 slots -- indefiniment,
+    # pendant que rien ne pouvait aboutir. Une panne devenait une charge
+    # soutenue sur l'API et sur le daemon. Le backoff double le delai a chaque
+    # echec consecutif jusqu'au plafond, et le jitter disperse les N slots qui
+    # sans lui repartiraient tous dans la meme seconde.
+    if [ "$rc" -ne 0 ]; then
+      fails=$(( fails + 1 ))
+      wait_s="$(backoff_delay "$fails")"
+      echo "[slot $slot] echec consecutif #$fails -- attente ${wait_s}s avant relance" >&2
+      sleep "$wait_s"
+    else
+      fails=0
+      sleep 2
+    fi
   done
   echo "[slot $slot] arret demande, boucle terminee"
 }
@@ -280,6 +637,12 @@ utiliser '$0 stop' d'abord, ou relancer sous une machine differente."
 est en cours. Attendre la fin des jobs, faire '$0 stop' (no-op si deja
 fait) puis '$0 start', OU relancer avec '$0 start $n --force'."
   fi
+  # Les trois bornes, verifiees AVANT de lever le sentinel : un refus ne doit
+  # laisser aucune trace, sinon un arret gracieux en cours serait annule par
+  # une tentative de demarrage que l'on vient justement de refuser.
+  assert_cgroup_budget
+  assert_cpu_budget "start" "$n" "$CPUS"
+  compute_blkio_args
   # Sur succes, on leve le sentinel -- le superviseur qui demarre prend
   # la main sur l'etat precedent (Defaut 2 dans son volet `start`
   # historiquement effacait sans condition ; ici il n'efface que si
@@ -302,8 +665,34 @@ cmd_stop() {
   # Arret GRACIEUX : on pose le sentinel, les boucles ne relancent plus de
   # conteneur. Le job en cours va a son terme -- on ne tue pas un job qui
   # tourne, il rendrait un rouge qui ne veut rien dire.
-  touch "$STOP_FILE"
-  echo "sentinel pose : aucun nouveau conteneur ne sera lance."
+  #
+  # LE SENTINEL SE VERIFIE APRES L'ECRITURE (#15091). Cette fonction rendait
+  # 0 quoi qu'il arrive : sous `set -uo pipefail` SANS `-e`, l'echec du
+  # `touch` n'interrompait rien, et le code de retour etait celui du dernier
+  # `echo`. Un arret inerte etait donc indiscernable d'un arret reussi.
+  #
+  # Ce n'est pas une hypothese : sur ai-01, l'unite appelait ce script sans
+  # COURSIA_RUNNER_STATE_DIR, le sentinel atterrissait dans un
+  # /root/.coursia-runner/ que ce script CREE lui-meme, le superviseur
+  # surveillait /var/lib/coursia-runner/ -- et `systemctl stop` annoncait le
+  # succes avant de retomber sur son SIGTERM. La reparation du cablage vit
+  # dans persist/ai-01/ ; celle-ci est la borne qui rend le meme defaut
+  # LISIBLE la prochaine fois, quel que soit l'appelant.
+  #
+  # Le test verifie la PRESENCE du fichier, pas le code de retour du touch :
+  # ce qui compte est qu'un fichier existe a l'endroit que les boucles
+  # surveillent -- un touch qui reussit sur un chemin que personne ne lit
+  # n'est pas un arret.
+  if ! touch "$STOP_FILE" 2>/dev/null || [ ! -e "$STOP_FILE" ]; then
+    echo "ERREUR: sentinel NON pose -- $STOP_FILE n'a pas pu etre ecrit." >&2
+    echo "  Les boucles de slot continuent de lancer des conteneurs." >&2
+    echo "  Verifier les droits sur $STATE_DIR, et que COURSIA_RUNNER_STATE_DIR" >&2
+    echo "  designe bien le repertoire surveille par le superviseur en cours" >&2
+    echo "  (un STATE_DIR different est cree en silence, et l'arret est inerte)." >&2
+    return 1
+  fi
+  echo "sentinel pose : $STOP_FILE"
+  echo "aucun nouveau conteneur ne sera lance."
   echo "Les jobs en cours vont a leur terme. Pour couper net (deconseille) :"
   echo "  docker ps --filter name=$NAME_PREFIX -q | xargs -r docker kill"
   echo "  docker ps --filter name=$LEAN_NAME_PREFIX -q | xargs -r docker kill"
@@ -329,6 +718,34 @@ cmd_status() {
       echo "  superviseurs actifs : $count (PID $pids)"
     fi
   fi
+  echo "== familles actives (toutes, tous state dirs) =="
+  # supervisor_pids() ci-dessus ne voit que `start` (c'est son role : garder
+  # l'idempotence de start). Le recensement inter-familles repond a l'autre
+  # question, celle que pose le budget CPU.
+  local fam_lines
+  fam_lines="$(supervisor_families)"
+  if [ -z "$fam_lines" ]; then
+    echo "  aucune famille active"
+  else
+    local pid fam n c
+    while read -r pid fam n; do
+      [ -z "${fam:-}" ] && continue
+      c="$(family_cpus_of "$pid" "$fam")"
+      echo "  $fam n=${n:-?} cpus=$c (pid $pid)"
+    done <<< "$fam_lines"
+  fi
+  echo "== bornes =="
+  if [ -n "$CGROUP_PARENT" ]; then
+    assert_cgroup_budget 2>&1 | sed 's/^/  /'
+  else
+    echo "  budget agrege : non declare (COURSIA_RUNNER_CGROUP_PARENT vide)"
+  fi
+  if [ -n "$DEVICE_WRITE_BPS$DEVICE_READ_BPS" ]; then
+    compute_blkio_args 2>&1 | sed 's/^/  /'
+  else
+    echo "  plafond par conteneur : non declare (COURSIA_RUNNER_DEVICE_WRITE_BPS vide)"
+  fi
+  echo "  budget CPU inter-familles : ${CPU_BUDGET:-0} vCPU (0 = pas de garde)"
   echo "== conteneurs runner en cours =="
   docker ps --filter "name=$NAME_PREFIX" --format '  {{.Names}}  {{.Status}}  {{.RunningFor}}' 2>/dev/null || true
   echo "== runners enregistres cote GitHub =="
@@ -365,19 +782,30 @@ waiter_loop() {
   # l'attente du gate. Pas de volume -- rien a persister.
   local slot="$1"
   local name="${WAITER_NAME_PREFIX}-${slot}"
+  local fails=0 wait_s
+  # Toolcache seul -- jamais de volume _work (cf commentaire WAITER_TOOLCACHE).
+  local tc_args=()
+  if [ "$WAITER_TOOLCACHE" = "1" ]; then
+    tc_args=(-v "$TOOLCACHE_VOLUME":"$TOOLCACHE_MOUNT" -e RUNNER_TOOL_CACHE="$TOOLCACHE_MOUNT")
+  fi
   echo "[waiter $slot] demarrage, nom runner=$name"
   while [ ! -f "$STOP_FILE" ]; do
     local token
     token="$(fetch_token)"
     if [ -z "$token" ]; then
-      echo "[waiter $slot] token indisponible (droit admin gh ?) -- nouvelle tentative dans 60 s" >&2
-      sleep 60
+      fails=$(( fails + 1 ))
+      wait_s="$(backoff_delay "$fails")"
+      echo "[waiter $slot] token indisponible (droit admin gh ?) -- echec consecutif #$fails, nouvelle tentative dans ${wait_s}s" >&2
+      sleep "$wait_s"
       continue
     fi
+    rotate_log "$STATE_DIR/$name.log"
     docker run --rm \
       --name "$name" \
       --cpus="$WAITER_CPUS" --memory="$WAITER_MEMORY" --pids-limit="$WAITER_PIDS" \
+      "${BLKIO_ARGS[@]+"${BLKIO_ARGS[@]}"}" \
       --security-opt=no-new-privileges \
+      "${tc_args[@]+"${tc_args[@]}"}" \
       -e ACTIONS_RUNNER_INPUT_TOKEN="$token" \
       -e ACTIONS_RUNNER_INPUT_URL="https://github.com/$REPO" \
       -e ACTIONS_RUNNER_INPUT_NAME="$name" \
@@ -385,7 +813,15 @@ waiter_loop() {
       "$IMAGE" >>"$STATE_DIR/$name.log" 2>&1
     local rc=$?
     echo "[waiter $slot] conteneur termine (rc=$rc)"
-    [ "$rc" -ne 0 ] && sleep 15 || sleep 2
+    if [ "$rc" -ne 0 ]; then
+      fails=$(( fails + 1 ))
+      wait_s="$(backoff_delay "$fails")"
+      echo "[waiter $slot] echec consecutif #$fails -- attente ${wait_s}s avant relance" >&2
+      sleep "$wait_s"
+    else
+      fails=0
+      sleep 2
+    fi
   done
   echo "[waiter $slot] arret demande, boucle terminee"
 }
@@ -409,6 +845,12 @@ cmd_waiters() {
       die "waiters deja lancees (pid $head_pid) -- arreter d'abord ($0 stop)"
     fi
   fi
+  # Les trois bornes, verifiees AVANT de lever le sentinel : un refus ne doit
+  # laisser aucune trace, sinon un arret gracieux en cours serait annule par
+  # une tentative de demarrage que l'on vient justement de refuser.
+  assert_cgroup_budget
+  assert_cpu_budget "waiters" "$n" "$WAITER_CPUS"
+  compute_blkio_args
   rm -f "$STATE_DIR/waiter-pids"
   echo "demarrage de $n waiter(s) ; labels=$WAITER_LABELS ; caps : cpus=$WAITER_CPUS memory=$WAITER_MEMORY pids=$WAITER_PIDS"
   for i in $(seq 1 "$n"); do
@@ -433,14 +875,18 @@ cmd_lean() {
   # Idempotence calquee sur cmd_waiters : le garde PPID de `start` filtre
   # `supervise.sh start` et ne verrait pas `lean`. Verrou par pid file.
   #
-  # Budget CPU hors garde (a documenter, ai-01 DM 2026-09-04) : le garde PPID
-  # ne couvre que les superviseurs d'un MEME prefix, donc `start` et `lean`
-  # coexistent par design (familles distinctes, containers distincts). La
-  # somme des caps CPU des familles actives n'est gardee par RIEN -- c'est
-  # l'operateur qui dimensionne : slots generiques (N x CPUS) + waiters
-  # (N x WAITER_CPUS) + slots lean (N x LEAN_CPUS) doit rester <= le total
-  # machine. Le pool lean est dimensionne pour tourner SEUL sur la jambe CI
-  # lourde (arret des autres familles avant `lean` quand la machine sature).
+  # Budget CPU inter-familles (#15091, fermeture du trou nomme ici depuis
+  # #14337). Le garde PPID ne couvre que les superviseurs d'un MEME prefix,
+  # donc `start`, `waiters` et `lean` coexistent par design -- et leur somme
+  # n'etait gardee par RIEN : « c'est l'operateur qui dimensionne ». C'est
+  # desormais assert_cpu_budget qui la garde, en lisant les familles actives
+  # dans la table des processus et leurs caps dans /proc/<pid>/environ.
+  # Il reste INACTIF tant que COURSIA_RUNNER_CPU_BUDGET vaut 0 : aucune
+  # machine ne se voit imposer un plafond qu'elle n'a pas declare (po-2024
+  # garde son comportement ; ai-01 declare 8 dans son wrapper).
+  # Le pool lean reste dimensionne pour tourner SEUL sur la jambe CI lourde --
+  # avec le budget arme, le demarrage est desormais REFUSE au lieu de degrader
+  # la machine en silence.
   if [ -f "$STATE_DIR/lean-pids" ]; then
     local head_pid
     head_pid="$(head -1 "$STATE_DIR/lean-pids" 2>/dev/null || true)"
@@ -448,6 +894,12 @@ cmd_lean() {
       die "pool lean deja lance (pid $head_pid) -- arreter d'abord ($0 stop)"
     fi
   fi
+  # Les trois bornes, verifiees AVANT de lever le sentinel : un refus ne doit
+  # laisser aucune trace, sinon un arret gracieux en cours serait annule par
+  # une tentative de demarrage que l'on vient justement de refuser.
+  assert_cgroup_budget
+  assert_cpu_budget "lean" "$n" "$LEAN_CPUS"
+  compute_blkio_args
   rm -f "$STATE_DIR/lean-pids"
   echo "demarrage de $n slot(s) lean ; labels=$LEAN_LABELS ; caps : cpus=$LEAN_CPUS memory=$LEAN_MEMORY pids=$LEAN_PIDS ; image=$LEAN_IMAGE ; .lake chaud=${LEAN_WORK_VOLUME_PREFIX}-{1..$n} -> $WORK_MOUNT"
   for i in $(seq 1 "$n"); do

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -14,8 +14,20 @@ mkdir -p "$TEST_DIR/bin" "$TEST_DIR/state-A" "$TEST_DIR/state-B" "$TEST_DIR/stat
 LOG="$TEST_DIR/test.log"
 : > "$LOG"
 
-ok() { echo "  PASS: $1"; }
-ko() { echo "  FAIL: $1"; }
+# Le verdict est TENU DANS UN FICHIER, pas dans une variable (#15091). Chaque
+# test tourne dans un sous-shell `( ... )` : un compteur shell y serait
+# incremente dans une copie et le parent lirait toujours zero. Le meme piege a
+# fait passer le test 15 a cote de son objet -- une fonction appelee dans
+# $( ) reinitialise un tableau que le parent ne voit jamais.
+#
+# Sans cet agregat, ce harnais SORTAIT 0 quoi qu'il arrive : un `ko` s'affiche,
+# et le code de retour reste celui du dernier echo. Un cablage CI l'aurait vu
+# vert en permanence -- exactement la classe de defaut que les gardes testes
+# ici existent pour empecher, reproduite dans l'outil qui les mesure.
+RESULTS="$TEST_DIR/results"
+: > "$RESULTS"
+ok() { echo "  PASS: $1"; echo "PASS $1" >> "$RESULTS"; }
+ko() { echo "  FAIL: $1"; echo "FAIL $1" >> "$RESULTS"; }
 
 # Stubs docker + gh + ps. Le stub docker simule une image A JOUR pour le
 # garde de fraicheur #14801 : au probe `run --entrypoint sha256sum`, il rend
@@ -305,3 +317,397 @@ echo "Test 10 : start passe le garde quand l'image est a jour (#14801)"
   wait 2>/dev/null
 )
 echo ""
+
+# ===========================================================================
+# Gardes #15091 -- bornes d'I/O, budget inter-familles, backoff, rotation.
+#
+# Ces tests appellent les fonctions DIRECTEMENT, en sourcant supervise.sh avec
+# l'argument `status` : le `case` final choisit alors la branche la moins
+# couteuse et rend la main sans `exit`, laissant les fonctions definies dans le
+# shell du test. Sourcer sans argument tomberait sur `*) ... exit 2`.
+#
+# Le sourcage se fait TOUJOURS avec un environnement de bornes VIERGE, et les
+# variables sont posees APRES : `cmd_status` appelle lui-meme assert_cgroup_budget,
+# qui appelle die() -- donc exit -- quand la slice manque sous exigence. Armer
+# les bornes avant de sourcer tuerait le sous-shell du test avant son premier
+# assert.
+# ===========================================================================
+
+mkdir -p "$TEST_DIR/state-G"
+source_supervise() {
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-G"
+  unset COURSIA_RUNNER_CGROUP_PARENT COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET
+  unset COURSIA_RUNNER_DEVICE_WRITE_BPS COURSIA_RUNNER_DEVICE_READ_BPS
+  unset COURSIA_RUNNER_BLKIO_DEVICE COURSIA_RUNNER_CPU_BUDGET
+  # shellcheck disable=SC1090
+  . "$SCRIPT_DIR/supervise.sh" status >/dev/null 2>&1
+}
+
+# --- Test 11 : backoff exponentiel, plafonne, jitter borne -----------------
+echo "Test 11 : backoff exponentiel plafonne et disperse (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  source_supervise
+  BACKOFF_MIN_SEC=5; BACKOFF_MAX_SEC=300
+  BACKOFF_JITTER_PCT=0   # jitter neutralise : on teste d'abord la loi
+  d1="$(backoff_delay 1)"; d2="$(backoff_delay 2)"; d3="$(backoff_delay 3)"
+  d9="$(backoff_delay 9)"; d20="$(backoff_delay 20)"
+  if [ "$d1" = "5" ] && [ "$d2" = "10" ] && [ "$d3" = "20" ]; then
+    ok "doublement a chaque echec consecutif : 5 10 20"
+  else
+    ko "loi de doublement attendue 5/10/20, obtenu $d1/$d2/$d3"
+  fi
+  if [ "$d9" = "300" ] && [ "$d20" = "300" ]; then
+    ok "plafond respecte (300 s a 9 et a 20 echecs)"
+  else
+    ko "plafond 300 attendu, obtenu $d9 (9 echecs) et $d20 (20 echecs)"
+  fi
+  # Controle POSITIF du jitter : sans lui, N slots repartent dans la MEME
+  # seconde -- le backoff deplace la rafale sans la disperser. On verifie donc
+  # qu'il produit reellement plusieurs valeurs distinctes, ET qu'elles restent
+  # dans la bande annoncee (+/- 25 % de 20 s -> [15, 25]).
+  BACKOFF_JITTER_PCT=25
+  distinct="$(for i in $(seq 1 40); do backoff_delay 3; done | sort -u | wc -l | tr -d ' ')"
+  outside="$(for i in $(seq 1 40); do backoff_delay 3; done | awk '$1 < 15 || $1 > 25' | wc -l | tr -d ' ')"
+  if [ "$distinct" -gt 1 ] && [ "$outside" = "0" ]; then
+    ok "jitter actif : $distinct valeurs distinctes, toutes dans [15,25]"
+  else
+    ko "jitter attendu disperse et borne, distinct=$distinct hors-bande=$outside"
+  fi
+)
+echo ""
+
+# --- Test 12 : budget CPU inter-familles -- REFUS au depassement -----------
+echo "Test 12 : budget CPU inter-familles refuse le depassement (#15091, trou #14337)"
+(
+  cd "$SCRIPT_DIR"
+  # 12 waiters a 1 vCPU deja actifs ; on demande 2 slots lean a 6 vCPU.
+  # 12 + 12 = 24 > 8 -> refus. C'est exactement la configuration que le cap
+  # --cpus PAR CONTENEUR declare conforme et qui prend 24 coeurs.
+  export PS_OUTPUT="jsboige  4242     1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh waiters 12"
+  source_supervise
+  CPU_BUDGET=8
+  err="$( (assert_cpu_budget "lean" 2 6) 2>&1 )"; rc=$?
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "budget CPU inter-familles depasse"; then
+    ok "depassement refuse (rc=$rc)"
+  else
+    ko "refus attendu, rc=$rc err=$err"
+  fi
+  if echo "$err" | grep -q "deja actif : waiters n=12 cpus=1" \
+     && echo "$err" | grep -q "demande    : lean n=2 cpus=6"; then
+    ok "le message NOMME les deux termes de la somme"
+  else
+    ko "detail par famille attendu dans le message, err=$err"
+  fi
+)
+echo ""
+
+# --- Test 13 : controle negatif -- le budget n'accuse pas a tort -----------
+echo "Test 13 : budget CPU -- controle negatif (sous le plafond, puis non arme)"
+(
+  cd "$SCRIPT_DIR"
+  export PS_OUTPUT="jsboige  4242     1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh waiters 4"
+  source_supervise
+  CPU_BUDGET=8
+  out="$( (assert_cpu_budget "start" 1 3) 2>&1 )"; rc=$?
+  if [ "$rc" = "0" ] && echo "$out" | grep -q "7.00 / 8"; then
+    ok "4x1 + 1x3 = 7 <= 8 : accepte, total affiche"
+  else
+    ko "acceptation attendue avec total 7.00, rc=$rc out=$out"
+  fi
+  # Non arme (0) : aucune machine ne se voit imposer un plafond non declare.
+  CPU_BUDGET=0
+  out="$( (assert_cpu_budget "lean" 8 6) 2>&1 )"; rc=$?
+  if [ "$rc" = "0" ] && [ -z "$out" ]; then
+    ok "budget non arme : inerte et muet, meme sur 48 vCPU demandes"
+  else
+    ko "inertie attendue quand CPU_BUDGET=0, rc=$rc out=$out"
+  fi
+)
+echo ""
+
+# --- Test 14 : borne agregee -- REFUS fail-closed quand elle manque --------
+echo "Test 14 : slice absente -- refus fail-closed et commande de deploiement (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  source_supervise
+  CGROUP_PARENT="coursia-absente-xyz.slice"
+  REQUIRE_CGROUP_BUDGET=1
+  err="$( (assert_cgroup_budget) 2>&1 )"; rc=$?
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "REFUS de demarrer"; then
+    ok "slice introuvable : demarrage refuse (rc=$rc)"
+  else
+    ko "refus attendu, rc=$rc err=$err"
+  fi
+  if echo "$err" | grep -q "persist/coursia-ci.slice" \
+     && echo "$err" | grep -q "systemctl daemon-reload"; then
+    ok "le refus porte la commande de deploiement"
+  else
+    ko "commande de deploiement attendue dans le message, err=$err"
+  fi
+  # Meme situation SANS l'exigence : avertit, ne bloque pas. C'est le
+  # comportement des machines qui n'ont pas deploye la slice (po-2024).
+  REQUIRE_CGROUP_BUDGET=0
+  err="$( (assert_cgroup_budget) 2>&1 )"; rc=$?
+  if [ "$rc" = "0" ] && echo "$err" | grep -q "AVERTISSEMENT"; then
+    ok "sans exigence : avertit et laisse passer (aucun defaut impose)"
+  else
+    ko "avertissement non bloquant attendu, rc=$rc err=$err"
+  fi
+)
+echo ""
+
+# --- Test 15 : plafond par conteneur -- drapeaux et aveu de non-application -
+echo "Test 15 : --device-write-bps cable, et non-resolution AVOUEE (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  source_supervise
+  DEVICE_WRITE_BPS=20971520; DEVICE_READ_BPS=41943040; BLKIO_DEVICE=/dev/fake0
+  compute_blkio_args >/dev/null 2>&1
+  joined="${BLKIO_ARGS[*]-}"
+  if [ "$joined" = "--device-write-bps /dev/fake0:20971520 --device-read-bps /dev/fake0:41943040" ]; then
+    ok "drapeaux construits exactement : $joined"
+  else
+    ko "drapeaux attendus write+read sur /dev/fake0, obtenu: $joined"
+  fi
+  # Controle negatif. Le point du test n'est pas que la liste soit vide --
+  # c'est que le script le DISE. Un plafond demande et silencieusement non
+  # applique laisse croire qu'on est borne.
+  BLKIO_DEVICE=""
+  # Appel DIRECT, pas $( ) : une substitution de commande execute la fonction
+  # dans un sous-shell, ou son `BLKIO_ARGS=()` de tete ne reinitialise que la
+  # copie du sous-shell -- le parent garderait les drapeaux du cas precedent et
+  # le test lirait une valeur perimee. Le script, lui, l'appelle bien dans son
+  # propre shell.
+  compute_blkio_args 2> "$TEST_DIR/blkio.err" >/dev/null
+  err="$(cat "$TEST_DIR/blkio.err")"
+  if [ "${#BLKIO_ARGS[@]}" = "0" ] && echo "$err" | grep -q "AUCUN plafond ne sera applique"; then
+    ok "device non resolvable : liste vide ET aveu explicite"
+  else
+    ko "aveu attendu quand le device n'est pas resolvable, err=$err args=${BLKIO_ARGS[*]-}"
+  fi
+)
+echo ""
+
+# --- Test 16 : rotation des journaux ---------------------------------------
+echo "Test 16 : rotation du journal de slot au-dela du seuil (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  source_supervise
+  LOG_MAX_BYTES=100
+  f="$TEST_DIR/state-G/rot.log"
+  head -c 40 /dev/zero | tr '\0' 'a' > "$f"
+  rotate_log "$f"
+  if [ "$(wc -c < "$f" | tr -d ' ')" = "40" ] && [ ! -f "$f.1" ]; then
+    ok "sous le seuil : journal intact, aucune generation creee"
+  else
+    ko "aucune rotation attendue sous le seuil"
+  fi
+  head -c 250 /dev/zero | tr '\0' 'b' > "$f"
+  rotate_log "$f"
+  if [ "$(wc -c < "$f" | tr -d ' ')" = "0" ] && [ "$(wc -c < "$f.1" | tr -d ' ')" = "250" ]; then
+    ok "au-dela du seuil : journal tronque, une generation conservee"
+  else
+    ko "rotation attendue : courant=$(wc -c < "$f") precedent=$(wc -c < "$f.1" 2>/dev/null)"
+  fi
+  # Inerte a seuil 0 -- personne ne perd ses journaux par un defaut non choisi.
+  LOG_MAX_BYTES=0
+  head -c 250 /dev/zero | tr '\0' 'c' > "$f"
+  rotate_log "$f"
+  if [ "$(wc -c < "$f" | tr -d ' ')" = "250" ]; then
+    ok "seuil a 0 : rotation desactivee"
+  else
+    ko "inertie attendue a seuil 0"
+  fi
+)
+echo ""
+
+# --- Test 17 : le toolcache des waiters atteint reellement docker run ------
+echo "Test 17 : waiters -- toolcache monte, et JAMAIS de volume _work (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/bin17" "$TEST_DIR/state-17" "$TEST_DIR/state-17b"
+  # Stub docker distinct : il doit repondre au probe de fraicheur #14801
+  # (`docker run --rm --entrypoint sha256sum`) AVANT de journaliser l'argv du
+  # vrai lancement, sinon le probe serait compte comme un lancement de waiter.
+  cat > "$TEST_DIR/bin17/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "run" ] && printf '%s' "\$*" | grep -q -- '--entrypoint sha256sum'; then
+  echo "$REPO_ENTRYPOINT_SHA  /opt/runner/entrypoint.sh"
+  exit 0
+fi
+if [ "\$1" = "run" ]; then
+  printf '%s\n' "\$*" >> "\$ARGV_LOG"
+  sleep 3
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin17/docker"
+  cp "$TEST_DIR/bin/gh" "$TEST_DIR/bin17/gh"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin17/ps"
+  export PATH="$TEST_DIR/bin17:$PATH"
+  export COURSIA_RUNNER_WAITER_NAME_PREFIX="test-waiter-17"
+
+  export ARGV_LOG="$TEST_DIR/state-17/docker-argv.txt"
+  : > "$ARGV_LOG"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-17"
+  timeout --kill-after=1 3 bash "$SCRIPT_DIR/supervise.sh" waiters 1 >/dev/null 2>&1
+  touch "$TEST_DIR/state-17/stop"   # les boucles orphelines sortent d'elles-memes
+  argv="$(cat "$ARGV_LOG" 2>/dev/null)"
+  if echo "$argv" | grep -q -- "-v coursia-runner-toolcache:/opt/hostedtoolcache" \
+     && echo "$argv" | grep -q -- "-e RUNNER_TOOL_CACHE=/opt/hostedtoolcache"; then
+    ok "toolcache monte sur le waiter (volume + RUNNER_TOOL_CACHE)"
+  else
+    ko "toolcache attendu dans l'argv du waiter, argv=$argv"
+  fi
+  # Garde #14385 : un _work PERSISTANT sur un pool sparse-checkout est le
+  # vecteur ferme par cette issue. Le toolcache n'est pas _work ; ce controle
+  # negatif est ce qui empeche la confusion de se glisser plus tard.
+  if [ -n "$argv" ] && ! echo "$argv" | grep -q -- "/home/runner/_work"; then
+    ok "aucun volume _work sur le waiter (garde #14385 preservee)"
+  else
+    ko "un volume _work est apparu sur le waiter -- REGRESSION #14385, argv=$argv"
+  fi
+  # Desactivable : la machine qui ne veut pas du toolcache le dit.
+  export ARGV_LOG="$TEST_DIR/state-17b/docker-argv.txt"
+  : > "$ARGV_LOG"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-17b"
+  export COURSIA_RUNNER_WAITER_TOOLCACHE=0
+  timeout --kill-after=1 3 bash "$SCRIPT_DIR/supervise.sh" waiters 1 >/dev/null 2>&1
+  touch "$TEST_DIR/state-17b/stop"
+  argv="$(cat "$ARGV_LOG" 2>/dev/null)"
+  if [ -n "$argv" ] && ! echo "$argv" | grep -q -- "coursia-runner-toolcache"; then
+    ok "COURSIA_RUNNER_WAITER_TOOLCACHE=0 : aucun montage"
+  else
+    ko "desactivation attendue, argv=$argv"
+  fi
+)
+echo ""
+
+# --- Test 18 : recensement inter-familles distinct du garde d'idempotence --
+echo "Test 18 : supervisor_families voit les 3 familles, supervisor_pids seulement start"
+(
+  cd "$SCRIPT_DIR"
+  export PS_OUTPUT="jsboige  111    1   10:00:00  bash scripts/ci/docker/linux-runner/supervise.sh start 8
+jsboige  222    1   10:00:00  bash scripts/ci/docker/linux-runner/supervise.sh waiters 12
+jsboige  333    1   10:00:00  bash scripts/ci/docker/linux-runner/supervise.sh lean 2
+jsboige  444  111   10:00:00  bash scripts/ci/docker/linux-runner/supervise.sh start 8"
+  source_supervise
+  fams="$(supervisor_families)"
+  n_fams="$(printf '%s\n' "$fams" | grep -c . )"
+  n_pids="$(supervisor_pids | grep -c . )"
+  if [ "$n_fams" = "3" ] && echo "$fams" | grep -q "222 waiters 12" \
+     && echo "$fams" | grep -q "333 lean 2"; then
+    ok "supervisor_families rend les 3 familles avec leur N"
+  else
+    ko "3 familles attendues, obtenu $n_fams : $fams"
+  fi
+  if [ "$n_pids" = "1" ]; then
+    ok "supervisor_pids reste borne a start (idempotence #14259 inchangee)"
+  else
+    ko "supervisor_pids doit voir 1 seul start, obtenu $n_pids"
+  fi
+  # Le fork PPID=111 ne doit compter dans NI l'un NI l'autre.
+  if ! echo "$fams" | grep -q "^444 "; then
+    ok "le fork slot_loop (PPID!=1) est exclu du recensement"
+  else
+    ko "un fork a ete compte comme superviseur : $fams"
+  fi
+)
+echo ""
+
+# --- Test 19 : l'arret gracieux ne peut plus annoncer un succes inerte ------
+# Defaut #15091 mesure sur ai-01 : cmd_stop rendait 0 quoi qu'il arrive. Le
+# script tourne sous `set -uo pipefail` SANS `-e`, donc l'echec du `touch`
+# n'interrompait rien et le code de retour etait celui du dernier `echo`. Un
+# arret inerte etait indiscernable d'un arret reussi -- et c'est exactement ce
+# qui s'est produit : l'unite ecrivait son sentinel dans /root/.coursia-runner/
+# pendant que le superviseur surveillait /var/lib/coursia-runner/.
+#
+# Le controle NEGATIF est la moitie qui compte. Un `touch` sur un chemin dont
+# le parent est un FICHIER ordinaire echoue (ENOTDIR) sur toutes les
+# plateformes, y compris MSYS -- la ou un test par permissions serait muet
+# sous Windows.
+echo "Test 19 : cmd_stop rend != 0 quand le sentinel n'a PAS pu etre pose (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  source_supervise
+
+  # (a) cas nominal : le sentinel est pose, rc=0, et le chemin est ANNONCE
+  #     (l'ancienne version ne le disait pas -- c'est ce silence qui a rendu
+  #     le mauvais STATE_DIR invisible pendant des semaines).
+  STATE_DIR="$TEST_DIR/state-19"
+  mkdir -p "$STATE_DIR"
+  STOP_FILE="$STATE_DIR/stop"
+  out="$(cmd_stop 2>&1)"; rc=$?
+  if [ "$rc" = "0" ] && [ -e "$STOP_FILE" ]; then
+    ok "cmd_stop nominal : sentinel pose, rc=0"
+  else
+    ko "cmd_stop nominal devrait poser $STOP_FILE et rendre 0 (rc=$rc)"
+  fi
+  if echo "$out" | grep -qF "$STOP_FILE"; then
+    ok "cmd_stop annonce le CHEMIN du sentinel"
+  else
+    ko "le chemin du sentinel doit etre annonce, obtenu : $out"
+  fi
+
+  # (b) controle negatif : parent = fichier ordinaire -> touch impossible.
+  printf 'ceci est un fichier, pas un repertoire\n' > "$TEST_DIR/pas-un-dir"
+  STATE_DIR="$TEST_DIR/pas-un-dir"
+  STOP_FILE="$STATE_DIR/stop"
+  out="$(cmd_stop 2>&1)"; rc=$?
+  if [ "$rc" != "0" ]; then
+    ok "cmd_stop rend rc=$rc quand le sentinel ne peut pas etre ecrit"
+  else
+    ko "REGRESSION : cmd_stop rend 0 sur un sentinel non pose"
+  fi
+  if echo "$out" | grep -q "sentinel NON pose" \
+     && echo "$out" | grep -q "COURSIA_RUNNER_STATE_DIR"; then
+    ok "le message nomme la cause ET la variable qui la gouverne"
+  else
+    ko "message d'echec insuffisant : $out"
+  fi
+  # Et surtout : il ne doit PAS annoncer le succes.
+  if ! echo "$out" | grep -q "aucun nouveau conteneur ne sera lance"; then
+    ok "aucun message de succes n'est emis sur un arret inerte"
+  else
+    ko "l'echec annonce quand meme le succes : $out"
+  fi
+)
+echo ""
+
+# --- Verdict agrege ---------------------------------------------------------
+# `|| echo 0` serait un piege ici, et il l'a ete : `grep -c` IMPRIME "0" avant
+# de sortir 1 quand il ne trouve rien, donc le repli SUFFIXE un second zero au
+# lieu de remplacer -- n_fail vaut alors "0\n0", qui n'est pas egal a "0", et
+# le harnais se declare rouge avec 0 echec. Un gestionnaire d'erreur qui
+# fabrique un resultat plus grand que le vrai. Le repli ne sert qu'au fichier
+# absent : c'est ${x:-0} qui le couvre, apres coup.
+n_pass="$(grep -c '^PASS ' "$RESULTS" 2>/dev/null)"; n_pass="${n_pass:-0}"
+n_fail="$(grep -c '^FAIL ' "$RESULTS" 2>/dev/null)"; n_fail="${n_fail:-0}"
+echo "==========================================================="
+echo "  $n_pass PASS / $n_fail FAIL"
+if [ "$n_fail" != "0" ]; then
+  echo ""
+  echo "Assertions en echec :"
+  grep '^FAIL ' "$RESULTS" | sed 's/^FAIL /  - /'
+  echo ""
+  echo "Repertoire de travail conserve pour diagnostic : $TEST_DIR"
+  exit 1
+fi
+# Controle de vivacite : un harnais qui n'a rien assere sort vert sans avoir
+# rien mesure. Zero assertion est un ECHEC, pas un succes -- c'est ce que rend
+# un fichier de test dont le chemin de stubs est casse.
+if [ "$n_pass" = "0" ]; then
+  echo "ERREUR: aucune assertion executee -- le harnais n'a rien mesure." >&2
+  exit 2
+fi
+rm -rf "$TEST_DIR"
+exit 0


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/tooling #14981

## Ce que fait cette PR

Elle pose les bornes d'I/O du parc de runners **sur les fichiers qui tournent reellement sur ai-01**, ferme un defaut d'arret gracieux mesure sur cette machine, et ecrit noir sur blanc trois corrections que je dois publiquement sur #15091 / #15094.

C'est la suite directe du diagnostic user — « le superviseur declenche un traffic disque fou et des git clones en serie » — et du mandat qui a suivi : *« optimiser au mieux tout le traffic et les acces engendres par le superviseur et ses workers avec de vrais gardes surtout en cas de panne »*.

## Les trois corrections que je dois

### 1. #15094 patche une copie qui ne tourne pas sur ai-01

`persist/coursia-runner.service` et `persist/coursia-runner-start.sh` sont ceux de **po-2024** : depot sous `/mnt/c/dev/CoursIA`, prefixe `myia-po-2024-linux-docker`, wrapper qui relaie n'importe quelle sous-commande. Ceux d'ai-01 different sur les trois points qui comptent — `/mnt/d/CoursIA`, `myia-ai-01-wsl`, et un premier argument qui est le **nombre de slots**, pas une sous-commande.

Un correctif porte a plat ne touchait donc pas la machine qui a gele. `persist/ai-01/` rend la confusion impossible, et `persist/README.md` porte la table de correspondance : dix lignes, une par artefact deploye sur l'une ou l'autre machine — dont cinq seulement que cette PR ecrit ou corrige, les autres etant des references po-2024 inchangees.

### 2. `systemctl start` ignore `disabled`

J'ai affirme que la machine etait au repos parce que les deux unites etaient `inactive` / `disabled`. C'etait incomplet : `disabled` ne dit que l'absence de lien dans `multi-user.target.wants`, et un `systemctl start` explicite demarre l'unite quand meme. La tache planifiee Windows **`CoursIA-LinuxRunners-Boot`** fait exactement cela a chaque demarrage.

Consequence pratique pour le lot UAC : **le travail sur le superviseur n'en demande aucun** (tout se fait sous WSL root, qui ne passe pas par l'elevation Windows). Les vrais items du lot sont les **taches planifiees**.

### 3. L'arret gracieux d'ai-01 n'a jamais fonctionne — et rendait 0 en le faisant

Mesure firsthand du 2026-09-07, via `wsl.exe -d Ubuntu -u root --` :

- `systemctl show coursia-runner.service -p Environment` rend `Environment=` — **vide**.
- `ExecStop=` appelle `supervise.sh stop` **directement**, sans passer par le wrapper.
- Sans `COURSIA_RUNNER_STATE_DIR`, `STATE_DIR` retombe sur `$HOME/.coursia-runner`, soit `/root/.coursia-runner` pour un service systemd.
- `supervise.sh` fait lui-meme `mkdir -p "$STATE_DIR"` : l'arret **cree** le repertoire, y pose son sentinel, et affiche son message de succes. Le repertoire n'existait pas avant la sonde ; il existait apres.
- Le superviseur, lui, surveille `/var/lib/coursia-runner/stop`.

`cmd_stop` rendait `0` quoi qu'il arrive : le script tourne sous `set -uo pipefail` **sans `-e`**, donc l'echec du `touch` n'aurait rien interrompu, et le code de retour etait celui du dernier `echo`. Un arret inerte etait indiscernable d'un arret reussi — pour systemd comme pour l'operateur.

La suite est mecanique : `systemctl stop` attend, rien ne se passe, puis `KillMode=mixed` envoie SIGTERM aux jobs en vol. C'est-a-dire precisement le « couper net » que le sentinel existe pour eviter, et que le commentaire de l'unite decrit comme produisant des rouges qui ne veulent rien dire.

La jambe **waiters** ne souffre pas de ce defaut : son wrapper porte une branche `stop`. `persist/ai-01/coursia-runner-start.sh` reprend cette forme. Les sentinels de sonde ont ete nettoyes (`rm -rf /root/.coursia-runner /root/.coursia-probe-absent`, verifies absents).

## Ce qui rend l'ordre de grandeur concret

Cout d'un clone complet du depot, mesure par lecture de metadonnees git — **aucun clone lance** : la machine sortait de deux gels d'I/O et deux autres lanes sondaient le disque au meme moment (consigne user : pas de scans disque concurrents).

| Grandeur | Valeur | Instrument |
|---|---|---|
| Objets dans le pack | 241 982 | `git count-objects -v` |
| **Transfere par un clone complet** | **3,70 Gio** | `size-pack` |
| **Ecrit par le checkout** | **1,14 Gio** (10 387 blobs) | somme de `git ls-tree -r -l HEAD` |
| `.git` sur disque (arbre deja construit) | 13 Go | `du -sh` |
| Arbre de travail apres builds | 67 Go | `du -sh` |

Les deux dernieres lignes ne sont **pas** ce qu'un clone ecrit : elles portent les artefacts de build. Un slot neuf ecrit la somme des deux premieres, **~4,8 Gio**. Douze slots qui repartent ensemble ecrivent une cinquantaine de gigaoctets avant la premiere ligne de CI — sans plafond, sur le disque de l'interactif.

## Les trois bornes, et laquelle borne quoi

Elles ne se remplacent pas : chacune couvre ce que les autres ne voient pas.

| Borne | Ou elle vit | Ce qu'elle borne | Ce qu'elle **ne peut pas** borner |
|---|---|---|---|
| `coursia-ci.slice` | `/etc/systemd/system/` + `cgroup-parent` du daemon | la **somme** de tous les conteneurs | rien en dessous : un slot glouton et une famille entiere lui sont identiques |
| `--device-write-bps` / `--device-read-bps` | drapeaux de chaque `docker run` | **un** conteneur | la somme : 12 conteneurs conformes un a un saturent quand meme le disque |
| `COURSIA_RUNNER_CPU_BUDGET` | verification au demarrage | la **somme des demandes** de vCPU entre familles | l'usage reel — c'est un refus de demarrage, pas un plafond kernel |

Mesures du 2026-09-07 sur ai-01 (cgroup v2, delegation complete, `/var/lib/docker` sur `/dev/sde` = 8:64) :

| | Debit cumule |
|---|---|
| 3 conteneurs, **sans** la slice | 5,4 + 5,9 + 5,6 = **16,9 Go/s** |
| 3 conteneurs, **sous** la slice (`wbps=209715200`) | 77,6 + 72,0 + 71,5 = **221 Mo/s** |

soit 5,4 % au-dessus des 209,7 Mo/s declares, facteur **76**. Le plafond par conteneur a ete verifie separement : 7,4 Go/s ramenes a 21,2 Mo/s sous un cap de 20 Mio/s, a 1 % pres.

**Le budget agrege est VERIFIE, pas re-impose.** Il s'applique par defaut du daemon (`cgroup-parent` dans `daemon.json`) ; le superviseur controle qu'il est en vigueur. La distinction n'est pas cosmetique : passer `--cgroup-parent` sur une machine ou la slice n'existe pas **cree** un cgroup vide, qui a l'apparence exacte d'un garde et ne borne rien.

## Reserve honnete — ce que la conteneurisation du superviseur ne resoudra PAS

La piece 3 de #15091 (conteneuriser le superviseur, PR separee) n'aura **aucun effet sur l'I/O des workers**. Le superviseur lance ses conteneurs a travers le socket du daemon : ils naissent dans le cgroup du daemon, pas dans le sien. Il en reste **oncle**, jamais parent. Un cgroup borne autour du superviseur ne borne que ses propres journaux.

Ce qu'elle apporte reellement : isolation de son environnement, `--restart on-failure` independant de systemd, cgroup propre pour ses ressources. Ce qu'elle coute : monter `/var/run/docker-ce.sock` dans le conteneur, **equivalent a root sur l'hote**. Les deux moities figureront dans la PR qui la porte.

## Ce que les valeurs par defaut font aux autres machines

Les bornes de **ressources** sont vides ou a 0 : une machine qui tire cette version sans rien declarer ne se voit imposer aucun plafond qu'elle n'a pas demande, et po-2024 garde son comportement. C'est le wrapper de chaque machine qui arme.

Deux valeurs ne sont **pas** inertes, et le bloc `BORNES` de l'en-tete le dit : le **backoff** (5 s -> 300 s, jitter 25 %) et la **rotation des journaux** (32 Mio). Ce ne sont pas des plafonds — elles ne refusent rien et ne ralentissent aucun travail qui aboutit. Elles ne mordent que sur ce qui echoue en boucle ou grossit sans borne, c'est-a-dire les deux comportements qui ont mis la machine par terre. Les laisser inertes aurait demande a chaque machine de reclamer explicitement de ne pas marteler l'API et de ne pas remplir son disque.

## Validation

```
39 PASS / 0 FAIL
```

**Un `rc=0` ne prouve rien tant qu'on n'a pas montre que l'outil sait rougir.** C'est le standard que je me suis fixe dans le corps de #15094, et il vaut ici deux fois :

1. **Le harnais sortait 0 quoi qu'il arrive.** Il imprimait `FAIL:` et rendait le code du dernier `echo` — un cablage CI l'aurait vu vert en permanence. Cette PR ajoute un verdict agrege. Les compteurs sont tenus **dans un fichier**, pas dans une variable : chaque test tourne dans un sous-shell `( ... )`, ou un compteur serait incremente dans une copie que le parent ne lit jamais.
2. **Controle positif execute.** Une assertion fausse injectee dans une copie du harnais rend `rc=1`, affiche `39 PASS / 1 FAIL` et liste l'echec.

Le meme piege de sous-shell avait fait passer le **test 15** a cote de son objet au cycle precedent : `err="$(compute_blkio_args 2>&1 >/dev/null)"` executait la fonction dans une substitution de commande, ou son `BLKIO_ARGS=()` de tete ne reinitialisait que la copie — l'assertion lisait les drapeaux du cas d'avant. Le **script etait correct** ; c'est le test qui mesurait une valeur perimee. Ce FAIL transitoire est le controle positif le plus honnete de ce harnais, et il est cite ici plutot que tu.

Et un troisieme, attrape a l'ecriture du verdict lui-meme : `grep -c || echo 0` **suffixe** un second zero au lieu de remplacer (`grep -c` imprime `0` *avant* de sortir 1), donc `n_fail` valait `"0\n0"` et le harnais se declarait rouge avec zero echec. Un gestionnaire d'erreur qui fabrique un resultat plus grand que le vrai.

Chaque garde porte son **controle negatif** :

| Test | Garde | Controle negatif |
|---|---|---|
| 11 | backoff 5/10/20, cap 300 s | jitter 25 % : > 1 valeur distincte sur 40 tirages, 0 hors [15,25] |
| 12 | refus de budget CPU nommant les deux termes | — |
| 13 | 4 waiters + `start 1 3` = 7,00/8 accepte | `CPU_BUDGET=0` inerte et **silencieux** sur 48 vCPU demandes |
| 14 | slice absente + `REQUIRE=1` -> refus | `REQUIRE=0` -> avertissement, `rc=0` |
| 15 | drapeaux `--device-*-bps` exacts | tableau vide **et** aveu `AUCUN plafond ne sera applique` |
| 16 | 250 o -> tronque, `.1` a 250 | 40 o sous seuil -> intact ; `LOG_MAX_BYTES=0` inerte |
| 17 | toolcache monte sur le waiter | **aucun** volume `_work` (garde #14385 preservee) ; `WAITER_TOOLCACHE=0` -> rien |
| 18 | `supervisor_families` voit 3 familles | `supervisor_pids` reste borne a `start` ; le fork PPID != 1 exclu des deux |
| **19** | `cmd_stop` rend 1 sur sentinel non pose | cas nominal `rc=0` + chemin annonce ; **aucun** message de succes sur l'echec |

Le controle negatif du test 19 passe par un parent qui est un **fichier ordinaire** (ENOTDIR) : un test par permissions serait muet sous Windows/MSYS.

`bash -n` propre sur les deux scripts. Aucune regression sur les gardes #14259 / #14801.

## Deploiement — apres merge, sous WSL root, sans UAC

Ordre obligatoire : **les bornes d'abord, le parc ensuite**. Rallumer avant de les poser ferait repartir les 17 runs en file sous le regime non borne qui a gele la machine.

```sh
install -m 0644 persist/daemon.json        /etc/docker/daemon.json
install -m 0644 persist/coursia-ci.slice   /etc/systemd/system/coursia-ci.slice
install -m 0644 persist/ai-01/coursia-runner.service  /etc/systemd/system/coursia-runner.service
install -m 0755 persist/ai-01/coursia-runner-start.sh /usr/local/bin/coursia-runner-start.sh
systemctl daemon-reload
systemctl restart docker.service     # docker-ce : 0 conteneur a la mesure
systemctl start coursia-ci.slice
cat /sys/fs/cgroup/coursia.slice/coursia-ci.slice/io.max   # la borne doit etre REELLE
./scripts/ci/docker/linux-runner/supervise.sh status
```

Le `restart docker.service` ne vise que **docker-ce** (`unix:///var/run/docker-ce.sock`, pid 253, `Name=MyIA-AI-01`), qui portait **0 conteneur**. Le socket par defaut est celui du proxy Docker Desktop (pid 10179), qui portait les 48 conteneurs du parc : il n'est pas touche.

Le chemin kernel porte **deux** niveaux — systemd imbrique automatiquement `coursia-ci.slice` sous `coursia.slice`. Chercher la slice a la racine du cgroup ne rend rien et se lit a tort comme une slice absente.

## Portee — ce que cette PR ne fait pas

- Elle **ne conteneurise pas** le superviseur (piece 3, PR separee, avec la reserve ci-dessus).
- Elle **ne deploie rien** : `persist/` n'est execute par personne dans le depot. Le deploiement est le geste manuel ci-dessus, apres merge.
- Elle **ne touche pas** aux fichiers de po-2024, ni a ceux que #15094 modifie.
- **G-VAR-1 n'est pas tenu par ce grain** : `tooling` est un genre META, comme #15075 et #15094 avant lui. Trois grains META d'affilee sur cette lane, c'est un defaut de provisionnement de ma part, et il est a moi de le corriger — le grain de contenu qui portera le cycle suivant sera nomme dans le rapport de fin de cycle, pas remis a plus tard.

See #15091


