### PR TITLE
fix(claudish,#15286): CLAUDISH_BASE_URL lue a l'appel, pas a l'import (V03 defaut 1)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/claudish_client.py
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/claudish_client.py
@@ -26,7 +26,12 @@ from typing import Iterator, List, Optional
 import httpx
 
 
-# URL par defaut : localhost en dev, models.myia.io en prod
+# URL par defaut : localhost en dev, models.myia.io en prod. La constante
+# reste exportee pour compatibilite (les tests la monkeypatchent), mais
+# depuis #15286 la resolution EFFECTIVE se fait a l'appel via
+# `_resolve_base_url` : poser CLAUDISH_BASE_URL dans une cellule APRES
+# l'import est honored (defaut V03 : valeur figee au chargement du module,
+# cible immobile sans erreur).
 DEFAULT_BASE_URL = os.environ.get("CLAUDISH_BASE_URL", "http://localhost:3000")
 ANTHROPIC_VERSION = "2023-06-01"
 
@@ -41,9 +46,20 @@ KNOWN_MODELS = [
 ]
 
 
+def _resolve_base_url(base_url: Optional[str] = None) -> str:
+    """URL de base effective, lue A L'APPEL (#15286).
+
+    Ordre de precedence : argument explicite > CLAUDISH_BASE_URL lu au
+    moment de l'appel > DEFAULT_BASE_URL (constante d'import, fallback de
+    compatibilite monkeypatche par les tests historiques).
+    """
+    resolved = base_url or os.environ.get("CLAUDISH_BASE_URL") or DEFAULT_BASE_URL
+    return resolved.rstrip("/")
+
+
 def get_endpoint(base_url: Optional[str] = None) -> str:
     """Retourne l'URL complet du endpoint /v1/messages."""
-    base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    base = _resolve_base_url(base_url)
     return f"{base}/v1/messages"
 
 
@@ -57,7 +73,7 @@ def get_api_key(env_var: str = "ANTHROPIC_AUTH_TOKEN") -> Optional[str]:
 
 def list_models(base_url: Optional[str] = None, timeout: float = 5.0) -> List[dict]:
     """Liste les modeles exposes par Claudish (endpoint /v1/models)."""
-    base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    base = _resolve_base_url(base_url)
     with httpx.Client(timeout=timeout) as client:
         r = client.get(f"{base}/v1/models")
         r.raise_for_status()

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/test_claudish_client.py
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/helpers/test_claudish_client.py
@@ -108,6 +108,9 @@ def test_known_models_includes_secondary_haiku():
 # --------------------------------------------------------------------------
 def test_get_endpoint_default_uses_module_default(monkeypatch):
     """Sans argument, get_endpoint utilise DEFAULT_BASE_URL + '/v1/messages'."""
+    # #15286 : delenv requis — l'env lue a l'appel primerait sur la
+    # constante patchee si le shell hote exporte CLAUDISH_BASE_URL.
+    monkeypatch.delenv("CLAUDISH_BASE_URL", raising=False)
     monkeypatch.setattr(claudish_client, "DEFAULT_BASE_URL", "http://localhost:3000")
     assert claudish_client.get_endpoint() == "http://localhost:3000/v1/messages"
 
@@ -132,6 +135,9 @@ def test_get_endpoint_custom_base_url():
 
 def test_get_endpoint_none_falls_back_to_default(monkeypatch):
     """base_url=None doit etre equivalent a ne rien passer."""
+    # #15286 : delenv requis — meme raison que :111 (env d'appel prime
+    # sur la constante patchee si le shell l'exporte).
+    monkeypatch.delenv("CLAUDISH_BASE_URL", raising=False)
     monkeypatch.setattr(claudish_client, "DEFAULT_BASE_URL", "http://fallback:5000")
     assert claudish_client.get_endpoint(None) == "http://fallback:5000/v1/messages"
 
@@ -723,3 +729,73 @@ def test_stream_chat_empty_delta_text_not_yielded(monkeypatch):
         claudish_client.httpx.Client = original_client
 
     assert deltas == ["kept"]
+
+
+# --------------------------------------------------------------------------
+# #15286 (V03) — lecture d'env a l'APPEL, pas a l'import
+# --------------------------------------------------------------------------
+def test_env_set_after_import_is_honored(monkeypatch):
+    """#15286 temoin : poser CLAUDISH_BASE_URL dans une cellule APRES
+    l'import doit etre honored par get_endpoint(). Defaut V03 : la lecture
+    d'environnement se faisait au chargement du module (DEFAULT_BASE_URL
+    fige a l'import), donc la cible ne bougeait pas -- silencieusement,
+    sans erreur. C'est exactement le geste etudiant : executer la cellule
+    d'import, decouvrir que l'endpoint est faux, corriger la variable dans
+    une cellule suivante, re-executer... et rien ne change.
+    """
+    monkeypatch.delenv("CLAUDISH_BASE_URL", raising=False)
+    # Reference relative a la constante (et non localhost:3000 en dur) :
+    # si le shell hote exportait deja CLAUDISH_BASE_URL au moment de
+    # l'import du module, la constante a gele cette valeur -- c'est le
+    # contrat de compat, le temoin porte sur l'env d'APPEL, pas l'import.
+    expected_default = claudish_client.DEFAULT_BASE_URL.rstrip("/") + "/v1/messages"
+    assert claudish_client.get_endpoint() == expected_default
+    monkeypatch.setenv("CLAUDISH_BASE_URL", "http://proxy-etudiant:4000")
+    assert claudish_client.get_endpoint() == "http://proxy-etudiant:4000/v1/messages"
+
+
+def test_explicit_base_url_still_wins_over_env(monkeypatch):
+    """#15286 controle de precedence : l'argument explicite base_url=
+    prime sur l'environnement pose a l'appel (et sur la constante)."""
+    monkeypatch.setenv("CLAUDISH_BASE_URL", "http://from-env:4000")
+    out = claudish_client.get_endpoint("https://explicit.myia.io")
+    assert out == "https://explicit.myia.io/v1/messages"
+
+
+def test_default_base_url_monkeypatch_still_fallback(monkeypatch):
+    """#15286 garde de compat : DEFAULT_BASE_URL reste exporte et reste
+    le fallback quand CLAUDISH_BASE_URL est absent a l'appel -- les tests
+    historiques (:109/:133) qui monkeypatchent la constante gardent leur
+    semantique. Le delenv protege le fallback contre une env heritee du
+    shell qui ferait gagner l'environnement sur la constante patchee.
+    """
+    monkeypatch.delenv("CLAUDISH_BASE_URL", raising=False)
+    monkeypatch.setattr(claudish_client, "DEFAULT_BASE_URL", "http://patched:5000")
+    assert claudish_client.get_endpoint() == "http://patched:5000/v1/messages"
+
+
+def test_list_models_honors_env_set_after_import(monkeypatch):
+    """#15286 : list_models (second consommateur, :60) lit aussi l'env a
+    l'appel. Le transport est stubbe -- le temoin verifie l'URL DEMANDEE
+    au transport, pas une reponse reelle."""
+    monkeypatch.setenv("CLAUDISH_BASE_URL", "http://proxy-etudiant:4000")
+    seen_urls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_urls.append(str(request.url))
+        return httpx.Response(200, json={"data": []})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as _:
+        # list_models construit son propre Client : on patch httpx.Client
+        # pour y injecter le transport (pattern MockTransport hermetique).
+        original_client = httpx.Client
+
+        def _client_with_transport(*args, **kwargs):
+            kwargs["transport"] = transport
+            return original_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "Client", _client_with_transport)
+        claudish_client.list_models()
+
+    assert seen_urls == ["http://proxy-etudiant:4000/v1/models"]


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #15179

## Resume (defaut 1 de #15286, V03)

`claudish_client.py:30` lisait `CLAUDISH_BASE_URL` **au chargement du module** et les deux consommateurs (`get_endpoint:46`, `list_models:60`) lisaient la constante figee. Poser la variable dans une cellule **apres** l'import n'avait aucun effet : la cible ne bougeait pas, sans erreur. Les deux consommateurs passent par `_resolve_base_url` : **argument explicite > env lue A L'APPEL > `DEFAULT_BASE_URL`** (constante d'import, fallback de compatibilite). `chat`/`stream_chat` routent par `get_endpoint` → couverts par construction.

## Temoin d'abord (acceptance 1)

Tests ecrits AVANT le fix, joues sur le main pristine (worktree frais, client non modifie) :

```
$ python -m pytest .../test_claudish_client.py -q      # main, temoin present, fix absent
FAILED test_env_set_after_import_is_honored      # get_endpoint() rend localhost:3000
                                                  # malgre l'env posee apres l'import
FAILED test_list_models_honors_env_set_after_import
                                                  # URL demandee au transport :
                                                  # http://localhost:3000/v1/models
                                                  # attendu : http://proxy-etudiant:4000/v1/models
======== 2 failed, 36 passed in 0.62s ========
```

Apres le fix :

```
$ python -m pytest .../test_claudish_client.py -q
======== 38 passed in 0.47s ========

$ CLAUDISH_BASE_URL=http://shell-leak:9000 python -m pytest .../test_claudish_client.py -q
======== 38 passed in 0.27s ========    # suite valide meme si le shell hote exporte la variable
```

## Garde (acceptance 2)

`DEFAULT_BASE_URL` reste exporte et reste le fallback quand l'env est absente a l'appel. Les deux tests historiques qui la monkeypatchent (`:109` `test_get_endpoint_default_uses_module_default`, `:136` `test_get_endpoint_none_falls_back_to_default`) passent — durcis d'un `monkeypatch.delenv` chacun : sans lui, un shell qui exporte `CLAUDISH_BASE_URL` ferait primer l'env d'appel sur la constante patchee et casserait la garde (semiantique preservee, robustesse ajoutee).

## Compte de tests (acceptance 3)

- 34 tests preexistants (PR #7391) : tous passent.
- 4 nouveaux : `test_env_set_after_import_is_honored` (temoin), `test_explicit_base_url_still_wins_over_env` (precedence), `test_default_base_url_monkeypatch_still_fallback` (garde de compat), `test_list_models_honors_env_set_after_import` (2e consommateur, URL demandee au transport `httpx.MockTransport`, zero reseau).
- **Total : 38 passed**, zero reseau, zero cle.

## Perimetre

Defaut 1 uniquement. Defaut 2 (table des quatre conventions d'env) = PR separee LIGHT/docs comme autorise par le dispatch. Le notebook `01-claude-code-via-claudish.ipynb` ne lit la constante que dans sa cellule d'import (verifie cellule par cellule) — pas de changement notebook, pas de re-execution requise.

See #15286 (defaut 1/2 ; defaut 2 = table des conventions, PR separee a venir)
