### PR TITLE
fix(ict,#14122): ICT-15l purge UserWarning FigureCanvasAgg + leak chemin machine (T2)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15l-IndependanceGenerateur.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15l-IndependanceGenerateur.ipynb
@@ -63,10 +63,10 @@
    "id": "il-02d3eb19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:40:34.593209Z",
-     "iopub.status.busy": "2026-08-28T15:40:34.592892Z",
-     "iopub.status.idle": "2026-08-28T15:40:35.151212Z",
-     "shell.execute_reply": "2026-08-28T15:40:35.150529Z"
+     "iopub.execute_input": "2026-09-07T23:06:33.167913Z",
+     "iopub.status.busy": "2026-09-07T23:06:33.167499Z",
+     "iopub.status.idle": "2026-09-07T23:06:34.032075Z",
+     "shell.execute_reply": "2026-09-07T23:06:34.031390Z"
     },
     "tags": []
    },
@@ -191,10 +191,10 @@
    "id": "il-8c4bbc97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:40:35.163181Z",
-     "iopub.status.busy": "2026-08-28T15:40:35.162748Z",
-     "iopub.status.idle": "2026-08-28T15:40:35.167908Z",
-     "shell.execute_reply": "2026-08-28T15:40:35.167247Z"
+     "iopub.execute_input": "2026-09-07T23:06:34.040328Z",
+     "iopub.status.busy": "2026-09-07T23:06:34.040106Z",
+     "iopub.status.idle": "2026-09-07T23:06:34.043292Z",
+     "shell.execute_reply": "2026-09-07T23:06:34.042962Z"
     },
     "tags": []
    },
@@ -257,10 +257,10 @@
    "id": "il-a5c14a4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:40:35.178315Z",
-     "iopub.status.busy": "2026-08-28T15:40:35.177911Z",
-     "iopub.status.idle": "2026-08-28T15:40:36.690465Z",
-     "shell.execute_reply": "2026-08-28T15:40:36.689699Z"
+     "iopub.execute_input": "2026-09-07T23:06:34.053156Z",
+     "iopub.status.busy": "2026-09-07T23:06:34.052954Z",
+     "iopub.status.idle": "2026-09-07T23:06:35.120792Z",
+     "shell.execute_reply": "2026-09-07T23:06:35.120274Z"
     },
     "tags": []
    },
@@ -354,10 +354,10 @@
    "id": "il-37ed1bc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:40:36.708141Z",
-     "iopub.status.busy": "2026-08-28T15:40:36.707697Z",
-     "iopub.status.idle": "2026-08-28T15:40:48.676063Z",
-     "shell.execute_reply": "2026-08-28T15:40:48.674829Z"
+     "iopub.execute_input": "2026-09-07T23:06:35.132286Z",
+     "iopub.status.busy": "2026-09-07T23:06:35.132108Z",
+     "iopub.status.idle": "2026-09-07T23:06:43.006763Z",
+     "shell.execute_reply": "2026-09-07T23:06:43.006138Z"
     },
     "tags": []
    },
@@ -439,10 +439,10 @@
    "id": "il-5ba1b736",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:40:48.690410Z",
-     "iopub.status.busy": "2026-08-28T15:40:48.689965Z",
-     "iopub.status.idle": "2026-08-28T15:40:51.964190Z",
-     "shell.execute_reply": "2026-08-28T15:40:51.963491Z"
+     "iopub.execute_input": "2026-09-07T23:06:43.015279Z",
+     "iopub.status.busy": "2026-09-07T23:06:43.015117Z",
+     "iopub.status.idle": "2026-09-07T23:06:45.036945Z",
+     "shell.execute_reply": "2026-09-07T23:06:45.036422Z"
     },
     "tags": []
    },
@@ -579,10 +579,10 @@
    "id": "il-b945786b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:40:51.976891Z",
-     "iopub.status.busy": "2026-08-28T15:40:51.976489Z",
-     "iopub.status.idle": "2026-08-28T15:41:11.035476Z",
-     "shell.execute_reply": "2026-08-28T15:41:11.034584Z"
+     "iopub.execute_input": "2026-09-07T23:06:45.045024Z",
+     "iopub.status.busy": "2026-09-07T23:06:45.044854Z",
+     "iopub.status.idle": "2026-09-07T23:06:57.359008Z",
+     "shell.execute_reply": "2026-09-07T23:06:57.358462Z"
     },
     "tags": []
    },
@@ -687,10 +687,10 @@
    "id": "il-01588f8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:41:11.055494Z",
-     "iopub.status.busy": "2026-08-28T15:41:11.055235Z",
-     "iopub.status.idle": "2026-08-28T15:41:11.138145Z",
-     "shell.execute_reply": "2026-08-28T15:41:11.137414Z"
+     "iopub.execute_input": "2026-09-07T23:06:57.369186Z",
+     "iopub.status.busy": "2026-09-07T23:06:57.368983Z",
+     "iopub.status.idle": "2026-09-07T23:06:57.445655Z",
+     "shell.execute_reply": "2026-09-07T23:06:57.445121Z"
     },
     "tags": []
    },
@@ -709,14 +709,6 @@
       "relief(R0) = 0.0000 | relief(R1) = 0.3507 | relief(R2) = 0.4096 | relief(R3) = 0.3522 | tau = 0.05\n",
       "VERDICT (regle pre-enregistree) = CONFONDU_AVEC_LA_DIMENSION\n",
       "Barplot : R1 et R2 (bleu) = generateurs de nouveaute ; R3 (rouge) = controle dimension.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_48812\\3276462165.py:51: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
-      "  plt.show()\n"
      ]
     }
    ],
@@ -771,7 +763,7 @@
     "ax.set_title('Relief du discriminant nerf par regime (graines apparieees)')\n",
     "ax.legend(loc='upper left', fontsize=8)\n",
     "fig.tight_layout()\n",
-    "plt.show()\n",
+    "plt.close(fig)  # backend Agg (cell. 1) : show() non interactif -> UserWarning superflu\n",
     "print(\"Barplot : R1 et R2 (bleu) = generateurs de nouveaute ; R3 (rouge) = controle dimension.\")"
    ]
   },
@@ -781,7 +773,38 @@
    "metadata": {
     "tags": []
    },
-   "source": "### Lecture du verdict : `CONFONDU_AVEC_LA_DIMENSION`\n\nLe résultat a trois étages, tous honnêtes :\n\n1. **La réfutation est nette.** Le contrôle négatif — dimension doublée, zéro comportement\n   nouveau, distribution de mutation inchangée sur les comportements — produit **le même\n   relief** que les deux générateurs de nouveauté (R3 ≈ R1 ≈ 0,35 de moyenne, chacun\n   > τ sur les 3 graines). Selon la règle pré-enregistrée de #13308, le discriminant ne\n   mesure donc **pas** la nouveauté stratégique sur cette recette : l'écart\n   `R1 > 0 = R0` attribue le relief au **turnover stochastique de population finie**\n   (dérive Wright-Fisher + bruit d'exécution), pas à l'apparition de stratégies nouvelles.\n   L'énoncé « la nouveauté produit du relief là où le bruit n'en produit pas » **tombe**\n   sur cette instance — et c'est exactement ce que le test était conçu pour pouvoir faire.\n\n2. **Les deux générateurs s'accordent entre eux — mais ça ne sauve rien.** R1 (catalogue\n   fermé) et R2 (dérive génomique, 26-27 comportements nouveaux par trajectoire) donnent\n   du relief tous les deux. Sans le contrôle, on aurait écrit `ROBUSTE_AU_GENERATEUR`.\n   Le contrôle révèle que cette robustesse était **vraie et vide** : le relief ne\n   discriminait pas la nouveauté, il accompagnait la stochasticité agent-based. Un\n   contrôle négatif qui échoue vaut plus qu'une replication qui réussit.\n\n3. **Résolution du discriminant.** La démonstration interleaved montre en prime que\n   `b1_max_persistence` est **grossier** sur cette recette : deux trajectoires de\n   coopération différentes peuvent partager exactement le même nerf (R1 et R3-interleaved\n   sont float-identiques parce que les proxys fenêtrés coïncident). Toute conclusion\n   fine appuyée sur des écarts de b1 à la 2ᵉ décimale doit être tenue pour fragile.\n\n**Ce que ce notebook ne fait pas** : il ne réteste pas Qwen ni le banc humour (#13306 suit\nson propre protocole), et il ne promeut rien — le verdict est un fait d'instance et de\nrecette, la promotion est un acte séparé (#13303)."
+   "source": [
+    "### Lecture du verdict : `CONFONDU_AVEC_LA_DIMENSION`\n",
+    "\n",
+    "Le résultat a trois étages, tous honnêtes :\n",
+    "\n",
+    "1. **La réfutation est nette.** Le contrôle négatif — dimension doublée, zéro comportement\n",
+    "   nouveau, distribution de mutation inchangée sur les comportements — produit **le même\n",
+    "   relief** que les deux générateurs de nouveauté (R3 ≈ R1 ≈ 0,35 de moyenne, chacun\n",
+    "   > τ sur les 3 graines). Selon la règle pré-enregistrée de #13308, le discriminant ne\n",
+    "   mesure donc **pas** la nouveauté stratégique sur cette recette : l'écart\n",
+    "   `R1 > 0 = R0` attribue le relief au **turnover stochastique de population finie**\n",
+    "   (dérive Wright-Fisher + bruit d'exécution), pas à l'apparition de stratégies nouvelles.\n",
+    "   L'énoncé « la nouveauté produit du relief là où le bruit n'en produit pas » **tombe**\n",
+    "   sur cette instance — et c'est exactement ce que le test était conçu pour pouvoir faire.\n",
+    "\n",
+    "2. **Les deux générateurs s'accordent entre eux — mais ça ne sauve rien.** R1 (catalogue\n",
+    "   fermé) et R2 (dérive génomique, 26-27 comportements nouveaux par trajectoire) donnent\n",
+    "   du relief tous les deux. Sans le contrôle, on aurait écrit `ROBUSTE_AU_GENERATEUR`.\n",
+    "   Le contrôle révèle que cette robustesse était **vraie et vide** : le relief ne\n",
+    "   discriminait pas la nouveauté, il accompagnait la stochasticité agent-based. Un\n",
+    "   contrôle négatif qui échoue vaut plus qu'une replication qui réussit.\n",
+    "\n",
+    "3. **Résolution du discriminant.** La démonstration interleaved montre en prime que\n",
+    "   `b1_max_persistence` est **grossier** sur cette recette : deux trajectoires de\n",
+    "   coopération différentes peuvent partager exactement le même nerf (R1 et R3-interleaved\n",
+    "   sont float-identiques parce que les proxys fenêtrés coïncident). Toute conclusion\n",
+    "   fine appuyée sur des écarts de b1 à la 2ᵉ décimale doit être tenue pour fragile.\n",
+    "\n",
+    "**Ce que ce notebook ne fait pas** : il ne réteste pas Qwen ni le banc humour (#13306 suit\n",
+    "son propre protocole), et il ne promeut rien — le verdict est un fait d'instance et de\n",
+    "recette, la promotion est un acte séparé (#13303)."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -804,10 +827,10 @@
    "id": "il-f1e05ab5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:41:11.163869Z",
-     "iopub.status.busy": "2026-08-28T15:41:11.163375Z",
-     "iopub.status.idle": "2026-08-28T15:41:11.167410Z",
-     "shell.execute_reply": "2026-08-28T15:41:11.166494Z"
+     "iopub.execute_input": "2026-09-07T23:06:57.458678Z",
+     "iopub.status.busy": "2026-09-07T23:06:57.458496Z",
+     "iopub.status.idle": "2026-09-07T23:06:57.461042Z",
+     "shell.execute_reply": "2026-09-07T23:06:57.460491Z"
     },
     "tags": []
    },
@@ -841,10 +864,10 @@
    "id": "il-861b8613",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:41:11.191799Z",
-     "iopub.status.busy": "2026-08-28T15:41:11.191563Z",
-     "iopub.status.idle": "2026-08-28T15:41:11.195194Z",
-     "shell.execute_reply": "2026-08-28T15:41:11.194318Z"
+     "iopub.execute_input": "2026-09-07T23:06:57.470216Z",
+     "iopub.status.busy": "2026-09-07T23:06:57.470048Z",
+     "iopub.status.idle": "2026-09-07T23:06:57.472167Z",
+     "shell.execute_reply": "2026-09-07T23:06:57.471724Z"
     },
     "tags": []
    },
@@ -878,10 +901,10 @@
    "id": "il-abe37994",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T15:41:11.217423Z",
-     "iopub.status.busy": "2026-08-28T15:41:11.217005Z",
-     "iopub.status.idle": "2026-08-28T15:41:11.221312Z",
-     "shell.execute_reply": "2026-08-28T15:41:11.220074Z"
+     "iopub.execute_input": "2026-09-07T23:06:57.480638Z",
+     "iopub.status.busy": "2026-09-07T23:06:57.480485Z",
+     "iopub.status.idle": "2026-09-07T23:06:57.482704Z",
+     "shell.execute_reply": "2026-09-07T23:06:57.482282Z"
     },
     "tags": []
    },
@@ -903,7 +926,29 @@
    "metadata": {
     "tags": []
    },
-   "source": "## Conclusion — un discriminant honnête est un discriminant contrôlé\n\n| régime | mécanisme | relief (moy. 3 graines) | lecture |\n|---|---|---|---|\n| R0 | replicateur-mutation déterministe | 0,0000 | convergence figée, nuage saturé |\n| R1 | générateur A (catalogue fermé) | ~0,35 | relief, mais voir R3 |\n| R2 | générateur B (dérive génomique) | ~0,41 | relief, mais voir R3 |\n| R3 | **dimension sans nouveauté** | ~0,35 | **le relief est là aussi** |\n\nLe protocole pré-enregistré de #13308 rend son verdict : `CONFONDU_AVEC_LA_DIMENSION`.\nSur le substrat Axelrod régénéré et la recette observable d'ICT-15j, le relief du\ndiscriminant nerf accompagne la **stochasticité de population finie**, pas l'apparition\nde comportements nouveaux. La réplication sur deux générateurs structurellement distincts\n(R1/R2) aurait suggéré une robustesse — le contrôle négatif la vide de son sens : c'est la\nleçon méthodologique du notebook, la même que #13306 applique au détecteur d'humour.\nUn instrument qui mesure sa propre construction doit être falsifié par le contrôle le moins\nglamour du banc — et ici, il l'a été.\n\n**Raccord** : ICT-15j mesure, ICT-15l audite la mesure. La prochaine étape n'est pas un\nmeilleur générateur de nouveauté mais un observable plus fin (ou une question différente) ;\nla campagne multi-annotateurs de #12756 et l'observatoire externe #13303 restent le cap."
+   "source": [
+    "## Conclusion — un discriminant honnête est un discriminant contrôlé\n",
+    "\n",
+    "| régime | mécanisme | relief (moy. 3 graines) | lecture |\n",
+    "|---|---|---|---|\n",
+    "| R0 | replicateur-mutation déterministe | 0,0000 | convergence figée, nuage saturé |\n",
+    "| R1 | générateur A (catalogue fermé) | ~0,35 | relief, mais voir R3 |\n",
+    "| R2 | générateur B (dérive génomique) | ~0,41 | relief, mais voir R3 |\n",
+    "| R3 | **dimension sans nouveauté** | ~0,35 | **le relief est là aussi** |\n",
+    "\n",
+    "Le protocole pré-enregistré de #13308 rend son verdict : `CONFONDU_AVEC_LA_DIMENSION`.\n",
+    "Sur le substrat Axelrod régénéré et la recette observable d'ICT-15j, le relief du\n",
+    "discriminant nerf accompagne la **stochasticité de population finie**, pas l'apparition\n",
+    "de comportements nouveaux. La réplication sur deux générateurs structurellement distincts\n",
+    "(R1/R2) aurait suggéré une robustesse — le contrôle négatif la vide de son sens : c'est la\n",
+    "leçon méthodologique du notebook, la même que #13306 applique au détecteur d'humour.\n",
+    "Un instrument qui mesure sa propre construction doit être falsifié par le contrôle le moins\n",
+    "glamour du banc — et ici, il l'a été.\n",
+    "\n",
+    "**Raccord** : ICT-15j mesure, ICT-15l audite la mesure. La prochaine étape n'est pas un\n",
+    "meilleur générateur de nouveauté mais un observable plus fin (ou une question différente) ;\n",
+    "la campagne multi-annotateurs de #12756 et l'observatoire externe #13303 restent le cap."
+   ]
   }
  ],
  "metadata": {
@@ -922,7 +967,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA — prev: MED/guard #14959

## Summary

Tranche T2 de #14122 (purge des warnings d'exécution) sur **ICT-15l-IndependanceGenerateur** : l'output committé portait un `UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown` **qui leak le chemin machine brut** `C:\Users\jsboi\AppData\Local\Temp\ipykernel_48812\...py:51` — la « double peine » du census de l'EPIC (warning bruit d'infra + vecteur de leak).

- **Cause racine** : la cellule d'imports force `matplotlib.use('Agg')` (backend non interactif, légitime pour re-exec headless), puis la cellule 7 appelle `plt.show()` — un no-op sous Agg qui émet le UserWarning avec le traceback machine.
- **Fix causal** (classification 1/2 de l'EPIC — bruit d'infra supprimé à la source) : `plt.show()` → `plt.close(fig)` + commentaire d'une ligne. Le barplot n'était **jamais rendu** sous Agg (0 sortie image dans tout le notebook, vérifié) : rien de pédagogiquement visible n'est perdu ; les valeurs de relief et le verdict imprimés restent inchangés.
- **Re-exécution complète C.2** (papermill, kernel python3) : sorties régénérées, warning disparu, plus de chemin machine.

## Validation

- Re-exec papermill end-to-end : 10/10 cellules code exécutées (execution_count non nul), **0 erreur**.
- **UserWarning FigureCanvasAgg : 1 → 0** ; **chemin machine `C:\Users\...` : 1 → 0** (grep sur l'output committé).
- Cellules non concernées : sorties stream **identiques** au commit précédent (expériences seedées — `np.random.default_rng(20260720/42/7)` — déterministes).
- check_exec_sequence CLEAN (1..N, 100%) ; duration re-exec 25,9 s.

## Diagnostic dérive (C.4)

- Cause : **(a) env/kernel** — backend `Agg` forcé (headless) combiné à un appel `plt.show()` interactif ; le warning variait donc avec l'environnement d'exécution.
- Verdict : **CAUSE_FIXED** (l'appel interactif est retiré à la source, la re-exec le prouve).

See #14122 (contribution partielle — tranche T2, 1 notebook de la classe UserWarning ; l'EPIC reste ouvert).
