### PR TITLE
enrich(qc,#11601): QC-Py-33 lectures et transitions -- densite 1468 -> 1850 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -474,6 +474,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "61e334f4",
+   "metadata": {},
+   "source": [
+    "### Ce que les trois dernières lignes garantissent : 15 séries complètes, 2768 jours alignés\n",
+    "\n",
+    "La sortie consacre quinze lignes à sa barre de progression, mais l'information utile tient dans\n",
+    "les trois dernières. **« Tickers valides : 15/15 »** n'est pas un compte de courtoisie :\n",
+    "l'environnement de la cellule suivante construit 15 actifs x 6 signaux = 90 nombres **par jour**,\n",
+    "et une seule série incomplète (une action cotée à partir de 2017, par exemple) décalerait\n",
+    "l'alignement des fenêtres glissantes — l'agent s'entraînerait sur des `NaN` sans qu'aucune erreur\n",
+    "ne soit levée. La validité se vérifie donc **avant** la construction de l'environnement, et c'est\n",
+    "ce que cette ligne atteste.\n",
+    "\n",
+    "Les deux autres nombres cadrent l'expérience : **2014-01-02 au 2024-12-31**, soit **2768 jours de\n",
+    "bourse**. Le code coupe ce bloc au `VAL_START = 2022-01-01` : tout ce qui précède nourrit\n",
+    "l'entraînement, tout ce qui suit (2022-2024) devient la fenêtre de validation — celle-là même sur\n",
+    "laquelle le tableau final de la section comparaison départagera DQN et PPO. Personne n'a vu ces\n",
+    "trois années avant l'évaluation : c'est la propriété qui rend la comparaison possible, et elle se\n",
+    "paie ici, dès le téléchargement.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "8c160dd5",
@@ -1570,6 +1593,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "da20f7fa",
+   "metadata": {},
+   "source": [
+    "### Lire la figure à quatre panneaux : trois instruments d'optimisation, un instrument de vérité\n",
+    "\n",
+    "La lecture précédente relisait les **lignes** de log ; cette figure en donne la vue en coupe. Les\n",
+    "quatre panneaux ne répètent pas la même information — ils forment deux familles distinctes.\n",
+    "\n",
+    "Les trois premiers mesurent **l'optimisation**. *PPO Policy Loss (Clipped Surrogate)*, en haut à\n",
+    "gauche : le nuage brut (alpha 0.6) n'est pas le signal — c'est la moyenne glissante sur 5 mesures\n",
+    "(tracée en rouge) qui compte, car l'objectif clippé est bruyant par construction. *Critic Value\n",
+    "Loss (MSE)*, en haut à droite : le critique apprend à prédire le retour du portefeuille, et sa\n",
+    "descente conditionne la qualité des avantages qui guident la politique. *Policy Entropy*, en bas à\n",
+    "gauche : le garde-fou — tant qu'elle reste nettement positive, la politique n'a pas collapsé sur\n",
+    "une action unique (une politique uniforme sur 4 actions vaut ln(4) ~ 1.39, et la lecture des logs\n",
+    "situait la politique autour de 45 % de ce maximum).\n",
+    "\n",
+    "Le quatrième panneau, *Sharpe de validation*, est le seul qui sorte du gymnase : il mesure ce que\n",
+    "la politique vaut **sur des données qu'elle n'a pas vues**, avec la ligne pointillée bleue du DQN\n",
+    "(0.657) comme brique de référence. La leçon de méthode est dans la dissymétrie : trois panneaux\n",
+    "peuvent descendre sereinement (l'algorithme optimise) pendant que le quatrième décroche (le\n",
+    "portefeuille ne suit pas) — exactement la divergence que la lecture des logs a documentée. Quand\n",
+    "vous réentraînez avec une autre seed, lisez ce panneau **en premier** : les trois autres peuvent\n",
+    "rester verts longtemps après que la généralisation a arrêté de progresser.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "95fa6dda",
    "metadata": {
     "papermill": {
@@ -1782,10 +1833,17 @@
     "tags": []
    },
    "source": [
-    "### Comparaison DQN vs PPO\n",
+    "### Comparaison DQN vs PPO : le protocole avant le verdict\n",
     "\n",
-    "Le tableau ci-dessous compare les deux agents sur les mêmes données de validation (2022-2024).\n",
-    "Le DQN (QC-Py-32) avait obtenu Sharpe=0.657, MaxDD=-22.94%, Return=+31.3%."
+    "Les deux agents s'affrontent sur les **mêmes données de validation (2022-2024)** — la fenêtre\n",
+    "que personne n'a vue pendant l'entraînement, celle que la lecture des données a cadrée dès le\n",
+    "téléchargement. Le DQN (QC-Py-32) y avait obtenu Sharpe = 0.657, MaxDD = -22.94 %, Return =\n",
+    "+31.3 %. Le terrain est identique ; ce qui diffère est la famille d'apprentissage : off-policy\n",
+    "pour le Dueling DQN (rejeu d'expériences passées), on-policy pour PPO (chaque mise à jour\n",
+    "consomme des trajectoires fraîches). Le tableau ci-dessous aligne les deux sur huit lignes — mais\n",
+    "lisez-le comme une **photo à seed unique** : la section précédente a montré le même PPO passer de\n",
+    "0.645 à 0.089 selon le checkpoint, une amplitude qui écrase l'écart final entre les deux\n",
+    "algorithmes.\n"
    ]
   },
   {
@@ -1966,6 +2024,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6317bfbe",
+   "metadata": {},
+   "source": [
+    "### Ce que les trois panneaux racontent que le tableau ne peut pas : le chemin, pas la destination\n",
+    "\n",
+    "Le tableau comparatif donne des **points d'arrivée** (Sharpe, Return, MaxDD) ; cette figure donne\n",
+    "le **chemin** — et deux chemins peuvent mener au même pourcentage final avec des risques\n",
+    "incomparables.\n",
+    "\n",
+    "Premier panneau : la courbe de valeur du portefeuille PPO sur la validation 2022-2024, avec la\n",
+    "ligne grise pointillée du `initial_cash` comme référence absolue. C'est elle qui rend le\n",
+    "**+34.6 %** lisible : l'écart vertical entre la courbe et la ligne grise, à droite du graphe,\n",
+    "est le gain — et les passages **sous** la ligne grise mesurent le temps passé à perdre. La légende\n",
+    "porte le `Sharpe=0.645` du tableau, pour que figure et table se répondent chiffre à chiffre.\n",
+    "Deuxième panneau : les rendements quotidiens en barres — la texture de l'activité, jour par jour,\n",
+    "là où le tableau ne conserve que des agrégats. Troisième panneau : le **drawdown** en aires\n",
+    "remplies, la lecture de risque que le Return seul dissimule. Le tableau chiffrait déjà\n",
+    "**-27.20 %** de MaxDD (contre -22.94 % pour le DQN) ; le panneau montre *quand* et *combien de\n",
+    "temps* le portefeuille est resté sous son maximum — un creux profond mais bref et un creux modéré\n",
+    "mais long ne sont pas le même risque, et aucun chiffre du tableau ne les distingue.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "480b59e8",
    "metadata": {
     "papermill": {
@@ -2060,6 +2142,30 @@
     "print(f\"  Assets: {N_ASSETS}\")\n",
     "print(f\"  Val Sharpe: {sharpe_ppo:.3f}\")\n",
     "print(f\"  Val Return: {total_return_ppo * 100:+.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f576f7a",
+   "metadata": {},
+   "source": [
+    "### L'artefact qui quitte le notebook : un passeport JSON de 3.4 MB\n",
+    "\n",
+    "La sortie dit précisément ce qui sort du notebook : `ppo_trading_model.json`, **3.4 MB** — pas le\n",
+    "`.pt` binaire de PyTorch, mais une sérialisation JSON, le format que le template QuantConnect de\n",
+    "la cellule suivante et l'ObjectStore avalent sans dépendance binaire. La taille se lit en la\n",
+    "croisant avec l'inventaire de paramètres de la section Architecture : **156 549 paramètres** pour\n",
+    "3.4 MB, soit environ 22 octets par paramètre — le JSON paie sa portabilité en verbosité (un\n",
+    "float64 binaire en occupe 8), et c'est ce prix qui rend le modèle lisible, diffable et chargeable\n",
+    "hors de l'environnement d'entraînement.\n",
+    "\n",
+    "Les lignes suivantes forment le **passeport** de l'artefact : `Algorithm: PPO (Actor-Critic)`,\n",
+    "`Assets: 15`, et surtout `Val Sharpe: 0.645` / `Val Return: +34.6%` — les métriques de validation\n",
+    "sont estampillées **dans** l'export. Un modèle déployé reste ainsi traçable vers son évaluation :\n",
+    "quand un backtest de production s'écarte de 0.645, l'écart se lit comme un changement de régime\n",
+    "de marché ou un drift de features, pas comme une inconnue. C'est aussi ce passeport qui garde la\n",
+    "section comparaison honnête : le +34.6 % du tableau et celui de l'export sont le même nombre,\n",
+    "mesuré une seule fois.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA — prev: MED/notebook-python #15078

## Summary

Tranche **round 2** de l'umbrella [#11601](https://github.com/jsboige/CoursIA/issues/11601) (bande 1200-2000 → cible ≥1500) : **QC-Py-33-RL-PPO-Trading — densité 1468 → 1850 c/code-cell**, enrichissement **markdown-only**, cellules code **byte-identiques**, zéro re-exécution (prose ancrée sur les sorties committées, pattern #15078 / #14972 / #15059).

Mesure fraîche `origin/main` (93c05cf102) avant le choix : la bande <1500 du périmètre QuantConnect (partition lane, c. #11601) se réduit à QC-Py-33 (1468, 16 cellules code — retenu), QC-Py-30 (1476, **bloqué** par PR #15098 po-2025, reproductibilité seed) et le companion `kelly_lean` (1274). QC-Py-33 était au plancher du round 1 (#11320, 712→1469, 2026-08-16) et n'avait jamais été repris.

## Ce qui est ajouté (5 cellules markdown, +111/−5)

| Après la cellule | Nouvelle lecture | Ancres (sorties committées) |
|---|---|---|
| Téléchargement (10) | ce que garantissent les 3 dernières lignes de sortie | `Tickers valides: 15/15`, `2014-01-02 au 2024-12-31`, `2768 jours`, `VAL_START = 2022-01-01` |
| Figure entraînement (29) | 3 instruments d'optimisation vs 1 instrument de vérité | panneaux du code (policy/value/entropy/val_sharpe), rolling(5) rouge, baseline DQN 0.657 (ligne bleue du code), ln 4 ≈ 1.39 |
| Courbes portefeuille (38) | le chemin, pas la destination | légende `Sharpe=0.645`, ligne `initial_cash`, MaxDD −27.20 % vs −22.94 % (tableau 36), +34.6 %, 2022-2024 |
| Export (40) | le passeport JSON | `ppo_trading_model.json`, `3.4 MB`, `Val Sharpe: 0.645`, `Val Return: +34.6%`, croisement 156 549 paramètres (§Architecture) ≈ 22 o/param |
| Transition comparaison (35, renforcée) | le protocole avant le verdict | fenêtre 2022-2024, DQN 0.657/−22.94/+31.3, off/on-policy (tableau), divergence checkpoints 0.645→0.089 (lecture logs existante) |

Chaque lecture cite des valeurs **relues dans les sorties réelles** des cellules qu'elle suit (anchor check strict). Aucune duplication : la lecture des logs (cellule existante) reste la seule à dériver la divergence policy/Sharpe ; les nouvelles lectures prennent des angles distincts (garantie d'alignement des données, sémiologie de la figure, lecture de risque du chemin, traçabilité de l'artefact).

## Validation (post-fix, worktree frais origin/main)

- **Densité** (`scripts/notebook_tools/pedagogy_density.py`) : `density: 1850` (29 612 c prose / 16 code cells) — bande cible 1500-2000 atteinte, `Below 1200: 0`.
- **Rendu markdown** (`detect_markdown_rendering.py`) : **violations: 0 total**.
- **Anchor check strict** (`check_interp_positioning.py`) : **findings total : 0**.
- **nbformat validate** : OK, 49 cellules (45 + 4).
- **C.2/H.3** : pre-commit entier passé au commit `fe776ace50` ; aucune cellule code modifiée — `git diff | grep -cE 'execution_count|"outputs"|cell_type.: .code'` = **0** (diff +111/−5, markdown uniquement).
- **C.1** : inchangé par construction (aucune cellule code touchée).
- Baseline densité non touchée, conforme au précédent #15078 (notebook seul).

See #11601

Co-Authored-By: Claude-Code <noreply@anthropic.com>
