### PR TITLE
fix(pymc): aligner le diagramme séquentiel sur la maladie cachée

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-4-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-4-Decision-Networks.ipynb
@@ -14,13 +14,12 @@
     "tags": []
    },
    "source": [
-    "# DecPyMC-4-Decision-Networks : Reseaux de Decision",
-    "\n",
+    "# DecPyMC-4-Decision-Networks : Reseaux de Decision\n",
     "**Serie** : Programmation Probabiliste avec PyMC (4/7)  \n",
     "**Duree estimee** : 55 minutes  \n",
     "**Prerequis** : Notebooks 3 (Graphes probabilistes), 14-16 (Utilite)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs\n",
     "\n",
@@ -29,7 +28,7 @@
     "- Comprendre les **arcs informationnels**\n",
     "- Modeliser des **decisions séquentielles**\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Navigation\n",
     "\n",
@@ -37,7 +36,7 @@
     "|-----------|--------|\n",
     "| [DecPyMC-3-Multi-Attribute](DecPyMC-3-Multi-Attribute.ipynb) | [DecPyMC-5-Value-Information](DecPyMC-5-Value-Information.ipynb) |\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1033,14 +1032,16 @@
     "\n",
     "```\n",
     "<Faire Test?> ----> [Résultat] ----> <Traiter?> ----> ((Utilite))\n",
-    "                                          ^\n",
-    "                                          |\n",
-    "[Maladie] ---------------------------------+\n",
+    "                                                       ^\n",
+    "                                                       |\n",
+    "[Maladie] ---------------------------------------------+\n",
     "```\n",
+    "\n",
+    "La maladie reste **non observée** avant les deux décisions : l'arc `Maladie -> Utilite` indique son effet sur le gain, pas une information disponible pour `Traiter`. Le résultat dépend de la maladie ; il n'est observé que si le test est fait. Le schéma omet cette dépendance probabiliste et l'arc de coût `Faire Test? -> Utilite`.\n",
     "\n",
     "Deux decisions séquentielles :\n",
     "1. D'abord : Faire le test ou non ?\n",
-    "2. Ensuite : Traiter ou non ? (en connaissant le résultat si test fait)"
+    "2. Ensuite : Traiter ou non ? (en connaissant le résultat si test fait ; sinon, selon la probabilité a priori)"
    ]
   },
   {
@@ -2150,7 +2151,7 @@
     "| **Politique** | Fonction observations -> decisions |\n",
     "| **Backward induction** | Resolution du dernier au premier noeud de decision |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Pour aller plus loin\n",
     "\n",
@@ -2160,7 +2161,7 @@
     "| Decisions robustes | [DecPyMC-6-Expert-Systems](DecPyMC-6-Expert-Systems.ipynb) |\n",
     "| Decisions séquentielles (MDPs) | [DecPyMC-7-Sequential](DecPyMC-7-Sequential.ipynb) |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Prochaine étape\n",
     "\n",
@@ -2170,7 +2171,7 @@
     "- La valeur de l'information d'echantillon (EVSI)\n",
     "- Des applications : droits de forage, chasse au tresor\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## References\n",
     "\n",
@@ -2197,7 +2198,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Conclusion** : Ce notebook a presente les reseaux de decision (diagrammes d'influence), les arcs informationnels, la resolution par backward induction, et les decisions séquentielles avec PyMC.\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/research-code #15000

## Résumé

Corrige une incohérence entre le diagramme des décisions séquentielles et le calcul qui le suit :

- la flèche `Maladie` aboutit désormais à `Utilite`, et non à la décision `Traiter` ;
- la prose rend explicite que la maladie reste cachée avant les décisions ;
- le résultat du test n'est observable que si le test est effectué ;
- sans test, le traitement est choisi à partir de la probabilité a priori.

Le calcul et ses sorties `43,6 / 84` sont préservés : ils étaient corrects sous ce contrat « maladie cachée ».

## Audit et reproduction

Un audit Astra a posé puis testé le claim central : le calcul devait optimiser la même structure d'information que celle représentée par le diagramme.

L'oracle indépendant énumère exhaustivement les politiques déterministes à partir de la distribution jointe maladie × résultat, sans appeler le helper du notebook :

| Structure d'information | Avec test | Sans test | Optimum global |
|---|---:|---:|---:|
| Maladie cachée, résultat observé si test | 43,6 | 84 | 84 |
| Maladie observée avant traitement (ancien arc) | 50 | 100 | 100 |
| Résultat observé après traitement (contrôle) | 34 | 84 | 84 |
| Maladie cachée, test gratuit (contrôle) | 93,6 | 84 | 93,6 |

Le caller a relancé l'oracle indépendamment : `ALL_ASSERTIONS_PASSED`. Les sorties fraîches des cellules code 14 et 22 sont exactement identiques aux sorties committées.

## Portée et intégrité du notebook

- un seul notebook modifié ;
- correction scientifique dans la cellule markdown index 21, ID `761a49a0` ;
- le hook canonique `fix-hr-separator` a en outre normalisé sept séparateurs décoratifs préexistants `---` → `***` dans les cellules markdown IDs `4d1dbaac`, `66a5401e` et `f7797277` ; le premier commit a été refusé puis le hook a passé au second passage, sans bypass ;
- diff final : `+14/−13` ;
- 43/43 IDs, types et ordre préservés ;
- aucun output ni `execution_count` modifié ; code et métadonnées préservés ;
- aucune réexécution requise pour cette correction exclusivement markdown ;
- aucun catalogue, ledger ou rapport d'audit committé.

Empreinte SHA-256 de la source :

```text
avant e6b64c71eec28bdf378818eaadaba9cd32fad49f3daca3edb62cb9f3ccf926e9
après c5e46020d4315ad8e96083a4eae5a98e4e42a693301ce02772475d04f6125eef
```

## Validations

- `notebook_tools.py validate ... --quick --json` : 1 OK, 0 avertissement, 0 erreur ;
- `notebook_lint.py ... --check c1,c2,structure,meta --json` : aucune violation ;
- `validate_pr_notebooks.py HEAD ... --json` : 14 cellules code, `EXEC_PROVED`, 0 erreur ;
- `check_notebook_navlinks.py ... --json` : 0 lien cassé ;
- `nbformat.validate` : valide ;
- `git diff --check` : aucun défaut ;
- contrôle ASCII : `+`, `|`, `^` alignés sous `Utilite`.

## Diagnostic dérive

Cause : **claim antérieure fabriquée dans le diagramme**. La convention du notebook définit `Chance -> Decision` comme un arc informationnel, mais l'ancien dessin reliait `Maladie` à `Traiter` alors que le calcul garde la maladie cachée. Verdict : **CAUSE_FIXED** — le diagramme et la prose expriment maintenant le contrat réellement calculé.

## Circuit pilote

Première correction réalisée selon le circuit direct demandé : **audit Astra → correction dans le même contexte → reproduction et contre-vérification indépendante → PR**, sans issue de transit. Les défauts profonds, ambigus ou architecturaux restent destinés à une issue de cadrage.
