### PR TITLE
fix(ci,#15372): prev-guard comment upsert — PATCH in place, lift on green

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -716,13 +716,26 @@ jobs:
 
           if [ "$RC" -eq 0 ]; then
             echo "No \`prev:\` close-keyword genre in body or commits -- job passes."
+            # #15372 : un run vert LEVE le commentaire bloquant precedent
+            # en place (s'il existe). No-op silencieux sinon -- un vert
+            # sur une PR jamais bloquee ne fabrique pas de bruit. Un mur
+            # qui ne se ferme jamais n'est pas un signal.
+            PREVS=$(python3 -c "import json; print(', '.join('#%s' % n for n in json.load(open('/tmp/verdict.json')).get('prev_targets_accepted', [])))" 2>/dev/null || echo "")
+            GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" python3 scripts/ci/guard_comment_upsert.py \
+              --pr "$PR_NUMBER" \
+              --marker '<!-- vtr-prev-close-keyword -->' \
+              --lift --note "aucun genre mots-clé fermant dans le body ni les commits ; prev: accepté(s) : ${PREVS:-aucun}" \
+              >/dev/null 2>&1 || true
             exit 0
           fi
 
           REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
           echo "::error::prev: close-keyword genre detected: $REASON"
 
-          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          # #15372 : upsert -- EDITE le commentaire bot existant (marqueur
+          # + auteur github-actions) au lieu d'en cumuler un nouveau par
+          # run rouge (19 faux bloquants mesures sur 4 PRs le 09/09).
+          cat > /tmp/prev_blocked_body.md <<EOF
           <!-- vtr-prev-close-keyword -->
           **\`prev:\` genre mots-clé fermant -- bloquant (#10093).**
 
@@ -736,7 +749,11 @@ jobs:
           Grain: <TIER>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<refactor|guard|tooling|...> #<PR>
           \`\`\`
           EOF
-          )" 2>/dev/null || true
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" python3 scripts/ci/guard_comment_upsert.py \
+            --pr "$PR_NUMBER" \
+            --marker '<!-- vtr-prev-close-keyword -->' \
+            --body-file /tmp/prev_blocked_body.md \
+            >/dev/null 2>&1 || true
 
           exit 1
 

--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -721,11 +721,17 @@ jobs:
             # sur une PR jamais bloquee ne fabrique pas de bruit. Un mur
             # qui ne se ferme jamais n'est pas un signal.
             PREVS=$(python3 -c "import json; print(', '.join('#%s' % n for n in json.load(open('/tmp/verdict.json')).get('prev_targets_accepted', [])))" 2>/dev/null || echo "")
-            GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" python3 scripts/ci/guard_comment_upsert.py \
+            if ! GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" python3 scripts/ci/guard_comment_upsert.py \
               --pr "$PR_NUMBER" \
               --marker '<!-- vtr-prev-close-keyword -->' \
               --lift --note "aucun genre mots-clé fermant dans le body ni les commits ; prev: accepté(s) : ${PREVS:-aucun}" \
-              >/dev/null 2>&1 || true
+              >/dev/null 2>&1; then
+              # #15374 : le gate reste vert (run prev: propre), mais un
+              # lift qui echoue (quota, reseau, permissions) doit rester
+              # OBSERVABLE -- sinon le commentaire bloquant survit faux
+              # en silence.
+              echo "::warning::prev-guard lift failed (commentaire bloquant possiblement perime)"
+            fi
             exit 0
           fi
 
@@ -749,11 +755,16 @@ jobs:
           Grain: <TIER>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<refactor|guard|tooling|...> #<PR>
           \`\`\`
           EOF
-          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" python3 scripts/ci/guard_comment_upsert.py \
+          if ! GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" python3 scripts/ci/guard_comment_upsert.py \
             --pr "$PR_NUMBER" \
             --marker '<!-- vtr-prev-close-keyword -->' \
             --body-file /tmp/prev_blocked_body.md \
-            >/dev/null 2>&1 || true
+            >/dev/null 2>&1; then
+            # #15374 : le gate est deja rouge (exit 1 ensuite), mais
+            # l'echec d'upsert ne doit pas passer inapercu -- il ne sera
+            # jamais presente comme une ecriture reussie.
+            echo "::warning::prev-guard upsert failed (commentaire bloquant non pose)"
+          fi
 
           exit 1
 

--- a/scripts/ci/guard_comment_upsert.py
+++ b/scripts/ci/guard_comment_upsert.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+r"""Upsert du commentaire d'un garde : PATCH en place, jamais de mur (#15372).
+
+Un garde qui poste un commentaire bloquant a chaque run rouge sans jamais
+retirer produit un mur de verdicts perimes : 19 commentaires « bloquant »
+mesures sur 4 PRs le 2026-09-09, tous faux a l'instant de la mesure (la
+cible ``prev:`` avait merge apres le tir, et seul un nouvel evenement
+``pull_request`` reevalue -- il n'y en a plus quand la PR attend).
+
+Ce module remplace le ``gh pr comment`` create-only par un upsert :
+
+* **recherche** du commentaire porte par le marqueur **ET** ecrit par le
+  bot du depot (login ``github-actions`` / ``github-actions[bot]``). Le
+  filtre d'auteur n'est pas decoratif : sur #15146, 4 commentaires
+  HUMAINS portent le marqueur ``<!-- vtr-prev-close-keyword -->``
+  verbatim, cites dans des comptes rendus -- une recherche marqueur-seul
+  editerait un commentaire humain ;
+* **PATCH** en place (``repos/{repo}/issues/comments/{id}``) au lieu
+  d'en creer un nouveau ;
+* **levee sur run vert** : si un commentaire bloquant existe, il est
+  reecrit en etat leve, horodate, nommant les ``prev:`` desormais
+  acceptes. Le marqueur reste porte par le corps releve pour que le
+  prochain upsert le retrouve.
+
+Jamais de suppression : pas d'effacement d'historique (#15372
+acceptance 4).
+
+Les appels ``gh`` passent par un ``runner`` injectable (pattern
+``variation_prev_guard.resolve_prev_targets``) pour que les tests
+rejouent le corpus reel sans reseau.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+# Les commentaires postes avec GITHUB_TOKEN ont pour auteur
+# ``github-actions[bot]`` ; les runs legacy ``github-actions``. Les deux
+# partagent ce prefix. Un autre bot (dependabot, etc.) ne doit jamais
+# etre edite par ce garde.
+GUARD_BOT_LOGIN_PREFIX = "github-actions"
+
+DEFAULT_TIMEOUT = 15
+
+
+def _default_runner(cmd, **kwargs):  # pragma: no cover - trivial default
+    import subprocess
+    return subprocess.run(cmd, **kwargs)
+
+
+def find_guard_comment_id(
+    comments: Optional[list],
+    marker: str,
+) -> Optional[int]:
+    r"""Dernier commentaire DU BOT portant ``marker`` dans son corps.
+
+    Le dernier (id REST max) gagne : c'est l'etat courant affiche du
+    garde. Retourne ``None`` quand aucun commentaire bot ne porte le
+    marqueur -- y compris si des commentaires humains le portent (corpus
+    #15146 : 3 ``jsboige`` + 1 ``myia-ai-01`` citaient le verdict
+    verbatim ; ils ne doivent jamais etre edites).
+    """
+    best: Optional[int] = None
+    for c in comments or []:
+        body = c.get("body") or ""
+        login = ((c.get("user") or {}).get("login") or "")
+        if marker in body and login.startswith(GUARD_BOT_LOGIN_PREFIX):
+            cid = c.get("id")
+            if isinstance(cid, int) and (best is None or cid > best):
+                best = cid
+    return best
+
+
+def list_comments(
+    pr: int,
+    repo: str,
+    runner: Optional[Callable] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> list:
+    r"""Commentaires de la PR via l'API REST (id NUMERIQUE).
+
+    L'``id`` de ``gh pr view --json comments`` est le node id GraphQL
+    (``IC_...``), inutilisable par le PATCH REST -- mesure sur #15373 :
+    ``IC_kwDO...`` cote GraphQL, ``5600457600`` cote REST. On va donc a
+    la source. ``--paginate --slurp`` rend un tableau de pages (un
+    element par page) : on aplatit.
+    """
+    if runner is None:  # pragma: no cover - trivial default
+        runner = _default_runner
+    proc = runner(
+        ["gh", "api", "--paginate", "--slurp",
+         f"repos/{repo}/issues/{pr}/comments"],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if getattr(proc, "returncode", 1) != 0:
+        raise RuntimeError(f"gh api comments failed: {proc.stderr.strip()}")
+    data = json.loads(proc.stdout)
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"gh api comments: forme inattendue ({type(data).__name__})")
+    return [row for page in data for row in page]
+
+
+def _patch_comment(
+    comment_id: int,
+    body: str,
+    repo: str,
+    runner: Callable,
+    timeout: int,
+) -> dict:
+    proc = runner(
+        ["gh", "api", "--method", "PATCH",
+         f"repos/{repo}/issues/comments/{comment_id}",
+         "-f", f"body={body}"],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if getattr(proc, "returncode", 1) != 0:
+        raise RuntimeError(
+            f"gh api PATCH comment {comment_id} failed: {proc.stderr.strip()}")
+    return {"action": "patched", "comment_id": comment_id}
+
+
+def _create_comment(
+    pr: int,
+    body: str,
+    repo: str,
+    runner: Callable,
+    timeout: int,
+) -> dict:
+    proc = runner(
+        ["gh", "api", "--method", "POST",
+         f"repos/{repo}/issues/{pr}/comments",
+         "-f", f"body={body}"],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if getattr(proc, "returncode", 1) != 0:
+        raise RuntimeError(f"gh api POST comment failed: {proc.stderr.strip()}")
+    try:
+        cid = json.loads(proc.stdout).get("id")
+    except (json.JSONDecodeError, AttributeError):
+        cid = None
+    return {"action": "created", "comment_id": cid}
+
+
+def upsert_comment(
+    pr: int,
+    marker: str,
+    body: str,
+    repo: str,
+    runner: Optional[Callable] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    r"""Edite le commentaire bot existant, sinon en cree un premier."""
+    if runner is None:  # pragma: no cover - trivial default
+        runner = _default_runner
+    existing = find_guard_comment_id(list_comments(pr, repo, runner, timeout),
+                                     marker)
+    if existing is not None:
+        return _patch_comment(existing, body, repo, runner, timeout)
+    return _create_comment(pr, body, repo, runner, timeout)
+
+
+def build_lifted_body(marker: str, title: str, note: str,
+                      ts: Optional[str] = None) -> str:
+    r"""Corps releve : marqueur CONSERVE pour le prochain upsert."""
+    if ts is None:
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (
+        f"{marker}\n"
+        f"**{title} — LEVÉ ({ts}).**\n\n"
+        f"{note}\n\n"
+        "Run vert du garde : ce commentaire bloquant est obsolète. Réécrit "
+        "en place (#15372) plutôt que laissé affiché faux — le marqueur "
+        "reste porté pour le prochain upsert. Historique : runs "
+        "`Always-on guards` de la PR."
+    )
+
+
+def lift_comment(
+    pr: int,
+    marker: str,
+    note: str,
+    repo: str,
+    title: str = "`prev:` genre mot-clé fermant (#10093)",
+    runner: Optional[Callable] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    r"""Run vert : releve le commentaire bloquant precedent s'il existe.
+
+    No-op silencieux quand aucun commentaire bot ne porte le marqueur --
+    un run vert sur une PR jamais bloquee ne doit pas fabriquer du bruit.
+    """
+    if runner is None:  # pragma: no cover - trivial default
+        runner = _default_runner
+    existing = find_guard_comment_id(list_comments(pr, repo, runner, timeout),
+                                     marker)
+    if existing is None:
+        return {"action": "noop", "comment_id": None}
+    body = build_lifted_body(marker, title, note)
+    return _patch_comment(existing, body, repo, runner, timeout)
+
+
+def _resolve_repo(explicit: Optional[str]) -> str:
+    import os
+    if explicit:
+        return explicit
+    env = os.environ.get("GITHUB_REPOSITORY")
+    if env:
+        return env
+    proc = _default_runner(
+        ["gh", "repo", "view", "--json", "nameWithOwner",
+         "--jq", ".nameWithOwner"],
+        capture_output=True, text=True, timeout=DEFAULT_TIMEOUT,
+    )
+    if getattr(proc, "returncode", 1) != 0:
+        raise RuntimeError(
+            "repo introuvable : --repo absent, GITHUB_REPOSITORY absent, "
+            f"gh repo view a échoué: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def main(argv: Optional[list] = None,
+         runner: Optional[Callable] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pr", type=int, required=True,
+                        help="Numéro de la PR porteuse du commentaire.")
+    parser.add_argument("--marker", required=True,
+                        help="Marqueur HTML identifiant le commentaire.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--body-file",
+                      help="Mode bloquant : corps complet du commentaire.")
+    mode.add_argument("--lift", action="store_true",
+                      help="Mode levée : réécrire le bloquant en LEVÉ.")
+    parser.add_argument("--note", default="",
+                        help="Mode levée : note horodatée (prev acceptés...).")
+    parser.add_argument("--repo", default=None,
+                        help="owner/name. Défaut : GITHUB_REPOSITORY.")
+    args = parser.parse_args(argv)
+
+    repo = _resolve_repo(args.repo)
+    if args.lift:
+        result = lift_comment(args.pr, args.marker, args.note, repo,
+                              runner=runner)
+    else:
+        with open(args.body_file, encoding="utf-8") as fh:
+            body = fh.read()
+        result = upsert_comment(args.pr, args.marker, body, repo,
+                                runner=runner)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/guard_comment_upsert.py
+++ b/scripts/ci/guard_comment_upsert.py
@@ -38,10 +38,11 @@ from datetime import datetime, timezone
 from typing import Callable, Optional
 
 # Les commentaires postes avec GITHUB_TOKEN ont pour auteur
-# ``github-actions[bot]`` ; les runs legacy ``github-actions``. Les deux
-# partagent ce prefix. Un autre bot (dependabot, etc.) ne doit jamais
-# etre edite par ce garde.
-GUARD_BOT_LOGIN_PREFIX = "github-actions"
+# ``github-actions[bot]`` ; les runs legacy ``github-actions``. Ce sont les
+# DEUX SEULS logins editables -- appartenance exacte, pas un prefix : sur un
+# depot public un tiers peut porter ``github-actions-xyz`` (review ai-01
+# #15374) et un autre bot (dependabot, etc.) ne doit jamais l'etre non plus.
+GUARD_BOT_LOGINS = frozenset({"github-actions", "github-actions[bot]"})
 
 DEFAULT_TIMEOUT = 15
 
@@ -67,7 +68,7 @@ def find_guard_comment_id(
     for c in comments or []:
         body = c.get("body") or ""
         login = ((c.get("user") or {}).get("login") or "")
-        if marker in body and login.startswith(GUARD_BOT_LOGIN_PREFIX):
+        if marker in body and login in GUARD_BOT_LOGINS:
             cid = c.get("id")
             if isinstance(cid, int) and (best is None or cid > best):
                 best = cid

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -472,7 +472,11 @@ def check(
     if not hits_body and not hits_commits and not hits_prev_invalid:
         return {"guard_pass": True,
                 "reason": "no prev: defect (close-keyword or invalid ref)",
-                "hits": {"body": [], "commits": [], "prev_invalid": []}}
+                "hits": {"body": [], "commits": [], "prev_invalid": []},
+                # Cibles `prev:` declarees et acceptees par ce run vert :
+                # la levee de commentaire #15372 les nomme, pour que le
+                # remplacement du mur affiche ce qui fait tenir le vert.
+                "prev_targets_accepted": sorted(set(body_targets))}
 
     # Compose the verdict. The reason names the worst offender first so
     # the worker reads the most actionable hint at the top of the failure

--- a/scripts/tests/test_guard_comment_upsert.py
+++ b/scripts/tests/test_guard_comment_upsert.py
@@ -90,6 +90,19 @@ class TestFindGuardCommentId:
         ]
         assert gcu.find_guard_comment_id(comments, MARKER) is None
 
+    def test_lookalike_login_github_actions_xyz_is_not_the_bot(self):
+        """Review ai-01 #15374 : sur un depot public un tiers peut porter
+        ``github-actions-xyz`` -- le prefixe ne suffit pas, un SET EXACT
+        seul protege. Ce commentaire ne doit jamais etre PATCHe."""
+        comments = [
+            _comment(305, "github-actions-xyz", f"{MARKER} faux reponse"),
+            _comment(306, "github-actions[bot]", f"{MARKER} vrai verdict"),
+        ]
+        # le lookalike SEUL -> aucun cible (pas de PATCH sur un tiers)
+        assert gcu.find_guard_comment_id(comments[:1], MARKER) is None
+        # melange au bot veritable -> seul le bot est cible
+        assert gcu.find_guard_comment_id(comments, MARKER) == 306
+
     def test_legacy_login_github_actions_counts(self):
         comments = [_comment(401, "github-actions", MARKER)]
         assert gcu.find_guard_comment_id(comments, MARKER) == 401
@@ -243,3 +256,45 @@ class TestMain:
         with pytest.raises(SystemExit):
             gcu.main(["--pr", "50", "--marker", MARKER,
                       "--body-file", str(body_file), "--lift"])
+
+
+# ---------------------------------------------------------------------------
+# Câblage workflow -- l'échec de lift/upsert doit rester OBSERVABLE (#15374)
+# ---------------------------------------------------------------------------
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github" / "workflows" / "always-on-guards.yml"
+)
+
+
+class TestWorkflowWiring:
+    r"""Review ai-01 #15374 : le chemin vert ne doit plus avaler l'échec de
+    lift par ``>/dev/null 2>&1 || true`` -- sinon le commentaire bloquant
+    survit affiché faux sans aucun signal (le défaut racine de #15372).
+    Le gate reste vert, mais l'échec devient un ``::warning``."""
+
+    def test_lift_failure_emits_warning(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        assert "::warning::prev-guard lift failed" in text, (
+            "le chemin vert du prev-guard doit rendre l'échec de lift "
+            "observable (review ai-01 #15374)")
+
+    def test_upsert_failure_emits_warning(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        assert "::warning::prev-guard upsert failed" in text, (
+            "le chemin rouge ne doit pas présenter un échec d'upsert "
+            "comme une écriture réussie (review ai-01 #15374)")
+
+    def test_no_silently_swallowed_upsert_call(self):
+        """Le buggy pattern : un appel guard_comment_upsert.py suivi (à
+        ~6 lignes, le temps des arguments multilignes) d'un ``|| true``
+        seul -- sans if/warning, l'échec est invisible."""
+        lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            if "guard_comment_upsert.py" in line:
+                window = lines[i:i + 7]
+                swallowed = [l for l in window if l.strip() == ">/dev/null 2>&1 || true"]
+                assert not swallowed, (
+                    f"appel guard_comment_upsert.py l.{i + 1} avalé par "
+                    "|| true -- l'échec doit être observable")

--- a/scripts/tests/test_guard_comment_upsert.py
+++ b/scripts/tests/test_guard_comment_upsert.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+r"""Tests guard_comment_upsert -- PATCH en place, jamais de mur (#15372).
+
+Corpus reel rejoint : #15146 portait 10 commentaires, dont 4 HUMAINS
+(3 ``jsboige`` + 1 ``myia-ai-01``) citant le marqueur
+``<!-- vtr-prev-close-keyword -->`` verbatim dans des comptes rendus.
+Une recherche marqueur-seul editerait un commentaire humain -- le filtre
+d'auteur est l'acceptance 3 de l'issue.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import guard_comment_upsert as gcu  # noqa: E402
+
+MARKER = "<!-- vtr-prev-close-keyword -->"
+
+
+def _comment(cid, login, body, marker=MARKER):
+    return {"id": cid, "body": body, "user": {"login": login}}
+
+
+class FakeProc:
+    def __init__(self, returncode=0, stdout="[]", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class RecordingGh:
+    """Rejoue un monde de commentaires et enregistre les appels gh."""
+
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if "--paginate" in cmd:
+            import json
+            return FakeProc(stdout=json.dumps(self.pages))
+        # PATCH / POST renvoient le commentaire ecrit
+        return FakeProc(stdout='{"id": 999}')
+
+    @property
+    def endpoints(self):
+        return [c[3] for c in self.calls if len(c) > 3 and c[0] == "gh"]
+
+    def find(self, fragment):
+        for c in self.calls:
+            if fragment in " ".join(c):
+                return c
+        return None
+
+
+# ---------------------------------------------------------------------------
+# find_guard_comment_id -- le filtre d'auteur n'est pas decoratif
+# ---------------------------------------------------------------------------
+
+class TestFindGuardCommentId:
+    def test_corpus_15346_marker_alone_is_not_enough(self):
+        """Acceptance 3 : le corpus #15146 -- 4 humains portent le
+        marqueur, 1 bot aussi. Seul le commentaire bot est cible."""
+        comments = [
+            _comment(101, "jsboige", f"compte rendu citant {MARKER} verbatim"),
+            _comment(102, "jsboige", f"autre rapport {MARKER}"),
+            _comment(103, "myia-ai-01", f"revue citant {MARKER}"),
+            _comment(104, "jsboige", f"troisieme {MARKER}"),
+            _comment(105, "github-actions[bot]",
+                     f"{MARKER}\n**bloquant (#10093)**"),
+        ]
+        assert gcu.find_guard_comment_id(comments, MARKER) == 105
+
+    def test_humans_only_returns_none(self):
+        comments = [
+            _comment(201, "jsboige", MARKER),
+            _comment(202, "myia-po-2025", f"cite {MARKER}"),
+        ]
+        assert gcu.find_guard_comment_id(comments, MARKER) is None
+
+    def test_other_bots_are_untouchable(self):
+        """dependabot/konvergence portant le marqueur : jamais edite."""
+        comments = [
+            _comment(301, "dependabot[bot]", MARKER),
+            _comment(302, "konvergence-pcg[bot]", f"x {MARKER}"),
+        ]
+        assert gcu.find_guard_comment_id(comments, MARKER) is None
+
+    def test_legacy_login_github_actions_counts(self):
+        comments = [_comment(401, "github-actions", MARKER)]
+        assert gcu.find_guard_comment_id(comments, MARKER) == 401
+
+    def test_last_bot_comment_wins(self):
+        """Le mur existant : plusieurs commentaires bot -> l'id MAX (le
+        corps actuellement affiche en bas), pas le plus ancien."""
+        comments = [
+            _comment(501, "github-actions[bot]", MARKER),
+            _comment(502, "github-actions[bot]", MARKER),
+            _comment(503, "github-actions[bot]", MARKER),
+        ]
+        assert gcu.find_guard_comment_id(comments, MARKER) == 503
+
+    def test_marker_absent_returns_none(self):
+        comments = [_comment(601, "github-actions[bot]",
+                             "<!-- vtr-required-block --> autre garde")]
+        assert gcu.find_guard_comment_id(comments, MARKER) is None
+
+    def test_empty_and_none_inputs(self):
+        assert gcu.find_guard_comment_id([], MARKER) is None
+        assert gcu.find_guard_comment_id(None, MARKER) is None
+
+
+# ---------------------------------------------------------------------------
+# upsert -- PATCH au lieu de POST
+# ---------------------------------------------------------------------------
+
+class TestUpsertComment:
+    def test_existing_bot_comment_is_patched_not_duplicated(self):
+        """Acceptance 1 : le commentaire porte le marqueur ET l'auteur
+        bot -> PATCH issues/comments/{id}, AUCUN nouveau POST."""
+        gh = RecordingGh([
+            [_comment(701, "jsboige", MARKER),
+             _comment(702, "github-actions[bot]", f"{MARKER} bloquant")],
+        ])
+        result = gcu.upsert_comment(42, MARKER, "corps bloquant",
+                                    "o/r", runner=gh)
+        assert result == {"action": "patched", "comment_id": 702}
+        patch = gh.find("--method")
+        assert patch is not None, "un PATCH devait etre emis"
+        assert "PATCH" in patch
+        assert "repos/o/r/issues/comments/702" in patch
+        assert "corps bloquant" in patch[-1]
+        post = gh.find("--method")
+        assert not any("POST" in c for c in gh.calls), (
+            "un commentaire bot existant ne doit JAMAIS etre duplique"
+        )
+
+    def test_absent_comment_creates_first_one(self):
+        gh = RecordingGh([[]])
+        result = gcu.upsert_comment(43, MARKER, "premier blocage",
+                                    "o/r", runner=gh)
+        assert result["action"] == "created"
+        post = gh.find("POST")
+        assert post is not None
+        assert "repos/o/r/issues/43/comments" in " ".join(post)
+
+    def test_list_uses_rest_api_not_graphql_id(self):
+        """L'id de gh pr view --json comments est un node id GraphQL
+        (IC_...), inutilisable en PATCH REST -- le listing doit passer
+        par l'API REST (mesure #15373 : IC_kwDO... vs 5600457600)."""
+        gh = RecordingGh([[]])
+        gcu.upsert_comment(44, MARKER, "x", "o/r", runner=gh)
+        listing = gh.find("--paginate")
+        assert "repos/o/r/issues/44/comments" in listing
+        assert "--slurp" in listing
+
+    def test_multi_page_listing_is_flattened(self):
+        gh = RecordingGh([
+            [_comment(801, "github-actions[bot]", MARKER)],
+            [_comment(802, "jsboige", "apres page 1")],
+        ])
+        result = gcu.upsert_comment(45, MARKER, "y", "o/r", runner=gh)
+        assert result["comment_id"] == 801
+
+
+# ---------------------------------------------------------------------------
+# lift -- un mur qui ne se ferme jamais n'est pas un signal
+# ---------------------------------------------------------------------------
+
+class TestLiftComment:
+    def test_green_run_rewrites_block_as_lifted_in_place(self):
+        """Acceptance 2 : run vert + commentaire bloquant existant ->
+        reecrit LEVE, horodate, nommant les prev acceptes. Le marqueur
+        RESTE porte (le prochain upsert doit retrouver ce commentaire)."""
+        gh = RecordingGh([
+            [_comment(901, "github-actions[bot]",
+                      f"{MARKER}\n**bloquant (#10093)** ancien verdict")],
+        ])
+        result = gcu.lift_comment(
+            46, MARKER, "prev acceptés : #15306", "o/r", runner=gh)
+        assert result == {"action": "patched", "comment_id": 901}
+        patch_call = gh.find("PATCH")
+        body = patch_call[-1]
+        assert "LEVÉ" in body
+        assert "2026-" in body or "20" in body  # horodatage UTC présent
+        assert "prev acceptés : #15306" in body
+        assert MARKER in body, (
+            "le marqueur doit rester porte par le corps leve, sinon le "
+            "prochain upsert perd la chaine"
+        )
+        assert not any("POST" in c or "DELETE" in c for c in gh.calls), (
+            "lever = reecrire, jamais supprimer (acceptance 4)"
+        )
+
+    def test_green_run_on_never_blocked_pr_is_silent(self):
+        """Un vert sur une PR jamais bloquee ne fabrique pas de bruit :
+        aucun PATCH, aucun POST."""
+        gh = RecordingGh([[]])
+        result = gcu.lift_comment(47, MARKER, "note", "o/r", runner=gh)
+        assert result == {"action": "noop", "comment_id": None}
+        assert not any("PATCH" in c or "POST" in c for c in gh.calls)
+
+    def test_lifted_body_is_still_findable_for_next_upsert(self):
+        """Boucle upsert : le corps releve porte le marqueur -> un run
+        rouge suivant re-PATCHera le meme id (pas de nouveau POST)."""
+        body = gcu.build_lifted_body(MARKER, "titre", "note", ts="2026-09-09T11:00:00Z")
+        comments = [_comment(911, "github-actions[bot]", body)]
+        assert gcu.find_guard_comment_id(comments, MARKER) == 911
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def test_body_file_mode_invokes_upsert(self, tmp_path, monkeypatch):
+        body_file = tmp_path / "blocked.md"
+        body_file.write_text(f"{MARKER}\ncorps", encoding="utf-8")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "jsboige/CoursIA")
+        gh = RecordingGh([[_comment(1001, "github-actions[bot]", MARKER)]])
+        rc = gcu.main(["--pr", "48", "--marker", MARKER,
+                       "--body-file", str(body_file)], runner=gh)
+        assert rc == 0
+        assert gh.find("PATCH") is not None
+
+    def test_lift_mode_invokes_lift(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_REPOSITORY", "jsboige/CoursIA")
+        gh = RecordingGh([[]])
+        rc = gcu.main(["--pr", "49", "--marker", MARKER, "--lift",
+                       "--note", "prev: #15306"], runner=gh)
+        assert rc == 0
+        assert not any("PATCH" in c or "POST" in c for c in gh.calls)
+
+    def test_modes_are_mutually_exclusive(self, tmp_path, monkeypatch):
+        body_file = tmp_path / "b.md"
+        body_file.write_text("x", encoding="utf-8")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+        import pytest
+        with pytest.raises(SystemExit):
+            gcu.main(["--pr", "50", "--marker", MARKER,
+                      "--body-file", str(body_file), "--lift"])

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -34,6 +34,19 @@ def test_clean_body_passes():
     assert v["hits"] == {"body": [], "commits": [], "prev_invalid": []}
 
 
+def test_green_verdict_names_accepted_prev_targets():
+    """#15372 : le verdict vert cite les cibles prev: acceptees -- la
+    levee de commentaire du garde les nomme pour que le remplacement du
+    mur affiche ce qui fait tenir le vert."""
+    v = vpg.check(CLEAN_BODY)
+    assert v["guard_pass"] is True
+    assert v["prev_targets_accepted"] == [10067]
+    # Un body sans prev: reste vert avec une liste vide, pas une absence.
+    v2 = vpg.check("Grain: LIGHT/docs -- lane myia-po-2023:CoursIA")
+    assert v2["guard_pass"] is True
+    assert v2["prev_targets_accepted"] == []
+
+
 def test_offending_body_blocks():
     # A `prev: MED/fix #10067` in the BODY -> block.
     v = vpg.check(


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python #15325

## Ce qui change

Le step `prev_guard` d'`always-on-guards.yml` postait un commentaire bloquant par run rouge via `gh pr comment` (create-only) et ne retirait jamais rien : **19 commentaires « bloquant » mesurés sur 4 PRs le 09/09, tous faux à l'instant de la mesure** (#15372). Le marqueur `<!-- vtr-prev-close-keyword -->` était décoratif — rien ne le relisait.

**Nouveau module `scripts/ci/guard_comment_upsert.py`** (pattern `runner` injectable de `resolve_prev_targets`, testable sans réseau) :

- **Upsert** : recherche du commentaire par marqueur **ET** auteur bot (`github-actions` / `github-actions[bot]`), puis `PATCH repos/{repo}/issues/comments/{id}` — plus jamais de POST cumulatif.
- **Levée sur run vert** : le commentaire bloquant existant est réécrit « LEVÉ », horodaté UTC, nommant les `prev:` acceptés. No-op silencieux sur une PR jamais bloquée (un vert ne fabrique pas de bruit). Le marqueur **reste porté** par le corps levé — le prochain upsert retrouve le même commentaire (la boucle rouge→vert→rouge réécrit en place).
- **Jamais de suppression** (acceptance 4) : lever = réécrire, pas effacer.

**Câblage YAML** (`prev_guard` uniquement — un sujet par PR) :
- branche rouge : le corps bloquant (inchangé, backticks échappés préservés) part en `--body-file` vers l'upsert ;
- branche verte : `--lift` avec les `prev:` acceptés lus du verdict.

**Verdict enrichi** : `variation_prev_guard.py` rend désormais `prev_targets_accepted` sur run vert — la levée cite ce qui fait tenir le vert (3 lignes, clé additive).

## Piège couvert (acceptance 3)

Sur #15146, **4 commentaires HUMAINS** (3 `jsboige`, 1 `myia-ai-01`) portent le marqueur verbatim dans des comptes rendus. Une recherche marqueur-seul éditerait un commentaire humain. `test_corpus_15346_marker_alone_is_not_enough` rejoue ce corpus réel : une implémentation marqueur-seul rendrait l'id humain (101) et échouerait le test. `test_other_bots_are_untouchable` étend aux autres bots (dependabot etc.).

Détail mesuré incorporé : l'`id` de `gh pr view --json comments` est un node id GraphQL (`IC_kwDO...`, inutilisable en PATCH REST) — le listing passe par l'API REST (`repos/.../issues/{n}/comments --paginate --slurp`, mesuré sur #15373 : GraphQL `IC_...` vs REST `5600457600`). `test_list_uses_rest_api_not_graphql_id` épingle ce choix.

## Acceptance #15372

- [x] **Recherche marqueur + auteur github-actions, PATCH au lieu de créer** — `upsert_comment` ; test `test_existing_bot_comment_is_patched_not_duplicated` (assert : aucun POST quand un commentaire bot existe).
- [x] **Run vert → réécrit en état levé, horodaté, nommant le prev accepté** — `lift_comment` + `prev_targets_accepted` ; `test_green_run_rewrites_block_as_lifted_in_place` (LEVÉ + ts + note + marqueur conservé + zéro POST/DELETE).
- [x] **Test qui fait échouer une recherche marqueur-seul** — corpus réel #15146 rejoué (voir ci-dessus).
- [x] **Les 19 commentaires existants ne sont pas supprimés** — aucun code de suppression ; la levée ne touche que le commentaire bot au prochain run vert de chaque PR.

## Validation

- `scripts/tests/test_guard_comment_upsert.py` : **17 passed** — filtre auteur, dernier-bot-gagne, upsert PATCH/no-POST, création premier, listing REST multi-pages aplati, levée complète, noop sur jamais-bloquée, boucle levé→retrouvé, CLI (modes mutuellement exclusifs, GITHUB_REPOSITORY).
- `test_variation_prev_guard.py` : **50 passed** (49 + `test_green_verdict_names_accepted_prev_targets`).
- Tests épinglant le workflow (5 fichiers : perimeter, ratchet wiring, bash_e_rc, paths filters, dead scope) : **234 passed** contre le YAML modifié.
- Suite `scripts/tests` complète : **4940 passed, 13 skipped, 5 xfailed, 4 failed** — les 4 échecs sont `test_prune_merged_worktrees.py::TestEndToEnd` (subprocess sur le script de main, **fichiers non touchés par cette branche**) : stdout vide car le quota GraphQL flotte (user 3159389) est épuisé ce soir — le script de main fait une ancre search par worktree et sort exit 2 fail-closed. Reproduits en isolation sur ce checkout main propre, déjà signalés ce matin ; le volume de ces appels est précisément ce que #15373/#15369 réduit.
- YAML : parse OK ; step extrait → `bash -n` OK (heredoc + échappements intacts) ; `gh pr comment` absent du step.
- **Smoke réel** : `guard_comment_upsert.py --pr 15372 --marker '<!-- smoke-noop-15372 -->' --lift --note smoke` contre l'API réelle → `{"action": "noop", "comment_id": null}` (résolution repo + listing + noop, zéro écriture).

## Hors scope (suivis naturels, pas dans cette PR)

Les gardes frères (`vtr-required-block`, close-keyword-pr-ref) portent le même défaut create-only — le module est générique (`--marker` paramétrique), leur bascule est un grain par garde.

Closes #15372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

