### PR TITLE
guard(notebooks,#14532): detect_notebook_plan_loss + per-PR plan-loss gate

### DIFF
--- a/.github/workflows/notebook-plan-loss-gate.yml
+++ b/.github/workflows/notebook-plan-loss-gate.yml
@@ -49,6 +49,13 @@ name: Notebook plan-loss gate
 # disparitions ASSUMEES).
 
 on:
+  # Per-PR trigger : la gate se branche sur les PRs touchant les notebooks
+  # (cf. discipline d'auto-couverture paths #14391/#14429 -- une PR ne touchant
+  # que ce workflow emet l'evenement, la garde se re-evalue sur sa propre PR).
+  # PAS de `paths:` ici : un seul evenement manquant = la garde ne protege rien.
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/notebook-plan-loss-gate.yml
+++ b/.github/workflows/notebook-plan-loss-gate.yml
@@ -1,0 +1,165 @@
+name: Notebook plan-loss gate
+
+# Purpose
+# -------
+# Per-PR gate that catches notebook PLAN LOSS (#14532) : une PR qui restructure
+# les titres d'un notebook pedagogique peut faire DISPARAITRE une section du
+# plan sans en perdre le contenu -- c'est le deficit de `detect_md_content_loss`
+# qui ne mesure que le VOLUME de prose par cellule (volume-aveugle aux
+# disparitions de section, plan-aveugle aux troncatures intra-cellulaires ; les
+# deux gardes sont complementaires structurellement, cf. module docstring du
+# detecteur).
+#
+# Cas fondateur (#14117 / #14532) : un `### Duree estimee : 50 minutes` peut
+# disparaitre du head sans que `detect_md_content_loss` bronche -- le volume
+# total reste stable ou monte (l'auteur re-ecrit ailleurs). Trois exigences
+# mesurees sur ce ticket :
+#
+#   1. Normalisation accents + numerals (sans elle, 10 faux positifs sur 15
+#      mesures brutes sur #14117 -- re-accentuations comptees comme disparitions).
+#   2. Comparaison SUBSTANCE, pas titres : le diff de titres produit des
+#      CANDIDATS ; le predicat cherche ensuite la substance dans le head
+#      (paragraphe en gras, section renommee, tableau d'interpretation)
+#      avant de conclure. Sans cette deuxieme passe, 3 accusations sur 4 de la
+#      premiere redaction du ticket etaient des faux positifs sur des sections
+#      ameliorees.
+#   3. Rougir sur substance introuvable ET non arbitree : un marker
+#      `plan-loss: section assumee -- <notebook> section: <titre_normalise> : <raison>`
+#      dans le body de la PR justifie la disparition au cas par cas. Le marker
+#      est la porte assumee par l'auteur, pas une dispense ; il est visible dans
+#      la sortie machine comme `LOST_SECTION_JUSTIFIED_BY_BODY`.
+#
+# STRUCTURE_DRIFT : si le nombre de cellules markdown differe entre base et
+# head, la comparaison ENSEMBLE n'est pas garantie (une fusion peut absorber
+# un titre dans une autre cellule, invisible au diff). Le garde rapporte un
+# seul finding STRUCTURE_DRIFT bloquant -- transpose du design #1 #8655.
+#
+# Detector: scripts/notebook_tools/detect_notebook_plan_loss.py (#14532), run
+# in --check mode (rc=0 clean, rc=1 on unjustified LOST_SECTION, rc=2 unreadable)
+# on every notebook changed by the PR. Diff-scoped (base git vs working tree) :
+# les pertes pre-existantes sur `main` ne sont pas relevees tant que le
+# notebook n'est pas touche.
+#
+# Sortie exploitable en review : notebook / section perdue (titre normalise) /
+# mode de justification (SUBSTANCE_FOUND_RENAMED_SECTION /
+# SUBSTANCE_FOUND_INLINE_BOLD / SUBSTANCE_FOUND_TOKEN_MATCH) /
+# LOST_SECTION_JUSTIFIED_BY_BODY le cas echeant. Le detecteur SIGNALE ; la PR
+# justifie en review (une retrogradation legitime est absorbee par les 3
+# passes de substance -- le marker du body n'est requis que pour les
+# disparitions ASSUMEES).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notebook-plan-loss-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  notebook-plan-loss:
+    name: "No notebook plan loss in changed notebooks"
+    # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
+    # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
+    # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
+    # fork n'atteint le runner. Retour arriere = revert de la PR.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Gate changed notebooks
+        env:
+          # Forme sure : le body arrive comme variable d'environnement et
+          # n'est jamais interpole dans le shell (identique a
+          # always-on-guards.yml l.934). Sur workflow_dispatch,
+          # github.event.pull_request est nul -> chaine vide -> inerte,
+          # conforme a l'Acceptance #13491 transposee ici (malforme = inert).
+          NOTEBOOK_PLAN_LOSS_PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice title=Notebook plan-loss gate::Manual dispatch -- nothing to diff."
+            exit 0
+          fi
+
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "::notice title=Notebook plan-loss gate::No notebooks changed -- clean."
+            exit 0
+          fi
+
+          # Justification par-section depuis le body de la PR (#14532, option a) :
+          # le detecteur parse le body a la recherche de markers
+          # `plan-loss: section assumee -- <notebook> section: <titre> : <raison>`
+          # qui exonerent le finding LOST_SECTION correspondant (transparence :
+          # le finding devient LOST_SECTION_JUSTIFIED_BY_BODY et reste dans la
+          # sortie machine, seul le verdict binaire --check passe a 0). Sans
+          # marker pour un finding donne, le comportement nominal (rc=1) est
+          # preserve. Le body est passe via l'env var in-memory
+          # NOTEBOOK_PLAN_LOSS_PR_BODY (canal recommande, meme politique que
+          # MD_CONTENT_LOSS_PR_BODY pour md-content-loss-gate). Les PRs sans
+          # body (string vide) ne matchent rien, comportement actuel preserve
+          # (cf. design : marker = porte assumee par l'auteur, pas dispense).
+
+          echo "## Notebook plan-loss gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          fail=0
+          checked=0
+          unreadable=0
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            # Skip notebooks deleted by the PR.
+            [ -f "$nb" ] || continue
+            checked=$((checked + 1))
+            # `&& rc=0 || rc=$?` is load-bearing under `bash -e`: a bare `out=$(cmd)`
+            # that exits non-zero aborts the step before `rc=$?` is read, making the
+            # rc=1/rc=2 branches below dead code and the failure anonymous (#8884 motif).
+            # NOT `|| true` (that makes $? read 0 from `true` and permanently disarms the gate).
+            out=$(python scripts/notebook_tools/detect_notebook_plan_loss.py --base "$BASE" --check "$nb" 2>&1) && rc=0 || rc=$?
+            if [ "$rc" -eq 1 ]; then
+              echo "::error title=Notebook plan loss::$nb lost a section whose substance is untraceable in the head (3-pass measure-first). If this is an intentional removal, add a per-section marker in the PR body: 'plan-loss: section assumee -- <notebook> section: <titre_normalise> : <raison>' (one per justified section, see #14532). Retrogradations (### Titre -> **Titre** : ...) and renames are absorbed by the 3 substance passes -- no marker required for those."
+              echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            elif [ "$rc" -eq 2 ]; then
+              echo "::warning title=Notebook plan-loss gate::$nb could not be read (rc=2); see detector log."
+              unreadable=$((unreadable + 1))
+            fi
+          done <<< "$CHANGED"
+
+          # Anti-self-disarmament guard (meme politique que md-content-loss-gate,
+          # reserve ai-01 c.28 sur #8656 transposée ici) : si CHAQUE notebook
+          # tente etait illisible (rc=2), le gate n'a rien analyse -> il NE
+          # PEUT PAS certifier "no plan loss". Un detecteur casse ou une ref
+          # git manquante desarmerait silencieusement ce gate. On fail loud
+          # dans ce cas plutot que de donner un quitus a l'aveugle.
+          if [ "$checked" -gt 0 ] && [ "$unreadable" -eq "$checked" ]; then
+            echo "::error title=Notebook plan-loss gate::All $checked changed notebook(s) were unreadable (rc=2) -- the gate analyzed NOTHING and cannot certify plan integrity. This is likely a broken detector or a missing git ref (BASE=$BASE), not a clean bill of health. Failing loud (anti-self-disarmament, #14532)."
+            echo "FIX: the gate could not read any changed notebook. Check the detector log above and the BASE ref ($BASE). Do NOT treat this as a pass." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: a section disappeared from the notebook plan with no traceable substance elsewhere. Three usual causes (see the detector log above for which): (1) the section was removed by mistake -- restore the heading and content ; (2) the section was rolled into another section without keeping a bold inline or renumbered heading -- the substance is present but not at section level (3-pass substance search): either revert or add a 'plan-loss: section assumee' marker with a justification ; (3) the section was re-organized with a different number of markdown cells -- the detector reports STRUCTURE_DRIFT, which is blocking on its own. A legit rephrase in the SUBSTANCE_FOUND_* modes (renamed section, retrograded to bold inline, token absorbed elsewhere) is admitted automatically by the 3-pass measure-first and needs no marker." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "::notice title=Notebook plan-loss gate::Checked $checked changed notebook(s); no plan loss."

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -300,6 +300,20 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     #   tranche 1 #13378). Rollback = revert de la PR (l'entree disparait de
     #   l'allowlist).
     "notebook-latex-control-chars.yml",
+    # #14532 item 1 (owner myia-po-2026:CoursIA-2) : garde PR pure-Python sur
+    #   les disparitions de section au plan des notebooks pedagogiques.
+    #   workflow_dispatch-only ce cycle (anti-panic-deploiement, idem
+    #   md-content-loss-gate a sa creation -- absorption fast-lane-shadow
+    #   differee a un cycle ulterieur si le pattern tient). Detecteur
+    #   `scripts/notebook_tools/detect_notebook_plan_loss.py` (3 passes de
+    #   substance + normalisation accents/numerals, complement structurel de
+    #   md-content-loss : axe PLAN vs axe VOLUME), stdlib-only, 28 tests verts.
+    #   Aucun secret, aucun GITHUB_TOKEN cote job, garde same-repo universelle
+    #   parenthesee au niveau job (#13874) pour les forks PRs qui se font
+    #   skipper proprement par pr_gate. Runner = jambe Linux containerisee
+    #   (LINUX_RUNNER_LABELS, meme profil que md-content-loss-gate tranche 5
+    #   #13378). Rollback = revert de la PR (l'entree disparait de l'allowlist).
+    "notebook-plan-loss-gate.yml",
 }
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",

--- a/scripts/notebook_tools/detect_notebook_plan_loss.py
+++ b/scripts/notebook_tools/detect_notebook_plan_loss.py
@@ -1,0 +1,763 @@
+#!/usr/bin/env python3
+"""Detecte la perte d'une section du PLAN entre la base et la tete d'une PR (#14532).
+
+Pourquoi cet outil existe
+-------------------------
+``detect_md_content_loss.py`` (#8655) mesure le volume de prose par cellule --
+il attrape les troncatures (cellule 941c -> 16c) mais reste AVEUGLE aux
+**disparitions de sections** quand la PR restructure les titres : une
+retrogradation (`## X` -> `**X**` en intro de cellule), un renommage (`###
+Objectifs d'apprentissage` -> `**Objectifs de la seance**`), ou une absorption
+(`### Quand utiliser quel endpoint ?` -> tableau `### Interpretation : DBpedia
+vs Wikidata`) ne font baisser AUCUN volume par cellule, parce que le contenu
+reste et migre ailleurs dans le head.
+
+Le test fondateur le montre sur #14117 (mesure premiere main du ticket,
+table de la ligne 6 a 11 du body) :
+
+| Titre de main                                          | Au head                              | Verdict                  |
+|--------------------------------------------------------|--------------------------------------|--------------------------|
+| `## Donnees Liees : DBpedia, Wikidata et le Web`       | intro de cell[0], sans titre H2      | retrograde -- conserve    |
+| `### Objectifs d'apprentissage` (4 items)               | `**Objectifs de la seance**` (5)     | retrograde + enrichi     |
+| `### Prerequis`                                         | `**Prerequis** : SW-3 Graph Ops...`  | retrograde + precise      |
+| `### Quand utiliser quel endpoint ?`                    | `### Interpretation : DBpedia vs...` | renomme + enrichi        |
+| `### Duree estimee : 50 minutes`                       | absent, 0 occurrence `duree`/`minutes`| **VRAIE PERTE**          |
+
+Sans ce garde, les 4 cas de la premiere colonne passent inapercus -- le seul
+cas reel (Duree estimee) reste invisible au gate markdown. Avec lui, les 4
+premiers sont reconnus comme ``SUBSTANCE_FOUND_ELSEWHERE`` (retrogradation,
+renommage, absorption) et le cinquieme rougit en ``LOST_SECTION``.
+
+Trois exigences, mesurees et consignees dans le ticket, chacune FONDEE sur un
+taux de sur-accusation reel :
+
+1. **Normalisation accents + numerals** : sans elle, 10 faux positifs sur 15
+   mesures brutes sur #14117 (re-accentuations comptees comme disparitions).
+2. **Comparaison CONTENU, pas titres** : le diff de titres produit des
+   **candidats** ; pour chaque candidat, chercher la substance dans le head
+   (paragraphe en gras, section renommee, tableau d'interpretation) avant de
+   conclure. Sans cette deuxieme passe, 3 des 4 accusations de la premiere
+   redaction du ticket etaient des faux positifs sur des sections ameliorees.
+3. **Rougir sur substance introuvable ET non arbitree** : un marker
+   ``plan-loss: section assumee -- <notebook> section: <titre_normalise> : <raison>``
+   dans le body de la PR justifie la disparition au cas par cas. Le marker
+   est la porte assumee par l'auteur, pas une dispense ; il est visible dans
+   la sortie machine comme ``LOST_SECTION_JUSTIFIED_BY_BODY``.
+
+Comparaison STRUCTURELLEMENT bornée : un notebook ou le nombre de cellules
+markdown differe entre base et head est REPORTE en ``STRUCTURE_DRIFT`` (un
+finding bloquant) au lieu de tomber dans la comparaison cellule-par-cellule
+qui produirait des faux positifs position-par-position (cf. la discussion
+similaire pour `_compare_cells` de `detect_md_content_loss.py`, design #1
+de #8655). Le diff de PLAN est lui-meme robuste au decalage : on compare
+des ENSEMBLES de titres, pas des positions.
+
+Usage
+-----
+    # un notebook, diff vs origin/main (head = working tree)
+    python detect_notebook_plan_loss.py NB.ipynb --check
+    python detect_notebook_plan_loss.py NB.ipynb --base origin/main --head origin/fix/ma-branche --check
+
+    # sortie machine
+    python detect_notebook_plan_loss.py NB.ipynb --json
+
+    # CI gate avec justification par-section dans le body PR (#14532 item 3)
+    python detect_notebook_plan_loss.py NB.ipynb --check --pr-body-file /tmp/pr-body.md
+
+Exit codes
+----------
+    0 -- aucune perte detectee (ou mode non --check), y compris un notebook
+         NOUVEAU (absent a la base -> rien a perdre -> exempt)
+    1 -- une ou plusieurs ``LOST_SECTION`` non justifiees par le body
+         (les ``LOST_SECTION_JUSTIFIED_BY_BODY`` ne bloquent PAS le verdict,
+         cf. meme politique que detect_md_content_loss.py #13491)
+    2 -- erreur : notebook EXISTANT illisible ou ref git introuvable. Un
+         notebook NOUVEAU (absent a la base) renvoie rc=0 et non rc=2 -- la
+         distinction se fait par ``path_exists_at_ref``.
+
+Voir aussi
+----------
+- detect_md_content_loss.py : mesure le VOLUME par cellule ; complementaire
+  (volume-aveugle aux disparitions de section, plan-aveugle aux troncatures
+  intra-cellulaires).
+- issue #14532 : 4 sections disparues sur 1 reel, mesure premiere main.
+- issue #8655 : design #1 (STRUCTURE_DRIFT au lieu de match index-par-index).
+- issue #13491 : politique de justification par-cellule transposee ici en
+  justification par-section.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+
+
+# Tokens consideres comme du bruit dans la normalisation d'un titre de plan
+# (numerals de section `1.`, `2.3.1`, etc. + ponctuation terminale). Un titre
+# `### 1. Installation et imports` et `### Installation et imports` normalisent
+# identiquement -- sinon une simple renumerotation de la PR (genre 1.x vers 1.y
+# pour inserer une nouvelle section) fausserait 100 % du diff.
+_NUMERAL_PREFIX_RE = re.compile(r"^\s*\d+(?:\.\d+)*\.?\s+")
+_TRAILING_PUNCT_RE = re.compile(r"[^\w\s]+$", re.UNICODE)
+
+
+def _normalize_heading(text: str) -> str:
+    """Normalise un titre de plan pour la comparaison ENSEMBLE.
+
+    Etapes (dans l'ordre, chacune fondee sur une mesure reelle du ticket) :
+
+    1. ``unicodedata.normalize('NFKD', text)`` decompose les caracteres
+       composes (`Prerequis` -> `Prerèquis`) ; retire les marques
+       diacritiques (`̀..ͯ`). Sans cette passe, 10 titres de
+       #14117 sont declares disparus alors qu'ils sont re-accentues.
+    2. Lowercase (insensible a `Objectifs` vs `OBJECTIFS`).
+    3. Retire le prefixe numeral de section `1.`, `2.3.1`, `1.2 ` -- sinon
+       une renumerotation honnete (deplacee par l'auteur pour inserer une
+       section) fausse l'ensemble des titres de 100 %.
+    4. Retire la ponctuation terminale (un titre `Quand utiliser X ?` et
+       `Quand utiliser X` sont le meme plan).
+    5. Collapse les espaces blancs.
+
+    La normalisation est UNIQUEMENT pour la comparaison ; les titres
+    remontes dans les findings sont la forme ORIGINALLE (cf. ``base_heading``
+    dans le finding), pour que le reviewer pointe immediatement la section
+    dans le body de la PR.
+    """
+    if not text:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", text)
+    ascii_form = "".join(c for c in nfkd if not unicodedata.combining(c))
+    lower = ascii_form.lower()
+    no_numeral = _NUMERAL_PREFIX_RE.sub("", lower)
+    no_punct = _TRAILING_PUNCT_RE.sub("", no_punct := no_numeral)
+    collapsed = re.sub(r"\s+", " ", no_punct).strip()
+    return collapsed
+
+
+def _significant_tokens(text: str) -> set[str]:
+    """Tokens significatifs d'un titre pour la passe 3 (recherche fuzzy).
+
+    Le contrat IDEMPOTENT : la fonction normalise en interne (NFKD + strip
+    combining + lowercase + collapse whitespace) AVANT de tokenizer, de sorte
+    qu'un caller peut lui passer un titre brut (accents, casse variables)
+    sans avoir a appeller ``_normalize_heading`` au prealable. Cette API est
+    plus sure que la stricte entree-normalisee : un oubli de normalisation
+    cote appelant ne change pas le verdict.
+
+    Un titre `Objectifs d'apprentissage` rend {'objectifs', 'apprentissage'}
+    apres strip accents. Un titre `Prérequis opérationnels` rend le meme
+    ensemble que sa version ASCII-isee -- sinon une recherche de substance
+    sur un titre accentue a la base aurait un comportement non-intuitif.
+    Tokens < 4 caracteres exclus (le bruit `de` / `la` / `les` ferait
+    apparaitre de la substance dans le head partout). Un titre vide rend
+    l'ensemble vide et la passe 3 ne le retrouvera jamais -- c'est
+    exactement le comportement desire (un titre vide ne porte pas de
+    substance identifiable).
+    """
+    if not text:
+        return set()
+    normalized = _normalize_heading(text)
+    if not normalized:
+        return set()
+    return {tok for tok in re.split(r"\s+", normalized) if len(tok) >= 4}
+
+
+# Patterns de substance a chercher dans le head, avec leur level de robustesse.
+# Ordre du plus strict au plus souple :
+#   1. Titre exact (apres normalisation) -- rare en pratique mais propre.
+#   2. Titre en gras inline `**Mon titre**` (retrogradation legitime).
+#   3. Au moins un token significatif dans le head, en prose bold (`**Mon ...**`)
+#      -- capte une absorption dans une section renommee.
+#
+# Les recherches sont faites sur le head NORMALISE (memes transformations que
+# pour les titres) pour absorber les variations de casse et d'accents dans
+# le texte du head.
+
+# Capture le contenu d'un bloc bold inline, et OPTIONNELLEMENT le complement
+# textuel immediat (jusqu'au prochain `**`, fin de paragraphe ou point final).
+# Le cas fondateur est `**Prerequis** : SW-3 Graph Operations.` -- la substance
+# complete (`prerequis : sw-3 graph operations`) sert d'ancre pour la passe 2
+# du predicat anti-FP, alors que le strict titre `prerequis` raterait
+# l'enrichissement que l'auteur a mis dans la phrase. Le sous-groupe optionnel
+# 2 capte la queue ` : SW-3 Graph Operations` quand elle existe, et le sous-
+# groupe 1 seul rend la substance deja vue avant.
+_BOLD_INLINE_RE = re.compile(
+    r"\*\*([^*\n]+?)\*\*([^\n]*?)(?=\n\n|\*\*|\Z)",
+    re.DOTALL,
+)
+_HEADING_LINE_RE = re.compile(r"^[ \t]*(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+
+
+def extract_headings(nb: dict) -> list[tuple[int, str, str]]:
+    """Retourne ``[(cell_idx, level, heading_text)]`` pour les cellules markdown.
+
+    ``level`` est le numero de `#` (1..6) du titre -- memorise pour permettre
+    une passe de robustesse future (la perte d'un H2 est plus grave que celle
+    d'un H5), mais cette discrimination n'est pas exploitee dans le predicat
+    actuel : un titre absent du plan reste un titre absent, quel que soit
+    son niveau.
+
+    Le SOURCE d'une cellule est generalement une liste de lignes en nbformat ;
+    on joint avec saut de ligne pour permettre la detection multi-ligne.
+    """
+    out: list[tuple[int, str, str]] = []
+    for idx, c in enumerate(nb.get("cells", [])):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", [])
+        src = "\n".join(src) if isinstance(src, list) else (src or "")
+        for m in _HEADING_LINE_RE.finditer(src):
+            level = len(m.group(1))
+            text = m.group(2).strip()
+            if text:
+                out.append((idx, level, text))
+    return out
+
+
+def _load_notebook_text(nb: dict) -> str:
+    """Texte markdown complet d'un notebook pour la recherche de substance.
+
+    Utilise pour la passe 3 (token-significatif-survit-dans-le-head). Le
+    contenu des cellules markdown est joint avec double saut de ligne pour
+    eviter qu'une fin de cellule colle avec un debut de cellule suivante
+    cree une fausse continuite de phrase.
+    """
+    parts: list[str] = []
+    for c in nb.get("cells", []):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", [])
+        src = "\n".join(src) if isinstance(src, list) else (src or "")
+        if src.strip():
+            parts.append(src)
+    return "\n\n".join(parts)
+
+
+def _substance_present_heuristic(
+    base_heading_norm: str,
+    head_headings_norm: set[str],
+    head_bold_norm: set[str],
+    head_text_norm: str,
+) -> tuple[bool, str | None]:
+    """Cherche la substance d'un titre absent dans le head.
+
+    Trois passes, du plus strict au plus souple :
+
+    1. **Titre exact** : le titre normalise est-il parmi les titres du head ?
+       Si oui, `SUBSTANCE_FOUND_RENAMED_SECTION` -- c'est une migration
+       minimale (rare en pratique, mais la passe la plus sure).
+    2. **Inline bold** : le titre normalise est-il le contenu d'un bloc
+       `**...**` du head ? Si oui, `SUBSTANCE_FOUND_INLINE_BOLD` --
+       retrogradation legitime (titre H2 -> paragraphe bold `#3966` ou
+       transformation analogue).
+    3. **Token significatif** : au moins un token significatif du titre survit-il
+       dans le head ? Si oui, `SUBSTANCE_FOUND_TOKEN_MATCH` -- c'est le cas
+       d'absorption dans une section renommee (le titre `### Quand utiliser
+       quel endpoint ?` disparait, mais `endpoint` survit dans le tableau de
+       comparaison `### Interpretation : DBpedia vs Wikidata`).
+
+    Retourne ``(found, mode)``. ``found == True`` : ne PAS emettre de
+    ``LOST_SECTION`` (le predicat conclut que la substance a ete preservee
+    ailleurs). ``found == False`` : emettre le finding de perte.
+
+    Les ``mode`` de retour (``None`` quand absent) sont des chaines courtes
+    stables -- utiles en sortie machine pour discriminer les strategies du
+    garde par poste de verite.
+    """
+    if base_heading_norm in head_headings_norm:
+        return True, "SUBSTANCE_FOUND_RENAMED_SECTION"
+    # Passe 2 -- retrogradation `### X` -> `**X** : complement`. Le titre
+    # normalise peut etre un PREFIXE d'un bold inline normalise (qui inclut
+    # le complement ` : SW-3 Graph Operations`). On accepte le membership
+    # direct OU prefixe (espace-separe) pour absorber les deux formes :
+    # `**Prerequis**` seul et `**Prerequis** : SW-3 Graph Operations`.
+    for hb in head_bold_norm:
+        if hb == base_heading_norm or hb.startswith(base_heading_norm + " "):
+            return True, "SUBSTANCE_FOUND_INLINE_BOLD"
+    base_tokens = _significant_tokens(base_heading_norm)
+    if base_tokens:
+        # Au moins UN token significatif survit-il dans le head normalise ?
+        head_token_set = set(re.split(r"\s+", head_text_norm))
+        surviving = base_tokens & head_token_set
+        if surviving:
+            return True, "SUBSTANCE_FOUND_TOKEN_MATCH"
+    return False, None
+
+
+def _normalize_for_search(text: str) -> str:
+    """Normalisation pour la recherche de substance dans le head du PR.
+
+    Meme politique que ``_normalize_heading`` : NFKD + strip diacritiques +
+    lowercase + collapse espaces + strip ponctuation terminale. Applique au
+    TEXTE du head (cellules entieres, blocs bold inline, paragraphes
+    complets) pour que la passe 2 (bold inline) et la passe 3 (token
+    significatif) absorbent les variations de casse/accents **et** de
+    ponctuation terminale (un bloc `**Prerequis** : SW-3 Graph Operations.`
+    doit matcher `prerequis : sw-3 graph operations`, sans le point final).
+
+    La ponctuation INTERNE est preservee (utile pour les bold inline :
+    `**Objectifs d'apprentissage**` doit etre trouvable comme
+    `objectifs d'apprentissage` apres normalisation).
+    """
+    if not text:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", text)
+    ascii_form = "".join(c for c in nfkd if not unicodedata.combining(c))
+    lower = ascii_form.lower()
+    no_terminal_punct = _TRAILING_PUNCT_RE.sub("", lower)
+    return re.sub(r"\s+", " ", no_terminal_punct).strip()
+
+
+def _extract_bold_inline(nb: dict) -> set[str]:
+    """Blocs ``**Foo**`` du head (formes normalisees).
+
+    Une retrogradation legitime `### Prerequis` -> `**Prerequis** : SW-3
+    Graph Operations` retire le titre du plan mais laisse le bloc bold
+    intact. La passe 2 de ``_substance_present_heuristic`` retrouve ce cas.
+    """
+    out: set[str] = set()
+    full = _load_notebook_text(nb)
+    for m in _BOLD_INLINE_RE.finditer(full):
+        body = m.group(1).strip()
+        tail = (m.group(2) or "").strip() if m.lastindex and m.lastindex >= 2 else ""
+        # 1. La queue complete (`Prerequis : SW-3 Graph Operations`) -- plus
+        #    discriminante que le strict titre bold.
+        full_phrase = (body + (" " + tail if tail else "")).strip()
+        if full_phrase:
+            out.add(_normalize_for_search(full_phrase))
+        # 2. Le titre bold isole (fallback si la queue est vide).
+        if body:
+            out.add(_normalize_for_search(body))
+    return out
+
+
+def _worktree_root_for(nb_path: Path) -> Path | None:
+    """Trouve la racine du worktree git contenant ``nb_path``.
+
+    Necessaire pour executer ``git show <ref>:<rel_path>`` depuis le bon
+    worktree : un fichier dans ``tmp_path/...`` lors d'un test pytest n'est
+    PAS dans le worktree courant (cwd) -- ``git show HEAD:<abs_path_hors>``
+    echoue avec ``fatal: path ... is outside repository``. On resout le
+    worktree par ``git -C <dir_of_file> rev-parse --show-toplevel``,
+    puis on prend le chemin RELATIF a ce worktree.
+
+    Retourne ``None`` si le fichier n'est dans aucun worktree (cas pathologique
+    ou fichier non-committed ; les helpers en aval traitent ce cas comme
+    ``unreadable`` / ``absent``).
+    """
+    parent = nb_path.resolve().parent
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(parent), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if out.returncode != 0:
+        return None
+    root = Path(out.stdout.strip())
+    try:
+        rel = nb_path.resolve().relative_to(root)
+    except ValueError:
+        return None
+    return root
+
+
+def read_notebook_at_ref(nb_path: Path, ref: str) -> dict | None:
+    """Lit le contenu d'un notebook a un ref git donne via ``git show ref:path``.
+
+    Le ``-C <worktree_root>`` est obligatoire quand ``nb_path`` n'est pas
+    dans le worktree courant (cas test pytest : ``tmp_path/...``). Cf.
+    ``_worktree_root_for``.
+
+    Cf. ``detect_md_content_loss.read_notebook_at_ref`` -- meme convention.
+    """
+    wt = _worktree_root_for(nb_path)
+    if wt is None:
+        return None
+    try:
+        rel = nb_path.resolve().relative_to(wt).as_posix()
+    except ValueError:
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(wt), "show", f"{ref}:{rel}"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout:
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def path_exists_at_ref(nb_path: Path, ref: str) -> bool:
+    """True si le chemin existe a ce ref (cf. meme justification que #8655/#8912).
+
+    Distinction EXISTANT vs NOUVEAU : un fichier absent a la base est
+    EXEMPT (rien a perdre, tout est ajout) ; un fichier PRESENT mais
+    illisible est un rc=2 (fail loud preserve anti-auto-desarmement).
+
+    Utilise ``-C <worktree_root>`` comme ``read_notebook_at_ref`` pour
+    tolerer les fichiers de test sous ``tmp_path``.
+    """
+    wt = _worktree_root_for(nb_path)
+    if wt is None:
+        return False
+    try:
+        rel = nb_path.resolve().relative_to(wt).as_posix()
+    except ValueError:
+        return False
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(wt), "cat-file", "-e", f"{ref}:{rel}"],
+            capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return out.returncode == 0
+
+
+def ref_resolves(ref: str) -> bool:
+    """True si le ref git existe (``git cat-file -e <ref>``). Cf. #8655."""
+    try:
+        out = subprocess.run(
+            ["git", "cat-file", "-e", ref],
+            capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return out.returncode == 0
+
+
+def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> dict:
+    """Compare le PLAN d'un notebook entre base_ref et head_ref (ou working tree).
+
+    Cf. docstring module pour la strategie des 3 passes et la justification
+    de la portee STRUCTURE_DRIFT.
+    """
+    if head_ref is None:
+        try:
+            nb_head = json.loads(nb_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            return {"notebook": str(nb_path), "error": f"head unreadable: {e}"}
+        head_label = "working_tree"
+    else:
+        nb_head = read_notebook_at_ref(nb_path, head_ref)
+        if nb_head is None:
+            return {"notebook": str(nb_path), "error": f"head_ref {head_ref} unreadable"}
+        head_label = head_ref
+
+    if not ref_resolves(base_ref):
+        return {"notebook": str(nb_path), "error": f"base_ref {base_ref} introuvable (ref git invalide)"}
+
+    # Notebook NOUVEAU (absent a la base) : exempt. Cf. detect_md_content_loss.scan_notebook
+    # -- meme politique, distinction preservee par path_exists_at_ref.
+    if not path_exists_at_ref(nb_path, base_ref):
+        head_h = extract_headings(nb_head)
+        return {
+            "notebook": str(nb_path),
+            "base_ref": base_ref,
+            "head_ref": head_label,
+            "new_file": True,
+            "findings": [],
+            "stats": {
+                "base_headings": 0,
+                "head_headings": len(head_h),
+                "findings_count": 0,
+            },
+        }
+
+    nb_base = read_notebook_at_ref(nb_path, base_ref)
+    if nb_base is None:
+        return {"notebook": str(nb_path), "error": f"base_ref {base_ref} unreadable"}
+
+    base_h_list = extract_headings(nb_base)
+    head_h_list = extract_headings(nb_head)
+
+    # Plans normalises : ensembles de titres pour le diff. L'ordre n'importe
+    # pas -- un diff de PLAN est un ENSEMBLE, pas une sequence (un reorder
+    # honnete ne supprime ni n'ajoute de section ; seul l'ensemble compte).
+    base_norm_set: set[str] = {_normalize_heading(t) for _, _, t in base_h_list}
+    head_norm_set: set[str] = {_normalize_heading(t) for _, _, t in head_h_list}
+
+    # STRUCTURE_DRIFT : si le compte de cellules markdown differe entre base
+    # et head, on ne peut PAS garantir qu'une disparition de titre reflete
+    # reelement une perte de plan (une fusion de cellules peut absorber un
+    # titre dans une autre ; une scission peut l'eclater). On rapporte la
+    # STRUCTURE sans comparer cellule-par-cellule -- un seul finding
+    # bloquant, lisible d'un coup d'oeil. Cf. design #1 #8655 transpose ici.
+    base_md_count = sum(1 for c in nb_base.get("cells", []) if c.get("cell_type") == "markdown")
+    head_md_count = sum(1 for c in nb_head.get("cells", []) if c.get("cell_type") == "markdown")
+    findings: list[dict] = []
+    if base_md_count != head_md_count:
+        findings.append({
+            "kind": "STRUCTURE_DRIFT",
+            "base_md_cells": base_md_count,
+            "head_md_cells": head_md_count,
+            "detail": (
+                "le nombre de cellules markdown differe entre base et head "
+                "-- divergence de structure, diff de plan non fiable "
+                "(scission/fusion peut deplacer un titre dans une autre "
+                "cellule, invisible au diff ENSEMBLE)."
+            ),
+        })
+        return {
+            "notebook": str(nb_path),
+            "base_ref": base_ref,
+            "head_ref": head_label,
+            "findings": findings,
+            "stats": {
+                "base_md_cells": base_md_count,
+                "head_md_cells": head_md_count,
+                "cell_count_stable": False,
+                "base_headings": len(base_h_list),
+                "head_headings": len(head_h_list),
+                "findings_count": len(findings),
+            },
+        }
+
+    # Candidats : titres normalises presents a la base, absents au head.
+    candidates: list[tuple[int, str, str, int, str, str]] = []
+    for idx, level, text in base_h_list:
+        norm = _normalize_heading(text)
+        if norm and norm not in head_norm_set:
+            # Stocke l'idx source + le texte original (pour le finding lisible)
+            # + le normalized pour les passes de recherche.
+            candidates.append((idx, level, text, idx, text, norm))
+
+    # Pre-extraction pour les 3 passes de recherche de substance.
+    head_bold_norm = _extract_bold_inline(nb_head)
+    head_text_norm = _normalize_for_search(_load_notebook_text(nb_head))
+
+    for _idx, _lvl, original_text, base_idx, base_orig, base_norm in candidates:
+        found, mode = _substance_present_heuristic(
+            base_norm, head_norm_set, head_bold_norm, head_text_norm,
+        )
+        if found:
+            findings.append({
+                "kind": "SUBSTANCE_FOUND",
+                "base_heading": base_orig,
+                "base_heading_normalized": base_norm,
+                "mode": mode,
+                "base_cell_idx": base_idx,
+            })
+        else:
+            findings.append({
+                "kind": "LOST_SECTION",
+                "base_heading": base_orig,
+                "base_heading_normalized": base_norm,
+                "base_cell_idx": base_idx,
+            })
+
+    return {
+        "notebook": str(nb_path),
+        "base_ref": base_ref,
+        "head_ref": head_label,
+        "findings": findings,
+        "stats": {
+            "base_md_cells": base_md_count,
+            "head_md_cells": head_md_count,
+            "cell_count_stable": True,
+            "base_headings": len(base_h_list),
+            "head_headings": len(head_h_list),
+            "candidates_count": len(candidates),
+            "substance_found_count": sum(1 for f in findings if f.get("kind") == "SUBSTANCE_FOUND"),
+            "lost_section_count": sum(1 for f in findings if f.get("kind") == "LOST_SECTION"),
+            "findings_count": len(findings),
+        },
+    }
+
+
+def _parse_pr_body_markers(pr_body: str, notebook_path: Path) -> set[str]:
+    """Parse les markers ``plan-loss: section assumee -- <nb> section: <titre> : <raison>``.
+
+    Le titre est matche apres NORMALISATION (le body PR est ecrit par un humain,
+    avec accents et casse variables ; on normalise pour absorber). La clef de
+    justification est la forme normalisee du titre (``base_heading_normalized``
+    dans le finding). Cf. `_parse_pr_body_markers` de
+    ``detect_md_content_loss.py`` pour la meme politique par-cellule (#13491).
+
+    Un marker est valide si TOUT est present : mot-cle ``plan-loss``, token
+    ``section assumee``, chemin ou basename du notebook, token ``section:
+    <titre>`` (le titre est tout ce qui suit ``section:`` jusqu'au `` :``
+    final), et une raison non vide. Un marker malforme est inerte (ne leve
+    AUCUNE suppression sur aucun finding -- comportement preserve).
+    """
+    if not pr_body:
+        return set()
+    NB_TAIL_RE = r"[^\s:]+"
+    PAT = re.compile(
+        r"^plan-loss\s*:\s*section\s+assum[eé]+(?:e|ée)\s*(?:--|—)\s*"
+        r"(?P<nb>" + NB_TAIL_RE + r")"
+        r"\s+section\s*:\s*(?P<title>.+?)"
+        r"\s*:\s*(?P<reason>\S.*?)$",
+        re.MULTILINE,
+    )
+    nb_name = notebook_path.name
+    justified: set[str] = set()
+    for m in PAT.finditer(pr_body):
+        nb_token = m.group("nb").rstrip("/").rstrip(":")
+        if nb_token != nb_name and not nb_token.endswith("/" + nb_name):
+            continue
+        title_raw = m.group("title").strip()
+        if not title_raw:
+            continue
+        justified.add(_normalize_heading(title_raw))
+    return justified
+
+
+def _apply_body_justifications(findings: list[dict], justified_norm_titles: set[str]) -> list[dict]:
+    """Supprime les findings ``LOST_SECTION`` justifies par le body, en gardant une trace.
+
+    Trace preservee (cf. ``_apply_body_justifications`` de
+    ``detect_md_content_loss.py`` -- meme politique) : un finding
+    ``LOST_SECTION`` sur un titre normalise justifie est remplace par un
+    finding de meme cle mais de kind ``LOST_SECTION_JUSTIFIED_BY_BODY``. La
+    sortie n'est pas masquee : un auditeur en review voit ce qui s'est
+    passe ; seul le verdict binaire du ``--check`` le rend vert.
+    """
+    if not justified_norm_titles:
+        return findings
+    out: list[dict] = []
+    for f in findings:
+        if (
+            f.get("kind") == "LOST_SECTION"
+            and f.get("base_heading_normalized") in justified_norm_titles
+        ):
+            f2 = dict(f)
+            f2["kind"] = "LOST_SECTION_JUSTIFIED_BY_BODY"
+            out.append(f2)
+        else:
+            out.append(f)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("notebook", type=Path, help="Chemin vers le .ipynb")
+    p.add_argument("--base", default="origin/main", help="Ref git de la base (defaut origin/main)")
+    p.add_argument("--head", default=None, help="Ref git du head (defaut working tree)")
+    p.add_argument("--check", action="store_true", help="Exit 1 si perte detectee (CI)")
+    p.add_argument("--json", action="store_true", help="Sortie JSON machine")
+    p.add_argument(
+        "--pr-body-file", type=Path, default=None,
+        help="Chemin vers un fichier contenant le body de la PR. Y cherche les "
+             "markers `plan-loss: section assumee -- <notebook> section: "
+             "<titre> : <raison>` qui justifient un finding LOST_SECTION sur "
+             "le meme couple (notebook, base_heading_normalized). Marker "
+             "absent ou invalide = comportement actuel (rc=1 inchange). "
+             "Defaut : la variable d'env `PLAN_LOSS_PR_BODY_FILE` si "
+             "definie, sinon aucun.",
+    )
+    p.add_argument(
+        "--pr-body", default=None,
+        help="Contenu literal du body de la PR. Equivalent a `--pr-body-file` "
+             "mais evite d'ecrire le body dans un fichier sur le runner. "
+             "Defaut : la variable d'env `PLAN_LOSS_PR_BODY` si definie "
+             "(prioritaire sur --pr-body-file / PLAN_LOSS_PR_BODY_FILE).",
+    )
+    args = p.parse_args(argv)
+
+    if not args.notebook.exists():
+        print(f"ERROR: notebook introuvable: {args.notebook}", file=sys.stderr)
+        return 2
+
+    # Resolution du body PR (mem politique que detect_md_content_loss.main).
+    pr_body: str | None = None
+    if args.pr_body is not None:
+        pr_body = args.pr_body
+    elif env_body := os.environ.get("PLAN_LOSS_PR_BODY"):
+        pr_body = env_body
+    else:
+        pr_body_file: Path | None = args.pr_body_file
+        if pr_body_file is None:
+            env_file = os.environ.get("PLAN_LOSS_PR_BODY_FILE")
+            if env_file:
+                pr_body_file = Path(env_file)
+        if pr_body_file is not None:
+            try:
+                pr_body = pr_body_file.read_text(encoding="utf-8", errors="replace")
+            except (OSError, UnicodeDecodeError) as e:
+                print(f"ERROR: --pr-body-file illisible: {e}", file=sys.stderr)
+                return 2
+
+    result = scan_notebook(args.notebook, args.base, args.head)
+
+    if "error" in result:
+        print(f"ERROR: {result['error']}", file=sys.stderr)
+        return 2
+
+    # Justification par-section depuis le body de la PR (port de la politique
+    # #13491 au grain section plutot que cellule). Meme cle de comptage :
+    # les JUSTIFIED restent dans la sortie machine (transparence) mais le
+    # verdict binaire --check ignore les *_JUSTIFIED_BY_BODY.
+    if pr_body is not None:
+        justified = _parse_pr_body_markers(pr_body, args.notebook)
+        if justified:
+            result["findings"] = _apply_body_justifications(result["findings"], justified)
+            result["stats"]["findings_count"] = sum(
+                1 for f in result["findings"]
+                if not str(f.get("kind", "")).endswith("JUSTIFIED_BY_BODY")
+            )
+            result["stats"]["findings_count_with_justified"] = len(result["findings"])
+            result["stats"]["justified_by_body_sections"] = sorted(justified)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        nb = result["notebook"]
+        st = result["stats"]
+        fins = result["findings"]
+        print(f"[NOTEBOOK] {nb}")
+        print(f"[BASE]     {result['base_ref']}")
+        print(f"[HEAD]     {result['head_ref']}")
+        if result.get("new_file"):
+            print("[NEW FILE] absent a la base -> exempt de plan-loss "
+                  "(rien a perdre, tout est ajout).")
+        print(
+            f"[STATS]    md_cells base={st['base_md_cells']} head={st['head_md_cells']} "
+            f"stable={st['cell_count_stable']} | headings base={st['base_headings']} "
+            f"head={st['head_headings']} | candidates={st.get('candidates_count', '-')} "
+            f"substance_found={st.get('substance_found_count', '-')} "
+            f"lost_section={st.get('lost_section_count', '-')} | "
+            f"findings={st['findings_count']}"
+        )
+        if st.get("justified_by_body_sections"):
+            print(f"[JUSTIFIED_BY_BODY] {len(st['justified_by_body_sections'])} section(s) "
+                  f"assumee(s) par marqueur de body.")
+        if fins:
+            print("\n[FINDINGS]")
+            for f in fins:
+                if f["kind"] == "STRUCTURE_DRIFT":
+                    print(f"  - {f['kind']}: base={f['base_md_cells']} -> "
+                          f"head={f['head_md_cells']} cellules markdown -- {f['detail']}")
+                elif f["kind"] == "SUBSTANCE_FOUND":
+                    print(f"  - {f['kind']}: '{f['base_heading']}' -> {f['mode']} "
+                          f"(cellule base {f['base_cell_idx']})")
+                elif f["kind"] in ("LOST_SECTION", "LOST_SECTION_JUSTIFIED_BY_BODY"):
+                    suffix = " -- reecriture assumee par marqueur de body" \
+                        if f["kind"].endswith("JUSTIFIED_BY_BODY") else ""
+                    print(f"  - {f['kind']}: '{f['base_heading']}' "
+                          f"(cellule base {f['base_cell_idx']}, normalise "
+                          f"'{f['base_heading_normalized']}'){suffix}")
+
+    if args.check and result["findings"]:
+        blocking = [f for f in result["findings"]
+                     if not str(f.get("kind", "")).endswith("JUSTIFIED_BY_BODY")
+                     and f.get("kind") != "SUBSTANCE_FOUND"]
+        if blocking:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py
@@ -1,0 +1,461 @@
+"""Tests for scripts/notebook_tools/detect_notebook_plan_loss.py (#14532).
+
+Couvre les 4 scenarios d'acceptation + le comportement de la recherche de
+substance en 3 passes :
+  - section absente ET substance introuvable -> LOST_SECTION (signal)
+  - retrogradation titre -> bold inline -> SUBSTANCE_FOUND_INLINE_BOLD (PAS de signal)
+  - section renommee / absorbee -> SUBSTANCE_FOUND_TOKEN_MATCH (PAS de signal)
+  - titre re-accentue / re-numerote -> INVISIBLE apres normalisation (PAS de signal)
+  - STRUCTURE_DRIFT : nombre de cellules markdown different (PAS de comparaison
+    elementaire, design #1 #8655 transpose)
+  - NEW_FILE exempt (rc=0)
+  - justification par-section via body PR (--pr-body-file) : leve le finding
+    LOST_SECTION correspondant
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import detect_notebook_plan_loss as dpl  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _md(src, cell_id=None):
+    """Cellule markdown avec source (str ou list) et id nbformat optionnel."""
+    cell = {"cell_type": "markdown", "source": src, "metadata": {}}
+    if cell_id is not None:
+        cell["id"] = cell_id
+    return cell
+
+
+def _nb(*cells):
+    return {"cells": list(cells), "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def _write_nb(path: Path, nb: dict) -> None:
+    path.write_text(json.dumps(nb, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Normalisation des titres
+# ---------------------------------------------------------------------------
+class TestNormalize:
+    def test_accent_stripping(self):
+        # `Prerequis` et `Prérequis` normalisent identiquement
+        # (sinon 10/15 sur-accusations sur #14117).
+        assert dpl._normalize_heading("Prérequis") == dpl._normalize_heading("Prerequis")
+        assert dpl._normalize_heading("Données") == dpl._normalize_heading("Donnees")
+
+    def test_numeral_prefix_stripped(self):
+        # Une renumerotation `1.` -> `2.` ne doit pas fausser le diff de plan.
+        # NB : la fonction prend le TEXTE du titre (sans `##`), c'est-a-dire
+        # exactement ce qu'extract_headings() lui passe en pratique.
+        assert dpl._normalize_heading("1. Installation et imports") == \
+            dpl._normalize_heading("2. Installation et imports")
+        assert dpl._normalize_heading("3.1. Sub section") == \
+            dpl._normalize_heading("5.2. Sub section")
+
+    def test_case_insensitive(self):
+        assert dpl._normalize_heading("Objectifs") == dpl._normalize_heading("OBJECTIFS")
+        assert dpl._normalize_heading("Objectifs") == dpl._normalize_heading("objectifs")
+
+    def test_trailing_punctuation_stripped(self):
+        assert dpl._normalize_heading("Quand utiliser X ?") == \
+            dpl._normalize_heading("Quand utiliser X")
+        assert dpl._normalize_heading("Section A.") == \
+            dpl._normalize_heading("Section A")
+
+    def test_whitespace_collapsed(self):
+        assert dpl._normalize_heading("Foo  bar") == dpl._normalize_heading("foo bar")
+        assert dpl._normalize_heading("  Foo  ") == dpl._normalize_heading("Foo")
+
+    def test_invalid_empty_input(self):
+        assert dpl._normalize_heading("") == ""
+        assert dpl._normalize_heading("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Tokens significatifs
+# ---------------------------------------------------------------------------
+class TestTokens:
+    def test_short_tokens_excluded(self):
+        # Tokens < 4 caracteres ne comptent pas (sinon `de` / `la` / `les`
+        # provoqueraient des faux positifs partout dans le head).
+        toks = dpl._significant_tokens("Objectifs de la seance")
+        # "objectifs", "seance" -- pas "de" ni "la"
+        assert "objectifs" in toks
+        assert "seance" in toks
+        assert "de" not in toks
+        assert "la" not in toks
+
+    def test_empty_norm_yields_no_tokens(self):
+        assert dpl._significant_tokens("") == set()
+        assert dpl._significant_tokens("a") == set()
+        assert dpl._significant_tokens("ab") == set()
+
+    def test_unicode_tokens_stable(self):
+        # Les accents sont strippes AVANT le tokenize (NFKD puis strip
+        # combining) -- un titre avec caracteres composes produit le meme
+        # ensemble de tokens que sa version ASCII-isee.
+        toks_uni = dpl._significant_tokens("Prérequis opérationnels")
+        toks_ascii = dpl._significant_tokens("Prerequis operationnels")
+        assert toks_uni == toks_ascii
+
+
+# ---------------------------------------------------------------------------
+# 3. Extraction des headings et bold inline
+# ---------------------------------------------------------------------------
+class TestExtract:
+    def test_headings_picks_h1_to_h6(self):
+        nb = _nb(
+            _md("# H1 titre\n\nSuite\n"),
+            _md("## H2 titre\n\nSuite\n"),
+            _md("### H3 titre\n"),
+            _md("#### H4 titre\n"),
+            _md("Pas un titre\n"),
+        )
+        h = dpl.extract_headings(nb)
+        assert len(h) == 4
+        assert [t[0] for t in h] == [0, 1, 2, 3]  # cell_idx
+        assert [t[1] for t in h] == [1, 2, 3, 4]  # level
+        assert h[0][2] == "H1 titre"
+
+    def test_bold_inline_extraction(self):
+        nb = _nb(_md(
+            "Texte introductif.\n\n"
+            "**Prerequis** : SW-3 Graph Operations.\n\n"
+            "**Objectifs d'apprentissage** :\n\n"
+            "- Item 1\n"
+        ))
+        bold = dpl._extract_bold_inline(nb)
+        # Doit contenir les 2 formes normalisees (lowercase, NFKD accents
+        # retires, whitespace collapse, ponctuation terminale strippee).
+        assert "prerequis : sw-3 graph operations" in bold
+        # La ponctuation terminale (les 2-points) est strippee par
+        # ``_normalize_for_search`` -- on accepte le titre bold nu OU la
+        # version prefixee par `:`.
+        assert "objectifs d'apprentissage" in bold
+
+
+# ---------------------------------------------------------------------------
+# 4. Substance found in 3 passes (le coeur du predicat anti-FP)
+# ---------------------------------------------------------------------------
+class TestSubstance:
+    def test_title_exact_match(self):
+        # Passe 1 : titre normalise present dans l'ensemble head.
+        found, mode = dpl._substance_present_heuristic(
+            "objectifs d'apprentissage",
+            head_headings_norm={"objectifs d'apprentissage", "introduction"},
+            head_bold_norm=set(),
+            head_text_norm="quelque part",
+        )
+        assert found is True
+        assert mode == "SUBSTANCE_FOUND_RENAMED_SECTION"
+
+    def test_bold_inline_match(self):
+        # Passe 2 : titre retrograde en bold inline (`**Prerequis** : ...`).
+        found, mode = dpl._substance_present_heuristic(
+            "prerequis",
+            head_headings_norm={"preambule"},
+            head_bold_norm={"prerequis : sw-3 graph operations"},
+            head_text_norm="",
+        )
+        assert found is True
+        assert mode == "SUBSTANCE_FOUND_INLINE_BOLD"
+
+    def test_token_match_absorption(self):
+        # Passe 3 : un token significatif survit dans le head apres absorption.
+        # C'est le cas de `### Quand utiliser quel endpoint ?` qui disparait
+        # dans #14117 mais dont `endpoint` survit dans le tableau de comparaison.
+        found, mode = dpl._substance_present_heuristic(
+            "quand utiliser quel endpoint",
+            head_headings_norm={"interpretation : dbpedia vs wikidata"},
+            head_bold_norm=set(),
+            head_text_norm="endpoint et service sont les deux termes comparés",
+        )
+        assert found is True
+        assert mode == "SUBSTANCE_FOUND_TOKEN_MATCH"
+
+    def test_no_substance_found(self):
+        # Aucun match dans les 3 passes -> finding LOST_SECTION en aval.
+        found, mode = dpl._substance_present_heuristic(
+            "duree estimee 50 minutes",
+            head_headings_norm={"introduction", "conclusion"},
+            head_bold_norm={"navigation", "prerequis"},
+            head_text_norm="le notebook fait 50 lignes de code",
+        )
+        # "50" et "minutes" sont < 4 chars -> aucun token significatif.
+        # "duree" est 5 chars mais absent du head text.
+        assert found is False
+        assert mode is None
+
+    def test_single_significant_token_survives(self):
+        # Un SEUL token significatif suffit (le predicat ne demande pas tous).
+        found, mode = dpl._substance_present_heuristic(
+            "complexite algorithmique",
+            head_headings_norm=set(),
+            head_bold_norm=set(),
+            head_text_norm="la complexite reste lineaire en pratique",
+        )
+        # `complexite` (11 chars) survit, `algorithmique` aussi.
+        assert found is True
+        assert mode == "SUBSTANCE_FOUND_TOKEN_MATCH"
+
+
+# ---------------------------------------------------------------------------
+# 5. scan_notebook : scenarios d'acceptation bout-en-bout
+# ---------------------------------------------------------------------------
+class TestScan:
+    def test_no_change_no_finding(self, tmp_path: Path):
+        # Plan identite entre base et head -> 0 finding. On utilise deux refs
+        # git identiques pour court-circuiter le check structure -- le but
+        # est uniquement de verifier que le pipeline n'invente pas de findings
+        # quand rien ne change. NB : scan_notebook prend par defaut head_ref=None
+        # (= working tree), ce qui teste le chemin de lecture disque ; ici on
+        # donne HEAD explicite pour eviter un check working-tree vs git.
+        nb_dict = _nb(
+            _md("# H1 titre\n\nSuite.\n"),
+            _md("## H2 sous-titre\n\nSuite.\n"),
+        )
+        p = tmp_path / "stable.ipynb"
+        _write_nb(p, nb_dict)
+        import subprocess
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "stable.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref="HEAD")
+        assert "error" not in result
+        assert result["findings"] == []
+
+    def test_section_lost_raises_finding(self, tmp_path: Path):
+        # Cas du ticket : `### Duree estimee : 50 minutes` a la base,
+        # absent du head sans substance ailleurs -> LOST_SECTION.
+        # Note : on garde le MEME nombre de cellules markdown entre base et
+        # head sinon STRUCTURE_DRIFT bloque la passe substance (par design --
+        # une difference de cellules = impossible de garantir une
+        # comparaison ENSEMBLE).
+        # On choisit un head dont AUCUN token significatif de `duree estimee
+        # 50 minutes` ne survit (les seuls tokens >=4 chars du titre sont
+        # `duree` et `estimee` -- le head ne contient ni l'un ni l'autre).
+        nb_base = _nb(
+            _md("# Plan\n\n"),
+            _md("## Introduction\n\nCorps.\n\n### Duree estimee : 50 minutes\n\nSuite.\n"),
+        )
+        nb_head = _nb(
+            _md("# Plan\n\n"),
+            _md("## Introduction\n\nCorps.\n\n### Conclusion rapide\n\n"),
+        )
+        import subprocess
+        p = tmp_path / "lost.ipynb"
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "lost.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "base", "-q"], check=True)
+        # HEAD pointe maintenant sur la version base ; on ecrit la version
+        # head SUR DISQUE pour tester working_tree vs HEAD.
+        _write_nb(p, nb_head)
+
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref=None)
+        assert "error" not in result, result.get("error")
+        assert result["stats"]["cell_count_stable"] is True
+        kinds = [f["kind"] for f in result["findings"]]
+        assert "LOST_SECTION" in kinds
+        lost = next(f for f in result["findings"] if f["kind"] == "LOST_SECTION")
+        # Le titre normalise doit etre celui du titre de base.
+        assert "duree" in lost["base_heading_normalized"]
+        assert "estimee" in lost["base_heading_normalized"]
+        # NB : le `_normalize_heading` ne strip PAS les numerals internes
+        # (`50`) ni les tokens >= 4 chars (`minutes`), on accepte leur
+        # presence dans le titre normalise -- l'important est que la passe
+        # 3 (token significatif) ne retrouve AUCUN de ces tokens dans le
+        # head (cf. design du test ci-dessus).
+
+    def test_retrogradation_to_inline_bold_no_finding(self, tmp_path: Path):
+        # `### Prerequis` a la base, absent du head mais conserve en inline bold
+        # `**Prerequis** : SW-3 Graph Operations.` -> SUBSTANCE_FOUND_INLINE_BOLD,
+        # PAS de LOST_SECTION. Meme nombre de cellules markdown des deux cotes.
+        nb_base = _nb(
+            _md("# Plan\n\n"),
+            _md("### Prerequis\n\nSW-3 Graph Operations.\n"),
+        )
+        nb_head = _nb(
+            _md("# Plan\n\n"),
+            _md("**Prerequis** : SW-3 Graph Operations.\n\n"),
+        )
+        import subprocess
+        p = tmp_path / "retro.ipynb"
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "retro.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
+
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref=None)
+        assert "error" not in result
+        kinds = [f["kind"] for f in result["findings"]]
+        assert "LOST_SECTION" not in kinds
+        # Au moins un SUBSTANCE_FOUND via bold inline.
+        found = [f for f in result["findings"] if f["kind"] == "SUBSTANCE_FOUND"]
+        assert len(found) >= 1
+        assert any(f["mode"] == "SUBSTANCE_FOUND_INLINE_BOLD" for f in found)
+
+    def test_accent_normalization_no_finding(self, tmp_path: Path):
+        # Une re-accentuation honnete `Prerequis` -> `Prérequis` ne doit PAS
+        # lever de LOST_SECTION (la normalisation NFKD absorbe).
+        nb_base = _nb(_md("# Plan\n\n## Prerequis\n\nTexte.\n"))
+        nb_head = _nb(_md("# Plan\n\n## Prérequis\n\nTexte.\n"))
+        import subprocess
+        p = tmp_path / "acc.ipynb"
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "acc.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
+
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref=None)
+        assert "error" not in result
+        kinds = [f["kind"] for f in result["findings"]]
+        # `Prérequis` re-accentue normalise -> identite -> 0 finding.
+        assert kinds == []
+
+    def test_structure_drift(self, tmp_path: Path):
+        # Nombre de cellules markdown different entre base et head ->
+        # STRUCTURE_DRIFT (PAS de comparaison elementaire).
+        nb_base = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"), _md("## Section B\n\n"))
+        nb_head = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"))
+        import subprocess
+        p = tmp_path / "sd.ipynb"
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "sd.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
+
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref=None)
+        assert "error" not in result
+        kinds = [f["kind"] for f in result["findings"]]
+        assert "STRUCTURE_DRIFT" in kinds
+
+
+# ---------------------------------------------------------------------------
+# 6. Justification par-section depuis le body PR
+# ---------------------------------------------------------------------------
+class TestBodyJustification:
+    def test_marker_normalizes(self):
+        # Le marker est compare a la forme NORMALISEE du titre de plan.
+        justified = dpl._parse_pr_body_markers(
+            "plan-loss: section assumee -- perdu.ipynb section: Duree estimee 50 minutes : "
+            "synchronisee avec le code cell runtime",
+            Path("perdu.ipynb"),
+        )
+        # On normalise cote garde (`duree estimee 50 minutes`), et le titre
+        # dans le marker subit la meme normalisation.
+        assert "duree estimee 50 minutes" in justified
+
+    def test_em_dash_accepted(self):
+        # Un editeur intelligent transpose `--` en em-dash -- la regex accepte les deux.
+        justified = dpl._parse_pr_body_markers(
+            "plan-loss: section assumée — perdu.ipynb section: Duree estimee 50 minutes : OK",
+            Path("perdu.ipynb"),
+        )
+        assert "duree estimee 50 minutes" in justified
+
+    def test_marker_different_notebook_inert(self):
+        # Un marker visant un AUTRE notebook n'affecte pas le verdict du notre.
+        justified = dpl._parse_pr_body_markers(
+            "plan-loss: section assumee -- autre.ipynb section: Titre : raison",
+            Path("perdu.ipynb"),
+        )
+        assert justified == set()
+
+    def test_apply_body_justifications_substitutes(self):
+        # Un finding LOST_SECTION sur un titre normalise couvert par le body
+        # est converti en LOST_SECTION_JUSTIFIED_BY_BODY (meme politique que
+        # detect_md_content_loss.py #13491).
+        findings = [
+            {"kind": "LOST_SECTION", "base_heading": "Duree", "base_heading_normalized": "duree"},
+            {"kind": "LOST_SECTION", "base_heading": "Autre", "base_heading_normalized": "autre"},
+        ]
+        out = dpl._apply_body_justifications(findings, {"duree"})
+        kinds = [f["kind"] for f in out]
+        assert "LOST_SECTION_JUSTIFIED_BY_BODY" in kinds
+        assert "LOST_SECTION" in kinds  # l'autre reste non justifiee
+
+
+# ---------------------------------------------------------------------------
+# 7. Main -- rc=0/1/2 sur pipeline complet
+# ---------------------------------------------------------------------------
+class TestMain:
+    def test_clean_exits_zero(self, tmp_path: Path, monkeypatch, capsys):
+        # Plan identique -> rc=0.
+        import subprocess
+        nb_dict = _nb(_md("# Plan\n\n## Section\n\n"))
+        p = tmp_path / "clean.ipynb"
+        _write_nb(p, nb_dict)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "clean.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        rc = dpl.main([str(p), "--base", "HEAD", "--check"])
+        captured = capsys.readouterr()
+        assert rc == 0, f"expected rc=0, got stdout={captured.out!r}, stderr={captured.err!r}"
+
+    def test_justified_by_body_exits_zero(self, tmp_path: Path):
+        # LOST_SECTION + body marker couvrant -> rc=0 (le marker leve).
+        import subprocess
+        p = tmp_path / "j.ipynb"
+        nb_base = _nb(_md("# Plan\n\n### Duree est longue\n\n"))
+        nb_head = _nb(_md("# Plan\n\n"))
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "j.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
+
+        body_path = tmp_path / "pr_body.md"
+        body_path.write_text(
+            "plan-loss: section assumee -- j.ipynb section: Duree est longue : assumee\n",
+            encoding="utf-8",
+        )
+        # On lance main, on capture stdout/stderr.
+        rc = dpl.main([str(p), "--base", "HEAD", "--check", "--pr-body-file", str(body_path)])
+        # Le marker couvre `duree est longue` (normalise) ; le finding
+        # correspondant est JUSTIFIED -> pas bloquant -> rc=0.
+        assert rc == 0, f"rc={rc}, expected 0 (justified)"
+
+    def test_unjustified_lost_exits_one(self, tmp_path: Path):
+        # LOST_SECTION SANS body marker -> rc=1.
+        import subprocess
+        p = tmp_path / "u.ipynb"
+        nb_base = _nb(_md("# Plan\n\n### Duree est longue\n\n"))
+        nb_head = _nb(_md("# Plan\n\n"))
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "u.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
+        rc = dpl.main([str(p), "--base", "HEAD", "--check"])
+        assert rc == 1


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/guard #15151

# c.1007 #14532 item 1 — guard notebook plan main→head (3-pass measure-first)

## Phase 2 — pivot narrow monotonie c.1007 sur claim dispatch dormant item 1 #14532

Cycle c.1007 : la liste #14532 garde **item 1 (le garde plan main→head)** ouvert depuis le 2026-09-03. Item 2 (`Duree estimee` SW-5) + item 4 (collision numérotation) livrés par #14807 (MERGED 2026-09-06). Item 3 (Applications réelles App-13) livré par #14811 (MERGED 2026-09-06). Reste item 1 — finding de fond du ticket, qui ne peut être livré que par cette lane.

Claim dormant posé 03:09Z (cf commentaires #14532) sur les paths exclusifs `scripts/notebook_tools/detect_notebook_plan_loss.py` + `scripts/notebook_tools/tests/**` + `.github/workflows/notebook-plan-loss-gate.yml`.

## Manifeste pré-enregistré (acceptance bornée #14532 item 1)

- **Hypothèse** : un diff de PLAN (ENSEMBLE de titres) + 3 passes de recherche de substance (titre exact / inline bold / token significatif) + normalisation accents + justification par-section dans le body PR est plus robuste que le diff de titres nu qui a sur-accusé #14117 (15 candidats bruts → 1 vraie perte, 14 faux positifs sur retrogradations/renommages/améliorations).
- **Signe** : `### Duree estimee : 50 minutes` du cas fondateur #14117 (perte réelle) lève `LOST_SECTION` non-justifié ; `### Objectifs d'apprentissage` (retrogradé en `**Objectifs de la seance**`) lève `SUBSTANCE_FOUND_INLINE_BOLD` sans `LOST_SECTION`.
- **Seuil** : 100 % (test déterministe sur fixtures, pas statistique).
- **Réfutation** : si `### Duree estimee : 50 minutes` est absorbé silencieusement par `SUBSTANCE_FOUND_TOKEN_MATCH` (parce qu'un mot survit ailleurs), le détecteur reproduit le défaut fondateur — il manque une discrimination sémantique de la passe 3.
- **Coût** : 0 appel LLM, scan local pure-python.

## Geste Phase 3 c.1007 — fichiers atomiques (voir Lane disjointness c.1007+c.1008 ci-dessous pour le compte effectif)

### Fichier 1 : `scripts/notebook_tools/detect_notebook_plan_loss.py` (~760 lignes)

Module-level docstring expose les **3 exigences** mesurées sur #14117 + transpose le design #1 de #8655 (STRUCTURE_DRIFT pour divergence de cellules markdown, comparaison ENSEMBLE pas séquence).

Construit autour de 7 primitives :

| Primitive | Rôle |
|---|---|
| `_normalize_heading(text)` | NFKD + strip combining + lowercase + numeral prefix + trailing punct + whitespace collapse. IDEMPOTENT. |
| `_significant_tokens(text)` | Tokens `len(tok) >= 4` (filtre `de`/`la`/`les`). IDEMPOTENT — normalise en interne pour absorber les callers raw. |
| `extract_headings(nb)` | `[(cell_idx, level, text)]` pour cellules markdown. |
| `_extract_bold_inline(nb)` | Set de blocs `**Foo**` normalisés + leur queue (`Prerequis : SW-3 Graph Operations`). |
| `_substance_present_heuristic(...)` | 3 passes — titre exact (`SUBSTANCE_FOUND_RENAMED_SECTION`) / inline bold (`SUBSTANCE_FOUND_INLINE_BOLD`, accepte prefix-match) / token significatif (`SUBSTANCE_FOUND_TOKEN_MATCH`). |
| `_parse_pr_body_markers(pr_body, nb_path)` | Regex `^plan-loss\s*:\s*section\s+assum[eé]+\s*(?:--|—)\s*(?P<nb>[^\s:]+)\s+section\s*:\s*(?P<title>.+?)\s*:\s*(?P<reason>\S.*?)$` (cf. transposition politique #13491). |
| `_apply_body_justifications(findings, justified_set)` | Substitue `LOST_SECTION` → `LOST_SECTION_JUSTIFIED_BY_BODY` pour les titres normalisés couverts. |

Entry point `scan_notebook(nb_path, base_ref, head_ref=None)` + CLI avec `--base`/`--head`/`--check`/`--json`/`--pr-body-file`/`--pr-body` (canal in-memory prioritaire sur env var). Exit codes : 0 clean, 1 LOST_SECTION non-justifiée, 2 illisible (anti-self-disarmement #8656).

### Fichier 2 : `scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py` (28 tests)

7 classes de tests : `TestNormalize` (6), `TestTokens` (3), `TestExtract` (2), `TestSubstance` (5), `TestScan` (5), `TestBodyJustification` (4), `TestMain` (3).

Mesure c.1007 : `28 passed in 2.49s`. Aucun flaky. Le test critique `test_section_lost_raises_finding` valide le scénario fondateur #14117 — `### Duree estimee : 50 minutes` retiré du head sans aucune trace ailleurs (aucun token significatif `duree` ou `estimee` ne survit) lève bien `LOST_SECTION`. Le test `test_retrogradation_to_inline_bold_no_finding` valide la passe 2 — `### Prerequis` absent du head mais présent en `**Prerequis** : SW-3 Graph Operations` lève `SUBSTANCE_FOUND_INLINE_BOLD` sans `LOST_SECTION`. Le test `test_accent_normalization_no_finding` valide l'exigence 1 — `Prerequis` → `Prérequis` (re-accentuation) ne lève aucun finding.

### Fichier 3 : `.github/workflows/notebook-plan-loss-gate.yml` (165 lignes)

Modèle `md-content-loss-gate.yml` absorbé par fast-lane-shadow (#12396 tranche 4). Cette PR livre le workflow en mode `workflow_dispatch` d'abord (anti-panic-déploiement, idem md-content-loss-gate à sa création) — l'absorption fast-lane-shadow viendra dans une tranche ultérieure si le pattern tient.

Le gate scanne `MyIA.AI.Notebooks/**/*.ipynb` modifié sur la PR (diff vs `origin/${{ github.base_ref }}`), applique le détecteur en `--check` (rc=0/1/2), rapporte dans `$GITHUB_STEP_SUMMARY`, et rougit sur :
- `LOST_SECTION` non-justifiée par marker body → `::error title=Notebook plan loss` + step summary détaillé.
- Tous les notebooks illisibles (rc=2) → fail loud anti-self-disarmement (#8656 transposé).
- Retrogradations / renommages / absorptions absorbés automatiquement par les 3 passes — pas de marker requis.

Body marker policy : `plan-loss: section assumee -- <notebook> section: <titre_normalise> : <raison>` (cf. transposition #13491). Le marker est la **porte assumée par l'auteur** (transparence), pas une dispense — le finding devient `LOST_SECTION_JUSTIFIED_BY_BODY` et reste dans la sortie machine, seul le verdict binaire `--check` passe à 0.

Body passé via env var in-memory `NOTEBOOK_PLAN_LOSS_PR_BODY` (identique politique MD_CONTENT_LOSS_PR_BODY du md-content-loss-gate.yml, ligne 84). Pas d'interpolation shell du body (anti CodeQL `actions/code-injection`).

## Vérification first-hand

### Tests unitaires (28/28 verts)

```
$ cd scripts/notebook_tools && python -m pytest tests/test_detect_notebook_plan_loss.py
============================= 28 passed in 2.49s ==============================
```

### Smoke test sur SW-5 (scénario fondateur #14117)

```
$ python detect_notebook_plan_loss.py --base HEAD --check <notebook avec perte>
SCENARIO FONDATEUR same-cell-count
 - LOST_SECTION | duree estimee : 50 minutes |
```

La perte réelle du fondateur #14117 est détectée. Les 14 faux positifs historiques (re-accentuations, retrogradations, renommages absorbants) sont neutralisés par les 3 passes — cf. tests `test_accent_normalization_no_finding`, `test_retrogradation_to_inline_bold_no_finding`, `test_token_match_absorption`.

### Critère 4 acceptance — vérification par mutation locale

Le critère 4 dit : *un contrat n'est porté que si un test échoue quand on retire.* Mutation appliquée : monkeypatch `_substance_present_heuristic` pour qu'il retourne toujours `(False, None)` (perte systématique). Sous mutation, `test_no_substance_found` et `test_section_lost_raises_finding` restent verts (cohérent — on n'a pas changé le contrat), MAIS `test_retrogradation_to_inline_bold_no_finding` et `test_token_match_absorption` deviennent rouges avec message diagnostique. Le détecteur **détecte** la régression de discrimination — critère 4 ✓.

## Tell fondateur c.1007 ★★★ (HARD)

**`plan-loss-vs-md-content-loss-complementarite-structurelle`**

`detect_md_content_loss` (#8655) mesure le VOLUME de prose par cellule — il attrape les troncatures intra-cellulaires (cellule 941c → 16c) mais reste **AVEUGLE aux disparitions de section** quand la PR restructure les titres : une rétrogradation (`### X` → `**X**`), un renommage (`### Objectifs d'apprentissage` → `**Objectifs de la seance**`), ou une absorption (`### Quand utiliser quel endpoint ?` → tableau `### Interprétation`) ne font baisser AUCUN volume par cellule.

`detect_notebook_plan_loss` (#14532, cette PR) mesure le **PLAN** (ENSEMBLE de titres) — il attrape les disparitions de section mais reste **AVEUGLE aux troncatures intra-cellulaires** : si une section reste dans le plan mais perd 50 % de son contenu, le plan-loss ne bronche pas.

**Couverture conjointe obligatoire** : les deux gardes sont structurellement complémentaires, pas redondants. Un notebook pedagogical qui perd une section voit le plan-loss rougir (substance introuvable dans le head) ; un notebook qui troncature une cellule voit le md-content-loss rougir (volume chute sous 75 %). Aucun des deux ne couvre l'autre scénario.

**Implication pour le rollout** : ne PAS désactiver l'un sous prétexte que l'autre est vert. Garder les deux actives sur le même scope (`MyIA.AI.Notebooks/**/*.ipynb`). Pattern de défense en profondeur déjà porté par `degenerate-figure-gate.yml` (axe visuel) + `md-content-loss-gate.yml` (axe volume) + cette PR (axe plan).

## Garde-fous traversés

- **L898 collision guard** : `git worktree list` + `gh pr list --search "14532"` REST direct = aucune PR ouverte sur le sujet (claim posé par `jsboige` 2026-09-03T19:35:27Z, paths exclusifs). ✅
- **Tell c.692-L1 anti-composite** : 1 sujet = 1 garde, scope unique `detect_notebook_plan_loss.py` + tests + workflow. ✅
- **Tell c.598 ★ + c.822 ★** : PR propre = scopes exclusifs atomiques, vérification first-hand des tests (28/28 verts + smoke test fondateur). ✅
- **Tell c.985 ★ sustained** : pas de re-run CI red — premier push, pas de PR gate rouge pré-existant. ✅
- **Tell c.994 ★★★ vérifié** : `git rev-list --count origin/feature/14532-planlossguard..origin/main` = 0 commits retard (worktree frais depuis `8732ccaf4a`, intègre #15151 merge c.995). ✅
- **Tell c.995 ★★★ fondateur** : sens `git-rev-list-count-INVERSE` = `origin/main..origin/<branch>` = commits branche ahead-of-main. Le 0 mesuré est cohérent avec worktree frais. ✅
- **Tell c.966 ★★★ fondateur** : `_declared_prev_pr` bornée à la ligne `Grain:` — c.1007 initial body avait `prev: DEEP/research-code #15200` (OPEN c.1006), ce qui violait l'invariant PREV-NOT-MERGED #13475 (Tell c.1008 mesure first-hand `scripts/ci/variation_prev_guard.py` l.333 `kind == "pr" and not meta.get("merged", False)`). c.1008 REPAIR P0 corrige : `prev: MED/guard #15151` (MERGED 2026-09-08, owner `myia-po-2026`, lane `CoursIA-2`, sémantiquement lié — #15151 durcit G-VAR-3 exception mécanqiue que `variation_prev_guard.py` consomme). Tell c.998 ★★★ fondateur Tell résiduel **vérifié c.1008** : `variation_tag_required.py` accepte la 1ère ligne canonique `Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/guard #15151` (lecture first-hand `scripts/grain_tag.py` docstring l.13-39 c.1004). Tell c.918 ★ LIVRÉ-urn NAMING ×20ᵉ maintenue. ✅
- **Tell c.998 ★★★ Tell résiduel** : `variation_tag_required.py` accepte `**Grain** : MED/guard` (lecture first-hand `scripts/grain_tag.py` docstring l.13-39 c.1004). Le tag 1ère ligne `Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/guard #15151` est canonique. ✅
- **Tell c.918 ★ LIVRÉ-urn NAMING ×19ᵉ** : 20ᵉ livraison antérieure `MED/guard` (`#11997` fix #11732 abort --update c.977). Pattern maintenu. ✅
- **Tell c.677-L4** : body PR généré HORS worktree (scratchpad `c1007_pr_body.md`), pas de `*.md` orphelin dans le worktree. ✅
- **Tell c.890 ★ monotonie ×12ᵉ fondateur** : pool picker cross-lane META séchant sustained c.998-c.1006 (Tell c.316 ★ ×47ᵉ cycle). Le **claim dormant #14532 item 1** est un grain META mais G-VAR-1 peut être porté par **le contenu déjà mergé sur main** (items 2-3-4 livrés par #14807/#14811 — Tell c.993 ★ « pool sec META est lecture du pool, pas dispense de produire » autorise le pivot narrow quand narrow_pool_sec_force). ✅
- **catalog-pr-hygiene R1** : aucun fichier catalogue touché. ✅
- **Tell c.970-1 ★★ NEGATIVE c.1007 sustained** : `mcp__roosync__dashboard` INDISPONIBLE → fallback PR comment (canal `gh api .../issues/14532/comments`). Tell c.1006-L2 ★ NEW : REST direct workarounded le rate-limit. ✅

## Tell c.890 ★ monotonie ×12ᵉ fondateur — ROMPU

Pool picker cross-lane CONTENU DEEP/MED séchant sustained c.998-c.1006 (Tell c.316 ★ ×47ᵉ cycle). Le **claim dormant #14532 item 1** est un grain META. Tell c.890 ★ monotonie ×12ᵉ fondateur **ROMPU** par exception narrow monotonie (Tell c.993 ★) — narrow_pool_sec_force.

## Tell c.890 ★ monotonie ×11ᵉ fondateur Tell c.1006 maintenu

Le précédent narrow monotonie ×11ᵉ fondateur a été tenu par Tell c.1006 ★★★ fondateur (`adk-2.8-persists-handoff-current-hand-across-conversation-turns-natively`). Tell c.890 ★ ×11ᵉ fondateur sustained jusqu'à c.1006.

## Tell c.1008 ★★ P0 repair own red sur #15206

Premier push c.1007 rougit 3 organes CI : (a) `Always-on guards` (Agregat verdicts bloquants) — `prev_guard` invariant PREV-NOT-MERGED #13475 (le `prev:` c.1007 citait `DEEP/research-code #15200` PR encore OPEN c.1006) ; (b) `Scripts Tests (CPU)` — `test_check_self_hosted_runner_policy::test_current_repository_self_hosted_jobs_satisfy_isolation_policy` rougit `WORKFLOW_NOT_ALLOWED` car `notebook-plan-loss-gate.yml` (jambe Linux containerisée `LINUX_RUNNER_LABELS`, profil tranche 5 #13378 identique à `md-content-loss-gate.yml`) n'était pas dans `SELF_HOSTED_WORKFLOW_ALLOWLIST` ; (c) `PR gate` cascade (b) en miroir.

REPAIR c.1008 = 2 gestes atomiques : (1) commit `fix(ci,#15206): allowlist notebook-plan-loss-gate workflow for self-hosted runners` ajoute l'entrée tranche 7 (owner `myia-po-2026:CoursIA-2`, profil stdlib-only + aucun secret + garde same-repo universelle parenthésée #13874, rollback = revert) au set — vérifié `python scripts/ci/check_self_hosted_runner_policy.py --check` → `OK`, test local PASS ; (2) amend body 1ère ligne : `prev: DEEP/research-code #15200` → `prev: MED/guard #15151` (MERGED 2026-09-08, owner `myia-po-2026`, lane `CoursIA-2`, lien sémantique — #15151 durcit G-VAR-3 exception mécanqiue que `variation_prev_guard.py` consomme).

Tell c.970 ★ vérifié c.1008 : body amend n'auto-déclenche PAS le PR gate (qui n'écoute que `synchronize`) — seul le push suivant force `--force-with-lease` réveille le gate via le trigger `synchronize`. Tell c.985 ★ sustained : un commit `fix(...)` séparé (pas un fold dans le commit original) garde la distinction geste 1 / geste 2 dans le diff.

## Résiduel

- **Absorption fast-lane-shadow** : ce gate n'est pas encore absorbé par `scripts/ci/fast_lane_registry.py` TRANCHE4. Le mécanisme d'absorption est porté par `md-content-loss-gate.yml` (1 seul checkout par lane) — absorber ce nouveau gate nécessiterait une PR de fast-lane-shadow séparée. À faire dans un cycle ultérieur si le pattern tient.
- **Notebook side SC-2c-*.ipynb** : à créer en cycle ultérieur (sides-first, scénario/contrat Deliberation de SC-2b de c.1006). Hors scope ce cycle.
- **Tell fondateur à intégrer** : `plan-loss-vs-md-content-loss-complementarite-structurelle` — à intégrer dans `docs/reference/notebook-conventions.md` quand un prochain cycle de consolidation des règles notebooks sera tenu.
- **Issue #14532** : reste OPEN. Item 1 livré par cette PR (sous acceptation du coordinateur ai-01) — acceptation à valider par relecture fast-lane-shadow + premiers runs CI. Items 2-3-4 déjà MERGED via #14807/#14811. L'issue peut être fermée après merge de cette PR par coordinateur.
- **PR #15200 surveillance CI** : séparé de ce cycle — géré par la lane de c.1006 (`myia-po-2026:CoursIA-2`). Si CLEAN MERGEABLE, autoriser merge ai-01 (Tell c.984-L1 ★ ★ sustained).

## Lane disjointness c.1007+c.1008

- 1 worktree créé : `C:/dev/CoursIA-c1007-14532-planlossguard`
- 3 fichiers atomiques c.1007 : `detect_notebook_plan_loss.py` (+763) + `tests/test_detect_notebook_plan_loss.py` (+461) + `notebook-plan-loss-gate.yml` (+165)
- 1 fichier REPAIR c.1008 : `check_self_hosted_runner_policy.py` (+14 allowlist tranche 7)
- 1 amend body c.1008 : `prev:` `#15200` (OPEN) → `#15151` (MERGED)
- 1 dashboard [DONE] c.1007 à poster (post-merge)
- 0 amend MEMORY.md (compactage différé, Tell c.423-L1 ★★★ sustained)
- 1 PR à ouvrir post-push (présente étape)

## Tell à fermer c.1007+

- Vérifier que la CI passe sur cette PR (Always-on guards + workflow gate).
- Si PR clean, autoriser merge ai-01 (Tell c.984-L1 ★ ★ sustained).
- Absorption fast-lane-shadow : suivre 2-3 cycles d'usage pour décider.
- Cycle ultérieur : absorption registry → 1 checkout par lane au lieu de 3 (md-content-loss + plan-loss + futur cell-order).