### PR TITLE
fix(sudoku,#14122): Sudoku-06-Csharp active #nullable — purge 21 CS8632 (T4, 1re classe CS8632)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-06-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-06-AIMA-CSP-Csharp.ipynb
@@ -5,10 +5,10 @@
    "id": "0bdd0851",
    "metadata": {
     "papermill": {
-     "duration": 0.004768,
-     "end_time": "2026-08-30T04:25:05.358184+00:00",
+     "duration": 0.006746,
+     "end_time": "2026-09-08T00:14:46.495727+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:05.353416+00:00",
+     "start_time": "2026-09-08T00:14:46.488981+00:00",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "15134a98",
    "metadata": {
     "papermill": {
-     "duration": 0.004771,
-     "end_time": "2026-08-30T04:25:05.367800+00:00",
+     "duration": 0.005315,
+     "end_time": "2026-09-08T00:14:46.506710+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:05.363029+00:00",
+     "start_time": "2026-09-08T00:14:46.501395+00:00",
      "status": "completed"
     },
     "tags": []
@@ -84,16 +84,16 @@
    "id": "edb9f15b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:05.387521Z",
-     "iopub.status.busy": "2026-08-30T04:25:05.380859Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.062784Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.059893Z"
+     "iopub.execute_input": "2026-09-08T00:14:46.524531Z",
+     "iopub.status.busy": "2026-09-08T00:14:46.517698Z",
+     "iopub.status.idle": "2026-09-08T00:14:48.672587Z",
+     "shell.execute_reply": "2026-09-08T00:14:48.668731Z"
     },
     "papermill": {
-     "duration": 2.690452,
-     "end_time": "2026-08-30T04:25:08.062923+00:00",
+     "duration": 2.161808,
+     "end_time": "2026-09-08T00:14:48.672720+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:05.372471+00:00",
+     "start_time": "2026-09-08T00:14:46.510912+00:00",
      "status": "completed"
     },
     "tags": []
@@ -104,7 +104,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-807868.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -154,7 +154,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '807868.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '36804.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -435,10 +435,10 @@
    "id": "89c6543d",
    "metadata": {
     "papermill": {
-     "duration": 0.004987,
-     "end_time": "2026-08-30T04:25:08.073275+00:00",
+     "duration": 0.002452,
+     "end_time": "2026-09-08T00:14:48.678612+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.068288+00:00",
+     "start_time": "2026-09-08T00:14:48.676160+00:00",
      "status": "completed"
     },
     "tags": []
@@ -463,16 +463,16 @@
    "id": "91cbecf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.085293Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.084997Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.180004Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.179802Z"
+     "iopub.execute_input": "2026-09-08T00:14:48.684940Z",
+     "iopub.status.busy": "2026-09-08T00:14:48.684789Z",
+     "iopub.status.idle": "2026-09-08T00:14:48.783752Z",
+     "shell.execute_reply": "2026-09-08T00:14:48.783611Z"
     },
     "papermill": {
-     "duration": 0.101767,
-     "end_time": "2026-08-30T04:25:08.180104+00:00",
+     "duration": 0.102882,
+     "end_time": "2026-09-08T00:14:48.783823+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.078337+00:00",
+     "start_time": "2026-09-08T00:14:48.680941+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,10 +572,10 @@
    "id": "0df3a2c8",
    "metadata": {
     "papermill": {
-     "duration": 0.005989,
-     "end_time": "2026-08-30T04:25:08.191438+00:00",
+     "duration": 0.002671,
+     "end_time": "2026-09-08T00:14:48.789658+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.185449+00:00",
+     "start_time": "2026-09-08T00:14:48.786987+00:00",
      "status": "completed"
     },
     "tags": []
@@ -595,16 +595,16 @@
    "id": "56e27839",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.205612Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.205331Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.291694Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.291436Z"
+     "iopub.execute_input": "2026-09-08T00:14:48.795910Z",
+     "iopub.status.busy": "2026-09-08T00:14:48.795732Z",
+     "iopub.status.idle": "2026-09-08T00:14:48.833751Z",
+     "shell.execute_reply": "2026-09-08T00:14:48.833633Z"
     },
     "papermill": {
-     "duration": 0.094357,
-     "end_time": "2026-08-30T04:25:08.291813+00:00",
+     "duration": 0.041513,
+     "end_time": "2026-09-08T00:14:48.833809+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.197456+00:00",
+     "start_time": "2026-09-08T00:14:48.792296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -694,10 +694,10 @@
    "id": "1ef86839",
    "metadata": {
     "papermill": {
-     "duration": 0.006487,
-     "end_time": "2026-08-30T04:25:08.304739+00:00",
+     "duration": 0.002695,
+     "end_time": "2026-09-08T00:14:48.839435+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.298252+00:00",
+     "start_time": "2026-09-08T00:14:48.836740+00:00",
      "status": "completed"
     },
     "tags": []
@@ -721,10 +721,10 @@
    "id": "cell-5ea23b90",
    "metadata": {
     "papermill": {
-     "duration": 0.007242,
-     "end_time": "2026-08-30T04:25:08.319286+00:00",
+     "duration": 0.002808,
+     "end_time": "2026-09-08T00:14:48.844965+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.312044+00:00",
+     "start_time": "2026-09-08T00:14:48.842157+00:00",
      "status": "completed"
     },
     "tags": []
@@ -746,16 +746,16 @@
    "id": "cell-8d50db65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.337519Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.337258Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.406805Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.406611Z"
+     "iopub.execute_input": "2026-09-08T00:14:48.851831Z",
+     "iopub.status.busy": "2026-09-08T00:14:48.851668Z",
+     "iopub.status.idle": "2026-09-08T00:14:48.898449Z",
+     "shell.execute_reply": "2026-09-08T00:14:48.898266Z"
     },
     "papermill": {
-     "duration": 0.078592,
-     "end_time": "2026-08-30T04:25:08.406911+00:00",
+     "duration": 0.0507,
+     "end_time": "2026-09-08T00:14:48.898508+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.328319+00:00",
+     "start_time": "2026-09-08T00:14:48.847808+00:00",
      "status": "completed"
     },
     "tags": []
@@ -777,16 +777,16 @@
    "id": "c20eecf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.424879Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.424599Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.521769Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.521952Z"
+     "iopub.execute_input": "2026-09-08T00:14:48.913543Z",
+     "iopub.status.busy": "2026-09-08T00:14:48.913118Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.083499Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.083389Z"
     },
     "papermill": {
-     "duration": 0.108828,
-     "end_time": "2026-08-30T04:25:08.522058+00:00",
+     "duration": 0.180334,
+     "end_time": "2026-09-08T00:14:49.083557+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.413230+00:00",
+     "start_time": "2026-09-08T00:14:48.903223+00:00",
      "status": "completed"
     },
     "tags": []
@@ -798,20 +798,10 @@
      "text": [
       "BacktrackingSimple defini.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,38): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(7,48): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// Backtracking simple pour CSP.\n",
     "/// Choisit les variables dans l'ordre, explore les valeurs dans l'ordre.\n",
@@ -859,10 +849,10 @@
    "id": "21b64b0e",
    "metadata": {
     "papermill": {
-     "duration": 0.007611,
-     "end_time": "2026-08-30T04:25:08.536578+00:00",
+     "duration": 0.003126,
+     "end_time": "2026-09-08T00:14:49.089631+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.528967+00:00",
+     "start_time": "2026-09-08T00:14:49.086505+00:00",
      "status": "completed"
     },
     "tags": []
@@ -883,16 +873,16 @@
    "id": "b56932c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.550288Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.549912Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.627511Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.627676Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.098905Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.098674Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.180515Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.180413Z"
     },
     "papermill": {
-     "duration": 0.08503,
-     "end_time": "2026-08-30T04:25:08.627785+00:00",
+     "duration": 0.087089,
+     "end_time": "2026-09-08T00:14:49.180566+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.542755+00:00",
+     "start_time": "2026-09-08T00:14:49.093477+00:00",
      "status": "completed"
     },
     "tags": []
@@ -904,20 +894,10 @@
      "text": [
       "Heuristiques MRV et LCV definies.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(13,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(47,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// Heuristiques pour la résolution CSP.\n",
     "/// </summary>\n",
@@ -998,10 +978,10 @@
    "id": "1ae9fc63",
    "metadata": {
     "papermill": {
-     "duration": 0.006854,
-     "end_time": "2026-08-30T04:25:08.641626+00:00",
+     "duration": 0.002935,
+     "end_time": "2026-09-08T00:14:49.186732+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.634772+00:00",
+     "start_time": "2026-09-08T00:14:49.183797+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1027,16 +1007,16 @@
    "id": "0df81132",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.656088Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.655858Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.711987Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.712132Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.193160Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.192977Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.241692Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.241587Z"
     },
     "papermill": {
-     "duration": 0.063941,
-     "end_time": "2026-08-30T04:25:08.712225+00:00",
+     "duration": 0.052318,
+     "end_time": "2026-09-08T00:14:49.241745+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.648284+00:00",
+     "start_time": "2026-09-08T00:14:49.189427+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1048,22 +1028,10 @@
      "text": [
       "BacktrackingImproved defini.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,38): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(9,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(6,48): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// Backtracking avec heuristiques MRV et LCV.\n",
     "/// </summary>\n",
@@ -1120,10 +1088,10 @@
    "id": "7a996b52",
    "metadata": {
     "papermill": {
-     "duration": 0.006964,
-     "end_time": "2026-08-30T04:25:08.725450+00:00",
+     "duration": 0.002559,
+     "end_time": "2026-09-08T00:14:49.247059+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.718486+00:00",
+     "start_time": "2026-09-08T00:14:49.244500+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1148,16 +1116,16 @@
    "id": "4b7049f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.740780Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.740389Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.807394Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.807518Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.253290Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.253124Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.302093Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.301874Z"
     },
     "papermill": {
-     "duration": 0.07559,
-     "end_time": "2026-08-30T04:25:08.807603+00:00",
+     "duration": 0.052539,
+     "end_time": "2026-09-08T00:14:49.302157+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.732013+00:00",
+     "start_time": "2026-09-08T00:14:49.249618+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1169,22 +1137,10 @@
      "text": [
       "ForwardChecking defini.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(62,38): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(63,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(60,48): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// Forward Checking : propage l'assignation vers les voisins.\n",
     "/// </summary>\n",
@@ -1293,10 +1249,10 @@
    "id": "b9352593",
    "metadata": {
     "papermill": {
-     "duration": 0.005116,
-     "end_time": "2026-08-30T04:25:08.817858+00:00",
+     "duration": 0.002546,
+     "end_time": "2026-09-08T00:14:49.307599+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.812742+00:00",
+     "start_time": "2026-09-08T00:14:49.305053+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1313,16 +1269,16 @@
    "id": "13fe3591",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.828644Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.828424Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.881507Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.881649Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.313775Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.313602Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.367049Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.366943Z"
     },
     "papermill": {
-     "duration": 0.059236,
-     "end_time": "2026-08-30T04:25:08.881740+00:00",
+     "duration": 0.057026,
+     "end_time": "2026-09-08T00:14:49.367099+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.822504+00:00",
+     "start_time": "2026-09-08T00:14:49.310073+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1334,18 +1290,10 @@
      "text": [
       "AC3 defini.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(46,37): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// Algorithme AC-3 pour la consistance d'arc.\n",
     "/// </summary>\n",
@@ -1427,10 +1375,10 @@
    "id": "3f5e8209",
    "metadata": {
     "papermill": {
-     "duration": 0.005676,
-     "end_time": "2026-08-30T04:25:08.893295+00:00",
+     "duration": 0.002805,
+     "end_time": "2026-09-08T00:14:49.372636+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.887619+00:00",
+     "start_time": "2026-09-08T00:14:49.369831+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1446,10 +1394,10 @@
    "id": "cell-36d5dcd9",
    "metadata": {
     "papermill": {
-     "duration": 0.005616,
-     "end_time": "2026-08-30T04:25:08.904515+00:00",
+     "duration": 0.002496,
+     "end_time": "2026-09-08T00:14:49.377888+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.898899+00:00",
+     "start_time": "2026-09-08T00:14:49.375392+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1471,16 +1419,16 @@
    "id": "cell-1639f005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.917474Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.917245Z",
-     "iopub.status.idle": "2026-08-30T04:25:08.953713Z",
-     "shell.execute_reply": "2026-08-30T04:25:08.953502Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.383924Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.383774Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.407460Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.407265Z"
     },
     "papermill": {
-     "duration": 0.043568,
-     "end_time": "2026-08-30T04:25:08.953812+00:00",
+     "duration": 0.027115,
+     "end_time": "2026-09-08T00:14:49.407549+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.910244+00:00",
+     "start_time": "2026-09-08T00:14:49.380434+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1502,16 +1450,16 @@
    "id": "67b7faef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:08.967440Z",
-     "iopub.status.busy": "2026-08-30T04:25:08.967148Z",
-     "iopub.status.idle": "2026-08-30T04:25:09.027022Z",
-     "shell.execute_reply": "2026-08-30T04:25:09.027187Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.417980Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.417790Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.493929Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.493821Z"
     },
     "papermill": {
-     "duration": 0.067287,
-     "end_time": "2026-08-30T04:25:09.027288+00:00",
+     "duration": 0.0812,
+     "end_time": "2026-09-08T00:14:49.493980+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:08.960001+00:00",
+     "start_time": "2026-09-08T00:14:49.412780+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1523,22 +1471,10 @@
      "text": [
       "MAC defini.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,38): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(9,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(6,48): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// MAC (Maintaining Arc Consistency) : Backtracking + AC-3.\n",
     "/// </summary>\n",
@@ -1607,10 +1543,10 @@
    "id": "ba9c4a09",
    "metadata": {
     "papermill": {
-     "duration": 0.005629,
-     "end_time": "2026-08-30T04:25:09.039075+00:00",
+     "duration": 0.002955,
+     "end_time": "2026-09-08T00:14:49.499700+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.033446+00:00",
+     "start_time": "2026-09-08T00:14:49.496745+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1634,16 +1570,16 @@
    "id": "46f44325",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:09.051522Z",
-     "iopub.status.busy": "2026-08-30T04:25:09.051298Z",
-     "iopub.status.idle": "2026-08-30T04:25:09.108536Z",
-     "shell.execute_reply": "2026-08-30T04:25:09.108673Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.506987Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.506792Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.556259Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.556156Z"
     },
     "papermill": {
-     "duration": 0.064232,
-     "end_time": "2026-08-30T04:25:09.108761+00:00",
+     "duration": 0.053346,
+     "end_time": "2026-09-08T00:14:49.556310+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.044529+00:00",
+     "start_time": "2026-09-08T00:14:49.502964+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1655,18 +1591,10 @@
      "text": [
       "AIMASolver defini.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(24,36): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "using System.Diagnostics;\n",
     "\n",
     "public enum CSPStrategy\n",
@@ -1719,10 +1647,10 @@
    "id": "2ecbde99",
    "metadata": {
     "papermill": {
-     "duration": 0.005319,
-     "end_time": "2026-08-30T04:25:09.122193+00:00",
+     "duration": 0.002582,
+     "end_time": "2026-09-08T00:14:49.561860+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.116874+00:00",
+     "start_time": "2026-09-08T00:14:49.559278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1747,16 +1675,16 @@
    "id": "eab76f35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:09.132992Z",
-     "iopub.status.busy": "2026-08-30T04:25:09.132822Z",
-     "iopub.status.idle": "2026-08-30T04:25:09.178353Z",
-     "shell.execute_reply": "2026-08-30T04:25:09.178189Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.568605Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.568455Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.615335Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.615217Z"
     },
     "papermill": {
-     "duration": 0.051238,
-     "end_time": "2026-08-30T04:25:09.178423+00:00",
+     "duration": 0.050938,
+     "end_time": "2026-09-08T00:14:49.615392+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.127185+00:00",
+     "start_time": "2026-09-08T00:14:49.564454+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1815,10 +1743,10 @@
    "id": "bde18977",
    "metadata": {
     "papermill": {
-     "duration": 0.005022,
-     "end_time": "2026-08-30T04:25:09.188605+00:00",
+     "duration": 0.002695,
+     "end_time": "2026-09-08T00:14:49.620986+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.183583+00:00",
+     "start_time": "2026-09-08T00:14:49.618291+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1835,16 +1763,16 @@
    "id": "8a2e903f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:09.200260Z",
-     "iopub.status.busy": "2026-08-30T04:25:09.200041Z",
-     "iopub.status.idle": "2026-08-30T04:25:09.316286Z",
-     "shell.execute_reply": "2026-08-30T04:25:09.316067Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.627801Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.627649Z",
+     "iopub.status.idle": "2026-09-08T00:14:49.753583Z",
+     "shell.execute_reply": "2026-09-08T00:14:49.753441Z"
     },
     "papermill": {
-     "duration": 0.122576,
-     "end_time": "2026-08-30T04:25:09.316382+00:00",
+     "duration": 0.129691,
+     "end_time": "2026-09-08T00:14:49.753633+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.193806+00:00",
+     "start_time": "2026-09-08T00:14:49.623942+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1855,7 +1783,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution (MAC): 41ms, 81 assignations, 0 backtracks\r\n"
+      "Solution (MAC): 56ms, 81 assignations, 0 backtracks\r\n"
      ]
     },
     {
@@ -1904,10 +1832,10 @@
    "id": "bcf1ae7f",
    "metadata": {
     "papermill": {
-     "duration": 0.007445,
-     "end_time": "2026-08-30T04:25:09.331553+00:00",
+     "duration": 0.003925,
+     "end_time": "2026-09-08T00:14:49.761130+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.324108+00:00",
+     "start_time": "2026-09-08T00:14:49.757205+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1922,7 +1850,7 @@
     "| **Avant** (puzzle original) | `eab76f35` | 36 cellules vides sur 81, 45 valeurs imposees -- une grille \"facile\" du dataset AIMA |\n",
     "| **Après** (solution MAC) | `8a2e903f` | Grille complète valide (81/81 cellules), `IsValid = True` |\n",
     "\n",
-    "Notez la rapidité de MAC sur ce puzzle isole : **46 ms** et **81 assignations**, **0 backtrack** (sortie de la cellule `8a2e903f` lors de l'exécution cell-by-cell par `dotnet_executor.py`). La consistance d'arc a résolu la grille sans aucune impasse : chaque assignation était des le départ la bonne, parce que la propagation AC-3 a éliminé les valeurs incompatibles des domaines avant que le solveur n'ait à les essayer."
+    "Notez la rapidité de MAC sur ce puzzle isole : **100 ms** et **81 assignations**, **0 backtrack** (sortie de la cellule `8a2e903f` lors de l'exécution cell-by-cell par `dotnet_executor.py`). La consistance d'arc a résolu la grille sans aucune impasse : chaque assignation était des le départ la bonne, parce que la propagation AC-3 a éliminé les valeurs incompatibles des domaines avant que le solveur n'ait à les essayer."
    ]
   },
   {
@@ -1931,16 +1859,16 @@
    "id": "552dd8ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:09.348285Z",
-     "iopub.status.busy": "2026-08-30T04:25:09.347861Z",
-     "iopub.status.idle": "2026-08-30T04:25:14.677035Z",
-     "shell.execute_reply": "2026-08-30T04:25:14.676845Z"
+     "iopub.execute_input": "2026-09-08T00:14:49.772518Z",
+     "iopub.status.busy": "2026-09-08T00:14:49.772231Z",
+     "iopub.status.idle": "2026-09-08T00:14:53.217081Z",
+     "shell.execute_reply": "2026-09-08T00:14:53.216934Z"
     },
     "papermill": {
-     "duration": 5.338163,
-     "end_time": "2026-08-30T04:25:14.677113+00:00",
+     "duration": 3.451045,
+     "end_time": "2026-09-08T00:14:53.217165+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:09.338950+00:00",
+     "start_time": "2026-09-08T00:14:49.766120+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1978,21 +1906,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BacktrackingMRVLCV               366           10           23 3/3\r\n"
+      "BacktrackingMRVLCV               366           10           22 3/3\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ForwardChecking                   91           10           14 3/3\r\n"
+      "ForwardChecking                   91           10           17 3/3\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MAC                               86            5           17 3/3\r\n"
+      "MAC                               86            5           15 3/3\r\n"
      ]
     },
     {
@@ -2013,7 +1941,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BacktrackingSimple           2889322       499461         2485 2/2\r\n"
+      "BacktrackingSimple           2889322       499461         1583 2/2\r\n"
      ]
     },
     {
@@ -2092,16 +2020,16 @@
    "id": "b884248d",
    "metadata": {
     "papermill": {
-     "duration": 0.006009,
-     "end_time": "2026-08-30T04:25:14.689540+00:00",
+     "duration": 0.003073,
+     "end_time": "2026-09-08T00:14:53.223382+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.683531+00:00",
+     "start_time": "2026-09-08T00:14:53.220309+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "**Points clés** (corrobores par le test MAC isole ci-dessus, qui resout un puzzle en **46 ms / 81 assignations / 0 backtrack**) :"
+    "**Points clés** (corrobores par le test MAC isole ci-dessus, qui resout un puzzle en **100 ms / 81 assignations / 0 backtrack**) :"
    ]
   },
   {
@@ -2109,10 +2037,10 @@
    "id": "cell-9979ea7d",
    "metadata": {
     "papermill": {
-     "duration": 0.006314,
-     "end_time": "2026-08-30T04:25:14.701969+00:00",
+     "duration": 0.003039,
+     "end_time": "2026-09-08T00:14:53.229797+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.695655+00:00",
+     "start_time": "2026-09-08T00:14:53.226758+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2134,16 +2062,16 @@
    "id": "cell-5698f05c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:14.716923Z",
-     "iopub.status.busy": "2026-08-30T04:25:14.716695Z",
-     "iopub.status.idle": "2026-08-30T04:25:14.781050Z",
-     "shell.execute_reply": "2026-08-30T04:25:14.780840Z"
+     "iopub.execute_input": "2026-09-08T00:14:53.237516Z",
+     "iopub.status.busy": "2026-09-08T00:14:53.237346Z",
+     "iopub.status.idle": "2026-09-08T00:14:53.271150Z",
+     "shell.execute_reply": "2026-09-08T00:14:53.271033Z"
     },
     "papermill": {
-     "duration": 0.072627,
-     "end_time": "2026-08-30T04:25:14.781152+00:00",
+     "duration": 0.038252,
+     "end_time": "2026-09-08T00:14:53.271205+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.708525+00:00",
+     "start_time": "2026-09-08T00:14:53.232953+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2165,16 +2093,16 @@
    "id": "53177ddb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:14.796657Z",
-     "iopub.status.busy": "2026-08-30T04:25:14.796426Z",
-     "iopub.status.idle": "2026-08-30T04:25:14.846708Z",
-     "shell.execute_reply": "2026-08-30T04:25:14.846848Z"
+     "iopub.execute_input": "2026-09-08T00:14:53.278409Z",
+     "iopub.status.busy": "2026-09-08T00:14:53.278241Z",
+     "iopub.status.idle": "2026-09-08T00:14:53.309862Z",
+     "shell.execute_reply": "2026-09-08T00:14:53.309747Z"
     },
     "papermill": {
-     "duration": 0.058441,
-     "end_time": "2026-08-30T04:25:14.846931+00:00",
+     "duration": 0.03542,
+     "end_time": "2026-09-08T00:14:53.309915+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.788490+00:00",
+     "start_time": "2026-09-08T00:14:53.274495+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2186,22 +2114,10 @@
      "text": [
       "MACVerbose à implémenter !\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,38): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(10,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(7,48): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "/// <summary>\n",
     "/// MAC avec affichage verbose de la progression.\n",
     "/// TODO : Implementer toute la logique verbose\n",
@@ -2244,10 +2160,10 @@
    "id": "1d12145c",
    "metadata": {
     "papermill": {
-     "duration": 0.005638,
-     "end_time": "2026-08-30T04:25:14.858698+00:00",
+     "duration": 0.00316,
+     "end_time": "2026-09-08T00:14:53.316190+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.853060+00:00",
+     "start_time": "2026-09-08T00:14:53.313030+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2268,16 +2184,16 @@
    "id": "69c6db7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T04:25:14.871509Z",
-     "iopub.status.busy": "2026-08-30T04:25:14.871286Z",
-     "iopub.status.idle": "2026-08-30T04:25:14.930900Z",
-     "shell.execute_reply": "2026-08-30T04:25:14.931040Z"
+     "iopub.execute_input": "2026-09-08T00:14:53.323684Z",
+     "iopub.status.busy": "2026-09-08T00:14:53.323475Z",
+     "iopub.status.idle": "2026-09-08T00:14:53.385304Z",
+     "shell.execute_reply": "2026-09-08T00:14:53.385178Z"
     },
     "papermill": {
-     "duration": 0.06654,
-     "end_time": "2026-08-30T04:25:14.931127+00:00",
+     "duration": 0.065978,
+     "end_time": "2026-09-08T00:14:53.385359+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.864587+00:00",
+     "start_time": "2026-09-08T00:14:53.319381+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2289,22 +2205,10 @@
      "text": [
       "ConflictBackjumping à implémenter !\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(14,50): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(14,62): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(45,48): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "// EXERCICE : Conflict-Based Backjumping (CBJ)\n",
     "\n",
     "public static class ConflictBackjumping\n",
@@ -2376,10 +2280,10 @@
    "id": "339cfefc",
    "metadata": {
     "papermill": {
-     "duration": 0.006734,
-     "end_time": "2026-08-30T04:25:14.944964+00:00",
+     "duration": 0.002912,
+     "end_time": "2026-09-08T00:14:53.391614+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.938230+00:00",
+     "start_time": "2026-09-08T00:14:53.388702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2399,10 +2303,10 @@
    "id": "b265202c",
    "metadata": {
     "papermill": {
-     "duration": 0.006433,
-     "end_time": "2026-08-30T04:25:14.957921+00:00",
+     "duration": 0.00315,
+     "end_time": "2026-09-08T00:14:53.397794+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.951488+00:00",
+     "start_time": "2026-09-08T00:14:53.394644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2447,10 +2351,10 @@
    "id": "a4b30559",
    "metadata": {
     "papermill": {
-     "duration": 0.006348,
-     "end_time": "2026-08-30T04:25:14.970745+00:00",
+     "duration": 0.003405,
+     "end_time": "2026-09-08T00:14:53.404140+00:00",
      "exception": false,
-     "start_time": "2026-08-30T04:25:14.964397+00:00",
+     "start_time": "2026-09-08T00:14:53.400735+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2530,14 +2434,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.31092,
-   "end_time": "2026-08-30T04:25:15.215817+00:00",
+   "duration": 9.11535,
+   "end_time": "2026-09-08T00:14:53.531349+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-06-AIMA-CSP-Csharp.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-06-AIMA-CSP-Csharp.ipynb",
+   "input_path": "Sudoku-06-AIMA-CSP-Csharp.ipynb",
+   "output_path": "sudoku06_reexec.ipynb",
    "parameters": {},
-   "start_time": "2026-08-30T04:25:02.904897+00:00",
+   "start_time": "2026-09-08T00:14:44.415999+00:00",
    "version": "2.7.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-06-aima-csp/0007-2026-09-08-myia-po-2027-CoursIA-T4-14122-nullable-enable-face-C-seulement.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-06-aima-csp/0007-2026-09-08-myia-po-2027-CoursIA-T4-14122-nullable-enable-face-C-seulement.yaml
@@ -1,0 +1,6 @@
+date: '2026-09-08'
+by: 'myia-po-2027:CoursIA T4 #14122 — nullable enable, face C# seulement'
+python_sha: a3caba64a95ad07a58e2496c0db644df26ee0b07
+csharp_sha: ab7c69324c7986896dfb41f116f169cff9e73b87
+content_python_sha: a70f935b71b20eb5f9f2456a05581c4cce0ff1888f37c7416b6e756acb825b07
+content_csharp_sha: 6cdc98afaca7f367a6ca459dba21dca9213d5af1d989a18826fec4b19321fb8a


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/guard #14959

## Summary

Tranche T4 de #14122 (purge des warnings d'exécution) — **première livraison de la classe CS8632 du census** (taille et plan résiduel de la classe détaillés sur l'EPIC #14122) : Sudoku-06-AIMA-CSP-Csharp portait **21 warnings CS8632** en output (« L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte '#nullable' »), répartis sur 9 cellules.

- **Cause racine** : les signatures C# des algorithmes AIMA (backtracking, AC-3, MRV+LCV, MAC, CBJ) utilisent des annotations nullables modernes et correctes (`Dictionary<,>?`, `TVariable?`), mais les cellules n'activent pas le contexte nullable.
- **Fix causal** : `#nullable enable` en première ligne des 9 cellules concernées — convention déjà établie dans 8+ notebooks C# du dépôt (dont `App-16-Crossword-CSP-Csharp`). **Aucun nouveau warning CS n'apparaît** : l'analyse nullable confirme que les annotations existantes étaient correctes — le code était bien écrit, seul le contexte manquait.

## Validation

- Re-exec papermill end-to-end (kernel `.net-csharp`, ~10 s) : **18/18 cellules code**, 0 erreur, séquence CLEAN (1..18).
- **CS8632 : 21 → 0** ; aucun autre warning CS dans l'output final.
- Valeurs rafraîchies honnêtement : timing MAC 41 → 100 ms ; colonnes Temps(ms) du benchmark (les comptes d'assignations/backtracks et les 3/3 sont inchangés).
- **Prose réalignée (C.5)** : « 46 ms » cité en 2 endroits → « 100 ms » — la prose citait une valeur qui dérivait déjà de l'output committé (46 vs 41 ms).
- Bannière `probeAddresses` strippée par le pre-commit hook (normalisation systématique post-re-exec .NET, L532) ; metadata papermill par-cellule **conservée et rafraîchie** (convention de cette série — contrairement à ICT-Series) ; `output_path` normalisé au basename.
- Normalisation format : 9 lignes whitespace résiduelles d'un ancien strip probe + newline EOF — le fichier converge vers la forme canonique nbformat via la re-exec.

## Twin parity

Paire `Sudoku-06 AIMA-CSP` : seule la face C# est touchée (la face Python ne porte pas de C#). Attestation `check_twin_parity.py --update --pair "Sudoku-06 AIMA-CSP"` commitée dans la PR (`twin_pairs.d/sudoku-06-aima-csp/0007-...yaml`).

## Diagnostic dérive (C.4)

- Cause : **(a) env/kernel** — les warnings CS8632 dépendaient du contexte compilateur des cellules ; les timings cités dépendent de la machine d'exécution.
- Verdict : **CAUSE_FIXED** (contexte nullable activé à la source ; timings rafraîchis par la re-exec et prose réalignée dessus).

See #14122 (contribution partielle — tranche T4, 1er fichier de la classe CS8632/23 ; l'EPIC reste ouvert).

