### PR TITLE
feat(lean,#14962): divergence Alexander 4_1 bornée — artefact de chiralité + variante signée qui restitue le classique

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
@@ -518,7 +518,9 @@ unique. Le trèfle (t² − t + 1) et le déterminant |P(−1)| = 5 = det(4_1)
 sont bien reproduits, mais la forme du polynôme diverge du classique sur la
 classe à 4 croisements — anomalie documentée exhaustivement (2736 câblages
 orientés testés, dont le câblage DT [4,6,8,2]) dans l'issue de suivi ouverte
-avec ce PR.
+avec ce PR. La divergence est formalisée ci-dessous
+(`alexander_figureEight_not_classical` : pas une unité) et réparée par la
+variante signée (`alexander_figureEight_signed` : le classique exact).
 -/
 theorem alexander_figureEight :
     alexanderPolynomial figureEight =
@@ -531,6 +533,125 @@ theorem alexander_figureEight :
   rw [det_three_aux]
   simp only [Matrix.of_apply]
   simp (config := { decide := true }) [alexanderEntry]
+  ring
+
+/-! #### Divergence de la classe 4 croisements — diagnostic et variante signée
+
+Diagnostic de l'anomalie #14962 : la ligne `alexanderEntry` est la ligne de
+Fox d'un croisement **positif** (dérivée de la relation de Wirtinger
+`x_o x_i x_o⁻¹ = x_out`, abélianisée). Le code PD ne codant pas la chiralité,
+la matrice non signée traite chaque croisement comme positif. Sur un
+diagramme tout positif — le trèfle `3_1` de `Basic.lean`, dont les trois
+croisements sont documentés positifs — la matrice EST la matrice d'Alexander
+et le mineur désigné retrouve le classique. Sur le nœud en huit `4_1`
+(amphichiral, deux croisements de chaque signe dans tout diagramme alterné
+minimal), la matrice est fausse sur les croisements négatifs : le mineur
+rend `−2t² + 2t − 1`, hors de la classe d'unités du classique `t² − 3t + 1`
+(ci-dessous `alexander_figureEight_not_classical`) — la divergence n'est
+donc PAS un artefact de représentant (une symétrisation ou une normalisation
+de Conway `Δ(1) = 1` ne peut pas la réparer), mais un artefact de chiralité.
+Le déterminant, lui, survit : `|P(−1)| = 5 = det(4_1)`
+(`alexander_figureEight_eval_neg_one`).
+
+La variante signée `alexanderPolynomialSigned` reçoit la chiralité en
+donnée et restitue le classique sur le huit : l'étiquetage alterné du
+diagramme DT-dérivé rend exactement `t² − 3t + 1`, son miroir
+`t · (t² − 3t + 1)` — même classe d'unités, comme l'exige l'amphichiralité. -/
+
+/-- Ligne d'Alexander d'un croisement **négatif** : dérivée de Fox de la
+relation de Wirtinger miroir `x_o⁻¹ x_i x_o = x_out`, multipliée par
+l'unité `t` pour rester polynomiale — `+1` sur l'arc entrant du dessous,
+`−t` sur l'arc sortant du dessous, `t−1` sur l'arc du dessus. Chaque ligne
+somme à zéro, comme pour `alexanderEntry`. -/
+noncomputable def alexanderEntryNeg (c : PDCrossing) (C : List Nat) : Polynomial ℤ :=
+  (if C.contains c.e1 then 1 else 0)
+    + (if C.contains c.e3 then -Polynomial.X else 0)
+    + (if C.contains c.e2 || C.contains c.e4 then Polynomial.X - 1 else 0)
+
+/-- Ligne d'Alexander signée : `true` (croisement positif) → `alexanderEntry`,
+`false` (croisement négatif) → `alexanderEntryNeg`. -/
+noncomputable def alexanderEntrySigned (c : PDCrossing) (s : Bool)
+    (C : List Nat) : Polynomial ℤ :=
+  if s then alexanderEntry c C else alexanderEntryNeg c C
+
+/-- Polynôme d'Alexander signé d'un diagramme : même mineur désigné que
+`alexanderPolynomialAux`, chaque croisement portant son signe (liste des
+signes parallèle aux croisements ; le signe du premier croisement est
+inutilisé — sa ligne est éliminée par le mineur, `getD true` neutre). -/
+noncomputable def alexanderPolynomialSigned (d : KnotDiagram)
+    (signs : List Bool) : AlexanderPoly :=
+  let arcs := arcPartition d
+  match d.crossings, arcs with
+  | [], _ => 1
+  | _ :: rest, arcs' =>
+      if arcs'.length = rest.length + 1 then
+        (Matrix.of fun (i j : Fin rest.length) =>
+          alexanderEntrySigned ((rest[i.1]?).getD ⟨1, 1, 1, 1⟩)
+            ((signs[i.1 + 1]?).getD true) ((arcs'[j.1]?).getD [])).det
+      else 0
+
+/-- La divergence n'est pas une unité : la valeur désignée sur le nœud en
+huit n'est égale à `ε · t^k · (t² − 3t + 1)` pour AUCUNE unité `ε = ±1` et
+aucun exposant `k`. Preuve par évaluations : en `0`, la valeur désignée rend
+`−1` ce qui force `k = 0` puis `ε = −1` ; en `2`, elle rend `−5` alors que
+`ε · 2^k · (2² − 3·2 + 1)` vaut alors `1`. -/
+theorem alexander_figureEight_not_classical :
+    ¬ ∃ (k : ℕ) (ε : ℤ), ε * ε = 1 ∧
+      alexanderPolynomial figureEight =
+        Polynomial.C ε * Polynomial.X ^ k * (Polynomial.X ^ 2 - 3 * Polynomial.X + 1) := by
+  rintro ⟨k, ε, -, h⟩
+  rcases k with _ | k
+  · have h0 := congrArg (Polynomial.eval 0) h
+    have h2 := congrArg (Polynomial.eval 2) h
+    rw [alexander_figureEight, pow_zero] at h0 h2
+    simp only [Polynomial.eval_one, Polynomial.eval_add, Polynomial.eval_mul,
+      Polynomial.eval_sub, Polynomial.eval_C, Polynomial.eval_X, pow_two, mul_one,
+      mul_zero, add_zero, zero_add, zero_sub] at h0 h2
+    norm_num at h0 h2
+    omega
+  · have h0 := congrArg (Polynomial.eval 0) h
+    rw [alexander_figureEight, pow_succ] at h0
+    simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_sub,
+      Polynomial.eval_C, Polynomial.eval_X, pow_two, mul_assoc, mul_zero, zero_mul,
+      mul_one, add_zero, zero_add, zero_sub] at h0
+    norm_num at h0
+
+/-- Le déterminant du nœud survit à la divergence : la valeur désignée en
+`−1` vaut `−5`, donc `|P(−1)| = 5 = det(4_1)` (classique : pour un nœud,
+`det = |Δ(−1)|` ; `4_1` est amphichiral). Le mineur non signé perd la forme
+du polynôme mais pas sa valeur en `−1`. -/
+theorem alexander_figureEight_eval_neg_one :
+    (alexanderPolynomial figureEight).eval (-1) = -5 := by
+  rw [alexander_figureEight]
+  simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_sub,
+    Polynomial.eval_X, pow_two, mul_zero, mul_one, add_zero, zero_add, zero_sub]
+  norm_num
+
+/-- La variante signée restitue le classique sur le nœud en huit :
+l'étiquetage alterné `[−, +, −, +]` du diagramme DT-dérivé (deux signes de
+chaque, toute paire miroir convient — `4_1` est amphichiral) rend
+exactement `t² − 3t + 1` sous le même mineur désigné. -/
+theorem alexander_figureEight_signed :
+    alexanderPolynomialSigned figureEightDiagram [false, true, false, true]
+      = Polynomial.X ^ 2 - 3 * Polynomial.X + 1 := by
+  simp only [alexanderPolynomialSigned, figureEightDiagram]
+  simp (config := { decide := true })
+  rw [det_three_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntrySigned, alexanderEntry, alexanderEntryNeg]
+  ring
+
+/-- Miroir du précédent : l'étiquetage alterné opposé `[+, −, +, −]` rend
+`t · (t² − 3t + 1)` — même classe d'unités, comme l'exige l'amphichiralité
+(les deux diagrammes miroirs représentent le même nœud). -/
+theorem alexander_figureEight_signed_mirror :
+    alexanderPolynomialSigned figureEightDiagram [true, false, true, false]
+      = Polynomial.X * (Polynomial.X ^ 2 - 3 * Polynomial.X + 1) := by
+  simp only [alexanderPolynomialSigned, figureEightDiagram]
+  simp (config := { decide := true })
+  rw [det_three_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntrySigned, alexanderEntry, alexanderEntryNeg]
   ring
 
 /-- Polynôme d'Alexander trivial du nœud de Conway — contenu classique

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -522,6 +522,9 @@ the determinant |P(−1)| = 5 = det(4_1) are reproduced, but the polynomial
 shape diverges from the classical value on the 4-crossing class — anomaly
 exhaustively documented (2736 orientation-valid wirings tested, including
 the DT [4,6,8,2] wiring) in the follow-up issue opened with this PR.
+The divergence is formalized below (`alexander_figureEight_not_classical`:
+not a unit) and repaired by the signed variant
+(`alexander_figureEight_signed`: the exact classical value).
 -/
 theorem alexander_figureEight :
     alexanderPolynomial figureEight =
@@ -534,6 +537,125 @@ theorem alexander_figureEight :
   rw [det_three_aux]
   simp only [Matrix.of_apply]
   simp (config := { decide := true }) [alexanderEntry]
+  ring
+
+/-! #### 4-crossing class divergence — diagnosis and signed variant
+
+Diagnosis of anomaly #14962: the `alexanderEntry` row is the Fox row of a
+**positive** crossing (derivative of the Wirtinger relation
+`x_o x_i x_o⁻¹ = x_out`, abelianized). Since the PD code does not encode
+chirality, the unsigned matrix treats every crossing as positive. On an
+all-positive diagram — the `3_1` trefoil of `Basic.lean`, whose three
+crossings are documented positive — the matrix IS the Alexander matrix and
+the designated minor recovers the classical value. On the figure-eight
+knot `4_1` (amphichiral, two crossings of each sign in any minimal
+alternating diagram), the matrix is wrong on the negative crossings: the
+minor returns `−2t² + 2t − 1`, outside the unit class of the classical
+`t² − 3t + 1` (see `alexander_figureEight_not_classical` below) — so the
+divergence is NOT a representative artifact (no symmetrization or Conway
+normalization `Δ(1) = 1` can repair it), but a chirality artifact. The
+determinant survives: `|P(−1)| = 5 = det(4_1)`
+(`alexander_figureEight_eval_neg_one`).
+
+The signed variant `alexanderPolynomialSigned` takes chirality as data and
+recovers the classical value on the figure-eight: the alternating labeling
+of the DT-derived diagram returns exactly `t² − 3t + 1`, its mirror
+`t · (t² − 3t + 1)` — same unit class, as amphichirality demands. -/
+
+/-- Alexander row of a **negative** crossing: Fox derivative of the mirror
+Wirtinger relation `x_o⁻¹ x_i x_o = x_out`, multiplied by the unit `t` to
+stay polynomial — `+1` on the incoming under-arc, `−t` on the outgoing
+under-arc, `t−1` on the over-arc. Each row sums to zero, as for
+`alexanderEntry`. -/
+noncomputable def alexanderEntryNeg (c : PDCrossing) (C : List Nat) : Polynomial ℤ :=
+  (if C.contains c.e1 then 1 else 0)
+    + (if C.contains c.e3 then -Polynomial.X else 0)
+    + (if C.contains c.e2 || C.contains c.e4 then Polynomial.X - 1 else 0)
+
+/-- Signed Alexander row: `true` (positive crossing) → `alexanderEntry`,
+`false` (negative crossing) → `alexanderEntryNeg`. -/
+noncomputable def alexanderEntrySigned (c : PDCrossing) (s : Bool)
+    (C : List Nat) : Polynomial ℤ :=
+  if s then alexanderEntry c C else alexanderEntryNeg c C
+
+/-- Signed Alexander polynomial of a diagram: same designated minor as
+`alexanderPolynomialAux`, each crossing carrying its sign (sign list
+parallel to the crossings; the first crossing's sign is unused — its row
+is eliminated by the minor, `getD true` neutral). -/
+noncomputable def alexanderPolynomialSigned (d : KnotDiagram)
+    (signs : List Bool) : AlexanderPoly :=
+  let arcs := arcPartition d
+  match d.crossings, arcs with
+  | [], _ => 1
+  | _ :: rest, arcs' =>
+      if arcs'.length = rest.length + 1 then
+        (Matrix.of fun (i j : Fin rest.length) =>
+          alexanderEntrySigned ((rest[i.1]?).getD ⟨1, 1, 1, 1⟩)
+            ((signs[i.1 + 1]?).getD true) ((arcs'[j.1]?).getD [])).det
+      else 0
+
+/-- The divergence is not a unit: the designated value on the figure-eight
+equals `ε · t^k · (t² − 3t + 1)` for NO unit `ε = ±1` and no exponent `k`.
+Proof by evaluations: at `0` the designated value returns `−1`, forcing
+`k = 0` then `ε = −1`; at `2` it returns `−5` while `ε · 2^k · (2² − 3·2 + 1)`
+then equals `1`. -/
+theorem alexander_figureEight_not_classical :
+    ¬ ∃ (k : ℕ) (ε : ℤ), ε * ε = 1 ∧
+      alexanderPolynomial figureEight =
+        Polynomial.C ε * Polynomial.X ^ k * (Polynomial.X ^ 2 - 3 * Polynomial.X + 1) := by
+  rintro ⟨k, ε, -, h⟩
+  rcases k with _ | k
+  · have h0 := congrArg (Polynomial.eval 0) h
+    have h2 := congrArg (Polynomial.eval 2) h
+    rw [alexander_figureEight, pow_zero] at h0 h2
+    simp only [Polynomial.eval_one, Polynomial.eval_add, Polynomial.eval_mul,
+      Polynomial.eval_sub, Polynomial.eval_C, Polynomial.eval_X, pow_two, mul_one,
+      mul_zero, add_zero, zero_add, zero_sub] at h0 h2
+    norm_num at h0 h2
+    omega
+  · have h0 := congrArg (Polynomial.eval 0) h
+    rw [alexander_figureEight, pow_succ] at h0
+    simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_sub,
+      Polynomial.eval_C, Polynomial.eval_X, pow_two, mul_assoc, mul_zero, zero_mul,
+      mul_one, add_zero, zero_add, zero_sub] at h0
+    norm_num at h0
+
+/-- The knot determinant survives the divergence: the designated value at
+`−1` equals `−5`, so `|P(−1)| = 5 = det(4_1)` (classical: for a knot,
+`det = |Δ(−1)|`; `4_1` is amphichiral). The unsigned minor loses the
+polynomial shape but not its value at `−1`. -/
+theorem alexander_figureEight_eval_neg_one :
+    (alexanderPolynomial figureEight).eval (-1) = -5 := by
+  rw [alexander_figureEight]
+  simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_sub,
+    Polynomial.eval_X, pow_two, mul_zero, mul_one, add_zero, zero_add, zero_sub]
+  norm_num
+
+/-- The signed variant recovers the classical value on the figure-eight:
+the alternating labeling `[−, +, −, +]` of the DT-derived diagram (two
+signs of each; any mirror pair works — `4_1` is amphichiral) returns
+exactly `t² − 3t + 1` under the same designated minor. -/
+theorem alexander_figureEight_signed :
+    alexanderPolynomialSigned figureEightDiagram [false, true, false, true]
+      = Polynomial.X ^ 2 - 3 * Polynomial.X + 1 := by
+  simp only [alexanderPolynomialSigned, figureEightDiagram]
+  simp (config := { decide := true })
+  rw [det_three_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntrySigned, alexanderEntry, alexanderEntryNeg]
+  ring
+
+/-- Mirror of the previous: the opposite alternating labeling `[+, −, +, −]`
+returns `t · (t² − 3t + 1)` — same unit class, as amphichirality demands
+(the two mirror diagrams represent the same knot). -/
+theorem alexander_figureEight_signed_mirror :
+    alexanderPolynomialSigned figureEightDiagram [true, false, true, false]
+      = Polynomial.X * (Polynomial.X ^ 2 - 3 * Polynomial.X + 1) := by
+  simp only [alexanderPolynomialSigned, figureEightDiagram]
+  simp (config := { decide := true })
+  rw [det_three_aux]
+  simp only [Matrix.of_apply]
+  simp (config := { decide := true }) [alexanderEntrySigned, alexanderEntry, alexanderEntryNeg]
   ring
 
 /-- Trivial Alexander polynomial of the Conway knot — classical content


### PR DESCRIPTION
Grain: DEEP/lean -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15056

## Résumé

#14962 tranche 1 — le « premier pas suggéré » de l'issue : **démontrer (borner) la divergence**, avec le diagnostic qui la répare. Le corps de l'issue demande de borner l'invariance puis de corriger la normalisation si elle échoue ; la mesure livrée ici montre que la correction demandée n'est **pas** une normalisation : la divergence est un **artefact de chiralité**, et la variante signée qui la répare est ajoutée avec preuve.

### Diagnostic (réplique Python validée, G.1)

`alexanderEntry` est exactement la **ligne de Fox d'un croisement positif** (dérivée de `x_o x_i x_o⁻¹ = x_out` abélianisée : `+t` entrant dessous, `−1` sortant dessous, `1−t` dessus). Le code PD ne codant pas la chiralité, la matrice non signée **traite chaque croisement comme positif** :

- trèfle `3_1` (documenté « trois croisements positifs » dans `Basic.lean`) → la matrice EST la matrice d'Alexander → classique exact `t²−t+1` (déjà prouvé sur main) ;
- huit `4_1` (amphichiral, 2+/2− dans tout diagramme alterné minimal) → matrice fausse sur les négatifs → `−2t²+2t−1`.

Réplique fidèle (`mergePair`/`arcPartition`/mineur désigné), revalidée indépendamment sur les deux théorèmes PROUVÉS de main (trèfle = `t²−t+1` ✓, huit = `−2t²+2t−1` ✓), puis énumération des 16 affectations de signes sur le câblage DT-dérivé avec la ligne négative dérivée `(over: t−1, in: +1, out: −t)` : les étiquetages alternés rendent le classique (`[−,+,−,+]` → **exactement** `t²−3t+1` ; `[+,−,+,−]` → `t·(t²−3t+1)`), l'affectation tout-positif (= fonction actuelle) ne le rend pas. Symétrisation ou Conway `Δ(1)=1` ne peuvent pas réparer `−2t²+2t−1` (non-unité, théorème ci-dessous) — c'est la réponse à l'option « normalisation » de l'issue.

### Livrable (2 fichiers, un sujet)

`Knots/Conway.lean` + jumeau `Knots/Conway_en.lean` (corps byte-identique vérifié par diff mécanique, docstrings FR/EN) :

| Nouveau | Contenu |
|---|---|
| `alexanderEntryNeg` | ligne de Fox d'un croisement négatif (dérivation Wirtinger miroir, ×t unité) |
| `alexanderEntrySigned` / `alexanderPolynomialSigned` | variante signée, même mineur désigné, chiralité en donnée |
| `alexander_figureEight_not_classical` | **la divergence n'est pas une unité** : `¬∃ k ε (ε²=1), P = ε·t^k·(t²−3t+1)` — preuve par évaluations en 0 et 2 |
| `alexander_figureEight_eval_neg_one` | le déterminant survit : `P(−1) = −5`, `|P(−1)| = 5 = det(4_1)` |
| `alexander_figureEight_signed` | l'alterné `[−,+,−,+]` rend **exactement le classique** `t²−3t+1` |
| `alexander_figureEight_signed_mirror` | le miroir `[+,−,+,−]` rend `t·(t²−3t+1)` — même classe d'unités (amphichiralité) |

Rien n'est retiré : `alexanderPolynomial` (non signé) et les 4 théorèmes existants sont inchangés ; la docstring d'honnêteté d'`alexander_figureEight` gagne seulement un renvoi vers les nouveaux théorèmes.

## Validation (critères B Lean)

- `grep -c sorry` avant/après : `Conway.lean` 12 → **12**, `Conway_en.lean` 13 → **13** (aucun nouveau, aucun retiré — les 5 nouveaux théorèmes sont complets).
- `lake build` **SUCCESS — 3010 jobs** (leanprover/lean4:v4.32.1, Mathlib v4.32.1, WSL, worktree frais sur b646b2fca).
- **Proof integrity** : `#print axioms` sur les 7 nouvelles déclarations (2 defs intermédiaires + 5 théorèmes) → `[propext, Classical.choice, Quot.sound]` uniquement, **zéro `sorryAx`**.
- Preuves par `decide` + `det_three_aux` + `ring` + `eval`/`omega` (même style que les théorèmes existants du fichier) ; code byte-identique FR↔EN vérifié par diff mécanique (docstrings FR/EN seuls écarts, discipline #4980).

## Résiduel (hors scope de cette PR)

- **Tranche 2** : porter les signes dans la donnée du nœud (champ du `KnotDiagram`/`PDCrossing` ou structure parallèle dérivée du DT) et faire de la variante signée LA fonction du nœud — décision de schema, à coordonner.
- **Interaction #14821** (preuve kernel `conway_trivial_alexander` ouverte) : **aucune** — la définition non signée et les énoncés `conway_trivial_alexander`/`KT_trivial_alexander` sont inchangés ; le travail en cours rebase sans changement de cible. Si la tranche 2 change la fonction du nœud, ces énoncés devront être revus — flag posé dans le commentaire de claim.
- L'invariance de Reidemeister **de la variante signée** (théorème séparé, machinerie `Reidemeister.lean` disponible) — tranche suivante naturelle.

See #14962 (tranche 1 : divergence bornée + diagnostic chirality + variante signée prouvée ; tranche 2 schema à arbitrer)
