### PR TITLE
fix(genai,#15261): FT-03 — aligner le résidu « 21 exemples » sur les 227 paires committées (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb
@@ -1101,7 +1101,7 @@
    "source": [
     "## 5. Entrainement SFT\n",
     "\n",
-    "Nous utilisons le `Trainer` de HuggingFace pour orchestrer l'entrainement. Le dataset est petit (21 exemples), donc nous ferons plusieurs epoques pour que le modèle apprenne bien le format instruction/reponse.\n",
+    "Nous utilisons le `Trainer` de HuggingFace pour orchestrer l'entrainement. Le dataset reste un corpus pédagogique petit (**227 paires** — cf. sorties des cellules précédentes : « Dataset SFT : 227 paires », « 227 exemples formates »), très en deçà des 10 000–1 000 000 paires d'un SFT de production, donc nous ferons plusieurs epoques pour que le modèle apprenne bien le format instruction/reponse.\n",
     "\n",
     "**Hyperparametres cles** :\n",
     "- `num_train_epochs=5` : le dataset est petit, on compense avec plus de passages\n",


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/genai #14774

fix(genai,#15261): FT-03 — aligner le résidu « dataset petit (21 exemples) » sur les 227 paires committées (markdown-only)

## Contexte

Issue #15261 (Astra wave 2, `CONFIRMED_PEDAGOGY`) : `FT-03-Supervised-FineTuning-SFT.ipynb` construit, affiche et interprète **227 paires** (vérifié firsthand dans les outputs committés : cellule `f850cac2` → `Dataset SFT : 227 paires (deterministe, graine 42)`, cellule `aeb5d3eb` → `227 exemples formates`), mais la cellule markdown `dbb4632c` (§5 Entraînement SFT) dit encore « Le dataset est petit (21 exemples) ». Résidu post-livraison du chantier #12428 (clos), pas une réouverture de son acceptance.

## Correctif (markdown-only, 1 substitution, diff +1/−1)

Cellule `dbb4632c` : la phrase stale devient —

> Le dataset reste un corpus pédagogique petit (**227 paires** — cf. sorties des cellules précédentes : « Dataset SFT : 227 paires », « 227 exemples formates »), très en deçà des 10 000–1 000 000 paires d'un SFT de production, donc nous ferons plusieurs epoques…

La portée pédagogique (« petit, donc plusieurs epochs ») est **préservée** — elle reste vraie à 227 paires ; seule la donnée stale change, avec renvoi aux outputs qui portent la mesure.

## Acceptance ↔ preuves

| Critère | Statut | Preuve |
|---|---|---|
| Aucune mention stale de 21 exemples | OK | Sweep nbformat post-fix : `21 exemples` / `petit (21` / `(21 ` = 0 occurrence restante (unique occurrence était `dbb4632c`) |
| Cohérence avec les outputs 227 | OK | Prose cite verbatim les deux lignes d'output (`Dataset SFT : 227 paires`, `227 exemples formates`) vérifiées firsthand dans le notebook committé |
| Markdown-only : code/outputs/exec counts/métadonnées préservés | OK | Comparateur nbformat vs `origin/main` : toutes cellules code byte-identiques (source/outputs/execution_count/metadata), seule `dbb4632c` (markdown) change ; pre-commit H.3 Passed |

## Plateau / garde

- L898/L1356 : issue OPEN, claim CLEAR au moment du pick (posé : commentaire 5594678575), aucune PR ouverte touchant le chemin (issue vérifiée + REST search).
- Worktree isolé `CoursIA-c335-ft03`, 1 fichier, diff `+1/−1`.

Closes #15261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
