### PR TITLE
fix(genai,15041): Copilot SDK — squelettes d'exercices extraits du markdown en vraies cellules code (G06 cas B)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb
@@ -1073,23 +1073,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercice 1 — invoquer `/prompt` et observer le flux SSE",
-    "",
-    "Complète la cellule suivante pour appeler le endpoint Scrutor `/prompt` avec une question courte (par exemple *« Quelle est la capitale du Japon ? »*) et observer le flux SSE chunk par chunk. Le format SSE rend chaque fragment précédé de `data: ` et terminé par `\\n\\n` — utilise `StreamReader.ReadLineAsync()` pour les séparer.",
-    "",
-    "Indice : il faut invoquer `POST http://127.0.0.1:5299/prompt` avec un body JSON `{ \"prompt\": \"...\" }` (le record C# s'appelle `PromptRequest(string Prompt)` et `System.Text.Json` est configuré en mode web par défaut dans ASP.NET Core 9, donc la propriété est `prompt` en snake-case). Garde le timeout HTTP à 30 s.",
-    "",
-    "**Critère de validation** : la cellule affiche le nombre de chunks SSE reçus, le premier chunk commence par `data:` et la concaténation forme une réponse cohérente sur le sujet posé.",
-    ""
+    "## Exercice 1 — invoquer `/prompt` et observer le flux SSE\n",
+    "\n",
+    "Complète la cellule suivante pour appeler le endpoint Scrutor `/prompt` avec une question courte (par exemple *« Quelle est la capitale du Japon ? »*) et observer le flux SSE chunk par chunk. Le format SSE rend chaque fragment précédé de `data: ` et terminé par `\\n\\n` — utilise `StreamReader.ReadLineAsync()` pour les séparer.\n",
+    "\n",
+    "Indice : il faut invoquer `POST http://127.0.0.1:5299/prompt` avec un body JSON `{ \"prompt\": \"...\" }` (le record C# s'appelle `PromptRequest(string Prompt)` et `System.Text.Json` est configuré en mode web par défaut dans ASP.NET Core 9, donc la propriété est `prompt` en snake-case). Garde le timeout HTTP à 30 s.\n",
+    "\n",
+    "**Critère de validation** : la cellule affiche le nombre de chunks SSE reçus, le premier chunk commence par `data:` et la concaténation forme une réponse cohérente sur le sujet posé."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "// EXERCICE 1 : POST /prompt et lecture du flux SSE.",
-    "// A compléter : envoyer la requête, lire le stream ligne par ligne, compter les chunks.",
-    "",
+    "// EXERCICE 1 : POST /prompt et lecture du flux SSE.\n",
+    "// A compléter : envoyer la requête, lire le stream ligne par ligne, compter les chunks.\n",
+    "\n",
     "Console.WriteLine(\"Exercice 1 à compléter : invoquer /prompt et compter les chunks SSE.\");"
    ],
    "execution_count": null,
@@ -1099,23 +1098,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercice 2 — généraliser Scrutor avec `MapEndpoints`",
-    "",
-    "L'exercice 1 du notebook [`04-Aspire-Streaming-Agent.ipynb`](../Aspire/04-Aspire-Streaming-Agent.ipynb) t'a fait réécrire un endpoint typé. Ici, on te demande de **généraliser la glue Scrutor** : la méthode `MapEndpoints` doit itérer sur `IEnumerable<IEndpoint>` résolu par DI et appeler `Map(...)` sur chacun. Vérifie aussi que `HealthEndpoint` est bien dans la liste retournée par `provider.GetServices<IEndpoint>()`.",
-    "",
-    "Indice : inspire-toi de la cellule 10. Le code complet est déjà dans `CopilotAgent.App/Program.cs` — compare avec ta version pour voir ce qui manque.",
-    "",
-    "**Critère de validation** : ta méthode `MapEndpoints` est appelée après `app.Build()` dans `CopilotAgent.App/Program.cs`, et `GET /health` retourne le JSON attendu.",
-    ""
+    "## Exercice 2 — généraliser Scrutor avec `MapEndpoints`\n",
+    "\n",
+    "L'exercice 1 du notebook [`04-Aspire-Streaming-Agent.ipynb`](../Aspire/04-Aspire-Streaming-Agent.ipynb) t'a fait réécrire un endpoint typé. Ici, on te demande de **généraliser la glue Scrutor** : la méthode `MapEndpoints` doit itérer sur `IEnumerable<IEndpoint>` résolu par DI et appeler `Map(...)` sur chacun. Vérifie aussi que `HealthEndpoint` est bien dans la liste retournée par `provider.GetServices<IEndpoint>()`.\n",
+    "\n",
+    "Indice : inspire-toi de la cellule 10. Le code complet est déjà dans `CopilotAgent.App/Program.cs` — compare avec ta version pour voir ce qui manque.\n",
+    "\n",
+    "**Critère de validation** : ta méthode `MapEndpoints` est appelée après `app.Build()` dans `CopilotAgent.App/Program.cs`, et `GET /health` retourne le JSON attendu."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "// EXERCICE 2 : généraliser la glue Scrutor.",
-    "// A compléter : déclarer IServiceCollection ScanEndpoints(I), IEndpointRouteBuilder MapEndpoints(I).",
-    "",
+    "// EXERCICE 2 : généraliser la glue Scrutor.\n",
+    "// A compléter : déclarer IServiceCollection ScanEndpoints(I), IEndpointRouteBuilder MapEndpoints(I).\n",
+    "\n",
     "Console.WriteLine(\"Exercice 2 à compléter : ScanEndpoints + MapEndpoints typés.\");"
    ],
    "execution_count": null,
@@ -1125,24 +1123,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercice 3 — câbler BYOK Azure OpenAI via `Provider` config",
-    "",
-    "Le SDK supporte Azure OpenAI en configurant `SessionConfig.Provider` avec un objet qui porte l'endpoint Azure, le déploiement, et la clé API. Sans cette clé (variable d'environnement `AZURE_OPENAI_API_KEY`), le notebook doit **stubber** le client (cf. règle C.1 : pas de `raise NotImplementedError`).",
-    "",
-    "Indice : en SDK 1.0.11, `Provider` est un objet `IDictionary<string, object>` (ou un type concret `CopilotProvider` — voir la doc NuGet 1.0.11). Les clés typiques sont `\"kind\"`, `\"base_url\"`, `\"api_key\"`, `\"wire_api\"`. Quand la clé Azure manque, le notebook doit afficher un message clair et un lien vers la doc, **pas** crasher.",
-    "",
-    "**Critère de validation** : sans clé, la cellule rend un message stub propre et un lien vers la doc NuGet ; avec une clé factice (variable d'env), elle tente la session et affiche l'erreur venue du provider (pas une `NullReferenceException`).",
-    ""
+    "## Exercice 3 — câbler BYOK Azure OpenAI via `Provider` config\n",
+    "\n",
+    "Le SDK supporte Azure OpenAI en configurant `SessionConfig.Provider` avec un objet qui porte l'endpoint Azure, le déploiement, et la clé API. Sans cette clé (variable d'environnement `AZURE_OPENAI_API_KEY`), le notebook doit **stubber** le client (cf. règle C.1 : pas de `raise NotImplementedError`).\n",
+    "\n",
+    "Indice : en SDK 1.0.11, `Provider` est un objet `IDictionary<string, object>` (ou un type concret `CopilotProvider` — voir la doc NuGet 1.0.11). Les clés typiques sont `\"kind\"`, `\"base_url\"`, `\"api_key\"`, `\"wire_api\"`. Quand la clé Azure manque, le notebook doit afficher un message clair et un lien vers la doc, **pas** crasher.\n",
+    "\n",
+    "**Critère de validation** : sans clé, la cellule rend un message stub propre et un lien vers la doc NuGet ; avec une clé factice (variable d'env), elle tente la session et affiche l'erreur venue du provider (pas une `NullReferenceException`)."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "// EXERCICE 3 : câbler BYOK Azure OpenAI via Provider (stubbé sans clé).",
-    "// A compléter : si AZURE_OPENAI_API_KEY est défini, créer une session avec Provider azure.",
-    "//                sinon, afficher un stub C.1-conform qui pointe vers la doc.",
-    "",
+    "// EXERCICE 3 : câbler BYOK Azure OpenAI via Provider (stubbé sans clé).\n",
+    "// A compléter : si AZURE_OPENAI_API_KEY est défini, créer une session avec Provider azure.\n",
+    "//                sinon, afficher un stub C.1-conform qui pointe vers la doc.\n",
+    "\n",
     "Console.WriteLine(\"Exercice 3 à compléter : branchement BYOK Azure OpenAI.\");"
    ],
    "execution_count": null,

--- a/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb
@@ -1071,67 +1071,82 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf64d643",
    "metadata": {},
    "source": [
-    "## Exercice 1 — invoquer `/prompt` et observer le flux SSE\n",
-    "\n",
-    "Complète la cellule suivante pour appeler le endpoint Scrutor `/prompt` avec une question courte (par exemple *« Quelle est la capitale du Japon ? »*) et observer le flux SSE chunk par chunk. Le format SSE rend chaque fragment précédé de `data: ` et terminé par `\\n\\n` — utilise `StreamReader.ReadLineAsync()` pour les séparer.\n",
-    "\n",
-    "Indice : il faut invoquer `POST http://127.0.0.1:5299/prompt` avec un body JSON `{ \"prompt\": \"...\" }` (le record C# s'appelle `PromptRequest(string Prompt)` et `System.Text.Json` est configuré en mode web par défaut dans ASP.NET Core 9, donc la propriété est `prompt` en snake-case). Garde le timeout HTTP à 30 s.\n",
-    "\n",
-    "```csharp\n",
-    "// EXERCICE 1 : POST /prompt et lecture du flux SSE.\n",
-    "// A compléter : envoyer la requête, lire le stream ligne par ligne, compter les chunks.\n",
-    "\n",
-    "Console.WriteLine(\"Exercice 1 à compléter : invoquer /prompt et compter les chunks SSE.\");\n",
-    "```\n",
-    "\n",
-    "**Critère de validation** : la cellule affiche le nombre de chunks SSE reçus, le premier chunk commence par `data:` et la concaténation forme une réponse cohérente sur le sujet posé."
+    "## Exercice 1 — invoquer `/prompt` et observer le flux SSE",
+    "",
+    "Complète la cellule suivante pour appeler le endpoint Scrutor `/prompt` avec une question courte (par exemple *« Quelle est la capitale du Japon ? »*) et observer le flux SSE chunk par chunk. Le format SSE rend chaque fragment précédé de `data: ` et terminé par `\\n\\n` — utilise `StreamReader.ReadLineAsync()` pour les séparer.",
+    "",
+    "Indice : il faut invoquer `POST http://127.0.0.1:5299/prompt` avec un body JSON `{ \"prompt\": \"...\" }` (le record C# s'appelle `PromptRequest(string Prompt)` et `System.Text.Json` est configuré en mode web par défaut dans ASP.NET Core 9, donc la propriété est `prompt` en snake-case). Garde le timeout HTTP à 30 s.",
+    "",
+    "**Critère de validation** : la cellule affiche le nombre de chunks SSE reçus, le premier chunk commence par `data:` et la concaténation forme une réponse cohérente sur le sujet posé.",
+    ""
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c32436b4",
+   "cell_type": "code",
    "metadata": {},
    "source": [
-    "## Exercice 2 — généraliser Scrutor avec `MapEndpoints`\n",
-    "\n",
-    "L'exercice 1 du notebook [`04-Aspire-Streaming-Agent.ipynb`](../Aspire/04-Aspire-Streaming-Agent.ipynb) t'a fait réécrire un endpoint typé. Ici, on te demande de **généraliser la glue Scrutor** : la méthode `MapEndpoints` doit itérer sur `IEnumerable<IEndpoint>` résolu par DI et appeler `Map(...)` sur chacun. Vérifie aussi que `HealthEndpoint` est bien dans la liste retournée par `provider.GetServices<IEndpoint>()`.\n",
-    "\n",
-    "Indice : inspire-toi de la cellule 10. Le code complet est déjà dans `CopilotAgent.App/Program.cs` — compare avec ta version pour voir ce qui manque.\n",
-    "\n",
-    "```csharp\n",
-    "// EXERCICE 2 : généraliser la glue Scrutor.\n",
-    "// A compléter : déclarer IServiceCollection ScanEndpoints(I), IEndpointRouteBuilder MapEndpoints(I).\n",
-    "\n",
-    "Console.WriteLine(\"Exercice 2 à compléter : ScanEndpoints + MapEndpoints typés.\");\n",
-    "```\n",
-    "\n",
-    "**Critère de validation** : ta méthode `MapEndpoints` est appelée après `app.Build()` dans `CopilotAgent.App/Program.cs`, et `GET /health` retourne le JSON attendu."
-   ]
+    "// EXERCICE 1 : POST /prompt et lecture du flux SSE.",
+    "// A compléter : envoyer la requête, lire le stream ligne par ligne, compter les chunks.",
+    "",
+    "Console.WriteLine(\"Exercice 1 à compléter : invoquer /prompt et compter les chunks SSE.\");"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
-   "id": "33bc0c0f",
    "metadata": {},
    "source": [
-    "## Exercice 3 — câbler BYOK Azure OpenAI via `Provider` config\n",
-    "\n",
-    "Le SDK supporte Azure OpenAI en configurant `SessionConfig.Provider` avec un objet qui porte l'endpoint Azure, le déploiement, et la clé API. Sans cette clé (variable d'environnement `AZURE_OPENAI_API_KEY`), le notebook doit **stubber** le client (cf. règle C.1 : pas de `raise NotImplementedError`).\n",
-    "\n",
-    "Indice : en SDK 1.0.11, `Provider` est un objet `IDictionary<string, object>` (ou un type concret `CopilotProvider` — voir la doc NuGet 1.0.11). Les clés typiques sont `\"kind\"`, `\"base_url\"`, `\"api_key\"`, `\"wire_api\"`. Quand la clé Azure manque, le notebook doit afficher un message clair et un lien vers la doc, **pas** crasher.\n",
-    "\n",
-    "```csharp\n",
-    "// EXERCICE 3 : câbler BYOK Azure OpenAI via Provider (stubbé sans clé).\n",
-    "// A compléter : si AZURE_OPENAI_API_KEY est défini, créer une session avec Provider azure.\n",
-    "//                sinon, afficher un stub C.1-conform qui pointe vers la doc.\n",
-    "\n",
-    "Console.WriteLine(\"Exercice 3 à compléter : branchement BYOK Azure OpenAI.\");\n",
-    "```\n",
-    "\n",
-    "**Critère de validation** : sans clé, la cellule rend un message stub propre et un lien vers la doc NuGet ; avec une clé factice (variable d'env), elle tente la session et affiche l'erreur venue du provider (pas une `NullReferenceException`)."
+    "## Exercice 2 — généraliser Scrutor avec `MapEndpoints`",
+    "",
+    "L'exercice 1 du notebook [`04-Aspire-Streaming-Agent.ipynb`](../Aspire/04-Aspire-Streaming-Agent.ipynb) t'a fait réécrire un endpoint typé. Ici, on te demande de **généraliser la glue Scrutor** : la méthode `MapEndpoints` doit itérer sur `IEnumerable<IEndpoint>` résolu par DI et appeler `Map(...)` sur chacun. Vérifie aussi que `HealthEndpoint` est bien dans la liste retournée par `provider.GetServices<IEndpoint>()`.",
+    "",
+    "Indice : inspire-toi de la cellule 10. Le code complet est déjà dans `CopilotAgent.App/Program.cs` — compare avec ta version pour voir ce qui manque.",
+    "",
+    "**Critère de validation** : ta méthode `MapEndpoints` est appelée après `app.Build()` dans `CopilotAgent.App/Program.cs`, et `GET /health` retourne le JSON attendu.",
+    ""
    ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "// EXERCICE 2 : généraliser la glue Scrutor.",
+    "// A compléter : déclarer IServiceCollection ScanEndpoints(I), IEndpointRouteBuilder MapEndpoints(I).",
+    "",
+    "Console.WriteLine(\"Exercice 2 à compléter : ScanEndpoints + MapEndpoints typés.\");"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 — câbler BYOK Azure OpenAI via `Provider` config",
+    "",
+    "Le SDK supporte Azure OpenAI en configurant `SessionConfig.Provider` avec un objet qui porte l'endpoint Azure, le déploiement, et la clé API. Sans cette clé (variable d'environnement `AZURE_OPENAI_API_KEY`), le notebook doit **stubber** le client (cf. règle C.1 : pas de `raise NotImplementedError`).",
+    "",
+    "Indice : en SDK 1.0.11, `Provider` est un objet `IDictionary<string, object>` (ou un type concret `CopilotProvider` — voir la doc NuGet 1.0.11). Les clés typiques sont `\"kind\"`, `\"base_url\"`, `\"api_key\"`, `\"wire_api\"`. Quand la clé Azure manque, le notebook doit afficher un message clair et un lien vers la doc, **pas** crasher.",
+    "",
+    "**Critère de validation** : sans clé, la cellule rend un message stub propre et un lien vers la doc NuGet ; avec une clé factice (variable d'env), elle tente la session et affiche l'erreur venue du provider (pas une `NullReferenceException`).",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "// EXERCICE 3 : câbler BYOK Azure OpenAI via Provider (stubbé sans clé).",
+    "// A compléter : si AZURE_OPENAI_API_KEY est défini, créer une session avec Provider azure.",
+    "//                sinon, afficher un stub C.1-conform qui pointe vers la doc.",
+    "",
+    "Console.WriteLine(\"Exercice 3 à compléter : branchement BYOK Azure OpenAI.\");"
+   ],
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/genai #15376

## G06 cas B — squelettes C# extraits du markdown en vraies cellules code

Grain Vibe `15041-csk-extract` — audit G06 **cas B** de #15041 (epic #15035). Le cas D (`emb-experience`) est suivi séparément : cette PR ne porte que le notebook CopilotSDK.

Run Mistral Vibe du 2026-09-09 15:56Z (PROMPT_OK, 193 s) + relay po-2025.

### Changement — `MyIA.AI.Notebooks/GenAI/Integrations-DotNet/CopilotSDK/01-GitHub-Copilot-SDK-Binding.ipynb`

- Les trois cellules markdown d'exercices ne portent plus le squelette dans un bloc ```csharp enfoui dans le markdown (le défaut de l'audit : la cellule de code promise n'existait pas).
- Trois cellules code insérées immédiatement après chaque énoncé, contenant le squelette extrait verbatim (commentaires « à compléter » + `Console.WriteLine` d'attente, règle C.1 : inoffensif à l'exécution).
- 19 → 22 cellules. Énoncés, indices et critères de validation inchangés ; cellules 0-15 (démos, conclusion) intactes.

### Relay po-2025 — correction + vérification

- Le run Vibe avait livré la bonne structure mais avec les retours à la ligne collapsés : cellules code mono-lignes donc inertes en C# (tout après le premier `//` est avalé) et énoncés reformattés. Défaut connu du lane Vibe.
- Le relay reconstruit les 6 cellules de façon déterministe depuis la base `f9bf4229f` : cellule code = fence extraite verbatim, énoncé = markdown moins la fence.
- Vérifié : JSON valide ; 22 cellules ; cellules 0-15 identiques à la base ; zéro bloc ```csharp restant dans les trois énoncés ; cellules code multi-lignes se terminant par l'instruction d'attente ; `execution_count` null, `outputs` [] ; aucune violation C.1.
- Notebook inchangé sur main entre `f9bf4229f` et `ef62273ed` (diff vide) — pas de divergence de fond.

🤖 Generated with [Claude Code](https://claude.com/claude/code)
