### PR TITLE
fix(genai): FT-01 prose re-ancree sur les sorties commitees -- 10 derives C.4/C.5 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -636,7 +636,7 @@
     "\n",
     "`Segments d'entrainement : 7` et `Dataset : 7 exemples`. Ce corpus est minuscule a dessein. Un fine-tuning complet sur 7 segments apprendrait surtout le bruit ; un LoRA a 294 912 parametres, lui, n'a **pas la capacite** de memoriser le corpus -- il ne peut capter que des regularites grossieres : longueur de phrase, ponctuation, champs lexicaux. C'est precissement ce qu'on veut pour un cours : l'etudiant voit la difference de style sans qu'un modele suffisamment puissant ne « triche » en recitant le corpus.\n",
     "\n",
-    "La contrepartie assumee : la generation de la section 5 montrera des repetitions (`(1) Le rue de Paris. (2) Le rue de Paris.`) -- signature typique d'un adaptateur sous-dimensionne entraîne sur peu de donnees. Distinguer « le style a ete transfere » de « la qualite du texte a ete amelioree » est l'un des apprentissages centraux de ce notebook."
+    "La contrepartie assumee : la generation de la section 5 montrera des repetitions (la boucle « l'une nouvelle, l'une nouvelle » du premier prompt) -- signature typique d'un adaptateur sous-dimensionne entraîne sur peu de donnees. Distinguer « le style a ete transfere » de « la qualite du texte a ete amelioree » est l'un des apprentissages centraux de ce notebook."
    ]
   },
   {
@@ -919,8 +919,8 @@
     "\n",
     "Trois lignes structurent la sortie :\n",
     "\n",
-    "- **`trainable params: 294,912 || all params: 124,734,720 || trainable%: 0.2364`** -- PEFT confirme la mesure de la section 3 (leger denominateur different : 124,7 M car il compte aussi les buffers de l'adaptateur). Seuls ces 0,24 % recoivent des gradients ; le reste du modele est gele.\n",
-    "- **`Perte finale : 5.0106`** -- sur 7 exemples, 10 epochs. Ce chiffre n'est **pas** une performance a etaler : il confirme surtout que l'optimisation a tourne sans diverger. Ce sera la valeur de reference de l'exercice 3.\n",
+    "- **`trainable params: 294,912 || all params: 124,734,720 || trainable%: 0.2364`** -- PEFT confirme la mesure de la section 3 (leger denominateur different : 124,7 M car il ajoute au total les 294 912 parametres de l'adaptateur). Seuls ces 0,24 % recoivent des gradients ; le reste du modele est gele.\n",
+    "- **`Perte finale : 5.0025`** -- sur 7 exemples, 10 epochs. Ce chiffre n'est **pas** une performance a etaler : il confirme surtout que l'optimisation a tourne sans diverger. Ce sera la valeur de reference de l'exercice 3.\n",
     "- **`Temps : ...`** -- sur RTX 3090 (runtime *machine-dep*), dix epochs sur GPT-2 en LoRA tiennent en une dizaine de secondes. C'est l'argument operationnel de LoRA : le meme budget en full fine-tuning devrait aussi porter les gradients et les etats d'optimiseur des 124 M parametres.\n",
     "\n",
     "Les avertissements (`GPU imbalance`, `NCCL`, `loss_type=None`) sont ceux d'une station multi-GPU heterogene -- ils documentent l'environnement, rien de l'entraînement lui-meme. La discipline de lecture : un warning s'explique avant de s'elimine."
@@ -965,7 +965,7 @@
     "\n",
     "L'évaluation naïve — prendre un seul prompt et comparer une génération du modèle original à une génération du modèle fine-tuné — est piégeuse. Elle confond deux effets : le changement de style induit par le fine-tuning, **et** le hasard de l'échantillonnage (top_p, temperature). Avec `temperature=0.8` et `do_sample=True`, deux appels successifs au même modèle sur le même prompt produisent des sorties différentes. Si on ne compare qu'une seule génération de chaque côté, on ne sait pas si l'écart observé est dû au fine-tuning ou au RNG.\n",
     "\n",
-    "La bonne pratique, appliquée ici, est de garder le prompt identique, la graine aléatoire aussi identique que faire se peut (Python `torch` est déterministe quand `seed=42` est fixé), et de ne faire varier qu'**un seul facteur** entre les deux côtés : la présence ou l'absence de l'adaptateur LoRA. C'est le seul design expérimental qui permet d'attribuer l'écart observé au fine-tuning.\n",
+    "La bonne pratique, appliquée ici : garder le prompt identique et les paramètres de génération identiques (`temperature=0.8`, `top_p=0.9`, `max_new_tokens=80`), et ne faire varier qu'**un seul facteur** entre les deux côtés : la présence ou l'absence de l'adaptateur LoRA. Une réserve honnête toutefois : la génération est échantillonnée (`do_sample=True`) et `generate_text` ne re-fixe pas la graine avant chaque appel — chaque côté est donc **un tirage unique**, pas une moyenne. L'écart observé est indicatif ; pour une isolation causale stricte, re-fixez `torch.manual_seed(...)` immédiatement avant chacun des deux appels.\n",
     "\n"
    ]
   },
@@ -991,7 +991,7 @@
     "|---|---|\n",
     "| que le **format** du corpus soit appris : phrases courtes et cadencées, ponctuation régulière, champ lexical resserré (rue, Paris, lune) | qu'un pastiche convaincant de Victor Hugo émerge |\n",
     "| que l'anglais du pré-entraînement recule au profit du français | que la grammaire, les accords ou le sens soient corrects |\n",
-    "| qu'un artefact de sous-dimensionnement apparaisse (la répétition `(1) Le rue de Paris.`) | qu'un texte fluide, varié et grammaticalement propre soit produit |\n",
+    "| qu'un artefact de sous-dimensionnement apparaisse (la répétition en boucle « l'une nouvelle ») | qu'un texte fluide, varié et grammaticalement propre soit produit |\n",
     "\n",
     "**Le critère de réussite atteignable à cette échelle est donc un critère de FORMAT, pas de contenu.** Ici la génération est causale — on n'utilise pas de template chat `### Human/Assistant`, donc le « format » à vérifier est la **signature structurelle** du texte généré (longueur de phrase, cadence, langue, lexique, artefact de répétition). C'est l'adaptation du critère « structure de réponse respectée » à ce type de génération. Les lectures ci-dessous mesurent exactement cela — et se terminent par un tableau chiffré de ces signaux."
    ]
@@ -1118,7 +1118,7 @@
     "\n",
     "Cote **original** : « l'amour d'un seul et de l'accérieur en France, l'un peut-etre la monde en France, l'ambassador sombre... » -- du francais approximatif, des accords inexistants, un effet salade de mots. GPT-2 small multilingual est un modele 124 M : son francais de surface est fragile.\n",
     "\n",
-    "Cote **fine-tune** : « les rues a la nouvelle a la lune. (1) Le rue de Paris. (2) Le rue de Paris. » -- la syntaxe reste approximative, mais trois choses ont change : les phrases sont **courtes**, la ponctuation **cadence** le texte (une phrase par ligne numerotee), et le vocabulaire s'est **resserre** sur le champ du corpus (rue, Paris, lune). C'est le transfert de style attendu d'un petit LoRA : il deplace la distribution vers les regularites du corpus sans ameliorer la grammaire de base. Juger un fine-tuning, c'est apprendre a lire cette difference pour ce qu'elle est."
+    "Cote **fine-tune** : « les rues à la nouvelle à la lune. Paris, l'une nouvelle, l'une nouvelle, l'une nouvelle, l'une nouvelle. » -- la syntaxe reste approximative, mais trois choses ont change : les phrases sont **courtes**, la ponctuation **cadence** le texte (une phrase par ligne), et le vocabulaire s'est **resserre** sur le champ du corpus (rues, Paris, lune) -- au prix d'une repetition en boucle typique d'un adaptateur sous-dimensionne. C'est le transfert de style attendu d'un petit LoRA : il deplace la distribution vers les regularites du corpus sans ameliorer la grammaire de base. Juger un fine-tuning, c'est apprendre a lire cette difference pour ce qu'elle est."
    ]
   },
   {
@@ -1220,12 +1220,12 @@
     "| Signal de format | Original (pré-entraîné) | Après LoRA (style Hugo) | Ce que ça dit |\n",
     "|---|---|---|---|\n",
     "| **Longueur de phrase** | phrases-salade enchaînées (« l'amour d'un seul et de l'accérieur en France, l'un peut-être la monde ») | phrases **courtes** et détachées (« les rues à la nouvelle à la lune. ») | le rythme du corpus est capté |\n",
-    "| **Cadence / ponctuation** | virgules en rafale, pas de découpage net | une **phrase par ligne** (2ᵉ prompt), parfois numérotée `(1)`, `(2)` | la structure du corpus est approchée |\n",
-    "| **Langue** | bascule en **anglais** en plein prompt français (« (I want you to see) ») | **entièrement français** (2ᵉ prompt) | le lexique du corpus a remplacé celui du pré-entraînement |\n",
+    "| **Cadence / ponctuation** | virgules en rafale, pas de découpage net | phrases **courtes et détachées**, une par ligne (1ᵉʳ prompt) | la structure du corpus est approchée |\n",
+    "| **Langue** | bascule en **anglais** en plein prompt français (« (I want you to see) ») | **français dominant**, l'anglais en recul net — un résidu anglophone affleure en fin de 2ᵉ prompt | le lexique du corpus déplace celui du pré-entraînement sans l'évacuer entièrement |\n",
     "| **Lexique du corpus** | champ large, hors corpus (« ambassador », « consommateurs ») | resserré sur le corpus (« rue », « Paris », « lune », « vie ») | le champ lexical cible émerge |\n",
-    "| **Artefact de sous-dimensionnement** | absent | **répétition** « (1) Le rue de Paris. (2) Le rue de Paris. » | signature d'un adaptateur sous-dimensionné sur 7 exemples |\n",
+    "| **Artefact de sous-dimensionnement** | absent | **répétition** en boucle « l'une nouvelle » (1ᵉʳ prompt), « leur leur » (2ᵉ prompt) | signature d'un adaptateur sous-dimensionné sur 7 exemples |\n",
     "\n",
-    "**Ce que la mesure confirme** : l'adaptateur a transféré le **format** (cadence, langue, lexique) et n'a **pas** transféré la maîtrise (grammaire, accords, sens — « le rue », « à la nouvelle à la lune »). Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le vérifie par ces cinq signaux, tous atteignables à cette échelle. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression)."
+    "**Ce que la mesure confirme** : l'adaptateur a transféré le **format** (cadence, langue, lexique) et n'a **pas** transféré la maîtrise (grammaire, accords, sens — « cette doute leur leur des mains »). Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le vérifie par ces cinq signaux — quatre nets, la langue en recul marqué sans être totale. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression)."
    ]
   },
   {
@@ -1242,14 +1242,14 @@
     "tags": []
    },
    "source": [
-    "### Lecture du resultat : la preuve la plus nette -- l'anglais a disparu\n",
+    "### Lecture du resultat : l'anglais recule tres nettement -- sans disparaitre tout a fait\n",
     "\n",
     "Ce deuxieme prompt donne la comparaison la plus parlante du notebook :\n",
     "\n",
     "- **ORIGINAL** : « Jean Valjean marchait dans la nuit **(I want you to see) It's the moment when the truth is revealed.** » -- le modele bascule en anglais au milieu d'un prompt francais, et enchaîne des restes de dialogues anglophones `(A) Vigour de vivre...`.\n",
-    "- **FINE-TUNE** : « ...a la vie est reponse une reputation des fois ne pas de la voiture, il vie en vie. Jusqu'il avait selon a la meme de la plus d'une faire... » -- imparfait, mais **entierement en francais**, avec une cadence de phrase longue typique du corpus Hugo.\n",
+    "- **FINE-TUNE** : « ...à la vie est réponse une réputation des fois en France, cette doute leur leur des mains, qui la comme de vie de la cette sommage. » -- imparfait, mais le **corps narratif reste en francais**, avec une cadence de phrase longue typique du corpus Hugo ; la generation se termine toutefois par un residu anglophone (« The question was: What were the effects of the French revolution... »).\n",
     "\n",
-    "Le prompt est identique, la graine et la temperature sont celles de la fonction `generate_text` : la seule difference entre les deux colonnes est l'adaptateur LoRA de 1,18 Mo. C'est la comparaison causale que la section 5 annoncait -- et la reponse est sans ambiguïte : **le style du corpus a ete transfere**, jusqu'a evacuer la langue du pre-entrainement."
+    "Le prompt est identique et les parametres de generation sont ceux de la fonction `generate_text` ; chaque cote reste neanmoins **un tirage echantillonne unique** (la graine n'est pas re-fixee avant chaque appel -- cf. la reserve de la section 5). La difference dominante entre les deux colonnes est l'adaptateur LoRA de 1,18 Mo : la generation passe durablement en francais la ou l'original basculait immediatement en anglais -- un transfert de style net, quoique non total (le residu anglophone final en temoigne)."
    ]
   },
   {
@@ -1562,7 +1562,7 @@
     "\n",
     "Le *learning rate* est l'hyperparametre le plus sensible du fine-tuning. Un LR trop faible = convergence lente, un LR trop eleve = divergence et degradation du modèle. Testez différentes valeurs pour trouver le point optimal.\n",
     "\n",
-    "**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale affichee etait de **5.0106** en **~13 s** sur RTX 3090 -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre."
+    "**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale mesuree est de **5.0025** (12,3 s sur la machine d'execution, valeur machine-dependante) -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre."
    ]
   },
   {
@@ -1621,19 +1621,19 @@
     "\n",
     "| Approche | Params entrainables | VRAM requise | Stockage adaptateur |\n",
     "|----------|--------------------:|-------------:|--------------------:|\n",
-    "| Full Fine-Tuning | 100% | 3-4x taille modèle | Modèle complet |\n",
-    "| Partial (2 couches) | ~5-15% | ~1.5x taille modèle | Couches modifiees |\n",
-    "| **LoRA (r=8)** | **~0.5%** | **~1.1x taille modèle** | **~2-5 Mo** |\n",
+    "| Full Fine-Tuning | 100 % (124 439 808) | 3-4x taille modèle | Modèle complet |\n",
+    "| Partial (2 couches) | **42,41 %** (52 773 120) | ~1.5x taille modèle | Couches modifiees |\n",
+    "| **LoRA (r=8)** | **0,24 %** (294 912) | **~1.1x taille modèle** | **1,18 Mo** |\n",
     "\n",
     "**Points cles** :\n",
     "- LoRA decompose la mise a jour en matrices de bas rang $B \\times A$ ou $r \\ll d, k$\n",
-    "- Seuls ~0.5% des paramètres sont entraines, mais la qualite reste proche du full fine-tuning\n",
+    "- Seuls 0,24 % des paramètres sont entraines (mesure section 3 ; `trainable%: 0.2364` cote PEFT), mais la qualite reste proche du full fine-tuning\n",
     "- Les adaptateurs sont portables : un seul modèle de base + N adaptateurs pour N tâches\n",
     "- Le rang $r$ contrôle le compromis expressivite/efficacite\n",
     "\n",
     "**Prochaines étapes** (FT-02) : LoRA sur un modèle plus grand avec quantization 4-bit (QLoRA).\n",
     "\n",
-    "**Ce que ce notebook a mesure, pas seulement annonce** : 124 439 808 parametres totaux pour GPT-2 ; 294 912 parametres entrainables en LoRA r=8 (0,24 %, `trainable%: 0.2364` cote PEFT) ; un adaptateur de **1,18 Mo** contre **497,8 Mo** pour le modele complet ; et une generation apres fine-tuning qui reste entierement en francais la ou le modele original laissait affleurer l'anglais. La suite logique est FT-02 : quantizer le modele de base en 4 bits (QLoRA) pour entrainer ces memes adaptateurs sur une fraction de la VRAM."
+    "**Ce que ce notebook a mesure, pas seulement annonce** : 124 439 808 parametres totaux pour GPT-2 ; 294 912 parametres entrainables en LoRA r=8 (0,24 %, `trainable%: 0.2364` cote PEFT) ; un adaptateur de **1,18 Mo** contre **497,8 Mo** pour le modele complet ; et une generation apres fine-tuning majoritairement en francais -- l'anglais du pre-entrainement y recule tres nettement sans etre evacue totalement -- la ou le modele original basculait en anglais. La suite logique est FT-02 : quantizer le modele de base en 4 bits (QLoRA) pour entrainer ces memes adaptateurs sur une fraction de la VRAM."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -1249,7 +1249,7 @@
     "- **ORIGINAL** : « Jean Valjean marchait dans la nuit **(I want you to see) It's the moment when the truth is revealed.** » -- le modele bascule en anglais au milieu d'un prompt francais, et enchaîne des restes de dialogues anglophones `(A) Vigour de vivre...`.\n",
     "- **FINE-TUNE** : « ...à la vie est réponse une réputation des fois en France, cette doute leur leur des mains, qui la comme de vie de la cette sommage. » -- imparfait, mais le **corps narratif reste en francais**, avec une cadence de phrase longue typique du corpus Hugo ; la generation se termine toutefois par un residu anglophone (« The question was: What were the effects of the French revolution... »).\n",
     "\n",
-    "Le prompt est identique et les parametres de generation sont ceux de la fonction `generate_text` ; chaque cote reste neanmoins **un tirage echantillonne unique** (la graine n'est pas re-fixee avant chaque appel -- cf. la reserve de la section 5). La difference dominante entre les deux colonnes est l'adaptateur LoRA de 1,18 Mo : la generation passe durablement en francais la ou l'original basculait immediatement en anglais -- un transfert de style net, quoique non total (le residu anglophone final en temoigne)."
+    "Le prompt est identique et les parametres de generation sont ceux de la fonction `generate_text` ; chaque cote reste neanmoins **un tirage echantillonne unique** (la graine n'est pas re-fixee avant chaque appel -- cf. la reserve de la section 5). Dans ce tirage commite, le corps de la generation fine-tune reste en francais la ou l'original basculait immediatement en anglais, avec un residu anglophone en finale : le contraste est **indicatif**, faute de re-echantillonnage controle -- un tirage par cote, pas une moyenne ; seul un protocole multi-tirages a graine fixee permettrait d'attribuer l'ecart a l'adaptateur LoRA de 1,18 Mo."
    ]
   },
   {
@@ -1633,7 +1633,7 @@
     "\n",
     "**Prochaines étapes** (FT-02) : LoRA sur un modèle plus grand avec quantization 4-bit (QLoRA).\n",
     "\n",
-    "**Ce que ce notebook a mesure, pas seulement annonce** : 124 439 808 parametres totaux pour GPT-2 ; 294 912 parametres entrainables en LoRA r=8 (0,24 %, `trainable%: 0.2364` cote PEFT) ; un adaptateur de **1,18 Mo** contre **497,8 Mo** pour le modele complet ; et une generation apres fine-tuning majoritairement en francais -- l'anglais du pre-entrainement y recule tres nettement sans etre evacue totalement -- la ou le modele original basculait en anglais. La suite logique est FT-02 : quantizer le modele de base en 4 bits (QLoRA) pour entrainer ces memes adaptateurs sur une fraction de la VRAM."
+    "**Ce que ce notebook a mesure, pas seulement annonce** : 124 439 808 parametres totaux pour GPT-2 ; 294 912 parametres entrainables en LoRA r=8 (0,24 %, `trainable%: 0.2364` cote PEFT) ; un adaptateur de **1,18 Mo** contre **497,8 Mo** pour le modele complet ; et, dans ce tirage commite, une generation apres fine-tuning majoritairement en francais -- l'anglais du pre-entrainement y recule sans etre evacue totalement -- la ou le modele original basculait en anglais : contraste indicatif faute de re-echantillonnage controle (cf. la reserve de la section 5). La suite logique est FT-02 : quantizer le modele de base en 4 bits (QLoRA) pour entrainer ces memes adaptateurs sur une fraction de la VRAM."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -634,7 +634,7 @@
    "source": [
     "### Lecture du resultat : sept segments, pas sept mille\n",
     "\n",
-    "`Segments d'entrainement : 7` et `Dataset : 7 exemples`. Ce corpus est minuscule a dessein. Un fine-tuning complet sur 7 segments apprendrait surtout le bruit ; un LoRA a 294 912 parametres, lui, n'a **pas la capacite** de memoriser le corpus -- il ne peut capter que des regularites grossieres : longueur de phrase, ponctuation, champs lexicaux. C'est precissement ce qu'on veut pour un cours : l'etudiant voit la difference de style sans qu'un modele suffisamment puissant ne « triche » en recitant le corpus.\n",
+    "`Segments d'entrainement : 7` et `Dataset : 7 exemples`. Ce corpus est minuscule a dessein. Un fine-tuning complet sur 7 segments apprendrait surtout le bruit ; avec un corpus aussi minuscule, meme un LoRA de 294 912 parametres court un **risque reel de sur-apprentissage** -- memorisation du corpus comprise. Ce run ne mesure pas ce risque (pas de loss d'evaluation disjointe ici) ; ce qu'on observe en pratique, ce sont des regularites grossieres : longueur de phrase, ponctuation, champs lexicaux.\n",
     "\n",
     "La contrepartie assumee : la generation de la section 5 montrera des repetitions (la boucle « l'une nouvelle, l'une nouvelle » du premier prompt) -- signature typique d'un adaptateur sous-dimensionne entraîne sur peu de donnees. Distinguer « le style a ete transfere » de « la qualite du texte a ete amelioree » est l'un des apprentissages centraux de ce notebook."
    ]
@@ -1225,7 +1225,7 @@
     "| **Lexique du corpus** | champ large, hors corpus (« ambassador », « consommateurs ») | resserré sur le corpus (« rue », « Paris », « lune », « vie ») | le champ lexical cible émerge |\n",
     "| **Artefact de sous-dimensionnement** | absent | **répétition** en boucle « l'une nouvelle » (1ᵉʳ prompt), « leur leur » (2ᵉ prompt) | signature d'un adaptateur sous-dimensionné sur 7 exemples |\n",
     "\n",
-    "**Ce que la mesure confirme** : l'adaptateur a transféré le **format** (cadence, langue, lexique) et n'a **pas** transféré la maîtrise (grammaire, accords, sens — « cette doute leur leur des mains »). Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le vérifie par ces cinq signaux — quatre nets, la langue en recul marqué sans être totale. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression)."
+    "**Ce que l'échantillon committé montre** : côté fine-tune, quatre signaux de format sont réunis (phrases courtes, cadence, lexique resserré, répétition d'artefact) et la langue reste dominante en français avec un résidu anglophone ; la maîtrise, elle, n'est pas au rendez-vous (grammaire, accords, sens — « cette doute leur leur des mains »). Ces observations sont **compatibles avec** un transfert de format par l'adaptateur, sans l'isoler causalement — un tirage unique par côté, cf. la réserve de la section 5. Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le lit sur ces cinq signaux — quatre nets, la langue en recul marqué sans être totale. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression)."
    ]
   },
   {
@@ -1627,7 +1627,7 @@
     "\n",
     "**Points cles** :\n",
     "- LoRA decompose la mise a jour en matrices de bas rang $B \\times A$ ou $r \\ll d, k$\n",
-    "- Seuls 0,24 % des paramètres sont entraines (mesure section 3 ; `trainable%: 0.2364` cote PEFT), mais la qualite reste proche du full fine-tuning\n",
+    "- Seuls 0,24 % des paramètres sont entraines (mesure section 3 ; `trainable%: 0.2364` cote PEFT) ; ce notebook n'execute pas de full fine-tuning de comparaison, aucune parité de qualité n'est donc mesurée ici\n",
     "- Les adaptateurs sont portables : un seul modèle de base + N adaptateurs pour N tâches\n",
     "- Le rang $r$ contrôle le compromis expressivite/efficacite\n",
     "\n",


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #15212

See #15035

> **Révision preflight passe 1 (629a3b004)** : les formulations causales des cellules [29] et [42] sont adoucies conformément au preflight — plus de « différence dominante = adaptateur », plus de « durablement », plus d'attribution causale nette ; les deux lectures sont ancrées au tirage commité (« dans ce tirage commité … contraste indicatif faute de ré-échantillonnage contrôlé », avec remède multi-tirages à graine fixée). Les réalignements factuels du commit initial sont inchangés.
>
> **Révision preflight passe 2 (64c3096cb)** : 3 claims non étayées retirées des cellules déjà modifiées — [16] l'impossibilité « n'a pas la capacité de memoriser » (indéfendable : 294 912 params vs 7 segments) devient **risque réel de sur-apprentissage, non mesuré par ce run** (aucune loss d'évaluation disjointe) ; [28] « l'adaptateur a transféré le format / la mesure confirme » devient lecture de l'**échantillon committé**, compatible avec le transfert sans isolation causale ; [42] « la qualité reste proche du full fine-tuning » est **retirée** — aucun full fine-tuning de comparaison n'est exécuté dans le notebook.

## What

Ré-ancrage markdown-only de `FT-01-Introduction-FineTuning.ipynb` sur ses sorties commitées : 25 remplacements ciblés dans 9 cellules markdown (3 commits), **outputs, `execution_count` et métadonnées (notebook + cellules) byte-identiques** (sha256 des outputs vérifié à chaque commit : `a01fcc6b…` inchangé ; snapshot metadata HEAD↔worktree identique). Aucune cellule code touchée → C.2 exception markdown-only, C.3 : aucune re-exécution due.

Discovered and verified by corrective-auditor: CONFIRMED_PEDAGOGY

## Dénominateurs exacts (recomptage indépendant post-révision, `nbformat` + scanner mécanique)

| Dénominateur | Valeur | Contre-vérification |
|---|---|---|
| Cellules totales | **43** | `nbformat.read` len(cells)=43, recoupé scanner mécanique |
| Cellules code | **13** — toutes exécutables, toutes porteuses d'outputs | `cell_type=='code'` count |
| `execution_count` | **1..13, aucun null** (0 paramètre d'exécution manquant) | list = [1..13], null=0 |
| Cellules code sans outputs | **0** | empty-outputs=0 |
| Sorties en erreur | **0** | output_type=='error' = 0 |
| Hits C.1 / secrets / chemins machines | **0 / 0 / 0** | scanner mécanique |
| Jumeaux `_en` de FT-01 | **0** (n'existe pas ; seul FT-05 en a un) | `ls` du dossier |

## Matrice acceptance ↔ diff ↔ contre-vérification

| Critère d'acceptance | Où dans le diff | Contre-vérification (commande → résultat) |
|---|---|---|
| Reproduction firsthand de chaque finding | chaque ligne du diff cite la cellule source vs la sortie commitée (table §Findings) | digests + `Read` des outputs bruts des cellules [11], [20], [25], [27], [31] → valeurs citées byte-trouvées |
| Seeds explicitement dispositionnés | §Scope du présent body | grep `LOAD_MODEL_AND_TRAIN` sur les 6 `*.ipynb` → 0 occurrence (README la promet) ; env-names : non reproduit dans le scope |
| Un notebook max, jamais README/twin/partagé | diff = 1 fichier, `FT-01-…ipynb` | `git diff --stat d54f805..HEAD` → 1 file, +20/−20 (diff cumulé 3 commits) ; API PR : commits=3, changed_files=1, +20/−20 |
| Dénominateurs exacts | table ci-dessus | recomptage indépendant double instrument (nbformat + scanner) → identiques |
| Pivot recount indépendant | table ci-dessus | 2 instruments distincts, mêmes valeurs |
| Assertions typées sur chaque édition | scripts `ft01_fix.py` (20 asserts) + `ft01_fix2.py` (2 asserts) + `ft01_fix3.py` (3 asserts), 1-occurrence par remplacement | sortie `applied 20/20`, `applied 2/2`, `applied 3/3` — tout échec d'assertion aurait avorté |
| Oracle = sorties commitées, qualification écrite | §Diagnostic dérive | sha256 outputs avant/après = `a01fcc6b…` identique à chaque commit (les outputs NE sont PAS l'oracle modifié par la PR) |
| Mutation négative / challenge pré-fix | — (absences exigées) | grep post-fix : `5.0106`=0, `(1) Le rue de Paris`=0, `entièrement français`=0, `entierement en francais`=0, `difference dominante`=0, `durablement`=0, `RTX 3090 --`=0, `pas la capacite de memoriser`=0, `la mesure confirme`=0, `proche du full fine-tuning`=0 |
| Validation finale complète post-dernier-commit | §Validation | batterie ci-dessous, relancée après 64c3096cb (3ᵉ et dernier commit) |
| FP / déjà-couverts = pas de patch | 2 FP documentés (FT-06 cell 11 exec-vide légitime ; FT-01 [21] « dizaine de secondes » ordre de grandeur) | aucun edit correspondant dans le diff |
| Deep/hors-scope = handoff, pas de patch | §Scope : README + FT-02..FT-06 | 0 fichier de ces chemins dans le diff |

## Diagnostic dérive

**Cause** : (b) claims antérieures écrites contre une run pré-re-exécution + (e) stochasticité non-seedée de la génération. Les sorties commitées sont fraîches (re-exec #14290, de-pin #15104 : « la sortie commitée devient la source unique ») — c'est la prose qui n'avait pas suivi.

**Verdict : CAUSE_FIXED** pour l'alignement valeur/citations. Le sous-point RNG est **documenté avec remède inline** (cellule [23] + lectures [29]/[42] : un tirage unique par côté, remède `torch.manual_seed(...)` par appel ; corriger le code exigerait une re-exécution GPU complète — fabrication locale CPU interdite).

## Findings corrigés (tous reproduits firsthand sur BASE_HEAD d54f8053, état post-#15104)

| # | Cellule(s) | Avant (prose) | Après (sorties commitées) |
|---|---|---|---|
| 1 | [21], [40] | `Perte finale : 5.0106` | `5.0025` (cellule [20] commitée) |
| 2 | [40] | `~13 s sur RTX 3090` (machine-pinné) | `12,3 s` cité + marqué machine-dépendant (C.5) |
| 3 | [16], [24], [26], [28] | citations fabriquées « (1) Le rue de Paris. (2) Le rue de Paris. » | boucle réelle « l'une nouvelle » (sortie cellule [25]) |
| 4 | [26], [28] | « une phrase par ligne numérotée (1), (2) » | phrases courtes détachées, une par ligne (1ᵉʳ prompt) — pas de numérotation dans les sorties |
| 5 | [28], [29], [42] | « **entièrement français** (2ᵉ prompt) » / « l'anglais a disparu » | contredit par la sortie commitée (fin de génération en anglais) → « français dominant, résidu anglophone en fin de 2ᵉ prompt » |
| 6 | [29] | citation stale « …des fois ne pas de la voiture, il vie en vie… » | texte commité réel (« …réputation des fois en France, cette doute leur leur des mains… ») |
| 7 | [23], [29] | claim de contrôle causal « graine… identique (seed=42 fixé) » — aucune graine fixée nulle part | réserve honnête : un tirage échantillonné unique par côté + remède inline |
| 8 | [42] | table Résumé « ~5-15% » / « ~0.5% » / « ~2-5 Mo » | mesures du notebook : **42,41 %** (52 773 120), **0,24 %** (294 912, PEFT 0.2364), **1,18 Mo** (cellules [11] + [31]) |
| 9 | [42] | « Seuls ~0.5% des paramètres » | 0,24 % |
| 10 | [21] | delta dénominateur PEFT « buffers de l'adaptateur » | les 294 912 paramètres de l'adaptateur (124 734 720 = 124 439 808 + 294 912) |
| 11 | [29], [42] (preflight p1) | « la différence dominante … est l'adaptateur LoRA » ; « passe **durablement** en français » | « dans ce tirage commité … contraste **indicatif** faute de ré-échantillonnage contrôlé » (629a3b004) |
| 12 | [16], [28], [42] (preflight p2) | « n'a **pas la capacité** de mémoriser le corpus » (impossibilité indéfendable) ; « l'adaptateur **a transféré** le format / **la mesure confirme** » (causal) ; « la qualité reste **proche du full fine-tuning** » (aucune comparaison full-FT exécutée) | risque réel de sur-apprentissage **non mesuré par ce run** ; lecture de l'échantillon committé **compatible avec** le transfert sans isolation causale ; claim de parité retirée (64c3096cb) |

## Validation post-fix (relancée après le dernier commit 64c3096cb)

- `check_markdown_claims_output.py` → exit 1 **advisory** : ensemble de findings **identique HEAD↔worktree** après chaque passe (11/11, 0 introduit, 0 retiré — diff JSON pré/post) ; les valeurs de la PR sont réelles mais citées loin de leur cellule source (heuristique de fenêtre), aucune fabrication
- `check_papermill_ratchet.py origin/main` → 0 changed / 0 régression (markdown-only exempt, `OUTPUTS_UNCHANGED`)
- `detect_code_in_markdown_cells.py --check --baseline` → OK
- Scanner C.1/C.2/null-exec/secrets/chemins → 0 hit
- `nbformat.validate` → VALID ; sha256 outputs avant/après identique ; exec counts 1..13 inchangés ; **métadonnées notebook + cellules byte-identiques** (snapshot stash HEAD↔worktree)
- Greps de mutation négative → toutes les chaînes stales/causales à 0 (table matrice, 10 motifs)
- Pre-commit hooks (gitleaks, H.3, #13326, strip banners) → Passed sur chaque commit

## Deconfliction

- BASE_HEAD `d54f8053` inchangé ; 82 PRs ouvertes scannées (fichiers via REST) → **0 intersection** avec `GenAI/FineTuning/**`
- `check_lane_claim.py 15035 --paths FT-01…` → CLEAR (claim union active de ma lane)
- Dernier toucher FT-01 : #15104 (merged) — findings vérifiés post-#15104, aucun déjà couvert

## Scope / limites

- 1 notebook = 1 branche = 1 PR. Residu observé laissé en place (hors périmètre de la présente révision, en tolérance) : cellule [1] « ~13 secondes » comme ordre de grandeur CPU-vs-GPU (« 5-10 minutes au lieu de ~13 s ») — cohérent avec 12,3 s à la précision de la phrase.
- Findings confirmés **non corrigés ici**, signalés au coordinateur :
  - `README.md` FineTuning : promet un mode démo `LOAD_MODEL_AND_TRAIN=False` **absent des 6 notebooks** ; décrit FT-01 comme DistilBERT + grille r=4/16/64 alors que le notebook exécute GPT-2 r=8 — README non éditable dans ce scope
  - FT-02 : « 20,7 s mesurés » vs commité 48.6s ; « 10 exemples × 3 époques » vs code `num_train_epochs=15`
  - FT-03 : « 21 exemples » vs 227 paires ; « nuance honnête » citant des extraits absents des sorties
  - FT-04 : « 98 % (106/108) » vs commité 105/108 (97 %) ; « +0,18 » vs +0.1483 ; « 0,655→0,237 » vs 0.6585→0.2419
  - FT-05 : « RTX 3090 » vs commité RTX 3070 Laptop (×2) ; Ilharco 2022 cité avec 2 arXiv IDs conflitants (2212.04089 correct vs 2210.09316) ; « 10 questions cross-domaine » vs 2 prompts ; « perplexité » jamais calculée
  - FT-06 : cellule [17] « le dénominateur a grossi » — contredit par les sorties commitées FT-03 et FT-06 (dénominateurs identiques 860 260 416)
