### PR TITLE
docs(rules): ai-01 chef de flotte — coordination/merges prioritaires

### DIFF
--- a/.claude/rules/coordinator-discipline.md
+++ b/.claude/rules/coordinator-discipline.md
@@ -1,6 +1,6 @@
 # Coordinator discipline — merge actively, no languishing requests
 
-S'applique au **coordinateur ai-01** (`myia-ai-01:CoursIA`), **chef de flotte** : management/coordination et merges d'abord ; la minutie est deleguee aux sous-agents ([model-delegation.md](model-delegation.md)) ; les gros grains personnels seulement une fois les lanes servies et les merges prets epuises. Les fonds historiques non urgents (ex. Aricie.Shared, #7265) sont du grignotage workers, pas du temps ai-01.
+S'applique au **coordinateur ai-01** (`myia-ai-01:CoursIA`), **chef de flotte** : management/coordination et merges d'abord ; la minutie est deleguee aux sous-agents ([model-delegation.md](model-delegation.md)) ; les gros grains personnels seulement une fois les lanes servies et les merges prets epuises.
 
 Detail complet (workflow batch merge + commandes + audit pre-merge + incidents + verbatims + mapping lanes + listes de rollout + 4-mecanismes de chaque regle) : [docs/secrets-and-coord-detail.md §2](../../docs/reference/secrets-and-coord-detail.md#2-coordinator-discipline-ai-01).
 

--- a/.claude/rules/coordinator-discipline.md
+++ b/.claude/rules/coordinator-discipline.md
@@ -1,6 +1,6 @@
 # Coordinator discipline — merge actively, no languishing requests
 
-S'applique au **coordinateur ai-01** (`myia-ai-01:CoursIA`).
+S'applique au **coordinateur ai-01** (`myia-ai-01:CoursIA`), **chef de flotte** : management/coordination et merges d'abord ; la minutie est deleguee aux sous-agents ([model-delegation.md](model-delegation.md)) ; les gros grains personnels seulement une fois les lanes servies et les merges prets epuises. Les fonds historiques non urgents (ex. Aricie.Shared, #7265) sont du grignotage workers, pas du temps ai-01.
 
 Detail complet (workflow batch merge + commandes + audit pre-merge + incidents + verbatims + mapping lanes + listes de rollout + 4-mecanismes de chaque regle) : [docs/secrets-and-coord-detail.md §2](../../docs/reference/secrets-and-coord-detail.md#2-coordinator-discipline-ai-01).
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/tooling #15203

## Summary

Persistance Git/harnais (minimale) du mandat user direct du 2026-09-08 : « coordinateur principal chef de flotte ». Une seule modification — la ligne de scope de `.claude/rules/coordinator-discipline.md` devient une definition de role :

- **management/coordination et merges d'abord** ;
- **minutie deleguee aux sous-agents** — regie par la rule existante `model-delegation.md` (modeles explicites haiku/sonnet ; mapping moteurs renvoye vers cluster-agents.md), volontairement **non dupliquee** ici ;
- **gros grains personnels seulement une fois les lanes servies et les merges prets epuises**.

## Pourquoi coordinator-discipline.md, et pas CLAUDE.md

- CLAUDE.md est conteste par deux PRs ouvertes (#15207, #15177) — collision evitee.
- La regle n'a pas de frontmatter `paths:` : auto-chargee chaque session, un pointeur CLAUDE.md serait une duplication inutile.
- #15204 path-gate 7 autres regles ; `coordinator-discipline.md` n'en fait pas partie — elle reste auto-chargee apres ce chantier, la formulation reste donc porteuse.

## Correctif post-review (meme PR)

La derniere phrase initiale (« fonds historiques non urgents ... pas du temps ai-01 ») a ete retiree : plus absolue que le mandat, qui pose une **priorite** (fond historique grignote au fil de l'eau par les workers), pas une interdiction. Aucun remplacement ajoute — la definition de role a trois clauses suffit. Body aligne dans le meme geste (exemple Aricie et reference d'epic retires, mandat garde general).

## Verifications

- **Collision fichier** : 0 PR ouverte touchant `.claude/rules/coordinator-discipline.md` (scan `files` des PRs ouvertes : #15207 = 7 autres regles + CLAUDE.md ; #15177 = pr-review-discipline + CLAUDE.md). Sweep `git log --branches --not origin/main` sur {CLAUDE.md, coordinator-discipline, model-delegation} : seul le chantier #15204 apparait, diff **nul** sur coordinator-discipline.md.
- **Lien ajoute** : `model-delegation.md`, chemin relatif meme dossier, present sur main (lecture disque).
- **Diff** : 1 fichier, 1 ligne remplacee (+1/-1), UTF-8 sans BOM.
- **Tests** : markdown de harnais — aucun test automatique cable sur `.claude/rules/` ; `check_docs_links.py` passe sans regression de lien.

## Hors scope

- Reduction globale du harnais : See #15204 (deja en vol via #15207).
- **Pas de merge ici** : toute modification de `.claude/rules/` requiert le sign-off user (CLAUDE.md section A).
