### PR TITLE
guard(grain_tag,#14780): mask backticked citations in find_close_keyword_pr_refs

### DIFF
--- a/scripts/ci/lane_claim_required.py
+++ b/scripts/ci/lane_claim_required.py
@@ -246,20 +246,23 @@ def check(
     regex_nums = sorted({h["number"] for h in closing})
 
     # #10323: for a PR BODY, GitHub's closingIssuesReferences is authoritative.
-    # The regex finder matches closing keywords even inside code spans, fenced
-    # blocks, or negations ("NOT closing #N") that GitHub's parser ignores. Only
-    # numbers GitHub actually resolved as closing refs can block; regex-only
-    # matches are logged IGNORED_BY_GITHUB and do not block. The regex stays the
-    # source of truth for COMMIT messages (scanned by pr_close_keyword_guard.py),
-    # which GitHub does not pre-resolve and where the squash trap is real.
+    # The regex finder used to match closing keywords even inside code spans,
+    # fenced blocks, or negations ("NOT closing #N") that GitHub's parser
+    # ignores; only numbers GitHub actually resolved as closing refs could
+    # block, and regex-only matches were logged IGNORED_BY_GITHUB. Since #14780
+    # the finder masks code spans itself (citation != declaration), so the
+    # IGNORED_BY_GITHUB residue is the NEGATION case -- the cross-check below
+    # still absorbs it. The regex stays the source of truth for COMMIT messages
+    # (scanned by pr_close_keyword_guard.py), which GitHub does not pre-resolve
+    # and where the squash trap is real.
     if pr_closing_refs is None:
         # Cross-check unavailable (fetch failed / older caller) -> fall back to
         # the regex finder. Do NOT disarm the gate on a network blip: a real
-        # closing ref still blocks; only the code-span FP resurfaces, and it is
+        # closing ref still blocks; only the negation FP resurfaces, and it is
         # warned so the gap is visible.
         warnings.append(
             "closingIssuesReferences unavailable -- using regex finder only; a "
-            "closing keyword in a code span/negation may false-positive (#10323)"
+            "closing keyword in a negation may false-positive (#10323)"
         )
         confirmed_nums = regex_nums
     else:

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -168,29 +168,10 @@ _PREV_PR_REF_RE = re.compile(
 )
 
 
-# Inline code spans and fenced blocks. A `prev:` clause written INSIDE
-# backticks is a CITATION (documentation of another grain's tag), never a
-# declaration -- the canonical tag line is plain text. #14550 measured the
-# cost of conflating the two: a lane that documented its successor, or that
-# explained WHY it did not point `prev:` at a still-open PR, had its own
-# correct tag overruled by its own prose. Masking preserves offsets so the
-# slices reported in the verdict stay meaningful.
-#
-# Backtick spans can wrap across a soft line break (Markdown reflow): a
-# citation of `` `prev: MED/training\n#14592` `` is still ONE code span,
-# not two. The previous `` `[^`\\n]*` `` forbade newlines and let the
-# second half escape the mask -- a defect measured on PR #14700's own
-# `` commits[0] `` (L4-L5 of the body) where the bug citation spanned two
-# lines and the unguarded half tripped `` _PREV_PR_REF_RE `` on
-# `` #14592 ``. We allow ``\\n`` inside the span (still forbidding a bare
-# backtick) so the whole citation is masked as one. Fenced blocks (```...```)
-# already accept newlines via ``.*?`` + ``re.DOTALL``.
-_CODE_SPAN_RE = re.compile(r"```.*?```|`[^`]*`", re.DOTALL)
-
-
-def _mask_code_spans(text: str) -> str:
-    r"""Blank out inline code spans / fenced blocks, preserving length."""
-    return _CODE_SPAN_RE.sub(lambda m: " " * len(m.group(0)), text)
+# Citation masking is shared with the close-keyword finder since #14780: the
+# citation/declaration split a `prev:` clause needs (#14550, multi-line #14700)
+# is the same split a ``fixes #N`` citation needs. The canonical surface lives
+# in grain_tag (``gt.mask_code_spans``) so both guards mask identically.
 
 
 def _first_grain_line(text: str | None) -> str | None:
@@ -281,7 +262,7 @@ def find_prev_self_references(text: str | None, current_pr: int | None) -> list[
     if not text or current_pr is None:
         return []
     out: list[dict] = []
-    for m in _PREV_PR_REF_RE.finditer(_mask_code_spans(text)):
+    for m in _PREV_PR_REF_RE.finditer(gt.mask_code_spans(text)):
         n = int(m.group(1))
         if n == current_pr:
             out.append({"prev_pr": n, "match": m.group(0)})
@@ -302,7 +283,7 @@ def find_prev_target_pr_numbers(text: str | None) -> list[int]:
         return []
     seen: set[int] = set()
     out: list[int] = []
-    for m in _PREV_PR_REF_RE.finditer(_mask_code_spans(text)):
+    for m in _PREV_PR_REF_RE.finditer(gt.mask_code_spans(text)):
         n = int(m.group(1))
         if n not in seen:
             seen.add(n)

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -361,6 +361,35 @@ def parse_prev(body: str | None) -> dict:
     return out
 
 
+# Inline code spans and fenced blocks -- the shared citation-masking surface.
+# Text inside backticks is a CITATION (documentation of another grain's tag,
+# or of a guard firing on one), never a declaration: the canonical forms
+# (`Grain:`, `prev:`, `Closes #N`) are plain text. #14550 measured the cost
+# of conflating the two on variation_prev_guard (a lane documenting its
+# successor had its own correct tag overruled by its own prose); #14780
+# measured the same defect on find_close_keyword_pr_refs (a PR documenting
+# the close-keyword guard with a backticked ``fixes #N`` citation tripped the
+# guard on its own explanatory text). Masking preserves offsets so the spans
+# reported in verdicts stay meaningful.
+#
+# Backtick runs of ANY length pair up (CommonMark-style): the opening run is
+# captured and must be closed by a run of the SAME length, so a double
+# backtick ``...`` citation is masked whole -- the previous `` `[^`]*` ``
+# matched the adjacent pair as an empty span and left the citation's CONTENT
+# bare (measured #14780: ``fixes #10094`` scanned as a live `fixes #10094`).
+# Spans wrap across a soft line break (Markdown reflow): `` `closes\n#1234` ``
+# is ONE code span, not two (#14700) -- the content class accepts newlines,
+# still forbidding a bare backtick. Fenced blocks (```...```) are matched
+# first, lazily and across lines, so a fence containing backticked inline
+# code is masked as one unit.
+CODE_SPAN_RE = re.compile(r"```.*?```|(`+)[^`]*\1", re.DOTALL)
+
+
+def mask_code_spans(text: str) -> str:
+    r"""Blank out inline code spans / fenced blocks, preserving length."""
+    return CODE_SPAN_RE.sub(lambda m: " " * len(m.group(0)), text)
+
+
 # Matches `<closing-keyword> #N` in free prose (#10101). The keyword set is
 # exactly `CLOSING_KEYWORDS` (the 9 GitHub auto-close words); the `#N` tail is
 # what GitHub parses as an auto-close instruction when the text lands in a
@@ -386,6 +415,14 @@ def find_close_keyword_pr_refs(text: str | None) -> list[dict]:
     carried a ``CLOSED <PR-number>`` line in prose, which a naive squash would
     have re-closed that PR (the same translation deliverable #10093 protects).
 
+    The scan runs on ``mask_code_spans(text)`` (#14780): a backticked
+    ``fixes #N`` is a CITATION of the closing pattern (documentation of the
+    guard, of a past incident, of another grain's tag), never a declaration,
+    and must not trip the guard on its own explanatory prose -- the same
+    citation/declaration split ``variation_prev_guard`` enforces on ``prev:``
+    since #14550/#14700. Offsets are preserved, so the spans above still
+    point into the original text.
+
     Each hit is ``{"keyword": <lowercased>, "number": <int>, "span": <tuple>}``:
     the keyword (lowercased for the 9-flexion test), the referenced number
     (the caller resolves it PR-vs-issue), and the match span (so the verdict
@@ -400,7 +437,7 @@ def find_close_keyword_pr_refs(text: str | None) -> list[dict]:
     if not text:
         return []
     hits = []
-    for m in CLOSE_KW_REF_RE.finditer(text):
+    for m in CLOSE_KW_REF_RE.finditer(mask_code_spans(text)):
         hits.append({
             "keyword": m.group(1).lower(),
             "number": int(m.group(2)),

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -632,6 +632,53 @@ def test_find_non_closing_refs_empty_and_none():
     assert gt.find_non_closing_refs("nothing here") == []
 
 
+def test_find_close_keyword_pr_refs_backtick_citation_not_a_declaration():
+    # #14780 (controle isole sur main da13579ca) : une PR qui DOCUMENTE le
+    # close-keyword guard cite le motif en prose -- la citation backtiquedee
+    # n'est pas une declaration et ne doit pas faire hit. Single backtick,
+    # double backtick (RST) et fenced block, mono-ligne.
+    assert gt.find_close_keyword_pr_refs(
+        "documents the guard firing on `fixes #10094` in prose"
+    ) == []
+    assert gt.find_close_keyword_pr_refs(
+        "documents the guard firing on ``fixes #10094`` in prose"
+    ) == []
+    assert gt.find_close_keyword_pr_refs(
+        "the finder docstring cites ``CLOSED <PR-number>`` as the incident"
+    ) == []
+    assert gt.find_close_keyword_pr_refs("```\nfixes #99\n```") == []
+
+
+def test_find_close_keyword_pr_refs_backtick_citation_wrapped():
+    # Meme citation repliee sur un soft line break (reflow Markdown) -- le
+    # span code traverse le \\n (#14700 pour prev:, meme split ici). Avant le
+    # fix, la deuxieme moitie s'echappait du masque et trippait le finder.
+    assert gt.find_close_keyword_pr_refs("we ``closes\n#1234`` wrapped") == []
+    assert gt.find_close_keyword_pr_refs("we `resolved\n#77` wrapped") == []
+
+
+def test_find_close_keyword_pr_refs_unbackticked_clause_still_hits():
+    # CONTROLE DE MORDANT : la meme clause SANS backticks reste un hit. Si la
+    # regex de masquage devenait trop large, ce test casse -- le garde doit
+    # garder ses dents sur les vraies declarations.
+    hits = gt.find_close_keyword_pr_refs(
+        "documents the guard firing on fixes #10094 in prose"
+    )
+    assert [h["number"] for h in hits] == [10094]
+    assert hits[0]["keyword"] == "fixes"
+
+
+def test_find_close_keyword_pr_refs_offsets_preserved_through_mask():
+    # Le span rendu doit pointer dans le texte ORIGINAL, pas dans le masque --
+    # le verdict du guard cite la ligne fautive grace a ces offsets. Un hit
+    # APRES une citation masquee garde donc sa vraie position.
+    text = "see `fixes #1` cited, but the real declaration is closes #2 here"
+    hits = gt.find_close_keyword_pr_refs(text)
+    assert [h["number"] for h in hits] == [2]
+    start, end = hits[0]["span"]
+    assert text[start:end] == "closes #2"
+
+
 def test_grain_word_boundary_graine_heading_does_not_shadow_real_tag():
     # #11771 (mesure 2026-08-19) : le body portait un titre `## Graine / Tag`
     # AVANT sa ligne `Grain:` conforme. Le motif acceptait ZERO separateur apres

--- a/scripts/tests/test_lane_claim_required.py
+++ b/scripts/tests/test_lane_claim_required.py
@@ -412,21 +412,26 @@ def test_10323_closing_keyword_in_negation_does_not_block():
 
 def test_10323_closing_keyword_in_inline_code_span_does_not_block():
     # `` `Closes #6724` `` inside backticks -- GitHub ignores closing keywords
-    # in inline code. Regex matches, GitHub doesn't -> no block.
+    # in inline code. Since #14780 the finder masks code spans itself, so the
+    # regex no longer MATCHES the span at all: no block (as before), and no
+    # IGNORED_BY_GITHUB residue either -- the FP is gone at the source, not
+    # neutralized after the fact.
     body = _body_with("Avoid the form `Closes #6724`; use `See #6724` instead.")
     fetch = _claimed_by_other_issue(6724)
     v = lcr.check(body, fetch, now=NOW, pr_closing_refs=set())
     assert v["guard_pass"] is True
-    assert any("IGNORED_BY_GITHUB" in w for w in v["warnings"])
+    assert not any("6724" in w for w in v["warnings"])
 
 
 def test_10323_closing_keyword_in_fenced_block_does_not_block():
-    # A closing keyword inside a ``` fenced code block is ignored by GitHub.
+    # A closing keyword inside a ``` fenced code block is ignored by GitHub --
+    # and since #14780 masked by the finder too. Same transition as the inline
+    # span: the hit disappears at the source instead of being IGNORED_BY_GITHUB.
     body = _body_with("Example of what NOT to write:\n```\nCloses #6724\n```\n")
     fetch = _claimed_by_other_issue(6724)
     v = lcr.check(body, fetch, now=NOW, pr_closing_refs=set())
     assert v["guard_pass"] is True
-    assert any("IGNORED_BY_GITHUB" in w for w in v["warnings"])
+    assert not any("6724" in w for w in v["warnings"])
 
 
 def test_10323_real_closing_ref_still_blocks_when_other_lane_claims():

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -17,8 +17,11 @@ from pathlib import Path
 
 # Insert `scripts/ci/` so the script under test is importable from a flat
 # `import variation_prev_guard` (same convention as test_variation_tag_required.py).
+# Insert `scripts/` too: the mask under test lives in grain_tag since #14780.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import grain_tag as gt  # noqa: E402
 import variation_prev_guard as vpg  # noqa: E402
 
 
@@ -620,7 +623,7 @@ def test_multiline_backtick_span_is_one_mask():
         "#14592` in backticks inside a numbered list, with NO `Grain:` "
         "line of its own."
     )
-    masked = vpg._mask_code_spans(multiline)
+    masked = gt.mask_code_spans(multiline)
     # The whole span (L4 backtick + newline + L5 leading `#14592` + L5
     # backtick) is replaced by spaces -- nothing for the regex to match.
     assert "14592" not in masked
@@ -639,7 +642,7 @@ def test_single_line_backtick_span_still_masked():
     # the working case BEFORE the fix and must remain working AFTER. If it
     # ever breaks, the fix has widened the regex too far.
     single = ("citing `prev: MED/training #14592` in backticks")
-    masked = vpg._mask_code_spans(single)
+    masked = gt.mask_code_spans(single)
     assert "14592" not in masked
     assert len(masked) == len(single)
     assert vpg.find_prev_self_references(single, current_pr=14592) == []
@@ -655,7 +658,7 @@ def test_adjacent_backticks_do_not_merge_into_one_span():
     # current regex is non-greedy and bounded by the FIRST closing
     # backtick, so they stay distinct.
     text = "`a`\n`b`"
-    masked = vpg._mask_code_spans(text)
+    masked = gt.mask_code_spans(text)
     # Two spans masked independently -- `` `a` `` (3) + newline (1) +
     # `` `b` `` (3) -- total 7 chars, all blanks except the newline.
     assert masked == "   \n   "


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #15092

## Le défaut (contrôle isolé de l'issue, reproduit avant fix)

`find_close_keyword_pr_refs` scannait le texte **brut** : une PR qui **documente** le close-keyword guard en citant le motif en prose — ``fixes #10094`` backtiqué, exactement ce que fait le docstring même du finder (`grain_tag.py`, qui cite ``CLOSED <PR-number>``) — déclenchait le garde sur **son propre texte explicatif**. Même famille auto-référentielle que #14550/#14703, sur le garde sœur. Reproduit sur main 7af725e96 :

```
gt.find_close_keyword_pr_refs("documents the guard firing on ``fixes #10094`` in prose")
-> [{'keyword': 'fixes', 'number': 10094, ...}]   FALSE POSITIF
```

**Découverte adjacente en route** : le masque existant de `variation_prev_guard` (inline + fenced) avait le même trou sur les **doubles backticks** — il matchait la paire de backticks adjacents comme un span *vide* et laissait le CONTENU de la citation nu. Le cas mesuré de l'issue n'aurait pas été fixé par simple extraction.

## Les gestes

1. **`grain_tag.mask_code_spans`** : surface de masquage partagée, extraite de `variation_prev_guard` (direction de dépendance correcte : `ci/*` importent `grain_tag`). Regex généralisée aux runs de longueur **appariée** (style CommonMark) :

   ```
   run ouvrante de N backticks, capturee, refermee par une run de
   MEME longueur (backreference) ; fenced matche en premier, lazy
   ```

   La run ouvrante doit donc être fermée par une run de **même longueur** : une citation en doubles backticks est masquée entière. Multi-lignes et fenced préservés (formes #14700 inchangées).
2. **`find_close_keyword_pr_refs` scanne le texte masqué**, offsets préservés (les verdicts continuent de citer la ligne fautive dans le texte original).
3. **`variation_prev_guard`** supprime sa copie locale et pointe sur la partagée — les deux gardes masquent désormais à l'identique.
4. **`lane_claim_required`** : la résidu `IGNORED_BY_GITHUB` (#10323) est désormais le cas **négation** seul ; message du fallback ajusté en conséquence.

## Acceptance (#14780)

- [x] masque inline + fenced avant le scan, réutilisé/extrait en commun, offsets préservés — `mask_code_spans` public dans `grain_tag.py`, test dédié : un hit **après** une citation masquée rend un `span` qui découpe le texte original (`text[start:end] == "closes #2"`)
- [x] citation mono-ligne ET repliée → aucun hit — tests : backtick simple, **double backtick (le cas exact de l'issue)**, fenced, ``closes\n#1234`` repliée, ``resolved\n#77`` repliée
- [x] contrôle de mordant : la même clause **sans** backticks reste un hit (`fixes #10094` nu → hit keyword `fixes`)
- [x] non-régression — 4 suites concernées (`test_grain_tag`, `test_variation_prev_guard`, `test_lane_claim_required`, `test_pr_close_keyword_guard`) : **186 passed** ; répertoire complet `scripts/tests/` : **4816 passed, 30 skipped, 5 xfailed** (8 min, 0 fail). Les 2 tests #10323 code-span changent de **sens** (documenté in situ) : le hit disparaît à la source au lieu d'être neutralisé `IGNORED_BY_GITHUB` après coup — même verdict `guard_pass`, moins de bruit
- [x] consommateurs vérifiés (`grep find_close_keyword_pr_refs`) : `pr_close_keyword_guard.py:126` et `lane_claim_required.py:159,245` passent tous par le finder → couverts automatiquement ; le chemin `variation_prev_guard` hérite du masque amélioré (double backtick) via l'extraction

## Contrôle positif sur cette PR elle-même

Ce body cite le motif piégé trois fois (backtick simple + double) : rejeu local du guard sur le body → **PASS** — c'est le cas d'usage exact du fix.

```
python scripts/ci/pr_close_keyword_guard.py --body-file <ce body>
-> {"guard_pass": true, ...}
```

## Hors scope (signalé, pas touché)

`find_non_closing_refs` (le scanner `See/Part of/Refs`, advisory `lane-claim-conflict` seulement) scanne aussi le brut et a le même potentiel de FP citation — impact advisory, un sujet par PR.

Closes #14780

