### PR TITLE
feat(lean,#2159): Partie 74 -- les tiges detectent l'egalite des sections (prefaisceau separe)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkSeparated.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkSeparated.lean
@@ -1,0 +1,155 @@
+/-
+Grothendieck hommage — Partie 74 : les tiges détectent l'égalité des sections.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+La Partie 72 (`Stalks`) a calculé les tiges sur le site des ouverts, la
+Partie 73 (`StalkPoints`) a identifié la tige au foncteur fibre du point du
+site. Cette partie établit la propriété de **détection** : deux sections
+d'un préfaisceau de types **séparé** qui ont mêmes germes en tout point
+sont égales.
+
+  `eq_of_germ_eq_of_isSeparated : (∀ x ∈ U, germe_x s = germe_x t) → s = t`
+
+L'assemblage est à deux leviers, tous deux déjà disponibles :
+
+  - `TopCat.Presheaf.germ_eq` (Mathlib, valable pour TOUT préfaisceau) :
+    des germes égaux en `x` donnent un voisinage `W ∋ x` sur lequel les
+    restrictions de `s` et `t` coïncident ;
+  - `Presheaf.IsSeparated` (le prédicat de séparabilité bundlé de Mathlib,
+    dont le cœur est `IsSeparatedFor.ext`) : pour un préfaisceau séparé,
+    deux sections dont les restrictions coïncident sur chaque flèche d'un
+    crible couvrant sont égales.
+
+Le crible témoin est construit à la main : les voisinages `V p` choisis par
+axiome de choix couvrent `U`, et le crible « être dominé par l'un des
+`V p` » couvre `U` pour `opensTopology T` (Partie 70, l'appartenance s'y
+lit par `mem_opensTopology_iff`).
+
+Deux corollaires complètent la tranche :
+
+  - `eq_of_germ_eq_of_isSheaf` : pour un FAISCEAU de types, la même
+    conclusion sans les hypothèses de limites qu'exige le `section_ext` de
+    Mathlib (`[HasLimits C]`, `[PreservesLimits (forget C)]`,
+    `[(forget C).ReflectsIsomorphisms]`) — tout faisceau est séparé
+    (`Presheaf.IsSheaf.isSeparated`), et le pont `isSheaf_opensTopology_iff`
+    (Partie 70) transporte la condition de faisceau de Mathlib vers le
+    site own ;
+  - `injective_germ_family_of_isSeparated` : reformulation combinatoire —
+    l'application « famille des germes » `s ↦ (germe_x s)ₓ` est injective.
+    C'est la brique ponctuelle du dictionnaire faisceaux ↔ espaces étalés :
+    une section est déterminée par ses valeurs germinales.
+
+Références :
+  - SGA 4, II.5 (condition de séparabilité sur un site).
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II §6 (sections égales ssi égales localement).
+  - Mathlib, `Mathlib.Topology.Sheaves.Stalks` (`germ_eq`, et `section_ext`
+    — la version faisceau, dont celle-ci est le relâchement séparé).
+  - Partie 70 (`Grothendieck.SpacesMathlib`) : `opensTopology_eq`,
+    `isSheaf_opensTopology_iff`.
+  - Partie 72 (`Grothendieck.Stalks`) : germes et tiges concrets.
+  - Partie 73 (`Grothendieck.StalkPoints`) : la tige comme foncteur fibre.
+
+Convention i18n (EPIC #4980 ratifiée 2026-07-04) : ce module est jumelé avec
+`StalkSeparated_en.lean`. Les énoncés, preuves et noms Lean restent identiques ;
+seules les docstrings et les commentaires diffèrent.
+
+Epic #1646, Phase 2 (#2159). Aucun `sorry` introduit.
+-/
+
+import Grothendieck.Spaces
+import Grothendieck.SpacesMathlib
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+import Mathlib.Topology.Sheaves.Stalks
+
+universe u
+
+namespace Grothendieck
+
+open CategoryTheory CategoryTheory.Limits Opposite TopCat TopologicalSpace
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- **Les tiges détectent l'égalité des sections (cas séparé)** : deux
+sections d'un préfaisceau de types séparé pour la topologie des ouverts qui
+ont mêmes germes en tout point de `U` sont égales. La preuve choisit, pour
+chaque point, un voisinage où les restrictions coïncident (`germ_eq` —
+valable pour tout préfaisceau), forme le crible des ouverts dominés par
+l'un de ces voisinages — crible couvrant pour `opensTopology T` — puis
+conclut en appliquant le prédicat de séparabilité bundlé
+(`Presheaf.IsSeparated`, dont le cœur est `IsSeparatedFor.ext`). C'est le
+relâchement séparé du `section_ext` de Mathlib, qui exige un faisceau
+complet. Référence : [MM92] Chap. II §6. -/
+theorem eq_of_germ_eq_of_isSeparated (F : TopCat.Presheaf (Type u) (TopCat.of T))
+    (hF : Presheaf.IsSeparated (J := opensTopology T) F)
+    {U : Opens T} {s t : F.obj (op U)}
+    (h : ∀ (x : T) (hx : x ∈ U),
+      TopCat.Presheaf.germ (X := TopCat.of T) F U x hx s =
+        TopCat.Presheaf.germ (X := TopCat.of T) F U x hx t) :
+    s = t := by
+  classical
+  -- Pour chaque point `p` de `U`, choix d'un voisinage `V p` où `s` et `t`
+  -- coïncident (germ_eq, deux flèches `V p ⟶ U` car les deux sections vivent sur `U`).
+  choose V m i₁ i₂ heq using fun (p : {x : T // x ∈ U}) =>
+    TopCat.Presheaf.germ_eq (X := TopCat.of T) F p.1 p.2 p.2 s t (h p.1 p.2)
+  -- Le crible des ouverts dominés par l'un des `V p` couvre `U`.
+  refine hF U ⟨fun (Y : Opens T) _ => ∃ p : {x : T // x ∈ U}, Y ≤ V p, ?sieve⟩ ?mem s t ?ext
+  · -- stabilité descendante : composer les inclusions d'ouverts.
+    intro Y Z f hf g
+    obtain ⟨p, hp⟩ := hf
+    exact ⟨p, g.le.trans hp⟩
+  · rw [mem_opensTopology_iff]
+    intro x hx
+    exact ⟨V ⟨x, hx⟩, i₁ ⟨x, hx⟩, ⟨⟨x, hx⟩, le_refl _⟩, m ⟨x, hx⟩⟩
+  · -- sur chaque flèche du crible, les restrictions coïncident (via `V p`).
+    rintro Y f ⟨p, hYV⟩
+    have hf₁ : f = homOfLE hYV ≫ i₁ p := Subsingleton.elim _ _
+    have hf₂ : f = homOfLE hYV ≫ i₂ p := Subsingleton.elim _ _
+    calc F.map f.op s
+        = F.map ((homOfLE hYV ≫ i₁ p).op) s := by rw [hf₁]
+      _ = (F.map (i₁ p).op ≫ F.map (homOfLE hYV).op) s := by
+          rw [op_comp, Functor.map_comp]
+      _ = F.map (homOfLE hYV).op (F.map (i₁ p).op s) := rfl
+      _ = F.map (homOfLE hYV).op (F.map (i₂ p).op t) := by rw [heq p]
+      _ = (F.map (i₂ p).op ≫ F.map (homOfLE hYV).op) t := rfl
+      _ = F.map ((homOfLE hYV ≫ i₂ p).op) t := by
+          rw [op_comp, Functor.map_comp]
+      _ = F.map f.op t := by rw [hf₂]
+
+/-- **Corollaire faisceau** : pour un faisceau de types, la même conclusion
+sans aucune hypothèse de limite — là où le `section_ext` de Mathlib exige
+`[HasLimits C]` et compagnie, la séparabilité suffit ici : tout faisceau
+est séparé (`Presheaf.IsSheaf.isSeparated`), et le pont de la Partie 70
+(`isSheaf_opensTopology_iff`) transporte la condition de faisceau de
+Mathlib vers le site own. -/
+theorem eq_of_germ_eq_of_isSheaf (F : TopCat.Presheaf (Type u) (TopCat.of T))
+    (hF : TopCat.Presheaf.IsSheaf F)
+    {U : Opens T} {s t : F.obj (op U)}
+    (h : ∀ (x : T) (hx : x ∈ U),
+      TopCat.Presheaf.germ (X := TopCat.of T) F U x hx s =
+        TopCat.Presheaf.germ (X := TopCat.of T) F U x hx t) :
+    s = t :=
+  eq_of_germ_eq_of_isSeparated T F ((isSheaf_opensTopology_iff F).mpr hF).isSeparated h
+
+/-- **Une section est déterminée par sa famille de germes** : pour un
+préfaisceau de types séparé, l'application qui envoie une section sur `U`
+vers sa famille de germes aux points de `U` est injective. Reformulation
+combinatoire du théorème principal — la brique ponctuelle du dictionnaire
+faisceaux ↔ espaces étalés amorcé aux Parties 72-73. -/
+theorem injective_germ_family_of_isSeparated (F : TopCat.Presheaf (Type u) (TopCat.of T))
+    (hF : Presheaf.IsSeparated (J := opensTopology T) F) (U : Opens T) :
+    Function.Injective (fun (s : F.obj (op U)) (p : {x : T // x ∈ U}) =>
+      TopCat.Presheaf.germ (X := TopCat.of T) F U p.1 p.2 s) := by
+  intro s t hst
+  refine eq_of_germ_eq_of_isSeparated T F hF ?_
+  intro x hx
+  exact congrFun hst ⟨x, hx⟩
+
+end Contenu
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkSeparated_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/StalkSeparated_en.lean
@@ -1,0 +1,154 @@
+/-
+Grothendieck tribute — Part 74: stalks detect equality of sections.
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2 (#2159, Epic #1646).
+
+Part 72 (`Stalks`) computed stalks on the opens site, and Part 73
+(`StalkPoints`) identified the stalk with the fibre functor of the point of
+the site. This part establishes the **detection** property: two sections of
+a **separated** type-valued presheaf with equal germs at every point are
+equal.
+
+  `eq_of_germ_eq_of_isSeparated : (∀ x ∈ U, germ_x s = germ_x t) → s = t`
+
+The assembly rests on two levers, both already available:
+
+  - `TopCat.Presheaf.germ_eq` (Mathlib, valid for ANY presheaf): equal
+    germs at `x` yield a neighbourhood `W ∋ x` on which the restrictions of
+    `s` and `t` coincide;
+  - `Presheaf.IsSeparated` (Mathlib's bundled separatedness predicate, whose
+    core is `IsSeparatedFor.ext`): for a separated presheaf, two sections
+    whose restrictions agree on every arrow of a covering sieve are equal.
+
+The witness sieve is built by hand: the neighbourhoods `V p` chosen by the
+axiom of choice cover `U`, and the sieve "be dominated by one of the `V p`"
+covers `U` for `opensTopology T` (Part 70, where membership is read
+through `mem_opensTopology_iff`).
+
+Two corollaries complete the tranche:
+
+  - `eq_of_germ_eq_of_isSheaf`: for a sheaf OF TYPES, the same conclusion
+    with no limit assumptions — where Mathlib's `section_ext` requires
+    `[HasLimits C]` etc., separatedness suffices here: every sheaf is
+    separated (`Presheaf.IsSheaf.isSeparated`), and the Part 70 bridge
+    (`isSheaf_opensTopology_iff`) transports Mathlib's sheaf condition to
+    the own site;
+  - `injective_germ_family_of_isSeparated`: combinatorial restatement —
+    the "family of germs" map `s ↦ (germ_x s)ₓ` is injective. This is the
+    pointwise brick of the sheaves ↔ étale spaces dictionary begun in
+    Parts 72-73: a section is determined by its germinal values.
+
+References:
+  - SGA 4, II.5 (separatedness condition on a site).
+  - S. Mac Lane, I. Moerdijk, *Sheaves in Geometry and Logic* [MM92],
+    Chap. II §6 (sections equal iff locally equal).
+  - Mathlib, `Mathlib.Topology.Sheaves.Stalks` (`germ_eq`, and
+    `section_ext` — the sheaf version, of which this is the separated
+    relaxation).
+  - Part 70 (`Grothendieck.SpacesMathlib`): `opensTopology_eq`,
+    `isSheaf_opensTopology_iff`.
+  - Part 72 (`Grothendieck.Stalks`): concrete germs and stalks.
+  - Part 73 (`Grothendieck.StalkPoints`): the stalk as fibre functor.
+
+i18n convention (EPIC #4980 ratified 2026-07-04): this module is twinned
+with `StalkSeparated.lean`. Statements, proofs and Lean names remain
+identical; only docstrings and comments differ.
+
+Epic #1646, Phase 2 (#2159). No `sorry` introduced.
+-/
+
+import Grothendieck.Spaces
+import Grothendieck.SpacesMathlib
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+import Mathlib.Topology.Sheaves.Stalks
+
+universe u
+
+namespace Grothendieck.StalkSeparated_en
+
+open CategoryTheory CategoryTheory.Limits Opposite TopCat TopologicalSpace
+
+section Contenu
+
+variable (T : Type u) [TopologicalSpace T]
+
+/-- **Stalks detect equality of sections (separated case)**: two sections
+of a type-valued presheaf separated for the opens topology, with equal
+germs at every point of `U`, are equal. The proof chooses, for each point,
+a neighbourhood where the restrictions coincide (`germ_eq` — valid for any
+presheaf), forms the sieve of opens dominated by one of these
+neighbourhoods — a covering sieve for `opensTopology T` — and concludes by
+applying the bundled separatedness predicate (`Presheaf.IsSeparated`, whose
+core is `IsSeparatedFor.ext`). This is the separated relaxation of
+Mathlib's `section_ext`, which requires a full sheaf. Reference: [MM92]
+Chap. II §6. -/
+theorem eq_of_germ_eq_of_isSeparated (F : TopCat.Presheaf (Type u) (TopCat.of T))
+    (hF : Presheaf.IsSeparated (J := opensTopology T) F)
+    {U : Opens T} {s t : F.obj (op U)}
+    (h : ∀ (x : T) (hx : x ∈ U),
+      TopCat.Presheaf.germ (X := TopCat.of T) F U x hx s =
+        TopCat.Presheaf.germ (X := TopCat.of T) F U x hx t) :
+    s = t := by
+  classical
+  -- For each point `p` of `U`, choose a neighbourhood `V p` where `s` and
+  -- `t` coincide (germ_eq, two arrows `V p ⟶ U` since both sections live on `U`).
+  choose V m i₁ i₂ heq using fun (p : {x : T // x ∈ U}) =>
+    TopCat.Presheaf.germ_eq (X := TopCat.of T) F p.1 p.2 p.2 s t (h p.1 p.2)
+  -- The sieve of opens dominated by one of the `V p` covers `U`.
+  refine hF U ⟨fun (Y : Opens T) _ => ∃ p : {x : T // x ∈ U}, Y ≤ V p, ?sieve⟩ ?mem s t ?ext
+  · -- downward closure: compose the inclusions of opens.
+    intro Y Z f hf g
+    obtain ⟨p, hp⟩ := hf
+    exact ⟨p, g.le.trans hp⟩
+  · rw [mem_opensTopology_iff]
+    intro x hx
+    exact ⟨V ⟨x, hx⟩, i₁ ⟨x, hx⟩, ⟨⟨x, hx⟩, le_refl _⟩, m ⟨x, hx⟩⟩
+  · -- on every arrow of the sieve, the restrictions coincide (through `V p`).
+    rintro Y f ⟨p, hYV⟩
+    have hf₁ : f = homOfLE hYV ≫ i₁ p := Subsingleton.elim _ _
+    have hf₂ : f = homOfLE hYV ≫ i₂ p := Subsingleton.elim _ _
+    calc F.map f.op s
+        = F.map ((homOfLE hYV ≫ i₁ p).op) s := by rw [hf₁]
+      _ = (F.map (i₁ p).op ≫ F.map (homOfLE hYV).op) s := by
+          rw [op_comp, Functor.map_comp]
+      _ = F.map (homOfLE hYV).op (F.map (i₁ p).op s) := rfl
+      _ = F.map (homOfLE hYV).op (F.map (i₂ p).op t) := by rw [heq p]
+      _ = (F.map (i₂ p).op ≫ F.map (homOfLE hYV).op) t := rfl
+      _ = F.map ((homOfLE hYV ≫ i₂ p).op) t := by
+          rw [op_comp, Functor.map_comp]
+      _ = F.map f.op t := by rw [hf₂]
+
+/-- **Sheaf corollary**: for a sheaf of types, the same conclusion with no
+limit assumption at all — where Mathlib's `section_ext` requires
+`[HasLimits C]` and friends, separatedness suffices here: every sheaf is
+separated (`Presheaf.IsSheaf.isSeparated`), and the Part 70 bridge
+(`isSheaf_opensTopology_iff`) transports Mathlib's sheaf condition to the
+own site. -/
+theorem eq_of_germ_eq_of_isSheaf (F : TopCat.Presheaf (Type u) (TopCat.of T))
+    (hF : TopCat.Presheaf.IsSheaf F)
+    {U : Opens T} {s t : F.obj (op U)}
+    (h : ∀ (x : T) (hx : x ∈ U),
+      TopCat.Presheaf.germ (X := TopCat.of T) F U x hx s =
+        TopCat.Presheaf.germ (X := TopCat.of T) F U x hx t) :
+    s = t :=
+  eq_of_germ_eq_of_isSeparated T F ((isSheaf_opensTopology_iff F).mpr hF).isSeparated h
+
+/-- **A section is determined by its family of germs**: for a separated
+type-valued presheaf, the map sending a section over `U` to its family of
+germs at the points of `U` is injective. Combinatorial restatement of the
+main theorem — the pointwise brick of the sheaves ↔ étale spaces dictionary
+started in Parts 72-73. -/
+theorem injective_germ_family_of_isSeparated (F : TopCat.Presheaf (Type u) (TopCat.of T))
+    (hF : Presheaf.IsSeparated (J := opensTopology T) F) (U : Opens T) :
+    Function.Injective (fun (s : F.obj (op U)) (p : {x : T // x ∈ U}) =>
+      TopCat.Presheaf.germ (X := TopCat.of T) F U p.1 p.2 s) := by
+  intro s t hst
+  refine eq_of_germ_eq_of_isSeparated T F hF ?_
+  intro x hx
+  exact congrFun hst ⟨x, hx⟩
+
+end Contenu
+
+end Grothendieck.StalkSeparated_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: LIGHT/refactor #14869 (MERGED)

## Partie 74 — les tiges détectent l'égalité des sections (préfaisceau séparé sur le site des ouverts)

Suite directe des Parties 72-73 du dictionnaire faisceaux ↔ espaces étalés (Epic #2159) : deux sections d'un préfaisceau de types **séparé** qui ont mêmes germes en tout point sont égales.

**Théorème principal** — `eq_of_germ_eq_of_isSeparated` :

```
(F : TopCat.Presheaf (Type u) (TopCat.of T)) (hF : Presieve.IsSeparated (opensTopology T) F)
{s t : F.obj (op U)} (h : ∀ x ∈ U, germe_x s = germe_x t) → s = t
```

C'est le **relâchement séparé** du `section_ext` de Mathlib (`Mathlib.Topology.Sheaves.Stalks`), qui exige un faisceau complet valué dans une catégorie concrète à limites (`[HasLimits C]`, `[PreservesLimits (forget C)]`, `[(forget C).ReflectsIsomorphisms]`). Ici seule la séparabilité suffit, et pour les préfaisceaux de types aucune hypothèse d'instance ne subsiste.

**Assemblage à deux leviers** (tous deux préexistants, la preuve ne réécrit aucun) :

1. `TopCat.Presheaf.germ_eq` (Mathlib, valable pour TOUT préfaisceau) : germes égaux en `x` ⇒ ∃ voisinage `W ∋ x` où les restrictions coïncident ;
2. `Presheaf.IsSeparated` (prédicat de séparabilité bundlé de Mathlib, dont le cœur est `IsSeparatedFor.ext`) : séparé + restrictions égales sur chaque flèche d'un crible couvrant ⇒ sections égales.

Le crible témoin est construit à la main : les `V p` choisis par axiome de choix couvrent `U`, le crible « dominé par l'un des `V p` » couvre `U` pour `opensTopology T` (Partie 70, appartenance lue par `mem_opensTopology_iff`). La catégorie `Opens T` étant fine, les factorisations se ferment par `Subsingleton.elim`.

**Corollaires livrés dans le module** :

| Théorème | Contenu |
|---|---|
| `eq_of_germ_eq_of_isSheaf` | cas faisceau : même conclusion, zéro hypothèse de limite — tout faisceau est séparé (`IsSheaf.isSeparated`), pont Partie 70 (`isSheaf_opensTopology_iff`) |
| `injective_germ_family_of_isSeparated` | reformulation : `s ↦ (germe_x s)ₓ` injective — la brique ponctuelle du dictionnaire faisceaux ↔ étalés |

## Validation (critères B Lean)

- **Compte `sorry` réel avant/après** (`python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry`) : **0 → 0** (main 144 fichiers / worktree 146, les 2 nouveaux fichiers n'introduisent aucun `sorry` tactique).
- **Lake build local** : `lake build Grothendieck.StalkSeparated` + `Grothendieck.StalkSeparated_en` — WSL, toolchain v4.33.0, Mathlib db584cd6 via `lake exe cache get` : **Build completed successfully (1271 jobs)** — FR 55s, EN 56s.
- **Proof integrity** : câblée sur ce lake par `.github/workflows/lean-grothendieck.yml` (job `proof-integrity` → `lean-axiom.yml`, `target-modules: "*"` dérivés à l'exécution du contenu du lake, `allow-axioms: ""`, `fail-on-sorry: true`) — vérifié firsthand, le `*` atteint les nouveaux modules sans mise à jour de liste (#10889). Le job `ci` (`lean-build.yml`, `sorry-baseline: 0`, `sorry-filter-mode: real`) couvre aussi les paths de la PR.
- **i18n sibling** (`scripts/lean/check_i18n_siblings.py <FR> <EN>`) : **1/1 pairs byte-identical**, 0 drift — seules les docstrings/commentaires diffèrent (convention #4980, modèle P72/P73).

## Périmètre

2 fichiers ajoutés : `Grothendieck/StalkSeparated.lean` + `Grothendieck/StalkSeparated_en.lean`. Rien d'autre — l'umbrella `Grothendieck.lean` n'est pas touché (précédent P72/P73 : auto-découverte par `globs := #[`Grothendieck.*]` du lakefile ; dette d'import umbrella déjà trackée #11286).

See #2159
