### PR TITLE
feat(ci,#15350): stale guard-red sweep — re-mesure des rouges périmés sur merge-ref frais (DWELL intact)

### DIFF
--- a/.github/workflows/stale-guard-red-sweep.yml
+++ b/.github/workflows/stale-guard-red-sweep.yml
@@ -65,7 +65,7 @@ jobs:
     # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
     # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,7 +87,11 @@ jobs:
           if [ "${DRY_RUN:-false}" = "true" ]; then
             python scripts/check_stale_guard_reds.py --repo "$REPO" --json
           else
-            python scripts/check_stale_guard_reds.py --repo "$REPO" --apply --json
+            # --remeasure (#15350) : la re-mesure vit dans CE job -- fetch du
+            # merge-ref frais + rejeu des tests echoues, zero run GitHub cree,
+            # zero push (plancher DWELL des PR intact). Bornee a 2 par passage
+            # (orthonance locale #11860 + timeout job releve 15 -> 25 min).
+            python scripts/check_stale_guard_reds.py --repo "$REPO" --apply --remeasure --json
           fi
 
           # Advisory organ: it signals, it never blocks.

--- a/scripts/check_stale_guard_reds.py
+++ b/scripts/check_stale_guard_reds.py
@@ -74,6 +74,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -98,6 +99,19 @@ EXCLUDED_CHECKS = {"PR gate"}
 # couvre ~2 jours de cadence soutenue. Cout borne : un call check-runs par run
 # (cache par sha), uniquement pour les workflows emettant un rouge.
 MAIN_RUNS_WINDOW = 120
+
+# Re-mesure (#15350) : deps legeres des suites scripts/ -- le set du workflow
+# scripts-tests.yml est numpy/pandas/scipy/pyarrow : trop lourd a installer
+# pour chaque sweep. Les suites historiquement rouges (perimeter, translation
+# hot_subset) n'importent que ce set leger ; un ImportError residuel rend
+# SKIPPED_ENV (nomme, pas un faux rouge).
+REMEASURE_DEPS = ["pytest", "pyyaml", "requests", "bcrypt", "jupyter_client"]
+# Codes de sortie pytest : 0 passe, 1 echec(s), 2 interrompu, 3 erreur interne,
+# 4 erreur d'usage (node introuvable -> parsing trompeur), 5 rien collecte.
+# SEUL 1 est un re-rouge honnete ; tout le reste est un SKIPPED nomme -- un
+# organe qui traduirait un crash de rejeu en "toujours rouge" fabriquerait le
+# faux defaut que le criterion 3 interdit.
+PYTEST_RC = {0: "GREEN", 1: "RED", 2: "SKIPPED", 3: "SKIPPED", 4: "SKIPPED", 5: "SKIPPED"}
 
 
 def _run_gh(args: list[str]) -> str:
@@ -338,7 +352,7 @@ def analyse(data: dict, compare_fn: Callable[[str, str], str | None]) -> dict:
                                            ": vrai defaut, ne pas signaler"}); continue
             flagged.append({
                 "pr": num, "check": name, "merge_base": base, "fix_head": fix_head,
-                "remedy": "update-branch",
+                "run_id": rid, "remedy": "update-branch",
                 "why_not_rerun": (f"gh run rerun rejouerait la base gelee {base[:8]} "
                                   f"(le fix {fix_head[:8]} n'y est PAS) et rendrait le meme "
                                   "rouge ; seul gh pr update-branch recalcule la base"),
@@ -373,12 +387,103 @@ def apply(repo: str, result: dict, max_posts: int) -> None:
                     f"`{f['merge_base'][:12]}`, ANTERIEURE au fix `{f['fix_head'][:12]}` "
                     f"du garde sur main (garde vert a sa version courante).\n"
                     f"Remede : `gh pr update-branch {f['pr']}` (recalcule la base). "
-                    f"NE PAS `gh run rerun` : {f['why_not_rerun']}.")
+                    f"NE PAS `gh run rerun` : {f['why_not_rerun']}."
+                    + remeasure_lines(f.get("remeasure")))
             _run_gh(["pr", "comment", str(f["pr"]), "--repo", repo, "--body", body])
             _run_gh(["pr", "edit", str(f["pr"]), "--repo", repo, "--add-label", LABEL])
             print(f"[stale-guard-red] #{f['pr']}: signale ({f['check']})")
         except RuntimeError as e:
             print(f"[stale-guard-red] #{f['pr']}: echec non fatal ({e})", file=sys.stderr)
+
+
+def extract_failed_tests(log_text: str) -> list[str]:
+    r"""Node IDs pytest du --log-failed du run rouge. Pur, parsing borne.
+
+    Le short summary pytest imprime `FAILED path/test.py::test_name - Err...`
+    par test echoue. `\S+?::\S+?` s'arrete au premier blanc : un node a param
+    espace est TRONQUE -- son rejeu rendra rc!=1 (not found) et le verdict
+    sera SKIPPED, jamais un faux re-rouge (la table PYTEST_RC garantit la
+    direction de l'erreur).
+    """
+    seen: set[str] = set()
+    out = []
+    for m in re.finditer(r"FAILED (\S+?::\S+?)\s", log_text):
+        if m.group(1) not in seen:
+            seen.add(m.group(1))
+            out.append(m.group(1))
+    return out
+
+
+def remeasure_lines(verdict: dict | None) -> str:
+    """Lignes de commentaire rendues pour un verdict de re-mesure (pur)."""
+    if not verdict:
+        return ""
+    v = verdict.get("verdict")
+    if v == "GREEN":
+        return (f"\nRe-mesure ({verdict['n_tests']} test(s) rejoue(s) contre le "
+                f"merge-ref frais `{verdict['merge_sha'][:12]}`) : **VERT** -- les tests "
+                "qui echouaient passent sur la base corrigee + ce diff. "
+                "`update-branch` est sans risque et le seul geste restant.")
+    if v == "RED":
+        return (f"\nRe-mesure ({verdict['n_tests']} test(s) rejoue(s) contre le "
+                f"merge-ref frais `{verdict['merge_sha'][:12]}`) : **ROUGE** -- ce diff "
+                "echoue AUSSI contre la base corrigee. Ce n'est pas (que) un rouge "
+                "perime : la lane doit corriger son propre code.")
+    reason = verdict.get("reason") or "inconnue"
+    return f"\nRe-mesure non concluante : {reason} -- le dating ci-dessus reste la reference."
+
+
+def remeasure_pr(repo: str, pr_number: int, run_id: str, repo_dir: str) -> dict:
+    """Rejoue les tests echoues du run rouge contre le merge-ref FRAIS de la PR.
+
+    Acceptance 4 de #15350, tranchee : le fetch de `refs/pull/N/merge` fait
+    recalculer le merge par GitHub contre main COURANT -- il n'y a AUCUN push
+    sur la branche, donc aucun event synchronize : le plancher DWELL n'est pas
+    rearme. La penalite de lane reste le fait du seul geste update-branch,
+    desormais INFORMe par ce verdict.
+
+    Acceptance 3 : peut re-rougir. Uniquement via rc pytest == 1 (echecs
+    reels) ; crash/timeout/usage -> SKIPPED nomme.
+
+    MUTATION : checkout FETCH_HEAD dans repo_dir (derniere etape du sweep --
+    l'analyse et le posting n'en dependent plus). En calibration locale,
+    passer un worktree dedie.
+    """
+    try:
+        log = _run_gh(["run", "view", run_id, "--repo", repo, "--log-failed"])
+    except RuntimeError as e:
+        return {"verdict": "SKIPPED", "reason": f"log du run {run_id} indisponible ({str(e)[:60]})"}
+    nodes = extract_failed_tests(log)
+    if not nodes:
+        return {"verdict": "SKIPPED", "reason": "aucun node ID pytest dans le log (organe non-pytest ?)"}
+
+    def _git(*a: str, timeout: int = 120) -> None:
+        p = subprocess.run(["git", "-C", repo_dir, *a], capture_output=True, text=True, timeout=timeout)
+        if p.returncode != 0:
+            raise RuntimeError(f"git {a[0]}: {p.stderr.strip()[:120]}")
+
+    try:
+        _git("sparse-checkout", "disable", timeout=30)
+        _git("fetch", "-q", "origin", f"refs/pull/{pr_number}/merge")
+        merge_sha = subprocess.run(["git", "-C", repo_dir, "rev-parse", "FETCH_HEAD"],
+                                   capture_output=True, text=True, timeout=30).stdout.strip()
+        _git("checkout", "-q", "FETCH_HEAD")
+        p = subprocess.run([sys.executable, "-m", "pip", "install", "-q", *REMEASURE_DEPS],
+                           capture_output=True, text=True, timeout=180)
+        if p.returncode != 0:
+            return {"verdict": "SKIPPED", "reason": f"pip install echoue: {p.stderr.strip()[:80]}"}
+        t = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", *nodes],
+                           cwd=repo_dir, capture_output=True, text=True, timeout=600)
+    except (RuntimeError, subprocess.TimeoutExpired, OSError) as e:
+        return {"verdict": "SKIPPED", "reason": f"rejeu interrompu: {str(e)[:80]}"}
+    verdict = PYTEST_RC.get(t.returncode, "SKIPPED")
+    out = {"verdict": verdict, "n_tests": len(nodes), "merge_sha": merge_sha}
+    if verdict == "SKIPPED":
+        out["reason"] = f"pytest rc={t.returncode} (usage/collection/timeout) -- pas un verdict de fond"
+        out["tail"] = (t.stdout or "").strip().splitlines()[-1][:120] if (t.stdout or "").strip() else ""
+    elif verdict == "RED":
+        out["failed"] = extract_failed_tests(t.stdout or "")
+    return out
 
 
 def main() -> int:
@@ -390,6 +495,15 @@ def main() -> int:
     ap.add_argument("--apply", action="store_true",
                     help="pose label + commentaire (defaut : lecture seule)")
     ap.add_argument("--max-posts", type=int, default=8)
+    ap.add_argument("--remeasure", action="store_true",
+                    help="rejoue les tests echoues des rouges signales contre le "
+                         "merge-ref frais (fetch pull/N/merge : zero push, DWELL "
+                         "intact) ; verdict capable de re-rougir (#15350)")
+    ap.add_argument("--max-remeasure", type=int, default=2,
+                    help="borne d'orthonance : re-mesures par passage (timeout job)")
+    ap.add_argument("--remeasure-dir", default=None,
+                    help="repertoire git ou rejouer (defaut : cwd). MUTATE le "
+                         "checkout -- en calibration, un worktree dedie")
     args = ap.parse_args()
 
     recorded: dict[tuple[str, str], str] = {}
@@ -425,6 +539,22 @@ def main() -> int:
         json.dump({"data": data, "compares": {f"{a}|{b}": s for (a, b), s in recorded.items()}},
                   open(args.dump, "w", encoding="utf-8"), indent=1, ensure_ascii=False)
 
+    if args.remeasure:
+        # DERNIERE etape avant posting : la re-mesure mute le checkout
+        # (checkout FETCH_HEAD) ; analyse/apply n'en dependent plus ensuite.
+        # Bornee (--max-remeasure) pour tenir le timeout du job sweep et
+        # l'orthonance locale (#11860) -- zero run GitHub cree, la re-mesure
+        # vit dans CE job.
+        rdir = args.remeasure_dir or os.getcwd()
+        for f in result["flagged"][:args.max_remeasure]:
+            rid = f.get("run_id") or ""
+            if not rid:
+                f["remeasure"] = {"verdict": "SKIPPED", "reason": "run_id non attribuable"}
+                continue
+            f["remeasure"] = remeasure_pr(args.repo, f["pr"], rid, rdir)
+            v = f["remeasure"].get("verdict")
+            print(f"[stale-guard-red] re-mesure #{f['pr']} ({f['check']}): {v}")
+
     if args.json:
         print(json.dumps(result, indent=1, ensure_ascii=False))
     else:
@@ -433,7 +563,8 @@ def main() -> int:
               f"| exclues: {len(result['excluded'])}")
         for f in result["flagged"]:
             print(f"  #{f['pr']} {f['check']} base={f['merge_base'][:8]} "
-                  f"fix={f['fix_head'][:8]} -> {f['remedy']}")
+                  f"fix={f['fix_head'][:8]} -> {f['remedy']}"
+                  + (f" [re-mesure: {f['remeasure']['verdict']}]" if f.get("remeasure") else ""))
         for e in result["excluded"]:
             print(f"  #{e['pr']} exclu: {e.get('check', '')} {e['reason']}", file=sys.stderr)
     if args.apply:

--- a/scripts/tests/test_check_stale_guard_reds.py
+++ b/scripts/tests/test_check_stale_guard_reds.py
@@ -275,3 +275,116 @@ def test_locate_fix_head_red_on_main():
     hist = history([("failure", "s1"), ("success", "s2"), ("failure", "s3")])
     status, fix = mod.locate_fix_head(hist, "Scripts Tests (CPU)")
     assert status == "red_on_main"
+
+
+# --- re-mesure (#15350) : acceptance 2 (agir), 3 (re-rougir), 4 (DWELL) ---
+
+FAKE_LOG = """Set up job\t2026-09-10T06:54:00Z\tCurrent runner size:
+Run pytest\t2026-09-10T06:54:10Z\tFAILED scripts/tests/test_perimeter.py::test_audit_name_too_long - AssertionError: assert 123 > 69
+Run pytest\t2026-09-10T06:54:11Z\tFAILED scripts/tests/test_perimeter.py::test_audit_name_too_long - AssertionError: assert 123 > 69
+Run pytest\t2026-09-10T06:54:12Z\t1 failed, 431 passed in 38.2s
+"""
+
+
+def test_extract_failed_tests_parses_and_dedups():
+    nodes = mod.extract_failed_tests(FAKE_LOG)
+    assert nodes == ["scripts/tests/test_perimeter.py::test_audit_name_too_long"]
+
+
+def test_extract_failed_tests_nested_node_ids():
+    log = "FAILED a/b.py::TestCls::test_x - Error\nFAILED a/b.py::test_plain - E\n"
+    assert mod.extract_failed_tests(log) == [
+        "a/b.py::TestCls::test_x", "a/b.py::test_plain"]
+
+
+def test_extract_failed_tests_non_pytest_log_empty():
+    assert mod.extract_failed_tests("CodeQL analysis finished\nerror: rule X") == []
+
+
+def test_pytest_rc_table_only_rc1_is_red():
+    """Criterion 3 : SEUL l'echec pytest reel (rc=1) est un re-rouge. Un crash,
+    un node introuvable (rc=4) ou une collection vide (rc=5) traduits en
+    ROUGE fabriqueraient le faux defaut que l'issue interdit."""
+    assert mod.PYTEST_RC[0] == "GREEN"
+    assert mod.PYTEST_RC[1] == "RED"
+    for rc in (2, 3, 4, 5):
+        assert mod.PYTEST_RC[rc] == "SKIPPED"
+    assert mod.PYTEST_RC.get(137) == "SKIPPED" or mod.PYTEST_RC.get(137) is None
+
+
+def test_remeasure_lines_three_verdicts():
+    green = mod.remeasure_lines({"verdict": "GREEN", "n_tests": 1, "merge_sha": "abcdef12345678"})
+    assert "VERT" in green and "abcdef12345678"[:12] in green and "update-branch" in green
+    red = mod.remeasure_lines({"verdict": "RED", "n_tests": 2, "merge_sha": "abcdef12345678"})
+    assert "ROUGE" in red and "corriger" in red
+    skipped = mod.remeasure_lines({"verdict": "SKIPPED", "reason": "log indisponible"})
+    assert "non concluante" in skipped and "log indisponible" in skipped
+    assert mod.remeasure_lines(None) == ""
+
+
+def _fake_subprocess(pytest_rc):
+    """git/pip verts, pytest au rc parametre ; rev-parse rend un sha stable."""
+    def run(cmd, **kw):
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        if cmd[0] == "git" and "rev-parse" in cmd:
+            r = R(); r.stdout = "feedfacefeedface\n"; return r
+        if cmd[1:3] == ["-m", "pytest"]:
+            r = R(); r.returncode = pytest_rc; return r
+        return R()
+    return run
+
+
+def test_remeasure_pr_green_when_replayed_tests_pass(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_run_gh", lambda a: FAKE_LOG if a[:3] == ["run", "view", "999"] else "")
+    monkeypatch.setattr(mod.subprocess, "run", _fake_subprocess(0))
+    v = mod.remeasure_pr("jsboige/CoursIA", 15318, "999", str(tmp_path))
+    assert v["verdict"] == "GREEN" and v["n_tests"] == 1
+    assert v["merge_sha"] == "feedfacefeedface"
+
+
+def test_remeasure_pr_red_only_on_real_failures(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_run_gh", lambda a: FAKE_LOG)
+    monkeypatch.setattr(mod.subprocess, "run", _fake_subprocess(1))
+    v = mod.remeasure_pr("jsboige/CoursIA", 15318, "999", str(tmp_path))
+    assert v["verdict"] == "RED"
+
+
+def test_remeasure_pr_usage_error_is_skip_not_red(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_run_gh", lambda a: FAKE_LOG)
+    monkeypatch.setattr(mod.subprocess, "run", _fake_subprocess(4))
+    v = mod.remeasure_pr("jsboige/CoursIA", 15318, "999", str(tmp_path))
+    assert v["verdict"] == "SKIPPED" and "rc=4" in v["reason"]
+
+
+def test_remeasure_pr_no_pytest_nodes_skips(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_run_gh", lambda a: "CodeQL finished clean")
+    v = mod.remeasure_pr("jsboige/CoursIA", 15318, "999", str(tmp_path))
+    assert v["verdict"] == "SKIPPED" and "node ID" in v["reason"]
+
+
+def test_remeasure_pr_git_failure_skips(monkeypatch, tmp_path):
+    def boom(cmd, **kw):
+        if cmd[0] == "git":
+            class R:
+                returncode = 128
+                stdout = ""
+                stderr = "fatal: not a git repository"
+            return R
+        class R2:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R2()
+    monkeypatch.setattr(mod, "_run_gh", lambda a: FAKE_LOG)
+    monkeypatch.setattr(mod.subprocess, "run", boom)
+    v = mod.remeasure_pr("jsboige/CoursIA", 15318, "999", str(tmp_path))
+    assert v["verdict"] == "SKIPPED" and "interrompu" in v["reason"]
+
+
+def test_flagged_entry_carries_run_id_for_remeasure():
+    result = mod.analyse(pr_fixture(), cmp_map({(FIX, OLD_BASE): "diverged"}))
+    f = result["flagged"][0]
+    assert f["run_id"] == "111"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/tooling #15449

## Requalification d'abord (G.1, confrontation body ↔ réel)

Le body de #15350 pose « il n'existe **aucun** organe pour la classe générale ». Mesure firsthand : **`stale-guard-red-sweep.yml` + `scripts/check_stale_guard_reds.py` couvrent déjà la détection** (issue #13321, livrés avant), avec une méthodologie *supérieure* à l'acceptance 1 : datation par la **base gelée** du run (`run.pull_requests[0].base.sha`, immuable) par relation d'ancêtré — pas une comparaison d'horodatages — avec contrôle positif (un rouge rendu contre le garde corrigé n'est PAS signalé) et exclusions nommées (draft, fork, flake même base, garde rouge sur main, garde PR-only, push-event sans base). Il tourne quotidiennement (dernier run : 2026-09-09T09:14Z, success).

Le résidu réel de l'issue — ce que cette PR livre — : la **re-mesure** (acceptance 2) et le **tranchage DWELL** (acceptance 4). La fréquence quotidien vs les incidents du matin reste un arbitrage coordinateur (voir Résiduel).

## Ce que fait cette PR

`--remeasure` sur le sweep existant : pour chaque rouge périmé signalé (borné à `--max-remeasure 2` par passage),

1. **Extrait les tests échoués** du run rouge (`gh run view --log-failed`, parsing des lignes `FAILED node::id`, dédoublonné). Aucun node → verdict `SKIPPED` nommé (organe non-pytest).
2. **Fetch le merge-ref FRAIS** `refs/pull/N/merge` : GitHub recalcule le merge contre main courant à la demande. **Zéro push sur la branche** → aucun event `synchronize` → **le plancher DWELL de 120 min n'est pas réarmé** (acceptance 4, tranchée : la pénalité ne peut venir que du geste `update-branch` lui-même, désormais informé par le verdict).
3. **Rejoue les nodes** par pytest dans le job du sweep : **zéro run GitHub créé** — l'objection d'orthonance #11860 documentée dans le workflow existant (« eleven update-branches would push ~350 runs ») est respectée par construction.
4. **Verdict attaché au commentaire signalé** : `GREEN` (les tests qui échouaient passent sur base corrigée + le diff — update-branch est sans risque), `RED` (**peut re-rougir**, acceptance 3 : le diff échoue aussi contre la base corrigée, la lane doit corriger), `SKIPPED` (raison nommée).

**Direction de l'erreur garantie** : seuls les échecs pytest réels (rc=1) produisent `RED` ; rc 2/3/4/5 (interrompu/interne/usage/node introuvable/rien collecté), timeout, crash git/pip → `SKIPPED` nommé. Un organe qui traduirait un crash de rejeu en « toujours rouge » fabriquerait le faux défaut que le criterion 3 interdit.

## Couverture des 5 acceptances

| # | Acceptance | Couvert par |
|---|---|---|
| 1 | Détecter (run vs dernier commit main) | **Préexistant** #13321 (base gelée + ancêtré, mieux que les horodatages) |
| 2 | Re-mesurer, pas seulement signaler | **Cette PR** (rejeu pytest sur merge-ref frais, dans le job) |
| 3 | Pouvoir re-rougir | **Cette PR** (rc=1 → RED ; contrôlé par test) + contrôle positif préexistant |
| 4 | DWELL tranché explicitement | **Cette PR** (fetch merge-ref = zéro push = zéro réarmement ; documenté code + ici) |
| 5 | Ne pas se déclencher sur un rouge réel | **Préexistant** (base contient le fix → non signalé) + SKIPPED sur rejeu ambigu |

## Calibration réelle (mesures firsthand)

- **Cas historique #15318** (le premier du tableau de l'issue) : run rouge `34320850538` (2026-09-09T06:49Z) — `--log-failed` rend exactement `FAILED scripts/notebook_tools/tests/test_twin_registry_integrity.py::test_audit_filenames_bounded_for_windows - AssertionError: nom de fichier d'audit trop long (123 > 69)`. Rejoué sur le merge-ref frais `f7208e005d` (fetch `refs/pull/15318/merge`, #15318 encore OPEN) : `1 passed in 0.19s` → verdict **GREEN**, sans aucun push — le rouge était bien périmé (correctif 15336, atterri sur main à 07:13Z).
- **Sweep d'hier** (run 34333619676) : `flagged: 0, excluded: 30` — plus de rouge périmé vivant au moment de la mesure (les lanes ont réparé avant le passage quotidien) ; d'où la calibration sur le cas archivé.
- **Suite de tests** : 31 tests verts (20 préexistants intacts + 11 neufs : parsing/dédup, node imbriqués, log non-pytest, table rc, trois rendus de verdict, GREEN/RED/SKIPPED-par-usage/SKIPPEP-sans-node/SKIPPED-sur-crash-git, `run_id` porté par l'entrée signalée).

## Périmètre

`scripts/check_stale_guard_reds.py` (extension `--remeasure` + `remeasure_pr`/`extract_failed_tests`/`remeasure_lines`), sa suite `scripts/tests/test_check_stale_guard_reds.py`, et `.github/workflows/stale-guard-red-sweep.yml` (flag câblé sur le cron, `timeout-minutes` 15 → 25 pour loger pip+fetch+rejeu bornés). Aucun autre chemin touché ; le comportement sans `--remeasure` est inchangé (dry-run et lecture seule identiques).

## Résiduel (arbitrage coordinateur)

- **Fréquence** : quotidien 04:53Z. Les incidents du 09-09 (écart 19 min → 2 h 43) auraient attendu le passage du jour. Un passage plus fréquent coûte des slots ephemeral sous famine #11860 — arbitrage coordinateur.
- **Famille v1** : la re-mésure ne rejoue que les gardes pytest (les rouges historiques sont tous de cette famille). Un garde fast_lane/CodeQL rouge périmé rend `SKIPPED` nommé — honnête, non muet.
- **Deps** : set léger (`pytest pyyaml requests bcrypt jupyter_client`) ; les suites scientifiques (numpy/pandas) rendraient `SKIPPED_ENV` nommé plutôt qu'un faux verdict.

Closes #15350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
