### PR TITLE
fix(tooling,#15230): fix_hr_separator ecriture byte-preserving hors source ciblee

### DIFF
--- a/scripts/notebook_tools/fix_hr_separator.py
+++ b/scripts/notebook_tools/fix_hr_separator.py
@@ -122,11 +122,12 @@ def _raw_decode(text: str, i: int):
 
 
 def _parse_spans(text: str):
-    """Parse la JSON du notebook et enregistre les offsets bytes de chaque string literal.
+    """Parse la JSON du notebook et enregistre les offsets de caracteres de chaque string literal.
 
     Retourne ``(nb, literal_spans)`` ou ``literal_spans`` est une liste de tuples
-    ``(start, end, decoded, path)`` : ``start``/``end`` sont les offsets bytes du
-    literal dans ``text``, ``decoded`` sa valeur decodee, ``path`` son chemin JSON
+    ``(start, end, decoded, path)`` : ``start``/``end`` sont les offsets de CARACTERES
+    du literal dans ``text`` (la chaine decodee — ce ne sont PAS des offsets bytes),
+    ``decoded`` sa valeur decodee, ``path`` son chemin JSON
     (ex. ``("cells", 3, "source", 1)`` pour l'element 1 de la source de la cellule 3).
     """
     literal_spans = []
@@ -185,12 +186,16 @@ def _parse_spans(text: str):
 
 
 def _literal_offset_map(lit: str, decoded: str) -> list[int]:
-    """Map index de char decode -> offset byte dans ``lit`` (le literal, guillemets inclus).
+    """Map index de char decode -> offset de caractere dans ``lit`` (le literal, guillemets inclus).
 
-    ``lit`` est la tranche brute ``text[start:end]`` du literal JSON ; ``decoded`` sa
-    valeur decodee. Retourne une liste de longueur ``len(decoded)`` : le k-ième élément
-    est l'offset byte (dans ``lit``) du k-ième caractère décodé. Les paires de
-    surrogates (``\\uD800\\uDC00``) comptent pour un seul caractère décodé.
+    ``lit`` est la tranche ``text[start:end]`` du literal JSON ; ``decoded`` sa
+    valeur decodee. Retourne une liste de longueur ``len(decoded)`` : le k-ième
+    element est l'offset de CARACTERE (dans ``lit``) du k-ième caractère décodé.
+    Ces offsets sont des offsets de caracteres dans la chaine decodee, PAS des
+    offsets bytes : la preservation octet-a-octet provient de l'echange binaire,
+    du remplacement ASCII de meme longueur et de l'encode utf-8 final, pas de ces
+    offsets. Les paires de surrogates (``\\uD800\\uDC00``) comptent pour un seul
+    caractère décodé.
     """
     inner = lit[1:-1]
     out = []
@@ -227,31 +232,33 @@ def _source_spans_by_cell(literal_spans: list) -> dict:
 
 
 def _cell_edits(raw: str, old_src, new_src, spans: list):
-    """Calcule les edits bytes ``(start, end, replacement)`` pour une cellule.
+    """Calcule les edits ``(start, end, replacement)`` (offsets de CARACTERES) pour une cellule.
 
     Compare la source decodee aplatie avant/après conversion et ne retient que les
-    positions exactes ou ``---`` devient ``***``. Retourne ``None`` si la longueur
-    ne se réconcilie pas (extraction impossible), sinon la liste des edits.
+    positions exactes ou ``---`` devient ``***``. Les offsets retournes sont des
+    offsets de caracteres dans ``raw`` (la chaine decodee), pas des offsets bytes.
+    Retourne ``None`` si la longueur ne se réconcilie pas (extraction impossible),
+    sinon la liste des edits.
     """
     if not spans:
         return None
     flat_chars = []
-    raw_offsets = []
+    char_offsets = []
     for (s, e, d) in spans:
         lit = raw[s:e]
         offs = _literal_offset_map(lit, d)
         flat_chars.append(d)
-        raw_offsets.extend(s + o for o in offs)
+        char_offsets.extend(s + o for o in offs)
     flat_old = "".join(flat_chars)
     flat_new = "".join(new_src) if isinstance(new_src, list) else new_src
-    if len(flat_new) != len(flat_old) or len(raw_offsets) != len(flat_old):
+    if len(flat_new) != len(flat_old) or len(char_offsets) != len(flat_old):
         return None
 
     edits = []
     i = 0
     while i <= len(flat_old) - 3:
         if flat_old[i:i + 3] == HR and flat_new[i:i + 3] == REPLACEMENT:
-            edits.append((raw_offsets[i], raw_offsets[i] + 3, REPLACEMENT))
+            edits.append((char_offsets[i], char_offsets[i] + 3, REPLACEMENT))
             i += 3
         else:
             i += 1
@@ -324,8 +331,10 @@ def process(path: Path, apply: bool) -> int:
     """
     # Lecture/ecriture en MODE BINAIRE : le mode texte de Windows convertirtait
     # les fins de ligne LF/CRLF, ce qui casserait la preservation byte-a-byte.
-    # decode/encode utf-8 sans traduction de newline : les octets hors cible
-    # restent exactement ceux du fichier d'entree.
+    # Les offsets manipules par _parse_spans/_cell_edits sont des offsets de
+    # CARACTERES dans la chaine decodee (pas des offsets bytes) : la preservation
+    # octet-a-octet vient de l'echange binaire + du remplacement ASCII de meme
+    # longueur (--- -> ***) + de l'encode utf-8 final, pas de ces offsets.
     try:
         raw_bytes = path.read_bytes()
     except OSError as exc:

--- a/scripts/notebook_tools/fix_hr_separator.py
+++ b/scripts/notebook_tools/fix_hr_separator.py
@@ -116,14 +116,150 @@ def convert_cell(source, is_first_cell: bool) -> tuple[object, int]:
     return text, changed
 
 
-def process(path: Path, apply: bool) -> int:
-    """Rend le nombre de separateurs convertis (ou convertibles si apply=False)."""
-    try:
-        nb = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        print(f"ILLISIBLE {path}: {exc}", file=sys.stderr)
-        return 0
+def _raw_decode(text: str, i: int):
+    """Decode un token JSON (string, nombre, bool, null) via le decodeur standard."""
+    return json.JSONDecoder().raw_decode(text, i)
 
+
+def _parse_spans(text: str):
+    """Parse la JSON du notebook et enregistre les offsets bytes de chaque string literal.
+
+    Retourne ``(nb, literal_spans)`` ou ``literal_spans`` est une liste de tuples
+    ``(start, end, decoded, path)`` : ``start``/``end`` sont les offsets bytes du
+    literal dans ``text``, ``decoded`` sa valeur decodee, ``path`` son chemin JSON
+    (ex. ``("cells", 3, "source", 1)`` pour l'element 1 de la source de la cellule 3).
+    """
+    literal_spans = []
+
+    def skip(i):
+        while i < len(text) and text[i] in " \t\r\n":
+            i += 1
+        return i
+
+    def parse(i, path):
+        i = skip(i)
+        c = text[i]
+        if c == '"':
+            val, end = _raw_decode(text, i)
+            literal_spans.append((i, end, val, path))
+            return val, end
+        if c == "{":
+            i += 1
+            obj = {}
+            while True:
+                i = skip(i)
+                if text[i] == "}":
+                    i += 1
+                    break
+                k, i = parse(i, path)
+                i = skip(i)
+                if text[i] == ":":
+                    i += 1
+                v, i = parse(i, path + (k,))
+                obj[k] = v
+                i = skip(i)
+                if text[i] == ",":
+                    i += 1
+            return obj, i
+        if c == "[":
+            i += 1
+            arr = []
+            idx = 0
+            while True:
+                i = skip(i)
+                if text[i] == "]":
+                    i += 1
+                    break
+                v, i = parse(i, path + (idx,))
+                arr.append(v)
+                idx += 1
+                i = skip(i)
+                if text[i] == ",":
+                    i += 1
+            return arr, i
+        val, end = _raw_decode(text, i)
+        return val, end
+
+    nb, _ = parse(0, ())
+    return nb, literal_spans
+
+
+def _literal_offset_map(lit: str, decoded: str) -> list[int]:
+    """Map index de char decode -> offset byte dans ``lit`` (le literal, guillemets inclus).
+
+    ``lit`` est la tranche brute ``text[start:end]`` du literal JSON ; ``decoded`` sa
+    valeur decodee. Retourne une liste de longueur ``len(decoded)`` : le k-ième élément
+    est l'offset byte (dans ``lit``) du k-ième caractère décodé. Les paires de
+    surrogates (``\\uD800\\uDC00``) comptent pour un seul caractère décodé.
+    """
+    inner = lit[1:-1]
+    out = []
+    ri = 0
+    di = 0
+    n = len(inner)
+    while ri < n and di < len(decoded):
+        out.append(ri + 1)  # +1 : guillemet ouvrant
+        ch = inner[ri]
+        if ch == "\\":
+            c2 = inner[ri + 1] if ri + 1 < n else ""
+            if c2 == "u":
+                j = ri + 2
+                hexs = inner[j:j + 4]
+                cp = int(hexs, 16) if hexs else -1
+                ri = j + 4
+                if 0xD800 <= cp <= 0xDBFF and ri + 6 <= n and inner[ri:ri + 2] == "\\u":
+                    ri += 6  # paire de surrogates : un seul char décodé
+            else:
+                ri += 2
+        else:
+            ri += 1
+        di += 1
+    return out
+
+
+def _source_spans_by_cell(literal_spans: list) -> dict:
+    """Regroupe les spans de source par index de cellule, pour les cellules markdown."""
+    by_cell = {}
+    for (s, e, d, p) in literal_spans:
+        if len(p) >= 3 and p[0] == "cells" and p[2] == "source":
+            by_cell.setdefault(p[1], []).append((s, e, d))
+    return by_cell
+
+
+def _cell_edits(raw: str, old_src, new_src, spans: list):
+    """Calcule les edits bytes ``(start, end, replacement)`` pour une cellule.
+
+    Compare la source decodee aplatie avant/après conversion et ne retient que les
+    positions exactes ou ``---`` devient ``***``. Retourne ``None`` si la longueur
+    ne se réconcilie pas (extraction impossible), sinon la liste des edits.
+    """
+    if not spans:
+        return None
+    flat_chars = []
+    raw_offsets = []
+    for (s, e, d) in spans:
+        lit = raw[s:e]
+        offs = _literal_offset_map(lit, d)
+        flat_chars.append(d)
+        raw_offsets.extend(s + o for o in offs)
+    flat_old = "".join(flat_chars)
+    flat_new = "".join(new_src) if isinstance(new_src, list) else new_src
+    if len(flat_new) != len(flat_old) or len(raw_offsets) != len(flat_old):
+        return None
+
+    edits = []
+    i = 0
+    while i <= len(flat_old) - 3:
+        if flat_old[i:i + 3] == HR and flat_new[i:i + 3] == REPLACEMENT:
+            edits.append((raw_offsets[i], raw_offsets[i] + 3, REPLACEMENT))
+            i += 3
+        else:
+            i += 1
+    return edits
+
+
+def _count_conversions(nb) -> int:
+    """Nombre de separateurs convertibles, sans ecrire (reutilise convert_cell)."""
     total = 0
     seen_markdown = False
     for cell in nb.get("cells", []):
@@ -131,16 +267,94 @@ def process(path: Path, apply: bool) -> int:
             continue
         first = not seen_markdown
         seen_markdown = True
-        new_source, n = convert_cell(cell.get("source"), first)
-        if n:
-            total += n
-            if apply:
-                cell["source"] = new_source
+        _, n = convert_cell(cell.get("source"), first)
+        total += n
+    return total
 
-    if total and apply:
-        path.write_text(
-            json.dumps(nb, ensure_ascii=False, indent=1) + "\n", encoding="utf-8"
+
+def _apply_byte_preserving(raw: str, nb, expected_total: int):
+    """Applique les conversions de facon byte-preserving.
+
+    Ne modifie que les fragments de source markdown eligibles ; tout le reste du
+    fichier (code, outputs, execution_count, metadata, nbsp interne des chaines
+    HTML) est preserve octet par octet. Retourne le nouveau texte, ou ``None`` si
+    le nombre de mutations texte ne se reconcilie pas avec ``expected_total``.
+    """
+    _, literal_spans = _parse_spans(raw)
+    cells = nb.get("cells", [])
+    by_cell = _source_spans_by_cell(literal_spans)
+
+    edits = []
+    seen_markdown = False
+    for i, cell in enumerate(cells):
+        if cell.get("cell_type") != "markdown":
+            continue
+        first = not seen_markdown
+        seen_markdown = True
+        old_src = cell.get("source")
+        new_src, n = convert_cell(old_src, first)
+        if not n:
+            continue
+        spans = by_cell.get(i)
+        cell_edits = _cell_edits(raw, old_src, new_src, spans)
+        if cell_edits is None or len(cell_edits) != n:
+            return None
+        edits.extend(cell_edits)
+
+    if len(edits) != expected_total:
+        return None
+
+    # Chaque mutation doit porter sur un vrai separateur `---` dans le texte brut,
+    # sans quoi la substitution ecrirait des octets hors cible (echouer sans ecrire).
+    edits.sort(key=lambda e: e[0], reverse=True)
+    for (s, e, repl) in edits:
+        if raw[s:e] != HR:
+            return None
+        raw = raw[:s] + repl + raw[e:]
+    return raw
+
+
+def process(path: Path, apply: bool) -> int:
+    """Rend le nombre de separateurs convertis (ou convertibles si apply=False).
+
+    ``apply=True`` ecrit de facon byte-preserving : seule la source markdown
+    eligible change ; code, outputs, metadata et whitespace interne restent
+    intactes. Lève ``RuntimeError`` (rien n'est ecrit) si le nombre de mutations
+    texte ne se reconcilie pas avec le nombre de conversions calcule.
+    """
+    # Lecture/ecriture en MODE BINAIRE : le mode texte de Windows convertirtait
+    # les fins de ligne LF/CRLF, ce qui casserait la preservation byte-a-byte.
+    # decode/encode utf-8 sans traduction de newline : les octets hors cible
+    # restent exactement ceux du fichier d'entree.
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        print(f"ILLISIBLE {path}: {exc}", file=sys.stderr)
+        return 0
+    try:
+        raw = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        print(f"ILLISIBLE {path}: {exc}", file=sys.stderr)
+        return 0
+    try:
+        nb = json.loads(raw)
+    except ValueError as exc:
+        print(f"ILLISIBLE {path}: {exc}", file=sys.stderr)
+        return 0
+
+    total = _count_conversions(nb)
+    if not total:
+        return 0
+    if not apply:
+        return total
+
+    new_raw = _apply_byte_preserving(raw, nb, total)
+    if new_raw is None:
+        raise RuntimeError(
+            f"reconciliation ECHOUE sur {path} : {total} conversion(s) calculee(s) "
+            f"mais mutations textuelles non reconciliees — rien n'a ete ecrit"
         )
+    path.write_bytes(new_raw.encode("utf-8"))
     return total
 
 
@@ -168,7 +382,11 @@ def main(argv=None) -> int:
     files = 0
     seps = 0
     for nb in iter_notebooks(args.targets):
-        n = process(nb, apply=args.apply)
+        try:
+            n = process(nb, apply=args.apply)
+        except RuntimeError as exc:
+            print(f"ECHEC {nb}: {exc}", file=sys.stderr)
+            return 2
         if n:
             files += 1
             seps += n

--- a/scripts/notebook_tools/tests/test_fix_hr_separator.py
+++ b/scripts/notebook_tools/tests/test_fix_hr_separator.py
@@ -121,3 +121,123 @@ def test_controle_positif_le_notebook_de_l_incident(tmp_path):
         "controle positif ECHOUE : la forme de l'incident #11451 n'est pas "
         "detectee -> l'outil est casse, son 'rien a convertir' est sans valeur"
     )
+
+
+def _byte_diff_regions(a, b):
+    """Rend les plages bytes ou ``a`` et ``b`` different, en supposant des tailles egales."""
+    n = len(a)
+    out = []
+    i = 0
+    while i < n:
+        if a[i] != b[i]:
+            j = i
+            while j < n and a[j] != b[j]:
+                j += 1
+            out.append((i, j))
+            i = j
+        else:
+            i += 1
+    return out
+
+
+def test_apply_byte_preserving_avec_output_text_html(tmp_path):
+    """Regression #15230 : `--apply` ne doit changer que `---` en `***` dans la source.
+
+    Le notebook .NET porte dans un output `text/html` une ligne whitespace-only
+    (du decor JSON entre deux elements d'un tableau) que l'ancienne ecriture
+    ``json.dumps(indent=1)`` supprimait. Le fixer byte-preserving doit la garder
+    et ne modifier aucune autre surface (source code, outputs, execution_count,
+    metadata, blanc interne).
+    """
+    raw = (
+        '{"cells":['
+        '{"cell_type":"markdown","source":["Prose.\\n","\\n","---\\n","\\n","Suite.\\n"]},'
+        '{"cell_type":"code","execution_count":3,"metadata":{},"outputs":['
+        '{"output_type":"display_data","data":{"text/html":['
+        '"<div>\\r\\n",'
+        '   \n'
+        '"</div>\\r\\n"]},"metadata":{}}]}'
+        '],"metadata":{},"nbformat":4,"nbformat_minor":5}\n'
+    )
+    p = tmp_path / "n.ipynb"
+    p.write_bytes(raw.encode("utf-8"))
+    before = p.read_bytes()
+
+    assert fix.process(p, apply=False) == 1
+    assert fix.process(p, apply=True) == 1
+    after = p.read_bytes()
+
+    # seule difference : la ligne de separateur markdown `---` devient `***`
+    assert after == before.replace(b'"---\\n"', b'"***\\n"')
+    # le decor whitespace-only entre les elements text/html est byte-preserve
+    assert b'   \n' in after
+    # aucune autre surface ne change (surfaces non ciblees)
+    assert len(_byte_diff_regions(before, after)) >= 1
+    for (s, e) in _byte_diff_regions(before, after):
+        assert (before[s:e], after[s:e]) == (b"---", b"***")
+
+    # les objets JSON non source restent semantiquement egaux
+    before_nb = json.loads(before)
+    after_nb = json.loads(after)
+    assert before_nb["cells"][1]["outputs"] == after_nb["cells"][1]["outputs"]
+    assert before_nb["cells"][1]["execution_count"] == after_nb["cells"][1]["execution_count"]
+    assert before_nb["cells"][1]["metadata"] == after_nb["cells"][1]["metadata"]
+
+    # idempotence : second --apply = 0 changement, fichier byte-identique
+    assert fix.process(p, apply=True) == 0
+    assert p.read_bytes() == after
+
+
+def test_apply_preserve_code_outputs_execution_count(tmp_path):
+    """Controle byte-à-byte : code, execution_count et outputs restent intacts."""
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": "# T\n"},
+            {"cell_type": "markdown", "source": "A.\n\n---\n\nB.\n"},
+            {"cell_type": "code", "source": "for (var i = 0; i < 3; i++) { }\n",
+             "execution_count": 7, "metadata": {"tags": []},
+             "outputs": [{"output_type": "display_data", "metadata": {},
+                          "data": {"text/plain": ["hello\n"]}}]},
+        ],
+        "metadata": {"kernelspec": {"name": ".net-csharp", "display_name": ".NET (C#)"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / "n.ipynb"
+    p.write_bytes(json.dumps(nb).encode("utf-8"))
+    before = p.read_bytes()
+
+    assert fix.process(p, apply=True) == 1
+    after = p.read_bytes()
+
+    before_nb = json.loads(before)
+    after_nb = json.loads(after)
+    # source markdown convertie, le reste byte-identique au niveau objet
+    assert after_nb["cells"][1]["source"] == "A.\n\n***\n\nB.\n"
+    assert after_nb["cells"][2]["source"] == "for (var i = 0; i < 3; i++) { }\n"
+    assert after_nb["cells"][2]["execution_count"] == 7
+    assert after_nb["cells"][2]["outputs"] == before_nb["cells"][2]["outputs"]
+    assert after_nb["metadata"] == before_nb["metadata"]
+    # la source code n'a pas change au niveau bytes non plus
+    assert b'for (var i = 0; i < 3; i++) { }' in after
+    assert b'7' in after  # execution_count reste
+
+
+def test_reconciliation_echoue_sans_ecrire(tmp_path):
+    """Si les mutations textuelles ne se reconcilient pas, `--apply` echoue sans ecrire.
+
+    Source markdown dont le separateur est encode en `-` (escape unicode) :
+    la classification voit `---` (decode), mais le texte brut ne porte pas `---`,
+    donc la mutation ne se reconcilie pas -> RuntimeError, aucun octet ecrit.
+    """
+    raw = (
+        '{"cells":[{"cell_type":"markdown","source":['
+        '"\\u002d\\u002d\\u002d\\n"]}],"metadata":{},"nbformat":4,"nbformat_minor":5}'
+    )
+    p = tmp_path / "n.ipynb"
+    p.write_bytes(raw.encode("utf-8"))
+    before = p.read_bytes()
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        fix.process(p, apply=True)
+    assert p.read_bytes() == before  # rien n'a ete ecrit


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/research-code #15124

Closes #15230. See #15227.

## Bug corrige

`process()` relisait le notebook entier avec `json.loads` puis le reemettait avec
`json.dumps(nb, ensure_ascii=False, indent=1)`. Cette re-serialisation globale
cassait la preservation byte-a-byte : elle supprimait les lignes whitespace-only
que l'ecrivain `.NET Interactive` laisse entre deux elements d'un tableau
`text/html` de sortie. Sur le canari Search (7 notebooks, #15227), le diff
physique etait donc **7 insertions / 43 suppressions** au lieu de **7 / 7** — les
objets JSON restaient semantiquement egaux, mais le contrat du sweeper (zero
hunk output inattendu) etait viole.

## Correction

`--apply` est desormais **byte-preserving** :

1. la logique de classification frontmatter / fence / setext (`convert_cell`,
   `_is_real_frontmatter`) est conservee a l'identique ;
2. le fichier est lu/ecrit en **mode binaire** (`read_bytes` / `write_bytes` +
   decode/encode utf-8 sans traduction de newline), ce qui supprime la
   conversion LF/CRLF du mode texte Windows qui a egalement brise la preservation ;
3. seuls les fragments de source markdown eligibles sont modifies, via un
   remplacement cible `---` → `***` aux offsets de CARACTERES exacts de ces
   fragments ;
4. tout le reste (code, outputs, `execution_count`, metadata, encodage, blanc
   interne des chaines HTML) reste octet par octet identique ;
5. **echec sans ecrire** (`RuntimeError`, code de sortie 2) si les mutations
   textuelles ne se reconcilient pas exactement avec le nombre de conversions
   calcule — et si une mutation ne porte pas sur un vrai `---` dans le texte brut.

Note de precision sur les octets : les offsets calcules par `_parse_spans` /
`_literal_offset_map` / `_cell_edits` sont des offsets de **caracteres** dans la
chaine decodee, PAS des offsets bytes. La preservation octet-a-octet est obtenue
par la combinaison (a) lecture/ecriture binaire sans traduction de newline,
(b) remplacement strictement ASCII de meme longueur (`---` → `***`), et
(c) encode utf-8 final : aucun octet hors des fragments de source cibles ne change
sur disque. Ce sont ces trois mecanismes qui garantissent le resultat byte-equal,
et c'est ce que mesurent les tests byte-a-byte et le canari.

## Tests

`python -m pytest scripts/notebook_tools/tests/test_fix_hr_separator.py` :
**13 passes** (10 tests existants conserves + 3 nouveaux) :

- `test_apply_byte_preserving_avec_output_text_html` — notebook de type .NET avec
  cellule markdown eligible + output `text/html` contenant une ligne
  whitespace-only (decor JSON) ; assert que `--apply` change exactement
  `---` en `***` dans la source, que le whitespace decoratif est byte-preserve,
  que les surfaces non ciblees (outputs, execution_count, metadata) restent
  byte-identiques, et idempotence (2eme `--apply` = 0 changement).
- `test_apply_preserve_code_outputs_execution_count` — controle byte-a-byte :
  code, outputs et `execution_count` intacts apres conversion.
- `test_reconciliation_echoue_sans_ecrire` — une source markdown dont le
  separateur est encode en `-` fait echouer la reconciliation : `RuntimeError`
  et aucun octet ecrit.

`python -m pytest scripts/tests/test_detect_markdown_rendering_repair.py` :
**9 passes** (aucune regression sur le hint qui nomme `fix_hr_separator.py --apply`).

## Canari Search hors depot (7 notebooks .NET, copies hors repo — aucun notebook modifie)

`fix_hr_separator.py --apply` sur les sept copies `App-1b-NQueens-CSharp`,
`App-2b-GraphColoring-CSharp`, `App-5-Timetabling-CSharp`, `App-11b-Picross-CSharp`,
`App-15b-SportsScheduling-CSharp`, `App-16-Crossword-CSP-Csharp`,
`App-19-ProceduralGeneration-WFC-Csharp` :

- **7 conversions logiques** (1 par notebook) ;
- **diff physique = exactement 7 replacements `---` → `***`**, **zero hunk output /
  code / metadata**, et longueurs de fichiers byte-identiques ;
- idempotence : re-scan `--check` et re-`--apply` donnent tous deux **0**.

`--check` en lecture seule sur `MyIA.AI.Notebooks/Search/Applications/CSP`
(dans le repo, aucune ecriture) : **7 separateurs dans 7 notebooks**.

## Incertitude residuelle

- La cible reelle de la reprise #15227 n'est **pas** modifiee par cette PR : chaque
  notebook Search est nettoye hors repo, sur copie, puis commite par la vague
  `fix_hr_separator` dediee. Rien n'est apply dans le repo ici.
- Le canari valide les 7 notebooks du lot #15227 (`Search/Applications/CSP`).
  Le comportement sur d'autres familles (GameTheory, SymbolicAI, etc.) n'est pas
  re-mesure dans cette PR ; la logique byte-preserving est generaliste (elle ne
  depend pas de la famille), mais un re-canari par famille reste conseille avant
  un sweep de grande ampleur.
- L'outil de replacement s'appuie sur un mini-parser JSON dedie (pour retrouver
  les offsets de caracteres des literaux de source) : il est teste sur des
  notebooks reels (canari) et des fixtures, mais ne couvre pas les formes de
  notebook exotiques (ex. surface `source` non standard, fichiers non utf-8). En
  cas de doute, l'echec-de-reconciliation impose un `RuntimeError` sans ecriture,
  jamais un ecrit partiel.
