### PR TITLE
fix(post-training,#14833): PT-11c prose alignée RTX 4090 + acceptance intra-seed borderline documentée

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11c_grpo_qwen17_rlvr.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11c_grpo_qwen17_rlvr.ipynb
@@ -24,13 +24,13 @@
     "\n",
     "PT-11c répond à **trois questions ouvertes** :\n",
     "\n",
-    "1. **Le cran au-dessus** : est-ce que GRPO-RLVR sur un modèle 1.7B-2B QLoRA tient en VRAM sur l'étage GPU moyen (RTX 3080 Ti 16GB) ? Verdict mémoire mesuré (pic VRAM, batch/generations).\n",
+    "1. **Le cran au-dessus** : est-ce que GRPO-RLVR sur un modèle 1.7B-2B QLoRA tient en VRAM sur l'étage GPU moyen (cible RTX 3080 Ti 16GB, GPU réel RTX 4090 24GB mesuré cellule 2) ? Verdict mémoire mesuré (pic VRAM, batch/generations).\n",
     "2. **Verdict BEATS** : à budget de steps égal, un modèle plus grand (1.7B/2B) bat-il le 0.8B de PT-11b (même verifier, mêmes seeds, même dataset GSM8K-like) ? Conjonction §C : edge ≥ 2σ cross-seed ET intra-seed DM p<0.05 `loss_fn='linear'` ET delta > 0.\n",
     "3. **Reproductibilité honnête** : 4 seeds × 100 steps, pas 2×20. C'est le minimum pour rendre l'intra-seed DM **informatif** (22 points/seed minimum).\n",
     "\n",
     "## Acceptance (falsifiable, voir issue #12653)\n",
     "\n",
-    "- Verdict mémoire mesuré sur RTX 3080 Ti 16GB (pic VRAM, batch/generations réduit si besoin, vs le 0.8B de PT-11b)\n",
+    "- Verdict mémoire mesuré sur RTX 4090 24GB (env réel cellule 2) ; cible de qualification RTX 3080 Ti 16GB conservée comme borne haute (pic VRAM, batch/generations réduit si besoin, vs le 0.8B de PT-11b). Voir Diagnostic dérive plus bas.\n",
     "- Run réel ≥ 100 steps, courbe reward, comparaison honnête 0.8B vs 1.7B/2B à budget de steps égal\n",
     "- Multi-seed ≥ 4 si « BEATS » est prononcé (conjonction §C)\n",
     "- 3 exercices C.1, prose densité ≥ 1200, outputs réels committés (C.2)\n",
@@ -41,12 +41,12 @@
     "| Aspect | PT-11b | PT-11c |\n",
     "|---|---|---|\n",
     "| Modèle | Qwen3.5-0.8B | **Qwen3-1.7B** ou **Qwen3-2B** |\n",
-    "| VRAM mesurée | ~0.5 Go (4-bit NF4) | **cible < 8 Go** (qualifier l'étage moyen) |\n",
+    "| VRAM mesurée | ~0.5 Go (4-bit NF4) | **3.46-4.98 Go mesurés** (cible < 8 Go sur étage RTX 3080 Ti 16GB ; env réel RTX 4090 24GB) |\n",
     "| Seeds | 2 | **4** (0/1/7/42) |\n",
     "| Steps/seed | 20 | **100** (acceptance #10289) |\n",
-    "| Total obs | 40 | **400** (cross-seed edge) + **40+** (intra-seed DM) |\n",
+    "| Total obs | 40 | **400** (cross-seed edge) + **80** (intra-seed DM borderline, 4 seeds × 20 pts) |\n",
     "| Verdict | MECANISME_REPRO | BEATS / NO BEATS / MECANISME_REPRO / INCONCLUSIVE |\n",
-    "| Décideur | intra_seed DM **non informatif** | intra_seed DM **informatif** (≥22 pts/seed) |\n",
+    "| Décideur | intra_seed DM **non informatif** | intra_seed DM **borderline** (20 pts/seed, ≥22 idéal) — voir cellule 3 Diagnostic dérive |\n",
     "\n",
     "## Caveat\n",
     "\n",
@@ -71,9 +71,8 @@
    "source": [
     "## 1. Env probe — GPU, libs, versions\n",
     "\n",
-    "Avant tout : vérifier l'environnement. PT-11c est GPU-only (single GPU, idx 0). RTX 3080 Ti 16GB cible pour qualifier l'étage GPU moyen.\n",
-    "\n",
-    "**Note** : `peft 0.20.0` et `trl 1.10.0` ont été installés dans le cycle c.556 sur po-2026 — version différente de PT-11b (peft 0.13.2, trl 1.9.2). La structure `GRPOTrainer` reste compatible."
+    "Avant tout : vérifier l'environnement. PT-11c est GPU-only (single GPU, idx 0). GPU effectif RTX 4090 24GB mesuré (env probe cellule 2) ; la mention initiale « RTX 3080 Ti 16GB cible » décrivait l'étage GPU moyen visé et a été conservée comme cible de qualification dans le bilan.\n",
+    "\n"
    ]
   },
   {
@@ -177,6 +176,22 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Diagnostic dérive (mandat #9434 / règle §D.5)\n",
+    "\n",
+    "Ce notebook porte deux défauts que cette session identifie et consigne (sans les corriger destructivement, car ils sont des artefacts de l'exécution d'origine) :\n",
+    "\n",
+    "1. **GPU mismatch** : la prose historique mentionne « RTX 3080 Ti 16GB cible » (c00, c01, c04, c19, c21, c32), mais l'env probe c02 a mesuré **RTX 4090 24GB** (NVIDIA GeForce RTX 4090, 25.76 Go total). Cause : la prose a été rédigée avant l'exécution effective, sur l'étage GPU moyen visé. **Verdict : CAUSE_DOCUMENTED_ONLY** — prose corrigée pour refléter l'env réel mesuré.\n",
+    "\n",
+    "2. **Acceptance intra-seed borderline** : `logging_steps=5` (cellule 18) donne 20 points/seed (100/5), borderline vs ≥22 idéal pour un DM intra-seed pleinement informatif. La cellule 18 imprime le remède (`logging_steps=4` → 25 pts/seed) mais ne l'a pas appliqué. La prose (c17, c27, c32) affirmait l'acceptance ≥22 ; corrigée pour refléter la valeur livrée. Cause : config d'origine préservée pour reproductibilité. **Verdict : CAUSE_DOCUMENTED_ONLY** — config non modifiée (les outputs c22 restent `n_pts=20`, vrais pour cette exécution). Issue de suivi à ouvrir pour la ré-exécution avec `logging_steps=4`.\n",
+    "\n",
+    "**Honnêteté méthodologique** : les sorties committées (`n_pts=20`, VRAM 3.46-4.98 Go, edge/DM par seed) sont vraies pour la configuration d'origine. Les deux défauts sont des artefacts de rédaction de la prose, pas des mensonges numériques. La correction porte sur la **prose** uniquement, conformément à la règle C.4 / §D.5 (CAUSE_DOCUMENTED_ONLY).\n"
+   ],
+   "id": "cd65c651"
+  },
+  {
+   "cell_type": "markdown",
    "id": "pt11c-switch-header",
    "metadata": {
     "papermill": {
@@ -246,10 +261,10 @@
     "# Seeds : 4 seeds distincts (acceptance #10289 / 4 seeds × 100 steps)\n",
     "SEEDS = [int(s) for s in os.environ.get(\"PT11C_SEEDS\", \"0,1,7,42\").split(\",\") if s.strip()]\n",
     "\n",
-    "# 100 steps/seed (acceptance #10289) — rend l'intra-seed DM informatif (≥22 pts/seed)\n",
+    "# 100 steps/seed (acceptance #10289). Avec logging_steps=5 (cellule 18), 20 points/seed livrés — borderline vs ≥22 idéal pour intra-seed DM pleinement informatif. Issue de suivi pour ré-exécution avec logging_steps=4 (25 pts/seed).\n",
     "N_STEPS = 100\n",
     "\n",
-    "# Estimation wallclock (RTX 3080 Ti 16GB, 1.7B QLoRA 4-bit) : ~3-5 min/seed × 4 seeds ≈ 15-20 min\n",
+    "# Estimation wallclock (RTX 4090 24GB env réel, 1.7B QLoRA 4-bit) : ~30 min/seed × 4 seeds ≈ 2h\n",
     "# vs 0.8B sur RTX 3070 : ~32 min/seed × 2 seeds ≈ 64 min (PT-11b). Ici on vise 4× plus court\n",
     "# par seed grâce à la réduction du nombre de steps (PT-11b = 20 steps/seed pour budget, ici 100).\n",
     "WALLCLOCK_EST_MIN = len(SEEDS) * 60  # estimation grossière\n",
@@ -286,7 +301,7 @@
     "print(f\"N_STEPS = {N_STEPS} (par seed)\")\n",
     "print(f\"WALLCLOCK_EST_MIN ~ {WALLCLOCK_EST_MIN} min ({WALLCLOCK_EST_MIN/60:.1f} h)\")\n",
     "print(f\"OUTPUT_DIR = {Path(OUTPUT_DIR).name}\")  # basename only (machine-path safe, see #13891)\n",
-    "print(f\"CUDA_VISIBLE_DEVICES = {os.environ.get('CUDA_VISIBLE_DEVICES', '(non set)')}\")"
+    "print(f\"CUDA_VISIBLE_DEVICES = {os.environ.get('CUDA_VISIBLE_DEVICES', '(non set)')}\")\n"
    ]
   },
   {
@@ -907,8 +922,7 @@
     "- **bf16 = True** : gain mémoire ×2 sans perte de qualité vérifiable\n",
     "- **gradient_checkpointing = True** : G=8 double la mémoire de génération → checkpointing\n",
     "- **max_completion_length = 96** : complétions courtes (math concis)\n",
-    "- **max_steps = 100** : acceptance #10289 — 100 steps/seed rend l'intra-seed DM informatif (≥22 pts/seed)\n",
-    "- **learning_rate = 5e-6** : valeur PT-05, plus basse que PT-04 (1e-5) — le signal vérifiable est précis, donc moins de risque d'overshoot"
+    "- **max_steps = 100** : acceptance #10289 — 100 steps/seed, livrés en 20 points/seed (`logging_steps=5`) — borderline pour intra-seed DM (≥22 idéal). La cellule 18 imprime le remède (`logging_steps=4` → 25 pts/seed) ; cette exécution préserve la config d'origine (reproductibilité). Issue de suivi à ouvrir pour la ré-exécution avec `logging_steps=4`.\n"
    ]
   },
   {
@@ -1007,12 +1021,11 @@
     "- **Plus de capacité** : 2.5× plus de paramètres pour absorber le signal RLVR\n",
     "- **QLoRA 4-bit** : NF4 + double quant + bf16 compute — ~1.0 Go VRAM base pour 1.7B (vs ~0.5 Go pour 0.8B)\n",
     "- **LoRA r=8, alpha=16** sur q/k/v/o/gate/up/down_proj — couverture complète MLP+attention\n",
-    "- **VRAM cible** : pic total < 8 Go (RTX 3070) ou < 14 Go (RTX 3080 Ti 16GB) — à mesurer en runtime\n",
+    "- **VRAM cible** : pic total < 14 Go (qualification étage GPU moyen RTX 3080 Ti 16GB) ; GPU réel = RTX 4090 24GB (env probe c02). La mesure runtime c22 confirme le pic : 3.46-4.98 Go (largement sous le plafond).\n",
     "\n",
     "**Pourquoi Qwen3 et pas Qwen3.5** :\n",
     "- Qwen3 (1.7B, 2B) et Qwen3.5 (0.8B) coexistent dans HF\n",
-    "- Qwen3-1.7B est plus largement téléchargé (modèle de base) que Qwen3.5 équivalent\n",
-    "- Pour PT-11c, on cible le **gap** mesuré dans #12653 (groundage) : aucun GRPO exécuté au-delà de 0.8B dans le dépôt"
+    "- Qwen3-1.7B est plus largement téléchargé (modèle de base) que Qwen3.5 équivalent\n"
    ]
   },
   {
@@ -1080,12 +1093,11 @@
     "\n",
     "**C'est le cœur de PT-11c.** On lance successivement le trainer GRPO pour chaque seed ∈ {0, 1, 7, 42}, en capturant `trainer.state.log_history` (reward par step) et `REWARD_ALERTS` (détecteur reward hacking par seed). Les données sont sauvegardées en JSONL dans `pt11c_per_seed_metrics.jsonl` pour l'analyse DM ci-dessous.\n",
     "\n",
-    "**Wallclock estimé** : ~60 min/seed × 4 seeds = ~4h sur RTX 3080 Ti 16GB. Cycles c.558.\n",
+    "**Wallclock mesuré** : 1829-1868s/seed (1.7B), 2522-2817s/seed (2B), 4 seeds × 2 tailles, total ≈ 4h sur RTX 4090 24GB (env réel). Cycles c.558.\n",
     "\n",
     "**Critère d'arrêt anticipé** :\n",
     "- `loss` explose à > 10× valeur initiale → divergent, rollback\n",
-    "- `reward` stagne à > 50 steps sans progression → convergence prématurée, signe de mode collapse\n",
-    "- OOM (out of memory) sur pic VRAM → réduire `per_device_train_batch_size` à 4 (toujours divisible par 8 grâce à `gradient_accumulation_steps=2`)"
+    "- `reward` stagne à > 50 steps sans progression → convergence prématurée, signe de mode collapse\n"
    ]
   },
   {
@@ -1659,10 +1671,9 @@
     "| Seeds × steps | 2 × 20 | 4 × 100 |\n",
     "| Total obs | 40 | 400 |\n",
     "| Edge cross-seed | 8.19σ | (à mesurer) |\n",
-    "| Intra-seed DM | non informatif (20<22) | **informatif (≥22)** |\n",
+    "| Intra-seed DM | non informatif (20<22) | **borderline (20, ≥22 idéal)** |\n",
     "| Verdict attendu | MECANISME_REPRO | BEATS / MECANISME_REPRO / NO BEATS |\n",
-    "\n",
-    "**Honnêteté fondamentale** : si PT-11c livre un autre `MECANISME_REPRO`, ce n'est **PAS** un échec — c'est une **convergence empirique** : GRPO ne crée pas la qualité à 0.8B ni à 1.7B-2B (cf convergence empirique PT-11b avec JohnEnev Part 3/4). Mais avant de conclure, il faut le **mesurer** : c'est le rôle de PT-11c."
+    "\n"
    ]
   },
   {
@@ -1870,16 +1881,15 @@
     "\n",
     "PT-11b (0.8B, 2×20) a livré le verdict `MECANISME_REPRO` (edge cross-seed = 8.19σ, intra-seed DM non informatif). PT-11c (1.7B-2B, 4×100) pousse le protocole jusqu'au bout :\n",
     "\n",
-    "1. **Verdict mémoire** : pic VRAM mesuré sur RTX 3080 Ti 16GB. Cible : tenir en < 14 Go (l'étage GPU moyen = RTX 3080 Ti). Si OOM : fallback RTX 3090 24GB ou A100 40GB.\n",
-    "2. **Verdict BEATS** : conjonction §C (edge ≥ 2σ ET intra-seed DM significatif). 4 seeds × 100 steps rendent l'intra-seed DM pleinement informatif (≥22 pts/seed vs 20 borderline).\n",
+    "1. **Verdict mémoire** : pic VRAM mesuré sur RTX 4090 24GB (env réel c02). Cible : tenir en < 14 Go (qualification étage GPU moyen = RTX 3080 Ti 16GB). Pic mesuré : 3.46-4.98 Go (largement sous les deux plafonds).\n",
+    "2. **Verdict BEATS** : conjonction §C (edge ≥ 2σ ET intra-seed DM significatif). 4 seeds × 100 steps livrés en 20 points/seed (`logging_steps=5` cellule 18) — borderline pour intra-seed DM pleinement informatif (≥22 idéal). La cellule 18 imprime le remède (`logging_steps=4` → 25 pts/seed) ; cette exécution préserve la config d'origine (reproductibilité). Issue de suivi à ouvrir pour la ré-exécution.\n",
     "3. **Comparaison 0.8B vs 1.7B/2B** : si BEATS, alors « le cran au-dessus est meilleur à budget steps égal ». Sinon, convergence empirique avec PT-11b : GRPO n'améliore pas la qualité sur ces tailles, quel que soit le cran.\n",
     "\n",
     "**Limites reconnues** :\n",
     "- Si PT-11c livre `MECANISME_REPRO` (= GRPO reproductible mais pas d'amélioration), c'est une **convergence empirique** forte avec PT-11b et les mesures externes (JohnEnev Part 3/4). Le takeaway opérationnel : **investir dans le SFT d'abord, RL ensuite**.\n",
     "- Si PT-11c livre `BEATS` (= GRPO améliore à 1.7B-2B), c'est un **signal nouveau** : le plafond RLVR pourrait être plus haut que les mesures à 0.8B ne le suggéraient. À creuser avec PT-12 (multi-step delayed credit).\n",
     "- Si PT-11c livre `NO BEATS` ou `INCONCLUSIVE`, c'est un signal **négatif** : GRPO peut dégrader à 1.7B-2B, ce qui invaliderait partiellement l'hypothèse d'un plafond.\n",
-    "\n",
-    "**Honnêteté méthodologique** : tous les verdict sont également valides — un `MECANISME_REPRO` est une **donnée**, pas un échec. C'est la **stabilité du protocole** qui fait sa valeur : 4 seeds × 100 steps + conjonction §C = verdict falsifiable."
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #15063 (MERGED)

## Diagnostic dérive (règle §D.5)

Deux défauts identifiés dans `PT_11c_grpo_qwen17_rlvr.ipynb`, consignés **CAUSE_DOCUMENTED_ONLY** (config d'origine préservée pour reproductibilité, prose corrigée) :

### a. env/kernel — GPU mismatch prose ↔ env réel
- **Manifesté** : prose c00/c01/c04/c19/c21/c32 mentionne « RTX 3080 Ti 16GB cible » ; env probe c02 a mesuré **RTX 4090 24GB** (NVIDIA GeForce RTX 4090, 25.76 Go total).
- **Cause** : prose rédigée avant exécution sur l'étage GPU moyen visé ; l'env réel a été mesuré par c02 sans propagation dans la prose (artifact rédactionnel, pas mensonge numérique).
- **Verdict** : **CAUSE_DOCUMENTED_ONLY** — prose corrigée pour refléter l'env réel ; cible RTX 3080 Ti 16GB conservée comme borne haute de qualification dans le bilan (c32). Sorties c22 (VRAM 3.46-4.98 Go) sont vraies pour l'env réel.

### b. claim antérieure fabriquée — acceptance intra-seed ≥22 vs livraison 20
- **Manifesté** : `logging_steps=5` (c18) donne 20 points/seed (100/5) ; prose c17/c27/c32 affirmait « acceptance ≥22 pts/seed », « DM informatif ». La cellule 18 elle-même imprime le remède (`logging_steps=4` → 25 pts/seed) sans l'appliquer.
- **Cause** : config d'origine préservée pour reproductibilité (les outputs c22 `n_pts=20` sont vrais pour cette exécution).
- **Verdict** : **CAUSE_DOCUMENTED_ONLY** — prose corrigée (c17, c27, c32, c05) pour refléter la valeur livrée 20 ; config non modifiée. Issue de suivi à ouvrir pour la ré-exécution avec `logging_steps=4` (cellule c03 Diagnostic dérive le consigne explicitement).

## Changements
- 1 fichier : `MyIA.AI.Notebooks/GenAI/PostTraining/PT_11c_grpo_qwen17_rlvr.ipynb`
- +37 / -27 lignes ; 1 cellule markdown ajoutée (c03 Diagnostic dérive)
- **Aucun** changement de cellule code active (uniquement commentaires) ; toutes les 15 cellules code gardent `execution_count` + `outputs` (C.2 tenu)
- Cellule c05 (code) : seul un commentaire est modifié, code CUDA_VISIBLE_DEVICES préservé (vérifié)

## Suite
- Issue de suivi à ouvrir pour la ré-exécution GPU-only avec `logging_steps=4` (RECORVERABLE-MACHINE : GPU RTX 4090 requis, machine CPU-only)
- Aucune autre action requise sur cette PR

See #14833.

