### PR TITLE
fix(twin-gate,#15387): walk git log en échec = infrastructure, jamais un verdict « fabricated »

### DIFF
--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -423,19 +423,36 @@ def _build_blob_history(repo_root: Path) -> tuple[dict, dict]:
     """
     import subprocess
 
-    # ``-m`` : montre le diff des merge commits contre chaque parent. Sans cette
-    # option, ``git log --raw`` supprime les diffs de merge -> un blob dont la
-    # premiere apparition est le RESULTAT d'une resolution de merge (typique des
-    # PRs twin ou un merge ``origin/main`` combine un header-hoist + un fix de
-    # runtime en un nouveau blob unique) est invisible au walker, et la rebaseline
-    # de ce blob echoue sur ``test_audit_shas_exist_in_file_history`` alors que le
-    # sha est un vrai blob git (``git cat-file`` / ``git ls-tree`` le confirment).
-    # ``-m`` reste dans les ancetres de HEAD (determinisme CI/local preserve, cf
-    # note supra sur le rejet de ``--all``) ; le parser deduplique via ``set()``.
-    proc = subprocess.run(
-        ["git", "log", "HEAD", "-m", "--raw", "--no-renames", "--abbrev=40", "--format="],
-        cwd=repo_root, capture_output=True, text=True, encoding="utf-8", errors="replace",
-    )
+    def _walk() -> subprocess.CompletedProcess:
+        # ``-m`` : montre le diff des merge commits contre chaque parent. Sans
+        # cette option, ``git log --raw`` supprime les diffs de merge -> un blob
+        # nee d'une resolution de merge (header-hoist + fix runtime combines)
+        # est invisible au walker alors que c'est un vrai blob git. ``-m``
+        # reste dans les ancetres de HEAD (determinisme CI/local, cf note sur
+        # le rejet de ``--all``) ; le parser deduplique via ``set()``.
+        return subprocess.run(
+            ["git", "log", "HEAD", "-m", "--raw", "--no-renames", "--abbrev=40", "--format="],
+            cwd=repo_root, capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+
+    # #15387 : le job CI checkout en clone blobless (``filter: blob:none``,
+    # scripts-tests.yml) ou le walk peut echouer en cours de route (fetch lazy
+    # d'un tree). Le stdout PARTIEL d'un walk en echec ne doit JAMAIS etre
+    # parse comme un historique complet : les blobs tombes hors de la portion
+    # parcourue classifiaient « fabricated » a tort (6 faux rouges ML-8/SW-8/
+    # Z3-Python-06 sur des attestations legitimes, runs 2026-09-09). Un walk
+    # qui echoue n'est pas une absence mesuree : 1 retry, puis verdict
+    # d'infrastructure distinct -- jamais un verdict de fond.
+    proc = _walk()
+    if proc.returncode != 0:
+        proc = _walk()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "HISTORY_WALK_INCOMPLETE (#15387) : git log -m --raw a terminé "
+            f"avec le code {proc.returncode} ; l'historique parcouru est "
+            "incomplet et un verdict « fabricated » ne serait pas fiable. "
+            "stderr=" + proc.stderr.strip()[:500]
+        )
     path_blobs: dict[str, set[str]] = {}
     blob_paths: dict[str, set[str]] = {}
     for line in proc.stdout.splitlines():
@@ -661,6 +678,69 @@ def test_classify_attested_sha_ok_fabricated_crossfile_renamed():
     v, d = _classify_attested_sha("shaX_renamed", "A/X.ipynb", path_blobs, blob_paths, declared)
     assert v == "renamed"
     assert "X_old" in d
+
+
+# --- tests _build_blob_history walk en echec (#15387) ------------------------
+#
+# En CI (checkout blobless, scripts-tests.yml), le walk `git log -m --raw`
+# peut terminer en erreur avec un stdout PARTIEL. L'ancien code parsait ce
+# stdout comme un historique complet -> les blobs hors de la portion
+# parcourue classifiaient « fabricated » a tort (6 faux rouges ML-8/SW-8/
+# Z3-Python-06 sur des attestations legitimes, runs 2026-09-09). Un walk en
+# echec doit avorter avec un verdict d'infrastructure distinct, apres 1
+# retry -- jamais se deguiser en verdict de fond.
+
+
+def _fake_raw_line(old: str, new: str, path: str) -> str:
+    return f":100644 100644 {old} {new} M\t{path}"
+
+
+def test_walk_en_echec_avorte_avec_verdict_infrastructure(monkeypatch):
+    """git log exit != 0 deux fois -> RuntimeError HISTORY_WALK_INCOMPLETE,
+    pas un « fabricated » sur stdout partiel."""
+    import subprocess
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 128,
+            stdout=_fake_raw_line("f" * 40, "e" * 40, "A/X.ipynb") + "\n",
+            stderr="fatal: promisor fetch failure",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="HISTORY_WALK_INCOMPLETE"):
+        _build_blob_history(Path("."))
+    assert len(calls) == 2, "1 essai + 1 retry avant l'abort"
+
+
+def test_walk_transitoire_retraye_puis_parse(monkeypatch):
+    """1er essai exit != 0 (stdout partiel avec un VRAI blob), retry OK :
+    c'est le stdout du RETRY qui est parse -- l'historique partiel du 1er
+    essai ne doit jamais alimenter path_blobs/blob_paths."""
+    import subprocess
+
+    real_line = _fake_raw_line("a" * 40, "b" * 40, "P/Y.ipynb")
+    state = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        state["n"] += 1
+        if state["n"] == 1:
+            return subprocess.CompletedProcess(
+                cmd, 1, stdout=_fake_raw_line("c" * 40, "d" * 40, "A/X.ipynb"),
+                stderr="fatal: transient",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout=real_line + "\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    path_blobs, blob_paths = _build_blob_history(Path("."))
+    assert "P/Y.ipynb" in path_blobs
+    assert ("b" * 40) in blob_paths
+    assert "A/X.ipynb" not in path_blobs, (
+        "la portion parcourue du walk echoue ne doit pas etre indexee"
+    )
 
 
 # --- tests verify_recorded_sha (#9399 volet b) ------------------------------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15381

## Ce qui change

`_build_blob_history` (le walker git de `test_audit_shas_exist_in_file_history`) vérifie désormais le **returncode** du `git log -m --raw` qu'il parse :

1. **1 retry** si le walk termine en erreur ;
2. après retry en échec : abort `RuntimeError HISTORY_WALK_INCOMPLETE` avec stderr — un verdict **d'infrastructure**, distinct du verdict de fond.

Le verdict `fabricated` ne peut plus être émis sur un historique incomplet.

## Cause racine (mesurée, pas supposée)

- Le job Scripts Tests (CPU) checkout avec `fetch-depth: 0` + `filter: blob:none` (scripts-tests.yml:141). Le walker parsait le stdout de `git log` **sans regarder le returncode** : un walk interrompu en cours de route laissait un stdout PARTIEL traité comme historique complet.
- **Le rouge est un faux positif mesuré** : le sha `98249788bd0a…` (ML-8 Clustering) **est un vrai blob** du carnet dans `git log HEAD -m --raw` en full history locale (compte = 1) ; l'attestation `0001-2026-08-18-myia-po-2026-CoursIA.yaml` est légitime. En CI les 6 entrées ML-8/SW-8/Z3-Python-06 classifiaient « fabricated » à tort.
- **Flakiness attestée** (runs 2026-09-09) : main @ 4197776c PASS 12:51 → main @ f9bf4229 FAIL 13:04 (run 34353984035, mêmes 6 sha) → branche fix/15201 PASS 13:18. Le rouge suit l'exécution runner, pas un commit.
- Impact : PR gate agrège ce job → **n'importe quelle PR peut rougir au hasard** et se voir bloquer le merge (cas réel : #15381 à 12:44).

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_twin_registry_integrity.py -q` : **43 passed** (41 préexistants + 2 nouveaux), full file, full history locale.
- 2 tests de régression (mock `subprocess.run`, zéro dépendance à l'état du repo) :
  - échec double → `pytest.raises(RuntimeError, match="HISTORY_WALK_INCOMPLETE")` + exactement 2 appels (1 essai + 1 retry) ;
  - échec transitoire → retry OK et **seul le stdout du retry est indexé** (la portion du walk échoué — qui contenait un vrai blob — n'alimente pas `path_blobs`).
- Le commentaire `-m` historique (diff de merge contre chaque parent, #9399) est préservé au-dessus du `_walk()`.

## Portée honnête

- Le fix transforme la truncature silencieuse en échec **bruyant et étiqueté** : si le runner blobless échoue 2×, la CI rougit toujours — mais avec `HISTORY_WALK_INCOMPLETE`, pas en calomniant des attestations. Le retry absorbe les échecs transitoires observés.
- Repro blobless locale en cours (clone gros) : le mécanisme précis du truncat (lazy-fetch tree vs autre) sera posté en commentaire si elle conclut avant merge — il ne conditionne pas la correction, qui vaut pour toute truncature.
- Non-cibles : les 41 orphelins squash (fallback contenu-atteste, voulu, inchangé) ; la légitimité des 6 attestations (établie, pas remise en cause).

Closes #15387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
