### PR TITLE
fix(probas,#15140): DecPyMC-8 migration arviz 1.1 (ci_prob/ci_kind + az.hdi prob)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-8-Actuarial-Credibility.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-8-Actuarial-Credibility.ipynb
@@ -5,10 +5,10 @@
    "id": "fe218f97",
    "metadata": {
     "papermill": {
-     "duration": 0.005485,
-     "end_time": "2026-09-08T01:22:11.023004+00:00",
+     "duration": 0.00812,
+     "end_time": "2026-09-11T11:51:58.189419",
      "exception": false,
-     "start_time": "2026-09-08T01:22:11.017519+00:00",
+     "start_time": "2026-09-11T11:51:58.181299",
      "status": "completed"
     },
     "tags": []
@@ -32,10 +32,10 @@
    "id": "f0fa83f1",
    "metadata": {
     "papermill": {
-     "duration": 0.004271,
-     "end_time": "2026-09-08T01:22:11.032535+00:00",
+     "duration": 0.007009,
+     "end_time": "2026-09-11T11:51:58.203943",
      "exception": false,
-     "start_time": "2026-09-08T01:22:11.028264+00:00",
+     "start_time": "2026-09-11T11:51:58.196934",
      "status": "completed"
     },
     "tags": []
@@ -61,10 +61,10 @@
    "id": "e7d916a0",
    "metadata": {
     "papermill": {
-     "duration": 0.004297,
-     "end_time": "2026-09-08T01:22:11.043372+00:00",
+     "duration": 0.006577,
+     "end_time": "2026-09-11T11:51:58.218553",
      "exception": false,
-     "start_time": "2026-09-08T01:22:11.039075+00:00",
+     "start_time": "2026-09-11T11:51:58.211976",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "c8218959",
    "metadata": {
     "papermill": {
-     "duration": 0.004231,
-     "end_time": "2026-09-08T01:22:11.052427+00:00",
+     "duration": 0.005135,
+     "end_time": "2026-09-11T11:51:58.229687",
      "exception": false,
-     "start_time": "2026-09-08T01:22:11.048196+00:00",
+     "start_time": "2026-09-11T11:51:58.224552",
      "status": "completed"
     },
     "tags": []
@@ -119,16 +119,16 @@
    "id": "b492836c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:11.064611Z",
-     "iopub.status.busy": "2026-09-08T01:22:11.063626Z",
-     "iopub.status.idle": "2026-09-08T01:22:12.423206Z",
-     "shell.execute_reply": "2026-09-08T01:22:12.423206Z"
+     "iopub.execute_input": "2026-09-11T11:51:58.246330Z",
+     "iopub.status.busy": "2026-09-11T11:51:58.246330Z",
+     "iopub.status.idle": "2026-09-11T11:52:00.028465Z",
+     "shell.execute_reply": "2026-09-11T11:52:00.026445Z"
     },
     "papermill": {
-     "duration": 1.366252,
-     "end_time": "2026-09-08T01:22:12.424214+00:00",
+     "duration": 1.792043,
+     "end_time": "2026-09-11T11:52:00.029467",
      "exception": false,
-     "start_time": "2026-09-08T01:22:11.057962+00:00",
+     "start_time": "2026-09-11T11:51:58.237424",
      "status": "completed"
     },
     "tags": []
@@ -259,10 +259,10 @@
    "id": "ccebf3af",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-09-08T01:22:12.430216+00:00",
+     "duration": 0.006602,
+     "end_time": "2026-09-11T11:52:00.043829",
      "exception": false,
-     "start_time": "2026-09-08T01:22:12.427216+00:00",
+     "start_time": "2026-09-11T11:52:00.037227",
      "status": "completed"
     },
     "tags": []
@@ -287,10 +287,10 @@
    "id": "78c85789",
    "metadata": {
     "papermill": {
-     "duration": 0.003083,
-     "end_time": "2026-09-08T01:22:12.435296+00:00",
+     "duration": 0.006698,
+     "end_time": "2026-09-11T11:52:00.058183",
      "exception": false,
-     "start_time": "2026-09-08T01:22:12.432213+00:00",
+     "start_time": "2026-09-11T11:52:00.051485",
      "status": "completed"
     },
     "tags": []
@@ -312,16 +312,16 @@
    "id": "2bc8c772",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:12.441505Z",
-     "iopub.status.busy": "2026-09-08T01:22:12.441505Z",
-     "iopub.status.idle": "2026-09-08T01:22:12.451415Z",
-     "shell.execute_reply": "2026-09-08T01:22:12.450404Z"
+     "iopub.execute_input": "2026-09-11T11:52:00.079526Z",
+     "iopub.status.busy": "2026-09-11T11:52:00.078526Z",
+     "iopub.status.idle": "2026-09-11T11:52:00.097746Z",
+     "shell.execute_reply": "2026-09-11T11:52:00.096736Z"
     },
     "papermill": {
-     "duration": 0.014109,
-     "end_time": "2026-09-08T01:22:12.451415+00:00",
+     "duration": 0.034223,
+     "end_time": "2026-09-11T11:52:00.100069",
      "exception": false,
-     "start_time": "2026-09-08T01:22:12.437306+00:00",
+     "start_time": "2026-09-11T11:52:00.065846",
      "status": "completed"
     },
     "tags": []
@@ -413,10 +413,10 @@
    "id": "b794e835",
    "metadata": {
     "papermill": {
-     "duration": 0.003179,
-     "end_time": "2026-09-08T01:22:12.457592+00:00",
+     "duration": 0.006735,
+     "end_time": "2026-09-11T11:52:00.114856",
      "exception": false,
-     "start_time": "2026-09-08T01:22:12.454413+00:00",
+     "start_time": "2026-09-11T11:52:00.108121",
      "status": "completed"
     },
     "tags": []
@@ -445,10 +445,10 @@
    "id": "f0138da2",
    "metadata": {
     "papermill": {
-     "duration": 0.003518,
-     "end_time": "2026-09-08T01:22:12.464216+00:00",
+     "duration": 0.008078,
+     "end_time": "2026-09-11T11:52:00.130945",
      "exception": false,
-     "start_time": "2026-09-08T01:22:12.460698+00:00",
+     "start_time": "2026-09-11T11:52:00.122867",
      "status": "completed"
     },
     "tags": []
@@ -475,16 +475,16 @@
    "id": "5e14b6d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:12.471216Z",
-     "iopub.status.busy": "2026-09-08T01:22:12.471216Z",
-     "iopub.status.idle": "2026-09-08T01:22:18.196305Z",
-     "shell.execute_reply": "2026-09-08T01:22:18.195244Z"
+     "iopub.execute_input": "2026-09-11T11:52:00.156491Z",
+     "iopub.status.busy": "2026-09-11T11:52:00.155363Z",
+     "iopub.status.idle": "2026-09-11T11:52:14.688859Z",
+     "shell.execute_reply": "2026-09-11T11:52:14.687341Z"
     },
     "papermill": {
-     "duration": 5.729596,
-     "end_time": "2026-09-08T01:22:18.196815+00:00",
+     "duration": 14.548406,
+     "end_time": "2026-09-11T11:52:14.689859",
      "exception": false,
-     "start_time": "2026-09-08T01:22:12.467219+00:00",
+     "start_time": "2026-09-11T11:52:00.141453",
      "status": "completed"
     },
     "tags": []
@@ -515,7 +515,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 500 tune and 500 draw iterations (1_000 + 1_000 draws total) took 2 seconds.\n"
+      "Sampling 2 chains for 500 tune and 500 draw iterations (1_000 + 1_000 draws total) took 5 seconds.\n"
      ]
     },
     {
@@ -555,8 +555,8 @@
        "      <th></th>\n",
        "      <th>mean</th>\n",
        "      <th>sd</th>\n",
-       "      <th>eti94_lb</th>\n",
-       "      <th>eti94_ub</th>\n",
+       "      <th>hdi94_lb</th>\n",
+       "      <th>hdi94_ub</th>\n",
        "      <th>ess_bulk</th>\n",
        "      <th>ess_tail</th>\n",
        "      <th>r_hat</th>\n",
@@ -654,7 +654,7 @@
        "</div>"
       ],
       "text/plain": [
-       "            mean      sd eti94_lb eti94_ub  ess_bulk  ess_tail r_hat  \\\n",
+       "            mean      sd hdi94_lb hdi94_ub  ess_bulk  ess_tail r_hat  \\\n",
        "mu_0_log   -2.34    0.15     -2.7     -2.1       649       567  1.00   \n",
        "sigma_0     0.28    0.15      0.1     0.62       366       512  1.00   \n",
        "theta[0]   0.083   0.023    0.041     0.13       530       385  1.00   \n",
@@ -709,7 +709,7 @@
     "    )\n",
     "\n",
     "print(\"Sampling termine.\")\n",
-    "summary = az.summary(idata, var_names=[\"mu_0_log\", \"sigma_0\", \"theta\"], ci_prob=0.94)\n",
+    "summary = az.summary(idata, var_names=[\"mu_0_log\", \"sigma_0\", \"theta\"], ci_prob=0.94, ci_kind=\"hdi\")\n",
     "summary\n"
    ]
   },
@@ -718,10 +718,10 @@
    "id": "ef2dbce0",
    "metadata": {
     "papermill": {
-     "duration": 0.003188,
-     "end_time": "2026-09-08T01:22:18.203366+00:00",
+     "duration": 0.008003,
+     "end_time": "2026-09-11T11:52:14.705223",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.200178+00:00",
+     "start_time": "2026-09-11T11:52:14.697220",
      "status": "completed"
     },
     "tags": []
@@ -754,10 +754,10 @@
    "id": "c1a59668",
    "metadata": {
     "papermill": {
-     "duration": 0.002511,
-     "end_time": "2026-09-08T01:22:18.208951+00:00",
+     "duration": 0.007001,
+     "end_time": "2026-09-11T11:52:14.720755",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.206440+00:00",
+     "start_time": "2026-09-11T11:52:14.713754",
      "status": "completed"
     },
     "tags": []
@@ -781,16 +781,16 @@
    "id": "9b5f897a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:18.216819Z",
-     "iopub.status.busy": "2026-09-08T01:22:18.216310Z",
-     "iopub.status.idle": "2026-09-08T01:22:18.229343Z",
-     "shell.execute_reply": "2026-09-08T01:22:18.228273Z"
+     "iopub.execute_input": "2026-09-11T11:52:14.751525Z",
+     "iopub.status.busy": "2026-09-11T11:52:14.750407Z",
+     "iopub.status.idle": "2026-09-11T11:52:14.778419Z",
+     "shell.execute_reply": "2026-09-11T11:52:14.776290Z"
     },
     "papermill": {
-     "duration": 0.017379,
-     "end_time": "2026-09-08T01:22:18.229900+00:00",
+     "duration": 0.045516,
+     "end_time": "2026-09-11T11:52:14.780315",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.212521+00:00",
+     "start_time": "2026-09-11T11:52:14.734799",
      "status": "completed"
     },
     "tags": []
@@ -832,10 +832,10 @@
    "id": "7989464a",
    "metadata": {
     "papermill": {
-     "duration": 0.00262,
-     "end_time": "2026-09-08T01:22:18.235817+00:00",
+     "duration": 0.007692,
+     "end_time": "2026-09-11T11:52:14.796438",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.233197+00:00",
+     "start_time": "2026-09-11T11:52:14.788746",
      "status": "completed"
     },
     "tags": []
@@ -866,10 +866,10 @@
    "id": "f447d3b9",
    "metadata": {
     "papermill": {
-     "duration": 0.0028,
-     "end_time": "2026-09-08T01:22:18.241769+00:00",
+     "duration": 0.012692,
+     "end_time": "2026-09-11T11:52:14.817884",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.238969+00:00",
+     "start_time": "2026-09-11T11:52:14.805192",
      "status": "completed"
     },
     "tags": []
@@ -886,16 +886,16 @@
    "id": "0505864b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:18.248999Z",
-     "iopub.status.busy": "2026-09-08T01:22:18.248438Z",
-     "iopub.status.idle": "2026-09-08T01:22:18.654553Z",
-     "shell.execute_reply": "2026-09-08T01:22:18.653548Z"
+     "iopub.execute_input": "2026-09-11T11:52:14.841689Z",
+     "iopub.status.busy": "2026-09-11T11:52:14.840506Z",
+     "iopub.status.idle": "2026-09-11T11:52:16.320224Z",
+     "shell.execute_reply": "2026-09-11T11:52:16.319215Z"
     },
     "papermill": {
-     "duration": 0.411011,
-     "end_time": "2026-09-08T01:22:18.655552+00:00",
+     "duration": 1.494625,
+     "end_time": "2026-09-11T11:52:16.322746",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.244541+00:00",
+     "start_time": "2026-09-11T11:52:14.828121",
      "status": "completed"
     },
     "tags": []
@@ -952,10 +952,10 @@
    "id": "3a87e5a7",
    "metadata": {
     "papermill": {
-     "duration": 0.004234,
-     "end_time": "2026-09-08T01:22:18.663786+00:00",
+     "duration": 0.009261,
+     "end_time": "2026-09-11T11:52:16.342367",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.659552+00:00",
+     "start_time": "2026-09-11T11:52:16.333106",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "230e4653",
    "metadata": {
     "papermill": {
-     "duration": 0.004606,
-     "end_time": "2026-09-08T01:22:18.672392+00:00",
+     "duration": 0.012,
+     "end_time": "2026-09-11T11:52:16.363789",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.667786+00:00",
+     "start_time": "2026-09-11T11:52:16.351789",
      "status": "completed"
     },
     "tags": []
@@ -1004,10 +1004,10 @@
    "id": "5f62e7e6",
    "metadata": {
     "papermill": {
-     "duration": 0.004265,
-     "end_time": "2026-09-08T01:22:18.680389+00:00",
+     "duration": 0.008803,
+     "end_time": "2026-09-11T11:52:16.381112",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.676124+00:00",
+     "start_time": "2026-09-11T11:52:16.372309",
      "status": "completed"
     },
     "tags": []
@@ -1028,16 +1028,16 @@
    "id": "9b64478e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:18.688780Z",
-     "iopub.status.busy": "2026-09-08T01:22:18.688780Z",
-     "iopub.status.idle": "2026-09-08T01:22:18.694092Z",
-     "shell.execute_reply": "2026-09-08T01:22:18.693057Z"
+     "iopub.execute_input": "2026-09-11T11:52:16.404374Z",
+     "iopub.status.busy": "2026-09-11T11:52:16.404374Z",
+     "iopub.status.idle": "2026-09-11T11:52:16.413522Z",
+     "shell.execute_reply": "2026-09-11T11:52:16.411898Z"
     },
     "papermill": {
-     "duration": 0.01158,
-     "end_time": "2026-09-08T01:22:18.695168+00:00",
+     "duration": 0.025599,
+     "end_time": "2026-09-11T11:52:16.416323",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.683588+00:00",
+     "start_time": "2026-09-11T11:52:16.390724",
      "status": "completed"
     },
     "tags": []
@@ -1072,10 +1072,10 @@
    "id": "78404e24",
    "metadata": {
     "papermill": {
-     "duration": 0.004992,
-     "end_time": "2026-09-08T01:22:18.703927+00:00",
+     "duration": 0.009033,
+     "end_time": "2026-09-11T11:52:16.433904",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.698935+00:00",
+     "start_time": "2026-09-11T11:52:16.424871",
      "status": "completed"
     },
     "tags": []
@@ -1092,16 +1092,16 @@
    "id": "bc068a6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:18.714021Z",
-     "iopub.status.busy": "2026-09-08T01:22:18.714021Z",
-     "iopub.status.idle": "2026-09-08T01:22:18.719235Z",
-     "shell.execute_reply": "2026-09-08T01:22:18.718191Z"
+     "iopub.execute_input": "2026-09-11T11:52:16.455583Z",
+     "iopub.status.busy": "2026-09-11T11:52:16.455057Z",
+     "iopub.status.idle": "2026-09-11T11:52:16.464881Z",
+     "shell.execute_reply": "2026-09-11T11:52:16.462867Z"
     },
     "papermill": {
-     "duration": 0.011744,
-     "end_time": "2026-09-08T01:22:18.719764+00:00",
+     "duration": 0.02192,
+     "end_time": "2026-09-11T11:52:16.465881",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.708020+00:00",
+     "start_time": "2026-09-11T11:52:16.443961",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1136,10 @@
    "id": "6b40492b",
    "metadata": {
     "papermill": {
-     "duration": 0.003976,
-     "end_time": "2026-09-08T01:22:18.728532+00:00",
+     "duration": 0.010968,
+     "end_time": "2026-09-11T11:52:16.485926",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.724556+00:00",
+     "start_time": "2026-09-11T11:52:16.474958",
      "status": "completed"
     },
     "tags": []
@@ -1161,16 +1161,16 @@
    "id": "b2af9c65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:18.738117Z",
-     "iopub.status.busy": "2026-09-08T01:22:18.736580Z",
-     "iopub.status.idle": "2026-09-08T01:22:18.743000Z",
-     "shell.execute_reply": "2026-09-08T01:22:18.741951Z"
+     "iopub.execute_input": "2026-09-11T11:52:16.507873Z",
+     "iopub.status.busy": "2026-09-11T11:52:16.506874Z",
+     "iopub.status.idle": "2026-09-11T11:52:16.514976Z",
+     "shell.execute_reply": "2026-09-11T11:52:16.513968Z"
     },
     "papermill": {
-     "duration": 0.012358,
-     "end_time": "2026-09-08T01:22:18.743614+00:00",
+     "duration": 0.021049,
+     "end_time": "2026-09-11T11:52:16.516976",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.731256+00:00",
+     "start_time": "2026-09-11T11:52:16.495927",
      "status": "completed"
     },
     "tags": []
@@ -1202,10 +1202,10 @@
    "id": "3570c3e4",
    "metadata": {
     "papermill": {
-     "duration": 0.005858,
-     "end_time": "2026-09-08T01:22:18.754405+00:00",
+     "duration": 0.008508,
+     "end_time": "2026-09-11T11:52:16.536009",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.748547+00:00",
+     "start_time": "2026-09-11T11:52:16.527501",
      "status": "completed"
     },
     "tags": []
@@ -1237,10 +1237,10 @@
    "id": "fc3b01df",
    "metadata": {
     "papermill": {
-     "duration": 0.004041,
-     "end_time": "2026-09-08T01:22:18.763534+00:00",
+     "duration": 0.009539,
+     "end_time": "2026-09-11T11:52:16.557247",
      "exception": false,
-     "start_time": "2026-09-08T01:22:18.759493+00:00",
+     "start_time": "2026-09-11T11:52:16.547708",
      "status": "completed"
     },
     "tags": []
@@ -1279,14 +1279,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 9.355172,
-   "end_time": "2026-09-08T01:22:19.427460+00:00",
+   "duration": 22.380054,
+   "end_time": "2026-09-11T11:52:17.773091",
    "environment_variables": {},
    "exception": null,
-   "input_path": "DecPyMC-8-Actuarial-Credibility.ipynb",
-   "output_path": "DecPyMC-8-Actuarial-Credibility.ipynb",
+   "input_path": "C:\\dev\\CoursIA-15333-rebase\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-8-Actuarial-Credibility.ipynb",
+   "output_path": "C:\\dev\\CoursIA-15333-rebase\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\PyMC\\DecPyMC-8-Actuarial-Credibility_output.ipynb",
    "parameters": {},
-   "start_time": "2026-09-08T01:22:10.072288+00:00",
+   "start_time": "2026-09-11T11:51:55.393037",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/tooling #15259

## Ce que cette PR est devenue (rebase 2026-09-11)

Cette PR a été ouverte comme la migration arviz 1.1 de `DecPyMC-8`. Entre-temps, **#15156 a mergé la même migration** sur `main` (commit `06ab17f62`, en fermant #15140). Après rebase, il ne reste donc **qu'une seule ligne de source** en diff — mais elle n'est pas cosmétique :

> #15156 a remplacé `hdi_prob=0.94` par **`ci_prob=0.94` seul**. En arviz 1.1, `ci_kind` défaut vaut `None`, que la bibliothèque résout en **`"eti"`**. L'intervalle affiché n'est donc plus un **HDI** mais un **ETI** — alors que la prose du notebook annonce « HDI 94 % » en trois endroits.

La preuve est dans les sorties committées : `origin/main` affiche les colonnes **`eti94_lb` / `eti94_ub`**, là où le notebook parle de HDI. **La sortie contredit sa propre prose.**

| | Source | Sorties committées |
|---|---|---|
| `origin/main` (post-#15156) | `az.summary(..., ci_prob=0.94)` | `eti94_lb` / `eti94_ub` |
| **cette PR** | `az.summary(..., ci_prob=0.94, ci_kind="hdi")` | **`hdi94_lb` / `hdi94_ub`** |

Le diff de **source** se réduit donc à :

```diff
-summary = az.summary(idata, var_names=["mu_0_log", "sigma_0", "theta"], ci_prob=0.94)
+summary = az.summary(idata, var_names=["mu_0_log", "sigma_0", "theta"], ci_prob=0.94, ci_kind="hdi")
```

Les 123 autres lignes de diff sont les **sorties ré-exécutées** (C.2 : cellule code modifiée ⇒ ré-exécution complète ; les noms de colonnes changent, les outputs ne peuvent pas être retouchés à la main).

`See #15592` (défaut systémique : un **second** notebook, `DecPyMC-2`, porte exactement la même dérive). `See #15140` (EPIC fermée par #15156 — le pattern cassé a bien disparu, mais cette dérive-ci est d'une autre nature : le notebook s'exécute et ment sur ce qu'il affiche).

## Validation réelle (H.1, règle C.2)

- **Ré-exécution complète** sur la tête rebasée, kernel `pymc-arviz11` (arviz **1.1.0**, pymc 6.3.1, python 3.12) : `notebook_tools.py execute` → **SUCCESS, 32,1 s**, 8/8 cellules code, `execution_count` **1→8 séquentiels**, **0 sortie d'erreur**.
- Le kernel `python3` du dépôt pointe sur le Python système 3.11 (arviz **0.23.4**), qui ne connaît pas `ci_prob` — l'exécution passe donc par le kernel `pymc-arviz11`, seul porteur d'arviz 1.1. Le `kernelspec` du notebook est **conservé à `python3`**, inchangé (valeur d'origine, identique à `main`).
- Colonnes d'intervalle après ré-exécution : **`hdi94_lb` / `hdi94_ub`** — cohérentes avec la prose « HDI 94 % ».
- **Diff source minimal** vérifié par comparaison cellule à cellule contre `origin/main` : **1 seule** cellule code diffère (cellule #2), d'une ligne. Aucun newline ni EOL parasite (fichier normalisé LF, sans newline final, comme `main`).

## Diff

1 fichier, `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-8-Actuarial-Credibility.ipynb` — source : 1 ligne ; sorties : ré-exécution.

## Suite

Le même geste reste à faire sur `DecPyMC-2-Utility-Money.ipynb` (3 appels `az.summary`, prose « HDI 89 % », sorties `eti89_*`) — suivi par **#15592**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)