### PR TITLE
fix(guard,#15171): detect_ascii_flowchart --json parseable malgré le warning-flood nbformat

### DIFF
--- a/scripts/notebook_tools/detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/detect_ascii_flowchart.py
@@ -73,6 +73,7 @@ import argparse
 import json
 import re
 import sys
+import warnings
 from pathlib import Path
 
 import nbformat
@@ -370,7 +371,18 @@ def _count_boxes_on_line(line: str) -> int:
 def scan_notebook(path: Path) -> dict:
     """Scan un notebook ; renvoie les cellules markdown contenant des flowcharts ASCII."""
     try:
-        nb = nbformat.read(path, as_version=4)
+        with warnings.catch_warnings():
+            # nbformat emet DuplicateCellId (sous-classe de Warning, module
+            # nbformat.warnings) pendant la lecture (ids de cellules
+            # non-uniques). En mode --json capture via pipe shell sur Windows,
+            # stderr+stdout s'entrelacent et le warning precedent le `{` du
+            # JSON -> json.loads echoue (#11962). On neutralise la categorie a
+            # la source : ces warnings ne sont pas actionnables (le detecteur
+            # ne transforme jamais le notebook) et n'ont de valeur qu'en dev,
+            # pas dans la sortie machine. Module-matche, donc toutes les
+            # categories nbformat (DuplicateCellId compris) sont couvertes.
+            warnings.filterwarnings("ignore", module="^nbformat")
+            nb = nbformat.read(path, as_version=4)
     except (OSError, NotJSONError, ValidationError) as exc:
         # Garde par-fichier (#12097) : un notebook illisible (BOM UTF-8,
         # JSON tronque, validation echouee) ne doit pas interrompre le scan

--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -520,6 +520,87 @@ class TestUnreadableNotebookSkipped:
 
 
 # ---------------------------------------------------------------------------
+# 4ter. --json warning-flood (#11962)
+# ---------------------------------------------------------------------------
+
+def _dup_id_notebook_dict() -> dict:
+    """Un notebook dont deux cellules partagent un id '' -> nbformat emet
+    `DuplicateCellId` (nbformat.warnings.DuplicateCellId) a la lecture.
+    Reproduit le warning de fond du corpus reel (ids de cellules non uniques)."""
+    return {
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "cells": [
+            {"cell_type": "markdown", "metadata": {}, "id": "",
+             "source": "# Header"},
+            {"cell_type": "markdown", "metadata": {}, "id": "",
+             "source": "# Duplicate id"},
+        ],
+    }
+
+
+class TestJsonModeWarningFlood:
+    """#11962 — le mode --json doit rendre une sortie STRICTEMENT parseable
+    (`json.loads` exit 0) quelque soit le volume de warnings nbformat emis
+    sur le scope. Sur Windows, en capture pipe shell, stderr+stdout
+    s'entrelacent : un DuplicateCellId qui precede le `{` du JSON casse
+    `json.loads`. Le fix neutralise la categorie a la source (lecture)."""
+
+    def test_multi_subtree_json_parseable(self, tmp_path):
+        import subprocess
+        import sys as _sys
+        # Scaffold >= 3 sous-arbres, chacun avec un notebook qui declenche
+        # le warning DuplicateCellId a la lecture.
+        for sub in ("a", "b", "c"):
+            d = tmp_path / sub
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "dup.ipynb").write_text(
+                json.dumps(_dup_id_notebook_dict()), encoding="utf-8"
+            )
+        repo_root = Path(__file__).resolve().parents[3]
+        script = repo_root / "scripts/notebook_tools/detect_ascii_flowchart.py"
+        # stderr=STDOUT reproduit l'entrelacement du pipe shell sur Windows :
+        # sans le fix, le warning nbformat precede le `{` -> json.loads echoue.
+        proc = subprocess.run(
+            [_sys.executable, str(script), "--json", str(tmp_path)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            cwd=repo_root,
+        )
+        assert proc.returncode == 0, proc.stderr
+        out = proc.stdout.decode("utf-8", "replace")
+        # La sortie doit commencer par le JSON ({) -- pas un warning.
+        assert out.lstrip().startswith("{"), (
+            f"warning-flood devant la sortie JSON : {out[:200]!r}"
+        )
+        result = json.loads(out)  # exit 0 = acceptation
+        assert result["files_scanned"] == 3
+        assert "findings" in result
+
+    def test_json_no_warning_residue_in_stdout(self, tmp_path):
+        import subprocess
+        import sys as _sys
+        # Même scenario, mais on verifie qu'aucun warning nbformat ne se
+        # retrouve dans stdout (le canal machine doit rester pur).
+        d = tmp_path / "solo"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "dup.ipynb").write_text(
+            json.dumps(_dup_id_notebook_dict()), encoding="utf-8"
+        )
+        repo_root = Path(__file__).resolve().parents[3]
+        script = repo_root / "scripts/notebook_tools/detect_ascii_flowchart.py"
+        proc = subprocess.run(
+            [_sys.executable, str(script), "--json", str(tmp_path)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            cwd=repo_root,
+        )
+        out = proc.stdout.decode("utf-8", "replace")
+        assert "DuplicateCellId" not in out
+        assert "warn" not in out.lower()
+        json.loads(out)
+
+
+# ---------------------------------------------------------------------------
 # 5. Corpus baseline pin (anti-regression)
 # ---------------------------------------------------------------------------
 
@@ -586,6 +667,7 @@ class TestCorpusBaseline:
             ["python", "scripts/notebook_tools/detect_ascii_flowchart.py",
              str(notebooks_dir), "--json"],
             capture_output=True, text=True, cwd=repo_root,
+            encoding="utf-8", errors="replace",  # #12811 : encode explicite, sinon cp1252 crash
         )
         if proc.returncode != 0:
             pytest.skip(f"scan returned {proc.returncode}")


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15071

## Le défaut (#15171)

`detect_ascii_flowchart.py --json MyIA.AI.Notebooks/` (scope global) produit une sortie **non parseable** : `json.loads` échoue avec `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. Cause racine reproduite **firsthand** (c.985, 2026-09-08) : `nbformat.read` émet des warnings `DuplicateCellId` (catégorie `nbformat.warnings.DuplicateCellId`, une sous-classe de `Warning`) à la lecture des notebooks à ids de cellules non-uniques. Sur un scope global, ces warnings précèdent le `{` initial du JSON et, en capture pipe shell sur Windows (stderr+stdout entrelacés), cassent le parse.

Mesure avant/après (synthetic, 3 sous-arbres × 1 notebook à ids dupliqués `id=''`, `stderr=STDOUT` pour reproduire l'entrelacement) :
- **AVANT** : `json.loads` échoue (`JSONDecodeError`), stdout commence par le chemin de la lib nbformat (warning), pas par `{`.
- **APRÈS** : `json.loads` exit 0, stdout commence par `{`, `files_scanned=3`.

Le fix est **côté émission** (la cause), pas un contournement : on neutralise la catégorie à la source, à la lecture. Le détecteur **ne transforme jamais** le notebook ; ces warnings ne sont pas actionnables et n'ont de valeur qu'en dev, pas dans la sortie machine.

## Le fix (2 fichiers, +94/−1)

1. **`scripts/notebook_tools/detect_ascii_flowchart.py`** — dans `scan_notebook`, la lecture est enveloppée de `warnings.catch_warnings()` + `filterwarnings("ignore", module="^nbformat")`. Matche-pas-catégorie volontaire : la classe est `nbformat.warnings.DuplicateCellId` (pas `UserWarning`), donc filtrer par module couvre toutes les catégories nbformat (vérifié par introspection du warning : `nbformat.warnings.DuplicateCellId`). La garde par-fichier `except (OSError, NotJSONError, ValidationError)` reste intacte (un notebook illisible continue d'être reporté dans `skipped`, cf. #12097).
2. **`scripts/notebook_tools/tests/test_detect_ascii_flowchart.py`** — 2 tests : `test_multi_subtree_json_parseable` (scope ≥3 sous-arbres, `stderr=STDOUT` = reproduction fidèle de l'entrelacement Windows, assert `json.loads` exit 0 + `files_scanned==3`), `test_json_no_warning_residue_in_stdout` (aucun `DuplicateCellId`/`warn` dans stdout, JSON parseable).

## Acceptance (#15171)

- [x] `--json MyIA.AI.Notebooks/` rend une sortie **strictement** parseable (`json.loads` exit 0) quelque soit le volume de warnings nbformat (reproduit à la main avec un scope multi-sous-arbres à ids dupliqués ; le scan réel du corpus rend 1239 fichiers scannés / 0 erreur / JSON valide).
- [x] Aucun warning parasite dans stdout en mode `--json` (assert `DuplicateCellId` absent, stdout démarre par `{`).
- [x] Comportement inchangé en mode texte (sortie stdout verbeuse) — rejoué : `Notebooks scanned : 1` etc.
- [x] Test unitaire ajouté qui scanne un scope multi-dossier (≥3 sous-arbres) et vérifie `json.loads()` exit 0 sur la sortie — 2 tests (accessibilité + absence de résidu).

## Contrôles

- **Reproduction première main** (avant le fix) : scope synthétique 3 sous-arbres, `stderr=STDOUT` → `JSONDecodeError`. Après : `JSON_OK`. La cause (module `nbformat`, catégorie `DuplicateCellId`) est identifiée par introspection, pas supposée.
- **Suite du module** : `pytest scripts/notebook_tools/tests/test_detect_ascii_flowchart.py` → **27 passed** (25 préexistants + 2 nouveaux), aucun changement de détection (le pin `CORPUS_BASELINE_*` reste un cliquet : la mesure corpus rend 0/0 à ce SHA, déjà desserré par le rollout #11962 qui a converti les flowcharts en Mermaid — baisse = le rollout, pas une perte de détection, et le test ne fait que *prévenir* sous le plancher).
- **Périmètre G.4** : 2 fichiers, +94/−1, 1 domaine (guard), ≥3000 lignes non atteint — one-subject-per-PR.

## Notes

- Le seul changement de comportement est l'absence de warning nbformat en sortie machine ; la détection de flowcharts et le rapport des notebooks illisibles sont inchangés.

Closes #15171
