### PR TITLE
docs(search,#14789): re-anchor Search-11c license attestation on the live archive

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11c-Empirical-Algorithm-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11c-Empirical-Algorithm-Selection.ipynb
@@ -4840,10 +4840,10 @@
     "\n",
     "- **Auteur** : Théodore Deguest (EPITA SCIA 2026, L4)\n",
     "- **Sujet** : *Benchmark cross-paradigme de solveurs de jeux* (Intelligence Symbolique)\n",
-    "- **Dépôt source** : [`L4-Benchmark-Cross-Paradigm`](https://github.com/jsboigeEpita/L4-Benchmark-Cross-Paradigm) (PR #42 — distillation de la tranche Sudoku)\n",
-    "- **Licence** : MIT (cf. fichier `LICENSE` du dépôt source)\n",
+    "- **Dépôt source** : [`L4-Benchmark-Cross-Paradigm`](https://github.com/jsboigeEpita/2026-Epita-Intelligence-Symbolique/tree/main/L4-Benchmark-Cross-Paradigm) — dépôt standalone supprimé, projet archivé en sous-dossier du repo public du cours (PR #42 — distillation de la tranche Sudoku)\n",
+    "- **Licence** : MIT — [`LICENSE` du repo de cours](https://github.com/jsboigeEpita/2026-Epita-Intelligence-Symbolique/blob/main/LICENSE) qui archive le projet (le sous-dossier n'a pas de `LICENSE` propre ; celle du repo couvre tout son contenu — vérifié le 2026-09-08)\n",
     "- **Périmètre distillé** : tranches 1/3 (Sudoku — 6 solveurs + harnais de benchmark) et 2/3 (Puissance 4 — random/minimax/alpha-beta/MCTS, round-robin double, sweep budget)\n",
-    "- **Note tranche 2** (2026-08-30) : le dépôt source n'est plus accessible en public (404) ; l'implémentation Puissance 4 est propre et conforme au protocole documenté (timeout, métriques uniformes, round-robin), les algorithmes étant enseignés dans App-14b/App-14\n",
+    "- **Note tranche 2** (mise à jour 2026-09-08) : le dépôt standalone n'existe plus (404 sous le compte propriétaire) ; le projet intégral est de nouveau public — archivé en sous-dossier du repo du cours (lien ci-dessus, `LICENSE` MIT incluse). L'implémentation Puissance 4 est propre et conforme au protocole documenté (timeout, métriques uniformes, round-robin), les algorithmes étant enseignés dans App-14b/App-14\n",
     "- **Périmètre non distillé** : tranche 3/3 (Wordle — élimination bayésienne/entropie/CSP)\n",
     "\n",
     "### 9.2 Méthode de distillation\n",
@@ -4852,7 +4852,7 @@
     "|-------|--------|\n",
     "| 1. Sélection | Tranche 1/3 (Sudoku) — la plus mature et testée (20 tests pytest passent sous WSL/Linux). |\n",
     "| 2. Reproduction | `git clone --depth=1` du dépôt + lecture des 7 fichiers (`grid.py`, `instances.py`, `backtracking.py`, `dancing_links.py`, `cp_sat.py`, `smt.py`, `genetic.py`, `simulated_annealing.py`, `core.py`). |\n",
-    "| 3. Vérification licence | WebFetch sur le README + `LICENSE` du dépôt : **MIT**, redistribution autorisée avec attribution. |\n",
+    "| 3. Vérification licence | WebFetch sur le README + `LICENSE` du dépôt : **MIT**, redistribution autorisée avec attribution. Re-vérifié le 2026-09-08 sur la cible actuelle (sous-dossier du repo de cours, `LICENSE` MIT à la racine du repo) — le lien d'origine est mort depuis la suppression du dépôt standalone (#14789). |\n",
     "| 4. Transformation | Code source reproduit **verbatim** dans des cellules code, **ajout de docstrings pédagogiques en français** (cf. CLAUDE.md §E — documentation primaire en français). **Aucune modification de l'algorithmique** — la logique reste identique au projet étudiant. |\n",
     "| 5. Enchâssement | Harnais de benchmark adapté (Windows : `signal.SIGALRM` → `time.monotonic()`), exécution séquentielle pour rester local et reproductible. |\n",
     "| 6. Attribution | Section 9 (cette section) + lien vers la PR source #42 + nom de l'auteur visible dans le header du notebook. |\n",
@@ -4909,7 +4909,7 @@
     "|-----------|-------------------|\n",
     "| [Search-02c-QuikGraph](Search-02c-QuikGraph.ipynb) | *notebooks dédiés Puissance 4 (minimax/MCTS) et Wordle (entropie) — distillation future des tranches 2/3 et 3/3 du projet étudiant* |\n",
     "\n",
-    "Pour le **périmètre complet** du benchmark cross-paradigme (Sudoku + Puissance 4 + Wordle), voir le dépôt source [`L4-Benchmark-Cross-Paradigm`](https://github.com/jsboigeEpita/L4-Benchmark-Cross-Paradigm), PR #42 (auteur : Théodore Deguest, EPITA SCIA 2026)."
+    "Pour le **périmètre complet** du benchmark cross-paradigme (Sudoku + Puissance 4 + Wordle), voir le dépôt source [`L4-Benchmark-Cross-Paradigm`](https://github.com/jsboigeEpita/2026-Epita-Intelligence-Symbolique/tree/main/L4-Benchmark-Cross-Paradigm) (archivé en sous-dossier du repo du cours), PR #42 (auteur : Théodore Deguest, EPITA SCIA 2026)."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/docs -- lane myia-po-2026:CoursIA -- prev: MED/tooling #15092

## L'enquête (acceptance item 1 — ce qu'il est advenu du dépôt)

Le dépôt standalone `jsboigeEpita/L4-Benchmark-Cross-Paradigm` est **supprimé** :

- `GET repos/jsboigeEpita/L4-Benchmark-Cross-Paradigm` : 404 (confirmé, déjà mesuré par l'issue sous deux jetons) ;
- le compte `jsboigeEpita` existe (User, 11 repos publics) et le dépôt n'y figure pas — ce n'est ni un renommage ni un transfert sous ce compte ;
- aucune copie publique dans le GitHub search (`L4-Benchmark`, `Cross-Paradigm`).

**Mais le projet intégral est de nouveau public** : il vit en **sous-dossier** du repo de cours [`jsboigeEpita/2026-Epita-Intelligence-Symbolique`](https://github.com/jsboigeEpita/2026-Epita-Intelligence-Symbolique) — code (`benchmark/`), data, tests (3 fichiers pytest), `notebook.ipynb`, `results/` avec figures. Et ce repo porte une **`LICENSE` MIT à sa racine** (« The 2026-Epita-Intelligence-Symbolique contributors ») qui couvre tout son contenu ; le sous-dossier n'a pas de LICENSE propre.

→ **La licence est rétablie** (branche « si la licence est ré-etablie » de l'acceptance) : remplacer l'URL par la référence qui tient et redater l'étape 3.

## Le fix (markdown-only, 2 cellules : 88 §9.1 et 90 navigation)

- **Dépôt source** : URL du sous-dossier vivant + mention explicite « dépôt standalone supprimé, projet archivé en sous-dossier du repo public du cours ».
- **Licence** : cite la `LICENSE` du repo de cours (lien direct), avec la précision que le sous-dossier n'a pas de LICENSE propre — c'est celle du repo qui couvre.
- **Note tranche 2** (qui datait l'inaccessibilité au 2026-08-30) : mise à jour au 2026-09-08 — le projet intégral est de nouveau public, licence incluse. La fin de la note (implémentation P4 propre et conforme) est conservée.
- **Table de méthode, étape 3** : re-vérification datée 2026-09-08 sur la cible actuelle, avec renvoi #14789 pour la traçabilité.

## Contrôles

- **Markdown-only** : cellules 88 et 90 changées, `source` seulement — comparaison cellule à cellule contre HEAD : `outputs` et `execution_count` **intacts**, aucune cellule code touchée (exception C.2 modifs uniquement markdown ; l'acceptance de l'issue exclut elle-même toute re-exécution).
- **Rien changé d'autre** : aucun renommage, aucune autre cellule (ils appartiennent à #13769).
- Diff : 5 lignes (1 fichier).

## Hors scope (signalé, pas touché)

La cellule 0 liste « 6 paradigmes » avec 7 items numérotés (Backtracking naïf, +MRV, DLX, GA, recuit, CP-SAT, SMT) — l'issue a vérifié que le compte de **6** est correct au sens des *solveurs de la tranche Sudoku reproduits* ; la numérotation 1-7 de cette liste n'est pas l'objet de #14789.

Closes #14789

