### PR TITLE
fix(ci,#14921): parity `needs: ci` on 10 lean workflows (option 4 du residu structurel)

### DIFF
--- a/.github/workflows/lean-asymmetric-information.yml
+++ b/.github/workflows/lean-asymmetric-information.yml
@@ -83,6 +83,7 @@ jobs:
   # cannot drift when modules are added. fail-on-sorry: true is coherent with
   # sorry-baseline "0" above: no acknowledged sorries exist.
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean

--- a/.github/workflows/lean-asymmetric-information.yml
+++ b/.github/workflows/lean-asymmetric-information.yml
@@ -83,7 +83,7 @@ jobs:
   # cannot drift when modules are added. fail-on-sorry: true is coherent with
   # sorry-baseline "0" above: no acknowledged sorries exist.
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -114,6 +114,7 @@ jobs:
   # ``scripts/lean/tests/test_conway_blocking_gate_whitelist_aligned.py``
   # (audit script: ``scripts/lean/audit_conway_blocking_gate_whitelist.py``).
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -114,7 +114,7 @@ jobs:
   # ``scripts/lean/tests/test_conway_blocking_gate_whitelist_aligned.py``
   # (audit script: ``scripts/lean/audit_conway_blocking_gate_whitelist.py``).
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean

--- a/.github/workflows/lean-formal-groups.yml
+++ b/.github/workflows/lean-formal-groups.yml
@@ -69,6 +69,7 @@ jobs:
   # the lake walk; the `_en` i18n siblings are excluded by default (FR-only
   # measurement, byte-parity covers the EN side structurally, cf #10997).
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/formal_groups_lean

--- a/.github/workflows/lean-formal-groups.yml
+++ b/.github/workflows/lean-formal-groups.yml
@@ -7,9 +7,10 @@ name: Lean CI (formal_groups_lean)
 # (#14785, sub-grain of #14771). 0 sorry by construction. Target Lean
 # v4.33.0 / Mathlib db584cd6 (anchor #14773); the lake is autonomous.
 # Same thin-dispatcher form as lean-hecke.yml (same FLT-port family).
-# Note: no `needs:` between the two jobs — the per-IP anonymous-git burst
-# of #14921 is specific to the self-hosted pool behind one residential IP;
-# GitHub-hosted jobs each get their own runner IP.
+# c.329: `needs: ci` on proof-integrity (below) is parity with knot_lean
+# (#14922) -- it ORDERS the two compiles. It does not halve the anonymous-git
+# burst of #14921: that concern is specific to the self-hosted pool behind
+# one residential IP; GitHub-hosted jobs each get their own runner IP.
 
 on:
   push:
@@ -69,7 +70,7 @@ jobs:
   # the lake walk; the `_en` i18n siblings are excluded by default (FR-only
   # measurement, byte-parity covers the EN side structurally, cf #10997).
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/formal_groups_lean

--- a/.github/workflows/lean-galois.yml
+++ b/.github/workflows/lean-galois.yml
@@ -84,7 +84,7 @@ jobs:
   # pattern as lean-knot.yml). Keep `./` until #10889 lands, then either form
   # is correct.
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: ./.github/workflows/lean-axiom.yml
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean

--- a/.github/workflows/lean-galois.yml
+++ b/.github/workflows/lean-galois.yml
@@ -84,6 +84,7 @@ jobs:
   # pattern as lean-knot.yml). Keep `./` until #10889 lands, then either form
   # is correct.
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: ./.github/workflows/lean-axiom.yml
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -111,6 +111,7 @@ jobs:
   # pattern as lean-knot.yml). Keep `./` until #10889 lands, then either form
   # is correct.
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: ./.github/workflows/lean-axiom.yml
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -111,7 +111,7 @@ jobs:
   # pattern as lean-knot.yml). Keep `./` until #10889 lands, then either form
   # is correct.
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: ./.github/workflows/lean-axiom.yml
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean

--- a/.github/workflows/lean-hecke.yml
+++ b/.github/workflows/lean-hecke.yml
@@ -65,6 +65,7 @@ jobs:
   # the lake walk; the `_en` i18n sibling is excluded by default (FR-only
   # measurement, byte-parity covers the EN side structurally, cf #10997).
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/hecke_lean

--- a/.github/workflows/lean-hecke.yml
+++ b/.github/workflows/lean-hecke.yml
@@ -65,7 +65,7 @@ jobs:
   # the lake walk; the `_en` i18n sibling is excluded by default (FR-only
   # measurement, byte-parity covers the EN side structurally, cf #10997).
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/hecke_lean

--- a/.github/workflows/lean-mimo.yml
+++ b/.github/workflows/lean-mimo.yml
@@ -92,6 +92,7 @@ jobs:
   # `--lib-root` heuristic in `check_target_coverage.py` does not cover a
   # flat lake; sensitivity_lean (also wired) takes the same shortcut.
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean

--- a/.github/workflows/lean-mimo.yml
+++ b/.github/workflows/lean-mimo.yml
@@ -92,7 +92,7 @@ jobs:
   # `--lib-root` heuristic in `check_target_coverage.py` does not cover a
   # flat lake; sensitivity_lean (also wired) takes the same shortcut.
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean

--- a/.github/workflows/lean-percolation.yml
+++ b/.github/workflows/lean-percolation.yml
@@ -64,7 +64,7 @@ jobs:
   # are EXCLUDED by default (FR-only measurement; the byte-parity of the i18n
   # pair is covered structurally by `lean-i18n-drift.yml`, #10007).
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean

--- a/.github/workflows/lean-percolation.yml
+++ b/.github/workflows/lean-percolation.yml
@@ -64,6 +64,7 @@ jobs:
   # are EXCLUDED by default (FR-only measurement; the byte-parity of the i18n
   # pair is covered structurally by `lean-i18n-drift.yml`, #10007).
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean

--- a/.github/workflows/lean-sensitivity.yml
+++ b/.github/workflows/lean-sensitivity.yml
@@ -65,7 +65,7 @@ jobs:
   # are EXCLUDED by default (FR-only measurement; the byte-parity of #10997
   # covers the EN side structurally).
   proof-integrity:
-    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean

--- a/.github/workflows/lean-sensitivity.yml
+++ b/.github/workflows/lean-sensitivity.yml
@@ -65,6 +65,7 @@ jobs:
   # are EXCLUDED by default (FR-only measurement; the byte-parity of #10997
   # covers the EN side structurally).
   proof-integrity:
+    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize after `ci` to halve anonymous git burst on cold cache
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -110,7 +110,14 @@ jobs:
   # SocialChoice/CERTIFIED.txt by
   # scripts/tests/test_check_certified_sorry.py::test_workflow_targets_match_manifest.
   proof-integrity:
-    needs: certified-no-sorry  # c.306 parity with knot_lean (#14922) requires `ci` job, but this workflow uses `certified-no-sorry` instead -- serialize after the cheap text-level gate (Hermes review c.322 #5580896587)
+    # c.327 (ai-01 CHANGES_REQUESTED 2026-09-08): the two REAL compiles (`build`
+    # and `proof-integrity`) must serialize. Depending only on the cheap
+    # text-level gate `certified-no-sorry` left both full builds running in
+    # parallel. Serialize `proof-integrity` behind `build` (which itself needs
+    # the cheap gate). This ORDERS the two compiles; it does NOT share their
+    # Lake caches (lean-axiom.yml and the `build` Mathlib cache use distinct
+    # keys) nor halve the clone count -- ai-01 flagged both as unproven.
+    needs: build
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/GameTheory/game_theory_lean
@@ -123,9 +130,9 @@ jobs:
   build:
     name: "Lake build"
     runs-on: ubuntu-latest
-    # Serialized only behind the CHEAP text-level gate (fail fast before
-    # spending a Mathlib build); proof-integrity (lean-axiom.yml) runs its own
-    # full build in parallel rather than doubling this one in series.
+    # Serialized behind the CHEAP text-level gate (fail fast before spending a
+    # Mathlib build). proof-integrity now depends on THIS job (c.327) so the two
+    # full compiles run in series instead of in parallel.
     needs: certified-no-sorry
     defaults:
       run:

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -110,6 +110,7 @@ jobs:
   # SocialChoice/CERTIFIED.txt by
   # scripts/tests/test_check_certified_sorry.py::test_workflow_targets_match_manifest.
   proof-integrity:
+    needs: certified-no-sorry  # c.306 parity with knot_lean (#14922) requires `ci` job, but this workflow uses `certified-no-sorry` instead -- serialize after the cheap text-level gate (Hermes review c.322 #5580896587)
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/GameTheory/game_theory_lean


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: DEEP/lean #14913 (c.290)

fix(ci,#14921): parity `needs: ci` on 10 lean workflows (option 4 du residu structurel)


## Périmètre effectif

- `.github/workflows/lean-asymmetric-information.yml`
- `.github/workflows/lean-conway.yml`
- `.github/workflows/lean-formal-groups.yml`
- `.github/workflows/lean-galois.yml`
- `.github/workflows/lean-grothendieck.yml`
- `.github/workflows/lean-hecke.yml`
- `.github/workflows/lean-mimo.yml`
- `.github/workflows/lean-percolation.yml`
- `.github/workflows/lean-sensitivity.yml`
- `.github/workflows/lean-social-choice.yml`

**Fichiers modifiés (périmètre effectif) : 10 fichiers** — les workflows listés ci-dessus.
**Corpus YAML-validé (contrôle de parse) : 11 fichiers** — les 10 modifiés + `lean-knot.yml` (témoin non modifié, PR #14922), validé pour contrôler la non-régression du parse `proof-integrity.needs`.

## Symptôme

Le PR #14922 MERGED 2026-09-06T20:47:10Z a ajouté `needs: ci` sur le job
`proof-integrity` de **`lean-knot.yml`** uniquement — un **edge de
sérialisation** entre le job de build et le job d'intégrité des axiomes,
dans l'objectif de réduire le pic de clones anonymes concurrents.

Mais l'option 4 du ticket #14921 (« **parité `conway_lean`** ») cache en
réalité un défaut **structurel transversal** : **17 workflows `lean-*`**
ont un job `proof-integrity` qui démarre simultanément au job de
compilation et donc déclenche en parallèle la même rafale de clones
anonymes.

Mesure firsthand (c.306) — grep `proof-integrity:` sur `.github/workflows/lean-*.yml` :

| Statut | Workflows |
|---|---|
| **Déjà corrigé** (PR #14922) | `lean-knot.yml` |
| **À corriger** (cette PR) | `lean-asymmetric-information` · `lean-conway` · `lean-formal-groups` · `lean-galois` · `lean-grothendieck` · `lean-hecke` · `lean-mimo` · `lean-percolation` · `lean-sensitivity` · `lean-social-choice` |
| **Pas de job proof-integrity** (hors scope) | `lean-argumentation` · `lean-assignment` · `lean-calibration` · `lean-conway-cgt` · `lean-decision-theory` · `lean-discrepancy` · `lean-erc20` · `lean-finiteness` · `lean-game-defs` · `lean-game-defs-ext` · `lean-game-theory` · `lean-i18n-drift` · `lean-kelly` · `lean-learning-theory` · `lean-mathlib-examples` · `lean-minimax` |

## Correctif

Une ligne par workflow — **sauf une exception** : `lean-social-choice.yml`
n'a **pas** de job `ci` (ses jobs sont `certified-no-sorry` ·
`proof-integrity` · `build`). Le pattern s'y écrit donc `needs: build`
(c.327, ai-01 CHANGES_REQUESTED 2026-09-08), pas `needs: ci`.

Cas général (workflows du périmètre avec un job `ci`, hors SocialChoice) :

```yaml
  proof-integrity:
    needs: ci  # c.306 parity with knot_lean (#14922) -- serialize the two compiles; ordering edge only, no measured clone-halving (c.329, ai-01 re-review #15150)
    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
    with:
      ...
```

Cas `lean-social-choice.yml` (pas de job `ci`) :

```yaml
  proof-integrity:
    needs: build  # c.327 -- serialize behind the real compile; no `ci` job in this workflow
    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
    with:
      ...
```

`needs` au même niveau d'indent que `uses:` (4 espaces — enfant du job,
pas du top-level).

**Portée honnête du correctif** : `needs` est un **edge de sérialisation**
dans le DAG — il **ordonne** les deux compiles (le job d'intégrité attend
le job de build qui le précède) et évite leur démarrage simultané. Il ne
**démontre ni** la restauration d'un cache `.lake` partagé — les workflows
réutilisables `lean-build` et `lean-axiom` portent des clés de cache
**distinctes** — **ni** une division mesurée des clones par deux. Ces deux
gains restent à établir par mesure dédiée (cf. Hors scope, option 1).

**Pass d'honnêteté des commentaires (c.329, ai-01 re-review 2026-09-08)** : les 9
commentaires généraux promettaient à l'origine « serialize after `ci` to halve
anonymous git burst on cold cache » — un gain **jamais mesuré**, retiré au commit
`1b9363d26` pour décrire la sérialisation effectivement ajoutée, sans gain mesuré sur le nombre de clones. Au passage, l'en-tête de `lean-formal-groups.yml` portait une
note pré-existente « Note: no `needs:` between the two jobs » que la ligne
`needs: ci` de cette PR rendait fausse — réécrite pour énoncer la sérialisation
comme parité/ordering, en conservant le fait que la rafale par-IP de #14921 est
spécifique au pool self-hosted. **Le commit `1b9363d26` révise les commentaires ; les dépendances YAML ajoutées par les commits précédents sont conservées** (`needs == "ci"` ×9, `"build"` ×1, re-vérifié post-commit).

## Acceptance

1. **YAML valide** : `yaml.safe_load` parse le périmètre modifié et le témoin non modifié `lean-knot.yml` sans erreur ; `proof-integrity.needs == "ci"` sur les workflows du périmètre qui ont un job `ci`, **`needs == "build"`** sur `lean-social-choice.yml` (exception documentée).
2. **Diff** : `git diff origin/main...HEAD --stat` = `10 files changed, 24 insertions(+), 6 deletions(-)` — cumul des trois commits `dac652b4f` (needs ×10) + `55179e343` (social-choice `needs: build` + commentaire multi-lignes) + `1b9363d26` (retrait des 9 promesses non mesurées + note formal-groups).
3. **LF préservé** sur le périmètre hors sensibilité, **CRLF préservé** sur `lean-sensitivity.yml` (défaut pré-existant — conversion LF hors scope).
4. **`proof-integrity-audit` non affecté** : ce job advisory reste sur sa sémantique parallèle (vérifié dans les témoins : `lean-conway.yml`, `lean-knot.yml`).
5. **Pas de MR cycle de re-run attendu** : `needs` est un **edge** dans le DAG, pas un changement de code exécuté ; les workflows restent fonctionnels, seul l'ordering change.

## Hors scope

- **Option 1** (harmoniser clé de cache `lean-build` ↔ `lean-axiom` par lake) — footprint quota ÷ 2, moyen-effort, PR dédiée à arbitrer séparément. C'est le prérequis pour rendre mesurable un éventuel gain de cache.
- **Option 2** (amaigrir le chemin caché `.lake/packages` + oleans toolchain, pas tout `.lake`) — faible-effort, PR dédiée.
- **Option 3** (PAT fetch authentifié via `x-access-token` extraheader) — **couverte par PR #15148 po-2027** sur `#14886`, en cours de validation CI.
- **Option 5+** (parité `lean-asymmetric-information` lui-même, qui était un lake **non couvert** par `knot_lean` à l'origine) — **fait dans cette PR**.

## Cross-référence

- #14921 — ticket umbrella, option 4 du résidu structurel **complétée** par cette PR
- #14922 — PR original sur `knot_lean` (référence canonique, 2026-09-06)
- #14886 — axe authentification, axe complémentaire couvert par #15148 (po-2027)

See #14921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>


