### PR TITLE
enrich(qc,#11601): Kelly_companion_lean lectures ancrees -- densite 1274 -> 1716 c/cell

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly_companion_lean.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly_companion_lean.ipynb
@@ -395,6 +395,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5811c2fb",
+   "metadata": {},
+   "source": [
+    "#### Lire une signature `#check` : le contrat du type, preuve à l'appui\n",
+    "\n",
+    "Les trois réponses du noyau ci-dessus ne sont pas des compliments — chacune **affiche un\n",
+    "théorème**. `KellyLean.Bet.hp_pos (self : Bet) : 0 < self.p` dit : *pour tout* pari bien\n",
+    "formé, la probabilité est strictement positive. `pq_add_eq_one` et `b_add_one_pos`\n",
+    "ajoutent les deux autres bornes du contrat : `p + q = 1` (le côté perdant complète le\n",
+    "gagnant) et `0 < b + 1` (le multiplicateur total reste positif — on ne peut pas « gagner »\n",
+    "moins que zéro fois sa mise).\n",
+    "\n",
+    "La subtilité est dans le **statut** de ces lignes : elles ne vérifient pas un pari\n",
+    "particulier, elles énoncent ce que le *type* `Bet` impose à **tout** habitant. Construire\n",
+    "une valeur de type `Bet` sans fournir `hp_pos` est impossible — le champ est une **preuve\n",
+    "embarquée**, pas une promesse documentée. C'est la différence entre un invariant de code\n",
+    "commenté (`// p doit être dans (0,1)`) et un invariant de type vérifié : le premier peut\n",
+    "mentir, le second ne compile pas s'il ment.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a7f41844",
    "metadata": {},
    "source": [
@@ -547,6 +569,27 @@
     "-- f = 0.25 est admissible pour ce pari : -1/2 < 0.25 < 1.\n",
     "example : Feasible parexemple 0.25 := by\n",
     "  unfold Feasible; simp only [parexemple]; constructor <;> norm_num"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3483eedc",
+   "metadata": {},
+   "source": [
+    "#### Ce que le noyau vient d'attester — et le point jaune qu'il ajoute\n",
+    "\n",
+    "Trois faits sont désormais **prouvés** pour `parexemple` : `q parexemple = 0.4` (le côté\n",
+    "perdant), `winWealth parexemple 0.25 = 1.5` et `loseWealth parexemple 0.25 = 0.75` — le\n",
+    "multiplicateur de richesse pour une mise naive d'un quart du capital. Chacun de ces\n",
+    "nombres est le verdict d'un `example` : le noyau a reconstruit la preuve, pas re-confirmé\n",
+    "un calcul déjà écrit.\n",
+    "\n",
+    "Reste le carré jaune : `This simp argument is unused: parexemple`. C'est le **linter**\n",
+    "qui parle, pas le vérificateur — la preuve passe, mais un argument de `simp only` était\n",
+    "superflu. Lire une sortie Lean, c'est trier les deux canaux : les théorèmes validés\n",
+    "(contenu mathématique) et les avertissements de style (la preuve fonctionne, elle est\n",
+    "juste moins économe qu'elle pourrait l'être). Un warning jaune ne fragilise jamais le\n",
+    "résultat ; il signale de la marge de nettoyage.\n"
    ]
   },
   {
@@ -787,6 +830,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b22f49a3",
+   "metadata": {},
+   "source": [
+    "#### L'edge instantié : `g'(0) = 0.8` pour notre pari\n",
+    "\n",
+    "La cellule précédente énonçait la formule générale ; celle-ci la **calcule** :\n",
+    "`growthGrad parexemple 0 = 0.6 * 2 - 0.4 = 0.8`, prouvé deux fois (par la formule, puis\n",
+    "par évaluation directe). Le nombre mérite une lecture : à la marge (f ≈ 0), chaque euro\n",
+    "supplémentaire engagé rapporte **0,8** en croissance logarithmique espérée — un edge\n",
+    "massif. C'est la pente qui dicte l'ordre de grandeur de la mise optimale : la section\n",
+    "suivante montrera que le phare `kellyFrac parexemple = 0.4` capte exactement cet edge\n",
+    "au dénominateur `b = 2` (f* = 0.8 / 2). Retenez le couple : **pente forte → fraction\n",
+    "élevée**, mais plafonnée par le risque de ruine — jamais par l'envie d'exploiter tout\n",
+    "l'edge d'un coup.\n",
+    "\n",
+    "La dernière ligne rappelle la ligne de base : `growth parexemple 0 = 0` — ne pas miser\n",
+    "n'engraisse personne, ce qui rend les deux bornes (0 et f*) lisibles dans le même verre.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "583ac3b2",
    "metadata": {},
    "source": [
@@ -1009,7 +1073,13 @@
     "\n",
     "**Conséquence pédagogique** : la même structure de preuve marcherait pour\n",
     "n'importe quel autre couple `(p, b)` admissible. Le noyau peut la rejouer\n",
-    "sans réécriture — c'est ce que l'exercice 1 vérifie avec un casino \"dévalué\"."
+    "sans réécriture — c'est ce que l'exercice 1 vérifie avec un casino \"dévalué\".\n",
+    "**Le satellite `kelly_unique` — l'inégalité stricte** : le `#check` affichait aussi\n",
+    "`kelly_unique` : pour `f ≠ kellyFrac β`, la croissance est **strictement** inférieure.\n",
+    "Le couple `≤` / `<` n'est pas un luxe d'énoncé : `kelly_optimal` dit que `f*` est un\n",
+    "maximum, `kelly_unique` dit qu'il est **seul** — aucune autre fraction n'ex æquo. En\n",
+    "pratique : un gestionnaire qui « arrondit » 0,4 à 0,5 n'a pas approximé l'optimum, il a\n",
+    "quitté l'optimum ; la décroissance est garantie dès le premier écart.\n"
    ]
   },
   {
@@ -1428,6 +1498,28 @@
     "--\n",
     "-- TODO etudiant\n",
     "example : True := trivial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fe5a3e0",
+   "metadata": {},
+   "source": [
+    "#### L'arc des trois exercices : le même fil, trois fois plus fin\n",
+    "\n",
+    "Les trois exercices rejouent le parcours du notebook sur un **autre** pari : `p = 0.51`,\n",
+    "`b = 1` — le casino « dévalué » du compte-cartes. Le contraste avec `parexemple` est la\n",
+    "leçon : l'edge tombe de `0.8` à `growthGrad = 0.02`, et la fraction de Kelly de `40 %`\n",
+    "à **2 %** du capital par main. Un fil fin change tout : le multiplicateur de gain à\n",
+    "l'optimum n'est plus `×1.8` mais `0.51 * (1+1) = 1.02` — deux pour cent de gain quand\n",
+    "on gagne, quatre-vingt-dix-huit pour cent du capital préservé quand on perd.\n",
+    "\n",
+    "L'exercice 1 vérifie le **contrat** (`q cePari = 0.49`), l'exercice 2 la **dynamique**\n",
+    "(`growth_zero` puis `growthGrad = 0.02` : l'edge existe, minuscule mais positif),\n",
+    "l'exercice 3 le **verdict** (`kellyFrac cePari = 0.02`). C'est exactement la structure\n",
+    "des sections 1 → 2 → 3 : type, croissance, optimum. Si les trois `example` passent au\n",
+    "noyau, vous avez redémontré Kelly sur un cas réaliste — là où l'edge ne se voit pas à\n",
+    "l'œil nu, seul le calcul tranche.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2024:CoursIA — prev: MED/notebook-python #15078

## Summary

Suite de la partition QC de l'umbrella [#11601](https://github.com/jsboige/CoursIA/issues/11601) (bande cible ≥1500) : **Kelly_companion_lean — densité 1274 → 1716 c/code-cell**, enrichissement **markdown-only**, cellules code **byte-identiques**, zéro re-exécution (exception C.2 markdown-only, pattern #15078 / #14972 / #15189).

Dernier livreur sur ce fichier : #14088 MERGED (649 → 1274, 2026-09-01) — la bande ≥1500 restait ouverte. Preflight L898/L1356 : aucun PR OPEN sur le path (claim amendé c.5582680510).

## Ce qui est ajouté (3 lectures + 1 enrichissement, +94/−2)

| Position | Nouvelle lecture | Ancres (sorties committées) |
|---|---|---|
| Après invariants (3) | lire une signature `#check` : le contrat du type, preuve embarquée | `KellyLean.Bet.hp_pos : 0 < self.p`, `pq_add_eq_one`, `b_add_one_pos` |
| Après pari concret (5) | ce que le noyau atteste + le carré jaune du linter | `q parexemple = 0.4`, `winWealth … 0.25 = 1.5`, `loseWealth … = 0.75`, warning 🟨 `This simp argument is unused` |
| Après edge (9) | l'edge instantié `g'(0) = 0.8` | `growthGrad parexemple 0 = 0.6 * 2 - 0.4 = 0.8`, `growth parexemple 0 = 0` |
| Enrichissement §3.1 (12) | le satellite `kelly_unique` — l'inégalité **stricte** | signature `kelly_unique` du `#check` (jamais lue en prose : le `≤` de `kelly_optimal` seul était couvert) |
| Après exercice 3 (20) | l'arc des trois exercices : le même fil, trois fois plus fin | `p = 0.51`, `growthGrad = 0.02`, `kellyFrac cePari = 0.02`, `0.51 * (1+1) = 1.02` |

La lecture du linter (cellule 5) ancre le **canal** (théorèmes validés vs avertissement de style) — les multiplicateurs restent les ancres primaires, le warning n'est cité que comme exemple du second canal.

## Validation (post-fix, worktree frais origin/main 68fb8cc4f0)

- **Densité** (`pedagogy_density.py`) : `density: 1716` (17 169 c prose / 10 code cells), bande 1500-2000 atteinte, `Below 1200: 0`.
- **Rendu markdown** (`detect_markdown_rendering.py`) : **violations: 0 total**.
- **Interp positioning** (`check_interp_positioning.py`) : **no misplaced interp cells**.
- **nbformat validate** : OK, 26 cellules (16 md + 10 code) — `MissingIDFieldWarning` préexistant (cellules d'origine sans id), non bloquant, inchangé.
- **C.2/H.3** : pre-commit entier passé au commit `183adf0ea5` ; aucune cellule code modifiée — churn `execution_count`/`outputs` dans le diff = **0** (+94/−2, markdown uniquement).
- **C.1** : inchangé par construction.
- Baseline densité non touchée (précédent #15078 : notebook seul).

See #11601

Co-Authored-By: Claude-Code <noreply@anthropic.com>
