### PR TITLE
fix(guards,#14532): new_file KeyError du render texte plan-loss — stats completes (debloque #15147)

### DIFF
--- a/scripts/notebook_tools/detect_notebook_plan_loss.py
+++ b/scripts/notebook_tools/detect_notebook_plan_loss.py
@@ -463,6 +463,13 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
     # -- meme politique, distinction preservee par path_exists_at_ref.
     if not path_exists_at_ref(nb_path, base_ref):
         head_h = extract_headings(nb_head)
+        # Meme jeu de cles de stats que les branches comparees : le render
+        # texte de main() indexe base_md_cells/head_md_cells/cell_count_stable
+        # -- leur absence faisait crasher new_file en KeyError (#15147, une
+        # PR de renommages traite chaque nouveau chemin comme un new_file).
+        head_md_count = sum(
+            1 for c in nb_head.get("cells", []) if c.get("cell_type") == "markdown"
+        )
         return {
             "notebook": str(nb_path),
             "base_ref": base_ref,
@@ -470,6 +477,9 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
             "new_file": True,
             "findings": [],
             "stats": {
+                "base_md_cells": 0,
+                "head_md_cells": head_md_count,
+                "cell_count_stable": False,
                 "base_headings": 0,
                 "head_headings": len(head_h),
                 "findings_count": 0,

--- a/scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py
@@ -354,6 +354,33 @@ class TestScan:
         kinds = [f["kind"] for f in result["findings"]]
         assert "STRUCTURE_DRIFT" in kinds
 
+    def test_new_file_exempt(self, tmp_path: Path):
+        # Notebook NOUVEAU (absent de la base) -> exempt (rien a perdre, tout
+        # est ajout) : 0 finding et stats COMPLETES. C'est le chemin qui
+        # crashe en KeyError 'base_md_cells' avant #15147 -- les renommages
+        # (MGS-7 -> MGS-07) sont vus comme des fichiers nouveaux par le gate.
+        import subprocess
+        other = tmp_path / "autre.ipynb"
+        _write_nb(other, _nb(_md("# Autre\n\n")))
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "autre.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+
+        p = tmp_path / "nouveau.ipynb"
+        _write_nb(p, _nb(_md("# Plan nouveau\n\n### Duree estimee : 50 minutes\n\n")))
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref=None)
+        assert "error" not in result, result.get("error")
+        assert result["new_file"] is True
+        assert result["findings"] == []
+        st = result["stats"]
+        assert st["base_md_cells"] == 0
+        assert st["head_md_cells"] == 1
+        assert st["cell_count_stable"] is False
+        assert st["base_headings"] == 0
+        assert st["head_headings"] == 2
+
 
 # ---------------------------------------------------------------------------
 # 6. Justification par-section depuis le body PR
@@ -459,3 +486,51 @@ class TestMain:
         _write_nb(p, nb_head)
         rc = dpl.main([str(p), "--base", "HEAD", "--check"])
         assert rc == 1
+
+    def test_new_file_text_mode_exits_zero(self, tmp_path: Path, capsys):
+        # new_file en mode TEXTE : la ligne [STATS] indexe
+        # st['base_md_cells'] -- c'etait le KeyError de #15147 (le gate
+        # lit rc=1 comme une perte de plan). Fichier PRESENT au disque,
+        # ABSENT a la base -> rc=0, banniere [NEW FILE], [STATS] rendu.
+        import subprocess
+        other = tmp_path / "autre.ipynb"
+        _write_nb(other, _nb(_md("# Autre\n\n")))
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "autre.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+
+        p = tmp_path / "nouveau.ipynb"
+        _write_nb(p, _nb(_md("# Plan nouveau\n\n### Duree estimee : 50 minutes\n\n")))
+        rc = dpl.main([str(p), "--base", "HEAD", "--check"])
+        captured = capsys.readouterr()
+        assert rc == 0, f"rc={rc}, stderr={captured.err!r}"
+        assert "[NEW FILE]" in captured.out
+        assert "md_cells base=0 head=1 stable=False" in captured.out
+
+    def test_new_file_json_mode_exits_zero(self, tmp_path: Path, capsys):
+        # new_file en mode JSON : sortie machine parseable, new_file=True,
+        # stats avec les memes cles que les branches comparees (celles que
+        # les consommateurs indexent, ex. le render texte ligne ci-dessus).
+        import json
+        import subprocess
+        other = tmp_path / "autre.ipynb"
+        _write_nb(other, _nb(_md("# Autre\n\n")))
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "autre.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+
+        p = tmp_path / "nouveau.ipynb"
+        _write_nb(p, _nb(_md("# Plan nouveau\n\n### Duree estimee : 50 minutes\n\n")))
+        rc = dpl.main([str(p), "--base", "HEAD", "--json"])
+        captured = capsys.readouterr()
+        assert rc == 0, f"rc={rc}, stderr={captured.err!r}"
+        result = json.loads(captured.out)
+        assert result["new_file"] is True
+        assert result["findings"] == []
+        assert result["stats"]["base_md_cells"] == 0
+        assert result["stats"]["head_md_cells"] == 1
+        assert result["stats"]["cell_count_stable"] is False


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/guard #15362

## Summary

Le gate `notebook-plan-loss-gate.yml` crashe sur les PRs qui RENOMMENT des notebooks : le detecteur indexe `st['base_md_cells']` en dur dans son render texte, mais la branche `new_file` (chemin ABSENT a la base) ne fournit pas ces cles -> KeyError, rc=1 — que le gate interprete comme une **perte de plan**. #15147 (renommages MGS-7 -> MGS-07, tranche B #14545) reste bloquee UNIQUEMENT sur ce crash, ses renames etant sains.

## Repro (avant, sur origin/main)

```
python detect_notebook_plan_loss.py --base origin/main --check newfile.ipynb
[NEW FILE] absent a la base -> exempt de plan-loss (rien a perdre, tout est ajout).
Traceback ... File ".../detect_notebook_plan_loss.py", line 727, in main
KeyError: 'base_md_cells'
rc=1   # lu par le gate comme une perte -> rouge sur chaque rename
```

## Fix

La branche `new_file` fournit maintenant le meme jeu de cles de stats que les branches comparees : `base_md_cells: 0`, `head_md_cells: <n>`, `cell_count_stable: False` — miroir exact de `detect_md_content_loss.py` (sa branche new_file a toujours porte ces cles). Le render texte redevient stable sur les trois chemins ; la sortie JSON n'ajoute QUE des cles (consommateurs intacts).

## Verification

- **Repro apres fix** : `[NEW FILE]` + `[STATS] md_cells base=0 head=2 stable=False ...` rendu, **rc=0** (exempt, exit 0 comme documente dans le docstring du module).
- **Tests** : +3 dans `test_detect_notebook_plan_loss.py` — scan `new_file` stats completes ; **main() mode texte** (`[NEW FILE]` + `[STATS]` rendus, rc=0) ; **main() mode JSON** (parseable, `new_file: true`) — **31 passed** (28 avant + 3).
- **Famille frere** : `test_detect_md_content_loss.py` **60 passed** (intacte).
- **Perimetre** : 2 fichiers `scripts/notebook_tools/` uniquement (script + tests) ; zero notebook, zero workflow touche (semantique rc=0/1/2 du gate inchangee), zero artefact catalogue.

## Deliverable

Correctif debloqueur pour #15147 (re-run apres merge, steer ai-01 msg-20260909T070530-7posx4) — aucune issue fermee par cette PR.

See #15147 — #14532
