### PR TITLE
fix(semanticweb,#14122): upgrader dotNetRDF 3.5.2 + note CS1701 corrigee (T0 spike)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
@@ -3,13 +3,22 @@
   {
    "cell_type": "markdown",
    "id": "cb0fea89-87c9-42df-880c-4143c0b3e9b2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004299,
+     "end_time": "2026-09-07T22:46:29.704906+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:29.700607+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# SW-9-CSharp-JSONLD -- JSON-LD avec dotNetRDF (twin C#)\n",
     "\n",
     "**Navigation** : [Index](./README.md) | [8-SHACL](SW-8-CSharp-SHACL.ipynb) | [9-Python](SW-9-Python-JSONLD.ipynb) | [10-RDFStar](SW-10-CSharp-RDFStar.ipynb)\n",
     "\n",
-    "Notebook C# / .NET Interactive sur **JSON-LD** avec dotNetRDF 3.4.1 : `@context`, parsing, serialisation, Schema.org, round-trip.\n",
+    "Notebook C# / .NET Interactive sur **JSON-LD** avec dotNetRDF 3.5.2 : `@context`, parsing, serialisation, Schema.org, round-trip.\n",
     "\n",
     "**Objectifs de la seance** :\n",
     "1. Comprendre JSON-LD (JSON for Linked Data) -- format W3C pour representer des graphes RDF en JSON.\n",
@@ -40,20 +49,28 @@
     "5. **Explorer le vocabulaire Schema.org** et faire un round-trip JSON-LD <-> Turtle.\n",
     "## Pourquoi un twin C# ?\n",
     "Le notebook Python original s'appuie sur **`rdflib`** + **`jsonld`** (`pyld`). Ce twin C# invoque le **vrai moteur dotNetRDF** (`VDS.RDF.Parsing.JsonLdParser`, `VDS.RDF.Writing.JsonLdWriter`) — pas de workaround. Subtilite API : JSON-LD etant un format de **dataset** (graphe nomme, mot-cle `@graph`), le parser/writer dotNetRDF opere sur un `TripleStore` (collection de graphes), pas un `Graph` unique comme les autres serialisations RDF. Value-add (EPIC #4956 Prong B) : les deux twins sont des compagnons cross-langage sur le **même standard W3C JSON-LD 1.1**.\n",
-    ".NET 9.0+ (kernel `csharp`). dotNetRDF 3.x (restaure via la directive nuget).\n",
-    ""
+    ".NET 9.0+ (kernel `csharp`). dotNetRDF 3.x (restaure via la directive nuget).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "1c2bacfd-ef33-4b3b-8734-1adfc6c1f289",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003056,
+     "end_time": "2026-09-07T22:46:29.711971+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:29.708915+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Setup -- chargement de dotNetRDF\n",
     "\n",
-    "dotNetRDF 3.4.1 inclut `JsonLdParser` (interface `IStoreReader`) et `JsonLdWriter` (interface `IStoreWriter`). Ce sont les deux classes principales pour JSON-LD.\n",
+    "dotNetRDF 3.5.2 inclut `JsonLdParser` (interface `IStoreReader`) et `JsonLdWriter` (interface `IStoreWriter`). Ce sont les deux classes principales pour JSON-LD.\n",
     "\n",
-    "**Sortie observee de code[0]** (verbatim) : `dotNetRDF: 3.4.1 charge -- JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles.`\n",
+    "**Sortie observee de code[0]** (verbatim) : `dotNetRDF: 3.5.2 charge -- JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles.`\n",
     "\n",
     "**Pourquoi dotNetRDF supporte JSON-LD** :\n",
     "- **Meta-package** : 3.x inclut tous les parsers/writers (Turtle, NTriples, RDF/XML, JSON-LD).\n",
@@ -62,17 +79,16 @@
     "\n",
     "**Implementation C# (import)** :\n",
     "```csharp\n",
-    "#r \"nuget: dotNetRDF, 3.4.1\"\n",
+    "#r \"nuget: dotNetRDF, 3.5.2\"\n",
     "using VDS.RDF;\n",
     "using VDS.RDF.Parsing;\n",
     "using VDS.RDF.Writing;\n",
     "```\n",
     "\n",
-    "**Note d'installation** : la cellule inclut un `warning CS1701` sur Newtonsoft.Json -- c'est un avertissement de version (System.Linq.Expressions 6.0 vs 10.0), pas une erreur. La compilation reussit.\n",
+    "**Note d'installation (CS1701)** : chaque cellule code emet des `warning CS1701` au chargement de dotNetRDF 3.5.2 (package .NETStandard2.0 sous un hote .NET 10) -- avertissement de resolution de version (System.Linq.Expressions 6.0 -> 10.0), pas une erreur : la compilation et l'execution reussissent. Ce sont des indications de liaison d'assembly benignes. Le `#pragma warning disable CS1701` ne les supprime pas (emises a la resolution de la reference nuget, avant la compilation de source) -- c'est pour cela qu'elles restent visibles.\n",
     "\n",
-    "On restaure le **vrai moteur .NET de RDF** : **dotNetRDF 3.4.1** (NuGet `VDS.RDF.*`), l'équivalent C# de `rdflib` + `pyld` côté Python. C'est le moteur W3C de référence sur la plateforme .NET — pas de workaround, pas de réimplémentation jouet (Prong A, EPIC #3801).\n",
-    "Subtilité API centrale de ce notebook : contrairement aux autres sérialisations RDF (Turtle, N-Triples) qui opèrent sur un `Graph` unique, le JSON-LD est nativement un format de **dataset** (graphe nommé, mot-clé `@graph`). Le `JsonLdParser` implémente donc `IStoreReader` (lit dans un `TripleStore`, collection de graphes) et le `JsonLdWriter` implémente `IStoreWriter` — d'où les helpers qui extraient le graphe par défaut du store avant interrogation.\n",
-    ""
+    "On restaure le **vrai moteur .NET de RDF** : **dotNetRDF 3.5.2** (NuGet `VDS.RDF.*`), l'équivalent C# de `rdflib` + `pyld` côté Python. C'est le moteur W3C de référence sur la plateforme .NET — pas de workaround, pas de réimplémentation jouet (Prong A, EPIC #3801).\n",
+    "Subtilité API centrale de ce notebook : contrairement aux autres sérialisations RDF (Turtle, N-Triples) qui opèrent sur un `Graph` unique, le JSON-LD est nativement un format de **dataset** (graphe nommé, mot-clé `@graph`). Le `JsonLdParser` implémente donc `IStoreReader` (lit dans un `TripleStore`, collection de graphes) et le `JsonLdWriter` implémente `IStoreWriter` — d'où les helpers qui extraient le graphe par défaut du store avant interrogation.\n"
    ]
   },
   {
@@ -81,17 +97,140 @@
    "id": "31076692-b982-48cc-a2ae-9858ac01b4ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:49.478847Z",
-     "iopub.status.busy": "2026-07-07T02:09:49.473040Z",
-     "iopub.status.idle": "2026-07-07T02:09:51.349721Z",
-     "shell.execute_reply": "2026-07-07T02:09:51.344528Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:29.745968Z",
+     "iopub.status.busy": "2026-09-07T22:46:29.739359Z",
+     "iopub.status.idle": "2026-09-07T22:46:31.846364Z",
+     "shell.execute_reply": "2026-09-07T22:46:31.841278Z"
+    },
+    "papermill": {
+     "duration": 2.130749,
+     "end_time": "2026-09-07T22:46:31.846476+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:29.715727+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>dotNetRDF, 3.4.1</span></li></ul></div></div>"
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '33116.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>dotNetRDF, 3.5.2</span></li></ul></div></div>"
       ]
      },
      "metadata": {},
@@ -100,7 +239,7 @@
     {
      "data": {
       "text/plain": [
-       "dotNetRDF: 3.4.1 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles."
+       "dotNetRDF: 3.5.2 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles."
       ]
      },
      "metadata": {},
@@ -109,7 +248,7 @@
    ],
    "source": [
     "// dotNetRDF 3.x : meta-package incluant JsonLdParser / JsonLdWriter\n",
-    "#r \"nuget: dotNetRDF, 3.4.1\"\n",
+    "#r \"nuget: dotNetRDF, 3.5.2\"\n",
     "\n",
     "using System;\n",
     "using System.Collections.Generic;\n",
@@ -126,13 +265,22 @@
     "static void Show(object o) { try { display(o); } catch { Console.WriteLine(o); } }\n",
     "static void Show(string label, object o) => Show($\"{label}: {o}\");\n",
     "\n",
-    "Show(\"dotNetRDF\", \"3.4.1 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles.\");\n"
+    "Show(\"dotNetRDF\", \"3.5.2 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles.\");\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e1de39cc-ed72-40e4-97c9-54fa3b8ea25f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002712,
+     "end_time": "2026-09-07T22:46:31.851676+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:31.848964+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Helpers de conversion RDF <-> JSON-LD\n",
     "\n",
@@ -172,8 +320,7 @@
     "\n",
     "**Note de portee** : `JsonLdWriter` produit la forme etendue (chacun des triplets est explicite). Pour la forme compactee (avec `@context`), il faut post-traiter la sortie.\n",
     "\n",
-    "On définit ici trois fonctions utilitaires qui encapsulent la subtilite API : JSON-LD se charge dans un `TripleStore` (dataset), pas un `Graph` unique. On extrait ensuite le graphe par defaut pour l'interroger comme un graphe RDF classique.\n",
-    ""
+    "On définit ici trois fonctions utilitaires qui encapsulent la subtilite API : JSON-LD se charge dans un `TripleStore` (dataset), pas un `Graph` unique. On extrait ensuite le graphe par defaut pour l'interroger comme un graphe RDF classique.\n"
    ]
   },
   {
@@ -182,11 +329,19 @@
    "id": "b78b10fc-015f-499d-abd6-5579daee1b43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:51.351328Z",
-     "iopub.status.busy": "2026-07-07T02:09:51.351120Z",
-     "iopub.status.idle": "2026-07-07T02:09:51.504047Z",
-     "shell.execute_reply": "2026-07-07T02:09:51.503749Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:31.858973Z",
+     "iopub.status.busy": "2026-09-07T22:46:31.858556Z",
+     "iopub.status.idle": "2026-09-07T22:46:32.073067Z",
+     "shell.execute_reply": "2026-09-07T22:46:32.072840Z"
+    },
+    "papermill": {
+     "duration": 0.21918,
+     "end_time": "2026-09-07T22:46:32.073145+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:31.853965+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -234,7 +389,16 @@
   {
    "cell_type": "markdown",
    "id": "c50f8e5d-f277-4752-a388-149c0979607d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00271,
+     "end_time": "2026-09-07T22:46:32.079026+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.076316+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Partie 1 -- `@context` : le dictionnaire de traduction\n",
     "\n",
@@ -270,8 +434,7 @@
     "\n",
     "JSON-LD = JSON + un **`@context`** qui mappe les termes courts (cles JSON) vers des **IRIs** RDF (identifiants globaux). Cela rend JSON compatible Linked Data sans alourdir la syntaxe.\n",
     "Exemple : `\"name\"` -> `http://schema.org/name`, `\"Person\"` -> `http://schema.org/Person`.\n",
-    "On construit d'abord un `@context` comme un `JObject` (Newtonsoft.Json), puis on l'utilise dans un document JSON-LD compact.\n",
-    ""
+    "On construit d'abord un `@context` comme un `JObject` (Newtonsoft.Json), puis on l'utilise dans un document JSON-LD compact.\n"
    ]
   },
   {
@@ -280,11 +443,19 @@
    "id": "e55cbd41-717b-4a9c-ba94-8f345a41fd74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:51.505584Z",
-     "iopub.status.busy": "2026-07-07T02:09:51.505380Z",
-     "iopub.status.idle": "2026-07-07T02:09:51.664013Z",
-     "shell.execute_reply": "2026-07-07T02:09:51.663783Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:32.086434Z",
+     "iopub.status.busy": "2026-09-07T22:46:32.085937Z",
+     "iopub.status.idle": "2026-09-07T22:46:32.329937Z",
+     "shell.execute_reply": "2026-09-07T22:46:32.330077Z"
+    },
+    "papermill": {
+     "duration": 0.248425,
+     "end_time": "2026-09-07T22:46:32.330158+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.081733+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -490,7 +661,16 @@
   {
    "cell_type": "markdown",
    "id": "c3130f3a-f9e3-4a20-b2b7-53bbccdc4439",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00522,
+     "end_time": "2026-09-07T22:46:32.340153+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.334933+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Partie 2 -- Parser du JSON-LD en graphe RDF\n",
     "\n",
@@ -527,8 +707,7 @@
     "\n",
     "**Note de portee** : `JsonLdParser` respecte la specification JSON-LD 1.1, y compris les features avancees (scoped contexts, `@nest`, `@propagate`).\n",
     "\n",
-    "Le `JsonLdParser` de dotNetRDF lit un document JSON-LD dans un `TripleStore` (JSON-LD = format dataset). On extrait le graphe par defaut, puis on l'interroge comme n'importe quel graphe RDF — par exemple en le serialisant en Turtle.\n",
-    ""
+    "Le `JsonLdParser` de dotNetRDF lit un document JSON-LD dans un `TripleStore` (JSON-LD = format dataset). On extrait le graphe par defaut, puis on l'interroge comme n'importe quel graphe RDF — par exemple en le serialisant en Turtle.\n"
    ]
   },
   {
@@ -537,11 +716,19 @@
    "id": "f6ef0f8b-8404-4185-8a2c-14b27fecf248",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:51.665901Z",
-     "iopub.status.busy": "2026-07-07T02:09:51.665653Z",
-     "iopub.status.idle": "2026-07-07T02:09:51.922535Z",
-     "shell.execute_reply": "2026-07-07T02:09:51.922818Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:32.352770Z",
+     "iopub.status.busy": "2026-09-07T22:46:32.352329Z",
+     "iopub.status.idle": "2026-09-07T22:46:32.622247Z",
+     "shell.execute_reply": "2026-09-07T22:46:32.621925Z"
+    },
+    "papermill": {
+     "duration": 0.276981,
+     "end_time": "2026-09-07T22:46:32.622406+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.345425+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -604,7 +791,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8367dbab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004111,
+     "end_time": "2026-09-07T22:46:32.630215+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.626104+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du parsing JSON-LD (ancre sur code[3])\n",
     "\n",
@@ -643,7 +840,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-f6ef0f8b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004351,
+     "end_time": "2026-09-07T22:46:32.637168+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.632817+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat : 6 triplets, l'expansion en action\n",
     "\n",
@@ -655,7 +861,16 @@
   {
    "cell_type": "markdown",
    "id": "4a719092-7e97-4ca1-b4a1-9aa7c6af6882",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004845,
+     "end_time": "2026-09-07T22:46:32.644893+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.640048+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Partie 3 -- Serialiser un graphe RDF en JSON-LD\n",
     "\n",
@@ -702,8 +917,7 @@
     "\n",
     "**Note de portee** : pour la forme compactee, on peut wrapper `JsonLdWriter` avec un post-processeur qui ajoute `@context`.\n",
     "\n",
-    "Inversement, le `JsonLdWriter` produit du JSON-LD (forme etendue) a partir d'un `TripleStore`. On reconstruit un graphe RDF a la main (assertion de triplets), on l'emballe dans un store, puis on le serialise.\n",
-    ""
+    "Inversement, le `JsonLdWriter` produit du JSON-LD (forme etendue) a partir d'un `TripleStore`. On reconstruit un graphe RDF a la main (assertion de triplets), on l'emballe dans un store, puis on le serialise.\n"
    ]
   },
   {
@@ -712,11 +926,19 @@
    "id": "e3f97053-b1f7-4797-beac-9d855c4a4aee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:51.924980Z",
-     "iopub.status.busy": "2026-07-07T02:09:51.924764Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.037555Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.037084Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:32.653820Z",
+     "iopub.status.busy": "2026-09-07T22:46:32.653578Z",
+     "iopub.status.idle": "2026-09-07T22:46:32.741105Z",
+     "shell.execute_reply": "2026-09-07T22:46:32.740951Z"
+    },
+    "papermill": {
+     "duration": 0.092625,
+     "end_time": "2026-09-07T22:46:32.741177+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.648552+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -783,7 +1005,16 @@
   {
    "cell_type": "markdown",
    "id": "e1dc3060-3cd5-40de-a4a1-ffb1e2bc58ba",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003121,
+     "end_time": "2026-09-07T22:46:32.747518+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.744397+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Partie 4 -- Explorer le vocabulaire Schema.org\n",
     "\n",
@@ -883,8 +1114,7 @@
     "- **SEO** : les moteurs de recherche utilisent Schema.org pour les rich snippets.\n",
     "\n",
     "**Schema.org** est un vocabulaire collaboratif (Google, Microsoft, Yahoo, Yandex) pour decrire les choses du web : `Person`, `Product`, `Event`, `Place`, `Organization`... JSON-LD est le format recommande pour embarquer ces données structurees dans les pages HTML (SEO, rich snippets, knowledge graph).\n",
-    "On construit un document Schema.org `Product` (avec une offre imbriquee et une note agregee) et on le valide en le parsant.\n",
-    ""
+    "On construit un document Schema.org `Product` (avec une offre imbriquee et une note agregee) et on le valide en le parsant.\n"
    ]
   },
   {
@@ -893,11 +1123,19 @@
    "id": "6b1d935a-b6ae-4777-a291-dab029da1f3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:52.039444Z",
-     "iopub.status.busy": "2026-07-07T02:09:52.039077Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.168848Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.168689Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:32.756816Z",
+     "iopub.status.busy": "2026-09-07T22:46:32.756552Z",
+     "iopub.status.idle": "2026-09-07T22:46:32.915016Z",
+     "shell.execute_reply": "2026-09-07T22:46:32.914773Z"
+    },
+    "papermill": {
+     "duration": 0.164553,
+     "end_time": "2026-09-07T22:46:32.915131+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.750578+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1131,7 +1369,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "3ec26790",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006635,
+     "end_time": "2026-09-07T22:46:32.927978+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.921343+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de Schema.org Product (ancre sur code[5])\n",
     "\n",
@@ -1230,7 +1478,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-6b1d935a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006654,
+     "end_time": "2026-09-07T22:46:32.940856+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.934202+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat : Schema.org Product valide\n",
     "\n",
@@ -1242,7 +1499,16 @@
   {
    "cell_type": "markdown",
    "id": "f95b7069-4c97-4631-9ec4-86cd2743e70e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006499,
+     "end_time": "2026-09-07T22:46:32.953112+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.946613+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Partie 5 -- `@graph` : regrouper plusieurs ressources\n",
     "\n",
@@ -1278,8 +1544,7 @@
     "\n",
     "**Note de portee** : `@graph` est standard JSON-LD 1.0/1.1. Il est largement supporte par les implementations.\n",
     "\n",
-    "Le mot-cle `@graph` permet de regrouper plusieurs ressources sous un même `@context`, sans que le nœud racine ne soit lui-même une ressource nommee. C'est la forme naturelle pour les datasets (plusieurs sujets decrits ensemble).\n",
-    ""
+    "Le mot-cle `@graph` permet de regrouper plusieurs ressources sous un même `@context`, sans que le nœud racine ne soit lui-même une ressource nommee. C'est la forme naturelle pour les datasets (plusieurs sujets decrits ensemble).\n"
    ]
   },
   {
@@ -1288,11 +1553,19 @@
    "id": "ec1a5735-a6ff-4e8b-b18b-474cf23b984e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:52.170095Z",
-     "iopub.status.busy": "2026-07-07T02:09:52.169910Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.258024Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.257865Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:32.966929Z",
+     "iopub.status.busy": "2026-09-07T22:46:32.966446Z",
+     "iopub.status.idle": "2026-09-07T22:46:33.082449Z",
+     "shell.execute_reply": "2026-09-07T22:46:33.082559Z"
+    },
+    "papermill": {
+     "duration": 0.123689,
+     "end_time": "2026-09-07T22:46:33.082636+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:32.958947+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1496,7 +1769,16 @@
   {
    "cell_type": "markdown",
    "id": "ee72c805-ca45-40ed-aeb8-cb8ad69519dd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004445,
+     "end_time": "2026-09-07T22:46:33.091383+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.086938+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Partie 6 -- Round-trip JSON-LD <-> Turtle\n",
     "\n",
@@ -1552,8 +1834,7 @@
     "- **Validation** : un round-trip reussi prouve que le parser/writer sont conformes.\n",
     "- **Tests** : on peut tester les implementations avec des round-trips.\n",
     "\n",
-    "Un test classique de conformite : parser du JSON-LD, serialiser en Turtle, re-parser, et verifier qu'on retrouve le même graphe (round-trip). On verifie l'isomorphisme par egalite de l'ensemble des triplets (sujet, predicat, objet).\n",
-    ""
+    "Un test classique de conformite : parser du JSON-LD, serialiser en Turtle, re-parser, et verifier qu'on retrouve le même graphe (round-trip). On verifie l'isomorphisme par egalite de l'ensemble des triplets (sujet, predicat, objet).\n"
    ]
   },
   {
@@ -1562,11 +1843,19 @@
    "id": "87472c21-847a-443f-b80d-c97698c1e592",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:52.259276Z",
-     "iopub.status.busy": "2026-07-07T02:09:52.259072Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.400411Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.400695Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:33.104747Z",
+     "iopub.status.busy": "2026-09-07T22:46:33.104374Z",
+     "iopub.status.idle": "2026-09-07T22:46:33.259584Z",
+     "shell.execute_reply": "2026-09-07T22:46:33.259686Z"
+    },
+    "papermill": {
+     "duration": 0.162664,
+     "end_time": "2026-09-07T22:46:33.259753+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.097089+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1720,7 +2009,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2e97a7d3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004027,
+     "end_time": "2026-09-07T22:46:33.267794+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.263767+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du round-trip JSON-LD <-> Turtle (ancre sur code[7])\n",
     "\n",
@@ -1780,7 +2079,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-87472c21",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005981,
+     "end_time": "2026-09-07T22:46:33.278976+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.272995+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat : round-trip OUI isomorphe\n",
     "\n",
@@ -1792,7 +2100,16 @@
   {
    "cell_type": "markdown",
    "id": "b3d47a4a-470f-4a4b-b04f-a3d28b0e810e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004297,
+     "end_time": "2026-09-07T22:46:33.287594+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.283297+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -1823,26 +2140,42 @@
     "4. **Schema.org** : vocabulaire de données structurees (Partie 4).\n",
     "5. **`@graph`** : regroupement de ressources (Partie 5).\n",
     "6. **Round-trip** JSON-LD <-> Turtle + isomorphisme (Partie 6).\n",
-    "Le notebook Python original utilise `rdflib` + `pyld` ; ce twin C# utilise **dotNetRDF** (`VDS.RDF.*`). Les deux sont des moteurs W3C complets. Value-add (EPIC #4956 Prong B) : comparaison cross-langage des API sur le même standard JSON-LD 1.1. Subtilite API notee : `JsonLdParser`/`JsonLdWriter` operent sur `TripleStore` (dataset), refletant que JSON-LD est nativement un format multi-graphes (mot-cle `@graph`).\n",
-    ""
+    "Le notebook Python original utilise `rdflib` + `pyld` ; ce twin C# utilise **dotNetRDF** (`VDS.RDF.*`). Les deux sont des moteurs W3C complets. Value-add (EPIC #4956 Prong B) : comparaison cross-langage des API sur le même standard JSON-LD 1.1. Subtilite API notee : `JsonLdParser`/`JsonLdWriter` operent sur `TripleStore` (dataset), refletant que JSON-LD est nativement un format multi-graphes (mot-cle `@graph`).\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "3b8fbe0b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00379,
+     "end_time": "2026-09-07T22:46:33.295758+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.291968+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
     "## Exercices à compléter\n",
-    "*Ces exercices prolongent les 6 piliers ci-dessus avec dotNetRDF. Les stubs utilisent des marqueurs `// TODO etudiant` — à compléter. Chaque exercice est précédé de son contexte (objectif + notion JSON-LD + API dotNetRDF).*\n",
-    ""
+    "*Ces exercices prolongent les 6 piliers ci-dessus avec dotNetRDF. Les stubs utilisent des marqueurs `// TODO etudiant` — à compléter. Chaque exercice est précédé de son contexte (objectif + notion JSON-LD + API dotNetRDF).*\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e90e997b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004439,
+     "end_time": "2026-09-07T22:46:33.304196+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.299757+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 -- Compaction avec un `@context` personnalise\n",
     "\n",
@@ -1866,8 +2199,7 @@
     "**Objectif.** Écrire un `@context` qui *compacte* un graphe de livres : remplacer les IRIs verbeux (`http://schema.org/title`, `.../author`, `.../datePublished`) par des termes courts français (`titre`, `auteur`, `publie`), puis l'utiliser pour construire un document JSON-LD compact lisible par un humain.\n",
     "**Notion JSON-LD — la compaction.** La *compaction* est l'inverse de l'expansion : partant d'un graphe RDF (ou d'un JSON-LD expansé), elle applique un `@context` pour produire le document JSON le plus court et lisible possible, où chaque propriété porte un terme court au lieu de son IRI complet. C'est ce que publie un site web dans sa balise `<script type=\"application/ld+json\">` : le terme `\"name\"` plutôt que `\"http://schema.org/name\"`.\n",
     "**API dotNetRDF.** Ici on construit manuellement le `@context` comme un `JObject` (`{\"@context\": {\"titre\": \"http://schema.org/title\", ...}}`) — la même structure qu'à la **Partie 1**. Le `JsonLdProcessor` de dotNetRDF sait compacter un graphe, mais l'exercice se concentre sur la *définition du contexte*, qui est le cœur pédagogique.\n",
-    "**Indices.** Étape 1 : mapper chaque terme court (`titre`/`auteur`/`publie`) vers son IRI Schema.org. Étape 2 : vérifier qu'un document construit avec ce contexte se parse bien en graphe RDF (round-trip).\n",
-    ""
+    "**Indices.** Étape 1 : mapper chaque terme court (`titre`/`auteur`/`publie`) vers son IRI Schema.org. Étape 2 : vérifier qu'un document construit avec ce contexte se parse bien en graphe RDF (round-trip).\n"
    ]
   },
   {
@@ -1876,11 +2208,19 @@
    "id": "bcf67b26-a4c1-45a9-81ec-9fcf45dd1082",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:52.402270Z",
-     "iopub.status.busy": "2026-07-07T02:09:52.402092Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.440457Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.440298Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:33.314499Z",
+     "iopub.status.busy": "2026-09-07T22:46:33.314126Z",
+     "iopub.status.idle": "2026-09-07T22:46:33.354164Z",
+     "shell.execute_reply": "2026-09-07T22:46:33.354385Z"
+    },
+    "papermill": {
+     "duration": 0.045919,
+     "end_time": "2026-09-07T22:46:33.354503+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.308584+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1922,7 +2262,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c2001f3f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00611,
+     "end_time": "2026-09-07T22:46:33.367360+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.361250+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de l'exercice 1 (stub) (ancre sur code[8])\n",
     "\n",
@@ -1962,7 +2312,16 @@
   {
    "cell_type": "markdown",
    "id": "5df03f9f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003813,
+     "end_time": "2026-09-07T22:46:33.374246+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.370433+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 -- Framing : extraire un sous-graphe type\n",
     "\n",
@@ -1989,8 +2348,7 @@
     "**Objectif.** Extraire d'un graphe RDF tous les nœuds de type `schema:Person` et retourner pour chacun son `@id` et son `schema:name`. C'est l'opération de *framing* — sélectionner un sous-graphe par sa forme (type, propriétés).\n",
     "**Notion JSON-LD — le framing.** Le *framing* (mot-clé `@frame`) sélectionne dans un graphe la partie qui matche un patron (« tous les nœuds de type Person avec leur nom »). En pratique, on l'émule souvent en énumérant les triples et en filtrant — c'est l'approche légère de cet exercice, qui évite d'introduire toute la mécanique du `JsonLdFrame`.\n",
     "**API dotNetRDF.** Le graphe `g4` (construit en **Partie 5**, dataset multi-ressources via `@graph`) expose `.Triples` : énumérez-le, filtrez les triples de prédicat `rdf:type` dont l'objet est `http://schema.org/Person`, puis pour chaque sujet trouvé récupérez son `schema:name`. Lien direct avec la **Partie 4** (vocabulaire Schema.org) et la **Partie 5** (`@graph`).\n",
-    "**Indices.** Étape 1 : identifier les sujets `?s rdf:type schema:Person`. Étape 2 : pour chacun, lire le triple `?s schema:name ?nom`.\n",
-    ""
+    "**Indices.** Étape 1 : identifier les sujets `?s rdf:type schema:Person`. Étape 2 : pour chacun, lire le triple `?s schema:name ?nom`.\n"
    ]
   },
   {
@@ -1999,11 +2357,19 @@
    "id": "e885d322-5e9e-4eb8-a653-3f26069bc557",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:52.442125Z",
-     "iopub.status.busy": "2026-07-07T02:09:52.441880Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.555450Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.555311Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:33.383499Z",
+     "iopub.status.busy": "2026-09-07T22:46:33.382789Z",
+     "iopub.status.idle": "2026-09-07T22:46:33.484089Z",
+     "shell.execute_reply": "2026-09-07T22:46:33.484229Z"
+    },
+    "papermill": {
+     "duration": 0.106496,
+     "end_time": "2026-09-07T22:46:33.484324+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.377828+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2057,7 +2423,16 @@
   {
    "cell_type": "markdown",
    "id": "86debbc4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006579,
+     "end_time": "2026-09-07T22:46:33.496522+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.489943+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 -- Valider un JSON-LD mal forme\n",
     "\n",
@@ -2078,8 +2453,7 @@
     "**Objectif.** Écrire une fonction `IsValidJsonLd(string json)` qui retourne `true` si la chaîne est du JSON-LD *parsable en graphe RDF*, `false` sinon.\n",
     "**Notion JSON-LD — qu'est-ce qu'un JSON-LD « valide » ?** « Valide » ici signifie *parsable* : la chaîne est du JSON bien formé ET son contenu se traduit en triples RDF. **Ce n'est pas** une garantie de justesse sémantique — un document peut être syntaxiquement valide mais décrire des données absurdes. La distinction *parsabilité* (mécanique) vs *correction* (sémantique) est exactement celle qu'on rencontre en XML (well-formed vs valid).\n",
     "**API dotNetRDF.** Le `JsonLdParser` lève une exception (`RdfParseException` ou `JsonReaderException`) si le JSON est cassé ou n'est pas du JSON-LD exploitable. D'où le pattern `try { parser.Load(...); return true; } catch { return false; }`. Lien avec la **Partie 2** (parser JSON-LD → graphe).\n",
-    "**Indices.** Encapsulez l'appel `LoadJsonLd` (qui invoque `JsonLdParser.Load`) dans un `try/catch`. Testez avec un cas correct (`{\"@id\":...}`) et un cas cassé (`{ce n'est pas du json}`).\n",
-    ""
+    "**Indices.** Encapsulez l'appel `LoadJsonLd` (qui invoque `JsonLdParser.Load`) dans un `try/catch`. Testez avec un cas correct (`{\"@id\":...}`) et un cas cassé (`{ce n'est pas du json}`).\n"
    ]
   },
   {
@@ -2088,11 +2462,19 @@
    "id": "0083077a-0e66-4910-80ec-6e41a83c3552",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T02:09:52.556681Z",
-     "iopub.status.busy": "2026-07-07T02:09:52.556498Z",
-     "iopub.status.idle": "2026-07-07T02:09:52.586386Z",
-     "shell.execute_reply": "2026-07-07T02:09:52.586218Z"
-    }
+     "iopub.execute_input": "2026-09-07T22:46:33.512906Z",
+     "iopub.status.busy": "2026-09-07T22:46:33.512549Z",
+     "iopub.status.idle": "2026-09-07T22:46:33.556547Z",
+     "shell.execute_reply": "2026-09-07T22:46:33.556408Z"
+    },
+    "papermill": {
+     "duration": 0.052749,
+     "end_time": "2026-09-07T22:46:33.556614+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.503865+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2130,7 +2512,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "1a348de6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004412,
+     "end_time": "2026-09-07T22:46:33.565280+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.560868+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de l'exercice 3 (stub) (ancre sur code[10])\n",
     "\n",
@@ -2175,12 +2567,20 @@
   {
    "cell_type": "markdown",
    "id": "3fb0f730-1209-4f00-a4db-de4e9e81e84a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003794,
+     "end_time": "2026-09-07T22:46:33.572643+00:00",
+     "exception": false,
+     "start_time": "2026-09-07T22:46:33.568849+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
-    "*Twin C# du notebook Python `SW-9-Python-JSONLD.ipynb`. Marathon parite .NET <-> Python (#4956, Prong B). dotNetRDF 3.4.1 (vrai moteur W3C JSON-LD 1.1).*\n",
-    ""
+    "*Twin C# du notebook Python `SW-9-Python-JSONLD.ipynb`. Marathon parite .NET <-> Python (#4956, Prong B). dotNetRDF 3.5.2 (vrai moteur W3C JSON-LD 1.1).*\n"
    ]
   }
  ],
@@ -2196,6 +2596,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.268952,
+   "end_time": "2026-09-07T22:46:33.701457+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "SW-9-CSharp-JSONLD.ipynb",
+   "output_path": "SW-9-CSharp-JSONLD.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-07T22:46:27.432505+00:00",
+   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelName": "csharp"

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld/0008-2026-09-08-myia-po-2027-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld/0008-2026-09-08-myia-po-2027-CoursIA.yaml
@@ -1,0 +1,6 @@
+date: '2026-09-08'
+by: myia-po-2027:CoursIA
+python_sha: da3142efa2d665de3f50baf1c96b0f33f3eceeda
+csharp_sha: 0349c1c2d2734385a3c4f0a349663b068a5583af
+content_python_sha: 988c346b165ddef55e1cd0e7a5f55655d4403abb7fef9fc3dbf359387f2b5f1d
+content_csharp_sha: 927d84df11a82aa854ec3e6cf91d2e3514f7b5cf7dcd3d6c750ec04871e54ef0


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/guard #14959

## Summary

Spike T0 de #14122 (tranche bloquante) sur SW-9-CSharp-JSONLD : mecanicien du warning CS1701 (210 lignes, census 2026-09-01). Verdict de levier ecrit avec logs reproductibles ; SW-9 porte desormais la note honnete et la version courante.

- **Upgrade dotNetRDF 3.4.1 → 3.5.2** (cellule setup `#r "nuget: dotNetRDF, 3.5.2"` + mentions markdown) : version stable courante ; verifie sain (11/11 cellules, 0 erreur, sorties pedagogiques identiques hors banniere de version `3.4.1` → `3.5.2`).
- **Note d'installation corrigee** (cellule Setup, etait imprecise : « sur Newtonsoft.Json », singulier) : decrit maintenant avec justesse le CS1701 — package .NETStandard2.0 sous un hote .NET 10, indications de liaison d'assembly benignes (System.Linq.Expressions 6.0 → 10.0), pas une erreur ; le `#pragma warning disable CS1701` ne les supprime pas.

## Validation (lever test, reproductible)

| Levier | Test | Resultat |
|---|---|---|
| Baseline (3.4.1) | papermill kernel .net-csharp, 11/11 cell, 0 erreur | 210 CS1701 (frais, non perimes) |
| (b) `#pragma warning disable CS1701` sur les 11 cellules | re-exec | **210 → 210** : INEFFECTIF |
| (a) upgrade dotNetRDF 3.5.2 | re-exec | 210 → 210, mais sain (0 erreur, sorties identiques) → adopte |
| (c) option kernel/hote | — | N/A (aucun NoWarn global par-notebook) |
| (d) verdict INTRINSIC | — | CS1701 = bruit benign de liaison, insuppressible cote source |

**Mecanisme tranche (contradiction Z3-09)** : le CS1701 est emis a la **resolution de la reference nuget**, avant la compilation de source — donc `#pragma` ne l'atteint pas. Les sorties Z3-09 n'etaient PAS perimees : le pragma y etait simplement inerte. Finding generalisable aux **fichiers de la classe CS1701** du census : la voie est la **documentation** (note honnete), pas la suppression. Les classes reellement corrigeables sont CS8632 (`#nullable enable`) et UserWarning (`filterwarnings`) — cibles des tranches suivantes.

## Validation

- re-execution papermill end-to-end : **11/11 cellules code executees** (execution_count non nul), **0 erreur**.
- Sorties pedagogiques `data` **identiques** entre 3.4.1 et 3.5.2 (hors banniere de version — diff 1 octet sur la cellule setup).
- Diff : uniquement version dotNetRDF + note corregee + outputs re-executes. Aucun hand-edit d'output (C.2 / secrets-hygiene regle 6).

See #14122 (contribution partielle — tranche T0 ; l'EPIC multi-tranches reste ouverte).

