### PR TITLE
Add: hcap of spaceships closed (2|v|<=p) -- translation-invariant reconstruction (13483 tranche 3c step 7)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -782,6 +782,509 @@ theorem hashlife_correct_margin_of_period (c : MacroCell) (k : Nat)
   hashlife_correct_margin_of_hcap c k h_central
     (fun t _ => hcap_of_period _ (canonical_sortDedup _) hT0 hper hdiv t)
 
+/-! ## Invariance par translation de la reconstruction (tranche 3, étape 7, brique 1)
+
+Le scoping étape 7 identifie la brique manquante pour la classe des **vaisseaux**
+(`evolve p g = shift v g`, dérive + période) : la reconstruction
+`gridToMacroCellWithOffset` est **invariante par translation** — translater la
+grille décale l'offset du cadre mais laisse la MacroCell (le quadtree) inchangée.
+C'est ce qui réduira la trajectoire d'un vaisseau à ses `p` phases : chaque
+`evolve t g` est un `shift` d'une phase, et le `shift` disparaît au passage dans
+la reconstruction. La chaîne : bornes min/max de la boîte translatées
+(`gridRowMin_shift` etc., via les témoins d'atteinte et `mem_shift`), puis le
+cadre suit (`gridFrame_shift` : offset translaté, niveau inchangé car les
+portées sont invariantes), puis le quadtree suit (`buildFromGrid_shift`, par
+induction sur le niveau via `elem`/`mem_shift`), d'où la MacroCell reconstruite
+est la même (`gridToMacroCellWithOffset_shift`). -/
+
+/-- L'image d'une cellule vivante est vivante dans la grille translatée :
+    forme directe (direction ← de `mem_shift`), temoin explicite. -/
+theorem mem_shift_image (v : Int × Int) (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    (p.1 + v.1, p.2 + v.2) ∈ shift v g := by
+  rw [mem_shift]
+  have heq : (p.1 + v.1 - v.1, p.2 + v.2 - v.2) = p := by ext <;> omega
+  rw [heq]; exact hp
+
+/-- La translation préserve la non-vacuité : l'image d'une cellule vivante
+    témoigne que `shift v g` n'est pas vide. -/
+theorem shift_ne_nil (v : Int × Int) (g : Grid) (hg : g ≠ []) : shift v g ≠ [] := by
+  obtain ⟨p, hp⟩ : ∃ p, p ∈ g := by
+    cases g with
+    | nil => exact absurd rfl hg
+    | cons p ps => exact ⟨p, by simp⟩
+  intro hnil
+  have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+  rw [hnil] at himg
+  exact absurd himg (by simp)
+
+/-- **Aide générique : un `foldl` de `max` (via `proj`) est *atteint*** — le
+    résultat est soit le départ `acc`, soit la projection d'un élément de la
+    liste. Jumeau de `foldl_proj_min_attained` (MacroCell L572) pour le max,
+    avec les branches de `le_total` échangées. -/
+theorem foldl_proj_max_attained (ps : Grid) (proj : Int × Int → Int) (acc : Int) :
+    ps.foldl (fun m q => max m (proj q)) acc = acc ∨
+    ∃ p ∈ ps, ps.foldl (fun m q => max m (proj q)) acc = proj p := by
+  induction ps generalizing acc with
+  | nil => left; rfl
+  | cons q qs ih =>
+    simp only [List.foldl_cons]
+    rcases ih (max acc (proj q)) with h | ⟨p, hp, hval⟩
+    · rcases le_total acc (proj q) with hle | hle
+      · right; exact ⟨q, by simp, by rw [h]; omega⟩
+      · left; rw [h]; omega
+    · right; exact ⟨p, by simp [hp], hval⟩
+
+/-- Le maximum de ligne d'une grille non vide est *atteint* par une cellule
+    vivante. Jumeau colonne-ligne de `gridRowMin_mem` (MacroCell L590). -/
+theorem gridRowMax_mem (g : Grid) (hg : g ≠ []) :
+    ∃ p ∈ g, p.1 = gridRowMax g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridRowMax]
+    rcases foldl_proj_max_attained ps (·.1) p₀.1 with h | ⟨p, hp, hval⟩
+    · exact ⟨p₀, by simp, h.symm⟩
+    · exact ⟨p, by simp [hp], hval.symm⟩
+
+/-- Le minimum de colonne d'une grille non vide est *atteint* par une cellule
+    vivante. Jumeau de `gridRowMin_mem` sur les colonnes. -/
+theorem gridColMin_mem (g : Grid) (hg : g ≠ []) :
+    ∃ p ∈ g, p.2 = gridColMin g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMin]
+    rcases foldl_proj_min_attained ps (·.2) p₀.2 with h | ⟨p, hp, hval⟩
+    · exact ⟨p₀, by simp, h.symm⟩
+    · exact ⟨p, by simp [hp], hval.symm⟩
+
+/-- Le maximum de colonne d'une grille non vide est *atteint* par une cellule
+    vivante. Jumeau de `gridRowMin_mem` sur les colonnes. -/
+theorem gridColMax_mem (g : Grid) (hg : g ≠ []) :
+    ∃ p ∈ g, p.2 = gridColMax g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMax]
+    rcases foldl_proj_max_attained ps (·.2) p₀.2 with h | ⟨p, hp, hval⟩
+    · exact ⟨p₀, by simp, h.symm⟩
+    · exact ⟨p, by simp [hp], hval.symm⟩
+
+/-- La boîte englobante suit la translation : minimum de ligne translaté
+    de `v.1`. Chaque direction se ferme par le temoin d'atteinte d'un côté
+    (`gridRowMin_mem`), la borne globale de l'autre
+    (`gridRowMin_lower_bound`, étape 5). -/
+theorem gridRowMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridRowMin (shift v g) = gridRowMin g + v.1 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · obtain ⟨p, hp, hval⟩ := gridRowMin_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := gridRowMin_le_of_mem _ _ himg
+    omega
+  · apply gridRowMin_lower_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := gridRowMin_le_of_mem g _ hpre
+    omega
+
+/-- La boîte englobante suit la translation : maximum de ligne translaté
+    de `v.1`. Miroir de `gridRowMin_shift` avec `gridRowMax_mem` (atteinte)
+    et `gridRowMax_upper_bound` (borne, étape 5). -/
+theorem gridRowMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridRowMax (shift v g) = gridRowMax g + v.1 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · apply gridRowMax_upper_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := le_gridRowMax_of_mem g _ hpre
+    omega
+  · obtain ⟨p, hp, hval⟩ := gridRowMax_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := le_gridRowMax_of_mem _ _ himg
+    omega
+
+/-- La boîte englobante suit la translation : minimum de colonne translaté
+    de `v.2`. Miroir colonne de `gridRowMin_shift`. -/
+theorem gridColMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridColMin (shift v g) = gridColMin g + v.2 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · obtain ⟨p, hp, hval⟩ := gridColMin_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := gridColMin_le_of_mem _ _ himg
+    omega
+  · apply gridColMin_lower_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := gridColMin_le_of_mem g _ hpre
+    omega
+
+/-- La boîte englobante suit la translation : maximum de colonne translaté
+    de `v.2`. Miroir colonne de `gridRowMax_shift`. -/
+theorem gridColMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridColMax (shift v g) = gridColMax g + v.2 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · apply gridColMax_upper_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := le_gridColMax_of_mem g _ hpre
+    omega
+  · obtain ⟨p, hp, hval⟩ := gridColMax_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := le_gridColMax_of_mem _ _ himg
+    omega
+
+/-- Le test de feuille de `buildFromGrid` est invariant par translation :
+    `elem` au point translaté de la grille translatée egal `elem` au point
+    original de la grille originale. Les deux sens de `mem_shift` ferment
+    les cas mixtes. -/
+theorem elem_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) :
+    (shift v g).elem (r0 + v.1, c0 + v.2) = g.elem (r0, c0) := by
+  by_cases h : (r0, c0) ∈ g
+  · rw [List.elem_iff.mpr h]
+    exact List.elem_iff.mpr (mem_shift_image v g _ h)
+  · have hf : g.elem (r0, c0) = false := by
+      rcases hbool : g.elem (r0, c0) with
+      | true => exact absurd (List.elem_iff.mp hbool) h
+      | false => rfl
+    have hf' : (shift v g).elem (r0 + v.1, c0 + v.2) = false := by
+      rcases hbool : (shift v g).elem (r0 + v.1, c0 + v.2) with
+      | true =>
+        exact absurd (fun hh => h (by
+          have hpre := (mem_shift v g _).mp (List.elem_iff.mp hbool)
+          have heq : (r0 + v.1 - v.1, c0 + v.2 - v.2) = (r0, c0) := by ext <;> omega
+          rw [heq] at hpre
+          exact hpre)) (fun hn => hh hn)
+      | false => rfl
+    rw [hf', hf]
+
+/-- **Le quadtree suit la translation** : reconstruire la grille translatée
+    depuis l'origine translatée redonne le quadtree original. Induction sur le
+    niveau — feuille par `elem_shift`, noeud par IH sur les quatre quadrants
+    (les offsets de quadrant `(r0 + v.1) + 2^n` se réassocient vers
+    `(r0 + 2^n) + v.1` par `ring` sur les casts). -/
+theorem buildFromGrid_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat) :
+    MacroCell.buildFromGrid (shift v g) (r0 + v.1) (c0 + v.2) lvl
+      = MacroCell.buildFromGrid g r0 c0 lvl := by
+  induction lvl generalizing r0 c0 with
+  | zero =>
+    simp only [MacroCell.buildFromGrid]
+    rw [elem_shift]
+  | succ n ih =>
+    simp only [MacroCell.buildFromGrid]
+    rw [show (c0 : Int) + v.2 + (2 ^ n : Nat) = c0 + (2 ^ n : Nat) + v.2 from by
+        push_cast; ring,
+        show (r0 : Int) + v.1 + (2 ^ n : Nat) = r0 + (2 ^ n : Nat) + v.1 from by
+        push_cast; ring,
+        ih r0 c0, ih r0 (c0 + (2 ^ n : Nat)),
+        ih (r0 + (2 ^ n : Nat)) c0, ih (r0 + (2 ^ n : Nat)) (c0 + (2 ^ n : Nat))]
+
+/-- **Le cadre suit la translation** : `gridFrame` de la grille translatée
+    egale le cadre original avec l'offset translaté et le **même niveau** —
+    les portées `(rMax + v) - (rMin + v)` sont invariantes, donc hauteur,
+    largeur et `ceilLog2` coïncident. -/
+theorem gridFrame_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat)
+    (hframe : gridFrame g = ((r0, c0), lvl)) (hne : g ≠ []) :
+    gridFrame (shift v g) = ((r0 + v.1, c0 + v.2), lvl) := by
+  cases g with
+  | nil => exact absurd rfl hne
+  | cons p₀ ps =>
+    have hne' : p₀ :: ps ≠ [] := List.cons_ne_nil p₀ ps
+    have hsne : shift v (p₀ :: ps) ≠ [] := shift_ne_nil v _ hne'
+    obtain ⟨q₀, qs, hq⟩ : ∃ q₀ qs, shift v (p₀ :: ps) = q₀ :: qs := by
+      cases h : shift v (p₀ :: ps) with
+      | nil => exact absurd h hsne
+      | cons q₀ qs => exact ⟨q₀, qs, rfl⟩
+    have h1 : gridRowMin (q₀ :: qs) = gridRowMin (p₀ :: ps) + v.1 :=
+      gridRowMin_shift v _ hne'
+    have h2 : gridRowMax (q₀ :: qs) = gridRowMax (p₀ :: ps) + v.1 :=
+      gridRowMax_shift v _ hne'
+    have h3 : gridColMin (q₀ :: qs) = gridColMin (p₀ :: ps) + v.2 :=
+      gridColMin_shift v _ hne'
+    have h4 : gridColMax (q₀ :: qs) = gridColMax (p₀ :: ps) + v.2 :=
+      gridColMax_shift v _ hne'
+    have hfr : gridFrame (p₀ :: ps)
+        = ((gridRowMin (p₀ :: ps) - 2, gridColMin (p₀ :: ps) - 2),
+           MacroCell.ceilLog2 (max (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat
+                                    (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat)) := rfl
+    rw [hfr] at hframe
+    obtain ⟨hp, hlvl⟩ := Prod.mk.injEq.mp hframe
+    obtain ⟨hr0, hc0⟩ := Prod.mk.injEq.mp hp
+    rw [hq]
+    have hfr' : gridFrame (q₀ :: qs)
+        = ((gridRowMin (q₀ :: qs) - 2, gridColMin (q₀ :: qs) - 2),
+           MacroCell.ceilLog2 (max (gridRowMax (q₀ :: qs) - gridRowMin (q₀ :: qs) + 5).toNat
+                                    (gridColMax (q₀ :: qs) - gridColMin (q₀ :: qs) + 5).toNat)) := rfl
+    rw [hfr']
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ hne'
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ hne'
+    refine Prod.ext (Prod.ext ?_ ?_) ?_
+    · omega
+    · omega
+    · have hH : (gridRowMax (q₀ :: qs) - gridRowMin (q₀ :: qs) + 5).toNat
+          = (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat := by omega
+      have hW : (gridColMax (q₀ :: qs) - gridColMin (q₀ :: qs) + 5).toNat
+          = (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat := by omega
+      rw [hH, hW, hlvl]
+
+/-- **La reconstruction est invariante par translation** (conclusion de la
+    brique 1) : la MacroCell reconstruite d'une grille translatée est
+    exactement celle de la grille originale — seul l'offset du cadre bouge.
+    Cas vide : les deux reconstructions sont la feuille morte de niveau 0.
+    Cas non vide : `gridFrame_shift` + `buildFromGrid_shift`. -/
+theorem gridToMacroCellWithOffset_shift (v : Int × Int) (g : Grid) :
+    (gridToMacroCellWithOffset (shift v g)).2 = (gridToMacroCellWithOffset g).2 := by
+  by_cases hg : g = []
+  · subst hg
+    simp [shift]
+  · obtain ⟨r0, c0, lvl, hframe⟩ : ∃ r0 c0 lvl, gridFrame g = ((r0, c0), lvl) :=
+      ⟨(gridFrame g).1.1, (gridFrame g).1.2, (gridFrame g).2, rfl⟩
+    have hframe' := gridFrame_shift v g r0 c0 lvl hframe hg
+    simp only [gridToMacroCellWithOffset, hframe, hframe']
+    exact buildFromGrid_shift v g r0 c0 lvl
+
+/-! ## L3 classe des vaisseaux — hcap des spaceships (tranche 3, étape 7)
+
+Troisième maillon L3 **entièrement clos** : la classe des vaisseaux
+(`evolve p g = shift v g` — l'API `IsSpaceship p v g` de HashlifeCorrectness
+déplie exactement `0 < p ∧ Canonical g ∧ evolve p g = shift v g`, donc ces
+énoncés s'appliquent mot pour mot aux vaisseaux du bestiaire : glider
+`p = 4, v = (1, -1)`, LWSS `p = 4, v = (0, 2)`).
+
+La composition que l'adjoint po-2025 réservait explicitement à po-2024 : la
+dérive remplace le point fixe des oscillateurs, donc la capture combine
+(i) la **réduction au résidu modulo `p` avec dérive** — `evolve t g` est un
+`shift ((t/p)•v)` de la phase `evolve (t%p) g` ; (ii) **l'invariance par
+translation de la reconstruction** (brique 1) — le `shift` disparaît dans
+`gridToMacroCellWithOffset`, ramenant la capture aux seules `p` phases ;
+(iii) la **fenêtre du saut absorbe la dérive** — le contenu paddé vit dans
+`[3·2^(k-1), 5·2^(k-1))` et `q = 2^k/p` périodes le dérivent de `q•v`, donc
+le test `[2^k, 2^k + 2^(k+1))²` contient la génération finale ssi
+`|q·v.i| ≤ 2^(k-1)`, i.e. **`2·|v.i| ≤ p` — vitesse au plus c/2**. LWSS
+(`v = (0, 2)`, `p = 4`) atteint la borne exactement ; le glider
+(`v = (1, -1)`, `p = 4`) la vérifie strictement. -/
+
+/-- **Chaque phase d'un vaisseau est un vaisseau.** Si `evolve p g = shift v g`,
+    alors toute phase `evolve r g` vérifie la même relation : l'évolution
+    commute à elle-même et au shift. Miroir exact de `evolve_phase_fix` avec
+    le point fixe remplacé par la relation de dérive. -/
+theorem evolve_spaceship_phase {p : Nat} (g : Grid) (v : Int × Int)
+    (hship : evolve p g = shift v g) (r : Nat) :
+    evolve p (evolve r g) = shift v (evolve r g) := by
+  rw [← evolve_add, Nat.add_comm p r, evolve_add, hship, evolve_shift]
+
+/-- **`m` périodes de vaisseau dérivent de `m•v`.** Copie locale adaptée de
+    `evolve_mulF_of_period` : `evolve (m * p) g = shift (m•v) g`, par
+    induction sur `m` via `evolve_add`, `evolve_shift` et `shift_shift`.
+    Le cas de base exige `shift_zero` (grille canonique). -/
+theorem evolve_spaceship_mulF {p : Nat} (g : Grid) (hg : Canonical g) (v : Int × Int)
+    (hship : evolve p g = shift v g) (m : Nat) :
+    evolve (m * p) g = shift (((m : Int) * v.1), ((m : Int) * v.2)) g := by
+  induction m with
+  | zero =>
+    rw [Nat.zero_mul, evolve_zero, Nat.cast_zero, Int.zero_mul,
+        Nat.cast_zero, Int.zero_mul]
+    exact (shift_zero hg).symm
+  | succ m ih =>
+    have hsplit : (m + 1) * p = m * p + p := by ring
+    rw [hsplit, evolve_add, hship, ← evolve_shift, ih, shift_shift]
+    have h1 : v.1 + ((m : Int) * v.1) = ((m + 1 : Nat) : Int) * v.1 := by
+      rw [Nat.cast_succ]; ring
+    have h2 : v.2 + ((m : Int) * v.2) = ((m + 1 : Nat) : Int) * v.2 := by
+      rw [Nat.cast_succ]; ring
+    rw [h1, h2]
+
+/-- **Réduction de la trajectoire au résidu modulo `p`, avec dérive.** Pour un
+    vaisseau, `evolve t g = shift ((t/p)•v) (evolve (t % p) g)` — le quotient
+    `t / p` de périodes complètes devient une translation composante par
+    composante, le résidu `t % p` porte la phase. Miroir de `evolve_mod_period`
+    où le quotient ne disparaissait pas mais devenait un shift. -/
+theorem evolve_spaceship_mod {p : Nat} (g : Grid) (hg : Canonical g) (v : Int × Int)
+    (hship : evolve p g = shift v g) (t : Nat) :
+    evolve t g = shift (((t / p : Nat) : Int) * v.1, ((t / p : Nat) : Int) * v.2)
+      (evolve (t % p) g) := by
+  have hsplit : t = p * (t / p) + t % p := (Nat.div_add_mod t p).symm
+  conv_lhs => rw [hsplit, evolve_add, Nat.mul_comm]
+  exact evolve_spaceship_mulF _ (evolve_spaceship_phase g hship _) _
+
+/-- **Interface (c) tranche 3, étape 7 — la classe des vaisseaux de vitesse
+    ≤ c/2 est capturée.** Version `jumpCapturedF` du critère vaisseau : tout
+    motif `evolve p (c.toGrid (0,0)) = shift v (c.toGrid (0,0))` porté par une
+    cellule bien formée de niveau `k ≥ 1`, avec `p ∣ 2^k` et la borne de
+    vitesse `2·|v.i| ≤ p` (les deux signes, chaque coordonnée), satisfait le
+    prédicat de capture. La génération finale du jump est le contenu paddé
+    dérivé de `q•v` (`q = 2^k/p`) : le contenu vit dans `[3·2^(k-1), 5·2^(k-1))²`
+    (géométrie `padCenter2` + `cellWfF_toGrid_bounds`), la dérive le déplace
+    d'au plus `2^(k-1)` par coordonnée, donc il reste dans la fenêtre du test
+    `[2^k, 2^k + 2^(k+1))²`. La monotonicité du produit `q·(2·v.i) ≤ q·p = 2^k`
+    transforme la borne de vitesse en borne de dérive — le seul pas non
+    linéaire, établi explicitement. -/
+theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
+    (hlvl : 1 ≤ c.level) {p : Nat} (v : Int × Int)
+    (hship : evolve p (c.toGrid (0, 0)) = shift v (c.toGrid (0, 0)))
+    (hdiv : p ∣ 2 ^ c.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    jumpCapturedF c = true := by
+  obtain ⟨hspd1a, hspd1b⟩ := hspd1
+  obtain ⟨hspd2a, hspd2b⟩ := hspd2
+  obtain ⟨q, hq⟩ := hdiv
+  have hcw : cellWf c := cellWf_of_wf c hwf
+  have hcan : Canonical (c.toGrid (0, 0)) := canonical_sortDedup _
+  have hmul : evolve (2 ^ c.level) (c.toGrid (0, 0))
+      = shift ((q : Int) * v.1, (q : Int) * v.2) (c.toGrid (0, 0)) := by
+    rw [hq, Nat.mul_comm]
+    exact evolve_spaceship_mulF _ hcan hship q
+  have hfinal : evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))
+      = shift ((3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.1,
+               (3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.2)
+          (c.toGrid (0, 0)) := by
+    rw [padCenter2_toGrid_shift c hlvl, ← evolve_shift, hmul, shift_shift]
+  rw [jumpCapturedF_iff]
+  intro p' hp'
+  rw [hfinal, mem_shift] at hp'
+  obtain ⟨hb1, hb2, hb3, hb4⟩ := cellWfF_toGrid_bounds hcw 0 0 hp'
+  dsimp only at hb1 hb2 hb3 hb4
+  have hpow : (2 ^ c.level : Int) = 2 * (2 ^ (c.level - 1) : Int) := by
+    have hsplit : c.level = (c.level - 1) + 1 := by omega
+    conv_lhs => rw [hsplit]
+    rw [pow_succ]
+    ring
+  have hnext : ((2 ^ (c.level + 1) : Nat) : Int)
+      = (2 ^ c.level : Int) + (2 ^ c.level : Int) := by
+    rw [Nat.cast_pow, pow_succ]
+    ring
+  have hy : (0 : Int) ≤ 2 ^ (c.level - 1) := by positivity
+  have hqnn : (0 : Int) ≤ (q : Nat) := by positivity
+  have hcast : ((q : Nat) : Int) * ((p : Nat) : Int) = ((2 ^ c.level : Nat) : Int) := by
+    rw [Nat.cast_mul, hq]
+  have hbridge : ((2 ^ c.level : Nat) : Int) = (2 ^ c.level : Int) :=
+    (Nat.cast_pow 2 c.level).symm
+  have hqA : 2 * ((q : Int) * v.1) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (2 * v.1) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left hspd1b hqnn
+    have e1 : (q : Int) * (2 * v.1) = 2 * ((q : Int) * v.1) := by ring
+    omega
+  have hqB : 2 * (-((q : Int) * v.1)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (-(2 * v.1)) ≤ (q : Int) * ((p : Nat) : Int) := by
+      have hneg : -(2 * v.1) = 2 * (-v.1) := by ring
+      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.1)) hspd1a hqnn
+      omega
+    have e1 : (q : Int) * (-(2 * v.1)) = 2 * (-((q : Int) * v.1)) := by ring
+    omega
+  have hqC : 2 * ((q : Int) * v.2) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (2 * v.2) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left hspd2b hqnn
+    have e1 : (q : Int) * (2 * v.2) = 2 * ((q : Int) * v.2) := by ring
+    omega
+  have hqD : 2 * (-((q : Int) * v.2)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (-(2 * v.2)) ≤ (q : Int) * ((p : Nat) : Int) := by
+      have hneg : -(2 * v.2) = 2 * (-v.2) := by ring
+      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.2)) hspd2a hqnn
+      omega
+    have e1 : (q : Int) * (-(2 * v.2)) = 2 * (-((q : Int) * v.2)) := by ring
+    omega
+  omega
+
+/-- **Transport de la relation de vaisseau à la reconstruction (rendue à
+    l'origine).** L'analogue de `periodic_fix_toGrid_zero` pour la dérive :
+    si `g` est canonique et vérifie `evolve p g = shift v g`, la MacroCell
+    reconstruite rendue à l'origine vérifie la même relation — navette
+    `toGrid_shift_grid`, commutation `evolve_shift`, round-trip ÉGALITÉ. -/
+theorem spaceship_step_toGrid_zero (g : Grid) (hg : Canonical g) {p : Nat}
+    (v : Int × Int) (hship : evolve p g = shift v g) :
+    evolve p ((gridToMacroCellWithOffset g).2.toGrid (0, 0))
+      = shift v ((gridToMacroCellWithOffset g).2.toGrid (0, 0)) := by
+  have hrt : (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1
+      = g := toGrid_gridToMacroCellWithOffset_eq g hg
+  have hshift : (gridToMacroCellWithOffset g).2.toGrid (0, 0)
+      = shift (0 - (gridToMacroCellWithOffset g).1.1,
+               0 - (gridToMacroCellWithOffset g).1.2)
+          ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
+    toGrid_shift_grid _ 0 0 _ _
+  rw [hshift, ← evolve_shift, hrt, hship]
+
+/-- **Capture de la reconstruction d'un vaisseau.** Pour toute phase canonique
+    `g` d'un vaisseau (`evolve p g = shift v g`), dont le niveau de
+    reconstruction divise l'horizon du saut (`p ∣ 2^level`) et dont la vitesse
+    vérifie `2·|v.i| ≤ p`, la reconstruction satisfait le prédicat de saut —
+    `jumpCapturedF_of_spaceship` consommé au niveau de la reconstruction, avec
+    wf (`buildFromGrid_wf`), niveau (`1 ≤ lvl` dès `g ≠ []`, borne n-aware) et
+    relation de dérive transportée (`spaceship_step_toGrid_zero`). Cas vide :
+    la reconstruction est une feuille morte de niveau 0, décidée par le noyau. -/
+theorem jumpCapturedF_reconstruction_of_spaceship (g : Grid) (hg : Canonical g)
+    {p : Nat} (v : Int × Int) (hship : evolve p g = shift v g)
+    (hdiv : p ∣ 2 ^ (gridToMacroCellWithOffset g).2.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    jumpCapturedF (gridToMacroCellWithOffset g).2 = true := by
+  by_cases hne : g = []
+  · subst hne
+    decide
+  · have hwf : ((gridToMacroCellWithOffset g).2).wf = true := by
+      unfold gridToMacroCellWithOffset
+      exact buildFromGrid_wf g _ _ _
+    have hlvl : 1 ≤ (gridToMacroCellWithOffset g).2.level := by
+      have hN := gridToMacroCellWithOffsetN_level_gt_n 2 g hne
+      rw [gridToMacroCellWithOffsetN_le_two_eq 2 g (by omega)] at hN
+      cases hL : (gridToMacroCellWithOffset g).2.level with
+      | zero => rw [hL] at hN; exact absurd hN (by decide)
+      | succ m => omega
+    exact jumpCapturedF_of_spaceship _ hwf hlvl v
+      (spaceship_step_toGrid_zero g hg hship) hdiv hspd1 hspd2
+
+/-- **hcap de la classe des vaisseaux, trajectoire complète.** Pour un vaisseau
+    canonique de période `p > 0`, dont **chaque phase** a un niveau de
+    reconstruction divisible par `p` et dont la vitesse vérifie `2·|v.i| ≤ p`,
+    tout instant `t` est capturé : la trajectoire se réduit à la phase `t % p`
+    **dérivée** de `(t/p)•v` (`evolve_spaceship_mod`), la translation
+    disparaît dans la reconstruction (`gridToMacroCellWithOffset_shift`,
+    brique 1), et la phase — canonique, vaisseau elle-même
+    (`evolve_spaceship_phase`) — est capturée. La prémisses de divisibilité et
+    de vitesse sont finies : elles portent sur les `p` phases seulement. -/
+theorem hcap_of_spaceship (g : Grid) (hg : Canonical g) {p : Nat} (hp0 : 0 < p)
+    (v : Int × Int) (hship : evolve p g = shift v g)
+    (hdiv : ∀ i, i < p →
+      p ∣ 2 ^ (gridToMacroCellWithOffset (evolve i g)).2.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    ∀ t, jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
+  intro t
+  rw [evolve_spaceship_mod g hg hship t, gridToMacroCellWithOffset_shift]
+  have hr : t % p < p := Nat.mod_lt _ hp0
+  have hcan : Canonical (evolve (t % p) g) := by
+    rcases Nat.eq_zero_or_pos (t % p) with h0 | hpos
+    · rw [h0]
+      simpa using hg
+    · exact canonical_evolve_of_pos hpos _
+  exact jumpCapturedF_reconstruction_of_spaceship _ hcan v
+    (evolve_spaceship_phase g hship _) (hdiv _ hr) hspd1 hspd2
+
+/-- **L3 clos pour la classe des vaisseaux de vitesse ≤ c/2 : correction
+    Hashlife des spaceships.** Corollaire d'assemblage — le troisième cas de
+    la décomposition P4.4 où le maillon L3 est **entièrement prouvé**, et la
+    composition que le scoping réservait à cette lane : pour toute MacroCell
+    dont la grille rendue à l'origine est un vaisseau `p > 0` de vitesse
+    `2·|v.i| ≤ p` (chaque phase de niveau divisible par `p`), l'égalité globale
+    `hashlife_correctN` s'applique à tout horizon `2^k` sous `centralCorrect`.
+    La classe couvre glider (`p = 4`, `v = (1, -1)`) et LWSS (`p = 4`,
+    `v = (0, 2)`, la borne exacte) dès que le niveau atteint `log₂ p = 2`. -/
+theorem hashlife_correct_margin_of_spaceship (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k) {p : Nat} (hp0 : 0 < p) (v : Int × Int)
+    (hship : evolve p (c.toGrid (0, 0)) = shift v (c.toGrid (0, 0)))
+    (hdiv : ∀ i, i < p →
+      p ∣ 2 ^ (gridToMacroCellWithOffset (evolve i (c.toGrid (0, 0)))).2.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correct_margin_of_hcap c k h_central
+    (fun t _ => hcap_of_spaceship _ (canonical_sortDedup _) hp0 v hship hdiv hspd1 hspd2 t)
+
 /-! ## Sanity-checks sur le bestiaire
 
 Le fragment `supportInMargin` est **décidable** (instance `Decidable (BoxAssezGrandN)`,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -883,7 +883,7 @@ theorem gridRowMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     have := gridRowMin_le_of_mem _ _ himg
     omega
   · apply gridRowMin_lower_bound _ _ hsne
-    rintro r ⟨hr⟩
+    intro r hr
     have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
     have := gridRowMin_le_of_mem g _ hpre
     omega
@@ -895,10 +895,11 @@ theorem gridRowMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     gridRowMax (shift v g) = gridRowMax g + v.1 := by
   have hsne : shift v g ≠ [] := shift_ne_nil v g hg
   apply le_antisymm
-  · apply gridRowMax_upper_bound _ _ hsne
-    rintro r ⟨hr⟩
-    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
-    have := le_gridRowMax_of_mem g _ hpre
+  · have hb := gridRowMax_upper_bound (shift v g) (gridRowMax g + v.1 + 1) hsne
+      (fun p hp => by
+        have hpre : (p.1 - v.1, p.2 - v.2) ∈ g := (mem_shift v g p).mp hp
+        have := le_gridRowMax_of_mem g _ hpre
+        omega)
     omega
   · obtain ⟨p, hp, hval⟩ := gridRowMax_mem g hg
     have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
@@ -916,7 +917,7 @@ theorem gridColMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     have := gridColMin_le_of_mem _ _ himg
     omega
   · apply gridColMin_lower_bound _ _ hsne
-    rintro r ⟨hr⟩
+    intro r hr
     have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
     have := gridColMin_le_of_mem g _ hpre
     omega
@@ -927,10 +928,11 @@ theorem gridColMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     gridColMax (shift v g) = gridColMax g + v.2 := by
   have hsne : shift v g ≠ [] := shift_ne_nil v g hg
   apply le_antisymm
-  · apply gridColMax_upper_bound _ _ hsne
-    rintro r ⟨hr⟩
-    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
-    have := le_gridColMax_of_mem g _ hpre
+  · have hb := gridColMax_upper_bound (shift v g) (gridColMax g + v.2 + 1) hsne
+      (fun p hp => by
+        have hpre : (p.1 - v.1, p.2 - v.2) ∈ g := (mem_shift v g p).mp hp
+        have := le_gridColMax_of_mem g _ hpre
+        omega)
     omega
   · obtain ⟨p, hp, hval⟩ := gridColMax_mem g hg
     have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
@@ -947,17 +949,17 @@ theorem elem_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) :
   · rw [List.elem_iff.mpr h]
     exact List.elem_iff.mpr (mem_shift_image v g _ h)
   · have hf : g.elem (r0, c0) = false := by
-      rcases hbool : g.elem (r0, c0) with
+      cases hbool : g.elem (r0, c0) with
       | true => exact absurd (List.elem_iff.mp hbool) h
       | false => rfl
     have hf' : (shift v g).elem (r0 + v.1, c0 + v.2) = false := by
-      rcases hbool : (shift v g).elem (r0 + v.1, c0 + v.2) with
+      cases hbool : (shift v g).elem (r0 + v.1, c0 + v.2) with
       | true =>
-        exact absurd (fun hh => h (by
-          have hpre := (mem_shift v g _).mp (List.elem_iff.mp hbool)
+        exact absurd (List.elem_iff.mp hbool) (fun hm => h (by
+          have hpre := (mem_shift v g _).mp hm
           have heq : (r0 + v.1 - v.1, c0 + v.2 - v.2) = (r0, c0) := by ext <;> omega
           rw [heq] at hpre
-          exact hpre)) (fun hn => hh hn)
+          exact hpre))
       | false => rfl
     rw [hf', hf]
 
@@ -998,21 +1000,23 @@ theorem gridFrame_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat)
       cases h : shift v (p₀ :: ps) with
       | nil => exact absurd h hsne
       | cons q₀ qs => exact ⟨q₀, qs, rfl⟩
-    have h1 : gridRowMin (q₀ :: qs) = gridRowMin (p₀ :: ps) + v.1 :=
-      gridRowMin_shift v _ hne'
-    have h2 : gridRowMax (q₀ :: qs) = gridRowMax (p₀ :: ps) + v.1 :=
-      gridRowMax_shift v _ hne'
-    have h3 : gridColMin (q₀ :: qs) = gridColMin (p₀ :: ps) + v.2 :=
-      gridColMin_shift v _ hne'
-    have h4 : gridColMax (q₀ :: qs) = gridColMax (p₀ :: ps) + v.2 :=
-      gridColMax_shift v _ hne'
+    have h1 : gridRowMin (q₀ :: qs) = gridRowMin (p₀ :: ps) + v.1 := by
+      rw [← hq]; exact gridRowMin_shift v _ hne'
+    have h2 : gridRowMax (q₀ :: qs) = gridRowMax (p₀ :: ps) + v.1 := by
+      rw [← hq]; exact gridRowMax_shift v _ hne'
+    have h3 : gridColMin (q₀ :: qs) = gridColMin (p₀ :: ps) + v.2 := by
+      rw [← hq]; exact gridColMin_shift v _ hne'
+    have h4 : gridColMax (q₀ :: qs) = gridColMax (p₀ :: ps) + v.2 := by
+      rw [← hq]; exact gridColMax_shift v _ hne'
     have hfr : gridFrame (p₀ :: ps)
         = ((gridRowMin (p₀ :: ps) - 2, gridColMin (p₀ :: ps) - 2),
            MacroCell.ceilLog2 (max (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat
                                     (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat)) := rfl
     rw [hfr] at hframe
-    obtain ⟨hp, hlvl⟩ := Prod.mk.injEq.mp hframe
-    obtain ⟨hr0, hc0⟩ := Prod.mk.injEq.mp hp
+    rw [Prod.mk.injEq] at hframe
+    obtain ⟨hp, hlvl⟩ := hframe
+    rw [Prod.mk.injEq] at hp
+    obtain ⟨hr0, hc0⟩ := hp
     rw [hq]
     have hfr' : gridFrame (q₀ :: qs)
         = ((gridRowMin (q₀ :: qs) - 2, gridColMin (q₀ :: qs) - 2),
@@ -1024,8 +1028,8 @@ theorem gridFrame_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat)
     have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
       gridColMin_le_gridColMax _ hne'
     refine Prod.ext (Prod.ext ?_ ?_) ?_
-    · omega
-    · omega
+    · dsimp only; omega
+    · dsimp only; omega
     · have hH : (gridRowMax (q₀ :: qs) - gridRowMin (q₀ :: qs) + 5).toNat
           = (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat := by omega
       have hW : (gridColMax (q₀ :: qs) - gridColMin (q₀ :: qs) + 5).toNat
@@ -1041,7 +1045,8 @@ theorem gridToMacroCellWithOffset_shift (v : Int × Int) (g : Grid) :
     (gridToMacroCellWithOffset (shift v g)).2 = (gridToMacroCellWithOffset g).2 := by
   by_cases hg : g = []
   · subst hg
-    simp [shift]
+    have hnil : shift v [] = [] := rfl
+    rw [hnil]
   · obtain ⟨r0, c0, lvl, hframe⟩ : ∃ r0 c0 lvl, gridFrame g = ((r0, c0), lvl) :=
       ⟨(gridFrame g).1.1, (gridFrame g).1.2, (gridFrame g).2, rfl⟩
     have hframe' := gridFrame_shift v g r0 c0 lvl hframe hg
@@ -1087,8 +1092,7 @@ theorem evolve_spaceship_mulF {p : Nat} (g : Grid) (hg : Canonical g) (v : Int �
     evolve (m * p) g = shift (((m : Int) * v.1), ((m : Int) * v.2)) g := by
   induction m with
   | zero =>
-    rw [Nat.zero_mul, evolve_zero, Nat.cast_zero, Int.zero_mul,
-        Nat.cast_zero, Int.zero_mul]
+    rw [Nat.zero_mul, evolve_zero, Nat.cast_zero, Int.zero_mul, Int.zero_mul]
     exact (shift_zero hg).symm
   | succ m ih =>
     have hsplit : (m + 1) * p = m * p + p := by ring
@@ -1109,8 +1113,12 @@ theorem evolve_spaceship_mod {p : Nat} (g : Grid) (hg : Canonical g) (v : Int ×
     evolve t g = shift (((t / p : Nat) : Int) * v.1, ((t / p : Nat) : Int) * v.2)
       (evolve (t % p) g) := by
   have hsplit : t = p * (t / p) + t % p := (Nat.div_add_mod t p).symm
+  have hg' : Canonical (evolve (t % p) g) := by
+    rcases Nat.eq_zero_or_pos (t % p) with h0 | hpos
+    · rw [h0, evolve_zero]; exact hg
+    · exact canonical_evolve_of_pos hpos _
   conv_lhs => rw [hsplit, evolve_add, Nat.mul_comm]
-  exact evolve_spaceship_mulF _ (evolve_spaceship_phase g hship _) _
+  exact evolve_spaceship_mulF _ hg' v (evolve_spaceship_phase g v hship _) _
 
 /-- **Interface (c) tranche 3, étape 7 — la classe des vaisseaux de vitesse
     ≤ c/2 est capturée.** Version `jumpCapturedF` du critère vaisseau : tout
@@ -1139,7 +1147,7 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
   have hmul : evolve (2 ^ c.level) (c.toGrid (0, 0))
       = shift ((q : Int) * v.1, (q : Int) * v.2) (c.toGrid (0, 0)) := by
     rw [hq, Nat.mul_comm]
-    exact evolve_spaceship_mulF _ hcan hship q
+    exact evolve_spaceship_mulF _ hcan v hship q
   have hfinal : evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))
       = shift ((3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.1,
                (3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.2)
@@ -1162,7 +1170,7 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
   have hy : (0 : Int) ≤ 2 ^ (c.level - 1) := by positivity
   have hqnn : (0 : Int) ≤ (q : Nat) := by positivity
   have hcast : ((q : Nat) : Int) * ((p : Nat) : Int) = ((2 ^ c.level : Nat) : Int) := by
-    rw [Nat.cast_mul, hq]
+    rw [← Nat.cast_mul, Nat.mul_comm q p, hq]
   have hbridge : ((2 ^ c.level : Nat) : Int) = (2 ^ c.level : Int) :=
     (Nat.cast_pow 2 c.level).symm
   have hqA : 2 * ((q : Int) * v.1) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
@@ -1171,10 +1179,8 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
     have e1 : (q : Int) * (2 * v.1) = 2 * ((q : Int) * v.1) := by ring
     omega
   have hqB : 2 * (-((q : Int) * v.1)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
-    have e0 : (q : Int) * (-(2 * v.1)) ≤ (q : Int) * ((p : Nat) : Int) := by
-      have hneg : -(2 * v.1) = 2 * (-v.1) := by ring
-      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.1)) hspd1a hqnn
-      omega
+    have e0 : (q : Int) * (-(2 * v.1)) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left (by omega) hqnn
     have e1 : (q : Int) * (-(2 * v.1)) = 2 * (-((q : Int) * v.1)) := by ring
     omega
   have hqC : 2 * ((q : Int) * v.2) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
@@ -1183,13 +1189,27 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
     have e1 : (q : Int) * (2 * v.2) = 2 * ((q : Int) * v.2) := by ring
     omega
   have hqD : 2 * (-((q : Int) * v.2)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
-    have e0 : (q : Int) * (-(2 * v.2)) ≤ (q : Int) * ((p : Nat) : Int) := by
-      have hneg : -(2 * v.2) = 2 * (-v.2) := by ring
-      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.2)) hspd2a hqnn
-      omega
+    have e0 : (q : Int) * (-(2 * v.2)) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left (by omega) hqnn
     have e1 : (q : Int) * (-(2 * v.2)) = 2 * (-((q : Int) * v.2)) := by ring
     omega
   omega
+
+/-- **Commutativité des translations.** Translater par `v` puis par `w`
+    egale translater par `w` puis par `v` : les deux compositions aboutissent
+    au vecteur somme. Par `shift_shift` sur chaque côté (paires explicitées),
+    puis égalité des vecteurs composante par composante. -/
+theorem shift_comm (v w : Int × Int) (g : Grid) :
+    shift v (shift w g) = shift w (shift v g) := by
+  obtain ⟨v1, v2⟩ := v
+  obtain ⟨w1, w2⟩ := w
+  have h1 : shift (v1, v2) (shift (w1, w2) g) = shift (v1 + w1, v2 + w2) g :=
+    shift_shift _ _ _ _ _
+  have h2 : shift (w1, w2) (shift (v1, v2) g) = shift (w1 + v1, w2 + v2) g :=
+    shift_shift _ _ _ _ _
+  rw [h1, h2]
+  congr 1
+  ext <;> ring
 
 /-- **Transport de la relation de vaisseau à la reconstruction (rendue à
     l'origine).** L'analogue de `periodic_fix_toGrid_zero` pour la dérive :
@@ -1207,7 +1227,7 @@ theorem spaceship_step_toGrid_zero (g : Grid) (hg : Canonical g) {p : Nat}
                0 - (gridToMacroCellWithOffset g).1.2)
           ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
     toGrid_shift_grid _ 0 0 _ _
-  rw [hshift, ← evolve_shift, hrt, hship]
+  rw [hshift, ← evolve_shift, hrt, hship, shift_comm]
 
 /-- **Capture de la reconstruction d'un vaisseau.** Pour toute phase canonique
     `g` d'un vaisseau (`evolve p g = shift v g`), dont le niveau de
@@ -1236,7 +1256,7 @@ theorem jumpCapturedF_reconstruction_of_spaceship (g : Grid) (hg : Canonical g)
       | zero => rw [hL] at hN; exact absurd hN (by decide)
       | succ m => omega
     exact jumpCapturedF_of_spaceship _ hwf hlvl v
-      (spaceship_step_toGrid_zero g hg hship) hdiv hspd1 hspd2
+      (spaceship_step_toGrid_zero g hg v hship) hdiv hspd1 hspd2
 
 /-- **hcap de la classe des vaisseaux, trajectoire complète.** Pour un vaisseau
     canonique de période `p > 0`, dont **chaque phase** a un niveau de
@@ -1255,7 +1275,7 @@ theorem hcap_of_spaceship (g : Grid) (hg : Canonical g) {p : Nat} (hp0 : 0 < p)
     (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
     ∀ t, jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
   intro t
-  rw [evolve_spaceship_mod g hg hship t, gridToMacroCellWithOffset_shift]
+  rw [evolve_spaceship_mod g hg v hship t, gridToMacroCellWithOffset_shift]
   have hr : t % p < p := Nat.mod_lt _ hp0
   have hcan : Canonical (evolve (t % p) g) := by
     rcases Nat.eq_zero_or_pos (t % p) with h0 | hpos
@@ -1263,7 +1283,7 @@ theorem hcap_of_spaceship (g : Grid) (hg : Canonical g) {p : Nat} (hp0 : 0 < p)
       simpa using hg
     · exact canonical_evolve_of_pos hpos _
   exact jumpCapturedF_reconstruction_of_spaceship _ hcan v
-    (evolve_spaceship_phase g hship _) (hdiv _ hr) hspd1 hspd2
+    (evolve_spaceship_phase g v hship _) (hdiv _ hr) hspd1 hspd2
 
 /-- **L3 clos pour la classe des vaisseaux de vitesse ≤ c/2 : correction
     Hashlife des spaceships.** Corollaire d'assemblage — le troisième cas de

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -783,6 +783,512 @@ theorem hashlife_correct_margin_of_period (c : MacroCell) (k : Nat)
   hashlife_correct_margin_of_hcap c k h_central
     (fun t _ => hcap_of_period _ (canonical_sortDedup _) hT0 hper hdiv t)
 
+/-! ## Translation invariance of the reconstruction (tranche 3, step 7, brick 1)
+
+Step-7 scoping identifies the missing brick for the **spaceship** class
+(`evolve p g = shift v g`, drift + period): the reconstruction
+`gridToMacroCellWithOffset` is **invariant under translation** — translating the
+grid shifts the frame offset but leaves the MacroCell (the quadtree) unchanged.
+This is what reduces a spaceship trajectory to its `p` phases: every
+`evolve t g` is a `shift` of some phase, and the `shift` vanishes when entering
+the reconstruction. The chain: translated bounding-box bounds
+(`gridRowMin_shift` etc., via attainment witnesses and `mem_shift`), then the
+frame follows (`gridFrame_shift`: offset translated, level unchanged since the
+spans are invariant), then the quadtree follows (`buildFromGrid_shift`, by
+induction on the level via `elem`/`mem_shift`), hence the reconstructed
+MacroCell is the same (`gridToMacroCellWithOffset_shift`). -/
+
+/-- The image of a live cell is live in the translated grid: direct form
+    (the ← direction of `mem_shift`), explicit witness. -/
+theorem mem_shift_image (v : Int × Int) (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    (p.1 + v.1, p.2 + v.2) ∈ shift v g := by
+  rw [mem_shift]
+  have heq : (p.1 + v.1 - v.1, p.2 + v.2 - v.2) = p := by ext <;> omega
+  rw [heq]; exact hp
+
+/-- Translation preserves non-emptiness: the image of a live cell witnesses
+    that `shift v g` is not empty. -/
+theorem shift_ne_nil (v : Int × Int) (g : Grid) (hg : g ≠ []) : shift v g ≠ [] := by
+  obtain ⟨p, hp⟩ : ∃ p, p ∈ g := by
+    cases g with
+    | nil => exact absurd rfl hg
+    | cons p ps => exact ⟨p, by simp⟩
+  intro hnil
+  have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+  rw [hnil] at himg
+  exact absurd himg (by simp)
+
+/-- **Generic helper: a `foldl` of `max` (via `proj`) is *attained*** — the
+    result is either the seed `acc` or the projection of a list element.
+    Twin of `foldl_proj_min_attained` (MacroCell L572) for the max, with the
+    `le_total` branches swapped. -/
+theorem foldl_proj_max_attained (ps : Grid) (proj : Int × Int → Int) (acc : Int) :
+    ps.foldl (fun m q => max m (proj q)) acc = acc ∨
+    ∃ p ∈ ps, ps.foldl (fun m q => max m (proj q)) acc = proj p := by
+  induction ps generalizing acc with
+  | nil => left; rfl
+  | cons q qs ih =>
+    simp only [List.foldl_cons]
+    rcases ih (max acc (proj q)) with h | ⟨p, hp, hval⟩
+    · rcases le_total acc (proj q) with hle | hle
+      · right; exact ⟨q, by simp, by rw [h]; omega⟩
+      · left; rw [h]; omega
+    · right; exact ⟨p, by simp [hp], hval⟩
+
+/-- The row maximum of a non-empty grid is *attained* by a live cell.
+    Row twin of `gridRowMax_mem`'s column siblings of `gridRowMin_mem`
+    (MacroCell L590). -/
+theorem gridRowMax_mem (g : Grid) (hg : g ≠ []) :
+    ∃ p ∈ g, p.1 = gridRowMax g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridRowMax]
+    rcases foldl_proj_max_attained ps (·.1) p₀.1 with h | ⟨p, hp, hval⟩
+    · exact ⟨p₀, by simp, h.symm⟩
+    · exact ⟨p, by simp [hp], hval.symm⟩
+
+/-- The column minimum of a non-empty grid is *attained* by a live cell.
+    Column twin of `gridRowMin_mem`. -/
+theorem gridColMin_mem (g : Grid) (hg : g ≠ []) :
+    ∃ p ∈ g, p.2 = gridColMin g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMin]
+    rcases foldl_proj_min_attained ps (·.2) p₀.2 with h | ⟨p, hp, hval⟩
+    · exact ⟨p₀, by simp, h.symm⟩
+    · exact ⟨p, by simp [hp], hval.symm⟩
+
+/-- The column maximum of a non-empty grid is *attained* by a live cell.
+    Column twin of `gridRowMin_mem`. -/
+theorem gridColMax_mem (g : Grid) (hg : g ≠ []) :
+    ∃ p ∈ g, p.2 = gridColMax g := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridColMax]
+    rcases foldl_proj_max_attained ps (·.2) p₀.2 with h | ⟨p, hp, hval⟩
+    · exact ⟨p₀, by simp, h.symm⟩
+    · exact ⟨p, by simp [hp], hval.symm⟩
+
+/-- The bounding box follows the translation: row minimum translated by
+    `v.1`. Each direction closes by the attainment witness on one side
+    (`gridRowMin_mem`), the global bound on the other
+    (`gridRowMin_lower_bound`, step 5). -/
+theorem gridRowMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridRowMin (shift v g) = gridRowMin g + v.1 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · obtain ⟨p, hp, hval⟩ := gridRowMin_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := gridRowMin_le_of_mem _ _ himg
+    omega
+  · apply gridRowMin_lower_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := gridRowMin_le_of_mem g _ hpre
+    omega
+
+/-- The bounding box follows the translation: row maximum translated by
+    `v.1`. Mirror of `gridRowMin_shift` with `gridRowMax_mem` (attainment)
+    and `gridRowMax_upper_bound` (bound, step 5). -/
+theorem gridRowMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridRowMax (shift v g) = gridRowMax g + v.1 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · apply gridRowMax_upper_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := le_gridRowMax_of_mem g _ hpre
+    omega
+  · obtain ⟨p, hp, hval⟩ := gridRowMax_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := le_gridRowMax_of_mem _ _ himg
+    omega
+
+/-- The bounding box follows the translation: column minimum translated by
+    `v.2`. Column mirror of `gridRowMin_shift`. -/
+theorem gridColMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridColMin (shift v g) = gridColMin g + v.2 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · obtain ⟨p, hp, hval⟩ := gridColMin_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := gridColMin_le_of_mem _ _ himg
+    omega
+  · apply gridColMin_lower_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := gridColMin_le_of_mem g _ hpre
+    omega
+
+/-- The bounding box follows the translation: column maximum translated by
+    `v.2`. Column mirror of `gridRowMax_shift`. -/
+theorem gridColMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
+    gridColMax (shift v g) = gridColMax g + v.2 := by
+  have hsne : shift v g ≠ [] := shift_ne_nil v g hg
+  apply le_antisymm
+  · apply gridColMax_upper_bound _ _ hsne
+    rintro r ⟨hr⟩
+    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
+    have := le_gridColMax_of_mem g _ hpre
+    omega
+  · obtain ⟨p, hp, hval⟩ := gridColMax_mem g hg
+    have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
+    have := le_gridColMax_of_mem _ _ himg
+    omega
+
+/-- The leaf test of `buildFromGrid` is translation-invariant: `elem` at the
+    translated point of the translated grid equals `elem` at the original
+    point of the original grid. Both directions of `mem_shift` close the
+    mixed cases. -/
+theorem elem_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) :
+    (shift v g).elem (r0 + v.1, c0 + v.2) = g.elem (r0, c0) := by
+  by_cases h : (r0, c0) ∈ g
+  · rw [List.elem_iff.mpr h]
+    exact List.elem_iff.mpr (mem_shift_image v g _ h)
+  · have hf : g.elem (r0, c0) = false := by
+      rcases hbool : g.elem (r0, c0) with
+      | true => exact absurd (List.elem_iff.mp hbool) h
+      | false => rfl
+    have hf' : (shift v g).elem (r0 + v.1, c0 + v.2) = false := by
+      rcases hbool : (shift v g).elem (r0 + v.1, c0 + v.2) with
+      | true =>
+        exact absurd (fun hh => h (by
+          have hpre := (mem_shift v g _).mp (List.elem_iff.mp hbool)
+          have heq : (r0 + v.1 - v.1, c0 + v.2 - v.2) = (r0, c0) := by ext <;> omega
+          rw [heq] at hpre
+          exact hpre)) (fun hn => hh hn)
+      | false => rfl
+    rw [hf', hf]
+
+/-- **The quadtree follows the translation**: rebuilding the translated grid
+    from the translated origin gives back the original quadtree. Induction on
+    the level — leaf by `elem_shift`, node by IH on the four quadrants (the
+    quadrant offsets `(r0 + v.1) + 2^n` re-associate to `(r0 + 2^n) + v.1` by
+    `ring` on the casts). -/
+theorem buildFromGrid_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat) :
+    MacroCell.buildFromGrid (shift v g) (r0 + v.1) (c0 + v.2) lvl
+      = MacroCell.buildFromGrid g r0 c0 lvl := by
+  induction lvl generalizing r0 c0 with
+  | zero =>
+    simp only [MacroCell.buildFromGrid]
+    rw [elem_shift]
+  | succ n ih =>
+    simp only [MacroCell.buildFromGrid]
+    rw [show (c0 : Int) + v.2 + (2 ^ n : Nat) = c0 + (2 ^ n : Nat) + v.2 from by
+        push_cast; ring,
+        show (r0 : Int) + v.1 + (2 ^ n : Nat) = r0 + (2 ^ n : Nat) + v.1 from by
+        push_cast; ring,
+        ih r0 c0, ih r0 (c0 + (2 ^ n : Nat)),
+        ih (r0 + (2 ^ n : Nat)) c0, ih (r0 + (2 ^ n : Nat)) (c0 + (2 ^ n : Nat))]
+
+/-- **The frame follows the translation**: `gridFrame` of the translated grid
+    equals the original frame with translated offset and the **same level** —
+    the spans `(rMax + v) - (rMin + v)` are invariant, so height, width and
+    `ceilLog2` coincide. -/
+theorem gridFrame_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat)
+    (hframe : gridFrame g = ((r0, c0), lvl)) (hne : g ≠ []) :
+    gridFrame (shift v g) = ((r0 + v.1, c0 + v.2), lvl) := by
+  cases g with
+  | nil => exact absurd rfl hne
+  | cons p₀ ps =>
+    have hne' : p₀ :: ps ≠ [] := List.cons_ne_nil p₀ ps
+    have hsne : shift v (p₀ :: ps) ≠ [] := shift_ne_nil v _ hne'
+    obtain ⟨q₀, qs, hq⟩ : ∃ q₀ qs, shift v (p₀ :: ps) = q₀ :: qs := by
+      cases h : shift v (p₀ :: ps) with
+      | nil => exact absurd h hsne
+      | cons q₀ qs => exact ⟨q₀, qs, rfl⟩
+    have h1 : gridRowMin (q₀ :: qs) = gridRowMin (p₀ :: ps) + v.1 :=
+      gridRowMin_shift v _ hne'
+    have h2 : gridRowMax (q₀ :: qs) = gridRowMax (p₀ :: ps) + v.1 :=
+      gridRowMax_shift v _ hne'
+    have h3 : gridColMin (q₀ :: qs) = gridColMin (p₀ :: ps) + v.2 :=
+      gridColMin_shift v _ hne'
+    have h4 : gridColMax (q₀ :: qs) = gridColMax (p₀ :: ps) + v.2 :=
+      gridColMax_shift v _ hne'
+    have hfr : gridFrame (p₀ :: ps)
+        = ((gridRowMin (p₀ :: ps) - 2, gridColMin (p₀ :: ps) - 2),
+           MacroCell.ceilLog2 (max (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat
+                                    (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat)) := rfl
+    rw [hfr] at hframe
+    obtain ⟨hp, hlvl⟩ := Prod.mk.injEq.mp hframe
+    obtain ⟨hr0, hc0⟩ := Prod.mk.injEq.mp hp
+    rw [hq]
+    have hfr' : gridFrame (q₀ :: qs)
+        = ((gridRowMin (q₀ :: qs) - 2, gridColMin (q₀ :: qs) - 2),
+           MacroCell.ceilLog2 (max (gridRowMax (q₀ :: qs) - gridRowMin (q₀ :: qs) + 5).toNat
+                                    (gridColMax (q₀ :: qs) - gridColMin (q₀ :: qs) + 5).toNat)) := rfl
+    rw [hfr']
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ hne'
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ hne'
+    refine Prod.ext (Prod.ext ?_ ?_) ?_
+    · omega
+    · omega
+    · have hH : (gridRowMax (q₀ :: qs) - gridRowMin (q₀ :: qs) + 5).toNat
+          = (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat := by omega
+      have hW : (gridColMax (q₀ :: qs) - gridColMin (q₀ :: qs) + 5).toNat
+          = (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat := by omega
+      rw [hH, hW, hlvl]
+
+/-- **The reconstruction is translation-invariant** (conclusion of brick 1):
+    the MacroCell rebuilt from a translated grid is exactly the one of the
+    original grid — only the frame offset moves. Empty case: both
+    reconstructions are the dead level-0 leaf. Non-empty case:
+    `gridFrame_shift` + `buildFromGrid_shift`. -/
+theorem gridToMacroCellWithOffset_shift (v : Int × Int) (g : Grid) :
+    (gridToMacroCellWithOffset (shift v g)).2 = (gridToMacroCellWithOffset g).2 := by
+  by_cases hg : g = []
+  · subst hg
+    simp [shift]
+  · obtain ⟨r0, c0, lvl, hframe⟩ : ∃ r0 c0 lvl, gridFrame g = ((r0, c0), lvl) :=
+      ⟨(gridFrame g).1.1, (gridFrame g).1.2, (gridFrame g).2, rfl⟩
+    have hframe' := gridFrame_shift v g r0 c0 lvl hframe hg
+    simp only [gridToMacroCellWithOffset, hframe, hframe']
+    exact buildFromGrid_shift v g r0 c0 lvl
+
+/-! ## L3 spaceship class — hcap of spaceships (tranche 3, step 7)
+
+Third L3 link **entirely closed**: the spaceship class
+(`evolve p g = shift v g` — the `IsSpaceship p v g` API of HashlifeCorrectness
+unfolds to exactly `0 < p ∧ Canonical g ∧ evolve p g = shift v g`, so these
+statements apply verbatim to the bestiary spaceships: glider `p = 4`,
+`v = (1, -1)`, LWSS `p = 4`, `v = (0, 2)`).
+
+The composition that the po-2025 adjoint explicitly reserved to po-2024:
+drift replaces the oscillator fixed point, so the capture combines
+(i) the **reduction to the residue modulo `p` with drift** — `evolve t g` is a
+`shift ((t/p)•v)` of the phase `evolve (t%p) g`; (ii) **translation invariance
+of the reconstruction** (brick 1) — the `shift` vanishes inside
+`gridToMacroCellWithOffset`, reducing the capture to the `p` phases only;
+(iii) **the jump window absorbs the drift** — the padded content lives in
+`[3·2^(k-1), 5·2^(k-1))` and `q = 2^k/p` periods drift it by `q•v`, so the
+test window `[2^k, 2^k + 2^(k+1))²` contains the final generation iff
+`|q·v.i| ≤ 2^(k-1)`, i.e. **`2·|v.i| ≤ p` — speed at most c/2**. LWSS
+(`v = (0, 2)`, `p = 4`) attains the bound exactly; the glider (`v = (1, -1)`,
+`p = 4`) satisfies it strictly. -/
+
+/-- **Every phase of a spaceship is a spaceship.** If
+    `evolve p g = shift v g`, then every phase `evolve r g` satisfies the same
+    relation: evolution commutes with itself and with the shift. Exact mirror
+    of `evolve_phase_fix` with the fixed point replaced by the drift
+    relation. -/
+theorem evolve_spaceship_phase {p : Nat} (g : Grid) (v : Int × Int)
+    (hship : evolve p g = shift v g) (r : Nat) :
+    evolve p (evolve r g) = shift v (evolve r g) := by
+  rw [← evolve_add, Nat.add_comm p r, evolve_add, hship, evolve_shift]
+
+/-- **`m` spaceship periods drift by `m•v`.** Adapted local copy of
+    `evolve_mulF_of_period`: `evolve (m * p) g = shift (m•v) g`, by induction
+    on `m` via `evolve_add`, `evolve_shift` and `shift_shift`. The base case
+    requires `shift_zero` (canonical grid). -/
+theorem evolve_spaceship_mulF {p : Nat} (g : Grid) (hg : Canonical g) (v : Int × Int)
+    (hship : evolve p g = shift v g) (m : Nat) :
+    evolve (m * p) g = shift (((m : Int) * v.1), ((m : Int) * v.2)) g := by
+  induction m with
+  | zero =>
+    rw [Nat.zero_mul, evolve_zero, Nat.cast_zero, Int.zero_mul,
+        Nat.cast_zero, Int.zero_mul]
+    exact (shift_zero hg).symm
+  | succ m ih =>
+    have hsplit : (m + 1) * p = m * p + p := by ring
+    rw [hsplit, evolve_add, hship, ← evolve_shift, ih, shift_shift]
+    have h1 : v.1 + ((m : Int) * v.1) = ((m + 1 : Nat) : Int) * v.1 := by
+      rw [Nat.cast_succ]; ring
+    have h2 : v.2 + ((m : Int) * v.2) = ((m + 1 : Nat) : Int) * v.2 := by
+      rw [Nat.cast_succ]; ring
+    rw [h1, h2]
+
+/-- **Trajectory reduction to the residue modulo `p`, with drift.** For a
+    spaceship, `evolve t g = shift ((t/p)•v) (evolve (t % p) g)` — the
+    quotient `t / p` of complete periods becomes a componentwise translation,
+    the residue `t % p` carries the phase. Mirror of `evolve_mod_period`
+    where the quotient did not vanish but became a shift. -/
+theorem evolve_spaceship_mod {p : Nat} (g : Grid) (hg : Canonical g) (v : Int × Int)
+    (hship : evolve p g = shift v g) (t : Nat) :
+    evolve t g = shift (((t / p : Nat) : Int) * v.1, ((t / p : Nat) : Int) * v.2)
+      (evolve (t % p) g) := by
+  have hsplit : t = p * (t / p) + t % p := (Nat.div_add_mod t p).symm
+  conv_lhs => rw [hsplit, evolve_add, Nat.mul_comm]
+  exact evolve_spaceship_mulF _ (evolve_spaceship_phase g hship _) _
+
+/-- **Interface (c) tranche 3, step 7 — the spaceship class of speed ≤ c/2 is
+    captured.** `jumpCapturedF` version of the spaceship criterion: any
+    pattern `evolve p (c.toGrid (0,0)) = shift v (c.toGrid (0,0))` carried by
+    a well-formed cell of level `k ≥ 1`, with `p ∣ 2^k` and the speed bound
+    `2·|v.i| ≤ p` (both signs, each coordinate), satisfies the capture
+    predicate. The final generation of the jump is the padded content drifted
+    by `q•v` (`q = 2^k/p`): the content lives in
+    `[3·2^(k-1), 5·2^(k-1))²` (geometry `padCenter2` + `cellWfF_toGrid_bounds`),
+    the drift moves it by at most `2^(k-1)` per coordinate, so it stays inside
+    the test window `[2^k, 2^k + 2^(k+1))²`. Product monotonicity
+    `q·(2·v.i) ≤ q·p = 2^k` turns the speed bound into a drift bound — the
+    only non-linear step, established explicitly. -/
+theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
+    (hlvl : 1 ≤ c.level) {p : Nat} (v : Int × Int)
+    (hship : evolve p (c.toGrid (0, 0)) = shift v (c.toGrid (0, 0)))
+    (hdiv : p ∣ 2 ^ c.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    jumpCapturedF c = true := by
+  obtain ⟨hspd1a, hspd1b⟩ := hspd1
+  obtain ⟨hspd2a, hspd2b⟩ := hspd2
+  obtain ⟨q, hq⟩ := hdiv
+  have hcw : cellWf c := cellWf_of_wf c hwf
+  have hcan : Canonical (c.toGrid (0, 0)) := canonical_sortDedup _
+  have hmul : evolve (2 ^ c.level) (c.toGrid (0, 0))
+      = shift ((q : Int) * v.1, (q : Int) * v.2) (c.toGrid (0, 0)) := by
+    rw [hq, Nat.mul_comm]
+    exact evolve_spaceship_mulF _ hcan hship q
+  have hfinal : evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))
+      = shift ((3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.1,
+               (3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.2)
+          (c.toGrid (0, 0)) := by
+    rw [padCenter2_toGrid_shift c hlvl, ← evolve_shift, hmul, shift_shift]
+  rw [jumpCapturedF_iff]
+  intro p' hp'
+  rw [hfinal, mem_shift] at hp'
+  obtain ⟨hb1, hb2, hb3, hb4⟩ := cellWfF_toGrid_bounds hcw 0 0 hp'
+  dsimp only at hb1 hb2 hb3 hb4
+  have hpow : (2 ^ c.level : Int) = 2 * (2 ^ (c.level - 1) : Int) := by
+    have hsplit : c.level = (c.level - 1) + 1 := by omega
+    conv_lhs => rw [hsplit]
+    rw [pow_succ]
+    ring
+  have hnext : ((2 ^ (c.level + 1) : Nat) : Int)
+      = (2 ^ c.level : Int) + (2 ^ c.level : Int) := by
+    rw [Nat.cast_pow, pow_succ]
+    ring
+  have hy : (0 : Int) ≤ 2 ^ (c.level - 1) := by positivity
+  have hqnn : (0 : Int) ≤ (q : Nat) := by positivity
+  have hcast : ((q : Nat) : Int) * ((p : Nat) : Int) = ((2 ^ c.level : Nat) : Int) := by
+    rw [Nat.cast_mul, hq]
+  have hbridge : ((2 ^ c.level : Nat) : Int) = (2 ^ c.level : Int) :=
+    (Nat.cast_pow 2 c.level).symm
+  have hqA : 2 * ((q : Int) * v.1) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (2 * v.1) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left hspd1b hqnn
+    have e1 : (q : Int) * (2 * v.1) = 2 * ((q : Int) * v.1) := by ring
+    omega
+  have hqB : 2 * (-((q : Int) * v.1)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (-(2 * v.1)) ≤ (q : Int) * ((p : Nat) : Int) := by
+      have hneg : -(2 * v.1) = 2 * (-v.1) := by ring
+      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.1)) hspd1a hqnn
+      omega
+    have e1 : (q : Int) * (-(2 * v.1)) = 2 * (-((q : Int) * v.1)) := by ring
+    omega
+  have hqC : 2 * ((q : Int) * v.2) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (2 * v.2) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left hspd2b hqnn
+    have e1 : (q : Int) * (2 * v.2) = 2 * ((q : Int) * v.2) := by ring
+    omega
+  have hqD : 2 * (-((q : Int) * v.2)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
+    have e0 : (q : Int) * (-(2 * v.2)) ≤ (q : Int) * ((p : Nat) : Int) := by
+      have hneg : -(2 * v.2) = 2 * (-v.2) := by ring
+      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.2)) hspd2a hqnn
+      omega
+    have e1 : (q : Int) * (-(2 * v.2)) = 2 * (-((q : Int) * v.2)) := by ring
+    omega
+  omega
+
+/-- **Transport of the spaceship relation to the reconstruction (rendered at
+    the origin).** The analogue of `periodic_fix_toGrid_zero` for drift: if
+    `g` is canonical and satisfies `evolve p g = shift v g`, the MacroCell
+    rebuilt at the origin satisfies the same relation — `toGrid_shift_grid`
+    shuttle, `evolve_shift` commutation, EQUALITY round-trip. -/
+theorem spaceship_step_toGrid_zero (g : Grid) (hg : Canonical g) {p : Nat}
+    (v : Int × Int) (hship : evolve p g = shift v g) :
+    evolve p ((gridToMacroCellWithOffset g).2.toGrid (0, 0))
+      = shift v ((gridToMacroCellWithOffset g).2.toGrid (0, 0)) := by
+  have hrt : (gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1
+      = g := toGrid_gridToMacroCellWithOffset_eq g hg
+  have hshift : (gridToMacroCellWithOffset g).2.toGrid (0, 0)
+      = shift (0 - (gridToMacroCellWithOffset g).1.1,
+               0 - (gridToMacroCellWithOffset g).1.2)
+          ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
+    toGrid_shift_grid _ 0 0 _ _
+  rw [hshift, ← evolve_shift, hrt, hship]
+
+/-- **Capture of the reconstruction of a spaceship.** For every canonical
+    phase `g` of a spaceship (`evolve p g = shift v g`), whose reconstruction
+    level divides the jump horizon (`p ∣ 2^level`) and whose speed satisfies
+    `2·|v.i| ≤ p`, the reconstruction satisfies the jump predicate —
+    `jumpCapturedF_of_spaceship` consumed at the reconstruction level, with
+    wf (`buildFromGrid_wf`), level (`1 ≤ lvl` as soon as `g ≠ []`, n-aware
+    bound) and the transported drift relation
+    (`spaceship_step_toGrid_zero`). Empty case: the reconstruction is a dead
+    level-0 leaf, decided by the kernel. -/
+theorem jumpCapturedF_reconstruction_of_spaceship (g : Grid) (hg : Canonical g)
+    {p : Nat} (v : Int × Int) (hship : evolve p g = shift v g)
+    (hdiv : p ∣ 2 ^ (gridToMacroCellWithOffset g).2.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    jumpCapturedF (gridToMacroCellWithOffset g).2 = true := by
+  by_cases hne : g = []
+  · subst hne
+    decide
+  · have hwf : ((gridToMacroCellWithOffset g).2).wf = true := by
+      unfold gridToMacroCellWithOffset
+      exact buildFromGrid_wf g _ _ _
+    have hlvl : 1 ≤ (gridToMacroCellWithOffset g).2.level := by
+      have hN := gridToMacroCellWithOffsetN_level_gt_n 2 g hne
+      rw [gridToMacroCellWithOffsetN_le_two_eq 2 g (by omega)] at hN
+      cases hL : (gridToMacroCellWithOffset g).2.level with
+      | zero => rw [hL] at hN; exact absurd hN (by decide)
+      | succ m => omega
+    exact jumpCapturedF_of_spaceship _ hwf hlvl v
+      (spaceship_step_toGrid_zero g hg hship) hdiv hspd1 hspd2
+
+/-- **hcap of the spaceship class, full trajectory.** For a canonical
+    spaceship of period `p > 0`, whose **every phase** has a reconstruction
+    level divisible by `p` and whose speed satisfies `2·|v.i| ≤ p`, every
+    instant `t` is captured: the trajectory reduces to the phase `t % p`
+    **drifted** by `(t/p)•v` (`evolve_spaceship_mod`), the translation
+    vanishes in the reconstruction (`gridToMacroCellWithOffset_shift`,
+    brick 1), and the phase — canonical, itself a spaceship
+    (`evolve_spaceship_phase`) — is captured. The divisibility and speed
+    premises are finite: they concern the `p` phases only. -/
+theorem hcap_of_spaceship (g : Grid) (hg : Canonical g) {p : Nat} (hp0 : 0 < p)
+    (v : Int × Int) (hship : evolve p g = shift v g)
+    (hdiv : ∀ i, i < p →
+      p ∣ 2 ^ (gridToMacroCellWithOffset (evolve i g)).2.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    ∀ t, jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
+  intro t
+  rw [evolve_spaceship_mod g hg hship t, gridToMacroCellWithOffset_shift]
+  have hr : t % p < p := Nat.mod_lt _ hp0
+  have hcan : Canonical (evolve (t % p) g) := by
+    rcases Nat.eq_zero_or_pos (t % p) with h0 | hpos
+    · rw [h0]
+      simpa using hg
+    · exact canonical_evolve_of_pos hpos _
+  exact jumpCapturedF_reconstruction_of_spaceship _ hcan v
+    (evolve_spaceship_phase g hship _) (hdiv _ hr) hspd1 hspd2
+
+/-- **L3 closed for the spaceship class of speed ≤ c/2: Hashlife correctness
+    of spaceships.** Assembly corollary — the third case of the P4.4
+    decomposition where the L3 link is **fully proven**, and the composition
+    that the scoping reserved to this lane: for every MacroCell whose grid
+    rendered at the origin is a spaceship `p > 0` of speed `2·|v.i| ≤ p`
+    (every phase of level divisible by `p`), the global equality
+    `hashlife_correctN` applies at every horizon `2^k` under `centralCorrect`.
+    The class covers glider (`p = 4`, `v = (1, -1)`) and LWSS (`p = 4`,
+    `v = (0, 2)`, the exact bound) as soon as the level reaches `log₂ p = 2`. -/
+theorem hashlife_correct_margin_of_spaceship (c : MacroCell) (k : Nat)
+    (h_central : centralCorrect c k) {p : Nat} (hp0 : 0 < p) (v : Int × Int)
+    (hship : evolve p (c.toGrid (0, 0)) = shift v (c.toGrid (0, 0)))
+    (hdiv : ∀ i, i < p →
+      p ∣ 2 ^ (gridToMacroCellWithOffset (evolve i (c.toGrid (0, 0)))).2.level)
+    (hspd1 : -(p : Int) ≤ 2 * v.1 ∧ 2 * v.1 ≤ (p : Int))
+    (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
+    evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) :=
+  hashlife_correct_margin_of_hcap c k h_central
+    (fun t _ => hcap_of_spaceship _ (canonical_sortDedup _) hp0 v hship hdiv hspd1 hspd2 t)
+
 /-! ## Sanity checks on the bestiary
 
 The fragment `supportInMargin` is **decidable** (instance `Decidable (BoxAssezGrandN)`,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -885,7 +885,7 @@ theorem gridRowMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     have := gridRowMin_le_of_mem _ _ himg
     omega
   · apply gridRowMin_lower_bound _ _ hsne
-    rintro r ⟨hr⟩
+    intro r hr
     have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
     have := gridRowMin_le_of_mem g _ hpre
     omega
@@ -897,10 +897,11 @@ theorem gridRowMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     gridRowMax (shift v g) = gridRowMax g + v.1 := by
   have hsne : shift v g ≠ [] := shift_ne_nil v g hg
   apply le_antisymm
-  · apply gridRowMax_upper_bound _ _ hsne
-    rintro r ⟨hr⟩
-    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
-    have := le_gridRowMax_of_mem g _ hpre
+  · have hb := gridRowMax_upper_bound (shift v g) (gridRowMax g + v.1 + 1) hsne
+      (fun p hp => by
+        have hpre : (p.1 - v.1, p.2 - v.2) ∈ g := (mem_shift v g p).mp hp
+        have := le_gridRowMax_of_mem g _ hpre
+        omega)
     omega
   · obtain ⟨p, hp, hval⟩ := gridRowMax_mem g hg
     have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
@@ -918,7 +919,7 @@ theorem gridColMin_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     have := gridColMin_le_of_mem _ _ himg
     omega
   · apply gridColMin_lower_bound _ _ hsne
-    rintro r ⟨hr⟩
+    intro r hr
     have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
     have := gridColMin_le_of_mem g _ hpre
     omega
@@ -929,10 +930,11 @@ theorem gridColMax_shift (v : Int × Int) (g : Grid) (hg : g ≠ []) :
     gridColMax (shift v g) = gridColMax g + v.2 := by
   have hsne : shift v g ≠ [] := shift_ne_nil v g hg
   apply le_antisymm
-  · apply gridColMax_upper_bound _ _ hsne
-    rintro r ⟨hr⟩
-    have hpre : (r.1 - v.1, r.2 - v.2) ∈ g := (mem_shift v g r).mp hr
-    have := le_gridColMax_of_mem g _ hpre
+  · have hb := gridColMax_upper_bound (shift v g) (gridColMax g + v.2 + 1) hsne
+      (fun p hp => by
+        have hpre : (p.1 - v.1, p.2 - v.2) ∈ g := (mem_shift v g p).mp hp
+        have := le_gridColMax_of_mem g _ hpre
+        omega)
     omega
   · obtain ⟨p, hp, hval⟩ := gridColMax_mem g hg
     have himg : (p.1 + v.1, p.2 + v.2) ∈ shift v g := mem_shift_image v g p hp
@@ -949,17 +951,17 @@ theorem elem_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) :
   · rw [List.elem_iff.mpr h]
     exact List.elem_iff.mpr (mem_shift_image v g _ h)
   · have hf : g.elem (r0, c0) = false := by
-      rcases hbool : g.elem (r0, c0) with
+      cases hbool : g.elem (r0, c0) with
       | true => exact absurd (List.elem_iff.mp hbool) h
       | false => rfl
     have hf' : (shift v g).elem (r0 + v.1, c0 + v.2) = false := by
-      rcases hbool : (shift v g).elem (r0 + v.1, c0 + v.2) with
+      cases hbool : (shift v g).elem (r0 + v.1, c0 + v.2) with
       | true =>
-        exact absurd (fun hh => h (by
-          have hpre := (mem_shift v g _).mp (List.elem_iff.mp hbool)
+        exact absurd (List.elem_iff.mp hbool) (fun hm => h (by
+          have hpre := (mem_shift v g _).mp hm
           have heq : (r0 + v.1 - v.1, c0 + v.2 - v.2) = (r0, c0) := by ext <;> omega
           rw [heq] at hpre
-          exact hpre)) (fun hn => hh hn)
+          exact hpre))
       | false => rfl
     rw [hf', hf]
 
@@ -1000,21 +1002,23 @@ theorem gridFrame_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat)
       cases h : shift v (p₀ :: ps) with
       | nil => exact absurd h hsne
       | cons q₀ qs => exact ⟨q₀, qs, rfl⟩
-    have h1 : gridRowMin (q₀ :: qs) = gridRowMin (p₀ :: ps) + v.1 :=
-      gridRowMin_shift v _ hne'
-    have h2 : gridRowMax (q₀ :: qs) = gridRowMax (p₀ :: ps) + v.1 :=
-      gridRowMax_shift v _ hne'
-    have h3 : gridColMin (q₀ :: qs) = gridColMin (p₀ :: ps) + v.2 :=
-      gridColMin_shift v _ hne'
-    have h4 : gridColMax (q₀ :: qs) = gridColMax (p₀ :: ps) + v.2 :=
-      gridColMax_shift v _ hne'
+    have h1 : gridRowMin (q₀ :: qs) = gridRowMin (p₀ :: ps) + v.1 := by
+      rw [← hq]; exact gridRowMin_shift v _ hne'
+    have h2 : gridRowMax (q₀ :: qs) = gridRowMax (p₀ :: ps) + v.1 := by
+      rw [← hq]; exact gridRowMax_shift v _ hne'
+    have h3 : gridColMin (q₀ :: qs) = gridColMin (p₀ :: ps) + v.2 := by
+      rw [← hq]; exact gridColMin_shift v _ hne'
+    have h4 : gridColMax (q₀ :: qs) = gridColMax (p₀ :: ps) + v.2 := by
+      rw [← hq]; exact gridColMax_shift v _ hne'
     have hfr : gridFrame (p₀ :: ps)
         = ((gridRowMin (p₀ :: ps) - 2, gridColMin (p₀ :: ps) - 2),
            MacroCell.ceilLog2 (max (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat
                                     (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat)) := rfl
     rw [hfr] at hframe
-    obtain ⟨hp, hlvl⟩ := Prod.mk.injEq.mp hframe
-    obtain ⟨hr0, hc0⟩ := Prod.mk.injEq.mp hp
+    rw [Prod.mk.injEq] at hframe
+    obtain ⟨hp, hlvl⟩ := hframe
+    rw [Prod.mk.injEq] at hp
+    obtain ⟨hr0, hc0⟩ := hp
     rw [hq]
     have hfr' : gridFrame (q₀ :: qs)
         = ((gridRowMin (q₀ :: qs) - 2, gridColMin (q₀ :: qs) - 2),
@@ -1026,8 +1030,8 @@ theorem gridFrame_shift (v : Int × Int) (g : Grid) (r0 c0 : Int) (lvl : Nat)
     have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
       gridColMin_le_gridColMax _ hne'
     refine Prod.ext (Prod.ext ?_ ?_) ?_
-    · omega
-    · omega
+    · dsimp only; omega
+    · dsimp only; omega
     · have hH : (gridRowMax (q₀ :: qs) - gridRowMin (q₀ :: qs) + 5).toNat
           = (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat := by omega
       have hW : (gridColMax (q₀ :: qs) - gridColMin (q₀ :: qs) + 5).toNat
@@ -1043,7 +1047,8 @@ theorem gridToMacroCellWithOffset_shift (v : Int × Int) (g : Grid) :
     (gridToMacroCellWithOffset (shift v g)).2 = (gridToMacroCellWithOffset g).2 := by
   by_cases hg : g = []
   · subst hg
-    simp [shift]
+    have hnil : shift v [] = [] := rfl
+    rw [hnil]
   · obtain ⟨r0, c0, lvl, hframe⟩ : ∃ r0 c0 lvl, gridFrame g = ((r0, c0), lvl) :=
       ⟨(gridFrame g).1.1, (gridFrame g).1.2, (gridFrame g).2, rfl⟩
     have hframe' := gridFrame_shift v g r0 c0 lvl hframe hg
@@ -1090,8 +1095,7 @@ theorem evolve_spaceship_mulF {p : Nat} (g : Grid) (hg : Canonical g) (v : Int �
     evolve (m * p) g = shift (((m : Int) * v.1), ((m : Int) * v.2)) g := by
   induction m with
   | zero =>
-    rw [Nat.zero_mul, evolve_zero, Nat.cast_zero, Int.zero_mul,
-        Nat.cast_zero, Int.zero_mul]
+    rw [Nat.zero_mul, evolve_zero, Nat.cast_zero, Int.zero_mul, Int.zero_mul]
     exact (shift_zero hg).symm
   | succ m ih =>
     have hsplit : (m + 1) * p = m * p + p := by ring
@@ -1112,8 +1116,12 @@ theorem evolve_spaceship_mod {p : Nat} (g : Grid) (hg : Canonical g) (v : Int ×
     evolve t g = shift (((t / p : Nat) : Int) * v.1, ((t / p : Nat) : Int) * v.2)
       (evolve (t % p) g) := by
   have hsplit : t = p * (t / p) + t % p := (Nat.div_add_mod t p).symm
+  have hg' : Canonical (evolve (t % p) g) := by
+    rcases Nat.eq_zero_or_pos (t % p) with h0 | hpos
+    · rw [h0, evolve_zero]; exact hg
+    · exact canonical_evolve_of_pos hpos _
   conv_lhs => rw [hsplit, evolve_add, Nat.mul_comm]
-  exact evolve_spaceship_mulF _ (evolve_spaceship_phase g hship _) _
+  exact evolve_spaceship_mulF _ hg' v (evolve_spaceship_phase g v hship _) _
 
 /-- **Interface (c) tranche 3, step 7 — the spaceship class of speed ≤ c/2 is
     captured.** `jumpCapturedF` version of the spaceship criterion: any
@@ -1142,7 +1150,7 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
   have hmul : evolve (2 ^ c.level) (c.toGrid (0, 0))
       = shift ((q : Int) * v.1, (q : Int) * v.2) (c.toGrid (0, 0)) := by
     rw [hq, Nat.mul_comm]
-    exact evolve_spaceship_mulF _ hcan hship q
+    exact evolve_spaceship_mulF _ hcan v hship q
   have hfinal : evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))
       = shift ((3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.1,
                (3 * 2 ^ (c.level - 1) : Int) + (q : Int) * v.2)
@@ -1165,7 +1173,7 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
   have hy : (0 : Int) ≤ 2 ^ (c.level - 1) := by positivity
   have hqnn : (0 : Int) ≤ (q : Nat) := by positivity
   have hcast : ((q : Nat) : Int) * ((p : Nat) : Int) = ((2 ^ c.level : Nat) : Int) := by
-    rw [Nat.cast_mul, hq]
+    rw [← Nat.cast_mul, Nat.mul_comm q p, hq]
   have hbridge : ((2 ^ c.level : Nat) : Int) = (2 ^ c.level : Int) :=
     (Nat.cast_pow 2 c.level).symm
   have hqA : 2 * ((q : Int) * v.1) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
@@ -1174,10 +1182,8 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
     have e1 : (q : Int) * (2 * v.1) = 2 * ((q : Int) * v.1) := by ring
     omega
   have hqB : 2 * (-((q : Int) * v.1)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
-    have e0 : (q : Int) * (-(2 * v.1)) ≤ (q : Int) * ((p : Nat) : Int) := by
-      have hneg : -(2 * v.1) = 2 * (-v.1) := by ring
-      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.1)) hspd1a hqnn
-      omega
+    have e0 : (q : Int) * (-(2 * v.1)) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left (by omega) hqnn
     have e1 : (q : Int) * (-(2 * v.1)) = 2 * (-((q : Int) * v.1)) := by ring
     omega
   have hqC : 2 * ((q : Int) * v.2) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
@@ -1186,13 +1192,27 @@ theorem jumpCapturedF_of_spaceship (c : MacroCell) (hwf : c.wf = true)
     have e1 : (q : Int) * (2 * v.2) = 2 * ((q : Int) * v.2) := by ring
     omega
   have hqD : 2 * (-((q : Int) * v.2)) ≤ 2 * (2 ^ (c.level - 1) : Int) := by
-    have e0 : (q : Int) * (-(2 * v.2)) ≤ (q : Int) * ((p : Nat) : Int) := by
-      have hneg : -(2 * v.2) = 2 * (-v.2) := by ring
-      have e0' := mul_le_mul_of_nonneg_left (b := (2 : Int) * (-v.2)) hspd2a hqnn
-      omega
+    have e0 : (q : Int) * (-(2 * v.2)) ≤ (q : Int) * ((p : Nat) : Int) :=
+      mul_le_mul_of_nonneg_left (by omega) hqnn
     have e1 : (q : Int) * (-(2 * v.2)) = 2 * (-((q : Int) * v.2)) := by ring
     omega
   omega
+
+/-- **Commutativity of translations.** Translating by `v` then by `w` equals
+    translating by `w` then by `v`: both compositions land on the sum vector.
+    Via `shift_shift` on each side (pairs made explicit), then componentwise
+    equality of the vectors. -/
+theorem shift_comm (v w : Int × Int) (g : Grid) :
+    shift v (shift w g) = shift w (shift v g) := by
+  obtain ⟨v1, v2⟩ := v
+  obtain ⟨w1, w2⟩ := w
+  have h1 : shift (v1, v2) (shift (w1, w2) g) = shift (v1 + w1, v2 + w2) g :=
+    shift_shift _ _ _ _ _
+  have h2 : shift (w1, w2) (shift (v1, v2) g) = shift (w1 + v1, w2 + v2) g :=
+    shift_shift _ _ _ _ _
+  rw [h1, h2]
+  congr 1
+  ext <;> ring
 
 /-- **Transport of the spaceship relation to the reconstruction (rendered at
     the origin).** The analogue of `periodic_fix_toGrid_zero` for drift: if
@@ -1210,7 +1230,7 @@ theorem spaceship_step_toGrid_zero (g : Grid) (hg : Canonical g) {p : Nat}
                0 - (gridToMacroCellWithOffset g).1.2)
           ((gridToMacroCellWithOffset g).2.toGrid (gridToMacroCellWithOffset g).1) :=
     toGrid_shift_grid _ 0 0 _ _
-  rw [hshift, ← evolve_shift, hrt, hship]
+  rw [hshift, ← evolve_shift, hrt, hship, shift_comm]
 
 /-- **Capture of the reconstruction of a spaceship.** For every canonical
     phase `g` of a spaceship (`evolve p g = shift v g`), whose reconstruction
@@ -1240,7 +1260,7 @@ theorem jumpCapturedF_reconstruction_of_spaceship (g : Grid) (hg : Canonical g)
       | zero => rw [hL] at hN; exact absurd hN (by decide)
       | succ m => omega
     exact jumpCapturedF_of_spaceship _ hwf hlvl v
-      (spaceship_step_toGrid_zero g hg hship) hdiv hspd1 hspd2
+      (spaceship_step_toGrid_zero g hg v hship) hdiv hspd1 hspd2
 
 /-- **hcap of the spaceship class, full trajectory.** For a canonical
     spaceship of period `p > 0`, whose **every phase** has a reconstruction
@@ -1259,7 +1279,7 @@ theorem hcap_of_spaceship (g : Grid) (hg : Canonical g) {p : Nat} (hp0 : 0 < p)
     (hspd2 : -(p : Int) ≤ 2 * v.2 ∧ 2 * v.2 ≤ (p : Int)) :
     ∀ t, jumpCapturedF (gridToMacroCellWithOffset (evolve t g)).2 = true := by
   intro t
-  rw [evolve_spaceship_mod g hg hship t, gridToMacroCellWithOffset_shift]
+  rw [evolve_spaceship_mod g hg v hship t, gridToMacroCellWithOffset_shift]
   have hr : t % p < p := Nat.mod_lt _ hp0
   have hcan : Canonical (evolve (t % p) g) := by
     rcases Nat.eq_zero_or_pos (t % p) with h0 | hpos
@@ -1267,7 +1287,7 @@ theorem hcap_of_spaceship (g : Grid) (hg : Canonical g) {p : Nat} (hp0 : 0 < p)
       simpa using hg
     · exact canonical_evolve_of_pos hpos _
   exact jumpCapturedF_reconstruction_of_spaceship _ hcan v
-    (evolve_spaceship_phase g hship _) (hdiv _ hr) hspd1 hspd2
+    (evolve_spaceship_phase g v hship _) (hdiv _ hr) hspd1 hspd2
 
 /-- **L3 closed for the spaceship class of speed ≤ c/2: Hashlife correctness
     of spaceships.** Assembly corollary — the third case of the P4.4


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #14984

## Summary

Tranche 3c **étape 7** de #13483 — **fermeture L3 pour la classe des vaisseaux** (`evolve p g = shift v g`) : `hashlife_correct_margin_of_spaceship`. Deux blocs, FR canonique + sibling `_en` (gate #4980). 1009 lignes ajoutées (503 FR + 506 EN), **0 suppression**.

**Brique 1 — invariance par translation de la reconstruction** (le scoping identifiait cette brique comme manquante) : translater la grille décale l'offset du cadre mais laisse la MacroCell (quadtree) inchangée. Chaîne : `mem_shift_image`/`shift_ne_nil` → témoins d'atteinte (`foldl_proj_max_attained` jumeau du lemme min L572, `gridRowMax_mem`/`gridColMin_mem`/`gridColMax_mem`) → bornes translatées (`gridRowMin_shift` etc., 4 directions) → `elem_shift` → `buildFromGrid_shift` (induction niveau) → `gridFrame_shift` → **`gridToMacroCellWithOffset_shift`**.

**Classe L3 spaceship** : `evolve_spaceship_phase` → `evolve_spaceship_mulF`/`evolve_spaceship_mod` (réduction au résidu `t % p` dérivé de `(t/p)•v`) → `jumpCapturedF_of_spaceship` (interface (c), vitesse `2·|v.i| ≤ p`) → `spaceship_step_toGrid_zero` + `jumpCapturedF_reconstruction_of_spaceship` → `hcap_of_spaceship` → **`hashlife_correct_margin_of_spaceship`** (assemblage via `hashlife_correct_margin_of_hcap`). La translation disparaît dans la reconstruction (brique 1) : la trajectoire infinie se réduit aux `p` phases. Couvre glider (`p=4, v=(1,-1)`) et LWSS (`p=4, v=(0,2)`, borne exacte).

## Validation

| Organe | Résultat |
|---|---|
| **Build `lake` FR** (`Conway.Life.HashlifeMarginFragment`) | **Build completed successfully (8669 jobs), exit 0** — commit `cb521b0c2f`, lake WSL natif toolchain v4.32.1, dépendance `HashlifeCorrectness` compilée localement (swap 32G) |
| **Build `lake` EN** (`Conway.Life.HashlifeMarginFragment_en`) | **Build completed successfully (8669 jobs), exit 0** — même commit |
| `count_code_sorry.py` (`distinct_code_sorry`) | **1 → 1** (baseline inchangée : seul le sorry cadre documenté INTRINSIC `hashlife_correct_margin` ligne 159 ; les lignes ajoutées sont sorry-free) |
| `check_i18n_siblings.py` | **18/18 byte-identical, 0 drift, 0 orphan** (sibling `_en` conforme) |
| Anti-régression | 0 délétion de preuve (le commit fix `cb521b0c2f` corrige 24 erreurs d'élaboration du WIP sans retirer d'énoncé ni de preuve acquise) |

**Note d'honnêteté sur l'historique** : la première tête de cette PR (`78c1f39df6`) portait un WIP qui n'avait jamais compilé — la CI a révélé ~24 erreurs d'élaboration (arguments `v` manquants dans 5 appels, syntaxe `rcases` verticale non supportée, API morte `Prod.mk.injEq.mp`, bornes strictes vs larges, etc.). Le commit `cb521b0c2f` les corrige une à une ; tout énoncé du WIP est préservé (130 ins/90 del, uniquement des tactiques).

La dépendance `Conway.Life.HashlifeCorrectness` (préexistante, non modifiée par ce diff) consomme ~26 Go à la compilation : compilée localement une fois (WSL, .wslconfig swap 32GB + cgroup MemoryMax=20G/MemorySwapMax=infinity), les oleans sont réutilisés par la CI via son cache dédié.

See #13483 (tranche 3c step 7 — contribution à l'epic).
