### PR TITLE
fix(ci,#15152): derive the 3 runner name prefixes from hostname, not hardcoded po-2024

### DIFF
--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -73,7 +73,14 @@ set -uo pipefail
 REPO="${COURSIA_RUNNER_REPO:-jsboige/CoursIA}"
 IMAGE="${COURSIA_RUNNER_IMAGE:-coursia-linux-runner:2.337.0}"
 LABELS="${COURSIA_RUNNER_LABELS:-self-hosted,coursia-ephemeral,coursia-linux}"
-NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-myia-po-2024-linux-docker}"
+# #15152 : le prefixe de nom derive de la MACHINE, pas d'un hote code en dur.
+# L'ancien defaut `myia-po-2024-*` faisait enregistrer les runners de toute
+# autre machine sous l'identite de po-2024 cote GitHub -- inventaire menteur
+# (un runner d'ai-01 lu comme fantome de po-2024) + collision de nom si les
+# deux machines montent des pools simultanement. La surcharge ENV explicite
+# reste prioritaire ; hostname lowercasse pour les hotes a nom Windowsien.
+MACHINE_ID="${COURSIA_RUNNER_MACHINE_ID:-$(hostname | tr 'A-Z' 'a-z')}"
+NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-${MACHINE_ID}-linux-docker}"
 STATE_DIR="${COURSIA_RUNNER_STATE_DIR:-$HOME/.coursia-runner}"
 STOP_FILE="$STATE_DIR/stop"
 
@@ -114,7 +121,7 @@ WORK_MOUNT="${COURSIA_RUNNER_WORK_MOUNT:-/home/runner/_work}"
 # de volume toolcache/_work : aucun job d'execution ne doit leur atterrir,
 # le gate bascule dessus uniquement (item B, ai-01).
 WAITER_LABELS="${COURSIA_RUNNER_WAITER_LABELS:-self-hosted,coursia-waiter}"
-WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-myia-po-2024-linux-waiter}"
+WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-${MACHINE_ID}-linux-waiter}"
 WAITER_CPUS="${COURSIA_RUNNER_WAITER_CPUS:-1}"
 WAITER_MEMORY="${COURSIA_RUNNER_WAITER_MEMORY:-1g}"
 WAITER_PIDS="${COURSIA_RUNNER_WAITER_PIDS:-128}"
@@ -138,7 +145,7 @@ WAITER_TOOLCACHE="${COURSIA_RUNNER_WAITER_TOOLCACHE:-1}"
 # survivent aux conteneurs, lake build devient incremental.
 LEAN_IMAGE="${COURSIA_LEAN_RUNNER_IMAGE:-coursia-lean-runner:2.337.0}"
 LEAN_LABELS="${COURSIA_LEAN_RUNNER_LABELS:-self-hosted,coursia-ephemeral,coursia-lean}"
-LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-myia-po-2024-lean-docker}"
+LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-${MACHINE_ID}-lean-docker}"
 LEAN_WORK_VOLUME_PREFIX="${COURSIA_LEAN_RUNNER_WORK_VOLUME_PREFIX:-coursia-runner-work-lean}"
 # 2 slots * 6 cpus = 12 des 16 coeurs au pire ; l'hote workstation prime
 # (cf CONTRAINTE en tete de fichier) -- baisser N ou les caps si la machine

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -29,13 +29,16 @@ RESULTS="$TEST_DIR/results"
 ok() { echo "  PASS: $1"; echo "PASS $1" >> "$RESULTS"; }
 ko() { echo "  FAIL: $1"; echo "FAIL $1" >> "$RESULTS"; }
 
-# Stubs docker + gh + ps. Le stub docker simule une image A JOUR pour le
-# garde de fraicheur #14801/#15105 : au probe `run --entrypoint sha256sum`, il
-# rend le sha256 du VRAI sibling du checkout (bake a la generation du stub).
-# La fonction assert_image_fresh lit DEUX fichiers depuis #15105 (work_cache_
-# health.sh est source par l'entrypoint) : le stub repond aux deux probes.
-# STUB_IMG_ENTRYPOINT_SHA / STUB_IMG_HEALTH_SHA forcent un ecart pour tester
-# le refus (tests 9 et 29).
+# Stubs docker + gh + ps + hostname. Le stub docker simule une image A JOUR
+# pour le garde de fraicheur #14801/#15105 : au probe `run --entrypoint
+# sha256sum`, il rend le sha256 du VRAI sibling du checkout (bake a la
+# generation du stub). La fonction assert_image_fresh lit DEUX fichiers
+# depuis #15105 (work_cache_health.sh est source par l'entrypoint) : le stub
+# repond aux deux probes. STUB_IMG_ENTRYPOINT_SHA / STUB_IMG_HEALTH_SHA
+# forcent un ecart pour tester le refus (tests 9 et 29).
+# Le stub hostname rend le defaut de supervise.sh (#15152) deterministe :
+# le prefixe derive de la machine, il ne doit jamais dependre de l'hote qui
+# execute la suite.
 REPO_ENTRYPOINT_SHA="$(sha256sum "$SCRIPT_DIR/entrypoint.sh" 2>/dev/null | awk '{print $1}')"
 REPO_HEALTH_SHA="$(sha256sum "$SCRIPT_DIR/work_cache_health.sh" 2>/dev/null | awk '{print $1}')"
 cat > "$TEST_DIR/bin/docker" <<STUB
@@ -90,6 +93,15 @@ echo "sleep $*" >> "${SLEEP_LOG:-/dev/null}"
 exit 0
 STUB
 chmod +x "$TEST_DIR/bin/sleep"
+
+# Stub hostname (#15152) : le prefixe des runners derive du hostname, le
+# rendre deterministe -- la suite ne doit jamais dependre de l'hote qui
+# l'execute.
+cat > "$TEST_DIR/bin/hostname" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "${HOSTNAME_STUB:-myia-default-host}"
+STUB
+chmod +x "$TEST_DIR/bin/hostname"
 
 # Helper : executer supervise.sh avec env detourne. Timeout pour eviter le
 # hang de wait() -- cmd_start lance wait() qui attend les slot_loop infinis.
@@ -1416,6 +1428,48 @@ STUB
   else
     ko "attendu rc=0 et backoff=2^59 plat ; rc=$rc31 seq=[$seq31] bad=$bad err=$(head -3 "$TEST_DIR/err31.log")"
   fi
+)
+echo ""
+
+# --- Test 32 : les trois prefixes par defaut derivent du hostname (#15152) --
+# L'ancien defaut codait myia-po-2024 en dur dans les trois familles : les
+# runners de toute autre machine s'enregistraient sous l'identite de po-2024.
+# Le test source le script AVEC un hostname stubbe en majuscules -- le
+# hostname donne doit produire les trois prefixes, lowercasses, SANS qu'aucune
+# variable ENV ne soit posee ; puis la surcharge ENV explicite (le contrat des
+# wrappers persist/) doit rester prioritaire sur la derivation.
+echo "Test 32 : hostname donne -> les trois prefixes de famille derives (#15152)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  export HOSTNAME_STUB="MYIA-TestHost-32"
+  unset COURSIA_RUNNER_NAME_PREFIX COURSIA_RUNNER_WAITER_NAME_PREFIX \
+        COURSIA_LEAN_RUNNER_NAME_PREFIX COURSIA_RUNNER_MACHINE_ID
+  source_supervise
+  if [ "${NAME_PREFIX:-}" = "myia-testhost-32-linux-docker" ]; then
+    ok "NAME_PREFIX derive du hostname lowercasse (${NAME_PREFIX:-vide})"
+  else
+    ko "NAME_PREFIX='${NAME_PREFIX:-vide}', attendu myia-testhost-32-linux-docker"
+  fi
+  if [ "${WAITER_NAME_PREFIX:-}" = "myia-testhost-32-linux-waiter" ]; then
+    ok "WAITER_NAME_PREFIX derive (${WAITER_NAME_PREFIX:-vide})"
+  else
+    ko "WAITER_NAME_PREFIX='${WAITER_NAME_PREFIX:-vide}', attendu myia-testhost-32-linux-waiter"
+  fi
+  if [ "${LEAN_NAME_PREFIX:-}" = "myia-testhost-32-lean-docker" ]; then
+    ok "LEAN_NAME_PREFIX derive (${LEAN_NAME_PREFIX:-vide})"
+  else
+    ko "LEAN_NAME_PREFIX='${LEAN_NAME_PREFIX:-vide}', attendu myia-testhost-32-lean-docker"
+  fi
+  export COURSIA_RUNNER_WAITER_NAME_PREFIX="wrapper-explicit-w"
+  source_supervise
+  if [ "$WAITER_NAME_PREFIX" = "wrapper-explicit-w" ] \
+     && [ "$NAME_PREFIX" = "myia-testhost-32-linux-docker" ]; then
+    ok "surcharge ENV prioritaire, familles non surchargees restent derivees"
+  else
+    ko "surcharge ENV cassee : W='$WAITER_NAME_PREFIX' N='$NAME_PREFIX'"
+  fi
+  unset COURSIA_RUNNER_WAITER_NAME_PREFIX HOSTNAME_STUB
 )
 echo ""
 


### PR DESCRIPTION
Grain: MED/ci — lane myia-po-2026:CoursIA — prev: notebook-python #15390

Closes #15152

## Le defaut

`supervise.sh` codait `myia-po-2024` en dur comme defaut des trois familles de runners (`NAME_PREFIX` docker, `WAITER_NAME_PREFIX` waiter, `LEAN_NAME_PREFIX` lean) : toute machine autre que po-2024 enregistrait ses runners sous l'identite de po-2024 cote GitHub.

## Le fix

Une seule source de verite, derivee de l'hote (proposition verbatim de l'issue) :

```bash
MACHINE_ID="${COURSIA_RUNNER_MACHINE_ID:-$(hostname | tr 'A-Z' 'a-z')}"
NAME_PREFIX="${COURSIA_RUNNER_NAME_PREFIX:-${MACHINE_ID}-linux-docker}"
WAITER_NAME_PREFIX="${COURSIA_RUNNER_WAITER_NAME_PREFIX:-${MACHINE_ID}-linux-waiter}"
LEAN_NAME_PREFIX="${COURSIA_LEAN_RUNNER_NAME_PREFIX:-${MACHINE_ID}-lean-docker}"
```

Hostname lowercasse (noms Windowsiens), `COURSIA_RUNNER_MACHINE_ID` comme surcharge machine explicite, les trois surcharges ENV par famille restent prioritaires.

## Criteres d'acceptance

- [x] **Machine sans variable ENV enregistre sous SON nom** : derivation `hostname` -> les trois prefixes ; surcharge ENV prioritaire (assertion dediee dans le test 21).
- [x] **Les trois familles couvertes** : les trois lignes remplacent leur defaut `myia-po-2024-*` (supervise.sh lignes 76/124/148 avant fix).
- [x] **Test hostname donne -> trois prefixes attendus** : Test 32 de `test_supervise_guards.sh` source le script avec un hostname stubbe en MAJUSCULES (`MYIA-TestHost-32`) et asserte `myia-testhost-32-linux-docker` / `-linux-waiter` / `-lean-docker` (derivation + lowercase + aucune dependence a l'hote d'execution), puis re-source avec `COURSIA_RUNNER_WAITER_NAME_PREFIX=wrapper-explicit-w` et asserte la priorite de la surcharge. Stub `hostname` deterministe ajoute au harnais (defaut `myia-default-host`).
- [x] **Aucun script de deploiement ne dependait du defaut po-2024** (verifie par `git grep` exhaustif) :
  - `persist/coursia-runner-start.sh:24` (po-2024) : export INCONDITIONNEL `COURSIA_RUNNER_NAME_PREFIX="myia-po-2024-linux-docker"` -- insensible au defaut.
  - `persist/ai-01/coursia-runner-start.sh:69` : export explicite `myia-ai-01-wsl`.
  - `persist/coursia-waiters-start.sh:38` (ai-01) : export explicite `myia-ai-01-linux-waiter`.
  - `persist/launch-runner.sh` / `hold-runner.ps1` / unites systemd (`coursia-runner.service`, `ai-01/*.service`, taches `-Boot`) : aucun ne touche aux prefixes -- ils invoquent les wrappers ci-dessus.
  - `COURSIA_LEAN_RUNNER_NAME_PREFIX` : AUCUNE reference hors supervise.sh -- la famille lean ne pouvait prendre QUE le defaut dur ; elle derive desormais.
  - `entrypoint.sh:7` : exemple dans un commentaire de doc, pas une dependance.

## Renommage cote GitHub des runners deja enregistres

Note pour l'issue : les runners etant ephemeres (`--ephemeral`, desenregistrement apres chaque job), les enregistrements sous le mauvais nom se purge naturellement au job suivant. Les familles ai-04/ai-01 qui tournaient aujourd'hui sous un nom po-2024 passent par les wrappers qui settaient DEJA explicitement le prefixe (docker-wsl, waiters) -- le defaut dur n'etait mordant que sur les demarrages manuels sans ENV, precisement le cas que ce fix ferme. Rien a desenregistrer a la main depuis le repo.

## Validation

Suite `test_supervise_guards.sh` (harnais existant, observation directe) :

```
Test 32 : hostname donne -> les trois prefixes de famille derives (#15152)
  PASS: NAME_PREFIX derive du hostname lowercasse (myia-testhost-32-linux-docker)
  PASS: WAITER_NAME_PREFIX derive (myia-testhost-32-linux-waiter)
  PASS: LEAN_NAME_PREFIX derive (myia-testhost-32-lean-docker)
  PASS: surcharge ENV prioritaire, familles non surchargees restent derivees

## Rebase post-#15166 (2026-09-11)

Rebase sans perte sur le main post-squash #15166 (conflit test_supervise_guards.sh, memes fichiers) :
- Tests 30-31 de #15166 (bornes backoff fail-closed, frontiere 2^59) conserves integralement.
- Mon test renumerote 21 -> 32 (sequence coherente apres les tests 22-31 de main), stub hostname conserve.
- Stub sleep global + REAL_SLEEP de main conserves ; stub hostname ajoute a cote.
- Suite complete relancee sur la tete rebasee : **70 PASS / 0 FAIL**.
  PASS: surcharge ENV prioritaire, familles non surchargees restent derivees
===========================================================
  43 PASS / 1 FAIL
```

Le 1 FAIL est le Test 10, PREEXISTANT sur main vierge (run de controle : 39 PASS / 1 FAIL, meme assertion `le garde a tort ou le start a echoue`, timeout du start dans le harnas local Windows) -- sans rapport avec ce diff, a tracker separement.

Collateral check : `persist/test_sentinel_purge.sh` avec le supervise.sh modifie = 11 PASS / 0 FAIL.
