### PR TITLE
fix(search,#14122): CSP-9-Distributed-Csharp active #nullable — purge 10 CS8632 (T5)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "markdown",
    "id": "51c388f5",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# CSP-9-Distributed\n",
     " : CSP Distribués (DisCSP)**Navigation** : [<< CSP-8-Temporal](CSP-8-Temporal.ipynb) | [Index](../README.md) | [App-1-NQueens >>](../Applications/CSP/App-1-NQueens.ipynb)> **Durée estimée** : 2h00## Objectifs d'apprentissageÀ la fin de ce notebook, vous saurez :1. **Comprendre** les défis de la résolution distribuée de CSP2. **Implémenter** l'algorithme Asynchronous Backtracking (ABT)3. **Découvrir** Asynchronous Weak-Commitment (AWC) et ses améliorations4. **Appliquer** les techniques de privacy-preserving CSP5. **Résoudre** des problèmes de coordination multi-agents## Prérequis- [CSP-1-Fundamentals-Csharp.ipynb](CSP-1-Fundamentals-Csharp.ipynb) — notions CSP (variables, domaines, contraintes)- [CSP-2-Consistency-Csharp.ipynb](CSP-2-Consistency-Csharp.ipynb) — propagation de contraintes## Lien avec EPIC #4956Ce notebook est le **binôme .NET** du [CSP-9-Distributed.ipynb](CSP-9-Distributed.ipynb) (Python). L'algorithme distribué Yokoo 1992 est implémenté **from scratch en C#** (pas de solver externe : l'ABT n'a pas de \"moteur SOTA centralisé\", c'est l'**algorithme** qui est le sujet)."
@@ -15,18 +17,134 @@
    "id": "93379df9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:20.003672Z",
-     "iopub.status.busy": "2026-07-04T00:57:19.998797Z",
-     "iopub.status.idle": "2026-07-04T00:57:21.051073Z",
-     "shell.execute_reply": "2026-07-04T00:57:21.049098Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:27.150248Z",
+     "iopub.status.busy": "2026-09-08T01:30:27.146067Z",
+     "iopub.status.idle": "2026-09-08T01:30:28.249453Z",
+     "shell.execute_reply": "2026-09-08T01:30:28.246106Z"
+    },
+    "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '38752.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".NET Version : 8.0.28\r\n"
+      ".NET Version : 10.0.11\r\n"
      ]
     },
     {
@@ -60,7 +178,9 @@
   {
    "cell_type": "markdown",
    "id": "c2017647",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 1. Formalisation du DisCSP### DéfinitionUn\n",
     " **DisCSP** (Distributed Constraint Satisfaction Problem) est défini par :- **Agents** : $A = \\{a_1, a_2, ..., a_n\\}$- **Variables** : Chaque agent $a_i$ contrôle un sous-ensemble $X_i \\subset X$- **Domaines** : Chaque variable $x_j$ a un domaine $D_j$- **Contraintes** : $C = C_{interne} \\cup C_{externe}$  - $C_{interne}$ : contraintes entre variables d'un même agent  - $C_{externe}$ : contraintes entre variables d'agents différents### Hypothèses classiques1. **Un agent = une variable** (simplification courante)2. **Communication asynchrone** par envoi de messages3. **Pas de mémoire partagée** entre agents4. **Échec détecté localement** par chaque agent### Pourquoi distribuer ?- **Scalabilité** : pas de solveur centralisé- **Confidentialité** : chaque agent garde ses contraintes locales- **Robustesse** : pas de point unique de défaillance- **Réalisme** : correspond à de nombreux scénarios multi-agents"
@@ -72,11 +192,12 @@
    "id": "c7e87141",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:21.052362Z",
-     "iopub.status.busy": "2026-07-04T00:57:21.052178Z",
-     "iopub.status.idle": "2026-07-04T00:57:21.332241Z",
-     "shell.execute_reply": "2026-07-04T00:57:21.332091Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:28.263771Z",
+     "iopub.status.busy": "2026-09-08T01:30:28.263458Z",
+     "iopub.status.idle": "2026-09-08T01:30:28.629901Z",
+     "shell.execute_reply": "2026-09-08T01:30:28.629719Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -127,7 +248,9 @@
   {
    "cell_type": "markdown",
    "id": "cc993327",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 2. Asynchronous Backtracking (ABT)\n",
     "\n",
@@ -160,11 +283,12 @@
    "id": "1cecb869",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:21.333327Z",
-     "iopub.status.busy": "2026-07-04T00:57:21.333157Z",
-     "iopub.status.idle": "2026-07-04T00:57:21.507834Z",
-     "shell.execute_reply": "2026-07-04T00:57:21.507962Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:28.644233Z",
+     "iopub.status.busy": "2026-09-08T01:30:28.644061Z",
+     "iopub.status.idle": "2026-09-08T01:30:28.963214Z",
+     "shell.execute_reply": "2026-09-08T01:30:28.963037Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -173,20 +297,10 @@
      "text": [
       "Classe ABTAgent definie.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(12,18): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(74,26): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "\n",
     "// === Classe ABTAgent (Yokoo et al. 1992) ===\n",
     "\n",
@@ -402,7 +516,9 @@
   {
    "cell_type": "markdown",
    "id": "81050a23",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Implémentation du système ABT\n",
     "Cette section implémente la classe `ABTSystem` qui simule la communication asynchrone entre agents. Le système gère la file de messages, orchestre le traitement des messages ABT (ok?, nogood, addlink, stop) et vérifie la convergence vers une solution.\n",
@@ -419,11 +535,12 @@
    "id": "635f3231",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:21.509424Z",
-     "iopub.status.busy": "2026-07-04T00:57:21.509173Z",
-     "iopub.status.idle": "2026-07-04T00:57:21.617981Z",
-     "shell.execute_reply": "2026-07-04T00:57:21.617853Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:28.979111Z",
+     "iopub.status.busy": "2026-09-08T01:30:28.978801Z",
+     "iopub.status.idle": "2026-09-08T01:30:29.122203Z",
+     "shell.execute_reply": "2026-09-08T01:30:29.122089Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -432,20 +549,10 @@
      "text": [
       "Classe ABTSystem definie.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,35): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(48,35): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "\n",
     "// === Classe ABTSystem : simulateur de communication asynchrone ===\n",
     "\n",
@@ -602,7 +709,9 @@
   {
    "cell_type": "markdown",
    "id": "c53c4f6e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Analyse de l'implémentation ABT\n",
     "\n",
@@ -629,7 +738,9 @@
   {
    "cell_type": "markdown",
    "id": "db70f189",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exemple\n",
     " : Coloration de graphe distribuéeConsidérons un problème de coloration de graphe où chaque noeud est un agent indépendant."
@@ -641,11 +752,12 @@
    "id": "9798f8ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:21.619042Z",
-     "iopub.status.busy": "2026-07-04T00:57:21.618877Z",
-     "iopub.status.idle": "2026-07-04T00:57:21.734863Z",
-     "shell.execute_reply": "2026-07-04T00:57:21.734658Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:29.143502Z",
+     "iopub.status.busy": "2026-09-08T01:30:29.143337Z",
+     "iopub.status.idle": "2026-09-08T01:30:29.310660Z",
+     "shell.execute_reply": "2026-09-08T01:30:29.310370Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -756,7 +868,9 @@
   {
    "cell_type": "markdown",
    "id": "d6ee1c81",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Interprétation\n",
     " : Analyse de la solution ABT**Résultat attendu** : la solution retournée par `system.run()` doit satisfaire **toutes** les arêtesdu cycle 0-1, 1-2, 2-3, 3-0 ; chaque arête relie deux couleurs différentes.**Vérification automatique** : la cellule précédente vérifie chaque arête et imprime `OK` ou `ECHEC`.Si l'exécution affiche autre chose que 4 `OK`, c'est qu'un bug est présent (à remonter via une issue).**Comment l'algorithme y arrive** :1. Chaque agent commence par choisir la première valeur compatible avec sa vue. Comme la vue est vide à l'init, l'agent 0 choisit `\"R\"` immédiatement et l'envoie aux agents 1, 2, 3 (lower_priority).2. L'agent 1 reçoit `ok?{0=R}`, met `agent_view[0] = \"R\"`, puis choisit `\"G\"` (différent de `\"R\"`).3. Idem pour les agents 2 et 3. Une fois la quiescence atteinte, `CheckSolution() && VerifyGlobalConstraints()` valide la solution globale.**Pourquoi la vérification globale ?** La cohérence locale chez chaque agent vérifie seulement la **vue**. Deux agents non reliés par priorité mais reliés par une arête pourraient choisir des valeurs incompatibles. `VerifyGlobalConstraints()` rejoue chaque arête avec les valeurs finales."
@@ -765,7 +879,9 @@
   {
    "cell_type": "markdown",
    "id": "c25d7bf9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Visualisation de la communication ABT"
    ]
@@ -776,11 +892,12 @@
    "id": "8f9b0b73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T07:11:19.227453Z",
-     "iopub.status.busy": "2026-07-22T07:11:19.226954Z",
-     "iopub.status.idle": "2026-07-22T07:11:23.119791Z",
-     "shell.execute_reply": "2026-07-22T07:11:23.119945Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:29.332430Z",
+     "iopub.status.busy": "2026-09-08T01:30:29.332184Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.138611Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.138505Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -794,7 +911,9 @@
     },
     {
      "data": {
-      "text/plain": []
+      "text/plain": [
+       
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -882,7 +1001,9 @@
   {
    "cell_type": "markdown",
    "id": "5bf6b957",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Interprétation de la visualisation\n",
     "**Graphe de coloration** (image ci-dessus) :\n",
@@ -899,7 +1020,9 @@
   {
    "cell_type": "markdown",
    "id": "93a92599",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 3. Asynchronous Weak-Commitment (AWC)\n",
     "### Limites d'ABT\n",
@@ -922,11 +1045,12 @@
    "id": "347b86d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.044827Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.044616Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.085106Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.085215Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.156673Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.156520Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.206948Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.206833Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -935,18 +1059,10 @@
      "text": [
       "Classe AWCAgent definie (herite de ABTAgent, ajoute AwcRank + promotion).\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,21): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "\n",
     "// === AWCAgent : ABT + reordonnancement dynamique ===\n",
     "\n",
@@ -998,7 +1114,9 @@
   {
    "cell_type": "markdown",
    "id": "b35ae939",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Analyse de l'extension AWC\n",
     "\n",
@@ -1031,7 +1149,9 @@
   {
    "cell_type": "markdown",
    "id": "a572d52f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 4. Privacy-Preserving CSP\n",
     "### Motivation\n",
@@ -1053,11 +1173,12 @@
    "id": "1e4a444d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.086549Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.086337Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.133196Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.132970Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.225425Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.225270Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.302445Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.302295Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1066,22 +1187,10 @@
      "text": [
       "Classes PrivateConstraint et PrivacyPreservingAgent definies.\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,18): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(11,62): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(20,46): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "\n",
     "// === Classes privacy-preserving ===\n",
     "\n",
@@ -1152,7 +1261,9 @@
   {
    "cell_type": "markdown",
    "id": "c72f1676",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Analyse de l'implémentation privacy-preserving\n",
     "\n",
@@ -1181,7 +1292,9 @@
   {
    "cell_type": "markdown",
    "id": "ca7a21c7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 5. Application\n",
     " : Ordonnancement Multi-Hôpital### ProblèmePlusieurs hôpitaux doivent coordonner leurs plannings sans révéler leurs contraintes internes :- **Hôpital A** : Besoins en urgences, préférences secrètes- **Hôpital B** : Spécialités chirurgicales, contraintes confidentielles- **Hôpital C** : Consultations externes, emploi du temps privé### Contraintes inter-hôpitaux- Échanges de personnel (médecins volants)- Transferts de patients- Partage d'équipements spécialisés"
@@ -1193,11 +1306,12 @@
    "id": "c3afe23c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.134732Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.134537Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.189108Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.188950Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.324044Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.323800Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.404050Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.403905Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1326,7 +1440,9 @@
   {
    "cell_type": "markdown",
    "id": "786087d8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Interprétation de l'ordonnancement multi-hôpital\n",
     "**Résultat attendu** : 3 hôpitaux, 5 créneaux, contrainte `slot != other_slot` → chaque hôpital doit recevoir un créneau **distinct**. Le système converge vers une telle allocation.\n",
@@ -1339,7 +1455,9 @@
   {
    "cell_type": "markdown",
    "id": "ad1b753b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 6. Comparaison des algorithmes DisCSP\n",
     "### Benchmark synthétique\n",
@@ -1352,11 +1470,12 @@
    "id": "efbbced8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.190233Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.190057Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.315423Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.315246Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.441733Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.441469Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.589641Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.589731Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1577,7 +1696,9 @@
   {
    "cell_type": "markdown",
    "id": "c2a79964",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Interprétation des résultats du benchmark\n",
     "\n",
@@ -1599,7 +1720,9 @@
   {
    "cell_type": "markdown",
    "id": "b68ce75a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 7. Exemples guidésLes exercices suivants réutilisent les classes `ABTAgent`, `ABTSystem`, `AWCAgent` et `PrivacyPreservingAgent` définies plus haut et les appliquent à des scénarios classiques\n",
     " : N-reines distribué, comparaison ABT/AWC, négociation sous préférences secrètes et mesure de la fuite d'information.### Exemple guide 1 : N-reines distribuéChaque agent contrôle **une colonne** de l'échiquier ; son domaine est `[0, n-1]` (la ligne de sa reine). La contrainte binaire : deux colonnes ne doivent partager ni ligne ni diagonale."
@@ -1611,11 +1734,12 @@
    "id": "03e05d28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.316623Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.316453Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.389098Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.388896Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.610152Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.610015Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.707901Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.707780Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1688,18 +1812,10 @@
      "text": [
       ". . Q . . .\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(12,24): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "\n",
     "// Exemple resolu : N-reines distribuees avec ABT (n=6)\n",
     "\n",
@@ -1770,7 +1886,9 @@
   {
    "cell_type": "markdown",
    "id": "61b24cb8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercice 1b\n",
     " : Coloration de graphe distribuée avec 5 couleurs**Énoncé** : Utilisez `ABTSystem` pour résoudre un problème de colorationde graphe avec **5 noeuds** et **5 couleurs**.Graphe (topologie différente de l'exemple) :- Arêtes : 0-1, 0-2, 1-3, 2-3, 3-4- Domaine : {R, G, B, Y, P} (Rouge, Vert, Bleu, Jaune, Violet)**Consignes** :1. Inspirez-vous de l'exemple de coloration 4-noeuds de l'exemple ci-dessus2. Vérifiez que la solution est valide (pas de conflit sur les arêtes)3. Affichez le nombre total de messages échangés"
@@ -1782,11 +1900,12 @@
    "id": "87c4444d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.390623Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.390361Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.422801Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.422541Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.722734Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.722581Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.749185Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.749065Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1815,7 +1934,9 @@
   {
    "cell_type": "markdown",
    "id": "2c3902fc",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exemple guide 2\n",
     " : Comparaison ABT vs AWCGénérez des instances aléatoires de coloration de graphe avec **densité variable** (fraction d'arêtes présentes) et comparez les métriques ABT vs AWC : nombre total de messages, nogoods échangés, taux de solutions trouvées. L'implémentation AWC du notebook augmente la priorité d'un agent qui accumule les conflits ; on s'attend à un avantage sur les instances denses."
@@ -1827,11 +1948,12 @@
    "id": "1817fd7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.424740Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.424274Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.519565Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.519394Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.765406Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.765220Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.872679Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.872557Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1950,7 +2072,9 @@
   {
    "cell_type": "markdown",
    "id": "9024bb05",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercice 2b\n",
     " : Impact de la densité de contraintes sur ABT**Énoncé** : Étudiez l'impact de la **densité de contraintes** sur les performancesd'ABT. Faites varier la densité et mesurez le nombre de messages.Paramètres :- N agents fixé à 6, domaine fixé à 3 couleurs- Densités à tester : 0.2, 0.4, 0.6, 0.8- 10 instances par densité (moyenne)**Consignes** :1. Utilisez la fonction de génération de graphe de l'exemple2. Tracez un graphique : densité (x) vs nombre de messages (y)3. Analysez : à quelle densité ABT commence-t-il à peiner ?"
@@ -1962,11 +2086,12 @@
    "id": "63fdd7ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.520660Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.520483Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.549504Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.549313Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.887784Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.887637Z",
+     "iopub.status.idle": "2026-09-08T01:30:33.914966Z",
+     "shell.execute_reply": "2026-09-08T01:30:33.914863Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1992,7 +2117,9 @@
   {
    "cell_type": "markdown",
    "id": "d8d1125c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exemple guide 3\n",
     " : Négociation multi-agent4 agents se disputent 5 ressources (créneaux horaires). Chaque agent a une **préférence secrète** (ordre sur les ressources). Contrainte dure : `AllDifferent` -- chaque agent reçoit une ressource distincte. Objectif : mesurer l'**utilité sociale** (somme des préférences) de la solution sans que les agents ne révèlent leur classement à autrui.Le truc : on fait du `PrivacyPreservingAgent` + ordre d'essai des valeurs dicté par les préférences (les agents commencent par essayer leur ressource préférée). Les préférences restent locales à chaque agent (jamais envoyées dans un `ok?` ou `nogood`)."
@@ -2004,11 +2131,12 @@
    "id": "7d329e8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.550891Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.550686Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.641604Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.641697Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:33.930317Z",
+     "iopub.status.busy": "2026-09-08T01:30:33.930165Z",
+     "iopub.status.idle": "2026-09-08T01:30:34.093583Z",
+     "shell.execute_reply": "2026-09-08T01:30:34.093451Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2068,18 +2196,10 @@
       "\n",
       "Bien-etre social : 18 / max theorique 20\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(18,27): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "\n",
     "// Exemple resolu : Negociation multi-agent avec preferences secretes\n",
     "\n",
@@ -2155,7 +2275,9 @@
   {
    "cell_type": "markdown",
    "id": "f225f1c3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercice 3b\n",
     " : Allocation de tâches avec préférences privées**Énoncé** : 5 agents doivent se répartir 8 tâches. Chaque agent a des**préférences secrètes** (score de préférence pour chaque tâche).Contraintes :- AllDifferent (une tâche par agent au plus)- Mais comme il y a 8 tâches et 5 agents, certaines tâches resteront non assignées- Objectif : maximiser l'utilité sociale (somme des utilités des agents)**Consignes** :1. Créez 5 agents avec préférences secrètes (utilisez `NegotiationAgent`)2. Lancez la négociation via `ABTSystem`3. Mesurez le bien-être social et le ratio par rapport au maximum théorique"
@@ -2167,11 +2289,12 @@
    "id": "a1004f12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.642696Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.642532Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.676183Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.676025Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:34.110210Z",
+     "iopub.status.busy": "2026-09-08T01:30:34.110059Z",
+     "iopub.status.idle": "2026-09-08T01:30:34.150940Z",
+     "shell.execute_reply": "2026-09-08T01:30:34.150809Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2200,7 +2323,9 @@
   {
    "cell_type": "markdown",
    "id": "74b477c0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exemple guide 4\n",
     " : Analyse de la fuite d'informationDans ABT, chaque message `ok?` **révèle la valeur** de l'expéditeur à l'agent destinataire. Si le graphe de contraintes n'est pas complet, un agent pourrait apprendre les valeurs d'agents qui ne sont **pas** ses voisins directs. C'est une fuite d'information.L'approche **MinimalDisclosure** corrige partiellement : un agent n'envoie sa valeur qu'aux `lower_priority` qui sont **VOISINS** dans le graphe de contraintes. On compare le nombre total de `ok?` envoyés."
@@ -2212,11 +2337,12 @@
    "id": "0518e56f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.677318Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.677144Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.775308Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.775065Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:34.168661Z",
+     "iopub.status.busy": "2026-09-08T01:30:34.168477Z",
+     "iopub.status.idle": "2026-09-08T01:30:34.266801Z",
+     "shell.execute_reply": "2026-09-08T01:30:34.266678Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2363,7 +2489,9 @@
   {
    "cell_type": "markdown",
    "id": "ab71154d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercice 4b\n",
     " : Étude comparative de la vie privée dans DisCSP**Énoncé** : Comparez 3 niveaux de protection de la vie privée :1. `ABTAgent` (révèle tout à tous les lower-priority)2. `MinimalDisclosureAgent` (révèle seulement aux voisins)3. `PartialDisclosureAgent` (à créer : révèle aux voisins directs + 1 hop)**Consignes** :1. Créez la classe `PartialDisclosureAgent` (entre ABTAgent et MinimalDisclosureAgent)2. Exécutez les 3 approches sur le même problème3. Mesurez et comparez messages, informations révélées, convergence"
@@ -2375,11 +2503,12 @@
    "id": "ccc8f5f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.777181Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.776910Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.860264Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.859892Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:34.284264Z",
+     "iopub.status.busy": "2026-09-08T01:30:34.284105Z",
+     "iopub.status.idle": "2026-09-08T01:30:34.319116Z",
+     "shell.execute_reply": "2026-09-08T01:30:34.318998Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2407,7 +2536,9 @@
   {
    "cell_type": "markdown",
    "id": "8796adb8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "### Papiers fondateurs\n",
@@ -2432,11 +2563,12 @@
    "id": "3a355ecd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:57:22.862668Z",
-     "iopub.status.busy": "2026-07-04T00:57:22.862204Z",
-     "iopub.status.idle": "2026-07-04T00:57:22.957608Z",
-     "shell.execute_reply": "2026-07-04T00:57:22.956736Z"
-    }
+     "iopub.execute_input": "2026-09-08T01:30:34.336858Z",
+     "iopub.status.busy": "2026-09-08T01:30:34.336642Z",
+     "iopub.status.idle": "2026-09-08T01:30:34.370043Z",
+     "shell.execute_reply": "2026-09-08T01:30:34.369936Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2592,7 +2724,9 @@
   {
    "cell_type": "markdown",
    "id": "3bff6eac",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Synthèse et bonnes pratiques\n",
     "\n",
@@ -2626,7 +2760,9 @@
   {
    "cell_type": "markdown",
    "id": "eaad00db",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "Ce notebook a présenté les **contraintes distribuées (DisCSP)**, où plusieurs agents coopèrent sans qu'aucun n'ait une vue d'ensemble.\n",
@@ -2642,37 +2778,6 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".NET (C#)",
-   "language": "C#",
-   "name": ".net-csharp"
-  },
-  "language_info": {
-   "file_extension": ".cs",
-   "mimetype": "text/x-csharp",
-   "name": "C#",
-   "pygments_lexer": "csharp",
-   "version": "13.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-28",
-   "validator": "manual"
-  }
- },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
@@ -2778,6 +2778,37 @@
    ]
   }
  ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-07-28",
+   "validator": "manual"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/scripts/notebook_tools/twin_pairs.d/csp-9-distributed/0005-2026-09-08-myia-po-2027-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-9-distributed/0005-2026-09-08-myia-po-2027-CoursIA.yaml
@@ -1,0 +1,6 @@
+date: '2026-09-08'
+by: myia-po-2027:CoursIA
+python_sha: adee0d476742b82cc2efb931e778f4fba271be35
+csharp_sha: daf186fc05bcbb3c42eac21dcf2415c02d68a7c8
+content_python_sha: 8875c36b493aa80600dda58e11d9742d0fcdcb60328924cc7cd2b8eb992126a3
+content_csharp_sha: 985d98efbc47b4b0e94e506eb04bef54712d5326075fc2aa4e6b4f3b9730b501


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/guard #14959

## Summary

Tranche T5 de #14122 (purge des warnings d'exécution) — **2ᵉ fichier de la classe CS8632** du census de cette classe (taille et plan résiduel détaillés sur l'EPIC #14122) : CSP-9-Distributed-Csharp portait **10 warnings CS8632** en output, répartis sur 6 cellules (agents ABT/AWC de Yokoo 1992, classes privacy-preserving, deux exemples résolus).

**Périmètre effectif : 2 fichiers** — `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb` et l'attestation twin-parity `scripts/notebook_tools/twin_pairs.d/csp-9-distributed/0005-2026-09-08-myia-po-2027-CoursIA.yaml`. Aucun workflow CI touché.

- **Cause racine** : signatures C# modernes et correctes (`Dictionary<,>?`, `TVariable?`) sans contexte nullable actif — même défaut que Sudoku-06 en T4 (#15144).
- **Fix causal** : `#nullable enable` en première ligne des 6 cellules — convention établie du dépôt. **Aucun nouveau warning CS** : l'inventaire passe de `{CS8632: 10, CS1701: 1}` à `{CS1701: 1}` (le CS1701 restant est préexistant, classe déjà traitée en T0 #15134).

## Validation

- Re-exec papermill end-to-end (kernel `.net-csharp`, ~10 s) : **19/19 cellules code**, 0 erreur, séquence CLEAN 1..19.
- **CS8632 : 10 → 0** ; inventaire CS reexec = `{CS1701: 1}` strictement (aucun nouveau warning).
- Diff de sources vérifié programmatiquement : **exactement 6 insertions** `#nullable enable`, aucune autre modification de source (le reste du diff = outputs régénérés par la re-exec, C.2).
- Seule dérive de stream : ligne version **.NET 8.0.28 → 10.0.11** (env d'exécution, valeur fraîche honnête).
- Normalisations sanctionnées : bannière `probeAddresses` strippée (9 lignes, `strip_probe_banner.py`), metadata papermill par-cellule strippée (**convention de la série Search** — l'original n'en porte aucune, contrairement à Sudoku), ligne « Loading extensions » du cache NuGet strippée par le hook pre-commit dédié (classe A kernel-injected).
- Env note : le restore `#r nuget:` exige `DOTNET_ROOT` système (`C:\Program Files\dotnet`) — sous le DOTNET_ROOT utilisateur, le kernel échoue avec `PackageRestoreResult: Must provide errors when succeeded is false` (leçon mémoire déjà consignée).

## Twin parity

Paire `CSP-9 Distributed` : seule la face C# est touchée (la face Python ne porte pas de C#). Attestation `check_twin_parity.py --update --pair "CSP-9 Distributed"` commitée dans la PR (`twin_pairs.d/csp-9-distributed/0005-2026-09-08-myia-po-2027-CoursIA.yaml`).

See #14122 (contribution partielle — tranche T5, 2ᵉ fichier de la classe CS8632 au census de l'EPIC ; l'EPIC reste ouvert).

## Correctif post-rouge (2026-09-08)

- **Quarto** : l'écriture T5 avait laissé le notebook **sans bloc `metadata` top-level** → `Validate Quarto build (PR)` échouait (`TypeError: Cannot read properties of undefined (reading 'kernelspec')`). Bloc restauré **byte-identique à `origin/main`** (kernelspec `.net-csharp`, `language_info`, `cost`) — commit 8b4d3609c544, +31 lignes, aucune cellule touchée (vérifié programmatiquement : seules les 6 cellules T5 divergent de main).
- **Perimeter guard (#11268)** : la notation census « CS8632/23 » était lue comme une assertion de 23 fichiers. Reformulée + périmètre effectif énuméré ci-dessus (2 fichiers).

