### PR TITLE
feat(genai,#15099): probe A — banc fixe + harnais de duel MiniCPM5-2B vs Qwen3-4B, verdict REFUSE

### DIFF
--- a/scripts/genai-stack/probe_15099_bench.json
+++ b/scripts/genai-stack/probe_15099_bench.json
@@ -1,0 +1,595 @@
+{
+ "meta": {
+  "issue": 15099,
+  "probe": "A",
+  "version": 1,
+  "description": "Banc fixe du duel MiniCPM5-2B vs Qwen3-4B (probe A, issue #15099). 70 prompts en 3 axes : 30 Q&A pedagogiques FR, 20 math, 20 code-gen. Deterministe : meme bench, meme sampling (temperature=1.0, top_p=0.95, seed fixe par item), GPU identique. Le correcteur tiers ne voit JAMAIS le nom du modele evalue (anti-biais).",
+  "parity_rule": "Parite sur un axe = score moyen MiniCPM >= 0.95 x score moyen Qwen sur cet axe. Acceptance (issue) : parite sur >= 2 axes/3, OU parite globale (>= 0.95 x sur les 70 items) avec win >= 30 % sur VRAM peak OU tokens/s."
+ },
+ "sampling": {
+  "temperature": 1.0,
+  "top_p": 0.95,
+  "max_tokens": {
+   "qa": 512,
+   "math": 640,
+   "code": 768
+  },
+  "seed": 15099
+ },
+ "qa": [
+  {
+   "id": "qa01",
+   "q": "Explique en trois phrases ce qu'est la tokenisation et pourquoi un meme mot peut etre coupe differemment selon la langue.",
+   "keys": [
+    "decoupage en unites (tokens/bpe/sous-mots)",
+    "vocabulaire fini/statistique",
+    "dependance a la langue/au corpus d'entrainement"
+   ]
+  },
+  {
+   "id": "qa02",
+   "q": "Quelle est la difference entre temperature et top_p dans l'echantillonnage d'un LLM ? Donne un exemple d'effet concret de chacun.",
+   "keys": [
+    "temperature = aplatissement/durcissement de la distribution",
+    "top_p = troncature du noyau cumulatif",
+    "effet creativite vs determinisme"
+   ]
+  },
+  {
+   "id": "qa03",
+   "q": "Pourquoi le RAG reduit-il les hallucinations par rapport a un simple prompt long ? Deux mecanismes suffisent.",
+   "keys": [
+    "ancrage dans des documents retires/verifiables",
+    "separation connaissances parametrique vs contextuelle",
+    "citation/traçabilite possible"
+   ]
+  },
+  {
+   "id": "qa04",
+   "q": "Explique la difference entre un embedding de phrase et une representation cachee d'un transformer (hidden state).",
+   "keys": [
+    "embedding = projection finale dediee a la similarite (ex. mean pooling normalise)",
+    "hidden state = activiation interne dependante de la couche",
+    "objectifs/applications differents (recherche vs analyse interne)"
+   ]
+  },
+  {
+   "id": "qa05",
+   "q": "Qu'est-ce que le context window d'un LLM et que se passe-t-il quand on depasse sa longueur maximale ?",
+   "keys": [
+    "nombre max de tokens traites (entree+sortie selon convention)",
+    "troncature ou erreur selon l'implementation",
+    "pas de memoire au-dela"
+   ]
+  },
+  {
+   "id": "qa06",
+   "q": "Explique en francais ce qu'est le quantization d'un modele (INT8/INT4) et son compromis principal.",
+   "keys": [
+    "reduction de la precision numerique des poids",
+    "gain memoire/latence",
+    "perte potentielle de qualite"
+   ]
+  },
+  {
+   "id": "qa07",
+   "q": "Quelle est la difference entre fine-tuning complet, LoRA et le prompting ? Une phrase chacun.",
+   "keys": [
+    "complet : tous les poids modifies, couteux",
+    "LoRA : petits rangs injectes, poids bases gels",
+    "prompting : aucun poids modifie"
+   ]
+  },
+  {
+   "id": "qa08",
+   "q": "Pourquoi un modele de langue predit-il un token a la fois et comment produit-il des phrases longues ?",
+   "keys": [
+    "distribution de probabilite sur le vocabulaire a chaque pas",
+    "boucle autoregressive (le token emis rejoint l'entree)",
+    "arret sur token special/limite"
+   ]
+  },
+  {
+   "id": "qa09",
+   "q": "Explique ce qu'est une attention head et pourquoi le mecanisme est dit 'multi-head'.",
+   "keys": [
+    "projection QKV + score d'attention pondere",
+    "plusieurs tetes = sous-espaces de relations differents",
+    "parallelisme des têtes concatenees"
+   ]
+  },
+  {
+   "id": "qa10",
+   "q": "Qu'est-ce que le cache KV et pourquoi accelere-t-il la generation ?",
+   "keys": [
+    "memorisation des cles/valeurs des tokens passes",
+    "evite le recalcul des couches pour le prefixe",
+    "gain quadratique->lineaire sur le passe"
+   ]
+  },
+  {
+   "id": "qa11",
+   "q": "Donne deux differences entre une API de chat-completion et une API de completion brute (text completion).",
+   "keys": [
+    "structure de messages/roles vs texte libre",
+    "template de chat applique cote serveur",
+    "gestion du contexte systeme"
+   ]
+  },
+  {
+   "id": "qa12",
+   "q": "Explique la difference entre zero-shot, one-shot et few-shot avec un exemple de tache de classification.",
+   "keys": [
+    "nombre d'exemples dans le prompt",
+    "le motif attendu est imite",
+    "plus d'exemples = contrainte plus forte mais prompt plus long"
+   ]
+  },
+  {
+   "id": "qa13",
+   "q": "Qu'est-ce qu'un system prompt et en quoi differe-t-il d'un user prompt dans une conversation ?",
+   "keys": [
+    "instruction cadre persistante",
+    "priorite/ton/format imposes",
+    "place en tete de la conversation"
+   ]
+  },
+  {
+   "id": "qa14",
+   "q": "Explique pourquoi la similarite cosinus est preferee au produit scalaire brut pour comparer des embeddings.",
+   "keys": [
+    "normalisation par les normes",
+    "independant de la magnitude/norme du vecteur",
+    "mesure d'orientation (semantique)"
+   ]
+  },
+  {
+   "id": "qa15",
+   "q": "Qu'est-ce que le mode 'thinking'/'raisonnement' d'un modele comme Qwen3 et quel est son cout ?",
+   "keys": [
+    "generation de raisonnement intermediaire avant la reponse",
+    "ameliore les taches multi-etapes",
+    "consomme des tokens/sortie supplementaires (latence+cout)"
+   ]
+  },
+  {
+   "id": "qa16",
+   "q": "Explique la difference entre un agent LLM et une simple chaine d'appels d'API scriptee.",
+   "keys": [
+    "boucle de decision (le modele choisit l'action suivante)",
+    "outils disponibles exposes au modele",
+    "arret/condition determines par le modele ou l'etat"
+   ]
+  },
+  {
+   "id": "qa17",
+   "q": "Qu'est-ce qu'un stop sequence et pourquoi en specifier une lors d'une generation batch ?",
+   "keys": [
+    "chaine qui termine la generation",
+    "evite le gaspillage de tokens apres la reponse utile",
+    "determinisme du decoupage"
+   ]
+  },
+  {
+   "id": "qa18",
+   "q": "Explique la notion de temperature=0 : est-ce une garantie de determinisme absolu ? Pourquoi ?",
+   "keys": [
+    "argmax (distribution degenerée)",
+    "pas de garantie absolue (arithmetique flottante, batching, materiel)",
+    "determinisme pratique, pas theorique"
+   ]
+  },
+  {
+   "id": "qa19",
+   "q": "Quelle est la difference entre perplexite et accuracy pour evaluer un modele de langue ?",
+   "keys": [
+    "perplexite = mesure continue sur la distribution (exp de la loss)",
+    "accuracy = mesure discretaire de tache",
+    "perplexite sans reference de tache, accuracy depend du benchmark"
+   ]
+  },
+  {
+   "id": "qa20",
+   "q": "Explique ce qu'est une attaque par injection de prompt dans un systeme RAG et donne une parade.",
+   "keys": [
+    "contenu hostile dans les documents recuperes",
+    "le modele execute une instruction cachee",
+    "parade : isolation/delimitation des sources, filtrage, schema de sortie contraint"
+   ]
+  },
+  {
+   "id": "qa21",
+   "q": "Pourquoi les modeles ont-ils une limite de sortie (max_tokens) distincte de la limite de contexte ?",
+   "keys": [
+    "entree vs sortie budgetees separement",
+    "controle du cout/latence",
+    "la sortie consomme la fenetre restante"
+   ]
+  },
+  {
+   "id": "qa22",
+   "q": "Explique la difference entre un tokenizer BPE et un tokenizer au niveau mot, avec un avantage du BPE.",
+   "keys": [
+    "BPE fusionne des sous-mots appris par frequence",
+    "niveau mot : vocabulaire enorme et mots inconnus (OOV)",
+    "BPE compresse mieux et gere les mots rares"
+   ]
+  },
+  {
+   "id": "qa23",
+   "q": "Qu'est-ce que le batching dans un serveur d'inference et pourquoi ameliore-t-il le debit sans forcement degrader la latence ?",
+   "keys": [
+    "plusieurs requetes traitees ensemble",
+    "saturation des GPU (operations paralleles)",
+    "decoupage continu/ordonnancement (continuous batching)"
+   ]
+  },
+  {
+   "id": "qa24",
+   "q": "Explique ce qu'est le distillation de modeles et son interet pedagogique-industriel.",
+   "keys": [
+    "un modele eleve (teacher) genere des cibles pour un eleve",
+    "l'eleve apprend des distributions, pas seulement des etiquettes",
+    "compression avec retention partielle des performances"
+   ]
+  },
+  {
+   "id": "qa25",
+   "q": "Quelle est la difference entre un modele de base (base) et un modele ajuste par instructions (instruct/chat) ?",
+   "keys": [
+    "base = continuation de texte brut",
+    "instruct = ajuste sur des dialogues/instructions",
+    "usage et formatage d'appel differents"
+   ]
+  },
+  {
+   "id": "qa26",
+   "q": "Explique pourquoi on normalise souvent les textes (minuscules, accents) avant une comparaison lexicale, et pourquoi ce n'est PAS necessaire avant un embedding neural.",
+   "keys": [
+    "comparaison lexicale = correspondance exacte de chaines",
+    "embedding capte la semantique au-dela de la casse",
+    "normalisation destructive peut meme nuire"
+   ]
+  },
+  {
+   "id": "qa27",
+   "q": "Qu'est-ce qu'un function call / tool call dans une API de LLM et comment la reponse est-elle structuree ?",
+   "keys": [
+    "declaration d'outils avec schema",
+    "le modele emet un appel structure (nom+arguments JSON)",
+    "le resultat est reinjecte pour un tour suivant"
+   ]
+  },
+  {
+   "id": "qa28",
+   "q": "Explique le compromis entre une fenetre de contexte longue et la qualite d'attention au milieu du contexte ('lost in the middle').",
+   "keys": [
+    "attention degrades au milieu des longs contextes",
+    "l'information en debut/fin est mieux retiree",
+    "longueur != comprehension uniforme"
+   ]
+  },
+  {
+   "id": "qa29",
+   "q": "Pourquoi un serveur vLLM est-il plus rapide qu'une boucle transformers.generate locale pour beaucoup de requetes ?",
+   "keys": [
+    "pagedattention/gestion memoire du cache KV efficace",
+    "continuous batching serveur",
+    "optimisations noyau/compilation"
+   ]
+  },
+  {
+   "id": "qa30",
+   "q": "Explique ce qu'est un benchmark LLM 'contamine' et comment un protocole propre l'evite.",
+   "keys": [
+    "les donnees de test ont ete vues a l'entrainement",
+    "scores gonfles sans capacite reelle",
+    "jeux de test prives/recents/renaissances (nouveaux items)"
+   ]
+  }
+ ],
+ "math": [
+  {
+   "id": "m01",
+   "q": "Un magasin applique une remise de 15 pourcent sur un article a 80 euros, puis une remise supplementaire de 10 pourcent sur le prix remise. Quel est le prix final en euros ?",
+   "golden": "61.20"
+  },
+  {
+   "id": "m02",
+   "q": "Calcule 7/8 + 3/4 et donne le resultat sous forme de fraction irreductible.",
+   "golden": "13/8"
+  },
+  {
+   "id": "m03",
+   "q": "Un train roule a 120 km/h. Combien de secondes met-il pour parcourir 500 metres ?",
+   "golden": "15"
+  },
+  {
+   "id": "m04",
+   "q": "Resous l'equation 3x - 7 = 2x + 5. Donne la valeur de x.",
+   "golden": "12"
+  },
+  {
+   "id": "m05",
+   "q": "Quel est le reste de la division de 7^3 par 13 ?",
+   "golden": "5"
+  },
+  {
+   "id": "m06",
+   "q": "Une classe de 28 eleves a une moyenne de 12/20. Si on retire les 3 meilleurs (moyenne 18), quelle est la moyenne des 25 restants ? Arrondis au centieme.",
+   "golden": "11.28"
+  },
+  {
+   "id": "m07",
+   "q": "Combien y a-t-il de multiples de 3 ou de 5 strictement inferieurs a 50 ?",
+   "golden": "23"
+  },
+  {
+   "id": "m08",
+   "q": "Un capital de 1000 euros est place a interets composes de 2 pourcent par an. Quel est le montant apres 3 ans, arrondi au centieme ?",
+   "golden": "1061.21"
+  },
+  {
+   "id": "m09",
+   "q": "Resous le systeme : 2x + y = 10 et x - y = 2. Donne x puis y.",
+   "golden": "x=4, y=2"
+  },
+  {
+   "id": "m10",
+   "q": "Quelle est la somme des 20 premiers entiers pairs strictement positifs (2+4+...+40) ?",
+   "golden": "420"
+  },
+  {
+   "id": "m11",
+   "q": "Une recette pour 4 personnes demande 300 g de farine. Combien pour 7 personnes, en grammes ?",
+   "golden": "525"
+  },
+  {
+   "id": "m12",
+   "q": "Si je lance deux des a six faces, quelle est la probabilite (fraction irreductible) que la somme fasse 7 ?",
+   "golden": "1/6"
+  },
+  {
+   "id": "m13",
+   "q": "Le perimetre d'un rectangle est 34 cm et sa longueur vaut le double de sa largeur. Quelle est son aire en cm2 ?",
+   "golden": "72"
+  },
+  {
+   "id": "m14",
+   "q": "Combien de zeros y a-t-il a la fin de 25 factoriel (25!) ?",
+   "golden": "6"
+  },
+  {
+   "id": "m15",
+   "q": "Un prix augmente de 20 pourcent puis baisse de 20 pourcent. Quelle est la variation totale en pourcent ?",
+   "golden": "-4 pourcent"
+  },
+  {
+   "id": "m16",
+   "q": "Resous : log2(x) = 5. Donne x.",
+   "golden": "32"
+  },
+  {
+   "id": "m17",
+   "q": "Dans un triangle rectangle, les cotes de l'angle droit mesurent 9 et 12. Quelle est la longueur de l'hypotenuse ?",
+   "golden": "15"
+  },
+  {
+   "id": "m18",
+   "q": "Trois machines font un travail en 6, 3 et 2 heures respectivement. Combien d'heures faut-il si elles travaillent ensemble ? Donne la fraction irreductible.",
+   "golden": "1"
+  },
+  {
+   "id": "m19",
+   "q": "Quelle est la moyenne des nombres premiers strictement compris entre 10 et 30 ?",
+   "golden": "20"
+  },
+  {
+   "id": "m20",
+   "q": "Une suite arithmetique commence a 7 avec une raison de 4. Quel est le 15e terme ?",
+   "golden": "63"
+  }
+ ],
+ "code": [
+  {
+   "id": "c01",
+   "q": "Ecris une fonction Python est_palindrome(s) qui renvoie True si la chaine s est un palindrome, en ignorant la casse et les caracteres non alphanumeriques. Donne uniquement le code.",
+   "golden": "def est_palindrome(s): t = [c.lower() for c in s if c.isalnum()]; return t == t[::-1]",
+   "tests": [
+    "est_palindrome('Esope reste ici et se repose') == True",
+    "est_palindrome('Bonjour') == False",
+    "est_palindrome('') == True"
+   ]
+  },
+  {
+   "id": "c02",
+   "q": "Ecris une fonction Python fizzbuzz(n) qui renvoie la liste des chaines pour 1..n selon les regles FizzBuzz classiques. Donne uniquement le code.",
+   "golden": "def fizzbuzz(n): return ['FizzBuzz' if i%15==0 else 'Fizz' if i%3==0 else 'Buzz' if i%5==0 else str(i) for i in range(1,n+1)]",
+   "tests": [
+    "fizzbuzz(15)[-1] == 'FizzBuzz'",
+    "fizzbuzz(3)[2] == 'Fizz'",
+    "fizzbuzz(5)[4] == 'Buzz'"
+   ]
+  },
+  {
+   "id": "c03",
+   "q": "Ecris une fonction Python compte_voyelles(s) qui renvoie le nombre de voyelles (a,e,i,o,u, insensible a la casse et aux accents via normalisation) dans s. Donne uniquement le code.",
+   "golden": "import unicodedata\ndef compte_voyelles(s):\n n = unicodedata.normalize('NFD', s.lower())\n return sum(1 for c in n if c in 'aeiou')",
+   "tests": [
+    "compte_voyelles('Hello') == 2",
+    "compte_voyelles('École à Paris') == 6",
+    "compte_voyelles('xyz') == 0"
+   ]
+  },
+  {
+   "id": "c04",
+   "q": "Ecris une fonction Python second_max(lst) qui renvoie le deuxieme plus grand element DISTINCT d'une liste, ou None s'il n'existe pas. Donne uniquement le code.",
+   "golden": "def second_max(lst): u = sorted(set(lst)); return u[-2] if len(u) >= 2 else None",
+   "tests": [
+    "second_max([3,1,4,1,5]) == 4",
+    "second_max([7,7,7]) is None",
+    "second_max([2]) is None"
+   ]
+  },
+  {
+   "id": "c05",
+   "q": "Ecris une fonction Python anagrammes(a, b) qui renvoie True si a et b sont des anagrammes (insensible a la casse, en ignorant les espaces). Donne uniquement le code.",
+   "golden": "def anagrammes(a, b): return sorted(a.replace(' ','').lower()) == sorted(b.replace(' ','').lower())",
+   "tests": [
+    "anagrammes('Chien', 'Niche') == True",
+    "anagrammes('Le chien', 'Niche le') == True",
+    "anagrammes('abc', 'abd') == False"
+   ]
+  },
+  {
+   "id": "c06",
+   "q": "Ecris une fonction Python somme_chiffres(n) qui renvoie la somme des chiffres de l'entier positif n. Donne uniquement le code.",
+   "golden": "def somme_chiffres(n): return sum(int(c) for c in str(n))",
+   "tests": [
+    "somme_chiffres(12345) == 15",
+    "somme_chiffres(0) == 0",
+    "somme_chiffres(999) == 27"
+   ]
+  },
+  {
+   "id": "c07",
+   "q": "Ecris une fonction Python binary_search(lst, x) qui renvoie l'index de x dans la liste triee lst, ou -1. Donne uniquement le code, sans utiliser index().",
+   "golden": "def binary_search(lst, x):\n lo, hi = 0, len(lst)-1\n while lo <= hi:\n  m = (lo+hi)//2\n  if lst[m] == x: return m\n  if lst[m] < x: lo = m+1\n  else: hi = m-1\n return -1",
+   "tests": [
+    "binary_search([1,3,5,7,9], 7) == 3",
+    "binary_search([1,3,5], 4) == -1",
+    "binary_search([], 1) == -1"
+   ]
+  },
+  {
+   "id": "c08",
+   "q": "Ecris une fonction Python puissance_rapide(b, e) qui calcule b puissance e (e entier >= 0) par exponentiation binaire, sans utiliser ** ni pow. Donne uniquement le code.",
+   "golden": "def puissance_rapide(b, e): \n r, p = 1, b\n while e:\n  if e & 1: r *= p\n  p *= p; e >>= 1\n return r",
+   "tests": [
+    "puissance_rapide(2, 10) == 1024",
+    "puissance_rapide(3, 0) == 1",
+    "puissance_rapide(5, 3) == 125"
+   ]
+  },
+  {
+   "id": "c09",
+   "q": "Ecris une fonction Python compresse(s) realisant un encodage RLE : 'aaabbc' -> 'a3b2c1'. Donne uniquement le code.",
+   "golden": "import itertools\ndef compresse(s):\n return ''.join(f'{c}{len(list(g))}' for c, g in itertools.groupby(s))",
+   "tests": [
+    "compresse('aaabbc') == 'a3b2c1'",
+    "compresse('') == ''",
+    "compresse('z') == 'z1'"
+   ]
+  },
+  {
+   "id": "c10",
+   "q": "Ecris une fonction Python indices_somme(lst, cible) qui renvoie les indices i < j des deux premiers elements distincts dont la somme vaut cible, ou None. Donne uniquement le code.",
+   "golden": "def indices_somme(lst, cible): \n vus = {}\n for i, v in enumerate(lst):\n  if cible - v in vus: return (vus[cible-v], i)\n  vus[v] = i\n return None",
+   "tests": [
+    "indices_somme([2,7,11,15], 9) == (0,1)",
+    "indices_somme([1,2,3], 10) is None",
+    "indices_somme([3,3], 6) == (0,1)"
+   ]
+  },
+  {
+   "id": "c11",
+   "q": "Ecris une fonction Python matrice_identite(n) qui renvoie la matrice identite n x n sous forme de listes de listes. Donne uniquement le code.",
+   "golden": "def matrice_identite(n): return [[1 if i == j else 0 for j in range(n)] for i in range(n)]",
+   "tests": [
+    "matrice_identite(3) == [[1,0,0],[0,1,0],[0,0,1]]",
+    "matrice_identite(1) == [[1]]",
+    "matrice_identite(0) == []"
+   ]
+  },
+  {
+   "id": "c12",
+   "q": "Ecris une fonction Python transposee(m) qui renvoie la transposee d'une matrice rectangulaire. Donne uniquement le code.",
+   "golden": "def transposee(m): return [list(t) for t in zip(*m)]",
+   "tests": [
+    "transposee([[1,2],[3,4],[5,6]]) == [[1,3,5],[2,4,6]]",
+    "transposee([[1]]) == [[1]]",
+    "transposee([[1,2,3]]) == [[1],[2],[3]]"
+   ]
+  },
+  {
+   "id": "c13",
+   "q": "Ecris une fonction Python frequence_mots(phrase) qui renvoie un dictionnaire mot -> nombre d'occurrences, en minuscules et sans ponctuation. Donne uniquement le code.",
+   "golden": "import re\nfrom collections import Counter\ndef frequence_mots(p):\n return dict(Counter(re.findall(r'[a-z0-9à-ÿ]+', p.lower())))",
+   "tests": [
+    "frequence_mots('Le chat, le chien.') == {'le': 2, 'chat': 1, 'chien': 1}",
+    "frequence_mots('') == {}",
+    "frequence_mots('Hello hello') == {'hello': 2}"
+   ]
+  },
+  {
+   "id": "c14",
+   "q": "Ecris une fonction Python est_bissextile(a) qui renvoie True si l'annee a est bissextile (regles gregoriennes completes). Donne uniquement le code.",
+   "golden": "def est_bissextile(a): return a % 4 == 0 and (a % 100 != 0 or a % 400 == 0)",
+   "tests": [
+    "est_bissextile(2000) == True",
+    "est_bissextile(1900) == False",
+    "est_bissextile(2024) == True"
+   ]
+  },
+  {
+   "id": "c15",
+   "q": "Ecris une fonction Python pgcd(a, b) par l'algorithme d'Euclide iteratif. Donne uniquement le code.",
+   "golden": "def pgcd(a, b): \n while b: a, b = b, a % b\n return a",
+   "tests": [
+    "pgcd(48, 18) == 6",
+    "pgcd(17, 5) == 1",
+    "pgcd(0, 7) == 7"
+   ]
+  },
+  {
+   "id": "c16",
+   "q": "Ecris une fonction Python camel_vers_snake(s) convertissant 'maVariableTest' en 'ma_variable_test'. Donne uniquement le code.",
+   "golden": "import re\ndef camel_vers_snake(s):\n return re.sub(r'(?<!^)(?=[A-Z])', '_', s).lower()",
+   "tests": [
+    "camel_vers_snake('maVariableTest') == 'ma_variable_test'",
+    "camel_vers_snake('x') == 'x'",
+    "camel_vers_snake('unMot') == 'un_mot'"
+   ]
+  },
+  {
+   "id": "c17",
+   "q": "Ecris une fonction Python valide_parentheses(s) qui renvoie True si les parentheses, crochets et accolades de s sont correctement imbriques. Donne uniquement le code.",
+   "golden": "def valide_parentheses(s):\n p = {')':'(', ']':'[', '}':'{'}; pile = []\n for c in s:\n  if c in '([{': pile.append(c)\n  elif c in p:\n   if not pile or pile.pop() != p[c]: return False\n return not pile",
+   "tests": [
+    "valide_parentheses('()[]{}') == True",
+    "valide_parentheses('([)]') == False",
+    "valide_parentheses('') == True"
+   ]
+  },
+  {
+   "id": "c18",
+   "q": "Ecris une fonction Python moyenne_mobile(lst, k) qui renvoie la liste des moyennes de chaque fenetre consecutive de k elements. Donne uniquement le code.",
+   "golden": "def moyenne_mobile(lst, k): return [sum(lst[i:i+k])/k for i in range(len(lst)-k+1)]",
+   "tests": [
+    "moyenne_mobile([1,2,3,4], 2) == [1.5, 2.5, 3.5]",
+    "moyenne_mobile([5], 1) == [5.0]",
+    "moyenne_mobile([1,2,3], 3) == [2.0]"
+   ]
+  },
+  {
+   "id": "c19",
+   "q": "Ecris une fonction Python top_k(lst, k) qui renvoie les k elements les plus frequents par ordre decroissant de frequence puis d'apparition. Donne uniquement le code.",
+   "golden": "from collections import Counter\ndef top_k(lst, k):\n c = Counter(lst)\n return sorted(c, key=lambda x: (-c[x], lst.index(x)))[:k]",
+   "tests": [
+    "top_k([1,1,2,3,3,3], 2) == [3,1]",
+    "top_k(['a'], 1) == ['a']",
+    "top_k([1,2], 0) == []"
+   ]
+  },
+  {
+   "id": "c20",
+   "q": "Ecris une fonction Python distance_levenshtein(a, b) (programmatique, programmation dynamique) qui renvoie la distance d'edition entre deux chaines. Donne uniquement le code.",
+   "golden": "def distance_levenshtein(a, b):\n m, n = len(a), len(b)\n prev = list(range(n+1))\n for i in range(1, m+1):\n  cur = [i] + [0]*n\n  for j in range(1, n+1):\n   cur[j] = min(prev[j]+1, cur[j-1]+1, prev[j-1] + (a[i-1] != b[j-1]))\n  prev = cur\n return prev[n]",
+   "tests": [
+    "distance_levenshtein('chat', 'chats') == 1",
+    "distance_levenshtein('', 'abc') == 3",
+    "distance_levenshtein('kitten', 'sitting') == 3"
+   ]
+  }
+ ]
+}

--- a/scripts/genai-stack/probe_minicpm5_duel.py
+++ b/scripts/genai-stack/probe_minicpm5_duel.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Probe A (issue #15099) : duel MiniCPM5-2B vs Qwen3-4B sur banc fixe local.
+
+Deux jambes sequentielles sur le meme GPU (vLLM, OpenAI-compatible), memes
+70 prompts (banc fixe probe_15099_bench.json), meme sampling (temperature=1.0,
+top_p=0.95, seed fixe par requete). Metriques :
+  - score par axe (Q&A pedagogique FR / math / code-gen), echelle 0-2 ;
+  - math : comparaison deterministe au golden (fallback correcteur tiers) ;
+  - code : execution reelle des tests du banc (deterministe, pas d'opinion) ;
+  - Q&A : correcteur tiers AVEUGLE (ne voit jamais le nom du modele evalue) ;
+  - tokens/s : usage completion / temps de requete, generation sequentielle ;
+  - VRAM : empreinte poids bf16 mesuree sur disque (somme safetensors).
+
+Correcteur : passerelle claudish models.myia.io (facade OpenAI-compatible,
+cle CLAUDISH_PROXY_KEY via .secrets/master.env), fallback OpenRouter
+(OPENROUTER_API_KEY). Aucun secret en dur, aucune valeur de cle affichee.
+
+Verdict (acceptance issue) : parite (>= 0.95 x Qwen) sur >= 2 axes/3,
+OU parite globale avec win >= 30 % sur VRAM poids ou tokens/s.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BENCH_PATH = SCRIPT_DIR / "probe_15099_bench.json"
+MASTER_ENV = Path(__file__).resolve().parents[2] / ".secrets" / "master.env"
+DEFAULT_PORT = 8199  # 8185 = serveur Qwen permanent de la flotte, ne pas toucher
+DEFAULT_GPU = 1  # RTX 3090 (GPU 0 = RTX 5080 occupee par la stack GenAI)
+PARITY_RATIO = 0.95
+WIN_RATIO = 0.30
+
+ENV_KEYS_NEEDED = ("CLAUDISH_PROXY_KEY", "OPENROUTER_API_KEY")
+
+
+# ---------------------------------------------------------------- utilitaires
+
+def load_master_env(keys: tuple[str, ...]) -> dict[str, str]:
+    """Charge les cles demandees depuis .secrets/master.env (KEY=VALUE).
+    Ne retourne jamais les valeurs a l'ecran ; l'appelant les met dans os.environ.
+    """
+    found: dict[str, str] = {}
+    if not MASTER_ENV.is_file():
+        return found
+    for line in MASTER_ENV.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        k = k.strip()
+        if k in keys:
+            v = v.strip().strip('"').strip("'")
+            if v:
+                found[k] = v
+    return found
+
+
+def http_post_json(url: str, payload: dict, headers: dict, timeout: float) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def http_get_ok(url: str, timeout: float = 5.0) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def gpu_vram_mib(gpu_index: int) -> int | None:
+    out = subprocess.run(
+        ["nvidia-smi", f"--query-gpu=memory.used", "--format=csv,noheader,nounits",
+         "-i", str(gpu_index)],
+        capture_output=True, text=True, timeout=15,
+    )
+    if out.returncode != 0:
+        return None
+    try:
+        return int(out.stdout.strip().splitlines()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+class VramMonitor(threading.Thread):
+    """Echantillonne la VRAM du GPU pendant toute la vie d'une jambe."""
+
+    def __init__(self, gpu_index: int, poll_s: float = 1.0):
+        super().__init__(daemon=True)
+        self.gpu_index = gpu_index
+        self.poll_s = poll_s
+        self._stop = threading.Event()
+        self.baseline_mib: int | None = None
+        self.peak_mib: int | None = None
+
+    def run(self) -> None:
+        self.baseline_mib = gpu_vram_mib(self.gpu_index)
+        self.peak_mib = self.baseline_mib
+        while not self._stop.is_set():
+            v = gpu_vram_mib(self.gpu_index)
+            if v is not None and (self.peak_mib is None or v > self.peak_mib):
+                self.peak_mib = v
+            self._stop.wait(self.poll_s)
+
+    def stop(self) -> None:
+        self._stop.set()
+        self.join(timeout=5)
+
+
+def weights_bytes_on_disk(model_path: Path) -> int:
+    """Somme des octets des fichiers safetensors du modele (empreinte poids reellement
+    servie, bf16). Mesure disque, byte-exact, reproductible."""
+    total = 0
+    for f in sorted(model_path.rglob("*.safetensors")):
+        total += f.stat().st_size
+    return total
+
+
+def chat_template_present(model_path: Path) -> bool:
+    """Pre-flight : le template de chat doit venir du snapshot — soit embarque dans
+    tokenizer_config.json, soit en fichier separe chat_template.jinja (convention
+    recente, cas MiniCPM5) — jamais du README du repo HF (contenu externe non
+    fiable, cf issue #15099)."""
+    jinja = model_path / "chat_template.jinja"
+    if jinja.is_file() and jinja.stat().st_size > 0:
+        return True
+    cfg = model_path / "tokenizer_config.json"
+    if not cfg.is_file():
+        return False
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return False
+    return bool(data.get("chat_template"))
+
+
+# ---------------------------------------------------------------- generation
+
+@dataclass
+class OneResponse:
+    item_id: str
+    axis: str
+    text: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    wall_s: float = 0.0
+    error: str = ""
+
+
+def chat_completion(port: int, model_name: str, question: str, max_tokens: int,
+                    sampling: dict, extra_body: dict | None = None,
+                    timeout: float = 180.0) -> OneResponse:
+    payload: dict = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": question}],
+        "temperature": sampling["temperature"],
+        "top_p": sampling["top_p"],
+        "seed": sampling["seed"],
+        "max_tokens": max_tokens,
+    }
+    if extra_body:
+        payload.update(extra_body)
+    t0 = time.perf_counter()
+    try:
+        data = http_post_json(
+            f"http://127.0.0.1:{port}/v1/chat/completions", payload, {}, timeout)
+    except Exception as exc:  # noqa: BLE001 - erreur reseau = reponse vide tracee
+        return OneResponse("", "", "", wall_s=time.perf_counter() - t0,
+                           error=f"{type(exc).__name__}: {exc}")
+    wall = time.perf_counter() - t0
+    try:
+        msg = data["choices"][0]["message"]
+        content = msg.get("content") or ""
+        reasoning = msg.get("reasoning_content")
+        if reasoning and not content:
+            return OneResponse("", "", "", wall_s=wall,
+                               error="reasoning_only_empty_content")
+        usage = data.get("usage") or {}
+        return OneResponse(
+            "", "", content,
+            prompt_tokens=int(usage.get("prompt_tokens") or 0),
+            completion_tokens=int(usage.get("completion_tokens") or 0),
+            wall_s=wall,
+        )
+    except (KeyError, IndexError, TypeError) as exc:
+        return OneResponse("", "", "", wall_s=wall, error=f"bad_payload: {exc}")
+
+
+# ---------------------------------------------------------------- verification
+
+_NUM_RE = re.compile(r"-?\d[\d\s]*(?:[.,]\d+)?")
+_FRAC_RE = re.compile(r"(-?\d+)\s*/\s*(\d+)")
+
+
+def _norm_number_txt(s: str) -> str:
+    return s.replace("\u00a0", " ").replace(",", ".").strip()
+
+
+def check_math(golden: str, text: str) -> int | None:
+    """2 = golden retrouve (nombre pur normalise, ou golden composite en
+    sous-chaine), None = indetermine -> correcteur. On ne cherche que dans les
+    ~600 derniers caracteres (la reponse utile est rarement noyee avant)."""
+    tail = _norm_number_txt(text[-600:])
+    g = _norm_number_txt(golden)
+    if re.fullmatch(r"-?\d+(?:[.,]\d+)?(?:\s*/\s*-?\d+)?", g):
+        # golden = nombre pur ou fraction
+        if "/" in g:
+            m = _FRAC_RE.search(g)
+            if m:
+                a, b = int(m.group(1)), int(m.group(2))
+                for fm in _FRAC_RE.finditer(tail):
+                    if int(fm.group(1)) == a and int(fm.group(2)) == b:
+                        return 2
+                return None  # pas retrouvee mot-a-mot : le correcteur tranche
+        gnum = g.replace(" ", "")
+        for m in _NUM_RE.finditer(tail):
+            if m.group(0).replace(" ", "") == gnum:
+                return 2
+        try:  # arrondi proche (ex. 61.2 vs 61.20), tolerance relative 1e-6
+            gt = float(gnum)
+            for m in _NUM_RE.finditer(tail):
+                v = float(m.group(0).replace(" ", ""))
+                if abs(v - gt) <= max(1e-6, abs(gt) * 1e-6):
+                    return 2
+        except ValueError:
+            pass
+        return None
+    # golden composite ("x=4, y=2", "-4 pourcent") : sous-chaine normalisee,
+    # sinon indetermine (le modele peut formater autrement) -> correcteur
+    if g.lower() in tail.lower():
+        return 2
+    return None
+
+
+def extract_code(text: str) -> str:
+    fence = re.search(r"```(?:python)?\s*\n(.*?)```", text, re.DOTALL)
+    if fence:
+        return fence.group(1).strip()
+    return text.strip()
+
+
+def check_code(item: dict, text: str) -> int:
+    """2 = tous les tests passent ; 1 = code valide + au moins un test ;
+    0 = ne compile pas / aucun test. Execution reelle, isolee, sans reseau."""
+    code = extract_code(text)
+    if not code or "def " not in code:
+        return 0
+    fn_name = re.search(r"def\s+([A-Za-z_]\w*)", code)
+    if not fn_name:
+        return 0
+    ns: dict = {}
+    import io, contextlib  # noqa: PLC0415 - isolation locale volontaire
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            exec(compile(code, "<gen>", "exec"), ns)  # noqa: S102 - banc ferme, pas d'input externe
+    except Exception:  # noqa: BLE001 - code genere : toute erreur = echec
+        return 0
+    tests = item.get("tests") or []
+    if not tests:
+        return 1
+    passed = 0
+    for t in tests:
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                r = eval(compile(t, "<test>", "eval"), ns)  # noqa: S307
+            if r:
+                passed += 1
+        except Exception:  # noqa: BLE001
+            continue
+    if passed == len(tests):
+        return 2
+    if passed >= 1:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------- correcteur
+
+CORRECTOR_SYSTEM = (
+    "Tu es un correcteur strict et impartial. On te donne une question, un "
+    "critere de reussite, et la reponse d'un modele. Note sur 0, 1, 2 :\n"
+    "2 = reussite complete (tous les points attendus / resultat exact) ;\n"
+    "1 = reussite partielle (bonne approche, elements manquants ou erreur mineure) ;\n"
+    "0 = faux, hors-sujet, vide ou refuse.\n"
+    "Reponds UNIQUEMENT avec un objet JSON : {\"score\": <0|1|2>, \"raison\": \"<20 mots max>\"}."
+)
+
+
+def corrector_score(question: str, criterion: str, answer: str, cfg: dict) -> int | None:
+    payload = {
+        "model": cfg["model"],
+        "temperature": 0.0,
+        "max_tokens": 200,
+        "messages": [
+            {"role": "system", "content": CORRECTOR_SYSTEM},
+            {"role": "user",
+             "content": f"QUESTION :\n{question}\n\nCRITERE DE REUSSITE :\n{criterion}\n\n"
+                        f"REPONSE A EVALUER :\n{answer[:4000]}"},
+        ],
+    }
+    for attempt, (base, key) in enumerate(cfg["endpoints"]):
+        for _ in range(2):  # 1 retry par endpoint sur erreur transitoire
+            try:
+                data = http_post_json(
+                    base, payload, {"Authorization": f"Bearer {key}"}, timeout=90)
+                txt = (data["choices"][0]["message"].get("content") or "").strip()
+                m = re.search(r"\{[^{}]*\"score\"\s*:\s*([012])[^{}]*\}", txt, re.DOTALL)
+                if m:
+                    return int(m.group(1))
+            except Exception:  # noqa: BLE001 - transitoire : retry puis endpoint suivant
+                time.sleep(2 * (attempt + 1))
+    return None
+
+
+# ---------------------------------------------------------------- serveur vLLM
+
+@dataclass
+class ServerHandle:
+    process: subprocess.Popen | None
+    container: str = ""
+
+    def shutdown(self) -> None:
+        if self.container:
+            subprocess.run(["docker", "stop", self.container], capture_output=True, timeout=120)
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+
+
+def boot_server(mode: str, model_path: Path, port: int, gpu: int,
+                 model_name: str, max_model_len: int,
+                 gpu_mem_util: float, venv_python: Path | None) -> ServerHandle:
+    common = [
+        "--model", str(model_path), "--served-model-name", model_name,
+        "--max-model-len", str(max_model_len), "--port", str(port if mode == "venv" else 8000),
+        "--gpu-memory-utilization", str(gpu_mem_util),
+    ]
+    if mode == "venv":
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = str(gpu)
+        env.pop("VLLM_LOGGING_LEVEL", None)
+        proc = subprocess.Popen(
+            [str(venv_python), "-m", "vllm.entrypoints.openai.api_server", *common],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+        return ServerHandle(process=proc)
+    # mode docker : image officielle vllm/vllm-openai, montage du snapshot
+    container = "probe-15099-leg"
+    subprocess.run(["docker", "rm", "-f", container], capture_output=True)
+    proc = subprocess.Popen([
+        "docker", "run", "--rm", "--name", container,
+        "--gpus", f"device={gpu}", "--shm-size", "8g",
+        "-v", f"{model_path}:/model", "-p", f"{port}:8000",
+        "vllm/vllm-openai:latest", *common,
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return ServerHandle(process=proc, container=container)
+
+
+def wait_ready(port: int, timeout_s: int = 900) -> bool:
+    t0 = time.time()
+    while time.time() - t0 < timeout_s:
+        if http_get_ok(f"http://127.0.0.1:{port}/health"):
+            return True
+        time.sleep(3)
+    return False
+
+
+# ---------------------------------------------------------------- jambe
+
+@dataclass
+class LegReport:
+    label: str
+    model_path: str
+    responses: list[OneResponse] = field(default_factory=list)
+    vram_baseline_mib: int | None = None
+    vram_peak_mib: int | None = None
+    weights_gib: float = 0.0
+    chat_template_from_snapshot: bool = False
+    boot_s: float = 0.0
+    scores: dict[str, float] = field(default_factory=dict)
+    tokens_per_s: float = 0.0
+
+
+def run_leg(label: str, model_path: Path, bench: dict, args, extra_body: dict | None) -> LegReport:
+    rep = LegReport(label=label, model_path=str(model_path))
+    rep.weights_gib = weights_bytes_on_disk(model_path) / (1024 ** 3)
+    rep.chat_template_from_snapshot = chat_template_present(model_path)
+
+    mon = VramMonitor(args.gpu)
+    mon.start()
+    t0 = time.time()
+    srv = boot_server(args.serve_mode, model_path, args.port, args.gpu,
+                      "duel", args.max_model_len, args.gpu_mem_util,
+                      args.venv_python)
+    try:
+        if not wait_ready(args.port):
+            print(f"[{label}] ERREUR : serveur pas pret en {time.time()-t0:.0f}s", file=sys.stderr)
+            return rep
+        rep.boot_s = time.time() - t0
+        print(f"[{label}] serveur pret en {rep.boot_s:.0f}s, poids {rep.weights_gib:.2f} GiB")
+
+        # echauffement (cuda graphs / compilation) hors mesure
+        chat_completion(args.port, "duel", "Dis simplement : pret.",
+                        16, bench["sampling"], extra_body, timeout=120)
+
+        items = [(a, it) for a in ("qa", "math", "code") for it in bench[a]]
+        if args.limit_per_axis:
+            per_axis: dict[str, int] = {}
+            kept = []
+            for a, it in items:
+                per_axis[a] = per_axis.get(a, 0) + 1
+                if per_axis[a] <= args.limit_per_axis:
+                    kept.append((a, it))
+            items = kept
+
+        for i, (axis, item) in enumerate(items, 1):
+            r = chat_completion(args.port, "duel", item["q"],
+                                bench["sampling"]["max_tokens"][axis],
+                                bench["sampling"], extra_body)
+            r.item_id, r.axis = item["id"], axis
+            rep.responses.append(r)
+            if i % 10 == 0 or i == len(items):
+                print(f"[{label}] {i}/{len(items)} faits "
+                      f"(dernier {r.item_id}, {r.completion_tokens} tok, {r.wall_s:.1f}s)")
+    finally:
+        srv.shutdown()
+        mon.stop()
+        rep.vram_baseline_mib, rep.vram_peak_mib = mon.baseline_mib, mon.peak_mib
+        time.sleep(5)  # laisser le GPU se vider avant la jambe suivante
+
+    ok = [r for r in rep.responses if not r.error]
+    tot_tok = sum(r.completion_tokens for r in ok)
+    tot_s = sum(r.wall_s for r in ok)
+    rep.tokens_per_s = tot_tok / tot_s if tot_s > 0 else 0.0
+    return rep
+
+
+# ---------------------------------------------------------------- verdict
+
+def score_leg(rep: LegReport, bench: dict, corr_cfg: dict | None) -> dict[str, list[int]]:
+    """Scores par item, puis moyenne par axe. Q&A -> correcteur aveugle ;
+    math -> deterministe puis correcteur ; code -> execution des tests."""
+    detail: dict[str, list[int]] = {"qa": [], "math": [], "code": []}
+    by_id = {it["id"]: it for axis in ("qa", "math", "code") for it in bench[axis]}
+    for r in rep.responses:
+        item = by_id.get(r.item_id)
+        if not item:
+            continue
+        if r.error or not r.text.strip():
+            detail[r.axis].append(0)
+            continue
+        if r.axis == "code":
+            detail["code"].append(check_code(item, r.text))
+        elif r.axis == "math":
+            d = check_math(item.get("golden", ""), r.text)
+            if d is None and corr_cfg:
+                d = corrector_score(item["q"], f"La reponse exacte attendue est : {item['golden']}",
+                                    r.text, corr_cfg)
+            detail["math"].append(d if d is not None else 0)
+        else:
+            keys = " ; ".join(item.get("keys", []))
+            s = None
+            if corr_cfg:
+                s = corrector_score(item["q"], f"Points attendus (tous = 2, partiels = 1) : {keys}",
+                                    r.text, corr_cfg)
+            detail["qa"].append(s if s is not None else 0)
+    return detail
+
+
+def fmt_table(mini: LegReport, qwen: LegReport,
+              d_mini: dict[str, list[int]], d_qwen: dict[str, list[int]]) -> str:
+    lines = ["| Metrique | MiniCPM5-2B | Qwen3-4B | ratio mini/qwen |",
+             "|---|---|---|---|"]
+    for axis, name in (("qa", "Q&A (0-2)"), ("math", "Math (0-2)"), ("code", "Code (0-2)")):
+        a = sum(d_mini[axis]) / len(d_mini[axis]) if d_mini[axis] else 0.0
+        b = sum(d_qwen[axis]) / len(d_qwen[axis]) if d_qwen[axis] else 0.0
+        ratio = a / b if b > 0 else float("inf")
+        lines.append(f"| {name} | {a:.3f} | {b:.3f} | {ratio:.3f} |")
+    allmini = sum(v for ax in d_mini.values() for v in ax) / max(
+        1, sum(len(ax) for ax in d_mini.values()))
+    allqwen = sum(v for ax in d_qwen.values() for v in ax) / max(
+        1, sum(len(ax) for ax in d_qwen.values()))
+    ratio = allmini / allqwen if allqwen > 0 else float("inf")
+    lines.append(f"| Global (0-2) | {allmini:.3f} | {allqwen:.3f} | {ratio:.3f} |")
+    t_ratio = mini.tokens_per_s / qwen.tokens_per_s if qwen.tokens_per_s > 0 else float("inf")
+    lines.append(f"| tokens/s | {mini.tokens_per_s:.1f} | {qwen.tokens_per_s:.1f} | {t_ratio:.3f} |")
+    w_ratio = mini.weights_gib / qwen.weights_gib if qwen.weights_gib > 0 else float("inf")
+    lines.append(f"| VRAM poids (GiB) | {mini.weights_gib:.2f} | {qwen.weights_gib:.2f} | {w_ratio:.3f} |")
+    if mini.vram_peak_mib and qwen.vram_peak_mib:
+        p_ratio = (mini.vram_peak_mib - (mini.vram_baseline_mib or 0)) / max(
+            1, qwen.vram_peak_mib - (qwen.vram_baseline_mib or 0))
+        lines.append(f"| VRAM peak serveur (MiB au-dessus base) | "
+                     f"{mini.vram_peak_mib - (mini.vram_baseline_mib or 0)} | "
+                     f"{qwen.vram_peak_mib - (qwen.vram_baseline_mib or 0)} | {p_ratio:.3f} |")
+    return "\n".join(lines)
+
+
+def verdict(mini: LegReport, qwen: LegReport,
+            d_mini: dict[str, list[int]], d_qwen: dict[str, list[int]]) -> dict:
+    axis_parities = {}
+    for axis in ("qa", "math", "code"):
+        a = sum(d_mini[axis]) / len(d_mini[axis]) if d_mini[axis] else 0.0
+        b = sum(d_qwen[axis]) / len(d_qwen[axis]) if d_qwen[axis] else 0.0
+        axis_parities[axis] = bool(b > 0 and a >= PARITY_RATIO * b)
+    n_axes = sum(axis_parities.values())
+    allmini = sum(v for ax in d_mini.values() for v in ax) / max(
+        1, sum(len(ax) for ax in d_mini.values()))
+    allqwen = sum(v for ax in d_qwen.values() for v in ax) / max(
+        1, sum(len(ax) for ax in d_qwen.values()))
+    global_parity = bool(allqwen > 0 and allmini >= PARITY_RATIO * allqwen)
+    vram_win = bool(qwen.weights_gib > 0 and
+                    (qwen.weights_gib - mini.weights_gib) / qwen.weights_gib >= WIN_RATIO)
+    tok_win = bool(qwen.tokens_per_s > 0 and
+                   (mini.tokens_per_s - qwen.tokens_per_s) / qwen.tokens_per_s >= WIN_RATIO)
+    accepted = (n_axes >= 2) or (global_parity and (vram_win or tok_win))
+    return {
+        "axis_parity": axis_parities, "axes_at_parity": n_axes,
+        "global_parity": global_parity, "vram_win_ge_30pct": vram_win,
+        "tokens_win_ge_30pct": tok_win, "accepted": accepted,
+        "rule": "accepte si >=2 axes/3 en parite, OU parite globale + win >=30% (VRAM ou tokens/s)",
+    }
+
+
+# ---------------------------------------------------------------- main
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--model-mini", type=Path, required=True,
+                    help="snapshot local MiniCPM5-2B (dossier HF cache)")
+    ap.add_argument("--model-qwen", type=Path, required=True,
+                    help="snapshot local Qwen3-4B")
+    ap.add_argument("--serve-mode", choices=("auto", "venv", "docker"), default="auto")
+    ap.add_argument("--venv-python", type=Path, default=Path("D:/Dev/venvs/vllm-probe/Scripts/python.exe"))
+    ap.add_argument("--gpu", type=int, default=DEFAULT_GPU)
+    ap.add_argument("--port", type=int, default=DEFAULT_PORT)
+    ap.add_argument("--max-model-len", type=int, default=8192)
+    ap.add_argument("--gpu-memory-utilization", type=float, default=0.90)
+    ap.add_argument("--limit-per-axis", type=int, default=0,
+                    help="smoke : limite le banc a N items/axe (0 = banc complet)")
+    ap.add_argument("--no-corrector", action="store_true",
+                    help="sans correcteur distant (smoke) : Q&A=0, math deterministe seulement")
+    ap.add_argument("--corrector-model", default="glm-5.2")
+    ap.add_argument("--corrector-fallback-model", default="google/gemini-2.5-flash")
+    ap.add_argument("--report", type=Path, required=True, help="chemin du rapport JSON de sortie")
+    args = ap.parse_args()
+
+    bench = json.loads(BENCH_PATH.read_text(encoding="utf-8"))
+    print(f"Banc : {sum(len(bench[a]) for a in ('qa','math','code'))} items, "
+          f"sampling {bench['sampling']}")
+
+    # correcteur : claudish primaire, OpenRouter fallback (noms de cles seulement)
+    corr_cfg: dict | None = None
+    if not args.no_corrector:
+        env = load_master_env(ENV_KEYS_NEEDED)
+        endpoints = []
+        if env.get("CLAUDISH_PROXY_KEY"):
+            endpoints.append(("https://models.myia.io/v1/chat/completions",
+                              env["CLAUDISH_PROXY_KEY"]))
+        if env.get("OPENROUTER_API_KEY"):
+            endpoints.append(("https://openrouter.ai/api/v1/chat/completions",
+                              env["OPENROUTER_API_KEY"]))
+        if endpoints:
+            corr_cfg = {"model": args.corrector_model, "endpoints": endpoints}
+            print(f"Correcteur : {endpoints[0][0]} (model {args.corrector_model}), "
+                  f"fallback x{len(endpoints)-1}")
+        else:
+            print("AVERTISSEMENT : aucune cle correcteur, Q&A sera 0", file=sys.stderr)
+
+    # mode serveur : venv si vllm importable, sinon docker
+    mode = args.serve_mode
+    if mode == "auto":
+        probe = subprocess.run(
+            [str(args.venv_python), "-c", "import vllm"], capture_output=True)
+        mode = "venv" if probe.returncode == 0 else "docker"
+    print(f"Serveur vLLM : mode {mode}")
+
+    for p in (args.model_mini, args.model_qwen):
+        if not p.is_dir():
+            print(f"ERREUR : snapshot absent {p}", file=sys.stderr)
+            return 2
+        if not chat_template_present(p):
+            print(f"ERREUR : pas de chat_template dans {p}/tokenizer_config.json "
+                  f"(template doit venir du snapshot, pas du README)", file=sys.stderr)
+            return 2
+
+    extra_mini: dict | None = None
+    extra_qwen = {"chat_template_kwargs": {"enable_thinking": False}}
+    mini = run_leg("MiniCPM5-2B", args.model_mini, bench, args, extra_mini)
+    qwen = run_leg("Qwen3-4B", args.model_qwen, bench, args, extra_qwen)
+
+    print("Scoring (deterministe + correcteur)...")
+    d_mini = score_leg(mini, bench, corr_cfg)
+    d_qwen = score_leg(qwen, bench, corr_cfg)
+    v = verdict(mini, qwen, d_mini, d_qwen)
+
+    report = {
+        "meta": {"issue": 15099, "probe": "A", "generated_at": now_utc(),
+                 "sampling": bench["sampling"], "serve_mode": mode,
+                 "gpu": args.gpu, "max_model_len": args.max_model_len,
+                 "corrector_model": args.corrector_model if corr_cfg else None,
+                 "limit_per_axis": args.limit_per_axis or None},
+        "mini": {**{k: v2 for k, v2 in mini.__dict__.items() if k != "responses"},
+                 "scores_detail": d_mini},
+        "qwen": {**{k: v2 for k, v2 in qwen.__dict__.items() if k != "responses"},
+                 "scores_detail": d_qwen},
+        "verdict": v,
+        "responses_mini": [r.__dict__ for r in mini.responses],
+        "responses_qwen": [r.__dict__ for r in qwen.responses],
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, ensure_ascii=False, indent=1), encoding="utf-8")
+
+    print()
+    print(fmt_table(mini, qwen, d_mini, d_qwen))
+    print()
+    print(f"VERDICT : {'ACCEPTE' if v['accepted'] else 'REFUSE'} "
+          f"(axes en parite {v['axes_at_parity']}/3, parite globale {v['global_parity']}, "
+          f"win VRAM {v['vram_win_ge_30pct']}, win tokens {v['tokens_win_ge_30pct']})")
+    print(f"Rapport : {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/genai-stack/probe_minicpm5_duel.py
+++ b/scripts/genai-stack/probe_minicpm5_duel.py
@@ -360,6 +360,7 @@ def corrector_score(question: str, criterion: str, answer: str, cfg: dict) -> in
 class ServerHandle:
     process: subprocess.Popen | None
     container: str = ""
+    log_path: Path | None = None
 
     def shutdown(self) -> None:
         if self.container:
@@ -372,11 +373,31 @@ class ServerHandle:
                 self.process.kill()
 
 
+def _hf_repo_root(snapshot: Path) -> tuple[Path, str] | None:
+    """Si le chemin est un snapshot du cache HF (models--org--name/snapshots/<sha>),
+    retourne (repo_root, suffixe_snapshot). Les fichiers d'un snapshot sont des
+    symlinks RELATIFS vers ../../blobs — monter le seul dossier snapshot casse
+    tous les liens dans le container ; il faut monter le repo entier."""
+    p = snapshot
+    for _ in range(4):
+        p = p.parent
+        if p.name.startswith("models--") and (p / "blobs").is_dir():
+            return p, snapshot.relative_to(p).as_posix()
+    return None
+
+
 def boot_server(mode: str, model_path: Path, port: int, gpu: int,
                  model_name: str, max_model_len: int,
                  gpu_mem_util: float, venv_python: Path | None) -> ServerHandle:
+    # mode docker : monter le repo HF entier (blobs + snapshots) pour que les
+    # symlinks relatifs du snapshot restent valides cote container
+    mount_src, model_arg = model_path, str(model_path)
+    if mode == "docker":
+        hf = _hf_repo_root(model_path)
+        if hf:
+            mount_src, model_arg = hf[0], f"/model/{hf[1]}"
     common = [
-        "--model", str(model_path), "--served-model-name", model_name,
+        "--model", model_arg, "--served-model-name", model_name,
         "--max-model-len", str(max_model_len), "--port", str(port if mode == "venv" else 8000),
         "--gpu-memory-utilization", str(gpu_mem_util),
     ]
@@ -388,23 +409,42 @@ def boot_server(mode: str, model_path: Path, port: int, gpu: int,
             [str(venv_python), "-m", "vllm.entrypoints.openai.api_server", *common],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
         return ServerHandle(process=proc)
-    # mode docker : image officielle vllm/vllm-openai, montage du snapshot
     container = "probe-15099-leg"
     subprocess.run(["docker", "rm", "-f", container], capture_output=True)
+    # Ciblage GPU deterministe : Docker Desktop ignore la restriction --gpus
+    # device=<uuid> (les 2 GPU restent visibles dans le container, mesure live
+    # probe A — vLLM tournait sur la 3080 Ti) ; CUDA_VISIBLE_DEVICES=<uuid>
+    # est, lui, honor directement par le runtime CUDA.
+    gpu_query = subprocess.run(
+        ["nvidia-smi", f"--query-gpu=uuid", "--format=csv,noheader", "-i", str(gpu)],
+        capture_output=True, text=True, timeout=15)
+    gpu_uuid = gpu_query.stdout.strip().splitlines()[0].strip() if gpu_query.returncode == 0 else ""
+    import tempfile  # noqa: PLC0415 - log de boot hors repo, debug uniquement
+    log_path = Path(tempfile.gettempdir()) / "probe_15099_boot.log"
+    log_f = open(log_path, "wb")  # noqa: SIM115 - ferme avec le process
     proc = subprocess.Popen([
         "docker", "run", "--rm", "--name", container,
-        "--gpus", f"device={gpu}", "--shm-size", "8g",
-        "-v", f"{model_path}:/model", "-p", f"{port}:8000",
+        "--gpus", "all", "--shm-size", "8g",
+        *(["-e", f"CUDA_VISIBLE_DEVICES={gpu_uuid}"] if gpu_uuid else []),
+        # Docker Desktop = backend WSL2 : vLLM gate le pinned memory (donc
+        # UVA) derriere ce flag ; torch pinne reellement (noyau >= 4.19.121)
+        "-e", "VLLM_WSL2_ENABLE_PIN_MEMORY=1",
+        "-v", f"{mount_src}:/model", "-p", f"{port}:8000",
         "vllm/vllm-openai:latest", *common,
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    return ServerHandle(process=proc, container=container)
+    ], stdout=log_f, stderr=subprocess.STDOUT)
+    return ServerHandle(process=proc, container=container, log_path=log_path)
 
 
-def wait_ready(port: int, timeout_s: int = 900) -> bool:
+def wait_ready(port: int, timeout_s: int = 900,
+               handle: "ServerHandle | None" = None) -> bool:
     t0 = time.time()
     while time.time() - t0 < timeout_s:
         if http_get_ok(f"http://127.0.0.1:{port}/health"):
             return True
+        if handle and handle.process and handle.process.poll() is not None:
+            print(f"ERREUR : container mort (rc={handle.process.returncode}) "
+                  f"apres {time.time()-t0:.0f}s — log : {handle.log_path}", file=sys.stderr)
+            return False
         time.sleep(3)
     return False
 
@@ -434,10 +474,10 @@ def run_leg(label: str, model_path: Path, bench: dict, args, extra_body: dict | 
     mon.start()
     t0 = time.time()
     srv = boot_server(args.serve_mode, model_path, args.port, args.gpu,
-                      "duel", args.max_model_len, args.gpu_mem_util,
+                      "duel", args.max_model_len, args.gpu_memory_utilization,
                       args.venv_python)
     try:
-        if not wait_ready(args.port):
+        if not wait_ready(args.port, handle=srv):
             print(f"[{label}] ERREUR : serveur pas pret en {time.time()-t0:.0f}s", file=sys.stderr)
             return rep
         rep.boot_s = time.time() - t0

--- a/scripts/genai-stack/probe_minicpm5_duel.py
+++ b/scripts/genai-stack/probe_minicpm5_duel.py
@@ -37,7 +37,13 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 BENCH_PATH = SCRIPT_DIR / "probe_15099_bench.json"
-MASTER_ENV = Path(__file__).resolve().parents[2] / ".secrets" / "master.env"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+# master.env est gitignore : selon l'arbre (worktree vs arbre partage) il peut
+# manquer — candidats dans l'ordre, puis os.environ en dernier recours
+MASTER_ENV_CANDIDATES = (
+    _REPO_ROOT / ".secrets" / "master.env",
+    Path("D:/Dev/CoursIA/.secrets/master.env"),
+)
 DEFAULT_PORT = 8199  # 8185 = serveur Qwen permanent de la flotte, ne pas toucher
 DEFAULT_GPU = 1  # RTX 3090 (GPU 0 = RTX 5080 occupee par la stack GenAI)
 PARITY_RATIO = 0.95
@@ -49,22 +55,26 @@ ENV_KEYS_NEEDED = ("CLAUDISH_PROXY_KEY", "OPENROUTER_API_KEY")
 # ---------------------------------------------------------------- utilitaires
 
 def load_master_env(keys: tuple[str, ...]) -> dict[str, str]:
-    """Charge les cles demandees depuis .secrets/master.env (KEY=VALUE).
-    Ne retourne jamais les valeurs a l'ecran ; l'appelant les met dans os.environ.
+    """Charge les cles demandees : os.environ d'abord, puis .secrets/master.env
+    (KEY=VALUE) sur les arbres candidats. Ne retourne jamais les valeurs a
+    l'ecran ; l'appelant les met dans os.environ.
     """
-    found: dict[str, str] = {}
-    if not MASTER_ENV.is_file():
-        return found
-    for line in MASTER_ENV.read_text(encoding="utf-8", errors="replace").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
+    found = {k: os.environ[k] for k in keys if os.environ.get(k)}
+    for cand in MASTER_ENV_CANDIDATES:
+        if not cand.is_file():
             continue
-        k, _, v = line.partition("=")
-        k = k.strip()
-        if k in keys:
-            v = v.strip().strip('"').strip("'")
-            if v:
-                found[k] = v
+        for line in cand.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            k = k.strip()
+            if k in keys and k not in found:
+                v = v.strip().strip('"').strip("'")
+                if v:
+                    found[k] = v
+        if all(k in found for k in keys):
+            break
     return found
 
 
@@ -313,7 +323,9 @@ def corrector_score(question: str, criterion: str, answer: str, cfg: dict) -> in
     payload = {
         "model": cfg["model"],
         "temperature": 0.0,
-        "max_tokens": 200,
+        # glm-5.2 emet du reasoning AVANT le content : budget large, sinon le
+        # content arrive vide (mesure live probe A)
+        "max_tokens": 700,
         "messages": [
             {"role": "system", "content": CORRECTOR_SYSTEM},
             {"role": "user",
@@ -325,11 +337,18 @@ def corrector_score(question: str, criterion: str, answer: str, cfg: dict) -> in
         for _ in range(2):  # 1 retry par endpoint sur erreur transitoire
             try:
                 data = http_post_json(
-                    base, payload, {"Authorization": f"Bearer {key}"}, timeout=90)
-                txt = (data["choices"][0]["message"].get("content") or "").strip()
+                    base, payload, {"Authorization": f"Bearer {key}"}, timeout=120)
+                msg = data["choices"][0]["message"]
+                txt = (msg.get("content") or "").strip()
                 m = re.search(r"\{[^{}]*\"score\"\s*:\s*([012])[^{}]*\}", txt, re.DOTALL)
                 if m:
                     return int(m.group(1))
+                # content vide/tronque par le raisonnement : chercher le verdict
+                # dans le raisonnement lui-meme ("Score: 2", '"score": 2')
+                r = msg.get("reasoning_content") or ""
+                m2 = re.search(r"(?:[Ss]core|\"score\")\s*[:=]\s*([012])(?!\d)", r)
+                if m2:
+                    return int(m2.group(1))
             except Exception:  # noqa: BLE001 - transitoire : retry puis endpoint suivant
                 time.sleep(2 * (attempt + 1))
     return None


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15050

See #15099 (probe A seule — la probe B reste ouverte)

## Probe A : duel MiniCPM5-2B vs Qwen3-4B — harnais + banc fixe + verdict

### Livrables

1. **`scripts/genai-stack/probe_15099_bench.json`** — banc fixe 70 items :
   - 30 Q&A pedagogiques FR (tokenisation, sampling, RAG, KV cache, paged attention, contamination de benchmarks...) avec points attendus par item ;
   - 20 math avec goldens exacts (pourcentages composes, fractions, probabilites, PGCD-contexte, suites, logs, combinatorique) ;
   - 20 code-gen avec tests executables (palindromes, RLE, Levenshtein, binary search, exponentiation binaire, parentheses, top-k...).
   - Self-test embarque dans le harnais : les 40 goldens math/code scorent 2 par les scorers deterministes, zero faux positif sur reponses volontairement fausses.

2. **`scripts/genai-stack/probe_minicpm5_duel.py`** — harnais de duel :
   - jambes vLLM **sequentielles sur le meme GPU** (RTX 3090, GPU 1), docker `vllm/vllm-openai:0.28.0` (>= 0.21 exigee par l'issue) ;
   - sampling fixe des deux cotes : temperature=1.0, top_p=0.95, seed=15099 par requete, max_tokens 512/640/768 par axe ;
   - Qwen3 servi avec `enable_thinking: false` (mode non-raisonnement, sinon la comparaison mesurerait un budget de tokens parti en <think>) ;
   - **scoring math deterministe** (golden normalise : nombres purs, fractions, composites en sous-chaine) avec arbitrage correcteur en fallback ;
   - **scoring code par execution reelle des tests du banc** (isole, sans reseau) — pas d'opinion de correcteur la ou c'est verifiable ;
   - **Q&A par correcteur tiers AVEUGLE** (ne voit jamais le nom du modele evalue) : passerelle claudish models.myia.io (glm-5.2), fallback OpenRouter ; calibre en live avant le duel (bonne reponse 2 / partielle 1 / hors-sujet 0) ;
   - tokens/s par usage de completion sur generation sequentielle ; VRAM = empreinte poids bf16 mesuree sur disque (somme safetensors, byte-exact) + pic serveur echantillonne ;
   - chat template verifie depuis le **snapshot** (tokenizer_config.json embarque OU chat_template.jinja separe, cas MiniCPM5) — jamais depuis le README du repo HF (tentative d'injection documentee dans l'issue) ;
   - montages docker resolus via repo-root HF (les snapshots sont des symlinks relatifs vers ../../blobs, monter le seul dossier snapshot les casse — mesure live).

### Resultat du duel (2026-09-08, RTX 3090 GPU 1, docker vllm/vllm-openai:0.28.0, 0 erreur sur 140 generations)

| Metrique | MiniCPM5-2B | Qwen3-4B | ratio mini/qwen |
|---|---|---|---|
| Q&A pedagogique FR (0-2) | 0.867 | 1.167 | **0.743** (parite NON) |
| Math (0-2) | 1.650 | 1.700 | **0.971** (parite OUI >= 0.95) |
| Code-gen (0-2) | 1.300 | 1.800 | **0.722** (parite NON) |
| Global 70 items (0-2) | 1.214 | 1.500 | 0.810 (parite NON) |
| tokens/s (generation sequentielle) | 115.0 | 76.8 | **1.497 (+50 %)** |
| VRAM poids bf16 (safetensors) | 4.69 GiB | 7.49 GiB | **0.626 (win 37.4 %)** |

**VERDICT : REFUSE** au sens de l'acceptance de l'issue — parite sur 1 axe/3 seulement (math), et la parite globale (requis pour coupler les wins VRAM/tokens) echoue a 0.810 < 0.95.

Lecture honnete : MiniCPM5-2B ne peut pas **remplacer** Qwen3-4B sur ce banc — il perd ~19 % de qualite globale (surtout code-gen : 13 reponses parfaites/20 vs 17/20, profil bimodal tout-ou-rien ; Q&A : 2 completions/30 vs 7/30, massivement des reponses partielles) ; il gagne decisivement en vitesse (+50 % tokens/s) et en empreinte (-37 % VRAM). C'est un candidat **tiers leger/vitesse**, pas un substitut qualite. Detail par axe dans le rapport JSON (genere par le harnais, seed fixe 15099, reproductible).

## Verifications

- Self-test scorers : 70/70 items, goldens math 20/20 detectes, code 20/20 a 2, zero faux positif.
- Smoke end-to-end : Qwen3.5-0.8B sur les deux jambes, 2 items/axe, docker, correcteur live — boucle complete serveur->generation->scoring->rapport.
- Aucun secret dans le depot : cles chargees de `.secrets/master.env` (gitignore) ou os.environ, jamais affichees.
- Base fraiche origin/main, catalogue non touche, aucun notebook.
