### PR TITLE
fix(genai,#15219): realigner six stubs d'exercices (commentaires [1..6] + intro + re-exec CLI)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -5,10 +5,10 @@
    "id": "3f1a7217",
    "metadata": {
     "papermill": {
-     "duration": 0.004084,
-     "end_time": "2026-08-23T19:32:01.567794",
+     "duration": 0.004038,
+     "end_time": "2026-09-09T08:01:15.635076",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.563710",
+     "start_time": "2026-09-09T08:01:15.631038",
      "status": "completed"
     },
     "tags": []
@@ -52,10 +52,10 @@
    "id": "f8fb81b3",
    "metadata": {
     "papermill": {
-     "duration": 0.003664,
-     "end_time": "2026-08-23T19:32:01.574998",
+     "duration": 0.003152,
+     "end_time": "2026-09-09T08:01:15.641461",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.571334",
+     "start_time": "2026-09-09T08:01:15.638309",
      "status": "completed"
     },
     "tags": []
@@ -74,16 +74,16 @@
    "id": "a6f5ac7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:01.583180Z",
-     "iopub.status.busy": "2026-08-23T19:32:01.582964Z",
-     "iopub.status.idle": "2026-08-23T19:32:01.590164Z",
-     "shell.execute_reply": "2026-08-23T19:32:01.589438Z"
+     "iopub.execute_input": "2026-09-09T08:01:15.647529Z",
+     "iopub.status.busy": "2026-09-09T08:01:15.647335Z",
+     "iopub.status.idle": "2026-09-09T08:01:15.656858Z",
+     "shell.execute_reply": "2026-09-09T08:01:15.656479Z"
     },
     "papermill": {
-     "duration": 0.012268,
-     "end_time": "2026-08-23T19:32:01.591120",
+     "duration": 0.01357,
+     "end_time": "2026-09-09T08:01:15.657602",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.578852",
+     "start_time": "2026-09-09T08:01:15.644032",
      "status": "completed"
     },
     "tags": []
@@ -131,10 +131,10 @@
    "id": "ea639250",
    "metadata": {
     "papermill": {
-     "duration": 0.003044,
-     "end_time": "2026-08-23T19:32:01.597852",
+     "duration": 0.002851,
+     "end_time": "2026-09-09T08:01:15.663354",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.594808",
+     "start_time": "2026-09-09T08:01:15.660503",
      "status": "completed"
     },
     "tags": []
@@ -150,10 +150,10 @@
    "id": "ad39c7b4",
    "metadata": {
     "papermill": {
-     "duration": 0.003011,
-     "end_time": "2026-08-23T19:32:01.604111",
+     "duration": 0.002939,
+     "end_time": "2026-09-09T08:01:15.669278",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.601100",
+     "start_time": "2026-09-09T08:01:15.666339",
      "status": "completed"
     },
     "tags": []
@@ -172,16 +172,16 @@
    "id": "68dff378",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:01.612462Z",
-     "iopub.status.busy": "2026-08-23T19:32:01.612198Z",
-     "iopub.status.idle": "2026-08-23T19:32:01.775719Z",
-     "shell.execute_reply": "2026-08-23T19:32:01.774922Z"
+     "iopub.execute_input": "2026-09-09T08:01:15.675590Z",
+     "iopub.status.busy": "2026-09-09T08:01:15.675318Z",
+     "iopub.status.idle": "2026-09-09T08:01:16.409502Z",
+     "shell.execute_reply": "2026-09-09T08:01:16.409074Z"
     },
     "papermill": {
-     "duration": 0.169503,
-     "end_time": "2026-08-23T19:32:01.776683",
+     "duration": 0.738314,
+     "end_time": "2026-09-09T08:01:16.410269",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.607180",
+     "start_time": "2026-09-09T08:01:15.671955",
      "status": "completed"
     },
     "tags": []
@@ -209,10 +209,10 @@
    "id": "6e6db82e",
    "metadata": {
     "papermill": {
-     "duration": 0.00398,
-     "end_time": "2026-08-23T19:32:01.785869",
+     "duration": 0.002897,
+     "end_time": "2026-09-09T08:01:16.418212",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.781889",
+     "start_time": "2026-09-09T08:01:16.415315",
      "status": "completed"
     },
     "tags": []
@@ -228,10 +228,10 @@
    "id": "d9561974",
    "metadata": {
     "papermill": {
-     "duration": 0.006121,
-     "end_time": "2026-08-23T19:32:01.795834",
+     "duration": 0.003998,
+     "end_time": "2026-09-09T08:01:16.425972",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.789713",
+     "start_time": "2026-09-09T08:01:16.421974",
      "status": "completed"
     },
     "tags": []
@@ -263,16 +263,16 @@
    "id": "21577bb2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:01.805473Z",
-     "iopub.status.busy": "2026-08-23T19:32:01.805138Z",
-     "iopub.status.idle": "2026-08-23T19:32:02.092772Z",
-     "shell.execute_reply": "2026-08-23T19:32:02.092191Z"
+     "iopub.execute_input": "2026-09-09T08:01:16.432653Z",
+     "iopub.status.busy": "2026-09-09T08:01:16.432408Z",
+     "iopub.status.idle": "2026-09-09T08:01:16.749346Z",
+     "shell.execute_reply": "2026-09-09T08:01:16.748606Z"
     },
     "papermill": {
-     "duration": 0.294032,
-     "end_time": "2026-08-23T19:32:02.094127",
+     "duration": 0.321861,
+     "end_time": "2026-09-09T08:01:16.750661",
      "exception": false,
-     "start_time": "2026-08-23T19:32:01.800095",
+     "start_time": "2026-09-09T08:01:16.428800",
      "status": "completed"
     },
     "tags": []
@@ -297,10 +297,10 @@
    "id": "4caec1fe",
    "metadata": {
     "papermill": {
-     "duration": 0.003349,
-     "end_time": "2026-08-23T19:32:02.102021",
+     "duration": 0.004644,
+     "end_time": "2026-09-09T08:01:16.759752",
      "exception": false,
-     "start_time": "2026-08-23T19:32:02.098672",
+     "start_time": "2026-09-09T08:01:16.755108",
      "status": "completed"
     },
     "tags": []
@@ -321,16 +321,16 @@
    "id": "3e3e2440",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:02.112530Z",
-     "iopub.status.busy": "2026-08-23T19:32:02.112116Z",
-     "iopub.status.idle": "2026-08-23T19:32:05.415837Z",
-     "shell.execute_reply": "2026-08-23T19:32:05.414529Z"
+     "iopub.execute_input": "2026-09-09T08:01:16.769358Z",
+     "iopub.status.busy": "2026-09-09T08:01:16.769116Z",
+     "iopub.status.idle": "2026-09-09T08:01:29.333971Z",
+     "shell.execute_reply": "2026-09-09T08:01:29.333486Z"
     },
     "papermill": {
-     "duration": 3.310809,
-     "end_time": "2026-08-23T19:32:05.417547",
+     "duration": 12.570219,
+     "end_time": "2026-09-09T08:01:29.334738",
      "exception": false,
-     "start_time": "2026-08-23T19:32:02.106738",
+     "start_time": "2026-09-09T08:01:16.764519",
      "status": "completed"
     },
     "tags": []
@@ -361,10 +361,10 @@
    "id": "9d3b4d7d",
    "metadata": {
     "papermill": {
-     "duration": 0.008337,
-     "end_time": "2026-08-23T19:32:05.433149",
+     "duration": 0.003631,
+     "end_time": "2026-09-09T08:01:29.341961",
      "exception": false,
-     "start_time": "2026-08-23T19:32:05.424812",
+     "start_time": "2026-09-09T08:01:29.338330",
      "status": "completed"
     },
     "tags": []
@@ -388,10 +388,10 @@
    "id": "0e966c23",
    "metadata": {
     "papermill": {
-     "duration": 0.007961,
-     "end_time": "2026-08-23T19:32:05.451922",
+     "duration": 0.003057,
+     "end_time": "2026-09-09T08:01:29.348248",
      "exception": false,
-     "start_time": "2026-08-23T19:32:05.443961",
+     "start_time": "2026-09-09T08:01:29.345191",
      "status": "completed"
     },
     "tags": []
@@ -420,16 +420,16 @@
    "id": "947c7f84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:05.469550Z",
-     "iopub.status.busy": "2026-08-23T19:32:05.468823Z",
-     "iopub.status.idle": "2026-08-23T19:32:11.393478Z",
-     "shell.execute_reply": "2026-08-23T19:32:11.392102Z"
+     "iopub.execute_input": "2026-09-09T08:01:29.356828Z",
+     "iopub.status.busy": "2026-09-09T08:01:29.356380Z",
+     "iopub.status.idle": "2026-09-09T08:01:38.135339Z",
+     "shell.execute_reply": "2026-09-09T08:01:38.134531Z"
     },
     "papermill": {
-     "duration": 5.935111,
-     "end_time": "2026-08-23T19:32:11.395025",
+     "duration": 8.784451,
+     "end_time": "2026-09-09T08:01:38.136358",
      "exception": false,
-     "start_time": "2026-08-23T19:32:05.459914",
+     "start_time": "2026-09-09T08:01:29.351907",
      "status": "completed"
     },
     "tags": []
@@ -440,7 +440,7 @@
      "output_type": "stream",
      "text": [
       "=== Reponse Claude ===\n",
-      "Bonjour ! Je suis prêt à vous aider — que puis-je faire pour vous aujourd'hui ?\n",
+      "Bonjour ! Je suis prêt à vous aider sur ce notebook `01-Claude-CLI-Bases.ipynb` — que souhaitez-vous faire ?\n",
       "\n"
      ]
     }
@@ -457,10 +457,10 @@
    "id": "345e49ac",
    "metadata": {
     "papermill": {
-     "duration": 0.005602,
-     "end_time": "2026-08-23T19:32:11.406652",
+     "duration": 0.003292,
+     "end_time": "2026-09-09T08:01:38.144037",
      "exception": false,
-     "start_time": "2026-08-23T19:32:11.401050",
+     "start_time": "2026-09-09T08:01:38.140745",
      "status": "completed"
     },
     "tags": []
@@ -477,16 +477,16 @@
    "id": "2bf264a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:11.420506Z",
-     "iopub.status.busy": "2026-08-23T19:32:11.419902Z",
-     "iopub.status.idle": "2026-08-23T19:32:18.119431Z",
-     "shell.execute_reply": "2026-08-23T19:32:18.118573Z"
+     "iopub.execute_input": "2026-09-09T08:01:38.151347Z",
+     "iopub.status.busy": "2026-09-09T08:01:38.151095Z",
+     "iopub.status.idle": "2026-09-09T08:01:43.061521Z",
+     "shell.execute_reply": "2026-09-09T08:01:43.060445Z"
     },
     "papermill": {
-     "duration": 6.707687,
-     "end_time": "2026-08-23T19:32:18.120859",
+     "duration": 4.915922,
+     "end_time": "2026-09-09T08:01:43.063084",
      "exception": false,
-     "start_time": "2026-08-23T19:32:11.413172",
+     "start_time": "2026-09-09T08:01:38.147162",
      "status": "completed"
     },
     "tags": []
@@ -497,7 +497,7 @@
      "output_type": "stream",
      "text": [
       "=== Reponse Claude ===\n",
-      "Python est un langage de programmation interprété, de haut niveau et à la syntaxe lisible, conçu pour être simple à écrire et à comprendre. Il est utilisé dans de nombreux domaines — développement web, science des données, intelligence artificielle, automatisation — grâce à son vaste écosystème de bibliothèques.\n",
+      "Python est un langage de programmation interprété, de haut niveau, à la syntaxe lisible et proche de l'anglais, ce qui en fait un excellent choix pour les débutants comme pour le prototypage rapide. Il est multi-paradigme (impératif, orienté objet, fonctionnel) et s'appuie sur un vaste écosystème de bibliothèques, ce qui le rend incontournable en data science, en IA et en automatisation de tâches.\n",
       "\n"
      ]
     }
@@ -516,10 +516,10 @@
    "id": "5fc10d0d",
    "metadata": {
     "papermill": {
-     "duration": 0.003749,
-     "end_time": "2026-08-23T19:32:18.129460",
+     "duration": 0.004064,
+     "end_time": "2026-09-09T08:01:43.072495",
      "exception": false,
-     "start_time": "2026-08-23T19:32:18.125711",
+     "start_time": "2026-09-09T08:01:43.068431",
      "status": "completed"
     },
     "tags": []
@@ -535,10 +535,10 @@
    "id": "d6f99fcb",
    "metadata": {
     "papermill": {
-     "duration": 0.003363,
-     "end_time": "2026-08-23T19:32:18.137602",
+     "duration": 0.004578,
+     "end_time": "2026-09-09T08:01:43.081269",
      "exception": false,
-     "start_time": "2026-08-23T19:32:18.134239",
+     "start_time": "2026-09-09T08:01:43.076691",
      "status": "completed"
     },
     "tags": []
@@ -568,16 +568,16 @@
    "id": "8cb4ccf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:18.146365Z",
-     "iopub.status.busy": "2026-08-23T19:32:18.146052Z",
-     "iopub.status.idle": "2026-08-23T19:32:22.401486Z",
-     "shell.execute_reply": "2026-08-23T19:32:22.399925Z"
+     "iopub.execute_input": "2026-09-09T08:01:43.095073Z",
+     "iopub.status.busy": "2026-09-09T08:01:43.094622Z",
+     "iopub.status.idle": "2026-09-09T08:01:48.245139Z",
+     "shell.execute_reply": "2026-09-09T08:01:48.244610Z"
     },
     "papermill": {
-     "duration": 4.261566,
-     "end_time": "2026-08-23T19:32:22.403355",
+     "duration": 5.157707,
+     "end_time": "2026-09-09T08:01:48.246075",
      "exception": false,
-     "start_time": "2026-08-23T19:32:18.141789",
+     "start_time": "2026-09-09T08:01:43.088368",
      "status": "completed"
     },
     "tags": []
@@ -590,11 +590,11 @@
       "=== Format Texte ===\n",
       "Voici 3 langages de programmation populaires :\n",
       "\n",
-      "1. **Python** — très utilisé en data science, IA, web et automatisation. Syntaxe lisible.\n",
-      "2. **JavaScript** — le langage du web (frontend et backend via Node.js), quasi omniprésent.\n",
-      "3. **Java** — langage robuste et performant, très présent en entreprise, Android et backend.\n",
+      "1. **Python** — polyvalent, idéal pour la data science, le ML et le scripting.\n",
+      "2. **JavaScript** — indispensable pour le web (front-end et back-end via Node.js).\n",
+      "3. **Java** — très utilisé en entreprise, Android et systèmes à grande échelle.\n",
       "\n",
-      "(Avec C++, C#, Go ou Rust selon le contexte, la liste peut varier.)\n",
+      "Ce sont les 3 langages les plus cités dans les classements (TIOBE, Stack Overflow) et ils couvrent un large spectre de domaines.\n",
       "\n"
      ]
     }
@@ -615,10 +615,10 @@
    "id": "604429de",
    "metadata": {
     "papermill": {
-     "duration": 0.005996,
-     "end_time": "2026-08-23T19:32:22.415522",
+     "duration": 0.003767,
+     "end_time": "2026-09-09T08:01:48.253606",
      "exception": false,
-     "start_time": "2026-08-23T19:32:22.409526",
+     "start_time": "2026-09-09T08:01:48.249839",
      "status": "completed"
     },
     "tags": []
@@ -635,16 +635,16 @@
    "id": "d412f7be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:22.430935Z",
-     "iopub.status.busy": "2026-08-23T19:32:22.430217Z",
-     "iopub.status.idle": "2026-08-23T19:32:29.068717Z",
-     "shell.execute_reply": "2026-08-23T19:32:29.067158Z"
+     "iopub.execute_input": "2026-09-09T08:01:48.262045Z",
+     "iopub.status.busy": "2026-09-09T08:01:48.261821Z",
+     "iopub.status.idle": "2026-09-09T08:01:53.038319Z",
+     "shell.execute_reply": "2026-09-09T08:01:53.037344Z"
     },
     "papermill": {
-     "duration": 6.647735,
-     "end_time": "2026-08-23T19:32:29.070521",
+     "duration": 4.782474,
+     "end_time": "2026-09-09T08:01:53.039815",
      "exception": false,
-     "start_time": "2026-08-23T19:32:22.422786",
+     "start_time": "2026-09-09T08:01:48.257341",
      "status": "completed"
     },
     "tags": []
@@ -660,18 +660,18 @@
       "  \"subtype\": \"success\",\n",
       "  \"is_error\": false,\n",
       "  \"api_error_status\": null,\n",
-      "  \"duration_ms\": 3334,\n",
-      "  \"duration_api_ms\": 5536,\n",
+      "  \"duration_ms\": 2869,\n",
+      "  \"duration_api_ms\": 3278,\n",
       "  \"num_turns\": 1,\n",
-      "  \"result\": \"```json\\n[\\n  { \\\"nom\\\": \\\"Django\\\", \\\"langage\\\": \\\"Python\\\" },\\n  { \\\"nom\\\": \\\"Rails\\\", \\\"langage\\\": \\\"Ruby\\\" },\\n  { \\\"nom\\\": \\\"Spring\\\", \\\"langage\\\": \\\"Java\\\" }\\n]\\n```\",\n",
+      "  \"result\": \"```json\\n[\\n  { \\\"name\\\": \\\"Django\\\", \\\"language\\\": \\\"Python\\\" },\\n  { \\\"name\\\": \\\"Express\\\", \\\"language\\\": \\\"JavaScript\\\" },\\n  { \\\"name\\\": \\\"Rails\\\", \\\"language\\\": \\\"Ruby\\\" }\\n]\\n```\",\n",
       "  \"stop_reason\": \"end_turn\",\n",
-      "  \"session_id\": \"384129d1-c347-4870-9d8b-d99929cd6be4\",\n",
-      "  \"total_cost_usd\": 0.096998,\n",
+      "  \"session_id\": \"edde99de-147c-4aba-8231-663fcf241d1d\",\n",
+      "  \"total_cost_usd\": 0.5577748,\n",
       "  \"usage\": {\n",
-      "    \"input_tokens\": 94827,\n",
+      "    \"input_tokens\": 110680,\n",
       "    \"cache_creation_input_tokens\": 0,\n",
       "    \"cache_read_input_tokens\": 0,\n",
-      "    \"output_tokens\": 125,\n",
+      "    \"output_tokens\": 163,\n",
       "    \"server_tool_use\": {\n",
       "      \"web_search_requests\": 0,\n",
       "      \"web_fetch_requests\": 0\n",
@@ -687,12 +687,22 @@
       "  },\n",
       "  \"modelUsage\": {\n",
       "    \"claude-haiku-4-5-20251001[1m]\": {\n",
-      "      \"inputTokens\": 95133,\n",
-      "      \"outputTokens\": 373,\n",
+      "      \"inputTokens\": 227,\n",
+      "      \"outputTokens\": 12,\n",
+      "      \"cacheReadInputTokens\": 128,\n",
+      "      \"cacheCreationInputTokens\": 0,\n",
+      "      \"webSearchRequests\": 0,\n",
+      "      \"costUSD\": 0.00029979999999999997,\n",
+      "      \"contextWindow\": 1000000,\n",
+      "      \"maxOutputTokens\": 32000\n",
+      "    },\n",
+      "    \"claude-sonnet-5[1m][1m]\": {\n",
+      "      \"inputTokens\": 110680,\n",
+      "      \"outputTokens\": 163,\n",
       "      \"cacheReadInputTokens\": 0,\n",
       "      \"cacheCreationInputTokens\": 0,\n",
       "      \"webSearchRequests\": 0,\n",
-      "      \"costUSD\": 0.096998,\n",
+      "      \"costUSD\": 0.557475,\n",
       "      \"contextWindow\": 1000000,\n",
       "      \"maxOutputTokens\": 32000\n",
       "    }\n",
@@ -700,7 +710,7 @@
       "  \"permission_denials\": [],\n",
       "  \"terminal_reason\": \"completed\",\n",
       "  \"fast_mode_state\": \"off\",\n",
-      "  \"uuid\": \"132b58cc-0e08-4cd3-8ddf-377a2d932a7b\"\n",
+      "  \"uuid\": \"aab03568-a5c8-445e-ae5f-e6e80e09d1db\"\n",
       "}\n"
      ]
     }
@@ -723,10 +733,10 @@
    "id": "4efff3d5",
    "metadata": {
     "papermill": {
-     "duration": 0.00732,
-     "end_time": "2026-08-23T19:32:29.085124",
+     "duration": 0.006119,
+     "end_time": "2026-09-09T08:01:53.051665",
      "exception": false,
-     "start_time": "2026-08-23T19:32:29.077804",
+     "start_time": "2026-09-09T08:01:53.045546",
      "status": "completed"
     },
     "tags": []
@@ -742,10 +752,10 @@
    "id": "d2828214",
    "metadata": {
     "papermill": {
-     "duration": 0.007364,
-     "end_time": "2026-08-23T19:32:29.100018",
+     "duration": 0.00642,
+     "end_time": "2026-09-09T08:01:53.063681",
      "exception": false,
-     "start_time": "2026-08-23T19:32:29.092654",
+     "start_time": "2026-09-09T08:01:53.057261",
      "status": "completed"
     },
     "tags": []
@@ -776,16 +786,16 @@
    "id": "9a764110",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:29.119530Z",
-     "iopub.status.busy": "2026-08-23T19:32:29.118822Z",
-     "iopub.status.idle": "2026-08-23T19:32:35.056710Z",
-     "shell.execute_reply": "2026-08-23T19:32:35.055495Z"
+     "iopub.execute_input": "2026-09-09T08:01:53.077466Z",
+     "iopub.status.busy": "2026-09-09T08:01:53.076907Z",
+     "iopub.status.idle": "2026-09-09T08:02:00.824283Z",
+     "shell.execute_reply": "2026-09-09T08:02:00.823717Z"
     },
     "papermill": {
-     "duration": 5.948677,
-     "end_time": "2026-08-23T19:32:35.058557",
+     "duration": 7.75489,
+     "end_time": "2026-09-09T08:02:00.825087",
      "exception": false,
-     "start_time": "2026-08-23T19:32:29.109880",
+     "start_time": "2026-09-09T08:01:53.070197",
      "status": "completed"
     },
     "tags": []
@@ -818,10 +828,10 @@
    "id": "68be1884",
    "metadata": {
     "papermill": {
-     "duration": 0.007822,
-     "end_time": "2026-08-23T19:32:35.074319",
+     "duration": 0.003425,
+     "end_time": "2026-09-09T08:02:00.832236",
      "exception": false,
-     "start_time": "2026-08-23T19:32:35.066497",
+     "start_time": "2026-09-09T08:02:00.828811",
      "status": "completed"
     },
     "tags": []
@@ -838,16 +848,16 @@
    "id": "d8d9720e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:35.094418Z",
-     "iopub.status.busy": "2026-08-23T19:32:35.093903Z",
-     "iopub.status.idle": "2026-08-23T19:32:45.434448Z",
-     "shell.execute_reply": "2026-08-23T19:32:45.432611Z"
+     "iopub.execute_input": "2026-09-09T08:02:00.840299Z",
+     "iopub.status.busy": "2026-09-09T08:02:00.839938Z",
+     "iopub.status.idle": "2026-09-09T08:02:15.371075Z",
+     "shell.execute_reply": "2026-09-09T08:02:15.370547Z"
     },
     "papermill": {
-     "duration": 10.352891,
-     "end_time": "2026-08-23T19:32:45.436245",
+     "duration": 14.536168,
+     "end_time": "2026-09-09T08:02:15.371805",
      "exception": false,
-     "start_time": "2026-08-23T19:32:35.083354",
+     "start_time": "2026-09-09T08:02:00.835637",
      "status": "completed"
     },
     "tags": []
@@ -859,56 +869,47 @@
      "text": [
       "=== Modele Sonnet (equilibre) ===\n",
       "=== Reponse Claude ===\n",
-      "En Python, la différence fondamentale :\n",
+      "En Python, la différence fondamentale est la **mutabilité** — tout le reste en découle.\n",
       "\n",
-      "**Liste (`list`)** — mutable\n",
-      "```python\n",
-      "lst = [1, 2, 3]\n",
-      "lst[0] = 99      # OK\n",
-      "lst.append(4)    # OK\n",
-      "```\n",
-      "\n",
-      "**Tuple (`tuple`)** — immuable\n",
-      "```python\n",
-      "tup = (1, 2, 3)\n",
-      "tup[0] = 99      # TypeError: 'tuple' object does not support item assignment\n",
-      "tup.append(4)    # AttributeError: 'tuple' object has no attribute 'append'\n",
-      "```\n",
-      "\n",
-      "## Points clés\n",
-      "\n",
-      "| Aspect | Liste | Tuple |\n",
+      "| | **List** | **Tuple** |\n",
       "|---|---|---|\n",
-      "| Mutation | Mutable | Immuable |\n",
-      "| Syntaxe | `[ ]` | `( )` |\n",
-      "| Performances | Plus lent (hash dynamique) | Plus rapide (structure fixe) |\n",
-      "| Hashable | Non | Oui → utilisable comme clé de dict / élément de set |\n",
-      "| Taille mémoire | Plus grande | Plus compacte |\n",
-      "| Usage typique | Collection qu'on modifie | Données fixes, **records** (ex : un point `(x, y)`) |\n",
+      "| Syntaxe | `[1, 2, 3]` | `(1, 2, 3)` |\n",
+      "| Mutabilité | **Mutable** (modifiable) | **Immutable** (figé) |\n",
+      "| Dictionnaire / set | Interdit (non hashable) | Autorisé si éléments hashables |\n",
+      "| Mémoire / vitesse | Plus lourd (redimensionnable) | Plus léger, légèrement plus rapide |\n",
+      "| Méthodes en place | `append()`, `remove()`, `sort()`, `pop()`… | `count()`, `index()` seulement |\n",
       "\n",
-      "## Nuances importantes\n",
+      "**1. La mutabilité est la vraie frontière.**\n",
+      "```python\n",
+      "liste = [1, 2, 3]\n",
+      "liste.append(4)          # OK → [1, 2, 3, 4]\n",
       "\n",
-      "1. **`(1)` ≠ `(1,)`** — pour un tuple d'un élément, la virgule est obligatoire :\n",
-      "   ```python\n",
-      "   type((1))    # <class 'int'>\n",
-      "   type((1,))   # <class 'tuple'>\n",
-      "   ```\n",
+      "tuple_ = (1, 2, 3)\n",
+      "tuple_.append(4)         # AttributeError : pas d'append\n",
+      "```\n",
       "\n",
-      "2. **L'immutabilité est superficielle** : si le tuple contient des objets mutables, ceux-ci restent modifiables.\n",
-      "   ```python\n",
-      "   tup = ([1, 2], [3, 4])   # tuple immuable...\n",
-      "   tup[0].append(99)        # ...mais la liste interne, elle, est mutable → OK\n",
-      "   ```\n",
+      "**2. Conséquence : hashable ou pas.**\n",
+      "```python\n",
+      "{(1, 2): \"point\"}   # OK, un tuple peut servir de clé\n",
+      "{[1, 2]: \"point\"}   # TypeError : une liste ne peut pas (unhashable)\n",
+      "```\n",
       "\n",
-      "3. **Unpacking / retour multiple** — les fonctions retournent souvent des tuples implicitement :\n",
-      "   ```python\n",
-      "   def divmod(a, b):\n",
-      "       return a // b, a % b   # tuple\n",
-      "   ```\n",
+      "**3. Sémantique d'usage (c'est le point pédagogique le plus utile).**\n",
+      "- **Liste** → collection **homogène**, de longueur **variable**, qu'on manipule : une liste de notes, de fichiers, de clients.\n",
+      "- **Tuple** → un **enregistrement hétérogène figé**, un « paquet » de valeurs liées : les coordonnées `(x, y)`, un `(nom, age)`, un retour multi-valeurs de fonction.\n",
       "\n",
-      "**Règle pratique** : `tuple` = données qui ne devraient pas changer (coordonnées, clés, records, retour de fonction) ; `list` = collection qu'on trie, agrège ou modifie. Le tuple est aussi souvent utilisé comme **clé de dictionnaire** précisément parce que l'immutabilité le rend hashable.\n",
+      "```python\n",
+      "def min_max(valeurs):\n",
+      "    return min(valeurs), max(valeurs)   # renvoie un tuple\n",
+      "```\n",
       "\n",
-      "Si tu le veux pour un notebook, je peux te rédiger une cellule pédagogique avec un exercice dessus.\n",
+      "**4. Piège classique : le tuple à un élément.**\n",
+      "```python\n",
+      "(3)      # un int, pas un tuple !  → 3\n",
+      "(3,)     # la virgule fait le tuple → (3,)\n",
+      "```\n",
+      "\n",
+      "**Règle mnémotechnique pour tes étudiants :** *là où le contenu doit changer → liste ; là où la structure doit rester stable et pouvoir servir de clé → tuple.* Le tuple est aussi un **contrat** : quand tu vois `(x, y)`, tu sais que la donnée n'est pas censée être modifiée, ce qui aide à la lecture du code.\n",
       "\n"
      ]
     }
@@ -929,10 +930,10 @@
    "id": "147bedf3",
    "metadata": {
     "papermill": {
-     "duration": 0.009152,
-     "end_time": "2026-08-23T19:32:45.453883",
+     "duration": 0.003385,
+     "end_time": "2026-09-09T08:02:15.378574",
      "exception": false,
-     "start_time": "2026-08-23T19:32:45.444731",
+     "start_time": "2026-09-09T08:02:15.375189",
      "status": "completed"
     },
     "tags": []
@@ -948,10 +949,10 @@
    "id": "35e0f118",
    "metadata": {
     "papermill": {
-     "duration": 0.009549,
-     "end_time": "2026-08-23T19:32:45.472991",
+     "duration": 0.003085,
+     "end_time": "2026-09-09T08:02:15.384835",
      "exception": false,
-     "start_time": "2026-08-23T19:32:45.463442",
+     "start_time": "2026-09-09T08:02:15.381750",
      "status": "completed"
     },
     "tags": []
@@ -980,16 +981,16 @@
    "id": "1318cd70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:45.498484Z",
-     "iopub.status.busy": "2026-08-23T19:32:45.497742Z",
-     "iopub.status.idle": "2026-08-23T19:32:56.187674Z",
-     "shell.execute_reply": "2026-08-23T19:32:56.186260Z"
+     "iopub.execute_input": "2026-09-09T08:02:15.391863Z",
+     "iopub.status.busy": "2026-09-09T08:02:15.391683Z",
+     "iopub.status.idle": "2026-09-09T08:02:22.891610Z",
+     "shell.execute_reply": "2026-09-09T08:02:22.890780Z"
     },
     "papermill": {
-     "duration": 10.704642,
-     "end_time": "2026-08-23T19:32:56.189060",
+     "duration": 7.504447,
+     "end_time": "2026-09-09T08:02:22.892441",
      "exception": false,
-     "start_time": "2026-08-23T19:32:45.484418",
+     "start_time": "2026-09-09T08:02:15.387994",
      "status": "completed"
     },
     "tags": []
@@ -1000,25 +1001,25 @@
      "output_type": "stream",
      "text": [
       "=== Reponse Claude ===\n",
-      "## Problème identifié : récursion naïve sans mémoïsation\n",
+      "Le problème de performance est la **répétition exponentielle des calculs** : l'implémentation récursive naïve recalcule les mêmes valeurs un nombre de fois grotesque.\n",
       "\n",
-      "La fonction recalculte **plusieurs fois les mêmes sous-problèmes** :\n",
+      "Pour `fibonacci(n)`, chaque appel en relance deux autres (`n-1` et `n-2`), donc la complexité est **O(2ⁿ)** — et, sans mémoïsation, `fibonacci(40)` déclenche déjà ~1,6 milliard d'appels.\n",
       "\n",
       "```python\n",
       "fibonacci(5)\n",
-      "  → fibonacci(4) + fibonacci(3)\n",
-      "    → (fibonacci(3) + fibonacci(2)) + (fibonacci(2) + fibonacci(1))\n",
+      "├── fibonacci(4)\n",
+      "│   ├── fibonacci(3)        # ← recalcul\n",
+      "│   │   ├── fibonacci(2)    # ← recalcul\n",
+      "│   │   └── fibonacci(1)\n",
+      "│   └── fibonacci(2)        # ← recalcul (déjà fait au-dessus)\n",
+      "└── fibonacci(3)            # ← recalcul (déjà fait tout à l'heure)\n",
       "```\n",
       "\n",
-      "On voit `fibonacci(3)` et `fibonacci(2)` apparaître **plusieurs fois** dans l'arbre d'appels. Chaque `fibonacci(n)` déclenche la recomputation complète de tous ses prédécesseurs.\n",
+      "Le même sous-problème (`fibonacci(3)`, `fibonacci(2)`, …) est résolu **des dizaines de fois pour le même `n`**.\n",
       "\n",
-      "**Complexité : O(2ⁿ)** — exponentielle. Le nombre d'appels croît comme le nombre de Fibonacci lui-même (~1.618ⁿ). Pour `n=40`, on parle de ~1 milliard d'appels ; `n=100` est inatteignable.\n",
+      "## Fixes possibles\n",
       "\n",
-      "**Cause racine** : aucun partage de résultats intermédiaires, alors que les sous-problèmes se chevauchent massivement (underlapping subproblems). C'est le contre-exemple classique où la programmation dynamique s'applique.\n",
-      "\n",
-      "## Solutions\n",
-      "\n",
-      "**1. Mémoïsation (DP top-down)** — O(n) temps, O(n) mémoire :\n",
+      "**1. Mémoïsation** — on passe à **O(n)** (chaque valeur calculée une seule fois) :\n",
       "\n",
       "```python\n",
       "from functools import lru_cache\n",
@@ -1030,7 +1031,7 @@
       "    return fibonacci(n-1) + fibonacci(n-2)\n",
       "```\n",
       "\n",
-      "**2. Itératif (DP bottom-up)** — O(n) temps, O(1) mémoire :\n",
+      "**2. Itératif** — **O(n)** en temps, **O(1)** en espace (encore meilleur que la mémoïsation qui stocke tout) :\n",
       "\n",
       "```python\n",
       "def fibonacci(n):\n",
@@ -1040,7 +1041,9 @@
       "    return a\n",
       "```\n",
       "\n",
-      "Le piège à retenir : un `_cache` global ou `@lru_cache` ne suffit pas si on **appelle** la fonction via un wrapper qui ne le partage pas (le cache doit être porté par la fonction récursive elle-même). La version itérative évite ce problème d'emblée.\n",
+      "**3. Formule de Binet** — O(log n) avec l'exponentiation matricielle, mais c'est plus de code pour un gain rarement nécessaire dans un notebook pédagogique.\n",
+      "\n",
+      "Tu veux que j'applique l'une de ces corrections à un notebook précis ?\n",
       "\n"
      ]
     }
@@ -1066,10 +1069,10 @@
    "id": "ac95a46a",
    "metadata": {
     "papermill": {
-     "duration": 0.008253,
-     "end_time": "2026-08-23T19:32:56.203311",
+     "duration": 0.003786,
+     "end_time": "2026-09-09T08:02:22.900074",
      "exception": false,
-     "start_time": "2026-08-23T19:32:56.195058",
+     "start_time": "2026-09-09T08:02:22.896288",
      "status": "completed"
     },
     "tags": []
@@ -1086,16 +1089,16 @@
    "id": "1af9624f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:32:56.221855Z",
-     "iopub.status.busy": "2026-08-23T19:32:56.221461Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.300055Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.298550Z"
+     "iopub.execute_input": "2026-09-09T08:02:22.908582Z",
+     "iopub.status.busy": "2026-09-09T08:02:22.908214Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.003662Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.003208Z"
     },
     "papermill": {
-     "duration": 11.08996,
-     "end_time": "2026-08-23T19:33:07.302046",
+     "duration": 11.100792,
+     "end_time": "2026-09-09T08:02:34.004477",
      "exception": false,
-     "start_time": "2026-08-23T19:32:56.212086",
+     "start_time": "2026-09-09T08:02:22.903685",
      "status": "completed"
     },
     "tags": []
@@ -1106,22 +1109,21 @@
      "output_type": "stream",
      "text": [
       "=== Reponse Claude ===\n",
-      "La version récursive naïve est en O(2^n). Voici les trois optimisations, de la plus simple à la plus puissante.\n",
-      "\n",
-      "## 1. Itérative — O(n), O(1)\n",
+      "Voici la version itérative — la plus simple à optimiser (O(n) en temps, O(1) en espace, plus de récursion exponentielle ni de débordement de pile) :\n",
       "\n",
       "```python\n",
       "def fibonacci(n):\n",
+      "    if n <= 1:\n",
+      "        return n\n",
       "    a, b = 0, 1\n",
-      "    for _ in range(n):\n",
+      "    for _ in range(2, n + 1):\n",
       "        a, b = b, a + b\n",
-      "    return a\n",
+      "    return b\n",
       "```\n",
       "\n",
-      "C'est la meilleure pour la plupart des cas (y compris n=0→0, n=1→1).\n",
+      "Variantes selon le besoin :\n",
       "\n",
-      "## 2. Mémöisation — O(n), O(n)\n",
-      "\n",
+      "**Mémoïsation** (récursif conservé mais sans recalculs, O(n) en temps, O(n) en mémoire) :\n",
       "```python\n",
       "from functools import lru_cache\n",
       "\n",
@@ -1132,38 +1134,20 @@
       "    return fibonacci(n-1) + fibonacci(n-2)\n",
       "```\n",
       "\n",
-      "Utile si la fonction est appelée plusieurs fois avec les mêmes n (le cache persiste entre appels).\n",
-      "\n",
-      "## 3. Exponentiation de matrice — O(log n)\n",
-      "\n",
+      "**Exponentiation de matrice** — O(log n), utile pour de très grands `n` (évite le blow-up mémoire de la mémoïsation) :\n",
       "```python\n",
+      "import numpy as np\n",
+      "\n",
       "def fibonacci(n):\n",
-      "    def mat_mul(a, b):\n",
-      "        return ((a[0]*b[0] + a[1]*b[2], a[0]*b[1] + a[1]*b[3]),\n",
-      "                (a[2]*b[0] + a[3]*b[2], a[2]*b[1] + a[3]*b[3]))\n",
-      "\n",
-      "    def mat_pow(m, n):\n",
-      "        r = (1, 0, 0, 1)\n",
-      "        while n:\n",
-      "            if n & 1:\n",
-      "                r = mat_mul(r, m)\n",
-      "            m = mat_mul(m, m)\n",
-      "            n >>= 1\n",
-      "        return r\n",
-      "\n",
-      "    if n == 0:\n",
-      "        return 0\n",
-      "    result = mat_pow((1, 1, 1, 0), n - 1)\n",
-      "    return result[0]\n",
+      "    if n <= 1:\n",
+      "        return n\n",
+      "    M = np.array([[1, 1], [1, 0]], dtype=object)\n",
+      "    return int(np.linalg.matrix_power(M, n - 1)[0, 0])\n",
       "```\n",
       "\n",
-      "Le tuple `(1, 1, 1, 0)` est la matrice de Fibonacci ; son élévation à `n-1` donne `(F_n, F_{n+1}; F_{n+1}, F_n)`.\n",
+      "Le choix dépend du contexte : **itératif** pour le cas général (lisible + efficace), **mémoïsation** si tu résous beaucoup de `fibonacci(n)` réutilisés en récursion, **matrice** pour des `n` très grands en galerie d'exemples.\n",
       "\n",
-      "---\n",
-      "\n",
-      "**Recommandation** : l'itérative (n°1) pour un notebook — simple, lisible, et déjà asymptotiquement optimale pour les tailles raisonnables. La version par matrice n'apporte un gain réel que pour des n très grands (n > ~10⁶) où elle évite l'overflow d'itérations — mais Python arbore via les big ints, donc ça reste du domaine du cas d'usage avancé.\n",
-      "\n",
-      "Note : ce sont des fonctions purement didactiques ; la vraie optimisation de productivité serait `fib = ...` en cache, mais la vraie réponse pour la production reste la version itérative.\n",
+      "Si tu veux l'intégrer dans une cellule du notebook sur la branche courante (`01-Claude-CLI-Bases.ipynb`), dis-le-moi et je l'insère avec ses sorties d'exécution.\n",
       "\n"
      ]
     }
@@ -1181,10 +1165,10 @@
    "id": "2be8942b",
    "metadata": {
     "papermill": {
-     "duration": 0.009178,
-     "end_time": "2026-08-23T19:33:07.320997",
+     "duration": 0.003522,
+     "end_time": "2026-09-09T08:02:34.011798",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.311819",
+     "start_time": "2026-09-09T08:02:34.008276",
      "status": "completed"
     },
     "tags": []
@@ -1200,10 +1184,10 @@
    "id": "6ec65427",
    "metadata": {
     "papermill": {
-     "duration": 0.010723,
-     "end_time": "2026-08-23T19:33:07.341502",
+     "duration": 0.00385,
+     "end_time": "2026-09-09T08:02:34.019237",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.330779",
+     "start_time": "2026-09-09T08:02:34.015387",
      "status": "completed"
     },
     "tags": []
@@ -1213,12 +1197,22 @@
     "\n",
     "Maintenant c'est a vous ! Completez les cellules suivantes.\n",
     "\n",
-    "Les six exercices qui suivent mesurent votre maîtrise des trois compétences introduites plus haut — composer un prompt, choisir le modèle adapté, et exploiter la sortie (texte ou JSON). Ils montent en autonomie : les exercices 1 et 2 consistent à appeler `run_claude()` avec les bons paramètres, tandis que les exercices 3 et 4 vous demandent d'écrire des fonctions réutilisables (`compare_models`, `extract_json_field`, `ask_about_topic`) qui combinent plusieurs concepts. Chaque stub est conçu pour s'exécuter sans erreur (`return None`) tant que la solution n'est pas écrite — vous pouvez exécuter le notebook de bout en bout puis revenir remplir les stubs un par un."
+    "Les six exercices qui suivent mesurent votre maîtrise des trois compétences introduites plus haut — composer un prompt, choisir le modèle adapté, et exploiter la sortie (texte ou JSON). Ils alternent les deux gestes : les exercices 1, 3 et 5 consistent à appeler directement `run_claude()` ou `run_claude_json()` avec les bons paramètres, tandis que les exercices 2, 4 et 6 vous demandent d'écrire des fonctions réutilisables (`compare_models`, `extract_json_field`, `ask_about_topic`) qui combinent plusieurs concepts. Chaque stub est conçu pour s'exécuter sans erreur (`return None`) tant que la solution n'est pas écrite — vous pouvez exécuter le notebook de bout en bout puis revenir remplir les stubs un par un."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "0d4f9f26",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003681,
+     "end_time": "2026-09-09T08:02:34.026382",
+     "exception": false,
+     "start_time": "2026-09-09T08:02:34.022701",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 : Expliquer un code mystère\n",
     "\n",
@@ -1238,16 +1232,16 @@
    "id": "9949c8ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:33:07.369020Z",
-     "iopub.status.busy": "2026-08-23T19:33:07.368499Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.373588Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.372473Z"
+     "iopub.execute_input": "2026-09-09T08:02:34.034571Z",
+     "iopub.status.busy": "2026-09-09T08:02:34.034291Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.037178Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.036769Z"
     },
     "papermill": {
-     "duration": 0.020282,
-     "end_time": "2026-08-23T19:33:07.375320",
+     "duration": 0.007911,
+     "end_time": "2026-09-09T08:02:34.037915",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.355038",
+     "start_time": "2026-09-09T08:02:34.030004",
      "status": "completed"
     },
     "tags": []
@@ -1273,10 +1267,10 @@
    "id": "6cf9c144",
    "metadata": {
     "papermill": {
-     "duration": 0.009272,
-     "end_time": "2026-08-23T19:33:07.393102",
+     "duration": 0.003489,
+     "end_time": "2026-09-09T08:02:34.045208",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.383830",
+     "start_time": "2026-09-09T08:02:34.041719",
      "status": "completed"
     },
     "tags": []
@@ -1293,16 +1287,16 @@
    "id": "3bd49bd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:33:07.420701Z",
-     "iopub.status.busy": "2026-08-23T19:33:07.419912Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.427352Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.425957Z"
+     "iopub.execute_input": "2026-09-09T08:02:34.053525Z",
+     "iopub.status.busy": "2026-09-09T08:02:34.053229Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.056680Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.056294Z"
     },
     "papermill": {
-     "duration": 0.023085,
-     "end_time": "2026-08-23T19:33:07.429260",
+     "duration": 0.008707,
+     "end_time": "2026-09-09T08:02:34.057354",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.406175",
+     "start_time": "2026-09-09T08:02:34.048647",
      "status": "completed"
     },
     "tags": []
@@ -1317,7 +1311,7 @@
     }
    ],
    "source": [
-    "# Exercice 6 : Comparaison de modeles\n",
+    "# Exercice 2 : Comparaison de modeles\n",
     "def compare_models(question, model1=\"haiku\", model2=\"sonnet\"):\n",
     "    \"\"\"Pose la meme question a deux modeles et retourne les reponses.\n",
     "    \n",
@@ -1344,7 +1338,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f06bbe19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00335,
+     "end_time": "2026-09-09T08:02:34.064303",
+     "exception": false,
+     "start_time": "2026-09-09T08:02:34.060953",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Une question simple avec Haiku\n",
     "\n",
@@ -1361,23 +1365,23 @@
    "id": "4befd33d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:33:07.447242Z",
-     "iopub.status.busy": "2026-08-23T19:33:07.446599Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.452128Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.450665Z"
+     "iopub.execute_input": "2026-09-09T08:02:34.073097Z",
+     "iopub.status.busy": "2026-09-09T08:02:34.072729Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.075503Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.075147Z"
     },
     "papermill": {
-     "duration": 0.017029,
-     "end_time": "2026-08-23T19:33:07.454060",
+     "duration": 0.007739,
+     "end_time": "2026-09-09T08:02:34.076087",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.437031",
+     "start_time": "2026-09-09T08:02:34.068348",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# EXERCICE 2 : Utilisez le modele haiku pour une question simple\n",
+    "# EXERCICE 3 : Utilisez le modele haiku pour une question simple\n",
     "# Demandez la syntaxe d'une boucle for en Python\n",
     "\n",
     "# Indice : Ajoutez le parametre model=\"haiku\" a run_claude()\n",
@@ -1393,10 +1397,10 @@
    "id": "80ec7bdf",
    "metadata": {
     "papermill": {
-     "duration": 0.009348,
-     "end_time": "2026-08-23T19:33:07.471121",
+     "duration": 0.003839,
+     "end_time": "2026-09-09T08:02:34.083719",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.461773",
+     "start_time": "2026-09-09T08:02:34.079880",
      "status": "completed"
     },
     "tags": []
@@ -1413,16 +1417,16 @@
    "id": "9b56d738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:33:07.491391Z",
-     "iopub.status.busy": "2026-08-23T19:33:07.490762Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.498516Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.497272Z"
+     "iopub.execute_input": "2026-09-09T08:02:34.091844Z",
+     "iopub.status.busy": "2026-09-09T08:02:34.091542Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.095265Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.094852Z"
     },
     "papermill": {
-     "duration": 0.019552,
-     "end_time": "2026-08-23T19:33:07.500389",
+     "duration": 0.008585,
+     "end_time": "2026-09-09T08:02:34.095927",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.480837",
+     "start_time": "2026-09-09T08:02:34.087342",
      "status": "completed"
     },
     "tags": []
@@ -1438,7 +1442,7 @@
     }
    ],
    "source": [
-    "# Exercice 5 : Extraire des donnees d'une reponse JSON\n",
+    "# Exercice 4 : Extraire des donnees d'une reponse JSON\n",
     "import json\n",
     "\n",
     "def extract_json_field(response_json, field_name):\n",
@@ -1477,10 +1481,10 @@
    "id": "c8d2c4d9",
    "metadata": {
     "papermill": {
-     "duration": 0.007759,
-     "end_time": "2026-08-23T19:33:07.516734",
+     "duration": 0.003597,
+     "end_time": "2026-09-09T08:02:34.103495",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.508975",
+     "start_time": "2026-09-09T08:02:34.099898",
      "status": "completed"
     },
     "tags": []
@@ -1497,23 +1501,23 @@
    "id": "e6060f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:33:07.539005Z",
-     "iopub.status.busy": "2026-08-23T19:33:07.538279Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.543529Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.542219Z"
+     "iopub.execute_input": "2026-09-09T08:02:34.111662Z",
+     "iopub.status.busy": "2026-09-09T08:02:34.111313Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.114583Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.113956Z"
     },
     "papermill": {
-     "duration": 0.018804,
-     "end_time": "2026-08-23T19:33:07.545352",
+     "duration": 0.00818,
+     "end_time": "2026-09-09T08:02:34.115430",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.526548",
+     "start_time": "2026-09-09T08:02:34.107250",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# EXERCICE 3 : Demandez une reponse en JSON\n",
+    "# EXERCICE 5 : Demandez une reponse en JSON\n",
     "# Demandez 5 bonnes pratiques Python avec nom et description\n",
     "\n",
     "# Indice : Utilisez run_claude_json() et specifiez le format dans le prompt\n",
@@ -1533,10 +1537,10 @@
    "id": "0c7fdd46",
    "metadata": {
     "papermill": {
-     "duration": 0.008157,
-     "end_time": "2026-08-23T19:33:07.561168",
+     "duration": 0.003624,
+     "end_time": "2026-09-09T08:02:34.122832",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.553011",
+     "start_time": "2026-09-09T08:02:34.119208",
      "status": "completed"
     },
     "tags": []
@@ -1553,16 +1557,16 @@
    "id": "006c3d6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T19:33:07.584420Z",
-     "iopub.status.busy": "2026-08-23T19:33:07.583885Z",
-     "iopub.status.idle": "2026-08-23T19:33:07.591160Z",
-     "shell.execute_reply": "2026-08-23T19:33:07.589920Z"
+     "iopub.execute_input": "2026-09-09T08:02:34.131335Z",
+     "iopub.status.busy": "2026-09-09T08:02:34.130884Z",
+     "iopub.status.idle": "2026-09-09T08:02:34.134926Z",
+     "shell.execute_reply": "2026-09-09T08:02:34.134331Z"
     },
     "papermill": {
-     "duration": 0.020602,
-     "end_time": "2026-08-23T19:33:07.592931",
+     "duration": 0.009271,
+     "end_time": "2026-09-09T08:02:34.135695",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.572329",
+     "start_time": "2026-09-09T08:02:34.126424",
      "status": "completed"
     },
     "tags": []
@@ -1577,7 +1581,7 @@
     }
    ],
    "source": [
-    "# Exercice 4 : Composer un prompt dynamique\n",
+    "# Exercice 6 : Composer un prompt dynamique\n",
     "def ask_about_topic(topic, language=\"Python\", detail_level=\"intermediaire\"):\n",
     "    \"\"\"Genere un prompt structure pour poser une question technique a Claude.\n",
     "    \n",
@@ -1602,7 +1606,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "88409630",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003987,
+     "end_time": "2026-09-09T08:02:34.143623",
+     "exception": false,
+     "start_time": "2026-09-09T08:02:34.139636",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Corrections guidées — les six exercices\n",
     "\n",
@@ -1646,10 +1660,10 @@
    "id": "6a1213fa",
    "metadata": {
     "papermill": {
-     "duration": 0.010514,
-     "end_time": "2026-08-23T19:33:07.611345",
+     "duration": 0.003679,
+     "end_time": "2026-09-09T08:02:34.151337",
      "exception": false,
-     "start_time": "2026-08-23T19:33:07.600831",
+     "start_time": "2026-09-09T08:02:34.147658",
      "status": "completed"
     },
     "tags": []
@@ -1742,14 +1756,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 68.263206,
-   "end_time": "2026-08-23T19:33:07.973174",
+   "duration": 80.589872,
+   "end_time": "2026-09-09T08:02:34.389370",
    "environment_variables": {},
    "exception": null,
-   "input_path": "01-Claude-CLI-Bases.ipynb",
-   "output_path": "01-Claude-CLI-Bases.ipynb",
+   "input_path": "D:/Dev/CoursIA-15219/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb",
+   "output_path": "D:/Dev/CoursIA-15219/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb",
    "parameters": {},
-   "start_time": "2026-08-23T19:31:59.709968",
+   "start_time": "2026-09-09T08:01:13.799498",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -525,7 +525,7 @@
     "tags": []
    },
    "source": [
-    "**Lecture.** Réponse obtenue : « Python est un langage de programmation interprété, de haut niveau et à la syntaxe lisible… ». La **forme** est intéressante : la réponse commence directement par la définition, sans formule de politesse, et déroule sur **deux phrases** comme demandé. C'est la marque d'un prompt bien calibré -- `claude -p \"...\"` traite la requête comme un **one-shot** et ne s'autorise pas le bavardage qu'une session interactive autoriserait.\n",
+    "**Lecture.** Réponse obtenue : « Python est un langage de programmation interprété, de haut niveau, à la syntaxe lisible… ». La **forme** est intéressante : la réponse commence directement par la définition, sans formule de politesse, et déroule sur **deux phrases** comme demandé. C'est la marque d'un prompt bien calibré -- `claude -p \"...\"` traite la requête comme un **one-shot** et ne s'autorise pas le bavardage qu'une session interactive autoriserait.\n",
     "\n",
     "**Métadonnée visible :** `print_response` masque la sortie brute par défaut, mais on peut inspecter `duration_api_ms` ou `total_cost_usd` en JSON (cf. cellule format JSON). Pour ce notebook, on reste en prose -- la sortie est plus pédagogique."
    ]

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -1353,7 +1353,7 @@
     "### Exercice 3 : Une question simple avec Haiku\n",
     "\n",
     "Après avoir comparé les modèles sur des questions riches (exercice précédent), testons le cas le plus\n",
-    "dégradé : une question **fermée et courte**. Dans la cellule `# EXERCICE 2` ci-dessous, demandez\n",
+    "dégradé : une question **fermée et courte**. Dans la cellule `# EXERCICE 3` ci-dessous, demandez\n",
     "au modèle `haiku` un fait simple (« Quelle est la capitale de l'Australie ? » par exemple), puis\n",
     "variez : une question ouverte courte, puis une consigne de format (« réponds en exactement 5 mots »).\n",
     "Observerez-vous la même économie de tokens ? Le même respect de la consigne ?"


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2023:CoursIA -- prev: LIGHT/guard #15344

## Summary

Dans `01-Claude-CLI-Bases.ipynb`, les six en-têtes markdown d'exercices sont ordonnés `[1..6]` mais les commentaires des six cellules code associées restaient `[1,6,2,5,3,4]` — un lecteur voyait un en-tête `Exercice 2` suivi d'une cellule commentée `Exercice 6`, seul le premier couple étant cohérent. L'introduction décrivait en outre une répartition qui ne correspondait plus à l'ordre réel (elle citait trois fonctions pour deux numéros).

- **Renumérotation** : les six commentaires code suivent désormais leur en-tête markdown immédiatement précédent, soit `{1,2,3,4,5,6}` dans l'ordre physique. Casse du libellé préservée.
- **Introduction réécrite** : décrit l'alternance réelle — appels directs (`run_claude()` / `run_claude_json()`) aux exercices 1/3/5, fonctions réutilisables (`compare_models`, `extract_json_field`, `ask_about_topic`) aux exercices 2/4/6.
- **Re-exécution entière** avec la vraie CLI Claude (`SIMULATION_MODE = False`) via papermill : 47/47 cellules, 18/18 cellules code `execution_count` non-null, 0 erreur, sorties réelles. Les sorties des cellules demo sont des réponses LLM fraîches (timing/`session_id`/coût non déterministes par nature — aucun output hand-édité, re-exécution seule).
- **Lectures réalignées** : après inspection des sorties fraîches, une seule lecture citait l'ancienne formulation Python (« de haut niveau **et** à la syntaxe lisible ») — alignée sur « de haut niveau **,** à la syntaxe lisible… ». Les autres lectures (JSON wrapper, Liste/Tuple mutabilité+hashabilité, fibonacci O(2ⁿ)/n=40, version itérative O(n)/O(1) `(a,b)`…) restent cohérentes avec les sorties fraîches.

Closes #15219

## Acceptance (issue) → livré

- [x] Chaque en-tête `### Exercice N` suivi d'une cellule code portant le même numéro N — séquence vérifiée `[1,2,3,4,5,6]`
- [x] Séquence des commentaires code = `[1,2,3,4,5,6]` dans l'ordre physique
- [x] Introduction décrit correctement les six exercices (alternance direct/fonctions)
- [x] Notebook ré-exécuté de bout en bout avec la vraie CLI : 18/18 code cells `execution_count` cohérent, 0 erreur, sorties réelles
- [x] Aucun output modifié à la main ; la lecture citante (cellule Python) réalignée sur la sortie fraîche (markdown-only)
- [x] Validators C.1/C.2, ordering (papermill 47/47), papermill ratchet et secrets passent

## Validation

- **C.1** : `grep` des patterns interdits (`raise NotImplementedError`, `assert False`, `1/0`) → 0 occurrence.
- **C.2** : 18/18 code cells `execution_count != null` ; 15 avec sorties (les 3 stubs d'exercice produisent volontairement rien — exécutés sans erreur). `nbformat.validate` → PASS.
- **Ratchets (post-commit, merge-base origin/main)** :
  - `check_output_failure_text.py origin/main` → `regressions: 0` (TOOL_FAILURE delta 0, MACHINE_PATH delta 0, aucun capability downgrade).
  - `check_output_flood.py origin/main` → `base_total: 15 / head_total: 15` (aucune croissance), `cells: []` (aucune cellule au-dessus du cap), `regressions: 0`.
- **Secrets** : aucun littéral de clé (`sk-`, `AIza`, `ghp_`) dans le notebook.
- **Base fraîche** : rebasé sur `origin/main` @ 75c8d140c5 (aucun commit amont ne touche le notebook).

