### PR TITLE
docs(claudish,#15418): réconcilier le guide proxy avec wires + cascade déployés

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
@@ -46,12 +46,12 @@ client ────────────────────────�
 └──────────────┘   └─────────────────┘   └──────────────────┘   │  Qwen / DeepSeek│
                           TLS, cache IIS        traduction wire  └─────────────────┘
                                                  + cascade + concurrence
-        agents distants (LAN) ──► sidecar ai-01 (192.168.0.46:3000) ──► même claudish
+        agents distants (LAN) ──► sidecar LAN ai-01 ──► même claudish
 ```
 
 - **claudish** tourne dans un conteneur Docker sur `po-2023`, port `3000` (hub).
 - La passerelle **IIS** (`models.myia.io`) termine le TLS et reverse-proxie vers le conteneur.
-- Le **sidecar ai-01** (`192.168.0.46:3000`) relaie en LAN pour les agents distants.
+- Le **sidecar LAN ai-01** relaie le hub pour les agents distants.
 - Les clients (agents Claude Code, clients OpenAI, bots Hermes/NanoClaw) pointent sur `https://models.myia.io` ou le sidecar selon leur position.
 
 ### Authentification client → claudish
@@ -189,7 +189,7 @@ Quand Z.AI est en surcharge, il renvoie du `429` (ou `503`). Un `429` brut, c'es
 
 **Le fix** : claudish distingue la surcharge transitoire du quota épuisé, convertit la première en `529 overloaded_error` avec un `Retry-After`, et applique un **backoff patient** (~5 min, 6 retries, schedule 5/10/20/40/80/150 s) côté proxy avant de rendre la main. Le client reçoit un `529` (signal « réessaie ») plutôt qu'un `429` (signal « arrête »). Validé en production : **36 épisodes de surcharge convertis en 529 sur une fenêtre, zéro `429` atteint un client.**
 
-*Leçon : les codes HTTP sont sémantiques (`429` ≠ `529`), et un client bien élevé réessaie sur `529`. Le dogfooding — tester ses propres fixes en prod sur le cluster — a révélé un chemin non couvert (le 429 HTTP-direct) que les tests unitaires n'avaient pas attrapés.*
+*Leçon : les codes HTTP sont sémantiques (`429` ≠ `529`), et un client bien élevé réessaie sur `529`. Le dogfooding — tester ses propres fixes en prod sur le cluster — a révélé un chemin non couvert (le 429 HTTP-direct) que les tests unitaires n'avaient pas attrapé.*
 
 ---
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
@@ -1,32 +1,37 @@
-# Claudish — Proxy Anthropic-Compatible Multi-Providers
+# Claudish — Proxy Multi-Providers, Wires Anthropic et OpenAI
 
 > Sources : [github.com/MadAppGang/claudish](https://github.com/MadAppGang/claudish) (upstream) · [github.com/jsboige/claudish](https://github.com/jsboige/claudish) (déploiement MyIA) · [claudish.com](https://claudish.com)
 
-Ce document décrit **Claudish** tel qu'il est déployé sur le cluster MyIA : un proxy compatible avec l'API Anthropic qui fait tourner Claude Code, les agents autonomes et les bots sur **n'importe quel fournisseur de modèles**. Il explique le principe, le router à 3 providers, la façon de connecter un agent (Claude Code) et un bot, les avancées du fork, et les war-stories qui ont forgé son design.
+Ce document décrit **Claudish** tel qu'il est déployé sur le cluster MyIA : un proxy qui fait tourner Claude Code, les agents autonomes et les bots sur **n'importe quel fournisseur de modèles**. Il explique le principe des deux wires d'entrée, la topologie, le router à 3 tiers avec cascade de bascule notifiée, la façon de connecter un agent (Claude Code) et un bot, les avancées du fork, et les war-stories qui ont forgé son design.
+
+> **État documenté au 2026-09-09** (#15418) : ce guide a été réconcilié avec le fork live (commits à l'appui) et des mesures directes du déploiement (`models.myia.io`). Les sections historiques sont datées comme telles.
 
 ---
 
-## 1. Le principe — un seul format wire, plusieurs providers
+## 1. Le principe — deux formats wire en entrée, plusieurs providers en sortie
 
-**Claude Code** (et le SDK, et tous les bots qui parlent le protocole Anthropic) adressent toujours `https://api.anthropic.com`. Claudish s'intercale entre le client et le fournisseur :
+**Claude Code** (et le SDK, et les bots qui parlent le protocole Anthropic) adressent toujours `https://api.anthropic.com` ; les clients **wire OpenAI** (GPT-5, Codex, routeurs tiers, notebooks) postent du `/chat/completions`. Claudish accepte **les deux** et s'intercale entre le client et le fournisseur :
 
 ```
-        parle Anthropic wire                traduit vers le provider cible
-client ──────────────────────► claudish ─────────────────────────────► GLM / Qwen / Anthropic
-(Claude Code, bot, SDK)        (proxy)        (OpenAI / Gemini / Anthropic / Ollama…)
+   wire Anthropic (/v1/messages) OU OpenAI (/v1/chat/completions)
+client ────────────────────────────────► claudish ─────────────────────────────► provider cible
+(Claude Code, bot, SDK, client OpenAI)    (proxy)     (Anthropic / GLM / MiniMax / Qwen / DeepSeek)
 ```
 
-- **En entrée**, claudish expose l'API Anthropic à l'identique (`/v1/messages`). Côté client, rien ne change.
-- **En sortie**, il traduit vers le wire du provider cible (OpenAI, Gemini, Anthropic natif, Ollama…).
-- **Résultat** : un agent conçu pour Claude peut parler à GLM, Qwen, Gemini, etc., sans toucher à son code.
+- **En entrée**, claudish expose `/v1/messages` (wire Anthropic) **et** `/v1/chat/completions` (wire OpenAI). Mesuré live le 2026-09-09 : un POST sur `https://models.myia.io/v1/chat/completions` répond `200` avec un corps JSON conforme OpenAI.
+- **En sortie**, il traduit vers le wire du provider cible (Anthropic natif, Anthropic-compatible comme MiniMax-M3, OpenAI-compatible comme z.ai GLM).
+- **Résultat** : un agent conçu pour Claude *ou* pour l'API OpenAI peut parler à GLM, MiniMax, Qwen, Anthropic, etc., sans toucher à son code.
+
+> **Historique (juillet 2026)** : le guide décrivait alors « un seul format wire en entrée » (`/v1/messages` seulement, `/chat/completions` → 404). C'était l'état du déploiement à cette date ; le wire OpenAI en entrée a été exposé et maintenu depuis (le fork livre encore des correctifs dédiés au handler OpenAI en septembre 2026).
 
 ### Upstream vs déploiement MyIA
 
 | | Upstream (MadAppGang) | Déploiement MyIA (jsboige) |
 |---|---|---|
 | **Rôle** | Outil open-source : « Claude Code. Any Model. » | Fork opérationnel du cluster |
-| **Forme** | CLI local (`claudish --model …`) | Service Docker persistant, exposé via passerelle IIS |
-| **Routing** | Fallback automatique multi-providers | **No-fallback** : 1 provider budgeté par tier (voir §3) |
+| **Forme** | CLI local (`claudish --model …`) | Service Docker persistant, exposé via passerelle IIS + sidecar LAN |
+| **Routing** | Fallback automatique multi-providers | **Cascade ordonnée par tier, TTL par step, bascule notifiée** (voir §3) |
+| **Wires d'entrée** | Anthropic | Anthropic **et** OpenAI |
 | **Ops** | — | Capture, surveillance trafic, watchdog, concurrence plafonnée (voir §6) |
 
 ---
@@ -36,39 +41,57 @@ client ──────────────────────► cla
 ```
 ┌──────────────┐   ┌─────────────────┐   ┌──────────────────┐   ┌─────────────────┐
 │ Claude Code  │   │  models.myia.io │   │  claudish        │   │  Provider cible │
-│  / agent     ├──►│  (IIS reverse-  ├──►│  po-2023:3000    ├──►│  GLM / Qwen /   │
-│  / bot       │   │   proxy, HTTPS) │   │  (Docker, Hono)  │   │  Anthropic      │
-└──────────────┘   └─────────────────┘   └──────────────────┘   └─────────────────┘
-                          TLS, cache IIS        traduction wire + concurrence
+│  / agent     ├──►│  (IIS reverse-  ├──►│  po-2023:3000    ├──►│  Anthropic /    │
+│  / bot       │   │   proxy, HTTPS) │   │  (Docker, Hono)  │   │  GLM / MiniMax /│
+└──────────────┘   └─────────────────┘   └──────────────────┘   │  Qwen / DeepSeek│
+                          TLS, cache IIS        traduction wire  └─────────────────┘
+                                                 + cascade + concurrence
+        agents distants (LAN) ──► sidecar ai-01 (192.168.0.46:3000) ──► même claudish
 ```
 
-- **claudish** tourne dans un conteneur Docker sur `po-2023`, port `3000`.
+- **claudish** tourne dans un conteneur Docker sur `po-2023`, port `3000` (hub).
 - La passerelle **IIS** (`models.myia.io`) termine le TLS et reverse-proxie vers le conteneur.
-- Tous les clients (agents Claude Code, bots Hermes/NanoClaw) pointent sur `https://models.myia.io`.
+- Le **sidecar ai-01** (`192.168.0.46:3000`) relaie en LAN pour les agents distants.
+- Les clients (agents Claude Code, clients OpenAI, bots Hermes/NanoClaw) pointent sur `https://models.myia.io` ou le sidecar selon leur position.
+
+### Authentification client → claudish
+
+Clé proxy **obligatoire** (fork 2026-08), acceptée dans **trois** en-têtes équivalents — vérifié dans le middleware `packages/cli/src/fork/middleware/proxy-auth.ts` du fork et mesuré live le 2026-09-09 :
+
+| En-tête | Forme |
+|---|---|
+| `x-proxy-key` | `x-proxy-key: <clé>` |
+| `x-api-key` | `x-api-key: <clé>` |
+| `Authorization` | `Authorization: Bearer <clé>` |
+
+Exceptions : les requêtes `GET` (healthcheck, découverte de modèles) passent sans clé ; le **pass-through Anthropic natif** est exempt (OAuth du client ou swap de clé géré par le handler natif). Toute autre requête sans clé valide reçoit `401 invalid proxy authentication`.
 
 ---
 
-## 3. Le router à 3 providers (no-fallback)
+## 3. Le router à 3 tiers — cascade ordonnée, bascule notifiée
 
-C'est le cœur du déploiement MyIA. Au lieu de laisser le proxy basculer silencieusement entre providers (ce qui change la qualité et le coût en plein milieu d'une conversation), **chaque tier de modèle a un unique provider budgeté** :
+C'est le cœur du déploiement MyIA. **Chaque tier a un provider nominal budgété** et une **cascade de bascule ordonnée** entre providers de même direction (`degraded>degraded>degraded` ou `improved>improved>improved`) — implémentée dans `packages/cli/src/fork/failover.ts` :
 
-| Tier | Modèle visible | Provider réel | Route | Budget |
-|------|----------------|---------------|-------|--------|
-| **Opus** (réflexion lourde) | `claude-opus-4-8` | Anthropic natif | `ai-01` | Max Claude |
-| **Sonnet** (usage courant) | `glm-5.2` | Z.AI GLM Coding Plan | `gc@glm-5.2` | Coding Plan |
-| **Haiku** (rapide, léger) | `qwen3.6-35b-a3b` | vLLM self-hosté | `vllm-myia@…` | GPU maison (po-2023) |
+| Tier | Provider nominal | Cascade (état au 2026-08-18) | Direction |
+|------|------------------|--------------------------------|-----------|
+| **Opus** (réflexion lourde) | Anthropic natif | `qwen-token-plan@qwen3.8-max > gc@glm-5.3 > ds@deepseek-v4-flash` | degraded |
+| **Sonnet** (usage courant) | z.ai GLM Coding Plan (GLM-5.3) | `ds@deepseek-v4-flash` (PAYG direct, latéral) | lateral |
+| **Haiku** (rapide, léger) | MiniMax-M3 (Anthropic-compatible) | `qwen-token-plan@qwen3.8-max > ds@deepseek-v4-flash` | improved |
 
-**Principe no-fallback :**
-- Sur un burst (rate-limit), claudish **backoff** puis réessaie le **même** provider.
-- Sur une panne franche, il **fail-hard** (erreur explicite) — il ne bascule **jamais** vers un autre provider en silence.
-- Raison : un switch de provider à l'insu de l'agent dégrade silencieusement la qualité et rend les coûts imprévisibles. Mieux vaut une erreur visible qu'une dérive cachée.
+**Fonctionnement de la cascade :**
+- Chaque step de la cascade a un **TTL indépendant** (échelle `10m/30m/1h/4h/24h`) qui survit à l'armement du rôle — un quota wall hebdomadaire (Qwen) n'est pas re-probé toutes les 10 min pendant que la fenêtre GLM 5h se ré-initialise.
+- Sur un burst (rate-limit), claudish **backoff** sur le step courant et passe au suivant quand le TTL expire.
+- Sur une panne franche, le step suivant prend la main **avec notice de dégradation explicite** : le marqueur `[claudish] Failover model active` apparaît dans la réponse (observé live le 2026-09-09 lors d'un épuisement du nominal GLM). Les notices existent en deux moments — **onset** (bascule) et **recovery** (retour au nominal), diffusées sur 3 canaux : log proxy, dashboard `workspace-claudish`, client (en-tête/corps SSE).
+- Le step final (PAYG direct) est **toujours servi** quand tout le reste est épuisé — l'agent ne meurt jamais, il dégrade avec notification.
+
+> **Historique — l'ère no-fallback (24/06/2026 → 12/08/2026)** : le déploiement a d'abord supprimé tout fallback (voir §7.1). La cascade notifiée l'a remplacée le 2026-08-12 (commit `823e614`) : la bascule existe de nouveau, mais **jamais silencieuse** — c'est la différence avec le fallback d'origine.
 
 ### Contrôle de concurrence
 
 Certains providers ne supportent pas les requêtes parallèles illimitées. Claudish plafonne la concurrence **par provider** :
 
-- **Haiku / Qwen (vLLM)** — cap `1` (séquentiel). Un GPU ne fait pas 4 prefills de 120K tokens en parallèle sans se gripper (`max-num-batched-tokens` saturé → famine GPU).
-- **Sonnet / GLM Coding** — cap `8`. Une rafale de longs streams GLM qui s'empilent congestionne l'event-loop du proxy et remonte en 503 côté IIS.
+- **GPU self-hosté (vLLM/Qwen)** — cap séquentiel. Un GPU ne fait pas 4 prefills de 120K tokens en parallèle sans se gripper (`max-num-batched-tokens` saturé → famine GPU).
+- **GLM Coding** — cap ~8. Une rafale de longs streams GLM qui s'empilent congestionne l'event-loop du proxy et remonte en 503 côté IIS.
 
 Au-delà du cap, les requêtes attendent en file FIFO et passent dès qu'un slot se libère — elles ne sont **jamais rejetées** (priorité absolue : ne jamais bloquer l'agent, voir §6).
 
@@ -81,17 +104,25 @@ Côté Claude Code (ou le SDK), on pointe simplement le base URL vers claudish :
 ```powershell
 $env:ANTHROPIC_BASE_URL = "https://models.myia.io"
 $env:ANTHROPIC_AUTH_TOKEN = "<clé claudish>"
-$env:ANTHROPIC_MODEL = "glm-5.2"          # tier Sonnet → Z.AI GLM
+$env:ANTHROPIC_MODEL = "glm-5.3"          # tier Sonnet → Z.AI GLM
 # ou laisse claudish choisir le tier via le profil actif
 ```
 
-C'est tout. Claude Code croit parler à Anthropic ; claudish route en réalité vers GLM/Qwen/Anthropic selon le modèle demandé.
+C'est tout. Claude Code croit parler à Anthropic ; claudish route en réalité vers GLM/MiniMax/Qwen/Anthropic selon le modèle demandé.
+
+### Et les clients wire OpenAI ?
+
+Un client OpenAI (notebook, GPT-5, Codex, routeur tiers) pointe sa base URL sur le même proxy et utilise le wire `/v1/chat/completions` :
+
+```python
+client = OpenAI(base_url="https://models.myia.io/v1", api_key="<clé claudish>")
+```
+
+Mesuré live le 2026-09-09 : POST `/v1/chat/completions` → `200` + JSON conforme OpenAI (le champ `model` de la réponse porte l'identité du modèle effectivement servi — utile pour vérifier qu'on n'est pas sur un step de cascade).
 
 ### Et Roo Code ?
 
-**Non, Roo Code ne passe pas par claudish.** Les deux outils ne se sont jamais croisés : Roo *déclinait* pile au moment où claudish *émergeait*. Roo s'est donc toujours configuré en **OpenRouter direct** (via l'UI Fournisseurs), et n'a jamais eu besoin du proxy. En pratique, le trafic du proxy est à **100 % du `claude-cli/*`** (Claude Code, le SDK, les bots) — aucune signature Roo, Cline ou OpenRouter.
-
-La raison technique : claudish ne sert que le **wire Anthropic** (`POST /v1/messages`). Un appel OpenAI-style `/chat/completions` renvoie `404`. Roo étant orienté wire OpenAI-compat, il ne peut pas consommer claudish tel quel.
+**Roo Code n'a jamais consommé claudish à ce jour** — mais pour des raisons d'historique, plus de wire. Les deux outils ne se sont jamais croisés : Roo *déclinait* pile au moment où claudish *émergeait* (juin-juillet 2026). Roo s'est donc toujours configuré en **OpenRouter direct** (via l'UI Fournisseurs). À l'époque des mesures, le trafic du proxy était à **100 % du `claude-cli/*`** (Claude Code, le SDK, les bots) — aucune signature Roo, Cline ou OpenRouter. Depuis, le wire OpenAI est exposé : un client Roo serait aujourd'hui techniquement consommable via le mode OpenAI-compatible, mais ce n'est pas la configuration de la flotte.
 
 > **Piège de télémétrie** : si vous voyez `cc_entrypoint=claude-vscode` dans les captures de trafic, c'est **Claude Code lancé depuis VS Code**, pas Roo Code. Les deux sont des extensions VS Code différentes ; ne pas les confondre.
 
@@ -101,18 +132,17 @@ La raison technique : claudish ne sert que le **wire Anthropic** (`POST /v1/mess
 
 ## 5. Connecter un bot — le trick du nom Claude (leçon Hermes)
 
-Les bots autonomes (Hermes, NanoClaw) parlent parfois un wire non-Anthropic (OpenAI `/chat/completions`). Or **claudish ne sert que le wire Anthropic** : un `/chat/completions` renvoie `404`.
-
-Deux approches, du plus simple au plus invasif :
+Les bots autonomes (Hermes, NanoClaw) parlent parfois un wire non-Anthropic. Depuis l'exposition du wire OpenAI en entrée, un bot OpenAI-native peut poster directement sur `/v1/chat/completions` — mais le pattern le plus robuste reste le **remap de nom** :
 
 | Option | Quoi faire | Quand |
 |--------|------------|-------|
-| **Remap de nom (recommandée)** | Le bot envoie un **nom de modèle Claude** (ex. `claude-sonnet-4-6`). Claudish le remappe vers le modèle budgeté du tier (`glm-5.2` via `gc@`) selon le profil actif. **1 ligne de config côté bot, aucun patch de wire.** | Le bot sait juste poster un `model` dans sa requête Anthropic. |
-| Patch du wire | Faire parler le bot Anthropic natif (messages/tools au format Anthropic) | Le bot a déjà une intégration Anthropic, ou on contrôle son code. |
+| **Remap de nom (recommandée)** | Le bot envoie un **nom de modèle Claude** (ex. `claude-sonnet-4-6`). Claudish le remappe vers le modèle budgeté du tier (`glm-5.3` via `gc@`) selon le profil actif. **1 ligne de config côté bot, aucun patch de wire.** | Le bot sait juste poster un `model` dans sa requête. |
+| Wire OpenAI direct | Poster sur `/v1/chat/completions` avec la clé proxy (`Authorization: Bearer` accepté, mesuré 2026-09-09). | Le bot est OpenAI-native et vous voulez la route la plus courte. |
+| Patch du wire | Faire parler le bot Anthropic natif (messages/tools au format Anthropic). | Le bot a déjà une intégration Anthropic, ou on contrôle son code. |
 
 > **Leçon Hermes (juin 2026)** : le bot Hermes bloquait le routing. Le fix n'a **pas** été de patcher le wire du bot, mais simplement de lui faire envoyer un nom Claude — claudish s'occupe du reste via le `modelMap` du profil. C'est le pattern réutilisable pour tout bot qui s'intègre au cluster.
 
-**Détail qui mord** : les slugs de modèle doivent correspondre exactement. `glm-5-2` (tiret) → 404 ; `glm-5.2` (point) → OK. À vérifier en cas d'erreur de routing inexpliquée.
+**Détail qui mord** : les slugs de modèle doivent correspondre exactement. `glm-5-2` (tiret) → 404 ; `glm-5.2` (point) → OK. À vérifier en cas d'erreur de routing inexpliquée. Les slugs des steps de cascade se lisent `provider@modèle` (ex. `gc@glm-5.3`, `ds@deepseek-v4-flash`).
 
 ---
 
@@ -122,6 +152,7 @@ Au-delà du routing de base, le fork `jsboige/claudish` ajoute ce qui fait tourn
 
 | Avancée | Rôle |
 |---------|------|
+| **Cascade de failover notifiée** | Rôle → cascade ordonnée de substituts, TTL par step (échelle 10m→24h), notices onset/recovery sur 3 canaux ; le step final PAYG est toujours servi (`fork/failover.ts`, mandat 2026-08-12). |
 | **Never-hang (priorité #1)** | Un flux se termine **toujours**, même si le provider coupe mid-stream ou renvoie du vide. Un agent bloqué est jugé pire qu'une erreur propre. |
 | **Overload 529** | Un 429 de **surcharge transitoire** (ou 503) est converti en `529 overloaded_error` + `Retry-After`, pour que le client **réessaie** au lieu d'abandonner ; le 429 « quota » reste distinct (passe tel quel). |
 | **Contrôle de concurrence** | `LocalModelQueue` (cap GPU) + `ConcurrencyLimiter` (cap provider remote), indépendants par provider (voir §3). |
@@ -134,13 +165,15 @@ Au-delà du routing de base, le fork `jsboige/claudish` ajoute ce qui fait tourn
 
 ## 7. War-stories — trois leçons du fork en production
 
-Ces trois épisodes, extraits de l'historique du fork `jsboige/claudish`, illustrent pourquoi le proxy est conçu *comme il l'est*. Chacun porte une leçon transférable au-delà de claudish.
+Ces trois épisodes, extraits de l'historique du fork `jsboige/claudish`, illustrent pourquoi le proxy est conçu *comme il l'est*. Chacun porte une leçon transférable au-delà de claudish. **Ce sont des récits historiques datés** — l'état courant du déploiement est décrit aux §1-§3.
 
-### 7.1 Architecture par soustraction — le no-fallback (24/06/2026)
+### 7.1 Architecture par soustraction — le no-fallback (24/06/2026) [HISTORIQUE — supersédé le 12/08/2026]
 
 Au démarrage, claudish enchaînait les providers en fallback : si GLM rate-limitait, il basculait sur Qwen. **Le problème** : cette bascule se faisait à l'insu de l'agent, en plein milieu d'une conversation — changeant la qualité du modèle et le coût d'un tour sur l'autre, de façon invisible et imprévisible. Pire, le chemin fallback vers Qwen (GPU maison) a grippé le backend à plusieurs reprises (concurrence non bornée sur des contextes longs = famine GPU).
 
-**La décision** n'a pas été d'ajouter du code pour mieux orchestrer les bascules, mais de **le retirer** : suppression de `defaultProvider`, une seule entrée par chaîne. Depuis, sur un burst claudish **backoff** puis réessaie le *même* provider ; sur une panne franche il **fail-hard** (erreur explicite). *Leçon : un fallback silencieux est une dégradation cachée. Mieux vaut une erreur visible qu'une dérive de qualité invisible — et un chemin de code en moins est un bug en moins.*
+**La décision d'alors** n'a pas été d'ajouter du code pour mieux orchestrer les bascules, mais de **le retirer** : suppression de `defaultProvider`, une seule entrée par chaîne. Sur un burst claudish backoff puis réessaie le *même* provider ; sur une panne franche il fail-hard. *Leçon : un fallback **silencieux** est une dégradation cachée.*
+
+**Ce que cette leçon est devenue** : le no-fallback strict a tenu de fin juin au 12/08/2026 (commit `823e614`). La cascade qui le remplace conserve le principe anti-silence — bascule **notifiée** (onset + recovery, 3 canaux), TTL par step, dernier step toujours servi — tout en réintroduisant la résilience multi-providers. La leçon transférable survit inchangée : *mieux vaut une bascule visible qu'une dérive de qualité invisible.*
 
 ### 7.2 Never-hang — le proxy qui crash déguisé en bug de stream (commit `8afe19d`, 14/06/2026)
 
@@ -156,7 +189,7 @@ Quand Z.AI est en surcharge, il renvoie du `429` (ou `503`). Un `429` brut, c'es
 
 **Le fix** : claudish distingue la surcharge transitoire du quota épuisé, convertit la première en `529 overloaded_error` avec un `Retry-After`, et applique un **backoff patient** (~5 min, 6 retries, schedule 5/10/20/40/80/150 s) côté proxy avant de rendre la main. Le client reçoit un `529` (signal « réessaie ») plutôt qu'un `429` (signal « arrête »). Validé en production : **36 épisodes de surcharge convertis en 529 sur une fenêtre, zéro `429` atteint un client.**
 
-*Leçon : les codes HTTP sont sémantiques (`429` ≠ `529`), et un client bien élevé réessaie sur `529`. Le dogfooding — tester ses propres fixes en prod sur le cluster — a révélé un chemin non couvert (le 429 HTTP-direct) que les tests unitaires n'avaient pas attrapé.*
+*Leçon : les codes HTTP sont sémantiques (`429` ≠ `529`), et un client bien élevé réessaie sur `529`. Le dogfooding — tester ses propres fixes en prod sur le cluster — a révélé un chemin non couvert (le 429 HTTP-direct) que les tests unitaires n'avaient pas attrapés.*
 
 ---
 
@@ -184,7 +217,8 @@ Deux pièges mesurés :
 |----------|-------|
 | `ANTHROPIC_BASE_URL` | URL claudish (les clients pointent ici au lieu de `api.anthropic.com`) |
 | `ANTHROPIC_AUTH_TOKEN` | Clé d'auth claudish |
-| `ANTHROPIC_MODEL` | Modèle/tier par défaut (`glm-5.2`, `claude-opus-4-8`, `qwen3.6-35b-a3b`) |
+| `ANTHROPIC_MODEL` | Modèle/tier par défaut (`glm-5.3`, `claude-opus-5`, `qwen3.6-35b-a3b`, `MiniMax-M3`) |
+| `OPENAI_BASE_URL` / `api_key` | Équivalent côté client wire OpenAI (base `https://models.myia.io/v1`) |
 | `CLAUDISH_BASE_URL` | Base URL du helper notebook (défaut `http://localhost:3000`, lue à l'appel — #15286/#15312) |
 | `providerConcurrency` (config) | Cap de concurrence par provider (`{ "glm-coding": 8 }`) |
 | `customEndpoints` (config) | Endpoints nommés (`vllm-myia@…`) avec leur propre `maxConcurrency` |
@@ -197,20 +231,22 @@ Deux pièges mesurés :
 
 | Symptôme | Cause | Fix |
 |----------|-------|-----|
-| `404` sur `/chat/completions` | Le bot parle wire OpenAI ; claudish ne sert que l'wire Anthropic | Option recommandée : envoyer un nom de modèle Claude (remap), ou faire parler le bot Anthropic |
-| `404` ou erreur de routing sur `glm-5-2` | Slug erroné (tiret au lieu du point) | Utiliser `glm-5.2` |
+| `401 invalid proxy authentication` | Clé proxy absente/erronée | Fournir la clé dans `x-proxy-key`, `x-api-key` ou `Authorization: Bearer` (§2) |
+| Réponses portant `[claudish] Failover model active` | **Pas une panne client** : le nominal du tier est épuisé, un step de cascade sert avec notice | Consulter le dashboard `workspace-claudish` / logs proxy ; le nominal revient à l'expiration du TTL (notice de recovery) |
+| `404` ou erreur de routing sur `glm-5-2` | Slug erroné (tiret au lieu du point) | Utiliser `glm-5.2` — ou le slug cascade `gc@glm-5.3` |
 | `503` intermittents côté IIS | Congestion du proxy (longs streams empilés sur un provider plafonné) | Vérifier les caps `providerConcurrency` ; le backoff/limiter doit lisser la rafale |
 | Agent qui « freeze » (socket closed) | Flux non terminé proprement | Ne devrait plus arriver (never-hang) — si oui, c'est un bug à reporter |
+| Client OpenAI qui échoue alors que Claude Code marche | Vérifier la base URL du client | Le wire OpenAI se consomme sur `<base>/v1/chat/completions` (mesuré 200 live le 2026-09-09) |
 
 ---
 
 ## 10. Liens & lectures
 
 - **Upstream** : [MadAppGang/claudish](https://github.com/MadAppGang/claudish) — code source, README, docs.
-- **Déploiement MyIA** : `jsboige/claudish` (fork), serveur `po-2023`, passerelle `models.myia.io`.
+- **Déploiement MyIA** : `jsboige/claudish` (fork), serveur `po-2023` (hub) + sidecar `ai-01`, passerelle `models.myia.io`.
 - **Bots consommateurs** : voir [Claw-Systems/](../Claw-Systems/) (Hermes, NanoClaw).
 - **Agents Claude Code consommateurs** : voir [Claude-Code/](../Claude-Code/).
 
 ---
 
-*Section Claudish — Juillet 2026. Proxy Anthropic-compatible multi-providers du cluster MyIA : un format wire en entrée, trois providers budgetés en sortie, jamais de bascule silencieuse.*
+*Section Claudish — réconciliée le 2026-09-09 (#15418) avec le fork live et le README canonique (refonte #11555). Proxy multi-providers du cluster MyIA : **deux formats wire en entrée** (Anthropic `/v1/messages` + OpenAI `/v1/chat/completions`), trois tiers routés en **cascade ordonnée notifiée** (Anthropic natif / GLM-5.3 / MiniMax-M3 / Qwen / DeepSeek) — bascule **jamais silencieuse** depuis le commit `823e614` (2026-08-12).*

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md
@@ -80,7 +80,7 @@ C'est le cœur du déploiement MyIA. **Chaque tier a un provider nominal budgét
 
 **Fonctionnement de la cascade :**
 - Chaque step de la cascade a un **TTL indépendant** (échelle `10m/30m/1h/4h/24h`) qui survit à l'armement du rôle — un quota wall hebdomadaire (Qwen) n'est pas re-probé toutes les 10 min pendant que la fenêtre GLM 5h se ré-initialise.
-- Sur un burst (rate-limit), claudish **backoff** sur le step courant et passe au suivant quand le TTL expire.
+- Sur une **exhaustion de quota**, claudish marque le step courant en échec, **passe immédiatement au suivant** et maintient le step épuisé **hors rotation pendant son TTL** ; à l'expiration du TTL, il le **re-sonde** (`markStepFailed` puis résolution qui saute les steps encore TTL-failed — `fork/failover.ts`). Les rate limits transitoires (à la minute) sont explicitement **exclues** de l'armement de la cascade : `isQuotaExhaustion` ne les compte pas comme une exhaustion, elles ne déclenchent pas de bascule.
 - Sur une panne franche, le step suivant prend la main **avec notice de dégradation explicite** : le marqueur `[claudish] Failover model active` apparaît dans la réponse (observé live le 2026-09-09 lors d'un épuisement du nominal GLM). Les notices existent en deux moments — **onset** (bascule) et **recovery** (retour au nominal), diffusées sur 3 canaux : log proxy, dashboard `workspace-claudish`, client (en-tête/corps SSE).
 - Le step final (PAYG direct) est **toujours servi** quand tout le reste est épuisé — l'agent ne meurt jamais, il dégrade avec notification.
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #15310

# docs(claudish): réconcilier le guide détaillé avec les wires et la cascade réellement déployés (#15418)

**Périmètre** : cette PR ne modifie que le guide détaillé `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/docs/Claudish-Proxy.md` (commit unique `e9dc18f57a`, base `origin/main` frais). Le README canonique, les notebooks, les helpers et les configs ne sont pas touchés ; aucun secret, URL privée ou capture de trafic (l'origine Astra et son ZIP restent sur GDrive privé, hors dépôt).

## Grounding (périmètre 1 de l'issue — ne pas recopier le ticket aveuglément)

Trois sources croisées, datées :

1. **Fork `jsboige/claudish` (lu au 2026-09-09, head `3e436321`)** :
   - `packages/cli/src/fork/failover.ts` — cascade **ordonnée** de substitutions par rôle (`>`-séparées), **TTL par step** avec backoff (l'échelle documentée `10m+30m+1h+4h ≈ 5h30` figure en commentaire du code), **deux notices** (onset + recovery, « the user's mandate 2026-08-12 »), **dernier step toujours servi**. État de step indépendant de l'auto-arm du rôle.
   - `packages/cli/src/fork/middleware/proxy-auth.ts` — clé proxy exigée dans `x-proxy-key` **OU** `x-api-key` **OU** `Authorization: Bearer` (le header authorization est accepté brut ou préfixé Bearer) ; GET/health exempt ; pass-through Anthropic natif exempt ; sinon `401 invalid proxy authentication`.
   - `packages/cli/src/adapters/openai-api-format.ts` + commits récents `bc636c1a`/`3ce3125d` (« fix(openai): strip unsupported schema patterns », 2026-09-09) — le wire OpenAI en entrée est une feature **maintenue activement**, pas une relique.
2. **Mesures directes du déploiement `models.myia.io` prises le 2026-09-09** (par la lane exécutante, pendant l'épisode de saturation GLM documenté sur PR #15411) :
   - `POST /v1/chat/completions` → **`200` + corps JSON conforme OpenAI** (dizaines d'appels dans la journée, auth `Authorization: Bearer`) — réfute les deux occurrences « renvoie 404 » ;
   - champ `model` de la réponse portant l'**identité effective** du modèle servi (`glm-5.2` sur appel direct par nom) ;
   - marqueur **`[claudish] Failover model active`** observé dans les réponses quand le nominal du tier était épuisé — preuve live de la cascade + notice de dégradation, exactement le comportement décrit par `failover-stream-notice.ts`.
3. **README canonique** (refonte 2026-08-18, #11555/#11562) — inchangé par cette PR : rien dans les mesures ci-dessus ne le contredit (la table de cascade est citée avec son millésime « état au 2026-08-18 » ; l'appel direct `glm-5.2` par nom ne contredit pas le nominal de tier `glm-5.3`).

## Corrections livrées (périmètres 2-4 de l'issue)

| Sujet | Avant (état juillet) | Après (groundé) |
|---|---|---|
| §1 principe | « un seul format wire », `/v1/messages` seul | **Deux wires** en entrée (`/v1/messages` + `/v1/chat/completions`), note historique datée pour l'ancienne lecture |
| §2 topologie | hub po-2023/IIS seul | + **sidecar LAN ai-01** ; section **auth** ajoutée (trois en-têtes équivalents, exemptions GET/pass-through Anthropic, source citée) |
| §3 router | « no-fallback », 1 provider/tier, GLM-5.2 + Qwen 3.6 | **Cascade ordonnée par tier + TTL par step + notices onset/recovery** (table millésimée 2026-08-18 : Anthropic/GLM-5.3/MiniMax-M3/qwen3.8-max/deepseek-v4-flash), encadré historique « ère no-fallback 24/06→12/08 » ; concurrence conservée (toujours d'actualité) |
| §4/§5 « `/chat/completions` renvoie 404 » (2 occurrences) | retirées avec **preuve inverse** : mesure live 200 du 2026-09-09 citée in-line ; §5 gagne l'option « wire OpenAI direct » à côté du remap de nom (qui reste recommandé) ; le passage Roo est re-datelé (histoire de flotte, plus un mur technique) |
| §7.1 war-story no-fallback | présentée comme architecture actuelle | **[HISTORIQUE — supersédé le 12/08/2026]**, avec le récit de ce que la leçon est devenue (bascule notifiée) ; 7.2/7.3 inchangées (déjà datées) |
| §6 avancées fork | — | ligne « cascade de failover notifiée » ajoutée |
| §8 variables | `glm-5.2` en exemple de tier | modèles courants (`glm-5.3`…), ligne `OPENAI_BASE_URL` pour les clients wire OpenAI ; table consommateurs #15286 conservée telle quelle |
| §9 troubleshooting | « `404` sur `/chat/completions` → contourner le wire OpenAI » | inversé : ligne `401` (clé proxy), ligne **marqueur failover** (« pas une panne client »), slug, 503, freeze, ligne client OpenAI (base URL) |
| footer | « un format wire en entrée… jamais de bascule silencieuse » | deux wires, cascade notifiée, réconciliation #15418 datée |

## Acceptance #15418 (6/6)

- [x] **Même verdict wires** guide ↔ README : deux wires d'entrée exposés (mesuré live + source fork).
- [x] **Même verdict failover** : cascade ordonnée + TTL + bascule notifiée (guide §3 = README table + `failover.ts`).
- [x] **Modèles/routes/auth/topologie vérifiés contre fork/déploiement et datés** : sources fork citées fichier par fichier, mesures live millésimées 2026-09-09, cascade millésimée 2026-08-18.
- [x] **Les deux « `/chat/completions` renvoie 404 »** : retirées avec preuve inverse (POST 200 mesuré le 2026-09-09) — le README n'avait pas à être corrigé.
- [x] **Sections historiques qualifiées** : note « Historique (juillet 2026) » en §1, encadré « ère no-fallback » en §3, §7.1 tagué `[HISTORIQUE — supersédé le 12/08/2026]`, §7.2/7.3 déjà datées par commit.
- [x] **Diff borné au guide** : grep croisé post-édition — plus aucune assertion « un seul format » / « no-fallback » courant / « 404 » sur le wire OpenAI dans l'un ou l'autre document (les seuls « 404 » restants concernent les slugs de modèle).

## Déconflit

- Claim déjà posé pour cette lane par ai-01 (commentaire 5608095206, path-scoped) — aucune autre PR ouverte ne touche ces chemins.
- Le README mentionne §5 du guide pour la leçon Hermes : l'ancre et le titre de §5 sont inchangés.

Closes #15418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

