### PR TITLE
fix(lean,#14773): bump finiteness_lean 4.32.1 -> v4.33.0 (rollout 4.33, core-only)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md
@@ -11,7 +11,7 @@ Lean 4 mini-project from Epic #2978 (deliverable C), shipped via PR #3018.
 
 ## Status
 
-- **Toolchain**: `leanprover/lean4:v4.32.0`
+- **Toolchain**: `leanprover/lean4:v4.33.0`
 - **Sorry**: **0 sorry, 0 axiom** — everything is proven or illustrated via `#eval`
 - **Build**: `lake build Finiteness` — **autonomous, without Mathlib** (Lean core only)
 - **Dependencies**: none

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
@@ -9,7 +9,7 @@ Mini-projet Lean 4 issu de l'Epic #2978 (livrable C), livré par la PR #3018.
 
 ## État
 
-- **Toolchain** : `leanprover/lean4:v4.32.1` (bump post-#11325, cf #11256 ; la section `Build` reflète toujours l'absence de Mathlib — voir `lean-toolchain` pour le pin exact)
+- **Toolchain** : `leanprover/lean4:v4.33.0` (rollout #14773 ; la section `Build` reflète toujours l'absence de Mathlib — voir `lean-toolchain` pour le pin exact)
 - **Sorry** : **0 sorry, 0 axiom** — tout est prouvé ou illustré par `#eval`
 - **Build** : `lake build Finiteness` — **autonome, sans Mathlib** (Lean core seul)
 - **Dépendances** : aucune

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.1
+leanprover/lean4:v4.33.0


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: DEEP/lean #15135

## Summary

Migration atomique du lake autonome `finiteness_lean` de **Lean 4.32.1 → v4.33.0** sous le rollout #14773. Le lake est **core-only** (aucune dépendance Mathlib — `lake-manifest.json` ne porte aucun package), ciblé en pilote Phase 1 du rollout. Le bump est **purement un pin** : zéro changement de code de preuve.

| Fichier | Avant | Après |
|---|---|---|
| `lean-toolchain` | `leanprover/lean4:v4.32.1` | `leanprover/lean4:v4.33.0` |
| `README.md` (FR) | Toolchain `v4.32.1` (bump post-#11325) | Toolchain `v4.33.0` (rollout #14773) |
| `README.en.md` (EN) | Toolchain `v4.32.0` — **déjà en retard d'un cran** | Toolchain `v4.33.0` |

Le lake contient une unique bibliothèque `Finiteness` (type inductif `Regex`, dérivée symbolique de Brzozowski, `nullable`/`accepts`/`deriv`) + son sibling `Finiteness/Basic_en.lean` (convention i18n #4980). Aucune preuve nommée à porter (uniquement des `def` et des `example` évalués).

## Validation

| Organe | Résultat |
|---|---|
| **Build `lake build`** | **SUCCESS** (lake WSL natif, toolchain v4.33.0, 4 jobs — `lake update` idempotent "already up-to-date") |
| `lake-manifest.json` | **byte-identical, inchangé** — régénéré par `lake update`, mais le lake n'a **aucune dépendance** (`packages: []`), donc le manifest est déjà au pin et ne bouge pas |
| `count_code_sorry.py --json` | **0 / 0 / 0** (`naive_sorry=0`, `code_sorry=0`, `distinct_code_sorry=0`) |
| `check_i18n_siblings.py` | **1/1 pairs byte-identical** — 0 drift · 0 orphan · 0 unbuilt (sibling `_en` conforme) |
| B.3 `#print axioms` | **N/A — job non câblé sur ce lake.** `lean-finiteness.yml` utilise `lean-build.yml` (sorry-baseline 0, mode `real`), il n'appelle **pas** `lean-axiom.yml`. De plus le lake ne porte **aucun théorème/lemme nommé** (uniquement `inductive Regex` + 6 `def` + `example` anonymes) : le diff ne touche **aucun** fichier `.lean`, donc l'ensemble d'axiomes est **identique à `main`** |

## Notes

- **Pas de régression de contenu** : diff `+3/−3` sur 3 fichiers de pin/doc, `+0` sur tout `.lean`. Le catalogue n'est pas régénéré (appartient à l'automatisation, cf catalog-pr-hygiene).
- **B.3 consigné explicitement** (jamais sauté en silence) : job proof-integrity non câblé sur finiteness + 0 théorème nommé — voir le tableau ci-dessus.

See #14773 (rollout EPIC ouvert — sous-grain atomique de la migration 4.33, pas une clôture).
