### PR TITLE
fix(notebook,#15227): align prose quantitative claims with re-verified outputs

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring-Statistical-Validity-Python.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring-Statistical-Validity-Python.ipynb
@@ -187,7 +187,7 @@
    "id": "cell-16ef0582",
    "metadata": {},
    "source": [
-    "Faut-il en conclure que DSATUR est \u00ab meilleure \u00bb que le glouton de ${g1 - d1}$ couleurs, et CP-SAT de ${d1 - c1}$ de plus ? **Non**, pour une raison simple : un autre tirage du m\u00eame graphe aurait pu donner des \u00e9carts diff\u00e9rents. La conclusion ci-dessus m\u00e9lange deux effets indissociables \u2014 la *diff\u00e9rence r\u00e9elle* entre strat\u00e9gies et la *particularit\u00e9* de cette instance. Pour les s\u00e9parer, il faut r\u00e9p\u00e9ter."
+    "Faut-il en conclure que DSATUR est \u00ab meilleure \u00bb que le glouton de 3 couleurs, et CP-SAT de 1 de plus ? **Non**, pour une raison simple : un autre tirage du m\u00eame graphe aurait pu donner des \u00e9carts diff\u00e9rents. La conclusion ci-dessus m\u00e9lange deux effets indissociables \u2014 la *diff\u00e9rence r\u00e9elle* entre strat\u00e9gies et la *particularit\u00e9* de cette instance. Pour les s\u00e9parer, il faut r\u00e9p\u00e9ter."
    ]
   },
   {
@@ -248,7 +248,7 @@
    "id": "cell-ae5535be",
    "metadata": {},
    "source": [
-    "La hi\u00e9rarchie glouton > DSATUR > CP-SAT tient **en moyenne**, mais la variabilit\u00e9 n'est pas nulle (l'\u00e9cart-type vaut environ $0{,}5$ couleur). Visualisons ces distributions :"
+    "La hi\u00e9rarchie glouton > DSATUR > CP-SAT tient **en moyenne**, mais la variabilit\u00e9 n'est pas nulle (l'\u00e9cart-type vaut de l'ordre de $0{,}3$ \u00e0 $0{,}9$ couleur selon la strat\u00e9gie). Visualisons ces distributions :"
    ]
   },
   {
@@ -364,7 +364,7 @@
    "id": "cell-806ffba6",
    "metadata": {},
    "source": [
-    "Les IC \u00e0 95 % sont **\u00e9troits** (largeur $\\approx 0{,}2$\u2013$0{,}3$ couleur) et **disjoints** entre strat\u00e9gies : m\u00eame la borne basse du glouton reste au-dessus de la borne haute de DSATUR, elle-m\u00eame au-dessus de celle de CP-SAT. C'est la preuve quantitative qui manquait au constat visuel."
+    "Les IC \u00e0 95 % sont **\u00e9troits** (largeur $\\approx 0{,}3$\u2013$0{,}8$ couleur) et **disjoints** entre strat\u00e9gies : m\u00eame la borne basse du glouton reste au-dessus de la borne haute de DSATUR, elle-m\u00eame au-dessus de celle de CP-SAT. C'est la preuve quantitative qui manquait au constat visuel."
    ]
   },
   {
@@ -428,7 +428,7 @@
    "id": "cell-b59a25b9",
    "metadata": {},
    "source": [
-    "Les trois $p$-valeurs sont minuscules ($\\sim 10^{-7}$ \u00e0 $10^{-9}$), tr\u00e8s en-dessous du seuil corrig\u00e9. Conclusion : **les trois hi\u00e9rarchies sont statistiquement significatives**, et ce n'est pas un artefact des comparaisons multiples."
+    "Les trois $p$-valeurs sont minuscules ($\\sim 10^{-6}$ \u00e0 $10^{-9}$), tr\u00e8s en-dessous du seuil corrig\u00e9. Conclusion : **les trois hi\u00e9rarchies sont statistiquement significatives**, et ce n'est pas un artefact des comparaisons multiples."
    ]
   },
   {
@@ -485,7 +485,7 @@
    "id": "cell-e7545c03",
    "metadata": {},
    "source": [
-    "Ici $r \\approx 1$ partout : chaque strat\u00e9gie domine la pr\u00e9c\u00e9dente sur **pratiquement toutes** les instances. L'effet n'est pas seulement d\u00e9tectable, il est **massif**. Pour coloration de graphes denses d'Erd\u0151s-R\u00e9nyi, DSATUR n'est pas \u00ab un peu meilleur \u00bb que le glouton \u2014 il l'emporte sur quasi toutes les instances test\u00e9es.\n",
+    "Ici $r$ vaut $0{,}84$ (glouton/DSATUR), $0{,}97$ (DSATUR/CP-SAT) et $1{,}00$ (glouton/CP-SAT) : chaque strat\u00e9gie domine la pr\u00e9c\u00e9dente sur **pratiquement toutes** les instances \u2014 mais DSATUR ne bat le glouton que sur 18 des 20 instances (\u00e9galit\u00e9 sur les 2 autres), d'o\u00f9 un effet **marqu\u00e9** ($r = 0{,}84$) et non $r \\approx 1$. L'effet n'en reste pas moins **massif**, pas seulement d\u00e9tectable. Pour coloration de graphes denses d'Erd\u0151s-R\u00e9nyi, DSATUR n'est pas \u00ab un peu meilleur \u00bb que le glouton \u2014 il l'emporte sur la quasi-totalit\u00e9 des instances test\u00e9es.\n",
     "\n",
     "> **Pourquoi pas les graphes de Mycielski ?** Une intuition r\u00e9pandue voudrait que les graphes de Mycielski (construction sans triangle avec nombre chromatique arbitraire) soient *le* cas o\u00f9 le glouton \u00e9choue. En pratique, avec l'ordre par d\u00e9faut de `networkx`, le glouton **et** DSATUR y trouvent le $\\chi$ exact : l'\u00e9cart n'appara\u00eet pas. Les graphes d'Erd\u0151s-R\u00e9nyi denses ($p \\geq 0{,}3$) sont le bon cas discriminant \u2014 c'est aussi ce que montre `App-2` sur son instance unique, et ce que ce notebook confirme *statistiquement* sur $N$ instances."
    ]
@@ -552,7 +552,7 @@
    "id": "cell-ffe6fad4",
    "metadata": {},
    "source": [
-    "Le gap grandit avec $p$ : sur des graphes **creux** ($p = 0{,}1$), glouton et DSATUR co\u00efncident quasi-syst\u00e9matiquement (peu de contraintes, les deux trouvent l'optimum) ; sur des graphes **denses** ($p \\geq 0{,}4$), DSATUR tire profit de l'ordre dynamique des sommets et \u00e9conomise r\u00e9guli\u00e8rement 1 \u00e0 3 couleurs. **Le verdict \u00ab DSATUR est meilleure \u00bb d\u00e9pend donc de la densit\u00e9** \u2014 un angle que la conclusion ponctuelle de `App-2` ne pouvait pas r\u00e9v\u00e9ler."
+    "Le gap s'accro\u00eet avec $p$ : sur des graphes **creux** ($p = 0{,}1$), l'\u00e9cart moyen entre glouton et DSATUR reste d'environ 1 couleur (DSATUR gagne sur 13 des 15 graphes, \u00e9galit\u00e9 sur 2) \u2014 ils ne co\u00efncident donc quasi-jamais ; sur des graphes **denses** ($p \\geq 0{,}4$), DSATUR tire profit de l'ordre dynamique des sommets et l'\u00e9cart moyen grimpe de 1,5 \u00e0 3 couleurs. **Le verdict \u00ab DSATUR est meilleure \u00bb d\u00e9pend donc de la densit\u00e9** \u2014 un angle que la conclusion ponctuelle de `App-2` ne pouvait pas r\u00e9v\u00e9ler."
    ]
   },
   {
@@ -564,9 +564,9 @@
     "\n",
     "| Question | R\u00e9ponse ponctuelle (`App-2`) | R\u00e9ponse statistique (ce notebook) |\n",
     "|---|---|---|\n",
-    "| DSATUR < glouton ? | \u00ab oui, sur cette instance \u00bb | **oui, significativement** ($p \\sim 10^{-7}$), effet massif ($r \\approx 1$), IC disjoints |\n",
+    "| DSATUR < glouton ? | \u00ab oui, sur cette instance \u00bb | **oui, significativement** ($p \\sim 10^{-6}$), effet marqu\u00e9 ($r = 0{,}84$), IC disjoints |\n",
     "| CP-SAT < DSATUR ? | \u00ab oui, sur cette instance \u00bb | **oui, significativement**, effet massif |\n",
-    "| Conclusion g\u00e9n\u00e9rale ? | \u00ab CP-SAT est le meilleur \u00bb | **sur graphes denses**, oui \u2014 mais le gap glouton/DSATUR s'annule sur graphes creux |\n",
+    "| Conclusion g\u00e9n\u00e9rale ? | \u00ab CP-SAT est le meilleur \u00bb | **sur graphes denses**, oui \u2014 mais sur graphes creux l'\u00e9cart glouton/DSATUR se r\u00e9duit \u00e0 environ 1 couleur (DSATUR n'y l'emporte que de peu) |\n",
     "\n",
     "**Le\u00e7on m\u00e9thodologique.** Une comparaison ponctuelle de solveurs sur **une** instance confond l'effet propre des strat\u00e9gies et la particularit\u00e9 du graphe tir\u00e9. \u00c9chantillonner $N$ instances, encadrer les moyennes par des IC bootstrap, tester la signification (Mann-Whitney + Bonferroni) et mesurer la taille d'effet transforme une intuition en conclusion d\u00e9fendable \u2014 et r\u00e9v\u00e8le les d\u00e9pendances (ici, en la densit\u00e9) que masque l'instance unique.\n",
     "\n",


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #15231  Audit Astra `DISCOVERY` de `Search/Applications/CSP/App-2-GraphColoring-Statistical-Validity-Python.ipynb` (issue #15227, claim `#issuecomment-5589446482`). `See #15227`.  ## Résumé  Notebook ré-exécuté de bout en bout (kernel `python3`, `nbconvert --execute`) : la fraîche reproduit **byte-à-byte** toutes les sorties committées (déterministe, `SEED=42`, vérifié). La comparaison prose ↔ sorties a révélé **sept écarts quantitatifs** dans la prose, tous corrigés ici. Le diff est **markdown-only** : zéro changement de cellule code, `outputs`, `execution_count` ou `metadata` (vérifié cellule par cellule).  Corrections (prose → sortie committée / fraîchement re-vérifiée) :  | Cellule | Ancienne prose | Sortie réelle | Correction | |---|---|---|---| | §2 (`g1-d1`, `d1-c1`) | `${g1 - d1}` / `${d1 - c1}` non substitués | 3 / 1 | `3 couleurs`, `1 de plus` | | §3 | écart-type « environ 0,5 » | 0,86 / 0,58 / 0,32 | « de l'ordre de 0,3 à 0,9 » | | §4 | largeur IC « ≈ 0,2–0,3 » | 0,80 / 0,55 / 0,30 | « ≈ 0,3–0,8 » | | §5 | p « ~10^-7 à 10^-9 » | 1,15e-6 / 9,58e-9 / 5,85e-9 | « ~10^-6 à 10^-9 » | | §6 | « r ≈ 1 partout » | 0,840 / 0,968 / 1,000 | r explicite + 18/20 victoires, 2 ex aequo | | §7 | « coïncident quasi-systématiquement » à p=0,1 | écart moyen 1,07 (13/15, 2 égalités) | « ne coïncident quasi-jamais » | | §8 synthèse | p~10^-7, r≈1 ; gap « s'annule » sur graphes creux | p=1,15e-6 ; r=0,84 ; gap 1,07 | valeurs corrigées + « se réduit » |  ## Diagnostic dérive (C.4)  **OBSERVATION** — les sept littéraux de prose ne correspondaient pas aux sorties committées, et une ré-exécution fraîche reproduit ces sorties byte-à-byte (`SEED=42`). La provenance historique de ces littéraux n'est pas prouvée : aucune causalité environnement/kernel/upstream n'est attribuée. Verdict local : **CAUSE_FIXED**, borné aux sept écarts prose-sorties corrigés dans ce diff. Les deux défauts méthodologiques du code (test indépendant malgré l'appariement, et statut `FEASIBLE` présenté comme exact) restent non corrigés ici et sont suivis par #15239.  Conséquence : la correction porte uniquement sur des **cellules markdown** ; aucune cellule code, `outputs`, `execution_count` ni `metadata` n'est modifié. La ré-exécution complète a servi de contre-vérification hors diff ; l'exemption C.3 signifie qu'aucun output artificiellement régénéré n'est committé.  ## Validation (exacte)  - `jupyter nbconvert --to notebook --execute --ExecutePreprocessor.kernel_name=python3 --timeout=60` → SUCCESS (57 s) ; **toutes sorties texte identiques** aux committées (diff script : "No text-output differences"). - `python scripts/notebook_tools/validate_pr_notebooks.py origin/main <nb>` → **1/1 passed** (11 cellules code). - `python scripts/notebook_tools/detect_markdown_rendering.py <nb>` → **0 violations**. - `python scripts/notebook_tools/check_interp_positioning.py <nb>` → **0 findings**. - `python scripts/notebook_tools/check_papermill_ratchet.py origin/main` → **0 regressions**, 0 notebooks changed. - C.1/C.2 : 11 cellules code, 0 `raise NotImplementedError`/`assert False`/`1/0`, `execution_count` non nul + `outputs` présents partout (vérifié). - Secrets : aucun credential, aucun literal dans le notebook (grep). - **Scope du diff** : cellule par cellule, seuls les `source` markdown des cellules [5,8,13,16,19,22,23] changent ; `outputs`, `execution_count`, `metadata`, `id` et le code de TOUTES les cellules sont **byte-identiques** (script de vérification, `[]` churn non-source).  ## Déconfliction  - `scripts/check_lane_claim.py 15227 --lane myia-po-2025:CoursIA-2 --paths <nb>` → `CLEAR`, `blocked=false`, `free_paths_size=1` (mon propre claim actif). - `scripts/check_lane_claim.py --lane myia-po-2025:CoursIA-2 --open-prs-on <nb>` → **NO open PR intersects**. Path free. - `gh pr list --state open --search "App-2-GraphColoring"` + `gh api pulls?state=open` → aucune PR ouverte sur ce chemin. - Historique : création `c28c1ea64` (#9823), newline `59f7f79fa` (#13606). Aucune PR de lecture/PR de site ouverte.  ## Incertitude résiduelle & findings profonds (hors scope de ce PR — suivis par #15239)  Aucune incertitude sur le diff local. Deux findings **profonds** confirmés sont **volontairement exclus** (audit, pas d'élargissement de patch), regroupés dans l'issue de correction mono-notebook #15239 :  1. **CP-SAT « exact » non prouvé (axis 3).** Sur les 20 instances main à p=0,4, `cpsat_color` renvoie `OPTIMAL` pour **1** instance et `FEASIBLE` pour **19** ; l'instance unique `G(50,0,4)` est `FEASIBLE` ; le sweep de densité est `FEASIBLE` pour les 5 instances de chaque p≥0,4 et `OPTIMAL` pour p≤0,3. La prose (« numérotation chromatique exacte », « nombre chromatique exact », « résolutions exactes », « CP-SAT est le meilleur ») sur-affirme : sous `FEASIBLE`, `ObjectiveValue()` est une **borne supérieure** (colorations valides trouvées dans ≤2 s), pas un χ prouvé. Le notebook lui-même admet le risque dans les exercices (« si certaines instances n'atteignent pas l'optimum prouvé »). Correction possible (exposer/asserter le statut, augmenter `time_limit`, ou qualifier la prose).  2. **Mann–Whitney indépendant sur données appariées (axis 2).** Les 20 mêmes graphes alimentent chaque stratégie (design **apparié**/bloqué), donc un test **apparié** (Wilcoxon signé / signe / permutation) est correct et non le test de Mann–Whitney indépendant. Impact **métrique** : Mann–Whitney donne ici des p-values plus petites (1,15e-6 / 9,58e-9 / 5,85e-9) que Wilcoxon signé (7,40e-5 / 2,41e-5 / 3,28e-5) ; c'est donc la **force de preuve qui est suraffirmée**, et non des p-values numériquement « surestimées ». Le test du signe orienté donne 3,81e-6 / 9,54e-7 / 9,54e-7. La conclusion directionnelle reste forte. Le rank-bisérial apparié, défini sur les rangs des différences non nulles avec `zero_method="wilcox"`, vaut 1,00 pour les trois paires ; les comptes victoires/ex aequo/défaites sont 18/2/0, 20/0/0 et 20/0/0.  ## Récapitulatif  - Files modifiés : `MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring-Statistical-Validity-Python.ipynb` (un seul, dans `PATHS`). - Aucun rapport commité, aucun secret, aucune review, aucun merge/close. La release de claim et le suivi profond ont été publiés sur #15227 et #15239 après livraison de cette PR.  Discovered and verified by corrective-auditor (myia-po-2025:CoursIA-2): CONFIRMED prose misalignment (7 écarts), markdown-only, outputs byte-identiques après ré-exécution fraîche. 