### PR TITLE
fix(ci,#15152): derive the 3 runner name prefixes from the hostname

### DIFF
--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -73,7 +73,14 @@ set -uo pipefail
 REPO="${COURSIA_RUNNER_REPO:-jsboige/CoursIA}"
 IMAGE="${COURSIA_RUNNER_IMAGE:-coursia-linux-runner:2.337.0}"
 LABELS="${COURSIA_RUNNER_LABELS:-self-hosted,coursia-ephemeral,coursia-linux}"
-NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-myia-po-2024-linux-docker}"
+# #15152 : le defaut des trois prefixes etait le nom d'UNE machine
+# (myia-po-2024) -- tout autre hote s'enregistrait cote GitHub sous
+# l'identite de po-2024 : inventaire menteur (un coordinateur attribue le
+# travail a la mauvaise machine) et collision de noms si po-2024 remonte
+# ses propres runners. Le defaut se derive de l'hote ; les surcharges
+# explicites par famille restent disponibles et prioritaires.
+MACHINE_ID="${COURSIA_RUNNER_MACHINE_ID:-$(hostname | tr 'A-Z' 'a-z')}"
+NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-${MACHINE_ID}-linux-docker}"
 STATE_DIR="${COURSIA_RUNNER_STATE_DIR:-$HOME/.coursia-runner}"
 STOP_FILE="$STATE_DIR/stop"
 
@@ -114,7 +121,7 @@ WORK_MOUNT="${COURSIA_RUNNER_WORK_MOUNT:-/home/runner/_work}"
 # de volume toolcache/_work : aucun job d'execution ne doit leur atterrir,
 # le gate bascule dessus uniquement (item B, ai-01).
 WAITER_LABELS="${COURSIA_RUNNER_WAITER_LABELS:-self-hosted,coursia-waiter}"
-WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-myia-po-2024-linux-waiter}"
+WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-${MACHINE_ID}-linux-waiter}"
 WAITER_CPUS="${COURSIA_RUNNER_WAITER_CPUS:-1}"
 WAITER_MEMORY="${COURSIA_RUNNER_WAITER_MEMORY:-1g}"
 WAITER_PIDS="${COURSIA_RUNNER_WAITER_PIDS:-128}"
@@ -138,7 +145,7 @@ WAITER_TOOLCACHE="${COURSIA_RUNNER_WAITER_TOOLCACHE:-1}"
 # survivent aux conteneurs, lake build devient incremental.
 LEAN_IMAGE="${COURSIA_LEAN_RUNNER_IMAGE:-coursia-lean-runner:2.337.0}"
 LEAN_LABELS="${COURSIA_LEAN_RUNNER_LABELS:-self-hosted,coursia-ephemeral,coursia-lean}"
-LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-myia-po-2024-lean-docker}"
+LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-${MACHINE_ID}-lean-docker}"
 LEAN_WORK_VOLUME_PREFIX="${COURSIA_LEAN_RUNNER_WORK_VOLUME_PREFIX:-coursia-runner-work-lean}"
 # 2 slots * 6 cpus = 12 des 16 coeurs au pire ; l'hote workstation prime
 # (cf CONTRAINTE en tete de fichier) -- baisser N ou les caps si la machine

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -683,6 +683,80 @@ echo "Test 19 : cmd_stop rend != 0 quand le sentinel n'a PAS pu etre pose (#1509
 )
 echo ""
 
+# --- Test 20 : prefixes derives de l'hote, pas po-2024 en dur (#15152) ------
+# Le defaut historique des trois prefixes etait le nom d'UNE machine
+# (myia-po-2024) : tout autre hote s'enregistrait sous l'identite de po-2024.
+# On stubbe `hostname` (MAJUSCULES volontaires : la derivation doit passer
+# le tr 'A-Z' 'a-z') et on verifie les trois familles + les surcharges.
+echo "Test 20 : les 3 prefixes se derivent du hostname, surcharges intactes (#15152)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  unset COURSIA_RUNNER_NAME_PREFIX COURSIA_RUNNER_WAITER_NAME_PREFIX \
+        COURSIA_LEAN_RUNNER_NAME_PREFIX COURSIA_RUNNER_MACHINE_ID
+  cat > "$TEST_DIR/bin/hostname" <<'STUB'
+#!/usr/bin/env bash
+echo "MYIA-TEST-99"
+STUB
+  chmod +x "$TEST_DIR/bin/hostname"
+  source_supervise
+
+  if [ "${MACHINE_ID:-}" = "myia-test-99" ]; then
+    ok "MACHINE_ID derive du hostname, majuscules normalisees (myia-test-99)"
+  else
+    ko "MACHINE_ID attendu myia-test-99, obtenu : ${MACHINE_ID:-vide}"
+  fi
+  if [ "${NAME_PREFIX:-}" = "myia-test-99-linux-docker" ]; then
+    ok "docker : NAME_PREFIX derive (myia-test-99-linux-docker)"
+  else
+    ko "docker : attendu myia-test-99-linux-docker, obtenu : ${NAME_PREFIX:-vide}"
+  fi
+  if [ "${WAITER_NAME_PREFIX:-}" = "myia-test-99-linux-waiter" ]; then
+    ok "waiter : WAITER_NAME_PREFIX derive (myia-test-99-linux-waiter)"
+  else
+    ko "waiter : attendu myia-test-99-linux-waiter, obtenu : ${WAITER_NAME_PREFIX:-vide}"
+  fi
+  if [ "${LEAN_NAME_PREFIX:-}" = "myia-test-99-lean-docker" ]; then
+    ok "lean : LEAN_NAME_PREFIX derive (myia-test-99-lean-docker)"
+  else
+    ko "lean : attendu myia-test-99-lean-docker, obtenu : ${LEAN_NAME_PREFIX:-vide}"
+  fi
+  case "$NAME_PREFIX$WAITER_NAME_PREFIX$LEAN_NAME_PREFIX" in
+    *myia-po-2024*)
+      ko "un prefixe porte encore po-2024 par defaut"
+      ;;
+    *)
+      ok "aucun des trois defauts ne porte po-2024"
+      ;;
+  esac
+
+  # Surcharges explicites : les trois env gardent la priorite sur la
+  # derivation (les wrappers persist/ s'appuient dessus, ex myia-ai-01-wsl).
+  export COURSIA_RUNNER_NAME_PREFIX="explicit-docker-20"
+  export COURSIA_RUNNER_WAITER_NAME_PREFIX="explicit-waiter-20"
+  export COURSIA_LEAN_RUNNER_NAME_PREFIX="explicit-lean-20"
+  source_supervise
+  if [ "${NAME_PREFIX:-}" = "explicit-docker-20" ]; then
+    ok "surcharge COURSIA_RUNNER_NAME_PREFIX prioritaire"
+  else
+    ko "surcharge docker ignoree, obtenu : ${NAME_PREFIX:-vide}"
+  fi
+  if [ "${WAITER_NAME_PREFIX:-}" = "explicit-waiter-20" ]; then
+    ok "surcharge COURSIA_RUNNER_WAITER_NAME_PREFIX prioritaire"
+  else
+    ko "surcharge waiter ignoree, obtenu : ${WAITER_NAME_PREFIX:-vide}"
+  fi
+  if [ "${LEAN_NAME_PREFIX:-}" = "explicit-lean-20" ]; then
+    ok "surcharge COURSIA_LEAN_RUNNER_NAME_PREFIX prioritaire"
+  else
+    ko "surcharge lean ignoree, obtenu : ${LEAN_NAME_PREFIX:-vide}"
+  fi
+
+  # Le stub hostname ne doit pas fuir sur un futur test ajoute apres celui-ci.
+  rm -f "$TEST_DIR/bin/hostname"
+)
+echo ""
+
 # --- Verdict agrege ---------------------------------------------------------
 # `|| echo 0` serait un piege ici, et il l'a ete : `grep -c` IMPRIME "0" avant
 # de sortir 1 quand il ne trouve rien, donc le repli SUFFIXE un second zero au


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/docs #15174

## Le defaut

`supervise.sh` codait en dur `myia-po-2024` comme defaut des TROIS prefixes de nom de runner (docker, waiter, lean) : sur toute machine autre que po-2024, les runners s'enregistraient cote GitHub sous l'identite de po-2024 -- inventaire menteur (mesure ai-01 2026-09-08 : `myia-po-2024-linux-docker-1 online` etait un runner d'ai-01) et risque actif de collision (po-2024 a 7 runners a l'arret en attente de redemarrage).

## Fix (supervise.sh)

```bash
MACHINE_ID="${COURSIA_RUNNER_MACHINE_ID:-$(hostname | tr 'A-Z' 'a-z')}"
NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-${MACHINE_ID}-linux-docker}"
WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-${MACHINE_ID}-linux-waiter}"
LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-${MACHINE_ID}-lean-docker}"
```

Une seule source de verite. Les trois surcharges explicites restent disponibles et prioritaires -- les wrappers `persist/` s'appuient dessus (`myia-ai-01-wsl`, `myia-ai-01-linux-waiter`, po-2024 docker) et ne changent PAS de comportement.

## Acceptance (issue #15152)

- [x] **start sans env sur un hote != po-2024 --> prefix = cette machine** : derivation Test 20 ; l'enregistrement GitHub suit le cablage existant `-e ACTIONS_RUNNER_INPUT_NAME="$name"` (lignes non modifiees).
- [x] **les trois familles couvertes** : Test 20 asserte les trois prefixes derives exacts.
- [x] **test hostname -> trois prefixes attendus** : Test 20 -- hostname stubbe en MAJUSCULES (`MYIA-TEST-99`), la derivation doit passer le `tr 'A-Z' 'a-z'` et rendre `myia-test-99-{linux-docker,linux-waiter,lean-docker}` + garde "aucun des trois defauts ne porte po-2024".
- [x] **aucun script de deploiement ne depend du defaut po-2024** : verifie (table ci-dessous).

## Verification des surfaces de deploiement (criterion 4)

| Surface | Verdict |
|---|---|
| `persist/coursia-runner-start.sh:24` (wrapper po-2024) | export EXPLICITE = surcharge, pas dependance du defaut -- inchange et correct (il epingle la machine qu'il deploie) |
| `persist/ai-01/coursia-runner-start.sh:69` | export explicite `myia-ai-01-wsl` -- surcharge prioritaire, inchange |
| `persist/coursia-waiters-start.sh` | export explicite `myia-ai-01-linux-waiter` -- surcharge, inchange |
| `persist/launch-runner.sh` | generique : `HOLDER_NAME` se derive DEJA de `$(hostname)` -- meme esprit que ce fix |
| `persist/hold-runner.ps1` | parametrique (`Distro`/`Service`) ; les copies hardcodees sont host-side (`hold-myia-po-2024.ps1`), hors repo |
| tache planifiee `CoursIA-LinuxRunners-Boot` | host-side (persist/README.md l.57) ; passe par le holder -> service -> wrapper qui exporte explicitement |
| workflows `.github/` | routage par LABEL (`coursia-linux`/`coursia-waiter`/`coursia-lean`), jamais par nom de runner -- renommer ne casse aucun routage |

## Tests

**Test 20** (nouveau, 8 assertions) : derivation hostname + normalisation majuscules, les trois prefixes exacts, aucun po-2024 residuel, les trois surcharges explicites prioritaires.

- **Rouge** sur le code d'origine : `42 PASS / 5 FAIL` (les 5 FAIL = exactement la signature du bug : les trois defauts po-2024 + MACHINE_ID absent + garde residuelle).
- Note harnais : la 1re version du test mourrait en SILENCIEUX sur `MACHINE_ID: unbound variable` (le `set -u` herite du sourcing abortait le sous-shell AVANT toute assertion, et le harnais se declarait vert 39/0) -- assertions gardees `${VAR:-}`, le FAIL est desormais enregistre.
- **Vert** apres fix : `47 PASS / 0 FAIL`, stable x3. `bash -n` OK sur les deux fichiers (shellcheck absent de la machine, comme constate sur #15166).

Note rebase : #15166 ajoute les tests 20-28 au meme harnais (non merge au moment de cette PR) -- si elle merge en premier, la renumerotation de ce Test 20 est le seul conflit, trivial.

## Gestes ops restants (non commettables dans une PR)

Les runners deja enregistres sous `myia-po-2024-*` se re-enregistrent sous le nom derive au prochain redemarrage de leur superviseur (ephemeres : sans perte, cf issue). Les inscriptions mortes resteront visibles offline cote GitHub jusqu'a purge `gh api` -- geste ai-01. **Aucun restart/deploy/quota effectue par cette PR** (contrainte worker).

Closes #15152
