### PR TITLE
docs(lean,#15368): Conway docstrings name the two proven labelings, not a mirror family

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
@@ -628,9 +628,10 @@ theorem alexander_figureEight_eval_neg_one :
   norm_num
 
 /-- La variante signée restitue le classique sur le nœud en huit :
-l'étiquetage alterné `[−, +, −, +]` du diagramme DT-dérivé (deux signes de
-chaque, toute paire miroir convient — `4_1` est amphichiral) rend
-exactement `t² − 3t + 1` sous le même mineur désigné. -/
+l'étiquetage alterné `[−, +, −, +]` du diagramme DT-dérivé rend
+exactement `t² − 3t + 1` sous le même mineur désigné, et son miroir
+`[+, −, +, −]` rend `t · (t² − 3t + 1)` — même classe d'unités, comme
+l'exige l'amphichiralité de `4_1`. -/
 theorem alexander_figureEight_signed :
     alexanderPolynomialSigned figureEightDiagram [false, true, false, true]
       = Polynomial.X ^ 2 - 3 * Polynomial.X + 1 := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -559,8 +559,9 @@ determinant survives: `|P(−1)| = 5 = det(4_1)`
 
 The signed variant `alexanderPolynomialSigned` takes chirality as data and
 recovers the classical value on the figure-eight: the alternating labeling
-of the DT-derived diagram returns exactly `t² − 3t + 1`, its mirror
-`t · (t² − 3t + 1)` — same unit class, as amphichirality demands. -/
+`[−, +, −, +]` of the DT-derived diagram returns exactly `t² − 3t + 1`,
+its mirror `[+, −, +, −]` returns `t · (t² − 3t + 1)` — same unit class,
+as amphichirality demands. -/
 
 /-- Alexander row of a **negative** crossing: Fox derivative of the mirror
 Wirtinger relation `x_o⁻¹ x_i x_o = x_out`, multiplied by the unit `t` to
@@ -632,9 +633,10 @@ theorem alexander_figureEight_eval_neg_one :
   norm_num
 
 /-- The signed variant recovers the classical value on the figure-eight:
-the alternating labeling `[−, +, −, +]` of the DT-derived diagram (two
-signs of each; any mirror pair works — `4_1` is amphichiral) returns
-exactly `t² − 3t + 1` under the same designated minor. -/
+the alternating labeling `[−, +, −, +]` of the DT-derived diagram returns
+exactly `t² − 3t + 1` under the same designated minor, and its mirror
+`[+, −, +, −]` returns `t · (t² − 3t + 1)` — same unit class, as
+amphichirality of `4_1` demands. -/
 theorem alexander_figureEight_signed :
     alexanderPolynomialSigned figureEightDiagram [false, true, false, true]
       = Polynomial.X ^ 2 - 3 * Polynomial.X + 1 := by


### PR DESCRIPTION
Grain: LIGHT/lean — lane myia-po-2026:CoursIA — prev: DEEP/lean #15120

## Summary

Résidu réserve 3 de la review NanoClaw sur #15120 : la docstring **FR** de `alexander_figureEight_signed` portait le quantificateur universel « toute paire miroir convient » que Lean n'établit pas (deux instances prouvées, pas une famille). Réécrite sur le modèle de l'EN qui nomme les deux étiquetages et le polynôme miroir explicite.

**Le sweep demandé (geste 2) a trouvé une instance de plus que l'issue n'en nommait** : le **theorem-docstring EN** (`Conway_en.lean:635-638`) portait le même surclaim (« any mirror pair works ») — l'issue citait le module-docstring EN (560-563, correct) mais le docstring au niveau du théorème avait le même réflexe. Corrigé identiquement.

| Endroit | Avant | Après |
|---|---|---|
| `Conway.lean:630` (theorem FR) | « toute paire miroir convient — 4_1 est amphichiral » | nomme `[−,+,−,+]` → `t²−3t+1` ET son miroir `[+,−,+,−]` → `t·(t²−3t+1)`, même classe d'unités |
| `Conway_en.lean:635` (theorem EN) | « any mirror pair works » (surclaim trouvé au sweep) | même formulation que le FR, avec les deux étiquetages explicites |
| `Conway_en.lean:560` (module EN, référence de l'issue) | correct mais abstrait (« the alternating labeling ») | gagne les étiquetages explicites — égalité de force de claim avec le FR (geste 3 : la paire se modifie ensemble) |

## Sweep quantificateurs (geste 2) — verdicts

- `mutateWindow_zero_window` « pour toute liste » / « for any list » (FR:153/EN:161) : **prouvé** — les binders `(cs : List PDCrossing) (ρ : KleinRot)` sont la quantification.
- l.434 « toute valeur non triviale d'un nœud à croisements le distingue du nœud trivial » : contrôles NÉGATIF/POSITIF — dérivable des deux valeurs prouvées (`alexander_unknot` Δ=1), pas un théorème absent.
- l.547 FR / l.551 EN « deux croisements de chaque signe dans tout diagramme alterné minimal » : contexte mathématique externe du diagnostic, **identique dans les deux langues** (pas de drift de paire), pointeurs « ci-dessous » vers ce qui est prouvé. Non touché.
- l.745 Freedman « tout nœud de Δ trivial est slice » : section « énoncé uniquement », `sorry` documenté permanent (Lean AI Leaderboard), référence publiée. Honnête, non touché.
- « chaque ligne somme à zéro » (alexanderEntry/Neg) : description de la construction (visible dans la formule), non touché.

## Validation

- **Diff = commentaires uniquement** (docstrings), 2 fichiers, +11/−8 : aucune ligne de preuve, de signature ou de tactique touchée — le build ne peut pas changer sémantiquement.
- `grep -c sorry` avant/après : **Conway.lean 12→12, Conway_en.lean 13→13** (0 ligne sorry dans le diff — les occurrences restantes sont les mentions de prose du stretch Freedman documenté).
- `check_i18n_siblings.py knot_lean` : **7/7 paires byte-identical, 0 drift, 0 orphan**.
- `lake build` + `Proof integrity (knot_lean)` : exécutés par la CI sur cette PR (paths `knot_lean/**.lean`) — liens cités en follow-up au terme des jobs (précédents #15357/#15379). Build local écarté : cache Mathlib local vide (toolchain v4.31.0-rc1) + WAN congestionné (`lake exe cache get` ~5 Go) — la CI est le chemin canonique de ce lake.

Closes #15368 (gestes 1-4 tous couverts).