### PR TITLE
docs(fine-tuning): FT-04 réaligner le bilan DPO sur les outputs committés (97 %, +0,1483, 0,6585→0,2419)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb
@@ -1632,11 +1632,11 @@
    "source": [
     "**Analyse — le verdict que l'ancienne version de ce notebook cachait.** Trois lectures, dans l'ordre d'importance :\n",
     "\n",
-    "1. **Le contraste train/eval est LA métrique.** Accuracy sur les 108 paires d'entraînement : **98 %** (106/108). Accuracy sur les **18 paires d'évaluation disjointes** — 6 sujets jamais vus, ni leurs réponses ni leurs rejets : **56 %** (10/18). L'ancienne version affichait « 6/6 (100 %) » en le présentant comme un succès : ce 100 %-là, c'est ce 98 %-là — de la **mémorisation**. À 56 % sur des fonds nouveaux, le DPO de 108 paires est à peine au-dessus du hasard (50 %) : à cette échelle, il apprend surtout les paires qu'il voit. La courbe d'epoch le confirme : l'eval passe par **39 %** à l'epoch 1 (sous le hasard — pousser les log-probs des paires vues dégrade d'abord la préférence ailleurs), puis remonte à 56 % et s'y stabilise.\n",
+    "1. **Le contraste train/eval est LA métrique.** Accuracy sur les 108 paires d'entraînement : **97 %** (105/108). Accuracy sur les **18 paires d'évaluation disjointes** — 6 sujets jamais vus, ni leurs réponses ni leurs rejets : **56 %** (10/18). L'ancienne version affichait « 6/6 (100 %) » en le présentant comme un succès : ce 100 %-là, c'est ce 97 %-là — de la **mémorisation**. À 56 % sur des fonds nouveaux, le DPO de 108 paires est à peine au-dessus du hasard (50 %) : à cette échelle, il apprend surtout les paires qu'il voit. La courbe d'epoch le confirme : l'eval passe par **39 %** à l'epoch 1 (sous le hasard — pousser les log-probs des paires vues dégrade d'abord la préférence ailleurs), puis remonte à 56 % et s'y stabilise.\n",
     "\n",
     "2. **Le transfert est réel mais inégal, famille par famille.** Rapporté au proxy du modèle de base (section 4 : vague 2 %, expéditive 7 %, hors-sujet 62 %), l'eval post-DPO donne : contre l'**expéditive** 5/6 (83 % — transfert net), contre le **vague** 2/6 (33 % — amélioré depuis 2 %, mais loin du compte), contre le **hors-sujet** 3/6 (50 % — pas mieux que le base, qui le classait déjà bien). Le DPO transfère ce qui est *cohérent entre sujets* (le style expéditif est toujours familier), moins ce qui est *spécifique* (le vague lisse ressemble à du bon texte pour un petit modèle).\n",
     "\n",
-    "3. **Les générations, elles, n'ont pas changé de ligue.** SFT et DPO produisent tous deux du semi-charabia (lisez-les ci-dessus). C'est la leçon la plus profonde du DPO à petite échelle : **il aligne un classement, il ne crée pas de compétence**. Le plafond des générations vient du SFT de départ (36 exemples) et de la taille du modèle — le DPO déplace les préférences relatives dans cet espace limité, il ne l'agrandit pas. La marge moyenne positive sur l'eval (+0,18 log-prob/token) dit que la direction est bonne ; le 56 % dit que le chemin est long. En production : SFT sérieux d'abord, DPO sur des dizaines de milliers de paires ensuite — et l'évaluation sur jeu disjoint, toujours."
+    "3. **Les générations, elles, n'ont pas changé de ligue.** SFT et DPO produisent tous deux du semi-charabia (lisez-les ci-dessus). C'est la leçon la plus profonde du DPO à petite échelle : **il aligne un classement, il ne crée pas de compétence**. Le plafond des générations vient du SFT de départ (36 exemples) et de la taille du modèle — le DPO déplace les préférences relatives dans cet espace limité, il ne l'agrandit pas. La marge moyenne positive sur l'eval (+0,1483 log-prob/token) dit que la direction est bonne ; le 56 % dit que le chemin est long. En production : SFT sérieux d'abord, DPO sur des dizaines de milliers de paires ensuite — et l'évaluation sur jeu disjoint, toujours."
    ]
   },
   {
@@ -2059,11 +2059,11 @@
     "| **DPO** | Optimisation directe des préférences, sans reward model séparé |\n",
     "| **Perte DPO** | Maximise la marge entre log-probs chosen vs rejected par rapport à la référence |\n",
     "| **Beta** | Paramètre de temperature controlant la force de l'alignement |\n",
-    "| **Résultat** | Train 98 % (mémorisation) vs **eval disjointe 56 %** — et des générations inchangées : DPO aligne un classement, il ne crée pas de compétence |\n",
+    "| **Résultat** | Train 97 % (mémorisation) vs **eval disjointe 56 %** — et des générations inchangées : DPO aligne un classement, il ne crée pas de compétence |\n",
     "\n",
     "**Prochaines étapes** : Le FT-05 explorera le merge de modèles et le routing, qui permettent de combiner plusieurs modèles specialises en un seul modèle plus performant.\n",
     "\n",
-    "**Bilan chiffré du TP** : 126 paires déterministes (graine 42), split **par fond** 108 train / 18 eval ; SFT de référence 36 exemples × 3 epochs ; DPO 3 epochs × 27 steps (batch 4, beta 0,1, lr 1e-5), perte 0,655 → 0,237. Le verdict en une ligne : la métrique d'entraînement (98 %) et la métrique de généralisation (56 %) **doivent toujours être lues ensemble** — une sans l'autre ment, dans un sens comme dans l'autre.\n",
+    "**Bilan chiffré du TP** : 126 paires déterministes (graine 42), split **par fond** 108 train / 18 eval ; SFT de référence 36 exemples × 3 epochs ; DPO 3 epochs × 27 steps (batch 4, beta 0,1, lr 1e-5), perte 0,6585 → 0,2419. Le verdict en une ligne : la métrique d'entraînement (97 %) et la métrique de généralisation (56 %) **doivent toujours être lues ensemble** — une sans l'autre ment, dans un sens comme dans l'autre.\n",
     "\n",
     "***\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/genai #15167

Closes #15262

## Constat (vérifié firsthand sur main 119ec7da0, pas seulement sur le commit de l'issue)

Les outputs committés de `FT-04-RLHF-DPO.ipynb` :
- cellule `b3a7520d` : epoch 1 loss **0.6585** (eval 39 %), epoch 3 loss **0.2419**, train **105/108 (97 %)**, eval **10/18 (56 %)** ;
- cellule `dfbc120b` : train **105/108 (97 %)**, marge eval **+0.1483 log-prob/token**.

La prose restait stale : `32fa6669` citait « 98 % (106/108) » et « +0,18 » ; `64ce4cf1` résumait « 98 % » et « 0,655 → 0,237 ».

## Correction (markdown-only, 3+3 valeurs)

| Cellule | Avant | Après |
|---|---|---|
| `32fa6669` | Accuracy train **98 % (106/108)** | **97 % (105/108)** |
| `32fa6669` | « ce 100 %-là, c'est ce 98 %-là » | « c'est ce 97 %-là » |
| `32fa6669` | « (+0,18 log-prob/token) » | « (+0,1483 log-prob/token) » |
| `64ce4cf1` | « Train 98 % (mémorisation) » | « Train 97 % (mémorisation) » |
| `64ce4cf1` | « perte 0,655 → 0,237 » | « perte 0,6585 → 0,2419 » |
| `64ce4cf1` | « la métrique d'entraînement (98 %) » | « (97 %) » |

Conservés tels quels : les citations historiques de l'ancienne version (« 6/6 (100 %) », « 100 % de préférences correctes » dans `7923db4b`) — elles décrivent explicitement le passé, pas les outputs courants ; le 39 % epoch-1 (vérifié : 7/18) et les compteurs par famille (2/6, 5/6, 3/6) sont exacts.

## Preuves

- **Acceptance #15262** : 105/108 (97 %) partout ✓ · +0,1483 ✓ · 0,6585 → 0,2419 ✓ · markdown-only ✓
- **Invariants** : comparaison nbformat intégrale old vs new — 32 cellules, IDs/types/ordre identiques, **aucune cellule code touchée** (source, outputs, execution_count byte-identiques), seules `32fa6669` et `64ce4cf1` (markdown) diffèrent.
- **Zéro output hand-édité** (règle Stop & Repair) — la régle C.2 exception markdown-only s'applique.
- Grep post-fix : plus aucune occurrence de 98 %, 106/108, +0,18, 0,655, 0,237 dans les cellules descriptives.

## Notes

- PR atomique : 1 notebook, 1 sujet. Catalogue byte-identique à main.
- Suite de la famille FT (FT-02 #15260 livré, FT-05 #15263 réparé round-2 par la lane CoursIA-2 de cette machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
