### PR TITLE
fix(genai,#15281): rendre le diagnostic Claude CLI operant sur ses trois chemins d'echec

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/helpers/claude_cli.py
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/helpers/claude_cli.py
@@ -65,13 +65,13 @@ def installation_status() -> Dict[str, Any]:
             }
         return {
             "state": "non-executable",
-            "message": f"Claude CLI trouve ({resolved_path}) mais 'claude --version' echoue (code {result.returncode})",
+            "message": f"Claude CLI trouve ({resolved}) mais 'claude --version' echoue (code {result.returncode})",
             "resolved_path": resolved
         }
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
         return {
             "state": "non-executable",
-            "message": f"Claude CLI trouve ({resolved_path}) mais non executable: {e}",
+            "message": f"Claude CLI trouve ({resolved}) mais non executable: {e}",
             "resolved_path": resolved
         }
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #15203

Closes #15281.

Finding **V01** (priorite P0) de l'audit externe EPF du 2026-09-09, reproduit firsthand avant correction.

## Le defaut

`installation_status()` affecte la variable locale `resolved`, mais interpole `resolved_path` — qui n'existe pas — dans les **deux** f-strings de message d'erreur (l. 68 et 74). Les cles de dictionnaire `"resolved_path": resolved` etaient correctes : seules les interpolations etaient fautives, ce qui rend le defaut invisible a la lecture rapide.

Consequence : les **trois** chemins d'echec du diagnostic (`returncode != 0`, `OSError`, `TimeoutExpired`) levaient `NameError` au lieu de rendre leur verdict, et `verify_installation()` propageait l'exception. Le diagnostic tombait donc **exactement quand l'installation est cassee** — le seul cas ou on l'appelle.

## Le correctif

Deux interpolations `{resolved_path}` -> `{resolved}`. Rien d'autre. Les trois etats du diagnostic sont conserves a l'identique.

## Preuve d'execution (temoin a processus simules)

Le temoin injecte les cinq cas d'acceptation de l'audit dans le helper reel (`shutil.which` et `subprocess.run` remplaces). **Aucun binaire `claude` n'est invoque** — le temoin mesure la logique de diagnostic, pas une installation.

Avant, sur `origin/main` a `a8d3ff498` :

```
  OK     1. binaire absent          -> state='introuvable'
  OK     2. --version rc=0          -> state='executable'
  ECHEC  3. code retour 1           -> exception NameError: name 'resolved_path' is not defined
  ECHEC  4. OSError                 -> exception NameError: name 'resolved_path' is not defined
  ECHEC  5. TimeoutExpired          -> exception NameError: name 'resolved_path' is not defined
  ECHEC  6. verify_installation()   -> exception NameError: name 'resolved_path' is not defined
  2/6 cas passent   (rc=1)
```

Apres, sur la tete de cette PR :

```
  OK     1. binaire absent          -> state='introuvable'
  OK     2. --version rc=0          -> state='executable'
  OK     3. code retour 1           -> state='non-executable' message="Claude CLI trouve (/usr/local/bin/claude) mais 'claude --version' echoue (code 1)"
  OK     4. OSError                 -> state='non-executable' message='Claude CLI trouve (/usr/local/bin/claude) mais non executable: permission refusee'
  OK     5. TimeoutExpired          -> state='non-executable' message="Claude CLI trouve (/usr/local/bin/claude) mais non executable: Command 'claude --version' timed out after 15 seconds"
  OK     6. verify_installation()   -> False (attendu False)
  6/6 cas passent   (rc=0)
```

Les trois echecs rendent bien `state=non-executable` **en nommant le chemin resolu et la cause**, ce qui est la valeur du diagnostic pour un poste etudiant.

## Portee et limites

- Ce sont des **processus simules**, pas des installations Windows/macOS/Linux reelles. La correction retire une exception de programmation ; elle ne certifie aucun parcours d'installation.
- Le temoin vit dans le scratchpad de session, pas dans le depot : il n'ajoute pas de fichier de test a maintenir pour une correction de deux interpolations. Sa sortie complete est citee ci-dessus, reproductible en injectant les memes cinq cas.
- V02 (trois parcours d'installation concurrents), V03 (profil de variables et cache d'endpoint Claudish) et V04 (role etudiant dans le harnais) du meme audit sont **hors scope** de cette PR et suivis separement.

## Urgence

CLI01 (`01-Claude-CLI-Bases.ipynb`) sert au demarrage de l'atelier EPF MSMIN5IN52 dont la premiere seance est le 2026-09-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
