### PR TITLE
fix(guard,#15349): detect_md_content_loss exempte les artefacts de run generes

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -92,6 +92,16 @@ Pour chaque notebook compare entre sa base git (defaut origin/main) et sa tete
      body PR, lisible par un auditeur ulterieur -- c'est la propriete que la
      baseline fichier ne donne pas avec la meme qualite.
 
+  9. EXEMPT LES ARTEFACTS DE RUN GENERES (#15349) : un notebook dont le
+     markdown est une SORTIE non deterministe d'un agent/LLM
+     (ex. ``Notebook-Generated.ipynb`` : la conversation multi-agents ECrit
+     les cellules a chaque run) est dispense du content-loss -- base-vs-head
+     mesure la variance de la generation, pas une perte de contenu. La
+     dispense n'est pas path-based aveugle : elle exige le nom canonique
+     (``GENERATED_ARTIFACT_NAMES``) ET une trace papermill dans ``metadata``
+     -- un fichier edite a la main qui porterait le nom sans avoir ete
+     execute par papermill reste verifie.
+
 Usage
 -----
     # un notebook, diff vs origin/main (head = working tree)
@@ -105,7 +115,8 @@ Usage
 Exit codes
 ----------
     0 -- aucune perte de contenu detectee (ou mode non --check), y compris un
-         notebook NOUVEAU (absent a la base : rien a comparer -> exempt)
+         notebook NOUVEAU (absent a la base : rien a comparer -> exempt) ou un
+         artefact de run genere (markdown non deterministe, #15349)
     1 -- une ou plusieurs pertes detectees (--check). Les findings ``TRUNCATED_CELL``
          pour lesquels un marker de body valide a ete trouve sont SUPPRIMES
          du verdict et la sortie les mentionne comme
@@ -121,6 +132,7 @@ Voir aussi
 - scan_md_hierarchy / check_notebook_navlinks -- gardes existants (volume-aveugles)
 - Issue #8655 -- cahier des charges + 3 cas reels
 - Issue #13491 -- justification par cellule (option (a) du choix de porte)
+- Issue #15349 -- artefacts de run generes (exemption content-loss)
 - Registre #3966 -- le rollout demotion-de-titres dont provient le defaut
 """
 from __future__ import annotations
@@ -174,6 +186,49 @@ def _fr_sibling_path(nb_path: Path) -> Path:
 def _is_translation_artifact(nb_path: Path) -> bool:
     """True si le notebook est un artefact de traduction (*_<lang>.ipynb)."""
     return _TRANSLATION_SUFFIX_RE.search(nb_path.name) is not None
+
+# ---------------------------------------------------------------------------
+# Artefacts de RUN generes (#15349). Un notebook dont le contenu est une
+# SORTIE non deterministe d'un agent/LLM (ex. SemanticKernel/Notebook-Generated
+# .ipynb : la conversation multi-agents ECrit les cellules a chaque run) a un
+# markdown qui varie d'un run a l'autre. Le comparer base-vs-head mesure la
+# VARIANCE de la generation, pas une perte : la "perte" detectee est la
+# variance normale de deux runs distincts (cf #15209 pour la classe de defaut),
+# et restaurer l'ancien texte a la main pour verdir le garde fabriquerait un
+# artefact de run (interdit, Stop & Repair). On exempte donc ce notebook du
+# content-loss, comme un nouveau fichier.
+#
+# Pas path-based aveugle : la predicate exige le nom canonique (un seul
+# Notebook-Generated.ipynb dans le depot) ET une trace d'execution papermill
+# (un vrai artefact de run est execute in-place). Un notebook EDITE A LA MAIN
+# qui porterait le meme nom sans cette trace reste verifie -- on ne dispense
+# pas un fichier au seul motif de son nom.
+# ---------------------------------------------------------------------------
+GENERATED_ARTIFACT_NAMES = {"Notebook-Generated.ipynb"}
+
+
+def _is_generated_artifact(nb_path: Path, nb_head: dict | None = None) -> bool:
+    """True si le notebook est un artefact de run genere (issue #15349).
+
+    Le predicat exige le nom canonique (``GENERATED_ARTIFACT_NAMES``) ET une
+    trace d'execution papermill dans ``metadata``, pour ne pas etre path-based
+    aveugle : un fichier edite a la main qui porterait le nom sans avoir ete
+    execute par papermill n'est pas dispense.
+
+    ``nb_head`` : la tete deja chargee par l'appelant (evite une relecture du
+    fichier) ; si ``None``, le notebook est relu depuis le disque.
+    """
+    if nb_path.name not in GENERATED_ARTIFACT_NAMES:
+        return False
+    metadata = nb_head.get("metadata") if isinstance(nb_head, dict) else None
+    if metadata is None:
+        try:
+            nb = json.loads(nb_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        metadata = nb.get("metadata") if isinstance(nb, dict) else None
+    return isinstance(metadata, dict) and "papermill" in metadata
+
 
 # Aliases EN des motifs structurants : en mode traduction, un motif FR disparu
 # mais present sous sa forme anglaise dans le rendu N'EST PAS une perte --
@@ -821,6 +876,30 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
             },
         }
 
+    # Artefact de run genere (issue #15349) : un notebook dont le markdown est
+    # une sortie non deterministe de run. La comparaison base-vs-head mesure la
+    # variance de la generation, pas une perte de contenu -- on l'exempte, comme
+    # un nouveau fichier (voir _is_generated_artifact pour le predicat non
+    # path-based aveugle).
+    if _is_generated_artifact(nb_path, nb_head):
+        head_md_gen = extract_md_cells(nb_head)
+        head_total_gen = sum(_norm_len(s) for _, _, s in head_md_gen)
+        return {
+            "notebook": str(nb_path),
+            "base_ref": base_ref,
+            "head_ref": head_label,
+            "generated_artifact": True,
+            "findings": [],
+            "stats": {
+                "base_md_cells": 0,
+                "head_md_cells": len(head_md_gen),
+                "cell_count_stable": False,
+                "base_total_normalized_chars": 0,
+                "head_total_normalized_chars": head_total_gen,
+                "findings_count": 0,
+            },
+        }
+
     nb_base = read_notebook_at_ref(nb_path, base_ref)
     if nb_base is None:
         return {"notebook": str(nb_path), "error": f"base_ref {base_ref} unreadable"}
@@ -1031,6 +1110,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"[TRANSLATION] artefact *_<lang>.ipynb -> comparaison au sibling FR "
                   f"de la meme revision ({result.get('fr_sibling')}), seuil "
                   f"{TRANSLATION_DROP_THRESHOLD}, motifs bilingues (#13548).")
+        if result.get("generated_artifact"):
+            print("[GENERATED-ARTEFACT] notebook de run genere -- markdown non "
+                  "deterministe, comparaison base-vs-head sans objet -> exempt "
+                  "de content-loss (#15349).")
         print(f"[STATS]    md_cells base={st['base_md_cells']} head={st['head_md_cells']} "
               f"stable={st['cell_count_stable']} | "
               f"normalized_chars base={st['base_total_normalized_chars']} "

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -449,6 +449,79 @@ class TestNewFileExemptionAndRefGuard:
 
 
 # ---------------------------------------------------------------------------
+# 9b. Artefact de run genere exempte (#15349)
+# ---------------------------------------------------------------------------
+class TestGeneratedArtifact:
+    """Un notebook dont le markdown est une sortie de run LLM non deterministe
+    (nom d'artefact canonique + trace papermill) est exempte de content-loss :
+    base-vs-head mesure la variance de la generation, pas une perte de contenu
+    (#15349). La dispense n'est pas path-based aveugle : sans trace papermill,
+    ou sous un nom hors ``GENERATED_ARTIFACT_NAMES``, le notebook reste verifie.
+    """
+
+    @staticmethod
+    def _head_with_papermill(body="> **Indices :**"):
+        """Tete dont la cellule markdown s'est effondree (ratio << 0.75)."""
+        head = _nb(_md(body))
+        head["metadata"]["papermill"] = {
+            "input_path": "Notebook-Generated.ipynb",
+            "output_path": "Notebook-Generated.ipynb",
+        }
+        return head
+
+    def _scan_gen(self, tmp_path, head_nb, nb_name="Notebook-Generated.ipynb"):
+        p = tmp_path / nb_name
+        p.write_text(json.dumps(head_nb), encoding="utf-8")
+        with mock.patch.object(dml, "read_notebook_at_ref",
+                               return_value=_nb(_md(EXERCISE_BODY))), \
+             mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True):
+            return dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
+
+    def test_generated_artifact_exempted(self, tmp_path):
+        # Artefact de run (nom canonique + papermill) -> exempt, 0 finding.
+        r = self._scan_gen(tmp_path, self._head_with_papermill())
+        assert r.get("generated_artifact") is True
+        assert r["stats"]["findings_count"] == 0
+        assert "error" not in r
+
+    def test_generated_artifact_main_exits_0(self, tmp_path):
+        # main() --check renvoie 0 pour l'artefact (le garde ne le rougit pas).
+        p = tmp_path / "Notebook-Generated.ipynb"
+        p.write_text(json.dumps(self._head_with_papermill()), encoding="utf-8")
+        with mock.patch.object(dml, "read_notebook_at_ref",
+                               return_value=_nb(_md(EXERCISE_BODY))), \
+             mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True):
+            assert dml.main([str(p), "--base", "MOCK", "--check"]) == 0
+
+    def test_generated_artifact_needs_papermill_trace(self, tmp_path):
+        # Meme nom d'artefact mais AUCUNE trace papermill -> verifie (non
+        # path-based aveugle) -> la troncature est signalee.
+        r = self._scan_gen(tmp_path, _nb(_md("> **Indices :**")))
+        assert r.get("generated_artifact") is not True
+        assert r["stats"]["findings_count"] >= 1
+        assert any(f["kind"] == "TRUNCATED_CELL" for f in r["findings"])
+
+    def test_non_generated_name_not_exempt(self, tmp_path):
+        # Trace papermill mais nom hors GENERATED_ARTIFACT_NAMES -> pas exempte.
+        r = self._scan_gen(tmp_path, self._head_with_papermill(),
+                           nb_name="ordinary.ipynb")
+        assert r.get("generated_artifact") is not True
+        assert r["stats"]["findings_count"] >= 1
+
+    def test_predicate_unit(self):
+        # Predicat pur : nom canonique + papermill -> True ; sans papermill
+        # -> False ; nom hors liste -> False (avant meme de lire la metadata).
+        assert dml._is_generated_artifact(
+            Path("Notebook-Generated.ipynb"), self._head_with_papermill()) is True
+        assert dml._is_generated_artifact(
+            Path("Notebook-Generated.ipynb"), _nb(_md("x"))) is False
+        assert dml._is_generated_artifact(
+            Path("ordinary.ipynb"), self._head_with_papermill()) is False
+
+
+# ---------------------------------------------------------------------------
 # 10. Frontmatter cost -> metadata.cost migration (#8919)
 # ---------------------------------------------------------------------------
 # Un bloc frontmatter YAML `cost:` retire d'une cellule alors que ses champs


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15301

## Résumé

Closes #15349 — le garde `detect_md_content_loss.py` (noyau du grain #12396) refuse la régénération légitime de l'artefact de run `SemanticKernel/Notebook-Generated.ipynb` : son markdown est une **sortie non déterministe du LLM du run** (la conversation multi-agents de 10b écrit les cellules à chaque exécution — précédent de commit paire outputs+artefact #12627). Le garde mesurait la **variance de la génération** (Titanic → transformation de données : cell 0, 2830 → 1455 caractères, ratio 0,514 < 0,75 ; motif « Prerequis » base=2) comme une perte de contenu — et la seule issue était de fabriquer l'artefact à la main (interdit, Stop & Repair).

**Correction (piste 1 de l'issue, design-gate approuvé en review)** : exemption additive, **non path-blind** — le prédicat `_is_generated_artifact()` exige à la fois le nom canonique (`GENERATED_ARTIFACT_NAMES`, un seul `Notebook-Generated.ipynb` dans le dépôt) **et** une trace d'exécution Papermill dans `metadata` (un vrai artefact de run est exécuté in-place). Un notebook édité à la main qui porterait le nom sans trace Papermill **reste vérifié** — on ne dispense pas un fichier au seul motif de son nom. L'artefact exempté est traité comme un fichier nouveau (rien à comparer base→head).

## Périmètre

Deux fichiers du dépôt, tous deux sous `scripts/notebook_tools/` : le garde `detect_md_content_loss.py` (+85 lignes : constante, prédicat, intégration au parcours, docstring d'en-tête §9) et son fichier de tests `tests/test_detect_md_content_loss.py` (classe `TestGeneratedArtifact` ajoutée). Aucun notebook, aucun workflow, aucune autre famille touchée.

## Validation

- `pytest scripts/notebook_tools/tests/test_detect_md_content_loss.py` au head `f206512816` : **65 passed** (relancés firsthand ce jour en worktree jetable).
- Nouvelle classe `TestGeneratedArtifact` — les cinq tests ajoutés couvrent : exemption effective (`test_generated_artifact_exempted`), sortie `--check` exit 0 sur le scénario de l'issue (`test_generated_artifact_main_exits_0`), **trace Papermill exigée** (`test_generated_artifact_needs_papermill_trace`), nom seul insuffisant (`test_non_generated_name_not_exempt`), prédicat unitaire (`test_predicate_unit`).
- Les comportements préexistants du garde (perte de markdown pédagogique édité main) restent couverts par les tests antérieurs du même fichier (aucun modifié en sémantique).

## Choix de design consigné

Pistes 2 (désactiver base→head sur reconnaissance de sortie de run) et 3 (décider que les artefacts de run ne se commettent plus — supersession de #12627) sont **écartées** dans ce grain : la piste 1 règle le défaut immédiat avec le prédicat le plus étroit ; la piste 3 est une décision de périmètre distincte qui, si elle se prend un jour, supersèdera celle-ci explicitement.

## Review

APPROVED ai-01 au head `f206512816` (revue source-grounded : « l'exemption exige à la fois le nom canonique unique et une trace Papermill »). Le présent body répare l'unique réserve mécanique restante (body vide → gate `Grain:` bloquant, c. 21:27Z) ; le diff est inchangé depuis la review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
