### PR TITLE
fix(search): propager les domaines singleton dans PureWFC

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
@@ -110,6 +110,10 @@ class PureWFC:
         return best
 
     def solve(self) -> Optional[np.ndarray]:
+        # Singleton domains still need adjacency propagation: no collapse will
+        # trigger it when the tileset contains only one tile.
+        if self.n_tiles == 1 and not self._propagate(0, 0):
+            return None
         stack = []
         while True:
             cell = self._pick_cell()

--- a/MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
@@ -23,6 +23,7 @@ seulement l'absence de crash :
 Run with: pytest tests/test_wfc_cpsat.py -v
 """
 
+import itertools
 import json
 import sys
 from pathlib import Path
@@ -119,6 +120,35 @@ class TestGenerateRandom:
 class TestPureWFC:
     """PureWFC : solveur par propagation de contraintes. L'invariant cle est
     que toute solution respecte les regles d'adjacence."""
+
+    @pytest.mark.parametrize("rows,cols", [(1, 1), (1, 2), (2, 1), (2, 2)])
+    @pytest.mark.parametrize("compatible", [False, True])
+    def test_singleton_satisfiability(self, rows, cols, compatible):
+        """Compare to exhaustive assignments, without solver/metric helpers.
+
+        Forbidden self-adjacency makes any grid with an edge unsatisfiable;
+        an isolated cell remains valid. Allowed self-adjacency is the control.
+        """
+        rules = [[compatible]]
+        tileset = {
+            "tiles": [{"id": 0, "name": "floor"}],
+            "weights": [1.0],
+            "adjacency": {"rules": {"0": rules[0]}},
+        }
+        solutions = [
+            assignment
+            for assignment in itertools.product(range(len(rules)), repeat=rows * cols)
+            if all(
+                rules[assignment[r * cols + c]][assignment[nr * cols + nc]]
+                for r in range(rows) for c in range(cols)
+                for nr, nc in ((r + 1, c), (r, c + 1))
+                if nr < rows and nc < cols
+            )
+        ]
+        grid = PureWFC(rows, cols, tileset, seed=42).solve()
+        assert (grid is not None) == bool(solutions)
+        if grid is not None:
+            assert tuple(grid.flat) in solutions
 
     def test_returns_grid(self, tileset):
         wfc = PureWFC(6, 6, tileset, seed=0)


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2025:CoursIA-2 — prev: MED/research-code #15000

## Résumé

Corrige un faux succès de `PureWFC` lorsque le tileset ne contient qu'une seule tuile. Les domaines sont alors singleton dès l'initialisation : aucun collapse ne se produit, donc l'ancienne implémentation retournait directement la grille sans propager les contraintes d'adjacence.

Reassessed by Astra/Fable then independently by myia-po-2025:CoursIA-2: CONFIRMED correctness bug.

## Défaut reproduit

Oracle indépendant : énumération exhaustive de toutes les affectations d'une grille, puis vérification directe des arêtes horizontales et verticales, sans appeler les helpers du solveur.

Pour une tuile unique dont l'auto-adjacence est interdite :

| Grille | Solutions oracle | Avant | Après |
|---|---:|---|---|
| 1×1 | 1 | grille valide | grille valide |
| 1×2 | 0 | grille faussement acceptée | `None` |
| 2×1 | 0 | grille faussement acceptée | `None` |
| 2×2 | 0 | grille faussement acceptée | `None` |

Contrôle positif avec auto-adjacence autorisée : les quatre dimensions restent satisfiables.

Résultat indépendant : **3 divergences sur 8 avant le fix, 0 sur 8 après**.

## Correction

Avant la boucle de collapse, propager une fois depuis `(0, 0)` lorsque `n_tiles == 1`. Cette branche est strictement nécessaire car `_pick_cell()` ignore les domaines de taille 1 ; pour les tilesets multi-tuiles, le premier collapse continue de déclencher la propagation comme auparavant.

Un test paramétré couvre les huit combinaisons et construit son oracle exhaustif sans réutiliser `_propagate()` ni les métriques WFC.

## Validation post-fix

```text
python verify_wfc_singleton.py MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
mismatches=0

python -m pytest MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py -q
52 passed in 0.93s

python -m pytest MyIA.AI.Notebooks/Search/tests -q
111 passed in 2.49s

python -m py_compile MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
PASS

git diff --check
PASS
```

Contrôle multi-tuile indépendant, grille 2×3, seeds `0, 1, 7, 42, 99` :

- damier `[[0,1],[1,0]]` : exactement deux solutions exhaustives ; chaque résultat du solveur appartient à cet ensemble ;
- adjacency vide : zéro solution exhaustive ; `None` sur les cinq seeds.

## Périmètre

- `MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py` : +4 lignes ;
- `MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py` : +30 lignes ;
- aucun notebook, output, catalogue, fichier généré ou API publique modifié ;
- signatures de fonctions inchangées.

## Diagnostic dérive

**Cause** : cas limite non propagé. Le solveur supposait implicitement qu'au moins un domaine aurait une entropie positive et déclencherait `_propagate()`. Cette hypothèse est fausse pour un tileset singleton.

**Verdict : `CAUSE_FIXED`.** Le test de régression confronte désormais le solveur à l'ensemble exhaustif des solutions pour les cas singleton satisfiables et insatisfiables.
