### PR TITLE
fix(pymc,#15108): DecPyMC-5 — monotonie EVSI (politique fixee vs optimale)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -5,10 +5,10 @@
    "id": "1d3c4b05",
    "metadata": {
     "papermill": {
-     "duration": 0.007138,
-     "end_time": "2026-08-01T20:10:12.212028",
+     "duration": 0.005942,
+     "end_time": "2026-09-07T22:43:49.709521",
      "exception": false,
-     "start_time": "2026-08-01T20:10:12.204890",
+     "start_time": "2026-09-07T22:43:49.703579",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "3b0146a8",
    "metadata": {
     "papermill": {
-     "duration": 0.005557,
-     "end_time": "2026-08-01T20:10:12.222964",
+     "duration": 0.005298,
+     "end_time": "2026-09-07T22:43:49.722620",
      "exception": false,
-     "start_time": "2026-08-01T20:10:12.217407",
+     "start_time": "2026-09-07T22:43:49.717322",
      "status": "completed"
     },
     "tags": []
@@ -67,16 +67,16 @@
    "id": "4e90e20f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:12.234127Z",
-     "iopub.status.busy": "2026-08-01T20:10:12.233821Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.001070Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.000552Z"
+     "iopub.execute_input": "2026-09-07T22:43:49.734840Z",
+     "iopub.status.busy": "2026-09-07T22:43:49.734545Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.593533Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.592972Z"
     },
     "papermill": {
-     "duration": 0.773727,
-     "end_time": "2026-08-01T20:10:13.001856",
+     "duration": 0.866669,
+     "end_time": "2026-09-07T22:43:50.594557",
      "exception": false,
-     "start_time": "2026-08-01T20:10:12.228129",
+     "start_time": "2026-09-07T22:43:49.727888",
      "status": "completed"
     },
     "tags": []
@@ -107,10 +107,10 @@
    "id": "61fb4ddc",
    "metadata": {
     "papermill": {
-     "duration": 0.004791,
-     "end_time": "2026-08-01T20:10:13.012039",
+     "duration": 0.005383,
+     "end_time": "2026-09-07T22:43:50.605942",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.007248",
+     "start_time": "2026-09-07T22:43:50.600559",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "019e4470",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.022249Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.022007Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.027869Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.027505Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.618390Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.617993Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.622624Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.622227Z"
     },
     "papermill": {
-     "duration": 0.011671,
-     "end_time": "2026-08-01T20:10:13.028486",
+     "duration": 0.012032,
+     "end_time": "2026-09-07T22:43:50.623376",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.016815",
+     "start_time": "2026-09-07T22:43:50.611344",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "id": "8f7dc8aa",
    "metadata": {
     "papermill": {
-     "duration": 0.004713,
-     "end_time": "2026-08-01T20:10:13.037855",
+     "duration": 0.005713,
+     "end_time": "2026-09-07T22:43:50.634919",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.033142",
+     "start_time": "2026-09-07T22:43:50.629206",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +240,10 @@
    "id": "e252949a",
    "metadata": {
     "papermill": {
-     "duration": 0.004632,
-     "end_time": "2026-08-01T20:10:13.047237",
+     "duration": 0.005549,
+     "end_time": "2026-09-07T22:43:50.645993",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.042605",
+     "start_time": "2026-09-07T22:43:50.640444",
      "status": "completed"
     },
     "tags": []
@@ -280,10 +280,10 @@
    "id": "c42398e6",
    "metadata": {
     "papermill": {
-     "duration": 0.004542,
-     "end_time": "2026-08-01T20:10:13.056181",
+     "duration": 0.005586,
+     "end_time": "2026-09-07T22:43:50.658965",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.051639",
+     "start_time": "2026-09-07T22:43:50.653379",
      "status": "completed"
     },
     "tags": []
@@ -304,16 +304,16 @@
    "id": "230b8b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.066186Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.065994Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.070135Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.069747Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.671465Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.671124Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.675323Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.674844Z"
     },
     "papermill": {
-     "duration": 0.010291,
-     "end_time": "2026-08-01T20:10:13.070830",
+     "duration": 0.011118,
+     "end_time": "2026-09-07T22:43:50.676030",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.060539",
+     "start_time": "2026-09-07T22:43:50.664912",
      "status": "completed"
     },
     "tags": []
@@ -368,10 +368,10 @@
    "id": "d38ad65e",
    "metadata": {
     "papermill": {
-     "duration": 0.004657,
-     "end_time": "2026-08-01T20:10:13.080450",
+     "duration": 0.006655,
+     "end_time": "2026-09-07T22:43:50.688930",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.075793",
+     "start_time": "2026-09-07T22:43:50.682275",
      "status": "completed"
     },
     "tags": []
@@ -404,16 +404,16 @@
    "id": "2c4ecfc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.090431Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.090251Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.094007Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.093508Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.704356Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.704064Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.707650Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.707167Z"
     },
     "papermill": {
-     "duration": 0.009768,
-     "end_time": "2026-08-01T20:10:13.094799",
+     "duration": 0.010938,
+     "end_time": "2026-09-07T22:43:50.708863",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.085031",
+     "start_time": "2026-09-07T22:43:50.697925",
      "status": "completed"
     },
     "tags": []
@@ -489,10 +489,10 @@
    "id": "fef2e2bc",
    "metadata": {
     "papermill": {
-     "duration": 0.004676,
-     "end_time": "2026-08-01T20:10:13.104462",
+     "duration": 0.006033,
+     "end_time": "2026-09-07T22:43:50.721703",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.099786",
+     "start_time": "2026-09-07T22:43:50.715670",
      "status": "completed"
     },
     "tags": []
@@ -521,10 +521,10 @@
    "id": "d5546018",
    "metadata": {
     "papermill": {
-     "duration": 0.004991,
-     "end_time": "2026-08-01T20:10:13.114213",
+     "duration": 0.005858,
+     "end_time": "2026-09-07T22:43:50.734239",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.109222",
+     "start_time": "2026-09-07T22:43:50.728381",
      "status": "completed"
     },
     "tags": []
@@ -548,16 +548,16 @@
    "id": "f6734232",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.124412Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.124222Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.128871Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.128445Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.747253Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.746958Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.752405Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.751877Z"
     },
     "papermill": {
-     "duration": 0.011014,
-     "end_time": "2026-08-01T20:10:13.129723",
+     "duration": 0.013094,
+     "end_time": "2026-09-07T22:43:50.753295",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.118709",
+     "start_time": "2026-09-07T22:43:50.740201",
      "status": "completed"
     },
     "tags": []
@@ -631,10 +631,10 @@
    "id": "a4db5e30",
    "metadata": {
     "papermill": {
-     "duration": 0.004594,
-     "end_time": "2026-08-01T20:10:13.139296",
+     "duration": 0.00708,
+     "end_time": "2026-09-07T22:43:50.766502",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.134702",
+     "start_time": "2026-09-07T22:43:50.759422",
      "status": "completed"
     },
     "tags": []
@@ -671,10 +671,10 @@
    "id": "8103fd34",
    "metadata": {
     "papermill": {
-     "duration": 0.004704,
-     "end_time": "2026-08-01T20:10:13.148757",
+     "duration": 0.006113,
+     "end_time": "2026-09-07T22:43:50.778329",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.144053",
+     "start_time": "2026-09-07T22:43:50.772216",
      "status": "completed"
     },
     "tags": []
@@ -693,16 +693,16 @@
    "id": "ba1428ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.159375Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.159129Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.162264Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.161868Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.802169Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.801895Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.805907Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.805262Z"
     },
     "papermill": {
-     "duration": 0.009221,
-     "end_time": "2026-08-01T20:10:13.162937",
+     "duration": 0.01725,
+     "end_time": "2026-09-07T22:43:50.807601",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.153716",
+     "start_time": "2026-09-07T22:43:50.790351",
      "status": "completed"
     },
     "tags": []
@@ -741,10 +741,10 @@
    "id": "6312f621",
    "metadata": {
     "papermill": {
-     "duration": 0.005093,
-     "end_time": "2026-08-01T20:10:13.173880",
+     "duration": 0.009083,
+     "end_time": "2026-09-07T22:43:50.826240",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.168787",
+     "start_time": "2026-09-07T22:43:50.817157",
      "status": "completed"
     },
     "tags": []
@@ -771,16 +771,16 @@
    "id": "6e219ca9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.184565Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.184268Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.187778Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.187387Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.849010Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.848579Z",
+     "iopub.status.idle": "2026-09-07T22:43:50.852419Z",
+     "shell.execute_reply": "2026-09-07T22:43:50.851891Z"
     },
     "papermill": {
-     "duration": 0.009649,
-     "end_time": "2026-08-01T20:10:13.188407",
+     "duration": 0.016878,
+     "end_time": "2026-09-07T22:43:50.853528",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.178758",
+     "start_time": "2026-09-07T22:43:50.836650",
      "status": "completed"
     },
     "tags": []
@@ -837,10 +837,10 @@
    "id": "28b493d8",
    "metadata": {
     "papermill": {
-     "duration": 0.004625,
-     "end_time": "2026-08-01T20:10:13.197929",
+     "duration": 0.011217,
+     "end_time": "2026-09-07T22:43:50.875738",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.193304",
+     "start_time": "2026-09-07T22:43:50.864521",
      "status": "completed"
     },
     "tags": []
@@ -870,10 +870,10 @@
    "id": "1b9da7e6",
    "metadata": {
     "papermill": {
-     "duration": 0.004916,
-     "end_time": "2026-08-01T20:10:13.207374",
+     "duration": 0.006939,
+     "end_time": "2026-09-07T22:43:50.895304",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.202458",
+     "start_time": "2026-09-07T22:43:50.888365",
      "status": "completed"
     },
     "tags": []
@@ -895,16 +895,16 @@
    "id": "c3e9ff82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.218664Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.218362Z",
-     "iopub.status.idle": "2026-08-01T20:10:13.671007Z",
-     "shell.execute_reply": "2026-08-01T20:10:13.670552Z"
+     "iopub.execute_input": "2026-09-07T22:43:50.909694Z",
+     "iopub.status.busy": "2026-09-07T22:43:50.909204Z",
+     "iopub.status.idle": "2026-09-07T22:43:51.380947Z",
+     "shell.execute_reply": "2026-09-07T22:43:51.380470Z"
     },
     "papermill": {
-     "duration": 0.459066,
-     "end_time": "2026-08-01T20:10:13.671756",
+     "duration": 0.480881,
+     "end_time": "2026-09-07T22:43:51.381992",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.212690",
+     "start_time": "2026-09-07T22:43:50.901111",
      "status": "completed"
     },
     "tags": []
@@ -966,10 +966,10 @@
    "id": "dbf8652d",
    "metadata": {
     "papermill": {
-     "duration": 0.00474,
-     "end_time": "2026-08-01T20:10:13.682256",
+     "duration": 0.005594,
+     "end_time": "2026-09-07T22:43:51.393353",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.677516",
+     "start_time": "2026-09-07T22:43:51.387759",
      "status": "completed"
     },
     "tags": []
@@ -993,16 +993,16 @@
    "id": "f9111a49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:13.692945Z",
-     "iopub.status.busy": "2026-08-01T20:10:13.692753Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.066668Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.066204Z"
+     "iopub.execute_input": "2026-09-07T22:43:51.407939Z",
+     "iopub.status.busy": "2026-09-07T22:43:51.407576Z",
+     "iopub.status.idle": "2026-09-07T22:43:54.318658Z",
+     "shell.execute_reply": "2026-09-07T22:43:54.318155Z"
     },
     "papermill": {
-     "duration": 2.380566,
-     "end_time": "2026-08-01T20:10:16.067407",
+     "duration": 2.920587,
+     "end_time": "2026-09-07T22:43:54.319578",
      "exception": false,
-     "start_time": "2026-08-01T20:10:13.686841",
+     "start_time": "2026-09-07T22:43:51.398991",
      "status": "completed"
     },
     "tags": []
@@ -1098,10 +1098,10 @@
    "id": "6e2e1b00",
    "metadata": {
     "papermill": {
-     "duration": 0.006562,
-     "end_time": "2026-08-01T20:10:16.079418",
+     "duration": 0.006724,
+     "end_time": "2026-09-07T22:43:54.332448",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.072856",
+     "start_time": "2026-09-07T22:43:54.325724",
      "status": "completed"
     },
     "tags": []
@@ -1133,10 +1133,10 @@
    "id": "fed67ea3",
    "metadata": {
     "papermill": {
-     "duration": 0.005117,
-     "end_time": "2026-08-01T20:10:16.089726",
+     "duration": 0.006024,
+     "end_time": "2026-09-07T22:43:54.344526",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.084609",
+     "start_time": "2026-09-07T22:43:54.338502",
      "status": "completed"
     },
     "tags": []
@@ -1158,16 +1158,16 @@
    "id": "3d5e5b52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.101671Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.101460Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.176717Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.176276Z"
+     "iopub.execute_input": "2026-09-07T22:43:54.357909Z",
+     "iopub.status.busy": "2026-09-07T22:43:54.357599Z",
+     "iopub.status.idle": "2026-09-07T22:43:54.483375Z",
+     "shell.execute_reply": "2026-09-07T22:43:54.482501Z"
     },
     "papermill": {
-     "duration": 0.082083,
-     "end_time": "2026-08-01T20:10:16.177409",
+     "duration": 0.133591,
+     "end_time": "2026-09-07T22:43:54.484453",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.095326",
+     "start_time": "2026-09-07T22:43:54.350862",
      "status": "completed"
     },
     "tags": []
@@ -1231,10 +1231,10 @@
    "id": "94ae7ff1",
    "metadata": {
     "papermill": {
-     "duration": 0.005786,
-     "end_time": "2026-08-01T20:10:16.189068",
+     "duration": 0.007551,
+     "end_time": "2026-09-07T22:43:54.499844",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.183282",
+     "start_time": "2026-09-07T22:43:54.492293",
      "status": "completed"
     },
     "tags": []
@@ -1252,10 +1252,10 @@
    "id": "634eddc5",
    "metadata": {
     "papermill": {
-     "duration": 0.005144,
-     "end_time": "2026-08-01T20:10:16.199637",
+     "duration": 0.007084,
+     "end_time": "2026-09-07T22:43:54.516709",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.194493",
+     "start_time": "2026-09-07T22:43:54.509625",
      "status": "completed"
     },
     "tags": []
@@ -1275,16 +1275,16 @@
    "id": "e6ebbde8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.212057Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.211794Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.419128Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.418463Z"
+     "iopub.execute_input": "2026-09-07T22:43:54.531621Z",
+     "iopub.status.busy": "2026-09-07T22:43:54.531348Z",
+     "iopub.status.idle": "2026-09-07T22:43:54.767175Z",
+     "shell.execute_reply": "2026-09-07T22:43:54.766465Z"
     },
     "papermill": {
-     "duration": 0.214903,
-     "end_time": "2026-08-01T20:10:16.419968",
+     "duration": 0.244172,
+     "end_time": "2026-09-07T22:43:54.767924",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.205065",
+     "start_time": "2026-09-07T22:43:54.523752",
      "status": "completed"
     },
     "tags": []
@@ -1366,10 +1366,10 @@
    "id": "0e59eb90",
    "metadata": {
     "papermill": {
-     "duration": 0.006877,
-     "end_time": "2026-08-01T20:10:16.433442",
+     "duration": 0.007172,
+     "end_time": "2026-09-07T22:43:54.782283",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.426565",
+     "start_time": "2026-09-07T22:43:54.775111",
      "status": "completed"
     },
     "tags": []
@@ -1403,10 +1403,10 @@
    "id": "456909ac",
    "metadata": {
     "papermill": {
-     "duration": 0.006546,
-     "end_time": "2026-08-01T20:10:16.448076",
+     "duration": 0.007208,
+     "end_time": "2026-09-07T22:43:54.796460",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.441530",
+     "start_time": "2026-09-07T22:43:54.789252",
      "status": "completed"
     },
     "tags": []
@@ -1447,10 +1447,10 @@
    "id": "c53912c2",
    "metadata": {
     "papermill": {
-     "duration": 0.007278,
-     "end_time": "2026-08-01T20:10:16.462121",
+     "duration": 0.006632,
+     "end_time": "2026-09-07T22:43:54.809955",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.454843",
+     "start_time": "2026-09-07T22:43:54.803323",
      "status": "completed"
     },
     "tags": []
@@ -1470,16 +1470,16 @@
    "id": "e832cd44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.475029Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.474833Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.481719Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.480993Z"
+     "iopub.execute_input": "2026-09-07T22:43:54.826328Z",
+     "iopub.status.busy": "2026-09-07T22:43:54.825995Z",
+     "iopub.status.idle": "2026-09-07T22:43:54.833564Z",
+     "shell.execute_reply": "2026-09-07T22:43:54.833122Z"
     },
     "papermill": {
-     "duration": 0.014317,
-     "end_time": "2026-08-01T20:10:16.482597",
+     "duration": 0.016517,
+     "end_time": "2026-09-07T22:43:54.834322",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.468280",
+     "start_time": "2026-09-07T22:43:54.817805",
      "status": "completed"
     },
     "tags": []
@@ -1594,10 +1594,10 @@
    "id": "f44f0f84",
    "metadata": {
     "papermill": {
-     "duration": 0.0058,
-     "end_time": "2026-08-01T20:10:16.495012",
+     "duration": 0.007742,
+     "end_time": "2026-09-07T22:43:54.856992",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.489212",
+     "start_time": "2026-09-07T22:43:54.849250",
      "status": "completed"
     },
     "tags": []
@@ -1628,10 +1628,10 @@
    "id": "ec3e3ae7",
    "metadata": {
     "papermill": {
-     "duration": 0.006419,
-     "end_time": "2026-08-01T20:10:16.507851",
+     "duration": 0.007822,
+     "end_time": "2026-09-07T22:43:54.872050",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.501432",
+     "start_time": "2026-09-07T22:43:54.864228",
      "status": "completed"
     },
     "tags": []
@@ -1649,16 +1649,16 @@
    "id": "5251bb1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.522779Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.522444Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.629374Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.628332Z"
+     "iopub.execute_input": "2026-09-07T22:43:54.887652Z",
+     "iopub.status.busy": "2026-09-07T22:43:54.887204Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.012619Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.011848Z"
     },
     "papermill": {
-     "duration": 0.115726,
-     "end_time": "2026-08-01T20:10:16.630260",
+     "duration": 0.135078,
+     "end_time": "2026-09-07T22:43:55.014088",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.514534",
+     "start_time": "2026-09-07T22:43:54.879010",
      "status": "completed"
     },
     "tags": []
@@ -1715,10 +1715,10 @@
    "id": "c6ef1bad",
    "metadata": {
     "papermill": {
-     "duration": 0.007053,
-     "end_time": "2026-08-01T20:10:16.644594",
+     "duration": 0.010513,
+     "end_time": "2026-09-07T22:43:55.033435",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.637541",
+     "start_time": "2026-09-07T22:43:55.022922",
      "status": "completed"
     },
     "tags": []
@@ -1740,16 +1740,16 @@
    "id": "160dd297",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.660204Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.659927Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.665323Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.664866Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.055262Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.054912Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.062654Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.061623Z"
     },
     "papermill": {
-     "duration": 0.014414,
-     "end_time": "2026-08-01T20:10:16.666043",
+     "duration": 0.019895,
+     "end_time": "2026-09-07T22:43:55.063823",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.651629",
+     "start_time": "2026-09-07T22:43:55.043928",
      "status": "completed"
     },
     "tags": []
@@ -1834,10 +1834,10 @@
    "id": "11d30395",
    "metadata": {
     "papermill": {
-     "duration": 0.006429,
-     "end_time": "2026-08-01T20:10:16.679205",
+     "duration": 0.009194,
+     "end_time": "2026-09-07T22:43:55.080481",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.672776",
+     "start_time": "2026-09-07T22:43:55.071287",
      "status": "completed"
     },
     "tags": []
@@ -1871,10 +1871,10 @@
    "id": "023c6fc9",
    "metadata": {
     "papermill": {
-     "duration": 0.007168,
-     "end_time": "2026-08-01T20:10:16.692949",
+     "duration": 0.009121,
+     "end_time": "2026-09-07T22:43:55.097018",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.685781",
+     "start_time": "2026-09-07T22:43:55.087897",
      "status": "completed"
     },
     "tags": []
@@ -1889,16 +1889,16 @@
    "id": "5d505001",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.708521Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.707980Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.784731Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.784274Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.117728Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.117359Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.214508Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.214001Z"
     },
     "papermill": {
-     "duration": 0.085272,
-     "end_time": "2026-08-01T20:10:16.785561",
+     "duration": 0.108604,
+     "end_time": "2026-09-07T22:43:55.215405",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.700289",
+     "start_time": "2026-09-07T22:43:55.106801",
      "status": "completed"
     },
     "tags": []
@@ -1940,10 +1940,10 @@
    "id": "6b60b611",
    "metadata": {
     "papermill": {
-     "duration": 0.006956,
-     "end_time": "2026-08-01T20:10:16.799714",
+     "duration": 0.008847,
+     "end_time": "2026-09-07T22:43:55.232096",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.792758",
+     "start_time": "2026-09-07T22:43:55.223249",
      "status": "completed"
     },
     "tags": []
@@ -1973,10 +1973,10 @@
    "id": "4e6002c0",
    "metadata": {
     "papermill": {
-     "duration": 0.006372,
-     "end_time": "2026-08-01T20:10:16.812761",
+     "duration": 0.007459,
+     "end_time": "2026-09-07T22:43:55.248301",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.806389",
+     "start_time": "2026-09-07T22:43:55.240842",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +1994,16 @@
    "id": "f5c89fe6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.826920Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.826723Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.831788Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.831354Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.264700Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.264487Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.269345Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.268854Z"
     },
     "papermill": {
-     "duration": 0.013509,
-     "end_time": "2026-08-01T20:10:16.832593",
+     "duration": 0.014332,
+     "end_time": "2026-09-07T22:43:55.270381",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.819084",
+     "start_time": "2026-09-07T22:43:55.256049",
      "status": "completed"
     },
     "tags": []
@@ -2080,10 +2080,10 @@
    "id": "349e1c4a",
    "metadata": {
     "papermill": {
-     "duration": 0.007309,
-     "end_time": "2026-08-01T20:10:16.847151",
+     "duration": 0.007587,
+     "end_time": "2026-09-07T22:43:55.285790",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.839842",
+     "start_time": "2026-09-07T22:43:55.278203",
      "status": "completed"
     },
     "tags": []
@@ -2113,10 +2113,10 @@
    "id": "cc202dd8",
    "metadata": {
     "papermill": {
-     "duration": 0.006427,
-     "end_time": "2026-08-01T20:10:16.860263",
+     "duration": 0.008757,
+     "end_time": "2026-09-07T22:43:55.303244",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.853836",
+     "start_time": "2026-09-07T22:43:55.294487",
      "status": "completed"
     },
     "tags": []
@@ -2125,23 +2125,35 @@
     "## 9. Extension : Stratégie séquentielle\n",
     "\n",
     "Et si on pouvait faire le **Test 1 d'abord**, puis decider du **Test 2** en fonction\n",
-    "du résultat ? C'est une stratégie séquentielle d'acquisition d'information.\n",
+    "du résultat ? C'est une acquisition d'information **séquentielle** : on conditionne le\n",
+    "second test au résultat du premier.\n",
     "\n",
-    "### Exercice 3 : EVSI d'une stratégie séquentielle (Test1 -> Test2)\n",
+    "### Exercice 3 : EVSI d'une politique séquentielle (Test1 -> Test2)\n",
     "\n",
-    "Calculez l'**EVSI** (Expected Value of Sample Information) d'une stratégie en deux\n",
-    "étapes : on effectue le Test 1 (cout `cout_t1`), puis **conditionnellement au résultat\n",
-    "positif** on effectue le Test 2 (cout `cout_t2`). Comparez cette stratégie séquentielle\n",
-    "a la stratégie \"Test 2 directement\" et a la stratégie \"ne pas tester\".\n",
+    "**Deux notions à distinguer** avant de calculer :\n",
+    "\n",
+    "- **Politique fixée** (imposée) : une règle de décision écrite à l'avance. Ici :\n",
+    "  *toujours faire Test 1, puis Test 2 seulement si Test 1 est positif*.\n",
+    "- **Politique optimale** : la règle qui maximise l'utilité espérée **sur un ensemble\n",
+    "  de politiques** — elle peut, sur chaque branche, s'arrêter ou continuer.\n",
+    "\n",
+    "Calculez l'**EVSI** (Expected Value of Sample Information) de la **politique fixée**\n",
+    "suivante : on effectue le Test 1 (cout `cout_t1`), puis **conditionnellement au résultat\n",
+    "positif** on effectue le Test 2 (cout `cout_t2`). Comparez-la à la stratégie\n",
+    "\"Test 2 directement\" et à la stratégie \"ne pas tester\".\n",
     "\n",
     "**Objectif** : Completez la fonction `stratégie_séquentielle` ci-dessous pour calculer\n",
-    "l'utilite esperee de la stratégie séquentielle optimale.\n",
+    "l'utilite esperee de la **politique fixée** (Test1 -> Test2 si Test1 positif).\n",
     "\n",
     "**Indices** :\n",
     "- Si Test 1 est négatif : pas de Test 2, decision = action optimale sans information\n",
     "- Si Test 1 est positif : le posterior après Test 1 devient le prior du Test 2\n",
-    "- L'EVSI = EU(stratégie séquentielle optimale) - EU(ne pas tester)\n",
-    "- Verifiez que la stratégie séquentielle >= Test 2 seul (propriete de monotonie de l'information)"
+    "- L'EVSI = EU(politique) - EU(ne pas tester)\n",
+    "- **Monotonie (à manier avec précaution)** : « la valeur ne diminue pas quand on ajoute\n",
+    "  de l'information » ne vaut que pour la **valeur optimale sur un ensemble qui contient\n",
+    "  les alternatives comparées**. Une **politique fixée** n'a aucune garantie de dominer une\n",
+    "  autre : celle imposée ici ne contient pas « Test 2 seul », donc elle peut lui être\n",
+    "  inférieure. L'exemple qui suit le forage démontre ce contre-exemple.\n"
    ]
   },
   {
@@ -2149,10 +2161,10 @@
    "id": "a5ff6753",
    "metadata": {
     "papermill": {
-     "duration": 0.006457,
-     "end_time": "2026-08-01T20:10:16.873373",
+     "duration": 0.008647,
+     "end_time": "2026-09-07T22:43:55.320231",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.866916",
+     "start_time": "2026-09-07T22:43:55.311584",
      "status": "completed"
     },
     "tags": []
@@ -2177,16 +2189,16 @@
    "id": "f2a157be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.887744Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.887388Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.893108Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.892707Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.337571Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.337052Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.343846Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.343050Z"
     },
     "papermill": {
-     "duration": 0.013974,
-     "end_time": "2026-08-01T20:10:16.893785",
+     "duration": 0.017105,
+     "end_time": "2026-09-07T22:43:55.345024",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.879811",
+     "start_time": "2026-09-07T22:43:55.327919",
      "status": "completed"
     },
     "tags": []
@@ -2287,10 +2299,10 @@
    "id": "evsi-negative-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.006622,
-     "end_time": "2026-08-01T20:10:16.907261",
+     "duration": 0.008601,
+     "end_time": "2026-09-07T22:43:55.363201",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.900639",
+     "start_time": "2026-09-07T22:43:55.354600",
      "status": "completed"
     },
     "tags": []
@@ -2337,21 +2349,159 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "monotonicite-fixee-vs-optimale-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007607,
+     "end_time": "2026-09-07T22:43:55.378572",
+     "exception": false,
+     "start_time": "2026-09-07T22:43:55.370965",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple guide : politique fixee vs politique optimale (monotonie)\n",
+    "\n",
+    "Le scénario du forage ci-dessus illustre une **politique fixée**. Pour voir le point\n",
+    "délicat de monotonie, énumérons **toutes** les politiques de la section 8 (scénario\n",
+    "médical, `prior_med` / `U_med` / `L1` / `L2`) en mettant les coûts à zéro, afin\n",
+    "d'isoler la valeur de l'information du coût des tests. L'ensemble des politiques\n",
+    "contient explicitement : ne pas tester, Test 1 seul, Test 2 directement, Test 1 puis\n",
+    "Test 2 seulement si positif, et Test 1 puis Test 2 sur chaque branche.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "monotonicite-oracle-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-07T22:43:55.398500Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.398075Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.407041Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.406503Z"
+    },
+    "papermill": {
+     "duration": 0.02158,
+     "end_time": "2026-09-07T22:43:55.408194",
+     "exception": false,
+     "start_time": "2026-09-07T22:43:55.386614",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Scenario medical, tests GRATUITS ===\n",
+      "  ne pas tester (seule decision) : 11\n",
+      "  Test 1 seul                    : 11\n",
+      "  Test 2 directement             : 24.020\n",
+      "  politique fixee (positive-only): 20.708\n",
+      "  politique optimale             : 24.020\n",
+      "  -> la fixee est DOMINEE par Test 2 seul : True\n",
+      "  -> monotonie de l'OPTIMAL (>= fixee)    : True\n",
+      "\n",
+      "=== Controle minimal (2 etats, Test1 non informatif, Test2 parfait, couts nuls) ===\n",
+      "  ne pas tester        : 50\n",
+      "  Test 2 seul          : 100\n",
+      "  politique fixee      : 75\n",
+      "  politique optimale   : 100\n",
+      "\n",
+      "=== Couts medicaux originaux (c1=50, c2=500) ===\n",
+      "  ne rien acquerir = optimum : 11 (le cout des tests depasse leur valeur)\n",
+      "\n",
+      "Verification : la monotonie vaut pour la VALEUR OPTIMALE (ensemble elargi), pas pour une politique fixee.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple guide : enumerer les politiques et verifier la monotonie sur l'optimal\n",
+    "# (scenario medical de la section 8 ; couts mis a 0 pour isoler la valeur du signal)\n",
+    "\n",
+    "def _eu_action(post_s, U):\n",
+    "    # meilleure action sachant le posterior post_s\n",
+    "    return max(U.T @ post_s)\n",
+    "\n",
+    "def _eu_test(prior, U, L):\n",
+    "    # EU d'acquerir le test L (likelihood L[etat, signal]) puis choisir la meilleure action\n",
+    "    P = prior @ L\n",
+    "    return sum(P[o] * _eu_action(prior * L[:, o] / P[o], U) for o in range(L.shape[1]))\n",
+    "\n",
+    "# Politique fixee : Test1 toujours ; si Test1+ alors Test2 ; si Test1- alors stop\n",
+    "def _eu_fixee(prior, U, L1, L2):\n",
+    "    P1 = prior @ L1\n",
+    "    eu_moins = _eu_action(prior * L1[:, 1] / P1[1], U)         # Test1- : stop\n",
+    "    Pp = prior * L1[:, 0] / P1[0]                              # prior Test2 = posterior Test1+\n",
+    "    P2 = Pp @ L2\n",
+    "    eu_plus = sum(P2[o] * _eu_action(Pp * L2[:, o] / P2[o], U) for o in range(2))\n",
+    "    return P1[1] * eu_moins + P1[0] * eu_plus\n",
+    "\n",
+    "# Politique optimale : Test1 toujours, puis sur CHAQUE branche max(stop, Test2)\n",
+    "def _eu_optimale(prior, U, L1, L2):\n",
+    "    P1 = prior @ L1\n",
+    "    def branche(post):\n",
+    "        P2 = post @ L2\n",
+    "        cont = sum(P2[o] * _eu_action(post * L2[:, o] / P2[o], U) for o in range(2))\n",
+    "        return max(_eu_action(post, U), cont)\n",
+    "    return P1[1] * branche(prior * L1[:, 1] / P1[1]) + P1[0] * branche(prior * L1[:, 0] / P1[0])\n",
+    "\n",
+    "eu_sans   = _eu_action(prior_med, U_med)\n",
+    "eu_t1     = _eu_test(prior_med, U_med, L1)\n",
+    "eu_t2     = _eu_test(prior_med, U_med, L2)\n",
+    "eu_fixee  = _eu_fixee(prior_med, U_med, L1, L2)\n",
+    "eu_optim  = _eu_optimale(prior_med, U_med, L1, L2)\n",
+    "\n",
+    "print(\"=== Scenario medical, tests GRATUITS ===\")\n",
+    "print(f\"  ne pas tester (seule decision) : {eu_sans:.0f}\")\n",
+    "print(f\"  Test 1 seul                    : {eu_t1:.0f}\")\n",
+    "print(f\"  Test 2 directement             : {eu_t2:.3f}\")\n",
+    "print(f\"  politique fixee (positive-only): {eu_fixee:.3f}\")\n",
+    "print(f\"  politique optimale             : {eu_optim:.3f}\")\n",
+    "print(f\"  -> la fixee est DOMINEE par Test 2 seul : {eu_fixee < eu_t2}\")\n",
+    "print(f\"  -> monotonie de l'OPTIMAL (>= fixee)    : {eu_optim >= eu_fixee}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"=== Controle minimal (2 etats, Test1 non informatif, Test2 parfait, couts nuls) ===\")\n",
+    "mprior = np.array([0.5, 0.5]); mU = np.array([[100, 0], [0, 100]])\n",
+    "mL1 = np.array([[0.5, 0.5], [0.5, 0.5]]); mL2 = np.array([[1.0, 0.0], [0.0, 1.0]])\n",
+    "print(f\"  ne pas tester        : {_eu_action(mprior, mU):.0f}\")\n",
+    "print(f\"  Test 2 seul          : {_eu_test(mprior, mU, mL2):.0f}\")\n",
+    "print(f\"  politique fixee      : {_eu_fixee(mprior, mU, mL1, mL2):.0f}\")\n",
+    "print(f\"  politique optimale   : {_eu_optimale(mprior, mU, mL1, mL2):.0f}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"=== Couts medicaux originaux (c1=50, c2=500) ===\")\n",
+    "print(f\"  ne rien acquerir = optimum : {eu_sans:.0f} (le cout des tests depasse leur valeur)\")\n",
+    "\n",
+    "assert eu_optim > eu_fixee, \"l'optimale doit dominer la politique fixee\"\n",
+    "assert eu_fixee < eu_t2, \"la politique fixee (positive-only) est dominee par Test 2 seul\"\n",
+    "assert abs(eu_optim - eu_t2) < 1e-9, \"l'optimale atteint au mieux la valeur de Test 2 seul (ici)\"\n",
+    "assert _eu_fixee(mprior, mU, mL1, mL2) < _eu_test(mprior, mU, mL2), \"contre-exemple minimal 75 < 100\"\n",
+    "print()\n",
+    "print(\"Verification : la monotonie vaut pour la VALEUR OPTIMALE (ensemble elargi), pas pour une politique fixee.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "id": "ca5ab857",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.921524Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.921327Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.925511Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.925098Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.426583Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.426246Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.430503Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.429973Z"
     },
     "papermill": {
-     "duration": 0.012436,
-     "end_time": "2026-08-01T20:10:16.926165",
+     "duration": 0.014705,
+     "end_time": "2026-09-07T22:43:55.431317",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.913729",
+     "start_time": "2026-09-07T22:43:55.416612",
      "status": "completed"
     },
     "tags": []
@@ -2396,10 +2546,10 @@
    "id": "300c4888",
    "metadata": {
     "papermill": {
-     "duration": 0.007428,
-     "end_time": "2026-08-01T20:10:16.940615",
+     "duration": 0.008872,
+     "end_time": "2026-09-07T22:43:55.447809",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.933187",
+     "start_time": "2026-09-07T22:43:55.438937",
      "status": "completed"
     },
     "tags": []
@@ -2417,10 +2567,10 @@
    "id": "4d8af0b9",
    "metadata": {
     "papermill": {
-     "duration": 0.007914,
-     "end_time": "2026-08-01T20:10:16.956195",
+     "duration": 0.008502,
+     "end_time": "2026-09-07T22:43:55.463873",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.948281",
+     "start_time": "2026-09-07T22:43:55.455371",
      "status": "completed"
     },
     "tags": []
@@ -2443,20 +2593,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "04a17e05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:16.980735Z",
-     "iopub.status.busy": "2026-08-01T20:10:16.980409Z",
-     "iopub.status.idle": "2026-08-01T20:10:16.992237Z",
-     "shell.execute_reply": "2026-08-01T20:10:16.991244Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.481826Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.481428Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.496442Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.495794Z"
     },
     "papermill": {
-     "duration": 0.028641,
-     "end_time": "2026-08-01T20:10:16.993314",
+     "duration": 0.025569,
+     "end_time": "2026-09-07T22:43:55.497341",
      "exception": false,
-     "start_time": "2026-08-01T20:10:16.964673",
+     "start_time": "2026-09-07T22:43:55.471772",
      "status": "completed"
     },
     "tags": []
@@ -2510,10 +2660,10 @@
    "id": "2573dea4",
    "metadata": {
     "papermill": {
-     "duration": 0.009312,
-     "end_time": "2026-08-01T20:10:17.012403",
+     "duration": 0.008788,
+     "end_time": "2026-09-07T22:43:55.513842",
      "exception": false,
-     "start_time": "2026-08-01T20:10:17.003091",
+     "start_time": "2026-09-07T22:43:55.505054",
      "status": "completed"
     },
     "tags": []
@@ -2528,20 +2678,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "6e9cdd71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:17.033231Z",
-     "iopub.status.busy": "2026-08-01T20:10:17.032995Z",
-     "iopub.status.idle": "2026-08-01T20:10:17.269145Z",
-     "shell.execute_reply": "2026-08-01T20:10:17.268782Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.531828Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.531603Z",
+     "iopub.status.idle": "2026-09-07T22:43:55.818295Z",
+     "shell.execute_reply": "2026-09-07T22:43:55.817614Z"
     },
     "papermill": {
-     "duration": 0.247848,
-     "end_time": "2026-08-01T20:10:17.270102",
+     "duration": 0.297563,
+     "end_time": "2026-09-07T22:43:55.819002",
      "exception": false,
-     "start_time": "2026-08-01T20:10:17.022254",
+     "start_time": "2026-09-07T22:43:55.521439",
      "status": "completed"
     },
     "tags": []
@@ -2619,7 +2769,16 @@
   {
    "cell_type": "markdown",
    "id": "b3c4e1f2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008685,
+     "end_time": "2026-09-07T22:43:55.836078",
+     "exception": false,
+     "start_time": "2026-09-07T22:43:55.827393",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : vitesse de convergence Monte Carlo\n",
     "\n",
@@ -2633,32 +2792,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "769bd2e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:17.286869Z",
-     "iopub.status.busy": "2026-08-01T20:10:17.286681Z",
-     "iopub.status.idle": "2026-08-01T20:10:35.949886Z",
-     "shell.execute_reply": "2026-08-01T20:10:35.948958Z"
+     "iopub.execute_input": "2026-09-07T22:43:55.854836Z",
+     "iopub.status.busy": "2026-09-07T22:43:55.854418Z",
+     "iopub.status.idle": "2026-09-07T22:44:05.966372Z",
+     "shell.execute_reply": "2026-09-07T22:44:05.965706Z"
     },
     "papermill": {
-     "duration": 18.672687,
-     "end_time": "2026-08-01T20:10:35.951062",
+     "duration": 10.121871,
+     "end_time": "2026-09-07T22:44:05.967275",
      "exception": false,
-     "start_time": "2026-08-01T20:10:17.278375",
+     "start_time": "2026-09-07T22:43:55.845404",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "g++ not available, if using conda: `conda install gxx`\n"
-     ]
-    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -2691,7 +2843,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 10_000 draw iterations (2_000 + 20_000 draws total) took 9 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 10_000 draw iterations (2_000 + 20_000 draws total) took 7 seconds.\n"
      ]
     },
     {
@@ -2777,10 +2929,10 @@
    "id": "b7bc368e",
    "metadata": {
     "papermill": {
-     "duration": 0.010408,
-     "end_time": "2026-08-01T20:10:35.970380",
+     "duration": 0.008341,
+     "end_time": "2026-09-07T22:44:05.984155",
      "exception": false,
-     "start_time": "2026-08-01T20:10:35.959972",
+     "start_time": "2026-09-07T22:44:05.975814",
      "status": "completed"
     },
     "tags": []
@@ -2801,20 +2953,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "520942ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:35.996262Z",
-     "iopub.status.busy": "2026-08-01T20:10:35.995923Z",
-     "iopub.status.idle": "2026-08-01T20:10:36.222451Z",
-     "shell.execute_reply": "2026-08-01T20:10:36.222039Z"
+     "iopub.execute_input": "2026-09-07T22:44:06.003212Z",
+     "iopub.status.busy": "2026-09-07T22:44:06.002712Z",
+     "iopub.status.idle": "2026-09-07T22:44:06.238834Z",
+     "shell.execute_reply": "2026-09-07T22:44:06.238337Z"
     },
     "papermill": {
-     "duration": 0.239518,
-     "end_time": "2026-08-01T20:10:36.223168",
+     "duration": 0.246722,
+     "end_time": "2026-09-07T22:44:06.239666",
      "exception": false,
-     "start_time": "2026-08-01T20:10:35.983650",
+     "start_time": "2026-09-07T22:44:05.992944",
      "status": "completed"
     },
     "tags": []
@@ -2917,10 +3069,10 @@
    "id": "3f79985d",
    "metadata": {
     "papermill": {
-     "duration": 0.008389,
-     "end_time": "2026-08-01T20:10:36.240656",
+     "duration": 0.009854,
+     "end_time": "2026-09-07T22:44:06.258899",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.232267",
+     "start_time": "2026-09-07T22:44:06.249045",
      "status": "completed"
     },
     "tags": []
@@ -2946,20 +3098,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "e7eec055",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:36.257793Z",
-     "iopub.status.busy": "2026-08-01T20:10:36.257575Z",
-     "iopub.status.idle": "2026-08-01T20:10:36.518335Z",
-     "shell.execute_reply": "2026-08-01T20:10:36.517805Z"
+     "iopub.execute_input": "2026-09-07T22:44:06.280827Z",
+     "iopub.status.busy": "2026-09-07T22:44:06.280370Z",
+     "iopub.status.idle": "2026-09-07T22:44:06.580258Z",
+     "shell.execute_reply": "2026-09-07T22:44:06.579661Z"
     },
     "papermill": {
-     "duration": 0.270432,
-     "end_time": "2026-08-01T20:10:36.519289",
+     "duration": 0.312067,
+     "end_time": "2026-09-07T22:44:06.581117",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.248857",
+     "start_time": "2026-09-07T22:44:06.269050",
      "status": "completed"
     },
     "tags": []
@@ -3043,10 +3195,10 @@
    "id": "89abb269",
    "metadata": {
     "papermill": {
-     "duration": 0.008642,
-     "end_time": "2026-08-01T20:10:36.537266",
+     "duration": 0.00913,
+     "end_time": "2026-09-07T22:44:06.609037",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.528624",
+     "start_time": "2026-09-07T22:44:06.599907",
      "status": "completed"
     },
     "tags": []
@@ -3061,20 +3213,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "f666376f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:36.555955Z",
-     "iopub.status.busy": "2026-08-01T20:10:36.555542Z",
-     "iopub.status.idle": "2026-08-01T20:10:36.829229Z",
-     "shell.execute_reply": "2026-08-01T20:10:36.828816Z"
+     "iopub.execute_input": "2026-09-07T22:44:06.628878Z",
+     "iopub.status.busy": "2026-09-07T22:44:06.628667Z",
+     "iopub.status.idle": "2026-09-07T22:44:06.940259Z",
+     "shell.execute_reply": "2026-09-07T22:44:06.939751Z"
     },
     "papermill": {
-     "duration": 0.283866,
-     "end_time": "2026-08-01T20:10:36.829911",
+     "duration": 0.322453,
+     "end_time": "2026-09-07T22:44:06.941085",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.546045",
+     "start_time": "2026-09-07T22:44:06.618632",
      "status": "completed"
     },
     "tags": []
@@ -3197,10 +3349,10 @@
    "id": "1ef76741",
    "metadata": {
     "papermill": {
-     "duration": 0.00919,
-     "end_time": "2026-08-01T20:10:36.848825",
+     "duration": 0.010072,
+     "end_time": "2026-09-07T22:44:06.961485",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.839635",
+     "start_time": "2026-09-07T22:44:06.951413",
      "status": "completed"
     },
     "tags": []
@@ -3234,10 +3386,10 @@
    "id": "56583bfd",
    "metadata": {
     "papermill": {
-     "duration": 0.009323,
-     "end_time": "2026-08-01T20:10:36.867223",
+     "duration": 0.010462,
+     "end_time": "2026-09-07T22:44:06.982255",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.857900",
+     "start_time": "2026-09-07T22:44:06.971793",
      "status": "completed"
     },
     "tags": []
@@ -3258,20 +3410,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "c752eb51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:36.886571Z",
-     "iopub.status.busy": "2026-08-01T20:10:36.886357Z",
-     "iopub.status.idle": "2026-08-01T20:10:37.000891Z",
-     "shell.execute_reply": "2026-08-01T20:10:37.000437Z"
+     "iopub.execute_input": "2026-09-07T22:44:07.004342Z",
+     "iopub.status.busy": "2026-09-07T22:44:07.004064Z",
+     "iopub.status.idle": "2026-09-07T22:44:07.138547Z",
+     "shell.execute_reply": "2026-09-07T22:44:07.138039Z"
     },
     "papermill": {
-     "duration": 0.125153,
-     "end_time": "2026-08-01T20:10:37.001573",
+     "duration": 0.146559,
+     "end_time": "2026-09-07T22:44:07.139329",
      "exception": false,
-     "start_time": "2026-08-01T20:10:36.876420",
+     "start_time": "2026-09-07T22:44:06.992770",
      "status": "completed"
     },
     "tags": []
@@ -3355,10 +3507,10 @@
    "id": "71a7f150",
    "metadata": {
     "papermill": {
-     "duration": 0.010248,
-     "end_time": "2026-08-01T20:10:37.022991",
+     "duration": 0.010732,
+     "end_time": "2026-09-07T22:44:07.161541",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.012743",
+     "start_time": "2026-09-07T22:44:07.150809",
      "status": "completed"
     },
     "tags": []
@@ -3394,10 +3546,10 @@
    "id": "cc2cc982",
    "metadata": {
     "papermill": {
-     "duration": 0.011068,
-     "end_time": "2026-08-01T20:10:37.044652",
+     "duration": 0.012093,
+     "end_time": "2026-09-07T22:44:07.184269",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.033584",
+     "start_time": "2026-09-07T22:44:07.172176",
      "status": "completed"
     },
     "tags": []
@@ -3435,10 +3587,10 @@
    "id": "hier-limits-md",
    "metadata": {
     "papermill": {
-     "duration": 0.012671,
-     "end_time": "2026-08-01T20:10:37.069623",
+     "duration": 0.012486,
+     "end_time": "2026-09-07T22:44:07.208619",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.056952",
+     "start_time": "2026-09-07T22:44:07.196133",
      "status": "completed"
     },
     "tags": []
@@ -3456,10 +3608,10 @@
    "id": "ex4_pymc_partial_pooling",
    "metadata": {
     "papermill": {
-     "duration": 0.011147,
-     "end_time": "2026-08-01T20:10:37.091071",
+     "duration": 0.011214,
+     "end_time": "2026-09-07T22:44:07.230306",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.079924",
+     "start_time": "2026-09-07T22:44:07.219092",
      "status": "completed"
     },
     "tags": []
@@ -3490,20 +3642,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "hier-model-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:37.115179Z",
-     "iopub.status.busy": "2026-08-01T20:10:37.113652Z",
-     "iopub.status.idle": "2026-08-01T20:10:37.120362Z",
-     "shell.execute_reply": "2026-08-01T20:10:37.119408Z"
+     "iopub.execute_input": "2026-09-07T22:44:07.253084Z",
+     "iopub.status.busy": "2026-09-07T22:44:07.252870Z",
+     "iopub.status.idle": "2026-09-07T22:44:07.258644Z",
+     "shell.execute_reply": "2026-09-07T22:44:07.258069Z"
     },
     "papermill": {
-     "duration": 0.018645,
-     "end_time": "2026-08-01T20:10:37.121697",
+     "duration": 0.018227,
+     "end_time": "2026-09-07T22:44:07.259404",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.103052",
+     "start_time": "2026-09-07T22:44:07.241177",
      "status": "completed"
     },
     "tags": []
@@ -3565,10 +3717,10 @@
    "id": "hier-shrink-md",
    "metadata": {
     "papermill": {
-     "duration": 0.014334,
-     "end_time": "2026-08-01T20:10:37.149858",
+     "duration": 0.010808,
+     "end_time": "2026-09-07T22:44:07.281074",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.135524",
+     "start_time": "2026-09-07T22:44:07.270266",
      "status": "completed"
     },
     "tags": []
@@ -3583,20 +3735,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "hier-shrink-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:37.172382Z",
-     "iopub.status.busy": "2026-08-01T20:10:37.171827Z",
-     "iopub.status.idle": "2026-08-01T20:10:37.177259Z",
-     "shell.execute_reply": "2026-08-01T20:10:37.176749Z"
+     "iopub.execute_input": "2026-09-07T22:44:07.304372Z",
+     "iopub.status.busy": "2026-09-07T22:44:07.304079Z",
+     "iopub.status.idle": "2026-09-07T22:44:07.307188Z",
+     "shell.execute_reply": "2026-09-07T22:44:07.306755Z"
     },
     "papermill": {
-     "duration": 0.017389,
-     "end_time": "2026-08-01T20:10:37.178129",
+     "duration": 0.015793,
+     "end_time": "2026-09-07T22:44:07.307940",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.160740",
+     "start_time": "2026-09-07T22:44:07.292147",
      "status": "completed"
     },
     "tags": []
@@ -3627,20 +3779,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "hier-evsi-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:37.200414Z",
-     "iopub.status.busy": "2026-08-01T20:10:37.199911Z",
-     "iopub.status.idle": "2026-08-01T20:10:37.203851Z",
-     "shell.execute_reply": "2026-08-01T20:10:37.203419Z"
+     "iopub.execute_input": "2026-09-07T22:44:07.331867Z",
+     "iopub.status.busy": "2026-09-07T22:44:07.331528Z",
+     "iopub.status.idle": "2026-09-07T22:44:07.335682Z",
+     "shell.execute_reply": "2026-09-07T22:44:07.335153Z"
     },
     "papermill": {
-     "duration": 0.016303,
-     "end_time": "2026-08-01T20:10:37.204866",
+     "duration": 0.016551,
+     "end_time": "2026-09-07T22:44:07.336496",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.188563",
+     "start_time": "2026-09-07T22:44:07.319945",
      "status": "completed"
     },
     "tags": []
@@ -3674,10 +3826,10 @@
    "id": "hier-interp-md",
    "metadata": {
     "papermill": {
-     "duration": 0.009892,
-     "end_time": "2026-08-01T20:10:37.225005",
+     "duration": 0.010973,
+     "end_time": "2026-09-07T22:44:07.358330",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.215113",
+     "start_time": "2026-09-07T22:44:07.347357",
      "status": "completed"
     },
     "tags": []
@@ -3695,10 +3847,10 @@
    "id": "abb2c9f2",
    "metadata": {
     "papermill": {
-     "duration": 0.011245,
-     "end_time": "2026-08-01T20:10:37.247926",
+     "duration": 0.010765,
+     "end_time": "2026-09-07T22:44:07.379937",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.236681",
+     "start_time": "2026-09-07T22:44:07.369172",
      "status": "completed"
     },
     "tags": []
@@ -3731,20 +3883,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "2417343e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-01T20:10:37.271731Z",
-     "iopub.status.busy": "2026-08-01T20:10:37.271331Z",
-     "iopub.status.idle": "2026-08-01T20:10:37.276778Z",
-     "shell.execute_reply": "2026-08-01T20:10:37.276270Z"
+     "iopub.execute_input": "2026-09-07T22:44:07.405460Z",
+     "iopub.status.busy": "2026-09-07T22:44:07.405209Z",
+     "iopub.status.idle": "2026-09-07T22:44:07.410066Z",
+     "shell.execute_reply": "2026-09-07T22:44:07.409665Z"
     },
     "papermill": {
-     "duration": 0.017413,
-     "end_time": "2026-08-01T20:10:37.277576",
+     "duration": 0.018775,
+     "end_time": "2026-09-07T22:44:07.410812",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.260163",
+     "start_time": "2026-09-07T22:44:07.392037",
      "status": "completed"
     },
     "tags": []
@@ -3814,10 +3966,10 @@
    "id": "9905e068",
    "metadata": {
     "papermill": {
-     "duration": 0.010357,
-     "end_time": "2026-08-01T20:10:37.298402",
+     "duration": 0.010693,
+     "end_time": "2026-09-07T22:44:07.432462",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.288045",
+     "start_time": "2026-09-07T22:44:07.421769",
      "status": "completed"
     },
     "tags": []
@@ -3864,10 +4016,10 @@
    "id": "a8db71b7",
    "metadata": {
     "papermill": {
-     "duration": 0.01018,
-     "end_time": "2026-08-01T20:10:37.318659",
+     "duration": 0.011103,
+     "end_time": "2026-09-07T22:44:07.454346",
      "exception": false,
-     "start_time": "2026-08-01T20:10:37.308479",
+     "start_time": "2026-09-07T22:44:07.443243",
      "status": "completed"
     },
     "tags": []
@@ -3925,14 +4077,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 27.857733,
-   "end_time": "2026-08-01T20:10:38.326449",
+   "duration": 20.518981,
+   "end_time": "2026-09-07T22:44:08.465741",
    "environment_variables": {},
    "exception": null,
-   "input_path": "DecPyMC-5-Value-Information.ipynb",
-   "output_path": "decpymc5_reexec.ipynb",
+   "input_path": "D:\\Dev\\CoursIA-15108\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-5-Value-Information.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-15108\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-5-Value-Information_output.ipynb",
    "parameters": {},
-   "start_time": "2026-08-01T20:10:10.468716",
+   "start_time": "2026-09-07T22:43:47.946760",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -5,10 +5,10 @@
    "id": "1d3c4b05",
    "metadata": {
     "papermill": {
-     "duration": 0.005942,
-     "end_time": "2026-09-07T22:43:49.709521",
+     "duration": 0.006116,
+     "end_time": "2026-09-08T20:40:51.701579",
      "exception": false,
-     "start_time": "2026-09-07T22:43:49.703579",
+     "start_time": "2026-09-08T20:40:51.695463",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "3b0146a8",
    "metadata": {
     "papermill": {
-     "duration": 0.005298,
-     "end_time": "2026-09-07T22:43:49.722620",
+     "duration": 0.005562,
+     "end_time": "2026-09-08T20:40:51.715069",
      "exception": false,
-     "start_time": "2026-09-07T22:43:49.717322",
+     "start_time": "2026-09-08T20:40:51.709507",
      "status": "completed"
     },
     "tags": []
@@ -67,16 +67,16 @@
    "id": "4e90e20f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:49.734840Z",
-     "iopub.status.busy": "2026-09-07T22:43:49.734545Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.593533Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.592972Z"
+     "iopub.execute_input": "2026-09-08T20:40:51.727143Z",
+     "iopub.status.busy": "2026-09-08T20:40:51.726822Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.035173Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.034785Z"
     },
     "papermill": {
-     "duration": 0.866669,
-     "end_time": "2026-09-07T22:43:50.594557",
+     "duration": 7.315252,
+     "end_time": "2026-09-08T20:40:59.035874",
      "exception": false,
-     "start_time": "2026-09-07T22:43:49.727888",
+     "start_time": "2026-09-08T20:40:51.720622",
      "status": "completed"
     },
     "tags": []
@@ -107,10 +107,10 @@
    "id": "61fb4ddc",
    "metadata": {
     "papermill": {
-     "duration": 0.005383,
-     "end_time": "2026-09-07T22:43:50.605942",
+     "duration": 0.00478,
+     "end_time": "2026-09-08T20:40:59.046301",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.600559",
+     "start_time": "2026-09-08T20:40:59.041521",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "019e4470",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.618390Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.617993Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.622624Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.622227Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.056484Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.056234Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.061576Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.061189Z"
     },
     "papermill": {
-     "duration": 0.012032,
-     "end_time": "2026-09-07T22:43:50.623376",
+     "duration": 0.01116,
+     "end_time": "2026-09-08T20:40:59.062227",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.611344",
+     "start_time": "2026-09-08T20:40:59.051067",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "id": "8f7dc8aa",
    "metadata": {
     "papermill": {
-     "duration": 0.005713,
-     "end_time": "2026-09-07T22:43:50.634919",
+     "duration": 0.004531,
+     "end_time": "2026-09-08T20:40:59.071774",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.629206",
+     "start_time": "2026-09-08T20:40:59.067243",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +240,10 @@
    "id": "e252949a",
    "metadata": {
     "papermill": {
-     "duration": 0.005549,
-     "end_time": "2026-09-07T22:43:50.645993",
+     "duration": 0.004645,
+     "end_time": "2026-09-08T20:40:59.081987",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.640444",
+     "start_time": "2026-09-08T20:40:59.077342",
      "status": "completed"
     },
     "tags": []
@@ -280,10 +280,10 @@
    "id": "c42398e6",
    "metadata": {
     "papermill": {
-     "duration": 0.005586,
-     "end_time": "2026-09-07T22:43:50.658965",
+     "duration": 0.0049,
+     "end_time": "2026-09-08T20:40:59.091432",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.653379",
+     "start_time": "2026-09-08T20:40:59.086532",
      "status": "completed"
     },
     "tags": []
@@ -304,16 +304,16 @@
    "id": "230b8b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.671465Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.671124Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.675323Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.674844Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.102574Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.102358Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.107119Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.106776Z"
     },
     "papermill": {
-     "duration": 0.011118,
-     "end_time": "2026-09-07T22:43:50.676030",
+     "duration": 0.011586,
+     "end_time": "2026-09-08T20:40:59.107954",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.664912",
+     "start_time": "2026-09-08T20:40:59.096368",
      "status": "completed"
     },
     "tags": []
@@ -368,10 +368,10 @@
    "id": "d38ad65e",
    "metadata": {
     "papermill": {
-     "duration": 0.006655,
-     "end_time": "2026-09-07T22:43:50.688930",
+     "duration": 0.004777,
+     "end_time": "2026-09-08T20:40:59.117756",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.682275",
+     "start_time": "2026-09-08T20:40:59.112979",
      "status": "completed"
     },
     "tags": []
@@ -404,16 +404,16 @@
    "id": "2c4ecfc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.704356Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.704064Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.707650Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.707167Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.128674Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.128493Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.132118Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.131692Z"
     },
     "papermill": {
-     "duration": 0.010938,
-     "end_time": "2026-09-07T22:43:50.708863",
+     "duration": 0.009836,
+     "end_time": "2026-09-08T20:40:59.132789",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.697925",
+     "start_time": "2026-09-08T20:40:59.122953",
      "status": "completed"
     },
     "tags": []
@@ -489,10 +489,10 @@
    "id": "fef2e2bc",
    "metadata": {
     "papermill": {
-     "duration": 0.006033,
-     "end_time": "2026-09-07T22:43:50.721703",
+     "duration": 0.005413,
+     "end_time": "2026-09-08T20:40:59.143766",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.715670",
+     "start_time": "2026-09-08T20:40:59.138353",
      "status": "completed"
     },
     "tags": []
@@ -507,7 +507,7 @@
     "\n",
     "| Paramètre | Valeur | Impact |\n",
     "|-----------|--------|--------|\n",
-    "| Seuil de decision | P = 0.50 | Au-dessus, forer ; en dessous, vendre |\n",
+    "| Seuil de decision | P = 0.70 | Au-dessus, forer ; en dessous, vendre — seuil = (prix_vente + cout_forage) / gain_petrole = (200 + 500) / 1000 |\n",
     "| EVPI | 90k EUR | Valeur maximale d'un test parfait |\n",
     "| Asymétrie des gains | 500k vs -500k | Forte incertitude = forte valeur d'information |\n",
     "\n",
@@ -521,10 +521,10 @@
    "id": "d5546018",
    "metadata": {
     "papermill": {
-     "duration": 0.005858,
-     "end_time": "2026-09-07T22:43:50.734239",
+     "duration": 0.004744,
+     "end_time": "2026-09-08T20:40:59.153345",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.728381",
+     "start_time": "2026-09-08T20:40:59.148601",
      "status": "completed"
     },
     "tags": []
@@ -548,16 +548,16 @@
    "id": "f6734232",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.747253Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.746958Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.752405Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.751877Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.164693Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.164415Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.168848Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.168450Z"
     },
     "papermill": {
-     "duration": 0.013094,
-     "end_time": "2026-09-07T22:43:50.753295",
+     "duration": 0.010908,
+     "end_time": "2026-09-08T20:40:59.169528",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.740201",
+     "start_time": "2026-09-08T20:40:59.158620",
      "status": "completed"
     },
     "tags": []
@@ -631,10 +631,10 @@
    "id": "a4db5e30",
    "metadata": {
     "papermill": {
-     "duration": 0.00708,
-     "end_time": "2026-09-07T22:43:50.766502",
+     "duration": 0.005169,
+     "end_time": "2026-09-08T20:40:59.180256",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.759422",
+     "start_time": "2026-09-08T20:40:59.175087",
      "status": "completed"
     },
     "tags": []
@@ -671,10 +671,10 @@
    "id": "8103fd34",
    "metadata": {
     "papermill": {
-     "duration": 0.006113,
-     "end_time": "2026-09-07T22:43:50.778329",
+     "duration": 0.00502,
+     "end_time": "2026-09-08T20:40:59.190896",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.772216",
+     "start_time": "2026-09-08T20:40:59.185876",
      "status": "completed"
     },
     "tags": []
@@ -693,16 +693,16 @@
    "id": "ba1428ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.802169Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.801895Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.805907Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.805262Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.201608Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.201300Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.204436Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.203956Z"
     },
     "papermill": {
-     "duration": 0.01725,
-     "end_time": "2026-09-07T22:43:50.807601",
+     "duration": 0.009433,
+     "end_time": "2026-09-08T20:40:59.205085",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.790351",
+     "start_time": "2026-09-08T20:40:59.195652",
      "status": "completed"
     },
     "tags": []
@@ -738,109 +738,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6312f621",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009083,
-     "end_time": "2026-09-07T22:43:50.826240",
-     "exception": false,
-     "start_time": "2026-09-07T22:43:50.817157",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice : Acheter un indice dans la chasse au trèsor\n",
-    "\n",
-    "La chasse au trèsor passe de 5 a **10 coffres**. Un marchand propose un **indice parfait**\n",
-    "(revelant exactement ou se trouve le trèsor) pour un certain prix.\n",
-    "\n",
-    "**Objectif** : Calculer l'EVPI pour 10 coffres, puis déterminer si l'achat de l'indice\n",
-    "a 30 unites est rentable. A partir de combien de coffres l'indice devient-il rentable ?\n",
-    "\n",
-    "**Indices** :\n",
-    "- Sans info : P(trouver) = 1/N, EU = P * valeur - cout_fouille\n",
-    "- Avec info parfaite : on fouille le bon coffre a coup sur, EU = valeur - cout_fouille\n",
-    "- EVPI = EU(info parfaite) - EU(sans info)\n",
-    "- L'indice est rentable si EVPI > cout_indice"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "6e219ca9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.849010Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.848579Z",
-     "iopub.status.idle": "2026-09-07T22:43:50.852419Z",
-     "shell.execute_reply": "2026-09-07T22:43:50.851891Z"
-    },
-    "papermill": {
-     "duration": 0.016878,
-     "end_time": "2026-09-07T22:43:50.853528",
-     "exception": false,
-     "start_time": "2026-09-07T22:43:50.836650",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice a completer : EVPI pour N coffres et decision d'achat d'indice\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice : EVPI pour N coffres et decision d'achat d'indice\n",
-    "# TODO etudiant : calculer l'EVPI pour un nombre variable de coffres\n",
-    "# et determiner a partir de combien de coffres l'indice vaut son cout.\n",
-    "\n",
-    "# Etape 1 : definir les parametres du scenario\n",
-    "n_coffres = 10          # nombre de coffres (au lieu de 5)\n",
-    "valeur_tresor = 100     # valeur du tresor\n",
-    "cout_fouille = 10       # cout de fouille d'un coffre\n",
-    "cout_indice = 30        # cout d'un indice parfait (revele le bon coffre)\n",
-    "\n",
-    "# Etape 2 : calculer EU sans information (choisir un coffre au hasard)\n",
-    "# Indice : p_tresor = 1 / n_coffres, EU = p_tresor * valeur_tresor - cout_fouille\n",
-    "eu_sans_info_ex = None  # TODO etudiant : remplacer par le calcul\n",
-    "\n",
-    "# Etape 3 : calculer EU avec information parfaite (savoir ou est le tresor)\n",
-    "# Indice : on fouille directement le bon coffre\n",
-    "eu_info_parfaite_ex = None  # TODO etudiant : remplacer par le calcul\n",
-    "\n",
-    "# Etape 4 : calculer l'EVPI\n",
-    "evpi_ex = None  # TODO etudiant : eu_info_parfaite_ex - eu_sans_info_ex\n",
-    "\n",
-    "# Etape 5 : comparer EVPI avec le cout de l'indice et conclure\n",
-    "# Indice : si EVPI > cout_indice, l'indice est rentable\n",
-    "achat_recommande = None  # TODO etudiant : True si EVPI >= cout_indice, False sinon\n",
-    "\n",
-    "result = {\n",
-    "    \"n_coffres\": n_coffres,\n",
-    "    \"eu_sans_info\": eu_sans_info_ex,\n",
-    "    \"eu_info_parfaite\": eu_info_parfaite_ex,\n",
-    "    \"evpi\": evpi_ex,\n",
-    "    \"cout_indice\": cout_indice,\n",
-    "    \"achat_recommande\": achat_recommande,\n",
-    "}\n",
-    "\n",
-    "print(\"Exercice a completer : EVPI pour N coffres et decision d'achat d'indice\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "28b493d8",
    "metadata": {
     "papermill": {
-     "duration": 0.011217,
-     "end_time": "2026-09-07T22:43:50.875738",
+     "duration": 0.015239,
+     "end_time": "2026-09-08T20:40:59.225369",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.864521",
+     "start_time": "2026-09-08T20:40:59.210130",
      "status": "completed"
     },
     "tags": []
@@ -867,13 +771,112 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6312f621",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005304,
+     "end_time": "2026-09-08T20:40:59.236081",
+     "exception": false,
+     "start_time": "2026-09-08T20:40:59.230777",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Acheter un indice dans la chasse au trèsor\n",
+    "\n",
+    "La chasse au trèsor passe de 5 a **10 coffres**. Un marchand propose un **indice parfait**\n",
+    "(revelant exactement ou se trouve le trèsor) pour un certain prix.\n",
+    "\n",
+    "**Objectif** : Calculer l'EVPI pour 10 coffres, puis déterminer si l'achat de l'indice\n",
+    "a 30 unites est rentable. A partir de combien de coffres l'indice devient-il rentable ?\n",
+    "\n",
+    "**Indices** :\n",
+    "- Sans info : P(trouver) = 1/N, EU = P * valeur - cout_fouille\n",
+    "- Avec info parfaite : on fouille le bon coffre a coup sur, EU = valeur - cout_fouille\n",
+    "- EVPI = EU(info parfaite) - EU(sans info)\n",
+    "- L'indice est rentable si EVPI > cout_indice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6e219ca9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T20:40:59.247126Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.246848Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.250619Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.250211Z"
+    },
+    "papermill": {
+     "duration": 0.009975,
+     "end_time": "2026-09-08T20:40:59.251229",
+     "exception": false,
+     "start_time": "2026-09-08T20:40:59.241254",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : EVPI pour N coffres et decision d'achat d'indice\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice : EVPI pour N coffres et decision d'achat d'indice\n",
+    "# TODO etudiant : calculer l'EVPI pour un nombre variable de coffres\n",
+    "# et determiner a partir de combien de coffres l'indice vaut son cout.\n",
+    "\n",
+    "# Etape 1 : definir les parametres du scenario\n",
+    "# Suffixes _ex : parametres ISOLES de l'exemple a 5 coffres ci-dessus, dont les\n",
+    "# cellules suivantes (detecteur de metal, EVPI parametrique) reutilisent les\n",
+    "# variables sans ecrasement.\n",
+    "n_coffres_ex = 10        # nombre de coffres (l'exemple en avait 5)\n",
+    "valeur_tresor_ex = 100   # valeur du tresor\n",
+    "cout_fouille_ex = 10     # cout de fouille d'un coffre\n",
+    "cout_indice = 30         # cout d'un indice parfait (revele le bon coffre)\n",
+    "\n",
+    "# Etape 2 : calculer EU sans information (choisir un coffre au hasard)\n",
+    "# Indice : p_tresor = 1 / n_coffres_ex, EU = p_tresor * valeur_tresor_ex - cout_fouille_ex\n",
+    "eu_sans_info_ex = None  # TODO etudiant : remplacer par le calcul\n",
+    "\n",
+    "# Etape 3 : calculer EU avec information parfaite (savoir ou est le tresor)\n",
+    "# Indice : on fouille directement le bon coffre\n",
+    "eu_info_parfaite_ex = None  # TODO etudiant : remplacer par le calcul\n",
+    "\n",
+    "# Etape 4 : calculer l'EVPI\n",
+    "evpi_ex = None  # TODO etudiant : eu_info_parfaite_ex - eu_sans_info_ex\n",
+    "\n",
+    "# Etape 5 : comparer EVPI avec le cout de l'indice et conclure\n",
+    "# Indice : si EVPI > cout_indice, l'indice est rentable\n",
+    "achat_recommande = None  # TODO etudiant : True si EVPI >= cout_indice, False sinon\n",
+    "\n",
+    "result = {\n",
+    "    \"n_coffres\": n_coffres_ex,\n",
+    "    \"eu_sans_info\": eu_sans_info_ex,\n",
+    "    \"eu_info_parfaite\": eu_info_parfaite_ex,\n",
+    "    \"evpi\": evpi_ex,\n",
+    "    \"cout_indice\": cout_indice,\n",
+    "    \"achat_recommande\": achat_recommande,\n",
+    "}\n",
+    "\n",
+    "print(\"Exercice a completer : EVPI pour N coffres et decision d'achat d'indice\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1b9da7e6",
    "metadata": {
     "papermill": {
-     "duration": 0.006939,
-     "end_time": "2026-09-07T22:43:50.895304",
+     "duration": 0.005234,
+     "end_time": "2026-09-08T20:40:59.261949",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.888365",
+     "start_time": "2026-09-08T20:40:59.256715",
      "status": "completed"
     },
     "tags": []
@@ -895,16 +898,16 @@
    "id": "c3e9ff82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:50.909694Z",
-     "iopub.status.busy": "2026-09-07T22:43:50.909204Z",
-     "iopub.status.idle": "2026-09-07T22:43:51.380947Z",
-     "shell.execute_reply": "2026-09-07T22:43:51.380470Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.273682Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.273491Z",
+     "iopub.status.idle": "2026-09-08T20:40:59.746070Z",
+     "shell.execute_reply": "2026-09-08T20:40:59.745447Z"
     },
     "papermill": {
-     "duration": 0.480881,
-     "end_time": "2026-09-07T22:43:51.381992",
+     "duration": 0.48034,
+     "end_time": "2026-09-08T20:40:59.747577",
      "exception": false,
-     "start_time": "2026-09-07T22:43:50.901111",
+     "start_time": "2026-09-08T20:40:59.267237",
      "status": "completed"
     },
     "tags": []
@@ -914,11 +917,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "EU avec detecteur (Monte Carlo) = 17.9\n",
-      "EVSI detecteur = 7.9\n",
-      "Efficacite EVSI/EVPI = 10%\n",
+      "EU avec detecteur (Monte Carlo) = 37.6\n",
+      "EVSI detecteur = 27.6\n",
+      "Efficacite EVSI/EVPI = 35%\n",
       "\n",
-      "Le detecteur capture ~10% de l'information parfaite.\n"
+      "Le detecteur capture ~35% de l'information parfaite.\n"
      ]
     }
    ],
@@ -966,10 +969,10 @@
    "id": "dbf8652d",
    "metadata": {
     "papermill": {
-     "duration": 0.005594,
-     "end_time": "2026-09-07T22:43:51.393353",
+     "duration": 0.006946,
+     "end_time": "2026-09-08T20:40:59.762376",
      "exception": false,
-     "start_time": "2026-09-07T22:43:51.387759",
+     "start_time": "2026-09-08T20:40:59.755430",
      "status": "completed"
     },
     "tags": []
@@ -993,16 +996,16 @@
    "id": "f9111a49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:51.407939Z",
-     "iopub.status.busy": "2026-09-07T22:43:51.407576Z",
-     "iopub.status.idle": "2026-09-07T22:43:54.318658Z",
-     "shell.execute_reply": "2026-09-07T22:43:54.318155Z"
+     "iopub.execute_input": "2026-09-08T20:40:59.776466Z",
+     "iopub.status.busy": "2026-09-08T20:40:59.776169Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.273475Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.273035Z"
     },
     "papermill": {
-     "duration": 2.920587,
-     "end_time": "2026-09-07T22:43:54.319578",
+     "duration": 2.506803,
+     "end_time": "2026-09-08T20:41:02.274975",
      "exception": false,
-     "start_time": "2026-09-07T22:43:51.398991",
+     "start_time": "2026-09-08T20:40:59.768172",
      "status": "completed"
     },
     "tags": []
@@ -1098,10 +1101,10 @@
    "id": "6e2e1b00",
    "metadata": {
     "papermill": {
-     "duration": 0.006724,
-     "end_time": "2026-09-07T22:43:54.332448",
+     "duration": 0.005302,
+     "end_time": "2026-09-08T20:41:02.286579",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.325724",
+     "start_time": "2026-09-08T20:41:02.281277",
      "status": "completed"
     },
     "tags": []
@@ -1133,10 +1136,10 @@
    "id": "fed67ea3",
    "metadata": {
     "papermill": {
-     "duration": 0.006024,
-     "end_time": "2026-09-07T22:43:54.344526",
+     "duration": 0.005791,
+     "end_time": "2026-09-08T20:41:02.297791",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.338502",
+     "start_time": "2026-09-08T20:41:02.292000",
      "status": "completed"
     },
     "tags": []
@@ -1158,16 +1161,16 @@
    "id": "3d5e5b52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:54.357909Z",
-     "iopub.status.busy": "2026-09-07T22:43:54.357599Z",
-     "iopub.status.idle": "2026-09-07T22:43:54.483375Z",
-     "shell.execute_reply": "2026-09-07T22:43:54.482501Z"
+     "iopub.execute_input": "2026-09-08T20:41:02.310599Z",
+     "iopub.status.busy": "2026-09-08T20:41:02.310365Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.396104Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.395452Z"
     },
     "papermill": {
-     "duration": 0.133591,
-     "end_time": "2026-09-07T22:43:54.484453",
+     "duration": 0.093788,
+     "end_time": "2026-09-08T20:41:02.397341",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.350862",
+     "start_time": "2026-09-08T20:41:02.303553",
      "status": "completed"
     },
     "tags": []
@@ -1231,10 +1234,10 @@
    "id": "94ae7ff1",
    "metadata": {
     "papermill": {
-     "duration": 0.007551,
-     "end_time": "2026-09-07T22:43:54.499844",
+     "duration": 0.006316,
+     "end_time": "2026-09-08T20:41:02.410391",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.492293",
+     "start_time": "2026-09-08T20:41:02.404075",
      "status": "completed"
     },
     "tags": []
@@ -1252,10 +1255,10 @@
    "id": "634eddc5",
    "metadata": {
     "papermill": {
-     "duration": 0.007084,
-     "end_time": "2026-09-07T22:43:54.516709",
+     "duration": 0.005952,
+     "end_time": "2026-09-08T20:41:02.422329",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.509625",
+     "start_time": "2026-09-08T20:41:02.416377",
      "status": "completed"
     },
     "tags": []
@@ -1275,16 +1278,16 @@
    "id": "e6ebbde8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:54.531621Z",
-     "iopub.status.busy": "2026-09-07T22:43:54.531348Z",
-     "iopub.status.idle": "2026-09-07T22:43:54.767175Z",
-     "shell.execute_reply": "2026-09-07T22:43:54.766465Z"
+     "iopub.execute_input": "2026-09-08T20:41:02.435096Z",
+     "iopub.status.busy": "2026-09-08T20:41:02.434593Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.608466Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.607894Z"
     },
     "papermill": {
-     "duration": 0.244172,
-     "end_time": "2026-09-07T22:43:54.767924",
+     "duration": 0.181265,
+     "end_time": "2026-09-08T20:41:02.609212",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.523752",
+     "start_time": "2026-09-08T20:41:02.427947",
      "status": "completed"
     },
     "tags": []
@@ -1366,10 +1369,10 @@
    "id": "0e59eb90",
    "metadata": {
     "papermill": {
-     "duration": 0.007172,
-     "end_time": "2026-09-07T22:43:54.782283",
+     "duration": 0.00677,
+     "end_time": "2026-09-08T20:41:02.623419",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.775111",
+     "start_time": "2026-09-08T20:41:02.616649",
      "status": "completed"
     },
     "tags": []
@@ -1403,10 +1406,10 @@
    "id": "456909ac",
    "metadata": {
     "papermill": {
-     "duration": 0.007208,
-     "end_time": "2026-09-07T22:43:54.796460",
+     "duration": 0.00744,
+     "end_time": "2026-09-08T20:41:02.638482",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.789252",
+     "start_time": "2026-09-08T20:41:02.631042",
      "status": "completed"
     },
     "tags": []
@@ -1426,7 +1429,7 @@
     "\n",
     "**Facteurs qui augmentent la valeur de l'information** :\n",
     "\n",
-    "1. **Incertitude elevee** : l'EVPI est maximal a la frontiere de decision (P ~ 0.35 dans notre forage)\n",
+    "1. **Incertitude elevee** : l'EVPI est maximal a la frontiere de decision (P = 0.70 dans notre forage — le seuil calculé où forer cesse de dominer vendre)\n",
     "2. **Asymétrie des gains** : des utilites très contrastees augmentent l'enjeu de la bonne decision\n",
     "3. **Reversibilite faible** : une decision irreversible rend l'information plus precieuse\n",
     "4. **Cout d'erreur eleve** : plus l'erreur coute cher, plus l'info vaut\n",
@@ -1447,10 +1450,10 @@
    "id": "c53912c2",
    "metadata": {
     "papermill": {
-     "duration": 0.006632,
-     "end_time": "2026-09-07T22:43:54.809955",
+     "duration": 0.007422,
+     "end_time": "2026-09-08T20:41:02.652888",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.803323",
+     "start_time": "2026-09-08T20:41:02.645466",
      "status": "completed"
     },
     "tags": []
@@ -1470,16 +1473,16 @@
    "id": "e832cd44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:54.826328Z",
-     "iopub.status.busy": "2026-09-07T22:43:54.825995Z",
-     "iopub.status.idle": "2026-09-07T22:43:54.833564Z",
-     "shell.execute_reply": "2026-09-07T22:43:54.833122Z"
+     "iopub.execute_input": "2026-09-08T20:41:02.671610Z",
+     "iopub.status.busy": "2026-09-08T20:41:02.671389Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.681836Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.680697Z"
     },
     "papermill": {
-     "duration": 0.016517,
-     "end_time": "2026-09-07T22:43:54.834322",
+     "duration": 0.021801,
+     "end_time": "2026-09-08T20:41:02.682959",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.817805",
+     "start_time": "2026-09-08T20:41:02.661158",
      "status": "completed"
     },
     "tags": []
@@ -1594,10 +1597,10 @@
    "id": "f44f0f84",
    "metadata": {
     "papermill": {
-     "duration": 0.007742,
-     "end_time": "2026-09-07T22:43:54.856992",
+     "duration": 0.008276,
+     "end_time": "2026-09-08T20:41:02.698671",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.849250",
+     "start_time": "2026-09-08T20:41:02.690395",
      "status": "completed"
     },
     "tags": []
@@ -1628,10 +1631,10 @@
    "id": "ec3e3ae7",
    "metadata": {
     "papermill": {
-     "duration": 0.007822,
-     "end_time": "2026-09-07T22:43:54.872050",
+     "duration": 0.007963,
+     "end_time": "2026-09-08T20:41:02.717662",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.864228",
+     "start_time": "2026-09-08T20:41:02.709699",
      "status": "completed"
     },
     "tags": []
@@ -1649,16 +1652,16 @@
    "id": "5251bb1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:54.887652Z",
-     "iopub.status.busy": "2026-09-07T22:43:54.887204Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.012619Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.011848Z"
+     "iopub.execute_input": "2026-09-08T20:41:02.739117Z",
+     "iopub.status.busy": "2026-09-08T20:41:02.738891Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.834950Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.834572Z"
     },
     "papermill": {
-     "duration": 0.135078,
-     "end_time": "2026-09-07T22:43:55.014088",
+     "duration": 0.10734,
+     "end_time": "2026-09-08T20:41:02.835739",
      "exception": false,
-     "start_time": "2026-09-07T22:43:54.879010",
+     "start_time": "2026-09-08T20:41:02.728399",
      "status": "completed"
     },
     "tags": []
@@ -1715,10 +1718,10 @@
    "id": "c6ef1bad",
    "metadata": {
     "papermill": {
-     "duration": 0.010513,
-     "end_time": "2026-09-07T22:43:55.033435",
+     "duration": 0.006712,
+     "end_time": "2026-09-08T20:41:02.849386",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.022922",
+     "start_time": "2026-09-08T20:41:02.842674",
      "status": "completed"
     },
     "tags": []
@@ -1740,16 +1743,16 @@
    "id": "160dd297",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.055262Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.054912Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.062654Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.061623Z"
+     "iopub.execute_input": "2026-09-08T20:41:02.865064Z",
+     "iopub.status.busy": "2026-09-08T20:41:02.864670Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.870407Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.869955Z"
     },
     "papermill": {
-     "duration": 0.019895,
-     "end_time": "2026-09-07T22:43:55.063823",
+     "duration": 0.014318,
+     "end_time": "2026-09-08T20:41:02.871019",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.043928",
+     "start_time": "2026-09-08T20:41:02.856701",
      "status": "completed"
     },
     "tags": []
@@ -1770,7 +1773,8 @@
       "  EVSI brut = 13, net = -487\n",
       "  Efficacite = 54%\n",
       "\n",
-      "Recommandation : Test 1 (EVSI net plus eleve)\n"
+      "Valeurs nettes (aucun test = 0) : aucun test = 0, Test 1 = -50, Test 2 = -487\n",
+      "Recommandation : aucun test (valeur nette maximale)\n"
      ]
     }
    ],
@@ -1825,8 +1829,12 @@
     "print(f\"  EVSI brut = {evsi_t2:.0f}, net = {evsi_t2 - cout_t2:.0f}\")\n",
     "print(f\"  Efficacite = {evsi_t2/evpi_med*100:.0f}%\")\n",
     "\n",
-    "print(f\"\\nRecommandation : {'Test 1' if evsi_t1 - cout_t1 > evsi_t2 - cout_t2 else 'Test 2'} \"\n",
-    "      f\"(EVSI net plus eleve)\")"
+    "# Decision : comparer les valeurs nettes AVEC l'option \"aucun test\" (valeur nette 0).\n",
+    "# Recommander un test a EVSI net negatif serait une erreur : ne rien acquerir domine.\n",
+    "nets = {\"aucun test\": 0.0, \"Test 1\": evsi_t1 - cout_t1, \"Test 2\": evsi_t2 - cout_t2}\n",
+    "reco = max(nets, key=nets.get)\n",
+    "print(\"\\nValeurs nettes (aucun test = 0) : \" + \", \".join(f\"{k} = {v:.0f}\" for k, v in nets.items()))\n",
+    "print(f\"Recommandation : {reco} (valeur nette maximale)\")"
    ]
   },
   {
@@ -1834,10 +1842,10 @@
    "id": "11d30395",
    "metadata": {
     "papermill": {
-     "duration": 0.009194,
-     "end_time": "2026-09-07T22:43:55.080481",
+     "duration": 0.006745,
+     "end_time": "2026-09-08T20:41:02.885948",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.071287",
+     "start_time": "2026-09-08T20:41:02.879203",
      "status": "completed"
     },
     "tags": []
@@ -1853,6 +1861,10 @@
     "|------|-----------|------|----------|------------|\n",
     "| Test 1 (sanguin) | ~0 EUR | 50 EUR | -50 EUR | ~0% |\n",
     "| Test 2 (imagerie) | 13 EUR | 500 EUR | -487 EUR | 54% |\n",
+    "\n",
+    "Les valeurs nettes étant toutes deux négatives (−50 et −487), l'option\n",
+    "**« aucun test »** (valeur nette zéro) domine : la recommandation rationnelle est\n",
+    "de ne rien acquérir et de garder l'action sans information (EU = 11).\n",
     "\n",
     "**Pourquoi les tests echouent ici** : La matrice d'utilite donne des valeurs faibles\n",
     "(EVPI = 24 seulement). Le test sanguin ne distingue pas suffisamment \"Leger\" de \"Grave\"\n",
@@ -1871,10 +1883,10 @@
    "id": "023c6fc9",
    "metadata": {
     "papermill": {
-     "duration": 0.009121,
-     "end_time": "2026-09-07T22:43:55.097018",
+     "duration": 0.007147,
+     "end_time": "2026-09-08T20:41:02.900506",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.087897",
+     "start_time": "2026-09-08T20:41:02.893359",
      "status": "completed"
     },
     "tags": []
@@ -1889,16 +1901,16 @@
    "id": "5d505001",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.117728Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.117359Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.214508Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.214001Z"
+     "iopub.execute_input": "2026-09-08T20:41:02.915402Z",
+     "iopub.status.busy": "2026-09-08T20:41:02.915213Z",
+     "iopub.status.idle": "2026-09-08T20:41:02.989616Z",
+     "shell.execute_reply": "2026-09-08T20:41:02.988989Z"
     },
     "papermill": {
-     "duration": 0.108604,
-     "end_time": "2026-09-07T22:43:55.215405",
+     "duration": 0.082446,
+     "end_time": "2026-09-08T20:41:02.990370",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.106801",
+     "start_time": "2026-09-08T20:41:02.907924",
      "status": "completed"
     },
     "tags": []
@@ -1940,10 +1952,10 @@
    "id": "6b60b611",
    "metadata": {
     "papermill": {
-     "duration": 0.008847,
-     "end_time": "2026-09-07T22:43:55.232096",
+     "duration": 0.007845,
+     "end_time": "2026-09-08T20:41:03.005690",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.223249",
+     "start_time": "2026-09-08T20:41:02.997845",
      "status": "completed"
     },
     "tags": []
@@ -1973,10 +1985,10 @@
    "id": "4e6002c0",
    "metadata": {
     "papermill": {
-     "duration": 0.007459,
-     "end_time": "2026-09-07T22:43:55.248301",
+     "duration": 0.007753,
+     "end_time": "2026-09-08T20:41:03.020780",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.240842",
+     "start_time": "2026-09-08T20:41:03.013027",
      "status": "completed"
     },
     "tags": []
@@ -1994,16 +2006,16 @@
    "id": "f5c89fe6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.264700Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.264487Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.269345Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.268854Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.039399Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.039191Z",
+     "iopub.status.idle": "2026-09-08T20:41:03.044717Z",
+     "shell.execute_reply": "2026-09-08T20:41:03.044111Z"
     },
     "papermill": {
-     "duration": 0.014332,
-     "end_time": "2026-09-07T22:43:55.270381",
+     "duration": 0.015602,
+     "end_time": "2026-09-08T20:41:03.046118",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.256049",
+     "start_time": "2026-09-08T20:41:03.030516",
      "status": "completed"
     },
     "tags": []
@@ -2080,10 +2092,10 @@
    "id": "349e1c4a",
    "metadata": {
     "papermill": {
-     "duration": 0.007587,
-     "end_time": "2026-09-07T22:43:55.285790",
+     "duration": 0.007867,
+     "end_time": "2026-09-08T20:41:03.064362",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.278203",
+     "start_time": "2026-09-08T20:41:03.056495",
      "status": "completed"
     },
     "tags": []
@@ -2113,10 +2125,10 @@
    "id": "cc202dd8",
    "metadata": {
     "papermill": {
-     "duration": 0.008757,
-     "end_time": "2026-09-07T22:43:55.303244",
+     "duration": 0.007377,
+     "end_time": "2026-09-08T20:41:03.080468",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.294487",
+     "start_time": "2026-09-08T20:41:03.073091",
      "status": "completed"
     },
     "tags": []
@@ -2146,7 +2158,7 @@
     "l'utilite esperee de la **politique fixée** (Test1 -> Test2 si Test1 positif).\n",
     "\n",
     "**Indices** :\n",
-    "- Si Test 1 est négatif : pas de Test 2, decision = action optimale sans information\n",
+    "- Si Test 1 est négatif : pas de Test 2, decision = action optimale **conditionnellement au résultat négatif** — la meilleure action sachant le posterior après Test 1−, pas celle du prior initial (le signal négatif du Test 1 reste acquis : ne pas faire le Test 2 ne l'efface pas)\n",
     "- Si Test 1 est positif : le posterior après Test 1 devient le prior du Test 2\n",
     "- L'EVSI = EU(politique) - EU(ne pas tester)\n",
     "- **Monotonie (à manier avec précaution)** : « la valeur ne diminue pas quand on ajoute\n",
@@ -2161,10 +2173,10 @@
    "id": "a5ff6753",
    "metadata": {
     "papermill": {
-     "duration": 0.008647,
-     "end_time": "2026-09-07T22:43:55.320231",
+     "duration": 0.006861,
+     "end_time": "2026-09-08T20:41:03.097352",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.311584",
+     "start_time": "2026-09-08T20:41:03.090491",
      "status": "completed"
     },
     "tags": []
@@ -2189,16 +2201,16 @@
    "id": "f2a157be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.337571Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.337052Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.343846Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.343050Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.111222Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.111022Z",
+     "iopub.status.idle": "2026-09-08T20:41:03.117408Z",
+     "shell.execute_reply": "2026-09-08T20:41:03.116986Z"
     },
     "papermill": {
-     "duration": 0.017105,
-     "end_time": "2026-09-07T22:43:55.345024",
+     "duration": 0.014599,
+     "end_time": "2026-09-08T20:41:03.118428",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.327919",
+     "start_time": "2026-09-08T20:41:03.103829",
      "status": "completed"
     },
     "tags": []
@@ -2299,10 +2311,10 @@
    "id": "evsi-negative-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.008601,
-     "end_time": "2026-09-07T22:43:55.363201",
+     "duration": 0.007312,
+     "end_time": "2026-09-08T20:41:03.134408",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.354600",
+     "start_time": "2026-09-08T20:41:03.127096",
      "status": "completed"
     },
     "tags": []
@@ -2353,10 +2365,10 @@
    "id": "monotonicite-fixee-vs-optimale-md",
    "metadata": {
     "papermill": {
-     "duration": 0.007607,
-     "end_time": "2026-09-07T22:43:55.378572",
+     "duration": 0.007545,
+     "end_time": "2026-09-08T20:41:03.148788",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.370965",
+     "start_time": "2026-09-08T20:41:03.141243",
      "status": "completed"
     },
     "tags": []
@@ -2369,7 +2381,28 @@
     "médical, `prior_med` / `U_med` / `L1` / `L2`) en mettant les coûts à zéro, afin\n",
     "d'isoler la valeur de l'information du coût des tests. L'ensemble des politiques\n",
     "contient explicitement : ne pas tester, Test 1 seul, Test 2 directement, Test 1 puis\n",
-    "Test 2 seulement si positif, et Test 1 puis Test 2 sur chaque branche.\n"
+    "Test 2 seulement si positif, et Test 1 puis Test 2 sur chaque branche.\n",
+    "\n",
+    "Deux hypothèses rendent l'énumération exacte :\n",
+    "\n",
+    "- **Indépendance conditionnelle** des tests sachant l'état :\n",
+    "  `P(s1, s2 | état) = P(s1 | état) · P(s2 | état)` — le posterior après les deux\n",
+    "  signaux ne dépend pas de l'ordre d'acquisition, et le Test 1 ne dégrade pas le\n",
+    "  Test 2 qui le suit.\n",
+    "- **Ensemble de politiques exhaustif** : l'ensemble énuméré ci-dessous contient\n",
+    "  « ne pas tester », « Test 1 seul », « Test 2 directement », la politique fixée\n",
+    "  « T1 puis T2 si + » et « T1 puis T2 sur chaque branche ». La valeur **optimale**\n",
+    "  est ≥ chacune **par construction** (l'optimisation maximise sur l'ensemble),\n",
+    "  y compris la politique fixée.\n",
+    "\n",
+    "Un test **gratuit** peut toujours être ignoré : la politique optimale qui commence\n",
+    "par Test 1 peut reproduire toute sous-politique — y compris « Test 2 seul ». Si\n",
+    "l'optimale atteint ici exactement la valeur de Test 2 seul, ce n'est pas une\n",
+    "coïncidence : pour cette matrice d'utilité le signal du Test 1 ne change jamais la\n",
+    "meilleure action (EVSI brut du Test 1 = 0, cf. `Test 1 seul : 11` = `ne pas tester :\n",
+    "11` dans la sortie), il est donc redondant. Le cas **payant** (c1 = 50, c2 = 500)\n",
+    "est tranché en comparant chaque coût à la **borne de valeur de l'information**\n",
+    "(l'EVSI brut du test), pas en réutilisant la fonction gratuite.\n"
    ]
   },
   {
@@ -2378,16 +2411,16 @@
    "id": "monotonicite-oracle-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.398500Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.398075Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.407041Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.406503Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.166141Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.165935Z",
+     "iopub.status.idle": "2026-09-08T20:41:03.174007Z",
+     "shell.execute_reply": "2026-09-08T20:41:03.173600Z"
     },
     "papermill": {
-     "duration": 0.02158,
-     "end_time": "2026-09-07T22:43:55.408194",
+     "duration": 0.017324,
+     "end_time": "2026-09-08T20:41:03.174649",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.386614",
+     "start_time": "2026-09-08T20:41:03.157325",
      "status": "completed"
     },
     "tags": []
@@ -2412,8 +2445,10 @@
       "  politique fixee      : 75\n",
       "  politique optimale   : 100\n",
       "\n",
-      "=== Couts medicaux originaux (c1=50, c2=500) ===\n",
-      "  ne rien acquerir = optimum : 11 (le cout des tests depasse leur valeur)\n",
+      "=== Couts medicaux originaux (c1=50, c2=500) : decision par borne de valeur ===\n",
+      "  EVSI brut Test 1 = -0 vs cout 50  -> borne nette -50\n",
+      "  EVSI brut Test 2 = 13 vs cout 500 -> borne nette -487\n",
+      "  -> optimum payant : aucun test (EU = 11)\n",
       "\n",
       "Verification : la monotonie vaut pour la VALEUR OPTIMALE (ensemble elargi), pas pour une politique fixee.\n"
      ]
@@ -2475,8 +2510,15 @@
     "print(f\"  politique optimale   : {_eu_optimale(mprior, mU, mL1, mL2):.0f}\")\n",
     "\n",
     "print()\n",
-    "print(\"=== Couts medicaux originaux (c1=50, c2=500) ===\")\n",
-    "print(f\"  ne rien acquerir = optimum : {eu_sans:.0f} (le cout des tests depasse leur valeur)\")\n",
+    "print(\"=== Couts medicaux originaux (c1=50, c2=500) : decision par borne de valeur ===\")\n",
+    "# Borne de valeur de l'information : meme GRATUIT, un test n'apporte que son EVSI\n",
+    "# brut. Si EVSI brut < cout, AUCUNE politique payante construite sur ce test ne\n",
+    "# peut battre \"ne rien acquerir\" — inutile d'evaluer la politique fixee payante.\n",
+    "bornes = {\"aucun test\": 0.0, \"Test 1\": evsi_t1 - 50, \"Test 2\": evsi_t2 - 500}\n",
+    "print(f\"  EVSI brut Test 1 = {evsi_t1:.0f} vs cout 50  -> borne nette {bornes['Test 1']:.0f}\")\n",
+    "print(f\"  EVSI brut Test 2 = {evsi_t2:.0f} vs cout 500 -> borne nette {bornes['Test 2']:.0f}\")\n",
+    "optimal_payant = max(bornes, key=bornes.get)\n",
+    "print(f\"  -> optimum payant : {optimal_payant} (EU = {eu_sans + bornes[optimal_payant]:.0f})\")\n",
     "\n",
     "assert eu_optim > eu_fixee, \"l'optimale doit dominer la politique fixee\"\n",
     "assert eu_fixee < eu_t2, \"la politique fixee (positive-only) est dominee par Test 2 seul\"\n",
@@ -2487,21 +2529,71 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "domination-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007704,
+     "end_time": "2026-09-08T20:41:03.190055",
+     "exception": false,
+     "start_time": "2026-09-08T20:41:03.182351",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : pourquoi la politique fixée est dominée\n",
+    "\n",
+    "Trois lectures de l'oracle ci-dessus :\n",
+    "\n",
+    "1. **La politique fixée est dominée par « Test 2 seul » (20,708 < 24,020).**\n",
+    "   Le signal du Test 1 ne change ici jamais la meilleure action (EVSI brut du\n",
+    "   Test 1 = 0 : « Test 1 seul » rapporte 11, exactement comme « ne pas tester »).\n",
+    "   Forcer ce test en première étape n'apporte donc rien — mais il conditionne\n",
+    "   l'accès au Test 2 à la seule branche positive : sur la branche Test 1− (la\n",
+    "   moitié du parcours environ), on repart avec le posterior du Test 1 seul,\n",
+    "   moins informatif que le Test 2 direct. On paie le séquencement sans encaisser\n",
+    "   d'information nouvelle.\n",
+    "\n",
+    "2. **La monotonie vaut pour l'optimal, pas pour une politique imposée.**\n",
+    "   L'ensemble énuméré contient à la fois « Test 2 seul » et la politique fixée :\n",
+    "   la valeur optimale (24,020) est supérieure ou égale à chacune par\n",
+    "   construction. L'optimale commence par Test 1 (gratuit : on peut toujours\n",
+    "   l'ignorer), puis sur chaque branche choisit le meilleur entre s'arrêter et\n",
+    "   continuer. Elle atteint ici exactement la valeur de Test 2 seul parce que le\n",
+    "   Test 1 est redondant pour cette matrice d'utilité (indépendance\n",
+    "   conditionnelle) — structurellement, pas par chance.\n",
+    "\n",
+    "3. **Le contrôle minimal isole le mécanisme.** Test 1 non informatif (50/50),\n",
+    "   Test 2 parfait : la fixée plafonne à 75 (le résultat parfait n'arrive que sur\n",
+    "   la moitié des branches), l'optimale atteint 100.\n",
+    "\n",
+    "### À vous : la version payante\n",
+    "\n",
+    "L'exercice ci-dessous reprend **exactement** ce cadre, mais avec les coûts réels\n",
+    "(`cout_t1=50`, `cout_t2=500`) : complétez `strategie_sequentielle` pour dériver\n",
+    "l'EU de la politique fixée **payante**, puis confrontez-la aux trois alternatives\n",
+    "(aucun test, Test 1 seul, Test 2 direct). L'oracle payant ci-dessus tranche déjà\n",
+    "l'optimum par la borne de valeur : votre calcul doit confirmer que la politique\n",
+    "fixée payante fait encore pire.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 19,
    "id": "ca5ab857",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.426583Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.426246Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.430503Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.429973Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.206237Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.205752Z",
+     "iopub.status.idle": "2026-09-08T20:41:03.209365Z",
+     "shell.execute_reply": "2026-09-08T20:41:03.208978Z"
     },
     "papermill": {
-     "duration": 0.014705,
-     "end_time": "2026-09-07T22:43:55.431317",
+     "duration": 0.012514,
+     "end_time": "2026-09-08T20:41:03.210252",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.416612",
+     "start_time": "2026-09-08T20:41:03.197738",
      "status": "completed"
     },
     "tags": []
@@ -2546,10 +2638,10 @@
    "id": "300c4888",
    "metadata": {
     "papermill": {
-     "duration": 0.008872,
-     "end_time": "2026-09-07T22:43:55.447809",
+     "duration": 0.008881,
+     "end_time": "2026-09-08T20:41:03.226762",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.438937",
+     "start_time": "2026-09-08T20:41:03.217881",
      "status": "completed"
     },
     "tags": []
@@ -2567,10 +2659,10 @@
    "id": "4d8af0b9",
    "metadata": {
     "papermill": {
-     "duration": 0.008502,
-     "end_time": "2026-09-07T22:43:55.463873",
+     "duration": 0.007225,
+     "end_time": "2026-09-08T20:41:03.241397",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.455371",
+     "start_time": "2026-09-08T20:41:03.234172",
      "status": "completed"
     },
     "tags": []
@@ -2597,16 +2689,16 @@
    "id": "04a17e05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.481826Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.481428Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.496442Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.495794Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.258745Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.258315Z",
+     "iopub.status.idle": "2026-09-08T20:41:03.267581Z",
+     "shell.execute_reply": "2026-09-08T20:41:03.267192Z"
     },
     "papermill": {
-     "duration": 0.025569,
-     "end_time": "2026-09-07T22:43:55.497341",
+     "duration": 0.019014,
+     "end_time": "2026-09-08T20:41:03.268257",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.471772",
+     "start_time": "2026-09-08T20:41:03.249243",
      "status": "completed"
     },
     "tags": []
@@ -2660,10 +2752,10 @@
    "id": "2573dea4",
    "metadata": {
     "papermill": {
-     "duration": 0.008788,
-     "end_time": "2026-09-07T22:43:55.513842",
+     "duration": 0.007925,
+     "end_time": "2026-09-08T20:41:03.283313",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.505054",
+     "start_time": "2026-09-08T20:41:03.275388",
      "status": "completed"
     },
     "tags": []
@@ -2682,16 +2774,16 @@
    "id": "6e9cdd71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.531828Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.531603Z",
-     "iopub.status.idle": "2026-09-07T22:43:55.818295Z",
-     "shell.execute_reply": "2026-09-07T22:43:55.817614Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.309628Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.309437Z",
+     "iopub.status.idle": "2026-09-08T20:41:03.550831Z",
+     "shell.execute_reply": "2026-09-08T20:41:03.550411Z"
     },
     "papermill": {
-     "duration": 0.297563,
-     "end_time": "2026-09-07T22:43:55.819002",
+     "duration": 0.260587,
+     "end_time": "2026-09-08T20:41:03.551509",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.521439",
+     "start_time": "2026-09-08T20:41:03.290922",
      "status": "completed"
     },
     "tags": []
@@ -2771,10 +2863,10 @@
    "id": "b3c4e1f2",
    "metadata": {
     "papermill": {
-     "duration": 0.008685,
-     "end_time": "2026-09-07T22:43:55.836078",
+     "duration": 0.007434,
+     "end_time": "2026-09-08T20:41:03.567261",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.827393",
+     "start_time": "2026-09-08T20:41:03.559827",
      "status": "completed"
     },
     "tags": []
@@ -2796,16 +2888,16 @@
    "id": "769bd2e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:43:55.854836Z",
-     "iopub.status.busy": "2026-09-07T22:43:55.854418Z",
-     "iopub.status.idle": "2026-09-07T22:44:05.966372Z",
-     "shell.execute_reply": "2026-09-07T22:44:05.965706Z"
+     "iopub.execute_input": "2026-09-08T20:41:03.583509Z",
+     "iopub.status.busy": "2026-09-08T20:41:03.583298Z",
+     "iopub.status.idle": "2026-09-08T20:41:16.991051Z",
+     "shell.execute_reply": "2026-09-08T20:41:16.990598Z"
     },
     "papermill": {
-     "duration": 10.121871,
-     "end_time": "2026-09-07T22:44:05.967275",
+     "duration": 13.417223,
+     "end_time": "2026-09-08T20:41:16.991808",
      "exception": false,
-     "start_time": "2026-09-07T22:43:55.845404",
+     "start_time": "2026-09-08T20:41:03.574585",
      "status": "completed"
     },
     "tags": []
@@ -2843,7 +2935,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 10_000 draw iterations (2_000 + 20_000 draws total) took 7 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 10_000 draw iterations (2_000 + 20_000 draws total) took 5 seconds.\n"
      ]
     },
     {
@@ -2929,10 +3021,10 @@
    "id": "b7bc368e",
    "metadata": {
     "papermill": {
-     "duration": 0.008341,
-     "end_time": "2026-09-07T22:44:05.984155",
+     "duration": 0.007183,
+     "end_time": "2026-09-08T20:41:17.006778",
      "exception": false,
-     "start_time": "2026-09-07T22:44:05.975814",
+     "start_time": "2026-09-08T20:41:16.999595",
      "status": "completed"
     },
     "tags": []
@@ -2957,16 +3049,16 @@
    "id": "520942ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:06.003212Z",
-     "iopub.status.busy": "2026-09-07T22:44:06.002712Z",
-     "iopub.status.idle": "2026-09-07T22:44:06.238834Z",
-     "shell.execute_reply": "2026-09-07T22:44:06.238337Z"
+     "iopub.execute_input": "2026-09-08T20:41:17.024273Z",
+     "iopub.status.busy": "2026-09-08T20:41:17.023898Z",
+     "iopub.status.idle": "2026-09-08T20:41:17.229091Z",
+     "shell.execute_reply": "2026-09-08T20:41:17.228713Z"
     },
     "papermill": {
-     "duration": 0.246722,
-     "end_time": "2026-09-07T22:44:06.239666",
+     "duration": 0.214825,
+     "end_time": "2026-09-08T20:41:17.229797",
      "exception": false,
-     "start_time": "2026-09-07T22:44:05.992944",
+     "start_time": "2026-09-08T20:41:17.014972",
      "status": "completed"
     },
     "tags": []
@@ -3069,10 +3161,10 @@
    "id": "3f79985d",
    "metadata": {
     "papermill": {
-     "duration": 0.009854,
-     "end_time": "2026-09-07T22:44:06.258899",
+     "duration": 0.01902,
+     "end_time": "2026-09-08T20:41:17.257694",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.249045",
+     "start_time": "2026-09-08T20:41:17.238674",
      "status": "completed"
     },
     "tags": []
@@ -3102,16 +3194,16 @@
    "id": "e7eec055",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:06.280827Z",
-     "iopub.status.busy": "2026-09-07T22:44:06.280370Z",
-     "iopub.status.idle": "2026-09-07T22:44:06.580258Z",
-     "shell.execute_reply": "2026-09-07T22:44:06.579661Z"
+     "iopub.execute_input": "2026-09-08T20:41:17.277491Z",
+     "iopub.status.busy": "2026-09-08T20:41:17.277081Z",
+     "iopub.status.idle": "2026-09-08T20:41:17.530417Z",
+     "shell.execute_reply": "2026-09-08T20:41:17.529873Z"
     },
     "papermill": {
-     "duration": 0.312067,
-     "end_time": "2026-09-07T22:44:06.581117",
+     "duration": 0.26436,
+     "end_time": "2026-09-08T20:41:17.531097",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.269050",
+     "start_time": "2026-09-08T20:41:17.266737",
      "status": "completed"
     },
     "tags": []
@@ -3195,10 +3287,10 @@
    "id": "89abb269",
    "metadata": {
     "papermill": {
-     "duration": 0.00913,
-     "end_time": "2026-09-07T22:44:06.609037",
+     "duration": 0.009125,
+     "end_time": "2026-09-08T20:41:17.549386",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.599907",
+     "start_time": "2026-09-08T20:41:17.540261",
      "status": "completed"
     },
     "tags": []
@@ -3217,16 +3309,16 @@
    "id": "f666376f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:06.628878Z",
-     "iopub.status.busy": "2026-09-07T22:44:06.628667Z",
-     "iopub.status.idle": "2026-09-07T22:44:06.940259Z",
-     "shell.execute_reply": "2026-09-07T22:44:06.939751Z"
+     "iopub.execute_input": "2026-09-08T20:41:17.568666Z",
+     "iopub.status.busy": "2026-09-08T20:41:17.568311Z",
+     "iopub.status.idle": "2026-09-08T20:41:17.836444Z",
+     "shell.execute_reply": "2026-09-08T20:41:17.835908Z"
     },
     "papermill": {
-     "duration": 0.322453,
-     "end_time": "2026-09-07T22:44:06.941085",
+     "duration": 0.27869,
+     "end_time": "2026-09-08T20:41:17.837160",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.618632",
+     "start_time": "2026-09-08T20:41:17.558470",
      "status": "completed"
     },
     "tags": []
@@ -3349,10 +3441,10 @@
    "id": "1ef76741",
    "metadata": {
     "papermill": {
-     "duration": 0.010072,
-     "end_time": "2026-09-07T22:44:06.961485",
+     "duration": 0.009509,
+     "end_time": "2026-09-08T20:41:17.857179",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.951413",
+     "start_time": "2026-09-08T20:41:17.847670",
      "status": "completed"
     },
     "tags": []
@@ -3386,10 +3478,10 @@
    "id": "56583bfd",
    "metadata": {
     "papermill": {
-     "duration": 0.010462,
-     "end_time": "2026-09-07T22:44:06.982255",
+     "duration": 0.010562,
+     "end_time": "2026-09-08T20:41:17.877433",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.971793",
+     "start_time": "2026-09-08T20:41:17.866871",
      "status": "completed"
     },
     "tags": []
@@ -3414,16 +3506,16 @@
    "id": "c752eb51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:07.004342Z",
-     "iopub.status.busy": "2026-09-07T22:44:07.004064Z",
-     "iopub.status.idle": "2026-09-07T22:44:07.138547Z",
-     "shell.execute_reply": "2026-09-07T22:44:07.138039Z"
+     "iopub.execute_input": "2026-09-08T20:41:17.901192Z",
+     "iopub.status.busy": "2026-09-08T20:41:17.900979Z",
+     "iopub.status.idle": "2026-09-08T20:41:18.047937Z",
+     "shell.execute_reply": "2026-09-08T20:41:18.047553Z"
     },
     "papermill": {
-     "duration": 0.146559,
-     "end_time": "2026-09-07T22:44:07.139329",
+     "duration": 0.161519,
+     "end_time": "2026-09-08T20:41:18.048696",
      "exception": false,
-     "start_time": "2026-09-07T22:44:06.992770",
+     "start_time": "2026-09-08T20:41:17.887177",
      "status": "completed"
     },
     "tags": []
@@ -3507,10 +3599,10 @@
    "id": "71a7f150",
    "metadata": {
     "papermill": {
-     "duration": 0.010732,
-     "end_time": "2026-09-07T22:44:07.161541",
+     "duration": 0.01007,
+     "end_time": "2026-09-08T20:41:18.069444",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.150809",
+     "start_time": "2026-09-08T20:41:18.059374",
      "status": "completed"
     },
     "tags": []
@@ -3546,10 +3638,10 @@
    "id": "cc2cc982",
    "metadata": {
     "papermill": {
-     "duration": 0.012093,
-     "end_time": "2026-09-07T22:44:07.184269",
+     "duration": 0.010203,
+     "end_time": "2026-09-08T20:41:18.100784",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.172176",
+     "start_time": "2026-09-08T20:41:18.090581",
      "status": "completed"
     },
     "tags": []
@@ -3587,10 +3679,10 @@
    "id": "hier-limits-md",
    "metadata": {
     "papermill": {
-     "duration": 0.012486,
-     "end_time": "2026-09-07T22:44:07.208619",
+     "duration": 0.011586,
+     "end_time": "2026-09-08T20:41:18.122334",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.196133",
+     "start_time": "2026-09-08T20:41:18.110748",
      "status": "completed"
     },
     "tags": []
@@ -3608,10 +3700,10 @@
    "id": "ex4_pymc_partial_pooling",
    "metadata": {
     "papermill": {
-     "duration": 0.011214,
-     "end_time": "2026-09-07T22:44:07.230306",
+     "duration": 0.009354,
+     "end_time": "2026-09-08T20:41:18.141665",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.219092",
+     "start_time": "2026-09-08T20:41:18.132311",
      "status": "completed"
     },
     "tags": []
@@ -3646,16 +3738,16 @@
    "id": "hier-model-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:07.253084Z",
-     "iopub.status.busy": "2026-09-07T22:44:07.252870Z",
-     "iopub.status.idle": "2026-09-07T22:44:07.258644Z",
-     "shell.execute_reply": "2026-09-07T22:44:07.258069Z"
+     "iopub.execute_input": "2026-09-08T20:41:18.161784Z",
+     "iopub.status.busy": "2026-09-08T20:41:18.161585Z",
+     "iopub.status.idle": "2026-09-08T20:41:18.166580Z",
+     "shell.execute_reply": "2026-09-08T20:41:18.166084Z"
     },
     "papermill": {
-     "duration": 0.018227,
-     "end_time": "2026-09-07T22:44:07.259404",
+     "duration": 0.015971,
+     "end_time": "2026-09-08T20:41:18.167262",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.241177",
+     "start_time": "2026-09-08T20:41:18.151291",
      "status": "completed"
     },
     "tags": []
@@ -3717,10 +3809,10 @@
    "id": "hier-shrink-md",
    "metadata": {
     "papermill": {
-     "duration": 0.010808,
-     "end_time": "2026-09-07T22:44:07.281074",
+     "duration": 0.011134,
+     "end_time": "2026-09-08T20:41:18.189711",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.270266",
+     "start_time": "2026-09-08T20:41:18.178577",
      "status": "completed"
     },
     "tags": []
@@ -3739,16 +3831,16 @@
    "id": "hier-shrink-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:07.304372Z",
-     "iopub.status.busy": "2026-09-07T22:44:07.304079Z",
-     "iopub.status.idle": "2026-09-07T22:44:07.307188Z",
-     "shell.execute_reply": "2026-09-07T22:44:07.306755Z"
+     "iopub.execute_input": "2026-09-08T20:41:18.211883Z",
+     "iopub.status.busy": "2026-09-08T20:41:18.211471Z",
+     "iopub.status.idle": "2026-09-08T20:41:18.214875Z",
+     "shell.execute_reply": "2026-09-08T20:41:18.214476Z"
     },
     "papermill": {
-     "duration": 0.015793,
-     "end_time": "2026-09-07T22:44:07.307940",
+     "duration": 0.014915,
+     "end_time": "2026-09-08T20:41:18.215587",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.292147",
+     "start_time": "2026-09-08T20:41:18.200672",
      "status": "completed"
     },
     "tags": []
@@ -3783,16 +3875,16 @@
    "id": "hier-evsi-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:07.331867Z",
-     "iopub.status.busy": "2026-09-07T22:44:07.331528Z",
-     "iopub.status.idle": "2026-09-07T22:44:07.335682Z",
-     "shell.execute_reply": "2026-09-07T22:44:07.335153Z"
+     "iopub.execute_input": "2026-09-08T20:41:18.236294Z",
+     "iopub.status.busy": "2026-09-08T20:41:18.236088Z",
+     "iopub.status.idle": "2026-09-08T20:41:18.239309Z",
+     "shell.execute_reply": "2026-09-08T20:41:18.238837Z"
     },
     "papermill": {
-     "duration": 0.016551,
-     "end_time": "2026-09-07T22:44:07.336496",
+     "duration": 0.014425,
+     "end_time": "2026-09-08T20:41:18.240003",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.319945",
+     "start_time": "2026-09-08T20:41:18.225578",
      "status": "completed"
     },
     "tags": []
@@ -3826,10 +3918,10 @@
    "id": "hier-interp-md",
    "metadata": {
     "papermill": {
-     "duration": 0.010973,
-     "end_time": "2026-09-07T22:44:07.358330",
+     "duration": 0.009973,
+     "end_time": "2026-09-08T20:41:18.260192",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.347357",
+     "start_time": "2026-09-08T20:41:18.250219",
      "status": "completed"
     },
     "tags": []
@@ -3847,10 +3939,10 @@
    "id": "abb2c9f2",
    "metadata": {
     "papermill": {
-     "duration": 0.010765,
-     "end_time": "2026-09-07T22:44:07.379937",
+     "duration": 0.01079,
+     "end_time": "2026-09-08T20:41:18.281406",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.369172",
+     "start_time": "2026-09-08T20:41:18.270616",
      "status": "completed"
     },
     "tags": []
@@ -3887,16 +3979,16 @@
    "id": "2417343e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T22:44:07.405460Z",
-     "iopub.status.busy": "2026-09-07T22:44:07.405209Z",
-     "iopub.status.idle": "2026-09-07T22:44:07.410066Z",
-     "shell.execute_reply": "2026-09-07T22:44:07.409665Z"
+     "iopub.execute_input": "2026-09-08T20:41:18.304536Z",
+     "iopub.status.busy": "2026-09-08T20:41:18.304165Z",
+     "iopub.status.idle": "2026-09-08T20:41:18.310090Z",
+     "shell.execute_reply": "2026-09-08T20:41:18.309381Z"
     },
     "papermill": {
-     "duration": 0.018775,
-     "end_time": "2026-09-07T22:44:07.410812",
+     "duration": 0.018482,
+     "end_time": "2026-09-08T20:41:18.310910",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.392037",
+     "start_time": "2026-09-08T20:41:18.292428",
      "status": "completed"
     },
     "tags": []
@@ -3966,10 +4058,10 @@
    "id": "9905e068",
    "metadata": {
     "papermill": {
-     "duration": 0.010693,
-     "end_time": "2026-09-07T22:44:07.432462",
+     "duration": 0.011456,
+     "end_time": "2026-09-08T20:41:18.333283",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.421769",
+     "start_time": "2026-09-08T20:41:18.321827",
      "status": "completed"
     },
     "tags": []
@@ -4016,10 +4108,10 @@
    "id": "a8db71b7",
    "metadata": {
     "papermill": {
-     "duration": 0.011103,
-     "end_time": "2026-09-07T22:44:07.454346",
+     "duration": 0.011461,
+     "end_time": "2026-09-08T20:41:18.356329",
      "exception": false,
-     "start_time": "2026-09-07T22:44:07.443243",
+     "start_time": "2026-09-08T20:41:18.344868",
      "status": "completed"
     },
     "tags": []
@@ -4077,14 +4169,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 20.518981,
-   "end_time": "2026-09-07T22:44:08.465741",
+   "duration": 29.486707,
+   "end_time": "2026-09-08T20:41:19.255833",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA-15108\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-5-Value-Information.ipynb",
    "output_path": "D:\\Dev\\CoursIA-15108\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-5-Value-Information_output.ipynb",
    "parameters": {},
-   "start_time": "2026-09-07T22:43:47.946760",
+   "start_time": "2026-09-08T20:40:49.769126",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -5,10 +5,10 @@
    "id": "1d3c4b05",
    "metadata": {
     "papermill": {
-     "duration": 0.006116,
-     "end_time": "2026-09-08T20:40:51.701579",
+     "duration": 0.012412,
+     "end_time": "2026-09-09T00:16:37.254322",
      "exception": false,
-     "start_time": "2026-09-08T20:40:51.695463",
+     "start_time": "2026-09-09T00:16:37.241910",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "3b0146a8",
    "metadata": {
     "papermill": {
-     "duration": 0.005562,
-     "end_time": "2026-09-08T20:40:51.715069",
+     "duration": 0.005668,
+     "end_time": "2026-09-09T00:16:37.269065",
      "exception": false,
-     "start_time": "2026-09-08T20:40:51.709507",
+     "start_time": "2026-09-09T00:16:37.263397",
      "status": "completed"
     },
     "tags": []
@@ -67,16 +67,16 @@
    "id": "4e90e20f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:51.727143Z",
-     "iopub.status.busy": "2026-09-08T20:40:51.726822Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.035173Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.034785Z"
+     "iopub.execute_input": "2026-09-09T00:16:37.281073Z",
+     "iopub.status.busy": "2026-09-09T00:16:37.280824Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.676406Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.675942Z"
     },
     "papermill": {
-     "duration": 7.315252,
-     "end_time": "2026-09-08T20:40:59.035874",
+     "duration": 1.402674,
+     "end_time": "2026-09-09T00:16:38.677253",
      "exception": false,
-     "start_time": "2026-09-08T20:40:51.720622",
+     "start_time": "2026-09-09T00:16:37.274579",
      "status": "completed"
     },
     "tags": []
@@ -107,10 +107,10 @@
    "id": "61fb4ddc",
    "metadata": {
     "papermill": {
-     "duration": 0.00478,
-     "end_time": "2026-09-08T20:40:59.046301",
+     "duration": 0.005244,
+     "end_time": "2026-09-09T00:16:38.688374",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.041521",
+     "start_time": "2026-09-09T00:16:38.683130",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "019e4470",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.056484Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.056234Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.061576Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.061189Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.700060Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.699806Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.704504Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.704148Z"
     },
     "papermill": {
-     "duration": 0.01116,
-     "end_time": "2026-09-08T20:40:59.062227",
+     "duration": 0.011707,
+     "end_time": "2026-09-09T00:16:38.705514",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.051067",
+     "start_time": "2026-09-09T00:16:38.693807",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "id": "8f7dc8aa",
    "metadata": {
     "papermill": {
-     "duration": 0.004531,
-     "end_time": "2026-09-08T20:40:59.071774",
+     "duration": 0.005003,
+     "end_time": "2026-09-09T00:16:38.715584",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.067243",
+     "start_time": "2026-09-09T00:16:38.710581",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +240,10 @@
    "id": "e252949a",
    "metadata": {
     "papermill": {
-     "duration": 0.004645,
-     "end_time": "2026-09-08T20:40:59.081987",
+     "duration": 0.005286,
+     "end_time": "2026-09-09T00:16:38.725645",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.077342",
+     "start_time": "2026-09-09T00:16:38.720359",
      "status": "completed"
     },
     "tags": []
@@ -280,10 +280,10 @@
    "id": "c42398e6",
    "metadata": {
     "papermill": {
-     "duration": 0.0049,
-     "end_time": "2026-09-08T20:40:59.091432",
+     "duration": 0.004824,
+     "end_time": "2026-09-09T00:16:38.735609",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.086532",
+     "start_time": "2026-09-09T00:16:38.730785",
      "status": "completed"
     },
     "tags": []
@@ -304,16 +304,16 @@
    "id": "230b8b5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.102574Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.102358Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.107119Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.106776Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.746348Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.746151Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.751193Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.750684Z"
     },
     "papermill": {
-     "duration": 0.011586,
-     "end_time": "2026-09-08T20:40:59.107954",
+     "duration": 0.011396,
+     "end_time": "2026-09-09T00:16:38.752020",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.096368",
+     "start_time": "2026-09-09T00:16:38.740624",
      "status": "completed"
     },
     "tags": []
@@ -368,10 +368,10 @@
    "id": "d38ad65e",
    "metadata": {
     "papermill": {
-     "duration": 0.004777,
-     "end_time": "2026-09-08T20:40:59.117756",
+     "duration": 0.00487,
+     "end_time": "2026-09-09T00:16:38.762498",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.112979",
+     "start_time": "2026-09-09T00:16:38.757628",
      "status": "completed"
     },
     "tags": []
@@ -404,16 +404,16 @@
    "id": "2c4ecfc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.128674Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.128493Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.132118Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.131692Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.772804Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.772538Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.776050Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.775719Z"
     },
     "papermill": {
-     "duration": 0.009836,
-     "end_time": "2026-09-08T20:40:59.132789",
+     "duration": 0.009566,
+     "end_time": "2026-09-09T00:16:38.776709",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.122953",
+     "start_time": "2026-09-09T00:16:38.767143",
      "status": "completed"
     },
     "tags": []
@@ -489,10 +489,10 @@
    "id": "fef2e2bc",
    "metadata": {
     "papermill": {
-     "duration": 0.005413,
-     "end_time": "2026-09-08T20:40:59.143766",
+     "duration": 0.005038,
+     "end_time": "2026-09-09T00:16:38.787471",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.138353",
+     "start_time": "2026-09-09T00:16:38.782433",
      "status": "completed"
     },
     "tags": []
@@ -521,10 +521,10 @@
    "id": "d5546018",
    "metadata": {
     "papermill": {
-     "duration": 0.004744,
-     "end_time": "2026-09-08T20:40:59.153345",
+     "duration": 0.005592,
+     "end_time": "2026-09-09T00:16:38.798422",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.148601",
+     "start_time": "2026-09-09T00:16:38.792830",
      "status": "completed"
     },
     "tags": []
@@ -548,16 +548,16 @@
    "id": "f6734232",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.164693Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.164415Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.168848Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.168450Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.811687Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.811453Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.816256Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.815752Z"
     },
     "papermill": {
-     "duration": 0.010908,
-     "end_time": "2026-09-08T20:40:59.169528",
+     "duration": 0.012843,
+     "end_time": "2026-09-09T00:16:38.817041",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.158620",
+     "start_time": "2026-09-09T00:16:38.804198",
      "status": "completed"
     },
     "tags": []
@@ -631,10 +631,10 @@
    "id": "a4db5e30",
    "metadata": {
     "papermill": {
-     "duration": 0.005169,
-     "end_time": "2026-09-08T20:40:59.180256",
+     "duration": 0.005735,
+     "end_time": "2026-09-09T00:16:38.828495",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.175087",
+     "start_time": "2026-09-09T00:16:38.822760",
      "status": "completed"
     },
     "tags": []
@@ -671,10 +671,10 @@
    "id": "8103fd34",
    "metadata": {
     "papermill": {
-     "duration": 0.00502,
-     "end_time": "2026-09-08T20:40:59.190896",
+     "duration": 0.006349,
+     "end_time": "2026-09-09T00:16:38.841268",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.185876",
+     "start_time": "2026-09-09T00:16:38.834919",
      "status": "completed"
     },
     "tags": []
@@ -693,16 +693,16 @@
    "id": "ba1428ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.201608Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.201300Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.204436Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.203956Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.855380Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.855072Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.858907Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.858436Z"
     },
     "papermill": {
-     "duration": 0.009433,
-     "end_time": "2026-09-08T20:40:59.205085",
+     "duration": 0.011932,
+     "end_time": "2026-09-09T00:16:38.860099",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.195652",
+     "start_time": "2026-09-09T00:16:38.848167",
      "status": "completed"
     },
     "tags": []
@@ -741,10 +741,10 @@
    "id": "28b493d8",
    "metadata": {
     "papermill": {
-     "duration": 0.015239,
-     "end_time": "2026-09-08T20:40:59.225369",
+     "duration": 0.009438,
+     "end_time": "2026-09-09T00:16:38.877283",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.210130",
+     "start_time": "2026-09-09T00:16:38.867845",
      "status": "completed"
     },
     "tags": []
@@ -774,10 +774,10 @@
    "id": "6312f621",
    "metadata": {
     "papermill": {
-     "duration": 0.005304,
-     "end_time": "2026-09-08T20:40:59.236081",
+     "duration": 0.009173,
+     "end_time": "2026-09-09T00:16:38.895277",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.230777",
+     "start_time": "2026-09-09T00:16:38.886104",
      "status": "completed"
     },
     "tags": []
@@ -804,16 +804,16 @@
    "id": "6e219ca9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.247126Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.246848Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.250619Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.250211Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.912340Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.912128Z",
+     "iopub.status.idle": "2026-09-09T00:16:38.916096Z",
+     "shell.execute_reply": "2026-09-09T00:16:38.915664Z"
     },
     "papermill": {
-     "duration": 0.009975,
-     "end_time": "2026-09-08T20:40:59.251229",
+     "duration": 0.014904,
+     "end_time": "2026-09-09T00:16:38.917217",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.241254",
+     "start_time": "2026-09-09T00:16:38.902313",
      "status": "completed"
     },
     "tags": []
@@ -873,10 +873,10 @@
    "id": "1b9da7e6",
    "metadata": {
     "papermill": {
-     "duration": 0.005234,
-     "end_time": "2026-09-08T20:40:59.261949",
+     "duration": 0.005217,
+     "end_time": "2026-09-09T00:16:38.927813",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.256715",
+     "start_time": "2026-09-09T00:16:38.922596",
      "status": "completed"
     },
     "tags": []
@@ -898,16 +898,16 @@
    "id": "c3e9ff82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.273682Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.273491Z",
-     "iopub.status.idle": "2026-09-08T20:40:59.746070Z",
-     "shell.execute_reply": "2026-09-08T20:40:59.745447Z"
+     "iopub.execute_input": "2026-09-09T00:16:38.941440Z",
+     "iopub.status.busy": "2026-09-09T00:16:38.941022Z",
+     "iopub.status.idle": "2026-09-09T00:16:39.527621Z",
+     "shell.execute_reply": "2026-09-09T00:16:39.526528Z"
     },
     "papermill": {
-     "duration": 0.48034,
-     "end_time": "2026-09-08T20:40:59.747577",
+     "duration": 0.595979,
+     "end_time": "2026-09-09T00:16:39.528913",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.267237",
+     "start_time": "2026-09-09T00:16:38.932934",
      "status": "completed"
     },
     "tags": []
@@ -969,10 +969,10 @@
    "id": "dbf8652d",
    "metadata": {
     "papermill": {
-     "duration": 0.006946,
-     "end_time": "2026-09-08T20:40:59.762376",
+     "duration": 0.007122,
+     "end_time": "2026-09-09T00:16:39.545852",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.755430",
+     "start_time": "2026-09-09T00:16:39.538730",
      "status": "completed"
     },
     "tags": []
@@ -996,16 +996,16 @@
    "id": "f9111a49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:40:59.776466Z",
-     "iopub.status.busy": "2026-09-08T20:40:59.776169Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.273475Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.273035Z"
+     "iopub.execute_input": "2026-09-09T00:16:39.569464Z",
+     "iopub.status.busy": "2026-09-09T00:16:39.569017Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.101863Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.100759Z"
     },
     "papermill": {
-     "duration": 2.506803,
-     "end_time": "2026-09-08T20:41:02.274975",
+     "duration": 2.54329,
+     "end_time": "2026-09-09T00:16:42.103328",
      "exception": false,
-     "start_time": "2026-09-08T20:40:59.768172",
+     "start_time": "2026-09-09T00:16:39.560038",
      "status": "completed"
     },
     "tags": []
@@ -1101,10 +1101,10 @@
    "id": "6e2e1b00",
    "metadata": {
     "papermill": {
-     "duration": 0.005302,
-     "end_time": "2026-09-08T20:41:02.286579",
+     "duration": 0.011402,
+     "end_time": "2026-09-09T00:16:42.125501",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.281277",
+     "start_time": "2026-09-09T00:16:42.114099",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1136,10 @@
    "id": "fed67ea3",
    "metadata": {
     "papermill": {
-     "duration": 0.005791,
-     "end_time": "2026-09-08T20:41:02.297791",
+     "duration": 0.005666,
+     "end_time": "2026-09-09T00:16:42.136845",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.292000",
+     "start_time": "2026-09-09T00:16:42.131179",
      "status": "completed"
     },
     "tags": []
@@ -1161,16 +1161,16 @@
    "id": "3d5e5b52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:02.310599Z",
-     "iopub.status.busy": "2026-09-08T20:41:02.310365Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.396104Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.395452Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.150138Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.149718Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.239882Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.239493Z"
     },
     "papermill": {
-     "duration": 0.093788,
-     "end_time": "2026-09-08T20:41:02.397341",
+     "duration": 0.097775,
+     "end_time": "2026-09-09T00:16:42.240544",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.303553",
+     "start_time": "2026-09-09T00:16:42.142769",
      "status": "completed"
     },
     "tags": []
@@ -1234,10 +1234,10 @@
    "id": "94ae7ff1",
    "metadata": {
     "papermill": {
-     "duration": 0.006316,
-     "end_time": "2026-09-08T20:41:02.410391",
+     "duration": 0.00722,
+     "end_time": "2026-09-09T00:16:42.253976",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.404075",
+     "start_time": "2026-09-09T00:16:42.246756",
      "status": "completed"
     },
     "tags": []
@@ -1255,10 +1255,10 @@
    "id": "634eddc5",
    "metadata": {
     "papermill": {
-     "duration": 0.005952,
-     "end_time": "2026-09-08T20:41:02.422329",
+     "duration": 0.00713,
+     "end_time": "2026-09-09T00:16:42.269252",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.416377",
+     "start_time": "2026-09-09T00:16:42.262122",
      "status": "completed"
     },
     "tags": []
@@ -1278,16 +1278,16 @@
    "id": "e6ebbde8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:02.435096Z",
-     "iopub.status.busy": "2026-09-08T20:41:02.434593Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.608466Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.607894Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.281755Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.281487Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.476423Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.475662Z"
     },
     "papermill": {
-     "duration": 0.181265,
-     "end_time": "2026-09-08T20:41:02.609212",
+     "duration": 0.202258,
+     "end_time": "2026-09-09T00:16:42.477314",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.427947",
+     "start_time": "2026-09-09T00:16:42.275056",
      "status": "completed"
     },
     "tags": []
@@ -1369,10 +1369,10 @@
    "id": "0e59eb90",
    "metadata": {
     "papermill": {
-     "duration": 0.00677,
-     "end_time": "2026-09-08T20:41:02.623419",
+     "duration": 0.007368,
+     "end_time": "2026-09-09T00:16:42.492969",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.616649",
+     "start_time": "2026-09-09T00:16:42.485601",
      "status": "completed"
     },
     "tags": []
@@ -1406,10 +1406,10 @@
    "id": "456909ac",
    "metadata": {
     "papermill": {
-     "duration": 0.00744,
-     "end_time": "2026-09-08T20:41:02.638482",
+     "duration": 0.007282,
+     "end_time": "2026-09-09T00:16:42.507524",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.631042",
+     "start_time": "2026-09-09T00:16:42.500242",
      "status": "completed"
     },
     "tags": []
@@ -1450,10 +1450,10 @@
    "id": "c53912c2",
    "metadata": {
     "papermill": {
-     "duration": 0.007422,
-     "end_time": "2026-09-08T20:41:02.652888",
+     "duration": 0.006647,
+     "end_time": "2026-09-09T00:16:42.520898",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.645466",
+     "start_time": "2026-09-09T00:16:42.514251",
      "status": "completed"
     },
     "tags": []
@@ -1473,16 +1473,16 @@
    "id": "e832cd44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:02.671610Z",
-     "iopub.status.busy": "2026-09-08T20:41:02.671389Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.681836Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.680697Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.537730Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.537467Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.546370Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.545955Z"
     },
     "papermill": {
-     "duration": 0.021801,
-     "end_time": "2026-09-08T20:41:02.682959",
+     "duration": 0.020031,
+     "end_time": "2026-09-09T00:16:42.547869",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.661158",
+     "start_time": "2026-09-09T00:16:42.527838",
      "status": "completed"
     },
     "tags": []
@@ -1597,10 +1597,10 @@
    "id": "f44f0f84",
    "metadata": {
     "papermill": {
-     "duration": 0.008276,
-     "end_time": "2026-09-08T20:41:02.698671",
+     "duration": 0.007608,
+     "end_time": "2026-09-09T00:16:42.563082",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.690395",
+     "start_time": "2026-09-09T00:16:42.555474",
      "status": "completed"
     },
     "tags": []
@@ -1631,10 +1631,10 @@
    "id": "ec3e3ae7",
    "metadata": {
     "papermill": {
-     "duration": 0.007963,
-     "end_time": "2026-09-08T20:41:02.717662",
+     "duration": 0.006787,
+     "end_time": "2026-09-09T00:16:42.578124",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.709699",
+     "start_time": "2026-09-09T00:16:42.571337",
      "status": "completed"
     },
     "tags": []
@@ -1652,16 +1652,16 @@
    "id": "5251bb1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:02.739117Z",
-     "iopub.status.busy": "2026-09-08T20:41:02.738891Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.834950Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.834572Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.595166Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.594761Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.704804Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.704355Z"
     },
     "papermill": {
-     "duration": 0.10734,
-     "end_time": "2026-09-08T20:41:02.835739",
+     "duration": 0.120885,
+     "end_time": "2026-09-09T00:16:42.705617",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.728399",
+     "start_time": "2026-09-09T00:16:42.584732",
      "status": "completed"
     },
     "tags": []
@@ -1718,10 +1718,10 @@
    "id": "c6ef1bad",
    "metadata": {
     "papermill": {
-     "duration": 0.006712,
-     "end_time": "2026-09-08T20:41:02.849386",
+     "duration": 0.007784,
+     "end_time": "2026-09-09T00:16:42.722194",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.842674",
+     "start_time": "2026-09-09T00:16:42.714410",
      "status": "completed"
     },
     "tags": []
@@ -1743,16 +1743,16 @@
    "id": "160dd297",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:02.865064Z",
-     "iopub.status.busy": "2026-09-08T20:41:02.864670Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.870407Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.869955Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.738133Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.737830Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.745373Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.744667Z"
     },
     "papermill": {
-     "duration": 0.014318,
-     "end_time": "2026-09-08T20:41:02.871019",
+     "duration": 0.016965,
+     "end_time": "2026-09-09T00:16:42.746512",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.856701",
+     "start_time": "2026-09-09T00:16:42.729547",
      "status": "completed"
     },
     "tags": []
@@ -1842,10 +1842,10 @@
    "id": "11d30395",
    "metadata": {
     "papermill": {
-     "duration": 0.006745,
-     "end_time": "2026-09-08T20:41:02.885948",
+     "duration": 0.010922,
+     "end_time": "2026-09-09T00:16:42.765735",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.879203",
+     "start_time": "2026-09-09T00:16:42.754813",
      "status": "completed"
     },
     "tags": []
@@ -1883,10 +1883,10 @@
    "id": "023c6fc9",
    "metadata": {
     "papermill": {
-     "duration": 0.007147,
-     "end_time": "2026-09-08T20:41:02.900506",
+     "duration": 0.008072,
+     "end_time": "2026-09-09T00:16:42.786316",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.893359",
+     "start_time": "2026-09-09T00:16:42.778244",
      "status": "completed"
     },
     "tags": []
@@ -1901,16 +1901,16 @@
    "id": "5d505001",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:02.915402Z",
-     "iopub.status.busy": "2026-09-08T20:41:02.915213Z",
-     "iopub.status.idle": "2026-09-08T20:41:02.989616Z",
-     "shell.execute_reply": "2026-09-08T20:41:02.988989Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.804229Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.803839Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.879939Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.879314Z"
     },
     "papermill": {
-     "duration": 0.082446,
-     "end_time": "2026-09-08T20:41:02.990370",
+     "duration": 0.085829,
+     "end_time": "2026-09-09T00:16:42.880688",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.907924",
+     "start_time": "2026-09-09T00:16:42.794859",
      "status": "completed"
     },
     "tags": []
@@ -1952,10 +1952,10 @@
    "id": "6b60b611",
    "metadata": {
     "papermill": {
-     "duration": 0.007845,
-     "end_time": "2026-09-08T20:41:03.005690",
+     "duration": 0.007629,
+     "end_time": "2026-09-09T00:16:42.896607",
      "exception": false,
-     "start_time": "2026-09-08T20:41:02.997845",
+     "start_time": "2026-09-09T00:16:42.888978",
      "status": "completed"
     },
     "tags": []
@@ -1985,10 +1985,10 @@
    "id": "4e6002c0",
    "metadata": {
     "papermill": {
-     "duration": 0.007753,
-     "end_time": "2026-09-08T20:41:03.020780",
+     "duration": 0.007237,
+     "end_time": "2026-09-09T00:16:42.911579",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.013027",
+     "start_time": "2026-09-09T00:16:42.904342",
      "status": "completed"
     },
     "tags": []
@@ -2006,16 +2006,16 @@
    "id": "f5c89fe6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.039399Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.039191Z",
-     "iopub.status.idle": "2026-09-08T20:41:03.044717Z",
-     "shell.execute_reply": "2026-09-08T20:41:03.044111Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.928475Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.928129Z",
+     "iopub.status.idle": "2026-09-09T00:16:42.933788Z",
+     "shell.execute_reply": "2026-09-09T00:16:42.933171Z"
     },
     "papermill": {
-     "duration": 0.015602,
-     "end_time": "2026-09-08T20:41:03.046118",
+     "duration": 0.014969,
+     "end_time": "2026-09-09T00:16:42.934510",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.030516",
+     "start_time": "2026-09-09T00:16:42.919541",
      "status": "completed"
     },
     "tags": []
@@ -2092,10 +2092,10 @@
    "id": "349e1c4a",
    "metadata": {
     "papermill": {
-     "duration": 0.007867,
-     "end_time": "2026-09-08T20:41:03.064362",
+     "duration": 0.007268,
+     "end_time": "2026-09-09T00:16:42.949752",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.056495",
+     "start_time": "2026-09-09T00:16:42.942484",
      "status": "completed"
     },
     "tags": []
@@ -2125,10 +2125,10 @@
    "id": "cc202dd8",
    "metadata": {
     "papermill": {
-     "duration": 0.007377,
-     "end_time": "2026-09-08T20:41:03.080468",
+     "duration": 0.007665,
+     "end_time": "2026-09-09T00:16:42.965440",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.073091",
+     "start_time": "2026-09-09T00:16:42.957775",
      "status": "completed"
     },
     "tags": []
@@ -2173,10 +2173,10 @@
    "id": "a5ff6753",
    "metadata": {
     "papermill": {
-     "duration": 0.006861,
-     "end_time": "2026-09-08T20:41:03.097352",
+     "duration": 0.007332,
+     "end_time": "2026-09-09T00:16:42.981364",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.090491",
+     "start_time": "2026-09-09T00:16:42.974032",
      "status": "completed"
     },
     "tags": []
@@ -2201,16 +2201,16 @@
    "id": "f2a157be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.111222Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.111022Z",
-     "iopub.status.idle": "2026-09-08T20:41:03.117408Z",
-     "shell.execute_reply": "2026-09-08T20:41:03.116986Z"
+     "iopub.execute_input": "2026-09-09T00:16:42.999285Z",
+     "iopub.status.busy": "2026-09-09T00:16:42.998825Z",
+     "iopub.status.idle": "2026-09-09T00:16:43.006273Z",
+     "shell.execute_reply": "2026-09-09T00:16:43.005647Z"
     },
     "papermill": {
-     "duration": 0.014599,
-     "end_time": "2026-09-08T20:41:03.118428",
+     "duration": 0.017439,
+     "end_time": "2026-09-09T00:16:43.007163",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.103829",
+     "start_time": "2026-09-09T00:16:42.989724",
      "status": "completed"
     },
     "tags": []
@@ -2311,10 +2311,10 @@
    "id": "evsi-negative-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.007312,
-     "end_time": "2026-09-08T20:41:03.134408",
+     "duration": 0.00784,
+     "end_time": "2026-09-09T00:16:43.022672",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.127096",
+     "start_time": "2026-09-09T00:16:43.014832",
      "status": "completed"
     },
     "tags": []
@@ -2365,10 +2365,10 @@
    "id": "monotonicite-fixee-vs-optimale-md",
    "metadata": {
     "papermill": {
-     "duration": 0.007545,
-     "end_time": "2026-09-08T20:41:03.148788",
+     "duration": 0.008659,
+     "end_time": "2026-09-09T00:16:43.038871",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.141243",
+     "start_time": "2026-09-09T00:16:43.030212",
      "status": "completed"
     },
     "tags": []
@@ -2401,8 +2401,11 @@
     "coïncidence : pour cette matrice d'utilité le signal du Test 1 ne change jamais la\n",
     "meilleure action (EVSI brut du Test 1 = 0, cf. `Test 1 seul : 11` = `ne pas tester :\n",
     "11` dans la sortie), il est donc redondant. Le cas **payant** (c1 = 50, c2 = 500)\n",
-    "est tranché en comparant chaque coût à la **borne de valeur de l'information**\n",
-    "(l'EVSI brut du test), pas en réutilisant la fonction gratuite.\n"
+    "est tranché par la **borne globale** : l'EVPI du scénario (24) est inférieure au\n",
+    "coût du test le moins cher (50), donc aucune politique payante — combinaison de\n",
+    "tests ou politique adaptative — ne peut battre « ne rien acquérir ». Les valeurs\n",
+    "« EVSI brut − coût » par test isolé décrivent les politiques individuelles, pas\n",
+    "une borne sur toutes les combinaisons.\n"
    ]
   },
   {
@@ -2411,16 +2414,16 @@
    "id": "monotonicite-oracle-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.166141Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.165935Z",
-     "iopub.status.idle": "2026-09-08T20:41:03.174007Z",
-     "shell.execute_reply": "2026-09-08T20:41:03.173600Z"
+     "iopub.execute_input": "2026-09-09T00:16:43.056366Z",
+     "iopub.status.busy": "2026-09-09T00:16:43.056103Z",
+     "iopub.status.idle": "2026-09-09T00:16:43.064694Z",
+     "shell.execute_reply": "2026-09-09T00:16:43.063876Z"
     },
     "papermill": {
-     "duration": 0.017324,
-     "end_time": "2026-09-08T20:41:03.174649",
+     "duration": 0.018682,
+     "end_time": "2026-09-09T00:16:43.065413",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.157325",
+     "start_time": "2026-09-09T00:16:43.046731",
      "status": "completed"
     },
     "tags": []
@@ -2445,10 +2448,11 @@
       "  politique fixee      : 75\n",
       "  politique optimale   : 100\n",
       "\n",
-      "=== Couts medicaux originaux (c1=50, c2=500) : decision par borne de valeur ===\n",
-      "  EVSI brut Test 1 = -0 vs cout 50  -> borne nette -50\n",
-      "  EVSI brut Test 2 = 13 vs cout 500 -> borne nette -487\n",
-      "  -> optimum payant : aucun test (EU = 11)\n",
+      "=== Couts medicaux originaux (c1=50, c2=500) : decision par borne GLOBALE ===\n",
+      "  EVPI = 24 < cout minimal 50 -> aucun test domine TOUTE politique payante\n",
+      "  Test 1 seul   : EVSI brut -0 - cout 50  = net -50 (politique individuelle)\n",
+      "  Test 2 direct : EVSI brut 13 - cout 500 = net -487 (politique individuelle)\n",
+      "  -> optimum : aucun test (EU = 11)\n",
       "\n",
       "Verification : la monotonie vaut pour la VALEUR OPTIMALE (ensemble elargi), pas pour une politique fixee.\n"
      ]
@@ -2510,15 +2514,19 @@
     "print(f\"  politique optimale   : {_eu_optimale(mprior, mU, mL1, mL2):.0f}\")\n",
     "\n",
     "print()\n",
-    "print(\"=== Couts medicaux originaux (c1=50, c2=500) : decision par borne de valeur ===\")\n",
-    "# Borne de valeur de l'information : meme GRATUIT, un test n'apporte que son EVSI\n",
-    "# brut. Si EVSI brut < cout, AUCUNE politique payante construite sur ce test ne\n",
-    "# peut battre \"ne rien acquerir\" — inutile d'evaluer la politique fixee payante.\n",
-    "bornes = {\"aucun test\": 0.0, \"Test 1\": evsi_t1 - 50, \"Test 2\": evsi_t2 - 500}\n",
-    "print(f\"  EVSI brut Test 1 = {evsi_t1:.0f} vs cout 50  -> borne nette {bornes['Test 1']:.0f}\")\n",
-    "print(f\"  EVSI brut Test 2 = {evsi_t2:.0f} vs cout 500 -> borne nette {bornes['Test 2']:.0f}\")\n",
-    "optimal_payant = max(bornes, key=bornes.get)\n",
-    "print(f\"  -> optimum payant : {optimal_payant} (EU = {eu_sans + bornes[optimal_payant]:.0f})\")\n",
+    "print(\"=== Couts medicaux originaux (c1=50, c2=500) : decision par borne GLOBALE ===\")\n",
+    "# Borne GLOBALE : meme gratuite, toute information rapporte au plus l'EVPI (24 ici).\n",
+    "# Toute politique qui commence une acquisition paie au moins le cout minimal (50)\n",
+    "# et gagne au plus l'EVPI avant couts : combinaison ou adaptative, AUCUNE politique\n",
+    "# payante ne peut battre \"ne rien acquerir\". L'EVSI d'un test SEUL ne suffirait pas\n",
+    "# comme borne (une politique adaptative peut combiner plusieurs tests) ; c'est l'EVPI\n",
+    "# qui tranche. Les nets ci-dessous decrivent les politiques individuelles.\n",
+    "print(f\"  EVPI = {evpi_med:.0f} < cout minimal 50 -> aucun test domine TOUTE politique payante\")\n",
+    "nets_payants = {\"aucun test\": 0.0, \"Test 1\": evsi_t1 - 50, \"Test 2\": evsi_t2 - 500}\n",
+    "print(f\"  Test 1 seul   : EVSI brut {evsi_t1:.0f} - cout 50  = net {nets_payants['Test 1']:.0f} (politique individuelle)\")\n",
+    "print(f\"  Test 2 direct : EVSI brut {evsi_t2:.0f} - cout 500 = net {nets_payants['Test 2']:.0f} (politique individuelle)\")\n",
+    "optimal_payant = max(nets_payants, key=nets_payants.get)\n",
+    "print(f\"  -> optimum : {optimal_payant} (EU = {eu_sans + nets_payants[optimal_payant]:.0f})\")\n",
     "\n",
     "assert eu_optim > eu_fixee, \"l'optimale doit dominer la politique fixee\"\n",
     "assert eu_fixee < eu_t2, \"la politique fixee (positive-only) est dominee par Test 2 seul\"\n",
@@ -2533,10 +2541,10 @@
    "id": "domination-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.007704,
-     "end_time": "2026-09-08T20:41:03.190055",
+     "duration": 0.007384,
+     "end_time": "2026-09-09T00:16:43.080346",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.182351",
+     "start_time": "2026-09-09T00:16:43.072962",
      "status": "completed"
     },
     "tags": []
@@ -2574,8 +2582,8 @@
     "(`cout_t1=50`, `cout_t2=500`) : complétez `strategie_sequentielle` pour dériver\n",
     "l'EU de la politique fixée **payante**, puis confrontez-la aux trois alternatives\n",
     "(aucun test, Test 1 seul, Test 2 direct). L'oracle payant ci-dessus tranche déjà\n",
-    "l'optimum par la borne de valeur : votre calcul doit confirmer que la politique\n",
-    "fixée payante fait encore pire.\n"
+    "l'optimum par la borne globale (EVPI = 24 < coût minimal 50) : votre calcul doit\n",
+    "confirmer que la politique fixée payante fait encore pire.\n"
    ]
   },
   {
@@ -2584,16 +2592,16 @@
    "id": "ca5ab857",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.206237Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.205752Z",
-     "iopub.status.idle": "2026-09-08T20:41:03.209365Z",
-     "shell.execute_reply": "2026-09-08T20:41:03.208978Z"
+     "iopub.execute_input": "2026-09-09T00:16:43.096546Z",
+     "iopub.status.busy": "2026-09-09T00:16:43.096290Z",
+     "iopub.status.idle": "2026-09-09T00:16:43.101256Z",
+     "shell.execute_reply": "2026-09-09T00:16:43.100482Z"
     },
     "papermill": {
-     "duration": 0.012514,
-     "end_time": "2026-09-08T20:41:03.210252",
+     "duration": 0.013837,
+     "end_time": "2026-09-09T00:16:43.102097",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.197738",
+     "start_time": "2026-09-09T00:16:43.088260",
      "status": "completed"
     },
     "tags": []
@@ -2638,10 +2646,10 @@
    "id": "300c4888",
    "metadata": {
     "papermill": {
-     "duration": 0.008881,
-     "end_time": "2026-09-08T20:41:03.226762",
+     "duration": 0.007104,
+     "end_time": "2026-09-09T00:16:43.118359",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.217881",
+     "start_time": "2026-09-09T00:16:43.111255",
      "status": "completed"
     },
     "tags": []
@@ -2659,10 +2667,10 @@
    "id": "4d8af0b9",
    "metadata": {
     "papermill": {
-     "duration": 0.007225,
-     "end_time": "2026-09-08T20:41:03.241397",
+     "duration": 0.007577,
+     "end_time": "2026-09-09T00:16:43.133982",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.234172",
+     "start_time": "2026-09-09T00:16:43.126405",
      "status": "completed"
     },
     "tags": []
@@ -2689,16 +2697,16 @@
    "id": "04a17e05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.258745Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.258315Z",
-     "iopub.status.idle": "2026-09-08T20:41:03.267581Z",
-     "shell.execute_reply": "2026-09-08T20:41:03.267192Z"
+     "iopub.execute_input": "2026-09-09T00:16:43.150183Z",
+     "iopub.status.busy": "2026-09-09T00:16:43.149679Z",
+     "iopub.status.idle": "2026-09-09T00:16:43.158369Z",
+     "shell.execute_reply": "2026-09-09T00:16:43.157963Z"
     },
     "papermill": {
-     "duration": 0.019014,
-     "end_time": "2026-09-08T20:41:03.268257",
+     "duration": 0.017431,
+     "end_time": "2026-09-09T00:16:43.159093",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.249243",
+     "start_time": "2026-09-09T00:16:43.141662",
      "status": "completed"
     },
     "tags": []
@@ -2752,10 +2760,10 @@
    "id": "2573dea4",
    "metadata": {
     "papermill": {
-     "duration": 0.007925,
-     "end_time": "2026-09-08T20:41:03.283313",
+     "duration": 0.007572,
+     "end_time": "2026-09-09T00:16:43.174618",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.275388",
+     "start_time": "2026-09-09T00:16:43.167046",
      "status": "completed"
     },
     "tags": []
@@ -2774,16 +2782,16 @@
    "id": "6e9cdd71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.309628Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.309437Z",
-     "iopub.status.idle": "2026-09-08T20:41:03.550831Z",
-     "shell.execute_reply": "2026-09-08T20:41:03.550411Z"
+     "iopub.execute_input": "2026-09-09T00:16:43.191438Z",
+     "iopub.status.busy": "2026-09-09T00:16:43.191005Z",
+     "iopub.status.idle": "2026-09-09T00:16:43.409692Z",
+     "shell.execute_reply": "2026-09-09T00:16:43.409165Z"
     },
     "papermill": {
-     "duration": 0.260587,
-     "end_time": "2026-09-08T20:41:03.551509",
+     "duration": 0.2279,
+     "end_time": "2026-09-09T00:16:43.410533",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.290922",
+     "start_time": "2026-09-09T00:16:43.182633",
      "status": "completed"
     },
     "tags": []
@@ -2863,10 +2871,10 @@
    "id": "b3c4e1f2",
    "metadata": {
     "papermill": {
-     "duration": 0.007434,
-     "end_time": "2026-09-08T20:41:03.567261",
+     "duration": 0.007816,
+     "end_time": "2026-09-09T00:16:43.426416",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.559827",
+     "start_time": "2026-09-09T00:16:43.418600",
      "status": "completed"
     },
     "tags": []
@@ -2888,16 +2896,16 @@
    "id": "769bd2e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:03.583509Z",
-     "iopub.status.busy": "2026-09-08T20:41:03.583298Z",
-     "iopub.status.idle": "2026-09-08T20:41:16.991051Z",
-     "shell.execute_reply": "2026-09-08T20:41:16.990598Z"
+     "iopub.execute_input": "2026-09-09T00:16:43.442675Z",
+     "iopub.status.busy": "2026-09-09T00:16:43.442466Z",
+     "iopub.status.idle": "2026-09-09T00:16:53.891721Z",
+     "shell.execute_reply": "2026-09-09T00:16:53.891374Z"
     },
     "papermill": {
-     "duration": 13.417223,
-     "end_time": "2026-09-08T20:41:16.991808",
+     "duration": 10.458419,
+     "end_time": "2026-09-09T00:16:53.892364",
      "exception": false,
-     "start_time": "2026-09-08T20:41:03.574585",
+     "start_time": "2026-09-09T00:16:43.433945",
      "status": "completed"
     },
     "tags": []
@@ -2935,7 +2943,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 10_000 draw iterations (2_000 + 20_000 draws total) took 5 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 10_000 draw iterations (2_000 + 20_000 draws total) took 6 seconds.\n"
      ]
     },
     {
@@ -3021,10 +3029,10 @@
    "id": "b7bc368e",
    "metadata": {
     "papermill": {
-     "duration": 0.007183,
-     "end_time": "2026-09-08T20:41:17.006778",
+     "duration": 0.00743,
+     "end_time": "2026-09-09T00:16:53.908019",
      "exception": false,
-     "start_time": "2026-09-08T20:41:16.999595",
+     "start_time": "2026-09-09T00:16:53.900589",
      "status": "completed"
     },
     "tags": []
@@ -3049,16 +3057,16 @@
    "id": "520942ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:17.024273Z",
-     "iopub.status.busy": "2026-09-08T20:41:17.023898Z",
-     "iopub.status.idle": "2026-09-08T20:41:17.229091Z",
-     "shell.execute_reply": "2026-09-08T20:41:17.228713Z"
+     "iopub.execute_input": "2026-09-09T00:16:53.925354Z",
+     "iopub.status.busy": "2026-09-09T00:16:53.925015Z",
+     "iopub.status.idle": "2026-09-09T00:16:54.134536Z",
+     "shell.execute_reply": "2026-09-09T00:16:54.133994Z"
     },
     "papermill": {
-     "duration": 0.214825,
-     "end_time": "2026-09-08T20:41:17.229797",
+     "duration": 0.218694,
+     "end_time": "2026-09-09T00:16:54.135315",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.014972",
+     "start_time": "2026-09-09T00:16:53.916621",
      "status": "completed"
     },
     "tags": []
@@ -3161,10 +3169,10 @@
    "id": "3f79985d",
    "metadata": {
     "papermill": {
-     "duration": 0.01902,
-     "end_time": "2026-09-08T20:41:17.257694",
+     "duration": 0.011649,
+     "end_time": "2026-09-09T00:16:54.156131",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.238674",
+     "start_time": "2026-09-09T00:16:54.144482",
      "status": "completed"
     },
     "tags": []
@@ -3194,16 +3202,16 @@
    "id": "e7eec055",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:17.277491Z",
-     "iopub.status.busy": "2026-09-08T20:41:17.277081Z",
-     "iopub.status.idle": "2026-09-08T20:41:17.530417Z",
-     "shell.execute_reply": "2026-09-08T20:41:17.529873Z"
+     "iopub.execute_input": "2026-09-09T00:16:54.172122Z",
+     "iopub.status.busy": "2026-09-09T00:16:54.171926Z",
+     "iopub.status.idle": "2026-09-09T00:16:54.417599Z",
+     "shell.execute_reply": "2026-09-09T00:16:54.417180Z"
     },
     "papermill": {
-     "duration": 0.26436,
-     "end_time": "2026-09-08T20:41:17.531097",
+     "duration": 0.254577,
+     "end_time": "2026-09-09T00:16:54.418470",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.266737",
+     "start_time": "2026-09-09T00:16:54.163893",
      "status": "completed"
     },
     "tags": []
@@ -3287,10 +3295,10 @@
    "id": "89abb269",
    "metadata": {
     "papermill": {
-     "duration": 0.009125,
-     "end_time": "2026-09-08T20:41:17.549386",
+     "duration": 0.008857,
+     "end_time": "2026-09-09T00:16:54.436257",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.540261",
+     "start_time": "2026-09-09T00:16:54.427400",
      "status": "completed"
     },
     "tags": []
@@ -3309,16 +3317,16 @@
    "id": "f666376f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:17.568666Z",
-     "iopub.status.busy": "2026-09-08T20:41:17.568311Z",
-     "iopub.status.idle": "2026-09-08T20:41:17.836444Z",
-     "shell.execute_reply": "2026-09-08T20:41:17.835908Z"
+     "iopub.execute_input": "2026-09-09T00:16:54.464460Z",
+     "iopub.status.busy": "2026-09-09T00:16:54.464241Z",
+     "iopub.status.idle": "2026-09-09T00:16:54.750103Z",
+     "shell.execute_reply": "2026-09-09T00:16:54.749553Z"
     },
     "papermill": {
-     "duration": 0.27869,
-     "end_time": "2026-09-08T20:41:17.837160",
+     "duration": 0.306281,
+     "end_time": "2026-09-09T00:16:54.751431",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.558470",
+     "start_time": "2026-09-09T00:16:54.445150",
      "status": "completed"
     },
     "tags": []
@@ -3441,10 +3449,10 @@
    "id": "1ef76741",
    "metadata": {
     "papermill": {
-     "duration": 0.009509,
-     "end_time": "2026-09-08T20:41:17.857179",
+     "duration": 0.010357,
+     "end_time": "2026-09-09T00:16:54.772431",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.847670",
+     "start_time": "2026-09-09T00:16:54.762074",
      "status": "completed"
     },
     "tags": []
@@ -3478,10 +3486,10 @@
    "id": "56583bfd",
    "metadata": {
     "papermill": {
-     "duration": 0.010562,
-     "end_time": "2026-09-08T20:41:17.877433",
+     "duration": 0.009725,
+     "end_time": "2026-09-09T00:16:54.791899",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.866871",
+     "start_time": "2026-09-09T00:16:54.782174",
      "status": "completed"
     },
     "tags": []
@@ -3506,16 +3514,16 @@
    "id": "c752eb51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:17.901192Z",
-     "iopub.status.busy": "2026-09-08T20:41:17.900979Z",
-     "iopub.status.idle": "2026-09-08T20:41:18.047937Z",
-     "shell.execute_reply": "2026-09-08T20:41:18.047553Z"
+     "iopub.execute_input": "2026-09-09T00:16:54.812554Z",
+     "iopub.status.busy": "2026-09-09T00:16:54.812339Z",
+     "iopub.status.idle": "2026-09-09T00:16:54.928296Z",
+     "shell.execute_reply": "2026-09-09T00:16:54.927763Z"
     },
     "papermill": {
-     "duration": 0.161519,
-     "end_time": "2026-09-08T20:41:18.048696",
+     "duration": 0.127898,
+     "end_time": "2026-09-09T00:16:54.929012",
      "exception": false,
-     "start_time": "2026-09-08T20:41:17.887177",
+     "start_time": "2026-09-09T00:16:54.801114",
      "status": "completed"
     },
     "tags": []
@@ -3599,10 +3607,10 @@
    "id": "71a7f150",
    "metadata": {
     "papermill": {
-     "duration": 0.01007,
-     "end_time": "2026-09-08T20:41:18.069444",
+     "duration": 0.010026,
+     "end_time": "2026-09-09T00:16:54.949117",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.059374",
+     "start_time": "2026-09-09T00:16:54.939091",
      "status": "completed"
     },
     "tags": []
@@ -3638,10 +3646,10 @@
    "id": "cc2cc982",
    "metadata": {
     "papermill": {
-     "duration": 0.010203,
-     "end_time": "2026-09-08T20:41:18.100784",
+     "duration": 0.010057,
+     "end_time": "2026-09-09T00:16:54.969695",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.090581",
+     "start_time": "2026-09-09T00:16:54.959638",
      "status": "completed"
     },
     "tags": []
@@ -3679,10 +3687,10 @@
    "id": "hier-limits-md",
    "metadata": {
     "papermill": {
-     "duration": 0.011586,
-     "end_time": "2026-09-08T20:41:18.122334",
+     "duration": 0.010297,
+     "end_time": "2026-09-09T00:16:54.990643",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.110748",
+     "start_time": "2026-09-09T00:16:54.980346",
      "status": "completed"
     },
     "tags": []
@@ -3700,10 +3708,10 @@
    "id": "ex4_pymc_partial_pooling",
    "metadata": {
     "papermill": {
-     "duration": 0.009354,
-     "end_time": "2026-09-08T20:41:18.141665",
+     "duration": 0.01087,
+     "end_time": "2026-09-09T00:16:55.010895",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.132311",
+     "start_time": "2026-09-09T00:16:55.000025",
      "status": "completed"
     },
     "tags": []
@@ -3738,16 +3746,16 @@
    "id": "hier-model-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:18.161784Z",
-     "iopub.status.busy": "2026-09-08T20:41:18.161585Z",
-     "iopub.status.idle": "2026-09-08T20:41:18.166580Z",
-     "shell.execute_reply": "2026-09-08T20:41:18.166084Z"
+     "iopub.execute_input": "2026-09-09T00:16:55.031701Z",
+     "iopub.status.busy": "2026-09-09T00:16:55.031437Z",
+     "iopub.status.idle": "2026-09-09T00:16:55.035953Z",
+     "shell.execute_reply": "2026-09-09T00:16:55.035554Z"
     },
     "papermill": {
-     "duration": 0.015971,
-     "end_time": "2026-09-08T20:41:18.167262",
+     "duration": 0.015588,
+     "end_time": "2026-09-09T00:16:55.036644",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.151291",
+     "start_time": "2026-09-09T00:16:55.021056",
      "status": "completed"
     },
     "tags": []
@@ -3809,10 +3817,10 @@
    "id": "hier-shrink-md",
    "metadata": {
     "papermill": {
-     "duration": 0.011134,
-     "end_time": "2026-09-08T20:41:18.189711",
+     "duration": 0.010639,
+     "end_time": "2026-09-09T00:16:55.057034",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.178577",
+     "start_time": "2026-09-09T00:16:55.046395",
      "status": "completed"
     },
     "tags": []
@@ -3831,16 +3839,16 @@
    "id": "hier-shrink-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:18.211883Z",
-     "iopub.status.busy": "2026-09-08T20:41:18.211471Z",
-     "iopub.status.idle": "2026-09-08T20:41:18.214875Z",
-     "shell.execute_reply": "2026-09-08T20:41:18.214476Z"
+     "iopub.execute_input": "2026-09-09T00:16:55.077820Z",
+     "iopub.status.busy": "2026-09-09T00:16:55.077531Z",
+     "iopub.status.idle": "2026-09-09T00:16:55.080389Z",
+     "shell.execute_reply": "2026-09-09T00:16:55.080063Z"
     },
     "papermill": {
-     "duration": 0.014915,
-     "end_time": "2026-09-08T20:41:18.215587",
+     "duration": 0.013771,
+     "end_time": "2026-09-09T00:16:55.080999",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.200672",
+     "start_time": "2026-09-09T00:16:55.067228",
      "status": "completed"
     },
     "tags": []
@@ -3875,16 +3883,16 @@
    "id": "hier-evsi-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:18.236294Z",
-     "iopub.status.busy": "2026-09-08T20:41:18.236088Z",
-     "iopub.status.idle": "2026-09-08T20:41:18.239309Z",
-     "shell.execute_reply": "2026-09-08T20:41:18.238837Z"
+     "iopub.execute_input": "2026-09-09T00:16:55.102321Z",
+     "iopub.status.busy": "2026-09-09T00:16:55.102053Z",
+     "iopub.status.idle": "2026-09-09T00:16:55.105206Z",
+     "shell.execute_reply": "2026-09-09T00:16:55.104886Z"
     },
     "papermill": {
-     "duration": 0.014425,
-     "end_time": "2026-09-08T20:41:18.240003",
+     "duration": 0.014178,
+     "end_time": "2026-09-09T00:16:55.105791",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.225578",
+     "start_time": "2026-09-09T00:16:55.091613",
      "status": "completed"
     },
     "tags": []
@@ -3918,10 +3926,10 @@
    "id": "hier-interp-md",
    "metadata": {
     "papermill": {
-     "duration": 0.009973,
-     "end_time": "2026-09-08T20:41:18.260192",
+     "duration": 0.010393,
+     "end_time": "2026-09-09T00:16:55.127127",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.250219",
+     "start_time": "2026-09-09T00:16:55.116734",
      "status": "completed"
     },
     "tags": []
@@ -3939,10 +3947,10 @@
    "id": "abb2c9f2",
    "metadata": {
     "papermill": {
-     "duration": 0.01079,
-     "end_time": "2026-09-08T20:41:18.281406",
+     "duration": 0.010352,
+     "end_time": "2026-09-09T00:16:55.146999",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.270616",
+     "start_time": "2026-09-09T00:16:55.136647",
      "status": "completed"
     },
     "tags": []
@@ -3979,16 +3987,16 @@
    "id": "2417343e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T20:41:18.304536Z",
-     "iopub.status.busy": "2026-09-08T20:41:18.304165Z",
-     "iopub.status.idle": "2026-09-08T20:41:18.310090Z",
-     "shell.execute_reply": "2026-09-08T20:41:18.309381Z"
+     "iopub.execute_input": "2026-09-09T00:16:55.168638Z",
+     "iopub.status.busy": "2026-09-09T00:16:55.168440Z",
+     "iopub.status.idle": "2026-09-09T00:16:55.173066Z",
+     "shell.execute_reply": "2026-09-09T00:16:55.172690Z"
     },
     "papermill": {
-     "duration": 0.018482,
-     "end_time": "2026-09-08T20:41:18.310910",
+     "duration": 0.017031,
+     "end_time": "2026-09-09T00:16:55.173704",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.292428",
+     "start_time": "2026-09-09T00:16:55.156673",
      "status": "completed"
     },
     "tags": []
@@ -4058,10 +4066,10 @@
    "id": "9905e068",
    "metadata": {
     "papermill": {
-     "duration": 0.011456,
-     "end_time": "2026-09-08T20:41:18.333283",
+     "duration": 0.019845,
+     "end_time": "2026-09-09T00:16:55.203955",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.321827",
+     "start_time": "2026-09-09T00:16:55.184110",
      "status": "completed"
     },
     "tags": []
@@ -4108,10 +4116,10 @@
    "id": "a8db71b7",
    "metadata": {
     "papermill": {
-     "duration": 0.011461,
-     "end_time": "2026-09-08T20:41:18.356329",
+     "duration": 0.010358,
+     "end_time": "2026-09-09T00:16:55.224536",
      "exception": false,
-     "start_time": "2026-09-08T20:41:18.344868",
+     "start_time": "2026-09-09T00:16:55.214178",
      "status": "completed"
     },
     "tags": []
@@ -4169,14 +4177,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 29.486707,
-   "end_time": "2026-09-08T20:41:19.255833",
+   "duration": 20.863232,
+   "end_time": "2026-09-09T00:16:56.152727",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA-15108\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-5-Value-Information.ipynb",
    "output_path": "D:\\Dev\\CoursIA-15108\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-5-Value-Information_output.ipynb",
    "parameters": {},
-   "start_time": "2026-09-08T20:40:49.769126",
+   "start_time": "2026-09-09T00:16:35.289495",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15074

## DecPyMC-5 : monotonie EVSI corrigée — politique fixée vs politique optimale

Closes #15108

Reassessed by myia-po-2023:CoursIA: CONFIRMED (finding reproduit par oracle indépendant — énumération pre-posterior directe, sans `compute_evsi` — qui redonne exactement les chiffres de l'issue : 24,020 / 20,708 / 75 / 100 / 11).

### Le finding

La consigne de l'exercice 3 (cellule `cc202dd8`) appelait « politique optimale » la règle fixée *Test 1 puis Test 2 seulement si Test 1 positif*, et posait la garantie `stratégie séquentielle >= Test 2 seul` au nom de la monotonie de l'information. Cette garantie est fausse : la politique fixée n'appartient pas à un ensemble qui contient « Test 2 seul », et elle lui est en réalité **dominée** (20,708 < 24,020 sur le scénario médical à tests gratuits ; 75 < 100 sur le contrôle minimal).

### Correctif retenu (contrat 2 — politique optimale)

1. **Consigne réécrite** (cellule 46) : distinction explicite **politique fixée** (règle imposée) vs **politique optimale** (max sur un ensemble). L'exercice conserve sa cible (calculer l'EU de la politique fixée), mais la garantie de monotonie est reformulée : elle ne vaut que pour la **valeur optimale sur un ensemble qui contient les alternatives comparées** — une politique fixée peut être dominée.
2. **Nouvelle cellule exemple (résolue)**, après l'interprétation du forage : énumère explicitement l'ensemble des politiques de la section 8 (scénario médical `prior_med`/`U_med`/`L1`/`L2`, coûts mis à 0 pour isoler la valeur du signal) et vérifie la monotonie sur l'**optimal**.

### Vérification réelle (oracle reproduit dans la cellule, sorties committées)

```text
=== Scenario medical, tests GRATUITS ===
  ne pas tester (seule decision) : 11
  Test 1 seul                    : 11
  Test 2 directement             : 24.020
  politique fixee (positive-only): 20.708
  politique optimale             : 24.020
  -> la fixee est DOMINEE par Test 2 seul : True
  -> monotonie de l'OPTIMAL (>= fixee)    : True

=== Controle minimal (2 etats, Test1 non informatif, Test2 parfait, couts nuls) ===
  ne pas tester        : 50
  Test 2 seul          : 100
  politique fixee      : 75
  politique optimale   : 100

=== Couts medicaux originaux (c1=50, c2=500) ===
  ne rien acquerir = optimum : 11 (le cout des tests depasse leur valeur)
```

### Re-exécution réelle (C.2)

Notebook entier re-exécuté (`notebook_tools.py execute --kernel python3`) : **30** cellules code, 0 `execution_count` null, 0 erreur, 22,2 s. L'exemple forage (cellules 47-48) reste intact (numériquement cohérent pour SA politique fixée) ; les cellules d'exercice stubbées (10, 18, 50, 74) sont préservées.

### Vérifications

- Diff source strictement confiné : cellule 46 réécrite + 2 cellules nouvelles (markdown 50, code 51) — rien d'autre (comparaison alignée 80 -> 82 cellules, aucune suppression, cellules 47-49 et 52-81 inchangées).
- Aucune sortie de cellule éditée à la main (100 % régénération par le kernel).
- Ratchets (base origin/main, merge-base `96a9ad68c45f`, après commit) : `check_output_failure_text.py` **1 changed / 0 regressed**, `check_output_flood.py` **1 changed / 0 regressed**, `check_cell_source_parses.py` **0 finding**.
- Catalogue byte-identique à main ; aucun fichier généré touché.
- Claim : commentaire issue 5576281401 (2026-09-08), pré-claim check fait (0 PR ouverte citant 15108).

## Diagnostic dérivé

Verdict : **CAUSE_FIXED** — la dérive venait d'une garantie de monotonie posée sur une politique **fixée** dont l'ensemble ne contenait pas l'alternative comparée. La consigne distingue désormais politique fixée vs optimale, l'exemple d'énumération démontre la dominance, et la monotonie est réaffectée à la valeur optimale sur un ensemble élargi.
