### PR TITLE
fix(search-09b): aligner la prose du zoom sur les sorties committées

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-09b-SpuriousMinima.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-09b-SpuriousMinima.ipynb
@@ -376,7 +376,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lecture du zoom.** Le point exhibé a toutes les cartes d'un vrai piège : déficit de $0{,}5550$ par rapport à $p^*$, gradient riemannien de l'ordre de $10^{-5}$ (stationnaire), et aucune des 200 perturbations de norme $0{,}02$ n'améliore la valeur — c'est bien un maximum *local*, pas un simple arrêt de l'algorithme. C'est exactement l'objet pathologique que toute méthode de recherche locale (cf. Search-4) redoute : le gradient ne dit plus rien, seul le déficit de valeur trahit le piège.\n",
+    "**Lecture du zoom.** Le point exhibé a toutes les cartes d'un vrai piège : déficit de $0{,}5551$ par rapport à $p^*$, gradient riemannien de l'ordre de $10^{-8}$ (stationnaire), et aucune des 200 perturbations de norme $0{,}02$ n'améliore la valeur — c'est bien un maximum *local*, pas un simple arrêt de l'algorithme. C'est exactement l'objet pathologique que toute méthode de recherche locale (cf. Search-4) redoute : le gradient ne dit plus rien, seul le déficit de valeur trahit le piège.\n",
     "\n",
     "## D. Friction et essais ratés (chemin de découverte)\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #15212

Discovered and verified by corrective-auditor: CONFIRMED_PEDAGOGY

## Résumé

Audit Astra `DISCOVERY` (issue #15227) du notebook Search-09b. La question d'audit principale — le seuil Burer–Monteiro emploie-t-il `n`=sommets au lieu de `m`=contraintes affines (soupçonné être le nombre d'arêtes pour Max-Cut SDP) — s'est résolue en **FALSE_POSITIVE** : le notebook est correct. Cette PR ne porte que l'unique défaut adjacent confirmé, une incohérence prose/sortie dans la cellule « Lecture du zoom ».

See #15227

## Question principale : `m = n` — FALSE_POSITIVE (aucune correction)

Vérifié contre les sources primaires :

- **Boumal–Voroninski–Bandeira (2018)**, *The non-convex Burer–Monteiro approach works on smooth SDPs* (ar5iv full text) : le SDP est `max ⟨C,Y⟩ s.t. 𝒜(Y)=b, Y ⪰ 0` avec `𝒜: 𝕊^{n×n} → ℝ^m` ; la condition de rang est **`p(p+1)/2 > m`**. Pour Max-Cut, **`𝒜` est la carte diagonale** `diag(Y)=1`, `b = 𝟙 ∈ ℝ^n` → **`m = n`**, pas le nombre d'arêtes. La forme factorisée est `diag(YY^T)=1` c'est-à-dire des lignes sur des sphères unité — exactement `(BM_r)` du notebook.
- **Burer–Monteiro (2005)** (reformulé dans l'intro BVB) : « we need only `p(p+1)/2 > m` », où `m` compte les contraintes d'égalité. La note Barvinok–Pataki du notebook est cohérente avec cette lecture.

Le nombre d'arêtes `|E|` vit dans l'objectif `W`, pas dans les contraintes : le soupçon « arêtes » est réfuté par la source, pas seulement par l'expérience.

**Contre-exemple demandé (n ≠ |E|)** — les deux lectures de `m` divergent exactement quand `n ≠ |E|` :

| Instance | n | \|E\| | r\*(n) (notebook) | r\*(\|E\|) (lecture réfutée) |
|---|---|---|---|---|
| C6 | 6 | 6 | 4 | 4 (coïncidence) |
| K8 | 8 | 28 | 4 | 8 |
| G(10,0.5) | 10 | 19 | 5 | 6 |
| Petersen (exercice) | 10 | 15 | 5 | 6 |

La source primaire tranche : `m = n`. La table du notebook (4/4/5) est la bonne.

## Question secondaire : « trois régimes identiques » — CONFIRMÉ

Ré-exécution fraîche sur `python3` (Python 3.13.14, cvxpy 1.9.2, numpy 2.4.4, CLARABEL) : **les 7 sorties de cellules code sont byte-identiques** aux sorties committées (`execution_count` 1–7, zéro erreur). Le recensement est déterministe sous graines fixes. Les trois régimes (r=1 universellement fallacieux 39/40·40/40·40/40 ; rangs intermédiaires en décroissance 5/40·0·12/40 ; zéro à `r ≥ r*`) correspondent exactement au tableau, et la nuance « propreté commençant avant r\* » (C6 et G10 dès r=3, K8 dès r=2) est la bonne.

## Défaut corrigé — CONFIRMED_PEDAGOGY

Cellule « Lecture du zoom » (section D), deux nombres de prose contredits par la sortie committée **et** par la ré-exécution fraîche :

| Prose (avant) | Sortie committée = fraîche | OBSERVATION / INFERENCE |
|---|---|---|
| déficit de `$0{,}5550$` | `deficit 0.5551` (pleine précision 0.55507) | **OBSERVATION** : `0.5550 = 14.3249 − 13.7699` (soustraction des deux valeurs affichées arrondies). **INFERENCE** : cohérent avec une prose dérivée des valeurs affichées ; la provenance textuelle n'est pas établie par la section D. |
| gradient « de l'ordre de `$10^{-5}$` » | `9.91e-08` (ordre 10⁻⁸) | **OBSERVATION** : sortie committée = fraîche = `9.91e-08` ≈ 10⁻⁸, contre prose 10⁻⁵. **INFERENCE** : peut refléter des paramètres antérieurs — la section D documente un ancien réglage (600 itér. / seuil 10⁻⁵) — mais la provenance textuelle n'est pas établie. |

## Diagnostic dérive (défaut corrigé)

- **OBSERVATION** : les valeurs de la sortie committée (byte-identiques à la ré-exécution fraîche) diffèrent de la prose — déficit `0.5551` vs `0.5550`, gradient `9.91e-08` vs `10⁻⁵`.
- **INFERENCE** : la prose ne reflète pas la sortie actuelle ; elle peut dater d'un état antérieur du notebook (paramètres antérieurs documentés en section D) ou d'une dérivation à partir des valeurs affichées. La provenance exacte n'est pas établie par le contenu du notebook ; ce qui justifie la correction est la **reproductibilité** de la valeur actuelle (ré-exécution fraîche byte-identique), pas la démonstration de l'origine de l'écart.
- **Verdict : `CAUSE_FIXED`** — la prose cite désormais les valeurs réelles de la sortie committée. Les valeurs étant byte-identiques sous ré-exécution fraîche, il n'y a pas de valeur « qui changera au prochain passage kernel » : la ré-alignement vient d'une exécution réelle, pas d'un alignement byte-surgical.

## Exécution et preuves

- `jupyter nbconvert --execute` (kernel `python3`, hors repo vers scratchpad) : toutes les cellules exécutées, sorties byte-identiques aux committées.
- `scripts/notebook_tools/validate_pr_notebooks.py origin/main` : **1/1 PASS** (7 cellules code).
- `scripts/notebook_tools/check_papermill_ratchet.py origin/main` : **0 changed / 0 regressions** (markdown-only ; aucun output, `execution_count` ni metadata touché).
- `scripts/notebook_tools/detect_markdown_rendering.py --check <target>` : OK, aucune nouvelle violation.
- Pre-commit local (H.3 refus-notebook-non-exécuté, source-list-newlines, oversized markdown-rendering, syntaxe source) : **Passed**.
- C.1 (`raise NotImplementedError` / `assert False` / `1/0`) : propre — stubs d'exercice = `return None  # TODO etudiant`.
- Scan secrets / littéraux inline : propre.
- Jumeau & traduction : ce notebook n'est ni dans `twin_pairs.d` ni dans `translations/`.

## Périmètre

- **1 fichier** : `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-09b-SpuriousMinima.ipynb`.
- Diff = **1 ligne / 2 jetons** (`$0{,}5550$`→`$0{,}5551$`, `$10^{-5}$`→`$10^{-8}$`), **byte-minimal** : aucune cellule code, aucun output, `execution_count` ni metadata modifiés.
- Aucun autre défaut trouvé dans le notebook. Le pont SOS SIAM 2023 reste bibliographique (déjà noté honnêtement en section E).

## Déconfliction

- Claim `#15227` (issuecomment-5589143805) posé par ma lane ; `check_lane_claim.py` → `my_active_claim=true`, `blocked=false`, **0 lane bloquante**, chemin libre.
- Aucune PR ouverte ne touche ce chemin (vérifié sur #15146, #14920, #15085 + recherche `SpuriousMinima`/`Burer`). Historique #13197 (création Search-17) et #13818 (renum → 09b) : mergés.
- `origin/main` = `58b92cc26` (snapshot de l'issue). Le réducteur avait d'abord tourné sous un checkout stale (verdict dead-glob erroné), puis relancé depuis la worktree canonique : exit 0.
- Travail sur une branche `fix/` à lane unique depuis `origin/main` frais ; pas de force push.

## Limites / résidualité

- Je n'ai pas falsifié la **non-dégénérescence** (condition du théorème) — le notebook le note honnêtement en section E. Le recensement n'est pas une preuve, mais la question d'audit portait sur la définition de `m`, pas sur la dégénérescence.
- Aucun claim GPU/vision : les sorties sont des tableaux numériques, la vérification visuelle n'ajoute rien.

Co-Authored-By: Claude Code <noreply@anthropic.com>
