### PR TITLE
ci(sweep,#15375): two-tier mature-first purge — caps derived from the 16-slot waiter pool

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -181,11 +181,33 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Cap the number of re-aggregations per sweep. A wide outage can
-          # leave dozens of PRs in this state at once; doing all of them in one
-          # job would run past the timeout. The next sweep (20 min later) takes
-          # the next batch.
-          MAX_POSTS=8
+          # Per-tier caps (#15375). A flat cap of 8 faced a measured queue
+          # of 38 candidates (2026-09-09T10:43Z, run 34341779278; 25 -> 38 in
+          # two hours while throughput stayed 8) -- a flat cap against a
+          # growing queue follows further and further behind. The remedy is
+          # NOT one big cap of 38: a re-run is fire-and-forget for this sweep,
+          # but it occupies a coursia-waiter slot for the gate's full ~9-12 min
+          # poll, and #13363 measures gate runs already holding a third of the
+          # runners. So the cap splits by what a re-run is WORTH:
+          #
+          #   MAX_MATURE=12 -- candidates whose stale verdict is older than
+          #     the 120-min dwell floor. Their re-run is immediately
+          #     conclusive (floor elapsed + all other checks green, which the
+          #     filter above already enforces, => SUCCESS => merge unblocked):
+          #     every slot spent here converts to a merge. 12 = 75% of the
+          #     16-slot coursia-waiter pool (measured 2026-09-09T12:5xZ),
+          #     leaving 4 slots for live PR traffic; the burst self-drains in
+          #     one gate pass (~12 min), so it is capacity-bounded, not
+          #     compounding.
+          #   MAX_IMMATURE=4 -- verdict younger than the floor: the re-run can
+          #     only re-render the same dwell FAIL, converting to nothing.
+          #     Kept above zero solely as the fallback for tier
+          #     misclassification (young verdict on an old head -- reopened
+          #     PR whose gate timed out again) and unreadable timestamps; down
+          #     from the flat 8 because buying 0 merges per purge is exactly
+          #     what #15375 exists to stop.
+          MAX_MATURE=12
+          MAX_IMMATURE=4
 
           # Collected over REST, one small call per PR, NOT one bulk GraphQL
           # query. `gh pr list --limit 60 --json statusCheckRollup` returns
@@ -227,6 +249,7 @@ jobs:
 
           python - <<'PY' > /tmp/candidates.txt
           import json, os, re, sys
+          from datetime import datetime, timezone
 
           # REST /check-runs is lowercase where GraphQL's rollup is uppercase.
           # A check counts as settled-green when it has completed with a
@@ -243,6 +266,23 @@ jobs:
           # below keeps the later verdict) or a real interruption that must not
           # be greenwashed. Asymmetric on purpose (#11862).
           RED = {"failure", "timed_out", "action_required", "cancelled"}
+
+          # Maturity floor for the two-tier service order (#15375). Mirrors
+          # DEFAULT_DWELL_MIN = 120.0 in scripts/ci/merge_dwell.py -- the
+          # dwell the re-run gate will itself measure against the HEAD COMMIT
+          # date. The tier proxy below uses the gate verdict's age instead of
+          # the head commit date (which this sweep does not collect); its
+          # soundness is one-directional on purpose: every leg examined here
+          # lives on the PR's CURRENT head SHA (the listing carries it), the
+          # gate leg on that SHA started strictly after the SHA's commit, and
+          # pr-gate.yml fires on every pull_request event -- so a push after
+          # the verdict would have produced a newer leg on a newer SHA.
+          # Verdict age >= floor therefore IMPLIES head commit age >= floor,
+          # i.e. the dwell has elapsed and the re-run is immediately
+          # conclusive. The converse is not claimed: a young verdict on an old
+          # head lands in tier 1 and waits an hour -- conservative, never
+          # wrong.
+          DWELL_FLOOR_S = 120.0 * 60
 
           # Test seam: the shipped selector is exec'd verbatim by
           # scripts/tests/test_pr_gate_sweep_select.py, which points this at a
@@ -380,7 +420,27 @@ jobs:
                       for k, c in red_others])
                   continue
 
-              print(f'{p["number"]} {p["sha"]} {str(p.get("fork", False)).lower()}')
+              # Tier: 0 = mature (verdict older than the dwell floor -> the
+              # re-run converts to a merge), 1 = immature (the re-run can only
+              # re-render the same dwell FAIL). The newest RED gate leg
+              # governs: any later leg on this SHA would be the one whose age
+              # bounds the last event. An unreadable/missing timestamp is
+              # tier 1, never tier 0 -- the immature lane still serves it
+              # (fallback cap), so it is never starved, only deprioritized.
+              red_gates = [c for c in gate_legs
+                           if (c.get("conclusion") or "") in RED]
+              newest_red = max((c.get("started_at") or "") for c in red_gates)
+              try:
+                  ts = (newest_red[:-1] + "+00:00"
+                        if newest_red.endswith("Z") else newest_red)
+                  verdict_age_s = (
+                      datetime.now(timezone.utc)
+                      - datetime.fromisoformat(ts)).total_seconds()
+                  rank = 0 if verdict_age_s >= DWELL_FLOOR_S else 1
+              except ValueError:
+                  rank = 1
+              print(f'{p["number"]} {p["sha"]} '
+                    f'{str(p.get("fork", False)).lower()} {rank}')
           PY
 
           # OLDEST FIRST, and the cap is the whole reason it matters.
@@ -405,22 +465,32 @@ jobs:
           # stay under the cap; above it the tail is never reached.
           #
           # PR numbers are monotonic in creation time, so a numeric sort IS
-          # the age order -- no extra API call.
-          sort -n -o /tmp/candidates.txt /tmp/candidates.txt
+          # the age order -- no extra API call. #15375 makes the order
+          # TWO-TIER: tier (4th field, 0 = mature) is the primary key, PR
+          # number the secondary -- mature candidates first (their re-run
+          # converts to a merge), oldest verdicts first within each tier.
+          sort -s -k4,4n -k1,1n -o /tmp/candidates.txt /tmp/candidates.txt
 
           COUNT=$(wc -l < /tmp/candidates.txt | tr -d ' ')
-          echo "[stale-sweep] PRs whose only red is a stale \`PR gate\`: $COUNT (oldest first)"
+          MATURE_N=$(awk '$4 == "0"' /tmp/candidates.txt | wc -l | tr -d ' ')
+          IMMATURE_N=$(awk '$4 == "1"' /tmp/candidates.txt | wc -l | tr -d ' ')
+          echo "[stale-sweep] PRs whose only red is a stale \`PR gate\`: $COUNT (mature $MATURE_N, served first / immature $IMMATURE_N)"
           if [ "$COUNT" = "0" ]; then
             echo "[stale-sweep] nothing to do"
             exit 0
           fi
 
-          n=0
-          while read -r NUM SHA FORK; do
+          m=0
+          i=0
+          while read -r NUM SHA FORK RANK; do
             [ -z "${NUM:-}" ] && continue
-            if [ "$n" -ge "$MAX_POSTS" ]; then
-              echo "[stale-sweep] cap $MAX_POSTS reached -- $((COUNT - n)) newer candidate(s) wait for the next sweep"
-              break
+            # Capped rows of one tier must not stop the loop: the sort puts
+            # mature first, so `continue` walks on into the immature block.
+            if [ "${RANK:-1}" = "0" ] && [ "$m" -ge "$MAX_MATURE" ]; then
+              continue
+            fi
+            if [ "${RANK:-1}" != "0" ] && [ "$i" -ge "$MAX_IMMATURE" ]; then
+              continue
             fi
             # Re-run the ORIGINAL run rather than POSTing a fresh verdict.
             #
@@ -449,7 +519,7 @@ jobs:
               # workflow run behind it, so there is nothing to re-run. Say so
               # rather than fail silently: this class needs its own handling.
               echo "[stale-sweep] #$NUM ($SHA): red \`PR gate\` with NO workflow run -- cannot re-run, skipping"
-              n=$((n + 1))
+              if [ "${RANK:-1}" = "0" ]; then m=$((m + 1)); else i=$((i + 1)); fi
               continue
             fi
 
@@ -462,8 +532,9 @@ jobs:
               gh run rerun "$RUN_ID" --repo "$REPO" \
                 || echo "[stale-sweep] re-run refused for #$NUM (non-fatal)"
             fi
-            n=$((n + 1))
+            if [ "${RANK:-1}" = "0" ]; then m=$((m + 1)); else i=$((i + 1)); fi
           done < /tmp/candidates.txt
+          echo "[stale-sweep] served: mature $m/$MATURE_N (cap $MAX_MATURE), immature $i/$IMMATURE_N (cap $MAX_IMMATURE) -- waiting for the next sweep: $((MATURE_N - m)) mature, $((IMMATURE_N - i)) immature"
 
           # Advisory organ: it acts, it never blocks.
           exit 0

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -34,6 +34,7 @@ import json
 import os
 import re
 import subprocess
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import yaml
@@ -130,7 +131,7 @@ def test_gate_cancelled_alone_is_candidate(tmp_path):
     alors bloquee sans rien de rouge -- le defaut #11862 mot pour mot.
     """
     out = _run_selector(tmp_path, [_pr(101, [GATE_CANCELLED, OTHER_GREEN])])
-    assert out.strip() == "101 deadbeef false"
+    assert out.strip() == "101 deadbeef false 0"
 
 
 def test_gate_cancelled_with_other_red_abstains(tmp_path):
@@ -145,14 +146,14 @@ def test_other_cancelled_superseded_by_green_still_candidate(tmp_path):
     cancelled_old = ("Hermes review", "completed", "cancelled", "2026-01-01T09:00:00Z")
     green_new = ("Hermes review", "completed", "success", "2026-01-01T11:00:00Z")
     out = _run_selector(tmp_path, [_pr(103, [GATE_FAIL, cancelled_old, green_new])])
-    assert out.strip() == "103 deadbeef false"
+    assert out.strip() == "103 deadbeef false 0"
 
 
 def test_gate_failure_others_green_candidate(tmp_path):
     """Regression : le comportement d'origine (failure/timeout/action_required)
     reste candidat."""
     out = _run_selector(tmp_path, [_pr(104, [GATE_FAIL, OTHER_GREEN])])
-    assert out.strip() == "104 deadbeef false"
+    assert out.strip() == "104 deadbeef false 0"
 
 
 def test_no_gate_leg_skipped(tmp_path):
@@ -172,7 +173,7 @@ def test_two_gate_legs_and_not_latest_wins(tmp_path):
     latest-wins)."""
     gate_success_new = ("PR gate", "completed", "success", "2026-01-01T12:00:00Z")
     out = _run_selector(tmp_path, [_pr(107, [GATE_FAIL, gate_success_new, OTHER_GREEN])])
-    assert out.strip() == "107 deadbeef false"
+    assert out.strip() == "107 deadbeef false 0"
 
 
 def test_other_latest_cancelled_is_candidate(tmp_path):
@@ -198,7 +199,7 @@ def test_other_latest_cancelled_is_candidate(tmp_path):
     """
     cancelled_new = ("Hermes review", "completed", "cancelled", "2026-01-01T11:00:00Z")
     out = _run_selector(tmp_path, [_pr(108, [GATE_FAIL, cancelled_new])])
-    assert out.strip() == "108 deadbeef false"
+    assert out.strip() == "108 deadbeef false 0"
 
 
 def test_other_cancelled_plus_failure_still_abstains(tmp_path):
@@ -278,7 +279,7 @@ def test_same_run_rerun_latest_wins(tmp_path):
         ("Hermes review", "completed", "success", "2026-01-01T16:21:00Z", 111),
     ]
     out = _run_selector(tmp_path, [_pr(110, [GATE_FAIL] + fail_then_green)])
-    assert out.strip() == "110 deadbeef false"
+    assert out.strip() == "110 deadbeef false 0"
 
 
 def test_cross_workflow_green_and_red_keeps_pr_out(tmp_path):
@@ -339,7 +340,7 @@ def test_same_workflow_twin_runs_green_supersedes_red(tmp_path):
         113, [GATE_FAIL, guard_old, guard_new],
         workflows={33432764140: 555, 33435266510: 555},
     )])
-    assert out.strip() == "113 deadbeef false"
+    assert out.strip() == "113 deadbeef false 0"
 
 
 def test_distinct_workflows_same_name_still_separate(tmp_path):
@@ -359,3 +360,78 @@ def test_distinct_workflows_same_name_still_separate(tmp_path):
         workflows={900: 555, 901: 777},
     )])
     assert out.strip() == ""
+
+
+# --- #15375 : le tier de maturite (4e champ), mature-first a la purge --------
+
+
+def _ts(minutes_ago):
+    """Horodatage ISO Z dynamique -- le tier se mesure contre le `now` du
+    selecteur, donc les fixtures de ce bloc doivent etre RELATIVES (les dates
+    fixes 2026-01-01 du bloc historique sont toutes matures par construction,
+    ce qui est aussi pourquoi leurs assertions portent un rang 0)."""
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_verdict_older_than_floor_is_mature(tmp_path):
+    """Le coeur de #15375 forme 3 : un verdict de 180 min sur un plancher de
+    120 min est MATURE -- sa relance est immediatement conclusive (le gate
+    re-mesurera un head commit forcement plus vieux encore, voir la preuve
+    d'etancheite dans le selecteur). Rang 0, servi en priorite."""
+    gate_old = ("PR gate", "completed", "failure", _ts(180))
+    out = _run_selector(tmp_path, [_pr(120, [gate_old, OTHER_GREEN])])
+    assert out.strip() == "120 deadbeef false 0"
+
+
+def test_young_verdict_is_immature(tmp_path):
+    """Falsification : un verdict de 5 min n'a PAS franchise le plancher -- la
+    relance ne pourrait que re-rendre le meme FAIL de dwell. Rang 1, servi en
+    second, sous un cap retreint."""
+    gate_young = ("PR gate", "completed", "failure", _ts(5))
+    out = _run_selector(tmp_path, [_pr(121, [gate_young, OTHER_GREEN])])
+    assert out.strip() == "121 deadbeef false 1"
+
+
+def test_newest_red_leg_decides_the_tier(tmp_path):
+    """Deux legs de gate rouges : c'est la PLUS RECENTE qui gouverne le tier.
+    Une leg ancienne (3 h) ne peut pas faire passer la PR pour mature si une
+    leg rouge plus jeune (10 min) existe -- le bornage du dernier evenement
+    est la leg la plus recente, pas la plus ancienne."""
+    red_old = ("PR gate", "completed", "failure", _ts(200))
+    red_new = ("PR gate", "completed", "failure", _ts(10))
+    out = _run_selector(tmp_path, [_pr(122, [red_old, red_new, OTHER_GREEN])])
+    assert out.strip() == "122 deadbeef false 1"
+
+
+def test_unreadable_verdict_timestamp_is_immature_never_mature(tmp_path):
+    """Un `started_at` vide ou non ISO ne peut pas être lu comme age : tier 1
+    (conservateur). Jamais 0 -- mais la file immature le sert quand meme (cap
+    de repli), donc pas de famine, seulement une depriorisation."""
+    gate_nots = ("PR gate", "completed", "failure", "")
+    out = _run_selector(tmp_path, [_pr(123, [gate_nots, OTHER_GREEN])])
+    assert out.strip() == "123 deadbeef false 1"
+    gate_garbage = ("PR gate", "completed", "failure", "hier-matin")
+    out = _run_selector(tmp_path, [_pr(124, [gate_garbage, OTHER_GREEN])])
+    assert out.strip() == "124 deadbeef false 1"
+
+
+def test_workflow_pins_tier_sort_and_per_tier_caps():
+    """Garde structurelle : le workflow trie par le 4e champ (tier) avant le
+    numero de PR, et porte les deux caps par tier. Sans ce pin, un revert du
+    sort binaire ou des caps ramenerait le cap plat de 8 sans qu'aucun test
+    d'acceptance du selecteur ne rougisse (le selecteur emet le rang, mais
+    rien ne l'oblige a le CONSOMMER)."""
+    with open(WORKFLOW, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    run = str(next(
+        step.get("run", "") for step in doc["jobs"]["sweep"]["steps"]
+        if "MAX_MATURE" in str(step.get("run", ""))
+    ))
+    assert "MAX_MATURE=12" in run
+    assert "MAX_IMMATURE=4" in run
+    assert "MAX_POSTS=8" not in run
+    assert "sort -s -k4,4n -k1,1n" in run
+    # Le cap d'un tier ne doit pas arreter la boucle : les immatures ranges
+    # derriere doivent rester servis (continue, pas break).
+    assert "break" not in re.sub(r"#.*", "", run.split("MAX_MATURE=12")[1].split("done <")[0])


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: docs #15380

## Quoi

Le stale-sweep servait 8 candidats quelconques (oldest-first) face à une file mesurée à 38 (#15375). Le service devient **two-tier** :

- **Tier 0 (mature, servi en premier)** : verdict `PR gate` rouge plus vieux que le plancher de dwell (120 min, `merge_dwell.py` `DEFAULT_DWELL_MIN`). La relance est immédiatement conclusive (plancher écoulé + autres checks verts, ce que le filtre enforce déjà) → chaque slot se convertit en merge. Cap `MAX_MATURE=12` = 75 % du pool `coursia-waiter` (**16 slots mesurés** 2026-09-09T12:5xZ via `actions/runners`), burst auto-drainant en un passage gate (~12 min) — capacité-borné, pas cumulatif.
- **Tier 1 (immature)** : verdict plus jeune que le plancher — la relance ne peut que re-rendre le même FAIL de dwell (0 merge par purge). Cap `MAX_IMMATURE=4` (l'ancien cap plat 8 dépensait l'essentiel de son budget en verdicts non conclusifs) ; gardé > 0 comme fallback de mauvaise classification du proxy (verdict jeune sur head vieux, p. ex. PR reopen dont le gate a re-timeouté) et d'horodatage illisible — pas de famine, seulement une dépriorisation.

Tri : `sort -s -k4,4n -k1,1n` (tier, puis numéro de PR) ; le cap d'un tier `continue` au lieu de `break`, donc les immatures rangés derrière restent servis.

## Étanchéité du proxy de maturité (unidirectionnel, délibérément)

Le tier se mesure sur l'âge du verdict, pas sur la date de commit de head (non collectée par le sweep). Toutes les legs examinées vivent sur le SHA de head courant (le listing le porte) ; la leg gate de ce SHA démarre strictement après son commit ; `pr-gate.yml` tire sur tout événement `pull_request` — un push postérieur aurait produit une leg plus récente sur un SHA plus récent. Donc **âge du verdict ≥ 120 min ⟹ âge du commit ≥ 120 min ⟹ plancher écoulé ⟹ relance conclusive**. La réciproque n'est pas claimée : un verdict jeune sur head vieux part en tier 1 et attend le prochain passage (conservateur, jamais faux).

## Pourquoi pas la forme 2 (second passage dans le même run)

Dormir ~10 min sur un runner coursia-linux pour re-tirer après stabilisation est strictement dominé par le cron horaire + caps élastiques : le burst mature est déjà servi au premier passage, et la file immature croît par conversion naturelle (chaque candidat devient mature 2 h après son dernier événement).

## Contre les contraintes que l'issue pose

- **#12728** (balayages qui s'entretuaient) : cadence (`cron '7 * * * *'`), pool `coursia-linux` et `timeout-minutes: 15` du sweep inchangés.
- **#13363** (un tiers des runners tenus par le gate) : burst borné à 16 gate runs max (12+4) = exactement la taille du pool waiter, self-drainant en ~12 min ; l'ancien cap plat dépensait jusqu'à 8 slots/h en relances non conclusives.
- **#13379** (oldest-first) : préservé — clé secondaire du tri, inchangé dans chaque tier.

## Validation

- `python -m pytest scripts/tests/test_pr_gate_sweep_select.py -q` → **23 passed** (les 7 assertions candidates passent au 4e champ rang ; +5 tests : mature/immature, la leg rouge la plus récente gouverne le tier, horodatage illisible → tier 1, pin structurel caps + sort + `continue` sans `break`).
- Voisins qui pinent ce workflow : `test_pr_gate_sweep_timing.py` + `test_merge_dwell.py` + `test_pr_gate_rerun_noop_guard.py` (21 passed) et `test_check_pr_perimeter.py::test_perimeter_workflow_rescued_by_universal_sweep` (passed).
- Simulation shell locale du tri two-tier + boucle à caps : mûrs d'abord, cap d'un tier n'arrête pas l'autre, comptes de service exacts.
- 2 fichiers touchés (workflow + son seam de tests), aucun catalogue, aucune dépendance nouvelle.

Closes #15375