### PR TITLE
fix(vibe-coding,#13410): 01-Claude-CLI-Bases -- aligner 2 Lectures sur les outputs reels

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -370,13 +370,17 @@
     "tags": []
    },
    "source": [
-    "**Lecture.** Sortie **non-nominale** : `Erreur de connexion: inconnue`. Le helper rend\n",
-    "un statut structure au lieu de lever une exception — et c'est la decision de conception importante :\n",
-    "un **statut** se teste (`if status.get(...)`), s'affiche et se journalise, alors qu'une exception\n",
-    "interrompt le notebook. Pour un outil en ligne de commande appele depuis du code, distinguer\n",
-    "« l'outil a repondu » de « l'outil a repondu OK » est la frontiere entre un script qui casse et un\n",
-    "script qui **rapporte**. Retenez le triplet retourne (sortie, erreur, code de retour) : il revient\n",
-    "dans toutes les cellules suivantes."
+    "**Lecture.** Sortie **nominale** : `Connexion OK` / `Modele actif: detected` — la session est\n",
+    "authentifiee et l'appel de sonde a reussi. Le helper rend un statut structure au lieu de lever\n",
+    "une exception — et c'est la decision de conception importante : un **statut** se teste\n",
+    "(`if status.get(...)`), s'affiche et se journalise, alors qu'une exception interrompt le notebook.\n",
+    "La branche `else` de la cellule ne serait empruntee qu'en cas d'echec (session expiree, proxy) :\n",
+    "elle afficherait alors `Erreur de connexion: <cause>` — ce helper renseigne toujours la cle\n",
+    "`error` quand `connected` est faux, le fallback `inconnue` du `get` restant donc theorique. Pour\n",
+    "un outil en ligne de commande appele depuis du code, distinguer « l'outil a repondu » de « l'outil\n",
+    "a repondu OK » est la frontiere entre un script qui casse et un script qui **rapporte**. Retenez\n",
+    "le triplet retourne (sortie, erreur, code de retour) : il revient dans toutes les cellules\n",
+    "suivantes."
    ]
   },
   {
@@ -521,7 +525,7 @@
     "tags": []
    },
    "source": [
-    "**Lecture.** Réponse obtenue : « Python est un langage interprété, multiparadigme (impératif, orienté objet, fonctionnel)… ». La **forme** est intéressante : la réponse commence directement par la définition, sans formule de politesse, et déroule sur **deux phrases** comme demandé. C'est la marque d'un prompt bien calibré -- `claude -p \"...\"` traite la requête comme un **one-shot** et ne s'autorise pas le bavardage qu'une session interactive autoriserait.\n",
+    "**Lecture.** Réponse obtenue : « Python est un langage de programmation interprété, de haut niveau et à la syntaxe lisible… ». La **forme** est intéressante : la réponse commence directement par la définition, sans formule de politesse, et déroule sur **deux phrases** comme demandé. C'est la marque d'un prompt bien calibré -- `claude -p \"...\"` traite la requête comme un **one-shot** et ne s'autorise pas le bavardage qu'une session interactive autoriserait.\n",
     "\n",
     "**Métadonnée visible :** `print_response` masque la sortie brute par défaut, mais on peut inspecter `duration_api_ms` ou `total_cost_usd` en JSON (cf. cellule format JSON). Pour ce notebook, on reste en prose -- la sortie est plus pédagogique."
    ]


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/research-code #15124

See #15035 — audit discovery. Cible : `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb` (seul fichier touche).

Discovered and verified by corrective-auditor: CONFIRMED pedagogy (interpretation cells contradicting stored real-CLI outputs)

## What

Deux cellules markdown d'interpretation contredisaient les **outputs reels commites** du notebook. Corrigees par alignement markdown-only : aucune cellule code modifiee, outputs et `execution_count` intacts (exemption markdown C.3).

| # | Cellule | Defaut (verifie firsthand) | Fix |
|---|---------|---------------------------|-----|
| 1 | Lecture apres `check_claude_status()` (id `9d3b4d7d`, cellule 11) | Annoncait « Sortie **non-nominale** : `Erreur de connexion: inconnue` » alors que l'output stocke — et reverifie en direct — est `Connexion OK` / `Modele actif: detected` | Decrit la sortie nominale reelle ; documente honnetement la branche `else` (elle n'affiche `inconnue` que si la cle `error` manquait — or le helper la renseigne toujours quand `connected` est faux) |

**Provenance du defaut n°1 (verifiee) :** l'issue #11696 avait releve dans CE notebook une sortie d'echec reelle commitee (`Erreur de connexion: [WinError 2] ...`, binaire absent) ; la reparation qui a suivi a regenere les outputs en nominal, mais la prose « Lecture » decrivant le cas d'echec est restee telle quelle. Ce fix complete cette reparation.
| 2 | Lecture apres la question Python (id `5fc10d0d`, cellule 16) | Citait « Python est un langage interprete, multiparadigme (imperatif, oriente objet, fonctionnel)… » — reponse absente de l'output stocke | Citation alignee sur l'output reel : « Python est un langage de programmation interprete, de haut niveau et a la syntaxe lisible… » (les observations exactes — deux phrases, one-shot, pas de politesse — sont conservees) |

## Proof of execution (vraie CLI, pas SIMULATION_MODE)

- `claude --version` → `2.1.7 (Claude Code)` (verifie ce cycle ; binaire sur PATH).
- Probe direct, cwd = `notebooks/`, `SIMULATION_MODE = False` : `verify_installation() → True` ; `check_claude_status() → {'connected': True, 'model': 'detected', 'base_url': 'detected'}` — la sortie nominale de la cellule statut est **reproduite en direct** ; c'est le ground truth du fix n°1.
- Aucune re-execution du notebook : le diff est markdown-only (`git diff` : 2 blocs `source` markdown, 12 insertions / 8 deletions, rien d'autre). Outputs et `execution_count` byte-intacts.

## Verdicts

- **SOTA : SOTA-OK.** Le notebook invoque la vraie CLI `claude` (helper `run_claude` → subprocess sur le binaire resolu, prompt par stdin) avec `SIMULATION_MODE = False` ; auth et routage verifies en direct. Aucune sortie degradee commitee (ASCII art, stub de service, sortie fabriquee : aucun).
- **Drift (lecture C.4) : cause (e) stochasticite de run + prose stale ; verdict CAUSE_FIXED par alignement markdown.** Les deux Lectures decrivaient des reponses d'une execution anterieure tout en les presentant comme la lecture de l'output affiche. Les valeurs re-alignees sont des **citations de prose**, pas des nombres de perf/timing/cout — l'alignement markdown est donc legitime sans re-execution (les outputs eux-memes ne bougent pas).

## Validators (relances post-fix)

`check_c2_compliance.py --path` 1/1 OK · `check_null_exec.py` OK · `audit_c1_c3.py --family GenAI` 0 violation (217 notebooks) · `check_papermill_ratchet.py origin/main` 0 changed / 0 regression · `check_exec_sequence.py` fully executed CLEAN 1..N · `detect_degraded_mode.py` 0 finding · `detect_stub_truth_returns.py` 0 fautif · grep C.1 (`raise NotImplementedError` / `assert False` / `1/0`) : aucun ; secrets / machine paths : aucun.

## Finding table (axes de l'audit)

| Axe | Candidat | Verdict | Action |
|---|---|---|---|
| 1 | Numerotation exercices : headers md « Exercice 1..6 » (cellules 33/35/37/39/41/43) vs commentaires de code « 1, 6, 2, 5, 3, 4 » (cellules 34/36/38/40/42/44) — seul le couple header 1 / comment 1 coincide | **CONFIRMED (non patche)** | Voir « Issue-ready » |
| 1 | Cellule d'intro (32) : « exercices 1 et 2 ... appeler run_claude() » vs « exercices 3 et 4 ... fonctions (compare_models, extract_json_field, ask_about_topic) » — 3 fonctions pour 2 numeros ; en realite fonctions en 2/4/6 et appels en 1/3/5 | **CONFIRMED (non patche, meme cluster)** | idem |
| 2 | Stubs `None` (« Comparaison : None », « Cout : None$ », « Reponse : None », « Prompt genere : None ») | **FALSE POSITIVE** — conforme C.1 (`return None  # TODO etudiant`), presentation honnete encadree (« retourne None tant que le stub n'est pas complete ») | rien |
| 3 | Version stockee `2.1.141` vs courante `2.1.7` | **Snapshot legitime** — sortie d'un appel live `get_claude_version()` ; l'interpretation (cellule 9) cadre explicitement la dependance a la version | rien |
| 3 | Lectures contredisant les outputs stockes (2 cas ci-dessus) | **CONFIRMED pedagogy** | **patche (cette PR)** |
| 4 | Contrat import/cwd : `sys.path.insert(0, 'helpers')` | **PASS** — reverifie : import OK depuis cwd `notebooks/` (helpers/ y est un sibling, le README de la serie documente ce repertoire) | rien |
| 5 | Docstrings des stubs decrivant un contrat complet sur un corps `None` | **FALSE POSITIVE** — TODO etudiants intentionnels (TODO / Indice / Etape presents), C.1 conforme | rien |
| 6 | Mode simulation / auth indisponible | **PASS** — le code porte `SIMULATION_MODE = False` (la mention `= True` n'existe qu'en prose documentaire de la cellule d'intro) ; auth reelle verifiee en direct | rien |

## Issue-ready (non patche — hors envelope « coherent local » de cette PR)

Suivi dédié : **#15219**.

**Cluster de numerotation des exercices.** Renommer les commentaires de stubs (`# Exercice 6` → `# Exercice 2`, `# EXERCICE 2` → `# EXERCICE 3`, `# Exercice 5` → `# Exercice 4`, `# EXERCICE 3` → `# Exercice 5`, `# Exercice 4` → `# Exercice 6`) modifie la source de cellules code → **re-execution complete obligatoire**, laquelle regenererait les 8 sorties LLM nondeterministes + la version : churn incompatible avec un fix cosmetique dans la meme PR (conflit de sujet). Recommandation : PR dediee « renumerotation + re-exec canonique », ou decision mainteneur de suivre le precedent rename-only de `66fec0a7e` pour la couche commentaires.

**Provenance du cluster (verifiee, chaine complete) :** l'issue **#2642** documentait pour ce notebook exactement `seq [1,6,2,5,3,4]` et prescrivait « renumeroter en ordre de lecture » ; le commit **`66fec0a7e`** (Closes #2642, « rename-only, preserves outputs ») n'a renumerote que la **couche markdown headers** (`### Exercice 6 : Comparer` → `### Exercice 1`, etc.) — la couche **commentaires de code** `[1,6,2,5,3,4]` n'a jamais ete reconcilee. **`#14669`** a renumerote les enonces md une seconde fois (1..6) sans toucher les stubs non plus. Aujourd'hui : headers 1..6 vs commentaires 1,6,2,5,3,4 en ordre de lecture — seul le couple header 1 / comment 1 coincide. La cellule d'intro (32) va avec le cluster : l'intro dit « exercices 3 et 4 → fonctions (compare_models, extract_json_field, ask_about_topic) » alors que les fonctions vivent en 2/4/6 et les appels en 1/3/5 (3 noms de fonctions pour 2 numeros cites).

## Boundary confirmation

- Seul fichier modifie : le notebook cible (commit `0b9b0eba2`, 1 file, 12+/8-). `helpers/claude_cli.py`, `examples/`, README, catalogue, translations : non touches.
- Aucun claim/comment ajoute sur l'issue (claim combine du coordinateur sur #15035).
- Pas de merge / close / review / HOLD / override.

