### PR TITLE
fix(guard,#13475): invariant 2 ne rougit que sur un prev: abandonne, plus sur un predecesseur en vol

### DIFF
--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -34,11 +34,18 @@ the genre-adjacency measurement G-VAR-3 enforces:
      the comparator direction), so the cap never measures anything. Real
      witness: #12875.
 
-  2. **PREV-NOT-MERGED** -- the `prev:` points at a PR that has NOT been
-     merged yet. The predecessor is a moving target: the author believed
-     their work flowed from a closed-but-still-editable PR, and the cap
-     silently compares against a genre that may still change. Real witness:
-     #13473.
+  2. **PREV-ABANDONED** -- the `prev:` points at a PR that was **closed
+     without merging**. The declared lineage was given up: nothing it
+     carries will ever reach `main`, so the adjacency is measured against
+     a grain that does not exist there.
+
+     This invariant used to read "not merged", i.e. it fired on OPEN PRs
+     too, and that was wrong -- see ``validate_prev_targets`` for the
+     measurement (five PRs blocked on 2026-09-08 whose four cited
+     predecessors were all merely in flight) and for why an OPEN
+     predecessor is the *mandated* state of a lane holding R1's floor.
+     The witness the original invariant cited, #13473, merged on
+     2026-08-29 without anyone touching it.
 
   3. **PREV-NOT-PR** -- the `prev:` points at an ISSUE (not a PR). The
      predecessor is never mergeable, so genre adjacency is structurally
@@ -58,7 +65,7 @@ Scans the PR body AND every commit message on the branch for:
   (a) `prev:` whose genre is a closing keyword (`grain_tag.CLOSING_KEYWORDS`)
       -- the #10093 invariant;
   (b) `prev:` whose PR reference violates one of the three #13475 invariants
-      (PREV-SELF / PREV-NOT-MERGED / PREV-NOT-PR).
+      (PREV-SELF / PREV-ABANDONED / PREV-NOT-PR).
 
 A single verdict is emitted on stdout:
 
@@ -118,13 +125,18 @@ cite is a documented exemption, not a defect.
 
 ## How the caller passes target metadata
 
-(b) requires knowing whether each cited `#N` resolves to a PR, and whether
-that PR is merged. The workflow fetches this with `gh` and writes it as a
-JSON dict:
+(b) requires knowing whether each cited `#N` resolves to a PR, and in
+which state. The workflow fetches this with `gh` and writes it as a JSON
+dict:
 
-    {"1234": {"kind": "pr", "merged": true},
-     "5678": {"kind": "pr", "merged": false},
-     "9012": {"kind": "issue"}}
+    {"1234": {"kind": "pr", "state": "MERGED", "merged": true},
+     "5678": {"kind": "pr", "state": "OPEN",   "merged": false},
+     "3456": {"kind": "pr", "state": "CLOSED", "merged": false},
+     "9012": {"kind": "issue", "state": "OPEN"}}
+
+``state`` is the field invariant (2) tests; the three PR states are three
+different verdicts (clean / clean / blocked) and the `merged` boolean
+cannot express that.
 
 The shape is the smallest information needed to evaluate the three
 invariants; the gate does not call `gh` itself (that would couple the
@@ -139,7 +151,7 @@ number -- which the caller passes via `--current-pr`.
     # with commit messages (JSON array of strings):
     python scripts/ci/variation_prev_guard.py --body-file body.txt --commits-file commits.json \\
         --current-pr 13918
-    # with target metadata (JSON dict of pr_number -> {kind, merged}):
+    # with target metadata (JSON dict of pr_number -> {kind, state}):
     python scripts/ci/variation_prev_guard.py --body-file body.txt --current-pr 13918 \\
         --prev-targets-file targets.json
 """
@@ -303,21 +315,80 @@ def validate_prev_targets(
     r"""Evaluate invariants (2) and (3) of #13475 against a target list.
 
     ``targets_meta`` is a dict `{str(pr_number): {"kind": "pr"|"issue",
-    "merged": bool}}` -- the JSON the workflow writes. ``location`` is
-    `"body"` or `"commits[<index>]"` so the verdict can name the slot.
+    "state": "OPEN"|"CLOSED"|"MERGED"}}` -- the JSON ``resolve_prev_targets``
+    writes. ``location`` is `"body"` or `"commits[<index>]"` so the verdict
+    can name the slot.
 
     Returns a list of `{"location", "kind", "prev_pr"}` hits:
 
-      * `kind="prev-not-merged"` -- the target is a PR but its `merged` flag
-        is false (invariant 2).
+      * `kind="prev-abandoned"` -- the target is a PR **closed without
+        merging**: the lineage the tag declares was given up, so the
+        `prev:` points at nothing that will ever reach `main` (invariant 2).
       * `kind="prev-not-pr"` -- the target is an issue (invariant 3).
 
-    A target missing from `targets_meta` (the workflow couldn't resolve it)
-    is NOT flagged: the FN-safety contract is "unresolved -> abstain",
-    matching `check_unaddressed_nits.py`'s posture on the same class of
-    problem. The silent-acceptance defect that #13475 measures is at the
-    SUFFICIIENT-information end (the metadata is right there in the file,
-    we just didn't read it), not at the unresolvable end.
+    **An OPEN target is NOT a hit.** Invariant 2 used to fire on any
+    non-merged PR, which conflated two states that are not remotely the
+    same defect:
+
+    ==========  =====================================================
+    target      what it says about the lineage
+    ==========  =====================================================
+    ``MERGED``  the predecessor landed -- clean
+    ``OPEN``    the predecessor is **still in flight** -- clean too
+    ``CLOSED``  the predecessor was abandoned -- the real defect
+    ==========  =====================================================
+
+    Flagging ``OPEN`` punished the exact behaviour R1 of
+    `proactive-coordination.md` *mandates*: "1 PR entre 2 wakeups =
+    PLANCHER, jamais plafond -- une PR livree ne clot pas la session,
+    re-pioche IMMEDIATEMENT". A lane that opens its next PR before the
+    previous one merges is working as instructed, and this gate rejected
+    it for that. Measured on 2026-09-08 at 13:20Z, by replaying this
+    organ against the real bodies and commit messages: **five** open PRs
+    blocked (#15156, #15190, #15207, #15209, #15210), citing **four**
+    distinct predecessors (#15129, #15175, #15199, #15203) -- **all four
+    OPEN, not one abandoned**. #15175 was blocked too, but on its own
+    ``prev-self``; the ``prev-not-merged`` it also carried was this
+    invariant firing a second time on the same self-reference, and the
+    repair removes that duplicate without touching the real defect.
+
+    An earlier count of this same set said *six*, including #15200. That
+    reading was correct when taken and is no longer reproducible: #15200's
+    body was replaced by ``...`` at 2026-09-08T13:11:52Z, which removed
+    its ``Grain:`` line and with it every ``prev:`` clause. It is recorded
+    here rather than quietly corrected, because a body that moves under a
+    content measurement is exactly what makes such a measurement look
+    wrong afterwards. (#15200 is now a grain-orphan -- a separate defect,
+    invisible to every lane guard, tracked by GRAIN-ORPHANS-SWEEP #13086.)
+
+    It is also the doctrine `variation_adjacency_guard.py` already holds
+    since #11963: "the `prev:` field is frozen at PR-open time, so a lane
+    that merges grains while the PR sits open made the gate block PRs the
+    rule never aimed at". The two organs read the same field; they now
+    read it the same way.
+
+    The witness #13475 recorded for invariant 2 -- #13473, tagged
+    ``prev: ... #13465`` while #13465 was OPEN -- **merged on 2026-08-29**.
+    The "defect" resolved itself the moment its predecessor landed, which
+    is what a transient state does and what a broken lineage does not.
+
+    Two abstentions, both deliberate:
+
+      * a target missing from ``targets_meta`` (the workflow couldn't
+        resolve it) is NOT flagged -- FN-safety contract "unresolved ->
+        abstain", matching `check_unaddressed_nits.py` on the same class of
+        problem. The silent-acceptance defect #13475 measures is at the
+        SUFFICIENT-information end (the metadata is right there in the
+        file, we just didn't read it), not at the unresolvable end;
+      * a PR-kind meta carrying **no ``state``** (a hand-written or legacy
+        ``--prev-targets-file`` from before this field existed) cannot
+        separate OPEN from CLOSED, so it is unresolved *for this predicate*
+        and abstains for the same reason. ``resolve_prev_targets`` always
+        emits ``state``; ``test_resolver_always_emits_state_for_a_pr`` is
+        the control that keeps this path an edge case rather than the norm.
+
+    ``merged`` is still emitted by the resolver for backward compatibility
+    with readers of the JSON, but it is **not** what this predicate tests.
     """
     if not target_prs or not targets_meta:
         return []
@@ -330,10 +401,15 @@ def validate_prev_targets(
         if kind == "issue":
             out.append({"location": location, "kind": "prev-not-pr",
                         "prev_pr": n})
-        elif kind == "pr" and not meta.get("merged", False):
-            out.append({"location": location, "kind": "prev-not-merged",
-                        "prev_pr": n})
-        # kind == "pr" and merged -> clean, no entry
+        elif kind == "pr":
+            state = str(meta.get("state") or "").upper()
+            if state == "CLOSED":
+                out.append({"location": location, "kind": "prev-abandoned",
+                            "prev_pr": n})
+            # MERGED -> landed, clean.
+            # OPEN   -> still in flight, clean (see docstring).
+            # ""     -> legacy meta without `state`: abstain, we cannot
+            #           tell OPEN from CLOSED and must not guess.
     return out
 
 
@@ -382,7 +458,7 @@ def check(
              "prev_pr": h["prev_pr"]}
             for h in find_prev_self_references(msg, current_pr)
         )
-    # PREV-NOT-MERGED + PREV-NOT-PR -- body + every commit. Each location
+    # PREV-ABANDONED + PREV-NOT-PR -- body + every commit. Each location
     # gets its own target list because the body and each commit carry
     # independent `prev:` clauses; aggregating them would mix concerns.
     body_targets = find_prev_target_pr_numbers(body)
@@ -425,8 +501,9 @@ def check(
         )
         reasons.append(
             f"`prev:` reference(s) fail invariant(s) ({kind_summary}) -> "
-            "point `prev:` at a MERGED PR of the same lane, distinct from "
-            "the current PR. See #13475."
+            "point `prev:` at a PR of the same lane, distinct from the "
+            "current PR, that is merged or still open -- never at an "
+            "abandoned (closed-unmerged) PR nor at an issue. See #13475."
         )
 
     return {
@@ -461,7 +538,7 @@ def _read_commits_file(path: str) -> list[str]:
 def _read_prev_targets_file(path: str) -> dict[str, dict]:
     """Read a prev-targets file as a JSON dict of metadata.
 
-    The workflow writes a dict ``{str(pr_number): {"kind", "merged"}}``
+    The workflow writes a dict ``{str(pr_number): {"kind", "state"}}``
     built from ``gh pr view`` / ``gh issue view`` lookups for each
     `prev:` reference. An empty/missing file yields an empty dict -- the
     gate then abstains on invariants 2/3 (FN-safety contract; see
@@ -489,7 +566,14 @@ def resolve_prev_targets(
     runner=None,
     timeout: int = 15,
 ) -> "dict[str, dict]":
-    r"""Resolve each `prev:` target to ``{"kind": "pr"|"issue", "merged": bool}``.
+    r"""Resolve each `prev:` target to ``{"kind", "state", "merged"}``.
+
+    ``state`` is the verbatim ``gh`` state -- ``OPEN`` / ``CLOSED`` /
+    ``MERGED`` -- and it is the field ``validate_prev_targets`` tests.
+    ``merged`` is kept as a derived convenience for readers of the JSON,
+    but collapsing the three states into that boolean is precisely what
+    made invariant 2 unable to tell "still in flight" from "abandoned"
+    (see that function's docstring).
 
     This is the half of #13475 that used to live in a heredoc inside
     ``always-on-guards.yml``, where no test could reach it -- and it was
@@ -534,13 +618,15 @@ def resolve_prev_targets(
             state = _json_field(pr.stdout, "state")
             if state:
                 out[str(n)] = {"kind": "pr",
+                               "state": state.upper(),
                                "merged": state.upper() == "MERGED"}
                 continue
         issue = runner(["gh", "issue", "view", str(n), "--json", "state"],
                        capture_output=True, text=True, timeout=timeout)
         if getattr(issue, "returncode", 1) == 0:
-            if _json_field(issue.stdout, "state"):
-                out[str(n)] = {"kind": "issue"}
+            istate = _json_field(issue.stdout, "state")
+            if istate:
+                out[str(n)] = {"kind": "issue", "state": istate.upper()}
                 continue
         # neither resolved -> omitted -> the gate abstains on this target
     return out
@@ -584,8 +670,8 @@ def main(argv: list[str] | None = None) -> int:
                         "(required to evaluate PREV-SELF)")
     p.add_argument("--prev-targets-file", metavar="FILE",
                    help="path to a JSON dict of "
-                        "{str(pr_number): {kind, merged}} for each cited "
-                        "`prev:` reference (required for PREV-NOT-MERGED "
+                        "{str(pr_number): {kind, state}} for each cited "
+                        "`prev:` reference (required for PREV-ABANDONED "
                         "and PREV-NOT-PR)")
     p.add_argument("--resolve-targets", action="store_true",
                    help="resolve each cited `prev:` reference with `gh` "

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -119,7 +119,8 @@ CLEAN_PREV_BODY = (
     "Grain: LIGHT/refactor -- lane myia-po-2026:CoursIA "
     "-- prev: LIGHT/refactor #13826"
 )
-CLEAN_PREV_TARGETS = {"13826": {"kind": "pr", "merged": True}}
+CLEAN_PREV_TARGETS = {"13826": {"kind": "pr", "state": "MERGED",
+                                "merged": True}}
 
 
 def test_prev_self_reference_blocks():
@@ -167,19 +168,67 @@ def test_prev_self_abstains_when_current_pr_unknown():
     assert v["guard_pass"] is True
 
 
-def test_prev_not_merged_blocks():
-    # #13473 measured: `prev: feat/notebook #13465` on PR #13473, where
-    # #13465 was OPEN at the time of the tag (the predecessor is a moving
-    # target whose genre could still change before merge).
-    v = vpg.check(
-        "Grain: feat/module -- lane myia-po-2026:CoursIA "
-        "-- prev: feat/notebook #13465",
-        current_pr=13473,
-        prev_targets={"13465": {"kind": "pr", "merged": False}},
-    )
+# Invariant 2 is a THREE-way discrimination, and the three cases must be
+# pinned together: a predicate tested only on its blocking case cannot be
+# distinguished from one that blocks on everything. That is exactly how the
+# original shipped -- `test_prev_not_merged_blocks` asserted the CLOSED
+# verdict while feeding it an OPEN target, and nothing in the suite said
+# the two were different.
+
+_ABANDONED_BODY = ("Grain: MED/guard -- lane myia-ai-01:CoursIA "
+                   "-- prev: MED/guard #13465")
+
+
+def test_prev_abandoned_blocks():
+    # CLOSED without merging: the declared lineage was given up. Nothing it
+    # carries will ever reach `main`, so adjacency is measured against a
+    # grain that does not exist there. This is the defect invariant 2 aims at.
+    v = vpg.check(_ABANDONED_BODY, current_pr=13473,
+                  prev_targets={"13465": {"kind": "pr", "state": "CLOSED",
+                                          "merged": False}})
     assert v["guard_pass"] is False
-    assert any(h["kind"] == "prev-not-merged" and h["prev_pr"] == 13465
+    assert any(h["kind"] == "prev-abandoned" and h["prev_pr"] == 13465
                for h in v["hits"]["prev_invalid"])
+
+
+def test_prev_open_abstains_the_predecessor_is_in_flight():
+    # THE REPAIR. Same body, same current PR, ONE field different -- and the
+    # verdict flips. A predecessor still open is not a broken lineage: it is
+    # the state R1 of `proactive-coordination.md` mandates ("1 PR entre 2
+    # wakeups = PLANCHER, jamais plafond -- re-pioche IMMEDIATEMENT").
+    #
+    # The witness the original invariant cited, #13473, was tagged
+    # `prev: ... #13465` while #13465 was OPEN -- and it MERGED on
+    # 2026-08-29 without anyone touching the tag. A "defect" that resolves
+    # itself when its predecessor lands is a transient state, not a defect.
+    v = vpg.check(_ABANDONED_BODY, current_pr=13473,
+                  prev_targets={"13465": {"kind": "pr", "state": "OPEN",
+                                          "merged": False}})
+    assert v["guard_pass"] is True
+    assert v["hits"]["prev_invalid"] == []
+
+
+def test_prev_merged_passes():
+    # The third state, kept explicit rather than left implicit in the
+    # end-to-end tests: MERGED is clean, and it must be clean for a REASON
+    # the suite states, not as a by-product of no other branch firing.
+    v = vpg.check(_ABANDONED_BODY, current_pr=13473,
+                  prev_targets={"13465": {"kind": "pr", "state": "MERGED",
+                                          "merged": True}})
+    assert v["guard_pass"] is True
+
+
+def test_legacy_meta_without_state_abstains_it_cannot_tell_open_from_closed():
+    # BACKWARD-COMPAT / FN-SAFETY. A hand-written or pre-#13475-repair
+    # `--prev-targets-file` carries only `merged`. `merged: False` covers
+    # BOTH open and closed, so the predicate has insufficient information
+    # and must abstain rather than guess -- the same contract as an
+    # unresolved target. `test_resolver_always_emits_state_for_a_pr` is
+    # what keeps this an edge case instead of the silent norm.
+    v = vpg.check(_ABANDONED_BODY, current_pr=13473,
+                  prev_targets={"13465": {"kind": "pr", "merged": False}})
+    assert v["guard_pass"] is True
+    assert v["hits"]["prev_invalid"] == []
 
 
 def test_prev_not_pr_blocks():
@@ -227,12 +276,13 @@ def test_combined_close_keyword_and_prev_self_reports_both():
     v = vpg.check(
         "Grain: MED/fix -- lane x:y -- prev: MED/fix #13465",
         current_pr=13465,
-        prev_targets={"13465": {"kind": "pr", "merged": False}},
+        prev_targets={"13465": {"kind": "pr", "state": "CLOSED",
+                                "merged": False}},
     )
     assert v["guard_pass"] is False
     assert any(h["genre"] == "fix" for h in v["hits"]["body"])
     assert any(h["kind"] == "prev-self" for h in v["hits"]["prev_invalid"])
-    assert any(h["kind"] == "prev-not-merged" for h in v["hits"]["prev_invalid"])
+    assert any(h["kind"] == "prev-abandoned" for h in v["hits"]["prev_invalid"])
     # Both reasons appear in the human-readable summary.
     assert "closing keywords" in v["reason"]
     assert "invariant" in v["reason"]
@@ -269,17 +319,21 @@ def test_find_prev_target_pr_numbers_helper():
 
 
 def test_validate_prev_targets_helper():
-    # Helper: builds the right hit dict per kind.
-    targets = [1, 2, 3]
+    # Helper: the full verdict table in one place. Two of the five rows are
+    # CLEAN and two are ABSTENTIONS -- a table listing only the blocking
+    # rows would pass under a predicate that blocks on everything.
+    targets = [1, 2, 3, 4, 5]
     meta = {
-        "1": {"kind": "pr", "merged": True},     # clean
-        "2": {"kind": "pr", "merged": False},    # PREV-NOT-MERGED
-        "3": {"kind": "issue"},                  # PREV-NOT-PR
-        # "4" absent on purpose -> abstain
+        "1": {"kind": "pr", "state": "MERGED", "merged": True},   # clean
+        "2": {"kind": "pr", "state": "CLOSED", "merged": False},  # ABANDONED
+        "3": {"kind": "issue", "state": "OPEN"},                  # NOT-PR
+        "4": {"kind": "pr", "state": "OPEN", "merged": False},    # in flight
+        "5": {"kind": "pr", "merged": False},                     # legacy
+        # "6" absent on purpose -> abstain (unresolved)
     }
-    hits = vpg.validate_prev_targets(targets, meta, location="body")
-    kinds = sorted(h["kind"] for h in hits)
-    assert kinds == ["prev-not-merged", "prev-not-pr"]
+    hits = vpg.validate_prev_targets(targets + [6], meta, location="body")
+    assert sorted(h["kind"] for h in hits) == ["prev-abandoned", "prev-not-pr"]
+    assert sorted(h["prev_pr"] for h in hits) == [2, 3]
 
 
 def test_prev_invalid_check_unaffected_by_existing_close_keyword_tests():
@@ -290,7 +344,8 @@ def test_prev_invalid_check_unaffected_by_existing_close_keyword_tests():
     v = vpg.check(
         "Grain: MED/fix -- lane x:y -- prev: MED/fix #100",
         current_pr=200,
-        prev_targets={"100": {"kind": "pr", "merged": True}},
+        prev_targets={"100": {"kind": "pr", "state": "MERGED",
+                              "merged": True}},
     )
     assert v["guard_pass"] is False
     assert any(h["genre"] == "fix" for h in v["hits"]["body"])
@@ -366,27 +421,44 @@ class FakeGh:
 
 
 WORLD = {14225: ("pr", "MERGED"),      # merged PR   -> the #13922 witness
-         13922: ("pr", "OPEN"),        # open PR
+         13922: ("pr", "OPEN"),        # open PR     -> in flight, clean
+         13999: ("pr", "CLOSED"),      # closed PR   -> abandoned, blocking
          14513: ("issue", "OPEN")}     # issue
 
 
 def test_resolve_prev_targets_merged_pr_is_a_merged_pr():
     gh = FakeGh(WORLD)
     assert vpg.resolve_prev_targets([14225], runner=gh) == {
-        "14225": {"kind": "pr", "merged": True}}
+        "14225": {"kind": "pr", "state": "MERGED", "merged": True}}
     # PR-first ordering: the issue endpoint is never consulted for a PR.
     assert [c[1] for c in gh.calls] == ["pr"]
 
 
 def test_resolve_prev_targets_open_pr_is_a_pr_not_merged():
     assert vpg.resolve_prev_targets([13922], runner=FakeGh(WORLD)) == {
-        "13922": {"kind": "pr", "merged": False}}
+        "13922": {"kind": "pr", "state": "OPEN", "merged": False}}
+
+
+def test_resolve_prev_targets_closed_pr_is_distinguishable_from_an_open_one():
+    # The whole point of surfacing `state` (2026-09-08). Before it, both an
+    # OPEN and a CLOSED PR came back as `merged: False` -- one dict, two
+    # situations, and `validate_prev_targets` was structurally unable to
+    # tell a predecessor still in flight from an abandoned one. The pair of
+    # assertions below IS the repair: same `kind`, same `merged`, and the
+    # only field that differs is the one the invariant now reads.
+    closed = vpg.resolve_prev_targets([13999], runner=FakeGh(WORLD))
+    opened = vpg.resolve_prev_targets([13922], runner=FakeGh(WORLD))
+    assert closed == {"13999": {"kind": "pr", "state": "CLOSED",
+                                "merged": False}}
+    assert closed["13999"]["merged"] == opened["13922"]["merged"], \
+        "`merged` alone cannot separate the two -- that is the defect"
+    assert closed["13999"]["state"] != opened["13922"]["state"]
 
 
 def test_resolve_prev_targets_issue_is_an_issue():
     gh = FakeGh(WORLD)
     assert vpg.resolve_prev_targets([14513], runner=gh) == {
-        "14513": {"kind": "issue"}}
+        "14513": {"kind": "issue", "state": "OPEN"}}
     # Both endpoints were tried, in that order.
     assert [c[1] for c in gh.calls] == ["pr", "issue"]
 
@@ -436,7 +508,24 @@ def test_original_state_merged_field_set_misclassifies_a_merged_pr():
 
     assert original_algorithm(14225) == {"kind": "issue"}          # the defect
     assert vpg.resolve_prev_targets([14225], runner=FakeGh(WORLD)) == {
-        "14225": {"kind": "pr", "merged": True}}                   # the repair
+        "14225": {"kind": "pr", "state": "MERGED",
+                  "merged": True}}                                # the repair
+
+
+def test_resolver_always_emits_state_for_every_pr_kind_it_returns():
+    """Keeps the `state`-less abstention an EDGE case, never the norm.
+
+    `validate_prev_targets` abstains on a PR-kind meta carrying no `state`,
+    because it cannot tell OPEN from CLOSED and must not guess. That
+    abstention is a courtesy to hand-written and legacy fixtures -- if the
+    real resolver ever stopped emitting `state`, the same code path would
+    silently turn invariant 2 off across the whole fleet, and every test
+    above would still be green. This is the control that would go red.
+    """
+    resolved = vpg.resolve_prev_targets(sorted(WORLD), runner=FakeGh(WORLD))
+    assert len(resolved) == len(WORLD), "fixture inerte: rien resolu"
+    without = [n for n, meta in resolved.items() if not meta.get("state")]
+    assert not without, "resolver emitted a PR meta with no state: %s" % without
 
 
 def test_check_passes_on_a_prev_pointing_at_a_resolved_merged_pr():
@@ -456,9 +545,17 @@ def test_check_passes_on_a_prev_pointing_at_a_resolved_merged_pr():
 
 # Shape of the real #14559 body: a valid tag pointing at a MERGED PR, and a
 # quoted tag of ANOTHER grain in the prose. Before the fix, the quotation won:
-# `finditer` swept the whole body, found #14548 (still open), and the guard
-# rejected the PR on `prev-not-merged` -- accusing a lane of a defect it had
-# taken care to avoid.
+# `finditer` swept the whole body, found #14548, and the guard rejected the
+# PR on the cited grain's target -- accusing a lane of a defect it had taken
+# care to avoid.
+#
+# NOTE (2026-09-08, invariant-2 repair): #14548 was OPEN in the real
+# incident, and OPEN was what made the leak visible back then. Since an OPEN
+# target no longer blocks, every fixture in this section holds it CLOSED
+# instead: the teeth of these tests are "a mask leak turns into a block",
+# and that only stays true if the leaked target is one the current predicate
+# rejects. Left at OPEN, the assertions below would pass on a totally broken
+# mask.
 CITING_BODY = (
     "Grain: DEEP/research-code -- lane myia-po-2026:CoursIA-2 -- "
     "prev: DEEP/research-code #14501\n"
@@ -471,9 +568,11 @@ CITING_BODY = (
 
 def test_backticked_prev_is_a_citation_not_a_declaration():
     # The real #14559 case. `prev:` is declared at #14501 (merged); the body
-    # also QUOTES another lane's tag pointing at #14548 (open).
-    targets = {"14501": {"kind": "pr", "merged": True},
-               "14548": {"kind": "pr", "merged": False}}
+    # also QUOTES another lane's tag pointing at #14548 (abandoned -- see
+    # the section NOTE: it was OPEN in the incident, and OPEN no longer
+    # blocks, so the leak has to land on a state that does).
+    targets = {"14501": {"kind": "pr", "state": "MERGED", "merged": True},
+               "14548": {"kind": "pr", "state": "CLOSED", "merged": False}}
     v = vpg.check(CITING_BODY, current_pr=14559, prev_targets=targets)
     assert 14548 not in vpg.find_prev_target_pr_numbers(CITING_BODY)
     assert v["hits"]["prev_invalid"] == []
@@ -496,14 +595,18 @@ def test_fenced_block_is_masked_too():
     assert vpg.find_prev_target_pr_numbers(body) == [14501]
 
 
-def test_plain_prev_at_an_open_pr_still_fails():
-    # NEGATIVE CONTROL -- the invariant is not weakened. A `prev:` written in
-    # plain text (the canonical tag) at a still-open PR must still be rejected.
+def test_plain_prev_at_an_abandoned_pr_still_fails():
+    # NEGATIVE CONTROL -- the mask is not a blanket amnesty. The SAME clause
+    # as the citation above, written in plain text (the canonical tag), at
+    # the SAME target, must still be rejected. This is the pair that proves
+    # the pass above was earned by the backticks, and not by a target the
+    # predicate waves through anyway.
     body = "Grain: MED/guard -- lane a:b -- prev: MED/guard #14548"
     v = vpg.check(body, current_pr=99999,
-                  prev_targets={"14548": {"kind": "pr", "merged": False}})
+                  prev_targets={"14548": {"kind": "pr", "state": "CLOSED",
+                                          "merged": False}})
     assert v["hits"]["prev_invalid"] == [
-        {"location": "body", "kind": "prev-not-merged", "prev_pr": 14548}]
+        {"location": "body", "kind": "prev-abandoned", "prev_pr": 14548}]
     assert v["guard_pass"] is False
 
 
@@ -521,10 +624,15 @@ def test_fully_backticked_tag_is_still_evaluated():
     # backticks and every `prev:` invariant goes silent. `grain_tag.parse_prev`
     # strips backticks before reading, so the DECLARATION is unioned back in.
     # Remove that union and this test goes green in the wrong direction.
+    #
+    # The union is what this measures, so the target must be one the
+    # predicate rejects (section NOTE): held CLOSED, a lost union turns the
+    # red into a green and the test speaks. Held OPEN it would be silent.
     body = "`Grain: MED/guard -- lane a:b -- prev: MED/guard #14548`\nSuite."
     assert vpg.find_prev_target_pr_numbers(body) == [14548]
     v = vpg.check(body, current_pr=99999,
-                  prev_targets={"14548": {"kind": "pr", "merged": False}})
+                  prev_targets={"14548": {"kind": "pr", "state": "CLOSED",
+                                          "merged": False}})
     assert v["guard_pass"] is False
 
 
@@ -537,7 +645,9 @@ def test_prose_citation_without_grain_line_is_not_a_declaration():
     # line at all (it's a normal commit message, not a worker-authored
     # grain). The previous `_declared_prev_pr` passed the WHOLE body to
     # `grain_tag.parse_prev`, which matched the prose citation and reported
-    # `prev: #14592` -- then PREV-SELF / PREV-NOT-MERGED fired.
+    # `prev: #14592` -- then PREV-SELF / PREV-NOT-MERGED fired (that
+    # second invariant is named PREV-ABANDONED since 2026-09-08; the old
+    # name is kept here because it is what the incident report said).
     #
     # After the fix, the search is BOUNDED to the first `Grain:` line:
     # absent -> None -> no declaration -> no false positive.
@@ -569,8 +679,11 @@ def test_prose_citation_after_tag_line_still_evaluates_tag():
         "Le meme defaut que `prev: MED/qc #14548` documentait sur #14548.\n"
     )
     assert vpg._declared_prev_pr(body) == 14501
-    targets = {"14501": {"kind": "pr", "merged": True},
-               "14548": {"kind": "pr", "merged": False}}
+    # #14548 held CLOSED for the same reason as the section NOTE: if the
+    # bounded search ever regressed to the prose citation, the verdict must
+    # go red rather than stay quietly green.
+    targets = {"14501": {"kind": "pr", "state": "MERGED", "merged": True},
+               "14548": {"kind": "pr", "state": "CLOSED", "merged": False}}
     v = vpg.check(body, current_pr=99999, prev_targets=targets)
     assert v["hits"]["prev_invalid"] == []
     assert v["guard_pass"] is True
@@ -605,7 +718,7 @@ def test_first_grain_line_helper_bounds_search():
 # The previous regex `` `[^`\\n]*` `` forbade newlines, so the closing
 # backtick at the start of L5 was orphaned and the L5 half escaped the
 # mask. `` _PREV_PR_REF_RE `` then matched `` #14592 `` and fired
-# `` prev-not-merged -> [14592] `` -- on the PR whose own commit message
+# `` prev-abandoned -> [14592] `` -- on the PR whose own commit message
 # documented the bug. The control in ai-01's analysis was exact: the same
 # citation on a SINGLE line was correctly masked; the soft break was the
 # only discriminant. We extend the span to allow `` \\n `` and pin the
@@ -686,15 +799,19 @@ def test_fenced_block_with_internal_backticks_still_masked():
 def test_multiline_backticked_citation_in_commit_passes_full_guard():
     # #14703 -- the issue's isolated control replayed at FULL GUARD level.
     # ai-01 measured the defect through the complete verdict path (the
-    # organ's `prev_invalid` named ``commits[0]`` / prev-not-merged / 14592);
-    # the mask-level tests above pin the mechanism, this one pins the
-    # end-to-end verdict the CI actually computes. The cited #14592 is held
-    # OPEN in ``prev_targets`` so a mask leak would turn into a block --
-    # the pass is earned by the mask, not by an accidentally-unresolvable
-    # target.
+    # organ's `prev_invalid` named ``commits[0]`` / the cited target /
+    # 14592); the mask-level tests above pin the mechanism, this one pins
+    # the end-to-end verdict the CI actually computes. The cited #14592 is
+    # held CLOSED in ``prev_targets`` so a mask leak would turn into a
+    # block -- the pass is earned by the mask, not by a target the current
+    # predicate would wave through anyway. (It was OPEN when this test was
+    # written; OPEN stopped blocking on 2026-09-08, which would have turned
+    # the three assertions below into tautologies.)
     targets = {
-        "13826": {"kind": "pr", "merged": True},   # the body's own prev
-        "14592": {"kind": "pr", "merged": False},  # the cited-in-prose PR
+        # the body's own prev
+        "13826": {"kind": "pr", "state": "MERGED", "merged": True},
+        # the cited-in-prose PR
+        "14592": {"kind": "pr", "state": "CLOSED", "merged": False},
     }
     commit_two_line = (
         "fix(guard): document citation defect\n"
@@ -738,23 +855,28 @@ def test_multiline_backticked_citation_in_commit_passes_full_guard():
     v = vpg.check(CLEAN_PREV_BODY, [commit_bare_wrapped],
                   current_pr=14703, prev_targets=targets)
     assert v["guard_pass"] is False
-    assert any(h["kind"] == "prev-not-merged" and h["prev_pr"] == 14592
+    assert any(h["kind"] == "prev-abandoned" and h["prev_pr"] == 14592
                and h["location"] == "commits[0]"
                for h in v["hits"]["prev_invalid"])
 
 
 # --- #14550, second defect: a silent fail-open is an unearned attestation ----
-# ai-01 measured it on #14515: CLEAN, PR gate green, mergeable -- with a
-# `prev:` at an OPEN PR, because the `gh` resolution happened to fail during
+# ai-01 measured it on #14515: CLEAN, PR gate green, mergeable -- with an
+# unevaluated `prev:`, because the `gh` resolution happened to fail during
 # THAT run. Same violation as four red PRs the same minute; only the
 # abstention differed, and nothing in the verdict said so.
+#
+# The 2026-09-08 repair of invariant 2 does NOT touch this: an abstention on
+# a lookup failure and an abstention on an in-flight predecessor are two
+# different silences, and only the first one is a gap in the measurement.
 
 def test_unresolved_prev_targets_pure_selector():
     # The selector names exactly what the gate could not measure: cited but
     # absent from the resolved dict -- whether the lookup raised (network,
     # gh absent) or the target itself did not resolve.
     assert vpg.unresolved_prev_targets({14483}, {}) == [14483]
-    assert vpg.unresolved_prev_targets({14483, 7}, {"14483": {"kind": "pr", "merged": True}}) == [7]
+    assert vpg.unresolved_prev_targets(
+        {14483, 7}, {"14483": {"kind": "pr", "state": "MERGED"}}) == [7]
     assert vpg.unresolved_prev_targets(set(), {}) == []
 
 
@@ -786,15 +908,23 @@ def test_resolution_failure_stays_green_but_flags_abstention(
     assert "#14459" in captured.err
 
 
-def test_14515_real_body_with_resolved_open_target_fails():
+def test_resolved_bad_target_fails_the_abstention_flag_is_not_the_predicate():
     # ACCEPTANCE 5 (#14550) -- positive control of the fail-open: with the
-    # resolution SUCCEEDING, the real #14515 tag (`prev: MED/notebook-python
-    # #14483`, target OPEN) must go red. The abstention flag repairs
-    # visibility, never the predicate.
+    # resolution SUCCEEDING on a target the predicate rejects, the verdict
+    # must go red. The abstention flag repairs VISIBILITY, never the
+    # predicate; if this ever passes, the fail-open has become permanent.
+    #
+    # The real #14515 tag cited an OPEN #14483, which is no longer a defect
+    # (see `test_prev_open_abstains_the_predecessor_is_in_flight`). What
+    # this test needs is any target the predicate DOES reject, so the shape
+    # is kept and the state moved to CLOSED -- otherwise the assertion would
+    # be measuring the repair instead of the fail-open.
     body = ("Grain: MED/notebook-python -- lane myia-po-2023:CoursIA -- "
             "prev: MED/notebook-python #14483")
-    v = vpg.check(body, prev_targets={"14483": {"kind": "pr", "merged": False}})
+    v = vpg.check(body, prev_targets={"14483": {"kind": "pr",
+                                                "state": "CLOSED",
+                                                "merged": False}})
     assert v["guard_pass"] is False
     kinds = {h["kind"] for h in v["hits"]["prev_invalid"]}
-    assert "prev-not-merged" in kinds
+    assert "prev-abandoned" in kinds
     assert "resolution_failed" not in v  # check() has nothing to abstain on


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/docs #15207

L'invariant 2 de #13475 rougissait sur **deux situations qui n'ont rien à voir**, parce que le résolveur écrasait un `state` à trois valeurs dans un booléen.

## Le défaut, en une ligne de code

`resolve_prev_targets` interrogeait `gh pr view --json state` — donc `OPEN` / `CLOSED` / `MERGED` — puis n'en gardait que `merged = (state == "MERGED")`. `validate_prev_targets`, qui ne voit que ce booléen, était **structurellement incapable** de séparer :

| état de la cible | ce que ça dit de la lignée | verdict dû |
|---|---|---|
| `MERGED` | le prédécesseur a atterri | propre |
| `OPEN` | le prédécesseur est **encore en vol** | propre aussi |
| `CLOSED` | le prédécesseur a été **abandonné** | **le vrai défaut** |

Les deux derniers rendaient `merged: false`. Les deux rougissaient.

## Pourquoi c'est le mauvais des deux qui rougissait le plus

Rougir sur `OPEN` punit **exactement** le comportement que R1 de [proactive-coordination.md](.claude/rules/proactive-coordination.md) *impose* :

> « 1 PR entre 2 wakeups = PLANCHER, jamais plafond — une PR livrée ne clôt pas la session, re-pioche IMMÉDIATEMENT »

Une lane qui ouvre sa PR suivante avant que la précédente ne merge **suit la consigne**. Ce garde la rejetait pour ça.

C'est aussi la doctrine que `variation_adjacency_guard.py` tient **déjà** depuis #11963 : *« le champ `prev:` est gelé à l'ouverture de la PR, donc une lane qui merge des grains pendant que sa PR attend faisait bloquer par le gate des PRs que la règle ne visait pas »*. Les deux organes lisent le même champ ; ils le lisent désormais pareil.

Et le témoin que #13475 citait pour l'invariant 2 — **#13473**, tagué `prev: … #13465` alors que #13465 était OPEN — **a mergé le 2026-08-29** sans que personne n'y touche. Un défaut qui se résout quand son prédécesseur atterrit est un **état transitoire**, pas une lignée cassée.

## Mesure — l'organe rejoué sur les vrais corps

Mesuré le **2026-09-08 à 13:20Z**, en rejouant `variation_prev_guard.py` (version `origin/main` puis version de cette PR) sur les vrais `body` + `commits` récupérés par `gh`, avec `--current-pr` **et** `--resolve-targets` :

| PR | avant | après |
|---|---|---|
| #15156 | `prev-not-merged → 15129` (body + `commits[0]`) | **passe** |
| #15190 | `prev-not-merged → 15175` | **passe** |
| #15207 | `prev-not-merged → 15203` | **passe** |
| #15209 | `prev-not-merged → 15199` | **passe** |
| #15210 | `prev-not-merged → 15175` (body + `commits[0]`) | **passe** |
| #15175 | `prev-self` **+** `prev-not-merged` (les deux sur 15175) | **`prev-self` seul, toujours rouge** |

Les **quatre** prédécesseurs cités — #15129, #15175, #15199, #15203 — sont **tous OPEN**, vérifiés un par un. **Aucun n'est abandonné.**

#15175 est le contrôle négatif du lot : il se cite lui-même, c'est un vrai défaut, et la réparation **ne le débloque pas**. Elle retire seulement le doublon — l'invariant 2 tirait une seconde fois sur la même auto-référence.

### Correction due sur un chiffre que j'ai avancé

Une mesure antérieure de ce même lot annonçait **six** PRs, en incluant **#15200**. Ce chiffre était juste au moment où il a été pris et **n'est plus reproductible** : le corps de #15200 a été remplacé par `...` (3 caractères) à **2026-09-08T13:11:52Z**, ce qui a supprimé sa ligne `Grain:` et avec elle toute clause `prev:`. Sous les deux versions du garde, #15200 passe désormais.

Je l'inscris — dans le docstring et ici — plutôt que de corriger le chiffre en silence : **un corps qui bouge sous une mesure de contenu est précisément ce qui fait passer cette mesure pour fausse après coup**. Effet de bord à traiter à part : #15200 est maintenant un **grain-orphelin**, invisible à tous les gardes de lane (GRAIN-ORPHANS-SWEEP #13086).

### Cette PR est elle-même le sixième cas

En rédigeant le tag j'ai d'abord écrit `prev: MED/docs #15204` — le numéro de l'**issue** que ma PR précédente traite, au lieu de la **PR** elle-même. C'est un vrai défaut (`prev-not-pr`), que les deux versions du garde rejettent, et je l'ai corrigé en `#15207` sur les deux surfaces (corps **et** message de commit — le garde lit les deux, réparer l'un seul laisse `commits[0]` rouge).

Or **#15207 est OPEN**. Cette PR est donc, sans l'avoir cherché, une instance du défaut qu'elle répare — et le contrôle positif vit dans l'artefact plutôt que dans un fixture :

| garde exécuté sur le corps et les commits réels de **#15211** | verdict |
|---|---|
| `origin/main` (ancien) | `guard_pass: false` — `prev-not-merged → [15207]`, sur `body` **et** `commits[0]`, `rc=1` |
| cette PR (nouveau) | `guard_pass: true` — `no prev: defect`, `rc=0` |

**La dépendance à nommer** : `always-on-guards.yml` se déclenche sur `pull_request` et fait un `actions/checkout` sans `ref:`, donc il extrait `refs/pull/N/merge` — le garde qui juge cette PR est celui de cette PR. Si le workflow lisait la version de la base, cette PR serait rouge sur son propre sujet et il faudrait pointer `prev:` vers une PR mergée pour l'ouvrir. Ce n'est pas une remarque théorique : c'est la condition qui rend le tableau ci-dessus vrai, et elle se lit dans le workflow, pas dans mon intention.

## Ce que la PR change

- `state` remonte jusqu'à `validate_prev_targets`, qui ne rougit plus que sur `CLOSED`.
- `merged` **reste émis** par le résolveur pour les lecteurs du JSON, mais **n'est plus le prédicat**.
- `prev-not-merged` → **`prev-abandoned`**. Le renommage est sûr : `git grep` sur `scripts/`, `.github/`, `docs/`, `.claude/` ne trouve **aucun consommateur** qui lise ce nom de kind — les seules références sont au chemin du module.
- **Deux abstentions délibérées, écrites** : cible non résolue (contrat FN-safety **inchangé**) ; et meta de kind `pr` **sans `state`** (fichier `--prev-targets-file` écrit à la main ou d'avant ce champ) — on ne peut pas deviner `OPEN` vs `CLOSED`, donc on s'abstient.

**Aucun workflow ne change.** `always-on-guards.yml` (l.704) passe déjà `--current-pr --resolve-targets` ; `variation-tag-guard.yml` (l.606) n'en passe aucun des deux et ne couvre donc que l'invariant close-keyword — hors périmètre.

## Tests — 40 → 49, et le point délicat

Le point délicat n'est pas d'ajouter des tests, c'est que **quatre tests de masquage utilisaient une cible OPEN comme mécanisme de blocage** pour prouver que le masquage marchait. Sous le nouveau prédicat, ils passeraient **sans avoir rien prouvé** — vert sur un masque totalement cassé.

Leurs fixtures passent donc en `CLOSED`, ce qui leur rend leurs dents :

1. `test_backticked_prev_is_a_citation_not_a_declaration`
2. `test_multiline_backticked_citation_in_commit_passes_full_guard`
3. `test_prose_citation_after_tag_line_still_evaluates_tag`
4. `test_fully_backticked_tag_is_still_evaluated` — dont le commentaire dit lui-même « retirez cette union et ce test devient vert dans la mauvaise direction »

**Le quatrième ne figurait pas au plan de patch.** Il a été trouvé en relisant la région plutôt qu'en faisant confiance au plan, et c'est la seule raison pour laquelle il n'est pas devenu vert en silence. Je le dis parce que le mode de défaillance visé ici est précisément celui-là : un test qui cesse de mesurer ne se plaint pas.

S'y ajoute un cinquième déplacement, de rôle différent : `test_plain_prev_at_an_open_pr_still_fails`, renommé `…_at_an_abandoned_pr_…`. Ce n'est pas un test de masquage mais son **contrôle négatif** — la même clause écrite en clair, sur la même cible, doit rester rouge, faute de quoi le vert du test de citation ne prouve rien.

`test_14515_real_body_with_resolved_open_target_fails` avait sa **prémisse inversée** par la réparation (« OPEN doit rougir »). Il est réécrit en `test_resolved_bad_target_fails_the_abstention_flag_is_not_the_predicate` sur une cible `CLOSED` : il continue de mesurer le **fail-open** de #14550, et non la réparation.

Neuf tests nets en plus, dont deux contrôles neufs :

- `test_resolve_prev_targets_closed_pr_is_distinguishable_from_an_open_one` — même `kind`, même `merged`, **seul `state` diffère**. C'est la réparation, écrite comme une assertion.
- `test_resolver_always_emits_state_for_every_pr_kind_it_returns` — garde l'abstention « legacy sans `state` » à l'état de **cas limite**. Si le vrai résolveur cessait d'émettre `state`, ce chemin éteindrait l'invariant 2 sur toute la flotte **et tous les autres tests resteraient verts**. Celui-ci rougirait.

### Contrôle de mutation, des deux côtés

Un garde qui ne rougit jamais et un garde qui rougit toujours rendent le même service :

| mutation appliquée au prédicat | résultat |
|---|---|
| trop permissif (`CLOSED` ne bloque plus) | **7 rouges** |
| régression vers l'ancien (`!= MERGED` rebloque `OPEN`) | **3 rouges** |
| aucune | 49 verts |

`scripts/tests/test_variation_prev_guard.py` : **49 passés**. Avec `test_variation_adjacency_guard.py` (l'organe frère, doctrine désormais commune) : **107 passés**.

### Suite complète — et les rouges qu'elle porte déjà

`pytest scripts/tests/ --ignore-glob='**/test_sudoku*'` : **4529 passés, 10 échoués, 15 skipped, 5 xfailed** (7 min 14).

Les dix échecs sont **antérieurs et hors d'atteinte de ce diff**, qui ne touche que `scripts/ci/variation_prev_guard.py` et son fichier de tests — aucun des deux n'est importé par les modules rouges :

- `scripts/tests/ml/test_garch_baseline.py` (9) — dépendance ML absente de cet environnement ;
- `scripts/tests/test_render_oversized_nbconvert.py::test_render_one_fail_non_notebook` (1) — ``Jupyter command `jupyter-nbconvert` not found``.

Je les note plutôt que de ne rapporter que le vert des deux fichiers concernés : une suite à 10 rouges annoncée « tout passe » est ce qui rend le prochain rouge illisible. Les modules `test_sudoku*` sont exclus de la commande pour la même raison — ils échouent à la **collecte** sur `No module named 'torch'`, également sans rapport.

See #13475
