### PR TITLE
docs(harness,#15287): nommer le destinataire des obligations de flotte en tete de CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 Guidance pour Claude Code travaillant avec le repository CoursIA.
 
+## À qui ce fichier s'adresse (à lire en premier)
+
+**Les obligations de flotte de ce fichier lient les agents du cluster CoursIA — le coordinateur `ai-01` et les workers `po-*` — et eux seuls.**
+
+**Si tu es l'agent d'un étudiant, d'un lecteur ou d'un contributeur externe, rien de tout cela ne te concerne.** Tu n'as **pas** de dashboard RooSync à lire, **pas** de lane à réclamer, **pas** d'inbox ni de heartbeat de cluster à consulter, **pas** de `[CLAIMED]` à poser, **pas** de tag `Grain:` à écrire, et **aucune** obligation de poster un rapport de début ou de fin de session. Ces objets n'existent pas pour toi : ne les cherche pas, et ne considère pas leur absence comme un blocage. Tu peux conclure ta session quand ton travail est fait.
+
+Ce qui te concerne, en revanche, parce que ça vaut pour quiconque écrit dans ce dépôt :
+
+| Section | Ce qu'elle exige de toi |
+|---|---|
+| **§C** — Notebooks | pas d'erreur volontaire dans un stub d'exercice ; notebooks committés avec leurs sorties |
+| **§D** — Anti-régression | ne pas remplacer une implémentation ou une preuve existante par un stub |
+| **§E** — Code style | pas d'emoji dans le code, documentation en français |
+| **Secrets** | aucun secret dans un commit — la règle n'a pas d'exception |
+
+Et si tu travailles dans un **dépôt de projet étudiant** (`jsboigeEPF/*`, `jsboigeEpita/*`, `jsboigeECE/*`), c'est **la charte de ce dépôt-là** qui fait autorité, pas ce fichier : ton périmètre est le dossier de ton groupe, et tes livraisons partent en PR vers le dépôt amont.
+
 ## Principes de collaboration (5)
 
 Cadre de travail (adapté de Karpathy + ajout user) : ces principes gouvernent **comment** travailler ; les RÈGLES CRITIQUES ci-dessous disent **quoi** respecter.


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/tooling #15203

## Le défaut

Un étudiant qui pointe un agent de codage sur un clone de CoursIA **hérite automatiquement** du harnais de la flotte : `CLAUDE.md` et `.claude/rules/*.md` sont auto-chargés, ils ne demandent pas la permission d'entrer dans le contexte.

Un agent étudiant **discipliné suit donc ces règles**. Il cherche un dashboard auquel il n'a pas accès, réclame une lane qui n'existe pas, et s'interdit de conclure sa session.

Le défaut n'est pas le contenu des obligations — elles sont justes pour leur destinataire. **C'est le destinataire qui n'était nommé nulle part.**

## Ce que fait cette PR

Une section en tête de `CLAUDE.md`, +17 lignes, un seul fichier. Elle :

1. dit que les obligations de flotte lient `ai-01` et les workers `po-*`, **et eux seuls** ;
2. **énumère nommément** ce qu'un agent externe ne doit pas chercher — dashboard, lane, inbox, heartbeat, marqueur de claim, tag `Grain:`, rapport de session — parce que c'est le fait de les *chercher* qui produit le blocage, pas leur existence ;
3. garde ce qui vaut pour tout le monde (§C notebooks, §D anti-régression, §E style, secrets), pour ne pas remplacer un excès par un trou ;
4. renvoie au dépôt de projet étudiant quand c'est là que l'agent travaille.

**Aucune obligation de flotte n'est retirée.** C'est le point 2 de l'acceptance, voie A (phrase de portée), et non la voie B (document d'entrée référencé depuis le README) — l'arbitrage était déjà posé en commentaire de #15285 pour ne pas mettre deux lanes sur `Vibe-Coding/README.md`.

## Acceptance 3 — le test de vérification, et ce qu'il ne couvre pas

Test A/B falsifiable. **Même prompt, même modèle (`haiku`), même format de sortie imposé ; seul l'extrait fourni change.** Chaque agent lit un fichier isolé et rien d'autre, et doit citer le passage qui tranche.

- extrait **AVANT** = `CLAUDE.md` d'`origin/main` : titre + §A (Coordination & Git)
- extrait **APRÈS** = même chose, avec la nouvelle section insérée

Question posée aux deux : *« un étudiant a cloné un dépôt public et lance un agent dessus ; d'après ce texte seul, que doit faire cet agent en début de session ? »*

| Item | AVANT | APRÈS |
|---|---|---|
| Lire un dashboard RooSync | **OUI** | **NON** |
| Lire une inbox RooSync | **OUI** | **NON** |
| Consulter le heartbeat cluster | **OUI** | **NON** |
| Poster un rapport de fin de session | **OUI** | **NON** |
| Écrire à `ai-01` faute de mission | **OUI** | **NON** |

Réponse libre AVANT : « *l'agent doit suivre un tour de coordination type en début de session : lire le dashboard workspace CoursIA complet, consulter l'inbox RooSync […], vérifier le heartbeat cluster […]. Sans mission assignée, il doit envoyer un message à ai-01.* »

Réponse libre APRÈS : « *L'agent en début de session ne doit RIEN faire des actions de coordination de flotte […]. Ce qui le concerne : les règles universelles (§C, §D, §E, secrets), et — pour un dépôt de projet étudiant — la charte du dépôt de groupe.* »

Les cinq items comportementaux basculent, chacun avec la citation qui le tranche. C'est exactement le critère demandé : l'agent **ne répond plus** « lire le dashboard RooSync ».

**Ce que le test ne couvre pas, et il faut le dire :**

- Un **sixième item** figurait dans le protocole (« le texte nomme-t-il explicitement son destinataire ? »). Il est **mal formé** : la convention de sortie que j'ai imposée définissait OUI comme « le texte demande cette action à l'agent », ce qui ne veut rien dire pour une question méta. Les deux agents l'ont donc mal ajusté. **Je ne le compte pas** — le test vaut 5/5 sur les items comportementaux, pas 6/6.
- Les agents lisent un **extrait**, pas un clone complet sans contexte de flotte. C'est un proxy assumé : un sous-agent lancé depuis ce dépôt auto-charge `CLAUDE.md` et ne peut structurellement pas jouer l'agent naïf. Le proxy teste ce qui est en cause — *le texte, à lui seul, produit-il la bonne conclusion* — et rien de plus.
- Premier essai sous `sonnet` : les deux agents sont tombés en `API Error 400`. Rejoué sous `haiku`, les deux ont abouti. Signalé à part, sans rapport avec le contenu de cette PR.

## Portée : moitié CoursIA seulement

L'acceptance 1 de #15287 (charte d'agent étudiant dans `jsboigeEPF/2026-MSMIN5IN52-GenAI`) **n'est pas dans cette PR** et ne peut pas y être : aucun compte du trousseau `ai-01` n'a `push` sur ce dépôt. Mesure et verdict `RECOVERABLE-USER-HAND` en commentaire de l'issue. Le blocage est re-signalé au user en `[ASK USER]`.

Donc : `See #15287`, pas `Closes` — l'issue reste ouverte sur sa moitié bloquée.

## Vérifications

- `git diff --stat` : 1 fichier, +17/−0. Aucun notebook, aucun catalogue, aucune traduction, aucun ledger.
- Aucune obligation de flotte supprimée : le diff est purement additif.
- Claim posée avant édition, scope `CLAUDE.md`, verdict `CLEAR` (aucune autre lane).
- Réattribution : ce grain était sur `myia-po-2027:CoursIA`, lane qui a demandé sa reprise (hors mission slides, échéance EPF ce matin). Relâché puis repris par `myia-ai-01:CoursIA` — `CLAUDE.md` est la surface du coordinateur.

## Note G-VAR-1

`MED/docs` est un genre **META** : cette PR **ne tient pas** le plancher de contenu de ma lane, et je ne prétends pas le contraire. Elle passe parce que la séance 1/6 est **aujourd'hui** et que les agents étudiants sont lancés pour la première fois cet après-midi. Le grain de contenu de ma lane est nommé séparément.

See #15287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
