### PR TITLE
fix(picker,#15139): delegation nits morte (TypeError avale) — point d'entree partage analyse_pr

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -3684,6 +3684,29 @@ def _print_sha_notes(result: dict) -> None:
               f"(absent des commits, non rattaché à cette PR) — non bloquant")
 
 
+def analyse_pr(pr: int) -> dict:
+    """Analyse pre-merge d'une PR ouverte, SANS impression — point d'entree
+    partage avec le picker (#15139).
+
+    `gate()` reste l'entree CLI (impression + rc) et couvre aussi l'audit
+    retro (cutoff = mergedAt). Ce wrapper couvre le cas pre-merge (cutoff =
+    now) pour les appelants programmeurs : jusqu'ici chacun re-assemblait
+    l'appel `analyse(...)` avec ses propres kwargs, et la derive de signature
+    entre les deux assemblages rendait la delegation du picker morte en
+    silence (TypeError avale -> dict vide -> la cause « point de review non
+    leve » ne se declenchait jamais). Un seul point d'entree, un seul
+    assemblage : ce qui diverge ici casse le merge-gate lui-meme et devient
+    visible immediatement.
+    """
+    data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
+    # #13639 : resolution serveur des SHAs cites-absents, AVANT analyse
+    # (qui reste pure). Sans ceci, la classe #13557 serait invisible.
+    data["_absent_sha_messages"] = _resolve_absent_sha_messages(data)
+    return analyse(data, review_threads(pr), datetime.now(timezone.utc),
+                   issue_info=gh_issue_info,
+                   dismissed_improperly=improper_dismissals(pr))
+
+
 def gate(pr: int, as_json: bool) -> int:
     data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
     # #13639 : resolution serveur des SHAs cites-absents, AVANT analyse

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1497,22 +1497,30 @@ def unaddressed_review_points(numbers: list[int]) -> dict[int, int]:
     Panne d'import ou de reseau : dictionnaire vide plutot qu'une exception. Le
     garde ne doit jamais empecher un tirage pour une raison technique -- mais
     l'appelant DIT que la surface n'a pas ete regardee (cf `nits_unavailable`).
+    Une erreur de CONTRAT avec l'organe (TypeError/AttributeError), en revanche,
+    n'est pas une PR illisible : elle est relancee pour rester visible (#15139).
     """
     if not numbers:
         return {}
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
     import check_unaddressed_nits as nits  # noqa: PLC0415 - import tardif volontaire
 
-    now = dt.datetime.now(dt.timezone.utc)
     out: dict[int, int] = {}
     for n in numbers:
         try:
-            data = nits.gh_json(["pr", "view", str(n), "--repo", REPO,
-                                 "--json", nits.FIELDS])
-            result = nits.analyse(
-                data, nits.review_threads(n), now,
-                issue_created=nits.gh_issue_created,
-                dismissed_improperly=nits.improper_dismissals(n))
+            # #15139 : delegation via le point d'entree `analyse_pr` de
+            # l'organe, pas un assemblage local de kwargs -- l'assemblage
+            # local avait derive (kwarg `issue_created` disparu de la
+            # signature) et le TypeError avale rendait un dict vide
+            # silencieux : la cause 4 ne se declenchait plus, pour aucune
+            # lane, pendant que le merge-gate (qui appelle juste) refusait
+            # les memes PRs.
+            result = nits.analyse_pr(n)
+        except (TypeError, AttributeError):
+            # Derive de contrat avec l'organe : bug d'appel, pas « PR
+            # illisible ». Propager jusqu'au try de `red_backlog` qui rend
+            # `nits_unavailable` -- visible, jamais un dict vide muet.
+            raise
         except Exception:  # noqa: BLE001 - une PR illisible ne bloque pas les autres
             continue
         if result.get("blocked"):

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -5491,3 +5491,65 @@ def test_ras_word_bound_rasoir_ne_leve_pas():
             "body": "Une couche ras de terre recouvre le chemin, mais la conclusion tient."}
     assert run([reserve, lift])["blocked"] is True
 
+
+
+# --- #15139 : analyse_pr, point d'entree pre-merge partage avec le picker ---
+
+def test_analyse_pr_assemble_comme_gate(monkeypatch):
+    """`analyse_pr` est l'assemblage pre-merge que `gate()` fait pour le CLI :
+    fetch + resolution #13639 des SHAs cites-absents + analyse a `now`, avec
+    le kwarg `issue_info` (le BON nom -- la delegation du picker appelait
+    `issue_created`, disparu de la signature, et son TypeError aval produisait
+    un dict vide silencieux).
+    """
+    payload = {
+        "number": 15139,
+        "title": "t",
+        "author": {"login": "jsboige"},
+        "comments": [USER_NIT],
+        "reviews": [],
+        "commits": [{"committedDate": at(19)}],
+        "mergedAt": None,
+    }
+    captured = {}
+
+    monkeypatch.setattr(mod, "gh_json", lambda args: dict(payload))
+    monkeypatch.setattr(mod, "_resolve_absent_sha_messages",
+                        lambda data, cap=5: {"abc123": "corps du message"})
+    monkeypatch.setattr(mod, "review_threads", lambda pr: [])
+    monkeypatch.setattr(mod, "improper_dismissals", lambda pr: [])
+
+    def fake_issue_info(n):
+        return None
+
+    monkeypatch.setattr(mod, "gh_issue_info", fake_issue_info)
+
+    real_analyse = mod.analyse
+
+    def spy_analyse(data, threads, cutoff, issue_info=None,
+                    dismissed_improperly=None):
+        captured.update(data=data, threads=threads, cutoff=cutoff,
+                        issue_info=issue_info, dismissed=dismissed_improperly)
+        return real_analyse(data, threads, cutoff, issue_info=issue_info,
+                            dismissed_improperly=dismissed_improperly)
+
+    monkeypatch.setattr(mod, "analyse", spy_analyse)
+
+    result = mod.analyse_pr(15139)
+
+    # Le nit user non leve traverse l'assemblage complet : le verdict du
+    # picker est celui du merge-gate sur les memes donnees.
+    assert result["blocked"] is True
+    # Resolution #13639 appliquee AVANT analyse (sinon la classe #13557
+    # serait invisible au pre-tirage).
+    assert captured["data"]["_absent_sha_messages"] == {"abc123": "corps du message"}
+    assert captured["threads"] == []
+    # Le kwarg transmis est `issue_info`, et c'est la fonction de l'organe
+    # telle que l'appelant la voit (monkeypatchee ici -> prouvee transmise
+    # telle quelle, jamais re-enveloppee).
+    assert captured["issue_info"] is fake_issue_info
+    assert captured["dismissed"] == []
+    # cutoff = now (pre-merge), pas mergedAt (None ici, mais l'assertion
+    # tiendrait aussi pour une PR mergee : analyse_pr est pre-merge).
+    delta = abs((captured["cutoff"] - datetime.now(timezone.utc)).total_seconds())
+    assert delta < 30

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -1848,3 +1848,60 @@ def test_14591_volet_a_cli_integration_prev_genre_autoload(tmp_path, monkeypatch
         f"auto-apply absent. Sortie: {captured[:400]}"
     )
     assert "tooling" in captured
+
+
+# --- #15139 : delegation a l'organe check_unaddressed_nits -----------------
+# Incident fondateur (2026-09-07, mesure sur myia-po-2027:CoursIA-2) : la lane
+# portait trois PRs a remarques non levees dont deux du user, et le picker
+# passait directement au tirage. La delegation re-assemblait l'appel
+# `analyse(...)` avec un kwarg `issue_created` disparu de la signature ->
+# TypeError sur CHAQUE PR, avale par le `except Exception: continue` ->
+# dict vide silencieux -> la cause « point de review non leve » ne pouvait
+# plus se declencher, pour aucune lane, pendant que le merge-gate (appel
+# correct) refusait les memes PRs.
+
+def test_unaddressed_review_points_delegue_a_analyse_pr(monkeypatch):
+    """La delegation passe par le point d'entree `analyse_pr` de l'organe --
+    un seul assemblage des kwargs, celui du merge-gate."""
+    import check_unaddressed_nits as nits
+    calls = []
+
+    def fake_analyse_pr(n):
+        calls.append(n)
+        return {"blocked": True, "blocking": [{"kind": "BLOCK"}, {"kind": "NIT"}]}
+
+    monkeypatch.setattr(nits, "analyse_pr", fake_analyse_pr)
+    assert pig.unaddressed_review_points([15049, 15081]) == {15049: 2, 15081: 2}
+    assert calls == [15049, 15081]
+
+
+def test_unaddressed_review_points_derive_de_contrat_visible(monkeypatch):
+    """Un TypeError de l'organe (derive de contrat) est RELANCE, pas classe
+    « PR illisible » : le bug d'appel doit rester visible (nits_unavailable
+    via red_backlog) au lieu d'un dict vide muet."""
+    import check_unaddressed_nits as nits
+
+    def broken_analyse_pr(n):
+        raise TypeError("analyse() got an unexpected keyword argument")
+
+    monkeypatch.setattr(nits, "analyse_pr", broken_analyse_pr)
+    import pytest
+    with pytest.raises(TypeError):
+        pig.unaddressed_review_points([15049])
+
+
+def test_unaddressed_review_points_pr_illisible_ne_bloque_pas_les_autres(monkeypatch):
+    """Une PR illisible (gh en erreur) reste avalee par PR : la panne d'UNE
+    PR ne doit pas empecher la detection sur les autres."""
+    import check_unaddressed_nits as nits
+    calls = []
+
+    def flaky_analyse_pr(n):
+        calls.append(n)
+        if n == 15049:
+            raise RuntimeError("gh: connection reset")
+        return {"blocked": True, "blocking": [{"kind": "NIT"}]}
+
+    monkeypatch.setattr(nits, "analyse_pr", flaky_analyse_pr)
+    assert pig.unaddressed_review_points([15049, 15081]) == {15081: 1}
+    assert calls == [15049, 15081]


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15050

## picker : la delegation nits etait MORTE (TypeError avale sur chaque PR)

Closes #15139

## Reponse a « à trancher » : ni l'hypothese 1, ni la 2 — une troisieme cause, prouvee par execution

L'issue proposait deux pistes : (1) `analyse` non appelee sur ce chemin, ou (2) la borne de 24 h appliquee a tort a la cause « point de review ». Verifiees toutes deux et ecartees :

- **(1) fausse** : `red_backlog` appelle `unaddressed_review_points` sans aucun filtre d'age ni de genre (pick_idle_grain.py, boucle sur `mine`), et la cause est inseree inconditionnellement quand `n_nits > 0`.
- **(2) fausse** : le declencheur `nits` (`triggers.append("nits")`) ne porte **aucune** condition d'age — seule la cause `file_saturation` (#12830) exige `age_hours >= saturation_hours`. Et `check_unaddressed_nits.analyse` n'a pas de periode de grace : `cutoff = mergedAt or now`, sans dwell.

**La vraie cause** — instrumentee directement sur la fixture :

```
>>> nits.analyse(data, threads, now,
...              issue_created=nits.gh_issue_created, ...)   # l'appel du picker
TypeError: analyse() got an unexpected keyword argument 'issue_created'
```

La signature de l'organe est `analyse(pr_data, threads, cutoff, issue_info=None, dismissed_improperly=None)` — le kwarg `issue_created` n'existe plus. Le picker levait donc un **TypeError sur CHAQUE PR**, avale par le `except Exception: continue` (« une PR illisible ne bloque pas les autres ») → dictionnaire vide silencieux → `nits_by_pr = {}` → la cause 4 ne pouvait plus se declencher, **pour aucune lane, sur aucun appel**. Pendant ce temps le merge-gate (`gate()`, l.3694) appelait correctement `issue_info=gh_issue_info` et refusait les memes PRs : la divergence exacte que proactive-coordination R5 pre-disait (« une lane autorisee a produire du neuf sur une PR que le merge-gate refusera »).

La fenetre de 24 h de l'issue etait un coincidence de timing plausible mais innocent : les nits de 8-10 h etaient invisibles pour la meme raison que des nits de 3 semaines l'auraient ete.

## Correctif structurel : un point d'entree partage, plus deux assemblages

Le vecteur de la derive, c'est l'**assemblage local des kwargs** dans le picker — une seconde ecriture de l'appel, condamnee a diverger. Le fix la supprime :

1. **`check_unaddressed_nits.analyse_pr(pr) -> dict`** (nouveau, +23 lignes) : l'assemblage pre-merge que `gate()` fait pour le CLI — fetch + resolution #13639 des SHAs cites-absents + `analyse(...)` a `now`. `gate()` reste inchange (il couvre aussi l'audit retro, cutoff = mergedAt).
2. **`pick_idle_grain.unaddressed_review_points`** appelle `nits.analyse_pr(n)` — plus aucun kwarg assemble cote picker. Ce qui diverge desormais casse le merge-gate lui-meme et devient visible immediatement.
3. **`TypeError`/`AttributeError` relances** au lieu d'etre classes « PR illisible » : une derive de contrat remonte jusqu'au try de `red_backlog` et se dit via `nits_unavailable` — visible, jamais un dict vide muet. Les pannes operationnelles (gh, reseau) restent avalees par PR.

## Controle positif obligatoire (celui de l'issue) — rejeu 2026-09-08

| Rejeu | Avant (main) | Apres (ce commit) |
|---|---|---|
| `--lane myia-po-2027:CoursIA-2 --prev-genre ledger` | « ROUGE IMPUTE A LA BASE » puis tirage normal, RC=0 — aucune PR nommee (reproduit aujourd'hui, identique a la mesure de l'issue) | **GRAIN DU CYCLE : reparer ses propres PRs** — **#15049** (1 point de review non leve) et **#15081** (4 points) nommees, cause review en tete |
| `--lane myia-po-2024:CoursIA-2 --prev-genre ledger` | (non mesure par l'issue) | **#15051** nommee (2 points) + #15033, #15102, #15110 egalement porteuses de points |

**Nuance documentee sur la fixture** : #15051 porte le tag `lane myia-po-2024:CoursIA-2` (verifie firsthand) — elle n'est `mine` pour AUCUN rejeu po-2027, contrairement au tableau de l'issue. Le triple controle de l'issue est donc couvert par les DEUX rejeus ci-dessus. Bonus confirme le caractere fleet-wide annonce par l'issue : le rejeu po-2024 fait resurgir des points invisibles sur 4 PRs supplementaires.

## Controle negatif + tests

- **4 nouveaux tests, tous rouges sur le code d'avant** (verifie par `git stash` des 2 fichiers source) : delegation via `analyse_pr` (echoue sur l'ancien code : jamais appele), derive de contrat relancee (echoue : `analyse_pr` inexistant), PR illisible isolee, assemblage organ (`issue_info` transmis, resolution #13639 appliquee, cutoff=now, verdict blocked traverse).
- 502 tests verts sur les 7 suites voisines (picker, picker_cache, nits x5) ; 104 sur picker+nits avec les nouveaux.

## Verifications

- Diff strictement confine : 4 fichiers (2 sources + 2 tests), +157/-7, base fraiche origin/main 7af725e968, aucun notebook, aucun catalogue.
- Pre-claim check : 0 PR ouverte citant 15139 (recherche nu titre+body), claim pose (issuecomment-5577347408).
- `python -m py_compile` OK sur les deux sources modifies.

## Diagnostic derive

Verdict : **CAUSE_FIXED** — la cause 4 etait morte par derive de contrat entre deux assemblages du meme appel organ, masquee par une except-borne trop large. Le point d'entree partage ferme la classe (plus de seconde ecriture), et la relance des erreurs de contrat rend toute recidive visible au lieu de la rendre invisible.
