### PR TITLE
fix(genai,#15035): PT-04 corrige l'exemple d'avantage GRPO [0.41,-0.82] -> [1,-1] (zero-mean)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
@@ -160,7 +160,7 @@
     "- $y_3$ : \"x = 2, verification : 2*2+3=7\" → reward 1.0 (correct + raisonnement)\n",
     "- $y_4$ : \"je ne sais pas\" → reward 0.0 (refusal)\n",
     "\n",
-    "Avantages : $\\hat{A} = [0.41, -0.82, 0.41, -0.82]$. Le modèle apprend a preferer $y_1$ et $y_3$, eviter $y_2$ et $y_4$."
+    "Avantages : $\\mu_G = 0.5$, $\\sigma_G = 0.5$, d'ou $\\hat{A} = [1.0, -1.0, 1.0, -1.0]$. Le modèle apprend a preferer $y_1$ et $y_3$, eviter $y_2$ et $y_4$."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #15212

Discovered and verified by Astra A: CONFIRMED_PEDAGOGY

See #15035

## Finding (decouvert independamment, reproduit firsthand)

`PT_04_grpo_deepseek_r1.ipynb`, cellule markdown `c072bf6b` (section « 2. Mathematiques du GRPO », exemple calcule « Intuition geometric », rewards [1, 0, 1, 0]) :

- **Commis** : `Â = [0.41, -0.82, 0.41, -0.82]`
- **Correct** : `mu_G = 0.5`, `sigma_G = 0.5`, d'ou `Â = [1.0, -1.0, 1.0, -1.0]`

Preuve d'erreur (deux jambes independantes) :

1. **Propriete zero-mean** : tout avantage normalise `(r - mu)/c` est zero-mean par construction, quelle que soit la constante `c` (population, ddof=1, batch…). La serie commise somme a `-0.82 != 0` — impossible pour cette famille de formules.
2. **Re-calcul exhaustif des variantes** :
   - formule population imprimee par la cellule 4 du notebook lui-meme (pseudocode DeepSeekMath, `sigma = sqrt(mean((r - mu)^2))`) : `sigma_G = 0.5` → `Â = [1, -1, 1, -1]` ;
   - variante torch `std` ddof=1 (defaut TRL) : `sigma = 0.577` → `Â = [0.866, -0.866, ...]`.
   Aucune des deux ne produit `[0.41, -0.82]` (0.41/0.5 asymetrique, non multiple d'aucun facteur coherent).

Corroboration interne : le « Piege 5 » du meme notebook enseigne que dans un groupe binaire equilibre, les avantages sont « des +1 ou -1 en pratique » — la correction aligne l'exemple calcule sur le piege documente par le notebook lui-meme.

Portee pedagogique : cellule du livrable cle GRPO — l'exemple d'avantage est la premiere manipulation concrete de `Â = (r - mu_G)/sigma_G`, la formule centrale du notebook.

## Fix

1 ligne, markdown-only, dans la cellule `c072bf6b` : remplace les valeurs fausses par `mu_G = 0.5`, `sigma_G = 0.5`, `Â = [1.0, -1.0, 1.0, -1.0]` (les valeurs `mu_G`/`sigma_G` deviennent explicites — l'exemple montre maintenant les deux etapes du calcul). Diff : 1 insertion / 1 deletion, aucun autre fichier.

## Verdict SOTA

Non-applicable au sens degraded-output (aucune substitution d'outil) : correction markdown-only qui preserve les **outputs reels du run CPU-safe commis** (CUDA=False, cellules training 23/25 avec outputs de skip) — regles C.2/C.3 : une modification markdown-only ne reclame pas de re-execution, et aucune sortie n'a ete fabriquee, degradee ou hand-editee.

## Oracle independant — qualifie et challenge

Script scratchpad oracle (hors repo) qui parse le notebook, extrait les rewards de l'exemple et re-calcule depuis la formule population :

- **Pre-fix failure** : valeurs commises `[0.41, -0.82, 0.41, -0.82]` != oracle `[1, -1, 1, -1]`, somme = -0.82 != 0 → l'oracle echouait sur l'etat commis (preuve qu'il detecte le defaut).
- **Post-fix PASS** : rewards parses `[1.0, 0.0, 1.0, 0.0]`, stated `[1.0, -1.0, 1.0, -1.0]`, oracle `[1.0, -1.0, 1.0, -1.0]`, MATCH: True, somme zero-mean = 0.0, mu/sigma stated = mu/sigma recalcules (0.5/0.5).
- **Mutation negative (anti-hardcodage)** : rewards `[1,1,0,0]` → oracle `[1, 1, -1, -1]` != valeurs corrigees — l'oracle n'est pas calibre pour repondre True inconditionnellement.
- **Cas limite** : rewards tous nuls → sigma = 0 → None (cas sans signal, conforme au garde `sigma + eps` du pseudocode de la cellule 4).

## Validation post-fix (relancee sur l'artefact corrige)

- `python scripts/notebook_tools/validate_pr_notebooks.py origin/main MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb`
  → `Notebook PR Validation: 1/1 passed` · `Total code cells checked: 13` · `PASS MyIA.AI.Notebooks\GenAI\PostTraining\PT_04_grpo_deepseek_r1.ipynb (13 cells) [coursia-ml-training]` · `All notebooks passed validation.`
- `python scripts/notebook_tools/check_papermill_ratchet.py origin/main` → PASS (ratchet outputs/metadata respecte : markdown-only, outputs inchanges)
- Ratchet source↔outputs, `detect_markdown_rendering.py --check --baseline`, `detect_code_in_markdown_cells.py --check --baseline` → PASS
- C.1 : `grep -E "raise NotImplementedError|assert False|1/0"` → 0 occurrence
- Compteurs post-fix : cells_total=31, cells_code=13, cells_executable=13, cells_parameters=1 (cellule 0 `BATCH_MODE`), null_exec=0, outputs_error=0
- Pre-commit hooks (gitleaks, H.3, probeAddresses scrub, #13326) : tous Passed au commit
- Regression grep : l'ancienne valeur `[0.41, -0.82` n'apparait plus nulle part dans le repo

## Deconfliction

- BASE_HEAD d54f8053b7c80b57663d3f032c6f76a44119b14f verifie a la Fence 1, Fence 2 et Fence 3 (HEAD = origin/main, aucun drift)
- Aucune PR ouverte n'intersecte `MyIA.AI.Notebooks/GenAI/PostTraining/` (re-verifie a la Fence 3)
- Reservation union #15035 (comment 5591616210) : `check_lane_claim.py 15035 --lane myia-po-2025:CoursIA-2 --paths <PT_04>` → `CLEAR` (my_active_claim, blocking_lanes=[], PT_04 libre)

## Scope et limites

- 1 notebook (PT_04), 1 ligne — correction atomique unique conformement au contrat Astra (1 agent = 1 notebook = 1 PR)
- Les autres findings de l'audit PT_01–PT_06 (prose stale PT_02, leak cwd PT_03, claims-vs-skip-outputs PT_05, observations PT_01/PT_06) sont reportes au coordinateur en issue-ready — aucun n'est corrige ici ; PT_03/PT_05 requierent une re-execution GPU (RECOVERABLE-MACHINE)
- Les outputs du run CPU commis sont conserves tels quels : la correction markdown ne touche aucune cellule code, donc aucune re-execution due (C.2 exception markdown-only, C.3 : 0 cellule code modifiee)


## Dénominateurs exacts et matrice acceptance ↔ diff

Dénominateurs recomptés indépendamment sur le head `be835359` : `cells_total=31`, `cells_code=13`, `cells_executable=13`, `cells_output_bearing=12`, `cells_parameters=1` (cellule taguée `injected-parameters`), `outputs_error=0`. La cellule Parameters est exécutée mais ne porte aucun output ; ces deux dénominateurs ne sont pas substituables.

| Critère d’acceptation | Diff/hunk ou preuve exacte | État | Contre-vérification |
|---|---|---|---|
| Reproduire le défaut mathématique | Cellule `c072bf6b`, ancienne série `[0.41,-0.82,0.41,-0.82]` | PASS | Somme `-0.82`; incompatible avec toute normalisation centrée affichée |
| Corriger par la formule du notebook | Même cellule, `mu_G=0.5`, `sigma_G=0.5`, `[1,-1,1,-1]` | PASS | Recalcul indépendant depuis rewards `[1,0,1,0]` |
| Un notebook et un hunk cohérent | 1 fichier, 1 insertion/1 suppression Markdown | PASS | Diff GitHub complet ; seule la source de `c072bf6b` diffère |
| Préserver code et artefacts exécutés | Aucun hunk code/output/metadata | PASS | Hashes code, outputs, execution counts et métadonnées identiques base→head |
| Oracle non tautologique | Recalcul population + propriété zero-mean | PASS | Pré-fix rejeté ; mutation `[1,1,0,0]` produit `[1,1,-1,-1]`, distincte du résultat corrigé |
| Validation post-fix | Validateurs listés ci-dessus | PASS | `validate_pr_notebooks` 1/1 ; ratchets et guards sans régression rapportée |
| Déconfliction | PT_04 uniquement | PASS au snapshot | 0 autre PR ouverte intersectant ce path ; head basé sur `d54f8053` |
