### PR TITLE
fix(secrets,#15145): REQUIRED_KEYS rend mesurable l'angle mort clé-absente-de-la-cible

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -32,9 +32,16 @@ MODES
   --strict    exit 1 when a SECRET key declared in SECRET_KEYS is absent
               from master.env (so a CI can distinguish "in sync" from
               "in sync on what I watch" -- a declared key that drifts can
-              only drift if master actually serves it, #14373). Combines
-              with --check. Without --strict, --check stays exit 0 on a
-              declared-but-absent key and only NAMES it.
+              only drift if master actually serves it, #14373), OR when a
+              key declared REQUIRED for a target (REQUIRED_KEYS, #15145)
+              has no line in that target / the target .env is missing on
+              disk. Combines with --check. Without --strict, --check stays
+              exit 0 on a declared-but-absent key and only NAMES it.
+  (#15145) --check also NAMES, per target: master keys with no line in the
+              target ("not provisioned" -- without a REQUIRED_KEYS entry
+              that is indistinguishable from "not needed"), and declared
+              targets missing from disk. sync() APPENDS the missing lines
+              for REQUIRED keys (master-served values only).
   --bootstrap ONE-SHOT: scan existing .env files, extract SECRET values,
               write master.env (first-seen value per key; conflicts
               reported). Use only to initialize master.env from a legacy
@@ -220,6 +227,34 @@ ALIASES: dict[str, str] = {
     "COMFYUI_AUTH_TOKEN": "COMFYUI_API_TOKEN",
 }
 
+# Per-target REQUIRED keys (#15145). sync() only rewrites lines that already
+# EXIST in a target, so a key the target's consumers read -- but that never
+# had a line there -- is invisible to ``--check`` ("[OK]" was exact about
+# what it looked at and false about the question asked: the GenAI/.env
+# VLLM_API_KEY incident served empty Authorization headers -> HTTP 401 while
+# ``--check`` stayed green). A key listed here for a target:
+#   * is APPENDED by sync() when the target exists and master serves it;
+#   * is NAMED by --check, and fails --check --strict (exit 1) when absent.
+# Keys enter this table only when grep-verified against the target's actual
+# consumers; everything else stays indistinguishable from "not needed" and
+# is reported as informational "not provisioned" lines, never silently OK.
+REQUIRED_KEYS: dict[str, frozenset[str]] = {
+    # GenAI notebooks .env: 9 notebooks read os.getenv("VLLM_API_KEY")
+    # against the vLLM endpoint (GenAI/Texte 10/10b/10c, GenAI/_research,
+    # RAG-09, SK-04, Aspire-02 + GameTheory-03c/28b which walk up to the
+    # same file). A missing line = None -> empty bearer -> 401.
+    "MyIA.AI.Notebooks/GenAI/.env": frozenset({"VLLM_API_KEY"}),
+}
+
+
+def env_label(env: Path) -> str:
+    """Repo-relative posix path for reports and REQUIRED_KEYS lookup;
+    absolute posix when the path is outside the repo (hermetic tmp tests)."""
+    try:
+        return env.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return env.as_posix()
+
 
 # --------------------------------------------------------------------------- #
 # dotenv parse / serialize (minimal, dependency-free)
@@ -369,9 +404,18 @@ def sync(check_only: bool, strict: bool = False) -> int:
 
     drift: list[str] = []
     written: list[str] = []
+    absent_targets: list[str] = []
+    not_provisioned: list[str] = []
+    required_gaps: list[str] = []
+    provisioned: list[str] = []
     for env in TARGET_ENVS:
         if not env.exists():
+            # #15145 geste 2 : une cible declaree absente du disque etait
+            # sautee sans un mot -- invisible a --check par construction.
+            absent_targets.append(env_label(env))
             continue
+        label = env_label(env)
+        target_keys = set(read_env(env).keys())
         original = env.read_text(encoding="utf-8").splitlines()
         changed = False
         out_lines: list[str] = []
@@ -389,9 +433,63 @@ def sync(check_only: bool, strict: bool = False) -> int:
                     out_lines.append(line)
             else:
                 out_lines.append(line)
+        # #15145 geste 1 : nommer les cles du master sans ligne ici. Sans
+        # REQUIRED_KEYS, "cette cible n'en a pas besoin" et "elle aurait du
+        # la recevoir" rendent la meme sortie -- c'est l'indiscernabilite
+        # qui etait le defaut, pas un chiffre.
+        gap = sorted(k for k in master
+                     if k not in target_keys and ALIASES.get(k, k) not in target_keys)
+        if gap:
+            not_provisioned.append(
+                f"  {label}: {len(gap)} master key(s) have no line here "
+                f"(not provisioned): {gap}")
+        # #15145 geste 3 : les cles DECLAREES requisent deviennent mesurables.
+        required = REQUIRED_KEYS.get(label)
+        if required:
+            missing_req = sorted(k for k in required
+                                 if k not in target_keys
+                                 and ALIASES.get(k, k) not in target_keys)
+            if missing_req:
+                if check_only:
+                    required_gaps.append(
+                        f"  {label}: REQUIRED key(s) with no line: {missing_req}")
+                else:
+                    out_lines.append("# provisioned by render_envs.py -- declared "
+                                     "REQUIRED key (cf #15145)")
+                    for k in missing_req:
+                        if k in master:
+                            out_lines.append(f"{k}={master[k]}")
+                            provisioned.append(f"  {label}: {k} {mask(master[k])}")
+                            changed = True
+                        else:
+                            required_gaps.append(
+                                f"  {label}: REQUIRED key {k} absent from "
+                                f"master.env (cannot provision)")
         if changed and not check_only:
             env.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
             written.append(env.parent.name)
+
+    if absent_targets:
+        for lbl in absent_targets:
+            req = REQUIRED_KEYS.get(lbl)
+            if req:
+                required_gaps.append(
+                    f"  {lbl}: .env missing on disk -- REQUIRED key(s) "
+                    f"{sorted(req)} invisible to --check")
+        print(f"[!] {len(absent_targets)} declared target .env missing on disk "
+              f"(skipped, invisible to drift comparison): {absent_targets}")
+    if not_provisioned:
+        print(f"[i] {len(not_provisioned)} target(s) carry master key(s) with no "
+              f"line -- not provisioned (indistinguishable from 'not needed' "
+              f"absent a REQUIRED_KEYS entry, cf #15145):")
+        for r in not_provisioned:
+            print(r)
+    if required_gaps:
+        print(f"[!] {len(required_gaps)} REQUIRED-key gap(s) "
+              f"(fix: run sync without --check; keys absent from master.env "
+              f"need a master.env edit):")
+        for g in required_gaps:
+            print(g)
 
     if drift:
         if check_only:
@@ -406,15 +504,21 @@ def sync(check_only: bool, strict: bool = False) -> int:
         print("\n[i] Restart impacted containers (ComfyUI-Login hashes regen at restart).")
         return 0
 
+    if provisioned:
+        print(f"[+] Provisioned {len(provisioned)} REQUIRED key line(s):")
+        for p in provisioned:
+            print(p)
+
+    on_disk = len(TARGET_ENVS) - len(absent_targets)
     if missing_in_master:
-        print(f"[OK] All {len(TARGET_ENVS)} target .env in sync with master.env "
-              f"within the {propagated} propagated key(s). "
+        print(f"[OK] {on_disk}/{len(TARGET_ENVS)} target .env on disk, in sync "
+              f"with master.env within the {propagated} propagated key(s). "
               f"{len(missing_in_master)} declared secret key(s) are OUT OF SCOPE "
               f"(absent from master.env): {sorted(missing_in_master)}.")
     else:
-        print(f"[OK] All {len(TARGET_ENVS)} target .env in sync with master.env "
-              f"({len(master)} secret keys). No drift.")
-    if strict and missing_in_master:
+        print(f"[OK] {on_disk}/{len(TARGET_ENVS)} target .env on disk, in sync "
+              f"with master.env ({len(master)} secret keys). No drift.")
+    if strict and (missing_in_master or required_gaps):
         return 1
     return 0
 
@@ -554,7 +658,9 @@ def main() -> int:
                            "--check blind spot, cf #9351)")
     p.add_argument("--strict", action="store_true",
                    help="exit 1 if a declared SECRET key is absent from "
-                        "master.env (CI gate, #14373)")
+                        "master.env (CI gate, #14373), or a REQUIRED key "
+                        "has no line in its target / the target .env is "
+                        "missing on disk (#15145)")
     args = p.parse_args()
     if args.bootstrap:
         return bootstrap()

--- a/scripts/secrets/tests/test_render_envs.py
+++ b/scripts/secrets/tests/test_render_envs.py
@@ -353,6 +353,22 @@ class TestConstants:
             "COMFYUI_AUTH_TOKEN": "COMFYUI_API_TOKEN",
         }
 
+    def test_required_keys_declared_secrets_and_real_labels(self):
+        """#15145 invariantes de la table REQUIRED_KEYS : chaque clé est un
+        SECRET déclaré (ou un alias déclaré) et chaque label correspond à une
+        entrée réelle de TARGET_ENVS -- un label typo n'aurait jamais matché
+        aucune cible et la garde serait morte-née (silencieusement OK)."""
+        for keys in render_envs.REQUIRED_KEYS.values():
+            for k in keys:
+                assert k in render_envs.SECRET_KEYS or k in render_envs.ALIASES, (
+                    f"REQUIRED key {k} is neither a SECRET_KEY nor an alias"
+                )
+        target_labels = {render_envs.env_label(p) for p in render_envs.TARGET_ENVS}
+        for lbl in render_envs.REQUIRED_KEYS:
+            assert lbl in target_labels, (
+                f"REQUIRED_KEYS label {lbl} matches no TARGET_ENVS entry"
+            )
+
 
 # --------------------------------------------------------------------------- #
 # bootstrap: state machine (monkeypatch MASTER_ENV + TARGET_ENVS)
@@ -958,3 +974,187 @@ class TestNotebookTargetEnvs:
         assert "OPENAI_API_KEY=canonical-oai" in text
         assert "SK_VERSION=1.45.0" in text, "non-secret key was wrongly clobbered"
         assert "NOTEBOOK_LOCALE=fr-FR" in text, "non-secret key was wrongly clobbered"
+
+
+# --------------------------------------------------------------------------- #
+# #15145 — REQUIRED_KEYS : une clé du master ABSENTE d'une cible n'était
+# jamais ajoutée, et --check rendait [OK] (aucune ligne à comparer). La
+# table rend l'absence mesurable : sync() appends, --check names,
+# --check --strict exit 1. + geste 1 (nommer les non-provisioned) et
+# geste 2 (nommer les cibles absentes du disque).
+# --------------------------------------------------------------------------- #
+class TestRequiredKeys15145:
+    def _setup(self, tmp_path, monkeypatch, master_text, env_files):
+        """tmp tree à la TestSync._setup ; REQUIRED_KEYS est patchée par le
+        test (labels = chemins posix absolus, hors REPO_ROOT)."""
+        master = tmp_path / "master.env"
+        master.write_text(master_text, encoding="utf-8")
+        monkeypatch.setattr(render_envs, "MASTER_ENV", master)
+        targets = []
+        for name, body in env_files:
+            p = _svc_env(tmp_path, name)
+            p.write_text(body, encoding="utf-8")
+            targets.append(p)
+        monkeypatch.setattr(render_envs, "TARGET_ENVS", targets)
+        return targets
+
+    def test_check_names_required_gap_exit0(self, tmp_path, monkeypatch, capsys):
+        """Geste 3, mode découverte : sans --strict, --check NOMME la clé
+        requise manquante et reste 0 (miroir de #14373 geste 1)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\nVLLM_API_KEY=vvv-secret-1234\n",
+            [("genai", "HF_TOKEN=stable\n")],
+        )
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"VLLM_API_KEY"})})
+        assert render_envs.sync(check_only=True) == 0
+        out = capsys.readouterr().out
+        assert "REQUIRED key(s) with no line" in out
+        assert "VLLM_API_KEY" in out
+        # Aucune écriture en mode check.
+        assert "VLLM_API_KEY" not in targets[0].read_text(encoding="utf-8")
+
+    def test_check_strict_required_gap_exit1(self, tmp_path, monkeypatch):
+        """Geste 3, mode garde : --check --strict sort 1 sur une clé requise
+        non provisionnée, SANS le moindre drift -- le vert ne couvrait que
+        les lignes existantes (contrôle FP de l'issue : le 401 silencieux
+        de l'incident GenAI/.env)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\nVLLM_API_KEY=vvv\n",
+            [("genai", "HF_TOKEN=stable\n")],
+        )
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"VLLM_API_KEY"})})
+        assert render_envs.sync(check_only=True, strict=True) == 1
+
+    def test_sync_appends_required_line_masked(self, tmp_path, monkeypatch, capsys):
+        """sync() APPEND la ligne manquante (valeur master) ; la sortie masque
+        la valeur (last-4), le fichier la porte en clair."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\nVLLM_API_KEY=vvv-secret-1234\n",
+            [("genai", "HF_TOKEN=stable\nCUSTOM_PORT=7\n")],
+        )
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"VLLM_API_KEY"})})
+        assert render_envs.sync(check_only=False) == 0
+        text = targets[0].read_text(encoding="utf-8")
+        assert "VLLM_API_KEY=vvv-secret-1234" in text
+        assert "CUSTOM_PORT=7" in text, "config locale clobbered"
+        out = capsys.readouterr().out
+        assert "vvv-secret-1234" not in out, "secret complet leaké en sortie"
+        assert "***1234" in out
+
+    def test_sync_required_idempotent(self, tmp_path, monkeypatch, capsys):
+        """Second run : no-op (la ligne existe désormais), plus de
+        '[+] Provisioned'."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "VLLM_API_KEY=vvv\n",
+            [("genai", "HF_TOKEN=stable\n")],
+        )
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"VLLM_API_KEY"})})
+        assert render_envs.sync(check_only=False) == 0
+        first = targets[0].read_text(encoding="utf-8")
+        capsys.readouterr()
+        assert render_envs.sync(check_only=False) == 0
+        assert targets[0].read_text(encoding="utf-8") == first
+        assert "[+] Provisioned" not in capsys.readouterr().out
+
+    def test_required_key_absent_from_master_named_strict1(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Clé requise absente du master : nommée (cannot provision), rien
+        d'écrit, --strict sort 1. SECRET_KEYS patchée pour isoler la voie
+        REQUIRED de la voie #14373 (missing_in_master)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\n",
+            [("genai", "HF_TOKEN=stable\n")],
+        )
+        monkeypatch.setattr(render_envs, "SECRET_KEYS", frozenset({"HF_TOKEN"}))
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"VLLM_API_KEY"})})
+        assert render_envs.sync(check_only=False, strict=True) == 1
+        out = capsys.readouterr().out
+        assert "absent from master.env" in out
+        assert "VLLM_API_KEY" not in targets[0].read_text(encoding="utf-8")
+
+    def test_alias_counts_as_provisioned(self, tmp_path, monkeypatch):
+        """Une cible portant le nom CANONIQUE satisfait une exigence posée sur
+        l'ALIAS (ALIASES = un secret logique sous deux noms). SECRET_KEYS
+        patchée pour isoler la voie alias de la voie #14373 (missing_in_master
+        sur les ~27 clés réelles absentes de ce master minimal)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "COMFYUI_API_TOKEN=tok\n",
+            [("nb", "COMFYUI_API_TOKEN=tok\n")],
+        )
+        monkeypatch.setattr(render_envs, "SECRET_KEYS",
+                            frozenset({"COMFYUI_API_TOKEN"}))
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"COMFYUI_AUTH_TOKEN"})})
+        assert render_envs.sync(check_only=True, strict=True) == 0
+
+    def test_absent_target_named_not_silent(self, tmp_path, monkeypatch, capsys):
+        """Geste 2 : une cible déclarée absente du disque est NOMMÉE (exit 0
+        sans --strict), et son compte n'entre plus dans le [OK] 'All N'."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\n",
+            [("svc", "HF_TOKEN=stable\n")],
+        )
+        absent = tmp_path / "nope" / ".env"  # déclaré, jamais créé
+        monkeypatch.setattr(render_envs, "TARGET_ENVS", targets + [absent])
+        assert render_envs.sync(check_only=True) == 0
+        out = capsys.readouterr().out
+        assert "missing on disk" in out
+        assert "nope/.env" in out
+        assert "[OK] 1/2 target .env on disk" in out
+
+    def test_absent_required_target_strict_exit1(self, tmp_path, monkeypatch):
+        """Cible requise absente du disque : invisible à --check par
+        construction -> --strict la fait échouer (sinon GenAI/.env supprimé
+        repasserait vert)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\nVLLM_API_KEY=vvv\n",
+            [("svc", "HF_TOKEN=stable\n")],
+        )
+        absent = tmp_path / "nope" / ".env"
+        monkeypatch.setattr(render_envs, "TARGET_ENVS", targets + [absent])
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {absent.as_posix(): frozenset({"VLLM_API_KEY"})})
+        assert render_envs.sync(check_only=True, strict=True) == 1
+
+    def test_not_provisioned_master_keys_named(self, tmp_path, monkeypatch, capsys):
+        """Geste 1 : les clés du master SANS ligne dans la cible sont nommées
+        en [i] (indiscernables de 'pas besoin' sans REQUIRED_KEYS)."""
+        self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=a\nWHISPER_API_KEY=b\n",
+            [("svc", "HF_TOKEN=a\n")],
+        )
+        assert render_envs.sync(check_only=True) == 0
+        out = capsys.readouterr().out
+        assert "not provisioned" in out
+        assert "WHISPER_API_KEY" in out
+
+    def test_main_check_strict_routes_required_gap(
+        self, tmp_path, monkeypatch
+    ):
+        """Le CLI route --check --strict vers la voie REQUIRED (cf
+        test_strict_flag_routes_to_sync_strict pour la voie #14373)."""
+        targets = self._setup(
+            tmp_path, monkeypatch,
+            "HF_TOKEN=stable\nVLLM_API_KEY=vvv\n",
+            [("genai", "HF_TOKEN=stable\n")],
+        )
+        monkeypatch.setattr(render_envs, "REQUIRED_KEYS",
+                            {targets[0].as_posix(): frozenset({"VLLM_API_KEY"})})
+        monkeypatch.setattr(sys, "argv",
+                            ["render_envs.py", "--check", "--strict"])
+        assert render_envs.main() == 1


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #15092

## Le défaut (#15145)

`sync()` ne réécrivait que les lignes déjà présentes dans une cible : une clé du master **sans ligne** dans la cible n'était jamais ajoutée, et `--check` rendait `[OK]` — aucune ligne à comparer. Incident observé : `GenAI/.env` sans `VLLM_API_KEY` → en-tête `Authorization` vide → HTTP 401 sur vLLM, relayé comme bloqueur user alors qu'il n'y en avait pas. Trois trous : absence jamais ajoutée (1), cibles déclarées absentes du disque sautées sans un mot (2), aucune déclaration du besoin par cible — 278 couples indiscernables (3).

## Les trois gestes

1. **Nommer l'angle mort** : `--check` imprime par cible les clés du master sans ligne (`[i] ... N master key(s) have no line here (not provisioned): [...]`). Le lecteur cesse de croire que `[OK]` répond « chaque consommateur a ses clés ».
2. **Cibles absentes du disque nommées** au lieu du `continue` muet (`[!] ... missing on disk (skipped, invisible to drift comparison)`), et le `[OK]` compte honnêtement `présentes/total` au lieu d'un « All N » incluant des fichiers qui n'existent pas.
3. **`REQUIRED_KEYS`** (`dict[label, frozenset]`, labels = chemins posix relatifs au repo) : une clé déclarée requise est **appendée par sync()** (valeur master uniquement ; masquée dans la sortie), **nommée par --check**, et **fait échouer `--check --strict`** quand elle manque — y compris quand la cible elle-même manque du disque. Une clé requise absente du master est nommée « cannot provision » (rien n'est inventé). Alias couverts : une cible portant le nom canonique satisfait une exigence posée sur l'alias.

### Entrée incident (grep-vérifiée)

`MyIA.AI.Notebooks/GenAI/.env` → `VLLM_API_KEY`. Consommateurs vérifiés sur `origin/main` (`git grep -l VLLM_API_KEY -- *.ipynb`) : 9 notebooks — GenAI/Texte 10/10b/10c, GenAI/_research/e2e_quant_validation, RAG-et-Memoire-Semantique/09, GenAI/SemanticKernel/04, GenAI/Integrations-DotNet/Aspire/02, GameTheory-03c + GameTheory-28b (ces deux derniers remontent `current_path` jusqu'au premier `.env` = `GenAI/.env`). L'entrée du commit d'incident (`2d3401c34` = PR #15097) n'est pas en cause : le trou préexistait.

## Preuve live (read-only, arbre réel po-2026, valeurs masquées)

`sync(check_only=True)` contre le checkout réel via driver re-raciné (aucune écriture) :

```
[!] 4 declared target .env missing on disk (skipped, invisible...): [Portfolio-IBKR..., Track2-GoogleADK, SemanticKernel, SymbolicLearning]
[i] 4 target(s) carry master key(s) with no line -- not provisioned...:
  MyIA.AI.Notebooks/GenAI/.env: 1 master key(s) ... ['MISTRAL_API_KEY']
  ...
[!] 1 REQUIRED-key gap(s) ...:
  MyIA.AI.Notebooks/GenAI/.env: REQUIRED key(s) with no line: ['VLLM_API_KEY']
[X] DRIFT detected (4 key(s) differ from master): ...   <- drift PREEXISTANT, detection inchangée
```

**L'incident se reproduit sur cette machine à l'instant** : `GenAI/.env` local n'a pas de ligne `VLLM_API_KEY` (cohérent avec les 401 vLLM du dashboard). Le master local ne sert pas cette clé (elle est dans les « absent from master ») → un `sync` ici nommerait « cannot provision » — le geste local (reprofiler le master, comme fait sur ai-01) appartient à l'ops machine, pas au mécanisme.

## Tests

11 ajoutés (`TestRequiredKeys15145` + invariant `TestConstants`) : nommage exit 0 / strict exit 1 sans drift, append + masque de la valeur, idempotence, clé requise absente du master (rien écrit, nommée, strict 1), satisfaction par alias, cible absente nommée + `[OK] 1/2` + strict 1, `[i]` not-provisioned, routage CLI `--check --strict`, invariants de table (clés ⊆ SECRET_KEYS ∪ ALIASES ; labels ⊆ labels TARGET_ENVS — un label typo serait une garde morte-née). Suite : **144 passed / 15 skipped** (skips docker préexistants). Aucun notebook touché ; catalogue byte-identique à main.

## Périmètre laissé ouvert (décision, pas fix mécanique)

Remplir `REQUIRED_KEYS` pour les 15 autres cibles = décider quelles clés chaque consommateur doit porter — la décision de périmètre que l'issue laisse au propriétaire de la flotte. Candidat documenté pour la prochaine entrée : `SymbolicAI/Lean/.env` (le commentaire TARGET_ENVS déclare déjà MISTRAL_API_KEY + ANTHROPIC_API_KEY comme centralisées, `agent_tests/prover/config.py` charge le fichier). Le mécanisme est prêt ; chaque entrée supplémentaire est data-only.

See #15145

