### PR TITLE
fix(ci,#15202): sortir le rendu Quarto complet du pool auto-heberge -- OOM exit 137, main rouge depuis 13 h

### DIFF
--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -72,12 +72,32 @@ jobs:
     # check_self_hosted_runner_policy) ; la selection push-only suit en &&.
     if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name == 'push'
     name: Build Quarto site
-    # Routage #14283 fin de chantier (feu vert ai-01 2026-09-02) : setup
-    # Quarto par tarball auto-contenu (voir le step Set up Quarto). Garde
-    # push-only = jamais de contexte fork ici. runs-on STATIQUE.
-    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de
-    # l'allowlist.
-    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    # RETOUR ARRIERE du routage #14283 pour CE job seulement (#15202).
+    # Le chemin de retour etait deja documente ici ; il est emprunte parce que
+    # le rendu complet ne tient plus dans le cap memoire du pool.
+    #
+    # Mesure (run 34217750689, tete 8732ccaf4a8d) : le rendu meurt a
+    # 1145/1276 notebooks sur `Killed` + exit 137 (SIGKILL de l'OOM killer),
+    # apres 18 min 2 s -- donc tres loin du timeout de 60 min. Ce n'est pas un
+    # timeout, c'est un OOM. Il se reproduit a 3072 Mo (07/09 23:02Z) comme a
+    # 1536 Mo (08/09) : le job ne tient plus depuis le resserrement du parc.
+    #
+    # Le cap du pool est JUSTE et reste inchange : il vaut ~10x le pic mesure
+    # des jobs ordinaires (38 et 160 MiB). Ce qui manquait a la mesure de
+    # dimensionnement, c'est CE job -- 1276 notebooks rendus dans un seul
+    # process Deno n'est pas du meme ordre. On ne regonfle donc pas le parc
+    # pour un seul job : on sort le job du parc.
+    #
+    # C'est aussi le meilleur choix sur les trois axes mesurables : le rendu
+    # est PLUS RAPIDE ici (19-24 min contre 25-31 min sur le pool), il ne
+    # prend AUCUNE RAM au serveur familial, et les minutes hosted sont
+    # gratuites (depot public).
+    #
+    # `validate-pr` RESTE sur le pool : il porte un step « Scope render list to
+    # this PR's changed documents » et ne rend que le diff, donc il est borne
+    # par construction. L'entree d'allowlist du workflow reste NECESSAIRE pour
+    # lui -- ne pas la retirer en croyant suivre la note d'origine.
+    runs-on: ubuntu-latest
     # 60 et non 30 depuis #14283 : le meme rendu prend 19-24 min sur
     # `ubuntu-latest` et 25-31 min sur le pool auto-heberge. Le plafond de 30
     # etait calibre sur la machine d'avant la bascule ; apres elle, il tombe


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/tooling #15182

Repare le rouge `Build Quarto site` sur `main`, ouvert depuis le **2026-09-07T23:02:54Z**. Diagnostic complet et mesures : **#15202**.

## Ce que c'est

Un **OOM**, pas un defaut de contenu et pas une consequence d'un merge.

```
[1145/1276] .../Planners-2-PDDL-Basics.ipynb
/tmp/quarto-1.10.18/bin/quarto: line 210: 390 Killed  "${QUARTO_DENO}" ...
##[error]Process completed with exit code 137.
```

`Killed` + exit **137** = SIGKILL de l'OOM killer. Le job a tourne **18 min 2 s** (`10:52:51Z -> 11:10:53Z`) contre un `timeout-minutes: 60` : **ce n'est pas un timeout**. Il meurt a ~90 % du corpus, ce qui est la signature d'une consommation qui croit avec le rendu dans **un seul** process Deno.

## Pourquoi, et pourquoi c'est de mon fait

Le job tourne sur le pool auto-heberge (routage #14283). Le cap memoire par slot y a ete resserre au titre du mandat user « pas plus de RAM que de disponible, avec de la marge ». Ce resserrement est **bien mesure et reste en place** : 1536 Mo valent ~10x le pic constate des jobs ordinaires (38 MiB et 160 MiB sous `docker stats`).

Le defaut n'est pas la valeur, c'est **l'echantillon** : il ne contenait pas le job le plus lourd du depot. Un rendu de 1276 notebooks n'est pas du meme ordre que 160 MiB. Le job OOM a **3072 Mo** (07/09 23:02Z) **comme** a **1536 Mo** (08/09) -- il ne tenait deja plus avant le dernier resserrement.

Classe [[instrument-must-name-what-it-measured]] : un dimensionnement se valide par les cas qu'il **n'a pas** vus.

## Le remede, et pourquoi celui-la

**On ne regonfle pas le parc pour un seul job -- on sort le job du parc.** Regonfler rendrait a un job unique la RAM que le mandat vient de rendre aux autres services.

Le chemin emprunte est celui que le workflow **documentait deja** (« Retour arriere = remettre `runs-on: ubuntu-latest` »). Il gagne sur les trois axes mesurables :

| Axe | Pool auto-heberge | `ubuntu-latest` |
|---|---|---|
| Duree du meme rendu | 25-31 min | **19-24 min** |
| RAM prise au serveur familial | jusqu'a l'OOM | **0** |
| Cout | un slot ~30 min, tres souvent annule | **gratuit** (depot public) |

Sortir du serveur familial le job le plus lourd, le plus long et le plus souvent annule est la lecture la plus fidele du mandat : c'est de la place **rendue**, pas de la RAM reclamee.

## Ce que la PR ne touche pas, et pourquoi c'est deliberé

- **`validate-pr` reste sur le pool.** Il porte un step « Scope render list to this PR's changed documents » : il ne rend que le diff, donc il est **borne par construction**. C'est precisement pour ca qu'il n'OOM pas.
- **L'entree d'allowlist `quarto-pages-deploy.yml` reste en place.** La note d'origine disait « retour arriere = ... + retrait de l'allowlist » ; la suivre a la lettre casserait `validate-pr`, qui en a toujours besoin. Le commentaire du workflow le dit maintenant explicitement, pour que le prochain lecteur ne retire pas l'entree par fidelite a une note devenue partiellement fausse.
- **Le cap du parc est inchange.** Il est bon ; c'est le job qui n'y a pas sa place.

## Verification

- `python scripts/ci/check_self_hosted_runner_policy.py` -> `OK -- all self-hosted jobs satisfy isolation policy` (148 workflows, 186 jobs, 120 self-hosted), rc=0.
- YAML recharge : `build.runs-on = ubuntu-latest`, `validate-pr` inchange sur `[self-hosted, coursia-ephemeral, coursia-linux]`.
- Le vert reel de `Build Quarto site` se lira **sur `main` apres merge** : le job est `push`-only par sa garde (`github.event_name == 'push'`), il ne peut donc pas s'executer sur cette PR. C'est une limite honnete de cette verification, pas un oubli.

## Suivis ouverts dans #15202, hors scope ici

1. **Le dimensionnement reel du parc n'est pas dans le depot.** `supervise.sh` porte `4g` ; la machine applique `1536m` via un drop-in systemd **non tracke**, et `grep -rn "1536m" scripts/ci/` ne rend rien. J'ai moi-meme conclu a tort « mon travail RAM n'a pas cause ce rouge » sur la foi de la ligne du depot avant de lire la machine.
2. **89 des 100 derniers runs de ce workflow sur `main` sont `cancelled`** (7 success, 4 failure). L'etat Quarto de `main` est donc non mesure la plupart du temps, et chaque annulation a quand meme consomme un slot.

See #15202
