### PR TITLE
fix(prover,#1453): prepare calibration in legacy CLI entrypoints

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/multi_agent_proof.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/multi_agent_proof.py
@@ -19,9 +19,11 @@ Usage:
 
 import argparse
 import asyncio
+from contextlib import contextmanager
 import json
 import sys
 from pathlib import Path
+from typing import Iterator
 
 sys.stdout.reconfigure(line_buffering=True)
 sys.stderr.reconfigure(line_buffering=True)
@@ -36,7 +38,57 @@ from prover import (
 from prover.config import LEAN_PROJECT_DIR
 from prover.verifier import verify_with_lean
 from prover.trace import TraceLogger as _TL
-from prover.lean_utils import count_real_sorries  # #9402: real-token counter
+from prover.lean_utils import count_real_sorries, stub_theorem_proof
+
+
+@contextmanager
+def _calibration_stub(demo: dict) -> Iterator[bool]:
+    """Temporarily expose a ``sorry_replacement`` calibration target."""
+    target = None
+    if (
+        demo.get("sorry_type") == "sorry_replacement"
+        and demo.get("file")
+        and demo.get("theorem_name")
+    ):
+        target_path = Path(demo["file"])
+        original = target_path.read_bytes()
+        if count_real_sorries(original.decode("utf-8")) == 0:
+            stubbed = stub_theorem_proof(
+                original.decode("utf-8"), demo["theorem_name"]
+            )
+            target_path.write_bytes(stubbed.encode("utf-8"))
+            target = (target_path, original)
+            print(
+                f"[CALIBRATION_STUB] theorem={demo['theorem_name']} "
+                f"line={demo.get('line')} - approved proof stubbed to sorry, "
+                "original restored on exit"
+            )
+
+    try:
+        yield target is not None
+    finally:
+        if target is not None:
+            target[0].write_bytes(target[1])
+            print("[CALIBRATION_RESTORE] approved proof restored")
+
+
+def _prove_demo(demo: dict, args: argparse.Namespace, trace: TraceLogger) -> dict:
+    """Run one sorry-mode demo with calibration preparation when declared."""
+    with _calibration_stub(demo):
+        if args.mode == "multi":
+            prover = MultiAgentSorryProver(trace=trace, provider=args.provider)
+            return asyncio.run(
+                prover.prove_sorry(
+                    demo=demo, max_iterations=args.max_iterations
+                )
+            )
+
+        prover = AutonomousProver(trace=trace, provider=args.provider)
+        return prover.prove_sorry(
+            demo=demo,
+            max_iterations=args.max_iterations,
+            strategic_hints=args.hints,
+        )
 
 
 def main():
@@ -77,30 +129,39 @@ def main():
             sys.exit(1)
 
         content = lean_path.read_text(encoding="utf-8")
-        sorry_count = count_real_sorries(content)  # #9402: real tokens, not prose
-        if sorry_count == 0:
-            print(f"No sorry found in {lean_path}")
-            sys.exit(0)
-
+        sorry_count = count_real_sorries(content)
         sorry_line = args.sorry_line
-        if sorry_line == 0:
-            for i, line in enumerate(content.split("\n"), 1):
-                if "sorry" in line:
-                    sorry_line = i
-                    break
 
-        # Check if a DEMOS entry matches this file + line
+        # A calibration file is committed with its approved proof, so match the
+        # configured target before the ordinary zero-sorry exit. An explicit
+        # line is required when one file contains several calibration targets.
         matched_demo = None
-        for d in DEMOS.values():
-            dfile = d.get("file", "")
-            if dfile and Path(dfile).resolve() == lean_path.resolve() and d.get("line") == sorry_line:
-                matched_demo = d
-                break
+        if sorry_line:
+            for candidate in DEMOS.values():
+                candidate_file = candidate.get("file", "")
+                if (
+                    candidate_file
+                    and Path(candidate_file).resolve() == lean_path.resolve()
+                    and candidate.get("line") == sorry_line
+                ):
+                    matched_demo = candidate
+                    break
 
         if matched_demo:
             demo = {**matched_demo}
-            print(f"  [Config] Matched DEMO '{matched_demo['name']}' for line {sorry_line}")
+            print(
+                f"  [Config] Matched DEMO '{matched_demo['name']}' "
+                f"for line {sorry_line}"
+            )
         else:
+            if sorry_count == 0:
+                print(f"No sorry found in {lean_path}")
+                sys.exit(0)
+            if sorry_line == 0:
+                for i, line in enumerate(content.split("\n"), 1):
+                    if "sorry" in line:
+                        sorry_line = i
+                        break
             demo = {
                 "name": lean_path.stem,
                 "file": str(lean_path),
@@ -111,21 +172,7 @@ def main():
 
         trace = TraceLogger()
 
-        if args.mode == "multi":
-            prover = MultiAgentSorryProver(
-                trace=trace, provider=args.provider,
-            )
-            result = asyncio.run(prover.prove_sorry(
-                demo=demo, max_iterations=args.max_iterations,
-            ))
-        else:
-            prover = AutonomousProver(
-                trace=trace, provider=args.provider,
-            )
-            result = prover.prove_sorry(
-                demo=demo, max_iterations=args.max_iterations,
-                strategic_hints=args.hints,
-            )
+        result = _prove_demo(demo, args, trace)
 
         trace.save(f"auto_{demo['name']}")
         return
@@ -161,40 +208,26 @@ def main():
     # ── Single demo run ──
     trace = TraceLogger()
 
-    if args.mode == "multi" and is_sorry_mode:
-        prover = MultiAgentSorryProver(
-            trace=trace, provider=args.provider,
-        )
-        result = asyncio.run(prover.prove_sorry(
-            demo=demo, max_iterations=args.max_iterations,
-        ))
+    if is_sorry_mode:
+        result = _prove_demo(demo, args, trace)
     else:
-        prover = AutonomousProver(
-            trace=trace, provider=args.provider,
+        # For standard demos, create synthetic sorry-mode demo
+        print(f"\n>>> PROVING: {demo['name']} ({demo.get('difficulty', '?')})...")
+        # Use verify_with_lean for standard theorem demos
+        result = verify_with_lean(
+            theorem=demo["theorem"],
+            tactic=demo["proof"],
+            imports=demo.get("imports"),
+            project_dir=LEAN_PROJECT_DIR,
+            trace=trace,
         )
-        if is_sorry_mode:
-            result = prover.prove_sorry(
-                demo=demo, max_iterations=args.max_iterations,
-                strategic_hints=args.hints,
-            )
-        else:
-            # For standard demos, create synthetic sorry-mode demo
-            print(f"\n>>> PROVING: {demo['name']} ({demo.get('difficulty', '?')})...")
-            # Use verify_with_lean for standard theorem demos
-            result = verify_with_lean(
-                theorem=demo["theorem"],
-                tactic=demo["proof"],
-                imports=demo.get("imports"),
-                project_dir=LEAN_PROJECT_DIR,
-                trace=trace,
-            )
-            print(f"\n{'='*60}")
-            print(f"RESULT: {'VALID' if result['success'] else 'INVALID'}")
-            print(f"  Tactic: {demo['proof']}")
-            print(f"  Time: {result['time_s']:.1f}s")
-            print(f"{'='*60}")
-            trace.save(f"demo_{demo['name']}")
-            return
+        print(f"\n{'='*60}")
+        print(f"RESULT: {'VALID' if result['success'] else 'INVALID'}")
+        print(f"  Tactic: {demo['proof']}")
+        print(f"  Time: {result['time_s']:.1f}s")
+        print(f"{'='*60}")
+        trace.save(f"demo_{demo['name']}")
+        return
 
     trace.save(f"{'multi' if args.mode == 'multi' else 'auto'}_{demo['name']}")
 
@@ -228,7 +261,10 @@ def _run_batch(demo_nums: list, provider: str = "zai", max_iterations: int = 3):
             prover = AutonomousProver(trace=trace, provider=provider)
 
             if demo.get("sorry_type"):
-                result = prover.prove_sorry(demo=demo, max_iterations=max_iterations)
+                with _calibration_stub(demo):
+                    result = prover.prove_sorry(
+                        demo=demo, max_iterations=max_iterations
+                    )
             else:
                 result = verify_with_lean(
                     theorem=demo["theorem"], tactic=demo["proof"],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover.py
@@ -2,12 +2,57 @@
 import sys
 import json
 import traceback
+from pathlib import Path
 
 sys.stdout.reconfigure(line_buffering=True)
 
 from prover.config import DEMOS
 from prover.trace import TraceLogger
 from prover.provers import AutonomousProver
+from prover.lean_utils import count_real_sorries, stub_theorem_proof
+
+
+def _run_demo(demo: dict, max_iters: int, timeout: int, provider: str) -> dict:
+    """Run one demo, exposing approved calibration proofs as temporary sorries."""
+    calibration_target = None
+    if (
+        demo.get("sorry_type") == "sorry_replacement"
+        and demo.get("file")
+        and demo.get("theorem_name")
+    ):
+        target_path = Path(demo["file"])
+        original = target_path.read_bytes()
+        if count_real_sorries(original.decode("utf-8")) == 0:
+            stubbed = stub_theorem_proof(
+                original.decode("utf-8"), demo["theorem_name"]
+            )
+            target_path.write_bytes(stubbed.encode("utf-8"))
+            calibration_target = (target_path, original)
+            print(
+                f"[CALIBRATION_STUB] theorem={demo['theorem_name']} "
+                f"line={demo.get('line')} - approved proof stubbed to sorry, "
+                "original restored on exit",
+                flush=True,
+            )
+
+    try:
+        trace = TraceLogger(output_dir=f"traces/{demo['name']}")
+        try:
+            prover = AutonomousProver(trace, provider=provider, hitl_enabled=False)
+            return prover.prove_sorry(
+                demo,
+                max_iterations=max_iters,
+                agent_timeout_s=timeout,
+            )
+        finally:
+            trace.save(demo["name"])
+    finally:
+        if calibration_target is not None:
+            calibration_target[0].write_bytes(calibration_target[1])
+            print(
+                "[CALIBRATION_RESTORE] approved proof restored", flush=True
+            )
+
 
 if __name__ == "__main__":
     demo_id = int(sys.argv[1]) if len(sys.argv) > 1 else 13
@@ -22,16 +67,11 @@ if __name__ == "__main__":
     if demo.get("proof_scaffolding"):
         print(f"  [Scaffold] {len(demo['proof_scaffolding'].splitlines())} lines of scaffolding provided", flush=True)
 
-    trace = TraceLogger(output_dir=f"traces/{demo['name']}")
-    prover = AutonomousProver(trace, provider=provider, hitl_enabled=False)
-
     try:
-        result = prover.prove_sorry(demo, max_iterations=max_iters,
-                                    agent_timeout_s=timeout)
+        result = _run_demo(demo, max_iters, timeout, provider)
         print(f"\nRESULT: {json.dumps(result, indent=2)}", flush=True)
     except Exception as e:
         print(f"\nCRASH: {e}", flush=True)
         traceback.print_exc()
 
-    trace.save(demo["name"])
     print("Done.", flush=True)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover.py
@@ -73,5 +73,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\nCRASH: {e}", flush=True)
         traceback.print_exc()
+        sys.exit(1)
 
     print("Done.", flush=True)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_multi_agent_proof_calibration.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_multi_agent_proof_calibration.py
@@ -1,0 +1,305 @@
+"""Regression tests for calibration preparation in the legacy CLI entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("agent_framework", reason="prover LLM stack absent (bare CI)")
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+SOURCE = """\
+namespace Calibration
+
+def targetValue : Nat := 3
+
+theorem approved_target : targetValue = 3 := by
+  decide
+
+end Calibration
+"""
+
+
+def _demo(target: Path) -> dict:
+    return {
+        "name": "CALIBRATION_TEST",
+        "file": str(target),
+        "line": 5,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "approved_target",
+        "description": "Calibration fixture committed with its approved proof.",
+    }
+
+
+def _target(tmp_path: Path) -> Path:
+    target = tmp_path / "Calibration.lean"
+    target.write_bytes(SOURCE.encode("utf-8"))
+    return target
+
+
+def _args(**overrides) -> argparse.Namespace:
+    values = {
+        "mode": "autonomous",
+        "provider": "offline",
+        "max_iterations": 2,
+        "hints": "",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_multi_cli_stub_restores_bytes_after_success(
+    tmp_path, monkeypatch, capsys
+):
+    launcher = importlib.import_module("multi_agent_proof")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    original_hash = hashlib.sha256(original).hexdigest()
+    seen = []
+
+    class FakeProver:
+        def __init__(self, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            current = Path(demo["file"]).read_bytes()
+            seen.append(current)
+            return {"success": False, "iterations": 1, "total_s": 0.0}
+
+    monkeypatch.setattr(launcher, "AutonomousProver", FakeProver)
+    result = launcher._prove_demo(
+        _demo(target), _args(), launcher.TraceLogger()
+    )
+
+    assert result["iterations"] == 1
+    assert len(seen) == 1
+    assert b":= by sorry" in seen[0]
+    assert target.read_bytes() == original
+    assert hashlib.sha256(target.read_bytes()).hexdigest() == original_hash
+    output = capsys.readouterr().out
+    assert "[CALIBRATION_STUB] theorem=approved_target" in output
+    assert "[CALIBRATION_RESTORE] approved proof restored" in output
+
+
+def test_multi_cli_stub_restores_bytes_after_exception(tmp_path, monkeypatch):
+    launcher = importlib.import_module("multi_agent_proof")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+
+    class ExplodingProver:
+        def __init__(self, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            assert b":= by sorry" in Path(demo["file"]).read_bytes()
+            raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(launcher, "AutonomousProver", ExplodingProver)
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        launcher._prove_demo(
+            _demo(target), _args(), launcher.TraceLogger()
+        )
+
+    assert target.read_bytes() == original
+
+
+def test_multi_cli_non_calibration_target_is_not_rewritten(
+    tmp_path, monkeypatch, capsys
+):
+    launcher = importlib.import_module("multi_agent_proof")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    demo = _demo(target)
+    demo["sorry_type"] = "full_proof"
+
+    class FakeProver:
+        def __init__(self, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            assert Path(demo["file"]).read_bytes() == original
+            return {"success": False, "iterations": 1, "total_s": 0.0}
+
+    monkeypatch.setattr(launcher, "AutonomousProver", FakeProver)
+    launcher._prove_demo(demo, _args(), launcher.TraceLogger())
+
+    assert target.read_bytes() == original
+    assert "CALIBRATION_STUB" not in capsys.readouterr().out
+
+
+def test_multi_cli_lean_mode_matches_clean_calibration_before_skip(
+    tmp_path, monkeypatch, capsys
+):
+    launcher = importlib.import_module("multi_agent_proof")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    demo = _demo(target)
+    seen = []
+
+    class FakeTrace:
+        def __init__(self, **kwargs):
+            pass
+
+        def save(self, name):
+            pass
+
+    class FakeProver:
+        def __init__(self, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            seen.append(Path(demo["file"]).read_bytes())
+            return {"success": False, "iterations": 1, "total_s": 0.0}
+
+    monkeypatch.setattr(launcher, "DEMOS", {39: demo})
+    monkeypatch.setattr(launcher, "TraceLogger", FakeTrace)
+    monkeypatch.setattr(launcher, "AutonomousProver", FakeProver)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "multi_agent_proof.py",
+            "--lean",
+            str(target),
+            "--sorry-line",
+            "5",
+            "--provider",
+            "offline",
+        ],
+    )
+
+    launcher.main()
+
+    assert len(seen) == 1
+    assert b":= by sorry" in seen[0]
+    assert target.read_bytes() == original
+    output = capsys.readouterr().out
+    assert "No sorry found" not in output
+    assert "Matched DEMO 'CALIBRATION_TEST'" in output
+    assert "CALIBRATION_STUB" in output
+
+
+def test_multi_cli_demo_mode_routes_through_calibration_wrapper(
+    tmp_path, monkeypatch, capsys
+):
+    launcher = importlib.import_module("multi_agent_proof")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    seen = []
+
+    class FakeTrace:
+        def __init__(self, **kwargs):
+            pass
+
+        def save(self, name):
+            pass
+
+    class FakeProver:
+        def __init__(self, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            seen.append(Path(demo["file"]).read_bytes())
+            return {"success": False, "iterations": 1, "total_s": 0.0}
+
+    monkeypatch.setattr(launcher, "DEMOS", {39: _demo(target)})
+    monkeypatch.setattr(launcher, "TraceLogger", FakeTrace)
+    monkeypatch.setattr(launcher, "AutonomousProver", FakeProver)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["multi_agent_proof.py", "--demo", "39", "--provider", "offline"],
+    )
+
+    launcher.main()
+
+    assert len(seen) == 1
+    assert b":= by sorry" in seen[0]
+    assert target.read_bytes() == original
+    output = capsys.readouterr().out
+    assert "RESULT: FAILED" in output
+    assert "CALIBRATION_STUB" in output
+
+
+def test_multi_cli_batch_prepares_each_calibration_target(
+    tmp_path, monkeypatch, capsys
+):
+    launcher = importlib.import_module("multi_agent_proof")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    seen = []
+
+    class FakeProver:
+        def __init__(self, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            seen.append(Path(demo["file"]).read_bytes())
+            return {"success": False, "iterations": 1, "total_s": 0.0}
+
+    monkeypatch.setattr(launcher, "AutonomousProver", FakeProver)
+    monkeypatch.setattr(launcher, "DEMOS", {39: _demo(target)})
+    results = launcher._run_batch([39], provider="offline", max_iterations=1)
+
+    assert len(results) == 1
+    assert b":= by sorry" in seen[0]
+    assert target.read_bytes() == original
+    output = capsys.readouterr().out
+    assert "CALIBRATION_STUB" in output
+    assert "CALIBRATION_RESTORE" in output
+
+
+def test_positional_cli_prepares_and_restores_calibration(
+    tmp_path, monkeypatch, capsys
+):
+    launcher = importlib.import_module("run_prover")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    seen = []
+
+    class FakeTrace:
+        def __init__(self, **kwargs):
+            pass
+
+        def save(self, name):
+            pass
+
+    class FakeProver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def prove_sorry(self, demo, **kwargs):
+            seen.append(Path(demo["file"]).read_bytes())
+            return {"success": False, "iterations": 1, "total_s": 0.0}
+
+    monkeypatch.setattr(launcher, "TraceLogger", FakeTrace)
+    monkeypatch.setattr(launcher, "AutonomousProver", FakeProver)
+    result = launcher._run_demo(_demo(target), 2, 30, "offline")
+
+    assert result["iterations"] == 1
+    assert b":= by sorry" in seen[0]
+    assert target.read_bytes() == original
+    output = capsys.readouterr().out
+    assert "[CALIBRATION_STUB] theorem=approved_target" in output
+    assert "[CALIBRATION_RESTORE] approved proof restored" in output
+
+
+def test_positional_cli_fails_before_write_when_theorem_is_missing(tmp_path):
+    launcher = importlib.import_module("run_prover")
+    target = _target(tmp_path)
+    original = target.read_bytes()
+    demo = _demo(target)
+    demo["theorem_name"] = "missing_target"
+
+    with pytest.raises(ValueError):
+        launcher._run_demo(demo, 2, 30, "offline")
+
+    assert target.read_bytes() == original


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2025:CoursIA — prev: MED/notebook-lean #15027

## Résumé

Ferme la matrice des entrypoints de calibration de l'Epic #1453. Après les corrections du lanceur racine (#13907) et du lanceur sous-répertoire (#14995), deux CLI historiques déléguaient encore directement à `prove_sorry` sans appliquer le pré-vol `sorry_replacement` :

- `agent_tests/multi_agent_proof.py` (`--demo`, `--batch` et `--lean`) ;
- `agent_tests/run_prover.py` (lanceur positional).

Sur les DEMOS 39-52, les fichiers sont committés avec leur preuve approuvée et portent donc zéro `sorry` réel. Ces deux entrypoints pouvaient ainsi ne jamais exposer la cible de calibration au prover ; `multi_agent_proof.py --lean` sortait explicitement par `No sorry found` avant même de résoudre le DEMO correspondant.

Claim : https://github.com/jsboige/CoursIA/issues/1453#issuecomment-5584230683

## Correction

- Réutilise le mécanisme éprouvé `stub_theorem_proof` pour les DEMOS déclarant `sorry_type: sorry_replacement`.
- Remplace temporairement la preuve approuvée par `:= by sorry` avant la délégation au prover.
- Émet les signaux `CALIBRATION_STUB` et `CALIBRATION_RESTORE`.
- Sauvegarde et restaure les octets originaux dans un `finally`, y compris lorsque le provider ou le prover lève une exception.
- Échoue avant toute écriture lorsque le théorème configuré est introuvable.
- Préserve les cibles non-calibration et les fichiers portant déjà un `sorry` réel.
- En mode `--lean`, résout d'abord un DEMO explicite fichier+ligne avant le skip zéro-sorry ; la ligne explicite reste requise pour désambiguïser les fichiers qui portent plusieurs cibles de calibration.

## Régressions

Nouveau fichier `tests/test_multi_agent_proof_calibration.py` :

1. stub 0→1 visible par le prover et restauration SHA/bytes après succès ;
2. restauration après exception ;
3. cible hors calibration jamais réécrite ;
4. chemin CLI `--lean` ne sort plus par le faux `No sorry found` ;
5. chemin CLI `--demo` passe par le wrapper ;
6. batch prépare chaque cible calibration ;
7. lanceur positional prépare puis restaure ;
8. théorème absent échoue avant écriture.

Les cinq tests existants du lanceur sous-répertoire #14995 sont rejoués en contrôle de parité.

## Validation post-fix

```text
python -m py_compile \
  MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/multi_agent_proof.py \
  MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover.py \
  MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_multi_agent_proof_calibration.py
PASS

python -m pytest \
  MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_multi_agent_proof_calibration.py \
  MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_subdir_launcher_calibration.py -q
13 passed in 1.08s

python -m pytest MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests -q
763 passed in 3.78s

git diff --check
PASS
```

## Périmètre et discipline Lean

- 3 fichiers : deux entrypoints Python + un test hermétique ;
- aucun fichier `.lean` ou notebook modifié ;
- compte `distinct_code_sorry` inchangé par construction ;
- lake build et proof-integrity : non applicables, aucun module Lean touché ;
- aucune clé/provider requise par les tests : les frontières LLM sont remplacées par des fakes qui lisent le fichier réellement stubbé sur disque.

## Résiduel honnête

Cette PR valide le cycle stub→spawn→restore de tous les entrypoints hors réseau. Le replay réel du gradient DEMOS 39-52 reste distinct et dépend d'un provider disponible ; le dernier replay documenté sur #1453 s'est arrêté proprement en `provider_outage` Mistral 402. Cette PR ne revendique donc pas une preuve Lean ni la récolte du gradient, uniquement la suppression du faux chemin zéro-itération.

See #1453
