### PR TITLE
chore(hygiene): ignorer /scratchpad/ et /canary.txt a la racine du depot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1047,3 +1047,9 @@ MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/pt11c_multiseed_output/
 # the script in the repo; the artefacts out.
 MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/_tranche2_15002/
 
+
+# Bacs a sable et sondes de lane a la racine du depot : artefacts de travail
+# d'agent, jamais du livrable. Non ignores jusqu'ici, donc un `git add -A`
+# d'une lane (ou d'un agent etudiant) les embarquait dans sa PR.
+/scratchpad/
+/canary.txt


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-ai-01:CoursIA — prev: MED/slides #15320

## Résumé

`git status` sur `main` montrait deux entrées `??` que rien n'ignorait :

```
?? canary.txt
?? scratchpad/
```

Un `git add -A` d'une lane — ou d'un **agent étudiant lancé sur ce dépôt cet après-midi** — les
embarquait dans sa PR. Ce sont des artefacts de travail d'agent (15 scripts `chk*.sh` /
`deploy_*.sh` / `diag.sh` / `disarm.sh` datés du 7 septembre pour `scratchpad/` ; des fragments
`sed`/`printf` pour `canary.txt`), jamais du livrable.

L'ancre `/` en tête est délibérée : elle borne le motif à la racine et **préserve** un `scratchpad/`
légitime ailleurs dans l'arbre.

## Ce que la PR ne fait pas

**Aucun fichier n'est supprimé.** Les deux vivent déjà hors de l'index ; la PR les empêche seulement
d'y entrer par accident. Rien n'est perdu, et le geste est réversible par retrait de deux lignes.

Je ne touche pas non plus au contenu de `scratchpad/`, qui n'est pas de moi.

## Validation — contrôles positifs ET négatifs, sur chemins réellement créés

Le motif `/scratchpad/` est **directory-only** : une sonde sur un chemin inexistant rend un faux
« non-ignoré ». C'est ce qui m'avait d'abord fait douter du constat, et c'est pourquoi la mesure est
faite sur des chemins matérialisés dans un worktree, pas sur des noms :

| Chemin | Attendu | Mesuré |
|---|---|---|
| `scratchpad/x.sh` | ignoré | **IGNORE** |
| `canary.txt` | ignoré | **IGNORE** |
| `scripts/scratchpad/keep.sh` | **non**-ignoré (ancre `/`) | non-ignoré |
| `README.md` | **non**-ignoré (contrôle négatif) | non-ignoré |

```
$ git add -An
add '.gitignore'
add 'scripts/scratchpad/keep.sh'      ← le contrôle négatif, volontairement créé
```

Ni `scratchpad/` ni `canary.txt` n'apparaissent plus dans ce que `git add -A` embarquerait. Les deux
lignes du tableau qui doivent **rester** non-ignorées le restent : un motif de détection se valide
par ses faux négatifs, pas par ses hits.

Pre-commit `gitleaks` : **Passed**.

## Portée

`.gitignore`, +6 lignes (dont 3 de commentaire), 0 suppression. Aucune autre PR ouverte ne touche
`.gitignore` (vérifié sur les 60 PRs ouvertes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
