### PR TITLE
fix(notebook-python,#15109): DecPyMC-7 requalifier l'indispensabilite MCMC (md-only, 25/25 cells code intactes)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
@@ -3271,9 +3271,11 @@
    "source": [
     "### Thompson Sampling avec MCMC PyMC (cas canonique)\n",
     "\n",
-    "Dans le cas Beta-Bernoulli, la posterior a une forme analytique. Mais pour des modèles plus complexes (recompenses gaussiennes avec variance inconnue, priors hiérarchiques), PyMC devient indispensable.\n",
+    "Dans le cas Beta-Bernoulli, la posterior a une forme analytique. Pour des modèles non conjugues (recompenses gaussiennes avec variance inconnue, priors hiérarchiques, vraisemblances non standard), PyMC generalise naturellement l'approche par echantillonnage MCMC.\n",
     "\n",
-    "Ici on illustre l'approche PyMC sur un bandit gaussien : on infere la moyenne de chaque bras via NUTS (Hoffman & Gelman, 2014), puis on echantillonne depuis la posterior pour la sélection."
+    "**Portee de cette illustration** : on presente ci-dessous un bandit gaussien a variance inconnue partagee. Pour ce modele precis, une alternative analytique reste applicable (marginalisation des moyennes mu, conditionnellement conjuguees sachant sigma, puis quadrature 1D sur log(sigma)). PyMC n'est donc pas *indispensable* ici ; il est *generalement applicable* des que la vraisemblance echappe a la conjugaison pratique.\n",
+    "\n",
+    "On illustre l'approche PyMC : on infere la moyenne de chaque bras via NUTS (Hoffman & Gelman, 2014), puis on echantillonne depuis la posterior pour la selection. PyMC devient preferable (et l'avantage devient decisif) sur des modeles ou la quadrature 1D ne tient pas : melanges de gaussiennes, vraisemblances discontinues ou non standard, priors hierarchiques riches."
    ]
   },
   {
@@ -4370,12 +4372,14 @@
     "|--------|----------------------------|----------------------|\n",
     "| **Mise a jour** | Formule fermee | Echantillonnage NUTS |\n",
     "| **Complexite** | O(1) par mise a jour | O(secondes) par ronde |\n",
-    "| **Flexibilite** | Bernoulli uniquement | Modèles arbitraires |\n",
+    "| **Flexibilite** | Bernoulli uniquement | Modèles ou la quadrature pratique echoue |\n",
     "| **Diagnostics** | Non nécessaire | ArviZ ($\\hat{R}$, ESS) |\n",
     "\n",
-    "**Avantage PyMC** : Quand le modèle de recompense n'a pas de forme conjuguee (mélange de gaussiennes, distributions heaviside, priors hiérarchiques), PyMC reste applicable tandis que l'approche analytique echoue.\n",
+    "**Avantage PyMC, scope precise** : pour le modele *exact* presente dans la cellule ci-dessus (moyennes mu_i gaussiennes, variance sigma inconnue partagee, vraisemblance Normale), une quadrature 1D sur log(sigma) apres marginalisation des mu reste applicable. PyMC n'apporte donc pas un avantage decisif *sur ce modele precis*. Il devient preferable sur les modeles ou la quadrature pratique echoue : melanges de gaussiennes, vraisemblances discontinues, priors hierarchiques riches, posteriors multimodales. PyMC est ici cite comme framework, pas comme un sampler specifique : NUTS (sampler par defaut) repose sur les gradients du log-posterior et peut etre inadapte aux vraisemblances discontinues ; sur de tels modeles, les samplers sans gradient fournis par PyMC (Metropolis, DEMetropolisZ, SMC) sont preferable. Le choix du sampler reste explicite et conditionne la viabilite du MCMC, independamment du framework employe.\n",
     "\n",
-    "**Cout** : L'echantillonnage MCMC a chaque ronde est plus lent, mais la justesse de l'inference compense dans les scénarios complexes (little data, priors informatifs)."
+    "**Contrat du trace retourne** : la fonction `pymc_thompson_bandit` ajuste la posterior sur les observations *disponibles au debut de chaque ronde*, echantillonne pour selectionner le bras, puis tire ce bras `n_pulls_per_round` fois. Le `trace` final rendu est donc ajuste sur l'avant-dernier lot d'observations ; il ne reflete pas les recompenses collectees lors du dernier tirage. Une posterior sur toutes les recompenses retournerait un fit ulterieur. Cette politique est exactement un **Thompson Sampling par lots** : le bras choisi (max d'un echantillon de la posterior, comme precise dans le docstring de la cellule de code ci-dessus) est tire `n_pulls_per_round` fois consecutives apres un seul ajustement de la posterior sur l'historique disponible. La ronde 0 fait exception et tire chaque bras une fois pour initialiser les observations.\n",
+    "\n",
+    "**Diagnostics** : la cellule de PyMC ci-dessus utilise 100 draws / 50 tune / 2 chaines (parametres reduits pour iteration rapide). Les diagnostics ArviZ complets ($\\hat{R}$, ESS) sur ce modele precis de bandit ne sont pas rapportes ici ; les diagnostics montres dans les cellules suivantes portent sur le modele de maintenance predictive (POMDP belief states) qui justifie un budget d'echantillonnage plus eleve. Toute interpretation d'une posterior MCMC comme reference de probabilite d'action precise exige ces diagnostics ; sur le modele de bandit ci-dessus, on lit les resultats comme une illustration qualitative du mecanisme, pas comme une mesure exacte."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #15113 (MERGED)

## Summary

Requalifie l'indispensabilité MCMC dans `DecPyMC-7-Sequential.ipynb`. Préserve le Thompson Sampling par lots valide et le code inchangé — corrige seulement 2 cellules markdown où la prose surdimensionnait la portée de PyMC par rapport au modèle exact présenté.

## c.988 — itération md-only (po-2025 adjoint dispatch DM HIGH)

Suite au dispatch DM HIGH `msg-20260908T064958-hkd4h5` (po-2025 adjoint, relecture head `a11d6f0e83`), 2 écarts sémantiques identifiés et levés **md-only** sans ré-exécution (correction n'affecte pas les valeurs exécutées).

**HEAD c.988** : `21e3e32221` (amend de `a11d6f0e83`, base inchangée). Diff vs head pré-c.988 : `1 file changed, 9 insertions(+), 5 deletions(-)`. 25/25 cellules code byte-identiques, 0 output, 0 execution_count, 0 cell ID, 0 ordre modifié.

### Écart (1) — cellule 58 : politique bras choisi vs « chaque bras »

**Défaut pointé par po-2025**. La cellule affirmait : *« on tire chaque bras `n_pulls_per_round` fois consecutives »*. La cellule 57 (`pymc_thompson_bandit`) montre le contraire — ronde 0 tire chaque bras une fois (initialisation) puis rondes r > 0 prennent `chosen_arm = np.argmax(posterior_matrix[sample_idx])` et tirent **uniquement** ce bras `n_pulls_per_round` fois.

**Cause racine**. La phrase a été ajoutée verbatim c.975 lors d'une réparation md-only qui décrivait le **mécanisme par lots** sans tracer la sémantique réelle du `chosen_arm`. Tell c.942-L1 ★ sustained : *« les valeurs mesurées citées en interprétation se RE-QUOTENT depuis la sortie exécutée, jamais d'un proto antérieur. »*

**Levée c.988**. Réécriture du paragraphe « Contrat du trace retourné » : le paragraphe distingue maintenant les 2 phases (r=0 chaque bras une fois pour initialiser, r>0 bras choisi `n_pulls_per_round` fois) au lieu de gommer la différence sous un « chaque bras » trompeur. Vrai-faux test : un étudiant lisant l'interprétation voit maintenant la même politique que le code ci-dessus.

### Écart (2) — cellule 58 : portée NUTS sur vraisemblances discontinues

**Défaut pointé par po-2025**. La cellule concluait : *« Il devient preferable sur les modeles ou la quadrature pratique echoue : ... vraisemblances discontinues ... »* — citation implicite de NUTS comme sampler par défaut, sans le dire.

Or NUTS repose sur les gradients du log-posterior (Hoffman & Gelman, 2014) et **peut être inadapté** aux vraisemblances discontinues (frontières dures, sauts). Sélectionner NUTS sur une vraisemblance discontinue est une erreur de cadrage, pas une limitation de PyMC (qui propose aussi Metropolis, DEMetropolisZ, SMC). Tell c.974-L2 sustained : *« la levée passe par le contenu commité, pas par un amend body seul. »*

**Levée c.988**. Réécriture du paragraphe « Avantage PyMC, scope précise » :
- Distingue framework (PyMC) et sampler (NUTS = défaut)
- Note que NUTS-gradient peut être inadapté aux discontinuités
- Cite les alternatives sans gradient (Metropolis, DEMetropolisZ, SMC)
- Élimine le doublon « vraisemblances non standard » (remplacé par « posteriors multimodales » dans la liste)

## État antérieur (c.974 + c.975 — accepté, conservé)

Le diagnostic dérive d'origine (audit po-2025 contre-vérification head `eef466d8f44`, c.975) reste valide. C.988 ajoute 2 corrections par-dessus la substance c.974/c.975 sans toucher au code.

## Périmètre

| Fichier | Type | Lignes |
|---|---|---|
| `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb` | M (md-only) | +9/-5 (cellule 58 L11 + L13) |

**Total** : 1 fichier, **25/25 cellules code préservées byte-identiques**. Vérification : `json.dumps(cell, sort_keys=True)` avant/après sur la cellule 57 (code) — identique. Aucune output, aucun execution_count, aucun cell ID, aucun ordre de cellule modifié.

**Pas de touche** sur : `docs/`, autres notebooks Probas, autres notebooks DecPyMC, scripts/, workflows CI, catalogue, baselines, seuils.

## Vérifications indépendantes (4 validations canoniques)

| Validation | Résultat |
|---|---|
| `validate_pr_notebooks.py origin/main` | **1/1 PASS** (25 cells code) |
| `check_notebook_navlinks.py` | **0 lien cassé** (1232 notebooks scannés) |
| `cell_order_ci.py --base main --head HEAD` | **OK** (exit 0) |
| `git diff --check` | **OK** (exit 0) |
| `check_pr_perimeter.py 15116` | **VERDICT: OK** (1 fichier, 0 workflow CI) |
| `validate_pr_notebooks.py` sur 25 cellules | byte-identity OK avant/après |

## Conformité aux règles

- **Tell c.949-L1 ★★ sustained** : édition de cellule markdown via `cell["source"]` avec `splitlines(keepends=True)`, `raw.endswith("\n")` détecté et préservé.
- **Tell c.972-L1 ★★ sustained** : post `json.dumps` sur `.ipynb`, CRLF → LF appliqué (`Tell c.901-L2`).
- **Tell c.898-L1 ★★★ sustained** : body PR = livrable audité, écrit HORS worktree (L677-L4 ★★).
- **Tell c.942-L1 ★ sustained** : valeurs citées « RE-QUOTÉES » depuis la sortie exécutée (`chosen_arm = np.argmax(...)` lue en cellule 57, pas un proto antérieur).
- **Tell c.984-L1 ★ sustained** : DM HIGH po-2025 → ma lane = break REPAIR PR rouge CONTENU prioritaire, G-VAR-1 éligible (REPAIR PR CONTENU = héritage genre, Tell c.971-L2 sustained).
- **Tell c.974-L1/L2 sustained** : Hermes « non bloquant pour moi » ≠ levé pour tiers ; levée en contenu commité (2 cellules 58 modifiées), pas en amend muet.
- **Tell c.886-L2 ★★★** : `--force-with-lease` plutôt que `--force` pour préserver le bail de la branche de PR à lane unique.
- **B.0** : aucun nit non levé (vérification corps de revue : po-2025 adjoint MSG `cbp3xm` STARTED acquitté, MSG `aap2lj` STARTED acquitté pour la séquenced #15175 en c.989).
- **G-VAR-1** : REPAIR PR CONTENU #15116 → tag `MED/notebook-python` → genre **CONTENU** → plancher TENU (Tell c.971-L2 sustained ×4).

## Leçon c.988

Toute réparation md-only sur cellule d'**interprétation** doit relire la cellule de **code** sous-jacente avant patch, pas seulement les cellules markdown voisines. Sinon la phrase ajoutée peut décrire un mécanisme plausible (mécanisme par lots) sans tracer le code réel (chosen_arm unique). Tell c.942-L1 ★ devient contraignant au moment du `commit --amend`, pas seulement à la rédaction initiale.

## Tag

Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #15113 (MERGED)

See #15109 · See MSG `msg-20260908T064958-hkd4h5` (po-2025 adjoint) · See MSG `msg-20260908T081244-cbp3xm` (STARTED reply)
