### PR TITLE
enrich(rl,#13410): rl_5 densite 704 -> 1266 c/cell — lectures confrontees aux sorties commitees

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
@@ -59,7 +59,15 @@
     "tags": []
    },
    "source": [
-    "## 1. Installation et imports"
+    "## 1. Installation et imports\n",
+    "\n",
+    "\n",
+    "La sortie commitee fixe les versions de travail — `gymnasium=1.3.0`, `numpy=2.4.6` — et c'est\n",
+    "la seule cellule du notebook qui parle d'infrastructure : tout ce qui suit est de l'algorithmique\n",
+    "sur des tables. Les re executions futures de ce notebook sous d'autres versions peuvent faire\n",
+    "bouger les nombres tires du RNG (les graines sont fixees, mais les generateurs de Gymnasium et\n",
+    "de NumPy evoluent) ; les lectures qui suivent citent les nombres committes, a confronter aux\n",
+    "sorties fraiches le cas echeant.\n"
    ]
   },
   {
@@ -119,7 +127,19 @@
     "- **FrozenLake-v1** : Grille 4x4 ou l'agent doit traverser un lac gele en evitant les trous. Espace d'etat : 16 cases, espace d'action : 4 directions.\n",
     "- **CliffWalking-v1** : Grille ou l'agent doit atteindre la sortie en longeant une falaise. Espace d'etat : 48 cases, espace d'action : 4 directions.\n",
     "\n",
-    "Ces environnements sont ideals pour les mÃ©thodes tabulaires car leur espace d'etat est assez petit pour stocker une table Q complete."
+    "Ces environnements sont ideals pour les mÃ©thodes tabulaires car leur espace d'etat est assez petit pour stocker une table Q complete.\n",
+    "\n",
+    "\n",
+    "Ces deux environnements ne sont pas interchangeables : ils portent chacun une moitie du notebook.\n",
+    "FrozenLake est le banc **model-based** — `env.unwrapped.P` expose l'integralite du modele de\n",
+    "transition, dont l'Iteration de Valeur et l'Iteration de Politique ont absolument besoin (leurs\n",
+    "backups echantillonnent `P` en boucle). CliffWalking est le banc **model-free** — les\n",
+    "algorithmes des sections 5 a 6quater n'ouvriront jamais `P` : ils apprennent uniquement des\n",
+    "quintuplets `(s, a, r, s', done)` observes en jouant. Les structures de recompense s'opposent\n",
+    "aussi : FrozenLake est *sparse* (+1 au but, 0 partout ailleurs — 15 cases muettes sur 16),\n",
+    "CliffWalking est *dense et punitif* (-1 par pas, -100 pour une chute dans la falaise). Une\n",
+    "methode qui ne marcherait que sur l'une de ces deux structures ne meriterait pas le nom de\n",
+    "generale ; le notebook la fera passer par les deux.\n"
    ]
   },
   {
@@ -207,7 +227,16 @@
    "source": [
     "L'espace d'etat comporte 16 cases (grille 4x4) et l'espace d'action 4 directions. Chaque case est identifiee par un entier de 0 a 15.\n",
     "\n",
-    "Pour les mÃ©thodes tabulaires, nous avons besoin de connaitre les probabilites de transition $P(s'|s, a)$. Gymnasium les expose via `env.unwrapped.P` (il faut acceder a l'environnement natif sous-jacent aux wrappers)."
+    "Pour les mÃ©thodes tabulaires, nous avons besoin de connaitre les probabilites de transition $P(s'|s, a)$. Gymnasium les expose via `env.unwrapped.P` (il faut acceder a l'environnement natif sous-jacent aux wrappers).\n",
+    "\n",
+    "\n",
+    "La sortie commitee donne la lecture brute : `Discrete(16)` pour les etats, `Discrete(4)` pour\n",
+    "les actions, avec la semantique fixee par Gymnasium (0=Gauche, 1=Bas, 2=Droite, 3=Haut — la\n",
+    "convention sera rappelee dans chaque affichage de politique). « Tabulaire » signifie exactement\n",
+    "ceci : la valeur peut vivre dans une table indexee par les entiers `(etat, action)` — ici\n",
+    "16 x 4 = 64 entrees. Tant que cette table tient en memoire, aucune approximation n'est\n",
+    "necessaire et toutes les garanties de convergence du TD tabulaire s'appliquent ; RL-6 montrera\n",
+    "ce qui casse quand l'espace d'etat devient continu et que la table doit devenir un reseau.\n"
    ]
   },
   {
@@ -281,7 +310,18 @@
    "source": [
     "Chaque transition est un tuple `(probabilite, etat_suivant, recompense, est_terminal)`. En mode non-glissant (`is_slippery=False`), chaque action a une probabilite de 1.0 de reussir.\n",
     "\n",
-    "En mode glissant (par defaut), l'action peut echouer et mener dans une direction adjacente, rendant le problÃ¨me stochastique."
+    "En mode glissant (par defaut), l'action peut echouer et mener dans une direction adjacente, rendant le problÃ¨me stochastique.\n",
+    "\n",
+    "\n",
+    "Les deux exemples committes meritent une lecture lente. Depuis l'etat 0 (le depart `S`), action\n",
+    "Droite : `[(1.0, 1, 0, False)]` — probabilite 1, etat 1, recompense 0, non terminal : un\n",
+    "deplacement deterministe banal. Depuis l'etat 1, action Bas : `[(1.0, 5, 0, True)]` — l'etat 5\n",
+    "est un **trou** (deuxieme ligne de la grille, case `H`), et le drapeau `True` dit que l'episode\n",
+    "s'y termine. Un seul mauvais pas depuis la case voisine du depart tue l'episode avec une\n",
+    "recompense nulle : c'est ce qui rend certaines actions interdites en pratique et donne son\n",
+    "relief a la fonction de valeur. En mode glissant (`is_slippery=True`, l'exercice 1), chacune de\n",
+    "ces listes singleton deviendrait une liste de trois issues possibles et la certitude\n",
+    "disparaitrait.\n"
    ]
   },
   {
@@ -388,6 +428,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "rl5-vi-anatomy",
+   "metadata": {},
+   "source": [
+    "\n",
+    "L'anatomie de la fonction qui vient d'etre definie, avant de la lancer. Chaque **balayage**\n",
+    "parcourt tous les etats et recalcule `V[s]` comme le maximum sur les actions de la somme\n",
+    "des transitions `P[s][a]` de `recompense + gamma * V[next_s] * (1 - done)` — l'application\n",
+    "litterale de l'equation d'optimalite de Bellman. Trois details de conception se lisent dans le\n",
+    "code :\n",
+    "\n",
+    "1. **La mise a jour est en place** (`V[s]` est ecrase pendant le balayage) : les etats tardifs\n",
+    "   de la boucle lisent les valeurs deja recalculees des etats precedents — variante dite\n",
+    "   de Gauss-Seidel, qui converge generalement en moins d'iterations qu'une version synchrone\n",
+    "   (copie fraiche lue en entier), au prix d'un ordre de parcours qui influe le chemin exact.\n",
+    "2. **Le facteur `(1 - done)`** est la facon tabulaire d'annuler le futur des etats terminaux :\n",
+    "   la transition qui mene au but (`done=True`) contribue sa recompense mais pas de valeur\n",
+    "   d'arrivee — c'est ce qui rend les trous exactement nuls dans la table finale.\n",
+    "3. **Le critere d'arret** compare le delta maximal du balayage a theta = 1e-8, inferieur a la\n",
+    "   precision utile des float — l'arret se fera sur un vrai point fixe, pas sur un artefact\n",
+    "   d'arrondi. La politique greedy est extraite apres coup par une seconde passe `argmax` sur\n",
+    "   la table V convergee.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "l0d2f012",
@@ -454,7 +519,17 @@
    "source": [
     "La fonction de valeur $V^*$ attribue des valeurs croissantes aux etats proches du but (case 15). Les etats terminaux (trous) ont une valeur de 0.\n",
     "\n",
-    "La politique greedy correspondante indique la direction optimale a suivre depuis chaque case pour atteindre le but."
+    "La politique greedy correspondante indique la direction optimale a suivre depuis chaque case pour atteindre le but.\n",
+    "\n",
+    "\n",
+    "L'arithmetique du decalage se verifie sur la table commitee. La trajectoire optimale depuis le\n",
+    "depart fait six deplacements ; la recompense +1 n'arrive qu'au dernier, si bien que\n",
+    "$V^*(0) = \\gamma^5 \\times 1 = 0{,}99^5 = 0{,}951$ — exactement la valeur affichee. Les etats\n",
+    "terminaux (trous) valent 0 : un etat sans futur n'a d'autre valeur que sa recompense de fin\n",
+    "(nulle pour une chute). Les cases 13 et 14 (0,99 et 1,0) forment le corridor d'arrivee, les\n",
+    "cases 8 a 10 (0,97-0,99) l'approche par le milieu — le gradient de valeur dessine la topologie\n",
+    "du lac, et la politique greedy ne fait que suivre la ligne de plus grande pente de cette\n",
+    "table.\n"
    ]
   },
   {
@@ -606,7 +681,17 @@
     "tags": []
    },
    "source": [
-    "La courbe de convergence montre une diminution exponentielle du delta maximum. En quelques itÃ©rations, les valeurs se stabilisent et l'algorithme converge vers l'unique point fixe de l'equation de Bellman."
+    "La courbe de convergence montre une diminution exponentielle du delta maximum. En quelques itÃ©rations, les valeurs se stabilisent et l'algorithme converge vers l'unique point fixe de l'equation de Bellman.\n",
+    "\n",
+    "\n",
+    "Le chiffre final merite l'arret : delta = 0,00e+00 a l'iteration 7 — une convergence **exacte**,\n",
+    "pas approchee. La raison est topologique : chaque balayage combine les valeurs des voisines\n",
+    "d'une case, donc une information de valeur se propage d'au plus une case par iteration ; la\n",
+    "trajectoire optimale de ce lac fait six deplacements, et au septieme balayage plus aucune\n",
+    "valeur ne peut bouger. Le seuil theta = 1e-8 n'a meme pas eu a trancher : le point fixe de\n",
+    "l'equation de Bellman est atteint avant que le critere d'arret ne s'exprime. Sur un environnement\n",
+    "stochastique ou glissant, la propagation resterait geometrique mais le delta ne serait plus\n",
+    "jamais exactement nul — d'ou le role habituel de theta, qui coupe la descente a epsilon pres.\n"
    ]
   },
   {
@@ -742,7 +827,18 @@
     "tags": []
    },
    "source": [
-    "Policy ItÃ©ration converge en peu d'itÃ©rations (ici 7 sur ce FrozenLake dÃ©terministe Ã  16 Ã©tats â€” comme l'ItÃ©ration de Valeur, qui converge elle aussi en 7 pas). Les deux mÃ©thodes aboutissent Ã  la mÃªme politique optimale, comme garanti par la thÃ©orie."
+    "Policy ItÃ©ration converge en peu d'itÃ©rations (ici 7 sur ce FrozenLake dÃ©terministe Ã  16 Ã©tats â€” comme l'ItÃ©ration de Valeur, qui converge elle aussi en 7 pas). Les deux mÃ©thodes aboutissent Ã  la mÃªme politique optimale, comme garanti par la thÃ©orie.\n",
+    "\n",
+    "\n",
+    "Les deux `True` committes (V(π) converge vers V*, politiques identiques) disent que\n",
+    "l'Iteration de Politique a trouve le meme optimum que l'Iteration de Valeur — la theorie le\n",
+    "garantit sur un MDP fini, le banc le verifie numeriquement. La difference n'est pas dans le\n",
+    "resultat mais dans le travail par iteration : l'Iteration de Politique resout **completement**\n",
+    "l'evaluation de sa politique courante (boucle interne jusqu'a convergence) avant de faire un\n",
+    "seul pas d'amelioration, quand l'Iteration de Valeur entrelace les deux a chaque balayage.\n",
+    "Sur 16 etats, les deux coutent des millisecondes ; la difference devient structurale sur de\n",
+    "grands espaces ou l'evaluation exacte est inabordable — c'est exactement le pont vers les\n",
+    "methodes model-free qui ouvrent la section 5.\n"
    ]
   },
   {
@@ -896,7 +992,18 @@
     "tags": []
    },
    "source": [
-    "**Du atome Ã  la boucle.** Cette unique mise Ã  jour ne change presque rien : Q(14,2) passe de 0 Ã  0.1. C'est normal â€” un seul pas d'information. La boucle d'entraÃ®nement ci-dessous **rÃ©pÃ¨te cet atome Ã  chaque pas de chaque Ã©pisode** : Ã  chaque transition rencontrÃ©e, la valeur ajustÃ©e se propage un peu plus loin, et la valeur du futur (le terme $\\gamma \\max_{a'} Q(s',a')$) devient non nulle dÃ¨s que les Ã©tats voisins sont eux-mÃªmes valorisÃ©s. C'est ce qui fait converger la table $Q$ vers $Q^*$ sans connaÃ®tre le modÃ¨le de transition."
+    "**Du atome Ã  la boucle.** Cette unique mise Ã  jour ne change presque rien : Q(14,2) passe de 0 Ã  0.1. C'est normal â€” un seul pas d'information. La boucle d'entraÃ®nement ci-dessous **rÃ©pÃ¨te cet atome Ã  chaque pas de chaque Ã©pisode** : Ã  chaque transition rencontrÃ©e, la valeur ajustÃ©e se propage un peu plus loin, et la valeur du futur (le terme $\\gamma \\max_{a'} Q(s',a')$) devient non nulle dÃ¨s que les Ã©tats voisins sont eux-mÃªmes valorisÃ©s. C'est ce qui fait converger la table $Q$ vers $Q^*$ sans connaÃ®tre le modÃ¨le de transition.\n",
+    "\n",
+    "\n",
+    "La contraction commitee est le coeur pedagogique de cette cellule : en dix mises a jour sur la\n",
+    "meme transition, Q(14,2) monte de 0,1 a 0,6513 par pas successifs 0,1 -> 0,19 -> 0,271 -> ...\n",
+    "Chaque update deplace Q d'une fraction alpha de l'erreur residuelle, donc l'ecart a la cible\n",
+    "est multiplie par (1 - alpha) = 0,9 a chaque pas : apres dix updates il ne vaut plus que\n",
+    "0,9^10 = 0,35 de l'erreur initiale, apres cent il serait negligeable. Q converge\n",
+    "asymptotiquement vers r = 1 sans jamais l'atteindre exactement — c'est le compromis de la\n",
+    "descente stochastique a taux constant : la stabilite (chaque erreur partielle corrigee) contre\n",
+    "la convergence exacte (qui exigerait un alpha decroissant). La boucle complete qui suit ne\n",
+    "fait que repeter cet atome sur des transitions variees.\n"
    ]
   },
   {
@@ -1021,7 +1128,17 @@
     "tags": []
    },
    "source": [
-    "Le Q-Learning converge vers la politique optimale mÃªme sans connaitre le modÃ¨le de transition. L'exploration decroissante ($\\varepsilon$ passe de 1.0 a 0.01) permet de visiter suffisamment d'etats au debut, puis d'exploiter la politique apprise."
+    "Le Q-Learning converge vers la politique optimale mÃªme sans connaitre le modÃ¨le de transition. L'exploration decroissante ($\\varepsilon$ passe de 1.0 a 0.01) permet de visiter suffisamment d'etats au debut, puis d'exploiter la politique apprise.\n",
+    "\n",
+    "\n",
+    "La nuance chiffee : 0,892 de recompense moyenne sur les 1000 derniers episodes, alors que\n",
+    "$V^*(\\text{depart}) = 0{,}951$. Ce n'est pas un defaut d'apprentissage — la politique extraite\n",
+    "est l'optimale, verifiee cellule contre cellule contre le resultat de l'Iteration de Valeur —\n",
+    "mais un effet du protocole de mesure : la recompense mesuree est celle du **comportement**,\n",
+    "encore ε-greedy avec ε ramene a 0,01. Environ 1 % des actions sont aleatoires ; certaines font\n",
+    "tomber l'agent dans un trou et annulent la recompense de tout l'episode. La table Q est\n",
+    "optimale ; la trajectoire executee, elle, continue d'explorer. Mesurer la politique greedy\n",
+    "seule — ce que fera la section 6 sur CliffWalking — retirerait exactement cet ecart.\n"
    ]
   },
   {
@@ -1085,7 +1202,19 @@
     "tags": []
    },
    "source": [
-    "La courbe montre la transition entre exploration (recompenses faibles et irregulieres au debut) et exploitation. La recompense moyenne se stabilise autour de ~0.89 (0.892 ici, avec la graine fixee a 42) sans atteindre 1.0 : l environnement est deterministe (is_slippery=False, cf cellule de creation de env), mais la strategie epsilon-greedy conserve environ 1% d actions aleatoires en fin d apprentissage (epsilon decroit jusqu a 0.01), et ces actions aleatoires font parfois tomber l agent dans un trou. Le point vraiment verificable et reproductible est la **convergence vers la politique optimale** : avec cette graine, la politique apprise correspond a la politique optimale calculee par iteration de valeur (sortie cellule precedente : Â« Correspond a la politique optimale ? True Â»)."
+    "La courbe montre la transition entre exploration (recompenses faibles et irregulieres au debut) et exploitation. La recompense moyenne se stabilise autour de ~0.89 (0.892 ici, avec la graine fixee a 42) sans atteindre 1.0 : l environnement est deterministe (is_slippery=False, cf cellule de creation de env), mais la strategie epsilon-greedy conserve environ 1% d actions aleatoires en fin d apprentissage (epsilon decroit jusqu a 0.01), et ces actions aleatoires font parfois tomber l agent dans un trou. Le point vraiment verificable et reproductible est la **convergence vers la politique optimale** : avec cette graine, la politique apprise correspond a la politique optimale calculee par iteration de valeur (sortie cellule precedente : Â« Correspond a la politique optimale ? True Â»).\n",
+    "\n",
+    "\n",
+    "Cette courbe est la premiere ou le **temps d'apprentissage** apparait : les iterations\n",
+    "precedentes (Valeur, Politique) balayaient un modele deja connu, ici la connaissance\n",
+    "s'accumule episode apres episode. Le regime transitoire des premiers milliers d'episodes\n",
+    "(recompenses faibles, irregulieres) correspond a ε eleve : l'agent marche au hasard, tombe dans\n",
+    "les trous, et chaque episode echoue. La montee ensuite n'est pas un changement d'algorithme\n",
+    "mais l'effet combine de la decroissance d'ε (0,999 par episode : ε passe sous 0,1 vers\n",
+    "l'episode 2300) et de la table Q qui a vu assez de transitions pour que la politique greedy\n",
+    "devienne correcte partout. La moyenne mobile sur 1000 episodes lisse la variance\n",
+    "d'echantillonnage — la recompense brute d'un episode reste binaire (1 ou 0) sur ce\n",
+    "environnement.\n"
    ]
   },
   {
@@ -1386,7 +1515,18 @@
    "source": [
     "La structure de CliffWalking est redoutable pour un agent : 48 Ã©tats (grille 4Ã—12), une **falaise mortelle** qui barre toute la ligne du bas entre le dÃ©part `S` et le but `G`. Chaque pas coÃ»te $-1$ (l'agent est incitÃ© Ã  Ãªtre bref), mais tomber dans la falaise coÃ»te $-100$ et renvoie immÃ©diatement au dÃ©part. Le compromis est donc le suivant : longer la falaise (chemin court, risque maximal) ou passer par le haut (chemin sÃ»r, mais plus de pas nÃ©gatifs).\n",
     "\n",
-    "LanÃ§ons maintenant le Q-Learning sur 10 000 Ã©pisodes et Ã©valuons la **politique greedy** obtenue â€” c'est ici que le caractÃ¨re *off-policy* du Q-Learning devrait lui permettre de dÃ©couvrir le chemin optimal le long de la falaise, mÃªme si l'exploration $\\varepsilon$-greedy prend parfois des actions sous-optimales en cours d'apprentissage."
+    "LanÃ§ons maintenant le Q-Learning sur 10 000 Ã©pisodes et Ã©valuons la **politique greedy** obtenue â€” c'est ici que le caractÃ¨re *off-policy* du Q-Learning devrait lui permettre de dÃ©couvrir le chemin optimal le long de la falaise, mÃªme si l'exploration $\\varepsilon$-greedy prend parfois des actions sous-optimales en cours d'apprentissage.\n",
+    "\n",
+    "\n",
+    "La geometrie commitee dit tout : depart en bas a gauche (3,0), but en bas a droite (3,11), et\n",
+    "**toute la ligne du bas entre eux est la falaise** (3,1 a 3,10). Deux familles de chemins\n",
+    "existent : remonter d'une ligne, traverser en surete, redescendre au but — long mais sans\n",
+    "risque ; ou rester sur la ligne du bas et longer la falaise sur 10 cases — court, mais chaque\n",
+    "pas cote a cote du gouffre. Avec la recompense -1 par pas et -100 par chute, le chemin du bord\n",
+    "vale -13 et le chemin sur vaut environ -17 (15 pas surs, chiffres a l'appui dans les cellules\n",
+    "qui suivent) : l'optimum **sans risque d'exploration** est le chemin du bord, mais cet optimum\n",
+    "ne dit rien de ce que vaut ce bord pour un agent qui se trompe encore 1 fois sur 100. Toute\n",
+    "la suite de la section 6 est la confrontation de ces deux lectures.\n"
    ]
   },
   {
@@ -1473,7 +1613,16 @@
     "tags": []
    },
    "source": [
-    "Le Q-Learning decouvre le chemin optimal le long de la falaise (recompense proche de -13). C'est un rÃ©sultat caractÃ©ristique de Q-Learning : en tant qu'algorithme off-policy, il apprend la politique optimale mÃªme si l'exploration utilise des actions sous-optimales."
+    "Le Q-Learning decouvre le chemin optimal le long de la falaise (recompense proche de -13). C'est un rÃ©sultat caractÃ©ristique de Q-Learning : en tant qu'algorithme off-policy, il apprend la politique optimale mÃªme si l'exploration utilise des actions sous-optimales.\n",
+    "\n",
+    "\n",
+    "Le ±0,0 committ est lui-meme une information : l'evaluation est deterministe (environnement\n",
+    "deterministe + politique greedy), donc l'ecart-type sur plusieurs episodes d'evaluation est\n",
+    "exactement nul — toute la variance qui apparaitra dans les ablations suivantes sera\n",
+    "entierement du cote de l'apprentissage (graines), jamais du cote de la mesure. Et -13,0 est\n",
+    "**la** recompense du chemin optimal : 13 deplacements a -1 (monter d'une ligne, traverser,\n",
+    "redescendre), aucune chute a -100. Le Q-Learning n'a pas seulement converge vers une bonne\n",
+    "politique — il a trouve exactement la trajectoire de longueur minimale.\n"
    ]
   },
   {
@@ -1633,6 +1782,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "rl5-sarsa-def",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Ce que cette fonction incarne : une seule chose change entre Q-Learning et SARSA — **la cible**.\n",
+    "Q-Learning ecrivait `r + gamma * max_a Q(s', a)` ; SARSA ecrit `r + gamma * Q(s', a')` ou `a'`\n",
+    "est l'action **effectivement tiree** par la meme politique ε-greedy au pas suivant. L'algorithme\n",
+    "ne critique pas la politique qu'il voudrait jouer, il critique celle qu'il joue vraiment. Deux\n",
+    "consequences directes se lisent dans le code :\n",
+    "\n",
+    "1. `next_action` doit etre tire **avant** la mise a jour (la cible en depend), puis rejouee\n",
+    "   comme action d'origine au pas suivant (`action = next_action`) — c'est le quintuplet\n",
+    "   `(s, a, r, s', a')` qui donne son nom a l'algorithme, contre le quadruplet du Q-Learning.\n",
+    "2. Au dernier pas d'un episode (`done`), la cible est la recompense nue — pas de `max`, pas\n",
+    "   d'echantillon : un etat terminal n'a pas d'action suivante a tirer.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "id": "cce182c8",
@@ -1681,6 +1849,18 @@
     "print(f\"SARSA  - recompense moyenne greedy : {mean_sarsa:.1f} +/- {std_sarsa:.1f}\")\n",
     "print(f\"Q-Learn - recompense moyenne greedy : {mean_r:.1f} +/- {std_r:.1f}\")\n",
     "print(f\"(Chemin optimal = -13)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rl5-sarsa-train",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Lecture des nombres avant la figure : SARSA -17,0 ± 0,0 ; Q-Learning -13,0 ± 0,0 ; optimum\n",
+    "-13. L'ecart de quatre points n'est pas un echec d'apprentissage — c'est le prix structurel\n",
+    "de la prudence on-policy, et la cellule suivante le rendra visible : les deux trajectoires\n",
+    "apprises n'empruntent pas la meme ligne de la grille.\n"
    ]
   },
   {
@@ -1850,6 +2030,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "rl5-expected-def",
+   "metadata": {},
+   "source": [
+    "\n",
+    "La modification tient dans la construction de la cible : la ou SARSA echantillonne **une**\n",
+    "action `a'` et paie la variance de ce tirage, Expected SARSA remplace l'echantillon par\n",
+    "l'esperance sous la politique comportementale — pour un ε-greedy,\n",
+    "`(1 - ε + ε/n) * max + (ε/n) * somme(Q(s', .))`, exactement la formule du docstring ci-dessus.\n",
+    "Le gain : la cible ne depend plus du tirage, seulement de la table — meme signal moyen, variance\n",
+    "d'echantillonnage en moins. Le cout : un balayage de la ligne `Q[s']` a chaque mise a jour,\n",
+    "negligeable en tabulaire (4 entrees), devient le facteur limitant en approximation (evaluer\n",
+    "toutes les actions d'un reseau a chaque pas). Entre le `max` de Q-Learning (optimiste,\n",
+    "biaise vers l'agent parfait) et l'echantillon de SARSA (non biais pour la politique jouee,\n",
+    "bruite), l'esperance est le tiers mesuré.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 21,
    "id": "b4c600a4",
@@ -1913,7 +2111,14 @@
     "tags": []
    },
    "source": [
-    "**Lecture du resultat.** Expected SARSA converge generalement plus vite que SARSA (moins de variance d'echantillon) tout en preservant la propriete on-policy. Avec $\\varepsilon$ qui decroit au cours de l'apprentissage, Expected SARSA tend vers Q-Learning en fin d'apprentissage (puisque $\\varepsilon \\to 0$, l'esperance devient $\\max$)."
+    "**Lecture du resultat.** Expected SARSA converge generalement plus vite que SARSA (moins de variance d'echantillon) tout en preservant la propriete on-policy. Avec $\\varepsilon$ qui decroit au cours de l'apprentissage, Expected SARSA tend vers Q-Learning en fin d'apprentissage (puisque $\\varepsilon \\to 0$, l'esperance devient $\\max$).\n",
+    "\n",
+    "\n",
+    "La position chiffee commitee complete le podium : Q-Learning -13,0, Expected SARSA -15,0,\n",
+    "SARSA -17,0. L'ordre n'est pas un artefact de graines — l'evaluation greedy est deterministe —\n",
+    "c'est la hierarchie exacte des trois cibles de mise a jour sur ce probleme : le `max` suppose\n",
+    "l'agent parfait et prend le bord, l'echantillon paie chaque incertitude d'exploration et prend\n",
+    "de la marge, l'esperance tient les deux.\n"
    ]
   },
   {
@@ -2042,6 +2247,23 @@
     "        rewards_per_episode.append(episode_reward)\n",
     "\n",
     "    return Q, np.array(rewards_per_episode)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rl5-nstep-def",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Le parametre `n` controle **l'horizon de bootstrap** : la cible additionne les `n` recompenses\n",
+    "effectivement recues puis amorce sur `Q[s_n, a_n]` — la valeur d'un etat atteint n pas plus\n",
+    "tard, pas celle du pas suivant. A `n = 1` on retrouve SARSA (un pas, puis bootstrap) ; a `n`\n",
+    "egal a la longueur des episodes, on aurait du Monte Carlo (aucun bootstrap, biais nul mais\n",
+    "variance maximale). Chaque valeur de `n` place la mise a jour sur le continuum biais-variance :\n",
+    "le bootstrap **biaise** (il fait confiance a une valeur encore approximative), le retour complet\n",
+    "**varie** (il depend de toute la trajectoire, exploration comprise). L'ablation qui suit\n",
+    "partage les memes 4 graines entre n in {1, 3, 5} — meme RNG, memes episodes explores — pour\n",
+    "que la difference inter-n ne se confonde pas avec la difference inter-graines.\n"
    ]
   },
   {
@@ -2264,6 +2486,28 @@
     "    'Politique cible vs comportementale': ['-', '-', 'Differentes', 'Identiques', 'Identiques']\n",
     "})\n",
     "display(comparison)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rl5-compare-read",
+   "metadata": {},
+   "source": [
+    "\n",
+    "La lecture transversale du tableau, colonne par colonne :\n",
+    "\n",
+    "- **Type** : les deux premieres lignes sont *model-based* (elles consomment `P` en boucle),\n",
+    "  les trois dernieres *model-free* (elles n'ont vu que des quintuplets observes) — c'est la\n",
+    "  frontiere la plus importante du notebook, elle correspond au passage FrozenLake/CliffWalking.\n",
+    "- **Cible** : ce que chaque algorithme ecrit comme valeur de suite — `V*(s)` pour l'iteration\n",
+    "  de Valeur, `V_pi(s)` pour l'iteration de Politique (la valeur de **sa** politique, pas de\n",
+    "  l'optimale), puis les trois variantes de cible Q deja rencontrees.\n",
+    "- **Connaissance du modele** : redondant avec Type mais dit la chose du point de vue de\n",
+    "  l'agent — ce qu'il doit savoir **avant** de commencer.\n",
+    "- **Politique cible vs comportementale** : la colonne qui separe off-policy (Q-Learning :\n",
+    "  apprend l'optimum en explorant autrement) de on-policy (SARSA, Expected SARSA : la politique\n",
+    "  evaluee est celle qui genere les donnees). C'est la colonne qui explique le -13 contre -17\n",
+    "  de la section 6 — deux reponses honnetes a deux questions differentes.\n"
    ]
   },
   {
@@ -2495,7 +2739,16 @@
    "source": [
     "### Exercice 5 : Bridge Q-Learning et SARSA via l'equation de Bellman\n",
     "\n",
-    "Sur papier, derivez l'equation de mise a jour d'une methode hybride qui utiliserait l'action *greedy* (comme Q-Learning) pendant les 100 premieres episodes (phase d'exploration), puis l'action *behaviorale* (comme SARSA) ensuite. Quel comportement attendez-vous sur CliffWalking ?"
+    "Sur papier, derivez l'equation de mise a jour d'une methode hybride qui utiliserait l'action *greedy* (comme Q-Learning) pendant les 100 premieres episodes (phase d'exploration), puis l'action *behaviorale* (comme SARSA) ensuite. Quel comportement attendez-vous sur CliffWalking ?\n",
+    "\n",
+    "\n",
+    "L'enjeu conceptuel : les deux algorithmes different par **une seule ligne** (la cible\n",
+    "`max_a Q(s',a)` contre `Q(s', a'_choisie)`), et l'exercice demande de construire le pont\n",
+    "explicite entre eux — une mise a jour qui commence comme SARSA et bascule sur le max apres un\n",
+    "episode charniere. La question interessante a se poser en implementant : la bascule est-elle\n",
+    "un changement de cible (le meme algorithme qui devient plus optimiste) ou un changement\n",
+    "d'algorithme (deux regimes appris sequentiellement) ? Le protocole de mesure doit separer les\n",
+    "deux lectures.\n"
    ]
   },
   {
@@ -2585,7 +2838,15 @@
    "source": [
     "### Exercice 6 : Variance d'echantillon vs variance bootstrap\n",
     "\n",
-    "Reprendre la cellule `n_step_sarsa` et tracer l'**ecart-type** de la recompense greedy finale (sur 4 graines) en fonction de $n \\in \\{1, 2, 3, 4, 5, 10\\}$. Verifier que la variance *augmente* avec $n$ â€” c'est l'effet attendu du compromis biais-variance."
+    "Reprendre la cellule `n_step_sarsa` et tracer l'**ecart-type** de la recompense greedy finale (sur 4 graines) en fonction de $n \\in \\{1, 2, 3, 4, 5, 10\\}$. Verifier que la variance *augmente* avec $n$ â€” c'est l'effet attendu du compromis biais-variance.\n",
+    "\n",
+    "\n",
+    "L'enjeu conceptuel : la cellule d'ablation n-step a montre la variance **inter-graines** (std\n",
+    "0,87 a n=5) ; cet exercice demande la variance **d'estimation** — combien de relances faut-il\n",
+    "pour se fier a un median a +/- 1 point de recompense. Le bootstrap (reechantillonnage avec\n",
+    "remise des runs observes) et l'echantillonnage direct donnent des intervalles differents sur\n",
+    "petits echantillons ; comparer les deux sur le meme jeu de runs est la facon la plus directe\n",
+    "de voir pourquoi les rapports multi-graines du depot exigent 4 seeds minimum.\n"
    ]
   },
   {
@@ -2663,7 +2924,15 @@
    "source": [
     "### Exercice 7 : Le double apprendre de SARSA($\\lambda$)\n",
     "\n",
-    "Lire la section 7.4 de Sutton & Barto. Implementer une version simplifiee de SARSA(\\lambda) avec traces d'eligibilite $e_t(s,a) = \\gamma\\lambda e_{t-1}(s,a) + \\mathbb{1}[S_t=s, A_t=a]$, et mise a jour apres chaque episode. Comparer la vitesse de convergence a SARSA(0) sur CliffWalking."
+    "Lire la section 7.4 de Sutton & Barto. Implementer une version simplifiee de SARSA(\\lambda) avec traces d'eligibilite $e_t(s,a) = \\gamma\\lambda e_{t-1}(s,a) + \\mathbb{1}[S_t=s, A_t=a]$, et mise a jour apres chaque episode. Comparer la vitesse de convergence a SARSA(0) sur CliffWalking.\n",
+    "\n",
+    "\n",
+    "L'enjeu conceptuel : SARSA(λ) ajoute les **traces d'eligibilite** — au lieu de re-apprendre\n",
+    "seulement le dernier quintuplet, chaque paire (s,a) visite garde une trace qui decroit de λ\n",
+    "par pas et qui distribue l'erreur TD vers tout l'historique recent de l'episode. C'est le\n",
+    "compromis de Monte Carlo (crediter toute la trajectoire) sans en payer le cout d'attendre la fin\n",
+    "d'episode. L'implementation demandee est la version lineaire du compromis que l'ablation n-step\n",
+    "a explore en discret.\n"
    ]
   },
   {
@@ -2738,6 +3007,35 @@
     "        epsilon = max(epsilon_end, epsilon * epsilon_decay)\n",
     "        rewards_per_episode.append(episode_reward)\n",
     "    return Q, np.array(rewards_per_episode)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rl5-synthese",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Synthese : la cible de mise a jour est une posture de risque\n",
+    "\n",
+    "Sur le meme CliffWalking, aux memes hyperparametres, les algorithmes ne rendent pas la meme\n",
+    "recompense greedy : Q-Learning -13,0 ; Expected SARSA -15,0 ; SARSA -17,0 ; n-step (n = 3 et 5)\n",
+    "-17,0 avec une variance de graines des n = 5. La seule chose qui differencie ces algorithmes\n",
+    "est **la cible de leur mise a jour** — ce qu'ils ecrivent dans Q(s, a) comme valeur de suite :\n",
+    "\n",
+    "| Cible | Forme | Recompense greedy |\n",
+    "|---|---|---|\n",
+    "| Maximum | `max_a Q(s', a)` — l'agent suppose parfait | -13,0 |\n",
+    "| Esperance | `E_pi[Q(s', a)]` — l'agent moyen sous exploration | -15,0 |\n",
+    "| Echantillon | `Q(s', a')` avec `a' ~ pi` — l'agent reellement joue | -17,0 |\n",
+    "\n",
+    "Le `max` est optimiste : il evalue l'optimum *comme si* l'agent jouait glouton a chaque pas,\n",
+    "et sa trajectoire apprise longe la falaise. L'echantillon paie chaque incertitude\n",
+    "d'exploration : il evalue l'optimum d'un agent qui se trompe encore, et sa trajectoire prend\n",
+    "du recul. L'esperance tient les deux par construction. Aucun n'est faux — ils repondent a des\n",
+    "questions differentes (que vaut le bord pour un agent parfait ? pour l'agent que je deploye ?)\n",
+    "— et le banc a trois bras rend la difference **visible dans la trajectoire**, pas seulement\n",
+    "dans un chiffre de recompense. C'est la lecon a emporter avant d'approximer : le choix de la\n",
+    "cible est un choix de deploiement.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
@@ -2262,8 +2262,12 @@
     "variance maximale). Chaque valeur de `n` place la mise a jour sur le continuum biais-variance :\n",
     "le bootstrap **biaise** (il fait confiance a une valeur encore approximative), le retour complet\n",
     "**varie** (il depend de toute la trajectoire, exploration comprise). L'ablation qui suit\n",
-    "partage les memes 4 graines entre n in {1, 3, 5} — meme RNG, memes episodes explores — pour\n",
-    "que la difference inter-n ne se confonde pas avec la difference inter-graines.\n"
+    "partage les memes 4 graines entre n in {1, 3, 5} : un protocole apparie par graines — memes\n",
+    "initialisations, meme calendrier d'exploration — qui neutralise la variance inter-graines.\n",
+    "Les trajectoires parcourues, elles, divergent des que n change les mises a jour (donc la\n",
+    "politique comportementale, donc la consommation du RNG) : la comparaison garantit des departs\n",
+    "apparies, pas des episodes identiques.\n",
+    "\n"
    ]
   },
   {
@@ -2744,11 +2748,13 @@
     "\n",
     "L'enjeu conceptuel : les deux algorithmes different par **une seule ligne** (la cible\n",
     "`max_a Q(s',a)` contre `Q(s', a'_choisie)`), et l'exercice demande de construire le pont\n",
-    "explicite entre eux — une mise a jour qui commence comme SARSA et bascule sur le max apres un\n",
-    "episode charniere. La question interessante a se poser en implementant : la bascule est-elle\n",
-    "un changement de cible (le meme algorithme qui devient plus optimiste) ou un changement\n",
-    "d'algorithme (deux regimes appris sequentiellement) ? Le protocole de mesure doit separer les\n",
-    "deux lectures.\n"
+    "explicite entre eux — une mise a jour qui commence comme Q-Learning (cible sur le max, une mise\n",
+    "a jour off-policy pendant la phase d'exploration) puis bascule sur la cible comportementale apres\n",
+    "l'episode charniere, comme le demande l'enonce. La question interessante a se poser en implementant :\n",
+    "la bascule est-elle un simple changement de cible (la meme methode dont la mise a jour devient\n",
+    "on-policy au lieu d'off-policy) ou un changement d'algorithme (deux regimes appris sequentiellement) ?\n",
+    "Le protocole de mesure doit separer les deux lectures.\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #15403

## Summary

Enrichissement de densité du notebook RL-5 (MDP/DP/Q-learning) : **704 → 1266 chars de prose par cellule code** (plancher #13410 : 1200), 66 → 73 cellules. Rotation de famille au sein de l'umbrella (Search → RL) après #15403/#15428.

## Ce qui change

**Markdown-only** — exception C.2 (pas de re-exécution requise) :
- les 31 cellules code et leurs outputs committés sont **byte-identiques** (vérifié : zéro ligne `execution_count`/`outputs` dans le diff ; exec counts 1-31 inchangés ; run de 4 cellules consécutives restant = bloc exercices 1-4, compact par design) ;
- 15 cellules markdown existantes approfondies (installation/versions ; les deux bancs FrozenLake model-based vs CliffWalking model-free et sparse vs dense-punitif ; `Discrete(16)`/`Discrete(4)` = 64 entrées tabulaires ; lecture des tuples de transition avec l'état 5-trou terminal ; arithmétique V\*(0)=γ⁵=0,951 ; convergence exacte delta=0 à l'itération 7 topologiquement expliquée ; VI vs PI travail-par-itération ; atome de contraction (1−α) ; 0,892 comportemental vs 0,951 greedy = coût ε=0,01 ; transition exploration→exploitation ; géométrie de la falaise et ses deux chemins ; ±0,0 déterminisme de la mesure ; podium -13/-15/-17 ; intro conceptuelle des exercices 5/6/7) ;
- 7 nouvelles cellules : `rl5-vi-anatomy` (mise à jour en place = Gauss-Seidel, facteur `(1-done)`, critère theta), `rl5-sarsa-def` (mécanique du quintuplet), `rl5-sarsa-train` (-17 vs -13 avant la figure), `rl5-expected-def` (espérance vs échantillon vs max), `rl5-nstep-def` (horizon de bootstrap, biais-variance, protocole 4 graines partagées), `rl5-compare-read` (lecture colonne par colonne du tableau comparatif), `rl5-synthese` (la cible de mise à jour comme posture de risque : Max -13 / Espérance -15 / Échantillon -17).

## Ancrage des nombres

Chaque prose confronte les sorties committées : VI delta=0,00e+00 itération 7 ; V\*(0)=0,951=γ⁵×1 (trajectoire 6 déplacements) ; atom Q(14,2) 0→0,1 puis contraction 0,1→0,6513 (raison 0,9, 0,9¹⁰=0,35) ; QL 0,892 vs 0,951 ; ε sous 0,1 vers l'épisode 2300 (0,999/épisode) ; CliffWalking 4×12, falaise (3,1)-(3,10) ; QL −13,0±0,0 = 13 déplacements ; SARSA −17,0±0,0 ; Expected −15,0±0,0 ; n-step n=1 −13,00, n=3 −17,00, n=5 −17,00±0,87.

## Validation

- structure : 73 cellules (31 code, 42 md), `id` sur cellules nouvelles, metadata `{}` simple, nbformat 4.5 ;
- `json` re-sérialisé indent=1, `ensure_ascii=False`, LF pur (0 octet CR avant/après) ;
- audit mojibake : 9 lignes `Ã` dans le diff = ré-serialisation byte-identique de dommages préexistants (9 lignes `-` = 9 lignes `+`, 47 lignes totales dans HEAD inchangées hors diff) — hors scope de ce grain ; mon texte ajouté est ASCII-propre, 4 coquilles corrigées avant commit ;
- pre-commit complet vert au premier passage.

See #13410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
