### PR TITLE
docs(archive,#13749): standardize recycle CSP dispositions

### DIFF
--- a/docs/reference/_archive-convention.md
+++ b/docs/reference/_archive-convention.md
@@ -10,7 +10,7 @@ Un dossier `_archive/` sans convention devient un **puits de code mort** : on y 
 
 - 11 emplacements `_archive/` dispersés (125 fichiers au total au 2026-08), conventions hétérogènes.
 - `scripts/genai-stack/_archive/` (constat empirique au 2026-08, **hors scope PR actuelle**) : 28 fichiers (37 % du répertoire) — code mort, certains cassés auto-admis. **Cible de la tranche 3** (cf table lignes 73-85).
-- `scripts/_archive/one_shot_fixes/` + `one_shots_post_463/` + `recycle_csp/` (constat empirique au 2026-08, **hors scope PR actuelle**) : ~30 fichiers sans README de disposition. **Cible de la tranche 2** (cf table lignes 73-85).
+- `scripts/_archive/one_shot_fixes/` + `one_shots_post_463/` + `recycle_csp/` (constat empirique au 2026-08) : ~30 fichiers dont les README de disposition n'appliquaient pas encore tous le standard. **Cible de la tranche 2** (cf table lignes 73-85).
 
 Le coût d'un `_archive/` non standardisé = **découverte impossible** : aucun successeur nommé, aucun verdict enregistré, aucun moyen de savoir si le script peut être ressuscité ou doit être supprimé.
 
@@ -79,7 +79,7 @@ Exception : si un dossier `_archive/` ne contient que des **données** (pas de s
 | `MyIA.AI.Notebooks/SymbolicAI/Planners/_archive/` | ❌ | tranche 4 |
 | `MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/_archive/` | ❌ | tranche 4 |
 | `MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/_archive/` | ❌ | tranche 4 |
-| `scripts/_archive/` | partiel | tranche 2A : `one_shots_post_463/` conforme ; `one_shot_fixes/` et `recycle_csp/` restent à standardiser |
+| `scripts/_archive/` | partiel | tranche 2A : `one_shots_post_463/` et `recycle_csp/` conformes ; `one_shot_fixes/` reste à standardiser |
 | `scripts/genai-stack/_archive/` | ❌ | tranche 3 (28 fichiers constatés au 2026-08, peut nécessiter split) — **hors scope PR actuelle** |
 | `scripts/sudoku/_archive/` | ❌ | tranche 4 |
 | `slides/S4-trading-algorithmique/_archive/` | ❌ | tranche 4 |

--- a/scripts/_archive/recycle_csp/README.md
+++ b/scripts/_archive/recycle_csp/README.md
@@ -1,57 +1,55 @@
-# `scripts/_archive/recycle_csp/` — CSP recycle one-shots (archived 2026-08-06)
+# Scripts de recyclage CSP archivés
 
-## Contexte
+Ce dossier conserve les sept scripts one-shot qui ont transformé les notebooks
+`CSP-3-Advanced` à `CSP-9-Distributed` pour l’issue #463. Leur mission a été
+livrée par les PR #469 à #475, puis les scripts ont été archivés par la PR
+#9575 le 6 août 2026.
 
-Cette archive contient les **7 one-shots historiques** (`recycle_csp3.py` à `recycle_csp9.py`) qui recyclaient les solutions étudiantes des notebooks CSP-3-Advanced à CSP-9-Distributed en `Exemple` labelés + créaient de nouveaux `Exercice` stubs avec variantes.
+Ils ne constituent plus des outils actifs : aucun autre script ne les importe,
+et leurs notebooks cibles existent sur `main`. Ils restent ici pour préserver
+la provenance exacte des transformations historiques.
 
-## Date d'archivage
+## Registre de disposition
 
-2026-08-06 (cycle worker po-2023 wakeup 39, c.9535-item4 partial).
+| Script | Verdict | Superseded by | Verdict recorded in |
+|---|---|---|---|
+| `recycle_csp3.py` | OBSOLETE — transformation livrée, puis état des labels remanié | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb` : livraison PR #469, remaniement issue #464 (commit `171e7862a`), restauration des labels d’exercice par le TP étudiant PR #601 | PR #469 ; issue #464 / commit `171e7862a` ; PR #601 ; archivage PR #9575 |
+| `recycle_csp4.py` | OBSOLETE — mission de migration remplie | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb` (PR #470) | PR #470 ; archivage #9575 |
+| `recycle_csp5.py` | OBSOLETE — mission de migration remplie | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb` (PR #471) | PR #471 ; archivage #9575 |
+| `recycle_csp6.py` | OBSOLETE — transformation livrée et raffinée | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb` : livraison PR #472, remaniement issue #464 (commit `171e7862a`), correction de label PR #9171 | PR #472 ; issue #464 / commit `171e7862a` ; PR #9171 ; archivage PR #9575 |
+| `recycle_csp7.py` | OBSOLETE — mission de migration remplie | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft.ipynb` (PR #473) | PR #473 ; archivage #9575 |
+| `recycle_csp8.py` | OBSOLETE — mission de migration remplie | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb` (PR #474) | PR #474 ; archivage #9575 |
+| `recycle_csp9.py` | OBSOLETE — mission de migration remplie | `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb` (PR #475) | PR #475 ; archivage #9575 |
 
-## Justification (`Consolider ≠ Archiver`, CLAUDE.md global)
+## Analyse et préservation
 
-1. **ANALYZE** ✓ — chaque script a une seule fonction : modifier **un** notebook CSP-* (recycler solutions étudiantes en labeled Exemples + créer exercise stubs variants).
-2. **MERGE** ✓ — la fonctionnalité est **déjà mergée dans les notebooks cibles**. Plus rien à fusionner ailleurs.
-3. **ARCHIVE** ✓ — déplacer vers ce dossier avec header documentant date + PRs supersedantes + features préservées.
+Chaque fichier possède une seule entrée top-level : le corps de module pour
+CSP-3 et CSP-4, puis `main()` pour CSP-5 à CSP-9. Les en-têtes de disposition
+dans les scripts rendent cette entrée explicite et renvoient vers le notebook
+qui porte désormais le contenu.
 
-## PRs supersedantes (post-archivage)
+La préservation a été vérifiée par l’historique Git : chaque PR #469 à #475 a
+livré le script et la transformation de son notebook dans le même commit. Les
+cas qui ont évolué ensuite sont documentés sans les masquer :
 
-| Notebook | PR supersedante | Statut |
-|---|---|---|
-| `CSP-3-Advanced` | [#469](https://github.com/jsboige/CoursIA/pull/469) (`fix(csp-3): recycle student solutions into Exemples + new exercise stubs (refs #463)`) | MERGED 2026-04-22 |
-| `CSP-9-Distributed` | [#475](https://github.com/jsboige/CoursIA/pull/475) (`fix(csp): recycle CSP-9-Distributed solutions into exercices with variant stubs (refs #463)`) | MERGED 2026-04-22 |
-| `CSP-4/5/6/7/8` | (même famille #463, dates avoisinantes) | MERGED |
+- CSP-3 suit la chaîne PR #469 → issue #464 / commit `171e7862a` → PR #601 ;
+  le contenu CSP demeure dans le notebook courant, mais les labels posés par le
+  one-shot ne sont plus son état final.
+- CSP-6 suit la chaîne PR #472 → issue #464 / commit `171e7862a` → PR #9171.
+- CSP-4, CSP-5, CSP-7, CSP-8 et CSP-9 conservent les exemples et variantes
+  livrés par leurs PR respectives.
 
-Issue #463 (CLOSED 2026-04-22) : « CSP leak recyclage » — entièrement résolu par ces 7 PRs.
+## Pourquoi conserver ces fichiers
 
-## Features préservées (par script)
+La suppression ferait perdre le source exact des transformations de 2026.
+L’archive locale au domaine garde cette provenance consultable sans présenter
+les scripts comme des outils réutilisables. Toute nouvelle évolution des
+notebooks doit modifier directement les notebooks ou un outil actif de
+`scripts/notebook_tools/`, jamais rejouer ces one-shots indexés par cellules.
 
-| Script | Fonction archivée | Notebook cible |
-|---|---|---|
-| `recycle_csp3.py` (373 L) | SEND+MORE → Exemple, Ex1: CROSS+ROADS=DANGER ; N-Reines symmetry → Exemple, Ex2: N-Reines 12x12 ; Mini-TSP Circuit → Exemple, Ex3: TSP 6 nodes | `CSP-3-Advanced.ipynb` |
-| `recycle_csp4.py` (240 L) | (variante CSP-4) | `CSP-4-...ipynb` |
-| `recycle_csp5.py` (285 L) | (variante CSP-5) | `CSP-5-...ipynb` |
-| `recycle_csp6.py` (276 L) | (variante CSP-6) | `CSP-6-...ipynb` |
-| `recycle_csp7.py` (252 L) | (variante CSP-7) | `CSP-7-...ipynb` |
-| `recycle_csp8.py` (238 L) | (variante CSP-8) | `CSP-8-...ipynb` |
-| `recycle_csp9.py` (238 L) | N-reines distribuées ABT → 5-node graph coloring with 5 colors ; ABT vs AWC comparison → constraint density impact study ; Multi-agent negotiation → 5-agent task allocation ; Information leakage measure → 3-level privacy comparison (38 → 46 cells, +8 : 4 md énoncés + 4 code stubs) | `CSP-9-Distributed.ipynb` |
+## Références
 
-## Call-sites
-
-- **Repo-wide** : `grep -rln "recycle_csp" --include="*.py" --include="*.ipynb" --include="*.md" --include="*.yml" --include="*.json"` = **0** résultats (en dehors des 7 fichiers eux-mêmes et ce README).
-- **scripts-reference.md** : aucun résultat.
-- Aucun import, aucune référence fonctionnelle ailleurs.
-
-## Pourquoi archiver plutôt que supprimer
-
-- **Traçabilité** : ce sont des one-shots liés à des **PRs MERGED avec valeur historique**. Supprimer = perte du diff-source.
-- **PR-review** : un reviewer qui regarde un commit de 2026-04 doit pouvoir retrouver le script utilisé.
-- **Anti-regression** : `git log --follow scripts/_archive/recycle_csp/recycle_csp9.py` continue de pointer vers le commit initial (`fd7b8eea` / `cf755fe6`).
-
-## Pattern sœur
-
-Cette archive suit la convention `scripts/_archive/<famille>/` déjà utilisée pour d'autres familles historiques du repo.
-
----
-
-**Refs** : #9535 item 4 partial · #463 (CLOSED) · PRs #469/#475 (et sœurs).
+- Issue source : #463
+- Archivage initial : PR #9575
+- Standard appliqué : `docs/reference/_archive-convention.md`
+- Suivi de standardisation : #13749

--- a/scripts/_archive/recycle_csp/recycle_csp3.py
+++ b/scripts/_archive/recycle_csp/recycle_csp3.py
@@ -6,6 +6,18 @@ Pattern: fix_issue_420.py (PR #453, Issue #420)
 Reference: Issue #463
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+#   (PR #469; reworked for issue #464 by commit 171e7862a; labels restored by PR #601)
+# - Verdict recorded in : PR #469 and archive PR #9575
+#
+# Per-function disposition :
+# - <module> : one-shot transform delivered by PR #469, reworked for issue
+#   #464 by commit 171e7862a, then its Exemple labels were removed by student
+#   TP PR #601; the current
+#   notebook preserves the CSP content rather than this script's label state.
+
 import json
 
 path = "MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb"

--- a/scripts/_archive/recycle_csp/recycle_csp4.py
+++ b/scripts/_archive/recycle_csp/recycle_csp4.py
@@ -6,6 +6,15 @@ Pattern: fix_issue_420.py (PR #453, Issue #420)
 Reference: Issue #463
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb (PR #470)
+# - Verdict recorded in : PR #470 and archive PR #9575
+#
+# Per-function disposition :
+# - <module> : one-shot notebook transform delivered by PR #470; retained only
+#   as the historical source of the split examples and new exercise stubs.
+
 import json
 
 path = "MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb"

--- a/scripts/_archive/recycle_csp/recycle_csp5.py
+++ b/scripts/_archive/recycle_csp/recycle_csp5.py
@@ -5,6 +5,15 @@ Converts 4 student solutions into labeled "Exemple resolu" cells
 and creates new exercise stubs with variant data.
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb (PR #471)
+# - Verdict recorded in : PR #471 and archive PR #9575
+#
+# Per-function disposition :
+# - main() : one-shot notebook transform delivered by PR #471; retained only
+#   as the historical source of the recycled examples and variant stubs.
+
 import json
 
 

--- a/scripts/_archive/recycle_csp/recycle_csp6.py
+++ b/scripts/_archive/recycle_csp/recycle_csp6.py
@@ -5,6 +5,17 @@ Converts 4 student solutions into labeled "Exemple resolu" cells
 and creates new exercise stubs with variant data.
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+#   (PR #472; reworked for issue #464 by commit 171e7862a; label fix PR #9171)
+# - Verdict recorded in : PR #472 and archive PR #9575
+#
+# Per-function disposition :
+# - main() : one-shot notebook transform delivered by PR #472, reworked for
+#   issue #464 by commit 171e7862a, then refined by PR #9171; retained only
+#   as historical source.
+
 import json
 
 

--- a/scripts/_archive/recycle_csp/recycle_csp7.py
+++ b/scripts/_archive/recycle_csp/recycle_csp7.py
@@ -5,6 +5,15 @@ Converts 4 student solutions into labeled "Exemple resolu" cells
 and creates new exercise stubs with variant data.
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft.ipynb (PR #473)
+# - Verdict recorded in : PR #473 and archive PR #9575
+#
+# Per-function disposition :
+# - main() : one-shot notebook transform delivered by PR #473; retained only
+#   as the historical source of the recycled examples and variant stubs.
+
 import json
 
 

--- a/scripts/_archive/recycle_csp/recycle_csp8.py
+++ b/scripts/_archive/recycle_csp/recycle_csp8.py
@@ -5,6 +5,15 @@ Converts 4 student solutions into labeled "Exemple resolu" cells
 and creates new exercise stubs with variant data.
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb (PR #474)
+# - Verdict recorded in : PR #474 and archive PR #9575
+#
+# Per-function disposition :
+# - main() : one-shot notebook transform delivered by PR #474; retained only
+#   as the historical source of the recycled examples and variant stubs.
+
 import json
 
 

--- a/scripts/_archive/recycle_csp/recycle_csp9.py
+++ b/scripts/_archive/recycle_csp/recycle_csp9.py
@@ -5,6 +5,15 @@ Converts 4 student solutions into labeled "Exemple resolu" cells
 and creates new exercise stubs with variant data.
 """
 
+# Archive header (standard _archive convention, 2026-08)
+# - Date archived : 2026-08-06
+# - Superseded by : MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb (PR #475)
+# - Verdict recorded in : PR #475 and archive PR #9575
+#
+# Per-function disposition :
+# - main() : one-shot notebook transform delivered by PR #475; retained only
+#   as the historical source of the recycled examples and variant stubs.
+
 import json
 
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: MED/notebook-lean #15027

## Résumé

Standardise la tranche `scripts/_archive/recycle_csp/` de l’umbrella #13749 sans modifier la logique des sept scripts archivés.

- remplace le README imprécis par le registre canonique à quatre colonnes : script, verdict, successeur et preuve durable ;
- ajoute un en-tête de disposition à chaque script, couvrant son unique entrée top-level ;
- nomme explicitement les PR de livraison #469 à #475 et l’archivage #9575 ;
- conserve les chaînes de disposition non uniformes : CSP-3 (PR #469 → issue #464 / commit `171e7862a` → PR #601) et CSP-6 (PR #472 → issue #464 / commit `171e7862a` → PR #9171) ;
- met à jour l’état de la tranche dans `docs/reference/_archive-convention.md`.

Cette PR est partielle : `scripts/_archive/one_shot_fixes/` reste à standardiser, ainsi que les emplacements listés comme tranches 3 et 4. Elle utilise donc `See #13749`, pas `Closes`.

## Preuves de préservation

Les PR #469 à #475 sont toutes mergées le 22 avril 2026. Chacune livre dans le même commit le script one-shot et son notebook cible :

| PR | Script | Notebook cible |
|---|---|---|
| #469 | `recycle_csp3.py` | `CSP-3-Advanced.ipynb` |
| #470 | `recycle_csp4.py` | `CSP-4-Scheduling.ipynb` |
| #471 | `recycle_csp5.py` | `CSP-5-Optimization.ipynb` |
| #472 | `recycle_csp6.py` | `CSP-6-Hybridization.ipynb` |
| #473 | `recycle_csp7.py` | `CSP-7-Soft.ipynb` |
| #474 | `recycle_csp8.py` | `CSP-8-Temporal.ipynb` |
| #475 | `recycle_csp9.py` | `CSP-9-Distributed.ipynb` |

Le grep repo-wide sur `origin/main` ne trouve que des références documentaires (`_quarto.yml`, READMEs et convention), aucun import ni appel actif.

## Validation

- `python -m compileall -q scripts/_archive/recycle_csp` : PASS ;
- analyse AST : 7 scripts, une entrée top-level documentée chacun (`<module>` pour CSP-3/4, `main()` pour CSP-5 à CSP-9) ;
- registre README : 7/7 lignes de script ;
- `python scripts/check_docs_links.py --check` : PASS, 0 nouveau lien cassé sur 6 677 ;
- `python -m pre_commit run --files ...` : PASS (`gitleaks`, garde `text=True`/encoding, parse source ; hooks notebook non applicables) ;
- `git diff --check` : PASS ;
- catalogue généré byte-identique à `origin/main` ;
- périmètre : 9 fichiers, uniquement la tranche et sa convention canonique.

## Hors périmètre

- aucune suppression ni déplacement de code ;
- aucune modification de notebook ;
- aucune standardisation de `one_shot_fixes/` ;
- aucune fermeture de #13749.

See #13749

