### PR TITLE
enrich(mgs,#13410): MGS-30 densite 610 -> 1507 c/cell — lectures confrontees aux sorties commitees

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-vs-mealpy/MGS-30-ScatterSearch-Decomposition.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-vs-mealpy/MGS-30-ScatterSearch-Decomposition.ipynb
@@ -36,7 +36,25 @@
     "| 3 | mealpy `OriginalScatterSearch` (subclass) | jumeau Glover pinné, même qf = 0,7 |\n",
     "\n",
     "Bras 1 contre bras 2 (**même engine**) isole la **contribution de l'axe diversité** ; bras 1 contre\n",
-    "bras 3 (**formules pinnées identiques**) isole l'**écart de noyau** (engine C# vs harnais mealpy).\n"
+    "bras 3 (**formules pinnées identiques**) isole l'**écart de noyau** (engine C# vs harnais mealpy).\n",
+    "\n",
+    "\n",
+    "**Position dans la série.** Huit paires ont précédé celle-ci ; aucune n'a ablaté l'axe\n",
+    "diversité. Les comparaisons MGS contre mealpy portaient jusqu'ici sur des formules distinctes\n",
+    "implantées de part et d'autre — l'écart mesuré y mélangeait noyau et sémantique. Cette paire 9/9\n",
+    "retourne le problème : les formules sont **pinnées identiques** dans les trois bras, et\n",
+    "l'ablation de `QualityFraction` interroge une hypothèse qu'aucune paire précédente ne pouvait\n",
+    "isoler — *sur ce puzzle, à ce budget, l'investissement de 30 % du Reference Set dans la\n",
+    "diversité max-min paie-t-il ?* C'est la recommandation de Glover portée au banc : le template\n",
+    "à cinq méthodes prescrit la diversité comme police d'assurance contre la stagnation prématurée ;\n",
+    "le banc la met à l'épreuve.\n",
+    "\n",
+    "**Plan de lecture.** Le socle pose la grille et le coût ; le moteur instancie les deux bras MGS\n",
+    "(complet et ablaté) ; le pont PythonNet fait entrer mealpy dans le même kernel ; la cellule\n",
+    "formules prouve l'absence de scatter search dans mealpy 3.0.2 et pinnise les formules des trois\n",
+    "bras ; la course témoin calibre ; le banc croisé mesure ; la cellule coût/éval isole la fitness\n",
+    "du moteur ; la lecture du croisement confronte les trois questions aux mesures ; trois\n",
+    "exercices prolongent."
    ]
   },
   {
@@ -272,7 +290,17 @@
     "**Lecture.** Le socle est posé, identique à MGS-28 au nom près — c'est voulu : la comparabilité\n",
     "entre paires exige le même substrat (grille, représentation R1, fonction de coût). 51 gènes continus\n",
     "dans [1, 10], arrondis + bornés vers 1..9 au décodage ; le coût compte les conflits de lignes,\n",
-    "colonnes et blocs, 0 si et seulement si la grille est résolue."
+    "colonnes et blocs, 0 si et seulement si la grille est résolue.\n",
+    "\n",
+    "\n",
+    "Deux choix de ce socle portent toute la paire. D'abord la **représentation R1** : les\n",
+    "métaheuristiques de ce banc (combinaison convexe comprise) travaillent dans le continu, alors\n",
+    "que le Sudoku est discret — le décodage *continu → arrondi → borné* est le pont obligé, et il\n",
+    "est identique des deux côtés du bench : un vecteur donné produira la même grille et le même\n",
+    "coût côté C# et côté Python (la cellule pont le vérifiera sur témoins). Ensuite la **fonction\n",
+    "de coût comme unique source de vérité** : elle seule définit « mieux », pour les trois bras\n",
+    "comme pour les exercices — aucune métrique annexe (diversité, distance) n'entre dans le\n",
+    "classement final ; ces métriques ne servent qu'à *construire* les candidats."
    ]
   },
   {
@@ -437,7 +465,19 @@
     "*tous* les slots par qualité : le RefSet s'effondre sur l'élitisme pur, c'est la limite\n",
     "`FitnessBasedElitistReinsertion` documentée dans `ScatterSearchReinsertion.cs` — « pure quality\n",
     "collapses the reference set onto the best point and starves the combination operator of distant\n",
-    "mates ». Les témoins graine 7 donnent le premier signal de cette famine."
+    "mates ». Les témoins graine 7 donnent le premier signal de cette famine.\n",
+    "\n",
+    "\n",
+    "Lu depuis Glover (1998), le template à cinq méthodes se projette ainsi sur la grammaire du\n",
+    "moteur : la **génération diversifiée** initiale est la population de départ ; l'**amélioration**\n",
+    "locale est différée (axe mémétique hors composé, comme le note la cellule formules) ; le\n",
+    "**Reference Set** est la population réinsérée à chaque génération ; la **combinaison** est la\n",
+    "corde convexe `lambda * x_a + (1 - lambda) * x_b` ; la réinsertion referme la boucle. À\n",
+    "population 50 et `QualityFraction = 0,7`, le partage concret est **35 slots par qualité, 15\n",
+    "par diversité max-min** : à chaque génération, le RefSet retient les 35 meilleurs puis complète\n",
+    "par les 15 plus éloignés (au sens RMS gène à gène) des déjà retenus. L'ablaté (`qf = 1,0`)\n",
+    "garde 50 slots par qualité et 0 par diversité : il retire exactement ces 15 places — l'écart\n",
+    "mesuré entre bras 1 et bras 2 sera donc attribuable à cette seule politique de réinsertion."
    ]
   },
   {
@@ -734,6 +774,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mgs30-lecture-temoin",
+   "metadata": {},
+   "source": [
+    "**Lecture du témoin.** Sur la graine 7, les trois bras rendent 54, 50 et 53 conflits pour\n",
+    "~8000 évaluations chacun — et le chronomètre dit déjà l'essentiel : le complet paie\n",
+    "**1017 ms** là où l'ablaté en rend **185** (5,5×) à budget égal. Le coût additionnel est le\n",
+    "prix de la combinaison sur un RefSet divers : croiser des mates éloignés produit des enfants\n",
+    "plus coûteux à évaluer, et surtout **ne converge pas plus vite ici** — l'ablaté fait mieux\n",
+    "(50) sur ce témoin. Le jumeau mealpy (53 conflits, 927 ms) se tient entre les deux. La\n",
+    "contre-vérification croisée clôt la construction : le coût C# du meilleur vecteur mealpy\n",
+    "vaut 53, exactement ce que le Python rapporte — les deux côtés parlent bien de la même\n",
+    "fonction. Ces témoins ne prouvent rien à eux seuls (une graine) ; ils calibrent l'ordre de\n",
+    "grandeur avant le banc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "52ab136f",
    "metadata": {
     "papermill": {
@@ -752,7 +809,17 @@
     "coût. Le subclass `OriginalScatterSearch` pousse le template Glover dans le harnais mealpy :\n",
     "génération d'un enfant par membre (combinaison convexe, mate aléatoire sans soi-même —\n",
     "`RandomIncludesCurrent = false` côté MGS), puis mise à jour du Reference Set b1-qualité /\n",
-    "b2-diversité sur le pool parents+enfants — la sémantique de `ScatterSearchReinsertion`."
+    "b2-diversité sur le pool parents+enfants — la sémantique de `ScatterSearchReinsertion`.\n",
+    "\n",
+    "\n",
+    "La sanity check mérite son statut de **précondition du banc entier** : elle fixe trois\n",
+    "vecteurs témoins déterministes et exige que la fonction C# et sa réimplémentation Python\n",
+    "rendent le même conflit. Si elle échouait, aucun écart ultérieur ne serait attribuable — un\n",
+    "décalage de décodage ou de comptage se glisserait dans chaque mesure. C'est parce qu'elle\n",
+    "passe que la suite peut lire « écart de moteur » dans une différence de conflits. Le subclass\n",
+    "mealpy, lui, écrit les formules du bras 1 dans le harnais numpy/Agent du paquet :\n",
+    "`generate_agent`/`evolve` portent le tirage `lambda`, le mate sans soi-même et la réinsertion\n",
+    "b1/b2 — RNG numpy en lieu et place du RNG du moteur, même sémantique déclarée."
    ]
   },
   {
@@ -871,7 +938,14 @@
     "commodité, c'est la seule voie pour un jumeau. Les formules pinnées fixent l'interprétation :\n",
     "l'écart bras 1 ↔ bras 2 est attributable à l'axe diversité (même engine), l'écart bras 1 ↔ bras 3\n",
     "au noyau (mêmes formules). Sans cette tranche, un écart brut ne dirait pas lequel des deux\n",
-    "axes le porte."
+    "axes le porte.\n",
+    "\n",
+    "\n",
+    "Noter que l'absence est mesurée **dans l'exécution même** (scan des 213 optimisateurs,\n",
+    "0 occurrence) : le notebook porte sa propre preuve, et une évolution future de mealpy qui\n",
+    "ajouterait un scatter search rendrait la cellule fausse à la prochaine exécution — le signal\n",
+    "viendrait du notebook, pas d'une note de version. C'est plus fort qu'une absence documentée\n",
+    "en prose, qui dérive silencieusement."
    ]
   },
   {
@@ -1386,18 +1460,35 @@
     "tags": []
    },
    "source": [
-    "**Lecture du croisement.** Trois lectures, une par question posée à la cellule formules.\n",
+    "**Lecture du croisement.** Trois lectures, une par question posée à la cellule formules —\n",
+    "chacune confrontée aux mesures du banc.\n",
     "\n",
-    "1. **L'axe diversité** (complet vs ablaté) : si le b2 max-min travaille, le bras complet devance\n",
-    "   l'ablaté ou le rattrape tard — et la forme par graine dit *quand* la diversité paie (croisement\n",
-    "   = elle paie tard ; persistant = elle paie tout du long). Un écart nul dirait que sur ce puzzle\n",
-    "   l'élitisme suffit, résultat en soi.\n",
-    "2. **Le noyau** (complet vs jumeau mealpy) : mêmes formules pinnées, même budget — l'écart restant\n",
-    "   mesure l'engine (allocation C#, collections typées) contre le harnais mealpy (numpy, objets\n",
-    "   Agent). La colonne ms/éval le chiffrime côté fitness pure, la cellule suivante l'isole.\n",
-    "3. **Le déterminisme** : les 3 répétitions par graine doivent rendre des conflits identiques des\n",
-    "   deux côtés (seeding explicite `ResetSeed` / `solve(seed=...)`) — sinon la lecture 1 et 2\n",
-    "   porte sur du bruit."
+    "1. **L'axe diversité** (complet vs ablaté, même engine) — *attendu* : si le b2 max-min\n",
+    "   travaille, le complet devance l'ablaté ou le rattrape tard ; la forme par graine dit\n",
+    "   *quand* la diversité paie. *Mesuré* : médianes **54,0 contre 52,0 — l'ablaté devant**, et\n",
+    "   la forme n'est pas du bruit : écart nul sur les graines 0 et 1 (les deux bras finissent\n",
+    "   identiques), +4 persistant pour l'ablaté sur la graine 7, −2 seulement pour le complet sur\n",
+    "   la graine 42. Verdict : sur ce puzzle à ce budget, les 15 slots de diversité max-min **ne\n",
+    "   paient pas** — l'ablaté les égalise ou les devance sur 3 graines sur 4. Les checkpoints\n",
+    "   plats du complet (54/54/54/54 dès 25 % du budget) montrent le mécanisme : un RefSet\n",
+    "   diversifié entretient des mates éloignés dont la corde convexe produit des enfants décodant\n",
+    "   loin de toute solution, sans amélioration locale pour les raffiner (amélioration différée,\n",
+    "   hors composé).\n",
+    "2. **Le noyau** (complet vs jumeau mealpy, formules pinnées) — *attendu* : à formules égales,\n",
+    "   l'écart restant mesure l'engine. *Mesuré* : médianes **54,0 contre 51,5 — le jumeau mealpy\n",
+    "   devant** sur 3 graines sur 4 (écarts persistants de 1 à 8 conflits ; seule la graine 42\n",
+    "   inverse, −7 pour MGS). La colonne ms/éval (0,113 contre 0,123, ratio 0,92×) écarte\n",
+    "   l'explication par le coût : la fitness pure est 5,25× **plus rapide** côté C# (0,007 contre\n",
+    "   0,037 ms/éval) — l'écart de qualité vient de l'ordre des opérations et des tirages propres\n",
+    "   à chaque harnais, pas d'un avantage de calcul. À formules déclarées identiques, deux\n",
+    "   moteurs divergent quand même : le pinning fixe les équations, pas la trajectoire.\n",
+    "3. **Le déterminisme** — *mesuré* : 12/12 bras-graines stables sur 3 répétitions (seeding\n",
+    "   explicite `ResetSeed` / `solve(seed=...)`). Les lectures 1 et 2 portent sur du signal, pas\n",
+    "   du bruit.\n",
+    "\n",
+    "Le classement final — jumeau mealpy (51,5) < ablaté (52,0) < complet (54,0) — est inverse de\n",
+    "l'intuition « plus de diversité, meilleur scatter search » : c'est précisément ce que le\n",
+    "troisième bras rendait visible."
    ]
   },
   {
@@ -1421,7 +1512,17 @@
     "Deux issues opposées : si l'ablaté referme l'écart, la diversité b2 n'était qu'une accélération\n",
     "de phase précoce ; s'il plafonne, l'élitisme pur verrouille le RefSet et le verrou s'aggrave avec\n",
     "le temps.\n",
-    "À compléter : `resultats64` rempli, verdict écrit."
+    "À compléter : `resultats64` rempli, verdict écrit.\n",
+    "\n",
+    "\n",
+    "Ce que « se referme » ou « s'installe » signifie pour l'hypothèse diversité : si l'écart\n",
+    "complet-ablaté s'annule à budget ×4, la diversité ne faisait que **ralentir la convergence\n",
+    "précoce** (le complet rattrape une fois la phase d'exploitation atteinte) ; s'il persiste ou\n",
+    "s'agrandit, la politique de réinsertion dégrade la recherche **en profondeur** sur ce puzzle\n",
+    "(mates éloignés → enfants hors bassin, sans amélioration locale pour les récupérer). Le témoin\n",
+    "graine 7 (54 contre 50 à budget ×1, checkpoints plats du complet) donne la prédiction à\n",
+    "battre. Compte tenu du témoin (~1 s pour 160 générations côté complet), attends-toi à ~4 s\n",
+    "par graine et par bras — environ une demi-minute pour la cellule complète."
    ]
   },
   {
@@ -1485,7 +1586,15 @@
     "**{0,5 · 0,85 · 1,0}** (4 graines, 160 générations) et confronte au bras complet (qf = 0,7)\n",
     "du banc : la contribution b2 est-elle monotone, présente un optimum intérieur, ou plate ?\n",
     "Attention au sens de lecture : qf **baisse** = **plus** de slots diversité (b1 = round(N·qf) qualité,\n",
-    "le reste diversité). À compléter : `sweepRows` rempli, verdict écrit."
+    "le reste diversité). À compléter : `sweepRows` rempli, verdict écrit.\n",
+    "\n",
+    "\n",
+    "Les trois lectures possibles du balayage : **monotone croissant** en qf (plus d'élitisme =\n",
+    "mieux → le puzzle est un problème d'exploitation, la diversité n'y sert à rien) ; **optimum\n",
+    "intérieur** autour de 0,85 (un peu de diversité aide, trop dessert — le régime que Glover\n",
+    "recommande en général) ; **plat** (indifférence : le RefSet est assez petit pour que la corde\n",
+    "convexe domine la politique de réinsertion). Le banc courant ne mesure que les extrêmes 0,7 et\n",
+    "1,0 — le balayage ajoute le point 0,5, côté sous-investi."
    ]
   },
   {
@@ -1549,7 +1658,14 @@
     "L'écart ms/éval entre bras peut venir du decode (R1 → grille), du comptage de conflits, ou du\n",
     "moteur lui-même. La cellule coût/éval mesure decode+coût ensemble ; sépare-les : chronomètre\n",
     "500 vecteurs en **deux passes** (decode seul avec coût jeté, coût seul sur grilles pré-décodées),\n",
-    "côté C# **et** côté Python. À compléter : `profilRows` rempli, verdict écrit."
+    "côté C# **et** côté Python. À compléter : `profilRows` rempli, verdict écrit.\n",
+    "\n",
+    "\n",
+    "Le prior à confronter : la cellule coût/éval mesure 5,25× en faveur du C# sur la fitness\n",
+    "complète (decode + coût), mais le rapport ms/éval du banc n'est que de 0,92×. Si le profil\n",
+    "confirme que decode et coût sont massivement plus rapides côté C#, alors le temps restant du\n",
+    "bench vit dans le **moteur** (allocation, collections, RNG), pas dans la fonction — et la\n",
+    "question devient : où exactement ?"
    ]
   },
   {
@@ -1592,6 +1708,30 @@
     "var profilRows = new List<(string cote, string passe, double msParEval)>();\n",
     "// ... mesures a ecrire ...\n",
     "Console.WriteLine(\"Exercice a completer : profil decode vs cost — ou va la milliseconde ?\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mgs30-conclusion",
+   "metadata": {},
+   "source": [
+    "## Conclusion de la paire 9/9\n",
+    "\n",
+    "Trois énoncés sortent du banc, tous mesurés : (1) **la diversité max-min ne paie pas sur ce\n",
+    "puzzle à ce budget** — l'ablaté (qf = 1,0) égalise ou devance le complet sur 3 graines sur 4,\n",
+    "médianes 52,0 contre 54,0 ; (2) **à formules pinnées identiques, le jumeau mealpy devance\n",
+    "l'engine C#** (51,5 contre 54,0) alors que sa fitness pure est 5,25× plus lente — l'écart de\n",
+    "noyau est un écart de trajectoire, pas de coût ; (3) **le déterminisme est intégral**\n",
+    "(12/12), les deux premiers énoncés portent sur du signal.\n",
+    "\n",
+    "Ce que cette paire ne dit pas : Scatter Search en général n'est pas condamné — un puzzle\n",
+    "Sudoku 51 à 8000 évaluations, une amélioration locale différée et une combinaison convexe\n",
+    "unique sont trois choix spécifiques ; un RefSet plus petit, une amélioration engagée ou un\n",
+    "path-relinking plus riche pourraient renverser le verdict. La valeur de la paire est\n",
+    "ailleurs : elle montre qu'une prescription de template (« garder 30 % de diversité », Glover)\n",
+    "est une **hypothèse testable**, pas une évidence — et que le banc à trois bras la teste sans\n",
+    "mélanger noyau et sémantique. La synthèse croisée des neuf paires (coût systématique contre\n",
+    "qualité spécifique) vit dans MGS-31."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #15403

## Summary

Enrichissement de densité du notebook MGS-30 (paire 9/9 de l'EPIC MGS-vs-mealpy) : **610 → 1507 chars de prose par cellule code** (plancher #13410 : 1200), 21 → 23 cellules. Précédent de genre : #14166 (MGS-20 : 608 → 3499).

## Ce qui change

**Markdown-only** — exception C.2 (pas de re-exécution requise) :
- les 10 cellules code et leurs outputs committés sont **byte-identiques** (vérifié : zéro ligne `execution_count`/`outputs` dans le diff ; exec counts 1-10, runs `[1,1,1,1,1,2,1,1,1]` inchangés — les gaps de prose étaient le déficit, pas des trous structurels) ;
- 8 cellules markdown existantes approfondies (intro + position dans la série et plan de lecture ; socle R1 et coût-comme-unique-vérité ; composé lu depuis Glover avec le partage concret 35/15 slots ; sanity-check-comme-précondition et mécanique du subclass mealpy ; absence mesurée dans-l'exécution ; chacun des 3 exercices reçoit ses lectures attendues et son estimateur de runtime) ;
- la cellule « Lecture du croisement » est réécrite en confrontation **attendu/mesuré** par question (verdict : la diversité ne paie pas ; le pinning fixe les équations, pas la trajectoire) ;
- 2 nouvelles cellules : `mgs30-lecture-temoin` (lecture de la course témoin, insérée après la cellule de code qu'elle interprète) et `mgs30-conclusion` (3 énoncés mesurés + ce que la paire ne dit pas + renvoi MGS-31).

## Ancrage des nombres

Chaque prose confronte les sorties committées : témoins graine 7 (complet 54 conflits/1017 ms, ablaté 50/185 ms, mealpy 53/927 ms, cross-check 53) ; médianes du banc (mealpy 51,5 < ablaté 52,0 < complet 54,0) ; axe per-seed (null/null/+4/−2) ; noyau mealpy devant 3/4 ; déterminisme 12/12 ; fitness pure 5,25× (0,007 vs 0,037 ms/éval) contre bench 0,92× ; scan 213 optimisateurs, 0 scatter.

## Validation

- structure : 23 cellules, 10 code, `id` sur cellules nouvelles, metadata `{}` simple ;
- `json` re-sérialisé en indent=1, `ensure_ascii=False`, LF pur, trailing `\n` ;
- pre-commit complet vert (y compris `fix-source-newlines` : 7 dernières lignes de cellules complétées du `\n` terminal).

See #13410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
