### PR TITLE
fix(ci,#15091): borner la RAM de la flotte CI cote hote -- slice sous suivi git + garde de budget

### DIFF
--- a/scripts/ci/docker/linux-runner/persist/coursia-ci.slice
+++ b/scripts/ci/docker/linux-runner/persist/coursia-ci.slice
@@ -50,6 +50,34 @@
 # borne que ce que le superviseur ecrit lui-meme, c'est-a-dire ses journaux.
 # Les unites gardent IOAccounting + IOWeight, qui eux sont honnetes a cette
 # place ; le plafond dur vit ici, ou vivent les conteneurs.
+#
+# ORDRE DE DEPLOIEMENT -- LA SLICE D'ABORD, LE SUPERVISEUR ENSUITE
+# ----------------------------------------------------------------
+# L'ordre n'est pas une preference de confort, il decide de ce que les gardes
+# voient. `running_ci_mb()` somme les conteneurs portant le label
+# `coursia-ci=1` ; un conteneur demarre AVANT que le daemon ne porte
+# `"cgroup-parent": "coursia-ci.slice"` garde son label mais reste HORS de la
+# slice. Il est donc compte par le garde userspace et ignore par le mur du
+# noyau -- l'ecart exact entre les deux qu'aucune des deux mesures ne signale.
+#
+# Sur une machine qui deploie la slice, dans cet ordre :
+#
+#   1. sudo cp coursia-ci.slice /etc/systemd/system/
+#      sudo cp daemon.json /etc/docker/daemon.json
+#   2. sudo systemctl daemon-reload && sudo systemctl start coursia-ci.slice
+#   3. sudo systemctl restart docker          # prend le cgroup-parent
+#   4. ./supervise.sh stop && ./supervise.sh start
+#      (etape 4 OBLIGATOIRE : les conteneurs deja en vie a l'etape 3 ne
+#       migrent PAS dans la slice -- seul un cycle de conteneur les y met)
+#   5. verification : le demarrage echo
+#      « [slice] mur agrege ACTIF : memory.high=... memory.max=... »
+#      Avec `COURSIA_REQUIRE_CI_SLICE=1`, son absence devient un refus de
+#      demarrer plutot qu'un avertissement.
+#
+# Sur une machine qui NE la deploie PAS (po-2024), il n'y a rien a faire :
+# `CI_CGROUP_PARENT` reste vide, `--cgroup-parent` n'est pas passe, et le
+# superviseur avertit sans refuser (cf assert_ci_slice dans supervise.sh).
+#
 [Unit]
 Description=CoursIA CI runner containers -- aggregate budget (all families)
 Documentation=https://github.com/jsboige/CoursIA/blob/main/docs/ci/self-hosted-runners.md
@@ -80,3 +108,34 @@ IOWriteBandwidthMax=/var/lib/docker 209715200
 IOReadBandwidthMax=/var/lib/docker 419430400
 
 MemoryAccounting=yes
+MemoryHigh=12G
+MemoryMax=16G
+MemorySwapMax=16G
+# POURQUOI 12 / 16.
+#
+# Ces deux nombres sont un CONTRAT CONSERVATEUR, pas le resultat d'une mesure
+# d'empreinte. La distinction est importante, parce que la mesure qui avait
+# d'abord servi a les justifier ne le pouvait pas :
+#
+#   Total Windows ........................ 191,8 Go
+#   Libre, flotte CI ARMEE ................ 39,3 Go
+#   Libre, flotte CI DESARMEE ............ 120,6 Go
+#
+# Ce releve est authentique, mais l'ecart entre ses deux dernieres lignes
+# N'EST PAS imputable a la flotte CI : entre les deux points, plus d'une
+# variable a bouge (services de l'hote, WSL, charge interactive). Un plan a
+# deux cellules ou plusieurs facteurs changent ensemble ne separe aucun
+# facteur -- il donne un ecart, jamais une attribution. Le corps de la PR qui
+# pose ces bornes le retracte explicitement ; ce commentaire ne doit pas
+# devenir la version qui survit a la retractation.
+#
+# Ce qui fonde 12/16 est donc l'autre bout du raisonnement, qui ne depend
+# d'aucune attribution : ai-01 porte ~80 % des services de la flotte ET reste
+# la workstation interactive du user. 16 Go de plafond dur laissent >170 Go a
+# tout le reste. Un contrat se choisit par ce qu'on veut GARANTIR aux autres,
+# pas par ce qu'on croit avoir mesure de soi.
+#
+# CE PLAFOND EST UN CONTRAT AVEC LES AUTRES SERVICES, PAS UN REGLAGE DE PERF.
+# Le monter demande une mesure cote hote ET une raison ecrite -- une mesure
+# d'empreinte marginale propre, celle qui manque ci-dessus (un seul facteur
+# change a la fois). Le baisser ne demande rien.

--- a/scripts/ci/docker/linux-runner/persist/host-distress-probe.ps1
+++ b/scripts/ci/docker/linux-runner/persist/host-distress-probe.ps1
@@ -1,0 +1,95 @@
+# Sonde de DETRESSE de l'hote Windows -- un echantillon, une ligne.
+#
+# Rend, separes par des espaces :
+#   pagewrites  pagesout  disk_queue_max  disk_idle_pct_min  vmmem_commit_mb  mapped_mb
+#
+# TOUT est rendu en ENTIERS, et les deux tailles en Mo, pas en Go. Sous locale
+# FR ce script rendait `91,7` -- virgule decimale -- que awk et l'arithmetique
+# bash lisent comme `91`. Une taille arrondie au Go perdrait par ailleurs la
+# resolution du critere `Mapped` (une eviction qdrant se voit bien avant 1 Go).
+# Pas de separateur decimal = pas de dependance a la locale.
+#
+# Rend une ligne vide et sort 1 si la mesure est impossible : jamais un chiffre
+# par defaut, jamais zero -- un zero fabrique est indiscernable d'une machine
+# saine, et c'est precisement ce qui transforme un garde en decor.
+#
+# CE QUI EST MESURE, ET POURQUOI CES COMPTEURS-LA (arbitrage Maintenance
+# 2026-09-07T22:59Z, apres le retrait de quatre seuils en une nuit) :
+#
+#   detresse reelle  -> PageWrites/s + PagesOutput/s SOUTENUS > 0, avec le
+#                       disque qui souffre (file > 0 et temps d'inactivite qui
+#                       s'effondre). Un compteur de NIVEAU ne dit rien.
+#   cout d'un process-> Win32_Process.PageFileUsage (commit prive). Jamais le
+#                       WorkingSet : Windows le rabote quand il pagine, donc
+#                       l'instrument BAISSE quand le probleme s'aggrave.
+#
+# Compteurs ECARTES et la raison, pour qu'ils ne reviennent pas :
+#   Available / FreePhysicalMemory  identiques (free + standby). Le standby
+#                                   n'est de la marge que si personne ne le
+#                                   reclame ; mesure ai-01 : 47,6 -> 91,6 Go
+#                                   pendant que la ressource ne bougeait pas.
+#   FreeAndZeroPageListBytes        Windows garde la free list basse PAR DESIGN.
+#                                   1,7 Go avec zero lecture disque = machine
+#                                   saine. Un plancher dessus est un faux rouge
+#                                   permanent.
+#   commit %                        « 78 etait mon invention » (Maintenance).
+#   PageReads/s seul                un taux sans terme de contrainte : 293/s
+#                                   avec latence 0 ms n'est pas une famine.
+#   AvgDisksecPerRead / PerWrite    UInt32 EN SECONDES dans la classe formatee :
+#                                   ils rendent 0 jusqu'a 1 s de latence.
+#                                   Mesure ai-01 2026-09-07 23:42Z : 0 sur les
+#                                   cinq disques. Un seuil a 5 ms dessus ne peut
+#                                   PAS se declencher -- garde vert par
+#                                   construction. On lit PercentIdleTime, qui a
+#                                   la resolution (98-99 % a l'instant sain).
+
+$ErrorActionPreference = 'Stop'
+try {
+    $m = Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory
+    if (-not $m) { exit 1 }
+
+    $d = @(Get-CimInstance Win32_PerfFormattedData_PerfDisk_PhysicalDisk |
+           Where-Object { $_.Name -ne '_Total' })
+    if ($d.Count -eq 0) { exit 1 }
+
+    $queueMax   = ($d | Measure-Object -Property CurrentDiskQueueLength -Maximum).Maximum
+    $idlePctMin = ($d | Measure-Object -Property PercentIdleTime -Minimum).Minimum
+
+    # Commit PRIVE de la VM WSL, en Go. PageFileUsage est en Ko.
+    $vm = @(Get-CimInstance Win32_Process | Where-Object { $_.Name -like 'vmmem*' })
+    $vmCommitMb = if ($vm.Count -gt 0) {
+        [int][math]::Round((($vm | Measure-Object -Property PageFileUsage -Sum).Sum) / 1KB)
+    } else { -1 }
+
+    # `Mapped` de la VM WSL, en Go : c'est le mmap qdrant. Une CHUTE = qdrant se
+    # fait evincer, critere d'abandon donne par Maintenance. -1 = non mesurable
+    # (wsl.exe absent ou distro non demarree) ; l'appelant traite -1 comme
+    # « inconnu », jamais comme « zero ».
+    #
+    # `wsl.exe -e cat` puis filtrage cote PowerShell : PAS de `sh -c "awk ..."`.
+    # Le motif awk traverse bash -> PowerShell -> wsl -> sh, et chaque etage
+    # mange une couche de quoting : mesure du 2026-09-07T23:47Z, awk recevait
+    # `{print` comme NOM DE FICHIER. Ne jamais faire transiter un motif par
+    # quatre interpretes quand on peut faire transiter du texte.
+    $mappedMb = -1
+    $wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+    if ($wsl) {
+        try {
+            $meminfo = & wsl.exe -e cat /proc/meminfo 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $hit = $meminfo | Where-Object { $_ -match '^Mapped:\s+(\d+)\s+kB' } | Select-Object -First 1
+                if ($hit -and $hit -match '^Mapped:\s+(\d+)\s+kB') {
+                    $mappedMb = [int][math]::Round([double]$Matches[1] / 1KB)
+                }
+            }
+        } catch { $mappedMb = -1 }
+    }
+
+    '{0} {1} {2} {3} {4} {5}' -f `
+        [int]$m.PageWritesPersec, [int]$m.PagesOutputPersec,
+        [int]$queueMax, [int]$idlePctMin, [int]$vmCommitMb, [int]$mappedMb
+    exit 0
+}
+catch {
+    exit 1
+}

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -86,7 +86,14 @@ STOP_FILE="$STATE_DIR/stop"
 
 # Caps par conteneur. Volontairement conservateurs : l'hote prime sur la CI.
 CPUS="${COURSIA_RUNNER_CPUS:-3}"
-MEMORY="${COURSIA_RUNNER_MEMORY:-4g}"
+# Cap par slot. Mesure `docker stats` sur des jobs REELS (ai-01, 2026-09-08) :
+# 38 MiB et 160 MiB (ce dernier a 129 % CPU, genuinement occupe) contre un cap
+# de 3072 MiB -- soit 1,2 % et 5,2 % du cap. 1536m reste ~10x le pic mesure, et
+# c'est ce chiffre qui debloque `auto` : a 3072m la demi-part de budget_slots()
+# plafonne le pool de travail a 2 slots (0 des qu'il tourne), a 1536m elle en
+# rend 4 sur un budget vide. L'arithmetique n'avait pas besoin d'etre changee,
+# le cap si.
+MEMORY="${COURSIA_RUNNER_MEMORY:-1536m}"
 PIDS="${COURSIA_RUNNER_PIDS:-384}"
 
 # Toolcache persistant : sans lui, chaque conteneur ephemere (un par job)
@@ -123,7 +130,7 @@ WORK_MOUNT="${COURSIA_RUNNER_WORK_MOUNT:-/home/runner/_work}"
 WAITER_LABELS="${COURSIA_RUNNER_WAITER_LABELS:-self-hosted,coursia-waiter}"
 WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-${MACHINE_ID}-linux-waiter}"
 WAITER_CPUS="${COURSIA_RUNNER_WAITER_CPUS:-1}"
-WAITER_MEMORY="${COURSIA_RUNNER_WAITER_MEMORY:-1g}"
+WAITER_MEMORY="${COURSIA_RUNNER_WAITER_MEMORY:-512m}"
 WAITER_PIDS="${COURSIA_RUNNER_WAITER_PIDS:-128}"
 # Toolcache partage sur les waiters (#15091). La premisse d'origine etait
 # « un slot qui attend ne coute rien », donc aucun volume. Elle tombe sur le
@@ -151,16 +158,35 @@ LEAN_WORK_VOLUME_PREFIX="${COURSIA_LEAN_RUNNER_WORK_VOLUME_PREFIX:-coursia-runne
 # (cf CONTRAINTE en tete de fichier) -- baisser N ou les caps si la machine
 # gene pendant un lake build.
 LEAN_CPUS="${COURSIA_LEAN_RUNNER_CPUS:-6}"
-LEAN_MEMORY="${COURSIA_LEAN_RUNNER_MEMORY:-8g}"
+LEAN_MEMORY="${COURSIA_LEAN_RUNNER_MEMORY:-6g}"
 LEAN_PIDS="${COURSIA_LEAN_RUNNER_PIDS:-512}"
 # Swap au-dela de la RAM du slot : les modules Hashlife de conway_lean
 # pointent a >16 Go au build a froid (exit 137 mesure sous --memory 8g,
 # 8716/8727 modules OK puis Walls.{SE,SW,NE} tues ; les runners hosted
 # s'en sortent par 32G de fallocate swap, lean-axiom.yml L~100). Un job
 # conteneurise n'a pas sudo pour creer son swap, donc le pool le porte :
-# memory-swap 24g = 8g RAM + 16g swap. Le swap n'est PAS de la RAM
-# reservee -- l'hote ne paie que si le pic survient.
-LEAN_MEMORY_SWAP="${COURSIA_LEAN_RUNNER_MEMORY_SWAP:-24g}"
+# --memory-swap est le TOTAL, donc 12g = 6g RAM (LEAN_MEMORY) + 6g swap.
+# Ce commentaire a deja menti deux fois (« 8g + 16g » quand LEAN_MEMORY etait
+# passe a 6g, puis « 24g » apres l'abaissement du total) : un commentaire qui
+# ment sur un cap memoire est pire qu'un commentaire absent -- c'est lui qu'on
+# relit en incident. Toute modification de l'un des deux nombres refait
+# l'arithmetique ici, dans le meme commit.
+#
+# Le swap n'est PAS de la RAM reservee : l'hote ne paie que si le pic
+# survient. Mais il paie alors en I/O, et sur ai-01 le pagefile partage le
+# NVMe -- une question de memoire s'y convertit en tempete de disque. Et
+# assert_memory_budget compte --memory seul : BUDGET_GB borne la RAM, jamais
+# le swap. A 24g le total, cela faisait 18 Go de swap PAR SLOT, soit 36 Go
+# qu'aucun budget ne voyait, ecrits sur le NVMe qui porte le pagefile de
+# l'hote -- exactement le mecanisme qui a fait redemarrer la machine.
+#
+# 12g : 6g de RAM (LEAN_MEMORY) + 6g de swap, 12 Go non comptes pour deux
+# slots au lieu de 36. Ce n'est PAS `= LEAN_MEMORY` : supprimer le swap ne
+# retire pas le pic de Hashlife, il transforme un build qui deborde en un
+# exit 137 -- c'est un curseur, pas un dogme. Si conway_lean redevient
+# infaisable a 12g, la reponse est de router ce lake sur un runner hosted
+# (32G de fallocate swap, lean-axiom.yml), pas de remonter le total ici.
+LEAN_MEMORY_SWAP="${COURSIA_LEAN_RUNNER_MEMORY_SWAP:-12g}"
 
 # ---------------------------------------------------------------------------
 # BORNES D'I/O ET BUDGET INTER-FAMILLES (#15091 pieces 2 et 4)
@@ -200,6 +226,20 @@ CGROUP_PARENT="${COURSIA_RUNNER_CGROUP_PARENT:-}"
 # (unite en `failed`, cf StartLimitBurst) plutot qu'un pool non borne qui
 # tourne comme si de rien n'etait -- c'est ce silence-la qui a gele ai-01.
 REQUIRE_CGROUP_BUDGET="${COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET:-0}"
+# Meme discipline pour le mur MEMOIRE de la slice. 1 = REFUSER de demarrer si
+# la slice est absente ou sans plafond ; 0 = avertir et continuer SANS placer
+# les conteneurs dedans.
+#
+# Le defaut est 0 parce que la slice est deployee sur ai-01 SEULEMENT
+# (persist/README.md : `coursia-ci.slice` -> machine ai-01). Un defaut a 1
+# ferait refuser de demarrer les runners de po-2024, qui n'ont pas la slice et
+# n'ont jamais eu a l'avoir. La machine qui LA deploie met la variable a 1 dans
+# son unite systemd, et obtient alors le fail-closed voulu.
+#
+# Le couple {avertir, ne pas placer} est ce qui evite le faux garde decrit en
+# tete de assert_ci_slice : sans slice on ne passe PAS --cgroup-parent, donc
+# docker ne cree pas un cgroup vide qui aurait l'air d'un mur.
+REQUIRE_CI_SLICE="${COURSIA_REQUIRE_CI_SLICE:-0}"
 # Plafond d'ecriture PAR CONTENEUR, en octets/s. Vide = pas de cap.
 DEVICE_WRITE_BPS="${COURSIA_RUNNER_DEVICE_WRITE_BPS:-}"
 DEVICE_READ_BPS="${COURSIA_RUNNER_DEVICE_READ_BPS:-}"
@@ -274,6 +314,358 @@ mkdir -p "$STATE_DIR"
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL='*'
 
+# ---------------------------------------------------------------------------
+# BUDGET MEMOIRE -- mesure cote HOTE, jamais cote VM
+# ---------------------------------------------------------------------------
+# INCIDENT FONDATEUR (2026-09-07). Ce superviseur a porte 8 slots + 12 waiters
+# sur ai-01 ; la machine a sature sa RAM, le disque s'est mis a swapper, GDrive
+# est tombe et ROOSYNC_SHARED_PATH avec lui. Le user a du faire redemarrer le
+# serveur a la main pour la QUATRIEME fois de la journee.
+#
+# LE DEFAUT N'ETAIT PAS LA VALEUR DES CAPS, C'ETAIT LEUR REFERENTIEL. Le script
+# ne mesurait rien du tout ; et toute mesure prise DANS la VM WSL lit ce que
+# .wslconfig AUTORISE la VM a retenir, pas ce que Windows a encore de libre :
+#
+#   MemAvailable dans la VM ............. 112,7 Go  <- ce qu'on aurait lu
+#   Libre cote Windows, au MEME instant ... 39,3 Go  <- la verite
+#
+# Ces deux lignes sont un releve SIMULTANE de deux referentiels : c'est ce qui
+# en fait une preuve. Le facteur ~2,9 entre elles ne depend d'aucune hypothese
+# sur ce qui tournait -- il mesure l'ecart entre « ce que .wslconfig autorise
+# la VM a retenir » et « ce que Windows a encore de libre », a la seconde pres.
+# N'importe quelle logique de dimensionnement lisant /proc/meminfo depuis la
+# VM sur-engage donc par construction, quels que soient les caps.
+#
+# UN TROISIEME RELEVE A ETE RETIRE D'ICI. Un « libre cote Windows, flotte
+# DESARMEE = 120,6 Go » figurait sous les deux lignes ci-dessus, et l'ecart
+# avec la deuxieme etait presente comme « l'empreinte de ce superviseur ».
+# Cette attribution est FAUSSE et a ete retractee : les deux points ne sont pas
+# simultanes, et entre eux plus d'une variable a bouge (la flotte, mais aussi
+# les caches du navigateur, GDrive, VS Code, le pagefile). Un plan a deux
+# cellules ou plusieurs facteurs changent ensemble ne separe aucun facteur --
+# il donne un ecart, jamais une attribution. L'argument du REFERENTIEL, lui,
+# survit intact : il ne repose que sur les deux lignes conservees.
+#
+# D'OU LA REGLE : la seule mesure qui fait autorite est celle de l'hote, et si
+# elle est INJOIGNABLE on REFUSE de demarrer. Un budget non mesure n'est pas un
+# budget -- c'est l'hypothese qui a coute quatre redemarrages.
+#
+# Ce garde est le pendant userspace de coursia-ci.slice (MemoryHigh / MemoryMax
+# / MemorySwapMax). Les deux sont necessaires et ne font pas le meme travail :
+# la slice est le mur que le noyau tient meme si ce script a tort ; ce garde
+# est ce qui evite d'aller taper dedans, et qui sait DIRE POURQUOI il refuse.
+
+# Part de RAM hote que la CI s'autorise, toutes familles confondues. Alignee
+# sur MemoryHigh de la slice : le budget userspace et le seuil de recuperation
+# du noyau annoncent le meme nombre.
+BUDGET_GB="${COURSIA_RUNNER_BUDGET_GB:-12}"
+# Le garde d'hote ne lit plus AUCUN compteur de NIVEAU. Il demande « la machine
+# est-elle en train de souffrir ? », pas « reste-t-il N Go ? » -- deux questions
+# differentes, et seule la premiere a une reponse mesurable sous Windows.
+#
+# Les deux seuils precedents (free reel >= 8 Go, commit <= 78 %) ont ete
+# RETIRES par leur auteur (Maintenance) dans l'heure qui a suivi leur mise en
+# service, mesures a l'appui : Windows garde la free list basse par design
+# (1,7 Go de free avec ZERO lecture disque = machine parfaitement saine), et le
+# 78 etait, verbatim, « mon invention ». Les recalibrer aurait laisse le garde
+# branche sur deux signaux declares non-valides ; on change de question.
+#
+# « Soutenu » veut dire DEUX echantillons espaces, pas un. Le faux positif du
+# 2026-09-07T22:53Z (un pic isole a 293 lectures/s, latence 0, file 0) est
+# exactement ce qu'un echantillon unique ne sait pas ecarter.
+DISTRESS_GAP_S="${COURSIA_RUNNER_DISTRESS_GAP_S:-15}"
+# Temps d'inactivite disque MINIMUM sur le disque le plus charge, en %. On lit
+# PercentIdleTime et non AvgDisksecPerRead/Write : ces deux-la sont des UInt32
+# EN SECONDES dans la classe formatee, donc a 0 jusqu'a 1 s de latence -- un
+# seuil en millisecondes dessus ne peut pas se declencher (mesure ai-01 du
+# 2026-09-07T23:42Z : 0 sur les cinq disques, machine saine ET machine en
+# tempete rendraient le meme 0).
+DISTRESS_IDLE_PCT_MAX="${COURSIA_RUNNER_DISTRESS_IDLE_PCT_MAX:-50}"
+# Chute de `Mapped` dans la VM WSL entre les deux echantillons, en Mo : c'est le
+# mmap qdrant qui se fait evincer. Critere d'abandon donne par Maintenance --
+# une eviction qdrant est le debut de la conversion memoire -> tempete d'I/O,
+# et elle precede les compteurs de detresse.
+MAPPED_DROP_MB="${COURSIA_RUNNER_MAPPED_DROP_MB:-512}"
+
+# Variables RETIREES. On refuse bruyamment plutot que d'ignorer en silence : un
+# operateur qui les positionne croit gouverner un garde qui ne les lit plus.
+for _retired in COURSIA_RUNNER_HOST_FREE_FLOOR_GB COURSIA_RUNNER_HOST_COMMIT_PCT_MAX \n                COURSIA_RUNNER_HOST_FREE_GB COURSIA_RUNNER_HOST_COMMIT_PCT; do
+  if [ -n "$(eval "echo \${${_retired}:-}")" ]; then
+    echo "[garde] AVERTISSEMENT : $_retired est RETIREE et n'est plus lue." >&2
+    echo "        Le garde d'hote ne lit plus de compteur de niveau (free, commit, Available)." >&2
+    echo "        Pour declarer une mesure sur un hote non-Windows : COURSIA_RUNNER_HOST_PROBE=\"<pagewrites> <pagesout> <file> <idle%> <vmmem_Mo> <mapped_Mo>\"" >&2
+  fi
+done
+unset _retired
+
+# Convertit un cap docker ("3g", "512m") en Mo entiers. Refuse tout le reste
+# plutot que de rendre un nombre faux : un budget calcule sur une unite mal lue
+# est pire qu'une absence de budget.
+mem_to_mb() {
+  local v
+  case "$1" in
+    *g|*G) v="${1%[gG]}" ;;
+    *m|*M) v="${1%[mM]}"; case "$v" in ""|*[!0-9]*) die "cap memoire non entier: $1 (attendu 3g, 512m)" ;; esac; echo "$v"; return 0 ;;
+    *) die "cap memoire non reconnu: $1 (attendu 3g, 512m)" ;;
+  esac
+  case "$v" in ""|*[!0-9]*) die "cap memoire non entier: $1 (attendu 3g, 512m)" ;; esac
+  echo $(( v * 1024 ))
+}
+
+# Etat de DETRESSE de l'hote Windows. Rend "" si la mesure est impossible --
+# jamais un chiffre par defaut, jamais zero : un zero fabrique est indiscernable
+# d'une machine saine, et c'est ainsi qu'un garde devient un decor.
+#
+# La sonde vit dans un FICHIER .ps1 a cote, pas dans une chaine inline. Un motif
+# qui traverse bash -> powershell -> wsl -> sh perd une couche de quoting par
+# etage : mesure du 2026-09-07T23:47Z, awk recevait `{print` comme nom de
+# fichier. Le fichier supprime trois de ces quatre etages.
+#
+# Contrat de sortie, six entiers separes par des espaces (aucun separateur
+# decimal : sous locale FR un `91,7` se lit `91` en arithmetique bash) :
+#
+#   pagewrites  pagesout  file_disque_max  idle_disque_min_%  vmmem_Mo  mapped_Mo
+#
+# vmmem_Mo est le commit PRIVE (Win32_Process.PageFileUsage), jamais le
+# WorkingSet : Windows rabote le WorkingSet quand il pagine, donc cet
+# instrument-la BAISSE quand le probleme s'aggrave. mapped_Mo vaut -1 quand la
+# VM n'est pas joignable -- « inconnu », a ne jamais confondre avec zero.
+# Meme dossier que RUNNER_CTX (defini plus bas pour le garde de fraicheur) :
+# on ne peut pas le reutiliser ici, il est calcule apres.
+PROBE_PS1="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/persist/host-distress-probe.ps1"
+
+host_probe() {
+  # Echappatoire EXPLICITE pour un hote non-Windows ou pour un controle positif :
+  # l'operateur DECLARE sa mesure au lieu de s'en passer. _PROBE_2 declare le
+  # SECOND echantillon -- sans lui les deux points sont identiques, et aucun
+  # critere differentiel (la chute de `Mapped`) ne peut etre mis a l'epreuve :
+  # un controle positif qui ne peut pas faire rougir le garde ne le valide pas.
+  local which="${1:-1}"
+  if [ -n "${COURSIA_RUNNER_HOST_PROBE:-}" ]; then
+    if [ "$which" = "2" ] && [ -n "${COURSIA_RUNNER_HOST_PROBE_2:-}" ]; then
+      echo "$COURSIA_RUNNER_HOST_PROBE_2"
+    else
+      echo "$COURSIA_RUNNER_HOST_PROBE"
+    fi
+    return 0
+  fi
+  command -v powershell.exe >/dev/null 2>&1 || return 0
+  [ -f "$PROBE_PS1" ] || return 0
+  powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+    -File "$(cygpath -w "$PROBE_PS1" 2>/dev/null || echo "$PROBE_PS1")" \
+    2>/dev/null | tr -d '\r' | head -1
+}
+
+# Deux echantillons espaces de DISTRESS_GAP_S. Ecrit son verdict et les nombres
+# qui le fondent sur stdout, et rend :
+#   0 = sain     1 = detresse soutenue     2 = non mesurable (fail-closed)
+#
+# Ce que la conjonction exige, sur LES DEUX echantillons :
+#   PageWrites/s > 0  ET  PagesOutput/s > 0
+# Plus un critere d'abandon independant : `Mapped` qui chute de plus de
+# MAPPED_DROP_MB entre les deux points = qdrant se fait evincer.
+#
+# POURQUOI la file disque et l'inactivite ne sont PLUS des conjoints.
+# L'arbitrage Maintenance du 2026-09-07T22:59Z en prescrivait quatre ensemble :
+# ecritures pagefile, sorties de pages, file d'attente disque >= 1, et disque
+# sous 50 % d'inactivite. Les deux derniers NE SE MESURENT PAS sur cet hote --
+# controle positif passe sur ai-01 le 2026-09-08T00:14Z :
+#
+#   charge                                        AvgDisksecPerTransfer   file
+#   au repos                                             0,0000 s          0
+#   320 Mo en FileOptions::WriteThrough, Flush(true)     0,0000 s          0
+#     force a chaque bloc de 4 Mo
+#
+# `CurrentDiskQueueLength` ne quitte pas zero sous une vraie tempete d'ecriture,
+# et `PercentIdleTime` reste a 92-99 % (8 mesures sur 105 s). Le test `q >= 1`
+# etait donc TOUJOURS faux et `id <= 50` presque toujours : deux conjoints
+# structurellement faux tuaient la conjonction ENTIERE. La garde tombait sur son
+# `return 0` « hote sain » quelle que soit la pagination -- un garde vert par
+# manque de mesure, exactement le defaut que la validation des douze champs
+# ci-dessous existe pour empecher. Elle ne pouvait pas l'attraper : elle verifie
+# que les champs sont des ENTIERS, pas que l'instrument est SENSIBLE, et un
+# champ toujours a 0 passe une validation d'integralite.
+#
+# On RETIRE les deux termes morts plutot que d'abaisser leur seuil : un seuil ne
+# repare pas un compteur qui ne bouge pas. Les deux jambes memoire, elles, sont
+# vivantes et lisent 0 sur une machine saine (0/8 sur 105 s) -- les exiger
+# seules ne fabrique donc pas de refus abusif, et rend la garde strictement PLUS
+# conservatrice, ce qui est la bonne direction pour une garde dont la
+# defaillance a envoye quelqu'un redemarrer le serveur au grenier.
+#
+# La file et l'inactivite restent RELEVEES et AFFICHEES : elles enrichissent le
+# message quand elles bougent, elles ne conditionnent plus le verdict. Si elles
+# redeviennent sensibles un jour (diskperf -y, ou un provider qui ne tronque pas
+# les latences NVMe sub-ms), les readmettre comme conjoints demande de REPASSER
+# le controle positif ci-dessus, pas de faire confiance a leur retour.
+host_distress_verdict() {
+  local a b pw_a po_a q_a id_a vm_a mp_a pw_b po_b q_b id_b vm_b mp_b drop _v
+  a="$(host_probe 1)"
+  [ -n "$a" ] || { echo "[garde] hote NON MESURABLE (sonde injoignable)"; return 2; }
+  # Gap nul = deux echantillons instantanes : ne meme pas appeler sleep. La
+  # suite de tests compte les backoffs via un stub sleep qui journalise TOUT
+  # appel -- un `sleep 0` de la sonde viendrait polluter la premiere entree
+  # de chaque sequence attendue (cf tests 22-23, 37-43).
+  [ "$DISTRESS_GAP_S" -gt 0 ] && sleep "$DISTRESS_GAP_S"
+  b="$(host_probe 2)"
+  [ -n "$b" ] || { echo "[garde] hote NON MESURABLE (2e echantillon perdu)"; return 2; }
+
+  read -r pw_a po_a q_a id_a vm_a mp_a <<< "$a"
+  read -r pw_b po_b q_b id_b vm_b mp_b <<< "$b"
+  # Valider les DOUZE valeurs, pas seulement les huit du predicat de detresse.
+  # Une sonde qui rend cinq champs au lieu de six laisse `mp_*` VIDE ; le test
+  # `[ "$mp_a" -ge 0 ]` echoue alors en silence sur stderr, la conjonction de
+  # detresse ne se declenche pas davantage, et la fonction tombe sur son
+  # `return 0` -- un garde VERT par manque de mesure, exactement le defaut que
+  # la version precedente portait deja sous une autre forme. On refuse.
+  for _v in "$pw_a" "$po_a" "$q_a" "$id_a" "$vm_a" "$mp_a"             "$pw_b" "$po_b" "$q_b" "$id_b" "$vm_b" "$mp_b"; do
+    if ! [[ "$_v" =~ ^-?[0-9]+$ ]]; then
+      echo "[garde] sonde ILLISIBLE (champ absent ou non entier) : a=[$a] b=[$b]"
+      return 2
+    fi
+  done
+
+  echo "[garde] t0 : pagewrites=$pw_a pagesout=$po_a file=$q_a idle=${id_a}% vmmem=${vm_a}Mo mapped=${mp_a}Mo"
+  echo "[garde] t+${DISTRESS_GAP_S}s : pagewrites=$pw_b pagesout=$po_b file=$q_b idle=${id_b}% vmmem=${vm_b}Mo mapped=${mp_b}Mo"
+
+  if [ "$mp_a" -ge 0 ] && [ "$mp_b" -ge 0 ]; then
+    drop=$(( mp_a - mp_b ))
+    if [ "$drop" -gt "$MAPPED_DROP_MB" ]; then
+      echo "[garde] DETRESSE : Mapped a chute de $drop Mo en ${DISTRESS_GAP_S}s (seuil $MAPPED_DROP_MB) -- le mmap qdrant se fait evincer."
+      return 1
+    fi
+  fi
+
+  if [ "$pw_a" -gt 0 ] && [ "$po_a" -gt 0 ] && [ "$pw_b" -gt 0 ] && [ "$po_b" -gt 0 ]; then
+    echo "[garde] DETRESSE SOUTENUE : ecritures pagefile ET sorties de pages > 0 sur les DEUX echantillons."
+    if [ "$q_a" -ge 1 ] || [ "$q_b" -ge 1 ] || [ "$id_a" -le "$DISTRESS_IDLE_PCT_MAX" ] || [ "$id_b" -le "$DISTRESS_IDLE_PCT_MAX" ]; then
+      echo "[garde] confirme cote disque : file=$q_a/$q_b, inactivite=${id_a}%/${id_b}% (seuil ${DISTRESS_IDLE_PCT_MAX}%)."
+    else
+      echo "[garde] cote disque MUET : file=$q_a/$q_b, inactivite=${id_a}%/${id_b}%. Ces deux compteurs sont connus"
+      echo "[garde] insensibles sur cet hote (controle positif ci-dessus) : leur silence ne contredit PAS le verdict."
+    fi
+    return 1
+  fi
+
+  # Ce que ce `return 0` prouve, et ce qu'il ne prouve PAS. Deux familles de
+  # gel ont ete observees le meme soir sur cet hote :
+  #   (a) 07/09 17:57 -- famine progressive, 14 min de preavis, dilation lisible ;
+  #   (b) 07/09 19:01 -- ZERO preavis, RAM a 43,2 %, 109 Go libres, aucune dilation.
+  # Ce garde, comme `Blackbox-Lateness` que Maintenance a promu en arbitre, ne
+  # voit que la famille (a). Un verdict sain est donc une absence de FAMINE,
+  # jamais une absence de GEL. C'est ecrit ici, et pas seulement retenu, parce
+  # qu'un garde qui rend vert finit toujours par etre lu comme une garantie.
+  echo "[garde] hote sain : aucune ecriture pagefile soutenue, disque libre."
+  echo "[garde] (un verdict sain exclut la FAMINE, pas le gel sans preavis -- famille (b) du 07/09 19:01.)"
+  return 0
+}
+
+# Memoisation : la sonde coute DISTRESS_GAP_S d'attente. `assert_memory_budget`
+# et `budget_slots` sont appeles dans le meme lancement -- les faire payer deux
+# fois 15 s pousserait a baisser l'ecart, donc a rendre le « soutenu » creux.
+# Appeler SANS substitution de commande : le resultat vit dans les globales.
+HOST_VERDICT_DONE=0
+HOST_VERDICT_RC=2
+HOST_VERDICT_OUT=""
+host_distress() {
+  if [ "$HOST_VERDICT_DONE" -eq 1 ]; then return "$HOST_VERDICT_RC"; fi
+  HOST_VERDICT_OUT="$(host_distress_verdict)"
+  HOST_VERDICT_RC=$?
+  HOST_VERDICT_DONE=1
+  return "$HOST_VERDICT_RC"
+}
+
+# Somme, en Mo, des caps memoire des conteneurs CI DEJA en vol. On lit la
+# limite REELLEMENT APPLIQUEE par docker (HostConfig.Memory), pas une
+# re-derivation des variables de ce script : c'est la seule facon de compter
+# une famille lancee par un AUTRE processus, avec un autre environnement --
+# soit exactement le trou que cmd_lean documente depuis toujours (« la somme
+# des caps des familles actives n'est gardee par RIEN »).
+running_ci_mb() {
+  local ids
+  ids="$(docker ps -q --filter 'label=coursia-ci=1' 2>/dev/null)"
+  if [ -z "$ids" ]; then echo 0; return 0; fi
+  docker inspect --format '{{.HostConfig.Memory}}' $ids 2>/dev/null \
+    | awk '{ s += $1 } END { printf "%d", s/1048576 }'
+}
+
+# Refuse le demarrage si la famille demandee ne tient pas dans le budget, ou si
+# l'hote est deja sous le plancher. Montre l'arithmetique dans les deux cas :
+# un refus qui ne montre pas son calcul se contourne au juge.
+assert_memory_budget() {
+  local famille="$1" n="$2" per="$3"
+  local per_mb want_mb used_mb budget_mb rc
+  per_mb="$(mem_to_mb "$per")"
+  want_mb=$(( per_mb * n ))
+  used_mb="$(running_ci_mb)"
+  budget_mb=$(( BUDGET_GB * 1024 ))
+
+  # Un refus qui ne montre pas sa mesure se conteste au juge, puis se contourne.
+  # Les deux echantillons partent donc AVEC le message d'erreur, pas sur un flux
+  # separe que l'operateur presse ne lira pas.
+  host_distress; rc=$?
+  [ "$rc" -eq 0 ] && echo "$HOST_VERDICT_OUT"
+
+  if [ "$rc" -eq 2 ]; then
+    die "$HOST_VERDICT_OUT
+etat de l'hote NON MESURABLE -- REFUS.
+Un budget non mesure n'est pas un budget, et un zero fabrique est indiscernable
+d'une machine saine. Sur un hote non-Windows, ou pour rejouer une mesure :
+  COURSIA_RUNNER_HOST_PROBE=\"<pagewrites> <pagesout> <file> <idle%> <vmmem_Mo> <mapped_Mo>\" $0 ..."
+  fi
+
+  if [ "$rc" -eq 1 ]; then
+    die "$HOST_VERDICT_OUT
+hote EN DETRESSE MESUREE -- REFUS.
+Les deux echantillons ci-dessus le montrent : la machine pagine deja pour
+elle-meme. Demarrer des slots maintenant, c'est ajouter de la pression a une
+machine qui en evacue -- et c'est ce qui envoie quelqu'un redemarrer le serveur.
+Attendre que la pression retombe. Les seuils se declarent, si vraiment besoin,
+par COURSIA_RUNNER_DISTRESS_IDLE_PCT_MAX / _GAP_S / COURSIA_RUNNER_MAPPED_DROP_MB
+-- en connaissance de cause, et jamais pour faire passer un demarrage."
+  fi
+
+  if [ $(( used_mb + want_mb )) -gt "$budget_mb" ]; then
+    local reste_mb max_n
+    reste_mb=$(( budget_mb - used_mb ))
+    max_n=$(( reste_mb / per_mb ))
+    [ "$max_n" -lt 0 ] && max_n=0
+    die "budget CI depasse -- REFUS.
+  deja en vol ......... $used_mb Mo
+  demande ($famille) .. $n x $per = $want_mb Mo
+  total ............... $(( used_mb + want_mb )) Mo
+  budget .............. $budget_mb Mo (COURSIA_RUNNER_BUDGET_GB=$BUDGET_GB)
+Il reste de la place pour $max_n slot(s) de cette famille.
+Arreter une autre famille, ou demarrer '$famille $max_n'."
+  fi
+
+  echo "[budget] hote sans detresse soutenue ; CI en vol ${used_mb} Mo + ${want_mb} Mo demandes <= ${budget_mb} Mo"
+}
+
+# Nombre de slots que le budget residuel autorise pour un cap donne. Sert au
+# mot-cle `auto` : le N cesse d'etre un chiffre choisi a la main -- c'est un
+# `8` ecrit a la main qui a sature la machine -- et se DERIVE de la mesure.
+budget_slots() {
+  local per_mb reste_mb part_mb n rc
+  per_mb="$(mem_to_mb "$1")"
+  # Hote en detresse OU non mesurable : `auto` rend 0. Fail-closed dans LES DEUX
+  # cas -- une mesure qui echoue doit couter un refus, sinon la panne de sonde
+  # devient le chemin le plus permissif. La sortie du garde part sur stderr :
+  # cette fonction ecrit UN nombre sur stdout, son appelant le lit.
+  host_distress; rc=$?
+  [ -n "$HOST_VERDICT_OUT" ] && echo "$HOST_VERDICT_OUT" >&2
+  if [ "$rc" -ne 0 ]; then echo 0; return 0; fi
+  reste_mb=$(( BUDGET_GB * 1024 - $(running_ci_mb) ))
+  # Part maximale qu'UNE famille peut reclamer d'un coup : la moitie du
+  # residuel. Les familles coexistent par design (prefixes distincts, gardes
+  # PPID aveugles l'un a l'autre) -- laisser la premiere tout prendre revient
+  # a n'avoir aucun budget.
+  part_mb=$(( reste_mb / 2 ))
+  n=$(( part_mb / per_mb ))
+  [ "$n" -lt 0 ] && n=0
+  echo "$n"
+}
+
 die() { echo "ERREUR: $*" >&2; exit 1; }
 
 # #15095 Garde de disponibilite du demon. Avant cette garde, un daemon
@@ -342,7 +734,7 @@ cycle_backoff() {
     # que tail ecrit encore -> SIGPIPE 141 -> sous `set -uo pipefail` la
     # pipeline est non nulle et un cycle AYANT travaille est classe en boucle
     # vide (backoff au lieu de sleep 2). Un gros log de cycle (>> tampon ~64
-    # Ko, cf test 28) revele la faute. `grep ... >/dev/null` lit tout jusqu'a
+    # Ko, cf test 40) revele la faute. `grep ... >/dev/null` lit tout jusqu'a
     # EOF : tail se termine proprement, rc=0 sur match.
     if tail -c "+$(( log_off + 1 ))" "$work_log" 2>/dev/null | grep "Running job" >/dev/null; then
       worked=1
@@ -643,8 +1035,56 @@ supervisor_pids() {
   # recompute pas pour les subshells) -- mesure : self=PPID=1 avec out=mon
   # propre PID, donc le garde s'auto-matchait et le service crash-loopait.
   me="$$"
-  out="$(ps -ef 2>/dev/null | grep '[s]upervise\.sh start' | awk -v me="$me" '$2 != me && $3==1 {print $2}')"
+  # #15163 : `$2 ~ /^[0-9]+$/`. Une ligne `ps -ef` dont les colonnes ont glisse
+  # (commande lancee en `bash -c ...`) peut placer un jeton non-numerique en $2.
+  # Sans ce filtre il est rendu comme un PID, et `cmd_start` die() alors sur un
+  # superviseur FANTOME -- meme wedge que la sentinelle perimee, autre cause.
+  # Le filtre ne peut pas produire de faux negatif : un vrai PID est numerique.
+  out="$(ps -ef 2>/dev/null | grep '[s]upervise\.sh start' | awk -v me="$me" '$2 ~ /^[0-9]+$/ && $2 != me && $3==1 {print $2}')"
   printf '%s\n' "$out"
+}
+
+any_supervisor_alive() {
+  local me out
+  # Volontairement PLUS LARGE que supervisor_pids() : ce dernier ne retient que
+  # les superviseurs de PPID 1 (lances par systemd, cf #14347). Un superviseur
+  # lance a la main (nohup depuis un shell) porte un PPID quelconque et lui
+  # echappe. Ici la decision est d'EFFACER une sentinelle : rater un superviseur
+  # vivant ferait repartir une seconde flotte par-dessus la premiere. On exclut
+  # donc seulement soi-meme et ses propres fils.
+  me="$$"
+  out="$(ps -ef 2>/dev/null | grep -E '[s]upervise\.sh (start|waiters|lean)'          | awk -v me="$me" '$2 ~ /^[0-9]+$/ && $2 != me && $3 != me {print $2}')"
+  printf '%s
+' "$out"
+}
+
+# Porte d'entree commune aux trois familles. Rend 0 si le demarrage peut
+# proceder ; die() sinon.
+#
+# #15163 -- la sentinelle SURVIT AU REBOOT, et c'est ce qui wedgeait le pool.
+# Mesure ai-01 du 2026-09-07 : stop gracieux a 22:37:01, reboot, puis
+# `Started coursia-runner.service` a 22:53:29 -> "ERREUR: sentinel STOP_FILE
+# present" -> status=1/FAILURE a 22:53:30. Pool a zero jusqu'a intervention
+# humaine, quatre fois dans la journee.
+#
+# Le raisonnement d'origine ("ne pas effacer, sinon un superviseur survivant
+# reprendrait") est deja garanti impossible par la garde qui precede dans
+# cmd_start : elle die() si un superviseur est actif. La sentinelle ne pouvait
+# donc mordre QUE dans le cas ou il n'y a plus rien a proteger.
+stop_sentinel_gate() {
+  [ -f "$STOP_FILE" ] || return 0
+  local alive
+  alive="$(any_supervisor_alive | tr '
+' ' ' | sed 's/ *$//')"
+  if [ -n "$alive" ]; then
+    die "sentinel STOP_FILE present ($STOP_FILE) ET un superviseur est vivant
+(PID $alive) -- un arret gracieux est reellement en cours. Attendre la fin des
+jobs en vol, puis relancer."
+  fi
+  echo "[sentinelle] $STOP_FILE present, mais AUCUN superviseur vivant : la" >&2
+  echo "[sentinelle] sentinelle est perimee (elle survit au reboot). Purge." >&2
+  rm -f "$STOP_FILE"
+  return 0
 }
 
 fetch_token() {
@@ -711,6 +1151,8 @@ slot_loop() {
     docker run --rm \
       --name "$name" \
       --cpus="$cpus" --memory="$memory" --pids-limit="$pids" \
+      --label coursia-ci=1 \
+      ${CI_CGROUP_PARENT:+--cgroup-parent="$CI_CGROUP_PARENT"} \
       "${swap_args[@]+"${swap_args[@]}"}" \
       "${BLKIO_ARGS[@]+"${BLKIO_ARGS[@]}"}" \
       --security-opt=no-new-privileges \
@@ -772,24 +1214,35 @@ cmd_start() {
   # on nomme les PIDs -- un deuxieme `start` produirait deux boucles
   # concurrantes portant des copies differentes de l'environnement
   # (incident po-2024 2026-09-02, plusieurs PRs de contenu bloquees).
+  assert_memory_budget start "$n" "$MEMORY"
+  assert_ci_slice
   local existing_pids
   existing_pids="$(supervisor_pids)"
   if [ -n "$existing_pids" ]; then
     die "un superviseur $NAME_PREFIX est deja actif (PID $existing_pids) ;
 utiliser '$0 stop' d'abord, ou relancer sous une machine differente."
   fi
-  # #14259 Defaut 2 : si le sentinel STOP_FILE est pose, refuser sauf
-  # `--force`. C'est le mecanisme cle qui protege un arret gracieux :
-  # un `stop` pose le sentinel, les boucles existantes ne relancent
-  # plus de conteneur, et un `start` ulterieur NE DOIT PAS effacer
-  # le sentinel sinon le superviseur (s'il survit) reprendrait. Le
-  # seul moyen de re-marcher apres un stop est `--force`, qui dit
-  # explicitement « j'ai conscience que je relance sur un stop en
-  # cours ».
-  if [ -f "$STOP_FILE" ] && [ "$force" -ne 1 ]; then
-    die "sentinel STOP_FILE present ($STOP_FILE) -- un arret gracieux
-est en cours. Attendre la fin des jobs, faire '$0 stop' (no-op si deja
-fait) puis '$0 start', OU relancer avec '$0 start $n --force'."
+  # #14259 Defaut 2 : le sentinel STOP_FILE protege un arret gracieux -- un
+  # `stop` le pose, les boucles ne relancent plus de conteneur, et un `start`
+  # qui l'effacerait ferait reprendre un superviseur encore vivant.
+  #
+  # #15163 : ce raisonnement etait juste, sa MISE EN OEUVRE ne l'etait pas.
+  # Le refus etait inconditionnel, alors que le sentinel est un FICHIER : il
+  # survit au reboot, quand plus aucun superviseur ne peut reprendre. Mesure
+  # ai-01 du 2026-09-07 -- stop gracieux a 22:37:01, reboot, puis
+  # `Started coursia-runner.service` a 22:53:29 -> "ERREUR: sentinel
+  # STOP_FILE present" -> status=1/FAILURE a 22:53:30. Pool a zero jusqu'a
+  # intervention humaine, quatre fois dans la journee.
+  #
+  # `stop_sentinel_gate` conserve le refus quand un superviseur est vivant, et
+  # purge quand il n'y en a aucun. Noter que la garde `existing_pids` ci-dessus
+  # a deja die() sur les superviseurs de PPID 1 : c'est `any_supervisor_alive`,
+  # plus large, qui rend le refus atteignable pour les autres.
+  #
+  # `--force` reste la sortie explicite pour relancer PAR-DESSUS un arret en
+  # cours, ce que la porte refuse justement de faire toute seule.
+  if [ "$force" -ne 1 ]; then
+    stop_sentinel_gate
   fi
   # Les trois bornes, verifiees AVANT de lever le sentinel : un refus ne doit
   # laisser aucune trace, sinon un arret gracieux en cours serait annule par
@@ -850,6 +1303,163 @@ cmd_stop() {
   echo "Les jobs en cours vont a leur terme. Pour couper net (deconseille) :"
   echo "  docker ps --filter name=$NAME_PREFIX -q | xargs -r docker kill"
   echo "  docker ps --filter name=$LEAN_NAME_PREFIX -q | xargs -r docker kill"
+  echo
+  # Point de mesure demande par Maintenance : l'arret d'un slot ne rend pas sa
+  # memoire tout de suite. Le commit prive de vmmemWSL redescend en differe, et
+  # c'est ce differe -- pas l'instant de l'arret -- qui dit ce que la CI coutait
+  # vraiment. Mesurer TROP TOT rend un chiffre qui accuse la CI d'occuper encore
+  # ce qu'elle a deja rendu.
+  echo "[mesure] relever a T+35 min (et pas avant) :"
+  echo "  $0 peak                                  # pic cgroup de la slice CI"
+  echo "  $(dirname "${BASH_SOURCE[0]}")/persist/host-distress-probe.ps1  # 5e champ = commit prive vmmemWSL, en Mo"
+}
+
+# --- MESURE DU PIC REEL DE LA SLICE CI ---------------------------------------
+#
+# BUDGET_GB dit ce qu'on s'AUTORISE ; il ne dit pas ce qu'on CONSOMME. Tant que
+# personne ne lit le pic, « 12 Go suffisent » reste une hypothese -- exactement
+# le genre d'hypothese que l'en-tete de ce fichier accuse d'avoir coute quatre
+# redemarrages. cgroup v2 expose le high-water mark reel : on le lit.
+#
+# memory.peak est un MAXIMUM ATTEINT DEPUIS LA CREATION DE LA SLICE, pas une
+# mesure instantanee et pas une moyenne. Deux consequences a ne pas oublier en
+# le lisant :
+#
+#   1. il ne redescend jamais. Un pic de 14 Go affiche apres coup ne dit pas
+#      que la CI tient 14 Go maintenant -- il dit qu'elle les a tenus une fois.
+#      C'est precisement ce qu'on veut pour dimensionner un plafond.
+#   2. il n'est REMISE A ZERO que sur noyau >= 6.9 (ecriture de 0 dans le
+#      fichier). Mesure sur ai-01 le 2026-09-07 : noyau 6.6.87.2-microsoft-
+#      standard-WSL2, fichier en -r--r--r--, l'ecriture est refusee. Pour
+#      repartir d'un pic vierge sur ce noyau il faut RECREER la slice
+#      (systemctl stop coursia-ci.slice), pas esperer un reset.
+#
+# La slice vit cote VM. Ce script tourne soit DANS la VM, soit sous Git Bash
+# cote Windows : on essaie la lecture directe, puis l'interop wsl.exe. Si
+# aucune ne repond on rend "" -- jamais un zero, qui se lirait comme « la CI
+# n'a rien consomme » alors qu'il signifie « je n'ai pas su regarder ».
+CI_SLICE_PATH="${COURSIA_CI_SLICE_PATH:-/sys/fs/cgroup/coursia.slice/coursia-ci.slice}"
+CI_SLICE_WSL_DISTRO="${COURSIA_CI_SLICE_WSL_DISTRO:-Ubuntu}"
+
+# `docker run --cgroup-parent` attend, sous le pilote cgroupfs, un chemin
+# RELATIF a la racine cgroup. On le derive du chemin absolu ci-dessus pour
+# qu'il n'existe qu'une seule source de verite entre lecture et placement.
+CI_CGROUP_PARENT="${CI_SLICE_PATH#/sys/fs/cgroup/}"
+
+slice_read() {
+  local f="$CI_SLICE_PATH/$1" v
+  if [ -r "$f" ]; then
+    cat "$f" 2>/dev/null | tr -d '\r\n '
+    return 0
+  fi
+  command -v wsl.exe >/dev/null 2>&1 || return 0
+  # wsl.exe repond en UTF-16LE quand la distro est introuvable : les octets
+  # nuls remontent sur STDOUT (pas stderr) et bash emet un avertissement par
+  # substitution. On les filtre -- un chemin d'erreur bruyant finit par noyer
+  # le message qui compte.
+  v="$(wsl.exe -d "$CI_SLICE_WSL_DISTRO" -u root -- cat "$f" 2>/dev/null | tr -d '\000\r\n ')"
+  case "$v" in ""|*[!0-9]*) return 0 ;; esac
+  echo "$v"
+}
+
+# Lecture BRUTE d'un fichier de la slice. `slice_read` ne rend QUE des
+# chiffres : il rend "" aussi bien pour un fichier illisible que pour la
+# valeur litterale `max` (cgroup sans plafond). Ces deux cas commandent des
+# actions OPPOSEES -- refuser de demarrer, ou demarrer en sachant qu'il n'y a
+# pas de mur -- donc le garde ci-dessous ne peut pas s'appuyer dessus.
+slice_read_raw() {
+  local f="$CI_SLICE_PATH/$1" v
+  if [ -r "$f" ]; then
+    cat "$f" 2>/dev/null | tr -d '\r\n '
+    return 0
+  fi
+  command -v wsl.exe >/dev/null 2>&1 || return 0
+  v="$(wsl.exe -d "$CI_SLICE_WSL_DISTRO" -u root -- cat "$f" 2>/dev/null | tr -d '\000\r\n ')"
+  case "$v" in *"No such file"*|*"cannot open"*|*"Permission denied"*) return 0 ;; esac
+  echo "$v"
+}
+
+# Garde de CABLAGE du mur agrege.
+#
+# Sans lui, `--cgroup-parent` sur un chemin ABSENT le fait CREER par docker
+# -- sans MemoryHigh ni MemoryMax. Le mur agrege redeviendrait decoratif,
+# mais cette fois `memory.peak` monterait et la slice AURAIT L'AIR cablee.
+# Un zero franc est recuperable ; un faux non-zero ne l'est pas. C'est le
+# meme defaut que celui repare ici : la slice existait, plafonnee, et aucun
+# conteneur n'y entrait -- `memory.peak` rendait 0 pendant que la CI
+# consommait 198 Mio dehors (mesure ai-01 2026-09-08T00:56Z).
+assert_ci_slice() {
+  local mx hi why=""
+  mx="$(slice_read_raw memory.max)"
+  case "$mx" in
+    "")  why="slice CI illisible ou absente ($CI_SLICE_PATH)" ;;
+    max) why="slice CI presente mais SANS plafond ($CI_SLICE_PATH/memory.max = max)" ;;
+  esac
+  if [ -n "$why" ]; then
+    if [ "$REQUIRE_CI_SLICE" = "1" ]; then
+      die "$why -- REFUS de demarrer (COURSIA_REQUIRE_CI_SLICE=1).
+Le mur agrege serait decoratif tout en paraissant actif. Deployer :
+    sudo cp scripts/ci/docker/linux-runner/persist/coursia-ci.slice /etc/systemd/system/
+    sudo cp scripts/ci/docker/linux-runner/persist/daemon.json /etc/docker/daemon.json
+    sudo systemctl daemon-reload && sudo systemctl start coursia-ci.slice"
+    fi
+    # Machine sans slice (po-2024) : on avertit, et surtout on NEUTRALISE le
+    # placement. Passer --cgroup-parent sur un chemin absent le ferait creer
+    # par docker, sans aucun plafond -- un mur qui a l'air d'un mur.
+    CI_CGROUP_PARENT=""
+    echo "[slice] $why -- mur memoire agrege NON ACTIF ; conteneurs non places."
+    echo "[slice] (COURSIA_REQUIRE_CI_SLICE=1 pour en faire un refus de demarrer)"
+    return 0
+  fi
+  hi="$(slice_read_raw memory.high)"
+  echo "[slice] mur agrege ACTIF : memory.high=$hi memory.max=$mx octets"
+  echo "[slice] ($CI_SLICE_PATH ; conteneurs places via --cgroup-parent=$CI_CGROUP_PARENT)"
+}
+
+# Affiche pic / courant / plafonds de la slice, et confronte le pic au budget.
+# C'est la seule ligne de ce script qui compare une DECLARATION a une MESURE.
+cmd_peak() {
+  local peak swpeak cur high max
+  peak="$(slice_read memory.peak)"
+  swpeak="$(slice_read memory.swap.peak)"
+  cur="$(slice_read memory.current)"
+  high="$(slice_read memory.high)"
+  max="$(slice_read memory.max)"
+
+  echo "== slice CI : pic mesure vs budget declare =="
+  if [ -z "$peak" ]; then
+    echo "  slice ILLISIBLE ($CI_SLICE_PATH) -- ni lecture directe ni interop wsl.exe."
+    echo "  Ce n'est PAS « pic nul » : la mesure a echoue. Verifier que la slice est"
+    echo "  deployee (scripts/ci/docker/linux-runner/persist/coursia-ci.slice)."
+    return 0
+  fi
+
+
+  _peak_gib() { awk -v x="$1" 'BEGIN{ if (x=="" || x=="max") print "-"; else printf "%.2f", x/1073741824 }'; }
+  echo "  memory.peak ......... $(_peak_gib "$peak") Gio   (max atteint depuis creation de la slice)"
+  echo "  memory.swap.peak .... $(_peak_gib "$swpeak") Gio"
+  echo "  memory.current ...... $(_peak_gib "$cur") Gio   (instantane)"
+  echo "  memory.high ......... $(_peak_gib "$high") Gio   (seuil de recuperation noyau)"
+  echo "  memory.max .......... $(_peak_gib "$max") Gio   (mur OOM)"
+
+  if [ "$peak" = "0" ]; then
+    echo "  -- pic a 0 : aucune charge n'a jamais tourne dans cette slice depuis sa"
+    echo "     creation. Le budget de $BUDGET_GB Go reste une HYPOTHESE non verifiee."
+    return 0
+  fi
+
+  local peak_mb budget_mb
+  peak_mb=$(( peak / 1048576 ))
+  budget_mb=$(( BUDGET_GB * 1024 ))
+  if [ "$peak_mb" -gt "$budget_mb" ]; then
+    echo "  -- PIC AU-DESSUS DU BUDGET : ${peak_mb} Mo mesures > ${budget_mb} Mo declares."
+    echo "     Le budget sous-estime la charge reelle. Soit baisser le nombre de slots,"
+    echo "     soit relever COURSIA_RUNNER_BUDGET_GB EN LE SACHANT -- pas par defaut."
+  else
+    awk -v p="$peak_mb" -v b="$budget_mb" 'BEGIN{
+      printf "  -- pic %d Mo sous le budget %d Mo (marge %d Mo, %.0f%% du budget utilise)\n",
+             p, b, b-p, 100*p/b }'
+  fi
 }
 
 cmd_status() {
@@ -927,6 +1537,9 @@ cmd_status() {
     fi
   fi
   [ -f "$STOP_FILE" ] && echo "== sentinel STOP pose : les boucles ne relancent plus =="
+  # Le pic fait partie de l'etat courant : un status qui montre les conteneurs
+  # sans montrer ce qu'ils ont reellement consomme laisse le budget invisible.
+  cmd_peak
 }
 
 waiter_loop() {
@@ -962,6 +1575,8 @@ waiter_loop() {
       --name "$name" \
       --cpus="$WAITER_CPUS" --memory="$WAITER_MEMORY" --pids-limit="$WAITER_PIDS" \
       "${BLKIO_ARGS[@]+"${BLKIO_ARGS[@]}"}" \
+      --label coursia-ci=1 \
+      ${CI_CGROUP_PARENT:+--cgroup-parent="$CI_CGROUP_PARENT"} \
       --security-opt=no-new-privileges \
       "${tc_args[@]+"${tc_args[@]}"}" \
       -e ACTIONS_RUNNER_INPUT_TOKEN="$token" \
@@ -984,7 +1599,7 @@ waiter_loop() {
 }
 
 cmd_waiters() {
-  local n="${1:-24}"
+  local n="${1:-8}"
   command -v docker >/dev/null || die "docker introuvable"
   command -v gh >/dev/null || die "gh introuvable"
   validate_backoff_env
@@ -993,7 +1608,7 @@ cmd_waiters() {
     || die "image $IMAGE absente -- construire d'abord :
     docker build -t $IMAGE scripts/ci/docker/linux-runner/"
   assert_image_fresh "$IMAGE" "docker build -t $IMAGE scripts/ci/docker/linux-runner/"
-  [ -f "$STOP_FILE" ] && die "sentinel STOP pose -- arreter d'abord ($0 stop)"
+  stop_sentinel_gate
   # Idempotence propre a la famille waiters : le garde de `start` filtre
   # `supervise.sh start` et ne voit pas `waiters`. Verrou porte par le pid
   # de la boucle -- si elle est morte, kill -0 echoue et on relance.
@@ -1010,6 +1625,8 @@ cmd_waiters() {
   assert_cgroup_budget
   assert_cpu_budget "waiters" "$n" "$WAITER_CPUS"
   compute_blkio_args
+  assert_memory_budget waiters "$n" "$WAITER_MEMORY"
+  assert_ci_slice
   rm -f "$STATE_DIR/waiter-pids"
   echo "demarrage de $n waiter(s) ; labels=$WAITER_LABELS ; caps : cpus=$WAITER_CPUS memory=$WAITER_MEMORY pids=$WAITER_PIDS"
   for i in $(seq 1 "$n"); do
@@ -1032,7 +1649,7 @@ cmd_lean() {
   # Dockerfile.lean FROM coursia-linux-runner : l'entrypoint est herite de la
   # base -- un ecart pointe soit vers l'image lean, soit vers sa base.
   assert_image_fresh "$LEAN_IMAGE" "docker build -t $LEAN_IMAGE -f scripts/ci/docker/linux-runner/Dockerfile.lean scripts/ci/docker/linux-runner/"
-  [ -f "$STOP_FILE" ] && die "sentinel STOP pose -- arreter d'abord ($0 stop)"
+  stop_sentinel_gate
   # Idempotence calquee sur cmd_waiters : le garde PPID de `start` filtre
   # `supervise.sh start` et ne verrait pas `lean`. Verrou par pid file.
   #
@@ -1061,6 +1678,8 @@ cmd_lean() {
   assert_cgroup_budget
   assert_cpu_budget "lean" "$n" "$LEAN_CPUS"
   compute_blkio_args
+  assert_memory_budget lean "$n" "$LEAN_MEMORY"
+  assert_ci_slice
   rm -f "$STATE_DIR/lean-pids"
   echo "demarrage de $n slot(s) lean ; labels=$LEAN_LABELS ; caps : cpus=$LEAN_CPUS memory=$LEAN_MEMORY pids=$LEAN_PIDS ; image=$LEAN_IMAGE ; .lake chaud=${LEAN_WORK_VOLUME_PREFIX}-{1..$n} -> $WORK_MOUNT"
   for i in $(seq 1 "$n"); do
@@ -1076,10 +1695,21 @@ cmd_lean() {
 }
 
 case "${1:-}" in
-  start)   shift; cmd_start "${1:-2}" "${2:-}" ;;
-  waiters) shift; cmd_waiters "${1:-24}" ;;
-  lean)    shift; cmd_lean "${1:-2}" ;;
+  start)   shift
+           # `auto` derive N du budget residuel au lieu de le lire en argv.
+           n_arg="${1:-2}"
+           [ "$n_arg" = "auto" ] && n_arg="$(budget_slots "$MEMORY")"
+           cmd_start "$n_arg" "${2:-}" ;;
+  waiters) shift
+           n_arg="${1:-8}"
+           [ "$n_arg" = "auto" ] && n_arg="$(budget_slots "$WAITER_MEMORY")"
+           cmd_waiters "$n_arg" ;;
+  lean)    shift
+           n_arg="${1:-1}"
+           [ "$n_arg" = "auto" ] && n_arg="$(budget_slots "$LEAN_MEMORY")"
+           cmd_lean "$n_arg" ;;
   stop)    cmd_stop ;;
   status)  cmd_status ;;
-  *) echo "usage: $0 {start [N] [--force]|waiters [N]|lean [N]|stop|status}"; exit 2 ;;
+  peak)    cmd_peak ;;
+  *) echo "usage: $0 {start [N] [--force]|waiters [N]|lean [N]|stop|status|peak}"; exit 2 ;;
 esac

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -35,7 +35,7 @@ ko() { echo "  FAIL: $1"; echo "FAIL $1" >> "$RESULTS"; }
 # generation du stub). La fonction assert_image_fresh lit DEUX fichiers
 # depuis #15105 (work_cache_health.sh est source par l'entrypoint) : le stub
 # repond aux deux probes. STUB_IMG_ENTRYPOINT_SHA / STUB_IMG_HEALTH_SHA
-# forcent un ecart pour tester le refus (tests 9 et 29).
+# forcent un ecart pour tester le refus (tests 9 et 41).
 # Le stub hostname rend le defaut de supervise.sh (#15152) deterministe :
 # le prefixe derive de la machine, il ne doit jamais dependre de l'hote qui
 # execute la suite.
@@ -82,9 +82,9 @@ chmod +x "$TEST_DIR/bin/ps"
 REAL_SLEEP="$(command -v sleep)"
 
 # Stub sleep GLOBAL : depuis que les boucles VIVENT (la fusion a corrige t0),
-# un cycle court attendait un backoff reel de 15 s ; les tests 1-3/7/10/22
+# un cycle court attendait un backoff reel de 15 s ; les tests 1-3/7/10/34
 # (timeouts 1-3 s) timeout-rent au lieu de mesurer. Ce stub rend toutes les
-# attentes de supervise.sh instantanees ; les tests 12-28 posent LEURS stubs
+# attentes de supervise.sh instantanees ; les tests 22 a 40 posent LEURS stubs
 # sleep logues pour compter les backoffs (non affectes : leurs bins passent
 # d'abord dans le PATH).
 cat > "$TEST_DIR/bin/sleep" <<'STUB'
@@ -103,11 +103,55 @@ printf '%s\n' "${HOSTNAME_STUB:-myia-default-host}"
 STUB
 chmod +x "$TEST_DIR/bin/hostname"
 
+# Le garde d'hote (#15091) prend DEUX echantillons espaces de DISTRESS_GAP_S et
+# lit des compteurs de performance Windows. Les tests 1 a 10 ne portent PAS sur
+# lui : on DECLARE une mesure nominale et un ecart nul. Sans cela chaque test
+# paierait 15 s d'attente et son verdict dependrait de l'etat reel de la machine
+# qui l'execute -- une suite dont le resultat varie avec la charge de l'hote ne
+# mesure plus les gardes qu'elle pretend mesurer.
+# Format : pagewrites pagesout file_disque idle%_min vmmem_Mo mapped_Mo
+export COURSIA_RUNNER_HOST_PROBE="0 0 0 95 40000 50000"
+export COURSIA_RUNNER_DISTRESS_GAP_S=0
+
+# Meme raison que le garde d'hote ci-dessus, pour le mur agrege (#15091) :
+# `assert_ci_slice` lit la slice CI, et sans declaration il lirait la VRAIE
+# slice de la machine -- via `wsl.exe`, a ~135 ms l'aller-retour, et en
+# echouant en bloc sur toute machine ou elle n'est pas deployee. Les tests 1
+# a 16 ne portent pas sur ce garde : on declare une slice PLAFONNEE, en
+# fichiers ordinaires (lus directement, sans interop). Les tests 17, 29, 30 et 31,
+# eux, surchargent ce chemin -- c'est leur objet.
+COURSIA_CI_SLICE_PATH="$TEST_DIR/slice-nominale"
+mkdir -p "$COURSIA_CI_SLICE_PATH"
+echo 17179869184 > "$COURSIA_CI_SLICE_PATH/memory.max"
+echo 12884901888 > "$COURSIA_CI_SLICE_PATH/memory.high"
+export COURSIA_CI_SLICE_PATH
+
 # Helper : executer supervise.sh avec env detourne. Timeout pour eviter le
 # hang de wait() -- cmd_start lance wait() qui attend les slot_loop infinis.
 # La fenetre (8 s) est large : elle borne execute() sans dependre d'une
 # machine rapide -- les refus testes arrivent en tete de cmd_start, la
 # charge machine ne doit pas les transformer en timeout.
+
+# Arret du superviseur d'UN test, et de lui seul.
+#
+# La version precedente terminait par `pkill -f 'supervise.sh start'`, non
+# scope : sur une machine ou un superviseur REEL tourne, lancer cette suite
+# le tuait en plein job -- et un job tue rend un rouge qui ne veut rien dire
+# (c'est la raison d'etre de `cmd_stop`, qui pose un sentinel au lieu de
+# tuer). On tue les enfants du test, puis les slot_loop que le superviseur a
+# lui-meme inscrits dans SON state dir : deux ensembles bornes au test.
+kill_test_supervisor() {
+  local tpid="$1" state="$2"
+  [ -n "$tpid" ] && pkill -P "$tpid" 2>/dev/null
+  if [ -f "$state/pids" ]; then
+    while read -r pid; do
+      [ -n "$pid" ] && kill "$pid" 2>/dev/null
+    done < "$state/pids"
+  fi
+  wait 2>/dev/null
+  return 0
+}
+
 run_supervise() {
   local args="$1"
   local prefix="$2"
@@ -118,6 +162,26 @@ run_supervise() {
   timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" $args >/dev/null 2>"$TEST_DIR/last.err"
   echo "rc=$?"
   cat "$TEST_DIR/last.err"
+}
+
+# Attente BORNEE plutot que `sleep <constante>`. Un `sleep 0.5` suivi d'une
+# assertion n'est pas un test, c'est une course : sur cette machine le prelude
+# de cmd_start met 680 a 924 ms (spawns de processus Git Bash + la sonde d'hote
+# a deux echantillons), et le test rendait donc FAIL sur un comportement
+# correct. On attend la CONDITION, avec un plafond -- l'echec reste un echec,
+# il cesse d'etre un chronometre.
+wait_until() {
+  local deadline_ms="$1"; shift
+  local waited=0
+  while [ "$waited" -lt "$deadline_ms" ]; do
+    if "$@"; then return 0; fi
+    # REAL_SLEEP, pas le stub : les tests exportent le PATH stubbe AVANT
+    # d'appeler wait_until -- un sleep nu tournerait instantanement et le
+    # plafond expirerait en millisecondes reelles, pas en deadline_ms.
+    "$REAL_SLEEP" 0.05
+    waited=$(( waited + 50 ))
+  done
+  return 1
 }
 
 # --- Test 1 : start quand un superviseur est deja actif refuse -----
@@ -135,11 +199,22 @@ echo "Test 1 : start quand un superviseur est deja actif (Defaut 1)"
 )
 echo ""
 
-# --- Test 2 : start apres stop sans --force refuse -----
-echo "Test 2 : start apres stop refuse, sentinel preserve (Defaut 2 sans --force)"
+# --- Test 2 : start apres stop, SUPERVISEUR VIVANT -> refus -----
+#
+# #15163 -- ce test verifiait auparavant le refus AVEC `unset PS_OUTPUT`,
+# c'est-a-dire dans le cas ou aucun superviseur ne tourne. C'etait pinner le
+# defaut : le sentinel est un fichier, il survit au reboot, et le refus
+# inconditionnel wedgeait donc le pool au demarrage de la machine (mesure du
+# 2026-09-07 : quatre redemarrages a la main dans la journee).
+#
+# Ce qui est teste ici est la moitie du Defaut 2 qui reste VRAIE : un arret
+# gracieux reellement en cours ne doit pas etre pietine. Le PPID du stub est
+# volontairement != 1 -- un superviseur de PPID 1 serait deja intercepte par la
+# garde `existing_pids` en amont, et le test ne mesurerait pas la porte.
+echo "Test 2 : start apres stop AVEC superviseur vivant refuse, sentinel preserve (#15163)"
 (
   cd "$SCRIPT_DIR"
-  unset PS_OUTPUT
+  export PS_OUTPUT="jsboige  33594  9876   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
   touch "$TEST_DIR/state-B/stop"
   rc="$(run_supervise 'start 1' 'test-prefix-B' "$TEST_DIR/state-B" 2>&1 | head -1 | sed 's/rc=//')"
   err="$(cat "$TEST_DIR/last.err")"
@@ -148,11 +223,19 @@ echo "Test 2 : start apres stop refuse, sentinel preserve (Defaut 2 sans --force
   else
     ko "start aurait du refuser sur sentinel, rc=$rc err=$err"
   fi
+  # Le refus doit NOMMER le superviseur qui le motive : c'est ce qui distingue
+  # un arret en cours d'une sentinelle perimee pour qui lit le journal.
+  if echo "$err" | grep -q "superviseur est vivant" && echo "$err" | grep -q "33594"; then
+    ok "le refus nomme le superviseur vivant (PID 33594)"
+  else
+    ko "le refus aurait du nommer le PID 33594, err=$err"
+  fi
   if [ -f "$TEST_DIR/state-B/stop" ]; then
     ok "sentinel preserve apres start refuse"
   else
     ko "sentinel aurait du etre preserve"
   fi
+  unset PS_OUTPUT
 )
 echo ""
 
@@ -165,23 +248,14 @@ echo "Test 3 : start --force leve sentinel (Defaut 2 avec --force)"
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-C"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-C"
   touch "$TEST_DIR/state-C/stop"
-  timeout --kill-after=1 15 bash "$SCRIPT_DIR/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
   TPID=$!
-  # Poll (pas de fenetre fixe) : la chaine de gardes pre-rebase fait vivre
-  # N processus stub ; sa duree depend de la charge machine.
-  leve=0
-  for _ in $(seq 1 24); do
-    [ ! -f "$TEST_DIR/state-C/stop" ] && { leve=1; break; }
-    "$REAL_SLEEP" 0.5
-  done
-  if [ "$leve" = "1" ]; then
+  if wait_until 4000 test ! -f "$TEST_DIR/state-C/stop"; then
     ok "sentinel leve par start --force"
   else
     ko "sentinel aurait du etre leve par start --force (encore present)"
   fi
-  pkill -P $TPID 2>/dev/null
-  pkill -f 'supervise.sh start' 2>/dev/null
-  wait 2>/dev/null
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
 )
 echo ""
 
@@ -270,12 +344,15 @@ STUB
   export COURSIA_RUNNER_GH_ACCOUNT="fake-account"
   export GH_CALLS_LOG="$TEST_DIR/gh7.calls"
   : > "$GH_CALLS_LOG"
-  timeout --kill-after=1 15 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/last.err" &
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/last.err" &
   TPID=$!
-  sleep 5
-  pkill -P $TPID 2>/dev/null
-  pkill -f 'supervise.sh start' 2>/dev/null
-  wait 2>/dev/null
+  # `sleep 1` n'etait pas une attente, c'etait un chronometre : le prelude de
+  # cmd_start met 680 a 924 ms (cf. wait_until ci-dessus) et le fetch du
+  # registration-token vit APRES lui. La marge etait de 76 ms -- le test
+  # passait ou echouait selon la charge, sans rien dire du code teste. On
+  # attend la CONDITION, plafonnee.
+  wait_until 5000 grep -q 'registration-token' "$GH_CALLS_LOG"
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
   if grep -q 'auth token --user fake-account' "$GH_CALLS_LOG"; then
     ok "fetch_token resout le token via gh auth token --user fake-account"
   else
@@ -354,12 +431,12 @@ echo "Test 10 : start passe le garde quand l'image est a jour (#14801)"
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-10"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-10"
   mkdir -p "$TEST_DIR/state-10"
-  timeout --kill-after=1 15 bash "$SCRIPT_DIR/supervise.sh" start 1 >"$TEST_DIR/out-10.log" 2>"$TEST_DIR/last.err" &
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" start 1 >"$TEST_DIR/out-10.log" 2>"$TEST_DIR/last.err" &
   TPID=$!
   # Signal fiable de "slots lances" : $STATE_DIR/pids est ecrit par
   # redirection directe (immediate), alors que les echoes stdout du
   # supervise sont bufferises (visibles seulement a la sortie du process).
-  # Poll : la chaine de gardes depend de la charge machine.
+  # Poll borne : la chaine de gardes depend de la charge machine.
   slots=0
   for _ in $(seq 1 24); do
     [ -s "$TEST_DIR/state-10/pids" ] && { slots=1; break; }
@@ -370,9 +447,313 @@ echo "Test 10 : start passe le garde quand l'image est a jour (#14801)"
   else
     ko "le garde a tort ou le start a echoue, out=$(cat "$TEST_DIR/out-10.log") err=$(cat "$TEST_DIR/last.err")"
   fi
-  pkill -P $TPID 2>/dev/null
-  pkill -f 'supervise.sh start' 2>/dev/null
-  wait 2>/dev/null
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
+)
+echo ""
+
+# --- Test 11 : CONTROLE POSITIF -- detresse soutenue refuse (#15091) -----
+#
+# Ce test est la raison d'etre des quatre suivants. Un garde qui ne rougit
+# jamais est indiscernable d'un garde debranche, et la version precedente de
+# celui-ci l'etait litteralement : elle lisait AvgDisksecPerRead, un UInt32 EN
+# SECONDES, contre un seuil en millisecondes -- il ne POUVAIT pas se declencher.
+# On verifie donc d'abord qu'il sait dire non.
+echo "Test 11 : start refuse sur une detresse soutenue sur les DEUX points (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-11"
+  # pagewrites>0 ET pagesout>0 ET file>=1 ET idle<=50 -- sur les deux points.
+  export COURSIA_RUNNER_HOST_PROBE="120 340 3 12 90000 50000"
+  export COURSIA_RUNNER_HOST_PROBE_2="98 410 2 18 91000 49800"
+  rc="$(run_supervise 'start 1' 'test-prefix-11' "$TEST_DIR/state-11" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "DETRESSE"; then
+    ok "detresse soutenue refusee (rc=$rc)"
+  else
+    ko "refus attendu sur detresse soutenue, rc=$rc err=$err"
+  fi
+  unset COURSIA_RUNNER_HOST_PROBE_2
+)
+echo ""
+
+# --- Test 11b : CONTROLE NEGATIF -- la detresse doit mordre alors que les deux
+# compteurs disque restent muets (#15091) -----
+#
+# C'est le test qui manquait, et son absence a laisse passer un garde mort.
+# Le Test 11 declare une detresse ou LES QUATRE termes sont vrais : il passait
+# aussi bien avant qu'apres, parce qu'il ne pouvait pas distinguer « la
+# conjonction fonctionne » de « la conjonction n'est jamais evaluee ».
+#
+# La signature reelle d'ai-01, mesuree le 2026-09-08T00:14Z : file d'attente
+# disque a 0 et disque a 92-99 % d'inactivite MEME sous 320 Mo d'ecriture
+# write-through. Avec les termes `q >= 1` et `id <= 50` dans la conjonction,
+# une machine qui pagine franchement (pagewrites ET pagesout soutenus sur les
+# deux points) etait declaree SAINE. Ce test rougit sur l'ancienne version.
+echo "Test 11b : detresse retenue meme avec file=0 et disque inactif (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-11b"
+  # pagewrites>0 ET pagesout>0 sur les deux points -- mais file=0 et idle=99,
+  # les valeurs que ces deux compteurs rendent TOUJOURS sur cet hote.
+  export COURSIA_RUNNER_HOST_PROBE="140 520 0 99 96000 50000"
+  export COURSIA_RUNNER_HOST_PROBE_2="155 610 0 98 97000 49900"
+  rc="$(run_supervise 'start 1' 'test-prefix-11b' "$TEST_DIR/state-11b" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "DETRESSE SOUTENUE"; then
+    if echo "$err" | grep -q "cote disque MUET"; then
+      ok "detresse retenue sans les compteurs disque, et le silence est dit (rc=$rc)"
+    else
+      ko "detresse retenue mais le silence des compteurs disque n'est pas signale, err=$err"
+    fi
+  else
+    ko "GARDE MORT : pagination soutenue declaree saine parce que file=0, rc=$rc err=$err"
+  fi
+  unset COURSIA_RUNNER_HOST_PROBE_2
+)
+echo ""
+
+# --- Test 12 : un SEUL point en detresse ne suffit pas (#15091) -----
+#
+# Le faux positif que Maintenance a elle-meme produit le 2026-09-07T22:53Z (un
+# pic isole a 293 lectures/s, latence 0, file 0) est exactement ce qu'un
+# echantillon unique ne sait pas ecarter. « Soutenu » veut dire deux points.
+echo "Test 12 : un pic isole ne declenche pas le refus (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-12"
+  export COURSIA_RUNNER_HOST_PROBE="120 340 3 12 90000 50000"
+  export COURSIA_RUNNER_HOST_PROBE_2="0 0 0 97 40000 50000"
+  rc="$(run_supervise 'start 1' 'test-prefix-12' "$TEST_DIR/state-12" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if ! echo "$err" | grep -q "DETRESSE"; then
+    ok "pic isole non retenu comme detresse (rc=$rc)"
+  else
+    ko "faux positif : un seul point a fait rougir le garde, err=$err"
+  fi
+  unset COURSIA_RUNNER_HOST_PROBE_2
+)
+echo ""
+
+# --- Test 13 : chute de Mapped -- critere d'abandon qdrant (#15091) -----
+echo "Test 13 : start refuse quand Mapped chute au-dela du seuil (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-13"
+  # Machine par ailleurs calme : seul le mmap qdrant se fait evincer (-2000 Mo).
+  export COURSIA_RUNNER_HOST_PROBE="0 0 0 95 40000 52000"
+  export COURSIA_RUNNER_HOST_PROBE_2="0 0 0 95 40000 50000"
+  rc="$(run_supervise 'start 1' 'test-prefix-13' "$TEST_DIR/state-13" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "Mapped"; then
+    ok "eviction du mmap qdrant refusee (rc=$rc)"
+  else
+    ko "refus attendu sur chute de Mapped, rc=$rc err=$err"
+  fi
+  unset COURSIA_RUNNER_HOST_PROBE_2
+)
+echo ""
+
+# --- Test 14 : sonde injoignable -- fail-CLOSED (#15091) -----
+#
+# Le controle qui manquait a la version precedente : une sonde muette doit
+# couter un REFUS. Si la panne de mesure etait le chemin le plus permissif,
+# il suffirait de casser la sonde pour desarmer le garde.
+echo "Test 14 : sonde injoignable = refus, jamais un vert par defaut (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-14" "$TEST_DIR/bin14"
+  # Stub powershell.exe muet, en tete de PATH : la sonde ne rend rien.
+  printf '#!/usr/bin/env bash
+exit 1
+' > "$TEST_DIR/bin14/powershell.exe"
+  chmod +x "$TEST_DIR/bin14/powershell.exe"
+  export PATH="$TEST_DIR/bin14:$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-14"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-14"
+  unset COURSIA_RUNNER_HOST_PROBE
+  unset COURSIA_RUNNER_HOST_PROBE_2
+  timeout --kill-after=1 5 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/last.err"
+  rc=$?
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "NON MESURABLE"; then
+    ok "sonde injoignable : refus fail-closed (rc=$rc)"
+  else
+    ko "refus attendu sur sonde injoignable, rc=$rc err=$err"
+  fi
+)
+echo ""
+
+# --- Test 15 : variable RETIREE -- avertissement bruyant (#15091) -----
+#
+# Les deux seuils precedents (free reel, % de commit) ont ete retires par leur
+# auteur. Un operateur qui les positionne encore doit l'APPRENDRE, pas croire
+# qu'il gouverne un garde qui ne les lit plus.
+echo "Test 15 : une variable retiree produit un avertissement (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-15"
+  export COURSIA_RUNNER_HOST_FREE_FLOOR_GB=8
+  run_supervise 'status' 'test-prefix-15' "$TEST_DIR/state-15" >/dev/null 2>&1
+  err="$(cat "$TEST_DIR/last.err")"
+  if echo "$err" | grep -q "RETIREE"; then
+    ok "variable retiree signalee a l'operateur"
+  else
+    ko "aucun avertissement sur variable retiree, err=$err"
+  fi
+  unset COURSIA_RUNNER_HOST_FREE_FLOOR_GB
+)
+echo ""
+
+# --- Test 16 : sonde TRONQUEE -- refus, pas un vert silencieux (#15091) -----
+#
+# Le controle qui manquait a la version precedente du garde, sous une autre
+# forme. Une sonde qui rend CINQ champs au lieu de six laisse `mapped` vide :
+# le test arithmetique echoue en silence, la conjonction de detresse ne se
+# declenche pas non plus, et la fonction tombe sur son chemin sain. Le garde
+# serait alors VERT PAR MANQUE DE MESURE -- indiscernable d'un garde debranche.
+echo "Test 16 : une sonde tronquee refuse au lieu de rendre vert (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-16"
+  export COURSIA_RUNNER_HOST_PROBE="0 0 0 95 40000"
+  rc="$(run_supervise 'start 1' 'test-prefix-16' "$TEST_DIR/state-16" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "ILLISIBLE"; then
+    ok "sonde tronquee refusee (rc=$rc)"
+  else
+    ko "refus attendu sur sonde tronquee, rc=$rc err=$err"
+  fi
+)
+echo ""
+
+# --- Test 17 : CONTROLE POSITIF -- slice plafonnee = mur annonce actif -----
+#
+# Le defaut repare ici : la slice existait, portait bien MemoryHigh 12 Gio et
+# MemoryMax 16 Gio, et AUCUN conteneur n'y entrait -- le `docker run` n'avait
+# pas de `--cgroup-parent`. Mesure ai-01 2026-09-08T00:56Z : memory.peak
+# rendait 0 pendant que deux conteneurs CI consommaient 198 Mio dehors. Le
+# mur agrege etait decoratif, et son propre instrument de pic le confirmait
+# en disant « aucune charge n'a jamais tourne » -- ce qui etait vrai de la
+# slice, et faux de la CI.
+echo "Test 17 : slice plafonnee -> le mur est annonce ACTIF (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-17" "$TEST_DIR/slice-ok"
+  echo "17179869184" > "$TEST_DIR/slice-ok/memory.max"
+  echo "12884901888" > "$TEST_DIR/slice-ok/memory.high"
+  export COURSIA_CI_SLICE_PATH="$TEST_DIR/slice-ok"
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-17"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-17"
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" start 1 >"$TEST_DIR/out-17.log" 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  wait_until 4000 grep -q "slots lances" "$TEST_DIR/out-17.log"
+  if grep -q "mur agrege ACTIF" "$TEST_DIR/out-17.log" && grep -q "slots lances" "$TEST_DIR/out-17.log"; then
+    ok "slice plafonnee : mur actif, slots lances"
+  else
+    ko "attendu 'mur agrege ACTIF' + demarrage, out=$(cat "$TEST_DIR/out-17.log") err=$(cat "$TEST_DIR/last.err")"
+  fi
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
+)
+echo ""
+
+# --- Test 18 : sentinelle perimee (aucun superviseur) -> purge -----
+#
+# Le cas du reboot, qui est la raison d'etre de #15163. Le sentinel est un
+# FICHIER : il survit a l'extinction de la machine. Au demarrage suivant plus
+# aucun superviseur ne peut "reprendre", donc il n'y a plus rien a proteger --
+# et le refus inconditionnel ne faisait que garder le pool a zero.
+echo "Test 18 : sentinelle sans superviseur vivant -> purgee, le start procede (#15163)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-20"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-20"
+  mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+  touch "$COURSIA_RUNNER_STATE_DIR/stop"
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  if wait_until 4000 test ! -f "$COURSIA_RUNNER_STATE_DIR/stop"; then
+    ok "sentinelle perimee purgee, sans --force"
+  else
+    ko "sentinelle aurait du etre purgee (aucun superviseur vivant)"
+  fi
+  err="$(cat "$TEST_DIR/last.err")"
+  if echo "$err" | grep -q "perimee"; then
+    ok "la purge est tracee en clair sur stderr"
+  else
+    ko "la purge aurait du etre tracee sur stderr, err=$err"
+  fi
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
+)
+echo ""
+
+# --- Test 19 : jeton non-numerique ne fabrique pas un superviseur -----
+#
+# Controle NEGATIF du scan de processus. Une ligne `ps -ef` a colonnes glissees
+# met un jeton non-numerique en $2 ; sans le filtre `$2 ~ /^[0-9]+$/`, il est
+# rendu comme un PID et la porte refuse au nom d'un superviseur qui n'existe
+# pas. Le PPID du stub est != 1 pour que `supervisor_pids` laisse passer et que
+# ce soit bien `any_supervisor_alive` qui soit mesure ici.
+echo "Test 19 : ligne ps a colonnes decalees -> aucun faux superviseur (#15163)"
+(
+  cd "$SCRIPT_DIR"
+  export PS_OUTPUT="jsboige  -c  9876  10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh start 4"
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-21"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-21"
+  mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+  touch "$COURSIA_RUNNER_STATE_DIR/stop"
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  if wait_until 4000 test ! -f "$COURSIA_RUNNER_STATE_DIR/stop"; then
+    ok "le jeton non-numerique n'a pas fabrique de superviseur"
+  else
+    ko "purge attendue : '-c' n'est pas un PID"
+  fi
+  err="$(cat "$TEST_DIR/last.err")"
+  if echo "$err" | grep -q "PID -c"; then
+    ko "un jeton non-numerique a ete rendu comme PID, err=$err"
+  else
+    ok "aucun PID non-numerique dans le diagnostic"
+  fi
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
+  unset PS_OUTPUT
+)
+echo ""
+
+# --- Test 20 : la porte couvre aussi la famille waiters -----
+#
+# Le wedge etait porte par TROIS sites (`start`, `waiters`, `lean`) ; corriger
+# `start` seul aurait laisse le pool d'attente bloque au reboot. La porte est
+# appelee avant `assert_memory_budget`, donc la purge est observable meme si la
+# suite refuse pour une autre raison.
+echo "Test 20 : la porte a sentinelle couvre aussi waiters (#15163)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  export PATH="$TEST_DIR/bin:$PATH"
+  export COURSIA_RUNNER_NAME_PREFIX="test-prefix-22"
+  export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-22"
+  mkdir -p "$COURSIA_RUNNER_STATE_DIR"
+  touch "$COURSIA_RUNNER_STATE_DIR/stop"
+  timeout --kill-after=1 8 bash "$SCRIPT_DIR/supervise.sh" waiters 1 >/dev/null 2>"$TEST_DIR/last.err" &
+  TPID=$!
+  if wait_until 4000 test ! -f "$COURSIA_RUNNER_STATE_DIR/stop"; then
+    ok "sentinelle perimee purgee aussi sur waiters"
+  else
+    ko "waiters aurait du purger la sentinelle perimee"
+  fi
+  kill_test_supervisor "$TPID" "$COURSIA_RUNNER_STATE_DIR"
 )
 echo ""
 
@@ -396,14 +777,15 @@ source_supervise() {
   export PATH="$TEST_DIR/bin:$PATH"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-G"
   unset COURSIA_RUNNER_CGROUP_PARENT COURSIA_RUNNER_REQUIRE_CGROUP_BUDGET
+  unset COURSIA_REQUIRE_CI_SLICE COURSIA_CI_SLICE_PATH
   unset COURSIA_RUNNER_DEVICE_WRITE_BPS COURSIA_RUNNER_DEVICE_READ_BPS
   unset COURSIA_RUNNER_BLKIO_DEVICE COURSIA_RUNNER_CPU_BUDGET
   # shellcheck disable=SC1090
   . "$SCRIPT_DIR/supervise.sh" status >/dev/null 2>&1
 }
 
-# --- Test 11 : daemon Docker indisponible -> start refuse AVANT tout (#15095)
-echo "Test 11 : start refuse si docker info echoue, avant gh et avant docker run"
+# --- Test 21 : daemon Docker indisponible -> start refuse AVANT tout (#15095)
+echo "Test 21 : start refuse si docker info echoue, avant gh et avant docker run"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -450,8 +832,8 @@ STUB
 )
 echo ""
 
-# --- Test 12 : cycles courts -> backoff exponentiel plafonne, rc-agnostique
-echo "Test 12 : backoff exponentiel 3,6,12,24... plafonne 24, identique rc=0 et rc!=0"
+# --- Test 22 : cycles courts -> backoff exponentiel plafonne, rc-agnostique
+echo "Test 22 : backoff exponentiel 3,6,12,24... plafonne 24, identique rc=0 et rc!=0"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -529,10 +911,10 @@ STUB
 )
 echo ""
 
-# --- Test 13 : plafond BACKOFF_CAP effectif (queue du test 12) -------------
-echo "Test 13 : le plafond CAP borne la file (entries 4+ toutes = CAP)"
+# --- Test 23 : plafond BACKOFF_CAP effectif (queue du test 22) -------------
+echo "Test 23 : le plafond CAP borne la file (entries 4+ toutes = CAP)"
 (
-  # Derive direct du test 12 : avec BASE=3/CAP=24, les cycles 4 a 8 valent
+  # Derive direct du test 22 : avec BASE=3/CAP=24, les cycles 4 a 8 valent
   # tous 24 -- 5 valeurs consecutives egales au cap prouvent le clamp sans
   # avoir besoin d'attendre 15*2^N secondes avec les vrais defauts.
   if [ "$(tail -5 "$TEST_DIR/sleep12.log" | sort -u)" = "24" ]; then
@@ -543,8 +925,8 @@ echo "Test 13 : le plafond CAP borne la file (entries 4+ toutes = CAP)"
 )
 echo ""
 
-# --- Test 14 : un cycle sain remet le compteur de backoff a zero -----------
-echo "Test 14 : cycle ayant vecu >= HEALTHY_CYCLE_SECS -> reset + sleep 2"
+# --- Test 24 : un cycle sain remet le compteur de backoff a zero -----------
+echo "Test 24 : cycle ayant vecu >= HEALTHY_CYCLE_SECS -> reset + sleep 2"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -617,8 +999,8 @@ STUB
 )
 echo ""
 
-# --- Test 15 : persist/ -- unit systemd fail-closed + garde wrapper ---------
-echo "Test 15 : checks textuels persist/ (unit systemd + wrapper) et bash -n"
+# --- Test 25 : persist/ -- unit systemd fail-closed + garde wrapper ---------
+echo "Test 25 : checks textuels persist/ (unit systemd + wrapper) et bash -n"
 (
   cd "$SCRIPT_DIR"
   svc="$SCRIPT_DIR/persist/coursia-runner.service"
@@ -642,8 +1024,8 @@ echo "Test 15 : checks textuels persist/ (unit systemd + wrapper) et bash -n"
   fi
 )
 echo ""
-# --- Test 16 : backoff exponentiel, plafonne, jitter borne -----------------
-echo "Test 16 : backoff exponentiel plafonne et disperse (#15091)"
+# --- Test 26 : backoff exponentiel, plafonne, jitter borne -----------------
+echo "Test 26 : backoff exponentiel plafonne et disperse (#15091)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -677,8 +1059,8 @@ echo "Test 16 : backoff exponentiel plafonne et disperse (#15091)"
 )
 echo ""
 
-# --- Test 17 : budget CPU inter-familles -- REFUS au depassement -----------
-echo "Test 17 : budget CPU inter-familles refuse le depassement (#15091, trou #14337)"
+# --- Test 27 : budget CPU inter-familles -- REFUS au depassement -----------
+echo "Test 27 : budget CPU inter-familles refuse le depassement (#15091, trou #14337)"
 (
   cd "$SCRIPT_DIR"
   # 12 waiters a 1 vCPU deja actifs ; on demande 2 slots lean a 6 vCPU.
@@ -702,8 +1084,8 @@ echo "Test 17 : budget CPU inter-familles refuse le depassement (#15091, trou #1
 )
 echo ""
 
-# --- Test 18 : controle negatif -- le budget n'accuse pas a tort -----------
-echo "Test 18 : budget CPU -- controle negatif (sous le plafond, puis non arme)"
+# --- Test 28 : controle negatif -- le budget n'accuse pas a tort -----------
+echo "Test 28 : budget CPU -- controle negatif (sous le plafond, puis non arme)"
 (
   cd "$SCRIPT_DIR"
   export PS_OUTPUT="jsboige  4242     1   10:28:11  bash scripts/ci/docker/linux-runner/supervise.sh waiters 4"
@@ -726,8 +1108,8 @@ echo "Test 18 : budget CPU -- controle negatif (sous le plafond, puis non arme)"
 )
 echo ""
 
-# --- Test 19 : borne agregee -- REFUS fail-closed quand elle manque --------
-echo "Test 19 : slice absente -- refus fail-closed et commande de deploiement (#15091)"
+# --- Test 29 : borne agregee -- REFUS fail-closed quand elle manque --------
+echo "Test 29 : slice absente -- refus fail-closed et commande de deploiement (#15091)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -758,8 +1140,97 @@ echo "Test 19 : slice absente -- refus fail-closed et commande de deploiement (#
 )
 echo ""
 
-# --- Test 20 : plafond par conteneur -- drapeaux et aveu de non-application -
-echo "Test 20 : --device-write-bps cable, et non-resolution AVOUEE (#15091)"
+# --- Test 30 : mur MEMOIRE, slice ABSENTE -> refus SOUS EXIGENCE, avertissement sinon ---
+#
+# Sous le pilote cgroupfs, `docker run --cgroup-parent <chemin absent>` CREE
+# le cgroup. Sans garde, un deploiement manquant produirait donc un cgroup
+# neuf SANS plafond : le mur ne bornerait rien, mais memory.peak monterait et
+# la slice aurait l'air cablee.
+#
+# La reponse a ce risque n'est PAS un refus inconditionnel : la slice est
+# deployee sur ai-01 SEULEMENT (persist/README.md), et un refus par defaut
+# ferait refuser de demarrer les runners de po-2024, qui ne l'ont jamais eue.
+# C'est la discipline opt-in que #15103 a posee pour assert_cgroup_budget, et
+# ce test verifie que le mur MEMOIRE la suit : refus si COURSIA_REQUIRE_CI_SLICE=1,
+# sinon avertissement + CI_CGROUP_PARENT vide (donc pas de --cgroup-parent
+# passe a docker, donc aucun cgroup fabrique).
+echo "Test 30 : slice absente -> refus sous exigence, avertissement sinon (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  source_supervise
+  CI_SLICE_PATH="$TEST_DIR/slice-nexiste-pas-$$"
+  CI_CGROUP_PARENT="fantome.slice"
+  REQUIRE_CI_SLICE=1
+  err="$( (assert_ci_slice) 2>&1 )"; rc=$?
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "REFUS de demarrer"; then
+    ok "slice absente sous exigence : demarrage refuse (rc=$rc)"
+  else
+    ko "refus attendu sur slice absente sous exigence, rc=$rc err=$err"
+  fi
+  if echo "$err" | grep -q "persist/coursia-ci.slice"      && echo "$err" | grep -q "systemctl daemon-reload"; then
+    ok "le refus porte la commande de deploiement"
+  else
+    ko "commande de deploiement attendue dans le message, err=$err"
+  fi
+  # Sans exigence : la machine sans slice demarre, mais NON placee.
+  REQUIRE_CI_SLICE=0
+  CI_CGROUP_PARENT="fantome.slice"
+  # Appel NU (pas de $(...)) : c est la forme des vrais sites d appel, et la
+  # seule ou l effet de bord CI_CGROUP_PARENT="" atteint le shell appelant.
+  assert_ci_slice > "$TEST_DIR/slice-warn.out" 2>&1; rc=$?
+  err="$(cat "$TEST_DIR/slice-warn.out")"
+  if [ "$rc" = "0" ] && echo "$err" | grep -q "NON ACTIF"; then
+    ok "sans exigence : avertit et laisse passer (aucun defaut impose)"
+  else
+    ko "avertissement non bloquant attendu, rc=$rc err=$err"
+  fi
+  if [ -z "$CI_CGROUP_PARENT" ]; then
+    ok "placement neutralise : --cgroup-parent ne sera pas passe"
+  else
+    ko "CI_CGROUP_PARENT devait etre vide, vaut '$CI_CGROUP_PARENT'"
+  fi
+)
+echo ""
+
+# --- Test 31 : mur MEMOIRE, slice presente mais SANS plafond -> meme discipline ---------
+#
+# Le cas que `slice_read` ne peut pas distinguer : il ne rend que des chiffres,
+# donc il rend "" pour un fichier illisible ET pour la valeur litterale `max`.
+# Ces deux cas commandent des actions opposees. C'est pour ce cas precis que
+# `slice_read_raw` existe -- un cgroup sans plafond est present, lisible, et
+# ne borne rien. Meme opt-in que le Test 28 : sur ai-01 c'est un refus, sur une
+# machine qui ne deploie pas la slice c'est un avertissement.
+echo "Test 31 : slice sans plafond (memory.max=max) -> refus sous exigence (#15091)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  source_supervise
+  mkdir -p "$TEST_DIR/slice-illimitee"
+  echo "max" > "$TEST_DIR/slice-illimitee/memory.max"
+  echo "max" > "$TEST_DIR/slice-illimitee/memory.high"
+  CI_SLICE_PATH="$TEST_DIR/slice-illimitee"
+  REQUIRE_CI_SLICE=1
+  err="$( (assert_ci_slice) 2>&1 )"; rc=$?
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "SANS plafond"; then
+    ok "slice sans plafond refusee sous exigence (rc=$rc)"
+  else
+    ko "refus attendu sur memory.max=max, rc=$rc err=$err"
+  fi
+  REQUIRE_CI_SLICE=0
+  CI_CGROUP_PARENT="fantome.slice"
+  assert_ci_slice > "$TEST_DIR/slice-warn2.out" 2>&1; rc=$?
+  err="$(cat "$TEST_DIR/slice-warn2.out")"
+  if [ "$rc" = "0" ] && echo "$err" | grep -q "SANS plafond"      && echo "$err" | grep -q "NON ACTIF" && [ -z "$CI_CGROUP_PARENT" ]; then
+    ok "sans exigence : avertit, nomme la cause, et ne place pas"
+  else
+    ko "avertissement non bloquant attendu, rc=$rc err=$err parent='$CI_CGROUP_PARENT'"
+  fi
+)
+echo ""
+
+# --- Test 32 : plafond par conteneur -- drapeaux et aveu de non-application -
+echo "Test 32 : --device-write-bps cable, et non-resolution AVOUEE (#15091)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -791,8 +1262,8 @@ echo "Test 20 : --device-write-bps cable, et non-resolution AVOUEE (#15091)"
 )
 echo ""
 
-# --- Test 21 : rotation des journaux ---------------------------------------
-echo "Test 21 : rotation du journal de slot au-dela du seuil (#15091)"
+# --- Test 33 : rotation des journaux ---------------------------------------
+echo "Test 33 : rotation du journal de slot au-dela du seuil (#15091)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -825,8 +1296,8 @@ echo "Test 21 : rotation du journal de slot au-dela du seuil (#15091)"
 )
 echo ""
 
-# --- Test 22 : le toolcache des waiters atteint reellement docker run ------
-echo "Test 22 : waiters -- toolcache monte, et JAMAIS de volume _work (#15091)"
+# --- Test 34 : le toolcache des waiters atteint reellement docker run ------
+echo "Test 34 : waiters -- toolcache monte, et JAMAIS de volume _work (#15091)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -896,8 +1367,8 @@ STUB
 )
 echo ""
 
-# --- Test 23 : recensement inter-familles distinct du garde d'idempotence --
-echo "Test 23 : supervisor_families voit les 3 familles, supervisor_pids seulement start"
+# --- Test 35 : recensement inter-familles distinct du garde d'idempotence --
+echo "Test 35 : supervisor_families voit les 3 familles, supervisor_pids seulement start"
 (
   cd "$SCRIPT_DIR"
   export PS_OUTPUT="jsboige  111    1   10:00:00  bash scripts/ci/docker/linux-runner/supervise.sh start 8
@@ -928,7 +1399,7 @@ jsboige  444  111   10:00:00  bash scripts/ci/docker/linux-runner/supervise.sh s
 )
 echo ""
 
-# --- Test 24 : l'arret gracieux ne peut plus annoncer un succes inerte ------
+# --- Test 36 : l'arret gracieux ne peut plus annoncer un succes inerte ------
 # Defaut #15091 mesure sur ai-01 : cmd_stop rendait 0 quoi qu'il arrive. Le
 # script tourne sous `set -uo pipefail` SANS `-e`, donc l'echec du `touch`
 # n'interrompait rien et le code de retour etait celui du dernier `echo`. Un
@@ -940,7 +1411,7 @@ echo ""
 # le parent est un FICHIER ordinaire echoue (ENOTDIR) sur toutes les
 # plateformes, y compris MSYS -- la ou un test par permissions serait muet
 # sous Windows.
-echo "Test 24 : cmd_stop rend != 0 quand le sentinel n'a PAS pu etre pose (#15091)"
+echo "Test 36 : cmd_stop rend != 0 quand le sentinel n'a PAS pu etre pose (#15091)"
 (
   cd "$SCRIPT_DIR"
   source_supervise
@@ -988,8 +1459,8 @@ echo "Test 24 : cmd_stop rend != 0 quand le sentinel n'a PAS pu etre pose (#1509
 )
 echo ""
 
-# --- Test 25 : saturation >65 cycles -- l'exponentiel ne deborde plus -------
-echo "Test 25 : 70 cycles courts consecutifs -- plafond tenu jusqu'au bout, jamais negatif ni nul (review #15166)"
+# --- Test 37 : saturation >65 cycles -- l'exponentiel ne deborde plus -------
+echo "Test 37 : 70 cycles courts consecutifs -- plafond tenu jusqu'au bout, jamais negatif ni nul (review #15166)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -1063,8 +1534,8 @@ STUB
 )
 echo ""
 
-# --- Test 26 : controle positif -- cycle court AVEC travail reel ------------
-echo "Test 26 : cycle court portant une execution de job -> pas de backoff, compteur remis a zero (review #15166)"
+# --- Test 38 : controle positif -- cycle court AVEC travail reel ------------
+echo "Test 38 : cycle court portant une execution de job -> pas de backoff, compteur remis a zero (review #15166)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -1136,8 +1607,8 @@ STUB
 )
 echo ""
 
-# --- Test 27 : cycle long rc!=0 n'est PAS automatiquement sain --------------
-echo "Test 27 : cycle vecu mais rc!=0 -> non qualifie sain, compteur conserve (review #15166)"
+# --- Test 39 : cycle long rc!=0 n'est PAS automatiquement sain --------------
+echo "Test 39 : cycle vecu mais rc!=0 -> non qualifie sain, compteur conserve (review #15166)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -1219,8 +1690,8 @@ STUB
 )
 echo ""
 
-# --- Test 28 : grand log de cycle -- grep -q tuait tail en SIGPIPE (#15166) --
-echo "Test 28 : cycle court AVEC travail sur un log de cycle >64 Ko -- le travail est reconnu malgre le volume (review #15166)"
+# --- Test 40 : grand log de cycle -- grep -q tuait tail en SIGPIPE (#15166) --
+echo "Test 40 : cycle court AVEC travail sur un log de cycle >64 Ko -- le travail est reconnu malgre le volume (review #15166)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -1301,12 +1772,12 @@ STUB
 )
 echo ""
 
-# --- Test 29 : garde de fraicheur -- health script perime refuse (#15105) ---
+# --- Test 41 : garde de fraicheur -- health script perime refuse (#15105) ---
 # Le garde lit DEUX fichiers depuis #15105 (work_cache_health.sh est source
 # par l'entrypoint). Le controle positif du COTE garde : un ecart sur le
 # SEUL fichier ajoute doit refuser exactement comme un ecart d'entrypoint --
 # sinon la porte que le nouveau fichier ouvre serait garde par personne.
-echo "Test 29 : start refuse si work_cache_health.sh de l'image != checkout (#15105)"
+echo "Test 41 : start refuse si work_cache_health.sh de l'image != checkout (#15105)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -1324,13 +1795,13 @@ echo "Test 29 : start refuse si work_cache_health.sh de l'image != checkout (#15
 )
 echo ""
 
-# --- Test 30 : validation fail-closed des 3 bornes env (review #15166 v2) ---
+# --- Test 42 : validation fail-closed des 3 bornes env (review #15166 v2) ---
 # Une config operateur invalide doit tuer le start AVANT toute boucle :
 # BASE=0 bouclait sur un backoff nul sans fin, et BASE/CAP proches de la
 # borne signee faisaient deborder le probe de cap_exp vers le negatif puis 0.
 # Chaque cas : rc!=0 (et !=124 : pas un timeout = pas de boucle), message
 # nommant la variable fautive.
-echo "Test 30 : bornes backoff invalides rejetees au demarrage (fail-closed)"
+echo "Test 42 : bornes backoff invalides rejetees au demarrage (fail-closed)"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT
@@ -1359,13 +1830,13 @@ echo "Test 30 : bornes backoff invalides rejetees au demarrage (fail-closed)"
 )
 echo ""
 
-# --- Test 31 : frontiere puissance de deux -- le doublement garde (v2) -----
+# --- Test 43 : frontiere puissance de deux -- le doublement garde (v2) -----
 # Repro review : BASE proche de la borne signee + CAP au-dela debordait le
 # probe (p=2^63 -> -2^63 -> 0 -> boucle infinie). Config valide limite : la
 # plus grande puissance de deux du domaine (2^59, 18 chiffres) en BASE=CAP.
 # Le backoff doit terminer (rc=0, pas de timeout) et rendre exactement la
 # borne, jamais un negatif ni un zero.
-echo "Test 31 : BASE=CAP=2^59 -- frontiere puissance de deux, pas de debordement"
+echo "Test 43 : BASE=CAP=2^59 -- frontiere puissance de deux, pas de debordement"
 (
   cd "$SCRIPT_DIR"
   unset PS_OUTPUT


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/tooling #15103

## Seconde correction — le garde lisait 85 Go de marge la ou il y en avait 235 Mo

Ajoutee apres coup, et elle **retracte un commit de cette PR meme** (`0ceed645a`, corrige par `725f8cd0c`).

J'avais change `host_free_gb()` de `FreePhysicalMemory` vers `AvailableMBytes`, en affirmant que le premier mesure les pages **libres** et le second les **libres + standby**. **Les deux rendent le meme nombre.** Ma « correction » remplacait un compteur par son synonyme.

Le controle que je n'avais pas fait — separer les **trois** compteurs au lieu d'en comparer deux (ai-01, 2026-09-07 22:44Z) :

| Compteur | Valeur | Ce que c'est |
|---|---:|---|
| `FreeAndZeroPageListBytes` | **0,23 Go** | les vraies pages libres |
| `StandbyCache*` (3 champs) | 84,0 Go | pages **rabotees** d'un working set vivant |
| `AvailableMBytes` | 85 Go | free + standby |
| `FreePhysicalMemory` | **85 Go** | **identique a Available**, pas au free |

J'avais justifie le changement sur une mesure ou les deux valaient 11,3 Go, en la qualifiant de « coincidence d'un cas pathologique ». Ils valent aussi tous deux 85. Deux coincidences aux deux extremites ne s'expliquent pas deux fois par la pathologie.

**Pourquoi ca compte ici** : les deux seuls appelants de cette fonction **autorisent une charge** (plancher de demarrage, et le `auto` de `budget_slots`). Or le standby n'est de la marge que si personne ne le reclame — ici il appartient a `vmmemWSL`, qui le refaute des qu'elle touche la page. Contrefactuel, machine dans l'etat du commit :

```
ancien garde   (FreePhysicalMemory) : 85 Go >= plancher 32 -> AUTORISE
commit 0ceed645a  (AvailableMBytes) : 85 Go >= plancher 32 -> AUTORISE
commit 725f8cd0c     (free reel)    :  0 Go <  plancher  8 -> REFUSE
```

C'est le faux vert exact qui autorise 12 Go de conteneurs et declenche la tempete de refaute que le garde existait pour empecher.

**Le piege symetrique, evite** : le plancher passe de 32 a **8 Go**. Garder 32 contre le free reel — ~30x la grandeur — aurait rendu le garde rouge **en permanence, machine saine comprise** : Windows garde toujours le free bas et remplit le standby, c'est son fonctionnement nominal. Changer le compteur sans changer le seuil remplace un faux vert par un faux rouge.

Le garde porte donc desormais **deux conditions independantes** : free reel >= 8 Go **et** commit systeme <= 78 %. Le free dit ce qu'on peut prendre maintenant, le commit ce que le systeme peut encore **promettre** ; ici free 0 % et commit 77 % — elles se franchissent separement. Les refus affichent les trois nombres, standby explicitement **non compte**, avec ce qu'un garde free+standby aurait lu a leur place.

Controles : nominal -> REFUS ; `auto` -> 0 slot ; plancher force a 50 Go -> passe ; 50 Go libres mais commit 90 % -> REFUS sur le commit ; contrefactuel ci-dessus mesure dans le meme etat machine.

## Instrumentation de pic — `BUDGET_GB` cesse d'etre une hypothese

`supervise.sh peak` lit `memory.peak` de la slice CI (high-water mark cgroup v2) et le compare au budget declare. A l'instant l'outil dit de lui-meme :

```
memory.peak ......... 0.00 Gio
-- pic a 0 : aucune charge n'a jamais tourne dans cette slice depuis sa
   creation. Le budget de 12 Go reste une HYPOTHESE non verifiee.
```

C'est le point : ce fichier accuse l'hypothese non mesuree d'avoir coute quatre redemarrages, et son propre budget n'avait jamais ete confronte a une consommation. `memory.peak` est en **lecture seule avant le noyau 6.9** (ai-01 est en 6.6.87.2, ecriture refusee) : repartir d'un pic vierge exige de **recreer la slice**, pas d'esperer un reset. C'est documente sur place.

Trois controles : slice absente -> « ILLISIBLE », jamais « pic nul » (un zero de mesure ratee doit rester discernable d'un vrai zero) ; distro WSL introuvable -> sortie propre (`wsl.exe` repond en UTF-16LE, les octets nuls remontaient sur stdout) ; slice ayant reellement tourne -> pic non nul compare au budget.

## Ce que le budget ne borne PAS — consigne, non modifie

`--memory-swap 24g` avec `LEAN_MEMORY=6g` fait **18 Go de swap par slot**, pas 16 : le commentaire annoncait « 8g + 16g » depuis un abaissement de cap non suivi. Et `assert_memory_budget` somme les `--memory` seuls — deux slots lean = 12 Go comptes, **jusqu'a 36 Go de swap non comptes**, sur le NVMe qui porte le pagefile. Aucun cap n'est modifie par cette PR : l'arbitrage appartient a Maintenance.

## Correction en tete de PR -- mon attribution initiale etait fausse

Cette PR a d'abord ete ouverte en attribuant **~81 Go** d'empreinte a mon superviseur. **Ce chiffre etait confondu, et je le retire.** La correction vient d'une mesure prise apres coup, et d'une mesure d'une autre lane (Maintenance ai-01) qui la contredisait.

| # | Etat | Windows libre | Ma flotte CI | Docker |
|---|---|---:|---|---|
| A | ce matin | 39,3 Go | **armee** | up (48 conteneurs) |
| B | pendant ce cycle | 120,6 Go | a l'arret | **DOWN** (0 conteneur) |
| C | maintenant | **29,1 Go** | a l'arret | up (48 conteneurs) |

J'avais lu le delta **A -> B = 81 Go** comme l'empreinte de mes runners. **Deux variables changeaient en meme temps** : ma flotte *et* Docker en entier. Le couple qui isole vraiment quelque chose est **B -> C**, ou seul Docker change : ~91 Go, **ma flotte etant a zero conteneur dans les deux etats**. Ces 91 Go ne me sont donc pas imputables.

Le controle qui tranche est **C** : ma flotte est a **0 conteneur** et la machine est a **29,1 Go libres** -- soit *moins* qu'en A, ou elle tournait. Et les 48 conteneurs presents **utilisent 24,3 Go** au total (`docker stats`), pas 100 et quelques.

**Je n'ai donc aucune mesure propre de l'empreinte marginale de ma flotte.** Dire qu'elle a cause les quatre montees au grenier n'est pas soutenu par mes chiffres. Le poids reel est ailleurs, et c'est Maintenance qui l'a mesure : retention memoire de la VM WSL2 (qui ne rend pas l'invite libere sans `autoMemoryReclaim=gradual`), plus **69 Go** de commit prive node/MCP cote Windows, contre un `memory=128GB` -- soit **197 Go demandes sur 191,8 Go physiques**. Cette arithmetique-la est un `[ASK]` user ouvert par Maintenance, et elle n'est pas la mienne a trancher.

## Ce qui reste vrai, et pourquoi cette PR tient quand meme

La correction porte sur **l'ampleur du blame**, pas sur l'existence du defaut. Restent etablis, independamment de toute attribution :

1. **Le superviseur se dimensionnait contre le plafond de la VM, jamais contre la disponibilite de l'hote.** `MemAvailable` dans la VM annoncait 112,7 Go de large pendant que l'hote etait tendu. Une logique qui lit `/proc/meminfo` depuis l'interieur sur-engage **par construction** -- ce defaut ne depend d'aucune mesure d'incident.
2. **La sur-declaration etait reelle** : `8x4g + 12x1g = 44 Go` de capacite declaree, sur une machine ou les **48** autres conteneurs consomment 24,3 Go ensemble. Meme sans etre la cause de l'incident, armer cela sans plafond agrege est imprudent.
3. **Le swap n'etait borne nulle part** : un slot Lean a `--memory-swap 24g` ecrit dans un **fichier sur le disque Windows** -- exactement le chemin qui fait tomber GDrive.
4. **`coursia-ci.slice` n'etait dans aucun depot** : `git ls-files` ne rendait rien. Le fichier qui plafonne la flotte entiere n'existait que deploye sur ai-01. C'est un defaut en soi.
5. **35 des 48 conteneurs n'ont aucun `--memory`, et 13 en declarent 110 Go a eux seuls.** Cette PR ne corrige pas cela -- elle borne seulement **ma** part. Le reste est un sujet de flotte, a ouvrir separement.

## Pourquoi `--memory` ne suffisait pas — trois trous

1. **`--memory` borne UN conteneur, jamais la somme des familles.** Les prefixes de nom `start` / `waiters` / `lean` etant distincts, la garde d'idempotence par PPID est **aveugle entre familles** : `8x4g + 12x1g = 44 Go` declares, pour ~70 Go observes.
2. **Le page cache est impute au cgroup fautif** en cgroup v2. L'organe est donc `MemoryHigh` (pression de recuperation), pas `MemoryMax` (mur de kill) — un mur seul fait tuer au lieu de faire ralentir.
3. **Le swap d'un conteneur est un FICHIER sur le disque Windows.** Un seul slot Lean a `--memory-swap 24g` peut y pousser 16 Go — c'est-a-dire exactement le geste qui fait tomber GDrive.

## Le correctif — quatre couches, chacune rattrapant une defaillance differente

| Couche | Ce qu'elle tient | Etat |
|---|---|---|
| `.wslconfig memory=` | plafond de la VM, impose par Windows | **non touche** — appartient a Maintenance |
| `coursia-ci.slice` | mur noyau, tient meme si le script a tort | **ajoute par cette PR** |
| `--memory` par conteneur | borne unitaire, somme desormais bornee par la couche au-dessus | abaisse |
| `assert_memory_budget` | refuse **avant** le mur, et **dit pourquoi** | ajoute |

### `coursia-ci.slice` passe sous suivi git

Le fichier qui plafonne la flotte entiere **n'etait pas dans le depot** : `git ls-files` ne rendait rien, il n'existait que deploye sur ai-01. C'est un defaut en soi, et cette PR le corrige. Il gagne au passage la ligne symetrique qui manquait a cote de `CPUQuota=800%` et `IOWriteBandwidthMax` :

```ini
MemoryAccounting=yes
MemoryHigh=12G
MemoryMax=16G
MemorySwapMax=16G
```

`*.slice` est epingle en `eol=lf` dans `.gitattributes` (2e commit) : sans cette ligne, un checkout Windows frais sous `core.autocrlf=true` rend la slice en CRLF, et un deploiement depuis ce checkout pousse `MemoryHigh=12G\r` dans systemd.

### Plafonds abaisses

| | avant | apres |
|---|---:|---:|
| `COURSIA_RUNNER_MEMORY` (start) | 4g | **3g** |
| `COURSIA_RUNNER_WAITER_MEMORY` | 1g | **512m** |
| `COURSIA_LEAN_RUNNER_MEMORY` | 8g | **6g** |
| defaut `waiters` | 24 | **8** |
| defaut `lean` | 2 | **1** |

### `LEAN_MEMORY_SWAP=24g` est CONSERVE, et borne

Il repose sur une mesure reelle : les modules Hashlife de `conway_lean` depassent 16 Go au build a froid — `exit 137` mesure sous `--memory 8g` (8716/8727 modules compiles, puis `Walls.{SE,SW,NE}` tues). Le retirer casserait un build qui marche. Il est desormais **borne** par `MemorySwapMax=16G` au niveau de la slice entiere, et le defaut lean passe de 2 slots a 1.

### La garde userspace

`assert_memory_budget` mesure **cote hote** (`powershell.exe`, joignable depuis Git Bash comme depuis l'interop WSL) et **echoue ferme** si la mesure est indisponible — avec une echappatoire explicite `COURSIA_RUNNER_HOST_FREE_GB` pour un hote pur Linux. `auto` derive N du budget residuel au lieu de le lire en argv, et une famille ne reclame jamais plus de la **moitie** du reste (sans cela, deux familles lancees par des processus distincts calculent chacune leur `auto` sur un budget qu'elles voient vide).

## Controle positif — la garde refuse exactement le geste qui a casse la machine

```
ERREUR: budget CI depasse -- REFUS.
  deja en vol ......... 0 Mo
  demande (start) .. 8 x 3g = 24576 Mo
  total ............... 24576 Mo
  budget .............. 12288 Mo (COURSIA_RUNNER_BUDGET_GB=12)
Il reste de la place pour 4 slot(s) de cette famille.
```

Branche du plancher hote, a 10 Go libres : `auto` rend **0 slot**, et `start 2` est refuse — *« hote a 10 Go libres, plancher 32 Go -- REFUS. La machine est deja tendue ; demarrer la CI maintenant la pousse dans le swap. »*

Codes de retour verifies : refus -> `rc=1`, acceptation -> `rc=0`.

`auto` ne rend plus le chiffre dangereux : **start -> 2, waiters -> 12, lean -> 1** (il rendait 24 pour les waiters avant le plafond de moitie).

Formes de cap invalides refusees proprement, sans fuite d'erreur d'arithmetique bash : `1.5g`, `3gb`, vide, `g`, `12x`, `abc`.

## Verification que les plafonds sont REELLEMENT en vigueur

`systemd-analyze verify` : `rc=0`. Apres `daemon-reload` + `systemctl start coursia-ci.slice` (qui ne demarre **aucun** processus), lecture dans `/sys/fs/cgroup/coursia.slice/coursia-ci.slice/` :

```
memory.high        12884901888    12 Gio
memory.max         17179869184    16 Gio
memory.swap.max    17179869184    16 Gio
cpu.max            800000 100000
cgroup.procs : 0
```

Ce n'est pas la lecture du fichier que j'ai ecrit : c'est ce que le noyau applique.

## Ce que cette PR ne fait PAS

- **Elle ne redemarre pas Docker.** La condition posee par le user tient : le redemarrage se fera quand plusieurs lanes l'auront invite apres concertation sur le dashboard global — pas sur ma seule parole.
- **Elle ne touche pas `.wslconfig`**, qui appartient a Maintenance et a la revue machine-globale en cours.
- **Le deploiement de la slice n'a eu lieu que sur ai-01.** Les autres machines de la flotte qui portent des runners ont besoin du meme geste ; il est desormais reproductible depuis le depot.
- **Le chemin de boot reste defectueux** et n'est pas corrige ici : la tache `-Boot` ne demarre que `coursia-runner` et jamais `coursia-waiters` ; les deux units sont `disabled` ; le verrou `ExecStop`/`ExecStart` par sentinelle rend `systemctl restart` structurellement impossible (seul `stop` -> `rm` -> `start` fonctionne). A tracker separement.

## Note de protocole

Ce grain est **META/`guard`** : il ne tient pas le plancher G-VAR-1 de contenu. C'est assume comme exception de mandat user direct — la flotte CI etait hors service et un membre de la famille du user a du redemarrer physiquement le serveur quatre fois dans la journee. Un grain de contenu reste du pour le cycle.

See #15091



---

## Correctif `6da5e6c27` — deux conjoints du garde etaient structurellement faux

Trouve en relisant mon propre code avant de proposer d'armer quoi que ce soit. **La garde que cette PR met en service ne pouvait pas se declencher.**

`host_distress_verdict()` exigeait quatre termes ENSEMBLE sur les deux echantillons : ecritures pagefile, sorties de pages, file d'attente disque `>= 1`, disque sous 50 % d'inactivite. Les deux derniers **ne se mesurent pas sur cet hote**. Controle positif passe sur ai-01 le 2026-09-08T00:14Z :

| charge | `AvgDisksecPerTransfer` | `CurrentDiskQueueLength` |
|---|---|---|
| au repos | 0,0000 s | 0 |
| 320 Mo en `FileOptions::WriteThrough`, `Flush(true)` force tous les 4 Mo | 0,0000 s | 0 |

`PercentIdleTime` reste par ailleurs a 92-99 % (8 mesures sur 105 s). Le test `q >= 1` etait donc **toujours faux**, et un seul terme structurellement faux tue la conjonction entiere : la garde tombait sur son `return 0` « hote sain » **quelle que soit la pagination**.

C'est un garde vert par manque de mesure — exactement ce que la validation des douze champs, deux ecrans plus haut dans le meme fichier, existe pour empecher. Elle ne pouvait pas l'attraper : elle verifie que les champs sont des **entiers**, pas que l'instrument est **sensible**. Un champ toujours a 0 passe une validation d'integralite sans faire de bruit.

**Correction** : les deux termes morts sont **retires** de la conjonction, pas recalibres — un seuil ne repare pas un compteur qui ne bouge pas. Le refus tient desormais aux deux jambes memoire seules, qui sont vivantes et lisent **0 sur une machine saine** (0/8 sur 105 s) : les exiger seules ne fabrique pas de refus abusif et rend la garde strictement **plus** conservatrice. File et inactivite restent relevees et affichees, en escalade — quand elles se taisent, le message le **dit**, au lieu de laisser croire a une absence de charge.

**Le controle negatif manquant est ajoute (Test 11b).** Le Test 11 existant declarait une detresse ou les quatre termes sont vrais : il passait aussi bien avant qu'apres, incapable de distinguer « la conjonction fonctionne » de « la conjonction n'est jamais evaluee ». Le nouveau test rejoue la signature mesuree d'ai-01 — pagination soutenue, `file=0`, `idle=99` — et **rougit sur l'ancienne version**, verifie en remettant l'ancien `supervise.sh` en place :

```
Test 11b : detresse retenue meme avec file=0 et disque inactif (#15091)
  FAIL: GARDE MORT : pagination soutenue declaree saine parce que file=0, rc=124 err=
```

`rc=124` n'est ni un refus ni meme un verdict : c'est le superviseur **deja en train de lancer ses runners**, jusqu'a ce que le `timeout` du harnais le tue. Le degat, reproduit.

Suite complete apres correction : **20 PASS, 0 FAIL**.

**Rien n'a ete arme.** L'engagement pris sur `global` et aupres des deux lanes Maintenance tient verbatim : *rien ne sera lance avant que les deux pools puissent monter dans la meme fenetre.*


---

## Correctif `074633435` — le mur agrege que cette PR livre ne bornait RIEN

Trouve en cherchant pourquoi `peak` rendait `0`. **Le titre de cette PR — « borner la RAM de la flotte CI cote hote » — etait faux tel que deploye.**

La slice existait, le noyau appliquait bien ses plafonds (la lecture `memory.high 12884901888 / memory.max 17179869184` deux ecrans plus haut est authentique), et **aucun conteneur n'y entrait**. `docker run` n'avait pas de `--cgroup-parent`. Mesure ai-01 2026-09-08T00:56Z, pendant que deux conteneurs CI tournaient :

| dans la slice | dehors |
|---|---|
| `cgroup.procs` : **0** | 2 conteneurs CI **Up** |
| sous-groupes : **0** | |
| `memory.current` : **4096 octets** | **198 Mio** consommes |

Les plafonds s'appliquaient a un cgroup vide. Les caps par conteneur (`--memory=3g`), eux, etaient reels — ils vivent dans le cgroup que docker cree lui-meme. C'est le **plafond agrege**, la contribution centrale de cette PR, qui ne bornait rien.

**Ce que `peak` disait, et que j'ai mal lu.** Sa mise en garde — « aucune charge n'a jamais tourne dans cette slice » — etait **vraie de la slice** et **fausse de la CI**. Un zero franc, rendu par un instrument correct, pointe au mauvais endroit. Je l'avais cite dans cette PR comme un argument en sa faveur.

### Le piege qu'un cablage naif laisse ouvert

Sous le pilote `cgroupfs`, `docker run --cgroup-parent <chemin absent>` ne echoue pas : il **cree** le cgroup, **sans plafond**. Le mur ne bornerait toujours rien — mais `memory.peak` monterait, et la slice **paraitrait** branchee. **Un zero franc se rattrape ; un non-zero faux ne se rattrape pas.**

D'ou `assert_ci_slice`, appele apres les trois `assert_memory_budget` : il refuse de demarrer plutot que de laisser docker fabriquer un sosie illimite. Deux refus distincts, parce qu'ils appellent deux gestes opposes :

- slice **illisible ou absente** -> deployer `persist/coursia-ci.slice` ;
- slice presente mais `memory.max` = `max` (**illimite**) -> verifier l'unite, `daemon-reload` + `start`.

`slice_read()` ne pouvait pas porter ce garde : elle filtre sur les chiffres, donc rend `""` aussi bien pour « illisible » que pour le litteral `max`. D'ou `slice_read_raw()`.

### Ce que le cap n'est pas — un facteur 30

| | reserve | consomme |
|---|---:|---:|
| slot 1 | 3 Gio | **40,93 Mio** (1,33 %) |
| slot 2 | 3 Gio | **157,3 Mio** (5,12 %) |
| **total** | **6144 Mo** | **198 Mio** |

`assert_memory_budget` somme les **caps**, et un cap est un plafond, pas une reservation. `BUDGET_GB=12` etait declare « HYPOTHESE non verifiee » dans cette PR meme : la voici confrontee a une mesure.

### Consequences sur la suite de tests, corrigees dans le meme commit

Le garde a rendu la suite **non hermetique** : sans declaration, il lisait la vraie slice de la machine via `wsl.exe`, et aurait echoue **en bloc** sur toute machine ou elle n'est pas deployee. Une slice nominale est desormais declaree globalement, en fichiers ordinaires — meme raison et meme forme que `COURSIA_RUNNER_HOST_PROBE` juste au-dessus. Les tests 17-19 la surchargent : c'est leur objet, et leur `rc=1` le prouve.

Il a aussi fait basculer une course preexistante. Le Test 7 attendait par `sleep 1` un fetch qui vit **apres** un prelude de 680 a 924 ms — **76 ms de marge**. Les deux allers-retours `wsl.exe` du garde (~135 ms piece, mesures) suffisaient a la franchir : le test passait ou echouait selon la charge, sans rien dire du code teste. Le `sleep` constant devient `wait_until 5000` — on attend la condition, plus le chronometre.

### Tests

- **17** (controle positif) : slice plafonnee -> `mur agrege ACTIF` **et** slots lances.
- **18** : slice absente -> `rc=1`, « illisible ou absente ».
- **19** : `memory.max=max` -> `rc=1`, « SANS plafond ». C'est celui qui compte : il couvre le cas ou la slice existe et ne borne rien — l'etat exact que cette PR livrait.

**23 PASS / 0 FAIL, stable sur 3 executions consecutives.**


### Correction du « facteur 30 » ci-dessus -- il decrivait un instant, pas le systeme

Le tableau « cap vs consomme » plus haut (198 Mio pour 6144 Mo reserves) a ete mesure sur deux conteneurs **au repos ou en charge legere**. Presente ainsi, il suggere que les caps sont surdimensionnes d'un ordre de grandeur. **Sous charge reelle, c'est faux.**

Mesure ai-01 2026-09-08T01:2xZ, les deux pools armes et **8 runners `busy=true`** :

| | |
|---:|---:|
| caps declares (2x3g + 6x512m) | 9216 Mo |
| `memory.peak` de la slice | **7731 Mo** |
| ratio | **84 %** |

Le rapport entre un cap et la consommation reelle va donc de **3 % a 84 %** selon que les conteneurs travaillent. Un cap est un plafond, c'est le seul enonce qui tienne dans les deux regimes ; le « facteur 30 » n'est pas une propriete du systeme, c'est la lecture d'un creux.

Je le corrige ici plutot que de le laisser, parce que c'est exactement le defaut que cette PR reproche a son propre `BUDGET_GB` : un nombre mesure une fois et generalise. La conclusion pratique change aussi -- le budget de 12 Go n'est **pas** massivement surdimensionne, il est utilise a 63 % en pointe avec les deux pools armes, ce qui est une marge raisonnable et non une reserve gaspillee.
