### PR TITLE
fix(vibe-coding): installation_status() rend son verdict sur ses 3 chemins d'échec (NameError resolved_path)

### DIFF
--- a/scripts/tests/test_claude_cli_installation_status.py
+++ b/scripts/tests/test_claude_cli_installation_status.py
@@ -1,0 +1,94 @@
+"""Temoins a processus simules pour installation_status()/verify_installation().
+
+Aucun binaire reel n'est invoque : shutil.which et subprocess.run sont
+remplaces par des mocks. Reproduit les six cas de #15281 -- le diagnostic
+doit rendre son verdict sur ses trois chemins d'echec, jamais lever
+NameError (le defaut historique : f-string interpolait resolved_path au
+lieu de la variable locale resolved).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_HELPERS = (
+    Path(__file__).resolve().parents[2]
+    / "MyIA.AI.Notebooks"
+    / "GenAI"
+    / "Vibe-Coding"
+    / "Claude-Code"
+    / "notebooks"
+    / "helpers"
+)
+sys.path.insert(0, str(_HELPERS))
+
+import claude_cli  # noqa: E402
+
+FAKE_PATH = "C:/fake/bin/claude.CMD"
+
+
+def _run_rc1(*args, **kwargs):
+    return subprocess.CompletedProcess(args=[args[0]], returncode=1, stdout="", stderr="boom")
+
+
+def test_absent_introuvable():
+    with mock.patch("shutil.which", return_value=None):
+        status = claude_cli.installation_status()
+    assert status["state"] == "introuvable"
+
+
+def test_version_ok_executable():
+    with mock.patch("shutil.which", return_value=FAKE_PATH), mock.patch(
+        "subprocess.run", return_value=subprocess.CompletedProcess(
+            args=["claude", "--version"], returncode=0, stdout="1.0.0", stderr=""
+        )
+    ):
+        status = claude_cli.installation_status()
+    assert status["state"] == "executable"
+    assert status["resolved_path"] == FAKE_PATH
+
+
+def test_returncode_1_non_executable_avec_chemin_et_code():
+    with mock.patch("shutil.which", return_value=FAKE_PATH), mock.patch(
+        "subprocess.run", side_effect=_run_rc1
+    ):
+        status = claude_cli.installation_status()
+    assert status["state"] == "non-executable"
+    assert FAKE_PATH in status["message"]
+    assert "code 1" in status["message"]
+    assert status["resolved_path"] == FAKE_PATH
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        subprocess.TimeoutExpired(cmd=["claude", "--version"], timeout=15),
+        OSError("acces refuse"),
+        FileNotFoundError("shim introuvable"),
+    ],
+)
+def test_exceptions_chemins_echec_non_executable(exc):
+    with mock.patch("shutil.which", return_value=FAKE_PATH), mock.patch(
+        "subprocess.run", side_effect=exc
+    ):
+        status = claude_cli.installation_status()
+    assert status["state"] == "non-executable"
+    assert FAKE_PATH in status["message"]
+    assert status["resolved_path"] == FAKE_PATH
+
+
+def test_verify_installation_false_quand_non_executable():
+    with mock.patch("shutil.which", return_value=FAKE_PATH), mock.patch(
+        "subprocess.run", side_effect=_run_rc1
+    ):
+        assert claude_cli.verify_installation() is False
+
+
+def test_verify_installation_false_quand_introuvable():
+    with mock.patch("shutil.which", return_value=None):
+        assert claude_cli.verify_installation() is False


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2023:CoursIA — prev: MED/genai #15167

See #15281 (defaut corrige sur main par #15282 — voir ci-dessous)

## Livrable apres rebase : les tests, le fix etant deja sur main

Le correctif de code (`{resolved_path}` -> `{resolved}` dans les deux f-strings de `installation_status()`, `claude_cli.py` l.68/74) a ete merge sur `main` par **#15282** (`dd3055a4808`) — verifie bit-a-bit identique par l'organe de path-collision (memes hashes de blob `4c9a1fc0ad..dc83bff69f`, cf note ai-01). Apres rebase sur `origin/main`, le diff de cette PR sur `claude_cli.py` se dissout : il ne reste que **les 8 temoins a processus simules** qui verrouillent les trois chemins d'echec du diagnostic — la partie que #15282 n'a pas.

Diff post-rebase : `scripts/tests/test_claude_cli_installation_status.py`, +94 lignes, 1 fichier.

## Ce que verrouillent les tests

`installation_status()` doit rendre son verdict (`introuvable` / `non-executable` / `executable`) sur ses **trois chemins d'echec** — jamais lever `NameError` (le defaut historique : les f-strings interpolaient `resolved_path` au lieu de la variable locale `resolved`).

| Test | Cas | Verdict attendu |
|---|---|---|
| `test_absent_introuvable` | `shutil.which` -> None | `state: introuvable` |
| `test_version_ok_executable` | rc=0, stdout 1.0.0 | `executable` + `resolved_path` present |
| `test_returncode_1_non_executable_avec_chemin_et_code` | rc=1 | `non-executable`, chemin ET code dans le message |
| `test_exceptions_chemins_echec_non_executable` (x3) | TimeoutExpired / OSError / FileNotFoundError | `non-executable`, chemin dans le message |
| `test_verify_installation_false_quand_non_executable` | rc=1 | `verify_installation()` -> False |
| `test_verify_installation_false_quand_introuvable` | which None | `verify_installation()` -> False |

Aucun binaire reel invoque : `shutil.which` et `subprocess.run` sont mockes (`FAKE_PATH = "C:/fake/bin/claude.CMD"` — shim Windows .CMD).

## Controle negatif (pre-rebase, sur la version cassee)

5 de ces tests echouaient sur la version pre-fix (`NameError: name 'resolved_path' is not defined` au lieu du verdict) : le temoin discrimine bien le defaut, il ne teste pas une tautologie.

## Validation

- `python -m pytest scripts/tests/test_claude_cli_installation_status.py -q` : **8 passed** en 0.07 s sur `origin/main` post-rebase (head `0b58b4f90e`).
- Rebase verifie : `git diff origin/main -- .../claude_cli.py` = vide (dissolution confirmee), `git diff origin/main...HEAD --stat` = le seul fichier de test.

## Historique de la branche

- `7fc7b84b10` : fix + tests (pre-#15282).
- `0b58b4f90e` : rebase sur `origin/main` (post-#15282) — le fix se dissout, les tests restent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)