### PR TITLE
docs(search,#14870): fix 2 dead Search-17b refs after the 11c renum

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -107,10 +107,10 @@ Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) son
 | Besoin | Détail |
 |--------|--------|
 | Python | 3.10+, environnement virtuel recommandé |
-| `ortools` | Search-9 (Linear Programming), Search-17b (CP-SAT) |
+| `ortools` | Search-9 (Linear Programming), Search-11c (CP-SAT) |
 | `deap` | Search-5 (Genetic Algorithms) |
 | `mealpy` | Search-11 (Métaheuristiques) |
-| `z3-solver` | Search-10 (Symbolic Automata), Search-17b (SMT) |
+| `z3-solver` | Search-10 (Symbolic Automata), Search-11c (SMT) |
 | OpenSpiel | Search-7 (MCTS) : requiert WSL ou Linux |
 | `cvxpy` | Search-09b (relaxation SDP, solveur CLARABEL embarqué) |
 | Kernel `lean4-wsl` | Search-09d : kernel Jupyter Lean 4 + miroir local du lake [`discrepancy_lean`](../discrepancy_lean/README.md) (Mathlib 4 via les packages du dépôt) — cf. [`docs/reference/wsl-kernels-detail.md`](../../../docs/reference/wsl-kernels-detail.md) |


### PR DESCRIPTION
Grain: MED/docs -- lane myia-po-2026:CoursIA -- prev: MED/tooling #15092

## Le défaut (#14870)

Le renommage `Search-17-Empirical-Algorithm-Selection` -> `Search-11c` (#14802, issue #13769) a corrigé la ligne de table (l.70) et la prose (l.86) mais a manqué les deux lignes de la table « Prérequis & environnement » : après le merge, `Search-17b` ne se résolvait plus nulle part dans le README.

## Vecteur (pourquoi une micro-PR maintenant)

Le body de l'issue prévoyait de replier ce fix dans le rebase de #14790 (renum tranche A, même fichier) ; #14790 est **MERGED (2026-09-06T15:06Z) sans avoir intégré le fix** — résidu `17b` l.110/113 vérifié firsthand sur origin/main 7af725e96 avant ce fix. La clause fallback du body (« si #14790 devait être fermée, le fix redevient une micro-PR autonome ») s'applique.

## Fix

2 lignes (l.110/l.113) : `Search-17b` -> `Search-11c`. Aucune cellule code, aucune re-exécution.

## Audit fichier-entier (règle E — README de série)

- (a) Disque : **40 notebooks** `.ipynb` (hors `_output`), 0 `.html`, 2 assets png.
- (b) Réconciliation disque <-> prose : **47 liens** dans le README, **tous résolus** (directement, ou via la convention uniforme de la série `.html` -> base `.ipynb` présente) ; résidu `17b` sur origin/main = **exactement les 2 lignes rapportées** ; aucun bloc `CATALOG-STATUS` dans ce README (aucun marqueur, 196 lignes).
- (c) Réciproque : chaque notebook du disque est référencé, **sauf un** — voir hors scope.

## Hors scope (signalé, pas touché)

- `Search-03e-AStar-Optimality.ipynb` est sur disque mais **absent du README** (ni lien, ni mention) — sujet séparé.
- La convention `.html` des liens anciens (base `.ipynb` existante, fichier `.html` non rendu) est uniforme dans la série — choix historique, pas un défaut de cette PR.

Closes #14870

