### PR TITLE
fix(ci,#15153): epingler le runner 2.337.0 et desactiver le self-update ephemere

### DIFF
--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -15,9 +15,9 @@
 
 FROM ubuntu:24.04
 
-ARG RUNNER_VERSION=2.336.0
-# Checksum officiel de la release v2.336.0 (notes de release actions/runner).
-ARG RUNNER_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
+ARG RUNNER_VERSION=2.337.0
+# Checksum officiel de la release v2.337.0 (notes de release actions/runner).
+ARG RUNNER_SHA256=70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613
 
 ENV DEBIAN_FRONTEND=noninteractive
 # python-is-python3 : les workflows stdlib-only appellent `python` nu

--- a/scripts/ci/docker/linux-runner/Dockerfile.lean
+++ b/scripts/ci/docker/linux-runner/Dockerfile.lean
@@ -24,7 +24,7 @@
 # coursia-linux : le label distinct EST la garantie de routage (un garde
 # Python ne doit pas atterrir sur un slot Lean, et inversement).
 
-FROM coursia-linux-runner:2.336.0
+FROM coursia-linux-runner:2.337.0
 
 # elan pince par SHA-256, meme discipline que le Dockerfile de base.
 # v4.2.4, asset elan-x86_64-unknown-linux-gnu.tar.gz (contient elan-init).

--- a/scripts/ci/docker/linux-runner/entrypoint.sh
+++ b/scripts/ci/docker/linux-runner/entrypoint.sh
@@ -50,7 +50,27 @@ done
 # ---------------------------------------------------------------------------
 
 cd /opt/runner
-./config.sh --unattended --ephemeral --replace
+# --disableupdate : le conteneur est --rm et le runner --ephemeral (un seul
+# job puis mort). Un self-update n'y est donc jamais CONSERVE -- GitHub ordonne
+# la mise a jour, le runner telecharge le tarball apres le job, le conteneur
+# meurt, --rm efface le telechargement, le suivant repart de l'image epinglee
+# et retelecharge. Le travail de mise a jour n'est jamais reutilise.
+# Mesure sur les 8 logs de slot de la flotte A, ~6 jours, pivot au rebuild de
+# l'image (2026-09-08T07:10Z), image epinglee 2.336.0 alors que GitHub exigeait
+# 2.337.0 :
+#                              avant     apres
+#   'Downloading ... runner'    7939         0
+#   'update process finished'   5566         0
+#   jobs termines               7535       169
+# Soit ~1,05 telechargement par job, et une borne basse d'egress de
+# 5566 x 215 Mio = 1,14 Tio perdus pour la seule flotte A sur la periode.
+# Les jobs se terminaient normalement : le defaut est du gaspillage de bande
+# passante, pas une famine CI -- ne pas invoquer ce bloc pour diagnostiquer
+# des jobs qui ne partent pas, la cause serait ailleurs.
+# La version du runner EST celle de l'image : elle se bumpe par un rebuild
+# (ARG RUNNER_VERSION du Dockerfile), jamais a chaud. Sans ce flag, la prochaine
+# exigence de version rearme exactement la meme boucle. Cf #15153, #15164.
+./config.sh --unattended --ephemeral --replace --disableupdate
 
 # Teardown symetrique : --ephemeral desenregistre de lui-meme apres le job ;
 # le trap couvre les sorties en erreur (config echoue, run.sh interrompu).

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -34,7 +34,7 @@
 set -uo pipefail
 
 REPO="${COURSIA_RUNNER_REPO:-jsboige/CoursIA}"
-IMAGE="${COURSIA_RUNNER_IMAGE:-coursia-linux-runner:2.336.0}"
+IMAGE="${COURSIA_RUNNER_IMAGE:-coursia-linux-runner:2.337.0}"
 LABELS="${COURSIA_RUNNER_LABELS:-self-hosted,coursia-ephemeral,coursia-linux}"
 NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-myia-po-2024-linux-docker}"
 STATE_DIR="${COURSIA_RUNNER_STATE_DIR:-$HOME/.coursia-runner}"
@@ -89,7 +89,7 @@ WAITER_PIDS="${COURSIA_RUNNER_WAITER_PIDS:-128}"
 # Le .lake chaud vit dans le volume _work PAR SLOT au prefixe dedie
 # coursia-runner-work-lean-{N} (pattern #14285) : .lake/packages et .lake/build
 # survivent aux conteneurs, lake build devient incremental.
-LEAN_IMAGE="${COURSIA_LEAN_RUNNER_IMAGE:-coursia-lean-runner:2.336.0}"
+LEAN_IMAGE="${COURSIA_LEAN_RUNNER_IMAGE:-coursia-lean-runner:2.337.0}"
 LEAN_LABELS="${COURSIA_LEAN_RUNNER_LABELS:-self-hosted,coursia-ephemeral,coursia-lean}"
 LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-myia-po-2024-lean-docker}"
 LEAN_WORK_VOLUME_PREFIX="${COURSIA_LEAN_RUNNER_WORK_VOLUME_PREFIX:-coursia-runner-work-lean}"


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/guard #15034

Livre les **deux volets** exiges par #15153, dans le meme commit, avec le lien entre eux ecrit.

## Le defaut

Un runner `--ephemeral` dans un conteneur `--rm` ne peut structurellement pas
**conserver** un self-update :

1. GitHub ordonne la mise a jour ;
2. le runner telecharge le tarball **apres** la fin du job ;
3. le conteneur sort (`--ephemeral`) et `--rm` efface le telechargement ;
4. le suivant repart de l'image epinglee et retelecharge.

La mise a jour n'est **jamais reutilisee**. C'est du telechargement pur, a chaque job.

## Mesure avant / apres (critere d'acceptance #2)

8 logs de slot de la flotte A, ~6 jours, pivot au rebuild de l'image (2026-09-08T07:10Z) :

| marqueur | avant | apres |
|---|---:|---:|
| `Downloading ... runner` | **7939** | **0** |
| `Runner update process finished` | **5566** | **0** |
| jobs termines | 7535 | 169 |

- **~1,05 telechargement par job** avant, **0** apres.
- Borne basse d'egress : **5566 x 215 Mio = 1,14 Tio** pour la seule flotte A
  sur la periode, entierement perdu (borne haute, telechargements entames :
  7939 x 215 Mio = 1,63 Tio).

**Correction d'une affirmation que je portais avant de mesurer** : les jobs se
terminaient normalement pendant tout l'episode (1290 le 2026-09-07, par exemple).
Il n'y a pas eu de famine ni de « zero job termine » — le defaut est du
gaspillage de bande passante, exactement comme #15153 le decrit. Le premier
etat de cette PR affirmait le contraire ; les comptes ci-dessus le refutent et
le texte a ete corrige.

## Controle positif (critere d'acceptance #3)

L'issue le demande nommement : *« verifier qu'un runner avec update desactive
prend bien les jobs — le refus silencieux de jobs serait pire que le
telechargement »*.

Apres le fix : **169 jobs pris et termines, dont 155 `Succeeded`, avec zero
telechargement**. Les runners prennent bien les jobs. Flotte saine a la
redaction : 8 conteneurs (`myia-ai-01-wsl-{1..4}` + `myia-ai-01-linux-waiter-{1..4}`)
sur `coursia-linux-runner:2.337.0`, uptimes echelonnes de 1 s a 12 min —
c'est-a-dire des slots qui prennent et **terminent** des jobs.

## Le fix — deux moities indissociables (critere d'acceptance #4)

| Moitie | Fichier | Seule, elle laisse quoi |
|---|---|---|
| `--disableupdate` sur `config.sh` | `entrypoint.sh` | rien : c'est le volet qui tient dans le temps |
| image `2.336.0` -> `2.337.0` | `Dockerfile`, `Dockerfile.lean`, `supervise.sh` | le defaut se rouvre a la prochaine release amont |

Le volet 1 sans le volet 2 laisserait tourner un runner en retard d'une version
(supporte, mais inutilement) ; le volet 2 sans le volet 1 rouvre le defaut au
prochain `actions/runner`. La version du runner **EST** celle de l'image : elle
se bumpe par un rebuild (`ARG RUNNER_VERSION`), jamais a chaud.

## Le pin n'est pas circulaire

`RUNNER_SHA256=70920811a4f8...` est **lu chez l'editeur** (notes de release
`actions/runner` v2.337.0, champ `BEGIN SHA linux-x64`), non recalcule sur le
tarball telecharge — un pin recalcule ne verifierait que l'identite du fichier
avec lui-meme.

Les blobs des quatre fichiers sont en LF pur, verifie au niveau octet avec un
controle positif sur des octets CRLF fabriques (`grep -c $'\r'` degenere en
`grep -c ''` sous Git Bash et rend le nombre de lignes, pas le nombre de CR).

## Portee

Cette PR porte **le bump d'image et le flag, seuls**. Les defauts de budget RAM
sont portes par #15123, qui les livre deja a l'identique — les hunks
correspondants ont ete retires de cette branche pour ne pas livrer deux fois le
meme changement.

## Defauts adjacents constates ici, deja traces ailleurs

1. **`coursia-lean-runner` n'existe sur aucun des deux daemons**, en aucune
   version : le chemin `supervise.sh lean` est mort *avant* cette PR, qui garde
   seulement les deux tags coherents. A filer separement.
2. **Aucune regle `.gitattributes` ne couvre `Dockerfile*`** : les blobs sont en
   LF aujourd'hui, mais rien ne le rend structurel — le fichier documente
   pourtant ce motif pour `*.sh` et `*.lean`. A filer separement.
3. **La derive de version d'image n'a pas de garde** : deja porte par #14801
   (« rien ne garantit qu'un correctif d'entrypoint atteigne l'image deployee »).

Closes #15153
See #15164
