### PR TITLE
fix(genai): medical_chatbot interp prose realigned to code and stored outputs (Astra #15035)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -269,11 +269,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du résultat : variables d'environnement chargées\n",
-    "\n",
-    "`load_dotenv()` retourne `True` quand un fichier `.env` est trouvé et parsé. C'est le **premier signal** que la configuration LLM est en place : `OPENAI_API_KEY` (modèle GPT-4), `AZURE_OPENAI_ENDPOINT` (déploiement Azure AI Foundry), ou un endpoint local ComfyUI/Qwen selon la cohorte. Si l'étudiant voit `False`, le notebook échouera plus loin lors de l'instanciation du kernel (`Kernel()` sans service LLM = crash silencieux)."
-   ]
+   "source": "### Lecture du résultat : variables d'environnement chargées\n\n`load_dotenv()` retourne `True` quand un fichier `.env` est trouvé et parsé. Pour ce notebook, une seule variable compte : `OPENAI_API_KEY` — la clé du modèle `gpt-4o-mini` que `create_kernel()` (ci-dessous) passe à `OpenAIChatCompletion`. C'est la seule que le code lit : aucun backend Azure ni ComfyUI/Qwen n'est branché ici. Un `False` — comme sur la sortie ci-dessus — signifie seulement qu'aucun fichier `.env` n'a été trouvé : l'exécution enregistrée a tourné avec la clé exportée dans l'environnement du process (d'où les 7 appels API réussis en fin de notebook). Le notebook échoue plus loin uniquement si `OPENAI_API_KEY` est absente à la fois du `.env` et de l'environnement (`Kernel()` sans service LLM = crash silencieux)."
   },
   {
    "cell_type": "markdown",
@@ -347,11 +343,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du résultat : logging structuré pour traçabilité multi-agent\n",
-    "\n",
-    "`\"Configuration des logs OK\"` valide le format `%(asctime)s [%(levelname)s] %(name)s: %(message)s` avec niveau `INFO`. C'est ce format que la cellule d'exécution de la consultation (en fin de notebook) affichera en sortie (horodatage + `[INFO] Début de la consultation médicale IA` au lancement de la consultation). Le logging **structuré** n'est pas un caprice pédagogique : sans lui, l'étudiant ne peut pas distinguer **qui parle** dans un chat à 3 agents — médecin, IA médicale ou pharmacien. Le préfixe `🚀` est un signal visuel (emoji utilisé comme tag sémantique) qui délimite les phases de l'orchestration : début de consultation, fin de tour, terminaison. L'étudiant doit noter l'horodatage (la date varie à chaque exécution) et l'ordre des événements : c'est cette trace qui valide ex-post la séquence orchestrale."
-   ]
+   "source": "### Lecture du résultat : logging structuré pour traçabilité multi-agent\n\n`\"Configuration des logs OK\"` valide le format `%(asctime)s [%(levelname)s] %(message)s` avec niveau `INFO`. C'est ce format que la cellule d'exécution de la consultation (en fin de notebook) affichera en sortie (horodatage + `[INFO] Début de la consultation médicale IA` au lancement de la consultation). Le logging **structuré** n'est pas un caprice pédagogique : sans lui, l'étudiant ne peut pas distinguer **qui parle** dans un chat à 3 agents — médecin, IA médicale ou pharmacien. La distinction ne vient pas du format (qui n'affiche ni le nom du logger ni l'émetteur) mais des appels de log explicites dans `run_medical_chat()` : `logger.info(f\"[{message.role}] {message.name}: {message.content}\")` identifie l'émetteur de chaque message, tour par tour. L'étudiant doit noter l'horodatage (la date varie à chaque exécution) et l'ordre des événements : c'est cette trace qui valide ex-post la séquence orchestrale."
   },
   {
    "cell_type": "markdown",
@@ -1421,11 +1413,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du résultat : squelette multi-agent complet, prêt pour l'exécution\n",
-    "\n",
-    "À ce stade du notebook, **toute la machinerie multi-agent est en place** : kernel partagé (1), 3+ plugins médicaux (médecin/IA/pharmacien/allergies), 3 agents conversationnels avec leurs prompts respectifs, 1 stratégie de terminaison médicale, 1 groupe de chat orchestré, 1 fonction `run_medical_chat()` async. Ce qui sépare ce notebook d'un squelette mort, c'est la cellule d'exécution (try/except `await run_medical_chat()`, ci-dessous) : l'appel asynchrone déclenche réellement l'orchestration et l'étudiant voit la conversation se dérouler tour par tour. **Pattern clé** : la complexité d'un système multi-agent est *cachée* dans le setup (tout ce qui précède) et *visible* dans l'exécution (les dernières cellules). L'étudiant doit comprendre ce distinguo pour scripter ses propres use cases."
-   ]
+   "source": "### Lecture du résultat : squelette multi-agent complet, prêt pour l'exécution\n\nÀ ce stade du notebook, **toute la machinerie multi-agent est en place** : kernel partagé (1), 3 plugins médicaux enregistrés (médecin/IA/pharmacien — le squelette `AllergyPlugin` de l'exercice 1, lui, n'est pas enregistré et reste à compléter), 3 agents conversationnels avec leurs prompts respectifs, 1 stratégie de terminaison médicale, 1 groupe de chat orchestré, 1 fonction `run_medical_chat()` async. Ce qui sépare ce notebook d'un squelette mort, c'est la cellule d'exécution (try/except `await run_medical_chat()`, ci-dessous) : l'appel asynchrone déclenche réellement l'orchestration et l'étudiant voit la conversation se dérouler tour par tour. **Pattern clé** : la complexité d'un système multi-agent est *cachée* dans le setup (tout ce qui précède) et *visible* dans l'exécution (les dernières cellules). L'étudiant doit comprendre ce distinguo pour scripter ses propres use cases."
   },
   {
    "cell_type": "markdown",
@@ -1547,11 +1535,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du résultat : fonction de chat médical prête\n",
-    "\n",
-    "`\"Fonction de chat médical prête\"` marque l'aboutissement du squelette : la fonction async `run_medical_chat()` peut être appelée pour démarrer la consultation simulée. Le `logger.info(\"🚀 Début de la consultation médicale IA\")` qui suit est le **premier signal d'exécution** quand l'étudiant lance la cellule d'exécution de la consultation (ci-dessous). À ce stade, le notebook a instancié **3 agents**, **1 kernel partagé**, **3+ plugins**, **1 stratégie de terminaison**, **1 groupe de chat** — toute la machinerie multi-agent est en place. La cellule d'exécution lance `await run_medical_chat()` qui bouclera jusqu'à ce que `MedicalTerminationStrategy.should_terminate()` retourne `True` (limite de 6 messages dans l'historique du groupe)."
-   ]
+   "source": "### Lecture du résultat : fonction de chat médical prête\n\n`\"Fonction de chat médical prête\"` marque l'aboutissement du squelette : la fonction async `run_medical_chat()` peut être appelée pour démarrer la consultation simulée. Le `logger.info(\"Début de la consultation médicale IA\")` qui ouvre `run_medical_chat()` est le **premier signal d'exécution** quand l'étudiant lance la cellule d'exécution de la consultation (ci-dessous). À ce stade, le notebook a instancié **3 agents**, **1 kernel partagé**, **3 plugins enregistrés**, **1 stratégie de terminaison**, **1 groupe de chat** — toute la machinerie multi-agent est en place. La cellule d'exécution lance `await run_medical_chat()` qui bouclera jusqu'à ce que `MedicalTerminationStrategy.should_terminate()` retourne `True` (limite de 6 messages dans l'historique du groupe)."
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -269,7 +269,7 @@
     },
     "tags": []
    },
-   "source": "### Lecture du résultat : variables d'environnement chargées\n\n`load_dotenv()` retourne `True` quand un fichier `.env` est trouvé et parsé. Pour ce notebook, une seule variable compte : `OPENAI_API_KEY` — la clé du modèle `gpt-4o-mini` que `create_kernel()` (ci-dessous) passe à `OpenAIChatCompletion`. C'est la seule que le code lit : aucun backend Azure ni ComfyUI/Qwen n'est branché ici. Un `False` — comme sur la sortie ci-dessus — signifie seulement qu'aucun fichier `.env` n'a été trouvé : l'exécution enregistrée a tourné avec la clé exportée dans l'environnement du process (d'où les 7 appels API réussis en fin de notebook). Le notebook échoue plus loin uniquement si `OPENAI_API_KEY` est absente à la fois du `.env` et de l'environnement (`Kernel()` sans service LLM = crash silencieux)."
+   "source": "### Lecture du résultat : variables d'environnement chargées\n\n`load_dotenv()` retourne `True` quand un fichier `.env` est trouvé et parsé. Pour ce notebook, une seule variable compte : `OPENAI_API_KEY` — la clé du modèle `gpt-4o-mini` que `create_kernel()` (ci-dessous) passe à `OpenAIChatCompletion`. C'est la seule que le code lit : aucun backend Azure ni ComfyUI/Qwen n'est branché ici. Un `False` — comme sur la sortie ci-dessus — signifie seulement qu'aucun fichier `.env` n'a été trouvé : l'exécution enregistrée a tourné avec la clé exportée dans l'environnement du process (d'où les 7 appels API réussis en fin de notebook). Si `OPENAI_API_KEY` est absente à la fois du `.env` et de l'environnement, la configuration du service ou le premier appel LLM échoue explicitement ; le `try/except` final ne masque pas cet échec."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/research-code #15124

See #15035 (Astra corrective wave 1, DISCOVERY target Medical-Chatbot — path-scoped claim held by the coordinator).

## Résumé

Correctif d'honnêteté prose/code sur `medical_chatbot.ipynb` : quatre cellules d'interprétation affirmaient des détails qui n'existent ni dans le code exécutable ni dans les sorties enregistrées. Réécrites pour décrire ce que le notebook fait réellement. Diff **markdown-only** (4 cellules), code et sorties inchangés (exception markdown de C.2).

## Findings corrigés (chacun falsifié contre le code et les sorties avant patch)

| Cellule | Avant (fabriqué) | Réel (code + sorties commités) |
|---|---|---|
| `43b69f3c` (c9) | backends `AZURE_OPENAI_ENDPOINT` (Azure AI Foundry) ou « endpoint local ComfyUI/Qwen selon la cohorte », « modèle GPT-4 » | `create_kernel()` (c14) lit uniquement `OPENAI_API_KEY` pour `gpt-4o-mini` via `OpenAIChatCompletion` — zéro code Azure/ComfyUI/Qwen (grep 0 hit sur les cellules code ; seul notebook CaseStudies à annoncer ces backends). En outre, la sortie commitée de `load_dotenv()` (c8) est `False` alors que la consultation a tourné : la prose « si vous voyez False, le notebook échouera » était contredite par la sortie elle-même. Le commit `32dddcd25` retire aussi le reliquat « crash silencieux » : l'absence de clé provoque un échec explicite que le `try/except` final ne masque pas |
| `fcebb55c` (c12) | format `%(asctime)s [%(levelname)s] %(name)s: %(message)s`, et préfixe 🚀 « qui délimite les phases de l'orchestration » | c11 : `format='%(asctime)s [%(levelname)s] %(message)s'` — **pas** de `%(name)s` ; aucun 🚀 dans aucun code ni aucune sortie. L'identification de l'émetteur vient du `logger.info(f"[{message.role}] {message.name}: {message.content}")` de `run_medical_chat()` (c54) |
| `8ba2019f` (c51) | « 3+ plugins médicaux (médecin/IA/pharmacien/allergies) » comptés dans la « machinerie en place » | 3 seuls `add_plugin` (c29 : doctor, medical, pharmacist) ; `AllergyPlugin` (exercice 1) n'est **jamais enregistré** et retourne `None` (stub TODO) |
| `a4b715be` (c55) | citation `logger.info("🚀 Début de la consultation médicale IA")` + « 3+ plugins » | c54 : `logger.info("Début de la consultation médicale IA")` — pas d'emoji ; 3 plugins enregistrés |

## Attestation

Discovered and verified by corrective-auditor: CONFIRMED prose-fabrication — chaque candidat a été falsifié contre le code exécutable et les sorties enregistrées avant patch ; les axes audités non confirmés sont explicitement écartés ci-dessous.

### Candidats écartés (falsifiés, pas de patch)

- **« Diagnostic complet » revendiqué** : la prose le disclose honnêtement — c2 (« la détection d'un diagnostic final par mot-clé étant laissée en exercice ») et c57 (« La détection d'un diagnostic final par mot-clé n'a pas eu lieu »). L'exécution batch (patient fixe, sans réponse) atteint la limite de 6 messages sans diagnostic, et c57 le dit. Pas d'overclaim.
- **Chiffres de c57** : « 7 appels gpt-4o-mini », « 5 tours d'agents », round-robin 0/1/2, « 2 plugins en parallèle » au premier tour médecin — vérifiés contre les événements explicites des 52 sorties stream de c56, puis reproduits par la re-exécution fraîche. Le comptage des 7 appels repose sur les sept événements HTTP distincts, pas sur une simple regex de mots-clés ; cela lève la réserve mineure de la review NanoClaw.
- **Exercices étudiants** : les 3 exercices (c22-23, c33-34, c45-46) sont de vrais stubs `# TODO etudiant` / `result = None` / `print("Exercice a completer")`, honnêtement étiquetés (C.1 conforme).

## Exécution (preuve)

- Re-exécution réelle post-fix hors repo (route maison `scripts/notebook_tools/notebook_tools.py execute --batch-mode`), `OPENAI_API_KEY` chargée depuis le store gitignored sans exposition (jamais affichée, jamais en ligne de commande) : **SUCCESS en 22,1 s**.
- 19/19 cellules code exécutées, **0 erreur**, 0 `raise NotImplementedError` (C.1).
- Sorties fraîches : 7 appels `gpt-4o-mini` (comptés dans les logs HTTP), séquence Docteur_Humain → IA_Medicale → Pharmacien → Docteur_Humain → IA_Medicale, `Consultation terminée.` — cohérent avec la prose commitée c57.
- Logs frais : **aucun** `%(name)s`, **aucun** 🚀 — falsification firsthand des claims supprimés.
- Zéro leak : pas de préfixe `sk-`, pas d'écho de `OPENAI_API_KEY`, pas de chemin machine.
- Sorties commitées inchangées (diff markdown-only, exception C.2) ; la re-exéc scratchpad est une preuve d'audit, non committée (C.3).

## SOTA verdict

**SOTA-OK** — vrai service OpenAI (`api.openai.com`, 7 appels HTTP 200), vraie orchestration multi-agent Semantic Kernel 1.43.0, sorties réelles ; rien de simulé.

## Diagnostic dérive

Cause **(b) claim antérieure fabriquée** : la passe de densité #11580 (« 15 interps ancrées sur outputs ») a rédigé des interps citant des détails inexistants (placeholder `%(name)s`, emoji 🚀, backends Azure/ComfyUI/Qwen, 4e plugin « en place »). Verdict : **CAUSE_FIXED** — prose réalignée sur le code et les sorties réels ; aucune valeur numérique ré-alignée à la main, aucune sortie hand-éditée (Stop & Repair respecté : la cause était dans la prose, pas dans les sorties).

## Non corrigé (reporté, hors diff markdown sûr)

Suivi dédié : **#15218**.

- c15/c20 : interps ancrées après la mauvaise cellule (c20 cite les sorties « Kernel instancie » / « Kernel configuré » de c25/c29 alors qu'elle suit c19). Correction structurelle = déplacement de cellules → risque de désynchronisation du jumeau EN apparié par index (translations CSV) → non touché ici.
- c14 : le print « Kernel Semantic Kernel créé » s'exécite alors que la cellule ne fait que **définir** la factory (l'instanciation est en c25) — fix code + re-exec, volontairement hors de ce diff markdown-only.

#15218 porte la déduplication, les preuves par id/index, la ré-exécution française requise et la resynchronisation automatisée du jumeau anglais.

## Périmètre

- Fichier unique : `MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb` (claim path-scoped #15035 respecté).
- Jumeau `medical_chatbot_en.ipynb` **non touché** (bot-owned, `translation-guard.yml`) ; la resync post-merge (`translation-sync.yml`) propagera la traduction.
- Catalogue, translations, README, helpers, twin registries : non touchés.

