### PR TITLE
fix(guard,#14532): plan-loss — le drift de cellules md ne bloque plus la détection de perte

### DIFF
--- a/scripts/notebook_tools/detect_notebook_plan_loss.py
+++ b/scripts/notebook_tools/detect_notebook_plan_loss.py
@@ -44,13 +44,19 @@ taux de sur-accusation reel :
    est la porte assumee par l'auteur, pas une dispense ; il est visible dans
    la sortie machine comme ``LOST_SECTION_JUSTIFIED_BY_BODY``.
 
-Comparaison STRUCTURELLEMENT bornée : un notebook ou le nombre de cellules
-markdown differe entre base et head est REPORTE en ``STRUCTURE_DRIFT`` (un
-finding bloquant) au lieu de tomber dans la comparaison cellule-par-cellule
-qui produirait des faux positifs position-par-position (cf. la discussion
-similaire pour `_compare_cells` de `detect_md_content_loss.py`, design #1
-de #8655). Le diff de PLAN est lui-meme robuste au decalage : on compare
-des ENSEMBLES de titres, pas des positions.
+Comparaison STRUCTURELLEMENT bornee : un notebook ou le nombre de cellules
+markdown differe entre base et head est REPORTE en ``STRUCTURE_DRIFT`` --
+un finding INFORMATIF, NON bloquant. La premiere redaction court-circuitait
+l'analyse sur ce drift (borne transposee de `_compare_cells` de
+`detect_md_content_loss.py`, design #1 de #8655, ou la comparaison de
+volume PAR CELLULE exige un appariement positionnel) ; or le diff de PLAN
+compare des ENSEMBLES de titres puis cherche la substance par texte, aucune
+passe n'apparie des positions : le drift ne peut y cacher aucune perte, et
+la borne rougissait sur tout enrichissement AJOUTANT une cellule markdown
+(le geste pedagogique standard du depot -- FP mesures : #15403 ajout pur, 0
+titre perdu ; #15390). La detection de perte tourne donc toujours, drift ou
+pas ; un titre reellement disparu et introuvable reste ``LOST_SECTION``
+bloquant meme sous drift.
 
 Usage
 -----
@@ -499,41 +505,34 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
     base_norm_set: set[str] = {_normalize_heading(t) for _, _, t in base_h_list}
     head_norm_set: set[str] = {_normalize_heading(t) for _, _, t in head_h_list}
 
-    # STRUCTURE_DRIFT : si le compte de cellules markdown differe entre base
-    # et head, on ne peut PAS garantir qu'une disparition de titre reflete
-    # reelement une perte de plan (une fusion de cellules peut absorber un
-    # titre dans une autre ; une scission peut l'eclater). On rapporte la
-    # STRUCTURE sans comparer cellule-par-cellule -- un seul finding
-    # bloquant, lisible d'un coup d'oeil. Cf. design #1 #8655 transpose ici.
+    # STRUCTURE_DRIFT : le compte de cellules markdown differe entre base et
+    # head. Signal INFORMATIF, non bloquant -- le diff de plan compare des
+    # ENSEMBLES de titres puis cherche la substance par texte, aucune de ces
+    # passes n'apparie des positions de cellules : une fusion/scission ne
+    # peut pas y cacher une perte (un titre disparu reste absent de
+    # l'ensemble head, substance comprise). La premiere redaction
+    # court-circuitait ici (borne transposee de detect_md_content_loss, ou
+    # la comparaison de volume PAR CELLULE exige un appariement positionnel)
+    # et rougissait sur tout enrichissement AJOUTANT une cellule markdown --
+    # le geste pedagogique standard du depot (FP mesures : #15403, ajout
+    # pur, 0 titre perdu ; #15390). La detection de perte tourne donc
+    # TOUJOURS, drift ou pas. Cf. #8655 design #1 pour l'origine de la borne.
     base_md_count = sum(1 for c in nb_base.get("cells", []) if c.get("cell_type") == "markdown")
     head_md_count = sum(1 for c in nb_head.get("cells", []) if c.get("cell_type") == "markdown")
+    cell_count_stable = base_md_count == head_md_count
     findings: list[dict] = []
-    if base_md_count != head_md_count:
+    if not cell_count_stable:
         findings.append({
             "kind": "STRUCTURE_DRIFT",
             "base_md_cells": base_md_count,
             "head_md_cells": head_md_count,
             "detail": (
                 "le nombre de cellules markdown differe entre base et head "
-                "-- divergence de structure, diff de plan non fiable "
-                "(scission/fusion peut deplacer un titre dans une autre "
-                "cellule, invisible au diff ENSEMBLE)."
+                "-- signal informatif, non bloquant : le diff de plan "
+                "compare des ENSEMBLES de titres et reste fiable au "
+                "decalage de cellules."
             ),
         })
-        return {
-            "notebook": str(nb_path),
-            "base_ref": base_ref,
-            "head_ref": head_label,
-            "findings": findings,
-            "stats": {
-                "base_md_cells": base_md_count,
-                "head_md_cells": head_md_count,
-                "cell_count_stable": False,
-                "base_headings": len(base_h_list),
-                "head_headings": len(head_h_list),
-                "findings_count": len(findings),
-            },
-        }
 
     # Candidats : titres normalises presents a la base, absents au head.
     candidates: list[tuple[int, str, str, int, str, str]] = []
@@ -576,7 +575,7 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
         "stats": {
             "base_md_cells": base_md_count,
             "head_md_cells": head_md_count,
-            "cell_count_stable": True,
+            "cell_count_stable": cell_count_stable,
             "base_headings": len(base_h_list),
             "head_headings": len(head_h_list),
             "candidates_count": len(candidates),
@@ -649,6 +648,19 @@ def _apply_body_justifications(findings: list[dict], justified_norm_titles: set[
         else:
             out.append(f)
     return out
+
+
+def _blocking_findings(findings: list[dict]) -> list[dict]:
+    """Findings qui font rougir ``--check`` : ``LOST_SECTION`` non justifiees.
+
+    ``SUBSTANCE_FOUND`` (perte apparente, substance retrouvee ailleurs) et
+    ``STRUCTURE_DRIFT`` (signal informatif de compte de cellules -- la
+    detection de perte tourne malgre lui, cf. scan_notebook) ne bloquent
+    pas, pas plus que les ``LOST_SECTION_JUSTIFIED_BY_BODY``.
+    """
+    return [f for f in findings
+            if not str(f.get("kind", "")).endswith("JUSTIFIED_BY_BODY")
+            and f.get("kind") not in ("SUBSTANCE_FOUND", "STRUCTURE_DRIFT")]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -761,10 +773,7 @@ def main(argv: list[str] | None = None) -> int:
                           f"'{f['base_heading_normalized']}'){suffix}")
 
     if args.check and result["findings"]:
-        blocking = [f for f in result["findings"]
-                     if not str(f.get("kind", "")).endswith("JUSTIFIED_BY_BODY")
-                     and f.get("kind") != "SUBSTANCE_FOUND"]
-        if blocking:
+        if _blocking_findings(result["findings"]):
             return 1
     return 0
 

--- a/scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py
@@ -6,8 +6,9 @@ substance en 3 passes :
   - retrogradation titre -> bold inline -> SUBSTANCE_FOUND_INLINE_BOLD (PAS de signal)
   - section renommee / absorbee -> SUBSTANCE_FOUND_TOKEN_MATCH (PAS de signal)
   - titre re-accentue / re-numerote -> INVISIBLE apres normalisation (PAS de signal)
-  - STRUCTURE_DRIFT : nombre de cellules markdown different (PAS de comparaison
-    elementaire, design #1 #8655 transpose)
+  - STRUCTURE_DRIFT : nombre de cellules markdown different -- signal
+    INFORMATIF non bloquant ; la detection de perte (LOST_SECTION) tourne
+    malgre le drift (fix FP d'ajout : #15403/#15390, borne #8655 retiree)
   - NEW_FILE exempt (rc=0)
   - justification par-section via body PR (--pr-body-file) : leve le finding
     LOST_SECTION correspondant
@@ -240,10 +241,10 @@ class TestScan:
     def test_section_lost_raises_finding(self, tmp_path: Path):
         # Cas du ticket : `### Duree estimee : 50 minutes` a la base,
         # absent du head sans substance ailleurs -> LOST_SECTION.
-        # Note : on garde le MEME nombre de cellules markdown entre base et
-        # head sinon STRUCTURE_DRIFT bloque la passe substance (par design --
-        # une difference de cellules = impossible de garantir une
-        # comparaison ENSEMBLE).
+        # (Le meme nombre de cellules n'est plus requis depuis le fix du
+        # court-circuit STRUCTURE_DRIFT : une difference de compte ne
+        # desarme plus la passe substance -- on le garde ici par simplicite
+        # du fixture.)
         # On choisit un head dont AUCUN token significatif de `duree estimee
         # 50 minutes` ne survit (les seuls tokens >=4 chars du titre sont
         # `duree` et `estimee` -- le head ne contient ni l'un ni l'autre).
@@ -336,8 +337,12 @@ class TestScan:
 
     def test_structure_drift(self, tmp_path: Path):
         # Nombre de cellules markdown different entre base et head ->
-        # STRUCTURE_DRIFT (PAS de comparaison elementaire).
-        nb_base = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"), _md("## Section B\n\n"))
+        # STRUCTURE_DRIFT informatif + la detection de perte TOURNE quand
+        # meme (fix du court-circuit). Le titre perdu porte des tokens
+        # UNIQUES (duree/estimee) pour ne pas tomber dans SUBSTANCE_FOUND
+        # par token partage avec un autre titre (cf. test_section_lost).
+        nb_base = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"),
+                      _md("### Duree estimee : 50 minutes\n\nSuite.\n\n"))
         nb_head = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"))
         import subprocess
         p = tmp_path / "sd.ipynb"
@@ -353,6 +358,13 @@ class TestScan:
         assert "error" not in result
         kinds = [f["kind"] for f in result["findings"]]
         assert "STRUCTURE_DRIFT" in kinds
+        # La perte REELLE (Duree estimee disparue, substance introuvable)
+        # reste detectee MALGRE le drift -- le drift ne court-circuite plus
+        # la detection.
+        assert "LOST_SECTION" in kinds
+        blocking_kinds = [f["kind"] for f in dpl._blocking_findings(result["findings"])]
+        assert "STRUCTURE_DRIFT" not in blocking_kinds
+        assert "LOST_SECTION" in blocking_kinds
 
     def test_new_file_exempt(self, tmp_path: Path):
         # Notebook NOUVEAU (absent de la base) -> exempt (rien a perdre, tout
@@ -381,10 +393,30 @@ class TestScan:
         assert st["base_headings"] == 0
         assert st["head_headings"] == 2
 
+    def test_structure_drift_pure_addition_not_blocking(self, tmp_path: Path):
+        # AJOUT pur d'une cellule markdown (le geste d'enrichissement
+        # standard -- cas #15403) : drift rapporte mais AUCUN titre perdu
+        # -> rien de bloquant.
+        nb_base = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"))
+        nb_head = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"),
+                      _md("## Ce qu'il faut retenir\n\nCloture.\n\n"))
+        import subprocess
+        p = tmp_path / "sd_add.ipynb"
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "sd_add.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
 
-# ---------------------------------------------------------------------------
-# 6. Justification par-section depuis le body PR
-# ---------------------------------------------------------------------------
+        result = dpl.scan_notebook(p, base_ref="HEAD", head_ref=None)
+        assert "error" not in result
+        kinds = [f["kind"] for f in result["findings"]]
+        assert kinds == ["STRUCTURE_DRIFT"]
+        assert dpl._blocking_findings(result["findings"]) == []
+        assert result["stats"]["cell_count_stable"] is False
+
 class TestBodyJustification:
     def test_marker_normalizes(self):
         # Le marker est compare a la forme NORMALISEE du titre de plan.
@@ -470,6 +502,26 @@ class TestMain:
         # Le marker couvre `duree est longue` (normalise) ; le finding
         # correspondant est JUSTIFIED -> pas bloquant -> rc=0.
         assert rc == 0, f"rc={rc}, expected 0 (justified)"
+
+    def test_pure_addition_exits_zero(self, tmp_path: Path, capsys):
+        # Enrichissement qui AJOUTE une cellule markdown, aucun titre perdu
+        # (cas #15403) : STRUCTURE_DRIFT informatif, rc=0.
+        import subprocess
+        p = tmp_path / "add.ipynb"
+        nb_base = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"))
+        nb_head = _nb(_md("# Plan\n\n"), _md("## Section A\n\n"),
+                      _md("## Ce qu'il faut retenir\n\nCloture.\n\n"))
+        _write_nb(p, nb_base)
+        subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t.t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "add", "add.ipynb"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "b", "-q"], check=True)
+        _write_nb(p, nb_head)
+        rc = dpl.main([str(p), "--base", "HEAD", "--check"])
+        captured = capsys.readouterr()
+        assert rc == 0, f"expected rc=0, got stdout={captured.out!r}, stderr={captured.err!r}"
+        assert "STRUCTURE_DRIFT" in captured.out
 
     def test_unjustified_lost_exits_one(self, tmp_path: Path):
         # LOST_SECTION SANS body marker -> rc=1.


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #15403

## Livrable

Repair P0 du cycle : le garde plan-loss rougissait sur des PR saines. `STRUCTURE_DRIFT` était un finding **bloquant** qui court-circuitait les passes candidats/substance dès qu'une PR changeait le compte de cellules markdown — or **ajouter** une cellule markdown est le geste d'enrichissement standard du dépôt (c'est littéralement le métier de notebook-enricher).

### Défaut mesuré (ce cycle)

| PR | Symptôme | Vérification firsthand |
|---|---|---|
| **#15403** (ma PR densité QC-Py-30) | check `No notebook plan loss` FAIL + PR gate FAIL | détecteur rejoué localement : `STRUCTURE_DRIFT base=39 -> head=40`, **0 candidat, 0 lost_section**, headings 25→26 — un ajout pur, rien à perdre |
| **#15390** (App-18c, autre lane) | même check FAIL 13 s | même message d'annotation ; le workflow logge un texte identique pour tout rc=1 (le défaut de lisibilité disparaît avec le fix : rc=1 ne surviendra plus que pour de vraies `LOST_SECTION`) |

Le marker de body (#14532 item 3) n'exonère que `LOST_SECTION` — aucune voie d'exonération pour le drift : l'échappatoire documentée ne couvrait pas ce cas.

### Pourquoi la borne était excessive (preuve par le code)

Les passes aval sont **position-indépendantes** : diff d'**ENSEMBLES** de titres normalisés, puis recherche de substance par bold inline et par texte global (`base_cell_idx` n'est que du reporting). Une fusion/scission de cellules ne peut pas y cacher une perte — un titre disparu reste absent de l'ensemble head, substance comprise. La borne était transposée de `detect_md_content_loss.py` (#8655 design 1), où la comparaison de volume **par cellule** exige, elle, un appariement positionnel. La docstring du garde le disait elle-même : « le diff de PLAN est lui-même robuste au décalage ».

### Le fix

- le drift est **rapporté mais ne court-circuite plus** : les passes candidats/substance tournent toujours ;
- `STRUCTURE_DRIFT` devient un signal **informatif, non bloquant** (verdict `--check` filtré par le nouveau helper testable `_blocking_findings`) ;
- `stats.cell_count_stable` porte la valeur réelle (était codée `True` sur le chemin post-borne) ;
- docstring module mise à jour (c'est la spec du garde).

**Aucun trou créé** : un titre réellement disparu et introuvable reste `LOST_SECTION` bloquant, drift ou pas — le fix ne peut que réduire les blocages, jamais les pertes détectées.

## Validation (post-fix, sur la tête rebasée 9fd265e8c5 (rebase post-merge #15364))

| Organe | Résultat |
|---|---|
| `pytest test_detect_notebook_plan_loss.py` | **33 PASS / 0 FAIL** (30 sur la première tête ; 28 avant ce fix) |
| Cas drift + perte réelle | `LOST_SECTION` détecté **malgré** le drift (le renforcement du test existant le prouve — c'est le cœur du fix) |
| Cas ajout pur | findings = `[STRUCTURE_DRIFT]` seul, `_blocking_findings` vide, CLI `--check` **rc=0** |
| Cas réel #15403 | détecteur fixé vs `origin/feature/11601-qcpy30-density` : **rc=0**, drift informatif, 0 lost |
| Cas fondateur #14532 | `test_section_lost_raises_finding` inchangé et vert (la détection d'origine survit) |

Voir #14532 (le garde) · FP mesurés : #15403, #15390.

## Périmètre

2 fichiers touchés : scripts/notebook_tools/detect_notebook_plan_loss.py, scripts/notebook_tools/tests/test_detect_notebook_plan_loss.py.

