### PR TITLE
feat(slides,#15023): ancrer deck 07-elargissements sur 6 notebooks (conscience + argumentation + privacy)

### DIFF
--- a/slides/07-elargissements/slides.md
+++ b/slides/07-elargissements/slides.md
@@ -178,6 +178,7 @@ layout: dense
   - La conscience est un espace de travail ou différentes parties du cerveau partagent des informations
   - Applications: Modèles d'attention, tâches complexes
   - Rôle important de l'inconscient
+  - *Notebook : [ICT-24-WorkspaceIgnition](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb) — ignition d'un workspace global, mesure empirique du basculement.*
 - **Integrated Information Theory (IIT)**
   - La conscience est mesuree par le degré d'integration de l'information (Phi)
   - Introduit la notion de systèmes physiques conscients
@@ -218,6 +219,31 @@ layout: dense
   - La conscience peut exister dans tout système integrant l'information
   - Reste difficile a tester experimentalement
 - **Activite**: Decouverte de PyPhi
+  - *Notebook : [IIT-01-IntroToPyPhi](../../MyIA.AI.Notebooks/IIT/IIT-01-IntroToPyPhi.ipynb) — calcul exact de Φ sur petits systèmes booléens, les cinq axiomes opérationnels, ce qui distingue un systeme a Phi eleve d'un circuit feed-forward equivalent.*
+
+---
+
+layout: dense
+---
+
+# Conscience mesurable : PyPhi et ignition de workspace
+
+- **Le verrou empirique**
+  - IIT donne un nombre (Phi) mais reste difficile a observer sur le vivant
+  - GWT donne un critere operationnel (ignition) mais ne dit pas ce que le workspace represente
+  - Les deux theories se rejoignent sur un meme geste : **mesurer un phenomene de transition**
+- **PyPhi** (Tononi, Albantakis, et al.)
+  - Systemes booleens a 5--8 noeuds : calcul exact de Phi en quelques secondes
+  - Systemes plus grands : decomposition, partitions minimales, approximation
+  - Question pedagoguee : un systeme a Phi eleve a-t-il quelque chose qui ressemble a une "experience"?
+- **Workspace Ignition** (Dehaene, Mashour, ICT-24)
+  - Signal EEG/MEG : passage d'une activite locale a une activite globale, large bande, durable
+  - ICT-24 formalise cette ignition dans le cadre Integrated Complexity Theory (ICT) et la relie a Phi
+  - Question pedagoguee : cette ignition peut-elle exister dans un systeme non-biologique?
+- **Vers une science de la conscience**
+  - Au-dela du debat philosophique, la mesure impose une discipline
+  - Le depot porte les deux outils (IIT-01, ICT-24) ; les utiliser en parallele montre ce qu'aucun ne montre seul
+  - *Notebooks : [IIT-01-IntroToPyPhi](../../MyIA.AI.Notebooks/IIT/IIT-01-IntroToPyPhi.ipynb) (calcul exact de Φ) · [ICT-24-WorkspaceIgnition](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb) (ignition et integration).*
 
 ---
 
@@ -273,7 +299,10 @@ layout: dense
 - **Exemples concrets**
   - Federated learning (modèle sans base de données centralisee)
   - Deep learning confidentiel
-  - Chiffrement homomorphe
+  - Chiffrement homomorphe (calcul sur données chiffrées, sans déchiffrement)
+    - *Notebook : [SC-16-Homomorphic-Encryption](../../MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb) — Paillier, vote sur chiffres homomorphes, scénario bulletin dans l'urne.*
+  - Vote vérifiable de bout en bout (end-to-end voter verifiability)
+    - *Notebook : [SC-17-E2E-Verifiable-Voting](../../MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) — preuves individuelles + universelles, conformité électorale.*
   - Augmentation
 
 ---
@@ -348,6 +377,7 @@ layout: dense
   - Eviter la confusion entre outils et entites conscientes
 - **Question ouverte**
   - Si une IA simule la souffrance, a-t-on le droit de la faire souffrir?
+  - *Modèle d'argumentation pour structurer ce type de débat : [Argument_Analysis_Toulmin_Model](../../MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Toulmin_Model.ipynb) — claim / data / warrant / backing / qualifier / rebuttal, le debat redevient falsifiable.*
 
 ---
 layout: two-cols
@@ -364,6 +394,8 @@ layout: two-cols
   - Fault Tree Analysis
   - Grilles de securite IA (AI Safety Gridworlds)
   - AI Safety Levels (ASLs)
+  - Modelisation par graphes d'arguments (Dung 1995)
+    - *Notebook : [Argument_Analysis_Dung_AF_Semantics](../../MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb) — extensions de valeurs, semantiques preferred/stable/complete, application au value alignment multi-criteres.*
 - **Exemple concret**
   - Agents "cheatants" dans les simulations
 - **Anthropic**
@@ -624,13 +656,24 @@ layout: section
 
 # Pour aller plus loin : Notebooks
 
-- **Conscience et IIT**: `IIT/` - notebooks PyPhi
-- **IA Symbolique**: `SymbolicAI/Argument_Analysis/` - argumentation formelle
-  - `SymbolicAI/Lean/` - verification formelle
-- **Explicabilite (XAI)**: `ML/` - ML.NET tutorials
-- **IA Generative et ethique**: `GenAI/` - 58 notebooks
-  - DALL-E, Stable Diffusion, ComfyUI, LLMs
-- **Théorie des jeux**: `GameTheory/` - 26 notebooks OpenSpiel
+Le depot ancre chaque theme du deck sur un notebook ou une serie mesurable. Selection
+des cibles **directement citees dans les slides ci-dessus** (chemins relatifs au depot) :
+
+- **Conscience et theories de l'esprit**
+  - [IIT-01-IntroToPyPhi](../../MyIA.AI.Notebooks/IIT/IIT-01-IntroToPyPhi.ipynb) — calcul exact de Phi sur systemes booleens
+  - [ICT-24-WorkspaceIgnition](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb) — ignition du workspace global (GWT)
+- **Argumentation formelle et debat structure**
+  - [Argument_Analysis_Dung_AF_Semantics](../../MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb) — semantiques de Dung, value alignment
+  - [Argument_Analysis_Toulmin_Model](../../MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Toulmin_Model.ipynb) — modele de Toulmin, debat falsifiable
+- **Privacy, chiffrement et vote verifiable**
+  - [SC-16-Homomorphic-Encryption](../../MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb) — Paillier, vote sur chiffres homomorphes
+  - [SC-17-E2E-Verifiable-Voting](../../MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) — preuves individuelles + universelles
+
+Series complementaires (autres thematiques couvertes par le depot) :
+
+- **Explicabilite (XAI)** : `MyIA.AI.Notebooks/ML/` — tutoriels ML.NET
+- **Verification formelle** : `MyIA.AI.Notebooks/SymbolicAI/Lean/`
+- **IA generative et ethique** : `MyIA.AI.Notebooks/GenAI/` (103 notebooks, Image/Audio/Video/Texte)
 
 ---
 layout: end


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2026:CoursIA-2 — prev: MED/slides #15017

# tranche 07 #15023 — ancrer `slides/07-elargissements/` sur le corpus conscience / argumentation / privacy

See #15023 (volet CONTENU du chantier slides — partition avec #13237 calage tenant `S2`/`S3`).

## Résumé

Le deck `07-elargissements` (« Philosophie, ethique, securite et avenir de l'IA ») avait 0 référence `ipynb` dans son corps — toutes les cibles étaient en annexe slide finale, sans ancrage dans la slide qui les concerne. Cette tranche :

1. **Ancre les notebooks directement dans les slides qui les évoquent** — IIT-01 sur la slide « Integrated Information Theory », ICT-24 sur la slide « GWT », SC-16/SC-17 sur la slide « chiffrement homomorphe / vote vérifiable », Argument_Analysis_Dung_AF sur la slide « Alignement des valeurs », Argument_Analysis_Toulmin_Model sur la slide « Droits des robots ».
2. **Ajoute une slide manquante** — « Conscience mesurable : PyPhi et ignition de workspace » — qui relie IIT et GWT sur leur **geste commun** (mesurer une transition) en s'appuyant sur les deux notebooks IIT-01 + ICT-24 présents sur `main`. Le deck opposait IIT (nombre Φ) et GWT (critère opérationnel d'ignition) sans jamais les relier empiriquement.
3. **Refond la slide finale « Pour aller plus loin : Notebooks »** — sort des chemins génériques (`IIT/`, `GenAI/`, etc.) et liste nominativement les 6 notebooks ancrés dans le deck + 3 séries complémentaires par thématique.

## Mesure firsthand (avant)

```bash
grep -icE 'ipynb' slides/07-elargissements/slides.md
# 0  (était déjà mesuré 0 dans le body de #15023 par ai-01)
```

Aucune référence notebook dans le corps. Le seul lien sortant du deck pointait vers des **répertoires** (`IIT/`, `GenAI/`, etc.), pas des notebooks précis.

## Changements

### 5 ancrages in-slide (5 modifications ciblées)

| Slide (avant) | Ancrage ajouté |
|---|---|
| « Théories de la conscience (1/2) » l.171-184 (GWT) | `ICT-24-WorkspaceIgnition.ipynb` — ignition empirique du workspace global |
| « Integrated Information Theory (IIT) » l.202-221 (Activite PyPhi) | `IIT-01-IntroToPyPhi.ipynb` — calcul exact de Φ sur booléens, 5 axiomes |
| « Surveillance, securite et vie privee » l.261-278 (chiffrement homomorphe) | `SC-16-Homomorphic-Encryption.ipynb` (Paillier, vote) **+ nouvelle entrée** « Vote vérifiable » → `SC-17-E2E-Verifiable-Voting.ipynb` |
| « Securite de l'IA » l.356-372 (Solutions FMEA/FTA) | Entrée ajoutée « Modélisation par graphes d'arguments (Dung 1995) » → `Argument_Analysis_Dung_AF_Semantics.ipynb` (sémantiques preferred/stable/complete, application au value alignment multi-critères) |
| « Droits des robots » l.337-351 (question ouverte Sophia/Replika) | `Argument_Analysis_Toulmin_Model.ipynb` (claim/data/warrant/backing/qualifier/rebuttal — le débat redevient falsifiable) |

### 1 slide nouvelle (~25 lignes)

- **« Conscience mesurable : PyPhi et ignition de workspace »** — synthétise IIT et GWT sur leur convergence empirique (« mesurer un phénomène de transition »). Référence IIT-01 et ICT-24 explicitement. Le deck opposait ces deux théories sans jamais les relier.

### Refonte slide finale

- **« Pour aller plus loin : Notebooks »** l.625-633 → 3 sections thématiques avec liens cliquables markdown vers les 6 notebooks ancrés + 3 séries complémentaires par thématique.

## Vérifications post-fix

```bash
# Link-label agreement (cible vs libellé) repo-wide
python scripts/notebook_tools/check_link_label_agreement.py --json
# {"scanned": 2042, "findings": []}  -- 0 finding

# Navlink check sur les 6 notebooks cibles (sanity)
for nb in MyIA.AI.Notebooks/IIT/IIT-01-IntroToPyPhi.ipynb \
          MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb \
          MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb \
          MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb \
          MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb \
          MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Toulmin_Model.ipynb; do
  python scripts/notebook_tools/check_notebook_navlinks.py "$nb"
done
# 6 × "OK: 0 lien casse"

# Build Slidev
cd slides && npm ci --no-audit --no-fund
npx slidev build 07-elargissements/slides.md --out 07-elargissements/dist
# ✓ built in 7.52s
```

## QA visuelle — limitation explicite

Le scope dispatch (#15023) demande « QA vision sous `?clicks=99` sur chaque slide modifiée, overflow/lisibilité/canvas attestés ». Cette QA demande une capability vision (MiniMax/ai-01, cf R5 `model-delegation.md`) — **ma lane po-2026 z.ai executor n'a pas cette capability**. Je m'engage à **pinger ai-01** sur le dashboard workspace pour QA visuelle après merge.

Build statique généré (`slides/07-elargissements/07-elargissements/dist/`) — 7 chunks md-*.js portent les 6 notebooks ancrés (vérifié par `grep -c` sur les assets). Le contenu est rendu, seul le contrôle overflow/lisibilité/canvas n'est pas exécutable par cette lane.

## Garde-fous traversés

- **c.692-L1** anti-composite : **1 fichier modifié**, +51/-8 sur slides/07-elargissements/slides.md. Pas de mélange avec le calage #13237 (ni image ni animation touchée).
- **catalog-pr-hygiene** : catalogue byte-identique à main, aucun toucher.
- **secrets-hygiene** : aucun literal inline.
- **Acceptance epic** :
  - Critère 1 (citations in-slide) : 5 ancrages in-slide + 1 slide nouvelle = 6 sections corps ancrées (vs 0 avant)
  - Critère 2 (sujets substantiels couverts) : nouvelle slide « Conscience mesurable » comble le manque IIT↔GWT empirique ; chiffrement homomorphe → vote vérifiable = ajout d'une 4ème garantie de privacy
  - Critère 3 (link-label + navlinks) : 0 finding repo-wide
  - Critère 4 (build Slidev) : SUCCESS 7.52s ; QA visuelle à déléguer (cf limitation ci-dessus)
  - Critère 5 (pas de mélange de volets) : aucun fichier `.image-row`, aucune animation layout touchée

## Portée de la PR

- **Un seul livrable** : ancrage contenu du deck 07 sur 6 notebooks du dépôt. Pas composite (1 fichier), G-VAR-1 TENU (MED/slides = CONTENU).
- **Référence** : `See #15023` (l'epic reste ouverte — d'autres tranches en cours par d'autres lanes). Cette PR traite UNE tranche.
- **Disjoint** : aucune intersection avec `slides/S2-...`/`S3-...` (claim-amend ai-01 c.990 sur #13237), `slides/08-...` (po-2024:CoursIA-2 PR #15026), `slides/05-...` (po-2027:CoursIA PR #15115), `slides/01-...`+`02-...` (po-2027:CoursIA-2 PR #15049+#15051), `slides/04-...` (po-2027:CoursIA claim en cours).

## Tell fondateur c.992

**`render_deck.py` n'est pas sur `main`** : l'instrument de QA visuelle créé par PR #15017 (#15127 MERGED?) n'est pas encore mergé → absent du worktree frais `feature/15023-deck07-elargissements`. Pour cette tranche, QA visuelle **non exécutable** par ma lane et non couverte par une autre voie automatique. **Escalade ai-01 demandée** post-merge pour QA vision `?clicks=99` sur les 6 slides touchées.
