### PR TITLE
fix(guard,#15193): un login suivi d'un point (fin de phrase) matche la frontiere d'identite

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -3042,8 +3042,14 @@ def _override_scopes_reserve(lift_body: str, nit_author: str) -> bool:
     if not nit_author:
         return True
     body = lift_body or ""
-    author_re = re.compile(r"(?<![A-Za-z0-9_.-])" + re.escape(nit_author)
-                           + r"(?![A-Za-z0-9_.-])")
+    # #15193: le `.` est exclu des frontieres (lookbehind ET lookahead) --
+    # un login suivi d'un point (fin de phrase) est une frontiere d'identite
+    # legitime : "la reserve de <login>." doit MATCHER. Seul un caractere de
+    # MOT (alnum/_) continue le token (anti "jsboige2" / "jsboige_x") ; `-`
+    # reste en classe pour proteger la sous-chaine ("Myia" dans
+    # "clusterManager-Myia").
+    author_re = re.compile(r"(?<![A-Za-z0-9_-])" + re.escape(nit_author)
+                           + r"(?![A-Za-z0-9_-])")
     if _scope_lifted_sentence(body, author_re):
         return True
     if nit_author in PERSONA_ALIAS_LOGINS or nit_author == "jsboige":

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -4933,6 +4933,30 @@ def test_14216_unite_scope_login_persona_et_anonyme():
     assert not mod._override_scopes_reserve(excl, "clusterManager-Myia")
 
 
+def test_15193_login_suivi_du_point_matche():
+    """#15193 — le `.` était dans la classe des frontières d'identité, si
+    bien que l'idiome recommandé par l'organe lui-même — « je lève aussi la
+    réserve de <login>. » (login en fin de phrase) — ne matchait jamais.
+    Un login suivi d'un point est une frontière d'identité légitime ; seul
+    un caractère de MOT (alnum/_) continue le token. Mesuré sur #15049 :
+    trois overrides successifs rejetés avant que la cause soit isolée."""
+    assert mod._override_scopes_reserve(
+        "… je lève aussi la réserve de jsboige.", "jsboige")
+    assert mod._override_scopes_reserve(
+        "… je lève aussi la réserve de jsboige elle-même.", "jsboige")
+    assert mod._override_scopes_reserve(
+        "… je lève aussi la réserve de jsboige, posée à 23:11Z.", "jsboige")
+    # frontière d'identité : un login suivi d'ALNUM ou d'un hyphen n'est pas
+    # le même token (anti sous-chaîne) ; la persona/inconnu reste inchangée.
+    assert not mod._override_scopes_reserve(
+        "Levée aussi de jsboige2.", "jsboige")
+    assert not mod._override_scopes_reserve(
+        "Levée aussi de jsboige-backup.", "jsboige")
+    assert not mod._override_scopes_reserve(
+        "Levée aussi de clusterManager-Myia.", "Myia")
+    assert mod._override_scopes_reserve("réserve Hermes levée", "jsboige")
+
+
 def test_14216_ignored_overrides_explique_le_scope_manquant():
     """#14216 — le rouge doit DIRE pourquoi l'override visible n'a rien
     éteint pour la réserve survivante (même exigence de nomination que


### PR DESCRIPTION
fix(guard,#15193): un login suivi d'un point (fin de phrase) matche la frontiere d'identite

Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/lean #15150 (c.327b)

## Symptome

`_override_scopes_reserve` (`scripts/check_unaddressed_nits.py`) construit la
frontiere d'identite du login ainsi :

```python
author_re = re.compile(r"(?<![A-Za-z0-9_.-])" + re.escape(nit_author)
                       + r"(?![A-Za-z0-9_.-])")
```

Le `.` est **dans** la classe du lookahead (et du lookbehind) negatif. Un
login suivi d'un point — donc **en fin de phrase** — ne matche jamais.
`finditer` ne rend aucune occurrence, `_scope_lifted_sentence` ne voie pas la
phrase, l'override est rejete.

## Pourquoi ca coute

Le diagnostic emis par l'organe lui-meme recommande cet idiome :

> une levee coordinatrice est scope par reserve ; la nommer dans une phrase de
> levee affirmative — « je leve aussi la reserve de <login> »

Ecrite telle quelle, la phrase se termine par le login. **Suivre la consigne a
la lettre produit un non-match** — et le message d'erreur redemande exactement
la forme qui vient d'echouer. Mesure sur #15049 : trois commentaires
d'override successifs, tous rejetes, avant que la cause soit isolee.

## Correctif

Retirer `.` des deux classes de frontieres, en conservant `-` :

```python
author_re = re.compile(r"(?<![A-Za-z0-9_-])" + re.escape(nit_author)
                       + r"(?![A-Za-z0-9_-])")
```

- `.` exclu : un login suivi d'un point (fin de phrase) est une frontiere
  d'identite **legitime** et doit matcher.
- `-` conserve : protege la sous-chaine (`Myia` dans `clusterManager-Myia` —
  test `test_14216_unite_scope_login_persona_et_anonyme`).
- alnum/`_` conserves : anti `jsboige2` / `jsboige_x`.

## Preuve (offline, contre le code de l'organe)

| Corps du commentaire | `_override_scopes_reserve(...,'jsboige')` |
|---|---|
| `… je leve aussi la reserve de jsboige.` — **l'idiome recommande** | `True` (etait `False`) |
| `… je leve aussi la reserve de jsboige elle-meme.` | `True` (inchangé) |
| `… je leve aussi la reserve de jsboige, posee a 23:11Z.` | `True` (inchangé) |
| `… je leve aussi la reserve de jsboige2.` | `False` (anti sous-chaine) |
| `… je leve aussi la reserve de jsboige-backup.` | `False` (anti sous-chaine) |
| `… je leve aussi la reserve de clusterManager-Myia.` (`'Myia'`) | `False` (anti sous-chaine) |
| `reserve Hermes levee` (persona alias) | `True` (inchangé) |

## Validation

- `python -m pytest scripts/tests/test_check_unaddressed_nits.py` : **387 passe**
- `python -m pytest scripts/tests/test_check_unaddressed_nits_{dismissal,followup,hold,mention,unevaluated}.py` : **102 passe**
- **489 tests verts**, 0 regression. Nouveau `test_15193_login_suivi_du_point_matche`
  reproduit le bug (etait `False`) et le leve apres fix.

## Note genre (G-VAR-1)

Grain `guard` = classe **META** : ne tient pas a lui seul le plancher
G-VAR-1 (pas de capacite CONTENU livree). Toutefois il s'attaque a la cause
racine de la PR rouge #15073 de cette lane (organe qui refusait la levee
F1/F2 nommee) et aide toutes les lanes (surcharge d'overrides rejetes). Le
grain CONTENU qui portera le prochain cycle de cette lane est nomme dans le
rapport de cycle : **#15176** (Lean ProgramGames L1, noyau borne).

## Cross-reference

- #15193 — issue ai-01 (coordinateur) : diagnostic + mesure offline, **cloturee par cette PR**
- #15073 — PR rouge de cette lane dont le blocage est (en partie) cette surcharge d'override refuse par l'organe
- #15049 — mesure du cout reel (3 overrides rejetes)

Closes #15193
