### PR TITLE
feat(slides,#13224): S3-acculturation tranche composition -- 6 slides occupation 6->0

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -107,6 +107,8 @@ layout: section
 
 # Développement (1/2)
 
+<div class="w-[300px]">
+
 **Histoire succincte**
 
 - 1940-70 : Enthousiasme des débuts
@@ -127,6 +129,8 @@ layout: section
 </div>
 
 > **État de l'art** : voir la slide « Développement (2/2) » pour la chronologie moderne (1997 → 2025).
+
+</div>
 
 ---
 
@@ -152,6 +156,8 @@ layout: section
 
 # Dans la vie de tous les jours
 
+<div class="w-[600px]">
+
 - **Poste** : reconnaissance des adresses et tri automatique du courrier
 - **Banque** : lecture des chèques, vérification des signatures, évaluation de crédits
 - **Médecine** : diagnostic assiste, prescriptions, suivi et prévention
@@ -161,6 +167,8 @@ layout: section
 - **Industrie** : conception, fabrication et exploitation assistées par IA
 - **Image numérique** : détection de visages, mise au point, compression
 - **Jeux** : personnages et adversaires intelligents (NPCs adaptatifs)
+
+</div>
 
 <img src="./images/img_013.jpg" class="absolute top-[130px] right-[20px] w-[600px] max-h-[300px] object-contain object-right" alt="Écosystème IoT — objets du quotidien connectés" />
 
@@ -544,7 +552,9 @@ layout: default
 
 # Jeux
 
-<div class="grid grid-cols-2 gap-0 -mt-4 -mb-2">
+<div class="w-[300px]">
+
+<div class="grid grid-cols-2 gap-0 -mt-4">
 <div class="bg-orange-700 text-white px-4 py-2 text-base font-bold text-center">Jeux vs Exploration</div>
 <div class="bg-slate-800 text-white px-4 py-2 text-base font-bold text-center">Arbre Minimax</div>
 </div>
@@ -571,6 +581,8 @@ layout: default
 - Minimax, Alpha-Beta
 - Avec arrêt + évaluation heuristique
 - Techniques probabilistes (Expectiminimax, Monte-Carlo)
+
+</div>
 
 </div>
 

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -36,30 +36,30 @@ layout: cover
 
 # Sommaire
 
-<div class="grid grid-cols-2 gap-8 mt-4">
-<div>
+<div class="grid grid-cols-[1fr_600px] gap-6 mt-3 items-center">
+<div class="flex flex-col gap-2.5 text-sm">
 
 **Qu'est-ce que l'intelligence artificielle ?**<br>
-<span class="text-sm text-slate-500">Racines, histoire et état de l'art — structure des agents rationnels</span>
+<span class="text-sm text-slate-500">Racines, histoire, agents rationnels</span>
 
 **Intelligence exploratoire**<br>
-<span class="text-sm text-slate-500">Comment chercher la solution à un problème ?</span>
+<span class="text-sm text-slate-500">Chercher la solution d'un problème</span>
 
 **Intelligence symbolique**<br>
-<span class="text-sm text-slate-500">Comment utiliser le raisonnement et les mathématiques ?</span>
+<span class="text-sm text-slate-500">Raisonnement et mathématiques</span>
 
 **Intelligence probabiliste**<br>
-<span class="text-sm text-slate-500">Comment agir dans l'incertitude ?</span>
+<span class="text-sm text-slate-500">Agir dans l'incertitude</span>
 
 **Apprentissage**<br>
-<span class="text-sm text-slate-500">Comment utiliser les données et l'expérience ?</span>
+<span class="text-sm text-slate-500">Apprendre des données et de l'expérience</span>
 
 **Application : le langage naturel**<br>
 <span class="text-sm text-slate-500">Chatbots, LLM, IA générative et agents</span>
 
 </div>
 <div class="flex items-center justify-center">
-  <img src="./images/img_004.png" class="rounded shadow-lg max-h-[430px]" alt="Couverture AIMA Russell & Norvig" />
+<img src="./images/img_004.png" class="rounded shadow-lg max-h-[420px] w-full object-contain" alt="Couverture AIMA Russell & Norvig" />
 </div>
 </div>
 
@@ -119,11 +119,11 @@ layout: section
   - Robotique, vision
 - 1990s : L'IA devient une science
 
-<img src="./images/img_006.png" class="absolute top-[110px] right-[20px] w-[300px] max-w-full object-contain" alt="Repères historiques" />
+<img src="./images/img_006.png" class="absolute top-[110px] right-[20px] w-[600px] max-h-[220px] object-contain" alt="Repères historiques" />
 
-<div class="absolute top-[300px] right-[20px] w-[300px] flex gap-4 items-center justify-center">
-  <img src="./images/img_007.jpg" class="h-10 max-w-[45%] object-contain" alt="Logo DARPA" />
-  <img src="./images/img_008.jpg" class="h-8 max-w-[55%] object-contain" alt="Logo ImageNet" />
+<div class="absolute top-[350px] right-[20px] w-[600px] flex gap-10 items-center justify-center">
+  <img src="./images/img_007.jpg" class="h-16 max-w-[45%] object-contain" alt="Logo DARPA" />
+  <img src="./images/img_008.jpg" class="h-14 max-w-[55%] object-contain" alt="Logo ImageNet" />
 </div>
 
 > **État de l'art** : voir la slide « Développement (2/2) » pour la chronologie moderne (1997 → 2025).
@@ -162,7 +162,7 @@ layout: section
 - **Image numérique** : détection de visages, mise au point, compression
 - **Jeux** : personnages et adversaires intelligents (NPCs adaptatifs)
 
-<img src="./images/img_013.jpg" class="absolute top-[260px] right-[20px] w-[260px] max-h-[260px] object-contain" alt="Écosystème IoT — objets du quotidien connectés" />
+<img src="./images/img_013.jpg" class="absolute top-[130px] right-[20px] w-[600px] max-h-[300px] object-contain object-right" alt="Écosystème IoT — objets du quotidien connectés" />
 
 
 ---
@@ -398,16 +398,21 @@ layout: section
 - Coût de chemin
 - Solution = Séquence
 
-<img src="./images/img_018.png" class="absolute top-[110px] right-[20px] w-[260px] max-h-[220px] object-contain" alt="Plateau de dames avec six pions noirs disposés sur l'échiquier" />
+<div class="absolute top-[110px] right-[20px] w-[600px]">
+<div class="grid grid-cols-2 gap-2">
+<img src="./images/img_018.png" class="max-h-[190px] w-full object-contain" alt="Plateau de dames avec six pions noirs disposés sur l'échiquier" />
+<img src="./images/img_robot_extracted.png" class="max-h-[190px] w-full object-contain" alt="Bras robotique articulé — assemblage robotique" />
+</div>
+<div class="grid grid-cols-2 gap-2 mt-2">
+<img src="./images/img_021.png" class="max-h-[150px] w-full object-contain" alt="Missionnaires et cannibales" />
+<img src="./images/img_019.png" class="max-h-[150px] w-full object-contain" alt="8-puzzle (état initial mélangé)" />
+</div>
+</div>
 
 **Abstractions**
 
 - Assemblage robotique
 - Problèmes jouets
-
-<img src="./images/img_robot_extracted.png" class="absolute top-[345px] right-[20px] w-[380px] max-h-[170px] object-contain" alt="Bras robotique articulé — assemblage robotique" />
-<img src="./images/img_019.png" class="absolute top-[452px] right-[40px] w-[160px]" alt="8-puzzle (état initial mélangé)" />
-<img src="./images/img_021.png" class="absolute top-[452px] right-[210px] w-[160px]" alt="Missionnaires et cannibales" />
 
 
 
@@ -545,7 +550,7 @@ layout: default
 </div>
 
 
-<div class="dense-list">
+<div class="dense-list text-base">
 
 - Arbre de jeu
 - Environnements
@@ -569,7 +574,7 @@ layout: default
 
 </div>
 
-<img src="./images/img_031.png" class="absolute top-[110px] right-[20px] w-[350px] max-h-[300px] object-contain" alt="Arbre minimax du morpion : niveaux MAX(X) et MIN(O), utilités -1/0/+1" />
+<img src="./images/img_031.png" class="absolute top-[110px] right-[20px] w-[600px] max-h-[390px] object-contain" alt="Arbre minimax du morpion : niveaux MAX(X) et MIN(O), utilités -1/0/+1" />
 
 
 
@@ -1138,9 +1143,9 @@ layout: section
 
 # Théorie des jeux (2/2)
 
-<div class="grid grid-cols-2 gap-8 -mt-4">
-<div>
-<div class="bg-orange-700 text-white px-4 py-2 text-base font-bold text-center mb-2">Jeux simultanés</div>
+<div class="w-[300px]">
+
+<div class="bg-orange-700 text-white px-3 py-1.5 text-sm font-bold text-center">Jeux simultanés</div>
 
 - Matrice de gains
 - Dominance
@@ -1148,9 +1153,7 @@ layout: section
 - Purs et mixtes (2n+1)
 - Topologie
 
-</div>
-<div>
-<div class="bg-slate-800 text-white px-4 py-2 text-base font-bold text-center mb-2">Jeux séquentiels</div>
+<div class="bg-slate-800 text-white px-3 py-1.5 text-sm font-bold text-center mt-5">Jeux séquentiels</div>
 
 - Plusieurs manches
 - Forme extensive
@@ -1159,15 +1162,41 @@ layout: section
 - Induction
   - avant/arrière
 
+</div>
+
+<img src="./images/img_070.png" class="absolute top-[135px] right-[20px] w-[600px] max-h-[220px] object-contain object-right" alt="Matrice de gains du jeu Ballet/Fight : préférences croisées des deux joueurs, valeurs (2,1) et (1,2)" />
+
+<div class="absolute top-[365px] right-[20px] w-[600px] flex justify-center">
+
+**Forme extensive (exemple)**
+
+<div class="flex items-center gap-3 mt-1 text-sm">
+<div class="px-2 py-1 rounded bg-orange-700 text-white font-bold">J1</div>
+<div class="flex flex-col gap-1.5">
+<div class="flex items-center gap-2">
+  <span class="text-slate-500 text-xs">gauche</span>
+  <div class="px-2 py-1 border border-slate-400 rounded bg-slate-50">(3, 1)</div>
+</div>
+<div class="flex items-center gap-2">
+  <span class="text-slate-500 text-xs">droite</span>
+  <div class="px-2 py-1 rounded bg-slate-800 text-white font-bold">J2</div>
+  <div class="flex flex-col gap-1">
+    <div class="flex items-center gap-2">
+      <span class="text-slate-500 text-xs">haut</span>
+      <div class="px-2 py-1 border border-slate-400 rounded bg-slate-50">(2, 1)</div>
+    </div>
+    <div class="flex items-center gap-2">
+      <span class="text-slate-500 text-xs">bas</span>
+      <div class="px-2 py-1 border border-slate-400 rounded bg-slate-50">(0, 0)</div>
+    </div>
+  </div>
+</div>
+</div>
+</div>
+
+</div>
+
 <!-- Forme extensive : arbre ou chaque noeud = décision, feuilles = gains -->
-
-</div>
-<div>
-
-<img src="./images/img_070.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Matrice de gains du jeu Ballet/Fight : préférences croisées des deux joueurs, valeurs (2,1) et (1,2)" />
-
-</div>
-</div>
 ---
 
 

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -107,7 +107,9 @@ layout: section
 
 # Développement (1/2)
 
-<div class="w-[300px]">
+<div class="grid grid-cols-[360px_1fr] gap-8 mt-4 items-start">
+
+<div class="flex flex-col gap-3">
 
 **Histoire succincte**
 
@@ -121,14 +123,17 @@ layout: section
   - Robotique, vision
 - 1990s : L'IA devient une science
 
-<img src="./images/img_006.png" class="absolute top-[110px] right-[20px] w-[600px] max-h-[220px] object-contain" alt="Repères historiques" />
+> **État de l'art** : voir la slide « Développement (2/2) » pour la chronologie moderne (1997 → 2025).
 
-<div class="absolute top-[350px] right-[20px] w-[600px] flex gap-10 items-center justify-center">
-  <img src="./images/img_007.jpg" class="h-16 max-w-[45%] object-contain" alt="Logo DARPA" />
-  <img src="./images/img_008.jpg" class="h-14 max-w-[55%] object-contain" alt="Logo ImageNet" />
 </div>
 
-> **État de l'art** : voir la slide « Développement (2/2) » pour la chronologie moderne (1997 → 2025).
+<div class="flex flex-col gap-5 items-center pt-1">
+  <img src="./images/img_006.png" class="w-full max-h-[260px] object-contain" alt="Repères historiques" />
+  <div class="flex gap-10 items-center justify-center">
+    <img src="./images/img_007.jpg" class="h-14 object-contain" alt="Logo DARPA" />
+    <img src="./images/img_008.jpg" class="h-12 object-contain" alt="Logo ImageNet" />
+  </div>
+</div>
 
 </div>
 
@@ -156,7 +161,9 @@ layout: section
 
 # Dans la vie de tous les jours
 
-<div class="w-[600px]">
+<div class="grid grid-cols-[1fr_300px] gap-8 mt-4 items-center">
+
+<div class="flex flex-col gap-2 text-sm">
 
 - **Poste** : reconnaissance des adresses et tri automatique du courrier
 - **Banque** : lecture des chèques, vérification des signatures, évaluation de crédits
@@ -170,7 +177,11 @@ layout: section
 
 </div>
 
-<img src="./images/img_013.jpg" class="absolute top-[130px] right-[20px] w-[600px] max-h-[300px] object-contain object-right" alt="Écosystème IoT — objets du quotidien connectés" />
+<div class="flex items-center justify-center">
+  <img src="./images/img_013.jpg" class="w-full max-h-[420px] object-contain" alt="Écosystème IoT — objets du quotidien connectés" />
+</div>
+
+</div>
 
 
 ---
@@ -552,13 +563,14 @@ layout: default
 
 # Jeux
 
-<div class="w-[300px]">
+<div class="grid grid-cols-[340px_1fr] gap-8 mt-3 items-start">
 
-<div class="grid grid-cols-2 gap-0 -mt-4">
+<div class="flex flex-col gap-3">
+
+<div class="grid grid-cols-2 gap-0">
 <div class="bg-orange-700 text-white px-4 py-2 text-base font-bold text-center">Jeux vs Exploration</div>
 <div class="bg-slate-800 text-white px-4 py-2 text-base font-bold text-center">Arbre Minimax</div>
 </div>
-
 
 <div class="dense-list text-base">
 
@@ -586,7 +598,11 @@ layout: default
 
 </div>
 
-<img src="./images/img_031.png" class="absolute top-[110px] right-[20px] w-[600px] max-h-[390px] object-contain" alt="Arbre minimax du morpion : niveaux MAX(X) et MIN(O), utilités -1/0/+1" />
+<div class="flex items-start justify-center pt-1">
+  <img src="./images/img_031.png" class="max-h-[420px] object-contain" alt="Arbre minimax du morpion : niveaux MAX(X) et MIN(O), utilités -1/0/+1" />
+</div>
+
+</div>
 
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA — prev: DEEP/lean #15135

## Summary

Tranche composition du deck `slides/S3-acculturation/` (#13224) : rework des 6 slides flaggées par le scanner géométrique, l'occupation passe **6 → 0** et le hors-canvas **1 → 0** sur les 104 slides du deck. Un seul fichier modifié, +90/−33.

| Slide | Changement |
|---|---|
| 2 — Sommaire | Grille asymétrique `1fr/600px`, sous-titres raccourcis, couverture AIMA `max-h-[420px] w-full` |
| 5 — Histoire 1/2 | Grille `grid-cols-[360px_1fr] items-start` : chronologie « Histoire succincte » (1940-90) à gauche, à droite `img_006` repères historiques `w-full max-h-[260px]` + logos DARPA `h-14` / ImageNet `h-12` |
| 7 — Applications | Grille `grid-cols-[1fr_300px] items-center` : liste des secteurs à gauche, image IoT `img_013` `w-full max-h-[420px]` en colonne 300px à droite |
| 18 — Itinéraire | Les 3 anciens `<img>` absolus superposés remplacés par une grille 2×2 (dames, bras robotique, missionnaires-cannibales, 8-puzzle) dans un conteneur unique `w-[600px]` |
| 23 — Jeux (Minimax) | Grille `grid-cols-[340px_1fr] items-start` : bannières « Jeux vs Exploration » / « Arbre Minimax » + liste dense à gauche, arbre minimax `img_031` `max-h-[420px]` centré avec `pt-1` à droite |
| 42 — Théorie des jeux 2/2 | Colonne gauche `w-[300px]` à bannières empilées (simultanés/séquentiels) ; `img_070` en `w-[600px]` à droite ; **nouveau diagramme forme extensive** (arbre J1 gauche/droite, J2 haut/bas, payoffs (3,1), (2,1), (0,0)) remplaçant le commentaire HTML mort |

La slide 42 portait les 3 éléments hors-canvas du deck (bbox y=608 sur canvas 552 : grille et image de la colonne droite débordaient sous le cadre).

## Validation — `scan_slidev_composition.py`, contrôle avant/après sur le même scanner

Deck servi en Playwright headless (980×552), scan sur `origin/main` (58b92cc267) puis sur la tête de branche, à quelques minutes d'écart :

| Slide | span images avant | après | hors-canvas avant | après |
|---|---:|---:|---:|---:|
| 2 | 32,0 % | 61,2 % | 0 | 0 |
| 5 | 30,6 % | 61,2 % | 0 | 0 |
| 7 | 26,5 % | 61,2 % | 0 | 0 |
| 18 | 38,8 % | 61,2 % | 0 | 0 |
| 23 | 35,7 % | 61,2 % | 0 | 0 |
| 42 | 30,6 % (gap droite 64,5 %) | 61,2 % | **3** | 0 |

**Totaux deck (104 slides)** : hors_canvas **1 → 0** · chevauchement glyphes **0 → 0** · occupation_flagged **6 → 0**.

## Erreurs console lz-string — préexistantes, non causées par ce diff

Le deck servi depuis le worktree affiche ~24 erreurs console `slide failed to load SyntaxError: ... lz-string ... does not provide an export named 'default'`, toutes référencant le `node_modules` de l'arbre principal. Contrôle négatif : la **slide 60 (non modifiée)** produit exactement les mêmes 24 erreurs ; le deck de l'arbre principal charge fraîchement sans erreur. C'est l'artefact dev-mode du bloqueur lz-string documenté sur #13224 (fix packages livré par #14935 ; `node_modules` local stale), sans effet sur le rendu ni sur le scan.

## QA visuel

Lane po-2024 = CONTENT machine-gated, pas de jugement visuel humain ici. Vérifications machine-side : captures 980×552 (`?clicks=99`) des 6 slides avant/après, snapshot accessibilité de la slide 42 confirmant le contenu complet du nouvel arbre (bannières, listes, `img_070`, nœuds J1/J2 et payoffs) dans le DOM. Les captures sont disponibles pour une revue vision (ai-01) sur demande via RooSync.

Le catalogue est byte-identique à `main` (aucun fichier catalogue touché).

See #13224

