### PR TITLE
fix(genai,#15385): .env.example templates must not satisfy their own fail-closed guard

### DIFF
--- a/docker-configurations/services/forge-turbo/.env.example
+++ b/docker-configurations/services/forge-turbo/.env.example
@@ -4,4 +4,4 @@ FORGE_PORT=17861
 # Authentification Gradio (Basic Auth)
 # Format: user:password
 FORGE_USER=admin
-FORGE_PASSWORD=changeme
+FORGE_PASSWORD=

--- a/docker-configurations/services/forge-turbo/README.md
+++ b/docker-configurations/services/forge-turbo/README.md
@@ -33,7 +33,7 @@ FORGE_PORT=17861
 
 # Authentification Gradio (Basic Auth)
 FORGE_USER=admin
-FORGE_PASSWORD=changeme  # A MODIFIER EN PRODUCTION
+FORGE_PASSWORD=  # a renseigner avant demarrage : compose refuse une valeur vide
 ```
 
 ### Arguments CLI
@@ -74,7 +74,7 @@ docker compose -f docker-configurations/services/forge-turbo/docker-compose.yml 
 ## Acces
 
 - **URL**: http://localhost:17861
-- **Auth**: admin / changeme (modifier dans .env)
+- **Auth**: admin / (mot de passe a definir dans .env — aucune valeur par defaut commitee)
 - **API**: http://localhost:17861/sdapi/v1/
 
 ## Dockerfile Custom
@@ -122,6 +122,7 @@ nvidia-smi
 ### Exemple API
 
 ```python
+import os
 import requests
 
 url = "http://localhost:17861/sdapi/v1/txt2img"
@@ -133,7 +134,7 @@ payload = {
     "cfg_scale": 1.0  # Turbo = cfg 1
 }
 
-response = requests.post(url, json=payload, auth=("admin", "changeme"))
+response = requests.post(url, json=payload, auth=("admin", os.environ["FORGE_PASSWORD"]))
 ```
 
 ## Troubleshooting

--- a/docker-configurations/services/sd-forge-main/.env.example
+++ b/docker-configurations/services/sd-forge-main/.env.example
@@ -1,5 +1,5 @@
 # SD Forge Main Service Configuration
 SD_FORGE_MAIN_API_KEY=your_sd_forge_main_api_key_here
 
-# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente.
-FORGE_PASSWORD=changeme
+# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente ou vide.
+FORGE_PASSWORD=

--- a/docker-configurations/services/sd-forge-main/README.md
+++ b/docker-configurations/services/sd-forge-main/README.md
@@ -34,7 +34,7 @@ docker logs sd-forge-main --tail 100 -f
 |----------|-------------|--------|
 | `SD_FORGE_MAIN_API_KEY` | Cle API pour l'authentification | A definir |
 | `FORGE_USER` (via `WEB_USER`) | Utilisateur Gradio | `admin` |
-| `FORGE_PASSWORD` (via `WEB_PASSWORD`) | Mot de passe Gradio | `changeme` |
+| `FORGE_PASSWORD` (via `WEB_PASSWORD`) | Mot de passe Gradio | A definir (fail-closed : aucune valeur commitee) |
 
 ### Arguments CLI
 
@@ -101,7 +101,7 @@ Note : pas de `.gitignore` dedie. Le fichier `.env` est exclu via le `.gitignore
 - **WebUI** : http://localhost:7860
 - **Cloud** : https://stable-diffusion-webui-forge.myia.io
 - **API** : http://localhost:7860/sdapi/v1/
-- **Auth** : admin / changeme (modifier dans `.env`)
+- **Auth** : admin / (mot de passe a definir dans `.env` — aucune valeur par defaut commitee)
 
 ## Dockerfile Custom
 

--- a/docker-configurations/services/sdnext/.env.example
+++ b/docker-configurations/services/sdnext/.env.example
@@ -1,5 +1,5 @@
 # SD.Next Service Configuration
 SDNEXT_API_KEY=your_sdnext_api_key_here
 
-# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente.
-FORGE_PASSWORD=changeme
+# FORGE_PASSWORD: mot de passe de ce service — valeur par instance, choisie localement, jamais centralisee ni publiee. Fail-closed : docker compose refuse de demarrer si absente ou vide.
+FORGE_PASSWORD=

--- a/docker-configurations/services/sdnext/README.md
+++ b/docker-configurations/services/sdnext/README.md
@@ -29,7 +29,7 @@ docker-compose logs -f sdnext
 |----------|-------------|--------|
 | `SDNEXT_API_KEY` | Cle API pour l'acces programmatique | - |
 | `WEB_USER` | Utilisateur Gradio (via `FORGE_USER`) | `admin` |
-| `WEB_PASSWORD` | Mot de passe Gradio (via `FORGE_PASSWORD`) | `changeme` |
+| `WEB_PASSWORD` | Mot de passe Gradio (via `FORGE_PASSWORD`) | A definir (fail-closed : aucune valeur commitee) |
 
 Parametres fixes dans `FORGE_ARGS` :
 

--- a/docker-configurations/services/whisper-webui/.env.example
+++ b/docker-configurations/services/whisper-webui/.env.example
@@ -13,7 +13,7 @@ WHISPER_PORT=36540
 
 # --- Authentification Gradio ---
 WHISPER_USER=admin
-WHISPER_PASSWORD=changeme
+WHISPER_PASSWORD=
 
 # --- Type Whisper ---
 # Options: whisper, faster_whisper, insanely_fast_whisper


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2026:CoursIA — prev: MED/tooling #15353

Closes #15385

## Le defaut

Les 4 `.env.example` livrent `FORGE_PASSWORD=changeme` (x3) / `WHISPER_PASSWORD=changeme` (x1). La garde `:?` du compose ne teste que *unset-or-empty* : une valeur presente et publique la satisfait. Le chemin documente `cp .env.example .env` + `docker compose up` demarrait donc silencieusement avec un credential publie dans le depot public -- le changement de mode de defaillance exactement decrit par l'issue (echec bruyant -> demarrage muet avec mot de passe connu).

## Le remede (forme 1 de l'issue, verbatim)

Valeur **vide** dans les templates : `FORGE_PASSWORD=` / `WHISPER_PASSWORD=`. La garde existante fait tout le travail -- aucun changement de compose. Commentaire des 2 templates qui en portent un etendu a « si absente **ou vide** » (desormais littéralement vrai de l'etat livre).

Les 6 lignes README cessent d'enseigner `changeme` comme valeur effective :
- tables « Defaut » (`sd-forge-main` l.37, `sdnext` l.32) : `A definir (fail-closed : aucune valeur commitee)` -- aligne sur la ligne `SD_FORGE_MAIN_API_KEY` « A definir » de la meme table ;
- lignes « Auth » (`sd-forge-main` l.104, `forge-turbo` l.77) : le credential devient « a definir », aucune valeur citee ;
- bloc config `forge-turbo` l.36 : `FORGE_PASSWORD=  # a renseigner avant demarrage : compose refuse une valeur vide` ;
- **exemple API executable** `forge-turbo` l.136 : `auth=("admin", os.environ["FORGE_PASSWORD"])` + `import os` -- le credential se lit de l'environnement, plus aucun literial.

## Criteres d'acceptance (mesures firsthand, docker 29.7.2)

- [x] **Les 4 templates ne satisfont plus leur garde** -- `cp .env.example .env && docker compose config` par service :

```
sd-forge-main : FAIL-CLOSED rc=1 :: FORGE_PASSWORD is missing a value: FORGE_PASSWORD must be set in this service .env (no committed default, it would be a published credential)
forge-turbo   : FAIL-CLOSED rc=1 :: FORGE_PASSWORD is missing a value: (message identique)
sdnext        : FAIL-CLOSED rc=1 :: FORGE_PASSWORD is missing a value: (message identique)
whisper-webui : FAIL-CLOSED rc=1 :: WHISPER_PASSWORD is missing a value: WHISPER_PASSWORD must be set in this service .env (...)
```

- [x] **Controle negatif** : vraie valeur renseignee -> `docker compose config` rc=0 sur les 4/4 (chemin nominal intact).
- [x] **6 lignes README** : plus aucune occurrence de `changeme` comme valeur ou credential d'exemple.
- [x] **Aucun secret reel** : uniquement des placeholders ; la valeur de test des mesures vivait dans un `.env` ephemere, supprime (worktree propre, 7 fichiers M).
- [x] **Grep de confirmation** : `git grep -n 'changeme' docker-configurations/services/` -> **vide** (rc=1).

## Diff

7 fichiers, +13/−12 : 4 `.env.example` + 3 README (`sd-forge-main`, `forge-turbo`, `sdnext`). Aucun compose, aucun workflow, aucun catalogue touches.
