### PR TITLE
fix(notebook-tools,#15223): matches_default_venv=null quand declared_venv inconnu

### DIFF
--- a/scripts/notebook_tools/tests/test_verify_kernel_env.py
+++ b/scripts/notebook_tools/tests/test_verify_kernel_env.py
@@ -159,13 +159,17 @@ class TestVerifyOne:
         assert "lean4-venv" in v["message"]
 
     def test_system_python_ok(self, tmp_path):
-        """Argv is /usr/bin/python3 (system) => OK, runtime uses active venv."""
+        """Argv is /usr/bin/python3 (system) => OK, runtime uses active venv.
+
+        The declared venv is unknown, so matches_default_venv must be None
+        (not True) -- nothing proves the match (#15223).
+        """
         nb, name, argv0 = _write_nb(tmp_path, argv0="/usr/bin/python3")
         with patch("jupyter_client.kernelspec.get_kernel_spec",
                    return_value=_mock_spec(argv0)):
             v = verify_one(nb)
         assert v["verdict"] == "OK"
-        assert v["matches_default_venv"] is True
+        assert v["matches_default_venv"] is None
         assert v["declared_venv"] is None
 
     def test_bare_python_ok(self, tmp_path):

--- a/scripts/notebook_tools/verify_kernel_env.py
+++ b/scripts/notebook_tools/verify_kernel_env.py
@@ -182,7 +182,10 @@ def verify_one(notebook_path: Path, default_venv: str = DEFAULT_WSL_VENV) -> dic
         # the original PR #14930 stdout divergence warning covers at
         # runtime -- at the static level we can only note it.
         out["verdict"] = "OK"
-        out["matches_default_venv"] = True
+        # No declared venv to compare against: the match is unverified, so
+        # the field is null (not true) -- the schema documents None = unknown
+        # (#15223). A downstream consumer must not read true here.
+        out["matches_default_venv"] = None
         out["message"] = (
             f"kernelspec '{name}' argv[0]={interp!r} resolves to a system "
             "or bare interpreter; wsl_papermill uses the active venv at "


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #15301

## Summary

Nit Hermes (review `jsboige` 2026-09-08T10:25:22Z sur PR #15191) : `verify_kernel_env.py` rendait `matches_default_venv: true` quand `declared_venv` était **inconnu** (argv system `/usr/bin/python3` ou bare `python`). Le message console était honnête (« déclaré=X, trouvé=Y, match probable ») mais le **champ JSON** était une affirmation tranchée — un consommateur aval pouvait lire `true` sans que le match avec le venv par défaut ait été démontré.

- **Fix** : `matches_default_venv = null` quand `declared_venv` est absent/non-résolvable (le schema documente déjà `# None = unknown` à la ligne 130). `true`/`false` restent réservés au cas `declared_venv` connu + match vérifié.
- **Test mis à jour** : `test_system_python_ok` vérifie désormais `is None` (comportement correct) au lieu de `is True` (comportement bugué).
- **Pas de consommateur cassé** : aucun consommateur ne lit `matches_default_venv` (grep : script + test uniquement ; ni workflow, ni `render_envs.py`) → `null` est schema-safe.

Closes #15223

## Acceptance (issue) → livré

- [x] `matches_default_venv=null` quand `declared_venv` absent/non-résolvable — `verify_one` rend `None`, `--json` sérialise `null`
- [x] Test ajouté/mis à jour dans `test_verify_kernel_env.py` :
  - `declared_venv=None` (argv system `/usr/bin/python3`) → `matches_default_venv=null` (`test_system_python_ok`, mis à jour)
  - `declared_venv=/home/jesse/coursia-wsl` + match exact → `true` (`test_matches_default`, intact)
  - `declared_venv=/home/jesse/.lean4-venv` + mismatch → `false` (`test_divergent_venv`, intact)
- [x] Cohérence schema consommateurs : `render_envs.py` et les workflows ne lisent pas ce champ (grep) → aucune tolérance `null` à ajouter
- [x] Version : PAS de marqueur `__version__` dans ce CLI autonome → bump PATCH non applicable littéralement (changement conservateur `True→null`, fix d'honnêteté, aucune rupture)

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_verify_kernel_env.py -q` → **28 passed** (avant : 28 ; le cas system-python passe de `True` à `None`).
- `git diff` : 2 fichiers, +10/−3 (fix 1 ligne + commentaire ; test docstring + assertion).
- Base fraîche : rebasé sur `origin/main @ 75c8d140c` (aucun commit amont ne touche ces fichiers).

