### PR TITLE
perf(ci,#15369): three-tier PR resolution in prune_merged_worktrees

### DIFF
--- a/scripts/ci/prune_merged_worktrees.py
+++ b/scripts/ci/prune_merged_worktrees.py
@@ -155,7 +155,9 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -536,7 +538,190 @@ def get_worktree_info(wt_path: str, current_path: str) -> dict:
     }
 
 
-def lookup_pr_for_branch(branch: str) -> Optional[dict]:
+# ----------------------------------------------------------------------------
+# Resolution PR a trois etages (#15369)
+# ----------------------------------------------------------------------------
+# Mesure fondatrice (rapport fleet po-2023 du 09/09 04:27) : 4 fermes en
+# « gh pr list failed » -- quota GraphQL du compte partage epuise, toutes
+# les machines tirant en meme temps. La resolution d'ancre coutait UN
+# appel search par worktree, sans aucun cache : lineaire en nombre de
+# worktrees (265 sur po-2026, 103 sur ai-01), sur un budget horaire
+# COMMUN a la flotte. Trois etages, du moins couteux au plus couteux :
+#
+# 1. cache disque par branche : verdicts MERGED uniquement, gardes par
+#    headRefOid (un MERGED est definitif POUR CES commits ; une branche
+#    re-poussee/re-PR porte un oid different -> miss -> etage suivant ;
+#    CLOSED n'est jamais cache, reopen possible) ;
+# 2. lot unique `--limit N` indexe par headRefName : une requete par
+#    passe au lieu de N. La fenetre est cappee : une ABSENCE du lot
+#    n'est jamais un verdict -- les branches absentes retombent sur
+#    l'ancre. Une ERREUR gh au lot degrade aussi vers l'ancre : une
+#    optimisation ne doit pas refuser des retraits legitimes ;
+# 3. l'ancre historique `--state all --search "head:<branche>"` :
+#    AUTHORITATIVE par decision ecrite (.claude/rules/git-workflow.md) --
+#    inchangee. La remplacer par commits/<oid>/pulls (faux negatifs
+#    mesures sur PRs OPEN) serait une regression, pas une optimisation.
+
+PR_VERDICT_CACHE_VERSION = 1
+PR_LISTING_WINDOW = 1000
+
+
+def _pr_cache_path() -> Path:
+    """Un fichier de verdicts par depot (cle = sha1 du remote origin)."""
+    proc = run_git(".", "remote", "get-url", "origin", check=False)
+    url = proc.stdout.strip() if proc.returncode == 0 else "unknown-repo"
+    key = hashlib.sha1(url.encode("utf-8")).hexdigest()[:12]
+    return Path.home() / ".cache" / "coursia" / "prune_pr_verdicts" / f"{key}.json"
+
+
+class PrResolution:
+    """Resolution PR a trois etages : cache disque -> lot -> ancre."""
+
+    def __init__(self, cache_path: Optional[Path] = None,
+                 listing_window: int = PR_LISTING_WINDOW):
+        self.cache_path = cache_path
+        self.listing_window = listing_window
+        self._entries: dict = {}
+        self._cache_dirty = False
+        self._index: Optional[dict] = None
+        self.stats = {
+            "cache_hits": 0,
+            "listing_calls": 0,
+            "listing_hits": 0,
+            "listing_degraded": 0,
+            "anchor_calls": 0,
+            "cache_writes": 0,
+        }
+        if self.cache_path is not None:
+            self._load_cache()
+
+    def _load_cache(self) -> None:
+        """Le cache est une economie, jamais une autorite : illisible = vide."""
+        try:
+            data = json.loads(self.cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if data.get("version") == PR_VERDICT_CACHE_VERSION:
+            self._entries = data.get("entries", {})
+
+    def flush(self) -> None:
+        if not self._cache_dirty or self.cache_path is None:
+            return
+        payload = {
+            "version": PR_VERDICT_CACHE_VERSION,
+            "entries": self._entries,
+        }
+        tmp = self.cache_path.with_suffix(".tmp")
+        try:
+            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp.write_text(json.dumps(payload), encoding="utf-8")
+            os.replace(tmp, self.cache_path)
+        except OSError:
+            return
+        self._cache_dirty = False
+
+    def _cache_get(self, branch: str, head_sha: Optional[str]) -> Optional[dict]:
+        entry = self._entries.get(branch)
+        if not entry or entry.get("state") != "MERGED":
+            return None
+        # Garde oid : le verdict MERGED vaut pour ces commits exactement.
+        if not head_sha or entry.get("headRefOid") != head_sha:
+            return None
+        return {
+            "number": entry["number"],
+            "state": "MERGED",
+            "url": entry.get("url"),
+            "headRefName": branch,
+            "headRefOid": entry.get("headRefOid"),
+        }
+
+    def _cache_put(self, row: dict) -> None:
+        if row.get("state") != "MERGED" or not row.get("headRefOid"):
+            return
+        self._entries[row["headRefName"]] = {
+            "number": row["number"],
+            "state": "MERGED",
+            "url": row.get("url"),
+            "headRefOid": row["headRefOid"],
+        }
+        self._cache_dirty = True
+        self.stats["cache_writes"] += 1
+
+    def _build_index(self) -> dict:
+        if self._index is not None:
+            return self._index
+        self.stats["listing_calls"] += 1
+        proc = run_gh(
+            "pr", "list",
+            "--state", "all",
+            "--json", "number,state,url,headRefName,headRefOid",
+            "--limit", str(self.listing_window),
+            check=False,
+        )
+        rows = None
+        if proc.returncode == 0:
+            try:
+                rows = json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                rows = None
+        if rows is None:
+            # Echec du lot -> degradation vers l'ancre (comportement
+            # d'avant #15369). L'index reste construit-vide : la
+            # degradation ne se joue qu'une fois par passe.
+            self._index = {}
+            self.stats["listing_degraded"] += 1
+            return self._index
+        index: dict = {}
+        for row in rows:
+            name = row.get("headRefName")
+            if not name:
+                continue
+            # Plusieurs PRs par nom de branche (close+reopen, re-PR) :
+            # garder la plus recente = numero max, meme choix que le
+            # rows[0] de l'ancre (retournee par date desc).
+            if (name not in index
+                    or row.get("number", 0) > index[name].get("number", 0)):
+                index[name] = row
+        self._index = index
+        return index
+
+    def resolve(self, branch: str,
+                head_sha: Optional[str] = None) -> Optional[dict]:
+        cached = self._cache_get(branch, head_sha)
+        if cached is not None:
+            self.stats["cache_hits"] += 1
+            return cached
+        index = self._build_index()
+        if branch in index:
+            row = index[branch]
+            self._cache_put(row)
+            self.stats["listing_hits"] += 1
+            return row
+        row = anchor_search_pr_for_branch(branch)
+        self.stats["anchor_calls"] += 1
+        if row:
+            self._cache_put(row)
+        return row
+
+
+_RESOLUTION: Optional[PrResolution] = None
+
+
+def get_pr_resolution() -> PrResolution:
+    """Singleton de passe : une seule requete de lot, un seul flush."""
+    global _RESOLUTION
+    if _RESOLUTION is None:
+        _RESOLUTION = PrResolution(cache_path=_pr_cache_path())
+    return _RESOLUTION
+
+
+def reset_pr_resolution() -> None:
+    """Tests : detache le singleton (chaque passe doit reconstruire)."""
+    global _RESOLUTION
+    _RESOLUTION = None
+
+
+def anchor_search_pr_for_branch(branch: str) -> Optional[dict]:
     """Cherche la PR dont le headRefName = branch.
 
     Ancre autoritative : `gh pr list --state all --search "head:<branch>"`.
@@ -547,7 +732,7 @@ def lookup_pr_for_branch(branch: str) -> Optional[dict]:
         "pr", "list",
         "--state", "all",
         "--search", f"head:{branch}",
-        "--json", "number,state,url,headRefName",
+        "--json", "number,state,url,headRefName,headRefOid",
         "--limit", "5",
         check=False,
     )
@@ -564,6 +749,19 @@ def lookup_pr_for_branch(branch: str) -> Optional[dict]:
     # possible apres close+reopen), on prend la plus recente en premier
     # (gh retourne deja par date desc).
     return rows[0]
+
+
+def lookup_pr_for_branch(branch: str,
+                         head_sha: Optional[str] = None) -> Optional[dict]:
+    """Resolution PR d'une branche via la couche a trois etages (#15369).
+
+    L'ancre `--state all --search head:<branche>` reste la source
+    autoritative ; les etages cache disque et lot unique ne font que
+    l'EVITER quand le verdict est deja etabli (MERGED garde par oid) ou
+    disponible dans la fenetre du lot. Une absence ou un echec des etages
+    d'economie retombe TOUJOURS sur l'ancre.
+    """
+    return get_pr_resolution().resolve(branch, head_sha)
 
 
 def lookup_pr_for_detached_head(wt_path: str) -> Optional[dict]:
@@ -654,8 +852,14 @@ def lookup_pr_for_detached_head(wt_path: str) -> Optional[dict]:
     return None
 
 
-def diagnose_worktree(wt_path: str, current_path: str) -> WorktreeStatus:
-    """Diagnostic complet d'un worktree."""
+def diagnose_worktree(wt_path: str, current_path: str,
+                      head_sha: Optional[str] = None) -> WorktreeStatus:
+    """Diagnostic complet d'un worktree.
+
+    `head_sha` (fourni par `list_worktrees`, porcelain) sert uniquement a
+    la garde oid du cache de verdicts MERGED (#15369) : sans lui, l'etage
+    cache est saute, jamais consulte a l'aveugle.
+    """
     info = get_worktree_info(wt_path, current_path)
 
     # Worktree courant : on ne tente JAMAIS de le retirer
@@ -810,7 +1014,7 @@ def diagnose_worktree(wt_path: str, current_path: str) -> WorktreeStatus:
     # Resolution PR
     pr = None
     if info["branch"]:
-        pr = lookup_pr_for_branch(info["branch"])
+        pr = lookup_pr_for_branch(info["branch"], head_sha=head_sha)
     elif not info["branch"]:
         pr = lookup_pr_for_detached_head(wt_path)
 
@@ -1085,10 +1289,18 @@ def main() -> int:
     statuses: list[WorktreeStatus] = []
     for wt in worktrees:
         try:
-            statuses.append(diagnose_worktree(wt["path"], current_path))
+            statuses.append(
+                diagnose_worktree(
+                    wt["path"], current_path, head_sha=wt.get("head_sha")
+                )
+            )
         except RuntimeError as e:
             print(f"ERROR diagnosing {wt['path']}: {e}", file=sys.stderr)
             return 2
+
+    # Les verdicts MERGED etablis pendant la passe survivent a la passe :
+    # persistance du cache de verdicts (#15369).
+    get_pr_resolution().flush()
 
     # Application
     apply_results: list[dict] = []
@@ -1130,6 +1342,7 @@ def main() -> int:
                 1 for s in statuses if s.decision == "SKIP_CURRENT"
             ),
             "dry_run": not args.apply,
+            "api_stats": get_pr_resolution().stats,
             "statuses": [s.to_dict() for s in statuses],
         }
         if args.apply:
@@ -1145,6 +1358,14 @@ def main() -> int:
             print(f"applied={removal_count}  errors={error_count}")
         else:
             print(render_text(statuses, dry_run=True))
+        # Budget API de la passe (#15369) : la mesure est un livrable, pas
+        # un side-effect silencieux.
+        st = get_pr_resolution().stats
+        print(
+            f"api: cache={st['cache_hits']} lot={st['listing_calls']}"
+            f" hits_lot={st['listing_hits']} ancre={st['anchor_calls']}"
+            f" degrade={st['listing_degraded']}"
+        )
 
     # Exit code
     if error_count > 0:

--- a/scripts/tests/test_prune_merged_worktrees.py
+++ b/scripts/tests/test_prune_merged_worktrees.py
@@ -373,7 +373,7 @@ class TestDiagnoseRefusalCauses:
         monkeypatch.setattr(pmw, "get_worktree_info", lambda *a: info)
         monkeypatch.setattr(
             pmw, "lookup_pr_for_branch",
-            lambda *a: {"state": "MERGED", "number": 42, "url": "u"},
+            lambda *a, **k: {"state": "MERGED", "number": 42, "url": "u"},
         )
         s = pmw.diagnose_worktree("C:/fake", "C:/other")
         assert s.decision == "REMOVE"
@@ -389,7 +389,7 @@ class TestDiagnoseRefusalCauses:
         monkeypatch.setattr(pmw, "get_worktree_info", lambda *a: info)
         monkeypatch.setattr(
             pmw, "lookup_pr_for_branch",
-            lambda *a: {"state": "MERGED", "number": 42, "url": "u"},
+            lambda *a, **k: {"state": "MERGED", "number": 42, "url": "u"},
         )
         s = pmw.diagnose_worktree("C:/fake", "C:/other")
         assert s.decision == "REFUSE"
@@ -800,6 +800,287 @@ def _fake_proc(returncode: int = 0, stdout: str = "", json_payload=None):
 
 
 # ---------------------------------------------------------------------------
+# Tests PrResolution -- couche a trois etages (#15369)
+# ---------------------------------------------------------------------------
+
+_PR_OID_A = "a" * 40
+_PR_OID_B = "b" * 40
+
+
+def _row(number, state, branch, oid=_PR_OID_A):
+    return {
+        "number": number, "state": state,
+        "url": f"https://example/pr/{number}",
+        "headRefName": branch, "headRefOid": oid,
+    }
+
+
+def _seed_cache_file(path, entries):
+    path.write_text(json.dumps({
+        "version": pmw.PR_VERDICT_CACHE_VERSION,
+        "entries": entries,
+    }), encoding="utf-8")
+
+
+def _stub_gh_listing_then_anchor(monkeypatch, listing_payload, anchor_payload):
+    """Les deux commandes gh se distinguent par '--search' (ancre seule)."""
+    def fake_gh(*args, **kwargs):
+        if "--search" in args:
+            return _fake_proc(json_payload=anchor_payload)
+        return _fake_proc(json_payload=listing_payload)
+    monkeypatch.setattr(pmw, "run_gh", fake_gh)
+
+
+class TestPrResolution:
+    """#15369 : cache disque MERGED-seul garde par oid, lot unique a
+    fenetre cappee, ancre autoritaire. Tout etage d'economie qui echoue,
+    ignore la branche ou ne peut pas trancher (head_sha inconnu) retombe
+    sur l'ancre -- son absence n'est JAMAIS un verdict."""
+
+    def test_cache_hit_merges_without_gh(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache.json"
+        _seed_cache_file(cache, {
+            "feature/merged": {
+                "number": 42, "state": "MERGED",
+                "url": "https://example/pr/42",
+                "headRefOid": _PR_OID_A,
+            },
+        })
+
+        def _no_gh(*a, **k):
+            raise AssertionError("cache hit ne doit declencher AUCUN appel gh")
+
+        monkeypatch.setattr(pmw, "run_gh", _no_gh)
+        res = pmw.PrResolution(cache_path=cache)
+        row = res.resolve("feature/merged", head_sha=_PR_OID_A)
+        assert row is not None and row["state"] == "MERGED"
+        assert row["number"] == 42
+        assert res.stats["cache_hits"] == 1
+        assert res.stats["listing_calls"] == 0
+        assert res.stats["anchor_calls"] == 0
+
+    def test_cache_oid_mismatch_never_answers_merged(self, tmp_path, monkeypatch):
+        """Branche re-poussee (nouveau head) : le MERGED cache vaut pour
+        d'autres commits. Une re-PR ouverte doit pouvoir se manifester --
+        la garde porte l'oid, pas le nom de branche."""
+        cache = tmp_path / "cache.json"
+        _seed_cache_file(cache, {
+            "feature/repushed": {
+                "number": 42, "state": "MERGED",
+                "url": "https://example/pr/42",
+                "headRefOid": _PR_OID_A,
+            },
+        })
+        _stub_gh_listing_then_anchor(
+            monkeypatch,
+            listing_payload=[],
+            anchor_payload=[_row(43, "OPEN", "feature/repushed", oid=_PR_OID_B)],
+        )
+        res = pmw.PrResolution(cache_path=cache)
+        row = res.resolve("feature/repushed", head_sha=_PR_OID_B)
+        assert row["state"] == "OPEN", (
+            "un MERGED cache d'un autre oid ne doit jamais masquer la "
+            "PR courante de la branche"
+        )
+        assert res.stats["cache_hits"] == 0
+        assert res.stats["anchor_calls"] == 1
+
+    def test_cache_without_head_sha_falls_through(self, tmp_path, monkeypatch):
+        """head_sha inconnu (HEAD absent du porcelain) : la garde oid ne
+        peut pas trancher -> jamais de verdict depuis le cache."""
+        cache = tmp_path / "cache.json"
+        _seed_cache_file(cache, {
+            "feature/guard": {
+                "number": 42, "state": "MERGED",
+                "url": "https://example/pr/42",
+                "headRefOid": _PR_OID_A,
+            },
+        })
+        _stub_gh_listing_then_anchor(monkeypatch, [], [])
+        res = pmw.PrResolution(cache_path=cache)
+        row = res.resolve("feature/guard", head_sha=None)
+        assert row is None
+        assert res.stats["cache_hits"] == 0
+
+    def test_listing_hit_avoids_anchor_and_is_shared(self, tmp_path, monkeypatch):
+        calls = []
+
+        def fake_gh(*args, **kwargs):
+            calls.append(list(args))
+            if "--search" in args:
+                raise AssertionError(
+                    "branche dans le lot : l'ancre ne doit pas etre appelee")
+            return _fake_proc(json_payload=[
+                _row(100, "MERGED", "feature/in-window", oid=_PR_OID_A),
+                _row(99, "OPEN", "feature/also-in", oid=_PR_OID_B),
+            ])
+
+        monkeypatch.setattr(pmw, "run_gh", fake_gh)
+        res = pmw.PrResolution(cache_path=None)
+        r1 = res.resolve("feature/in-window", head_sha=_PR_OID_A)
+        assert r1["number"] == 100 and r1["state"] == "MERGED"
+        r2 = res.resolve("feature/also-in")
+        assert r2["number"] == 99
+        # Un seul appel de lot pour la passe entiere.
+        assert res.stats["listing_calls"] == 1
+        assert res.stats["listing_hits"] == 2
+        assert res.stats["anchor_calls"] == 0
+
+    def test_listing_keeps_max_number_per_branch(self, tmp_path, monkeypatch):
+        """close+reopen / re-PR : deux PRs partagent headRefName et le lot
+        n'est pas garanti trie par date. Garder numero max = le verdict le
+        plus recent, meme choix que le rows[0] de l'ancre (date desc)."""
+        monkeypatch.setattr(pmw, "run_gh", lambda *a, **k: _fake_proc(
+            json_payload=[
+                _row(41, "CLOSED", "feature/re-pr", oid=_PR_OID_A),
+                _row(57, "OPEN", "feature/re-pr", oid=_PR_OID_B),
+            ]))
+        res = pmw.PrResolution(cache_path=None)
+        row = res.resolve("feature/re-pr")
+        assert row["number"] == 57
+
+    def test_listing_error_degrades_to_anchor_once(self, tmp_path, monkeypatch):
+        anchor_rows = [_row(77, "MERGED", "feature/anchor-only", oid=_PR_OID_A)]
+
+        def fake_gh(*args, **kwargs):
+            if "--search" in args:
+                wanted = next(
+                    a for a in args if str(a).startswith("head:"))[len("head:"):]
+                payload = [r for r in anchor_rows
+                           if r["headRefName"] == wanted]
+                return _fake_proc(json_payload=payload)
+            return _fake_proc(returncode=1, stdout="rate limited")
+
+        monkeypatch.setattr(pmw, "run_gh", fake_gh)
+        res = pmw.PrResolution(cache_path=None)
+        row = res.resolve("feature/anchor-only", head_sha=_PR_OID_A)
+        assert row["number"] == 77 and row["state"] == "MERGED"
+        assert res.stats["listing_degraded"] == 1
+        # La degradation ne rejoue pas le lot a chaque branche : la
+        # deuxieme resolution va direct a l'ancre.
+        assert res.resolve("feature/other") is None
+        assert res.stats["listing_calls"] == 1
+        assert res.stats["anchor_calls"] == 2
+
+    def test_capped_window_miss_falls_to_anchor_never_absent(self, tmp_path, monkeypatch):
+        """Branche hors fenetre --limit 1000 : son absence du lot n'est
+        PAS un verdict. L'ancre tranche (ici OPEN -> le travailleur vit)."""
+        _stub_gh_listing_then_anchor(
+            monkeypatch,
+            listing_payload=[],
+            anchor_payload=[_row(88, "OPEN", "feature/old", oid=_PR_OID_A)],
+        )
+        res = pmw.PrResolution(cache_path=None)
+        row = res.resolve("feature/old", head_sha=_PR_OID_A)
+        assert row is not None and row["state"] == "OPEN"
+        assert res.stats["anchor_calls"] == 1
+
+    def test_closed_rows_never_cached(self, tmp_path, monkeypatch):
+        """CLOSED peut rouvrir : le cache ne fige JAMAIS ce verdict
+        (divergence assumee avec la suggestion de l'issue, documentee).
+        Un fichier pre-seed reste byte-identique : rien a ecrire."""
+        cache = tmp_path / "cache.json"
+        seeded = {
+            "feature/already": {
+                "number": 7, "state": "MERGED",
+                "url": "https://example/pr/7",
+                "headRefOid": _PR_OID_A,
+            },
+        }
+        _seed_cache_file(cache, seeded)
+        _stub_gh_listing_then_anchor(
+            monkeypatch,
+            listing_payload=[_row(90, "CLOSED", "feature/closed", oid=_PR_OID_A)],
+            anchor_payload=[],
+        )
+        res = pmw.PrResolution(cache_path=cache)
+        row = res.resolve("feature/closed", head_sha=_PR_OID_A)
+        assert row["state"] == "CLOSED"
+        assert res.stats["cache_writes"] == 0
+        res.flush()
+        assert json.loads(cache.read_text(encoding="utf-8"))["entries"] == seeded
+
+    def test_merged_from_listing_persisted_and_replayed(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache.json"
+        _stub_gh_listing_then_anchor(
+            monkeypatch,
+            listing_payload=[_row(91, "MERGED", "feature/keep", oid=_PR_OID_A)],
+            anchor_payload=[],
+        )
+        res = pmw.PrResolution(cache_path=cache)
+        res.resolve("feature/keep", head_sha=_PR_OID_A)
+        assert res.stats["cache_writes"] == 1
+        res.flush()
+        assert cache.exists()
+
+        # Passe suivante : cache disque -> zero appel gh.
+        def _no_gh(*a, **k):
+            raise AssertionError("relecture cache ne doit pas appeler gh")
+
+        monkeypatch.setattr(pmw, "run_gh", _no_gh)
+        res2 = pmw.PrResolution(cache_path=cache)
+        row = res2.resolve("feature/keep", head_sha=_PR_OID_A)
+        assert row["state"] == "MERGED" and row["number"] == 91
+        assert res2.stats["cache_hits"] == 1
+
+    def test_squash_merge_control_repush_misses_cache(self, tmp_path, monkeypatch):
+        """Controle squash-merge : branche squash-mergee puis recree
+        depuis main = head NOUVEAU -> l'oid garde fait rater le cache ->
+        l'ancre (aucune PR pour ce head) rend None -> REFUSE
+        no_pr_match, jamais REMOVE sur un souvenir."""
+        cache = tmp_path / "cache.json"
+        _seed_cache_file(cache, {
+            "feature/squash": {
+                "number": 42, "state": "MERGED",
+                "url": "https://example/pr/42",
+                "headRefOid": _PR_OID_A,
+            },
+        })
+        _stub_gh_listing_then_anchor(monkeypatch, [], [])
+        res = pmw.PrResolution(cache_path=cache)
+        row = res.resolve("feature/squash", head_sha=_PR_OID_B)
+        assert row is None
+        assert res.stats["cache_hits"] == 0
+
+    def test_flush_swallows_oserror(self, tmp_path, monkeypatch):
+        """Le cache est une economie : un echec d'ecriture ne doit jamais
+        faire echouer la passe."""
+        cache = tmp_path / "cache.json"
+        _stub_gh_listing_then_anchor(
+            monkeypatch,
+            listing_payload=[_row(93, "MERGED", "feature/x", oid=_PR_OID_A)],
+            anchor_payload=[],
+        )
+        res = pmw.PrResolution(cache_path=cache)
+        res.resolve("feature/x", head_sha=_PR_OID_A)
+
+        def boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_text", boom)
+        res.flush()  # ne doit pas lever
+
+    def test_lookup_delegates_to_singleton_with_oid(self, monkeypatch):
+        seen = {}
+
+        class FakeRes:
+            stats = {}
+
+            def resolve(self, branch, head_sha=None):
+                seen["branch"] = branch
+                seen["head_sha"] = head_sha
+                return None
+
+        monkeypatch.setattr(pmw, "_RESOLUTION", FakeRes())
+        try:
+            pmw.lookup_pr_for_branch("feature/deleg", head_sha="cafe")
+            assert seen == {"branch": "feature/deleg", "head_sha": "cafe"}
+        finally:
+            pmw.reset_pr_resolution()
+        assert pmw._RESOLUTION is None
+
+
+# ---------------------------------------------------------------------------
 # Tests render_text -- fidelite au disque en mode --apply (#14476)
 # ---------------------------------------------------------------------------
 
@@ -968,7 +1249,8 @@ class TestToleratedCleanup14619:
                 untracked=["bg_logs/", "lake_7012.log.relaunch"]),
         )
         monkeypatch.setattr(
-            pmw, "lookup_pr_for_branch", lambda b: dict(_MERGED_PR))
+            pmw, "lookup_pr_for_branch",
+            lambda b, head_sha=None: dict(_MERGED_PR))
         s = pmw.diagnose_worktree("C:/fake/wt", "C:/elsewhere")
         assert s.decision == "REMOVE"
 
@@ -978,7 +1260,8 @@ class TestToleratedCleanup14619:
             lambda *a, **k: _fake_info(untracked=["residu.bin"]),
         )
         monkeypatch.setattr(
-            pmw, "lookup_pr_for_branch", lambda b: dict(_MERGED_PR))
+            pmw, "lookup_pr_for_branch",
+            lambda b, head_sha=None: dict(_MERGED_PR))
         s = pmw.diagnose_worktree("C:/fake/wt", "C:/elsewhere")
         assert s.decision == "REFUSE"
         assert s.refusal_reason == "untolerated_untracked:1"
@@ -1262,7 +1545,8 @@ class TestEndToEndHermetic14693:
     def _merged_anchor(self, monkeypatch):
         monkeypatch.setattr(
             pmw, "lookup_pr_for_branch",
-            lambda branch: dict(self.MERGED_PR, headRefName=branch),
+            lambda branch, head_sha=None: dict(
+                self.MERGED_PR, headRefName=branch),
         )
 
     def test_tolerated_artifacts_only_is_removed(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #15317

## Ce qui change

`lookup_pr_for_branch` resolvait une ancre `gh pr list --state all --search "head:<branche>"` **par worktree** — lineaire en worktrees, des centaines d'appels search par passe fleet sur le quota partage `jsboige` (3159389). Symptome mesure : exit=2 « gh pr list failed » sur 4 fermes du rapport fleet 09/09 04:27.

Couche a trois etages, **l'ancre reste autoritaire** ([git-workflow.md](.claude/rules/git-workflow.md)) :

1. **Cache disque** par remote (`~/.cache/coursia/prune_pr_verdicts/<sha1-remote>.json`) : verdicts **MERGED uniquement**, gardes par `headRefOid` — un MERGED est definitif pour exactement ces commits ; une branche re-poussee (nouvel oid) fait rater le cache. **CLOSED n'est jamais cache** (rouverture possible — divergence assumee avec la suggestion voie 1 de l'issue, motivee). Cache illisible / echec d'ecriture = no-op silencieux (une economie n'est jamais une autorite).
2. **Lot unique** `gh pr list --state all --limit 1000 --json number,state,url,headRefName,headRefOid`, indexe par `headRefName` (numero **max** par branche = verdict le plus recent, parite avec le `rows[0]` date-desc de l'ancre). **L'absence de la fenetre cappee n'est JAMAIS un verdict** : elle retombe sur l'ancre. Erreur du lot = degradation vers l'ancre, une seule fois par passe.
3. **Ancre inchangee** : `--state all --search head:<branche>`, jamais `commits/<oid>/pulls`. Erreur gh -> `RuntimeError` -> exit 2 fail-closed, "pas de PR" -> REFUSE.

Sortie : `api_stats` dans le JSON (`cache_hits, listing_calls, listing_hits, listing_degraded, anchor_calls, cache_writes`) + ligne `api:` en mode texte.

## Acceptance #15369

- [x] **Passe bornee et mesuree, avant/apres** — ferme CoursIA (po-2023), 62 worktrees scannes, 42 resolutions PR : **avant = 42 appels search ancre ; apres = 1 appel de lot + 0 ancre** (api_stats : `cache_hits=22, listing_hits=20, listing_calls=1, anchor_calls=0, cache_writes=4`). Dry-run (pas de `--apply` sur une ferme qui n'est pas la mienne) ; la ferme CoursIA-2, taille comparable, a livre un second measure see ci-dessous.
- [x] **Ancre `--state all` autoritative** — corps de l'ancre recopie tel quel dans `anchor_search_pr_for_branch` ; aucun basculement REST ascendance.
- [x] **Troncature / erreur gh -> REFUSE, jamais REMOVE** — absence de la fenetre -> ancre (test `test_capped_window_miss_falls_to_anchor_never_absent`) ; erreur de lot -> degradation ancre (`test_listing_error_degrades_to_anchor_once`) ; erreur ancre -> `RuntimeError` -> exit 2 (contract existant, teste). **Controle live** : la passe CoursIA-2 a croise le quota GraphQL partage en cours de diagnostic -> `ERROR diagnosing D:/Dev/CoursIA-12914-c543: gh pr list failed: GraphQL: API rate limit already exceeded` -> **exit 2, zero retrait** — le fail-closed s'est demontre de lui-meme sur la vraie panne que l'issue cherche a reduire.
- [x] **Controle squash-merge rejoue** — `TestEndToEndHermetic14693::test_tolerated_artifacts_only_is_removed` (vrai depot + vrai worktree, PR MERGED, retrait reel du disque) reste vert ; `test_squash_merge_control_repush_misses_cache` couvre le cas symetrique (branche recree depuis main = nouvel oid -> rater le cache -> ancre vide -> REFUSE `no_pr_match`, jamais REMOVE sur un souvenir).

## Tests

`python -m pytest scripts/tests/test_prune_merged_worktrees.py` : **89 passed, 2 skipped** (79 preexistants adaptes signature `head_sha` + 12 nouveaux `TestPrResolution` : garde oid, re-push/reopen, CLOSED-never-cached, fallthrough fenetre cappee, degrade lot, controle squash, stats, flush OSError, delegation singleton).

Closes #15369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
