### PR TITLE
chore(hygiene,#13742): de-track transformer_checkpoint.pt (LFS) + arbitrage binaires tranche 1

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/.gitignore
+++ b/MyIA.AI.Notebooks/QuantConnect/.gitignore
@@ -70,7 +70,6 @@ object-store/
 *.h5
 *.pt
 # EXCEPTION: Final model files referenced by executed notebooks (tracked via git LFS)
-!Python/transformer_checkpoint.pt
 !Python/transformer_multiasset_model.pt
 !Python/best_ppo_model.pt
 !Python/best_dqn_model.pt

--- a/MyIA.AI.Notebooks/QuantConnect/Python/transformer_checkpoint.pt
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/transformer_checkpoint.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ab08a4d64a1d215e1ccf5600f4b48fee371755ce3d0e7e9c0b2fc82d11b58b3
-size 43541550


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #14984

## Summary

Tranche 1 des binaires VERIFIÉS de #13742 — arbitrage des 3 lignes de la première table + action. #14321 (docs/data-policy) a livré la partie doc ; cette PR tranche les binaires au cas par cas.

| Binaire | Mesure | Verdict | Action |
|---|---|---|---|
| `MyIA.Trading.Converter/7z-x64.dll` + `7z-x86.dll` | 3,0 + 2,6 Mo | **CONSERVÉES** (refus écrit) | Rien. Référencées par le chemin `CompressionLibrary.SevenZipSharp` : `CompressionHelper.cs:282` charge `7z-x64.dll`/`7z-x86.dll` selon la bitness, PackageReference `Squid-Box.SevenZipSharp` 1.6.1.23 (csproj:53), configs exemples `"Library": "SevenZipSharp"`, doc README §Compression. Le mode est un chemin réel, pas mort. |
| `QuantConnect/Python/transformer_checkpoint.pt` | 41,5 Mo (LFS) | **RETIRÉ du suivi** | `git rm --cached` du pointeur LFS + retrait de l'exception `.gitignore` `!Python/transformer_checkpoint.pt`. C'est un **checkpoint de reprise** de training — le notebook QC-Py-31 l'écrit au run et imprime « (ne pas commit) » (l.1979) ; distinct du modèle final `transformer_multiasset_model.pt` (conservé, l.1862). Régénérable (reprise from-scratch, l.1886-1888), pas un modèle final. |
| `ML/ML.Net/taxi-fare.csv` | 24 Mo | **DÉJÀ couvert** | Rien. Le fichier est **gitignore** (match `git check-ignore`) depuis le 2026-08-30 — 24 Mo non trackés. L'arbitrage « LFS ou fetch-script » est résolu par l'état : déjà non versionné. |

Fichiers touchés : `MyIA.AI.Notebooks/QuantConnect/.gitignore` (retrait d'une ligne d'exception) + suppression du pointeur LFS `transformer_checkpoint.pt` (3 lignes). Le fichier reste sur disque comme artifact de training local (aucune donnée perdue).

## Validation

| Organe | Résultat |
|---|---|
| `git check-ignore transformer_checkpoint.pt` | match (`*.pt` couvre le fichier après retrait de l'exception) |
| `git lfs ls-files --cached` | fichier ABSENT de l'index LFS (retrait effectif) |
| Notebook | aucun notebook modifié → aucune re-exécution requise ; le retrait d'un artifact de training ne casse pas l'exécution (cas from-scratch couvert, QC-Py-31 l.1886-1888) |
| Anti-régression | que des délétions d'hygiène (pointeur LFS + exception gitignore), 0 code retiré ; les autre `.pt` finaux (modèles) restent suivis |

See #13742 (tranche 1 — l'arbitrage des binaires RAPPORTÉS/datasets reste à trancher dans des tranches suivantes).
