### PR TITLE
fix(symbolicai,#14122): SL-4-Csharp active #nullable — purge 7 CS8632 (T6)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
@@ -5,10 +5,10 @@
    "id": "0539e864",
    "metadata": {
     "papermill": {
-     "duration": 0.003542,
-     "end_time": "2026-08-15T19:07:20.949555+00:00",
+     "duration": 0.002287,
+     "end_time": "2026-09-08T07:46:22.354816+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:20.946013+00:00",
+     "start_time": "2026-09-08T07:46:22.352529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -34,16 +34,36 @@
    "id": "a71360f7",
    "metadata": {
     "papermill": {
-     "duration": 0.002788,
-     "end_time": "2026-08-15T19:07:20.955412+00:00",
+     "duration": 0.001549,
+     "end_time": "2026-09-08T07:46:22.358312+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:20.952624+00:00",
+     "start_time": "2026-09-08T07:46:22.356763+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## Introduction\n\n### Pourquoi l'ILP ?\n\nL'apprentissage propositionnel (SL-1 à SL-3) apprend des conjonctions d'attributs fixes. Mais la connaissance du monde réel est **relationnelle** : « X est parent de Y », « si X est ancêtre de Y et Y de Z, alors X est ancêtre de Z ». La **Programmation Logique Inductive** (ILP, AIMA §19.5) apprend de telles **règles logiques du premier ordre** (clauses Horn) à partir d'exemples positifs/négatifs et d'un **background knowledge**.\n\n### Deux familles d'algorithmes\n\n| Approche | Direction | Algorithme emblématique |\n|----------|-----------|------------------------|\n| **Top-down** | Général → spécifique (on spécialise) | **FOIL** (Quinlan 1990) |\n| **Bottom-up** | Spécifique → général (on généralise) | **Résolution inverse** (Muggleton 1987), opérateurs V/W |\n\nFOIL part d'une règle vide et **ajoute** des littéraux pour réduire les négatifs couverts (gain d'information). La résolution inverse part de faits et **absorbe** (V) ou **combine** (W) des clauses pour généraliser.\n\n### Complémentarité (#3801)\n\n| Aspect | Python (twin) | Twin C# (ici) |\n|--------|---------------|----------------|\n| Moteur from-scratch | stdlib (dataclass) | **record C# + BCL, 0 NuGet** |\n| SOTA ILP | **Popper** (ASP + Prolog) | **SOTA-OK** : pont clingo `Process.Start` (§9) |\n"
+    "## Introduction\n",
+    "\n",
+    "### Pourquoi l'ILP ?\n",
+    "\n",
+    "L'apprentissage propositionnel (SL-1 à SL-3) apprend des conjonctions d'attributs fixes. Mais la connaissance du monde réel est **relationnelle** : « X est parent de Y », « si X est ancêtre de Y et Y de Z, alors X est ancêtre de Z ». La **Programmation Logique Inductive** (ILP, AIMA §19.5) apprend de telles **règles logiques du premier ordre** (clauses Horn) à partir d'exemples positifs/négatifs et d'un **background knowledge**.\n",
+    "\n",
+    "### Deux familles d'algorithmes\n",
+    "\n",
+    "| Approche | Direction | Algorithme emblématique |\n",
+    "|----------|-----------|------------------------|\n",
+    "| **Top-down** | Général → spécifique (on spécialise) | **FOIL** (Quinlan 1990) |\n",
+    "| **Bottom-up** | Spécifique → général (on généralise) | **Résolution inverse** (Muggleton 1987), opérateurs V/W |\n",
+    "\n",
+    "FOIL part d'une règle vide et **ajoute** des littéraux pour réduire les négatifs couverts (gain d'information). La résolution inverse part de faits et **absorbe** (V) ou **combine** (W) des clauses pour généraliser.\n",
+    "\n",
+    "### Complémentarité (#3801)\n",
+    "\n",
+    "| Aspect | Python (twin) | Twin C# (ici) |\n",
+    "|--------|---------------|----------------|\n",
+    "| Moteur from-scratch | stdlib (dataclass) | **record C# + BCL, 0 NuGet** |\n",
+    "| SOTA ILP | **Popper** (ASP + Prolog) | **SOTA-OK** : pont clingo `Process.Start` (§9) |\n"
    ]
   },
   {
@@ -51,10 +71,10 @@
    "id": "98632c76",
    "metadata": {
     "papermill": {
-     "duration": 0.003021,
-     "end_time": "2026-08-15T19:07:20.961321+00:00",
+     "duration": 0.001675,
+     "end_time": "2026-09-08T07:46:22.361612+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:20.958300+00:00",
+     "start_time": "2026-09-08T07:46:22.359937+00:00",
      "status": "completed"
     },
     "tags": []
@@ -73,16 +93,16 @@
    "id": "a9a3aca9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:20.979356Z",
-     "iopub.status.busy": "2026-08-15T19:07:20.971604Z",
-     "iopub.status.idle": "2026-08-15T19:07:23.197449Z",
-     "shell.execute_reply": "2026-08-15T19:07:23.192877Z"
+     "iopub.execute_input": "2026-09-08T07:46:22.374525Z",
+     "iopub.status.busy": "2026-09-08T07:46:22.368134Z",
+     "iopub.status.idle": "2026-09-08T07:46:24.376462Z",
+     "shell.execute_reply": "2026-09-08T07:46:24.372138Z"
     },
     "papermill": {
-     "duration": 2.233543,
-     "end_time": "2026-08-15T19:07:23.197778+00:00",
+     "duration": 2.013033,
+     "end_time": "2026-09-08T07:46:24.376557+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:20.964235+00:00",
+     "start_time": "2026-09-08T07:46:22.363524+00:00",
      "status": "completed"
     },
     "tags": []
@@ -97,6 +117,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -106,7 +127,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -121,6 +145,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -132,11 +157,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '158680.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '960.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -180,11 +207,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -272,26 +301,10 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(35,40): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(43,40): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(53,97): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(53,40): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n",
-      "(11,39): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "// Cellule 1 — Literal, HornClause, unification (persistant cross-cell .net-csharp)\n",
     "using System;\n",
     "using System.Collections.Generic;\n",
@@ -380,10 +393,10 @@
    "id": "430ef3f7",
    "metadata": {
     "papermill": {
-     "duration": 0.003403,
-     "end_time": "2026-08-15T19:07:23.204938+00:00",
+     "duration": 0.002163,
+     "end_time": "2026-09-08T07:46:24.381262+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.201535+00:00",
+     "start_time": "2026-09-08T07:46:24.379099+00:00",
      "status": "completed"
     },
     "tags": []
@@ -404,16 +417,16 @@
    "id": "ac28569d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:23.213642Z",
-     "iopub.status.busy": "2026-08-15T19:07:23.213424Z",
-     "iopub.status.idle": "2026-08-15T19:07:23.456609Z",
-     "shell.execute_reply": "2026-08-15T19:07:23.456428Z"
+     "iopub.execute_input": "2026-09-08T07:46:24.386490Z",
+     "iopub.status.busy": "2026-09-08T07:46:24.386321Z",
+     "iopub.status.idle": "2026-09-08T07:46:24.617468Z",
+     "shell.execute_reply": "2026-09-08T07:46:24.617332Z"
     },
     "papermill": {
-     "duration": 0.248199,
-     "end_time": "2026-08-15T19:07:23.456689+00:00",
+     "duration": 0.234185,
+     "end_time": "2026-09-08T07:46:24.617528+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.208490+00:00",
+     "start_time": "2026-09-08T07:46:24.383343+00:00",
      "status": "completed"
     },
     "tags": []
@@ -554,10 +567,10 @@
    "id": "c1c33137",
    "metadata": {
     "papermill": {
-     "duration": 0.004275,
-     "end_time": "2026-08-15T19:07:23.465323+00:00",
+     "duration": 0.00323,
+     "end_time": "2026-09-08T07:46:24.623092+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.461048+00:00",
+     "start_time": "2026-09-08T07:46:24.619862+00:00",
      "status": "completed"
     },
     "tags": []
@@ -576,16 +589,16 @@
    "id": "bf0052cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:23.476632Z",
-     "iopub.status.busy": "2026-08-15T19:07:23.476376Z",
-     "iopub.status.idle": "2026-08-15T19:07:23.610610Z",
-     "shell.execute_reply": "2026-08-15T19:07:23.610296Z"
+     "iopub.execute_input": "2026-09-08T07:46:24.629639Z",
+     "iopub.status.busy": "2026-09-08T07:46:24.629436Z",
+     "iopub.status.idle": "2026-09-08T07:46:24.728306Z",
+     "shell.execute_reply": "2026-09-08T07:46:24.728178Z"
     },
     "papermill": {
-     "duration": 0.140737,
-     "end_time": "2026-08-15T19:07:23.610739+00:00",
+     "duration": 0.102494,
+     "end_time": "2026-09-08T07:46:24.728367+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.470002+00:00",
+     "start_time": "2026-09-08T07:46:24.625873+00:00",
      "status": "completed"
     },
     "tags": []
@@ -734,10 +747,10 @@
    "id": "b408a87e",
    "metadata": {
     "papermill": {
-     "duration": 0.005551,
-     "end_time": "2026-08-15T19:07:23.623104+00:00",
+     "duration": 0.002669,
+     "end_time": "2026-09-08T07:46:24.734039+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.617553+00:00",
+     "start_time": "2026-09-08T07:46:24.731370+00:00",
      "status": "completed"
     },
     "tags": []
@@ -754,16 +767,16 @@
    "id": "58744f18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:23.637040Z",
-     "iopub.status.busy": "2026-08-15T19:07:23.636714Z",
-     "iopub.status.idle": "2026-08-15T19:07:23.835107Z",
-     "shell.execute_reply": "2026-08-15T19:07:23.834935Z"
+     "iopub.execute_input": "2026-09-08T07:46:24.740311Z",
+     "iopub.status.busy": "2026-09-08T07:46:24.740147Z",
+     "iopub.status.idle": "2026-09-08T07:46:24.880137Z",
+     "shell.execute_reply": "2026-09-08T07:46:24.880001Z"
     },
     "papermill": {
-     "duration": 0.205808,
-     "end_time": "2026-08-15T19:07:23.835195+00:00",
+     "duration": 0.143677,
+     "end_time": "2026-09-08T07:46:24.880200+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.629387+00:00",
+     "start_time": "2026-09-08T07:46:24.736523+00:00",
      "status": "completed"
     },
     "tags": []
@@ -966,10 +979,10 @@
    "id": "6e53df30",
    "metadata": {
     "papermill": {
-     "duration": 0.006078,
-     "end_time": "2026-08-15T19:07:23.847127+00:00",
+     "duration": 0.00332,
+     "end_time": "2026-09-08T07:46:24.887190+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.841049+00:00",
+     "start_time": "2026-09-08T07:46:24.883870+00:00",
      "status": "completed"
     },
     "tags": []
@@ -989,16 +1002,16 @@
    "id": "755e9fc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:23.860092Z",
-     "iopub.status.busy": "2026-08-15T19:07:23.859853Z",
-     "iopub.status.idle": "2026-08-15T19:07:24.021957Z",
-     "shell.execute_reply": "2026-08-15T19:07:24.022086Z"
+     "iopub.execute_input": "2026-09-08T07:46:24.895405Z",
+     "iopub.status.busy": "2026-09-08T07:46:24.895200Z",
+     "iopub.status.idle": "2026-09-08T07:46:25.068292Z",
+     "shell.execute_reply": "2026-09-08T07:46:25.068128Z"
     },
     "papermill": {
-     "duration": 0.169448,
-     "end_time": "2026-08-15T19:07:24.022169+00:00",
+     "duration": 0.177627,
+     "end_time": "2026-09-08T07:46:25.068361+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:23.852721+00:00",
+     "start_time": "2026-09-08T07:46:24.890734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1098,18 +1111,10 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,25): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "// Cellule 5 — Operateurs V (absorption) et W (identification)\n",
     "public static HornClause? ApplyVOperator(HornClause clause, Literal backgroundFact)\n",
     "{\n",
@@ -1195,10 +1200,10 @@
    "id": "76d24ec5",
    "metadata": {
     "papermill": {
-     "duration": 0.008403,
-     "end_time": "2026-08-15T19:07:24.037137+00:00",
+     "duration": 0.003956,
+     "end_time": "2026-09-08T07:46:25.076446+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.028734+00:00",
+     "start_time": "2026-09-08T07:46:25.072490+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1217,16 +1222,16 @@
    "id": "7901d67e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:24.049809Z",
-     "iopub.status.busy": "2026-08-15T19:07:24.049610Z",
-     "iopub.status.idle": "2026-08-15T19:07:24.279199Z",
-     "shell.execute_reply": "2026-08-15T19:07:24.279450Z"
+     "iopub.execute_input": "2026-09-08T07:46:25.085246Z",
+     "iopub.status.busy": "2026-09-08T07:46:25.085021Z",
+     "iopub.status.idle": "2026-09-08T07:46:25.265582Z",
+     "shell.execute_reply": "2026-09-08T07:46:25.265333Z"
     },
     "papermill": {
-     "duration": 0.236712,
-     "end_time": "2026-08-15T19:07:24.279597+00:00",
+     "duration": 0.185603,
+     "end_time": "2026-09-08T07:46:25.265700+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.042885+00:00",
+     "start_time": "2026-09-08T07:46:25.080097+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1307,18 +1312,10 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(30,20): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
     }
    ],
    "source": [
+    "#nullable enable\n",
     "// Cellule 6 — FOIL covering sequentiel avec trace\n",
     "public static (List<HornClause> rules, HashSet<(string X,string Y)> uncovered) FoilStepByStep(\n",
     "    string targetPred, string[] targetArgs, string[] constants,\n",
@@ -1402,10 +1399,10 @@
    "id": "86e01782",
    "metadata": {
     "papermill": {
-     "duration": 0.013026,
-     "end_time": "2026-08-15T19:07:24.305978+00:00",
+     "duration": 0.00419,
+     "end_time": "2026-09-08T07:46:25.275395+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.292952+00:00",
+     "start_time": "2026-09-08T07:46:25.271205+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1422,16 +1419,16 @@
    "id": "38f9c9a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:24.336937Z",
-     "iopub.status.busy": "2026-08-15T19:07:24.336416Z",
-     "iopub.status.idle": "2026-08-15T19:07:24.575373Z",
-     "shell.execute_reply": "2026-08-15T19:07:24.575190Z"
+     "iopub.execute_input": "2026-09-08T07:46:25.285708Z",
+     "iopub.status.busy": "2026-09-08T07:46:25.285305Z",
+     "iopub.status.idle": "2026-09-08T07:46:25.446281Z",
+     "shell.execute_reply": "2026-09-08T07:46:25.446131Z"
     },
     "papermill": {
-     "duration": 0.25557,
-     "end_time": "2026-08-15T19:07:24.575463+00:00",
+     "duration": 0.166457,
+     "end_time": "2026-09-08T07:46:25.446345+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.319893+00:00",
+     "start_time": "2026-09-08T07:46:25.279888+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1749,10 +1746,10 @@
    "id": "19d976b4",
    "metadata": {
     "papermill": {
-     "duration": 0.008712,
-     "end_time": "2026-08-15T19:07:24.593138+00:00",
+     "duration": 0.004131,
+     "end_time": "2026-09-08T07:46:25.455249+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.584426+00:00",
+     "start_time": "2026-09-08T07:46:25.451118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1768,10 +1765,10 @@
    "id": "d6f7497c",
    "metadata": {
     "papermill": {
-     "duration": 0.00926,
-     "end_time": "2026-08-15T19:07:24.611507+00:00",
+     "duration": 0.003865,
+     "end_time": "2026-09-08T07:46:25.463141+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.602247+00:00",
+     "start_time": "2026-09-08T07:46:25.459276+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1790,16 +1787,16 @@
    "id": "fbf850e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:24.632660Z",
-     "iopub.status.busy": "2026-08-15T19:07:24.632306Z",
-     "iopub.status.idle": "2026-08-15T19:07:24.747595Z",
-     "shell.execute_reply": "2026-08-15T19:07:24.747401Z"
+     "iopub.execute_input": "2026-09-08T07:46:25.471991Z",
+     "iopub.status.busy": "2026-09-08T07:46:25.471825Z",
+     "iopub.status.idle": "2026-09-08T07:46:25.564862Z",
+     "shell.execute_reply": "2026-09-08T07:46:25.564638Z"
     },
     "papermill": {
-     "duration": 0.126448,
-     "end_time": "2026-08-15T19:07:24.747681+00:00",
+     "duration": 0.098169,
+     "end_time": "2026-09-08T07:46:25.564970+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.621233+00:00",
+     "start_time": "2026-09-08T07:46:25.466801+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1835,10 +1832,10 @@
    "id": "f9d768ec",
    "metadata": {
     "papermill": {
-     "duration": 0.009016,
-     "end_time": "2026-08-15T19:07:24.765574+00:00",
+     "duration": 0.004726,
+     "end_time": "2026-09-08T07:46:25.577010+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.756558+00:00",
+     "start_time": "2026-09-08T07:46:25.572284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1857,16 +1854,16 @@
    "id": "188b5294",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:24.784933Z",
-     "iopub.status.busy": "2026-08-15T19:07:24.784677Z",
-     "iopub.status.idle": "2026-08-15T19:07:24.845200Z",
-     "shell.execute_reply": "2026-08-15T19:07:24.845019Z"
+     "iopub.execute_input": "2026-09-08T07:46:25.589466Z",
+     "iopub.status.busy": "2026-09-08T07:46:25.589239Z",
+     "iopub.status.idle": "2026-09-08T07:46:25.646749Z",
+     "shell.execute_reply": "2026-09-08T07:46:25.646447Z"
     },
     "papermill": {
-     "duration": 0.071084,
-     "end_time": "2026-08-15T19:07:24.845301+00:00",
+     "duration": 0.065166,
+     "end_time": "2026-09-08T07:46:25.646885+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.774217+00:00",
+     "start_time": "2026-09-08T07:46:25.581719+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1901,10 +1898,10 @@
    "id": "a0c0f5a5",
    "metadata": {
     "papermill": {
-     "duration": 0.008111,
-     "end_time": "2026-08-15T19:07:24.862039+00:00",
+     "duration": 0.01124,
+     "end_time": "2026-09-08T07:46:25.666917+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.853928+00:00",
+     "start_time": "2026-09-08T07:46:25.655677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1923,16 +1920,16 @@
    "id": "8332c7ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:24.879493Z",
-     "iopub.status.busy": "2026-08-15T19:07:24.879217Z",
-     "iopub.status.idle": "2026-08-15T19:07:24.950586Z",
-     "shell.execute_reply": "2026-08-15T19:07:24.950301Z"
+     "iopub.execute_input": "2026-09-08T07:46:25.688247Z",
+     "iopub.status.busy": "2026-09-08T07:46:25.687991Z",
+     "iopub.status.idle": "2026-09-08T07:46:25.788410Z",
+     "shell.execute_reply": "2026-09-08T07:46:25.788181Z"
     },
     "papermill": {
-     "duration": 0.080482,
-     "end_time": "2026-08-15T19:07:24.950713+00:00",
+     "duration": 0.111889,
+     "end_time": "2026-09-08T07:46:25.788471+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.870231+00:00",
+     "start_time": "2026-09-08T07:46:25.676582+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1968,10 +1965,10 @@
    "id": "9cec227d",
    "metadata": {
     "papermill": {
-     "duration": 0.008184,
-     "end_time": "2026-08-15T19:07:24.968178+00:00",
+     "duration": 0.004232,
+     "end_time": "2026-09-08T07:46:25.796933+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.959994+00:00",
+     "start_time": "2026-09-08T07:46:25.792701+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2000,16 +1997,16 @@
    "id": "b6adf2d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T19:07:24.986571Z",
-     "iopub.status.busy": "2026-08-15T19:07:24.986302Z",
-     "iopub.status.idle": "2026-08-15T19:07:25.635482Z",
-     "shell.execute_reply": "2026-08-15T19:07:25.635293Z"
+     "iopub.execute_input": "2026-09-08T07:46:25.807232Z",
+     "iopub.status.busy": "2026-09-08T07:46:25.807058Z",
+     "iopub.status.idle": "2026-09-08T07:46:26.331159Z",
+     "shell.execute_reply": "2026-09-08T07:46:26.330942Z"
     },
     "papermill": {
-     "duration": 0.659086,
-     "end_time": "2026-08-15T19:07:25.635561+00:00",
+     "duration": 0.530056,
+     "end_time": "2026-09-08T07:46:26.331263+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:24.976475+00:00",
+     "start_time": "2026-09-08T07:46:25.801207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2347,10 +2344,10 @@
    "id": "c7a59b8e",
    "metadata": {
     "papermill": {
-     "duration": 0.010423,
-     "end_time": "2026-08-15T19:07:25.656269+00:00",
+     "duration": 0.009449,
+     "end_time": "2026-09-08T07:46:26.350067+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:25.645846+00:00",
+     "start_time": "2026-09-08T07:46:26.340618+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2368,10 +2365,10 @@
    "id": "5aa92035",
    "metadata": {
     "papermill": {
-     "duration": 0.015376,
-     "end_time": "2026-08-15T19:07:25.683224+00:00",
+     "duration": 0.004731,
+     "end_time": "2026-09-08T07:46:26.362664+00:00",
      "exception": false,
-     "start_time": "2026-08-15T19:07:25.667848+00:00",
+     "start_time": "2026-09-08T07:46:26.357933+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2412,14 +2409,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 8.257588,
-   "end_time": "2026-08-15T19:07:26.259002+00:00",
+   "duration": 7.617468,
+   "end_time": "2026-09-08T07:46:26.489912+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp_output.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb",
    "parameters": {},
-   "start_time": "2026-08-15T19:07:18.001414+00:00",
+   "start_time": "2026-09-08T07:46:18.872444+00:00",
    "version": "2.6.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/sl-4-inductivelogicprogramming/0008-2026-09-08-myia-po-2027-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-4-inductivelogicprogramming/0008-2026-09-08-myia-po-2027-CoursIA.yaml
@@ -1,0 +1,6 @@
+date: '2026-09-08'
+by: myia-po-2027:CoursIA
+python_sha: 1921eb10edcd3e2e932cbc145b28693aea1123da
+csharp_sha: af6d59ef6bfd4e6ded8478012edaed10ce113875
+content_python_sha: b1bef7343160148d5a11230e6a5914aa4049e4dcd476edcc999f76c469f7e031
+content_csharp_sha: 646162a217c2b8c2ed94e2a5d87151ce052747d41b2841855f9da8bd3b2f5a9f


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: MED/guard #14959

## Summary

Tranche T6 de #14122 (purge des warnings d'exécution) — **SL-4-InductiveLogicProgramming-Csharp** portait **7 warnings CS8632** en output (« L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte '#nullable' »), répartis sur 3 cellules (unification, opérateurs V, FOIL covering).

- **Cause racine** : signatures C# modernes et correctes (`HornClause?`, `List<>?`, `Dictionary<,>?`) sans contexte nullable actif — même défaut que CSP-9 en T5 (#15158).
- **Fix causal** : `#nullable enable` en première ligne des 3 cellules concernées — convention établie du dépôt (8+ notebooks C# déjà traités). **Aucun nouveau warning CS** : l'analyse nullable confirme que les annotations existantes étaient correctes — le code était bien écrit, seul le contexte manquait.
- **Stricteté du diff de source** : exactement **3 insertions** `#nullable enable` (vérifié programmatiquement, delta cellule par cellule), aucune autre modification de source.

## Validation

- Re-exec papermill end-to-end (kernel `.net-csharp`, ~7 s) : **11/11 cellules code**, 0 erreur, séquence CLEAN (1..11).
- **CS8632 : 7 → 0** ; inventaire CS reexec = `{}` strictement (aucun nouveau warning).
- Bannière `probeAddresses` strippée par le hook pre-commit (9 lignes — normalisation systématique post-re-exec .NET, L532) ; metadata papermill conservée (convention de cette série, présente sur HEAD).
- Env note : le restore `#r nuget:` exige `DOTNET_ROOT` système (`C:\Program Files\dotnet`) — sous le DOTNET_ROOT utilisateur, le kernel échoue avec `PackageRestoreResult: Must provide errors when succeeded is false`.

## Twin parity

Paire `SL-4 InductiveLogicProgramming` : seule la face C# est touchée (purge nullable). Attestation `check_twin_parity.py --update --pair "SL-4 InductiveLogicProgramming"` commitée dans la PR (`twin_pairs.d/sl-4-inductivelogicprogramming/0008-2026-09-08-myia-po-2027-CoursIA.yaml`).

See #14122 (contribution partielle — tranche T6 ; l'EPIC multi-tranches reste ouverte).
