### PR TITLE
fix(twin,#15345): dedupe byte-identical audits + guard index/digest uniqueness

### DIFF
--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -340,6 +340,56 @@ def test_audit_filenames_bounded_for_windows():
     )
 
 
+def test_audit_index_unique_and_no_identical_duplicates_per_pair():
+    """#15345 : deux invariants du journal file-per-audit, invisibles a tout
+    garde de nommage (les deux cas constates portaient des noms canoniques ou
+    bornes).
+
+    1. Unicite du prefixe ``NNNN`` dans une paire : l'index zero-pade est la
+       cle de tri du journal (``sorted(glob)`` = ordre d'append, #14911) ;
+       deux fichiers au meme index rendent leur ordre relatif dependant du
+       reste du nom. Incident fondateur : #15225 (cap du lane slug a 48
+       chars) a AJOUTE la copie cappee sans retirer l'original long -- deux
+       ``0008`` dans gametheory-6-evolutiontrust.
+
+    2. Absence de deux attestations byte-identiques dans une paire : des
+       octets identiques ne portent aucune information incrementale (date,
+       lane et shas identiques), et ``_load_audits_from_files`` append chaque
+       fichier -- le journal double-compterait un audit unique. Incident
+       fondateur : gametheory-13-imperfectinfo-cfr 0003/0005, herites de la
+       liste inline de l'ancien registre mono-fichier (la migration #14940 a
+       copie 12 entrees vers 12 fichiers, doublon compris).
+
+    Controle positif : ce test est ROUGE sur le registre pre-deduplication
+    (les deux classes ci-dessus) et VERT apres suppression des deux copies
+    redundantes.
+    """
+    import hashlib
+
+    bad_index: list[str] = []
+    bad_dup: list[str] = []
+    for pair_dir in sorted(p for p in REGISTRY_DIR.iterdir() if p.is_dir()):
+        seen_idx: dict[str, str] = {}
+        seen_digest: dict[str, str] = {}
+        for f in sorted(pair_dir.glob("*.yaml")):
+            idx = f.name.split("-", 1)[0]
+            prev = seen_idx.setdefault(idx, f.name)
+            if prev != f.name:
+                bad_index.append(f"{pair_dir.name}: {prev} et {f.name}")
+            digest = hashlib.sha256(f.read_bytes()).hexdigest()
+            twin = seen_digest.setdefault(digest, f.name)
+            if twin != f.name:
+                bad_dup.append(f"{pair_dir.name}: {twin} et {f.name}")
+    assert not bad_index, (
+        f"prefixe NNNN duplique dans une paire (l'index est la cle de tri du "
+        f"journal, #14911/#15345) : {bad_index}"
+    )
+    assert not bad_dup, (
+        f"attestations byte-identiques intra-paire (le journal double-compte "
+        f"un audit unique, #15345) : {bad_dup}"
+    )
+
+
 # --- Verification d'integrite des sha attestes (#9399 volet b) ---
 
 

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr/0005-2026-08-06-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr/0005-2026-08-06-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,0 @@
-date: '2026-08-06'
-by: myia-po-2023:CoursIA
-python_sha: b3bd262cde2415bb2c9fccc4e8bd2c81558356e9
-csharp_sha: 1d6da069eae78cde4f5b345be9b1e04193e90ab8
-content_python_sha: 793e5533a28e7743ae17b4738104264540f86e5ec891589c69870ebbaddb2165
-content_csharp_sha: 1029ed07df0d1d47e21dbb9eb4edbba761c01b178fcfbe22fdfe24f379c26108

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust/0008-2026-08-24-CoursIA-2-DRIFT-INTRO-ESS.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust/0008-2026-08-24-CoursIA-2-DRIFT-INTRO-ESS.yaml
@@ -1,8 +1,0 @@
-date: '2026-08-24'
-by: 'myia-po-2027:CoursIA-2 -- DRIFT_INTRODUCED attendu : livraison substance ESS
-  C# de Maynard Smith (verdicts 7x7 + x0 + Faucon-Colombe), 7 cellules ajoutees (cell
-  18-28), cell 21 ESS code, papermill strip applique (volet c #9399 metadata-immune)'
-python_sha: f330b4d038bf312f8ad5c6f98d923dda45b0d162
-csharp_sha: d465d4c9c186893032969564dc6cdbe675d1a050
-content_python_sha: 5dcde663bc2227b9d7a784c806f95761a6f3284a363bcf892a4a3f98b41fedab
-content_csharp_sha: 01e5645cc9f961328cdd8b4f145378847b26dfac812d2d99323a8ced083d67be


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: LIGHT/ledger #15336

# Registre twin : dédup des faux-jumeaux + garde double-invariant (#15345)

Réparation des deux classes de doublons constatées sur `main` par ai-01 (#15345), toutes deux **survivant à #15336** (git mv pur, zéro dédup). Verdict complet (historique git + ancien registre mono-fichier) déposé sur l'issue — **aucune des deux n'est un défaut du writer courant**. Mécanismes distincts, même réparation : suppression d'une copie redondante avec preuve de préservation + garde de non-régression sur les deux invariants.

## gametheory-6 — index `0008` dupliqué + double attestation

Cause : **#15225** (cap du lane slug à 48 chars) a **ajouté** la copie plafonnée `0008-2026-08-24-myia-po-2027-CoursIA-2.yaml` **sans retirer** l'original trop long. Table de vérité : migration #14940 → un seul `0008` (208 chars) ; #15129 → renommé 123 chars ; **#15225 → deux `0008`** ; #15336 → original renommé `0008-2026-08-24-CoursIA-2-DRIFT-INTRO-ESS.yaml`. L'ancien registre portait l'entrée une seule fois — la duplication naît du commit de cap.

Fix : suppression de `0008-2026-08-24-CoursIA-2-DRIFT-INTRO-ESS.yaml`, conservation de la copie canonique `0008-2026-08-24-myia-po-2027-CoursIA-2.yaml` (ce que #15225 destinait à laisser). Préservation : même blob `450541d0` (549 o), byte-identical, rien perdu.

## gametheory-13 — `0003` ≡ `0005` byte-identiques

Cause : doublon hérité de l'ancienne liste inline — l'ancien registre avait 12 entrées dont les rangs 3 et 5 identiques (rang 4 distinct) ; la migration #14940 a copié 12→12 fidèlement. Octets identiques = zéro information incrémentale.

Fix : suppression de `0005-...` (occurrence tardive), conservation de `0003-...` (première attestation). Préservation : sha256 identique `28df601416e3` + historique git.

## Garde (livrable durable, acceptance 4)

`test_audit_index_unique_and_no_identical_duplicates_per_pair` — deux invariants : unicité du préfixe `NNNN` par paire ; absence d'attestations byte-identiques intra-paire. C'est le second qui faisait défaut — la classe B est invisible à tout garde de nommage.

**Validation** (contrôle positif mesuré en local) :
- ROUGE état initial (classe A : double `0008` gametheory-6) ;
- ROUGE post-paire-6 (classe B isolée : `0003`/`0005` gametheory-13) — détection indépendante prouvée ;
- VERT post-dédup ; suite `test_twin_registry_integrity.py` **41 passed** (1 warning préexistant d'orphans par squash) ;
- `check_twin_parity --check` **157 paires DRIFT=0** — verdicts inchangés (suppression d'audits non-derniers ; `_latest` = 0012 des deux côtés).

Closes #15345
