### PR TITLE
fix(genai,#15035): module 02 OWUI — prose/spec fidelity + v0.11 currency (RBAC, extrait admin, note C.3)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/02-navigation-authentification/02-Navigation-Auth-QA-OWUI.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/02-navigation-authentification/02-Navigation-Auth-QA-OWUI.ipynb
@@ -236,22 +236,30 @@
     "| Route | Section | Accès |\n",
     "|-------|---------|-------|\n",
     "| `/` , `/c/{id}` | Chat (nouvelle / existante conversation) | Utilisateur connecté |\n",
-    "| `/admin` , `/admin/settings` | Panneau admin & réglages globaux | **Admin uniquement** |\n",
-    "| `/workspace/*` | Bases de connaissances, modèles, prompts, fonctions | Utilisateur connecté |\n",
+    "| `/admin` | Panneau admin — liste des utilisateurs | **Admin uniquement** |\n",
+    "| `/admin/settings` | Réglages — **v0.11** : redirige vers `/`, les réglages vivent dans une fenêtre à onglets (page distincte jusqu'à la v0.10) | **Admin uniquement** |\n",
+    "| `/workspace/*` | Bases de connaissances, modèles, prompts | Utilisateur connecté |\n",
+    "| `/admin/functions` | Fonctions (plugins : filtres, actions, outils) — gérées côté admin | **Admin uniquement** |\n",
     "| `/channels` | Canaux de discussion collaboratifs | Utilisateur connecté |\n",
     "\n",
-    "Regardons le **test d'accès admin** — il illustre deux gestes clé : la navigation (`goto`) et l'assertion **localisée** (le libellé du titre dépend de la langue de l'interface) :\n",
+    "Regardons le **test d'accès admin** (code réel du spec, annoté) — il illustre la navigation (`goto`), l'assertion **localisée** (le libellé dépend de la langue de l'interface) et l'assertion de **donnée** (la table est rendue) :\n",
     "\n",
     "```ts\n",
     "test('acceder au panneau admin — liste des utilisateurs', async ({ page }) => {\n",
     "  await page.goto('/admin');                       // 1. naviguer vers la route admin\n",
-    "  await expect(page.getByRole('heading',           // 2. localiser + asserter\n",
-    "        { name: /utilisateurs|users/i }))          //    (libellé FR ou EN — robuste au drift)\n",
-    "        .toBeVisible();\n",
+    "\n",
+    "  // 2. assertion localisée : « Utilisateurs » (FR) ou « Users » (EN) —\n",
+    "  //    .or() accepte les deux, robuste au drift de traduction\n",
+    "  await expect(\n",
+    "    page.getByText('Utilisateurs').or(page.getByText('Users')).first()\n",
+    "  ).toBeVisible({ timeout: 15_000 });\n",
+    "\n",
+    "  // 3. assertion de donnée : la table des utilisateurs est bien rendue\n",
+    "  await expect(page.locator('table')).toBeVisible({ timeout: 15_000 });\n",
     "});\n",
     "```\n",
     "\n",
-    "Deux leçons : (1) **`goto('/admin')`** suffit — si le `storageState` est valide et le rôle admin, on arrive ; sinon, SvelteKit redirige (le test échoue proprement). (2) **`/utilisateurs|users/i`** accepte les deux langues : un sélecteur multilingue résiste au drift de libellé entre versions — c'est exactement le réflexe anti-casse qu'on cherche."
+    "Deux leçons : (1) **`goto('/admin')`** suffit — si le `storageState` est valide et le rôle admin, on arrive ; sinon, SvelteKit redirige (le test échoue proprement). (2) **`.or()` accepte les deux langues** : un sélecteur multilingue résiste au drift de libellé entre versions — c'est exactement le réflexe anti-casse qu'on cherche. Et l'assertion ne s'arrête pas au titre : vérifier la **table** confirme que la page a réellement chargé ses données, pas seulement son en-tête."
    ]
   },
   {
@@ -694,9 +702,9 @@
     "\n",
     "➡️ **Étape 3 — [Module 03 : Chat & Streaming](../03-chat-streaming/).** Tu y attaqueras le cœur métier : le chat IA en streaming, son non-déterminisme, et les assertions tolérantes qui vont avec.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
-    "> **Note de reproductibilité (C.3).** Les cellules de ce notebook ont été exécutées hors-ligne : lecture du `.spec.ts`, inventaire `--list` (sans navigateur) et démonstrations pure-Python. Aucune ne requiert d'instance Open WebUI ni de secret. L'exécution **live** des tests E2E (navigateur + plateforme) est volontairement différée au capstone et sera revalidée en Phase 3 (Open WebUI v0.9.6). Aucun claim de compatibilité v0.9.6 n'est porté par ce module."
+    "> **Note de reproductibilité (C.3).** Les cellules de ce notebook ont été exécutées hors-ligne : lecture du `.spec.ts`, inventaire `--list` (sans navigateur) et démonstrations pure-Python. Aucune ne requiert d'instance Open WebUI ni de secret. L'exécution **live** des tests E2E (navigateur + plateforme) est volontairement différée au capstone ; la suite a depuis été **revalidée sur la flotte v0.11.0** (campagne #9854, 2026-08-10), dont les pièges mesurés (redirection `/admin/settings`, payload chat) sont documentés dans [`WHATS-NEW-v0.11.md`](../WHATS-NEW-v0.11.md). Aucun claim de compatibilité au-delà de v0.11.0 n'est porté par ce module."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #15212

See #15035

Discovered and verified by corrective-auditor (Astra D, DISCOVERY): CONFIRMED_PEDAGOGY — prose-vs-spec fidelity + version currency sur le notebook du module 02.

## Périmètre (AUDIT_SCOPE → PATHS gelés)

Audit discovery des six modules Playwright-OWUI (01-06). Un seul notebook sélectionné pour correction : `02-Navigation-Auth-QA-OWUI.ipynb` (seul à cumuler les quatre findings ; les 01/03/04/05/06 sont sains sur ces axes). Édition markdown uniquement — outputs préservés (exception C.3). Specs/READMEs/helpers = preuve en lecture seule, jamais édités.

## Findings (tous reproduits firsthand)

### F1 — Extrait du test admin inventé (CONFIRMED_PEDAGOGY)
Le notebook §3 présentait sous le titre réel du test un extrait `getByRole('heading', { name: /utilisateurs|users/i })`. Le spec réel (`02-navigation-auth.spec.ts:56-66`) utilise `page.getByText('Utilisateurs').or(page.getByText('Users')).first()` **plus** une assertion sur la `table`. Le CONCEPT déclaré par le spec lui-même (« On utilise .or() pour accepter les deux ») n'était pas celui enseigné.
**Fix** : extrait remplacé par le code réel du spec — vérifié par script : 7/7 lignes substantives identiques (seuls les commentaires pédagogiques diffèrent). La leçon porte désormais sur `.or()` + l'assertion de donnée (table), conformes au spec.

### F2 — Table RBAC stale pour v0.11 (CONFIRMED, monnaie de version)
La table présentait `/admin/settings` comme page admin active et les « fonctions » sous `/workspace/*`. Or :
- depuis **v0.11**, `/admin/settings` **redirige vers `/`** (réglages = fenêtre à onglets) — triple preuve indépendante : (a) spec TEST 3 réécrit avec `waitForURL` hors `/admin/settings` + chronologie mesurée au 2026-08-07 ; (b) `WHATS-NEW-v0.11.md` §1 (même chronologie 4,3 s/7,5 s/10,7 s) ; (c) `helpers/selectors.ts` SETTINGS « VERIFIE firsthand contre v0.11.0 fr-FR (2026-08-07) ».
- les fonctions sont gérées côté admin : le spec TEST 7 navigue `/admin/functions` (« Elles sont gerees par l'admin »), pas `/workspace/functions`.
**Fix** : table actualisée — `/admin/settings` documenté comme redirection v0.11 (page distincte jusqu'à v0.10, tolérance conservée comme dans le spec), ligne dédiée `/admin/functions`, `fonctions` retirée de `/workspace/*`.

### F3 — Note de reproductibilité périmée (CONFIRMED)
La note finale promettait une revalidation « Phase 3 (Open WebUI v0.9.6) ». La campagne **#9854 (2026-08-10)** a déjà revalidé les modules 01-06 contre **v0.11.0** (README série + `WHATS-NEW-v0.11.md` : « La campagne de revalidation est déjà faite »).
**Fix** : note actualisée — revalidation v0.11.0 faite, lien vers `WHATS-NEW-v0.11.md`, claim de compatibilité borné à v0.11.0.

### Seed H02 (advisory) — disposition
Le compteur de 00-Parcours et son défaut de classification sont hors PATHS (exclusion #15146 active sur `00-Parcours-QA-OWUI.ipynb`) : non patchés ici. La leçon a été appliquée — aucune confiance aux comptes agrégés : tous les dénominateurs (4/8/7/7/8/7 tests par module, 5 « exercices embarqués » module 03, etc.) ont été recomptés mécaniquement depuis les specs, et les outputs d'inventaire committés (réels pour 01 et 06, repli honnête « node_modules absent » pour 02-05) ont été confrontés aux fichiers.

## Déconfliction (3 clôtures)
- HEAD de branche = BASE_HEAD `d54f8053b7c80b57663d3f032c6f76a44119b14f` = `origin/main` au moment de l'audit.
- Seule PR ouverte touchant Playwright-OWUI : #15146 (`00-Parcours` seul, exclu, aucune intersection avec mon path).
- `check_lane_claim.py 15035` : `blocking_lanes: []` ; claim union (commentaire 5591616210, 2026-09-08T20:44:30Z) couvre 01-06 pour ma lane ; claim de rétrécissement posé au nom de la lane avant édition : [#15035 (commentaire 5591743931)](https://github.com/jsboige/CoursIA/issues/15035#issuecomment-5591743931).

## Validation post-fix (relancée après le dernier commit `4d2ef5fd2`)
- `nbformat.validate` : OK.
- `audit_c1_c3.py --family GenAI` : 0 violation (217 notebooks).
- `validate_pr_notebooks.py` : 1/1 PASS (8 cellules code, exec_count tous non-null, 0 erreur).
- `check_papermill_ratchet.py origin/main` : 1 notebook changé, 0 régression (BLOCK_REMOVED = canonicalisation `---`→`***` par le pre-commit `fix-hr-separator`, auto-fix accepté).
- `detect_markdown_rendering.py --check` : 0 nouvelle erreur ERROR.
- Diff : 2 cellules markdown touchées, 0 cellule code, 0 output modifié → outputs réels préservés (C.3 markdown-only).
- Fidélité de l'extrait : comparaison scriptée notebook↔spec, 7/7 lignes substantives identiques.

## Dénominateurs exacts (mesurés sur le HEAD `4d2ef5fd2`, script JSON)

**19 cellules totales** · **8 code** (toutes exécutables, `execution_count` non-null, **8/8 porteuses d'outputs**) · 11 markdown · **0 cellule parameters** (aucun tag papermill) · **0 output d'erreur** · 0 exec null · 0 output vide. Diff : 2 cellules markdown touchées, 0 cellule code, 0 output modifié.

## Matrice acceptance ↔ diff ↔ counter-check (contrat Astra)

| Acceptance (critère du contrat) | Diff (hunk/livrable) | Counter-check (commande + résultat) |
|---|---|---|
| Reproduction firsthand avant correction | MD cell 5 (table + extrait) et MD cell 18 (note) — 3 segments réécrits | Lecture directe `02-navigation-auth.spec.ts:56-66` + TEST 3 (l.103-121) + TEST 7 (l.175-185) ; `WHATS-NEW-v0.11.md` §1 ; `helpers/selectors.ts:122-157` |
| Seed disposition (H02, advisory) | Aucun diff sur `00-Parcours` ni sur le compteur | Exclusion vérifiée : #15146 seule PR ouverte sur Playwright-OWUI (00-Parcours seul) ; dénominateurs des 6 modules recomptés depuis les specs (4/8/7/7/8/7) |
| Un notebook maximum | 1 fichier, +17/−9 | `git diff --stat` : 1 fichier ; `gh pr view 15251 --json files` : 1 path |
| Dénominateurs exacts | Aucun changement de cellule code/output | Scan JSON sur HEAD : 19 cellules, 8 code, 8/8 output-bearing, 0 parameters, 0 erreur |
| Pivots indépendants (oracle independence) | Hunk table RBAC | 4 oracles croisés : spec TEST 3 (`waitForURL` hors `/admin/settings`), WHATS-NEW-v0.11 §1 (chronologie mesurée 4,3/7,5/10,7 s), `selectors.ts` SETTINGS (« VERIFIE firsthand v0.11.0 »), spec TEST 7 (`goto('/admin/functions')`) |
| Types d'assertion / fidélité de l'extrait | Hunk extrait admin | Script de comparaison notebook↔spec : **7/7 lignes substantives identiques** (seuls les commentaires pédagogiques diffèrent) |
| Mutation négative / challenge pre-fix | — (aucun diff : tentatives de falsification, toutes survécues) | F1 : pas de label « simplifié/adapté » sous le titre réel du test ; F2 : aucun qualificatif de version dans la table d'origine ; F3 : revalidation #9854 postérieure à la promesse « Phase 3 v0.9.6 » |
| Validation réelle post-fix (relancée après le dernier commit) | — | `nbformat.validate` OK · `validate_pr_notebooks` 1/1 PASS (8 cellules) · `check_papermill_ratchet origin/main` 0 régression · `audit_c1_c3 --family GenAI` 0/217 · `detect_markdown_rendering` 0 nouvelle erreur |
| False/already-covered → pas de patch | Aucun diff sur notebooks 01/03/04/05/06 | Scans mécaniques (exec/outputs/erreurs) + lecture complète : sains sur les axes audités ; FP documentés (nb 03 prose « stable », nb 04 arithmétique instance-dépendante) |
| Cross-file/systémique → issue-ready seulement | F3 résiduel : note v0.9.6 stale dans 01/03/04/05 | Hors PATHS gelés (contrainte 1 notebook) — grain dupliquable documenté en Limites, à dispatcher par le coordinateur |

## Limites
- Les notes de reproductibilité stale « v0.9.6 » persistent dans les notebooks 01/03/04/05 (hors PATHS gelés — un notebook max). Même grain duplicable par lane si le coordinateur le souhaite.
- L'exécution live des specs (Playwright + OWUI v0.11.0) requiert `.env` + credentials : non faite ici (RECOVERABLE-USER-HAND si exigée) ; la campagne #9854 du 2026-08-10 en fait foi côté plateforme.
- Verdict SOTA : la série exécute le vrai outil (Playwright) et le notebook assume honnêtement son rôle de couche pédagogique hors-ligne — SOTA-OK (aucune sortie dégradée committée).

## Livrable
1 fichier : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/Open-WebUI/Playwright-OWUI/02-navigation-authentification/02-Navigation-Auth-QA-OWUI.ipynb` (+17/−9).
