### PR TITLE
Fix: authenticate lake git clones under concurrent CI runs (#14886)

### DIFF
--- a/.github/actions/lean-axiom/action.yml
+++ b/.github/actions/lean-axiom/action.yml
@@ -43,6 +43,18 @@ runs:
         ./elan-init -y --default-toolchain none
         echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+    # #14886: under concurrent CI runs, anonymous `lake` clones of public deps
+    # (mathlib4 included) trip GitHub's unauthenticated-rate credential prompt;
+    # `git` dies code 128. Authenticate clones with the job token BEFORE the
+    # first `lake` call so the cache-restore + lake-build path never crosses
+    # the unauthenticated threshold. Echoes only redacted `insteadOf` keys
+    # so the token never reaches the log.
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        git config --get-regexp '^url\..*\.insteadof$' | sed -E 's#://[^@/]+@#://***@#g'
+
     - name: Cache Lake build artifacts
       uses: actions/cache@v4
       with:

--- a/.github/actions/lean-build/action.yml
+++ b/.github/actions/lean-build/action.yml
@@ -130,6 +130,18 @@ runs:
         ./elan-init -y --default-toolchain none
         echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+    # #14886: under concurrent CI runs, anonymous `lake` clones of public deps
+    # (mathlib4 included) trip GitHub's unauthenticated-rate credential prompt;
+    # `git` dies code 128. Authenticate clones with the job token BEFORE the
+    # first `lake` call so the cache-restore + lake-build path never crosses
+    # the unauthenticated threshold. Echoes only redacted `insteadOf` keys
+    # so the token never reaches the log.
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        git config --get-regexp '^url\..*\.insteadof$' | sed -E 's#://[^@/]+@#://***@#g'
+
     - name: Cache Lake build artifacts
       uses: actions/cache@v4
       with:

--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -88,6 +88,18 @@ jobs:
         ./elan-init -y --default-toolchain none
         echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+    # #14886: under concurrent CI runs, anonymous `lake` clones of public deps
+    # (mathlib4 included) trip GitHub's unauthenticated-rate credential prompt;
+    # `git` dies code 128. Authenticate clones with the job token BEFORE the
+    # first `lake` call so the cache-restore + lake-build path never crosses
+    # the unauthenticated threshold. Echoes only redacted `insteadOf` keys
+    # so the token never reaches the log.
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        git config --get-regexp '^url\..*\.insteadof$' | sed -E 's#://[^@/]+@#://***@#g'
+
     - name: Cache Lake build artifacts
       uses: actions/cache@v4
       with:

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -175,6 +175,18 @@ jobs:
         ./elan-init -y --default-toolchain none
         echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+    # #14886: under concurrent CI runs, anonymous `lake` clones of public deps
+    # (mathlib4 included) trip GitHub's unauthenticated-rate credential prompt;
+    # `git` dies code 128. Authenticate clones with the job token BEFORE the
+    # first `lake` call so the cache-restore + lake-build path never crosses
+    # the unauthenticated threshold. Echoes only redacted `insteadOf` keys
+    # so the token never reaches the log.
+    - name: Authenticate lake's git clones
+      shell: bash
+      run: |
+        git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+        git config --get-regexp '^url\..*\.insteadof$' | sed -E 's#://[^@/]+@#://***@#g'
+
     - name: Cache Lake build artifacts
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2027:CoursIA-2 — prev: MED/slides #15049

Closes #14886.

## Symptôme

Run `34027638170`, PR #14821, `knot_lean`. Les deux jobs Lean (build + axiom) cold-cache clonent mathlib4 + 8 deps publics en parallèle depuis la même IP de sortie. Sur la fenêtre 10:35:54 → 10:36:18 (~24 s), GitHub répond aux requêtes anonymes par un prompt credentials ; `git` sans terminal meurt `code 128`. Quatre échecs mesurés, signature identique :

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: the remote end hung up unexpectedly
error: external command 'git' exited with code 128
```

Le discriminant est l'heure, pas le paquet. `LeanSearchClient` réussit à 10:34:20 sur le job build et échoue à 10:36:07 sur le job axiom ; `Qq` et `batteries` tombent dans la même fenêtre sur le job build. Les trois dépôts sont publics (`curl -o /dev/null -w '%{http_code}' .../info/refs?service=git-upload-pack` → `200`), ce n'est ni une dépendance disparue, ni un passage privé.

## Cause (3 mesures)

1. Aucun `git config --get-regexp 'url\..*\.insteadof'` dans les deux jobs (`grep -c extraheader` → 0 dans les logs). Les ~9 clones partent en anonyme.
2. `lake exe cache get` ne couvre que les oleans ; les sources sont clonées de toute façon.
3. Les deux jobs ont des clés de cache distinctes (`.github/actions/lean-axiom/action.yml:56`). Sur miss, chacun re-clone les 9 deps indépendamment et en parallèle, mathlib4 compris (3 min 30 à 4 min chacun).

## Correctif

Une étape `Authenticate lake's git clones` insérée **avant** le premier appel `lake` dans chacun des 4 fichiers :

- `.github/workflows/lean-build.yml` (réutilisable hosted)
- `.github/workflows/lean-axiom.yml` (réutilisable hosted)
- `.github/actions/lean-build/action.yml` (composite self-hosted)
- `.github/actions/lean-axiom/action.yml` (composite self-hosted)

L'étape pose l'`insteadOf` avec le job token GHA :

```yaml
git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
git config --get-regexp '^url\..*\.insteadof$' | sed -E 's#://[^@/]+@#://***@#g'
```

- Le token reste dans le store de secrets GHA (jamais commité, jamais loggé).
- La seconde ligne `sed` masque tout `://user:pass@` → `://***@` avant d'écho, donc le token n'atteint pas stdout.

## Acceptance (cf #14886 §Acceptance)

1. `git config --get-regexp` rend **une** ligne `insteadOf` dans chaque job (affichée redacted dans le log). Vérifiable par inspection de run.
2. **Contrôle positif** : un run de `knot_lean` avec les caches des deux jobs vidés (la condition qui a produit l'échec) — les 18 clones aboutissent, zéro `code 128`. Un run qui tape le cache ne prouve rien : il ne clone pas.
3. Aucun jeton en clair dans le log ni dans l'arbre. Vérifié par `git grep -E "(secrets\.|TOKEN|ghp_)" .github/` → vide.

## Diff

```
.github/actions/lean-axiom/action.yml | 12 ++++++++++++
.github/actions/lean-build/action.yml | 12 ++++++++++++
.github/workflows/lean-axiom.yml      | 12 ++++++++++++
.github/workflows/lean-build.yml      | 12 ++++++++++++
4 files changed, 48 insertions(+)
```

Strict minimum, isolé à 4 fichiers (les 2 workflows réutilisables + les 2 composite actions qui les twinnent pour le pool self-hosted Lean #14337 tranche 2a).

## Pré-requis pour le merge

- Le contrôle positif #2 (cache vidé sur les deux jobs) demande une exécution CI : c'est ce que le run sur la PR donnera.
- Si un run séparé est nécessaire (workflow_dispatch + paramètre `cache-disabled: true`), le demander ; sinon le run mergé sur la PR suffit.

## Notes

- Ne ferme pas le second axe de #14886 (mutualiser les 9 deps entre les deux jobs, périmètre #4362). Cette PR traite uniquement l'authentification, qui est la cause immédiate et suffisante.
- Le `sorry` gate de `knot_lean` reste à baseline (10/10) — l'échec n'a jamais touché la logique de preuve, seulement le clone des deps.
