### PR TITLE
fix(ci,#15359): slides-composition relay — checkout + retrait du || true avaleur

### DIFF
--- a/.github/workflows/slides-composition-pr-relay.yml
+++ b/.github/workflows/slides-composition-pr-relay.yml
@@ -47,6 +47,26 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # #15359 — le relais n'avait AUCUN checkout : sur un runner
+      # self-hosted le workspace est vide, `git diff` échoue, et le
+      # `|| true` transformait la panne en `Touched decks: 0` vert
+      # (faux négatif silencieux, run 34315275538 sur #15334). Le bout
+      # de git diff exige les deux SHAs : `fetch-depth: 0` (historique
+      # complet) + `ref: head.sha` (le head réel de la PR, pas le ref
+      # merge). Clone partiel `blob:none` + sparse `slides/` (série
+      # #11843, même patron que le nocturne) : le diff et le `[ -f ]`
+      # n'ont besoin que de l'arbre + slides/. Le `|| true` est retiré :
+      # un relais qui ne peut pas savoir ce qu'il doit relayer doit
+      # rougir, pas rendre zéro.
+      - name: Checkout (blobless sparse, head de la PR)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: |
+            slides
+
       - name: Resolve touched deck paths from PR diff
         id: resolve
         env:
@@ -56,12 +76,10 @@ jobs:
           set -uo pipefail
           # #11923 + #14226 — la découverte reprend exactement la logique du
           # nocturne, pour qu'un deck qui aurait fait rougir le nocturne
-          # soit vu par ce relay. On évite le sparse-checkout (clone léger
-          # complet suffit, default depth 1 — pas de fetch-depth: 0) parce
-          # que la PR ne touche pas l'historique.
+          # soit vu par ce relay.
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          CHANGED=$(git diff --name-only "${BASE}...${HEAD}" -- slides/ || true)
+          CHANGED=$(git diff --name-only "${BASE}...${HEAD}" -- slides/)
           if grep -qE 'slides/(theme-ia101|package(-lock)?\.json)' <<< "$CHANGED"; then
             # infra partagée touchée : tous les decks -- mais le sparse-checkout
             # du nocturne a peut-être ignoré certains. On les découvre par find.

--- a/scripts/tests/test_slides_composition_pr_relay.py
+++ b/scripts/tests/test_slides_composition_pr_relay.py
@@ -1,0 +1,150 @@
+"""Non-regression #15359: le relais de composition doit voir les decks.
+
+Le relais `slides-composition-pr-relay.yml` n'avait aucune etape
+`actions/checkout` : sur un runner self-hosted le workspace est vide,
+`git diff "${BASE}...${HEAD}" -- slides/` echoue, et le `|| true`
+transformait la panne en `Touched decks: 0` vert — faux negatif
+silencieux (run 34315275538 sur #15334, qui touchait pourtant
+`slides/08-ia-generative/slides.md` +126/−14).
+
+Controle negatif (#15359) : un detecteur se valide par ses faux
+negatifs, pas par ses hits — une PR connue pour toucher un deck doit
+rendre N >= 1. Deux volets :
+
+1. Structurel — le workflow contient un checkout `fetch-depth: 0` sur
+   le head de la PR, et le `git diff` du step `resolve` n'est plus
+   avale (`|| true` absent) ;
+2. Comportemental — la pipeline de decouverte (diff + grep + dedup +
+   existence du fichier) rend N >= 1 sur un depot git minimal qui
+   touche un deck, et 0 sur un depot qui ne touche rien.
+
+Run:
+    python -m pytest scripts/tests/test_slides_composition_pr_relay.py
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "slides-composition-pr-relay.yml"
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _git_run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8", errors="replace",
+    )
+
+
+@pytest.fixture
+def tiny_repo(tmp_path: Path):
+    """Depot git minimal : un deck `slides/demo/slides.md` + un autre fichier."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_run(repo, "init", "-q", "-b", "main")
+    _git_run(repo, "config", "user.email", "test@local")
+    _git_run(repo, "config", "user.name", "test")
+    deck = repo / "slides" / "demo"
+    deck.mkdir(parents=True)
+    other = repo / "docs"
+    other.mkdir()
+    (deck / "slides.md").write_text("# Deck\nbody\n", encoding="utf-8")
+    (other / "readme.md").write_text("docs\n", encoding="utf-8")
+    _git_run(repo, "add", ".")
+    _git_run(repo, "commit", "-q", "-m", "base")
+    return repo
+
+
+def _discovery(
+    repo: Path, base: str, head: str, changed: str
+) -> tuple[int, list[str]]:
+    """Rejoue le step `resolve` du relais (decouverte des decks touches).
+
+    La pipeline exacte du workflow (grep + dedup + existence locale du
+    `slides.md`) — parametree par la sortie de `git diff` pour rester
+    hermétique aux SHAs reels.
+    """
+    decks = []
+    if re.search(r"slides/(theme-ia101|package(-lock)?\.json)", changed):
+        # infra partagee : tous les decks — branche non couverte ici,
+        # le comportement hermetique vise la decouverte par diff.
+        return 0, decks
+    for path in sorted(
+        {m.group(1) for m in re.finditer(r"^slides/([^/]+)/", changed, re.M)}
+    ):
+        if (repo / "slides" / path / "slides.md").is_file():
+            decks.append(f"slides/{path}/slides.md")
+    return len(decks), decks
+
+
+# --- volet 1 : structure du workflow -----------------------------------------
+
+def test_workflow_has_checkout_before_resolve():
+    """Un `uses: actions/checkout@v4` doit preceder le step `resolve`."""
+    text = _workflow_text()
+    checkout = text.index("uses: actions/checkout@v4")
+    resolve = text.index("id: resolve")
+    assert checkout < resolve
+
+
+def test_checkout_fetches_head_and_full_history():
+    """`ref: head.sha` + `fetch-depth: 0` : les deux SHAs du diff existent."""
+    m = re.search(
+        r"uses: actions/checkout@v4(.*?)-\s+name:\s+Resolve",
+        _workflow_text(),
+        re.S,
+    )
+    assert m, "bloc checkout manquant avant le step Resolve"
+    block = m.group(1)
+    assert "ref: ${{ github.event.pull_request.head.sha }}" in block
+    assert "fetch-depth: 0" in block
+
+
+def test_git_diff_not_swallowed():
+    """Le `|| true` sur le `git diff` est retire : une panne doit rougir."""
+    m = re.search(r"CHANGED=\$\(git diff[^\n]*\)", _workflow_text())
+    assert m, "ligne CHANGED=$(git diff ...) introuvable"
+    line = m.group(0)
+    assert "|| true" not in line
+    assert "slides/" in line
+
+
+# --- volet 2 : comportement (controle negatif) --------------------------------
+
+def test_discovery_renders_at_least_one_on_deck_touching_diff(
+    tiny_repo: Path,
+):
+    """Une PR connue pour toucher un deck doit rendre N >= 1."""
+    (tiny_repo / "slides" / "demo" / "slides.md").write_text(
+        "# Deck\nbody modifie\n", encoding="utf-8"
+    )
+    changed = _git_run(
+        tiny_repo, "diff", "--name-only", "HEAD", "--", "slides/"
+    ).stdout
+    assert "slides/demo/slides.md" in changed
+    n, _ = _discovery(tiny_repo, "HEAD", "HEAD", changed)
+    assert n >= 1
+
+
+def test_discovery_renders_zero_on_untouched_slides(tiny_repo: Path):
+    """Un diff qui ne touche que docs/ ne revele aucun deck."""
+    (tiny_repo / "docs" / "readme.md").write_text("docs modifie\n", encoding="utf-8")
+    changed = _git_run(
+        tiny_repo, "diff", "--name-only", "HEAD", "--", "slides/"
+    ).stdout
+    n, _ = _discovery(tiny_repo, "HEAD", "HEAD", changed)
+    assert n == 0


### PR DESCRIPTION
Closes #15359

## Summary

`slides-composition-pr-relay.yml` n'avait **aucune étape `actions/checkout`** : sur un runner self-hosted le workspace est vide, `git diff --name-only "${BASE}...${HEAD}" -- slides/` échoue, et le `|| true` avalait l'erreur → `CHANGED` vide → `Touched decks: 0` **vert**. Faux négatif silencieux mesuré sur le run **34315275538** de la PR **#15334** : le relais a rendu `Touched decks: 0` sur une PR qui touchait pourtant `slides/08-ia-generative/slides.md` (+126/−14) et `style.css` (+52/−0) — un deck de 126 lignes ajoutées est passé sous l'organe sans être vu.

**Fix** (additif, patron du nocturne `slides-composition-advisory.yml`, série #11843) :

1. **Checkout** `actions/checkout@v4` ajouté en tête de job : `ref: ${{ github.event.pull_request.head.sha }}` (le head réel, pas le ref merge) + `fetch-depth: 0` (les deux SHAs du diff doivent exister localement) + `filter: blob:none` + sparse `slides/` — le diff d'arbres et le `[ -f slides/<d>/slides.md ]` n'ont besoin que de l'arbre + du contenu slides/, on ne clone pas les blobs hors zone.
2. **Retrait du `|| true`** sur le `git diff` : un relais qui ne peut pas savoir ce qu'il doit relayer **rougit**, il ne rend pas zéro. (Les `|| true` restants ne couvrent que des appels `gh api` et des tests d'existence — pas la découverte des decks.)
3. **Contrôle négatif** (#15359 : un détecteur se valide par ses faux négatifs, pas par ses hits) : tests de non-régression + rejeu sur données réelles.

## Validation

- **Nouveaux tests** `scripts/tests/test_slides_composition_pr_relay.py` : **5/5 PASS** — volet structurel (checkout avant `resolve` ; `ref: head.sha` + `fetch-depth: 0` présents ; le `git diff` ne porte plus `|| true`) + volet comportemental hermétique (pipeline de découverte → N ≥ 1 sur diff touchant un deck, N = 0 sur diff innocent, sur dépôt git minimal).
- **Contrôle négatif sur données réelles** (rejeu de la pipeline sur les SHAs réels de #15334, `866c3bb16...` → `0fa5e717a...`) :
  ```
  CHANGED = slides/08-ia-generative/slides.md
            slides/08-ia-generative/style.css
  DECKS   = slides/08-ia-generative/slides.md
  N = 1   (avant fix : Touched decks: 0 sur le run 34315275538)
  ```
- Suite `scripts/tests/` : **4927 passed, 13 skipped, 5 xfailed**. 4 échecs dans `test_prune_merged_worktrees.py::TestEndToEnd` **pré-existants** (reproduits sur main propre sans mes changements, `git stash` → même 4 failed) — exit-code environnement, hors scope.
- `compileall` PASS ; YAML parses avec `yaml.safe_load`. Diff : 2 fichiers, +172/−4. Aucun notebook, aucun secret. `runs-on` statique et garde anti-fork inchangés (policy `check_self_hosted_runner_policy.py` respectée).

## Grain

Grain: MED/guard -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #15315
