### PR TITLE
fix(runners,#15105): intégrité + maintenance bornée du cache _work persistant

### DIFF
--- a/scripts/ci/docker/linux-runner/Dockerfile
+++ b/scripts/ci/docker/linux-runner/Dockerfile
@@ -76,6 +76,9 @@ RUN echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
 USER runner
 WORKDIR /opt/runner
 
+# work_cache_health.sh : moitie executante de #15105, sourcee par l'entrypoint
+# au demarrage de chaque conteneur (controle du cache _work persistant).
+COPY --chown=runner:runner work_cache_health.sh /opt/runner/work_cache_health.sh
 COPY --chown=runner:runner entrypoint.sh /opt/runner/entrypoint.sh
 RUN chmod +x /opt/runner/entrypoint.sh
 

--- a/scripts/ci/docker/linux-runner/entrypoint.sh
+++ b/scripts/ci/docker/linux-runner/entrypoint.sh
@@ -49,6 +49,22 @@ for gitdir in "$ACTIONS_RUNNER_INPUT_WORK"/*/*/.git; do
 done
 # ---------------------------------------------------------------------------
 
+# --- Sante du cache de depot persistant (#15105) ---------------------------
+# Meme hook job-started que le bloc sparse ci-dessus : le volume _work survit
+# au conteneur, l'entrypoint est le seul point qui s'execute avant
+# l'enregistrement du runner -- donc avant qu'un job n'attrape le cache.
+# Deux passes par clone : integrite (refs cassees -> reparation ou purge,
+# le gate de la flotte etait une loterie 1-sur-8 sans que rien le nomme),
+# puis maintenance (repack -ad si le compte de packs depasse le seuil ;
+# gc.auto=0 fait que rien d'autre ne consolide jamais). Le detail et les
+# trois controles positifs (safe.directory, stderr, .promisor) sont dans
+# work_cache_health.sh.
+WCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$WCH_DIR/work_cache_health.sh"
+wch_check_workdir "$ACTIONS_RUNNER_INPUT_WORK" "${RUNNER_WORK_CACHE_PACK_THRESHOLD:-16}"
+# ---------------------------------------------------------------------------
+
 cd /opt/runner
 # --disableupdate : le conteneur est --rm et le runner --ephemeral (un seul
 # job puis mort). Un self-update n'y est donc jamais CONSERVE -- GitHub ordonne

--- a/scripts/ci/docker/linux-runner/persist/README.md
+++ b/scripts/ci/docker/linux-runner/persist/README.md
@@ -217,11 +217,43 @@ Les journaux des **conteneurs** sont bornes ailleurs, par `daemon.json`
 (`log-driver: local`, 10 Mo x 3). Deux mecanismes distincts, ecrits a deux endroits
 differents, qui remplissaient chacun le meme disque.
 
+## Maintenance du cache `_work` (#15105)
+
+`actions/checkout` pose `gc.auto = 0` dans le depot du slot : correct pour un
+workspace jetable, faux depuis que #14285 rend ce workspace persistant. Chaque
+job depose un pack promisor de plus (slot 1 : **264 packs** au diagnostic,
+compte croissant sans plafond), et un arret brutal laisse des refs de ZERO
+octet qui transforment le gate en loterie -- le slot 7 en portait 1471.
+
+Deux passes vivent dans l'entrypoint du conteneur (avant l'enregistrement du
+runner : aucun job en vol ne les paie, et elles tournent sous les bornes d'I/O
+du conteneur lui-meme) :
+
+- **Integrite, inconditionnelle** : refs cassees detectees sur le canal stderr
+  de `for-each-ref` (rc=0 -- seul le warning nomme la ref), reparees par
+  retrait des fichiers vides de `.git/refs` et `.git/logs` UNIQUEMENT (un
+  marqueur `.promisor` vide est legitime et vit sous `.git/objects` :
+  hors perimetre par construction), et purge du clone si le depot reste muet.
+- **Repack, seuille** : `COURSIA_RUNNER_CACHE_PACK_THRESHOLD` (defaut **16**,
+  0 = desactive) descend au conteneur ; au-dela, `git repack -ad` consolide
+  avec la mesure avant/apres au journal. Non inerte au meme titre que
+  `COURSIA_RUNNER_LOG_MAX_BYTES` : son absence est une croissance de disque
+  sans borne, pas un plafond qu'une machine n'a pas demande. Sur un clone
+  partiel `blob:none`, le repack est sur (mesure sur fixture au filtre
+  reellement honore : 5 packs promisor -> 1, marqueur preserve, lazy-fetch et
+  fetch incremental intacts).
+
+La garde de fraicheur #14801 lit desormais **deux** scripts embarques
+(`entrypoint.sh` ET `work_cache_health.sh` qu'il source) : un correctif merge
+mais non rebuild sur l'un ou l'autre est refuse au demarrage du pool.
+
 ## Voir aussi
 
 - [`../supervise.sh`](../supervise.sh) -- le superviseur, ses trois pools et ses bornes
-- [`../test_supervise_guards.sh`](../test_supervise_guards.sh) -- 18 tests, chaque garde avec son controle negatif
+- [`../test_supervise_guards.sh`](../test_supervise_guards.sh) -- 20 tests, chaque garde avec son controle negatif
+- [`../test_work_cache_health.sh`](../test_work_cache_health.sh) -- sante du cache `_work` sur fixtures git reelles (#15105)
 - [`../../../../../docs/ci/self-hosted-runners.md`](../../../../../docs/ci/self-hosted-runners.md) -- vue d'ensemble du parc
 - **#15091** -- revision du design du superviseur (traffic disque, isolation)
 - **#14385** -- volumes `_work` par slot -- les waiters n'en montent pas, le test 17 le garde
 - **#14801** -- fraicheur de l'image, verifiee par empreinte de l'entrypoint
+- **#15105** -- integrite et maintenance du cache `_work` persistant

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -232,6 +232,16 @@ BACKOFF_MAX_SEC="${COURSIA_RUNNER_BACKOFF_MAX_SEC:-300}"
 # jitter la disperse.
 BACKOFF_JITTER_PCT="${COURSIA_RUNNER_BACKOFF_JITTER_PCT:-25}"
 
+# Seuil de packs du cache _work persistant (#15105). Au-dela, l'entrypoint du
+# conteneur repack le clone (gc.auto=0 pose par actions/checkout : rien
+# d'autre ne consolide jamais -- slot 1 : 264 packs, compte croissant a
+# chaque job). NON inerte au meme titre que LOG_MAX_BYTES : son absence est
+# une croissance de disque sans borne, pas un plafond qu'une machine n'a pas
+# demande. 0 = desactive. Le knob descend au conteneur par -e ; la passe
+# integrite (refs cassees) est, elle, inconditionnelle -- cf
+# work_cache_health.sh et le bloc entrypoint #15105.
+CACHE_PACK_THRESHOLD="${COURSIA_RUNNER_CACHE_PACK_THRESHOLD:-16}"
+
 mkdir -p "$STATE_DIR"
 
 # Git Bash (MSYS) sous Windows reecrit les arguments de forme /posix/path des
@@ -255,21 +265,24 @@ RUNNER_CTX="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # daemon docker-ce WSL construite 5 h AVANT le merge, jamais rebatie), et ce
 # silence a produit les rouges fantomes du sparse-checkout empoisonne. Le
 # demarrage d'un pool est le seul point qui s'execute inconditionnellement
-# (un job annule ne joue aucun step post) : on y compare le sha256 du
-# entrypoint.sh de CE checkout a celui embarque dans l'image. La lecture
+# (un job annule ne joue aucun step post) : on y compare le sha256 de CHAQUE
+# script embarque de CE checkout (entrypoint.sh, et depuis #15105
+# work_cache_health.sh qu'il source) a celui porte par l'image. La lecture
 # cote image passe par `docker run --entrypoint sha256sum` -- le Dockerfile
-# place le script a /opt/runner/entrypoint.sh et MSYS_NO_PATHCONV (exporte
-# plus haut) protege l'argument POSIX sous Git Bash.
+# place les scripts sous /opt/runner/ et MSYS_NO_PATHCONV (exporte plus haut)
+# protege l'argument POSIX sous Git Bash.
 assert_image_fresh() {
   local image="$1" build_cmd="$2"
-  local repo_sha img_sha
-  repo_sha="$(sha256sum "$RUNNER_CTX/entrypoint.sh" 2>/dev/null | awk '{print $1}')"
-  [ -n "$repo_sha" ] || die "entrypoint.sh introuvable a cote de supervise.sh ($RUNNER_CTX) -- lancer depuis un checkout du depot"
-  img_sha="$(docker run --rm --entrypoint sha256sum "$image" /opt/runner/entrypoint.sh 2>/dev/null | awk '{print $1}')"
-  [ -n "$img_sha" ] || die "lecture de /opt/runner/entrypoint.sh dans $image impossible (docker run --entrypoint sha256sum)"
-  [ "$repo_sha" = "$img_sha" ] || die "image $image PERIMEE : entrypoint.sh du checkout ($repo_sha) != entrypoint embarque ($img_sha).
+  local f repo_sha img_sha
+  for f in entrypoint.sh work_cache_health.sh; do
+    repo_sha="$(sha256sum "$RUNNER_CTX/$f" 2>/dev/null | awk '{print $1}')"
+    [ -n "$repo_sha" ] || die "$f introuvable a cote de supervise.sh ($RUNNER_CTX) -- lancer depuis un checkout du depot"
+    img_sha="$(docker run --rm --entrypoint sha256sum "$image" /opt/runner/$f 2>/dev/null | awk '{print $1}')"
+    [ -n "$img_sha" ] || die "lecture de /opt/runner/$f dans $image impossible (docker run --entrypoint sha256sum)"
+    [ "$repo_sha" = "$img_sha" ] || die "image $image PERIMEE : $f du checkout ($repo_sha) != version embarquee ($img_sha).
 Un correctif merge mais non deploye est indiscernable d'un correctif absent (#14801, #14385). Reconstruire :
     $build_cmd"
+  done
 }
 
 # --- Bornes d'I/O : resolution du device et des drapeaux docker -------------
@@ -564,6 +577,7 @@ slot_loop() {
       -v "$TOOLCACHE_VOLUME":"$TOOLCACHE_MOUNT" \
       -v "${vol_prefix}-${slot}":"$WORK_MOUNT" \
       -e RUNNER_TOOL_CACHE="$TOOLCACHE_MOUNT" \
+      -e RUNNER_WORK_CACHE_PACK_THRESHOLD="$CACHE_PACK_THRESHOLD" \
       -e ACTIONS_RUNNER_INPUT_TOKEN="$token" \
       -e ACTIONS_RUNNER_INPUT_URL="https://github.com/$REPO" \
       -e ACTIONS_RUNNER_INPUT_NAME="$name" \

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -31,13 +31,19 @@ ko() { echo "  FAIL: $1"; echo "FAIL $1" >> "$RESULTS"; }
 
 # Stubs docker + gh + ps. Le stub docker simule une image A JOUR pour le
 # garde de fraicheur #14801 : au probe `run --entrypoint sha256sum`, il rend
-# le sha256 du VRAI entrypoint.sh sibling (bake a la generation du stub).
-# STUB_IMG_ENTRYPOINT_SHA force un ecart pour tester le refus (test 9).
+# le sha256 du VRAI script sibling demande (entrypoint.sh, et depuis #15105
+# work_cache_health.sh -- le garde lit les DEUX, le stub dispatche sur le
+# chemin passe en argument). STUB_IMG_ENTRYPOINT_SHA / STUB_IMG_HEALTH_SHA
+# forcent un ecart pour tester le refus (tests 9 et 20).
 REPO_ENTRYPOINT_SHA="$(sha256sum "$SCRIPT_DIR/entrypoint.sh" 2>/dev/null | awk '{print $1}')"
+REPO_HEALTH_SHA="$(sha256sum "$SCRIPT_DIR/work_cache_health.sh" 2>/dev/null | awk '{print $1}')"
 cat > "$TEST_DIR/bin/docker" <<STUB
 #!/usr/bin/env bash
 if [ "\$1" = "run" ]; then
-  echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+  case "\$*" in
+    *'/opt/runner/entrypoint.sh')        echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh" ;;
+    *'/opt/runner/work_cache_health.sh') echo "\${STUB_IMG_HEALTH_SHA:-$REPO_HEALTH_SHA}  /opt/runner/work_cache_health.sh" ;;
+  esac
   exit 0
 fi
 exit 0
@@ -121,9 +127,13 @@ echo "Test 3 : start --force leve sentinel (Defaut 2 avec --force)"
   export COURSIA_RUNNER_NAME_PREFIX="test-prefix-C"
   export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-C"
   touch "$TEST_DIR/state-C/stop"
-  timeout --kill-after=1 2 bash "$SCRIPT_DIR/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
+  timeout --kill-after=1 4 bash "$SCRIPT_DIR/supervise.sh" start 1 --force >/dev/null 2>"$TEST_DIR/last.err" &
   TPID=$!
-  sleep 0.5
+  # 1.5 s : le garde de fraicheur #15105 lit DEUX scripts embarques, soit
+  # deux probes docker de plus avant le rm du sentinel -- sous Git Bash ou
+  # chaque fork de stub coute ~100 ms, 0.5 s coupaient parfois AVANT le rm
+  # et le test echouait sur une question de delai, pas d'intention.
+  sleep 1.5
   if [ ! -f "$TEST_DIR/state-C/stop" ]; then
     ok "sentinel leve par start --force"
   else
@@ -539,7 +549,10 @@ echo "Test 17 : waiters -- toolcache monte, et JAMAIS de volume _work (#15091)"
   cat > "$TEST_DIR/bin17/docker" <<STUB
 #!/usr/bin/env bash
 if [ "\$1" = "run" ] && printf '%s' "\$*" | grep -q -- '--entrypoint sha256sum'; then
-  echo "$REPO_ENTRYPOINT_SHA  /opt/runner/entrypoint.sh"
+  case "\$*" in
+    *'/opt/runner/entrypoint.sh')        echo "$REPO_ENTRYPOINT_SHA  /opt/runner/entrypoint.sh" ;;
+    *'/opt/runner/work_cache_health.sh') echo "$REPO_HEALTH_SHA  /opt/runner/work_cache_health.sh" ;;
+  esac
   exit 0
 fi
 if [ "\$1" = "run" ]; then
@@ -680,6 +693,29 @@ echo "Test 19 : cmd_stop rend != 0 quand le sentinel n'a PAS pu etre pose (#1509
   else
     ko "l'echec annonce quand meme le succes : $out"
   fi
+)
+echo ""
+
+# --- Test 20 : garde de fraicheur -- health script perime refuse (#15105) ---
+# Le garde lit DEUX fichiers depuis #15105 (work_cache_health.sh est source
+# par l'entrypoint). Le controle positif du COTE garde : un ecart sur le
+# SEUL fichier ajoute doit refuser exactement comme un ecart d'entrypoint --
+# sinon la porte que le nouveau fichier ouvre serait garde par personne.
+echo "Test 20 : start refuse si work_cache_health.sh de l'image != checkout (#15105)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/state-20"
+  STUB_IMG_HEALTH_SHA=e000000000000000000000000000000000000000000000000000000000000000e
+  export STUB_IMG_HEALTH_SHA
+  rc="$(run_supervise 'start 1' 'test-prefix-20' "$TEST_DIR/state-20" 2>&1 | head -1 | sed 's/rc=//')"
+  err="$(cat "$TEST_DIR/last.err")"
+  if [ "$rc" != "0" ] && echo "$err" | grep -q "PERIMEE" && echo "$err" | grep -q "work_cache_health.sh"; then
+    ok "health script perime refuse, fichier FAUTIF nomme (rc=$rc)"
+  else
+    ko "refus sur work_cache_health.sh attendu, rc=$rc err=$err"
+  fi
+  unset STUB_IMG_HEALTH_SHA
 )
 echo ""
 

--- a/scripts/ci/docker/linux-runner/test_work_cache_health.sh
+++ b/scripts/ci/docker/linux-runner/test_work_cache_health.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# Tests de sante du cache _work (#15105), par observation directe du
+# comportement sur des fixtures git REELLES (pas de stub : les semantiques
+# testees -- warning stderr, rc=0, marqueurs .promisor -- sont celles de git
+# lui-meme, mesurees sur 2.43, la version de l'image ubuntu:24.04 de la
+# flotte).
+#
+# L'acceptance de #15105 exige que le detecteur soit « valide par ses faux
+# negatifs, pas par ses hits » : chaque garde a donc son controle NEGATIF
+# (ce que l'organe ne doit PAS faire) a cote de son controle positif.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TEST_DIR="$(mktemp -d /tmp/wch-test-XXXXXX)"
+LOG="$TEST_DIR/test.log"
+: > "$LOG"
+
+# Verdict tenu dans un fichier (pattern test_supervise_guards.sh : un
+# compteur shell dans un sous-shell ( ... ) n'est jamais vu du parent).
+RESULTS="$TEST_DIR/results"
+: > "$RESULTS"
+ok() { echo "  PASS: $1"; echo "PASS $1" >> "$RESULTS"; }
+ko() { echo "  FAIL: $1"; echo "FAIL $1" >> "$RESULTS"; }
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/work_cache_health.sh"
+
+# --- Fixture : depot source avec historique, et clone --no-local -----------
+# Le --no-local force le transport (pas de hardlinks) : chaque fetch ecrit
+# un pack distinct, exactement le mecanisme d'accumulation de la flotte
+# (mesure #15105 : 1 pack promisor par job).
+mk_source() {
+  local src="$1" i
+  git init -q --bare "$src"
+  # allowFilter : sans lui le file:// ignore --filter et le clone n'est PAS
+  # partiel -- or la flotte l'est (blob:none), et c'est ce qui fait qu'un
+  # fetch ecrit un PACK promisor (un clone complet ecrit des objets meubles
+  # pour les petits lots : le fixture ne reproduirait pas l'accumulation).
+  git -C "$src" config uploadpack.allowFilter true
+  git init -q "$TEST_DIR/seed"
+  git -C "$TEST_DIR/seed" config user.email t@t
+  git -C "$TEST_DIR/seed" config user.name t
+  for i in 1 2 3; do
+    head -c 1024 /dev/urandom | base64 > "$TEST_DIR/seed/f$i.txt"
+    git -C "$TEST_DIR/seed" add .
+    git -C "$TEST_DIR/seed" commit -qm "c$i"
+  done
+  git -C "$TEST_DIR/seed" push -q "$src" HEAD:main
+}
+
+add_commit_and_fetch() {
+  local src="$1" dst="$2" i="$3"
+  head -c 512 /dev/urandom | base64 > "$TEST_DIR/seed/g$i.txt"
+  git -C "$TEST_DIR/seed" add .
+  git -C "$TEST_DIR/seed" commit -qm "g$i"
+  git -C "$TEST_DIR/seed" push -q "$src" HEAD:main
+  git -C "$dst" fetch -q origin 2>/dev/null
+}
+
+echo "Test 1 : depot sain -- le detecteur VOIT les refs (controle positif du faux negatif « 0 refs saines »)"
+(
+  R="$TEST_DIR/healthy"
+  git init -q -b main "$R"
+  git -C "$R" config user.email t@t; git -C "$R" config user.name t
+  echo x > "$R/f"; git -C "$R" add .; git -C "$R" commit -qm x
+  nrefs="$(wch_ref_count "$R")"
+  if [ "$nrefs" -gt 0 ]; then
+    ok "un depot sain rend $nrefs refs lisibles (jamais 0)"
+  else
+    ko "0 refs sur un depot sain -- le faux negatif ownership/lecture est DE retour"
+  fi
+  out="$(wch_integrity_pass "$R")"
+  if [ -d "$R" ] && [ -n "$(ls -A "$R" 2>/dev/null)" ]; then
+    ok "depot sain conserve (aucune purge intempestive)"
+  else
+    ko "un depot sain a ete purge -- regression"
+  fi
+)
+echo ""
+
+echo "Test 2 : refs cassees -- le canal est STDERR, le rc est 0"
+(
+  R="$TEST_DIR/broken"
+  git init -q -b main "$R"
+  git -C "$R" config user.email t@t; git -C "$R" config user.name t
+  echo x > "$R/f"; git -C "$R" add .; git -C "$R" commit -qm x
+  mkdir -p "$R/.git/refs/remotes/origin"
+  : > "$R/.git/refs/remotes/origin/zero1"
+  : > "$R/.git/refs/heads/zero2"
+  # Controle du canal : for-each-ref rend rc=0 (mesure git 2.43) -- tout
+  # detecteur fonde sur le code de retour est aveugle par construction.
+  wch_git -C "$R" for-each-ref >/dev/null 2>&1
+  fer_rc=$?
+  if [ "$fer_rc" = "0" ]; then
+    ok "rc=0 confirme avec refs cassees -- la detection DOIT lire stderr"
+  else
+    ko "rc=$fer_rc inattendu (le fixture ne reproduit plus la semantique mesuree)"
+  fi
+  broken="$(wch_broken_refs "$R")"
+  if [ "$(printf '%s\n' "$broken" | grep -c .)" = "2" ]; then
+    ok "wch_broken_refs nomme les 2 refs cassees via stderr"
+  else
+    ko "2 refs cassees attendues, obtenu: [$broken]"
+  fi
+  out="$(wch_integrity_pass "$R" 2>&1)"
+  if echo "$out" | grep -q "reparation" && echo "$out" | grep -q "retire(s)"; then
+    ok "passe integrite journalise la reparation"
+  else
+    ko "journal de reparation attendu, obtenu: $out"
+  fi
+  if [ ! -e "$R/.git/refs/remotes/origin/zero1" ] && [ ! -e "$R/.git/refs/heads/zero2" ]; then
+    ok "fichiers de ref de zero octet retires"
+  else
+    ko "des refs vides survivent a la reparation"
+  fi
+  # La reparation ne doit avoir emporte AUCUNE ref valide.
+  if git -C "$R" rev-parse -q --verify main >/dev/null 2>&1 \
+     && git -C "$R" rev-parse -q --verify refs/remotes/origin/zero1 >/dev/null 2>&1; then
+    ko "main valide + ref cassee resolue ? etat incoherent"
+  elif git -C "$R" rev-parse -q --verify main >/dev/null 2>&1; then
+    ok "ref valide main intacte apres reparation"
+  else
+    ko "la reparation a emporte la ref valide main"
+  fi
+  if [ -z "$(wch_broken_refs "$R")" ]; then
+    ok "plus aucune ref cassee apres reparation"
+  else
+    ko "refs cassees residuelles: $(wch_broken_refs "$R")"
+  fi
+)
+echo ""
+
+echo "Test 3 : garde .promisor -- la reparation ne touche JAMAIS objects/ (controle negatif)"
+(
+  R="$TEST_DIR/promisor"
+  git init -q -b main "$R"
+  git -C "$R" config user.email t@t; git -C "$R" config user.name t
+  echo x > "$R/f"; git -C "$R" add .; git -C "$R" commit -qm x
+  mkdir -p "$R/.git/objects/pack" "$R/.git/objects/info"
+  # Un marqueur .promisor est un fichier de ZERO octet legitime ; un find
+  # -type f -empty -delete naif sur .git en emporterait un par pack.
+  : > "$R/.git/objects/pack/pack-deadbeef.promisor"
+  : > "$R/.git/objects/pack/pack-cafebabe.promisor"
+  : > "$R/.git/objects/info/commit-graph.vierge"
+  mkdir -p "$R/.git/refs/heads"; : > "$R/.git/refs/heads/zero"
+  wch_drop_empty_refs "$R" >/dev/null
+  if [ -e "$R/.git/objects/pack/pack-deadbeef.promisor" ] \
+     && [ -e "$R/.git/objects/pack/pack-cafebabe.promisor" ] \
+     && [ -e "$R/.git/objects/info/commit-graph.vierge" ]; then
+    ok "les fichiers vides d'objects/ survivent tous (perimetre = garde)"
+  else
+    ko "la reparation a touche .git/objects -- le geste naif est DE dans l'organe"
+  fi
+  if [ ! -e "$R/.git/refs/heads/zero" ]; then
+    ok "la ref vide sous refs/ est bien retiree (le perimetre n'est pas trop etroit)"
+  else
+    ko "refs/ non couvert -- perimetre trop etroit"
+  fi
+)
+echo ""
+
+echo "Test 4 : depot muet (0 refs lisibles) -- purge, jamais un « sain » non prouve"
+(
+  R="$TEST_DIR/muet"
+  git init -q -b main "$R"
+  rm -rf "$R/.git/refs"/* "$R/.git/logs" 2>/dev/null
+  rm -f "$R/.git/packed-refs"
+  out="$(wch_integrity_pass "$R" 2>&1)"
+  if [ ! -d "$R" ]; then
+    ok "depot sans ref lisible purge (le job suivant reclonera)"
+  else
+    ko "un depot muet a ete conserve comme sain -- le faux negatif est DE"
+  fi
+  if echo "$out" | grep -q "IRRECUPERABLE"; then
+    ok "la purge est NOMMEE dans le journal"
+  else
+    ko "journal de purge attendu, obtenu: $out"
+  fi
+)
+echo ""
+
+echo "Test 5 : compte de packs borne -- mesure avant/apres journalisee"
+(
+  SRC="$TEST_DIR/src5"; R="$TEST_DIR/clone5"
+  mk_source "$SRC"
+  git clone -q --no-local --filter=blob:none "file://$SRC" "$R" 2>/dev/null
+  for i in 4 5 6; do add_commit_and_fetch "$SRC" "$R" "$i"; done
+  n_packs="$(wch_pack_count "$R")"
+  if [ "$n_packs" -ge 4 ]; then
+    ok "fixture fidèle : $n_packs packs accumulés (1 par fetch, comme la flotte)"
+  else
+    ko "fixture insuffisante ($n_packs packs) -- le test ne prouve plus rien"
+  fi
+  out="$(wch_maintenance_pass "$R" 2)"
+  after="$(wch_pack_count "$R")"
+  if [ "$after" = "1" ]; then
+    ok "repack : $n_packs -> $after packs"
+  else
+    ko "1 pack attendu apres repack, obtenu $after"
+  fi
+  if echo "$out" | grep -q "repack $n_packs -> $after"; then
+    ok "la mesure avant/apres est dans le journal (acceptance #15105)"
+  else
+    ko "journal de mesure attendu, obtenu: $out"
+  fi
+  # Le clone consolide reste un clone : fetch incremental + rev-parse.
+  git -C "$R" rev-parse -q --verify origin/main >/dev/null 2>&1 \
+    && ok "depot fonctionnel apres repack (rev-parse origin/main)" \
+    || ko "rev-parse casse apres repack"
+  n_prom="$(ls "$R"/.git/objects/pack/*.promisor 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "$n_prom" -ge 1 ]; then
+    ok "marqueur .promisor preserve sur le pack consolide ($n_prom)"
+  else
+    ko "promisor disparu -- le pack consolide serait pris pour complet"
+  fi
+  add_commit_and_fetch "$SRC" "$R" 7
+  if git -C "$R" rev-parse -q --verify origin/main >/dev/null 2>&1; then
+    ok "fetch incremental OK apres repack"
+  else
+    ko "fetch incremental casse apres repack"
+  fi
+)
+echo ""
+
+echo "Test 6 : seuils inertes -- 0 desactive, sous-le-seil ne repack pas (controles negatifs)"
+(
+  SRC="$TEST_DIR/src6"; R="$TEST_DIR/clone6"
+  mk_source "$SRC"
+  git clone -q --no-local --filter=blob:none "file://$SRC" "$R" 2>/dev/null
+  for i in 4 5 6; do add_commit_and_fetch "$SRC" "$R" "$i"; done
+  before="$(wch_pack_count "$R")"
+  out="$(wch_maintenance_pass "$R" 0)"
+  if [ "$(wch_pack_count "$R")" = "$before" ] && [ -z "$out" ]; then
+    ok "seuil 0 : inerte et muet"
+  else
+    ko "seuil 0 doit desactiver la maintenance, out=[$out]"
+  fi
+  out="$(wch_maintenance_pass "$R" 9999)"
+  if [ "$(wch_pack_count "$R")" = "$before" ] && [ -z "$out" ]; then
+    ok "sous le seuil : aucun repack (le cache incremental n'est pas derange)"
+  else
+    ko "un repack a eu lieu sous le seuil, out=[$out]"
+  fi
+)
+echo ""
+
+echo "Test 7 : passe complete sur un _work -- layout <workdir>/<repo>/<repo> (glob entrypoint)"
+(
+  W="$TEST_DIR/work"
+  # Layout actions/checkout : _work/<repo>/<repo>/.git -- DEUX niveaux, le
+  # meme glob que l'entrypoint (*/*/.git). Un niveau de plus serait invisible
+  # a la passe.
+  ORG="$W/CoursIA/CoursIA"
+  mkdir -p "$ORG"
+  SRC="$TEST_DIR/src7"
+  mk_source "$SRC"
+  git clone -q --no-local "file://$SRC" "$ORG" 2>/dev/null
+  mkdir -p "$ORG/.git/refs/remotes/origin"
+  : > "$ORG/.git/refs/remotes/origin/broken"
+  out="$(wch_check_workdir "$W" 2)"
+  if [ ! -e "$ORG/.git/refs/remotes/origin/broken" ] && [ -d "$ORG" ]; then
+    ok "workdir : ref cassee reparee, clone conserve"
+  else
+    ko "workdir : etat inattendu (broken presente: $([ -e "$ORG/.git/refs/remotes/origin/broken" ] && echo oui || echo non), clone: $([ -d "$ORG" ] && echo oui || echo non))"
+  fi
+  # Le rapport de sante ne doit jamais casser l'appelant (entrypoint set -e).
+  if wch_check_workdir "$W" 2 >/dev/null 2>&1; then
+    ok "wch_check_workdir rend toujours 0 (garde jamais fatal)"
+  else
+    ko "wch_check_workdir a rendu non-zero -- il tuerait l'entrypoint sous set -e"
+  fi
+)
+echo ""
+
+# --- Verdict agrege ---------------------------------------------------------
+n_pass="$(grep -c '^PASS ' "$RESULTS" 2>/dev/null)"; n_pass="${n_pass:-0}"
+n_fail="$(grep -c '^FAIL ' "$RESULTS" 2>/dev/null)"; n_fail="${n_fail:-0}"
+echo "==========================================================="
+echo "  $n_pass PASS / $n_fail FAIL"
+if [ "$n_fail" != "0" ]; then
+  echo ""
+  echo "Assertions en echec :"
+  grep '^FAIL ' "$RESULTS" | sed 's/^FAIL /  - /'
+  echo ""
+  echo "Repertoire de travail conserve pour diagnostic : $TEST_DIR"
+  exit 1
+fi
+if [ "$n_pass" = "0" ]; then
+  echo "ERREUR: aucune assertion executee -- le harnais n'a rien mesure." >&2
+  exit 2
+fi
+rm -rf "$TEST_DIR"
+exit 0

--- a/scripts/ci/docker/linux-runner/work_cache_health.sh
+++ b/scripts/ci/docker/linux-runner/work_cache_health.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Sante du cache de depot persistant `_work` (#15105).
+#
+# POURQUOI CE FICHIER EXISTE
+# --------------------------
+# `actions/checkout` pose `gc.auto = 0` dans le depot du slot : correct pour
+# un workspace jetable, faux depuis que #14285 a rendu ce workspace persistant.
+# Deux defauts d'une meme cause, mesures firsthand sur ai-01 le 2026-09-07 :
+#
+#   1. Croissance des packs sans borne. Chaque job depose un pack promisor de
+#      plus (recuperation paresseuse sous partialclonefilter=blob:none) ; slot 1
+#      : 264 packs dont 263 promisor, 849M de .git, et le compte croit a
+#      chaque job. Rien ne consolide jamais rien.
+#   2. Aucune precondition d'integrite. Le slot 7 portait 1471 fichiers de
+#      ref de ZERO octet (sequelle d'arrets brutaux : dirent validee, contenu
+#      jamais ecrit). `git fetch` bute dessus et abandonne -- le gate de toute
+#      la flotte etait devenu une loterie 1-sur-8, et AUCUN organe ne l'avait
+#      nomme.
+#
+# Ce fichier est la moitie executante ; l'autre moitie (cablement, knob,
+# garde de fraicheur) vit dans entrypoint.sh et supervise.sh. Il est SOURCE,
+# jamais execute seul -- les tests le sourcent de la meme facon
+# (test_work_cache_health.sh).
+#
+# LES TROIS CONTROLES POSITIFS que tout organe ecrit ici doit porter
+# (chacun vient d'un faux negatif REEL, cf #15105) :
+#
+#   - safe.directory : `git` refuse un depot d'un autre uid ("dubious
+#     ownership") ET, stderr supprime, rend ZERO ref sans erreur visible --
+#     indiscernable d'un cache sain. Toute lecture passe par wch_git, qui
+#     porte -c safe.directory='*'.
+#   - stderr, pas le code de retour : `git for-each-ref` rend rc=0 avec une
+#     ref cassee ; le seul canal qui la nomme est le warning "ignoring broken
+#     ref" sur STDERR (mesure, git 2.43 : rc=0 + warning).
+#   - .promisor vide est LEGITIME : c'est un marqueur de pack a recuperation
+#     paresseuse. La reparation ne touche QUE .git/refs et .git/logs -- JAMAIS
+#     .git/objects, ou un `find -type f -empty -delete` naif emporterait les
+#     marqueurs et fabriquerait une seconde corruption deguisee en reparation.
+#
+# Le geste de reparation (refs vides retirees, objects/ hors perimetre) est
+# celui prouve sur le slot 7 : 1472 refs cassees -> 0, les 2,5 Gio d'objets
+# intacts, 0 octet de clone.
+#
+# La reparation irrecuperable est le PURGE du clone (rm -rf du checkout) :
+# le job suivant reclonera (cout ~80-148 s mesure #14285, contre un cache qui
+# empoisonne silencieusement tout job qui l'attrape). C'est le meme geste que
+# le desarmement sparse #14385, et il accepte le meme cout sur les pools lean
+# (un .lake chaud perdu se reconstruit ; un cache corrompu ne se diagnostique
+# pas tout seul).
+
+# Toute lecture git du cache passe par ici : le controle positif
+# "dubious ownership" est porte par l'appel, pas par la chance que l'uid
+# d'execution coincide avec celui d'actions/checkout.
+wch_git() {
+  git -c safe.directory='*' "$@"
+}
+
+# Refs cassees du depot, une par ligne -- lues sur le CANAL stderr de
+# for-each-ref (rc=0 avec une ref cassee : le code de retour ne dit rien).
+# Sortie vide = aucune ref cassee detectee. Un depot illisible (fatal:
+# dubious ownership, .git detruit a moitie) rend une sortie vide AUSSI --
+# c'est pourquoi l'appelant croise toujours avec wch_ref_count, et ne
+# conclut "sain" que sur un compte > 0.
+wch_broken_refs() {
+  local repo="$1"
+  wch_git -C "$repo" for-each-ref 2>&1 >/dev/null \
+    | sed -n 's/^warning: ignoring broken ref //p'
+}
+
+# Nombre de refs lisibles. Le controle positif du detecteur : un depot
+# existant dont ce compte rend 0 est INDISSERNABLE d'un depot refuse pour
+# ownership ou d'un .git muet -- on ne conclut jamais "sain" dessus.
+wch_ref_count() {
+  local repo="$1"
+  wch_git -C "$repo" for-each-ref --format 'x' 2>/dev/null | wc -l | tr -d ' '
+}
+
+# Retire les fichiers de ref/reflog de ZERO octet, dans .git/refs et
+# .git/logs UNIQUEMENT. Le perimetre EST la garde .promisor : les marqueurs
+# promisor vivent sous .git/objects/pack et ne peuvent pas etre atteints
+# d'ici. Rend le nombre de fichiers retires.
+wch_drop_empty_refs() {
+  local repo="$1" n=0 d f
+  for d in "$repo/.git/refs" "$repo/.git/logs"; do
+    [ -d "$d" ] || continue
+    # -print0/read -d '' : un nom de ref contenant un saut de ligne resterait
+    # invisible a un `for` sur la sortie texte.
+    while IFS= read -r -d '' f; do
+      # if et pas && : l'entrypoint tourne sous set -e ; un rm echoue
+      # n'a jamais le droit de tuer le conteneur avant l'enregistrement.
+      if rm -f -- "$f"; then n=$(( n + 1 )); fi
+    done < <(find "$d" -type f -empty -print0 2>/dev/null)
+  done
+  printf '%s\n' "$n"
+}
+
+# Compte de packs du depot -- la grandeur que la maintenance borne.
+wch_pack_count() {
+  local repo="$1"
+  ls "$repo"/.git/objects/pack/*.pack 2>/dev/null | wc -l | tr -d ' '
+}
+
+# Precondition d'integrite AVANT qu'un slot n'accepte un job : detecte les
+# refs cassees, repare (refs/logs vides retires), re-verifie, et purge le
+# clone si le depot reste muet. Rend 0 dans tous les cas -- un garde de sante
+# ne doit JAMAIS etre la raison pour laquelle un slot meurt avant de
+# s'enregistrer ; ses decisions se lisent dans son journal.
+wch_integrity_pass() {
+  local repo="$1" broken n refs_purged
+  [ -d "$repo/.git" ] || return 0
+
+  broken="$(wch_broken_refs "$repo")"
+  if [ -n "$broken" ]; then
+    n="$(printf '%s\n' "$broken" | grep -c .)"
+    echo "work_cache: $n ref(s) cassee(s) dans $repo -- reparation (refs/logs vides retires, objects/ hors perimetre)"
+    refs_purged="$(wch_drop_empty_refs "$repo")"
+    echo "work_cache: $refs_purged fichier(s) de zero octet retire(s) sous .git/refs et .git/logs"
+  fi
+
+  # Re-verification APRES reparation. Les deux conditions qui suivent sont
+  # les deux faces du meme faux negatif : un depot qui rend encore des refs
+  # cassees est mal repare ; un depot dont AUCUNE ref n'est lisible est
+  # indiscernable d'un cache refuse (ownership) ou muet -- dans les deux cas
+  # le seul etat honnete est le clone frais, pas un "sain" non prouve.
+  broken="$(wch_broken_refs "$repo")"
+  n="$(wch_ref_count "$repo")"
+  if [ -n "$broken" ] || [ "$n" -eq 0 ]; then
+    echo "work_cache: $repo IRRECUPERABLE (${n} refs lisibles, encore $(printf '%s\n' "$broken" | grep -c .) cassees) -- purge du clone, le job suivant reclonera"
+    rm -rf -- "$repo"
+    return 0
+  fi
+  [ -n "${WCH_VERBOSE:-}" ] && echo "work_cache: $repo sain ($n refs lisibles)"
+  return 0
+}
+
+# Maintenance PERIODIQUE du cache : consolide les packs quand leur compte
+# depasse le seuil, avec la mesure avant/apres dans le journal. gc.auto=0
+# (pose par actions/checkout) fait que rien d'autre ne consolidera jamais --
+# sans cette borne, le compte croit a chaque job sans plafond (#15105
+# defaut 1 : 264 packs sur le slot 1).
+#
+# `git repack -ad` est SUR sur un clone partiel blob:none, mesure sur un
+# fixture au filtre reellement honore (blobs absents du depot local) :
+# 5 packs promisor -> 1, reseau nul pendant le repack, marqueur .promisor
+# preserve sur le pack consolide, et le lazy-fetch comme le fetch
+# incremental fonctionnent apres. Le seuil fait que le repack ne se paye
+# qu'une fois tous les N jobs, jamais a chaque job.
+#
+# Un echec de repack n'est PAS fatal : il se dit dans le journal et le
+# prochain passage retentera -- le compte reste alors ce qu'il etait, le
+# garde ne cree pas de regression.
+wch_maintenance_pass() {
+  local repo="$1" threshold="$2" before after
+  [ "$threshold" -gt 0 ] || return 0
+  [ -d "$repo/.git" ] || return 0
+  before="$(wch_pack_count "$repo")"
+  if [ "$before" -le "$threshold" ]; then
+    return 0
+  fi
+  if ! wch_git -C "$repo" repack -ad >/dev/null 2>&1; then
+    echo "work_cache: repack ECHEC dans $repo ($before packs) -- cache conserve tel quel, nouvelle tentative au prochain passage" >&2
+    return 0
+  fi
+  after="$(wch_pack_count "$repo")"
+  echo "work_cache: $repo repack $before -> $after packs (seuil $threshold)"
+  return 0
+}
+
+# Passe complete sur un _work : integrite puis maintenance, sur chaque clone
+# trouve sous <workdir>/<repo>/<repo>. Cote entrypoint, ce bloc tourne
+# AVANT config.sh : le runner n'est pas encore enregistre, donc aucun job
+# n'est ralenti en vol -- le cout de la maintenance est paye par le slot
+# entre deux jobs, sous les bornes d'I/O de son propre conteneur
+# (--device-write-bps + slice agregee, #15091/#15103), sans plomberie hote.
+wch_check_workdir() {
+  local workdir="$1" threshold="${2:-0}" gitdir repo
+  [ -d "$workdir" ] || return 0
+  for gitdir in "$workdir"/*/*/.git; do
+    [ -e "$gitdir" ] || continue
+    repo="${gitdir%/.git}"
+    wch_integrity_pass "$repo"
+    wch_maintenance_pass "$repo" "$threshold"
+  done
+  return 0
+}


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/docs #15174

## Sujet

`actions/checkout` pose `gc.auto = 0` dans le dépôt du slot : correct pour un workspace jetable, faux depuis #14285 qui l'a rendu persistant. Deux défauts d'une même cause, mesurés firsthand sur ai-01 (2026-09-07) : croissance des packs sans borne (slot 1 : 264 packs dont 263 promisor) et aucune précondition d'intégrité (slot 7 : 1471 refs de zéro octet, gate en loterie 1-sur-8 sans qu'aucun organe ne le nomme).

## Livrable

- **`work_cache_health.sh` (nouveau)**, sourcé par l'entrypoint :
  - **Intégrité (inconditionnelle)** : refs cassées lues sur le **canal stderr** de `for-each-ref` (rc=0 mesuré sur git 2.43 — seul le warning `ignoring broken ref` nomme la ref) ; réparation = retrait des fichiers de zéro octet de `.git/refs` et `.git/logs` **UNIQUEMENT** — le marqueur `.promisor` vide est légitime et vit sous `.git/objects` : hors périmètre par construction (les deux pièges de l'issue) ; purge du clone si le dépôt reste muet (0 refs lisibles = indiscernable d'un refus ownership, jamais un « sain » non prouvé).
  - **Maintenance (seuillée)** : `git repack -ad` au-delà de `COURSIA_RUNNER_CACHE_PACK_THRESHOLD` (défaut 16, 0 = désactivé), mesure avant/après au journal. Tout git passe par `-c safe.directory='*'` (contrôle positif « dubious ownership » : stderr supprimé, un dépôt refusé rend 0 refs sans erreur visible).
- **`entrypoint.sh`** : hook job-started avant l'enregistrement du runner — aucun job en vol ne paie, les passes tournent sous les bornes d'I/O du conteneur lui-même (`--device-write-bps` + slice, #15091/#15103), zéro plomberie hôte (même précédent que le désarmement sparse #14385).
- **`supervise.sh`** : knob transmis au conteneur par `-e` ; **garde de fraîcheur #14801 étendue aux deux scripts embarqués** (entrypoint + work_cache_health) — un correctif mergé mais non rebuild sur l'un ou l'autre est refusé au démarrage du pool.
- **`Dockerfile`** : COPY du nouveau script. **`persist/README.md`** : section maintenance (rationale du défaut non-inerte, calqué sur LOG_MAX_BYTES).

## Mesures (WSL git 2.43 = version de l'image ubuntu:24.04 de la flotte)

| Question | Mesure |
|---|---|
| Accumulation | reproduite : 1 pack par fetch (1 → 11 en 10 fetches) |
| `repack -ad` sur clone au filtre **réellement honoré** (blobs absents) | 5 packs promisor → 1, réseau nul pendant le repack, `.promisor` préservé sur le pack consolidé, lazy-fetch + fetch incrémental OK après |
| Refs de zéro octet | `for-each-ref` rc=0 + warning stderr ; réparation par périmètre refs/logs ; fichiers vides de `objects/` intacts |
| Dubious ownership (dépôt root, sonde user) | rc=128, 0 refs sans stderr ; `-c safe.directory='*'` lit les refs |

## Tests (chaque garde avec son contrôle négatif — acceptance « validé par ses faux négatifs »)

- `test_work_cache_health.sh` (nouveau, fixtures git réelles, clone partiel `blob:none` fidèle à la flotte) : **22 PASS / 0 FAIL** en WSL ET Git Bash. Couvre : dépôt sain vu (>0 refs — le faux négatif « 0 refs saines »), canal stderr, réparation sans emporter les refs valides, **garde .promisor** (fichiers vides d'objects/ survivent), purge du dépôt muet, repack borné avec mesure avant/après, seuils inertes (0 et sous-le-seuil), passe workdir complète jamais fatale (`set -e` de l'entrypoint).
- `test_supervise_guards.sh` : **40 PASS / 0 FAIL** en WSL ET Git Bash. Test 20 nouveau : écart `work_cache_health.sh` entre checkout et image → refus `PERIMEE` avec fichier fautif nommé. Stub docker dispatche sur le chemin sondé (2 probes). `sleep` du test 3 relevé à 1.5 s (les 2 probes de plus débordaient les 0.5 s sous Git Bash — échec de délai, pas d'intention).

## Acceptance #15105

- [x] Un slot au cache corrompu est **nommé par un organe** : l'entrypoint journalise `work_cache: N ref(s) cassée(s)… réparation` / `IRRECUPERABLE… purge` avant tout enregistrement.
- [x] Le compte de packs d'un slot actif est **borné, avec la mesure avant/après citée** : seuil 16 par défaut, journal `repack N -> M packs (seuil 16)`, mesure locale citée ci-dessus.
- [x] Le détecteur **porte ses contrôles positifs** (safe.directory, stderr lu, .promisor préservé) — validé par ses faux négatifs (tests 1, 3 et la sonde ownership).

## Déploiement (ai-01 / po-2024)

La garde de fraîchure refusera le démarrage tant que l'image n'est pas rebâtie — c'est le comportement voulu (#14801) :
```
docker build -t coursia-linux-runner:2.337.0 scripts/ci/docker/linux-runner/
```
Le knob est armé par défaut (16) ; `COURSIA_RUNNER_CACHE_PACK_THRESHOLD=0` le désactive par machine.

Closes #15105