### PR TITLE
fix(ci,#15184): force stdout UTF-8 de fetch_merged_prs_since (cp1252)

### DIFF
--- a/scripts/ci/fetch_merged_prs_since.py
+++ b/scripts/ci/fetch_merged_prs_since.py
@@ -159,6 +159,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"fetch_merged_prs_since: {e}", file=sys.stderr)
         return 1
 
+    # Windows stdout est cp1252 -- forcer UTF-8 (UnicodeEncodeError sinon, #15184).
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
     json.dump(prs, sys.stdout, ensure_ascii=False)
     print()
     return 0

--- a/scripts/tests/test_fetch_merged_prs_since.py
+++ b/scripts/tests/test_fetch_merged_prs_since.py
@@ -17,6 +17,7 @@ Two mechanisms produced that degradation, and these tests pin both shut:
 Run:
     python -m pytest scripts/tests/test_fetch_merged_prs_since.py
 """
+import io
 import shutil
 import subprocess
 import sys
@@ -128,6 +129,28 @@ def test_main_returns_1_when_the_fetch_raises():
         assert fmps.main(["--days", "3"]) == 1
     finally:
         fmps.fetch = original
+
+
+def test_main_writes_utf8_on_cp1252_stdout(monkeypatch):
+    """#15184: Windows stdout is cp1252 -- a PR body with a non-cp1252
+    character (e.g. '→') raised UnicodeEncodeError and the whole window was
+    lost, silently degrading the adjacency guard to `prev: declared`.
+    main() must force UTF-8 so the window is always consumable."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    original = fmps.fetch
+    fmps.fetch = lambda since: [
+        {"number": 1, "body": "a → b", "mergedAt": "2026-09-08T00:00:00Z"}
+    ]
+    try:
+        assert fmps.main(["--days", "3"]) == 0
+    finally:
+        fmps.fetch = original
+
+    stream.flush()
+    data = stream.buffer.getvalue().decode("utf-8")
+    assert "a → b" in data
 
 
 @pytest.mark.skipif(shutil.which("gh") is None, reason="gh binary absent")


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA — prev: MED/slides #15130

## Summary

`fetch_merged_prs_since.py:162` fait `json.dump(prs, sys.stdout, ensure_ascii=False)`. Sur un stdout Windows cp1252, un titre/body de PR portant un caractère hors-cp1252 (ex. `→`) lève `UnicodeEncodeError` → le fetch entier échoue (exit 1), la fenêtre merge est perdue, et le gate G-VAR-3 retombe **silencieusement** sur le champ `prev: declared` — c'est-à-dire sur le mauvais axe (mesure : #15151 bloqué sur `declared` alors que la séquence mergée montrait une exemption #14357 légitime).

Ce PR isole le défaut **de sortie** (encode vers stdout) que la tranche-1 de #13140 ne couvrait pas (elle corrigeait le décodage en entrée de `run_gh`, ligne 64). Le fix force le canal de sortie en UTF-8 : les lecteurs (`variation_light_cap.py --replay`, `variation_adjacency_guard.py`) ouvrent déjà en `encoding="utf-8"` — le producteur doit écrire en UTF-8.

## Validation

- `python -m pytest scripts/tests/test_fetch_merged_prs_since.py` : **8 passed** (7 existants + 1 nouveau).
- **Vérifié par faux négatif** : en retirant le `reconfigure`, la même invocation lève bien `UnicodeEncodeError: 'charmap' codec can't encode character '→'` en `:162` — le test attrape la régression exacte, pas une approximation.
- **179 passed** sur le périmètre dépendant (`test_fetch_merged_prs_since`, `test_pick_idle_grain`, `test_variation_tag_comment_trigger`, `test_refresh_stale_adjacency`, `test_variation_adjacency_guard`) — aucune régression sur les consommateurs de la fenêtre.
- Pré-commit : `Refuse NEW text=True without encoding=` → Passed (le pattern reste respecté).

## Changements

| Fichier | Rôle |
|---|---|
| `scripts/ci/fetch_merged_prs_since.py` | `sys.stdout.reconfigure(encoding="utf-8")` avant le `json.dump` (guard `hasattr` pour les flux sans `reconfigure`, ex. capsys) |
| `scripts/tests/test_fetch_merged_prs_since.py` | test `test_main_writes_utf8_on_cp1252_stdout` : simule un stdout cp1252 portant `a → b`, vérifie `main()` rend 0 et produit une sortie UTF-8 décodable |

La CI (runner Linux) n'était pas affectée par le crash ; le reproductif est local Windows. Ce fix débloque la vérification locale de la fenêtre merge sur Windows.

See #15184 — ferme l'item d'acceptance lié (« le fetch produise une fenêtre lisible ») ; l'issue reste ouverte pour l'item principal (le gate ne doit pas trancher un ban absolu sur `prev_source=declared`).
