### PR TITLE
ci(lean,#15305): wire proof-integrity gate onto planning_lean

### DIFF
--- a/.github/workflows/lean-planning.yml
+++ b/.github/workflows/lean-planning.yml
@@ -22,6 +22,14 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lean-toolchain'
+      # The gate's own implementation: a change to it must re-run the gate
+      # (same rationale as lean-sensitivity.yml, cf #8951 / #15305).
+      - '.github/workflows/lean-planning.yml'
+      - '.github/workflows/lean-axiom.yml'
+      # The axiom step is a Python program (`from lean_server import LeanVerifier`);
+      # lean_server.py + lean_utils.py ARE gate inputs (cf #8722).
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   pull_request:
     branches: [main]
     paths:
@@ -29,6 +37,11 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lean-toolchain'
+      # The gate must run on the PR that introduces or changes it (cf #8712).
+      - '.github/workflows/lean-planning.yml'
+      - '.github/workflows/lean-axiom.yml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   workflow_dispatch:
 
 permissions:
@@ -46,3 +59,29 @@ jobs:
       display-name: planning_lean
       sorry-baseline: "0"
       sorry-filter-mode: real
+
+  # Level 3 proof-integrity gate (criterion B.3 of pr-review-discipline) —
+  # closes #15305: planning_lean was the wired-lake exception with NO axiom
+  # gate, so a proof edit had no CI organ forbidding a new `sorry`,
+  # transitive `sorryAx` or `native_decide`. Same reusable-form caller as
+  # lean-sensitivity.yml (12th caller): needs `ci` only for compile ordering
+  # (parity #14922), the gate rebuilds from its own cache entry.
+  # allow-axioms: "" — the defaults (propext, funext, Classical.choice,
+  # Quot.lift, Quot.mk, Quot.sound) are an explicit-name whitelist, no
+  # wildcard (#15305 acceptance 3); a NEW axiom name = a red.
+  # fail-on-sorry: true — sorry-baseline is 0, the lake is fully proven.
+  # target-modules: "*" (issue #10889) — the module list is derived at
+  # runtime by check_target_coverage.discover_modules (the advisory script
+  # itself), so Planning.Strips/Relaxation/Admissibility are covered by
+  # construction, not by a hand-maintained list that can drift (#15305
+  # acceptance 1). `_en` i18n siblings stay excluded (FR-only measurement,
+  # include-i18n-siblings default false).
+  proof-integrity:
+    needs: ci
+    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean
+      display-name: planning_lean
+      target-modules: "*"
+      allow-axioms: ""
+      fail-on-sorry: true


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: translation #15326

Closes #15305

## Le trou

`planning_lean` n'avait **aucun garde proof-integrity en CI** (réserve NanoClaw posée en review de #15237, portée par ce ticket) : onze lakes câblés sur `lean-axiom.yml`, planning pas. Une édition de preuve sur ce lake ne rencontrait aucun organe CI lui interdisant un nouveau `sorry`, un `sorryAx` transitif ou un `native_decide` — le B.3 des PRs sur ce lake se lisait « non applicable, job non câblé ».

## Le câblage (12e caller du réutilisable, forme identique à lean-sensitivity.yml)

```yaml
proof-integrity:
  needs: ci
  uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
  with:
    project-path: MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean
    display-name: planning_lean
    target-modules: "*"
    allow-axioms: ""
    fail-on-sorry: true
```

Paths : self-cover du gate ajouté aux deux déclencheurs (workflow lui-même + `lean-axiom.yml` + `lean_server.py` + `prover/lean_utils.py` — cf #8712/#8951/#8722 : le gate doit tourner sur la PR qui l'introduit ou le change).

## Criteres d'acceptance

- [x] **1. target-modules atteint les 3 modules, vérifié par l'advisory, pas par lecture d'intention** : `target-modules: "*"` → la liste des modules est DÉRIVÉE à l'exécution par `check_target_coverage.discover_modules` (le script advisory lui-même, importé par le step gate — lean-axiom.yml l.211-230). `Planning.Strips`, `Planning.Relaxation`, `Planning.Admissibility` sont couverts par construction, et l'énumération vide est un échec dur (« a gate that inspects nothing must fail »). Siblings `_en` exclus par défaut (mesure FR-only #10889). Le gate s'exécute sur CETTE PR (paths self-cover).
- [ ] **2. Run vert sur main à la tête courante** : le gate tourne sur cette PR (ubuntu-latest, indépendant du pool coursia-lean non déployé #15205) ; le vert sur main suit le merge. Le premier run du gate sur cette PR est la mesure de référence.
- [x] **3. Jamais de wildcard** : `allow-axioms: ""` — la whitelist par défaut du workflow réutilisable est une liste de NOMS EXPLICITES (`propext, funext, Classical.choice, Quot.lift, Quot.mk, Quot.sound`) ; tout NOUVEAU nom d'axiome = rouge. Le cliquet est intact.
- [ ] **4. Ligne `planning_lean` du coverage doc mise à jour avec la mesure** : ajoutée dans cette PR (commit 2) dès que le log du premier run du gate est lisible — précédent percolation #14904 (« mesuré au câblage CI ») : la mesure EST le run du câblage.

## Mesures locales (source, pre-gate)

- `count_code_sorry.py --lake planning_lean --json` : **`distinct_code_sorry = 0`** sur 7 fichiers (naive_sorry 5 = prose/docstrings) → `fail-on-sorry: true` cohérent avec `sorry-baseline: "0"` du job ci.
- `git grep native_decide` : 0 fichier.

Diff : 1 fichier (lean-planning.yml), +39. Aucun .lean touché, scope du lake build inchangé.