### PR TITLE
docs(claude-code,#15419): corriger l'installation du proxy — le paquet npm openrouter-proxy n'existe pas

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
@@ -97,7 +97,7 @@ Cliquez sur ce lien : [Installer Claude Code pour VS Code](vscode:extension/anth
 
 ## Configuration avec OpenRouter (couche d'accès aux modèles — distincte de l'installation)
 
-**Condition qui sélectionne cette voie d'accès** : vous passez par OpenRouter (clé fournie par le formateur) plutôt que par un compte Anthropic direct. Ce n'est pas un second chemin d'installation : l'outil `claude` installé ci-dessus est le même, seule la couche d'accès aux modèles change. Le proxy est un paquet npm : Node.js est requis pour cette brique, même si Claude Code a été installé nativement.
+**Condition qui sélectionne cette voie d'accès** : vous passez par OpenRouter (clé fournie par le formateur) plutôt que par un compte Anthropic direct. Ce n'est pas un second chemin d'installation : l'outil `claude` installé ci-dessus est le même, seule la couche d'accès aux modèles change. Le proxy est un script Node issu d'un dépôt Git (zéro dépendance) : Node.js est requis pour cette brique, même si Claude Code a été installé nativement.
 
 > **Diagnostic du proxy** : vérifiez qu'il tourne avec `curl http://127.0.0.1:8899/api/v1/models` — une réponse JSON avec la liste des modèles confirme qu'il est actif. **Symptôme s'il ne tourne pas** : chaque appel modèle de Claude Code échoue avec une erreur de connexion (`fetch failed` / `connection refused`) vers `http://127.0.0.1:8899` — y compris des jours plus tard si le proxy a été lancé détaché en arrière-plan et que la machine a redémarré. Rattachez d'abord la panne au proxy avant de soupçonner votre clé ou votre installation.
 
@@ -107,15 +107,18 @@ Les requêtes OpenRouter ne sont pas strictement compatibles avec le protocole A
 
 **Installation :**
 
+> **Vérifié le 2026-09-09 (#15419)** : le paquet `openrouter-proxy` **n'existe pas sur le registre npm** (`npm install -g openrouter-proxy` → 404). L'installation réelle, conforme au dépôt upstream, est un clonage Git — zéro dépendance, seul Node.js (≥ 16) est requis.
+
 ```bash
-npm install -g openrouter-proxy
+git clone https://github.com/ahaostudy/openrouter-proxy.git
 ```
 
 **Lancement :**
 
 ```bash
 # Lance le proxy sur le port 8899 par defaut
-openrouter-proxy
+cd openrouter-proxy
+node proxy.js
 ```
 
 Le proxy doit tourner en arrière-plan tant que vous utilisez Claude Code. Verifiez qu'il fonctionne :
@@ -128,16 +131,16 @@ Une réponse JSON avec la liste des modèles confirme que le proxy est actif.
 
 **Lancement automatique (optionnel) :**
 
-Windows - Ajoutez a votre profil PowerShell (`notepad $PROFILE`) :
+Windows - Ajoutez a votre profil PowerShell (`notepad $PROFILE`), en adaptant le chemin du clone :
 
 ```powershell
-Start-Process -WindowStyle Hidden -FilePath "openrouter-proxy"
+Start-Process -WindowStyle Hidden -FilePath "node" -ArgumentList "$HOME\openrouter-proxy\proxy.js"
 ```
 
 macOS / Linux - Ajoutez a `~/.zshrc` ou `~/.bashrc` :
 
 ```bash
-(openrouter-proxy &>/dev/null &)
+(node ~/openrouter-proxy/proxy.js &>/dev/null &)
 ```
 
 ### Étape 1 : Obtenir la Clé API OpenRouter

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
@@ -16,16 +16,19 @@ Claude Code utilise le protocole Anthropic pour communiquer avec les modèles. O
 
 ### Installation
 
+> **Vérifié le 2026-09-09 (#15419)** : le paquet `openrouter-proxy` **n'existe pas sur le registre npm** (`npm install -g openrouter-proxy` → 404). L'installation réelle, conforme au dépôt upstream, est un clonage Git — zéro dépendance, seul Node.js (≥ 16) est requis.
+
 ```bash
-# Installer le proxy globalement via npm
-npm install -g openrouter-proxy
+# Cloner le dépôt (emplacement au choix, il servira à chaque démarrage)
+git clone https://github.com/ahaostudy/openrouter-proxy.git
 ```
 
 ### Démarrage
 
 ```bash
 # Lance le proxy sur le port 8899 par defaut
-openrouter-proxy
+cd openrouter-proxy
+node proxy.js
 ```
 
 Le proxy tourne en arrière-plan et traduit les requêtes Claude Code vers OpenRouter. Gardez-le actif tant que vous utilisez Claude Code.
@@ -34,16 +37,16 @@ Le proxy tourne en arrière-plan et traduit les requêtes Claude Code vers OpenR
 
 Pour éviter de le lancer manuellement a chaque session :
 
-**Windows** - Ajoutez a votre profil PowerShell (`notepad $PROFILE`) :
+**Windows** - Ajoutez a votre profil PowerShell (`notepad $PROFILE`), en adaptant le chemin du clone :
 
 ```powershell
-Start-Process -WindowStyle Hidden -FilePath "openrouter-proxy"
+Start-Process -WindowStyle Hidden -FilePath "node" -ArgumentList "$HOME\openrouter-proxy\proxy.js"
 ```
 
 **macOS / Linux** - Ajoutez a `~/.zshrc` ou `~/.bashrc` :
 
 ```bash
-(openrouter-proxy &>/dev/null &)
+(node ~/openrouter-proxy/proxy.js &>/dev/null &)
 ```
 
 **Checkpoint :** Vérifiez que le proxy tourne :
@@ -54,7 +57,7 @@ curl http://127.0.0.1:8899/api/v1/models
 
 Si vous voyez une réponse JSON avec des modèles, le proxy fonctionne.
 
-**Symptôme si le proxy ne tourne pas** : chaque appel modèle de Claude Code échoue avec une erreur de connexion (`fetch failed` / `connection refused`) vers `http://127.0.0.1:8899`. Si vous aviez activé le lancement automatique détaché, un redémarrage du poste l'a arrêté sans message visible : relancez simplement `openrouter-proxy` dans un terminal, puis re-testez le `curl` ci-dessus.
+**Symptôme si le proxy ne tourne pas** : chaque appel modèle de Claude Code échoue avec une erreur de connexion (`fetch failed` / `connection refused`) vers `http://127.0.0.1:8899`. Si vous aviez activé le lancement automatique détaché, un redémarrage du poste l'a arrêté sans message visible : relancez simplement `node proxy.js` dans le dossier du proxy, puis re-testez le `curl` ci-dessus.
 
 ---
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA-2 — prev: MED/genai #15376

# docs(claude-code): corriger l'installation du proxy OpenRouter — le paquet npm n'existe pas

**Périmètre** : deux fichiers de doc étudiant (`Claude-Code/docs/OPENROUTER_SETUP.md`, `Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md`), bloc « Étape 0 » uniquement (+19/−13, commit `3e2799b92b`, base main frais). Aucun notebook, aucun code, aucun secret.

## Écart découvert pendant le smoke live #15419 (acceptance : « devient une PR docs atomique séparée »)

L'Étape 0 des deux guides enseignait :

```bash
npm install -g openrouter-proxy   # -> 404 Not Found
```

**Preuve** : `npm view openrouter-proxy` sur registry.npmjs.org → `E404 Not Found` (mesuré 2026-09-09 ~20:54Z). Le paquet n'est pas publié sur npm — l'upstream [ahaostudy/openrouter-proxy](https://github.com/ahaostudy/openrouter-proxy) documente l'installation réelle : `git clone` + `node proxy.js` (zéro dépendance, `engines.node >= 16`).

**Chemin vérifié live (2026-09-09, machine po-2023)** : `git clone` → `node proxy.js` → écoute sur `127.0.0.1:8899` → `curl /api/v1/models` → HTTP 200 (catalogue réel) → trois réponses modèle réelles via Claude Code (alias sonnet/opus/haiku) → contrôle négatif ConnectionRefused proxy arrêté → reprise après redémarrage. Le témoin complet du smoke est posté sur l'issue #15419.

## Corrections

| Bloc | Avant | Après |
|---|---|---|
| Installation | `npm install -g openrouter-proxy` (404) | `git clone https://github.com/ahaostudy/openrouter-proxy.git` + note de vérification datée |
| Démarrage | `openrouter-proxy` | `cd openrouter-proxy && node proxy.js` |
| Auto-launch Windows | `Start-Process ... "openrouter-proxy"` | `Start-Process ... "node" -ArgumentList "$HOME\openrouter-proxy\proxy.js"` |
| Auto-launch macOS/Linux | `(openrouter-proxy &>/dev/null &)` | `(node ~/openrouter-proxy/proxy.js &>/dev/null &)` |
| Symptôme (SETUP) | « relancez `openrouter-proxy` » | « relancez `node proxy.js` dans le dossier du proxy » |
| Intro (INSTALLATION) | « Le proxy est un paquet npm » | « un script Node issu d'un dépôt Git (zéro dépendance) » — l'exigence Node.js reste exacte |

Le reste (port 8899, checkpoint curl, symptôme `fetch failed`/`connection refused`) est confirmé par le smoke et inchangé.

See #15419 (contribution partielle : l'écart documentaire détecté pendant le smoke ; le témoin d'exécution du parcours complet est livré sur l'issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
