### PR TITLE
fix(genai,#15117): R05 — le print du 1er exemple guide annonce encore « Exercice 1 »

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb
@@ -5,10 +5,10 @@
    "id": "5b08c667",
    "metadata": {
     "papermill": {
-     "duration": 0.009048,
-     "end_time": "2026-09-07T18:04:46.595977",
+     "duration": 0.006932,
+     "end_time": "2026-09-07T21:59:19.663841",
      "exception": false,
-     "start_time": "2026-09-07T18:04:46.586929",
+     "start_time": "2026-09-07T21:59:19.656909",
      "status": "completed"
     },
     "tags": []
@@ -50,10 +50,10 @@
    "id": "99f69b09",
    "metadata": {
     "papermill": {
-     "duration": 0.008397,
-     "end_time": "2026-09-07T18:04:46.612750",
+     "duration": 0.007004,
+     "end_time": "2026-09-07T21:59:19.683952",
      "exception": false,
-     "start_time": "2026-09-07T18:04:46.604353",
+     "start_time": "2026-09-07T21:59:19.676948",
      "status": "completed"
     },
     "tags": []
@@ -77,16 +77,16 @@
    "id": "872a4a4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:04:46.634452Z",
-     "iopub.status.busy": "2026-09-07T18:04:46.633902Z",
-     "iopub.status.idle": "2026-09-07T18:04:47.940091Z",
-     "shell.execute_reply": "2026-09-07T18:04:47.939377Z"
+     "iopub.execute_input": "2026-09-07T21:59:19.702848Z",
+     "iopub.status.busy": "2026-09-07T21:59:19.702848Z",
+     "iopub.status.idle": "2026-09-07T21:59:20.774101Z",
+     "shell.execute_reply": "2026-09-07T21:59:20.774101Z"
     },
     "papermill": {
-     "duration": 1.319637,
-     "end_time": "2026-09-07T18:04:47.941315",
+     "duration": 1.088141,
+     "end_time": "2026-09-07T21:59:20.776100",
      "exception": false,
-     "start_time": "2026-09-07T18:04:46.621678",
+     "start_time": "2026-09-07T21:59:19.687959",
      "status": "completed"
     },
     "tags": []
@@ -96,10 +96,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "N=    1,000 (d=64) | k-NN exact top-10 :     0.2 ms\n",
-      "N=   10,000 (d=64) | k-NN exact top-10 :     2.9 ms\n",
-      "N=  100,000 (d=64) | k-NN exact top-10 :    32.6 ms\n",
-      "N=1,000,000 (d=64) | k-NN exact top-10 :   237.1 ms\n"
+      "N=    1,000 (d=64) | k-NN exact top-10 :     0.6 ms\n",
+      "N=   10,000 (d=64) | k-NN exact top-10 :     2.1 ms\n",
+      "N=  100,000 (d=64) | k-NN exact top-10 :    20.6 ms\n",
+      "N=1,000,000 (d=64) | k-NN exact top-10 :   207.3 ms\n"
      ]
     }
    ],
@@ -139,10 +139,10 @@
    "id": "336b70ac",
    "metadata": {
     "papermill": {
-     "duration": 0.004209,
-     "end_time": "2026-09-07T18:04:47.949946",
+     "duration": 0.005087,
+     "end_time": "2026-09-07T21:59:20.783795",
      "exception": false,
-     "start_time": "2026-09-07T18:04:47.945737",
+     "start_time": "2026-09-07T21:59:20.778708",
      "status": "completed"
     },
     "tags": []
@@ -168,16 +168,16 @@
    "id": "05c79505",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:04:47.959247Z",
-     "iopub.status.busy": "2026-09-07T18:04:47.959247Z",
-     "iopub.status.idle": "2026-09-07T18:04:48.745817Z",
-     "shell.execute_reply": "2026-09-07T18:04:48.744301Z"
+     "iopub.execute_input": "2026-09-07T21:59:20.796309Z",
+     "iopub.status.busy": "2026-09-07T21:59:20.795310Z",
+     "iopub.status.idle": "2026-09-07T21:59:21.804441Z",
+     "shell.execute_reply": "2026-09-07T21:59:21.803427Z"
     },
     "papermill": {
-     "duration": 0.792961,
-     "end_time": "2026-09-07T18:04:48.747013",
+     "duration": 1.017133,
+     "end_time": "2026-09-07T21:59:21.805442",
      "exception": false,
-     "start_time": "2026-09-07T18:04:47.954052",
+     "start_time": "2026-09-07T21:59:20.788309",
      "status": "completed"
     },
     "tags": []
@@ -224,10 +224,10 @@
    "id": "98ef526b",
    "metadata": {
     "papermill": {
-     "duration": 0.003699,
-     "end_time": "2026-09-07T18:04:48.755236",
+     "duration": 0.003515,
+     "end_time": "2026-09-07T21:59:21.812461",
      "exception": false,
-     "start_time": "2026-09-07T18:04:48.751537",
+     "start_time": "2026-09-07T21:59:21.808946",
      "status": "completed"
     },
     "tags": []
@@ -251,10 +251,10 @@
    "id": "dcaffeac",
    "metadata": {
     "papermill": {
-     "duration": 0.004584,
-     "end_time": "2026-09-07T18:04:48.764086",
+     "duration": 0.0036,
+     "end_time": "2026-09-07T21:59:21.820712",
      "exception": false,
-     "start_time": "2026-09-07T18:04:48.759502",
+     "start_time": "2026-09-07T21:59:21.817112",
      "status": "completed"
     },
     "tags": []
@@ -282,16 +282,16 @@
    "id": "e6cb79d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:04:48.773595Z",
-     "iopub.status.busy": "2026-09-07T18:04:48.773595Z",
-     "iopub.status.idle": "2026-09-07T18:04:48.792064Z",
-     "shell.execute_reply": "2026-09-07T18:04:48.790056Z"
+     "iopub.execute_input": "2026-09-07T21:59:21.832618Z",
+     "iopub.status.busy": "2026-09-07T21:59:21.832028Z",
+     "iopub.status.idle": "2026-09-07T21:59:21.850902Z",
+     "shell.execute_reply": "2026-09-07T21:59:21.850305Z"
     },
     "papermill": {
-     "duration": 0.025475,
-     "end_time": "2026-09-07T18:04:48.793350",
+     "duration": 0.025176,
+     "end_time": "2026-09-07T21:59:21.851907",
      "exception": false,
-     "start_time": "2026-09-07T18:04:48.767875",
+     "start_time": "2026-09-07T21:59:21.826731",
      "status": "completed"
     },
     "tags": []
@@ -337,10 +337,10 @@
    "id": "48358bc6",
    "metadata": {
     "papermill": {
-     "duration": 0.005397,
-     "end_time": "2026-09-07T18:04:48.803230",
+     "duration": 0.003599,
+     "end_time": "2026-09-07T21:59:21.860520",
      "exception": false,
-     "start_time": "2026-09-07T18:04:48.797833",
+     "start_time": "2026-09-07T21:59:21.856921",
      "status": "completed"
     },
     "tags": []
@@ -361,16 +361,16 @@
    "id": "a0ee062a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:04:48.816029Z",
-     "iopub.status.busy": "2026-09-07T18:04:48.815524Z",
-     "iopub.status.idle": "2026-09-07T18:05:05.973390Z",
-     "shell.execute_reply": "2026-09-07T18:05:05.973390Z"
+     "iopub.execute_input": "2026-09-07T21:59:21.870365Z",
+     "iopub.status.busy": "2026-09-07T21:59:21.869365Z",
+     "iopub.status.idle": "2026-09-07T21:59:40.301167Z",
+     "shell.execute_reply": "2026-09-07T21:59:40.299524Z"
     },
     "papermill": {
-     "duration": 17.167189,
-     "end_time": "2026-09-07T18:05:05.975350",
+     "duration": 18.437757,
+     "end_time": "2026-09-07T21:59:40.302257",
      "exception": false,
-     "start_time": "2026-09-07T18:04:48.808161",
+     "start_time": "2026-09-07T21:59:21.864500",
      "status": "completed"
     },
     "tags": []
@@ -380,7 +380,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "collection 'chunks' créée sur disque -> <USER_PATH>\\AppData\\Local\\Temp\\rag05_ykg77ysq\n"
+      "collection 'chunks' créée sur disque -> <USER_PATH>\\AppData\\Local\\Temp\\rag05_vymdqugb\n"
      ]
     },
     {
@@ -422,10 +422,10 @@
    "id": "661a9585",
    "metadata": {
     "papermill": {
-     "duration": 0.006999,
-     "end_time": "2026-09-07T18:05:05.989359",
+     "duration": 0.006973,
+     "end_time": "2026-09-07T21:59:40.318766",
      "exception": false,
-     "start_time": "2026-09-07T18:05:05.982360",
+     "start_time": "2026-09-07T21:59:40.311793",
      "status": "completed"
     },
     "tags": []
@@ -447,16 +447,16 @@
    "id": "8ef39016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:06.000148Z",
-     "iopub.status.busy": "2026-09-07T18:05:05.999596Z",
-     "iopub.status.idle": "2026-09-07T18:05:06.068701Z",
-     "shell.execute_reply": "2026-09-07T18:05:06.066697Z"
+     "iopub.execute_input": "2026-09-07T21:59:40.336639Z",
+     "iopub.status.busy": "2026-09-07T21:59:40.336067Z",
+     "iopub.status.idle": "2026-09-07T21:59:40.410437Z",
+     "shell.execute_reply": "2026-09-07T21:59:40.408924Z"
     },
     "papermill": {
-     "duration": 0.074572,
-     "end_time": "2026-09-07T18:05:06.068701",
+     "duration": 0.085034,
+     "end_time": "2026-09-07T21:59:40.411455",
      "exception": false,
-     "start_time": "2026-09-07T18:05:05.994129",
+     "start_time": "2026-09-07T21:59:40.326421",
      "status": "completed"
     },
     "tags": []
@@ -483,10 +483,10 @@
    "id": "2f0e6cd0",
    "metadata": {
     "papermill": {
-     "duration": 0.004849,
-     "end_time": "2026-09-07T18:05:06.080255",
+     "duration": 0.007033,
+     "end_time": "2026-09-07T21:59:40.424005",
      "exception": false,
-     "start_time": "2026-09-07T18:05:06.075406",
+     "start_time": "2026-09-07T21:59:40.416972",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +512,10 @@
    "id": "6c546513",
    "metadata": {
     "papermill": {
-     "duration": 0.003868,
-     "end_time": "2026-09-07T18:05:06.088485",
+     "duration": 0.006822,
+     "end_time": "2026-09-07T21:59:40.438331",
      "exception": false,
-     "start_time": "2026-09-07T18:05:06.084617",
+     "start_time": "2026-09-07T21:59:40.431509",
      "status": "completed"
     },
     "tags": []
@@ -543,16 +543,16 @@
    "id": "4d83e15c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:06.099863Z",
-     "iopub.status.busy": "2026-09-07T18:05:06.099338Z",
-     "iopub.status.idle": "2026-09-07T18:05:06.130384Z",
-     "shell.execute_reply": "2026-09-07T18:05:06.128860Z"
+     "iopub.execute_input": "2026-09-07T21:59:40.450107Z",
+     "iopub.status.busy": "2026-09-07T21:59:40.450107Z",
+     "iopub.status.idle": "2026-09-07T21:59:40.472547Z",
+     "shell.execute_reply": "2026-09-07T21:59:40.470860Z"
     },
     "papermill": {
-     "duration": 0.037981,
-     "end_time": "2026-09-07T18:05:06.131379",
+     "duration": 0.030009,
+     "end_time": "2026-09-07T21:59:40.473535",
      "exception": false,
-     "start_time": "2026-09-07T18:05:06.093398",
+     "start_time": "2026-09-07T21:59:40.443526",
      "status": "completed"
     },
     "tags": []
@@ -628,10 +628,10 @@
    "id": "bf8383b9",
    "metadata": {
     "papermill": {
-     "duration": 0.004572,
-     "end_time": "2026-09-07T18:05:06.140248",
+     "duration": 0.004999,
+     "end_time": "2026-09-07T21:59:40.483542",
      "exception": false,
-     "start_time": "2026-09-07T18:05:06.135676",
+     "start_time": "2026-09-07T21:59:40.478543",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +657,10 @@
    "id": "e711c757",
    "metadata": {
     "papermill": {
-     "duration": 0.004379,
-     "end_time": "2026-09-07T18:05:06.149618",
+     "duration": 0.00463,
+     "end_time": "2026-09-07T21:59:40.493120",
      "exception": false,
-     "start_time": "2026-09-07T18:05:06.145239",
+     "start_time": "2026-09-07T21:59:40.488490",
      "status": "completed"
     },
     "tags": []
@@ -689,16 +689,16 @@
    "id": "3b070cc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:06.163297Z",
-     "iopub.status.busy": "2026-09-07T18:05:06.163297Z",
-     "iopub.status.idle": "2026-09-07T18:05:07.348611Z",
-     "shell.execute_reply": "2026-09-07T18:05:07.347417Z"
+     "iopub.execute_input": "2026-09-07T21:59:40.503974Z",
+     "iopub.status.busy": "2026-09-07T21:59:40.502958Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.324161Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.323518Z"
     },
     "papermill": {
-     "duration": 1.194107,
-     "end_time": "2026-09-07T18:05:07.349858",
+     "duration": 0.827711,
+     "end_time": "2026-09-07T21:59:41.325166",
      "exception": false,
-     "start_time": "2026-09-07T18:05:06.155751",
+     "start_time": "2026-09-07T21:59:40.497455",
      "status": "completed"
     },
     "tags": []
@@ -708,7 +708,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphe petit-monde bâti : 10000 nœuds, m=8, r=3 — 1.2s\n"
+      "graphe petit-monde bâti : 10000 nœuds, m=8, r=3 — 0.8s\n"
      ]
     }
    ],
@@ -746,10 +746,10 @@
    "id": "15be578f",
    "metadata": {
     "papermill": {
-     "duration": 0.005592,
-     "end_time": "2026-09-07T18:05:07.359878",
+     "duration": 0.003001,
+     "end_time": "2026-09-07T21:59:41.332182",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.354286",
+     "start_time": "2026-09-07T21:59:41.329181",
      "status": "completed"
     },
     "tags": []
@@ -770,16 +770,16 @@
    "id": "1cd46fa2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:07.372239Z",
-     "iopub.status.busy": "2026-09-07T18:05:07.371697Z",
-     "iopub.status.idle": "2026-09-07T18:05:07.471262Z",
-     "shell.execute_reply": "2026-09-07T18:05:07.469597Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.341088Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.340463Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.416629Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.415628Z"
     },
     "papermill": {
-     "duration": 0.106985,
-     "end_time": "2026-09-07T18:05:07.471262",
+     "duration": 0.081969,
+     "end_time": "2026-09-07T21:59:41.418150",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.364277",
+     "start_time": "2026-09-07T21:59:41.336181",
      "status": "completed"
     },
     "tags": []
@@ -789,7 +789,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "référence exacte : recall@10=1.000, latence=2.0 ms, évaluations=10000 par requête\n"
+      "référence exacte : recall@10=1.000, latence=1.7 ms, évaluations=10000 par requête\n"
      ]
     }
    ],
@@ -815,10 +815,10 @@
    "id": "da8b3e9e",
    "metadata": {
     "papermill": {
-     "duration": 0.00529,
-     "end_time": "2026-09-07T18:05:07.481558",
+     "duration": 0.005004,
+     "end_time": "2026-09-07T21:59:41.427167",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.476268",
+     "start_time": "2026-09-07T21:59:41.422163",
      "status": "completed"
     },
     "tags": []
@@ -837,16 +837,16 @@
    "id": "0a423623",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:07.496901Z",
-     "iopub.status.busy": "2026-09-07T18:05:07.496326Z",
-     "iopub.status.idle": "2026-09-07T18:05:07.655896Z",
-     "shell.execute_reply": "2026-09-07T18:05:07.654624Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.437441Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.436900Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.558188Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.557382Z"
     },
     "papermill": {
-     "duration": 0.169821,
-     "end_time": "2026-09-07T18:05:07.657067",
+     "duration": 0.12702,
+     "end_time": "2026-09-07T21:59:41.558188",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.487246",
+     "start_time": "2026-09-07T21:59:41.431168",
      "status": "completed"
     },
     "tags": []
@@ -856,20 +856,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " ef  | recall@10 | latence(ms) | évaluations\n"
+      " ef  | recall@10 | latence(ms) | évaluations\n",
+      "   1 | 0.040    |    0.13   | 16\n",
+      "   2 | 0.050    |    0.20   | 30\n",
+      "   4 | 0.070    |    0.43   | 61\n",
+      "   8 | 0.165    |    0.47   | 116\n",
+      "  16 | 0.240    |    1.05   | 179\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   1 | 0.040    |    0.29   | 16\n",
-      "   2 | 0.050    |    0.36   | 30\n",
-      "   4 | 0.070    |    0.55   | 61\n",
-      "   8 | 0.165    |    0.38   | 116\n",
-      "  16 | 0.240    |    0.91   | 179\n",
-      "  32 | 0.405    |    1.71   | 307\n",
-      "  64 | 0.645    |    2.69   | 521\n"
+      "  32 | 0.405    |    1.39   | 307\n",
+      "  64 | 0.645    |    1.52   | 521\n"
      ]
     }
    ],
@@ -922,10 +922,10 @@
    "id": "6f1a05c8",
    "metadata": {
     "papermill": {
-     "duration": 0.005846,
-     "end_time": "2026-09-07T18:05:07.668417",
+     "duration": 0.005005,
+     "end_time": "2026-09-07T21:59:41.567624",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.662571",
+     "start_time": "2026-09-07T21:59:41.562619",
      "status": "completed"
     },
     "tags": []
@@ -953,16 +953,16 @@
    "id": "5d865191",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:07.683822Z",
-     "iopub.status.busy": "2026-09-07T18:05:07.683822Z",
-     "iopub.status.idle": "2026-09-07T18:05:07.857128Z",
-     "shell.execute_reply": "2026-09-07T18:05:07.855799Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.577002Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.575981Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.683298Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.683298Z"
     },
     "papermill": {
-     "duration": 0.182518,
-     "end_time": "2026-09-07T18:05:07.858141",
+     "duration": 0.11261,
+     "end_time": "2026-09-07T21:59:41.684234",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.675623",
+     "start_time": "2026-09-07T21:59:41.571624",
      "status": "completed"
     },
     "tags": []
@@ -1016,10 +1016,10 @@
    "id": "6a70f864",
    "metadata": {
     "papermill": {
-     "duration": 0.006648,
-     "end_time": "2026-09-07T18:05:07.869965",
+     "duration": 0.004001,
+     "end_time": "2026-09-07T21:59:41.692235",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.863317",
+     "start_time": "2026-09-07T21:59:41.688234",
      "status": "completed"
     },
     "tags": []
@@ -1050,10 +1050,10 @@
    "id": "d6c07d66",
    "metadata": {
     "papermill": {
-     "duration": 0.006451,
-     "end_time": "2026-09-07T18:05:07.882914",
+     "duration": 0.003504,
+     "end_time": "2026-09-07T21:59:41.699253",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.876463",
+     "start_time": "2026-09-07T21:59:41.695749",
      "status": "completed"
     },
     "tags": []
@@ -1076,16 +1076,16 @@
    "id": "99a8b748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:07.899737Z",
-     "iopub.status.busy": "2026-09-07T18:05:07.899208Z",
-     "iopub.status.idle": "2026-09-07T18:05:07.948663Z",
-     "shell.execute_reply": "2026-09-07T18:05:07.946983Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.709042Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.709042Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.731725Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.730998Z"
     },
     "papermill": {
-     "duration": 0.05969,
-     "end_time": "2026-09-07T18:05:07.949720",
+     "duration": 0.028623,
+     "end_time": "2026-09-07T21:59:41.732662",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.890030",
+     "start_time": "2026-09-07T21:59:41.704039",
      "status": "completed"
     },
     "tags": []
@@ -1123,10 +1123,10 @@
    "id": "c8ce81ab",
    "metadata": {
     "papermill": {
-     "duration": 0.004518,
-     "end_time": "2026-09-07T18:05:07.959960",
+     "duration": 0.003938,
+     "end_time": "2026-09-07T21:59:41.740323",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.955442",
+     "start_time": "2026-09-07T21:59:41.736385",
      "status": "completed"
     },
     "tags": []
@@ -1154,10 +1154,10 @@
    "id": "d91992e5",
    "metadata": {
     "papermill": {
-     "duration": 0.006457,
-     "end_time": "2026-09-07T18:05:07.973025",
+     "duration": 0.003508,
+     "end_time": "2026-09-07T21:59:41.748036",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.966568",
+     "start_time": "2026-09-07T21:59:41.744528",
      "status": "completed"
     },
     "tags": []
@@ -1190,10 +1190,10 @@
    "id": "89e80388",
    "metadata": {
     "papermill": {
-     "duration": 0.004928,
-     "end_time": "2026-09-07T18:05:07.982836",
+     "duration": 0.004504,
+     "end_time": "2026-09-07T21:59:41.756541",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.977908",
+     "start_time": "2026-09-07T21:59:41.752037",
      "status": "completed"
     },
     "tags": []
@@ -1222,16 +1222,16 @@
    "id": "0e411f47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:08.002586Z",
-     "iopub.status.busy": "2026-09-07T18:05:08.002049Z",
-     "iopub.status.idle": "2026-09-07T18:05:08.240631Z",
-     "shell.execute_reply": "2026-09-07T18:05:08.238775Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.765565Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.765565Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.934497Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.934497Z"
     },
     "papermill": {
-     "duration": 0.250735,
-     "end_time": "2026-09-07T18:05:08.242250",
+     "duration": 0.174437,
+     "end_time": "2026-09-07T21:59:41.935497",
      "exception": false,
-     "start_time": "2026-09-07T18:05:07.991515",
+     "start_time": "2026-09-07T21:59:41.761060",
      "status": "completed"
     },
     "tags": []
@@ -1241,7 +1241,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 : latence dims=128 : [(10000, 4.7), (100000, 45.7)]\n",
+      "Exemple guide 1 : latence dims=128 : [(10000, 3.4), (100000, 36.9)]\n",
       "Effet attendu de la dimension : à mesurer — la latence doit croître avec d, mais l'ordre de grandeur reste en N.\n"
      ]
     }
@@ -1261,7 +1261,7 @@
     "    return rows\n",
     "\n",
     "result = mur_latence_exo(dims=128)\n",
-    "print(\"Exercice 1 : latence dims=128 :\", [(n, round(ms, 1)) for n, ms in result])\n",
+    "print(\"Exemple guide 1 : latence dims=128 :\", [(n, round(ms, 1)) for n, ms in result])\n",
     "print(\"Effet attendu de la dimension : à mesurer — la latence doit croître avec d, mais l'ordre de grandeur reste en N.\")\n"
    ]
   },
@@ -1270,10 +1270,10 @@
    "id": "b1aaa5cb",
    "metadata": {
     "papermill": {
-     "duration": 0.009645,
-     "end_time": "2026-09-07T18:05:08.260995",
+     "duration": 0.003502,
+     "end_time": "2026-09-07T21:59:41.943001",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.251350",
+     "start_time": "2026-09-07T21:59:41.939499",
      "status": "completed"
     },
     "tags": []
@@ -1294,16 +1294,16 @@
    "id": "83a78773",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:08.282747Z",
-     "iopub.status.busy": "2026-09-07T18:05:08.282158Z",
-     "iopub.status.idle": "2026-09-07T18:05:08.302032Z",
-     "shell.execute_reply": "2026-09-07T18:05:08.299862Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.952630Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.952630Z",
+     "iopub.status.idle": "2026-09-07T21:59:41.965539Z",
+     "shell.execute_reply": "2026-09-07T21:59:41.965539Z"
     },
     "papermill": {
-     "duration": 0.032763,
-     "end_time": "2026-09-07T18:05:08.303093",
+     "duration": 0.018912,
+     "end_time": "2026-09-07T21:59:41.966541",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.270330",
+     "start_time": "2026-09-07T21:59:41.947629",
      "status": "completed"
     },
     "tags": []
@@ -1333,10 +1333,10 @@
    "id": "9da4b0c1",
    "metadata": {
     "papermill": {
-     "duration": 0.00969,
-     "end_time": "2026-09-07T18:05:08.322397",
+     "duration": 0.003999,
+     "end_time": "2026-09-07T21:59:41.974539",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.312707",
+     "start_time": "2026-09-07T21:59:41.970540",
      "status": "completed"
     },
     "tags": []
@@ -1355,16 +1355,16 @@
    "id": "dad4b659",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:08.345259Z",
-     "iopub.status.busy": "2026-09-07T18:05:08.344725Z",
-     "iopub.status.idle": "2026-09-07T18:05:08.684354Z",
-     "shell.execute_reply": "2026-09-07T18:05:08.682207Z"
+     "iopub.execute_input": "2026-09-07T21:59:41.982582Z",
+     "iopub.status.busy": "2026-09-07T21:59:41.982582Z",
+     "iopub.status.idle": "2026-09-07T21:59:42.089271Z",
+     "shell.execute_reply": "2026-09-07T21:59:42.089271Z"
     },
     "papermill": {
-     "duration": 0.353318,
-     "end_time": "2026-09-07T18:05:08.685961",
+     "duration": 0.112694,
+     "end_time": "2026-09-07T21:59:42.090273",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.332643",
+     "start_time": "2026-09-07T21:59:41.977579",
      "status": "completed"
     },
     "tags": []
@@ -1402,10 +1402,10 @@
    "id": "68625efd",
    "metadata": {
     "papermill": {
-     "duration": 0.010251,
-     "end_time": "2026-09-07T18:05:08.705956",
+     "duration": 0.005001,
+     "end_time": "2026-09-07T21:59:42.099272",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.695705",
+     "start_time": "2026-09-07T21:59:42.094271",
      "status": "completed"
     },
     "tags": []
@@ -1427,16 +1427,16 @@
    "id": "d9fdea59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:08.727336Z",
-     "iopub.status.busy": "2026-09-07T18:05:08.726795Z",
-     "iopub.status.idle": "2026-09-07T18:05:08.746199Z",
-     "shell.execute_reply": "2026-09-07T18:05:08.744001Z"
+     "iopub.execute_input": "2026-09-07T21:59:42.109195Z",
+     "iopub.status.busy": "2026-09-07T21:59:42.108196Z",
+     "iopub.status.idle": "2026-09-07T21:59:42.120537Z",
+     "shell.execute_reply": "2026-09-07T21:59:42.119985Z"
     },
     "papermill": {
-     "duration": 0.031789,
-     "end_time": "2026-09-07T18:05:08.747275",
+     "duration": 0.018355,
+     "end_time": "2026-09-07T21:59:42.121544",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.715486",
+     "start_time": "2026-09-07T21:59:42.103189",
      "status": "completed"
     },
     "tags": []
@@ -1466,10 +1466,10 @@
    "id": "a5cce54f",
    "metadata": {
     "papermill": {
-     "duration": 0.009121,
-     "end_time": "2026-09-07T18:05:08.765786",
+     "duration": 0.004514,
+     "end_time": "2026-09-07T21:59:42.132071",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.756665",
+     "start_time": "2026-09-07T21:59:42.127557",
      "status": "completed"
     },
     "tags": []
@@ -1488,16 +1488,16 @@
    "id": "fd1ee930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:08.789887Z",
-     "iopub.status.busy": "2026-09-07T18:05:08.788812Z",
-     "iopub.status.idle": "2026-09-07T18:05:08.853635Z",
-     "shell.execute_reply": "2026-09-07T18:05:08.851198Z"
+     "iopub.execute_input": "2026-09-07T21:59:42.142143Z",
+     "iopub.status.busy": "2026-09-07T21:59:42.142143Z",
+     "iopub.status.idle": "2026-09-07T21:59:42.168241Z",
+     "shell.execute_reply": "2026-09-07T21:59:42.167256Z"
     },
     "papermill": {
-     "duration": 0.077847,
-     "end_time": "2026-09-07T18:05:08.854712",
+     "duration": 0.031169,
+     "end_time": "2026-09-07T21:59:42.168241",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.776865",
+     "start_time": "2026-09-07T21:59:42.137072",
      "status": "completed"
     },
     "tags": []
@@ -1535,10 +1535,10 @@
    "id": "07d64ee4",
    "metadata": {
     "papermill": {
-     "duration": 0.008585,
-     "end_time": "2026-09-07T18:05:08.873530",
+     "duration": 0.007028,
+     "end_time": "2026-09-07T21:59:42.182283",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.864945",
+     "start_time": "2026-09-07T21:59:42.175255",
      "status": "completed"
     },
     "tags": []
@@ -1562,16 +1562,16 @@
    "id": "b293a37c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T18:05:08.899065Z",
-     "iopub.status.busy": "2026-09-07T18:05:08.898536Z",
-     "iopub.status.idle": "2026-09-07T18:05:08.913695Z",
-     "shell.execute_reply": "2026-09-07T18:05:08.912594Z"
+     "iopub.execute_input": "2026-09-07T21:59:42.191776Z",
+     "iopub.status.busy": "2026-09-07T21:59:42.191776Z",
+     "iopub.status.idle": "2026-09-07T21:59:42.198782Z",
+     "shell.execute_reply": "2026-09-07T21:59:42.197803Z"
     },
     "papermill": {
-     "duration": 0.030878,
-     "end_time": "2026-09-07T18:05:08.915745",
+     "duration": 0.012517,
+     "end_time": "2026-09-07T21:59:42.198782",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.884867",
+     "start_time": "2026-09-07T21:59:42.186265",
      "status": "completed"
     },
     "tags": []
@@ -1601,10 +1601,10 @@
    "id": "ee96182e",
    "metadata": {
     "papermill": {
-     "duration": 0.009448,
-     "end_time": "2026-09-07T18:05:08.934939",
+     "duration": 0.00353,
+     "end_time": "2026-09-07T21:59:42.206824",
      "exception": false,
-     "start_time": "2026-09-07T18:05:08.925491",
+     "start_time": "2026-09-07T21:59:42.203294",
      "status": "completed"
     },
     "tags": []
@@ -1656,14 +1656,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 24.264146,
-   "end_time": "2026-09-07T18:05:09.491351",
+   "duration": 24.90412,
+   "end_time": "2026-09-07T21:59:42.558624",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb",
+   "input_path": "05-Stockage-Vectoriel.ipynb",
+   "output_path": "05-Stockage-Vectoriel.ipynb",
    "parameters": {},
-   "start_time": "2026-09-07T18:04:45.227205",
+   "start_time": "2026-09-07T21:59:17.654504",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: LIGHT/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15097

## Résumé

Séquelle cosmétique de #15097 (repérée par la review Hermes, laissée hors de cette PR pour ne pas mobiliser une re-exécution sur une chaîne) : le titre de la cellule disait « Exemple guide 1 » mais son `print` annonçait encore « Exercice 1 : latence dims=128 » — l'étudiant lisait deux « exercice 1 » dans le même notebook (le résolu + la variante ouverte numérotée à partir de 1).

- Libellé du `print` renommé : `Exercice 1 :` → `Exemple guide 1 :` (source uniquement, 1 occurrence).
- Re-exécution complète du notebook (C.2 — la chaîne vit dans une sortie) : kernel `coursia-ml-training`, 17 cellules code, 0 erreur, 0 `execution_count` null.
- Les 2 autres occurrences légitimes d'« Exercice 1 » (la variante ouverte c31/c32) sont intactes.

## Validation

- Sortie régénérée première ligne : `Exemple guide 1 : latence dims=128 : [(10000, 3.4), (100000, 36.9)]`.
- Churn = sorties re-sérialisées + latences non-déterministes (4.7→3.4 ms, 45.7→36.9 ms — mesures temporelles, attendu).
- Chemins machine normalisés par le hook pre-commit (`<USER_PATH>`, pattern établi #15097) — blob committé vérifié : 0 chemin brut.
- Diff : 1 fichier, 216+/216−, zéro source touché hors le libellé.

Closes #15117